### PR TITLE
Skip re-evaluating unchanged skill modules (codex review on #3)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3025,12 +3025,14 @@ export default function App() {
   const extensionKeybindingsRef = useRef<
     Map<string, { combo: string; action: string; description?: string }>
   >(new Map());
-  // Set of skill-package module names whose `aethon.frontendEntry` JS
-  // body has been evaluated and registered in the SkillRegistry.
-  // Tracked so an `extension_skill_modules` delta with a smaller list
-  // can unregister components from skills that were dropped (uninstall
-  // or rename).
-  const skillModuleNamesRef = useRef<Set<string>>(new Set());
+  // name → code for skill-package modules whose `aethon.frontendEntry`
+  // JS bodies have been evaluated and registered in the SkillRegistry.
+  // Tracked so:
+  //   - dropped skills (name absent from a fresh delta) get unregistered
+  //   - identical re-deliveries (same name + same code) skip re-eval,
+  //     so the duplicate `ready` the bridge fires after the startup
+  //     `report` doesn't run top-level side effects twice
+  const skillModulesRef = useRef<Map<string, string>>(new Map());
 
   // Built once — handlers close over App-scope helpers via the ctx passed at
   // dispatch time, so the registry itself doesn't need state in scope.
@@ -3176,13 +3178,13 @@ export default function App() {
   // code). Errors per module are caught and surfaced as a `notice` so
   // one broken skill doesn't kill the others.
   function hydrateSkillModules(list: { name: string; code: string }[]) {
-    const previous = skillModuleNamesRef.current;
+    const previous = skillModulesRef.current;
     const { loaded, unregistered } = reconcileSkillModules(
       previous,
       list,
       registry,
     );
-    skillModuleNamesRef.current = new Set(list.map((m) => m.name));
+    skillModulesRef.current = new Map(list.map((m) => [m.name, m.code]));
     for (const m of loaded) {
       if (m.error) {
         appendSystem(`skill module ${m.name}: ${m.error}`);
@@ -3192,7 +3194,8 @@ export default function App() {
       // Bump a counter so any A2UIRenderer subtree using a now-changed
       // component type re-resolves through the SkillRegistry on the
       // next render. The registry itself doesn't trigger React updates;
-      // bumping a piece of state owned by App.tsx does.
+      // bumping a piece of state owned by App.tsx does. Skipped (no-op)
+      // modules don't need a bump — their components are unchanged.
       setState((prev) => ({
         ...prev,
         skillModulesGen: ((prev.skillModulesGen as number | undefined) ?? 0) + 1,

--- a/src/skills/skillModuleLoader.test.ts
+++ b/src/skills/skillModuleLoader.test.ts
@@ -76,8 +76,8 @@ describe("reconcileSkillModules", () => {
   });
 
   it("loads new modules and tracks their names", () => {
-    const { loaded, unregistered } = reconcileSkillModules(
-      new Set<string>(),
+    const { loaded, unregistered, skipped } = reconcileSkillModules(
+      new Map<string, string>(),
       [
         {
           name: "alpha",
@@ -92,24 +92,21 @@ describe("reconcileSkillModules", () => {
     );
     expect(loaded.map((l) => l.name)).toEqual(["alpha", "beta"]);
     expect(unregistered).toEqual([]);
+    expect(skipped).toEqual([]);
     expect(registry.resolve("a")).toBeDefined();
     expect(registry.resolve("b")).toBeDefined();
   });
 
   it("unregisters modules that disappear from the next delta", () => {
+    const code = `skill.registerComponent("a", function () { return null; });`;
     reconcileSkillModules(
-      new Set<string>(),
-      [
-        {
-          name: "alpha",
-          code: `skill.registerComponent("a", function () { return null; });`,
-        },
-      ],
+      new Map<string, string>(),
+      [{ name: "alpha", code }],
       registry,
     );
     expect(registry.resolve("a")).toBeDefined();
     const { unregistered } = reconcileSkillModules(
-      new Set(["alpha"]),
+      new Map([["alpha", code]]),
       [],
       registry,
     );
@@ -117,31 +114,57 @@ describe("reconcileSkillModules", () => {
     expect(registry.resolve("a")).toBeUndefined();
   });
 
-  it("re-evaluates a re-shipped module so component code can hot-reload", () => {
+  it("re-evaluates a re-shipped module when its code changes", () => {
+    const v1Code = `skill.registerComponent("v", function V1() { return React.createElement("div", null, "v1"); });`;
     reconcileSkillModules(
-      new Set<string>(),
-      [
-        {
-          name: "live",
-          code: `skill.registerComponent("v", function V1() { return React.createElement("div", null, "v1"); });`,
-        },
-      ],
+      new Map<string, string>(),
+      [{ name: "live", code: v1Code }],
       registry,
     );
     const v1 = registry.resolve("v");
     expect(v1).toBeDefined();
-    reconcileSkillModules(
-      new Set(["live"]),
-      [
-        {
-          name: "live",
-          code: `skill.registerComponent("v", function V2() { return React.createElement("div", null, "v2"); });`,
-        },
-      ],
+    const v2Code = `skill.registerComponent("v", function V2() { return React.createElement("div", null, "v2"); });`;
+    const { loaded, skipped } = reconcileSkillModules(
+      new Map([["live", v1Code]]),
+      [{ name: "live", code: v2Code }],
       registry,
     );
+    expect(loaded.map((l) => l.name)).toEqual(["live"]);
+    expect(skipped).toEqual([]);
     const v2 = registry.resolve("v");
     expect(v2).toBeDefined();
     expect(v2).not.toBe(v1);
+  });
+
+  it("skips byte-identical re-deliveries so duplicate ready events don't double-run side effects", () => {
+    const code = `
+      // Top-level side effect — simulates a skill that injects a
+      // <style> or arms a setInterval at module load.
+      globalThis.__skill_runs = (globalThis.__skill_runs ?? 0) + 1;
+      skill.registerComponent("s", function () { return null; });
+    `;
+    const g = globalThis as unknown as { __skill_runs?: number };
+    g.__skill_runs = 0;
+    const first = reconcileSkillModules(
+      new Map<string, string>(),
+      [{ name: "stable", code }],
+      registry,
+    );
+    expect(first.loaded.map((l) => l.name)).toEqual(["stable"]);
+    expect(first.skipped).toEqual([]);
+    expect(g.__skill_runs).toBe(1);
+
+    const second = reconcileSkillModules(
+      new Map([["stable", code]]),
+      [{ name: "stable", code }],
+      registry,
+    );
+    expect(second.loaded).toEqual([]);
+    expect(second.skipped).toEqual(["stable"]);
+    // Critical: the side effect did NOT run a second time.
+    expect(g.__skill_runs).toBe(1);
+    // Component still resolves (it was never unregistered).
+    expect(registry.resolve("s")).toBeDefined();
+    delete g.__skill_runs;
   });
 });

--- a/src/skills/skillModuleLoader.ts
+++ b/src/skills/skillModuleLoader.ts
@@ -115,32 +115,52 @@ export function skillRegistryName(moduleName: string): string {
 }
 
 /**
- * Apply the full `extension_skill_modules` payload — wholesale replace.
- * Removes any previously-loaded modules that aren't in the new list,
- * then evaluates the new ones.
+ * Apply the full `extension_skill_modules` payload — wholesale replace,
+ * but skip re-evaluating modules whose code hasn't changed since the
+ * previous load.
  *
- * @param previous — names from the prior load (so we know what to unregister).
- *   Use the `name` returned by `LoadedSkillModule` (NOT the registry
- *   name); this helper handles the prefix.
+ * The startup path sends a `ready` followed by a `report` (which
+ * triggers another `ready`), so the same skill list arrives twice in
+ * one webview lifetime. Without the skip-on-unchanged path, every
+ * top-level side effect in a skill module (timers, DOM listeners,
+ * style injection) would run twice, and a failing module would emit
+ * duplicate system notices. Caller passes a name → code map so we
+ * can hash-compare without recomputing the previous set's source.
+ *
+ * @param previous — name → code from the prior load (so we know what
+ *   to unregister AND what's unchanged). Use the `name` returned by
+ *   `LoadedSkillModule` (NOT the registry name); this helper handles
+ *   the prefix.
  */
 export function reconcileSkillModules(
-  previous: ReadonlySet<string>,
+  previous: ReadonlyMap<string, string>,
   next: SkillModule[],
   registry: SkillRegistry,
-): { loaded: LoadedSkillModule[]; unregistered: string[] } {
-  const nextNames = new Set(next.map((m) => m.name));
+): { loaded: LoadedSkillModule[]; unregistered: string[]; skipped: string[] } {
+  const nextByName = new Map(next.map((m) => [m.name, m]));
   const unregistered: string[] = [];
-  for (const name of previous) {
-    if (!nextNames.has(name)) {
+  for (const name of previous.keys()) {
+    if (!nextByName.has(name)) {
       registry.unregister(skillRegistryName(name));
       unregistered.push(name);
     }
   }
+  const skipped: string[] = [];
+  const toEval: SkillModule[] = [];
+  for (const m of next) {
+    if (previous.get(m.name) === m.code) {
+      // Same name, byte-identical code — components are still in the
+      // registry from the prior eval. No-op.
+      skipped.push(m.name);
+      continue;
+    }
+    toEval.push(m);
+  }
   // Always unregister BEFORE re-registering so a re-evaluated skill's
   // old components don't linger if the new evaluation fails midway.
-  for (const m of next) {
+  for (const m of toEval) {
     registry.unregister(skillRegistryName(m.name));
   }
-  const loaded = next.map((m) => evaluateSkillModule(m, registry));
-  return { loaded, unregistered };
+  const loaded = toEval.map((m) => evaluateSkillModule(m, registry));
+  return { loaded, unregistered, skipped };
 }


### PR DESCRIPTION
## Summary

Address the [P2] finding from the codex review on #3: the startup path emits `ready` then `report` (which fires a second `ready`), so the same `extension_skill_modules` list arrives twice. The prior `hydrateSkillModules` always unregistered + re-evaluated every module, which meant a skill with top-level side effects (timers, DOM listeners, style injection) would run them twice, and a failing module would emit duplicate system notices.

Track previous module code per name; on each delta, byte-compare and skip identical re-deliveries. Returns `{loaded, unregistered, skipped}` so callers know the no-op path was hit.

## Test plan

- [x] `bunx tsc -b --noEmit` clean
- [x] `bunx eslint .` clean
- [x] `bunx vitest run` — 107/107 (one new test verifying side effects only run once across duplicate ready deliveries)
- [x] `cargo clippy -D warnings` clean