### PR TITLE
feat(canvas): programmatic canvas push API

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -355,11 +355,12 @@ receive the same surface as the first arg to their `register(api)`.
 - `registerMenuItem({label, action, location?, id?, parent?})` / `unregisterMenuItem(id)` — Add menu metadata for A2UI-driven menus
 - `registerEventRoute({componentId?, eventType?})` / `unregisterEventRoute(route)` — Route matching built-in events through extension handlers
 - `registerLayout({id, name, description?, payload})` / `unregisterLayout(id)` / `listLayouts()` — Append to the runtime layout catalogue from the agent side; activation still goes through `setLayout(payload)` (or, on the frontend, `window.aethon.activateLayout(id)`)
+- `canvas.{emit, append, clear, patch}` — Programmatic canvas push API; sugar over `setState("/canvas", …)`. Also surfaced on the handler `ctx` (tab-pinned variant) so a sidebar click can `ctx.canvas.append(...)` without rebuilding the envelope or losing tab attribution mid-handler. Implementation in `agent/canvas.ts` (covered by 23 vitest cases under `agent/canvas.test.ts`).
 - `getFrontendState(path?)`, `getRuntimeSnapshot()`, `getLayout()`, `getLayoutSlots()` — Introspection helpers used by the system prompt and agent-side diagnostics
 
 ### Still on the backlog
 
-- Programmatic canvas push API (`ctx.canvas.emit(...)`)
+(none — M1–M5 surface complete.)
 
 ### Discovery
 

--- a/agent/canvas.test.ts
+++ b/agent/canvas.test.ts
@@ -1,0 +1,315 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import {
+  makeCanvasApi,
+  normalizeCanvasComponents,
+  readCanvasComponentsFromTabState,
+  type CanvasComponent,
+  type CanvasMutationResult,
+} from "./canvas";
+
+interface SetStateCall {
+  path: string;
+  value: unknown;
+  sourceTabId: string | undefined;
+}
+
+interface Harness {
+  calls: SetStateCall[];
+  /**
+   * Per-tab mirror — keyed by tabId, value is the bridge's view of what
+   * was last written. Each setState fold-merges the path/value into this
+   * map (only `/canvas` paths matter for these tests, so we just track
+   * the canvas slot).
+   */
+  mirror: Map<string, { canvas?: { components?: CanvasComponent[] } }>;
+  attributedTab: string | undefined;
+  api: ReturnType<typeof makeCanvasApi>;
+}
+
+function newHarness(opts: {
+  attributedTab?: string;
+  initialMirror?: Record<string, { canvas?: { components?: CanvasComponent[] } }>;
+  setStateResult?: CanvasMutationResult;
+} = {}): Harness {
+  const calls: SetStateCall[] = [];
+  const mirror = new Map<string, { canvas?: { components?: CanvasComponent[] } }>();
+  if (opts.initialMirror) {
+    for (const [k, v] of Object.entries(opts.initialMirror)) mirror.set(k, v);
+  }
+  const harness: Harness = {
+    calls,
+    mirror,
+    attributedTab: opts.attributedTab,
+    api: makeCanvasApi(undefined, {
+      setState: (path, value, sourceTabId) => {
+        calls.push({ path, value, sourceTabId });
+        const tabId = sourceTabId ?? harness.attributedTab;
+        if (path === "/canvas" && tabId) {
+          mirror.set(tabId, { canvas: value });
+        }
+        return Promise.resolve(opts.setStateResult ?? { ok: true });
+      },
+      resolveAttributedTab: (explicit) => explicit ?? harness.attributedTab,
+      readCanvasComponents: (tabId) =>
+        readCanvasComponentsFromTabState(tabId ? mirror.get(tabId) : undefined),
+    }),
+  };
+  return harness;
+}
+
+describe("normalizeCanvasComponents", () => {
+  it("wraps a single component into an array", () => {
+    const c: CanvasComponent = { type: "card", props: { title: "x" } };
+    expect(normalizeCanvasComponents(c)).toEqual([c]);
+  });
+
+  it("returns a fresh array with valid entries kept in order", () => {
+    const a: CanvasComponent = { type: "card" };
+    const b: CanvasComponent = { type: "text" };
+    expect(normalizeCanvasComponents([a, b])).toEqual([a, b]);
+  });
+
+  it("filters out null / non-objects / typeless entries", () => {
+    const valid: CanvasComponent = { type: "card" };
+    expect(
+      normalizeCanvasComponents([
+        valid,
+        null,
+        undefined,
+        "string",
+        42,
+        { props: { foo: 1 } }, // missing type
+        { type: "" }, // empty type
+      ]),
+    ).toEqual([valid]);
+  });
+
+  it("returns an empty array for null / undefined input", () => {
+    expect(normalizeCanvasComponents(null)).toEqual([]);
+    expect(normalizeCanvasComponents(undefined)).toEqual([]);
+  });
+});
+
+describe("readCanvasComponentsFromTabState", () => {
+  it("returns empty when tab state is missing", () => {
+    expect(readCanvasComponentsFromTabState(undefined)).toEqual([]);
+  });
+
+  it("returns empty when canvas slot is unset", () => {
+    expect(readCanvasComponentsFromTabState({})).toEqual([]);
+  });
+
+  it("returns the components array verbatim when present", () => {
+    const c: CanvasComponent = { type: "card" };
+    expect(
+      readCanvasComponentsFromTabState({ canvas: { components: [c] } }),
+    ).toEqual([c]);
+  });
+
+  it("filters non-object entries inside components", () => {
+    const c: CanvasComponent = { type: "card" };
+    expect(
+      readCanvasComponentsFromTabState({
+        canvas: { components: [c, null, "junk", 42] as unknown[] },
+      }),
+    ).toEqual([c]);
+  });
+});
+
+describe("makeCanvasApi.emit", () => {
+  let h: Harness;
+  beforeEach(() => {
+    h = newHarness({ attributedTab: "tab-1" });
+  });
+
+  it("writes /canvas with a {components: [...]} envelope", async () => {
+    const c: CanvasComponent = { type: "card", props: { title: "hi" } };
+    const r = await h.api.emit(c);
+    expect(r).toEqual({ ok: true });
+    expect(h.calls).toHaveLength(1);
+    expect(h.calls[0]).toEqual({
+      path: "/canvas",
+      value: { components: [c] },
+      sourceTabId: undefined,
+    });
+  });
+
+  it("accepts an array of components", async () => {
+    const c1: CanvasComponent = { type: "card" };
+    const c2: CanvasComponent = { type: "text" };
+    await h.api.emit([c1, c2]);
+    expect(h.calls[0].value).toEqual({ components: [c1, c2] });
+  });
+
+  it("emits with an empty components array when given an empty list", async () => {
+    await h.api.emit([]);
+    expect(h.calls[0].value).toEqual({ components: [] });
+  });
+});
+
+describe("makeCanvasApi.append", () => {
+  it("reads existing components and appends new ones", async () => {
+    const existing: CanvasComponent = { type: "card", id: "old" };
+    const h = newHarness({
+      attributedTab: "tab-1",
+      initialMirror: { "tab-1": { canvas: { components: [existing] } } },
+    });
+    const fresh: CanvasComponent = { type: "text", id: "new" };
+    await h.api.append(fresh);
+    expect(h.calls).toHaveLength(1);
+    expect(h.calls[0].value).toEqual({ components: [existing, fresh] });
+  });
+
+  it("falls back to emit-equivalent when the canvas is empty", async () => {
+    const h = newHarness({ attributedTab: "tab-1" });
+    const c: CanvasComponent = { type: "card" };
+    await h.api.append(c);
+    expect(h.calls[0].value).toEqual({ components: [c] });
+  });
+
+  it("is a no-op (returns ok) when given zero valid components", async () => {
+    const h = newHarness({ attributedTab: "tab-1" });
+    const r = await h.api.append([]);
+    expect(r).toEqual({ ok: true });
+    expect(h.calls).toHaveLength(0);
+  });
+
+  it("filters invalid entries before appending", async () => {
+    const h = newHarness({ attributedTab: "tab-1" });
+    const c: CanvasComponent = { type: "card" };
+    // The runtime helper is defensive against null entries and typeless
+    // / empty-type objects; those wouldn't compile through the normal
+    // `CanvasComponent[]` signature, so push them in as `unknown` first
+    // and let the runtime filter strip them.
+    const inputs: unknown[] = [c, null, { type: "" }];
+    await h.api.append(inputs as CanvasComponent[]);
+    expect(h.calls[0].value).toEqual({ components: [c] });
+  });
+
+  it("does not see other tabs' canvas state under concurrent dispatches", async () => {
+    const onTab1: CanvasComponent = { type: "card", id: "tab1-existing" };
+    const onTab2: CanvasComponent = { type: "card", id: "tab2-existing" };
+    const h = newHarness({
+      attributedTab: "tab-1",
+      initialMirror: {
+        "tab-1": { canvas: { components: [onTab1] } },
+        "tab-2": { canvas: { components: [onTab2] } },
+      },
+    });
+    // Bind to tab-2 explicitly — append should read tab-2's mirror, not tab-1's.
+    const tab2Api = makeCanvasApi("tab-2", {
+      setState: (path, value, sourceTabId) => {
+        h.calls.push({ path, value, sourceTabId });
+        return Promise.resolve({ ok: true });
+      },
+      resolveAttributedTab: (explicit) => explicit ?? "tab-1",
+      readCanvasComponents: (id) =>
+        readCanvasComponentsFromTabState(id ? h.mirror.get(id) : undefined),
+    });
+    const fresh: CanvasComponent = { type: "text", id: "fresh" };
+    await tab2Api.append(fresh);
+    expect(h.calls[0].sourceTabId).toBe("tab-2");
+    expect(h.calls[0].value).toEqual({ components: [onTab2, fresh] });
+  });
+});
+
+describe("makeCanvasApi.clear", () => {
+  it("writes /canvas with an empty components array", async () => {
+    const h = newHarness({ attributedTab: "tab-1" });
+    await h.api.clear();
+    expect(h.calls[0]).toEqual({
+      path: "/canvas",
+      value: { components: [] },
+      sourceTabId: undefined,
+    });
+  });
+});
+
+describe("makeCanvasApi.patch", () => {
+  let h: Harness;
+  beforeEach(() => {
+    h = newHarness({ attributedTab: "tab-1" });
+  });
+
+  it("prefixes /canvas to the subpath", async () => {
+    await h.api.patch("/components/0/props/title", "hello");
+    expect(h.calls[0]).toEqual({
+      path: "/canvas/components/0/props/title",
+      value: "hello",
+      sourceTabId: undefined,
+    });
+  });
+
+  it("accepts subpaths without a leading slash", async () => {
+    await h.api.patch("components/0/props/title", "hello");
+    expect(h.calls[0].path).toBe("/canvas/components/0/props/title");
+  });
+
+  it("rejects empty / non-string subpath without calling setState", async () => {
+    const r1 = await h.api.patch("", "x");
+    const r2 = await h.api.patch(42 as unknown as string, "x");
+    expect(r1.ok).toBe(false);
+    expect(r2.ok).toBe(false);
+    expect(h.calls).toHaveLength(0);
+  });
+});
+
+describe("makeCanvasApi tab attribution", () => {
+  it("forwards boundTabId as sourceTabId on every write", async () => {
+    const h = newHarness();
+    const api = makeCanvasApi("tab-bound", {
+      setState: (path, value, sourceTabId) => {
+        h.calls.push({ path, value, sourceTabId });
+        return Promise.resolve({ ok: true });
+      },
+      resolveAttributedTab: (explicit) => explicit ?? "tab-active",
+      readCanvasComponents: () => [],
+    });
+    await api.emit({ type: "card" });
+    await api.append({ type: "text" });
+    await api.clear();
+    await api.patch("/foo", 1);
+    expect(h.calls.map((c) => c.sourceTabId)).toEqual([
+      "tab-bound",
+      "tab-bound",
+      "tab-bound",
+      "tab-bound",
+    ]);
+  });
+
+  it("global variant (boundTabId undefined) uses resolveAttributedTab for append reads", async () => {
+    const calls: SetStateCall[] = [];
+    const seen: (string | undefined)[] = [];
+    const existing: CanvasComponent = { type: "card", id: "from-active-tab" };
+    const api = makeCanvasApi(undefined, {
+      setState: (path, value, sourceTabId) => {
+        calls.push({ path, value, sourceTabId });
+        return Promise.resolve({ ok: true });
+      },
+      resolveAttributedTab: (explicit) => {
+        seen.push(explicit);
+        return explicit ?? "tab-active";
+      },
+      readCanvasComponents: (id) =>
+        id === "tab-active" ? [existing] : [],
+    });
+    await api.append({ type: "text", id: "new" });
+    expect(seen).toEqual([undefined]);
+    expect(calls[0].value).toEqual({
+      components: [existing, { type: "text", id: "new" }],
+    });
+    expect(calls[0].sourceTabId).toBeUndefined();
+  });
+});
+
+describe("makeCanvasApi error propagation", () => {
+  it("propagates setState failure through emit", async () => {
+    const api = makeCanvasApi(undefined, {
+      setState: () => Promise.resolve({ ok: false, error: "frontend_rejected: oops" }),
+      resolveAttributedTab: () => undefined,
+      readCanvasComponents: () => [],
+    });
+    const r = await api.emit({ type: "card" });
+    expect(r).toEqual({ ok: false, error: "frontend_rejected: oops" });
+  });
+});

--- a/agent/canvas.ts
+++ b/agent/canvas.ts
@@ -1,0 +1,124 @@
+/**
+ * Programmatic canvas push API — sugar over `setState("/canvas", ...)`.
+ *
+ * Extracted from `agent/main.ts` so it has a unit-test surface without
+ * spinning up the full bridge. The factory takes `setState` and a
+ * per-tab canvas reader as plain dependencies; the bridge wires them to
+ * its real `_setState` and `perTabExtState` map. Pure module — no I/O,
+ * no globals, no shared state.
+ *
+ * The four operations:
+ *   emit(c | c[])    — replace `/canvas` with `{components: [...]}`
+ *   append(c | c[])  — read existing components, push new ones, write back
+ *   clear()          — write `{components: []}`
+ *   patch(p, value)  — sugar over setState("/canvas" + p, value)
+ *
+ * `append` reads from the bridge's mirror rather than asking the
+ * frontend, so it works pre-`ready` (boot-time extension code) and stays
+ * consistent under concurrent handler dispatches on different tabs.
+ */
+export interface CanvasComponent {
+  id?: string;
+  type: string;
+  props?: Record<string, unknown>;
+  children?: unknown[];
+}
+
+export interface CanvasMutationResult {
+  ok: boolean;
+  error?: string;
+}
+
+export interface CanvasApi {
+  emit(components: CanvasComponent | CanvasComponent[]): Promise<CanvasMutationResult>;
+  append(components: CanvasComponent | CanvasComponent[]): Promise<CanvasMutationResult>;
+  clear(): Promise<CanvasMutationResult>;
+  patch(subpath: string, value: unknown): Promise<CanvasMutationResult>;
+}
+
+export interface CanvasDeps {
+  /**
+   * Tab-aware setState. Mirrors the bridge's `_setState(path, value, sourceTabId?)`.
+   * The factory always passes `boundTabId` as `sourceTabId` so attribution
+   * is explicit; pass `undefined` to defer to ALS / active-tab fallback.
+   */
+  setState: (
+    path: string,
+    value: unknown,
+    sourceTabId: string | undefined,
+  ) => Promise<CanvasMutationResult>;
+  /**
+   * Returns the currently-attributed tab when no explicit id was given.
+   * The bridge wires this to `tabContext.getStore() ?? currentAgentTabId`.
+   * Used only by `append` to decide which tab's mirrored canvas to read.
+   */
+  resolveAttributedTab: (explicitTabId: string | undefined) => string | undefined;
+  /** Returns the components currently mirrored at `/canvas` for the tab, or `[]`. */
+  readCanvasComponents: (tabId: string | undefined) => CanvasComponent[];
+}
+
+export function normalizeCanvasComponents(input: unknown): CanvasComponent[] {
+  if (input == null) return [];
+  const arr = Array.isArray(input) ? input : [input];
+  return arr.filter(
+    (c): c is CanvasComponent =>
+      !!c &&
+      typeof c === "object" &&
+      typeof (c as { type?: unknown }).type === "string" &&
+      (c as { type: string }).type.length > 0,
+  );
+}
+
+export function readCanvasComponentsFromTabState(
+  tabState: Record<string, unknown> | undefined,
+): CanvasComponent[] {
+  if (!tabState) return [];
+  const canvas = tabState.canvas as { components?: unknown } | undefined;
+  const components = canvas?.components;
+  return Array.isArray(components)
+    ? (components.filter(
+        (c) => !!c && typeof c === "object",
+      ) as CanvasComponent[])
+    : [];
+}
+
+/**
+ * Build a canvas API bound to a specific tab (or to the floating
+ * "active tab" when `boundTabId` is undefined). The bridge calls this
+ * once per handler dispatch (binding to the originating tabId) and
+ * once at boot for the global `aethon.canvas` (binding to undefined,
+ * so writes flow through the same ALS / active-tab fallback that
+ * `setState(path, value)` uses).
+ */
+export function makeCanvasApi(
+  boundTabId: string | undefined,
+  deps: CanvasDeps,
+): CanvasApi {
+  return {
+    emit(components) {
+      const list = normalizeCanvasComponents(components);
+      return deps.setState("/canvas", { components: list }, boundTabId);
+    },
+    append(components) {
+      const additions = normalizeCanvasComponents(components);
+      if (additions.length === 0) return Promise.resolve({ ok: true });
+      const attributedTab = deps.resolveAttributedTab(boundTabId);
+      const existing = deps.readCanvasComponents(attributedTab);
+      return deps.setState(
+        "/canvas",
+        { components: [...existing, ...additions] },
+        boundTabId,
+      );
+    },
+    clear() {
+      return deps.setState("/canvas", { components: [] }, boundTabId);
+    },
+    patch(subpath, value) {
+      if (typeof subpath !== "string" || subpath.length === 0) {
+        return Promise.resolve({ ok: false, error: "subpath required" });
+      }
+      const normalized = subpath.startsWith("/") ? subpath : "/" + subpath;
+      return deps.setState("/canvas" + normalized, value, boundTabId);
+    },
+  };
+}

--- a/agent/main.ts
+++ b/agent/main.ts
@@ -140,6 +140,11 @@ import { homedir } from "node:os";
 import { pathToFileURL } from "node:url";
 import { findProjectExtensionDirs } from "./project-extensions";
 import {
+  makeCanvasApi as buildCanvasApi,
+  readCanvasComponentsFromTabState,
+} from "./canvas";
+import type { CanvasApi } from "./canvas";
+import {
   readSessionMetadata,
   readSessionTranscript,
 } from "./session-history";
@@ -1384,6 +1389,7 @@ async function main() {
       setState: AethonApi["setState"];
       registerComponent: AethonApi["registerComponent"];
       pi: PiHandlerCtx;
+      canvas: AethonApi["canvas"];
     },
   ) => void | Promise<void>;
   const a2uiEventHandlers: { match: A2UIEventMatch; handler: A2UIEventHandler }[] = [];
@@ -1519,6 +1525,32 @@ async function main() {
       ...(attributedTab ? { tabId: attributedTab } : {}),
     });
     return promise;
+  }
+  // Programmatic canvas push API — sugar over `setState("/canvas", ...)`.
+  // Implementation lives in `./canvas.ts` so it can be unit-tested
+  // without booting the bridge; we just pass the bridge-private helpers
+  // (`_setState`, the per-tab mirror reader, the attribution resolver)
+  // as deps.
+  //
+  // `emit` replaces /canvas wholesale; `append` reads the bridge's
+  // mirrored copy in `perTabExtState` and pushes new entries onto the
+  // end; `clear` writes an empty components array; `patch` is a thin
+  // sugar over setState("/canvas" + subpath, value) — useful for
+  // streaming updates to a specific component's props during a turn.
+  //
+  // The handler-ctx variant binds the attributed tab (via `makeCanvasApi(tabId)`)
+  // so a sidebar click that routes to a handler keeps writing to the
+  // originating tab even if the user has switched while the handler
+  // was async.
+  function makeCanvasApi(tabId: string | undefined): CanvasApi {
+    return buildCanvasApi(tabId, {
+      setState: (path, value, sourceTabId) => _setState(path, value, sourceTabId),
+      resolveAttributedTab: (explicit) =>
+        explicit ?? tabContext.getStore() ?? currentAgentTabId,
+      readCanvasComponents: (id) => readCanvasComponentsFromTabState(
+        id ? perTabExtState.get(id) : undefined,
+      ),
+    });
   }
   // Pi may re-run extension register() per session, and `tabs` create
   // sessions on demand — so without dedup, every new tab would re-add
@@ -2121,6 +2153,9 @@ async function main() {
     getLayoutSlots: _getLayoutSlots,
     getFrontendState: _getFrontendState,
     getRuntimeSnapshot: _getRuntimeSnapshot,
+    // Programmatic canvas push API. Tab attribution flows through the
+    // same priority chain as setState (explicit > ALS > currentAgentTabId).
+    canvas: makeCanvasApi(undefined),
   };
   type AethonApi = typeof aethonApi;
   (globalThis as { aethon?: AethonApi }).aethon = aethonApi;
@@ -2928,6 +2963,11 @@ async function main() {
           // the right tab even when the user has since switched.
           const tabScopedSetState = (path: string, value: unknown) =>
             _setState(path, value, handlerTabId);
+          // Tab-scoped canvas helper for handlers — same attribution
+          // guarantee as tabScopedSetState. `append` reads from the
+          // bridge's per-tab mirror, so concurrent dispatches on
+          // different tabs see their own canvas state.
+          const tabScopedCanvas = makeCanvasApi(handlerTabId);
           for (const { match, handler } of a2uiEventHandlers) {
             if (match.templateRootType && match.templateRootType !== ev.templateRootType) continue;
             if (match.componentType && match.componentType !== ev.componentType) continue;
@@ -2965,6 +3005,7 @@ async function main() {
                     setState: tabScopedSetState,
                     registerComponent: aethonApi.registerComponent,
                     pi: piCtx,
+                    canvas: tabScopedCanvas,
                   }),
                 ),
               )

--- a/agent/system-prompt.ts
+++ b/agent/system-prompt.ts
@@ -218,9 +218,15 @@ There are two channels:
 2. **Persistent UI** — call \`aethon.setLayout / patchLayout / setState\` to
    modify the workspace itself (sidebar items, status bar, themes, panels).
    Good for ongoing surfaces. Survives webview reload.
-   For progressive canvas UI, seed \`/canvas\` with an A2UI payload and then
-   patch nested paths such as \`/canvas/components/0/props/title\`; JSON
-   Pointer state writes preserve arrays.
+   For progressive canvas UI, prefer the canvas helper:
+   \`aethon.canvas.emit(component | components[])\` to replace the canvas,
+   \`aethon.canvas.append(...)\` to add without rebuilding the envelope,
+   \`aethon.canvas.patch("/components/0/props/title", "Indexing")\` to
+   stream partial updates, \`aethon.canvas.clear()\` to empty it. Same
+   helper is on the handler \`ctx\` (\`ctx.canvas\`) and pins to the
+   originating tab. Falls back to \`setState("/canvas", ...)\` for
+   anything the helper doesn't cover; both write through the same
+   array-preserving JSON Pointer path.
 
 For tool-driven actions (e.g. a sidebar item that runs a bash command),
 combine: \`registerSidebarSection\` for the entry + \`onEvent\` to handle

--- a/docs/aethon-agent/api.md
+++ b/docs/aethon-agent/api.md
@@ -86,6 +86,48 @@ globalThis.aethon.patchLayout("/components/0/props/areas", [
 ]);
 ```
 
+### `canvas.emit / append / clear / patch`
+
+Programmatic canvas push API — sugar over `setState("/canvas", …)` so
+you don't have to compose the `{components: [...]}` envelope every time.
+Also available on the handler `ctx` (see `onEvent` below) — the ctx
+variant pins to the originating tab so writes survive a tab switch
+mid-handler.
+
+```ts
+// Replace the canvas with a fresh component (or array).
+await globalThis.aethon.canvas.emit({
+  id: "indexing-card",
+  type: "card",
+  props: { title: "Indexing", state: "running" },
+});
+
+// Append onto the existing canvas without reading it manually.
+await globalThis.aethon.canvas.append({
+  id: "next-step",
+  type: "card",
+  props: { title: "Compiling" },
+});
+
+// Empty the canvas.
+await globalThis.aethon.canvas.clear();
+
+// Patch a subpath. Leading `/` is optional; `/canvas` is always prefixed.
+await globalThis.aethon.canvas.patch(
+  "/components/0/props/state",
+  "ok",
+);
+```
+
+Each method returns the same `Promise<MutationResult>` as `setState`.
+`append` reads the bridge's per-tab mirror (no IPC round-trip) so it
+works during boot before the frontend has reported `ready` and stays
+consistent under concurrent handler dispatches on different tabs.
+
+Use this in preference to manual `setState("/canvas", …)` for new
+extensions: the helper survives canvas-shape changes (e.g. if `/canvas`
+ever gains sibling fields beyond `components`).
+
 ### `registerComponent(type, template)`
 
 Define a new A2UI component type. The template is a single A2UI component

--- a/examples/pi-extensions/aethon-types.d.ts
+++ b/examples/pi-extensions/aethon-types.d.ts
@@ -58,11 +58,48 @@ interface AethonPiHandlerCtx {
   readonly signal: AbortSignal | undefined;
 }
 
+interface AethonCanvasComponent {
+  id?: string;
+  type: string;
+  props?: Record<string, unknown>;
+  children?: unknown[];
+}
+
+/**
+ * Programmatic canvas push API — sugar over `setState("/canvas", ...)`.
+ * Per-tab attribution mirrors `setState`: the handler-ctx variant pins
+ * to the originating tab; the global `aethon.canvas` resolves attribution
+ * via AsyncLocalStorage / current active turn.
+ */
+interface AethonCanvasApi {
+  /** Replace the canvas with the given component (or array of components). */
+  emit(
+    components: AethonCanvasComponent | AethonCanvasComponent[],
+  ): Promise<{ ok: boolean; error?: string }>;
+  /** Push the given component(s) onto the end of the existing canvas list. */
+  append(
+    components: AethonCanvasComponent | AethonCanvasComponent[],
+  ): Promise<{ ok: boolean; error?: string }>;
+  /** Empty the canvas. */
+  clear(): Promise<{ ok: boolean; error?: string }>;
+  /**
+   * Patch a subpath under `/canvas` — e.g. `patch("/components/0/props/title", "Indexing")`.
+   * Leading slash is optional. Useful for streaming partial updates while
+   * a turn is still in flight.
+   */
+  patch(
+    subpath: string,
+    value: unknown,
+  ): Promise<{ ok: boolean; error?: string }>;
+}
+
 interface AethonEventCtx {
   setState(path: string, value: unknown): void;
   registerComponent(componentType: string, template: unknown): void;
   /** Pi-coding-agent surface scoped for UI handlers. */
   pi: AethonPiHandlerCtx;
+  /** Tab-scoped canvas helper — writes inherit the originating tab. */
+  canvas: AethonCanvasApi;
 }
 
 declare global {
@@ -146,6 +183,15 @@ declare global {
           ok: boolean;
           error?: string;
         }>;
+
+        /**
+         * Programmatic canvas push API. Lets handlers (or boot-time
+         * extension code) replace, append to, clear, or patch the
+         * `/canvas` slot without composing the wrapper envelope every
+         * time. Attribution falls back through the same priority chain
+         * setState uses (active turn → last-known active tab).
+         */
+        canvas: AethonCanvasApi;
       }
     | undefined;
 }


### PR DESCRIPTION
## Summary

Last remaining SPEC backlog item — `aethon.canvas.{emit, append, clear, patch}` on both `globalThis.aethon` and the handler `ctx`. Sugar over `setState("/canvas", ...)` so handlers can push UI without composing the `{components: [...]}` envelope or reading the existing canvas before appending.

- Pure helper extracted to `agent/canvas.ts` (covered by 23 vitest cases). The bridge wires real `_setState`, the per-tab mirror reader, and the attribution resolver in.
- Handler ctx variant binds `handlerTabId`; global variant defers attribution to ALS / `currentAgentTabId` via the same priority chain `setState` uses.
- `append` reads from the bridge's mirrored `perTabExtState` so it works pre-`ready` and stays consistent under concurrent dispatches on different tabs (covered by a dedicated test).
- Ambient `aethon-types.d.ts` exposes `AethonCanvasApi` + `AethonCanvasComponent` to extension authors.
- System prompt + bundled `api.md` teach the agent to prefer `canvas.*` over manual `/canvas` `setState`. `SPEC.md` marks the item shipped (`Still on the backlog` is now empty).

## Test plan

- [x] `bunx vitest run agent/canvas.test.ts` — 23 passing
- [x] `nix develop -c check` — clippy + tsc + ESLint + cargo test (14) + vitest (130) all green
- [ ] Codex peer review (`codex review --base main` high reasoning) before merge

## Notes

`MutationResult` and `CanvasMutationResult` share the same shape (`{ok, error?}`); the canvas module declares its own type alias rather than importing from `agent/main.ts` so the helper stays standalone-testable. Cross-shape compatibility is structural.