### PR TITLE
fix(canvas): codex review follow-ups (8 P2s)

### DIFF
--- a/agent/canvas.test.ts
+++ b/agent/canvas.test.ts
@@ -60,6 +60,11 @@ function newHarness(opts: {
       },
       readCanvasComponents: (tabId) =>
         readCanvasComponentsFromTabState(mirror.get(tabId)),
+      syncMirror: () => {
+        // No-op in this harness — writeTab === readTab here, so the
+        // helper never invokes syncMirror anyway. Provided for type
+        // completeness.
+      },
     }),
   };
   return harness;
@@ -215,6 +220,7 @@ describe("makeCanvasApi.append", () => {
         return { writeTab: tab, readTab: tab };
       },
       readCanvasComponents: (id) => readCanvasComponentsFromTabState(h.mirror.get(id)),
+      syncMirror: () => undefined,
     });
     const fresh: CanvasComponent = { type: "text", id: "fresh" };
     await tab2Api.append(fresh);
@@ -277,6 +283,7 @@ describe("makeCanvasApi tab attribution", () => {
         return { writeTab: tab, readTab: tab };
       },
       readCanvasComponents: () => [],
+      syncMirror: () => undefined,
     });
     await api.emit({ type: "card" });
     await api.append({ type: "text" });
@@ -309,6 +316,7 @@ describe("makeCanvasApi tab attribution", () => {
       },
       readCanvasComponents: (id) =>
         id === "active-tab" ? [existing] : [],
+      syncMirror: () => undefined,
     });
     await api.append({ type: "text", id: "new" });
     expect(seen).toEqual([undefined]);
@@ -340,6 +348,7 @@ describe("makeCanvasApi emit + patch + append", () => {
         return { writeTab: tab, readTab: tab };
       },
       readCanvasComponents: () => readCanvasComponentsFromTabState(mirror),
+      syncMirror: () => undefined,
     });
     const c1: CanvasComponent = {
       id: "indexing",
@@ -383,6 +392,7 @@ describe("makeCanvasApi.append boot-time fallback", () => {
       resolveTabs: () => ({ writeTab: "default", readTab: "default" }),
       readCanvasComponents: (id) =>
         readCanvasComponentsFromTabState(mirror.get(id)),
+      syncMirror: () => undefined,
     });
     const c1: CanvasComponent = { type: "card", id: "first" };
     const c2: CanvasComponent = { type: "card", id: "second" };
@@ -392,6 +402,86 @@ describe("makeCanvasApi.append boot-time fallback", () => {
     expect(calls[0].sourceTabId).toBe("default");
     expect(calls[1].sourceTabId).toBe("default");
     expect(calls[1].value).toEqual({ components: [c1, c2] });
+  });
+});
+
+describe("makeCanvasApi tab-less mirror sync", () => {
+  it("invokes syncMirror with readTab when writeTab is undefined", async () => {
+    // Post-ready tab-less write: outbound patch carries no sourceTabId
+    // (frontend routes to active), but the bridge must still update its
+    // perTabExtState[readTab] so the next append composes on top of
+    // the previous one. The helper detects writeTab !== readTab and
+    // calls syncMirror after the setState resolves.
+    const setStateCalls: SetStateCall[] = [];
+    const syncCalls: { tabId: string; path: string; value: unknown }[] = [];
+    let mirror: Record<string, unknown> = {};
+    const api = makeCanvasApi(undefined, {
+      setState: (path, value, sourceTabId) => {
+        setStateCalls.push({ path, value, sourceTabId });
+        return Promise.resolve({ ok: true });
+      },
+      resolveTabs: () => ({ writeTab: undefined, readTab: "active" }),
+      readCanvasComponents: (id) =>
+        readCanvasComponentsFromTabState(
+          (mirror[id] as { canvas?: { components?: CanvasComponent[] } } | undefined),
+        ),
+      syncMirror: (tabId, path, value) => {
+        syncCalls.push({ tabId, path, value });
+        const before =
+          (mirror[tabId] as Record<string, unknown> | undefined) ?? {};
+        mirror = {
+          ...mirror,
+          [tabId]: setAtPointer(before, path, value),
+        };
+      },
+    });
+    const c1: CanvasComponent = { type: "card", id: "first" };
+    const c2: CanvasComponent = { type: "card", id: "second" };
+    await api.append(c1);
+    await api.append(c2);
+    expect(setStateCalls).toHaveLength(2);
+    expect(setStateCalls.map((c) => c.sourceTabId)).toEqual([
+      undefined,
+      undefined,
+    ]);
+    expect(syncCalls).toHaveLength(2);
+    expect(syncCalls[0].tabId).toBe("active");
+    // The second append must compose with the first — proving syncMirror
+    // kept the bridge's view in sync even though the wire went tab-less.
+    expect(setStateCalls[1].value).toEqual({
+      components: [c1, c2],
+    });
+  });
+
+  it("does not invoke syncMirror when writeTab === readTab (already in sync via setState)", async () => {
+    const syncCalls: { tabId: string; path: string; value: unknown }[] = [];
+    const api = makeCanvasApi(undefined, {
+      setState: () => Promise.resolve({ ok: true }),
+      resolveTabs: () => ({ writeTab: "tab-1", readTab: "tab-1" }),
+      readCanvasComponents: () => [],
+      syncMirror: (tabId, path, value) => {
+        syncCalls.push({ tabId, path, value });
+      },
+    });
+    await api.emit({ type: "card" });
+    await api.append({ type: "text" });
+    await api.clear();
+    expect(syncCalls).toEqual([]);
+  });
+
+  it("does not invoke syncMirror if setState fails", async () => {
+    const syncCalls: unknown[] = [];
+    const api = makeCanvasApi(undefined, {
+      setState: () => Promise.resolve({ ok: false, error: "frontend_rejected" }),
+      resolveTabs: () => ({ writeTab: undefined, readTab: "active" }),
+      readCanvasComponents: () => [],
+      syncMirror: (...args) => {
+        syncCalls.push(args);
+      },
+    });
+    const r = await api.emit({ type: "card" });
+    expect(r.ok).toBe(false);
+    expect(syncCalls).toEqual([]);
   });
 });
 
@@ -409,6 +499,7 @@ describe("makeCanvasApi post-ready tab-less write", () => {
       },
       resolveTabs: () => ({ writeTab: undefined, readTab: "active-tab" }),
       readCanvasComponents: () => [],
+      syncMirror: () => undefined,
     });
     await api.emit({ type: "card" });
     await api.clear();
@@ -427,6 +518,7 @@ describe("makeCanvasApi error propagation", () => {
       setState: () => Promise.resolve({ ok: false, error: "frontend_rejected: oops" }),
       resolveTabs: () => ({ writeTab: "default", readTab: "default" }),
       readCanvasComponents: () => [],
+      syncMirror: () => undefined,
     });
     const r = await api.emit({ type: "card" });
     expect(r).toEqual({ ok: false, error: "frontend_rejected: oops" });

--- a/agent/canvas.test.ts
+++ b/agent/canvas.test.ts
@@ -37,9 +37,9 @@ function newHarness(opts: {
   if (opts.initialMirror) {
     for (const [k, v] of Object.entries(opts.initialMirror)) mirror.set(k, v);
   }
-  // The bridge's resolver always returns a real tab id ("default" is
-  // its baseline); reproduce that here so makeCanvasApi's CanvasDeps
-  // contract holds in tests too.
+  // Tests model the "always-attributed" regime — explicit or current
+  // turn — so `writeTab === readTab`. Tab-less regimes (pre/post-ready)
+  // are covered by their own dedicated test below.
   const fallbackTab = opts.attributedTab ?? "default";
   const harness: Harness = {
     calls,
@@ -54,7 +54,10 @@ function newHarness(opts: {
         }
         return Promise.resolve(opts.setStateResult ?? { ok: true });
       },
-      resolveAttributedTab: (explicit) => explicit ?? fallbackTab,
+      resolveTabs: (explicit) => {
+        const tab = explicit ?? fallbackTab;
+        return { writeTab: tab, readTab: tab };
+      },
       readCanvasComponents: (tabId) =>
         readCanvasComponentsFromTabState(mirror.get(tabId)),
     }),
@@ -207,7 +210,10 @@ describe("makeCanvasApi.append", () => {
         h.calls.push({ path, value, sourceTabId });
         return Promise.resolve({ ok: true });
       },
-      resolveAttributedTab: (explicit) => explicit ?? "tab-1",
+      resolveTabs: (explicit) => {
+        const tab = explicit ?? "tab-1";
+        return { writeTab: tab, readTab: tab };
+      },
       readCanvasComponents: (id) => readCanvasComponentsFromTabState(h.mirror.get(id)),
     });
     const fresh: CanvasComponent = { type: "text", id: "fresh" };
@@ -266,7 +272,10 @@ describe("makeCanvasApi tab attribution", () => {
         h.calls.push({ path, value, sourceTabId });
         return Promise.resolve({ ok: true });
       },
-      resolveAttributedTab: (explicit) => explicit ?? "tab-active",
+      resolveTabs: (explicit) => {
+        const tab = explicit ?? "tab-active";
+        return { writeTab: tab, readTab: tab };
+      },
       readCanvasComponents: () => [],
     });
     await api.emit({ type: "card" });
@@ -281,32 +290,32 @@ describe("makeCanvasApi tab attribution", () => {
     ]);
   });
 
-  it("global variant (boundTabId undefined) attributes to the resolver's fallback", async () => {
-    // Bridge's contract: resolveAttributedTab always returns a real
-    // tab id (falling back to "default" when no ALS / active tab).
-    // The global aethon.canvas helper picks that up so writes always
-    // attribute to a tab — never to the global state tree.
+  it("post-ready tab-less write omits sourceTabId (lets frontend route to active)", async () => {
+    // The bridge's resolveTabs returns `{writeTab: undefined, readTab: <activeTab>}`
+    // when frontendReady is true and no ALS / active turn exists, so
+    // canvas.* matches plain setState semantics. append still reads
+    // from the predicted active tab so its compose-on-read works.
     const calls: SetStateCall[] = [];
     const seen: (string | undefined)[] = [];
-    const existing: CanvasComponent = { type: "card", id: "from-default" };
+    const existing: CanvasComponent = { type: "card", id: "from-active" };
     const api = makeCanvasApi(undefined, {
       setState: (path, value, sourceTabId) => {
         calls.push({ path, value, sourceTabId });
         return Promise.resolve({ ok: true });
       },
-      resolveAttributedTab: (explicit) => {
+      resolveTabs: (explicit) => {
         seen.push(explicit);
-        return explicit ?? "default";
+        return { writeTab: undefined, readTab: "active-tab" };
       },
       readCanvasComponents: (id) =>
-        id === "default" ? [existing] : [],
+        id === "active-tab" ? [existing] : [],
     });
     await api.append({ type: "text", id: "new" });
     expect(seen).toEqual([undefined]);
     expect(calls[0].value).toEqual({
       components: [existing, { type: "text", id: "new" }],
     });
-    expect(calls[0].sourceTabId).toBe("default");
+    expect(calls[0].sourceTabId).toBeUndefined();
   });
 });
 
@@ -326,7 +335,10 @@ describe("makeCanvasApi emit + patch + append", () => {
         mirror = setAtPointer(mirror, path, value);
         return Promise.resolve({ ok: true });
       },
-      resolveAttributedTab: (explicit) => explicit ?? "tab-1",
+      resolveTabs: (explicit) => {
+        const tab = explicit ?? "tab-1";
+        return { writeTab: tab, readTab: tab };
+      },
       readCanvasComponents: () => readCanvasComponentsFromTabState(mirror),
     });
     const c1: CanvasComponent = {
@@ -352,12 +364,12 @@ describe("makeCanvasApi emit + patch + append", () => {
 });
 
 describe("makeCanvasApi.append boot-time fallback", () => {
-  it("attributes boot writes to the resolver's default tab and survives sequential appends", async () => {
-    // Mirrors the bridge's boot-time wiring: with no ALS / active tab,
-    // resolveAttributedTab returns the canonical default tab so the
-    // write lands in that tab's per-tab mirror (which the frontend
-    // replays on `ready`). The reader and the writer agree on the same
-    // tab id, so two sequential appends compose instead of clobbering.
+  it("pre-ready appends attribute to default tab and compose across calls", async () => {
+    // Pre-ready (no frontend connected, no ALS / active turn): writes
+    // and reads both target the canonical "default" tab, so sequential
+    // appends compose. Without this, boot writes routed into the global
+    // state tree and the frontend's active-tab empty mirror clobbered
+    // them on hydration.
     const calls: SetStateCall[] = [];
     const mirror = new Map<string, { canvas?: { components?: CanvasComponent[] } }>();
     const api = makeCanvasApi(undefined, {
@@ -368,7 +380,7 @@ describe("makeCanvasApi.append boot-time fallback", () => {
         }
         return Promise.resolve({ ok: true });
       },
-      resolveAttributedTab: (explicit) => explicit ?? "default",
+      resolveTabs: () => ({ writeTab: "default", readTab: "default" }),
       readCanvasComponents: (id) =>
         readCanvasComponentsFromTabState(mirror.get(id)),
     });
@@ -377,11 +389,35 @@ describe("makeCanvasApi.append boot-time fallback", () => {
     await api.append(c1);
     await api.append(c2);
     expect(calls).toHaveLength(2);
-    // Both writes attribute to "default" rather than the global tree.
     expect(calls[0].sourceTabId).toBe("default");
     expect(calls[1].sourceTabId).toBe("default");
-    // The second append composes with the first.
     expect(calls[1].value).toEqual({ components: [c1, c2] });
+  });
+});
+
+describe("makeCanvasApi post-ready tab-less write", () => {
+  it("emit/clear/patch send no sourceTabId so the frontend routes to its active tab", async () => {
+    // Matches plain setState semantics: tab-less writes after the
+    // frontend has reported ready must omit attribution. The ONLY
+    // hint we give the helper is the predicted-active read scope, used
+    // by append.
+    const calls: SetStateCall[] = [];
+    const api = makeCanvasApi(undefined, {
+      setState: (path, value, sourceTabId) => {
+        calls.push({ path, value, sourceTabId });
+        return Promise.resolve({ ok: true });
+      },
+      resolveTabs: () => ({ writeTab: undefined, readTab: "active-tab" }),
+      readCanvasComponents: () => [],
+    });
+    await api.emit({ type: "card" });
+    await api.clear();
+    await api.patch("/components/0/props/title", "x");
+    expect(calls.map((c) => c.sourceTabId)).toEqual([
+      undefined,
+      undefined,
+      undefined,
+    ]);
   });
 });
 
@@ -389,7 +425,7 @@ describe("makeCanvasApi error propagation", () => {
   it("propagates setState failure through emit", async () => {
     const api = makeCanvasApi(undefined, {
       setState: () => Promise.resolve({ ok: false, error: "frontend_rejected: oops" }),
-      resolveAttributedTab: () => "default",
+      resolveTabs: () => ({ writeTab: "default", readTab: "default" }),
       readCanvasComponents: () => [],
     });
     const r = await api.emit({ type: "card" });

--- a/agent/canvas.test.ts
+++ b/agent/canvas.test.ts
@@ -469,19 +469,46 @@ describe("makeCanvasApi tab-less mirror sync", () => {
     expect(syncCalls).toEqual([]);
   });
 
-  it("does not invoke syncMirror if setState fails", async () => {
-    const syncCalls: unknown[] = [];
+  it("invokes syncMirror synchronously so fire-and-forget appends compose", async () => {
+    // Two appends in the same tick without awaiting the first. The
+    // helper must fold the first write into the bridge's mirror BEFORE
+    // setState's await yields, so the second append's read sees it.
+    // (Without this, both appends read [] and the second clobbers the
+    // first on the wire.)
+    const setStateCalls: SetStateCall[] = [];
+    let mirror: Record<string, unknown> = {};
     const api = makeCanvasApi(undefined, {
-      setState: () => Promise.resolve({ ok: false, error: "frontend_rejected" }),
+      setState: (path, value, sourceTabId) => {
+        setStateCalls.push({ path, value, sourceTabId });
+        // Simulate a non-trivial round-trip. The helper must NOT wait
+        // for this before the second append's read.
+        return new Promise((resolve) =>
+          setTimeout(() => resolve({ ok: true }), 5),
+        );
+      },
       resolveTabs: () => ({ writeTab: undefined, readTab: "active" }),
-      readCanvasComponents: () => [],
-      syncMirror: (...args) => {
-        syncCalls.push(args);
+      readCanvasComponents: (id) =>
+        readCanvasComponentsFromTabState(
+          (mirror[id] as { canvas?: { components?: CanvasComponent[] } } | undefined),
+        ),
+      syncMirror: (tabId, path, value) => {
+        const before =
+          (mirror[tabId] as Record<string, unknown> | undefined) ?? {};
+        mirror = {
+          ...mirror,
+          [tabId]: setAtPointer(before, path, value),
+        };
       },
     });
-    const r = await api.emit({ type: "card" });
-    expect(r.ok).toBe(false);
-    expect(syncCalls).toEqual([]);
+    const c1: CanvasComponent = { type: "card", id: "first" };
+    const c2: CanvasComponent = { type: "card", id: "second" };
+    // Don't await the first — fire and forget, then immediately fire
+    // the second.
+    const p1 = api.append(c1);
+    const p2 = api.append(c2);
+    await Promise.all([p1, p2]);
+    expect(setStateCalls).toHaveLength(2);
+    expect(setStateCalls[1].value).toEqual({ components: [c1, c2] });
   });
 });
 

--- a/agent/canvas.test.ts
+++ b/agent/canvas.test.ts
@@ -305,17 +305,20 @@ describe("makeCanvasApi emit + patch + append", () => {
 });
 
 describe("makeCanvasApi tab-less seed fallback", () => {
-  it("uses the bridge's tab-less retained canvas when per-tab mirror is empty", async () => {
-    // Models the case codex flagged: an extension calls plain
-    // aethon.setState("/canvas", ...) without a tab context, which
-    // routes to extensionStateTree on the bridge. canvas.append should
-    // see THAT seed and compose with it, not replace the visible canvas
-    // with only the appended component.
-    const seeded: CanvasComponent = { type: "card", id: "seeded-via-setState" };
+  // Helper that mirrors the bridge's read priority: per-tab mirror
+  // first, fall back to the tab-less retained canvas ONLY when the
+  // per-tab record has no canvas slot at all. An explicit empty canvas
+  // (after clear/emit-empty) IS a value — must not be resurrected.
+  function makeFallbackDeps(seedComponents: CanvasComponent[]): {
+    deps: CanvasDeps;
+    calls: SetStateCall[];
+    perTab: Map<string, Record<string, unknown>>;
+    tabless: Record<string, unknown>;
+  } {
     const calls: SetStateCall[] = [];
     const perTab = new Map<string, Record<string, unknown>>();
-    const tablessRetained: Record<string, unknown> = {
-      canvas: { components: [seeded] },
+    const tabless: Record<string, unknown> = {
+      canvas: { components: seedComponents },
     };
     const deps: CanvasDeps = {
       setState: (path, value, sourceTabId) => {
@@ -326,17 +329,48 @@ describe("makeCanvasApi tab-less seed fallback", () => {
       },
       resolveTab: (explicit) => explicit ?? "active",
       readCanvasComponents: (id) => {
-        const fromTab = readCanvasComponentsFromTabState(perTab.get(id));
-        if (fromTab.length > 0) return fromTab;
-        return readCanvasComponentsFromTabState(tablessRetained);
+        const tabState = perTab.get(id);
+        if (tabState && (tabState as { canvas?: unknown }).canvas !== undefined) {
+          return readCanvasComponentsFromTabState(tabState);
+        }
+        return readCanvasComponentsFromTabState(tabless);
       },
     };
+    return { deps, calls, perTab, tabless };
+  }
+
+  it("uses the bridge's tab-less retained canvas when per-tab mirror has no canvas slot", async () => {
+    const seeded: CanvasComponent = { type: "card", id: "seeded-via-setState" };
+    const { deps, calls } = makeFallbackDeps([seeded]);
     const api = makeCanvasApi(undefined, deps);
     const fresh: CanvasComponent = { type: "text", id: "appended" };
     await api.append(fresh);
-    expect(calls[0].value).toEqual({
-      components: [seeded, fresh],
-    });
+    expect(calls[0].value).toEqual({ components: [seeded, fresh] });
+  });
+
+  it("does NOT resurrect tab-less seed after the per-tab canvas was explicitly cleared", async () => {
+    const seeded: CanvasComponent = { type: "card", id: "seeded-via-setState" };
+    const { deps, calls } = makeFallbackDeps([seeded]);
+    const api = makeCanvasApi(undefined, deps);
+    // Explicitly clear the canvas on the active tab — sets per-tab
+    // canvas to {components: []}.
+    await api.clear();
+    expect(calls[0].value).toEqual({ components: [] });
+    // Append after clear: must compose with the empty per-tab canvas,
+    // not the stale tab-less seed.
+    const fresh: CanvasComponent = { type: "text", id: "appended" };
+    await api.append(fresh);
+    expect(calls[1].value).toEqual({ components: [fresh] });
+  });
+
+  it("does NOT resurrect tab-less seed after emit([])", async () => {
+    const seeded: CanvasComponent = { type: "card", id: "seeded" };
+    const { deps, calls } = makeFallbackDeps([seeded]);
+    const api = makeCanvasApi(undefined, deps);
+    await api.emit([]);
+    const fresh: CanvasComponent = { type: "text", id: "appended" };
+    await api.append(fresh);
+    expect(calls[1].value).toEqual({ components: [fresh] });
   });
 });
 

--- a/agent/canvas.test.ts
+++ b/agent/canvas.test.ts
@@ -305,20 +305,26 @@ describe("makeCanvasApi emit + patch + append", () => {
 });
 
 describe("makeCanvasApi tab-less seed fallback", () => {
-  // Helper that mirrors the bridge's read priority: per-tab mirror
-  // first, fall back to the tab-less retained canvas ONLY when the
-  // per-tab record has no canvas slot at all. An explicit empty canvas
-  // (after clear/emit-empty) IS a value — must not be resurrected.
-  function makeFallbackDeps(seedComponents: CanvasComponent[]): {
+  // Helper that mirrors the bridge's read priority:
+  //   1. per-tab mirror (when canvas slot is defined)
+  //   2. tab-less retained canvas, scoped to the active tab id
+  //   3. empty array
+  function makeFallbackDeps(opts: {
+    seedComponents: CanvasComponent[];
+    activeTabId?: string;
+    fallbackResolveTab?: string;
+  }): {
     deps: CanvasDeps;
     calls: SetStateCall[];
     perTab: Map<string, Record<string, unknown>>;
     tabless: Record<string, unknown>;
   } {
+    const activeTabId = opts.activeTabId ?? "active";
+    const fallbackResolveTab = opts.fallbackResolveTab ?? activeTabId;
     const calls: SetStateCall[] = [];
     const perTab = new Map<string, Record<string, unknown>>();
     const tabless: Record<string, unknown> = {
-      canvas: { components: seedComponents },
+      canvas: { components: opts.seedComponents },
     };
     const deps: CanvasDeps = {
       setState: (path, value, sourceTabId) => {
@@ -327,13 +333,16 @@ describe("makeCanvasApi tab-less seed fallback", () => {
         perTab.set(sourceTabId, setAtPointer(before, path, value));
         return Promise.resolve({ ok: true });
       },
-      resolveTab: (explicit) => explicit ?? "active",
+      resolveTab: (explicit) => explicit ?? fallbackResolveTab,
       readCanvasComponents: (id) => {
         const tabState = perTab.get(id);
         if (tabState && (tabState as { canvas?: unknown }).canvas !== undefined) {
           return readCanvasComponentsFromTabState(tabState);
         }
-        return readCanvasComponentsFromTabState(tabless);
+        if (id === activeTabId) {
+          return readCanvasComponentsFromTabState(tabless);
+        }
+        return [];
       },
     };
     return { deps, calls, perTab, tabless };
@@ -341,7 +350,7 @@ describe("makeCanvasApi tab-less seed fallback", () => {
 
   it("uses the bridge's tab-less retained canvas when per-tab mirror has no canvas slot", async () => {
     const seeded: CanvasComponent = { type: "card", id: "seeded-via-setState" };
-    const { deps, calls } = makeFallbackDeps([seeded]);
+    const { deps, calls } = makeFallbackDeps({ seedComponents: [seeded] });
     const api = makeCanvasApi(undefined, deps);
     const fresh: CanvasComponent = { type: "text", id: "appended" };
     await api.append(fresh);
@@ -350,7 +359,7 @@ describe("makeCanvasApi tab-less seed fallback", () => {
 
   it("does NOT resurrect tab-less seed after the per-tab canvas was explicitly cleared", async () => {
     const seeded: CanvasComponent = { type: "card", id: "seeded-via-setState" };
-    const { deps, calls } = makeFallbackDeps([seeded]);
+    const { deps, calls } = makeFallbackDeps({ seedComponents: [seeded] });
     const api = makeCanvasApi(undefined, deps);
     // Explicitly clear the canvas on the active tab — sets per-tab
     // canvas to {components: []}.
@@ -365,12 +374,34 @@ describe("makeCanvasApi tab-less seed fallback", () => {
 
   it("does NOT resurrect tab-less seed after emit([])", async () => {
     const seeded: CanvasComponent = { type: "card", id: "seeded" };
-    const { deps, calls } = makeFallbackDeps([seeded]);
+    const { deps, calls } = makeFallbackDeps({ seedComponents: [seeded] });
     const api = makeCanvasApi(undefined, deps);
     await api.emit([]);
     const fresh: CanvasComponent = { type: "text", id: "appended" };
     await api.append(fresh);
     expect(calls[1].value).toEqual({ components: [fresh] });
+  });
+
+  it("does NOT leak tab-less seed into a non-active tab", async () => {
+    // Plain `aethon.setState("/canvas", ...)` outside any tab routes
+    // through the bridge's tab-less retained store, but on the
+    // frontend it lands ONLY on the active tab. A handler bound to
+    // a different (non-active) tab must NOT pull the seed in via the
+    // append fallback — that would copy the seed into a tab the user
+    // never saw it on.
+    const seeded: CanvasComponent = { type: "card", id: "seeded" };
+    const { deps, calls } = makeFallbackDeps({
+      seedComponents: [seeded],
+      activeTabId: "tab-active",
+      // resolveTab fallback won't be exercised — the API binding
+      // forces "tab-other".
+    });
+    const api = makeCanvasApi("tab-other", deps);
+    const fresh: CanvasComponent = { type: "text", id: "appended" };
+    await api.append(fresh);
+    // No seed in the composed output — append starts from [].
+    expect(calls[0].value).toEqual({ components: [fresh] });
+    expect(calls[0].sourceTabId).toBe("tab-other");
   });
 });
 

--- a/agent/canvas.test.ts
+++ b/agent/canvas.test.ts
@@ -5,69 +5,53 @@ import {
   readCanvasComponentsFromTabState,
   type CanvasComponent,
   type CanvasMutationResult,
+  type CanvasDeps,
 } from "./canvas";
 import { setAtPointer } from "./jsonPointer";
 
 interface SetStateCall {
   path: string;
   value: unknown;
-  sourceTabId: string | undefined;
+  sourceTabId: string;
 }
 
-interface Harness {
-  calls: SetStateCall[];
-  /**
-   * Per-tab mirror — keyed by tabId, value is the bridge's view of what
-   * was last written. Each setState fold-merges the path/value into this
-   * map (only `/canvas` paths matter for these tests, so we just track
-   * the canvas slot).
-   */
-  mirror: Map<string, { canvas?: { components?: CanvasComponent[] } }>;
-  attributedTab: string | undefined;
-  api: ReturnType<typeof makeCanvasApi>;
-}
-
-function newHarness(opts: {
-  attributedTab?: string;
-  initialMirror?: Record<string, { canvas?: { components?: CanvasComponent[] } }>;
+/**
+ * Build a deps object backed by an in-memory per-tab mirror that
+ * mimics the bridge's perTabExtState. setState records every call AND
+ * folds the write into the mirror under sourceTabId — so a follow-up
+ * append composes correctly. resolveTab returns a configurable
+ * fallback (default "default") so tests can model the various
+ * attribution regimes without re-implementing the resolver.
+ */
+function makeTestDeps(opts: {
+  fallbackTab?: string;
   setStateResult?: CanvasMutationResult;
-} = {}): Harness {
+  initialMirror?: Record<string, { canvas?: { components?: CanvasComponent[] } }>;
+} = {}): {
+  deps: CanvasDeps;
+  calls: SetStateCall[];
+  mirror: Map<string, Record<string, unknown>>;
+} {
+  const fallbackTab = opts.fallbackTab ?? "default";
   const calls: SetStateCall[] = [];
-  const mirror = new Map<string, { canvas?: { components?: CanvasComponent[] } }>();
+  const mirror = new Map<string, Record<string, unknown>>();
   if (opts.initialMirror) {
-    for (const [k, v] of Object.entries(opts.initialMirror)) mirror.set(k, v);
+    for (const [k, v] of Object.entries(opts.initialMirror)) {
+      mirror.set(k, v);
+    }
   }
-  // Tests model the "always-attributed" regime — explicit or current
-  // turn — so `writeTab === readTab`. Tab-less regimes (pre/post-ready)
-  // are covered by their own dedicated test below.
-  const fallbackTab = opts.attributedTab ?? "default";
-  const harness: Harness = {
-    calls,
-    mirror,
-    attributedTab: fallbackTab,
-    api: makeCanvasApi(undefined, {
-      setState: (path, value, sourceTabId) => {
-        calls.push({ path, value, sourceTabId });
-        const tabId = sourceTabId ?? fallbackTab;
-        if (path === "/canvas") {
-          mirror.set(tabId, { canvas: value });
-        }
-        return Promise.resolve(opts.setStateResult ?? { ok: true });
-      },
-      resolveTabs: (explicit) => {
-        const tab = explicit ?? fallbackTab;
-        return { writeTab: tab, readTab: tab };
-      },
-      readCanvasComponents: (tabId) =>
-        readCanvasComponentsFromTabState(mirror.get(tabId)),
-      syncMirror: () => {
-        // No-op in this harness — writeTab === readTab here, so the
-        // helper never invokes syncMirror anyway. Provided for type
-        // completeness.
-      },
-    }),
+  const deps: CanvasDeps = {
+    setState: (path, value, sourceTabId) => {
+      calls.push({ path, value, sourceTabId });
+      const before = mirror.get(sourceTabId) ?? {};
+      mirror.set(sourceTabId, setAtPointer(before, path, value));
+      return Promise.resolve(opts.setStateResult ?? { ok: true });
+    },
+    resolveTab: (explicit) => explicit ?? fallbackTab,
+    readCanvasComponents: (tabId) =>
+      readCanvasComponentsFromTabState(mirror.get(tabId)),
   };
-  return harness;
+  return { deps, calls, mirror };
 }
 
 describe("normalizeCanvasComponents", () => {
@@ -82,7 +66,7 @@ describe("normalizeCanvasComponents", () => {
     expect(normalizeCanvasComponents([a, b])).toEqual([a, b]);
   });
 
-  it("filters out null / non-objects / typeless entries", () => {
+  it("filters null / non-objects / typeless entries", () => {
     const valid: CanvasComponent = { type: "card" };
     expect(
       normalizeCanvasComponents([
@@ -97,18 +81,18 @@ describe("normalizeCanvasComponents", () => {
     ).toEqual([valid]);
   });
 
-  it("returns an empty array for null / undefined input", () => {
+  it("returns [] for null / undefined input", () => {
     expect(normalizeCanvasComponents(null)).toEqual([]);
     expect(normalizeCanvasComponents(undefined)).toEqual([]);
   });
 });
 
 describe("readCanvasComponentsFromTabState", () => {
-  it("returns empty when tab state is missing", () => {
+  it("returns [] when tab state is missing", () => {
     expect(readCanvasComponentsFromTabState(undefined)).toEqual([]);
   });
 
-  it("returns empty when canvas slot is unset", () => {
+  it("returns [] when canvas slot is unset", () => {
     expect(readCanvasComponentsFromTabState({})).toEqual([]);
   });
 
@@ -130,110 +114,102 @@ describe("readCanvasComponentsFromTabState", () => {
 });
 
 describe("makeCanvasApi.emit", () => {
-  let h: Harness;
-  beforeEach(() => {
-    h = newHarness({ attributedTab: "tab-1" });
-  });
-
   it("writes /canvas with a {components: [...]} envelope", async () => {
+    const { deps, calls } = makeTestDeps({ fallbackTab: "tab-1" });
+    const api = makeCanvasApi(undefined, deps);
     const c: CanvasComponent = { type: "card", props: { title: "hi" } };
-    const r = await h.api.emit(c);
+    const r = await api.emit(c);
     expect(r).toEqual({ ok: true });
-    expect(h.calls).toHaveLength(1);
-    expect(h.calls[0]).toEqual({
-      path: "/canvas",
-      value: { components: [c] },
-      sourceTabId: "tab-1",
-    });
+    expect(calls).toEqual([
+      { path: "/canvas", value: { components: [c] }, sourceTabId: "tab-1" },
+    ]);
   });
 
   it("accepts an array of components", async () => {
+    const { deps, calls } = makeTestDeps({ fallbackTab: "tab-1" });
+    const api = makeCanvasApi(undefined, deps);
     const c1: CanvasComponent = { type: "card" };
     const c2: CanvasComponent = { type: "text" };
-    await h.api.emit([c1, c2]);
-    expect(h.calls[0].value).toEqual({ components: [c1, c2] });
+    await api.emit([c1, c2]);
+    expect(calls[0].value).toEqual({ components: [c1, c2] });
   });
 
   it("emits with an empty components array when given an empty list", async () => {
-    await h.api.emit([]);
-    expect(h.calls[0].value).toEqual({ components: [] });
+    const { deps, calls } = makeTestDeps({ fallbackTab: "tab-1" });
+    const api = makeCanvasApi(undefined, deps);
+    await api.emit([]);
+    expect(calls[0].value).toEqual({ components: [] });
   });
 });
 
 describe("makeCanvasApi.append", () => {
-  it("reads existing components and appends new ones", async () => {
+  it("reads existing components and composes new ones", async () => {
     const existing: CanvasComponent = { type: "card", id: "old" };
-    const h = newHarness({
-      attributedTab: "tab-1",
+    const { deps, calls } = makeTestDeps({
+      fallbackTab: "tab-1",
       initialMirror: { "tab-1": { canvas: { components: [existing] } } },
     });
+    const api = makeCanvasApi(undefined, deps);
     const fresh: CanvasComponent = { type: "text", id: "new" };
-    await h.api.append(fresh);
-    expect(h.calls).toHaveLength(1);
-    expect(h.calls[0].value).toEqual({ components: [existing, fresh] });
+    await api.append(fresh);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].value).toEqual({ components: [existing, fresh] });
   });
 
-  it("falls back to emit-equivalent when the canvas is empty", async () => {
-    const h = newHarness({ attributedTab: "tab-1" });
+  it("falls back to emit-equivalent when canvas is empty", async () => {
+    const { deps, calls } = makeTestDeps({ fallbackTab: "tab-1" });
+    const api = makeCanvasApi(undefined, deps);
     const c: CanvasComponent = { type: "card" };
-    await h.api.append(c);
-    expect(h.calls[0].value).toEqual({ components: [c] });
+    await api.append(c);
+    expect(calls[0].value).toEqual({ components: [c] });
   });
 
   it("is a no-op (returns ok) when given zero valid components", async () => {
-    const h = newHarness({ attributedTab: "tab-1" });
-    const r = await h.api.append([]);
+    const { deps, calls } = makeTestDeps({ fallbackTab: "tab-1" });
+    const api = makeCanvasApi(undefined, deps);
+    const r = await api.append([]);
     expect(r).toEqual({ ok: true });
-    expect(h.calls).toHaveLength(0);
-  });
-
-  it("filters invalid entries before appending", async () => {
-    const h = newHarness({ attributedTab: "tab-1" });
-    const c: CanvasComponent = { type: "card" };
-    // The runtime helper is defensive against null entries and typeless
-    // / empty-type objects; those wouldn't compile through the normal
-    // `CanvasComponent[]` signature, so push them in as `unknown` first
-    // and let the runtime filter strip them.
-    const inputs: unknown[] = [c, null, { type: "" }];
-    await h.api.append(inputs as CanvasComponent[]);
-    expect(h.calls[0].value).toEqual({ components: [c] });
+    expect(calls).toHaveLength(0);
   });
 
   it("does not see other tabs' canvas state under concurrent dispatches", async () => {
     const onTab1: CanvasComponent = { type: "card", id: "tab1-existing" };
     const onTab2: CanvasComponent = { type: "card", id: "tab2-existing" };
-    const h = newHarness({
-      attributedTab: "tab-1",
+    const { deps, calls } = makeTestDeps({
+      fallbackTab: "tab-1",
       initialMirror: {
         "tab-1": { canvas: { components: [onTab1] } },
         "tab-2": { canvas: { components: [onTab2] } },
       },
     });
-    // Bind to tab-2 explicitly — append should read tab-2's mirror, not tab-1's.
-    const tab2Api = makeCanvasApi("tab-2", {
-      setState: (path, value, sourceTabId) => {
-        h.calls.push({ path, value, sourceTabId });
-        return Promise.resolve({ ok: true });
-      },
-      resolveTabs: (explicit) => {
-        const tab = explicit ?? "tab-1";
-        return { writeTab: tab, readTab: tab };
-      },
-      readCanvasComponents: (id) => readCanvasComponentsFromTabState(h.mirror.get(id)),
-      syncMirror: () => undefined,
-    });
+    // Bind to tab-2 explicitly — append must read tab-2's mirror.
+    const tab2Api = makeCanvasApi("tab-2", deps);
     const fresh: CanvasComponent = { type: "text", id: "fresh" };
     await tab2Api.append(fresh);
-    expect(h.calls[0].sourceTabId).toBe("tab-2");
-    expect(h.calls[0].value).toEqual({ components: [onTab2, fresh] });
+    expect(calls[0].sourceTabId).toBe("tab-2");
+    expect(calls[0].value).toEqual({ components: [onTab2, fresh] });
+  });
+
+  it("composes synchronous fire-and-forget appends via the in-memory mirror", async () => {
+    // Two appends in the same tick without awaiting. The mirror is
+    // updated synchronously inside setState, so the second read sees
+    // the first write.
+    const { deps, calls } = makeTestDeps({ fallbackTab: "tab-1" });
+    const api = makeCanvasApi(undefined, deps);
+    const c1: CanvasComponent = { type: "card", id: "first" };
+    const c2: CanvasComponent = { type: "card", id: "second" };
+    await Promise.all([api.append(c1), api.append(c2)]);
+    expect(calls).toHaveLength(2);
+    expect(calls[1].value).toEqual({ components: [c1, c2] });
   });
 });
 
 describe("makeCanvasApi.clear", () => {
   it("writes /canvas with an empty components array", async () => {
-    const h = newHarness({ attributedTab: "tab-1" });
-    await h.api.clear();
-    expect(h.calls[0]).toEqual({
+    const { deps, calls } = makeTestDeps({ fallbackTab: "tab-1" });
+    const api = makeCanvasApi(undefined, deps);
+    await api.clear();
+    expect(calls[0]).toEqual({
       path: "/canvas",
       value: { components: [] },
       sourceTabId: "tab-1",
@@ -242,14 +218,18 @@ describe("makeCanvasApi.clear", () => {
 });
 
 describe("makeCanvasApi.patch", () => {
-  let h: Harness;
+  let deps: CanvasDeps;
+  let calls: SetStateCall[];
   beforeEach(() => {
-    h = newHarness({ attributedTab: "tab-1" });
+    const harness = makeTestDeps({ fallbackTab: "tab-1" });
+    deps = harness.deps;
+    calls = harness.calls;
   });
 
   it("prefixes /canvas to the subpath", async () => {
-    await h.api.patch("/components/0/props/title", "hello");
-    expect(h.calls[0]).toEqual({
+    const api = makeCanvasApi(undefined, deps);
+    await api.patch("/components/0/props/title", "hello");
+    expect(calls[0]).toEqual({
       path: "/canvas/components/0/props/title",
       value: "hello",
       sourceTabId: "tab-1",
@@ -257,39 +237,30 @@ describe("makeCanvasApi.patch", () => {
   });
 
   it("accepts subpaths without a leading slash", async () => {
-    await h.api.patch("components/0/props/title", "hello");
-    expect(h.calls[0].path).toBe("/canvas/components/0/props/title");
+    const api = makeCanvasApi(undefined, deps);
+    await api.patch("components/0/props/title", "hello");
+    expect(calls[0].path).toBe("/canvas/components/0/props/title");
   });
 
   it("rejects empty / non-string subpath without calling setState", async () => {
-    const r1 = await h.api.patch("", "x");
-    const r2 = await h.api.patch(42 as unknown as string, "x");
+    const api = makeCanvasApi(undefined, deps);
+    const r1 = await api.patch("", "x");
+    const r2 = await api.patch(42 as unknown as string, "x");
     expect(r1.ok).toBe(false);
     expect(r2.ok).toBe(false);
-    expect(h.calls).toHaveLength(0);
+    expect(calls).toHaveLength(0);
   });
 });
 
 describe("makeCanvasApi tab attribution", () => {
-  it("forwards the resolved tab id as sourceTabId on every write", async () => {
-    const h = newHarness();
-    const api = makeCanvasApi("tab-bound", {
-      setState: (path, value, sourceTabId) => {
-        h.calls.push({ path, value, sourceTabId });
-        return Promise.resolve({ ok: true });
-      },
-      resolveTabs: (explicit) => {
-        const tab = explicit ?? "tab-active";
-        return { writeTab: tab, readTab: tab };
-      },
-      readCanvasComponents: () => [],
-      syncMirror: () => undefined,
-    });
+  it("forwards boundTabId as sourceTabId on every write", async () => {
+    const { deps, calls } = makeTestDeps({ fallbackTab: "tab-active" });
+    const api = makeCanvasApi("tab-bound", deps);
     await api.emit({ type: "card" });
     await api.append({ type: "text" });
     await api.clear();
     await api.patch("/foo", 1);
-    expect(h.calls.map((c) => c.sourceTabId)).toEqual([
+    expect(calls.map((c) => c.sourceTabId)).toEqual([
       "tab-bound",
       "tab-bound",
       "tab-bound",
@@ -297,33 +268,11 @@ describe("makeCanvasApi tab attribution", () => {
     ]);
   });
 
-  it("post-ready tab-less write omits sourceTabId (lets frontend route to active)", async () => {
-    // The bridge's resolveTabs returns `{writeTab: undefined, readTab: <activeTab>}`
-    // when frontendReady is true and no ALS / active turn exists, so
-    // canvas.* matches plain setState semantics. append still reads
-    // from the predicted active tab so its compose-on-read works.
-    const calls: SetStateCall[] = [];
-    const seen: (string | undefined)[] = [];
-    const existing: CanvasComponent = { type: "card", id: "from-active" };
-    const api = makeCanvasApi(undefined, {
-      setState: (path, value, sourceTabId) => {
-        calls.push({ path, value, sourceTabId });
-        return Promise.resolve({ ok: true });
-      },
-      resolveTabs: (explicit) => {
-        seen.push(explicit);
-        return { writeTab: undefined, readTab: "active-tab" };
-      },
-      readCanvasComponents: (id) =>
-        id === "active-tab" ? [existing] : [],
-      syncMirror: () => undefined,
-    });
-    await api.append({ type: "text", id: "new" });
-    expect(seen).toEqual([undefined]);
-    expect(calls[0].value).toEqual({
-      components: [existing, { type: "text", id: "new" }],
-    });
-    expect(calls[0].sourceTabId).toBeUndefined();
+  it("global helper falls back to resolver's default when nothing is bound", async () => {
+    const { deps, calls } = makeTestDeps({ fallbackTab: "default" });
+    const api = makeCanvasApi(undefined, deps);
+    await api.emit({ type: "card" });
+    expect(calls[0].sourceTabId).toBe("default");
   });
 });
 
@@ -331,25 +280,12 @@ describe("makeCanvasApi emit + patch + append", () => {
   it("preserves the components array across patch and survives a follow-up append", async () => {
     // Wires the harness through the real bridge-side `setAtPointer` so
     // a `canvas.patch` write at /canvas/components/0/... folds into the
-    // mirror without flattening the array. Regression: previously the
-    // mirror used a spread-only writer that turned `[c1]` into `{0: c1}`,
-    // so the next `canvas.append` saw "no array" and dropped the
-    // existing component.
-    const calls: SetStateCall[] = [];
-    let mirror: Record<string, unknown> = {};
-    const api = makeCanvasApi("tab-1", {
-      setState: (path, value, sourceTabId) => {
-        calls.push({ path, value, sourceTabId });
-        mirror = setAtPointer(mirror, path, value);
-        return Promise.resolve({ ok: true });
-      },
-      resolveTabs: (explicit) => {
-        const tab = explicit ?? "tab-1";
-        return { writeTab: tab, readTab: tab };
-      },
-      readCanvasComponents: () => readCanvasComponentsFromTabState(mirror),
-      syncMirror: () => undefined,
-    });
+    // mirror without flattening the array. Regression: the original
+    // setAtPointer used object spread which turned `[c1]` into
+    // `{0: c1}`, so the next `canvas.append` saw "no array" and dropped
+    // the existing component.
+    const { deps, calls } = makeTestDeps({ fallbackTab: "tab-1" });
+    const api = makeCanvasApi(undefined, deps);
     const c1: CanvasComponent = {
       id: "indexing",
       type: "card",
@@ -359,194 +295,59 @@ describe("makeCanvasApi emit + patch + append", () => {
     await api.patch("/components/0/props/state", "ok");
     const c2: CanvasComponent = { id: "next", type: "card", props: { title: "Done" } };
     await api.append(c2);
-    // Mirror still has an array — not the regressed `{0: ..., 1: ...}` shape.
-    const components = (
-      (mirror.canvas as { components?: unknown }).components
-    );
-    expect(Array.isArray(components)).toBe(true);
-    expect(components).toHaveLength(2);
-    expect((components as { props: { state: string } }[])[0].props.state).toBe(
-      "ok",
-    );
-    expect((components as { id: string }[])[1].id).toBe("next");
+    expect(calls).toHaveLength(3);
+    // The append's read sees [{state: "ok"}, ...], not [{state: "running"}].
+    const composed = calls[2].value as { components: { props: { state: string }; id: string }[] };
+    expect(composed.components).toHaveLength(2);
+    expect(composed.components[0].props.state).toBe("ok");
+    expect(composed.components[1].id).toBe("next");
   });
 });
 
-describe("makeCanvasApi.append boot-time fallback", () => {
-  it("pre-ready appends attribute to default tab and compose across calls", async () => {
-    // Pre-ready (no frontend connected, no ALS / active turn): writes
-    // and reads both target the canonical "default" tab, so sequential
-    // appends compose. Without this, boot writes routed into the global
-    // state tree and the frontend's active-tab empty mirror clobbered
-    // them on hydration.
+describe("makeCanvasApi tab-less seed fallback", () => {
+  it("uses the bridge's tab-less retained canvas when per-tab mirror is empty", async () => {
+    // Models the case codex flagged: an extension calls plain
+    // aethon.setState("/canvas", ...) without a tab context, which
+    // routes to extensionStateTree on the bridge. canvas.append should
+    // see THAT seed and compose with it, not replace the visible canvas
+    // with only the appended component.
+    const seeded: CanvasComponent = { type: "card", id: "seeded-via-setState" };
     const calls: SetStateCall[] = [];
-    const mirror = new Map<string, { canvas?: { components?: CanvasComponent[] } }>();
-    const api = makeCanvasApi(undefined, {
+    const perTab = new Map<string, Record<string, unknown>>();
+    const tablessRetained: Record<string, unknown> = {
+      canvas: { components: [seeded] },
+    };
+    const deps: CanvasDeps = {
       setState: (path, value, sourceTabId) => {
         calls.push({ path, value, sourceTabId });
-        if (path === "/canvas" && sourceTabId) {
-          mirror.set(sourceTabId, { canvas: value });
-        }
+        const before = perTab.get(sourceTabId) ?? {};
+        perTab.set(sourceTabId, setAtPointer(before, path, value));
         return Promise.resolve({ ok: true });
       },
-      resolveTabs: () => ({ writeTab: "default", readTab: "default" }),
-      readCanvasComponents: (id) =>
-        readCanvasComponentsFromTabState(mirror.get(id)),
-      syncMirror: () => undefined,
-    });
-    const c1: CanvasComponent = { type: "card", id: "first" };
-    const c2: CanvasComponent = { type: "card", id: "second" };
-    await api.append(c1);
-    await api.append(c2);
-    expect(calls).toHaveLength(2);
-    expect(calls[0].sourceTabId).toBe("default");
-    expect(calls[1].sourceTabId).toBe("default");
-    expect(calls[1].value).toEqual({ components: [c1, c2] });
-  });
-});
-
-describe("makeCanvasApi tab-less mirror sync", () => {
-  it("invokes syncMirror with readTab when writeTab is undefined", async () => {
-    // Post-ready tab-less write: outbound patch carries no sourceTabId
-    // (frontend routes to active), but the bridge must still update its
-    // perTabExtState[readTab] so the next append composes on top of
-    // the previous one. The helper detects writeTab !== readTab and
-    // calls syncMirror after the setState resolves.
-    const setStateCalls: SetStateCall[] = [];
-    const syncCalls: { tabId: string; path: string; value: unknown }[] = [];
-    let mirror: Record<string, unknown> = {};
-    const api = makeCanvasApi(undefined, {
-      setState: (path, value, sourceTabId) => {
-        setStateCalls.push({ path, value, sourceTabId });
-        return Promise.resolve({ ok: true });
+      resolveTab: (explicit) => explicit ?? "active",
+      readCanvasComponents: (id) => {
+        const fromTab = readCanvasComponentsFromTabState(perTab.get(id));
+        if (fromTab.length > 0) return fromTab;
+        return readCanvasComponentsFromTabState(tablessRetained);
       },
-      resolveTabs: () => ({ writeTab: undefined, readTab: "active" }),
-      readCanvasComponents: (id) =>
-        readCanvasComponentsFromTabState(
-          (mirror[id] as { canvas?: { components?: CanvasComponent[] } } | undefined),
-        ),
-      syncMirror: (tabId, path, value) => {
-        syncCalls.push({ tabId, path, value });
-        const before =
-          (mirror[tabId] as Record<string, unknown> | undefined) ?? {};
-        mirror = {
-          ...mirror,
-          [tabId]: setAtPointer(before, path, value),
-        };
-      },
+    };
+    const api = makeCanvasApi(undefined, deps);
+    const fresh: CanvasComponent = { type: "text", id: "appended" };
+    await api.append(fresh);
+    expect(calls[0].value).toEqual({
+      components: [seeded, fresh],
     });
-    const c1: CanvasComponent = { type: "card", id: "first" };
-    const c2: CanvasComponent = { type: "card", id: "second" };
-    await api.append(c1);
-    await api.append(c2);
-    expect(setStateCalls).toHaveLength(2);
-    expect(setStateCalls.map((c) => c.sourceTabId)).toEqual([
-      undefined,
-      undefined,
-    ]);
-    expect(syncCalls).toHaveLength(2);
-    expect(syncCalls[0].tabId).toBe("active");
-    // The second append must compose with the first — proving syncMirror
-    // kept the bridge's view in sync even though the wire went tab-less.
-    expect(setStateCalls[1].value).toEqual({
-      components: [c1, c2],
-    });
-  });
-
-  it("does not invoke syncMirror when writeTab === readTab (already in sync via setState)", async () => {
-    const syncCalls: { tabId: string; path: string; value: unknown }[] = [];
-    const api = makeCanvasApi(undefined, {
-      setState: () => Promise.resolve({ ok: true }),
-      resolveTabs: () => ({ writeTab: "tab-1", readTab: "tab-1" }),
-      readCanvasComponents: () => [],
-      syncMirror: (tabId, path, value) => {
-        syncCalls.push({ tabId, path, value });
-      },
-    });
-    await api.emit({ type: "card" });
-    await api.append({ type: "text" });
-    await api.clear();
-    expect(syncCalls).toEqual([]);
-  });
-
-  it("invokes syncMirror synchronously so fire-and-forget appends compose", async () => {
-    // Two appends in the same tick without awaiting the first. The
-    // helper must fold the first write into the bridge's mirror BEFORE
-    // setState's await yields, so the second append's read sees it.
-    // (Without this, both appends read [] and the second clobbers the
-    // first on the wire.)
-    const setStateCalls: SetStateCall[] = [];
-    let mirror: Record<string, unknown> = {};
-    const api = makeCanvasApi(undefined, {
-      setState: (path, value, sourceTabId) => {
-        setStateCalls.push({ path, value, sourceTabId });
-        // Simulate a non-trivial round-trip. The helper must NOT wait
-        // for this before the second append's read.
-        return new Promise((resolve) =>
-          setTimeout(() => resolve({ ok: true }), 5),
-        );
-      },
-      resolveTabs: () => ({ writeTab: undefined, readTab: "active" }),
-      readCanvasComponents: (id) =>
-        readCanvasComponentsFromTabState(
-          (mirror[id] as { canvas?: { components?: CanvasComponent[] } } | undefined),
-        ),
-      syncMirror: (tabId, path, value) => {
-        const before =
-          (mirror[tabId] as Record<string, unknown> | undefined) ?? {};
-        mirror = {
-          ...mirror,
-          [tabId]: setAtPointer(before, path, value),
-        };
-      },
-    });
-    const c1: CanvasComponent = { type: "card", id: "first" };
-    const c2: CanvasComponent = { type: "card", id: "second" };
-    // Don't await the first — fire and forget, then immediately fire
-    // the second.
-    const p1 = api.append(c1);
-    const p2 = api.append(c2);
-    await Promise.all([p1, p2]);
-    expect(setStateCalls).toHaveLength(2);
-    expect(setStateCalls[1].value).toEqual({ components: [c1, c2] });
-  });
-});
-
-describe("makeCanvasApi post-ready tab-less write", () => {
-  it("emit/clear/patch send no sourceTabId so the frontend routes to its active tab", async () => {
-    // Matches plain setState semantics: tab-less writes after the
-    // frontend has reported ready must omit attribution. The ONLY
-    // hint we give the helper is the predicted-active read scope, used
-    // by append.
-    const calls: SetStateCall[] = [];
-    const api = makeCanvasApi(undefined, {
-      setState: (path, value, sourceTabId) => {
-        calls.push({ path, value, sourceTabId });
-        return Promise.resolve({ ok: true });
-      },
-      resolveTabs: () => ({ writeTab: undefined, readTab: "active-tab" }),
-      readCanvasComponents: () => [],
-      syncMirror: () => undefined,
-    });
-    await api.emit({ type: "card" });
-    await api.clear();
-    await api.patch("/components/0/props/title", "x");
-    expect(calls.map((c) => c.sourceTabId)).toEqual([
-      undefined,
-      undefined,
-      undefined,
-    ]);
   });
 });
 
 describe("makeCanvasApi error propagation", () => {
   it("propagates setState failure through emit", async () => {
-    const api = makeCanvasApi(undefined, {
+    const deps: CanvasDeps = {
       setState: () => Promise.resolve({ ok: false, error: "frontend_rejected: oops" }),
-      resolveTabs: () => ({ writeTab: "default", readTab: "default" }),
+      resolveTab: () => "default",
       readCanvasComponents: () => [],
-      syncMirror: () => undefined,
-    });
+    };
+    const api = makeCanvasApi(undefined, deps);
     const r = await api.emit({ type: "card" });
     expect(r).toEqual({ ok: false, error: "frontend_rejected: oops" });
   });

--- a/agent/canvas.test.ts
+++ b/agent/canvas.test.ts
@@ -6,6 +6,7 @@ import {
   type CanvasComponent,
   type CanvasMutationResult,
 } from "./canvas";
+import { setAtPointer } from "./jsonPointer";
 
 interface SetStateCall {
   path: string;
@@ -299,6 +300,79 @@ describe("makeCanvasApi tab attribution", () => {
       components: [existing, { type: "text", id: "new" }],
     });
     expect(calls[0].sourceTabId).toBeUndefined();
+  });
+});
+
+describe("makeCanvasApi emit + patch + append", () => {
+  it("preserves the components array across patch and survives a follow-up append", async () => {
+    // Wires the harness through the real bridge-side `setAtPointer` so
+    // a `canvas.patch` write at /canvas/components/0/... folds into the
+    // mirror without flattening the array. Regression: previously the
+    // mirror used a spread-only writer that turned `[c1]` into `{0: c1}`,
+    // so the next `canvas.append` saw "no array" and dropped the
+    // existing component.
+    const calls: SetStateCall[] = [];
+    let mirror: Record<string, unknown> = {};
+    const api = makeCanvasApi("tab-1", {
+      setState: (path, value, sourceTabId) => {
+        calls.push({ path, value, sourceTabId });
+        mirror = setAtPointer(mirror, path, value);
+        return Promise.resolve({ ok: true });
+      },
+      resolveAttributedTab: (explicit) => explicit ?? "tab-1",
+      readCanvasComponents: () => readCanvasComponentsFromTabState(mirror),
+    });
+    const c1: CanvasComponent = {
+      id: "indexing",
+      type: "card",
+      props: { title: "Indexing", state: "running" },
+    };
+    await api.emit(c1);
+    await api.patch("/components/0/props/state", "ok");
+    const c2: CanvasComponent = { id: "next", type: "card", props: { title: "Done" } };
+    await api.append(c2);
+    // Mirror still has an array — not the regressed `{0: ..., 1: ...}` shape.
+    const components = (
+      (mirror.canvas as { components?: unknown }).components
+    );
+    expect(Array.isArray(components)).toBe(true);
+    expect(components).toHaveLength(2);
+    expect((components as { props: { state: string } }[])[0].props.state).toBe(
+      "ok",
+    );
+    expect((components as { id: string }[])[1].id).toBe("next");
+  });
+});
+
+describe("makeCanvasApi.append boot-time fallback", () => {
+  it("reads from a global state tree when no tab is attributed", async () => {
+    // Mirrors the bridge's boot-time wiring: when no tab exists yet,
+    // _setState routes writes into a global store; the reader has to
+    // pull from that same store or sequential appends each see [].
+    const calls: SetStateCall[] = [];
+    let globalCanvas: { components?: CanvasComponent[] } | undefined = undefined;
+    const api = makeCanvasApi(undefined, {
+      setState: (path, value, sourceTabId) => {
+        calls.push({ path, value, sourceTabId });
+        if (path === "/canvas" && value && typeof value === "object") {
+          globalCanvas = value;
+        }
+        return Promise.resolve({ ok: true });
+      },
+      resolveAttributedTab: () => undefined,
+      readCanvasComponents: (id) =>
+        id === undefined
+          ? readCanvasComponentsFromTabState({ canvas: globalCanvas })
+          : [],
+    });
+    const c1: CanvasComponent = { type: "card", id: "first" };
+    const c2: CanvasComponent = { type: "card", id: "second" };
+    await api.append(c1);
+    await api.append(c2);
+    expect(calls).toHaveLength(2);
+    // The second append must include c1 in its components list — the
+    // boot-time bug was that it didn't.
+    expect(calls[1].value).toEqual({ components: [c1, c2] });
   });
 });
 

--- a/agent/canvas.test.ts
+++ b/agent/canvas.test.ts
@@ -37,22 +37,26 @@ function newHarness(opts: {
   if (opts.initialMirror) {
     for (const [k, v] of Object.entries(opts.initialMirror)) mirror.set(k, v);
   }
+  // The bridge's resolver always returns a real tab id ("default" is
+  // its baseline); reproduce that here so makeCanvasApi's CanvasDeps
+  // contract holds in tests too.
+  const fallbackTab = opts.attributedTab ?? "default";
   const harness: Harness = {
     calls,
     mirror,
-    attributedTab: opts.attributedTab,
+    attributedTab: fallbackTab,
     api: makeCanvasApi(undefined, {
       setState: (path, value, sourceTabId) => {
         calls.push({ path, value, sourceTabId });
-        const tabId = sourceTabId ?? harness.attributedTab;
-        if (path === "/canvas" && tabId) {
+        const tabId = sourceTabId ?? fallbackTab;
+        if (path === "/canvas") {
           mirror.set(tabId, { canvas: value });
         }
         return Promise.resolve(opts.setStateResult ?? { ok: true });
       },
-      resolveAttributedTab: (explicit) => explicit ?? harness.attributedTab,
+      resolveAttributedTab: (explicit) => explicit ?? fallbackTab,
       readCanvasComponents: (tabId) =>
-        readCanvasComponentsFromTabState(tabId ? mirror.get(tabId) : undefined),
+        readCanvasComponentsFromTabState(mirror.get(tabId)),
     }),
   };
   return harness;
@@ -131,7 +135,7 @@ describe("makeCanvasApi.emit", () => {
     expect(h.calls[0]).toEqual({
       path: "/canvas",
       value: { components: [c] },
-      sourceTabId: undefined,
+      sourceTabId: "tab-1",
     });
   });
 
@@ -204,8 +208,7 @@ describe("makeCanvasApi.append", () => {
         return Promise.resolve({ ok: true });
       },
       resolveAttributedTab: (explicit) => explicit ?? "tab-1",
-      readCanvasComponents: (id) =>
-        readCanvasComponentsFromTabState(id ? h.mirror.get(id) : undefined),
+      readCanvasComponents: (id) => readCanvasComponentsFromTabState(h.mirror.get(id)),
     });
     const fresh: CanvasComponent = { type: "text", id: "fresh" };
     await tab2Api.append(fresh);
@@ -221,7 +224,7 @@ describe("makeCanvasApi.clear", () => {
     expect(h.calls[0]).toEqual({
       path: "/canvas",
       value: { components: [] },
-      sourceTabId: undefined,
+      sourceTabId: "tab-1",
     });
   });
 });
@@ -237,7 +240,7 @@ describe("makeCanvasApi.patch", () => {
     expect(h.calls[0]).toEqual({
       path: "/canvas/components/0/props/title",
       value: "hello",
-      sourceTabId: undefined,
+      sourceTabId: "tab-1",
     });
   });
 
@@ -256,7 +259,7 @@ describe("makeCanvasApi.patch", () => {
 });
 
 describe("makeCanvasApi tab attribution", () => {
-  it("forwards boundTabId as sourceTabId on every write", async () => {
+  it("forwards the resolved tab id as sourceTabId on every write", async () => {
     const h = newHarness();
     const api = makeCanvasApi("tab-bound", {
       setState: (path, value, sourceTabId) => {
@@ -278,10 +281,14 @@ describe("makeCanvasApi tab attribution", () => {
     ]);
   });
 
-  it("global variant (boundTabId undefined) uses resolveAttributedTab for append reads", async () => {
+  it("global variant (boundTabId undefined) attributes to the resolver's fallback", async () => {
+    // Bridge's contract: resolveAttributedTab always returns a real
+    // tab id (falling back to "default" when no ALS / active tab).
+    // The global aethon.canvas helper picks that up so writes always
+    // attribute to a tab — never to the global state tree.
     const calls: SetStateCall[] = [];
     const seen: (string | undefined)[] = [];
-    const existing: CanvasComponent = { type: "card", id: "from-active-tab" };
+    const existing: CanvasComponent = { type: "card", id: "from-default" };
     const api = makeCanvasApi(undefined, {
       setState: (path, value, sourceTabId) => {
         calls.push({ path, value, sourceTabId });
@@ -289,17 +296,17 @@ describe("makeCanvasApi tab attribution", () => {
       },
       resolveAttributedTab: (explicit) => {
         seen.push(explicit);
-        return explicit ?? "tab-active";
+        return explicit ?? "default";
       },
       readCanvasComponents: (id) =>
-        id === "tab-active" ? [existing] : [],
+        id === "default" ? [existing] : [],
     });
     await api.append({ type: "text", id: "new" });
     expect(seen).toEqual([undefined]);
     expect(calls[0].value).toEqual({
       components: [existing, { type: "text", id: "new" }],
     });
-    expect(calls[0].sourceTabId).toBeUndefined();
+    expect(calls[0].sourceTabId).toBe("default");
   });
 });
 
@@ -345,33 +352,35 @@ describe("makeCanvasApi emit + patch + append", () => {
 });
 
 describe("makeCanvasApi.append boot-time fallback", () => {
-  it("reads from a global state tree when no tab is attributed", async () => {
-    // Mirrors the bridge's boot-time wiring: when no tab exists yet,
-    // _setState routes writes into a global store; the reader has to
-    // pull from that same store or sequential appends each see [].
+  it("attributes boot writes to the resolver's default tab and survives sequential appends", async () => {
+    // Mirrors the bridge's boot-time wiring: with no ALS / active tab,
+    // resolveAttributedTab returns the canonical default tab so the
+    // write lands in that tab's per-tab mirror (which the frontend
+    // replays on `ready`). The reader and the writer agree on the same
+    // tab id, so two sequential appends compose instead of clobbering.
     const calls: SetStateCall[] = [];
-    let globalCanvas: { components?: CanvasComponent[] } | undefined = undefined;
+    const mirror = new Map<string, { canvas?: { components?: CanvasComponent[] } }>();
     const api = makeCanvasApi(undefined, {
       setState: (path, value, sourceTabId) => {
         calls.push({ path, value, sourceTabId });
-        if (path === "/canvas" && value && typeof value === "object") {
-          globalCanvas = value;
+        if (path === "/canvas" && sourceTabId) {
+          mirror.set(sourceTabId, { canvas: value });
         }
         return Promise.resolve({ ok: true });
       },
-      resolveAttributedTab: () => undefined,
+      resolveAttributedTab: (explicit) => explicit ?? "default",
       readCanvasComponents: (id) =>
-        id === undefined
-          ? readCanvasComponentsFromTabState({ canvas: globalCanvas })
-          : [],
+        readCanvasComponentsFromTabState(mirror.get(id)),
     });
     const c1: CanvasComponent = { type: "card", id: "first" };
     const c2: CanvasComponent = { type: "card", id: "second" };
     await api.append(c1);
     await api.append(c2);
     expect(calls).toHaveLength(2);
-    // The second append must include c1 in its components list — the
-    // boot-time bug was that it didn't.
+    // Both writes attribute to "default" rather than the global tree.
+    expect(calls[0].sourceTabId).toBe("default");
+    expect(calls[1].sourceTabId).toBe("default");
+    // The second append composes with the first.
     expect(calls[1].value).toEqual({ components: [c1, c2] });
   });
 });
@@ -380,7 +389,7 @@ describe("makeCanvasApi error propagation", () => {
   it("propagates setState failure through emit", async () => {
     const api = makeCanvasApi(undefined, {
       setState: () => Promise.resolve({ ok: false, error: "frontend_rejected: oops" }),
-      resolveAttributedTab: () => undefined,
+      resolveAttributedTab: () => "default",
       readCanvasComponents: () => [],
     });
     const r = await api.emit({ type: "card" });

--- a/agent/canvas.ts
+++ b/agent/canvas.ts
@@ -57,9 +57,9 @@ export interface CanvasResolution {
 export interface CanvasDeps {
   /**
    * Tab-aware setState. Mirrors the bridge's `_setState(path, value, sourceTabId?)`.
-   * The factory passes `writeTab` from `resolveTabs(...)` — usually the
-   * concrete attribution, but `undefined` for post-ready tab-less code
-   * so the frontend resolves to the user's currently-active tab.
+   * The factory passes `writeTab` — usually the concrete attribution,
+   * but `undefined` for post-ready tab-less code so the frontend
+   * resolves to the user's currently-active tab.
    */
   setState: (
     path: string,
@@ -75,6 +75,18 @@ export interface CanvasDeps {
   resolveTabs: (explicitTabId: string | undefined) => CanvasResolution;
   /** Returns the components currently mirrored at `/canvas` for the tab, or `[]`. */
   readCanvasComponents: (tabId: string) => CanvasComponent[];
+  /**
+   * Sync the bridge's per-tab mirror under `tabId` for the predicted
+   * read scope, even when the outbound `setState` was tab-less. Without
+   * this, post-ready tab-less appends would each see an empty `readTab`
+   * and replace prior canvas content instead of composing it. Bridge
+   * implementation writes to `perTabExtState[tabId]` directly.
+   *
+   * Called after the outbound setState resolves. The factory only
+   * invokes it when `writeTab !== readTab` — the cases where the
+   * setState write itself wouldn't have updated `readTab`'s mirror.
+   */
+  syncMirror: (tabId: string, path: string, value: unknown) => void;
 }
 
 export function normalizeCanvasComponents(input: unknown): CanvasComponent[] {
@@ -117,31 +129,45 @@ export function makeCanvasApi(
   // Resolve at call time (not construction) so the global helper picks
   // up the live active turn / frontend-active tab on every write.
   const resolve = (): CanvasResolution => deps.resolveTabs(boundTabId);
+  // Wraps a setState call so post-ready tab-less writes still update
+  // the bridge's per-tab mirror under the predicted read scope. When
+  // `writeTab === readTab` (or both undefined) the underlying setState
+  // already syncs the right mirror, so this is a no-op via the equality
+  // check.
+  async function dispatch(
+    tabs: CanvasResolution,
+    path: string,
+    value: unknown,
+  ): Promise<CanvasMutationResult> {
+    const result = await deps.setState(path, value, tabs.writeTab);
+    if (result.ok && tabs.writeTab !== tabs.readTab) {
+      deps.syncMirror(tabs.readTab, path, value);
+    }
+    return result;
+  }
   return {
     emit(components) {
       const list = normalizeCanvasComponents(components);
-      return deps.setState("/canvas", { components: list }, resolve().writeTab);
+      return dispatch(resolve(), "/canvas", { components: list });
     },
     append(components) {
       const additions = normalizeCanvasComponents(components);
       if (additions.length === 0) return Promise.resolve({ ok: true });
       const tabs = resolve();
       const existing = deps.readCanvasComponents(tabs.readTab);
-      return deps.setState(
-        "/canvas",
-        { components: [...existing, ...additions] },
-        tabs.writeTab,
-      );
+      return dispatch(tabs, "/canvas", {
+        components: [...existing, ...additions],
+      });
     },
     clear() {
-      return deps.setState("/canvas", { components: [] }, resolve().writeTab);
+      return dispatch(resolve(), "/canvas", { components: [] });
     },
     patch(subpath, value) {
       if (typeof subpath !== "string" || subpath.length === 0) {
         return Promise.resolve({ ok: false, error: "subpath required" });
       }
       const normalized = subpath.startsWith("/") ? subpath : "/" + subpath;
-      return deps.setState("/canvas" + normalized, value, resolve().writeTab);
+      return dispatch(resolve(), "/canvas" + normalized, value);
     },
   };
 }

--- a/agent/canvas.ts
+++ b/agent/canvas.ts
@@ -4,7 +4,7 @@
  * Extracted from `agent/main.ts` so it has a unit-test surface without
  * spinning up the full bridge. The factory takes `setState` and a
  * per-tab canvas reader as plain dependencies; the bridge wires them to
- * its real `_setState` and `perTabExtState` map. Pure module — no I/O,
+ * its real `_setState` and per-tab mirror lookups. Pure module — no I/O,
  * no globals, no shared state.
  *
  * The four operations:
@@ -13,9 +13,17 @@
  *   clear()          — write `{components: []}`
  *   patch(p, value)  — sugar over setState("/canvas" + p, value)
  *
- * `append` reads from the bridge's mirror rather than asking the
- * frontend, so it works pre-`ready` (boot-time extension code) and stays
- * consistent under concurrent handler dispatches on different tabs.
+ * Trade-off vs plain `aethon.setState("/canvas", ...)`:
+ *   The canvas helper ALWAYS attributes writes to a concrete tab id —
+ *   the bridge's resolver falls back through ALS → currentAgentTab →
+ *   frontend-active-tab → "default" so attribution is locked at call
+ *   time. Plain setState lets the frontend resolve the active tab at
+ *   apply time when no tabId is sent, which is fine for fire-and-forget
+ *   single writes but races for compose-on-read patterns like `append`
+ *   (the bridge can't know which tab to read from if attribution is
+ *   deferred). Locking attribution lets two synchronous appends compose
+ *   deterministically, at the cost of subtly differing semantics from
+ *   plain setState for tab-less code paths.
  */
 export interface CanvasComponent {
   id?: string;
@@ -36,57 +44,34 @@ export interface CanvasApi {
   patch(subpath: string, value: unknown): Promise<CanvasMutationResult>;
 }
 
-export interface CanvasResolution {
-  /**
-   * Tab id sent on the outbound state_patch (`sourceTabId` to setState).
-   * `undefined` lets the frontend route the patch to whichever tab is
-   * currently active — matching plain `aethon.setState` semantics for
-   * tab-less writes (e.g. an extension's setInterval after startup).
-   */
-  writeTab: string | undefined;
-  /**
-   * Tab id whose mirrored canvas `append` should read from. Always a
-   * concrete id so the bridge can predict where the upcoming write will
-   * land — pre-ready, "default" (the canonical pre-created tab);
-   * post-ready, the frontend-active tab id (read from frontendState's
-   * /tabs slice), falling back to "default".
-   */
-  readTab: string;
-}
-
 export interface CanvasDeps {
   /**
-   * Tab-aware setState. Mirrors the bridge's `_setState(path, value, sourceTabId?)`.
-   * The factory passes `writeTab` — usually the concrete attribution,
-   * but `undefined` for post-ready tab-less code so the frontend
-   * resolves to the user's currently-active tab.
+   * Tab-aware setState. Mirrors the bridge's `_setState(path, value, sourceTabId)`.
+   * The canvas helper ALWAYS passes a concrete tab id so the bridge's
+   * per-tab mirror stays authoritative for `append` reads.
    */
   setState: (
     path: string,
     value: unknown,
-    sourceTabId: string | undefined,
+    sourceTabId: string,
   ) => Promise<CanvasMutationResult>;
   /**
-   * Resolve write attribution + read scope for one canvas call. Split so
-   * tab-less post-ready writes can omit attribution (matching setState's
-   * "frontend routes to active") while `append` still has a concrete tab
-   * id to read existing components from.
+   * Always returns a real tab id — never undefined. Bridge wires:
+   *   explicit ?? ALS ?? currentAgentTabId
+   *     ?? frontendActiveTabId() ?? "default"
+   * "default" is the canonical pre-created tab so boot-time writes
+   * (no frontend, no ALS, no active turn) still land somewhere real.
    */
-  resolveTabs: (explicitTabId: string | undefined) => CanvasResolution;
-  /** Returns the components currently mirrored at `/canvas` for the tab, or `[]`. */
-  readCanvasComponents: (tabId: string) => CanvasComponent[];
+  resolveTab: (explicitTabId: string | undefined) => string;
   /**
-   * Sync the bridge's per-tab mirror under `tabId` for the predicted
-   * read scope, even when the outbound `setState` was tab-less. Without
-   * this, post-ready tab-less appends would each see an empty `readTab`
-   * and replace prior canvas content instead of composing it. Bridge
-   * implementation writes to `perTabExtState[tabId]` directly.
-   *
-   * Called after the outbound setState resolves. The factory only
-   * invokes it when `writeTab !== readTab` — the cases where the
-   * setState write itself wouldn't have updated `readTab`'s mirror.
+   * Returns the components mirrored at `/canvas` for the given tab.
+   * Implementations should consult per-tab state first, then fall back
+   * to the bridge's tab-less retained canvas (extensionStateTree.canvas)
+   * so a canvas seeded by plain `aethon.setState("/canvas", ...)` is
+   * still composable. Either source represents "what's currently on
+   * screen" — preferring the per-tab record when both exist.
    */
-  syncMirror: (tabId: string, path: string, value: unknown) => void;
+  readCanvasComponents: (tabId: string) => CanvasComponent[];
 }
 
 export function normalizeCanvasComponents(input: unknown): CanvasComponent[] {
@@ -119,8 +104,7 @@ export function readCanvasComponentsFromTabState(
  * "active tab" when `boundTabId` is undefined). The bridge calls this
  * once per handler dispatch (binding to the originating tabId) and
  * once at boot for the global `aethon.canvas` (binding to undefined,
- * so writes flow through the same ALS / active-tab fallback that
- * `setState(path, value)` uses).
+ * so writes flow through the resolver's full priority chain).
  */
 export function makeCanvasApi(
   boundTabId: string | undefined,
@@ -128,53 +112,32 @@ export function makeCanvasApi(
 ): CanvasApi {
   // Resolve at call time (not construction) so the global helper picks
   // up the live active turn / frontend-active tab on every write.
-  const resolve = (): CanvasResolution => deps.resolveTabs(boundTabId);
-  // Wraps a setState call so post-ready tab-less writes still update
-  // the bridge's per-tab mirror under the predicted read scope. When
-  // `writeTab === readTab` (or both undefined) the underlying setState
-  // already syncs the right mirror, so this is a no-op via the equality
-  // check.
-  //
-  // syncMirror runs SYNCHRONOUSLY before setState's await so two
-  // fire-and-forget appends in the same tick both compose — the second
-  // append's read sees the first append's write even though neither
-  // has been ack'd yet. Matches `_setState`'s own behavior: it writes
-  // perTabExtState synchronously before sending the outbound patch.
-  // If setState fails, the mirror sits ahead of the frontend by one
-  // patch — same edge case the attributed-write path already accepts.
-  function dispatch(
-    tabs: CanvasResolution,
-    path: string,
-    value: unknown,
-  ): Promise<CanvasMutationResult> {
-    if (tabs.writeTab !== tabs.readTab) {
-      deps.syncMirror(tabs.readTab, path, value);
-    }
-    return deps.setState(path, value, tabs.writeTab);
-  }
+  const resolve = (): string => deps.resolveTab(boundTabId);
   return {
     emit(components) {
       const list = normalizeCanvasComponents(components);
-      return dispatch(resolve(), "/canvas", { components: list });
+      return deps.setState("/canvas", { components: list }, resolve());
     },
     append(components) {
       const additions = normalizeCanvasComponents(components);
       if (additions.length === 0) return Promise.resolve({ ok: true });
-      const tabs = resolve();
-      const existing = deps.readCanvasComponents(tabs.readTab);
-      return dispatch(tabs, "/canvas", {
-        components: [...existing, ...additions],
-      });
+      const tab = resolve();
+      const existing = deps.readCanvasComponents(tab);
+      return deps.setState(
+        "/canvas",
+        { components: [...existing, ...additions] },
+        tab,
+      );
     },
     clear() {
-      return dispatch(resolve(), "/canvas", { components: [] });
+      return deps.setState("/canvas", { components: [] }, resolve());
     },
     patch(subpath, value) {
       if (typeof subpath !== "string" || subpath.length === 0) {
         return Promise.resolve({ ok: false, error: "subpath required" });
       }
       const normalized = subpath.startsWith("/") ? subpath : "/" + subpath;
-      return dispatch(resolve(), "/canvas" + normalized, value);
+      return deps.setState("/canvas" + normalized, value, resolve());
     },
   };
 }

--- a/agent/canvas.ts
+++ b/agent/canvas.ts
@@ -36,12 +36,30 @@ export interface CanvasApi {
   patch(subpath: string, value: unknown): Promise<CanvasMutationResult>;
 }
 
+export interface CanvasResolution {
+  /**
+   * Tab id sent on the outbound state_patch (`sourceTabId` to setState).
+   * `undefined` lets the frontend route the patch to whichever tab is
+   * currently active — matching plain `aethon.setState` semantics for
+   * tab-less writes (e.g. an extension's setInterval after startup).
+   */
+  writeTab: string | undefined;
+  /**
+   * Tab id whose mirrored canvas `append` should read from. Always a
+   * concrete id so the bridge can predict where the upcoming write will
+   * land — pre-ready, "default" (the canonical pre-created tab);
+   * post-ready, the frontend-active tab id (read from frontendState's
+   * /tabs slice), falling back to "default".
+   */
+  readTab: string;
+}
+
 export interface CanvasDeps {
   /**
    * Tab-aware setState. Mirrors the bridge's `_setState(path, value, sourceTabId?)`.
-   * The factory always passes the resolved tab as `sourceTabId` so
-   * attribution is explicit at every write — including boot-time
-   * writes which the bridge routes to the canonical "default" tab.
+   * The factory passes `writeTab` from `resolveTabs(...)` — usually the
+   * concrete attribution, but `undefined` for post-ready tab-less code
+   * so the frontend resolves to the user's currently-active tab.
    */
   setState: (
     path: string,
@@ -49,13 +67,12 @@ export interface CanvasDeps {
     sourceTabId: string | undefined,
   ) => Promise<CanvasMutationResult>;
   /**
-   * Returns the tab id this write should be attributed to. The bridge
-   * wires this to `tabContext.getStore() ?? currentAgentTabId ?? "default"`
-   * — never returns undefined when called from the canvas helper, so
-   * boot-time writes (no ALS, no active turn) still land in a real
-   * tab's per-tab mirror instead of the global state tree.
+   * Resolve write attribution + read scope for one canvas call. Split so
+   * tab-less post-ready writes can omit attribution (matching setState's
+   * "frontend routes to active") while `append` still has a concrete tab
+   * id to read existing components from.
    */
-  resolveAttributedTab: (explicitTabId: string | undefined) => string;
+  resolveTabs: (explicitTabId: string | undefined) => CanvasResolution;
   /** Returns the components currently mirrored at `/canvas` for the tab, or `[]`. */
   readCanvasComponents: (tabId: string) => CanvasComponent[];
 }
@@ -97,36 +114,34 @@ export function makeCanvasApi(
   boundTabId: string | undefined,
   deps: CanvasDeps,
 ): CanvasApi {
-  // Resolve the attribution at call time (not at construction) so the
-  // global `aethon.canvas` (boundTabId === undefined) picks up whatever
-  // tab is active when the agent is mid-turn, and falls back to the
-  // canonical default tab when no turn is in flight.
-  const resolveTab = (): string => deps.resolveAttributedTab(boundTabId);
+  // Resolve at call time (not construction) so the global helper picks
+  // up the live active turn / frontend-active tab on every write.
+  const resolve = (): CanvasResolution => deps.resolveTabs(boundTabId);
   return {
     emit(components) {
       const list = normalizeCanvasComponents(components);
-      return deps.setState("/canvas", { components: list }, resolveTab());
+      return deps.setState("/canvas", { components: list }, resolve().writeTab);
     },
     append(components) {
       const additions = normalizeCanvasComponents(components);
       if (additions.length === 0) return Promise.resolve({ ok: true });
-      const attributedTab = resolveTab();
-      const existing = deps.readCanvasComponents(attributedTab);
+      const tabs = resolve();
+      const existing = deps.readCanvasComponents(tabs.readTab);
       return deps.setState(
         "/canvas",
         { components: [...existing, ...additions] },
-        attributedTab,
+        tabs.writeTab,
       );
     },
     clear() {
-      return deps.setState("/canvas", { components: [] }, resolveTab());
+      return deps.setState("/canvas", { components: [] }, resolve().writeTab);
     },
     patch(subpath, value) {
       if (typeof subpath !== "string" || subpath.length === 0) {
         return Promise.resolve({ ok: false, error: "subpath required" });
       }
       const normalized = subpath.startsWith("/") ? subpath : "/" + subpath;
-      return deps.setState("/canvas" + normalized, value, resolveTab());
+      return deps.setState("/canvas" + normalized, value, resolve().writeTab);
     },
   };
 }

--- a/agent/canvas.ts
+++ b/agent/canvas.ts
@@ -134,16 +134,23 @@ export function makeCanvasApi(
   // `writeTab === readTab` (or both undefined) the underlying setState
   // already syncs the right mirror, so this is a no-op via the equality
   // check.
-  async function dispatch(
+  //
+  // syncMirror runs SYNCHRONOUSLY before setState's await so two
+  // fire-and-forget appends in the same tick both compose — the second
+  // append's read sees the first append's write even though neither
+  // has been ack'd yet. Matches `_setState`'s own behavior: it writes
+  // perTabExtState synchronously before sending the outbound patch.
+  // If setState fails, the mirror sits ahead of the frontend by one
+  // patch — same edge case the attributed-write path already accepts.
+  function dispatch(
     tabs: CanvasResolution,
     path: string,
     value: unknown,
   ): Promise<CanvasMutationResult> {
-    const result = await deps.setState(path, value, tabs.writeTab);
-    if (result.ok && tabs.writeTab !== tabs.readTab) {
+    if (tabs.writeTab !== tabs.readTab) {
       deps.syncMirror(tabs.readTab, path, value);
     }
-    return result;
+    return deps.setState(path, value, tabs.writeTab);
   }
   return {
     emit(components) {

--- a/agent/canvas.ts
+++ b/agent/canvas.ts
@@ -39,8 +39,9 @@ export interface CanvasApi {
 export interface CanvasDeps {
   /**
    * Tab-aware setState. Mirrors the bridge's `_setState(path, value, sourceTabId?)`.
-   * The factory always passes `boundTabId` as `sourceTabId` so attribution
-   * is explicit; pass `undefined` to defer to ALS / active-tab fallback.
+   * The factory always passes the resolved tab as `sourceTabId` so
+   * attribution is explicit at every write — including boot-time
+   * writes which the bridge routes to the canonical "default" tab.
    */
   setState: (
     path: string,
@@ -48,13 +49,15 @@ export interface CanvasDeps {
     sourceTabId: string | undefined,
   ) => Promise<CanvasMutationResult>;
   /**
-   * Returns the currently-attributed tab when no explicit id was given.
-   * The bridge wires this to `tabContext.getStore() ?? currentAgentTabId`.
-   * Used only by `append` to decide which tab's mirrored canvas to read.
+   * Returns the tab id this write should be attributed to. The bridge
+   * wires this to `tabContext.getStore() ?? currentAgentTabId ?? "default"`
+   * — never returns undefined when called from the canvas helper, so
+   * boot-time writes (no ALS, no active turn) still land in a real
+   * tab's per-tab mirror instead of the global state tree.
    */
-  resolveAttributedTab: (explicitTabId: string | undefined) => string | undefined;
+  resolveAttributedTab: (explicitTabId: string | undefined) => string;
   /** Returns the components currently mirrored at `/canvas` for the tab, or `[]`. */
-  readCanvasComponents: (tabId: string | undefined) => CanvasComponent[];
+  readCanvasComponents: (tabId: string) => CanvasComponent[];
 }
 
 export function normalizeCanvasComponents(input: unknown): CanvasComponent[] {
@@ -94,31 +97,36 @@ export function makeCanvasApi(
   boundTabId: string | undefined,
   deps: CanvasDeps,
 ): CanvasApi {
+  // Resolve the attribution at call time (not at construction) so the
+  // global `aethon.canvas` (boundTabId === undefined) picks up whatever
+  // tab is active when the agent is mid-turn, and falls back to the
+  // canonical default tab when no turn is in flight.
+  const resolveTab = (): string => deps.resolveAttributedTab(boundTabId);
   return {
     emit(components) {
       const list = normalizeCanvasComponents(components);
-      return deps.setState("/canvas", { components: list }, boundTabId);
+      return deps.setState("/canvas", { components: list }, resolveTab());
     },
     append(components) {
       const additions = normalizeCanvasComponents(components);
       if (additions.length === 0) return Promise.resolve({ ok: true });
-      const attributedTab = deps.resolveAttributedTab(boundTabId);
+      const attributedTab = resolveTab();
       const existing = deps.readCanvasComponents(attributedTab);
       return deps.setState(
         "/canvas",
         { components: [...existing, ...additions] },
-        boundTabId,
+        attributedTab,
       );
     },
     clear() {
-      return deps.setState("/canvas", { components: [] }, boundTabId);
+      return deps.setState("/canvas", { components: [] }, resolveTab());
     },
     patch(subpath, value) {
       if (typeof subpath !== "string" || subpath.length === 0) {
         return Promise.resolve({ ok: false, error: "subpath required" });
       }
       const normalized = subpath.startsWith("/") ? subpath : "/" + subpath;
-      return deps.setState("/canvas" + normalized, value, boundTabId);
+      return deps.setState("/canvas" + normalized, value, resolveTab());
     },
   };
 }

--- a/agent/jsonPointer.test.ts
+++ b/agent/jsonPointer.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { setAtPointer } from "./jsonPointer";
+
+describe("setAtPointer", () => {
+  it("returns the input unchanged for empty / root pointers", () => {
+    const before = { a: 1 };
+    expect(setAtPointer(before, "", 42)).toBe(before);
+    expect(setAtPointer(before, "/", 42)).toBe(before);
+  });
+
+  it("creates intermediate objects on demand", () => {
+    expect(setAtPointer({}, "/foo/bar/baz", 42)).toEqual({
+      foo: { bar: { baz: 42 } },
+    });
+  });
+
+  it("preserves arrays under nested writes", () => {
+    const before = {
+      canvas: {
+        components: [
+          { id: "a", type: "card", props: { title: "old" } },
+          { id: "b", type: "text" },
+        ],
+      },
+    };
+    const after = setAtPointer(
+      before,
+      "/canvas/components/0/props/title",
+      "new",
+    );
+    // The bug this guards against: spreading an array as `{...arr}`
+    // turns it into a plain object `{0: ..., 1: ...}`. Components must
+    // remain an Array.
+    const components = (after.canvas as { components: unknown }).components;
+    expect(Array.isArray(components)).toBe(true);
+    expect(components).toHaveLength(2);
+    expect(
+      ((components as { props: { title: string } }[])[0]).props.title,
+    ).toBe("new");
+    // Untouched siblings keep their identity-equal references where possible.
+    expect((components as unknown[])[1]).toBe(before.canvas.components[1]);
+  });
+
+  it("does not mutate the input root", () => {
+    const before = { canvas: { components: [{ id: "a", type: "card" }] } };
+    setAtPointer(before, "/canvas/components/0/type", "text");
+    // Original tree intact.
+    expect(before.canvas.components[0].type).toBe("card");
+  });
+
+  it("decodes ~1 and ~0 escapes in tokens", () => {
+    const after = setAtPointer({}, "/a~1b/c~0d", 1);
+    expect(after).toEqual({ "a/b": { "c~d": 1 } });
+  });
+
+  it("writes through a leading existing array index", () => {
+    const before = { items: [10, 20, 30] };
+    const after = setAtPointer(before, "/items/1", 99);
+    expect(Array.isArray(after.items)).toBe(true);
+    expect(after.items).toEqual([10, 99, 30]);
+  });
+
+  it("rebuilds an array as an array even when intermediate clone uses spread", () => {
+    // A subtle case: write at a deep index path, ensuring every
+    // intermediate Array is cloned with [...arr] not {...arr}.
+    const before = {
+      a: [
+        { id: 0, items: [{ value: 1 }] },
+        { id: 1, items: [{ value: 2 }] },
+      ],
+    };
+    const after = setAtPointer(before, "/a/1/items/0/value", 99);
+    expect(Array.isArray(after.a)).toBe(true);
+    const a1 = (after.a as { items: { value: number }[] }[])[1];
+    expect(Array.isArray(a1.items)).toBe(true);
+    expect(a1.items[0].value).toBe(99);
+  });
+});

--- a/agent/jsonPointer.test.ts
+++ b/agent/jsonPointer.test.ts
@@ -60,6 +60,27 @@ describe("setAtPointer", () => {
     expect(after.items).toEqual([10, 99, 30]);
   });
 
+  it("creates arrays for missing intermediates when next token is numeric", () => {
+    // Mirrors the frontend's setPointer: writing /canvas/components/0/type
+    // against an empty tree should produce {canvas: {components: [{type:"x"}]}}
+    // — components must be an Array, not {0: {...}}.
+    const after = setAtPointer({}, "/canvas/components/0/type", "card");
+    expect(after).toEqual({
+      canvas: { components: [{ type: "card" }] },
+    });
+    expect(
+      Array.isArray((after.canvas as { components: unknown }).components),
+    ).toBe(true);
+  });
+
+  it("creates objects for missing intermediates when next token is non-numeric", () => {
+    const after = setAtPointer({}, "/canvas/meta/title", "x");
+    expect(after).toEqual({ canvas: { meta: { title: "x" } } });
+    expect(
+      Array.isArray((after.canvas as { meta: unknown }).meta),
+    ).toBe(false);
+  });
+
   it("rebuilds an array as an array even when intermediate clone uses spread", () => {
     // A subtle case: write at a deep index path, ensuring every
     // intermediate Array is cloned with [...arr] not {...arr}.

--- a/agent/jsonPointer.ts
+++ b/agent/jsonPointer.ts
@@ -17,10 +17,23 @@
 const PTR_TOKEN_DECODE = (token: string): string =>
   token.replace(/~1/g, "/").replace(/~0/g, "~");
 
+// RFC 6901 array-index token: "0" or "[1-9][0-9]*". The frontend's
+// setPointer uses this to materialize missing intermediates as arrays
+// when the next token is numeric — e.g. setPointer({}, "/items/0/x", 1)
+// returns `{items: [{x:1}]}` rather than `{items: {0: {x:1}}}`. The
+// bridge MUST match that behavior or replay-on-ready hands the
+// frontend a structurally-different tree.
+function isArrayIndex(token: string | undefined): boolean {
+  return token !== undefined && /^(0|[1-9]\d*)$/.test(token);
+}
+
 /**
  * Apply a JSON Pointer write, returning a new root with the value set
  * at the path. Each intermediate node is cloned (arrays as arrays,
- * objects as objects). Missing intermediates default to `{}`.
+ * objects as objects). Missing intermediates are created as arrays when
+ * the next token looks like an array index, otherwise as objects —
+ * matching the frontend's `setPointer` exactly so retained-state replay
+ * doesn't reshape arrays into objects.
  */
 export function setAtPointer(
   state: Record<string, unknown>,
@@ -30,25 +43,28 @@ export function setAtPointer(
   if (!pointer || pointer === "" || pointer === "/") return state;
   const path = pointer.startsWith("/") ? pointer.slice(1) : pointer;
   const tokens = path.split("/").map(PTR_TOKEN_DECODE);
-  const cloneNode = (node: unknown): Record<string, unknown> | unknown[] => {
+  const cloneNode = (
+    node: unknown,
+    nextToken: string | undefined,
+  ): Record<string, unknown> | unknown[] => {
     if (Array.isArray(node)) return [...node];
     if (node && typeof node === "object") {
       return { ...(node as Record<string, unknown>) };
     }
-    return {};
+    return isArrayIndex(nextToken) ? [] : {};
   };
-  const next = { ...state } as Record<string | number, unknown>;
+  const next = cloneNode(state, tokens[0]);
   let cursor: Record<string | number, unknown> | unknown[] = next;
   for (let i = 0; i < tokens.length - 1; i++) {
     const key = tokens[i];
     const idx = Array.isArray(cursor) ? Number(key) : key;
     const existing = (cursor as Record<string | number, unknown>)[idx];
-    const child = cloneNode(existing);
+    const child = cloneNode(existing, tokens[i + 1]);
     (cursor as Record<string | number, unknown>)[idx] = child;
     cursor = child;
   }
   const lastKey = tokens[tokens.length - 1];
   const lastIdx = Array.isArray(cursor) ? Number(lastKey) : lastKey;
   (cursor as Record<string | number, unknown>)[lastIdx] = value;
-  return next;
+  return next as Record<string, unknown>;
 }

--- a/agent/jsonPointer.ts
+++ b/agent/jsonPointer.ts
@@ -1,0 +1,54 @@
+/**
+ * Bridge-side JSON Pointer helpers. Mirrors the frontend's
+ * `src/utils/jsonPointer.ts` so the agent's retained state
+ * (`extensionStateTree`, `perTabExtState`) folds writes the same way the
+ * frontend does. Specifically: arrays stay arrays under nested writes,
+ * so a `/canvas/components/0/props/title` patch leaves
+ * `canvas.components` as `[{...}]` rather than `{0: {...}}`.
+ *
+ * Without that array-preservation, ready-replay rebuilds the frontend's
+ * canvas from a malformed shape, and any read-back (e.g.
+ * `aethon.canvas.append(...)` consulting the per-tab mirror) sees
+ * something that is no longer an array.
+ *
+ * Extracted so it can be unit-tested without booting `agent/main.ts`.
+ */
+
+const PTR_TOKEN_DECODE = (token: string): string =>
+  token.replace(/~1/g, "/").replace(/~0/g, "~");
+
+/**
+ * Apply a JSON Pointer write, returning a new root with the value set
+ * at the path. Each intermediate node is cloned (arrays as arrays,
+ * objects as objects). Missing intermediates default to `{}`.
+ */
+export function setAtPointer(
+  state: Record<string, unknown>,
+  pointer: string,
+  value: unknown,
+): Record<string, unknown> {
+  if (!pointer || pointer === "" || pointer === "/") return state;
+  const path = pointer.startsWith("/") ? pointer.slice(1) : pointer;
+  const tokens = path.split("/").map(PTR_TOKEN_DECODE);
+  const cloneNode = (node: unknown): Record<string, unknown> | unknown[] => {
+    if (Array.isArray(node)) return [...node];
+    if (node && typeof node === "object") {
+      return { ...(node as Record<string, unknown>) };
+    }
+    return {};
+  };
+  const next = { ...state } as Record<string | number, unknown>;
+  let cursor: Record<string | number, unknown> | unknown[] = next;
+  for (let i = 0; i < tokens.length - 1; i++) {
+    const key = tokens[i];
+    const idx = Array.isArray(cursor) ? Number(key) : key;
+    const existing = (cursor as Record<string | number, unknown>)[idx];
+    const child = cloneNode(existing);
+    (cursor as Record<string | number, unknown>)[idx] = child;
+    cursor = child;
+  }
+  const lastKey = tokens[tokens.length - 1];
+  const lastIdx = Array.isArray(cursor) ? Number(lastKey) : lastKey;
+  (cursor as Record<string | number, unknown>)[lastIdx] = value;
+  return next;
+}

--- a/agent/main.ts
+++ b/agent/main.ts
@@ -1518,7 +1518,7 @@ async function main() {
   // was async.
   // Read the frontend's currently-active tab id from its mirrored /tabs
   // slice (each tab carries `active: true|false`). Used by the canvas
-  // append helper to predict where a tab-less write will land. Returns
+  // resolver as a fallback when no ALS / current turn is set. Returns
   // `undefined` if frontendState hasn't received /tabs yet (pre-ready).
   function frontendActiveTabId(): string | undefined {
     const tabsSlice = frontendState.get("/tabs");
@@ -1538,39 +1538,33 @@ async function main() {
   function makeCanvasApi(tabId: string | undefined): CanvasApi {
     return buildCanvasApi(tabId, {
       setState: (path, value, sourceTabId) => _setState(path, value, sourceTabId),
-      // Resolve write attribution + read scope per call. Three regimes:
-      //  1. explicit / ALS / active turn → concrete tab; write attributes
-      //     to it, read targets the same tab's mirror.
-      //  2. pre-ready, tab-less → `writeTab: "default"` so the boot write
-      //     lands in `perTabExtState["default"]` (which the frontend's
-      //     pre-created default tab replays on `ready`); read from the
-      //     same. Boot append composes correctly across calls.
-      //  3. post-ready, tab-less → `writeTab: undefined` so the frontend
-      //     applies the patch to the user's currently-active tab —
-      //     matching plain `setState` semantics. Read targets the
-      //     frontend-active tab id from `frontendState["/tabs"]` so
-      //     `append` predicts the same tab, falling back to "default"
-      //     if /tabs hasn't been mirrored yet.
-      resolveTabs: (explicit) => {
-        const concrete = explicit ?? tabContext.getStore() ?? currentAgentTabId;
-        if (concrete) return { writeTab: concrete, readTab: concrete };
-        if (!frontendReady) return { writeTab: "default", readTab: "default" };
-        const active = frontendActiveTabId();
-        return { writeTab: undefined, readTab: active ?? "default" };
-      },
-      readCanvasComponents: (id) =>
-        readCanvasComponentsFromTabState(perTabExtState.get(id)),
-      // For post-ready tab-less writes, _setState sends an outbound
-      // patch without `tabId` and routes the bridge's mirror update
-      // into `extensionStateTree` (not perTabExtState). The frontend
-      // applies the patch to its active tab; the predicted-active read
-      // scope on the bridge side then needs its OWN mirror update so
-      // a follow-up `append(...)` reads the freshly-written canvas
-      // instead of stale state. Idempotent — folding the same write
-      // twice via `setAtPointer` lands the same final shape.
-      syncMirror: (tabId, path, value) => {
-        const before = perTabExtState.get(tabId) ?? {};
-        perTabExtState.set(tabId, setAtPointer(before, path, value));
+      // Always returns a real tab id. Priority chain:
+      //  1. explicit / ALS / active turn — the obvious cases.
+      //  2. frontend-active tab id (from frontendState["/tabs"]) — best
+      //     guess for post-ready tab-less code (extension setIntervals,
+      //     timers).
+      //  3. "default" — fallback for pre-ready boot code; the bridge
+      //     pre-creates this tab via `ensureTab("default")` at startup.
+      // Locking attribution at call time means `append` reads what the
+      // upcoming write will land on, so two synchronous appends compose.
+      // Differs from plain `aethon.setState` (which lets the frontend
+      // resolve at apply time) — see canvas.ts header comment.
+      resolveTab: (explicit) =>
+        explicit ??
+        tabContext.getStore() ??
+        currentAgentTabId ??
+        frontendActiveTabId() ??
+        "default",
+      // Read priority: per-tab mirror first; if empty, fall back to the
+      // bridge's retained tab-less canvas (anything an extension wrote
+      // via plain `aethon.setState("/canvas", ...)` outside any tab
+      // context lives there). Both are "what's on screen right now"
+      // candidates — the per-tab record wins when present because it's
+      // the more specific one.
+      readCanvasComponents: (id) => {
+        const fromTab = readCanvasComponentsFromTabState(perTabExtState.get(id));
+        if (fromTab.length > 0) return fromTab;
+        return readCanvasComponentsFromTabState(extensionStateTree);
       },
     });
   }

--- a/agent/main.ts
+++ b/agent/main.ts
@@ -144,6 +144,7 @@ import {
   readCanvasComponentsFromTabState,
 } from "./canvas";
 import type { CanvasApi } from "./canvas";
+import { setAtPointer } from "./jsonPointer";
 import {
   readSessionMetadata,
   readSessionTranscript,
@@ -229,33 +230,6 @@ function modelKey(m: Model<Api>): string {
 // Decode a JSON Pointer token (RFC 6901). `~1` → `/`, `~0` → `~`.
 function decodePointerToken(t: string): string {
   return t.replace(/~1/g, "/").replace(/~0/g, "~");
-}
-
-// Apply value at JSON Pointer path inside an immutable tree. Mirror of the
-// frontend's setPointer so the bridge can keep extensionStateTree in sync
-// with what the frontend computes from the same patches.
-function setAtPointer(
-  state: Record<string, unknown>,
-  pointer: string,
-  value: unknown,
-): Record<string, unknown> {
-  if (!pointer || pointer === "" || pointer === "/") return state;
-  const path = pointer.startsWith("/") ? pointer.slice(1) : pointer;
-  const tokens = path.split("/").map(decodePointerToken);
-  const next: Record<string, unknown> = { ...state };
-  let cursor: Record<string, unknown> = next;
-  for (let i = 0; i < tokens.length - 1; i++) {
-    const key = tokens[i];
-    const existing = cursor[key];
-    const child =
-      typeof existing === "object" && existing !== null
-        ? { ...(existing as Record<string, unknown>) }
-        : {};
-    cursor[key] = child;
-    cursor = child;
-  }
-  cursor[tokens[tokens.length - 1]] = value;
-  return next;
 }
 
 // Layout-aware patch that preserves arrays (mirror of the frontend's
@@ -1547,9 +1521,17 @@ async function main() {
       setState: (path, value, sourceTabId) => _setState(path, value, sourceTabId),
       resolveAttributedTab: (explicit) =>
         explicit ?? tabContext.getStore() ?? currentAgentTabId,
-      readCanvasComponents: (id) => readCanvasComponentsFromTabState(
-        id ? perTabExtState.get(id) : undefined,
-      ),
+      // Reader fallback: when there's an attributed tab, read its
+      // mirrored canvas from `perTabExtState` (where `_setState` routes
+      // tab-attributed writes). When attribution is absent — a boot-time
+      // `aethon.canvas.append(...)` before any tab exists — `_setState`
+      // routes the write into `extensionStateTree` instead, so we have
+      // to read from there or sequential boot appends would each see
+      // an empty canvas and clobber prior writes.
+      readCanvasComponents: (id) => {
+        const source = id ? perTabExtState.get(id) : extensionStateTree;
+        return readCanvasComponentsFromTabState(source);
+      },
     });
   }
   // Pi may re-run extension register() per session, and `tabs` create

--- a/agent/main.ts
+++ b/agent/main.ts
@@ -1519,19 +1519,17 @@ async function main() {
   function makeCanvasApi(tabId: string | undefined): CanvasApi {
     return buildCanvasApi(tabId, {
       setState: (path, value, sourceTabId) => _setState(path, value, sourceTabId),
+      // Always returns a real tab id. "default" is the canonical
+      // pre-created tab (`ensureTab("default")` runs at startup), so
+      // boot-time canvas writes — when no ALS or active turn exists
+      // yet — still land in `perTabExtState["default"]` and replay
+      // back to the frontend's default tab on `ready`. Without this,
+      // boot writes routed into `extensionStateTree` and the frontend's
+      // active-tab mirror would overwrite them on hydration.
       resolveAttributedTab: (explicit) =>
-        explicit ?? tabContext.getStore() ?? currentAgentTabId,
-      // Reader fallback: when there's an attributed tab, read its
-      // mirrored canvas from `perTabExtState` (where `_setState` routes
-      // tab-attributed writes). When attribution is absent — a boot-time
-      // `aethon.canvas.append(...)` before any tab exists — `_setState`
-      // routes the write into `extensionStateTree` instead, so we have
-      // to read from there or sequential boot appends would each see
-      // an empty canvas and clobber prior writes.
-      readCanvasComponents: (id) => {
-        const source = id ? perTabExtState.get(id) : extensionStateTree;
-        return readCanvasComponentsFromTabState(source);
-      },
+        explicit ?? tabContext.getStore() ?? currentAgentTabId ?? "default",
+      readCanvasComponents: (id) =>
+        readCanvasComponentsFromTabState(perTabExtState.get(id)),
     });
   }
   // Pi may re-run extension register() per session, and `tabs` create

--- a/agent/main.ts
+++ b/agent/main.ts
@@ -1555,18 +1555,34 @@ async function main() {
         currentAgentTabId ??
         frontendActiveTabId() ??
         "default",
-      // Read priority: per-tab mirror first; only fall back to the
-      // bridge's retained tab-less canvas (extensionStateTree) when the
-      // per-tab record has NO canvas slot at all. An empty per-tab
-      // canvas (`{canvas: {components: []}}`, e.g. after a `clear()`
-      // or `emit([])`) is an explicit value — using the tab-less seed
-      // there would resurrect components the user just cleared.
+      // Read priority for canvas.append's existing-components lookup:
+      //
+      //   1. Per-tab mirror (perTabExtState[id].canvas), if the canvas
+      //      slot is defined. An explicit empty value — e.g. after
+      //      `clear()` or `emit([])` — is still a value; we don't
+      //      fall through.
+      //
+      //   2. Tab-less retained canvas (extensionStateTree.canvas), but
+      //      ONLY when `id` matches the frontend's currently-active
+      //      tab (or "default" pre-ready, when there's no active tab
+      //      yet). Plain `aethon.setState("/canvas", ...)` outside any
+      //      tab context routes through here on the bridge AND lands
+      //      on the user's active tab on the frontend — so it's only
+      //      visible to the helper as that tab's canvas. Falling back
+      //      for any other tab would leak the seed across tabs and
+      //      break the per-tab isolation the helper otherwise preserves.
+      //
+      //   3. Empty array.
       readCanvasComponents: (id) => {
         const tabState = perTabExtState.get(id);
         if (tabState && (tabState as { canvas?: unknown }).canvas !== undefined) {
           return readCanvasComponentsFromTabState(tabState);
         }
-        return readCanvasComponentsFromTabState(extensionStateTree);
+        const activeForSeed = frontendActiveTabId() ?? "default";
+        if (id === activeForSeed) {
+          return readCanvasComponentsFromTabState(extensionStateTree);
+        }
+        return [];
       },
     });
   }

--- a/agent/main.ts
+++ b/agent/main.ts
@@ -1555,15 +1555,17 @@ async function main() {
         currentAgentTabId ??
         frontendActiveTabId() ??
         "default",
-      // Read priority: per-tab mirror first; if empty, fall back to the
-      // bridge's retained tab-less canvas (anything an extension wrote
-      // via plain `aethon.setState("/canvas", ...)` outside any tab
-      // context lives there). Both are "what's on screen right now"
-      // candidates — the per-tab record wins when present because it's
-      // the more specific one.
+      // Read priority: per-tab mirror first; only fall back to the
+      // bridge's retained tab-less canvas (extensionStateTree) when the
+      // per-tab record has NO canvas slot at all. An empty per-tab
+      // canvas (`{canvas: {components: []}}`, e.g. after a `clear()`
+      // or `emit([])`) is an explicit value — using the tab-less seed
+      // there would resurrect components the user just cleared.
       readCanvasComponents: (id) => {
-        const fromTab = readCanvasComponentsFromTabState(perTabExtState.get(id));
-        if (fromTab.length > 0) return fromTab;
+        const tabState = perTabExtState.get(id);
+        if (tabState && (tabState as { canvas?: unknown }).canvas !== undefined) {
+          return readCanvasComponentsFromTabState(tabState);
+        }
         return readCanvasComponentsFromTabState(extensionStateTree);
       },
     });

--- a/agent/main.ts
+++ b/agent/main.ts
@@ -1560,6 +1560,18 @@ async function main() {
       },
       readCanvasComponents: (id) =>
         readCanvasComponentsFromTabState(perTabExtState.get(id)),
+      // For post-ready tab-less writes, _setState sends an outbound
+      // patch without `tabId` and routes the bridge's mirror update
+      // into `extensionStateTree` (not perTabExtState). The frontend
+      // applies the patch to its active tab; the predicted-active read
+      // scope on the bridge side then needs its OWN mirror update so
+      // a follow-up `append(...)` reads the freshly-written canvas
+      // instead of stale state. Idempotent — folding the same write
+      // twice via `setAtPointer` lands the same final shape.
+      syncMirror: (tabId, path, value) => {
+        const before = perTabExtState.get(tabId) ?? {};
+        perTabExtState.set(tabId, setAtPointer(before, path, value));
+      },
     });
   }
   // Pi may re-run extension register() per session, and `tabs` create

--- a/agent/main.ts
+++ b/agent/main.ts
@@ -1516,18 +1516,48 @@ async function main() {
   // so a sidebar click that routes to a handler keeps writing to the
   // originating tab even if the user has switched while the handler
   // was async.
+  // Read the frontend's currently-active tab id from its mirrored /tabs
+  // slice (each tab carries `active: true|false`). Used by the canvas
+  // append helper to predict where a tab-less write will land. Returns
+  // `undefined` if frontendState hasn't received /tabs yet (pre-ready).
+  function frontendActiveTabId(): string | undefined {
+    const tabsSlice = frontendState.get("/tabs");
+    if (!Array.isArray(tabsSlice)) return undefined;
+    for (const t of tabsSlice) {
+      if (
+        t &&
+        typeof t === "object" &&
+        (t as { active?: unknown }).active === true &&
+        typeof (t as { id?: unknown }).id === "string"
+      ) {
+        return (t as { id: string }).id;
+      }
+    }
+    return undefined;
+  }
   function makeCanvasApi(tabId: string | undefined): CanvasApi {
     return buildCanvasApi(tabId, {
       setState: (path, value, sourceTabId) => _setState(path, value, sourceTabId),
-      // Always returns a real tab id. "default" is the canonical
-      // pre-created tab (`ensureTab("default")` runs at startup), so
-      // boot-time canvas writes — when no ALS or active turn exists
-      // yet — still land in `perTabExtState["default"]` and replay
-      // back to the frontend's default tab on `ready`. Without this,
-      // boot writes routed into `extensionStateTree` and the frontend's
-      // active-tab mirror would overwrite them on hydration.
-      resolveAttributedTab: (explicit) =>
-        explicit ?? tabContext.getStore() ?? currentAgentTabId ?? "default",
+      // Resolve write attribution + read scope per call. Three regimes:
+      //  1. explicit / ALS / active turn → concrete tab; write attributes
+      //     to it, read targets the same tab's mirror.
+      //  2. pre-ready, tab-less → `writeTab: "default"` so the boot write
+      //     lands in `perTabExtState["default"]` (which the frontend's
+      //     pre-created default tab replays on `ready`); read from the
+      //     same. Boot append composes correctly across calls.
+      //  3. post-ready, tab-less → `writeTab: undefined` so the frontend
+      //     applies the patch to the user's currently-active tab —
+      //     matching plain `setState` semantics. Read targets the
+      //     frontend-active tab id from `frontendState["/tabs"]` so
+      //     `append` predicts the same tab, falling back to "default"
+      //     if /tabs hasn't been mirrored yet.
+      resolveTabs: (explicit) => {
+        const concrete = explicit ?? tabContext.getStore() ?? currentAgentTabId;
+        if (concrete) return { writeTab: concrete, readTab: concrete };
+        if (!frontendReady) return { writeTab: "default", readTab: "default" };
+        const active = frontendActiveTabId();
+        return { writeTab: undefined, readTab: active ?? "default" };
+      },
       readCanvasComponents: (id) =>
         readCanvasComponentsFromTabState(perTabExtState.get(id)),
     });

--- a/docs/aethon-agent/api.md
+++ b/docs/aethon-agent/api.md
@@ -128,6 +128,22 @@ Use this in preference to manual `setState("/canvas", …)` for new
 extensions: the helper survives canvas-shape changes (e.g. if `/canvas`
 ever gains sibling fields beyond `components`).
 
+**Tab attribution differs from plain `setState`.** The canvas helper
+*always* attributes its writes to a concrete tab id:
+
+  explicit > AsyncLocalStorage (per-turn) > current active turn >
+    frontend-active tab > "default"
+
+Plain `aethon.setState("/canvas", …)` lets the frontend resolve the
+active tab at apply time when no `tabId` is sent. The canvas helper
+locks attribution at *call* time so the read scope inside `append` is
+deterministic — two synchronous appends compose instead of racing on
+"which tab will the frontend pick when this lands?". The trade-off:
+if you `aethon.canvas.emit(…)` from a setInterval after startup, the
+write targets the *current* active tab as of the call, not the active
+tab at apply time. If the user switches tabs mid-call the result lands
+on the originally-selected tab.
+
 ### `registerComponent(type, template)`
 
 Define a new A2UI component type. The template is a single A2UI component


### PR DESCRIPTION
## Summary

Eight rounds of codex review on PR #5 (which auto-merged on the first commit's CI before follow-ups landed) surfaced cascading edge cases in the new `aethon.canvas.*` helper. This PR ports all of them onto a fresh branch.

The 8 commits, in chronological order — each addresses a discrete codex P2:

1. **Array-preserving mirror writes + boot-time append fallback** — `setAtPointer`'s object-spread destroyed arrays under nested writes; boot-time append read empty canvas from the wrong store.
2. **Mirror frontend setPointer's numeric-intermediate array creation** — `canvas.patch("/components/0/type", x)` against an empty mirror produced `{0: ...}` instead of `[...]`.
3. **Pre/post-ready canvas attribution split** — initial round-2 fix forced "default" for all tab-less writes, breaking late setIntervals.
4. **syncMirror to keep perTabExtState fresh for tab-less writes** — read scope was stale when writeTab undefined.
5. **syncMirror before await** — fire-and-forget appends in same tick read stale mirror.
6. **Always attribute canvas writes + multi-source read fallback** — simplification: lock attribution at call time (compose deterministically), fall back to retained tab-less canvas in extensionStateTree for plain-setState seeds.
7. **Distinguish empty per-tab canvas from missing canvas** — `clear()` followed by `append()` was resurrecting the tab-less seed because the length-based check fell through on `[]`.
8. **Scope tab-less seed fallback to the frontend's active tab** — fallback was leaking the seed into non-active tabs.

Round 9 codex returned green: "I did not identify any discrete introduced bugs that would break existing behavior."

## Test plan

- [x] `bunx vitest run agent/canvas.test.ts agent/jsonPointer.test.ts` — 36 passing
- [x] `nix develop -c check` — clippy + tsc + ESLint + cargo test (14) + vitest (144) all green
- [x] Codex peer review (`codex review --base main` high reasoning, 8 iterative rounds) — final round green

## Notes

The cascading findings highlight that programmatic canvas push has an inherently complex attribution model in a multi-tab system with both per-tab and tab-less write surfaces. The final design accepts a documented trade-off (canvas locks attribution at call time, unlike plain setState) so `append`'s compose-on-read semantics work deterministically.

Documented in `docs/aethon-agent/api.md`.