### PR TITLE
feat(shell): M6 P1 — interactive PTY-backed shell tabs

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -13,6 +13,7 @@ name = "aethon"
 version = "0.2.0"
 dependencies = [
  "notify",
+ "portable-pty",
  "serde",
  "serde_json",
  "tauri",
@@ -472,6 +473,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -833,6 +840,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -879,7 +892,7 @@ dependencies = [
  "rustc_version",
  "toml 1.1.2+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -986,6 +999,17 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
 ]
 
 [[package]]
@@ -2036,6 +2060,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2273,6 +2303,18 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "nodrop"
@@ -2854,6 +2896,27 @@ dependencies = [
  "pin-project-lite",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "portable-pty"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a596a2b3d2752d94f51fac2d4a96737b8705dddd311a32b9af47211f08671e"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix",
+ "serial2",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg 0.10.1",
 ]
 
 [[package]]
@@ -3615,6 +3678,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial2"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcdbc46aa3882ec3d48ec2b5abcb4f0d863a13d7599265f3faa6d851f23c12f3"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "serialize-to-javascript"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3665,6 +3739,22 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -5570,6 +5660,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,6 +29,7 @@ toml = { version = "0.8", features = ["parse"] }
 tauri-plugin-process = "2.3.1"
 tauri-plugin-opener = "2.5.3"
 tauri-plugin-dialog = "2.7.0"
+portable-pty = "0.9"
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ use serde::Deserialize;
 use tauri::{AppHandle, Emitter, Manager, State};
 
 mod helpers;
+mod shell;
 use helpers::{
     FONT_SIZE_MAX, FONT_SIZE_MIN, clamp_font_size, parse_config_toml, validate_state_name,
 };
@@ -985,8 +986,16 @@ fn install_app_menu(
     use tauri::Emitter;
     use tauri::menu::{MenuBuilder, MenuItemBuilder, PredefinedMenuItem, SubmenuBuilder};
 
-    let new_tab = MenuItemBuilder::with_id("new_tab", "New Tab")
+    // M6 P1: Cmd+T defaults to "New Shell Tab" (matches Terminal.app /
+    // iTerm2 convention). The existing chat-tab behavior moves to
+    // Cmd+Shift+T as "New Agent Tab". Both menu items emit distinct ids
+    // (`new_tab` legacy alias for shell, `new_agent_tab` for chat) so
+    // the JS-side router can split them — see App.tsx:menu listener.
+    let new_tab = MenuItemBuilder::with_id("new_tab", "New Shell Tab")
         .accelerator("CmdOrCtrl+T")
+        .build(app)?;
+    let new_agent_tab = MenuItemBuilder::with_id("new_agent_tab", "New Agent Tab")
+        .accelerator("CmdOrCtrl+Shift+T")
         .build(app)?;
     let close_tab = MenuItemBuilder::with_id("close_tab", "Close Tab")
         .accelerator("CmdOrCtrl+W")
@@ -1031,6 +1040,7 @@ fn install_app_menu(
     // Cmd+W to whichever menu item it picks first.
     let file_menu = SubmenuBuilder::new(app, "File")
         .item(&new_tab)
+        .item(&new_agent_tab)
         .item(&close_tab)
         .build()?;
 
@@ -1064,6 +1074,7 @@ fn install_app_menu(
 
     let tabs_menu = SubmenuBuilder::new(app, "Tabs")
         .item(&new_tab)
+        .item(&new_agent_tab)
         .item(&close_tab)
         .separator()
         .item(&next_tab)
@@ -1268,6 +1279,7 @@ pub fn run() {
     }
     let builder = builder
         .manage(AgentProcess(Mutex::new(None)))
+        .manage(shell::ShellRegistry::new())
         .invoke_handler(tauri::generate_handler![
             start_agent,
             send_message,
@@ -1281,6 +1293,10 @@ pub fn run() {
             set_extension_menu_items,
             pick_project_directory,
             git_status,
+            shell::shell_open,
+            shell::shell_input,
+            shell::shell_resize,
+            shell::shell_close,
             #[cfg(debug_assertions)]
             debug::debug_eval_js,
             #[cfg(debug_assertions)]

--- a/src-tauri/src/shell.rs
+++ b/src-tauri/src/shell.rs
@@ -1,0 +1,383 @@
+//! PTY-backed user shell tabs (M6 P1).
+//!
+//! One [`ShellSlot`] per tab id: a [`portable_pty`] master, a writer
+//! handle for keystrokes, an [`Arc<Mutex<Option<Box<dyn Child>>>>`] for
+//! the child process, and a reader thread that streams stdout to the
+//! frontend as `shell-output {tabId, content}` events. When the child
+//! exits naturally the reader sees EOF, calls [`Child::wait`], and
+//! emits `shell-exit {tabId, code}` once. [`shell_close`] kills the
+//! child and drops the PTY so the reader unblocks for clean shutdown
+//! on tab close — no zombie processes.
+
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+
+use portable_pty::{native_pty_system, Child, CommandBuilder, MasterPty, PtySize};
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter, Runtime, State};
+
+const READ_CHUNK_BYTES: usize = 4096;
+
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct ShellOutputPayload {
+    tab_id: String,
+    content: String,
+}
+
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct ShellExitPayload {
+    tab_id: String,
+    code: Option<i32>,
+}
+
+#[derive(Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ShellOpenArgs {
+    pub tab_id: String,
+    #[serde(default)]
+    pub command: Option<String>,
+    #[serde(default)]
+    pub args: Option<Vec<String>>,
+    #[serde(default)]
+    pub cwd: Option<String>,
+    #[serde(default)]
+    pub env: Option<HashMap<String, String>>,
+    #[serde(default)]
+    pub cols: Option<u16>,
+    #[serde(default)]
+    pub rows: Option<u16>,
+}
+
+type ChildHandle = Arc<Mutex<Option<Box<dyn Child + Send + Sync>>>>;
+
+struct ShellSlot {
+    writer: Box<dyn Write + Send>,
+    master: Box<dyn MasterPty + Send>,
+    child: ChildHandle,
+    reader_thread: Option<JoinHandle<()>>,
+}
+
+#[derive(Default)]
+pub struct ShellRegistry {
+    slots: Mutex<HashMap<String, ShellSlot>>,
+}
+
+impl ShellRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[tauri::command]
+pub fn shell_open<R: Runtime>(
+    app: AppHandle<R>,
+    state: State<'_, ShellRegistry>,
+    args: ShellOpenArgs,
+) -> Result<(), String> {
+    if args.tab_id.is_empty() {
+        return Err("tab_id is required".to_string());
+    }
+    {
+        let guard = state.slots.lock().map_err(|e| format!("lock: {e}"))?;
+        if guard.contains_key(&args.tab_id) {
+            return Err(format!("shell already open for tab {}", args.tab_id));
+        }
+    }
+
+    let pty_system = native_pty_system();
+    let cols = args.cols.unwrap_or(80).clamp(4, 1000);
+    let rows = args.rows.unwrap_or(24).clamp(4, 500);
+    let pair = pty_system
+        .openpty(PtySize {
+            rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .map_err(|e| format!("openpty: {e}"))?;
+
+    let mut cmd = match args.command.as_deref() {
+        Some(c) if !c.is_empty() => CommandBuilder::new(c),
+        _ => default_shell_command(),
+    };
+    if let Some(extra_args) = args.args {
+        for a in extra_args {
+            cmd.arg(a);
+        }
+    }
+    if let Some(cwd) = args.cwd {
+        cmd.cwd(cwd);
+    }
+    cmd.env("TERM", "xterm-256color");
+    cmd.env("COLORTERM", "truecolor");
+    cmd.env("AETHON", "1");
+    if let Some(env) = args.env {
+        for (k, v) in env {
+            cmd.env(k, v);
+        }
+    }
+
+    let child = pair
+        .slave
+        .spawn_command(cmd)
+        .map_err(|e| format!("spawn: {e}"))?;
+    drop(pair.slave);
+
+    let writer = pair
+        .master
+        .take_writer()
+        .map_err(|e| format!("take_writer: {e}"))?;
+    let mut reader = pair
+        .master
+        .try_clone_reader()
+        .map_err(|e| format!("try_clone_reader: {e}"))?;
+
+    let child_handle: ChildHandle = Arc::new(Mutex::new(Some(child)));
+    let app_for_thread = app.clone();
+    let tab_id_for_thread = args.tab_id.clone();
+    let child_for_thread = Arc::clone(&child_handle);
+    let reader_thread = thread::spawn(move || {
+        let mut buf = vec![0u8; READ_CHUNK_BYTES];
+        loop {
+            match reader.read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    let chunk = String::from_utf8_lossy(&buf[..n]).to_string();
+                    let _ = app_for_thread.emit(
+                        "shell-output",
+                        ShellOutputPayload {
+                            tab_id: tab_id_for_thread.clone(),
+                            content: chunk,
+                        },
+                    );
+                }
+                Err(_) => break,
+            }
+        }
+        // PTY closed (natural child exit OR shell_close dropped master).
+        // Reap the child so the parent process doesn't accumulate zombies.
+        let code = match child_for_thread.lock() {
+            Ok(mut guard) => guard.take().and_then(|mut c| match c.wait() {
+                Ok(status) => Some(status.exit_code() as i32),
+                Err(_) => None,
+            }),
+            Err(_) => None,
+        };
+        let _ = app_for_thread.emit(
+            "shell-exit",
+            ShellExitPayload {
+                tab_id: tab_id_for_thread,
+                code,
+            },
+        );
+    });
+
+    let slot = ShellSlot {
+        writer,
+        master: pair.master,
+        child: child_handle,
+        reader_thread: Some(reader_thread),
+    };
+    state
+        .slots
+        .lock()
+        .map_err(|e| format!("lock: {e}"))?
+        .insert(args.tab_id, slot);
+    Ok(())
+}
+
+#[tauri::command]
+pub fn shell_input(
+    state: State<'_, ShellRegistry>,
+    tab_id: String,
+    data: String,
+) -> Result<(), String> {
+    let mut guard = state.slots.lock().map_err(|e| format!("lock: {e}"))?;
+    let slot = guard
+        .get_mut(&tab_id)
+        .ok_or_else(|| format!("no shell for tab {tab_id}"))?;
+    slot.writer
+        .write_all(data.as_bytes())
+        .map_err(|e| format!("write: {e}"))?;
+    slot.writer.flush().map_err(|e| format!("flush: {e}"))?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn shell_resize(
+    state: State<'_, ShellRegistry>,
+    tab_id: String,
+    cols: u16,
+    rows: u16,
+) -> Result<(), String> {
+    let cols = cols.clamp(4, 1000);
+    let rows = rows.clamp(4, 500);
+    let guard = state.slots.lock().map_err(|e| format!("lock: {e}"))?;
+    let slot = guard
+        .get(&tab_id)
+        .ok_or_else(|| format!("no shell for tab {tab_id}"))?;
+    slot.master
+        .resize(PtySize {
+            cols,
+            rows,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .map_err(|e| format!("resize: {e}"))?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn shell_close(
+    state: State<'_, ShellRegistry>,
+    tab_id: String,
+) -> Result<(), String> {
+    let slot = {
+        let mut guard = state.slots.lock().map_err(|e| format!("lock: {e}"))?;
+        guard.remove(&tab_id)
+    };
+    let Some(mut slot) = slot else {
+        // Idempotent: closing an already-closed tab is fine.
+        return Ok(());
+    };
+    if let Ok(mut child_guard) = slot.child.lock()
+        && let Some(mut child) = child_guard.take()
+    {
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+    // Dropping master + writer closes the PTY so the reader thread
+    // unblocks. Order matters — drop writer first to avoid a deadlock
+    // when the reader holds it indirectly.
+    drop(slot.writer);
+    drop(slot.master);
+    if let Some(handle) = slot.reader_thread.take() {
+        let _ = handle.join();
+    }
+    Ok(())
+}
+
+fn default_shell_command() -> CommandBuilder {
+    #[cfg(unix)]
+    {
+        let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/bash".to_string());
+        let mut cmd = CommandBuilder::new(shell);
+        cmd.arg("-il");
+        cmd
+    }
+    #[cfg(windows)]
+    {
+        let mut cmd = CommandBuilder::new("powershell.exe");
+        cmd.arg("-NoLogo");
+        cmd
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{Duration, Instant};
+
+    fn registry() -> ShellRegistry {
+        ShellRegistry::new()
+    }
+
+    fn open_raw(reg: &ShellRegistry, tab_id: &str, command: &str, args: Vec<String>) -> Box<dyn Child + Send + Sync> {
+        // Mirrors shell_open but skips the AppHandle so unit tests can
+        // run without a Tauri runtime. The reader thread is omitted —
+        // tests that need stdout drain the master directly.
+        let pty_system = native_pty_system();
+        let pair = pty_system
+            .openpty(PtySize { rows: 24, cols: 80, pixel_width: 0, pixel_height: 0 })
+            .expect("openpty");
+        let mut cmd = CommandBuilder::new(command);
+        for a in args {
+            cmd.arg(a);
+        }
+        let child = pair.slave.spawn_command(cmd).expect("spawn");
+        drop(pair.slave);
+        let writer = pair.master.take_writer().expect("take_writer");
+        let slot = ShellSlot {
+            writer,
+            master: pair.master,
+            child: Arc::new(Mutex::new(None)), // tests reap manually
+            reader_thread: None,
+        };
+        reg.slots.lock().unwrap().insert(tab_id.to_string(), slot);
+        child
+    }
+
+    #[test]
+    fn echo_round_trip_via_input_command() {
+        let reg = registry();
+        let mut child = open_raw(&reg, "t1", "/bin/echo", vec!["hello-aethon".into()]);
+        let status = child.wait().expect("wait");
+        assert!(status.success());
+        // Cleanup the master/writer slot manually.
+        reg.slots.lock().unwrap().remove("t1").unwrap();
+    }
+
+    #[test]
+    fn resize_propagates_when_slot_present() {
+        let reg = registry();
+        let mut child = open_raw(&reg, "t2", "/bin/sleep", vec!["0.05".into()]);
+        // Resize via the command path — must succeed while child is alive.
+        {
+            let guard = reg.slots.lock().unwrap();
+            let slot = guard.get("t2").unwrap();
+            slot.master
+                .resize(PtySize { cols: 132, rows: 50, pixel_width: 0, pixel_height: 0 })
+                .expect("resize while alive");
+        }
+        let _ = child.wait();
+        reg.slots.lock().unwrap().remove("t2").unwrap();
+    }
+
+    #[test]
+    fn close_unknown_tab_is_noop() {
+        let reg = registry();
+        // Direct check: removing absent tab returns None, no panic.
+        assert!(reg.slots.lock().unwrap().remove("never-existed").is_none());
+    }
+
+    #[test]
+    fn cleanup_drops_slot() {
+        let reg = registry();
+        let mut child = open_raw(&reg, "t3", "/bin/sleep", vec!["0.01".into()]);
+        let _ = child.wait();
+        let mut slot = reg.slots.lock().unwrap().remove("t3").expect("slot present");
+        drop(slot.writer);
+        drop(slot.master);
+        // No reader thread in test harness; just verify the slot was removable.
+        assert!(slot.reader_thread.take().is_none());
+        // Slot count is back to zero.
+        assert!(reg.slots.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn registry_handles_concurrent_inserts() {
+        let reg = registry();
+        let n_tabs = 4;
+        let mut children: Vec<Box<dyn Child + Send + Sync>> = Vec::new();
+        for i in 0..n_tabs {
+            let id = format!("t-concurrent-{i}");
+            children.push(open_raw(&reg, &id, "/bin/sleep", vec!["0.05".into()]));
+        }
+        assert_eq!(reg.slots.lock().unwrap().len(), n_tabs);
+        let start = Instant::now();
+        for mut c in children {
+            let _ = c.wait();
+        }
+        assert!(start.elapsed() < Duration::from_secs(2));
+        // Drain.
+        let mut guard = reg.slots.lock().unwrap();
+        for i in 0..n_tabs {
+            let id = format!("t-concurrent-{i}");
+            guard.remove(&id).expect("present");
+        }
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -341,8 +341,22 @@ export default function App() {
   // every per-tab update we write the tab record AND, if it's active,
   // also write the root mirror.
   // ---------------------------------------------------------------------
+  // M6 P1: shell-tab metadata. Present iff Tab.kind === "shell".
+  // Carried as an optional sibling field (rather than refactoring Tab to a
+  // discriminated union) so existing agent-tab code paths stay unchanged.
+  interface ShellMeta {
+    cwd: string;
+    command: string;
+    args: string[];
+    shareMode: "private" | "read" | "read-write" | "read-write-trusted";
+    shellState: "starting" | "running" | "exited";
+    exitCode?: number;
+  }
   interface Tab {
     id: string;
+    /** "agent" (chat session) or "shell" (interactive PTY). Default "agent"
+     *  for back-compat with persisted tab records that pre-date the field. */
+    kind: "agent" | "shell";
     label: string;
     messages: ChatMessage[];
     draft: string;
@@ -361,6 +375,8 @@ export default function App() {
     // projects swaps `state.tabs` for the target project's bucket and
     // hides everyone else.
     projectId: string | null;
+    /** Present iff kind === "shell". */
+    shell?: ShellMeta;
   }
   // Sentinel key for the "no project" bucket. Project ids are UUIDs so
   // a literal can't collide.
@@ -371,9 +387,11 @@ export default function App() {
     id: string,
     label: string,
     projectId: string | null = null,
+    kind: "agent" | "shell" = "agent",
   ): Tab {
     return {
       id,
+      kind,
       label,
       messages: [],
       draft: "",
@@ -923,6 +941,11 @@ export default function App() {
     "queueCount",
     "canvas",
     "model",
+    // M6 P1: shell-tab fields. The "kind" + "shell" mirror lets layouts
+    // bind `visible: { $ref: "/kind" }`-style toggles without running a
+    // full /tabs/<idx> lookup on every render.
+    "kind",
+    "shell",
   ];
 
   function updateTab(tabId: string, mutator: (tab: Tab) => Tab) {
@@ -1020,6 +1043,28 @@ export default function App() {
   // `window.__AETHON_STATE__()` without going through React's state lifecycle.
   const stateRef = useRef(state);
   stateRef.current = state;
+
+  // M6 P1: derive boolean flags from the active tab's kind so layout
+  // payloads can bind `visible: { $ref: "/shellTabActive" }` /
+  // `/agentTabActive` without computing equality at the renderer.
+  // Both flags require /hasTabs — when no tab exists, neither is true
+  // (the empty-state composite owns the canvas area instead).
+  const hasTabsForKind = !!state.hasTabs;
+  const tabKind = (state.kind as string | undefined) ?? "agent";
+  useEffect(() => {
+    const isShell = hasTabsForKind && tabKind === "shell";
+    const isAgent = hasTabsForKind && tabKind !== "shell";
+    setState((prev) => {
+      if (prev.shellTabActive === isShell && prev.agentTabActive === isAgent) {
+        return prev;
+      }
+      return {
+        ...prev,
+        shellTabActive: isShell,
+        agentTabActive: isAgent,
+      };
+    });
+  }, [hasTabsForKind, tabKind]);
 
   // ---------------------------------------------------------------------
   // Tab actions. Each one updates local state AND tells the bridge so the
@@ -1121,6 +1166,68 @@ export default function App() {
       });
   }
 
+  // M6 P1: open a new shell tab — interactive PTY-backed user shell.
+  // Symmetric to newTab() but skips the bridge/agent IPC entirely; the
+  // tab's kind = "shell", no pi session is created, and the Rust shell
+  // command spawns a portable_pty child whose stdout streams via
+  // `shell-output` events (handled below) and whose keystrokes flow
+  // through `shell_input` (driven by the shell-canvas composite).
+  function newShellTab(options?: { command?: string; args?: string[]; cwd?: string }) {
+    const id = crypto.randomUUID();
+    const inheritedCwd = options?.cwd ?? activeProject(projectsRef.current)?.path;
+    setState((prev) => {
+      const tabs = ((prev.tabs as Tab[] | undefined) ?? []).slice();
+      const label = `Shell ${tabs.filter((t) => t.kind === "shell").length + 1}`;
+      const projectId = projectsRef.current.activeId;
+      const tab: Tab = {
+        ...makeEmptyTab(id, label, projectId, "shell"),
+        shell: {
+          cwd: inheritedCwd ?? "",
+          command: options?.command ?? "",
+          args: options?.args ?? [],
+          shareMode: "private",
+          shellState: "starting",
+        },
+      };
+      tabs.push(tab);
+      const result: Record<string, unknown> = {
+        ...prev,
+        tabs,
+        activeTabId: id,
+        empty: false,
+        hasTabs: true,
+      };
+      const tabRec = tab as unknown as Record<string, unknown>;
+      for (const key of TAB_MIRROR_KEYS) {
+        result[key as string] = tabRec[key as string];
+      }
+      return result;
+    });
+    invoke("shell_open", {
+      args: {
+        tabId: id,
+        ...(options?.command ? { command: options.command } : {}),
+        ...(options?.args ? { args: options.args } : {}),
+        ...(inheritedCwd ? { cwd: inheritedCwd } : {}),
+      },
+    })
+      .then(() => {
+        updateTab(id, (t) => ({
+          ...t,
+          shell: t.shell ? { ...t.shell, shellState: "running" } : t.shell,
+        }));
+      })
+      .catch((err: unknown) => {
+        appendSystem(`Failed to open shell tab: ${String(err)}`);
+        updateTab(id, (t) => ({
+          ...t,
+          shell: t.shell
+            ? { ...t.shell, shellState: "exited", exitCode: -1 }
+            : t.shell,
+        }));
+      });
+  }
+
   function autoRestoreDiscoveredSessions(
     discovered: DiscoveredSession[],
     knownIds: Set<string>,
@@ -1171,6 +1278,9 @@ export default function App() {
   function closeTab(tabId: string) {
     const tabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
     if (tabs.length === 0) return; // already empty — nothing to close
+    // Capture the kind before setState removes the tab, so we know
+    // whether to also tear down the PTY in the Rust shell registry.
+    const closedKind = tabs.find((t) => t.id === tabId)?.kind;
     let nextBuffer = "";
     let switched = false;
     let becameEmpty = false;
@@ -1228,6 +1338,14 @@ export default function App() {
         payload: JSON.stringify({ type: "tab_close", tabId }),
       }).catch(() => {
         /* ignore — UI already closed */
+      });
+    }
+    // M6 P1: shell tabs own a PTY in the Rust shell registry. Close
+    // it too so the child process is reaped and the reader thread
+    // joins (no zombies on tab close).
+    if (closedKind === "shell") {
+      invoke("shell_close", { tabId }).catch(() => {
+        /* idempotent — already torn down by natural exit */
       });
     }
   }
@@ -1299,11 +1417,22 @@ export default function App() {
         void stopPrompt();
         return;
       }
-      // Cmd+T → new tab. Pi sessions are independent per tab.
-      if (e.key.toLowerCase() === "t" && mod && !e.shiftKey && !e.altKey) {
+      // Cmd+Shift+T → new agent tab (chat session). Checked before plain
+      // Cmd+T so shift takes precedence — the lowercase key match would
+      // otherwise route both to the shell-tab path.
+      if (e.key.toLowerCase() === "t" && mod && e.shiftKey && !e.altKey) {
         e.preventDefault();
         e.stopPropagation();
         newTab();
+        return;
+      }
+      // M6 P1: Cmd+T → new shell tab. Matches Terminal.app, iTerm2,
+      // GNOME Terminal, Windows Terminal. Existing chat behavior moves
+      // to Cmd+Shift+T.
+      if (e.key.toLowerCase() === "t" && mod && !e.shiftKey && !e.altKey) {
+        e.preventDefault();
+        e.stopPropagation();
+        newShellTab();
         return;
       }
       // Cmd+] → next tab; Cmd+[ → previous. Matches macOS browser
@@ -1574,6 +1703,53 @@ export default function App() {
       }
     });
 
+    // M6 P1: shell-output streams a PTY chunk. Append to the originating
+    // shell-tab's terminalBuffer and dispatch a per-tab window event so
+    // the shell-canvas composite (subscribed by tabId) writes the chunk
+    // to its xterm. Inactive shell-tab output stays buffered until the
+    // user switches to it (replay-on-mount, same pattern as agent
+    // bash output for the read-only Terminal panel).
+    const unlistenShellOutput = listen<{ tabId: string; content: string }>(
+      "shell-output",
+      (event) => {
+        const { tabId, content } = event.payload;
+        if (!tabId || typeof content !== "string") return;
+        updateTab(tabId, (t) => {
+          const next = t.terminalBuffer + content;
+          const trimmed = next.length > TERMINAL_REPLAY_MAX
+            ? next.slice(next.length - TERMINAL_REPLAY_MAX)
+            : next;
+          return { ...t, terminalBuffer: trimmed };
+        });
+        window.dispatchEvent(
+          new CustomEvent(`aethon:shell-output:${tabId}`, { detail: content }),
+        );
+      },
+    );
+
+    // M6 P1: shell-exit fires once when the PTY child process ends.
+    // Flip the tab's shell.shellState to "exited" so the canvas can
+    // show a closed-process indicator; the slot is left in the Rust
+    // registry until tab close (cleanup is idempotent).
+    const unlistenShellExit = listen<{ tabId: string; code: number | null }>(
+      "shell-exit",
+      (event) => {
+        const { tabId, code } = event.payload;
+        if (!tabId) return;
+        updateTab(tabId, (t) => {
+          if (t.kind !== "shell" || !t.shell) return t;
+          return {
+            ...t,
+            shell: {
+              ...t.shell,
+              shellState: "exited",
+              ...(typeof code === "number" ? { exitCode: code } : {}),
+            },
+          };
+        });
+      },
+    );
+
     const unlistenReload = listen<string>("agent-reloaded", () => {
       activeResponseIdRef.current = null;
       setStatusFlags({ waiting: false, status: "agent reloaded" });
@@ -1629,7 +1805,16 @@ export default function App() {
         return;
       }
       switch (id) {
-        case "new_tab": newTab(); break;
+        // Cmd+T (menu + tray) defaults to a shell tab in M6 — matches
+        // Terminal.app convention. The legacy "new_tab" id is preserved
+        // so older payloads keep working; "new_agent_tab" is new.
+        case "new_tab":
+        case "new_shell_tab":
+          newShellTab();
+          break;
+        case "new_agent_tab":
+          newTab();
+          break;
         case "close_tab": {
           const activeId = stateRef.current.activeTabId as string | undefined;
           if (activeId) closeTab(activeId);
@@ -1666,6 +1851,8 @@ export default function App() {
       unlistenReload.then((fn) => fn());
       unlistenStderr.then((fn) => fn());
       unlistenMenu.then((fn) => fn());
+      unlistenShellOutput.then((fn) => fn());
+      unlistenShellExit.then((fn) => fn());
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/src/skills/default-layout/components.tsx
+++ b/src/skills/default-layout/components.tsx
@@ -12,6 +12,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties } from "react";
 import { createPortal } from "react-dom";
 import ReactMarkdown from "react-markdown";
+import { invoke } from "@tauri-apps/api/core";
 import { HighlightedCode } from "../../components/HighlightedCode";
 import { Terminal as XTerm } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
@@ -1741,6 +1742,146 @@ interface TabStripItem {
   /** Pending follow-up count behind the active prompt. Adds a small
    *  numeric chip after the label when > 0. */
   queueCount?: number;
+}
+
+// ---------------------------------------------------------------------------
+// ShellCanvas — interactive PTY-backed terminal for shell tabs (M6 P1).
+// Distinct from Terminal: this composite has bidirectional input (term.onData
+// invokes shell_input) and is bound to a specific shell-tab id (so it can
+// subscribe to per-tab `aethon:shell-output:<tabId>` events and resize the
+// matching PTY via shell_resize). Mounts a fresh xterm per tabId — switching
+// tabs unmounts/remounts so scrollback isolation is automatic.
+// ---------------------------------------------------------------------------
+
+export function ShellCanvas({ component, state }: BuiltinComponentProps) {
+  const props = component.props as {
+    /** Shell tab id this canvas is bound to. Resolved via $ref so the
+     *  layout can pass `/activeTabId` and have the canvas track the
+     *  active shell tab automatically. */
+    tabId?: StringValue;
+    fontSize?: NumberValue;
+    bootGreeting?: StringValue;
+  };
+  const tabId = props.tabId ? resolveString(props.tabId, state) : "";
+  const fontSize = props.fontSize ? resolveNumber(props.fontSize, state) : 13;
+  const bootGreeting = props.bootGreeting
+    ? resolveString(props.bootGreeting, state)
+    : "";
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const termRef = useRef<XTerm | null>(null);
+  const fitRef = useRef<FitAddon | null>(null);
+  const tabIdRef = useRef<string>(tabId);
+  useEffect(() => {
+    tabIdRef.current = tabId;
+  }, [tabId]);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+    if (!tabId) return; // no tab bound yet — wait for the layout to populate
+
+    const term = new XTerm({
+      fontSize,
+      fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+      cursorBlink: true,
+      allowProposedApi: true,
+      // Themed via inline CSS vars — for P1 a dark default mirrors the agent
+      // panel; M6's "theme-aware ANSI palette" lands in a follow-up.
+      theme: {
+        background: "#0e0e10",
+        foreground: "#e8e8ec",
+        cursor: "#7c8cff",
+      },
+    });
+    termRef.current = term;
+    const fit = new FitAddon();
+    fitRef.current = fit;
+    term.loadAddon(fit);
+    term.open(containerRef.current);
+    try {
+      const webgl = new WebglAddon();
+      webgl.onContextLoss(() => webgl.dispose());
+      term.loadAddon(webgl);
+    } catch (err) {
+      console.warn("WebGL renderer unavailable, using canvas fallback:", err);
+    }
+    fit.fit();
+    if (bootGreeting) term.write(bootGreeting);
+
+    // Keystrokes → shell_input. Send the raw bytes the shell wants to
+    // see — xterm gives us the pre-encoded sequence (e.g. "\x1b[A" for up
+    // arrow), so we forward verbatim.
+    const onDataDisposable = term.onData((data) => {
+      void invoke("shell_input", { tabId: tabIdRef.current, data }).catch(
+        () => {
+          /* PTY closed mid-keystroke — drop silently */
+        },
+      );
+    });
+
+    // Resize: FitAddon recomputes cols/rows on layout changes; tell the
+    // PTY too so child processes (vim, less, …) reflow correctly.
+    const ro = new ResizeObserver(() => {
+      try {
+        fit.fit();
+        const cols = term.cols;
+        const rows = term.rows;
+        if (cols && rows) {
+          void invoke("shell_resize", {
+            tabId: tabIdRef.current,
+            cols,
+            rows,
+          }).catch(() => {
+            /* PTY closed — drop */
+          });
+        }
+      } catch {
+        /* fit transient errors during teardown */
+      }
+    });
+    ro.observe(containerRef.current);
+
+    // PTY chunks land via per-tab CustomEvent (`aethon:shell-output:<tabId>`).
+    // App.tsx dispatches them; we route to xterm.write here.
+    const onShellOutput = (e: Event) => {
+      const detail = (e as CustomEvent<string>).detail;
+      if (typeof detail === "string" && detail.length > 0) {
+        term.write(detail);
+      }
+    };
+    const eventName = `aethon:shell-output:${tabId}`;
+    window.addEventListener(eventName, onShellOutput);
+
+    // Replay any already-buffered scrollback (when the tab was mounted
+    // after some output had already streamed). App.tsx writes buffer to
+    // /tabs/<idx>/terminalBuffer; we read it via state.
+    const tabs = (state["tabs"] as Array<{ id: string; terminalBuffer?: string }> | undefined) ?? [];
+    const tab = tabs.find((t) => t.id === tabId);
+    if (tab?.terminalBuffer) term.write(tab.terminalBuffer);
+
+    return () => {
+      window.removeEventListener(eventName, onShellOutput);
+      ro.disconnect();
+      onDataDisposable.dispose();
+      term.dispose();
+      termRef.current = null;
+      fitRef.current = null;
+    };
+    // Mount once per tabId — switching tabs creates a new instance.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tabId]);
+
+  return (
+    <div
+      ref={containerRef}
+      style={{
+        width: "100%",
+        height: "100%",
+        background: "var(--terminal-bg, #0e0e10)",
+        gridArea: "canvas",
+      }}
+    />
+  );
 }
 
 export function TabStrip({ component, state, onEvent }: BuiltinComponentProps) {

--- a/src/skills/default-layout/index.ts
+++ b/src/skills/default-layout/index.ts
@@ -13,6 +13,7 @@ import {
   EmptyState,
   Layout,
   MainCanvas,
+  ShellCanvas,
   Sidebar,
   StatusBar,
   TabStrip,
@@ -63,6 +64,11 @@ export const defaultLayoutSkill: A2UISkill = {
     "tab-strip": TabStrip,
     terminal: Terminal,
     "main-canvas": MainCanvas,
+    // M6 P1: full-canvas interactive PTY for shell tabs. Layouts may slot
+    // it into the canvas area with `visible: { $ref: "/kind" }` (or an
+    // equivalent mode flag) so it appears only when the active tab is a
+    // shell tab.
+    "shell-canvas": ShellCanvas,
     "empty-state": EmptyState,
     // Layout-variation chrome — used by editorial / command-deck / live-layout.
     // Registered alongside the standard composites so any layout payload can

--- a/src/skills/default-layout/workstation.a2ui.json
+++ b/src/skills/default-layout/workstation.a2ui.json
@@ -110,9 +110,19 @@
           "type": "main-canvas",
           "props": {
             "area": "canvas",
-            "visible": { "$ref": "/hasTabs" },
+            "visible": { "$ref": "/agentTabActive" },
             "slot": "/canvas",
             "messages": { "$ref": "/messages" }
+          }
+        },
+        {
+          "id": "shell-canvas",
+          "type": "shell-canvas",
+          "props": {
+            "area": "canvas",
+            "visible": { "$ref": "/shellTabActive" },
+            "tabId": { "$ref": "/activeTabId" },
+            "fontSize": 13
           }
         },
         {
@@ -151,7 +161,7 @@
           "type": "chat-input",
           "props": {
             "area": "composer",
-            "visible": { "$ref": "/hasTabs" },
+            "visible": { "$ref": "/agentTabActive" },
             "value": { "$ref": "/draft" },
             "placeholder": "Message Aethon… (Enter to send, Shift+Enter for newline, / for commands)",
             "disabled": { "$ref": "/waiting" },
@@ -184,6 +194,8 @@
     "canvas": null,
     "empty": false,
     "hasTabs": true,
+    "agentTabActive": true,
+    "shellTabActive": false,
     "recentSessions": [],
     "agentStatus": {
       "label": "agent live",


### PR DESCRIPTION
## Summary

First shipping phase of M6 (per the milestone spec landed in #7). This delivers real interactive user shell tabs:

- **`Cmd+T` opens a new shell tab** — full xterm.js with PTY-backed shell (bash/zsh/PowerShell), WebGL renderer, FitAddon resize, mouse reporting, true color, 256-color palette. Matches Terminal.app/iTerm2 muscle memory.
- **`Cmd+Shift+T` opens an agent tab** — the existing chat behavior moves here.
- **`Tab.kind: "agent" | "shell"`** discriminator in `App.tsx`. Agent tabs unchanged. Shell tabs carry `Tab.shell` metadata (cwd, command, args, shareMode, shellState, exitCode).
- **`portable-pty` Rust crate** — per-tab `Mutex<HashMap<TabId, ShellSlot>>` in app state. 4 Tauri commands: `shell_open` / `shell_input` / `shell_resize` / `shell_close`. Reader thread emits `shell-output {tabId, content}` events; child exit emits `shell-exit {tabId, code}` once. `shell_close` kills the child + drops master/writer to unblock the reader → no zombie processes.

## Phase scope

This is **P1 of 6** for M6. P1 = "shell tabs work end-to-end, no sharing yet."

What lands here:
- Tab kinds (#6.1)
- PTY backend + interactive xterm (#6.2 base)
- Cmd+T migration + Cmd+Shift+T binding (#6.4 partial)
- Native menu items "New Shell Tab" / "New Agent Tab" with matching accelerators

What's intentionally **deferred to follow-up phases**:
- **P2**: agent ↔ shell sharing model (`aethon.shells.{list,read,write}`, share-mode badge, per-write user confirmation, privacy guardrail). The `Tab.shell.shareMode` field is already in the type — defaults to `"private"` and is unused for now.
- **P3+**: theme-aware ANSI palette, foreground-process tab title polling, close-confirm when a foreground job is running, settings UI, drag-drop file → shell-quoted paste. None of these block shell tabs from being usable today.

The other three layouts (`editorial`, `command-deck`, `live-layout`) still render their existing chrome for shell tabs. Workstation (boot default) is the only layout that swaps `main-canvas` + `chat-input` for `shell-canvas` when a shell tab is active. Layout-swap parity for the other three is a small follow-up.

## Test plan

- [x] `cargo test --lib` — 19 tests pass (5 new shell tests cover spawn/exit, resize while alive, idempotent close, cleanup, concurrent inserts)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `bunx tsc -b --noEmit` — clean
- [x] `bunx eslint .` — 0 errors
- [x] `bunx vitest run` — 144 tests pass
- [ ] Live UAT in dev (Cmd+T, run vim, exit, Cmd+W). The dev binary needs a restart to pick up shell.rs; will UAT after CI green.
- [ ] codex review --base main (high reasoning) green