### PR TITLE
fix(palette): collapse sections globally + fix arrow nav + clearer active row

### DIFF
--- a/src/skills/default-layout/command-palette.tsx
+++ b/src/skills/default-layout/command-palette.tsx
@@ -87,12 +87,55 @@ export function CommandPalette({ state, onEvent }: BuiltinComponentProps) {
     row?.scrollIntoView({ block: "nearest" });
   }, [clamped, palette.open]);
 
-  if (!palette.open) return null;
-
+  // Belt-and-braces navigation: a document-level keydown handler that
+  // fires regardless of where focus actually lives. The input's own
+  // onKeyDown (below) handles the common case, but if anything steals
+  // focus mid-render — a re-render that shifts focus, a row's
+  // onMouseEnter, an extension keystroke handler — the input would go
+  // deaf to ArrowUp/Down. Capture-phase listener so it beats other
+  // bubble-phase keydown listeners on the same combos.
   const close = () => onEvent("close");
   const select = (item: PaletteItem) => onEvent("select", { item });
   const setQuery = (q: string) => onEvent("query", { value: q });
   const setIndex = (idx: number) => onEvent("navigate", { index: idx });
+  useEffect(() => {
+    if (!palette.open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        e.stopPropagation();
+        setIndex(items.length > 0 ? (clamped + 1) % items.length : 0);
+        // Refocus input — the user keeps typing into it after navigating.
+        inputRef.current?.focus();
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        e.stopPropagation();
+        setIndex(
+          items.length > 0
+            ? (clamped - 1 + items.length) % items.length
+            : 0,
+        );
+        inputRef.current?.focus();
+        return;
+      }
+      if (e.key === "Enter") {
+        const target = items[clamped];
+        if (target) {
+          e.preventDefault();
+          e.stopPropagation();
+          select(target);
+        }
+        return;
+      }
+    };
+    document.addEventListener("keydown", handler, true);
+    return () => document.removeEventListener("keydown", handler, true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [palette.open, clamped, items.length]);
+
+  if (!palette.open) return null;
 
   const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Escape") {
@@ -122,16 +165,22 @@ export function CommandPalette({ state, onEvent }: BuiltinComponentProps) {
     }
   };
 
-  // Group display items by section while preserving their ranked order.
-  // We don't re-sort within a section — ranking already accounts for the
-  // user's section preference (`>`, `@`, `?` prefixes).
+  // Group display items by section. Each section appears once with all
+  // its matching items — even if score-sort interleaved sections in the
+  // ranked list (e.g. "/theme" slash-command outscoring some theme rows
+  // pushed Ember/Æther into a separate Themes block from Paper). Section
+  // *order* follows first-appearance in the ranked list so the highest-
+  // scoring section's block lands at the top; *items within* a section
+  // keep their score-sorted order.
   const grouped: { section: PaletteSection; items: PaletteItem[] }[] = [];
+  const sectionIndex = new Map<PaletteSection, number>();
   for (const item of items) {
-    const last = grouped[grouped.length - 1];
-    if (last && last.section === item.section) {
-      last.items.push(item);
-    } else {
+    const idx = sectionIndex.get(item.section);
+    if (idx === undefined) {
+      sectionIndex.set(item.section, grouped.length);
       grouped.push({ section: item.section, items: [item] });
+    } else {
+      grouped[idx].items.push(item);
     }
   }
 

--- a/src/skills/default-layout/palette-items.ts
+++ b/src/skills/default-layout/palette-items.ts
@@ -294,7 +294,14 @@ export function rankItems(
   }
   const scored: { item: PaletteItem; score: number }[] = [];
   for (const item of items) {
-    const haystack = `${item.label} ${item.hint ?? ""} ${item.id}`;
+    // Score against user-visible text plus the section label. Including
+    // the internal `id` (e.g. `keybind:builtin:meta+b`) made fuzzy hit
+    // unrelated rows whose ids happened to share characters with the
+    // query (typing "theme" matched every keybinding because their ids
+    // contain h/e/m in order). The section label is what users actually
+    // expect to search by — typing "theme" should find every theme,
+    // typing "model" every model — so we score it explicitly here.
+    const haystack = `${item.label} ${item.hint ?? ""} ${SECTION_LABEL[item.section]}`;
     let score = fuzzyScore(q, haystack);
     if (score <= 0) continue;
     if (preferred && item.section === preferred) score += 20;

--- a/src/styles.css
+++ b/src/styles.css
@@ -2716,9 +2716,17 @@ body.ae-resizing-sidebar * {
   font-size: var(--text-sm);
   line-height: 1.3;
   min-width: 0;
+  /* Reserve space for the active-row accent rail so non-active rows
+     don't shift on highlight transitions. */
+  border-left: 3px solid transparent;
 }
 .ae-palette-row-active {
   background: var(--accent-soft);
+  border-left-color: var(--accent);
+}
+.ae-palette-row-active .ae-palette-row-label {
+  color: var(--accent);
+  font-weight: 500;
 }
 .ae-palette-row-label {
   color: var(--text);


### PR DESCRIPTION
## Summary

User-reported: searching for \"theme\" in the command palette only listed one theme (Æther) instead of all three, and arrow keys felt like they did nothing after typing.

Three contributing issues, all in the command palette, fixed together:

### 1. Section grouping was contiguous-only
The grouped renderer split sections every time score-sort interleaved them. Typing \"theme\" ranked \`/theme\` highest, then a slash-command (\`/model\`) intervened, and the *Themes* block fragmented into two section headers. The first Themes block held only the highest-scoring theme; the rest landed in a second Themes block scrolled off-screen. Fix: group by section name globally so each section appears once, in first-appearance order, with all matching items.

### 2. \`id\` in the search haystack matched too loosely
Internal ids (\`keybind:builtin:meta+b\`, \`theme:ember\`) leaked characters into fuzzy matching — \"theme\" matched every keybinding because their ids contained h/e/m in order. Fix: drop \`id\` from the haystack and add the section *label* instead, which is what users actually expect to search by (\"theme\" → all themes, \"model\" → all models).

### 3. Arrow nav depended on input focus
\`onKeyDown\` on the input handles Arrow/Enter, but if anything stole focus mid-render (extension keystroke handler, row \`onMouseEnter\` setState, re-render shifting focus) those keys went deaf. Fix: document-level capture-phase keydown listener while the palette is open. \`stopPropagation\` to avoid the input's own \`onKeyDown\` double-firing; refocus the input after navigating so typing continues seamlessly.

### Bonus: clearer active row
3px accent rail on the active row's left edge, accent-tinted label, 500-weight font. The previous 16% alpha fill alone was too easy to miss against Paper's cream background, which contributed to the \"arrows feel like they do nothing\" report.

## Test plan

- [x] All 144 vitest cases pass; \`tsc -b --noEmit\` + \`eslint .\` clean.
- [x] Live UAT via \`aethon-debug\`: typing \"theme\" now returns one Themes block with all 3 themes (Ember, Æther, Paper); ArrowDown advances index 0→5 through the merged Themes section, input stays focused, active row visibly highlighted.
- [ ] codex review --base main (high reasoning) green