### PR TITLE
fix(shell): address codex P1+P2 follow-ups on M6 P2.2

### DIFF
--- a/agent/main.ts
+++ b/agent/main.ts
@@ -1421,13 +1421,28 @@ async function main() {
     });
     return { id, promise };
   }
-  /** Wait until the frontend handshake completes. Used by query-style
-   *  ops (`aethon.shells.list/read`) so they don't ride the
-   *  side-effect-mutation shortcut that returns `{ok:true, data:undefined}`
-   *  pre-ready. */
-  async function awaitFrontendReady(): Promise<void> {
-    if (frontendReady) return;
-    await frontendReadyPromise;
+  /** Wait until the frontend handshake completes, bounded by `timeoutMs`
+   *  so we never deadlock during extension registration. Extensions
+   *  that call `aethon.shells.list()` from inside their async
+   *  `register()` would otherwise hang forever: the stdin loop (which
+   *  receives the eventual `report`) doesn't start until registration
+   *  completes, and registration is blocked on this very await.
+   *
+   *  Returns `true` when ready, `false` on timeout. Callers that pass
+   *  no timeout block until ready (legitimate from post-startup code
+   *  like event handlers and tool calls). */
+  async function awaitFrontendReady(timeoutMs?: number): Promise<boolean> {
+    if (frontendReady) return true;
+    if (typeof timeoutMs !== "number") {
+      await frontendReadyPromise;
+      return true;
+    }
+    return await Promise.race<boolean>([
+      frontendReadyPromise.then(() => true),
+      new Promise<boolean>((resolve) =>
+        setTimeout(() => resolve(false), timeoutMs),
+      ),
+    ]);
   }
 
   function ackMutation(
@@ -2216,16 +2231,29 @@ async function main() {
   // ack timeout because it can wait on user confirmation in the UI.
   const SHELL_WRITE_ACK_TIMEOUT_MS = 5 * 60 * 1000; // 5 min — user may step away
 
+  /** Bounded wait for the frontend handshake before sending a query.
+   *  Mirrors the regular mutation-ack timeout so an extension that
+   *  awaits `aethon.shells.list()` from its async `register()` gets a
+   *  clean `frontend_not_ready` failure after 5 s instead of a process
+   *  deadlock (registration runs before the stdin loop starts; the
+   *  stdin loop is what delivers `report`, so a long await blocks
+   *  startup). */
+  const SHELL_QUERY_READY_WAIT_MS = MUTATION_ACK_TIMEOUT_MS;
+
   async function _shellQuery(
     op: "list" | "read" | "write",
     args: Record<string, unknown> = {},
     timeoutMs?: number,
   ): Promise<MutationResult> {
     // Queries need real data, not the side-effect-mutation shortcut.
-    // Pre-ready callers (extension boot, autorun scripts) wait here so
-    // the frontend has a chance to wire its `shell_query` handler before
-    // we send and the ack has somewhere to land.
-    await awaitFrontendReady();
+    // Bounded so register-time callers never deadlock startup.
+    const ready = await awaitFrontendReady(SHELL_QUERY_READY_WAIT_MS);
+    if (!ready) {
+      return {
+        ok: false,
+        error: "frontend_not_ready",
+      };
+    }
     const { id, promise } = trackMutation(timeoutMs);
     send({ type: "shell_query", mutationId: id, op, args });
     return promise;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -120,6 +120,13 @@ const BOOT_LAYOUT: A2UIPayload = defaultLayoutSkill.layout!;
 
 const ZOOM_MIN = 0.7;
 const ZOOM_MAX = 1.6;
+/** Lifetime of an Allow/Deny prompt for `aethon.shells.write` in
+ *  read-write mode. Set ~30 s under the bridge-side ack timeout
+ *  (5 min) so a late click can never inject keystrokes after the
+ *  caller's promise has already failed with `timeout`. The auto-
+ *  expire flows through the existing notification dismiss path,
+ *  which resolves the consent as deny. */
+const SHELL_WRITE_PROMPT_TTL_MS = 4 * 60 * 1000 + 30 * 1000;
 
 function writeUiViewportVars(scale: number) {
   const root = document.documentElement;
@@ -1059,9 +1066,9 @@ export default function App() {
     return { ok: true };
   }
 
-  /** Push a sticky notification with Allow / Deny actions and resolve
-   *  with the user's choice (or false on dismiss). The pending choice
-   *  is keyed off the notification id and stored in
+  /** Push a Allow/Deny notification and resolve with the user's choice
+   *  (or `false` on dismiss / auto-expire). The pending choice is
+   *  keyed off the notification id and stored in
    *  `shellWriteConsentRef` so the existing notification action route
    *  can hand back the resolution. */
   function promptShellWriteConfirmation(input: {
@@ -1083,7 +1090,13 @@ export default function App() {
         title: `Agent wants to type in "${input.tabLabel}"`,
         message: preview,
         kind: "warning",
-        durationMs: null, // sticky — only user choice or dismiss closes it
+        // Auto-expire ~30 s before the bridge's 5-min ack timeout so a
+        // late Allow click can never invoke `shell_write` after the
+        // caller's promise has already resolved as timed-out. The
+        // notification's `expire` event flows through the existing
+        // dismiss path → `resolveShellWriteConsent(id, false)` →
+        // bridge sees a denied result and the prompt vanishes.
+        durationMs: SHELL_WRITE_PROMPT_TTL_MS,
         actions: [
           { label: "Allow", action: `shell-write-allow:${id}` },
           { label: "Deny", action: `shell-write-deny:${id}` },


### PR DESCRIPTION
Codex flagged two issues on PR #14 that landed via auto-merge before this fix could be folded in. Both are real and shipped now on \`main\`.

## P1 — register-time deadlock

If an extension calls \`aethon.shells.list/read/write\` from its async \`register()\`, \`awaitFrontendReady()\` blocks forever. The stdin loop that delivers \`report\` (which flips \`frontendReady\`) doesn't start until registration completes — and registration is blocked on this very await.

**Fix**: bound the wait to \`MUTATION_ACK_TIMEOUT_MS\` (5 s) and return \`{ok:false, error:"frontend_not_ready"}\` on timeout. The caller can retry post-startup or accept the failure; registration unblocks within 5 s of the worst case.

## P2 — late-click race on shell-write prompts

A \`read-write\` write prompt left unanswered for > 5 min crosses the bridge ack timeout. The caller's promise resolves as \`timeout\`, but the sticky notification stays live. A late Allow click would then invoke \`shell_write\`, injecting keystrokes after the caller had already failed/retried — exactly the kind of late-effect surprise the privacy gate is supposed to prevent.

**Fix**: set the notification \`durationMs\` to 4m30s (under the bridge ack timeout). Auto-expire flows through the existing dismiss/expire handler, which calls \`resolveShellWriteConsent(id, false)\` — the resolver is gone before the bridge times out, so a late click is a no-op.

## Test plan

- [x] cargo test --lib shell:: (30 tests)
- [x] cargo clippy --all-targets -- -D warnings clean
- [x] bunx tsc -b --noEmit clean
- [x] bunx eslint . clean
- [x] bunx vitest run (150)
- [ ] codex re-review