### PR TITLE
feat(ux): shells render in bottom panel as sub-tabs; Cmd+T focus-aware

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,16 +124,16 @@ console) can swap chrome at runtime:
 
 | Combo | Action |
 |---|---|
-| `Cmd+T` | New shell tab (Terminal.app convention) |
-| `Cmd+Shift+T` | New agent tab |
+| `Cmd+T` | New tab — **focus-aware**: agent tab when outside the bottom terminal panel, shell sub-tab when focus is inside the panel |
+| `Cmd+Shift+T` | New shell sub-tab (always — auto-opens the bottom panel) |
 | `Cmd+W` | Close active tab |
 | `Cmd+Opt+T` | Reopen most-recently-closed tab |
-| `Cmd+]` / `Cmd+[` | Next / previous tab |
-| `Cmd+Shift+]` / `Cmd+Shift+[` | Move active tab right / left |
-| `Cmd+1`..`Cmd+8` | Jump to tab N |
-| `Cmd+9` | Jump to last tab |
+| `Cmd+]` / `Cmd+[` | Next / previous *agent* tab (top strip; shells are filtered) |
+| `Cmd+Shift+]` / `Cmd+Shift+[` | Move active agent tab right / left |
+| `Cmd+1`..`Cmd+8` | Jump to agent tab N |
+| `Cmd+9` | Jump to last agent tab |
 | `Cmd+P` / `Cmd+Shift+P` | Command palette (switcher / commands) |
-| `Cmd+\`` | Toggle agent bash output panel (read-only sink for bash tool output — distinct from the interactive shell-tab PTY) |
+| `Cmd+\`` | Toggle bottom terminal panel (Agent bash sub-tab + each user shell as a sub-tab) |
 | `Cmd+B` | Toggle sidebar |
 | `Cmd+K` | Clear chat |
 | `Cmd+.` | Stop current prompt |
@@ -145,25 +145,34 @@ same set under Ctrl. Native menu accelerators in `src-tauri/src/lib.rs`
 mirror these. Extension `aethon.registerKeybinding` priority is
 unchanged: extensions run first and may override built-ins.
 
-### "Two terminals" mental model
+### Terminal panel mental model
 
-Aethon ships **two distinct terminal surfaces**, intentionally
-separated:
+The **bottom terminal panel** (toggle `Cmd+\``) is a tabbed surface
+hosting two kinds of sub-tabs:
 
-1. **Agent bash output panel** (`Cmd+\``, header reads "Agent bash · read-only").
-   A read-only stream of the bash tool's stdout for the active agent
-   tab — what the agent saw when it ran `ls` / `git diff` / `npm test`.
-   Same content also appears in chat as a tool card; the panel just
-   pins it visible while you scroll chat.
-2. **Shell tabs** (`Cmd+T`, M6 P1+P2). Full interactive PTY backed by
+1. **Agent bash** (always present, sub-tab id `"agent-bash"`,
+   read-only). A live stream of the bash tool's stdout for the active
+   agent tab. Same content also appears in chat as a tool card; the
+   panel pins it visible while you scroll chat.
+2. **Shell sub-tabs** (zero or more). Full interactive PTYs backed by
    `portable-pty`. TUI-capable (vim, htop, fzf), 256-color, mouse
    reporting. Status line under the xterm shows
    `cwd · command · share-mode badge · cols×rows`.
 
-The label contrast is deliberate. Don't merge them — they serve
-different needs. If a user only wants the agent's bash visible, the
-panel is enough; if they want to drive their own shell, that's a
-shell tab.
+The top tab strip carries **only agent tabs** (chat sessions). Shell
+sub-tabs render in the bottom panel; the `TabStrip` composite filters
+out `kind === "shell"` automatically.
+
+`Cmd+T` is **focus-aware**: focus inside the bottom panel → new shell
+sub-tab; focus elsewhere → new agent tab. `Cmd+Shift+T` always spawns
+a new shell sub-tab and auto-opens the panel. This matches the
+mental model "new tab of whatever surface I'm using".
+
+State paths: `/terminalPanel/activeSubId` tracks which sub-tab is
+visible (defaults to `"agent-bash"`). `/terminal/open` toggles the
+whole panel. Shells live in `/tabs` next to agents but with
+`kind === "shell"` — the rendering layer routes them to the correct
+surface.
 
 ### Tab kinds — agent vs shell
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1345,18 +1345,22 @@ export default function App() {
         },
       };
       tabs.push(tab);
-      const result: Record<string, unknown> = {
+      // M6 restructure: shells live in the bottom panel as sub-tabs,
+      // not the top tab strip. Don't promote to /activeTabId — that
+      // stays on the user's agent tab. Instead, open the panel and
+      // make this shell the active sub-tab so the user sees it.
+      const panel =
+        (prev.terminalPanel as { activeSubId?: string } | undefined) ?? {};
+      const term =
+        (prev.terminal as { open?: boolean } | undefined) ?? {};
+      return {
         ...prev,
         tabs,
-        activeTabId: id,
-        empty: false,
-        hasTabs: true,
+        terminalPanel: { ...panel, activeSubId: id },
+        terminal: { ...term, open: true },
+        // hasTabs / empty unchanged — those track the AGENT tab strip,
+        // and shells don't affect that surface.
       };
-      const tabRec = tab as unknown as Record<string, unknown>;
-      for (const key of TAB_MIRROR_KEYS) {
-        result[key as string] = tabRec[key as string];
-      }
-      return result;
     });
     invoke("shell_open", {
       args: {
@@ -1427,21 +1431,63 @@ export default function App() {
   }
 
   function nextTab(direction: 1 | -1) {
-    const tabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
+    const tabs = ((stateRef.current.tabs as Tab[] | undefined) ?? [])
+      .filter((t) => t.kind !== "shell");
     if (tabs.length <= 1) return;
     const activeId = stateRef.current.activeTabId as string | undefined;
     const idx = tabs.findIndex((t) => t.id === activeId);
-    if (idx < 0) return;
+    if (idx < 0) {
+      // Active tab is no longer an agent (or not in /tabs). Jump to
+      // the first agent tab in the requested direction.
+      setActiveTab(direction > 0 ? tabs[0].id : tabs[tabs.length - 1].id);
+      return;
+    }
     const nextIdx = (idx + direction + tabs.length) % tabs.length;
     setActiveTab(tabs[nextIdx].id);
+  }
+
+  /** True when keyboard focus is anywhere inside the bottom terminal
+   *  panel (the agent-bash xterm or any shell sub-tab). Drives the
+   *  focus-aware Cmd+T routing: focus in the panel → new shell sub-tab,
+   *  otherwise → new agent tab. Falls back to false outside Tauri
+   *  (no DOM) so unit tests don't have to mock `document`. */
+  function isFocusInTerminalPanel(): boolean {
+    if (typeof document === "undefined") return false;
+    const focused = document.activeElement;
+    if (!focused) return false;
+    const panel = document.querySelector(".ae-terminal-panel");
+    return !!panel?.contains(focused);
+  }
+
+  /** Switch which sub-tab is active in the bottom terminal panel
+   *  (M6 restructure). Sub-tab id is either the special string
+   *  "agent-bash" (the always-present read-only view) or a shell tab
+   *  id from `/tabs`. Auto-opens the panel if it was hidden so the
+   *  user can see the result of their click. */
+  function setActiveSubTab(subId: string) {
+    setState((prev) => {
+      const panel =
+        (prev.terminalPanel as { activeSubId?: string } | undefined) ?? {};
+      const term = (prev.terminal as { open?: boolean } | undefined) ?? {};
+      if (panel.activeSubId === subId && term.open === true) {
+        return prev;
+      }
+      return {
+        ...prev,
+        terminalPanel: { ...panel, activeSubId: subId },
+        terminal: { ...term, open: true },
+      };
+    });
   }
 
   /** Jump to tab at zero-based index, clamped to the live tab list.
    *  No-op when out of range so a Cmd+5 with only 3 tabs is silent
    *  rather than throwing. Used by Cmd/Ctrl+1..9 keybindings (browser
-   *  + iTerm convention). */
+   *  + iTerm convention). Filters to agent tabs only — shell tabs live
+   *  in the bottom panel and have their own selection. */
   function jumpToTab(idx: number) {
-    const tabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
+    const tabs = ((stateRef.current.tabs as Tab[] | undefined) ?? [])
+      .filter((t) => t.kind !== "shell");
     if (tabs.length === 0) return;
     if (idx < 0 || idx >= tabs.length) return;
     setActiveTab(tabs[idx].id);
@@ -1669,22 +1715,30 @@ export default function App() {
         void stopPrompt();
         return;
       }
-      // Cmd+Shift+T → new agent tab (chat session). Checked before plain
-      // Cmd+T so shift takes precedence — the lowercase key match would
-      // otherwise route both to the shell-tab path.
+      // Cmd+Shift+T → explicit new shell sub-tab in the bottom panel
+      // (M6 restructure). Auto-opens the panel and makes the new shell
+      // the active sub-tab. Useful when the user wants a shell without
+      // having to focus the bottom panel first.
       if (e.key.toLowerCase() === "t" && mod && e.shiftKey && !e.altKey) {
         e.preventDefault();
         e.stopPropagation();
-        newTab();
+        newShellTab();
         return;
       }
-      // M6 P1: Cmd+T → new shell tab. Matches Terminal.app, iTerm2,
-      // GNOME Terminal, Windows Terminal. Existing chat behavior moves
-      // to Cmd+Shift+T.
+      // Cmd+T — focus-aware (M6 restructure):
+      //   - focus inside the bottom terminal panel → new shell sub-tab
+      //   - focus elsewhere → new agent tab (the pre-P1 default)
+      // Matches the user's mental model: "new tab" of whatever surface
+      // I'm currently using. Browsers, VS Code, and iTerm all key off
+      // the focused surface for "new"-style shortcuts.
       if (e.key.toLowerCase() === "t" && mod && !e.shiftKey && !e.altKey) {
         e.preventDefault();
         e.stopPropagation();
-        newShellTab();
+        if (isFocusInTerminalPanel()) {
+          newShellTab();
+        } else {
+          newTab();
+        }
         return;
       }
       // Cmd+] → next tab; Cmd+[ → previous. Matches macOS browser
@@ -4432,6 +4486,29 @@ export default function App() {
       // `vertical-tab-rail`). Matching by type keeps the contract layout-
       // agnostic so a new layout's tabs work without touching App.tsx.
       const tabType = component.type;
+
+      // Terminal panel sub-tab events (M6 restructure). The panel
+      // hosts the read-only agent-bash sub-tab plus every shell as a
+      // separate sub-tab; selection / close / new-shell live here.
+      if (component.type === "terminal-panel") {
+        const sel = data as { subTabId?: string } | undefined;
+        if (eventType === "select-sub-tab" && sel?.subTabId) {
+          setActiveSubTab(sel.subTabId);
+          return true;
+        }
+        if (eventType === "close-sub-tab" && sel?.subTabId) {
+          // Closing a shell sub-tab is just closing its underlying tab.
+          // The agent-bash sub-tab can't be closed (no X button rendered).
+          if (sel.subTabId !== "agent-bash") {
+            closeTab(sel.subTabId);
+          }
+          return true;
+        }
+        if (eventType === "new-shell-sub-tab") {
+          newShellTab();
+          return true;
+        }
+      }
 
       // Shell-canvas: badge click cycles share mode. Look up current
       // mode in the bound tab, advance via the cycle helper, persist

--- a/src/skills/default-layout/components.tsx
+++ b/src/skills/default-layout/components.tsx
@@ -1866,6 +1866,191 @@ interface TabStripItem {
   /** Pending follow-up count behind the active prompt. Adds a small
    *  numeric chip after the label when > 0. */
   queueCount?: number;
+  /** "agent" (chat session) or "shell" (interactive PTY). Shell tabs
+   *  no longer render in the top tab strip — they live in the bottom
+   *  terminal panel as sub-tabs alongside the read-only agent-bash
+   *  view. The TabStrip composite filters them out so any layout that
+   *  binds `/tabs` to TabStrip drops shells automatically. */
+  kind?: "agent" | "shell";
+}
+
+// ---------------------------------------------------------------------------
+// TerminalPanel — tabbed bottom-of-screen terminal area (M6 restructure).
+//
+// Replaces the standalone Terminal composite in the workstation layout's
+// `terminal` cell. The panel hosts:
+//   - One always-present "Agent bash" sub-tab (read-only sink for the
+//     agent's bash-tool output — same content the old solo Terminal showed).
+//   - Zero or more user shell sub-tabs (interactive PTYs spawned via
+//     `Cmd+T` while focus is in the panel, or `Cmd+Shift+T` regardless).
+//
+// Active sub-tab is tracked at `/terminalPanel/activeSubId`, defaulting to
+// "agent-bash". Switching sub-tabs unmounts/remounts the inner xterm so
+// per-sub-tab scrollback isolation is automatic.
+// ---------------------------------------------------------------------------
+
+const AGENT_BASH_SUB_ID = "agent-bash";
+
+interface ShellSubTabItem {
+  id: string;
+  label: string;
+  shellState?: string;
+}
+
+export function TerminalPanel({
+  component,
+  state,
+  onEvent,
+}: BuiltinComponentProps) {
+  const props = component.props as {
+    visible?: BooleanValue;
+    fontSize?: NumberValue;
+  };
+  const visible = props.visible ? resolveBoolean(props.visible, state) : true;
+
+  // Pull shell sub-tabs out of the unified /tabs list. Shells live in
+  // /tabs (same as agent tabs) but render in this panel rather than the
+  // top tab strip — the TabStrip composite filters them out.
+  const tabsRef = state["tabs"];
+  const shellTabs: ShellSubTabItem[] = useMemo(() => {
+    const tabs = (tabsRef as
+      | Array<{ id: string; kind?: string; label: string; shell?: { shellState?: string } }>
+      | undefined) ?? [];
+    return tabs
+      .filter((t) => t.kind === "shell")
+      .map((t) => ({
+        id: t.id,
+        label: t.label,
+        shellState: t.shell?.shellState,
+      }));
+  }, [tabsRef]);
+
+  // Active sub-tab id. Held under /terminalPanel/activeSubId so it
+  // persists across renders and can be addressed via $ref. Defaults to
+  // "agent-bash" — the read-only view is always present.
+  const panelState =
+    (state["terminalPanel"] as { activeSubId?: string } | undefined) ?? {};
+  const requestedActiveId = panelState.activeSubId ?? AGENT_BASH_SUB_ID;
+  // Clamp to a valid sub-tab id. If the requested id no longer exists
+  // (e.g. user closed a shell that was active), fall back to agent-bash
+  // so we always render something.
+  const activeSubId = useMemo(() => {
+    if (requestedActiveId === AGENT_BASH_SUB_ID) return AGENT_BASH_SUB_ID;
+    if (shellTabs.some((s) => s.id === requestedActiveId))
+      return requestedActiveId;
+    return AGENT_BASH_SUB_ID;
+  }, [requestedActiveId, shellTabs]);
+
+  if (!visible) return null;
+
+  return (
+    <div className="ae-terminal-panel" style={{ gridArea: "terminal" }}>
+      <div className="ae-terminal-panel-tabs" role="tablist">
+        <SubTabPill
+          id={AGENT_BASH_SUB_ID}
+          label="Agent bash"
+          hint="read-only"
+          active={activeSubId === AGENT_BASH_SUB_ID}
+          onSelect={() =>
+            onEvent("select-sub-tab", { subTabId: AGENT_BASH_SUB_ID })
+          }
+        />
+        {shellTabs.map((s, i) => (
+          <SubTabPill
+            key={s.id}
+            id={s.id}
+            label={s.label || `Shell ${i + 1}`}
+            hint={s.shellState === "exited" ? "exited" : undefined}
+            active={activeSubId === s.id}
+            closable
+            onSelect={() => onEvent("select-sub-tab", { subTabId: s.id })}
+            onClose={() => onEvent("close-sub-tab", { subTabId: s.id })}
+          />
+        ))}
+        <button
+          type="button"
+          className="ae-terminal-panel-new"
+          aria-label="New shell"
+          title="New shell tab (⌘T while focused here)"
+          onClick={() => onEvent("new-shell-sub-tab")}
+        >
+          +
+        </button>
+      </div>
+      <div className="ae-terminal-panel-body">
+        {activeSubId === AGENT_BASH_SUB_ID ? (
+          <Terminal
+            component={{
+              id: `${component.id}-agent-bash`,
+              type: "terminal",
+              props: {
+                fontSize: props.fontSize ?? 13,
+                subscribeToBash: true,
+                readOnly: true,
+              },
+            }}
+            state={state}
+            onEvent={onEvent}
+          />
+        ) : (
+          <ShellCanvas
+            component={{
+              id: `${component.id}-shell-${activeSubId}`,
+              type: "shell-canvas",
+              props: {
+                tabId: activeSubId,
+                fontSize: props.fontSize ?? 13,
+              },
+            }}
+            state={state}
+            onEvent={onEvent}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SubTabPill(props: {
+  id: string;
+  label: string;
+  hint?: string;
+  active: boolean;
+  closable?: boolean;
+  onSelect: () => void;
+  onClose?: () => void;
+}) {
+  const { label, hint, active, closable, onSelect, onClose } = props;
+  return (
+    <div
+      role="tab"
+      aria-selected={active}
+      className={
+        active ? "ae-sub-tab ae-sub-tab-active" : "ae-sub-tab"
+      }
+      onMouseDown={(e) => {
+        if ((e.target as HTMLElement).closest(".ae-sub-tab-close")) return;
+        e.preventDefault();
+        onSelect();
+      }}
+    >
+      <span className="ae-sub-tab-label">{label}</span>
+      {hint && <span className="ae-sub-tab-hint">{hint}</span>}
+      {closable && (
+        <button
+          type="button"
+          className="ae-sub-tab-close"
+          aria-label={`Close ${label}`}
+          onClick={(e) => {
+            e.stopPropagation();
+            onClose?.();
+          }}
+        >
+          ×
+        </button>
+      )}
+    </div>
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -2108,13 +2293,18 @@ export function TabStrip({ component, state, onEvent }: BuiltinComponentProps) {
   };
   const tabs: TabStripItem[] = useMemo(() => {
     if (!props.tabs) return [];
-    if (Array.isArray(props.tabs)) return props.tabs;
-    const ref = props.tabs as { $ref?: string };
-    if (typeof ref.$ref === "string") {
-      const v = resolvePointer(state, ref.$ref);
-      if (Array.isArray(v)) return v as TabStripItem[];
-    }
-    return [];
+    const raw: TabStripItem[] = Array.isArray(props.tabs)
+      ? props.tabs
+      : (() => {
+          const ref = props.tabs as { $ref?: string };
+          if (typeof ref.$ref !== "string") return [];
+          const v = resolvePointer(state, ref.$ref);
+          return Array.isArray(v) ? (v as TabStripItem[]) : [];
+        })();
+    // Filter out shell tabs — they render in the bottom terminal panel
+    // as sub-tabs (M6 restructure). Records without `kind` predate the
+    // discriminator and are treated as agent.
+    return raw.filter((t) => t.kind !== "shell");
   }, [props.tabs, state]);
   const activeId = props.activeId ? resolveString(props.activeId, state) : "";
 

--- a/src/skills/default-layout/index.ts
+++ b/src/skills/default-layout/index.ts
@@ -18,6 +18,7 @@ import {
   StatusBar,
   TabStrip,
   Terminal,
+  TerminalPanel,
   ToolCard,
 } from "./components";
 import {
@@ -70,6 +71,10 @@ export const defaultLayoutSkill: A2UISkill = {
     // equivalent mode flag) so it appears only when the active tab is a
     // shell tab.
     "shell-canvas": ShellCanvas,
+    // M6 restructure: tabbed bottom panel. Hosts the read-only
+    // agent-bash sub-tab + every user shell as a separate sub-tab.
+    // Replaces the standalone `terminal` cell in workstation.
+    "terminal-panel": TerminalPanel,
     // M6 P4: tool-call card with live elapsed-time clock + long-running
     // amber warning at 30s. Bridge emits this for tool execution events
     // (replacing the plain `card` primitive in toolCardPayload).

--- a/src/skills/default-layout/workstation.a2ui.json
+++ b/src/skills/default-layout/workstation.a2ui.json
@@ -116,16 +116,6 @@
           }
         },
         {
-          "id": "shell-canvas",
-          "type": "shell-canvas",
-          "props": {
-            "area": "canvas",
-            "visible": { "$ref": "/shellTabActive" },
-            "tabId": { "$ref": "/activeTabId" },
-            "fontSize": 13
-          }
-        },
-        {
           "id": "empty-state",
           "type": "empty-state",
           "props": {
@@ -146,14 +136,12 @@
           }
         },
         {
-          "id": "terminal",
-          "type": "terminal",
+          "id": "terminal-panel",
+          "type": "terminal-panel",
           "props": {
             "area": "terminal",
             "visible": { "$ref": "/terminal/open" },
-            "fontSize": 13,
-            "subscribeToBash": true,
-            "readOnly": true
+            "fontSize": 13
           }
         },
         {
@@ -228,6 +216,9 @@
     "project": null,
     "terminal": {
       "open": false
+    },
+    "terminalPanel": {
+      "activeSubId": "agent-bash"
     },
     "slashCommands": []
   }

--- a/src/styles.css
+++ b/src/styles.css
@@ -2903,6 +2903,100 @@ body.ae-resizing-sidebar * {
 }
 
 /* =============================================================================
+   Terminal panel — tabbed bottom-of-screen surface (M6 restructure).
+   Hosts the read-only Agent bash sub-tab plus every user shell as a
+   separate sub-tab pill. The active sub-tab fills the body below.
+   ============================================================================= */
+
+.ae-terminal-panel {
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-elev);
+  border-top: 1px solid var(--border);
+  min-height: 0;
+  height: 240px;
+}
+.ae-terminal-panel-tabs {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: stretch;
+  gap: 2px;
+  padding: 0 8px;
+  background: var(--bg);
+  border-bottom: 1px solid var(--border);
+  overflow-x: auto;
+  scrollbar-width: thin;
+}
+.ae-sub-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  font-size: var(--chrome-text-compact);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  color: var(--text-dim);
+  border: 1px solid transparent;
+  border-bottom: none;
+  border-radius: 6px 6px 0 0;
+  cursor: pointer;
+  white-space: nowrap;
+  user-select: none;
+  margin-top: 2px;
+}
+.ae-sub-tab:hover {
+  background: color-mix(in oklab, var(--accent) 8%, transparent);
+}
+.ae-sub-tab-active {
+  background: var(--bg-elev);
+  border-color: var(--border);
+  color: var(--text);
+}
+.ae-sub-tab-label {
+  flex: 0 0 auto;
+}
+.ae-sub-tab-hint {
+  font-size: var(--chrome-text-muted);
+  color: var(--text-dim);
+  font-style: italic;
+}
+.ae-sub-tab-close {
+  background: transparent;
+  border: 0;
+  color: var(--text-dim);
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 2px;
+  margin-left: 2px;
+}
+.ae-sub-tab-close:hover {
+  color: var(--text);
+}
+.ae-terminal-panel-new {
+  background: transparent;
+  border: 0;
+  color: var(--text-dim);
+  font-size: 1rem;
+  cursor: pointer;
+  padding: 0 10px;
+  align-self: stretch;
+}
+.ae-terminal-panel-new:hover {
+  color: var(--accent);
+  background: color-mix(in oklab, var(--accent) 8%, transparent);
+}
+.ae-terminal-panel-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+.ae-terminal-panel-body > * {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+/* =============================================================================
    Tool card — agent tool-call surface with live elapsed-time clock.
    Replaces the plain `card` primitive for tool execution events. Color
    shifts with state: idle = dim, running = accent, ≥30 s long-running =


### PR DESCRIPTION
**Restructure addressing user feedback that the dual-terminal model felt odd.**

## New mental model

- **Top tab strip** = agent tabs only (chat sessions).
- **Bottom terminal panel** = tabbed area with \`[Agent Bash · read-only]\` + each user shell as its own sub-tab + a \`+\` for spawning new shells.
- **\`Cmd+T\`** is focus-aware:
  - Focus inside the panel → new shell sub-tab
  - Focus elsewhere → new agent tab (restoring pre-M6-P1 behavior)
- **\`Cmd+Shift+T\`** always spawns a new shell sub-tab and auto-opens the panel.

## Why

The old model:
- \`Cmd+T\` always spawned a shell tab in the top strip
- The bottom panel was a separate \"Agent bash · read-only\" terminal
- Both used xterm; the only visual difference was the header label
- Users saw two terminals and didn't know which was which

The new model collapses that into one tabbed surface (familiar to anyone who's used VS Code or iTerm). The top strip is exclusively for agent conversations.

## Implementation

- New \`TerminalPanel\` composite renders the sub-tab strip + delegates the active body to either the existing read-only Terminal (for agent-bash) or the existing ShellCanvas (for shell sub-tabs).
- \`TabStrip\` filters out \`kind === \"shell\"\` so any layout binding \`/tabs\` to the top strip drops shells automatically.
- \`workstation.a2ui.json\`: replaces the standalone \`terminal\` cell with \`terminal-panel\`; removes the dedicated shell-canvas grid cell.
- \`App.tsx\`: \`setActiveSubTab\`, \`isFocusInTerminalPanel\`, sub-tab event routing (\`select-sub-tab\` / \`close-sub-tab\` / \`new-shell-sub-tab\`). \`newShellTab\` no longer promotes to \`/activeTabId\`; it makes the new shell the active *sub-tab* and opens the panel. \`nextTab\` and \`jumpToTab\` filter to agent tabs.
- Boot state seeds \`/terminalPanel/activeSubId = \"agent-bash\"\`.

## Out of scope

- Variation layouts (editorial / command-deck / live-layout) still use the old solo Terminal — they don't host this restructure.
- Migration notification: shells are still in \`/tabs\` (just rendered elsewhere), so existing persisted shell tabs migrate silently.

## Test plan

- [x] tsc / eslint / vitest 150 / cargo clippy / cargo test 48 all green
- [ ] Live UAT: open agent tab, hit \`Cmd+T\` (focus in chat) → new agent tab; hit \`Cmd+T\` with focus in panel → new shell sub-tab; hit \`Cmd+Shift+T\` → shell sub-tab + panel opens
- [ ] codex peer review