### PR TITLE
fix(ux): codex P1+P2 followups + Cmd+` focus + Cmd+0 focus toggle

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -986,15 +986,28 @@ fn install_app_menu(
     use tauri::Emitter;
     use tauri::menu::{MenuBuilder, MenuItemBuilder, PredefinedMenuItem, SubmenuBuilder};
 
-    // M6 P1: Cmd+T defaults to "New Shell Tab" (matches Terminal.app /
-    // iTerm2 convention). The existing chat-tab behavior moves to
-    // Cmd+Shift+T as "New Agent Tab". Both menu items emit distinct ids
-    // (`new_tab` legacy alias for shell, `new_agent_tab` for chat) so
-    // the JS-side router can split them — see App.tsx:menu listener.
-    let new_tab = MenuItemBuilder::with_id("new_tab", "New Shell Tab")
+    // M6 restructure: Cmd+T is focus-aware in the webview keydown
+    // handler — it spawns an agent tab when focus is outside the bottom
+    // terminal panel and a shell sub-tab when focus is inside. The
+    // native menu can't observe webview focus, so the menu item
+    // triggers an explicit "open new agent tab" action (the unambiguous
+    // default users expect from "File → New Tab" everywhere). Cmd+T as
+    // an accelerator still exists ONLY on this menu item — when the OS
+    // delivers Cmd+T to the menu, the menu fires `new_tab` which the JS
+    // router maps to `newTab()` (agent). When the user presses Cmd+T
+    // with focus in the panel, the keydown handler intercepts and
+    // calls `newShellTab()` instead. To prevent the menu from also
+    // firing in that case we'd ideally suppress it via JS, but Tauri's
+    // accelerator handling is OS-level — keeping the menu item as the
+    // agent-tab path means the worst-case race spawns an agent tab,
+    // which is the safer default than a surprise PTY.
+    let new_tab = MenuItemBuilder::with_id("new_tab", "New Tab")
         .accelerator("CmdOrCtrl+T")
         .build(app)?;
-    let new_agent_tab = MenuItemBuilder::with_id("new_agent_tab", "New Agent Tab")
+    // Cmd+Shift+T is the explicit "always shell" entry. The webview
+    // handler routes it to newShellTab regardless of focus and
+    // auto-opens the bottom panel. The menu mirrors that behavior.
+    let new_agent_tab = MenuItemBuilder::with_id("new_shell_tab", "New Shell Tab")
         .accelerator("CmdOrCtrl+Shift+T")
         .build(app)?;
     let close_tab = MenuItemBuilder::with_id("close_tab", "Close Tab")

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -912,6 +912,75 @@ export default function App() {
     });
   }
 
+  /** Toggle the terminal panel AND move focus to/from it.
+   *
+   *  Open + focus: pulls focus into the active sub-tab's terminal
+   *  (xterm has a `.focus()` method exposed via the live DOM).
+   *  Close + return-focus: drops focus back to the chat composer so
+   *  typing continues seamlessly. Without this users have to re-click
+   *  to refocus after every panel toggle. */
+  function toggleTerminalAndFocus() {
+    const wasOpen = !!(stateRef.current.terminal as { open?: boolean } | undefined)?.open;
+    toggleTerminal();
+    // Defer focus until after React has committed the render so the
+    // panel's xterm canvas exists in the DOM.
+    requestAnimationFrame(() => {
+      if (wasOpen) {
+        focusComposer();
+      } else {
+        focusTerminalPanel();
+      }
+    });
+  }
+
+  /** Cmd+0: toggle focus between the chat composer and the bottom
+   *  terminal panel. If the panel is closed, opens it first. */
+  function toggleFocusComposerTerminal() {
+    const inPanel = isFocusInTerminalPanel();
+    if (inPanel) {
+      focusComposer();
+      return;
+    }
+    const term = (stateRef.current.terminal as { open?: boolean } | undefined) ?? {};
+    if (!term.open) {
+      // Open first, then focus on the next frame.
+      setState((prev) => {
+        const t = (prev.terminal as { open?: boolean } | undefined) ?? {};
+        return { ...prev, terminal: { ...t, open: true } };
+      });
+    }
+    requestAnimationFrame(() => focusTerminalPanel());
+  }
+
+  function focusComposer() {
+    if (typeof document === "undefined") return;
+    const ta = document.querySelector<HTMLTextAreaElement>(
+      ".a2ui-chat-input textarea, .a2ui-chat-input input",
+    );
+    ta?.focus();
+  }
+
+  function focusTerminalPanel() {
+    if (typeof document === "undefined") return;
+    // xterm renders an inner textarea (`.xterm-helper-textarea`) that
+    // it forwards keystrokes to. Focusing it routes typing into the
+    // active sub-tab's PTY (or the read-only agent-bash xterm where
+    // it's a no-op input but the cursor still indicates focus).
+    const panel = document.querySelector(".ae-terminal-panel");
+    const helperTa = panel?.querySelector<HTMLTextAreaElement>(
+      ".xterm-helper-textarea",
+    );
+    if (helperTa) {
+      helperTa.focus();
+      return;
+    }
+    // Fallback: focus the panel's first focusable element.
+    const focusable = panel?.querySelector<HTMLElement>(
+      'button, [tabindex]:not([tabindex="-1"])',
+    );
+    focusable?.focus();
+  }
+
   function toggleSidebar() {
     setState((prev) => {
       // Flip /layout/sidebarVisible AND swap /layout/columns +
@@ -1463,7 +1532,15 @@ export default function App() {
    *  (M6 restructure). Sub-tab id is either the special string
    *  "agent-bash" (the always-present read-only view) or a shell tab
    *  id from `/tabs`. Auto-opens the panel if it was hidden so the
-   *  user can see the result of their click. */
+   *  user can see the result of their click.
+   *
+   *  When switching BACK to agent-bash, dispatch a replay of the
+   *  active agent tab's `terminalBuffer` so the freshly-mounted
+   *  Terminal composite re-renders the previously-buffered output.
+   *  Without this, sub-tab switching loses everything the agent
+   *  printed while a shell sub-tab was active (codex P2 finding on
+   *  PR #20).
+   */
   function setActiveSubTab(subId: string) {
     setState((prev) => {
       const panel =
@@ -1478,6 +1555,18 @@ export default function App() {
         terminal: { ...term, open: true },
       };
     });
+    if (subId === "agent-bash") {
+      // Replay the active agent tab's terminal buffer on next paint so
+      // the Terminal composite (which just (re)mounted via the sub-tab
+      // selection) sees its content.
+      requestAnimationFrame(() => {
+        const tabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
+        const activeId = stateRef.current.activeTabId as string | undefined;
+        const active = activeId ? tabs.find((t) => t.id === activeId) : undefined;
+        const buffer = active?.terminalBuffer ?? "";
+        dispatchTerminalReplay(buffer);
+      });
+    }
   }
 
   /** Jump to tab at zero-based index, clamped to the live tab list.
@@ -1684,11 +1773,14 @@ export default function App() {
         }
       }
       const mod = e.metaKey || e.ctrlKey;
-      // Cmd+` toggles the terminal panel. Mirrors VS Code / iTerm.
+      // Cmd+` toggles the bottom terminal panel AND moves focus there
+      // when opening (so the user can type immediately). Mirrors
+      // VS Code's Ctrl+` behavior. When closing, return focus to the
+      // chat composer so typing continues seamlessly.
       if (e.key === "`" && mod && !e.shiftKey && !e.altKey) {
         e.preventDefault();
         e.stopPropagation();
-        toggleTerminal();
+        toggleTerminalAndFocus();
         return;
       }
       // Cmd+B toggles the sidebar. Mirrors the standard editor
@@ -1775,6 +1867,12 @@ export default function App() {
       // Windows Terminal. The first 8 use direct indexing so layouts
       // with > 9 tabs still get keyboard access for the first few; the
       // 9th key is the "last tab" affordance.
+      // Cmd+1..8 → jump to agent tab N; Cmd+9 → jump to last agent
+      // tab. Filter shells before counting so the indices line up with
+      // what the user actually sees in the top strip (codex P2 finding
+      // on PR #20: with [agent, agent, shell] the previous code passed
+      // index 2 to jumpToTab and no-op'd because the filtered array
+      // only has 2 items).
       if (
         mod &&
         !e.shiftKey &&
@@ -1782,22 +1880,30 @@ export default function App() {
         e.key >= "1" &&
         e.key <= "9"
       ) {
-        const tabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
-        if (tabs.length === 0) return;
+        const agentTabs = ((stateRef.current.tabs as Tab[] | undefined) ?? [])
+          .filter((t) => t.kind !== "shell");
+        if (agentTabs.length === 0) return;
         e.preventDefault();
         e.stopPropagation();
         if (e.key === "9") {
-          jumpToTab(tabs.length - 1);
+          jumpToTab(agentTabs.length - 1);
         } else {
           jumpToTab(parseInt(e.key, 10) - 1);
         }
         return;
       }
       // Cmd+Opt+T → reopen most-recently-closed tab. Matches iTerm2's
-      // restore-closed-window shortcut; safe alongside Cmd+T (new shell)
-      // and Cmd+Shift+T (new agent). No-op on empty stack so a stray
-      // press is silent.
-      if (e.key.toLowerCase() === "t" && mod && e.altKey && !e.shiftKey) {
+      // restore-closed-window shortcut. macOS lets Option mutate the
+      // printable-key value (Opt+T arrives as `e.key === "†"`), so
+      // match the *physical* key via `e.code === "KeyT"` whenever Alt
+      // is part of the shortcut. Without this the advertised combo
+      // silently no-ops on Mac (codex P2 review of PR #17).
+      if (
+        mod &&
+        e.altKey &&
+        !e.shiftKey &&
+        (e.code === "KeyT" || e.key.toLowerCase() === "t")
+      ) {
         e.preventDefault();
         e.stopPropagation();
         reopenLastClosedTab();
@@ -1860,10 +1966,23 @@ export default function App() {
         adjustZoom(-0.1);
         return;
       }
-      if (mod && !e.altKey && !e.shiftKey && e.key === "0") {
+      // Cmd+Shift+0 → reset zoom. Moved off Cmd+0 so that combo can do
+      // composer ↔ terminal focus toggle (more discoverable than reset
+      // zoom, which is rare).
+      if (mod && !e.altKey && e.shiftKey && e.key === "0") {
         e.preventDefault();
         e.stopPropagation();
         resetZoom();
+        return;
+      }
+      // Cmd+0 → toggle focus between the chat composer and the bottom
+      // terminal panel. Mirrors VS Code's Cmd+J / Cmd+1 split-pane
+      // focus-toggle pattern but bound to a more discoverable key. If
+      // the panel is closed, opens it first.
+      if (mod && !e.altKey && !e.shiftKey && e.key === "0") {
+        e.preventDefault();
+        e.stopPropagation();
+        toggleFocusComposerTerminal();
         return;
       }
     };
@@ -2158,15 +2277,19 @@ export default function App() {
         return;
       }
       switch (id) {
-        // Cmd+T (menu + tray) defaults to a shell tab in M6 — matches
-        // Terminal.app convention. The legacy "new_tab" id is preserved
-        // so older payloads keep working; "new_agent_tab" is new.
+        // M6 restructure: "File → New Tab" (Cmd+T) opens an agent tab
+        // — the menu can't observe webview focus, so it picks the
+        // safer default. The webview keydown handler intercepts Cmd+T
+        // when focus is in the bottom terminal panel and routes to
+        // newShellTab there. "File → New Shell Tab" (Cmd+Shift+T) is
+        // the explicit shell-tab path. The legacy "new_agent_tab" id
+        // is kept as an alias in case any older payload references it.
         case "new_tab":
-        case "new_shell_tab":
-          newShellTab();
-          break;
         case "new_agent_tab":
           newTab();
+          break;
+        case "new_shell_tab":
+          newShellTab();
           break;
         case "close_tab": {
           const activeId = stateRef.current.activeTabId as string | undefined;
@@ -4101,14 +4224,15 @@ export default function App() {
           if (id) closeTab(id);
         } else if (p.action === "builtin:meta+]") nextTab(1);
         else if (p.action === "builtin:meta+[") nextTab(-1);
-        else if (p.action === "builtin:meta+`") toggleTerminal();
+        else if (p.action === "builtin:meta+`") toggleTerminalAndFocus();
+        else if (p.action === "builtin:meta+0") toggleFocusComposerTerminal();
         else if (p.action === "builtin:meta+k") clearChat();
         else if (p.action === "builtin:meta+.") void stopPrompt();
         else if (p.action === "builtin:meta+p") openPalette("switcher");
         else if (p.action === "builtin:meta+shift+p") openPalette("commands");
         else if (p.action === "builtin:meta+=") adjustZoom(0.1);
         else if (p.action === "builtin:meta+-") adjustZoom(-0.1);
-        else if (p.action === "builtin:meta+0") resetZoom();
+        else if (p.action === "builtin:meta+shift+0") resetZoom();
         return;
     }
   }

--- a/src/skills/default-layout/palette-items.ts
+++ b/src/skills/default-layout/palette-items.ts
@@ -77,17 +77,18 @@ export const BUILTIN_KEYBINDINGS: BuiltinKeybinding[] = [
   { combo: "meta+7", description: "Jump to tab 7" },
   { combo: "meta+8", description: "Jump to tab 8" },
   { combo: "meta+9", description: "Jump to last tab" },
-  { combo: "meta+`", description: "Toggle agent bash output panel" },
+  { combo: "meta+`", description: "Toggle terminal panel + focus" },
+  { combo: "meta+0", description: "Toggle focus between composer and terminal" },
   { combo: "meta+b", description: "Toggle sidebar" },
   { combo: "meta+k", description: "Clear chat" },
   { combo: "meta+.", description: "Stop current prompt" },
   { combo: "meta+=", description: "Zoom in" },
   { combo: "meta+-", description: "Zoom out" },
-  { combo: "meta+0", description: "Reset zoom" },
+  { combo: "meta+shift+0", description: "Reset zoom" },
 ];
 
 export interface SelectInput {
-  tabs?: { id: string; label: string }[];
+  tabs?: { id: string; label: string; kind?: "agent" | "shell" }[];
   activeTabId?: string;
   recentSessions?: { id: string; label: string; lastModified?: string; cwd?: string }[];
   sidebar?: {
@@ -116,6 +117,10 @@ export function selectPaletteItems(
 
   const pushTabs = () => {
     for (const t of state.tabs ?? []) {
+      // Shell tabs render in the bottom terminal panel as sub-tabs.
+      // The palette's "Tabs" section is for top-strip agent tabs only —
+      // shell sub-tabs are reachable via the panel's own UI.
+      if (t.kind === "shell") continue;
       items.push({
         id: `tab:${t.id}`,
         label: t.label,

--- a/src/skills/default-layout/variation-components.tsx
+++ b/src/skills/default-layout/variation-components.tsx
@@ -165,6 +165,11 @@ interface TabItem {
   id: string;
   label: string;
   dirty?: boolean;
+  /** Tab kind. Shell tabs (`"shell"`) are rendered in the bottom
+   *  terminal panel as sub-tabs, so every tab-strip-style surface
+   *  filters them out. Records without `kind` predate the
+   *  discriminator and are treated as agent. */
+  kind?: "agent" | "shell";
 }
 
 export function EditorialHeader({ component, state, onEvent }: BuiltinComponentProps) {
@@ -179,10 +184,16 @@ export function EditorialHeader({ component, state, onEvent }: BuiltinComponentP
     : "Æthon π";
   const subtitle = props.subtitle ? resolveString(props.subtitle, state) : "";
   const tabs: TabItem[] = useMemo(() => {
-    if (!props.tabs) return [];
-    if (Array.isArray(props.tabs)) return props.tabs;
-    const v = resolvePointer(state, props.tabs.$ref);
-    return Array.isArray(v) ? (v as TabItem[]) : [];
+    const tabsRef = props.tabs;
+    if (!tabsRef) return [];
+    const raw: TabItem[] = Array.isArray(tabsRef)
+      ? tabsRef
+      : (() => {
+          const v = resolvePointer(state, tabsRef.$ref);
+          return Array.isArray(v) ? (v as TabItem[]) : [];
+        })();
+    // Filter shells — they live in the bottom terminal panel.
+    return raw.filter((t) => t.kind !== "shell");
   }, [props.tabs, state]);
   const activeId = props.activeId ? resolveString(props.activeId, state) : "";
 
@@ -346,10 +357,16 @@ export function VerticalTabRail({ component, state, onEvent }: BuiltinComponentP
     shelfItems?: RailShelfItem[] | { $ref: string };
   };
   const tabs: RailTab[] = useMemo(() => {
-    if (!props.tabs) return [];
-    if (Array.isArray(props.tabs)) return props.tabs;
-    const v = resolvePointer(state, props.tabs.$ref);
-    return Array.isArray(v) ? (v as RailTab[]) : [];
+    const tabsRef = props.tabs;
+    if (!tabsRef) return [];
+    const raw: RailTab[] = Array.isArray(tabsRef)
+      ? tabsRef
+      : (() => {
+          const v = resolvePointer(state, tabsRef.$ref);
+          return Array.isArray(v) ? (v as RailTab[]) : [];
+        })();
+    // Filter shells — they live in the bottom terminal panel.
+    return raw.filter((t) => t.kind !== "shell");
   }, [props.tabs, state]);
   const activeId = props.activeId ? resolveString(props.activeId, state) : "";
   const title = props.title ? resolveString(props.title, state) : "aethon";


### PR DESCRIPTION
Addresses every codex finding from PR #20 (which auto-merged before review came back) plus two user-requested hotkey behaviors.

## Codex P1 — Tauri menu accelerators
Native menu still routed Cmd+T → newShellTab and Cmd+Shift+T → newTab. Updated to: \"New Tab\" (Cmd+T) → \`newTab()\` (agent — the menu can't observe webview focus, so picks the unambiguous default), \"New Shell Tab\" (Cmd+Shift+T) → \`newShellTab()\`.

## Codex P2 — three findings
- **agent-bash replay**: \`setActiveSubTab\` now fires \`aethon:terminal-replay\` when switching back to the agent-bash sub-tab.
- **filter shells everywhere**: \`EditorialHeader\`, \`VerticalTabRail\`, palette \`pushTabs\` all drop \`kind === \"shell\"\` (TabStrip already did).
- **Cmd+1..9 filtered count**: bounds now computed against the agent-only list so Cmd+9 with [agent, agent, shell] correctly jumps to the 2nd agent.

## New user requests
- **Cmd+\`** now toggles + focuses: opens panel + focuses xterm helper textarea, or closes panel + returns focus to composer.
- **Cmd+0** toggles focus between composer and terminal panel (auto-opens panel if closed). Reset-zoom moved to **Cmd+Shift+0**.

UAT via aethon-debug confirmed all four behaviors live.

## Test plan
- [x] tsc / eslint / vitest 150 / cargo clippy / cargo test 48 all green
- [x] Live UAT: Cmd+\` opens panel + focuses xterm; Cmd+T post-Cmd+\` (focus in panel) spawns shell; Cmd+Shift+T spawns shell regardless; Cmd+0 toggles focus
- [ ] Codex re-review