### PR TITLE
feat(p5): bridge crash recovery — auto-restart + frontend notice

### DIFF
--- a/src-tauri/src/helpers.rs
+++ b/src-tauri/src/helpers.rs
@@ -57,6 +57,10 @@ pub struct ShellConfig {
     /// "read-write", "read-write-trusted". Anything else falls back to
     /// "private" so a typo can't accidentally widen exposure.
     pub default_share_mode: Option<String>,
+    /// When the bun bridge child crashes unexpectedly, automatically
+    /// respawn it. Default `true`. Set `false` to surface the crash
+    /// notice without auto-restart (useful when debugging the bridge).
+    pub auto_restart_agent: Option<bool>,
 }
 
 #[derive(Default, Deserialize)]
@@ -115,6 +119,7 @@ pub fn parse_config_toml(input: &str) -> serde_json::Value {
         },
         "shell": {
             "defaultShareMode": default_share_mode,
+            "autoRestartAgent": cfg.shell.auto_restart_agent.unwrap_or(true),
         },
     })
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,7 +1,9 @@
+use std::collections::VecDeque;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
-use std::sync::{Mutex, OnceLock};
+use std::sync::atomic::AtomicBool;
+use std::sync::{Arc, Mutex, OnceLock};
 
 use serde::Deserialize;
 use tauri::{AppHandle, Emitter, Manager, State};
@@ -258,6 +260,18 @@ async fn pick_project_directory(app: AppHandle) -> Result<Option<String>, String
 
 struct AgentProcess(Mutex<Option<Child>>);
 
+/// Shared atomic flag set by the file-watcher debounce worker just
+/// before it kills the bun child for a hot-reload. The stdout reader
+/// checks this on EOF: if true, the kill was intentional (`agent-reloaded`
+/// was already emitted) — reset and stay silent. If false, the child
+/// died unexpectedly and we emit `agent-crashed` so the frontend can
+/// surface a notice + offer auto-restart.
+struct AgentReloadFlag(Arc<AtomicBool>);
+
+fn agent_reload_in_progress(app: &AppHandle) -> Arc<AtomicBool> {
+    Arc::clone(&app.state::<AgentReloadFlag>().0)
+}
+
 /// Find the project root (the directory containing `agent/main.ts`). Tauri
 /// launches the dev binary with cwd set to `src-tauri/`, but our agent script
 /// lives one level up, so a naive relative path resolves to the wrong place.
@@ -475,8 +489,17 @@ fn ensure_agent_spawned(guard: &mut Option<Child>, app: &AppHandle) -> Result<()
     let pid = child.id();
     eprintln!("[agent] spawned pid={pid}");
 
+    // Tail-buffer of recent stderr lines. When the bun child crashes
+    // unexpectedly, the supervisor emits an `agent-crashed` event with
+    // the last few lines so the frontend can surface a useful error
+    // notice rather than a generic "process exited" toast.
+    let stderr_tail: Arc<Mutex<VecDeque<String>>> = Arc::new(Mutex::new(VecDeque::with_capacity(32)));
+    const STDERR_TAIL_CAP: usize = 32;
+
     let stdout = child.stdout.take().ok_or("no stdout on spawned agent")?;
     let app_stdout = app.clone();
+    let reload_flag_stdout = agent_reload_in_progress(app);
+    let stderr_tail_for_supervisor = Arc::clone(&stderr_tail);
     std::thread::spawn(move || {
         let reader = BufReader::new(stdout);
         for line in reader.lines() {
@@ -488,6 +511,28 @@ fn ensure_agent_spawned(guard: &mut Option<Child>, app: &AppHandle) -> Result<()
             }
         }
         eprintln!("[agent] stdout reader for pid={pid} exited");
+        // Stdout reader exits when the child closes stdout — i.e. the
+        // child has died. Distinguish intentional kills (hot-reload via
+        // the file watcher, which sets `agent_reload_in_progress` first)
+        // from unexpected crashes. Reset the flag for the next cycle.
+        if reload_flag_stdout.swap(false, std::sync::atomic::Ordering::AcqRel) {
+            // Intentional kill — `agent-reloaded` was already emitted by
+            // the watcher; nothing more to do.
+            return;
+        }
+        // Unexpected exit. Surface a notice with stderr tail so the
+        // user sees something actionable.
+        let tail: Vec<String> = match stderr_tail_for_supervisor.lock() {
+            Ok(g) => g.iter().cloned().collect(),
+            Err(_) => Vec::new(),
+        };
+        let _ = app_stdout.emit(
+            "agent-crashed",
+            serde_json::json!({
+                "pid": pid,
+                "stderrTail": tail,
+            }),
+        );
     });
 
     // Capture stderr too — when the agent crashes inside Tauri's spawn env,
@@ -496,12 +541,19 @@ fn ensure_agent_spawned(guard: &mut Option<Child>, app: &AppHandle) -> Result<()
     // aethon-debug skill / status bar to surface.
     let stderr = child.stderr.take().ok_or("no stderr on spawned agent")?;
     let app_stderr = app.clone();
+    let stderr_tail_writer = Arc::clone(&stderr_tail);
     std::thread::spawn(move || {
         let reader = BufReader::new(stderr);
         for line in reader.lines() {
             match line {
                 Ok(text) => {
                     eprintln!("[agent stderr pid={pid}] {text}");
+                    if let Ok(mut g) = stderr_tail_writer.lock() {
+                        if g.len() >= STDERR_TAIL_CAP {
+                            g.pop_front();
+                        }
+                        g.push_back(text.clone());
+                    }
                     let _ = app_stderr.emit("agent-stderr", text);
                 }
                 Err(_) => break,
@@ -640,6 +692,11 @@ fn run_debounce_worker(rx: std::sync::mpsc::Receiver<DebounceMsg>, app: AppHandl
             && let Some(mut child) = guard.take()
         {
             let pid = child.id();
+            // Mark this kill as intentional so the stdout reader
+            // doesn't surface it as a crash. The reader resets the
+            // flag on EOF.
+            let reload_flag = agent_reload_in_progress(&app);
+            reload_flag.store(true, std::sync::atomic::Ordering::Release);
             let _ = child.kill();
             let _ = child.wait();
             let _ = app.emit("agent-reloaded", "");
@@ -1293,6 +1350,7 @@ pub fn run() {
     }
     let builder = builder
         .manage(AgentProcess(Mutex::new(None)))
+        .manage(AgentReloadFlag(Arc::new(AtomicBool::new(false))))
         .manage(shell::ShellRegistry::new())
         .invoke_handler(tauri::generate_handler![
             start_agent,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -570,6 +570,9 @@ export default function App() {
   // latest value without re-binding.
   const notifyOnCompletionRef = useRef<boolean>(true);
   const notifyMinDurationMsRef = useRef<number>(8 * 1000);
+  // P5: live config for [shell] auto_restart_agent. Read by the
+  // `agent-crashed` listener.
+  const autoRestartAgentRef = useRef<boolean>(true);
   // Built-in themes always available. CSS for these lives in styles.css —
   // we don't inject a <style> tag for them.
   const BUILTIN_THEMES: { id: string; label: string }[] = [
@@ -710,6 +713,8 @@ export default function App() {
       notifyOnCompletionRef.current = config.ui.notifyOnCompletion;
       notifyMinDurationMsRef.current =
         Math.max(0, config.ui.notifyMinDurationSeconds) * 1000;
+      // P5: [shell] auto_restart_agent.
+      autoRestartAgentRef.current = config.shell.autoRestartAgent;
 
       // [agent] model: when set, seed the picker default for this
       // session. Only applied if no per-session model has been saved
@@ -2231,6 +2236,63 @@ export default function App() {
       });
     });
 
+    // P5: bridge crash recovery. Rust supervisor emits this when the
+    // bun child exits unexpectedly (intentional hot-reload kills go
+    // through `agent-reloaded` instead). Clear all per-tab waiting
+    // state, surface a notice, and auto-restart per [shell] config.
+    const unlistenCrashed = listen<{ pid?: number; stderrTail?: string[] }>(
+      "agent-crashed",
+      (event) => {
+        const tail = event.payload?.stderrTail ?? [];
+        const lastLine = tail.length > 0 ? tail[tail.length - 1] : "no stderr";
+        activeResponseIdRef.current = null;
+        // Clear waiting/queue across every tab — pi sessions are gone.
+        setState((prev) => {
+          const tabs = ((prev.tabs as Tab[] | undefined) ?? []).map((t) => ({
+            ...t,
+            waiting: false,
+            queueCount: 0,
+          }));
+          return {
+            ...prev,
+            tabs,
+            waiting: false,
+            queueCount: 0,
+            status: "agent crashed",
+          };
+        });
+        const willAutoRestart = autoRestartAgentRef.current;
+        pushNotification({
+          id: "ae-agent-crashed",
+          title: "Agent process exited unexpectedly",
+          message: lastLine.slice(0, 200),
+          kind: "error",
+          // Keep visible until the user dismisses or restart succeeds —
+          // a transient toast would race a user who's away from the
+          // keyboard while a long agent turn died.
+          durationMs: null,
+          actions: willAutoRestart
+            ? [{ label: "Dismiss", action: "ae-agent-crashed:dismiss" }]
+            : [
+                { label: "Restart", action: "ae-agent-crashed:restart" },
+                { label: "Dismiss", action: "ae-agent-crashed:dismiss" },
+              ],
+        });
+        if (willAutoRestart) {
+          // Brief delay so the user actually sees the notice flash
+          // before the next request silently respawns. The next chat
+          // send will respawn anyway via ensure_agent_spawned, but
+          // priming here means the system-prompt + ready handshake
+          // happens up-front.
+          window.setTimeout(() => {
+            invoke("start_agent").catch(() => {
+              /* respawn deferred to next user action */
+            });
+          }, 500);
+        }
+      },
+    );
+
     // Mirror agent stderr into the chat as a system message — when the bridge
     // dies on startup this is the only signal we have.
     const unlistenStderr = listen<string>("agent-stderr", (event) => {
@@ -2362,6 +2424,7 @@ export default function App() {
     return () => {
       unlistenResponse.then((fn) => fn());
       unlistenReload.then((fn) => fn());
+      unlistenCrashed.then((fn) => fn());
       unlistenStderr.then((fn) => fn());
       unlistenMenu.then((fn) => fn());
       unlistenShellOutput.then((fn) => fn());
@@ -4468,6 +4531,21 @@ export default function App() {
         if (isShellWriteDismiss && id) {
           resolveShellWriteConsent(id, false);
           dismissNotification(id);
+          return true;
+        }
+        // P5: agent-crashed notification actions. Restart respawns
+        // the bridge; dismiss just closes the toast.
+        if (
+          eventType === "action" &&
+          typeof action === "string" &&
+          action.startsWith("ae-agent-crashed:")
+        ) {
+          if (action === "ae-agent-crashed:restart") {
+            invoke("start_agent").catch((err: unknown) => {
+              console.warn("agent restart failed:", err);
+            });
+          }
+          if (id) dismissNotification(id);
           return true;
         }
       }

--- a/src/config.ts
+++ b/src/config.ts
@@ -31,6 +31,9 @@ export interface AethonConfig {
      *  the agent sees nothing until the user explicitly opts in via the
      *  status-bar badge. Configurable via `[shell] default_share_mode`. */
     defaultShareMode: ShareMode;
+    /** Auto-respawn the bun bridge child on unexpected exit. Default
+     *  true; configurable via `[shell] auto_restart_agent`. */
+    autoRestartAgent: boolean;
   };
 }
 
@@ -43,7 +46,7 @@ const DEFAULTS: AethonConfig = {
     notifyMinDurationSeconds: 8,
   },
   agent: { model: null },
-  shell: { defaultShareMode: "private" },
+  shell: { defaultShareMode: "private", autoRestartAgent: true },
 };
 
 function hasTauri(): boolean {
@@ -87,6 +90,10 @@ export function getConfig(): Promise<AethonConfig> {
         },
         shell: {
           defaultShareMode: normalizeShareMode(obj?.shell?.defaultShareMode),
+          autoRestartAgent:
+            typeof obj?.shell?.autoRestartAgent === "boolean"
+              ? obj.shell.autoRestartAgent
+              : true,
         },
       };
     } catch (err) {


### PR DESCRIPTION
Detects bun bridge child crashes and surfaces a notice + auto-restart per config. Distinguishes intentional hot-reload kills (file-watcher sets a shared atomic flag) from unexpected exits.

## Changes
- **Rust**: \`AgentReloadFlag\` Tauri-managed state; stdout reader emits \`agent-crashed { pid, stderrTail }\` on unexpected exit; stderr ring buffer (last 32 lines) feeds the event.
- **Frontend**: \`agent-crashed\` listener clears per-tab \`waiting\`/\`queueCount\`, surfaces a sticky error notification with the last stderr line. Auto-restarts after 500ms when \`[shell] auto_restart_agent = true\` (default); otherwise offers a Restart button.
- **Config**: new \`[shell] auto_restart_agent\` key (default \`true\`).

## Test plan
- [x] tsc / eslint / vitest 150 / cargo clippy / cargo test 48 all green
- [ ] codex review