### PR TITLE
feat(p2.3): register aethon.shells.{list,read,write} as pi tools

### DIFF
--- a/agent/main.ts
+++ b/agent/main.ts
@@ -131,6 +131,7 @@ import {
   getAgentDir,
 } from "@mariozechner/pi-coding-agent";
 import type { Api, Model } from "@mariozechner/pi-ai";
+import { buildShellTools } from "./shell-tools";
 import { AsyncLocalStorage } from "node:async_hooks";
 import { createInterface } from "node:readline";
 import { mkdirSync, readFileSync } from "node:fs";
@@ -2593,6 +2594,12 @@ async function main() {
       settingsManager,
       sessionManager,
       resourceLoader,
+      // M6 P2.3: pi-tool registration for aethon.shells.{list,read,write}.
+      // The model can now invoke these via tool-use protocol instead of
+      // having to know to call globalThis.aethon.shells.* from inside a
+      // bash tool. Each tool is a thin wrapper; the security boundary
+      // (share-mode gates + privacy floor) is enforced Rust-side.
+      customTools: buildShellTools(),
       ...(initialModel ? { model: initialModel } : {}),
     });
 

--- a/agent/shell-tools.ts
+++ b/agent/shell-tools.ts
@@ -1,0 +1,163 @@
+// Pi tool definitions wrapping `globalThis.aethon.shells.*` so the model
+// can invoke shell sharing via the standard tool-use protocol (M6 P2.3).
+//
+// The aethon.shells API ships from agent/main.ts as a globalThis surface.
+// Without these tool wrappers, the model would have to know to call
+// `globalThis.aethon.shells.read({...})` from inside a `bash` tool — not
+// discoverable via tool catalogs. With these registered, the model sees
+// `listShells` / `readShell` / `writeShell` alongside built-in tools.
+//
+// Each tool is a thin shim: validate args, call the bridge API, return
+// the result as a TextContent payload. The actual security boundary
+// (share-mode gates + privacy floor) lives in shell.rs and is enforced
+// regardless of how the API is reached.
+
+import type { ToolDefinition } from "@mariozechner/pi-coding-agent";
+import { defineTool } from "@mariozechner/pi-coding-agent";
+import { Type, type Static } from "typebox";
+
+interface ShellsApi {
+  list(): Promise<{ ok: boolean; error?: string; data?: unknown }>;
+  read(args: {
+    tabId: string;
+    sinceTotal?: number;
+    maxBytes?: number;
+  }): Promise<{ ok: boolean; error?: string; data?: unknown }>;
+  write(args: {
+    tabId: string;
+    text: string;
+  }): Promise<{ ok: boolean; error?: string; data?: unknown }>;
+}
+
+function getShellsApi(): ShellsApi | null {
+  const g = globalThis as { aethon?: { shells?: ShellsApi } };
+  return g.aethon?.shells ?? null;
+}
+
+function errResult(message: string) {
+  return {
+    content: [{ type: "text" as const, text: `Error: ${message}` }],
+    details: null,
+    errorMessage: message,
+  };
+}
+
+const ListParams = Type.Object({});
+type ListParamsT = Static<typeof ListParams>;
+
+const ReadParams = Type.Object({
+  tabId: Type.String({
+    description: "Shell tab id from listShells.",
+  }),
+  sinceTotal: Type.Optional(
+    Type.Number({
+      description:
+        "Cursor returned by the previous read. Pass to resume forward; omit to get the latest maxBytes.",
+    }),
+  ),
+  maxBytes: Type.Optional(
+    Type.Number({
+      description: "Cap on returned content size (default 8192, hard cap 65536).",
+    }),
+  ),
+});
+type ReadParamsT = Static<typeof ReadParams>;
+
+const WriteParams = Type.Object({
+  tabId: Type.String({
+    description: "Shell tab id from listShells.",
+  }),
+  text: Type.String({
+    description:
+      "Keystrokes to inject. Include '\\n' to submit a command. Each call requires user approval in 'read-write' mode; 'read-write-trusted' skips the prompt.",
+  }),
+});
+type WriteParamsT = Static<typeof WriteParams>;
+
+export function buildShellTools(): ToolDefinition[] {
+  const listTool = defineTool({
+    name: "listShells",
+    label: "List shells",
+    description:
+      "List shareable shell tabs (those whose share mode is read, read-write, or read-write-trusted). Returns metadata only — no scrollback. Use readShell for content.",
+    promptSnippet:
+      "listShells: list user shell tabs the user has shared with you",
+    parameters: ListParams,
+    async execute(
+      _callId: string,
+      _params: ListParamsT,
+    ) {
+      const api = getShellsApi();
+      if (!api) return errResult("aethon.shells API unavailable");
+      const r = await api.list();
+      if (!r.ok) return errResult(r.error ?? "unknown");
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(r.data ?? [], null, 2),
+          },
+        ],
+        details: r.data,
+      };
+    },
+  }) as ToolDefinition;
+
+  const readTool = defineTool({
+    name: "readShell",
+    label: "Read shell scrollback",
+    description:
+      "Return recent terminal output from a shareable shell tab. Forward-paging from sinceTotal; cold-start (no cursor) returns the latest maxBytes. Refuses tabs whose share mode is 'private'.",
+    promptSnippet:
+      "readShell: stream a user shell's recent output (gated by share mode)",
+    parameters: ReadParams,
+    async execute(
+      _callId: string,
+      params: ReadParamsT,
+    ) {
+      const api = getShellsApi();
+      if (!api) return errResult("aethon.shells API unavailable");
+      const r = await api.read({
+        tabId: params.tabId,
+        ...(params.sinceTotal !== undefined ? { sinceTotal: params.sinceTotal } : {}),
+        ...(params.maxBytes !== undefined ? { maxBytes: params.maxBytes } : {}),
+      });
+      if (!r.ok) return errResult(r.error ?? "unknown");
+      const data = (r.data ?? {}) as {
+        content?: string;
+        totalAppended?: number;
+        shareFloor?: number;
+        shareMode?: string;
+      };
+      return {
+        content: [{ type: "text" as const, text: data.content ?? "" }],
+        details: data,
+      };
+    },
+  }) as ToolDefinition;
+
+  const writeTool = defineTool({
+    name: "writeShell",
+    label: "Write to shell",
+    description:
+      "Inject keystrokes into a shareable shell tab. Each call requires user approval in 'read-write' mode (the user sees an Allow/Deny prompt); 'read-write-trusted' skips the prompt. Refuses tabs whose share mode is 'private' or 'read'. Include '\\n' in `text` to submit a command.",
+    promptSnippet:
+      "writeShell: drive a user shell (gated by user confirmation in read-write mode)",
+    parameters: WriteParams,
+    async execute(
+      _callId: string,
+      params: WriteParamsT,
+    ) {
+      const api = getShellsApi();
+      if (!api) return errResult("aethon.shells API unavailable");
+      const r = await api.write({ tabId: params.tabId, text: params.text });
+      if (!r.ok) return errResult(r.error ?? "unknown");
+      return {
+        content: [{ type: "text" as const, text: "ok" }],
+        details: r.data ?? null,
+      };
+    },
+  }) as ToolDefinition;
+
+  return [listTool, readTool, writeTool];
+}


### PR DESCRIPTION
Adds three pi tools that wrap the existing \`globalThis.aethon.shells\` surface so the model can invoke them via standard tool-use protocol.

## Tools
- \`listShells\` — shareable-tab metadata only.
- \`readShell\` — forward-paging from sinceTotal; cold-start returns latest maxBytes; refuses private.
- \`writeShell\` — gated to read-write/read-write-trusted; user confirmation runs unchanged; refuses private/read.

Wired via \`createAgentSession\`'s \`customTools\` option (no extra extension file needed). Security boundary still enforced Rust-side.

## Test plan
- [x] tsc / eslint / vitest 150 / cargo all green
- [ ] codex review