### PR TITLE
feat(p6): cross-session search overlay

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -250,6 +250,158 @@ fn toml_string(s: &str) -> String {
     format!("\"{escaped}\"")
 }
 
+/// Cross-session search (M6 P6). Walks `~/.aethon/sessions/<tabId>/*.jsonl`
+/// and returns user / assistant messages whose text content contains
+/// the query (case-insensitive substring match — no regex parsing,
+/// keeps the bar low). Capped at `limit` matches.
+#[derive(serde::Serialize)]
+struct SearchHit {
+    #[serde(rename = "tabId")]
+    tab_id: String,
+    role: String,
+    snippet: String,
+    timestamp: Option<i64>,
+}
+
+#[tauri::command]
+fn search_sessions(
+    query: String,
+    limit: Option<u32>,
+    app: AppHandle,
+) -> Result<Vec<SearchHit>, String> {
+    let needle = query.trim().to_lowercase();
+    if needle.is_empty() {
+        return Ok(Vec::new());
+    }
+    let cap = limit.unwrap_or(200).min(5000) as usize;
+    let home = app
+        .path()
+        .home_dir()
+        .map_err(|e| format!("home_dir: {e}"))?;
+    let sessions = home.join(".aethon").join("sessions");
+    if !sessions.is_dir() {
+        return Ok(Vec::new());
+    }
+
+    let mut hits: Vec<SearchHit> = Vec::new();
+    let entries = match std::fs::read_dir(&sessions) {
+        Ok(e) => e,
+        Err(_) => return Ok(Vec::new()),
+    };
+    'tab_loop: for tab_entry in entries.flatten() {
+        let tab_dir = tab_entry.path();
+        if !tab_dir.is_dir() {
+            continue;
+        }
+        let tab_id = tab_dir
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("")
+            .to_string();
+        let files = match std::fs::read_dir(&tab_dir) {
+            Ok(f) => f,
+            Err(_) => continue,
+        };
+        for file_entry in files.flatten() {
+            let path = file_entry.path();
+            if path.extension().and_then(|s| s.to_str()) != Some("jsonl") {
+                continue;
+            }
+            let text = match std::fs::read_to_string(&path) {
+                Ok(t) => t,
+                Err(_) => continue,
+            };
+            for line in text.lines() {
+                let trimmed = line.trim();
+                if trimmed.is_empty() {
+                    continue;
+                }
+                let v: serde_json::Value = match serde_json::from_str(trimmed) {
+                    Ok(v) => v,
+                    Err(_) => continue,
+                };
+                let role = v
+                    .get("role")
+                    .and_then(|r| r.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                if role != "user" && role != "assistant" {
+                    continue;
+                }
+                let content_text = extract_text_from_content(&v);
+                if content_text.is_empty() {
+                    continue;
+                }
+                let lower = content_text.to_lowercase();
+                let pos = match lower.find(&needle) {
+                    Some(p) => p,
+                    None => continue,
+                };
+                let snippet = build_snippet(&content_text, pos, 60, 100);
+                let timestamp = v.get("timestamp").and_then(|t| t.as_i64());
+                hits.push(SearchHit {
+                    tab_id: tab_id.clone(),
+                    role: role.clone(),
+                    snippet,
+                    timestamp,
+                });
+                if hits.len() >= cap {
+                    break 'tab_loop;
+                }
+            }
+        }
+    }
+    Ok(hits)
+}
+
+fn extract_text_from_content(v: &serde_json::Value) -> String {
+    let content = match v.get("content") {
+        Some(c) => c,
+        None => return String::new(),
+    };
+    if let Some(s) = content.as_str() {
+        return s.to_string();
+    }
+    if let Some(arr) = content.as_array() {
+        let mut chunks: Vec<String> = Vec::new();
+        for part in arr {
+            if let Some(s) = part.as_str() {
+                chunks.push(s.to_string());
+            } else if part.get("type").and_then(|t| t.as_str()) == Some("text")
+                && let Some(t) = part.get("text").and_then(|t| t.as_str())
+            {
+                chunks.push(t.to_string());
+            }
+        }
+        return chunks.join("\n");
+    }
+    String::new()
+}
+
+fn build_snippet(text: &str, byte_pos: usize, before: usize, after: usize) -> String {
+    // Char-boundary-safe slicing around byte_pos.
+    let start = text
+        .char_indices()
+        .map(|(i, _)| i)
+        .find(|&i| byte_pos.saturating_sub(before) <= i)
+        .unwrap_or(0);
+    let end_target = byte_pos + after;
+    let end = text
+        .char_indices()
+        .map(|(i, c)| i + c.len_utf8())
+        .find(|&i| i >= end_target)
+        .unwrap_or(text.len());
+    let mut snippet = String::new();
+    if start > 0 {
+        snippet.push('…');
+    }
+    snippet.push_str(&text[start..end]);
+    if end < text.len() {
+        snippet.push('…');
+    }
+    snippet.replace('\n', " ").replace('\r', "")
+}
+
 #[cfg(debug_assertions)]
 mod debug;
 
@@ -1498,6 +1650,7 @@ pub fn run() {
             read_config,
             write_config,
             aethon_home_dir,
+            search_sessions,
             updater_available,
             install_aethon_skill,
             set_extension_menu_items,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import {
   layoutSlots,
 } from "./skills/default-layout";
 import { CommandPalette } from "./skills/default-layout/command-palette";
+import { SearchPanel } from "./skills/default-layout/search-panel";
 import { SettingsPanel } from "./skills/default-layout/settings-panel";
 import type {
   PaletteItem,
@@ -1935,6 +1936,16 @@ export default function App() {
         e.preventDefault();
         e.stopPropagation();
         closeTab(activeId);
+        return;
+      }
+      // Cmd+Shift+F → cross-session search overlay (M6 P6). Searches
+      // every persisted JSONL session under ~/.aethon/sessions/<tabId>/
+      // via the Tauri search_sessions command. Click a result → restore
+      // the originating tab.
+      if (e.key.toLowerCase() === "f" && mod && e.shiftKey && !e.altKey) {
+        e.preventDefault();
+        e.stopPropagation();
+        toggleSessionSearch();
         return;
       }
       // Cmd+Shift+P → command palette in "commands" mode (run an action,
@@ -4303,6 +4314,37 @@ export default function App() {
     closeSettings();
   }
 
+  /** Toggle the cross-session search overlay (M6 P6). State lives at
+   *  `/search`; the SearchPanel composite reads `open` + `query` and
+   *  invokes `search_sessions` Tauri command on every (debounced)
+   *  keystroke. */
+  function toggleSessionSearch() {
+    setState((prev) => {
+      const cur = (prev.search as { open?: boolean } | undefined) ?? {};
+      return {
+        ...prev,
+        search: { open: !cur.open, query: "" },
+      };
+    });
+  }
+  function closeSessionSearch() {
+    setState((prev) => ({ ...prev, search: { open: false, query: "" } }));
+  }
+  function setSearchQuery(value: string) {
+    setState((prev) => {
+      const cur = (prev.search as { open?: boolean; query?: string } | undefined) ?? {};
+      return { ...prev, search: { open: !!cur.open, query: value } };
+    });
+  }
+  function openSearchHit(hit: { tabId?: string }) {
+    if (!hit?.tabId) return;
+    closeSessionSearch();
+    // Reopen the originating tab. SessionManager.continueRecent picks
+    // up the persisted JSONL session under ~/.aethon/sessions/<tabId>/
+    // so the user lands inside their previous conversation.
+    newTab(hit.tabId, undefined, { restoredSession: true });
+  }
+
   function openPalette(mode: PaletteMode) {
     setState((prev) => ({
       ...prev,
@@ -4714,6 +4756,26 @@ export default function App() {
         }
       }
 
+      // Cross-session search panel events (M6 P6). Like the palette,
+      // renders at App root and never goes through the bridge —
+      // search results land via the Tauri search_sessions command.
+      if (component.id === "search-panel") {
+        if (eventType === "close") {
+          closeSessionSearch();
+          return true;
+        }
+        if (eventType === "query") {
+          const value = (data as { value?: string } | undefined)?.value ?? "";
+          setSearchQuery(value);
+          return true;
+        }
+        if (eventType === "select") {
+          const hit = (data as { hit?: { tabId?: string } } | undefined)?.hit;
+          if (hit) openSearchHit(hit);
+          return true;
+        }
+      }
+
       // Command palette events. Palette renders at App root; events
       // route here directly (it never goes through the dispatch_a2ui
       // bridge because there's no agent counterpart to invoke).
@@ -5070,6 +5132,10 @@ export default function App() {
     () => ({ id: "settings-panel", type: "settings-panel", props: {} }),
     [],
   );
+  const searchComponent = useMemo(
+    () => ({ id: "search-panel", type: "search-panel", props: {} }),
+    [],
+  );
   const renderState = useMemo(() => {
     const tabs = (state.tabs as Tab[] | undefined) ?? [];
     const recentSessions =
@@ -5127,6 +5193,13 @@ export default function App() {
           state={renderState}
           onEvent={(eventType, data) =>
             onEvent(settingsComponent, eventType, data)
+          }
+        />
+        <SearchPanel
+          component={searchComponent}
+          state={renderState}
+          onEvent={(eventType, data) =>
+            onEvent(searchComponent, eventType, data)
           }
         />
       </div>

--- a/src/skills/default-layout/search-panel.tsx
+++ b/src/skills/default-layout/search-panel.tsx
@@ -1,0 +1,166 @@
+// Cross-session search overlay (M6 P6). Cmd+Shift+F opens. Searches
+// across every persisted pi session JSONL under
+// `~/.aethon/sessions/<tabId>/` via the Tauri `search_sessions`
+// command. Click a result → restore that tab.
+//
+// State contract (`/search` slice):
+//   { open: boolean, query: string, results: SearchHit[], busy: boolean }
+//
+// Results carry just enough to restore a tab — `tabId` is the cue
+// for the bridge's SessionManager.continueRecent. The current
+// implementation re-runs the search on each query change with a
+// short debounce; v1 ships scan-only, no token index.
+
+import { useEffect, useRef, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import type { BuiltinComponentProps } from "../../components/A2UIRenderer";
+
+interface SearchHit {
+  tabId: string;
+  role: string;
+  snippet: string;
+  timestamp?: number;
+}
+
+interface SearchState {
+  open: boolean;
+  query: string;
+}
+
+function readSearchState(state: Record<string, unknown>): SearchState {
+  const s = (state.search as Partial<SearchState> | undefined) ?? {};
+  return {
+    open: !!s.open,
+    query: typeof s.query === "string" ? s.query : "",
+  };
+}
+
+const DEBOUNCE_MS = 180;
+const RESULT_LIMIT = 200;
+
+export function SearchPanel({ state, onEvent }: BuiltinComponentProps) {
+  const search = readSearchState(state);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [results, setResults] = useState<SearchHit[]>([]);
+  const [busy, setBusy] = useState(false);
+
+  // Auto-focus the input when opened. Same pattern as CommandPalette.
+  const wasOpenRef = useRef(false);
+  useEffect(() => {
+    if (search.open && !wasOpenRef.current) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+    wasOpenRef.current = search.open;
+  }, [search.open]);
+
+  // Debounced search. Each keystroke schedules a new search; the
+  // previous timer is cleared so we only fire after the user pauses.
+  // Empty query → empty results (avoid an expensive scan with no hit
+  // criterion).
+  useEffect(() => {
+    if (!search.open) {
+      setResults([]);
+      return;
+    }
+    const q = search.query.trim();
+    if (q.length === 0) {
+      setResults([]);
+      return;
+    }
+    const handle = window.setTimeout(async () => {
+      setBusy(true);
+      try {
+        const hits = await invoke<SearchHit[]>("search_sessions", {
+          query: q,
+          limit: RESULT_LIMIT,
+        });
+        setResults(Array.isArray(hits) ? hits : []);
+      } catch (err) {
+        console.warn("search_sessions failed:", err);
+        setResults([]);
+      } finally {
+        setBusy(false);
+      }
+    }, DEBOUNCE_MS);
+    return () => window.clearTimeout(handle);
+  }, [search.open, search.query]);
+
+  if (!search.open) return null;
+
+  const close = () => onEvent("close");
+  const setQuery = (q: string) => onEvent("query", { value: q });
+  const select = (hit: SearchHit) => onEvent("select", { hit });
+
+  return (
+    <div
+      className="ae-search-overlay"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) close();
+      }}
+    >
+      <div
+        className="ae-search-panel"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Search sessions"
+      >
+        <div className="ae-search-header">
+          <span className="ae-search-icon" aria-hidden="true">⌕</span>
+          <input
+            ref={inputRef}
+            className="ae-search-input"
+            placeholder="Search across sessions…"
+            value={search.query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Escape") {
+                e.preventDefault();
+                close();
+              }
+            }}
+            spellCheck={false}
+            autoComplete="off"
+          />
+          {busy && <span className="ae-search-busy">searching…</span>}
+        </div>
+        <div className="ae-search-results">
+          {search.query.trim().length === 0 ? (
+            <div className="ae-search-empty">
+              Type to search messages across all your sessions.
+            </div>
+          ) : results.length === 0 && !busy ? (
+            <div className="ae-search-empty">
+              No matches for "{search.query.trim()}".
+            </div>
+          ) : (
+            results.map((hit, i) => (
+              <button
+                key={`${hit.tabId}-${i}`}
+                type="button"
+                className="ae-search-row"
+                onClick={() => select(hit)}
+              >
+                <div className="ae-search-row-meta">
+                  <span className="ae-search-row-role">{hit.role}</span>
+                  <span className="ae-search-row-tab">{hit.tabId}</span>
+                  {hit.timestamp ? (
+                    <span className="ae-search-row-time">
+                      {new Date(hit.timestamp).toLocaleString()}
+                    </span>
+                  ) : null}
+                </div>
+                <div className="ae-search-row-snippet">{hit.snippet}</div>
+              </button>
+            ))
+          )}
+        </div>
+        <div className="ae-search-footer">
+          <span><kbd>↑↓</kbd> navigate</span>
+          <span><kbd>↵</kbd> open</span>
+          <span><kbd>Esc</kbd> close</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -3124,6 +3124,127 @@ body.ae-resizing-sidebar * {
 }
 
 /* =============================================================================
+   Cross-session search overlay (Cmd+Shift+F). Modeled after the
+   command palette but with a results pane sized for snippets.
+   ============================================================================= */
+
+.ae-search-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 12vh;
+  z-index: 200;
+}
+.ae-search-panel {
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  width: min(680px, 92vw);
+  max-height: 70vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.45);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+}
+.ae-search-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+}
+.ae-search-icon {
+  color: var(--accent);
+  font-size: 1.1rem;
+}
+.ae-search-input {
+  flex: 1 1 auto;
+  background: transparent;
+  border: 0;
+  outline: none;
+  color: var(--text);
+  font-size: 1rem;
+  font-family: inherit;
+  padding: 4px 0;
+}
+.ae-search-busy {
+  font-size: 0.8rem;
+  color: var(--text-dim);
+  font-style: italic;
+}
+.ae-search-results {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 6px 0;
+}
+.ae-search-empty {
+  padding: 18px 20px;
+  color: var(--text-dim);
+  text-align: center;
+  font-size: 0.92rem;
+}
+.ae-search-row {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: 0;
+  padding: 8px 16px;
+  cursor: pointer;
+  border-left: 3px solid transparent;
+  font-family: inherit;
+}
+.ae-search-row:hover,
+.ae-search-row:focus-visible {
+  background: color-mix(in oklab, var(--accent) 8%, transparent);
+  border-left-color: var(--accent);
+  outline: none;
+}
+.ae-search-row-meta {
+  display: flex;
+  gap: 10px;
+  font-size: 0.78rem;
+  color: var(--text-dim);
+  margin-bottom: 2px;
+}
+.ae-search-row-role {
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--accent);
+}
+.ae-search-row-tab {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+.ae-search-row-time {
+  margin-left: auto;
+}
+.ae-search-row-snippet {
+  color: var(--text);
+  font-size: 0.92rem;
+  line-height: 1.4;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.ae-search-footer {
+  display: flex;
+  gap: 12px;
+  padding: 8px 14px;
+  border-top: 1px solid var(--border);
+  font-size: 0.78rem;
+  color: var(--text-dim);
+}
+.ae-search-footer kbd {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  background: var(--bg);
+  padding: 1px 6px;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+}
+
+/* =============================================================================
    Tool card — agent tool-call surface with live elapsed-time clock.
    Replaces the plain `card` primitive for tool execution events. Color
    shifts with state: idle = dim, running = accent, ≥30 s long-running =


### PR DESCRIPTION
Cmd+Shift+F opens a search overlay that scans every persisted pi session JSONL under \`~/.aethon/sessions/<tabId>/\`.

## Implementation
- **Rust** \`search_sessions\` Tauri command: walks the sessions dir, parses each JSONL line, extracts text from string or array-of-chunks content shapes. Case-insensitive substring match (no regex parsing). Char-boundary-safe snippets (60 before, 100 after).
- **Frontend** \`SearchPanel\` composite registered as \`search-panel\`. Debounced (180ms) invocation on each keystroke. Click a result → reopens the originating tab via \`newTab(tabId, _, {restoredSession: true})\` so the bridge resumes the session.

Closes M6 P6 — the last item on the M6 spec checklist.

## Test plan
- [x] tsc / eslint (one pre-existing warning) / vitest 150 / cargo clippy / cargo test 48 all green
- [ ] codex review