### PR TITLE
feat(ui): session history alignment, model fix, sticky scroll, UI polish

### DIFF
--- a/.claude/skills/aethon-debug/scripts/debug-eval.sh
+++ b/.claude/skills/aethon-debug/scripts/debug-eval.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 # Aethon debug eval helper — sends JS to the running Aethon debug server.
+# Auto-starts the dev build if it is not running.
+#
 # Usage: debug-eval.sh 'return 1 + 1'
 #        echo 'return document.title' | debug-eval.sh
 #
@@ -7,41 +9,132 @@
 #   1. $AETHON_DEBUG_PORT — explicit override
 #   2. ~/.aethon/dev-info.json — written by scripts/dev.sh on each launch.
 #      Lets the skill find the port even when the wrapper auto-incremented
-#      because 19433 was busy. The file is removed when the dev session
-#      exits, so a stale file from a crashed run just falls through to
-#      the default.
+#      because 19433 was busy.
 #   3. 19433 — built-in default (matches src-tauri's DEFAULT_DEBUG_PORT)
-#
-# The dev build must be running (`bun tauri dev` or the devshell `dev` helper).
-# Release builds have no debug server (gated by #[cfg(debug_assertions)]).
 set -euo pipefail
 
+SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_DIR="$(cd "${SKILL_DIR}/../.." && pwd)"
 HOST="127.0.0.1"
 DEV_INFO="${HOME}/.aethon/dev-info.json"
-TIMEOUT=12
+EVAL_TIMEOUT=12
+START_TIMEOUT=240   # seconds to wait for app to start / compile
+DEV_LOG="${TMPDIR:-/tmp}/aethon-dev.log"
 
-if [[ -n "${AETHON_DEBUG_PORT:-}" ]]; then
-  PORT="${AETHON_DEBUG_PORT}"
-elif [[ -f "${DEV_INFO}" ]]; then
-  # Pull debugPort from dev-info.json. python3 is already a dependency
-  # of this script for the TCP I/O below, so reuse it instead of jq.
-  PORT="$(python3 -c "
+# ---------------------------------------------------------------------------
+# Port resolution
+# ---------------------------------------------------------------------------
+resolve_port() {
+  if [[ -n "${AETHON_DEBUG_PORT:-}" ]]; then
+    echo "${AETHON_DEBUG_PORT}"
+    return
+  fi
+  if [[ -f "${DEV_INFO}" ]]; then
+    python3 -c "
 import json, sys
 try:
     with open('${DEV_INFO}') as f:
         info = json.load(f)
     p = info.get('debugPort')
     if isinstance(p, int) and p > 0:
-        print(p)
-        sys.exit(0)
+        print(p); sys.exit(0)
 except Exception:
     pass
 print(19433)
-" 2>/dev/null || echo 19433)"
-else
-  PORT=19433
-fi
+" 2>/dev/null || echo 19433
+  else
+    echo 19433
+  fi
+}
 
+# ---------------------------------------------------------------------------
+# Check if the debug server is reachable on a given port
+# ---------------------------------------------------------------------------
+server_up() {
+  local port="$1"
+  python3 -c "
+import socket, sys
+s = socket.socket()
+s.settimeout(1)
+try:
+    s.connect(('${HOST}', ${port}))
+    s.close()
+    sys.exit(0)
+except Exception:
+    sys.exit(1)
+" 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# Start dev build in the background if not already running
+# ---------------------------------------------------------------------------
+ensure_app_running() {
+  local port
+  port="$(resolve_port)"
+
+  if server_up "${port}"; then
+    echo "${port}"
+    return
+  fi
+
+  # Check if existing dev-info.json points to a live PID
+  if [[ -f "${DEV_INFO}" ]]; then
+    local pid
+    pid="$(python3 -c "
+import json, sys
+try:
+    with open('${DEV_INFO}') as f:
+        info = json.load(f)
+    p = info.get('pid')
+    if isinstance(p, int) and p > 0:
+        print(p); sys.exit(0)
+except Exception:
+    pass
+sys.exit(1)
+" 2>/dev/null)" && kill -0 "${pid}" 2>/dev/null && {
+      # PID is alive but server not yet ready — it might still be compiling
+      echo "INFO: Dev process (PID ${pid}) is alive but debug server not up yet — waiting..." >&2
+    } || true
+  fi
+
+  if ! server_up "${port}"; then
+    echo "INFO: Aethon dev build not running — starting it (output: ${DEV_LOG})" >&2
+    echo "INFO: This may take up to a few minutes on first compile." >&2
+
+    # Prefer the devshell entry point; fall back to bun directly
+    if command -v dev &>/dev/null; then
+      nohup bash -c "cd '${REPO_DIR}' && dev" >"${DEV_LOG}" 2>&1 &
+    else
+      nohup bash -c "cd '${REPO_DIR}' && bun tauri dev" >"${DEV_LOG}" 2>&1 &
+    fi
+  fi
+
+  # Wait for the server to come up
+  local elapsed=0
+  local dot_interval=10
+  local last_dot=0
+  while ! server_up "$(resolve_port)"; do
+    if (( elapsed >= START_TIMEOUT )); then
+      echo "" >&2
+      echo "ERROR: Timed out after ${START_TIMEOUT}s waiting for debug server." >&2
+      echo "       Check dev build output: tail ${DEV_LOG}" >&2
+      exit 1
+    fi
+    if (( elapsed - last_dot >= dot_interval )); then
+      printf "  waiting (%ds)...\n" "${elapsed}" >&2
+      last_dot=${elapsed}
+    fi
+    sleep 2
+    (( elapsed += 2 ))
+  done
+  echo "INFO: Debug server ready." >&2
+
+  resolve_port
+}
+
+# ---------------------------------------------------------------------------
+# Read JS from args or stdin
+# ---------------------------------------------------------------------------
 if [[ $# -gt 0 ]]; then
   JS="$*"
 else
@@ -54,16 +147,16 @@ if [[ -z "${JS}" ]]; then
   exit 1
 fi
 
+PORT="$(ensure_app_running)"
+
 python3 -c "
 import socket, sys
 s = socket.socket()
-s.settimeout(${TIMEOUT})
+s.settimeout(${EVAL_TIMEOUT})
 try:
     s.connect(('${HOST}', ${PORT}))
 except ConnectionRefusedError:
     sys.stderr.write('ERROR: cannot connect to debug server on ${HOST}:${PORT}\n')
-    sys.stderr.write('Start the dev build with \`bun tauri dev\` (or the devshell \`dev\` helper).\n')
-    sys.stderr.write('Release builds have no debug server.\n')
     sys.exit(1)
 s.sendall(sys.stdin.buffer.read())
 s.shutdown(socket.SHUT_WR)

--- a/.claude/skills/aethon-debug/scripts/debug-screenshot.sh
+++ b/.claude/skills/aethon-debug/scripts/debug-screenshot.sh
@@ -1,10 +1,16 @@
 #!/usr/bin/env bash
-# Capture a screenshot of the desktop. Returns the path on stdout.
+# Capture a screenshot of the Aethon dev app window.
+# Auto-starts the dev build if it is not running, then focuses the window
+# via the debug server before capturing.
+#
+# Returns the path to the PNG on stdout.
 # Default save location: ${TMPDIR:-/tmp}/aethon-debug/aethon-<timestamp>.png
 # Override with --output PATH.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 OUT="${TMPDIR:-/tmp}/aethon-debug/aethon-$(date +%Y%m%d-%H%M%S).png"
+FOCUS_TIMEOUT=3
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -25,9 +31,16 @@ done
 
 mkdir -p "$(dirname "$OUT")"
 
+# Ensure the app is running (auto-starts if needed) and focus the window
+# so the screenshot captures the actual Aethon UI, not whatever is on top.
+"${SCRIPT_DIR}/debug-eval.sh" 'window.focus(); return "focused"' >/dev/null 2>&1 || true
+
+# Give the window manager a moment to bring the window forward.
+sleep "${FOCUS_TIMEOUT}"
+
 case "$(uname -s)" in
   Darwin)
-    # -x silences the shutter sound, default capture is the full main display.
+    # -x silences the shutter sound; captures the full main display.
     screencapture -x "$OUT"
     ;;
   Linux)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,9 @@ by the agent.
 - **Agent**: TypeScript via `@mariozechner/pi-coding-agent`, run as a `bun`
   subprocess spawned from the Rust shell
 - **Dev env**: Nix flake (flake-parts + numtide/devshell + treefmt-nix +
-  rust-overlay), Rust toolchain pinned at **1.92.0**
+  rust-overlay), Rust toolchain pinned at **1.92.0** in `flake.nix` (via
+  rust-overlay); `rust-toolchain.toml` says `channel = "stable"` for non-Nix
+  builds — the Nix pin takes precedence inside the devshell
 - **Targets**: macOS (aarch64), Linux (x86_64 / aarch64), Windows (later)
 
 ## Common Commands
@@ -38,6 +40,10 @@ devshell exposes these helpers (defined in `flake.nix`):
 
 `bun tauri dev` and `bun tauri build` also work (they go through the JS-side
 `@tauri-apps/cli` wrapper). One-time after pulling: `bun install`.
+
+To run a single test file: `bunx vitest run agent/terminal-stream.test.ts`.
+To run tests matching a name: `bunx vitest run -t "test name pattern"`.
+To run a single Rust test: `cargo test --lib -p aethon -- helpers::test_name`.
 
 ## Architecture
 
@@ -70,6 +76,12 @@ devshell exposes these helpers (defined in `flake.nix`):
      history on restart.
    - `agent/terminal-stream.ts` — buffers `bash`-tool output as an A2UI
      terminal stream (the `BashTerminalStreamState` snapshot type).
+   - `agent/canvas.ts` — helpers for building and patching A2UI canvas payloads.
+   - `agent/agent-errors.ts` — extracts structured error info from pi agent
+     end-of-run errors (wraps `AgentEndError` classification).
+   - `agent/shell-tools.ts` — pi tool implementations for
+     `listShells`/`readShell`/`writeShell` (bridge-side counterpart to the
+     Rust `shell_query` Tauri command).
 3. **React frontend** (`src/`) — see below. Listens for `agent-response`
    events, parses each line, and routes it into the chat history or canvas.
 
@@ -222,9 +234,8 @@ read clamp + privacy floor have to live where the PTY does. Most code paths spec
 composite (`ShellCanvas` in `components.tsx`) replaces the agent
 `main-canvas` + `chat-input` cells when a shell tab is active —
 controlled by the `/agentTabActive` / `/shellTabActive` `$ref` visibility
-flags in `workstation.a2ui.json`. Keybindings: `Cmd+T` = new shell tab,
-`Cmd+Shift+T` = new agent tab (Terminal.app convention; configurable via
-`[shortcuts] new_tab_kind` once that setting lands).
+flags in `workstation.a2ui.json`. Keybindings: `Cmd+T` = new agent tab (focus-aware — new shell sub-tab when
+focus is inside the bottom panel), `Cmd+Shift+T` = new shell sub-tab (always).
 
 ### Command palette
 
@@ -415,17 +426,14 @@ The authoritative checklist is in `SPEC.md` ("Status Checklist" section,
 keyed against milestones M1–M5). Update both that checklist and any
 relevant notes here when capabilities land.
 
-**Quick highlights as of writing:** M1–M5 complete + M6 P1 shipped
-(interactive PTY-backed user shell tabs via `portable-pty`, `Tab.kind`
-discriminator, `Cmd+T` = shell / `Cmd+Shift+T` = agent, theme-agnostic
-xterm) + M6 P2 shipped (per-tab `ShareMode` 4-value enum with
-privacy-floor guardrail, `aethon.shells.{list, read, write}` bridge
-API with per-write Allow/Deny user confirmation in `read-write` mode,
-clickable share-mode badge in the shell status line, `[shell]
-default_share_mode` config seeded inside `shell_open` so the floor
-pins at byte 0). Pi-tool registration of `listShells`/`readShell`/
-`writeShell` is the next phase — the API is already reachable via
-`globalThis.aethon.shells.*` from extensions today.
+**Quick highlights as of writing:** M1–M6 complete. M6 shipped: interactive
+PTY-backed user shell tabs (`portable-pty`, `Tab.kind` discriminator,
+theme-agnostic xterm), per-tab `ShareMode` 4-value enum with privacy-floor
+guardrail, `aethon.shells.{list, read, write}` bridge API with per-write
+Allow/Deny user confirmation, pi-tool registration of
+`listShells`/`readShell`/`writeShell` (in `agent/shell-tools.ts`), Settings
+UI overlay, fullscreen, search overlay, drag-and-drop into composer, bridge
+crash recovery, OS notifications.
 Tool execution surfaces as A2UI cards, multi-tab persistent
 sessions, light theme, system tray + native menu, slash command picker,
 real `~/.aethon/config.toml`, layout-slot contract (`canvas` +
@@ -446,7 +454,7 @@ Cmd+Shift+P commands), v0.2.0 GitHub release with macOS .dmg + Linux
 | `cargo test --lib`           | Rust unit tests under `src-tauri/src/helpers.rs` | `test`           |
 | `bunx tsc -b --noEmit`       | TypeScript types (frontend + agent)              | `check`          |
 | `bunx eslint .`              | TS + React lint, type-aware via tsconfig         | `lint`           |
-| `bunx vitest run`            | TS unit tests (`src/**/*.test.ts`)               | `test`           |
+| `bunx vitest run`            | TS unit tests (`src/**/*.test.ts` + `agent/**/*.test.ts`) | `test`    |
 | `bunx vitest run --coverage` | TS coverage report (v8)                          | `coverage`       |
 
 The `check` devshell command runs all of the above as a single CI gate.

--- a/README.md
+++ b/README.md
@@ -113,30 +113,20 @@ input for Nix builds.
 
 ## Architecture
 
-```
-┌────────────────────────────────────────────────────────────┐
-│                     Aethon (.app / .deb)                    │
-│                                                            │
-│  ┌────────────────┐    stdio (JSON lines)   ┌────────────┐ │
-│  │  Tauri Shell    │◄─────────────────────►│  Pi Agent  │ │
-│  │  (Rust)         │                        │  (bun bin) │ │
-│  │                 │                        │            │ │
-│  │  • windows      │   A2UI components      │  • pi-ai   │ │
-│  │  • tray + menu  │◄───────────────────────│  • tools   │ │
-│  │  • file watch   │                        │  • skills  │ │
-│  │  • spawn agent  │   user / UI events     │  • exts    │ │
-│  └────────┬────────┘──────────────────────► └────────────┘ │
-│           │ Tauri IPC                                       │
-│           ▼                                                 │
-│  ┌──────────────────────────────────────────────────────┐  │
-│  │             React Frontend (Vite)                    │  │
-│  │  ┌─────────────────────┐  ┌──────────────────────┐  │  │
-│  │  │  A2UI Renderer       │  │  default-layout     │  │  │
-│  │  │  (19 primitives +    │  │  (sidebar, canvas,  │  │  │
-│  │  │  scoped templates)   │  │  terminal, ...)     │  │  │
-│  │  └─────────────────────┘  └──────────────────────┘  │  │
-│  └──────────────────────────────────────────────────────┘  │
-└────────────────────────────────────────────────────────────┘
+```mermaid
+graph TD
+    subgraph aethon["Aethon (.app / .deb)"]
+        TS["Tauri Shell (Rust)\nwindows · tray + menu · file watch · spawn agent"]
+        PA["Pi Agent (bun bin)\npi-ai · tools · skills · exts"]
+        subgraph react["React Frontend (Vite)"]
+            R["A2UI Renderer\n19 primitives + scoped templates"]
+            L["default-layout\nsidebar · canvas · terminal · …"]
+        end
+
+        TS -- "stdin JSON lines\nuser / UI events" --> PA
+        PA -- "stdout JSON lines\nA2UI components + responses" --> TS
+        TS <-- "Tauri IPC" --> react
+    end
 ```
 
 | Layer                  | Owns                                                                                    | Doesn't own                                                     |

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ input for Nix builds.
 
 ```mermaid
 graph TD
-    subgraph aethon["Aethon (.app / .deb)"]
+    subgraph aethon["Aethon"]
         TS["Tauri Shell (Rust)\nwindows · tray + menu · file watch · spawn agent"]
         PA["Pi Agent (bun bin)\npi-ai · tools · skills · exts"]
         subgraph react["React Frontend (Vite)"]

--- a/agent/main.ts
+++ b/agent/main.ts
@@ -788,7 +788,12 @@ async function discoverPersistedTabs(): Promise<
     }
     return [];
   }
-  const results: { tabId: string; lastModified: number; cwd?: string }[] = [];
+  const results: {
+    tabId: string;
+    lastModified: number;
+    cwd?: string;
+    firstUserMessage?: string;
+  }[] = [];
   for (const name of entries) {
     if (name === "default") continue;
     if (!/^[A-Za-z0-9_-]{1,128}$/.test(name)) continue;
@@ -2894,7 +2899,12 @@ async function main() {
   // in `ready` so the frontend can offer "Recent sessions" in the
   // empty-state composite. Excludes "default" (which the frontend
   // pre-creates anyway). Sorted descending by lastModified.
-  let discoveredTabs: { tabId: string; lastModified: number; cwd?: string }[] = [];
+  let discoveredTabs: {
+    tabId: string;
+    lastModified: number;
+    cwd?: string;
+    firstUserMessage?: string;
+  }[] = [];
 
   function defaultModelKey(): string {
     const def = tabs.get("default");
@@ -3355,6 +3365,20 @@ async function main() {
   scheduleStateFileWrite();
 
   emitReady();
+
+  // Replay the default tab's persisted pi session history to the frontend
+  // so all tabs use the same session_history IPC path. This replaces the
+  // frontend's messages.json read, making pi's JSONL the single source of
+  // truth for all tabs (not just non-default ones).
+  readSessionTranscript(tabSessionDir("default"))
+    .then((messages) => {
+      if (messages.length > 0) {
+        send({ type: "session_history", tabId: "default", messages });
+      }
+    })
+    .catch((err) => {
+      logger.scope("session").warn(`default tab history replay failed: ${(err as Error).message}`);
+    });
 
   const rl = createInterface({ input: process.stdin });
 

--- a/agent/session-history.ts
+++ b/agent/session-history.ts
@@ -19,6 +19,9 @@ interface LatestSessionLog {
 export interface SessionLogMetadata {
   cwd?: string;
   lastModified: number;
+  /** First user-turn text, trimmed to 60 chars. Used to label sessions
+   *  meaningfully in the sidebar instead of showing raw UUID slices. */
+  firstUserMessage?: string;
 }
 
 function textFromContent(content: unknown): string {
@@ -122,7 +125,15 @@ async function latestSessionLog(sessionDir: string): Promise<LatestSessionLog | 
   return latest;
 }
 
-function cwdFromSessionLines(lines: Iterable<string>): string | undefined {
+const MAX_LABEL_CHARS = 60;
+
+function metaFromSessionLines(lines: Iterable<string>): {
+  cwd?: string;
+  firstUserMessage?: string;
+} {
+  let cwd: string | undefined;
+  let firstUserMessage: string | undefined;
+
   for (const line of lines) {
     const trimmed = line.trim();
     if (!trimmed) continue;
@@ -135,12 +146,31 @@ function cwdFromSessionLines(lines: Iterable<string>): string | undefined {
     }
     if (!entry || typeof entry !== "object") continue;
     const record = entry as Record<string, unknown>;
-    if (record.type !== "session") continue;
-    return typeof record.cwd === "string" && record.cwd.length > 0
-      ? record.cwd
-      : undefined;
+
+    if (!cwd && record.type === "session") {
+      cwd =
+        typeof record.cwd === "string" && record.cwd.length > 0
+          ? record.cwd
+          : undefined;
+    }
+
+    if (!firstUserMessage && record.type === "message") {
+      const msg = record.message as Record<string, unknown> | undefined;
+      if (msg?.role === "user") {
+        const text = textFromContent(msg.content);
+        if (text) {
+          firstUserMessage =
+            text.length > MAX_LABEL_CHARS
+              ? `${text.slice(0, MAX_LABEL_CHARS - 1)}…`
+              : text;
+        }
+      }
+    }
+
+    if (cwd && firstUserMessage) break;
   }
-  return undefined;
+
+  return { cwd, firstUserMessage };
 }
 
 export async function readSessionMetadata(
@@ -150,10 +180,11 @@ export async function readSessionMetadata(
   if (!latest) return null;
 
   const raw = await readFile(latest.path, "utf8");
-  const cwd = cwdFromSessionLines(raw.split(/\r?\n/));
+  const { cwd, firstUserMessage } = metaFromSessionLines(raw.split(/\r?\n/));
   return {
     lastModified: latest.mtimeMs,
     ...(cwd ? { cwd } : {}),
+    ...(firstUserMessage ? { firstUserMessage } : {}),
   };
 }
 

--- a/flake.nix
+++ b/flake.nix
@@ -336,6 +336,12 @@
                 help = "Format Rust + Nix + JSON/MD/YAML/CSS (prettier) + TOML (taplo)";
                 command = "treefmt \"$@\"";
               }
+              {
+                category = "build";
+                name = "clean";
+                help = "Remove Rust build artifacts (src-tauri/target/)";
+                command = "cargo clean --manifest-path src-tauri/Cargo.toml \"$@\"";
+              }
             ];
           };
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -167,6 +167,9 @@ interface DiscoveredSession {
   tabId: string;
   lastModified: number;
   cwd?: string;
+  /** First user message text, trimmed to 60 chars by the bridge. Used to
+   *  label sidebar history items meaningfully instead of UUID slices. */
+  firstUserMessage?: string;
 }
 
 interface SidebarHistoryItem {
@@ -417,21 +420,26 @@ export default function App() {
     recentSessions: RecentSessionItem[],
   ): SidebarHistoryItem[] => {
     const openIds = new Set(tabs.map((t) => t.id));
-    const previewText = (messages: ChatMessage[]) => {
-      const last = [...messages]
-        .reverse()
-        .find((m) => typeof m.text === "string" && m.text.trim().length > 0);
-      return last?.text?.replace(/\s+/g, " ").trim() ?? "";
+    const firstUserText = (messages: ChatMessage[]): string => {
+      const first = messages.find(
+        (m) => m.role === "user" && typeof m.text === "string" && m.text.trim().length > 0,
+      );
+      return first?.text?.replace(/\s+/g, " ").trim().slice(0, 48) ?? "";
     };
     const openHistory = tabs
       .filter((t) => t.messages.length > 0)
       .map((t) => {
-        const preview = previewText(t.messages);
+        const firstMsg = firstUserText(t.messages);
+        // Use first user message as the display label when the tab still has
+        // a generic sequential name (Tab 1, Tab 2, …). Explicit renames keep
+        // their name.
+        const label = /^Tab \d+$/.test(t.label) && firstMsg ? firstMsg : t.label;
+        const hint = t.id === activeTabId ? "active" : `${t.messages.length} msg`;
         return {
           id: `tab:${t.id}`,
-          label: t.label,
-          hint: t.id === activeTabId ? "active" : `${t.messages.length} msg`,
-          tooltip: preview || t.label,
+          label,
+          hint,
+          tooltip: firstMsg || label,
           active: t.id === activeTabId,
         };
       });
@@ -441,7 +449,7 @@ export default function App() {
         id: `session:${s.id}`,
         label: s.label,
         hint: s.lastModified,
-        tooltip: "Restore session",
+        tooltip: s.cwd ? s.cwd : "Restore session",
       }));
     return [...openHistory, ...restoredHistory].slice(0, 16);
   }, []);
@@ -474,12 +482,24 @@ export default function App() {
     return discovered
       .filter((d) => !openIds.has(d.tabId))
       .slice(0, 8)
-      .map((d) => ({
-        id: d.tabId,
-        label: `Session ${d.tabId.slice(0, 8)}`,
-        lastModified: formatRelativeTime(d.lastModified),
-        ...(d.cwd ? { cwd: d.cwd } : {}),
-      }));
+      .map((d) => {
+        // Derive a human-readable label in priority order:
+        //   1. First user message text (most descriptive)
+        //   2. Project directory basename
+        //   3. Fallback UUID prefix
+        const cwdBasename = d.cwd
+          ? d.cwd.replace(/[/\\]+$/, "").split(/[/\\]/).pop() ?? ""
+          : "";
+        const label = d.firstUserMessage
+          ? d.firstUserMessage.replace(/\s+/g, " ").trim()
+          : cwdBasename || `Session ${d.tabId.slice(0, 8)}`;
+        return {
+          id: d.tabId,
+          label,
+          lastModified: formatRelativeTime(d.lastModified),
+          ...(d.cwd ? { cwd: d.cwd } : {}),
+        };
+      });
   }
 
   function syncRecentSessionsToState() {
@@ -541,6 +561,10 @@ export default function App() {
   const autoRestoredSessionIdsRef = useRef(new Set<string>());
   const allDiscoveredSessionsRef = useRef<DiscoveredSession[]>([]);
   const projectsLoadedRef = useRef(false);
+  // Pi's default model from the last `ready` event. Used to seed new tabs
+  // before ready fires (or when the active tab has no model yet), so the
+  // picker never shows a blank "model ▼" label.
+  const piDefaultModelRef = useRef<string>("");
 
   // Themes — three built-in palettes (ember/paper/aether) plus
   // extension-registered ones. Persisted to `~/.aethon/theme` so the choice
@@ -838,99 +862,19 @@ export default function App() {
     });
   }
 
-  // Persistent chat history — restore on mount, write debounced on change.
-  // Cap at 200 messages and 8KB per text field. Storage is `~/.aethon/messages.json`
-  // via Tauri commands; the previous localStorage key is migrated on first read.
-  const PERSIST_FILE = "messages.json";
-  const LEGACY_LS_KEY = "aethon-messages";
-  const MAX_MESSAGES = 200;
-
-  // Restore on mount. First read disk; if empty, migrate any legacy
-  // localStorage value the first build wrote. Tracked as state (not a ref)
-  // so the persistence effect re-runs once restore completes — otherwise a
-  // message that arrived during the async read window would never trigger
-  // a disk write on a fresh install.
-  const [restored, setRestored] = useState(false);
-  useEffect(() => {
-    (async () => {
-      const raw = await readStateWithLocalStorageFallback(
-        PERSIST_FILE,
-        LEGACY_LS_KEY,
-      );
-      try {
-        if (raw) {
-          const parsed = JSON.parse(raw);
-          if (Array.isArray(parsed) && parsed.length > 0) {
-            // Restore into the default tab. Prepend before any messages
-            // that landed during the async read window (agent-stderr,
-            // an early send, …) and dedupe by id so a re-mount doesn't
-            // double up. Multi-tab persistence is per-default-tab only
-            // for now; per-tab restore is a follow-up.
-            setState((prev) => {
-              const tabs = ((prev.tabs as Tab[] | undefined) ?? []).slice();
-              const idx = tabs.findIndex((t) => t.id === "default");
-              if (idx < 0) return prev;
-              const live = tabs[idx].messages;
-              const seen = new Set(live.map((m) => m.id));
-              const merged = [
-                ...(parsed as ChatMessage[]).filter((m) => !seen.has(m.id)),
-                ...live,
-              ];
-              tabs[idx] = { ...tabs[idx], messages: merged };
-              const result: Record<string, unknown> = { ...prev, tabs };
-              if (prev.activeTabId === "default") result.messages = merged;
-              return result;
-            });
-          }
-        }
-      } catch {
-        /* corrupt — ignore */
-      } finally {
-        setRestored(true);
-      }
-    })();
-  }, []);
-
-  // Debounced write of the default tab's messages. Skipped until the
-  // initial restore completes so we don't overwrite the on-disk file
-  // with the empty boot state. Other tabs aren't persisted yet — they
-  // exist only for the lifetime of the app session.
-  const persistTimerRef = useRef<number | null>(null);
-  const defaultTabMessages = useMemo(() => {
-    const tabs = (state.tabs as Tab[] | undefined) ?? [];
-    return tabs.find((t) => t.id === "default")?.messages ?? [];
-  }, [state.tabs]);
-  useEffect(() => {
-    if (!restored) return;
-    if (persistTimerRef.current !== null) {
-      window.clearTimeout(persistTimerRef.current);
-    }
-    persistTimerRef.current = window.setTimeout(() => {
-      const slim = defaultTabMessages.slice(-MAX_MESSAGES).map(trimMessage);
-      writeState(PERSIST_FILE, JSON.stringify(slim)).catch(() => {
-        /* surfaced via console.warn in persist.ts */
-      });
-    }, 400);
-    return () => {
-      if (persistTimerRef.current !== null) {
-        window.clearTimeout(persistTimerRef.current);
-      }
-    };
-  }, [defaultTabMessages, restored]);
+  // Chat history is now persisted exclusively via pi's JSONL session files
+  // under $AETHON_SESSIONS_DIR/<tabId>/. On startup the bridge emits a
+  // `session_history` event for every tab (including "default") so all tabs
+  // use the same restore path — no separate messages.json needed.
 
   function clearChat() {
-    // Clear only the active tab's messages. Only flush the persisted
-    // history file when the active tab IS the default — non-default tabs
-    // aren't persisted, so writing `[]` here would wipe the saved
-    // default-tab history that's still showing under another tab.
-    const wasDefault =
-      (stateRef.current.activeTabId as string | undefined) === "default";
+    // Clears the active tab's in-memory message list. Pi's JSONL file is
+    // managed by the session itself; clearing chat here only affects the UI
+    // view for this session slot. The agent will continue writing new turns
+    // to the same session file, so a restart still sees prior history — this
+    // is intentional (Cmd+K is a "clean view" action, not a "delete history"
+    // action). If the user wants to start fresh, they open a new tab.
     updateActiveTab((tab) => ({ ...tab, messages: [] }));
-    if (wasDefault) {
-      writeState(PERSIST_FILE, "[]").catch(() => {
-        /* ignore */
-      });
-    }
   }
 
   function toggleTerminal() {
@@ -1492,12 +1436,13 @@ export default function App() {
       }, 5000);
     }
     // Inherit the previously-active tab's model so the picker stays
-    // consistent. Without this, the new tab's pi session would default
-    // to whatever ~/.pi/agent/settings.json declares — which is often
-    // outside the user's enabledModels glob and would leave the picker
-    // showing nothing highlighted.
-    const inheritedModel =
-      ((stateRef.current.model as string | undefined) ?? "").trim();
+    // consistent. Fall back to piDefaultModelRef (populated when `ready`
+    // fires) so tabs opened before ready still get a valid model, preventing
+    // the blank "model ▼" display seen when tab creation races agent startup.
+    const inheritedModel = (
+      (stateRef.current.model as string | undefined) ||
+      piDefaultModelRef.current
+    ).trim();
     setState((prev) => {
       const tabs = ((prev.tabs as Tab[] | undefined) ?? []).slice();
       // Use the restoreLabel when restoring a persisted session so the
@@ -3090,6 +3035,10 @@ export default function App() {
     switch (data.type) {
       case "ready": {
         const model = (data.model as string) || "";
+        // Cache pi's default model so new tabs created before `ready` fires
+        // (or before a session's model initialises) can inherit it immediately
+        // instead of showing blank "model ▼".
+        if (model) piDefaultModelRef.current = model;
         const models = (data.models as ModelDescriptor[]) ?? [];
         // Hydrate any extension-registered component templates the bridge
         // discovered at boot. setTemplates is wholesale (bridge is the
@@ -3256,6 +3205,13 @@ export default function App() {
             const dIdx = localTabs.findIndex((t) => t.id === "default");
             if (dIdx >= 0) {
               localTabs[dIdx] = { ...localTabs[dIdx], model };
+            }
+            // Backfill any tab that has no model yet (e.g. opened before
+            // ready fired) with pi's default so the picker is never blank.
+            for (let i = 0; i < localTabs.length; i++) {
+              if (!localTabs[i].model && model) {
+                localTabs[i] = { ...localTabs[i], model };
+              }
             }
             for (const bt of bridgeTabs) {
               if (bt.id === "default") continue;

--- a/src/skills/default-layout/components.tsx
+++ b/src/skills/default-layout/components.tsx
@@ -42,6 +42,7 @@ import type {
   A2UIEventHandler,
   BuiltinComponentProps,
 } from "../../components/A2UIRenderer";
+import { useStickyScroll } from "../../utils/useStickyScroll";
 
 // Adapter: react-markdown invokes `code` for both inline AND fenced code
 // blocks. We split on whether the parent is `<pre>` (fenced) and route
@@ -888,9 +889,39 @@ export function Sidebar({
 }
 
 // ---------------------------------------------------------------------------
-// ChatHistory — scrollable message feed. Messages can be plain text or
-// embedded A2UI subtrees (rendered recursively).
+// ScrollToBottomPill — shown when the user has scrolled up. Uses position:sticky
+// so it sits inside the scrollable flex container without absolute positioning.
 // ---------------------------------------------------------------------------
+
+function ScrollToBottomPill({
+  visible,
+  onClick,
+}: {
+  visible: boolean;
+  onClick: () => void;
+}) {
+  if (!visible) return null;
+  return (
+    <button
+      className="a2ui-scroll-to-bottom"
+      onClick={onClick}
+      aria-label="Scroll to latest message"
+    >
+      ↓ latest
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ChatHistory — scrollable message feed with sticky-follow auto-scroll.
+// Messages can be plain text or embedded A2UI subtrees (rendered recursively).
+// ---------------------------------------------------------------------------
+
+function roleBadge(role: string): string {
+  if (role === "user") return "YOU";
+  if (role === "agent") return "AI";
+  return "SYS";
+}
 
 export function ChatHistory({ component, state, tabId }: BuiltinComponentProps) {
   const props = component.props as {
@@ -899,49 +930,49 @@ export function ChatHistory({ component, state, tabId }: BuiltinComponentProps) 
   };
 
   const listRef = useRef<HTMLDivElement>(null);
+  const { isAtBottom, scrollToBottom, handleContentChanged } = useStickyScroll(listRef);
+
   const messages = (resolvePointer(state, props.messages.$ref) as ChatMessage[]) || [];
   const emptyHint = props.emptyHint
     ? resolveString(props.emptyHint, state)
-    : "Send a message to start a conversation.";
-  // M6 P6 search refinement: when reopening a tab from a search hit,
-  // scroll to the first message containing the matched substring
-  // instead of the bottom. Driven by `state.scrollToMatchByTab[tabId]`
-  // — App.tsx populates this from the search-hit click and clears it
-  // after one render so subsequent message arrivals scroll-to-bottom
-  // again as usual.
+    : "Start a conversation.";
+
+  // Search-hit restore: scroll to the matching message and flash it.
+  // Driven by `state.scrollToMatchByTab[tabId]` — App.tsx populates
+  // this on search-result click and clears it after 5 s.
   const scrollToMatchByTab =
     (state.scrollToMatchByTab as Record<string, string> | undefined) ?? {};
   const scrollToMatch = tabId ? scrollToMatchByTab[tabId] : undefined;
 
+  const prevScrollToMatch = useRef<string | undefined>(undefined);
   useEffect(() => {
     const el = listRef.current;
-    if (!el) return;
-    if (scrollToMatch && messages.length > 0) {
-      const needle = scrollToMatch.toLowerCase();
-      const idx = messages.findIndex((m) =>
-        (m.text ?? "").toLowerCase().includes(needle),
-      );
-      if (idx >= 0) {
-        const row = el.querySelectorAll(".a2ui-chat-message")[idx];
-        if (row instanceof HTMLElement) {
-          row.scrollIntoView({ block: "center", behavior: "auto" });
-          row.classList.add("a2ui-chat-message-flash");
-          window.setTimeout(
-            () => row.classList.remove("a2ui-chat-message-flash"),
-            1200,
-          );
-          return;
-        }
+    if (!el || !scrollToMatch || scrollToMatch === prevScrollToMatch.current) return;
+    prevScrollToMatch.current = scrollToMatch;
+    const needle = scrollToMatch.toLowerCase();
+    const idx = messages.findIndex((m) =>
+      (m.text ?? "").toLowerCase().includes(needle),
+    );
+    if (idx >= 0) {
+      const row = el.querySelectorAll(".a2ui-chat-message")[idx];
+      if (row instanceof HTMLElement) {
+        row.scrollIntoView({ block: "center", behavior: "auto" });
+        row.classList.add("a2ui-chat-message-flash");
+        window.setTimeout(() => row.classList.remove("a2ui-chat-message-flash"), 1200);
       }
     }
-    el.scrollTop = el.scrollHeight;
-    // `messages.length` + `scrollToMatch` capture the cases that should
-    // re-run scroll: a new message arrived OR a search hit just landed.
-    // The closure also reads each message's text inside `findIndex`,
-    // but adding `messages` to deps would re-fire on every text-stream
-    // chunk and yank the user back to the match every render.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [messages.length, scrollToMatch]);
+  }, [scrollToMatch]);
+
+  // Notify the sticky-scroll hook when new messages arrive so it can
+  // auto-scroll if the user is already at the bottom.
+  const prevLength = useRef(messages.length);
+  useEffect(() => {
+    if (messages.length !== prevLength.current) {
+      prevLength.current = messages.length;
+      handleContentChanged();
+    }
+  }, [messages.length, handleContentChanged]);
 
   return (
     <div className="a2ui-chat-history" ref={listRef}>
@@ -950,7 +981,7 @@ export function ChatHistory({ component, state, tabId }: BuiltinComponentProps) 
       ) : (
         messages.map((m) => (
           <div key={m.id} className={`a2ui-chat-message ${m.role}`}>
-            <span className="a2ui-chat-role">{m.role}</span>
+            <span className="a2ui-chat-role">{roleBadge(m.role)}</span>
             {m.text && (
               <div className="a2ui-chat-text a2ui-markdown">
                 <ReactMarkdown components={MARKDOWN_COMPONENTS}>{m.text}</ReactMarkdown>
@@ -962,6 +993,7 @@ export function ChatHistory({ component, state, tabId }: BuiltinComponentProps) 
           </div>
         ))
       )}
+      <ScrollToBottomPill visible={!isAtBottom && messages.length > 0} onClick={scrollToBottom} />
     </div>
   );
 }
@@ -996,10 +1028,17 @@ export function MainCanvas({ component, state, tabId }: BuiltinComponentProps) {
     : "The agent's canvas is empty. Send a message to populate it.";
 
   const listRef = useRef<HTMLDivElement>(null);
+  const { isAtBottom, scrollToBottom, handleContentChanged } = useStickyScroll(listRef);
+
+  const prevLength = useRef(messages.length);
+  const prevLive = useRef(liveSubtree);
   useEffect(() => {
-    const el = listRef.current;
-    if (el) el.scrollTop = el.scrollHeight;
-  }, [messages.length, liveSubtree]);
+    const lengthChanged = messages.length !== prevLength.current;
+    const liveChanged = liveSubtree !== prevLive.current;
+    prevLength.current = messages.length;
+    prevLive.current = liveSubtree;
+    if (lengthChanged || liveChanged) handleContentChanged();
+  }, [messages.length, liveSubtree, handleContentChanged]);
 
   return (
     <main className="a2ui-canvas" ref={listRef}>
@@ -1008,7 +1047,7 @@ export function MainCanvas({ component, state, tabId }: BuiltinComponentProps) {
       )}
       {messages.map((m) => (
         <div key={m.id} className={`a2ui-canvas-message ${m.role}`}>
-          <span className="a2ui-canvas-role">{m.role}</span>
+          <span className="a2ui-canvas-role">{roleBadge(m.role)}</span>
           {m.text && (
             <div className="a2ui-canvas-text a2ui-markdown">
               <ReactMarkdown>{m.text}</ReactMarkdown>
@@ -1022,6 +1061,7 @@ export function MainCanvas({ component, state, tabId }: BuiltinComponentProps) {
           <A2UIRenderer payload={liveSubtree} state={state} tabId={tabId} />
         </div>
       )}
+      <ScrollToBottomPill visible={!isAtBottom && (messages.length > 0 || !!liveSubtree)} onClick={scrollToBottom} />
     </main>
   );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1494,38 +1494,51 @@ body.ae-resizing-sidebar * {
   min-width: 0;
   min-height: 0;
   overflow-y: auto;
-  padding: 12px;
-  gap: 8px;
+  padding: 16px 12px 12px;
+  gap: 10px;
+  contain: layout style;
 }
 
+/* Base bubble — shared by all roles. */
 .a2ui-chat-message {
-  padding: 8px 12px;
-  border-radius: 10px;
-  border: 1px solid var(--border);
+  padding: 10px 14px;
   font-size: var(--text-sm);
   min-width: 0;
+  max-width: 88%;
+  line-height: 1.55;
+  position: relative;
 }
 
+/* User messages: right-aligned bubble with a flat bottom-right corner
+   (standard chat convention), pushed to the right. */
 .a2ui-chat-message.user {
   background: var(--user-bubble);
+  border: 1px solid var(--border);
+  border-radius: 14px 14px 4px 14px;
+  align-self: flex-end;
+  margin-left: 12%;
 }
 
+/* Agent messages: left-aligned, borderless — the background colour
+   provides enough separation without border noise. */
 .a2ui-chat-message.agent {
   background: var(--agent-bubble);
+  border: 1px solid transparent;
+  border-radius: 4px 14px 14px 14px;
+  align-self: flex-start;
+  margin-right: 4%;
 }
 
-/* System bubbles surface bridge stderr / lifecycle notices. They're
-   not conversation, so they shouldn't compete with user / agent
-   bubbles for attention — strip the chrome down to a faint inline
-   note, monospace for log readability, and let the role label do
-   double duty as the visual cue. */
+/* System bubbles: faint log-line style — not part of the conversation. */
 .a2ui-chat-message.system {
   background: transparent;
   border: 0;
-  padding: 2px 0 4px;
+  padding: 2px 4px;
   font-size: var(--text-xs);
   color: var(--text-dim);
-  opacity: 0.75;
+  opacity: 0.7;
+  align-self: center;
+  max-width: 100%;
 }
 
 .a2ui-chat-message.system .a2ui-chat-text {
@@ -1539,13 +1552,19 @@ body.ae-resizing-sidebar * {
   display: none;
 }
 
+/* Role badge — small pill above the bubble content. */
 .a2ui-chat-role {
-  display: block;
+  display: inline-block;
   font-size: var(--chrome-text-muted);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: var(--accent);
+  margin-bottom: 5px;
+  opacity: 0.75;
+}
+
+.a2ui-chat-message.user .a2ui-chat-role {
   color: var(--text-dim);
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  margin-bottom: 2px;
 }
 
 .a2ui-chat-empty {
@@ -1553,6 +1572,45 @@ body.ae-resizing-sidebar * {
   text-align: center;
   font-size: var(--text-sm);
   margin: auto;
+  opacity: 0.6;
+  line-height: 1.6;
+}
+
+/* Scroll-to-bottom pill — uses position:sticky so it floats at the bottom
+   of the flex container without needing absolute/fixed positioning. */
+.a2ui-scroll-to-bottom {
+  position: sticky;
+  bottom: 10px;
+  align-self: center;
+  background: var(--accent);
+  color: var(--btn-text, var(--bg));
+  border: none;
+  border-radius: 20px;
+  padding: 5px 16px;
+  font-size: var(--text-xs);
+  font-weight: 600;
+  font-family: var(--font-ui);
+  cursor: pointer;
+  z-index: 10;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.35);
+  animation: a2ui-pill-in 0.15s ease both;
+  flex-shrink: 0;
+  margin-top: 4px;
+}
+
+.a2ui-scroll-to-bottom:hover {
+  filter: brightness(1.1);
+}
+
+@keyframes a2ui-pill-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 /* ---- Chat input --------------------------------------------------------- */
@@ -1560,8 +1618,9 @@ body.ae-resizing-sidebar * {
 .a2ui-chat-input {
   display: flex;
   gap: 8px;
-  padding: 10px 16px;
-  border-top: 1px solid var(--border);
+  padding: 10px 14px 12px;
+  border-top: none;
+  box-shadow: 0 -1px 0 var(--border), 0 -4px 12px rgba(0, 0, 0, 0.12);
   background: var(--bg-elev);
   width: 100%;
   align-items: stretch;
@@ -1643,11 +1702,12 @@ body.ae-resizing-sidebar * {
   background: var(--bg-input);
   color: var(--text);
   border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 10px 12px;
+  border-radius: 10px;
+  padding: 10px 14px;
   font: inherit;
   outline: none;
-  min-height: 44px;
+  min-height: 46px;
+  line-height: 1.5;
   transition:
     border-color 120ms ease,
     box-shadow 120ms ease;

--- a/src/utils/useStickyScroll.ts
+++ b/src/utils/useStickyScroll.ts
@@ -1,0 +1,97 @@
+import {
+  type RefObject,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+
+/** Distance from the bottom (px) within which we consider the user "at bottom". */
+const BOTTOM_THRESHOLD = 60;
+
+/**
+ * Sticky-follow scroll for chat windows.
+ *
+ * When the user is at (or near) the bottom, new content auto-scrolls the
+ * container to keep up. Scrolling up breaks auto-follow. Clicking the returned
+ * `scrollToBottom` re-enables it. Works with streaming content via
+ * `handleContentChanged` — call it whenever content updates asynchronously so
+ * the hook can scroll without waiting for a React render cycle.
+ *
+ * Uses a `programmaticRef` flag to distinguish auto-scrolls from user scrolls
+ * so the scroll listener doesn't incorrectly detect our own scrolls as a
+ * user-initiated "scroll away". A `requestAnimationFrame` coalescor prevents
+ * stacked scroll calls during streaming bursts.
+ */
+export function useStickyScroll(containerRef: RefObject<HTMLDivElement | null>) {
+  const [isAtBottom, setIsAtBottom] = useState(true);
+  // Set before any programmatic scroll so the scroll listener knows to ignore it.
+  const programmaticRef = useRef(false);
+  const rafRef = useRef<number | null>(null);
+
+  const checkAndMaybeScroll = useCallback(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const atBottom =
+      el.scrollTop + el.clientHeight >= el.scrollHeight - BOTTOM_THRESHOLD;
+    if (atBottom) {
+      programmaticRef.current = true;
+      el.scrollTop = el.scrollHeight;
+      setIsAtBottom(true);
+    } else {
+      setIsAtBottom(false);
+    }
+  }, [containerRef]);
+
+  /** Call when async content changes (streaming tokens, new messages, etc.). */
+  const handleContentChanged = useCallback(() => {
+    if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+    rafRef.current = requestAnimationFrame(() => {
+      rafRef.current = null;
+      checkAndMaybeScroll();
+    });
+  }, [checkAndMaybeScroll]);
+
+  /** Snap to bottom and re-enable auto-follow. */
+  const scrollToBottom = useCallback(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    programmaticRef.current = true;
+    el.scrollTop = el.scrollHeight;
+    setIsAtBottom(true);
+  }, [containerRef]);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    const onScroll = () => {
+      // Ignore scrolls we triggered ourselves.
+      if (programmaticRef.current) {
+        programmaticRef.current = false;
+        return;
+      }
+      const atBottom =
+        el.scrollTop + el.clientHeight >= el.scrollHeight - BOTTOM_THRESHOLD;
+      setIsAtBottom(atBottom);
+    };
+
+    // ResizeObserver: catches panel resize, window resize, font-size changes.
+    const ro = new ResizeObserver(handleContentChanged);
+    // MutationObserver: catches new message nodes, streaming text, tool-card expansion.
+    const mo = new MutationObserver(handleContentChanged);
+
+    el.addEventListener("scroll", onScroll, { passive: true });
+    ro.observe(el);
+    mo.observe(el, { childList: true, subtree: true, characterData: true });
+
+    return () => {
+      el.removeEventListener("scroll", onScroll);
+      ro.disconnect();
+      mo.disconnect();
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+    };
+  }, [containerRef, handleContentChanged]);
+
+  return { isAtBottom, scrollToBottom, handleContentChanged };
+}


### PR DESCRIPTION
## Summary

- **Session history unified**: Drop `messages.json` for the default tab. Bridge now emits `session_history` for it at startup via pi JSONL — all tabs use the same IPC path. Pi is the single source of truth.
- **Better session labels**: `session-history.ts` extracts `firstUserMessage` from JSONL; sidebar history now shows the first user turn (≤60 chars) instead of UUID slices.
- **Model default fix**: `piDefaultModelRef` caches the model from the `ready` event; new tabs inherit it via `inheritedModel` fallback; tabs opened before `ready` fires are backfilled.
- **Sticky scroll (`useStickyScroll` hook)**: RAF-coalesced MutationObserver + ResizeObserver replaces imperative `scrollTop` on length change. Respects user scroll intent via `programmaticRef`. `ScrollToBottomPill` (position:sticky) appears when not at bottom, disappears on click.
- **UI polish**: chat-bubble border-radius, YOU/AI/SYS role badge pills, input shadow separator, `contain: layout style` on scroll containers.
- **`cargo clean` devshell command**: passes `--manifest-path src-tauri/Cargo.toml` so it works from repo root.
- **aethon-debug skill**: `debug-eval.sh` auto-starts the dev build when not running; `debug-screenshot.sh` uses PID-bound focus via debug-eval before capture.

## Test plan

- [x] 208/208 vitest tests pass
- [x] `tsc --noEmit` clean
- [x] `eslint .` clean
- [x] UAT: model correctly shown in new tab (GPT-5.5, not empty)
- [x] UAT: scroll pill appears when scrolled up, disappears on click
- [x] UAT: session history labels show first user message text
- [x] UAT: default tab messages restored from pi JSONL (not messages.json)