### PR TITLE
fix(safety): extension runtime safety — size guard, hang escape, menu/scroll/delete fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,6 +237,36 @@ controlled by the `/agentTabActive` / `/shellTabActive` `$ref` visibility
 flags in `workstation.a2ui.json`. Keybindings: `Cmd+T` = new agent tab (focus-aware — new shell sub-tab when
 focus is inside the bottom panel), `Cmd+Shift+T` = new shell sub-tab (always).
 
+### Slash commands (client-side)
+
+`src/slashCommands.ts` registers frontend-only slash commands that run
+without an LLM round-trip (e.g. `/clear`, `/theme`, `/extensions`). They
+receive a `SlashCommandContext` with `appendSystem`, `notify`, `clearChat`,
+`setTheme`, etc. These are distinct from pi's server-side slash commands
+(extension/skill-registered, dispatched through the bridge) — pi's
+`getCommands()`/handler API is not yet plumbed through. When adding a purely
+UI action, prefer the client-side registry; only go through the bridge when
+the agent needs to observe or act on the command.
+
+### Extension frontend loading
+
+Extensions can ship React components by setting `aethon.frontendEntry` in
+their `package.json` to a relative JS file path. The bridge reads that file
+and sends its contents as a string in `extension_frontend_modules` events.
+`src/skills/extensionFrontendLoader.ts` receives these events, wraps each
+body in `new Function("React", "skill", code)`, and calls the result with
+`React` + a `{ registerComponent(type, fn) }` API object. Components
+registered this way land in the `SkillRegistry` and are resolved alongside
+built-in skill components. A delta payload replaces the full previous set —
+re-evaluated modules hot-swap their components; removed modules unregister
+theirs. The trust model is identical to bridge-side extension code (user
+installed it, no sandbox).
+
+`SkillRegistry` also has a `.registerTemplate(type, payload)` path for
+declarative A2UI subtree templates — used when an extension provides a
+component as an A2UI JSON fragment rather than a React function. The
+renderer prefers React components when both exist for the same type.
+
 ### Command palette
 
 `Cmd+P` opens the switcher (tabs / sessions / projects / layouts /
@@ -445,6 +475,24 @@ the built-in catalogue today; extensions can register more via
 returns `Promise<MutationResult>`), command palette (Cmd+P switcher /
 Cmd+Shift+P commands), v0.2.0 GitHub release with macOS .dmg + Linux
 .deb/AppImage + Windows NSIS bundles via Nix overlay.
+
+## State persistence
+
+`src/persist.ts` is the disk I/O layer for frontend state. It wraps Tauri
+`read_state` / `write_state` commands with a graceful no-op fallback when
+running outside Tauri (unit tests, plain browser). One-time migration: on
+first read it checks `localStorage` for the same key so users upgrading from
+the pre-Tauri build keep their history. All tab/canvas state serialisation
+goes through here; don't invoke Tauri storage commands directly from
+components.
+
+## Releases
+
+See `RELEASING.md` for the full release workflow: keypair generation,
+wiring the public key into `tauri.conf.json`, CI secrets, and how to cut a
+tag. Summary: push a `v*.*.*` tag → GitHub Actions builds signed macOS DMGs,
+Linux `.deb`/`.rpm`, and Windows NSIS, uploads `latest.json` for the
+in-app updater.
 
 ## Test coverage + linting
 

--- a/agent/main.ts
+++ b/agent/main.ts
@@ -225,6 +225,11 @@ export interface MutationResult {
   data?: unknown;
 }
 const MUTATION_ACK_TIMEOUT_MS = 5_000;
+// setState size guards. Extensions writing large blobs (e.g. base64 images)
+// to state can block the stdout pipe and freeze the event loop. Warn at 64 KB
+// so authors notice; reject hard at 512 KB so the bridge never stalls.
+const STATE_PAYLOAD_WARN_BYTES = 64 * 1024;   // 64 KB — log WARN
+const STATE_PAYLOAD_HARD_BYTES = 512 * 1024;  // 512 KB — reject
 let _mutationCounter = 0;
 function nextMutationId(): string {
   _mutationCounter += 1;
@@ -462,6 +467,17 @@ interface AethonExtensionApi {
 // teardowns fire when the active project changes; user-level (or out-of-
 // register()) teardowns persist for the lifetime of the bridge.
 let currentExtensionLoadScope: "user" | "project" | null = null;
+// Display name of the extension whose register() is currently on the stack.
+// Set for the duration of register() — same lifetime as currentExtensionLoadScope.
+// Used by _setState's size guard so the WARN names the offending extension.
+let currentExtensionName: string | null = null;
+// Scoped logger for LLM turn lifecycle. Fills the silent gap between user
+// message and LLM response — exactly the window where hangs are hardest to
+// diagnose.
+const turnLog = logger.scope("turn");
+// Per-tab wall-clock turn start times. Set in agent_start, consumed in
+// agent_end to compute durationMs.
+const turnStartTimes = new Map<string, number>();
 const projectExtensionTeardowns: Array<() => void | Promise<void>> = [];
 const userExtensionTeardowns: Array<() => void | Promise<void>> = [];
 
@@ -956,11 +972,14 @@ async function loadAethonExtensionDirectory(
       // calls bind to the right teardown bucket. Project-directory
       // teardowns fire on project switch; user-level teardowns persist.
       const prevScope = currentExtensionLoadScope;
+      const prevExtName = currentExtensionName;
       currentExtensionLoadScope = options.source === "project-directory" ? "project" : "user";
+      currentExtensionName = displayName;
       try {
         await register(api);
       } finally {
         currentExtensionLoadScope = prevScope;
+        currentExtensionName = prevExtName;
       }
       options.loadedFiles?.add(file);
       registry.set(displayName, options.source);
@@ -1947,6 +1966,36 @@ async function main() {
   ): Promise<MutationResult> {
     if (!path || typeof path !== "string") {
       return Promise.resolve({ ok: false, error: "path required" });
+    }
+    // Size guard: measure the serialized payload before it hits stdout.
+    // A 180 MB write blocks the Node event loop (pipe backpressure) and
+    // prevents the bridge from processing LLM responses or stdin commands.
+    {
+      const extStateLog = logger.scope("ext-state");
+      let serialized: string | undefined;
+      try {
+        serialized = JSON.stringify(value);
+      } catch {
+        // Non-serializable values will fail naturally in send() below.
+      }
+      if (serialized !== undefined) {
+        const bytes = Buffer.byteLength(serialized, "utf8");
+        const who = currentExtensionName ? ` (${currentExtensionName})` : "";
+        if (bytes > STATE_PAYLOAD_HARD_BYTES) {
+          const kb = Math.round(bytes / 1024);
+          extStateLog.warn(
+            `setState rejected: path=${path} size=${kb}KB exceeds 512KB limit${who} — store file paths, not content`,
+          );
+          return Promise.resolve({
+            ok: false,
+            error: "payload exceeds 512 KB limit — store file paths, not content",
+          });
+        }
+        if (bytes > STATE_PAYLOAD_WARN_BYTES) {
+          const kb = Math.round(bytes / 1024);
+          extStateLog.warn(`setState large payload: path=${path} size=${kb}KB${who}`);
+        }
+      }
     }
     // tabId attribution priority:
     //   1. explicit sourceTabId (handler-scoped ctx.setState)
@@ -2974,6 +3023,20 @@ async function main() {
         name: m.name,
         code: m.code,
       })),
+      // Full extensions list for the sidebar display. Mirrors what
+      // getRuntimeSnapshot() exposes to the agent, but sent on every ready
+      // so the frontend can hydrate /sidebar/extensions without reading the
+      // state file.
+      extensionsList: [...loadedExtensions.entries()].map(([name, source]) => ({
+        name,
+        source,
+      })),
+      failedExtensionsList: [...loadFailures.entries()].map(([name, info]) => ({
+        name,
+        source: info.source,
+        error: info.error,
+        ...(info.path ? { path: info.path } : {}),
+      })),
       discoveredTabs,
     });
   }
@@ -3127,6 +3190,8 @@ async function main() {
           // set currentAgentTabId so any setStates the agent triggers
           // route correctly. Cleared in agent_end below.
           currentAgentTabId = tabId;
+          turnStartTimes.set(tabId, Date.now());
+          turnLog.info(`start model=${session.model ? modelKey(session.model) : "unknown"} tabId=${tabId}`);
           if (rec.queuedCount > 0) {
             rec.queuedCount -= 1;
             // The previous agent_end cleared promptInFlight, but pi has
@@ -3231,6 +3296,21 @@ async function main() {
           const failedMessage = extractAgentEndError(event.messages);
           if (failedMessage) {
             send({ type: "error", tabId, message: failedMessage });
+          }
+          {
+            const startMs = turnStartTimes.get(tabId);
+            turnStartTimes.delete(tabId);
+            const durationMs = startMs !== undefined ? Date.now() - startMs : -1;
+            const modelStr = session.model ? modelKey(session.model) : "unknown";
+            const lastAssistant = [...(event.messages ?? [])].reverse().find(
+              (m) => (m as { role?: string }).role === "assistant",
+            ) as { stopReason?: string } | undefined;
+            const reason = lastAssistant?.stopReason ?? "unknown";
+            if (reason === "error") {
+              turnLog.warn(`end model=${modelStr} tabId=${tabId} durationMs=${durationMs} stopReason=${reason}`);
+            } else {
+              turnLog.info(`end model=${modelStr} tabId=${tabId} durationMs=${durationMs} stopReason=${reason}`);
+            }
           }
           rec.agentEndFired = true;
           rec.promptInFlight = false;

--- a/agent/main.ts
+++ b/agent/main.ts
@@ -228,8 +228,33 @@ const MUTATION_ACK_TIMEOUT_MS = 5_000;
 // setState size guards. Extensions writing large blobs (e.g. base64 images)
 // to state can block the stdout pipe and freeze the event loop. Warn at 64 KB
 // so authors notice; reject hard at 512 KB so the bridge never stalls.
-const STATE_PAYLOAD_WARN_BYTES = 64 * 1024;   // 64 KB — log WARN
-const STATE_PAYLOAD_HARD_BYTES = 512 * 1024;  // 512 KB — reject
+// Defaults if unset / unparseable. Overrides come from
+// `AETHON_STATE_WARN_KB` / `AETHON_STATE_HARD_KB`, which the Rust shell
+// derives from `[extensions]` in `~/.aethon/config.toml`. The shell
+// already clamps user input; we re-resolve here for defence-in-depth.
+import {
+  resolveStateLimits,
+  makeExtStateLogLimiter,
+} from "./state-limits";
+const { warnKb: STATE_WARN_KB, hardKb: STATE_HARD_KB } = resolveStateLimits(
+  process.env.AETHON_STATE_WARN_KB,
+  process.env.AETHON_STATE_HARD_KB,
+);
+const STATE_PAYLOAD_WARN_BYTES = STATE_WARN_KB * 1024;
+const STATE_PAYLOAD_HARD_BYTES = STATE_HARD_KB * 1024;
+// Misbehaving extensions can hit the size guard on a setInterval, so we
+// rate-limit per (kind, extension, path) — first occurrence logs in full,
+// repeats within the window are counted and folded into the next log line.
+const EXT_STATE_LOG_WINDOW_MS = 60_000;
+const extStateLogLimiter = makeExtStateLogLimiter(EXT_STATE_LOG_WINDOW_MS);
+function shouldLogExtStateRejection(key: string): { log: boolean; suppressed: number } {
+  return extStateLogLimiter.shouldLog(key);
+}
+// Per-path attribution: setInterval-driven setState calls run *after*
+// register() returns, so currentExtensionName has already reset to null.
+// We remember the last extension we saw write to each path so async
+// callbacks still get attributed to the right extension.
+const extPathOwners = new Map<string, string>();
 let _mutationCounter = 0;
 function nextMutationId(): string {
   _mutationCounter += 1;
@@ -1980,20 +2005,44 @@ async function main() {
       }
       if (serialized !== undefined) {
         const bytes = Buffer.byteLength(serialized, "utf8");
-        const who = currentExtensionName ? ` (${currentExtensionName})` : "";
+        if (currentExtensionName) extPathOwners.set(path, currentExtensionName);
+        const attributed = currentExtensionName ?? extPathOwners.get(path) ?? null;
+        const who = attributed ? ` (${attributed})` : "";
+        const ext = attributed ?? "?";
         if (bytes > STATE_PAYLOAD_HARD_BYTES) {
           const kb = Math.round(bytes / 1024);
-          extStateLog.warn(
-            `setState rejected: path=${path} size=${kb}KB exceeds 512KB limit${who} — store file paths, not content`,
-          );
+          const decision = shouldLogExtStateRejection(`reject|${ext}|${path}`);
+          if (decision.log) {
+            const tail =
+              decision.suppressed > 0 ? ` (+${decision.suppressed} suppressed in last ${EXT_STATE_LOG_WINDOW_MS / 1000}s)` : "";
+            extStateLog.warn(
+              `setState rejected: path=${path} size=${kb}KB exceeds ${STATE_HARD_KB}KB limit${who}${tail} — store file paths, not content`,
+            );
+            // User-visible signal — frontend pushes a deduped notification per
+            // extension so the user knows an extension is misbehaving even
+            // though the failure was silenced from chat.
+            send({
+              type: "extension_runtime_error",
+              name: attributed,
+              kind: "state-too-large",
+              path,
+              sizeKB: kb,
+              limitKB: STATE_HARD_KB,
+            });
+          }
           return Promise.resolve({
             ok: false,
-            error: "payload exceeds 512 KB limit — store file paths, not content",
+            error: `payload exceeds ${STATE_HARD_KB} KB limit — store file paths, not content`,
           });
         }
         if (bytes > STATE_PAYLOAD_WARN_BYTES) {
           const kb = Math.round(bytes / 1024);
-          extStateLog.warn(`setState large payload: path=${path} size=${kb}KB${who}`);
+          const decision = shouldLogExtStateRejection(`large|${ext}|${path}`);
+          if (decision.log) {
+            const tail =
+              decision.suppressed > 0 ? ` (+${decision.suppressed} suppressed in last ${EXT_STATE_LOG_WINDOW_MS / 1000}s)` : "";
+            extStateLog.warn(`setState large payload: path=${path} size=${kb}KB${who}${tail}`);
+          }
         }
       }
     }

--- a/agent/state-limits.test.ts
+++ b/agent/state-limits.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import {
+  STATE_PAYLOAD_HARD_KB_DEFAULT,
+  STATE_PAYLOAD_LIMIT_MAX_KB,
+  STATE_PAYLOAD_WARN_KB_DEFAULT,
+  makeExtStateLogLimiter,
+  readKbEnv,
+  resolveStateLimits,
+} from "./state-limits";
+
+describe("readKbEnv", () => {
+  it("returns fallback when env var is undefined", () => {
+    expect(readKbEnv(undefined, 64)).toBe(64);
+  });
+
+  it("returns fallback when env var is empty", () => {
+    expect(readKbEnv("", 64)).toBe(64);
+  });
+
+  it("returns fallback for non-numeric input — better than crashing on a typo", () => {
+    expect(readKbEnv("notanumber", 64)).toBe(64);
+  });
+
+  it("returns fallback for zero or negative — these aren't meaningful thresholds", () => {
+    expect(readKbEnv("0", 64)).toBe(64);
+    expect(readKbEnv("-100", 64)).toBe(64);
+  });
+
+  it("clamps absurdly large values to the bridge ceiling", () => {
+    expect(readKbEnv("999999", 64)).toBe(STATE_PAYLOAD_LIMIT_MAX_KB);
+  });
+
+  it("passes valid integers through unchanged", () => {
+    expect(readKbEnv("128", 64)).toBe(128);
+    expect(readKbEnv("1024", 64)).toBe(1024);
+  });
+});
+
+describe("resolveStateLimits", () => {
+  it("uses defaults when both env vars are absent", () => {
+    const { warnKb, hardKb } = resolveStateLimits(undefined, undefined);
+    expect(warnKb).toBe(STATE_PAYLOAD_WARN_KB_DEFAULT);
+    expect(hardKb).toBe(STATE_PAYLOAD_HARD_KB_DEFAULT);
+  });
+
+  it("respects explicit overrides", () => {
+    const { warnKb, hardKb } = resolveStateLimits("32", "256");
+    expect(warnKb).toBe(32);
+    expect(hardKb).toBe(256);
+  });
+
+  it("raises hard up to warn so WARN tier remains reachable", () => {
+    // If a user inverts the pair (hard < warn), every WARN-tier write
+    // would hit the HARD reject first — making the WARN log dead code.
+    // Resolve by raising hard to warn, keeping warn unchanged.
+    const { warnKb, hardKb } = resolveStateLimits("200", "100");
+    expect(warnKb).toBe(200);
+    expect(hardKb).toBe(200);
+  });
+
+  it("clamps absurdly large hard value to the bridge ceiling", () => {
+    const { warnKb, hardKb } = resolveStateLimits("32", "999999");
+    expect(warnKb).toBe(32);
+    expect(hardKb).toBe(STATE_PAYLOAD_LIMIT_MAX_KB);
+  });
+
+  it("treats env var '0' as invalid → falls back to default (not 0KB which would reject every write)", () => {
+    // The Rust-side resolver clamps 0 up to 1 when it appears in
+    // config.toml, but as an env var '0' likely means a typo or a
+    // deliberate "unset" gesture. Treat as fallback so the bridge
+    // still has a working guard rather than rejecting every setState.
+    const { warnKb, hardKb } = resolveStateLimits("0", "0");
+    expect(warnKb).toBeGreaterThan(0);
+    expect(hardKb).toBeGreaterThan(0);
+  });
+});
+
+describe("makeExtStateLogLimiter", () => {
+  it("logs the first occurrence", () => {
+    const limiter = makeExtStateLogLimiter(60_000, () => 1000);
+    const result = limiter.shouldLog("k1");
+    expect(result.log).toBe(true);
+    expect(result.suppressed).toBe(0);
+  });
+
+  it("suppresses repeats within the window", () => {
+    let now = 1000;
+    const limiter = makeExtStateLogLimiter(60_000, () => now);
+    expect(limiter.shouldLog("k1").log).toBe(true);
+    now = 30_000;
+    expect(limiter.shouldLog("k1").log).toBe(false);
+    expect(limiter.shouldLog("k1").log).toBe(false);
+  });
+
+  it("emits a count of suppressed entries when the window expires", () => {
+    let now = 1000;
+    const limiter = makeExtStateLogLimiter(60_000, () => now);
+    expect(limiter.shouldLog("k1").log).toBe(true);
+    // Three repeats inside the window — all suppressed, none logged.
+    now = 10_000;
+    limiter.shouldLog("k1");
+    limiter.shouldLog("k1");
+    limiter.shouldLog("k1");
+    // Window expires; next log should report the suppressed count.
+    now = 65_000;
+    const result = limiter.shouldLog("k1");
+    expect(result.log).toBe(true);
+    expect(result.suppressed).toBe(3);
+  });
+
+  it("tracks separate keys independently", () => {
+    const now = 1000;
+    const limiter = makeExtStateLogLimiter(60_000, () => now);
+    expect(limiter.shouldLog("a").log).toBe(true);
+    // 'b' has never logged; should still get its first entry through.
+    expect(limiter.shouldLog("b").log).toBe(true);
+    // 'a' is in its window; stay suppressed.
+    expect(limiter.shouldLog("a").log).toBe(false);
+  });
+
+  it("starts a fresh window after a log fires", () => {
+    let now = 1000;
+    const limiter = makeExtStateLogLimiter(60_000, () => now);
+    limiter.shouldLog("k"); // first
+    now = 65_000;
+    limiter.shouldLog("k"); // second log — window resets here
+    now = 70_000;
+    // Still inside the second window — should suppress.
+    expect(limiter.shouldLog("k").log).toBe(false);
+  });
+});

--- a/agent/state-limits.ts
+++ b/agent/state-limits.ts
@@ -1,0 +1,74 @@
+/**
+ * State-payload size guard helpers — extracted from main.ts so the
+ * env-var parsing and per-(extension, path) rate limiter can be unit
+ * tested without booting the full bridge.
+ *
+ * Mirrors the Rust-side `resolve_ext_state_limits` in
+ * `src-tauri/src/helpers.rs` — the shell side already clamps user input
+ * before we see it, but we re-clamp here in case a user pokes the env
+ * var directly. The two implementations must agree on:
+ *   1. defaults (64 / 512 KB)
+ *   2. min / max bounds (1 / 8192 KB)
+ *   3. the "raise hard up to warn" normalization
+ */
+
+export const STATE_PAYLOAD_LIMIT_MIN_KB = 1;
+export const STATE_PAYLOAD_LIMIT_MAX_KB = 8 * 1024;
+export const STATE_PAYLOAD_WARN_KB_DEFAULT = 64;
+export const STATE_PAYLOAD_HARD_KB_DEFAULT = 512;
+
+/** Parse a positive integer from an env var, clamped to bridge bounds. */
+export function readKbEnv(
+  raw: string | undefined,
+  fallback: number,
+): number {
+  if (!raw) return fallback;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n <= 0) return fallback;
+  return Math.min(STATE_PAYLOAD_LIMIT_MAX_KB, Math.max(STATE_PAYLOAD_LIMIT_MIN_KB, n));
+}
+
+/**
+ * Resolve the (warn, hard) pair the bridge will use. Applies defaults
+ * for missing values, clamps each, then guarantees `warn <= hard` by
+ * raising hard up to warn — otherwise the WARN tier could never fire.
+ */
+export function resolveStateLimits(
+  warnRaw: string | undefined,
+  hardRaw: string | undefined,
+): { warnKb: number; hardKb: number } {
+  const warnKb = readKbEnv(warnRaw, STATE_PAYLOAD_WARN_KB_DEFAULT);
+  const hardKbRaw = readKbEnv(hardRaw, STATE_PAYLOAD_HARD_KB_DEFAULT);
+  const hardKb = Math.max(warnKb, hardKbRaw);
+  return { warnKb, hardKb };
+}
+
+/**
+ * Per-(kind, extension, path) rate limiter for ext-state log lines.
+ * First occurrence in a window logs immediately. Repeats within the
+ * window are counted and folded into the next log line as a "+N
+ * suppressed" suffix once the window expires.
+ */
+export interface RateLimiter {
+  shouldLog(key: string): { log: boolean; suppressed: number };
+}
+
+export function makeExtStateLogLimiter(
+  windowMs: number,
+  now: () => number = Date.now,
+): RateLimiter {
+  const state = new Map<string, { lastAt: number; suppressed: number }>();
+  return {
+    shouldLog(key: string) {
+      const t = now();
+      const entry = state.get(key);
+      if (!entry || t - entry.lastAt >= windowMs) {
+        const suppressed = entry?.suppressed ?? 0;
+        state.set(key, { lastAt: t, suppressed: 0 });
+        return { log: true, suppressed };
+      }
+      entry.suppressed += 1;
+      return { log: false, suppressed: 0 };
+    },
+  };
+}

--- a/src-tauri/src/helpers.rs
+++ b/src-tauri/src/helpers.rs
@@ -91,6 +91,21 @@ pub struct ShortcutsConfig {
 }
 
 #[derive(Default, Deserialize)]
+pub struct ExtensionsConfig {
+    /// Soft warning threshold (KB) for an extension's `setState` payload.
+    /// Above this, the bridge logs a WARN naming the extension and path.
+    /// Default 64. Range clamped to [1, EXT_STATE_MAX_KB].
+    pub state_warn_kb: Option<u32>,
+    /// Hard rejection threshold (KB) for an extension's `setState`
+    /// payload. Above this the write is rejected before it hits stdout
+    /// and the extension's mutation Promise resolves to
+    /// `{ ok:false, error }`. Default 512. Range clamped to
+    /// [1, EXT_STATE_MAX_KB]. The cap exists because a single very
+    /// large stdout write can block the bridge's Node event loop.
+    pub state_hard_kb: Option<u32>,
+}
+
+#[derive(Default, Deserialize)]
 pub struct AethonConfig {
     #[serde(default)]
     pub ui: UiConfig,
@@ -100,6 +115,8 @@ pub struct AethonConfig {
     pub shell: ShellConfig,
     #[serde(default)]
     pub shortcuts: ShortcutsConfig,
+    #[serde(default)]
+    pub extensions: ExtensionsConfig,
 }
 
 /// Validate-and-normalize the configured default share mode. Unknown
@@ -126,6 +143,27 @@ pub fn normalize_new_tab_kind(input: Option<&str>) -> &'static str {
     }
 }
 
+/// Hard ceiling on the configurable state-payload limits (KB). The bridge
+/// writes setState payloads to stdout; a single very large write can block
+/// the Node event loop. 8 MiB is well above any sensible UI state but
+/// still keeps the bridge responsive on a slow consumer.
+pub const EXT_STATE_MAX_KB: u32 = 8 * 1024;
+pub const EXT_STATE_WARN_KB_DEFAULT: u32 = 64;
+pub const EXT_STATE_HARD_KB_DEFAULT: u32 = 512;
+
+/// Resolve the (warn, hard) state-size limits in KB. Applies defaults for
+/// missing values, clamps each to [1, EXT_STATE_MAX_KB], then guarantees
+/// `warn <= hard` by raising hard if a user picks a hard < warn (otherwise
+/// the WARN tier could never fire). Returns the canonical pair the bridge
+/// should use.
+pub fn resolve_ext_state_limits(warn: Option<u32>, hard: Option<u32>) -> (u32, u32) {
+    let clamp = |n: u32| n.clamp(1, EXT_STATE_MAX_KB);
+    let warn_kb = clamp(warn.unwrap_or(EXT_STATE_WARN_KB_DEFAULT));
+    let hard_kb_raw = clamp(hard.unwrap_or(EXT_STATE_HARD_KB_DEFAULT));
+    let hard_kb = hard_kb_raw.max(warn_kb);
+    (warn_kb, hard_kb)
+}
+
 /// Parse a TOML config string into the canonical JSON shape the frontend
 /// consumes. Falls back to defaults on parse error so a malformed user
 /// file never blocks app boot. Returns the same shape regardless of what
@@ -150,6 +188,8 @@ pub fn parse_config_toml(input: &str) -> serde_json::Value {
         .as_deref()
         .filter(|s| !s.is_empty());
     let default_args: Vec<String> = cfg.shell.default_args.unwrap_or_default();
+    let (state_warn_kb, state_hard_kb) =
+        resolve_ext_state_limits(cfg.extensions.state_warn_kb, cfg.extensions.state_hard_kb);
     serde_json::json!({
         "ui": {
             "theme": cfg.ui.theme,
@@ -171,6 +211,10 @@ pub fn parse_config_toml(input: &str) -> serde_json::Value {
         },
         "shortcuts": {
             "newTabKind": new_tab_kind,
+        },
+        "extensions": {
+            "stateWarnKb": state_warn_kb,
+            "stateHardKb": state_hard_kb,
         },
     })
 }
@@ -373,11 +417,99 @@ prompt_before_close = false
             let v = parse_config_toml(input);
             assert!(v["ui"].is_object());
             assert!(v["agent"].is_object());
+            assert!(v["extensions"].is_object());
             assert!(v["ui"].as_object().unwrap().contains_key("theme"));
             assert!(v["ui"].as_object().unwrap().contains_key("fontSize"));
             assert!(v["ui"].as_object().unwrap().contains_key("restoreTabs"));
             assert!(v["agent"].as_object().unwrap().contains_key("model"));
+            assert!(v["extensions"]
+                .as_object()
+                .unwrap()
+                .contains_key("stateWarnKb"));
+            assert!(v["extensions"]
+                .as_object()
+                .unwrap()
+                .contains_key("stateHardKb"));
         }
+    }
+
+    // ── resolve_ext_state_limits ───────────────────────────────────────────
+
+    #[test]
+    fn resolve_ext_state_limits_uses_defaults_when_absent() {
+        let (warn, hard) = resolve_ext_state_limits(None, None);
+        assert_eq!(warn, EXT_STATE_WARN_KB_DEFAULT);
+        assert_eq!(hard, EXT_STATE_HARD_KB_DEFAULT);
+    }
+
+    #[test]
+    fn resolve_ext_state_limits_clamps_min_and_max() {
+        // 0 is not a meaningful threshold — clamp up to 1.
+        let (warn, hard) = resolve_ext_state_limits(Some(0), Some(0));
+        assert_eq!(warn, 1);
+        assert_eq!(hard, 1);
+        // Above the ceiling clamps down. EXT_STATE_MAX_KB caps a runaway
+        // user value so a single stdout write can't OOM the bridge.
+        let (warn, hard) = resolve_ext_state_limits(Some(u32::MAX), Some(u32::MAX));
+        assert_eq!(warn, EXT_STATE_MAX_KB);
+        assert_eq!(hard, EXT_STATE_MAX_KB);
+    }
+
+    #[test]
+    fn resolve_ext_state_limits_raises_hard_to_warn_floor() {
+        // Inverted user input: hard < warn would mean WARN never fires
+        // (every WARN-tier write exceeds the HARD-tier reject first).
+        // Resolve by raising hard up to warn, keeping warn untouched.
+        let (warn, hard) = resolve_ext_state_limits(Some(200), Some(100));
+        assert_eq!(warn, 200);
+        assert_eq!(hard, 200);
+    }
+
+    #[test]
+    fn resolve_ext_state_limits_passthrough_valid_pair() {
+        let (warn, hard) = resolve_ext_state_limits(Some(32), Some(256));
+        assert_eq!(warn, 32);
+        assert_eq!(hard, 256);
+    }
+
+    #[test]
+    fn parse_config_toml_extracts_extensions_section() {
+        let v = parse_config_toml(
+            r#"[extensions]
+state_warn_kb = 128
+state_hard_kb = 1024
+"#,
+        );
+        assert_eq!(v["extensions"]["stateWarnKb"], 128);
+        assert_eq!(v["extensions"]["stateHardKb"], 1024);
+    }
+
+    #[test]
+    fn parse_config_toml_extensions_defaults_when_omitted() {
+        let v = parse_config_toml("");
+        assert_eq!(v["extensions"]["stateWarnKb"], EXT_STATE_WARN_KB_DEFAULT);
+        assert_eq!(v["extensions"]["stateHardKb"], EXT_STATE_HARD_KB_DEFAULT);
+    }
+
+    #[test]
+    fn parse_config_toml_extensions_partial_section_uses_defaults() {
+        // Only one key present — the other should fall back to its default.
+        let v = parse_config_toml("[extensions]\nstate_hard_kb = 2048\n");
+        assert_eq!(v["extensions"]["stateWarnKb"], EXT_STATE_WARN_KB_DEFAULT);
+        assert_eq!(v["extensions"]["stateHardKb"], 2048);
+    }
+
+    #[test]
+    fn parse_config_toml_extensions_inverted_pair_normalized() {
+        // hard < warn is normalized so WARN remains reachable.
+        let v = parse_config_toml(
+            r#"[extensions]
+state_warn_kb = 500
+state_hard_kb = 100
+"#,
+        );
+        assert_eq!(v["extensions"]["stateWarnKb"], 500);
+        assert_eq!(v["extensions"]["stateHardKb"], 500);
     }
 
     // ── clamp_font_size ────────────────────────────────────────────────────

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -998,6 +998,17 @@ fn ensure_agent_spawned(guard: &mut Option<Child>, app: &AppHandle) -> Result<()
         command.env("AETHON_USER_DIR", &user_dir);
         command.env("AETHON_STATE_FILE", &state_file);
         command.env("AETHON_SESSIONS_DIR", &sessions_dir);
+        // Read [extensions] state_warn_kb / state_hard_kb from
+        // ~/.aethon/config.toml and pass to the bridge as env vars. We
+        // re-parse on every spawn so a config edit picks up on next
+        // bridge restart without a full app reboot.
+        let cfg_path = user_dir.join("config.toml");
+        let raw = std::fs::read_to_string(&cfg_path).unwrap_or_default();
+        let cfg_json = parse_config_toml(&raw);
+        let warn_kb = cfg_json["extensions"]["stateWarnKb"].as_u64().unwrap_or(64);
+        let hard_kb = cfg_json["extensions"]["stateHardKb"].as_u64().unwrap_or(512);
+        command.env("AETHON_STATE_WARN_KB", warn_kb.to_string());
+        command.env("AETHON_STATE_HARD_KB", hard_kb.to_string());
     }
 
     let mut child = command
@@ -1822,7 +1833,6 @@ fn install_app_menu(
     app: &AppHandle,
     extension_items: &[ExtensionMenuItem],
 ) -> Result<(), Box<dyn std::error::Error>> {
-    use tauri::Emitter;
     use tauri::menu::{MenuBuilder, MenuItemBuilder, PredefinedMenuItem, SubmenuBuilder};
 
     // M6 restructure: Cmd+T is focus-aware in the webview keydown
@@ -1986,13 +1996,11 @@ fn install_app_menu(
 
     app.set_menu(menu)?;
 
-    app.on_menu_event(|app, event| {
-        let id = event.id().0.as_str();
-        // Forward as a Tauri event so the React side's centralized
-        // dispatcher (mirror of the Cmd+T / Cmd+] / Cmd+W keydown
-        // handlers) fires the same code path.
-        let _ = app.emit("menu", id);
-    });
+    // NOTE: `app.on_menu_event` is registered once in `setup()` because
+    // Tauri's handler list is additive — calling it here would stack a
+    // new closure on every `set_extension_menu_items` invocation, so a
+    // single click would fire the React handler N times (the cause of
+    // the "Help → Aethon Documentation opens N tabs" bug).
 
     Ok(())
 }
@@ -2310,6 +2318,15 @@ pub fn run() {
             // macOS items (Quit / Hide / Cut / Copy / Minimize / etc.)
             // get native NS actions for free, no event handler needed.
             install_app_menu(app.handle(), &[])?;
+            // Register the menu-click → "menu" event forwarder ONCE here.
+            // install_app_menu rebuilds and re-attaches the NSMenu whenever
+            // extension menu items change, but Tauri's `on_menu_event`
+            // handlers are additive — registering inside that function
+            // would stack a new closure per rebuild and emit duplicates.
+            app.handle().on_menu_event(|app, event| {
+                let id = event.id().0.as_str();
+                let _ = app.emit("menu", id);
+            });
             install_tray(app.handle(), &[])?;
             // Initialize the extension menu store empty; the bridge
             // ships items via `extension_menu_items` events that the

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1122,8 +1122,33 @@ fn send_message(
 }
 
 /// Forward an arbitrary JSON command (e.g. `{"type":"set_model","id":"..."}`)
-/// to the agent's stdin. Used by the model picker and any future runtime
-/// controls that aren't wrapped in `dispatch_a2ui_event`.
+/// Hard-kill the running agent child. Called by the frontend's hang-warn
+/// notification "Force restart" button. Unlike the file-watcher kill (which
+/// sets `agent_reload_in_progress` so EOF emits `agent-reloaded`), we
+/// intentionally let the crash path fire: the existing `agent-crashed`
+/// handler in App.tsx clears waiting state and (if auto_restart_agent = true)
+/// respawns automatically.
+///
+/// This bypasses blocked stdin — even if the Node event loop is frozen by
+/// backpressured stdout writes, Rust can still kill the child OS process.
+#[tauri::command]
+fn force_restart_agent(state: State<'_, AgentProcess>) -> Result<(), String> {
+    let mut guard = state.0.lock().map_err(|e| e.to_string())?;
+    if let Some(mut child) = guard.take() {
+        let pid = child.id();
+        tracing::warn!(target: "aethon::agent", "force_restart_agent: killing pid={pid}");
+        let _ = child.kill();
+        // Reap the child so it doesn't become a zombie while we wait for
+        // the stdout reader thread to detect EOF and emit agent-crashed.
+        let _ = child.wait();
+    }
+    // If guard is None the agent wasn't running — no-op is correct.
+    Ok(())
+}
+
+/// Forward an arbitrary JSON payload to the agent's stdin. Used by the model
+/// picker and any future runtime controls that aren't wrapped in
+/// `dispatch_a2ui_event`.
 #[tauri::command]
 fn agent_command(
     payload: String,
@@ -2235,6 +2260,7 @@ pub fn run() {
             start_agent,
             send_message,
             agent_command,
+            force_restart_agent,
             dispatch_a2ui_event,
             read_state,
             write_state,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6044,19 +6044,16 @@ export default function App() {
         if (!sessionId) return true;
         promptDeleteSessionConfirmation(label).then((allowed) => {
           if (!allowed) return;
-          // If the session is currently open as a tab, close it first
-          // so the in-memory state goes away in lockstep with the
-          // on-disk delete. closeTab is a no-op for unknown ids.
           const isOpen = (stateRef.current.tabs as Tab[] | undefined)?.some(
             (t) => t.id === sessionId,
           );
-          if (isOpen) closeTab(sessionId);
+          // Delete first, then close. Doing the reverse leaves the user
+          // with a closed tab and a failure notification when the Tauri
+          // command refuses (e.g. the default session). codex P2 review
+          // feedback.
           invoke("delete_session", { tabId: sessionId })
             .then(() => {
-              // Drop the entry from the in-memory cache and re-derive
-              // both the recent-sessions list (palette) and the sidebar
-              // history section so the deleted row disappears
-              // immediately — no need to wait for the next bridge ready.
+              if (isOpen) closeTab(sessionId);
               allDiscoveredSessionsRef.current =
                 allDiscoveredSessionsRef.current.filter(
                   (s) => s.tabId !== sessionId,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -606,7 +606,12 @@ export default function App() {
   // Hang-warn: push a sticky "Still working…" notification if the active tab
   // stays waiting longer than HANG_WARN_MS. Per-tab timers keyed by tabId.
   const HANG_WARN_MS = 30_000;
-  const HANG_WARN_NOTIF_ID = "ae-hang-warn";
+  // Per-tab notification id so a `response_end` for tab B doesn't dismiss
+  // tab A's still-hung warning (codex P2 review feedback).
+  const hangWarnNotifId = (tabId: string) => `ae-hang-warn:${tabId}`;
+  // Track which tabs currently have a hang notification surfaced so the
+  // crash/reload paths can dismiss them all without scanning.
+  const hangWarnActiveRef = useRef<Set<string>>(new Set());
   const hangWarnTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
   // P4: live config for OS notifications. Mirrors `config.ui.notifyOnCompletion`
   // / `notifyMinDurationSeconds` and is updated in the boot config effect.
@@ -1113,8 +1118,9 @@ export default function App() {
     });
   }
 
-  async function stopPrompt() {
-    const tabId = (stateRef.current.activeTabId as string | undefined) ?? "default";
+  async function stopPrompt(explicitTabId?: string) {
+    const tabId =
+      explicitTabId ?? (stateRef.current.activeTabId as string | undefined) ?? "default";
     try {
       await invoke("agent_command", {
         payload: JSON.stringify({ type: "stop", tabId }),
@@ -2754,7 +2760,8 @@ export default function App() {
       activeResponseIdRef.current = null;
       for (const h of hangWarnTimersRef.current.values()) clearTimeout(h);
       hangWarnTimersRef.current.clear();
-      dismissNotification(HANG_WARN_NOTIF_ID);
+      for (const tid of hangWarnActiveRef.current) dismissNotification(hangWarnNotifId(tid));
+      hangWarnActiveRef.current.clear();
       setStatusFlags({ waiting: false, status: "agent reloaded" });
       // Re-prime the agent so we get a fresh `ready` event with the new code.
       invoke("start_agent").catch(() => {
@@ -2774,7 +2781,8 @@ export default function App() {
         activeResponseIdRef.current = null;
         for (const h of hangWarnTimersRef.current.values()) clearTimeout(h);
         hangWarnTimersRef.current.clear();
-        dismissNotification(HANG_WARN_NOTIF_ID);
+        for (const tid of hangWarnActiveRef.current) dismissNotification(hangWarnNotifId(tid));
+        hangWarnActiveRef.current.clear();
         // Clear waiting/queue across every tab — pi sessions are gone.
         setState((prev) => {
           const tabs = ((prev.tabs as Tab[] | undefined) ?? []).map((t) => ({
@@ -3801,14 +3809,15 @@ export default function App() {
             const tabs = (cur.tabs as Tab[] | undefined) ?? [];
             const tab = tabs.find((t) => t.id === tabId);
             if (!tab?.waiting) return;
+            hangWarnActiveRef.current.add(tabId);
             pushNotification({
-              id: HANG_WARN_NOTIF_ID,
+              id: hangWarnNotifId(tabId),
               title: "Still working…",
               message: "The agent is taking longer than expected.",
               kind: "warning",
               durationMs: null,
               actions: [
-                { label: "Stop", action: "hang-warn:stop" },
+                { label: "Stop", action: `hang-warn:stop:${tabId}` },
                 { label: "Force restart", action: "hang-warn:force-restart" },
               ],
             });
@@ -3851,12 +3860,15 @@ export default function App() {
             return { ...prev, status: "ready" };
           });
         }
-        // Clear the hang-warn timer and dismiss the notification (if it
-        // appeared) now that the turn resolved normally.
+        // Clear the hang-warn timer and dismiss this tab's notification
+        // (if it appeared). Per-tab id so an unrelated tab's response_end
+        // doesn't dismiss a still-hung tab's warning.
         {
           const h = hangWarnTimersRef.current.get(tabId);
           if (h !== undefined) { clearTimeout(h); hangWarnTimersRef.current.delete(tabId); }
-          dismissNotification(HANG_WARN_NOTIF_ID);
+          if (hangWarnActiveRef.current.delete(tabId)) {
+            dismissNotification(hangWarnNotifId(tabId));
+          }
         }
         // P4: fire native OS notification when an agent turn completes
         // while the window is unfocused (or the originating tab isn't
@@ -5646,8 +5658,14 @@ export default function App() {
           typeof action === "string" &&
           action.startsWith("hang-warn:")
         ) {
-          if (action === "hang-warn:stop") {
-            void stopPrompt();
+          if (action.startsWith("hang-warn:stop")) {
+            // Stop carries the tabId of the hung tab (set when the
+            // notification was pushed) so the right session is stopped
+            // even if the user is on a different tab when they click.
+            const targetTabId = action.startsWith("hang-warn:stop:")
+              ? action.slice("hang-warn:stop:".length)
+              : undefined;
+            void stopPrompt(targetTabId);
           } else if (action === "hang-warn:force-restart") {
             // force_restart_agent SIGKILLs the bun child from Rust, bypassing
             // blocked stdin. The existing agent-crashed handler then fires,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,7 @@ import { deletePointer, setPointer } from "./utils/jsonPointer";
 import { registerGrammar as registerHighlightGrammar } from "./utils/highlight";
 import { cycleShareMode } from "./utils/shareMode";
 import { shellQuoteAll } from "./utils/shellQuote";
+import { extractSessionId } from "./utils/sidebarHistory";
 // Vite resolves `?url` imports to a hashed asset URL at build time. Injecting
 // the URL into layout state lets the header bind via `{"$ref": "/logoUrl"}`
 // instead of hardcoding a path that might 404 in a production bundle.
@@ -2839,7 +2840,11 @@ export default function App() {
       const isRawCrash =
         /^(Error|TypeError|ReferenceError|SyntaxError|RangeError|Uncaught|panic:)/i.test(text) ||
         /\bthrow\s+new\s|\bCannot\s+find\s+(module|package)\b|\bEACCES\b|\bENOENT\b/i.test(text);
-      if (isLeveledFailure || isRawCrash) {
+      // Routine extension feedback (size-guard rejections, etc.) goes to bridge
+      // logs only — surfacing it to chat would spam the feed when an extension
+      // misbehaves on a setInterval.
+      const isExtensionNoise = /\b(WARN|INFO)\s+ext-state:/.test(text);
+      if ((isLeveledFailure || isRawCrash) && !isExtensionNoise) {
         appendMessage({
           id: crypto.randomUUID(),
           role: "system",
@@ -3967,6 +3972,29 @@ export default function App() {
             tabId,
           );
         }
+        break;
+      }
+      case "extension_runtime_error": {
+        // Sticky, deduped notification per extension. Bridge already
+        // rate-limits the underlying log line, so we get one notification
+        // when the misbehavior starts (or resumes after the suppression
+        // window) — not one every 2s.
+        const name = (data.name as string | undefined) ?? "(unknown)";
+        const kind = (data.kind as string | undefined) ?? "error";
+        const path = (data.path as string | undefined) ?? "";
+        const sizeKB = data.sizeKB as number | undefined;
+        const limitKB = data.limitKB as number | undefined;
+        const message =
+          kind === "state-too-large" && sizeKB !== undefined && limitKB !== undefined
+            ? `setState ${path} rejected — ${sizeKB} KB exceeds ${limitKB} KB limit. Store file paths, not content.`
+            : `Extension reported a runtime error.`;
+        pushNotification({
+          id: `ext-runtime-error:${name}`,
+          title: `Extension \`${name}\` is misbehaving`,
+          message,
+          kind: "warning",
+          durationMs: null,
+        });
         break;
       }
       // Legacy single-shot response (kept so old bridge builds still render).
@@ -5988,18 +6016,23 @@ export default function App() {
         const selected = data as
           | { sessionId?: string; itemId?: string; label?: string }
           | undefined;
-        // Strip the "session:" prefix as a defensive fallback in case a
+        // Strip the "session:" or "tab:" prefix defensively in case a
         // future caller forgets the split — the sidebar already strips
         // it but we don't want a stray prefix to land in the Tauri
         // command path validator.
         const raw = selected?.sessionId ?? selected?.itemId ?? "";
-        const sessionId = raw.startsWith("session:")
-          ? raw.slice("session:".length)
-          : raw;
+        const sessionId = extractSessionId(raw);
         const label = selected?.label ?? sessionId;
         if (!sessionId) return true;
         promptDeleteSessionConfirmation(label).then((allowed) => {
           if (!allowed) return;
+          // If the session is currently open as a tab, close it first
+          // so the in-memory state goes away in lockstep with the
+          // on-disk delete. closeTab is a no-op for unknown ids.
+          const isOpen = (stateRef.current.tabs as Tab[] | undefined)?.some(
+            (t) => t.id === sessionId,
+          );
+          if (isOpen) closeTab(sessionId);
           invoke("delete_session", { tabId: sessionId })
             .then(() => {
               // Drop the entry from the in-memory cache and re-derive

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -542,6 +542,15 @@ export default function App() {
       // shapes are documented on the components themselves.
       palette: { open: false, mode: "switcher", query: "", selectedIndex: 0 },
       notifications: [],
+      // Seed /sidebar/extensions so the $ref-bound sidebar section renders
+      // the built-in entry immediately — hydrateExtensions() fills in
+      // dynamically-loaded extensions once `ready` arrives.
+      sidebar: {
+        ...(BOOT_LAYOUT.state?.sidebar as Record<string, unknown> | undefined),
+        extensions: [
+          { id: "extension-layout", label: "default-layout", hint: "core", active: true },
+        ],
+      },
     };
   });
 
@@ -593,6 +602,11 @@ export default function App() {
   // on `response_end`. Used to compute turn duration for the OS
   // completion notification gate.
   const turnStartedAtRef = useRef<Map<string, number>>(new Map());
+  // Hang-warn: push a sticky "Still working…" notification if the active tab
+  // stays waiting longer than HANG_WARN_MS. Per-tab timers keyed by tabId.
+  const HANG_WARN_MS = 30_000;
+  const HANG_WARN_NOTIF_ID = "ae-hang-warn";
+  const hangWarnTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
   // P4: live config for OS notifications. Mirrors `config.ui.notifyOnCompletion`
   // / `notifyMinDurationSeconds` and is updated in the boot config effect.
   // Held in a ref (not state) so the response_end handler reads the
@@ -688,6 +702,39 @@ export default function App() {
           themes,
         },
       };
+    });
+  }
+
+  // Hydrate the sidebar extensions list from the bridge's loaded/failed sets.
+  // Called on `ready` (startup + project switch) so the list always reflects
+  // what the current bridge process has actually loaded.
+  function hydrateExtensions(
+    loaded: { name: string; source: string }[],
+    failed: { name: string; source: string; error?: string }[],
+  ) {
+    const sourceLabel = (s: string) =>
+      s === "project-directory" ? "project"
+      : s === "global-directory" ? "user"
+      : s === "extension-package" ? "package"
+      : s;
+    const items = [
+      { id: "extension-layout", label: "default-layout", hint: "core", active: true },
+      ...loaded.map((e) => ({
+        id: `ext:${e.name}`,
+        label: e.name,
+        hint: sourceLabel(e.source),
+        active: true,
+      })),
+      ...failed.map((e) => ({
+        id: `ext-failed:${e.name}`,
+        label: e.name,
+        hint: `${sourceLabel(e.source)} · failed`,
+        active: false,
+      })),
+    ];
+    setState((prev) => {
+      const sidebar = (prev.sidebar as Record<string, unknown>) ?? {};
+      return { ...prev, sidebar: { ...sidebar, extensions: items } };
     });
   }
 
@@ -2704,6 +2751,9 @@ export default function App() {
 
     const unlistenReload = listen<string>("agent-reloaded", () => {
       activeResponseIdRef.current = null;
+      for (const h of hangWarnTimersRef.current.values()) clearTimeout(h);
+      hangWarnTimersRef.current.clear();
+      dismissNotification(HANG_WARN_NOTIF_ID);
       setStatusFlags({ waiting: false, status: "agent reloaded" });
       // Re-prime the agent so we get a fresh `ready` event with the new code.
       invoke("start_agent").catch(() => {
@@ -2721,6 +2771,9 @@ export default function App() {
         const tail = event.payload?.stderrTail ?? [];
         const lastLine = tail.length > 0 ? tail[tail.length - 1] : "no stderr";
         activeResponseIdRef.current = null;
+        for (const h of hangWarnTimersRef.current.values()) clearTimeout(h);
+        hangWarnTimersRef.current.clear();
+        dismissNotification(HANG_WARN_NOTIF_ID);
         // Clear waiting/queue across every tab — pi sessions are gone.
         setState((prev) => {
           const tabs = ((prev.tabs as Tab[] | undefined) ?? []).map((t) => ({
@@ -3132,6 +3185,10 @@ export default function App() {
         // when the merge runs. hydrateThemes also injects the CSS so a
         // saved choice has the rule available before data-theme is read.
         hydrateThemes(extThemes);
+        hydrateExtensions(
+          (data.extensionsList as { name: string; source: string }[] | undefined) ?? [],
+          (data.failedExtensionsList as { name: string; source: string; error?: string }[] | undefined) ?? [],
+        );
         registry.setTemplates(extComponents);
         // Restore extension-registered slash commands so the picker shows
         // them on first paint (no need to wait for an extension_slash_commands
@@ -3727,6 +3784,32 @@ export default function App() {
         if (stateRef.current.activeTabId === tabId) {
           setState((prev) => ({ ...prev, status: "thinking…" }));
         }
+        // Start hang-warn timer. Reset if a queue-drained prompt_started
+        // fires for the same tab (the 30s clock restarts on each new turn).
+        {
+          const prev = hangWarnTimersRef.current.get(tabId);
+          if (prev !== undefined) clearTimeout(prev);
+          const handle = setTimeout(() => {
+            hangWarnTimersRef.current.delete(tabId);
+            const cur = stateRef.current;
+            if ((cur.activeTabId as string | undefined) !== tabId) return;
+            const tabs = (cur.tabs as Tab[] | undefined) ?? [];
+            const tab = tabs.find((t) => t.id === tabId);
+            if (!tab?.waiting) return;
+            pushNotification({
+              id: HANG_WARN_NOTIF_ID,
+              title: "Still working…",
+              message: "The agent is taking longer than expected.",
+              kind: "warning",
+              durationMs: null,
+              actions: [
+                { label: "Stop", action: "hang-warn:stop" },
+                { label: "Force restart", action: "hang-warn:force-restart" },
+              ],
+            });
+          }, HANG_WARN_MS);
+          hangWarnTimersRef.current.set(tabId, handle);
+        }
         break;
       }
       case "queued": {
@@ -3762,6 +3845,13 @@ export default function App() {
             if (q > 0) return prev;
             return { ...prev, status: "ready" };
           });
+        }
+        // Clear the hang-warn timer and dismiss the notification (if it
+        // appeared) now that the turn resolved normally.
+        {
+          const h = hangWarnTimersRef.current.get(tabId);
+          if (h !== undefined) { clearTimeout(h); hangWarnTimersRef.current.delete(tabId); }
+          dismissNotification(HANG_WARN_NOTIF_ID);
         }
         // P4: fire native OS notification when an agent turn completes
         // while the window is unfocused (or the originating tab isn't
@@ -5517,6 +5607,25 @@ export default function App() {
           if (action === "ae-agent-crashed:restart") {
             invoke("start_agent").catch((err: unknown) => {
               console.warn("agent restart failed:", err);
+            });
+          }
+          if (id) dismissNotification(id);
+          return true;
+        }
+        // Hang-warn notification actions.
+        if (
+          eventType === "action" &&
+          typeof action === "string" &&
+          action.startsWith("hang-warn:")
+        ) {
+          if (action === "hang-warn:stop") {
+            void stopPrompt();
+          } else if (action === "hang-warn:force-restart") {
+            // force_restart_agent SIGKILLs the bun child from Rust, bypassing
+            // blocked stdin. The existing agent-crashed handler then fires,
+            // clearing waiting state and (if auto_restart_agent) respawning.
+            invoke("force_restart_agent").catch((err: unknown) => {
+              console.warn("force_restart_agent failed:", err);
             });
           }
           if (id) dismissNotification(id);

--- a/src/skills/default-layout/components.tsx
+++ b/src/skills/default-layout/components.tsx
@@ -43,6 +43,7 @@ import type {
   BuiltinComponentProps,
 } from "../../components/A2UIRenderer";
 import { useStickyScroll } from "../../utils/useStickyScroll";
+import { canDeleteHistoryItem, extractSessionId } from "../../utils/sidebarHistory";
 
 // Adapter: react-markdown invokes `code` for both inline AND fenced code
 // blocks. We split on whether the parent is `<pre>` (fenced) and route
@@ -702,13 +703,15 @@ export function Sidebar({
     item,
     sectionId,
   ) => {
-    // Projects → "Remove from Projects". History items prefixed `session:`
-    // → "Delete session". Open agent tabs (`tab:` prefix) and other
-    // sections have no context-menu actions yet.
+    // Projects → "Remove from Projects". History items prefixed
+    // `session:` (closed) or `tab:` (currently open) → "Delete session".
+    // For an open tab, the App-side handler closes the tab first, then
+    // deletes the on-disk session — symmetric with the X close button +
+    // explicit delete, just collapsed into one action.
     let kind: SidebarContextMenuState["kind"] | null = null;
     if (sectionId === "projects") {
       kind = "project";
-    } else if (sectionId === "history" && item.id.startsWith("session:")) {
+    } else if (sectionId === "history" && canDeleteHistoryItem(item.id)) {
       kind = "session";
     }
     if (!kind) return;
@@ -739,15 +742,13 @@ export function Sidebar({
 
   const deleteContextSession = () => {
     if (!contextMenu) return;
-    // itemId is `session:<tabId>` — strip the prefix so App.tsx receives
-    // the raw tabId that the bridge / Tauri command both expect.
-    const sessionId = contextMenu.itemId.startsWith("session:")
-      ? contextMenu.itemId.slice("session:".length)
-      : contextMenu.itemId;
+    // itemId is `session:<tabId>` (closed) or `tab:<tabId>` (open) —
+    // strip whichever prefix is present so App.tsx receives the raw
+    // tabId the bridge / Tauri command both expect.
     onEvent("delete-session", {
       sectionId: contextMenu.sectionId,
       itemId: contextMenu.itemId,
-      sessionId,
+      sessionId: extractSessionId(contextMenu.itemId),
       label: contextMenu.label,
     });
     setContextMenu(null);

--- a/src/skills/default-layout/workstation.a2ui.json
+++ b/src/skills/default-layout/workstation.a2ui.json
@@ -78,9 +78,7 @@
               {
                 "id": "extensions",
                 "title": "extensions",
-                "items": [
-                  { "id": "extension-layout", "label": "default-layout", "hint": "core", "active": true }
-                ]
+                "items": { "$ref": "/sidebar/extensions" }
               },
               {
                 "id": "panels",

--- a/src/utils/sidebarHistory.test.ts
+++ b/src/utils/sidebarHistory.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { canDeleteHistoryItem, extractSessionId } from "./sidebarHistory";
+
+describe("extractSessionId", () => {
+  it("strips session: prefix", () => {
+    expect(extractSessionId("session:abc-123")).toBe("abc-123");
+  });
+
+  it("strips tab: prefix — open agent tabs share the delete flow", () => {
+    expect(extractSessionId("tab:abc-123")).toBe("abc-123");
+  });
+
+  it("returns the input unchanged when no known prefix is present", () => {
+    expect(extractSessionId("abc-123")).toBe("abc-123");
+  });
+
+  it("does not double-strip — a session:tab:foo id keeps the inner literal", () => {
+    expect(extractSessionId("session:tab:foo")).toBe("tab:foo");
+  });
+});
+
+describe("canDeleteHistoryItem", () => {
+  it("accepts session: ids", () => {
+    expect(canDeleteHistoryItem("session:x")).toBe(true);
+  });
+
+  it("accepts tab: ids — fixes the WebKit context-menu falling through", () => {
+    // Before this fix, right-clicking an open tab in the chat-history
+    // section showed Reload / Inspect Element instead of the Delete
+    // action, because the openItemContextMenu handler only triggered
+    // for `session:` ids and bailed for `tab:` ids — so e.preventDefault
+    // never ran.
+    expect(canDeleteHistoryItem("tab:x")).toBe(true);
+  });
+
+  it("rejects unknown prefixes so we don't show no-op actions", () => {
+    expect(canDeleteHistoryItem("project:x")).toBe(false);
+    expect(canDeleteHistoryItem("naked-id")).toBe(false);
+    expect(canDeleteHistoryItem("")).toBe(false);
+  });
+});

--- a/src/utils/sidebarHistory.ts
+++ b/src/utils/sidebarHistory.ts
@@ -1,0 +1,25 @@
+/**
+ * Sidebar chat-history item ids carry one of two prefixes:
+ *   - `tab:<id>`     — the session is currently open as an agent tab
+ *   - `session:<id>` — the session is closed but discoverable on disk
+ *
+ * Both forms map to the same underlying tabId / sessionId (they're the
+ * same string in the bridge). The right-click "Delete session" action
+ * accepts either; this helper normalizes the input so the Tauri
+ * command's path validator never sees a stray prefix.
+ */
+export function extractSessionId(itemId: string): string {
+  if (itemId.startsWith("session:")) return itemId.slice("session:".length);
+  if (itemId.startsWith("tab:")) return itemId.slice("tab:".length);
+  return itemId;
+}
+
+/**
+ * Whether a sidebar chat-history item id represents something that can
+ * be deleted via the context menu — currently both prefixes qualify.
+ * Anything without a known prefix (future kinds, malformed ids) is
+ * left alone so we don't show a delete action that would no-op.
+ */
+export function canDeleteHistoryItem(itemId: string): boolean {
+  return itemId.startsWith("session:") || itemId.startsWith("tab:");
+}

--- a/src/utils/stickyScrollController.test.ts
+++ b/src/utils/stickyScrollController.test.ts
@@ -90,18 +90,18 @@ describe("StickyScrollController", () => {
   });
 
   it("does NOT silently suppress real user scrolls when the programmatic scroll was a no-op (codex P2)", () => {
-    // Regression: if the consumer's scrollTop assignment didn't actually
-    // move the container (e.g. already at bottom, mutation didn't grow
-    // height), no synthesized scroll event fires. Setting
+    // Regression: when the container is already at the bottom, the hook
+    // writes `el.scrollTop = el.scrollHeight` but the browser clamps it
+    // to `scrollHeight - clientHeight` (the actual max), which is the
+    // current value — so no scroll event fires. Setting
     // programmaticPending unconditionally would leave the flag stale and
-    // the user's NEXT real scroll-away would be silently ignored.
-    // The hook avoids this by calling notifyProgrammaticScroll only
-    // when scrollTop actually changes — so the controller never sees
-    // a stale flag in this scenario.
+    // suppress the user's NEXT real scroll-away. The hook detects this
+    // by reading scrollTop after the assignment and only calls
+    // notifyProgrammaticScroll when it actually moved.
     const c = new StickyScrollController();
     c.onContentChanged(); // returns scrollToBottom: true
-    // Hook decides scrollTop is already at scrollHeight (no-op);
-    // does NOT call notifyProgrammaticScroll. User then scrolls away.
+    // Hook does the write, sees scrollTop didn't change, does NOT call
+    // notifyProgrammaticScroll. User then scrolls away.
     const follow = c.onScroll(M(0, 200, 1000));
     expect(follow).toBe(false);
   });

--- a/src/utils/stickyScrollController.test.ts
+++ b/src/utils/stickyScrollController.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import {
+  StickyScrollController,
+  isAtBottom,
+} from "./stickyScrollController";
+
+const M = (scrollTop: number, clientHeight: number, scrollHeight: number) =>
+  ({ scrollTop, clientHeight, scrollHeight });
+
+describe("isAtBottom", () => {
+  it("treats exact-bottom as at-bottom", () => {
+    // scrollTop + clientHeight === scrollHeight  →  at bottom
+    expect(isAtBottom(M(800, 200, 1000))).toBe(true);
+  });
+
+  it("returns false when far from bottom", () => {
+    expect(isAtBottom(M(0, 200, 1000))).toBe(false);
+  });
+
+  it("respects the threshold so a few pixels short still counts as bottom", () => {
+    // 30px short of bottom, threshold defaults to 60.
+    expect(isAtBottom(M(770, 200, 1000))).toBe(true);
+  });
+
+  it("threshold can be overridden", () => {
+    expect(isAtBottom(M(770, 200, 1000), 10)).toBe(false);
+  });
+});
+
+describe("StickyScrollController", () => {
+  it("starts in follow mode so first paint snaps to bottom", () => {
+    const c = new StickyScrollController();
+    expect(c.follow).toBe(true);
+  });
+
+  it("user scrolling away breaks follow", () => {
+    const c = new StickyScrollController();
+    expect(c.onScroll(M(0, 200, 1000))).toBe(false);
+    expect(c.follow).toBe(false);
+  });
+
+  it("user scrolling back to bottom restores follow", () => {
+    const c = new StickyScrollController();
+    c.onScroll(M(0, 200, 1000));
+    expect(c.onScroll(M(800, 200, 1000))).toBe(true);
+    expect(c.follow).toBe(true);
+  });
+
+  it("auto-scrolls when content arrives and follow is on — does NOT recompute scroll position from current DOM", () => {
+    const c = new StickyScrollController();
+    // No metrics passed to onContentChanged — that's the point of the fix.
+    // The controller trusts the follow flag, set during the last user
+    // interaction, and ignores whatever scrollHeight is right now.
+    const d = c.onContentChanged();
+    expect(d.scrollToBottom).toBe(true);
+  });
+
+  it("does not auto-scroll if user has scrolled away (follow=false)", () => {
+    const c = new StickyScrollController();
+    c.onScroll(M(0, 200, 1000));
+    const d = c.onContentChanged();
+    expect(d.scrollToBottom).toBe(false);
+  });
+
+  it("regression: content arrival after user-was-at-bottom does NOT lose follow", () => {
+    // The old hook would: user scrolls to bottom → (1000 height) →
+    // message arrives → DOM mutation grows scrollHeight to 1100 → hook
+    // recomputes "at bottom?" with scrollTop=800, clientHeight=200,
+    // scrollHeight=1100 → 1000 < 1040 → atBottom=FALSE → follow lost,
+    // user gets stranded. This test asserts the controller does NOT
+    // make that mistake — it consults the cached follow flag instead.
+    const c = new StickyScrollController();
+    c.onScroll(M(800, 200, 1000)); // user at bottom, follow=true
+    expect(c.follow).toBe(true);
+    // Content grows. We do NOT pass new metrics — the controller must
+    // not depend on them for the auto-scroll decision.
+    const d = c.onContentChanged();
+    expect(d.scrollToBottom).toBe(true);
+    expect(c.follow).toBe(true);
+  });
+
+  it("ignores the synthesized scroll event from its own programmatic scroll", () => {
+    const c = new StickyScrollController();
+    // Suppose scrollHeight just grew. Controller will scroll-to-bottom,
+    // and the consumer reports that scroll back via onScroll. The new
+    // metrics show the user is at the new bottom — but the controller
+    // should NOT treat this as a fresh user gesture (that would be
+    // benign here, but the symmetric case — user briefly above bottom
+    // when our scroll fires — would mistakenly disable follow).
+    c.onContentChanged(); // programmatic scroll requested
+    // Pretend the consumer's scroll handler fires WHILE the user is
+    // momentarily not at the bottom (e.g. between the scroll request
+    // and the actual scroll completing). The controller must not flip
+    // follow off based on this synthesized event.
+    const followAfter = c.onScroll(M(500, 200, 1100));
+    expect(followAfter).toBe(true);
+  });
+
+  it("resume() forces follow on regardless of prior scroll-away", () => {
+    const c = new StickyScrollController();
+    c.onScroll(M(0, 200, 1000)); // user away
+    expect(c.follow).toBe(false);
+    const d = c.resume();
+    expect(d.scrollToBottom).toBe(true);
+    expect(c.follow).toBe(true);
+  });
+
+  it("a real user scroll after a programmatic scroll still updates follow", () => {
+    const c = new StickyScrollController();
+    c.onContentChanged(); // programmatic-pending = true
+    c.onScroll(M(900, 200, 1100)); // consumes the programmatic flag
+    expect(c.follow).toBe(true);
+    // Now a genuine user scroll should be honoured.
+    c.onScroll(M(0, 200, 1100));
+    expect(c.follow).toBe(false);
+  });
+});

--- a/src/utils/stickyScrollController.test.ts
+++ b/src/utils/stickyScrollController.test.ts
@@ -81,19 +81,29 @@ describe("StickyScrollController", () => {
 
   it("ignores the synthesized scroll event from its own programmatic scroll", () => {
     const c = new StickyScrollController();
-    // Suppose scrollHeight just grew. Controller will scroll-to-bottom,
-    // and the consumer reports that scroll back via onScroll. The new
-    // metrics show the user is at the new bottom — but the controller
-    // should NOT treat this as a fresh user gesture (that would be
-    // benign here, but the symmetric case — user briefly above bottom
-    // when our scroll fires — would mistakenly disable follow).
-    c.onContentChanged(); // programmatic scroll requested
-    // Pretend the consumer's scroll handler fires WHILE the user is
-    // momentarily not at the bottom (e.g. between the scroll request
-    // and the actual scroll completing). The controller must not flip
-    // follow off based on this synthesized event.
+    c.onContentChanged(); // decision says scroll
+    // Hook tells the controller it actually moved the container.
+    c.notifyProgrammaticScroll();
+    // First scroll event after a programmatic scroll is consumed.
     const followAfter = c.onScroll(M(500, 200, 1100));
     expect(followAfter).toBe(true);
+  });
+
+  it("does NOT silently suppress real user scrolls when the programmatic scroll was a no-op (codex P2)", () => {
+    // Regression: if the consumer's scrollTop assignment didn't actually
+    // move the container (e.g. already at bottom, mutation didn't grow
+    // height), no synthesized scroll event fires. Setting
+    // programmaticPending unconditionally would leave the flag stale and
+    // the user's NEXT real scroll-away would be silently ignored.
+    // The hook avoids this by calling notifyProgrammaticScroll only
+    // when scrollTop actually changes — so the controller never sees
+    // a stale flag in this scenario.
+    const c = new StickyScrollController();
+    c.onContentChanged(); // returns scrollToBottom: true
+    // Hook decides scrollTop is already at scrollHeight (no-op);
+    // does NOT call notifyProgrammaticScroll. User then scrolls away.
+    const follow = c.onScroll(M(0, 200, 1000));
+    expect(follow).toBe(false);
   });
 
   it("resume() forces follow on regardless of prior scroll-away", () => {
@@ -107,7 +117,8 @@ describe("StickyScrollController", () => {
 
   it("a real user scroll after a programmatic scroll still updates follow", () => {
     const c = new StickyScrollController();
-    c.onContentChanged(); // programmatic-pending = true
+    c.onContentChanged();
+    c.notifyProgrammaticScroll();
     c.onScroll(M(900, 200, 1100)); // consumes the programmatic flag
     expect(c.follow).toBe(true);
     // Now a genuine user scroll should be honoured.

--- a/src/utils/stickyScrollController.ts
+++ b/src/utils/stickyScrollController.ts
@@ -67,7 +67,6 @@ export class StickyScrollController {
    */
   onContentChanged(): StickyDecision {
     if (this.followFlag) {
-      this.programmaticPending = true;
       return { scrollToBottom: true, follow: true };
     }
     return { scrollToBottom: false, follow: false };
@@ -76,7 +75,16 @@ export class StickyScrollController {
   /** User clicked the "scroll to bottom" pill. Re-enable follow. */
   resume(): StickyDecision {
     this.followFlag = true;
-    this.programmaticPending = true;
     return { scrollToBottom: true, follow: true };
+  }
+
+  /** Tell the controller a programmatic scroll just happened and the
+   *  next scroll event should be ignored. The hook calls this only
+   *  when the assignment to `scrollTop` will actually move the
+   *  container — otherwise no scroll event fires and a stale
+   *  `programmaticPending` would silently swallow the user's NEXT
+   *  scroll-away (codex P2 review feedback). */
+  notifyProgrammaticScroll(): void {
+    this.programmaticPending = true;
   }
 }

--- a/src/utils/stickyScrollController.ts
+++ b/src/utils/stickyScrollController.ts
@@ -1,0 +1,82 @@
+/**
+ * Pure follow-intent controller behind useStickyScroll. Extracted so the
+ * "follow flag updated on user scroll only, never recomputed on content
+ * change" rule is testable without React + jsdom.
+ *
+ * The bug this fixes: a previous version re-read scrollTop / scrollHeight
+ * inside the MutationObserver callback. Because mutations have already
+ * grown scrollHeight by then, the post-mutation read says "not at bottom"
+ * even when the user *was* at the bottom an instant ago — sticky scroll
+ * silently breaks for any message taller than the threshold.
+ *
+ * The fix: track a separate `follow` flag. The flag flips only on
+ * user-driven scroll events (we know it's user-driven because the
+ * controller did not just programmatically scroll). Content updates do
+ * not touch the flag — they just consult it.
+ */
+
+export interface ScrollMetrics {
+  scrollTop: number;
+  clientHeight: number;
+  scrollHeight: number;
+}
+
+export interface StickyDecision {
+  /** Whether the consumer should programmatically scroll to bottom now. */
+  scrollToBottom: boolean;
+  /** Current follow state — useful for an "isAtBottom" UI indicator. */
+  follow: boolean;
+}
+
+export const DEFAULT_BOTTOM_THRESHOLD = 60;
+
+export function isAtBottom(metrics: ScrollMetrics, threshold = DEFAULT_BOTTOM_THRESHOLD): boolean {
+  return metrics.scrollTop + metrics.clientHeight >= metrics.scrollHeight - threshold;
+}
+
+export class StickyScrollController {
+  private followFlag = true;
+  // True when the next scroll event reflects a programmatic scroll we
+  // just issued — used to ignore that event so we don't accidentally
+  // turn off follow on our own auto-scrolls.
+  private programmaticPending = false;
+  private readonly threshold: number;
+
+  constructor(threshold: number = DEFAULT_BOTTOM_THRESHOLD) {
+    this.threshold = threshold;
+  }
+
+  get follow(): boolean {
+    return this.followFlag;
+  }
+
+  /** User scrolled (or the container was scrolled programmatically and the
+   *  consumer reported it). Returns the current follow state.
+   */
+  onScroll(metrics: ScrollMetrics): boolean {
+    if (this.programmaticPending) {
+      this.programmaticPending = false;
+      return this.followFlag;
+    }
+    this.followFlag = isAtBottom(metrics, this.threshold);
+    return this.followFlag;
+  }
+
+  /** New content arrived. Decide whether to scroll. The follow flag is
+   *  NOT recomputed from current DOM state — that's the fix.
+   */
+  onContentChanged(): StickyDecision {
+    if (this.followFlag) {
+      this.programmaticPending = true;
+      return { scrollToBottom: true, follow: true };
+    }
+    return { scrollToBottom: false, follow: false };
+  }
+
+  /** User clicked the "scroll to bottom" pill. Re-enable follow. */
+  resume(): StickyDecision {
+    this.followFlag = true;
+    this.programmaticPending = true;
+    return { scrollToBottom: true, follow: true };
+  }
+}

--- a/src/utils/useStickyScroll.ts
+++ b/src/utils/useStickyScroll.ts
@@ -25,17 +25,21 @@ export function useStickyScroll(containerRef: RefObject<HTMLDivElement | null>) 
   }
   const rafRef = useRef<number | null>(null);
 
-  // Assign scrollTop conditionally and tell the controller about the
-  // synthesized scroll event ONLY if the assignment will actually move
-  // the container — see notifyProgrammaticScroll for why.
+  // Assign scrollTop and tell the controller about the synthesized
+  // scroll event ONLY if the assignment actually moved the container.
+  // Don't try to predict whether a move will happen up front — browsers
+  // clamp `scrollTop` to `scrollHeight - clientHeight`, so writing
+  // `scrollHeight` no-ops when already at bottom and no event fires.
+  // Reading scrollTop *after* the write is the only reliable signal.
+  // (codex P2 review feedback.)
   const programmaticScrollTo = (
     el: HTMLDivElement,
     target: number,
     ctrl: StickyScrollController,
   ) => {
-    if (el.scrollTop === target) return;
-    ctrl.notifyProgrammaticScroll();
+    const before = el.scrollTop;
     el.scrollTop = target;
+    if (el.scrollTop !== before) ctrl.notifyProgrammaticScroll();
   };
 
   const handleContentChanged = useCallback(() => {

--- a/src/utils/useStickyScroll.ts
+++ b/src/utils/useStickyScroll.ts
@@ -25,6 +25,19 @@ export function useStickyScroll(containerRef: RefObject<HTMLDivElement | null>) 
   }
   const rafRef = useRef<number | null>(null);
 
+  // Assign scrollTop conditionally and tell the controller about the
+  // synthesized scroll event ONLY if the assignment will actually move
+  // the container — see notifyProgrammaticScroll for why.
+  const programmaticScrollTo = (
+    el: HTMLDivElement,
+    target: number,
+    ctrl: StickyScrollController,
+  ) => {
+    if (el.scrollTop === target) return;
+    ctrl.notifyProgrammaticScroll();
+    el.scrollTop = target;
+  };
+
   const handleContentChanged = useCallback(() => {
     if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
     rafRef.current = requestAnimationFrame(() => {
@@ -33,7 +46,7 @@ export function useStickyScroll(containerRef: RefObject<HTMLDivElement | null>) 
       const ctrl = controllerRef.current;
       if (!el || !ctrl) return;
       const decision = ctrl.onContentChanged();
-      if (decision.scrollToBottom) el.scrollTop = el.scrollHeight;
+      if (decision.scrollToBottom) programmaticScrollTo(el, el.scrollHeight, ctrl);
     });
   }, [containerRef]);
 
@@ -42,7 +55,7 @@ export function useStickyScroll(containerRef: RefObject<HTMLDivElement | null>) 
     const ctrl = controllerRef.current;
     if (!el || !ctrl) return;
     const decision = ctrl.resume();
-    if (decision.scrollToBottom) el.scrollTop = el.scrollHeight;
+    if (decision.scrollToBottom) programmaticScrollTo(el, el.scrollHeight, ctrl);
     setIsAtBottom(true);
   }, [containerRef]);
 
@@ -69,7 +82,7 @@ export function useStickyScroll(containerRef: RefObject<HTMLDivElement | null>) 
 
     requestAnimationFrame(() => {
       const elNow = containerRef.current;
-      if (elNow && ctrl.follow) elNow.scrollTop = elNow.scrollHeight;
+      if (elNow && ctrl.follow) programmaticScrollTo(elNow, elNow.scrollHeight, ctrl);
     });
 
     return () => {

--- a/src/utils/useStickyScroll.ts
+++ b/src/utils/useStickyScroll.ts
@@ -5,85 +5,72 @@ import {
   useRef,
   useState,
 } from "react";
-
-/** Distance from the bottom (px) within which we consider the user "at bottom". */
-const BOTTOM_THRESHOLD = 60;
+import {
+  DEFAULT_BOTTOM_THRESHOLD,
+  StickyScrollController,
+} from "./stickyScrollController";
 
 /**
- * Sticky-follow scroll for chat windows.
- *
- * When the user is at (or near) the bottom, new content auto-scrolls the
- * container to keep up. Scrolling up breaks auto-follow. Clicking the returned
- * `scrollToBottom` re-enables it. Works with streaming content via
- * `handleContentChanged` — call it whenever content updates asynchronously so
- * the hook can scroll without waiting for a React render cycle.
- *
- * Uses a `programmaticRef` flag to distinguish auto-scrolls from user scrolls
- * so the scroll listener doesn't incorrectly detect our own scrolls as a
- * user-initiated "scroll away". A `requestAnimationFrame` coalescor prevents
- * stacked scroll calls during streaming bursts.
+ * React adapter over StickyScrollController. The controller (which has
+ * its own tests) owns the follow-intent flag; this hook just wires it
+ * up to ResizeObserver / MutationObserver and the container's scroll
+ * events. The unit tests for the bug-fix logic live next to the
+ * controller — see stickyScrollController.test.ts.
  */
 export function useStickyScroll(containerRef: RefObject<HTMLDivElement | null>) {
   const [isAtBottom, setIsAtBottom] = useState(true);
-  // Set before any programmatic scroll so the scroll listener knows to ignore it.
-  const programmaticRef = useRef(false);
+  const controllerRef = useRef<StickyScrollController | null>(null);
+  if (controllerRef.current === null) {
+    controllerRef.current = new StickyScrollController(DEFAULT_BOTTOM_THRESHOLD);
+  }
   const rafRef = useRef<number | null>(null);
 
-  const checkAndMaybeScroll = useCallback(() => {
-    const el = containerRef.current;
-    if (!el) return;
-    const atBottom =
-      el.scrollTop + el.clientHeight >= el.scrollHeight - BOTTOM_THRESHOLD;
-    if (atBottom) {
-      programmaticRef.current = true;
-      el.scrollTop = el.scrollHeight;
-      setIsAtBottom(true);
-    } else {
-      setIsAtBottom(false);
-    }
-  }, [containerRef]);
-
-  /** Call when async content changes (streaming tokens, new messages, etc.). */
   const handleContentChanged = useCallback(() => {
     if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
     rafRef.current = requestAnimationFrame(() => {
       rafRef.current = null;
-      checkAndMaybeScroll();
+      const el = containerRef.current;
+      const ctrl = controllerRef.current;
+      if (!el || !ctrl) return;
+      const decision = ctrl.onContentChanged();
+      if (decision.scrollToBottom) el.scrollTop = el.scrollHeight;
     });
-  }, [checkAndMaybeScroll]);
+  }, [containerRef]);
 
-  /** Snap to bottom and re-enable auto-follow. */
   const scrollToBottom = useCallback(() => {
     const el = containerRef.current;
-    if (!el) return;
-    programmaticRef.current = true;
-    el.scrollTop = el.scrollHeight;
+    const ctrl = controllerRef.current;
+    if (!el || !ctrl) return;
+    const decision = ctrl.resume();
+    if (decision.scrollToBottom) el.scrollTop = el.scrollHeight;
     setIsAtBottom(true);
   }, [containerRef]);
 
   useEffect(() => {
     const el = containerRef.current;
-    if (!el) return;
+    const ctrl = controllerRef.current;
+    if (!el || !ctrl) return;
 
     const onScroll = () => {
-      // Ignore scrolls we triggered ourselves.
-      if (programmaticRef.current) {
-        programmaticRef.current = false;
-        return;
-      }
-      const atBottom =
-        el.scrollTop + el.clientHeight >= el.scrollHeight - BOTTOM_THRESHOLD;
-      setIsAtBottom(atBottom);
+      const next = ctrl.onScroll({
+        scrollTop: el.scrollTop,
+        clientHeight: el.clientHeight,
+        scrollHeight: el.scrollHeight,
+      });
+      setIsAtBottom(next);
     };
 
-    // ResizeObserver: catches panel resize, window resize, font-size changes.
     const ro = new ResizeObserver(handleContentChanged);
-    // MutationObserver: catches new message nodes, streaming text, tool-card expansion.
     const mo = new MutationObserver(handleContentChanged);
 
     el.addEventListener("scroll", onScroll, { passive: true });
     ro.observe(el);
     mo.observe(el, { childList: true, subtree: true, characterData: true });
+
+    requestAnimationFrame(() => {
+      const elNow = containerRef.current;
+      if (elNow && ctrl.follow) elNow.scrollTop = elNow.scrollHeight;
+    });
 
     return () => {
       el.removeEventListener("scroll", onScroll);


### PR DESCRIPTION
## Summary

Hardens the bridge against misbehaving extensions and clears up a handful of UX bugs the user surfaced during a hang investigation in the `mold` project.

### Bridge safety
- `setState` size guard: warn at 64 KB, reject at 512 KB by default (configurable). Rate-limited per (kind, extension, path) with 60s windows + `+N suppressed` rollup so a setInterval-based misbehavior doesn't fill chat or logs.
- Per-path attribution memoizes the registering extension so async callbacks (where `currentExtensionName` has reset post-`register()`) still get the right name.
- New `extension_runtime_error` event drives a sticky, deduped notification per extension naming the path + limit. Routine size-guard WARNs are excluded from the chat-stderr filter.
- Configurable via `[extensions]` `state_warn_kb` / `state_hard_kb` in `~/.aethon/config.toml`. Resolved Rust-side, plumbed via `AETHON_STATE_*_KB` env vars. Bounds [1, 8192] KB; `hard < warn` is normalized.

### Turn lifecycle + hang escape
- `agent_start` / `agent_end` log lines with model + duration + stop reason, written to `~/.aethon/logs/bridge.YYYY-MM-DD.log`.
- 30s "Still working…" sticky notification with **Stop** + **Force restart** actions. Per-tab notification id (codex P2): tab B finishing no longer dismisses tab A's still-hung warning, and Stop targets the originating tab.
- New `force_restart_agent` Tauri command SIGKILLs the bun child from Rust, bypassing blocked stdin.

### UX bugs
- **Help → Aethon Documentation opens N tabs** — `app.on_menu_event` was registered inside `install_app_menu` (additive), so each `set_extension_menu_items` call stacked another forwarder. Moved to one-time setup.
- **Right-click on chat history doesn't show Delete** — only `session:` ids triggered the custom menu; `tab:` (open) ids fell through to WebKit. Both now show Delete; deleting an open tab closes it before deleting on disk.
- **Sticky scroll lost follow on every new message** — observer callback recomputed "at bottom?" from the post-mutation DOM. Replaced with a follow-intent flag updated only on user scroll events. Codex P2 follow-up: `notifyProgrammaticScroll()` is called only when `scrollTop` actually moves so the flag never goes stale.
- **Extensions sidebar was hardcoded** — now bound to `/sidebar/extensions`, hydrated from `extensionsList` / `failedExtensionsList` in the bridge `ready` payload.

## Test plan

- [x] `bunx tsc -b --noEmit` — clean
- [x] `bunx eslint .` — clean
- [x] `bunx vitest run` — 245 passing (36 new across `state-limits`, `stickyScrollController`, `sidebarHistory`)
- [x] `cargo test --lib` — 73 passing (8 new for `resolve_ext_state_limits` + extensions config section)
- [x] `cargo clippy -D warnings` — clean
- [x] Manual: image-gallery extension in `mold` project triggers WARN once per 60s with `+N suppressed` rollup, no chat spam, sticky notification appears and is deduped per extension.