### PR TITLE
refactor(components): extract text primitives (Phase 6 #2)

### DIFF
--- a/src/components/builtins.tsx
+++ b/src/components/builtins.tsx
@@ -15,11 +15,11 @@ import {
   resolveBoolean,
 } from "../utils/dataBinding";
 import { resolvePointer } from "../utils/jsonPointer";
-import { HighlightedCode } from "./HighlightedCode";
 import type { ComponentProps } from "./primitives/shared";
 import { resolvedName } from "./primitives/shared";
 
 export { Image, Icon } from "./primitives/media";
+export { Text, Heading, Paragraph, Code, Divider } from "./primitives/text";
 
 function formValues(form: HTMLFormElement): Record<string, unknown> {
   const values: Record<string, unknown> = {};
@@ -45,27 +45,6 @@ function formValues(form: HTMLFormElement): Record<string, unknown> {
   }
 
   return values;
-}
-
-// Text component
-export function Text({ component, state }: ComponentProps) {
-  const props = component.props as {
-    content: StringValue;
-    variant?: "body" | "small" | "large";
-    color?: string;
-  };
-
-  const content = resolveString(props.content, state);
-  const variant = props.variant || "body";
-  const color = props.color;
-
-  const style: CSSProperties = {
-    color: color || "inherit",
-    fontSize:
-      variant === "small" ? "0.875rem" : variant === "large" ? "1.125rem" : "1rem",
-  };
-
-  return <span style={style}>{content}</span>;
 }
 
 // Card component
@@ -209,76 +188,6 @@ export function Container({ component, state, renderChildren }: ComponentProps) 
       {renderChildren && renderChildren()}
     </div>
   );
-}
-
-// Code component — Prism-tokenized highlighter that drives every token
-// color from CSS custom properties (--syntax-keyword, --syntax-string, …).
-// Each palette wires its own values, so re-skinning highlighting is just a
-// matter of registering a new theme. Extensions that want a different
-// engine entirely (shiki, highlight.js, …) can register a higher-level
-// component and route their layouts at it instead of the primitive.
-export function Code({ component, state }: ComponentProps) {
-  const props = component.props as {
-    content: StringValue;
-    language?: string;
-    showLineNumbers?: BooleanValue;
-  };
-
-  const content = resolveString(props.content, state);
-  const language = props.language;
-  const showLineNumbers = props.showLineNumbers
-    ? resolveBoolean(props.showLineNumbers, state)
-    : false;
-
-  return (
-    <HighlightedCode
-      code={content}
-      language={language}
-      showLineNumbers={showLineNumbers}
-    />
-  );
-}
-
-// Heading primitive — wraps an h1/h2/h3 according to `level` prop.
-export function Heading({ component, state }: ComponentProps) {
-  const props = component.props as {
-    content: StringValue;
-    level?: 1 | 2 | 3 | 4 | 5 | 6;
-  };
-  const content = resolveString(props.content, state);
-  const level = props.level && props.level >= 1 && props.level <= 6 ? props.level : 2;
-  const Tag = (`h${level}` as unknown) as keyof React.JSX.IntrinsicElements;
-  return <Tag style={{ margin: 0 }}>{content}</Tag>;
-}
-
-// Paragraph primitive — text with default block flow.
-export function Paragraph({ component, state }: ComponentProps) {
-  const props = component.props as { content: StringValue };
-  const content = resolveString(props.content, state);
-  return <p style={{ margin: "0 0 8px 0", lineHeight: 1.5 }}>{content}</p>;
-}
-
-// Divider primitive — thin horizontal rule.
-export function Divider({ component }: ComponentProps) {
-  const props = component.props as
-    | { orientation?: "horizontal" | "vertical" }
-    | undefined;
-  const vertical = props?.orientation === "vertical";
-  const style: CSSProperties = vertical
-    ? {
-        width: 1,
-        alignSelf: "stretch",
-        background: "var(--border)",
-        margin: "0 8px",
-      }
-    : {
-        height: 1,
-        width: "100%",
-        background: "var(--border)",
-        margin: "8px 0",
-        border: "none",
-      };
-  return vertical ? <span style={style} aria-hidden /> : <hr style={style} />;
 }
 
 // Checkbox primitive — fires `change` with `{ value: boolean }`.

--- a/src/components/primitives/text.tsx
+++ b/src/components/primitives/text.tsx
@@ -1,0 +1,100 @@
+/**
+ * Text A2UI primitives — Text, Heading, Paragraph, Code, Divider.
+ */
+
+import type { CSSProperties } from "react";
+import type { BooleanValue, StringValue } from "../../types/a2ui";
+import { resolveBoolean, resolveString } from "../../utils/dataBinding";
+import { HighlightedCode } from "../HighlightedCode";
+import type { ComponentProps } from "./shared";
+
+// Text component
+export function Text({ component, state }: ComponentProps) {
+  const props = component.props as {
+    content: StringValue;
+    variant?: "body" | "small" | "large";
+    color?: string;
+  };
+
+  const content = resolveString(props.content, state);
+  const variant = props.variant || "body";
+  const color = props.color;
+
+  const style: CSSProperties = {
+    color: color || "inherit",
+    fontSize:
+      variant === "small" ? "0.875rem" : variant === "large" ? "1.125rem" : "1rem",
+  };
+
+  return <span style={style}>{content}</span>;
+}
+
+// Code component — Prism-tokenized highlighter that drives every token
+// color from CSS custom properties (--syntax-keyword, --syntax-string, …).
+// Each palette wires its own values, so re-skinning highlighting is just a
+// matter of registering a new theme. Extensions that want a different
+// engine entirely (shiki, highlight.js, …) can register a higher-level
+// component and route their layouts at it instead of the primitive.
+export function Code({ component, state }: ComponentProps) {
+  const props = component.props as {
+    content: StringValue;
+    language?: string;
+    showLineNumbers?: BooleanValue;
+  };
+
+  const content = resolveString(props.content, state);
+  const language = props.language;
+  const showLineNumbers = props.showLineNumbers
+    ? resolveBoolean(props.showLineNumbers, state)
+    : false;
+
+  return (
+    <HighlightedCode
+      code={content}
+      language={language}
+      showLineNumbers={showLineNumbers}
+    />
+  );
+}
+
+// Heading primitive — wraps an h1/h2/h3 according to `level` prop.
+export function Heading({ component, state }: ComponentProps) {
+  const props = component.props as {
+    content: StringValue;
+    level?: 1 | 2 | 3 | 4 | 5 | 6;
+  };
+  const content = resolveString(props.content, state);
+  const level = props.level && props.level >= 1 && props.level <= 6 ? props.level : 2;
+  const Tag = (`h${level}` as unknown) as keyof React.JSX.IntrinsicElements;
+  return <Tag style={{ margin: 0 }}>{content}</Tag>;
+}
+
+// Paragraph primitive — text with default block flow.
+export function Paragraph({ component, state }: ComponentProps) {
+  const props = component.props as { content: StringValue };
+  const content = resolveString(props.content, state);
+  return <p style={{ margin: "0 0 8px 0", lineHeight: 1.5 }}>{content}</p>;
+}
+
+// Divider primitive — thin horizontal rule.
+export function Divider({ component }: ComponentProps) {
+  const props = component.props as
+    | { orientation?: "horizontal" | "vertical" }
+    | undefined;
+  const vertical = props?.orientation === "vertical";
+  const style: CSSProperties = vertical
+    ? {
+        width: 1,
+        alignSelf: "stretch",
+        background: "var(--border)",
+        margin: "0 8px",
+      }
+    : {
+        height: 1,
+        width: "100%",
+        background: "var(--border)",
+        margin: "8px 0",
+        border: "none",
+      };
+  return vertical ? <span style={style} aria-hidden /> : <hr style={style} />;
+}


### PR DESCRIPTION
## Summary

Phase 6 split #2 of 5. Issue #43.

- Splits `Text`, `Heading`, `Paragraph`, `Code`, and `Divider` out of
  `src/components/builtins.tsx` into
  `src/components/primitives/text.tsx`.
- `builtins.tsx` re-exports them so existing call sites
  (`A2UIRenderer`, `builtins.test.tsx`) keep working unchanged.

No logic changes.

## Test plan

- [x] `bunx tsc -b --noEmit`
- [x] `bunx eslint .`
- [x] `bunx vitest run` (305 / 305 passed)

Refs #43. Stacked behind #44 (now merged).