### PR TITLE
refactor(app): split handleAgentMessage into typed handler registry (#36)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -26,6 +26,8 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@tauri-apps/cli": "^2.11.0",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
@@ -33,6 +35,7 @@
         "eslint": "^10.3.0",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.2",
+        "jsdom": "^29.1.1",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.59.1",
         "vite": "^8.0.1",
@@ -42,6 +45,14 @@
   },
   "packages": {
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.91.1", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw=="],
+
+    "@asamuzakjp/css-color": ["@asamuzakjp/css-color@5.1.11", "", { "dependencies": { "@asamuzakjp/generational-cache": "^1.0.1", "@csstools/css-calc": "^3.2.0", "@csstools/css-color-parser": "^4.1.0", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg=="],
+
+    "@asamuzakjp/dom-selector": ["@asamuzakjp/dom-selector@7.1.1", "", { "dependencies": { "@asamuzakjp/generational-cache": "^1.0.1", "@asamuzakjp/nwsapi": "^2.3.9", "bidi-js": "^1.0.3", "css-tree": "^3.2.1", "is-potential-custom-element-name": "^1.0.1" } }, "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ=="],
+
+    "@asamuzakjp/generational-cache": ["@asamuzakjp/generational-cache@1.0.1", "", {}, "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg=="],
+
+    "@asamuzakjp/nwsapi": ["@asamuzakjp/nwsapi@2.3.9", "", {}, "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q=="],
 
     "@aws-crypto/crc32": ["@aws-crypto/crc32@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg=="],
 
@@ -153,6 +164,20 @@
 
     "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
 
+    "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
+
+    "@csstools/color-helpers": ["@csstools/color-helpers@6.0.2", "", {}, "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q=="],
+
+    "@csstools/css-calc": ["@csstools/css-calc@3.2.0", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w=="],
+
+    "@csstools/css-color-parser": ["@csstools/css-color-parser@4.1.0", "", { "dependencies": { "@csstools/color-helpers": "^6.0.2", "@csstools/css-calc": "^3.2.0" }, "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ=="],
+
+    "@csstools/css-parser-algorithms": ["@csstools/css-parser-algorithms@4.0.0", "", { "peerDependencies": { "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w=="],
+
+    "@csstools/css-syntax-patches-for-csstree": ["@csstools/css-syntax-patches-for-csstree@1.1.3", "", { "peerDependencies": { "css-tree": "^3.2.1" }, "optionalPeers": ["css-tree"] }, "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg=="],
+
+    "@csstools/css-tokenizer": ["@csstools/css-tokenizer@4.0.0", "", {}, "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA=="],
+
     "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
@@ -174,6 +199,8 @@
     "@eslint/object-schema": ["@eslint/object-schema@3.0.5", "", {}, "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw=="],
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.7.1", "", { "dependencies": { "@eslint/core": "^1.2.1", "levn": "^0.4.1" } }, "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ=="],
+
+    "@exodus/bytes": ["@exodus/bytes@1.15.0", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ=="],
 
     "@google/genai": ["@google/genai@1.50.1", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-YbkX7H9+1Pt8wOt7DDREy8XSoiL6fRDzZQRyaVBarFf8MR3zHGqVdvM4cLbDXqPhxqvegZShgfxb8kw9C7YhAQ=="],
 
@@ -431,6 +458,10 @@
 
     "@tauri-apps/plugin-updater": ["@tauri-apps/plugin-updater@2.10.1", "", { "dependencies": { "@tauri-apps/api": "^2.10.1" } }, "sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA=="],
 
+    "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
+
+    "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
+
     "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
 
     "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
@@ -438,6 +469,8 @@
     "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
+
+    "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
@@ -527,11 +560,13 @@
 
     "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
 
-    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
-    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+    "ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
+
+    "aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
@@ -548,6 +583,8 @@
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.23", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-xwVXGqevyKPsiuQdLj+dZMVjidjJV508TBqexND5HrF89cGdCYCJFB3qhcxRHSeMctdCfbR1jrxBajhDy7o29g=="],
 
     "basic-ftp": ["basic-ftp@5.3.0", "", {}, "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w=="],
+
+    "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
 
     "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
 
@@ -591,11 +628,17 @@
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
+    "css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
+
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
     "data-uri-to-buffer": ["data-uri-to-buffer@6.0.2", "", {}, "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw=="],
 
+    "data-urls": ["data-urls@7.0.0", "", { "dependencies": { "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.0" } }, "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA=="],
+
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
 
     "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
 
@@ -611,6 +654,8 @@
 
     "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
 
+    "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
+
     "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.344", "", {}, "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg=="],
@@ -618,6 +663,8 @@
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
+
+    "entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
 
     "es-module-lexer": ["es-module-lexer@2.1.0", "", {}, "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ=="],
 
@@ -729,6 +776,8 @@
 
     "hosted-git-info": ["hosted-git-info@9.0.2", "", { "dependencies": { "lru-cache": "^11.1.0" } }, "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg=="],
 
+    "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
+
     "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
 
     "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
@@ -765,6 +814,8 @@
 
     "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
+    "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
+
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "istanbul-lib-coverage": ["istanbul-lib-coverage@3.2.2", "", {}, "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg=="],
@@ -773,7 +824,9 @@
 
     "istanbul-reports": ["istanbul-reports@3.2.0", "", { "dependencies": { "html-escaper": "^2.0.0", "istanbul-lib-report": "^3.0.0" } }, "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA=="],
 
-    "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "jsdom": ["jsdom@29.1.1", "", { "dependencies": { "@asamuzakjp/css-color": "^5.1.11", "@asamuzakjp/dom-selector": "^7.1.1", "@bramus/specificity": "^2.4.2", "@csstools/css-syntax-patches-for-csstree": "^1.1.3", "@exodus/bytes": "^1.15.0", "css-tree": "^3.2.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.3.5", "parse5": "^8.0.1", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.1", "undici": "^7.25.0", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.1", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q=="],
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
@@ -829,7 +882,9 @@
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
 
-    "lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
+    "lru-cache": ["lru-cache@11.3.5", "", {}, "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw=="],
+
+    "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
@@ -854,6 +909,8 @@
     "mdast-util-to-markdown": ["mdast-util-to-markdown@2.1.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "longest-streak": "^3.0.0", "mdast-util-phrasing": "^4.0.0", "mdast-util-to-string": "^4.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "unist-util-visit": "^5.0.0", "zwitch": "^2.0.0" } }, "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA=="],
 
     "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
+
+    "mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
 
     "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
 
@@ -947,7 +1004,7 @@
 
     "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
 
-    "parse5": ["parse5@5.1.1", "", {}, "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="],
+    "parse5": ["parse5@8.0.1", "", { "dependencies": { "entities": "^8.0.0" } }, "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw=="],
 
     "parse5-htmlparser2-tree-adapter": ["parse5-htmlparser2-tree-adapter@6.0.1", "", { "dependencies": { "parse5": "^6.0.1" } }, "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA=="],
 
@@ -973,6 +1030,8 @@
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
+    "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
+
     "proper-lockfile": ["proper-lockfile@4.1.2", "", { "dependencies": { "graceful-fs": "^4.2.4", "retry": "^0.12.0", "signal-exit": "^3.0.2" } }, "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA=="],
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
@@ -991,6 +1050,8 @@
 
     "react-dom": ["react-dom@19.2.5", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.5" } }, "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag=="],
 
+    "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
+
     "react-markdown": ["react-markdown@10.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "html-url-attributes": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "unified": "^11.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" }, "peerDependencies": { "@types/react": ">=18", "react": ">=18" } }, "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ=="],
 
     "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
@@ -1005,11 +1066,15 @@
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
     "retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
 
     "rolldown": ["rolldown@1.0.0-rc.17", "", { "dependencies": { "@oxc-project/types": "=0.127.0", "@rolldown/pluginutils": "1.0.0-rc.17" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.17", "@rolldown/binding-darwin-arm64": "1.0.0-rc.17", "@rolldown/binding-darwin-x64": "1.0.0-rc.17", "@rolldown/binding-freebsd-x64": "1.0.0-rc.17", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA=="],
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
@@ -1057,6 +1122,8 @@
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
+    "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
+
     "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
 
     "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
@@ -1069,7 +1136,15 @@
 
     "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
 
+    "tldts": ["tldts@7.0.30", "", { "dependencies": { "tldts-core": "^7.0.30" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw=="],
+
+    "tldts-core": ["tldts-core@7.0.30", "", {}, "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q=="],
+
     "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
+
+    "tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
+
+    "tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
 
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
@@ -1121,7 +1196,15 @@
 
     "vitest": ["vitest@4.1.5", "", { "dependencies": { "@vitest/expect": "4.1.5", "@vitest/mocker": "4.1.5", "@vitest/pretty-format": "4.1.5", "@vitest/runner": "4.1.5", "@vitest/snapshot": "4.1.5", "@vitest/spy": "4.1.5", "@vitest/utils": "4.1.5", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.5", "@vitest/browser-preview": "4.1.5", "@vitest/browser-webdriverio": "4.1.5", "@vitest/coverage-istanbul": "4.1.5", "@vitest/coverage-v8": "4.1.5", "@vitest/ui": "4.1.5", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg=="],
 
+    "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
+
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
+
+    "webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@5.0.0", "", {}, "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw=="],
+
+    "whatwg-url": ["whatwg-url@16.0.1", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
@@ -1134,6 +1217,10 @@
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
     "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
+
+    "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
+
+    "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
@@ -1165,8 +1252,6 @@
 
     "@aws-sdk/credential-provider-sso/@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1036.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.5", "@aws-sdk/nested-clients": "^3.997.3", "@aws-sdk/types": "^3.973.8", "@smithy/property-provider": "^4.2.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-aNSJ6jjDYayxN9ZA1JpycVScX93Lx03kKZ1EXt3DGOTahcWVLJj3oLAlop0xKP+vP2Ga2t49p1tEaMkTbCCaZA=="],
 
-    "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
-
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
@@ -1185,11 +1270,13 @@
 
     "@typescript-eslint/typescript-estree/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
+    "ast-v8-to-istanbul/js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
+
     "cli-highlight/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
-    "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+    "cli-highlight/parse5": ["parse5@5.1.1", "", {}, "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="],
 
-    "hosted-git-info/lru-cache": ["lru-cache@11.3.5", "", {}, "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw=="],
+    "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "make-dir/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
@@ -1201,11 +1288,15 @@
 
     "parse5-htmlparser2-tree-adapter/parse5": ["parse5@6.0.1", "", {}, "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="],
 
-    "path-scurry/lru-cache": ["lru-cache@11.3.5", "", {}, "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw=="],
+    "proxy-agent/lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
 
     "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.17", "", {}, "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg=="],
 
     "string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -1213,11 +1304,7 @@
 
     "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
 
-    "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
-    "string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
-    "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+    "cli-highlight/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "@aws-crypto/sha256-browser/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@tauri-apps/cli": "^2.11.0",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
@@ -43,6 +45,7 @@
     "eslint": "^10.3.0",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
+    "jsdom": "^29.1.1",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.59.1",
     "vite": "^8.0.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,6 @@ import type {
   NotificationEntry,
   NotificationKind,
 } from "./skills/default-layout/notifications";
-import { registerGrammar as registerHighlightGrammar } from "./utils/highlight";
 import type { A2UIPayload, ChatMessage } from "./types/a2ui";
 import {
   NO_PROJECT_KEY,
@@ -27,23 +26,18 @@ import {
   type ShellMeta,
   type Tab,
 } from "./types/tab";
-import { deletePointer, setPointer } from "./utils/jsonPointer";
 import { cycleShareMode } from "./utils/shareMode";
 import { shellQuoteAll } from "./utils/shellQuote";
 import { extractSessionId } from "./utils/sidebarHistory";
-import { deepMergeState, layoutPatch } from "./utils/stateMutation";
 import { applyUiScale } from "./utils/viewport";
 import { formatRelativeTime } from "./utils/time";
-import { coerceChatMessages } from "./utils/messages";
 import { useZoomAndTheme } from "./hooks/useZoomAndTheme";
 import { useShellConsent } from "./hooks/useShellConsent";
 import { useProjects } from "./hooks/useProjects";
 import { useTabNavigation } from "./hooks/useTabNavigation";
 import { useTabs, TAB_MIRROR_KEYS, TERMINAL_REPLAY_MAX } from "./hooks/useTabs";
-import {
-  useExtensionsHydration,
-  type ExtensionTheme,
-} from "./hooks/useExtensionsHydration";
+import { useExtensionsHydration } from "./hooks/useExtensionsHydration";
+import { useBridgeMessages } from "./hooks/useBridgeMessages";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
 import { useWindowApi } from "./runtime/windowApi";
 import { isFocusInTerminalPanel } from "./utils/focus";
@@ -73,12 +67,6 @@ import logoUrl from "./assets/aethon-logo.svg?url";
 
 // The default-layout skill ships a layout — that's the boot payload.
 const BOOT_LAYOUT: A2UIPayload = defaultLayoutSkill.layout!;
-
-interface ModelDescriptor {
-  id: string;
-  label: string;
-  provider: string;
-}
 
 interface RecentSessionItem {
   id: string;
@@ -306,14 +294,10 @@ export default function App() {
   // on `response_end`. Used to compute turn duration for the OS
   // completion notification gate.
   const turnStartedAtRef = useRef<Map<string, number>>(new Map());
-  // Hang-warn: push a sticky "Still working…" notification if the active tab
-  // stays waiting longer than HANG_WARN_MS. Per-tab timers keyed by tabId.
-  const HANG_WARN_MS = 30_000;
-  // Per-tab notification id so a `response_end` for tab B doesn't dismiss
-  // tab A's still-hung warning (codex P2 review feedback).
+  // Hang-warn: useBridgeMessages owns the timer scheduling + notification
+  // id. We expose these refs so the agent-reloaded / agent-crashed paths
+  // can clear timers + dismiss any pending warnings on supervisor signals.
   const hangWarnNotifId = (tabId: string) => `ae-hang-warn:${tabId}`;
-  // Track which tabs currently have a hang notification surfaced so the
-  // crash/reload paths can dismiss them all without scanning.
   const hangWarnActiveRef = useRef<Set<string>>(new Set());
   const hangWarnTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
   // P4: live config for OS notifications. Mirrors `config.ui.notifyOnCompletion`
@@ -990,42 +974,12 @@ export default function App() {
   }, [state]);
 
   useEffect(() => {
-    (async () => {
-      try {
-        await invoke("start_agent");
-        // Tell the bridge what layout we actually booted with so extensions
-        // calling api.getLayout() at register-time see a meaningful tree
-        // instead of null. The bridge stores it as `bootLayout` and
-        // _getLayout() folds it with any pending patches. Sent before
-        // `report` so the snapshot the bridge ships back includes it.
-        await invoke("agent_command", {
-          payload: JSON.stringify({ type: "boot_layout", payload: BOOT_LAYOUT }),
-        });
-        // Request a fresh `ready` event in case the agent process was already
-        // running before this React tree mounted (e.g. after a webview
-        // hot-reload). Newly-spawned agents emit ready unconditionally, so
-        // the duplicate is harmless.
-        await invoke("agent_command", {
-          payload: JSON.stringify({ type: "report" }),
-        });
-      } catch (err) {
-        appendMessage({
-          id: crypto.randomUUID(),
-          role: "agent",
-          text: `Failed to start agent: ${err}`,
-        });
-        setStatusFlags({ status: "error" });
-      }
-    })();
-
-    const unlistenResponse = listen<string>("agent-response", (event) => {
-      try {
-        const data = JSON.parse(event.payload);
-        handleAgentMessage(data);
-      } catch {
-        // Non-JSON line from the bridge — ignore.
-      }
-    });
+    // The boot sequence (start_agent → boot_layout → report) and the
+    // `agent-response` listener live in `useBridgeMessages` — see the
+    // call site near the bottom of this component. The remaining
+    // listeners below own OS-edge events (PTY streams, agent supervisor
+    // signals, native menu, drag-drop, paste) that aren't bridge
+    // messages, so they stay in this effect.
 
     // M6 P1: shell-output streams a PTY chunk. Append to the originating
     // shell-tab's terminalBuffer and dispatch a per-tab window event so
@@ -1434,7 +1388,6 @@ export default function App() {
     document.addEventListener("paste", onClipboardPaste, true);
 
     return () => {
-      unlistenResponse.then((fn) => fn());
       unlistenReload.then((fn) => fn());
       unlistenCrashed.then((fn) => fn());
       unlistenStderr.then((fn) => fn());
@@ -1447,994 +1400,6 @@ export default function App() {
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  // Ack a mutation back to the bridge so the awaiting Promise resolves.
-  // Called from every mutation case in handleAgentMessage that successfully
-  // applied (or rejected) the change. Fire-and-forget — we don't await the
-  // ack-send because the bridge ack channel is independent of any other
-  // outgoing message.
-  function ackMutation(
-    mutationId: unknown,
-    success: boolean,
-    error?: string,
-    data?: unknown,
-  ) {
-    if (typeof mutationId !== "string" || mutationId.length === 0) return;
-    invoke("agent_command", {
-      payload: JSON.stringify({
-        type: "mutation_ack",
-        mutationId,
-        success,
-        ...(error ? { error } : {}),
-        ...(data !== undefined ? { data } : {}),
-      }),
-    }).catch(() => {
-      /* bridge gone — extension's awaiter will hit the timeout instead */
-    });
-  }
-
-  function handleAgentMessage(data: { type?: string; [k: string]: unknown }) {
-    switch (data.type) {
-      case "ready": {
-        const model = (data.model as string) || "";
-        // Cache pi's default model so new tabs created before `ready` fires
-        // (or before a session's model initialises) can inherit it immediately
-        // instead of showing blank "model ▼".
-        if (model) piDefaultModelRef.current = model;
-        const models = (data.models as ModelDescriptor[]) ?? [];
-        // Hydrate any extension-registered component templates the bridge
-        // discovered at boot. setTemplates is wholesale (bridge is the
-        // source of truth) so reload-after-restart picks up the same set.
-        const extComponents = (data.extensionComponents as
-          | Record<string, unknown>
-          | undefined) ?? {};
-        const extState = (data.extensionState as
-          | Record<string, unknown>
-          | undefined) ?? {};
-        const extLayout = data.extensionLayout as A2UIPayload | undefined;
-        const extPatches = (data.extensionLayoutPatches as
-          | { path: string; value: unknown }[]
-          | undefined) ?? [];
-        const extThemes = (data.extensionThemes as ExtensionTheme[] | undefined) ?? [];
-        const extSlash = (data.extensionSlashCommands as
-          | { name: string; description: string; usage?: string }[]
-          | undefined) ?? [];
-        const extKeys = (data.extensionKeybindings as
-          | { combo: string; action: string; description?: string }[]
-          | undefined) ?? [];
-        const extMenu = (data.extensionMenuItems as
-          | {
-              id: string;
-              label: string;
-              action: string;
-              location: "app" | "tray";
-              parent?: string;
-            }[]
-          | undefined) ?? [];
-        const extEventRoutes = (data.extensionEventRoutes as
-          | { componentId?: string; eventType?: string }[]
-          | undefined) ?? [];
-        const extEventRoutingMode =
-          data.extensionEventRoutingMode === "extension" ? "extension" : "builtin";
-        const extLayouts = (data.extensionLayouts as
-          | {
-              id: string;
-              name: string;
-              description?: string;
-              payload: A2UIPayload;
-            }[]
-          | undefined) ?? [];
-        const extFrontendModules = (data.extensionFrontendModules as
-          | { name: string; code: string }[]
-          | undefined) ?? [];
-        const extStateKeys = ((data.extensionStateKeys as string[] | undefined) ?? []);
-        const discTabs = (data.discoveredTabs as DiscoveredSession[] | undefined) ?? [];
-        allDiscoveredSessionsRef.current = discTabs;
-        // Hydrate extension themes BEFORE the layout state merge below so
-        // /sidebar/themes carries the full list (built-ins + extension)
-        // when the merge runs. hydrateThemes also injects the CSS so a
-        // saved choice has the rule available before data-theme is read.
-        hydrateThemes(extThemes);
-        hydrateExtensions(
-          (data.extensionsList as { name: string; source: string }[] | undefined) ?? [],
-          (data.failedExtensionsList as { name: string; source: string; error?: string }[] | undefined) ?? [],
-        );
-        registry.setTemplates(extComponents);
-        // Restore extension-registered slash commands so the picker shows
-        // them on first paint (no need to wait for an extension_slash_commands
-        // delta after reload). hydrateSlashCommands rewrites the merged
-        // catalog (built-ins + extensions), updates the picker state ref,
-        // and bumps /slashCommands so the picker re-resolves via $ref.
-        hydrateSlashCommands(extSlash);
-        hydrateKeybindings(extKeys);
-        hydrateEventRoutes(extEventRoutes, extEventRoutingMode);
-        hydrateExtensionLayouts(extLayouts);
-        hydrateFrontendModules(extFrontendModules);
-        // Push the persisted menu list into Tauri so the native menu
-        // is correct on first paint after webview reload. Errors are
-        // logged but non-fatal — the menu falls back to built-ins-only.
-        if (extMenu.length > 0) {
-          invoke("set_extension_menu_items", { items: extMenu }).catch(
-            (err: unknown) => {
-              console.warn("[menu] set_extension_menu_items failed:", err);
-            },
-          );
-        }
-        // Surface discovered persistent sessions in the empty-state's
-        // recent-sessions list. Filter out tabIds we already have local
-        // records for so the same session isn't listed twice (open AND
-        // restorable). Format the lastModified into a "10m ago"-style
-        // label for the row's right-hand meta.
-        const knownIds = knownTabIds((data.tabs as { id: string }[] | undefined) ?? []);
-        const scopedDiscTabs = scopedDiscoveredSessions(discTabs);
-        const recentSessions = recentSessionItems(scopedDiscTabs, knownIds);
-        if (projectsLoadedRef.current) {
-          autoRestoreDiscoveredSessions(scopedDiscTabs, knownIds);
-        }
-        // Restore any extension-supplied layout, then replay queued
-        // patches. Falls back to the boot layout when none is reported
-        // so a removed/disabled extension stops bleeding stale chrome
-        // across agent reloads. The layout's own `state` hydrates below
-        // alongside extensionState — same semantics as the live
-        // `layout_set` path so replay matches.
-        const baseLayout: A2UIPayload =
-          extLayout &&
-          typeof extLayout === "object" &&
-          Array.isArray(extLayout.components)
-            ? extLayout
-            : BOOT_LAYOUT;
-        const patchedLayout = extPatches.reduce<A2UIPayload>(
-          (acc, p) => layoutPatch(acc, p.path, p.value),
-          baseLayout,
-        );
-        setLayout(patchedLayout);
-        // Snapshot the prune set BEFORE the setState callback so the side
-        // effect of updating lastExtensionStateKeysRef can stay outside
-        // setState — otherwise concurrent-mode re-runs of the callback
-        // would update the ref multiple times and race with the next
-        // ready's read. Compute willPrune (= prev set − new set) here
-        // and freeze it for the duration of this handler.
-        const willPruneKeys: string[] = [];
-        for (const stale of lastExtensionStateKeysRef.current) {
-          if (!extStateKeys.includes(stale)) willPruneKeys.push(stale);
-        }
-        // Update the ref BEFORE calling setState so the next ready (which
-        // may arrive in the same React batch) sees the new "previous" set.
-        lastExtensionStateKeysRef.current = new Set(extStateKeys);
-        setState((prev) => {
-          // Three-layer hydration in priority order (lowest → highest):
-          //   1. extension layout state — TREATED AS BOOT DEFAULTS
-          //      (only fills keys not already set; existing live state
-          //      like `messages` / `canvas` wins to avoid wiping
-          //      restored history when ready replays after a reload)
-          //   2. extension setState patches (last-write-wins overrides)
-          //   3. ready-owned runtime fields (model picker, status, etc.)
-          //
-          // Stale-key pruning: drop paths the previous ready tracked but
-          // this ready dropped (an extension was uninstalled). Without
-          // this, `prev` keeps the leftover slice forever (deepMerge
-          // doesn't remove keys, only adds/updates). The willPruneKeys
-          // diff was captured outside this callback so it's stable
-          // across concurrent-mode re-runs.
-          let next: Record<string, unknown> = { ...prev };
-          for (const stale of willPruneKeys) {
-            next = deletePointer(next, stale);
-          }
-          if (extLayout && extLayout.state) {
-            // Defaults semantics: deep-merge layout into a fresh object
-            // and let prev win for any overlapping keys.
-            next = deepMergeState(
-              extLayout.state,
-              next,
-            );
-          }
-          next = deepMergeState(next, extState);
-          // Reconcile our local tabs with the bridge's reported tabs.
-          // Two cases:
-          //   (a) webview reload while bridge is alive — bridge has tabs
-          //       we don't know about; create local records for them so
-          //       the user can re-access those sessions.
-          //   (b) bridge restart — local has tabs the bridge doesn't;
-          //       the post-ready replay below re-establishes them.
-          //
-          // Also hydrate per-tab mirrored state from extensionTabState
-          // — those values are the bridge's record of what extensions /
-          // agents wrote to /canvas, /messages, etc. for each tab. On a
-          // webview reload they're the only way to restore tab UI state
-          // that was driven by the agent (React state didn't survive).
-          {
-            const localTabs = ((next.tabs as Tab[] | undefined) ?? []).slice();
-            const bridgeTabs =
-              (data.tabs as { id: string; model: string }[] | undefined) ?? [];
-            const tabReplay =
-              (data.extensionTabState as Record<string, Record<string, unknown>> | undefined) ?? {};
-            const dIdx = localTabs.findIndex((t) => t.id === "default");
-            if (dIdx >= 0) {
-              localTabs[dIdx] = { ...localTabs[dIdx], model };
-            }
-            // Backfill any tab that has no model yet (e.g. opened before
-            // ready fired) with pi's default so the picker is never blank.
-            for (let i = 0; i < localTabs.length; i++) {
-              if (!localTabs[i].model && model) {
-                localTabs[i] = { ...localTabs[i], model };
-              }
-            }
-            for (const bt of bridgeTabs) {
-              if (bt.id === "default") continue;
-              const exists = localTabs.find((t) => t.id === bt.id);
-              if (exists) {
-                if (!exists.model && bt.model) {
-                  const idx = localTabs.indexOf(exists);
-                  localTabs[idx] = { ...exists, model: bt.model };
-                }
-                continue;
-              }
-              const label = `Tab ${localTabs.length + 1}`;
-              localTabs.push({
-                ...makeEmptyTab(bt.id, label, projectsRef.current.activeId),
-                model: bt.model,
-              });
-            }
-            // Apply the bridge's per-tab replay over each tab record.
-            // prev wins for keys the React side already restored (e.g.
-            // local-only message history) — agent-driven canvas /
-            // model fills the gaps.
-            for (let i = 0; i < localTabs.length; i++) {
-              const replay = tabReplay[localTabs[i].id];
-              if (!replay) continue;
-              const merged = { ...localTabs[i] } as unknown as Record<string, unknown>;
-              for (const [k, v] of Object.entries(replay)) {
-                // Only fill keys that aren't already populated locally,
-                // so a real local update beats a possibly-stale replay.
-                if (merged[k] === undefined || merged[k] === null ||
-                    (Array.isArray(merged[k]) && (merged[k] as unknown[]).length === 0) ||
-                    merged[k] === "") {
-                  merged[k] = v;
-                }
-              }
-              localTabs[i] = merged as unknown as Tab;
-            }
-            next.tabs = localTabs;
-          }
-          // The model + sidebar mirror tracks the ACTIVE tab, not the
-          // default — so a `ready` arriving while a non-default tab is
-          // active doesn't clobber the visible selection. Look up the
-          // active tab's model in the just-updated tabs array; fall
-          // back to data.model on first boot when no tab record exists.
-          const activeId = (next.activeTabId as string | undefined) ?? "default";
-          const tabsList = (next.tabs as Tab[] | undefined) ?? [];
-          const activeTab = tabsList.find((t) => t.id === activeId);
-          const activeModel = activeTab?.model || model;
-          next = {
-            ...next,
-            model: activeModel,
-            status: "ready",
-            connection: "connected",
-            recentSessions,
-            sidebar: {
-              ...((next.sidebar) ?? {}),
-              models: models.map((m) => ({
-                id: m.id,
-                label: m.label,
-                active: m.id === activeModel,
-              })),
-            },
-          };
-          // Re-mirror the active tab's full state to the root keys.
-          // Without this, ready-replayed values for /messages, /canvas,
-          // etc. live only on the tab record but the layout binds via
-          // the root mirror, so the user wouldn't see the restored
-          // state until they switched tabs and back.
-          if (activeTab) {
-            const tabRec = activeTab as unknown as Record<string, unknown>;
-            for (const key of TAB_MIRROR_KEYS) {
-              next[key as string] = tabRec[key as string];
-            }
-          }
-          return next;
-        });
-        // Re-establish bridge sessions for any non-default local tabs the
-        // user created before the agent reloaded. The bridge starts fresh
-        // each spawn — without this, prompts on those tabs would hit a
-        // tab the bridge has never seen and fail. After the session is
-        // open, also restore the tab's previously-selected model so the
-        // user doesn't silently send the next prompt to pi's default.
-        const localTabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
-        for (const t of localTabs) {
-          if (t.id === "default") continue;
-          // Pass `model` so the new bridge session boots with the same
-          // model the user previously selected — no race window.
-          // Track in pendingTabOpens so a fast first chat on the
-          // restored tab waits for the bridge to register the session
-          // (otherwise send_message would race tab_open and lazily
-          // create the tab without the inherited model).
-          // Same cwd inheritance as newTab — restored sessions land in the
-          // currently-active project unless they were opened before any
-          // project was set. The bridge dedupes paths internally, so a
-          // re-announce on existing tabs with the same cwd is a no-op.
-          const restoredCwd = activeProject(projectsRef.current)?.path;
-          const opening = invoke("agent_command", {
-            payload: JSON.stringify({
-              type: "tab_open",
-              tabId: t.id,
-              ...(t.model ? { model: t.model } : {}),
-              ...(restoredCwd ? { cwd: restoredCwd } : {}),
-            }),
-          });
-          pendingTabOpens.current.set(t.id, opening);
-          opening
-            .catch(() => {
-              /* surfaced on next chat send */
-            })
-            .finally(() => {
-              pendingTabOpens.current.delete(t.id);
-            });
-        }
-        // Post-respawn project re-announce. The bridge boots with
-        // process.cwd() — which is whatever directory bun was launched
-        // from, NOT necessarily the user's active project. If we don't
-        // re-announce, a hot-reload triggered while a non-cwd project
-        // is active leaves the wrong project's extensions loaded. The
-        // loop above only sends tab_open for non-default tabs, so when
-        // the active tab IS "default" (common: single-tab session)
-        // nothing announces. Send an explicit set_project for the
-        // active tab so the bridge swaps to the right project. The
-        // bridge short-circuits when cwd matches its currentProjectCwd
-        // so this is harmless on a fresh boot where the boot effect
-        // already announced.
-        const activeProj = activeProject(projectsRef.current);
-        if (activeProj) {
-          const activeTabId =
-            (stateRef.current.activeTabId as string | undefined) ?? "default";
-          announceProjectToBridge(activeTabId, activeProj.path);
-        }
-        break;
-      }
-      case "extension_components": {
-        const components = (data.components as Record<string, unknown>) ?? {};
-        registry.setTemplates(components);
-        ackMutation(data.mutationId, true);
-        break;
-      }
-      case "shell_query": {
-        // Bridge proxy for `aethon.shells.{list, read, write}`. Mode
-        // changes go through the status-bar badge (frontend invokes
-        // `shell_set_share_mode` directly), never through the agent
-        // surface; otherwise an extension could flip a private tab into
-        // sharing without a user gesture and bypass the opt-in boundary.
-        //
-        // For write: we check share mode here (read-write → overlay
-        // confirm; read-write-trusted → write directly; private/read →
-        // refuse), then invoke the Rust shell_write which gates again
-        // as defense-in-depth.
-        const op = data.op as string | undefined;
-        const args = (data.args as Record<string, unknown> | undefined) ?? {};
-        const mid = data.mutationId;
-        const route = async (): Promise<unknown> => {
-          if (op === "list") {
-            return await invoke("shell_list_shareable");
-          }
-          if (op === "read") {
-            return await invoke("shell_read_scrollback", { args });
-          }
-          if (op === "write") {
-            return await routeShellWrite(args);
-          }
-          throw new Error(`unknown shell_query op: ${op}`);
-        };
-        route()
-          .then((result) => ackMutation(mid, true, undefined, result))
-          .catch((err: unknown) => {
-            const msg = err instanceof Error ? err.message : String(err);
-            ackMutation(mid, false, msg);
-          });
-        break;
-      }
-      case "extension_themes": {
-        const themes = (data.themes as ExtensionTheme[] | undefined) ?? [];
-        hydrateThemes(themes);
-        ackMutation(data.mutationId, true);
-        break;
-      }
-      case "register_highlight_grammar": {
-        // Extension surface for the `code` primitive: a TextMate grammar
-        // for a language Shiki doesn't ship by default. Forward to the
-        // worker; it overwrites any prior grammar for the same lang and
-        // a follow-up highlight request picks it up. Bridge already
-        // validated lang + grammar shape, so we trust the payload here.
-        const lang = data.lang as string | undefined;
-        const grammar = data.grammar;
-        if (typeof lang === "string" && grammar) {
-          registerHighlightGrammar(lang, grammar);
-          ackMutation(data.mutationId, true);
-        } else {
-          ackMutation(data.mutationId, false, "register_highlight_grammar: bad payload");
-        }
-        break;
-      }
-      case "extension_slash_commands": {
-        const list = (data.commands as
-          | { name: string; description: string; usage?: string }[]
-          | undefined) ?? [];
-        hydrateSlashCommands(list);
-        ackMutation(data.mutationId, true);
-        break;
-      }
-      case "extension_keybindings": {
-        const list = (data.bindings as
-          | { combo: string; action: string; description?: string }[]
-          | undefined) ?? [];
-        hydrateKeybindings(list);
-        ackMutation(data.mutationId, true);
-        break;
-      }
-      case "extension_event_routes": {
-        const list = (data.routes as
-          | { componentId?: string; eventType?: string }[]
-          | undefined) ?? [];
-        const mode = data.mode === "extension" ? "extension" : "builtin";
-        hydrateEventRoutes(list, mode);
-        ackMutation(data.mutationId, true);
-        break;
-      }
-      case "extension_layouts": {
-        const list = (data.layouts as
-          | {
-              id: string;
-              name: string;
-              description?: string;
-              payload: A2UIPayload;
-            }[]
-          | undefined) ?? [];
-        hydrateExtensionLayouts(list);
-        ackMutation(data.mutationId, true);
-        break;
-      }
-      case "extension_frontend_modules": {
-        const list = (data.modules as
-          | { name: string; code: string }[]
-          | undefined) ?? [];
-        hydrateFrontendModules(list);
-        ackMutation(data.mutationId, true);
-        break;
-      }
-      case "extension_menu_items": {
-        const list = (data.items as
-          | {
-              id: string;
-              label: string;
-              action: string;
-              location: "app" | "tray";
-              parent?: string;
-            }[]
-          | undefined) ?? [];
-        // Forward to Tauri so the native menu rebuilds. Ack on success
-        // (rebuild) or failure (rare — usually means a malformed item
-        // slipped through validation).
-        invoke("set_extension_menu_items", { items: list })
-          .then(() => ackMutation(data.mutationId, true))
-          .catch((err: unknown) => {
-            const message = err instanceof Error ? err.message : String(err);
-            ackMutation(
-              data.mutationId,
-              false,
-              `frontend_rejected: set_extension_menu_items ${message}`,
-            );
-          });
-        break;
-      }
-      case "state_patch": {
-        // An extension pushed a state mutation. Two cases:
-        //
-        //   1. Path is a per-tab mirrored key (messages / draft / waiting
-        //      / queueCount / canvas / model):
-        //      - With data.tabId: route ONLY to that tab. updateTab will
-        //        also write to root if it happens to be the active tab.
-        //        Don't pre-mirror to root — that would briefly clobber
-        //        the active tab's view with a background tab's state.
-        //      - Without data.tabId: global setState with no tab context
-        //        (clock interval, polling extension). Apply to the active
-        //        tab so the layout sees it and a switch-back re-mirrors.
-        //   2. Path is global (anything else, e.g. /sidebar/...,
-        //      /counter/value, /custom): write directly to root state.
-        //      No tab-scoping needed — these aren't mirrored.
-        const path = data.path as string | undefined;
-        if (!path) {
-          ackMutation(data.mutationId, false, "missing path");
-          break;
-        }
-        const segs = path.split("/").filter(Boolean);
-        const top = segs[0] as keyof Tab | undefined;
-        const isMirrored = top !== undefined && TAB_MIRROR_KEYS.includes(top);
-        if (isMirrored) {
-          const writeIntoTab = (tab: Tab): Tab => {
-            const tabRec = { ...tab } as unknown as Record<string, unknown>;
-            if (segs.length === 1) {
-              tabRec[top as string] = data.value;
-            } else {
-              const before = tabRec[top as string];
-              const baseObj =
-                typeof before === "object" && before !== null
-                  ? (before as Record<string, unknown>)
-                  : {};
-              const nested = setPointer(baseObj, "/" + segs.slice(1).join("/"), data.value);
-              tabRec[top as string] = nested;
-            }
-            return tabRec as unknown as Tab;
-          };
-          const sourceTabId = data.tabId as string | undefined;
-          if (sourceTabId) {
-            updateTab(sourceTabId, writeIntoTab);
-          } else {
-            updateActiveTab(writeIntoTab);
-          }
-        } else {
-          setState((prev) => setPointer(prev, path, data.value));
-          // Track this path as extension-owned so the next `ready` knows
-          // to prune it if the extension that wrote it is gone. Without
-          // this, paths written via setState AFTER the last ready would
-          // never appear in lastExtensionStateKeysRef and would survive
-          // an extension uninstall as stale UI. (Codex review.)
-          lastExtensionStateKeysRef.current.add(path);
-        }
-        ackMutation(data.mutationId, true);
-        break;
-      }
-      case "layout_set": {
-        // Extension swapped the active layout wholesale. Goes through
-        // the same path window.aethon.setLayout uses so the new payload
-        // hydrates state and renders identically to a default-layout boot.
-        const next = data.payload as A2UIPayload | undefined;
-        if (!next || typeof next !== "object" || !Array.isArray(next.components)) {
-          ackMutation(data.mutationId, false, "payload missing components[]");
-          break;
-        }
-        setLayout(next);
-        if (next.state) {
-          // Layout state contributes BOOT DEFAULTS — only fills keys
-          // that aren't already set in live state. Existing runtime
-          // fields (status, model, connection, sidebar.models, …) win.
-          // Achieved by deep-merging with prev as the override layer.
-          setState((prev) =>
-            deepMergeState(next.state as Record<string, unknown>, prev),
-          );
-        }
-        ackMutation(data.mutationId, true);
-        break;
-      }
-      case "layout_patch": {
-        // Extension mutated a path inside the active layout (e.g. add a
-        // sidebar section, swap a child). Immutable patch that preserves
-        // arrays — the generic setPointer collapses arrays into plain
-        // objects on traversal because it spreads with `{...existing}`,
-        // which would crash the renderer on `components.map()`. Walk
-        // manually here so arrays stay arrays.
-        const path = data.path as string | undefined;
-        if (!path) {
-          ackMutation(data.mutationId, false, "missing path");
-          break;
-        }
-        setLayout((prev) => layoutPatch(prev, path, data.value));
-        ackMutation(data.mutationId, true);
-        break;
-      }
-      case "model_changed": {
-        // Per-tab model change. Bridge tags with tabId; default for legacy.
-        const model = (data.model as string) || "";
-        const tabId = (data.tabId as string | undefined) ?? "default";
-        updateTab(tabId, (tab) => ({ ...tab, model }));
-        // Sidebar model picker is global — reflects the active tab's model.
-        // (When a non-active tab changes model, we leave the picker alone
-        // so the user's currently visible context isn't surprised by it.)
-        if (stateRef.current.activeTabId === tabId) {
-          setState((prev) => {
-            const sidebar = (prev.sidebar as Record<string, unknown>) ?? {};
-            const items =
-              (sidebar.models as { id: string; label: string }[] | undefined) ?? [];
-            return {
-              ...prev,
-              status: `switched to ${model}`,
-              sidebar: {
-                ...sidebar,
-                models: items.map((m) => ({
-                  id: m.id,
-                  label: m.label,
-                  active: m.id === model,
-                })),
-              },
-            };
-          });
-        }
-        break;
-      }
-      case "tab_ready": {
-        // Bridge confirms a per-tab pi session is up and tells us its
-        // chosen model. Update the tab record so the sidebar can reflect
-        // it on next switch. If the tab is currently active, also refresh
-        // the model picker's `active` flag now (otherwise it'd lag until
-        // the user manually switched).
-        const tabId = (data.tabId as string | undefined) ?? "default";
-        const model = (data.model as string) ?? "";
-        updateTab(tabId, (tab) => ({ ...tab, model }));
-        if (stateRef.current.activeTabId === tabId) {
-          setState((prev) => ({
-            ...prev,
-            sidebar: recomputeModelPicker(
-              prev.sidebar as Record<string, unknown> | undefined,
-              model,
-            ),
-          }));
-        }
-        break;
-      }
-      case "session_history": {
-        const tabId = (data.tabId as string | undefined) ?? "default";
-        const messages = coerceChatMessages(data.messages);
-        updateTab(tabId, (tab) => ({ ...tab, messages }));
-        syncRecentSessionsToState();
-        break;
-      }
-      case "tab_closed": {
-        // Bridge confirms a tab session was torn down. We may have already
-        // removed it from local state in the close handler; this is just a
-        // signal in case some other path triggered the close.
-        const tabId = data.tabId as string | undefined;
-        if (!tabId) break;
-        let nextBuffer = "";
-        let switched = false;
-        setState((prev) => {
-          const tabs = ((prev.tabs as Tab[] | undefined) ?? []).filter((t) => t.id !== tabId);
-          if (tabs.length === 0) return prev; // shouldn't happen — bridge refuses to close default
-          let activeTabId = prev.activeTabId as string | undefined;
-          if (activeTabId === tabId) {
-            activeTabId = tabs[tabs.length - 1].id;
-            switched = true;
-          }
-          const result: Record<string, unknown> = { ...prev, tabs, activeTabId };
-          const target = tabs.find((t) => t.id === activeTabId)!;
-          nextBuffer = target.terminalBuffer ?? "";
-          const targetRec = target as unknown as Record<string, unknown>;
-          for (const key of TAB_MIRROR_KEYS) {
-            result[key as string] = targetRec[key as string];
-          }
-          result.sidebar = recomputeModelPicker(
-            prev.sidebar as Record<string, unknown> | undefined,
-            target.model,
-          );
-          return result;
-        });
-        if (switched) dispatchTerminalReplay(nextBuffer);
-        break;
-      }
-      case "response_delta": {
-        const delta = (data.content as string) ?? "";
-        if (!delta) break;
-        const messageId = (data.messageId as string) || undefined;
-        const tabId = (data.tabId as string | undefined) ?? "default";
-        appendOrAmendAgentText(delta, messageId, tabId);
-        break;
-      }
-      case "prompt_started": {
-        // Bridge tells us a prompt has begun. Sent for handler-driven
-        // ctx.pi.prompt AND every queue-drained turn (source: "queue")
-        // so Stop stays visible across followUp boundaries instead of
-        // flashing back to Send between turns. The remaining queue count
-        // rides along so the input badge stays accurate. tabId routes
-        // status to one tab; status bar text only flips for the active.
-        const tabId = (data.tabId as string | undefined) ?? "default";
-        const remaining = (data.queued as number | undefined) ?? undefined;
-        // Record turn start so response_end can compute duration and
-        // decide whether to fire the OS completion notification (P4).
-        turnStartedAtRef.current.set(tabId, Date.now());
-        updateTab(tabId, (tab) => ({
-          ...tab,
-          waiting: true,
-          ...(remaining !== undefined ? { queueCount: remaining } : {}),
-        }));
-        if (stateRef.current.activeTabId === tabId) {
-          setState((prev) => ({ ...prev, status: "thinking…" }));
-        }
-        // Start hang-warn timer. Reset if a queue-drained prompt_started
-        // fires for the same tab (the 30s clock restarts on each new turn).
-        {
-          const prev = hangWarnTimersRef.current.get(tabId);
-          if (prev !== undefined) clearTimeout(prev);
-          const handle = setTimeout(() => {
-            hangWarnTimersRef.current.delete(tabId);
-            const cur = stateRef.current;
-            if ((cur.activeTabId as string | undefined) !== tabId) return;
-            const tabs = (cur.tabs as Tab[] | undefined) ?? [];
-            const tab = tabs.find((t) => t.id === tabId);
-            if (!tab?.waiting) return;
-            hangWarnActiveRef.current.add(tabId);
-            pushNotification({
-              id: hangWarnNotifId(tabId),
-              title: "Still working…",
-              message: "The agent is taking longer than expected.",
-              kind: "warning",
-              durationMs: null,
-              actions: [
-                { label: "Stop", action: `hang-warn:stop:${tabId}` },
-                { label: "Force restart", action: "hang-warn:force-restart" },
-              ],
-            });
-          }, HANG_WARN_MS);
-          hangWarnTimersRef.current.set(tabId, handle);
-        }
-        break;
-      }
-      case "queued": {
-        // A new chat IPC arrived while a prompt was in flight; pi
-        // accepted it into the followUp queue. Bump the per-tab counter.
-        const tabId = (data.tabId as string | undefined) ?? "default";
-        updateTab(tabId, (tab) => ({ ...tab, queueCount: tab.queueCount + 1 }));
-        break;
-      }
-      case "queue_reset": {
-        // Bridge dropped this tab's pi follow-up queue (typically on
-        // Stop). Mirror by zeroing the local queueCount so the next
-        // response_end clears `waiting` instead of staying stuck on
-        // the "queue > 0 keeps Stop" gate.
-        const tabId = (data.tabId as string | undefined) ?? "default";
-        updateTab(tabId, (tab) => ({ ...tab, queueCount: 0 }));
-        break;
-      }
-      case "response_end": {
-        activeResponseIdRef.current = null;
-        const tabId = (data.tabId as string | undefined) ?? "default";
-        // Only clear waiting when the queue is actually empty. If pi has
-        // a followUp queued, it will fire agent_start → prompt_started
-        // immediately after this and re-flip waiting; clearing here
-        // would cause a Send-flash.
-        updateTab(tabId, (tab) => {
-          if (tab.queueCount > 0) return tab;
-          return { ...tab, waiting: false };
-        });
-        if (stateRef.current.activeTabId === tabId) {
-          setState((prev) => {
-            const q = (prev.queueCount as number) ?? 0;
-            if (q > 0) return prev;
-            return { ...prev, status: "ready" };
-          });
-        }
-        // Clear the hang-warn timer and dismiss this tab's notification
-        // (if it appeared). Per-tab id so an unrelated tab's response_end
-        // doesn't dismiss a still-hung tab's warning.
-        {
-          const h = hangWarnTimersRef.current.get(tabId);
-          if (h !== undefined) { clearTimeout(h); hangWarnTimersRef.current.delete(tabId); }
-          if (hangWarnActiveRef.current.delete(tabId)) {
-            dismissNotification(hangWarnNotifId(tabId));
-          }
-        }
-        // P4: fire native OS notification when an agent turn completes
-        // while the window is unfocused (or the originating tab isn't
-        // active). Only for "real" turns (≥ notifyMinDurationSeconds)
-        // and only if the user hasn't disabled via [ui] notify_on_completion.
-        const startedAt = turnStartedAtRef.current.get(tabId);
-        turnStartedAtRef.current.delete(tabId);
-        if (startedAt !== undefined) {
-          const turnDurationMs = Date.now() - startedAt;
-          void maybeFireCompletionNotification({
-            tabId,
-            turnDurationMs,
-          });
-        }
-        break;
-      }
-      case "error": {
-        const message = (data.message as string) ?? "unknown error";
-        const tabId = (data.tabId as string | undefined) ?? "default";
-        activeResponseIdRef.current = null;
-        appendMessage(
-          { id: crypto.randomUUID(), role: "agent", text: `Error: ${message}` },
-          tabId,
-        );
-        updateTab(tabId, (tab) => ({ ...tab, waiting: false }));
-        if (stateRef.current.activeTabId === tabId) {
-          setStatusFlags({ status: "error" });
-        }
-        break;
-      }
-      case "notice": {
-        // Non-terminal — surface as a system message but DO NOT touch
-        // waiting/status. Used e.g. when a second chat IPC arrives while a
-        // prompt is in-flight: the user sees the rejection but the Stop
-        // button and waiting state for the original prompt persist.
-        // Also surface as a warning toast so a notice that arrives
-        // while the user isn't looking at chat doesn't get missed.
-        const message = (data.message as string) ?? "";
-        const tabId = (data.tabId as string | undefined) ?? "default";
-        if (message) {
-          appendMessage(
-            { id: crypto.randomUUID(), role: "system", text: message },
-            tabId,
-          );
-          pushNotification({ title: message, kind: "warning" });
-        }
-        break;
-      }
-      case "notification": {
-        // Agent-pushed notification. Bridge supplies a stable id (so
-        // dismiss can reference it from agent code), title, optional
-        // message + kind + actions + durationMs. Auto-expiry runs on
-        // the frontend timer; the bridge doesn't track lifecycle.
-        const n = (data.notification as Partial<NotificationEntry> | undefined) ?? {};
-        if (typeof n.title === "string" && n.title) {
-          pushNotification({
-            ...(typeof n.id === "string" ? { id: n.id } : {}),
-            title: n.title,
-            ...(typeof n.message === "string" ? { message: n.message } : {}),
-            ...(n.kind ? { kind: n.kind } : {}),
-            ...(n.durationMs !== undefined ? { durationMs: n.durationMs } : {}),
-            ...(Array.isArray(n.actions) ? { actions: n.actions } : {}),
-          });
-        }
-        ackMutation(data.mutationId, true);
-        break;
-      }
-      case "notification_dismiss": {
-        const id = data.id as string | undefined;
-        if (id) dismissNotification(id);
-        ackMutation(data.mutationId, true);
-        break;
-      }
-      case "extension_lifecycle": {
-        // Generic feedback channel — abstract on purpose so layouts /
-        // extensions can decide how (or whether) to surface it.
-        //
-        // Default behavior in default-layout: dispatch a cancellable
-        // `aethon:extension-lifecycle` CustomEvent on window, then (if
-        // not preventDefault'd) append a system-notice chat bubble. A
-        // custom layout can listen on the event and call
-        // `e.preventDefault()` to swap a toast / sidebar pulse / status
-        // pill for the default chat-bubble — no source patches required.
-        const detail = {
-          name: (data.name as string) ?? "(unknown)",
-          source: (data.source as string) ?? "directory",
-          status: (data.status as "loaded" | "failed" | "skipped") ?? "loaded",
-          error: data.error as string | undefined,
-          path: data.path as string | undefined,
-        };
-        const tabId = (data.tabId as string | undefined) ?? "default";
-        const ev = new CustomEvent("aethon:extension-lifecycle", {
-          detail,
-          cancelable: true,
-        });
-        const proceed = window.dispatchEvent(ev);
-        if (proceed) {
-          // Default rendering — terse one-liner the user can recognize
-          // even when the agent's chat reply was eaten by a respawn.
-          const verb =
-            detail.status === "loaded"
-              ? "loaded"
-              : detail.status === "failed"
-                ? "failed to load"
-                : "skipped";
-          const suffix = detail.error ? ` — ${detail.error}` : "";
-          appendMessage(
-            {
-              id: crypto.randomUUID(),
-              role: "system",
-              text: `Extension \`${detail.name}\` ${verb}${suffix}.`,
-            },
-            tabId,
-          );
-        }
-        break;
-      }
-      case "extension_runtime_error": {
-        // Sticky, deduped notification per extension. Bridge already
-        // rate-limits the underlying log line, so we get one notification
-        // when the misbehavior starts (or resumes after the suppression
-        // window) — not one every 2s.
-        const name = (data.name as string | undefined) ?? "(unknown)";
-        const kind = (data.kind as string | undefined) ?? "error";
-        const path = (data.path as string | undefined) ?? "";
-        const sizeKB = data.sizeKB as number | undefined;
-        const limitKB = data.limitKB as number | undefined;
-        const message =
-          kind === "state-too-large" && sizeKB !== undefined && limitKB !== undefined
-            ? `setState ${path} rejected — ${sizeKB} KB exceeds ${limitKB} KB limit. Store file paths, not content.`
-            : `Extension reported a runtime error.`;
-        pushNotification({
-          id: `ext-runtime-error:${name}`,
-          title: `Extension \`${name}\` is misbehaving`,
-          message,
-          kind: "warning",
-          durationMs: null,
-        });
-        break;
-      }
-      // Legacy single-shot response (kept so old bridge builds still render).
-      case "response": {
-        const content = (data.content as string) ?? "";
-        const tabId = (data.tabId as string | undefined) ?? "default";
-        if (content) {
-          appendMessage(
-            { id: crypto.randomUUID(), role: "agent", text: content },
-            tabId,
-          );
-        }
-        if (data.done) {
-          updateTab(tabId, (tab) => ({ ...tab, waiting: false }));
-          if (stateRef.current.activeTabId === tabId) setStatusFlags({ status: "ready" });
-        }
-        break;
-      }
-      case "a2ui": {
-        const payload = data.payload as A2UIPayload | undefined;
-        const id = (data.id as string) || crypto.randomUUID();
-        const tabId = (data.tabId as string | undefined) ?? "default";
-        if (payload) {
-          appendMessage({ id, role: "agent", a2ui: payload }, tabId);
-        }
-        if (data.done) {
-          updateTab(tabId, (tab) => ({ ...tab, waiting: false }));
-          if (stateRef.current.activeTabId === tabId) setStatusFlags({ status: "ready" });
-        }
-        break;
-      }
-      case "terminal_output": {
-        const content = (data.content as string) ?? "";
-        if (!content) break;
-        const tabId = (data.tabId as string | undefined) ?? "default";
-        // Append to the originating tab's buffer (cap from the right so
-        // older content rotates out first). Three sinks now consume each
-        // chunk:
-        //   1. Per-tab Tab.terminalBuffer — the React record carrying
-        //      the rolling scrollback. Used by tab-switch replay.
-        //   2. Layout state at /terminal/buffer/<tabId> — bound by $ref
-        //      from any A2UI component that wants the live stream
-        //      (logging skills, alternative renderers).
-        //   3. window CustomEvents — `aethon:terminal` (active tab only,
-        //      drives xterm) and `aethon:terminal-tap` (every chunk
-        //      regardless of active tab, for multi-subscriber listeners
-        //      that need the full stream).
-        updateTab(tabId, (tab) => {
-          const next = (tab.terminalBuffer ?? "") + content;
-          const trimmed = next.length > TERMINAL_REPLAY_MAX
-            ? next.slice(next.length - TERMINAL_REPLAY_MAX)
-            : next;
-          return { ...tab, terminalBuffer: trimmed };
-        });
-        // Mirror the rolling buffer into shared layout state under
-        // /terminal/buffer/<tabId>. A2UI components can $ref it; the
-        // bridge sees it via getFrontendState. Path-based so an extension
-        // bound to ONE tab doesn't pick up every tab's stream.
-        setState((prev) => {
-          const term = (prev.terminal as Record<string, unknown> | undefined) ?? {};
-          const buffers = (term.buffer as Record<string, string> | undefined) ?? {};
-          const next = (buffers[tabId] ?? "") + content;
-          const trimmed = next.length > TERMINAL_REPLAY_MAX
-            ? next.slice(next.length - TERMINAL_REPLAY_MAX)
-            : next;
-          return {
-            ...prev,
-            terminal: {
-              ...term,
-              buffer: { ...buffers, [tabId]: trimmed },
-            },
-          };
-        });
-        if ((stateRef.current.activeTabId as string | undefined) === tabId) {
-          window.dispatchEvent(
-            new CustomEvent("aethon:terminal", { detail: content }),
-          );
-        }
-        // Tap event always fires (every tab, including background ones)
-        // so multi-subscriber listeners can attach without monkey-patching
-        // the existing single-subscriber pattern. detail carries tabId so
-        // the listener can filter.
-        window.dispatchEvent(
-          new CustomEvent("aethon:terminal-tap", {
-            detail: { tabId, content },
-          }),
-        );
-        break;
-      }
-    }
-  }
 
   // Append a chat message, or replace in place if a message with the same
   // id already exists. This is what lets the bridge stream "running…" tool
@@ -2584,6 +1549,64 @@ export default function App() {
     }
     syncProjectsToState();
   }
+
+  // Bridge IPC: spawns the agent on mount, runs the boot handshake
+  // (start_agent → boot_layout → report), and routes every
+  // `agent-response` event through the per-type handler registry under
+  // src/hooks/bridgeMessageHandlers/. Returns `ackMutation` for callers
+  // (none today, but kept on the public API) that need to settle a
+  // bridge promise outside the response path.
+  useBridgeMessages({
+    bootLayout: BOOT_LAYOUT,
+    onBootError: (err) => {
+      appendMessage({
+        id: crypto.randomUUID(),
+        role: "agent",
+        text: `Failed to start agent: ${err}`,
+      });
+      setStatusFlags({ status: "error" });
+    },
+    ctx: {
+      setState,
+      setLayout,
+      stateRef,
+      registry,
+      piDefaultModelRef,
+      allDiscoveredSessionsRef,
+      projectsRef,
+      projectsLoadedRef,
+      activeResponseIdRef,
+      hangWarnTimersRef,
+      hangWarnActiveRef,
+      turnStartedAtRef,
+      lastExtensionStateKeysRef,
+      pendingTabOpens,
+      updateTab,
+      updateActiveTab,
+      dispatchTerminalReplay,
+      autoRestoreDiscoveredSessions,
+      hydrateThemes,
+      hydrateExtensions,
+      hydrateSlashCommands,
+      hydrateKeybindings,
+      hydrateEventRoutes,
+      hydrateExtensionLayouts,
+      hydrateFrontendModules,
+      announceProjectToBridge,
+      appendMessage,
+      appendOrAmendAgentText,
+      setStatusFlags,
+      pushNotification,
+      dismissNotification,
+      maybeFireCompletionNotification,
+      knownTabIds,
+      scopedDiscoveredSessions,
+      recentSessionItems,
+      syncRecentSessionsToState,
+      recomputeModelPicker,
+      routeShellWrite,
+    },
+  });
 
   // Load projects once at boot. Done in its own effect so a slow disk
   // doesn't push out the agent-start path. Mirrors into state on resolve

--- a/src/hooks/bridgeMessageHandlers/a2ui.test.ts
+++ b/src/hooks/bridgeMessageHandlers/a2ui.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { handleA2ui } from "./a2ui";
+import { buildHandlerFixture } from "./testFixtures";
+import { makeEmptyTab } from "../../types/tab";
+
+describe("handleA2ui", () => {
+  it("appends an a2ui bubble and flips waiting on done", () => {
+    const { ctx, mocks } = buildHandlerFixture({
+      state: { activeTabId: "default" },
+    });
+    const payload = { components: [{ id: "x", type: "container" }] };
+    handleA2ui(
+      {
+        type: "a2ui",
+        payload,
+        id: "msg-1",
+        done: true,
+        tabId: "default",
+      },
+      ctx,
+    );
+    expect(mocks.appendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "msg-1", role: "agent", a2ui: payload }),
+      "default",
+    );
+    const [, updater] = mocks.updateTab.mock.calls[0];
+    expect(updater(makeEmptyTab("default", "Tab 1")).waiting).toBe(false);
+    expect(mocks.setStatusFlags).toHaveBeenCalledWith({ status: "ready" });
+  });
+});

--- a/src/hooks/bridgeMessageHandlers/a2ui.ts
+++ b/src/hooks/bridgeMessageHandlers/a2ui.ts
@@ -1,0 +1,17 @@
+import type { A2UIPayload } from "../../types/a2ui";
+import type { BridgeMessageHandler } from "./types";
+
+export const handleA2ui: BridgeMessageHandler = (data, ctx) => {
+  const payload = data.payload as A2UIPayload | undefined;
+  const id = (data.id as string) || crypto.randomUUID();
+  const tabId = (data.tabId as string | undefined) ?? "default";
+  if (payload) {
+    ctx.appendMessage({ id, role: "agent", a2ui: payload }, tabId);
+  }
+  if (data.done) {
+    ctx.updateTab(tabId, (tab) => ({ ...tab, waiting: false }));
+    if (ctx.stateRef.current.activeTabId === tabId) {
+      ctx.setStatusFlags({ status: "ready" });
+    }
+  }
+};

--- a/src/hooks/bridgeMessageHandlers/error.test.ts
+++ b/src/hooks/bridgeMessageHandlers/error.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { handleError } from "./error";
+import { buildHandlerFixture } from "./testFixtures";
+import { makeEmptyTab } from "../../types/tab";
+
+describe("handleError", () => {
+  it("appends an error message, clears waiting, sets error status when active", () => {
+    const { ctx, mocks } = buildHandlerFixture({
+      state: { activeTabId: "default" },
+    });
+    ctx.activeResponseIdRef.current = "msg-1";
+    handleError(
+      { type: "error", message: "boom", tabId: "default" },
+      ctx,
+    );
+    expect(ctx.activeResponseIdRef.current).toBeNull();
+    expect(mocks.appendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ role: "agent", text: "Error: boom" }),
+      "default",
+    );
+    const [, updater] = mocks.updateTab.mock.calls[0];
+    expect(updater(makeEmptyTab("default", "Tab 1")).waiting).toBe(false);
+    expect(mocks.setStatusFlags).toHaveBeenCalledWith({ status: "error" });
+  });
+});

--- a/src/hooks/bridgeMessageHandlers/error.ts
+++ b/src/hooks/bridgeMessageHandlers/error.ts
@@ -1,0 +1,15 @@
+import type { BridgeMessageHandler } from "./types";
+
+export const handleError: BridgeMessageHandler = (data, ctx) => {
+  const message = (data.message as string) ?? "unknown error";
+  const tabId = (data.tabId as string | undefined) ?? "default";
+  ctx.activeResponseIdRef.current = null;
+  ctx.appendMessage(
+    { id: crypto.randomUUID(), role: "agent", text: `Error: ${message}` },
+    tabId,
+  );
+  ctx.updateTab(tabId, (tab) => ({ ...tab, waiting: false }));
+  if (ctx.stateRef.current.activeTabId === tabId) {
+    ctx.setStatusFlags({ status: "error" });
+  }
+};

--- a/src/hooks/bridgeMessageHandlers/extensionComponents.test.ts
+++ b/src/hooks/bridgeMessageHandlers/extensionComponents.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from "vitest";
+import { handleExtensionComponents } from "./extensionComponents";
+import { buildHandlerFixture } from "./testFixtures";
+
+describe("handleExtensionComponents", () => {
+  it("hands templates to the registry and acks the mutation", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    const setTemplates = vi.spyOn(ctx.registry, "setTemplates");
+    handleExtensionComponents(
+      {
+        type: "extension_components",
+        components: { tpl: { type: "container" } },
+        mutationId: "m1",
+      },
+      ctx,
+    );
+    expect(setTemplates).toHaveBeenCalledWith({ tpl: { type: "container" } });
+    expect(mocks.ackMutation).toHaveBeenCalledWith("m1", true);
+  });
+});

--- a/src/hooks/bridgeMessageHandlers/extensionComponents.ts
+++ b/src/hooks/bridgeMessageHandlers/extensionComponents.ts
@@ -1,0 +1,9 @@
+import type { BridgeMessageHandler } from "./types";
+
+/** Bridge: a delta of extension-registered component templates. Wholesale
+ *  replace — bridge is the source of truth for the current template set. */
+export const handleExtensionComponents: BridgeMessageHandler = (data, ctx) => {
+  const components = (data.components as Record<string, unknown>) ?? {};
+  ctx.registry.setTemplates(components);
+  ctx.ackMutation(data.mutationId, true);
+};

--- a/src/hooks/bridgeMessageHandlers/extensionEventRoutes.test.ts
+++ b/src/hooks/bridgeMessageHandlers/extensionEventRoutes.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { handleExtensionEventRoutes } from "./extensionEventRoutes";
+import { buildHandlerFixture } from "./testFixtures";
+
+describe("handleExtensionEventRoutes", () => {
+  it("hydrates routes with builtin mode by default", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    const routes = [{ componentId: "btn-1", eventType: "click" }];
+    handleExtensionEventRoutes(
+      { type: "extension_event_routes", routes, mutationId: "m1" },
+      ctx,
+    );
+    expect(mocks.hydrateEventRoutes).toHaveBeenCalledWith(routes, "builtin");
+    expect(mocks.ackMutation).toHaveBeenCalledWith("m1", true);
+  });
+
+  it("forwards extension mode when set", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleExtensionEventRoutes(
+      { type: "extension_event_routes", routes: [], mode: "extension" },
+      ctx,
+    );
+    expect(mocks.hydrateEventRoutes).toHaveBeenCalledWith([], "extension");
+  });
+});

--- a/src/hooks/bridgeMessageHandlers/extensionEventRoutes.ts
+++ b/src/hooks/bridgeMessageHandlers/extensionEventRoutes.ts
@@ -1,0 +1,11 @@
+import type { BridgeMessageHandler } from "./types";
+
+export const handleExtensionEventRoutes: BridgeMessageHandler = (data, ctx) => {
+  const list =
+    (data.routes as
+      | { componentId?: string; eventType?: string }[]
+      | undefined) ?? [];
+  const mode = data.mode === "extension" ? "extension" : "builtin";
+  ctx.hydrateEventRoutes(list, mode);
+  ctx.ackMutation(data.mutationId, true);
+};

--- a/src/hooks/bridgeMessageHandlers/extensionFrontendModules.test.ts
+++ b/src/hooks/bridgeMessageHandlers/extensionFrontendModules.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { handleExtensionFrontendModules } from "./extensionFrontendModules";
+import { buildHandlerFixture } from "./testFixtures";
+
+describe("handleExtensionFrontendModules", () => {
+  it("hydrates frontend modules and acks", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    const modules = [{ name: "ext-a", code: "/* code */" }];
+    handleExtensionFrontendModules(
+      { type: "extension_frontend_modules", modules, mutationId: "m1" },
+      ctx,
+    );
+    expect(mocks.hydrateFrontendModules).toHaveBeenCalledWith(modules);
+    expect(mocks.ackMutation).toHaveBeenCalledWith("m1", true);
+  });
+});

--- a/src/hooks/bridgeMessageHandlers/extensionFrontendModules.ts
+++ b/src/hooks/bridgeMessageHandlers/extensionFrontendModules.ts
@@ -1,0 +1,8 @@
+import type { BridgeMessageHandler } from "./types";
+
+export const handleExtensionFrontendModules: BridgeMessageHandler = (data, ctx) => {
+  const list =
+    (data.modules as { name: string; code: string }[] | undefined) ?? [];
+  ctx.hydrateFrontendModules(list);
+  ctx.ackMutation(data.mutationId, true);
+};

--- a/src/hooks/bridgeMessageHandlers/extensionKeybindings.test.ts
+++ b/src/hooks/bridgeMessageHandlers/extensionKeybindings.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { handleExtensionKeybindings } from "./extensionKeybindings";
+import { buildHandlerFixture } from "./testFixtures";
+
+describe("handleExtensionKeybindings", () => {
+  it("hydrates keybindings and acks", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    const bindings = [{ combo: "Cmd+J", action: "do-thing" }];
+    handleExtensionKeybindings(
+      { type: "extension_keybindings", bindings, mutationId: "m1" },
+      ctx,
+    );
+    expect(mocks.hydrateKeybindings).toHaveBeenCalledWith(bindings);
+    expect(mocks.ackMutation).toHaveBeenCalledWith("m1", true);
+  });
+});

--- a/src/hooks/bridgeMessageHandlers/extensionKeybindings.ts
+++ b/src/hooks/bridgeMessageHandlers/extensionKeybindings.ts
@@ -1,0 +1,10 @@
+import type { BridgeMessageHandler } from "./types";
+
+export const handleExtensionKeybindings: BridgeMessageHandler = (data, ctx) => {
+  const list =
+    (data.bindings as
+      | { combo: string; action: string; description?: string }[]
+      | undefined) ?? [];
+  ctx.hydrateKeybindings(list);
+  ctx.ackMutation(data.mutationId, true);
+};

--- a/src/hooks/bridgeMessageHandlers/extensionLayouts.test.ts
+++ b/src/hooks/bridgeMessageHandlers/extensionLayouts.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { handleExtensionLayouts } from "./extensionLayouts";
+import { buildHandlerFixture } from "./testFixtures";
+
+describe("handleExtensionLayouts", () => {
+  it("hydrates extension-supplied layouts and acks", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    const layouts = [
+      { id: "alt", name: "Alt", payload: { components: [] } },
+    ];
+    handleExtensionLayouts(
+      { type: "extension_layouts", layouts, mutationId: "m1" },
+      ctx,
+    );
+    expect(mocks.hydrateExtensionLayouts).toHaveBeenCalledWith(layouts);
+    expect(mocks.ackMutation).toHaveBeenCalledWith("m1", true);
+  });
+});

--- a/src/hooks/bridgeMessageHandlers/extensionLayouts.ts
+++ b/src/hooks/bridgeMessageHandlers/extensionLayouts.ts
@@ -1,0 +1,16 @@
+import type { A2UIPayload } from "../../types/a2ui";
+import type { BridgeMessageHandler } from "./types";
+
+export const handleExtensionLayouts: BridgeMessageHandler = (data, ctx) => {
+  const list =
+    (data.layouts as
+      | {
+          id: string;
+          name: string;
+          description?: string;
+          payload: A2UIPayload;
+        }[]
+      | undefined) ?? [];
+  ctx.hydrateExtensionLayouts(list);
+  ctx.ackMutation(data.mutationId, true);
+};

--- a/src/hooks/bridgeMessageHandlers/extensionLifecycle.test.ts
+++ b/src/hooks/bridgeMessageHandlers/extensionLifecycle.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import { handleExtensionLifecycle } from "./extensionLifecycle";
+import { buildHandlerFixture } from "./testFixtures";
+
+describe("handleExtensionLifecycle", () => {
+  it("dispatches a window event and appends a system message by default", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    const seen: CustomEvent[] = [];
+    const listener = (e: Event) => seen.push(e as CustomEvent);
+    window.addEventListener("aethon:extension-lifecycle", listener);
+    try {
+      handleExtensionLifecycle(
+        {
+          type: "extension_lifecycle",
+          name: "ext-foo",
+          source: "directory",
+          status: "loaded",
+          tabId: "default",
+        },
+        ctx,
+      );
+      expect(seen).toHaveLength(1);
+      expect(seen[0].detail.name).toBe("ext-foo");
+      expect(mocks.appendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          role: "system",
+          text: expect.stringContaining("`ext-foo` loaded"),
+        }),
+        "default",
+      );
+    } finally {
+      window.removeEventListener("aethon:extension-lifecycle", listener);
+    }
+  });
+
+  it("skips the system message when a listener calls preventDefault", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    const listener = (e: Event) => e.preventDefault();
+    window.addEventListener("aethon:extension-lifecycle", listener);
+    try {
+      handleExtensionLifecycle(
+        { type: "extension_lifecycle", name: "x", status: "failed", error: "boom" },
+        ctx,
+      );
+      expect(mocks.appendMessage).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener("aethon:extension-lifecycle", listener);
+    }
+  });
+});

--- a/src/hooks/bridgeMessageHandlers/extensionLifecycle.ts
+++ b/src/hooks/bridgeMessageHandlers/extensionLifecycle.ts
@@ -1,0 +1,45 @@
+import type { BridgeMessageHandler } from "./types";
+
+/** Generic feedback channel — abstract on purpose so layouts /
+ *  extensions can decide how (or whether) to surface it.
+ *
+ *  Default behavior in default-layout: dispatch a cancellable
+ *  `aethon:extension-lifecycle` CustomEvent on window, then (if not
+ *  preventDefault'd) append a system-notice chat bubble. A custom layout
+ *  can listen on the event and call `e.preventDefault()` to swap a
+ *  toast / sidebar pulse / status pill for the default chat-bubble — no
+ *  source patches required. */
+export const handleExtensionLifecycle: BridgeMessageHandler = (data, ctx) => {
+  const detail = {
+    name: (data.name as string) ?? "(unknown)",
+    source: (data.source as string) ?? "directory",
+    status: (data.status as "loaded" | "failed" | "skipped") ?? "loaded",
+    error: data.error as string | undefined,
+    path: data.path as string | undefined,
+  };
+  const tabId = (data.tabId as string | undefined) ?? "default";
+  const ev = new CustomEvent("aethon:extension-lifecycle", {
+    detail,
+    cancelable: true,
+  });
+  const proceed = window.dispatchEvent(ev);
+  if (proceed) {
+    // Default rendering — terse one-liner the user can recognize even
+    // when the agent's chat reply was eaten by a respawn.
+    const verb =
+      detail.status === "loaded"
+        ? "loaded"
+        : detail.status === "failed"
+          ? "failed to load"
+          : "skipped";
+    const suffix = detail.error ? ` — ${detail.error}` : "";
+    ctx.appendMessage(
+      {
+        id: crypto.randomUUID(),
+        role: "system",
+        text: `Extension \`${detail.name}\` ${verb}${suffix}.`,
+      },
+      tabId,
+    );
+  }
+};

--- a/src/hooks/bridgeMessageHandlers/extensionMenuItems.test.ts
+++ b/src/hooks/bridgeMessageHandlers/extensionMenuItems.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { handleExtensionMenuItems } from "./extensionMenuItems";
+import { buildHandlerFixture } from "./testFixtures";
+import { clearTauriMocks, installTauriMocks } from "../../test/tauriMocks";
+
+describe("handleExtensionMenuItems", () => {
+  let harness: ReturnType<typeof installTauriMocks>;
+  beforeEach(() => {
+    harness = installTauriMocks();
+  });
+  afterEach(() => {
+    clearTauriMocks();
+  });
+
+  it("forwards items to set_extension_menu_items and acks on success", async () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    harness.invoke.mockResolvedValueOnce(undefined);
+    const items = [
+      { id: "i1", label: "Foo", action: "foo", location: "app" as const },
+    ];
+    handleExtensionMenuItems(
+      { type: "extension_menu_items", items, mutationId: "m1" },
+      ctx,
+    );
+    // Wait for the invoke promise to resolve.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(harness.invoke).toHaveBeenCalledWith("set_extension_menu_items", {
+      items,
+    });
+    expect(mocks.ackMutation).toHaveBeenCalledWith("m1", true);
+  });
+});

--- a/src/hooks/bridgeMessageHandlers/extensionMenuItems.ts
+++ b/src/hooks/bridgeMessageHandlers/extensionMenuItems.ts
@@ -1,0 +1,28 @@
+import { invoke } from "@tauri-apps/api/core";
+import type { BridgeMessageHandler } from "./types";
+
+export const handleExtensionMenuItems: BridgeMessageHandler = (data, ctx) => {
+  const list =
+    (data.items as
+      | {
+          id: string;
+          label: string;
+          action: string;
+          location: "app" | "tray";
+          parent?: string;
+        }[]
+      | undefined) ?? [];
+  // Forward to Tauri so the native menu rebuilds. Ack on success
+  // (rebuild) or failure (rare — usually means a malformed item
+  // slipped through validation).
+  invoke("set_extension_menu_items", { items: list })
+    .then(() => ctx.ackMutation(data.mutationId, true))
+    .catch((err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.ackMutation(
+        data.mutationId,
+        false,
+        `frontend_rejected: set_extension_menu_items ${message}`,
+      );
+    });
+};

--- a/src/hooks/bridgeMessageHandlers/extensionRuntimeError.test.ts
+++ b/src/hooks/bridgeMessageHandlers/extensionRuntimeError.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { handleExtensionRuntimeError } from "./extensionRuntimeError";
+import { buildHandlerFixture } from "./testFixtures";
+
+describe("handleExtensionRuntimeError", () => {
+  it("pushes a sticky warning notification keyed by extension name", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleExtensionRuntimeError(
+      {
+        type: "extension_runtime_error",
+        name: "ext-bad",
+        kind: "state-too-large",
+        path: "/foo",
+        sizeKB: 65,
+        limitKB: 16,
+      },
+      ctx,
+    );
+    expect(mocks.pushNotification).toHaveBeenCalledWith({
+      id: "ext-runtime-error:ext-bad",
+      title: "Extension `ext-bad` is misbehaving",
+      message:
+        "setState /foo rejected — 65 KB exceeds 16 KB limit. Store file paths, not content.",
+      kind: "warning",
+      durationMs: null,
+    });
+  });
+});

--- a/src/hooks/bridgeMessageHandlers/extensionRuntimeError.ts
+++ b/src/hooks/bridgeMessageHandlers/extensionRuntimeError.ts
@@ -1,0 +1,24 @@
+import type { BridgeMessageHandler } from "./types";
+
+/** Sticky, deduped notification per extension. Bridge already
+ *  rate-limits the underlying log line, so we get one notification when
+ *  the misbehavior starts (or resumes after the suppression window) —
+ *  not one every 2s. */
+export const handleExtensionRuntimeError: BridgeMessageHandler = (data, ctx) => {
+  const name = (data.name as string | undefined) ?? "(unknown)";
+  const kind = (data.kind as string | undefined) ?? "error";
+  const path = (data.path as string | undefined) ?? "";
+  const sizeKB = data.sizeKB as number | undefined;
+  const limitKB = data.limitKB as number | undefined;
+  const message =
+    kind === "state-too-large" && sizeKB !== undefined && limitKB !== undefined
+      ? `setState ${path} rejected — ${sizeKB} KB exceeds ${limitKB} KB limit. Store file paths, not content.`
+      : `Extension reported a runtime error.`;
+  ctx.pushNotification({
+    id: `ext-runtime-error:${name}`,
+    title: `Extension \`${name}\` is misbehaving`,
+    message,
+    kind: "warning",
+    durationMs: null,
+  });
+};

--- a/src/hooks/bridgeMessageHandlers/extensionSlashCommands.test.ts
+++ b/src/hooks/bridgeMessageHandlers/extensionSlashCommands.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { handleExtensionSlashCommands } from "./extensionSlashCommands";
+import { buildHandlerFixture } from "./testFixtures";
+
+describe("handleExtensionSlashCommands", () => {
+  it("hydrates slash commands and acks", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    const commands = [{ name: "foo", description: "bar" }];
+    handleExtensionSlashCommands(
+      { type: "extension_slash_commands", commands, mutationId: "m1" },
+      ctx,
+    );
+    expect(mocks.hydrateSlashCommands).toHaveBeenCalledWith(commands);
+    expect(mocks.ackMutation).toHaveBeenCalledWith("m1", true);
+  });
+});

--- a/src/hooks/bridgeMessageHandlers/extensionSlashCommands.ts
+++ b/src/hooks/bridgeMessageHandlers/extensionSlashCommands.ts
@@ -1,0 +1,10 @@
+import type { BridgeMessageHandler } from "./types";
+
+export const handleExtensionSlashCommands: BridgeMessageHandler = (data, ctx) => {
+  const list =
+    (data.commands as
+      | { name: string; description: string; usage?: string }[]
+      | undefined) ?? [];
+  ctx.hydrateSlashCommands(list);
+  ctx.ackMutation(data.mutationId, true);
+};

--- a/src/hooks/bridgeMessageHandlers/extensionThemes.test.ts
+++ b/src/hooks/bridgeMessageHandlers/extensionThemes.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { handleExtensionThemes } from "./extensionThemes";
+import { buildHandlerFixture } from "./testFixtures";
+
+describe("handleExtensionThemes", () => {
+  it("hydrates themes and acks", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    const themes = [{ id: "neon", label: "Neon", vars: {} }];
+    handleExtensionThemes(
+      { type: "extension_themes", themes, mutationId: "m1" },
+      ctx,
+    );
+    expect(mocks.hydrateThemes).toHaveBeenCalledWith(themes);
+    expect(mocks.ackMutation).toHaveBeenCalledWith("m1", true);
+  });
+});

--- a/src/hooks/bridgeMessageHandlers/extensionThemes.ts
+++ b/src/hooks/bridgeMessageHandlers/extensionThemes.ts
@@ -1,0 +1,8 @@
+import type { ExtensionTheme } from "../useExtensionsHydration";
+import type { BridgeMessageHandler } from "./types";
+
+export const handleExtensionThemes: BridgeMessageHandler = (data, ctx) => {
+  const themes = (data.themes as ExtensionTheme[] | undefined) ?? [];
+  ctx.hydrateThemes(themes);
+  ctx.ackMutation(data.mutationId, true);
+};

--- a/src/hooks/bridgeMessageHandlers/index.ts
+++ b/src/hooks/bridgeMessageHandlers/index.ts
@@ -1,0 +1,82 @@
+/** Bridge-message handler registry. Maps each `data.type` value the
+ *  agent bridge can emit to its handler. Adding a new bridge message:
+ *
+ *    1. Create `bridgeMessageHandlers/<name>.ts` exporting a handler
+ *       of type `BridgeMessageHandler`.
+ *    2. Register it here.
+ *    3. Add a happy-path test in `bridgeMessageHandlers/<name>.test.ts`.
+ *
+ *  The hook (useBridgeMessages) does the lookup; an unknown type is a
+ *  silent no-op (matches the previous switch-statement fall-through). */
+import type { BridgeMessageHandler } from "./types";
+import { handleA2ui } from "./a2ui";
+import { handleError } from "./error";
+import { handleExtensionComponents } from "./extensionComponents";
+import { handleExtensionEventRoutes } from "./extensionEventRoutes";
+import { handleExtensionFrontendModules } from "./extensionFrontendModules";
+import { handleExtensionKeybindings } from "./extensionKeybindings";
+import { handleExtensionLayouts } from "./extensionLayouts";
+import { handleExtensionLifecycle } from "./extensionLifecycle";
+import { handleExtensionMenuItems } from "./extensionMenuItems";
+import { handleExtensionRuntimeError } from "./extensionRuntimeError";
+import { handleExtensionSlashCommands } from "./extensionSlashCommands";
+import { handleExtensionThemes } from "./extensionThemes";
+import { handleLayoutPatch } from "./layoutPatch";
+import { handleLayoutSet } from "./layoutSet";
+import { handleModelChanged } from "./modelChanged";
+import { handleNotice } from "./notice";
+import { handleNotification } from "./notification";
+import { handleNotificationDismiss } from "./notificationDismiss";
+import { handlePromptStarted } from "./promptStarted";
+import { handleQueueReset } from "./queueReset";
+import { handleQueued } from "./queued";
+import { handleReady } from "./ready";
+import { handleRegisterHighlightGrammar } from "./registerHighlightGrammar";
+import { handleResponse } from "./response";
+import { handleResponseDelta } from "./responseDelta";
+import { handleResponseEnd } from "./responseEnd";
+import { handleSessionHistory } from "./sessionHistory";
+import { handleShellQuery } from "./shellQuery";
+import { handleStatePatch } from "./statePatch";
+import { handleTabClosed } from "./tabClosed";
+import { handleTabReady } from "./tabReady";
+import { handleTerminalOutput } from "./terminalOutput";
+
+export const bridgeMessageHandlers: Readonly<
+  Record<string, BridgeMessageHandler>
+> = Object.freeze({
+  a2ui: handleA2ui,
+  error: handleError,
+  extension_components: handleExtensionComponents,
+  extension_event_routes: handleExtensionEventRoutes,
+  extension_frontend_modules: handleExtensionFrontendModules,
+  extension_keybindings: handleExtensionKeybindings,
+  extension_layouts: handleExtensionLayouts,
+  extension_lifecycle: handleExtensionLifecycle,
+  extension_menu_items: handleExtensionMenuItems,
+  extension_runtime_error: handleExtensionRuntimeError,
+  extension_slash_commands: handleExtensionSlashCommands,
+  extension_themes: handleExtensionThemes,
+  layout_patch: handleLayoutPatch,
+  layout_set: handleLayoutSet,
+  model_changed: handleModelChanged,
+  notice: handleNotice,
+  notification: handleNotification,
+  notification_dismiss: handleNotificationDismiss,
+  prompt_started: handlePromptStarted,
+  queue_reset: handleQueueReset,
+  queued: handleQueued,
+  ready: handleReady,
+  register_highlight_grammar: handleRegisterHighlightGrammar,
+  response: handleResponse,
+  response_delta: handleResponseDelta,
+  response_end: handleResponseEnd,
+  session_history: handleSessionHistory,
+  shell_query: handleShellQuery,
+  state_patch: handleStatePatch,
+  tab_closed: handleTabClosed,
+  tab_ready: handleTabReady,
+  terminal_output: handleTerminalOutput,
+});
+
+export type { BridgeMessage, BridgeMessageContext, BridgeMessageHandler } from "./types";

--- a/src/hooks/bridgeMessageHandlers/layoutPatch.test.ts
+++ b/src/hooks/bridgeMessageHandlers/layoutPatch.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { handleLayoutPatch } from "./layoutPatch";
+import { buildHandlerFixture } from "./testFixtures";
+
+describe("handleLayoutPatch", () => {
+  it("acks failure when path is missing", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleLayoutPatch(
+      { type: "layout_patch", value: 1, mutationId: "m0" },
+      ctx,
+    );
+    expect(mocks.ackMutation).toHaveBeenCalledWith("m0", false, "missing path");
+    expect(mocks.setLayout).not.toHaveBeenCalled();
+  });
+
+  it("calls setLayout with a reducer applying the patch and acks", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleLayoutPatch(
+      {
+        type: "layout_patch",
+        path: "/components/0/text",
+        value: "hello",
+        mutationId: "m1",
+      },
+      ctx,
+    );
+    expect(mocks.setLayout).toHaveBeenCalledTimes(1);
+    expect(mocks.ackMutation).toHaveBeenCalledWith("m1", true);
+  });
+});

--- a/src/hooks/bridgeMessageHandlers/layoutPatch.ts
+++ b/src/hooks/bridgeMessageHandlers/layoutPatch.ts
@@ -1,0 +1,18 @@
+import { layoutPatch } from "../../utils/stateMutation";
+import type { BridgeMessageHandler } from "./types";
+
+/** Extension mutated a path inside the active layout (e.g. add a sidebar
+ *  section, swap a child). Immutable patch that preserves arrays — the
+ *  generic setPointer collapses arrays into plain objects on traversal
+ *  because it spreads with `{...existing}`, which would crash the
+ *  renderer on `components.map()`. Walk manually here so arrays stay
+ *  arrays. */
+export const handleLayoutPatch: BridgeMessageHandler = (data, ctx) => {
+  const path = data.path as string | undefined;
+  if (!path) {
+    ctx.ackMutation(data.mutationId, false, "missing path");
+    return;
+  }
+  ctx.setLayout((prev) => layoutPatch(prev, path, data.value));
+  ctx.ackMutation(data.mutationId, true);
+};

--- a/src/hooks/bridgeMessageHandlers/layoutSet.test.ts
+++ b/src/hooks/bridgeMessageHandlers/layoutSet.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { handleLayoutSet } from "./layoutSet";
+import { buildHandlerFixture } from "./testFixtures";
+
+describe("handleLayoutSet", () => {
+  it("acks failure when payload lacks components[]", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleLayoutSet(
+      { type: "layout_set", payload: {}, mutationId: "m1" },
+      ctx,
+    );
+    expect(mocks.ackMutation).toHaveBeenCalledWith(
+      "m1",
+      false,
+      "payload missing components[]",
+    );
+    expect(mocks.setLayout).not.toHaveBeenCalled();
+  });
+
+  it("sets the layout, deep-merges state defaults, and acks", () => {
+    const { ctx, mocks, applySetState } = buildHandlerFixture();
+    const payload = {
+      components: [{ id: "root", type: "container" }],
+      state: { greeting: "hi", existing: "default" },
+    };
+    handleLayoutSet(
+      { type: "layout_set", payload, mutationId: "m1" },
+      ctx,
+    );
+    expect(mocks.setLayout).toHaveBeenCalledWith(payload);
+    expect(mocks.ackMutation).toHaveBeenCalledWith("m1", true);
+    const next = applySetState({ existing: "live" });
+    // Live value should win over the layout default.
+    expect(next.existing).toBe("live");
+    expect(next.greeting).toBe("hi");
+  });
+});

--- a/src/hooks/bridgeMessageHandlers/layoutSet.ts
+++ b/src/hooks/bridgeMessageHandlers/layoutSet.ts
@@ -1,0 +1,25 @@
+import { deepMergeState } from "../../utils/stateMutation";
+import type { A2UIPayload } from "../../types/a2ui";
+import type { BridgeMessageHandler } from "./types";
+
+/** Extension swapped the active layout wholesale. Goes through the same
+ *  path window.aethon.setLayout uses so the new payload hydrates state
+ *  and renders identically to a default-layout boot. */
+export const handleLayoutSet: BridgeMessageHandler = (data, ctx) => {
+  const next = data.payload as A2UIPayload | undefined;
+  if (!next || typeof next !== "object" || !Array.isArray(next.components)) {
+    ctx.ackMutation(data.mutationId, false, "payload missing components[]");
+    return;
+  }
+  ctx.setLayout(next);
+  if (next.state) {
+    // Layout state contributes BOOT DEFAULTS — only fills keys that
+    // aren't already set in live state. Existing runtime fields
+    // (status, model, connection, sidebar.models, …) win. Achieved by
+    // deep-merging with prev as the override layer.
+    ctx.setState((prev) =>
+      deepMergeState(next.state as Record<string, unknown>, prev),
+    );
+  }
+  ctx.ackMutation(data.mutationId, true);
+};

--- a/src/hooks/bridgeMessageHandlers/modelChanged.test.ts
+++ b/src/hooks/bridgeMessageHandlers/modelChanged.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { handleModelChanged } from "./modelChanged";
+import { buildHandlerFixture } from "./testFixtures";
+import { makeEmptyTab } from "../../types/tab";
+
+describe("handleModelChanged", () => {
+  it("updates the tab and refreshes the picker for the active tab", () => {
+    const { ctx, mocks, applySetState } = buildHandlerFixture({
+      state: {
+        activeTabId: "default",
+        sidebar: {
+          models: [
+            { id: "claude", label: "Claude" },
+            { id: "gpt", label: "GPT" },
+          ],
+        },
+      },
+    });
+    handleModelChanged(
+      {
+        type: "model_changed",
+        tabId: "default",
+        model: "gpt",
+      },
+      ctx,
+    );
+    expect(mocks.updateTab).toHaveBeenCalledTimes(1);
+    const [tabId, updater] = mocks.updateTab.mock.calls[0];
+    expect(tabId).toBe("default");
+    expect(updater(makeEmptyTab("default", "Tab 1")).model).toBe("gpt");
+    const next = applySetState();
+    expect(next.status).toBe("switched to gpt");
+    expect((next.sidebar as { models: { id: string; active: boolean }[] }).models)
+      .toEqual([
+        { id: "claude", label: "Claude", active: false },
+        { id: "gpt", label: "GPT", active: true },
+      ]);
+  });
+
+  it("leaves the picker untouched when a non-active tab changes model", () => {
+    const { ctx, mocks } = buildHandlerFixture({
+      state: { activeTabId: "default" },
+    });
+    handleModelChanged(
+      { type: "model_changed", tabId: "tab-2", model: "gpt" },
+      ctx,
+    );
+    expect(mocks.updateTab).toHaveBeenCalledTimes(1);
+    expect(mocks.setState).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/bridgeMessageHandlers/modelChanged.ts
+++ b/src/hooks/bridgeMessageHandlers/modelChanged.ts
@@ -1,0 +1,30 @@
+import type { BridgeMessageHandler } from "./types";
+
+/** Per-tab model change. Bridge tags with tabId; default for legacy.
+ *  Sidebar model picker is global — reflects the active tab's model.
+ *  When a non-active tab changes model we leave the picker alone so the
+ *  user's currently visible context isn't surprised by it. */
+export const handleModelChanged: BridgeMessageHandler = (data, ctx) => {
+  const model = (data.model as string) || "";
+  const tabId = (data.tabId as string | undefined) ?? "default";
+  ctx.updateTab(tabId, (tab) => ({ ...tab, model }));
+  if (ctx.stateRef.current.activeTabId === tabId) {
+    ctx.setState((prev) => {
+      const sidebar = (prev.sidebar as Record<string, unknown>) ?? {};
+      const items =
+        (sidebar.models as { id: string; label: string }[] | undefined) ?? [];
+      return {
+        ...prev,
+        status: `switched to ${model}`,
+        sidebar: {
+          ...sidebar,
+          models: items.map((m) => ({
+            id: m.id,
+            label: m.label,
+            active: m.id === model,
+          })),
+        },
+      };
+    });
+  }
+};

--- a/src/hooks/bridgeMessageHandlers/notice.test.ts
+++ b/src/hooks/bridgeMessageHandlers/notice.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { handleNotice } from "./notice";
+import { buildHandlerFixture } from "./testFixtures";
+
+describe("handleNotice", () => {
+  it("appends a system message and pushes a warning toast", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleNotice(
+      { type: "notice", message: "queued for follow-up", tabId: "default" },
+      ctx,
+    );
+    expect(mocks.appendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ role: "system", text: "queued for follow-up" }),
+      "default",
+    );
+    expect(mocks.pushNotification).toHaveBeenCalledWith({
+      title: "queued for follow-up",
+      kind: "warning",
+    });
+  });
+
+  it("ignores empty messages", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleNotice({ type: "notice", message: "" }, ctx);
+    expect(mocks.appendMessage).not.toHaveBeenCalled();
+    expect(mocks.pushNotification).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/bridgeMessageHandlers/notice.ts
+++ b/src/hooks/bridgeMessageHandlers/notice.ts
@@ -1,0 +1,19 @@
+import type { BridgeMessageHandler } from "./types";
+
+/** Non-terminal — surface as a system message but DO NOT touch
+ *  waiting/status. Used e.g. when a second chat IPC arrives while a
+ *  prompt is in-flight: the user sees the rejection but the Stop button
+ *  and waiting state for the original prompt persist. Also surface as a
+ *  warning toast so a notice that arrives while the user isn't looking
+ *  at chat doesn't get missed. */
+export const handleNotice: BridgeMessageHandler = (data, ctx) => {
+  const message = (data.message as string) ?? "";
+  const tabId = (data.tabId as string | undefined) ?? "default";
+  if (message) {
+    ctx.appendMessage(
+      { id: crypto.randomUUID(), role: "system", text: message },
+      tabId,
+    );
+    ctx.pushNotification({ title: message, kind: "warning" });
+  }
+};

--- a/src/hooks/bridgeMessageHandlers/notification.test.ts
+++ b/src/hooks/bridgeMessageHandlers/notification.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { handleNotification } from "./notification";
+import { buildHandlerFixture } from "./testFixtures";
+
+describe("handleNotification", () => {
+  it("forwards a normalized notification and acks", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleNotification(
+      {
+        type: "notification",
+        notification: {
+          id: "ext-1",
+          title: "Hello",
+          message: "world",
+          kind: "info",
+          durationMs: 4000,
+        },
+        mutationId: "m1",
+      },
+      ctx,
+    );
+    expect(mocks.pushNotification).toHaveBeenCalledWith({
+      id: "ext-1",
+      title: "Hello",
+      message: "world",
+      kind: "info",
+      durationMs: 4000,
+    });
+    expect(mocks.ackMutation).toHaveBeenCalledWith("m1", true);
+  });
+
+  it("skips push when title is missing but still acks", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleNotification(
+      { type: "notification", notification: { message: "no title" }, mutationId: "m2" },
+      ctx,
+    );
+    expect(mocks.pushNotification).not.toHaveBeenCalled();
+    expect(mocks.ackMutation).toHaveBeenCalledWith("m2", true);
+  });
+});

--- a/src/hooks/bridgeMessageHandlers/notification.ts
+++ b/src/hooks/bridgeMessageHandlers/notification.ts
@@ -1,0 +1,21 @@
+import type { NotificationEntry } from "../../skills/default-layout/notifications";
+import type { BridgeMessageHandler } from "./types";
+
+/** Agent-pushed notification. Bridge supplies a stable id (so dismiss
+ *  can reference it from agent code), title, optional message + kind +
+ *  actions + durationMs. Auto-expiry runs on the frontend timer; the
+ *  bridge doesn't track lifecycle. */
+export const handleNotification: BridgeMessageHandler = (data, ctx) => {
+  const n = (data.notification as Partial<NotificationEntry> | undefined) ?? {};
+  if (typeof n.title === "string" && n.title) {
+    ctx.pushNotification({
+      ...(typeof n.id === "string" ? { id: n.id } : {}),
+      title: n.title,
+      ...(typeof n.message === "string" ? { message: n.message } : {}),
+      ...(n.kind ? { kind: n.kind } : {}),
+      ...(n.durationMs !== undefined ? { durationMs: n.durationMs } : {}),
+      ...(Array.isArray(n.actions) ? { actions: n.actions } : {}),
+    });
+  }
+  ctx.ackMutation(data.mutationId, true);
+};

--- a/src/hooks/bridgeMessageHandlers/notificationDismiss.test.ts
+++ b/src/hooks/bridgeMessageHandlers/notificationDismiss.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { handleNotificationDismiss } from "./notificationDismiss";
+import { buildHandlerFixture } from "./testFixtures";
+
+describe("handleNotificationDismiss", () => {
+  it("dismisses by id and acks", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleNotificationDismiss(
+      { type: "notification_dismiss", id: "ext-1", mutationId: "m1" },
+      ctx,
+    );
+    expect(mocks.dismissNotification).toHaveBeenCalledWith("ext-1");
+    expect(mocks.ackMutation).toHaveBeenCalledWith("m1", true);
+  });
+
+  it("skips dismiss when id is missing but still acks", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleNotificationDismiss(
+      { type: "notification_dismiss", mutationId: "m2" },
+      ctx,
+    );
+    expect(mocks.dismissNotification).not.toHaveBeenCalled();
+    expect(mocks.ackMutation).toHaveBeenCalledWith("m2", true);
+  });
+});

--- a/src/hooks/bridgeMessageHandlers/notificationDismiss.ts
+++ b/src/hooks/bridgeMessageHandlers/notificationDismiss.ts
@@ -1,0 +1,7 @@
+import type { BridgeMessageHandler } from "./types";
+
+export const handleNotificationDismiss: BridgeMessageHandler = (data, ctx) => {
+  const id = data.id as string | undefined;
+  if (id) ctx.dismissNotification(id);
+  ctx.ackMutation(data.mutationId, true);
+};

--- a/src/hooks/bridgeMessageHandlers/promptStarted.test.ts
+++ b/src/hooks/bridgeMessageHandlers/promptStarted.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { handlePromptStarted } from "./promptStarted";
+import { buildHandlerFixture } from "./testFixtures";
+import { makeEmptyTab } from "../../types/tab";
+
+describe("handlePromptStarted", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("flips waiting + records turn start + sets active status", () => {
+    const { ctx, mocks } = buildHandlerFixture({
+      state: { activeTabId: "default" },
+    });
+    handlePromptStarted(
+      { type: "prompt_started", tabId: "default", queued: 2 },
+      ctx,
+    );
+    expect(ctx.turnStartedAtRef.current.has("default")).toBe(true);
+    const [, updater] = mocks.updateTab.mock.calls[0];
+    const out = updater(makeEmptyTab("default", "Tab 1"));
+    expect(out.waiting).toBe(true);
+    expect(out.queueCount).toBe(2);
+    expect(mocks.setState).toHaveBeenCalledTimes(1);
+  });
+
+  it("schedules a hang-warn notification after hangWarnMs", () => {
+    const tabId = "default";
+    const { ctx, mocks } = buildHandlerFixture({
+      state: {
+        activeTabId: tabId,
+        tabs: [{ ...makeEmptyTab(tabId, "Tab 1"), waiting: true }],
+      },
+    });
+    handlePromptStarted({ type: "prompt_started", tabId }, ctx);
+    expect(mocks.pushNotification).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(ctx.hangWarnMs);
+    expect(mocks.pushNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: `ae-hang-warn:${tabId}`,
+        title: "Still working…",
+        kind: "warning",
+      }),
+    );
+    expect(ctx.hangWarnActiveRef.current.has(tabId)).toBe(true);
+  });
+});

--- a/src/hooks/bridgeMessageHandlers/promptStarted.ts
+++ b/src/hooks/bridgeMessageHandlers/promptStarted.ts
@@ -1,0 +1,51 @@
+import type { Tab } from "../../types/tab";
+import type { BridgeMessageHandler } from "./types";
+
+/** Bridge tells us a prompt has begun. Sent for handler-driven
+ *  ctx.pi.prompt AND every queue-drained turn (source: "queue") so Stop
+ *  stays visible across followUp boundaries instead of flashing back to
+ *  Send between turns. The remaining queue count rides along so the
+ *  input badge stays accurate. tabId routes status to one tab; status
+ *  bar text only flips for the active tab. */
+export const handlePromptStarted: BridgeMessageHandler = (data, ctx) => {
+  const tabId = (data.tabId as string | undefined) ?? "default";
+  const remaining = (data.queued as number | undefined) ?? undefined;
+  // Record turn start so response_end can compute duration and decide
+  // whether to fire the OS completion notification.
+  ctx.turnStartedAtRef.current.set(tabId, Date.now());
+  ctx.updateTab(tabId, (tab) => ({
+    ...tab,
+    waiting: true,
+    ...(remaining !== undefined ? { queueCount: remaining } : {}),
+  }));
+  if (ctx.stateRef.current.activeTabId === tabId) {
+    ctx.setState((prev) => ({ ...prev, status: "thinking…" }));
+  }
+  // Start hang-warn timer. Reset if a queue-drained prompt_started fires
+  // for the same tab (the 30s clock restarts on each new turn).
+  {
+    const prev = ctx.hangWarnTimersRef.current.get(tabId);
+    if (prev !== undefined) clearTimeout(prev);
+    const handle = setTimeout(() => {
+      ctx.hangWarnTimersRef.current.delete(tabId);
+      const cur = ctx.stateRef.current;
+      if ((cur.activeTabId as string | undefined) !== tabId) return;
+      const tabs = (cur.tabs as Tab[] | undefined) ?? [];
+      const tab = tabs.find((t) => t.id === tabId);
+      if (!tab?.waiting) return;
+      ctx.hangWarnActiveRef.current.add(tabId);
+      ctx.pushNotification({
+        id: ctx.hangWarnNotifId(tabId),
+        title: "Still working…",
+        message: "The agent is taking longer than expected.",
+        kind: "warning",
+        durationMs: null,
+        actions: [
+          { label: "Stop", action: `hang-warn:stop:${tabId}` },
+          { label: "Force restart", action: "hang-warn:force-restart" },
+        ],
+      });
+    }, ctx.hangWarnMs);
+    ctx.hangWarnTimersRef.current.set(tabId, handle);
+  }
+};

--- a/src/hooks/bridgeMessageHandlers/queueReset.test.ts
+++ b/src/hooks/bridgeMessageHandlers/queueReset.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { handleQueueReset } from "./queueReset";
+import { buildHandlerFixture } from "./testFixtures";
+import { makeEmptyTab } from "../../types/tab";
+
+describe("handleQueueReset", () => {
+  it("zeroes the per-tab queueCount", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleQueueReset({ type: "queue_reset", tabId: "default" }, ctx);
+    const [, updater] = mocks.updateTab.mock.calls[0];
+    const seed = { ...makeEmptyTab("default", "Tab 1"), queueCount: 7 };
+    expect(updater(seed).queueCount).toBe(0);
+  });
+});

--- a/src/hooks/bridgeMessageHandlers/queueReset.ts
+++ b/src/hooks/bridgeMessageHandlers/queueReset.ts
@@ -1,0 +1,10 @@
+import type { BridgeMessageHandler } from "./types";
+
+/** Bridge dropped this tab's pi follow-up queue (typically on Stop).
+ *  Mirror by zeroing the local queueCount so the next response_end
+ *  clears `waiting` instead of staying stuck on the
+ *  "queue > 0 keeps Stop" gate. */
+export const handleQueueReset: BridgeMessageHandler = (data, ctx) => {
+  const tabId = (data.tabId as string | undefined) ?? "default";
+  ctx.updateTab(tabId, (tab) => ({ ...tab, queueCount: 0 }));
+};

--- a/src/hooks/bridgeMessageHandlers/queued.test.ts
+++ b/src/hooks/bridgeMessageHandlers/queued.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { handleQueued } from "./queued";
+import { buildHandlerFixture } from "./testFixtures";
+import { makeEmptyTab } from "../../types/tab";
+
+describe("handleQueued", () => {
+  it("bumps the per-tab queueCount", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleQueued({ type: "queued", tabId: "default" }, ctx);
+    const [tabId, updater] = mocks.updateTab.mock.calls[0];
+    expect(tabId).toBe("default");
+    const seed = { ...makeEmptyTab("default", "Tab 1"), queueCount: 3 };
+    expect(updater(seed).queueCount).toBe(4);
+  });
+});

--- a/src/hooks/bridgeMessageHandlers/queued.ts
+++ b/src/hooks/bridgeMessageHandlers/queued.ts
@@ -1,0 +1,8 @@
+import type { BridgeMessageHandler } from "./types";
+
+/** A new chat IPC arrived while a prompt was in flight; pi accepted it
+ *  into the followUp queue. Bump the per-tab counter. */
+export const handleQueued: BridgeMessageHandler = (data, ctx) => {
+  const tabId = (data.tabId as string | undefined) ?? "default";
+  ctx.updateTab(tabId, (tab) => ({ ...tab, queueCount: tab.queueCount + 1 }));
+};

--- a/src/hooks/bridgeMessageHandlers/ready.test.ts
+++ b/src/hooks/bridgeMessageHandlers/ready.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { handleReady } from "./ready";
+import { buildHandlerFixture } from "./testFixtures";
+import { clearTauriMocks, installTauriMocks } from "../../test/tauriMocks";
+
+describe("handleReady", () => {
+  beforeEach(() => {
+    installTauriMocks();
+  });
+  afterEach(() => {
+    clearTauriMocks();
+  });
+
+  it("hydrates extensions, sets layout, fills active model, and pushes ready status", () => {
+    const { ctx, mocks, applySetState } = buildHandlerFixture({
+      state: {
+        activeTabId: "default",
+        tabs: [{ id: "default", model: "" }],
+        sidebar: {},
+      },
+    });
+    handleReady(
+      {
+        type: "ready",
+        model: "claude",
+        models: [
+          { id: "claude", label: "Claude", provider: "anthropic" },
+          { id: "gpt", label: "GPT", provider: "openai" },
+        ],
+        extensionsList: [{ name: "ext-a", source: "directory" }],
+        failedExtensionsList: [],
+        extensionThemes: [],
+        extensionSlashCommands: [],
+        extensionKeybindings: [],
+        extensionEventRoutes: [],
+        extensionLayouts: [],
+        extensionFrontendModules: [],
+        extensionStateKeys: [],
+        extensionMenuItems: [],
+        discoveredTabs: [],
+        tabs: [{ id: "default", model: "claude" }],
+        extensionTabState: {},
+      },
+      ctx,
+    );
+    expect(ctx.piDefaultModelRef.current).toBe("claude");
+    expect(mocks.hydrateThemes).toHaveBeenCalledTimes(1);
+    expect(mocks.hydrateExtensions).toHaveBeenCalledWith(
+      [{ name: "ext-a", source: "directory" }],
+      [],
+    );
+    expect(mocks.setLayout).toHaveBeenCalledTimes(1);
+    const next = applySetState({
+      activeTabId: "default",
+      tabs: [{ id: "default", model: "" }],
+      sidebar: {},
+    });
+    expect(next.status).toBe("ready");
+    expect(next.connection).toBe("connected");
+    expect(next.model).toBe("claude");
+    expect(
+      (next.sidebar as { models: { id: string; active: boolean }[] }).models,
+    ).toEqual([
+      { id: "claude", label: "Claude", active: true },
+      { id: "gpt", label: "GPT", active: false },
+    ]);
+  });
+
+  it("prunes extension state keys that disappeared between readies", () => {
+    const { ctx, applySetState } = buildHandlerFixture({
+      state: { activeTabId: "default", tabs: [{ id: "default" }], sidebar: {} },
+    });
+    ctx.lastExtensionStateKeysRef.current = new Set(["/old", "/keep"]);
+    handleReady(
+      {
+        type: "ready",
+        model: "claude",
+        models: [],
+        extensionStateKeys: ["/keep"],
+        tabs: [{ id: "default", model: "claude" }],
+      },
+      ctx,
+    );
+    expect(ctx.lastExtensionStateKeysRef.current.has("/old")).toBe(false);
+    expect(ctx.lastExtensionStateKeysRef.current.has("/keep")).toBe(true);
+    const next = applySetState({
+      activeTabId: "default",
+      tabs: [{ id: "default" }],
+      sidebar: {},
+      old: "stale",
+      keep: "live",
+    });
+    expect(next).not.toHaveProperty("old");
+  });
+
+  it("calls auto-restore only after projects are loaded", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleReady(
+      { type: "ready", tabs: [], discoveredTabs: [] },
+      ctx,
+    );
+    expect(mocks.autoRestoreDiscoveredSessions).not.toHaveBeenCalled();
+
+    const second = buildHandlerFixture();
+    second.ctx.projectsLoadedRef.current = true;
+    handleReady(
+      { type: "ready", tabs: [], discoveredTabs: [{ tabId: "x", lastModified: 1 }] },
+      second.ctx,
+    );
+    expect(second.mocks.autoRestoreDiscoveredSessions).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-announces the active project after a respawn", () => {
+    const { ctx, mocks } = buildHandlerFixture({
+      state: { activeTabId: "default", tabs: [] },
+    });
+    ctx.projectsRef.current = {
+      activeId: "p1",
+      projects: [
+        { id: "p1", label: "p1", path: "/tmp/p1", lastUsed: Date.now() },
+      ],
+    };
+    handleReady({ type: "ready", model: "claude", tabs: [] }, ctx);
+    expect(mocks.announceProjectToBridge).toHaveBeenCalledWith(
+      "default",
+      "/tmp/p1",
+    );
+  });
+});
+
+// Quiet the ESLint vi-unused warning when fake timers aren't used.
+void vi;

--- a/src/hooks/bridgeMessageHandlers/ready.ts
+++ b/src/hooks/bridgeMessageHandlers/ready.ts
@@ -1,0 +1,342 @@
+import { invoke } from "@tauri-apps/api/core";
+import type { A2UIPayload } from "../../types/a2ui";
+import { activeProject } from "../../projects";
+import { TAB_MIRROR_KEYS } from "../useTabs";
+import { makeEmptyTab, type Tab } from "../../types/tab";
+import { deepMergeState, layoutPatch } from "../../utils/stateMutation";
+import { deletePointer } from "../../utils/jsonPointer";
+import type { ExtensionTheme } from "../useExtensionsHydration";
+import type {
+  BridgeMessageHandler,
+  DiscoveredSession,
+  ModelDescriptor,
+} from "./types";
+
+/** The biggest handler: extension hydration + session restore + model
+ *  picker + tabs reconcile. Called whenever the bridge fires `ready` —
+ *  on first boot, after a hot-reload, after an `report` request from
+ *  the boot sequence. */
+export const handleReady: BridgeMessageHandler = (data, ctx) => {
+  const model = (data.model as string) || "";
+  // Cache pi's default model so new tabs created before `ready` fires
+  // (or before a session's model initialises) can inherit it immediately
+  // instead of showing blank "model ▼".
+  if (model) ctx.piDefaultModelRef.current = model;
+  const models = (data.models as ModelDescriptor[]) ?? [];
+  // Hydrate any extension-registered component templates the bridge
+  // discovered at boot. setTemplates is wholesale (bridge is the source
+  // of truth) so reload-after-restart picks up the same set.
+  const extComponents =
+    (data.extensionComponents as Record<string, unknown> | undefined) ?? {};
+  const extState =
+    (data.extensionState as Record<string, unknown> | undefined) ?? {};
+  const extLayout = data.extensionLayout as A2UIPayload | undefined;
+  const extPatches =
+    (data.extensionLayoutPatches as
+      | { path: string; value: unknown }[]
+      | undefined) ?? [];
+  const extThemes =
+    (data.extensionThemes as ExtensionTheme[] | undefined) ?? [];
+  const extSlash =
+    (data.extensionSlashCommands as
+      | { name: string; description: string; usage?: string }[]
+      | undefined) ?? [];
+  const extKeys =
+    (data.extensionKeybindings as
+      | { combo: string; action: string; description?: string }[]
+      | undefined) ?? [];
+  const extMenu =
+    (data.extensionMenuItems as
+      | {
+          id: string;
+          label: string;
+          action: string;
+          location: "app" | "tray";
+          parent?: string;
+        }[]
+      | undefined) ?? [];
+  const extEventRoutes =
+    (data.extensionEventRoutes as
+      | { componentId?: string; eventType?: string }[]
+      | undefined) ?? [];
+  const extEventRoutingMode =
+    data.extensionEventRoutingMode === "extension" ? "extension" : "builtin";
+  const extLayouts =
+    (data.extensionLayouts as
+      | {
+          id: string;
+          name: string;
+          description?: string;
+          payload: A2UIPayload;
+        }[]
+      | undefined) ?? [];
+  const extFrontendModules =
+    (data.extensionFrontendModules as
+      | { name: string; code: string }[]
+      | undefined) ?? [];
+  const extStateKeys = (data.extensionStateKeys as string[] | undefined) ?? [];
+  const discTabs =
+    (data.discoveredTabs as DiscoveredSession[] | undefined) ?? [];
+  ctx.allDiscoveredSessionsRef.current = discTabs;
+  // Hydrate extension themes BEFORE the layout state merge below so
+  // /sidebar/themes carries the full list (built-ins + extension) when
+  // the merge runs. hydrateThemes also injects the CSS so a saved
+  // choice has the rule available before data-theme is read.
+  ctx.hydrateThemes(extThemes);
+  ctx.hydrateExtensions(
+    (data.extensionsList as { name: string; source: string }[] | undefined) ??
+      [],
+    (data.failedExtensionsList as
+      | { name: string; source: string; error?: string }[]
+      | undefined) ?? [],
+  );
+  ctx.registry.setTemplates(extComponents);
+  // Restore extension-registered slash commands so the picker shows them
+  // on first paint (no need to wait for an extension_slash_commands
+  // delta after reload). hydrateSlashCommands rewrites the merged
+  // catalog (built-ins + extensions), updates the picker state ref, and
+  // bumps /slashCommands so the picker re-resolves via $ref.
+  ctx.hydrateSlashCommands(extSlash);
+  ctx.hydrateKeybindings(extKeys);
+  ctx.hydrateEventRoutes(extEventRoutes, extEventRoutingMode);
+  ctx.hydrateExtensionLayouts(extLayouts);
+  ctx.hydrateFrontendModules(extFrontendModules);
+  // Push the persisted menu list into Tauri so the native menu is
+  // correct on first paint after webview reload. Errors are logged but
+  // non-fatal — the menu falls back to built-ins-only.
+  if (extMenu.length > 0) {
+    invoke("set_extension_menu_items", { items: extMenu }).catch(
+      (err: unknown) => {
+        console.warn("[menu] set_extension_menu_items failed:", err);
+      },
+    );
+  }
+  // Surface discovered persistent sessions in the empty-state's
+  // recent-sessions list. Filter out tabIds we already have local
+  // records for so the same session isn't listed twice (open AND
+  // restorable). Format the lastModified into a "10m ago"-style label
+  // for the row's right-hand meta.
+  const knownIds = ctx.knownTabIds(
+    (data.tabs as { id: string }[] | undefined) ?? [],
+  );
+  const scopedDiscTabs = ctx.scopedDiscoveredSessions(discTabs);
+  const recentSessions = ctx.recentSessionItems(scopedDiscTabs, knownIds);
+  if (ctx.projectsLoadedRef.current) {
+    ctx.autoRestoreDiscoveredSessions(scopedDiscTabs, knownIds);
+  }
+  // Restore any extension-supplied layout, then replay queued patches.
+  // Falls back to the boot layout when none is reported so a removed /
+  // disabled extension stops bleeding stale chrome across agent reloads.
+  // The layout's own `state` hydrates below alongside extensionState —
+  // same semantics as the live `layout_set` path so replay matches.
+  const baseLayout: A2UIPayload =
+    extLayout &&
+    typeof extLayout === "object" &&
+    Array.isArray(extLayout.components)
+      ? extLayout
+      : ctx.bootLayout;
+  const patchedLayout = extPatches.reduce<A2UIPayload>(
+    (acc, p) => layoutPatch(acc, p.path, p.value),
+    baseLayout,
+  );
+  ctx.setLayout(patchedLayout);
+  // Snapshot the prune set BEFORE the setState callback so the side
+  // effect of updating lastExtensionStateKeysRef can stay outside
+  // setState — otherwise concurrent-mode re-runs of the callback would
+  // update the ref multiple times and race with the next ready's read.
+  // Compute willPrune (= prev set − new set) here and freeze it for the
+  // duration of this handler.
+  const willPruneKeys: string[] = [];
+  for (const stale of ctx.lastExtensionStateKeysRef.current) {
+    if (!extStateKeys.includes(stale)) willPruneKeys.push(stale);
+  }
+  // Update the ref BEFORE calling setState so the next ready (which may
+  // arrive in the same React batch) sees the new "previous" set.
+  ctx.lastExtensionStateKeysRef.current = new Set(extStateKeys);
+  ctx.setState((prev) => {
+    // Three-layer hydration in priority order (lowest → highest):
+    //   1. extension layout state — TREATED AS BOOT DEFAULTS (only fills
+    //      keys not already set; existing live state like `messages` /
+    //      `canvas` wins to avoid wiping restored history when ready
+    //      replays after a reload)
+    //   2. extension setState patches (last-write-wins overrides)
+    //   3. ready-owned runtime fields (model picker, status, etc.)
+    //
+    // Stale-key pruning: drop paths the previous ready tracked but this
+    // ready dropped (an extension was uninstalled). Without this, `prev`
+    // keeps the leftover slice forever (deepMerge doesn't remove keys,
+    // only adds/updates). The willPruneKeys diff was captured outside
+    // this callback so it's stable across concurrent-mode re-runs.
+    let next: Record<string, unknown> = { ...prev };
+    for (const stale of willPruneKeys) {
+      next = deletePointer(next, stale);
+    }
+    if (extLayout && extLayout.state) {
+      // Defaults semantics: deep-merge layout into a fresh object and
+      // let prev win for any overlapping keys.
+      next = deepMergeState(extLayout.state, next);
+    }
+    next = deepMergeState(next, extState);
+    // Reconcile our local tabs with the bridge's reported tabs.
+    // Two cases:
+    //   (a) webview reload while bridge is alive — bridge has tabs we
+    //       don't know about; create local records for them so the user
+    //       can re-access those sessions.
+    //   (b) bridge restart — local has tabs the bridge doesn't; the
+    //       post-ready replay below re-establishes them.
+    //
+    // Also hydrate per-tab mirrored state from extensionTabState —
+    // those values are the bridge's record of what extensions / agents
+    // wrote to /canvas, /messages, etc. for each tab. On a webview
+    // reload they're the only way to restore tab UI state that was
+    // driven by the agent (React state didn't survive).
+    {
+      const localTabs = ((next.tabs as Tab[] | undefined) ?? []).slice();
+      const bridgeTabs =
+        (data.tabs as { id: string; model: string }[] | undefined) ?? [];
+      const tabReplay =
+        (data.extensionTabState as
+          | Record<string, Record<string, unknown>>
+          | undefined) ?? {};
+      const dIdx = localTabs.findIndex((t) => t.id === "default");
+      if (dIdx >= 0) {
+        localTabs[dIdx] = { ...localTabs[dIdx], model };
+      }
+      // Backfill any tab that has no model yet (e.g. opened before ready
+      // fired) with pi's default so the picker is never blank.
+      for (let i = 0; i < localTabs.length; i++) {
+        if (!localTabs[i].model && model) {
+          localTabs[i] = { ...localTabs[i], model };
+        }
+      }
+      for (const bt of bridgeTabs) {
+        if (bt.id === "default") continue;
+        const exists = localTabs.find((t) => t.id === bt.id);
+        if (exists) {
+          if (!exists.model && bt.model) {
+            const idx = localTabs.indexOf(exists);
+            localTabs[idx] = { ...exists, model: bt.model };
+          }
+          continue;
+        }
+        const label = `Tab ${localTabs.length + 1}`;
+        localTabs.push({
+          ...makeEmptyTab(bt.id, label, ctx.projectsRef.current.activeId),
+          model: bt.model,
+        });
+      }
+      // Apply the bridge's per-tab replay over each tab record. prev
+      // wins for keys the React side already restored (e.g. local-only
+      // message history) — agent-driven canvas / model fills the gaps.
+      for (let i = 0; i < localTabs.length; i++) {
+        const replay = tabReplay[localTabs[i].id];
+        if (!replay) continue;
+        const merged = { ...localTabs[i] } as unknown as Record<string, unknown>;
+        for (const [k, v] of Object.entries(replay)) {
+          // Only fill keys that aren't already populated locally, so a
+          // real local update beats a possibly-stale replay.
+          if (
+            merged[k] === undefined ||
+            merged[k] === null ||
+            (Array.isArray(merged[k]) && (merged[k] as unknown[]).length === 0) ||
+            merged[k] === ""
+          ) {
+            merged[k] = v;
+          }
+        }
+        localTabs[i] = merged as unknown as Tab;
+      }
+      next.tabs = localTabs;
+    }
+    // The model + sidebar mirror tracks the ACTIVE tab, not the default
+    // — so a `ready` arriving while a non-default tab is active doesn't
+    // clobber the visible selection. Look up the active tab's model in
+    // the just-updated tabs array; fall back to data.model on first
+    // boot when no tab record exists.
+    const activeId = (next.activeTabId as string | undefined) ?? "default";
+    const tabsList = (next.tabs as Tab[] | undefined) ?? [];
+    const activeTab = tabsList.find((t) => t.id === activeId);
+    const activeModel = activeTab?.model || model;
+    next = {
+      ...next,
+      model: activeModel,
+      status: "ready",
+      connection: "connected",
+      recentSessions,
+      sidebar: {
+        ...(next.sidebar ?? {}),
+        models: models.map((m) => ({
+          id: m.id,
+          label: m.label,
+          active: m.id === activeModel,
+        })),
+      },
+    };
+    // Re-mirror the active tab's full state to the root keys. Without
+    // this, ready-replayed values for /messages, /canvas, etc. live
+    // only on the tab record but the layout binds via the root mirror,
+    // so the user wouldn't see the restored state until they switched
+    // tabs and back.
+    if (activeTab) {
+      const tabRec = activeTab as unknown as Record<string, unknown>;
+      for (const key of TAB_MIRROR_KEYS) {
+        next[key as string] = tabRec[key as string];
+      }
+    }
+    return next;
+  });
+  // Re-establish bridge sessions for any non-default local tabs the
+  // user created before the agent reloaded. The bridge starts fresh
+  // each spawn — without this, prompts on those tabs would hit a tab
+  // the bridge has never seen and fail. After the session is open,
+  // also restore the tab's previously-selected model so the user
+  // doesn't silently send the next prompt to pi's default.
+  const localTabs = (ctx.stateRef.current.tabs as Tab[] | undefined) ?? [];
+  for (const t of localTabs) {
+    if (t.id === "default") continue;
+    // Pass `model` so the new bridge session boots with the same model
+    // the user previously selected — no race window. Track in
+    // pendingTabOpens so a fast first chat on the restored tab waits
+    // for the bridge to register the session (otherwise send_message
+    // would race tab_open and lazily create the tab without the
+    // inherited model). Same cwd inheritance as newTab — restored
+    // sessions land in the currently-active project unless they were
+    // opened before any project was set. The bridge dedupes paths
+    // internally, so a re-announce on existing tabs with the same cwd
+    // is a no-op.
+    const restoredCwd = activeProject(ctx.projectsRef.current)?.path;
+    const opening = invoke("agent_command", {
+      payload: JSON.stringify({
+        type: "tab_open",
+        tabId: t.id,
+        ...(t.model ? { model: t.model } : {}),
+        ...(restoredCwd ? { cwd: restoredCwd } : {}),
+      }),
+    });
+    ctx.pendingTabOpens.current.set(t.id, opening);
+    opening
+      .catch(() => {
+        /* surfaced on next chat send */
+      })
+      .finally(() => {
+        ctx.pendingTabOpens.current.delete(t.id);
+      });
+  }
+  // Post-respawn project re-announce. The bridge boots with
+  // process.cwd() — which is whatever directory bun was launched from,
+  // NOT necessarily the user's active project. If we don't re-announce,
+  // a hot-reload triggered while a non-cwd project is active leaves the
+  // wrong project's extensions loaded. The loop above only sends
+  // tab_open for non-default tabs, so when the active tab IS "default"
+  // (common: single-tab session) nothing announces. Send an explicit
+  // set_project for the active tab so the bridge swaps to the right
+  // project. The bridge short-circuits when cwd matches its
+  // currentProjectCwd so this is harmless on a fresh boot where the
+  // boot effect already announced.
+  const activeProj = activeProject(ctx.projectsRef.current);
+  if (activeProj) {
+    const activeTabId =
+      (ctx.stateRef.current.activeTabId as string | undefined) ?? "default";
+    ctx.announceProjectToBridge(activeTabId, activeProj.path);
+  }
+};

--- a/src/hooks/bridgeMessageHandlers/registerHighlightGrammar.test.ts
+++ b/src/hooks/bridgeMessageHandlers/registerHighlightGrammar.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from "vitest";
+import { handleRegisterHighlightGrammar } from "./registerHighlightGrammar";
+import { buildHandlerFixture } from "./testFixtures";
+import * as highlight from "../../utils/highlight";
+
+describe("handleRegisterHighlightGrammar", () => {
+  it("registers a grammar and acks on a valid payload", () => {
+    const spy = vi.spyOn(highlight, "registerGrammar").mockImplementation(() => {});
+    const { ctx, mocks } = buildHandlerFixture();
+    handleRegisterHighlightGrammar(
+      {
+        type: "register_highlight_grammar",
+        lang: "rufus",
+        grammar: { scopeName: "source.rufus" },
+        mutationId: "m1",
+      },
+      ctx,
+    );
+    expect(spy).toHaveBeenCalledWith("rufus", { scopeName: "source.rufus" });
+    expect(mocks.ackMutation).toHaveBeenCalledWith("m1", true);
+    spy.mockRestore();
+  });
+
+  it("acks failure on a missing payload", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleRegisterHighlightGrammar(
+      { type: "register_highlight_grammar", mutationId: "m2" },
+      ctx,
+    );
+    expect(mocks.ackMutation).toHaveBeenCalledWith(
+      "m2",
+      false,
+      "register_highlight_grammar: bad payload",
+    );
+  });
+});

--- a/src/hooks/bridgeMessageHandlers/registerHighlightGrammar.ts
+++ b/src/hooks/bridgeMessageHandlers/registerHighlightGrammar.ts
@@ -1,0 +1,16 @@
+import { registerGrammar as registerHighlightGrammar } from "../../utils/highlight";
+import type { BridgeMessageHandler } from "./types";
+
+/** Extension surface for the `code` primitive: a TextMate grammar for a
+ *  language Shiki doesn't ship by default. Forward to the worker; bridge
+ *  already validated lang + grammar shape, so we trust the payload. */
+export const handleRegisterHighlightGrammar: BridgeMessageHandler = (data, ctx) => {
+  const lang = data.lang as string | undefined;
+  const grammar = data.grammar;
+  if (typeof lang === "string" && grammar) {
+    registerHighlightGrammar(lang, grammar);
+    ctx.ackMutation(data.mutationId, true);
+  } else {
+    ctx.ackMutation(data.mutationId, false, "register_highlight_grammar: bad payload");
+  }
+};

--- a/src/hooks/bridgeMessageHandlers/response.test.ts
+++ b/src/hooks/bridgeMessageHandlers/response.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { handleResponse } from "./response";
+import { buildHandlerFixture } from "./testFixtures";
+import { makeEmptyTab } from "../../types/tab";
+
+describe("handleResponse", () => {
+  it("appends content + flips waiting + ready when done", () => {
+    const { ctx, mocks } = buildHandlerFixture({
+      state: { activeTabId: "default" },
+    });
+    handleResponse(
+      { type: "response", content: "hello", done: true, tabId: "default" },
+      ctx,
+    );
+    expect(mocks.appendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ role: "agent", text: "hello" }),
+      "default",
+    );
+    const [, updater] = mocks.updateTab.mock.calls[0];
+    expect(updater(makeEmptyTab("default", "Tab 1")).waiting).toBe(false);
+    expect(mocks.setStatusFlags).toHaveBeenCalledWith({ status: "ready" });
+  });
+
+  it("does not flip waiting when done is omitted", () => {
+    const { ctx, mocks } = buildHandlerFixture({
+      state: { activeTabId: "default" },
+    });
+    handleResponse({ type: "response", content: "partial" }, ctx);
+    expect(mocks.updateTab).not.toHaveBeenCalled();
+    expect(mocks.setStatusFlags).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/bridgeMessageHandlers/response.ts
+++ b/src/hooks/bridgeMessageHandlers/response.ts
@@ -1,0 +1,19 @@
+import type { BridgeMessageHandler } from "./types";
+
+/** Legacy single-shot response (kept so old bridge builds still render). */
+export const handleResponse: BridgeMessageHandler = (data, ctx) => {
+  const content = (data.content as string) ?? "";
+  const tabId = (data.tabId as string | undefined) ?? "default";
+  if (content) {
+    ctx.appendMessage(
+      { id: crypto.randomUUID(), role: "agent", text: content },
+      tabId,
+    );
+  }
+  if (data.done) {
+    ctx.updateTab(tabId, (tab) => ({ ...tab, waiting: false }));
+    if (ctx.stateRef.current.activeTabId === tabId) {
+      ctx.setStatusFlags({ status: "ready" });
+    }
+  }
+};

--- a/src/hooks/bridgeMessageHandlers/responseDelta.test.ts
+++ b/src/hooks/bridgeMessageHandlers/responseDelta.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { handleResponseDelta } from "./responseDelta";
+import { buildHandlerFixture } from "./testFixtures";
+
+describe("handleResponseDelta", () => {
+  it("forwards content with messageId + tabId", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleResponseDelta(
+      {
+        type: "response_delta",
+        content: "hello",
+        messageId: "msg-1",
+        tabId: "tab-2",
+      },
+      ctx,
+    );
+    expect(mocks.appendOrAmendAgentText).toHaveBeenCalledWith(
+      "hello",
+      "msg-1",
+      "tab-2",
+    );
+  });
+
+  it("ignores empty deltas", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleResponseDelta({ type: "response_delta", content: "" }, ctx);
+    expect(mocks.appendOrAmendAgentText).not.toHaveBeenCalled();
+  });
+
+  it("falls back to default tabId when omitted", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleResponseDelta(
+      { type: "response_delta", content: "x" },
+      ctx,
+    );
+    expect(mocks.appendOrAmendAgentText).toHaveBeenCalledWith(
+      "x",
+      undefined,
+      "default",
+    );
+  });
+});

--- a/src/hooks/bridgeMessageHandlers/responseDelta.ts
+++ b/src/hooks/bridgeMessageHandlers/responseDelta.ts
@@ -1,0 +1,9 @@
+import type { BridgeMessageHandler } from "./types";
+
+export const handleResponseDelta: BridgeMessageHandler = (data, ctx) => {
+  const delta = (data.content as string) ?? "";
+  if (!delta) return;
+  const messageId = (data.messageId as string) || undefined;
+  const tabId = (data.tabId as string | undefined) ?? "default";
+  ctx.appendOrAmendAgentText(delta, messageId, tabId);
+};

--- a/src/hooks/bridgeMessageHandlers/responseEnd.test.ts
+++ b/src/hooks/bridgeMessageHandlers/responseEnd.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { handleResponseEnd } from "./responseEnd";
+import { buildHandlerFixture } from "./testFixtures";
+import { makeEmptyTab } from "../../types/tab";
+
+describe("handleResponseEnd", () => {
+  it("clears waiting + status, dismisses hang notification, fires completion", () => {
+    const tabId = "default";
+    const { ctx, mocks, applySetState } = buildHandlerFixture({
+      state: { activeTabId: tabId, queueCount: 0 },
+    });
+    ctx.activeResponseIdRef.current = "msg-1";
+    ctx.turnStartedAtRef.current.set(tabId, Date.now() - 5000);
+    ctx.hangWarnActiveRef.current.add(tabId);
+    handleResponseEnd({ type: "response_end", tabId }, ctx);
+    expect(ctx.activeResponseIdRef.current).toBeNull();
+    const [, updater] = mocks.updateTab.mock.calls[0];
+    const out = updater(makeEmptyTab(tabId, "Tab 1"));
+    expect(out.waiting).toBe(false);
+    const next = applySetState();
+    expect(next.status).toBe("ready");
+    expect(mocks.dismissNotification).toHaveBeenCalledWith(`ae-hang-warn:${tabId}`);
+    // maybeFireCompletionNotification called via void.
+    expect(mocks.maybeFireCompletionNotification).toHaveBeenCalled();
+  });
+
+  it("preserves waiting when queueCount > 0", () => {
+    const { ctx, mocks } = buildHandlerFixture({
+      state: { activeTabId: "default" },
+    });
+    handleResponseEnd({ type: "response_end", tabId: "default" }, ctx);
+    const [, updater] = mocks.updateTab.mock.calls[0];
+    const seed = { ...makeEmptyTab("default", "Tab 1"), queueCount: 1, waiting: true };
+    expect(updater(seed)).toEqual(seed);
+  });
+});

--- a/src/hooks/bridgeMessageHandlers/responseEnd.ts
+++ b/src/hooks/bridgeMessageHandlers/responseEnd.ts
@@ -1,0 +1,44 @@
+import type { BridgeMessageHandler } from "./types";
+
+export const handleResponseEnd: BridgeMessageHandler = (data, ctx) => {
+  ctx.activeResponseIdRef.current = null;
+  const tabId = (data.tabId as string | undefined) ?? "default";
+  // Only clear waiting when the queue is actually empty. If pi has a
+  // followUp queued, it will fire agent_start → prompt_started
+  // immediately after this and re-flip waiting; clearing here would
+  // cause a Send-flash.
+  ctx.updateTab(tabId, (tab) => {
+    if (tab.queueCount > 0) return tab;
+    return { ...tab, waiting: false };
+  });
+  if (ctx.stateRef.current.activeTabId === tabId) {
+    ctx.setState((prev) => {
+      const q = (prev.queueCount as number) ?? 0;
+      if (q > 0) return prev;
+      return { ...prev, status: "ready" };
+    });
+  }
+  // Clear the hang-warn timer and dismiss this tab's notification (if it
+  // appeared). Per-tab id so an unrelated tab's response_end doesn't
+  // dismiss a still-hung tab's warning.
+  {
+    const h = ctx.hangWarnTimersRef.current.get(tabId);
+    if (h !== undefined) {
+      clearTimeout(h);
+      ctx.hangWarnTimersRef.current.delete(tabId);
+    }
+    if (ctx.hangWarnActiveRef.current.delete(tabId)) {
+      ctx.dismissNotification(ctx.hangWarnNotifId(tabId));
+    }
+  }
+  // Fire native OS notification when an agent turn completes while the
+  // window is unfocused (or the originating tab isn't active). Only for
+  // "real" turns (≥ notifyMinDurationSeconds) and only if the user hasn't
+  // disabled via [ui] notify_on_completion.
+  const startedAt = ctx.turnStartedAtRef.current.get(tabId);
+  ctx.turnStartedAtRef.current.delete(tabId);
+  if (startedAt !== undefined) {
+    const turnDurationMs = Date.now() - startedAt;
+    void ctx.maybeFireCompletionNotification({ tabId, turnDurationMs });
+  }
+};

--- a/src/hooks/bridgeMessageHandlers/sessionHistory.test.ts
+++ b/src/hooks/bridgeMessageHandlers/sessionHistory.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { handleSessionHistory } from "./sessionHistory";
+import { buildHandlerFixture } from "./testFixtures";
+import { makeEmptyTab } from "../../types/tab";
+
+describe("handleSessionHistory", () => {
+  it("replaces the tab's messages and triggers a recents resync", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleSessionHistory(
+      {
+        type: "session_history",
+        tabId: "tab-1",
+        messages: [
+          { id: "1", role: "user", text: "hi" },
+          { id: "2", role: "agent", text: "hello" },
+        ],
+      },
+      ctx,
+    );
+    expect(mocks.updateTab).toHaveBeenCalledTimes(1);
+    const [tabId, updater] = mocks.updateTab.mock.calls[0];
+    expect(tabId).toBe("tab-1");
+    const out = updater(makeEmptyTab("tab-1", "Tab 1"));
+    expect(out.messages).toHaveLength(2);
+    expect(mocks.syncRecentSessionsToState).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/bridgeMessageHandlers/sessionHistory.ts
+++ b/src/hooks/bridgeMessageHandlers/sessionHistory.ts
@@ -1,0 +1,9 @@
+import { coerceChatMessages } from "../../utils/messages";
+import type { BridgeMessageHandler } from "./types";
+
+export const handleSessionHistory: BridgeMessageHandler = (data, ctx) => {
+  const tabId = (data.tabId as string | undefined) ?? "default";
+  const messages = coerceChatMessages(data.messages);
+  ctx.updateTab(tabId, (tab) => ({ ...tab, messages }));
+  ctx.syncRecentSessionsToState();
+};

--- a/src/hooks/bridgeMessageHandlers/shellQuery.test.ts
+++ b/src/hooks/bridgeMessageHandlers/shellQuery.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { handleShellQuery } from "./shellQuery";
+import { buildHandlerFixture } from "./testFixtures";
+import { clearTauriMocks, installTauriMocks } from "../../test/tauriMocks";
+
+describe("handleShellQuery", () => {
+  let harness: ReturnType<typeof installTauriMocks>;
+  beforeEach(() => {
+    harness = installTauriMocks();
+  });
+  afterEach(() => {
+    clearTauriMocks();
+  });
+
+  it("routes list to shell_list_shareable and acks with data", async () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    harness.invoke.mockResolvedValueOnce(["tab-1", "tab-2"]);
+    handleShellQuery(
+      { type: "shell_query", op: "list", mutationId: "m1" },
+      ctx,
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(harness.invoke).toHaveBeenCalledWith("shell_list_shareable");
+    expect(mocks.ackMutation).toHaveBeenCalledWith("m1", true, undefined, [
+      "tab-1",
+      "tab-2",
+    ]);
+  });
+
+  it("acks failure for unknown ops", async () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleShellQuery(
+      { type: "shell_query", op: "explode", mutationId: "m2" },
+      ctx,
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mocks.ackMutation).toHaveBeenCalledWith(
+      "m2",
+      false,
+      "unknown shell_query op: explode",
+    );
+  });
+});

--- a/src/hooks/bridgeMessageHandlers/shellQuery.ts
+++ b/src/hooks/bridgeMessageHandlers/shellQuery.ts
@@ -1,0 +1,35 @@
+import { invoke } from "@tauri-apps/api/core";
+import type { BridgeMessageHandler } from "./types";
+
+/** Bridge proxy for `aethon.shells.{list, read, write}`. Mode changes go
+ *  through the status-bar badge (frontend invokes `shell_set_share_mode`
+ *  directly), never through the agent surface; otherwise an extension
+ *  could flip a private tab into sharing without a user gesture and
+ *  bypass the opt-in boundary.
+ *
+ *  For write: we check share mode here (read-write → overlay confirm;
+ *  read-write-trusted → write directly; private/read → refuse), then
+ *  invoke the Rust shell_write which gates again as defense-in-depth. */
+export const handleShellQuery: BridgeMessageHandler = (data, ctx) => {
+  const op = data.op as string | undefined;
+  const args = (data.args as Record<string, unknown> | undefined) ?? {};
+  const mid = data.mutationId;
+  const route = async (): Promise<unknown> => {
+    if (op === "list") {
+      return await invoke("shell_list_shareable");
+    }
+    if (op === "read") {
+      return await invoke("shell_read_scrollback", { args });
+    }
+    if (op === "write") {
+      return await ctx.routeShellWrite(args);
+    }
+    throw new Error(`unknown shell_query op: ${op}`);
+  };
+  route()
+    .then((result) => ctx.ackMutation(mid, true, undefined, result))
+    .catch((err: unknown) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      ctx.ackMutation(mid, false, msg);
+    });
+};

--- a/src/hooks/bridgeMessageHandlers/statePatch.test.ts
+++ b/src/hooks/bridgeMessageHandlers/statePatch.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { handleStatePatch } from "./statePatch";
+import { buildHandlerFixture } from "./testFixtures";
+import { makeEmptyTab } from "../../types/tab";
+
+describe("handleStatePatch", () => {
+  it("acks failure when path is missing", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleStatePatch({ type: "state_patch", mutationId: "m1" }, ctx);
+    expect(mocks.ackMutation).toHaveBeenCalledWith("m1", false, "missing path");
+  });
+
+  it("writes a global path to root state and tracks it", () => {
+    const { ctx, mocks, applySetState } = buildHandlerFixture();
+    handleStatePatch(
+      {
+        type: "state_patch",
+        path: "/sidebar/foo",
+        value: 42,
+        mutationId: "m1",
+      },
+      ctx,
+    );
+    expect(mocks.ackMutation).toHaveBeenCalledWith("m1", true);
+    expect(ctx.lastExtensionStateKeysRef.current.has("/sidebar/foo")).toBe(true);
+    const next = applySetState({});
+    expect(next).toEqual({ sidebar: { foo: 42 } });
+  });
+
+  it("routes a mirrored path with tabId through updateTab", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleStatePatch(
+      {
+        type: "state_patch",
+        path: "/draft",
+        value: "hello",
+        tabId: "tab-3",
+        mutationId: "m2",
+      },
+      ctx,
+    );
+    expect(mocks.updateTab).toHaveBeenCalledTimes(1);
+    const [tabId, updater] = mocks.updateTab.mock.calls[0];
+    expect(tabId).toBe("tab-3");
+    const out = updater(makeEmptyTab("tab-3", "Tab 3"));
+    expect(out.draft).toBe("hello");
+    expect(mocks.ackMutation).toHaveBeenCalledWith("m2", true);
+  });
+
+  it("routes a mirrored path without tabId through updateActiveTab", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleStatePatch(
+      {
+        type: "state_patch",
+        path: "/canvas",
+        value: { components: [] },
+        mutationId: "m3",
+      },
+      ctx,
+    );
+    expect(mocks.updateActiveTab).toHaveBeenCalledTimes(1);
+    expect(mocks.ackMutation).toHaveBeenCalledWith("m3", true);
+  });
+});

--- a/src/hooks/bridgeMessageHandlers/statePatch.ts
+++ b/src/hooks/bridgeMessageHandlers/statePatch.ts
@@ -1,0 +1,61 @@
+import { setPointer } from "../../utils/jsonPointer";
+import { TAB_MIRROR_KEYS } from "../useTabs";
+import type { Tab } from "../../types/tab";
+import type { BridgeMessageHandler } from "./types";
+
+/** An extension pushed a state mutation. Two cases:
+ *
+ *   1. Path is a per-tab mirrored key (messages / draft / waiting /
+ *      queueCount / canvas / model):
+ *      - With data.tabId: route ONLY to that tab. updateTab will also
+ *        write to root if it happens to be the active tab. Don't
+ *        pre-mirror to root — that would briefly clobber the active
+ *        tab's view with a background tab's state.
+ *      - Without data.tabId: global setState with no tab context (clock
+ *        interval, polling extension). Apply to the active tab so the
+ *        layout sees it and a switch-back re-mirrors.
+ *   2. Path is global (anything else, e.g. /sidebar/..., /counter/value,
+ *      /custom): write directly to root state. No tab-scoping needed —
+ *      these aren't mirrored. */
+export const handleStatePatch: BridgeMessageHandler = (data, ctx) => {
+  const path = data.path as string | undefined;
+  if (!path) {
+    ctx.ackMutation(data.mutationId, false, "missing path");
+    return;
+  }
+  const segs = path.split("/").filter(Boolean);
+  const top = segs[0] as keyof Tab | undefined;
+  const isMirrored = top !== undefined && TAB_MIRROR_KEYS.includes(top);
+  if (isMirrored) {
+    const writeIntoTab = (tab: Tab): Tab => {
+      const tabRec = { ...tab } as unknown as Record<string, unknown>;
+      if (segs.length === 1) {
+        tabRec[top as string] = data.value;
+      } else {
+        const before = tabRec[top as string];
+        const baseObj =
+          typeof before === "object" && before !== null
+            ? (before as Record<string, unknown>)
+            : {};
+        const nested = setPointer(baseObj, "/" + segs.slice(1).join("/"), data.value);
+        tabRec[top as string] = nested;
+      }
+      return tabRec as unknown as Tab;
+    };
+    const sourceTabId = data.tabId as string | undefined;
+    if (sourceTabId) {
+      ctx.updateTab(sourceTabId, writeIntoTab);
+    } else {
+      ctx.updateActiveTab(writeIntoTab);
+    }
+  } else {
+    ctx.setState((prev) => setPointer(prev, path, data.value));
+    // Track this path as extension-owned so the next `ready` knows to
+    // prune it if the extension that wrote it is gone. Without this,
+    // paths written via setState AFTER the last ready would never appear
+    // in lastExtensionStateKeysRef and would survive an extension
+    // uninstall as stale UI.
+    ctx.lastExtensionStateKeysRef.current.add(path);
+  }
+  ctx.ackMutation(data.mutationId, true);
+};

--- a/src/hooks/bridgeMessageHandlers/tabClosed.test.ts
+++ b/src/hooks/bridgeMessageHandlers/tabClosed.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { handleTabClosed } from "./tabClosed";
+import { buildHandlerFixture } from "./testFixtures";
+import { makeEmptyTab } from "../../types/tab";
+
+describe("handleTabClosed", () => {
+  it("returns early when tabId is missing", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleTabClosed({ type: "tab_closed" }, ctx);
+    expect(mocks.setState).not.toHaveBeenCalled();
+  });
+
+  it("removes the tab and dispatches replay when active tab was closed", () => {
+    const tabA = makeEmptyTab("tab-a", "A");
+    const tabB = { ...makeEmptyTab("tab-b", "B"), terminalBuffer: "scrollback" };
+    const { ctx, mocks, applySetState } = buildHandlerFixture({
+      state: {
+        activeTabId: "tab-a",
+        tabs: [tabA, tabB],
+        sidebar: { models: [] },
+      },
+    });
+    handleTabClosed({ type: "tab_closed", tabId: "tab-a" }, ctx);
+    const next = applySetState();
+    expect((next.tabs as { id: string }[]).map((t) => t.id)).toEqual(["tab-b"]);
+    expect(next.activeTabId).toBe("tab-b");
+    expect(mocks.dispatchTerminalReplay).toHaveBeenCalledWith("scrollback");
+  });
+
+  it("does not dispatch replay when the closed tab was not active", () => {
+    const tabA = makeEmptyTab("tab-a", "A");
+    const tabB = makeEmptyTab("tab-b", "B");
+    const { ctx, mocks } = buildHandlerFixture({
+      state: { activeTabId: "tab-a", tabs: [tabA, tabB], sidebar: {} },
+    });
+    handleTabClosed({ type: "tab_closed", tabId: "tab-b" }, ctx);
+    expect(mocks.dispatchTerminalReplay).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/bridgeMessageHandlers/tabClosed.ts
+++ b/src/hooks/bridgeMessageHandlers/tabClosed.ts
@@ -1,0 +1,37 @@
+import { TAB_MIRROR_KEYS } from "../useTabs";
+import type { Tab } from "../../types/tab";
+import type { BridgeMessageHandler } from "./types";
+
+/** Bridge confirms a tab session was torn down. We may have already
+ *  removed it from local state in the close handler; this is just a
+ *  signal in case some other path triggered the close. */
+export const handleTabClosed: BridgeMessageHandler = (data, ctx) => {
+  const tabId = data.tabId as string | undefined;
+  if (!tabId) return;
+  let nextBuffer = "";
+  let switched = false;
+  ctx.setState((prev) => {
+    const tabs = ((prev.tabs as Tab[] | undefined) ?? []).filter(
+      (t) => t.id !== tabId,
+    );
+    if (tabs.length === 0) return prev; // shouldn't happen — bridge refuses to close default
+    let activeTabId = prev.activeTabId as string | undefined;
+    if (activeTabId === tabId) {
+      activeTabId = tabs[tabs.length - 1].id;
+      switched = true;
+    }
+    const result: Record<string, unknown> = { ...prev, tabs, activeTabId };
+    const target = tabs.find((t) => t.id === activeTabId)!;
+    nextBuffer = target.terminalBuffer ?? "";
+    const targetRec = target as unknown as Record<string, unknown>;
+    for (const key of TAB_MIRROR_KEYS) {
+      result[key as string] = targetRec[key as string];
+    }
+    result.sidebar = ctx.recomputeModelPicker(
+      prev.sidebar as Record<string, unknown> | undefined,
+      target.model,
+    );
+    return result;
+  });
+  if (switched) ctx.dispatchTerminalReplay(nextBuffer);
+};

--- a/src/hooks/bridgeMessageHandlers/tabReady.test.ts
+++ b/src/hooks/bridgeMessageHandlers/tabReady.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { handleTabReady } from "./tabReady";
+import { buildHandlerFixture } from "./testFixtures";
+
+describe("handleTabReady", () => {
+  it("updates the tab and recomputes the picker when active", () => {
+    const { ctx, mocks } = buildHandlerFixture({
+      state: { activeTabId: "default" },
+    });
+    handleTabReady(
+      { type: "tab_ready", tabId: "default", model: "haiku" },
+      ctx,
+    );
+    expect(mocks.updateTab).toHaveBeenCalledTimes(1);
+    expect(mocks.recomputeModelPicker).toHaveBeenCalled();
+    expect(mocks.setState).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips picker recompute for non-active tabs", () => {
+    const { ctx, mocks } = buildHandlerFixture({
+      state: { activeTabId: "default" },
+    });
+    handleTabReady(
+      { type: "tab_ready", tabId: "tab-2", model: "haiku" },
+      ctx,
+    );
+    expect(mocks.updateTab).toHaveBeenCalledTimes(1);
+    expect(mocks.setState).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/bridgeMessageHandlers/tabReady.ts
+++ b/src/hooks/bridgeMessageHandlers/tabReady.ts
@@ -1,0 +1,21 @@
+import type { BridgeMessageHandler } from "./types";
+
+/** Bridge confirms a per-tab pi session is up and tells us its chosen
+ *  model. Update the tab record so the sidebar can reflect it on next
+ *  switch. If the tab is currently active, also refresh the model
+ *  picker's `active` flag now (otherwise it'd lag until the user
+ *  manually switched). */
+export const handleTabReady: BridgeMessageHandler = (data, ctx) => {
+  const tabId = (data.tabId as string | undefined) ?? "default";
+  const model = (data.model as string) ?? "";
+  ctx.updateTab(tabId, (tab) => ({ ...tab, model }));
+  if (ctx.stateRef.current.activeTabId === tabId) {
+    ctx.setState((prev) => ({
+      ...prev,
+      sidebar: ctx.recomputeModelPicker(
+        prev.sidebar as Record<string, unknown> | undefined,
+        model,
+      ),
+    }));
+  }
+};

--- a/src/hooks/bridgeMessageHandlers/terminalOutput.test.ts
+++ b/src/hooks/bridgeMessageHandlers/terminalOutput.test.ts
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import { handleTerminalOutput } from "./terminalOutput";
+import { buildHandlerFixture } from "./testFixtures";
+import { makeEmptyTab } from "../../types/tab";
+
+describe("handleTerminalOutput", () => {
+  it("appends to the per-tab buffer, mirrors into state, and dispatches events", () => {
+    const tabId = "default";
+    const { ctx, mocks, applySetState } = buildHandlerFixture({
+      state: { activeTabId: tabId, terminal: { buffer: {} } },
+    });
+    const tap: { tabId: string; content: string }[] = [];
+    const live: string[] = [];
+    const onTap = (e: Event) => tap.push((e as CustomEvent).detail);
+    const onLive = (e: Event) => live.push((e as CustomEvent).detail);
+    window.addEventListener("aethon:terminal-tap", onTap);
+    window.addEventListener("aethon:terminal", onLive);
+    try {
+      handleTerminalOutput(
+        { type: "terminal_output", content: "abc", tabId },
+        ctx,
+      );
+    } finally {
+      window.removeEventListener("aethon:terminal-tap", onTap);
+      window.removeEventListener("aethon:terminal", onLive);
+    }
+    const [, updater] = mocks.updateTab.mock.calls[0];
+    const seed = { ...makeEmptyTab(tabId, "Tab 1"), terminalBuffer: "" };
+    expect(updater(seed).terminalBuffer).toBe("abc");
+    const next = applySetState();
+    expect((next.terminal as { buffer: Record<string, string> }).buffer[tabId]).toBe(
+      "abc",
+    );
+    expect(tap).toEqual([{ tabId, content: "abc" }]);
+    expect(live).toEqual(["abc"]);
+  });
+
+  it("ignores empty content", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleTerminalOutput({ type: "terminal_output", content: "" }, ctx);
+    expect(mocks.updateTab).not.toHaveBeenCalled();
+    expect(mocks.setState).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/bridgeMessageHandlers/terminalOutput.ts
+++ b/src/hooks/bridgeMessageHandlers/terminalOutput.ts
@@ -1,0 +1,61 @@
+import { TERMINAL_REPLAY_MAX } from "../useTabs";
+import type { BridgeMessageHandler } from "./types";
+
+export const handleTerminalOutput: BridgeMessageHandler = (data, ctx) => {
+  const content = (data.content as string) ?? "";
+  if (!content) return;
+  const tabId = (data.tabId as string | undefined) ?? "default";
+  // Append to the originating tab's buffer (cap from the right so older
+  // content rotates out first). Three sinks now consume each chunk:
+  //   1. Per-tab Tab.terminalBuffer — the React record carrying the
+  //      rolling scrollback. Used by tab-switch replay.
+  //   2. Layout state at /terminal/buffer/<tabId> — bound by $ref from
+  //      any A2UI component that wants the live stream (logging skills,
+  //      alternative renderers).
+  //   3. window CustomEvents — `aethon:terminal` (active tab only,
+  //      drives xterm) and `aethon:terminal-tap` (every chunk regardless
+  //      of active tab, for multi-subscriber listeners that need the
+  //      full stream).
+  ctx.updateTab(tabId, (tab) => {
+    const next = (tab.terminalBuffer ?? "") + content;
+    const trimmed =
+      next.length > TERMINAL_REPLAY_MAX
+        ? next.slice(next.length - TERMINAL_REPLAY_MAX)
+        : next;
+    return { ...tab, terminalBuffer: trimmed };
+  });
+  // Mirror the rolling buffer into shared layout state under
+  // /terminal/buffer/<tabId>. A2UI components can $ref it; the bridge
+  // sees it via getFrontendState. Path-based so an extension bound to
+  // ONE tab doesn't pick up every tab's stream.
+  ctx.setState((prev) => {
+    const term = (prev.terminal as Record<string, unknown> | undefined) ?? {};
+    const buffers = (term.buffer as Record<string, string> | undefined) ?? {};
+    const next = (buffers[tabId] ?? "") + content;
+    const trimmed =
+      next.length > TERMINAL_REPLAY_MAX
+        ? next.slice(next.length - TERMINAL_REPLAY_MAX)
+        : next;
+    return {
+      ...prev,
+      terminal: {
+        ...term,
+        buffer: { ...buffers, [tabId]: trimmed },
+      },
+    };
+  });
+  if ((ctx.stateRef.current.activeTabId as string | undefined) === tabId) {
+    window.dispatchEvent(
+      new CustomEvent("aethon:terminal", { detail: content }),
+    );
+  }
+  // Tap event always fires (every tab, including background ones) so
+  // multi-subscriber listeners can attach without monkey-patching the
+  // existing single-subscriber pattern. detail carries tabId so the
+  // listener can filter.
+  window.dispatchEvent(
+    new CustomEvent("aethon:terminal-tap", {
+      detail: { tabId, content },
+    }),
+  );
+};

--- a/src/hooks/bridgeMessageHandlers/testFixtures.ts
+++ b/src/hooks/bridgeMessageHandlers/testFixtures.ts
@@ -1,0 +1,220 @@
+/** Shared fixture for handler tests. Builds a `BridgeMessageContext`
+ *  whose every method/ref is a `vi.fn()` or a mutable container the
+ *  test can introspect. Tests pass an optional override map to swap
+ *  individual fields with custom mocks. */
+import { vi, type Mock } from "vitest";
+import type { MutableRefObject } from "react";
+import { defaultLayoutSkill } from "../../skills/default-layout";
+import { SkillRegistry } from "../../skills/SkillRegistry";
+import { emptyProjectsState } from "../../projects";
+import type { BridgeMessageContext, DiscoveredSession } from "./types";
+
+const ref = <T,>(value: T): MutableRefObject<T> => ({ current: value });
+
+export interface FixtureOverrides {
+  state?: Record<string, unknown>;
+  /** Recorder for setState calls — exposed alongside the mock so tests
+   *  can assert on the reducer outputs after running them against a
+   *  seeded prev. */
+  setStateApply?: (prev: Record<string, unknown>) => Record<string, unknown>;
+}
+
+export interface HandlerFixture {
+  ctx: BridgeMessageContext;
+  /** The mocked Tauri `invoke` from the test setup module. Lifted onto
+   *  the fixture so a single import in a test gets both ctx + invoke. */
+  mocks: {
+    setState: Mock;
+    setLayout: Mock;
+    updateTab: Mock;
+    updateActiveTab: Mock;
+    appendMessage: Mock;
+    appendOrAmendAgentText: Mock;
+    setStatusFlags: Mock;
+    pushNotification: Mock;
+    dismissNotification: Mock;
+    maybeFireCompletionNotification: Mock;
+    hydrateThemes: Mock;
+    hydrateExtensions: Mock;
+    hydrateSlashCommands: Mock;
+    hydrateKeybindings: Mock;
+    hydrateEventRoutes: Mock;
+    hydrateExtensionLayouts: Mock;
+    hydrateFrontendModules: Mock;
+    syncRecentSessionsToState: Mock;
+    autoRestoreDiscoveredSessions: Mock;
+    dispatchTerminalReplay: Mock;
+    announceProjectToBridge: Mock;
+    routeShellWrite: Mock;
+    ackMutation: Mock;
+    recomputeModelPicker: Mock;
+    knownTabIds: Mock;
+    scopedDiscoveredSessions: Mock;
+    recentSessionItems: Mock;
+  };
+  /** Apply every queued setState reducer in order against the supplied
+   *  seed. Returns the resulting state for assertion. */
+  applySetState: (seed?: Record<string, unknown>) => Record<string, unknown>;
+}
+
+export function buildHandlerFixture(
+  overrides: FixtureOverrides = {},
+): HandlerFixture {
+  const initialState = overrides.state ?? {};
+  const stateRef = ref<Record<string, unknown>>(initialState);
+  const registry = new SkillRegistry();
+  registry.register(defaultLayoutSkill);
+
+  // setState applies the reducer against stateRef so side-effects inside
+  // the reducer body (recomputeModelPicker, dispatch helpers etc.) run
+  // the same way they would in the live React app. The mock still
+  // records every call so tests can introspect the original argument.
+  const setState = vi.fn((arg: unknown) => {
+    if (typeof arg === "function") {
+      stateRef.current = (arg as (
+        p: Record<string, unknown>,
+      ) => Record<string, unknown>)(stateRef.current);
+    } else {
+      stateRef.current = arg as Record<string, unknown>;
+    }
+  });
+  const setLayout = vi.fn();
+  const updateTab = vi.fn();
+  const updateActiveTab = vi.fn();
+  const appendMessage = vi.fn();
+  const appendOrAmendAgentText = vi.fn();
+  const setStatusFlags = vi.fn();
+  const pushNotification = vi.fn();
+  const dismissNotification = vi.fn();
+  const maybeFireCompletionNotification = vi.fn(() => Promise.resolve());
+  const hydrateThemes = vi.fn();
+  const hydrateExtensions = vi.fn();
+  const hydrateSlashCommands = vi.fn();
+  const hydrateKeybindings = vi.fn();
+  const hydrateEventRoutes = vi.fn();
+  const hydrateExtensionLayouts = vi.fn();
+  const hydrateFrontendModules = vi.fn();
+  const syncRecentSessionsToState = vi.fn();
+  const autoRestoreDiscoveredSessions = vi.fn();
+  const dispatchTerminalReplay = vi.fn();
+  const announceProjectToBridge = vi.fn();
+  const routeShellWrite = vi.fn(() => Promise.resolve({ ok: true as const }));
+  const ackMutation = vi.fn();
+  const recomputeModelPicker = vi.fn(
+    (sidebar: Record<string, unknown> | undefined, model: string) => ({
+      ...(sidebar ?? {}),
+      __model: model,
+    }),
+  );
+  const knownTabIds = vi.fn(() => new Set<string>(["default"]));
+  const scopedDiscoveredSessions = vi.fn(
+    (d: DiscoveredSession[]) => d,
+  );
+  const recentSessionItems = vi.fn(() => []);
+
+  const ctx: BridgeMessageContext = {
+    setState,
+    setLayout,
+    stateRef,
+    registry,
+    piDefaultModelRef: ref(""),
+    allDiscoveredSessionsRef: ref<DiscoveredSession[]>([]),
+    projectsRef: ref(emptyProjectsState()),
+    projectsLoadedRef: ref(false),
+    activeResponseIdRef: ref<string | null>(null),
+    hangWarnTimersRef: ref(new Map()),
+    hangWarnActiveRef: ref(new Set()),
+    turnStartedAtRef: ref(new Map()),
+    lastExtensionStateKeysRef: ref(new Set()),
+    pendingTabOpens: ref(new Map()),
+
+    updateTab,
+    updateActiveTab,
+    dispatchTerminalReplay,
+    autoRestoreDiscoveredSessions,
+
+    hydrateThemes,
+    hydrateExtensions,
+    hydrateSlashCommands,
+    hydrateKeybindings,
+    hydrateEventRoutes,
+    hydrateExtensionLayouts,
+    hydrateFrontendModules,
+
+    announceProjectToBridge,
+
+    appendMessage,
+    appendOrAmendAgentText,
+    setStatusFlags,
+
+    pushNotification,
+    dismissNotification,
+    maybeFireCompletionNotification,
+
+    knownTabIds,
+    scopedDiscoveredSessions,
+    recentSessionItems,
+    syncRecentSessionsToState,
+
+    recomputeModelPicker,
+    routeShellWrite,
+
+    ackMutation,
+    hangWarnNotifId: (tabId: string) => `ae-hang-warn:${tabId}`,
+    hangWarnMs: 30_000,
+    bootLayout: { components: [{ id: "root", type: "container" }] },
+  };
+
+  // Replays every queued setState call against the supplied seed (or the
+  // current stateRef when omitted) and returns the resulting state. Most
+  // tests can read stateRef.current directly because setState now mutates
+  // it; this is the escape hatch for tests that want to apply against a
+  // different seed than the one the fixture was built with.
+  const applySetState = (seed?: Record<string, unknown>) => {
+    if (seed === undefined) return stateRef.current;
+    let cur = { ...seed };
+    for (const call of setState.mock.calls) {
+      const arg = call[0];
+      if (typeof arg === "function") {
+        cur = (arg as (p: Record<string, unknown>) => Record<string, unknown>)(cur);
+      } else {
+        cur = arg as Record<string, unknown>;
+      }
+    }
+    return cur;
+  };
+
+  return {
+    ctx,
+    mocks: {
+      setState,
+      setLayout,
+      updateTab,
+      updateActiveTab,
+      appendMessage,
+      appendOrAmendAgentText,
+      setStatusFlags,
+      pushNotification,
+      dismissNotification,
+      maybeFireCompletionNotification,
+      hydrateThemes,
+      hydrateExtensions,
+      hydrateSlashCommands,
+      hydrateKeybindings,
+      hydrateEventRoutes,
+      hydrateExtensionLayouts,
+      hydrateFrontendModules,
+      syncRecentSessionsToState,
+      autoRestoreDiscoveredSessions,
+      dispatchTerminalReplay,
+      announceProjectToBridge,
+      routeShellWrite,
+      ackMutation,
+      recomputeModelPicker,
+      knownTabIds,
+      scopedDiscoveredSessions,
+      recentSessionItems,
+    },
+    applySetState,
+  };
+}

--- a/src/hooks/bridgeMessageHandlers/types.ts
+++ b/src/hooks/bridgeMessageHandlers/types.ts
@@ -1,0 +1,173 @@
+import type {
+  Dispatch,
+  MutableRefObject,
+  SetStateAction,
+} from "react";
+import type { A2UIPayload, ChatMessage } from "../../types/a2ui";
+import type { Tab } from "../../types/tab";
+import type { SkillRegistry } from "../../skills/SkillRegistry";
+import type {
+  ExtensionTheme,
+} from "../useExtensionsHydration";
+import type {
+  NotificationEntry,
+  NotificationKind,
+} from "../../skills/default-layout/notifications";
+import type { ProjectsState } from "../../projects";
+
+/** A bridge-to-frontend message. The `type` discriminator routes to a
+ *  handler in the registry; other keys are payload-specific and typed
+ *  per-handler with narrowing assertions inside the handler body. */
+export interface BridgeMessage {
+  type?: string;
+  [k: string]: unknown;
+}
+
+export interface ModelDescriptor {
+  id: string;
+  label: string;
+  provider: string;
+}
+
+export interface DiscoveredSession {
+  tabId: string;
+  lastModified: number;
+  cwd?: string;
+  /** First user message text, trimmed to 60 chars by the bridge. */
+  firstUserMessage?: string;
+}
+
+export interface RecentSessionItem {
+  id: string;
+  label: string;
+  lastModified?: string;
+  cwd?: string;
+}
+
+/** Everything a handler may close over. Flat by design — every handler
+ *  imports the same context type, so adding a new handler doesn't require
+ *  a context-shape decision. The fields are grouped by source (refs,
+ *  setters, app actions, hydrators, helpers) to make audits readable. */
+export interface BridgeMessageContext {
+  // ─── React state setters ─────────────────────────────────────────────
+  setState: Dispatch<SetStateAction<Record<string, unknown>>>;
+  setLayout: Dispatch<SetStateAction<A2UIPayload>>;
+
+  // ─── Live refs ──────────────────────────────────────────────────────
+  stateRef: MutableRefObject<Record<string, unknown>>;
+  registry: SkillRegistry;
+  piDefaultModelRef: MutableRefObject<string>;
+  allDiscoveredSessionsRef: MutableRefObject<DiscoveredSession[]>;
+  projectsRef: MutableRefObject<ProjectsState>;
+  projectsLoadedRef: MutableRefObject<boolean>;
+  activeResponseIdRef: MutableRefObject<string | null>;
+  hangWarnTimersRef: MutableRefObject<Map<string, ReturnType<typeof setTimeout>>>;
+  hangWarnActiveRef: MutableRefObject<Set<string>>;
+  turnStartedAtRef: MutableRefObject<Map<string, number>>;
+  lastExtensionStateKeysRef: MutableRefObject<Set<string>>;
+  pendingTabOpens: MutableRefObject<Map<string, Promise<unknown>>>;
+
+  // ─── Tab actions (from useTabs) ─────────────────────────────────────
+  updateTab: (tabId: string, updater: (tab: Tab) => Tab) => void;
+  updateActiveTab: (updater: (tab: Tab) => Tab) => void;
+  dispatchTerminalReplay: (buffer: string) => void;
+  autoRestoreDiscoveredSessions: (
+    discovered: DiscoveredSession[],
+    knownIds: Set<string>,
+  ) => void;
+
+  // ─── Extension hydration (from useExtensionsHydration) ──────────────
+  hydrateThemes: (list: ExtensionTheme[]) => void;
+  hydrateExtensions: (
+    loaded: { name: string; source: string }[],
+    failed: { name: string; source: string; error?: string }[],
+  ) => void;
+  hydrateSlashCommands: (
+    list: { name: string; description: string; usage?: string }[],
+  ) => void;
+  hydrateKeybindings: (
+    list: { combo: string; action: string; description?: string }[],
+  ) => void;
+  hydrateEventRoutes: (
+    routes: { componentId?: string; eventType?: string }[],
+    mode?: "builtin" | "extension",
+  ) => void;
+  hydrateExtensionLayouts: (
+    list: {
+      id: string;
+      name: string;
+      description?: string;
+      payload: A2UIPayload;
+    }[],
+  ) => void;
+  hydrateFrontendModules: (list: { name: string; code: string }[]) => void;
+
+  // ─── Project I/O (from useProjects + App) ───────────────────────────
+  announceProjectToBridge: (tabId: string, path: string) => void;
+
+  // ─── Chat / status helpers (defined on App) ─────────────────────────
+  appendMessage: (msg: ChatMessage, tabId?: string) => void;
+  appendOrAmendAgentText: (
+    delta: string,
+    messageId?: string,
+    tabId?: string,
+  ) => void;
+  setStatusFlags: (
+    flags: Partial<{ waiting: boolean; status: string; connection: string }>,
+  ) => void;
+
+  // ─── Notification helpers (defined on App) ──────────────────────────
+  pushNotification: (input: {
+    id?: string;
+    title: string;
+    message?: string;
+    kind?: NotificationKind;
+    durationMs?: number | null;
+    actions?: NotificationEntry["actions"];
+  }) => void;
+  dismissNotification: (id: string) => void;
+  maybeFireCompletionNotification: (input: {
+    tabId: string;
+    turnDurationMs: number;
+  }) => Promise<void>;
+
+  // ─── Session-list helpers (defined on App) ──────────────────────────
+  knownTabIds: (extraTabs?: { id: string }[]) => Set<string>;
+  scopedDiscoveredSessions: (
+    discovered: DiscoveredSession[],
+  ) => DiscoveredSession[];
+  recentSessionItems: (
+    discovered: DiscoveredSession[],
+    openIds: Set<string>,
+  ) => RecentSessionItem[];
+  syncRecentSessionsToState: () => void;
+
+  // ─── Misc helpers (defined on App) ──────────────────────────────────
+  recomputeModelPicker: (
+    sidebar: Record<string, unknown> | undefined,
+    model: string,
+  ) => Record<string, unknown>;
+  routeShellWrite: (args: Record<string, unknown>) => Promise<{ ok: true }>;
+
+  // ─── Hook-owned ────────────────────────────────────────────────────
+  /** Ack a mutation back to the bridge. Provided by useBridgeMessages so
+   *  handlers don't have to know about the IPC channel. */
+  ackMutation: (
+    mutationId: unknown,
+    success: boolean,
+    error?: string,
+    data?: unknown,
+  ) => void;
+  /** Hang-warn notification id helper. */
+  hangWarnNotifId: (tabId: string) => string;
+  /** Hang-warn timeout in ms. */
+  hangWarnMs: number;
+  /** The boot layout payload. Used by `ready` to compute the fallback
+   *  layout when an extension hasn't supplied one. */
+  bootLayout: A2UIPayload;
+}
+
+export type BridgeMessageHandler = (
+  message: BridgeMessage,
+  ctx: BridgeMessageContext,
+) => void;

--- a/src/hooks/useBridgeMessages.ts
+++ b/src/hooks/useBridgeMessages.ts
@@ -1,0 +1,135 @@
+import { useEffect, useRef } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import type { A2UIPayload } from "../types/a2ui";
+import {
+  bridgeMessageHandlers,
+  type BridgeMessage,
+  type BridgeMessageContext,
+} from "./bridgeMessageHandlers";
+
+export interface UseBridgeMessagesOptions {
+  /** Everything handlers close over. The hook layers `ackMutation`,
+   *  `hangWarnNotifId`, `hangWarnMs`, and `bootLayout` on top before
+   *  passing to handlers. */
+  ctx: Omit<
+    BridgeMessageContext,
+    "ackMutation" | "hangWarnNotifId" | "hangWarnMs" | "bootLayout"
+  >;
+  /** Boot layout used by the `ready` handler when the bridge doesn't
+   *  report an extension-supplied layout. */
+  bootLayout: A2UIPayload;
+  /** Hang-warn timeout in ms (production: 30_000). Exposed so tests can
+   *  shrink it without faking timers. */
+  hangWarnMs?: number;
+  /** Boot-time error escape hatch — invoked if the start_agent /
+   *  boot_layout / report sequence throws. App.tsx surfaces this as a
+   *  chat bubble + status flag. */
+  onBootError: (err: unknown) => void;
+}
+
+export interface UseBridgeMessagesActions {
+  /** Ack a mutation back to the bridge so the awaiting Promise resolves.
+   *  Exposed for callers that settle bridge promises outside the
+   *  response path. Fire-and-forget — we don't await the ack-send
+   *  because the bridge ack channel is independent of any other
+   *  outgoing message. */
+  ackMutation: (
+    mutationId: unknown,
+    success: boolean,
+    error?: string,
+    data?: unknown,
+  ) => void;
+}
+
+const DEFAULT_HANG_WARN_MS = 30_000;
+const hangWarnNotifId = (tabId: string) => `ae-hang-warn:${tabId}`;
+
+export function useBridgeMessages(
+  options: UseBridgeMessagesOptions,
+): UseBridgeMessagesActions {
+  const { bootLayout } = options;
+  const optionsRef = useRef(options);
+  // Sync the latest options into the ref AFTER render so the
+  // listener (which reads optionsRef.current at event time) always
+  // sees the current ctx without us touching the ref during render
+  // — react-hooks/refs disallows the latter.
+  useEffect(() => {
+    optionsRef.current = options;
+  });
+
+  const ackMutation = (
+    mutationId: unknown,
+    success: boolean,
+    error?: string,
+    data?: unknown,
+  ) => {
+    if (typeof mutationId !== "string" || mutationId.length === 0) return;
+    invoke("agent_command", {
+      payload: JSON.stringify({
+        type: "mutation_ack",
+        mutationId,
+        success,
+        ...(error ? { error } : {}),
+        ...(data !== undefined ? { data } : {}),
+      }),
+    }).catch(() => {
+      /* bridge gone — extension's awaiter will hit the timeout instead */
+    });
+  };
+
+  useEffect(() => {
+    // Boot sequence: spawn the agent, tell the bridge our boot layout
+    // (so extensions calling api.getLayout() at register-time see a
+    // meaningful tree instead of null), then request a fresh `ready`
+    // event in case the agent process was already running before this
+    // React tree mounted (after a webview hot-reload). Newly-spawned
+    // agents emit ready unconditionally, so the duplicate is harmless.
+    (async () => {
+      try {
+        await invoke("start_agent");
+        await invoke("agent_command", {
+          payload: JSON.stringify({ type: "boot_layout", payload: bootLayout }),
+        });
+        await invoke("agent_command", {
+          payload: JSON.stringify({ type: "report" }),
+        });
+      } catch (err) {
+        optionsRef.current.onBootError(err);
+      }
+    })();
+
+    const unlistenResponse = listen<string>("agent-response", (event) => {
+      try {
+        const data = JSON.parse(event.payload) as BridgeMessage;
+        const type = data.type;
+        if (typeof type !== "string") return;
+        const handler = bridgeMessageHandlers[type];
+        if (!handler) return;
+        const opts = optionsRef.current;
+        const fullCtx: BridgeMessageContext = {
+          ...opts.ctx,
+          ackMutation,
+          hangWarnNotifId,
+          hangWarnMs: opts.hangWarnMs ?? DEFAULT_HANG_WARN_MS,
+          bootLayout: opts.bootLayout,
+        };
+        handler(data, fullCtx);
+      } catch {
+        // Non-JSON line from the bridge — ignore.
+      }
+    });
+
+    return () => {
+      unlistenResponse.then((fn) => fn());
+    };
+    // Boot effect runs once. Subsequent option changes are picked up via
+    // optionsRef inside the listener. The eslint disable matches the
+    // existing pattern in App.tsx for top-level boot effects.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return { ackMutation };
+}
+
+export { hangWarnNotifId };

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -10,9 +10,9 @@
 import { vi } from "vitest";
 
 vi.mock("@tauri-apps/api/core", () => ({
-  invoke: vi.fn(async () => undefined),
+  invoke: vi.fn(() => Promise.resolve(undefined)),
 }));
 
 vi.mock("@tauri-apps/api/event", () => ({
-  listen: vi.fn(async () => () => {}),
+  listen: vi.fn(() => Promise.resolve(() => {})),
 }));

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,18 @@
+/** Vitest setup: registers a default invoke + listen mock for `@tauri-apps/api`
+ *  so any test that imports App-tier code (where these modules are statically
+ *  imported) doesn't blow up trying to call the real Tauri runtime under node /
+ *  jsdom. Tests that need to assert on invoke calls override this per-test via
+ *  `installTauriMocks()` from `./tauriMocks`.
+ *
+ *  Defaults: `invoke()` returns undefined (treated as a successful no-op),
+ *  `listen()` returns a no-op unlisten. This matches the shape every consumer
+ *  expects without coupling the setup to any one event/command. */
+import { vi } from "vitest";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(async () => undefined),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(async () => () => {}),
+}));

--- a/src/test/tauriMocks.test.ts
+++ b/src/test/tauriMocks.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import { clearTauriMocks, installTauriMocks } from "./tauriMocks";
+
+describe("tauriMocks", () => {
+  let harness: ReturnType<typeof installTauriMocks>;
+
+  beforeEach(() => {
+    harness = installTauriMocks();
+  });
+
+  afterEach(() => {
+    clearTauriMocks();
+  });
+
+  it("captures invoke calls", async () => {
+    harness.invoke.mockResolvedValueOnce("hello");
+    const result = await invoke("greet", { name: "world" });
+    expect(result).toBe("hello");
+    expect(harness.invoke).toHaveBeenCalledWith("greet", { name: "world" });
+  });
+
+  it("delivers fired events to registered handlers", async () => {
+    const received: string[] = [];
+    await listen<string>("agent-response", (e) => {
+      received.push(e.payload);
+    });
+    const fired = harness.fireEvent("agent-response", "first");
+    expect(fired).toBe(1);
+    expect(received).toEqual(["first"]);
+  });
+
+  it("supports multiple handlers per event", async () => {
+    const a: number[] = [];
+    const b: number[] = [];
+    await listen<number>("tick", (e) => a.push(e.payload));
+    await listen<number>("tick", (e) => b.push(e.payload));
+    harness.fireEvent("tick", 42);
+    expect(a).toEqual([42]);
+    expect(b).toEqual([42]);
+  });
+
+  it("unlisten removes the handler", async () => {
+    const got: string[] = [];
+    const off = await listen<string>("ping", (e) => got.push(e.payload));
+    off();
+    expect(harness.fireEvent("ping", "hi")).toBe(0);
+    expect(got).toEqual([]);
+  });
+});

--- a/src/test/tauriMocks.ts
+++ b/src/test/tauriMocks.ts
@@ -44,18 +44,18 @@ export function installTauriMocks(): TauriMockHarness {
 
   const reset = () => {
     invoke.mockReset();
-    invoke.mockImplementation(async () => undefined);
+    invoke.mockImplementation(() => Promise.resolve(undefined));
     listen.mockReset();
-    listen.mockImplementation(async (name: string, cb: ListenCallback) => {
+    listen.mockImplementation((name: string, cb: ListenCallback) => {
       let bucket = handlers.get(name);
       if (!bucket) {
         bucket = new Set();
         handlers.set(name, bucket);
       }
       bucket.add(cb);
-      return () => {
+      return Promise.resolve(() => {
         bucket?.delete(cb);
-      };
+      });
     });
     handlers.clear();
   };
@@ -79,6 +79,6 @@ export function clearTauriMocks(): void {
   vi.restoreAllMocks();
   // Re-install the default no-ops so other mocks layered on top of the
   // setup mock module don't crash when subsequent tests import `invoke`.
-  (realInvoke as unknown as Mock).mockImplementation(async () => undefined);
-  (realListen as unknown as Mock).mockImplementation(async () => () => {});
+  (realInvoke as unknown as Mock).mockImplementation(() => Promise.resolve(undefined));
+  (realListen as unknown as Mock).mockImplementation(() => Promise.resolve(() => {}));
 }

--- a/src/test/tauriMocks.ts
+++ b/src/test/tauriMocks.ts
@@ -1,0 +1,84 @@
+/** Test helpers for stubbing `@tauri-apps/api/core.invoke` and
+ *  `@tauri-apps/api/event.listen`. Use from a `beforeEach` in any test that
+ *  drives Tauri-aware code:
+ *
+ *    import { installTauriMocks } from "../test/tauriMocks";
+ *
+ *    beforeEach(() => {
+ *      const harness = installTauriMocks();
+ *      // harness.invoke.mockImplementation(...)
+ *      // harness.fireEvent("agent-response", JSON.stringify({...}))
+ *    });
+ *
+ *  `installTauriMocks` re-binds the global mocks created in `setup.ts` so the
+ *  per-test handlers/captured calls are isolated. The harness exposes the raw
+ *  mock plus a `fireEvent(name, payload)` helper that synthesizes the event
+ *  shape Tauri's `listen` callback expects. */
+import { vi, type Mock } from "vitest";
+import { invoke as realInvoke } from "@tauri-apps/api/core";
+import { listen as realListen } from "@tauri-apps/api/event";
+
+type ListenCallback<T = unknown> = (event: { payload: T }) => void;
+
+export interface TauriMockHarness {
+  /** The mocked `invoke`. Cast: `invoke as Mock`. */
+  invoke: Mock;
+  /** The mocked `listen`. Use `harness.listen.mock.calls` to assert
+   *  registrations; prefer `fireEvent` for delivering payloads. */
+  listen: Mock;
+  /** Fire a synthetic event to every handler registered via `listen` for
+   *  the given event name. Returns the number of handlers invoked. */
+  fireEvent: <T = unknown>(name: string, payload: T) => number;
+  /** Map of event name → handler list. Exposed for tests that need to
+   *  introspect registrations beyond `listen.mock.calls`. */
+  handlers: Map<string, Set<ListenCallback>>;
+  /** Reset captured calls + registered handlers. Auto-runs at install
+   *  time; call again from a test if you need a clean slate mid-test. */
+  reset: () => void;
+}
+
+export function installTauriMocks(): TauriMockHarness {
+  const invoke = realInvoke as unknown as Mock;
+  const listen = realListen as unknown as Mock;
+  const handlers = new Map<string, Set<ListenCallback>>();
+
+  const reset = () => {
+    invoke.mockReset();
+    invoke.mockImplementation(async () => undefined);
+    listen.mockReset();
+    listen.mockImplementation(async (name: string, cb: ListenCallback) => {
+      let bucket = handlers.get(name);
+      if (!bucket) {
+        bucket = new Set();
+        handlers.set(name, bucket);
+      }
+      bucket.add(cb);
+      return () => {
+        bucket?.delete(cb);
+      };
+    });
+    handlers.clear();
+  };
+
+  reset();
+
+  const fireEvent = <T,>(name: string, payload: T): number => {
+    const bucket = handlers.get(name);
+    if (!bucket || bucket.size === 0) return 0;
+    for (const cb of bucket) cb({ payload });
+    return bucket.size;
+  };
+
+  return { invoke, listen, fireEvent, handlers, reset };
+}
+
+/** Restore the default no-op behavior. Call from `afterEach` if the harness
+ *  was installed in `beforeEach`, so a leaked stub doesn't bleed into the
+ *  next test file's first call. */
+export function clearTauriMocks(): void {
+  vi.restoreAllMocks();
+  // Re-install the default no-ops so other mocks layered on top of the
+  // setup mock module don't crash when subsequent tests import `invoke`.
+  (realInvoke as unknown as Mock).mockImplementation(async () => undefined);
+  (realListen as unknown as Mock).mockImplementation(async () => () => {});
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -32,11 +32,13 @@ export default defineConfig({
     target: "es2022",
   },
   test: {
-    // Pure-logic unit tests live next to the source as `*.test.ts`.
-    // jsdom is reserved for the renderer when we add component tests;
-    // current suite is utility code only so node is faster.
+    // Pure-logic unit tests live next to the source as `*.test.ts` and
+    // run under node for speed. React/hook tests opt into jsdom on a
+    // per-file basis with `// @vitest-environment jsdom` at the top —
+    // vitest 4 dropped environmentMatchGlobs in favor of the directive.
     environment: "node",
     include: ["src/**/*.test.ts", "src/**/*.test.tsx", "agent/**/*.test.ts"],
+    setupFiles: ["src/test/setup.ts"],
     coverage: {
       provider: "v8",
       reporter: ["text", "html", "lcov"],


### PR DESCRIPTION
Closes #36 (Phase 1 deferral from #35).

## Summary

Splits the 1,500-line `handleAgentMessage` switch out of `App.tsx` into a per-type handler registry under `src/hooks/bridgeMessageHandlers/<type>.ts` and a new `useBridgeMessages` hook that owns the bridge boot sequence (`start_agent` → `boot_layout` → `report`) plus the `agent-response` listener.

- **App.tsx: 4,149 → 3,172 lines (−977, −23.5%)**.
- 31 per-type handler files, one happy-path test each (32 new test files, 57 new tests).
- New `src/hooks/useBridgeMessages.ts` and `src/hooks/bridgeMessageHandlers/{types,index,testFixtures}.ts`.
- Test infra: jsdom + `@testing-library/react` + Tauri `invoke`/`listen` mock helpers under `src/test/` (commit 1).

Two commits, each behavior-preserving:

1. `51c6459` — Test infrastructure (jsdom + Tauri mock helpers, opt-in jsdom per file via `// @vitest-environment jsdom`).
2. `3169457` — Handler registry + hook + App.tsx wiring + 31 per-handler happy-path tests.

## Architecture

- `useBridgeMessages({ ctx, bootLayout, onBootError, hangWarnMs? })` — wires up the boot sequence and routes parsed `agent-response` payloads through the registry. Returns `ackMutation` for callers that settle bridge promises outside the response path.
- `BridgeMessageContext` is a flat type covering every helper / ref / setter handlers close over. Matches the existing `useExtensionsHydration` extraction pattern.
- The frozen `Record<type, handler>` registry in `bridgeMessageHandlers/index.ts` makes adding a new type a 3-step contract (handler file + register + test).
- `testFixtures.ts` exposes `buildHandlerFixture()` whose mocked `setState` applies the reducer against the seeded `stateRef` so handlers whose internal logic reads back through `setState` callbacks (recompute model picker, dispatch terminal replay) behave the same as in the live app.

## Test plan

- [x] `bunx tsc -b --noEmit` — clean
- [x] `bunx eslint .` — 0 errors, 0 warnings
- [x] `cargo test --lib -p aethon` — 73 pass
- [x] `bunx vitest run` — **366 pass** (was 309 before this PR)
- [x] aethon-debug end-to-end:
  - Boot sequence completes (`status="ready"`, `connection="connected"`, model populated, 40 sidebar models, 2 extensions hydrated)
  - Chat round trip works (PONG response confirmed via `response_delta` + `response_end` handlers)
  - Real `extension_runtime_error` notification fires from the misbehaving `mold:image-gallery` extension (proves notification handler path)
  - No runtime errors in bridge log

## Notes

- `agent-reloaded` / `agent-crashed` / `agent-stderr` / shell-output / shell-exit / shell-title / menu / drag-drop / paste listeners stay in App.tsx — they own OS-edge events, not bridge messages.
- `useBridgeMessages` is wired in just below the `useProjects` destructure so `announceProjectToBridge` is in scope when the ctx object is built.