### PR TITLE
refactor(app): split onEvent into per-prefix route table (#37)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,9 +26,8 @@ import {
   type ShellMeta,
   type Tab,
 } from "./types/tab";
-import { cycleShareMode } from "./utils/shareMode";
+import { dispatchEvent, type EventRouteContext } from "./eventRoutes";
 import { shellQuoteAll } from "./utils/shellQuote";
-import { extractSessionId } from "./utils/sidebarHistory";
 import { applyUiScale } from "./utils/viewport";
 import { formatRelativeTime } from "./utils/time";
 import { useZoomAndTheme } from "./hooks/useZoomAndTheme";
@@ -2498,604 +2497,76 @@ export default function App() {
     }
   }
 
-  // Intercept events from layout-level components before they reach the agent.
-  // The layout speaks A2UI, but a few interactions need to drive native APIs
-  // (Tauri IPC for chat send, model picker) — this is where the renderer
-  // hands off control.
-  const onEvent = useMemo(
-    () => async (component: { id: string; type?: string }, eventType: string, data?: unknown) => {
-      // Reserved system notifications: shell-write consent prompts
-      // (M6 P2.2) MUST run before extension-route interception so a
-      // user-driven Allow/Deny / dismiss can never be hijacked by an
-      // extension. Same-name event matches on `notification-stack`
-      // would otherwise route to the bridge and the user's click
-      // becomes a silent no-op while `aethon.shells.write` waits for
-      // its 5-min timeout. Filter narrowly: only events whose action
-      // string starts with the reserved `shell-write-` prefix, plus
-      // `dismiss`/`expire` of an id that has a pending resolver. Any
-      // other notification-stack event still flows through routing.
-      if (component.id === "notification-stack") {
-        const id = (data as { id?: string } | undefined)?.id;
-        const action = (data as { action?: string } | undefined)?.action;
-        const isShellWriteAction =
-          eventType === "action" &&
-          typeof action === "string" &&
-          action.startsWith("shell-write-");
-        const isShellWriteDismiss =
-          (eventType === "dismiss" || eventType === "expire") &&
-          typeof id === "string" &&
-          hasPendingShellWriteConsent(id);
-        if (isShellWriteAction && id && action) {
-          const allowed = action.startsWith("shell-write-allow:");
-          resolveShellWriteConsent(id, allowed);
-          dismissNotification(id);
-          return true;
-        }
-        if (isShellWriteDismiss && id) {
-          resolveShellWriteConsent(id, false);
-          dismissNotification(id);
-          return true;
-        }
-        // Close-shell-tab consent prompts. Same security shape as
-        // shell-write — must run before extension-route interception
-        // so a user's Close / Cancel can't be hijacked. Filter
-        // narrowly on the reserved `shell-close-` prefix + a dismiss
-        // of an id with a pending resolver.
-        const isShellCloseAction =
-          eventType === "action" &&
-          typeof action === "string" &&
-          action.startsWith("shell-close-");
-        const isShellCloseDismiss =
-          (eventType === "dismiss" || eventType === "expire") &&
-          typeof id === "string" &&
-          hasPendingShellCloseConsent(id);
-        if (isShellCloseAction && id && action) {
-          const allowed = action.startsWith("shell-close-allow:");
-          resolveShellCloseConsent(id, allowed);
-          dismissNotification(id);
-          return true;
-        }
-        if (isShellCloseDismiss && id) {
-          resolveShellCloseConsent(id, false);
-          dismissNotification(id);
-          return true;
-        }
-        // Session-delete consent prompts. Same security shape as the
-        // shell-close path — narrowly filtered on the reserved
-        // `session-delete-` prefix + a dismiss of an id with a pending
-        // resolver. Must run before extension-route interception so a
-        // user's Delete / Cancel can't be hijacked by a registered
-        // notification handler.
-        const isSessionDeleteAction =
-          eventType === "action" &&
-          typeof action === "string" &&
-          action.startsWith("session-delete-");
-        const isSessionDeleteDismiss =
-          (eventType === "dismiss" || eventType === "expire") &&
-          typeof id === "string" &&
-          hasPendingSessionDeleteConsent(id);
-        if (isSessionDeleteAction && id && action) {
-          const allowed = action.startsWith("session-delete-allow:");
-          resolveSessionDeleteConsent(id, allowed);
-          dismissNotification(id);
-          return true;
-        }
-        if (isSessionDeleteDismiss && id) {
-          resolveSessionDeleteConsent(id, false);
-          dismissNotification(id);
-          return true;
-        }
-        // P5: agent-crashed notification actions. Restart respawns
-        // the bridge; dismiss just closes the toast.
-        if (
-          eventType === "action" &&
-          typeof action === "string" &&
-          action.startsWith("ae-agent-crashed:")
-        ) {
-          if (action === "ae-agent-crashed:restart") {
-            invoke("start_agent").catch((err: unknown) => {
-              console.warn("agent restart failed:", err);
-            });
-          }
-          if (id) dismissNotification(id);
-          return true;
-        }
-        // Hang-warn notification actions.
-        if (
-          eventType === "action" &&
-          typeof action === "string" &&
-          action.startsWith("hang-warn:")
-        ) {
-          if (action.startsWith("hang-warn:stop")) {
-            // Stop carries the tabId of the hung tab (set when the
-            // notification was pushed) so the right session is stopped
-            // even if the user is on a different tab when they click.
-            const targetTabId = action.startsWith("hang-warn:stop:")
-              ? action.slice("hang-warn:stop:".length)
-              : undefined;
-            void stopPrompt(targetTabId);
-          } else if (action === "hang-warn:force-restart") {
-            // force_restart_agent SIGKILLs the bun child from Rust, bypassing
-            // blocked stdin. The existing agent-crashed handler then fires,
-            // clearing waiting state and (if auto_restart_agent) respawning.
-            invoke("force_restart_agent").catch((err: unknown) => {
-              console.warn("force_restart_agent failed:", err);
-            });
-          }
-          if (id) dismissNotification(id);
-          return true;
-        }
-      }
-      // Extensions can register event-route intercepts via
-      // aethon.registerEventRoute. When an event matches a registered
-      // route, we return false here so the renderer falls through to
-      // the default dispatch (a2ui_event → bridge), letting the
-      // extension's aethon.onEvent({componentType, descendantId})
-      // handler run instead of the built-in switch below. Wildcards:
-      // a route with only `componentId` matches any eventType for
-      // that component; only `eventType` matches every component.
-      if (extensionEventRoutingModeRef.current === "extension") {
-        return false;
-      }
-      const routes = extensionEventRoutesRef.current;
-      if (routes.length > 0) {
-        const matched = routes.some((r) => {
-          const cidOk = !r.componentId || r.componentId === component.id;
-          const evtOk = !r.eventType || r.eventType === eventType;
-          return cidOk && evtOk;
-        });
-        if (matched) {
-          // Suppress optimistic UI: the renderer always applies an
-          // optimistic update for change/submit on $ref-bound inputs
-          // before this callback runs, but for an intercepted submit
-          // we still want the bridge to get the event so a paired
-          // handler on the bridge can decide what to do (e.g. preprocess
-          // the prompt before sendChat).
-          // Returning false lets the renderer's invoke('dispatch_a2ui_event')
-          // fire normally. `data` (which carries `value` for submits)
-          // rides along intact.
-          // Suppress sendChat side effect for chat-input submits — the
-          // bridge handler is now the source of truth for that event.
-          // For other intercepted events (sidebar select, tab close)
-          // returning false here is sufficient.
-          // (We don't filter by component.id; the test above did that.)
-          return false;
-        }
-      }
-      // Settings panel events (M6 P3). Renders at App root like the
-      // palette. Update applies a partial AethonConfig to the pending
-      // overlay; save commits via write_config; close discards.
-      if (component.id === "settings-panel") {
-        if (eventType === "close") {
-          closeSettings();
-          return true;
-        }
-        if (eventType === "update") {
-          const patch = (data as { patch?: Record<string, unknown> } | undefined)?.patch;
-          if (patch) applySettingsPatch(patch);
-          return true;
-        }
-        if (eventType === "save") {
-          void saveSettings();
-          return true;
-        }
-      }
-
-      // Cross-session search panel events (M6 P6). Like the palette,
-      // renders at App root and never goes through the bridge —
-      // search results land via the Tauri search_sessions command.
-      if (component.id === "search-panel") {
-        if (eventType === "close") {
-          closeSessionSearch();
-          return true;
-        }
-        if (eventType === "query") {
-          const value = (data as { value?: string } | undefined)?.value ?? "";
-          setSearchQuery(value);
-          return true;
-        }
-        if (eventType === "scope") {
-          const scope = (data as { scope?: "all" | "current" } | undefined)
-            ?.scope;
-          if (scope === "all" || scope === "current") {
-            setSearchScope(scope);
-          }
-          return true;
-        }
-        if (eventType === "select") {
-          const hit = (data as
-            | {
-                hit?: {
-                  tabId?: string;
-                  snippetMatch?: string;
-                };
-              }
-            | undefined)?.hit;
-          if (hit) openSearchHit(hit);
-          return true;
-        }
-      }
-
-      // Command palette events. Palette renders at App root; events
-      // route here directly (it never goes through the dispatch_a2ui
-      // bridge because there's no agent counterpart to invoke).
-      if (component.id === "command-palette") {
-        if (eventType === "close") {
-          closePalette();
-          return true;
-        }
-        if (eventType === "query") {
-          const value = (data as { value?: string } | undefined)?.value ?? "";
-          setState((prev) => ({
-            ...prev,
-            palette: { ...(prev.palette ?? {}), query: value, selectedIndex: 0 },
-          }));
-          return true;
-        }
-        if (eventType === "navigate") {
-          const idx = (data as { index?: number } | undefined)?.index ?? 0;
-          setState((prev) => ({
-            ...prev,
-            palette: { ...(prev.palette ?? {}), selectedIndex: idx },
-          }));
-          return true;
-        }
-        if (eventType === "select") {
-          const item = (data as { item?: PaletteItem } | undefined)?.item;
-          if (item) {
-            // Close FIRST so a slow handler doesn't leave the palette
-            // open over the result. Then run async.
-            closePalette();
-            void runPaletteItem(item);
-          }
-          return true;
-        }
-      }
-      // Notification stack events.
-      if (component.id === "notification-stack") {
-        const id = (data as { id?: string } | undefined)?.id;
-        if ((eventType === "dismiss" || eventType === "expire") && id) {
-          // Dismissing a pending shell-write / shell-close / session-delete
-          // confirmation = deny. All resolvers fire on every dismiss/expire
-          // so a dropped notification can't dangle the originator's promise.
-          resolveShellWriteConsent(id, false);
-          resolveShellCloseConsent(id, false);
-          resolveSessionDeleteConsent(id, false);
-          dismissNotification(id);
-          return true;
-        }
-        if (eventType === "action" && id) {
-          const action = (data as { action?: string } | undefined)?.action;
-          // Built-in shell-write / shell-close / session-delete Allow/Deny
-          // actions resolve pending consents without a bridge round-trip.
-          // Other actions get forwarded as a2ui events for extension matchers.
-          if (action && action.startsWith("shell-write-")) {
-            const allowed = action.startsWith("shell-write-allow:");
-            resolveShellWriteConsent(id, allowed);
-          } else if (action && action.startsWith("shell-close-")) {
-            const allowed = action.startsWith("shell-close-allow:");
-            resolveShellCloseConsent(id, allowed);
-          } else if (action && action.startsWith("session-delete-")) {
-            const allowed = action.startsWith("session-delete-allow:");
-            resolveSessionDeleteConsent(id, allowed);
-          } else if (action) {
-            invoke("dispatch_a2ui_event", {
-              event: JSON.stringify({
-                componentId: `notification__tpl__${id}`,
-                componentType: "notification",
-                templateRootType: "notification",
-                eventType: "invoke",
-                data: { id, action },
-              }),
-              tabId: stateRef.current.activeTabId,
-            }).catch(() => {
-              /* ignore — bridge gone */
-            });
-          }
-          dismissNotification(id);
-          return true;
-        }
-      }
-      if (component.id === "chat-input" && eventType === "submit") {
-        const value = (data as { value?: string } | undefined)?.value ?? "";
-        await sendChat(value);
-        return true;
-      }
-      if (component.id === "chat-input" && eventType === "change") {
-        // The renderer's optimistic update wrote /draft (the active-tab
-        // mirror); also write into the active tab record so an unsent
-        // draft survives a tab switch and isn't clobbered when the
-        // tab is re-mirrored to root on switch-back.
-        const value = (data as { value?: string } | undefined)?.value ?? "";
-        updateActiveTab((tab) => ({ ...tab, draft: value }));
-        return true;
-      }
-      if (component.id === "chat-input" && eventType === "cancel") {
-        await stopPrompt();
-        return true;
-      }
-      // Tab events route by component *type* — id may vary across layouts
-      // (workstation hoists the strip into the header as `header-tabs`).
-      // Matching by type keeps the contract layout-agnostic so a future
-      // layout's tabs work without touching App.tsx.
-      const tabType = component.type;
-
-      // Terminal panel sub-tab events (M6 restructure). The panel
-      // hosts the read-only agent-bash sub-tab plus every shell as a
-      // separate sub-tab; selection / close / new-shell live here.
-      if (component.type === "terminal-panel") {
-        const sel = data as { subTabId?: string } | undefined;
-        if (eventType === "select-sub-tab" && sel?.subTabId) {
-          setActiveSubTab(sel.subTabId);
-          return true;
-        }
-        if (eventType === "close-sub-tab" && sel?.subTabId) {
-          // Closing a shell sub-tab is just closing its underlying tab.
-          // The agent-bash sub-tab can't be closed (no X button rendered).
-          if (sel.subTabId !== "agent-bash") {
-            closeTab(sel.subTabId);
-          }
-          return true;
-        }
-        if (eventType === "new-shell-sub-tab") {
-          newShellTab();
-          return true;
-        }
-      }
-
-      // Share-mode cycle. Match either source: the inline badge inside
-      // ShellCanvas re-emits on the shell-canvas channel; a standalone
-      // `<share-mode-badge>` placed directly in a custom layout emits
-      // on its own component type. Either path runs the same effect:
-      // look up the current mode, advance via the cycle helper, persist
-      // through the Rust side AND mirror locally so the badge label
-      // refreshes immediately.
-      if (
-        eventType === "cycle-share-mode" &&
-        (component.type === "shell-canvas" ||
-          component.type === "share-mode-badge")
-      ) {
-        const sel = data as { tabId?: string } | undefined;
-        const id = sel?.tabId;
-        if (typeof id !== "string" || !id) return true;
-        const tabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
-        const tab = tabs.find((t) => t.id === id);
-        if (!tab || tab.kind !== "shell" || !tab.shell) return true;
-        const next = cycleShareMode(tab.shell.shareMode);
-        invoke("shell_set_share_mode", { tabId: id, mode: next })
-          .then(() => {
-            applyShareModeToTab(id, next);
-          })
-          .catch((err: unknown) => {
-            const msg = err instanceof Error ? err.message : String(err);
-            console.warn("shell_set_share_mode failed:", msg);
-          });
-        return true;
-      }
-
-      const isTabSurface = tabType === "tab-strip";
-      if (isTabSurface) {
-        const sel = data as { tabId?: string; action?: string; id?: string } | undefined;
-        if (eventType === "select" && sel?.tabId) {
-          setActiveTab(sel.tabId);
-          return true;
-        }
-        if (eventType === "close" && sel?.tabId) {
-          closeTab(sel.tabId);
-          return true;
-        }
-        if (eventType === "new") {
-          newTab();
-          return true;
-        }
-      }
-      if (component.id === "empty-state") {
-        if (eventType === "new-tab") {
-          newTab();
-          return true;
-        }
-        if (eventType === "open-project") {
-          // Pop the native folder picker. On a successful pick we've
-          // already persisted + announced the new project — open a
-          // fresh tab in it so the user lands ready-to-chat. If they
-          // cancel, leave the empty state visible.
-          openProjectFromPicker().then((id) => {
-            if (id) newTab();
-          });
-          return true;
-        }
-        if (eventType === "select-project") {
-          const sel = data as
-            | { projectId?: string; label?: string; path?: string }
-            | undefined;
-          if (sel?.projectId) {
-            setActiveProjectById(sel.projectId);
-            // Only seed a fresh tab when the project's bucket is empty.
-            // If the user already has tabs in this project, the bucket
-            // load above restored them — popping a new tab on top would
-            // be jarring.
-            const tabsAfter =
-              (stateRef.current.tabs as Tab[] | undefined) ?? [];
-            if (tabsAfter.length === 0) newTab();
-          }
-          return true;
-        }
-        if (eventType === "restore-session") {
-          const sel = data as
-            | { sessionId?: string; label?: string; cwd?: string }
-            | undefined;
-          if (sel?.sessionId) {
-            // Re-open the persisted session by reusing the same tabId.
-            // The bridge's SessionManager.continueRecent reads the
-            // existing JSONL files so the LLM history is restored too.
-            newTab(sel.sessionId, sel.label ?? "Restored Session", {
-              restoredSession: true,
-              ...(sel.cwd ? { cwd: sel.cwd } : {}),
-            });
-          } else {
-            newTab();
-          }
-          return true;
-        }
-      }
-      if (component.id === "sidebar" && eventType === "resize") {
-        const next = (data as { width?: number } | undefined)?.width;
-        if (typeof next === "number") {
-          // Patch the leading width token in /layout/columns. Layouts
-          // shape their grid columns as either "${SIDEBAR}px minmax(0,1fr)"
-          // or "${SIDEBAR}px minmax(0,1fr) ${INSPECTOR}px" — replace just the first
-          // token so non-sidebar columns survive the rewrite.
-          setState((prev) => {
-            const layout = (prev.layout as Record<string, unknown> | undefined) ?? {};
-            const current =
-              (layout.columns as string | undefined) ?? "220px minmax(0,1fr)";
-            const tokens = current.trim().split(/\s+/);
-            tokens[0] = `${next}px`;
-            return { ...prev, layout: { ...layout, columns: tokens.join(" ") } };
-          });
-        }
-        return true;
-      }
-      if (component.id === "sidebar" && eventType === "resize-end") {
-        // Persist the final width so the next boot opens at the same
-        // size. Read from state.layout.columns (the in-flight value the
-        // resize listener just wrote) so a single source of truth wins.
-        const layout = (stateRef.current.layout as Record<string, unknown> | undefined) ?? {};
-        const cols = (layout.columns as string | undefined) ?? "";
-        const lead = cols.trim().split(/\s+/)[0] ?? "";
-        const px = parseInt(lead, 10);
-        if (Number.isFinite(px) && px > 0) {
-          writeState("sidebar_width", String(px)).catch(() => {
-            /* ignore — best-effort */
-          });
-        }
-        return true;
-      }
-      if (component.id === "sidebar" && eventType === "remove-project") {
-        const selected = data as
-          | { projectId?: string; itemId?: string }
-          | undefined;
-        const projectId = selected?.projectId ?? selected?.itemId;
-        return projectId ? removeProjectById(projectId) : true;
-      }
-      if (component.id === "sidebar" && eventType === "delete-session") {
-        const selected = data as
-          | { sessionId?: string; itemId?: string; label?: string }
-          | undefined;
-        // Strip the "session:" or "tab:" prefix defensively in case a
-        // future caller forgets the split — the sidebar already strips
-        // it but we don't want a stray prefix to land in the Tauri
-        // command path validator.
-        const raw = selected?.sessionId ?? selected?.itemId ?? "";
-        const sessionId = extractSessionId(raw);
-        const label = selected?.label ?? sessionId;
-        if (!sessionId) return true;
-        promptDeleteSessionConfirmation(label).then((allowed) => {
-          if (!allowed) return;
-          const isOpen = (stateRef.current.tabs as Tab[] | undefined)?.some(
-            (t) => t.id === sessionId,
-          );
-          // Delete first, then close. Doing the reverse leaves the user
-          // with a closed tab and a failure notification when the Tauri
-          // command refuses (e.g. the default session). codex P2 review
-          // feedback.
-          invoke("delete_session", { tabId: sessionId })
-            .then(() => {
-              if (isOpen) closeTab(sessionId);
-              allDiscoveredSessionsRef.current =
-                allDiscoveredSessionsRef.current.filter(
-                  (s) => s.tabId !== sessionId,
-                );
-              syncRecentSessionsToState();
-              pushNotification({
-                title: "Session deleted",
-                message: label,
-                kind: "success",
-              });
-            })
-            .catch((err: unknown) => {
-              pushNotification({
-                title: "Delete session failed",
-                message: String(err),
-                kind: "error",
-              });
-            });
-        });
-        return true;
-      }
-      // Sidebar select + dropdown chrome pickers (model-picker /
-      // appearance-menu) all use the same `{sectionId, itemId}` event
-      // shape. Route by section so a chrome dropdown and a sidebar row
-      // converge on the same backing action.
-      const isSectionedSelect =
-        eventType === "select" &&
-        (component.id === "sidebar" ||
-          component.id === "model-picker" ||
-          component.id === "appearance-menu");
-      if (isSectionedSelect) {
-        const selected = data as { sectionId?: string; itemId?: string } | undefined;
-        if (selected?.itemId === "toggle-terminal") {
-          toggleTerminal();
-          return true;
-        }
-        if (selected?.itemId === "clear-chat") {
-          clearChat();
-          return true;
-        }
-        if (selected?.sectionId === "models" && selected.itemId) {
-          await setModel(selected.itemId);
-          return true;
-        }
-        if (selected?.sectionId === "themes" && selected.itemId) {
-          // Accept any registered theme id (built-ins + extension themes).
-          // The CSS for built-ins lives in styles.css; extension themes
-          // had their <style> tag injected on hydrateThemes().
-          setTheme(selected.itemId);
-          return true;
-        }
-        if (selected?.sectionId === "layouts" && selected.itemId) {
-          activateLayoutById(selected.itemId);
-          return true;
-        }
-        if (selected?.sectionId === "projects" && selected.itemId) {
-          // The sidebar's projects section also surfaces an "Open
-          // project…" action item; intercept it here so we don't try
-          // to look it up as a project id.
-          if (selected.itemId === "open-project") {
-            openProjectFromPicker();
-            return true;
-          }
-          setActiveProjectById(selected.itemId);
-          return true;
-        }
-        if (selected?.sectionId === "history" && selected.itemId) {
-          if (selected.itemId.startsWith("tab:")) {
-            setActiveTab(selected.itemId.slice(4));
-            return true;
-          }
-          if (selected.itemId.startsWith("session:")) {
-            const sessionId = selected.itemId.slice(8);
-            const recentSessions =
-              (stateRef.current.recentSessions as RecentSessionItem[] | undefined) ?? [];
-            const item = recentSessions.find((s) => s.id === sessionId);
-            newTab(sessionId, item?.label ?? `Session ${sessionId.slice(0, 8)}`, {
-              restoredSession: true,
-              ...(item?.cwd ? { cwd: item.cwd } : {}),
-            });
-            return true;
-          }
-          return true;
-        }
-      }
-      return false;
-    },
-    // The closures inside this onEvent dispatch (newTab, closeTab,
-    // sendChat, etc.) read live state via stateRef / setState callbacks.
-    // Adding them as deps would force the memo to re-build every render
-    // — losing any consumer-side memoization keyed on its identity —
-    // without changing observed behavior.
+  // Intercept events from layout-level components before they reach
+  // the agent. The layout speaks A2UI, but a few interactions need to
+  // drive native APIs (Tauri IPC for chat send, model picker) — the
+  // dispatcher lives in `src/eventRoutes/` and is wired here. Three
+  // precedence layers, in order: shell-consent reserved prefixes
+  // (security boundary), extension event-routes (extensibility),
+  // built-in route table.
+  const eventRouteCtx = useMemo<EventRouteContext>(
+    () => ({
+      setState,
+      stateRef,
+      extensionEventRoutesRef,
+      extensionEventRoutingModeRef,
+      allDiscoveredSessionsRef,
+      hasPendingShellWriteConsent,
+      resolveShellWriteConsent,
+      hasPendingShellCloseConsent,
+      resolveShellCloseConsent,
+      hasPendingSessionDeleteConsent,
+      resolveSessionDeleteConsent,
+      promptDeleteSessionConfirmation,
+      pushNotification,
+      dismissNotification,
+      sendChat,
+      stopPrompt,
+      updateActiveTab,
+      newTab,
+      newShellTab,
+      closeTab,
+      setActiveTab,
+      setActiveSubTab,
+      applyShareModeToTab,
+      closeSettings,
+      applySettingsPatch,
+      saveSettings,
+      closeSessionSearch,
+      setSearchQuery,
+      setSearchScope,
+      openSearchHit,
+      closePalette,
+      runPaletteItem,
+      toggleTerminal,
+      clearChat,
+      setModel,
+      setTheme,
+      activateLayoutById,
+      openProjectFromPicker,
+      setActiveProjectById,
+      removeProjectById,
+      syncRecentSessionsToState,
+      invoke,
+      writeState,
+    }),
+    // Built once and reused across renders. Every closure inside
+    // (sendChat, newTab, …) reads live state via stateRef / setState
+    // callbacks; adding them as deps would force the memo to re-build
+    // every render — losing any consumer-side memoization keyed on its
+    // identity — without changing observed behavior.
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [],
+  );
+
+  const onEvent = useMemo(
+    () =>
+      (
+        component: { id: string; type?: string },
+        eventType: string,
+        data?: unknown,
+      ) => dispatchEvent({ component, eventType, data }, eventRouteCtx),
+    [eventRouteCtx],
   );
 
   const renderState = useMemo(() => {

--- a/src/eventRoutes/chatInput.test.ts
+++ b/src/eventRoutes/chatInput.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { handleChatInput } from "./chatInput";
+import { buildRouteFixture } from "./testFixtures";
+
+describe("handleChatInput", () => {
+  it("submit forwards value to sendChat", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    const handled = await handleChatInput(
+      {
+        component: { id: "chat-input" },
+        eventType: "submit",
+        data: { value: "hello" },
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.sendChat).toHaveBeenCalledWith("hello");
+  });
+
+  it("change persists draft into the active tab record", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    const handled = await handleChatInput(
+      {
+        component: { id: "chat-input" },
+        eventType: "change",
+        data: { value: "draft text" },
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.updateActiveTab).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancel maps to stopPrompt", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    const handled = await handleChatInput(
+      { component: { id: "chat-input" }, eventType: "cancel" },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.stopPrompt).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns false for non-chat-input components", async () => {
+    const { ctx } = buildRouteFixture();
+    const handled = await handleChatInput(
+      { component: { id: "sidebar" }, eventType: "submit" },
+      ctx,
+    );
+    expect(handled).toBe(false);
+  });
+});

--- a/src/eventRoutes/chatInput.ts
+++ b/src/eventRoutes/chatInput.ts
@@ -1,0 +1,30 @@
+import type { EventRouteHandler } from "./types";
+
+/** chat-input: submit forwards to native sendChat (replacing the
+ *  bridge round-trip), change persists the unsent draft into the
+ *  active tab record, cancel maps to stopPrompt. */
+export const handleChatInput: EventRouteHandler = async (
+  { component, eventType, data },
+  ctx,
+) => {
+  if (component.id !== "chat-input") return false;
+  if (eventType === "submit") {
+    const value = (data as { value?: string } | undefined)?.value ?? "";
+    await ctx.sendChat(value);
+    return true;
+  }
+  if (eventType === "change") {
+    // The renderer's optimistic update already wrote /draft (the
+    // active-tab mirror); also write into the active tab record so an
+    // unsent draft survives a tab switch and isn't clobbered when the
+    // tab is re-mirrored to root on switch-back.
+    const value = (data as { value?: string } | undefined)?.value ?? "";
+    ctx.updateActiveTab((tab) => ({ ...tab, draft: value }));
+    return true;
+  }
+  if (eventType === "cancel") {
+    await ctx.stopPrompt();
+    return true;
+  }
+  return false;
+};

--- a/src/eventRoutes/extensions.test.ts
+++ b/src/eventRoutes/extensions.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { matchesExtensionRoute } from "./extensions";
+import { buildRouteFixture } from "./testFixtures";
+
+describe("matchesExtensionRoute", () => {
+  it("returns true when routing mode is 'extension'", () => {
+    const { ctx } = buildRouteFixture({ extensionRoutingMode: "extension" });
+    expect(
+      matchesExtensionRoute(
+        { component: { id: "anything" }, eventType: "click" },
+        ctx,
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false when no routes are registered", () => {
+    const { ctx } = buildRouteFixture();
+    expect(
+      matchesExtensionRoute(
+        { component: { id: "settings-panel" }, eventType: "close" },
+        ctx,
+      ),
+    ).toBe(false);
+  });
+
+  it("matches by componentId", () => {
+    const { ctx } = buildRouteFixture({
+      extensionRoutes: [{ componentId: "settings-panel" }],
+    });
+    expect(
+      matchesExtensionRoute(
+        { component: { id: "settings-panel" }, eventType: "close" },
+        ctx,
+      ),
+    ).toBe(true);
+  });
+
+  it("matches by eventType (componentId wildcard)", () => {
+    const { ctx } = buildRouteFixture({
+      extensionRoutes: [{ eventType: "submit" }],
+    });
+    expect(
+      matchesExtensionRoute(
+        { component: { id: "anything" }, eventType: "submit" },
+        ctx,
+      ),
+    ).toBe(true);
+  });
+
+  it("does not match when only componentId differs", () => {
+    const { ctx } = buildRouteFixture({
+      extensionRoutes: [{ componentId: "other-panel", eventType: "submit" }],
+    });
+    expect(
+      matchesExtensionRoute(
+        { component: { id: "settings-panel" }, eventType: "submit" },
+        ctx,
+      ),
+    ).toBe(false);
+  });
+});

--- a/src/eventRoutes/extensions.ts
+++ b/src/eventRoutes/extensions.ts
@@ -1,0 +1,24 @@
+import type { EventRouteContext, EventRouteEvent } from "./types";
+
+/** Returns true when an extension has registered an event-route that
+ *  matches this event (componentId + eventType, with both wildcards
+ *  permitted). Handled separately from the route table because a
+ *  match's effect is "skip built-ins, forward to bridge" rather than
+ *  "handled, suppress forward" — the dispatcher consults this gate
+ *  between shell-consent and built-ins. */
+export function matchesExtensionRoute(
+  event: EventRouteEvent,
+  ctx: EventRouteContext,
+): boolean {
+  // "extension" mode: extensions have taken over routing entirely. The
+  // dispatcher returns false (forward to bridge) for every event.
+  if (ctx.extensionEventRoutingModeRef.current === "extension") return true;
+
+  const routes = ctx.extensionEventRoutesRef.current;
+  if (routes.length === 0) return false;
+  return routes.some((r) => {
+    const cidOk = !r.componentId || r.componentId === event.component.id;
+    const evtOk = !r.eventType || r.eventType === event.eventType;
+    return cidOk && evtOk;
+  });
+}

--- a/src/eventRoutes/index.test.ts
+++ b/src/eventRoutes/index.test.ts
@@ -1,0 +1,126 @@
+/** Routing precedence contract for `dispatchEvent`.
+ *
+ *  Contract: shell-consent reserved prefixes > extension event-routes
+ *  > built-in routes. Any change to the dispatcher must keep these
+ *  invariants — they're the security boundary (consent can't be
+ *  hijacked) and the extensibility surface (extensions can override
+ *  built-ins).
+ *
+ *  The tests assert via observable side-effects on the route ctx —
+ *  whether the consent resolver fired, whether the built-in handler
+ *  ran, what the dispatcher's return value was. */
+import { describe, expect, it } from "vitest";
+import { dispatchEvent } from "./index";
+import { buildRouteFixture } from "./testFixtures";
+
+describe("dispatchEvent — precedence contract", () => {
+  it("Layer 1 wins over Layer 2: shell-write-allow runs even when an extension matches notification-stack", async () => {
+    const { ctx, mocks } = buildRouteFixture({
+      pendingShellWriteIds: ["nid-1"],
+      // An extension has registered for notification-stack actions —
+      // would intercept the event under Layer 2 if Layer 1 didn't win.
+      extensionRoutes: [
+        { componentId: "notification-stack", eventType: "action" },
+      ],
+    });
+    const handled = await dispatchEvent(
+      {
+        component: { id: "notification-stack" },
+        eventType: "action",
+        data: { id: "nid-1", action: "shell-write-allow:req-1" },
+      },
+      ctx,
+    );
+    // Handled via consent gate → return true (suppress forward).
+    expect(handled).toBe(true);
+    expect(mocks.resolveShellWriteConsent).toHaveBeenCalledWith("nid-1", true);
+    // The notifications built-in must NOT have run a second resolution
+    // pass on top of the consent gate's call.
+    expect(mocks.dismissNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it("Layer 2 wins over Layer 3: an extension match short-circuits built-ins and returns false (forward to bridge)", async () => {
+    const { ctx, mocks } = buildRouteFixture({
+      extensionRoutes: [{ componentId: "settings-panel" }],
+    });
+    const handled = await dispatchEvent(
+      { component: { id: "settings-panel" }, eventType: "close" },
+      ctx,
+    );
+    // false = renderer forwards to bridge so the extension's
+    // aethon.onEvent matcher fires.
+    expect(handled).toBe(false);
+    // The settings built-in must NOT have run.
+    expect(mocks.closeSettings).not.toHaveBeenCalled();
+  });
+
+  it("'extension' routing mode forwards every event without running built-ins", async () => {
+    const { ctx, mocks } = buildRouteFixture({
+      extensionRoutingMode: "extension",
+    });
+    const handled = await dispatchEvent(
+      {
+        component: { id: "chat-input" },
+        eventType: "submit",
+        data: { value: "hi" },
+      },
+      ctx,
+    );
+    expect(handled).toBe(false);
+    expect(mocks.sendChat).not.toHaveBeenCalled();
+  });
+
+  it("Layer 3 runs only when no extension matches — built-in chat-input submit fires sendChat", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    const handled = await dispatchEvent(
+      {
+        component: { id: "chat-input" },
+        eventType: "submit",
+        data: { value: "hello" },
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.sendChat).toHaveBeenCalledWith("hello");
+  });
+
+  it("Layer 3 lookup uses both id-key and type-key — type-keyed terminal-panel matches even when id differs across layouts", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    const handled = await dispatchEvent(
+      {
+        component: { id: "any-layout-terminal", type: "terminal-panel" },
+        eventType: "new-shell-sub-tab",
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.newShellTab).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns false when nothing matches — renderer falls back to default forward", async () => {
+    const { ctx } = buildRouteFixture();
+    const handled = await dispatchEvent(
+      { component: { id: "unknown-thing" }, eventType: "unknown-event" },
+      ctx,
+    );
+    expect(handled).toBe(false);
+  });
+
+  it("Layer 1: dismiss of an id without a pending consent falls through to Layer 3", async () => {
+    // No pending consent + no extension route + dismiss arrives → the
+    // notifications built-in (Layer 3) handles it as the safety-net
+    // resolve-and-dismiss path.
+    const { ctx, mocks } = buildRouteFixture();
+    const handled = await dispatchEvent(
+      {
+        component: { id: "notification-stack" },
+        eventType: "dismiss",
+        data: { id: "stranger" },
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    // Built-in path called dismissNotification once.
+    expect(mocks.dismissNotification).toHaveBeenCalledWith("stranger");
+  });
+});

--- a/src/eventRoutes/index.ts
+++ b/src/eventRoutes/index.ts
@@ -1,0 +1,113 @@
+/** Event route table. Maps each renderer-side event to a handler.
+ *  Adding a new route:
+ *
+ *    1. Create `eventRoutes/<name>.ts` exporting an `EventRouteHandler`.
+ *    2. Register it under the appropriate prefix key(s) in
+ *       BUILTIN_ROUTE_TABLE below.
+ *    3. Add a happy-path test in `eventRoutes/<name>.test.ts`.
+ *
+ *  Three precedence layers, enforced by `dispatchEvent`:
+ *
+ *    1. **Shell-consent reserved prefixes** — security boundary. A
+ *       user's Allow / Deny / dismiss on a shell-write / shell-close
+ *       / session-delete prompt MUST resolve before any extension
+ *       matcher sees the event.
+ *    2. **Extension event routes** — when an extension has registered
+ *       a route that matches this event, the dispatcher returns
+ *       `false` (renderer forwards to bridge → extension's
+ *       `aethon.onEvent` handler runs), skipping built-ins.
+ *    3. **Built-in routes** — keyed by `id:<componentId>` and
+ *       `type:<componentType>`; each handler returns `true` if it
+ *       matched and handled.
+ *
+ *  See `dispatchEvent.test.ts` for the precedence contract test. */
+import type {
+  EventRouteContext,
+  EventRouteEvent,
+  EventRouteHandler,
+} from "./types";
+import { handleShellConsent } from "./shellConsent";
+import { matchesExtensionRoute } from "./extensions";
+import { handleChatInput } from "./chatInput";
+import { handleSettings } from "./settings";
+import { handleSearch } from "./search";
+import { handlePalette } from "./palette";
+import { handleNotifications } from "./notifications";
+import { handleTerminalPanel, handleShareModeCycle } from "./terminal";
+import { handleTabStrip, handleEmptyState } from "./tabStrip";
+import {
+  handleSidebarResize,
+  handleSidebarResizeEnd,
+  handleSidebarRemoveProject,
+  handleSidebarDeleteSession,
+  handleSectionedSelect,
+} from "./sidebar";
+
+/** Lookup table for built-in routes. Keys are `id:<componentId>` or
+ *  `type:<componentType>`. The dispatcher computes both keys for an
+ *  event and concatenates the matched handler lists. Order within a
+ *  list is the order of declaration here. */
+export const BUILTIN_ROUTE_TABLE: ReadonlyMap<string, readonly EventRouteHandler[]> =
+  new Map<string, readonly EventRouteHandler[]>([
+    // notification-stack: `handleShellConsent` is run separately as the
+    // top-precedence gate; the general handler runs here.
+    ["id:notification-stack", [handleNotifications]],
+    ["id:settings-panel", [handleSettings]],
+    ["id:search-panel", [handleSearch]],
+    ["id:command-palette", [handlePalette]],
+    ["id:chat-input", [handleChatInput]],
+    ["id:empty-state", [handleEmptyState]],
+    ["id:sidebar", [
+      handleSidebarResize,
+      handleSidebarResizeEnd,
+      handleSidebarRemoveProject,
+      handleSidebarDeleteSession,
+      handleSectionedSelect,
+    ]],
+    ["id:model-picker", [handleSectionedSelect]],
+    ["id:appearance-menu", [handleSectionedSelect]],
+    ["type:terminal-panel", [handleTerminalPanel]],
+    ["type:tab-strip", [handleTabStrip]],
+    ["type:shell-canvas", [handleShareModeCycle]],
+    ["type:share-mode-badge", [handleShareModeCycle]],
+  ]);
+
+/** Dispatch a renderer-side event through the precedence layers.
+ *  Returns true when a handler claimed the event (renderer suppresses
+ *  its default forward); false when no handler claimed it OR an
+ *  extension route matched (renderer forwards to bridge). */
+export async function dispatchEvent(
+  event: EventRouteEvent,
+  ctx: EventRouteContext,
+): Promise<boolean> {
+  // Layer 1: shell-consent reserved prefixes.
+  if (await handleShellConsent(event, ctx)) return true;
+
+  // Layer 2: extension-route interception. When matched the renderer
+  // forwards to the bridge so the extension's matcher fires; built-ins
+  // are skipped entirely.
+  if (matchesExtensionRoute(event, ctx)) return false;
+
+  // Layer 3: built-ins. Look up handlers by id-key then type-key; first
+  // handler to return true wins.
+  const idKey = `id:${event.component.id}`;
+  const handlers: EventRouteHandler[] = [];
+  const idHandlers = BUILTIN_ROUTE_TABLE.get(idKey);
+  if (idHandlers) handlers.push(...idHandlers);
+  if (event.component.type) {
+    const typeHandlers = BUILTIN_ROUTE_TABLE.get(
+      `type:${event.component.type}`,
+    );
+    if (typeHandlers) handlers.push(...typeHandlers);
+  }
+  for (const handler of handlers) {
+    if (await handler(event, ctx)) return true;
+  }
+  return false;
+}
+
+export type {
+  EventRouteContext,
+  EventRouteEvent,
+  EventRouteHandler,
+} from "./types";

--- a/src/eventRoutes/notifications.test.ts
+++ b/src/eventRoutes/notifications.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { handleNotifications } from "./notifications";
+import { buildRouteFixture } from "./testFixtures";
+
+describe("handleNotifications", () => {
+  it("dismiss resolves all three consents defensively and dismisses", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    const handled = await handleNotifications(
+      {
+        component: { id: "notification-stack" },
+        eventType: "dismiss",
+        data: { id: "ext-1" },
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.resolveShellWriteConsent).toHaveBeenCalledWith("ext-1", false);
+    expect(mocks.resolveShellCloseConsent).toHaveBeenCalledWith("ext-1", false);
+    expect(mocks.resolveSessionDeleteConsent).toHaveBeenCalledWith(
+      "ext-1",
+      false,
+    );
+    expect(mocks.dismissNotification).toHaveBeenCalledWith("ext-1");
+  });
+
+  it("ae-agent-crashed:restart invokes start_agent", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    const handled = await handleNotifications(
+      {
+        component: { id: "notification-stack" },
+        eventType: "action",
+        data: { id: "n1", action: "ae-agent-crashed:restart" },
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.invoke).toHaveBeenCalledWith("start_agent");
+    expect(mocks.dismissNotification).toHaveBeenCalledWith("n1");
+  });
+
+  it("hang-warn:stop:<tabId> stops that tab specifically", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    const handled = await handleNotifications(
+      {
+        component: { id: "notification-stack" },
+        eventType: "action",
+        data: { id: "n2", action: "hang-warn:stop:tab-xyz" },
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.stopPrompt).toHaveBeenCalledWith("tab-xyz");
+    expect(mocks.dismissNotification).toHaveBeenCalledWith("n2");
+  });
+
+  it("hang-warn:force-restart invokes force_restart_agent", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    await handleNotifications(
+      {
+        component: { id: "notification-stack" },
+        eventType: "action",
+        data: { id: "n3", action: "hang-warn:force-restart" },
+      },
+      ctx,
+    );
+    expect(mocks.invoke).toHaveBeenCalledWith("force_restart_agent");
+  });
+
+  it("forwards an unknown action through dispatch_a2ui_event", async () => {
+    const { ctx, mocks } = buildRouteFixture({
+      state: { activeTabId: "tab-active" },
+    });
+    await handleNotifications(
+      {
+        component: { id: "notification-stack" },
+        eventType: "action",
+        data: { id: "n4", action: "ext:custom" },
+      },
+      ctx,
+    );
+    const [cmd, args] = mocks.invoke.mock.calls[0];
+    expect(cmd).toBe("dispatch_a2ui_event");
+    const event = JSON.parse((args as { event: string }).event);
+    expect(event).toMatchObject({
+      componentId: "notification__tpl__n4",
+      componentType: "notification",
+      eventType: "invoke",
+      data: { id: "n4", action: "ext:custom" },
+    });
+    expect((args as { tabId: string }).tabId).toBe("tab-active");
+  });
+
+  it("returns false for non-notification-stack components", async () => {
+    const { ctx } = buildRouteFixture();
+    const handled = await handleNotifications(
+      { component: { id: "settings-panel" }, eventType: "action" },
+      ctx,
+    );
+    expect(handled).toBe(false);
+  });
+});

--- a/src/eventRoutes/notifications.ts
+++ b/src/eventRoutes/notifications.ts
@@ -1,0 +1,97 @@
+import type { EventRouteHandler } from "./types";
+
+/** General notification-stack handler. Runs AFTER `handleShellConsent`
+ *  in the dispatch table — the consent gate has already short-circuited
+ *  the three reserved action prefixes (shell-write-, shell-close-,
+ *  session-delete-). Remaining shapes:
+ *
+ *  • dismiss/expire of any id — defensively resolves consents to
+ *    `false` so a dropped notification can't dangle the originator's
+ *    promise (idempotent: the ids without pending resolvers are no-ops).
+ *  • action with reserved prefix arriving at the general handler (e.g.
+ *    extension flipped routing late) — same defensive resolve.
+ *  • ae-agent-crashed: action — restart the bridge.
+ *  • hang-warn: action — stop / force-restart.
+ *  • everything else with an action — forward to the bridge as a
+ *    `notification.invoke` a2ui event for extension matchers. */
+export const handleNotifications: EventRouteHandler = (
+  { component, eventType, data },
+  ctx,
+) => {
+  if (component.id !== "notification-stack") return false;
+  const id = (data as { id?: string } | undefined)?.id;
+
+  if ((eventType === "dismiss" || eventType === "expire") && id) {
+    // Safety net — resolve all three consent kinds to false; resolvers
+    // for ids without a pending entry are no-ops.
+    ctx.resolveShellWriteConsent(id, false);
+    ctx.resolveShellCloseConsent(id, false);
+    ctx.resolveSessionDeleteConsent(id, false);
+    ctx.dismissNotification(id);
+    return true;
+  }
+
+  if (eventType === "action" && id) {
+    const action = (data as { action?: string } | undefined)?.action;
+    if (action && action.startsWith("shell-write-")) {
+      const allowed = action.startsWith("shell-write-allow:");
+      ctx.resolveShellWriteConsent(id, allowed);
+    } else if (action && action.startsWith("shell-close-")) {
+      const allowed = action.startsWith("shell-close-allow:");
+      ctx.resolveShellCloseConsent(id, allowed);
+    } else if (action && action.startsWith("session-delete-")) {
+      const allowed = action.startsWith("session-delete-allow:");
+      ctx.resolveSessionDeleteConsent(id, allowed);
+    } else if (
+      action &&
+      action.startsWith("ae-agent-crashed:")
+    ) {
+      if (action === "ae-agent-crashed:restart") {
+        ctx.invoke("start_agent").catch((err: unknown) => {
+          console.warn("agent restart failed:", err);
+        });
+      }
+      ctx.dismissNotification(id);
+      return true;
+    } else if (action && action.startsWith("hang-warn:")) {
+      if (action.startsWith("hang-warn:stop")) {
+        // Stop carries the tabId of the hung tab so the right session
+        // is stopped even if the user is on a different tab when they
+        // click.
+        const targetTabId = action.startsWith("hang-warn:stop:")
+          ? action.slice("hang-warn:stop:".length)
+          : undefined;
+        void ctx.stopPrompt(targetTabId);
+      } else if (action === "hang-warn:force-restart") {
+        // force_restart_agent SIGKILLs the bun child from Rust,
+        // bypassing blocked stdin. The agent-crashed handler clears
+        // waiting state and (if auto_restart_agent) respawns.
+        ctx.invoke("force_restart_agent").catch((err: unknown) => {
+          console.warn("force_restart_agent failed:", err);
+        });
+      }
+      ctx.dismissNotification(id);
+      return true;
+    } else if (action) {
+      const tabId = ctx.stateRef.current.activeTabId as string | undefined;
+      ctx
+        .invoke("dispatch_a2ui_event", {
+          event: JSON.stringify({
+            componentId: `notification__tpl__${id}`,
+            componentType: "notification",
+            templateRootType: "notification",
+            eventType: "invoke",
+            data: { id, action },
+          }),
+          tabId,
+        })
+        .catch(() => {
+          /* ignore — bridge gone */
+        });
+    }
+    ctx.dismissNotification(id);
+    return true;
+  }
+
+  return false;
+};

--- a/src/eventRoutes/palette.test.ts
+++ b/src/eventRoutes/palette.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { handlePalette } from "./palette";
+import { buildRouteFixture } from "./testFixtures";
+
+describe("handlePalette", () => {
+  it("close calls closePalette", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    const handled = await handlePalette(
+      { component: { id: "command-palette" }, eventType: "close" },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.closePalette).toHaveBeenCalledTimes(1);
+  });
+
+  it("query writes /palette/query and resets selectedIndex", async () => {
+    const { ctx, applySetState } = buildRouteFixture({
+      state: { palette: { open: true, query: "old", selectedIndex: 5 } },
+    });
+    await handlePalette(
+      {
+        component: { id: "command-palette" },
+        eventType: "query",
+        data: { value: "new" },
+      },
+      ctx,
+    );
+    const next = applySetState({
+      palette: { open: true, query: "old", selectedIndex: 5 },
+    });
+    expect(next.palette).toEqual({
+      open: true,
+      query: "new",
+      selectedIndex: 0,
+    });
+  });
+
+  it("navigate updates only selectedIndex", async () => {
+    const { ctx, applySetState } = buildRouteFixture();
+    await handlePalette(
+      {
+        component: { id: "command-palette" },
+        eventType: "navigate",
+        data: { index: 3 },
+      },
+      ctx,
+    );
+    const next = applySetState({
+      palette: { open: true, query: "q", selectedIndex: 0 },
+    });
+    expect(next.palette).toEqual({
+      open: true,
+      query: "q",
+      selectedIndex: 3,
+    });
+  });
+
+  it("select closes palette and runs the item", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    const item = { kind: "tab" as const, tabId: "abc", label: "tab abc" };
+    const handled = await handlePalette(
+      {
+        component: { id: "command-palette" },
+        eventType: "select",
+        data: { item },
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.closePalette).toHaveBeenCalledTimes(1);
+    expect(mocks.runPaletteItem).toHaveBeenCalledWith(item);
+  });
+});

--- a/src/eventRoutes/palette.ts
+++ b/src/eventRoutes/palette.ts
@@ -1,0 +1,49 @@
+import type { EventRouteHandler } from "./types";
+import type { PaletteItem } from "../skills/default-layout/palette-items";
+
+/** command-palette renders at App root and never goes through the
+ *  dispatch_a2ui bridge (no agent counterpart to invoke). Events land
+ *  here directly. Selection runs the item *after* closing the palette
+ *  so a slow handler doesn't leave the result obscured. */
+export const handlePalette: EventRouteHandler = (
+  { component, eventType, data },
+  ctx,
+) => {
+  if (component.id !== "command-palette") return false;
+  if (eventType === "close") {
+    ctx.closePalette();
+    return true;
+  }
+  if (eventType === "query") {
+    const value = (data as { value?: string } | undefined)?.value ?? "";
+    ctx.setState((prev) => ({
+      ...prev,
+      palette: {
+        ...(prev.palette ?? {}),
+        query: value,
+        selectedIndex: 0,
+      },
+    }));
+    return true;
+  }
+  if (eventType === "navigate") {
+    const idx = (data as { index?: number } | undefined)?.index ?? 0;
+    ctx.setState((prev) => ({
+      ...prev,
+      palette: {
+        ...(prev.palette ?? {}),
+        selectedIndex: idx,
+      },
+    }));
+    return true;
+  }
+  if (eventType === "select") {
+    const item = (data as { item?: PaletteItem } | undefined)?.item;
+    if (item) {
+      ctx.closePalette();
+      void ctx.runPaletteItem(item);
+    }
+    return true;
+  }
+  return false;
+};

--- a/src/eventRoutes/search.test.ts
+++ b/src/eventRoutes/search.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { handleSearch } from "./search";
+import { buildRouteFixture } from "./testFixtures";
+
+describe("handleSearch", () => {
+  it("close calls closeSessionSearch", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    const handled = await handleSearch(
+      { component: { id: "search-panel" }, eventType: "close" },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.closeSessionSearch).toHaveBeenCalledTimes(1);
+  });
+
+  it("query forwards the search string", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    const handled = await handleSearch(
+      {
+        component: { id: "search-panel" },
+        eventType: "query",
+        data: { value: "needle" },
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.setSearchQuery).toHaveBeenCalledWith("needle");
+  });
+
+  it("scope=current narrows the search", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    const handled = await handleSearch(
+      {
+        component: { id: "search-panel" },
+        eventType: "scope",
+        data: { scope: "current" },
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.setSearchScope).toHaveBeenCalledWith("current");
+  });
+
+  it("select opens the chosen hit", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    const handled = await handleSearch(
+      {
+        component: { id: "search-panel" },
+        eventType: "select",
+        data: { hit: { tabId: "abc", snippetMatch: "needle" } },
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.openSearchHit).toHaveBeenCalledWith({
+      tabId: "abc",
+      snippetMatch: "needle",
+    });
+  });
+});

--- a/src/eventRoutes/search.ts
+++ b/src/eventRoutes/search.ts
@@ -1,0 +1,40 @@
+import type { EventRouteHandler } from "./types";
+
+/** search-panel renders at App root. Search results land via the
+ *  Tauri search_sessions command, not the bridge — events here drive
+ *  the overlay's local state. */
+export const handleSearch: EventRouteHandler = (
+  { component, eventType, data },
+  ctx,
+) => {
+  if (component.id !== "search-panel") return false;
+  if (eventType === "close") {
+    ctx.closeSessionSearch();
+    return true;
+  }
+  if (eventType === "query") {
+    const value = (data as { value?: string } | undefined)?.value ?? "";
+    ctx.setSearchQuery(value);
+    return true;
+  }
+  if (eventType === "scope") {
+    const scope = (data as { scope?: "all" | "current" } | undefined)?.scope;
+    if (scope === "all" || scope === "current") {
+      ctx.setSearchScope(scope);
+    }
+    return true;
+  }
+  if (eventType === "select") {
+    const hit = (data as
+      | {
+          hit?: {
+            tabId?: string;
+            snippetMatch?: string;
+          };
+        }
+      | undefined)?.hit;
+    if (hit) ctx.openSearchHit(hit);
+    return true;
+  }
+  return false;
+};

--- a/src/eventRoutes/settings.test.ts
+++ b/src/eventRoutes/settings.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { handleSettings } from "./settings";
+import { buildRouteFixture } from "./testFixtures";
+
+describe("handleSettings", () => {
+  it("close calls closeSettings", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    const handled = await handleSettings(
+      { component: { id: "settings-panel" }, eventType: "close" },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.closeSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it("update applies a partial config patch", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    const handled = await handleSettings(
+      {
+        component: { id: "settings-panel" },
+        eventType: "update",
+        data: { patch: { theme: "dark" } },
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.applySettingsPatch).toHaveBeenCalledWith({ theme: "dark" });
+  });
+
+  it("save commits via saveSettings", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    const handled = await handleSettings(
+      { component: { id: "settings-panel" }, eventType: "save" },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.saveSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns false for other components", async () => {
+    const { ctx } = buildRouteFixture();
+    const handled = await handleSettings(
+      { component: { id: "search-panel" }, eventType: "close" },
+      ctx,
+    );
+    expect(handled).toBe(false);
+  });
+});

--- a/src/eventRoutes/settings.ts
+++ b/src/eventRoutes/settings.ts
@@ -1,0 +1,25 @@
+import type { EventRouteHandler } from "./types";
+
+/** settings-panel renders at App root and never goes through the
+ *  bridge — events drive the panel's pending overlay directly. */
+export const handleSettings: EventRouteHandler = (
+  { component, eventType, data },
+  ctx,
+) => {
+  if (component.id !== "settings-panel") return false;
+  if (eventType === "close") {
+    ctx.closeSettings();
+    return true;
+  }
+  if (eventType === "update") {
+    const patch = (data as { patch?: Record<string, unknown> } | undefined)
+      ?.patch;
+    if (patch) ctx.applySettingsPatch(patch);
+    return true;
+  }
+  if (eventType === "save") {
+    void ctx.saveSettings();
+    return true;
+  }
+  return false;
+};

--- a/src/eventRoutes/shellConsent.test.ts
+++ b/src/eventRoutes/shellConsent.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import { handleShellConsent, SHELL_CONSENT_PREFIXES } from "./shellConsent";
+import { buildRouteFixture } from "./testFixtures";
+
+describe("handleShellConsent", () => {
+  it("exposes the canonical reserved prefix list", () => {
+    expect(SHELL_CONSENT_PREFIXES).toEqual([
+      "shell-write-",
+      "shell-close-",
+      "session-delete-",
+    ]);
+  });
+
+  it("shell-write-allow resolves consent to true and dismisses", async () => {
+    const { ctx, mocks } = buildRouteFixture({
+      pendingShellWriteIds: ["nid-1"],
+    });
+    const handled = await handleShellConsent(
+      {
+        component: { id: "notification-stack" },
+        eventType: "action",
+        data: { id: "nid-1", action: "shell-write-allow:request-1" },
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.resolveShellWriteConsent).toHaveBeenCalledWith("nid-1", true);
+    expect(mocks.dismissNotification).toHaveBeenCalledWith("nid-1");
+  });
+
+  it("shell-write-deny resolves consent to false", async () => {
+    const { ctx, mocks } = buildRouteFixture({
+      pendingShellWriteIds: ["nid-2"],
+    });
+    await handleShellConsent(
+      {
+        component: { id: "notification-stack" },
+        eventType: "action",
+        data: { id: "nid-2", action: "shell-write-deny:request-2" },
+      },
+      ctx,
+    );
+    expect(mocks.resolveShellWriteConsent).toHaveBeenCalledWith("nid-2", false);
+  });
+
+  it("dismiss of a pending shell-close id resolves to false", async () => {
+    const { ctx, mocks } = buildRouteFixture({
+      pendingShellCloseIds: ["nid-3"],
+    });
+    const handled = await handleShellConsent(
+      {
+        component: { id: "notification-stack" },
+        eventType: "dismiss",
+        data: { id: "nid-3" },
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.resolveShellCloseConsent).toHaveBeenCalledWith("nid-3", false);
+  });
+
+  it("session-delete-allow resolves and dismisses", async () => {
+    const { ctx, mocks } = buildRouteFixture({
+      pendingSessionDeleteIds: ["nid-4"],
+    });
+    const handled = await handleShellConsent(
+      {
+        component: { id: "notification-stack" },
+        eventType: "action",
+        data: { id: "nid-4", action: "session-delete-allow:abc" },
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.resolveSessionDeleteConsent).toHaveBeenCalledWith(
+      "nid-4",
+      true,
+    );
+  });
+
+  it("returns false for non-notification-stack components", async () => {
+    const { ctx } = buildRouteFixture();
+    const handled = await handleShellConsent(
+      {
+        component: { id: "settings-panel" },
+        eventType: "action",
+        data: { id: "x", action: "shell-write-allow:y" },
+      },
+      ctx,
+    );
+    expect(handled).toBe(false);
+  });
+
+  it("returns false for an unrelated notification-stack action", async () => {
+    const { ctx } = buildRouteFixture();
+    const handled = await handleShellConsent(
+      {
+        component: { id: "notification-stack" },
+        eventType: "action",
+        data: { id: "x", action: "ae-agent-crashed:restart" },
+      },
+      ctx,
+    );
+    expect(handled).toBe(false);
+  });
+
+  it("returns false for dismiss of an id without a pending resolver", async () => {
+    const { ctx } = buildRouteFixture();
+    const handled = await handleShellConsent(
+      {
+        component: { id: "notification-stack" },
+        eventType: "dismiss",
+        data: { id: "stranger" },
+      },
+      ctx,
+    );
+    expect(handled).toBe(false);
+  });
+});

--- a/src/eventRoutes/shellConsent.ts
+++ b/src/eventRoutes/shellConsent.ts
@@ -1,0 +1,95 @@
+import type { EventRouteHandler } from "./types";
+
+/** Reserved shell-consent action prefixes on `notification-stack`.
+ *  Listed so the contract test and any new audit can assert against the
+ *  canonical set. Adding to this list means adding a `resolveX` /
+ *  `hasPendingX` pair on EventRouteContext and a branch below. */
+export const SHELL_CONSENT_PREFIXES = Object.freeze([
+  "shell-write-",
+  "shell-close-",
+  "session-delete-",
+] as const);
+
+/** Top-precedence route. Runs before extension interception so a user's
+ *  Allow / Deny / dismiss on a shell-consent prompt can never be
+ *  hijacked by an extension that registered for `notification-stack`.
+ *  Filters narrowly on the three reserved action prefixes plus
+ *  dismiss/expire of an id with a pending resolver — every other
+ *  notification-stack event falls through. */
+export const handleShellConsent: EventRouteHandler = ({
+  component,
+  eventType,
+  data,
+}, ctx) => {
+  if (component.id !== "notification-stack") return false;
+  const id = (data as { id?: string } | undefined)?.id;
+  const action = (data as { action?: string } | undefined)?.action;
+
+  // shell-write
+  if (
+    eventType === "action" &&
+    typeof action === "string" &&
+    action.startsWith("shell-write-") &&
+    id
+  ) {
+    const allowed = action.startsWith("shell-write-allow:");
+    ctx.resolveShellWriteConsent(id, allowed);
+    ctx.dismissNotification(id);
+    return true;
+  }
+  if (
+    (eventType === "dismiss" || eventType === "expire") &&
+    typeof id === "string" &&
+    ctx.hasPendingShellWriteConsent(id)
+  ) {
+    ctx.resolveShellWriteConsent(id, false);
+    ctx.dismissNotification(id);
+    return true;
+  }
+
+  // shell-close
+  if (
+    eventType === "action" &&
+    typeof action === "string" &&
+    action.startsWith("shell-close-") &&
+    id
+  ) {
+    const allowed = action.startsWith("shell-close-allow:");
+    ctx.resolveShellCloseConsent(id, allowed);
+    ctx.dismissNotification(id);
+    return true;
+  }
+  if (
+    (eventType === "dismiss" || eventType === "expire") &&
+    typeof id === "string" &&
+    ctx.hasPendingShellCloseConsent(id)
+  ) {
+    ctx.resolveShellCloseConsent(id, false);
+    ctx.dismissNotification(id);
+    return true;
+  }
+
+  // session-delete
+  if (
+    eventType === "action" &&
+    typeof action === "string" &&
+    action.startsWith("session-delete-") &&
+    id
+  ) {
+    const allowed = action.startsWith("session-delete-allow:");
+    ctx.resolveSessionDeleteConsent(id, allowed);
+    ctx.dismissNotification(id);
+    return true;
+  }
+  if (
+    (eventType === "dismiss" || eventType === "expire") &&
+    typeof id === "string" &&
+    ctx.hasPendingSessionDeleteConsent(id)
+  ) {
+    ctx.resolveSessionDeleteConsent(id, false);
+    ctx.dismissNotification(id);
+    return true;
+  }
+
+  return false;
+};

--- a/src/eventRoutes/sidebar.test.ts
+++ b/src/eventRoutes/sidebar.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+import {
+  handleSidebarResize,
+  handleSidebarResizeEnd,
+  handleSidebarRemoveProject,
+  handleSidebarDeleteSession,
+  handleSectionedSelect,
+} from "./sidebar";
+import { buildRouteFixture } from "./testFixtures";
+
+describe("handleSidebarResize", () => {
+  it("rewrites just the leading column token", async () => {
+    const { ctx, applySetState } = buildRouteFixture();
+    const handled = await handleSidebarResize(
+      {
+        component: { id: "sidebar" },
+        eventType: "resize",
+        data: { width: 280 },
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    const next = applySetState({
+      layout: { columns: "220px minmax(0,1fr) 320px" },
+    });
+    expect((next.layout as { columns: string }).columns).toBe(
+      "280px minmax(0,1fr) 320px",
+    );
+  });
+});
+
+describe("handleSidebarResizeEnd", () => {
+  it("persists the current sidebar width", async () => {
+    const { ctx, mocks } = buildRouteFixture({
+      state: { layout: { columns: "240px minmax(0,1fr)" } },
+    });
+    await handleSidebarResizeEnd(
+      { component: { id: "sidebar" }, eventType: "resize-end" },
+      ctx,
+    );
+    expect(mocks.writeState).toHaveBeenCalledWith("sidebar_width", "240");
+  });
+});
+
+describe("handleSidebarRemoveProject", () => {
+  it("delegates to removeProjectById", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    const handled = await handleSidebarRemoveProject(
+      {
+        component: { id: "sidebar" },
+        eventType: "remove-project",
+        data: { projectId: "proj-1" },
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.removeProjectById).toHaveBeenCalledWith("proj-1");
+  });
+});
+
+describe("handleSidebarDeleteSession", () => {
+  it("prompts then deletes when allowed", async () => {
+    const { ctx, mocks } = buildRouteFixture({
+      promptDeleteAllow: true,
+      state: { tabs: [{ id: "sess-1", kind: "agent" }] },
+    });
+    await handleSidebarDeleteSession(
+      {
+        component: { id: "sidebar" },
+        eventType: "delete-session",
+        data: { sessionId: "sess-1", label: "Chat 1" },
+      },
+      ctx,
+    );
+    // Resolve the prompt promise + the delete_session invoke.
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mocks.invoke).toHaveBeenCalledWith("delete_session", {
+      tabId: "sess-1",
+    });
+  });
+
+  it("returns true and does nothing on empty input", async () => {
+    const { ctx, mocks } = buildRouteFixture({ promptDeleteAllow: true });
+    const handled = await handleSidebarDeleteSession(
+      {
+        component: { id: "sidebar" },
+        eventType: "delete-session",
+        data: {},
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.promptDeleteSessionConfirmation).not.toHaveBeenCalled();
+  });
+});
+
+describe("handleSectionedSelect", () => {
+  it("toggle-terminal hits toggleTerminal", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    await handleSectionedSelect(
+      {
+        component: { id: "sidebar" },
+        eventType: "select",
+        data: { itemId: "toggle-terminal" },
+      },
+      ctx,
+    );
+    expect(mocks.toggleTerminal).toHaveBeenCalledTimes(1);
+  });
+
+  it("models section calls setModel", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    await handleSectionedSelect(
+      {
+        component: { id: "model-picker" },
+        eventType: "select",
+        data: { sectionId: "models", itemId: "anthropic/claude-opus-4-7" },
+      },
+      ctx,
+    );
+    expect(mocks.setModel).toHaveBeenCalledWith("anthropic/claude-opus-4-7");
+  });
+
+  it("themes section calls setTheme", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    await handleSectionedSelect(
+      {
+        component: { id: "appearance-menu" },
+        eventType: "select",
+        data: { sectionId: "themes", itemId: "dim" },
+      },
+      ctx,
+    );
+    expect(mocks.setTheme).toHaveBeenCalledWith("dim");
+  });
+
+  it("history section with tab: prefix activates that tab", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    await handleSectionedSelect(
+      {
+        component: { id: "sidebar" },
+        eventType: "select",
+        data: { sectionId: "history", itemId: "tab:abc123" },
+      },
+      ctx,
+    );
+    expect(mocks.setActiveTab).toHaveBeenCalledWith("abc123");
+  });
+
+  it("projects open-project triggers the picker", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    await handleSectionedSelect(
+      {
+        component: { id: "sidebar" },
+        eventType: "select",
+        data: { sectionId: "projects", itemId: "open-project" },
+      },
+      ctx,
+    );
+    expect(mocks.openProjectFromPicker).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns false for non-select events", async () => {
+    const { ctx } = buildRouteFixture();
+    const handled = await handleSectionedSelect(
+      { component: { id: "sidebar" }, eventType: "click" },
+      ctx,
+    );
+    expect(handled).toBe(false);
+  });
+});

--- a/src/eventRoutes/sidebar.ts
+++ b/src/eventRoutes/sidebar.ts
@@ -1,0 +1,206 @@
+import type { EventRouteHandler } from "./types";
+import { extractSessionId } from "../utils/sidebarHistory";
+import type { Tab } from "../types/tab";
+
+interface RecentSessionItem {
+  id: string;
+  label: string;
+  lastModified?: string;
+  cwd?: string;
+}
+
+/** sidebar resize: live drag updates the leading column token in
+ *  /layout/columns. Layouts shape grid columns as either
+ *  "${SIDEBAR}px minmax(0,1fr)" or
+ *  "${SIDEBAR}px minmax(0,1fr) ${INSPECTOR}px" — replace just the first
+ *  token so non-sidebar columns survive the rewrite. */
+export const handleSidebarResize: EventRouteHandler = (
+  { component, eventType, data },
+  ctx,
+) => {
+  if (component.id !== "sidebar" || eventType !== "resize") return false;
+  const next = (data as { width?: number } | undefined)?.width;
+  if (typeof next === "number") {
+    ctx.setState((prev) => {
+      const layout =
+        (prev.layout as Record<string, unknown> | undefined) ?? {};
+      const current =
+        (layout.columns as string | undefined) ?? "220px minmax(0,1fr)";
+      const tokens = current.trim().split(/\s+/);
+      tokens[0] = `${next}px`;
+      return { ...prev, layout: { ...layout, columns: tokens.join(" ") } };
+    });
+  }
+  return true;
+};
+
+/** sidebar resize-end: persist the final width so the next boot opens
+ *  at the same size. Reads from state.layout.columns (the in-flight
+ *  value the resize listener just wrote) so a single source of truth
+ *  wins. */
+export const handleSidebarResizeEnd: EventRouteHandler = (
+  { component, eventType },
+  ctx,
+) => {
+  if (component.id !== "sidebar" || eventType !== "resize-end") return false;
+  const layout =
+    (ctx.stateRef.current.layout as Record<string, unknown> | undefined) ?? {};
+  const cols = (layout.columns as string | undefined) ?? "";
+  const lead = cols.trim().split(/\s+/)[0] ?? "";
+  const px = parseInt(lead, 10);
+  if (Number.isFinite(px) && px > 0) {
+    ctx.writeState("sidebar_width", String(px)).catch(() => {
+      /* ignore — best-effort */
+    });
+  }
+  return true;
+};
+
+/** sidebar remove-project: delegate to the projects hook. Returns true
+ *  when no projectId is present (treat as handled rather than fall
+ *  through — there's no other handler that wants this event). */
+export const handleSidebarRemoveProject: EventRouteHandler = (
+  { component, eventType, data },
+  ctx,
+) => {
+  if (component.id !== "sidebar" || eventType !== "remove-project") {
+    return false;
+  }
+  const selected = data as
+    | { projectId?: string; itemId?: string }
+    | undefined;
+  const projectId = selected?.projectId ?? selected?.itemId;
+  return projectId ? ctx.removeProjectById(projectId) : true;
+};
+
+/** sidebar delete-session: prompt user, then delete via the Tauri
+ *  command. Delete-then-close ordering matters — the reverse leaves
+ *  the user with a closed tab and a failure notification when the
+ *  Tauri command refuses (e.g. the default session). */
+export const handleSidebarDeleteSession: EventRouteHandler = (
+  { component, eventType, data },
+  ctx,
+) => {
+  if (component.id !== "sidebar" || eventType !== "delete-session") {
+    return false;
+  }
+  const selected = data as
+    | { sessionId?: string; itemId?: string; label?: string }
+    | undefined;
+  // Strip the "session:" or "tab:" prefix defensively in case a future
+  // caller forgets the split — the sidebar already strips it but we
+  // don't want a stray prefix to land in the Tauri command path
+  // validator.
+  const raw = selected?.sessionId ?? selected?.itemId ?? "";
+  const sessionId = extractSessionId(raw);
+  const label = selected?.label ?? sessionId;
+  if (!sessionId) return true;
+  ctx.promptDeleteSessionConfirmation(label).then((allowed) => {
+    if (!allowed) return;
+    const isOpen = (ctx.stateRef.current.tabs as Tab[] | undefined)?.some(
+      (t) => t.id === sessionId,
+    );
+    ctx
+      .invoke("delete_session", { tabId: sessionId })
+      .then(() => {
+        if (isOpen) ctx.closeTab(sessionId);
+        ctx.allDiscoveredSessionsRef.current =
+          ctx.allDiscoveredSessionsRef.current.filter(
+            (s) => s.tabId !== sessionId,
+          );
+        ctx.syncRecentSessionsToState();
+        ctx.pushNotification({
+          title: "Session deleted",
+          message: label,
+          kind: "success",
+        });
+      })
+      .catch((err: unknown) => {
+        ctx.pushNotification({
+          title: "Delete session failed",
+          message: String(err),
+          kind: "error",
+        });
+      });
+  });
+  return true;
+};
+
+/** Sidebar select + dropdown chrome pickers (model-picker /
+ *  appearance-menu) all use the same `{sectionId, itemId}` event
+ *  shape. Route by section so a chrome dropdown and a sidebar row
+ *  converge on the same backing action. */
+export const handleSectionedSelect: EventRouteHandler = async (
+  { component, eventType, data },
+  ctx,
+) => {
+  const isSectionedSelect =
+    eventType === "select" &&
+    (component.id === "sidebar" ||
+      component.id === "model-picker" ||
+      component.id === "appearance-menu");
+  if (!isSectionedSelect) return false;
+
+  const selected = data as
+    | { sectionId?: string; itemId?: string }
+    | undefined;
+  if (selected?.itemId === "toggle-terminal") {
+    ctx.toggleTerminal();
+    return true;
+  }
+  if (selected?.itemId === "clear-chat") {
+    ctx.clearChat();
+    return true;
+  }
+  if (selected?.sectionId === "models" && selected.itemId) {
+    await ctx.setModel(selected.itemId);
+    return true;
+  }
+  if (selected?.sectionId === "themes" && selected.itemId) {
+    // Accept any registered theme id (built-ins + extension themes).
+    // Built-in CSS lives in styles.css; extension themes had their
+    // <style> tag injected on hydrateThemes().
+    ctx.setTheme(selected.itemId);
+    return true;
+  }
+  if (selected?.sectionId === "layouts" && selected.itemId) {
+    ctx.activateLayoutById(selected.itemId);
+    return true;
+  }
+  if (selected?.sectionId === "projects" && selected.itemId) {
+    // The sidebar's projects section also surfaces an "Open project…"
+    // action item; intercept it here so we don't try to look it up as
+    // a project id.
+    if (selected.itemId === "open-project") {
+      ctx.openProjectFromPicker();
+      return true;
+    }
+    ctx.setActiveProjectById(selected.itemId);
+    return true;
+  }
+  if (selected?.sectionId === "history" && selected.itemId) {
+    if (selected.itemId.startsWith("tab:")) {
+      ctx.setActiveTab(selected.itemId.slice(4));
+      return true;
+    }
+    if (selected.itemId.startsWith("session:")) {
+      const sessionId = selected.itemId.slice(8);
+      const recentSessions =
+        (ctx.stateRef.current.recentSessions as
+          | RecentSessionItem[]
+          | undefined) ?? [];
+      const item = recentSessions.find((s) => s.id === sessionId);
+      ctx.newTab(
+        sessionId,
+        item?.label ?? `Session ${sessionId.slice(0, 8)}`,
+        {
+          restoredSession: true,
+          ...(item?.cwd ? { cwd: item.cwd } : {}),
+        },
+      );
+      return true;
+    }
+    return true;
+  }
+  return false;
+};

--- a/src/eventRoutes/tabStrip.test.ts
+++ b/src/eventRoutes/tabStrip.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { handleTabStrip, handleEmptyState } from "./tabStrip";
+import { buildRouteFixture } from "./testFixtures";
+
+describe("handleTabStrip", () => {
+  it("select activates the chosen tab", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    const handled = await handleTabStrip(
+      {
+        component: { id: "header-tabs", type: "tab-strip" },
+        eventType: "select",
+        data: { tabId: "tab-3" },
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.setActiveTab).toHaveBeenCalledWith("tab-3");
+  });
+
+  it("close removes the chosen tab", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    await handleTabStrip(
+      {
+        component: { id: "header-tabs", type: "tab-strip" },
+        eventType: "close",
+        data: { tabId: "tab-4" },
+      },
+      ctx,
+    );
+    expect(mocks.closeTab).toHaveBeenCalledWith("tab-4");
+  });
+
+  it("new spawns a fresh tab", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    await handleTabStrip(
+      {
+        component: { id: "header-tabs", type: "tab-strip" },
+        eventType: "new",
+      },
+      ctx,
+    );
+    expect(mocks.newTab).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("handleEmptyState", () => {
+  it("new-tab spawns a tab", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    const handled = await handleEmptyState(
+      { component: { id: "empty-state" }, eventType: "new-tab" },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.newTab).toHaveBeenCalledTimes(1);
+  });
+
+  it("select-project switches and seeds a fresh tab when bucket is empty", async () => {
+    const { ctx, mocks } = buildRouteFixture({ state: { tabs: [] } });
+    await handleEmptyState(
+      {
+        component: { id: "empty-state" },
+        eventType: "select-project",
+        data: { projectId: "proj-1" },
+      },
+      ctx,
+    );
+    expect(mocks.setActiveProjectById).toHaveBeenCalledWith("proj-1");
+    expect(mocks.newTab).toHaveBeenCalledTimes(1);
+  });
+
+  it("restore-session reuses the sessionId as the new tabId", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    await handleEmptyState(
+      {
+        component: { id: "empty-state" },
+        eventType: "restore-session",
+        data: { sessionId: "sess-9", label: "old chat", cwd: "/repo" },
+      },
+      ctx,
+    );
+    expect(mocks.newTab).toHaveBeenCalledWith("sess-9", "old chat", {
+      restoredSession: true,
+      cwd: "/repo",
+    });
+  });
+});

--- a/src/eventRoutes/tabStrip.ts
+++ b/src/eventRoutes/tabStrip.ts
@@ -1,0 +1,86 @@
+import type { EventRouteHandler } from "./types";
+import type { Tab } from "../types/tab";
+
+/** tab-strip: select / close / new. Tab events route by component
+ *  *type* — id may vary across layouts (workstation hoists the strip
+ *  into the header as `header-tabs`). Matching by type keeps the
+ *  contract layout-agnostic so a future layout's tabs work without
+ *  touching the dispatcher. */
+export const handleTabStrip: EventRouteHandler = (
+  { component, eventType, data },
+  ctx,
+) => {
+  if (component.type !== "tab-strip") return false;
+  const sel = data as
+    | { tabId?: string; action?: string; id?: string }
+    | undefined;
+  if (eventType === "select" && sel?.tabId) {
+    ctx.setActiveTab(sel.tabId);
+    return true;
+  }
+  if (eventType === "close" && sel?.tabId) {
+    ctx.closeTab(sel.tabId);
+    return true;
+  }
+  if (eventType === "new") {
+    ctx.newTab();
+    return true;
+  }
+  return false;
+};
+
+/** empty-state CTA buttons: new-tab, open-project, select-project,
+ *  restore-session. Renders when the active project has no open tabs;
+ *  selection events here seed a fresh tab in the chosen project. */
+export const handleEmptyState: EventRouteHandler = (
+  { component, eventType, data },
+  ctx,
+) => {
+  if (component.id !== "empty-state") return false;
+  if (eventType === "new-tab") {
+    ctx.newTab();
+    return true;
+  }
+  if (eventType === "open-project") {
+    // Pop the native folder picker. On a successful pick we've already
+    // persisted + announced the new project — open a fresh tab in it
+    // so the user lands ready-to-chat. On cancel, leave empty state.
+    ctx.openProjectFromPicker().then((id) => {
+      if (id) ctx.newTab();
+    });
+    return true;
+  }
+  if (eventType === "select-project") {
+    const sel = data as
+      | { projectId?: string; label?: string; path?: string }
+      | undefined;
+    if (sel?.projectId) {
+      ctx.setActiveProjectById(sel.projectId);
+      // Only seed a fresh tab when the project's bucket is empty. If
+      // the user already has tabs in this project, the bucket load
+      // restored them — popping a new tab on top would be jarring.
+      const tabsAfter =
+        (ctx.stateRef.current.tabs as Tab[] | undefined) ?? [];
+      if (tabsAfter.length === 0) ctx.newTab();
+    }
+    return true;
+  }
+  if (eventType === "restore-session") {
+    const sel = data as
+      | { sessionId?: string; label?: string; cwd?: string }
+      | undefined;
+    if (sel?.sessionId) {
+      // Re-open the persisted session by reusing the same tabId. The
+      // bridge's SessionManager.continueRecent reads the existing JSONL
+      // files so the LLM history is restored too.
+      ctx.newTab(sel.sessionId, sel.label ?? "Restored Session", {
+        restoredSession: true,
+        ...(sel.cwd ? { cwd: sel.cwd } : {}),
+      });
+    } else {
+      ctx.newTab();
+    }
+    return true;
+  }
+  return false;
+};

--- a/src/eventRoutes/terminal.test.ts
+++ b/src/eventRoutes/terminal.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import { handleTerminalPanel, handleShareModeCycle } from "./terminal";
+import { buildRouteFixture } from "./testFixtures";
+import type { Tab } from "../types/tab";
+
+describe("handleTerminalPanel", () => {
+  it("select-sub-tab routes to setActiveSubTab", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    const handled = await handleTerminalPanel(
+      {
+        component: { id: "tp", type: "terminal-panel" },
+        eventType: "select-sub-tab",
+        data: { subTabId: "shell-1" },
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.setActiveSubTab).toHaveBeenCalledWith("shell-1");
+  });
+
+  it("close-sub-tab on a shell sub-tab closes that tab", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    await handleTerminalPanel(
+      {
+        component: { id: "tp", type: "terminal-panel" },
+        eventType: "close-sub-tab",
+        data: { subTabId: "shell-2" },
+      },
+      ctx,
+    );
+    expect(mocks.closeTab).toHaveBeenCalledWith("shell-2");
+  });
+
+  it("close-sub-tab on agent-bash is a no-op", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    const handled = await handleTerminalPanel(
+      {
+        component: { id: "tp", type: "terminal-panel" },
+        eventType: "close-sub-tab",
+        data: { subTabId: "agent-bash" },
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.closeTab).not.toHaveBeenCalled();
+  });
+
+  it("new-shell-sub-tab spawns a shell", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    await handleTerminalPanel(
+      {
+        component: { id: "tp", type: "terminal-panel" },
+        eventType: "new-shell-sub-tab",
+      },
+      ctx,
+    );
+    expect(mocks.newShellTab).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("handleShareModeCycle", () => {
+  function shellTab(id: string, mode: Tab["shell"]): Tab {
+    return {
+      id,
+      kind: "shell",
+      shell: mode,
+      label: id,
+      messages: [],
+      draft: "",
+    } as unknown as Tab;
+  }
+
+  it("cycles share mode and persists via shell_set_share_mode", async () => {
+    const tab = shellTab("shell-7", {
+      cwd: "/tmp",
+      command: "bash",
+      args: [],
+      shareMode: "private",
+      shellState: "running",
+    });
+    const { ctx, mocks } = buildRouteFixture({
+      state: { tabs: [tab] },
+    });
+    const handled = await handleShareModeCycle(
+      {
+        component: { id: "shell-canvas", type: "shell-canvas" },
+        eventType: "cycle-share-mode",
+        data: { tabId: "shell-7" },
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    // Cycle order: private → read.
+    expect(mocks.invoke).toHaveBeenCalledWith("shell_set_share_mode", {
+      tabId: "shell-7",
+      mode: "read",
+    });
+  });
+
+  it("returns false for the wrong eventType / componentType", async () => {
+    const { ctx } = buildRouteFixture();
+    const handled = await handleShareModeCycle(
+      {
+        component: { id: "shell-canvas", type: "shell-canvas" },
+        eventType: "click",
+        data: { tabId: "x" },
+      },
+      ctx,
+    );
+    expect(handled).toBe(false);
+  });
+
+  it("no-ops when tabId is missing", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    const handled = await handleShareModeCycle(
+      {
+        component: { id: "share-mode-badge", type: "share-mode-badge" },
+        eventType: "cycle-share-mode",
+        data: {},
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.invoke).not.toHaveBeenCalled();
+  });
+});

--- a/src/eventRoutes/terminal.ts
+++ b/src/eventRoutes/terminal.ts
@@ -1,0 +1,65 @@
+import type { EventRouteHandler } from "./types";
+import { cycleShareMode } from "../utils/shareMode";
+import type { Tab } from "../types/tab";
+
+/** terminal-panel: the bottom panel hosting the read-only agent-bash
+ *  sub-tab plus every shell as a sub-tab. Sub-tab select / close /
+ *  new-shell live here. The agent-bash sub-tab can't be closed (no X
+ *  button rendered), so a stray close request is a no-op. */
+export const handleTerminalPanel: EventRouteHandler = (
+  { component, eventType, data },
+  ctx,
+) => {
+  if (component.type !== "terminal-panel") return false;
+  const sel = data as { subTabId?: string } | undefined;
+  if (eventType === "select-sub-tab" && sel?.subTabId) {
+    ctx.setActiveSubTab(sel.subTabId);
+    return true;
+  }
+  if (eventType === "close-sub-tab" && sel?.subTabId) {
+    if (sel.subTabId !== "agent-bash") {
+      ctx.closeTab(sel.subTabId);
+    }
+    return true;
+  }
+  if (eventType === "new-shell-sub-tab") {
+    ctx.newShellTab();
+    return true;
+  }
+  return false;
+};
+
+/** Share-mode badge cycle. Match either source: the inline badge inside
+ *  ShellCanvas re-emits on the shell-canvas channel; a standalone
+ *  `<share-mode-badge>` placed directly in a custom layout emits on
+ *  its own component type. Persists through the Rust side AND mirrors
+ *  locally so the badge label refreshes immediately. */
+export const handleShareModeCycle: EventRouteHandler = (
+  { component, eventType, data },
+  ctx,
+) => {
+  if (
+    eventType !== "cycle-share-mode" ||
+    (component.type !== "shell-canvas" &&
+      component.type !== "share-mode-badge")
+  ) {
+    return false;
+  }
+  const sel = data as { tabId?: string } | undefined;
+  const id = sel?.tabId;
+  if (typeof id !== "string" || !id) return true;
+  const tabs = (ctx.stateRef.current.tabs as Tab[] | undefined) ?? [];
+  const tab = tabs.find((t) => t.id === id);
+  if (!tab || tab.kind !== "shell" || !tab.shell) return true;
+  const next = cycleShareMode(tab.shell.shareMode);
+  ctx
+    .invoke("shell_set_share_mode", { tabId: id, mode: next })
+    .then(() => {
+      ctx.applyShareModeToTab(id, next);
+    })
+    .catch((err: unknown) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn("shell_set_share_mode failed:", msg);
+    });
+  return true;
+};

--- a/src/eventRoutes/testFixtures.ts
+++ b/src/eventRoutes/testFixtures.ts
@@ -1,0 +1,241 @@
+/** Shared fixture for event-route tests. Builds an `EventRouteContext`
+ *  whose every method/ref is a `vi.fn()` or a mutable container the
+ *  test can introspect. Tests pass an optional override map to swap
+ *  individual fields with custom mocks. Mirrors the shape of
+ *  `bridgeMessageHandlers/testFixtures.ts` (#36). */
+import { vi, type Mock } from "vitest";
+import type { MutableRefObject } from "react";
+import type { EventRouteContext, DiscoveredSession } from "./types";
+
+const ref = <T,>(value: T): MutableRefObject<T> => ({ current: value });
+
+export interface FixtureOverrides {
+  state?: Record<string, unknown>;
+  extensionRoutes?: { componentId?: string; eventType?: string }[];
+  extensionRoutingMode?: "builtin" | "extension";
+  pendingShellWriteIds?: string[];
+  pendingShellCloseIds?: string[];
+  pendingSessionDeleteIds?: string[];
+  promptDeleteAllow?: boolean;
+}
+
+export interface RouteFixture {
+  ctx: EventRouteContext;
+  mocks: {
+    setState: Mock;
+    resolveShellWriteConsent: Mock;
+    resolveShellCloseConsent: Mock;
+    resolveSessionDeleteConsent: Mock;
+    promptDeleteSessionConfirmation: Mock;
+    pushNotification: Mock;
+    dismissNotification: Mock;
+    sendChat: Mock;
+    stopPrompt: Mock;
+    updateActiveTab: Mock;
+    newTab: Mock;
+    newShellTab: Mock;
+    closeTab: Mock;
+    setActiveTab: Mock;
+    setActiveSubTab: Mock;
+    applyShareModeToTab: Mock;
+    closeSettings: Mock;
+    applySettingsPatch: Mock;
+    saveSettings: Mock;
+    closeSessionSearch: Mock;
+    setSearchQuery: Mock;
+    setSearchScope: Mock;
+    openSearchHit: Mock;
+    closePalette: Mock;
+    runPaletteItem: Mock;
+    toggleTerminal: Mock;
+    clearChat: Mock;
+    setModel: Mock;
+    setTheme: Mock;
+    activateLayoutById: Mock;
+    openProjectFromPicker: Mock;
+    setActiveProjectById: Mock;
+    removeProjectById: Mock;
+    syncRecentSessionsToState: Mock;
+    invoke: Mock;
+    writeState: Mock;
+  };
+  /** Apply every queued setState reducer in order against the supplied
+   *  seed (or the current stateRef when omitted). */
+  applySetState: (seed?: Record<string, unknown>) => Record<string, unknown>;
+}
+
+export function buildRouteFixture(
+  overrides: FixtureOverrides = {},
+): RouteFixture {
+  const initialState = overrides.state ?? {};
+  const stateRef = ref<Record<string, unknown>>(initialState);
+
+  const setState = vi.fn((arg: unknown) => {
+    if (typeof arg === "function") {
+      stateRef.current = (arg as (
+        p: Record<string, unknown>,
+      ) => Record<string, unknown>)(stateRef.current);
+    } else {
+      stateRef.current = arg as Record<string, unknown>;
+    }
+  });
+
+  const pendingWrite = new Set(overrides.pendingShellWriteIds ?? []);
+  const pendingClose = new Set(overrides.pendingShellCloseIds ?? []);
+  const pendingDelete = new Set(overrides.pendingSessionDeleteIds ?? []);
+
+  const resolveShellWriteConsent = vi.fn((id: string, _allowed: boolean) => {
+    pendingWrite.delete(id);
+  });
+  const resolveShellCloseConsent = vi.fn((id: string, _allowed: boolean) => {
+    pendingClose.delete(id);
+  });
+  const resolveSessionDeleteConsent = vi.fn(
+    (id: string, _allowed: boolean) => {
+      pendingDelete.delete(id);
+    },
+  );
+  const promptDeleteSessionConfirmation = vi.fn(() =>
+    Promise.resolve(overrides.promptDeleteAllow ?? false),
+  );
+  const pushNotification = vi.fn();
+  const dismissNotification = vi.fn();
+  const sendChat = vi.fn(() => Promise.resolve());
+  const stopPrompt = vi.fn(() => Promise.resolve());
+  const updateActiveTab = vi.fn();
+  const newTab = vi.fn();
+  const newShellTab = vi.fn();
+  const closeTab = vi.fn();
+  const setActiveTab = vi.fn();
+  const setActiveSubTab = vi.fn();
+  const applyShareModeToTab = vi.fn();
+  const closeSettings = vi.fn();
+  const applySettingsPatch = vi.fn();
+  const saveSettings = vi.fn(() => Promise.resolve());
+  const closeSessionSearch = vi.fn();
+  const setSearchQuery = vi.fn();
+  const setSearchScope = vi.fn();
+  const openSearchHit = vi.fn();
+  const closePalette = vi.fn();
+  const runPaletteItem = vi.fn(() => Promise.resolve());
+  const toggleTerminal = vi.fn();
+  const clearChat = vi.fn();
+  const setModel = vi.fn(() => Promise.resolve());
+  const setTheme = vi.fn();
+  const activateLayoutById = vi.fn();
+  const openProjectFromPicker = vi.fn(() =>
+    Promise.resolve<string | null>(null),
+  );
+  const setActiveProjectById = vi.fn();
+  const removeProjectById = vi.fn(() => true);
+  const syncRecentSessionsToState = vi.fn();
+  const invoke = vi.fn(() => Promise.resolve(undefined));
+  const writeState = vi.fn(() => Promise.resolve(true));
+
+  const ctx: EventRouteContext = {
+    setState,
+    stateRef,
+    extensionEventRoutesRef: ref(overrides.extensionRoutes ?? []),
+    extensionEventRoutingModeRef: ref(
+      overrides.extensionRoutingMode ?? "builtin",
+    ),
+    allDiscoveredSessionsRef: ref<DiscoveredSession[]>([]),
+    hasPendingShellWriteConsent: (id: string) => pendingWrite.has(id),
+    resolveShellWriteConsent,
+    hasPendingShellCloseConsent: (id: string) => pendingClose.has(id),
+    resolveShellCloseConsent,
+    hasPendingSessionDeleteConsent: (id: string) => pendingDelete.has(id),
+    resolveSessionDeleteConsent,
+    promptDeleteSessionConfirmation,
+    pushNotification,
+    dismissNotification,
+    sendChat,
+    stopPrompt,
+    updateActiveTab,
+    newTab,
+    newShellTab,
+    closeTab,
+    setActiveTab,
+    setActiveSubTab,
+    applyShareModeToTab,
+    closeSettings,
+    applySettingsPatch,
+    saveSettings,
+    closeSessionSearch,
+    setSearchQuery,
+    setSearchScope,
+    openSearchHit,
+    closePalette,
+    runPaletteItem,
+    toggleTerminal,
+    clearChat,
+    setModel,
+    setTheme,
+    activateLayoutById,
+    openProjectFromPicker,
+    setActiveProjectById,
+    removeProjectById,
+    syncRecentSessionsToState,
+    invoke,
+    writeState,
+  };
+
+  const applySetState = (seed?: Record<string, unknown>) => {
+    if (seed === undefined) return stateRef.current;
+    let cur = { ...seed };
+    for (const call of setState.mock.calls) {
+      const arg = call[0];
+      if (typeof arg === "function") {
+        cur = (arg as (
+          p: Record<string, unknown>,
+        ) => Record<string, unknown>)(cur);
+      } else {
+        cur = arg as Record<string, unknown>;
+      }
+    }
+    return cur;
+  };
+
+  return {
+    ctx,
+    mocks: {
+      setState,
+      resolveShellWriteConsent,
+      resolveShellCloseConsent,
+      resolveSessionDeleteConsent,
+      promptDeleteSessionConfirmation,
+      pushNotification,
+      dismissNotification,
+      sendChat,
+      stopPrompt,
+      updateActiveTab,
+      newTab,
+      newShellTab,
+      closeTab,
+      setActiveTab,
+      setActiveSubTab,
+      applyShareModeToTab,
+      closeSettings,
+      applySettingsPatch,
+      saveSettings,
+      closeSessionSearch,
+      setSearchQuery,
+      setSearchScope,
+      openSearchHit,
+      closePalette,
+      runPaletteItem,
+      toggleTerminal,
+      clearChat,
+      setModel,
+      setTheme,
+      activateLayoutById,
+      openProjectFromPicker,
+      setActiveProjectById,
+      removeProjectById,
+      syncRecentSessionsToState,
+      invoke,
+      writeState,
+    },
+    applySetState,
+  };
+}

--- a/src/eventRoutes/types.ts
+++ b/src/eventRoutes/types.ts
@@ -1,0 +1,129 @@
+import type {
+  Dispatch,
+  MutableRefObject,
+  SetStateAction,
+} from "react";
+import type { Tab } from "../types/tab";
+import type { ShareMode } from "../utils/shareMode";
+import type {
+  NotificationEntry,
+  NotificationKind,
+} from "../skills/default-layout/notifications";
+import type { PaletteItem } from "../skills/default-layout/palette-items";
+
+/** A renderer-side event from `<A2UIRenderer onEvent>`. The renderer
+ *  calls `onEvent({id, type}, eventType, data)`; we package the trio
+ *  here so handlers can pattern-match on a single argument. */
+export interface EventRouteEvent {
+  component: { id: string; type?: string };
+  eventType: string;
+  data?: unknown;
+}
+
+/** Tracks pending session/project listings the dispatcher needs to
+ *  drive sidebar history mutations. */
+export interface DiscoveredSession {
+  tabId: string;
+  lastModified: number;
+  cwd?: string;
+  firstUserMessage?: string;
+}
+
+/** Everything a route handler may close over. Flat by design — every
+ *  handler imports the same context, so adding a new handler doesn't
+ *  require a context-shape decision. Mirrors the BridgeMessageContext
+ *  pattern from #36. */
+export interface EventRouteContext {
+  // ─── React state setters ─────────────────────────────────────────────
+  setState: Dispatch<SetStateAction<Record<string, unknown>>>;
+
+  // ─── Live refs ──────────────────────────────────────────────────────
+  stateRef: MutableRefObject<Record<string, unknown>>;
+  extensionEventRoutesRef: MutableRefObject<
+    { componentId?: string; eventType?: string }[]
+  >;
+  extensionEventRoutingModeRef: MutableRefObject<"builtin" | "extension">;
+  allDiscoveredSessionsRef: MutableRefObject<DiscoveredSession[]>;
+
+  // ─── Shell-consent gates (from useShellConsent) ─────────────────────
+  hasPendingShellWriteConsent: (id: string) => boolean;
+  resolveShellWriteConsent: (id: string, allowed: boolean) => void;
+  hasPendingShellCloseConsent: (id: string) => boolean;
+  resolveShellCloseConsent: (id: string, allowed: boolean) => void;
+  hasPendingSessionDeleteConsent: (id: string) => boolean;
+  resolveSessionDeleteConsent: (id: string, allowed: boolean) => void;
+  promptDeleteSessionConfirmation: (label: string) => Promise<boolean>;
+
+  // ─── Notifications ──────────────────────────────────────────────────
+  pushNotification: (input: {
+    id?: string;
+    title: string;
+    message?: string;
+    kind?: NotificationKind;
+    durationMs?: number | null;
+    actions?: NotificationEntry["actions"];
+  }) => void;
+  dismissNotification: (id: string) => void;
+
+  // ─── Chat / prompt ──────────────────────────────────────────────────
+  sendChat: (text: string) => Promise<void>;
+  stopPrompt: (explicitTabId?: string) => Promise<void>;
+  updateActiveTab: (updater: (tab: Tab) => Tab) => void;
+
+  // ─── Tab / shell actions (from useTabs) ─────────────────────────────
+  newTab: (
+    tabId?: string,
+    label?: string,
+    options?: {
+      restoredSession?: boolean;
+      cwd?: string;
+      scrollToMatch?: string;
+    },
+  ) => void;
+  newShellTab: () => void;
+  closeTab: (tabId: string) => void;
+  setActiveTab: (tabId: string) => void;
+  setActiveSubTab: (subId: string) => void;
+  applyShareModeToTab: (tabId: string, mode: ShareMode) => void;
+
+  // ─── Settings panel ─────────────────────────────────────────────────
+  closeSettings: () => void;
+  applySettingsPatch: (patch: Record<string, unknown>) => void;
+  saveSettings: () => Promise<void>;
+
+  // ─── Search panel ───────────────────────────────────────────────────
+  closeSessionSearch: () => void;
+  setSearchQuery: (value: string) => void;
+  setSearchScope: (scope: "all" | "current") => void;
+  openSearchHit: (hit: { tabId?: string; snippetMatch?: string }) => void;
+
+  // ─── Command palette ────────────────────────────────────────────────
+  closePalette: () => void;
+  runPaletteItem: (item: PaletteItem) => Promise<void>;
+
+  // ─── Sidebar / chrome / projects ────────────────────────────────────
+  toggleTerminal: () => void;
+  clearChat: () => void;
+  setModel: (id: string) => Promise<void>;
+  setTheme: (id: string) => void;
+  activateLayoutById: (id: string) => void;
+  openProjectFromPicker: () => Promise<string | null>;
+  setActiveProjectById: (id: string) => void;
+  removeProjectById: (id: string) => boolean;
+  syncRecentSessionsToState: () => void;
+
+  // ─── Tauri IPC (injected so tests can mock it) ─────────────────────
+  invoke: (cmd: string, args?: Record<string, unknown>) => Promise<unknown>;
+  /** Persist key/value to disk via the Tauri state command. Returns
+   *  `true` on success; the dispatcher's callers ignore the boolean
+   *  (best-effort write). */
+  writeState: (name: string, content: string) => Promise<boolean>;
+}
+
+/** A single route handler. Returns `true` when it has handled the
+ *  event (renderer should suppress its default forward); `false` if it
+ *  did not match (dispatcher tries the next route). */
+export type EventRouteHandler = (
+  event: EventRouteEvent,
+  ctx: EventRouteContext,
+) => boolean | Promise<boolean>;


### PR DESCRIPTION
## Summary

Closes #37. Move the ~600-line `onEvent` useMemo from `App.tsx` into `src/eventRoutes/`, a route table dispatched via three precedence layers:

1. **Shell-consent reserved prefixes** (`shell-write-`, `shell-close-`, `session-delete-`) — security boundary; consent runs before any extension matcher.
2. **Extension event-routes** — when matched, returns `false` so the renderer forwards to the bridge and the extension's `aethon.onEvent` handler runs (built-ins are skipped).
3. **Built-in routes** — keyed by `id:<componentId>` and `type:<componentType>` in a `Map`, looked up per dispatch.

Per-route files: `chatInput.ts`, `tabStrip.ts`, `sidebar.ts`, `palette.ts`, `notifications.ts` (with `shellConsent.ts` co-located as the top-precedence gate), `settings.ts`, `search.ts`, `terminal.ts`, `extensions.ts`. `App.tsx`'s `onEvent` collapses to a thin `(event) => dispatchEvent(event, ctx)` over a memoized `EventRouteContext`.

`App.tsx` -598 / +69 lines.

## Tests

- 11 per-route happy-path vitests (66 new test cases) using a shared `testFixtures.ts` mirroring the `bridgeMessageHandlers` pattern from #36.
- `index.test.ts` — precedence contract test that pins the three-layer ordering so future edits can't silently let an extension hijack a shell-write consent prompt or shadow a built-in surface.
- All 432 vitests + 74 Rust tests pass under `check`.

## Verification

Verified live via aethon-debug:
- chat-input `change` writes both `/draft` (optimistic) and `tab.draft` (via `updateActiveTab`).
- `Cmd+P` opens palette; typing into the palette input writes `/palette/query` and resets `selectedIndex`.
- `Esc` closes palette through `handlePalette`.
- Notification dismiss via X click drops count 2 → 1.
- `Cmd+,` opens settings; clicking Cancel routes through `handleSettings`.
- `Cmd+T` x3 grows tabs 1 → 3; clicking the X on a tab drops 3 → 2.
- `setActiveProject` switches project (sidebar dispatcher path).

## Test plan

- [x] `bunx tsc -b --noEmit` clean
- [x] `bunx eslint .` clean (0/0)
- [x] `bunx vitest run` (432 passed, 74 new)
- [x] `cargo test --lib` (74 passed)
- [x] aethon-debug end-to-end: chat-input change, palette open/query/close, settings open/close, notification dismiss, tab create/close, project switch
- [ ] codex peer review