### PR TITLE
Extension resilience: graceful failure, right-click toggle, session rename

### DIFF
--- a/agent/aethon-api.ts
+++ b/agent/aethon-api.ts
@@ -42,7 +42,12 @@ import {
   setLayout,
   unregisterLayout,
 } from "./layout-manager";
-import { makeCanvasApi, setState } from "./state-mutation";
+import {
+  EXT_STATE_LOG_WINDOW_MS,
+  makeCanvasApi,
+  setState,
+} from "./state-mutation";
+import { makeExtStateLogLimiter } from "./state-limits";
 import { normalizeTheme, RESERVED_THEME_IDS } from "./extension-loader";
 import type { CanvasApi } from "./canvas";
 import type { RuntimeSnapshot } from "./system-prompt";
@@ -141,7 +146,15 @@ export function buildAethonApi(
   state: AethonAgentState,
   deps: AethonApiDeps,
 ): AethonApi {
-  const stateMutationDeps = { send: deps.send };
+  // One shared rate limiter for setState size-guard logging + the
+  // `extension_runtime_error` notice. Without sharing, every setState
+  // call would spin up a fresh limiter that always logs the first
+  // invocation — defeating dedup and re-popping the "extension is
+  // misbehaving" toast on every rejected write.
+  const stateMutationDeps = {
+    send: deps.send,
+    extStateLogLimiter: makeExtStateLogLimiter(EXT_STATE_LOG_WINDOW_MS),
+  };
   const layoutDeps = {
     send: deps.send,
     scheduleStateFileWrite: deps.scheduleStateFileWrite,

--- a/agent/aethon-api.ts
+++ b/agent/aethon-api.ts
@@ -69,6 +69,8 @@ const BUILTIN_SLASH_NAMES = new Set([
   "theme",
   "model",
   "reset",
+  "reload",
+  "rename",
   "terminal",
   "extensions",
   "sidebar",

--- a/agent/disabled-extensions.test.ts
+++ b/agent/disabled-extensions.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  disabledExtensionsFile,
+  loadDisabledExtensions,
+  saveDisabledExtensions,
+} from "./disabled-extensions";
+
+describe("disabled-extensions persistence", () => {
+  it("loads an empty set when the file is missing", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "aethon-dis-"));
+    try {
+      const set = await loadDisabledExtensions(dir);
+      expect(set.size).toBe(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("round-trips through save + load", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "aethon-dis-"));
+    try {
+      await saveDisabledExtensions(dir, new Set(["b-ext", "a-ext"]));
+      // Sorted on disk so the file is stable across writes.
+      const text = readFileSync(disabledExtensionsFile(dir), "utf8");
+      expect(JSON.parse(text)).toEqual({ disabled: ["a-ext", "b-ext"] });
+      const loaded = await loadDisabledExtensions(dir);
+      expect([...loaded].sort()).toEqual(["a-ext", "b-ext"]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores malformed JSON gracefully", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "aethon-dis-"));
+    try {
+      // Write garbage.
+      const file = disabledExtensionsFile(dir);
+      const fs = await import("node:fs/promises");
+      await fs.writeFile(file, "{not json", "utf8");
+      const set = await loadDisabledExtensions(dir);
+      expect(set.size).toBe(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/agent/disabled-extensions.test.ts
+++ b/agent/disabled-extensions.test.ts
@@ -33,6 +33,23 @@ describe("disabled-extensions persistence", () => {
     }
   });
 
+  it("throws when the destination is unwritable so the caller can revert", async () => {
+    // Point at a path that can't be created — a regular file used as
+    // the parent dir. mkdir(file/...) errors with ENOTDIR, which we
+    // want to propagate so the dispatcher refuses the toggle.
+    const dir = mkdtempSync(join(tmpdir(), "aethon-dis-"));
+    try {
+      const fs = await import("node:fs/promises");
+      const sentinelFile = join(dir, "not-a-dir");
+      await fs.writeFile(sentinelFile, "i am a file", "utf8");
+      await expect(
+        saveDisabledExtensions(sentinelFile, new Set(["x"])),
+      ).rejects.toThrow();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("ignores malformed JSON gracefully", async () => {
     const dir = mkdtempSync(join(tmpdir(), "aethon-dis-"));
     try {

--- a/agent/disabled-extensions.ts
+++ b/agent/disabled-extensions.ts
@@ -1,0 +1,62 @@
+/**
+ * Persistence for the user's "disabled extensions" list.
+ *
+ * One JSON file at `<userDir>/disabled-extensions.json` with the shape
+ * `{ "disabled": ["name1", "name2"] }`. Loaded on bridge boot, rewritten
+ * whenever the user toggles an extension via the sidebar context menu.
+ *
+ * The set lives on `state.disabledExtensions` and is consulted by the
+ * loader (`extension-loader.ts`) to skip imports.
+ */
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { logger } from "./logger";
+
+const FILE_NAME = "disabled-extensions.json";
+
+export function disabledExtensionsFile(userDir: string): string {
+  return join(userDir, FILE_NAME);
+}
+
+export async function loadDisabledExtensions(
+  userDir: string,
+): Promise<Set<string>> {
+  const file = disabledExtensionsFile(userDir);
+  try {
+    const text = await readFile(file, "utf8");
+    const parsed = JSON.parse(text) as { disabled?: unknown };
+    if (!parsed || !Array.isArray(parsed.disabled)) return new Set();
+    const out = new Set<string>();
+    for (const v of parsed.disabled) {
+      if (typeof v === "string" && v.length > 0) out.add(v);
+    }
+    return out;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return new Set();
+    logger
+      .scope("disabled-ext")
+      .warn(`read ${file}: ${(err as Error).message}`);
+    return new Set();
+  }
+}
+
+export async function saveDisabledExtensions(
+  userDir: string,
+  disabled: Set<string>,
+): Promise<void> {
+  const file = disabledExtensionsFile(userDir);
+  const payload = JSON.stringify(
+    { disabled: [...disabled].sort() },
+    null,
+    2,
+  );
+  try {
+    await mkdir(dirname(file), { recursive: true });
+    await writeFile(file, payload + "\n", "utf8");
+  } catch (err) {
+    logger
+      .scope("disabled-ext")
+      .warn(`write ${file}: ${(err as Error).message}`);
+  }
+}

--- a/agent/disabled-extensions.ts
+++ b/agent/disabled-extensions.ts
@@ -41,6 +41,11 @@ export async function loadDisabledExtensions(
   }
 }
 
+/** Persist the disabled list. Throws on failure so the caller can
+ *  refuse the toggle (revert in-memory, surface an error) instead of
+ *  silently losing the user's intent — a swallowed write means a
+ *  successful-looking toast followed by a bridge reload that re-loads
+ *  the extension because the on-disk file still says "enabled". */
 export async function saveDisabledExtensions(
   userDir: string,
   disabled: Set<string>,
@@ -58,5 +63,6 @@ export async function saveDisabledExtensions(
     logger
       .scope("disabled-ext")
       .warn(`write ${file}: ${(err as Error).message}`);
+    throw err;
   }
 }

--- a/agent/dispatcher.ts
+++ b/agent/dispatcher.ts
@@ -731,7 +731,29 @@ export async function runDispatcher(
     if (disabled === wasDisabled) return; // no-op
     if (disabled) state.disabledExtensions.add(name);
     else state.disabledExtensions.delete(name);
-    await saveDisabledExtensions(state.userDir, state.disabledExtensions);
+    try {
+      await saveDisabledExtensions(state.userDir, state.disabledExtensions);
+    } catch (err) {
+      // Persistence failed — revert the in-memory toggle so the next
+      // operation sees the on-disk truth, and surface a notice instead
+      // of a misleading success toast + bridge reload that would
+      // re-load the extension and silently lose the user's intent.
+      if (disabled) state.disabledExtensions.delete(name);
+      else state.disabledExtensions.add(name);
+      const message = err instanceof Error ? err.message : String(err);
+      deps.send({
+        type: "error",
+        message: `set_extension_disabled: persist failed: ${message}`,
+      });
+      void notify(state, notifDeps, {
+        id: `aethon:extension-toggle:${name}`,
+        title: `Could not ${disabled ? "disable" : "enable"} \`${name}\``,
+        message: `Persist failed: ${message}`,
+        kind: "error",
+        durationMs: 6000,
+      });
+      return;
+    }
     // Surface the change to the frontend immediately. The loaded set
     // doesn't change until restart; the sidebar shows a `(disabled)` row
     // by deriving from `loadedExtensions ∩ ¬disabledExtensions` plus the

--- a/agent/dispatcher.ts
+++ b/agent/dispatcher.ts
@@ -131,6 +131,7 @@ export function unloadProjectExtensions(
     if (info.source === "project-directory") state.loadFailures.delete(name);
   }
   state.loadedProjectExtensionFiles.clear();
+  state.failedProjectExtensionFiles.clear();
 
   state.extensionComponents.clear();
   for (const [k, v] of state.projectBaseline.components) {
@@ -542,6 +543,7 @@ export async function runDispatcher(
         extensionApi,
         state.loadedExtensions,
         state.loadedProjectExtensionFiles,
+        state.failedProjectExtensionFiles,
         deps.loadHooks,
       );
       state.currentProjectCwd = cwdOverride;
@@ -630,6 +632,7 @@ export async function runDispatcher(
       extensionApi,
       state.loadedExtensions,
       state.loadedProjectExtensionFiles,
+      state.failedProjectExtensionFiles,
       deps.loadHooks,
     );
     if (loadingNoticeTimer !== null) {

--- a/agent/dispatcher.ts
+++ b/agent/dispatcher.ts
@@ -43,6 +43,7 @@ import {
 } from "./extension-loader";
 import { patchLayoutTree } from "./layout-manager";
 import { readSessionTranscript } from "./session-history";
+import { saveDisabledExtensions } from "./disabled-extensions";
 
 export interface DispatcherDeps {
   send: (obj: Record<string, unknown>) => void;
@@ -386,6 +387,10 @@ export async function runDispatcher(
           state.bootLayout = msg.payload;
           break;
         }
+        case "set_extension_disabled": {
+          await handleSetExtensionDisabled(state, deps, notifDeps, msg);
+          break;
+        }
         default: {
           deps.send({
             type: "error",
@@ -690,6 +695,70 @@ export async function runDispatcher(
       state.currentAgentTabId = undefined;
     }
     deps.send({ type: "tab_closed", tabId });
+  }
+
+  async function handleSetExtensionDisabled(
+    state: AethonAgentState,
+    deps: DispatcherDeps,
+    notifDeps: { send: (m: Record<string, unknown>) => void },
+    msg: InboundMessage,
+  ): Promise<void> {
+    const name = (msg as { name?: unknown }).name;
+    const disabled = (msg as { disabled?: unknown }).disabled;
+    if (typeof name !== "string" || !name) {
+      deps.send({
+        type: "error",
+        message: "set_extension_disabled: name required",
+      });
+      return;
+    }
+    if (typeof disabled !== "boolean") {
+      deps.send({
+        type: "error",
+        message: "set_extension_disabled: disabled must be boolean",
+      });
+      return;
+    }
+    const wasDisabled = state.disabledExtensions.has(name);
+    if (disabled === wasDisabled) return; // no-op
+    if (disabled) state.disabledExtensions.add(name);
+    else state.disabledExtensions.delete(name);
+    await saveDisabledExtensions(state.userDir, state.disabledExtensions);
+    // Surface the change to the frontend immediately. The loaded set
+    // doesn't change until restart; the sidebar shows a `(disabled)` row
+    // by deriving from `loadedExtensions ∩ ¬disabledExtensions` plus the
+    // explicit disabled list. We re-emit the lifecycle event so the
+    // hydration handler can move the row to the right bucket.
+    deps.send({
+      type: "extension_lifecycle",
+      name,
+      source: "directory",
+      status: disabled ? "disabled" : "enabled",
+    });
+    // Notify the user before signalling the bridge restart so the toast
+    // is rendered before agent-reloaded clears the in-flight UI state.
+    void notify(state, notifDeps, {
+      id: `aethon:extension-toggle:${name}`,
+      title: disabled
+        ? `Disabled \`${name}\``
+        : `Enabled \`${name}\``,
+      message: disabled
+        ? "Reloading bridge to fully unload…"
+        : "Reloading bridge to load…",
+      kind: "info",
+      durationMs: 4000,
+    });
+    // Ask the frontend to force-restart the bridge. We can't restart
+    // ourselves from inside the bridge (the Tauri shell owns the child
+    // and needs to flip its `agent_reload_in_progress` flag so the
+    // supervisor emits `agent-reloaded` instead of `agent-crashed`).
+    // The frontend's reload-required handler invokes `force_restart_agent`
+    // — on respawn, the new bridge reads disabled-extensions.json on boot
+    // and the loader honors it.
+    deps.send({
+      type: "reload_required",
+      reason: `extension-toggle:${name}`,
+    });
   }
 
   async function handleA2UIEvent(

--- a/agent/dispatcher.ts
+++ b/agent/dispatcher.ts
@@ -42,7 +42,11 @@ import {
   loadProjectAethonExtensions,
 } from "./extension-loader";
 import { patchLayoutTree } from "./layout-manager";
-import { readSessionTranscript } from "./session-history";
+import {
+  readSessionMetadata,
+  readSessionTranscript,
+  writeSessionLabel,
+} from "./session-history";
 import { saveDisabledExtensions } from "./disabled-extensions";
 
 export interface DispatcherDeps {
@@ -389,6 +393,10 @@ export async function runDispatcher(
         }
         case "set_extension_disabled": {
           await handleSetExtensionDisabled(state, deps, notifDeps, msg);
+          break;
+        }
+        case "set_session_label": {
+          await handleSetSessionLabel(state, deps, msg);
           break;
         }
         default: {
@@ -759,6 +767,43 @@ export async function runDispatcher(
       type: "reload_required",
       reason: `extension-toggle:${name}`,
     });
+  }
+
+  async function handleSetSessionLabel(
+    state: AethonAgentState,
+    deps: DispatcherDeps,
+    msg: InboundMessage,
+  ): Promise<void> {
+    const tabId = (msg as { tabId?: unknown }).tabId;
+    const labelField = (msg as { label?: unknown }).label;
+    if (typeof tabId !== "string" || !tabId) {
+      deps.send({
+        type: "error",
+        message: "set_session_label: tabId required",
+      });
+      return;
+    }
+    const label = typeof labelField === "string" ? labelField : "";
+    try {
+      await writeSessionLabel(tabSessionDir(state, tabId), label);
+    } catch (err) {
+      deps.send({
+        type: "error",
+        message: `set_session_label: ${(err as Error).message}`,
+      });
+      return;
+    }
+    // Refresh the discovered-tabs cache so the next emitReady (which the
+    // frontend triggers by sending `report` after this command finishes)
+    // reflects the new label. Cheap to re-read just the one entry.
+    const refreshed = await readSessionMetadata(tabSessionDir(state, tabId));
+    if (refreshed) {
+      const idx = state.discoveredTabs.findIndex((t) => t.tabId === tabId);
+      const entry = { tabId, ...refreshed };
+      if (idx >= 0) state.discoveredTabs[idx] = entry;
+      else state.discoveredTabs.push(entry);
+    }
+    emitReady(state, deps);
   }
 
   async function handleA2UIEvent(

--- a/agent/extension-loader.test.ts
+++ b/agent/extension-loader.test.ts
@@ -11,6 +11,7 @@ import {
 import {
   RESERVED_THEME_IDS,
   discoverPersistedTabs,
+  loadAethonExtensionDirectory,
   loadAethonExtensions,
   normalizeTheme,
   projectExtensionDisplayName,
@@ -144,12 +145,12 @@ describe("loadAethonExtensions", () => {
       );
       const f = makeFixture(root);
       let seen: { type: string; template: unknown } | null = null;
-      const api: AethonExtensionApi = {
-        registerComponent(componentType, template) {
+      const api = {
+        registerComponent(componentType: string, template: unknown) {
           seen = { type: componentType, template };
         },
         setState() {},
-      };
+      } as unknown as AethonExtensionApi;
       const registry = new Map<string, ExtensionSource>();
       await loadAethonExtensions(f.state, f.deps, api, registry);
       expect(seen).toEqual({ type: "hello", template: { type: "card" } });
@@ -170,10 +171,10 @@ describe("loadAethonExtensions", () => {
       mkdirSync(extDir, { recursive: true });
       writeFileSync(join(extDir, "noop.mjs"), `export const x = 1;`);
       const f = makeFixture(root);
-      const api: AethonExtensionApi = {
+      const api = {
         registerComponent() {},
         setState() {},
-      };
+      } as unknown as AethonExtensionApi;
       const registry = new Map<string, ExtensionSource>();
       const failures: { name: string; status: string }[] = [];
       await loadAethonExtensions(f.state, f.deps, api, registry, {
@@ -201,18 +202,61 @@ describe("loadAethonExtensions", () => {
       );
       const f = makeFixture(root);
       let observedDuringRegister: string | null = "<unset>";
-      const api: AethonExtensionApi = {
+      const api = {
         registerComponent() {
           observedDuringRegister = f.state.currentExtensionName;
         },
         setState() {},
-      };
+      } as unknown as AethonExtensionApi;
       const registry = new Map<string, ExtensionSource>();
       await loadAethonExtensions(f.state, f.deps, api, registry);
       // While register() ran, currentExtensionName was the displayName.
       expect(observedDuringRegister).toMatch(/^stamp-/);
       // After load, it's restored to null.
       expect(f.state.currentExtensionName).toBeNull();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not retry a failed extension file on the next load pass", async () => {
+    const root = mkdtempSync(join(tmpdir(), "aethon-ext-"));
+    try {
+      const extDir = join(root, "extensions");
+      mkdirSync(extDir, { recursive: true });
+      // Throws synchronously inside register() — counts as a "failed" load.
+      writeFileSync(
+        join(extDir, "boom.mjs"),
+        `export function register() { throw new Error("boom"); }`,
+      );
+      const f = makeFixture(root);
+      const api = {
+        registerComponent() {},
+        setState() {},
+      } as unknown as AethonExtensionApi;
+      const registry = new Map<string, ExtensionSource>();
+      const loadedFiles = new Set<string>();
+      const failedFiles = new Set<string>();
+      const opts = {
+        dir: extDir,
+        source: "project-directory" as const,
+        logPrefix: "test",
+        loadedFiles,
+        failedFiles,
+      };
+      await loadAethonExtensionDirectory(f.state, f.deps, api, registry, opts);
+      const failuresAfterFirst = f.sent.filter(
+        (m) => m.type === "extension_lifecycle" && m.status === "failed",
+      ).length;
+      expect(failuresAfterFirst).toBe(1);
+      expect(failedFiles.size).toBe(1);
+      // Second pass: file is in failedFiles, so it's skipped — no new
+      // extension_lifecycle event, no log spam.
+      await loadAethonExtensionDirectory(f.state, f.deps, api, registry, opts);
+      const failuresAfterSecond = f.sent.filter(
+        (m) => m.type === "extension_lifecycle" && m.status === "failed",
+      ).length;
+      expect(failuresAfterSecond).toBe(1);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/agent/extension-loader.test.ts
+++ b/agent/extension-loader.test.ts
@@ -219,6 +219,33 @@ describe("loadAethonExtensions", () => {
     }
   });
 
+  it("skips disabled extensions and emits a `disabled` lifecycle event", async () => {
+    const root = mkdtempSync(join(tmpdir(), "aethon-ext-"));
+    try {
+      const extDir = join(root, "extensions");
+      mkdirSync(extDir, { recursive: true });
+      writeFileSync(
+        join(extDir, "muted.mjs"),
+        `export function register(api) { api.registerComponent("muted", null); }`,
+      );
+      const f = makeFixture(root);
+      f.state.disabledExtensions.add("muted");
+      const api = {
+        registerComponent() {},
+        setState() {},
+      } as unknown as AethonExtensionApi;
+      const registry = new Map<string, ExtensionSource>();
+      await loadAethonExtensions(f.state, f.deps, api, registry);
+      expect(registry.size).toBe(0);
+      const lifecycle = f.sent.find(
+        (m) => m.type === "extension_lifecycle" && m.status === "disabled",
+      );
+      expect(lifecycle).toMatchObject({ name: "muted", status: "disabled" });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("does not retry a failed extension file on the next load pass", async () => {
     const root = mkdtempSync(join(tmpdir(), "aethon-ext-"));
     try {

--- a/agent/extension-loader.ts
+++ b/agent/extension-loader.ts
@@ -138,7 +138,7 @@ export async function loadAethonExtensionDirectory(
   // Parallelize import; keep register() sequential so registrations against
   // shared maps (handler dedupe, theme/component registries) stay
   // deterministic.
-  const candidates = entries
+  const allCandidates = entries
     .filter((name) => /\.(ts|js|mjs)$/.test(name))
     .map((name) => ({
       name,
@@ -151,6 +151,27 @@ export async function loadAethonExtensionDirectory(
         !options.loadedFiles?.has(c.file) &&
         !options.failedFiles?.has(c.file),
     );
+
+  // Honor the user's "disabled" list: emit a `disabled` lifecycle event
+  // (so the sidebar can surface the row + the failure registry knows
+  // the extension is intentionally not loaded) and skip the import.
+  // Don't add to failedFiles — the user can re-enable, at which point
+  // we want a fresh load attempt.
+  const candidates: typeof allCandidates = [];
+  for (const c of allCandidates) {
+    if (state.disabledExtensions.has(c.displayName)) {
+      log.info(`${c.name}: disabled by user, skipping`);
+      deps.send({
+        type: "extension_lifecycle",
+        name: c.displayName,
+        source: options.source,
+        status: "disabled",
+        path: c.file,
+      });
+      continue;
+    }
+    candidates.push(c);
+  }
 
   const imports = await Promise.allSettled(
     candidates.map(
@@ -378,6 +399,17 @@ export async function loadAethonExtensionPackages(
     }
   }
   for (const c of candidates) {
+    if (state.disabledExtensions.has(c.name)) {
+      logger.scope("ext-package").info(`${c.name}: disabled by user, skipping`);
+      deps.send({
+        type: "extension_lifecycle",
+        name: c.name,
+        source: "extension-package",
+        status: "disabled",
+        path: c.dir,
+      });
+      continue;
+    }
     const entry = c.manifest.aethon?.entry;
     if (typeof entry !== "string" || entry.length === 0) {
       logger.scope("ext-package").warn(`${c.name}: aethon.entry not set, skipping`);

--- a/agent/extension-loader.ts
+++ b/agent/extension-loader.ts
@@ -104,6 +104,10 @@ interface LoadDirectoryOptions {
   logPrefix: string;
   displayName?: (fileName: string) => string;
   loadedFiles?: Set<string>;
+  /** Files we previously tried to import that errored. Skipped on retry
+   *  to keep the warn-loop quiet; the failure is already in
+   *  `state.loadFailures` and surfaced via `extension_lifecycle`. */
+  failedFiles?: Set<string>;
   onLoaded?: (name: string) => void;
   onFailure?: (failure: {
     name: string;
@@ -142,7 +146,11 @@ export async function loadAethonExtensionDirectory(
       displayName:
         options.displayName?.(name) ?? name.replace(/\.(ts|js|mjs)$/, ""),
     }))
-    .filter((c) => !options.loadedFiles?.has(c.file));
+    .filter(
+      (c) =>
+        !options.loadedFiles?.has(c.file) &&
+        !options.failedFiles?.has(c.file),
+    );
 
   const imports = await Promise.allSettled(
     candidates.map(
@@ -164,6 +172,7 @@ export async function loadAethonExtensionDirectory(
       const register = mod.register ?? mod.default?.register;
       if (typeof register !== "function") {
         log.warn(`${name}: no register() export, skipping`);
+        options.failedFiles?.add(file);
         deps.send({
           type: "extension_lifecycle",
           name: displayName,
@@ -209,6 +218,7 @@ export async function loadAethonExtensionDirectory(
     } catch (err) {
       const message = (err as Error).message;
       log.warn(`${name}: ${message}`);
+      options.failedFiles?.add(file);
       deps.send({
         type: "extension_lifecycle",
         name: displayName,
@@ -251,6 +261,7 @@ export async function loadProjectAethonExtensions(
   api: AethonExtensionApi,
   registry: Map<string, ExtensionSource>,
   loadedFiles: Set<string>,
+  failedFiles: Set<string>,
   hooks?: LoadHooks,
 ): Promise<{ loaded: number; failed: number }> {
   const dirs = await findProjectExtensionDirs(cwd);
@@ -277,6 +288,7 @@ export async function loadProjectAethonExtensions(
       source: "project-directory",
       logPrefix: "aethon-project-ext",
       loadedFiles,
+      failedFiles,
       displayName: (name) =>
         projectExtensionDisplayName(projectRoot, extensionDir, name),
       onLoaded: wrappedHooks.onLoaded,

--- a/agent/main.ts
+++ b/agent/main.ts
@@ -81,6 +81,7 @@ import {
   emitReady,
   tabSessionDir,
 } from "./tab-lifecycle";
+import { loadDisabledExtensions } from "./disabled-extensions";
 import {
   captureProjectExtensionBaseline,
   runDispatcher,
@@ -126,6 +127,11 @@ async function main(): Promise<void> {
   state.authStorage = AuthStorage.create();
   state.modelRegistry = ModelRegistry.create(state.authStorage);
   state.settingsManager = SettingsManager.create(process.cwd());
+
+  // -- User's persisted "disabled extensions" list -----------------------
+  // Read before any extension load so the loader honors it on first pass.
+  const disabled = await loadDisabledExtensions(state.userDir);
+  for (const name of disabled) state.disabledExtensions.add(name);
 
   // -- Bundled boot resources read synchronously --------------------------
   if (bootLayoutFile) {

--- a/agent/main.ts
+++ b/agent/main.ts
@@ -59,7 +59,6 @@ import { resolveAethonSystemPrompt } from "./system-prompt";
 import { readSessionTranscript } from "./session-history";
 import {
   AethonAgentState,
-  type AethonExtensionApi,
   type ExtensionFailure,
   type ExtensionFailureSource,
   type LayoutSlotsCatalogue,
@@ -166,25 +165,12 @@ async function main(): Promise<void> {
   const extDeps = { send };
 
   // -- aethon API -- build BEFORE createAgentSession so pi extensions that
-  // touch globalThis.aethon.* see the real API instead of undefined. -----
+  // touch globalThis.aethon.* see the real API instead of undefined. The
+  // same object is the one passed to extension `register(api)` calls — see
+  // `AethonExtensionApi` in state.ts for why we don't wrap it. -----
   const aethonApi = buildAethonApi(state, apiDeps);
   (globalThis as { aethon?: typeof aethonApi }).aethon = aethonApi;
-
-  // The bridge-private extension API surface used by the loaders. Wraps
-  // aethonApi to satisfy the AethonExtensionApi contract (registerComponent
-  // / setState / registerTheme / onUnload).
-  const extensionApi: AethonExtensionApi = {
-    registerComponent: (componentType, template) => {
-      void aethonApi.registerComponent(componentType, template);
-    },
-    setState: (path, value) => {
-      void aethonApi.setState(path, value);
-    },
-    registerTheme: (theme) => {
-      void aethonApi.registerTheme(theme);
-    },
-    onUnload: aethonApi.onUnload,
-  };
+  const extensionApi = aethonApi;
 
   // -- pi resource loader (system prompt, tools, memory) ------------------
   state.resourceLoader = new DefaultResourceLoader({
@@ -254,6 +240,7 @@ async function main(): Promise<void> {
     extensionApi,
     state.loadedExtensions,
     state.loadedProjectExtensionFiles,
+    state.failedProjectExtensionFiles,
     loadHooks,
   );
   state.currentProjectCwd = process.cwd();

--- a/agent/runtime-snapshot.ts
+++ b/agent/runtime-snapshot.ts
@@ -54,6 +54,7 @@ export function getRuntimeSnapshot(state: AethonAgentState): RuntimeSnapshot {
       error: info.error,
       ...(info.path ? { path: info.path } : {}),
     })),
+    disabledExtensions: [...state.disabledExtensions].sort(),
     themes: [...state.extensionThemes.values()].map((t) => ({
       id: t.id,
       label: t.label,

--- a/agent/session-history.test.ts
+++ b/agent/session-history.test.ts
@@ -4,8 +4,10 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   parseSessionHistoryLines,
+  readSessionLabel,
   readSessionMetadata,
   readSessionTranscript,
+  writeSessionLabel,
 } from "./session-history";
 
 const roots: string[] = [];
@@ -129,5 +131,21 @@ describe("readSessionTranscript", () => {
     await expect(readSessionMetadata(dir)).resolves.toMatchObject({
       cwd: "/tmp/project",
     });
+  });
+
+  it("round-trips a custom session label and surfaces it through readSessionMetadata", async () => {
+    const dir = await tempRoot();
+    await writeFile(
+      join(dir, "session.jsonl"),
+      `${JSON.stringify({ type: "session", id: "x", cwd: "/tmp/p" })}\n`,
+    );
+    expect(await readSessionLabel(dir)).toBeUndefined();
+    await writeSessionLabel(dir, "  Refactor pass  ");
+    expect(await readSessionLabel(dir)).toBe("Refactor pass");
+    const meta = await readSessionMetadata(dir);
+    expect(meta?.customLabel).toBe("Refactor pass");
+    // Empty label clears the file.
+    await writeSessionLabel(dir, "");
+    expect(await readSessionLabel(dir)).toBeUndefined();
   });
 });

--- a/agent/session-history.ts
+++ b/agent/session-history.ts
@@ -1,5 +1,49 @@
-import { readdir, readFile, stat } from "node:fs/promises";
+import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+
+const LABEL_FILE = "label.txt";
+const MAX_CUSTOM_LABEL_CHARS = 120;
+
+/** Per-session custom label set via the sidebar "Rename session…"
+ *  context-menu action. Returns undefined if no label has been set
+ *  (or if the file can't be read — best-effort, never throws). */
+export async function readSessionLabel(
+  sessionDir: string,
+): Promise<string | undefined> {
+  try {
+    const text = await readFile(join(sessionDir, LABEL_FILE), "utf8");
+    const trimmed = text.trim();
+    if (!trimmed) return undefined;
+    return trimmed.length > MAX_CUSTOM_LABEL_CHARS
+      ? trimmed.slice(0, MAX_CUSTOM_LABEL_CHARS)
+      : trimmed;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    return undefined;
+  }
+}
+
+/** Write a custom label for the given session. Empty / whitespace-only
+ *  input clears the label (deletes the file). The session dir is
+ *  created if missing so the call is safe before any chat turn. */
+export async function writeSessionLabel(
+  sessionDir: string,
+  label: string,
+): Promise<void> {
+  await mkdir(sessionDir, { recursive: true });
+  const trimmed = label.trim().slice(0, MAX_CUSTOM_LABEL_CHARS);
+  const path = join(sessionDir, LABEL_FILE);
+  if (!trimmed) {
+    try {
+      const fs = await import("node:fs/promises");
+      await fs.unlink(path);
+    } catch {
+      // Already absent — the desired end state.
+    }
+    return;
+  }
+  await writeFile(path, trimmed + "\n", "utf8");
+}
 
 const MAX_RESTORED_MESSAGES = 200;
 const MAX_TEXT_CHARS = 8 * 1024;
@@ -22,6 +66,9 @@ export interface SessionLogMetadata {
   /** First user-turn text, trimmed to 60 chars. Used to label sessions
    *  meaningfully in the sidebar instead of showing raw UUID slices. */
   firstUserMessage?: string;
+  /** User-supplied label (sidebar "Rename session…" / `/rename`).
+   *  Wins over `firstUserMessage` when both are present. */
+  customLabel?: string;
 }
 
 function textFromContent(content: unknown): string {
@@ -181,10 +228,12 @@ export async function readSessionMetadata(
 
   const raw = await readFile(latest.path, "utf8");
   const { cwd, firstUserMessage } = metaFromSessionLines(raw.split(/\r?\n/));
+  const customLabel = await readSessionLabel(sessionDir);
   return {
     lastModified: latest.mtimeMs,
     ...(cwd ? { cwd } : {}),
     ...(firstUserMessage ? { firstUserMessage } : {}),
+    ...(customLabel ? { customLabel } : {}),
   };
 }
 

--- a/agent/state-mutation.test.ts
+++ b/agent/state-mutation.test.ts
@@ -114,6 +114,31 @@ describe("setState", () => {
     ).toEqual(big);
   });
 
+  it("emits extension_runtime_error once per (ext+kind+path), regardless of log-limiter decision", async () => {
+    // The user-facing event is gated by state.notifiedExtRuntimeErrors,
+    // not the log limiter. Even with a permissive limiter, only the
+    // first rejection per key surfaces a notification.
+    const f = makeFixture();
+    f.state.currentExtensionName = "loopy-ext";
+    const huge = "x".repeat(200 * 1024);
+    await setState(f.state, f.deps, "/blob", huge);
+    await setState(f.state, f.deps, "/blob", huge);
+    await setState(f.state, f.deps, "/blob", huge);
+    const errs = f.sent.filter((m) => m.type === "extension_runtime_error");
+    expect(errs.length).toBe(1);
+  });
+
+  it("re-notifies after a successful setState clears the sticky flag", async () => {
+    const f = makeFixture();
+    f.state.currentExtensionName = "flaky-ext";
+    const huge = "x".repeat(200 * 1024);
+    await setState(f.state, f.deps, "/blob", huge);
+    await setState(f.state, f.deps, "/blob", "ok"); // recovers
+    await setState(f.state, f.deps, "/blob", huge); // breaks again
+    const errs = f.sent.filter((m) => m.type === "extension_runtime_error");
+    expect(errs.length).toBe(2);
+  });
+
   it("records currentExtensionName as path owner for later async writes", async () => {
     const f = makeFixture();
     f.state.currentExtensionName = "my-ext";

--- a/agent/state-mutation.ts
+++ b/agent/state-mutation.ts
@@ -89,6 +89,14 @@ export function setState(
         extStateLog.warn(
           `setState rejected: path=${path} size=${kb}KB exceeds ${state.statePayloadHardKb}KB limit${who}${tail} — store file paths, not content`,
         );
+      }
+      // User-facing notification: send once per (ext+kind+path), not on
+      // every limiter window. The toast is sticky and the user can't
+      // un-see it; periodic re-pops are pure noise. Cleared when the
+      // same path receives a successful setState.
+      const notifyKey = `${ext}|state-too-large|${path}`;
+      if (!state.notifiedExtRuntimeErrors.has(notifyKey)) {
+        state.notifiedExtRuntimeErrors.add(notifyKey);
         deps.send({
           type: "extension_runtime_error",
           name: attributed,
@@ -116,6 +124,13 @@ export function setState(
         );
       }
     }
+  }
+  // Successful write below the hard cap — clear any sticky
+  // notification flag for this path so a future regression re-notifies.
+  if (serialized !== undefined) {
+    const ext =
+      state.currentExtensionName ?? state.extPathOwners.get(path) ?? "?";
+    state.notifiedExtRuntimeErrors.delete(`${ext}|state-too-large|${path}`);
   }
   // tabId attribution priority: explicit → ALS → currentAgentTabId.
   // setIntervals registered at module-load time have NO ALS context —

--- a/agent/state.ts
+++ b/agent/state.ts
@@ -134,6 +134,10 @@ export interface DiscoveredTab {
   lastModified: number;
   cwd?: string;
   firstUserMessage?: string;
+  /** User-supplied label (via the sidebar "Rename session…" action).
+   *  When present, the sidebar shows this instead of `firstUserMessage`.
+   *  Persisted at `<sessionsDir>/<tabId>/label.txt`. */
+  customLabel?: string;
 }
 
 export interface ModelDescriptor {

--- a/agent/state.ts
+++ b/agent/state.ts
@@ -371,6 +371,11 @@ export class AethonAgentState {
   // -- Loading state -------------------------------------------------------
   readonly loadedExtensions = new Map<string, ExtensionSource>();
   readonly loadFailures = new Map<string, ExtensionFailure>();
+  /** Extension display-names the user has explicitly disabled. Persisted
+   *  on disk at `<userDir>/disabled-extensions.json` and consulted by
+   *  the loader to skip imports. The displayName is the same string the
+   *  sidebar shows (e.g. `mold:image-gallery`, `my-user-ext`). */
+  readonly disabledExtensions = new Set<string>();
   readonly loadedProjectExtensionFiles = new Set<string>();
   /** Project extension files we already tried to load and that errored.
    *  Tracked separately from `loadedProjectExtensionFiles` so we don't

--- a/agent/state.ts
+++ b/agent/state.ts
@@ -63,12 +63,19 @@ export interface MutationResult {
   data?: unknown;
 }
 
-export interface AethonExtensionApi {
-  registerComponent(componentType: string, template: unknown): void;
-  setState(path: string, value: unknown): void;
-  registerTheme?: (theme: unknown) => void;
-  onUnload?: (fn: () => void | Promise<void>) => void;
-}
+/** The API surface extensions receive in their `register(api)` call.
+ *
+ *  Aliased to the full `AethonApi` (the same object installed on
+ *  `globalThis.aethon`) because there is no real sandbox between the
+ *  bridge and an extension — they share a Bun runtime and could reach
+ *  `globalThis.aethon` directly anyway. The previous narrow 4-method
+ *  shim caused `api.registerSidebarSection is not a function` errors
+ *  for extensions that followed the documented contract.
+ *
+ *  Imported as `import type` to keep this circular-import safe — types
+ *  are erased at runtime. */
+import type { AethonApi } from "./aethon-api";
+export type AethonExtensionApi = AethonApi;
 
 export interface AethonExtensionModule {
   register?: (api: AethonExtensionApi) => void | Promise<void>;
@@ -365,6 +372,12 @@ export class AethonAgentState {
   readonly loadedExtensions = new Map<string, ExtensionSource>();
   readonly loadFailures = new Map<string, ExtensionFailure>();
   readonly loadedProjectExtensionFiles = new Set<string>();
+  /** Project extension files we already tried to load and that errored.
+   *  Tracked separately from `loadedProjectExtensionFiles` so we don't
+   *  re-import (and re-warn about) the same broken file on every
+   *  `tab_open` / `set_project` for the same project. Cleared by
+   *  `unloadProjectExtensions`, so switching projects does retry. */
+  readonly failedProjectExtensionFiles = new Set<string>();
   readonly projectExtensionTeardowns: Array<() => void | Promise<void>> = [];
   readonly userExtensionTeardowns: Array<() => void | Promise<void>> = [];
   /** Tracks which extension scope's register() is currently on the stack.
@@ -381,6 +394,12 @@ export class AethonAgentState {
    *  extension we saw write to each path so async callbacks still get
    *  attributed to the right extension. */
   readonly extPathOwners = new Map<string, string>();
+  /** Keys (`${ext}|${kind}|${path}`) we've already surfaced as a
+   *  user-facing `extension_runtime_error` event. We notify once per
+   *  problem and rely on the log-throttler for ongoing visibility. The
+   *  key is cleared when the same path receives a successful setState,
+   *  so a recovered-then-broken extension re-notifies. */
+  readonly notifiedExtRuntimeErrors = new Set<string>();
   projectBaseline: ProjectBaselineSnapshot | null = null;
 
   // -- Mutation acks / handshake ------------------------------------------

--- a/agent/system-prompt.ts
+++ b/agent/system-prompt.ts
@@ -48,6 +48,13 @@ export interface RuntimeSnapshot {
     error: string;
     path?: string;
   }[];
+  // Extensions the user has explicitly disabled via the sidebar
+  // right-click menu. Persisted at `<userDir>/disabled-extensions.json`
+  // and consulted by the loader on every boot. The agent should respect
+  // user intent — if a disabled extension is also in `extensions`, the
+  // toggle landed mid-session and a restart is needed for it to fully
+  // unload.
+  disabledExtensions: string[];
   themes: { id: string; label: string }[];
   components: string[];
   layoutSummary: string;

--- a/agent/tab-lifecycle.ts
+++ b/agent/tab-lifecycle.ts
@@ -340,6 +340,7 @@ export function emitReady(
         ...(info.path ? { path: info.path } : {}),
       }),
     ),
+    disabledExtensionsList: [...state.disabledExtensions].sort(),
     discoveredTabs: state.discoveredTabs,
   });
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -422,6 +422,32 @@ fn force_restart_agent(state: State<'_, AgentProcess>) -> Result<(), String> {
     Ok(())
 }
 
+/// Intentional kill-and-respawn for state changes the bridge can't apply
+/// hot (currently: the user toggling an extension via the sidebar). Sets
+/// the supervisor's `agent_reload_in_progress` flag BEFORE killing so the
+/// stdout reader treats EOF as a clean reload (emits `agent-reloaded`,
+/// not `agent-crashed`). The frontend's `agent-reloaded` handler then
+/// invokes `start_agent` and the new bridge boots fresh — for the
+/// disable-extension case, it reads `disabled-extensions.json` and the
+/// loader honors the user's intent.
+#[tauri::command]
+fn reload_agent(state: State<'_, AgentProcess>, app: AppHandle) -> Result<(), String> {
+    let reload_flag = agent_reload_in_progress(&app);
+    reload_flag.store(true, std::sync::atomic::Ordering::Release);
+    let mut guard = state.0.lock().map_err(|e| e.to_string())?;
+    if let Some(mut child) = guard.take() {
+        let pid = child.id();
+        tracing::info!(target: "aethon::agent", "reload_agent: killing pid={pid}");
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+    // Emit agent-reloaded immediately so the frontend re-primes via
+    // start_agent — the stdout reader thread also resets the flag and
+    // returns silently when it sees EOF, avoiding a duplicate event.
+    let _ = app.emit("agent-reloaded", "extension-toggle");
+    Ok(())
+}
+
 /// Forward an arbitrary JSON payload to the agent's stdin. Used by the model
 /// picker and any future runtime controls that aren't wrapped in
 /// `dispatch_a2ui_event`.
@@ -649,6 +675,7 @@ pub fn run() {
             send_message,
             agent_command,
             force_restart_agent,
+            reload_agent,
             dispatch_a2ui_event,
             save_paste_image,
             commands::config::read_state,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -432,18 +432,23 @@ fn force_restart_agent(state: State<'_, AgentProcess>) -> Result<(), String> {
 /// loader honors the user's intent.
 #[tauri::command]
 fn reload_agent(state: State<'_, AgentProcess>, app: AppHandle) -> Result<(), String> {
-    let reload_flag = agent_reload_in_progress(&app);
-    reload_flag.store(true, std::sync::atomic::Ordering::Release);
     let mut guard = state.0.lock().map_err(|e| e.to_string())?;
+    // Only set the reload flag when there's actually a child to kill —
+    // the stdout reader thread is what resets the flag on EOF, so
+    // setting it without a child to die would leave it stale and the
+    // next genuine crash would be misclassified as an intentional
+    // reload (no agent-crashed notification).
     if let Some(mut child) = guard.take() {
         let pid = child.id();
+        let reload_flag = agent_reload_in_progress(&app);
+        reload_flag.store(true, std::sync::atomic::Ordering::Release);
         tracing::info!(target: "aethon::agent", "reload_agent: killing pid={pid}");
         let _ = child.kill();
         let _ = child.wait();
     }
-    // Emit agent-reloaded immediately so the frontend re-primes via
-    // start_agent — the stdout reader thread also resets the flag and
-    // returns silently when it sees EOF, avoiding a duplicate event.
+    // Emit agent-reloaded so the frontend re-primes via start_agent.
+    // Safe to emit even when no child existed — the listener invokes
+    // start_agent which is a no-op if the agent is already absent.
     let _ = app.emit("agent-reloaded", "extension-toggle");
     Ok(())
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -650,6 +650,22 @@ export default function App() {
           label: p.label,
           path: p.path,
         })),
+      reloadAgent: async () => {
+        await invoke("reload_agent");
+      },
+      renameSession: async (tabId: string, label: string) => {
+        await invoke("agent_command", {
+          payload: JSON.stringify({
+            type: "set_session_label",
+            tabId,
+            label,
+          }),
+        });
+      },
+      activeTabId: () => {
+        const id = stateRef.current.activeTabId;
+        return typeof id === "string" && id.length > 0 ? id : null;
+      },
       activeProject: () => {
         const a = activeProject(projectsRef.current);
         return a ? { id: a.id, label: a.label, path: a.path } : null;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -654,6 +654,22 @@ export default function App() {
         await invoke("reload_agent");
       },
       renameSession: async (tabId: string, label: string) => {
+        // Optimistic in-memory update so the open-tab row in the sidebar
+        // history (and the top tab strip + palette) reflect the new
+        // label immediately. The bridge persists label.txt; on the next
+        // ready re-emit the closed-session bucket also picks it up.
+        setState((prev) => {
+          const tabs = (prev.tabs as Tab[] | undefined) ?? [];
+          const idx = tabs.findIndex((t) => t.id === tabId);
+          if (idx < 0) return prev;
+          const trimmed = label.trim();
+          const fallback = `Tab ${idx + 1}`;
+          const nextLabel = trimmed.length > 0 ? trimmed : fallback;
+          if (tabs[idx].label === nextLabel) return prev;
+          const next = [...tabs];
+          next[idx] = { ...next[idx], label: nextLabel };
+          return { ...prev, tabs: next };
+        });
         await invoke("agent_command", {
           payload: JSON.stringify({
             type: "set_session_label",

--- a/src/eventRoutes/index.ts
+++ b/src/eventRoutes/index.ts
@@ -40,6 +40,7 @@ import {
   handleSidebarResizeEnd,
   handleSidebarRemoveProject,
   handleSidebarDeleteSession,
+  handleSidebarToggleExtension,
   handleSectionedSelect,
 } from "./sidebar";
 
@@ -62,6 +63,7 @@ export const BUILTIN_ROUTE_TABLE: ReadonlyMap<string, readonly EventRouteHandler
       handleSidebarResizeEnd,
       handleSidebarRemoveProject,
       handleSidebarDeleteSession,
+      handleSidebarToggleExtension,
       handleSectionedSelect,
     ]],
     ["id:model-picker", [handleSectionedSelect]],

--- a/src/eventRoutes/index.ts
+++ b/src/eventRoutes/index.ts
@@ -40,6 +40,7 @@ import {
   handleSidebarResizeEnd,
   handleSidebarRemoveProject,
   handleSidebarDeleteSession,
+  handleSidebarRenameSession,
   handleSidebarToggleExtension,
   handleSectionedSelect,
 } from "./sidebar";
@@ -63,6 +64,7 @@ export const BUILTIN_ROUTE_TABLE: ReadonlyMap<string, readonly EventRouteHandler
       handleSidebarResizeEnd,
       handleSidebarRemoveProject,
       handleSidebarDeleteSession,
+      handleSidebarRenameSession,
       handleSidebarToggleExtension,
       handleSectionedSelect,
     ]],

--- a/src/eventRoutes/sidebar.test.ts
+++ b/src/eventRoutes/sidebar.test.ts
@@ -4,6 +4,7 @@ import {
   handleSidebarResizeEnd,
   handleSidebarRemoveProject,
   handleSidebarDeleteSession,
+  handleSidebarRenameSession,
   handleSidebarToggleExtension,
   handleSectionedSelect,
 } from "./sidebar";
@@ -93,6 +94,28 @@ describe("handleSidebarDeleteSession", () => {
     );
     expect(handled).toBe(true);
     expect(mocks.promptDeleteSessionConfirmation).not.toHaveBeenCalled();
+  });
+});
+
+describe("handleSidebarRenameSession", () => {
+  it("forwards a set_session_label command to the bridge", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    const handled = await handleSidebarRenameSession(
+      {
+        component: { id: "sidebar" },
+        eventType: "rename-session",
+        data: { sessionId: "tab-7", label: "Refactor pass" },
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.invoke).toHaveBeenCalledWith("agent_command", {
+      payload: JSON.stringify({
+        type: "set_session_label",
+        tabId: "tab-7",
+        label: "Refactor pass",
+      }),
+    });
   });
 });
 

--- a/src/eventRoutes/sidebar.test.ts
+++ b/src/eventRoutes/sidebar.test.ts
@@ -4,6 +4,7 @@ import {
   handleSidebarResizeEnd,
   handleSidebarRemoveProject,
   handleSidebarDeleteSession,
+  handleSidebarToggleExtension,
   handleSectionedSelect,
 } from "./sidebar";
 import { buildRouteFixture } from "./testFixtures";
@@ -92,6 +93,42 @@ describe("handleSidebarDeleteSession", () => {
     );
     expect(handled).toBe(true);
     expect(mocks.promptDeleteSessionConfirmation).not.toHaveBeenCalled();
+  });
+});
+
+describe("handleSidebarToggleExtension", () => {
+  it("forwards a set_extension_disabled command to the bridge", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    const handled = await handleSidebarToggleExtension(
+      {
+        component: { id: "sidebar" },
+        eventType: "toggle-extension",
+        data: { name: "mold:image-gallery", disabled: true },
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.invoke).toHaveBeenCalledWith("agent_command", {
+      payload: JSON.stringify({
+        type: "set_extension_disabled",
+        name: "mold:image-gallery",
+        disabled: true,
+      }),
+    });
+  });
+
+  it("ignores non-toggle events for the sidebar", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    const handled = await handleSidebarToggleExtension(
+      {
+        component: { id: "sidebar" },
+        eventType: "select",
+        data: { name: "x", disabled: true },
+      },
+      ctx,
+    );
+    expect(handled).toBe(false);
+    expect(mocks.invoke).not.toHaveBeenCalled();
   });
 });
 

--- a/src/eventRoutes/sidebar.test.ts
+++ b/src/eventRoutes/sidebar.test.ts
@@ -117,6 +117,56 @@ describe("handleSidebarRenameSession", () => {
       }),
     });
   });
+
+  it("optimistically updates an open tab's label so the rename is instant", async () => {
+    const { ctx, applySetState } = buildRouteFixture({
+      state: {
+        tabs: [
+          { id: "tab-7", kind: "agent", label: "Tab 1" },
+          { id: "tab-9", kind: "agent", label: "Tab 2" },
+        ],
+      },
+    });
+    await handleSidebarRenameSession(
+      {
+        component: { id: "sidebar" },
+        eventType: "rename-session",
+        data: { sessionId: "tab-7", label: "Refactor pass" },
+      },
+      ctx,
+    );
+    const next = applySetState({
+      tabs: [
+        { id: "tab-7", kind: "agent", label: "Tab 1" },
+        { id: "tab-9", kind: "agent", label: "Tab 2" },
+      ],
+    });
+    const tabs = next.tabs as { id: string; label: string }[];
+    expect(tabs[0].label).toBe("Refactor pass");
+    expect(tabs[1].label).toBe("Tab 2");
+  });
+
+  it("empty label restores the auto sequential label for the open tab", async () => {
+    const { ctx, applySetState } = buildRouteFixture({
+      state: {
+        tabs: [
+          { id: "tab-3", kind: "agent", label: "Custom name" },
+        ],
+      },
+    });
+    await handleSidebarRenameSession(
+      {
+        component: { id: "sidebar" },
+        eventType: "rename-session",
+        data: { sessionId: "tab-3", label: "  " },
+      },
+      ctx,
+    );
+    const next = applySetState({
+      tabs: [{ id: "tab-3", kind: "agent", label: "Custom name" }],
+    });
+    expect((next.tabs as { label: string }[])[0].label).toBe("Tab 1");
+  });
 });
 
 describe("handleSidebarToggleExtension", () => {

--- a/src/eventRoutes/sidebar.ts
+++ b/src/eventRoutes/sidebar.ts
@@ -126,6 +126,38 @@ export const handleSidebarDeleteSession: EventRouteHandler = (
   return true;
 };
 
+/** sidebar toggle-extension: forward to the bridge so the user's
+ *  disabled list is updated + persisted. The bridge re-emits `ready`
+ *  on success so the sidebar entry shifts buckets without a refresh. */
+export const handleSidebarToggleExtension: EventRouteHandler = (
+  { component, eventType, data },
+  ctx,
+) => {
+  if (component.id !== "sidebar" || eventType !== "toggle-extension") {
+    return false;
+  }
+  const selected = data as
+    | { name?: string; disabled?: boolean }
+    | undefined;
+  if (!selected?.name || typeof selected.disabled !== "boolean") return true;
+  ctx
+    .invoke("agent_command", {
+      payload: JSON.stringify({
+        type: "set_extension_disabled",
+        name: selected.name,
+        disabled: selected.disabled,
+      }),
+    })
+    .catch((err: unknown) => {
+      ctx.pushNotification({
+        title: "Toggle extension failed",
+        message: String(err),
+        kind: "error",
+      });
+    });
+  return true;
+};
+
 /** Sidebar select + dropdown chrome pickers (model-picker /
  *  appearance-menu) all use the same `{sectionId, itemId}` event
  *  shape. Route by section so a chrome dropdown and a sidebar row

--- a/src/eventRoutes/sidebar.ts
+++ b/src/eventRoutes/sidebar.ts
@@ -126,6 +126,41 @@ export const handleSidebarDeleteSession: EventRouteHandler = (
   return true;
 };
 
+/** sidebar rename-session: forward the new label to the bridge. The
+ *  bridge persists `<sessionsDir>/<tabId>/label.txt` and re-emits
+ *  `ready` so the sidebar history list re-renders with the new label. */
+export const handleSidebarRenameSession: EventRouteHandler = (
+  { component, eventType, data },
+  ctx,
+) => {
+  if (component.id !== "sidebar" || eventType !== "rename-session") {
+    return false;
+  }
+  const selected = data as
+    | { sessionId?: string; itemId?: string; label?: string }
+    | undefined;
+  const raw = selected?.sessionId ?? selected?.itemId ?? "";
+  const sessionId = extractSessionId(raw);
+  const label = typeof selected?.label === "string" ? selected.label : "";
+  if (!sessionId) return true;
+  ctx
+    .invoke("agent_command", {
+      payload: JSON.stringify({
+        type: "set_session_label",
+        tabId: sessionId,
+        label,
+      }),
+    })
+    .catch((err: unknown) => {
+      ctx.pushNotification({
+        title: "Rename session failed",
+        message: String(err),
+        kind: "error",
+      });
+    });
+  return true;
+};
+
 /** sidebar toggle-extension: forward to the bridge so the user's
  *  disabled list is updated + persisted. The bridge re-emits `ready`
  *  on success so the sidebar entry shifts buckets without a refresh. */

--- a/src/eventRoutes/sidebar.ts
+++ b/src/eventRoutes/sidebar.ts
@@ -1,4 +1,4 @@
-import type { EventRouteHandler } from "./types";
+import type { EventRouteContext, EventRouteHandler } from "./types";
 import { extractSessionId } from "../utils/sidebarHistory";
 import type { Tab } from "../types/tab";
 
@@ -126,9 +126,13 @@ export const handleSidebarDeleteSession: EventRouteHandler = (
   return true;
 };
 
-/** sidebar rename-session: forward the new label to the bridge. The
- *  bridge persists `<sessionsDir>/<tabId>/label.txt` and re-emits
- *  `ready` so the sidebar history list re-renders with the new label. */
+/** sidebar rename-session: forward the new label to the bridge AND
+ *  optimistically update the open tab's label if the target is
+ *  currently open. The bridge persists
+ *  `<sessionsDir>/<tabId>/label.txt` and re-emits `ready`; the
+ *  optimistic update is what makes the change visible immediately for
+ *  open-tab rows (whose `tab:` label flows from `Tab.label`, not from
+ *  `recentSessions`/`discoveredTabs`). */
 export const handleSidebarRenameSession: EventRouteHandler = (
   { component, eventType, data },
   ctx,
@@ -143,6 +147,7 @@ export const handleSidebarRenameSession: EventRouteHandler = (
   const sessionId = extractSessionId(raw);
   const label = typeof selected?.label === "string" ? selected.label : "";
   if (!sessionId) return true;
+  applyOptimisticTabLabel(ctx, sessionId, label);
   ctx
     .invoke("agent_command", {
       payload: JSON.stringify({
@@ -160,6 +165,32 @@ export const handleSidebarRenameSession: EventRouteHandler = (
     });
   return true;
 };
+
+/** Update an open tab's `label` in App state when renaming a currently
+ *  open session. Empty input restores the auto-derived sequential
+ *  "Tab N" label using the tab's existing index in the array (matches
+ *  the original useTabs naming convention so the auto-label fallback
+ *  behaviour from `buildSidebarHistory` kicks in). No-op if no tab
+ *  matches the id. */
+function applyOptimisticTabLabel(
+  ctx: EventRouteContext,
+  tabId: string,
+  label: string,
+): void {
+  ctx.setState((prev) => {
+    const tabs = (prev.tabs as { id: string; label: string }[] | undefined) ??
+      [];
+    const idx = tabs.findIndex((t) => t.id === tabId);
+    if (idx < 0) return prev;
+    const trimmed = label.trim();
+    const fallback = `Tab ${idx + 1}`;
+    const nextLabel = trimmed.length > 0 ? trimmed : fallback;
+    if (tabs[idx].label === nextLabel) return prev;
+    const nextTabs = [...tabs];
+    nextTabs[idx] = { ...nextTabs[idx], label: nextLabel };
+    return { ...prev, tabs: nextTabs };
+  });
+}
 
 /** sidebar toggle-extension: forward to the bridge so the user's
  *  disabled list is updated + persisted. The bridge re-emits `ready`

--- a/src/eventRoutes/types.ts
+++ b/src/eventRoutes/types.ts
@@ -27,6 +27,7 @@ export interface DiscoveredSession {
   lastModified: number;
   cwd?: string;
   firstUserMessage?: string;
+  customLabel?: string;
 }
 
 /** Everything a route handler may close over. Flat by design — every

--- a/src/hooks/bridgeMessageHandlers/extensionLifecycle.ts
+++ b/src/hooks/bridgeMessageHandlers/extensionLifecycle.ts
@@ -13,7 +13,13 @@ export const handleExtensionLifecycle: BridgeMessageHandler = (data, ctx) => {
   const detail = {
     name: (data.name as string) ?? "(unknown)",
     source: (data.source as string) ?? "directory",
-    status: (data.status as "loaded" | "failed" | "skipped") ?? "loaded",
+    status:
+      (data.status as
+        | "loaded"
+        | "failed"
+        | "skipped"
+        | "disabled"
+        | "enabled") ?? "loaded",
     error: data.error as string | undefined,
     path: data.path as string | undefined,
   };
@@ -25,13 +31,19 @@ export const handleExtensionLifecycle: BridgeMessageHandler = (data, ctx) => {
   const proceed = window.dispatchEvent(ev);
   if (proceed) {
     // Default rendering — terse one-liner the user can recognize even
-    // when the agent's chat reply was eaten by a respawn.
+    // when the agent's chat reply was eaten by a respawn. Disable /
+    // enable toggles also surface here so the user (and the next-turn
+    // system prompt, which lists disabledExtensions) have a record.
     const verb =
       detail.status === "loaded"
         ? "loaded"
         : detail.status === "failed"
           ? "failed to load"
-          : "skipped";
+          : detail.status === "disabled"
+            ? "disabled by user"
+            : detail.status === "enabled"
+              ? "re-enabled by user"
+              : "skipped";
     const suffix = detail.error ? ` — ${detail.error}` : "";
     ctx.appendMessage(
       {

--- a/src/hooks/bridgeMessageHandlers/index.ts
+++ b/src/hooks/bridgeMessageHandlers/index.ts
@@ -31,6 +31,7 @@ import { handlePromptStarted } from "./promptStarted";
 import { handleQueueReset } from "./queueReset";
 import { handleQueued } from "./queued";
 import { handleReady } from "./ready";
+import { handleReloadRequired } from "./reloadRequired";
 import { handleRegisterHighlightGrammar } from "./registerHighlightGrammar";
 import { handleResponse } from "./response";
 import { handleResponseDelta } from "./responseDelta";
@@ -67,6 +68,7 @@ export const bridgeMessageHandlers: Readonly<
   queue_reset: handleQueueReset,
   queued: handleQueued,
   ready: handleReady,
+  reload_required: handleReloadRequired,
   register_highlight_grammar: handleRegisterHighlightGrammar,
   response: handleResponse,
   response_delta: handleResponseDelta,

--- a/src/hooks/bridgeMessageHandlers/ready.test.ts
+++ b/src/hooks/bridgeMessageHandlers/ready.test.ts
@@ -48,6 +48,7 @@ describe("handleReady", () => {
     expect(mocks.hydrateExtensions).toHaveBeenCalledWith(
       [{ name: "ext-a", source: "directory" }],
       [],
+      [],
     );
     expect(mocks.setLayout).toHaveBeenCalledTimes(1);
     const next = applySetState({

--- a/src/hooks/bridgeMessageHandlers/ready.ts
+++ b/src/hooks/bridgeMessageHandlers/ready.ts
@@ -89,6 +89,7 @@ export const handleReady: BridgeMessageHandler = (data, ctx) => {
     (data.failedExtensionsList as
       | { name: string; source: string; error?: string }[]
       | undefined) ?? [],
+    (data.disabledExtensionsList as string[] | undefined) ?? [],
   );
   ctx.registry.setTemplates(extComponents);
   // Restore extension-registered slash commands so the picker shows them

--- a/src/hooks/bridgeMessageHandlers/reloadRequired.test.ts
+++ b/src/hooks/bridgeMessageHandlers/reloadRequired.test.ts
@@ -1,0 +1,25 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { handleReloadRequired } from "./reloadRequired";
+import { buildHandlerFixture } from "./testFixtures";
+import { clearTauriMocks, installTauriMocks } from "../../test/tauriMocks";
+
+describe("handleReloadRequired", () => {
+  let harness: ReturnType<typeof installTauriMocks>;
+  beforeEach(() => {
+    harness = installTauriMocks();
+  });
+  afterEach(() => {
+    clearTauriMocks();
+  });
+
+  it("invokes reload_agent (which emits agent-reloaded → useOsEdges respawns)", async () => {
+    const { ctx } = buildHandlerFixture();
+    harness.invoke.mockResolvedValue(undefined);
+    handleReloadRequired(
+      { type: "reload_required", reason: "extension-toggle:x" },
+      ctx,
+    );
+    await Promise.resolve();
+    expect(harness.invoke).toHaveBeenCalledWith("reload_agent");
+  });
+});

--- a/src/hooks/bridgeMessageHandlers/reloadRequired.ts
+++ b/src/hooks/bridgeMessageHandlers/reloadRequired.ts
@@ -1,0 +1,25 @@
+import { invoke } from "@tauri-apps/api/core";
+import type { BridgeMessageHandler } from "./types";
+
+/** Bridge asks the supervisor to restart it. Used after a state change
+ *  the bridge can't apply hot — e.g. user toggled an extension via the
+ *  sidebar context menu. We invoke `force_restart_agent`, which sets
+ *  the supervisor's `agent_reload_in_progress` flag so the next agent
+ *  command respawns the bridge cleanly (emits `agent-reloaded`, not
+ *  `agent-crashed`). The new bridge reads disabled-extensions.json on
+ *  boot and the loader honors the user's intent.
+ */
+export const handleReloadRequired: BridgeMessageHandler = (data, _ctx) => {
+  const reason = (data.reason as string | undefined) ?? "unspecified";
+  // `reload_agent` sets the supervisor's agent_reload_in_progress flag
+  // before killing the child, so EOF is treated as a clean reload
+  // (emits `agent-reloaded`, not `agent-crashed`). The existing
+  // `agent-reloaded` listener (useOsEdges) re-primes via start_agent,
+  // so we don't need to chain an explicit spawn here.
+  invoke("reload_agent").catch((err: unknown) => {
+    // Best-effort. If the restart fails the toggle still applies on
+    // the next manual restart; we just won't get an instant reload.
+    // eslint-disable-next-line no-console
+    console.warn(`reload_required (${reason}): reload_agent failed`, err);
+  });
+};

--- a/src/hooks/bridgeMessageHandlers/types.ts
+++ b/src/hooks/bridgeMessageHandlers/types.ts
@@ -81,6 +81,7 @@ export interface BridgeMessageContext {
   hydrateExtensions: (
     loaded: { name: string; source: string }[],
     failed: { name: string; source: string; error?: string }[],
+    disabled?: string[],
   ) => void;
   hydrateSlashCommands: (
     list: { name: string; description: string; usage?: string }[],

--- a/src/hooks/bridgeMessageHandlers/types.ts
+++ b/src/hooks/bridgeMessageHandlers/types.ts
@@ -35,6 +35,7 @@ export interface DiscoveredSession {
   cwd?: string;
   /** First user message text, trimmed to 60 chars by the bridge. */
   firstUserMessage?: string;
+  customLabel?: string;
 }
 
 export interface RecentSessionItem {

--- a/src/hooks/useExtensionsHydration.ts
+++ b/src/hooks/useExtensionsHydration.ts
@@ -56,6 +56,7 @@ export interface UseExtensionsHydrationActions {
   hydrateExtensions: (
     loaded: { name: string; source: string }[],
     failed: { name: string; source: string; error?: string }[],
+    disabled?: string[],
   ) => void;
   hydrateEventRoutes: (
     routes: { componentId?: string; eventType?: string }[],
@@ -187,6 +188,7 @@ export function useExtensionsHydration(
   function hydrateExtensions(
     loaded: { name: string; source: string }[],
     failed: { name: string; source: string; error?: string }[],
+    disabled: string[] = [],
   ) {
     const sourceLabel = (s: string) =>
       s === "project-directory"
@@ -196,6 +198,12 @@ export function useExtensionsHydration(
           : s === "extension-package"
             ? "package"
             : s;
+    const disabledSet = new Set(disabled);
+    // An extension may appear in `loaded` (live this run) but also be
+    // marked disabled (toggle landed mid-session, takes effect after
+    // restart). Show it in the disabled bucket so the user sees their
+    // pending intent, with a hint that a restart is needed to fully
+    // unload it.
     const items = [
       {
         id: "extension-layout",
@@ -203,18 +211,31 @@ export function useExtensionsHydration(
         hint: "core",
         active: true,
       },
-      ...loaded.map((e) => ({
-        id: `ext:${e.name}`,
-        label: e.name,
-        hint: sourceLabel(e.source),
-        active: true,
-      })),
-      ...failed.map((e) => ({
-        id: `ext-failed:${e.name}`,
-        label: e.name,
-        hint: `${sourceLabel(e.source)} · failed`,
-        active: false,
-      })),
+      ...loaded
+        .filter((e) => !disabledSet.has(e.name))
+        .map((e) => ({
+          id: `ext:${e.name}`,
+          label: e.name,
+          hint: sourceLabel(e.source),
+          active: true,
+        })),
+      ...failed
+        .filter((e) => !disabledSet.has(e.name))
+        .map((e) => ({
+          id: `ext-failed:${e.name}`,
+          label: e.name,
+          hint: `${sourceLabel(e.source)} · failed`,
+          active: false,
+        })),
+      ...disabled.map((name) => {
+        const stillLoaded = loaded.some((e) => e.name === name);
+        return {
+          id: `ext-disabled:${name}`,
+          label: name,
+          hint: stillLoaded ? "disabled · restart" : "disabled",
+          active: false,
+        };
+      }),
     ];
     setState((prev) => {
       const sidebar = (prev.sidebar as Record<string, unknown>) ?? {};

--- a/src/hooks/useProjectOps.ts
+++ b/src/hooks/useProjectOps.ts
@@ -40,6 +40,7 @@ interface DiscoveredSession {
   /** First user message text, trimmed to 60 chars by the bridge. Used to
    *  label sidebar history items meaningfully instead of UUID slices. */
   firstUserMessage?: string;
+  customLabel?: string;
 }
 
 interface SidebarHistoryItem {
@@ -242,9 +243,13 @@ export function useProjectOps(
         const cwdBasename = d.cwd
           ? d.cwd.replace(/[/\\]+$/, "").split(/[/\\]/).pop() ?? ""
           : "";
-        const label = d.firstUserMessage
-          ? d.firstUserMessage.replace(/\s+/g, " ").trim()
-          : cwdBasename || `Session ${d.tabId.slice(0, 8)}`;
+        // Custom label (set via /rename or sidebar context menu) wins
+        // over the auto-derived first-user-message label.
+        const label = d.customLabel
+          ? d.customLabel
+          : d.firstUserMessage
+            ? d.firstUserMessage.replace(/\s+/g, " ").trim()
+            : cwdBasename || `Session ${d.tabId.slice(0, 8)}`;
         return {
           id: d.tabId,
           label,

--- a/src/hooks/useTabs.ts
+++ b/src/hooks/useTabs.ts
@@ -55,6 +55,7 @@ interface DiscoveredSession {
   lastModified: number;
   cwd?: string;
   firstUserMessage?: string;
+  customLabel?: string;
 }
 
 interface NotificationInput {

--- a/src/skills/default-layout/sidebar/index.tsx
+++ b/src/skills/default-layout/sidebar/index.tsx
@@ -48,9 +48,13 @@ interface SidebarContextMenuState {
   label: string;
   // Discriminator so the rendered menu shows the right action. "project"
   // prompts for "Remove from Projects"; "session" prompts for
-  // "Delete session". Set by `openItemContextMenu` based on the
+  // "Delete session". "extension-enabled" / "extension-disabled" prompt
+  // for Disable / Enable. Set by `openItemContextMenu` based on the
   // section + item id.
-  kind: "project" | "session";
+  kind: "project" | "session" | "extension-enabled" | "extension-disabled";
+  /** For `extension-*` kinds, the extension's display name (item id
+   *  minus the `ext:` / `ext-failed:` / `ext-disabled:` prefix). */
+  extensionName?: string;
 }
 
 export function Sidebar({
@@ -106,12 +110,28 @@ export function Sidebar({
     // `session:` (closed) or `tab:` (currently open) → "Delete session".
     // For an open tab, the App-side handler closes the tab first, then
     // deletes the on-disk session — symmetric with the X close button +
-    // explicit delete, just collapsed into one action.
+    // explicit delete, just collapsed into one action. Extensions
+    // (sidebar section "extensions", item ids `ext:` / `ext-failed:` /
+    // `ext-disabled:`) → Disable / Enable.
     let kind: SidebarContextMenuState["kind"] | null = null;
+    let extensionName: string | undefined;
     if (sectionId === "projects") {
       kind = "project";
     } else if (sectionId === "history" && canDeleteHistoryItem(item.id)) {
       kind = "session";
+    } else if (sectionId === "extensions") {
+      if (item.id.startsWith("ext:")) {
+        kind = "extension-enabled";
+        extensionName = item.id.slice("ext:".length);
+      } else if (item.id.startsWith("ext-failed:")) {
+        kind = "extension-enabled";
+        extensionName = item.id.slice("ext-failed:".length);
+      } else if (item.id.startsWith("ext-disabled:")) {
+        kind = "extension-disabled";
+        extensionName = item.id.slice("ext-disabled:".length);
+      }
+      // Hard-coded built-ins (default-layout) have id "extension-layout"
+      // and no toggle — the sidebar core lives in the binary.
     }
     if (!kind) return;
     e.preventDefault();
@@ -125,6 +145,7 @@ export function Sidebar({
       itemId: item.id,
       label: item.label,
       kind,
+      extensionName,
     });
   };
 
@@ -149,6 +170,17 @@ export function Sidebar({
       itemId: contextMenu.itemId,
       sessionId: extractSessionId(contextMenu.itemId),
       label: contextMenu.label,
+    });
+    setContextMenu(null);
+  };
+
+  const toggleContextExtension = (disabled: boolean) => {
+    if (!contextMenu || !contextMenu.extensionName) return;
+    onEvent("toggle-extension", {
+      sectionId: contextMenu.sectionId,
+      itemId: contextMenu.itemId,
+      name: contextMenu.extensionName,
+      disabled,
     });
     setContextMenu(null);
   };
@@ -315,7 +347,7 @@ export function Sidebar({
                   Keeps files on disk
                 </div>
               </>
-            ) : (
+            ) : contextMenu.kind === "session" ? (
               <>
                 <button
                   type="button"
@@ -327,6 +359,34 @@ export function Sidebar({
                 </button>
                 <div className="a2ui-sidebar-context-menu-note">
                   Removes saved transcript
+                </div>
+              </>
+            ) : contextMenu.kind === "extension-enabled" ? (
+              <>
+                <button
+                  type="button"
+                  className="a2ui-sidebar-context-menu-item"
+                  role="menuitem"
+                  onClick={() => toggleContextExtension(true)}
+                >
+                  Disable extension
+                </button>
+                <div className="a2ui-sidebar-context-menu-note">
+                  Restart Aethon to fully unload
+                </div>
+              </>
+            ) : (
+              <>
+                <button
+                  type="button"
+                  className="a2ui-sidebar-context-menu-item"
+                  role="menuitem"
+                  onClick={() => toggleContextExtension(false)}
+                >
+                  Enable extension
+                </button>
+                <div className="a2ui-sidebar-context-menu-note">
+                  Restart Aethon (or /reload) to load
                 </div>
               </>
             )}

--- a/src/skills/default-layout/sidebar/index.tsx
+++ b/src/skills/default-layout/sidebar/index.tsx
@@ -174,6 +174,26 @@ export function Sidebar({
     setContextMenu(null);
   };
 
+  const renameContextSession = () => {
+    if (!contextMenu) return;
+    // Native prompt is intentionally lo-fi — keeps the surface tiny and
+    // matches the existing browser-prompt fallbacks elsewhere
+    // (delete confirmation, project picker errors). A richer modal can
+    // come later without changing the wire format.
+    const next = window.prompt("Rename session", contextMenu.label);
+    if (next === null) {
+      setContextMenu(null);
+      return;
+    }
+    onEvent("rename-session", {
+      sectionId: contextMenu.sectionId,
+      itemId: contextMenu.itemId,
+      sessionId: extractSessionId(contextMenu.itemId),
+      label: next,
+    });
+    setContextMenu(null);
+  };
+
   const toggleContextExtension = (disabled: boolean) => {
     if (!contextMenu || !contextMenu.extensionName) return;
     onEvent("toggle-extension", {
@@ -353,12 +373,20 @@ export function Sidebar({
                   type="button"
                   className="a2ui-sidebar-context-menu-item"
                   role="menuitem"
+                  onClick={renameContextSession}
+                >
+                  Rename session…
+                </button>
+                <button
+                  type="button"
+                  className="a2ui-sidebar-context-menu-item"
+                  role="menuitem"
                   onClick={deleteContextSession}
                 >
                   Delete session…
                 </button>
                 <div className="a2ui-sidebar-context-menu-note">
-                  Removes saved transcript
+                  Delete removes the saved transcript
                 </div>
               </>
             ) : contextMenu.kind === "extension-enabled" ? (

--- a/src/slashCommands.test.ts
+++ b/src/slashCommands.test.ts
@@ -106,6 +106,9 @@ describe("buildBuiltinSlashCommands", () => {
       removeProject: () => false,
       listProjects: () => [],
       activeProject: () => null,
+      reloadAgent: () => Promise.resolve(),
+      renameSession: () => Promise.resolve(),
+      activeTabId: () => "default",
     };
     const extensions = buildBuiltinSlashCommands().find((c) => c.name === "extensions")!;
 
@@ -115,5 +118,80 @@ describe("buildBuiltinSlashCommands", () => {
     expect(notifications).toContain("Installing extension");
     expect(system[0]).toContain("Extension install complete");
     expect(system[0]).toContain("installed output");
+  });
+
+  it("/rename forwards to renameSession with the active tab id", async () => {
+    const calls: { tabId: string; label: string }[] = [];
+    const ctx: SlashCommandContext = {
+      appendSystem: () => {},
+      notify: () => {},
+      clearChat: () => {},
+      setTheme: () => {},
+      listThemes: () => [],
+      setModel: async () => {},
+      resetLayout: () => {},
+      listExtensions: () => [],
+      installExtension: () => Promise.resolve(""),
+      listModels: () => [],
+      toggleTerminal: () => {},
+      toggleSidebar: () => {},
+      activateLayout: () => false,
+      listLayouts: () => [],
+      pickProject: () => Promise.resolve(null),
+      openProject: () => "",
+      setActiveProject: () => false,
+      clearProject: () => {},
+      removeProject: () => false,
+      listProjects: () => [],
+      activeProject: () => null,
+      reloadAgent: () => Promise.resolve(),
+      renameSession: (tabId, label) => {
+        calls.push({ tabId, label });
+        return Promise.resolve();
+      },
+      activeTabId: () => "tab-7",
+    };
+    const rename = buildBuiltinSlashCommands().find((c) => c.name === "rename")!;
+    await rename.run("Refactor pass", ctx);
+    expect(calls).toEqual([{ tabId: "tab-7", label: "Refactor pass" }]);
+  });
+
+  it("/reload calls reloadAgent and toasts", async () => {
+    let reloadCalls = 0;
+    const titles: string[] = [];
+    const ctx: SlashCommandContext = {
+      appendSystem: () => {},
+      notify: (input) => titles.push(input.title),
+      clearChat: () => {},
+      setTheme: () => {},
+      listThemes: () => [],
+      setModel: async () => {},
+      resetLayout: () => {},
+      listExtensions: () => [],
+      installExtension: () => Promise.resolve(""),
+      listModels: () => [],
+      toggleTerminal: () => {},
+      toggleSidebar: () => {},
+      activateLayout: () => false,
+      listLayouts: () => [],
+      pickProject: () => Promise.resolve(null),
+      openProject: () => "",
+      setActiveProject: () => false,
+      clearProject: () => {},
+      removeProject: () => false,
+      listProjects: () => [],
+      activeProject: () => null,
+      reloadAgent: () => {
+        reloadCalls += 1;
+        return Promise.resolve();
+      },
+      renameSession: () => Promise.resolve(),
+      activeTabId: () => null,
+    };
+    const reload = buildBuiltinSlashCommands().find((c) => c.name === "reload")!;
+    expect(reload).toBeDefined();
+    await reload.run("", ctx);
+    expect(reloadCalls).toBe(1);
+    expect(titles).toContain("Reloading agent…");
   });
 });

--- a/src/slashCommands.ts
+++ b/src/slashCommands.ts
@@ -52,6 +52,17 @@ export interface SlashCommandContext {
   removeProject: (id: string) => boolean;
   listProjects: () => { id: string; label: string; path: string }[];
   activeProject: () => { id: string; label: string; path: string } | null;
+  /** Hard-reload the agent bridge subprocess. Goes through the same
+   *  supervisor path as the right-click "Disable extension" toggle:
+   *  the new bridge re-discovers extensions, themes, slash commands,
+   *  re-reads disabled-extensions.json, and emits a fresh `ready`. */
+  reloadAgent: () => Promise<void>;
+  /** Rename a session by tabId. Empty `label` clears the custom label
+   *  and falls back to the auto-derived first-user-message label. */
+  renameSession: (tabId: string, label: string) => Promise<void>;
+  /** Currently active tab id, or null when none. Used by `/rename` so
+   *  no-arg target inference can hit the right session. */
+  activeTabId: () => string | null;
 }
 
 /** A single completion option for a slash command's argument. The picker
@@ -151,6 +162,56 @@ export function buildBuiltinSlashCommands(): SlashCommand[] {
       run: (_args, ctx) => {
         ctx.resetLayout();
         ctx.notify({ title: "Layout reset", kind: "success" });
+      },
+    },
+    {
+      name: "reload",
+      description:
+        "Reload the agent bridge — re-discover extensions, themes, and slash commands",
+      run: async (_args, ctx) => {
+        ctx.notify({
+          title: "Reloading agent…",
+          kind: "info",
+        });
+        try {
+          await ctx.reloadAgent();
+        } catch (err) {
+          ctx.notify({
+            title: "Reload failed",
+            message: String(err),
+            kind: "error",
+          });
+        }
+      },
+    },
+    {
+      name: "rename",
+      description:
+        "Rename the active session (empty input restores the auto-label)",
+      usage: "[new label]",
+      run: async (args, ctx) => {
+        const tabId = ctx.activeTabId();
+        if (!tabId) {
+          ctx.notify({
+            title: "No active session",
+            kind: "warning",
+          });
+          return;
+        }
+        const label = args.trim();
+        try {
+          await ctx.renameSession(tabId, label);
+          ctx.notify({
+            title: label ? `Renamed to “${label}”` : "Restored default label",
+            kind: "success",
+          });
+        } catch (err) {
+          ctx.notify({
+            title: "Rename failed",
+            message: String(err),
+            kind: "error",
+          });
+        }
       },
     },
     {


### PR DESCRIPTION
## Summary

Tracks down a real broken project extension (`mold:image-gallery` setting 184 MB into `/repoGallery` on a tight loop) and fixes the surrounding resilience gaps that turned one buggy extension into an unrecoverable UI. Adds the missing escape hatches: right-click to disable a misbehaving extension, `/reload` to re-discover everything, right-click + `/rename` to label sessions sensibly.

Four commits, 600 tests green, codex peer review run + P2 findings addressed.

### `fix(agent)` — make extensions fail gracefully and stop spamming notifications
- **Widen `AethonExtensionApi` to alias `AethonApi`.** The 4-method shim (`registerComponent`, `setState`, `registerTheme`, `onUnload`) never grew when sidebar/themes/events/layouts were added, so every extension following the documented contract crashed on `api.registerSidebarSection is not a function`. There's no sandbox between bridge and extension anyway — they share a Bun runtime. Aliasing makes the type match reality.
- **Track failed extension files alongside successful ones.** The loader's dedupe set only carried successes, so each `tab_open` / `set_project` re-imported the same broken file and re-emitted lifecycle warnings. A new parallel `failedFiles` set is populated on import / register failure; cleared on project unload so a new project still retries.
- **Wire a single shared `extStateLogLimiter` through `stateMutationDeps`.** Every `setState` call was building a fresh limiter that always logged the first invocation, defeating the 60s dedup window entirely. Plus a sticky per-(ext+kind+path) gate on the user-facing `extension_runtime_error` event so the misbehaving toast fires once per problem (not once per minute, not once per call).

### `feat(extensions)` — right-click sidebar to disable an extension, instant reload
- **Persisted disabled list** at `<userDir>/disabled-extensions.json`, honored by both user-dir and project-dir loaders + extension packages on the first pass after boot.
- **New `set_extension_disabled` bridge message** + new `reload_agent` Tauri command. `reload_agent` sets the supervisor's `agent_reload_in_progress` flag *only when there's a child to kill* (the codex P2 fix) before killing, so EOF emits `agent-reloaded` (not `agent-crashed`); the existing `useOsEdges` listener re-primes via `start_agent`. The new bridge boots, reads the disabled file, and the loader honors it.
- **Sidebar context menu** on each extension row offers Disable / Enable based on the row's prefix (`ext:` vs `ext-disabled:`). SYS chat bubble + `disabledExtensions` field on the runtime snapshot mean the agent's next-turn system prompt sees the change.

### `feat(sessions)` — rename a session via right-click or `/rename`
- **Per-session `label.txt`** at `<sessionsDir>/<tabId>/label.txt`. `customLabel` wins over the auto-derived `firstUserMessage` everywhere it's surfaced (sidebar history, palette, top tab strip).
- **New `set_session_label` bridge message** persists + refreshes the discovered-tabs cache + re-emits `ready`.
- **Sidebar context menu** adds "Rename session…" above the existing "Delete session…" (native `prompt()` for the input — minimal surface matching the existing delete flow).
- **`/rename [new label]`** slash command using `activeTabId()` from context. Empty input restores the auto-label.
- Both call sites apply the new label optimistically to the matching open tab so the rename is instant for `tab:` rows too — not just the closed-session bucket (codex P2 fix).

### `fix(extension-resilience)` — codex P2 findings
- `reload_agent` no longer leaves `agent_reload_in_progress` stale when there's no child to kill (would have swallowed the next genuine crash).
- `saveDisabledExtensions` throws on write failure; the dispatcher reverts the in-memory toggle and surfaces an error toast instead of pretending success and losing the user's intent on the next bridge reload.
- Renaming an active tab now updates the open-tab label optimistically (was only updating the closed-session bucket).

## Test plan
- [x] `check` (clippy + tsc + ESLint + cargo test + vitest) — 88 files / 600 tests green
- [x] Manual UAT: disable / re-enable `mold:image-gallery` from the sidebar; toast pops once per problem; bridge reloads cleanly with `agent-reloaded`; SYS bubble records the toggle; persistence file reflects state across restarts
- [x] Codex peer review (`codex review --base main`) — all P2 findings addressed in the final commit
- [ ] Re-run codex review against the final commit before merge