### PR TITLE
Close M5/M6 abstraction-integrity gaps — type-keyed routing, non-blocking hot-reload, opt-in chat chrome

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -374,6 +374,28 @@ or `type:<componentType>`. New built-in handlers go in
 `eventRoutes/<name>.ts` + a happy-path test, then registered under the
 matching key(s) in `BUILTIN_ROUTE_TABLE`.
 
+**Always key chrome-composite handlers by `type:<componentType>`, not
+`id:`** — that's how `aethon.registerComponent("<type>", custom)` and
+custom-layout payloads with renamed instances stay routable. Use
+`id:<…>` only for genuine instance-specific dispatch (none today). The
+12 chrome composites (sidebar, command-palette, settings-panel,
+search-panel, notification-stack, chat-input, empty-state,
+terminal-panel, tab-strip, model-picker, appearance-menu,
+share-mode-badge, shell-canvas) all dispatch by type as of #N.
+
+### Hot-reload doesn't kill in-flight prompts
+
+The Rust file-watcher (`commands/extensions.rs::run_debounce_worker`)
+no longer SIGKILLs the bun child when an extension file changes.
+Instead it writes `{"type":"reload_request"}` to the child's stdin.
+The bridge sets `state.reloadPending`, drains active
+`tab.promptInFlight`, writes a `{"type":"_reload_done"}` sentinel to
+stdout, and `process.exit(0)`s. The supervisor's stdout reader peeks
+for that sentinel, sets the reload-in-progress flag, emits
+`agent-reloaded`, and the next IPC call respawns. So an extension
+drop never aborts a user's LLM turn. The fallback hard-kill path
+remains for the case where stdin is wedged.
+
 ## Conventions
 
 - **Conventional Commits** for all messages: `feat(scope):`, `fix(scope):`, etc.

--- a/SPEC.md
+++ b/SPEC.md
@@ -310,12 +310,40 @@ then sharing, then polish.
 #### Abstraction integrity
 
 - [x] **App-root overlays go through the registry** — `command-palette`,
-      `notification-stack`, `settings-panel`, `search-panel`, and the
-      `share-mode-badge` are mounted via `<RegistryComponent type="…">` (or
-      `useSkillRegistry().resolve(…)` inside their host) so a skill can
-      replace any of them with `aethon.registerComponent("<type>", custom)`.
-      Previously these were direct-imported in `App.tsx`, silently defeating
-      the documented override path.
+      `notification-stack`, `settings-panel`, and `search-panel` are
+      mounted at App root via `<RegistryComponent type="…">`; the
+      `share-mode-badge` is mounted inline inside `shell/canvas.tsx`
+      (also via `<RegistryComponent>`, so skills can still replace it
+      with `aethon.registerComponent("share-mode-badge", custom)`).
+      Previously the App-root overlays were direct-imported in
+      `App.tsx`, silently defeating the documented override path.
+- [x] **Built-in event routes dispatch by type, not id** — every
+      chrome composite (`sidebar`, `command-palette`, `settings-panel`,
+      `search-panel`, `notification-stack`, `chat-input`, `empty-state`,
+      `terminal-panel`, `tab-strip`, `model-picker`, `appearance-menu`,
+      `share-mode-badge`, `shell-canvas`) has its built-in handler
+      registered under `type:<componentType>` in
+      `src/eventRoutes/index.ts`. A custom layout payload may rename
+      the instance (`{id: "primary-side-rail", type: "sidebar"}`) and
+      events still route correctly. Previously each handler also had a
+      defensive `if (component.id !== "<literal>") return false` guard
+      that broke the override contract; those guards are gone and
+      `index.test.ts` covers eight renamed-instance regression cases.
+- [x] **`main-canvas` chat mode is opt-in** — binding `messages`
+      enables chat-history rendering, the empty hint, and the "↓
+      latest" pill; omitting `messages` (and binding only `slot`)
+      makes the canvas a pure scroll viewport so non-chat extension
+      hosts (image gallery, dashboard, …) don't inherit chat chrome.
+- [x] **Hot-reload no longer kills in-flight prompts** — the Rust
+      file-watcher now sends `{type:"reload_request"}` over the
+      bridge's stdin instead of SIGKILLing the bun child. The bridge
+      drains active prompts (`tab.promptInFlight`), writes a
+      `{"type":"_reload_done"}` sentinel, and exits cleanly. The
+      supervisor's stdout reader sees the sentinel, sets the
+      reload-in-progress flag, emits `agent-reloaded`, and the
+      frontend respawns lazily on the next request. Previous
+      behaviour aborted the user's LLM turn whenever an extension
+      file changed.
 
 #### Documentation + tests
 

--- a/agent/dispatcher.ts
+++ b/agent/dispatcher.ts
@@ -267,6 +267,37 @@ export async function runDispatcher(
   const stateMutationDeps = { send: deps.send };
   const notifDeps = { send: deps.send };
 
+  /** If a reload was requested AND no tab has a prompt in flight, write
+   *  the `_reload_done` sentinel and exit cleanly. The Rust supervisor's
+   *  stdout reader watches for the sentinel so it can flag the upcoming
+   *  EOF as an intentional reload (not a crash) and emit `agent-reloaded`.
+   *  The next chat / agent_command request lazily respawns the bridge with
+   *  the new extension state.
+   *
+   *  Idempotent — safe to call after every prompt completion. */
+  function maybeExitForReload(
+    state: AethonAgentState,
+    deps: DispatcherDeps,
+  ): void {
+    if (!state.reloadPending) return;
+    for (const tab of state.tabs.values()) {
+      if (tab.promptInFlight) return;
+    }
+    deps.send({ type: "_reload_done" });
+    // Flush stdout before exiting so the supervisor sees the sentinel
+    // before the EOF. process.stdout is non-blocking on a pipe, so a
+    // synchronous .write() returning false would otherwise let the EOF
+    // race the sentinel line.
+    if (typeof process.stdout.write === "function") {
+      try {
+        process.stdout.write("");
+      } catch {
+        /* ignore */
+      }
+    }
+    process.exit(0);
+  }
+
   for await (const line of rl) {
     const trimmed = line.trim();
     if (!trimmed) continue;
@@ -302,6 +333,15 @@ export async function runDispatcher(
         case "report": {
           markFrontendReady(state);
           emitReady(state, deps);
+          break;
+        }
+        case "reload_request": {
+          // Rust file-watcher asked us to reload because an extension
+          // file changed. Drain in-flight prompts first, then exit so
+          // the supervisor respawns us cleanly. Killing the bridge
+          // mid-prompt would lose the user's turn — see issue #N.
+          state.reloadPending = true;
+          maybeExitForReload(state, deps);
           break;
         }
         case "mutation_ack": {
@@ -453,6 +493,10 @@ export async function runDispatcher(
         if (!queued && state.currentAgentTabId === tabId) {
           state.currentAgentTabId = undefined;
         }
+        // If a hot-reload was deferred while this prompt was running,
+        // honor it now. Idempotent — does nothing if no reload is
+        // pending or another tab still has a prompt in flight.
+        maybeExitForReload(state, deps);
       });
     if (queued) {
       deps.send({ type: "queued", tabId });

--- a/agent/state.ts
+++ b/agent/state.ts
@@ -434,6 +434,13 @@ export class AethonAgentState {
    *  draft, messagesCount). */
   readonly frontendState = new Map<string, unknown>();
 
+  // -- Hot-reload coordination --------------------------------------------
+  /** Set when the Rust file watcher sends `reload_request`. The bridge
+   *  drains in-flight prompts then exits cleanly so the supervisor can
+   *  respawn it with fresh extensions on the next request — instead of
+   *  the watcher SIGKILLing mid-prompt. */
+  reloadPending = false;
+
   constructor(opts: AethonAgentStateOptions) {
     this.userDir = opts.userDir;
     this.stateFile = opts.stateFile;

--- a/docs/aethon-agent/components.md
+++ b/docs/aethon-agent/components.md
@@ -17,6 +17,32 @@ Every component looks like:
 
 `children` is optional. `id` MUST be unique within the tree.
 
+## Override identity — type, not id
+
+When you replace a chrome composite via
+`aethon.registerComponent("<type>", custom)`, the override is keyed by
+**component type**, not instance id. The built-in event-route table
+dispatches under `type:<componentType>` for every chrome composite
+(`sidebar`, `command-palette`, `settings-panel`, `search-panel`,
+`notification-stack`, `chat-input`, `empty-state`, `terminal-panel`,
+`tab-strip`, `model-picker`, `appearance-menu`, `share-mode-badge`,
+`shell-canvas`), so a custom layout payload may rename the instance:
+
+```json
+{ "id": "primary-side-rail", "type": "sidebar", "props": { … } }
+```
+
+Events from `primary-side-rail` still route to the built-in sidebar
+handler because the dispatcher matches `type: "sidebar"`. The same
+holds for any registered override — preserve the canonical type and
+the wiring works; the id is yours to choose.
+
+The 19 primitives (`text`, `heading`, `paragraph`, `code`, `card`,
+`container`, `divider`, `button`, `text-input`, `date-picker`,
+`select`, `checkbox`, `slider`, `table`, `list`, `image`, `icon`,
+`form`, `form-field`) are intentionally NOT overridable — they are the
+substrate composites are built from.
+
 ## Data Binding via `$ref`
 
 Anywhere a prop accepts a value, you can substitute a JSON-Pointer
@@ -758,7 +784,7 @@ events for extension handlers to observe.
 {
   area?: string,
   slot?: string,                    // pointer to live A2UI subtree
-  messages?: { $ref: string },      // chat history binding
+  messages?: { $ref: string },      // chat history binding (optional)
   emptyHint?: StringValue,          // shown when no messages + no live subtree
   components?: ComponentTree[],
 }
@@ -768,6 +794,13 @@ The default chat canvas. Most extensions don't need to touch this — to
 add ad-hoc UI, return a per-message A2UI payload from the agent or set
 state on a bound `$ref`. Override `emptyHint` to show a different
 welcome line when the canvas is empty.
+
+**Chat mode is opt-in.** If you bind `messages`, the canvas renders
+the chat history, the empty hint, and the "↓ latest" sticky-scroll
+pill. If you OMIT `messages` and bind only `slot`, the canvas is a
+pure scroll viewport — no chat chrome, no pill. That's the right
+shape for non-chat hosts (image galleries, dashboards, custom panes)
+that just need a scroll container.
 
 For progressive UI, seed the canvas slot with an A2UI payload and patch
 nested paths as work completes:

--- a/src-tauri/src/commands/extensions.rs
+++ b/src-tauri/src/commands/extensions.rs
@@ -423,11 +423,21 @@ struct DebounceMsg {
 }
 
 /// Single-thread debounce worker — collapses bursts of file events
-/// into one agent kill after the channel goes quiet for `settle_ms`.
+/// into one reload request after the channel goes quiet for `settle_ms`.
 /// Each new message resets the timeout; the largest settle requested
 /// across the burst wins (so a node_modules event that arrives during
 /// an extension burst doesn't get prematurely fired).
+///
+/// Reload mechanism (changed 2026-05): instead of SIGKILLing the bun
+/// child mid-prompt — which loses the user's in-flight LLM turn — we
+/// send a `{"type":"reload_request"}` line over stdin. The bridge
+/// drains active prompts, writes a `_reload_done` sentinel to stdout,
+/// and exits cleanly. The supervisor's stdout reader watches for the
+/// sentinel and flags the upcoming EOF as an intentional reload so
+/// the frontend gets `agent-reloaded` (not `agent-crashed`). The next
+/// IPC call lazily respawns with fresh extension state.
 fn run_debounce_worker(rx: std::sync::mpsc::Receiver<DebounceMsg>, app: AppHandle) {
+    use std::io::Write;
     use std::sync::mpsc::RecvTimeoutError;
 
     loop {
@@ -449,24 +459,47 @@ fn run_debounce_worker(rx: std::sync::mpsc::Receiver<DebounceMsg>, app: AppHandl
                 Err(RecvTimeoutError::Disconnected) => return,
             }
         }
-        // Quiet — fire the kill once.
+        // Quiet — ask the bridge to drain & respawn. Holds the child
+        // alive (`as_mut`, not `take`) so an in-flight prompt's stdin
+        // pipe stays open while pi finishes the turn.
         let state: State<'_, AgentProcess> = app.state();
         if let Ok(mut guard) = state.0.lock()
-            && let Some(mut child) = guard.take()
+            && let Some(child) = guard.as_mut()
         {
+            // Capture pid before the mutable borrow on `child.stdin`
+            // so we can log it without the borrow-checker complaining
+            // about overlapping immutable + mutable borrows of `child`.
             let pid = child.id();
-            // Mark this kill as intentional so the stdout reader
-            // doesn't surface it as a crash. The reader resets the
-            // flag on EOF.
-            let reload_flag = agent_reload_in_progress(&app);
-            reload_flag.store(true, std::sync::atomic::Ordering::Release);
-            let _ = child.kill();
-            let _ = child.wait();
-            let _ = app.emit("agent-reloaded", "");
-            tracing::info!(
-                target: "aethon::agent_watch",
-                "killed pid={pid} after {settle}ms settle; will respawn on next request (last paths={last_paths:?})",
-            );
+            let write_result = match child.stdin.as_mut() {
+                Some(stdin) => writeln!(stdin, "{{\"type\":\"reload_request\"}}")
+                    .and_then(|_| stdin.flush()),
+                None => Err(std::io::Error::other("agent stdin closed")),
+            };
+            match write_result {
+                Ok(()) => {
+                    tracing::info!(
+                        target: "aethon::agent_watch",
+                        "asked pid={pid} to reload after {settle}ms settle (last paths={last_paths:?})",
+                    );
+                }
+                Err(err) => {
+                    // Stdin is closed — child is gone or wedged. Fall
+                    // back to the legacy hard-kill so the next request
+                    // lazily respawns. Mark intentional so the stdout
+                    // reader emits agent-reloaded, not agent-crashed.
+                    tracing::warn!(
+                        target: "aethon::agent_watch",
+                        "reload_request write failed for pid={pid}: {err}; falling back to kill",
+                    );
+                    let reload_flag = agent_reload_in_progress(&app);
+                    reload_flag.store(true, std::sync::atomic::Ordering::Release);
+                    if let Some(mut dead) = guard.take() {
+                        let _ = dead.kill();
+                        let _ = dead.wait();
+                    }
+                    let _ = app.emit("agent-reloaded", "");
+                }
+            }
         }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -304,6 +304,21 @@ fn ensure_agent_spawned(guard: &mut Option<Child>, app: &AppHandle) -> Result<()
         for line in reader.lines() {
             match line {
                 Ok(text) => {
+                    // Sentinel from the bridge meaning "I'm about to
+                    // exit cleanly because the watcher asked me to
+                    // reload." Set the flag BEFORE the EOF arrives so
+                    // the post-loop handler treats it as intentional,
+                    // and emit `agent-reloaded` here so the frontend
+                    // can clear waiting state and respawn lazily.
+                    if text.contains("\"_reload_done\"") {
+                        reload_flag_stdout
+                            .store(true, std::sync::atomic::Ordering::Release);
+                        let _ = app_stdout.emit("agent-reloaded", "");
+                        // Don't forward the sentinel — it's bridge↔
+                        // supervisor-internal and would confuse the
+                        // frontend's agent-response router.
+                        continue;
+                    }
                     let _ = app_stdout.emit("agent-response", text);
                 }
                 Err(_) => break,

--- a/src/eventRoutes/chatInput.test.ts
+++ b/src/eventRoutes/chatInput.test.ts
@@ -41,12 +41,8 @@ describe("handleChatInput", () => {
     expect(mocks.stopPrompt).toHaveBeenCalledTimes(1);
   });
 
-  it("returns false for non-chat-input components", async () => {
-    const { ctx } = buildRouteFixture();
-    const handled = await handleChatInput(
-      { component: { id: "sidebar" }, eventType: "submit" },
-      ctx,
-    );
-    expect(handled).toBe(false);
-  });
+  // Wrong-id rejection is no longer the handler's responsibility — the
+  // route table dispatches by `type:chat-input`, so a non-chat-input
+  // event simply never reaches this handler. See index.test.ts for the
+  // type-keyed routing contract.
 });

--- a/src/eventRoutes/chatInput.ts
+++ b/src/eventRoutes/chatInput.ts
@@ -2,12 +2,14 @@ import type { EventRouteHandler } from "./types";
 
 /** chat-input: submit forwards to native sendChat (replacing the
  *  bridge round-trip), change persists the unsent draft into the
- *  active tab record, cancel maps to stopPrompt. */
+ *  active tab record, cancel maps to stopPrompt.
+ *
+ *  Routed by `type:chat-input` so a registry override (or a layout
+ *  payload that renames the composer instance) still routes events. */
 export const handleChatInput: EventRouteHandler = async (
-  { component, eventType, data },
+  { eventType, data },
   ctx,
 ) => {
-  if (component.id !== "chat-input") return false;
   if (eventType === "submit") {
     const value = (data as { value?: string } | undefined)?.value ?? "";
     await ctx.sendChat(value);

--- a/src/eventRoutes/index.test.ts
+++ b/src/eventRoutes/index.test.ts
@@ -25,7 +25,7 @@ describe("dispatchEvent — precedence contract", () => {
     });
     const handled = await dispatchEvent(
       {
-        component: { id: "notification-stack" },
+        component: { id: "notification-stack", type: "notification-stack" },
         eventType: "action",
         data: { id: "nid-1", action: "shell-write-allow:req-1" },
       },
@@ -44,7 +44,10 @@ describe("dispatchEvent — precedence contract", () => {
       extensionRoutes: [{ componentId: "settings-panel" }],
     });
     const handled = await dispatchEvent(
-      { component: { id: "settings-panel" }, eventType: "close" },
+      {
+        component: { id: "settings-panel", type: "settings-panel" },
+        eventType: "close",
+      },
       ctx,
     );
     // false = renderer forwards to bridge so the extension's
@@ -60,7 +63,7 @@ describe("dispatchEvent — precedence contract", () => {
     });
     const handled = await dispatchEvent(
       {
-        component: { id: "chat-input" },
+        component: { id: "chat-input", type: "chat-input" },
         eventType: "submit",
         data: { value: "hi" },
       },
@@ -74,7 +77,7 @@ describe("dispatchEvent — precedence contract", () => {
     const { ctx, mocks } = buildRouteFixture();
     const handled = await dispatchEvent(
       {
-        component: { id: "chat-input" },
+        component: { id: "chat-input", type: "chat-input" },
         eventType: "submit",
         data: { value: "hello" },
       },
@@ -113,7 +116,7 @@ describe("dispatchEvent — precedence contract", () => {
     const { ctx, mocks } = buildRouteFixture();
     const handled = await dispatchEvent(
       {
-        component: { id: "notification-stack" },
+        component: { id: "notification-stack", type: "notification-stack" },
         eventType: "dismiss",
         data: { id: "stranger" },
       },
@@ -122,5 +125,123 @@ describe("dispatchEvent — precedence contract", () => {
     expect(handled).toBe(true);
     // Built-in path called dismissNotification once.
     expect(mocks.dismissNotification).toHaveBeenCalledWith("stranger");
+  });
+});
+
+/** Type-keyed routing contract — closes the abstraction-integrity gap
+ *  identified in the M5/M6 audit. A custom layout payload (or a skill
+ *  override) may rename the chrome-composite instance; events should
+ *  still route to the correct built-in handler because the route table
+ *  keys on `type:`, not `id:`. */
+describe("dispatchEvent — chrome composites route by type, not id", () => {
+  it("renamed command-palette instance still routes selection", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    const item = { kind: "tab" as const, tabId: "abc", label: "tab abc" };
+    const handled = await dispatchEvent(
+      {
+        // A skill swapped command-palette and assigned its own id.
+        component: { id: "primary-cmd-deck", type: "command-palette" },
+        eventType: "select",
+        data: { item },
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.runPaletteItem).toHaveBeenCalledWith(item);
+  });
+
+  it("renamed sidebar instance still routes select to handleSectionedSelect", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    const handled = await dispatchEvent(
+      {
+        component: { id: "primary-side-rail", type: "sidebar" },
+        eventType: "select",
+        data: { sectionId: "themes", itemId: "ember" },
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.setTheme).toHaveBeenCalledWith("ember");
+  });
+
+  it("renamed settings-panel instance still routes close", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    const handled = await dispatchEvent(
+      {
+        component: { id: "config-overlay", type: "settings-panel" },
+        eventType: "close",
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.closeSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it("renamed search-panel instance still routes close", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    const handled = await dispatchEvent(
+      {
+        component: { id: "history-finder", type: "search-panel" },
+        eventType: "close",
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.closeSessionSearch).toHaveBeenCalledTimes(1);
+  });
+
+  it("renamed notification-stack instance still dismisses", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    const handled = await dispatchEvent(
+      {
+        component: { id: "toast-rail", type: "notification-stack" },
+        eventType: "dismiss",
+        data: { id: "nid-9" },
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.dismissNotification).toHaveBeenCalledWith("nid-9");
+  });
+
+  it("renamed empty-state instance still routes new-tab", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    const handled = await dispatchEvent(
+      {
+        component: { id: "welcome-card", type: "empty-state" },
+        eventType: "new-tab",
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.newTab).toHaveBeenCalledTimes(1);
+  });
+
+  it("renamed model-picker instance still routes setModel", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    const handled = await dispatchEvent(
+      {
+        component: { id: "header-model-dropdown", type: "model-picker" },
+        eventType: "select",
+        data: { sectionId: "models", itemId: "anthropic/claude-opus-4-7" },
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.setModel).toHaveBeenCalledWith("anthropic/claude-opus-4-7");
+  });
+
+  it("renamed chat-input instance still routes submit", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    const handled = await dispatchEvent(
+      {
+        component: { id: "composer-1", type: "chat-input" },
+        eventType: "submit",
+        data: { value: "hello" },
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.sendChat).toHaveBeenCalledWith("hello");
   });
 });

--- a/src/eventRoutes/index.ts
+++ b/src/eventRoutes/index.ts
@@ -48,18 +48,23 @@ import {
 /** Lookup table for built-in routes. Keys are `id:<componentId>` or
  *  `type:<componentType>`. The dispatcher computes both keys for an
  *  event and concatenates the matched handler lists. Order within a
- *  list is the order of declaration here. */
+ *  list is the order of declaration here.
+ *
+ *  Chrome composites are keyed by **type** so a custom layout payload
+ *  (or a `aethon.registerComponent(<type>, …)` override) that renames
+ *  the instance still routes correctly. `id:<…>` is reserved for true
+ *  instance-specific routing — none today. */
 export const BUILTIN_ROUTE_TABLE: ReadonlyMap<string, readonly EventRouteHandler[]> =
   new Map<string, readonly EventRouteHandler[]>([
     // notification-stack: `handleShellConsent` is run separately as the
     // top-precedence gate; the general handler runs here.
-    ["id:notification-stack", [handleNotifications]],
-    ["id:settings-panel", [handleSettings]],
-    ["id:search-panel", [handleSearch]],
-    ["id:command-palette", [handlePalette]],
-    ["id:chat-input", [handleChatInput]],
-    ["id:empty-state", [handleEmptyState]],
-    ["id:sidebar", [
+    ["type:notification-stack", [handleNotifications]],
+    ["type:settings-panel", [handleSettings]],
+    ["type:search-panel", [handleSearch]],
+    ["type:command-palette", [handlePalette]],
+    ["type:chat-input", [handleChatInput]],
+    ["type:empty-state", [handleEmptyState]],
+    ["type:sidebar", [
       handleSidebarResize,
       handleSidebarResizeEnd,
       handleSidebarRemoveProject,
@@ -68,8 +73,8 @@ export const BUILTIN_ROUTE_TABLE: ReadonlyMap<string, readonly EventRouteHandler
       handleSidebarToggleExtension,
       handleSectionedSelect,
     ]],
-    ["id:model-picker", [handleSectionedSelect]],
-    ["id:appearance-menu", [handleSectionedSelect]],
+    ["type:model-picker", [handleSectionedSelect]],
+    ["type:appearance-menu", [handleSectionedSelect]],
     ["type:terminal-panel", [handleTerminalPanel]],
     ["type:tab-strip", [handleTabStrip]],
     ["type:shell-canvas", [handleShareModeCycle]],

--- a/src/eventRoutes/notifications.test.ts
+++ b/src/eventRoutes/notifications.test.ts
@@ -90,12 +90,8 @@ describe("handleNotifications", () => {
     expect((args as { tabId: string }).tabId).toBe("tab-active");
   });
 
-  it("returns false for non-notification-stack components", async () => {
-    const { ctx } = buildRouteFixture();
-    const handled = await handleNotifications(
-      { component: { id: "settings-panel" }, eventType: "action" },
-      ctx,
-    );
-    expect(handled).toBe(false);
-  });
+  // Wrong-component rejection is no longer this handler's job — the
+  // route table dispatches by `type:notification-stack`, so an event
+  // for a different type never reaches handleNotifications. See
+  // index.test.ts for the type-keyed routing contract.
 });

--- a/src/eventRoutes/notifications.ts
+++ b/src/eventRoutes/notifications.ts
@@ -15,10 +15,9 @@ import type { EventRouteHandler } from "./types";
  *  • everything else with an action — forward to the bridge as a
  *    `notification.invoke` a2ui event for extension matchers. */
 export const handleNotifications: EventRouteHandler = (
-  { component, eventType, data },
+  { eventType, data },
   ctx,
 ) => {
-  if (component.id !== "notification-stack") return false;
   const id = (data as { id?: string } | undefined)?.id;
 
   if ((eventType === "dismiss" || eventType === "expire") && id) {

--- a/src/eventRoutes/palette.ts
+++ b/src/eventRoutes/palette.ts
@@ -4,12 +4,14 @@ import type { PaletteItem } from "../skills/default-layout/palette-items";
 /** command-palette renders at App root and never goes through the
  *  dispatch_a2ui bridge (no agent counterpart to invoke). Events land
  *  here directly. Selection runs the item *after* closing the palette
- *  so a slow handler doesn't leave the result obscured. */
+ *  so a slow handler doesn't leave the result obscured.
+ *
+ *  Routed by `type:command-palette` (not id) so a custom layout payload
+ *  that renames the palette instance still routes correctly. */
 export const handlePalette: EventRouteHandler = (
-  { component, eventType, data },
+  { eventType, data },
   ctx,
 ) => {
-  if (component.id !== "command-palette") return false;
   if (eventType === "close") {
     ctx.closePalette();
     return true;

--- a/src/eventRoutes/search.ts
+++ b/src/eventRoutes/search.ts
@@ -2,12 +2,13 @@ import type { EventRouteHandler } from "./types";
 
 /** search-panel renders at App root. Search results land via the
  *  Tauri search_sessions command, not the bridge — events here drive
- *  the overlay's local state. */
+ *  the overlay's local state.
+ *
+ *  Routed by `type:search-panel` (registry override key), not id. */
 export const handleSearch: EventRouteHandler = (
-  { component, eventType, data },
+  { eventType, data },
   ctx,
 ) => {
-  if (component.id !== "search-panel") return false;
   if (eventType === "close") {
     ctx.closeSessionSearch();
     return true;

--- a/src/eventRoutes/settings.test.ts
+++ b/src/eventRoutes/settings.test.ts
@@ -37,12 +37,8 @@ describe("handleSettings", () => {
     expect(mocks.saveSettings).toHaveBeenCalledTimes(1);
   });
 
-  it("returns false for other components", async () => {
-    const { ctx } = buildRouteFixture();
-    const handled = await handleSettings(
-      { component: { id: "search-panel" }, eventType: "close" },
-      ctx,
-    );
-    expect(handled).toBe(false);
-  });
+  // Wrong-component rejection is no longer this handler's job — the
+  // route table dispatches by `type:settings-panel`, so an event for a
+  // different type never reaches handleSettings. See index.test.ts for
+  // the type-keyed routing contract.
 });

--- a/src/eventRoutes/settings.ts
+++ b/src/eventRoutes/settings.ts
@@ -1,12 +1,15 @@
 import type { EventRouteHandler } from "./types";
 
 /** settings-panel renders at App root and never goes through the
- *  bridge — events drive the panel's pending overlay directly. */
+ *  bridge — events drive the panel's pending overlay directly.
+ *
+ *  Routed by `type:settings-panel` so an extension's
+ *  `aethon.registerComponent("settings-panel", custom)` override still
+ *  receives events even when the layout payload renames the instance. */
 export const handleSettings: EventRouteHandler = (
-  { component, eventType, data },
+  { eventType, data },
   ctx,
 ) => {
-  if (component.id !== "settings-panel") return false;
   if (eventType === "close") {
     ctx.closeSettings();
     return true;

--- a/src/eventRoutes/sidebar.ts
+++ b/src/eventRoutes/sidebar.ts
@@ -13,12 +13,16 @@ interface RecentSessionItem {
  *  /layout/columns. Layouts shape grid columns as either
  *  "${SIDEBAR}px minmax(0,1fr)" or
  *  "${SIDEBAR}px minmax(0,1fr) ${INSPECTOR}px" — replace just the first
- *  token so non-sidebar columns survive the rewrite. */
+ *  token so non-sidebar columns survive the rewrite.
+ *
+ *  All sidebar handlers below are routed by `type:sidebar` (registry
+ *  override key) so a custom layout that renames the sidebar instance
+ *  still receives these events — only the eventType filters apply. */
 export const handleSidebarResize: EventRouteHandler = (
-  { component, eventType, data },
+  { eventType, data },
   ctx,
 ) => {
-  if (component.id !== "sidebar" || eventType !== "resize") return false;
+  if (eventType !== "resize") return false;
   const next = (data as { width?: number } | undefined)?.width;
   if (typeof next === "number") {
     ctx.setState((prev) => {
@@ -39,10 +43,10 @@ export const handleSidebarResize: EventRouteHandler = (
  *  value the resize listener just wrote) so a single source of truth
  *  wins. */
 export const handleSidebarResizeEnd: EventRouteHandler = (
-  { component, eventType },
+  { eventType },
   ctx,
 ) => {
-  if (component.id !== "sidebar" || eventType !== "resize-end") return false;
+  if (eventType !== "resize-end") return false;
   const layout =
     (ctx.stateRef.current.layout as Record<string, unknown> | undefined) ?? {};
   const cols = (layout.columns as string | undefined) ?? "";
@@ -60,12 +64,10 @@ export const handleSidebarResizeEnd: EventRouteHandler = (
  *  when no projectId is present (treat as handled rather than fall
  *  through — there's no other handler that wants this event). */
 export const handleSidebarRemoveProject: EventRouteHandler = (
-  { component, eventType, data },
+  { eventType, data },
   ctx,
 ) => {
-  if (component.id !== "sidebar" || eventType !== "remove-project") {
-    return false;
-  }
+  if (eventType !== "remove-project") return false;
   const selected = data as
     | { projectId?: string; itemId?: string }
     | undefined;
@@ -78,12 +80,10 @@ export const handleSidebarRemoveProject: EventRouteHandler = (
  *  the user with a closed tab and a failure notification when the
  *  Tauri command refuses (e.g. the default session). */
 export const handleSidebarDeleteSession: EventRouteHandler = (
-  { component, eventType, data },
+  { eventType, data },
   ctx,
 ) => {
-  if (component.id !== "sidebar" || eventType !== "delete-session") {
-    return false;
-  }
+  if (eventType !== "delete-session") return false;
   const selected = data as
     | { sessionId?: string; itemId?: string; label?: string }
     | undefined;
@@ -134,12 +134,10 @@ export const handleSidebarDeleteSession: EventRouteHandler = (
  *  open-tab rows (whose `tab:` label flows from `Tab.label`, not from
  *  `recentSessions`/`discoveredTabs`). */
 export const handleSidebarRenameSession: EventRouteHandler = (
-  { component, eventType, data },
+  { eventType, data },
   ctx,
 ) => {
-  if (component.id !== "sidebar" || eventType !== "rename-session") {
-    return false;
-  }
+  if (eventType !== "rename-session") return false;
   const selected = data as
     | { sessionId?: string; itemId?: string; label?: string }
     | undefined;
@@ -196,12 +194,10 @@ function applyOptimisticTabLabel(
  *  disabled list is updated + persisted. The bridge re-emits `ready`
  *  on success so the sidebar entry shifts buckets without a refresh. */
 export const handleSidebarToggleExtension: EventRouteHandler = (
-  { component, eventType, data },
+  { eventType, data },
   ctx,
 ) => {
-  if (component.id !== "sidebar" || eventType !== "toggle-extension") {
-    return false;
-  }
+  if (eventType !== "toggle-extension") return false;
   const selected = data as
     | { name?: string; disabled?: boolean }
     | undefined;
@@ -226,18 +222,16 @@ export const handleSidebarToggleExtension: EventRouteHandler = (
 
 /** Sidebar select + dropdown chrome pickers (model-picker /
  *  appearance-menu) all use the same `{sectionId, itemId}` event
- *  shape. Route by section so a chrome dropdown and a sidebar row
- *  converge on the same backing action. */
+ *  shape. Registered under three route-table type keys
+ *  (`type:sidebar`, `type:model-picker`, `type:appearance-menu`) so
+ *  registry overrides win without per-instance id matching — route by
+ *  section so a chrome dropdown and a sidebar row converge on the
+ *  same backing action. */
 export const handleSectionedSelect: EventRouteHandler = async (
-  { component, eventType, data },
+  { eventType, data },
   ctx,
 ) => {
-  const isSectionedSelect =
-    eventType === "select" &&
-    (component.id === "sidebar" ||
-      component.id === "model-picker" ||
-      component.id === "appearance-menu");
-  if (!isSectionedSelect) return false;
+  if (eventType !== "select") return false;
 
   const selected = data as
     | { sectionId?: string; itemId?: string }

--- a/src/eventRoutes/tabStrip.ts
+++ b/src/eventRoutes/tabStrip.ts
@@ -31,12 +31,13 @@ export const handleTabStrip: EventRouteHandler = (
 
 /** empty-state CTA buttons: new-tab, open-project, select-project,
  *  restore-session. Renders when the active project has no open tabs;
- *  selection events here seed a fresh tab in the chosen project. */
+ *  selection events here seed a fresh tab in the chosen project.
+ *
+ *  Routed by `type:empty-state` (registry override key). */
 export const handleEmptyState: EventRouteHandler = (
-  { component, eventType, data },
+  { eventType, data },
   ctx,
 ) => {
-  if (component.id !== "empty-state") return false;
   if (eventType === "new-tab") {
     ctx.newTab();
     return true;

--- a/src/skills/default-layout/chat.tsx
+++ b/src/skills/default-layout/chat.tsx
@@ -268,8 +268,13 @@ export function MainCanvas({ component, state, tabId }: BuiltinComponentProps) {
     emptyHint?: StringValue;
   };
 
-  const messages = props.messages
-    ? ((resolvePointer(state, props.messages.$ref) as ChatMessage[]) || [])
+  // Chat-mode is opt-in: extensions hosting non-chat content (galleries,
+  // dashboards, etc.) bind only `slot` and omit `messages`. Without
+  // messages bound, the canvas is a pure scroll viewport — no chat
+  // empty-state, no message list, no "↓ latest" pill bleeding through.
+  const chatMode = props.messages !== undefined;
+  const messages = chatMode
+    ? ((resolvePointer(state, props.messages!.$ref) as ChatMessage[]) || [])
     : [];
 
   const live = props.slot ? resolvePointer(state, props.slot) : null;
@@ -296,8 +301,13 @@ export function MainCanvas({ component, state, tabId }: BuiltinComponentProps) {
   }, [messages.length, liveSubtree, handleContentChanged]);
 
   return (
-    <main className="a2ui-canvas" ref={listRef}>
-      {messages.length === 0 && !liveSubtree && (
+    <main
+      className={
+        chatMode ? "a2ui-canvas" : "a2ui-canvas a2ui-canvas-bare"
+      }
+      ref={listRef}
+    >
+      {chatMode && messages.length === 0 && !liveSubtree && (
         <div className="a2ui-canvas-empty">{emptyHint}</div>
       )}
       {messages.map((m) => (
@@ -316,7 +326,12 @@ export function MainCanvas({ component, state, tabId }: BuiltinComponentProps) {
           <A2UIRenderer payload={liveSubtree} state={state} tabId={tabId} />
         </div>
       )}
-      <ScrollToBottomPill visible={!isAtBottom && (messages.length > 0 || !!liveSubtree)} onClick={scrollToBottom} />
+      {chatMode && (
+        <ScrollToBottomPill
+          visible={!isAtBottom && (messages.length > 0 || !!liveSubtree)}
+          onClick={scrollToBottom}
+        />
+      )}
     </main>
   );
 }


### PR DESCRIPTION
## Summary

Closes three override-contract gaps surfaced by an audit of M5/M6 against SPEC.md:

1. **Event-route handlers now key on `type:`, not `id:`.** A custom layout payload that renamed a chrome composite (`{id: "primary-side-rail", type: "sidebar"}`) used to render fine but its events fell through — every built-in handler had a `if (component.id !== "<literal>") return false` guard, and the route table was keyed `id:sidebar`, `id:command-palette`, etc. Now keyed by component type. Eight new regression tests in `src/eventRoutes/index.test.ts` cover renamed instances of each composite.

2. **Hot-reload doesn't abort in-flight prompts.** The Rust file-watcher (`commands/extensions.rs::run_debounce_worker`) used to SIGKILL the bun child whenever an extension file changed, killing the user's LLM turn. It now writes `{"type":"reload_request"}` to stdin; the bridge drains active prompts, writes a `{"type":"_reload_done"}` sentinel, and exits cleanly. Supervisor sees the sentinel → emits `agent-reloaded` → frontend respawns lazily. Hard-kill fallback retained for the case where stdin is wedged.

3. **`main-canvas` chat-mode is opt-in.** Used to always render the message list, empty hint, and "↓ latest" pill — leaking chat chrome into non-chat extension hosts (image gallery, dashboards). Binding `messages` enables chat features; omitting it gives you a pure scroll viewport rendering only the live `slot` subtree.

Docs (`docs/aethon-agent/components.md`, SPEC §M6, CLAUDE.md) updated to document the type-vs-id contract, the chat-mode opt-in, and the new hot-reload mechanism.

## Test plan
- [x] `bunx vitest run` — 605/605 pass (88 files)
- [x] `bunx tsc -b --noEmit` — clean
- [x] `bunx eslint .` — 0 errors (1 pre-existing warning, unrelated)
- [x] `cargo test --lib` — 74/74 pass
- [x] `cargo clippy -- -D warnings` — clean
- [ ] Manual: drop a project-extension with a renamed `sidebar` instance; confirm clicks still route
- [ ] Manual: trigger a hot-reload mid-prompt; confirm the prompt completes before the bridge respawns
- [ ] Manual: register a `main-canvas` host without `messages` prop; confirm no chat pill leaks