### PR TITLE
fix(ui): chat-input visibility + per-project session scoping

### DIFF
--- a/agent/main.ts
+++ b/agent/main.ts
@@ -91,6 +91,40 @@ function send(obj: Record<string, unknown>): void {
   process.stdout.write(JSON.stringify(obj) + "\n");
 }
 
+/**
+ * Read the active project's cwd from `<userDir>/projects.json`.
+ *
+ * The frontend's `useProjectOps` boot effect sends `set_project` shortly
+ * after the bridge is ready, but that arrives over the dispatcher loop —
+ * which races the synchronous boot replay below. Reading projects.json
+ * directly lets the bridge scope the default tab's `ensureTab` and
+ * session replay to the right cwd on its very first paint, instead of
+ * picking the most-recently-touched session in `sessions/default/`
+ * regardless of which project produced it.
+ *
+ * Returns `undefined` if the file is missing, malformed, or has no
+ * active project; the caller falls back to project-agnostic behaviour.
+ */
+async function readActiveProjectCwd(userDir: string): Promise<string | undefined> {
+  try {
+    const text = await Bun.file(join(userDir, "projects.json")).text();
+    const parsed = JSON.parse(text) as {
+      activeId?: unknown;
+      projects?: { id?: unknown; path?: unknown }[];
+    };
+    if (typeof parsed.activeId !== "string" || !parsed.activeId) return undefined;
+    if (!Array.isArray(parsed.projects)) return undefined;
+    const active = parsed.projects.find(
+      (p) => p && typeof p.id === "string" && p.id === parsed.activeId,
+    );
+    return active && typeof active.path === "string" && active.path.length > 0
+      ? active.path
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 async function main(): Promise<void> {
   // -- Configuration -------------------------------------------------------
   const userDir = process.env.AETHON_USER_DIR ?? join(homedir(), ".aethon");
@@ -255,6 +289,15 @@ async function main(): Promise<void> {
   await state.resourceLoader.reload();
 
   // -- Default tab -------------------------------------------------------
+  // Resolve the active project's cwd from disk so the default tab's
+  // session resume is scoped to the right project on first paint —
+  // otherwise a `default` session from a previously-active project
+  // leaks into whatever the user opens next (sessions/default/ is
+  // shared across project buckets).
+  const activeProjectCwd = await readActiveProjectCwd(userDir);
+  if (activeProjectCwd) {
+    state.tabProjectCwds.set("default", activeProjectCwd);
+  }
   const tabDeps = { send };
   await ensureTab(state, tabDeps, "default");
 
@@ -265,8 +308,15 @@ async function main(): Promise<void> {
   emitReady(state, tabDeps);
 
   // Replay the default tab's persisted pi session history so all tabs use
-  // the same session_history IPC path.
-  readSessionTranscript(tabSessionDir(state, "default"))
+  // the same session_history IPC path. Scope the read by the SAME cwd
+  // `ensureTab` resolved against — when no project is active, both fall
+  // back to `process.cwd()`. Passing `undefined` here would let the
+  // replay surface the latest JSONL from any cwd while `ensureTab` (which
+  // filters via `findSessionFileMatchingCwd`) created an empty session,
+  // leaving the UI showing a leaked transcript that the agent cannot
+  // continue.
+  const defaultTabReplayCwd = activeProjectCwd ?? process.cwd();
+  readSessionTranscript(tabSessionDir(state, "default"), defaultTabReplayCwd)
     .then((messages) => {
       if (messages.length > 0) {
         send({ type: "session_history", tabId: "default", messages });

--- a/agent/session-history.test.ts
+++ b/agent/session-history.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  findSessionFileMatchingCwd,
   parseSessionHistoryLines,
   readSessionLabel,
   readSessionMetadata,
@@ -147,5 +148,149 @@ describe("readSessionTranscript", () => {
     // Empty label clears the file.
     await writeSessionLabel(dir, "");
     expect(await readSessionLabel(dir)).toBeUndefined();
+  });
+});
+
+describe("readSessionTranscript with expectedCwd", () => {
+  // Helper: write a minimal one-message session for a given cwd.
+  async function writeMiniSession(
+    dir: string,
+    name: string,
+    cwd: string,
+    text: string,
+    mtimeSec: number,
+  ): Promise<void> {
+    const path = join(dir, name);
+    const lines = [
+      JSON.stringify({ type: "session", id: name, cwd }),
+      JSON.stringify({
+        type: "message",
+        id: `${name}-u`,
+        message: { role: "user", content: [{ type: "text", text }] },
+      }),
+    ];
+    await writeFile(path, `${lines.join("\n")}\n`);
+    await utimes(path, new Date(mtimeSec * 1000), new Date(mtimeSec * 1000));
+  }
+
+  it("returns the matching project's session, not the latest by mtime", async () => {
+    const dir = await tempRoot();
+    await writeMiniSession(dir, "old.jsonl", "/tmp/target", "from target", 1_000);
+    await writeMiniSession(dir, "leak.jsonl", "/tmp/other", "from other", 9_000);
+    // Without the cwd filter the latest mtime ("leak.jsonl") wins.
+    await expect(readSessionTranscript(dir)).resolves.toEqual([
+      { id: "leak.jsonl-u", role: "user", text: "from other" },
+    ]);
+    // With the cwd filter, the older matching session is returned.
+    await expect(
+      readSessionTranscript(dir, "/tmp/target"),
+    ).resolves.toEqual([
+      { id: "old.jsonl-u", role: "user", text: "from target" },
+    ]);
+  });
+
+  it("returns no messages when no session matches the requested cwd", async () => {
+    const dir = await tempRoot();
+    await writeMiniSession(dir, "other.jsonl", "/tmp/other", "from other", 1_000);
+    await expect(
+      readSessionTranscript(dir, "/tmp/target"),
+    ).resolves.toEqual([]);
+  });
+
+  it("does not diverge from ensureTab when no active project is set", async () => {
+    // Regression — codex peer review of the cwd-scoped session fix:
+    // when the bridge boots without an active project, `ensureTab`
+    // filters persisted files by `process.cwd()` and creates a fresh
+    // session if none match. The boot replay must scope the transcript
+    // read by the same cwd; otherwise the UI displays the latest JSONL
+    // from any project while the agent session is empty, and the user's
+    // next prompt loses the displayed context. Caller in main.ts now
+    // passes `process.cwd()` (not `undefined`) when no project is set.
+    const dir = await tempRoot();
+    await writeMiniSession(dir, "other.jsonl", "/tmp/other", "from other", 9_000);
+    // Caller's no-project fallback (== `activeProjectCwd ?? process.cwd()`).
+    await expect(
+      readSessionTranscript(dir, process.cwd()),
+    ).resolves.toEqual([]);
+  });
+});
+
+describe("findSessionFileMatchingCwd", () => {
+  // Helper: write a session file with a given header.cwd at a given mtime.
+  async function writeSession(
+    dir: string,
+    name: string,
+    cwd: string | undefined,
+    mtimeSec: number,
+  ): Promise<string> {
+    const path = join(dir, name);
+    const header: Record<string, unknown> = {
+      type: "session",
+      id: name.replace(/\.jsonl$/, ""),
+    };
+    if (cwd !== undefined) header.cwd = cwd;
+    await writeFile(path, `${JSON.stringify(header)}\n`);
+    await utimes(path, new Date(mtimeSec * 1000), new Date(mtimeSec * 1000));
+    return path;
+  }
+
+  it("returns undefined when the directory does not exist", async () => {
+    const root = await tempRoot();
+    await expect(
+      findSessionFileMatchingCwd(join(root, "nope"), "/tmp/project"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("returns undefined when no session header matches the requested cwd", async () => {
+    const dir = await tempRoot();
+    await writeSession(dir, "a.jsonl", "/tmp/other-project", 1_000);
+    await writeSession(dir, "b.jsonl", "/tmp/another-project", 2_000);
+    await expect(
+      findSessionFileMatchingCwd(dir, "/tmp/target"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("returns the most recent session whose cwd matches", async () => {
+    const dir = await tempRoot();
+    await writeSession(dir, "old.jsonl", "/tmp/target", 1_000);
+    const newer = await writeSession(dir, "new.jsonl", "/tmp/target", 3_000);
+    // A more recent session for a *different* cwd must not be picked.
+    await writeSession(dir, "leak.jsonl", "/tmp/other-project", 9_000);
+    await expect(
+      findSessionFileMatchingCwd(dir, "/tmp/target"),
+    ).resolves.toBe(newer);
+  });
+
+  it("ignores trailing slashes when comparing cwds", async () => {
+    const dir = await tempRoot();
+    const path = await writeSession(dir, "a.jsonl", "/tmp/project/", 1_000);
+    await expect(
+      findSessionFileMatchingCwd(dir, "/tmp/project"),
+    ).resolves.toBe(path);
+  });
+
+  it("skips legacy session files that have no cwd in the header", async () => {
+    const dir = await tempRoot();
+    // Legacy session: no cwd field. Must not be matched as if cwd were "".
+    await writeSession(dir, "legacy.jsonl", undefined, 5_000);
+    await expect(findSessionFileMatchingCwd(dir, "")).resolves.toBeUndefined();
+    const fresh = await writeSession(dir, "fresh.jsonl", "/tmp/target", 1_000);
+    await expect(
+      findSessionFileMatchingCwd(dir, "/tmp/target"),
+    ).resolves.toBe(fresh);
+  });
+
+  it("does not leak the most-recent session from another project (regression)", async () => {
+    // Reproduces the "default tab loads the wrong project's chat" bug:
+    // the user worked on project B last, switched to project A, and on
+    // cold start the bridge resumed the latest-by-mtime session — which
+    // belonged to B. ensureTab now passes the result of this helper to
+    // SessionManager.open; an undefined return forces a fresh session
+    // instead of opening the leaked one.
+    const dir = await tempRoot();
+    await writeSession(dir, "project-b-session.jsonl", "/tmp/project-b", 9_000);
+    await expect(
+      findSessionFileMatchingCwd(dir, "/tmp/project-a"),
+    ).resolves.toBeUndefined();
   });
 });

--- a/agent/session-history.ts
+++ b/agent/session-history.ts
@@ -142,6 +142,83 @@ export function parseSessionHistoryLines(lines: Iterable<string>): RestoredChatM
   return messages.slice(-MAX_RESTORED_MESSAGES);
 }
 
+async function readSessionHeaderCwd(path: string): Promise<string | undefined> {
+  // The session header (`{type:"session", cwd: "..."}`) is always the
+  // first line of the .jsonl. Read just enough to parse it — full-file
+  // reads add up when this is called for every file in a session dir.
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf8");
+  } catch {
+    return undefined;
+  }
+  const newline = raw.indexOf("\n");
+  const firstLine = (newline === -1 ? raw : raw.slice(0, newline)).trim();
+  if (!firstLine) return undefined;
+  let entry: unknown;
+  try {
+    entry = JSON.parse(firstLine);
+  } catch {
+    return undefined;
+  }
+  if (!entry || typeof entry !== "object") return undefined;
+  const record = entry as Record<string, unknown>;
+  if (record.type !== "session") return undefined;
+  return typeof record.cwd === "string" && record.cwd.length > 0
+    ? record.cwd
+    : undefined;
+}
+
+/**
+ * Find the most-recently-modified `.jsonl` session file in `sessionDir`
+ * whose header `cwd` matches `expectedCwd`. Returns the absolute path,
+ * or `undefined` when no matching file exists.
+ *
+ * Used by `ensureTab` to resume the right project's session for the
+ * shared `default` tab id — a project-agnostic `continueRecent` would
+ * pick whichever session was touched last regardless of project, which
+ * leaks one project's chat into another on cold start.
+ *
+ * Trailing slashes on the cwd are normalised; case-sensitivity follows
+ * the host filesystem (we only compare strings — pi's session header
+ * stores whatever `process.cwd()` returned, so an exact match is fine
+ * on the platforms we ship).
+ */
+export async function findSessionFileMatchingCwd(
+  sessionDir: string,
+  expectedCwd: string,
+): Promise<string | undefined> {
+  let entries: string[];
+  try {
+    entries = await readdir(sessionDir);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    return undefined;
+  }
+  const target = expectedCwd.replace(/[/\\]+$/, "");
+  const matches: LatestSessionLog[] = [];
+  for (const name of entries) {
+    if (!name.endsWith(".jsonl")) continue;
+    const path = join(sessionDir, name);
+    let mtimeMs: number;
+    try {
+      mtimeMs = (await stat(path)).mtimeMs;
+    } catch {
+      continue;
+    }
+    const cwd = await readSessionHeaderCwd(path);
+    if (!cwd) continue;
+    if (cwd.replace(/[/\\]+$/, "") !== target) continue;
+    matches.push({ path, mtimeMs, name });
+  }
+  if (matches.length === 0) return undefined;
+  matches.sort((a, b) => {
+    if (b.mtimeMs !== a.mtimeMs) return b.mtimeMs - a.mtimeMs;
+    return b.name.localeCompare(a.name);
+  });
+  return matches[0].path;
+}
+
 async function latestSessionLog(sessionDir: string): Promise<LatestSessionLog | null> {
   let entries: string[];
   try {
@@ -239,10 +316,23 @@ export async function readSessionMetadata(
 
 export async function readSessionTranscript(
   sessionDir: string,
+  expectedCwd?: string,
 ): Promise<RestoredChatMessage[]> {
-  const latest = await latestSessionLog(sessionDir);
-  if (!latest) return [];
+  // When `expectedCwd` is provided, only restore from a session whose
+  // header cwd matches — the shared `default` tab dir collects sessions
+  // from every project the user worked in, and the latest by mtime can
+  // belong to a different project than the one currently active. The
+  // unscoped path (no expectedCwd) keeps the prior behaviour for callers
+  // that already know the dir maps 1:1 to the requested context (e.g.
+  // UUID-keyed restored tabs whose dir is project-private by construction).
+  let path: string | undefined;
+  if (expectedCwd !== undefined) {
+    path = await findSessionFileMatchingCwd(sessionDir, expectedCwd);
+  } else {
+    path = (await latestSessionLog(sessionDir))?.path;
+  }
+  if (!path) return [];
 
-  const raw = await readFile(latest.path, "utf8");
+  const raw = await readFile(path, "utf8");
   return parseSessionHistoryLines(raw.split(/\r?\n/));
 }

--- a/agent/tab-lifecycle.ts
+++ b/agent/tab-lifecycle.ts
@@ -23,6 +23,7 @@ import type { Api, Model } from "@mariozechner/pi-ai";
 import { buildShellTools } from "./shell-tools";
 import { logger } from "./logger";
 import { extractAgentEndError } from "./agent-errors";
+import { findSessionFileMatchingCwd } from "./session-history";
 import { consumeBashTerminalSnapshot } from "./terminal-stream";
 import type {
   AethonAgentState,
@@ -372,7 +373,17 @@ export async function ensureTab(
   try {
     const dir = tabSessionDir(state, tabId);
     mkdirSync(dir, { recursive: true });
-    sessionManager = SessionManager.continueRecent(resolvedCwd, dir);
+    // Sessions are stored per-tabId, but `default` is shared across
+    // every project bucket — a plain `continueRecent` would resume
+    // whichever project last wrote there, leaking the wrong chat into
+    // a freshly-opened project. Open the most-recent session whose
+    // header cwd matches the active project; if none matches, start
+    // fresh under the same dir rather than picking up an unrelated
+    // project's history (`continueRecent` would).
+    const matching = await findSessionFileMatchingCwd(dir, resolvedCwd);
+    sessionManager = matching
+      ? SessionManager.open(matching, dir)
+      : SessionManager.create(resolvedCwd, dir);
   } catch (err) {
     logger
       .scope("session")

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import { SkillRegistry } from "./skills/SkillRegistry";
 import { SkillRegistryProvider } from "./skills/registry";
 import { defaultLayoutSkill } from "./skills/default-layout";
 import type { A2UIPayload } from "./types/a2ui";
-import { makeEmptyTab, type Tab } from "./types/tab";
+import { deriveTabActiveFlags, makeEmptyTab, type Tab } from "./types/tab";
 import { dispatchEvent, type EventRouteContext } from "./eventRoutes";
 import { useZoomAndTheme } from "./hooks/useZoomAndTheme";
 import { useShellConsent } from "./hooks/useShellConsent";
@@ -778,10 +778,19 @@ export default function App() {
     // (the orphan-active-id case in switchProjectBucket fallthrough) —
     // the visible UI stays consistent.
     const hasTabs = tabs.length > 0;
+    // Derive /agentTabActive + /shellTabActive from the active tab's kind
+    // so layout `visible: { $ref: "/agentTabActive" }` bindings can never
+    // lag behind the tabs/activeTabId mutation that produced them.
+    const { agentTabActive, shellTabActive } = deriveTabActiveFlags(
+      tabs,
+      state.activeTabId as string | undefined,
+    );
     return {
       ...state,
       hasTabs,
       empty: !hasTabs,
+      agentTabActive,
+      shellTabActive,
       sidebar: {
         ...sidebar,
         history,

--- a/src/hooks/useTabs.ts
+++ b/src/hooks/useTabs.ts
@@ -1,5 +1,4 @@
 import {
-  useEffect,
   useRef,
   type Dispatch,
   type MutableRefObject,
@@ -135,8 +134,7 @@ export interface UseTabsActions {
  * Tab lifecycle: create (newTab/newShellTab), switch (setActiveTab/
  * setActiveSubTab), update (updateTab/updateActiveTab), close
  * (closeTab/closeTabNow), and undo-close (pushClosedTab/
- * reopenLastClosedTab). Plus the kind-derived /shellTabActive +
- * /agentTabActive mirror effect and the tab-replay event dispatch.
+ * reopenLastClosedTab).
  *
  * The hook keeps its state local in refs; project bucket swap and
  * orchestration-level wiring (chat-input dispatch, sidebar history,
@@ -144,6 +142,10 @@ export interface UseTabsActions {
  * callbacks. Shell config refs are passed in (rather than owned)
  * because the boot config effect and the settings panel apply path
  * also write to them.
+ *
+ * /agentTabActive + /shellTabActive are derived in App's renderState
+ * from tabs/activeTabId — not mirrored here — so they can't lag the
+ * tabs mutation that produced them.
  */
 export function useTabs(ctx: UseTabsContext): UseTabsActions {
   const {
@@ -166,27 +168,6 @@ export function useTabs(ctx: UseTabsContext): UseTabsActions {
   const pendingTabOpens = useRef(new Map<string, Promise<unknown>>());
   const closedTabsRef = useRef<ClosedTabEntry[]>([]);
   const autoRestoredSessionIdsRef = useRef(new Set<string>());
-
-  // Mirror /shellTabActive + /agentTabActive based on the active tab's
-  // kind so layout payloads can $ref them without computing equality
-  // at the renderer. Both flags require /hasTabs — when no tab exists,
-  // neither is true (the empty-state composite owns the canvas area).
-  const hasTabsForKind = !!stateRef.current.hasTabs;
-  const tabKind = (stateRef.current.kind as string | undefined) ?? "agent";
-  useEffect(() => {
-    const isShell = hasTabsForKind && tabKind === "shell";
-    const isAgent = hasTabsForKind && tabKind !== "shell";
-    setState((prev) => {
-      if (prev.shellTabActive === isShell && prev.agentTabActive === isAgent) {
-        return prev;
-      }
-      return {
-        ...prev,
-        shellTabActive: isShell,
-        agentTabActive: isAgent,
-      };
-    });
-  }, [hasTabsForKind, tabKind, setState]);
 
   function updateTab(tabId: string, mutator: (tab: Tab) => Tab) {
     setState((prev) => {

--- a/src/types/tab.test.ts
+++ b/src/types/tab.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   NO_PROJECT_KEY,
+  deriveTabActiveFlags,
   makeEmptyTab,
   projectBucketKey,
 } from "./tab";
@@ -60,5 +61,54 @@ describe("makeEmptyTab", () => {
     const b = makeEmptyTab("b", "B");
     a.messages.push({ id: "m", role: "user", text: "hi" });
     expect(b.messages).toEqual([]);
+  });
+});
+
+describe("deriveTabActiveFlags", () => {
+  it("returns both false when there are no tabs", () => {
+    expect(deriveTabActiveFlags([], undefined)).toEqual({
+      agentTabActive: false,
+      shellTabActive: false,
+    });
+  });
+
+  it("flags agent active for an agent tab", () => {
+    const a = makeEmptyTab("a", "A");
+    expect(deriveTabActiveFlags([a], "a")).toEqual({
+      agentTabActive: true,
+      shellTabActive: false,
+    });
+  });
+
+  it("flags shell active for a shell tab", () => {
+    const s = makeEmptyTab("s", "Shell", null, "shell");
+    expect(deriveTabActiveFlags([s], "s")).toEqual({
+      agentTabActive: false,
+      shellTabActive: true,
+    });
+  });
+
+  it("falls through to agent when activeTabId points at a missing tab", () => {
+    // Orphan-active-id case: tabs exist but the active id doesn't match
+    // any of them. Defaulting to agent matches the existing behaviour
+    // before this helper was introduced (kind ?? "agent" fallback).
+    const a = makeEmptyTab("a", "A");
+    expect(deriveTabActiveFlags([a], "missing")).toEqual({
+      agentTabActive: true,
+      shellTabActive: false,
+    });
+  });
+
+  it("recomputes synchronously after a tabs mutation", () => {
+    // Regression: useTabs used to mirror these flags via a useEffect
+    // that read stateRef.current — which lags state by one render. A
+    // newTab() following a project-bucket switch left agentTabActive
+    // at false, hiding the chat-input on a fresh tab. Deriving the
+    // flags here from (tabs, activeTabId) makes them synchronous.
+    const before = deriveTabActiveFlags([], undefined);
+    expect(before.agentTabActive).toBe(false);
+    const a = makeEmptyTab("a", "A");
+    const after = deriveTabActiveFlags([a], "a");
+    expect(after.agentTabActive).toBe(true);
   });
 });

--- a/src/types/tab.ts
+++ b/src/types/tab.ts
@@ -90,3 +90,30 @@ export function makeEmptyTab(
     projectId,
   };
 }
+
+/**
+ * Derive `/agentTabActive` and `/shellTabActive` from the current tab
+ * list and active id. Both gates require at least one tab; when no
+ * tab is active the empty-state composite owns the canvas area.
+ *
+ * Lives here (rather than as a useEffect mirror) so layout `visible:
+ * { $ref: "/agentTabActive" }` bindings can never lag behind a
+ * tabs/activeTabId mutation — the gates recompute synchronously
+ * inside App.tsx's renderState memo.
+ */
+export function deriveTabActiveFlags(
+  tabs: Tab[],
+  activeTabId: string | undefined,
+): { agentTabActive: boolean; shellTabActive: boolean } {
+  if (tabs.length === 0) {
+    return { agentTabActive: false, shellTabActive: false };
+  }
+  const activeTab = activeTabId
+    ? tabs.find((t) => t.id === activeTabId)
+    : undefined;
+  const isShell = activeTab?.kind === "shell";
+  return {
+    agentTabActive: !isShell,
+    shellTabActive: isShell,
+  };
+}


### PR DESCRIPTION
## Summary

Two regressions affecting fresh tabs and project switches, plus the codex peer-review follow-up.

### 1. Chat input missing on fresh tabs

`useTabs` mirrored `/agentTabActive` + `/shellTabActive` via a `useEffect` whose deps were computed from `stateRef.current` — which lags real state by one render. After a project-bucket switch followed by `newTab()`, the stale deps prevented the effect from firing, leaving `agentTabActive: false` and hiding both `chat-input` and `main-canvas` (both gate visibility on that flag). The empty-state composite was also hidden because `empty: !hasTabs` was correctly `false`, so the canvas area rendered as a blank cream pane.

**Fix**: derive both flags synchronously inside App.tsx's `renderState` memo via a new `deriveTabActiveFlags(tabs, activeTabId)` helper in `src/types/tab.ts`. The lagging mirror effect in `useTabs.ts` is removed.

### 2. Sessions leaked across projects

`~/.aethon/sessions/<tabId>/` is shared across project buckets, but the bridge resumed the latest file by mtime regardless of which project produced it. Opening Aethon in project A while the last `default`-tab session belonged to project B replayed B's chat under A's project. Both `ensureTab` and the boot transcript replay are affected.

**Fix**: scope both paths by cwd. New `findSessionFileMatchingCwd(sessionDir, expectedCwd)` helper finds the most-recent `.jsonl` whose header cwd matches; falls back to a fresh session via `SessionManager.create` when none matches (no longer `continueRecent`, which would silently pick an unrelated project's session). `main.ts` reads the active project's cwd from `projects.json` directly via `readActiveProjectCwd(userDir)` so the scoping is correct on first paint — before `set_project` arrives over the dispatcher loop and races the boot replay.

### 3. Codex review follow-up

Initial fix had `ensureTab` filter by `process.cwd()` in the no-project case while `readSessionTranscript` was called with `undefined`, falling through to the unscoped latest-by-mtime path. UI would show a leaked transcript while the agent session was empty → user's next prompt loses context.

**Fix**: both paths now resolve to the same cwd (`activeProjectCwd ?? process.cwd()`).

## End-to-end verification

Dev build on port 1422 with claudex active and a leaked `default` session (`cwd=/Users/jamesbrink/Projects/utensils/aethon`) on disk:

```json
{
  "messages": [],
  "agentTabActive": true,
  "project": { "label": "claudex", "path": "/Users/jamesbrink/Projects/utensils/claudex" },
  "tabs": [{ "id": "default", "kind": "agent", "projectId": "59d572fc-...", "nMsg": 0 }]
}
```

## Test plan

- [x] `bunx vitest run` — 619/619 pass (88 files; +13 new tests)
- [x] `bunx tsc -b --noEmit` — clean
- [x] `bunx eslint .` — 0 errors (1 pre-existing warning, unrelated)
- [x] `cargo test --lib` — 74/74 pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] Live dev build: state inspection confirms no leaked transcript and chat-input visible
- [ ] Manual: open Aethon with project A active, switch to project B in a fresh bucket, hit Cmd+T — chat-input renders
- [ ] Manual: with a leaked `sessions/default/` from project B on disk, open Aethon under project A — no B chat history surfaces