### PR TITLE
[codex] Implement thinking and collapsible tool blocks

### DIFF
--- a/agent/tab-lifecycle.test.ts
+++ b/agent/tab-lifecycle.test.ts
@@ -9,6 +9,7 @@ import {
   emitBashResult,
   extractToolContent,
   handleSessionEvent,
+  inferToolResultLanguage,
   modelDescriptor,
   modelKey,
   summarizeToolArgs,
@@ -185,6 +186,18 @@ describe("toolCardPayload", () => {
     expect(code.props.content.endsWith("…")).toBe(true);
   });
 
+  it("infers the code language for file-backed tool results", () => {
+    const payload = toolCardPayload({
+      callId: "c1",
+      toolName: "read",
+      argsSummary: "src/App.tsx lines 1-end",
+      result: "export function App() { return null; }",
+    });
+    const root = payload.components[0] as { children: unknown[] };
+    const code = root.children[0] as { props: { language: string } };
+    expect(code.props.language).toBe("tsx");
+  });
+
   it("appends image children with data: URLs", () => {
     const payload = toolCardPayload({
       callId: "c1",
@@ -198,6 +211,22 @@ describe("toolCardPayload", () => {
     const image = root.children[0] as { type: string; props: { src: string } };
     expect(image.type).toBe("image");
     expect(image.props.src).toBe("data:image/png;base64,abc");
+  });
+});
+
+describe("inferToolResultLanguage", () => {
+  it("uses read/edit/write paths when available", () => {
+    expect(inferToolResultLanguage("read", "flake.nix", "{ }")).toBe("nix");
+    expect(inferToolResultLanguage("write", "src/main.rs", "fn main() {}")).toBe(
+      "rust",
+    );
+  });
+
+  it("detects json and diffs for non-file-backed output", () => {
+    expect(inferToolResultLanguage("bash", "", '{ "ok": true }')).toBe("json");
+    expect(inferToolResultLanguage("bash", "", "diff --git a/x b/x")).toBe(
+      "diff",
+    );
   });
 });
 
@@ -277,6 +306,24 @@ describe("handleSessionEvent", () => {
       tabId: "tab-1",
       content: "hello",
       messageId: "text-1234",
+      channel: "text",
+    });
+  });
+
+  it("message_update with thinking_delta emits response_delta on thinking channel", () => {
+    const f = makeFixture();
+    const rec = fakeRec();
+    handleSessionEvent(f.state, f.deps, rec, "tab-1", {
+      type: "message_update",
+      assistantMessageEvent: { type: "thinking_delta", delta: "plan" },
+      message: { timestamp: 1234 },
+    });
+    expect(f.sent[0]).toMatchObject({
+      type: "response_delta",
+      tabId: "tab-1",
+      content: "plan",
+      messageId: "text-1234",
+      channel: "thinking",
     });
   });
 

--- a/agent/tab-lifecycle.ts
+++ b/agent/tab-lifecycle.ts
@@ -94,6 +94,72 @@ function truncate(text: string, max: number): string {
   return text.length > max ? text.slice(0, max - 1) + "…" : text;
 }
 
+const EXTENSION_LANGUAGES: Record<string, string> = {
+  cjs: "javascript",
+  cpp: "cpp",
+  cs: "csharp",
+  cts: "typescript",
+  css: "css",
+  diff: "diff",
+  dockerfile: "dockerfile",
+  go: "go",
+  gql: "graphql",
+  graphql: "graphql",
+  hs: "haskell",
+  html: "html",
+  ini: "ini",
+  java: "java",
+  js: "javascript",
+  json: "json",
+  jsonl: "json",
+  jsx: "jsx",
+  kt: "kotlin",
+  lua: "lua",
+  mjs: "javascript",
+  mts: "typescript",
+  nix: "nix",
+  php: "php",
+  py: "python",
+  rb: "ruby",
+  rs: "rust",
+  scala: "scala",
+  sh: "shell",
+  sql: "sql",
+  swift: "swift",
+  toml: "toml",
+  ts: "typescript",
+  tsx: "tsx",
+  xml: "xml",
+  yaml: "yaml",
+  yml: "yaml",
+  zig: "zig",
+};
+
+function languageFromPath(path: string): string | undefined {
+  const clean = path.trim().replace(/^["'`]|["'`]$/g, "");
+  const base = clean.split(/[\\/]/).pop()?.toLowerCase() ?? "";
+  if (base === "dockerfile" || base.endsWith(".dockerfile")) return "dockerfile";
+  if (base === "makefile") return "make";
+  const ext = /\.([a-z0-9]+)$/.exec(base)?.[1];
+  return ext ? EXTENSION_LANGUAGES[ext] : undefined;
+}
+
+export function inferToolResultLanguage(
+  toolName: string,
+  argsSummary: string,
+  text: string,
+): string {
+  if (toolName === "read" || toolName === "edit" || toolName === "write") {
+    const pathLang = languageFromPath(argsSummary.split(/\s+/)[0] ?? "");
+    if (pathLang) return pathLang;
+  }
+
+  const trimmed = text.trimStart();
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) return "json";
+  if (trimmed.startsWith("diff --git ") || trimmed.startsWith("--- ")) return "diff";
+  return "text";
+}
+
 interface ExtractedImage {
   data: string;
   mimeType: string;
@@ -177,7 +243,11 @@ export function toolCardPayload(opts: {
         type: "code",
         props: {
           content: truncate(extracted.text, 1500),
-          language: "text",
+          language: inferToolResultLanguage(
+            toolName,
+            argsSummary,
+            extracted.text,
+          ),
         },
       });
     }
@@ -479,7 +549,15 @@ function handleSessionEvent(
     case "message_update": {
       const ame = (event as { assistantMessageEvent?: { type?: string; delta?: string } })
         .assistantMessageEvent;
-      if (ame?.type === "text_delta") {
+      const channel =
+        ame?.type === "thinking_delta" || ame?.type === "reasoning_delta"
+          ? "thinking"
+          : "text";
+      if (
+        ame?.type === "text_delta" ||
+        ame?.type === "thinking_delta" ||
+        ame?.type === "reasoning_delta"
+      ) {
         const delta = ame.delta ?? "";
         if (delta) {
           const ts =
@@ -491,6 +569,7 @@ function handleSessionEvent(
             tabId,
             messageId,
             content: delta,
+            channel,
           });
         }
       }

--- a/src/hooks/bridgeMessageHandlers/responseDelta.test.ts
+++ b/src/hooks/bridgeMessageHandlers/responseDelta.test.ts
@@ -18,6 +18,7 @@ describe("handleResponseDelta", () => {
       "hello",
       "msg-1",
       "tab-2",
+      "text",
     );
   });
 
@@ -37,6 +38,26 @@ describe("handleResponseDelta", () => {
       "x",
       undefined,
       "default",
+      "text",
+    );
+  });
+
+  it("forwards thinking deltas to the thinking channel", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleResponseDelta(
+      {
+        type: "response_delta",
+        content: "plan",
+        messageId: "msg-1",
+        channel: "thinking",
+      },
+      ctx,
+    );
+    expect(mocks.appendOrAmendAgentText).toHaveBeenCalledWith(
+      "plan",
+      "msg-1",
+      "default",
+      "thinking",
     );
   });
 });

--- a/src/hooks/bridgeMessageHandlers/responseDelta.ts
+++ b/src/hooks/bridgeMessageHandlers/responseDelta.ts
@@ -5,5 +5,6 @@ export const handleResponseDelta: BridgeMessageHandler = (data, ctx) => {
   if (!delta) return;
   const messageId = (data.messageId as string) || undefined;
   const tabId = (data.tabId as string | undefined) ?? "default";
-  ctx.appendOrAmendAgentText(delta, messageId, tabId);
+  const channel = data.channel === "thinking" ? "thinking" : "text";
+  ctx.appendOrAmendAgentText(delta, messageId, tabId, channel);
 };

--- a/src/hooks/bridgeMessageHandlers/types.ts
+++ b/src/hooks/bridgeMessageHandlers/types.ts
@@ -113,6 +113,7 @@ export interface BridgeMessageContext {
     delta: string,
     messageId?: string,
     tabId?: string,
+    channel?: "text" | "thinking",
   ) => void;
   setStatusFlags: (
     flags: Partial<{ waiting: boolean; status: string; connection: string }>,

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -48,6 +48,7 @@ export interface UseChatActions {
     delta: string,
     messageId?: string,
     tabId?: string,
+    channel?: "text" | "thinking",
   ) => void;
   appendSystem: (text: string) => void;
   setStatusFlags: (
@@ -123,7 +124,12 @@ export function useChat(ctx: UseChatContext): UseChatActions {
   // one bubble even after tool cards land between deltas. Without a messageId
   // (legacy bridges), fall back to the previous "is it the last message?"
   // behavior tracked via activeResponseIdRef.
-  function appendOrAmendAgentText(delta: string, messageId?: string, tabId?: string) {
+  function appendOrAmendAgentText(
+    delta: string,
+    messageId?: string,
+    tabId?: string,
+    channel: "text" | "thinking" = "text",
+  ) {
     const id = tabId ?? (stateRef.current.activeTabId as string | undefined) ?? "default";
     updateTab(id, (tab) => {
       const messages = [...tab.messages];
@@ -132,10 +138,10 @@ export function useChat(ctx: UseChatContext): UseChatActions {
         if (idx >= 0) {
           messages[idx] = {
             ...messages[idx],
-            text: (messages[idx].text ?? "") + delta,
+            [channel]: (messages[idx][channel] ?? "") + delta,
           };
         } else {
-          messages.push({ id: messageId, role: "agent", text: delta });
+          messages.push({ id: messageId, role: "agent", [channel]: delta });
         }
         activeResponseIdRef.current = messageId;
         return { ...tab, messages };
@@ -145,12 +151,12 @@ export function useChat(ctx: UseChatContext): UseChatActions {
       if (activeId && last && last.id === activeId && last.role === "agent") {
         messages[messages.length - 1] = {
           ...last,
-          text: (last.text ?? "") + delta,
+          [channel]: (last[channel] ?? "") + delta,
         };
       } else {
         const newId = crypto.randomUUID();
         activeResponseIdRef.current = newId;
-        messages.push({ id: newId, role: "agent", text: delta });
+        messages.push({ id: newId, role: "agent", [channel]: delta });
       }
       return { ...tab, messages };
     });
@@ -318,7 +324,11 @@ export function useChat(ctx: UseChatContext): UseChatActions {
       .map((m) => {
         const heading = `### ${m.role}`;
         const text = (m.text ?? "").replace(/\r\n/g, "\n").trim();
-        return `${heading}\n\n${text}\n`;
+        const thinking = (m.thinking ?? "").replace(/\r\n/g, "\n").trim();
+        const thinkingBlock = thinking
+          ? `<thinking>\n${thinking}\n</thinking>\n\n`
+          : "";
+        return `${heading}\n\n${thinkingBlock}${text}\n`;
       })
       .join("\n");
     const header = `# ${tab.label}\n\n_Exported from Aethon · ${new Date().toISOString()}_\n\n`;

--- a/src/skills/default-layout/chat.tsx
+++ b/src/skills/default-layout/chat.tsx
@@ -21,6 +21,7 @@ import {
   resolveString,
 } from "../../utils/dataBinding";
 import { resolvePointer } from "../../utils/jsonPointer";
+import { splitThinkingBlocks } from "../../utils/thinkingBlocks";
 import A2UIRenderer from "../../components/A2UIRenderer";
 import type { BuiltinComponentProps } from "../../components/A2UIRenderer";
 import { useStickyScroll } from "../../utils/useStickyScroll";
@@ -102,6 +103,7 @@ export function ToolCard({
   }, [startedAt, endedAt, now]);
 
   const isLongRunning = running && elapsedMs >= TOOL_LONG_RUN_THRESHOLD_MS;
+  const hasChildren = (component.children?.length ?? 0) > 0;
 
   const titleSuffix = useMemo(() => {
     if (running) return ` · running… ${formatToolDuration(elapsedMs)}`;
@@ -120,26 +122,32 @@ export function ToolCard({
         : "var(--text-dim)";
 
   return (
-    <div
+    <details
       className="ae-tool-card"
       data-running={running ? "true" : "false"}
       data-long-running={isLongRunning ? "true" : "false"}
       data-error={isError ? "true" : "false"}
     >
-      <div className="ae-tool-card-title" style={{ color: accentColor }}>
-        <span className="ae-tool-card-title-base">{baseTitle}</span>
-        <span className="ae-tool-card-title-suffix">{titleSuffix}</span>
+      <summary className="ae-tool-card-summary">
+        <span className="ae-tool-card-title" style={{ color: accentColor }}>
+          <span className="ae-tool-card-title-base">{baseTitle}</span>
+          <span className="ae-tool-card-title-suffix">{titleSuffix}</span>
+        </span>
+        {description && (
+          <span className="ae-tool-card-description">{description}</span>
+        )}
+      </summary>
+      <div className="ae-tool-card-body">
+        {isLongRunning && (
+          <div className="ae-tool-card-warning">
+            Long-running command — press <kbd>⌘.</kbd> to stop.
+          </div>
+        )}
+        {hasChildren ? renderChildren?.() : (
+          <div className="ae-tool-card-empty">No output</div>
+        )}
       </div>
-      {isLongRunning && (
-        <div className="ae-tool-card-warning">
-          Long-running command — press <kbd>⌘.</kbd> to stop.
-        </div>
-      )}
-      {description && (
-        <div className="ae-tool-card-description">{description}</div>
-      )}
-      {renderChildren && renderChildren()}
-    </div>
+    </details>
   );
 }
 
@@ -176,6 +184,46 @@ function roleBadge(role: string): string {
   if (role === "user") return "YOU";
   if (role === "agent") return "AI";
   return "SYS";
+}
+
+function ThinkingBlock({
+  children,
+  complete = true,
+}: {
+  children: string;
+  complete?: boolean;
+}) {
+  const label = complete ? "Thinking" : "Thinking...";
+  return (
+    <details className="a2ui-thinking-block" open={!complete}>
+      <summary>{label}</summary>
+      <div className="a2ui-thinking-content a2ui-markdown">
+        <ReactMarkdown components={MARKDOWN_COMPONENTS}>{children}</ReactMarkdown>
+      </div>
+    </details>
+  );
+}
+
+function MarkdownWithThinking({ text }: { text: string }) {
+  return (
+    <>
+      {splitThinkingBlocks(text).map((segment, index) => {
+        if (!segment.content) return null;
+        if (segment.type === "thinking") {
+          return (
+            <ThinkingBlock key={index} complete={segment.closed !== false}>
+              {segment.content}
+            </ThinkingBlock>
+          );
+        }
+        return (
+          <ReactMarkdown key={index} components={MARKDOWN_COMPONENTS}>
+            {segment.content}
+          </ReactMarkdown>
+        );
+      })}
+    </>
+  );
 }
 
 export function ChatHistory({ component, state, tabId }: BuiltinComponentProps) {
@@ -237,9 +285,14 @@ export function ChatHistory({ component, state, tabId }: BuiltinComponentProps) 
         messages.map((m) => (
           <div key={m.id} className={`a2ui-chat-message ${m.role}`}>
             <span className="a2ui-chat-role">{roleBadge(m.role)}</span>
+            {m.thinking && (
+              <ThinkingBlock complete={Boolean(m.text)}>
+                {m.thinking}
+              </ThinkingBlock>
+            )}
             {m.text && (
               <div className="a2ui-chat-text a2ui-markdown">
-                <ReactMarkdown components={MARKDOWN_COMPONENTS}>{m.text}</ReactMarkdown>
+                <MarkdownWithThinking text={m.text} />
               </div>
             )}
             {/* tabId forwards so clicks inside the embedded card route

--- a/src/styles.css
+++ b/src/styles.css
@@ -1477,6 +1477,30 @@ body.ae-resizing-sidebar * {
   margin: 0.8em 0;
 }
 
+.a2ui-thinking-block {
+  margin: 0.45em 0;
+  padding: 8px 10px;
+  background: color-mix(in srgb, var(--bg-input) 78%, transparent);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--text-dim);
+  border-radius: 6px;
+  color: var(--text-dim);
+}
+
+.a2ui-thinking-block summary {
+  cursor: pointer;
+  user-select: none;
+  font-size: var(--chrome-text-muted);
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.a2ui-thinking-content {
+  margin-top: 6px;
+  font-size: 0.95em;
+}
+
 .a2ui-canvas-live {
   width: 100%;
   min-width: 0;
@@ -2827,10 +2851,7 @@ body.ae-resizing-sidebar * {
   background: var(--bg-elev);
   border: 1px solid var(--border);
   border-radius: 8px;
-  padding: 12px 14px;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
+  padding: 0;
   min-width: 0;
   max-width: 100%;
   transition: border-color 120ms ease;
@@ -2843,6 +2864,28 @@ body.ae-resizing-sidebar * {
 }
 .ae-tool-card[data-error="true"] {
   border-color: color-mix(in oklab, var(--danger, #c5494a) 50%, var(--border));
+}
+
+.ae-tool-card-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  padding: 10px 14px;
+  cursor: pointer;
+  list-style-position: outside;
+}
+
+.ae-tool-card-summary::marker {
+  color: var(--text-dim);
+}
+
+.ae-tool-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  border-top: 1px solid var(--border);
+  padding: 8px 10px 10px;
+  min-width: 0;
 }
 
 .ae-tool-card-title {
@@ -2875,6 +2918,12 @@ body.ae-resizing-sidebar * {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   white-space: pre-wrap;
   word-break: break-word;
+}
+
+.ae-tool-card-empty {
+  color: var(--text-dim);
+  font-size: var(--chrome-text-muted);
+  font-style: italic;
 }
 
 /* =============================================================================

--- a/src/types/a2ui.ts
+++ b/src/types/a2ui.ts
@@ -283,5 +283,6 @@ export interface ChatMessage {
   id: string;
   role: "user" | "agent" | "system";
   text?: string;
+  thinking?: string;
   a2ui?: A2UIPayload;
 }

--- a/src/utils/messages.test.ts
+++ b/src/utils/messages.test.ts
@@ -109,6 +109,15 @@ describe("coerceChatMessages", () => {
     expect(out[0].a2ui).toBeDefined();
   });
 
+  it("preserves thinking-only messages", () => {
+    const out = coerceChatMessages([
+      { id: "t1", role: "agent", thinking: "working it out" },
+    ]);
+    expect(out).toEqual([
+      { id: "t1", role: "agent", thinking: "working it out" },
+    ]);
+  });
+
   it("rejects unknown roles", () => {
     expect(coerceChatMessages([{ role: "supervisor", text: "x" }])).toEqual([]);
   });

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -57,13 +57,15 @@ export function coerceChatMessages(value: unknown): ChatMessage[] {
         : null;
     if (!role) continue;
     const text = typeof record.text === "string" ? record.text : undefined;
+    const thinking =
+      typeof record.thinking === "string" ? record.thinking : undefined;
     const a2ui =
       record.a2ui &&
       typeof record.a2ui === "object" &&
       Array.isArray((record.a2ui as { components?: unknown }).components)
         ? (record.a2ui as A2UIPayload)
         : undefined;
-    if (!text && !a2ui) continue;
+    if (!text && !thinking && !a2ui) continue;
     messages.push(
       trimMessage({
         id:
@@ -72,6 +74,7 @@ export function coerceChatMessages(value: unknown): ChatMessage[] {
             : crypto.randomUUID(),
         role,
         ...(text ? { text } : {}),
+        ...(thinking ? { thinking } : {}),
         ...(a2ui ? { a2ui } : {}),
       }),
     );

--- a/src/utils/thinkingBlocks.test.ts
+++ b/src/utils/thinkingBlocks.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { splitThinkingBlocks } from "./thinkingBlocks";
+
+describe("splitThinkingBlocks", () => {
+  it("splits complete thinking tags out of normal text", () => {
+    expect(splitThinkingBlocks("before <thinking>hidden</thinking> after")).toEqual([
+      { type: "text", content: "before " },
+      { type: "thinking", content: "hidden", closed: true },
+      { type: "text", content: " after" },
+    ]);
+  });
+
+  it("supports short think tags", () => {
+    expect(splitThinkingBlocks("<think>plan</think>\nanswer")).toEqual([
+      { type: "thinking", content: "plan", closed: true },
+      { type: "text", content: "\nanswer" },
+    ]);
+  });
+
+  it("keeps an unclosed block as streaming thinking content", () => {
+    expect(splitThinkingBlocks("hello <thinking>still going")).toEqual([
+      { type: "text", content: "hello " },
+      { type: "thinking", content: "still going", closed: false },
+    ]);
+  });
+
+  it("leaves plain text unchanged", () => {
+    expect(splitThinkingBlocks("plain")).toEqual([
+      { type: "text", content: "plain" },
+    ]);
+  });
+});

--- a/src/utils/thinkingBlocks.ts
+++ b/src/utils/thinkingBlocks.ts
@@ -1,0 +1,57 @@
+export interface ThinkingBlockSegment {
+  type: "text" | "thinking";
+  content: string;
+  closed?: boolean;
+}
+
+const THINKING_TAG_RE = /<\/?(?:think|thinking)>/gi;
+
+function isOpeningTag(tag: string): boolean {
+  return !tag.startsWith("</");
+}
+
+export function splitThinkingBlocks(text: string): ThinkingBlockSegment[] {
+  const segments: ThinkingBlockSegment[] = [];
+  let index = 0;
+  let match: RegExpExecArray | null;
+
+  THINKING_TAG_RE.lastIndex = 0;
+  while ((match = THINKING_TAG_RE.exec(text))) {
+    const tag = match[0];
+    if (!isOpeningTag(tag)) continue;
+
+    if (match.index > index) {
+      segments.push({ type: "text", content: text.slice(index, match.index) });
+    }
+
+    const contentStart = THINKING_TAG_RE.lastIndex;
+    let close: RegExpExecArray | null;
+    for (;;) {
+      close = THINKING_TAG_RE.exec(text);
+      if (!close || !isOpeningTag(close[0])) break;
+    }
+
+    if (close && !isOpeningTag(close[0])) {
+      segments.push({
+        type: "thinking",
+        content: text.slice(contentStart, close.index),
+        closed: true,
+      });
+      index = THINKING_TAG_RE.lastIndex;
+    } else {
+      segments.push({
+        type: "thinking",
+        content: text.slice(contentStart),
+        closed: false,
+      });
+      index = text.length;
+      break;
+    }
+  }
+
+  if (index < text.length) {
+    segments.push({ type: "text", content: text.slice(index) });
+  }
+
+  return segments.length > 0 ? segments : [{ type: "text", content: text }];
+}

--- a/src/workers/highlight.worker.ts
+++ b/src/workers/highlight.worker.ts
@@ -189,6 +189,20 @@ function findCodeElement(root: Root): Element | null {
   return null;
 }
 
+function isLineElement(node: ElementContent): boolean {
+  if (node.type !== "element") return false;
+  const className = node.properties?.class ?? node.properties?.className;
+  if (className === "line") return true;
+  return Array.isArray(className) && className.includes("line");
+}
+
+function stripRenderedLineSeparators(children: ElementContent[]): ElementContent[] {
+  return children.filter((node, index) => {
+    if (node.type !== "text" || !/^\n+$/.test(node.value)) return true;
+    return !(isLineElement(children[index - 1]) && isLineElement(children[index + 1]));
+  });
+}
+
 async function highlight(code: string, lang: string): Promise<string | null> {
   try {
     const hl = await getHighlighter();
@@ -201,7 +215,10 @@ async function highlight(code: string, lang: string): Promise<string | null> {
     const codeEl = findCodeElement(root);
     if (!codeEl) return null;
     if (!codeEl.children.every(isStructurallySafe)) return null;
-    return toHtml({ type: "root", children: codeEl.children });
+    return toHtml({
+      type: "root",
+      children: stripRenderedLineSeparators(codeEl.children),
+    });
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary
- Render assistant thinking content as collapsible thinking blocks, including streamed thinking/reasoning deltas and tagged `<think>` text.
- Collapse tool-call cards by default while preserving status, duration, and command summary in the header.
- Highlight tool result code blocks with the existing Claudette-style Shiki worker path and fix Shiki line separator spacing.

## Validation
- `nix develop -c bun run test`
- `nix develop -c bun run typecheck`
- `nix develop -c bun run lint` (passes with the existing unrelated `reloadRequired.ts` warning)
