### PR TITLE
[codex] Speed up long chat sessions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import { useProjectOps } from "./hooks/useProjectOps";
 import { useOsEdges } from "./hooks/useOsEdges";
 import type { SlashCommandContext } from "./slashCommands";
 import { writeState } from "./persist";
+import { createAppStore, useAppState } from "./state/appStore";
 import {
   activeProject,
   emptyProjectsState,
@@ -71,7 +72,7 @@ export default function App() {
   // JSON Pointer from the layout payload. We seed `logoUrl` here so the header
   // can $ref it without the layout JSON having to know the hashed asset path.
   // Initial state also seeds one default tab + the active-tab mirror keys.
-  const [state, setState] = useState<Record<string, unknown>>(() => {
+  const appStore = useMemo(() => createAppStore((() => {
     const tab0 = makeEmptyTab("default", "Tab 1");
     return {
       ...(BOOT_LAYOUT.state ?? {}),
@@ -105,7 +106,9 @@ export default function App() {
         ],
       },
     };
-  });
+  })()), []);
+  const state = useAppState(appStore, (s) => s);
+  const setState = appStore.setState;
 
   // Active layout payload — replaceable. Skills can swap the chrome wholesale
   // by calling window.aethon.setLayout(payload), or register a new skill via
@@ -116,10 +119,13 @@ export default function App() {
   // `window.__AETHON_STATE__()` without going through React's state
   // lifecycle. Synced in commit phase — handlers see the latest state
   // because they only dereference after the next render commits.
-  const stateRef = useRef(state);
+  const stateRef = useRef(appStore.getState());
   useEffect(() => {
-    stateRef.current = state;
-  });
+    stateRef.current = appStore.getState();
+    return appStore.subscribe(() => {
+      stateRef.current = appStore.getState();
+    });
+  }, [appStore]);
 
   // ---------------------------------------------------------------------
   // App-owned shared refs — owned here (rather than inside their primary
@@ -798,6 +804,18 @@ export default function App() {
       },
     };
   }, [buildSidebarHistory, state]);
+  const renderRecord = renderState as Record<string, unknown>;
+  const notificationsOpen =
+    ((renderRecord.notifications as unknown[] | undefined) ?? []).length > 0;
+  const paletteOpen = Boolean(
+    (renderRecord.palette as { open?: boolean } | undefined)?.open,
+  );
+  const settingsOpen = Boolean(
+    (renderRecord.settings as { open?: boolean } | undefined)?.open,
+  );
+  const searchOpen = Boolean(
+    (renderRecord.search as { open?: boolean } | undefined)?.open,
+  );
 
   return (
     <SkillRegistryProvider registry={registry}>
@@ -815,30 +833,38 @@ export default function App() {
             /open), so the renderers stay mounted but render null when
             closed. tabId is forwarded so extension override templates
             route their bridge events against the active pi session. */}
-        <RegistryComponent
-          type="notification-stack"
-          state={renderState}
-          onEvent={onEvent}
-          tabId={state.activeTabId as string | undefined}
-        />
-        <RegistryComponent
-          type="command-palette"
-          state={renderState}
-          onEvent={onEvent}
-          tabId={state.activeTabId as string | undefined}
-        />
-        <RegistryComponent
-          type="settings-panel"
-          state={renderState}
-          onEvent={onEvent}
-          tabId={state.activeTabId as string | undefined}
-        />
-        <RegistryComponent
-          type="search-panel"
-          state={renderState}
-          onEvent={onEvent}
-          tabId={state.activeTabId as string | undefined}
-        />
+        {notificationsOpen && (
+          <RegistryComponent
+            type="notification-stack"
+            state={renderState}
+            onEvent={onEvent}
+            tabId={state.activeTabId as string | undefined}
+          />
+        )}
+        {paletteOpen && (
+          <RegistryComponent
+            type="command-palette"
+            state={renderState}
+            onEvent={onEvent}
+            tabId={state.activeTabId as string | undefined}
+          />
+        )}
+        {settingsOpen && (
+          <RegistryComponent
+            type="settings-panel"
+            state={renderState}
+            onEvent={onEvent}
+            tabId={state.activeTabId as string | undefined}
+          />
+        )}
+        {searchOpen && (
+          <RegistryComponent
+            type="search-panel"
+            state={renderState}
+            onEvent={onEvent}
+            tabId={state.activeTabId as string | undefined}
+          />
+        )}
       </div>
     </SkillRegistryProvider>
   );

--- a/src/eventRoutes/terminal.test.ts
+++ b/src/eventRoutes/terminal.test.ts
@@ -56,6 +56,48 @@ describe("handleTerminalPanel", () => {
     );
     expect(mocks.newShellTab).toHaveBeenCalledTimes(1);
   });
+
+  it("resize stores the terminal panel height in state", async () => {
+    const { ctx, applySetState } = buildRouteFixture({
+      state: { terminalPanel: { activeSubId: "agent-bash" } },
+    });
+    const handled = await handleTerminalPanel(
+      {
+        component: { id: "tp", type: "terminal-panel" },
+        eventType: "resize",
+        data: { height: 360 },
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    const next = applySetState();
+    expect((next.terminalPanel as { height?: number }).height).toBe(360);
+  });
+
+  it("resize clamps height and resize-end persists the current value", async () => {
+    const { ctx, mocks, applySetState } = buildRouteFixture({
+      state: { terminalPanel: { height: 240 } },
+    });
+    await handleTerminalPanel(
+      {
+        component: { id: "tp", type: "terminal-panel" },
+        eventType: "resize",
+        data: { height: 9999 },
+      },
+      ctx,
+    );
+    const next = applySetState();
+    expect((next.terminalPanel as { height?: number }).height).toBe(720);
+
+    await handleTerminalPanel(
+      {
+        component: { id: "tp", type: "terminal-panel" },
+        eventType: "resize-end",
+      },
+      ctx,
+    );
+    expect(mocks.writeState).toHaveBeenCalledWith("terminal_height", "720");
+  });
 });
 
 describe("handleShareModeCycle", () => {

--- a/src/eventRoutes/terminal.ts
+++ b/src/eventRoutes/terminal.ts
@@ -2,6 +2,17 @@ import type { EventRouteHandler } from "./types";
 import { cycleShareMode } from "../utils/shareMode";
 import type { Tab } from "../types/tab";
 
+const TERMINAL_PANEL_MIN_HEIGHT = 120;
+const TERMINAL_PANEL_MAX_HEIGHT = 720;
+
+function clampTerminalHeight(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null;
+  return Math.max(
+    TERMINAL_PANEL_MIN_HEIGHT,
+    Math.min(TERMINAL_PANEL_MAX_HEIGHT, Math.round(value)),
+  );
+}
+
 /** terminal-panel: the bottom panel hosting the read-only agent-bash
  *  sub-tab plus every shell as a sub-tab. Sub-tab select / close /
  *  new-shell live here. The agent-bash sub-tab can't be closed (no X
@@ -24,6 +35,36 @@ export const handleTerminalPanel: EventRouteHandler = (
   }
   if (eventType === "new-shell-sub-tab") {
     ctx.newShellTab();
+    return true;
+  }
+  if (eventType === "resize") {
+    const next = clampTerminalHeight(
+      (data as { height?: unknown } | undefined)?.height,
+    );
+    if (next !== null) {
+      ctx.setState((prev) => {
+        const panel =
+          (prev.terminalPanel as Record<string, unknown> | undefined) ?? {};
+        if (panel.height === next) return prev;
+        return {
+          ...prev,
+          terminalPanel: { ...panel, height: next },
+        };
+      });
+    }
+    return true;
+  }
+  if (eventType === "resize-end") {
+    const panel =
+      (ctx.stateRef.current.terminalPanel as
+        | Record<string, unknown>
+        | undefined) ?? {};
+    const height = clampTerminalHeight(panel.height);
+    if (height !== null) {
+      ctx.writeState("terminal_height", String(height)).catch(() => {
+        /* ignore — best-effort */
+      });
+    }
     return true;
   }
   return false;

--- a/src/hooks/bridgeMessageHandlers/responseDelta.test.ts
+++ b/src/hooks/bridgeMessageHandlers/responseDelta.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { handleResponseDelta } from "./responseDelta";
+import { flushResponseDeltas, handleResponseDelta } from "./responseDelta";
 import { buildHandlerFixture } from "./testFixtures";
 
 describe("handleResponseDelta", () => {
@@ -14,6 +14,7 @@ describe("handleResponseDelta", () => {
       },
       ctx,
     );
+    flushResponseDeltas("tab-2");
     expect(mocks.appendOrAmendAgentText).toHaveBeenCalledWith(
       "hello",
       "msg-1",
@@ -34,6 +35,7 @@ describe("handleResponseDelta", () => {
       { type: "response_delta", content: "x" },
       ctx,
     );
+    flushResponseDeltas("default");
     expect(mocks.appendOrAmendAgentText).toHaveBeenCalledWith(
       "x",
       undefined,
@@ -53,11 +55,34 @@ describe("handleResponseDelta", () => {
       },
       ctx,
     );
+    flushResponseDeltas("default");
     expect(mocks.appendOrAmendAgentText).toHaveBeenCalledWith(
       "plan",
       "msg-1",
       "default",
       "thinking",
+    );
+  });
+
+  it("coalesces adjacent deltas for the same message before flushing", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleResponseDelta(
+      { type: "response_delta", content: "hel", messageId: "msg-1" },
+      ctx,
+    );
+    handleResponseDelta(
+      { type: "response_delta", content: "lo", messageId: "msg-1" },
+      ctx,
+    );
+    expect(mocks.appendOrAmendAgentText).not.toHaveBeenCalled();
+
+    flushResponseDeltas("default");
+    expect(mocks.appendOrAmendAgentText).toHaveBeenCalledTimes(1);
+    expect(mocks.appendOrAmendAgentText).toHaveBeenCalledWith(
+      "hello",
+      "msg-1",
+      "default",
+      "text",
     );
   });
 });

--- a/src/hooks/bridgeMessageHandlers/responseDelta.ts
+++ b/src/hooks/bridgeMessageHandlers/responseDelta.ts
@@ -1,4 +1,50 @@
 import type { BridgeMessageHandler } from "./types";
+import type { BridgeMessageContext } from "./types";
+
+interface PendingDelta {
+  ctx: BridgeMessageContext;
+  tabId: string;
+  messageId?: string;
+  channel: "text" | "thinking";
+  content: string;
+}
+
+const pending = new Map<string, PendingDelta>();
+let flushScheduled = false;
+
+function keyFor(
+  tabId: string,
+  messageId: string | undefined,
+  channel: "text" | "thinking",
+): string {
+  return `${tabId}\u0000${messageId ?? ""}\u0000${channel}`;
+}
+
+function scheduleFlush() {
+  if (flushScheduled) return;
+  flushScheduled = true;
+  const flush = () => flushResponseDeltas();
+  if (typeof window !== "undefined" && "requestAnimationFrame" in window) {
+    window.requestAnimationFrame(flush);
+  } else {
+    setTimeout(flush, 16);
+  }
+}
+
+export function flushResponseDeltas(tabId?: string): void {
+  flushScheduled = false;
+  for (const [key, item] of [...pending]) {
+    if (tabId && item.tabId !== tabId) continue;
+    pending.delete(key);
+    item.ctx.appendOrAmendAgentText(
+      item.content,
+      item.messageId,
+      item.tabId,
+      item.channel,
+    );
+  }
+  if (pending.size > 0) scheduleFlush();
+}
 
 export const handleResponseDelta: BridgeMessageHandler = (data, ctx) => {
   const delta = (data.content as string) ?? "";
@@ -6,5 +52,13 @@ export const handleResponseDelta: BridgeMessageHandler = (data, ctx) => {
   const messageId = (data.messageId as string) || undefined;
   const tabId = (data.tabId as string | undefined) ?? "default";
   const channel = data.channel === "thinking" ? "thinking" : "text";
-  ctx.appendOrAmendAgentText(delta, messageId, tabId, channel);
+  const key = keyFor(tabId, messageId, channel);
+  const existing = pending.get(key);
+  if (existing) {
+    existing.content += delta;
+    existing.ctx = ctx;
+  } else {
+    pending.set(key, { ctx, tabId, messageId, channel, content: delta });
+  }
+  scheduleFlush();
 };

--- a/src/hooks/bridgeMessageHandlers/responseEnd.ts
+++ b/src/hooks/bridgeMessageHandlers/responseEnd.ts
@@ -1,8 +1,10 @@
 import type { BridgeMessageHandler } from "./types";
+import { flushResponseDeltas } from "./responseDelta";
 
 export const handleResponseEnd: BridgeMessageHandler = (data, ctx) => {
   ctx.activeResponseIdRef.current = null;
   const tabId = (data.tabId as string | undefined) ?? "default";
+  flushResponseDeltas(tabId);
   // Only clear waiting when the queue is actually empty. If pi has a
   // followUp queued, it will fire agent_start → prompt_started
   // immediately after this and re-flip waiting; clearing here would

--- a/src/hooks/bridgeMessageHandlers/terminalOutput.test.ts
+++ b/src/hooks/bridgeMessageHandlers/terminalOutput.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from "vitest";
-import { handleTerminalOutput } from "./terminalOutput";
+import { flushTerminalOutput, handleTerminalOutput } from "./terminalOutput";
 import { buildHandlerFixture } from "./testFixtures";
 import { makeEmptyTab } from "../../types/tab";
 
@@ -25,6 +25,7 @@ describe("handleTerminalOutput", () => {
       window.removeEventListener("aethon:terminal-tap", onTap);
       window.removeEventListener("aethon:terminal", onLive);
     }
+    flushTerminalOutput(tabId);
     const [, updater] = mocks.updateTab.mock.calls[0];
     const seed = { ...makeEmptyTab(tabId, "Tab 1"), terminalBuffer: "" };
     expect(updater(seed).terminalBuffer).toBe("abc");
@@ -41,5 +42,29 @@ describe("handleTerminalOutput", () => {
     handleTerminalOutput({ type: "terminal_output", content: "" }, ctx);
     expect(mocks.updateTab).not.toHaveBeenCalled();
     expect(mocks.setState).not.toHaveBeenCalled();
+  });
+
+  it("coalesces scrollback mirror writes while preserving live events", () => {
+    const tabId = "default";
+    const { ctx, mocks } = buildHandlerFixture({
+      state: { activeTabId: tabId, terminal: { buffer: {} } },
+    });
+    const live: string[] = [];
+    const onLive = (e: Event) => live.push((e as CustomEvent).detail);
+    window.addEventListener("aethon:terminal", onLive);
+    try {
+      handleTerminalOutput({ type: "terminal_output", content: "a", tabId }, ctx);
+      handleTerminalOutput({ type: "terminal_output", content: "b", tabId }, ctx);
+    } finally {
+      window.removeEventListener("aethon:terminal", onLive);
+    }
+    expect(live).toEqual(["a", "b"]);
+    expect(mocks.updateTab).not.toHaveBeenCalled();
+
+    flushTerminalOutput(tabId);
+    expect(mocks.updateTab).toHaveBeenCalledTimes(1);
+    const [, updater] = mocks.updateTab.mock.calls[0];
+    const seed = { ...makeEmptyTab(tabId, "Tab 1"), terminalBuffer: "" };
+    expect(updater(seed).terminalBuffer).toBe("ab");
   });
 });

--- a/src/hooks/bridgeMessageHandlers/terminalOutput.ts
+++ b/src/hooks/bridgeMessageHandlers/terminalOutput.ts
@@ -1,21 +1,41 @@
 import { TERMINAL_REPLAY_MAX } from "../useTabs";
-import type { BridgeMessageHandler } from "./types";
+import type { BridgeMessageContext, BridgeMessageHandler } from "./types";
 
-export const handleTerminalOutput: BridgeMessageHandler = (data, ctx) => {
-  const content = (data.content as string) ?? "";
-  if (!content) return;
-  const tabId = (data.tabId as string | undefined) ?? "default";
-  // Append to the originating tab's buffer (cap from the right so older
-  // content rotates out first). Three sinks now consume each chunk:
-  //   1. Per-tab Tab.terminalBuffer — the React record carrying the
-  //      rolling scrollback. Used by tab-switch replay.
-  //   2. Layout state at /terminal/buffer/<tabId> — bound by $ref from
-  //      any A2UI component that wants the live stream (logging skills,
-  //      alternative renderers).
-  //   3. window CustomEvents — `aethon:terminal` (active tab only,
-  //      drives xterm) and `aethon:terminal-tap` (every chunk regardless
-  //      of active tab, for multi-subscriber listeners that need the
-  //      full stream).
+interface PendingTerminalOutput {
+  ctx: BridgeMessageContext;
+  tabId: string;
+  content: string;
+}
+
+const pendingTerminal = new Map<string, PendingTerminalOutput>();
+let terminalFlushScheduled = false;
+
+function scheduleTerminalFlush() {
+  if (terminalFlushScheduled) return;
+  terminalFlushScheduled = true;
+  const flush = () => flushTerminalOutput();
+  if (typeof window !== "undefined" && "requestAnimationFrame" in window) {
+    window.requestAnimationFrame(flush);
+  } else {
+    setTimeout(flush, 16);
+  }
+}
+
+export function flushTerminalOutput(tabId?: string): void {
+  terminalFlushScheduled = false;
+  for (const [key, item] of [...pendingTerminal]) {
+    if (tabId && item.tabId !== tabId) continue;
+    pendingTerminal.delete(key);
+    mirrorTerminalContent(item.ctx, item.tabId, item.content);
+  }
+  if (pendingTerminal.size > 0) scheduleTerminalFlush();
+}
+
+function mirrorTerminalContent(
+  ctx: BridgeMessageContext,
+  tabId: string,
+  content: string,
+) {
   ctx.updateTab(tabId, (tab) => {
     const next = (tab.terminalBuffer ?? "") + content;
     const trimmed =
@@ -24,10 +44,6 @@ export const handleTerminalOutput: BridgeMessageHandler = (data, ctx) => {
         : next;
     return { ...tab, terminalBuffer: trimmed };
   });
-  // Mirror the rolling buffer into shared layout state under
-  // /terminal/buffer/<tabId>. A2UI components can $ref it; the bridge
-  // sees it via getFrontendState. Path-based so an extension bound to
-  // ONE tab doesn't pick up every tab's stream.
   ctx.setState((prev) => {
     const term = (prev.terminal as Record<string, unknown> | undefined) ?? {};
     const buffers = (term.buffer as Record<string, string> | undefined) ?? {};
@@ -44,6 +60,31 @@ export const handleTerminalOutput: BridgeMessageHandler = (data, ctx) => {
       },
     };
   });
+}
+
+export const handleTerminalOutput: BridgeMessageHandler = (data, ctx) => {
+  const content = (data.content as string) ?? "";
+  if (!content) return;
+  const tabId = (data.tabId as string | undefined) ?? "default";
+  // Append to the originating tab's buffer (cap from the right so older
+  // content rotates out first). Three sinks now consume each chunk:
+  //   1. Per-tab Tab.terminalBuffer — the React record carrying the
+  //      rolling scrollback. Used by tab-switch replay.
+  //   2. Layout state at /terminal/buffer/<tabId> — bound by $ref from
+  //      any A2UI component that wants the live stream (logging skills,
+  //      alternative renderers).
+  //   3. window CustomEvents — `aethon:terminal` (active tab only,
+  //      drives xterm) and `aethon:terminal-tap` (every chunk regardless
+  //      of active tab, for multi-subscriber listeners that need the
+  //      full stream).
+  const existing = pendingTerminal.get(tabId);
+  if (existing) {
+    existing.content += content;
+    existing.ctx = ctx;
+  } else {
+    pendingTerminal.set(tabId, { ctx, tabId, content });
+  }
+  scheduleTerminalFlush();
   if ((ctx.stateRef.current.activeTabId as string | undefined) === tabId) {
     window.dispatchEvent(
       new CustomEvent("aethon:terminal", { detail: content }),

--- a/src/hooks/useBootConfig.ts
+++ b/src/hooks/useBootConfig.ts
@@ -208,6 +208,27 @@ export function useBootConfig(
           return { ...prev, layout: { ...layout, columns: tokens.join(" ") } };
         });
       }
+      // Restore saved terminal panel height. The panel itself reads from
+      // /terminalPanel/height, so this survives layout rerenders without
+      // replacing the active layout payload.
+      const savedTerminalHeight = (
+        await readStateWithLocalStorageFallback("terminal_height", "")
+      ).trim();
+      const terminalHeight = parseInt(savedTerminalHeight, 10);
+      if (
+        Number.isFinite(terminalHeight) &&
+        terminalHeight >= 120 &&
+        terminalHeight <= 720
+      ) {
+        setState((prev) => {
+          const panel =
+            (prev.terminalPanel as Record<string, unknown> | undefined) ?? {};
+          return {
+            ...prev,
+            terminalPanel: { ...panel, height: terminalHeight },
+          };
+        });
+      }
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/src/skills/default-layout/chat.tsx
+++ b/src/skills/default-layout/chat.tsx
@@ -5,7 +5,7 @@
  * that pairs message history with a live-rendered A2UI subtree.
  */
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import ReactMarkdown from "react-markdown";
 import type {
@@ -43,6 +43,9 @@ import { readUiScale } from "./layout";
 // ---------------------------------------------------------------------------
 
 const TOOL_LONG_RUN_THRESHOLD_MS = 30 * 1000;
+const DRAFT_COMMIT_DELAY_MS = 80;
+const INITIAL_VISIBLE_MESSAGES = 160;
+const MESSAGE_PAGE_SIZE = 120;
 
 // eslint-disable-next-line react-refresh/only-export-components -- exported for vitest unit tests; doesn't affect HMR semantics in practice
 export function formatToolDuration(ms: number): string {
@@ -226,6 +229,58 @@ function MarkdownWithThinking({ text }: { text: string }) {
   );
 }
 
+const MemoMarkdownWithThinking = memo(MarkdownWithThinking);
+
+const ChatMessageRow = memo(
+  function ChatMessageRow({
+    message,
+    state,
+    tabId,
+    className = "a2ui-chat-message",
+  }: {
+    message: ChatMessage;
+    state: Record<string, unknown>;
+    tabId?: string;
+    className?: string;
+  }) {
+    return (
+      <div className={`${className} ${message.role}`}>
+        <span className={className === "a2ui-canvas-message" ? "a2ui-canvas-role" : "a2ui-chat-role"}>
+          {roleBadge(message.role)}
+        </span>
+        {message.thinking && (
+          <ThinkingBlock complete={Boolean(message.text)}>
+            {message.thinking}
+          </ThinkingBlock>
+        )}
+        {message.text && (
+          <div
+            className={
+              className === "a2ui-canvas-message"
+                ? "a2ui-canvas-text a2ui-markdown"
+                : "a2ui-chat-text a2ui-markdown"
+            }
+          >
+            {className === "a2ui-canvas-message" ? (
+              <ReactMarkdown>{message.text}</ReactMarkdown>
+            ) : (
+              <MemoMarkdownWithThinking text={message.text} />
+            )}
+          </div>
+        )}
+        {message.a2ui && (
+          <A2UIRenderer payload={message.a2ui} state={state} tabId={tabId} />
+        )}
+      </div>
+    );
+  },
+  (prev, next) =>
+    prev.message === next.message &&
+    prev.tabId === next.tabId &&
+    prev.className === next.className &&
+    (!next.message.a2ui || prev.state === next.state),
+);
+
 export function ChatHistory({ component, state, tabId }: BuiltinComponentProps) {
   const props = component.props as {
     messages: { $ref: string };
@@ -235,7 +290,16 @@ export function ChatHistory({ component, state, tabId }: BuiltinComponentProps) 
   const listRef = useRef<HTMLDivElement>(null);
   const { isAtBottom, scrollToBottom, handleContentChanged } = useStickyScroll(listRef);
 
-  const messages = (resolvePointer(state, props.messages.$ref) as ChatMessage[]) || [];
+  const messages = useMemo(
+    () => (resolvePointer(state, props.messages.$ref) as ChatMessage[]) || [],
+    [props.messages.$ref, state],
+  );
+  const [visibleCount, setVisibleCount] = useState(INITIAL_VISIBLE_MESSAGES);
+  const visibleMessages = useMemo(
+    () => messages.slice(Math.max(0, messages.length - visibleCount)),
+    [messages, visibleCount],
+  );
+  const hiddenCount = Math.max(0, messages.length - visibleMessages.length);
   const emptyHint = props.emptyHint
     ? resolveString(props.emptyHint, state)
     : "Start a conversation.";
@@ -257,11 +321,30 @@ export function ChatHistory({ component, state, tabId }: BuiltinComponentProps) 
       (m.text ?? "").toLowerCase().includes(needle),
     );
     if (idx >= 0) {
-      const row = el.querySelectorAll(".a2ui-chat-message")[idx];
-      if (row instanceof HTMLElement) {
-        row.scrollIntoView({ block: "center", behavior: "auto" });
-        row.classList.add("a2ui-chat-message-flash");
-        window.setTimeout(() => row.classList.remove("a2ui-chat-message-flash"), 1200);
+      const start = Math.max(0, messages.length - visibleCount);
+      if (idx < start) {
+        window.setTimeout(() => {
+          setVisibleCount(messages.length - idx);
+          const row = el.querySelectorAll(".a2ui-chat-message")[0];
+          if (row instanceof HTMLElement) {
+            row.scrollIntoView({ block: "center", behavior: "auto" });
+            row.classList.add("a2ui-chat-message-flash");
+            window.setTimeout(
+              () => row.classList.remove("a2ui-chat-message-flash"),
+              1200,
+            );
+          }
+        }, 0);
+      } else {
+        const row = el.querySelectorAll(".a2ui-chat-message")[idx - start];
+        if (row instanceof HTMLElement) {
+          row.scrollIntoView({ block: "center", behavior: "auto" });
+          row.classList.add("a2ui-chat-message-flash");
+          window.setTimeout(
+            () => row.classList.remove("a2ui-chat-message-flash"),
+            1200,
+          );
+        }
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -277,29 +360,36 @@ export function ChatHistory({ component, state, tabId }: BuiltinComponentProps) 
     }
   }, [messages.length, handleContentChanged]);
 
+  useEffect(() => {
+    if (messages.length < visibleCount) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setVisibleCount(INITIAL_VISIBLE_MESSAGES);
+    }
+  }, [messages.length, visibleCount]);
+
   return (
     <div className="a2ui-chat-history" ref={listRef}>
       {messages.length === 0 ? (
         <div className="a2ui-chat-empty">{emptyHint}</div>
       ) : (
-        messages.map((m) => (
-          <div key={m.id} className={`a2ui-chat-message ${m.role}`}>
-            <span className="a2ui-chat-role">{roleBadge(m.role)}</span>
-            {m.thinking && (
-              <ThinkingBlock complete={Boolean(m.text)}>
-                {m.thinking}
-              </ThinkingBlock>
-            )}
-            {m.text && (
-              <div className="a2ui-chat-text a2ui-markdown">
-                <MarkdownWithThinking text={m.text} />
-              </div>
-            )}
-            {/* tabId forwards so clicks inside the embedded card route
-                back to the originating tab's pi session. */}
-            {m.a2ui && <A2UIRenderer payload={m.a2ui} state={state} tabId={tabId} />}
-          </div>
-        ))
+        <>
+          {hiddenCount > 0 && (
+            <button
+              type="button"
+              className="a2ui-chat-load-older"
+              onClick={() =>
+                setVisibleCount((n) =>
+                  Math.min(messages.length, n + MESSAGE_PAGE_SIZE),
+                )
+              }
+            >
+              Load older messages ({hiddenCount})
+            </button>
+          )}
+          {visibleMessages.map((m) => (
+            <ChatMessageRow key={m.id} message={m} state={state} tabId={tabId} />
+          ))}
+        </>
       )}
       <ScrollToBottomPill visible={!isAtBottom && messages.length > 0} onClick={scrollToBottom} />
     </div>
@@ -326,9 +416,19 @@ export function MainCanvas({ component, state, tabId }: BuiltinComponentProps) {
   // messages bound, the canvas is a pure scroll viewport — no chat
   // empty-state, no message list, no "↓ latest" pill bleeding through.
   const chatMode = props.messages !== undefined;
-  const messages = chatMode
-    ? ((resolvePointer(state, props.messages!.$ref) as ChatMessage[]) || [])
-    : [];
+  const messages = useMemo(
+    () =>
+      chatMode
+        ? (resolvePointer(state, props.messages!.$ref) as ChatMessage[]) || []
+        : [],
+    [chatMode, props.messages, state],
+  );
+  const [visibleCount, setVisibleCount] = useState(INITIAL_VISIBLE_MESSAGES);
+  const visibleMessages = useMemo(
+    () => messages.slice(Math.max(0, messages.length - visibleCount)),
+    [messages, visibleCount],
+  );
+  const hiddenCount = Math.max(0, messages.length - visibleMessages.length);
 
   const live = props.slot ? resolvePointer(state, props.slot) : null;
   const liveSubtree =
@@ -353,6 +453,13 @@ export function MainCanvas({ component, state, tabId }: BuiltinComponentProps) {
     if (lengthChanged || liveChanged) handleContentChanged();
   }, [messages.length, liveSubtree, handleContentChanged]);
 
+  useEffect(() => {
+    if (messages.length < visibleCount) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setVisibleCount(INITIAL_VISIBLE_MESSAGES);
+    }
+  }, [messages.length, visibleCount]);
+
   return (
     <main
       className={
@@ -363,16 +470,25 @@ export function MainCanvas({ component, state, tabId }: BuiltinComponentProps) {
       {chatMode && messages.length === 0 && !liveSubtree && (
         <div className="a2ui-canvas-empty">{emptyHint}</div>
       )}
-      {messages.map((m) => (
-        <div key={m.id} className={`a2ui-canvas-message ${m.role}`}>
-          <span className="a2ui-canvas-role">{roleBadge(m.role)}</span>
-          {m.text && (
-            <div className="a2ui-canvas-text a2ui-markdown">
-              <ReactMarkdown>{m.text}</ReactMarkdown>
-            </div>
-          )}
-          {m.a2ui && <A2UIRenderer payload={m.a2ui} state={state} tabId={tabId} />}
-        </div>
+      {chatMode && hiddenCount > 0 && (
+        <button
+          type="button"
+          className="a2ui-chat-load-older"
+          onClick={() =>
+            setVisibleCount((n) => Math.min(messages.length, n + MESSAGE_PAGE_SIZE))
+          }
+        >
+          Load older messages ({hiddenCount})
+        </button>
+      )}
+      {visibleMessages.map((m) => (
+        <ChatMessageRow
+          key={m.id}
+          message={m}
+          state={state}
+          tabId={tabId}
+          className="a2ui-canvas-message"
+        />
       ))}
       {liveSubtree && (
         <div className="a2ui-canvas-live">
@@ -475,7 +591,66 @@ export function ChatInput({ component, state, onEvent }: BuiltinComponentProps) 
     queueBadgeFormat?: StringValue;
   };
 
-  const value = props.value ? resolveString(props.value, state) : "";
+  const externalValue = props.value ? resolveString(props.value, state) : "";
+  const [localValue, setLocalValue] = useState(externalValue);
+  const localValueRef = useRef(localValue);
+  const lastExternalValueRef = useRef(externalValue);
+  const draftTimerRef = useRef<number | null>(null);
+  const lastCommittedDraftRef = useRef(externalValue);
+  const onEventRef = useRef(onEvent);
+
+  useEffect(() => {
+    localValueRef.current = localValue;
+  }, [localValue]);
+  useEffect(() => {
+    onEventRef.current = onEvent;
+  }, [onEvent]);
+
+  useEffect(() => {
+    if (externalValue === lastExternalValueRef.current) return;
+    lastExternalValueRef.current = externalValue;
+    lastCommittedDraftRef.current = externalValue;
+    if (draftTimerRef.current !== null) {
+      window.clearTimeout(draftTimerRef.current);
+      draftTimerRef.current = null;
+    }
+    setLocalValue(externalValue);
+  }, [externalValue]);
+
+  const commitDraft = (next: string) => {
+    if (draftTimerRef.current !== null) {
+      window.clearTimeout(draftTimerRef.current);
+      draftTimerRef.current = null;
+    }
+    if (next === lastCommittedDraftRef.current) return;
+    lastCommittedDraftRef.current = next;
+    onEventRef.current("change", { value: next });
+  };
+
+  const scheduleDraftCommit = () => {
+    if (draftTimerRef.current !== null) {
+      window.clearTimeout(draftTimerRef.current);
+    }
+    draftTimerRef.current = window.setTimeout(() => {
+      draftTimerRef.current = null;
+      commitDraft(localValueRef.current);
+    }, DRAFT_COMMIT_DELAY_MS);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (draftTimerRef.current !== null) {
+        window.clearTimeout(draftTimerRef.current);
+        draftTimerRef.current = null;
+      }
+      const latest = localValueRef.current;
+      if (latest !== lastCommittedDraftRef.current) {
+        onEventRef.current("change", { value: latest });
+      }
+    };
+  }, []);
+
+  const value = localValue;
   const placeholder = props.placeholder
     ? resolveString(props.placeholder, state)
     : "";
@@ -625,11 +800,14 @@ export function ChatInput({ component, state, onEvent }: BuiltinComponentProps) 
   const insertMatch = (m: PickerMatch) => {
     const text =
       m.kind === "command" ? `/${m.cmd.name} ` : `/${m.cmd.name} ${m.choice.value}`;
-    onEvent("change", { value: text });
+    setLocalValue(text);
+    commitDraft(text);
   };
 
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    onEvent("change", { value: e.target.value });
+    const next = e.target.value;
+    setLocalValue(next);
+    scheduleDraftCommit();
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -671,7 +849,8 @@ export function ChatInput({ component, state, onEvent }: BuiltinComponentProps) 
         if (slashMatch.mode === "arg") {
           const choice = (list[highlightIdx] ?? list[0]) as ArgMatch;
           const submitText = `/${choice.cmd.name} ${choice.choice.value}`;
-          onEvent("change", { value: submitText });
+          setLocalValue(submitText);
+          commitDraft(submitText);
           onEvent("submit", { value: submitText });
           return;
         }
@@ -693,6 +872,7 @@ export function ChatInput({ component, state, onEvent }: BuiltinComponentProps) 
         // Always submit — the bridge uses pi's followUp queue when an
         // earlier prompt is still in flight, so the user can keep
         // typing without "agent busy" rejections.
+        commitDraft(v);
         onEvent("submit", { value: v });
       }
     }
@@ -700,6 +880,7 @@ export function ChatInput({ component, state, onEvent }: BuiltinComponentProps) 
 
   const handleClick = () => {
     if (value.trim().length > 0) {
+      commitDraft(value);
       onEvent("submit", { value });
     }
   };
@@ -749,7 +930,8 @@ export function ChatInput({ component, state, onEvent }: BuiltinComponentProps) 
                     e.preventDefault();
                     if (m.kind === "arg") {
                       const submitText = `/${m.cmd.name} ${m.choice.value}`;
-                      onEvent("change", { value: submitText });
+                      setLocalValue(submitText);
+                      commitDraft(submitText);
                       onEvent("submit", { value: submitText });
                     } else {
                       insertMatch(m);

--- a/src/skills/default-layout/shell/panel.tsx
+++ b/src/skills/default-layout/shell/panel.tsx
@@ -13,7 +13,7 @@
  * per-sub-tab scrollback isolation is automatic.
  */
 
-import { useMemo } from "react";
+import { useMemo, useRef } from "react";
 import type {
   BooleanValue,
   NumberValue,
@@ -24,6 +24,9 @@ import { Terminal } from "../terminal";
 import { ShellCanvas } from "./canvas";
 
 const AGENT_BASH_SUB_ID = "agent-bash";
+const TERMINAL_PANEL_DEFAULT_HEIGHT = 240;
+const TERMINAL_PANEL_MIN_HEIGHT = 120;
+const TERMINAL_PANEL_MAX_HEIGHT = 720;
 
 interface ShellSubTabItem {
   id: string;
@@ -63,8 +66,17 @@ export function TerminalPanel({
   // persists across renders and can be addressed via $ref. Defaults to
   // "agent-bash" — the read-only view is always present.
   const panelState =
-    (state["terminalPanel"] as { activeSubId?: string } | undefined) ?? {};
+    (state["terminalPanel"] as { activeSubId?: string; height?: number } | undefined) ?? {};
   const requestedActiveId = panelState.activeSubId ?? AGENT_BASH_SUB_ID;
+  const panelRef = useRef<HTMLDivElement>(null);
+  const height =
+    typeof panelState.height === "number" &&
+    Number.isFinite(panelState.height)
+      ? Math.max(
+          TERMINAL_PANEL_MIN_HEIGHT,
+          Math.min(TERMINAL_PANEL_MAX_HEIGHT, Math.round(panelState.height)),
+        )
+      : TERMINAL_PANEL_DEFAULT_HEIGHT;
   // Clamp to a valid sub-tab id. If the requested id no longer exists
   // (e.g. user closed a shell that was active), fall back to agent-bash
   // so we always render something.
@@ -77,8 +89,44 @@ export function TerminalPanel({
 
   if (!visible) return null;
 
+  const onResizeStart = (e: React.MouseEvent) => {
+    e.preventDefault();
+    const panel = panelRef.current;
+    if (!panel) return;
+    const startY = e.clientY;
+    const startHeight = panel.getBoundingClientRect().height;
+    document.body.classList.add("ae-resizing-terminal");
+    const onMove = (ev: MouseEvent) => {
+      const dy = startY - ev.clientY;
+      const next = Math.max(
+        TERMINAL_PANEL_MIN_HEIGHT,
+        Math.min(TERMINAL_PANEL_MAX_HEIGHT, Math.round(startHeight + dy)),
+      );
+      onEvent("resize", { height: next });
+    };
+    const onUp = () => {
+      document.body.classList.remove("ae-resizing-terminal");
+      document.removeEventListener("mousemove", onMove);
+      document.removeEventListener("mouseup", onUp);
+      onEvent("resize-end");
+    };
+    document.addEventListener("mousemove", onMove);
+    document.addEventListener("mouseup", onUp);
+  };
+
   return (
-    <div className="ae-terminal-panel" style={{ gridArea: "terminal" }}>
+    <div
+      ref={panelRef}
+      className="ae-terminal-panel"
+      style={{ gridArea: "terminal", height }}
+    >
+      <div
+        className="ae-terminal-panel-resize-handle"
+        role="separator"
+        aria-orientation="horizontal"
+        aria-label="Resize terminal panel"
+        onMouseDown={onResizeStart}
+      />
       <div className="ae-terminal-panel-tabs" role="tablist">
         <SubTabPill
           id={AGENT_BASH_SUB_ID}

--- a/src/skills/default-layout/workstation.a2ui.json
+++ b/src/skills/default-layout/workstation.a2ui.json
@@ -5,7 +5,7 @@
       "type": "layout",
       "props": {
         "columns": { "$ref": "/layout/columns" },
-        "rows": "38px minmax(0,1fr) auto auto auto",
+        "rows": { "$ref": "/layout/rows" },
         "areas": { "$ref": "/layout/areas" },
         "slotMap": { "empty-state": "canvas" }
       },
@@ -190,6 +190,7 @@
     "layout": {
       "sidebarVisible": true,
       "columns": "220px minmax(0,1fr)",
+      "rows": "38px minmax(0,1fr) auto auto auto",
       "areas": [
         "sidebar header",
         "sidebar canvas",

--- a/src/state/appStore.test.ts
+++ b/src/state/appStore.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from "vitest";
+import { createAppStore } from "./appStore";
+
+describe("appStore", () => {
+  it("applies value and updater writes while keeping stateRef fresh", () => {
+    const store = createAppStore({ count: 0 });
+    store.setState((prev) => ({ ...prev, count: 1 }));
+    expect(store.getState().count).toBe(1);
+    expect(store.stateRef.current.count).toBe(1);
+
+    store.setState({ count: 2 });
+    expect(store.getState().count).toBe(2);
+    expect(store.stateRef.current.count).toBe(2);
+  });
+
+  it("notifies selector subscribers only when the selected value changes", () => {
+    const store = createAppStore({ draft: "", status: "ready" });
+    const listener = vi.fn();
+    store.subscribeSelector((s) => s.draft, listener);
+
+    store.setState((prev) => ({ ...prev, status: "thinking" }));
+    expect(listener).not.toHaveBeenCalled();
+
+    store.setState((prev) => ({ ...prev, draft: "hello" }));
+    expect(listener).toHaveBeenCalledWith("hello", "");
+  });
+});

--- a/src/state/appStore.ts
+++ b/src/state/appStore.ts
@@ -1,0 +1,74 @@
+import { useSyncExternalStore, type Dispatch, type SetStateAction } from "react";
+
+export type AppState = Record<string, unknown>;
+export type AppStateUpdate = SetStateAction<AppState>;
+export type AppStateSelector<T> = (state: AppState) => T;
+export type EqualityFn<T> = (a: T, b: T) => boolean;
+
+export interface AppStore {
+  getState: () => AppState;
+  setState: Dispatch<AppStateUpdate>;
+  subscribe: (listener: () => void) => () => void;
+  subscribeSelector: <T>(
+    selector: AppStateSelector<T>,
+    listener: (next: T, prev: T) => void,
+    equality?: EqualityFn<T>,
+  ) => () => void;
+  stateRef: { current: AppState };
+}
+
+const objectIs = <T,>(a: T, b: T) => Object.is(a, b);
+
+export function createAppStore(initialState: AppState): AppStore {
+  let state = initialState;
+  const stateRef = { current: state };
+  const listeners = new Set<() => void>();
+
+  const getState = () => state;
+
+  const setState: Dispatch<AppStateUpdate> = (update) => {
+    const next =
+      typeof update === "function"
+        ? update(state)
+        : update;
+    if (Object.is(next, state)) return;
+    state = next;
+    stateRef.current = next;
+    for (const listener of [...listeners]) listener();
+  };
+
+  const subscribe = (listener: () => void) => {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  };
+
+  const subscribeSelector = <T,>(
+    selector: AppStateSelector<T>,
+    listener: (next: T, prev: T) => void,
+    equality: EqualityFn<T> = objectIs,
+  ) => {
+    let selected = selector(state);
+    return subscribe(() => {
+      const next = selector(state);
+      if (equality(selected, next)) return;
+      const prev = selected;
+      selected = next;
+      listener(next, prev);
+    });
+  };
+
+  return { getState, setState, subscribe, subscribeSelector, stateRef };
+}
+
+export function useAppState<T>(
+  store: AppStore,
+  selector: AppStateSelector<T>,
+): T {
+  return useSyncExternalStore(
+    store.subscribe,
+    () => selector(store.getState()),
+    () => selector(store.getState()),
+  );
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1523,6 +1523,23 @@ body.ae-resizing-sidebar * {
   contain: layout style;
 }
 
+.a2ui-chat-load-older {
+  align-self: center;
+  border: 1px solid var(--border);
+  background: var(--bg-elev);
+  color: var(--text-dim);
+  border-radius: 6px;
+  padding: 5px 10px;
+  font: inherit;
+  font-size: var(--text-xs);
+  cursor: pointer;
+}
+
+.a2ui-chat-load-older:hover {
+  color: var(--text);
+  border-color: var(--border);
+}
+
 /* Base bubble — shared by all roles. */
 .a2ui-chat-message {
   padding: 10px 14px;
@@ -2429,12 +2446,40 @@ body.ae-resizing-sidebar * {
    ============================================================================= */
 
 .ae-terminal-panel {
+  position: relative;
   display: flex;
   flex-direction: column;
   background: var(--bg-elev);
   border-top: 1px solid var(--border);
   min-height: 0;
   height: 240px;
+}
+.ae-terminal-panel-resize-handle {
+  position: absolute;
+  top: -4px;
+  left: 0;
+  right: 0;
+  height: 8px;
+  cursor: ns-resize;
+  z-index: 2;
+}
+.ae-terminal-panel-resize-handle::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 3px;
+  height: 1px;
+  background: transparent;
+}
+.ae-terminal-panel-resize-handle:hover::before,
+body.ae-resizing-terminal .ae-terminal-panel-resize-handle::before {
+  background: var(--accent);
+}
+body.ae-resizing-terminal,
+body.ae-resizing-terminal * {
+  cursor: ns-resize !important;
+  user-select: none !important;
 }
 .ae-terminal-panel-tabs {
   flex: 0 0 auto;


### PR DESCRIPTION
## Summary

- speeds up long chat sessions by moving app state behind an external store adapter
- debounces chat draft writes so typing no longer rerenders the full long transcript on every keystroke
- batches response and terminal stream state updates while keeping terminal live events immediate
- windows and memoizes long chat rendering with a load-older control
- makes the terminal panel resizable and persists the selected height

## Validation

- bun run typecheck
- bunx vitest run
- bun run lint (0 errors; existing warning in reloadRequired.ts)
