### PR TITLE
docs(readme): trim to a focused overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,135 +12,52 @@
 <p align="center">
   <a href="LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
   <img alt="Status: early development" src="https://img.shields.io/badge/status-early%20development-orange">
-  <img alt="Tauri 2" src="https://img.shields.io/badge/Tauri-2-FFC131?logo=tauri&logoColor=white">
-  <img alt="React 19" src="https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=black">
-  <img alt="Rust 1.92" src="https://img.shields.io/badge/Rust-1.92-DEA584?logo=rust&logoColor=white">
-  <img alt="Bun" src="https://img.shields.io/badge/Bun-1.x-FBF0DF?logo=bun&logoColor=black">
-  <img alt="Nix flake" src="https://img.shields.io/badge/Nix-flake-5277C3?logo=nixos&logoColor=white">
   <img alt="Platforms: macOS | Linux | Windows" src="https://img.shields.io/badge/platforms-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey">
 </p>
 
-> **Early development — not ready for production use.** The API and protocol surface are still settling; expect breaking changes between commits.
+> **Early development — not ready for production use.** Expect breaking changes between commits.
 
-Aethon embeds the [pi coding agent][pi] inside a Tauri 2 desktop shell and renders its output as live, interactive UI via the [A2UI][a2ui] protocol. The interface is not a fixed IDE layout — it's a **canvas the agent populates dynamically**. Skills bring their own components, themes control the look, the agent decides the layout.
+Aethon embeds the [pi coding agent][pi] inside a Tauri 2 desktop shell and renders its output as live, interactive UI via the [A2UI][a2ui] protocol. The interface is not a fixed IDE layout — it's a **canvas the agent populates dynamically**.
 
-The name comes from Greek mythology: _Αἴθων_, one of the horses that pulled Helios's sun chariot. The blazing one that shapes what you see.
+The name comes from Greek mythology: _Αἴθων_, one of the horses that pulled Helios's sun chariot.
 
 [pi]: https://github.com/mariozechner/pi-coding-agent
 [a2ui]: https://github.com/google/a2ui
 
----
+## Highlights
 
-## What it can do
-
-- **Multi-tab workspace** — top-strip agent tabs (one pi conversation each) plus a bottom-panel terminal with sub-tabs: a read-only "Agent bash" stream and zero-or-more interactive PTY shells (xterm.js + WebGL, full TUI / 256-color / true-color). Focus-aware `⌘T`, `⌘1`–`⌘9` jump, `⌘W` close, `⌘⌥T` reopen.
-- **Native shell integration** — system tray + macOS menu, auto-updater (`tauri-plugin-updater` against GitHub Releases), persistent chat history / tabs / themes / projects / `~/.aethon/config.toml`, per-tab pi session continuity.
-- **Agent-controlled UI** — themes (`aethon.registerTheme` or `~/.aethon/themes/*.json`) drive the whole palette including terminal ANSI; any A2UI built-in (composites or app-root overlays like `command-palette`, `notification-stack`, `settings-panel`, `search-panel`) is overridable via `aethon.registerComponent`. One built-in layout (`workstation`); extensions register more via `aethon.registerLayout`.
-- **Agent ↔ shell sharing** — four-value `shareMode` (`private` / `read` / `read-write` / `read-write-trusted`) per shell, clickable badge to cycle. Bridge surface `aethon.shells.{list, read, write}` exposes scrollback (forward-only, privacy floor enforced Rust-side) and keystroke injection (Allow/Deny prompt per write unless trusted).
-- **Extensibility** — drop a `.ts` into `~/.aethon/extensions/` for hot-reload, or `npm install --prefix ~/.aethon/skills <pkg>` for npm-distributed extensions (manifest via `package.json#aethon`); project-local extensions discovered from cwd up to its git root. Extensions register slash commands, keybindings, menu items, event routes, layouts, A2UI components, and themes — all reported back in the runtime snapshot.
-- **Built-in slash commands** — `/clear`, `/help`, `/theme`, `/model`, `/reset`, `/terminal`, `/extensions`, `/sidebar`, `/layout`, `/project`. Unknown commands fall through to pi.
-
-See [`SPEC.md`](SPEC.md) for the full status checklist and [`CHANGELOG.md`](CHANGELOG.md) for release notes.
-
----
+- **Multi-tab workspace** — agent tabs on top, interactive PTY shells in a bottom panel (xterm.js, full TUI / 256-color).
+- **Agent-controlled UI** — themes, layouts, and components are all data the agent (or an extension) can register at runtime.
+- **Extensibility** — drop a `.ts` into `~/.aethon/extensions/` for hot-reload, or `npm install` a skill package. Project-local extensions resolve from cwd up.
+- **Native shell** — system tray, native menu, auto-updater, persistent sessions, `~/.aethon/config.toml`.
+- **Bring your own LLM** — pi reads `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / equivalents.
 
 ## Getting started
 
-Requires [Nix][nix] with flakes enabled. With [direnv][direnv], the dev shell activates automatically when you `cd` into the directory.
+Requires [Nix][nix] with flakes enabled. With [direnv][direnv] the dev shell activates on `cd`.
 
 ```bash
-nix develop          # enter the dev shell (rust toolchain + bun + tauri CLI)
-bun install          # install JS deps
-dev                  # launch the app with hot reload
+nix develop          # rust toolchain + bun + tauri CLI
+bun install
+dev                  # launch with hot reload
 ```
 
-Bring your own LLM key — pi reads `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / equivalents from the environment. See pi's docs for the full multi-provider setup.
+Or build a release bundle: `build-app`. Full CI gate: `check`.
+
+The flake also exposes `nix build .#aethon` and `overlays.default` for downstream consumers.
 
 [nix]: https://nixos.org/download
 [direnv]: https://direnv.net
 
-### Nix package
+## Documentation
 
-The flake also exposes a distribution package and overlay:
-
-```bash
-nix build .#aethon
-nix run .#aethon
-```
-
-Downstream flakes can consume `overlays.default`, which provides `pkgs.aethon`.
-The package follows nixpkgs' Tauri pattern (`cargo-tauri.hook` +
-`fetchNpmDeps`) and uses `package-lock.json` as the reproducible npm dependency
-input for Nix builds.
-
-### Devshell commands
-
-| Command     | What it does                                                                                |
-| ----------- | ------------------------------------------------------------------------------------------- |
-| `dev`       | Launch the app with hot reload (auto-increments Vite + debug ports if 1420/19433 are busy)  |
-| `build-app` | Release bundle (`.app` / `.dmg` on macOS, `.deb` / `.rpm` on Linux, NSIS `.exe` on Windows) |
-| `check`     | Full CI gate: clippy + tsc + ESLint + cargo test + vitest                                   |
-| `lint`      | ESLint frontend + agent (no auto-fix)                                                       |
-| `test`      | Run Rust + TS tests (cargo test --lib + vitest run)                                         |
-| `coverage`  | TS coverage report under `coverage/` (vitest v8)                                            |
-| `fmt`       | Format Rust + Nix with treefmt                                                              |
-
----
-
-## Architecture
-
-```mermaid
-graph TD
-    subgraph aethon["Aethon"]
-        TS["Tauri Shell (Rust)\nwindows · tray + menu · file watch · spawn agent"]
-        PA["Pi Agent (bun bin)\npi-ai · tools · skills · exts"]
-        subgraph react["React Frontend (Vite)"]
-            R["A2UI Renderer\n19 primitives + scoped templates"]
-            L["default-layout\nsidebar · canvas · terminal · …"]
-        end
-
-        TS -- "stdin JSON lines\nuser / UI events" --> PA
-        PA -- "stdout JSON lines\nA2UI components + responses" --> TS
-        TS <-- "Tauri IPC" --> react
-    end
-```
-
-| Layer                  | Owns                                                                                    | Doesn't own                                                     |
-| ---------------------- | --------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
-| **Tauri shell (Rust)** | OS surface — windows, tray, native menus, file watcher, spawning the agent subprocess   | Any business logic, agent awareness, A2UI knowledge             |
-| **Pi agent (Bun)**     | LLM interaction, tool execution, session management, extension loading, A2UI emission   | OS resources                                                    |
-| **React frontend**     | Rendering A2UI payloads, dispatching events, persisting local state, hosting the chrome | The chrome is data — `default-layout` is itself an A2UI payload |
-
-The default layout _is_ a skill (`src/skills/default-layout/`). Replacing it requires no React changes — just register a different layout payload via `aethon.setLayout(...)`.
-
----
-
-## Project layout
-
-```
-aethon/
-├── src/                 # React frontend (entry: src/main.tsx)
-├── src-tauri/           # Rust Tauri shell (lib + helpers + watcher)
-├── agent/               # Pi agent bridge (run as a bun subprocess)
-├── docs/aethon-agent/   # Bundled reference docs the agent reads
-├── examples/            # Pi extensions + extension packages (reference)
-├── flake.nix            # Nix dev environment, package, and overlay
-├── bun.lock             # Bun lockfile (used by `bun install` in the devshell)
-├── package-lock.json    # npm dependency snapshot for reproducible Nix builds
-└── package.json         # Frontend deps + tauri CLI
-```
-
-For agent-side authoring docs (the API surface, A2UI components, extension recipes), see [`docs/aethon-agent/`](docs/aethon-agent/). The same files ship inside the binary as bundled resources so the agent can read them at runtime.
-
-For repository conventions and architecture deep-dives, see [`CLAUDE.md`](CLAUDE.md).
-
----
-
-## Releasing
-
-[`RELEASING.md`](RELEASING.md) walks through generating an updater signing keypair, configuring GitHub Actions secrets, and cutting a release that the in-app updater can consume.
-
----
+| Doc                                                    | What's there                                          |
+| ------------------------------------------------------ | ----------------------------------------------------- |
+| [`SPEC.md`](SPEC.md)                                   | Design vision and milestone status checklist          |
+| [`CLAUDE.md`](CLAUDE.md)                               | Architecture deep-dive, conventions, devshell details |
+| [`docs/aethon-agent/`](docs/aethon-agent/)             | Agent-side API surface, A2UI components, extensions   |
+| [`RELEASING.md`](RELEASING.md)                         | Updater keypair, CI secrets, cutting a release        |
+| [`CHANGELOG.md`](CHANGELOG.md)                         | Release notes                                         |
 
 ## License
 


### PR DESCRIPTION
## Summary

Trims `README.md` from ~150 lines to ~70. Moves architecture deep-dive,
devshell command table, and project layout tree to `CLAUDE.md` (which
already documents them in more depth). The README now orients a
first-time visitor in a screenful and links out for the rest.

## What changed

- **Kept**: hero, tagline, status warning, what-it-is paragraph, quick
  start, doc-index table, license.
- **Cut**: verbose "What it can do" bullet block (replaced by 5 punchy
  highlights), full devshell command table (now `dev` / `build-app` /
  `check` mentioned inline + pointer to `CLAUDE.md`), Mermaid
  architecture diagram + per-layer responsibilities table, project
  layout tree, expanded Nix package section, dedicated Releasing
  section (now a row in the docs table).
- Removed redundant tech badges (Tauri / React / Rust / Bun / Nix) —
  kept license, status, and platforms.

## Verification

- Trimmed file renders; diff stat: `1 file changed, 24 insertions(+), 107 deletions(-)`.
- All linked files (`SPEC.md`, `CLAUDE.md`, `docs/aethon-agent/`,
  `RELEASING.md`, `CHANGELOG.md`, `LICENSE`, `assets/brand/`) exist on
  `main`.

> Note: this PR was opened as part of testing the Claudette workflow;
> happy to close without merging if you'd rather keep the long-form README.