### PR TITLE
test(ci): intentional type error to verify CI failure detection

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -56,7 +56,7 @@ export interface AethonConfig {
 
 const DEFAULTS: AethonConfig = {
   ui: {
-    theme: null,
+    theme: 42, // TEST: intentional type error — number is not assignable to string | null
     fontSize: null,
     restoreTabs: false,
     notifyOnCompletion: true,


### PR DESCRIPTION
## Summary

- Assigns `42` (number) to `theme: string | null` in `src/config.ts` to produce a deliberate TypeScript compile error
- This PR exists to verify that CI correctly catches and reports type errors

## Test plan

- [ ] CI `check` job should fail with a `tsc` type error on `src/config.ts:59`
- [ ] No other jobs should be affected