### PR TITLE
docs(readme): extend tagline to reflect layout control

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </p>
 
 <p align="center">
-  <em>An agent-driven desktop shell where the agent decides what you see.</em>
+  <em>An agent-driven desktop shell where the agent decides what you see — and how.</em>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary

- Minor wording update to the README tagline: adds `— and how` to reinforce that the agent controls both content and layout, which is core to Aethon's design.

## Test plan

- [ ] Verify the tagline renders correctly in GitHub's Markdown preview