### PR TITLE
feat(chat): compact modern chat redesign

### DIFF
--- a/src/skills/default-layout/chat.tsx
+++ b/src/skills/default-layout/chat.tsx
@@ -60,16 +60,29 @@ export function formatToolDuration(ms: number): string {
 // Status icons for tool card pill
 function ToolStatusIcon({ running, isError, isLongRunning }: { running: boolean; isError: boolean; isLongRunning: boolean }) {
   if (running) {
+    const label = isLongRunning ? "Tool long-running" : "Tool running";
     return (
-      <span className={`ae-tool-status-icon ae-tool-status-running${isLongRunning ? " ae-tool-status-long" : ""}`} aria-label="running">
-        <span className="ae-tool-spinner" />
+      <span
+        role="img"
+        aria-label={label}
+        className={`ae-tool-status-icon ae-tool-status-running${isLongRunning ? " ae-tool-status-long" : ""}`}
+      >
+        <span className="ae-tool-spinner" aria-hidden="true" />
       </span>
     );
   }
   if (isError) {
-    return <span className="ae-tool-status-icon ae-tool-status-error" aria-label="failed">✕</span>;
+    return (
+      <span role="img" aria-label="Tool failed" className="ae-tool-status-icon ae-tool-status-error">
+        <span aria-hidden="true">✕</span>
+      </span>
+    );
   }
-  return <span className="ae-tool-status-icon ae-tool-status-done" aria-label="done">✓</span>;
+  return (
+    <span role="img" aria-label="Tool completed" className="ae-tool-status-icon ae-tool-status-done">
+      <span aria-hidden="true">✓</span>
+    </span>
+  );
 }
 
 export function ToolCard({
@@ -165,10 +178,10 @@ export function ToolCard({
 
 function TypingIndicator() {
   return (
-    <div className="ae-typing-indicator" aria-label="Agent is thinking">
-      <span className="ae-typing-dot" />
-      <span className="ae-typing-dot" />
-      <span className="ae-typing-dot" />
+    <div role="status" aria-label="Agent is thinking" className="ae-typing-indicator">
+      <span className="ae-typing-dot" aria-hidden="true" />
+      <span className="ae-typing-dot" aria-hidden="true" />
+      <span className="ae-typing-dot" aria-hidden="true" />
     </div>
   );
 }

--- a/src/skills/default-layout/chat.tsx
+++ b/src/skills/default-layout/chat.tsx
@@ -57,6 +57,21 @@ export function formatToolDuration(ms: number): string {
   return `${min}m ${sec.toString().padStart(2, "0")}s`;
 }
 
+// Status icons for tool card pill
+function ToolStatusIcon({ running, isError, isLongRunning }: { running: boolean; isError: boolean; isLongRunning: boolean }) {
+  if (running) {
+    return (
+      <span className={`ae-tool-status-icon ae-tool-status-running${isLongRunning ? " ae-tool-status-long" : ""}`} aria-label="running">
+        <span className="ae-tool-spinner" />
+      </span>
+    );
+  }
+  if (isError) {
+    return <span className="ae-tool-status-icon ae-tool-status-error" aria-label="failed">✕</span>;
+  }
+  return <span className="ae-tool-status-icon ae-tool-status-done" aria-label="done">✓</span>;
+}
+
 export function ToolCard({
   component,
   state,
@@ -108,21 +123,11 @@ export function ToolCard({
   const isLongRunning = running && elapsedMs >= TOOL_LONG_RUN_THRESHOLD_MS;
   const hasChildren = (component.children?.length ?? 0) > 0;
 
-  const titleSuffix = useMemo(() => {
-    if (running) return ` · running… ${formatToolDuration(elapsedMs)}`;
-    if (isError) return ` · failed in ${formatToolDuration(elapsedMs)}`;
-    if (startedAt !== undefined)
-      return ` · completed in ${formatToolDuration(elapsedMs)}`;
+  const timeSuffix = useMemo(() => {
+    if (running) return formatToolDuration(elapsedMs);
+    if (startedAt !== undefined) return formatToolDuration(elapsedMs);
     return "";
-  }, [running, isError, startedAt, elapsedMs]);
-
-  const accentColor = isError
-    ? "var(--danger, #c5494a)"
-    : isLongRunning
-      ? "var(--warning, #d18a2c)"
-      : running
-        ? "var(--accent)"
-        : "var(--text-dim)";
+  }, [running, startedAt, elapsedMs]);
 
   return (
     <details
@@ -132,25 +137,39 @@ export function ToolCard({
       data-error={isError ? "true" : "false"}
     >
       <summary className="ae-tool-card-summary">
-        <span className="ae-tool-card-title" style={{ color: accentColor }}>
-          <span className="ae-tool-card-title-base">{baseTitle}</span>
-          <span className="ae-tool-card-title-suffix">{titleSuffix}</span>
-        </span>
+        <ToolStatusIcon running={running} isError={isError} isLongRunning={isLongRunning} />
+        <span className="ae-tool-card-name">{baseTitle}</span>
         {description && (
           <span className="ae-tool-card-description">{description}</span>
         )}
+        {timeSuffix && (
+          <span className="ae-tool-card-time">{timeSuffix}</span>
+        )}
+        {isLongRunning && (
+          <span className="ae-tool-card-long-hint">long-running · <kbd>⌘.</kbd> to stop</span>
+        )}
       </summary>
       <div className="ae-tool-card-body">
-        {isLongRunning && (
-          <div className="ae-tool-card-warning">
-            Long-running command — press <kbd>⌘.</kbd> to stop.
-          </div>
-        )}
         {hasChildren ? renderChildren?.() : (
           <div className="ae-tool-card-empty">No output</div>
         )}
       </div>
     </details>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// TypingIndicator — animated three-dot pulse shown while the agent is thinking
+// (waiting=true but no streaming tokens yet).
+// ---------------------------------------------------------------------------
+
+function TypingIndicator() {
+  return (
+    <div className="ae-typing-indicator" aria-label="Agent is thinking">
+      <span className="ae-typing-dot" />
+      <span className="ae-typing-dot" />
+      <span className="ae-typing-dot" />
+    </div>
   );
 }
 
@@ -237,30 +256,31 @@ const ChatMessageRow = memo(
     state,
     tabId,
     className = "a2ui-chat-message",
+    prevRole,
   }: {
     message: ChatMessage;
     state: Record<string, unknown>;
     tabId?: string;
     className?: string;
+    prevRole?: string;
   }) {
+    const isCanvas = className === "a2ui-canvas-message";
+    const roleClass = isCanvas ? "a2ui-canvas-role" : "a2ui-chat-role";
+    const textClass = isCanvas ? "a2ui-canvas-text a2ui-markdown" : "a2ui-chat-text a2ui-markdown";
+    // Suppress role label for consecutive messages from same sender
+    const showRole = prevRole !== message.role;
     return (
-      <div className={`${className} ${message.role}`}>
-        <span className={className === "a2ui-canvas-message" ? "a2ui-canvas-role" : "a2ui-chat-role"}>
-          {roleBadge(message.role)}
-        </span>
+      <div className={`${className} ${message.role}${showRole ? "" : " ae-msg-cont"}`}>
+        {showRole && message.role !== "system" && (
+          <span className={roleClass}>{roleBadge(message.role)}</span>
+        )}
         {message.thinking && (
           <ThinkingBlock complete={Boolean(message.text)}>
             {message.thinking}
           </ThinkingBlock>
         )}
         {message.text && (
-          <div
-            className={
-              className === "a2ui-canvas-message"
-                ? "a2ui-canvas-text a2ui-markdown"
-                : "a2ui-chat-text a2ui-markdown"
-            }
-          >
+          <div className={textClass}>
             <MemoMarkdownWithThinking text={message.text} />
           </div>
         )}
@@ -274,6 +294,7 @@ const ChatMessageRow = memo(
     prev.message === next.message &&
     prev.tabId === next.tabId &&
     prev.className === next.className &&
+    prev.prevRole === next.prevRole &&
     (!next.message.a2ui || prev.state === next.state),
 );
 
@@ -382,8 +403,14 @@ export function ChatHistory({ component, state, tabId }: BuiltinComponentProps) 
               Load older messages ({hiddenCount})
             </button>
           )}
-          {visibleMessages.map((m) => (
-            <ChatMessageRow key={m.id} message={m} state={state} tabId={tabId} />
+          {visibleMessages.map((m, i) => (
+            <ChatMessageRow
+              key={m.id}
+              message={m}
+              state={state}
+              tabId={tabId}
+              prevRole={i > 0 ? visibleMessages[i - 1].role : undefined}
+            />
           ))}
         </>
       )}
@@ -477,19 +504,23 @@ export function MainCanvas({ component, state, tabId }: BuiltinComponentProps) {
           Load older messages ({hiddenCount})
         </button>
       )}
-      {visibleMessages.map((m) => (
+      {visibleMessages.map((m, i) => (
         <ChatMessageRow
           key={m.id}
           message={m}
           state={state}
           tabId={tabId}
           className="a2ui-canvas-message"
+          prevRole={i > 0 ? visibleMessages[i - 1].role : undefined}
         />
       ))}
       {liveSubtree && (
         <div className="a2ui-canvas-live">
           <A2UIRenderer payload={liveSubtree} state={state} tabId={tabId} />
         </div>
+      )}
+      {chatMode && state.waiting === true && !liveSubtree && messages.length > 0 && (
+        <TypingIndicator />
       )}
       {chatMode && (
         <ScrollToBottomPill

--- a/src/styles.css
+++ b/src/styles.css
@@ -229,9 +229,15 @@
   }
   .a2ui-terminal,
   .ae-agent-pill-dot,
-  .app-header-pill[data-state="thinking"]::before {
+  .app-header-pill[data-state="thinking"]::before,
+  .ae-typing-dot,
+  .ae-tool-spinner {
     animation: none !important;
   }
+  /* Keep dots visible but static when motion is reduced */
+  .ae-typing-dot { opacity: 0.35; }
+  /* Keep spinner visible as a static partial ring */
+  .ae-tool-spinner { opacity: 0.6; }
 }
 
 * {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1007,8 +1007,8 @@ body.ae-resizing-sidebar .a2ui-layout {
   min-width: 0;
   min-height: 0;
   overflow-y: auto;
-  padding: 20px;
-  gap: 12px;
+  padding: 16px 20px 12px;
+  gap: 4px;
   background: var(--bg);
 }
 
@@ -1261,31 +1261,62 @@ body.ae-resizing-sidebar .a2ui-layout {
 }
 
 .a2ui-canvas-message {
-  max-width: min(70%, 100%);
+  max-width: min(88%, 100%);
   min-width: 0;
-  padding: 10px 14px;
-  border-radius: 12px;
-  border: 1px solid var(--border);
+  padding: 8px 12px;
+  line-height: 1.5;
 }
 
 .a2ui-canvas-message.user {
   align-self: flex-end;
   background: var(--user-bubble);
+  border: 1px solid var(--border);
+  border-radius: 14px 14px 4px 14px;
+  margin-left: 14%;
+  margin-top: 8px;
+}
+.a2ui-canvas-message.user.ae-msg-cont {
+  border-radius: 14px 4px 4px 14px;
+  margin-top: -2px;
 }
 
-.a2ui-canvas-message.agent,
+.a2ui-canvas-message.agent {
+  align-self: stretch;
+  background: transparent;
+  max-width: 100%;
+  padding-left: 4px;
+  margin-top: 12px;
+}
+.a2ui-canvas-message.agent.ae-msg-cont {
+  margin-top: 2px;
+}
+.a2ui-canvas-message.agent .a2ui-canvas-role {
+  color: color-mix(in oklab, var(--accent) 55%, var(--text-dim));
+}
+
 .a2ui-canvas-message.system {
-  align-self: flex-start;
-  background: var(--agent-bubble);
+  align-self: center;
+  background: transparent;
+  border: 0;
+  font-size: var(--text-xs);
+  color: var(--text-dim);
+  opacity: 0.7;
+  max-width: 100%;
 }
 
 .a2ui-canvas-role {
   display: block;
-  font-size: var(--chrome-text-muted);
-  color: var(--text-dim);
-  margin-bottom: 4px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.09em;
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  color: var(--accent);
+  margin-bottom: 4px;
+  opacity: 0.65;
+}
+.a2ui-canvas-message.user .a2ui-canvas-role {
+  color: var(--text-dim);
+  text-align: right;
 }
 
 .a2ui-canvas-text {
@@ -1348,8 +1379,8 @@ body.ae-resizing-sidebar .a2ui-layout {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 .a2ui-markdown pre {
-  margin: 0.5em 0;
-  padding: 10px 12px;
+  margin: 0.35em 0;
+  padding: 8px 12px;
   background: var(--bg-input);
   border: 1px solid var(--border);
   border-radius: 6px;
@@ -1369,15 +1400,15 @@ body.ae-resizing-sidebar .a2ui-layout {
    visually agree when mixed in the same message. */
 .a2ui-code {
   position: relative;
-  margin: 0.5em 0;
-  padding: 12px 14px;
+  margin: 0.35em 0;
+  padding: 8px 12px;
   background: var(--bg-input);
   border: 1px solid var(--border);
   border-radius: 6px;
   overflow-x: auto;
   font-family: var(--font-mono);
   font-size: var(--text-sm);
-  line-height: 1.55;
+  line-height: 1.5;
   color: var(--syntax-text, var(--text));
   white-space: pre;
   max-width: 100%;
@@ -1390,6 +1421,20 @@ body.ae-resizing-sidebar .a2ui-layout {
   display: block;
   width: max-content;
   min-width: 100%;
+}
+
+/* `text` language blocks — typically file paths and single commands.
+   Render as a compact reference chip with a left accent bar. */
+.a2ui-code[data-language="text"] {
+  padding: 5px 10px 5px 10px;
+  font-size: var(--chrome-text-compact);
+  line-height: 1.45;
+  border-left: 2px solid var(--accent);
+  border-radius: 0 6px 6px 0;
+  color: var(--text-dim);
+}
+.a2ui-code[data-language="text"] .a2ui-code-lang {
+  display: none;
 }
 .a2ui-code-line {
   display: block;
@@ -1545,8 +1590,8 @@ body.ae-resizing-sidebar .a2ui-layout {
   min-width: 0;
   min-height: 0;
   overflow-y: auto;
-  padding: 16px 12px 12px;
-  gap: 10px;
+  padding: 12px 12px 8px;
+  gap: 4px;
   contain: layout style;
 }
 
@@ -1569,32 +1614,47 @@ body.ae-resizing-sidebar .a2ui-layout {
 
 /* Base bubble — shared by all roles. */
 .a2ui-chat-message {
-  padding: 10px 14px;
+  padding: 8px 12px;
   font-size: var(--text-sm);
   min-width: 0;
   max-width: 88%;
-  line-height: 1.55;
+  line-height: 1.5;
   position: relative;
 }
 
-/* User messages: right-aligned bubble with a flat bottom-right corner
-   (standard chat convention), pushed to the right. */
+/* Continuation message — same sender, no top margin needed */
+.a2ui-chat-message.ae-msg-cont {
+  margin-top: -2px;
+}
+
+/* User messages: right-aligned bubble, compact. */
 .a2ui-chat-message.user {
   background: var(--user-bubble);
   border: 1px solid var(--border);
   border-radius: 14px 14px 4px 14px;
   align-self: flex-end;
-  margin-left: 12%;
+  margin-left: 14%;
+  margin-top: 8px;
+}
+.a2ui-chat-message.user.ae-msg-cont {
+  border-radius: 14px 4px 4px 14px;
+  margin-top: -2px;
 }
 
-/* Agent messages: left-aligned, borderless — the background colour
-   provides enough separation without border noise. */
+/* Agent messages: full-width, no heavy box. */
 .a2ui-chat-message.agent {
-  background: var(--agent-bubble);
-  border: 1px solid transparent;
-  border-radius: 4px 14px 14px 14px;
-  align-self: flex-start;
-  margin-right: 4%;
+  background: transparent;
+  border: 0;
+  align-self: stretch;
+  max-width: 100%;
+  padding-left: 4px;
+  margin-top: 12px;
+}
+.a2ui-chat-message.agent.ae-msg-cont {
+  margin-top: 2px;
+}
+.a2ui-chat-message.agent .a2ui-chat-role {
+  color: color-mix(in oklab, var(--accent) 55%, var(--text-dim));
 }
 
 /* System bubbles: faint log-line style — not part of the conversation. */
@@ -1620,19 +1680,21 @@ body.ae-resizing-sidebar .a2ui-layout {
   display: none;
 }
 
-/* Role badge — small pill above the bubble content. */
+/* Role badge — slim label above first message in a run. */
 .a2ui-chat-role {
-  display: inline-block;
-  font-size: var(--chrome-text-muted);
+  display: block;
+  font-size: 10px;
   font-weight: 700;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
   color: var(--accent);
-  margin-bottom: 5px;
-  opacity: 0.75;
+  margin-bottom: 4px;
+  opacity: 0.65;
 }
 
 .a2ui-chat-message.user .a2ui-chat-role {
   color: var(--text-dim);
+  text-align: right;
 }
 
 .a2ui-chat-empty {
@@ -1679,6 +1741,34 @@ body.ae-resizing-sidebar .a2ui-layout {
     opacity: 1;
     transform: translateY(0);
   }
+}
+
+/* ---- Typing indicator --------------------------------------------------- */
+
+.ae-typing-indicator {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 10px 4px 4px;
+  align-self: flex-start;
+}
+
+.ae-typing-dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  background: var(--text-dim);
+  border-radius: 50%;
+  opacity: 0.4;
+  animation: ae-dot-pulse 1.2s ease-in-out infinite both;
+}
+.ae-typing-dot:nth-child(1) { animation-delay: 0s; }
+.ae-typing-dot:nth-child(2) { animation-delay: 0.2s; }
+.ae-typing-dot:nth-child(3) { animation-delay: 0.4s; }
+
+@keyframes ae-dot-pulse {
+  0%, 80%, 100% { opacity: 0.25; transform: scale(0.85); }
+  40%            { opacity: 0.9;  transform: scale(1.1); }
 }
 
 /* ---- Chat input --------------------------------------------------------- */
@@ -2919,77 +3009,156 @@ body.ae-resizing-terminal * {
    warning amber, error = danger red.
    ============================================================================= */
 
+/* Tool card — compact pill style, collapsed by default */
 .ae-tool-card {
-  background: var(--bg-elev);
+  background: transparent;
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: 20px;
   padding: 0;
   min-width: 0;
   max-width: 100%;
-  transition: border-color 120ms ease;
+  width: fit-content;
+  transition: border-color 120ms ease, background 120ms ease;
+}
+.ae-tool-card[open] {
+  border-radius: 10px;
+  width: 100%;
+  background: var(--bg-elev);
 }
 .ae-tool-card[data-running="true"] {
-  border-color: color-mix(in oklab, var(--accent) 35%, var(--border));
+  border-color: color-mix(in oklab, var(--accent) 40%, var(--border));
 }
 .ae-tool-card[data-long-running="true"] {
-  border-color: color-mix(in oklab, var(--warning, #d18a2c) 50%, var(--border));
+  border-color: color-mix(in oklab, var(--warning, #d18a2c) 55%, var(--border));
 }
 .ae-tool-card[data-error="true"] {
-  border-color: color-mix(in oklab, var(--danger, #c5494a) 50%, var(--border));
+  border-color: color-mix(in oklab, var(--danger, #c5494a) 55%, var(--border));
 }
 
 .ae-tool-card-summary {
   display: flex;
-  flex-direction: column;
-  gap: 5px;
-  padding: 10px 14px;
+  flex-direction: row;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px 4px 8px;
   cursor: pointer;
-  list-style-position: outside;
+  list-style: none;
+  user-select: none;
+  white-space: nowrap;
+  overflow: hidden;
 }
-
-.ae-tool-card-summary::marker {
-  color: var(--text-dim);
+.ae-tool-card-summary::-webkit-details-marker {
+  display: none;
+}
+.ae-tool-card[open] .ae-tool-card-summary {
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--border);
+  border-radius: 10px 10px 0 0;
+  white-space: normal;
 }
 
 .ae-tool-card-body {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  border-top: 1px solid var(--border);
   padding: 8px 10px 10px;
   min-width: 0;
 }
 
-.ae-tool-card-title {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: baseline;
-  gap: 6px;
-  font-weight: 500;
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: var(--chrome-text-compact);
+/* Status icon + spinner */
+.ae-tool-status-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  font-size: 10px;
+  font-weight: 700;
+  border-radius: 50%;
 }
-.ae-tool-card-title-base {
-  color: var(--text);
+.ae-tool-status-done {
+  color: var(--text-dim);
 }
-.ae-tool-card-title-suffix {
-  color: inherit;
-  font-variant-numeric: tabular-nums;
-  opacity: 0.85;
+.ae-tool-status-error {
+  color: var(--danger, #c5494a);
+}
+.ae-tool-status-running {
+  color: var(--accent);
+}
+.ae-tool-status-long {
+  color: var(--warning, #d18a2c);
 }
 
-.ae-tool-card-warning {
-  font-size: var(--chrome-text-muted);
-  color: var(--warning, #d18a2c);
-  font-style: italic;
+/* Spinning ring animation */
+.ae-tool-spinner {
+  display: inline-block;
+  width: 11px;
+  height: 11px;
+  border: 2px solid color-mix(in oklab, var(--accent) 30%, transparent);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: ae-spin 0.7s linear infinite;
+}
+.ae-tool-status-long .ae-tool-spinner {
+  border-top-color: var(--warning, #d18a2c);
+  border-color: color-mix(in oklab, var(--warning, #d18a2c) 30%, transparent);
+}
+
+@keyframes ae-spin {
+  to { transform: rotate(360deg); }
+}
+
+.ae-tool-card-name {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: var(--chrome-text-compact);
+  font-weight: 500;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
 }
 
 .ae-tool-card-description {
   color: var(--text-dim);
   font-size: var(--chrome-text-muted);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+  min-width: 0;
+}
+.ae-tool-card[open] .ae-tool-card-description {
   white-space: pre-wrap;
   word-break: break-word;
+  overflow: visible;
+  text-overflow: unset;
+}
+
+.ae-tool-card-time {
+  color: var(--text-dim);
+  font-size: var(--chrome-text-muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+  margin-left: auto;
+  padding-left: 8px;
+}
+.ae-tool-card[data-running="true"] .ae-tool-card-time {
+  color: var(--accent);
+}
+.ae-tool-card[data-error="true"] .ae-tool-card-time {
+  color: var(--danger, #c5494a);
+}
+
+.ae-tool-card-long-hint {
+  color: var(--warning, #d18a2c);
+  font-size: var(--chrome-text-muted);
+  flex-shrink: 0;
+}
+.ae-tool-card-long-hint kbd {
+  font-family: inherit;
+  opacity: 0.8;
 }
 
 .ae-tool-card-empty {

--- a/src/styles.css
+++ b/src/styles.css
@@ -244,6 +244,7 @@ body,
   height: 100%;
   width: 100%;
   overflow: hidden;
+  overscroll-behavior: none;
 }
 
 body {
@@ -352,6 +353,7 @@ body {
   min-width: 0;
   min-height: 0;
   overflow-y: auto;
+  overscroll-behavior: none;
   position: relative;
 }
 
@@ -1007,6 +1009,7 @@ body.ae-resizing-sidebar .a2ui-layout {
   min-width: 0;
   min-height: 0;
   overflow-y: auto;
+  overscroll-behavior: none;
   padding: 16px 20px 12px;
   gap: 4px;
   background: var(--bg);
@@ -1041,6 +1044,7 @@ body.ae-resizing-sidebar .a2ui-layout {
   background: var(--bg);
   padding: 40px 20px;
   overflow-y: auto;
+  overscroll-behavior: none;
 }
 
 .a2ui-empty-state-card {
@@ -1273,22 +1277,25 @@ body.ae-resizing-sidebar .a2ui-layout {
   border: 1px solid var(--border);
   border-radius: 14px 14px 4px 14px;
   margin-left: 14%;
-  margin-top: 8px;
+  margin-top: 10px;
 }
 .a2ui-canvas-message.user.ae-msg-cont {
   border-radius: 14px 4px 4px 14px;
-  margin-top: -2px;
+  margin-top: 2px;
 }
 
 .a2ui-canvas-message.agent {
   align-self: stretch;
   background: transparent;
+  border-top: 1px solid color-mix(in oklab, var(--border) 45%, transparent);
   max-width: 100%;
-  padding-left: 4px;
-  margin-top: 12px;
+  padding: 8px 12px 4px 4px;
+  margin-top: 8px;
 }
 .a2ui-canvas-message.agent.ae-msg-cont {
-  margin-top: 2px;
+  border-top: none;
+  padding-top: 2px;
+  margin-top: 1px;
 }
 .a2ui-canvas-message.agent .a2ui-canvas-role {
   color: color-mix(in oklab, var(--accent) 55%, var(--text-dim));
@@ -1311,12 +1318,13 @@ body.ae-resizing-sidebar .a2ui-layout {
   letter-spacing: 0.09em;
   text-transform: uppercase;
   color: var(--accent);
-  margin-bottom: 4px;
-  opacity: 0.65;
+  margin-bottom: 3px;
+  opacity: 0.8;
 }
 .a2ui-canvas-message.user .a2ui-canvas-role {
   color: var(--text-dim);
   text-align: right;
+  opacity: 0.55;
 }
 
 .a2ui-canvas-text {
@@ -1426,12 +1434,23 @@ body.ae-resizing-sidebar .a2ui-layout {
 /* `text` language blocks — typically file paths and single commands.
    Render as a compact reference chip with a left accent bar. */
 .a2ui-code[data-language="text"] {
-  padding: 5px 10px 5px 10px;
+  padding: 4px 10px;
   font-size: var(--chrome-text-compact);
   line-height: 1.45;
   border-left: 2px solid var(--accent);
-  border-radius: 0 6px 6px 0;
+  border-right: none;
+  border-top: none;
+  border-bottom: none;
+  border-radius: 0;
+  background: transparent;
   color: var(--text-dim);
+  width: fit-content;
+  max-width: 100%;
+  margin: 0.2em 0;
+}
+.a2ui-code[data-language="text"] code {
+  width: auto;
+  min-width: 0;
 }
 .a2ui-code[data-language="text"] .a2ui-code-lang {
   display: none;
@@ -1450,17 +1469,14 @@ body.ae-resizing-sidebar .a2ui-layout {
 }
 .a2ui-code-lang {
   position: absolute;
-  top: 6px;
-  right: 10px;
+  top: 5px;
+  right: 8px;
   font-family: var(--font-mono);
-  font-size: var(--chrome-text-muted);
+  font-size: 10px;
   letter-spacing: 0.04em;
   text-transform: lowercase;
   color: var(--text-dim);
-  background: var(--bg);
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  padding: 1px 8px;
+  opacity: 0.55;
   pointer-events: none;
 }
 .a2ui-code-inline {
@@ -1550,27 +1566,29 @@ body.ae-resizing-sidebar .a2ui-layout {
 }
 
 .a2ui-thinking-block {
-  margin: 0.45em 0;
-  padding: 8px 10px;
-  background: color-mix(in srgb, var(--bg-input) 78%, transparent);
-  border: 1px solid var(--border);
-  border-left: 3px solid var(--text-dim);
-  border-radius: 6px;
+  margin: 0.3em 0;
+  padding: 5px 8px;
+  background: transparent;
+  border: none;
+  border-left: 2px solid color-mix(in oklab, var(--text-dim) 40%, transparent);
+  border-radius: 0;
   color: var(--text-dim);
 }
 
 .a2ui-thinking-block summary {
   cursor: pointer;
   user-select: none;
-  font-size: var(--chrome-text-muted);
+  font-size: 10px;
   font-weight: 700;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
+  opacity: 0.6;
 }
 
 .a2ui-thinking-content {
-  margin-top: 6px;
-  font-size: 0.95em;
+  margin-top: 4px;
+  font-size: 0.9em;
+  opacity: 0.75;
 }
 
 .a2ui-canvas-live {
@@ -1590,6 +1608,7 @@ body.ae-resizing-sidebar .a2ui-layout {
   min-width: 0;
   min-height: 0;
   overflow-y: auto;
+  overscroll-behavior: none;
   padding: 12px 12px 8px;
   gap: 4px;
   contain: layout style;
@@ -1634,24 +1653,27 @@ body.ae-resizing-sidebar .a2ui-layout {
   border-radius: 14px 14px 4px 14px;
   align-self: flex-end;
   margin-left: 14%;
-  margin-top: 8px;
+  margin-top: 10px;
 }
 .a2ui-chat-message.user.ae-msg-cont {
   border-radius: 14px 4px 4px 14px;
-  margin-top: -2px;
+  margin-top: 2px;
 }
 
 /* Agent messages: full-width, no heavy box. */
 .a2ui-chat-message.agent {
   background: transparent;
   border: 0;
+  border-top: 1px solid color-mix(in oklab, var(--border) 45%, transparent);
   align-self: stretch;
   max-width: 100%;
-  padding-left: 4px;
-  margin-top: 12px;
+  padding: 8px 12px 4px 4px;
+  margin-top: 8px;
 }
 .a2ui-chat-message.agent.ae-msg-cont {
-  margin-top: 2px;
+  border-top: none;
+  padding-top: 2px;
+  margin-top: 1px;
 }
 .a2ui-chat-message.agent .a2ui-chat-role {
   color: color-mix(in oklab, var(--accent) 55%, var(--text-dim));
@@ -1688,13 +1710,14 @@ body.ae-resizing-sidebar .a2ui-layout {
   letter-spacing: 0.09em;
   text-transform: uppercase;
   color: var(--accent);
-  margin-bottom: 4px;
-  opacity: 0.65;
+  margin-bottom: 3px;
+  opacity: 0.8;
 }
 
 .a2ui-chat-message.user .a2ui-chat-role {
   color: var(--text-dim);
   text-align: right;
+  opacity: 0.55;
 }
 
 .a2ui-chat-empty {
@@ -2337,6 +2360,7 @@ body.ae-resizing-sidebar .a2ui-layout {
 .ae-palette-list {
   flex: 1;
   overflow-y: auto;
+  overscroll-behavior: none;
   padding: 4px 0;
 }
 
@@ -2727,6 +2751,7 @@ body.ae-resizing-terminal * {
 .ae-settings-body {
   padding: 16px 20px;
   overflow-y: auto;
+  overscroll-behavior: none;
   flex: 1 1 auto;
 }
 .ae-settings-section {
@@ -2881,6 +2906,7 @@ body.ae-resizing-terminal * {
 .ae-search-results {
   flex: 1 1 auto;
   overflow-y: auto;
+  overscroll-behavior: none;
   padding: 6px 0;
 }
 .ae-search-empty {


### PR DESCRIPTION
## Summary

- **Compact message layout** — agent messages are full-width unbounded text (no heavy bubble box); user messages stay as right-aligned bubbles with tighter padding
- **Tool cards** — redesigned as horizontal inline pills: spinning ring icon while running, ✓/✕ status icons on completion, time inline, long-running hint. Collapsed by default.
- **`text` code blocks** — file paths and command references now render as compact left-accent chips instead of full-width dark boxes
- **Turn separators** — subtle hairline above each new AI turn; consecutive messages from the same sender suppress both the role badge and the separator (`ae-msg-cont`)
- **Typing indicator** — three-dot pulse shown when `waiting=true` before first token arrives
- **No rubber-band scroll** — `overscroll-behavior: none` on all scrollable containers (canvas, chat-history, sidebar, palette, settings, search)
- **Thinking blocks** — minimal left-border strip, transparent background, smaller label
- **Code block lang badge** — plain dim text, no pill border

## Visual changes

| Before | After |
|--------|-------|
| Agent messages: large bordered box with `agent-bubble` background | Full-width flat text, subtle turn separator line |
| Tool cards: full box with column layout | Compact horizontal pill, spinner animation |
| `text` blocks: full-width dark rectangle | Left-accent chip, `fit-content` width |
| All panes: WebKit rubber-band bounce | `overscroll-behavior: none` throughout |

## Test plan

- [ ] Send a chat message and verify user bubble + AI response layout
- [ ] Trigger a tool call and verify pill style with running spinner → ✓ complete
- [ ] Expand a tool card to verify body content renders correctly
- [ ] Check consecutive messages from same sender suppress role badge
- [ ] Verify typing indicator appears between send and first token
- [ ] Scroll to top/bottom in chat — confirm no rubber-band bounce
- [ ] Check light theme (Paper — cream light) renders acceptably