### PR TITLE
feat(theme): add Brink palette

### DIFF
--- a/agent/extension-loader.ts
+++ b/agent/extension-loader.ts
@@ -43,6 +43,7 @@ export const RESERVED_THEME_IDS = new Set([
   "paper",
   "aether",
   "signature",
+  "brink",
 ]);
 
 export interface ExtensionLoaderDeps {

--- a/agent/system-prompt.ts
+++ b/agent/system-prompt.ts
@@ -417,7 +417,7 @@ export function buildRuntimeSection(snapshot: RuntimeSnapshot): string {
 
   if (snapshot.themes.length > 0) {
     lines.push("");
-    lines.push("Registered themes (in addition to the built-in ember / paper / aether palettes):");
+    lines.push("Registered themes (in addition to the built-in ember / paper / aether / brink palettes):");
     for (const t of snapshot.themes) {
       lines.push(`- \`${t.id}\` — ${t.label}`);
     }

--- a/docs/aethon-agent/components.md
+++ b/docs/aethon-agent/components.md
@@ -698,7 +698,7 @@ Clicking the share-mode badge cycles through the four modes (`private`
 
 The xterm theme reads from CSS custom properties — `--terminal-bg`,
 `--terminal-fg`, `--terminal-cursor`, `--terminal-selection`, plus the
-16 `--ansi-*` keys. Built-in themes (`ember`, `paper`, `aether`) ship
+16 `--ansi-*` keys. Built-in themes (`ember`, `paper`, `aether`, `brink`) ship
 all 20; extension themes can opt in by setting them in the theme's
 `vars` block, otherwise xterm falls back to a sensible dark default.
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,8 +8,8 @@ import { SHARE_MODES } from "./utils/shareMode";
 export interface AethonConfig {
   ui: {
     /** Theme id from `[ui] theme = "..."`. Built-ins are
-     *  `ember`, `paper`, and `aether`; legacy `signature` maps to
-     *  `aether`. Extensions can register additional ids via
+     *  `ember`, `paper`, `aether`, and `brink`; legacy `signature` maps
+     *  to `aether`. Extensions can register additional ids via
      *  `aethon.registerTheme`. */
     theme: string | null;
     fontSize: number | null;

--- a/src/hooks/useExtensionsHydration.ts
+++ b/src/hooks/useExtensionsHydration.ts
@@ -61,6 +61,7 @@ export const BUILTIN_THEMES: { id: string; label: string }[] = [
   { id: "ember", label: "Ember — warm dark" },
   { id: "paper", label: "Paper — cream light" },
   { id: "aether", label: "Æther — signature" },
+  { id: "brink", label: "Brink — Ristretto warm chrome with gold accent" },
 ];
 
 export interface UseExtensionsHydrationContext {

--- a/src/skills/default-layout/settings-panel.tsx
+++ b/src/skills/default-layout/settings-panel.tsx
@@ -39,6 +39,7 @@ const BUILTIN_THEMES = [
   { id: "ember", label: "Ember — warm dark" },
   { id: "paper", label: "Paper — cream light" },
   { id: "aether", label: "Æther — signature" },
+  { id: "brink", label: "Brink — Ristretto warm chrome with gold accent" },
 ];
 
 // 16-swatch ANSI preview block — order matches xterm's standard ANSI

--- a/src/skills/default-layout/workstation.a2ui.json
+++ b/src/skills/default-layout/workstation.a2ui.json
@@ -202,7 +202,8 @@
       "themes": [
         { "id": "ember", "label": "Ember — warm dark", "active": true },
         { "id": "paper", "label": "Paper — cream light" },
-        { "id": "aether", "label": "Æther — signature" }
+        { "id": "aether", "label": "Æther — signature" },
+        { "id": "brink", "label": "Brink — Ristretto warm chrome with gold accent" }
       ]
     },
     "projects": [],

--- a/src/styles.css
+++ b/src/styles.css
@@ -212,6 +212,67 @@
   --ansi-bright-white: #fef3e2;
 }
 
+/* Brink — mid-tone warm chrome (Ristretto base) with gold accent. Ported
+   from the Claudette `brink` theme; ANSI + syntax tokens derived to keep
+   the Ristretto/Tokyo-Night cohort cohesive (gold keywords, pink errors,
+   cyan functions, lavender symbols). */
+:root[data-theme="brink"] {
+  color-scheme: dark;
+  --bg: #2c2525;
+  --bg-elev: #504646;
+  --bg-input: #241e1e;
+  --border: #6e6464;
+  --text: #f1e5e7;
+  --text-dim: #d0c4c6;
+  --accent: #f9cc6c;
+  --accent-soft: rgba(249, 204, 108, 0.2);
+  --accent-hover-tint: rgba(249, 204, 108, 0.1);
+  --accent-active-tint: rgba(249, 204, 108, 0.16);
+  --btn-text: #2c2525;
+  --user-bubble: #3a302f;
+  --agent-bubble: #3f3434;
+  --scrollbar-thumb: #6e6464;
+  --scrollbar-thumb-hover: #7a6e70;
+  --success: #adda78;
+  --warn: #f9cc6c;
+  --error: #fd6883;
+  /* Syntax-highlighting palette — Brink (Ristretto-flavored). Gold
+     keywords on warm brown; symbols/functions/variables ride the same
+     pink/cyan/lavender accents the chat surfaces use. */
+  --syntax-text: #f1e5e7;
+  --syntax-comment: #907e80;
+  --syntax-punctuation: #b0a4a6;
+  --syntax-keyword: #f9cc6c;
+  --syntax-string: #adda78;
+  --syntax-number: #f38d70;
+  --syntax-symbol: #a8a9eb;
+  --syntax-operator: #d0c4c6;
+  --syntax-function: #85dacc;
+  --syntax-variable: #fd6883;
+  /* xterm theme + ANSI palette — Brink (Ristretto). Terminal uses the
+     darker chat-input brown so it visually anchors below the chrome. */
+  --terminal-bg: #1e1818;
+  --terminal-fg: #f1e5e7;
+  --terminal-cursor: #f9cc6c;
+  --terminal-selection: rgba(249, 204, 108, 0.28);
+  --ansi-black: #241e1e;
+  --ansi-red: #fd6883;
+  --ansi-green: #adda78;
+  --ansi-yellow: #f9cc6c;
+  --ansi-blue: #82aaff;
+  --ansi-magenta: #a8a9eb;
+  --ansi-cyan: #85dacc;
+  --ansi-white: #d0c4c6;
+  --ansi-bright-black: #504646;
+  --ansi-bright-red: #ff8294;
+  --ansi-bright-green: #c2e893;
+  --ansi-bright-yellow: #ffd98a;
+  --ansi-bright-blue: #9bb8ff;
+  --ansi-bright-magenta: #c4c5f4;
+  --ansi-bright-cyan: #a8e8de;
+  --ansi-bright-white: #f1e5e7;
+}
+
 /* Motion timing tokens + reduced-motion + focus-ring tokens — applied
    across every palette so a single declaration controls every component. */
 :root {


### PR DESCRIPTION
## Summary

- Adds a fourth built-in theme, **Brink**, ported from the [`feat/theme-brink`](https://github.com/utensils/Claudette/tree/feat/theme-brink) branch of Claudette. Warm brown chrome (`#2c2525`), mid-tone sidebar (`#504646`), gold accent (`#f9cc6c`), pink/coral mascot — Ristretto vibes.
- Adds matching syntax + 16-color ANSI tokens (Claudette's Brink only ships chrome tokens, so these are derived: gold keywords, green strings, coral errors, cyan functions, lavender symbols) so the terminal + code highlighter pick up the theme without falling back to xterm defaults.
- Registers `brink` in:
  - `RESERVED_THEME_IDS` (extensions can't claim the id)
  - `BUILTIN_THEMES` (sidebar + settings dropdown)
  - `workstation.a2ui.json` (boot payload's sidebar themes list)
  - `system-prompt.ts` (agent's known-themes line)

## Verification

- `check` passes (clippy + tsc + ESLint + cargo test + 677 vitest tests, all green).
- Live verified via `aethon-debug`: setting `data-theme="brink"` on `<html>` resolves every token through CSSOM (`--bg #2c2525`, `--accent #f9cc6c`, `--ansi-yellow #f9cc6c`, `--syntax-keyword #f9cc6c`, `--terminal-bg #1e1818`).
- Sidebar themes list now reports four entries with `brink` selectable.

## Test plan

- [ ] Open Settings → Theme dropdown → Brink and confirm chrome flips.
- [ ] Open a shell tab and confirm xterm picks up the brink ANSI palette.
- [ ] Confirm a code block in chat renders with the gold-keyword syntax palette.