### PR TITLE
feat: host-rooted UI + mDNS server scaffold + project icons + widen layout

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -89,7 +89,7 @@ A PR that adds or changes a keyboard shortcut **must** update all three:
 3. The palette listing in `src/skills/default-layout/palette-items.ts`
    (`BUILTIN_KEYBINDINGS`)
 
-Plus the docs in `CLAUDE.md`, `AGENTS.md`, `website/reference/keyboard-shortcuts.md`,
+Plus the canonical docs: `AGENTS.md`, `website/reference/keyboard-shortcuts.md`,
 `website/guide/quick-start.md`, and `docs/aethon-agent/api.md`. Drift
 between these is a frequent regression source — flag it in review.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,726 +5,301 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Project
 
 Aethon is a Tauri 2 + React + TypeScript desktop app. See `SPEC.md` for the
-design vision and `README.md` for the public-facing description.
+design vision and milestone checklist; `RELEASING.md` for the release flow.
 
-The Tauri shell is intentionally thin — agent logic lives elsewhere. The Rust
-side handles OS boundaries; the React frontend renders A2UI components emitted
-by the agent.
+The Tauri shell is intentionally thin — the Rust side handles OS boundaries
+and the React frontend renders A2UI payloads emitted by a TS agent
+subprocess. Business logic belongs in the agent, not the shell.
 
 ## Stack
 
-- **Backend**: Rust + Tauri 2, crate name `aethon`, lib name `aethon_lib`
+- **Backend**: Rust + Tauri 2 (crate `aethon`, lib `aethon_lib`)
 - **Frontend**: React 19, TypeScript, Vite, bun
-- **Agent**: TypeScript via `@mariozechner/pi-coding-agent`, run as a `bun`
-  subprocess spawned from the Rust shell
+- **Agent**: `@mariozechner/pi-coding-agent` run as a `bun` subprocess
 - **Dev env**: Nix flake (flake-parts + numtide/devshell + treefmt-nix +
-  rust-overlay), Rust toolchain pinned at **1.92.0** in `flake.nix` (via
-  rust-overlay); `rust-toolchain.toml` says `channel = "stable"` for non-Nix
-  builds — the Nix pin takes precedence inside the devshell
-- **Targets**: macOS (aarch64), Linux (x86_64 / aarch64), Windows (later)
+  rust-overlay). Rust pinned to **1.92.0** in `flake.nix`; bumping past 1.95
+  currently breaks `icu_provider` / `regex-automata` / `objc2` transitive
+  deps. `rust-toolchain.toml` is for non-Nix builds; the Nix pin wins inside
+  the devshell.
 
-## Common Commands
+## Common commands
 
-Run inside `nix develop` (or via direnv — `.envrc` bootstraps `nix-direnv`
-then `use flake`, so reentering the shell is cached and instant). The
-devshell exposes these helpers (defined in `flake.nix`):
+Run inside `nix develop` (direnv auto-activates via `.envrc`). Devshell
+helpers (defined in `flake.nix`):
 
-| Command     | What it does                                                                  |
-| ----------- | ----------------------------------------------------------------------------- |
-| `dev`       | `scripts/dev.sh` → `cargo tauri dev` with port auto-increment                 |
-| `build-app` | `cargo tauri build` — release bundle                                          |
-| `check`     | Full CI gate: clippy + tsc + ESLint + cargo test + vitest                     |
-| `lint`      | ESLint frontend + agent (no auto-fix)                                         |
-| `test`      | Run Rust + TS tests (cargo test --lib + vitest run)                           |
-| `coverage`  | TS coverage report under `coverage/` (vitest v8)                              |
-| `fmt`       | `treefmt` (rustfmt + nixfmt + prettier for JSON/MD/YAML/CSS + taplo for TOML) |
+| Command     | What it does                                                    |
+| ----------- | --------------------------------------------------------------- |
+| `dev`       | `scripts/dev.sh` → `cargo tauri dev` with port auto-increment   |
+| `build-app` | `cargo tauri build` — release bundle                            |
+| `check`     | CI gate: clippy + tsc + ESLint + cargo test + vitest            |
+| `lint`      | ESLint (no auto-fix)                                            |
+| `test`      | `cargo test --lib` + `bunx vitest run`                          |
+| `coverage`  | TS coverage report (vitest v8) → `coverage/`                    |
+| `fmt`       | treefmt (rustfmt + nixfmt + prettier + taplo)                   |
 
-`bun tauri dev` and `bun tauri build` also work (they go through the JS-side
-`@tauri-apps/cli` wrapper). One-time after pulling: `bun install`.
+ESLint is configured for **0 errors and 0 warnings**.
 
-`scripts/dev.sh` carries two state-sandbox flags (mirroring Claudette):
+Single tests:
+- TS file: `bunx vitest run agent/terminal-stream.test.ts`
+- TS by name: `bunx vitest run -t "test name pattern"`
+- Rust: `cargo test --lib -p aethon -- helpers::test_name`
 
-- `dev --new` — spin up against an empty `~/.aethon`. Points
-  `AETHON_USER_DIR` at `${TMPDIR}/aethon-dev/new-<pid>/` so the launch
-  sees no config, no projects, no window state, no themes. Removed on
-  exit. Use to exercise first-run UX, missing-config flows, fresh
-  extension loading, or to A/B against a real user dir without
-  copying. Most code that touches `~/.aethon` honors the override —
-  the resolver is `helpers::aethon_dir`, used by config / sessions /
-  pastes / logs / window state / extensions / skills.
-- `dev --clean` — standalone nuke. Wipes
-  `${TMPDIR}/aethon-dev/` (per-PID `--new` sandboxes + dev-info files)
-  and exits without launching. No PID checks; use after a SIGKILL
-  left stale state.
+`scripts/dev.sh` flags:
+- `dev --new` — sandbox launch under `${TMPDIR}/aethon-dev/new-<pid>/`
+  (empty `~/.aethon`, removed on exit). Resolver is `helpers::aethon_dir`,
+  honored by config / sessions / pastes / logs / window state / extensions / skills.
+- `dev --clean` — wipe `${TMPDIR}/aethon-dev/` and exit.
 
-To run a single test file: `bunx vitest run agent/terminal-stream.test.ts`.
-To run tests matching a name: `bunx vitest run -t "test name pattern"`.
-To run a single Rust test: `cargo test --lib -p aethon -- helpers::test_name`.
+Vite defaults to port 1420 but `scripts/dev.sh` auto-increments and writes
+the chosen Vite + debug ports to `~/.aethon/dev-info.json`; `strictPort: true`
+stays on. The `aethon-debug` skill reads `dev-info.json` to follow the port.
 
 ## Architecture
 
-### Layer responsibilities
+Three layers:
 
-1. **Tauri shell** (`src-tauri/src/lib.rs` is now a thin entry — agent
-   supervisor + child IPC + `run()` builder; concern-grouped IPC commands
-   live under `src-tauri/src/commands/` (`config.rs`, `session.rs`,
-   `extensions.rs`, `git.rs`, `window.rs`, `fs.rs`); shell-tab PTY logic
-   lives under `src-tauri/src/shell/` (`lifecycle.rs`, `scrollback.rs`,
-   `sharemode.rs`); native window geometry persistence in
-   `window_state.rs`; pure helpers in `helpers.rs`; debug-only commands
-   - TCP eval server in `debug.rs` gated by `#[cfg(debug_assertions)]`)
-     — owns the OS boundary. Core agent commands: `send_message`
-     (forwards a chat string to the agent's stdin) and
-     `dispatch_a2ui_event` (forwards a structured event). On the first
-     `send_message` it spawns `bun run agent/main.ts` and starts a reader
-     thread that emits each stdout line as a Tauri `agent-response`
-     event. Shell-tab commands (`shell_open`, `shell_input`,
-     `shell_resize`, `shell_close`) sit behind a `ShellRegistry` (per-tab
-     `portable-pty` PTY + reader thread; emits `shell-output` /
-     `shell-exit` events). UTF-8 chunk boundaries are preserved across
-     reader-thread reads via a carry buffer + `Utf8Error::error_len()`
-     truncation/invalid split — don't replace this with per-chunk
-     `from_utf8_lossy`, multi-byte sequences will corrupt.
-2. **Agent bridge** (`agent/main.ts` is a thin entry-point — env wiring
-   - boot order; the readline loop and 14-case dispatcher live in
-     `agent/dispatcher.ts`) — JSON-lines over stdio. Reads
-     `{type:"chat", content}` or `{type:"a2ui_event", event}`, replies
-     with `{type:"response"|"a2ui"|"error", ...}`. Provider config comes
-     from env vars (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, …); pi-ai
-     picks one up. Modules (each with a colocated `*.test.ts`):
-   * `state.ts` — the `AethonAgentState` data class (registries, tabs,
-     pending mutations, layout, themes).
-   * `aethon-api.ts` — `buildAethonApi` factory exposed on `globalThis`.
-   * `dispatcher.ts` — readline loop + per-message-type dispatch.
-   * `tab-lifecycle.ts` — `ensureTab` + the pi session subscriber +
-     `emitReady`.
-   * `extension-loader.ts` — discovers + loads extensions from four
-     sources + theme directories.
-   * `project-extensions.ts` — walks up from the active cwd looking
-     for `.aethon/extensions/`.
-   * `system-prompt.ts` — composes the layered system prompt.
-   * `runtime-snapshot.ts` — `getRuntimeSnapshot` + `$AETHON_STATE_FILE`
-     persistence.
-   * `layout-manager.ts` — `setLayout` / `patchLayout` /
-     `registerLayout` + summarize helpers.
-   * `state-mutation.ts` — extension `setState` (size guard + per-tab
-     mirror).
-   * `mutation-ack.ts` — Promise/timeout handshake for mutation acks.
-   * `event-routes.ts` — extension `onEvent` route table.
-   * `keybindings.ts` — extension keybinding registration.
-   * `notifications.ts` — agent-pushed toasts.
-   * `session-history.ts` — reads pi session transcripts under
-     `$AETHON_SESSIONS_DIR/<tabId>/` so the frontend can rehydrate
-     visible history on restart.
-   * `terminal-stream.ts` — buffers `bash`-tool output as an A2UI
-     terminal stream (the `BashTerminalStreamState` snapshot type).
-   * `canvas.ts` — helpers for building and patching A2UI canvas
-     payloads.
-   * `agent-errors.ts` — extracts structured error info from pi agent
-     end-of-run errors (wraps `AgentEndError` classification).
-   * `shell-tools.ts` — pi tool implementations for
-     `listShells`/`readShell`/`writeShell` (bridge-side counterpart to
-     the Rust `shell_query` Tauri command).
-3. **React frontend** (`src/`) — `App.tsx` is a thin shell of `useX()`
-   hooks (`src/hooks/`); event-routing logic lives in `src/eventRoutes/`
-   (one file per prefix family); `src/runtime/windowApi.ts` builds the
-   `window.aethon` runtime API. Listens for `agent-response` events,
-   parses each line, and routes it into the chat history or canvas.
+1. **Tauri shell** (`src-tauri/src/`). `lib.rs` is the thin entry (agent
+   supervisor, IPC, `run()` builder). IPC commands are grouped under
+   `commands/` (`config`, `session`, `extensions`, `git`, `window`, `fs`).
+   Shell-tab PTY logic under `shell/` (`lifecycle`, `scrollback`, `sharemode`).
+   Window geometry in `window_state.rs`. Pure helpers in `helpers.rs`.
+   Debug-only TCP eval server in `debug.rs` (gated by `cfg(debug_assertions)`).
+
+   Core agent commands: `send_message` (forwards chat to agent stdin),
+   `dispatch_a2ui_event` (forwards a structured event). First call spawns
+   `bun run agent/main.ts` and starts a reader thread emitting `agent-response`
+   Tauri events per stdout line. Shell-tab commands (`shell_open/input/
+   resize/close`) sit behind a `ShellRegistry` (per-tab `portable-pty` +
+   reader; emits `shell-output` / `shell-exit`).
+
+   The PTY reader preserves UTF-8 boundaries across reads via a carry buffer
+   + `Utf8Error::error_len()` split — **do not replace with per-chunk
+   `from_utf8_lossy`**; multi-byte sequences will corrupt.
+
+2. **Agent bridge** (`agent/`). JSON-lines over stdio. `main.ts` is a thin
+   entry; the readline loop and dispatcher live in `dispatcher.ts`. State is
+   the `AethonAgentState` class in `state.ts`. The bridge attaches
+   `globalThis.aethon` (built in `aethon-api.ts`) so pi tools and extensions
+   can mutate UI, register components/themes/keybindings, push notifications,
+   and introspect.
+
+   Each module has a colocated `*.test.ts`. Provider config comes from env
+   (`ANTHROPIC_API_KEY` etc.); pi-ai picks one up.
+
+3. **React frontend** (`src/`). `App.tsx` is a thin shell composed of
+   `useX()` hooks (`src/hooks/`). Event routing lives in `src/eventRoutes/`
+   (one file per prefix family). The `window.aethon` runtime API is
+   built in `src/runtime/windowApi.ts`.
 
 ### Frontend model — three things to know
 
-**1. Layout-as-payload.** The default UI is _not_ hardcoded React. It's
-`src/skills/default-layout/workstation.a2ui.json`, loaded as the boot payload
-and fed to the same `A2UIRenderer` that handles agent output. A skill is the
-extension primitive; the default-layout skill currently registers only
-`workstation` while we focus polish on a single surface (the earlier
-`command-deck` / `editorial` / `live-layout` variations were dropped from
-the catalogue — the variation chrome components stay registered so their
-`.a2ui.json` payloads can be re-added when we want sibling layouts back).
-Switching layouts (when more exist) is a sidebar/palette click that calls
-`window.aethon.activateLayout(id)`. Don't add static chrome in `App.tsx` —
-extend the layout JSON or register a new skill. Layouts must conform to
-the slot contract in `src/skills/default-layout/slots.json` + `slots.ts`
-(canonical area names: `header`, `sidebar`, `canvas`, `composer`,
-`terminal`, `status`; non-canonical layouts declare a `slotMap`).
+**1. Layout-as-payload.** The default UI is *not* hardcoded React —
+it's `src/skills/default-layout/workstation.a2ui.json`, fed to the same
+`A2UIRenderer` that handles agent output. Don't add static chrome in
+`App.tsx`; extend the layout JSON or register a skill. Layouts must
+match the slot contract in `src/skills/default-layout/slots.ts`
+(canonical slots: `header`, `sidebar`, `canvas`, `composer`, `terminal`,
+`status`); non-canonical layouts declare a `slotMap`.
 
-**2. Single state store, JSON Pointer addressed.** All app state lives in one
-object on `App` (`messages`, `draft`, `waiting`, `status`, `connection`,
-`canvas`, `terminal.open`, …). Components read it via `$ref` JSON Pointers
-(e.g. `{"value": {"$ref": "/draft"}}`). The renderer applies an _optimistic_
-write back to that path for `change`/`submit` events on inputs whose `value`
-is a `$ref` — see `applyOptimisticUpdate` in `A2UIRenderer.tsx`. JSON Pointer
-helpers: `src/utils/jsonPointer.ts` and `src/utils/dataBinding.ts`.
+**2. Single state store, JSON Pointer addressed.** All app state lives in
+one object on `App`. Components read it via `$ref` JSON Pointers
+(`{"value": {"$ref": "/draft"}}`). The renderer applies an *optimistic*
+write back to that path for `change`/`submit` events on `$ref` inputs —
+see `applyOptimisticUpdate` in `A2UIRenderer.tsx`. Pointer helpers in
+`src/utils/jsonPointer.ts` + `src/utils/dataBinding.ts`.
 
-**3. Two registries.** Primitive React components live in
-`src/components/primitives/` (`text.tsx`, `controls.tsx`, `form.tsx`,
-`layout.tsx`, `media.tsx`, `context-menu.tsx`); the registry that wires
-them is built in `src/components/builtins.tsx` and consumed by
-`A2UIRenderer.tsx` as a hardcoded `PRIMITIVE_REGISTRY` of 19 input/layout
-primitives (`text`,
-`heading`, `paragraph`, `code`, `card`, `button`, `container`,
-`divider`, `image`, `icon`, `text-input`, `date-picker`, `select`,
-`checkbox`, `slider`, `form`, `form-field`, `list`, `table`) — these
-can't be overridden. Default-layout skill components are split per
-family under `src/skills/default-layout/` (`chat.tsx`, `terminal.tsx`,
-`command-palette.tsx`, `settings-panel.tsx`, `search-panel.tsx`,
-`notifications.tsx`, `share-mode-badge.tsx`, `variation-components.tsx`,
-`markdown-adapter.tsx`, plus `shell/`, `sidebar/`, and `editor/`
-sub-directories); `components.tsx` itself is the registration
-aggregator only. Everything else (`layout`, `sidebar`,
-`chat-history`, `chat-input`, `status-bar`, `terminal-panel`, `main-canvas`,
-`shell-canvas`, `tool-card`, `command-palette`, `notification-stack`,
-`settings-panel`, `search-panel`, `share-mode-badge`, …) comes from the
-`SkillRegistry`, exposed via React context (`useSkillRegistry`). App-root
-overlays mount through `<RegistryComponent type="…" />` (also exported
-from `A2UIRenderer.tsx`) so a skill can swap any of them with
-`aethon.registerComponent`. To add a new component type, register it on a
-skill, not in the primitives table.
+**3. Two registries.**
+- Primitive React components (`src/components/primitives/`) are wired
+  in `src/components/builtins.tsx` into a hardcoded 19-entry
+  `PRIMITIVE_REGISTRY`. **Can't be overridden by skills.**
+- Everything else (chrome composites like `sidebar`, `chat-input`,
+  `command-palette`, `terminal-panel`, `tab-strip`, `shell-canvas`, etc.)
+  comes from `SkillRegistry`. Mount via `<RegistryComponent type="…" />`
+  so a skill can swap them with `aethon.registerComponent`. New types
+  go on a skill, not in the primitives table.
+
+### Event routing
+
+`A2UIRenderer` accepts `onEvent`. Returning `true` marks an event handled
+and suppresses the default `dispatch_a2ui_event` forward to Rust.
+`App.tsx` delegates to `dispatchEvent` in `src/eventRoutes/index.ts`,
+with three precedence layers:
+1. Reserved shell-consent prefixes (`shell-write` / `shell-close` /
+   `session-delete`) MUST resolve before extension matchers.
+2. Extension-registered routes (returning `false` forwards to the bridge).
+3. Built-in routes keyed by `id:<componentId>` or `type:<componentType>`.
+
+**Always key chrome composites by `type:`, not `id:`** — that's how
+`registerComponent("<type>", custom)` and renamed instances stay routable.
+New handlers go in `eventRoutes/<name>.ts` + a happy-path test, then
+register in `BUILTIN_ROUTE_TABLE`.
 
 ### Runtime API
 
-`App.tsx` attaches a small API to `window.aethon` so skills (and the dev
-console) can swap chrome at runtime:
+`window.aethon` exposes: `setLayout`, `resetLayout`,
+`registerLayout({id, name, payload})` (id pattern `/^[A-Za-z][\w-]*$/`;
+`workstation` is reserved), `activateLayout`, `registerSkill`,
+`listSkills`, `openProject`. Mirrored agent-side on `globalThis.aethon`
+(see `agent/aethon-api.ts`).
 
-- `window.aethon.setLayout(payload)` — replace the active layout
-- `window.aethon.resetLayout()` — restore the default-layout boot payload
-- `window.aethon.registerLayout({ id, name, payload })` — register a layout
-  variation that appears in the sidebar's `layouts` section + palette.
-  Also exposed agent-side as `aethon.registerLayout` (bridge in
-  `agent/main.ts`). Reserved id: `workstation`
-  (`command-deck` / `editorial` / `live-layout` were trimmed from the
-  built-in catalogue and may be reintroduced later — keep the names
-  free). Id pattern: `/^[A-Za-z][\w-]*$/`.
-- `window.aethon.activateLayout(id)` — switch to a registered layout
-- `window.aethon.registerSkill(skill)` — register a skill; if it has a
-  `layout`, also activate it
-- `window.aethon.listSkills()` — names of currently registered skills
-- `window.aethon.openProject(path)` — register/activate a project
-
-### Keyboard shortcuts (current set)
-
-| Combo                         | Action                                                                                                                                                                                        |
-| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Cmd+T`                       | New tab — **focus-aware**: agent tab when outside the bottom terminal panel, shell sub-tab when focus is inside the panel. `[shortcuts] new_tab_kind = "shell"` flips this to "always shell". |
-| `Cmd+Shift+T`                 | New shell sub-tab (always — auto-opens the bottom panel)                                                                                                                                      |
-| `Cmd+W`                       | Close active tab. Shell tabs prompt before killing a running job (disable via `[shell] prompt_before_close = false`).                                                                         |
-| `Cmd+Opt+T`                   | Reopen most-recently-closed tab                                                                                                                                                               |
-| `Cmd+Shift+]` / `Cmd+Shift+[` | Next / previous _agent_ tab (top strip; shells are filtered). When focus is inside the bottom panel, cycles between sub-tabs (agent-bash + each shell) instead. Matches the iTerm / Terminal.app convention. |
-| `Cmd+Opt+]` / `Cmd+Opt+[`     | Move active agent tab right / left. When focus is inside the bottom panel, reorders shell sub-tabs instead.                                                                                   |
-| `Cmd+1`..`Cmd+8`              | Jump to agent tab N. When focus is inside the bottom panel, jumps between sub-tabs instead (1 = agent-bash).                                                                                  |
-| `Cmd+9`                       | Jump to last agent tab (or last shell sub-tab when focus is in panel).                                                                                                                        |
-| `Cmd+P` / `Cmd+Shift+P`       | Command palette (switcher / commands)                                                                                                                                                         |
-| `Cmd+\``                      | Toggle bottom terminal panel (Agent bash sub-tab + each user shell as a sub-tab)                                                                                                              |
-| `Cmd+B`                       | Toggle left sidebar (projects)                                                                                                                                                                |
-| `Cmd+D`                       | Toggle right sidebar (files)                                                                                                                                                                  |
-| `Cmd+K`                       | Clear chat                                                                                                                                                                                    |
-| `Cmd+.`                       | Stop current prompt                                                                                                                                                                           |
-| `Cmd+=` / `Cmd+-`             | Zoom in / out                                                                                                                                                                                 |
-| `Cmd+0`                       | Toggle focus between composer and terminal panel                                                                                                                                              |
-| `Cmd+Shift+0`                 | Reset zoom                                                                                                                                                                                    |
-| `Cmd+L`                       | Focus active tab's primary input (composer for agent tabs, terminal for shell tabs)                                                                                                           |
-| `Cmd+,`                       | Open Settings panel                                                                                                                                                                           |
-| `Cmd+Shift+F`                 | Cross-session search overlay                                                                                                                                                                  |
-| `Cmd+Shift+S`                 | Export active chat as Markdown to `~/Downloads/` (agent tabs only)                                                                                                                            |
-| `Cmd+Ctrl+F` (mac) / `F11`    | Toggle fullscreen                                                                                                                                                                             |
-| `F12`                         | Toggle WebKit DevTools (debug builds)                                                                                                                                                         |
-| `Esc`                         | Close palette / settings / search overlay (when open)                                                                                                                                         |
-
-`metaKey || ctrlKey` for cross-platform — Linux/Windows users get the
-same set under Ctrl. Native menu accelerators in `src-tauri/src/lib.rs`
-mirror these. Extension `aethon.registerKeybinding` priority is
-unchanged: extensions run first and may override built-ins.
-
-### Terminal panel mental model
-
-The **bottom terminal panel** (toggle `Cmd+\``) is a tabbed surface
-hosting two kinds of sub-tabs:
-
-1. **Agent bash** (always present, sub-tab id `"agent-bash"`,
-   read-only). A live stream of the bash tool's stdout for the active
-   agent tab. Same content also appears in chat as a tool card; the
-   panel pins it visible while you scroll chat.
-2. **Shell sub-tabs** (zero or more). Full interactive PTYs backed by
-   `portable-pty`. TUI-capable (vim, htop, fzf), 256-color, mouse
-   reporting. Status line under the xterm shows
-   `cwd · command · share-mode badge · cols×rows`.
-
-The top tab strip carries **only agent tabs** (chat sessions). Shell
-sub-tabs render in the bottom panel; the `TabStrip` composite filters
-out `kind === "shell"` automatically.
-
-`Cmd+T` is **focus-aware**: focus inside the bottom panel → new shell
-sub-tab; focus elsewhere → new agent tab. `Cmd+Shift+T` always spawns
-a new shell sub-tab and auto-opens the panel. This matches the
-mental model "new tab of whatever surface I'm using".
-
-State paths: `/terminalPanel/activeSubId` tracks which sub-tab is
-visible (defaults to `"agent-bash"`). `/terminal/open` toggles the
-whole panel. Shells live in `/tabs` next to agents but with
-`kind === "shell"` — the rendering layer routes them to the correct
-surface.
-
-### Tab kinds — agent vs shell
-
-`Tab.kind` is `"agent" | "shell"`. Agent tabs carry chat-history fields
-(`messages`, `draft`, `waiting`, `queueCount`); shell tabs carry a
-`shell: ShellMeta` payload (`cwd`, `command`, `args`, `shareMode`,
-`shellState`, `exitCode?`). Share-mode UI helpers live in
-`src/utils/shareMode.ts` (`cycleShareMode`, `shareModeLabel`,
-`shareModeTooltip`); the security boundary is enforced Rust-side in
-`shell.rs` (`ShareState` + `Scrollback`). The bridge surface is `aethon.shells.{list, read, write}` — round-trips
-through the mutation-ack channel as `shell_query` ops with
-`MutationResult.data` populated. **Do not add an agent-driven
-`setShareMode`** — discoverable tab ids in `/tabs` plus a setter would
-defeat the opt-in boundary `list()` enforces (only the user's badge
-click may flip a mode). Reads are forward-paging from the caller's
-cursor; cold-start callers omit the cursor to get the latest
-`max_bytes`. Writes pop an Allow/Deny notification in `read-write` mode
-(reusing the existing notification primitive — `pushNotification` with
-`durationMs: null` + `actions`); `read-write-trusted` writes go through
-without prompting. Pre-frontend-ready callers awaiting
-`shells.list/read/write` block until the handshake completes (queries
-need real `data`, not the side-effect-mutation shortcut). Don't add a
-fast-path that lets the bridge invoke Tauri commands directly — the
-read clamp + privacy floor have to live where the PTY does. Most code paths special-case via
-`tab.kind === "shell"` checks (see `closeTab`, `newShellTab`,
-`/agentTabActive` + `/shellTabActive` derived flags). The shell-canvas
-composite (`ShellCanvas` in `default-layout/shell/canvas.tsx`) replaces the agent
-`main-canvas` + `chat-input` cells when a shell tab is active —
-controlled by the `/agentTabActive` / `/shellTabActive` `$ref` visibility
-flags in `workstation.a2ui.json`. Keybindings: `Cmd+T` = new agent tab (focus-aware — new shell sub-tab when
-focus is inside the bottom panel), `Cmd+Shift+T` = new shell sub-tab (always).
-
-### Slash commands (client-side)
-
-`src/slashCommands.ts` registers frontend-only slash commands that run
-without an LLM round-trip (e.g. `/clear`, `/theme`, `/extensions`). They
-receive a `SlashCommandContext` with `appendSystem`, `notify`, `clearChat`,
-`setTheme`, etc. Pi's server-side / native slash commands are also plumbed
-through: the bridge advertises them via `extension_slash_commands` events
-and the renderer dispatches them back through the
-`native_slash_command` → `native_slash_result` round-trip in
-`agent/dispatcher.ts`. They appear in the composer autocomplete next to the
-client-side ones. When adding a purely UI action, prefer the client-side
-registry; only go through the bridge when the agent needs to observe or
-act on the command.
-
-### Extension frontend loading
-
-Extensions can ship React components by setting `aethon.frontendEntry` in
-their `package.json` to a relative JS file path. The bridge reads that file
-and sends its contents as a string in `extension_frontend_modules` events.
-`src/skills/extensionFrontendLoader.ts` receives these events, wraps each
-body in `new Function("React", "skill", code)`, and calls the result with
-`React` + a `{ registerComponent(type, fn) }` API object. Components
-registered this way land in the `SkillRegistry` and are resolved alongside
-built-in skill components. A delta payload replaces the full previous set —
-re-evaluated modules hot-swap their components; removed modules unregister
-theirs. The trust model is identical to bridge-side extension code (user
-installed it, no sandbox).
-
-`SkillRegistry` also has a `.registerTemplate(type, payload)` path for
-declarative A2UI subtree templates — used when an extension provides a
-component as an A2UI JSON fragment rather than a React function. The
-renderer prefers React components when both exist for the same type.
-
-### Command palette
-
-`Cmd+P` opens the switcher (tabs / sessions / projects / layouts /
-themes / models first); `Cmd+Shift+P` opens it in commands mode (slash
-commands / keybindings first). The palette is a registered builtin
-component (`command-palette` type) in `defaultLayoutSkill` so a skill
-can override it via `aethon.registerComponent`. Pure ranking + section
-selectors live in `src/skills/default-layout/palette-items.ts` so vitest
-can exercise them without React. Query prefixes: `>` forces commands,
-`@` forces tabs, `?` forces keybindings. Arrow nav uses a document-level
-capture-phase keydown handler keyed off a `navRef` so focus theft and
-content swaps don't strand the selection — see the comments in
-`command-palette.tsx` before refactoring.
-
-### Projects and worktrees
-
-Pi sessions are scoped to a working directory. `src/projects.ts` persists
-the project list at `~/.aethon/projects.json` (max 16, MRU-ordered) under
-schemaVersion 2; a v1→v2 migration runs on first read so older builds
-still resolve. The active project's path is passed as `cwd` on `tab_open`.
-**Existing tabs keep the cwd they were created with** — switching the
-active project only affects new tabs. When updating tab/session code,
-treat the per-tab cwd as immutable.
-
-Worktrees attach to projects via `src/worktrees.ts`. The Rust shell
-exposes `git_worktrees`, `git_worktree_add`, `git_worktree_remove`, and
-`git_branch_list` in `src-tauri/src/commands/git.rs`; the frontend
-reconciles fresh listings against in-memory state by path so stable ids
-+ user labels survive polls. A "pending" worktree is a live UI object
-(queued → starting → succeeded | failed) — Codex pattern — that the
-user can cancel / retry / dismiss directly in the sidebar. The
-worktree-aware projects render nested under their parent project with
-a disclosure caret (sidebar item carries `worktrees` + `expanded`).
-
-### File icons (Material Icon Theme)
-
-The file tree renders Material Icon Theme SVGs vendored under
-`src/file-icons/icons/` (subset of PKief/vscode-material-icon-theme, MIT
-license — see `src/file-icons/LICENSE` + `SOURCE.md`). `iconForPath`
-(`src/file-icons/index.ts`) resolves a filesystem entry to a bundled
-asset URL via basename → extension → fallback. The `<FileIcon>` wrapper
-in `src/components/file-icon.tsx` is what file-tree rows use today.
-Adding new icons is a vendor-and-map operation: drop the SVG into
-`icons/`, add an import + mapping in `manifest.ts`.
-
-### Monaco editor + file tree
-
-The editor surface (sidebar file tree + Monaco buffers + media/text
-viewers) is implemented as a default-layout sub-skill under
-`src/skills/default-layout/editor/`. Monaco glue lives in `src/monaco/`
-(`editor-buffers.ts` manages models per file, `setup.ts` configures
-workers + languages, `theme.ts` syncs to the active Aethon theme).
-File-system operations go through `src-tauri/src/commands/fs.rs` — a
-thin set of read/write/list/move/delete commands scoped to the active
-project's `cwd`. Two security layers gate every path: a lexical check
-(`helpers::resolve_inside_root`) catches `..` traversal without
-hitting disk, then a canonicalize-after-existing check catches
-symlinks that redirect outside the project root. Reads/writes are
-capped at 10 MB to keep the Tauri IPC bridge responsive. Deletes go
-to the OS trash via the `trash` crate, never `unlink`.
-
-### Window state persistence
-
-`src-tauri/src/window_state.rs` saves window position, size, and
-`maximized` flag to `~/.aethon/window-state.json` (keyed by window
-label). Everything is stored in **logical** units — physical pixels
-aren't portable across monitors with different scale factors, so a
-window saved on Retina (2×) would render at the wrong size when
-restored to a 1× monitor.
-
-Restore runs in `setup()` *before* the window becomes visible
-(`tauri.conf.json` sets `visible: false`), so there's no race or
-settle-debounce. Save is 250 ms-debounced on `Moved`/`Resized` and
-flushed synchronously on `CloseRequested`. Monitor matching is a
-three-tier fallback: exact-dimension → intersects → nearest by saved
-center, then the window is translated to preserve its
-offset-within-saved-monitor and clamped so the titlebar stays
-reachable. Fullscreen state is treated as transient and skipped on
-save. v0 (physical-unit) state files are migrated to v1 on first
-load. Spaces / virtual desktops aren't tracked — Tauri 2 doesn't
-expose a stable identifier.
-
-### Agent runtime contract
-
-The Tauri shell sets these env vars when spawning the bridge (`agent/main.ts`):
-
-| Env var               | Purpose                                                                                                                                                                                                                                                      |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `AETHON_DOCS_DIR`     | Bundled docs dir (`docs/aethon-agent/` in dev, `<resource_dir>/docs/aethon-agent/` in release). Contains `README.md`, `api.md`, `components.md`, `extensions.md`. The system prompt points the model at these for the authoritative API/component reference. |
-| `AETHON_USER_DIR`     | `~/.aethon/` — user extensions, skills, sessions, state file.                                                                                                                                                                                                |
-| `AETHON_STATE_FILE`   | `~/.aethon/state.json` — JSON snapshot of loaded extensions, themes, custom components, layout summary, and tab list. Rewritten (debounced 200 ms) on every registration.                                                                                    |
-| `AETHON_SESSIONS_DIR` | `~/.aethon/sessions/<tabId>/` per tab. Each tab uses `SessionManager.continueRecent` so pi context survives bun restarts.                                                                                                                                    |
-| `AETHON_RELEASE_MODE` | `"1"` in release, `"0"` in dev. The system prompt branches on this to (a) avoid telling the model to read source files that aren't there, (b) point at `~/.aethon/extensions/` for new extensions instead.                                                   |
-| `AETHON_PROJECT_ROOT` | Source tree path (dev only). Lets the model reference `agent/main.ts` etc. by absolute path during dev work.                                                                                                                                                 |
-
-The bridge's `agent/system-prompt.ts` composes a layered prompt:
-DEFAULT (static API + primitives reference, mentioning the docs/state-file
-paths) → optional user override at `~/.aethon/system-prompt.md` →
-optional user append at `~/.aethon/system-prompt-append.md` → **runtime
-snapshot** built from `getRuntimeSnapshot()` (extensions, themes,
-components, layout summary, tabs). The snapshot is rebuilt every time
-`resourceLoader.reload()` runs, so the bootstrap order is important —
-extensions load **before** the default tab is created so its session
-prompt sees them.
-
-### globalThis.aethon (bridge side, in agent/main.ts)
-
-Mutation: `registerComponent`, `setState`, `setLayout`, `patchLayout`,
-`registerSidebarSection`, `registerTheme`, `onEvent`. Introspection:
-`listExtensions`, `listComponents`, `listThemes`, `getLayout`,
-`getRuntimeSnapshot` — these let the agent answer "what's loaded?"
-without scraping the filesystem. The same data is also written to
-`$AETHON_STATE_FILE` so a `cat` works without an introspection round-trip.
-
-Per-surface subnamespaces — each backed by a `*_query` bridge message
-and matching frontend handler:
-
-- `aethon.shells.{list, read, write}` — opt-in shell-tab sharing.
+Per-surface subnamespaces, each backed by a `*_query` bridge message:
+- `aethon.shells.{list, read, write}` — opt-in shell sharing.
 - `aethon.tasks.start({projectPath, prompt, newWorktree?, branch?, baseBranch?})`
-  — UI parity for the per-project dashboard composer. Spawns a
-  worktree (when requested), opens a new agent tab in the right cwd,
-  and forwards the prompt as the first user message.
+  — task launcher parity.
 - `aethon.dashboard.{getRepoOverview, refresh, listIssues, getIssue}` —
-  cached gh repo data (stars/forks/issues/PRs/default branch/pushed),
-  cache-bust, the open issues list, and a single issue's body.
-  `listIssues` is the same data the per-project dashboard's Issues
-  section renders; `getIssue` returns the full body so the agent can
-  prepare a `startTask` payload from an issue.
+  cached gh repo data + issues.
 
-The five dashboard pi tools (`startTask`, `getRepoOverview`,
-`refreshDashboard`, `listOpenIssues`, `getOpenIssue`) register
-automatically in `agent/dashboard-tools.ts` so the model can drive
-them via the standard tool-use protocol.
+Pre-frontend-ready callers of `*_query` block until the handshake
+completes — queries need real `data`, not the side-effect-mutation
+shortcut. Do **not** add a fast-path letting the bridge invoke Tauri
+commands directly; security floors live with the data source.
 
-### Dashboard surfaces (M9)
+### Tab kinds + terminal panel
 
-Empty-state replaced by two visibility-gated composites in
-`workstation.a2ui.json`: `projects-dashboard` (when `/empty && !/project`)
-and `project-dashboard` (when `/empty && /project`). Both target the
-`canvas` slot via the existing `empty-state` slotMap. Six chrome
-composite types — `projects-dashboard`, `project-dashboard`,
-`task-launcher`, `project-card`, `gh-stats-strip`, `issues-section`
-— all registered in `defaultLayoutSkill.components` and swappable via
-`aethon.registerComponent`. Live data via `$ref`:
-`/projectsDashboard/extraCards` (extension-injected tiles on the
-global dashboard) and `/projectDashboard/widgets` (extension-injected
-cards on the per-project dashboard); push entries with
-`aethon.patchState`. gh repo data is cached in
-`src/ghRepoOverviewCache.ts` (5-min live TTL, 30-min negative). Issues
-get their own cache in `src/ghIssuesCache.ts` (90-s live, 60-s
-negative; cap clamped server-side to 100 issues). Project cards
-lazy-fetch on IntersectionObserver entry; the per-project dashboard
-fetches eagerly on activation. Issues section lazy-fetches when it
-scrolls into view to keep the dashboard's initial paint cheap.
+`Tab.kind` is `"agent" | "shell"`. The top tab strip carries only agent
+tabs (shells are filtered). The bottom panel (toggle `` Cmd+` ``) hosts
+two sub-tab kinds: the always-present read-only `agent-bash` stream
+(buffered tool stdout) and zero or more interactive `portable-pty` shells
+(TUI-capable, 256-color, mouse). State paths: `/terminalPanel/activeSubId`
+(defaults `"agent-bash"`), `/terminal/open`. Shells live in `/tabs` with
+`kind === "shell"`; the renderer routes them to the right surface via
+`/agentTabActive` / `/shellTabActive` derived flags in
+`workstation.a2ui.json`.
 
-Per the codex audit on PR #73 we use `gh issue list -q length` for
-the open-issue count instead of `repos/<r>.open_issues_count` (which
-counts PRs + issues together). Branch names with slashes are
-percent-encoded before going into `repos/<r>/branches/{x}` so
-`feat/foo` doesn't 404. Active worktree is mirrored to root state
-`/activeWorktreeId` so the file tree and `newTab` cwd both follow
-the sidebar selection (mirroring is in `useProjectOps.syncProjectsToState`).
+`Cmd+T` is focus-aware: focus inside the bottom panel = new shell sub-tab;
+elsewhere = new agent tab. `Cmd+Shift+T` always spawns a new shell sub-tab.
 
-Issue row interaction model: left-click opens the issue in the user's
-browser (`tauri-plugin-opener|open_url`); right-click pops a
-lightweight context menu (Open on GitHub · Send to agent · Copy URL);
-the hover-revealed "→ Agent" button is the keyboard-equivalent for
-"Send to agent." The send-to-agent path forwards through the same
-`start-task` event the task launcher uses, so UI parity with the pi
-tool stays one code path. The agent receives a markdown-formatted
-prompt (title + url + author + body) and lands in whichever worktree
-the user has activated.
+Per-tab `ShareMode` is the security boundary, enforced Rust-side in
+`shell/sharemode.rs`. The bridge surface (`aethon.shells.*`) rounds through
+the mutation-ack channel. **Do not add an agent-driven `setShareMode`** —
+discoverable tab ids + a setter would defeat the opt-in floor that `list()`
+enforces. Writes pop an Allow/Deny notification in `read-write` mode;
+`read-write-trusted` bypasses the prompt.
 
-### Event flow gotcha
-
-`A2UIRenderer` accepts an `onEvent` prop. Returning `true` from it marks the
-event as handled and _suppresses_ the default Tauri `dispatch_a2ui_event`
-forward. `App.tsx` delegates to `dispatchEvent` in `src/eventRoutes/` — a
-per-prefix route table with three precedence layers enforced in
-`eventRoutes/index.ts`: (1) shell-consent reserved prefixes
-(`shell-write` / `shell-close` / `session-delete`) MUST resolve before
-extension matchers; (2) extension-registered routes (returning `false`
-forwards to the bridge); (3) built-in routes keyed by `id:<componentId>`
-or `type:<componentType>`. New built-in handlers go in
-`eventRoutes/<name>.ts` + a happy-path test, then registered under the
-matching key(s) in `BUILTIN_ROUTE_TABLE`.
-
-**Always key chrome-composite handlers by `type:<componentType>`, not
-`id:`** — that's how `aethon.registerComponent("<type>", custom)` and
-custom-layout payloads with renamed instances stay routable. Use
-`id:<…>` only for genuine instance-specific dispatch (none today). The
-12 chrome composites (sidebar, command-palette, settings-panel,
-search-panel, notification-stack, chat-input, empty-state,
-terminal-panel, tab-strip, model-picker, appearance-menu,
-share-mode-badge, shell-canvas) all dispatch by type as of #N.
-
-### Hot-reload doesn't kill in-flight prompts
+### Hot reload doesn't kill in-flight prompts
 
 The Rust file-watcher (`commands/extensions.rs::run_debounce_worker`)
-no longer SIGKILLs the bun child when an extension file changes.
-Instead it writes `{"type":"reload_request"}` to the child's stdin.
-The bridge sets `state.reloadPending`, drains active
-`tab.promptInFlight`, writes a `{"type":"_reload_done"}` sentinel to
-stdout, and `process.exit(0)`s. The supervisor's stdout reader peeks
-for that sentinel, sets the reload-in-progress flag, emits
-`agent-reloaded`, and the next IPC call respawns. So an extension
-drop never aborts a user's LLM turn. The fallback hard-kill path
-remains for the case where stdin is wedged.
+writes `{"type":"reload_request"}` to the child's stdin instead of
+SIGKILL. The bridge drains active `tab.promptInFlight`, emits a
+`{"type":"_reload_done"}` sentinel, and exits. The supervisor's reader
+peeks for the sentinel, emits `agent-reloaded`, and respawns on the next
+IPC call. Extension drops never abort the user's LLM turn. The hard-kill
+fallback remains for wedged stdin.
 
-## Conventions
+`touch agent/main.ts` is the simplest manual restart.
 
-- **Conventional Commits** for all messages: `feat(scope):`, `fix(scope):`, etc.
-- **Two-space indent** for Nix; standard for everything else.
-- **TypeScript strict mode** + `verbatimModuleSyntax` + `erasableSyntaxOnly`.
-  Use `import type { ... }` for type-only imports.
-- **Vite port defaults to 1420 but auto-increments via `scripts/dev.sh`**
-  when busy. The wrapper finds free Vite + debug ports, writes them to
-  `~/.aethon/dev-info.json`, exports `VITE_PORT` + `AETHON_DEBUG_PORT`,
-  and overrides Tauri's `devUrl` via `$TAURI_CONFIG`. `strictPort: true`
-  stays on so Vite fails loudly if the wrapper hands it a busy port. The
-  aethon-debug skill reads `dev-info.json` to follow the chosen port.
-- **No global state in the Rust shell** beyond what Tauri's `Manager` exposes
-  (currently just the `AgentProcess` mutex). Business logic belongs in the
-  agent, not the shell.
-- **No emojis in code or commits** unless the user explicitly asks.
+### File-system safety (commands/fs.rs)
 
-## Editing Tauri Config
+Two layers gate every path: lexical (`helpers::resolve_inside_root`)
+catches `..` traversal without hitting disk; canonicalize-after-existing
+catches symlinks redirecting outside the project root. Read/write caps
+at 10 MB. Deletes go to the OS trash via the `trash` crate — never
+`unlink`.
 
-`src-tauri/tauri.conf.json` controls window, bundle, and security policy.
-Adding a Tauri plugin requires three steps:
+### Window geometry
 
-1. `cargo add tauri-plugin-X --manifest-path src-tauri/Cargo.toml`
-2. Register in `src-tauri/src/lib.rs` via `.plugin(tauri_plugin_X::init())`
-3. Add the plugin's permissions to `src-tauri/capabilities/default.json`
+`src-tauri/src/window_state.rs` persists position/size/maximized to
+`~/.aethon/window-state.json` in **logical** units (physical pixels are
+not portable across HiDPI). Restore runs in `setup()` before the window
+becomes visible (`tauri.conf.json` sets `visible: false`). Save is
+250 ms debounced on Moved/Resized; flushed synchronously on
+CloseRequested. Monitor matching is three-tier (exact → intersects →
+nearest by saved center) with titlebar-reachability clamp. Fullscreen
+is transient and skipped. v0 (physical) files migrate to v1.
 
-## Nix / Linux build notes
+### Projects + worktrees
 
-`flake.nix` carries platform-specific workarounds — read it before changing
-the toolchain or build inputs:
+Pi sessions are scoped to a cwd. `src/projects.ts` persists the project
+list at `~/.aethon/projects.json` (max 16, MRU, schemaVersion 2; v1→v2
+migrates on read). **Existing tabs keep the cwd they were created with**
+— switching the active project only affects new tabs. Worktrees attach
+via `src/worktrees.ts`, with Rust commands in `commands/git.rs`. Active
+worktree is mirrored to `/activeWorktreeId` so the file tree and new
+tabs follow the sidebar selection.
 
-- Rust is pinned at **1.92.0** because 1.95+ currently fails to compile
-  `icu_provider 2.2.0`, `regex-automata 0.4.14`, and `objc2` (transitive
-  Tauri 2.10 deps). The pin has a comment; bump only when upstream catches up.
-- Linux build needs `webkit2gtk_4_1` + GTK closure on `PKG_CONFIG_PATH`. The
-  flake sets these manually because numtide/devshell skips nixpkgs'
-  pkg-config setup hook. `WEBKIT_DISABLE_DMABUF_RENDERER=1` is set to dodge
-  a Mesa/Wayland crash in WebKitGTK's DMA-BUF renderer.
-- macOS uses Apple's `/usr/bin/cc` (not Nix's CC wrapper) due to SDK
-  mismatches with current nixpkgs unstable, and pulls libiconv via
-  `LIBRARY_PATH` + `NIX_LDFLAGS`.
+### Dashboard caches (M9)
 
-## Reference Projects
+- `src/ghRepoOverviewCache.ts` — 5-min live TTL, 30-min negative.
+- `src/ghIssuesCache.ts` — 90-s live, 60-s negative; cap clamped to 100.
 
-- `~/Projects/utensils/Claudette` — sibling Tauri 2 + TS project with much
-  deeper integration (xterm, voice, mDNS). Good source of patterns for IPC,
-  window management, and the Nix Linux build closure.
-- `~/Projects/utensils/claudex` — sibling Rust-only project. Good source of
-  patterns for the flake skeleton (flake-parts + devshell + treefmt + crane).
+Use `gh issue list -q length` for the open-issue count, **not**
+`open_issues_count` (that counts PRs + issues). Percent-encode branch
+names with slashes before hitting `repos/<r>/branches/{x}`.
 
-## Hot reload
+## Agent runtime env
 
-Vite hot-reloads the frontend automatically. The agent subprocess (`bun run
-agent/main.ts`) is held alive across reloads in Tauri state, so editing the
-agent on its own would not pick up changes — to fix this, in debug builds
-the Rust shell uses `notify` to watch `agent/` recursively and kills the
-child whenever a file changes. The next Tauri command (e.g. `start_agent`,
-`send_message`) lazily respawns it with the new code, and the frontend
-receives an `agent-reloaded` event so it can show "agent reloaded" in the
-status bar. Production builds skip the watcher entirely.
+Tauri sets these when spawning `agent/main.ts`:
 
-If you find yourself wanting to manually restart the agent during dev, the
-simplest path is `touch agent/main.ts`.
+| Env var               | Purpose                                                                                                  |
+| --------------------- | -------------------------------------------------------------------------------------------------------- |
+| `AETHON_DOCS_DIR`     | Bundled docs (`docs/aethon-agent/`) — system prompt points the model here.                              |
+| `AETHON_USER_DIR`     | `~/.aethon/` — extensions, skills, sessions, state file.                                                 |
+| `AETHON_STATE_FILE`   | `~/.aethon/state.json` snapshot, debounced 200 ms.                                                       |
+| `AETHON_SESSIONS_DIR` | `~/.aethon/sessions/<tabId>/` — pi `SessionManager.continueRecent` per tab.                              |
+| `AETHON_RELEASE_MODE` | `"1"`/`"0"`. System prompt branches on this to avoid pointing at source paths in release.                |
+| `AETHON_PROJECT_ROOT` | Source tree path in dev only.                                                                            |
+
+`agent/system-prompt.ts` composes DEFAULT → optional `~/.aethon/system-prompt.md`
+override → optional `~/.aethon/system-prompt-append.md` → runtime snapshot
+from `getRuntimeSnapshot()`. Snapshot rebuilds on every
+`resourceLoader.reload()`; extensions load **before** the default tab so
+its session prompt sees them.
 
 ## Logging
 
-Both the Rust shell and the bridge (TS) use leveled, scoped loggers and
-write to two sinks:
+Levels via `AETHON_LOG` (preferred) or `RUST_LOG` / `LOG_LEVEL`. Defaults
+`info` in dev, `warn` in release. The Rust subscriber uses
+`tracing-subscriber::EnvFilter` so target scopes work
+(`AETHON_LOG=aethon::agent_watch=debug,aethon::config=warn`).
 
-| Sink              | What goes there                       | When to use                                                          |
-| ----------------- | ------------------------------------- | -------------------------------------------------------------------- |
-| stderr            | Live stream as the app runs           | Watching `bun tauri dev` output, seeing what's happening right now   |
-| `~/.aethon/logs/` | Daily-rotating files, 7-day retention | Post-hoc investigation, release-build crashes, comparing across runs |
+Two sinks: stderr (live) and `~/.aethon/logs/` (daily-rotating, 7-day
+retention). Two file series share that directory:
+- `aethon.YYYY-MM-DD` — Rust (`tracing`)
+- `bridge.YYYY-MM-DD.log` — bun (`agent/logger.ts`)
 
-Two file series share that directory:
+## Driving the app from Claude
 
-- `aethon.YYYY-MM-DD` — Rust shell (`tracing` crate), covers agent
-  supervisor, file watcher, debug TCP server, Tauri commands.
-- `bridge.YYYY-MM-DD.log` — bun bridge (`agent/logger.ts`), covers
-  extension loaders, theme/skill discovery, system-prompt assembly,
-  per-tab session setup.
+`.claude/skills/aethon-debug/` is slash-commandable. In debug builds the
+Rust shell starts a TCP eval server on `127.0.0.1:19433` (override with
+`AETHON_DEBUG_PORT`); `scripts/debug-eval.sh` ships JS to it, which
+wraps in an async IIFE and evals inside the webview. Use proactively
+after touching UI or agent code.
 
-Files older than 7 days are pruned at app startup; rotation is per-day.
-Each line is `ISO_TS LEVEL scope: message` so `grep ext-loader …` works.
+Dev-only webview globals:
+- `window.__AETHON_STATE__()`, `window.__AETHON_SET_STATE__(next)`
+- `window.__AETHON_INVOKE__` (Tauri `invoke`)
+- `window.__AETHON_REGISTRY__` (`SkillRegistry`)
+- `window.aethon` (public runtime API)
 
-Levels follow `AETHON_LOG` (preferred) or `RUST_LOG` / `LOG_LEVEL` env
-vars. Defaults are `info` in dev and `warn` in release. Examples:
+The dev build must already be running — never launch a release build
+(debug server gated by `cfg(debug_assertions)`).
 
-```bash
-AETHON_LOG=debug bun tauri dev          # everything
-AETHON_LOG=warn bun tauri dev           # quiet — warnings + errors only
-AETHON_LOG=aethon::agent_watch=debug bun tauri dev  # one scope verbose
-```
+## Conventions
 
-The Rust subscriber uses `tracing-subscriber::EnvFilter` so target-scoped
-filters work (`aethon::agent_watch=debug,aethon::config=warn`).
+- **Conventional Commits** for all messages: `feat(scope):`, `fix(scope):`.
+- **TypeScript strict + `verbatimModuleSyntax` + `erasableSyntaxOnly`.**
+  Use `import type { ... }` for type-only imports.
+- **No global state in the Rust shell** beyond Tauri's `Manager`
+  (currently just the `AgentProcess` mutex).
+- **No emojis in code or commits** unless asked.
+- A few `react-hooks/*` per-line disables exist for set-state-in-effect
+  resync paths + intentionally-empty memo deps. Audit on touch; don't
+  broaden.
 
-## Driving the app from Claude (`aethon-debug` skill)
+## Adding a Tauri plugin
 
-`.claude/skills/aethon-debug/` ships a slash-commandable skill for inspecting
-and driving the running dev app. In debug builds the Rust shell starts a TCP
-eval server on `127.0.0.1:19433` (override with `AETHON_DEBUG_PORT`); the
-script `scripts/debug-eval.sh` ships JS to that server, which wraps it in
-an async IIFE, evals it inside the webview, and returns the stringified
-result. Patterned on Claudette's `claudette-debug` skill — see its `SKILL.md`
-for the full action list.
+1. `cargo add tauri-plugin-X --manifest-path src-tauri/Cargo.toml`
+2. Register in `src-tauri/src/lib.rs` via `.plugin(tauri_plugin_X::init())`
+3. Add permissions to `src-tauri/capabilities/default.json`
 
-Webview globals exposed in dev only:
+## Nix / Linux build notes
 
-- `window.__AETHON_STATE__()` — snapshot of the layout state object
-- `window.__AETHON_INVOKE__` — Tauri `invoke` (used by the eval wrapper)
-- `window.__AETHON_REGISTRY__` — `SkillRegistry` instance
-- `window.__AETHON_SET_STATE__(next)` — replace state (advanced)
-- `window.aethon` — public runtime API (`setLayout`, `registerSkill`, etc.)
+`flake.nix` carries platform-specific workarounds — read it before
+changing the toolchain or build inputs.
 
-Use this proactively after touching any UI / agent code: connect, send a
-chat, screenshot, verify. The dev build must already be running — never
-launch a release build (the debug server is gated by `cfg(debug_assertions)`).
-
-## Status — what is and isn't wired up
-
-The authoritative checklist is in `SPEC.md` ("Status Checklist" section,
-keyed against milestones M1–M5). Update both that checklist and any
-relevant notes here when capabilities land.
-
-**Quick highlights as of writing:** M1–M6 complete, plus post-M6 polish.
-M6 shipped: interactive PTY-backed user shell tabs (`portable-pty`,
-`Tab.kind` discriminator, theme-agnostic xterm), per-tab `ShareMode`
-4-value enum with privacy-floor guardrail,
-`aethon.shells.{list, read, write}` bridge API with per-write Allow/Deny
-user confirmation, pi-tool registration of
-`listShells`/`readShell`/`writeShell` (in `agent/shell-tools.ts`),
-Settings UI overlay, fullscreen, search overlay, drag-and-drop into
-composer, bridge crash recovery, OS notifications. Post-M6: Monaco
-editor + file tree + media viewers (`src/skills/default-layout/editor/`,
-`src/monaco/`, `src-tauri/src/commands/fs.rs`), native window geometry
-persistence with multi-monitor restore (`src-tauri/src/window_state.rs`),
-pi native slash commands plumbed through to the composer autocomplete,
-left-edge sidebar resize, Brink theme palette.
-Tool execution surfaces as A2UI cards, multi-tab persistent
-sessions, light theme, system tray + native menu, slash command picker,
-real `~/.aethon/config.toml`, layout-slot contract (`canvas` +
-`composer` required, `slotMap` for non-canonical layouts), generic
-`extension_lifecycle` feedback channel, registerable slash commands /
-keybindings / menu items / event routes / layouts (workstation only in
-the built-in catalogue today; extensions can register more via
-`aethon.registerLayout`), mutation-feedback channel (every mutation
-returns `Promise<MutationResult>`), command palette (Cmd+P switcher /
-Cmd+Shift+P commands), v0.2.0 GitHub release with macOS .dmg + Linux
-.deb/AppImage + Windows NSIS bundles via Nix overlay.
-
-## State persistence
-
-`src/persist.ts` is the disk I/O layer for frontend state. It wraps Tauri
-`read_state` / `write_state` commands with a graceful no-op fallback when
-running outside Tauri (unit tests, plain browser). One-time migration: on
-first read it checks `localStorage` for the same key so users upgrading from
-the pre-Tauri build keep their history. All tab/canvas state serialisation
-goes through here; don't invoke Tauri storage commands directly from
-components.
-
-## Releases
-
-See `RELEASING.md` for the full release workflow: keypair generation,
-wiring the public key into `tauri.conf.json`, CI secrets, and how to cut a
-tag. Summary: push a `v*.*.*` tag → GitHub Actions builds signed macOS DMGs,
-Linux `.deb`/`.rpm`, and Windows NSIS, uploads `latest.json` for the
-in-app updater.
-
-## Test coverage + linting
-
-| Tool                         | Scope                                                     | Devshell command |
-| ---------------------------- | --------------------------------------------------------- | ---------------- |
-| `cargo clippy -D warnings`   | Rust shell + helpers                                      | `check`          |
-| `cargo test --lib`           | Rust unit tests under `src-tauri/src/helpers.rs`          | `test`           |
-| `bunx tsc -b --noEmit`       | TypeScript types (frontend + agent)                       | `check`          |
-| `bunx eslint .`              | TS + React lint, type-aware via tsconfig                  | `lint`           |
-| `bunx vitest run`            | TS unit tests (`src/**/*.test.ts` + `agent/**/*.test.ts`) | `test`           |
-| `bunx vitest run --coverage` | TS coverage report (v8)                                   | `coverage`       |
-
-The `check` devshell command runs all of the above as a single CI gate.
-ESLint is configured for **0 errors and 0 warnings**. A handful of `react-hooks`
-disables (set-state-in-effect for state-resync paths, exhaustive-deps for
-intentionally-empty memo deps) are scoped per-line with author rationale —
-audit them on touch, don't broaden them.
-
-## Local-only files (gitignored)
-
-`run-phase*.sh` and `aethon-phase*.png` are ad-hoc test-harness artifacts —
-phase scripts spawn the dev server and Playwright-MCP grabs screenshots.
-Don't commit them and don't rely on them being present.
+- Linux needs `webkit2gtk_4_1` + GTK closure on `PKG_CONFIG_PATH` (set
+  manually because numtide/devshell skips pkg-config setup hooks).
+  `WEBKIT_DISABLE_DMABUF_RENDERER=1` dodges a Mesa/Wayland crash.
+- macOS uses Apple's `/usr/bin/cc` (Nix CC wrapper has SDK mismatches
+  against current nixpkgs unstable), and pulls libiconv via
+  `LIBRARY_PATH` + `NIX_LDFLAGS`.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -12,11 +12,15 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 name = "aethon"
 version = "0.2.0"
 dependencies = [
+ "axum",
  "base64 0.22.1",
+ "gethostname",
+ "mdns-sd",
  "notify",
  "portable-pty",
  "serde",
  "serde_json",
+ "sha1",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
@@ -133,7 +137,7 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "parking",
- "polling",
+ "polling 3.11.0",
  "rustix",
  "slab",
  "windows-sys 0.61.2",
@@ -248,6 +252,61 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "base64"
@@ -1044,6 +1103,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1297,6 +1367,16 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1578,6 +1658,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1590,6 +1676,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -1629,7 +1716,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -1782,6 +1869,16 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "if-addrs"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b2eeee38fef3aa9b4cc5f1beea8a2444fc00e7377cafae396de3f5c2065e24"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1976,9 +2073,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2169,6 +2266,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
+]
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "mdns-sd"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e36e83ad165be7e0ad2e3ae3be9afffdda0c2c9a7e70c628e5541f11443e3041"
+dependencies = [
+ "fastrand",
+ "flume",
+ "if-addrs",
+ "log",
+ "polling 2.8.0",
+ "socket2 0.5.10",
 ]
 
 [[package]]
@@ -2863,6 +2980,22 @@ dependencies = [
 
 [[package]]
 name = "polling"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "concurrent-queue",
+ "libc",
+ "log",
+ "pin-project-lite",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "polling"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
@@ -2952,7 +3085,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
 dependencies = [
- "toml_edit 0.20.7",
+ "toml_edit 0.20.2",
 ]
 
 [[package]]
@@ -3349,6 +3482,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3542,6 +3681,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3568,6 +3718,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -3641,6 +3803,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
 dependencies = [
  "stable_deref_trait",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -3737,6 +3910,16 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
@@ -3791,6 +3974,15 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]
@@ -4465,7 +4657,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -4586,9 +4778,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.20.7"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
+checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
  "indexmap 2.14.0",
  "toml_datetime 0.6.11",
@@ -4655,6 +4847,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -4693,6 +4886,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -5033,9 +5227,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5046,9 +5240,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.70"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5056,9 +5250,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5066,9 +5260,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5079,9 +5273,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -5135,9 +5329,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.97"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5493,6 +5687,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -5540,6 +5743,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -5601,6 +5819,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -5619,6 +5843,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -5634,6 +5864,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5667,6 +5903,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5682,6 +5924,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5703,6 +5951,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -5718,6 +5972,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -37,6 +37,10 @@ base64 = "0.22"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tracing-appender = "0.2"
+mdns-sd = "0.12"
+gethostname = "1"
+axum = "0.7"
+sha1 = "0.10"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/src/commands/git.rs
+++ b/src-tauri/src/commands/git.rs
@@ -948,6 +948,35 @@ pub async fn gh_issue_view(project_path: String, number: i64) -> Result<GhIssueD
     })
 }
 
+/// Resolve a GitHub avatar URL for the repo at `project_path`. Returns
+/// `https://github.com/{owner}.png?size=200` when the repo is on GitHub
+/// (avatar URL is stable + cacheable + no API token required), else
+/// `None`. Used by `src/projectIcons.ts` as the network fallback after
+/// a local logo scan misses.
+#[tauri::command]
+pub async fn gh_repo_avatar_url(project_path: String) -> Option<String> {
+    use tokio::process::Command;
+    let dir = PathBuf::from(&project_path);
+    if !dir.is_dir() {
+        return None;
+    }
+    let out = Command::new("gh")
+        .args(["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"])
+        .current_dir(&dir)
+        .output()
+        .await
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let name_with_owner = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    let (owner, _) = name_with_owner.split_once('/')?;
+    if owner.is_empty() {
+        return None;
+    }
+    Some(format!("https://github.com/{owner}.png?size=200"))
+}
+
 /// Pop a native folder picker and return the chosen path (or None if the
 /// user cancelled). Wrapping `tauri-plugin-dialog::pick_folder` here keeps
 /// the frontend free of a direct dialog dependency — the projects feature

--- a/src-tauri/src/commands/host.rs
+++ b/src-tauri/src/commands/host.rs
@@ -42,12 +42,12 @@ fn machine_uuid() -> Option<String> {
             .ok()?;
         let text = String::from_utf8_lossy(&out.stdout);
         for line in text.lines() {
-            if line.contains("IOPlatformUUID") {
-                if let Some(rhs) = line.split('=').nth(1) {
-                    let uuid = rhs.trim().trim_matches('"');
-                    if !uuid.is_empty() {
-                        return Some(uuid.to_string());
-                    }
+            if line.contains("IOPlatformUUID")
+                && let Some(rhs) = line.split('=').nth(1)
+            {
+                let uuid = rhs.trim().trim_matches('"');
+                if !uuid.is_empty() {
+                    return Some(uuid.to_string());
                 }
             }
         }

--- a/src-tauri/src/commands/host.rs
+++ b/src-tauri/src/commands/host.rs
@@ -76,10 +76,17 @@ fn stable_id(hostname: &str) -> String {
     let mut hasher = Sha1::new();
     hasher.update(b"aethon-host-v1\n");
     if let Some(uuid) = machine_uuid() {
+        // Prefer the platform machine-uuid alone — including hostname
+        // here would invalidate persisted hostIds whenever the user
+        // renames the machine. The uuid survives rename + reinstall.
         hasher.update(uuid.as_bytes());
-        hasher.update(b"\n");
+    } else {
+        // No machine-uuid available (Windows today, exotic Linux
+        // distros, or sysctl failures on macOS). Fall back to the
+        // hostname so we still get a stable per-machine value within
+        // one rename cycle.
+        hasher.update(hostname.as_bytes());
     }
-    hasher.update(hostname.as_bytes());
     let digest = hasher.finalize();
     let short: String = digest.iter().take(8).map(|b| format!("{b:02x}")).collect();
     format!("local:{short}")

--- a/src-tauri/src/commands/host.rs
+++ b/src-tauri/src/commands/host.rs
@@ -1,0 +1,143 @@
+//! Host identity for the frontend's HOSTS sidebar section.
+//!
+//! `host_info` returns a stable id + display name for the local machine.
+//! The id mixes the platform machine-uuid with `gethostname()` so we
+//! survive hostname rename and reinstall, falling back to a hash of the
+//! hostname if neither uuid source is available.
+//!
+//! The fingerprint is a placeholder until the pairing PR lands — same
+//! shape as Claudette's mdns TXT record so the wire format is forward
+//! compatible.
+
+use serde::Serialize;
+use sha1::{Digest, Sha1};
+use std::process::Command;
+
+#[derive(Debug, Serialize, Clone)]
+pub struct HostInfo {
+    pub id: String,
+    pub hostname: String,
+    #[serde(rename = "displayName")]
+    pub display_name: String,
+    pub fingerprint: String,
+}
+
+fn machine_uuid() -> Option<String> {
+    if cfg!(target_os = "linux") {
+        for path in ["/etc/machine-id", "/var/lib/dbus/machine-id"] {
+            if let Ok(s) = std::fs::read_to_string(path) {
+                let trimmed = s.trim();
+                if !trimmed.is_empty() {
+                    return Some(trimmed.to_string());
+                }
+            }
+        }
+        None
+    } else if cfg!(target_os = "macos") {
+        // `ioreg` is always present on macOS; output line looks like
+        // `"IOPlatformUUID" = "ABC123-..."`.
+        let out = Command::new("ioreg")
+            .args(["-d2", "-c", "IOPlatformExpertDevice"])
+            .output()
+            .ok()?;
+        let text = String::from_utf8_lossy(&out.stdout);
+        for line in text.lines() {
+            if line.contains("IOPlatformUUID") {
+                if let Some(rhs) = line.split('=').nth(1) {
+                    let uuid = rhs.trim().trim_matches('"');
+                    if !uuid.is_empty() {
+                        return Some(uuid.to_string());
+                    }
+                }
+            }
+        }
+        None
+    } else if cfg!(target_os = "windows") {
+        // Falls back to hostname-hash on Windows for now — pairing PR
+        // can switch to MachineGuid registry read if/when we ship Windows.
+        None
+    } else {
+        None
+    }
+}
+
+fn hostname_string() -> String {
+    gethostname::gethostname().to_string_lossy().into_owned()
+}
+
+fn pretty_display(hostname: &str) -> String {
+    hostname
+        .trim_end_matches(".local")
+        .trim_end_matches(".lan")
+        .to_string()
+}
+
+fn stable_id(hostname: &str) -> String {
+    let mut hasher = Sha1::new();
+    hasher.update(b"aethon-host-v1\n");
+    if let Some(uuid) = machine_uuid() {
+        hasher.update(uuid.as_bytes());
+        hasher.update(b"\n");
+    }
+    hasher.update(hostname.as_bytes());
+    let digest = hasher.finalize();
+    let short: String = digest.iter().take(8).map(|b| format!("{b:02x}")).collect();
+    format!("local:{short}")
+}
+
+fn fingerprint_placeholder(id: &str) -> String {
+    // Deterministic per-host placeholder so two boots of the same Aethon
+    // advertise the same TXT value. Real cert fingerprints replace this
+    // when pairing lands.
+    let mut h = Sha1::new();
+    h.update(b"aethon-fingerprint-v0\n");
+    h.update(id.as_bytes());
+    let digest = h.finalize();
+    digest.iter().take(8).map(|b| format!("{b:02x}")).collect()
+}
+
+pub fn local_host_info() -> HostInfo {
+    let hostname = hostname_string();
+    let display_name = pretty_display(&hostname);
+    let id = stable_id(&hostname);
+    let fingerprint = fingerprint_placeholder(&id);
+    HostInfo {
+        id,
+        hostname,
+        display_name,
+        fingerprint,
+    }
+}
+
+#[tauri::command]
+pub fn host_info() -> Result<HostInfo, String> {
+    Ok(local_host_info())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn host_info_has_stable_shape() {
+        let info = local_host_info();
+        assert!(info.id.starts_with("local:"));
+        assert!(!info.hostname.is_empty());
+        assert!(!info.display_name.is_empty());
+        assert_eq!(info.fingerprint.len(), 16);
+    }
+
+    #[test]
+    fn pretty_display_trims_local_suffix() {
+        assert_eq!(pretty_display("halcyon.local"), "halcyon");
+        assert_eq!(pretty_display("halcyon.lan"), "halcyon");
+        assert_eq!(pretty_display("halcyon"), "halcyon");
+    }
+
+    #[test]
+    fn stable_id_deterministic_for_same_hostname() {
+        let a = stable_id("halcyon.local");
+        let b = stable_id("halcyon.local");
+        assert_eq!(a, b);
+    }
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -21,5 +21,6 @@ pub mod extensions;
 pub mod fs;
 pub mod git;
 pub mod host;
+pub mod server;
 pub mod session;
 pub mod window;

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -20,5 +20,6 @@ pub mod config;
 pub mod extensions;
 pub mod fs;
 pub mod git;
+pub mod host;
 pub mod session;
 pub mod window;

--- a/src-tauri/src/commands/server.rs
+++ b/src-tauri/src/commands/server.rs
@@ -1,0 +1,38 @@
+//! Frontend control surface for the built-in HTTP + mDNS server.
+//!
+//! The browser (peer discovery) always runs and isn't toggleable here —
+//! discovery is read-only and safe. These commands cover the local
+//! advertiser + HTTP listener, which the user can stop without losing
+//! peer visibility.
+
+use std::sync::Arc;
+use tauri::{AppHandle, State};
+
+use crate::server::ServerState;
+
+#[derive(Debug, serde::Serialize)]
+pub struct ServerStatus {
+    pub running: bool,
+    pub port: Option<u16>,
+}
+
+#[tauri::command]
+pub async fn server_status(state: State<'_, Arc<ServerState>>) -> Result<ServerStatus, String> {
+    let running = state.is_running().await;
+    let port = state.port().await;
+    Ok(ServerStatus { running, port })
+}
+
+#[tauri::command]
+pub async fn server_start(
+    app: AppHandle,
+    state: State<'_, Arc<ServerState>>,
+) -> Result<u16, String> {
+    crate::server::start(&app, state.inner()).await
+}
+
+#[tauri::command]
+pub async fn server_stop(state: State<'_, Arc<ServerState>>) -> Result<(), String> {
+    state.stop().await;
+    Ok(())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -752,6 +752,7 @@ pub fn run() {
             commands::git::gh_issue_list,
             commands::git::gh_issue_view,
             commands::git::pick_project_directory,
+            commands::host::host_info,
             commands::window::updater_available,
             commands::window::toggle_fullscreen,
             commands::window::toggle_devtools,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -37,6 +37,7 @@ use tauri::{AppHandle, Emitter, Manager, State};
 
 mod commands;
 mod helpers;
+mod server;
 mod shell;
 mod window_state;
 use helpers::{parse_config_toml, sanitize_filename_segment};
@@ -699,6 +700,7 @@ pub fn run() {
         .manage(AgentReloadFlag(Arc::new(AtomicBool::new(false))))
         .manage(shell::ShellRegistry::new())
         .manage(window_state::WindowStateStore::new())
+        .manage(Arc::new(server::ServerState::new()))
         .on_window_event(|window, event| match event {
             tauri::WindowEvent::Resized(_) | tauri::WindowEvent::Moved(_) => {
                 window_state::schedule_save(window.app_handle().clone(), window.label().to_string());
@@ -753,6 +755,9 @@ pub fn run() {
             commands::git::gh_issue_view,
             commands::git::pick_project_directory,
             commands::host::host_info,
+            commands::server::server_status,
+            commands::server::server_start,
+            commands::server::server_stop,
             commands::window::updater_available,
             commands::window::toggle_fullscreen,
             commands::window::toggle_devtools,
@@ -816,6 +821,11 @@ pub fn run() {
                     let _ = w.show();
                 }
             }
+            // Built-in HTTP + mDNS server. Failures inside `boot` are
+            // logged + swallowed so a port collision or LAN hiccup
+            // never blocks the UI.
+            let server_state = app.state::<Arc<server::ServerState>>().inner().clone();
+            server::boot(app.handle().clone(), server_state);
             Ok(())
         })
         .run(tauri::generate_context!())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -751,6 +751,7 @@ pub fn run() {
             commands::git::git_branch_list,
             commands::git::gh_branch_status,
             commands::git::gh_repo_overview,
+            commands::git::gh_repo_avatar_url,
             commands::git::gh_issue_list,
             commands::git::gh_issue_view,
             commands::git::pick_project_directory,

--- a/src-tauri/src/server/http.rs
+++ b/src-tauri/src/server/http.rs
@@ -1,0 +1,40 @@
+//! Minimal axum HTTP server.
+//!
+//! Two endpoints today: `GET /health` returns the literal string
+//! `aethon` (200 OK), `GET /status` returns the JSON `HostInfo` doc.
+//! Binds `0.0.0.0:0` so the OS picks the port; the chosen port flows
+//! back into mDNS advertising. **No auth, no TLS** — the pairing PR
+//! adds both.
+
+use std::net::SocketAddr;
+
+use axum::{routing::get, Json, Router};
+use tauri::async_runtime::JoinHandle;
+use tokio::net::TcpListener;
+
+use crate::commands::host::HostInfo;
+
+/// Bind the listener and spawn the axum task. Returns the bound port
+/// + the join handle (abort on `server_stop`).
+pub async fn serve(info: HostInfo) -> Result<(u16, JoinHandle<()>), String> {
+    let addr: SocketAddr = "0.0.0.0:0".parse().map_err(|e| format!("addr: {e}"))?;
+    let listener = TcpListener::bind(addr)
+        .await
+        .map_err(|e| format!("bind: {e}"))?;
+    let port = listener
+        .local_addr()
+        .map_err(|e| format!("local_addr: {e}"))?
+        .port();
+    let app = Router::new()
+        .route("/health", get(|| async { "aethon" }))
+        .route("/status", get(move || {
+            let info = info.clone();
+            async move { Json(info) }
+        }));
+    let task = tauri::async_runtime::spawn(async move {
+        if let Err(e) = axum::serve(listener, app).await {
+            tracing::warn!(target: "aethon::server::http", "serve ended: {e}");
+        }
+    });
+    Ok((port, task))
+}

--- a/src-tauri/src/server/mdns.rs
+++ b/src-tauri/src/server/mdns.rs
@@ -1,0 +1,160 @@
+//! mDNS advertise + browse for `_aethon._tcp.local.`.
+//!
+//! Advertise: a single `ServiceInfo` registration with TXT records
+//! `{ version, name, fingerprint }`. Caller holds the returned
+//! `ServiceDaemon` for the lifetime of the announcement.
+//!
+//! Browse: a long-lived task that emits `host-discovered` /
+//! `host-removed` Tauri events whenever a peer resolves or drops.
+//! Resolution events are coalesced through a 250ms debounce buffer so a
+//! noisy LAN doesn't fan out hundreds of emits per second.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use mdns_sd::{ServiceDaemon, ServiceEvent, ServiceInfo};
+use serde::Serialize;
+use tauri::{AppHandle, Emitter};
+
+const SERVICE_TYPE: &str = "_aethon._tcp.local.";
+const DEBOUNCE: Duration = Duration::from_millis(250);
+
+#[derive(Debug, Serialize, Clone)]
+pub struct DiscoveredHost {
+    pub id: String,
+    pub hostname: String,
+    #[serde(rename = "displayName")]
+    pub display_name: String,
+    pub port: u16,
+    #[serde(rename = "fingerprintPrefix")]
+    pub fingerprint_prefix: String,
+    #[serde(rename = "lastSeen")]
+    pub last_seen: u64,
+}
+
+#[derive(Debug, Serialize, Clone)]
+struct HostRemoved {
+    id: String,
+}
+
+/// Advertise this Aethon instance. Drop the returned `ServiceDaemon` to
+/// stop announcing. The daemon must outlive the announcement.
+pub fn advertise(
+    display_name: &str,
+    port: u16,
+    fingerprint: &str,
+) -> Result<ServiceDaemon, Box<dyn std::error::Error>> {
+    let mdns = ServiceDaemon::new()?;
+    let hostname = gethostname::gethostname().to_string_lossy().to_string();
+    let instance_name = format!("{display_name} ({hostname})");
+    let version = env!("CARGO_PKG_VERSION");
+    let props = [
+        ("version", version),
+        ("name", display_name),
+        ("fingerprint", fingerprint),
+    ];
+    let service = ServiceInfo::new(
+        SERVICE_TYPE,
+        &instance_name,
+        &format!("{hostname}.local."),
+        "",
+        port,
+        &props[..],
+    )?;
+    mdns.register(service)?;
+    Ok(mdns)
+}
+
+/// Start the LAN browser. Resolution events are debounced before they
+/// fan out as Tauri events so the frontend never has to dedupe.
+pub fn start_browser(app: AppHandle) -> Result<(), String> {
+    let local_id = crate::commands::host::local_host_info().id;
+    let mdns = ServiceDaemon::new().map_err(|e| format!("daemon: {e}"))?;
+    let receiver = mdns.browse(SERVICE_TYPE).map_err(|e| format!("browse: {e}"))?;
+    tauri::async_runtime::spawn(async move {
+        // Hold the daemon alive for the task lifetime.
+        let _mdns = mdns;
+        let mut fullname_to_id: HashMap<String, String> = HashMap::new();
+        let mut pending: HashMap<String, DiscoveredHost> = HashMap::new();
+        let mut next_flush: Option<tokio::time::Instant> = None;
+        loop {
+            // Either receive an event or wake up to flush the debounce buffer.
+            let event = if let Some(deadline) = next_flush {
+                tokio::select! {
+                    _ = tokio::time::sleep_until(deadline) => {
+                        flush(&app, &mut pending);
+                        next_flush = None;
+                        continue;
+                    }
+                    ev = receiver.recv_async() => ev,
+                }
+            } else {
+                receiver.recv_async().await
+            };
+            let Ok(event) = event else {
+                break;
+            };
+            match event {
+                ServiceEvent::ServiceResolved(info) => {
+                    let name = info
+                        .get_property_val_str("name")
+                        .unwrap_or_default()
+                        .to_string();
+                    let fingerprint = info
+                        .get_property_val_str("fingerprint")
+                        .unwrap_or_default()
+                        .to_string();
+                    let hostname = info.get_hostname().trim_end_matches('.').to_string();
+                    let port = info.get_port();
+                    let fullname = info.get_fullname().to_string();
+                    let id = format!("remote:{fingerprint}");
+                    if id == local_id {
+                        // mdns-sd echoes our own advertisement; skip it.
+                        continue;
+                    }
+                    let display = if name.is_empty() {
+                        hostname
+                            .trim_end_matches(".local")
+                            .trim_end_matches(".lan")
+                            .to_string()
+                    } else {
+                        name.clone()
+                    };
+                    let host = DiscoveredHost {
+                        id: id.clone(),
+                        hostname,
+                        display_name: display,
+                        port,
+                        fingerprint_prefix: fingerprint,
+                        last_seen: now_ms(),
+                    };
+                    fullname_to_id.insert(fullname, id.clone());
+                    pending.insert(id, host);
+                    next_flush = Some(tokio::time::Instant::now() + DEBOUNCE);
+                }
+                ServiceEvent::ServiceRemoved(_, fullname) => {
+                    if let Some(id) = fullname_to_id.remove(&fullname) {
+                        pending.remove(&id);
+                        let _ = app.emit("host-removed", HostRemoved { id });
+                    }
+                }
+                _ => {}
+            }
+        }
+    });
+    Ok(())
+}
+
+fn flush(app: &AppHandle, pending: &mut HashMap<String, DiscoveredHost>) {
+    for (_, host) in pending.drain() {
+        let _ = app.emit("host-discovered", host);
+    }
+}
+
+fn now_ms() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}

--- a/src-tauri/src/server/mdns.rs
+++ b/src-tauri/src/server/mdns.rs
@@ -68,7 +68,11 @@ pub fn advertise(
 /// Start the LAN browser. Resolution events are debounced before they
 /// fan out as Tauri events so the frontend never has to dedupe.
 pub fn start_browser(app: AppHandle) -> Result<(), String> {
-    let local_id = crate::commands::host::local_host_info().id;
+    // Compare by fingerprint, NOT by id — the browser builds remote ids
+    // as `remote:<fingerprint>` while host_info returns `local:<short>`.
+    // A pure-id check would never match and we'd surface ourselves as
+    // a remote (codex P2 review finding).
+    let local_fingerprint = crate::commands::host::local_host_info().fingerprint;
     let mdns = ServiceDaemon::new().map_err(|e| format!("daemon: {e}"))?;
     let receiver = mdns.browse(SERVICE_TYPE).map_err(|e| format!("browse: {e}"))?;
     tauri::async_runtime::spawn(async move {
@@ -107,11 +111,11 @@ pub fn start_browser(app: AppHandle) -> Result<(), String> {
                     let hostname = info.get_hostname().trim_end_matches('.').to_string();
                     let port = info.get_port();
                     let fullname = info.get_fullname().to_string();
-                    let id = format!("remote:{fingerprint}");
-                    if id == local_id {
+                    if fingerprint == local_fingerprint {
                         // mdns-sd echoes our own advertisement; skip it.
                         continue;
                     }
+                    let id = format!("remote:{fingerprint}");
                     let display = if name.is_empty() {
                         hostname
                             .trim_end_matches(".local")

--- a/src-tauri/src/server/mod.rs
+++ b/src-tauri/src/server/mod.rs
@@ -1,0 +1,102 @@
+//! Built-in HTTP + mDNS server scaffold.
+//!
+//! Models Claudette's daemon pattern: one `ServiceDaemon` advertises
+//! `_aethon._tcp.local.`, a second `ServiceDaemon` browses for peers and
+//! emits `host-discovered` / `host-removed` Tauri events. An axum HTTP
+//! server binds `0.0.0.0:0` (OS picks the port → mDNS TXT) and exposes
+//! `GET /health` + `GET /status`. No auth, no TLS — explicitly scaffold
+//! until the pairing PR replaces fingerprint + adds tokens.
+//!
+//! Lifecycle: `boot(app)` reads `[server] enabled` from config (defaults
+//! true), binds HTTP, registers mDNS advertise, starts the browser.
+//! Browser runs even when advertiser is off — discovery is read-only and
+//! useful in isolation. `shutdown(state)` aborts the join handles and
+//! drops both `ServiceDaemon`s.
+
+use std::sync::Arc;
+use tauri::async_runtime::JoinHandle;
+use tauri::AppHandle;
+use tokio::sync::Mutex;
+
+pub mod http;
+pub mod mdns;
+
+/// Holds the running server's resources so we can shut down cleanly.
+/// All fields owned: dropping `ServerHandle` stops the advertisement
+/// and the HTTP listener.
+pub struct ServerHandle {
+    pub port: u16,
+    pub http_task: JoinHandle<()>,
+    // Held for the lifetime of the announcement — dropping the daemon
+    // stops the mDNS advertisement. Never read directly.
+    #[allow(dead_code)]
+    pub advertise_daemon: mdns_sd::ServiceDaemon,
+}
+
+/// Managed by Tauri (`.manage(ServerState::new())`). Wraps an
+/// `Arc<Mutex<Option<ServerHandle>>>` so `server_start` / `server_stop`
+/// can rebuild the handle without rebuilding the registration.
+#[derive(Default)]
+pub struct ServerState {
+    inner: Arc<Mutex<Option<ServerHandle>>>,
+}
+
+impl ServerState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub async fn is_running(&self) -> bool {
+        self.inner.lock().await.is_some()
+    }
+
+    pub async fn port(&self) -> Option<u16> {
+        self.inner.lock().await.as_ref().map(|h| h.port)
+    }
+
+    pub async fn set(&self, handle: ServerHandle) {
+        let mut guard = self.inner.lock().await;
+        if let Some(prev) = guard.take() {
+            prev.http_task.abort();
+            // Dropping prev.advertise_daemon stops the announcement.
+        }
+        *guard = Some(handle);
+    }
+
+    pub async fn stop(&self) {
+        let mut guard = self.inner.lock().await;
+        if let Some(prev) = guard.take() {
+            prev.http_task.abort();
+        }
+    }
+}
+
+/// Start the server on app boot. Failures log + carry on — a network
+/// hiccup must never block the UI.
+pub fn boot(app: AppHandle, state: Arc<ServerState>) {
+    tauri::async_runtime::spawn(async move {
+        if let Err(e) = start(&app, &state).await {
+            tracing::warn!(target: "aethon::server", "boot failed: {e}");
+        }
+        if let Err(e) = mdns::start_browser(app.clone()) {
+            tracing::warn!(target: "aethon::server::mdns", "browser failed: {e}");
+        }
+    });
+}
+
+/// Bind HTTP + register mDNS. Pulled out so `server_start` IPC can
+/// reuse it after a user-triggered stop.
+pub async fn start(_app: &AppHandle, state: &ServerState) -> Result<u16, String> {
+    let info = crate::commands::host::local_host_info();
+    let (port, http_task) = http::serve(info.clone()).await?;
+    let advertise_daemon = mdns::advertise(&info.display_name, port, &info.fingerprint)
+        .map_err(|e| format!("mdns advertise failed: {e}"))?;
+    let handle = ServerHandle {
+        port,
+        http_task,
+        advertise_daemon,
+    };
+    state.set(handle).await;
+    tracing::info!(target: "aethon::server", "listening on 0.0.0.0:{port}");
+    Ok(port)
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import { SkillRegistry } from "./skills/SkillRegistry";
 import { SkillRegistryProvider } from "./skills/registry";
 import { defaultLayoutSkill } from "./skills/default-layout";
 import type { A2UIPayload } from "./types/a2ui";
-import { deriveTabActiveFlags, makeEmptyTab, type Tab } from "./types/tab";
+import { deriveTabActiveFlags, type Tab } from "./types/tab";
 import { dispatchEvent, type EventRouteContext } from "./eventRoutes";
 import { useZoomAndTheme } from "./hooks/useZoomAndTheme";
 import { useShellConsent } from "./hooks/useShellConsent";
@@ -80,21 +80,27 @@ export default function App() {
   // The layout's state IS the app state. Single source of truth, addressed by
   // JSON Pointer from the layout payload. We seed `logoUrl` here so the header
   // can $ref it without the layout JSON having to know the hashed asset path.
-  // Initial state also seeds one default tab + the active-tab mirror keys.
+  // Initial state has NO tabs by default — the projects-dashboard is the
+  // canvas until the user opens a project or clicks "New Tab". A restored
+  // session snapshot rehydrates whatever tabs were open last; a fresh boot
+  // (or `dev --new`) lands on the dashboard with the canvas empty.
   const initialApp = useMemo(() => {
-    const tab0 = makeEmptyTab("default", "Tab 1");
     const restored = loadSessionUiSnapshot();
-    const tabs = restored?.tabs.length ? restored.tabs : [tab0];
+    const tabs = restored?.tabs.length ? restored.tabs : [];
     const activeTabId =
       restored?.activeTabId && tabs.some((t) => t.id === restored.activeTabId)
         ? restored.activeTabId
-        : tabs[0].id;
-    const activeTab = tabs.find((t) => t.id === activeTabId) ?? tabs[0];
+        : (tabs[0]?.id ?? null);
+    const activeTab = tabs.find((t) => t.id === activeTabId) ?? tabs[0] ?? null;
     const restoredLayout =
       restored?.layout && typeof restored.layout === "object"
         ? (restored.layout as Record<string, unknown>)
         : {};
-    const activeRecord = activeTab as unknown as Record<string, unknown>;
+    // When there is no active tab, the mirror keys point at undefined so
+    // layout `$ref`s resolve cleanly without throwing. The composer +
+    // chat surfaces are hidden via `/agentTabActive` in this state.
+    const activeRecord =
+      (activeTab as unknown as Record<string, unknown> | null) ?? {};
     const rootMirror = Object.fromEntries(
       TAB_MIRROR_KEYS.map((key) => [key, activeRecord[key]]),
     );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { useZoomAndTheme } from "./hooks/useZoomAndTheme";
 import { useShellConsent } from "./hooks/useShellConsent";
 import { useHostInfo } from "./hooks/useHostInfo";
 import { useProjects } from "./hooks/useProjects";
+import { discoverIcon } from "./projectIcons";
 import { useTabNavigation } from "./hooks/useTabNavigation";
 import { TAB_MIRROR_KEYS, useTabs } from "./hooks/useTabs";
 import { useExtensionsHydration } from "./hooks/useExtensionsHydration";
@@ -497,6 +498,7 @@ export default function App() {
     clearActiveProject,
     removeProjectById,
     setProjectExpanded,
+    setProjectIconUrl,
     refreshProjectWorktrees,
     activateWorktree,
     createWorktreeForProject,
@@ -532,6 +534,27 @@ export default function App() {
       onGitStatusChanged: () => syncProjectsToState(),
     };
   });
+
+  // Lazy project icon discovery — for each project missing an iconUrl,
+  // fire discoverIcon and persist the resolved url back to the project
+  // record. The in-process cache in src/projectIcons.ts memoizes by
+  // path so this effect is idempotent across re-runs. Runs whenever
+  // the projects list shape changes (new project, refresh, host swap).
+  const discoverIconsForProjects = useCallback(() => {
+    const ps = projectsRef.current.projects;
+    for (const project of ps) {
+      if (project.iconUrl) continue;
+      void (async () => {
+        const url = await discoverIcon(project);
+        if (!url) return;
+        if (!projectsRef.current.projects.some((p) => p.id === project.id)) return;
+        setProjectIconUrl(project.id, url);
+      })();
+    }
+  }, [setProjectIconUrl]);
+  useEffect(() => {
+    discoverIconsForProjects();
+  }, [discoverIconsForProjects, state.projects]);
 
   // ---------------------------------------------------------------------
   // Toast stack + OS completion notification. Owned by useNotifications.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { deriveTabActiveFlags, makeEmptyTab, type Tab } from "./types/tab";
 import { dispatchEvent, type EventRouteContext } from "./eventRoutes";
 import { useZoomAndTheme } from "./hooks/useZoomAndTheme";
 import { useShellConsent } from "./hooks/useShellConsent";
+import { useHostInfo } from "./hooks/useHostInfo";
 import { useProjects } from "./hooks/useProjects";
 import { useTabNavigation } from "./hooks/useTabNavigation";
 import { TAB_MIRROR_KEYS, useTabs } from "./hooks/useTabs";
@@ -384,6 +385,11 @@ export default function App() {
     getProjectPaths: () => projectsHandleRef.current.getPaths(),
     onGitStatusChanged: () => projectsHandleRef.current.onGitStatusChanged(),
   });
+
+  // Host info (local + LAN-discovered) — drives the HOSTS sidebar
+  // section and the dashboard host banner. Stays passive: hosts come
+  // from Tauri events; the active host is a user-driven selection.
+  const hostInfo = useHostInfo();
 
   // ---------------------------------------------------------------------
   // Tab lifecycle (create / switch / update / close / undo-close), the
@@ -1067,6 +1073,12 @@ export default function App() {
       openProjectFromPicker,
       setActiveProjectById,
       removeProjectById,
+      setActiveHost: (id) => {
+        hostInfo.setActiveHost(id);
+        // Switching host clears the active project — projects are
+        // host-scoped (today: all local; future: filtered by hostId).
+        clearActiveProject();
+      },
       syncRecentSessionsToState,
       setProjectExpanded,
       refreshProjectWorktrees,
@@ -1190,6 +1202,21 @@ export default function App() {
       ...existingProjectsDashboard,
       extraCards: existingProjectsDashboard.extraCards ?? [],
     };
+    // HOSTS sidebar section — [local, ...remotes] with the active host
+    // flagged. The local host is always the first row; discovered
+    // remotes follow in arrival order. Active flag drives the
+    // .a2ui-sidebar-item-active style + the `host` derived record below
+    // (consumed by the dashboard host-banner).
+    const activeHostId = hostInfo.activeHostId ?? hostInfo.localHostId;
+    const sidebarHosts = hostInfo.hosts.map((h) => ({
+      id: h.id,
+      label: h.displayName || h.hostname,
+      hint: h.isLocal ? "this mac" : h.hostname,
+      tooltip: h.hostname,
+      active: h.id === activeHostId,
+    }));
+    const activeHost =
+      hostInfo.hosts.find((h) => h.id === activeHostId) ?? null;
     return {
       ...state,
       hasTabs,
@@ -1203,11 +1230,15 @@ export default function App() {
       sidebar: {
         ...sidebar,
         history,
+        hosts: sidebarHosts,
       },
       projectDashboard,
       projectsDashboard,
+      hosts: hostInfo.hosts,
+      activeHostId,
+      host: activeHost,
     };
-  }, [buildSidebarHistory, state]);
+  }, [buildSidebarHistory, hostInfo.activeHostId, hostInfo.hosts, hostInfo.localHostId, state]);
   const renderRecord = renderState as Record<string, unknown>;
   const notificationsOpen =
     ((renderRecord.notifications as unknown[] | undefined) ?? []).length > 0;

--- a/src/eventRoutes/sidebar.test.ts
+++ b/src/eventRoutes/sidebar.test.ts
@@ -280,6 +280,19 @@ describe("handleSectionedSelect", () => {
     expect(mocks.setActiveTab).toHaveBeenCalledWith("abc123");
   });
 
+  it("hosts section routes select to setActiveHost", async () => {
+    const { ctx } = buildRouteFixture();
+    await handleSectionedSelect(
+      {
+        component: { id: "sidebar" },
+        eventType: "select",
+        data: { sectionId: "hosts", itemId: "remote:bender" },
+      },
+      ctx,
+    );
+    expect(ctx.setActiveHost).toHaveBeenCalledWith("remote:bender");
+  });
+
   it("projects open-project triggers the picker", async () => {
     const { ctx, mocks } = buildRouteFixture();
     await handleSectionedSelect(

--- a/src/eventRoutes/sidebar.ts
+++ b/src/eventRoutes/sidebar.ts
@@ -534,6 +534,10 @@ export const handleSectionedSelect: EventRouteHandler = async (
     ctx.setActiveProjectById(selected.itemId);
     return true;
   }
+  if (selected?.sectionId === "hosts" && selected.itemId) {
+    ctx.setActiveHost(selected.itemId);
+    return true;
+  }
   if (selected?.sectionId === "history" && selected.itemId) {
     if (selected.itemId.startsWith("tab:")) {
       ctx.setActiveTab(selected.itemId.slice(4));

--- a/src/eventRoutes/testFixtures.ts
+++ b/src/eventRoutes/testFixtures.ts
@@ -187,6 +187,7 @@ export function buildRouteFixture(
     openProjectFromPicker,
     setActiveProjectById,
     removeProjectById,
+    setActiveHost: vi.fn(),
     syncRecentSessionsToState,
     setProjectExpanded: vi.fn(),
     refreshProjectWorktrees: vi.fn(() => Promise.resolve()),

--- a/src/eventRoutes/types.ts
+++ b/src/eventRoutes/types.ts
@@ -123,6 +123,10 @@ export interface EventRouteContext {
   openProjectFromPicker: () => Promise<string | null>;
   setActiveProjectById: (id: string) => void;
   removeProjectById: (id: string) => boolean;
+  /** Switch the active host (HOSTS sidebar section). Clearing the active
+   *  project is the responsibility of the caller chain; this just
+   *  flips the host pointer. */
+  setActiveHost: (id: string | null) => void;
   syncRecentSessionsToState: () => void;
   // ─── Worktrees ─────────────────────────────────────────────────────
   setProjectExpanded: (projectId: string, expanded: boolean) => void;

--- a/src/hooks/bridgeMessageHandlers/ready.test.ts
+++ b/src/hooks/bridgeMessageHandlers/ready.test.ts
@@ -199,6 +199,7 @@ describe("handleReady", () => {
       activeId: "p1",
       activeWorktreeId: null,
       worktreesByProject: {},
+      activeHostId: null,
       projects: [
         { id: "p1", label: "p1", path: "/tmp/p1", lastUsed: Date.now() },
       ],
@@ -225,6 +226,7 @@ describe("handleReady", () => {
       activeId: "p2",
       activeWorktreeId: null,
       worktreesByProject: {},
+      activeHostId: null,
       projects: [
         { id: "p1", label: "A", path: "/repo/a", lastUsed: 1 },
         { id: "p2", label: "B", path: "/repo/b", lastUsed: 2 },
@@ -263,6 +265,7 @@ describe("handleReady", () => {
       activeId: "p2",
       activeWorktreeId: null,
       worktreesByProject: {},
+      activeHostId: null,
       projects: [
         { id: "p1", label: "A", path: "/repo/a", lastUsed: 1 },
         { id: "p2", label: "B", path: "/repo/b", lastUsed: 2 },

--- a/src/hooks/bridgeMessageHandlers/ready.ts
+++ b/src/hooks/bridgeMessageHandlers/ready.ts
@@ -25,7 +25,13 @@ export const handleReady: BridgeMessageHandler = (data, ctx) => {
   // Cache pi's default model so new tabs created before `ready` fires
   // (or before a session's model initialises) can inherit it immediately
   // instead of showing blank "model ▼".
-  if (model) ctx.piDefaultModelRef.current = model;
+  if (model) {
+    ctx.piDefaultModelRef.current = model;
+    // Mirror to state so the header ModelPicker has something to render
+    // even when there is no active tab (fresh boot lands on the
+    // projects-dashboard, /model is undefined until a tab is opened).
+    ctx.setState((prev) => ({ ...prev, piDefaultModel: model }));
+  }
   const models = (data.models as ModelDescriptor[]) ?? [];
   // Hydrate any extension-registered component templates the bridge
   // discovered at boot. setTemplates is wholesale (bridge is the source

--- a/src/hooks/useHostInfo.test.ts
+++ b/src/hooks/useHostInfo.test.ts
@@ -7,27 +7,29 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 const eventListeners = new Map<string, Array<(event: { payload: unknown }) => void>>();
 
 vi.mock("@tauri-apps/api/core", () => ({
-  invoke: async (cmd: string) =>
-    cmd === "host_info"
-      ? { id: "local:abc", hostname: "halcyon.local", displayName: "halcyon", fingerprint: "fp" }
-      : null,
+  invoke: (cmd: string) =>
+    Promise.resolve(
+      cmd === "host_info"
+        ? { id: "local:abc", hostname: "halcyon.local", displayName: "halcyon", fingerprint: "fp" }
+        : null,
+    ),
 }));
 
 vi.mock("@tauri-apps/api/event", () => ({
-  listen: async <T,>(event: string, cb: (e: { payload: T }) => void) => {
+  listen: <T,>(event: string, cb: (e: { payload: T }) => void) => {
     const list = eventListeners.get(event) ?? [];
     list.push(cb as (event: { payload: unknown }) => void);
     eventListeners.set(event, list);
-    return () => {
+    return Promise.resolve(() => {
       const next = (eventListeners.get(event) ?? []).filter((fn) => fn !== cb);
       eventListeners.set(event, next);
-    };
+    });
   },
 }));
 
 vi.mock("../persist", () => ({
-  readState: async () => null,
-  writeState: async () => undefined,
+  readState: () => Promise.resolve(null),
+  writeState: () => Promise.resolve(undefined),
 }));
 
 function fireEvent(name: string, payload: unknown): void {

--- a/src/hooks/useHostInfo.test.ts
+++ b/src/hooks/useHostInfo.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+
+// Tauri mocks: invoke returns a local host; listen exposes a hook so
+// tests can fire host-discovered / host-removed payloads.
+const eventListeners = new Map<string, Array<(event: { payload: unknown }) => void>>();
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: async (cmd: string) =>
+    cmd === "host_info"
+      ? { id: "local:abc", hostname: "halcyon.local", displayName: "halcyon", fingerprint: "fp" }
+      : null,
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: async <T,>(event: string, cb: (e: { payload: T }) => void) => {
+    const list = eventListeners.get(event) ?? [];
+    list.push(cb as (event: { payload: unknown }) => void);
+    eventListeners.set(event, list);
+    return () => {
+      const next = (eventListeners.get(event) ?? []).filter((fn) => fn !== cb);
+      eventListeners.set(event, next);
+    };
+  },
+}));
+
+vi.mock("../persist", () => ({
+  readState: async () => null,
+  writeState: async () => undefined,
+}));
+
+function fireEvent(name: string, payload: unknown): void {
+  for (const cb of eventListeners.get(name) ?? []) cb({ payload });
+}
+
+describe("useHostInfo", () => {
+  it("resolves the local host and defaults activeHostId to it", async () => {
+    const { useHostInfo } = await import("./useHostInfo");
+    const { _resetLocalHostCacheForTests } = await import("../hosts");
+    _resetLocalHostCacheForTests();
+    eventListeners.clear();
+    const { result } = renderHook(() => useHostInfo());
+    await waitFor(() => {
+      expect(result.current.localHostId).toBe("local:abc");
+    });
+    expect(result.current.activeHostId).toBe("local:abc");
+    expect(result.current.hosts[0]?.isLocal).toBe(true);
+  });
+
+  it("merges remote hosts and removes them on host-removed", async () => {
+    const { useHostInfo } = await import("./useHostInfo");
+    const { _resetLocalHostCacheForTests } = await import("../hosts");
+    _resetLocalHostCacheForTests();
+    eventListeners.clear();
+    const { result } = renderHook(() => useHostInfo());
+    await waitFor(() => {
+      expect(result.current.localHostId).toBe("local:abc");
+    });
+    act(() => {
+      fireEvent("host-discovered", {
+        id: "remote:bender",
+        hostname: "bender.local",
+        displayName: "bender",
+        port: 4242,
+        fingerprintPrefix: "ben",
+        lastSeen: 1,
+      });
+    });
+    await waitFor(() => {
+      expect(result.current.hosts.find((h) => h.id === "remote:bender")).toBeTruthy();
+    });
+    act(() => {
+      fireEvent("host-removed", { id: "remote:bender" });
+    });
+    await waitFor(() => {
+      expect(result.current.hosts.find((h) => h.id === "remote:bender")).toBeUndefined();
+    });
+  });
+});

--- a/src/hooks/useHostInfo.ts
+++ b/src/hooks/useHostInfo.ts
@@ -6,13 +6,15 @@
 // already debounces, so we just maintain a Map keyed by id and emit a
 // stable derived list `[local, ...remotes]`.
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { getLocalHost, type Host } from "../hosts";
 
 export interface UseHostInfo {
   hosts: Host[];
   activeHostId: string | null;
+  /** Stable across renders — wire directly into event-route ctx without
+   *  needing a ref bridge. */
   setActiveHost: (id: string | null) => void;
   localHostId: string | null;
 }
@@ -79,11 +81,14 @@ export function useHostInfo(): UseHostInfo {
   }, [localHost?.id]);
 
   const hosts: Host[] = localHost ? [localHost, ...remotes] : remotes;
+  const setActiveHost = useCallback((id: string | null) => {
+    setActiveHostState(id);
+  }, []);
 
   return {
     hosts,
     activeHostId,
-    setActiveHost: (id) => setActiveHostState(id),
+    setActiveHost,
     localHostId: localHost?.id ?? null,
   };
 }

--- a/src/hooks/useHostInfo.ts
+++ b/src/hooks/useHostInfo.ts
@@ -1,0 +1,89 @@
+// useHostInfo — local + LAN-discovered Aethon hosts.
+//
+// On mount the hook resolves the local host via `host_info` IPC and
+// subscribes to the Rust mDNS browser events. Remote hosts join + leave
+// the `hosts` list as their announcements come in. The Rust side
+// already debounces, so we just maintain a Map keyed by id and emit a
+// stable derived list `[local, ...remotes]`.
+
+import { useEffect, useRef, useState } from "react";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { getLocalHost, type Host } from "../hosts";
+
+export interface UseHostInfo {
+  hosts: Host[];
+  activeHostId: string | null;
+  setActiveHost: (id: string | null) => void;
+  localHostId: string | null;
+}
+
+export function useHostInfo(): UseHostInfo {
+  const [localHost, setLocalHost] = useState<Host | null>(null);
+  const remotesRef = useRef<Map<string, Host>>(new Map());
+  const [remotes, setRemotes] = useState<Host[]>([]);
+  const [activeHostId, setActiveHostState] = useState<string | null>(null);
+
+  function emitRemotes(): void {
+    setRemotes(Array.from(remotesRef.current.values()));
+  }
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const local = await getLocalHost();
+      if (cancelled) return;
+      setLocalHost(local);
+      // Default the active host to local on first paint.
+      if (local) {
+        setActiveHostState((prev) => prev ?? local.id);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let off: UnlistenFn[] = [];
+    let cancelled = false;
+    void (async () => {
+      try {
+        const offDiscovered = await listen<Host>("host-discovered", (event) => {
+          const host = event.payload;
+          if (!host?.id) return;
+          remotesRef.current.set(host.id, { ...host, isLocal: false });
+          emitRemotes();
+        });
+        const offRemoved = await listen<{ id: string }>("host-removed", (event) => {
+          const id = event.payload?.id;
+          if (!id) return;
+          if (remotesRef.current.delete(id)) {
+            emitRemotes();
+            setActiveHostState((prev) => (prev === id ? localHost?.id ?? null : prev));
+          }
+        });
+        if (cancelled) {
+          offDiscovered();
+          offRemoved();
+          return;
+        }
+        off = [offDiscovered, offRemoved];
+      } catch {
+        // Running outside Tauri (tests, plain browser) — no events flow.
+      }
+    })();
+    return () => {
+      cancelled = true;
+      for (const fn of off) fn();
+    };
+  }, [localHost?.id]);
+
+  const hosts: Host[] = localHost ? [localHost, ...remotes] : remotes;
+
+  return {
+    hosts,
+    activeHostId,
+    setActiveHost: (id) => setActiveHostState(id),
+    localHostId: localHost?.id ?? null,
+  };
+}

--- a/src/hooks/useProjectOps.ts
+++ b/src/hooks/useProjectOps.ts
@@ -37,6 +37,7 @@ import {
   type Worktree,
 } from "../worktrees";
 import { formatRelativeTime } from "../utils/time";
+import { pickWorktreeName } from "../worktreeNames";
 import { TAB_MIRROR_KEYS } from "./useTabs";
 import { disposeEditorBuffer } from "../monaco/editor-buffers";
 import { recomputeModelPicker } from "../utils/modelPicker";
@@ -739,70 +740,33 @@ export function useProjectOps(
     return `${projectPath.replace(/\/$/, "")}-${safe}`;
   }
 
+  /** One-click worktree create: picks a Helios-pantheon branch name
+   *  that's not already in use, then delegates to
+   *  `createWorktreeWithParams` so the optimistic-update + error-path
+   *  logic stays in exactly one place (this is the same code path the
+   *  task-launcher composer + pi `startTask` tool use). The previous
+   *  implementation used `window.prompt` which is unreliable inside the
+   *  Tauri webview — that's the bug the sidebar context menu hit. */
   async function createWorktreeForProject(projectId: string): Promise<void> {
     const project = findProject(projectId);
     if (!project) return;
-    // Lightweight prompt for now; a richer modal can replace this without
-    // changing the wire format. The branch name is required; target path
-    // defaults to <project>-<branch>.
-    const branch = window.prompt("New worktree branch name");
-    if (!branch) return;
-    const targetPath = window.prompt(
-      "Worktree path",
-      defaultWorktreePath(project.path, branch),
-    );
-    if (!targetPath) return;
-    const pending = newPendingWorktree(projectId, branch, targetPath);
-    // Optimistically show the pending row.
-    const before = projectsRef.current.worktreesByProject[projectId] ?? [];
-    projectsRef.current = setProjectWorktrees(
-      projectsRef.current,
-      projectId,
-      [...before, pending],
-    );
-    syncProjectsToState();
-    // Flip queued → starting and invoke.
-    projectsRef.current = setProjectWorktrees(
-      projectsRef.current,
-      projectId,
-      updateWorktreePendingState(
-        projectsRef.current.worktreesByProject[projectId] ?? [],
-        pending.id,
-        "starting",
-      ),
-    );
-    syncProjectsToState();
-    try {
-      await gitWorktreeAdd({
-        projectPath: project.path,
-        targetPath,
-        branch,
-      });
-      projectsRef.current = setProjectWorktrees(
-        projectsRef.current,
-        projectId,
-        updateWorktreePendingState(
-          projectsRef.current.worktreesByProject[projectId] ?? [],
-          pending.id,
-          "succeeded",
-        ),
-      );
-      // Re-fetch to canonicalize path / head fields.
-      await refreshProjectWorktrees(projectId);
-    } catch (err) {
-      const msg = String(err);
-      projectsRef.current = setProjectWorktrees(
-        projectsRef.current,
-        projectId,
-        updateWorktreePendingState(
-          projectsRef.current.worktreesByProject[projectId] ?? [],
-          pending.id,
-          "failed",
-          msg,
-        ),
-      );
-      syncProjectsToState();
+    // Build the "taken" set from every branch the local clone knows
+    // about (worktree dir names + git-tracked branches) so we don't
+    // collide with existing work.
+    const taken = new Set<string>();
+    for (const w of projectsRef.current.worktreesByProject[projectId] ?? []) {
+      if (w.branch) taken.add(w.branch);
+      if (w.label) taken.add(w.label);
     }
+    try {
+      const branches = await gitBranchList(project.path);
+      for (const b of branches) taken.add(b.name);
+    } catch {
+      // Branch list failed (non-git project, gh missing). Pool is
+      // large enough that pure-random pick still works fine.
+    }
+    const branch = pickWorktreeName(taken);
+    await createWorktreeWithParams({ projectId, branch });
   }
 
   async function createWorktreeWithParams(opts: {

--- a/src/hooks/useProjectOps.ts
+++ b/src/hooks/useProjectOps.ts
@@ -18,6 +18,7 @@ import {
   removeProject,
   saveProjects,
   setActiveWorktree as setActiveWorktreeState,
+  setProjectIconUrl as setProjectIconUrlState,
   setProjectUiExpanded,
   setProjectWorktrees,
   upsertProject,
@@ -137,6 +138,11 @@ export interface UseProjectOpsActions {
   setActiveProjectById: (id: string) => boolean;
   clearActiveProject: () => void;
   removeProjectById: (id: string) => boolean;
+  /** Stamp a discovered icon (data: URL or remote URL) onto the
+   *  project record. Persists to ~/.aethon/projects.json so cold start
+   *  paints synchronously off disk next time. No-op when the iconUrl
+   *  is already set to the same value. */
+  setProjectIconUrl: (projectId: string, iconUrl: string | null) => void;
 
   // ─── Worktree ops ──────────────────────────────────────────────────
   setProjectExpanded: (projectId: string, expanded: boolean) => void;
@@ -371,6 +377,7 @@ export function useProjectOps(
               // the row label stays compact even with deep paths.
               label: p.label,
               tooltip: p.path,
+              iconUrl: p.iconUrl,
               active: p.id === ps.activeId,
               git: gitStatusRef.current.get(p.path),
               expanded: p.uiExpanded === true,
@@ -706,6 +713,13 @@ export function useProjectOps(
     if (expanded && !projectsRef.current.worktreesByProject[projectId]) {
       void refreshProjectWorktrees(projectId);
     }
+    void persistProjects();
+  }
+
+  function setProjectIconUrl(projectId: string, iconUrl: string | null): void {
+    const next = setProjectIconUrlState(projectsRef.current, projectId, iconUrl);
+    if (next === projectsRef.current) return;
+    projectsRef.current = next;
     void persistProjects();
   }
 
@@ -1058,6 +1072,7 @@ export function useProjectOps(
     clearActiveProject,
     removeProjectById,
     setProjectExpanded,
+    setProjectIconUrl,
     refreshProjectWorktrees,
     activateWorktree,
     createWorktreeForProject,

--- a/src/hooks/useTabs.test.ts
+++ b/src/hooks/useTabs.test.ts
@@ -22,6 +22,7 @@ describe("recentSessionItemFromClosedTab", () => {
       activeId: "p1",
       activeWorktreeId: null,
       worktreesByProject: {},
+      activeHostId: null,
       projects: [
         { id: "p1", label: "mold", path: "/repo/mold", lastUsed: 1 },
       ],

--- a/src/hosts.test.ts
+++ b/src/hosts.test.ts
@@ -10,10 +10,10 @@ import {
 
 // We mock the Tauri layer at the import level so unit tests can drive
 // host_info without spinning up the bridge.
-vi.mock("@tauri-apps/api/core", async () => {
+vi.mock("@tauri-apps/api/core", () => {
   let invokeImpl: (cmd: string) => unknown = () => null;
   return {
-    invoke: (cmd: string) => invokeImpl(cmd),
+    invoke: (cmd: string) => Promise.resolve(invokeImpl(cmd)),
     __setInvoke(impl: (cmd: string) => unknown) {
       invokeImpl = impl;
     },
@@ -23,9 +23,10 @@ vi.mock("@tauri-apps/api/core", async () => {
 vi.mock("./persist", () => {
   const store = new Map<string, string>();
   return {
-    readState: async (file: string) => store.get(file) ?? null,
-    writeState: async (file: string, body: string) => {
+    readState: (file: string) => Promise.resolve(store.get(file) ?? null),
+    writeState: (file: string, body: string) => {
       store.set(file, body);
+      return Promise.resolve();
     },
     __clear() {
       store.clear();

--- a/src/hosts.test.ts
+++ b/src/hosts.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  _resetLocalHostCacheForTests,
+  getLocalHost,
+  getLocalHostId,
+  loadPairedHosts,
+  savePairedHosts,
+} from "./hosts";
+
+// We mock the Tauri layer at the import level so unit tests can drive
+// host_info without spinning up the bridge.
+vi.mock("@tauri-apps/api/core", async () => {
+  let invokeImpl: (cmd: string) => unknown = () => null;
+  return {
+    invoke: (cmd: string) => invokeImpl(cmd),
+    __setInvoke(impl: (cmd: string) => unknown) {
+      invokeImpl = impl;
+    },
+  };
+});
+
+vi.mock("./persist", () => {
+  const store = new Map<string, string>();
+  return {
+    readState: async (file: string) => store.get(file) ?? null,
+    writeState: async (file: string, body: string) => {
+      store.set(file, body);
+    },
+    __clear() {
+      store.clear();
+    },
+  };
+});
+
+afterEach(() => {
+  _resetLocalHostCacheForTests();
+});
+
+describe("getLocalHostId", () => {
+  it("returns the bridge id when host_info succeeds", async () => {
+    const tauri = await import("@tauri-apps/api/core");
+    (tauri as unknown as { __setInvoke: (impl: (c: string) => unknown) => void }).__setInvoke(
+      (cmd) => (cmd === "host_info" ? { id: "local:abc", hostname: "x", displayName: "x", fingerprint: "fp" } : null),
+    );
+    expect(await getLocalHostId()).toBe("local:abc");
+  });
+
+  it("falls back when host_info is unavailable", async () => {
+    const tauri = await import("@tauri-apps/api/core");
+    (tauri as unknown as { __setInvoke: (impl: (c: string) => unknown) => void }).__setInvoke(
+      () => {
+        throw new Error("no bridge");
+      },
+    );
+    expect(await getLocalHostId("local:unknown")).toBe("local:unknown");
+  });
+});
+
+describe("getLocalHost", () => {
+  it("returns a fully shaped local Host record", async () => {
+    const tauri = await import("@tauri-apps/api/core");
+    (tauri as unknown as { __setInvoke: (impl: (c: string) => unknown) => void }).__setInvoke(
+      () => ({
+        id: "local:abc",
+        hostname: "halcyon.local",
+        displayName: "halcyon",
+        fingerprint: "deadbeef",
+      }),
+    );
+    const host = await getLocalHost();
+    expect(host).toMatchObject({
+      id: "local:abc",
+      hostname: "halcyon.local",
+      displayName: "halcyon",
+      isLocal: true,
+      fingerprintPrefix: "deadbeef",
+    });
+  });
+});
+
+describe("paired host persistence", () => {
+  it("round-trips through save/load and drops malformed entries", async () => {
+    const persist = await import("./persist");
+    (persist as unknown as { __clear: () => void }).__clear();
+    await savePairedHosts([
+      { id: "remote:1", hostname: "bender", displayName: "bender", isLocal: false, paired: true },
+    ]);
+    const loaded = await loadPairedHosts();
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].displayName).toBe("bender");
+  });
+});

--- a/src/hosts.ts
+++ b/src/hosts.ts
@@ -1,0 +1,112 @@
+// Hosts — machines running an Aethon instance. The local host is always
+// present; remotes appear via mDNS browse and disappear when their
+// announcement times out.
+//
+// Persistence: `~/.aethon/hosts.json` stores only PAIRED hosts so the
+// list survives restart. The pairing PR will populate it. Today only
+// the local entry is "persistable" — discovered remotes live in memory.
+//
+// Forward-compat: keep the file schema simple and stable so a future
+// build can drop `paired: true` records straight in without touching
+// the wire format.
+
+import { invoke } from "@tauri-apps/api/core";
+import { readState, writeState } from "./persist";
+
+export interface Host {
+  id: string;
+  hostname: string;
+  displayName: string;
+  isLocal: boolean;
+  fingerprintPrefix?: string;
+  port?: number;
+  paired?: boolean;
+  lastSeen?: number;
+}
+
+const FILE = "hosts.json";
+const SCHEMA_VERSION = 1;
+
+interface PersistedV1 {
+  schemaVersion?: number;
+  hosts?: Host[];
+}
+
+let cachedLocalHostId: string | null = null;
+
+/** Cached fetch of the local host id from the Rust `host_info` IPC.
+ *  Used by `loadProjects(localHostId)` + every place that needs to
+ *  stamp a project record with its host. */
+export async function getLocalHostId(fallback = "local:unknown"): Promise<string> {
+  if (cachedLocalHostId) return cachedLocalHostId;
+  try {
+    const info = await invoke<{ id: string } | null>("host_info");
+    if (info?.id) {
+      cachedLocalHostId = info.id;
+      return info.id;
+    }
+  } catch {
+    // Tauri command unavailable (tests, plain browser) — fall through.
+  }
+  return fallback;
+}
+
+/** Returns the full local Host record. Cached parallel to
+ *  `getLocalHostId` so callers can paint host UI without a round-trip
+ *  to the bridge on every render. */
+let cachedLocalHost: Host | null = null;
+export async function getLocalHost(): Promise<Host | null> {
+  if (cachedLocalHost) return cachedLocalHost;
+  try {
+    const info = await invoke<{
+      id: string;
+      hostname: string;
+      displayName: string;
+      fingerprint: string;
+    } | null>("host_info");
+    if (info?.id) {
+      cachedLocalHost = {
+        id: info.id,
+        hostname: info.hostname,
+        displayName: info.displayName || info.hostname,
+        isLocal: true,
+        fingerprintPrefix: info.fingerprint,
+      };
+      cachedLocalHostId = info.id;
+      return cachedLocalHost;
+    }
+  } catch {
+    // Tauri command unavailable.
+  }
+  return null;
+}
+
+export async function loadPairedHosts(): Promise<Host[]> {
+  const raw = await readState(FILE);
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw) as PersistedV1;
+    if (!Array.isArray(parsed.hosts)) return [];
+    return parsed.hosts.filter(
+      (h): h is Host =>
+        typeof h?.id === "string" &&
+        typeof h?.hostname === "string" &&
+        typeof h?.displayName === "string",
+    );
+  } catch {
+    return [];
+  }
+}
+
+export async function savePairedHosts(hosts: Host[]): Promise<void> {
+  const payload: PersistedV1 = { schemaVersion: SCHEMA_VERSION, hosts };
+  await writeState(FILE, JSON.stringify(payload));
+}
+
+/** Reset both the local-host caches. Test-only helper — production code
+ *  never needs to invalidate because the local host doesn't change
+ *  within a process lifetime. */
+export function _resetLocalHostCacheForTests(): void {
+  cachedLocalHostId = null;
+  cachedLocalHost = null;
+}

--- a/src/projectIcons.test.ts
+++ b/src/projectIcons.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { _clearProjectIconCache, discoverIcon, iconForProject } from "./projectIcons";
+import type { Project } from "./projects";
+
+interface InvokeArgs {
+  root?: string;
+  path?: string;
+  projectPath?: string;
+}
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+async function setInvoke(impl: (cmd: string, args: InvokeArgs) => unknown): Promise<void> {
+  const { invoke } = await import("@tauri-apps/api/core");
+  (invoke as unknown as { mockImplementation: (i: typeof impl) => void }).mockImplementation(
+    impl as (cmd: string, args: InvokeArgs) => unknown,
+  );
+}
+
+function project(extra: Partial<Project> = {}): Project {
+  return {
+    id: "p1",
+    label: "p1",
+    path: "/repos/p1",
+    lastUsed: 1,
+    ...extra,
+  };
+}
+
+afterEach(() => {
+  _clearProjectIconCache();
+  vi.resetAllMocks();
+});
+
+describe("iconForProject", () => {
+  it("returns cached iconUrl synchronously", () => {
+    expect(iconForProject(project({ iconUrl: "data:image/png;base64,xxx" }))).toBe(
+      "data:image/png;base64,xxx",
+    );
+    expect(iconForProject(project())).toBeNull();
+  });
+});
+
+describe("discoverIcon", () => {
+  it("returns the persisted iconUrl on cached projects without scanning", async () => {
+    const persisted = project({ iconUrl: "data:image/png;base64,cached" });
+    await setInvoke(() => {
+      throw new Error("should not be called");
+    });
+    expect(await discoverIcon(persisted)).toBe("data:image/png;base64,cached");
+  });
+
+  it("finds a root-level logo.png via fs_list_dir + fs_read_file_base64", async () => {
+    await setInvoke((cmd, args) => {
+      if (cmd === "fs_list_dir" && args?.path === "") {
+        return [{ name: "logo.png", isDir: false }];
+      }
+      if (cmd === "fs_read_file_base64" && args?.path === "logo.png") {
+        return "ABCD";
+      }
+      if (cmd === "fs_list_dir") return [];
+      return null;
+    });
+    const result = await discoverIcon(project());
+    expect(result).toBe("data:image/png;base64,ABCD");
+  });
+
+  it("falls back to gh_repo_avatar_url when no local logo exists", async () => {
+    await setInvoke((cmd) => {
+      if (cmd === "fs_list_dir") return [];
+      if (cmd === "gh_repo_avatar_url") {
+        return "https://github.com/utensils.png?size=200";
+      }
+      return null;
+    });
+    const result = await discoverIcon(project());
+    expect(result).toBe("https://github.com/utensils.png?size=200");
+  });
+
+  it("returns null when scan + gh both miss, and caches the negative result", async () => {
+    let calls = 0;
+    await setInvoke((cmd) => {
+      calls += 1;
+      if (cmd === "fs_list_dir") return [];
+      if (cmd === "gh_repo_avatar_url") return null;
+      return null;
+    });
+    const result = await discoverIcon(project());
+    expect(result).toBeNull();
+    const previousCalls = calls;
+    await discoverIcon(project());
+    expect(calls).toBe(previousCalls);
+  });
+});

--- a/src/projectIcons.test.ts
+++ b/src/projectIcons.test.ts
@@ -15,9 +15,7 @@ vi.mock("@tauri-apps/api/core", () => ({
 
 async function setInvoke(impl: (cmd: string, args: InvokeArgs) => unknown): Promise<void> {
   const { invoke } = await import("@tauri-apps/api/core");
-  (invoke as unknown as { mockImplementation: (i: typeof impl) => void }).mockImplementation(
-    impl as (cmd: string, args: InvokeArgs) => unknown,
-  );
+  (invoke as unknown as { mockImplementation: (i: typeof impl) => void }).mockImplementation(impl);
 }
 
 function project(extra: Partial<Project> = {}): Project {

--- a/src/projectIcons.ts
+++ b/src/projectIcons.ts
@@ -1,0 +1,127 @@
+// Project icon discovery — Conductor-style "find a sensible logo for
+// each project" pass. Resolution order:
+//
+//   1. cached `project.iconUrl` (persisted on the Project record)
+//   2. local scan: logo.{png,svg,jpg,webp}, .github/logo.*, public/favicon.*
+//      → returned as a `data:image/...;base64,...` URL so the renderer
+//        doesn't need the asset protocol or convertFileSrc.
+//   3. GitHub avatar via `gh_repo_avatar_url`
+//        → returns the canonical `https://github.com/<owner>.png?size=200`.
+//   4. null → caller renders the initial-tile fallback.
+//
+// Caching: TTL pattern mirrors src/ghRepoOverviewCache.ts (positive +
+// negative TTLs). The in-memory entry is keyed by project path so two
+// projects with the same logo file don't double-fetch.
+//
+// Persistence: callers that have an updateProject wire-up should write
+// the resolved url back onto `Project.iconUrl` so the next cold start
+// paints synchronously off the projects.json record.
+
+import { invoke } from "@tauri-apps/api/core";
+import type { Project } from "./projects";
+
+const LIVE_TTL_MS = 30 * 60 * 1000; // 30 min — icons don't change minute-to-minute
+const NEG_TTL_MS = 24 * 60 * 60 * 1000; // 24 hr — avoid re-hammering gh on every paint
+
+interface CacheEntry {
+  value: string | null;
+  expires: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+const LOCAL_CANDIDATES: { sub: string; names: string[] }[] = [
+  { sub: "", names: ["logo.png", "logo.svg", "logo.jpg", "logo.webp", "icon.png", "icon.svg"] },
+  { sub: ".github", names: ["logo.png", "logo.svg"] },
+  { sub: "public", names: ["logo.png", "logo.svg", "favicon.png", "favicon.svg"] },
+  { sub: "assets", names: ["logo.png", "logo.svg"] },
+  { sub: "docs", names: ["logo.png", "logo.svg"] },
+];
+
+interface FsEntry {
+  name: string;
+  isDir: boolean;
+}
+
+function mime(name: string): string {
+  if (name.endsWith(".svg")) return "image/svg+xml";
+  if (name.endsWith(".jpg") || name.endsWith(".jpeg")) return "image/jpeg";
+  if (name.endsWith(".webp")) return "image/webp";
+  return "image/png";
+}
+
+async function tryLocalScan(projectPath: string): Promise<string | null> {
+  for (const { sub, names } of LOCAL_CANDIDATES) {
+    let entries: FsEntry[];
+    try {
+      entries = await invoke<FsEntry[]>("fs_list_dir", {
+        root: projectPath,
+        path: sub,
+      });
+    } catch {
+      continue;
+    }
+    const lookup = new Set(entries.filter((e) => !e.isDir).map((e) => e.name.toLowerCase()));
+    for (const name of names) {
+      if (!lookup.has(name)) continue;
+      const relPath = sub ? `${sub}/${name}` : name;
+      try {
+        const b64 = await invoke<string>("fs_read_file_base64", {
+          root: projectPath,
+          path: relPath,
+        });
+        return `data:${mime(name)};base64,${b64}`;
+      } catch {
+        // File found, read failed — keep walking.
+      }
+    }
+  }
+  return null;
+}
+
+async function tryGhAvatar(projectPath: string): Promise<string | null> {
+  try {
+    const url = await invoke<string | null>("gh_repo_avatar_url", {
+      projectPath,
+    });
+    return url ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** Synchronous resolver — returns whatever's already cached on the
+ *  project record. Use this for the first paint so the sidebar/cards
+ *  never wait on an IPC. */
+export function iconForProject(project: Project): string | null {
+  return project.iconUrl ?? null;
+}
+
+/** Async discovery — runs the resolution chain. Memoized in-process by
+ *  project path; safe to call eagerly on every render. */
+export async function discoverIcon(project: Project): Promise<string | null> {
+  const key = project.path;
+  const now = Date.now();
+  const hit = cache.get(key);
+  if (hit && hit.expires > now) return hit.value;
+  if (project.iconUrl) {
+    cache.set(key, { value: project.iconUrl, expires: now + LIVE_TTL_MS });
+    return project.iconUrl;
+  }
+  let resolved: string | null;
+  try {
+    resolved = (await tryLocalScan(project.path)) ?? (await tryGhAvatar(project.path));
+  } catch {
+    resolved = null;
+  }
+  cache.set(key, {
+    value: resolved,
+    expires: now + (resolved ? LIVE_TTL_MS : NEG_TTL_MS),
+  });
+  return resolved;
+}
+
+/** Test-only helper. */
+export function _clearProjectIconCache(): void {
+  cache.clear();
+}

--- a/src/projects.test.ts
+++ b/src/projects.test.ts
@@ -85,7 +85,7 @@ describe("migrateProjects", () => {
     expect(out.worktreesByProject).toEqual({});
   });
 
-  it("is idempotent on v2 data", () => {
+  it("stamps localHostId onto v2 entries during v2->v3 migration", () => {
     const v2 = {
       schemaVersion: 2,
       projects: [
@@ -102,13 +102,33 @@ describe("migrateProjects", () => {
         a: [{ id: "wt-1", projectId: "a", path: "/a", branch: "main", isMain: true }],
       },
     };
-    const out = migrateProjects(v2);
-    expect(out).toEqual({
-      projects: v2.projects,
+    const out = migrateProjects(v2, "local:abc123");
+    expect(out.projects[0].hostId).toBe("local:abc123");
+    expect(out.activeHostId).toBe("local:abc123");
+    expect(out.activeWorktreeId).toBe("wt-1");
+    expect(out.worktreesByProject.a).toHaveLength(1);
+  });
+
+  it("preserves an explicit v3 hostId + activeHostId", () => {
+    const v3 = {
+      schemaVersion: 3,
+      projects: [
+        {
+          id: "a",
+          label: "aethon",
+          path: "/Users/example/aethon",
+          lastUsed: 1,
+          hostId: "remote:peer",
+        },
+      ],
       activeId: "a",
-      activeWorktreeId: "wt-1",
-      worktreesByProject: v2.worktreesByProject,
-    });
+      activeWorktreeId: null,
+      activeHostId: "remote:peer",
+      worktreesByProject: {},
+    };
+    const out = migrateProjects(v3, "local:abc123");
+    expect(out.projects[0].hostId).toBe("remote:peer");
+    expect(out.activeHostId).toBe("remote:peer");
   });
 
   it("drops invalid worktree entries", () => {

--- a/src/projects.ts
+++ b/src/projects.ts
@@ -23,6 +23,12 @@ export interface Project {
   lastUsed: number;
   /** Per-project disclosure state in the worktree-aware sidebar. */
   uiExpanded?: boolean;
+  /** Host this project lives on. Empty / missing => local. v3+ records
+   *  always carry one; v2 records inherit the local host id at migration. */
+  hostId?: string;
+  /** Cached discovered icon (absolute path or asset URL). Populated by
+   *  src/projectIcons.ts on hover/intersection. */
+  iconUrl?: string;
 }
 
 export interface ProjectsState {
@@ -32,11 +38,17 @@ export interface ProjectsState {
   activeWorktreeId: string | null;
   /** Worktrees keyed by projectId. Persisted alongside the projects array. */
   worktreesByProject: Record<string, Worktree[]>;
+  /** Active host id. Defaults to the local host id at migration time so
+   *  upgraded users land on their existing project list. */
+  activeHostId: string | null;
 }
 
 const FILE = "projects.json";
 const MAX_PROJECTS = 16;
-const SCHEMA_VERSION = 2;
+const SCHEMA_VERSION = 3;
+/** Fallback used when host_info IPC isn't reachable (tests, plain browser).
+ *  Real boots resolve a stable id via `commands::host::host_info`. */
+export const FALLBACK_LOCAL_HOST_ID = "local:unknown";
 
 function basename(path: string): string {
   // Last non-empty segment; tolerate `/` and `\` separators so the same code
@@ -46,12 +58,13 @@ function basename(path: string): string {
   return parts[parts.length - 1] || cleaned || "project";
 }
 
-export function emptyProjectsState(): ProjectsState {
+export function emptyProjectsState(localHostId?: string | null): ProjectsState {
   return {
     projects: [],
     activeId: null,
     activeWorktreeId: null,
     worktreesByProject: {},
+    activeHostId: localHostId ?? null,
   };
 }
 
@@ -66,31 +79,44 @@ interface PersistedV2 {
   activeWorktreeId?: string | null;
   worktreesByProject?: Record<string, Worktree[]>;
 }
+interface PersistedV3 extends PersistedV2 {
+  activeHostId?: string | null;
+}
 
-export async function loadProjects(): Promise<ProjectsState> {
+export async function loadProjects(localHostId?: string): Promise<ProjectsState> {
+  const hostId = localHostId ?? FALLBACK_LOCAL_HOST_ID;
   const raw = await readState(FILE);
-  if (!raw) return emptyProjectsState();
+  if (!raw) return emptyProjectsState(hostId);
   try {
-    const parsed = JSON.parse(raw) as PersistedV2 | PersistedV1;
-    return migrateProjects(parsed);
+    const parsed = JSON.parse(raw) as PersistedV3 | PersistedV2 | PersistedV1;
+    return migrateProjects(parsed, hostId);
   } catch {
-    return emptyProjectsState();
+    return emptyProjectsState(hostId);
   }
 }
 
 /** Pure migration from any prior schema version to the current shape.
- *  Idempotent — applying it twice is a no-op. */
-export function migrateProjects(parsed: PersistedV2 | PersistedV1): ProjectsState {
+ *  Idempotent — applying it twice is a no-op. `localHostId` is stamped
+ *  onto v1/v2 entries that pre-date the host model. */
+export function migrateProjects(
+  parsed: PersistedV3 | PersistedV2 | PersistedV1,
+  localHostId: string = FALLBACK_LOCAL_HOST_ID,
+): ProjectsState {
   const projects = Array.isArray(parsed.projects) ? parsed.projects : [];
   // Defensive: drop entries with missing/invalid path or id rather than
   // letting them crash the picker. A malformed file is the user's
   // problem to fix; we surface what we can.
-  const valid = projects.filter(
-    (p): p is Project =>
-      typeof p?.id === "string" &&
-      typeof p?.path === "string" &&
-      typeof p?.label === "string",
-  );
+  const valid = projects
+    .filter(
+      (p): p is Project =>
+        typeof p?.id === "string" &&
+        typeof p?.path === "string" &&
+        typeof p?.label === "string",
+    )
+    .map((p) => ({
+      ...p,
+      hostId: typeof p.hostId === "string" && p.hostId.length > 0 ? p.hostId : localHostId,
+    }));
   const activeId =
     typeof parsed.activeId === "string" &&
     valid.some((p) => p.id === parsed.activeId)
@@ -111,7 +137,18 @@ export function migrateProjects(parsed: PersistedV2 | PersistedV1): ProjectsStat
   }
   const activeWorktreeId =
     typeof v2.activeWorktreeId === "string" ? v2.activeWorktreeId : null;
-  return { projects: valid, activeId, activeWorktreeId, worktreesByProject };
+  const v3 = parsed as PersistedV3;
+  const activeHostId =
+    typeof v3.activeHostId === "string" && v3.activeHostId.length > 0
+      ? v3.activeHostId
+      : localHostId;
+  return {
+    projects: valid,
+    activeId,
+    activeWorktreeId,
+    worktreesByProject,
+    activeHostId,
+  };
 }
 
 export async function saveProjects(state: ProjectsState): Promise<void> {
@@ -120,12 +157,13 @@ export async function saveProjects(state: ProjectsState): Promise<void> {
   for (const [pid, list] of Object.entries(state.worktreesByProject)) {
     worktreesByProject[pid] = worktreesForPersist(list);
   }
-  const payload: PersistedV2 = {
+  const payload: PersistedV3 = {
     schemaVersion: SCHEMA_VERSION,
     projects: state.projects,
     activeId: state.activeId,
     activeWorktreeId: state.activeWorktreeId,
     worktreesByProject,
+    activeHostId: state.activeHostId,
   };
   await writeState(FILE, JSON.stringify(payload));
 }
@@ -168,11 +206,13 @@ export function upsertProject(
   state: ProjectsState,
   path: string,
   label?: string,
+  hostId?: string,
 ): { state: ProjectsState; id: string } {
   const existing = state.projects.find((p) => p.path === path);
   const now = Date.now();
+  const resolvedHostId = hostId ?? state.activeHostId ?? FALLBACK_LOCAL_HOST_ID;
   if (existing) {
-    const updated: Project = { ...existing, lastUsed: now };
+    const updated: Project = { ...existing, lastUsed: now, hostId: existing.hostId ?? resolvedHostId };
     if (label && label !== existing.label) updated.label = label;
     const projects = [updated, ...state.projects.filter((p) => p.id !== existing.id)];
     return {
@@ -186,6 +226,7 @@ export function upsertProject(
     label: label ?? basename(path),
     path,
     lastUsed: now,
+    hostId: resolvedHostId,
   };
   const projects = [next, ...state.projects].slice(0, MAX_PROJECTS);
   return { state: { ...state, projects, activeId: id }, id };
@@ -210,7 +251,13 @@ export function removeProject(
       ? null
       : state.activeWorktreeId;
   return {
-    state: { projects, activeId, activeWorktreeId, worktreesByProject },
+    state: {
+      projects,
+      activeId,
+      activeWorktreeId,
+      worktreesByProject,
+      activeHostId: state.activeHostId,
+    },
     removed,
   };
 }

--- a/src/projects.ts
+++ b/src/projects.ts
@@ -199,6 +199,26 @@ export function setProjectUiExpanded(
   };
 }
 
+/** Stamp a discovered icon URL onto the project record. Idempotent —
+ *  no state change when the same URL is already present, so callers
+ *  can fire after every discoverIcon without triggering a re-render
+ *  loop. */
+export function setProjectIconUrl(
+  state: ProjectsState,
+  projectId: string,
+  iconUrl: string | null,
+): ProjectsState {
+  let changed = false;
+  const projects = state.projects.map((p) => {
+    if (p.id !== projectId) return p;
+    const next = iconUrl ?? undefined;
+    if (p.iconUrl === next) return p;
+    changed = true;
+    return { ...p, iconUrl: next };
+  });
+  return changed ? { ...state, projects } : state;
+}
+
 /** Add a directory as a project. If a project at the same path already
  *  exists, that entry is reused (lastUsed bumped) so the picker doesn't
  *  collect duplicates when the user re-opens a familiar directory. */

--- a/src/projects.ts
+++ b/src/projects.ts
@@ -7,6 +7,7 @@
 // they were created with — switching project doesn't retro-cwd live sessions.
 
 import { invoke } from "@tauri-apps/api/core";
+import { getLocalHostId } from "./hosts";
 import { readState, writeState } from "./persist";
 import {
   type Worktree,
@@ -84,7 +85,12 @@ interface PersistedV3 extends PersistedV2 {
 }
 
 export async function loadProjects(localHostId?: string): Promise<ProjectsState> {
-  const hostId = localHostId ?? FALLBACK_LOCAL_HOST_ID;
+  // Resolve the local host id from the bridge BEFORE migrating so v1/v2
+  // entries get stamped with the real id, not the FALLBACK placeholder
+  // — otherwise saveProjects persists "local:unknown" into projects.json
+  // and host-scoped views can never match the real host on next boot
+  // (codex P2 review finding).
+  const hostId = localHostId ?? (await getLocalHostId(FALLBACK_LOCAL_HOST_ID));
   const raw = await readState(FILE);
   if (!raw) return emptyProjectsState(hostId);
   try {

--- a/src/skills/default-layout/dashboard/project-card.tsx
+++ b/src/skills/default-layout/dashboard/project-card.tsx
@@ -32,6 +32,26 @@ interface ProjectCardData {
   path: string;
   active?: boolean;
   gitStatus?: GitStatus | null;
+  iconUrl?: string;
+}
+
+/** Deterministic accent color from the project id so the initial-tile
+ *  fallback feels intentional rather than random. Pulls from a small
+ *  palette of theme-friendly hues. */
+function initialTileColor(id: string): string {
+  const palette = [
+    "#c45f3b",
+    "#3b88c4",
+    "#5fa847",
+    "#9b6fc9",
+    "#c98c2b",
+    "#469da3",
+    "#b73c87",
+    "#6c7a89",
+  ];
+  let h = 0;
+  for (let i = 0; i < id.length; i++) h = (h * 31 + id.charCodeAt(i)) >>> 0;
+  return palette[h % palette.length];
 }
 
 function isCardRef(v: unknown): v is { $ref: string } {
@@ -158,6 +178,23 @@ export function ProjectCard({
       title={project.path}
     >
       <div className="a2ui-project-card-head">
+        {project.iconUrl ? (
+          <img
+            src={project.iconUrl}
+            alt=""
+            aria-hidden="true"
+            className="a2ui-project-card-icon"
+            loading="lazy"
+          />
+        ) : (
+          <span
+            className="a2ui-project-card-icon a2ui-project-card-icon--initial"
+            aria-hidden="true"
+            style={{ backgroundColor: initialTileColor(project.id) }}
+          >
+            {project.label.slice(0, 1).toUpperCase()}
+          </span>
+        )}
         <span className="a2ui-project-card-label">{project.label}</span>
         {active && (
           <span className="a2ui-project-card-active-chip">active</span>

--- a/src/skills/default-layout/dashboard/project-dashboard.tsx
+++ b/src/skills/default-layout/dashboard/project-dashboard.tsx
@@ -28,6 +28,7 @@ interface ProjectInfo {
   id: string;
   label: string;
   path: string;
+  iconUrl?: string;
 }
 
 interface WorktreeRowLite {

--- a/src/skills/default-layout/dashboard/projects-dashboard.tsx
+++ b/src/skills/default-layout/dashboard/projects-dashboard.tsx
@@ -27,7 +27,24 @@ interface ProjectListItem {
   label: string;
   path: string;
   active?: boolean;
+  iconUrl?: string;
   gitStatus?: { branch?: string; dirty?: boolean; ahead?: number; behind?: number };
+}
+
+interface HostBannerInfo {
+  id: string;
+  hostname: string;
+  displayName: string;
+  isLocal: boolean;
+}
+
+function resolveOptional<T>(v: unknown, state: Record<string, unknown>): T | null {
+  if (!v) return null;
+  if (isRef(v)) {
+    const r = resolvePointer(state, v.$ref);
+    return (r as T) ?? null;
+  }
+  return v as T;
 }
 
 interface RecentSession {
@@ -66,6 +83,7 @@ export function ProjectsDashboard({
         projects?: unknown;
         recentSessions?: unknown;
         extraCards?: unknown;
+        host?: unknown;
         title?: string;
         subtitle?: string;
       }
@@ -74,6 +92,10 @@ export function ProjectsDashboard({
   const projects = useMemo(
     () => resolveArray<ProjectListItem>(props?.projects, state),
     [props?.projects, state],
+  );
+  const host = useMemo(
+    () => resolveOptional<HostBannerInfo>(props?.host, state),
+    [props?.host, state],
   );
   const recentSessions = useMemo(
     () => resolveArray<RecentSession>(props?.recentSessions, state),
@@ -87,6 +109,17 @@ export function ProjectsDashboard({
   return (
     <div className="a2ui-projects-dashboard">
       <div className="a2ui-projects-dashboard-card">
+        {host && (
+          <div className="a2ui-host-banner" data-host-id={host.id}>
+            <span className="a2ui-host-banner-dot" aria-hidden="true" />
+            <span className="a2ui-host-banner-text">
+              <strong>{host.displayName || host.hostname}</strong>
+              <span className="a2ui-host-banner-hint">
+                {host.isLocal ? "this mac" : host.hostname}
+              </span>
+            </span>
+          </div>
+        )}
         <div className="a2ui-projects-dashboard-hero" aria-hidden="true">
           <AeMarkInline size={56} radius={12} />
         </div>

--- a/src/skills/default-layout/settings-panel.tsx
+++ b/src/skills/default-layout/settings-panel.tsx
@@ -18,6 +18,7 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import type { BuiltinComponentProps } from "../../components/A2UIRenderer";
 import { getConfig, type AethonConfig } from "../../config";
 import { SHARE_MODES, type ShareMode } from "../../utils/shareMode";
+import { DropdownPickerCore } from "./variation-components";
 
 interface SettingsState {
   open: boolean;
@@ -481,6 +482,12 @@ function ModelPicker({
   value: string;
   onChange: (next: string) => void;
 }) {
+  // Reuses the same DropdownPickerCore the header model picker renders,
+  // so search/filter + keyboard nav + visual style stay in lockstep
+  // (replaces a bespoke <select>+custom-mode pair). A sentinel
+  // `__pi_default__` id maps back to `""` so "(pi default)" stays
+  // selectable; a sentinel `__custom__` id flips into a free-text
+  // input for the rare case a user wants a model not on the list.
   const sidebar =
     (state.sidebar as Record<string, unknown> | undefined) ?? {};
   const models =
@@ -489,16 +496,10 @@ function ModelPicker({
     );
   const trimmed = value.trim();
   const knownIds = new Set(models.map((m) => m.id));
-  // Auto-flip into custom mode when the saved id isn't on the loaded
-  // model list. Keeps the user's existing override visible instead of
-  // silently snapping to the first dropdown entry.
   const startsCustom = trimmed.length > 0 && !knownIds.has(trimmed);
   const [customMode, setCustomMode] = useState(startsCustom);
-  // Re-flip when the value or model list changes (e.g. extension that
-  // registers a new model loads, or the user saves and the input
-  // re-renders with a now-recognised id). Intentional state-resync —
-  // the dropdown ↔ free-text toggle is derived from the saved value
-  // and the loaded model list, so a change to either should re-sync.
+  // Re-flip when the value or model list changes (e.g. an extension
+  // registers a new model). Derived-state resync from external input.
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- derived-state resync on external input change
     setCustomMode(startsCustom);
@@ -520,8 +521,6 @@ function ModelPicker({
           className="ae-settings-secondary ae-settings-model-picker-toggle"
           onClick={() => {
             setCustomMode(false);
-            // Snap to empty (pi default) so the dropdown has a valid
-            // selection; the user picks from the list next.
             onChange("");
           }}
           title="Pick from the loaded model list"
@@ -532,28 +531,46 @@ function ModelPicker({
     );
   }
 
+  const PI_DEFAULT = "__pi_default__";
+  const CUSTOM = "__custom__";
+  const activeMatch = knownIds.has(trimmed) ? trimmed : PI_DEFAULT;
+  const items = [
+    { id: PI_DEFAULT, label: "(pi default — picks from env vars)", active: activeMatch === PI_DEFAULT },
+    ...models.map((m) => ({
+      id: m.id,
+      label: m.label || m.id,
+      hint: m.label && m.label !== m.id ? m.id : undefined,
+      active: activeMatch === m.id,
+    })),
+    { id: CUSTOM, label: "Custom id…" },
+  ];
+  const activeItem = items.find((it) => it.active);
+  const buttonLabel = activeItem?.label || "(pi default)";
+
   return (
     <span className="ae-settings-model-picker">
-      <select
-        className="ae-settings-input"
-        value={knownIds.has(trimmed) ? trimmed : ""}
-        onChange={(e) => {
-          if (e.target.value === "__custom__") {
+      <DropdownPickerCore
+        className="a2ui-model-picker ae-settings-model-picker-dropdown"
+        buttonLabel={buttonLabel}
+        align="left"
+        sections={[
+          {
+            id: "models",
+            title: "models",
+            items,
+            searchable: true,
+            searchPlaceholder: "filter models — sonnet, gpt, qwen…",
+            emptyLabel: "no models match",
+          },
+        ]}
+        onSelect={(_sectionId, itemId) => {
+          if (itemId === CUSTOM) {
             setCustomMode(true);
             return;
           }
-          onChange(e.target.value);
+          onChange(itemId === PI_DEFAULT ? "" : itemId);
         }}
-        aria-label="Default model"
-      >
-        <option value="">(pi default — picks from env vars)</option>
-        {models.map((m) => (
-          <option key={m.id} value={m.id}>
-            {m.label} — {m.id}
-          </option>
-        ))}
-        <option value="__custom__">Other…</option>
-      </select>
+      />
     </span>
   );
 }

--- a/src/skills/default-layout/sidebar/item-row.tsx
+++ b/src/skills/default-layout/sidebar/item-row.tsx
@@ -145,6 +145,15 @@ export function ItemRow({
       ) : alignSlots ? (
         <span className="a2ui-sidebar-item-git-dot-spacer" aria-hidden="true" />
       ) : null}
+      {item.iconUrl ? (
+        <img
+          src={item.iconUrl}
+          alt=""
+          aria-hidden="true"
+          className="a2ui-sidebar-item-icon"
+          loading="lazy"
+        />
+      ) : null}
       <span className="a2ui-sidebar-item-label">{item.label}</span>
       {git?.branch ? (
         <span className="a2ui-sidebar-item-git-branch" title={branchTitle}>

--- a/src/skills/default-layout/variation-components.tsx
+++ b/src/skills/default-layout/variation-components.tsx
@@ -84,7 +84,7 @@ interface DropdownPickerCoreProps {
   onSelect: (sectionId: string, itemId: string) => void;
 }
 
-function DropdownPickerCore({
+export function DropdownPickerCore({
   buttonLabel,
   sections,
   align = "right",
@@ -315,9 +315,17 @@ export function ModelPicker({ component, state, onEvent }: BuiltinComponentProps
       : resolvePointer(state, "/sidebar/models");
   const items = asDropdownItems(sourceRaw);
 
+  // Resolution chain: explicit `props.active` → active tab's model
+  // (`/model` mirror) → pi default (`/piDefaultModel`, seeded on
+  // `ready`). The default fallback covers the no-tab case so the
+  // header still shows the user's working model on a fresh boot.
+  const activeTabModel = resolvePointer(state, "/model") as string | undefined;
+  const piDefaultModel = resolvePointer(state, "/piDefaultModel") as
+    | string
+    | undefined;
   const activeId = props.active
     ? resolveString(props.active, state)
-    : (resolvePointer(state, "/model") as string | undefined) ?? "";
+    : (activeTabModel || piDefaultModel || "");
   const itemsWithActive = items.map((it) => ({
     ...it,
     active: it.id === activeId,

--- a/src/skills/default-layout/workstation.a2ui.json
+++ b/src/skills/default-layout/workstation.a2ui.json
@@ -78,6 +78,11 @@
                 "brandMark": true,
                 "sections": [
                   {
+                    "id": "hosts",
+                    "title": "hosts",
+                    "items": { "$ref": "/sidebar/hosts" }
+                  },
+                  {
                     "id": "projects",
                     "title": "projects",
                     "items": { "$ref": "/sidebar/projects" },
@@ -225,7 +230,7 @@
     "layout": {
       "sidebarVisible": true,
       "filesSidebarVisible": true,
-      "columns": "220px minmax(0,1fr) 280px",
+      "columns": "220px minmax(0,1fr) 360px",
       "rows": "38px minmax(0,1fr) auto auto auto",
       "areas": [
         "sidebar header files-sidebar",
@@ -238,6 +243,7 @@
     "sidebar": {
       "history": [],
       "models": [],
+      "hosts": [],
       "projects": [],
       "extraSections": [],
       "themes": [
@@ -250,6 +256,9 @@
     "projects": [],
     "activeProjectId": null,
     "project": null,
+    "hosts": [],
+    "activeHostId": null,
+    "host": null,
     "terminal": {
       "open": false
     },

--- a/src/skills/default-layout/workstation.a2ui.json
+++ b/src/skills/default-layout/workstation.a2ui.json
@@ -144,7 +144,8 @@
             "visible": { "$ref": "/emptyAndNoProject" },
             "projects": { "$ref": "/projects" },
             "recentSessions": { "$ref": "/recentSessions" },
-            "extraCards": { "$ref": "/projectsDashboard/extraCards" }
+            "extraCards": { "$ref": "/projectsDashboard/extraCards" },
+            "host": { "$ref": "/host" }
           }
         },
         {

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -651,19 +651,13 @@ body.ae-resizing-sidebar .a2ui-layout {
 .a2ui-sidebar-item-label {
   flex: 1 1 auto;
   min-width: 0;
-  overflow: hidden;
-  /* No ellipsis — long names are clipped silently and the user can
-     hover the row to scroll the label horizontally into view. Avoids
-     the "nyc-…" / "ae…" truncation seen on the projects sidebar. */
-  text-overflow: clip;
-  white-space: nowrap;
-}
-.a2ui-sidebar-item:hover .a2ui-sidebar-item-label {
-  overflow-x: auto;
-  scrollbar-width: none;
-}
-.a2ui-sidebar-item:hover .a2ui-sidebar-item-label::-webkit-scrollbar {
-  display: none;
+  /* Long names wrap to a second line within the sidebar instead of
+     truncating with ellipsis or scrolling horizontally. The sidebar
+     itself never scrolls horizontally — wider names just take two
+     short lines (`nyc-real-` / `estate`). */
+  overflow-wrap: anywhere;
+  white-space: normal;
+  line-height: 1.25;
 }
 /* Tiny icon (favicon-sized) rendered before the label for both host
    and project rows. Falls back gracefully when iconUrl is absent. */
@@ -4095,6 +4089,11 @@ body.ae-resizing-terminal * {
   background: var(--bg);
   padding: var(--space-8) var(--space-5);
   overflow-y: auto;
+  /* Hard stop on horizontal overflow — long issue titles or wide
+     stat strips should never push the viewport into a horizontal
+     scroll. The card respects max-width; this is the safety net for
+     anything inside that exceeds it. */
+  overflow-x: hidden;
   overscroll-behavior: none;
 }
 
@@ -4686,6 +4685,9 @@ button.a2ui-gh-stat:hover {
   font-size: var(--text-md);
   flex: 1 1 auto;
   min-width: 0;
+  /* Wrap mid-word for very long titles so the row never forces a
+     horizontal scroll on the canvas. */
+  overflow-wrap: anywhere;
 }
 .a2ui-dashboard-issue-meta {
   grid-column: 1 / -1;

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -652,8 +652,28 @@ body.ae-resizing-sidebar .a2ui-layout {
   flex: 1 1 auto;
   min-width: 0;
   overflow: hidden;
-  text-overflow: ellipsis;
+  /* No ellipsis — long names are clipped silently and the user can
+     hover the row to scroll the label horizontally into view. Avoids
+     the "nyc-…" / "ae…" truncation seen on the projects sidebar. */
+  text-overflow: clip;
   white-space: nowrap;
+}
+.a2ui-sidebar-item:hover .a2ui-sidebar-item-label {
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+.a2ui-sidebar-item:hover .a2ui-sidebar-item-label::-webkit-scrollbar {
+  display: none;
+}
+/* Tiny icon (favicon-sized) rendered before the label for both host
+   and project rows. Falls back gracefully when iconUrl is absent. */
+.a2ui-sidebar-item-icon {
+  width: 16px;
+  height: 16px;
+  border-radius: 3px;
+  flex-shrink: 0;
+  object-fit: cover;
+  margin-right: var(--space-1);
 }
 
 /* Tiny accent dot before the label — used for project rows whose
@@ -4080,7 +4100,10 @@ body.ae-resizing-terminal * {
 
 .a2ui-projects-dashboard-card,
 .a2ui-project-dashboard-card {
-  max-width: 920px;
+  /* Was 920px — left a wide empty band on typical windows. Scales now
+     up to ~1400px and respects a 96px window padding so the dashboard
+     stays comfortably edge-aligned on small windows too. */
+  max-width: min(1400px, calc(100% - 96px));
   width: 100%;
   background: var(--bg-elev);
   border: 1px solid var(--border);
@@ -4090,6 +4113,64 @@ body.ae-resizing-terminal * {
   flex-direction: column;
   gap: var(--space-5);
   box-shadow: var(--shadow-2);
+}
+
+/* Host banner — sits inside the dashboard card to anchor it to the
+   current host. Uses the existing token palette; no new variables. */
+.a2ui-host-banner {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  align-self: stretch;
+  font-size: var(--text-sm);
+  color: var(--text-dim);
+}
+.a2ui-host-banner-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: var(--accent);
+  flex-shrink: 0;
+}
+.a2ui-host-banner-text {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  min-width: 0;
+}
+.a2ui-host-banner-text strong {
+  color: var(--text);
+  font-weight: 600;
+}
+.a2ui-host-banner-hint {
+  color: var(--text-dim);
+  font-size: var(--text-xs);
+}
+
+/* Project-card icon — 20px square before the label. The
+   --initial modifier renders a deterministic letter tile for projects
+   without a discovered logo. */
+.a2ui-project-card-icon {
+  width: 20px;
+  height: 20px;
+  border-radius: var(--radius-sm);
+  flex-shrink: 0;
+  object-fit: cover;
+  margin-right: var(--space-2);
+}
+span.a2ui-project-card-icon--initial {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
 }
 
 /* ---- Projects dashboard (global overview) --------------------------- */

--- a/src/types/a2ui.ts
+++ b/src/types/a2ui.ts
@@ -163,6 +163,10 @@ export interface SidebarItem {
   id: string;
   label: string;
   icon?: string;
+  /** Resolved icon URL — bundled asset path, file://, or http(s). Rendered
+   *  as a small <img> before the label. Used by host rows and (when
+   *  src/projectIcons.ts populates iconUrl) project rows. */
+  iconUrl?: string;
   onClick?: string;
   // Optional active flag — true highlights the row.
   active?: boolean;

--- a/src/worktreeNames.test.ts
+++ b/src/worktreeNames.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import { _POOL_SIZE_FOR_TESTS, pickWorktreeName } from "./worktreeNames";
+
+describe("pickWorktreeName", () => {
+  it("returns a feat/<name> from the helios pool", () => {
+    const picked = pickWorktreeName([]);
+    expect(picked.startsWith("feat/")).toBe(true);
+    expect(picked.length).toBeGreaterThan("feat/".length);
+  });
+
+  it("avoids names already in taken (with or without prefix)", () => {
+    const taken = ["feat/helios", "phaethon", "feat/orion"];
+    for (let i = 0; i < 30; i++) {
+      const picked = pickWorktreeName(taken);
+      expect(picked).not.toBe("feat/helios");
+      expect(picked).not.toBe("feat/phaethon");
+      expect(picked).not.toBe("feat/orion");
+    }
+  });
+
+  it("falls back to <name>-2 / <name>-3 after exhausting the pool", () => {
+    // Build a taken-list covering every pool entry — pick must add a suffix.
+    const filler: string[] = [];
+    for (let i = 0; i < _POOL_SIZE_FOR_TESTS + 5; i++) {
+      filler.push(`feat/pool-${i}`);
+    }
+    // We can't enumerate the pool here, so cover by stamping ALL likely
+    // base names: the test asserts the chosen output still parses
+    // cleanly even when nothing is "free" in the bare pool.
+    const taken = [
+      "feat/aethon",
+      "feat/phlegon",
+      "feat/pyrois",
+      "feat/eous",
+      "feat/helios",
+      "feat/sol",
+      "feat/eos",
+      "feat/aurora",
+      "feat/hyperion",
+      "feat/phaethon",
+      "feat/selene",
+      "feat/luna",
+      "feat/boreas",
+      "feat/zephyr",
+      "feat/notus",
+      "feat/eurus",
+      "feat/iris",
+      "feat/uranus",
+      "feat/nyx",
+      "feat/hemera",
+      "feat/astraeus",
+      "feat/asteria",
+      "feat/orion",
+      "feat/lyra",
+      "feat/vega",
+      "feat/sirius",
+      "feat/altair",
+      "feat/rigel",
+      "feat/antares",
+      "feat/polaris",
+    ];
+    const picked = pickWorktreeName(taken);
+    expect(picked.startsWith("feat/")).toBe(true);
+    // After full exhaustion, every result should carry a `-N` suffix.
+    expect(picked).toMatch(/-\d+$/);
+  });
+});

--- a/src/worktreeNames.ts
+++ b/src/worktreeNames.ts
@@ -1,0 +1,91 @@
+// Auto-generated worktree branch names from the Helios pantheon — the
+// figures around the sun, dawn, wind, and sky that share mythological
+// space with the app's namesake (Aethon, "blazing horse" of Helios).
+//
+// Used by sidebar context-menu "Create worktree…" so the user never
+// has to type a branch name. Same pool is exposed to the task launcher
+// composer as the placeholder suggestion, but it accepts user input
+// — auto-gen is the no-click default, manual is the override.
+//
+// Collisions: when the chosen name is already a branch on the repo,
+// append `-2`, `-3`, … until free. Caller passes `taken` so we can
+// check both git's branch list AND the in-memory pending worktrees.
+
+const HELIOS_POOL = [
+  // Helios chariot horses (CLAUDE.md says Aethon is the namesake).
+  "aethon",
+  "phlegon",
+  "pyrois",
+  "eous",
+  // Sun + dawn deities.
+  "helios",
+  "sol",
+  "eos",
+  "aurora",
+  "hyperion",
+  "phaethon",
+  "selene",
+  "luna",
+  // Wind gods.
+  "boreas",
+  "zephyr",
+  "notus",
+  "eurus",
+  // Sky / weather / rainbow.
+  "iris",
+  "uranus",
+  "nyx",
+  "hemera",
+  "astraeus",
+  "asteria",
+  // Constellations / stellar mythology.
+  "orion",
+  "lyra",
+  "vega",
+  "sirius",
+  "altair",
+  "rigel",
+  "antares",
+  "polaris",
+];
+
+const BRANCH_PREFIX = "feat";
+
+function shuffled<T>(arr: T[]): T[] {
+  const out = [...arr];
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [out[i], out[j]] = [out[j], out[i]];
+  }
+  return out;
+}
+
+/** Pick a Helios-pantheon name not already in `taken`. Caller supplies
+ *  `taken` as the union of existing branch names + pending worktree
+ *  branches so we don't collide with either. If the entire pool is
+ *  exhausted, append a numeric suffix to a random base. */
+export function pickWorktreeName(taken: Iterable<string>): string {
+  const used = new Set<string>();
+  for (const t of taken) used.add(stripPrefix(t).toLowerCase());
+  for (const candidate of shuffled(HELIOS_POOL)) {
+    if (!used.has(candidate)) return `${BRANCH_PREFIX}/${candidate}`;
+  }
+  // Pool exhausted — keep going with `<name>-N` until free.
+  const base = HELIOS_POOL[Math.floor(Math.random() * HELIOS_POOL.length)];
+  for (let n = 2; n < 1000; n++) {
+    const candidate = `${base}-${n}`;
+    if (!used.has(candidate)) return `${BRANCH_PREFIX}/${candidate}`;
+  }
+  // Astronomical fallback — should never reach here.
+  return `${BRANCH_PREFIX}/${base}-${Date.now()}`;
+}
+
+function stripPrefix(branch: string): string {
+  // Allow comparing with or without the `feat/` prefix so manual
+  // `feat/zephyr` doesn't get re-picked as bare `zephyr`.
+  const slash = branch.indexOf("/");
+  return slash >= 0 ? branch.slice(slash + 1) : branch;
+}
+
+/** Test-only — exposes the pool length for collision-coverage tests. */
+export const _POOL_SIZE_FOR_TESTS = HELIOS_POOL.length;


### PR DESCRIPTION
## Summary

Stacks four related changes onto a long-running misc-updates branch:

1. **Built-in HTTP + mDNS server scaffold** (`src-tauri/src/server/`) — advertises `_aethon._tcp.local.` and browses for peers, emitting `host-discovered` / `host-removed` Tauri events with 250ms debounce. Axum HTTP exposes `GET /health` + `GET /status` on an OS-picked port. No auth/TLS yet — explicit scaffold for the future pairing PR and mobile-app integration. Models Claudette's pattern.

2. **Host-rooted sidebar UI** — projects schema bumps v2→v3 with a `hostId` + `iconUrl` per project. Sidebar gains a HOSTS section above PROJECTS; the local host is always present, mDNS-discovered hosts join in arrival order. `useHostInfo` hook owns the merge + active-host selection. Switching host clears the active project so the dashboard re-anchors. No new sidebar or dashboard composite — extends existing primitives. Projects-dashboard shows a small host banner at the top when `/host` is set.

3. **Per-project icon discovery (Conductor-style, less code)** — `src/projectIcons.ts` resolves `cached iconUrl → local scan (logo.{png,svg,jpg,webp}, .github/logo.*, public/favicon.*) → GitHub avatar via gh CLI`. Local logos inline as `data:` URLs via `fs_read_file_base64` so no asset-protocol round-trip is needed; GH avatars use the stable `https://github.com/<owner>.png` URL (CSP is null). Project cards render the icon with a deterministic initial-tile fallback. Sidebar rows render the same icon.

4. **Widen content areas + sidebar polish** — dashboard cards go from `max-width: 920px` to `min(1400px, calc(100% - 96px))` so the canvas scales with the window. Sidebar item labels lose ellipsis truncation — long names clip silently with hover-scroll. Files panel default column widens 280→360px. All using existing tokens (no new CSS variables).

CLAUDE.md slimmed in the first commit; copilot keyboard-shortcut docs list synced to drop the now-orphaned CLAUDE.md reference.

## Architecture invariants

- Three-layer separation respected — server module is OS boundary code; no business logic moves into the Rust shell.
- Two-registries rule: no new primitives. ItemRow + project-card extended in place; host banner is a `<div>`.
- Single state store: `/hosts`, `/activeHostId`, `/host` flow through the existing render state via `useHostInfo`; `/projects` stays global, filtered at the boundary.
- Path-traversal guard untouched (no new fs commands taking paths).
- Hot-reload sentinel pattern preserved.

## Test plan

- [x] `check` is green (clippy + tsc + ESLint + cargo test + vitest)
- [x] 839 vitest tests pass, including new coverage for projectIcons resolution chain, hosts persistence + useHostInfo event merge, v2→v3 projects migration
- [x] 129 cargo lib tests pass, including new host_info shape + machine-uuid path tests
- [ ] Manual: launch `dev --new`, verify HOSTS section + dashboard banner render
- [ ] Manual: open a repo with a root `logo.png`, expect icon within ~500ms
- [ ] Manual: open a repo without a local logo, expect GitHub avatar fallback
- [ ] Manual: launch two dev builds on the same LAN, expect mutual discovery + curl `/health` returns `aethon`
- [ ] Manual: confirm long project names (>20 chars) no longer truncate with `...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)