### PR TITLE
[codex] Misc UI fixes, extension controls, and layout polish

### DIFF
--- a/src-tauri/src/commands/extensions.rs
+++ b/src-tauri/src/commands/extensions.rs
@@ -231,41 +231,40 @@ pub fn install_app_menu(
         .item(&issues_item)
         .build()?;
 
-    // Build the extension submenu. Each extension item id is prefixed
-    // with `ext:` so the React-side menu dispatcher can route it to
-    // a2ui_event without colliding with built-in ids. Items with
-    // `location: "tray"` are deferred to the tray builder below.
+    // Build the extension submenu. The first item is a built-in escape
+    // hatch for managing/disable toggling extensions even when an old
+    // extension has broken the rendered workspace. Extension-provided
+    // item ids are prefixed with `ext:` so the React-side menu dispatcher
+    // can route them to a2ui_event without colliding with built-in ids.
+    // Items with `location: "tray"` are deferred to the tray builder below.
     let app_extension_items: Vec<&ExtensionMenuItem> = extension_items
         .iter()
         .filter(|i| i.location == "app")
         .collect();
-    let extensions_submenu = if !app_extension_items.is_empty() {
-        let mut b = SubmenuBuilder::new(app, "Extensions");
-        for item in &app_extension_items {
-            let id = format!("ext:{}", item.action);
-            let mb = MenuItemBuilder::with_id(&id, &item.label).build(app)?;
-            b = b.item(&mb);
-        }
-        Some(b.build()?)
-    } else {
-        None
-    };
+    let manage_extensions =
+        MenuItemBuilder::with_id("manage_extensions", "Manage Extensions…").build(app)?;
+    let mut extensions_builder = SubmenuBuilder::new(app, "Extensions").item(&manage_extensions);
+    if !app_extension_items.is_empty() {
+        extensions_builder = extensions_builder.separator();
+    }
+    for item in &app_extension_items {
+        let id = format!("ext:{}", item.action);
+        let mb = MenuItemBuilder::with_id(&id, &item.label).build(app)?;
+        extensions_builder = extensions_builder.item(&mb);
+    }
+    let extensions_submenu = extensions_builder.build()?;
 
     #[cfg(target_os = "macos")]
     let menu = {
         let mut b = MenuBuilder::new(app)
             .items(&[&app_menu, &file_menu, &edit_menu, &view_menu, &tabs_menu]);
-        if let Some(ref s) = extensions_submenu {
-            b = b.item(s);
-        }
+        b = b.item(&extensions_submenu);
         b.items(&[&window_menu, &help_menu]).build()?
     };
     #[cfg(not(target_os = "macos"))]
     let menu = {
         let mut b = MenuBuilder::new(app).items(&[&file_menu, &edit_menu, &view_menu, &tabs_menu]);
-        if let Some(ref s) = extensions_submenu {
-            b = b.item(s);
-        }
+        b = b.item(&extensions_submenu);
         b.items(&[&window_menu, &help_menu]).build()?
     };
 
@@ -531,8 +530,8 @@ pub fn start_agent_watcher(app: AppHandle) -> Option<AgentWatcher> {
         // hot-reloads without a manual restart. `helpers::aethon_dir`
         // honors the `AETHON_USER_DIR` override so `dev.sh --new` lands
         // the sandboxed extensions in the per-PID tmp tree.
-        let aethon_root = crate::helpers::aethon_dir(Some(h.clone()))
-            .unwrap_or_else(|| h.join(".aethon"));
+        let aethon_root =
+            crate::helpers::aethon_dir(Some(h.clone())).unwrap_or_else(|| h.join(".aethon"));
         let aethon_ext = aethon_root.join("extensions");
         let _ = std::fs::create_dir_all(&aethon_ext);
         if aethon_ext.exists() {
@@ -952,6 +951,23 @@ mod tests {
         assert!(
             body.contains("install_tray("),
             "set_extension_menu_items must call install_tray so location: \"tray\" extension items appear",
+        );
+    }
+
+    /// Extensions can break the rendered workspace itself, so the app
+    /// menu must always keep a built-in management entry available
+    /// outside extension-controlled UI. Extension-provided items are
+    /// additive; they must not be the condition for showing the menu.
+    #[test]
+    fn app_menu_always_exposes_extension_management() {
+        let src = include_str!("extensions.rs");
+        assert!(
+            src.contains("MenuItemBuilder::with_id(\"manage_extensions\", \"Manage Extensions…\")"),
+            "the app menu needs a built-in Manage Extensions item",
+        );
+        assert!(
+            src.contains("SubmenuBuilder::new(app, \"Extensions\").item(&manage_extensions)"),
+            "the Extensions submenu should be created even when no extension-registered menu items exist",
         );
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -896,6 +896,7 @@ export default function App() {
     resetZoom,
     toggleFocusComposerTerminal,
     toggleSettings,
+    closeSettings,
     focusActiveContextInput,
     exportActiveChatMarkdown,
     pushNotification,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
 import { useWindowApi } from "./runtime/windowApi";
 import { useBootConfig } from "./hooks/useBootConfig";
 import { useNotifications } from "./hooks/useNotifications";
-import { useFocus } from "./hooks/useFocus";
+import { useFocus, workstationRows } from "./hooks/useFocus";
 import { useChat } from "./hooks/useChat";
 import { useFrontendStateMirror } from "./hooks/useFrontendStateMirror";
 import { useUiOverlays } from "./hooks/useUiOverlays";
@@ -37,6 +37,12 @@ import {
   saveSessionUiSnapshot,
   type SessionUiSnapshot,
 } from "./state/sessionUiSnapshot";
+import {
+  loadLayoutPrefsFromDisk,
+  loadLayoutPrefsSync,
+  mergeLayoutPrefsIntoState,
+  saveLayoutPrefs,
+} from "./layoutPrefs";
 import {
   activeProject,
   emptyProjectsState,
@@ -86,6 +92,7 @@ export default function App() {
   // (or `dev --new`) lands on the dashboard with the canvas empty.
   const initialApp = useMemo(() => {
     const restored = loadSessionUiSnapshot();
+    const layoutPrefs = loadLayoutPrefsSync();
     const tabs = restored?.tabs.length ? restored.tabs : [];
     const activeTabId =
       restored?.activeTabId && tabs.some((t) => t.id === restored.activeTabId)
@@ -96,6 +103,22 @@ export default function App() {
       restored?.layout && typeof restored.layout === "object"
         ? (restored.layout as Record<string, unknown>)
         : {};
+    const bootTerminalPanel = BOOT_LAYOUT.state?.terminalPanel;
+    const restoredTerminalPanel = restored?.terminalPanel;
+    const terminalPanel = {
+      ...(bootTerminalPanel && typeof bootTerminalPanel === "object"
+        ? bootTerminalPanel
+        : {}),
+      ...(restoredTerminalPanel && typeof restoredTerminalPanel === "object"
+        ? restoredTerminalPanel
+        : {}),
+      ...(layoutPrefs?.terminalPanel ?? {}),
+    } as Record<string, unknown>;
+    const bootLayout = BOOT_LAYOUT.state?.layout;
+    const terminalOpen =
+      (restored?.terminal as { open?: boolean } | undefined)?.open ?? false;
+    const terminalHeight =
+      typeof terminalPanel.height === "number" ? terminalPanel.height : 240;
     // When there is no active tab, the mirror keys point at undefined so
     // layout `$ref`s resolve cleanly without throwing. The composer +
     // chat surfaces are hidden via `/agentTabActive` in this state.
@@ -106,46 +129,44 @@ export default function App() {
     );
     return {
       appStore: createAppStore({
-      ...(BOOT_LAYOUT.state ?? {}),
-      ...(restored?.terminal ? { terminal: restored.terminal } : {}),
-      ...(restored?.terminalPanel ? { terminalPanel: restored.terminalPanel } : {}),
-      ...(restored?.scrollToMatchByTab
-        ? { scrollToMatchByTab: restored.scrollToMatchByTab }
-        : {}),
-      ...(restored?.projectModels ? { projectModels: restored.projectModels } : {}),
-      logoUrl,
-      // App version surfaced as a state slice so layout JSON can $ref it
-      // (e.g. sidebar's `version` prop). Single source of truth is
-      // package.json — vite injects __APP_VERSION__ at build time. The
-      // "v" prefix matches the human-friendly format the UI used before.
-      appVersion: `v${__APP_VERSION__}`,
-      tabs,
-      activeTabId,
-      // Mirror keys point at the active tab's empty view so layout bindings
-      // see well-defined values from boot.
-      ...rootMirror,
-      // Layout-agnostic UI surfaces — the palette + notification stack
-      // both render at App root so they overlay every layout. State
-      // shapes are documented on the components themselves.
-      palette: { open: false, mode: "switcher", query: "", selectedIndex: 0 },
-      notifications: [],
-      // Seed /sidebar/extensions so the $ref-bound sidebar section renders
-      // the built-in entry immediately — hydrateExtensions() fills in
-      // dynamically-loaded extensions once `ready` arrives.
-      sidebar: {
-        ...(BOOT_LAYOUT.state?.sidebar as Record<string, unknown> | undefined),
-        extensions: [
-          { id: "extension-layout", label: "default-layout", hint: "core", active: true },
-        ],
-      },
-      ...(Object.keys(restoredLayout).length > 0
-        ? {
-            layout: {
-              ...(BOOT_LAYOUT.state?.layout ?? {}),
-              ...restoredLayout,
-            },
-          }
-        : {}),
+        ...(BOOT_LAYOUT.state ?? {}),
+        ...(restored?.terminal ? { terminal: restored.terminal } : {}),
+        terminalPanel,
+        ...(restored?.scrollToMatchByTab
+          ? { scrollToMatchByTab: restored.scrollToMatchByTab }
+          : {}),
+        ...(restored?.projectModels ? { projectModels: restored.projectModels } : {}),
+        logoUrl,
+        // App version surfaced as a state slice so layout JSON can $ref it
+        // (e.g. sidebar's `version` prop). Single source of truth is
+        // package.json — vite injects __APP_VERSION__ at build time. The
+        // "v" prefix matches the human-friendly format the UI used before.
+        appVersion: `v${__APP_VERSION__}`,
+        tabs,
+        activeTabId,
+        // Mirror keys point at the active tab's empty view so layout bindings
+        // see well-defined values from boot.
+        ...rootMirror,
+        // Layout-agnostic UI surfaces — the palette + notification stack
+        // both render at App root so they overlay every layout. State
+        // shapes are documented on the components themselves.
+        palette: { open: false, mode: "switcher", query: "", selectedIndex: 0 },
+        notifications: [],
+        // Seed /sidebar/extensions so the $ref-bound sidebar section renders
+        // the built-in entry immediately — hydrateExtensions() fills in
+        // dynamically-loaded extensions once `ready` arrives.
+        sidebar: {
+          ...(BOOT_LAYOUT.state?.sidebar as Record<string, unknown> | undefined),
+          extensions: [
+            { id: "extension-layout", label: "default-layout", hint: "core", active: true },
+          ],
+        },
+        layout: {
+          ...(bootLayout && typeof bootLayout === "object" ? bootLayout : {}),
+          ...restoredLayout,
+          ...(layoutPrefs?.layout ?? {}),
+          rows: workstationRows(terminalOpen, terminalHeight),
+        },
       }),
       hasSyncSessionSnapshot: Boolean(restored),
     };
@@ -248,6 +269,9 @@ export default function App() {
           /* persist is best effort */
         });
       });
+      saveLayoutPrefs(appStore.getState()).catch(() => {
+        /* persist is best effort */
+      });
     };
     const schedulePersist = () => {
       if (!persistenceStarted) return;
@@ -291,6 +315,17 @@ export default function App() {
       window.removeEventListener("beforeunload", persistNow);
     };
   }, [appStore, hasSyncSessionSnapshot, restoreSessionUiSnapshot]);
+
+  useEffect(() => {
+    let cancelled = false;
+    void loadLayoutPrefsFromDisk().then((prefs) => {
+      if (cancelled || !prefs) return;
+      setState((prev) => mergeLayoutPrefsIntoState(prev, prefs));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [setState]);
 
   // ---------------------------------------------------------------------
   // App-owned shared refs — owned here (rather than inside their primary

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -152,14 +152,11 @@ export default function App() {
         // shapes are documented on the components themselves.
         palette: { open: false, mode: "switcher", query: "", selectedIndex: 0 },
         notifications: [],
-        // Seed /sidebar/extensions so the $ref-bound sidebar section renders
-        // the built-in entry immediately — hydrateExtensions() fills in
-        // dynamically-loaded extensions once `ready` arrives.
+        // Seed /sidebar/extensions so Settings and the sidebar have a stable
+        // list shape before the bridge sends the first ready payload.
         sidebar: {
           ...(BOOT_LAYOUT.state?.sidebar as Record<string, unknown> | undefined),
-          extensions: [
-            { id: "extension-layout", label: "default-layout", hint: "core", active: true },
-          ],
+          extensions: [],
         },
         layout: {
           ...(bootLayout && typeof bootLayout === "object" ? bootLayout : {}),
@@ -772,6 +769,7 @@ export default function App() {
   // ref-tracked defaults without a page reload.
   // ---------------------------------------------------------------------
   const {
+    openSettings,
     toggleSettings,
     closeSettings,
     applySettingsPatch,
@@ -956,6 +954,7 @@ export default function App() {
     stopPrompt,
     toggleTerminal,
     toggleFilesSidebar,
+    openSettings,
     pushNotification,
     dismissNotification,
     checkForUpdates,

--- a/src/eventRoutes/dashboard.test.ts
+++ b/src/eventRoutes/dashboard.test.ts
@@ -125,6 +125,47 @@ describe("handleProjectDashboard", () => {
     expect(handled).toBe(true);
     expect(ctx.activateWorktree).toHaveBeenCalledWith("w-1");
   });
+
+  it("forwards dashboard worktree removal to the shared remove route", async () => {
+    const { ctx } = buildRouteFixture();
+    const handled = await handleProjectDashboard(
+      {
+        component: { id: "project-dashboard", type: "project-dashboard" },
+        eventType: "remove-worktree",
+        data: { worktreeId: "wt-1", confirmed: true },
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(ctx.removeWorktreeById).toHaveBeenCalledWith("wt-1", {
+      confirmed: true,
+    });
+  });
+
+  it("forwards issue-section start-task events emitted through the project dashboard", async () => {
+    const { ctx } = buildRouteFixture();
+    const handled = await handleProjectDashboard(
+      {
+        component: { id: "project-dashboard", type: "project-dashboard" },
+        eventType: "start-task",
+        data: {
+          projectId: "p1",
+          prompt: "Please work on issue #927",
+          worktreeId: "wt-1",
+          source: "github-issue",
+        },
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(ctx.startTaskInProject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "p1",
+        prompt: "Please work on issue #927",
+        worktreeId: "wt-1",
+      }),
+    );
+  });
 });
 
 describe("handleTaskLauncher", () => {

--- a/src/eventRoutes/dashboard.test.ts
+++ b/src/eventRoutes/dashboard.test.ts
@@ -29,7 +29,9 @@ describe("handleProjectsDashboard", () => {
   });
 
   it("select-project-card activates the project", async () => {
-    const { ctx, mocks } = buildRouteFixture();
+    const { ctx, mocks, applySetState } = buildRouteFixture({
+      state: { landing: { kind: "worktree", worktreeId: "w-1" } },
+    });
     const handled = await handleProjectsDashboard(
       {
         component: { id: "x", type: "projects-dashboard" },
@@ -39,7 +41,9 @@ describe("handleProjectsDashboard", () => {
       ctx,
     );
     expect(handled).toBe(true);
+    expect(ctx.activateWorktree).toHaveBeenCalledWith(null);
     expect(mocks.setActiveProjectById).toHaveBeenCalledWith("p1");
+    expect(applySetState().landing).toBeNull();
   });
 
   it("remove-project-card removes by id", async () => {
@@ -70,6 +74,25 @@ describe("handleProjectsDashboard", () => {
     expect(mocks.newTab).toHaveBeenCalledWith("tab-42", "Earlier", {
       restoredSession: true,
       cwd: "/p",
+    });
+  });
+
+  it("delete-session can skip the sticky prompt after inline confirmation", async () => {
+    const { ctx, mocks } = buildRouteFixture({ promptDeleteAllow: true });
+    const handled = await handleProjectsDashboard(
+      {
+        component: { id: "x", type: "projects-dashboard" },
+        eventType: "delete-session",
+        data: { sessionId: "tab-42", label: "Earlier", confirmed: true },
+      },
+      ctx,
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(handled).toBe(true);
+    expect(mocks.promptDeleteSessionConfirmation).not.toHaveBeenCalled();
+    expect(mocks.invoke).toHaveBeenCalledWith("delete_session", {
+      tabId: "tab-42",
     });
   });
 });
@@ -180,6 +203,7 @@ describe("handleTaskLauncher", () => {
       },
       ctx,
     );
+    expect(ctx.activateWorktree).toHaveBeenCalledWith(null);
     expect(mocks.setActiveProjectById).toHaveBeenCalledWith("p2");
   });
 });

--- a/src/eventRoutes/dashboard.ts
+++ b/src/eventRoutes/dashboard.ts
@@ -15,7 +15,10 @@
  * the same handlers.
  */
 import type { EventRouteHandler } from "./types";
-import { handleSidebarDeleteSession } from "./sidebar";
+import {
+  handleSidebarDeleteSession,
+  handleSidebarRemoveWorktree,
+} from "./sidebar";
 
 /** New-tab / Open Project… / restore-session / select-project-card
  *  for the global projects-dashboard surface. */
@@ -80,6 +83,12 @@ export const handleProjectDashboard: EventRouteHandler = (
   { eventType, data },
   ctx,
 ) => {
+  if (eventType === "start-task") {
+    return handleTaskLauncher(
+      { component: { id: "", type: "task-launcher" }, eventType, data },
+      ctx,
+    );
+  }
   if (eventType === "create-worktree") {
     const sel = data as { projectId?: string } | undefined;
     if (sel?.projectId) void ctx.createWorktreeForProject(sel.projectId);
@@ -89,6 +98,12 @@ export const handleProjectDashboard: EventRouteHandler = (
     const sel = data as { worktreeId?: string } | undefined;
     if (sel?.worktreeId) ctx.activateWorktree(sel.worktreeId);
     return true;
+  }
+  if (eventType === "remove-worktree") {
+    return handleSidebarRemoveWorktree(
+      { component: { id: "", type: "sidebar" }, eventType, data },
+      ctx,
+    );
   }
   if (eventType === "refresh-dashboard") {
     // Refresh path doesn't bust the gh cache directly from here — the

--- a/src/eventRoutes/dashboard.ts
+++ b/src/eventRoutes/dashboard.ts
@@ -15,6 +15,7 @@
  * the same handlers.
  */
 import type { EventRouteHandler } from "./types";
+import { handleSidebarDeleteSession } from "./sidebar";
 
 /** New-tab / Open Project… / restore-session / select-project-card
  *  for the global projects-dashboard surface. */
@@ -32,7 +33,11 @@ export const handleProjectsDashboard: EventRouteHandler = (
   }
   if (eventType === "select-project-card") {
     const sel = data as { projectId?: string } | undefined;
-    if (sel?.projectId) ctx.setActiveProjectById(sel.projectId);
+    if (sel?.projectId) {
+      ctx.activateWorktree(null);
+      ctx.setActiveProjectById(sel.projectId);
+      ctx.setState((prev) => ({ ...prev, landing: null }));
+    }
     return true;
   }
   if (eventType === "request-card-menu") {
@@ -59,6 +64,12 @@ export const handleProjectsDashboard: EventRouteHandler = (
       ctx.newTab();
     }
     return true;
+  }
+  if (eventType === "delete-session") {
+    return handleSidebarDeleteSession(
+      { component: { id: "", type: "sidebar" }, eventType, data },
+      ctx,
+    );
   }
   return false;
 };

--- a/src/eventRoutes/editor.test.ts
+++ b/src/eventRoutes/editor.test.ts
@@ -111,6 +111,62 @@ describe("handleEditorCanvas", () => {
 });
 
 describe("handleFileTree", () => {
+  it("resizes the files sidebar column and remembers the width", () => {
+    const fx = buildRouteFixture();
+    const claimed = handleFileTree(
+      {
+        component: { id: "file-tree", type: "file-tree" },
+        eventType: "resize",
+        data: { width: 512 },
+      },
+      fx.ctx,
+    );
+    expect(claimed).toBe(true);
+    const next = fx.applySetState({
+      layout: { columns: "240px minmax(0,1fr) 360px" },
+    });
+    expect(next.layout).toEqual(
+      expect.objectContaining({
+        columns: "240px minmax(0,1fr) 512px",
+        lastRightWidth: "512px",
+      }),
+    );
+  });
+
+  it("clamps files sidebar resize width", () => {
+    const fx = buildRouteFixture();
+    handleFileTree(
+      {
+        component: { id: "file-tree", type: "file-tree" },
+        eventType: "resize",
+        data: { width: 1200 },
+      },
+      fx.ctx,
+    );
+    const next = fx.applySetState({
+      layout: { columns: "220px minmax(0,1fr) 360px" },
+    });
+    expect((next.layout as { columns: string; lastRightWidth: string }).columns)
+      .toBe("220px minmax(0,1fr) 640px");
+    expect((next.layout as { lastRightWidth: string }).lastRightWidth).toBe(
+      "640px",
+    );
+  });
+
+  it("handles files sidebar resize-end without a one-off write", () => {
+    const fx = buildRouteFixture();
+    const claimed = handleFileTree(
+      {
+        component: { id: "file-tree", type: "file-tree" },
+        eventType: "resize-end",
+        data: {},
+      },
+      fx.ctx,
+    );
+    expect(claimed).toBe(true);
+    expect(fx.mocks.writeState).not.toHaveBeenCalled();
+  });
+
   it("opens an editor tab on file-tree-open", () => {
     const fx = buildRouteFixture();
     const claimed = handleFileTree(

--- a/src/eventRoutes/editor.test.ts
+++ b/src/eventRoutes/editor.test.ts
@@ -205,13 +205,17 @@ describe("handleFileTree", () => {
       {
         component: { id: "file-tree", type: "file-tree" },
         eventType: "file-tree-open",
-        data: { filePath: "/projects/aethon/src/App.tsx" },
+        data: {
+          filePath: "/projects/aethon/src/App.tsx",
+          rootPath: "/projects/aethon",
+        },
       },
       fx.ctx,
     );
     expect(claimed).toBe(true);
     expect(fx.mocks.newEditorTab).toHaveBeenCalledWith(
       "/projects/aethon/src/App.tsx",
+      { rootPath: "/projects/aethon" },
     );
   });
 

--- a/src/eventRoutes/editor.test.ts
+++ b/src/eventRoutes/editor.test.ts
@@ -71,6 +71,38 @@ describe("handleEditorCanvas", () => {
     );
   });
 
+  it("uses an editor tab root override when saving user-dir files", async () => {
+    const fx = buildRouteFixture({
+      state: {
+        project: { path: "/projects/aethon" },
+        tabs: [
+          {
+            id: "tab-1",
+            kind: "editor",
+            editor: {
+              filePath: "/Users/test/.aethon/system-prompt.md",
+              rootPath: "/Users/test/.aethon",
+            },
+          },
+        ],
+      },
+    });
+    const claimed = await handleEditorCanvas(
+      editorEvent("editor-save", {
+        tabId: "tab-1",
+        filePath: "/Users/test/.aethon/system-prompt.md",
+        content: "You are Aethon.",
+      }),
+      fx.ctx,
+    );
+    expect(claimed).toBe(true);
+    expect(fx.mocks.invoke).toHaveBeenCalledWith("fs_write_file", {
+      root: "/Users/test/.aethon",
+      path: "/Users/test/.aethon/system-prompt.md",
+      content: "You are Aethon.",
+    });
+  });
+
   it("surfaces a notification when fs_write_file errors", async () => {
     const fx = buildRouteFixture({
       state: { project: { path: "/projects/aethon" } },

--- a/src/eventRoutes/editor.ts
+++ b/src/eventRoutes/editor.ts
@@ -131,7 +131,9 @@ export const handleFileTree: EventRouteHandler = (
     const payload = asRecord(event.data);
     const filePath = typeof payload.filePath === "string" ? payload.filePath : "";
     if (!filePath) return false;
-    ctx.newEditorTab(filePath);
+    const rootPath = typeof payload.rootPath === "string" ? payload.rootPath : "";
+    if (rootPath) ctx.newEditorTab(filePath, { rootPath });
+    else ctx.newEditorTab(filePath);
     return true;
   }
   if (event.eventType === "file-tree-rename") {

--- a/src/eventRoutes/editor.ts
+++ b/src/eventRoutes/editor.ts
@@ -63,7 +63,11 @@ export const handleEditorCanvas: EventRouteHandler = async (
       const content = typeof payload.content === "string" ? payload.content : "";
       if (!filePath) return true;
       const project = ctx.stateRef.current.project as { path?: string } | undefined;
-      const root = project?.path ?? "";
+      const tabs = (ctx.stateRef.current.tabs as
+        | Array<{ id: string; editor?: { rootPath?: string } }>
+        | undefined) ?? [];
+      const tabRoot = tabs.find((t) => t.id === tabId)?.editor?.rootPath;
+      const root = tabRoot ?? project?.path ?? "";
       try {
         await ctx.invoke("fs_write_file", { root, path: filePath, content });
         ctx.updateEditorMeta(tabId, { isDirty: false });

--- a/src/eventRoutes/editor.ts
+++ b/src/eventRoutes/editor.ts
@@ -22,6 +22,16 @@ function asRecord(data: unknown): Record<string, unknown> {
   return data && typeof data === "object" ? (data as Record<string, unknown>) : {};
 }
 
+const FILES_SIDEBAR_MIN_WIDTH = 220;
+const FILES_SIDEBAR_MAX_WIDTH = 640;
+
+function clampFilesSidebarWidth(value: number): number {
+  return Math.max(
+    FILES_SIDEBAR_MIN_WIDTH,
+    Math.min(FILES_SIDEBAR_MAX_WIDTH, Math.round(value)),
+  );
+}
+
 export const handleEditorCanvas: EventRouteHandler = async (
   event: EventRouteEvent,
   ctx: EventRouteContext,
@@ -81,6 +91,38 @@ export const handleFileTree: EventRouteHandler = (
   event: EventRouteEvent,
   ctx: EventRouteContext,
 ): boolean => {
+  if (event.eventType === "resize") {
+    const payload = asRecord(event.data);
+    const rawWidth = typeof payload.width === "number" ? payload.width : NaN;
+    if (!Number.isFinite(rawWidth)) return true;
+    const width = clampFilesSidebarWidth(rawWidth);
+    ctx.setState((prev) => {
+      const layout =
+        (prev.layout as Record<string, unknown> | undefined) ?? {};
+      const current =
+        typeof layout.columns === "string"
+          ? layout.columns
+          : "220px minmax(0,1fr) 360px";
+      const tokens = current.trim().split(/\s+/);
+      if (tokens.length >= 3) {
+        tokens[tokens.length - 1] = `${width}px`;
+      } else if (tokens.length >= 2 && layout.filesSidebarVisible !== false) {
+        tokens.push(`${width}px`);
+      }
+      return {
+        ...prev,
+        layout: {
+          ...layout,
+          columns: tokens.join(" "),
+          lastRightWidth: `${width}px`,
+        },
+      };
+    });
+    return true;
+  }
+  if (event.eventType === "resize-end") {
+    return true;
+  }
   if (event.eventType === "file-tree-open") {
     const payload = asRecord(event.data);
     const filePath = typeof payload.filePath === "string" ? payload.filePath : "";

--- a/src/eventRoutes/settings.test.ts
+++ b/src/eventRoutes/settings.test.ts
@@ -37,6 +37,58 @@ describe("handleSettings", () => {
     expect(mocks.saveSettings).toHaveBeenCalledTimes(1);
   });
 
+  it("opens system-prompt.md in an editor tab rooted at the Aethon dir", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    mocks.invoke
+      .mockResolvedValueOnce("/Users/test/.aethon")
+      .mockResolvedValueOnce("");
+    const handled = await handleSettings(
+      {
+        component: { id: "settings-panel" },
+        eventType: "open-system-prompt",
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(mocks.invoke).toHaveBeenNthCalledWith(1, "aethon_home_dir");
+    expect(mocks.invoke).toHaveBeenNthCalledWith(2, "read_state", {
+      name: "system-prompt.md",
+    });
+    expect(mocks.invoke).toHaveBeenNthCalledWith(3, "write_state", {
+      name: "system-prompt.md",
+      content: "",
+    });
+    expect(mocks.newEditorTab).toHaveBeenCalledWith(
+      "/Users/test/.aethon/system-prompt.md",
+      { rootPath: "/Users/test/.aethon" },
+    );
+    expect(mocks.closeSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not overwrite an existing system prompt while opening it", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    mocks.invoke
+      .mockResolvedValueOnce("/Users/test/.aethon")
+      .mockResolvedValueOnce("custom prompt");
+    await handleSettings(
+      {
+        component: { id: "settings-panel" },
+        eventType: "open-system-prompt",
+      },
+      ctx,
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(mocks.invoke).not.toHaveBeenCalledWith("write_state", {
+      name: "system-prompt.md",
+      content: "",
+    });
+    expect(mocks.newEditorTab).toHaveBeenCalledWith(
+      "/Users/test/.aethon/system-prompt.md",
+      { rootPath: "/Users/test/.aethon" },
+    );
+  });
+
   it("reset-layout-prefs restores layout defaults and clears persisted prefs", async () => {
     const { ctx, mocks, applySetState } = buildRouteFixture({
       state: {

--- a/src/eventRoutes/settings.test.ts
+++ b/src/eventRoutes/settings.test.ts
@@ -37,6 +37,26 @@ describe("handleSettings", () => {
     expect(mocks.saveSettings).toHaveBeenCalledTimes(1);
   });
 
+  it("forwards extension toggles from the settings panel", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    const handled = await handleSettings(
+      {
+        component: { id: "settings-panel" },
+        eventType: "toggle-extension",
+        data: { name: "mold:image-gallery", disabled: true },
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.invoke).toHaveBeenCalledWith("agent_command", {
+      payload: JSON.stringify({
+        type: "set_extension_disabled",
+        name: "mold:image-gallery",
+        disabled: true,
+      }),
+    });
+  });
+
   it("opens system-prompt.md in an editor tab rooted at the Aethon dir", async () => {
     const { ctx, mocks } = buildRouteFixture();
     mocks.invoke

--- a/src/eventRoutes/settings.test.ts
+++ b/src/eventRoutes/settings.test.ts
@@ -37,6 +37,43 @@ describe("handleSettings", () => {
     expect(mocks.saveSettings).toHaveBeenCalledTimes(1);
   });
 
+  it("reset-layout-prefs restores layout defaults and clears persisted prefs", async () => {
+    const { ctx, mocks, applySetState } = buildRouteFixture({
+      state: {
+        layout: {
+          sidebarVisible: false,
+          filesSidebarVisible: false,
+          columns: "310px minmax(0,1fr)",
+          lastLeftWidth: "310px",
+          lastRightWidth: "520px",
+        },
+        terminalPanel: { activeSubId: "agent-bash", height: 420 },
+      },
+    });
+    const handled = await handleSettings(
+      {
+        component: { id: "settings-panel" },
+        eventType: "reset-layout-prefs",
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    const next = applySetState();
+    expect(next.layout).toEqual(
+      expect.objectContaining({
+        sidebarVisible: true,
+        filesSidebarVisible: true,
+        columns: "220px minmax(0,1fr) 360px",
+        lastLeftWidth: "220px",
+        lastRightWidth: "360px",
+      }),
+    );
+    expect(next.terminalPanel).toEqual({ activeSubId: "agent-bash" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(mocks.writeState).toHaveBeenCalledWith("layout_prefs", "");
+    expect(mocks.writeState).toHaveBeenCalledWith("file-tree-prefs.json", "");
+  });
+
   // Wrong-component rejection is no longer this handler's job — the
   // route table dispatches by `type:settings-panel`, so an event for a
   // different type never reaches handleSettings. See index.test.ts for

--- a/src/eventRoutes/settings.test.ts
+++ b/src/eventRoutes/settings.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { handleSettings } from "./settings";
 import { buildRouteFixture } from "./testFixtures";
+import { DEFAULT_AETHON_SYSTEM_PROMPT } from "../systemPromptBaseline";
 
 describe("handleSettings", () => {
   it("close calls closeSettings", async () => {
@@ -77,7 +78,11 @@ describe("handleSettings", () => {
     });
     expect(mocks.invoke).toHaveBeenNthCalledWith(3, "write_state", {
       name: "system-prompt.md",
-      content: "",
+      content: expect.stringContaining("# About Aethon"),
+    });
+    expect(mocks.invoke.mock.calls[2]?.[1]).toEqual({
+      name: "system-prompt.md",
+      content: expect.stringContaining(DEFAULT_AETHON_SYSTEM_PROMPT.slice(0, 80)),
     });
     expect(mocks.newEditorTab).toHaveBeenCalledWith(
       "/Users/test/.aethon/system-prompt.md",

--- a/src/eventRoutes/settings.ts
+++ b/src/eventRoutes/settings.ts
@@ -3,6 +3,7 @@ import {
   clearLayoutPrefs,
   resetLayoutPrefsInState,
 } from "../layoutPrefs";
+import { buildEditableSystemPromptBaseline } from "../systemPromptBaseline";
 
 /** settings-panel renders at App root and never goes through the
  *  bridge — events drive the panel's pending overlay directly.
@@ -59,8 +60,11 @@ export const handleSettings: EventRouteHandler = (
         }
         const fileName = "system-prompt.md";
         const existing = await ctx.invoke("read_state", { name: fileName });
-        if (typeof existing !== "string" || existing.length === 0) {
-          await ctx.invoke("write_state", { name: fileName, content: "" });
+        if (typeof existing !== "string" || existing.trim().length === 0) {
+          await ctx.invoke("write_state", {
+            name: fileName,
+            content: buildEditableSystemPromptBaseline(),
+          });
         }
         ctx.newEditorTab(`${dir}/${fileName}`, { rootPath: dir });
         ctx.closeSettings();

--- a/src/eventRoutes/settings.ts
+++ b/src/eventRoutes/settings.ts
@@ -28,6 +28,31 @@ export const handleSettings: EventRouteHandler = (
     void ctx.saveSettings();
     return true;
   }
+  if (eventType === "open-system-prompt") {
+    void ctx
+      .invoke("aethon_home_dir")
+      .then(async (dir) => {
+        if (typeof dir !== "string" || dir.length === 0) {
+          throw new Error("Aethon directory unavailable");
+        }
+        const fileName = "system-prompt.md";
+        const existing = await ctx.invoke("read_state", { name: fileName });
+        if (typeof existing !== "string" || existing.length === 0) {
+          await ctx.invoke("write_state", { name: fileName, content: "" });
+        }
+        ctx.newEditorTab(`${dir}/${fileName}`, { rootPath: dir });
+        ctx.closeSettings();
+      })
+      .catch((err: unknown) => {
+        ctx.pushNotification({
+          title: "Open system prompt failed",
+          message: String(err),
+          kind: "error",
+          durationMs: 6000,
+        });
+      });
+    return true;
+  }
   if (eventType === "reset-layout-prefs") {
     ctx.setState((prev) => resetLayoutPrefsInState(prev));
     void clearLayoutPrefs(ctx.writeState);

--- a/src/eventRoutes/settings.ts
+++ b/src/eventRoutes/settings.ts
@@ -28,6 +28,28 @@ export const handleSettings: EventRouteHandler = (
     void ctx.saveSettings();
     return true;
   }
+  if (eventType === "toggle-extension") {
+    const selected = data as
+      | { name?: string; disabled?: boolean }
+      | undefined;
+    if (!selected?.name || typeof selected.disabled !== "boolean") return true;
+    void ctx
+      .invoke("agent_command", {
+        payload: JSON.stringify({
+          type: "set_extension_disabled",
+          name: selected.name,
+          disabled: selected.disabled,
+        }),
+      })
+      .catch((err: unknown) => {
+        ctx.pushNotification({
+          title: "Toggle extension failed",
+          message: String(err),
+          kind: "error",
+        });
+      });
+    return true;
+  }
   if (eventType === "open-system-prompt") {
     void ctx
       .invoke("aethon_home_dir")

--- a/src/eventRoutes/settings.ts
+++ b/src/eventRoutes/settings.ts
@@ -1,4 +1,8 @@
 import type { EventRouteHandler } from "./types";
+import {
+  clearLayoutPrefs,
+  resetLayoutPrefsInState,
+} from "../layoutPrefs";
 
 /** settings-panel renders at App root and never goes through the
  *  bridge — events drive the panel's pending overlay directly.
@@ -22,6 +26,21 @@ export const handleSettings: EventRouteHandler = (
   }
   if (eventType === "save") {
     void ctx.saveSettings();
+    return true;
+  }
+  if (eventType === "reset-layout-prefs") {
+    ctx.setState((prev) => resetLayoutPrefsInState(prev));
+    void clearLayoutPrefs(ctx.writeState);
+    void ctx.writeState("file-tree-prefs.json", "");
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(new Event("aethon:reset-file-tree-prefs"));
+    }
+    ctx.pushNotification({
+      title: "Layout reset",
+      message: "Sidebar and panel sizes restored.",
+      kind: "success",
+      durationMs: 2400,
+    });
     return true;
   }
   return false;

--- a/src/eventRoutes/sidebar.test.ts
+++ b/src/eventRoutes/sidebar.test.ts
@@ -3,6 +3,7 @@ import {
   handleSidebarResize,
   handleSidebarResizeEnd,
   handleSidebarRemoveProject,
+  handleSidebarRemoveWorktree,
   handleSidebarDeleteSession,
   handleSidebarRenameSession,
   handleSidebarToggleExtension,
@@ -58,6 +59,24 @@ describe("handleSidebarRemoveProject", () => {
     );
     expect(handled).toBe(true);
     expect(mocks.removeProjectById).toHaveBeenCalledWith("proj-1");
+  });
+});
+
+describe("handleSidebarRemoveWorktree", () => {
+  it("passes inline confirmation through to the project operation", async () => {
+    const { ctx } = buildRouteFixture();
+    const handled = await handleSidebarRemoveWorktree(
+      {
+        component: { id: "sidebar" },
+        eventType: "remove-worktree",
+        data: { worktreeId: "wt-1", confirmed: true },
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(ctx.removeWorktreeById).toHaveBeenCalledWith("wt-1", {
+      confirmed: true,
+    });
   });
 });
 

--- a/src/eventRoutes/sidebar.test.ts
+++ b/src/eventRoutes/sidebar.test.ts
@@ -306,6 +306,29 @@ describe("handleSectionedSelect", () => {
     expect(mocks.openProjectFromPicker).toHaveBeenCalledTimes(1);
   });
 
+  it("projects section selects the main project and clears worktree landing", async () => {
+    const { ctx, mocks, applySetState } = buildRouteFixture({
+      state: {
+        landing: {
+          kind: "worktree",
+          projectId: "proj-1",
+          worktreeId: "wt-1",
+        },
+      },
+    });
+    await handleSectionedSelect(
+      {
+        component: { id: "sidebar" },
+        eventType: "select",
+        data: { sectionId: "projects", itemId: "proj-1" },
+      },
+      ctx,
+    );
+    expect(ctx.activateWorktree).toHaveBeenCalledWith(null);
+    expect(mocks.setActiveProjectById).toHaveBeenCalledWith("proj-1");
+    expect(applySetState().landing).toBeNull();
+  });
+
   it("returns false for non-select events", async () => {
     const { ctx } = buildRouteFixture();
     const handled = await handleSectionedSelect(

--- a/src/eventRoutes/sidebar.ts
+++ b/src/eventRoutes/sidebar.ts
@@ -352,8 +352,13 @@ export const handleSidebarRemoveWorktree: EventRouteHandler = (
   ctx,
 ) => {
   if (eventType !== "remove-worktree") return false;
-  const worktreeId = (data as { worktreeId?: string } | undefined)?.worktreeId;
-  if (worktreeId) void ctx.removeWorktreeById(worktreeId);
+  const selected =
+    (data as { worktreeId?: string; confirmed?: boolean } | undefined) ?? {};
+  if (selected.worktreeId) {
+    void ctx.removeWorktreeById(selected.worktreeId, {
+      confirmed: selected.confirmed === true,
+    });
+  }
   return true;
 };
 export const handleSidebarCancelPendingWorktree: EventRouteHandler = (

--- a/src/eventRoutes/sidebar.ts
+++ b/src/eventRoutes/sidebar.ts
@@ -82,7 +82,7 @@ export const handleSidebarDeleteSession: EventRouteHandler = (
 ) => {
   if (eventType !== "delete-session") return false;
   const selected = data as
-    | { sessionId?: string; itemId?: string; label?: string }
+    | { sessionId?: string; itemId?: string; label?: string; confirmed?: boolean }
     | undefined;
   // Strip the "session:" or "tab:" prefix defensively in case a future
   // caller forgets the split — the sidebar already strips it but we
@@ -92,7 +92,7 @@ export const handleSidebarDeleteSession: EventRouteHandler = (
   const sessionId = extractSessionId(raw);
   const label = selected?.label ?? sessionId;
   if (!sessionId) return true;
-  ctx.promptDeleteSessionConfirmation(label).then((allowed) => {
+  const deleteAfterConfirmation = (allowed: boolean) => {
     if (!allowed) return;
     const isOpen = (ctx.stateRef.current.tabs as Tab[] | undefined)?.some(
       (t) => t.id === sessionId,
@@ -119,7 +119,12 @@ export const handleSidebarDeleteSession: EventRouteHandler = (
           kind: "error",
         });
       });
-  });
+  };
+  if (selected?.confirmed === true) {
+    deleteAfterConfirmation(true);
+  } else {
+    ctx.promptDeleteSessionConfirmation(label).then(deleteAfterConfirmation);
+  }
   return true;
 };
 
@@ -314,8 +319,8 @@ export const handleSidebarOpenWorktreeInNewTab: EventRouteHandler = (
       break;
     }
   }
-  ctx.activateWorktree(worktreeId);
   if (projectId) ctx.setActiveProjectById(projectId);
+  ctx.activateWorktree(worktreeId);
   ctx.setState((prev) => ({ ...prev, landing: null }));
   ctx.newTab(undefined, undefined, path ? { cwd: path } : undefined);
   return true;
@@ -336,8 +341,8 @@ export const handleSidebarStartSession: EventRouteHandler = (
     (data as
       | { worktreeId?: string; projectId?: string; path?: string }
       | undefined) ?? {};
-  if (payload.worktreeId) ctx.activateWorktree(payload.worktreeId);
   if (payload.projectId) ctx.setActiveProjectById(payload.projectId);
+  if (payload.worktreeId) ctx.activateWorktree(payload.worktreeId);
   ctx.setState((prev) => ({ ...prev, landing: null }));
   ctx.newTab(undefined, undefined, payload.path ? { cwd: payload.path } : undefined);
   return true;
@@ -531,7 +536,9 @@ export const handleSectionedSelect: EventRouteHandler = async (
       ctx.openProjectFromPicker();
       return true;
     }
+    ctx.activateWorktree(null);
     ctx.setActiveProjectById(selected.itemId);
+    ctx.setState((prev) => ({ ...prev, landing: null }));
     return true;
   }
   if (selected?.sectionId === "hosts" && selected.itemId) {

--- a/src/eventRoutes/terminal.test.ts
+++ b/src/eventRoutes/terminal.test.ts
@@ -57,9 +57,13 @@ describe("handleTerminalPanel", () => {
     expect(mocks.newShellTab).toHaveBeenCalledTimes(1);
   });
 
-  it("resize stores the terminal panel height in state", async () => {
+  it("resize stores the terminal panel height and updates the open row track", async () => {
     const { ctx, applySetState } = buildRouteFixture({
-      state: { terminalPanel: { activeSubId: "agent-bash" } },
+      state: {
+        terminal: { open: true },
+        terminalPanel: { activeSubId: "agent-bash" },
+        layout: { rows: "38px minmax(0,1fr) 240px auto auto" },
+      },
     });
     const handled = await handleTerminalPanel(
       {
@@ -72,6 +76,9 @@ describe("handleTerminalPanel", () => {
     expect(handled).toBe(true);
     const next = applySetState();
     expect((next.terminalPanel as { height?: number }).height).toBe(360);
+    expect((next.layout as { rows?: string }).rows).toBe(
+      "38px minmax(0,1fr) 360px auto auto",
+    );
   });
 
   it("resize clamps height and resize-end avoids legacy one-off writes", async () => {

--- a/src/eventRoutes/terminal.ts
+++ b/src/eventRoutes/terminal.ts
@@ -46,9 +46,19 @@ export const handleTerminalPanel: EventRouteHandler = (
         const panel =
           (prev.terminalPanel as Record<string, unknown> | undefined) ?? {};
         if (panel.height === next) return prev;
+        const terminal =
+          (prev.terminal as { open?: boolean } | undefined) ?? {};
+        const layout =
+          (prev.layout as Record<string, unknown> | undefined) ?? {};
         return {
           ...prev,
           terminalPanel: { ...panel, height: next },
+          layout: terminal.open
+            ? {
+                ...layout,
+                rows: `38px minmax(0,1fr) ${next}px auto auto`,
+              }
+            : layout,
         };
       });
     }

--- a/src/eventRoutes/types.ts
+++ b/src/eventRoutes/types.ts
@@ -82,7 +82,7 @@ export interface EventRouteContext {
     },
   ) => void;
   newShellTab: () => void;
-  newEditorTab: (filePath: string) => void;
+  newEditorTab: (filePath: string, opts?: { rootPath?: string }) => void;
   updateEditorMeta: (tabId: string, patch: Partial<EditorMeta>) => void;
   /** Reconcile any open editor tabs whose `editor.filePath` is `from`
    *  (or, when `kind === "dir"`, starts with `from/`) to point at the
@@ -149,7 +149,10 @@ export interface EventRouteContext {
      *  true. When omitted, the project root is used. */
     worktreeId?: string;
   }) => Promise<void>;
-  removeWorktreeById: (worktreeId: string) => Promise<void>;
+  removeWorktreeById: (
+    worktreeId: string,
+    opts?: { confirmed?: boolean },
+  ) => Promise<void>;
   dismissPendingWorktree: (worktreeId: string) => void;
   retryPendingWorktree: (worktreeId: string) => Promise<void>;
   renameWorktree: (worktreeId: string, label: string) => void;

--- a/src/hooks/useChat.test.ts
+++ b/src/hooks/useChat.test.ts
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import type { Dispatch, MutableRefObject, SetStateAction } from "react";
+
+import { makeEmptyTab, type Tab } from "../types/tab";
+import { useChat, type UseChatContext } from "./useChat";
+
+const invoke = vi.fn((..._args: unknown[]) => Promise.resolve(undefined));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (cmd: string, args?: unknown) => invoke(cmd, args),
+}));
+
+afterEach(() => {
+  invoke.mockClear();
+});
+
+function buildContext(overrides: Record<string, unknown> = {}): {
+  ctx: UseChatContext;
+  stateRef: MutableRefObject<Record<string, unknown>>;
+  recordProjectModel: ReturnType<typeof vi.fn>;
+} {
+  const tab = {
+    ...makeEmptyTab("tab-1", "Tab 1"),
+    model: "anthropic/claude-opus-4-7",
+    projectId: "project-1",
+  };
+  const stateRef: MutableRefObject<Record<string, unknown>> = {
+    current: {
+      activeTabId: "tab-1",
+      model: "anthropic/claude-opus-4-7",
+      waiting: false,
+      sidebar: {
+        models: [
+          { id: "anthropic/claude-opus-4-7", label: "Claude Opus 4.7" },
+          { id: "openai/gpt-5.5", label: "GPT-5.5" },
+        ],
+      },
+      tabs: [tab],
+      ...overrides,
+    },
+  };
+  const setState: Dispatch<SetStateAction<Record<string, unknown>>> = (arg) => {
+    stateRef.current =
+      typeof arg === "function" ? arg(stateRef.current) : arg;
+  };
+  const updateTab = (tabId: string, mutator: (tab: Tab) => Tab) => {
+    setState((prev) => {
+      const tabs = ((prev.tabs as Tab[] | undefined) ?? []).slice();
+      const idx = tabs.findIndex((t) => t.id === tabId);
+      if (idx < 0) return prev;
+      const next = mutator(tabs[idx]);
+      tabs[idx] = next;
+      return {
+        ...prev,
+        tabs,
+        ...(prev.activeTabId === tabId ? { model: next.model } : {}),
+      };
+    });
+  };
+  const recordProjectModel = vi.fn();
+  return {
+    stateRef,
+    recordProjectModel,
+    ctx: {
+      setState,
+      stateRef,
+      updateTab,
+      updateActiveTab: (mutator) =>
+        updateTab(stateRef.current.activeTabId as string, mutator),
+      pendingTabOpens: { current: new Map() },
+      slashCommandsRef: { current: [] },
+      pushNotification: vi.fn(),
+      slashContext: () =>
+        ({
+          appendSystem: vi.fn(),
+          notify: vi.fn(),
+          clearChat: vi.fn(),
+          setTheme: vi.fn(),
+          setModel: vi.fn(),
+        }) as unknown as ReturnType<UseChatContext["slashContext"]>,
+      persistLocalChatMessage: vi.fn(),
+      recordProjectModel,
+    },
+  };
+}
+
+describe("useChat setModel", () => {
+  it("optimistically mirrors the selected model into the active tab and picker", async () => {
+    const { ctx, stateRef, recordProjectModel } = buildContext();
+    const { result } = renderHook(() => useChat(ctx));
+
+    await act(async () => {
+      await result.current.setModel("openai/gpt-5.5");
+    });
+
+    expect(invoke).toHaveBeenCalledWith("agent_command", {
+      payload: JSON.stringify({
+        type: "set_model",
+        id: "openai/gpt-5.5",
+        tabId: "tab-1",
+      }),
+    });
+    expect(recordProjectModel).toHaveBeenCalledWith("openai/gpt-5.5", "tab-1");
+    expect(stateRef.current.model).toBe("openai/gpt-5.5");
+    expect(
+      (stateRef.current.tabs as Tab[])[0].model,
+    ).toBe("openai/gpt-5.5");
+    expect(
+      (
+        (stateRef.current.sidebar as { models: { id: string; active?: boolean }[] })
+          .models
+      ).find((m) => m.id === "openai/gpt-5.5")?.active,
+    ).toBe(true);
+  });
+
+  it("leaves the visible model alone while the active prompt is busy", async () => {
+    const { ctx, stateRef } = buildContext({ waiting: true });
+    const { result } = renderHook(() => useChat(ctx));
+
+    await act(async () => {
+      await result.current.setModel("openai/gpt-5.5");
+    });
+
+    expect(invoke).toHaveBeenCalledWith("agent_command", {
+      payload: JSON.stringify({
+        type: "set_model",
+        id: "openai/gpt-5.5",
+        tabId: "tab-1",
+      }),
+    });
+    expect(stateRef.current.model).toBe("anthropic/claude-opus-4-7");
+    expect(
+      (stateRef.current.tabs as Tab[])[0].model,
+    ).toBe("anthropic/claude-opus-4-7");
+  });
+});

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -13,6 +13,7 @@ import {
   type SlashCommandContext,
 } from "../slashCommands";
 import type { NotificationInput } from "./useNotifications";
+import { recomputeModelPicker } from "../utils/modelPicker";
 
 export interface UseChatContext {
   setState: Dispatch<SetStateAction<Record<string, unknown>>>;
@@ -282,12 +283,38 @@ export function useChat(ctx: UseChatContext): UseChatActions {
 
   async function setModel(id: string) {
     const tabId = (stateRef.current.activeTabId as string | undefined) ?? "default";
+    const previousModel = (stateRef.current.model as string | undefined) ?? "";
+    const canOptimisticallyMirror = stateRef.current.waiting !== true;
     recordProjectModel(id, tabId);
+    if (canOptimisticallyMirror) {
+      updateTab(tabId, (tab) => ({ ...tab, model: id }));
+      setState((prev) => ({
+        ...prev,
+        model: id,
+        status: `switching to ${id}...`,
+        sidebar: recomputeModelPicker(
+          prev.sidebar as Record<string, unknown> | undefined,
+          id,
+        ),
+      }));
+    }
     try {
       await invoke("agent_command", {
         payload: JSON.stringify({ type: "set_model", id, tabId }),
       });
     } catch (err) {
+      if (previousModel && canOptimisticallyMirror) {
+        updateTab(tabId, (tab) => ({ ...tab, model: previousModel }));
+        setState((prev) => ({
+          ...prev,
+          model: previousModel,
+          status: "model switch failed",
+          sidebar: recomputeModelPicker(
+            prev.sidebar as Record<string, unknown> | undefined,
+            previousModel,
+          ),
+        }));
+      }
       appendMessage(
         {
           id: crypto.randomUUID(),

--- a/src/hooks/useExtensionsHydration.test.ts
+++ b/src/hooks/useExtensionsHydration.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { filterExtensionSummariesByProject } from "./useExtensionsHydration";
+import {
+  buildExtensionSidebarItems,
+  filterExtensionSummariesByProject,
+} from "./useExtensionsHydration";
 
 describe("filterExtensionSummariesByProject", () => {
   it("keeps global extensions and only the active project's local extensions", () => {
@@ -55,5 +58,103 @@ describe("filterExtensionSummariesByProject", () => {
     );
 
     expect(filtered).toEqual([]);
+  });
+});
+
+describe("buildExtensionSidebarItems", () => {
+  it("surfaces user, project, failed, and disabled extensions without the core layout", () => {
+    const items = buildExtensionSidebarItems(
+      [
+        { name: "default-layout", source: "directory" },
+        { name: "user-ext", source: "directory" },
+        {
+          name: "mold:gallery",
+          source: "project-directory",
+          projectRoot: "/repo/mold",
+        },
+        { name: "package-ext", source: "extension-package" },
+      ],
+      [
+        {
+          name: "broken-ext",
+          source: "directory",
+          error: "boom",
+        },
+      ],
+      ["disabled-ext"],
+      "/repo/mold",
+    );
+
+    expect(items).toEqual([
+      {
+        id: "ext:user-ext",
+        label: "user-ext",
+        hint: "user",
+        active: true,
+      },
+      {
+        id: "ext:mold:gallery",
+        label: "mold:gallery",
+        hint: "project",
+        active: true,
+      },
+      {
+        id: "ext:package-ext",
+        label: "package-ext",
+        hint: "package",
+        active: true,
+      },
+      {
+        id: "ext-failed:broken-ext",
+        label: "broken-ext",
+        hint: "user · failed",
+        active: false,
+      },
+      {
+        id: "ext-disabled:disabled-ext",
+        label: "disabled-ext",
+        hint: "disabled",
+        active: false,
+      },
+    ]);
+  });
+
+  it("shows a restart hint when a newly disabled extension is still loaded", () => {
+    const items = buildExtensionSidebarItems(
+      [{ name: "user-ext", source: "directory" }],
+      [],
+      ["user-ext"],
+    );
+
+    expect(items).toEqual([
+      {
+        id: "ext-disabled:user-ext",
+        label: "user-ext",
+        hint: "disabled · restart",
+        active: false,
+      },
+    ]);
+  });
+
+  it("filters project extensions to the active project", () => {
+    const items = buildExtensionSidebarItems(
+      [
+        {
+          name: "mold:gallery",
+          source: "project-directory",
+          projectRoot: "/repo/mold",
+        },
+        {
+          name: "other:gallery",
+          source: "project-directory",
+          projectRoot: "/repo/other",
+        },
+      ],
+      [],
+      [],
+      "/repo/mold",
+    );
+
+    expect(items.map((item) => item.label)).toEqual(["mold:gallery"]);
   });
 });

--- a/src/hooks/useExtensionsHydration.ts
+++ b/src/hooks/useExtensionsHydration.ts
@@ -6,7 +6,7 @@ import {
   type SetStateAction,
 } from "react";
 import { invoke } from "@tauri-apps/api/core";
-import type { A2UIPayload } from "../types/a2ui";
+import type { A2UIPayload, SidebarItem } from "../types/a2ui";
 import {
   buildBuiltinSlashCommands,
   type SlashCommand,
@@ -36,6 +36,12 @@ export interface ExtensionFailureSummary extends ExtensionSummary {
   error?: string;
 }
 
+export type ExtensionSidebarItem = SidebarItem & {
+  hint?: string;
+};
+
+const CORE_EXTENSION_NAMES = new Set(["default-layout"]);
+
 function normalizeExtensionProjectPath(path: string | undefined | null): string {
   return (path ?? "").replace(/[/\\]+$/, "");
 }
@@ -53,6 +59,73 @@ export function filterExtensionSummariesByProject<
       (activePath === projectRoot || activePath.startsWith(`${projectRoot}/`))
     );
   });
+}
+
+function extensionSourceLabel(source: string): string {
+  switch (source) {
+    case "directory":
+    case "global-directory":
+      return "user";
+    case "project-directory":
+      return "project";
+    case "extension-package":
+      return "package";
+    default:
+      return source;
+  }
+}
+
+export function buildExtensionSidebarItems(
+  loaded: ExtensionSummary[],
+  failed: ExtensionFailureSummary[],
+  disabled: string[] = [],
+  activeProjectPath: string | null = null,
+): ExtensionSidebarItem[] {
+  const scopedLoaded = filterExtensionSummariesByProject(
+    loaded,
+    activeProjectPath,
+  );
+  const scopedFailed = filterExtensionSummariesByProject(
+    failed,
+    activeProjectPath,
+  );
+  const disabledSet = new Set(disabled);
+  // An extension may appear in `loaded` (live this run) but also be
+  // marked disabled (toggle landed mid-session, takes effect after
+  // restart). Show it in the disabled bucket so the user sees their
+  // pending intent, with a hint that a restart is needed to fully
+  // unload it.
+  return [
+    ...scopedLoaded
+      .filter((e) => !CORE_EXTENSION_NAMES.has(e.name))
+      .filter((e) => !disabledSet.has(e.name))
+      .map((e) => ({
+        id: `ext:${e.name}`,
+        label: e.name,
+        hint: extensionSourceLabel(e.source),
+        active: true,
+      })),
+    ...scopedFailed
+      .filter((e) => !CORE_EXTENSION_NAMES.has(e.name))
+      .filter((e) => !disabledSet.has(e.name))
+      .map((e) => ({
+        id: `ext-failed:${e.name}`,
+        label: e.name,
+        hint: `${extensionSourceLabel(e.source)} · failed`,
+        active: false,
+      })),
+    ...disabled
+      .filter((name) => !CORE_EXTENSION_NAMES.has(name))
+      .map((name) => {
+        const stillLoaded = loaded.some((e) => e.name === name);
+        return {
+          id: `ext-disabled:${name}`,
+          label: name,
+          hint: stillLoaded ? "disabled · restart" : "disabled",
+          active: false,
+        };
+      }),
+  ];
 }
 
 /** Built-in themes always available. CSS for these lives in src/styles/themes.css —
@@ -263,61 +336,12 @@ export function useExtensionsHydration(
     disabled: string[] = [],
     activeProjectPath: string | null = null,
   ) {
-    const scopedLoaded = filterExtensionSummariesByProject(
+    const items = buildExtensionSidebarItems(
       loaded,
-      activeProjectPath,
-    );
-    const scopedFailed = filterExtensionSummariesByProject(
       failed,
+      disabled,
       activeProjectPath,
     );
-    const sourceLabel = (s: string) =>
-      s === "project-directory"
-        ? "project"
-        : s === "global-directory"
-          ? "user"
-          : s === "extension-package"
-            ? "package"
-            : s;
-    const disabledSet = new Set(disabled);
-    // An extension may appear in `loaded` (live this run) but also be
-    // marked disabled (toggle landed mid-session, takes effect after
-    // restart). Show it in the disabled bucket so the user sees their
-    // pending intent, with a hint that a restart is needed to fully
-    // unload it.
-    const items = [
-      {
-        id: "extension-layout",
-        label: "default-layout",
-        hint: "core",
-        active: true,
-      },
-      ...scopedLoaded
-        .filter((e) => !disabledSet.has(e.name))
-        .map((e) => ({
-          id: `ext:${e.name}`,
-          label: e.name,
-          hint: sourceLabel(e.source),
-          active: true,
-        })),
-      ...scopedFailed
-        .filter((e) => !disabledSet.has(e.name))
-        .map((e) => ({
-          id: `ext-failed:${e.name}`,
-          label: e.name,
-          hint: `${sourceLabel(e.source)} · failed`,
-          active: false,
-        })),
-      ...disabled.map((name) => {
-        const stillLoaded = loaded.some((e) => e.name === name);
-        return {
-          id: `ext-disabled:${name}`,
-          label: name,
-          hint: stillLoaded ? "disabled · restart" : "disabled",
-          active: false,
-        };
-      }),
-    ];
     setState((prev) => {
       const sidebar = (prev.sidebar as Record<string, unknown>) ?? {};
       return { ...prev, sidebar: { ...sidebar, extensions: items } };

--- a/src/hooks/useFocus.test.ts
+++ b/src/hooks/useFocus.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { workstationLayout } from "./useFocus";
+import { workstationLayout, workstationRows } from "./useFocus";
 
 describe("workstationLayout", () => {
   it("returns canonical 3-column shape with both sidebars visible", () => {
@@ -24,13 +24,13 @@ describe("workstationLayout", () => {
       true,
       false,
     );
-    expect(result.columns).toBe("220px minmax(0,1fr)");
+    expect(result.columns).toBe("220px minmax(0,1fr) 0px");
     expect(result.areas).toEqual([
-      "sidebar header",
-      "sidebar canvas",
-      "sidebar terminal",
-      "sidebar composer",
-      "status status",
+      "sidebar header files-sidebar",
+      "sidebar canvas files-sidebar",
+      "sidebar terminal files-sidebar",
+      "sidebar composer files-sidebar",
+      "status status status",
     ]);
   });
 
@@ -40,13 +40,13 @@ describe("workstationLayout", () => {
       false,
       true,
     );
-    expect(result.columns).toBe("minmax(0,1fr) 280px");
+    expect(result.columns).toBe("0px minmax(0,1fr) 280px");
     expect(result.areas).toEqual([
-      "header files-sidebar",
-      "canvas files-sidebar",
-      "terminal files-sidebar",
-      "composer files-sidebar",
-      "status status",
+      "sidebar header files-sidebar",
+      "sidebar canvas files-sidebar",
+      "sidebar terminal files-sidebar",
+      "sidebar composer files-sidebar",
+      "status status status",
     ]);
   });
 
@@ -56,13 +56,13 @@ describe("workstationLayout", () => {
       false,
       false,
     );
-    expect(result.columns).toBe("minmax(0,1fr)");
+    expect(result.columns).toBe("0px minmax(0,1fr) 0px");
     expect(result.areas).toEqual([
-      "header",
-      "canvas",
-      "terminal",
-      "composer",
-      "status",
+      "sidebar header files-sidebar",
+      "sidebar canvas files-sidebar",
+      "sidebar terminal files-sidebar",
+      "sidebar composer files-sidebar",
+      "status status status",
     ]);
   });
 
@@ -108,5 +108,38 @@ describe("workstationLayout", () => {
     expect(
       workstationLayout({ columns: "garbage" }, true, true).columns,
     ).toBe("220px minmax(0,1fr) 280px");
+  });
+
+  it("animates hidden chrome tracks with 0px sentinels but preserves memos", () => {
+    const hidden = workstationLayout(
+      {
+        columns: "0px minmax(0,1fr) 0px",
+        lastLeftWidth: "330px",
+        lastRightWidth: "410px",
+      },
+      true,
+      true,
+    );
+    expect(hidden.columns).toBe("330px minmax(0,1fr) 410px");
+  });
+});
+
+describe("workstationRows", () => {
+  it("uses a fixed terminal track so console toggles can animate", () => {
+    expect(workstationRows(false, 240)).toBe(
+      "38px minmax(0,1fr) 0px auto auto",
+    );
+    expect(workstationRows(true, 360)).toBe(
+      "38px minmax(0,1fr) 360px auto auto",
+    );
+  });
+
+  it("clamps terminal track height", () => {
+    expect(workstationRows(true, 10)).toBe(
+      "38px minmax(0,1fr) 120px auto auto",
+    );
+    expect(workstationRows(true, 900)).toBe(
+      "38px minmax(0,1fr) 720px auto auto",
+    );
   });
 });

--- a/src/hooks/useFocus.ts
+++ b/src/hooks/useFocus.ts
@@ -24,6 +24,7 @@ export interface UseFocusActions {
 
 const DEFAULT_LEFT_WIDTH = "220px";
 const DEFAULT_RIGHT_WIDTH = "280px";
+const DEFAULT_TERMINAL_HEIGHT = 240;
 
 function parseWidth(token: string | undefined, fallback: string): string {
   return token && /^\d+px$/.test(token) ? token : fallback;
@@ -31,7 +32,8 @@ function parseWidth(token: string | undefined, fallback: string): string {
 
 /**
  * Pick out the left + right px widths from any of the workstation's
- * column shapes. The grid template can be:
+ * column shapes. The modern grid stays 3-column so hidden sidebars can
+ * animate as 0px tracks, but older persisted state may still have:
  *   [L, 1fr, R]   3-column (canonical)
  *   [L, 1fr]      2-column left-only
  *   [1fr, R]      2-column right-only
@@ -56,17 +58,24 @@ function pickWidths(current: {
   // shape) or when the last token is px AND the layout had no left
   // sidebar (2-col right-only).
   const inferredLeft =
-    first && /^minmax/.test(first) ? undefined : first;
+    first && !/^minmax/.test(first) && first !== "0px" ? first : undefined;
   const inferredRight =
-    tokens.length >= 3 && last && /^\d+px$/.test(last)
+    tokens.length >= 3 && last && /^\d+px$/.test(last) && last !== "0px"
       ? last
-      : tokens.length === 2 && last && /^\d+px$/.test(last) && first && /^minmax/.test(first)
+      : tokens.length === 2 &&
+          last &&
+          /^\d+px$/.test(last) &&
+          last !== "0px" &&
+          first &&
+          /^minmax/.test(first)
         ? last
         : undefined;
-  const memoLeft =
-    typeof current.lastLeftWidth === "string" ? current.lastLeftWidth : undefined;
-  const memoRight =
-    typeof current.lastRightWidth === "string" ? current.lastRightWidth : undefined;
+  const memoLeft = typeof current.lastLeftWidth === "string"
+    ? current.lastLeftWidth
+    : undefined;
+  const memoRight = typeof current.lastRightWidth === "string"
+    ? current.lastRightWidth
+    : undefined;
   return {
     left: parseWidth(inferredLeft ?? memoLeft, DEFAULT_LEFT_WIDTH),
     right: parseWidth(inferredRight ?? memoRight, DEFAULT_RIGHT_WIDTH),
@@ -76,8 +85,8 @@ function pickWidths(current: {
 /**
  * Compose the workstation grid template from `{left, right}` visibility +
  * the user's most-recently-resized widths. Layout-as-payload means the
- * sidebar can't just `display: none` — the grid column would still claim
- * space — so each toggle has to rewrite `columns` and `areas` in lockstep.
+ * sidebar can't just `display: none` — that snaps in WebKit. Keep a
+ * stable 3-column grid and animate hidden chrome tracks down to 0px.
  *
  * Width tokens are pulled from the current `layout.columns` so user
  * resizes survive a hide/show round-trip; falls back to the boot defaults
@@ -99,19 +108,13 @@ export function workstationLayout(
 } {
   const { left, right } = pickWidths(current);
 
-  const parts: string[] = [];
-  const areaCols: string[] = [];
-  if (leftVisible) {
-    parts.push(left);
-    areaCols.push("sidebar");
-  }
-  parts.push("minmax(0,1fr)");
-  const centerIndex = areaCols.length;
-  areaCols.push("__center__");
-  if (rightVisible) {
-    parts.push(right);
-    areaCols.push("files-sidebar");
-  }
+  const parts = [
+    leftVisible ? left : "0px",
+    "minmax(0,1fr)",
+    rightVisible ? right : "0px",
+  ];
+  const areaCols = ["sidebar", "__center__", "files-sidebar"];
+  const centerIndex = 1;
 
   const rowFor = (centerName: string) => {
     const cols = [...areaCols];
@@ -134,6 +137,24 @@ export function workstationLayout(
   };
 }
 
+function terminalHeightFromState(state: Record<string, unknown>): number {
+  const panel = state.terminalPanel as { height?: unknown } | undefined;
+  const height = panel?.height;
+  return typeof height === "number" && Number.isFinite(height)
+    ? Math.max(120, Math.min(720, Math.round(height)))
+    : DEFAULT_TERMINAL_HEIGHT;
+}
+
+export function workstationRows(
+  terminalOpen: boolean,
+  terminalHeight: number,
+): string {
+  const terminalTrack = terminalOpen
+    ? `${Math.max(120, Math.min(720, Math.round(terminalHeight)))}px`
+    : "0px";
+  return `38px minmax(0,1fr) ${terminalTrack} auto auto`;
+}
+
 /**
  * Focus + chrome-toggle helpers. The hook owns:
  *   - terminal panel toggling (open/close + focus shuttle)
@@ -152,7 +173,16 @@ export function useFocus(ctx: UseFocusContext): UseFocusActions {
   function toggleTerminal() {
     setState((prev) => {
       const term = (prev.terminal as { open?: boolean; output?: string }) ?? {};
-      return { ...prev, terminal: { ...term, open: !term.open } };
+      const nextOpen = !term.open;
+      const layout = (prev.layout as Record<string, unknown> | undefined) ?? {};
+      return {
+        ...prev,
+        terminal: { ...term, open: nextOpen },
+        layout: {
+          ...layout,
+          rows: workstationRows(nextOpen, terminalHeightFromState(prev)),
+        },
+      };
     });
   }
 
@@ -219,7 +249,15 @@ export function useFocus(ctx: UseFocusContext): UseFocusActions {
       // Open first, then focus on the next frame.
       setState((prev) => {
         const t = (prev.terminal as { open?: boolean } | undefined) ?? {};
-        return { ...prev, terminal: { ...t, open: true } };
+        const layout = (prev.layout as Record<string, unknown> | undefined) ?? {};
+        return {
+          ...prev,
+          terminal: { ...t, open: true },
+          layout: {
+            ...layout,
+            rows: workstationRows(true, terminalHeightFromState(prev)),
+          },
+        };
       });
     }
     requestAnimationFrame(() => focusTerminalPanel());
@@ -239,7 +277,16 @@ export function useFocus(ctx: UseFocusContext): UseFocusActions {
       if (!term.open) {
         setState((prev) => {
           const t = (prev.terminal as { open?: boolean } | undefined) ?? {};
-          return { ...prev, terminal: { ...t, open: true } };
+          const layout =
+            (prev.layout as Record<string, unknown> | undefined) ?? {};
+          return {
+            ...prev,
+            terminal: { ...t, open: true },
+            layout: {
+              ...layout,
+              rows: workstationRows(true, terminalHeightFromState(prev)),
+            },
+          };
         });
       }
       requestAnimationFrame(() => focusTerminalPanel());

--- a/src/hooks/useKeyboardShortcuts.test.tsx
+++ b/src/hooks/useKeyboardShortcuts.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import type { MutableRefObject } from "react";
+import {
+  useKeyboardShortcuts,
+  type UseKeyboardShortcutsContext,
+} from "./useKeyboardShortcuts";
+
+afterEach(() => {
+  cleanup();
+});
+
+const ref = <T,>(value: T): MutableRefObject<T> => ({ current: value });
+
+function Harness({ ctx }: { ctx: UseKeyboardShortcutsContext }) {
+  useKeyboardShortcuts(ctx);
+  return null;
+}
+
+function buildContext(
+  state: Record<string, unknown>,
+): UseKeyboardShortcutsContext {
+  return {
+    stateRef: ref(state),
+    extensionKeybindingsRef: ref(new Map()),
+    shortcutsNewTabKindRef: ref("agent"),
+    toggleTerminalAndFocus: vi.fn(),
+    toggleSidebar: vi.fn(),
+    toggleFilesSidebar: vi.fn(),
+    toggleEditorPreview: vi.fn(),
+    clearChat: vi.fn(),
+    stopPrompt: vi.fn(),
+    newTab: vi.fn(),
+    newShellTab: vi.fn(),
+    nextTab: vi.fn(),
+    nextShellSubTab: vi.fn(),
+    moveActiveTab: vi.fn(),
+    moveActiveShellSubTab: vi.fn(),
+    jumpToTab: vi.fn(),
+    jumpToShellSubTab: vi.fn(),
+    reopenLastClosedTab: vi.fn(),
+    closeTab: vi.fn(),
+    toggleSessionSearch: vi.fn(),
+    openPalette: vi.fn(),
+    closePalette: vi.fn(),
+    adjustZoom: vi.fn(),
+    resetZoom: vi.fn(),
+    toggleFocusComposerTerminal: vi.fn(),
+    toggleSettings: vi.fn(),
+    closeSettings: vi.fn(),
+    focusActiveContextInput: vi.fn(),
+    exportActiveChatMarkdown: vi.fn(() => Promise.resolve()),
+    pushNotification: vi.fn(),
+  };
+}
+
+describe("useKeyboardShortcuts Escape handling", () => {
+  it("closes Settings when it is the active overlay", () => {
+    const ctx = buildContext({
+      palette: { open: false },
+      settings: { open: true },
+    });
+    render(<Harness ctx={ctx} />);
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(ctx.closeSettings).toHaveBeenCalledTimes(1);
+    expect(ctx.closePalette).not.toHaveBeenCalled();
+  });
+
+  it("keeps palette precedence over Settings", () => {
+    const ctx = buildContext({
+      palette: { open: true },
+      settings: { open: true },
+    });
+    render(<Harness ctx={ctx} />);
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(ctx.closePalette).toHaveBeenCalledTimes(1);
+    expect(ctx.closeSettings).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -52,6 +52,7 @@ export interface UseKeyboardShortcutsContext {
   resetZoom: () => void;
   toggleFocusComposerTerminal: () => void;
   toggleSettings: () => void;
+  closeSettings: () => void;
   focusActiveContextInput: () => void;
   exportActiveChatMarkdown: () => Promise<void>;
   pushNotification: (n: NotificationInput) => void;
@@ -279,7 +280,8 @@ export function useKeyboardShortcuts(ctx: UseKeyboardShortcutsContext): void {
         ctx.openPalette("files");
         return;
       }
-      // Esc closes the palette when open.
+      // Esc closes the active overlay, with palette taking precedence
+      // because it can sit on top of Settings.
       if (e.key === "Escape") {
         const palette = ctx.stateRef.current.palette as
           | { open?: boolean }
@@ -288,6 +290,15 @@ export function useKeyboardShortcuts(ctx: UseKeyboardShortcutsContext): void {
           e.preventDefault();
           e.stopPropagation();
           ctx.closePalette();
+          return;
+        }
+        const settings = ctx.stateRef.current.settings as
+          | { open?: boolean }
+          | undefined;
+        if (settings?.open) {
+          e.preventDefault();
+          e.stopPropagation();
+          ctx.closeSettings();
           return;
         }
       }

--- a/src/hooks/useOsEdges.ts
+++ b/src/hooks/useOsEdges.ts
@@ -47,6 +47,7 @@ export interface UseOsEdgesContext {
   // ─── Focus + chrome ─────────────────────────────────────────────────
   toggleTerminal: () => void;
   toggleFilesSidebar: () => void;
+  openSettings: (section?: string) => void;
 
   // ─── Notifications ──────────────────────────────────────────────────
   pushNotification: (n: NotificationInput) => string;
@@ -94,6 +95,7 @@ export function useOsEdges(ctx: UseOsEdgesContext): void {
     stopPrompt,
     toggleTerminal,
     toggleFilesSidebar,
+    openSettings,
     pushNotification,
     dismissNotification,
     checkForUpdates,
@@ -353,6 +355,7 @@ export function useOsEdges(ctx: UseOsEdgesContext): void {
           break;
         }
         case "toggle_files_sidebar": toggleFilesSidebar(); break;
+        case "manage_extensions": openSettings("extensions"); break;
         case "clear_chat": clearChat(); break;
         case "stop_prompt": void stopPrompt(); break;
         case "check_updates": {

--- a/src/hooks/useProjectOps.test.ts
+++ b/src/hooks/useProjectOps.test.ts
@@ -1,10 +1,72 @@
-import { describe, expect, it } from "vitest";
+// @vitest-environment jsdom
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { NO_PROJECT_KEY, type Tab } from "../types/tab";
+import type { ProjectsState } from "../projects";
+import { installTauriMocks, clearTauriMocks } from "../test/tauriMocks";
 import {
   nonEmptyProjectTabs,
   projectIdFromBucketKey,
   tabsForProjectBucket,
+  useProjectOps,
+  type UseProjectOpsContext,
 } from "./useProjectOps";
+
+afterEach(() => {
+  clearTauriMocks();
+});
+
+const ref = <T,>(value: T) => ({ current: value });
+
+function makeProjectsState(
+  overrides: Partial<ProjectsState> = {},
+): ProjectsState {
+  return {
+    projects: [
+      {
+        id: "project-1",
+        label: "aethon",
+        path: "/projects/aethon",
+        lastUsed: 1,
+      },
+    ],
+    activeId: null,
+    activeWorktreeId: null,
+    worktreesByProject: {},
+    activeHostId: null,
+    ...overrides,
+  };
+}
+
+function renderProjectOps(initialProjects: ProjectsState) {
+  const stateRef = ref<Record<string, unknown>>({
+    tabs: [],
+    activeTabId: undefined,
+  });
+  const projectsRef = ref(initialProjects);
+  const setState = vi.fn((next) => {
+    stateRef.current =
+      typeof next === "function" ? next(stateRef.current) : next;
+  });
+  const ctx: UseProjectOpsContext = {
+    setState,
+    stateRef,
+    projectsRef,
+    piDefaultModelRef: ref("gpt-5.5"),
+    gitStatusRef: ref(new Map()),
+    refreshGitStatusFor: vi.fn(() => Promise.resolve()),
+    refreshAllGitStatus: vi.fn(() => Promise.resolve()),
+    announceProjectToBridge: vi.fn(),
+    watchProjectForBridge: vi.fn(),
+    unwatchProjectForBridge: vi.fn(),
+    dispatchTerminalReplay: vi.fn(),
+    autoRestoreDiscoveredSessions: vi.fn(),
+  };
+  const rendered = renderHook(() => useProjectOps(ctx));
+  projectsRef.current = initialProjects;
+  return { ...rendered, projectsRef, stateRef, setState };
+}
 
 describe("projectIdFromBucketKey", () => {
   it("maps the no-project bucket back to null", () => {
@@ -62,5 +124,100 @@ describe("nonEmptyProjectTabs", () => {
       "chat",
       "shell",
     ]);
+  });
+});
+
+describe("useProjectOps worktree refresh", () => {
+  it("refreshes worktrees when reselecting a project with cached rows", async () => {
+    const harness = installTauriMocks();
+    harness.invoke.mockImplementation((cmd: string) => {
+      if (cmd === "git_worktrees") {
+        return Promise.resolve([
+          {
+            path: "/projects/aethon",
+            branch: "main",
+            head: "abc123",
+            isMain: true,
+            locked: false,
+          },
+        ]);
+      }
+      return Promise.resolve(undefined);
+    });
+    const cached = {
+      id: "wt-cached",
+      projectId: "project-1",
+      path: "/projects/aethon-old",
+      branch: "old",
+      isMain: false,
+    };
+    const { result } = renderProjectOps(
+      makeProjectsState({
+        worktreesByProject: { "project-1": [cached] },
+      }),
+    );
+
+    act(() => {
+      expect(result.current.setActiveProjectById("project-1")).toBe(true);
+    });
+
+    await waitFor(() => {
+      expect(harness.invoke).toHaveBeenCalledWith("git_worktrees", {
+        projectPath: "/projects/aethon",
+      });
+    });
+  });
+
+  it("clears a stale active worktree missing from a fresh git listing", async () => {
+    const harness = installTauriMocks();
+    harness.invoke.mockImplementation((cmd: string) => {
+      if (cmd === "git_worktrees") {
+        return Promise.resolve([
+          {
+            path: "/projects/aethon",
+            branch: "main",
+            head: "abc123",
+            isMain: true,
+            locked: false,
+          },
+        ]);
+      }
+      return Promise.resolve(undefined);
+    });
+    const staleWorktree = {
+      id: "wt-deleted",
+      projectId: "project-1",
+      path: "/projects/aethon-deleted",
+      branch: "deleted",
+      isMain: false,
+    };
+    const { result, projectsRef } = renderProjectOps(
+      makeProjectsState({
+        activeId: "project-1",
+        activeWorktreeId: "wt-deleted",
+        worktreesByProject: { "project-1": [staleWorktree] },
+      }),
+    );
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    projectsRef.current = makeProjectsState({
+      activeId: "project-1",
+      activeWorktreeId: "wt-deleted",
+      worktreesByProject: { "project-1": [staleWorktree] },
+    });
+
+    await act(async () => {
+      await result.current.refreshProjectWorktrees("project-1");
+    });
+
+    expect(projectsRef.current.activeWorktreeId).toBeNull();
+    expect(projectsRef.current.worktreesByProject["project-1"]).toHaveLength(1);
+    expect(projectsRef.current.worktreesByProject["project-1"]?.[0]).toMatchObject({
+      path: "/projects/aethon",
+      branch: "main",
+      isMain: true,
+    });
   });
 });

--- a/src/hooks/useProjectOps.ts
+++ b/src/hooks/useProjectOps.ts
@@ -609,12 +609,11 @@ export function useProjectOps(
       unwatchProjectForBridge(previousActive.path);
     }
     watchProjectForBridge(target.path);
-    // Fire-and-forget worktree refresh — populates the disclosure rows
-    // on first switch. The data lives in `worktreesByProject[id]` and
-    // surfaces through syncProjectsToState.
-    if (!projectsRef.current.worktreesByProject[id]) {
-      void refreshProjectWorktrees(id);
-    }
+    // Fire-and-forget worktree refresh on every switch. External git
+    // worktree adds/removes/locks can happen while the user is looking
+    // at another project, so cached rows are only a fast initial paint,
+    // not a reason to skip discovery.
+    void refreshProjectWorktrees(id);
     return true;
   }
 
@@ -752,11 +751,20 @@ export function useProjectOps(
       const listing = await gitWorktrees(project.path);
       const prior = projectsRef.current.worktreesByProject[projectId] ?? [];
       const next = reconcileWorktrees(projectId, prior, listing);
-      projectsRef.current = setProjectWorktrees(
+      let nextState = setProjectWorktrees(
         projectsRef.current,
         projectId,
         next,
       );
+      const activeWorktreeId = nextState.activeWorktreeId;
+      if (
+        nextState.activeId === projectId &&
+        activeWorktreeId &&
+        !next.some((w) => w.id === activeWorktreeId)
+      ) {
+        nextState = { ...nextState, activeWorktreeId: null };
+      }
+      projectsRef.current = nextState;
       void persistProjects();
     } catch {
       // Swallow; project might not be a git repo. The UI shows zero

--- a/src/hooks/useProjectOps.ts
+++ b/src/hooks/useProjectOps.ts
@@ -514,7 +514,7 @@ export function useProjectOps(
       path,
       label,
     );
-    projectsRef.current = nextProjects;
+    projectsRef.current = { ...nextProjects, activeWorktreeId: null };
     persistProjects();
     // Fetch git status for the (possibly new) project so the chip
     // appears on the same render that adds the row, not 30s later.
@@ -542,6 +542,7 @@ export function useProjectOps(
         p.id === id ? { ...p, lastUsed: Date.now() } : p,
       ),
       activeId: id,
+      activeWorktreeId: null,
     };
     persistProjects();
     const nextTabId = switchProjectBucket(fromKey, toKey);
@@ -565,7 +566,11 @@ export function useProjectOps(
   function clearActiveProject() {
     const fromKey = projectBucketKey(projectsRef.current.activeId);
     const previousActive = activeProject(projectsRef.current);
-    projectsRef.current = { ...projectsRef.current, activeId: null };
+    projectsRef.current = {
+      ...projectsRef.current,
+      activeId: null,
+      activeWorktreeId: null,
+    };
     persistProjects();
     const nextTabId = switchProjectBucket(fromKey, NO_PROJECT_KEY);
     syncRecentSessionsToState();

--- a/src/hooks/useProjectOps.ts
+++ b/src/hooks/useProjectOps.ts
@@ -161,7 +161,10 @@ export interface UseProjectOpsActions {
     targetPath?: string;
     baseBranch?: string;
   }) => Promise<string | null>;
-  removeWorktreeById: (worktreeId: string) => Promise<void>;
+  removeWorktreeById: (
+    worktreeId: string,
+    opts?: { confirmed?: boolean },
+  ) => Promise<void>;
   dismissPendingWorktree: (worktreeId: string) => void;
   retryPendingWorktree: (worktreeId: string) => Promise<void>;
   renameWorktree: (worktreeId: string, label: string) => void;
@@ -246,6 +249,36 @@ export function useProjectOps(
   const tabBucketsRef = useRef<
     Map<string, { tabs: Tab[]; activeTabId: string | undefined }>
   >(new Map());
+  const projectSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+
+  function saveProjectsBestEffort(snapshot: ProjectsState): void {
+    void saveProjects(snapshot).catch((err) => {
+      console.warn("saveProjects failed:", err);
+    });
+  }
+
+  function scheduleProjectsSave(delayMs = 250): void {
+    if (projectSaveTimerRef.current !== null) {
+      clearTimeout(projectSaveTimerRef.current);
+    }
+    projectSaveTimerRef.current = setTimeout(() => {
+      projectSaveTimerRef.current = null;
+      saveProjectsBestEffort(projectsRef.current);
+    }, delayMs);
+  }
+
+  useEffect(() => {
+    return () => {
+      if (projectSaveTimerRef.current !== null) {
+        clearTimeout(projectSaveTimerRef.current);
+        projectSaveTimerRef.current = null;
+        saveProjectsBestEffort(projectsRef.current);
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const buildSidebarHistory = useCallback((
     tabs: Tab[],
@@ -350,56 +383,64 @@ export function useProjectOps(
   // Carries the cached git status from gitStatusRef so a sync triggered
   // for non-git reasons (lastUsed bump, label change) doesn't drop the
   // badges.
-  function syncProjectsToState() {
+  function buildProjectsMirror(
+    prev: Record<string, unknown>,
+    tabsForRecent?: Tab[],
+  ): Record<string, unknown> {
     const ps = projectsRef.current;
     const active = activeProject(ps);
+    const sidebar = (prev.sidebar as Record<string, unknown> | undefined) ?? {};
+    const tabs = tabsForRecent ?? ((prev.tabs as Tab[] | undefined) ?? []);
+    const tabIds = new Set(tabs.map((t) => t.id).concat(["default"]));
+    return {
+      projects: ps.projects,
+      activeProjectId: ps.activeId,
+      activeWorktreeId: ps.activeWorktreeId,
+      project: active
+        ? { id: active.id, label: active.label, path: active.path }
+        : null,
+      sessionLabel: active ? active.label : "",
+      sidebar: {
+        ...sidebar,
+        projects: ps.projects.map((p) => {
+          const wts = ps.worktreesByProject[p.id] ?? [];
+          return {
+            id: p.id,
+            // Basename is what we surface; the absolute path lives
+            // behind the row's native tooltip (title attribute) so
+            // the row label stays compact even with deep paths.
+            label: p.label,
+            tooltip: p.path,
+            iconUrl: p.iconUrl,
+            active: p.id === ps.activeId,
+            git: gitStatusRef.current.get(p.path),
+            expanded: p.uiExpanded === true,
+            worktrees: wts.map((w) => ({
+              id: w.id,
+              label: w.label ?? w.branch ?? "worktree",
+              branch: w.branch,
+              path: w.path,
+              active: w.id === ps.activeWorktreeId,
+              isMain: w.isMain,
+              pendingState: w.pendingState,
+              pendingError: w.pendingError,
+              locked: w.locked,
+            })),
+          };
+        }),
+      },
+      recentSessions: recentSessionItems(
+        scopedDiscoveredSessions(allDiscoveredSessionsRef.current),
+        tabIds,
+      ),
+    };
+  }
+
+  function syncProjectsToState() {
     setState((prev) => {
-      const sidebar = (prev.sidebar as Record<string, unknown> | undefined) ?? {};
-      const tabIds = new Set(
-        (((prev.tabs as Tab[] | undefined) ?? []).map((t) => t.id)).concat(["default"]),
-      );
       return {
         ...prev,
-        projects: ps.projects,
-        activeProjectId: ps.activeId,
-        activeWorktreeId: ps.activeWorktreeId,
-        project: active
-          ? { id: active.id, label: active.label, path: active.path }
-          : null,
-        sessionLabel: active ? active.label : "",
-        sidebar: {
-          ...sidebar,
-          projects: ps.projects.map((p) => {
-            const wts = ps.worktreesByProject[p.id] ?? [];
-            return {
-              id: p.id,
-              // Basename is what we surface; the absolute path lives
-              // behind the row's native tooltip (title attribute) so
-              // the row label stays compact even with deep paths.
-              label: p.label,
-              tooltip: p.path,
-              iconUrl: p.iconUrl,
-              active: p.id === ps.activeId,
-              git: gitStatusRef.current.get(p.path),
-              expanded: p.uiExpanded === true,
-              worktrees: wts.map((w) => ({
-                id: w.id,
-                label: w.label ?? w.branch ?? "worktree",
-                branch: w.branch,
-                path: w.path,
-                active: w.id === ps.activeWorktreeId,
-                isMain: w.isMain,
-                pendingState: w.pendingState,
-                pendingError: w.pendingError,
-                locked: w.locked,
-              })),
-            };
-          }),
-        },
-        recentSessions: recentSessionItems(
-          scopedDiscoveredSessions(allDiscoveredSessionsRef.current),
-          tabIds,
-        ),
+        ...buildProjectsMirror(prev),
       };
     });
   }
@@ -423,8 +464,15 @@ export function useProjectOps(
   // immediately. If the new project has no bucket yet, we leave tabs
   // empty + flip /empty so the empty-state composite renders. Project
   // switching never creates conversation tabs.
-  function switchProjectBucket(fromKey: string, toKey: string): string | undefined {
+  function switchProjectBucket(
+    fromKey: string,
+    toKey: string,
+    opts: { mirrorProjects?: boolean } = {},
+  ): string | undefined {
     if (fromKey === toKey) {
+      if (opts.mirrorProjects === true) {
+        setState((prev) => ({ ...prev, ...buildProjectsMirror(prev) }));
+      }
       return stateRef.current.activeTabId as string | undefined;
     }
     let nextTerminalBuffer = "";
@@ -494,6 +542,9 @@ export function useProjectOps(
         result.hasTabs = next.tabs.length > 0;
         nextTerminalBuffer = "";
       }
+      if (opts.mirrorProjects === true) {
+        Object.assign(result, buildProjectsMirror(result, next.tabs));
+      }
       return result;
     });
     // Replay the new active tab's terminal buffer (or clear if none).
@@ -515,15 +566,16 @@ export function useProjectOps(
       label,
     );
     projectsRef.current = { ...nextProjects, activeWorktreeId: null };
-    persistProjects();
     // Fetch git status for the (possibly new) project so the chip
     // appears on the same render that adds the row, not 30s later.
     void refreshGitStatusFor(path);
     // Switch to the project's tab bucket BEFORE notifying the bridge.
     // If this is a brand-new project, the bucket is empty and the empty
     // state composite renders until the user explicitly creates a tab.
-    const nextTabId = switchProjectBucket(fromKey, projectBucketKey(id));
-    syncRecentSessionsToState();
+    const nextTabId = switchProjectBucket(fromKey, projectBucketKey(id), {
+      mirrorProjects: true,
+    });
+    scheduleProjectsSave();
     const tabId = nextTabId ?? "default";
     announceProjectToBridge(tabId, path);
     return id;
@@ -544,9 +596,10 @@ export function useProjectOps(
       activeId: id,
       activeWorktreeId: null,
     };
-    persistProjects();
-    const nextTabId = switchProjectBucket(fromKey, toKey);
-    syncRecentSessionsToState();
+    const nextTabId = switchProjectBucket(fromKey, toKey, {
+      mirrorProjects: true,
+    });
+    scheduleProjectsSave();
     const tabId = nextTabId ?? "default";
     announceProjectToBridge(tabId, target.path);
     // Swap the file-watcher's project ext dir so edits in the new
@@ -559,7 +612,9 @@ export function useProjectOps(
     // Fire-and-forget worktree refresh — populates the disclosure rows
     // on first switch. The data lives in `worktreesByProject[id]` and
     // surfaces through syncProjectsToState.
-    void refreshProjectWorktrees(id);
+    if (!projectsRef.current.worktreesByProject[id]) {
+      void refreshProjectWorktrees(id);
+    }
     return true;
   }
 
@@ -571,9 +626,10 @@ export function useProjectOps(
       activeId: null,
       activeWorktreeId: null,
     };
-    persistProjects();
-    const nextTabId = switchProjectBucket(fromKey, NO_PROJECT_KEY);
-    syncRecentSessionsToState();
+    const nextTabId = switchProjectBucket(fromKey, NO_PROJECT_KEY, {
+      mirrorProjects: true,
+    });
+    scheduleProjectsSave();
     const tabId = nextTabId ?? "default";
     announceProjectToBridge(tabId, null);
     if (previousActive) unwatchProjectForBridge(previousActive.path);
@@ -719,7 +775,8 @@ export function useProjectOps(
     if (expanded && !projectsRef.current.worktreesByProject[projectId]) {
       void refreshProjectWorktrees(projectId);
     }
-    void persistProjects();
+    syncProjectsToState();
+    scheduleProjectsSave();
   }
 
   function setProjectIconUrl(projectId: string, iconUrl: string | null): void {
@@ -730,11 +787,13 @@ export function useProjectOps(
   }
 
   function activateWorktree(worktreeId: string | null): void {
+    if (projectsRef.current.activeWorktreeId === worktreeId) return;
     projectsRef.current = setActiveWorktreeState(
       projectsRef.current,
       worktreeId,
     );
-    void persistProjects();
+    setState((prev) => ({ ...prev, ...buildProjectsMirror(prev) }));
+    scheduleProjectsSave();
   }
 
   // Branch / target path defaults for the "Create worktree" prompt. The
@@ -837,7 +896,10 @@ export function useProjectOps(
     }
   }
 
-  async function removeWorktreeById(worktreeId: string): Promise<void> {
+  async function removeWorktreeById(
+    worktreeId: string,
+    opts: { confirmed?: boolean } = {},
+  ): Promise<void> {
     const hit = findProjectOfWorktree(worktreeId);
     if (!hit) return;
     const { project, worktree } = hit;
@@ -846,8 +908,10 @@ export function useProjectOps(
       return;
     }
     const label = worktree.label ?? worktree.branch ?? "worktree";
-    const ok = window.confirm(`Remove worktree '${label}'?`);
-    if (!ok) return;
+    if (opts.confirmed !== true) {
+      const ok = window.confirm(`Remove worktree '${label}'?`);
+      if (!ok) return;
+    }
     try {
       await gitWorktreeRemove({
         projectPath: project.path,

--- a/src/hooks/useTabs.ts
+++ b/src/hooks/useTabs.ts
@@ -181,7 +181,7 @@ export interface UseTabsActions {
   /** Open (or focus, if already open) an editor tab for `filePath`.
    *  `filePath` must be inside the active project; the EditorCanvas
    *  composite handles the actual fs_read_file call on mount. */
-  newEditorTab: (filePath: string) => void;
+  newEditorTab: (filePath: string, opts?: { rootPath?: string }) => void;
   /** Set the dirty flag + cursor on the active editor tab. Used by
    *  EditorCanvas to mirror Monaco's model state back to the layout. */
   updateEditorMeta: (tabId: string, patch: Partial<EditorMeta>) => void;
@@ -563,11 +563,15 @@ export function useTabs(ctx: UseTabsContext): UseTabsActions {
   /** Open (or focus) an editor tab for the supplied absolute path. If a
    *  tab for the same path already exists in the current project bucket,
    *  switch to it instead of creating a duplicate. */
-  function newEditorTab(filePath: string) {
+  function newEditorTab(filePath: string, opts: { rootPath?: string } = {}) {
     if (!filePath) return;
+    const rootPath = opts.rootPath;
     const tabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
     const existing = tabs.find(
-      (t) => t.kind === "editor" && t.editor?.filePath === filePath,
+      (t) =>
+        t.kind === "editor" &&
+        t.editor?.filePath === filePath &&
+        (t.editor.rootPath ?? "") === (rootPath ?? ""),
     );
     if (existing) {
       setActiveTab(existing.id);
@@ -580,6 +584,7 @@ export function useTabs(ctx: UseTabsContext): UseTabsActions {
       ...makeEmptyTab(id, editorLabelForPath(filePath), projectId, "editor"),
       editor: {
         filePath,
+        ...(rootPath ? { rootPath } : {}),
         language,
         isDirty: false,
       },

--- a/src/hooks/useUiOverlays.ts
+++ b/src/hooks/useUiOverlays.ts
@@ -60,6 +60,7 @@ export interface UseUiOverlaysContext {
 
 export interface UseUiOverlaysActions {
   // ─── Settings ───────────────────────────────────────────────────────
+  openSettings: (section?: string) => void;
   toggleSettings: () => void;
   closeSettings: () => void;
   applySettingsPatch: (
@@ -135,19 +136,30 @@ export function useUiOverlays(
    *  open via `getConfig()`, exposes form bindings via the
    *  `/settings/pending` slice, and writes back via the
    *  `write_config` Tauri command on Save. */
+  function openSettings(section?: string) {
+    setState((prev) => ({
+      ...prev,
+      settings: {
+        open: true,
+        pending: null,
+        focusSection: section ?? null,
+      },
+    }));
+  }
+
   function toggleSettings() {
     setState((prev) => {
       const cur = (prev.settings as { open?: boolean } | undefined) ?? {};
       return {
         ...prev,
-        settings: { open: !cur.open, pending: null },
+        settings: { open: !cur.open, pending: null, focusSection: null },
       };
     });
   }
   function closeSettings() {
     setState((prev) => ({
       ...prev,
-      settings: { open: false, pending: null },
+      settings: { open: false, pending: null, focusSection: null },
     }));
   }
   /** Apply a partial AethonConfig patch to `/settings/pending`. The
@@ -512,6 +524,7 @@ export function useUiOverlays(
   }
 
   return {
+    openSettings,
     toggleSettings,
     closeSettings,
     applySettingsPatch,

--- a/src/layoutPrefs.test.ts
+++ b/src/layoutPrefs.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearLayoutPrefs,
+  layoutPrefsFromState,
+  loadLayoutPrefsSync,
+  mergeLayoutPrefsIntoState,
+  resetLayoutPrefsInState,
+  saveLayoutPrefs,
+} from "./layoutPrefs";
+
+describe("layoutPrefs", () => {
+  beforeEach(() => {
+    const store = new Map<string, string>();
+    vi.stubGlobal("window", {
+      localStorage: {
+        getItem: vi.fn((key: string) => store.get(key) ?? null),
+        setItem: vi.fn((key: string, value: string) => {
+          store.set(key, value);
+        }),
+        removeItem: vi.fn((key: string) => {
+          store.delete(key);
+        }),
+        clear: vi.fn(() => {
+          store.clear();
+        }),
+      },
+    });
+  });
+
+  it("extracts durable chrome layout prefs even when no tabs exist", () => {
+    const prefs = layoutPrefsFromState({
+      tabs: [],
+      layout: {
+        sidebarVisible: false,
+        filesSidebarVisible: true,
+        columns: "302px minmax(0,1fr) 480px",
+        lastLeftWidth: "302px",
+        lastRightWidth: "480px",
+        areas: ["header header", "canvas files-sidebar"],
+      },
+      terminalPanel: { activeSubId: "agent-bash", height: 360 },
+    });
+    expect(prefs).toEqual({
+      layout: {
+        sidebarVisible: false,
+        filesSidebarVisible: true,
+        columns: "302px minmax(0,1fr) 480px",
+        lastLeftWidth: "302px",
+        lastRightWidth: "480px",
+        areas: ["header header", "canvas files-sidebar"],
+      },
+      terminalPanel: { height: 360 },
+    });
+  });
+
+  it("saves and synchronously reloads layout prefs from localStorage", async () => {
+    const writer = vi.fn(() => Promise.resolve(true));
+    await saveLayoutPrefs(
+      {
+        layout: { columns: "260px minmax(0,1fr) 420px" },
+        terminalPanel: { height: 280 },
+      },
+      writer,
+    );
+    expect(writer).toHaveBeenCalledWith(
+      "layout_prefs",
+      expect.stringContaining("420px"),
+    );
+    expect(loadLayoutPrefsSync()).toEqual({
+      layout: { columns: "260px minmax(0,1fr) 420px" },
+      terminalPanel: { height: 280 },
+    });
+  });
+
+  it("merges loaded prefs into existing state without dropping other keys", () => {
+    const next = mergeLayoutPrefsIntoState(
+      {
+        layout: { rows: "38px minmax(0,1fr)", columns: "220px minmax(0,1fr)" },
+        terminal: { open: true },
+        terminalPanel: { activeSubId: "agent-bash" },
+      },
+      {
+        layout: { columns: "300px minmax(0,1fr) 500px" },
+        terminalPanel: { height: 410 },
+      },
+    );
+    expect(next).toEqual({
+      layout: {
+        rows: "38px minmax(0,1fr) 410px auto auto",
+        columns: "300px minmax(0,1fr) 500px",
+      },
+      terminal: { open: true },
+      terminalPanel: { activeSubId: "agent-bash", height: 410 },
+    });
+  });
+
+  it("clears prefs and resets state to workstation defaults", async () => {
+    const writer = vi.fn(() => Promise.resolve(true));
+    await saveLayoutPrefs(
+      {
+        layout: { columns: "300px minmax(0,1fr) 500px" },
+        terminalPanel: { height: 410 },
+      },
+      writer,
+    );
+    await clearLayoutPrefs(writer);
+    expect(loadLayoutPrefsSync()).toBeNull();
+    expect(writer).toHaveBeenLastCalledWith("layout_prefs", "");
+
+    const next = resetLayoutPrefsInState({
+      layout: { rows: "38px minmax(0,1fr)", columns: "300px minmax(0,1fr)" },
+      terminalPanel: { activeSubId: "agent-bash", height: 410 },
+    });
+    expect(next.layout).toEqual(
+      expect.objectContaining({
+        columns: "220px minmax(0,1fr) 360px",
+        rows: "38px minmax(0,1fr) 0px auto auto",
+        sidebarVisible: true,
+        filesSidebarVisible: true,
+      }),
+    );
+    expect(next.terminalPanel).toEqual({ activeSubId: "agent-bash" });
+  });
+});

--- a/src/layoutPrefs.ts
+++ b/src/layoutPrefs.ts
@@ -1,0 +1,222 @@
+import {
+  readStateWithLocalStorageFallback,
+  writeState as writePersistedState,
+} from "./persist";
+
+export const LAYOUT_PREFS_FILE = "layout_prefs";
+
+const KEY = "aethon:layout-prefs:v1";
+const DEFAULT_LEFT_WIDTH = "220px";
+const DEFAULT_RIGHT_WIDTH = "360px";
+const DEFAULT_TERMINAL_HEIGHT = 240;
+const TERMINAL_HEIGHT_MIN = 120;
+const TERMINAL_HEIGHT_MAX = 720;
+
+export interface LayoutPrefs {
+  layout?: Record<string, unknown>;
+  terminalPanel?: Record<string, unknown>;
+}
+
+type StateWriter = (name: string, content: string) => Promise<boolean>;
+
+function canUseLocalStorage(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.localStorage?.getItem === "function" &&
+    typeof window.localStorage?.setItem === "function" &&
+    typeof window.localStorage?.removeItem === "function"
+  );
+}
+
+function isPx(value: unknown): value is string {
+  return typeof value === "string" && /^\d+px$/.test(value);
+}
+
+function sanitizeColumns(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const tokens = value.trim().split(/\s+/);
+  if (tokens.length < 2 || !isPx(tokens[0])) return undefined;
+  const right = tokens.length >= 3 && isPx(tokens[tokens.length - 1])
+    ? tokens[tokens.length - 1]
+    : undefined;
+  return right
+    ? `${tokens[0]} minmax(0,1fr) ${right}`
+    : `${tokens[0]} minmax(0,1fr)`;
+}
+
+function sanitizeAreas(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const areas = value.filter(
+    (area): area is string => typeof area === "string" && area.trim().length > 0,
+  );
+  return areas.length > 0 ? areas : undefined;
+}
+
+function clampTerminalHeight(value: unknown): number {
+  return typeof value === "number" &&
+    Number.isFinite(value) &&
+    value >= TERMINAL_HEIGHT_MIN &&
+    value <= TERMINAL_HEIGHT_MAX
+    ? Math.round(value)
+    : DEFAULT_TERMINAL_HEIGHT;
+}
+
+function rowsForTerminal(open: unknown, height: unknown): string {
+  const track = open === true ? `${clampTerminalHeight(height)}px` : "0px";
+  return `38px minmax(0,1fr) ${track} auto auto`;
+}
+
+export function sanitizeLayoutPrefs(input: unknown): LayoutPrefs | null {
+  if (!input || typeof input !== "object") return null;
+  const src = input as { layout?: unknown; terminalPanel?: unknown };
+  const prefs: LayoutPrefs = {};
+
+  if (src.layout && typeof src.layout === "object") {
+    const layoutInput = src.layout as Record<string, unknown>;
+    const layout: Record<string, unknown> = {};
+    if (typeof layoutInput.sidebarVisible === "boolean") {
+      layout.sidebarVisible = layoutInput.sidebarVisible;
+    }
+    if (typeof layoutInput.filesSidebarVisible === "boolean") {
+      layout.filesSidebarVisible = layoutInput.filesSidebarVisible;
+    }
+    const columns = sanitizeColumns(layoutInput.columns);
+    if (columns) layout.columns = columns;
+    if (isPx(layoutInput.lastLeftWidth)) {
+      layout.lastLeftWidth = layoutInput.lastLeftWidth;
+    }
+    if (isPx(layoutInput.lastRightWidth)) {
+      layout.lastRightWidth = layoutInput.lastRightWidth;
+    }
+    const areas = sanitizeAreas(layoutInput.areas);
+    if (areas) layout.areas = areas;
+    if (Object.keys(layout).length > 0) prefs.layout = layout;
+  }
+
+  if (src.terminalPanel && typeof src.terminalPanel === "object") {
+    const panelInput = src.terminalPanel as Record<string, unknown>;
+    const panel: Record<string, unknown> = {};
+    if (
+      typeof panelInput.height === "number" &&
+      panelInput.height >= TERMINAL_HEIGHT_MIN &&
+      panelInput.height <= TERMINAL_HEIGHT_MAX
+    ) {
+      panel.height = panelInput.height;
+    }
+    if (Object.keys(panel).length > 0) prefs.terminalPanel = panel;
+  }
+
+  return Object.keys(prefs).length > 0 ? prefs : null;
+}
+
+export function layoutPrefsFromState(
+  state: Record<string, unknown>,
+): LayoutPrefs | null {
+  return sanitizeLayoutPrefs({
+    layout: state.layout,
+    terminalPanel: state.terminalPanel,
+  });
+}
+
+export function loadLayoutPrefsSync(): LayoutPrefs | null {
+  if (!canUseLocalStorage()) return null;
+  try {
+    const raw = window.localStorage.getItem(KEY);
+    if (!raw) return null;
+    return sanitizeLayoutPrefs(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+}
+
+export async function loadLayoutPrefsFromDisk(): Promise<LayoutPrefs | null> {
+  const raw = await readStateWithLocalStorageFallback(LAYOUT_PREFS_FILE, KEY);
+  try {
+    return raw ? sanitizeLayoutPrefs(JSON.parse(raw)) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function mergeLayoutPrefsIntoState(
+  state: Record<string, unknown>,
+  prefs: LayoutPrefs | null,
+): Record<string, unknown> {
+  if (!prefs) return state;
+  const layout =
+    (state.layout as Record<string, unknown> | undefined) ?? {};
+  const terminalPanel =
+    (state.terminalPanel as Record<string, unknown> | undefined) ?? {};
+  const mergedTerminalPanel = prefs.terminalPanel
+    ? { ...terminalPanel, ...prefs.terminalPanel }
+    : terminalPanel;
+  const mergedLayout = prefs.layout ? { ...layout, ...prefs.layout } : layout;
+  const terminal = state.terminal as { open?: unknown } | undefined;
+  return {
+    ...state,
+    layout: {
+      ...mergedLayout,
+      rows: rowsForTerminal(terminal?.open, mergedTerminalPanel.height),
+    },
+    ...(prefs.terminalPanel ? { terminalPanel: mergedTerminalPanel } : {}),
+  };
+}
+
+export function resetLayoutPrefsInState(
+  state: Record<string, unknown>,
+): Record<string, unknown> {
+  const layout =
+    (state.layout as Record<string, unknown> | undefined) ?? {};
+  const terminalPanel =
+    (state.terminalPanel as Record<string, unknown> | undefined) ?? {};
+  const { height: _height, ...terminalRest } = terminalPanel;
+  const terminal = state.terminal as { open?: unknown } | undefined;
+  return {
+    ...state,
+    layout: {
+      ...layout,
+      sidebarVisible: true,
+      filesSidebarVisible: true,
+      columns: `${DEFAULT_LEFT_WIDTH} minmax(0,1fr) ${DEFAULT_RIGHT_WIDTH}`,
+      rows: rowsForTerminal(terminal?.open, DEFAULT_TERMINAL_HEIGHT),
+      lastLeftWidth: DEFAULT_LEFT_WIDTH,
+      lastRightWidth: DEFAULT_RIGHT_WIDTH,
+      areas: [
+        "sidebar header files-sidebar",
+        "sidebar canvas files-sidebar",
+        "sidebar terminal files-sidebar",
+        "sidebar composer files-sidebar",
+        "status status status",
+      ],
+    },
+    terminalPanel: terminalRest,
+  };
+}
+
+export async function saveLayoutPrefs(
+  state: Record<string, unknown>,
+  writer: StateWriter = writePersistedState,
+): Promise<void> {
+  const prefs = layoutPrefsFromState(state);
+  const content = prefs ? JSON.stringify(prefs) : "";
+  try {
+    if (canUseLocalStorage()) {
+      if (content) window.localStorage.setItem(KEY, content);
+      else window.localStorage.removeItem(KEY);
+    }
+  } catch {
+    /* best-effort */
+  }
+  await writer(LAYOUT_PREFS_FILE, content);
+}
+
+export async function clearLayoutPrefs(
+  writer: StateWriter = writePersistedState,
+): Promise<void> {
+  try {
+    if (canUseLocalStorage()) window.localStorage.removeItem(KEY);
+  } catch {
+    /* best-effort */
+  }
+  await writer(LAYOUT_PREFS_FILE, "");
+}

--- a/src/skills/default-layout/dashboard/project-dashboard.test.tsx
+++ b/src/skills/default-layout/dashboard/project-dashboard.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ProjectDashboard } from "./project-dashboard";
+import type { A2UIComponent } from "../../../types/a2ui";
+import { SkillRegistry } from "../../SkillRegistry";
+import { SkillRegistryProvider } from "../../registry";
+
+vi.mock("../../../ghRepoOverviewCache", () => ({
+  getRepoOverview: vi.fn(
+    () =>
+      new Promise(() => {
+        /* keep dashboard overview pending */
+      }),
+  ),
+}));
+
+afterEach(() => cleanup());
+
+function dashboard(props: Record<string, unknown>): A2UIComponent {
+  return {
+    id: "project-dashboard",
+    type: "project-dashboard",
+    props,
+  };
+}
+
+function renderDashboard(onEvent = vi.fn()) {
+  const registry = new SkillRegistry();
+  render(
+    <SkillRegistryProvider registry={registry}>
+      <ProjectDashboard
+        component={dashboard({
+          project: { id: "p1", label: "aethon", path: "/repo" },
+          worktrees: [
+            {
+              id: "main",
+              label: "main",
+              branch: "main",
+              path: "/repo",
+              isMain: true,
+            },
+            {
+              id: "wt-1",
+              label: "feature-x",
+              branch: "feature-x",
+              path: "/repo-feature-x",
+            },
+          ],
+          recentSessions: [],
+          widgets: [],
+          otherProjects: [],
+        })}
+        state={{}}
+        onEvent={onEvent}
+      />
+    </SkillRegistryProvider>,
+  );
+  return { onEvent };
+}
+
+describe("ProjectDashboard worktree removal", () => {
+  it("opens inline confirmation from a worktree remove icon", () => {
+    const { onEvent } = renderDashboard();
+    fireEvent.click(screen.getByRole("button", { name: "Remove feature-x" }));
+    expect(onEvent).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("button", { name: "Confirm remove feature-x" }).textContent,
+    ).toBe("Confirm");
+  });
+
+  it("confirms worktree removal without switching the row", () => {
+    const { onEvent } = renderDashboard();
+    fireEvent.click(screen.getByRole("button", { name: "Remove feature-x" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Confirm remove feature-x" }),
+    );
+    expect(onEvent).toHaveBeenCalledTimes(1);
+    expect(onEvent).toHaveBeenCalledWith(
+      "remove-worktree",
+      expect.objectContaining({ worktreeId: "wt-1", confirmed: true }),
+      "wt-1",
+    );
+  });
+
+  it("clears inline confirmation when the pointer leaves", () => {
+    const { onEvent } = renderDashboard();
+    const row = screen.getByText("feature-x").closest("li")!;
+    fireEvent.click(screen.getByRole("button", { name: "Remove feature-x" }));
+    fireEvent.mouseLeave(row);
+    expect(
+      screen.queryByRole("button", { name: "Confirm remove feature-x" }),
+    ).toBeNull();
+    fireEvent.click(row);
+    expect(onEvent).toHaveBeenCalledWith(
+      "switch-worktree",
+      expect.objectContaining({ worktreeId: "wt-1" }),
+      "wt-1",
+    );
+  });
+
+  it("does not show remove affordance for the main worktree", () => {
+    renderDashboard();
+    expect(screen.queryByRole("button", { name: "Remove main" })).toBeNull();
+  });
+});

--- a/src/skills/default-layout/dashboard/project-dashboard.tsx
+++ b/src/skills/default-layout/dashboard/project-dashboard.tsx
@@ -19,6 +19,7 @@ import { GhStatsStrip } from "./gh-stats-strip";
 import { TaskLauncher } from "./task-launcher";
 import { AeMarkInline } from "../layout";
 import { RegistryComponent } from "../../../components/A2UIRenderer";
+import { DashboardSessionRow } from "./session-row";
 import {
   getRepoOverview,
   type GhRepoOverview,
@@ -274,25 +275,25 @@ export function ProjectDashboard({
             <h2>Recent sessions</h2>
             <ul className="a2ui-project-dashboard-sessions">
               {recentSessions.slice(0, 8).map((s) => (
-                <li
+                <DashboardSessionRow
                   key={s.id}
-                  onClick={() =>
+                  session={s}
+                  classPrefix="a2ui-project-dashboard"
+                  onRestore={() =>
                     onEvent(
                       "restore-session",
                       { sessionId: s.id, label: s.label, cwd: s.cwd },
                       s.id,
                     )
                   }
-                >
-                  <span className="a2ui-project-dashboard-session-label">
-                    {s.label}
-                  </span>
-                  {s.lastModified && (
-                    <span className="a2ui-project-dashboard-session-meta">
-                      {s.lastModified}
-                    </span>
-                  )}
-                </li>
+                  onDelete={() =>
+                    onEvent(
+                      "delete-session",
+                      { sessionId: s.id, label: s.label, confirmed: true },
+                      s.id,
+                    )
+                  }
+                />
               ))}
             </ul>
           </section>

--- a/src/skills/default-layout/dashboard/project-dashboard.tsx
+++ b/src/skills/default-layout/dashboard/project-dashboard.tsx
@@ -82,6 +82,9 @@ export function ProjectDashboard({
   state,
   onEvent,
 }: BuiltinComponentProps) {
+  const [confirmingWorktreeId, setConfirmingWorktreeId] = useState<
+    string | null
+  >(null);
   const props = component.props as
     | {
         project?: unknown;
@@ -235,37 +238,94 @@ export function ProjectDashboard({
               </button>
             </header>
             <ul className="a2ui-project-dashboard-worktrees">
-              {worktrees.map((w) => (
-                <li
-                  key={w.id}
-                  className={
-                    "a2ui-project-dashboard-worktree" +
-                    (w.active ? " is-active" : "")
-                  }
-                  onClick={() =>
-                    onEvent(
-                      "switch-worktree",
-                      { worktreeId: w.id, projectId: project.id },
-                      w.id,
-                    )
-                  }
-                  title={w.path}
-                >
-                  <span className="a2ui-project-dashboard-worktree-label">
-                    {w.label || w.branch || "worktree"}
-                  </span>
-                  {w.branch && (
-                    <span className="a2ui-project-dashboard-worktree-branch">
-                      ⎇ {w.branch}
+              {worktrees.map((w) => {
+                const label = w.label || w.branch || "worktree";
+                const confirming = confirmingWorktreeId === w.id;
+                return (
+                  <li
+                    key={w.id}
+                    className={
+                      "a2ui-project-dashboard-worktree" +
+                      (w.active ? " is-active" : "") +
+                      (confirming ? " is-confirming" : "")
+                    }
+                    onMouseLeave={() => {
+                      if (confirming) setConfirmingWorktreeId(null);
+                    }}
+                    onClick={() => {
+                      if (confirming) return;
+                      onEvent(
+                        "switch-worktree",
+                        { worktreeId: w.id, projectId: project.id },
+                        w.id,
+                      );
+                    }}
+                    title={w.path}
+                  >
+                    <span className="a2ui-project-dashboard-worktree-label">
+                      {label}
                     </span>
-                  )}
-                  {w.isMain && (
-                    <span className="a2ui-project-dashboard-worktree-main">
-                      main
-                    </span>
-                  )}
-                </li>
-              ))}
+                    {w.branch && (
+                      <span className="a2ui-project-dashboard-worktree-branch">
+                        ⎇ {w.branch}
+                      </span>
+                    )}
+                    {w.isMain ? (
+                      <span className="a2ui-project-dashboard-worktree-main">
+                        main
+                      </span>
+                    ) : confirming ? (
+                      <button
+                        type="button"
+                        className="a2ui-project-dashboard-worktree-confirm-remove"
+                        aria-label={`Confirm remove ${label}`}
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          onEvent(
+                            "remove-worktree",
+                            {
+                              worktreeId: w.id,
+                              projectId: project.id,
+                              confirmed: true,
+                            },
+                            w.id,
+                          );
+                        }}
+                      >
+                        Confirm
+                      </button>
+                    ) : (
+                      <button
+                        type="button"
+                        className="a2ui-project-dashboard-worktree-remove"
+                        aria-label={`Remove ${label}`}
+                        title="Remove worktree"
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          setConfirmingWorktreeId(w.id);
+                        }}
+                      >
+                        <svg
+                          viewBox="0 0 16 16"
+                          width="14"
+                          height="14"
+                          aria-hidden="true"
+                          focusable="false"
+                        >
+                          <path
+                            d="M5.5 2.75h5M6.25 2.75l.5-1h2.5l.5 1M3.5 4.5h9M5 4.5l.55 9h4.9l.55-9M7 6.5v5M9 6.5v5"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth="1.35"
+                          />
+                        </svg>
+                      </button>
+                    )}
+                  </li>
+                );
+              })}
             </ul>
           </section>
         )}

--- a/src/skills/default-layout/dashboard/projects-dashboard.tsx
+++ b/src/skills/default-layout/dashboard/projects-dashboard.tsx
@@ -21,6 +21,7 @@ import type { BuiltinComponentProps } from "../../../components/A2UIRenderer";
 import { resolvePointer } from "../../../utils/jsonPointer";
 import { AeMarkInline } from "../layout";
 import { RegistryComponent } from "../../../components/A2UIRenderer";
+import { DashboardSessionRow } from "./session-row";
 
 interface ProjectListItem {
   id: string;
@@ -190,25 +191,25 @@ export function ProjectsDashboard({
             <h2>Recent sessions</h2>
             <ul className="a2ui-projects-dashboard-sessions">
               {recentSessions.slice(0, 6).map((s) => (
-                <li
+                <DashboardSessionRow
                   key={s.id}
-                  onClick={() =>
+                  session={s}
+                  classPrefix="a2ui-projects-dashboard"
+                  onRestore={() =>
                     onEvent(
                       "restore-session",
                       { sessionId: s.id, label: s.label, cwd: s.cwd },
                       s.id,
                     )
                   }
-                >
-                  <span className="a2ui-projects-dashboard-session-label">
-                    {s.label}
-                  </span>
-                  {s.lastModified && (
-                    <span className="a2ui-projects-dashboard-session-meta">
-                      {s.lastModified}
-                    </span>
-                  )}
-                </li>
+                  onDelete={() =>
+                    onEvent(
+                      "delete-session",
+                      { sessionId: s.id, label: s.label, confirmed: true },
+                      s.id,
+                    )
+                  }
+                />
               ))}
             </ul>
           </section>

--- a/src/skills/default-layout/dashboard/session-row.test.tsx
+++ b/src/skills/default-layout/dashboard/session-row.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DashboardSessionRow } from "./session-row";
+
+afterEach(() => cleanup());
+
+describe("DashboardSessionRow", () => {
+  it("restores the session when the row is clicked", () => {
+    const onRestore = vi.fn();
+    const onDelete = vi.fn();
+    render(
+      <ul>
+        <DashboardSessionRow
+          session={{
+            id: "s1",
+            label: "Refactor notes",
+            lastModified: "1h ago",
+          }}
+          classPrefix="a2ui-projects-dashboard"
+          onRestore={onRestore}
+          onDelete={onDelete}
+        />
+      </ul>,
+    );
+
+    fireEvent.click(screen.getByText("Refactor notes"));
+    expect(onRestore).toHaveBeenCalledTimes(1);
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+
+  it("opens inline confirmation from the trash icon", () => {
+    const onRestore = vi.fn();
+    const onDelete = vi.fn();
+    render(
+      <ul>
+        <DashboardSessionRow
+          session={{ id: "s1", label: "Refactor notes" }}
+          classPrefix="a2ui-projects-dashboard"
+          onRestore={onRestore}
+          onDelete={onDelete}
+        />
+      </ul>,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Delete Refactor notes" }),
+    );
+    expect(
+      screen.getByRole("button", { name: "Confirm delete Refactor notes" })
+        .textContent,
+    ).toBe("Confirm");
+    expect(onDelete).not.toHaveBeenCalled();
+    expect(onRestore).not.toHaveBeenCalled();
+  });
+
+  it("deletes without also restoring when inline confirmation is clicked", () => {
+    const onRestore = vi.fn();
+    const onDelete = vi.fn();
+    render(
+      <ul>
+        <DashboardSessionRow
+          session={{ id: "s1", label: "Refactor notes" }}
+          classPrefix="a2ui-projects-dashboard"
+          onRestore={onRestore}
+          onDelete={onDelete}
+        />
+      </ul>,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Delete Refactor notes" }),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "Confirm delete Refactor notes" }),
+    );
+    expect(onDelete).toHaveBeenCalledTimes(1);
+    expect(onRestore).not.toHaveBeenCalled();
+  });
+
+  it("clears inline confirmation on mouse leave", () => {
+    const onRestore = vi.fn();
+    const onDelete = vi.fn();
+    const { container } = render(
+      <ul>
+        <DashboardSessionRow
+          session={{ id: "s1", label: "Refactor notes" }}
+          classPrefix="a2ui-projects-dashboard"
+          onRestore={onRestore}
+          onDelete={onDelete}
+        />
+      </ul>,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Delete Refactor notes" }),
+    );
+    fireEvent.mouseLeave(container.querySelector("li")!);
+    fireEvent.click(screen.getByText("Refactor notes"));
+
+    expect(onDelete).not.toHaveBeenCalled();
+    expect(onRestore).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/skills/default-layout/dashboard/session-row.tsx
+++ b/src/skills/default-layout/dashboard/session-row.tsx
@@ -1,0 +1,90 @@
+import { useState } from "react";
+
+export interface DashboardSessionRowItem {
+  id: string;
+  label: string;
+  lastModified?: string;
+  cwd?: string;
+}
+
+export function DashboardSessionRow({
+  session,
+  classPrefix,
+  onRestore,
+  onDelete,
+}: {
+  session: DashboardSessionRowItem;
+  classPrefix: string;
+  onRestore: () => void;
+  onDelete: () => void;
+}) {
+  const [confirming, setConfirming] = useState(false);
+
+  return (
+    <li
+      className={
+        confirming
+          ? "a2ui-dashboard-session-row is-confirming"
+          : "a2ui-dashboard-session-row"
+      }
+      onMouseLeave={() => setConfirming(false)}
+      onClick={() => {
+        if (!confirming) onRestore();
+      }}
+    >
+      <span className={`${classPrefix}-session-label`}>{session.label}</span>
+      <span className={`${classPrefix}-session-actions`}>
+        {confirming ? (
+          <span className="a2ui-dashboard-session-confirm">
+            <button
+              type="button"
+              className="a2ui-dashboard-session-confirm-delete"
+              aria-label={`Confirm delete ${session.label}`}
+              onClick={(event) => {
+                event.stopPropagation();
+                onDelete();
+              }}
+            >
+              Confirm
+            </button>
+          </span>
+        ) : (
+          <>
+            {session.lastModified && (
+              <span className={`${classPrefix}-session-meta`}>
+                {session.lastModified}
+              </span>
+            )}
+            <button
+              type="button"
+              className={`${classPrefix}-session-delete`}
+              aria-label={`Delete ${session.label}`}
+              title="Delete saved session"
+              onClick={(event) => {
+                event.stopPropagation();
+                setConfirming(true);
+              }}
+            >
+              <svg
+                viewBox="0 0 16 16"
+                width="14"
+                height="14"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M5.5 2.75h5M6.25 2.75l.5-1h2.5l.5 1M3.5 4.5h9M5 4.5l.55 9h4.9l.55-9M7 6.5v5M9 6.5v5"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="1.35"
+                />
+              </svg>
+            </button>
+          </>
+        )}
+      </span>
+    </li>
+  );
+}

--- a/src/skills/default-layout/editor/canvas.tsx
+++ b/src/skills/default-layout/editor/canvas.tsx
@@ -52,6 +52,7 @@ interface EditorTabLike {
   kind?: string;
   editor?: {
     filePath?: string;
+    rootPath?: string;
     language?: string;
     isDirty?: boolean;
     cursorLine?: number;
@@ -75,7 +76,7 @@ export function EditorCanvas({ component, state, onEvent }: BuiltinComponentProp
   const boundTab = tabs.find((t) => t.id === tabId);
   const editorMeta = boundTab?.editor;
   const project = state["project"] as { path?: string } | undefined;
-  const projectPath = project?.path ?? "";
+  const projectPath = editorMeta?.rootPath ?? project?.path ?? "";
 
   const containerRef = useRef<HTMLDivElement>(null);
   const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);

--- a/src/skills/default-layout/layout.test.tsx
+++ b/src/skills/default-layout/layout.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { Layout } from "./layout";
+import type { A2UIComponent } from "../../types/a2ui";
+
+afterEach(() => cleanup());
+
+function renderLayout(children: A2UIComponent[]) {
+  return render(
+    <Layout
+      component={{
+        id: "root",
+        type: "layout",
+        props: {
+          columns: "0px minmax(0,1fr) 0px",
+          rows: "38px minmax(0,1fr) 0px auto auto",
+          areas: [
+            "sidebar header files-sidebar",
+            "sidebar canvas files-sidebar",
+            "sidebar terminal files-sidebar",
+            "sidebar composer files-sidebar",
+            "status status status",
+          ],
+        },
+        children,
+      }}
+      state={{ layout: { sidebarVisible: false }, terminal: { open: false } }}
+      onEvent={() => {}}
+      renderChild={(child) => <div>{child.id}</div>}
+    />,
+  );
+}
+
+describe("Layout panel motion affordances", () => {
+  it("keeps chrome panels mounted while their grid tracks animate closed", () => {
+    const { container } = renderLayout([
+      {
+        id: "sidebar",
+        type: "container",
+        props: { area: "sidebar", visible: false },
+      },
+      {
+        id: "terminal",
+        type: "terminal-panel",
+        props: { area: "terminal", visible: false },
+      },
+      {
+        id: "canvas",
+        type: "container",
+        props: { area: "canvas", visible: false },
+      },
+    ]);
+
+    const cells = container.querySelectorAll<HTMLElement>(".a2ui-layout-cell");
+    expect(cells[0]?.style.display).toBe("flex");
+    expect(cells[0]?.dataset.visible).toBe("false");
+    expect(cells[1]?.style.display).toBe("flex");
+    expect(cells[1]?.dataset.visible).toBe("false");
+    expect(cells[2]?.style.display).toBe("none");
+  });
+
+  it("leaves grid transition ownership to CSS", () => {
+    const { container } = renderLayout([]);
+    const root = container.querySelector<HTMLElement>(".a2ui-layout");
+    expect(root?.style.transition).toBe("");
+  });
+});

--- a/src/skills/default-layout/layout.tsx
+++ b/src/skills/default-layout/layout.tsx
@@ -149,7 +149,6 @@ export function Layout({
     height: "100%",
     width: "100%",
     minHeight: 0,
-    transition: "grid-template-columns 180ms ease",
   };
 
   return (
@@ -169,14 +168,22 @@ export function Layout({
           childProps?.visible === undefined
             ? true
             : resolveBoolean(childProps.visible, state);
+        const keepsMountedForMotion =
+          area === "sidebar" || area === "files-sidebar" || area === "terminal";
         const cellStyle: CSSProperties = {
           gridArea: area,
           minWidth: 0,
           minHeight: 0,
-          display: visible ? "flex" : "none",
+          display: visible || keepsMountedForMotion ? "flex" : "none",
         };
         return (
-          <div key={child.id} className="a2ui-layout-cell" style={cellStyle}>
+          <div
+            key={child.id}
+            className="a2ui-layout-cell"
+            data-area={area}
+            data-visible={visible ? "true" : "false"}
+            style={cellStyle}
+          >
             {renderChild?.(child)}
           </div>
         );

--- a/src/skills/default-layout/settings-panel.tsx
+++ b/src/skills/default-layout/settings-panel.tsx
@@ -118,14 +118,8 @@ export function SettingsPanel({ state, onEvent }: BuiltinComponentProps) {
       console.warn("open config.toml failed:", err);
     }
   };
-  const openSystemPromptFile = async () => {
-    try {
-      const aethonDir = (await invoke<string>("aethon_home_dir")) ?? "";
-      const path = `${aethonDir}/system-prompt.md`;
-      await openUrl(`file://${path}`);
-    } catch (err) {
-      console.warn("open system-prompt.md failed:", err);
-    }
+  const openSystemPromptFile = () => {
+    onEvent("open-system-prompt");
   };
 
   return (

--- a/src/skills/default-layout/settings-panel.tsx
+++ b/src/skills/default-layout/settings-panel.tsx
@@ -22,6 +22,7 @@ import { DropdownPickerCore } from "./variation-components";
 
 interface SettingsState {
   open: boolean;
+  focusSection: string | null;
   /** User's unsaved edits. Null when the panel hasn't loaded the
    *  config yet OR the user hasn't touched anything. The form reads
    *  from `pending` first, falling back to the config snapshot. */
@@ -32,6 +33,8 @@ function readSettingsState(state: Record<string, unknown>): SettingsState {
   const s = (state.settings as Partial<SettingsState> | undefined) ?? {};
   return {
     open: !!s.open,
+    focusSection:
+      typeof s.focusSection === "string" ? s.focusSection : null,
     pending: (s.pending as Partial<AethonConfig> | null) ?? null,
   };
 }
@@ -99,6 +102,20 @@ export function SettingsPanel({ state, onEvent }: BuiltinComponentProps) {
     };
   }, [configSnapshot, settings.pending]);
 
+  useEffect(() => {
+    if (!settings.open || !eff || !settings.focusSection) return;
+    const frame = window.requestAnimationFrame(() => {
+      const target = [
+        ...document.querySelectorAll<HTMLElement>("[data-settings-section]"),
+      ].find((el) => el.dataset.settingsSection === settings.focusSection);
+      target?.scrollIntoView({
+        block: "start",
+        behavior: "smooth",
+      });
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [eff, settings.focusSection, settings.open]);
+
   if (!settings.open) return null;
 
   const update = (patch: Partial<AethonConfig>) => {
@@ -151,7 +168,7 @@ export function SettingsPanel({ state, onEvent }: BuiltinComponentProps) {
           <div className="ae-settings-body">Loading…</div>
         ) : (
           <div className="ae-settings-body">
-            <Section title="Appearance">
+            <Section id="appearance" title="Appearance">
               <Field label="Theme">
                 <select
                   className="ae-settings-input"
@@ -195,7 +212,7 @@ export function SettingsPanel({ state, onEvent }: BuiltinComponentProps) {
               </Field>
             </Section>
 
-            <Section title="Notifications">
+            <Section id="notifications" title="Notifications">
               <Field label="Notify on agent completion (when unfocused)">
                 <input
                   type="checkbox"
@@ -227,7 +244,7 @@ export function SettingsPanel({ state, onEvent }: BuiltinComponentProps) {
               </Field>
             </Section>
 
-            <Section title="Agent">
+            <Section id="agent" title="Agent">
               <Field label="Default model for new tabs">
                 <ModelPicker
                   state={state}
@@ -249,7 +266,7 @@ export function SettingsPanel({ state, onEvent }: BuiltinComponentProps) {
               </Field>
             </Section>
 
-            <Section title="Shell">
+            <Section id="shell" title="Shell">
               <Field label="Default share mode for new shell tabs">
                 <select
                   className="ae-settings-input"
@@ -316,7 +333,7 @@ export function SettingsPanel({ state, onEvent }: BuiltinComponentProps) {
               </Field>
             </Section>
 
-            <Section title="Behavior">
+            <Section id="behavior" title="Behavior">
               <Field label="Confirm close when shell job is running">
                 <input
                   type="checkbox"
@@ -368,7 +385,7 @@ export function SettingsPanel({ state, onEvent }: BuiltinComponentProps) {
               </div>
             </Section>
 
-            <Section title="Updater">
+            <Section id="updater" title="Updater">
               <Field label="Release channel">
                 <select
                   className="ae-settings-input"
@@ -387,11 +404,11 @@ export function SettingsPanel({ state, onEvent }: BuiltinComponentProps) {
               </p>
             </Section>
 
-            <Section title="Extensions">
+            <Section id="extensions" title="Extensions">
               <ExtensionsList state={state} onEvent={onEvent} />
             </Section>
 
-            <Section title="Advanced">
+            <Section id="advanced" title="Advanced">
               <p className="ae-settings-note">
                 For keys not surfaced here, edit{" "}
                 <code>~/.aethon/config.toml</code> directly. The Save button
@@ -437,9 +454,9 @@ export function SettingsPanel({ state, onEvent }: BuiltinComponentProps) {
   );
 }
 
-function Section(props: { title: string; children: React.ReactNode }) {
+function Section(props: { id: string; title: string; children: React.ReactNode }) {
   return (
-    <section className="ae-settings-section">
+    <section className="ae-settings-section" data-settings-section={props.id}>
       <h3 className="ae-settings-section-title">{props.title}</h3>
       <div className="ae-settings-section-body">{props.children}</div>
     </section>
@@ -595,8 +612,9 @@ function ExtensionsList({
   if (items.length === 0) {
     return (
       <p className="ae-settings-note">
-        No extensions loaded. Drop a <code>.mjs</code> into{" "}
-        <code>~/.aethon/extensions/</code> to register one.
+        No user or project extensions loaded. Drop a <code>.mjs</code> into{" "}
+        <code>~/.aethon/extensions/</code> or the active project's{" "}
+        <code>.aethon/extensions/</code> directory to register one.
       </p>
     );
   }

--- a/src/skills/default-layout/settings-panel.tsx
+++ b/src/skills/default-layout/settings-panel.tsx
@@ -406,6 +406,13 @@ export function SettingsPanel({ state, onEvent }: BuiltinComponentProps) {
               <button
                 type="button"
                 className="ae-settings-secondary"
+                onClick={() => onEvent("reset-layout-prefs")}
+              >
+                Reset layout
+              </button>
+              <button
+                type="button"
+                className="ae-settings-secondary"
                 onClick={openConfigFile}
               >
                 Open config.toml

--- a/src/skills/default-layout/shell/panel.tsx
+++ b/src/skills/default-layout/shell/panel.tsx
@@ -24,7 +24,6 @@ import { Terminal } from "../terminal";
 import { ShellCanvas } from "./canvas";
 
 const AGENT_BASH_SUB_ID = "agent-bash";
-const TERMINAL_PANEL_DEFAULT_HEIGHT = 240;
 const TERMINAL_PANEL_MIN_HEIGHT = 120;
 const TERMINAL_PANEL_MAX_HEIGHT = 720;
 
@@ -69,14 +68,6 @@ export function TerminalPanel({
     (state["terminalPanel"] as { activeSubId?: string; height?: number } | undefined) ?? {};
   const requestedActiveId = panelState.activeSubId ?? AGENT_BASH_SUB_ID;
   const panelRef = useRef<HTMLDivElement>(null);
-  const height =
-    typeof panelState.height === "number" &&
-    Number.isFinite(panelState.height)
-      ? Math.max(
-          TERMINAL_PANEL_MIN_HEIGHT,
-          Math.min(TERMINAL_PANEL_MAX_HEIGHT, Math.round(panelState.height)),
-        )
-      : TERMINAL_PANEL_DEFAULT_HEIGHT;
   // Clamp to a valid sub-tab id. If the requested id no longer exists
   // (e.g. user closed a shell that was active), fall back to agent-bash
   // so we always render something.
@@ -86,8 +77,6 @@ export function TerminalPanel({
       return requestedActiveId;
     return AGENT_BASH_SUB_ID;
   }, [requestedActiveId, shellTabs]);
-
-  if (!visible) return null;
 
   const onResizeStart = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -117,8 +106,11 @@ export function TerminalPanel({
   return (
     <div
       ref={panelRef}
-      className="ae-terminal-panel"
-      style={{ gridArea: "terminal", height }}
+      className={
+        visible ? "ae-terminal-panel" : "ae-terminal-panel is-closed"
+      }
+      aria-hidden={!visible}
+      style={{ gridArea: "terminal", height: "100%" }}
     >
       <div
         className="ae-terminal-panel-resize-handle"

--- a/src/skills/default-layout/sidebar/file-tree.test.tsx
+++ b/src/skills/default-layout/sidebar/file-tree.test.tsx
@@ -53,13 +53,28 @@ afterEach(() => {
 });
 
 describe("FileTreePanel", () => {
-  it("shows an empty state when no project is active", () => {
+  it("falls back to the Aethon home dir when no project is active", async () => {
+    invokeMock
+      .mockResolvedValueOnce("/Users/test/.aethon")
+      .mockResolvedValueOnce([
+        {
+          name: "system-prompt.md",
+          path: "/Users/test/.aethon/system-prompt.md",
+          kind: "file",
+        },
+      ]);
     render(
       <FileTreePanel
         {...panelProps({ state: {} })}
       />,
     );
-    expect(screen.getByText("no project")).toBeTruthy();
+    await waitFor(() => screen.getByText("system-prompt.md"));
+    expect(screen.getByText(".aethon")).toBeTruthy();
+    expect(invokeMock).toHaveBeenNthCalledWith(1, "aethon_home_dir");
+    expect(invokeMock).toHaveBeenNthCalledWith(2, "fs_list_dir", {
+      root: "/Users/test/.aethon",
+      path: "/Users/test/.aethon",
+    });
   });
 
   it("lists the project root on mount", async () => {
@@ -87,7 +102,40 @@ describe("FileTreePanel", () => {
     row.click();
     expect(onEvent).toHaveBeenCalledWith("file-tree-open", {
       filePath: "/projects/aethon/src/App.tsx",
+      rootPath: "/projects/aethon",
     });
+  });
+
+  it("uses the active editor root when no project is active", async () => {
+    invokeMock.mockResolvedValueOnce([
+      {
+        name: "system-prompt.md",
+        path: "/Users/test/.aethon/system-prompt.md",
+        kind: "file",
+      },
+    ]);
+    render(
+      <FileTreePanel
+        {...panelProps({
+          state: {
+            activeTabId: "editor-1",
+            tabs: [
+              {
+                id: "editor-1",
+                kind: "editor",
+                editor: { rootPath: "/Users/test/.aethon" },
+              },
+            ],
+          },
+        })}
+      />,
+    );
+    await waitFor(() => screen.getByText("system-prompt.md"));
+    expect(invokeMock).toHaveBeenCalledWith("fs_list_dir", {
+      root: "/Users/test/.aethon",
+      path: "/Users/test/.aethon",
+    });
+    expect(invokeMock).not.toHaveBeenCalledWith("aethon_home_dir");
   });
 
   it("renders an error state when fs_list_dir rejects", async () => {
@@ -139,6 +187,7 @@ describe("FileTreePanel", () => {
     await waitFor(() => {
       expect(onEvent).toHaveBeenCalledWith("file-tree-open", {
         filePath: "/projects/aethon/src/new.ts",
+        rootPath: "/projects/aethon",
       });
     });
   });

--- a/src/skills/default-layout/sidebar/file-tree.tsx
+++ b/src/skills/default-layout/sidebar/file-tree.tsx
@@ -48,6 +48,14 @@ interface TreeNode {
   loadError?: string;
 }
 
+interface EditorTabShape {
+  id?: string;
+  kind?: string;
+  editor?: {
+    rootPath?: string;
+  };
+}
+
 /** Persisted expand-state. Each project keeps its own set of expanded
  *  absolute paths so reopening lands on the prior view. Capped per
  *  project to bound the persisted file's size. */
@@ -57,6 +65,10 @@ interface ExpandedStore {
 
 const EXPAND_STATE_FILE = "file-tree.json";
 const EXPANDED_CAP_PER_PROJECT = 200;
+
+function basename(path: string): string {
+  return path.split(/[/\\]+/).filter(Boolean).pop() ?? path;
+}
 
 /** Return the directory of `node`'s entry: the node itself when it's a
  *  folder, the containing folder when it's a file. Used by the
@@ -145,11 +157,37 @@ export function FileTreePanel({ component, state, onEvent }: BuiltinComponentPro
   const embedMode = componentProps.embed ?? "left-stack";
   const fillsContainer = embedMode === "right-sidebar";
   const project = state["project"] as ProjectShape | undefined;
+  const tabs = (state["tabs"] as EditorTabShape[] | undefined) ?? [];
+  const activeTabId = state["activeTabId"] as string | undefined;
+  const activeTab = activeTabId
+    ? tabs.find((t) => t.id === activeTabId)
+    : undefined;
+  const activeEditorRoot =
+    activeTab?.kind === "editor" ? activeTab.editor?.rootPath : undefined;
+  const [aethonRoot, setAethonRoot] = useState<string>("");
+
+  useEffect(() => {
+    if (project?.path || activeEditorRoot || aethonRoot) return;
+    let cancelled = false;
+    void invoke<string>("aethon_home_dir")
+      .then((dir) => {
+        if (!cancelled && dir) setAethonRoot(dir);
+      })
+      .catch(() => {
+        /* Dashboard files are best-effort when the home dir is unavailable. */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [activeEditorRoot, aethonRoot, project?.path]);
+
   // Honor the active worktree when one is selected — `/activeWorktreeId`
   // is mirrored onto root state by useProjectOps. The file tree should
   // reflect whichever cwd new tabs would inherit so user mental model
   // stays "file panel = where I'm working." Falls back to the project
-  // root when no worktree is active.
+  // root when no worktree is active. When no project is active, browse
+  // the active editor tab's root (e.g. ~/.aethon from Settings) or the
+  // Aethon home dir for the dashboard.
   const activeWorktreeId = (state["activeWorktreeId"] as string | null) ?? null;
   const projectPath = (() => {
     if (activeWorktreeId) {
@@ -167,8 +205,9 @@ export function FileTreePanel({ component, state, onEvent }: BuiltinComponentPro
         if (wt?.path) return wt.path;
       }
     }
-    return project?.path ?? "";
+    return project?.path ?? activeEditorRoot ?? aethonRoot;
   })();
+  const rootLabel = (project?.name ?? basename(projectPath)) || "files";
 
   // Root node represents the project's working directory. Children are
   // loaded eagerly on mount; switching projects swaps roots.
@@ -304,7 +343,7 @@ export function FileTreePanel({ component, state, onEvent }: BuiltinComponentPro
         if (cancelled) return;
         const rootNode: TreeNode = {
           entry: {
-            name: project?.name ?? projectPath.split("/").filter(Boolean).pop() ?? projectPath,
+            name: rootLabel,
             path: projectPath,
             kind: "dir",
           },
@@ -359,7 +398,7 @@ export function FileTreePanel({ component, state, onEvent }: BuiltinComponentPro
     return () => {
       cancelled = true;
     };
-  }, [projectPath, project?.name]);
+  }, [projectPath, rootLabel]);
 
   // Load a folder's children on demand. No-op if already loaded.
   const loadFolderChildren = useCallback(
@@ -432,7 +471,10 @@ export function FileTreePanel({ component, state, onEvent }: BuiltinComponentPro
       toggleFolder(node);
       return;
     }
-    onEvent("file-tree-open", { filePath: node.entry.path });
+    onEvent("file-tree-open", {
+      filePath: node.entry.path,
+      rootPath: projectPathRef.current,
+    });
   };
 
   const onRowContextMenu = (e: React.MouseEvent, node: TreeNode) => {
@@ -525,7 +567,10 @@ export function FileTreePanel({ component, state, onEvent }: BuiltinComponentPro
         path: target,
       });
       await refreshFolder(parentPath);
-      onEvent("file-tree-open", { filePath: target });
+      onEvent("file-tree-open", {
+        filePath: target,
+        rootPath: projectPathRef.current,
+      });
     } catch (err) {
       window.alert(`Failed to create file: ${String(err)}`);
     }
@@ -793,7 +838,7 @@ export function FileTreePanel({ component, state, onEvent }: BuiltinComponentPro
       | undefined) ?? [];
   const activeProject = sidebarProjects.find((p) => p.active === true);
   const activeWorktree = activeProject?.worktrees?.find((w) => w.active === true);
-  const headerLabel = activeProject?.label ?? project?.name ?? "files";
+  const headerLabel = activeProject?.label ?? rootLabel;
   const headerBranch =
     activeWorktree?.label ?? activeWorktree?.branch ?? activeProject?.git?.branch;
 

--- a/src/skills/default-layout/sidebar/file-tree.tsx
+++ b/src/skills/default-layout/sidebar/file-tree.tsx
@@ -114,6 +114,8 @@ const PANEL_PREFS_FILE = "file-tree-prefs.json";
 const PANEL_HEIGHT_DEFAULT = 280;
 const PANEL_HEIGHT_MIN = 120;
 const PANEL_HEIGHT_MAX = 1200;
+const SIDEBAR_WIDTH_MIN = 220;
+const SIDEBAR_WIDTH_MAX = 640;
 
 interface PanelPrefs {
   collapsed?: boolean;
@@ -244,8 +246,17 @@ export function FileTreePanel({ component, state, onEvent }: BuiltinComponentPro
   // the outside without prop drilling.
   useEffect(() => {
     const toggle = () => setHidden((h) => !h);
+    const resetPrefs = () => {
+      setCollapsed(false);
+      setHidden(false);
+      setHeight(PANEL_HEIGHT_DEFAULT);
+    };
     window.addEventListener("aethon:toggle-file-tree", toggle);
-    return () => window.removeEventListener("aethon:toggle-file-tree", toggle);
+    window.addEventListener("aethon:reset-file-tree-prefs", resetPrefs);
+    return () => {
+      window.removeEventListener("aethon:toggle-file-tree", toggle);
+      window.removeEventListener("aethon:reset-file-tree-prefs", resetPrefs);
+    };
   }, []);
 
   // Schedule a debounced persist whenever the active project's expand
@@ -687,6 +698,42 @@ export function FileTreePanel({ component, state, onEvent }: BuiltinComponentPro
     document.addEventListener("mouseup", onUp);
   };
 
+  const startSidebarResize = (e: React.MouseEvent) => {
+    e.preventDefault();
+    const startX = e.clientX;
+    const host = (e.currentTarget as HTMLElement).closest(".ae-file-tree");
+    const startWidth = Math.round(
+      host?.getBoundingClientRect().width ?? SIDEBAR_WIDTH_MIN,
+    );
+    document.body.classList.add("ae-resizing-sidebar");
+    const onMove = (ev: MouseEvent) => {
+      const dx = startX - ev.clientX;
+      const next = Math.max(
+        SIDEBAR_WIDTH_MIN,
+        Math.min(SIDEBAR_WIDTH_MAX, Math.round(startWidth + dx)),
+      );
+      onEvent("resize", { width: next });
+    };
+    const onUp = () => {
+      document.body.classList.remove("ae-resizing-sidebar");
+      document.removeEventListener("mousemove", onMove);
+      document.removeEventListener("mouseup", onUp);
+      onEvent("resize-end");
+    };
+    document.addEventListener("mousemove", onMove);
+    document.addEventListener("mouseup", onUp);
+  };
+
+  const sidebarResizeHandle = fillsContainer ? (
+    <div
+      className="ae-file-tree-sidebar-resize-handle"
+      role="separator"
+      aria-orientation="vertical"
+      aria-label="Resize files sidebar"
+      onMouseDown={startSidebarResize}
+    />
+  ) : null;
+
   // Items array for the right-click menu. Memoizing on the contextMenu
   // identity is enough here — handlers reference state via closures and
   // close over a stable `contextMenu` per render, so changing the menu
@@ -797,7 +844,8 @@ export function FileTreePanel({ component, state, onEvent }: BuiltinComponentPro
         className={`ae-file-tree ae-file-tree-empty${collapsed ? " is-collapsed" : ""}`}
         style={panelStyle}
       >
-        {!collapsed && (
+        {sidebarResizeHandle}
+        {!collapsed && !fillsContainer && (
           <div
             className="ae-file-tree-resize-handle"
             role="separator"
@@ -819,7 +867,8 @@ export function FileTreePanel({ component, state, onEvent }: BuiltinComponentPro
         className={`ae-file-tree${collapsed ? " is-collapsed" : ""}`}
         style={panelStyle}
       >
-        {!collapsed && (
+        {sidebarResizeHandle}
+        {!collapsed && !fillsContainer && (
           <div
             className="ae-file-tree-resize-handle"
             role="separator"
@@ -839,7 +888,8 @@ export function FileTreePanel({ component, state, onEvent }: BuiltinComponentPro
         className={`ae-file-tree${collapsed ? " is-collapsed" : ""}`}
         style={panelStyle}
       >
-        {!collapsed && (
+        {sidebarResizeHandle}
+        {!collapsed && !fillsContainer && (
           <div
             className="ae-file-tree-resize-handle"
             role="separator"
@@ -860,6 +910,7 @@ export function FileTreePanel({ component, state, onEvent }: BuiltinComponentPro
       aria-label="Project files"
       style={panelStyle}
     >
+      {sidebarResizeHandle}
       {!collapsed && !fillsContainer && (
         <div
           className="ae-file-tree-resize-handle"

--- a/src/skills/default-layout/sidebar/index.test.tsx
+++ b/src/skills/default-layout/sidebar/index.test.tsx
@@ -1,0 +1,154 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { Sidebar } from ".";
+import type { A2UIComponent } from "../../../types/a2ui";
+import type { ComponentProps } from "react";
+
+afterEach(() => cleanup());
+
+type SidebarOnEvent = ComponentProps<typeof Sidebar>["onEvent"];
+type SidebarOnEventMock = ReturnType<typeof vi.fn<SidebarOnEvent>>;
+
+function sidebarComponent(props: Record<string, unknown>): A2UIComponent {
+  return {
+    id: "sidebar",
+    type: "sidebar",
+    props,
+  };
+}
+
+function renderSidebar({
+  props = {},
+  state = {},
+  onEvent = vi.fn<SidebarOnEvent>(),
+}: {
+  props?: Record<string, unknown>;
+  state?: Record<string, unknown>;
+  onEvent?: SidebarOnEventMock;
+} = {}) {
+  render(
+    <Sidebar
+      component={sidebarComponent({
+        title: "aethon",
+        sections: [
+          {
+            id: "projects",
+            title: "projects",
+            items: [{ id: "project:aethon", label: "aethon" }],
+          },
+        ],
+        ...props,
+      })}
+      state={state}
+      onEvent={onEvent}
+      renderChildWithState={() => null}
+    />,
+  );
+  return { onEvent };
+}
+
+describe("Sidebar extension controls", () => {
+  it("auto-renders extension controls when extension items are hydrated", () => {
+    renderSidebar({
+      state: {
+        sidebar: {
+          extensions: [
+            {
+              id: "ext:mold-gallery",
+              label: "mold-gallery",
+              hint: "project",
+              active: true,
+            },
+          ],
+        },
+      },
+    });
+
+    expect(screen.getByText("extensions")).toBeTruthy();
+    expect(screen.getByText("mold-gallery")).toBeTruthy();
+    expect(screen.getByText("project")).toBeTruthy();
+  });
+
+  it("routes extension toggles from the auto-rendered context menu", () => {
+    const { onEvent } = renderSidebar({
+      state: {
+        sidebar: {
+          extensions: [
+            {
+              id: "ext:mold-gallery",
+              label: "mold-gallery",
+              hint: "project",
+              active: true,
+            },
+          ],
+        },
+      },
+    });
+
+    fireEvent.contextMenu(screen.getByText("mold-gallery").closest("li")!);
+    fireEvent.click(screen.getByRole("menuitem", { name: /Disable extension/ }));
+
+    expect(onEvent).toHaveBeenCalledWith(
+      "toggle-extension",
+      {
+        sectionId: "extensions",
+        itemId: "ext:mold-gallery",
+        name: "mold-gallery",
+        disabled: true,
+      },
+    );
+  });
+
+  it("does not duplicate a layout-provided extensions section", () => {
+    renderSidebar({
+      props: {
+        sections: [
+          {
+            id: "extensions",
+            title: "custom extensions",
+            items: [{ id: "manual", label: "Manual row" }],
+          },
+        ],
+      },
+      state: {
+        sidebar: {
+          extensions: [
+            {
+              id: "ext:mold-gallery",
+              label: "mold-gallery",
+              hint: "project",
+              active: true,
+            },
+          ],
+        },
+      },
+    });
+
+    expect(screen.getByText("custom extensions")).toBeTruthy();
+    expect(screen.getByText("Manual row")).toBeTruthy();
+    expect(screen.queryByText("mold-gallery")).toBeNull();
+  });
+
+  it("hides empty sections that opt into hideWhenEmpty", () => {
+    renderSidebar({
+      props: {
+        sections: [
+          {
+            id: "extensions",
+            title: "extensions",
+            items: { $ref: "/sidebar/extensions" },
+            hideWhenEmpty: true,
+          },
+        ],
+      },
+      state: {
+        sidebar: {
+          extensions: [],
+        },
+      },
+    });
+
+    expect(screen.queryByText("extensions")).toBeNull();
+  });
+});

--- a/src/skills/default-layout/sidebar/index.tsx
+++ b/src/skills/default-layout/sidebar/index.tsx
@@ -535,8 +535,18 @@ export function Sidebar({
           const actions = section.actions ?? [];
           const isProjects = section.id === "projects";
           return (
-            <div key={section.id} className="a2ui-sidebar-section">
-              <div className="a2ui-sidebar-section-title">{section.title}</div>
+            <div
+              key={section.id}
+              className={[
+                "a2ui-sidebar-section",
+                section.title ? "" : "a2ui-sidebar-section-no-title",
+              ]
+                .filter(Boolean)
+                .join(" ")}
+            >
+              {section.title && (
+                <div className="a2ui-sidebar-section-title">{section.title}</div>
+              )}
               {items.length === 0 ? (
                 <div className="a2ui-sidebar-empty">empty</div>
               ) : (

--- a/src/skills/default-layout/sidebar/index.tsx
+++ b/src/skills/default-layout/sidebar/index.tsx
@@ -495,8 +495,28 @@ export function Sidebar({
     const resolved = resolvePointer(state, raw.$ref);
     return Array.isArray(resolved) ? (resolved as SidebarSection[]) : [];
   })();
+  const extensionItems = (() => {
+    const sidebar = (state.sidebar as Record<string, unknown> | undefined) ?? {};
+    const raw = sidebar.extensions;
+    return Array.isArray(raw) ? (raw as SidebarItem[]) : [];
+  })();
+  const hasExplicitExtensionSection = [
+    ...(props.sections ?? []),
+    ...(extraSections as SidebarSectionExt[]),
+  ].some((section) => section.id === "extensions");
+  const extensionSections: SidebarSectionExt[] =
+    extensionItems.length > 0 && !hasExplicitExtensionSection
+      ? [
+          {
+            id: "extensions",
+            title: "extensions",
+            items: extensionItems,
+          },
+        ]
+      : [];
   const allSections: SidebarSectionExt[] = [
     ...(props.sections ?? []),
+    ...extensionSections,
     ...(extraSections as SidebarSectionExt[]),
   ];
 
@@ -517,6 +537,9 @@ export function Sidebar({
       <div className="a2ui-sidebar-sections">
         {allSections.map((section) => {
           const items = resolveItems(section.items);
+          if (section.hideWhenEmpty === true && items.length === 0) {
+            return null;
+          }
           const monoItems = section.monoItems === true;
           if (section.searchable === true || section.groupByPrefix === true) {
             return (

--- a/src/skills/default-layout/sidebar/worktree-row.test.tsx
+++ b/src/skills/default-layout/sidebar/worktree-row.test.tsx
@@ -84,6 +84,53 @@ describe("WorktreeRow", () => {
     );
   });
 
+  it("opens inline confirmation from the remove icon", () => {
+    const { onEvent } = harness(wt({ label: "feature-x" }));
+    const row = screen.getByText("feature-x").closest("li")!;
+    fireEvent.click(screen.getByRole("button", { name: "Remove feature-x" }));
+    expect(onEvent).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("button", { name: "Confirm remove feature-x" }).textContent,
+    ).toBe("Confirm");
+    fireEvent.click(row);
+    expect(onEvent).not.toHaveBeenCalled();
+  });
+
+  it("confirms inline worktree removal without switching rows", () => {
+    const { onEvent } = harness(wt({ label: "feature-x" }));
+    fireEvent.click(screen.getByRole("button", { name: "Remove feature-x" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Confirm remove feature-x" }),
+    );
+    expect(onEvent).toHaveBeenCalledTimes(1);
+    expect(onEvent).toHaveBeenCalledWith(
+      "remove-worktree",
+      expect.objectContaining({ worktreeId: "wt-1", confirmed: true }),
+      "wt-1",
+    );
+  });
+
+  it("clears inline remove confirmation when the pointer leaves", () => {
+    const { onEvent } = harness(wt({ label: "feature-x" }));
+    const row = screen.getByText("feature-x").closest("li")!;
+    fireEvent.click(screen.getByRole("button", { name: "Remove feature-x" }));
+    fireEvent.mouseLeave(row);
+    expect(
+      screen.queryByRole("button", { name: "Confirm remove feature-x" }),
+    ).toBeNull();
+    fireEvent.click(row);
+    expect(onEvent).toHaveBeenCalledWith(
+      "switch-worktree",
+      expect.objectContaining({ worktreeId: "wt-1" }),
+      "wt-1",
+    );
+  });
+
+  it("does not show inline remove for the main worktree", () => {
+    harness(wt({ isMain: true, label: "main" }));
+    expect(screen.queryByRole("button", { name: "Remove main" })).toBeNull();
+  });
+
   it("flags main worktree with accent glyph", () => {
     harness(wt({ isMain: true, label: "main" }));
     const row = screen.getByText("main").closest("li")!;

--- a/src/skills/default-layout/sidebar/worktree-row.tsx
+++ b/src/skills/default-layout/sidebar/worktree-row.tsx
@@ -10,6 +10,7 @@
  * joins the regular list.
  */
 
+import { useState } from "react";
 import type { BuiltinComponentProps } from "../../../components/A2UIRenderer";
 
 export interface WorktreeSidebarItem {
@@ -43,9 +44,11 @@ export function WorktreeRow({
   onEvent,
   onItemContextMenu,
 }: WorktreeRowProps) {
+  const [confirmingRemove, setConfirmingRemove] = useState(false);
   const pending = item.pendingState;
   const isPendingActive = pending === "queued" || pending === "starting";
   const isFailed = pending === "failed";
+  const canRemoveInline = !item.isMain && !isPendingActive && !isFailed;
 
   const className = [
     "a2ui-sidebar-item",
@@ -65,12 +68,13 @@ export function WorktreeRow({
     <li
       className={className}
       title={tooltip}
+      onMouseLeave={() => setConfirmingRemove(false)}
       onClick={() => {
-        if (isPendingActive || isFailed) return;
+        if (isPendingActive || isFailed || confirmingRemove) return;
         onEvent("switch-worktree", { sectionId, worktreeId: item.id }, item.id);
       }}
       onDoubleClick={() => {
-        if (isPendingActive || isFailed) return;
+        if (isPendingActive || isFailed || confirmingRemove) return;
         onEvent(
           "open-worktree-in-new-tab",
           { sectionId, worktreeId: item.id },
@@ -165,6 +169,55 @@ export function WorktreeRow({
           title="Worktree is locked"
         >
           ◆
+        </span>
+      ) : null}
+      {canRemoveInline ? (
+        <span className="ae-worktree-remove-slot">
+          {confirmingRemove ? (
+            <button
+              type="button"
+              className="ae-worktree-confirm-remove"
+              aria-label={`Confirm remove ${displayLabel}`}
+              onClick={(e) => {
+                e.stopPropagation();
+                onEvent(
+                  "remove-worktree",
+                  { sectionId, worktreeId: item.id, confirmed: true },
+                  item.id,
+                );
+              }}
+            >
+              Confirm
+            </button>
+          ) : (
+            <button
+              type="button"
+              className="ae-worktree-remove"
+              aria-label={`Remove ${displayLabel}`}
+              title="Remove worktree"
+              onClick={(e) => {
+                e.stopPropagation();
+                setConfirmingRemove(true);
+              }}
+            >
+              <svg
+                viewBox="0 0 16 16"
+                width="14"
+                height="14"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M5.5 2.75h5M6.25 2.75l.5-1h2.5l.5 1M3.5 4.5h9M5 4.5l.55 9h4.9l.55-9M7 6.5v5M9 6.5v5"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="1.35"
+                />
+              </svg>
+            </button>
+          )}
         </span>
       ) : null}
     </li>

--- a/src/skills/default-layout/variation-components.test.tsx
+++ b/src/skills/default-layout/variation-components.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import { ModelPicker } from "./variation-components";
+
+beforeEach(() => {
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+    cb(0);
+    return 1;
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("ModelPicker", () => {
+  it("emits the selected model id from the rendered dropdown", () => {
+    const onEvent = vi.fn();
+    render(
+      <ModelPicker
+        component={{ id: "model-picker", type: "model-picker", props: {} }}
+        state={{
+          model: "anthropic/claude-opus-4-7",
+          sidebar: {
+            models: [
+              {
+                id: "anthropic/claude-opus-4-7",
+                label: "Claude Opus 4.7",
+              },
+              { id: "openai/gpt-5.5", label: "GPT-5.5" },
+            ],
+          },
+        }}
+        onEvent={onEvent}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Claude Opus 4.7/i }));
+    fireEvent.change(screen.getByPlaceholderText(/filter models/i), {
+      target: { value: "gpt" },
+    });
+    fireEvent.click(screen.getByText("GPT-5.5").closest("li")!);
+
+    expect(onEvent).toHaveBeenCalledWith(
+      "select",
+      { sectionId: "models", itemId: "openai/gpt-5.5" },
+      "openai/gpt-5.5",
+    );
+    expect(screen.queryByRole("listbox")).toBeNull();
+  });
+
+  it("supports keyboard selection inside the portal listbox", () => {
+    const onEvent = vi.fn();
+    render(
+      <ModelPicker
+        component={{ id: "model-picker", type: "model-picker", props: {} }}
+        state={{
+          model: "anthropic/claude-opus-4-7",
+          sidebar: {
+            models: [
+              { id: "anthropic/claude-opus-4-7", label: "Claude Opus 4.7" },
+              { id: "openai/gpt-5.5", label: "GPT-5.5" },
+            ],
+          },
+        }}
+        onEvent={onEvent}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Claude Opus 4.7/i }));
+    fireEvent.keyDown(screen.getByText("GPT-5.5").closest("li")!, {
+      key: "Enter",
+    });
+
+    expect(onEvent).toHaveBeenCalledWith(
+      "select",
+      { sectionId: "models", itemId: "openai/gpt-5.5" },
+      "openai/gpt-5.5",
+    );
+  });
+});

--- a/src/skills/default-layout/variation-components.tsx
+++ b/src/skills/default-layout/variation-components.tsx
@@ -10,6 +10,7 @@
  */
 
 import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import type {
   BooleanValue,
   StringValue,
@@ -166,6 +167,104 @@ export function DropdownPickerCore({
     requestAnimationFrame(() => searchRef.current?.focus());
   }, [open]);
 
+  const panel =
+    open && coords ? (
+      <div
+        ref={panelRef}
+        className="a2ui-dropdown-panel"
+        data-align={align}
+        role="listbox"
+        style={{
+          top: coords.top,
+          width: coords.width,
+          ...(align === "right"
+            ? { right: coords.right }
+            : { left: coords.left }),
+        }}
+      >
+        {sections.map((section, sIdx) => {
+          const q = (queries[section.id] ?? "").trim().toLowerCase();
+          const filtered = q
+            ? section.items.filter(
+                (it) =>
+                  it.id.toLowerCase().includes(q) ||
+                  it.label.toLowerCase().includes(q),
+              )
+            : section.items;
+          return (
+            <div className="a2ui-dropdown-section" key={section.id}>
+              {section.title && (
+                <div className="a2ui-dropdown-section-title">
+                  {section.title}
+                </div>
+              )}
+              {section.searchable && (
+                <input
+                  ref={sIdx === 0 ? searchRef : undefined}
+                  type="text"
+                  className="a2ui-dropdown-search"
+                  placeholder={
+                    section.searchPlaceholder ??
+                    `filter ${(section.title ?? section.id).toLowerCase()}...`
+                  }
+                  value={queries[section.id] ?? ""}
+                  onChange={(e) =>
+                    setQueries((prev) => ({
+                      ...prev,
+                      [section.id]: e.target.value,
+                    }))
+                  }
+                  spellCheck={false}
+                  autoComplete="off"
+                />
+              )}
+              {filtered.length === 0 ? (
+                <div className="a2ui-dropdown-empty">
+                  {section.emptyLabel ?? "no matches"}
+                </div>
+              ) : (
+                <ul className="a2ui-dropdown-list">
+                  {filtered.map((it) => (
+                    <li
+                      key={it.id}
+                      className={[
+                        "a2ui-dropdown-item",
+                        it.active ? "a2ui-dropdown-item-active" : "",
+                      ]
+                        .filter(Boolean)
+                        .join(" ")}
+                      onClick={() => {
+                        onSelect(section.id, it.id);
+                        close();
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key !== "Enter" && e.key !== " ") return;
+                        e.preventDefault();
+                        onSelect(section.id, it.id);
+                        close();
+                      }}
+                      role="option"
+                      aria-selected={it.active === true}
+                      tabIndex={0}
+                    >
+                      <span className="a2ui-dropdown-item-label">
+                        {it.label}
+                      </span>
+                      {it.hint && (
+                        <span className="a2ui-dropdown-item-hint">
+                          {it.hint}
+                        </span>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    ) : null;
+
   return (
     <div
       ref={rootRef}
@@ -185,95 +284,7 @@ export function DropdownPickerCore({
           ▾
         </span>
       </button>
-      {open && coords && (
-        <div
-          ref={panelRef}
-          className="a2ui-dropdown-panel"
-          data-align={align}
-          role="listbox"
-          style={{
-            top: coords.top,
-            width: coords.width,
-            ...(align === "right"
-              ? { right: coords.right }
-              : { left: coords.left }),
-          }}
-        >
-          {sections.map((section, sIdx) => {
-            const q = (queries[section.id] ?? "").trim().toLowerCase();
-            const filtered = q
-              ? section.items.filter(
-                  (it) =>
-                    it.id.toLowerCase().includes(q) ||
-                    it.label.toLowerCase().includes(q),
-                )
-              : section.items;
-            return (
-              <div className="a2ui-dropdown-section" key={section.id}>
-                {section.title && (
-                  <div className="a2ui-dropdown-section-title">
-                    {section.title}
-                  </div>
-                )}
-                {section.searchable && (
-                  <input
-                    ref={sIdx === 0 ? searchRef : undefined}
-                    type="text"
-                    className="a2ui-dropdown-search"
-                    placeholder={
-                      section.searchPlaceholder ??
-                      `filter ${(section.title ?? section.id).toLowerCase()}…`
-                    }
-                    value={queries[section.id] ?? ""}
-                    onChange={(e) =>
-                      setQueries((prev) => ({
-                        ...prev,
-                        [section.id]: e.target.value,
-                      }))
-                    }
-                    spellCheck={false}
-                    autoComplete="off"
-                  />
-                )}
-                {filtered.length === 0 ? (
-                  <div className="a2ui-dropdown-empty">
-                    {section.emptyLabel ?? "no matches"}
-                  </div>
-                ) : (
-                  <ul className="a2ui-dropdown-list">
-                    {filtered.map((it) => (
-                      <li
-                        key={it.id}
-                        className={[
-                          "a2ui-dropdown-item",
-                          it.active ? "a2ui-dropdown-item-active" : "",
-                        ]
-                          .filter(Boolean)
-                          .join(" ")}
-                        onClick={() => {
-                          onSelect(section.id, it.id);
-                          close();
-                        }}
-                        role="option"
-                        aria-selected={it.active === true}
-                      >
-                        <span className="a2ui-dropdown-item-label">
-                          {it.label}
-                        </span>
-                        {it.hint && (
-                          <span className="a2ui-dropdown-item-hint">
-                            {it.hint}
-                          </span>
-                        )}
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              </div>
-            );
-          })}
-        </div>
-      )}
+      {panel ? createPortal(panel, document.body) : null}
     </div>
   );
 }

--- a/src/skills/default-layout/workstation.a2ui.json
+++ b/src/skills/default-layout/workstation.a2ui.json
@@ -79,7 +79,7 @@
                 "sections": [
                   {
                     "id": "hosts",
-                    "title": "hosts",
+                    "title": "",
                     "items": { "$ref": "/sidebar/hosts" }
                   },
                   {
@@ -232,7 +232,7 @@
       "sidebarVisible": true,
       "filesSidebarVisible": true,
       "columns": "220px minmax(0,1fr) 360px",
-      "rows": "38px minmax(0,1fr) auto auto auto",
+      "rows": "38px minmax(0,1fr) 0px auto auto",
       "areas": [
         "sidebar header files-sidebar",
         "sidebar canvas files-sidebar",

--- a/src/skills/default-layout/workstation.a2ui.json
+++ b/src/skills/default-layout/workstation.a2ui.json
@@ -89,6 +89,12 @@
                     "actions": [
                       { "id": "open-project", "label": "Open project…" }
                     ]
+                  },
+                  {
+                    "id": "extensions",
+                    "title": "extensions",
+                    "items": { "$ref": "/sidebar/extensions" },
+                    "hideWhenEmpty": true
                   }
                 ],
                 "extraSections": { "$ref": "/sidebar/extraSections" }
@@ -246,6 +252,7 @@
       "models": [],
       "hosts": [],
       "projects": [],
+      "extensions": [],
       "extraSections": [],
       "themes": [
         { "id": "ember", "label": "Ember — warm dark", "active": true },

--- a/src/state/sessionUiSnapshot.test.ts
+++ b/src/state/sessionUiSnapshot.test.ts
@@ -123,4 +123,25 @@ describe("sessionUiSnapshot", () => {
       columns: "256px minmax(0,1fr) 360px",
     });
   });
+
+  it("restores hidden files sidebar as a 0px track for panel animation", () => {
+    const tab = {
+      ...makeEmptyTab("tab-a", "A"),
+      messages: [{ id: "m1", role: "user" as const, text: "hi" }],
+    };
+    saveSessionUiSnapshot({
+      tabs: [tab],
+      activeTabId: "tab-a",
+      layout: {
+        sidebarVisible: true,
+        filesSidebarVisible: false,
+        columns: "256px minmax(0,1fr)",
+      },
+    });
+
+    expect(loadSessionUiSnapshot()?.layout).toMatchObject({
+      filesSidebarVisible: false,
+      columns: "256px minmax(0,1fr) 0px",
+    });
+  });
 });

--- a/src/state/sessionUiSnapshot.test.ts
+++ b/src/state/sessionUiSnapshot.test.ts
@@ -80,6 +80,34 @@ describe("sessionUiSnapshot", () => {
     expect(restored?.activeTabId).toBe("agent");
   });
 
+  it("preserves editor rootPath for files outside the active project", () => {
+    const tab = {
+      ...makeEmptyTab("editor", "system-prompt.md", null, "editor"),
+      editor: {
+        filePath: "/Users/test/.aethon/system-prompt.md",
+        rootPath: "/Users/test/.aethon",
+        language: "markdown",
+        isDirty: true,
+        cursorLine: 12,
+        cursorColumn: 4,
+      },
+    };
+
+    saveSessionUiSnapshot({
+      tabs: [tab],
+      activeTabId: "editor",
+    });
+
+    expect(loadSessionUiSnapshot()?.tabs[0]?.editor).toMatchObject({
+      filePath: "/Users/test/.aethon/system-prompt.md",
+      rootPath: "/Users/test/.aethon",
+      language: "markdown",
+      isDirty: false,
+      cursorLine: 12,
+      cursorColumn: 4,
+    });
+  });
+
   it("does not persist blank empty new tabs", () => {
     saveSessionUiSnapshot({
       tabs: [

--- a/src/state/sessionUiSnapshot.ts
+++ b/src/state/sessionUiSnapshot.ts
@@ -72,25 +72,18 @@ function durableLayoutSnapshot(layout: unknown): Record<string, unknown> | undef
   }
   if (typeof input.columns === "string") {
     // Preserve fixed left + right column widths; reset the center to
-    // minmax(0,1fr) so the user's resize sticks across reloads. Three
-    // shapes are supported:
-    //   "<L>px minmax(0,1fr)"            (files sidebar hidden)
-    //   "<L>px minmax(0,1fr) <R>px"      (canonical: left + files-right)
-    //   (legacy: any old 2-col shape)    → upgrade to 3-col 280px
-    //
-    // Critically: when filesSidebarVisible is explicitly false, the live
-    // grid is 2-col, and we must keep it 2-col on restore — otherwise
-    // the right pane stays hidden but its 280px slot renders as blank
-    // space until the user toggles the panel back.
+    // minmax(0,1fr) so the user's resize sticks across reloads. Hidden
+    // sidebars stay as 0px sentinel tracks so the grid can animate
+    // toggles instead of changing track count.
     const filesHidden = input.filesSidebarVisible === false;
     const tokens = input.columns.trim().split(/\s+/);
     const first = tokens[0];
     const last = tokens[tokens.length - 1];
     if (tokens.length >= 2 && /^\d+px$/.test(first)) {
-      if (filesHidden) {
-        next.columns = `${first} minmax(0,1fr)`;
-      } else if (/^\d+px$/.test(last) && tokens.length >= 3) {
+      if (/^\d+px$/.test(last) && tokens.length >= 3) {
         next.columns = `${first} minmax(0,1fr) ${last}`;
+      } else if (filesHidden) {
+        next.columns = `${first} minmax(0,1fr) 0px`;
       } else {
         // Legacy snapshot — let the boot payload's default fill in
         // the right column so the redesigned 3-column layout still

--- a/src/state/sessionUiSnapshot.ts
+++ b/src/state/sessionUiSnapshot.ts
@@ -151,6 +151,9 @@ export function parseSessionUiSnapshot(raw: string): SessionUiSnapshot | null {
           ? {
               editor: {
                 filePath: t.editor.filePath,
+                ...(typeof t.editor.rootPath === "string" && t.editor.rootPath
+                  ? { rootPath: t.editor.rootPath }
+                  : {}),
                 language: typeof t.editor.language === "string"
                   ? t.editor.language
                   : "plaintext",

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -138,17 +138,15 @@ body {
   min-width: 0;
   min-height: 0;
   overflow: hidden;
-  /* Animate column / row template changes so toggling the sidebar,
-     files sidebar, or terminal panel feels smooth instead of snapping.
-     `transition: grid-template-*` is widely supported in WebKit/Blink
-     since 2024; Firefox lags but Aethon ships in a WebKit Tauri shell
-     so this lands. Resize drags suppress the transition (see
-     `body.ae-resizing-sidebar`) so live drag stays buttery. */
+  /* Animate stable panel tracks so sidebar/console toggles glide like
+     Codex. Resize drags suppress the transition so live drag stays direct. */
+  will-change: grid-template-columns, grid-template-rows;
   transition:
-    grid-template-columns var(--motion-base) var(--ease-out),
-    grid-template-rows var(--motion-base) var(--ease-out);
+    grid-template-columns var(--motion-panel) var(--ease-panel),
+    grid-template-rows var(--motion-panel) var(--ease-panel);
 }
 body.ae-resizing-sidebar .a2ui-layout,
+body.ae-resizing-terminal .a2ui-layout,
 body.ae-resizing-composer .a2ui-layout {
   transition: none;
 }
@@ -157,6 +155,13 @@ body.ae-resizing-composer .a2ui-layout {
   overflow: hidden;
   min-width: 0;
   min-height: 0;
+  opacity: 1;
+  pointer-events: auto;
+  transition: opacity var(--motion-panel) var(--ease-panel);
+}
+.a2ui-layout-cell[data-visible="false"] {
+  opacity: 0;
+  pointer-events: none;
 }
 
 .a2ui-layout-cell > .a2ui-renderer,
@@ -344,6 +349,28 @@ body.ae-resizing-sidebar .ae-file-tree-resize-handle {
     transparent 4px
   );
 }
+.ae-file-tree-sidebar-resize-handle {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: -3px;
+  width: 6px;
+  cursor: ew-resize;
+  z-index: 12;
+  background: transparent;
+  transition: background 120ms ease;
+}
+.ae-file-tree-sidebar-resize-handle:hover,
+body.ae-resizing-sidebar .ae-file-tree-sidebar-resize-handle {
+  background: linear-gradient(
+    to right,
+    transparent 0,
+    transparent 2px,
+    var(--accent, #ff6a18) 2px,
+    var(--accent, #ff6a18) 4px,
+    transparent 4px
+  );
+}
 .ae-file-tree-list {
   list-style: none;
   margin: 0;
@@ -503,6 +530,9 @@ body.ae-resizing-sidebar .a2ui-layout {
 .a2ui-sidebar-section {
   padding: var(--space-1) 0;
 }
+.a2ui-sidebar-section-no-title {
+  padding-top: 0;
+}
 
 .a2ui-sidebar-section-title {
   padding: var(--space-3) var(--space-4) var(--space-2);
@@ -623,7 +653,12 @@ body.ae-resizing-sidebar .a2ui-layout {
 /* Right-aligned hint chip — `⌘\``, `⌘K`, `2h`, `yest`. Mono, dim, 10px. */
 .a2ui-sidebar-item-hint {
   margin-left: auto;
-  flex-shrink: 0;
+  flex: 0 1 auto;
+  min-width: 0;
+  max-width: 40%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   color: var(--text-dim);
   font-size: var(--chrome-text-compact);
   font-family: var(--font-mono);
@@ -651,12 +686,9 @@ body.ae-resizing-sidebar .a2ui-layout {
 .a2ui-sidebar-item-label {
   flex: 1 1 auto;
   min-width: 0;
-  /* Long names wrap to a second line within the sidebar instead of
-     truncating with ellipsis or scrolling horizontally. The sidebar
-     itself never scrolls horizontally — wider names just take two
-     short lines (`nyc-real-` / `estate`). */
-  overflow-wrap: anywhere;
-  white-space: normal;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   line-height: 1.25;
 }
 /* Tiny icon (favicon-sized) rendered before the label for both host
@@ -3120,7 +3152,13 @@ body.ae-resizing-composer * {
   background: var(--bg-elev);
   border-top: 1px solid var(--border);
   min-height: 0;
-  height: 240px;
+  height: 100%;
+  opacity: 1;
+  transition: opacity var(--motion-panel) var(--ease-panel);
+}
+.ae-terminal-panel.is-closed {
+  opacity: 0;
+  pointer-events: none;
 }
 .ae-terminal-panel-resize-handle {
   position: absolute;
@@ -4275,6 +4313,7 @@ span.a2ui-project-card-icon--initial {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: var(--space-3);
   padding: var(--space-2) var(--space-3);
   border-radius: var(--radius-sm);
   cursor: pointer;
@@ -4282,6 +4321,11 @@ span.a2ui-project-card-icon--initial {
 }
 .a2ui-projects-dashboard-sessions li:hover {
   background: var(--bg-hover);
+}
+.a2ui-projects-dashboard-sessions li.is-confirming,
+.a2ui-project-dashboard-sessions li.is-confirming {
+  background: var(--bg-hover);
+  cursor: default;
 }
 .a2ui-projects-dashboard-session-label {
   font-size: var(--text-md);
@@ -4294,8 +4338,84 @@ span.a2ui-project-card-icon--initial {
 .a2ui-projects-dashboard-session-meta {
   font-size: var(--chrome-text-muted);
   color: var(--text-dim);
-  margin-left: var(--space-3);
   flex-shrink: 0;
+}
+.a2ui-projects-dashboard-session-actions,
+.a2ui-project-dashboard-session-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex: 0 0 auto;
+  min-width: max-content;
+}
+.a2ui-dashboard-session-confirm {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: max-content;
+}
+.a2ui-dashboard-session-confirm-delete {
+  height: 28px;
+  padding: 0 var(--space-3);
+  border-radius: var(--radius-sm);
+  font-size: var(--chrome-text-compact);
+  border: 1px solid color-mix(in oklab, var(--error) 28%, var(--border));
+  background: color-mix(in oklab, var(--error) 10%, transparent);
+  color: var(--error);
+  cursor: pointer;
+  transition:
+    background var(--motion-fast) var(--ease-out),
+    border-color var(--motion-fast) var(--ease-out),
+    color var(--motion-fast) var(--ease-out);
+}
+.a2ui-dashboard-session-confirm-delete:hover {
+  background: color-mix(in oklab, var(--error) 16%, transparent);
+  border-color: color-mix(in oklab, var(--error) 52%, var(--border));
+}
+.a2ui-dashboard-session-confirm-delete:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+.a2ui-projects-dashboard-session-delete,
+.a2ui-project-dashboard-session-delete {
+  display: inline-grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  color: var(--text-dim);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  opacity: 0;
+  transform: scale(0.96);
+  transition:
+    opacity var(--motion-fast) var(--ease-out),
+    transform var(--motion-fast) var(--ease-out),
+    color var(--motion-fast) var(--ease-out),
+    background var(--motion-fast) var(--ease-out),
+    border-color var(--motion-fast) var(--ease-out);
+}
+.a2ui-projects-dashboard-sessions li:hover .a2ui-projects-dashboard-session-delete,
+.a2ui-projects-dashboard-session-delete:focus-visible,
+.a2ui-projects-dashboard-sessions li.is-confirming .a2ui-projects-dashboard-session-delete,
+.a2ui-project-dashboard-sessions li:hover .a2ui-project-dashboard-session-delete,
+.a2ui-project-dashboard-session-delete:focus-visible,
+.a2ui-project-dashboard-sessions li.is-confirming .a2ui-project-dashboard-session-delete {
+  opacity: 1;
+  transform: scale(1);
+}
+.a2ui-projects-dashboard-session-delete:hover,
+.a2ui-project-dashboard-session-delete:hover {
+  color: var(--error);
+  background: color-mix(in oklab, var(--error) 10%, transparent);
+  border-color: color-mix(in oklab, var(--error) 28%, transparent);
+}
+.a2ui-projects-dashboard-session-delete:focus-visible,
+.a2ui-project-dashboard-session-delete:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
 }
 
 /* ---- Project card --------------------------------------------------- */
@@ -4558,6 +4678,7 @@ button.a2ui-gh-stat:hover {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: var(--space-3);
   padding: var(--space-2) var(--space-3);
   border-radius: var(--radius-sm);
   cursor: pointer;
@@ -4578,7 +4699,7 @@ button.a2ui-gh-stat:hover {
 .a2ui-project-dashboard-session-meta {
   font-size: var(--chrome-text-muted);
   color: var(--text-dim);
-  margin-left: var(--space-3);
+  flex-shrink: 0;
 }
 
 .a2ui-project-dashboard-widgets {

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -33,6 +33,10 @@
 .ae-settings-panel *,
 .ae-notification,
 .ae-notification *,
+.a2ui-projects-dashboard,
+.a2ui-projects-dashboard *,
+.a2ui-project-dashboard,
+.a2ui-project-dashboard *,
 .a2ui-empty-state,
 .a2ui-empty-state *,
 .a2ui-empty-state-card,
@@ -42,6 +46,15 @@
 }
 
 [data-selectable] {
+  user-select: text;
+  -webkit-user-select: text;
+}
+
+input,
+textarea,
+[contenteditable="true"],
+.monaco-editor,
+.monaco-editor * {
   user-select: text;
   -webkit-user-select: text;
 }
@@ -819,6 +832,14 @@ body.ae-resizing-sidebar .a2ui-layout {
 .ae-worktree-branch {
   margin-left: auto;
 }
+.ae-worktree-remove-slot {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex: 0 0 auto;
+  min-width: 28px;
+  margin-left: var(--space-1);
+}
 .ae-worktree-row--pending {
   opacity: 0.8;
 }
@@ -852,6 +873,55 @@ body.ae-resizing-sidebar .a2ui-layout {
   outline: none;
   background: var(--accent-hover-tint);
   color: var(--accent);
+}
+.ae-worktree-remove {
+  display: inline-grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  color: var(--text-dim);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  opacity: 0;
+  transform: scale(0.96);
+  transition:
+    opacity var(--motion-fast) var(--ease-out),
+    transform var(--motion-fast) var(--ease-out),
+    color var(--motion-fast) var(--ease-out),
+    background var(--motion-fast) var(--ease-out),
+    border-color var(--motion-fast) var(--ease-out);
+}
+.ae-worktree-row:hover .ae-worktree-remove,
+.ae-worktree-remove:focus-visible {
+  opacity: 1;
+  transform: scale(1);
+}
+.ae-worktree-remove:hover {
+  color: var(--error);
+  background: color-mix(in oklab, var(--error) 10%, transparent);
+  border-color: color-mix(in oklab, var(--error) 28%, transparent);
+}
+.ae-worktree-remove:focus-visible,
+.ae-worktree-confirm-remove:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+.ae-worktree-confirm-remove {
+  height: 26px;
+  padding: 0 var(--space-2);
+  border-radius: var(--radius-sm);
+  font-size: var(--chrome-text-compact);
+  border: 1px solid color-mix(in oklab, var(--error) 28%, var(--border));
+  background: color-mix(in oklab, var(--error) 10%, transparent);
+  color: var(--error);
+  cursor: pointer;
+}
+.ae-worktree-confirm-remove:hover {
+  background: color-mix(in oklab, var(--error) 16%, transparent);
+  border-color: color-mix(in oklab, var(--error) 52%, var(--border));
 }
 .ae-worktree-lock {
   flex-shrink: 0;
@@ -4665,6 +4735,57 @@ button.a2ui-gh-stat:hover {
   color: var(--text-dim);
   text-transform: uppercase;
   letter-spacing: 0.08em;
+}
+.a2ui-project-dashboard-worktree-remove {
+  display: inline-grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  margin-left: auto;
+  padding: 0;
+  color: var(--text-dim);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  opacity: 0;
+  transform: scale(0.96);
+  transition:
+    opacity var(--motion-fast) var(--ease-out),
+    transform var(--motion-fast) var(--ease-out),
+    color var(--motion-fast) var(--ease-out),
+    background var(--motion-fast) var(--ease-out),
+    border-color var(--motion-fast) var(--ease-out);
+}
+.a2ui-project-dashboard-worktree:hover .a2ui-project-dashboard-worktree-remove,
+.a2ui-project-dashboard-worktree-remove:focus-visible {
+  opacity: 1;
+  transform: scale(1);
+}
+.a2ui-project-dashboard-worktree-remove:hover {
+  color: var(--error);
+  background: color-mix(in oklab, var(--error) 10%, transparent);
+  border-color: color-mix(in oklab, var(--error) 28%, transparent);
+}
+.a2ui-project-dashboard-worktree-confirm-remove {
+  height: 28px;
+  margin-left: auto;
+  padding: 0 var(--space-3);
+  border-radius: var(--radius-sm);
+  font-size: var(--chrome-text-compact);
+  border: 1px solid color-mix(in oklab, var(--error) 28%, var(--border));
+  background: color-mix(in oklab, var(--error) 10%, transparent);
+  color: var(--error);
+  cursor: pointer;
+}
+.a2ui-project-dashboard-worktree-confirm-remove:hover {
+  background: color-mix(in oklab, var(--error) 16%, transparent);
+  border-color: color-mix(in oklab, var(--error) 52%, var(--border));
+}
+.a2ui-project-dashboard-worktree-remove:focus-visible,
+.a2ui-project-dashboard-worktree-confirm-remove:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
 }
 
 .a2ui-project-dashboard-sessions {

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -293,6 +293,7 @@
     --motion-fast: 0ms;
     --motion-base: 0ms;
     --motion-slow: 60ms;
+    --motion-panel: 0ms;
   }
   .a2ui-terminal,
   .ae-agent-pill-dot,

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -69,12 +69,14 @@
   /* Easing — paired with --motion-* below for transition shorthands. */
   --ease-out: cubic-bezier(0.2, 0.7, 0.2, 1);
   --ease-out-strong: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-panel: cubic-bezier(0.16, 1, 0.3, 1);
   --ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
 
   /* Motion timing — overridden by prefers-reduced-motion in themes.css. */
   --motion-fast: 120ms;
   --motion-base: 160ms;
   --motion-slow: 240ms;
+  --motion-panel: 300ms;
 
   /* App layout — UI scale + viewport normalization. */
   --app-ui-scale: 1;

--- a/src/systemPromptBaseline.test.ts
+++ b/src/systemPromptBaseline.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildEditableSystemPromptBaseline,
+  DEFAULT_AETHON_SYSTEM_PROMPT,
+} from "./systemPromptBaseline";
+
+describe("system prompt baseline", () => {
+  it("extracts the bridge's default Aethon prompt for editor seeding", () => {
+    expect(DEFAULT_AETHON_SYSTEM_PROMPT).toContain("# About Aethon");
+    expect(DEFAULT_AETHON_SYSTEM_PROMPT).toContain(
+      "`globalThis.aethon.getRuntimeSnapshot()`",
+    );
+  });
+
+  it("explains why the live runtime snapshot is not persisted", () => {
+    const baseline = buildEditableSystemPromptBaseline();
+    expect(baseline).toContain(DEFAULT_AETHON_SYSTEM_PROMPT);
+    expect(baseline).toContain(
+      "live runtime snapshot and system-prompt-append.md",
+    );
+  });
+});

--- a/src/systemPromptBaseline.ts
+++ b/src/systemPromptBaseline.ts
@@ -1,0 +1,41 @@
+import systemPromptSource from "../agent/system-prompt.ts?raw";
+
+function extractDefaultPrompt(source: string): string {
+  const marker = "export const DEFAULT_AETHON_PROMPT = `";
+  const start = source.indexOf(marker);
+  if (start === -1) return "";
+  let escaped = false;
+  let out = "";
+  for (let i = start + marker.length; i < source.length; i += 1) {
+    const ch = source[i];
+    if (escaped) {
+      out += ch === "`" || ch === "$" ? ch : `\\${ch}`;
+      escaped = false;
+      continue;
+    }
+    if (ch === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (ch === "`") return out.trimEnd();
+    out += ch;
+  }
+  return out.trimEnd();
+}
+
+export const DEFAULT_AETHON_SYSTEM_PROMPT = extractDefaultPrompt(
+  systemPromptSource,
+);
+
+export function buildEditableSystemPromptBaseline(): string {
+  const base = DEFAULT_AETHON_SYSTEM_PROMPT.trim();
+  const note = [
+    "<!--",
+    "This file is a full override for Aethon's base system prompt.",
+    "The live runtime snapshot and system-prompt-append.md are appended",
+    "automatically by the bridge, so they are intentionally not copied",
+    "here as stale editable text.",
+    "-->",
+  ].join("\n");
+  return `${base}\n\n${note}\n`;
+}

--- a/src/types/a2ui.ts
+++ b/src/types/a2ui.ts
@@ -157,6 +157,8 @@ export interface SidebarSection {
   id: string;
   title: string;
   items: SidebarItem[] | { $ref: string };
+  /** When true, the default sidebar omits the section until it has items. */
+  hideWhenEmpty?: boolean;
 }
 
 export interface SidebarItem {

--- a/src/types/tab.ts
+++ b/src/types/tab.ts
@@ -29,6 +29,9 @@ export interface ShellMeta {
  */
 export interface EditorMeta {
   filePath: string;
+  /** Optional filesystem root for files outside the active project tree
+   *  (for example ~/.aethon/system-prompt.md opened from Settings). */
+  rootPath?: string;
   language: string;
   isDirty: boolean;
   cursorLine?: number;


### PR DESCRIPTION
## Summary

This PR bundles the current miscellaneous Aethon UI polish and reliability pass on `chore/misc-updates-fixes`.

Highlights:
- Fixes the model picker so model selection is reliable and covered by regression tests.
- Improves sidebar layout density, resize persistence, and smooth sidebar / console toggling behavior.
- Adds inline delete confirmation flows for saved sessions and worktrees, including dashboard worktree rows.
- Speeds up project/worktree switching and refreshes worktree discovery when projects are reselected.
- Adds extension management affordances in Settings and the native Extensions menu, including enable/disable support.
- Implements the Settings system prompt editor flow in Monaco, seeding `~/.aethon/system-prompt.md` from the current Aethon baseline when empty.
- Makes Escape dismiss the Settings dialog.
- Defaults the dashboard file tree to `~/.aethon`, and preserves editor `rootPath` for files outside the active project across reloads.
- Fixes project-root selection so selecting a main project does not get stuck on a stale worktree view.
- Makes GitHub issue rows feel app-native and wires Send to Agent behavior.

## Why

A few UI surfaces had drifted into awkward states after the recent dashboard/editor/sidebar refactors: model changes could get stuck, the files pane had no useful root on the dashboard, settings opened a system prompt without a useful baseline, extension controls were visible but not operational, and cached worktree rows could become stale after external git changes.

This branch makes those paths feel like one coherent desktop app again: persistent layout state, smooth chrome transitions, inline confirmation controls, real editor-backed settings files, and live project/worktree refreshes.

## Notable Fixes

- `system-prompt.md` is created under `~/.aethon` with Aethon's default prompt as an editable baseline, while the bridge still appends the runtime snapshot and append file dynamically.
- Editor tabs now retain `editor.rootPath` through session snapshot restore, so user-dir files like `~/.aethon/system-prompt.md` continue to read and save after app reload.
- Project re-selection now refreshes worktree listings every time, not only on first load, and clears a stale active worktree if the fresh git listing no longer contains it.
- File-tree open events now carry `rootPath` so Monaco can operate on non-project roots.
- Settings Escape handling preserves palette precedence but closes Settings when it is the active overlay.

## Validation

- `bunx vitest run src/state/sessionUiSnapshot.test.ts src/hooks/useProjectOps.test.ts`
- `bunx vitest run src/skills/default-layout/sidebar/file-tree.test.tsx src/eventRoutes/editor.test.ts`
- `bunx vitest run src/hooks/useKeyboardShortcuts.test.tsx src/eventRoutes/settings.test.ts src/systemPromptBaseline.test.ts`
- `bun run typecheck`
- `bun run lint` passes with 5 pre-existing warnings in dashboard/editor/layout files unrelated to this PR.
- `bun run test` passes: 130 test files, 896 tests.
- `git diff --check`
- Live dev-webview sanity check verified the dashboard file tree now roots at `.aethon` and lists `extensions`, `logs`, `sessions`, `config.toml`, etc.
