### PR TITLE
fix: restore sessions with worktree context

### DIFF
--- a/agent/active-project-cwd.test.ts
+++ b/agent/active-project-cwd.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { activeProjectCwdFromJson } from "./active-project-cwd";
+
+describe("activeProjectCwdFromJson", () => {
+  it("uses the active project path when no worktree is active", () => {
+    expect(
+      activeProjectCwdFromJson(
+        JSON.stringify({
+          activeId: "p1",
+          projects: [{ id: "p1", path: "/repo/app" }],
+        }),
+      ),
+    ).toBe("/repo/app");
+  });
+
+  it("uses the active worktree path when one is selected", () => {
+    expect(
+      activeProjectCwdFromJson(
+        JSON.stringify({
+          activeId: "p1",
+          activeWorktreeId: "wt-1",
+          projects: [{ id: "p1", path: "/repo/app" }],
+          worktreesByProject: {
+            p1: [
+              {
+                id: "wt-1",
+                projectId: "p1",
+                path: "/repo/app-fix-session-restore",
+              },
+            ],
+          },
+        }),
+      ),
+    ).toBe("/repo/app-fix-session-restore");
+  });
+
+  it("falls back to the project path when the active worktree is stale", () => {
+    expect(
+      activeProjectCwdFromJson(
+        JSON.stringify({
+          activeId: "p1",
+          activeWorktreeId: "missing",
+          projects: [{ id: "p1", path: "/repo/app" }],
+          worktreesByProject: { p1: [] },
+        }),
+      ),
+    ).toBe("/repo/app");
+  });
+
+  it("returns undefined for malformed project state", () => {
+    expect(activeProjectCwdFromJson("{nope")).toBeUndefined();
+  });
+});

--- a/agent/active-project-cwd.ts
+++ b/agent/active-project-cwd.ts
@@ -1,0 +1,66 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+interface PersistedProject {
+  id?: unknown;
+  path?: unknown;
+}
+
+interface PersistedWorktree {
+  id?: unknown;
+  projectId?: unknown;
+  path?: unknown;
+}
+
+interface PersistedProjects {
+  activeId?: unknown;
+  activeWorktreeId?: unknown;
+  projects?: PersistedProject[];
+  worktreesByProject?: Record<string, PersistedWorktree[]>;
+}
+
+export function activeProjectCwdFromJson(text: string): string | undefined {
+  let parsed: PersistedProjects;
+  try {
+    parsed = JSON.parse(text) as PersistedProjects;
+  } catch {
+    return undefined;
+  }
+  if (typeof parsed.activeId !== "string" || !parsed.activeId) return undefined;
+  if (!Array.isArray(parsed.projects)) return undefined;
+  const active = parsed.projects.find(
+    (p) => p && typeof p.id === "string" && p.id === parsed.activeId,
+  );
+  const projectPath =
+    active && typeof active.path === "string" && active.path.length > 0
+      ? active.path
+      : undefined;
+  if (!projectPath) return undefined;
+
+  if (typeof parsed.activeWorktreeId === "string" && parsed.activeWorktreeId) {
+    const worktrees = parsed.worktreesByProject?.[parsed.activeId] ?? [];
+    const activeWorktree = worktrees.find(
+      (w) =>
+        w &&
+        w.id === parsed.activeWorktreeId &&
+        w.projectId === parsed.activeId &&
+        typeof w.path === "string" &&
+        w.path.length > 0,
+    );
+    if (typeof activeWorktree?.path === "string") return activeWorktree.path;
+  }
+
+  return projectPath;
+}
+
+export async function readActiveProjectCwd(
+  userDir: string,
+): Promise<string | undefined> {
+  try {
+    return activeProjectCwdFromJson(
+      await readFile(join(userDir, "projects.json"), "utf8"),
+    );
+  } catch {
+    return undefined;
+  }
+}

--- a/agent/main.ts
+++ b/agent/main.ts
@@ -57,6 +57,7 @@ import { logger } from "./logger";
 import { resolveStateLimits } from "./state-limits";
 import { resolveAethonSystemPrompt } from "./system-prompt";
 import { readSessionTranscript } from "./session-history";
+import { readActiveProjectCwd } from "./active-project-cwd";
 import {
   AethonAgentState,
   type ExtensionFailure,
@@ -76,53 +77,12 @@ import {
   discoverPersistedTabs,
   discoverPiAethonExtensions,
 } from "./extension-loader";
-import {
-  ensureTab,
-  emitReady,
-  tabSessionDir,
-} from "./tab-lifecycle";
+import { ensureTab, emitReady, tabSessionDir } from "./tab-lifecycle";
 import { loadDisabledExtensionsSnapshot } from "./disabled-extensions";
-import {
-  captureProjectExtensionBaseline,
-  runDispatcher,
-} from "./dispatcher";
+import { captureProjectExtensionBaseline, runDispatcher } from "./dispatcher";
 
 function send(obj: Record<string, unknown>): void {
   process.stdout.write(JSON.stringify(obj) + "\n");
-}
-
-/**
- * Read the active project's cwd from `<userDir>/projects.json`.
- *
- * The frontend's `useProjectOps` boot effect sends `set_project` shortly
- * after the bridge is ready, but that arrives over the dispatcher loop —
- * which races the synchronous boot replay below. Reading projects.json
- * directly lets the bridge scope the default tab's `ensureTab` and
- * session replay to the right cwd on its very first paint, instead of
- * picking the most-recently-touched session in `sessions/default/`
- * regardless of which project produced it.
- *
- * Returns `undefined` if the file is missing, malformed, or has no
- * active project; the caller falls back to project-agnostic behaviour.
- */
-async function readActiveProjectCwd(userDir: string): Promise<string | undefined> {
-  try {
-    const text = await Bun.file(join(userDir, "projects.json")).text();
-    const parsed = JSON.parse(text) as {
-      activeId?: unknown;
-      projects?: { id?: unknown; path?: unknown }[];
-    };
-    if (typeof parsed.activeId !== "string" || !parsed.activeId) return undefined;
-    if (!Array.isArray(parsed.projects)) return undefined;
-    const active = parsed.projects.find(
-      (p) => p && typeof p.id === "string" && p.id === parsed.activeId,
-    );
-    return active && typeof active.path === "string" && active.path.length > 0
-      ? active.path
-      : undefined;
-  } catch {
-    return undefined;
-  }
 }
 
 async function main(): Promise<void> {

--- a/src-tauri/src/commands/extensions.rs
+++ b/src-tauri/src/commands/extensions.rs
@@ -24,15 +24,13 @@
 
 use std::collections::HashSet;
 use std::path::PathBuf;
-use std::process::{Command, Stdio};
+use std::process::Stdio;
 use std::sync::{Arc, Mutex};
 
 use serde::Deserialize;
 use tauri::{AppHandle, Emitter, Manager, State};
 
-use crate::{
-    AgentProcess, AgentReloadFlag, agent_reload_in_progress, project_root, resolved_login_path,
-};
+use crate::{AgentProcess, AgentReloadFlag, agent_reload_in_progress, env, project_root};
 
 // ─────────────────────────── menu items ────────────────────────────
 
@@ -815,12 +813,12 @@ pub async fn install_aethon_extension(
         .join("skills");
     let install_dir = skills_dir.clone();
     let install_spec = spec.clone();
-    let path_override = resolved_login_path();
+    let path_override = env::resolved_login_path();
 
     let install_result = tauri::async_runtime::spawn_blocking(move || {
         std::fs::create_dir_all(&install_dir)
             .map_err(|e| format!("create {}: {e}", install_dir.display()))?;
-        let mut command = Command::new("npm");
+        let mut command = env::command("npm");
         command
             .arg("install")
             .arg("--prefix")

--- a/src-tauri/src/commands/fs.rs
+++ b/src-tauri/src/commands/fs.rs
@@ -503,7 +503,6 @@ pub fn fs_walk_project(root: String) -> Result<Vec<String>, String> {
 /// existence/non-existence info to the user-visible Finder window.
 #[tauri::command]
 pub fn fs_reveal_in_file_manager(root: String, path: String) -> Result<(), String> {
-    use std::process::Command;
     let root_path = PathBuf::from(&root);
     let req = PathBuf::from(&path);
     let p = crate::helpers::resolve_inside_root(&root_path, &req)
@@ -521,7 +520,7 @@ pub fn fs_reveal_in_file_manager(root: String, path: String) -> Result<(), Strin
     let p = canon;
     #[cfg(target_os = "macos")]
     {
-        Command::new("open")
+        crate::env::command("open")
             .arg("-R")
             .arg(&p)
             .spawn()
@@ -530,7 +529,7 @@ pub fn fs_reveal_in_file_manager(root: String, path: String) -> Result<(), Strin
     }
     #[cfg(target_os = "windows")]
     {
-        Command::new("explorer.exe")
+        crate::env::command("explorer.exe")
             .arg(format!("/select,{}", p.display()))
             .spawn()
             .map_err(|e| format!("explorer.exe: {e}"))?;
@@ -540,7 +539,7 @@ pub fn fs_reveal_in_file_manager(root: String, path: String) -> Result<(), Strin
     {
         // No portable "select-this-file" on Linux; open the parent dir.
         let parent = p.parent().unwrap_or(&p);
-        Command::new("xdg-open")
+        crate::env::command("xdg-open")
             .arg(parent)
             .spawn()
             .map_err(|e| format!("xdg-open: {e}"))?;
@@ -565,7 +564,6 @@ pub fn fs_reveal_in_file_manager(root: String, path: String) -> Result<(), Strin
 /// Finder/Explorer/xdg-open, which is itself visible to the user.
 #[tauri::command]
 pub fn fs_open_in_file_manager(path: String) -> Result<(), String> {
-    use std::process::Command;
     let p = PathBuf::from(&path);
     if !p.is_absolute() {
         return Err(format!("path must be absolute: {path}"));
@@ -580,7 +578,7 @@ pub fn fs_open_in_file_manager(path: String) -> Result<(), String> {
     let target = canon;
     #[cfg(target_os = "macos")]
     {
-        Command::new("open")
+        crate::env::command("open")
             .arg(&target)
             .spawn()
             .map_err(|e| format!("open: {e}"))?;
@@ -588,7 +586,7 @@ pub fn fs_open_in_file_manager(path: String) -> Result<(), String> {
     }
     #[cfg(target_os = "windows")]
     {
-        Command::new("explorer.exe")
+        crate::env::command("explorer.exe")
             .arg(&target)
             .spawn()
             .map_err(|e| format!("explorer.exe: {e}"))?;
@@ -596,7 +594,7 @@ pub fn fs_open_in_file_manager(path: String) -> Result<(), String> {
     }
     #[cfg(all(unix, not(target_os = "macos")))]
     {
-        Command::new("xdg-open")
+        crate::env::command("xdg-open")
             .arg(&target)
             .spawn()
             .map_err(|e| format!("xdg-open: {e}"))?;
@@ -611,7 +609,6 @@ pub fn fs_open_in_file_manager(path: String) -> Result<(), String> {
 /// applications on arbitrary files.
 #[tauri::command]
 pub fn fs_open_in_default_app(root: String, path: String) -> Result<(), String> {
-    use std::process::Command;
     let root_path = PathBuf::from(&root);
     let req = PathBuf::from(&path);
     let p = crate::helpers::resolve_inside_root(&root_path, &req)
@@ -629,7 +626,7 @@ pub fn fs_open_in_default_app(root: String, path: String) -> Result<(), String> 
     let p = canon;
     #[cfg(target_os = "macos")]
     {
-        Command::new("open")
+        crate::env::command("open")
             .arg(&p)
             .spawn()
             .map_err(|e| format!("open: {e}"))?;
@@ -638,7 +635,7 @@ pub fn fs_open_in_default_app(root: String, path: String) -> Result<(), String> 
     #[cfg(target_os = "windows")]
     {
         // start "" "<file>" — the empty title argument is required by cmd.
-        Command::new("cmd")
+        crate::env::command("cmd")
             .args(["/C", "start", ""])
             .arg(&p)
             .spawn()
@@ -647,7 +644,7 @@ pub fn fs_open_in_default_app(root: String, path: String) -> Result<(), String> 
     }
     #[cfg(all(unix, not(target_os = "macos")))]
     {
-        Command::new("xdg-open")
+        crate::env::command("xdg-open")
             .arg(&p)
             .spawn()
             .map_err(|e| format!("xdg-open: {e}"))?;

--- a/src-tauri/src/commands/git.rs
+++ b/src-tauri/src/commands/git.rs
@@ -10,6 +10,8 @@ use std::path::PathBuf;
 
 use tauri::AppHandle;
 
+use crate::env;
+
 /// Read minimal git status for a project directory. Used by the
 /// sidebar to surface a branch chip + dirty dot per project. Returns
 /// `None` when the path isn't a git repository so the caller can
@@ -34,14 +36,13 @@ pub struct GitStatus {
 
 #[tauri::command]
 pub async fn git_status(path: String) -> Result<Option<GitStatus>, String> {
-    use std::process::Command;
     let dir = PathBuf::from(&path);
     if !dir.is_dir() {
         return Ok(None);
     }
     // Quick presence check — `git rev-parse --is-inside-work-tree`.
     // Saves spawning the porcelain pass on a non-git directory.
-    let inside = Command::new("git")
+    let inside = env::command("git")
         .arg("-C")
         .arg(&dir)
         .args(["rev-parse", "--is-inside-work-tree"])
@@ -55,7 +56,7 @@ pub async fn git_status(path: String) -> Result<Option<GitStatus>, String> {
     }
     // Branch: prefer the symbolic name. Falls back to a short SHA on
     // detached HEAD so the chip still says something useful.
-    let branch_out = Command::new("git")
+    let branch_out = env::command("git")
         .arg("-C")
         .arg(&dir)
         .args(["symbolic-ref", "--short", "HEAD"])
@@ -65,7 +66,7 @@ pub async fn git_status(path: String) -> Result<Option<GitStatus>, String> {
         Some(o) if o.status.success() => {
             Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
         }
-        _ => Command::new("git")
+        _ => env::command("git")
             .arg("-C")
             .arg(&dir)
             .args(["rev-parse", "--short", "HEAD"])
@@ -80,7 +81,7 @@ pub async fn git_status(path: String) -> Result<Option<GitStatus>, String> {
     //   …
     // The header line is parsed for ahead/behind (when an upstream is
     // configured). Any subsequent line means the worktree is dirty.
-    let porcelain = Command::new("git")
+    let porcelain = env::command("git")
         .arg("-C")
         .arg(&dir)
         .args(["status", "--porcelain=v1", "--branch"])
@@ -159,12 +160,11 @@ pub struct BranchInfo {
 /// record format. Returns an empty vec when the path isn't a git repo.
 #[tauri::command]
 pub async fn git_worktrees(project_path: String) -> Result<Vec<Worktree>, String> {
-    use std::process::Command;
     let dir = PathBuf::from(&project_path);
     if !dir.is_dir() {
         return Ok(Vec::new());
     }
-    let output = Command::new("git")
+    let output = env::command("git")
         .arg("-C")
         .arg(&dir)
         .args(["worktree", "list", "--porcelain"])
@@ -250,13 +250,12 @@ pub async fn git_worktree_add(
     branch: String,
     base: Option<String>,
 ) -> Result<Worktree, String> {
-    use std::process::Command;
     let dir = PathBuf::from(&project_path);
     if !dir.is_dir() {
         return Err(format!("not a directory: {project_path}"));
     }
     // Detect whether the branch exists so we know whether to pass `-b`.
-    let exists = Command::new("git")
+    let exists = env::command("git")
         .arg("-C")
         .arg(&dir)
         .args(["rev-parse", "--verify", "--quiet"])
@@ -264,7 +263,7 @@ pub async fn git_worktree_add(
         .output()
         .map(|o| o.status.success())
         .unwrap_or(false);
-    let mut cmd = Command::new("git");
+    let mut cmd = env::command("git");
     cmd.arg("-C").arg(&dir).args(["worktree", "add"]);
     if !exists {
         cmd.arg("-b").arg(&branch).arg(&target_path);
@@ -296,7 +295,6 @@ pub async fn git_worktree_remove(
     worktree_path: String,
     force: bool,
 ) -> Result<(), String> {
-    use std::process::Command;
     let dir = PathBuf::from(&project_path);
     let list = git_worktrees(project_path.clone()).await?;
     let canonical = std::fs::canonicalize(&worktree_path)
@@ -309,7 +307,7 @@ pub async fn git_worktree_remove(
     if target.is_main {
         return Err("cannot remove the main worktree".to_string());
     }
-    let mut cmd = Command::new("git");
+    let mut cmd = env::command("git");
     cmd.arg("-C").arg(&dir).args(["worktree", "remove"]);
     if force {
         cmd.arg("--force");
@@ -328,12 +326,11 @@ pub async fn git_worktree_remove(
 /// Used by the "create worktree from existing branch" picker.
 #[tauri::command]
 pub async fn git_branch_list(project_path: String) -> Result<Vec<BranchInfo>, String> {
-    use std::process::Command;
     let dir = PathBuf::from(&project_path);
     if !dir.is_dir() {
         return Ok(Vec::new());
     }
-    let output = Command::new("git")
+    let output = env::command("git")
         .arg("-C")
         .arg(&dir)
         .args([
@@ -415,14 +412,13 @@ pub async fn gh_branch_status(
 }
 
 fn gh_branch_status_inner(project_path: &str, branch: &str) -> GhBranchStatus {
-    use std::process::Command;
     let mut status = GhBranchStatus::default();
     let dir = PathBuf::from(project_path);
     if !dir.is_dir() || branch.is_empty() {
         return status;
     }
     // 1. gh available + authed?
-    let auth = Command::new("gh").args(["auth", "status"]).output();
+    let auth = env::command("gh").args(["auth", "status"]).output();
     let Ok(out) = auth else { return status };
     if !out.status.success() {
         return status;
@@ -435,7 +431,7 @@ fn gh_branch_status_inner(project_path: &str, branch: &str) -> GhBranchStatus {
     //    convention), so we rely on `current_dir(&dir)` and a bare
     //    invocation. Output empty / non-zero on non-GitHub remotes,
     //    which doubles as our "is this on GitHub?" check.
-    let repo_out = Command::new("gh")
+    let repo_out = env::command("gh")
         .args([
             "repo",
             "view",
@@ -462,7 +458,7 @@ fn gh_branch_status_inner(project_path: &str, branch: &str) -> GhBranchStatus {
     //    as a separate path element and returns 404 even when the
     //    branch exists.
     let branch_encoded = url_encode_path_segment(branch);
-    let pushed_out = Command::new("gh")
+    let pushed_out = env::command("gh")
         .args([
             "api",
             "-X",
@@ -480,7 +476,7 @@ fn gh_branch_status_inner(project_path: &str, branch: &str) -> GhBranchStatus {
     //    open + closed (incl. merged). Limit 5 keeps the call cheap and
     //    the UI tidy. `--json` makes parsing robust against future CLI
     //    output tweaks.
-    let pr_out = Command::new("gh")
+    let pr_out = env::command("gh")
         .args([
             "pr",
             "list",
@@ -633,7 +629,6 @@ pub async fn gh_repo_overview(project_path: String) -> Result<GhRepoOverview, St
 
 async fn gh_repo_overview_inner(project_path: &str) -> GhRepoOverview {
     use std::time::Duration;
-    use tokio::process::Command;
     let mut overview = GhRepoOverview::default();
     let dir = PathBuf::from(project_path);
     if !dir.is_dir() {
@@ -641,7 +636,10 @@ async fn gh_repo_overview_inner(project_path: &str) -> GhRepoOverview {
     }
 
     // gh available + authed?
-    let auth = Command::new("gh").args(["auth", "status"]).output().await;
+    let auth = env::tokio_command("gh")
+        .args(["auth", "status"])
+        .output()
+        .await;
     let Ok(out) = auth else { return overview };
     if !out.status.success() {
         return overview;
@@ -650,7 +648,7 @@ async fn gh_repo_overview_inner(project_path: &str) -> GhRepoOverview {
 
     let dir_a = dir.clone();
     let repo_view_fut = async move {
-        Command::new("gh")
+        env::tokio_command("gh")
             .args([
                 "repo",
                 "view",
@@ -664,7 +662,7 @@ async fn gh_repo_overview_inner(project_path: &str) -> GhRepoOverview {
 
     let dir_b = dir.clone();
     let pr_count_fut = async move {
-        Command::new("gh")
+        env::tokio_command("gh")
             .args([
                 "pr", "list", "--state", "open", "--json", "number", "-q", "length",
             ])
@@ -682,7 +680,7 @@ async fn gh_repo_overview_inner(project_path: &str) -> GhRepoOverview {
     // which counts issues + PRs together and inflates the dashboard
     // figure when the repo has open PRs.
     let issue_count_fut = async move {
-        let count_out = Command::new("gh")
+        let count_out = env::tokio_command("gh")
             .args([
                 "issue", "list", "--state", "open", "--limit", "1000", "--json", "number", "-q",
                 "length",
@@ -833,7 +831,6 @@ pub(crate) fn parse_gh_issue_list(s: &str) -> Vec<GhIssue> {
 #[tauri::command]
 pub async fn gh_issue_list(project_path: String, limit: Option<u32>) -> Vec<GhIssue> {
     use std::time::Duration;
-    use tokio::process::Command;
     let dir = PathBuf::from(&project_path);
     if !dir.is_dir() {
         return Vec::new();
@@ -841,7 +838,7 @@ pub async fn gh_issue_list(project_path: String, limit: Option<u32>) -> Vec<GhIs
     let limit = limit.unwrap_or(30).clamp(1, 100);
     let limit_str = limit.to_string();
     tokio::time::timeout(Duration::from_secs(5), async {
-        let out = Command::new("gh")
+        let out = env::tokio_command("gh")
             .args([
                 "issue",
                 "list",
@@ -872,7 +869,6 @@ pub async fn gh_issue_list(project_path: String, limit: Option<u32>) -> Vec<GhIs
 #[tauri::command]
 pub async fn gh_issue_view(project_path: String, number: i64) -> Result<GhIssueDetail, String> {
     use std::time::Duration;
-    use tokio::process::Command;
     let dir = PathBuf::from(&project_path);
     if !dir.is_dir() {
         return Err(format!("not a directory: {project_path}"));
@@ -881,7 +877,7 @@ pub async fn gh_issue_view(project_path: String, number: i64) -> Result<GhIssueD
         return Err("issue number must be positive".into());
     }
     let out = tokio::time::timeout(Duration::from_secs(5), async {
-        Command::new("gh")
+        env::tokio_command("gh")
             .args([
                 "issue",
                 "view",
@@ -939,12 +935,11 @@ pub async fn gh_issue_view(project_path: String, number: i64) -> Result<GhIssueD
 /// a local logo scan misses.
 #[tauri::command]
 pub async fn gh_repo_avatar_url(project_path: String) -> Option<String> {
-    use tokio::process::Command;
     let dir = PathBuf::from(&project_path);
     if !dir.is_dir() {
         return None;
     }
-    let out = Command::new("gh")
+    let out = env::tokio_command("gh")
         .args([
             "repo",
             "view",

--- a/src-tauri/src/commands/host.rs
+++ b/src-tauri/src/commands/host.rs
@@ -11,7 +11,8 @@
 
 use serde::Serialize;
 use sha1::{Digest, Sha1};
-use std::process::Command;
+
+use crate::env;
 
 #[derive(Debug, Serialize, Clone)]
 pub struct HostInfo {
@@ -36,7 +37,7 @@ fn machine_uuid() -> Option<String> {
     } else if cfg!(target_os = "macos") {
         // `ioreg` is always present on macOS; output line looks like
         // `"IOPlatformUUID" = "ABC123-..."`.
-        let out = Command::new("ioreg")
+        let out = env::command("ioreg")
             .args(["-d2", "-c", "IOPlatformExpertDevice"])
             .output()
             .ok()?;

--- a/src-tauri/src/env.rs
+++ b/src-tauri/src/env.rs
@@ -1,0 +1,174 @@
+//! External command environment helpers.
+//!
+//! Release builds are often launched by a desktop shell, not a terminal.
+//! That means PATH can be missing Homebrew, Nix profiles, cargo bins, and
+//! other user-managed tool directories. Keep command lookup here so every
+//! Rust IPC command resolves dependencies the same way.
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::OnceLock;
+
+const COMMON_TOOL_DIRS: &[&str] = &[
+    "/run/current-system/sw/bin",
+    "/nix/var/nix/profiles/default/bin",
+    "/opt/homebrew/bin",
+    "/usr/local/bin",
+    "/usr/bin",
+    "/bin",
+    "/usr/sbin",
+    "/sbin",
+];
+
+fn push_path(out: &mut Vec<PathBuf>, seen: &mut HashSet<PathBuf>, path: PathBuf) {
+    if path.as_os_str().is_empty() {
+        return;
+    }
+    if seen.insert(path.clone()) {
+        out.push(path);
+    }
+}
+
+fn push_path_list(out: &mut Vec<PathBuf>, seen: &mut HashSet<PathBuf>, value: &str) {
+    for path in std::env::split_paths(value) {
+        push_path(out, seen, path);
+    }
+}
+
+fn home_relative(path: &str) -> Option<PathBuf> {
+    let home = std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from)?;
+    Some(home.join(path))
+}
+
+fn shell_env_path() -> Option<String> {
+    static CACHED: OnceLock<Option<String>> = OnceLock::new();
+    CACHED
+        .get_or_init(|| {
+            let shell = std::env::var("SHELL").unwrap_or_else(|_| {
+                if cfg!(target_os = "windows") {
+                    "cmd".to_string()
+                } else {
+                    "/bin/sh".to_string()
+                }
+            });
+            if cfg!(target_os = "windows") {
+                return None;
+            }
+            let out = Command::new(&shell).args(["-ilc", "env"]).output().ok()?;
+            if !out.status.success() {
+                return None;
+            }
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            let value = stdout
+                .lines()
+                .find_map(|line| line.strip_prefix("PATH="))?
+                .to_string();
+            if value.is_empty() { None } else { Some(value) }
+        })
+        .clone()
+}
+
+pub(crate) fn resolved_tool_path() -> String {
+    static CACHED: OnceLock<String> = OnceLock::new();
+    CACHED
+        .get_or_init(|| {
+            let mut paths = Vec::new();
+            let mut seen = HashSet::new();
+            if let Ok(path) = std::env::var("PATH") {
+                push_path_list(&mut paths, &mut seen, &path);
+            }
+            if let Some(path) = shell_env_path() {
+                push_path_list(&mut paths, &mut seen, &path);
+            }
+            if let Some(user) = std::env::var_os("USER").and_then(|v| v.into_string().ok()) {
+                push_path(
+                    &mut paths,
+                    &mut seen,
+                    PathBuf::from(format!("/etc/profiles/per-user/{user}/bin")),
+                );
+            }
+            for rel in [
+                ".nix-profile/bin",
+                ".local/state/nix/profile/bin",
+                ".local/bin",
+                ".cargo/bin",
+            ] {
+                if let Some(path) = home_relative(rel) {
+                    push_path(&mut paths, &mut seen, path);
+                }
+            }
+            for path in COMMON_TOOL_DIRS {
+                push_path(&mut paths, &mut seen, PathBuf::from(path));
+            }
+            std::env::join_paths(paths)
+                .map(|v| v.to_string_lossy().to_string())
+                .unwrap_or_else(|_| std::env::var("PATH").unwrap_or_default())
+        })
+        .clone()
+}
+
+pub(crate) fn resolved_login_path() -> Option<String> {
+    let path = resolved_tool_path();
+    if path.is_empty() { None } else { Some(path) }
+}
+
+fn has_separator(program: &str) -> bool {
+    program.contains('/') || program.contains('\\')
+}
+
+pub(crate) fn resolve_program(program: &str) -> Option<PathBuf> {
+    if has_separator(program) {
+        let path = PathBuf::from(program);
+        return path.exists().then_some(path);
+    }
+    for dir in std::env::split_paths(&resolved_tool_path()) {
+        let candidate = dir.join(program);
+        if candidate.exists() {
+            return Some(candidate);
+        }
+        #[cfg(windows)]
+        {
+            let candidate = dir.join(format!("{program}.exe"));
+            if candidate.exists() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+pub(crate) fn command(program: &str) -> Command {
+    let mut command =
+        Command::new(resolve_program(program).unwrap_or_else(|| PathBuf::from(program)));
+    command.env("PATH", resolved_tool_path());
+    command
+}
+
+pub(crate) fn tokio_command(program: &str) -> tokio::process::Command {
+    let mut command = tokio::process::Command::new(
+        resolve_program(program).unwrap_or_else(|| PathBuf::from(program)),
+    );
+    command.env("PATH", resolved_tool_path());
+    command
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolved_path_includes_common_nix_locations() {
+        let path = resolved_tool_path();
+        let paths: Vec<_> = std::env::split_paths(&path).collect();
+        assert!(paths.contains(&PathBuf::from("/run/current-system/sw/bin")));
+        assert!(paths.contains(&PathBuf::from("/nix/var/nix/profiles/default/bin")));
+    }
+
+    #[test]
+    fn resolve_program_does_not_require_login_shell_for_system_tools() {
+        assert!(resolve_program("sh").is_some() || resolve_program("cmd").is_some());
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -36,6 +36,7 @@ use std::sync::{Arc, Mutex, OnceLock};
 use tauri::{AppHandle, Emitter, Manager, State};
 
 mod commands;
+mod env;
 mod helpers;
 mod server;
 mod shell;
@@ -79,49 +80,6 @@ pub(crate) fn project_root() -> PathBuf {
         }
     }
     cwd
-}
-
-/// Capture the user's login-shell PATH so the sidecar can find tools that
-/// live outside launchd's minimal `/usr/bin:/bin:/usr/sbin:/sbin`. macOS
-/// .app launches inherit that minimal PATH and lose Homebrew, Nix profile
-/// dirs, `~/.npm-global/bin`, etc. — pi's package resolver hits this
-/// immediately with `npm root -g` when settings.json declares any npm
-/// package source. Mirrors the workaround VS Code / Sublime / iTerm use.
-///
-/// Cached forever once computed (the shell hop costs ~50–200 ms). Only
-/// runs on macOS in release builds — Linux/Windows GUI launchers preserve
-/// the inherited environment, and dev launches happen from a terminal that
-/// already has the right PATH.
-pub(crate) fn resolved_login_path() -> Option<String> {
-    static CACHED: OnceLock<Option<String>> = OnceLock::new();
-    CACHED
-        .get_or_init(|| {
-            if !cfg!(target_os = "macos") {
-                return None;
-            }
-            // SHELL points at the user's login shell; fall back to zsh
-            // (the macOS default since 10.15) when unset.
-            let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
-            // -i forces interactive mode so ~/.zshrc / ~/.bashrc /
-            // ~/.config/fish/config.fish are sourced. -l makes it a
-            // login shell so ~/.zprofile / ~/.bash_profile fire too.
-            //
-            // Run `env` instead of trying to `echo $PATH` directly: fish
-            // treats $PATH as a list and prints entries space-separated
-            // (POSIX wants colons), which would silently corrupt the
-            // recovered value. `env` always emits the actual exported
-            // environment with PATH= colon-separated, regardless of the
-            // shell that runs it.
-            let out = Command::new(&shell).args(["-ilc", "env"]).output().ok()?;
-            if !out.status.success() {
-                return None;
-            }
-            let stdout = String::from_utf8_lossy(&out.stdout);
-            let path_line = stdout.lines().find(|l| l.starts_with("PATH="))?;
-            let value = path_line.strip_prefix("PATH=")?.to_string();
-            if value.is_empty() { None } else { Some(value) }
-        })
-        .clone()
 }
 
 /// Locate the bundled `aethon-agent` sidecar binary. Tauri's externalBin
@@ -177,7 +135,7 @@ fn find_sidecar_binary() -> Result<PathBuf, String> {
 /// `aethon-agent` sidecar bundled by Tauri, with `PI_PACKAGE_DIR` set to
 /// the shipped pi metadata so `pi-coding-agent`'s package.json read at
 /// module load doesn't fail, plus an enriched PATH (see
-/// `resolved_login_path`) so pi can find npm/git when scanning user
+/// `env::resolved_login_path`) so pi can find npm/git when scanning user
 /// packages from `~/.pi/agent/settings.json`. Stdout is read on a
 /// background thread; each line is emitted as an `agent-response`
 /// Tauri event.
@@ -213,7 +171,7 @@ fn ensure_agent_spawned(guard: &mut Option<Child>, app: &AppHandle) -> Result<()
             .join("skills")
             .join("default-layout")
             .join("slots.json");
-        let mut c = Command::new("bun");
+        let mut c = env::command("bun");
         c.current_dir(&root).arg("run").arg("agent/main.ts");
         c.env("AETHON_RELEASE_MODE", "0");
         c.env("AETHON_PROJECT_ROOT", &root);
@@ -251,7 +209,7 @@ fn ensure_agent_spawned(guard: &mut Option<Child>, app: &AppHandle) -> Result<()
         // pi's `npm root -g` (run when resolving user packages from
         // ~/.pi/agent/settings.json) fails with ENOENT. Source the user's
         // login shell once to recover the real PATH and inject it.
-        if let Some(path) = resolved_login_path() {
+        if let Some(path) = env::resolved_login_path() {
             c.env("PATH", path);
         }
         c

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -137,7 +137,9 @@ export default function App() {
         ...(restored?.scrollToMatchByTab
           ? { scrollToMatchByTab: restored.scrollToMatchByTab }
           : {}),
-        ...(restored?.projectModels ? { projectModels: restored.projectModels } : {}),
+        ...(restored?.projectModels
+          ? { projectModels: restored.projectModels }
+          : {}),
         logoUrl,
         // App version surfaced as a state slice so layout JSON can $ref it
         // (e.g. sidebar's `version` prop). Single source of truth is
@@ -157,7 +159,9 @@ export default function App() {
         // Seed /sidebar/extensions so Settings and the sidebar have a stable
         // list shape before the bridge sends the first ready payload.
         sidebar: {
-          ...(BOOT_LAYOUT.state?.sidebar as Record<string, unknown> | undefined),
+          ...(BOOT_LAYOUT.state?.sidebar as
+            | Record<string, unknown>
+            | undefined),
           extensions: [],
         },
         layout: {
@@ -210,48 +214,52 @@ export default function App() {
     });
   }
 
-  const restoreSessionUiSnapshot = useCallback((snapshot: SessionUiSnapshot) => {
-    setState((prev) => {
-      const tabs = snapshot.tabs.length ? snapshot.tabs : [];
-      if (tabs.length === 0) return prev;
-      const activeTabId =
-        snapshot.activeTabId && tabs.some((t) => t.id === snapshot.activeTabId)
-          ? snapshot.activeTabId
-          : tabs[0].id;
-      const activeTab = tabs.find((t) => t.id === activeTabId) ?? tabs[0];
-      const activeRecord = activeTab as unknown as Record<string, unknown>;
-      const rootMirror = Object.fromEntries(
-        TAB_MIRROR_KEYS.map((key) => [key, activeRecord[key]]),
-      );
-      const restoredLayout =
-        snapshot.layout && typeof snapshot.layout === "object"
-          ? (snapshot.layout as Record<string, unknown>)
-          : {};
-      const currentLayout =
-        (prev.layout as Record<string, unknown> | undefined) ?? {};
-      return {
-        ...prev,
-        ...(snapshot.terminal ? { terminal: snapshot.terminal } : {}),
-        ...(snapshot.terminalPanel
-          ? { terminalPanel: snapshot.terminalPanel }
-          : {}),
-        ...(snapshot.scrollToMatchByTab
-          ? { scrollToMatchByTab: snapshot.scrollToMatchByTab }
-          : {}),
-        ...(snapshot.projectModels
-          ? { projectModels: snapshot.projectModels }
-          : {}),
-        ...(Object.keys(restoredLayout).length > 0
-          ? { layout: { ...currentLayout, ...restoredLayout } }
-          : {}),
-        tabs,
-        activeTabId,
-        empty: false,
-        hasTabs: true,
-        ...rootMirror,
-      };
-    });
-  }, [setState]);
+  const restoreSessionUiSnapshot = useCallback(
+    (snapshot: SessionUiSnapshot) => {
+      setState((prev) => {
+        const tabs = snapshot.tabs.length ? snapshot.tabs : [];
+        if (tabs.length === 0) return prev;
+        const activeTabId =
+          snapshot.activeTabId &&
+          tabs.some((t) => t.id === snapshot.activeTabId)
+            ? snapshot.activeTabId
+            : tabs[0].id;
+        const activeTab = tabs.find((t) => t.id === activeTabId) ?? tabs[0];
+        const activeRecord = activeTab as unknown as Record<string, unknown>;
+        const rootMirror = Object.fromEntries(
+          TAB_MIRROR_KEYS.map((key) => [key, activeRecord[key]]),
+        );
+        const restoredLayout =
+          snapshot.layout && typeof snapshot.layout === "object"
+            ? (snapshot.layout as Record<string, unknown>)
+            : {};
+        const currentLayout =
+          (prev.layout as Record<string, unknown> | undefined) ?? {};
+        return {
+          ...prev,
+          ...(snapshot.terminal ? { terminal: snapshot.terminal } : {}),
+          ...(snapshot.terminalPanel
+            ? { terminalPanel: snapshot.terminalPanel }
+            : {}),
+          ...(snapshot.scrollToMatchByTab
+            ? { scrollToMatchByTab: snapshot.scrollToMatchByTab }
+            : {}),
+          ...(snapshot.projectModels
+            ? { projectModels: snapshot.projectModels }
+            : {}),
+          ...(Object.keys(restoredLayout).length > 0
+            ? { layout: { ...currentLayout, ...restoredLayout } }
+            : {}),
+          tabs,
+          activeTabId,
+          empty: false,
+          hasTabs: true,
+          ...rootMirror,
+        };
+      });
+    },
+    [setState],
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -354,7 +362,9 @@ export default function App() {
   // useOsEdges clears them on supervisor signals.
   const hangWarnNotifId = (tabId: string) => `ae-hang-warn:${tabId}`;
   const hangWarnActiveRef = useRef<Set<string>>(new Set());
-  const hangWarnTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+  const hangWarnTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(
+    new Map(),
+  );
   const sessionSnapshotPersistTimerRef = useRef<number | null>(null);
 
   // Forward handles populated below as hooks construct. Lets earlier
@@ -392,7 +402,7 @@ export default function App() {
     shellPromptBeforeCloseRef,
     shortcutsNewTabKindRef,
     reapplyConfig,
-  } = useBootConfig({ setState });
+  } = useBootConfig({ setState, piDefaultModelRef });
 
   // ---------------------------------------------------------------------
   // UI zoom + theme switching are owned by useZoomAndTheme. The hook
@@ -601,7 +611,8 @@ export default function App() {
       void (async () => {
         const url = await discoverIcon(project);
         if (!url) return;
-        if (!projectsRef.current.projects.some((p) => p.id === project.id)) return;
+        if (!projectsRef.current.projects.some((p) => p.id === project.id))
+          return;
         setProjectIconUrl(project.id, url);
       })();
     }
@@ -1022,8 +1033,15 @@ export default function App() {
         return await invoke<string>("install_aethon_extension", { spec });
       },
       listModels: () => {
-        const sidebar = (stateRef.current.sidebar as Record<string, unknown>) ?? {};
-        return ((sidebar.models as { id: string; label: string; active?: boolean }[]) ?? []);
+        const sidebar =
+          (stateRef.current.sidebar as Record<string, unknown>) ?? {};
+        return (
+          (sidebar.models as {
+            id: string;
+            label: string;
+            active?: boolean;
+          }[]) ?? []
+        );
       },
       toggleTerminal,
       toggleSidebar,
@@ -1036,7 +1054,8 @@ export default function App() {
           description: l.description,
         })),
       pickProject: openProjectFromPicker,
-      openProject: (path: string, label?: string) => openProjectByPath(path, label),
+      openProject: (path: string, label?: string) =>
+        openProjectByPath(path, label),
       setActiveProject: setActiveProjectById,
       clearProject: clearActiveProject,
       removeProject: removeProjectById,
@@ -1131,7 +1150,7 @@ export default function App() {
       newEditorTab,
       updateEditorMeta,
       renameEditorTabsForPath,
-    closeEditorTabsForPath,
+      closeEditorTabsForPath,
       closeTab,
       setActiveTab,
       setActiveSubTab,
@@ -1189,7 +1208,8 @@ export default function App() {
         component: { id: string; type?: string },
         eventType: string,
         data?: unknown,
-      ) => dispatchEvent({ component, eventType, data }, eventRouteCtx),
+      ) =>
+        dispatchEvent({ component, eventType, data }, eventRouteCtx),
     [eventRouteCtx],
   );
 
@@ -1197,7 +1217,8 @@ export default function App() {
     const tabs = (state.tabs as Tab[] | undefined) ?? [];
     const recentSessions =
       (state.recentSessions as RecentSessionItem[] | undefined) ?? [];
-    const sidebar = (state.sidebar as Record<string, unknown> | undefined) ?? {};
+    const sidebar =
+      (state.sidebar as Record<string, unknown> | undefined) ?? {};
     const history = buildSidebarHistory(
       tabs,
       state.activeTabId as string | undefined,
@@ -1237,8 +1258,7 @@ export default function App() {
     const activeProjectId =
       (state.project as { id?: string } | null | undefined)?.id ?? null;
     const sidebarProjects =
-      ((state.sidebar as { projects?: unknown } | undefined)
-        ?.projects as
+      ((state.sidebar as { projects?: unknown } | undefined)?.projects as
         | { id: string; worktrees?: unknown }[]
         | undefined) ?? [];
     const activeProjectSidebarEntry = sidebarProjects.find(
@@ -1265,9 +1285,7 @@ export default function App() {
       ? projectsArr.filter((p) => p.id !== activeProjectId)
       : projectsArr;
     const existingProjectDashboard =
-      (state.projectDashboard as
-        | { widgets?: unknown[] }
-        | undefined) ?? {};
+      (state.projectDashboard as { widgets?: unknown[] } | undefined) ?? {};
     const projectDashboard = {
       ...existingProjectDashboard,
       otherProjects,
@@ -1276,9 +1294,7 @@ export default function App() {
       widgets: existingProjectDashboard.widgets ?? [],
     };
     const existingProjectsDashboard =
-      (state.projectsDashboard as
-        | { extraCards?: unknown[] }
-        | undefined) ?? {};
+      (state.projectsDashboard as { extraCards?: unknown[] } | undefined) ?? {};
     const projectsDashboard = {
       ...existingProjectsDashboard,
       extraCards: existingProjectsDashboard.extraCards ?? [],
@@ -1319,7 +1335,13 @@ export default function App() {
       activeHostId,
       host: activeHost,
     };
-  }, [buildSidebarHistory, hostInfo.activeHostId, hostInfo.hosts, hostInfo.localHostId, state]);
+  }, [
+    buildSidebarHistory,
+    hostInfo.activeHostId,
+    hostInfo.hosts,
+    hostInfo.localHostId,
+    state,
+  ]);
   const renderRecord = renderState as Record<string, unknown>;
   const notificationsOpen =
     ((renderRecord.notifications as unknown[] | undefined) ?? []).length > 0;

--- a/src/eventRoutes/dashboard.test.ts
+++ b/src/eventRoutes/dashboard.test.ts
@@ -11,7 +11,10 @@ describe("handleProjectsDashboard", () => {
   it("new-tab calls ctx.newTab", async () => {
     const { ctx, mocks } = buildRouteFixture();
     const handled = await handleProjectsDashboard(
-      { component: { id: "projects-dashboard", type: "projects-dashboard" }, eventType: "new-tab" },
+      {
+        component: { id: "projects-dashboard", type: "projects-dashboard" },
+        eventType: "new-tab",
+      },
       ctx,
     );
     expect(handled).toBe(true);
@@ -21,7 +24,10 @@ describe("handleProjectsDashboard", () => {
   it("open-project calls openProjectFromPicker", async () => {
     const { ctx, mocks } = buildRouteFixture();
     const handled = await handleProjectsDashboard(
-      { component: { id: "x", type: "projects-dashboard" }, eventType: "open-project" },
+      {
+        component: { id: "x", type: "projects-dashboard" },
+        eventType: "open-project",
+      },
       ctx,
     );
     expect(handled).toBe(true);
@@ -74,6 +80,44 @@ describe("handleProjectsDashboard", () => {
     expect(mocks.newTab).toHaveBeenCalledWith("tab-42", "Earlier", {
       restoredSession: true,
       cwd: "/p",
+    });
+  });
+
+  it("restore-session navigates to the matching worktree before opening", async () => {
+    const { ctx, mocks } = buildRouteFixture({
+      state: {
+        activeProjectId: "p1",
+        projects: [{ id: "p1", path: "/repo/app" }],
+        sidebar: {
+          projects: [
+            {
+              id: "p1",
+              worktrees: [
+                { id: "wt-1", path: "/repo/app-fix-session-restore" },
+              ],
+            },
+          ],
+        },
+      },
+    });
+    const handled = await handleProjectsDashboard(
+      {
+        component: { id: "x", type: "projects-dashboard" },
+        eventType: "restore-session",
+        data: {
+          sessionId: "tab-42",
+          label: "Earlier",
+          cwd: "/repo/app-fix-session-restore",
+        },
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.setActiveProjectById).not.toHaveBeenCalled();
+    expect(mocks.activateWorktree).toHaveBeenCalledWith("wt-1");
+    expect(mocks.newTab).toHaveBeenCalledWith("tab-42", "Earlier", {
+      restoredSession: true,
+      cwd: "/repo/app-fix-session-restore",
     });
   });
 

--- a/src/eventRoutes/dashboard.ts
+++ b/src/eventRoutes/dashboard.ts
@@ -19,6 +19,7 @@ import {
   handleSidebarDeleteSession,
   handleSidebarRemoveWorktree,
 } from "./sidebar";
+import { restoreSessionFromSelection } from "./sessionRestore";
 
 /** New-tab / Open Project… / restore-session / select-project-card
  *  for the global projects-dashboard surface. */
@@ -58,14 +59,7 @@ export const handleProjectsDashboard: EventRouteHandler = (
     const sel = data as
       | { sessionId?: string; label?: string; cwd?: string }
       | undefined;
-    if (sel?.sessionId) {
-      ctx.newTab(sel.sessionId, sel.label ?? "Restored Session", {
-        restoredSession: true,
-        ...(sel.cwd ? { cwd: sel.cwd } : {}),
-      });
-    } else {
-      ctx.newTab();
-    }
+    restoreSessionFromSelection(ctx, sel);
     return true;
   }
   if (eventType === "delete-session") {
@@ -119,7 +113,10 @@ export const handleProjectDashboard: EventRouteHandler = (
     return true;
   }
   // Reuse global handlers for shared events (restore-session etc).
-  return handleProjectsDashboard({ component: { id: "", type: "" }, eventType, data }, ctx);
+  return handleProjectsDashboard(
+    { component: { id: "", type: "" }, eventType, data },
+    ctx,
+  );
 };
 
 /** task-launcher submit — the heart of the per-project composer. */

--- a/src/eventRoutes/sessionRestore.ts
+++ b/src/eventRoutes/sessionRestore.ts
@@ -1,0 +1,99 @@
+import type { EventRouteContext } from "./types";
+
+interface RestoreSelection {
+  sessionId?: string;
+  label?: string;
+  cwd?: string;
+  scrollToMatch?: string;
+}
+
+interface ProjectStateItem {
+  id?: unknown;
+  path?: unknown;
+}
+
+interface SidebarProjectItem {
+  id?: unknown;
+  path?: unknown;
+  worktrees?: {
+    id?: unknown;
+    path?: unknown;
+  }[];
+}
+
+function normalizePath(path: string | undefined): string {
+  return (path ?? "").replace(/[/\\]+$/, "");
+}
+
+function alignProjectToSessionCwd(ctx: EventRouteContext, cwd?: string): void {
+  const target = normalizePath(cwd);
+  if (!target) return;
+  const state = ctx.stateRef.current;
+  const projects = Array.isArray(state.projects)
+    ? (state.projects as ProjectStateItem[])
+    : [];
+  const sidebar =
+    state.sidebar && typeof state.sidebar === "object"
+      ? (state.sidebar as { projects?: unknown })
+      : {};
+  const sidebarProjects = Array.isArray(sidebar.projects)
+    ? (sidebar.projects as SidebarProjectItem[])
+    : [];
+
+  for (const project of projects) {
+    if (
+      typeof project.id === "string" &&
+      typeof project.path === "string" &&
+      normalizePath(project.path) === target
+    ) {
+      if (state.activeProjectId !== project.id)
+        ctx.setActiveProjectById(project.id);
+      ctx.activateWorktree(null);
+      return;
+    }
+  }
+
+  for (const project of sidebarProjects) {
+    if (typeof project.id !== "string") continue;
+    if (
+      typeof project.path === "string" &&
+      normalizePath(project.path) === target
+    ) {
+      if (state.activeProjectId !== project.id)
+        ctx.setActiveProjectById(project.id);
+      ctx.activateWorktree(null);
+      return;
+    }
+    for (const worktree of project.worktrees ?? []) {
+      if (
+        typeof worktree.id === "string" &&
+        typeof worktree.path === "string" &&
+        normalizePath(worktree.path) === target
+      ) {
+        if (state.activeProjectId !== project.id)
+          ctx.setActiveProjectById(project.id);
+        ctx.activateWorktree(worktree.id);
+        return;
+      }
+    }
+  }
+}
+
+export function restoreSessionFromSelection(
+  ctx: EventRouteContext,
+  selection: RestoreSelection | undefined,
+): void {
+  if (!selection?.sessionId) {
+    ctx.newTab();
+    return;
+  }
+
+  alignProjectToSessionCwd(ctx, selection.cwd);
+  ctx.newTab(selection.sessionId, selection.label ?? "Restored Session", {
+    restoredSession: true,
+    ...(selection.cwd ? { cwd: selection.cwd } : {}),
+    ...(selection.scrollToMatch
+      ? { scrollToMatch: selection.scrollToMatch }
+      : {}),
+  });
+}

--- a/src/eventRoutes/sidebar.ts
+++ b/src/eventRoutes/sidebar.ts
@@ -1,6 +1,7 @@
 import type { EventRouteContext, EventRouteHandler } from "./types";
 import { extractSessionId } from "../utils/sidebarHistory";
 import type { Tab } from "../types/tab";
+import { restoreSessionFromSelection } from "./sessionRestore";
 
 interface RecentSessionItem {
   id: string;
@@ -26,8 +27,7 @@ export const handleSidebarResize: EventRouteHandler = (
   const next = (data as { width?: number } | undefined)?.width;
   if (typeof next === "number") {
     ctx.setState((prev) => {
-      const layout =
-        (prev.layout as Record<string, unknown> | undefined) ?? {};
+      const layout = (prev.layout as Record<string, unknown> | undefined) ?? {};
       const current =
         (layout.columns as string | undefined) ?? "220px minmax(0,1fr)";
       const tokens = current.trim().split(/\s+/);
@@ -51,9 +51,7 @@ export const handleSidebarResize: EventRouteHandler = (
 
 /** sidebar resize-end: handled for drag lifecycle symmetry. The app-wide
  *  session UI snapshot persists the final /layout/columns value. */
-export const handleSidebarResizeEnd: EventRouteHandler = (
-  { eventType },
-) => {
+export const handleSidebarResizeEnd: EventRouteHandler = ({ eventType }) => {
   if (eventType !== "resize-end") return false;
   return true;
 };
@@ -66,9 +64,7 @@ export const handleSidebarRemoveProject: EventRouteHandler = (
   ctx,
 ) => {
   if (eventType !== "remove-project") return false;
-  const selected = data as
-    | { projectId?: string; itemId?: string }
-    | undefined;
+  const selected = data as { projectId?: string; itemId?: string } | undefined;
   const projectId = selected?.projectId ?? selected?.itemId;
   return projectId ? ctx.removeProjectById(projectId) : true;
 };
@@ -82,7 +78,12 @@ export const handleSidebarDeleteSession: EventRouteHandler = (
 ) => {
   if (eventType !== "delete-session") return false;
   const selected = data as
-    | { sessionId?: string; itemId?: string; label?: string; confirmed?: boolean }
+    | {
+        sessionId?: string;
+        itemId?: string;
+        label?: string;
+        confirmed?: boolean;
+      }
     | undefined;
   // Strip the "session:" or "tab:" prefix defensively in case a future
   // caller forgets the split — the sidebar already strips it but we
@@ -178,8 +179,8 @@ function applyOptimisticTabLabel(
   label: string,
 ): void {
   ctx.setState((prev) => {
-    const tabs = (prev.tabs as { id: string; label: string }[] | undefined) ??
-      [];
+    const tabs =
+      (prev.tabs as { id: string; label: string }[] | undefined) ?? [];
     const idx = tabs.findIndex((t) => t.id === tabId);
     if (idx < 0) return prev;
     const trimmed = label.trim();
@@ -202,7 +203,10 @@ export const handleSidebarToggleProjectExpand: EventRouteHandler = (
   const selected = data as { itemId?: string } | undefined;
   if (!selected?.itemId) return true;
   // Read current expanded flag from state.
-  const projects = (ctx.stateRef.current.projects as Array<{ id: string; uiExpanded?: boolean }> | undefined) ?? [];
+  const projects =
+    (ctx.stateRef.current.projects as
+      | Array<{ id: string; uiExpanded?: boolean }>
+      | undefined) ?? [];
   const project = projects.find((p) => p.id === selected.itemId);
   ctx.setProjectExpanded(selected.itemId, !(project?.uiExpanded ?? false));
   return true;
@@ -344,7 +348,11 @@ export const handleSidebarStartSession: EventRouteHandler = (
   if (payload.projectId) ctx.setActiveProjectById(payload.projectId);
   if (payload.worktreeId) ctx.activateWorktree(payload.worktreeId);
   ctx.setState((prev) => ({ ...prev, landing: null }));
-  ctx.newTab(undefined, undefined, payload.path ? { cwd: payload.path } : undefined);
+  ctx.newTab(
+    undefined,
+    undefined,
+    payload.path ? { cwd: payload.path } : undefined,
+  );
   return true;
 };
 export const handleSidebarRemoveWorktree: EventRouteHandler = (
@@ -386,7 +394,8 @@ export const handleSidebarRenameWorktree: EventRouteHandler = (
   if (eventType !== "rename-worktree") return false;
   const { worktreeId, label } =
     (data as { worktreeId?: string; label?: string } | undefined) ?? {};
-  if (worktreeId && typeof label === "string") ctx.renameWorktree(worktreeId, label);
+  if (worktreeId && typeof label === "string")
+    ctx.renameWorktree(worktreeId, label);
   return true;
 };
 
@@ -399,14 +408,15 @@ export const handleSidebarOpenProjectInFinder: EventRouteHandler = async (
   if (eventType !== "open-project-in-finder") return false;
   const projectId = (data as { projectId?: string } | undefined)?.projectId;
   if (!projectId) return true;
-  const projects = (ctx.stateRef.current.projects as Array<{ id: string; path?: string }> | undefined) ?? [];
+  const projects =
+    (ctx.stateRef.current.projects as
+      | Array<{ id: string; path?: string }>
+      | undefined) ?? [];
   const path = projects.find((p) => p.id === projectId)?.path;
   if (!path) return true;
-  await ctx
-    .invoke("fs_open_in_file_manager", { path })
-    .catch(() => {
-      /* command may not exist in older builds; ignore */
-    });
+  await ctx.invoke("fs_open_in_file_manager", { path }).catch(() => {
+    /* command may not exist in older builds; ignore */
+  });
   return true;
 };
 export const handleSidebarCopyProjectPath: EventRouteHandler = (
@@ -416,7 +426,10 @@ export const handleSidebarCopyProjectPath: EventRouteHandler = (
   if (eventType !== "copy-project-path") return false;
   const projectId = (data as { projectId?: string } | undefined)?.projectId;
   if (!projectId) return true;
-  const projects = (ctx.stateRef.current.projects as Array<{ id: string; path?: string }> | undefined) ?? [];
+  const projects =
+    (ctx.stateRef.current.projects as
+      | Array<{ id: string; path?: string }>
+      | undefined) ?? [];
   const path = projects.find((p) => p.id === projectId)?.path;
   if (path && navigator.clipboard) {
     void navigator.clipboard.writeText(path).catch(() => {});
@@ -430,14 +443,13 @@ export const handleSidebarOpenWorktreeInFinder: EventRouteHandler = async (
   if (eventType !== "open-worktree-in-finder") return false;
   const path = (data as { path?: string } | undefined)?.path;
   if (!path) return true;
-  await ctx
-    .invoke("fs_open_in_file_manager", { path })
-    .catch(() => {});
+  await ctx.invoke("fs_open_in_file_manager", { path }).catch(() => {});
   return true;
 };
-export const handleSidebarCopyWorktreePath: EventRouteHandler = (
-  { eventType, data },
-) => {
+export const handleSidebarCopyWorktreePath: EventRouteHandler = ({
+  eventType,
+  data,
+}) => {
   if (eventType !== "copy-worktree-path") return false;
   const path = (data as { path?: string } | undefined)?.path;
   if (path && navigator.clipboard) {
@@ -452,7 +464,8 @@ export const handleSidebarRenameProject: EventRouteHandler = (
   if (eventType !== "rename-project") return false;
   const { projectId, label } =
     (data as { projectId?: string; label?: string } | undefined) ?? {};
-  if (projectId && typeof label === "string") ctx.renameProject(projectId, label);
+  if (projectId && typeof label === "string")
+    ctx.renameProject(projectId, label);
   return true;
 };
 
@@ -477,9 +490,7 @@ export const handleSidebarToggleExtension: EventRouteHandler = (
   ctx,
 ) => {
   if (eventType !== "toggle-extension") return false;
-  const selected = data as
-    | { name?: string; disabled?: boolean }
-    | undefined;
+  const selected = data as { name?: string; disabled?: boolean } | undefined;
   if (!selected?.name || typeof selected.disabled !== "boolean") return true;
   ctx
     .invoke("agent_command", {
@@ -512,9 +523,7 @@ export const handleSectionedSelect: EventRouteHandler = async (
 ) => {
   if (eventType !== "select") return false;
 
-  const selected = data as
-    | { sectionId?: string; itemId?: string }
-    | undefined;
+  const selected = data as { sectionId?: string; itemId?: string } | undefined;
   if (selected?.itemId === "toggle-terminal") {
     ctx.toggleTerminal();
     return true;
@@ -575,14 +584,11 @@ export const handleSectionedSelect: EventRouteHandler = async (
           | RecentSessionItem[]
           | undefined) ?? [];
       const item = recentSessions.find((s) => s.id === sessionId);
-      ctx.newTab(
+      restoreSessionFromSelection(ctx, {
         sessionId,
-        item?.label ?? `Session ${sessionId.slice(0, 8)}`,
-        {
-          restoredSession: true,
-          ...(item?.cwd ? { cwd: item.cwd } : {}),
-        },
-      );
+        label: item?.label ?? `Session ${sessionId.slice(0, 8)}`,
+        cwd: item?.cwd,
+      });
       return true;
     }
     return true;

--- a/src/eventRoutes/tabStrip.ts
+++ b/src/eventRoutes/tabStrip.ts
@@ -1,4 +1,5 @@
 import type { EventRouteHandler } from "./types";
+import { restoreSessionFromSelection } from "./sessionRestore";
 
 /** tab-strip: select / close / new. Tab events route by component
  *  *type* — id may vary across layouts (workstation hoists the strip
@@ -58,17 +59,7 @@ export const handleEmptyState: EventRouteHandler = (
     const sel = data as
       | { sessionId?: string; label?: string; cwd?: string }
       | undefined;
-    if (sel?.sessionId) {
-      // Re-open the persisted session by reusing the same tabId. The
-      // bridge's SessionManager.continueRecent reads the existing JSONL
-      // files so the LLM history is restored too.
-      ctx.newTab(sel.sessionId, sel.label ?? "Restored Session", {
-        restoredSession: true,
-        ...(sel.cwd ? { cwd: sel.cwd } : {}),
-      });
-    } else {
-      ctx.newTab();
-    }
+    restoreSessionFromSelection(ctx, sel);
     return true;
   }
   return false;

--- a/src/eventRoutes/testFixtures.ts
+++ b/src/eventRoutes/testFixtures.ts
@@ -7,7 +7,7 @@ import { vi, type Mock } from "vitest";
 import type { MutableRefObject } from "react";
 import type { EventRouteContext, DiscoveredSession } from "./types";
 
-const ref = <T,>(value: T): MutableRefObject<T> => ({ current: value });
+const ref = <T>(value: T): MutableRefObject<T> => ({ current: value });
 
 export interface FixtureOverrides {
   state?: Record<string, unknown>;
@@ -60,6 +60,7 @@ export interface RouteFixture {
     setActiveProjectById: Mock;
     removeProjectById: Mock;
     syncRecentSessionsToState: Mock;
+    activateWorktree: Mock;
     invoke: Mock;
     writeState: Mock;
   };
@@ -76,9 +77,9 @@ export function buildRouteFixture(
 
   const setState = vi.fn((arg: unknown) => {
     if (typeof arg === "function") {
-      stateRef.current = (arg as (
-        p: Record<string, unknown>,
-      ) => Record<string, unknown>)(stateRef.current);
+      stateRef.current = (
+        arg as (p: Record<string, unknown>) => Record<string, unknown>
+      )(stateRef.current);
     } else {
       stateRef.current = arg as Record<string, unknown>;
     }
@@ -94,11 +95,9 @@ export function buildRouteFixture(
   const resolveShellCloseConsent = vi.fn((id: string, _allowed: boolean) => {
     pendingClose.delete(id);
   });
-  const resolveSessionDeleteConsent = vi.fn(
-    (id: string, _allowed: boolean) => {
-      pendingDelete.delete(id);
-    },
-  );
+  const resolveSessionDeleteConsent = vi.fn((id: string, _allowed: boolean) => {
+    pendingDelete.delete(id);
+  });
   const promptDeleteSessionConfirmation = vi.fn(() =>
     Promise.resolve(overrides.promptDeleteAllow ?? false),
   );
@@ -137,6 +136,7 @@ export function buildRouteFixture(
   const setActiveProjectById = vi.fn();
   const removeProjectById = vi.fn(() => true);
   const syncRecentSessionsToState = vi.fn();
+  const activateWorktree = vi.fn();
   const invoke = vi.fn(() => Promise.resolve(undefined));
   const writeState = vi.fn(() => Promise.resolve(true));
 
@@ -191,7 +191,7 @@ export function buildRouteFixture(
     syncRecentSessionsToState,
     setProjectExpanded: vi.fn(),
     refreshProjectWorktrees: vi.fn(() => Promise.resolve()),
-    activateWorktree: vi.fn(),
+    activateWorktree,
     createWorktreeForProject: vi.fn(() => Promise.resolve()),
     startTaskInProject: vi.fn(() => Promise.resolve()),
     removeWorktreeById: vi.fn(() => Promise.resolve()),
@@ -210,9 +210,9 @@ export function buildRouteFixture(
     for (const call of setState.mock.calls) {
       const arg = call[0];
       if (typeof arg === "function") {
-        cur = (arg as (
-          p: Record<string, unknown>,
-        ) => Record<string, unknown>)(cur);
+        cur = (arg as (p: Record<string, unknown>) => Record<string, unknown>)(
+          cur,
+        );
       } else {
         cur = arg as Record<string, unknown>;
       }
@@ -238,7 +238,7 @@ export function buildRouteFixture(
       newEditorTab,
       updateEditorMeta,
       renameEditorTabsForPath,
-    closeEditorTabsForPath,
+      closeEditorTabsForPath,
       closeTab,
       setActiveTab,
       setActiveSubTab,
@@ -261,6 +261,7 @@ export function buildRouteFixture(
       setActiveProjectById,
       removeProjectById,
       syncRecentSessionsToState,
+      activateWorktree,
       invoke,
       writeState,
     },

--- a/src/hooks/bridgeMessageHandlers/ready.test.ts
+++ b/src/hooks/bridgeMessageHandlers/ready.test.ts
@@ -99,6 +99,52 @@ describe("handleReady", () => {
     ]);
   });
 
+  it("keeps the configured default model ahead of the bridge fallback", () => {
+    const configuredModel = "openai/user-configured-model";
+    const bridgeFallbackModel = "anthropic/provider-default-model";
+    const { ctx, applySetState } = buildHandlerFixture({
+      state: {
+        activeTabId: "default",
+        tabs: [{ id: "default", model: "" }],
+        sidebar: {},
+        piDefaultModel: configuredModel,
+      },
+    });
+    ctx.piDefaultModelRef.current = configuredModel;
+    handleReady(
+      {
+        type: "ready",
+        model: bridgeFallbackModel,
+        models: [
+          {
+            id: bridgeFallbackModel,
+            label: "Provider Default",
+            provider: "anthropic",
+          },
+          { id: configuredModel, label: "Configured", provider: "openai" },
+        ],
+        extensionStateKeys: [],
+        discoveredTabs: [],
+        tabs: [{ id: "default", model: bridgeFallbackModel }],
+      },
+      ctx,
+    );
+
+    const next = applySetState();
+    expect(ctx.piDefaultModelRef.current).toBe(configuredModel);
+    expect(next.model).toBe(configuredModel);
+    expect(next.piDefaultModel).toBe(configuredModel);
+    expect((next.tabs as { id: string; model: string }[])[0].model).toBe(
+      configuredModel,
+    );
+    expect(
+      (next.sidebar as { models: { id: string; active: boolean }[] }).models,
+    ).toEqual([
+      { id: bridgeFallbackModel, label: "Provider Default", active: false },
+      { id: configuredModel, label: "Configured", active: true },
+    ]);
+  });
+
   it("prunes extension state keys that disappeared between readies", () => {
     const { ctx, applySetState } = buildHandlerFixture({
       state: { activeTabId: "default", tabs: [{ id: "default" }], sidebar: {} },
@@ -253,6 +299,59 @@ describe("handleReady", () => {
         tabId: "tab-2",
         restoreHistory: true,
         cwd: "/repo/a",
+      }),
+    ]);
+  });
+
+  it("requests transcript replay for worktree tabs with their tab cwd", () => {
+    const harness = installTauriMocks();
+    const { ctx } = buildHandlerFixture({
+      state: {
+        activeTabId: "tab-2",
+        tabs: [
+          {
+            id: "tab-2",
+            model: "gpt",
+            projectId: "p1",
+            cwd: "/repo/a-fix-session-restore",
+          },
+        ],
+      },
+    });
+    ctx.projectsRef.current = {
+      activeId: "p1",
+      activeWorktreeId: "wt-1",
+      worktreesByProject: {
+        p1: [
+          {
+            id: "wt-1",
+            projectId: "p1",
+            path: "/repo/a-fix-session-restore",
+            branch: "fix/session-restore",
+            isMain: false,
+          },
+        ],
+      },
+      activeHostId: null,
+      projects: [{ id: "p1", label: "A", path: "/repo/a", lastUsed: 1 }],
+    };
+    handleReady(
+      {
+        type: "ready",
+        model: "claude",
+        tabs: [{ id: "default", model: "claude" }],
+      },
+      ctx,
+    );
+    const payloads = harness.invoke.mock.calls
+      .filter((call) => call[0] === "agent_command")
+      .map((call) => JSON.parse(call[1].payload as string));
+    expect(payloads).toEqual([
+      expect.objectContaining({
+        type: "tab_open",
+        tabId: "tab-2",
+        restoreHistory: true,
+        cwd: "/repo/a-fix-session-restore",
       }),
     ]);
   });

--- a/src/hooks/bridgeMessageHandlers/ready.ts
+++ b/src/hooks/bridgeMessageHandlers/ready.ts
@@ -26,12 +26,18 @@ export const handleReady: BridgeMessageHandler = (data, ctx) => {
   // Cache pi's default model so new tabs created before `ready` fires
   // (or before a session's model initialises) can inherit it immediately
   // instead of showing blank "model ▼".
-  if (model) {
+  if (model && !ctx.piDefaultModelRef.current) {
     ctx.piDefaultModelRef.current = model;
+  }
+  const fallbackModel = ctx.piDefaultModelRef.current || model;
+  if (fallbackModel) {
     // Mirror to state so the header ModelPicker has something to render
     // even when there is no active tab (fresh boot lands on the
     // projects-dashboard, /model is undefined until a tab is opened).
-    ctx.setState((prev) => ({ ...prev, piDefaultModel: model }));
+    ctx.setState((prev) => ({
+      ...prev,
+      piDefaultModel: prev.piDefaultModel || fallbackModel,
+    }));
   }
   const models = (data.models as ModelDescriptor[]) ?? [];
   // Hydrate any extension-registered component templates the bridge
@@ -231,27 +237,33 @@ export const handleReady: BridgeMessageHandler = (data, ctx) => {
     {
       const localTabs = ((next.tabs as Tab[] | undefined) ?? []).slice();
       const bridgeTabs =
-        (data.tabs as { id: string; model: string; cwd?: string }[] | undefined) ??
-        [];
+        (data.tabs as
+          | { id: string; model: string; cwd?: string }[]
+          | undefined) ?? [];
       const tabReplay =
         (data.extensionTabState as
           | Record<string, Record<string, unknown>>
           | undefined) ?? {};
       const dIdx = localTabs.findIndex((t) => t.id === "default");
-      if (dIdx >= 0) {
-        localTabs[dIdx] = { ...localTabs[dIdx], model };
+      if (dIdx >= 0 && !localTabs[dIdx].model && fallbackModel) {
+        localTabs[dIdx] = { ...localTabs[dIdx], model: fallbackModel };
       }
       // Backfill any tab that has no model yet (e.g. opened before ready
       // fired) with pi's default so the picker is never blank.
       for (let i = 0; i < localTabs.length; i++) {
-        if (!localTabs[i].model && model) {
-          localTabs[i] = { ...localTabs[i], model };
+        if (!localTabs[i].model && fallbackModel) {
+          localTabs[i] = { ...localTabs[i], model: fallbackModel };
         }
       }
       for (let i = 0; i < localTabs.length; i++) {
-        const bt = bridgeTabs.find((candidate) => candidate.id === localTabs[i].id);
+        const bt = bridgeTabs.find(
+          (candidate) => candidate.id === localTabs[i].id,
+        );
         if (bt?.model && !localTabs[i].model) {
           localTabs[i] = { ...localTabs[i], model: bt.model };
+        }
+        if (bt?.cwd && !localTabs[i].cwd) {
+          localTabs[i] = { ...localTabs[i], cwd: bt.cwd };
         }
       }
       // Apply the bridge's per-tab replay over each tab record. prev
@@ -289,7 +301,7 @@ export const handleReady: BridgeMessageHandler = (data, ctx) => {
     const activeId = (next.activeTabId as string | undefined) ?? "default";
     const tabsList = (next.tabs as Tab[] | undefined) ?? [];
     const activeTab = tabsList.find((t) => t.id === activeId);
-    const activeModel = activeTab?.model || model;
+    const activeModel = activeTab?.model || fallbackModel;
     next = {
       ...next,
       model: activeModel,
@@ -339,7 +351,7 @@ export const handleReady: BridgeMessageHandler = (data, ctx) => {
     const tabProject = t.projectId
       ? ctx.projectsRef.current.projects.find((p) => p.id === t.projectId)
       : null;
-    const restoredCwd = tabProject?.path;
+    const restoredCwd = t.cwd ?? tabProject?.path;
     const opening = invoke("agent_command", {
       payload: JSON.stringify({
         type: "tab_open",

--- a/src/hooks/useBootConfig.ts
+++ b/src/hooks/useBootConfig.ts
@@ -12,6 +12,7 @@ import type { ShellMeta } from "../types/tab";
 
 export interface UseBootConfigContext {
   setState: Dispatch<SetStateAction<Record<string, unknown>>>;
+  piDefaultModelRef: MutableRefObject<string>;
 }
 
 export interface UseBootConfigActions {
@@ -59,10 +60,8 @@ export interface UseBootConfigActions {
  * see the latest values without re-binding listeners on every config
  * change.
  */
-export function useBootConfig(
-  ctx: UseBootConfigContext,
-): UseBootConfigActions {
-  const { setState } = ctx;
+export function useBootConfig(ctx: UseBootConfigContext): UseBootConfigActions {
+  const { setState, piDefaultModelRef } = ctx;
 
   const defaultShareModeRef = useRef<ShellMeta["shareMode"]>("private");
   const notifyOnCompletionRef = useRef<boolean>(true);
@@ -96,6 +95,14 @@ export function useBootConfig(
     shellInheritEnvRef.current = fresh.shell.inheritEnv;
     shellPromptBeforeCloseRef.current = fresh.shell.promptBeforeClose;
     shortcutsNewTabKindRef.current = fresh.shortcuts.newTabKind;
+    if (fresh.agent.model) {
+      piDefaultModelRef.current = fresh.agent.model;
+      setState((prev) => ({
+        ...prev,
+        model: fresh.agent.model!,
+        piDefaultModel: fresh.agent.model!,
+      }));
+    }
   }
 
   useEffect(() => {
@@ -170,11 +177,14 @@ export function useBootConfig(
       // time, so writing /model here makes the next set_model dispatch
       // pick it up.
       if (config.agent.model) {
+        piDefaultModelRef.current = config.agent.model;
         setState((prev) => ({
           ...prev,
-          // Use as the initial display value; the actual session model
-          // is still authoritative and wins on `ready` hydration.
-          model: (prev.model) || config.agent.model!,
+          // Use as the initial display value and the new-tab fallback.
+          // Per-tab model_changed events remain authoritative after a
+          // session is actually running.
+          model: config.agent.model!,
+          piDefaultModel: config.agent.model!,
         }));
       }
       // Restore saved UI zoom (Cmd+/-). Stored as a string number on

--- a/src/hooks/useProjectOps.test.ts
+++ b/src/hooks/useProjectOps.test.ts
@@ -17,7 +17,7 @@ afterEach(() => {
   clearTauriMocks();
 });
 
-const ref = <T,>(value: T) => ({ current: value });
+const ref = <T>(value: T) => ({ current: value });
 
 function makeProjectsState(
   overrides: Partial<ProjectsState> = {},
@@ -86,9 +86,9 @@ describe("tabsForProjectBucket", () => {
     expect(tabsForProjectBucket(tabs, "project-1").map((t) => t.id)).toEqual([
       "p1",
     ]);
-    expect(tabsForProjectBucket(tabs, NO_PROJECT_KEY).map((t) => t.id)).toEqual([
-      "none",
-    ]);
+    expect(tabsForProjectBucket(tabs, NO_PROJECT_KEY).map((t) => t.id)).toEqual(
+      ["none"],
+    );
   });
 });
 
@@ -123,6 +123,45 @@ describe("nonEmptyProjectTabs", () => {
     expect(nonEmptyProjectTabs(tabs).map((t) => t.id)).toEqual([
       "chat",
       "shell",
+    ]);
+  });
+});
+
+describe("useProjectOps session scoping", () => {
+  it("scopes discovered sessions to the active worktree cwd", () => {
+    const { result } = renderProjectOps(
+      makeProjectsState({
+        activeId: "project-1",
+        activeWorktreeId: "wt-1",
+        worktreesByProject: {
+          "project-1": [
+            {
+              id: "wt-1",
+              projectId: "project-1",
+              path: "/projects/aethon-fix-session-restore",
+              branch: "fix/session-restore",
+              isMain: false,
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(
+      result.current.scopedDiscoveredSessions([
+        { tabId: "main", lastModified: 1, cwd: "/projects/aethon" },
+        {
+          tabId: "worktree",
+          lastModified: 2,
+          cwd: "/projects/aethon-fix-session-restore",
+        },
+      ]),
+    ).toEqual([
+      {
+        tabId: "worktree",
+        lastModified: 2,
+        cwd: "/projects/aethon-fix-session-restore",
+      },
     ]);
   });
 });
@@ -214,7 +253,9 @@ describe("useProjectOps worktree refresh", () => {
 
     expect(projectsRef.current.activeWorktreeId).toBeNull();
     expect(projectsRef.current.worktreesByProject["project-1"]).toHaveLength(1);
-    expect(projectsRef.current.worktreesByProject["project-1"]?.[0]).toMatchObject({
+    expect(
+      projectsRef.current.worktreesByProject["project-1"]?.[0],
+    ).toMatchObject({
       path: "/projects/aethon",
       branch: "main",
       isMain: true,
@@ -311,17 +352,17 @@ describe("useProjectOps worktree creation", () => {
       return Promise.resolve(undefined);
     });
     const initial = makeProjectsState({
-        activeId: "project-1",
-        projects: [
-          {
-            id: "project-1",
-            label: "aethon",
-            path: "/projects/aethon",
-            lastUsed: 1,
-            worktreeBaseBranch: "upstream/trunk",
-          },
-        ],
-      });
+      activeId: "project-1",
+      projects: [
+        {
+          id: "project-1",
+          label: "aethon",
+          path: "/projects/aethon",
+          lastUsed: 1,
+          worktreeBaseBranch: "upstream/trunk",
+        },
+      ],
+    });
     const { result, projectsRef } = renderProjectOps(initial);
     await act(async () => {
       await Promise.resolve();

--- a/src/hooks/useProjectOps.ts
+++ b/src/hooks/useProjectOps.ts
@@ -6,13 +6,10 @@ import {
   type MutableRefObject,
   type SetStateAction,
 } from "react";
-import {
-  NO_PROJECT_KEY,
-  projectBucketKey,
-  type Tab,
-} from "../types/tab";
+import { NO_PROJECT_KEY, projectBucketKey, type Tab } from "../types/tab";
 import {
   DEFAULT_WORKTREE_BASE_BRANCH,
+  activeCwd,
   activeProject,
   loadProjects,
   pickProjectDirectory,
@@ -233,9 +230,7 @@ export function nonEmptyProjectTabs(tabs: Tab[]): Tab[] {
  * branch is load-bearing: without it, a stale activeTabId would leave
  * `empty:true` with `tabs.length>0`.
  */
-export function useProjectOps(
-  ctx: UseProjectOpsContext,
-): UseProjectOpsActions {
+export function useProjectOps(ctx: UseProjectOpsContext): UseProjectOpsActions {
   const {
     setState,
     stateRef,
@@ -286,58 +281,70 @@ export function useProjectOps(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const buildSidebarHistory = useCallback((
-    tabs: Tab[],
-    activeTabId: string | undefined,
-    recentSessions: RecentSessionItem[],
-  ): SidebarHistoryItem[] => {
-    const openIds = new Set(tabs.map((t) => t.id));
-    const firstUserText = (messages: ChatMessage[]): string => {
-      const first = messages.find(
-        (m) => m.role === "user" && typeof m.text === "string" && m.text.trim().length > 0,
-      );
-      return first?.text?.replace(/\s+/g, " ").trim().slice(0, 48) ?? "";
-    };
-    const openHistory = tabs
-      .filter((t) => t.messages.length > 0)
-      .map((t) => {
-        const firstMsg = firstUserText(t.messages);
-        // Use first user message as the display label when the tab still has
-        // a generic sequential name (Tab 1, Tab 2, …). Explicit renames keep
-        // their name.
-        const label = /^Tab \d+$/.test(t.label) && firstMsg ? firstMsg : t.label;
-        const hint = t.id === activeTabId ? "active" : `${t.messages.length} msg`;
-        return {
-          id: `tab:${t.id}`,
-          label,
-          hint,
-          tooltip: firstMsg || label,
-          active: t.id === activeTabId,
-        };
-      });
-    const restoredHistory = recentSessions
-      .filter((s) => !openIds.has(s.id))
-      .map((s) => ({
-        id: `session:${s.id}`,
-        label: s.label,
-        hint: s.lastModified,
-        tooltip: s.cwd ? s.cwd : "Restore session",
-      }));
-    return [...openHistory, ...restoredHistory].slice(0, 16);
-  }, []);
+  const buildSidebarHistory = useCallback(
+    (
+      tabs: Tab[],
+      activeTabId: string | undefined,
+      recentSessions: RecentSessionItem[],
+    ): SidebarHistoryItem[] => {
+      const openIds = new Set(tabs.map((t) => t.id));
+      const firstUserText = (messages: ChatMessage[]): string => {
+        const first = messages.find(
+          (m) =>
+            m.role === "user" &&
+            typeof m.text === "string" &&
+            m.text.trim().length > 0,
+        );
+        return first?.text?.replace(/\s+/g, " ").trim().slice(0, 48) ?? "";
+      };
+      const openHistory = tabs
+        .filter((t) => t.messages.length > 0)
+        .map((t) => {
+          const firstMsg = firstUserText(t.messages);
+          // Use first user message as the display label when the tab still has
+          // a generic sequential name (Tab 1, Tab 2, …). Explicit renames keep
+          // their name.
+          const label =
+            /^Tab \d+$/.test(t.label) && firstMsg ? firstMsg : t.label;
+          const hint =
+            t.id === activeTabId ? "active" : `${t.messages.length} msg`;
+          return {
+            id: `tab:${t.id}`,
+            label,
+            hint,
+            tooltip: firstMsg || label,
+            active: t.id === activeTabId,
+          };
+        });
+      const restoredHistory = recentSessions
+        .filter((s) => !openIds.has(s.id))
+        .map((s) => ({
+          id: `session:${s.id}`,
+          label: s.label,
+          hint: s.lastModified,
+          tooltip: s.cwd ? s.cwd : "Restore session",
+        }));
+      return [...openHistory, ...restoredHistory].slice(0, 16);
+    },
+    [],
+  );
 
   function scopedDiscoveredSessions(
     discovered: DiscoveredSession[],
   ): DiscoveredSession[] {
-    const active = activeProject(projectsRef.current);
-    if (!active) return discovered;
-    const activePath = normalizeSessionPath(active.path);
-    return discovered.filter((session) => normalizeSessionPath(session.cwd) === activePath);
+    const activePath = normalizeSessionPath(
+      activeCwd(projectsRef.current) ?? undefined,
+    );
+    if (!activePath) return discovered;
+    return discovered.filter(
+      (session) => normalizeSessionPath(session.cwd) === activePath,
+    );
   }
 
   function knownTabIds(extraTabs: { id: string }[] = []): Set<string> {
     return new Set(
-      (((stateRef.current.tabs as Tab[] | undefined) ?? []).map((t) => t.id))
+      ((stateRef.current.tabs as Tab[] | undefined) ?? [])
+        .map((t) => t.id)
         .concat(extraTabs.map((t) => t.id))
         .concat(["default"]),
     );
@@ -356,7 +363,10 @@ export function useProjectOps(
         //   2. Project directory basename
         //   3. Fallback UUID prefix
         const cwdBasename = d.cwd
-          ? d.cwd.replace(/[/\\]+$/, "").split(/[/\\]/).pop() ?? ""
+          ? (d.cwd
+              .replace(/[/\\]+$/, "")
+              .split(/[/\\]/)
+              .pop() ?? "")
           : "";
         // Custom label (set via /rename or sidebar context menu) wins
         // over the auto-derived first-user-message label.
@@ -396,7 +406,7 @@ export function useProjectOps(
     const ps = projectsRef.current;
     const active = activeProject(ps);
     const sidebar = (prev.sidebar as Record<string, unknown> | undefined) ?? {};
-    const tabs = tabsForRecent ?? ((prev.tabs as Tab[] | undefined) ?? []);
+    const tabs = tabsForRecent ?? (prev.tabs as Tab[] | undefined) ?? [];
     const tabIds = new Set(tabs.map((t) => t.id).concat(["default"]));
     return {
       projects: ps.projects,
@@ -762,11 +772,7 @@ export function useProjectOps(
       const listing = await gitWorktrees(project.path);
       const prior = projectsRef.current.worktreesByProject[projectId] ?? [];
       const next = reconcileWorktrees(projectId, prior, listing);
-      let nextState = setProjectWorktrees(
-        projectsRef.current,
-        projectId,
-        next,
-      );
+      let nextState = setProjectWorktrees(projectsRef.current, projectId, next);
       const activeWorktreeId = nextState.activeWorktreeId;
       if (
         nextState.activeId === projectId &&
@@ -799,7 +805,11 @@ export function useProjectOps(
   }
 
   function setProjectIconUrl(projectId: string, iconUrl: string | null): void {
-    const next = setProjectIconUrlState(projectsRef.current, projectId, iconUrl);
+    const next = setProjectIconUrlState(
+      projectsRef.current,
+      projectId,
+      iconUrl,
+    );
     if (next === projectsRef.current) return;
     projectsRef.current = next;
     void persistProjects();
@@ -888,10 +898,11 @@ export function useProjectOps(
     const pending = newPendingWorktree(opts.projectId, branch, targetPath);
     const baseBranch = resolveWorktreeBaseBranch(project, opts.baseBranch);
     const before = projectsRef.current.worktreesByProject[opts.projectId] ?? [];
-    projectsRef.current = setProjectWorktrees(projectsRef.current, opts.projectId, [
-      ...before,
-      pending,
-    ]);
+    projectsRef.current = setProjectWorktrees(
+      projectsRef.current,
+      opts.projectId,
+      [...before, pending],
+    );
     syncProjectsToState();
     projectsRef.current = setProjectWorktrees(
       projectsRef.current,
@@ -978,10 +989,7 @@ export function useProjectOps(
         list,
       );
       if (projectsRef.current.activeWorktreeId === worktreeId) {
-        projectsRef.current = setActiveWorktreeState(
-          projectsRef.current,
-          null,
-        );
+        projectsRef.current = setActiveWorktreeState(projectsRef.current, null);
       }
       void persistProjects();
     } catch (err) {

--- a/src/hooks/useTabs.test.ts
+++ b/src/hooks/useTabs.test.ts
@@ -23,9 +23,7 @@ describe("recentSessionItemFromClosedTab", () => {
       activeWorktreeId: null,
       worktreesByProject: {},
       activeHostId: null,
-      projects: [
-        { id: "p1", label: "mold", path: "/repo/mold", lastUsed: 1 },
-      ],
+      projects: [{ id: "p1", label: "mold", path: "/repo/mold", lastUsed: 1 }],
     };
 
     expect(recentSessionItemFromClosedTab(tab, projects)).toEqual({
@@ -36,9 +34,50 @@ describe("recentSessionItemFromClosedTab", () => {
     });
   });
 
+  it("keeps a closed worktree chat scoped to its original cwd", () => {
+    const tab = {
+      ...makeEmptyTab("worktree-tab", "Tab 1", "p1"),
+      cwd: "/repo/mold-fix-session-restore",
+      messages: [
+        {
+          id: "m1",
+          role: "user" as const,
+          text: "Recover this branch session",
+        },
+      ],
+    };
+    const projects = {
+      activeId: "p1",
+      activeWorktreeId: "wt-1",
+      worktreesByProject: {
+        p1: [
+          {
+            id: "wt-1",
+            projectId: "p1",
+            path: "/repo/mold-fix-session-restore",
+            branch: "fix/session-restore",
+            isMain: false,
+          },
+        ],
+      },
+      activeHostId: null,
+      projects: [{ id: "p1", label: "mold", path: "/repo/mold", lastUsed: 1 }],
+    };
+
+    expect(recentSessionItemFromClosedTab(tab, projects)).toEqual({
+      id: "worktree-tab",
+      label: "Recover this branch session",
+      lastModified: "now",
+      cwd: "/repo/mold-fix-session-restore",
+    });
+  });
+
   it("does not create history entries for empty tabs", () => {
     expect(
-      recentSessionItemFromClosedTab(makeEmptyTab("t1", "Tab 1"), emptyProjectsState()),
+      recentSessionItemFromClosedTab(
+        makeEmptyTab("t1", "Tab 1"),
+        emptyProjectsState(),
+      ),
     ).toBeNull();
   });
 });

--- a/src/hooks/useTabs.ts
+++ b/src/hooks/useTabs.ts
@@ -14,10 +14,7 @@ import {
 } from "../types/tab";
 import { languageFromPath } from "../monaco/language-detection";
 import { disposeEditorBuffer } from "../monaco/editor-buffers";
-import {
-  activeCwd,
-  type ProjectsState,
-} from "../projects";
+import { activeCwd, type ProjectsState } from "../projects";
 import { getConfig } from "../config";
 import { recomputeModelPicker } from "../utils/modelPicker";
 
@@ -37,6 +34,7 @@ export const TAB_MIRROR_KEYS: (keyof Tab)[] = [
   "queueCount",
   "canvas",
   "model",
+  "cwd",
   // M6 P1: shell-tab fields. The "kind" + "shell" mirror lets layouts
   // bind `visible: { $ref: "/kind" }`-style toggles without running a
   // full /tabs/<idx> lookup on every render.
@@ -65,7 +63,9 @@ function sessionLabel(session: DiscoveredSession): string {
   return `Session ${session.tabId.slice(0, 8)}`;
 }
 
-function sessionLabelFromMessages(messages: Tab["messages"]): string | undefined {
+function sessionLabelFromMessages(
+  messages: Tab["messages"],
+): string | undefined {
   const first = messages.find(
     (m) =>
       m.role === "user" &&
@@ -97,14 +97,15 @@ export function recentSessionItemFromClosedTab(
   projects: ProjectsState,
 ): { id: string; label: string; lastModified: string; cwd?: string } | null {
   if (tab.kind !== "agent" || tab.messages.length === 0) return null;
-  const projectPath = tab.projectId
+  const fallbackProjectPath = tab.projectId
     ? projects.projects.find((p) => p.id === tab.projectId)?.path
     : undefined;
+  const cwd = tab.cwd ?? fallbackProjectPath;
   return {
     id: tab.id,
     label: sessionLabelFromMessages(tab.messages) ?? tab.label,
     lastModified: "now",
-    ...(projectPath ? { cwd: projectPath } : {}),
+    ...(cwd ? { cwd } : {}),
   };
 }
 
@@ -171,7 +172,11 @@ export interface UseTabsActions {
   newTab: (
     restoreId?: string,
     restoreLabel?: string,
-    options?: { restoredSession?: boolean; cwd?: string; scrollToMatch?: string },
+    options?: {
+      restoredSession?: boolean;
+      cwd?: string;
+      scrollToMatch?: string;
+    },
   ) => void;
   newShellTab: (options?: {
     command?: string;
@@ -363,7 +368,9 @@ export function useTabs(ctx: UseTabsContext): UseTabsActions {
       requestAnimationFrame(() => {
         const tabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
         const activeId = stateRef.current.activeTabId as string | undefined;
-        const active = activeId ? tabs.find((t) => t.id === activeId) : undefined;
+        const active = activeId
+          ? tabs.find((t) => t.id === activeId)
+          : undefined;
         const buffer = active?.terminalBuffer ?? "";
         dispatchTerminalReplay(buffer);
       });
@@ -414,6 +421,8 @@ export function useTabs(ctx: UseTabsContext): UseTabsActions {
     // the last model selected in that project, then the visible/global
     // model, then pi's ready-reported default.
     const projectId = projectsRef.current.activeId;
+    const inheritedCwd =
+      options?.cwd ?? activeCwd(projectsRef.current) ?? undefined;
     const inheritedModel = modelForNewProjectTab(
       stateRef.current,
       projectId,
@@ -428,10 +437,12 @@ export function useTabs(ctx: UseTabsContext): UseTabsActions {
       : undefined;
     setState((prev) => {
       const tabs = ((prev.tabs as Tab[] | undefined) ?? []).slice();
-      const label = restoreLabel ?? existingSessionLabel ?? `Tab ${tabs.length + 1}`;
+      const label =
+        restoreLabel ?? existingSessionLabel ?? `Tab ${tabs.length + 1}`;
       const tab: Tab = {
         ...makeEmptyTab(id, label, projectId),
         model: inheritedModel,
+        ...(inheritedCwd ? { cwd: inheritedCwd } : {}),
       };
       tabs.push(tab);
       const result: Record<string, unknown> = {
@@ -454,8 +465,6 @@ export function useTabs(ctx: UseTabsContext): UseTabsActions {
     // Clear the shared xterm so it doesn't keep showing the previous
     // tab's scrollback until the next switch / output event.
     dispatchTerminalReplay("");
-    const inheritedCwd =
-      options?.cwd ?? activeCwd(projectsRef.current) ?? undefined;
     const opening = invoke("agent_command", {
       payload: JSON.stringify({
         type: "tab_open",
@@ -556,7 +565,10 @@ export function useTabs(ctx: UseTabsContext): UseTabsActions {
   /** Compute a tab label from a file path: just the basename, since the
    *  full path is shown in the editor status strip. */
   function editorLabelForPath(filePath: string): string {
-    const slash = Math.max(filePath.lastIndexOf("/"), filePath.lastIndexOf("\\"));
+    const slash = Math.max(
+      filePath.lastIndexOf("/"),
+      filePath.lastIndexOf("\\"),
+    );
     return slash >= 0 ? filePath.slice(slash + 1) : filePath;
   }
 
@@ -731,11 +743,11 @@ export function useTabs(ctx: UseTabsContext): UseTabsActions {
         if (!config.ui.restoreTabs) return;
         const liveIds = new Set([
           ...knownIds,
-          ...(((stateRef.current.tabs as Tab[] | undefined) ?? []).map(
+          ...((stateRef.current.tabs as Tab[] | undefined) ?? []).map(
             (t) => t.id,
-          )),
+          ),
         ]);
-      const toRestore = discovered
+        const toRestore = discovered
           .filter((d) => !liveIds.has(d.tabId))
           .filter((d) => !autoRestoredSessionIdsRef.current.has(d.tabId))
           .slice(0, 8);
@@ -773,6 +785,7 @@ export function useTabs(ctx: UseTabsContext): UseTabsActions {
             args: tab.shell.args,
           }
         : {}),
+      ...(tab.kind === "agent" && tab.cwd ? { cwd: tab.cwd } : {}),
       ...(tab.kind === "editor" && tab.editor
         ? { filePath: tab.editor.filePath }
         : {}),
@@ -816,7 +829,10 @@ export function useTabs(ctx: UseTabsContext): UseTabsActions {
       // unsaved buffer state is intentionally not preserved across close.
       newEditorTab(entry.filePath);
     } else {
-      newTab(entry.id, entry.label, { restoredSession: true });
+      newTab(entry.id, entry.label, {
+        restoredSession: true,
+        ...(entry.cwd ? { cwd: entry.cwd } : {}),
+      });
     }
   }
 

--- a/src/state/sessionUiSnapshot.test.ts
+++ b/src/state/sessionUiSnapshot.test.ts
@@ -16,6 +16,7 @@ describe("sessionUiSnapshot", () => {
   it("round-trips open tabs, active tab, and chrome state", () => {
     const tabA = {
       ...makeEmptyTab("tab-a", "A"),
+      cwd: "/repo/a-worktree",
       messages: [{ id: "m1", role: "user" as const, text: "hi" }],
     };
     const tabB = {
@@ -38,7 +39,12 @@ describe("sessionUiSnapshot", () => {
     expect(loadSessionUiSnapshot()).toMatchObject({
       activeTabId: "tab-b",
       tabs: [
-        { id: "tab-a", label: "A", messages: [{ text: "hi" }] },
+        {
+          id: "tab-a",
+          label: "A",
+          cwd: "/repo/a-worktree",
+          messages: [{ text: "hi" }],
+        },
         { id: "tab-b", label: "B", canvas: { type: "card" } },
       ],
       // Legacy 2-column snapshot upgrades to the new 3-column shape on
@@ -114,7 +120,9 @@ describe("sessionUiSnapshot", () => {
         makeEmptyTab("blank", "Tab 1"),
         {
           ...makeEmptyTab("active-chat", "Tell me about this app"),
-          messages: [{ id: "m1", role: "user", text: "Tell me about this app" }],
+          messages: [
+            { id: "m1", role: "user", text: "Tell me about this app" },
+          ],
         },
       ],
       activeTabId: "blank",

--- a/src/types/tab.ts
+++ b/src/types/tab.ts
@@ -69,6 +69,9 @@ export interface Tab {
   // projects swaps `state.tabs` for the target project's bucket and
   // hides everyone else.
   projectId: string | null;
+  // Immutable working directory the bridge session was created with.
+  // For worktree sessions this is the worktree path, not the project root.
+  cwd?: string;
   /** Present iff kind === "shell". */
   shell?: ShellMeta;
   /** Present iff kind === "editor". */
@@ -89,7 +92,7 @@ export interface ClosedTabEntry {
   kind: TabKind;
   label: string;
   projectId: string | null;
-  /** Shell tabs only — passed back to newShellTab. */
+  /** Agent and shell tabs — passed back to reopen/restore paths. */
   cwd?: string;
   command?: string;
   args?: string[];


### PR DESCRIPTION
## Summary

- restore saved sessions through a shared route that activates the matching project and worktree before reopening the tab
- preserve agent tab cwd through tab state, closed-tab history, ready replay, session snapshots, and bridge startup
- centralize release command spawning behind an enriched PATH resolver so desktop launches can find `gh`, `git`, `npm`, `bun`, and platform opener commands from Nix, Homebrew, system, Cargo, and local profile paths
- honor the configured `[agent].model` as the effective startup and new-tab default instead of letting the provider default overwrite it during ready hydration

## Root Cause

Session restore only reopened a tab id; it did not first move the visible project/worktree selection back to the cwd that originally owned that session. At the same time, tab cwd was not carried through all restore and replay paths, so hot reloads and restored sessions could fall back to the project root.

Release builds inherit a sparse desktop-launch PATH, especially for Nix-managed tools, so direct `Command::new("gh")`/`git`/`npm` calls could fail even though the tools were available in an interactive shell.

The model picker cached the bridge/provider default from `ready` unconditionally, which could displace the user-configured `[agent].model` before a new tab was created.

## Validation

- `bunx vitest run agent/active-project-cwd.test.ts src/hooks/bridgeMessageHandlers/ready.test.ts src/hooks/useTabs.test.ts src/hooks/useProjectOps.test.ts src/state/sessionUiSnapshot.test.ts src/eventRoutes/dashboard.test.ts`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib`
- `bun run typecheck`
- `bun run test`
- `bun run lint` (passes with the existing 5 React compiler warnings in untouched files)
- `git diff --check`
- `nix flake check`
