### PR TITLE
fix(chat): support steering and scoped cwd sessions

### DIFF
--- a/agent/active-project-cwd.test.ts
+++ b/agent/active-project-cwd.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { activeProjectCwdFromJson } from "./active-project-cwd";
+import {
+  activeProjectCwdFromJson,
+  resolveStartupCwd,
+} from "./active-project-cwd";
 
 describe("activeProjectCwdFromJson", () => {
   it("uses the active project path when no worktree is active", () => {
@@ -13,25 +16,19 @@ describe("activeProjectCwdFromJson", () => {
     ).toBe("/repo/app");
   });
 
-  it("uses the active worktree path when one is selected", () => {
+  it("prefers the active worktree path when present", () => {
     expect(
       activeProjectCwdFromJson(
         JSON.stringify({
           activeId: "p1",
-          activeWorktreeId: "wt-1",
-          projects: [{ id: "p1", path: "/repo/app" }],
+          activeWorktreeId: "wt1",
+          projects: [{ id: "p1", path: "/repo/aethon" }],
           worktreesByProject: {
-            p1: [
-              {
-                id: "wt-1",
-                projectId: "p1",
-                path: "/repo/app-fix-session-restore",
-              },
-            ],
+            p1: [{ id: "wt1", projectId: "p1", path: "/repo/aethon-fix" }],
           },
         }),
       ),
-    ).toBe("/repo/app-fix-session-restore");
+    ).toBe("/repo/aethon-fix");
   });
 
   it("falls back to the project path when the active worktree is stale", () => {
@@ -49,5 +46,17 @@ describe("activeProjectCwdFromJson", () => {
 
   it("returns undefined for malformed project state", () => {
     expect(activeProjectCwdFromJson("{nope")).toBeUndefined();
+  });
+});
+
+describe("resolveStartupCwd", () => {
+  it("uses active project, then dev project root, then process cwd", () => {
+    expect(resolveStartupCwd("/repo/project", "/repo/aethon", "/")).toBe(
+      "/repo/project",
+    );
+    expect(resolveStartupCwd(undefined, "/repo/aethon", "/")).toBe(
+      "/repo/aethon",
+    );
+    expect(resolveStartupCwd(undefined, undefined, "/")).toBe("/");
   });
 });

--- a/agent/active-project-cwd.ts
+++ b/agent/active-project-cwd.ts
@@ -64,3 +64,13 @@ export async function readActiveProjectCwd(
     return undefined;
   }
 }
+
+export function resolveStartupCwd(
+  activeProjectCwd: string | undefined,
+  projectRoot: string | undefined,
+  processCwd: string,
+): string {
+  if (activeProjectCwd && activeProjectCwd.length > 0) return activeProjectCwd;
+  if (projectRoot && projectRoot.length > 0) return projectRoot;
+  return processCwd;
+}

--- a/agent/dispatcher.test.ts
+++ b/agent/dispatcher.test.ts
@@ -51,9 +51,9 @@ function fakeTabRecord(overrides: Partial<TabRecord> = {}): TabRecord {
   return {
     id: "tab-1",
     session: {
-      prompt: async () => {},
-      steer: async () => {},
-      followUp: async () => {},
+      prompt: () => Promise.resolve(),
+      steer: () => Promise.resolve(),
+      followUp: () => Promise.resolve(),
     } as unknown as TabRecord["session"],
     toolArgsCache: new Map(),
     promptInFlight: false,
@@ -73,14 +73,17 @@ describe("handleChat", () => {
     const tab = fakeTabRecord({
       promptInFlight: true,
       session: {
-        prompt: async (...args: unknown[]) => {
+        prompt: (...args: unknown[]) => {
           promptCalls.push(args);
+          return Promise.resolve();
         },
-        followUp: async (...args: unknown[]) => {
+        followUp: (...args: unknown[]) => {
           followUpCalls.push(args);
+          return Promise.resolve();
         },
-        steer: async (...args: unknown[]) => {
+        steer: (...args: unknown[]) => {
           steerCalls.push(args);
+          return Promise.resolve();
         },
       } as unknown as TabRecord["session"],
     });
@@ -108,12 +111,14 @@ describe("handleChat", () => {
       promptInFlight: true,
       queuedCount: 2,
       session: {
-        prompt: async (...args: unknown[]) => {
+        prompt: (...args: unknown[]) => {
           promptCalls.push(args);
+          return Promise.resolve();
         },
-        followUp: async () => {},
-        steer: async (...args: unknown[]) => {
+        followUp: () => Promise.resolve(),
+        steer: (...args: unknown[]) => {
           steerCalls.push(args);
+          return Promise.resolve();
         },
       } as unknown as TabRecord["session"],
     });
@@ -143,9 +148,10 @@ describe("handleChat", () => {
           promptCalls.push(args);
           return pendingPrompt;
         },
-        followUp: async () => {},
-        steer: async (...args: unknown[]) => {
+        followUp: () => Promise.resolve(),
+        steer: (...args: unknown[]) => {
           steerCalls.push(args);
+          return Promise.resolve();
         },
       } as unknown as TabRecord["session"],
     });
@@ -174,8 +180,8 @@ describe("handleChat", () => {
           promptCalls.push(args);
           return new Promise<void>(() => {});
         },
-        followUp: async () => {},
-        steer: async () => {},
+        followUp: () => Promise.resolve(),
+        steer: () => Promise.resolve(),
       } as unknown as TabRecord["session"],
     });
     f.state.tabs.set("tab-1", first);

--- a/agent/dispatcher.test.ts
+++ b/agent/dispatcher.test.ts
@@ -3,12 +3,14 @@ import {
   AethonAgentState,
   type AethonAgentStateOptions,
   type ProjectBaselineSnapshot,
+  type TabRecord,
 } from "./state";
 import {
   captureProjectExtensionBaseline,
   exportTargetForSlashCommand,
   formatContextUsageMessage,
   formatSessionStatsMessage,
+  handleChat,
   unloadProjectExtensions,
 } from "./dispatcher";
 
@@ -44,6 +46,155 @@ function makeFixture() {
     writes: () => writes,
   };
 }
+
+function fakeTabRecord(overrides: Partial<TabRecord> = {}): TabRecord {
+  return {
+    id: "tab-1",
+    session: {
+      prompt: async () => {},
+      steer: async () => {},
+      followUp: async () => {},
+    } as unknown as TabRecord["session"],
+    toolArgsCache: new Map(),
+    promptInFlight: false,
+    agentEndFired: false,
+    queuedCount: 0,
+    toolCardSeq: 0,
+    ...overrides,
+  };
+}
+
+describe("handleChat", () => {
+  it("queues normal messages while a prompt is in flight", async () => {
+    const f = makeFixture();
+    const promptCalls: unknown[][] = [];
+    const followUpCalls: unknown[][] = [];
+    const steerCalls: unknown[][] = [];
+    const tab = fakeTabRecord({
+      promptInFlight: true,
+      session: {
+        prompt: async (...args: unknown[]) => {
+          promptCalls.push(args);
+        },
+        followUp: async (...args: unknown[]) => {
+          followUpCalls.push(args);
+        },
+        steer: async (...args: unknown[]) => {
+          steerCalls.push(args);
+        },
+      } as unknown as TabRecord["session"],
+    });
+    f.state.tabs.set("tab-1", tab);
+
+    await handleChat(f.state, f.deps, {
+      type: "chat",
+      content: "after this",
+      tabId: "tab-1",
+      mode: "normal",
+    });
+
+    expect(tab.queuedCount).toBe(1);
+    expect(promptCalls).toEqual([]);
+    expect(followUpCalls).toEqual([["after this"]]);
+    expect(steerCalls).toEqual([]);
+    expect(f.sent).toContainEqual({ type: "queued", tabId: "tab-1" });
+  });
+
+  it("steers command-enter messages into the active prompt", async () => {
+    const f = makeFixture();
+    const promptCalls: unknown[][] = [];
+    const steerCalls: unknown[][] = [];
+    const tab = fakeTabRecord({
+      promptInFlight: true,
+      queuedCount: 2,
+      session: {
+        prompt: async (...args: unknown[]) => {
+          promptCalls.push(args);
+        },
+        followUp: async () => {},
+        steer: async (...args: unknown[]) => {
+          steerCalls.push(args);
+        },
+      } as unknown as TabRecord["session"],
+    });
+    f.state.tabs.set("tab-1", tab);
+
+    await handleChat(f.state, f.deps, {
+      type: "chat",
+      content: "look here now",
+      tabId: "tab-1",
+      mode: "steer",
+    });
+
+    expect(tab.queuedCount).toBe(2);
+    expect(promptCalls).toEqual([]);
+    expect(steerCalls).toEqual([["look here now"]]);
+    expect(f.sent).not.toContainEqual({ type: "queued", tabId: "tab-1" });
+  });
+
+  it("treats steer as a normal prompt when the tab is idle", async () => {
+    const f = makeFixture();
+    const promptCalls: unknown[][] = [];
+    const steerCalls: unknown[][] = [];
+    const pendingPrompt = new Promise<void>(() => {});
+    const tab = fakeTabRecord({
+      session: {
+        prompt: (...args: unknown[]) => {
+          promptCalls.push(args);
+          return pendingPrompt;
+        },
+        followUp: async () => {},
+        steer: async (...args: unknown[]) => {
+          steerCalls.push(args);
+        },
+      } as unknown as TabRecord["session"],
+    });
+    f.state.tabs.set("tab-1", tab);
+
+    await handleChat(f.state, f.deps, {
+      type: "chat",
+      content: "start fresh",
+      tabId: "tab-1",
+      mode: "steer",
+    });
+
+    expect(promptCalls).toEqual([["start fresh"]]);
+    expect(steerCalls).toEqual([]);
+    expect(tab.promptInFlight).toBe(true);
+  });
+
+  it("starts an idle tab immediately even while another tab is running", async () => {
+    const f = makeFixture();
+    const first = fakeTabRecord({ id: "tab-1", promptInFlight: true });
+    const promptCalls: unknown[][] = [];
+    const second = fakeTabRecord({
+      id: "tab-2",
+      session: {
+        prompt: (...args: unknown[]) => {
+          promptCalls.push(args);
+          return new Promise<void>(() => {});
+        },
+        followUp: async () => {},
+        steer: async () => {},
+      } as unknown as TabRecord["session"],
+    });
+    f.state.tabs.set("tab-1", first);
+    f.state.tabs.set("tab-2", second);
+
+    await handleChat(f.state, f.deps, {
+      type: "chat",
+      content: "run in parallel",
+      tabId: "tab-2",
+      mode: "normal",
+    });
+
+    expect(first.queuedCount).toBe(0);
+    expect(second.queuedCount).toBe(0);
+    expect(second.promptInFlight).toBe(true);
+    expect(promptCalls).toEqual([["run in parallel"]]);
+    expect(f.sent).not.toContainEqual({ type: "queued", tabId: "tab-2" });
+  });
+});
 
 describe("captureProjectExtensionBaseline", () => {
   it("snapshots every extension registry independently of the live one", () => {

--- a/agent/dispatcher.ts
+++ b/agent/dispatcher.ts
@@ -28,10 +28,7 @@ import type {
 } from "./state";
 import type { AethonApi } from "./aethon-api";
 import { logger } from "./logger";
-import {
-  ackMutation,
-  markFrontendReady,
-} from "./mutation-ack";
+import { ackMutation, markFrontendReady } from "./mutation-ack";
 import { dismissNotification, notify } from "./notifications";
 import { setState, makeCanvasApi } from "./state-mutation";
 import {
@@ -41,9 +38,7 @@ import {
   modelKey,
   tabSessionDir,
 } from "./tab-lifecycle";
-import {
-  loadProjectAethonExtensions,
-} from "./extension-loader";
+import { loadProjectAethonExtensions } from "./extension-loader";
 import { patchLayoutTree } from "./layout-manager";
 import {
   appendLocalChatMessage,
@@ -259,9 +254,10 @@ export function unloadProjectExtensions(
   deps.scheduleStateFileWrite();
 }
 
-interface InboundMessage {
+export interface InboundMessage {
   type: string;
   content?: string;
+  mode?: "normal" | "steer";
   name?: string;
   args?: string;
   id?: string;
@@ -401,6 +397,90 @@ export function formatSessionStatsMessage(
   return lines.join("\n");
 }
 
+/** If a reload was requested AND no tab has a prompt in flight, write
+ *  the `_reload_done` sentinel and exit cleanly. The Rust supervisor's
+ *  stdout reader watches for the sentinel so it can flag the upcoming
+ *  EOF as an intentional reload instead of a crash. */
+function maybeExitForReload(
+  state: AethonAgentState,
+  deps: DispatcherDeps,
+): void {
+  if (!state.reloadPending) return;
+  for (const tab of state.tabs.values()) {
+    if (tab.promptInFlight) return;
+  }
+  deps.send({ type: "_reload_done" });
+  // Flush stdout before exiting so the supervisor sees the sentinel
+  // before the EOF.
+  if (typeof process.stdout.write === "function") {
+    try {
+      process.stdout.write("");
+    } catch {
+      /* ignore */
+    }
+  }
+  process.exit(0);
+}
+
+export async function handleChat(
+  state: AethonAgentState,
+  deps: DispatcherDeps,
+  msg: InboundMessage,
+): Promise<void> {
+  if (!msg.content) {
+    deps.send({ type: "error", message: "chat: missing content" });
+    return;
+  }
+  const tabId = msg.tabId ?? "default";
+  const tab = await ensureTab(state, deps, tabId);
+  const wantsSteer = msg.mode === "steer";
+  if (wantsSteer && tab.promptInFlight) {
+    state.currentAgentTabId = tabId;
+    const content = msg.content;
+    state.tabContext
+      .run(tabId, () => tab.session.steer(content))
+      .catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : String(err);
+        deps.send({ type: "error", tabId, message: `steer: ${message}` });
+      });
+    return;
+  }
+  const queued = tab.promptInFlight;
+  if (queued) {
+    tab.queuedCount += 1;
+    const content = msg.content;
+    state.tabContext
+      .run(tabId, () => tab.session.followUp(content))
+      .catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : String(err);
+        deps.send({ type: "error", tabId, message: `followUp: ${message}` });
+      });
+    deps.send({ type: "queued", tabId });
+    return;
+  }
+
+  tab.promptInFlight = true;
+  tab.agentEndFired = false;
+  state.currentAgentTabId = tabId;
+  const content = msg.content;
+  state.tabContext
+    .run(tabId, () => tab.session.prompt(content))
+    .catch((err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err);
+      deps.send({ type: "error", tabId, message: `prompt: ${message}` });
+    })
+    .finally(() => {
+      if (!tab.agentEndFired) {
+        tab.promptInFlight = false;
+        deps.send({ type: "response_end", tabId });
+      }
+      if (state.currentAgentTabId === tabId) {
+        state.currentAgentTabId = undefined;
+      }
+      maybeExitForReload(state, deps);
+    });
+}
+
 /** Run the inbound dispatcher loop. Returns when stdin closes. */
 export async function runDispatcher(
   state: AethonAgentState,
@@ -411,37 +491,6 @@ export async function runDispatcher(
   const rl = createInterface({ input: process.stdin });
   const stateMutationDeps = { send: deps.send };
   const notifDeps = { send: deps.send };
-
-  /** If a reload was requested AND no tab has a prompt in flight, write
-   *  the `_reload_done` sentinel and exit cleanly. The Rust supervisor's
-   *  stdout reader watches for the sentinel so it can flag the upcoming
-   *  EOF as an intentional reload (not a crash) and emit `agent-reloaded`.
-   *  The next chat / agent_command request lazily respawns the bridge with
-   *  the new extension state.
-   *
-   *  Idempotent — safe to call after every prompt completion. */
-  function maybeExitForReload(
-    state: AethonAgentState,
-    deps: DispatcherDeps,
-  ): void {
-    if (!state.reloadPending) return;
-    for (const tab of state.tabs.values()) {
-      if (tab.promptInFlight) return;
-    }
-    deps.send({ type: "_reload_done" });
-    // Flush stdout before exiting so the supervisor sees the sentinel
-    // before the EOF. process.stdout is non-blocking on a pipe, so a
-    // synchronous .write() returning false would otherwise let the EOF
-    // race the sentinel line.
-    if (typeof process.stdout.write === "function") {
-      try {
-        process.stdout.write("");
-      } catch {
-        /* ignore */
-      }
-    }
-    process.exit(0);
-  }
 
   for await (const line of rl) {
     const trimmed = line.trim();
@@ -606,55 +655,6 @@ export async function runDispatcher(
 
   // ---- Per-message handlers -------------------------------------------
 
-  async function handleChat(
-    state: AethonAgentState,
-    deps: DispatcherDeps,
-    msg: InboundMessage,
-  ): Promise<void> {
-    if (!msg.content) {
-      deps.send({ type: "error", message: "chat: missing content" });
-      return;
-    }
-    const tabId = msg.tabId ?? "default";
-    const tab = await ensureTab(state, deps, tabId);
-    const queued = tab.promptInFlight;
-    if (!queued) {
-      tab.promptInFlight = true;
-      tab.agentEndFired = false;
-    } else {
-      tab.queuedCount += 1;
-    }
-    if (!queued) state.currentAgentTabId = tabId;
-    const content = msg.content;
-    state.tabContext
-      .run(tabId, () =>
-        tab.session.prompt(
-          content,
-          queued ? { streamingBehavior: "followUp" } : undefined,
-        ),
-      )
-      .catch((err: unknown) => {
-        const message = err instanceof Error ? err.message : String(err);
-        deps.send({ type: "error", tabId, message: `prompt: ${message}` });
-      })
-      .finally(() => {
-        if (!queued && !tab.agentEndFired) {
-          tab.promptInFlight = false;
-          deps.send({ type: "response_end", tabId });
-        }
-        if (!queued && state.currentAgentTabId === tabId) {
-          state.currentAgentTabId = undefined;
-        }
-        // If a hot-reload was deferred while this prompt was running,
-        // honor it now. Idempotent — does nothing if no reload is
-        // pending or another tab still has a prompt in flight.
-        maybeExitForReload(state, deps);
-      });
-    if (queued) {
-      deps.send({ type: "queued", tabId });
-    }
-  }
-
   async function handleSetModel(
     state: AethonAgentState,
     deps: DispatcherDeps,
@@ -670,8 +670,7 @@ export async function runDispatcher(
       deps.send({
         type: "notice",
         tabId,
-        message:
-          "agent busy — stop the current prompt before switching models",
+        message: "agent busy — stop the current prompt before switching models",
       });
       return;
     }
@@ -938,14 +937,15 @@ export async function runDispatcher(
     }
     const restoreHistory =
       (msg as { restoreHistory?: unknown }).restoreHistory === true;
-    let restoredMessages: Awaited<ReturnType<typeof readSessionTranscript>> = [];
+    let restoredMessages: Awaited<ReturnType<typeof readSessionTranscript>> =
+      [];
     if (restoreHistory) {
       try {
         const expectedCwd =
           cwdOverride ??
           state.tabProjectCwds.get(tabId) ??
           (tabId === "default"
-            ? state.currentProjectCwd ?? process.cwd()
+            ? (state.currentProjectCwd ?? process.cwd())
             : undefined);
         restoredMessages = await readSessionTranscript(
           tabSessionDir(state, tabId),
@@ -990,7 +990,10 @@ export async function runDispatcher(
       return;
     }
     if (typeof cwd !== "string" || cwd.length === 0) {
-      deps.send({ type: "error", message: "set_project: cwd must be string|null" });
+      deps.send({
+        type: "error",
+        message: "set_project: cwd must be string|null",
+      });
       return;
     }
     state.tabProjectCwds.set(tabId, cwd);
@@ -1136,7 +1139,10 @@ export async function runDispatcher(
         state.disabledExtensionMeta.set(
           name,
           failureInfo.projectRoot
-            ? { source: failureInfo.source, projectRoot: failureInfo.projectRoot }
+            ? {
+                source: failureInfo.source,
+                projectRoot: failureInfo.projectRoot,
+              }
             : { source: failureInfo.source },
         );
       }
@@ -1193,9 +1199,7 @@ export async function runDispatcher(
     // is rendered before agent-reloaded clears the in-flight UI state.
     void notify(state, notifDeps, {
       id: `aethon:extension-toggle:${name}`,
-      title: disabled
-        ? `Disabled \`${name}\``
-        : `Enabled \`${name}\``,
+      title: disabled ? `Disabled \`${name}\`` : `Enabled \`${name}\``,
       message: disabled
         ? "Reloading bridge to fully unload…"
         : "Reloading bridge to load…",
@@ -1270,11 +1274,7 @@ export async function runDispatcher(
     const record = payload as Record<string, unknown>;
     const role = record.role;
     const text = record.text;
-    if (
-      role !== "user" &&
-      role !== "agent" &&
-      role !== "system"
-    ) {
+    if (role !== "user" && role !== "agent" && role !== "system") {
       deps.send({
         type: "notice",
         tabId,
@@ -1293,7 +1293,9 @@ export async function runDispatcher(
     try {
       const localCwd =
         state.tabProjectCwds.get(tabId) ??
-        (tabId === "default" ? state.currentProjectCwd ?? process.cwd() : undefined);
+        (tabId === "default"
+          ? (state.currentProjectCwd ?? process.cwd())
+          : undefined);
       await appendLocalChatMessage(tabSessionDir(state, tabId), {
         id:
           typeof record.id === "string" && record.id.length > 0
@@ -1331,7 +1333,11 @@ export async function runDispatcher(
     const piCtx = buildPiHandlerCtx(state, deps, handlerTab, handlerTabId);
     const tabScopedSetState = (path: string, value: unknown) =>
       setState(state, stateMutationDeps, path, value, handlerTabId);
-    const tabScopedCanvas = makeCanvasApi(state, stateMutationDeps, handlerTabId);
+    const tabScopedCanvas = makeCanvasApi(
+      state,
+      stateMutationDeps,
+      handlerTabId,
+    );
 
     for (const { match, handler } of state.a2uiEventHandlers) {
       if (

--- a/agent/main.ts
+++ b/agent/main.ts
@@ -57,7 +57,7 @@ import { logger } from "./logger";
 import { resolveStateLimits } from "./state-limits";
 import { resolveAethonSystemPrompt } from "./system-prompt";
 import { readSessionTranscript } from "./session-history";
-import { readActiveProjectCwd } from "./active-project-cwd";
+import { readActiveProjectCwd, resolveStartupCwd } from "./active-project-cwd";
 import {
   AethonAgentState,
   type ExtensionFailure,
@@ -244,17 +244,24 @@ async function main(): Promise<void> {
   // restores the registries from this snapshot.
   captureProjectExtensionBaseline(state);
 
+  const activeProjectCwd = await readActiveProjectCwd(userDir);
+  const startupCwd = resolveStartupCwd(
+    activeProjectCwd,
+    projectRoot,
+    process.cwd(),
+  );
+
   await loadProjectAethonExtensions(
     state,
     extDeps,
-    process.cwd(),
+    startupCwd,
     extensionApi,
     state.loadedExtensions,
     state.loadedProjectExtensionFiles,
     state.failedProjectExtensionFiles,
     loadHooks,
   );
-  state.currentProjectCwd = process.cwd();
+  state.currentProjectCwd = startupCwd;
 
   // Reload so the appendSystemPromptOverride sees the populated extensions.
   await state.resourceLoader.reload();
@@ -265,10 +272,7 @@ async function main(): Promise<void> {
   // otherwise a `default` session from a previously-active project
   // leaks into whatever the user opens next (sessions/default/ is
   // shared across project buckets).
-  const activeProjectCwd = await readActiveProjectCwd(userDir);
-  if (activeProjectCwd) {
-    state.tabProjectCwds.set("default", activeProjectCwd);
-  }
+  state.tabProjectCwds.set("default", startupCwd);
   const tabDeps = { send };
   await ensureTab(state, tabDeps, "default");
 
@@ -281,13 +285,12 @@ async function main(): Promise<void> {
   // Replay the default tab's persisted pi session history so all tabs use
   // the same session_history IPC path. Scope the read by the SAME cwd
   // `ensureTab` resolved against — when no project is active, both fall
-  // back to `process.cwd()`. Passing `undefined` here would let the
+  // back to the startup cwd. Passing `undefined` here would let the
   // replay surface the latest JSONL from any cwd while `ensureTab` (which
   // filters via `findSessionFileMatchingCwd`) created an empty session,
   // leaving the UI showing a leaked transcript that the agent cannot
   // continue.
-  const defaultTabReplayCwd = activeProjectCwd ?? process.cwd();
-  readSessionTranscript(tabSessionDir(state, "default"), defaultTabReplayCwd)
+  readSessionTranscript(tabSessionDir(state, "default"), startupCwd)
     .then((messages) => {
       if (messages.length > 0) {
         send({ type: "session_history", tabId: "default", messages });

--- a/agent/state.test.ts
+++ b/agent/state.test.ts
@@ -81,6 +81,7 @@ describe("AethonAgentState", () => {
       promptInFlight: false,
       agentEndFired: false,
       queuedCount: 0,
+      toolCardSeq: 0,
     });
     expect(s.extensionComponents.get("foo")).toEqual({ type: "card" });
     expect(s.tabs.get("default")?.id).toBe("default");

--- a/agent/state.ts
+++ b/agent/state.ts
@@ -218,6 +218,7 @@ export interface TabRecord {
     {
       name: string;
       summary: string;
+      uiId: string;
       bashStream?: BashTerminalStreamState;
       /** Epoch ms — when tool_execution_start fired. Used by the M6 P4
        *  `tool-card` component to render a live elapsed-time clock. */
@@ -227,6 +228,7 @@ export interface TabRecord {
   promptInFlight: boolean;
   agentEndFired: boolean;
   queuedCount: number;
+  toolCardSeq: number;
 }
 
 export interface ProjectBaselineSnapshot {

--- a/agent/tab-lifecycle.test.ts
+++ b/agent/tab-lifecycle.test.ts
@@ -35,8 +35,8 @@ const baseOpts: AethonAgentStateOptions = {
   statePayloadHardKb: 512,
 };
 
-function makeFixture() {
-  const state = new AethonAgentState(baseOpts);
+function makeFixture(opts: Partial<AethonAgentStateOptions> = {}) {
+  const state = new AethonAgentState({ ...baseOpts, ...opts });
   const sent: Record<string, unknown>[] = [];
   return {
     state,
@@ -57,6 +57,7 @@ function fakeRec(model = "anthropic/claude-x"): TabRecord {
     promptInFlight: false,
     agentEndFired: false,
     queuedCount: 0,
+    toolCardSeq: 0,
   };
 }
 
@@ -151,7 +152,7 @@ describe("extractToolContent", () => {
 describe("toolCardPayload", () => {
   it("renders a running card with title + description", () => {
     const payload = toolCardPayload({
-      callId: "c1",
+      id: "tool-c1",
       toolName: "bash",
       argsSummary: "echo hi",
       running: true,
@@ -176,7 +177,7 @@ describe("toolCardPayload", () => {
   it("appends a code child for text results, with a 1500 char cap", () => {
     const result = "x".repeat(2000);
     const payload = toolCardPayload({
-      callId: "c1",
+      id: "tool-c1",
       toolName: "read",
       argsSummary: "",
       result,
@@ -193,7 +194,7 @@ describe("toolCardPayload", () => {
 
   it("infers the code language for file-backed tool results", () => {
     const payload = toolCardPayload({
-      callId: "c1",
+      id: "tool-c1",
       toolName: "read",
       argsSummary: "src/App.tsx lines 1-end",
       result: "export function App() { return null; }",
@@ -205,7 +206,7 @@ describe("toolCardPayload", () => {
 
   it("appends image children with data: URLs", () => {
     const payload = toolCardPayload({
-      callId: "c1",
+      id: "tool-c1",
       toolName: "screenshot",
       argsSummary: "",
       result: {
@@ -244,8 +245,8 @@ describe("tabSessionDir", () => {
 });
 
 describe("emitReady", () => {
-  it("includes per-tab cwd so the frontend can keep project buckets isolated", () => {
-    const f = makeFixture();
+  it("includes project root and per-tab cwd so the frontend can keep cwd scoped", () => {
+    const f = makeFixture({ projectRoot: "/repo/aethon" });
     const rec = fakeRec("anthropic/claude-x");
     rec.id = "tab-1";
     f.state.tabs.set("tab-1", rec);
@@ -255,6 +256,7 @@ describe("emitReady", () => {
 
     expect(f.sent[0]).toMatchObject({
       type: "ready",
+      projectRoot: "/repo/aethon",
       tabs: [
         {
           id: "tab-1",
@@ -452,10 +454,36 @@ describe("handleSessionEvent", () => {
     });
     expect(rec.toolArgsCache.has("c1")).toBe(true);
     const a2uiMsg = f.sent.find((m) => m.type === "a2ui");
-    expect(a2uiMsg).toMatchObject({ id: "tool-c1" });
+    expect(a2uiMsg).toMatchObject({ id: "tool-1-c1" });
     expect(f.sent.find((m) => m.type === "terminal_output")).toMatchObject({
       content: "\r\n$ ls\r\n",
     });
+  });
+
+  it("keeps repeated SDK tool call ids as distinct chat cards", () => {
+    const f = makeFixture();
+    const rec = fakeRec();
+    handleSessionEvent(f.state, f.deps, rec, "tab-1", {
+      type: "tool_execution_start",
+      toolCallId: "c1",
+      toolName: "bash",
+      args: { command: "one" },
+    });
+    handleSessionEvent(f.state, f.deps, rec, "tab-1", {
+      type: "tool_execution_end",
+      toolCallId: "c1",
+      toolName: "bash",
+      result: "done",
+    });
+    handleSessionEvent(f.state, f.deps, rec, "tab-1", {
+      type: "tool_execution_start",
+      toolCallId: "c1",
+      toolName: "bash",
+      args: { command: "two" },
+    });
+
+    const ids = f.sent.filter((m) => m.type === "a2ui").map((m) => m.id);
+    expect(ids).toEqual(["tool-1-c1", "tool-1-c1", "tool-2-c1"]);
   });
 
   it("agent_end clears promptInFlight, sets agentEndFired, emits response_end", () => {

--- a/agent/tab-lifecycle.ts
+++ b/agent/tab-lifecycle.ts
@@ -72,11 +72,18 @@ export function summarizeToolArgs(toolName: string, args: unknown): string {
   const a = args as Record<string, unknown>;
   switch (toolName) {
     case "read":
-      return [a.path, a.startLine && `lines ${a.startLine}-${a.endLine ?? "end"}`]
+      return [
+        a.path,
+        a.startLine && `lines ${a.startLine}-${a.endLine ?? "end"}`,
+      ]
         .filter(Boolean)
         .join(" ");
     case "bash":
-      return String(a.command ?? "").split("\n")[0]?.slice(0, 200) ?? "";
+      return (
+        String(a.command ?? "")
+          .split("\n")[0]
+          ?.slice(0, 200) ?? ""
+      );
     case "edit":
     case "write":
       return String(a.path ?? "");
@@ -141,7 +148,8 @@ const EXTENSION_LANGUAGES: Record<string, string> = {
 function languageFromPath(path: string): string | undefined {
   const clean = path.trim().replace(/^["'`]|["'`]$/g, "");
   const base = clean.split(/[\\/]/).pop()?.toLowerCase() ?? "";
-  if (base === "dockerfile" || base.endsWith(".dockerfile")) return "dockerfile";
+  if (base === "dockerfile" || base.endsWith(".dockerfile"))
+    return "dockerfile";
   if (base === "makefile") return "make";
   const ext = /\.([a-z0-9]+)$/.exec(base)?.[1];
   return ext ? EXTENSION_LANGUAGES[ext] : undefined;
@@ -159,7 +167,8 @@ export function inferToolResultLanguage(
 
   const trimmed = text.trimStart();
   if (trimmed.startsWith("{") || trimmed.startsWith("[")) return "json";
-  if (trimmed.startsWith("diff --git ") || trimmed.startsWith("--- ")) return "diff";
+  if (trimmed.startsWith("diff --git ") || trimmed.startsWith("--- "))
+    return "diff";
   return "text";
 }
 
@@ -219,7 +228,7 @@ export function extractToolContent(result: unknown): ExtractedResult {
 
 /** Build the A2UI payload for a tool-call card. */
 export function toolCardPayload(opts: {
-  callId: string;
+  id: string;
   toolName: string;
   argsSummary: string;
   result?: unknown;
@@ -228,21 +237,14 @@ export function toolCardPayload(opts: {
   startedAt?: number;
   endedAt?: number;
 }) {
-  const {
-    callId,
-    toolName,
-    argsSummary,
-    result,
-    isError,
-    startedAt,
-    endedAt,
-  } = opts;
+  const { id, toolName, argsSummary, result, isError, startedAt, endedAt } =
+    opts;
   const children: unknown[] = [];
   if (result !== undefined) {
     const extracted = extractToolContent(result);
     if (extracted.text) {
       children.push({
-        id: `tool-${callId}-result`,
+        id: `${id}-result`,
         type: "code",
         props: {
           content: truncate(extracted.text, 1500),
@@ -256,7 +258,7 @@ export function toolCardPayload(opts: {
     }
     extracted.images.forEach((img, i) => {
       children.push({
-        id: `tool-${callId}-image-${i}`,
+        id: `${id}-image-${i}`,
         type: "image",
         props: {
           src: `data:${img.mimeType};base64,${img.data}`,
@@ -268,7 +270,7 @@ export function toolCardPayload(opts: {
   return {
     components: [
       {
-        id: `tool-${callId}`,
+        id,
         type: "tool-card",
         props: {
           title: toolName,
@@ -332,9 +334,7 @@ export function buildPickerModels(
   let pickerModels: Model<Api>[];
   if (enabled && enabled.length > 0) {
     const patterns = enabled.map(compilePattern);
-    pickerModels = all.filter((m) =>
-      patterns.some((p) => p.test(modelKey(m))),
-    );
+    pickerModels = all.filter((m) => patterns.some((p) => p.test(modelKey(m))));
   } else {
     pickerModels = state.modelRegistry.getAvailable();
   }
@@ -384,6 +384,7 @@ export function emitReady(
   deps.send({
     type: "ready",
     model: defaultModelKey(state),
+    projectRoot: state.projectRoot,
     models: state.cachedModels,
     tabs: [...state.tabs.values()].map((t) => ({
       id: t.id,
@@ -493,7 +494,9 @@ export function collectPiSlashCommands(
     warnedMissingExtensionRunner = true;
     logger
       .scope("slash")
-      .warn("pi extension command discovery is using a private session API; _extensionRunner is unavailable");
+      .warn(
+        "pi extension command discovery is using a private session API; _extensionRunner is unavailable",
+      );
   }
   // TODO: switch extension command discovery to pi's public API once exposed.
   for (const command of runner?.getRegisteredCommands?.() ?? []) {
@@ -624,6 +627,7 @@ export async function ensureTab(
     promptInFlight: false,
     agentEndFired: false,
     queuedCount: 0,
+    toolCardSeq: 0,
   };
   state.tabs.set(tabId, rec);
   refreshPiSlashCommands(state, session);
@@ -668,9 +672,7 @@ function handleSessionEvent(
     case "agent_start": {
       state.currentAgentTabId = tabId;
       state.turnStartTimes.set(tabId, Date.now());
-      const model = rec.session.model
-        ? modelKey(rec.session.model)
-        : "unknown";
+      const model = rec.session.model ? modelKey(rec.session.model) : "unknown";
       turnLog.info(`start model=${model} tabId=${tabId}`);
       if (rec.queuedCount > 0) {
         rec.queuedCount -= 1;
@@ -690,8 +692,9 @@ function handleSessionEvent(
       break;
     }
     case "message_update": {
-      const ame = (event as { assistantMessageEvent?: { type?: string; delta?: string } })
-        .assistantMessageEvent;
+      const ame = (
+        event as { assistantMessageEvent?: { type?: string; delta?: string } }
+      ).assistantMessageEvent;
       const channel =
         ame?.type === "thinking_delta" || ame?.type === "reasoning_delta"
           ? "thinking"
@@ -704,8 +707,8 @@ function handleSessionEvent(
         const delta = ame.delta ?? "";
         if (delta) {
           const ts =
-            ((event as { message?: { timestamp?: number } }).message
-              ?.timestamp) ?? 0;
+            (event as { message?: { timestamp?: number } }).message
+              ?.timestamp ?? 0;
           const messageId = `text-${ts}`;
           deps.send({
             type: "response_delta",
@@ -726,19 +729,21 @@ function handleSessionEvent(
       };
       const summary = summarizeToolArgs(ev.toolName, ev.args);
       const startedAt = Date.now();
+      const uiId = `tool-${++rec.toolCardSeq}-${ev.toolCallId}`;
       rec.toolArgsCache.set(ev.toolCallId, {
         name: ev.toolName,
         summary,
+        uiId,
         startedAt,
       });
       const payload = toolCardPayload({
-        callId: ev.toolCallId,
+        id: uiId,
         toolName: ev.toolName,
         argsSummary: summary,
         running: true,
         startedAt,
       });
-      deps.send({ type: "a2ui", tabId, id: `tool-${ev.toolCallId}`, payload });
+      deps.send({ type: "a2ui", tabId, id: uiId, payload });
       if (ev.toolName === "bash") {
         const cmd = String(
           (ev.args as { command?: unknown } | undefined)?.command ?? "",
@@ -765,6 +770,7 @@ function handleSessionEvent(
           cached = {
             name: ev.toolName,
             summary: summarizeToolArgs(ev.toolName, ev.args),
+            uiId: `tool-${++rec.toolCardSeq}-${ev.toolCallId}`,
           };
           rec.toolArgsCache.set(ev.toolCallId, cached);
         }
@@ -786,8 +792,9 @@ function handleSessionEvent(
         isError?: boolean;
       };
       const cached = rec.toolArgsCache.get(ev.toolCallId);
+      const uiId = cached?.uiId ?? `tool-${++rec.toolCardSeq}-${ev.toolCallId}`;
       const payload = toolCardPayload({
-        callId: ev.toolCallId,
+        id: uiId,
         toolName: ev.toolName,
         argsSummary: cached?.summary ?? "",
         result: ev.result,
@@ -796,7 +803,7 @@ function handleSessionEvent(
           ? { startedAt: cached.startedAt, endedAt: Date.now() }
           : {}),
       });
-      deps.send({ type: "a2ui", tabId, id: `tool-${ev.toolCallId}`, payload });
+      deps.send({ type: "a2ui", tabId, id: uiId, payload });
       if (ev.toolName === "bash") {
         const extracted = extractToolContent(ev.result);
         const streamed = consumeBashTerminalSnapshot(
@@ -818,8 +825,12 @@ function handleSessionEvent(
       const startMs = state.turnStartTimes.get(tabId);
       state.turnStartTimes.delete(tabId);
       const durationMs = startMs !== undefined ? Date.now() - startMs : -1;
-      const modelStr = rec.session.model ? modelKey(rec.session.model) : "unknown";
-      const lastAssistant = [...((messages ?? []) as { role?: string; stopReason?: string }[])]
+      const modelStr = rec.session.model
+        ? modelKey(rec.session.model)
+        : "unknown";
+      const lastAssistant = [
+        ...((messages ?? []) as { role?: string; stopReason?: string }[]),
+      ]
         .reverse()
         .find((m) => m.role === "assistant");
       const reason = lastAssistant?.stopReason ?? "unknown";

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -358,6 +358,7 @@ fn start_agent(state: State<'_, AgentProcess>, app: AppHandle) -> Result<(), Str
 fn send_message(
     message: String,
     tab_id: Option<String>,
+    mode: Option<String>,
     state: State<'_, AgentProcess>,
     app: AppHandle,
 ) -> Result<(), String> {
@@ -371,6 +372,7 @@ fn send_message(
     let payload = serde_json::json!({
         "type": "chat",
         "content": message,
+        "mode": mode.unwrap_or_else(|| "normal".to_string()),
         "tabId": tab_id.unwrap_or_else(|| "default".to_string()),
     });
     writeln!(stdin, "{}", payload).map_err(|e| format!("write failed: {e}"))?;

--- a/src/eventRoutes/chatInput.test.ts
+++ b/src/eventRoutes/chatInput.test.ts
@@ -3,7 +3,7 @@ import { handleChatInput } from "./chatInput";
 import { buildRouteFixture } from "./testFixtures";
 
 describe("handleChatInput", () => {
-  it("submit forwards value to sendChat", async () => {
+  it("submit forwards value to sendChat as a normal message", async () => {
     const { ctx, mocks } = buildRouteFixture();
     const handled = await handleChatInput(
       {
@@ -14,7 +14,21 @@ describe("handleChatInput", () => {
       ctx,
     );
     expect(handled).toBe(true);
-    expect(mocks.sendChat).toHaveBeenCalledWith("hello");
+    expect(mocks.sendChat).toHaveBeenCalledWith("hello", { mode: "normal" });
+  });
+
+  it("submit forwards command-enter steering mode", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    const handled = await handleChatInput(
+      {
+        component: { id: "chat-input" },
+        eventType: "submit",
+        data: { value: "look now", mode: "steer" },
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.sendChat).toHaveBeenCalledWith("look now", { mode: "steer" });
   });
 
   it("change persists draft into the active tab record", async () => {

--- a/src/eventRoutes/chatInput.ts
+++ b/src/eventRoutes/chatInput.ts
@@ -12,7 +12,11 @@ export const handleChatInput: EventRouteHandler = async (
 ) => {
   if (eventType === "submit") {
     const value = (data as { value?: string } | undefined)?.value ?? "";
-    await ctx.sendChat(value);
+    const mode =
+      (data as { mode?: unknown } | undefined)?.mode === "steer"
+        ? "steer"
+        : "normal";
+    await ctx.sendChat(value, { mode });
     return true;
   }
   if (eventType === "change") {

--- a/src/eventRoutes/index.test.ts
+++ b/src/eventRoutes/index.test.ts
@@ -84,7 +84,7 @@ describe("dispatchEvent — precedence contract", () => {
       ctx,
     );
     expect(handled).toBe(true);
-    expect(mocks.sendChat).toHaveBeenCalledWith("hello");
+    expect(mocks.sendChat).toHaveBeenCalledWith("hello", { mode: "normal" });
   });
 
   it("Layer 3 lookup uses both id-key and type-key — type-keyed terminal-panel matches even when id differs across layouts", async () => {
@@ -242,6 +242,6 @@ describe("dispatchEvent — chrome composites route by type, not id", () => {
       ctx,
     );
     expect(handled).toBe(true);
-    expect(mocks.sendChat).toHaveBeenCalledWith("hello");
+    expect(mocks.sendChat).toHaveBeenCalledWith("hello", { mode: "normal" });
   });
 });

--- a/src/eventRoutes/types.ts
+++ b/src/eventRoutes/types.ts
@@ -1,8 +1,4 @@
-import type {
-  Dispatch,
-  MutableRefObject,
-  SetStateAction,
-} from "react";
+import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 import type { EditorMeta, Tab } from "../types/tab";
 import type { ShareMode } from "../utils/shareMode";
 import type {
@@ -67,7 +63,10 @@ export interface EventRouteContext {
   dismissNotification: (id: string) => void;
 
   // ─── Chat / prompt ──────────────────────────────────────────────────
-  sendChat: (text: string) => Promise<void>;
+  sendChat: (
+    text: string,
+    options?: { mode?: "normal" | "steer" },
+  ) => Promise<void>;
   stopPrompt: (explicitTabId?: string) => Promise<void>;
   updateActiveTab: (updater: (tab: Tab) => Tab) => void;
 

--- a/src/hooks/bridgeMessageHandlers/ready.test.ts
+++ b/src/hooks/bridgeMessageHandlers/ready.test.ts
@@ -23,6 +23,7 @@ describe("handleReady", () => {
       {
         type: "ready",
         model: "claude",
+        projectRoot: "/repo/aethon",
         models: [
           { id: "claude", label: "Claude", provider: "anthropic" },
           { id: "gpt", label: "GPT", provider: "openai" },
@@ -91,6 +92,7 @@ describe("handleReady", () => {
     expect(next.status).toBe("ready");
     expect(next.connection).toBe("connected");
     expect(next.model).toBe("claude");
+    expect(next.projectRoot).toBe("/repo/aethon");
     expect(
       (next.sidebar as { models: { id: string; active: boolean }[] }).models,
     ).toEqual([

--- a/src/hooks/bridgeMessageHandlers/ready.ts
+++ b/src/hooks/bridgeMessageHandlers/ready.ts
@@ -23,6 +23,10 @@ import type {
  *  the boot sequence. */
 export const handleReady: BridgeMessageHandler = (data, ctx) => {
   const model = (data.model as string) || "";
+  const projectRoot =
+    typeof data.projectRoot === "string" && data.projectRoot.length > 0
+      ? data.projectRoot
+      : undefined;
   // Cache pi's default model so new tabs created before `ready` fires
   // (or before a session's model initialises) can inherit it immediately
   // instead of showing blank "model ▼".
@@ -304,6 +308,7 @@ export const handleReady: BridgeMessageHandler = (data, ctx) => {
     const activeModel = activeTab?.model || fallbackModel;
     next = {
       ...next,
+      ...(projectRoot ? { projectRoot } : {}),
       model: activeModel,
       status: "ready",
       connection: "connected",

--- a/src/hooks/useChat.test.ts
+++ b/src/hooks/useChat.test.ts
@@ -42,8 +42,7 @@ function buildContext(overrides: Record<string, unknown> = {}): {
     },
   };
   const setState: Dispatch<SetStateAction<Record<string, unknown>>> = (arg) => {
-    stateRef.current =
-      typeof arg === "function" ? arg(stateRef.current) : arg;
+    stateRef.current = typeof arg === "function" ? arg(stateRef.current) : arg;
   };
   const updateTab = (tabId: string, mutator: (tab: Tab) => Tab) => {
     setState((prev) => {
@@ -87,6 +86,36 @@ function buildContext(overrides: Record<string, unknown> = {}): {
 }
 
 describe("useChat setModel", () => {
+  it("sends normal chat messages with normal mode", async () => {
+    const { ctx } = buildContext();
+    const { result } = renderHook(() => useChat(ctx));
+
+    await act(async () => {
+      await result.current.sendChat("hello");
+    });
+
+    expect(invoke).toHaveBeenCalledWith("send_message", {
+      message: "hello",
+      tabId: "tab-1",
+      mode: "normal",
+    });
+  });
+
+  it("sends command-enter messages with steer mode", async () => {
+    const { ctx } = buildContext();
+    const { result } = renderHook(() => useChat(ctx));
+
+    await act(async () => {
+      await result.current.sendChat("look now", { mode: "steer" });
+    });
+
+    expect(invoke).toHaveBeenCalledWith("send_message", {
+      message: "look now",
+      tabId: "tab-1",
+      mode: "steer",
+    });
+  });
+
   it("optimistically mirrors the selected model into the active tab and picker", async () => {
     const { ctx, stateRef, recordProjectModel } = buildContext();
     const { result } = renderHook(() => useChat(ctx));
@@ -104,14 +133,13 @@ describe("useChat setModel", () => {
     });
     expect(recordProjectModel).toHaveBeenCalledWith("openai/gpt-5.5", "tab-1");
     expect(stateRef.current.model).toBe("openai/gpt-5.5");
-    expect(
-      (stateRef.current.tabs as Tab[])[0].model,
-    ).toBe("openai/gpt-5.5");
+    expect((stateRef.current.tabs as Tab[])[0].model).toBe("openai/gpt-5.5");
     expect(
       (
-        (stateRef.current.sidebar as { models: { id: string; active?: boolean }[] })
-          .models
-      ).find((m) => m.id === "openai/gpt-5.5")?.active,
+        stateRef.current.sidebar as {
+          models: { id: string; active?: boolean }[];
+        }
+      ).models.find((m) => m.id === "openai/gpt-5.5")?.active,
     ).toBe(true);
   });
 
@@ -131,8 +159,8 @@ describe("useChat setModel", () => {
       }),
     });
     expect(stateRef.current.model).toBe("anthropic/claude-opus-4-7");
-    expect(
-      (stateRef.current.tabs as Tab[])[0].model,
-    ).toBe("anthropic/claude-opus-4-7");
+    expect((stateRef.current.tabs as Tab[])[0].model).toBe(
+      "anthropic/claude-opus-4-7",
+    );
   });
 });

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -59,7 +59,10 @@ export interface UseChatActions {
   ) => void;
 
   clearChat: () => void;
-  sendChat: (text: string) => Promise<void>;
+  sendChat: (
+    text: string,
+    options?: { mode?: "normal" | "steer" },
+  ) => Promise<void>;
   setModel: (id: string) => Promise<void>;
   stopPrompt: (explicitTabId?: string) => Promise<void>;
   exportActiveChatMarkdown: () => Promise<void>;
@@ -110,7 +113,10 @@ export function useChat(ctx: UseChatContext): UseChatActions {
   // tabId routes to the right tab record; defaults to the active tab so
   // legacy callers that pre-date the multi-tab refactor stay correct.
   function appendMessage(msg: ChatMessage, tabId?: string) {
-    const id = tabId ?? (stateRef.current.activeTabId as string | undefined) ?? "default";
+    const id =
+      tabId ??
+      (stateRef.current.activeTabId as string | undefined) ??
+      "default";
     updateTab(id, (tab) => {
       const messages = [...tab.messages];
       const idx = messages.findIndex((m) => m.id === msg.id);
@@ -135,7 +141,10 @@ export function useChat(ctx: UseChatContext): UseChatActions {
     tabId?: string,
     channel: "text" | "thinking" = "text",
   ) {
-    const id = tabId ?? (stateRef.current.activeTabId as string | undefined) ?? "default";
+    const id =
+      tabId ??
+      (stateRef.current.activeTabId as string | undefined) ??
+      "default";
     updateTab(id, (tab) => {
       const messages = [...tab.messages];
       if (messageId) {
@@ -189,7 +198,9 @@ export function useChat(ctx: UseChatContext): UseChatActions {
 
   async function stopPrompt(explicitTabId?: string) {
     const tabId =
-      explicitTabId ?? (stateRef.current.activeTabId as string | undefined) ?? "default";
+      explicitTabId ??
+      (stateRef.current.activeTabId as string | undefined) ??
+      "default";
     try {
       await invoke("agent_command", {
         payload: JSON.stringify({ type: "stop", tabId }),
@@ -207,7 +218,10 @@ export function useChat(ctx: UseChatContext): UseChatActions {
     }
   }
 
-  async function sendChat(text: string) {
+  async function sendChat(
+    text: string,
+    options?: { mode?: "normal" | "steer" },
+  ) {
     const trimmed = text.trim();
     if (!trimmed) return;
 
@@ -245,7 +259,9 @@ export function useChat(ctx: UseChatContext): UseChatActions {
     }
 
     const sendText = trimmed.startsWith("//") ? trimmed.slice(1) : trimmed;
-    const tabId = (stateRef.current.activeTabId as string | undefined) ?? "default";
+    const mode = options?.mode === "steer" ? "steer" : "normal";
+    const tabId =
+      (stateRef.current.activeTabId as string | undefined) ?? "default";
     appendMessage(
       { id: crypto.randomUUID(), role: "user", text: sendText },
       tabId,
@@ -263,10 +279,14 @@ export function useChat(ctx: UseChatContext): UseChatActions {
     // own error path below.
     const pending = pendingTabOpens.current.get(tabId);
     if (pending) {
-      try { await pending; } catch { /* ignore */ }
+      try {
+        await pending;
+      } catch {
+        /* ignore */
+      }
     }
     try {
-      await invoke("send_message", { message: sendText, tabId });
+      await invoke("send_message", { message: sendText, tabId, mode });
     } catch (err) {
       appendMessage(
         {
@@ -277,12 +297,14 @@ export function useChat(ctx: UseChatContext): UseChatActions {
         tabId,
       );
       updateTab(tabId, (tab) => ({ ...tab, waiting: false }));
-      if (stateRef.current.activeTabId === tabId) setStatusFlags({ status: "error" });
+      if (stateRef.current.activeTabId === tabId)
+        setStatusFlags({ status: "error" });
     }
   }
 
   async function setModel(id: string) {
-    const tabId = (stateRef.current.activeTabId as string | undefined) ?? "default";
+    const tabId =
+      (stateRef.current.activeTabId as string | undefined) ?? "default";
     const previousModel = (stateRef.current.model as string | undefined) ?? "";
     const canOptimisticallyMirror = stateRef.current.waiting !== true;
     recordProjectModel(id, tabId);

--- a/src/hooks/useTabs.test.ts
+++ b/src/hooks/useTabs.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { emptyProjectsState } from "../projects";
 import { makeEmptyTab } from "../types/tab";
 import {
+  cwdForNewTab,
   modelForNewProjectTab,
   recentSessionItemFromClosedTab,
 } from "./useTabs";
@@ -101,5 +102,29 @@ describe("modelForNewProjectTab", () => {
       modelForNewProjectTab({ model: "openai/gpt-5.5" }, "p1", "fallback"),
     ).toBe("openai/gpt-5.5");
     expect(modelForNewProjectTab({}, "p1", "fallback")).toBe("fallback");
+  });
+});
+
+describe("cwdForNewTab", () => {
+  it("prefers the active project cwd", () => {
+    const projects = {
+      activeId: "p1",
+      activeWorktreeId: null,
+      worktreesByProject: {},
+      activeHostId: null,
+      projects: [
+        { id: "p1", label: "Aethon", path: "/repo/aethon", lastUsed: 1 },
+      ],
+    };
+
+    expect(cwdForNewTab(projects, { projectRoot: "/fallback" })).toBe(
+      "/repo/aethon",
+    );
+  });
+
+  it("falls back to the dev project root when no project is selected", () => {
+    expect(
+      cwdForNewTab(emptyProjectsState(), { projectRoot: "/repo/aethon" }),
+    ).toBe("/repo/aethon");
   });
 });

--- a/src/hooks/useTabs.ts
+++ b/src/hooks/useTabs.ts
@@ -92,6 +92,18 @@ export function modelForNewProjectTab(
   ).trim();
 }
 
+export function cwdForNewTab(
+  projects: ProjectsState,
+  appState: Record<string, unknown>,
+): string | null {
+  const projectCwd = activeCwd(projects);
+  if (projectCwd) return projectCwd;
+  const projectRoot = appState.projectRoot;
+  return typeof projectRoot === "string" && projectRoot.length > 0
+    ? projectRoot
+    : null;
+}
+
 export function recentSessionItemFromClosedTab(
   tab: Tab,
   projects: ProjectsState,
@@ -422,7 +434,9 @@ export function useTabs(ctx: UseTabsContext): UseTabsActions {
     // model, then pi's ready-reported default.
     const projectId = projectsRef.current.activeId;
     const inheritedCwd =
-      options?.cwd ?? activeCwd(projectsRef.current) ?? undefined;
+      options?.cwd ??
+      cwdForNewTab(projectsRef.current, stateRef.current) ??
+      undefined;
     const inheritedModel = modelForNewProjectTab(
       stateRef.current,
       projectId,
@@ -491,7 +505,9 @@ export function useTabs(ctx: UseTabsContext): UseTabsActions {
   }) {
     const id = crypto.randomUUID();
     const inheritedCwd =
-      options?.cwd ?? activeCwd(projectsRef.current) ?? undefined;
+      options?.cwd ??
+      cwdForNewTab(projectsRef.current, stateRef.current) ??
+      undefined;
     const seedShareMode = defaultShareModeRef.current;
     const resolvedCommand =
       options?.command ?? shellDefaultCommandRef.current ?? undefined;

--- a/src/skills/default-layout/chat.test.tsx
+++ b/src/skills/default-layout/chat.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ChatInput } from "./chat";
+
+afterEach(() => cleanup());
+
+function renderInput(onEvent = vi.fn()) {
+  render(
+    <ChatInput
+      component={{
+        id: "chat-input",
+        type: "chat-input",
+        props: { value: "", placeholder: "Message" },
+      }}
+      state={{}}
+      onEvent={onEvent}
+    />,
+  );
+  return {
+    input: screen.getByPlaceholderText("Message"),
+    onEvent,
+  };
+}
+
+describe("ChatInput", () => {
+  it("submits bare Enter as a normal queued-capable message", () => {
+    const { input, onEvent } = renderInput();
+
+    fireEvent.change(input, { target: { value: "queue this" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(onEvent).toHaveBeenLastCalledWith("submit", {
+      value: "queue this",
+      mode: "normal",
+    });
+  });
+
+  it("submits command-enter as a steering message", () => {
+    const { input, onEvent } = renderInput();
+
+    fireEvent.change(input, { target: { value: "steer this" } });
+    fireEvent.keyDown(input, { key: "Enter", metaKey: true });
+
+    expect(onEvent).toHaveBeenLastCalledWith("submit", {
+      value: "steer this",
+      mode: "steer",
+    });
+  });
+
+  it("submits ctrl-enter as a steering message for non-mac keyboards", () => {
+    const { input, onEvent } = renderInput();
+
+    fireEvent.change(input, { target: { value: "steer with ctrl" } });
+    fireEvent.keyDown(input, { key: "Enter", ctrlKey: true });
+
+    expect(onEvent).toHaveBeenLastCalledWith("submit", {
+      value: "steer with ctrl",
+      mode: "steer",
+    });
+  });
+
+  it("does not submit shift-enter", () => {
+    const { input, onEvent } = renderInput();
+
+    fireEvent.change(input, { target: { value: "new line" } });
+    fireEvent.keyDown(input, { key: "Enter", shiftKey: true });
+
+    expect(onEvent).not.toHaveBeenCalledWith("submit", expect.any(Object));
+  });
+});

--- a/src/skills/default-layout/chat.tsx
+++ b/src/skills/default-layout/chat.tsx
@@ -58,7 +58,15 @@ export function formatToolDuration(ms: number): string {
 }
 
 // Status icons for tool card pill
-function ToolStatusIcon({ running, isError, isLongRunning }: { running: boolean; isError: boolean; isLongRunning: boolean }) {
+function ToolStatusIcon({
+  running,
+  isError,
+  isLongRunning,
+}: {
+  running: boolean;
+  isError: boolean;
+  isLongRunning: boolean;
+}) {
   if (running) {
     const label = isLongRunning ? "Tool long-running" : "Tool running";
     return (
@@ -73,13 +81,21 @@ function ToolStatusIcon({ running, isError, isLongRunning }: { running: boolean;
   }
   if (isError) {
     return (
-      <span role="img" aria-label="Tool failed" className="ae-tool-status-icon ae-tool-status-error">
+      <span
+        role="img"
+        aria-label="Tool failed"
+        className="ae-tool-status-icon ae-tool-status-error"
+      >
         <span aria-hidden="true">✕</span>
       </span>
     );
   }
   return (
-    <span role="img" aria-label="Tool completed" className="ae-tool-status-icon ae-tool-status-done">
+    <span
+      role="img"
+      aria-label="Tool completed"
+      className="ae-tool-status-icon ae-tool-status-done"
+    >
       <span aria-hidden="true">✓</span>
     </span>
   );
@@ -108,10 +124,10 @@ export function ToolCard({
   const startedAt = props.startedAt
     ? resolveNumber(props.startedAt, state)
     : undefined;
-  const endedAt = props.endedAt ? resolveNumber(props.endedAt, state) : undefined;
-  const isError = props.isError
-    ? resolveBoolean(props.isError, state)
-    : false;
+  const endedAt = props.endedAt
+    ? resolveNumber(props.endedAt, state)
+    : undefined;
+  const isError = props.isError ? resolveBoolean(props.isError, state) : false;
   const running = startedAt !== undefined && endedAt === undefined;
 
   // Tick at 4 Hz while running so the clock stays smooth without
@@ -150,20 +166,26 @@ export function ToolCard({
       data-error={isError ? "true" : "false"}
     >
       <summary className="ae-tool-card-summary">
-        <ToolStatusIcon running={running} isError={isError} isLongRunning={isLongRunning} />
+        <ToolStatusIcon
+          running={running}
+          isError={isError}
+          isLongRunning={isLongRunning}
+        />
         <span className="ae-tool-card-name">{baseTitle}</span>
         {description && (
           <span className="ae-tool-card-description">{description}</span>
         )}
-        {timeSuffix && (
-          <span className="ae-tool-card-time">{timeSuffix}</span>
-        )}
+        {timeSuffix && <span className="ae-tool-card-time">{timeSuffix}</span>}
         {isLongRunning && (
-          <span className="ae-tool-card-long-hint">long-running · <kbd>⌘.</kbd> to stop</span>
+          <span className="ae-tool-card-long-hint">
+            long-running · <kbd>⌘.</kbd> to stop
+          </span>
         )}
       </summary>
       <div className="ae-tool-card-body">
-        {hasChildren ? renderChildren?.() : (
+        {hasChildren ? (
+          renderChildren?.()
+        ) : (
           <div className="ae-tool-card-empty">No output</div>
         )}
       </div>
@@ -178,7 +200,11 @@ export function ToolCard({
 
 function TypingIndicator() {
   return (
-    <div role="status" aria-label="Agent is thinking" className="ae-typing-indicator">
+    <div
+      role="status"
+      aria-label="Agent is thinking"
+      className="ae-typing-indicator"
+    >
       <span className="ae-typing-dot" aria-hidden="true" />
       <span className="ae-typing-dot" aria-hidden="true" />
       <span className="ae-typing-dot" aria-hidden="true" />
@@ -233,7 +259,9 @@ function ThinkingBlock({
     <details className="a2ui-thinking-block" open={!complete}>
       <summary>{label}</summary>
       <div className="a2ui-thinking-content a2ui-markdown">
-        <ReactMarkdown components={MARKDOWN_COMPONENTS}>{children}</ReactMarkdown>
+        <ReactMarkdown components={MARKDOWN_COMPONENTS}>
+          {children}
+        </ReactMarkdown>
       </div>
     </details>
   );
@@ -279,11 +307,15 @@ const ChatMessageRow = memo(
   }) {
     const isCanvas = className === "a2ui-canvas-message";
     const roleClass = isCanvas ? "a2ui-canvas-role" : "a2ui-chat-role";
-    const textClass = isCanvas ? "a2ui-canvas-text a2ui-markdown" : "a2ui-chat-text a2ui-markdown";
+    const textClass = isCanvas
+      ? "a2ui-canvas-text a2ui-markdown"
+      : "a2ui-chat-text a2ui-markdown";
     // Suppress role label for consecutive messages from same sender
     const showRole = prevRole !== message.role;
     return (
-      <div className={`${className} ${message.role}${showRole ? "" : " ae-msg-cont"}`}>
+      <div
+        className={`${className} ${message.role}${showRole ? "" : " ae-msg-cont"}`}
+      >
         {showRole && message.role !== "system" && (
           <span className={roleClass}>{roleBadge(message.role)}</span>
         )}
@@ -311,14 +343,19 @@ const ChatMessageRow = memo(
     (!next.message.a2ui || prev.state === next.state),
 );
 
-export function ChatHistory({ component, state, tabId }: BuiltinComponentProps) {
+export function ChatHistory({
+  component,
+  state,
+  tabId,
+}: BuiltinComponentProps) {
   const props = component.props as {
     messages: { $ref: string };
     emptyHint?: StringValue;
   };
 
   const listRef = useRef<HTMLDivElement>(null);
-  const { isAtBottom, scrollToBottom, handleContentChanged } = useStickyScroll(listRef);
+  const { isAtBottom, scrollToBottom, handleContentChanged } =
+    useStickyScroll(listRef);
 
   const messages = useMemo(
     () => (resolvePointer(state, props.messages.$ref) as ChatMessage[]) || [],
@@ -344,7 +381,8 @@ export function ChatHistory({ component, state, tabId }: BuiltinComponentProps) 
   const prevScrollToMatch = useRef<string | undefined>(undefined);
   useEffect(() => {
     const el = listRef.current;
-    if (!el || !scrollToMatch || scrollToMatch === prevScrollToMatch.current) return;
+    if (!el || !scrollToMatch || scrollToMatch === prevScrollToMatch.current)
+      return;
     prevScrollToMatch.current = scrollToMatch;
     const needle = scrollToMatch.toLowerCase();
     const idx = messages.findIndex((m) =>
@@ -427,7 +465,10 @@ export function ChatHistory({ component, state, tabId }: BuiltinComponentProps) 
           ))}
         </>
       )}
-      <ScrollToBottomPill visible={!isAtBottom && messages.length > 0} onClick={scrollToBottom} />
+      <ScrollToBottomPill
+        visible={!isAtBottom && messages.length > 0}
+        onClick={scrollToBottom}
+      />
     </div>
   );
 }
@@ -468,7 +509,7 @@ export function MainCanvas({ component, state, tabId }: BuiltinComponentProps) {
 
   const live = props.slot ? resolvePointer(state, props.slot) : null;
   const liveSubtree =
-    live && typeof live === "object" && "components" in (live)
+    live && typeof live === "object" && "components" in live
       ? (live as { components: A2UIComponent[] })
       : null;
 
@@ -477,7 +518,8 @@ export function MainCanvas({ component, state, tabId }: BuiltinComponentProps) {
     : "The agent's canvas is empty. Send a message to populate it.";
 
   const listRef = useRef<HTMLDivElement>(null);
-  const { isAtBottom, scrollToBottom, handleContentChanged } = useStickyScroll(listRef);
+  const { isAtBottom, scrollToBottom, handleContentChanged } =
+    useStickyScroll(listRef);
 
   const prevLength = useRef(messages.length);
   const prevLive = useRef(liveSubtree);
@@ -498,9 +540,7 @@ export function MainCanvas({ component, state, tabId }: BuiltinComponentProps) {
 
   return (
     <main
-      className={
-        chatMode ? "a2ui-canvas" : "a2ui-canvas a2ui-canvas-bare"
-      }
+      className={chatMode ? "a2ui-canvas" : "a2ui-canvas a2ui-canvas-bare"}
       ref={listRef}
     >
       {chatMode && messages.length === 0 && !liveSubtree && (
@@ -511,7 +551,9 @@ export function MainCanvas({ component, state, tabId }: BuiltinComponentProps) {
           type="button"
           className="a2ui-chat-load-older"
           onClick={() =>
-            setVisibleCount((n) => Math.min(messages.length, n + MESSAGE_PAGE_SIZE))
+            setVisibleCount((n) =>
+              Math.min(messages.length, n + MESSAGE_PAGE_SIZE),
+            )
           }
         >
           Load older messages ({hiddenCount})
@@ -532,9 +574,10 @@ export function MainCanvas({ component, state, tabId }: BuiltinComponentProps) {
           <A2UIRenderer payload={liveSubtree} state={state} tabId={tabId} />
         </div>
       )}
-      {chatMode && state.waiting === true && !liveSubtree && messages.length > 0 && (
-        <TypingIndicator />
-      )}
+      {chatMode &&
+        state.waiting === true &&
+        !liveSubtree &&
+        messages.length > 0 && <TypingIndicator />}
       {chatMode && (
         <ScrollToBottomPill
           visible={!isAtBottom && (messages.length > 0 || !!liveSubtree)}
@@ -599,7 +642,11 @@ function normalizeArgChoices(raw: unknown): SlashArgChoice[] {
   return out;
 }
 
-export function ChatInput({ component, state, onEvent }: BuiltinComponentProps) {
+export function ChatInput({
+  component,
+  state,
+  onEvent,
+}: BuiltinComponentProps) {
   const props = component.props as {
     value?: StringValue;
     placeholder?: StringValue;
@@ -701,9 +748,15 @@ export function ChatInput({ component, state, onEvent }: BuiltinComponentProps) 
     ? resolveString(props.placeholder, state)
     : "";
   const busy = props.disabled ? resolveBoolean(props.disabled, state) : false;
-  const queueCount = props.queueCount ? resolveNumber(props.queueCount, state) : 0;
-  const sendLabel = props.sendLabel ? resolveString(props.sendLabel, state) : "Send";
-  const stopLabel = props.stopLabel ? resolveString(props.stopLabel, state) : "Stop";
+  const queueCount = props.queueCount
+    ? resolveNumber(props.queueCount, state)
+    : 0;
+  const sendLabel = props.sendLabel
+    ? resolveString(props.sendLabel, state)
+    : "Send";
+  const stopLabel = props.stopLabel
+    ? resolveString(props.stopLabel, state)
+    : "Stop";
   const stopTitle = props.stopTitle
     ? resolveString(props.stopTitle, state)
     : "Stop the current prompt";
@@ -747,7 +800,11 @@ export function ChatInput({ component, state, onEvent }: BuiltinComponentProps) 
   // Both use the same picker UI; each match shape is normalized to a
   // common interface so the renderer below doesn't branch.
   type CommandMatch = { kind: "command"; cmd: SlashCommandHint };
-  type ArgMatch = { kind: "arg"; cmd: SlashCommandHint; choice: SlashArgChoice };
+  type ArgMatch = {
+    kind: "arg";
+    cmd: SlashCommandHint;
+    choice: SlashArgChoice;
+  };
   type PickerMatch = CommandMatch | ArgMatch;
 
   const slashMatch = useMemo((): {
@@ -816,7 +873,9 @@ export function ChatInput({ component, state, onEvent }: BuiltinComponentProps) 
   const COMPOSER_MIN_HEIGHT = 46;
   const COMPOSER_MAX_HEIGHT = 360;
   const [composerHeight, setComposerHeight] = useState<number>(70);
-  const composerResizeRef = useRef<{ startY: number; startH: number } | null>(null);
+  const composerResizeRef = useRef<{ startY: number; startH: number } | null>(
+    null,
+  );
 
   const startComposerResize = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
@@ -864,7 +923,10 @@ export function ChatInput({ component, state, onEvent }: BuiltinComponentProps) 
       const scale = readUiScale();
       const viewportWidth = window.innerWidth / scale;
       const viewportHeight = window.innerHeight / scale;
-      const left = Math.max(8, Math.min(r.left / scale + 16, viewportWidth - 128));
+      const left = Math.max(
+        8,
+        Math.min(r.left / scale + 16, viewportWidth - 128),
+      );
       const availableWidth = Math.max(0, viewportWidth - left - 8);
       const preferredWidth = Math.max(160, r.width / scale - 32);
       setMenuAnchor({
@@ -887,7 +949,9 @@ export function ChatInput({ component, state, onEvent }: BuiltinComponentProps) 
   // to `/<name> <value>` ready to submit.
   const insertMatch = (m: PickerMatch) => {
     const text =
-      m.kind === "command" ? `/${m.cmd.name} ` : `/${m.cmd.name} ${m.choice.value}`;
+      m.kind === "command"
+        ? `/${m.cmd.name} `
+        : `/${m.cmd.name} ${m.choice.value}`;
     setLocalValue(text);
     commitDraft(text);
   };
@@ -899,6 +963,19 @@ export function ChatInput({ component, state, onEvent }: BuiltinComponentProps) 
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    const submit = (mode: "normal" | "steer") => {
+      const v = (e.target as HTMLTextAreaElement).value;
+      if (v.trim().length === 0) return;
+      commitDraft(v);
+      onEvent("submit", { value: v, mode });
+    };
+
+    if (e.key === "Enter" && !e.shiftKey && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      submit("steer");
+      return;
+    }
+
     if (slashMatch) {
       const list = slashMatch.matches;
       if (e.key === "ArrowDown") {
@@ -939,14 +1016,14 @@ export function ChatInput({ component, state, onEvent }: BuiltinComponentProps) 
           const submitText = `/${choice.cmd.name} ${choice.choice.value}`;
           setLocalValue(submitText);
           commitDraft(submitText);
-          onEvent("submit", { value: submitText });
+          onEvent("submit", { value: submitText, mode: "normal" });
           return;
         }
         const exact = (list as CommandMatch[]).find(
           (c) => v === `/${c.cmd.name}` || v.startsWith(`/${c.cmd.name} `),
         );
         if (exact && v.trim().length > 0) {
-          onEvent("submit", { value: v });
+          onEvent("submit", { value: v, mode: "normal" });
           return;
         }
         insertMatch(list[highlightIdx] ?? list[0]);
@@ -955,21 +1032,18 @@ export function ChatInput({ component, state, onEvent }: BuiltinComponentProps) 
     }
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
-      const v = (e.target as HTMLTextAreaElement).value;
-      if (v.trim().length > 0) {
-        // Always submit — the bridge uses pi's followUp queue when an
-        // earlier prompt is still in flight, so the user can keep
-        // typing without "agent busy" rejections.
-        commitDraft(v);
-        onEvent("submit", { value: v });
-      }
+      // Always submit — the bridge uses pi's followUp queue when an
+      // earlier prompt is still in flight, so the user can keep typing
+      // without "agent busy" rejections. Cmd/Ctrl+Enter above opts into
+      // mid-turn steering instead.
+      submit("normal");
     }
   };
 
   const handleClick = () => {
     if (value.trim().length > 0) {
       commitDraft(value);
-      onEvent("submit", { value });
+      onEvent("submit", { value, mode: "normal" });
     }
   };
 
@@ -981,7 +1055,9 @@ export function ChatInput({ component, state, onEvent }: BuiltinComponentProps) 
     <div
       className="a2ui-chat-input"
       ref={inputContainerRef}
-      style={{ "--composer-height": `${composerHeight}px` } as React.CSSProperties}
+      style={
+        { "--composer-height": `${composerHeight}px` } as React.CSSProperties
+      }
     >
       {/* Resize handle — drag UP to grow, DOWN to shrink. Sits on the
           top edge so the cursor naturally targets it when the user
@@ -994,7 +1070,8 @@ export function ChatInput({ component, state, onEvent }: BuiltinComponentProps) 
         title="Drag to resize composer"
         onMouseDown={startComposerResize}
       />
-      {slashMatch && menuAnchor &&
+      {slashMatch &&
+        menuAnchor &&
         createPortal(
           <div
             className="a2ui-slash-menu"
@@ -1008,7 +1085,9 @@ export function ChatInput({ component, state, onEvent }: BuiltinComponentProps) 
           >
             {slashMatch.mode === "arg" && slashMatch.cmd && (
               <div className="a2ui-slash-arg-header">
-                <span className="a2ui-slash-arg-cmd">/{slashMatch.cmd.name}</span>
+                <span className="a2ui-slash-arg-cmd">
+                  /{slashMatch.cmd.name}
+                </span>
                 <span className="a2ui-slash-arg-hint">
                   {slashMatch.cmd.description ?? "select an option"}
                 </span>
@@ -1016,7 +1095,9 @@ export function ChatInput({ component, state, onEvent }: BuiltinComponentProps) 
             )}
             {slashMatch.matches.map((m, i) => {
               const key =
-                m.kind === "command" ? m.cmd.name : `${m.cmd.name}::${m.choice.value}`;
+                m.kind === "command"
+                  ? m.cmd.name
+                  : `${m.cmd.name}::${m.choice.value}`;
               return (
                 <div
                   key={key}
@@ -1035,7 +1116,7 @@ export function ChatInput({ component, state, onEvent }: BuiltinComponentProps) 
                       const submitText = `/${m.cmd.name} ${m.choice.value}`;
                       setLocalValue(submitText);
                       commitDraft(submitText);
-                      onEvent("submit", { value: submitText });
+                      onEvent("submit", { value: submitText, mode: "normal" });
                     } else {
                       insertMatch(m);
                     }
@@ -1044,22 +1125,38 @@ export function ChatInput({ component, state, onEvent }: BuiltinComponentProps) 
                 >
                   {m.kind === "command" ? (
                     <>
-                      <span className="a2ui-slash-item-name">/{m.cmd.name}</span>
+                      <span className="a2ui-slash-item-name">
+                        /{m.cmd.name}
+                      </span>
                       {m.cmd.usage && (
-                        <span className="a2ui-slash-item-usage"> {m.cmd.usage}</span>
+                        <span className="a2ui-slash-item-usage">
+                          {" "}
+                          {m.cmd.usage}
+                        </span>
                       )}
                       {m.cmd.description && (
-                        <span className="a2ui-slash-item-desc"> — {m.cmd.description}</span>
+                        <span className="a2ui-slash-item-desc">
+                          {" "}
+                          — {m.cmd.description}
+                        </span>
                       )}
                     </>
                   ) : (
                     <>
-                      <span className="a2ui-slash-item-name">{m.choice.value}</span>
+                      <span className="a2ui-slash-item-name">
+                        {m.choice.value}
+                      </span>
                       {m.choice.label && m.choice.label !== m.choice.value && (
-                        <span className="a2ui-slash-item-desc"> — {m.choice.label}</span>
+                        <span className="a2ui-slash-item-desc">
+                          {" "}
+                          — {m.choice.label}
+                        </span>
                       )}
                       {m.choice.description && (
-                        <span className="a2ui-slash-item-desc"> — {m.choice.description}</span>
+                        <span className="a2ui-slash-item-desc">
+                          {" "}
+                          — {m.choice.description}
+                        </span>
                       )}
                     </>
                   )}
@@ -1107,7 +1204,14 @@ export function ChatInput({ component, state, onEvent }: BuiltinComponentProps) 
               viewBox="0 0 16 16"
               aria-hidden="true"
             >
-              <rect x="3" y="3" width="10" height="10" rx="1.5" fill="currentColor" />
+              <rect
+                x="3"
+                y="3"
+                width="10"
+                height="10"
+                rx="1.5"
+                fill="currentColor"
+              />
             </svg>
             <span className="a2ui-chat-input-send-label">{stopLabel}</span>
           </button>


### PR DESCRIPTION
## Summary

- route Cmd/Ctrl+Enter through mid-turn steering while plain Enter remains a queued follow-up
- keep tool-call cards visible across agent turns by giving repeated SDK tool ids stable per-tab UI ids
- scope default agent and shell cwd to the active project or dev Aethon project root instead of / or ~
- add regression coverage for steering, queueing, cwd fallback, tool-card persistence, and parallel tab prompting

## Validation

- bunx tsc --noEmit
- bunx vitest run
- cargo check --manifest-path src-tauri/Cargo.toml
- git diff --check
