### PR TITLE
[codex] harden steering and queued message UX

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,24 @@ jobs:
       - name: Vitest
         run: bunx vitest run
 
+  e2e:
+    name: e2e (playwright)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.x
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Version files are synced
+        run: bun run version:check
+      - name: Install Playwright Chromium
+        run: bunx playwright install --with-deps chromium
+      - name: Playwright
+        run: bun run test:e2e
+
   rust:
     name: rust (clippy + cargo test)
     strategy:

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,8 @@ result-*
 *.profdata
 lcov.info
 coverage/
+playwright-report/
+test-results/
 
 # Phase test harness and ad-hoc screenshots (local-only).
 # Ignore all .png + .zip globally, then re-include the bundled Tauri

--- a/agent/dispatcher.test.ts
+++ b/agent/dispatcher.test.ts
@@ -104,6 +104,42 @@ describe("handleChat", () => {
     expect(f.sent).toContainEqual({ type: "queued", tabId: "tab-1" });
   });
 
+  it("rolls back the queue count when followUp rejects", async () => {
+    const f = makeFixture();
+    const tab = fakeTabRecord({
+      promptInFlight: true,
+      queuedCount: 2,
+      session: {
+        prompt: () => Promise.resolve(),
+        followUp: () => Promise.reject(new Error("queue offline")),
+        steer: () => Promise.resolve(),
+      } as unknown as TabRecord["session"],
+    });
+    f.state.tabs.set("tab-1", tab);
+
+    await handleChat(f.state, f.deps, {
+      type: "chat",
+      content: "after this",
+      tabId: "tab-1",
+      mode: "normal",
+    });
+
+    expect(f.sent).toContainEqual({ type: "queued", tabId: "tab-1" });
+    await vi.waitFor(() => {
+      expect(tab.queuedCount).toBe(2);
+      expect(f.sent).toContainEqual({
+        type: "queue_reset",
+        tabId: "tab-1",
+        queued: 2,
+      });
+      expect(f.sent).toContainEqual({
+        type: "error",
+        tabId: "tab-1",
+        message: "followUp: queue offline",
+      });
+    });
+  });
+
   it("steers command-enter messages into the active prompt", async () => {
     const f = makeFixture();
     const promptCalls: unknown[][] = [];

--- a/agent/dispatcher.ts
+++ b/agent/dispatcher.ts
@@ -452,7 +452,13 @@ export async function handleChat(
     state.tabContext
       .run(tabId, () => tab.session.followUp(content))
       .catch((err: unknown) => {
+        tab.queuedCount = Math.max(0, tab.queuedCount - 1);
         const message = err instanceof Error ? err.message : String(err);
+        deps.send({
+          type: "queue_reset",
+          tabId,
+          queued: tab.queuedCount,
+        });
         deps.send({ type: "error", tabId, message: `followUp: ${message}` });
       });
     deps.send({ type: "queued", tabId });

--- a/bun.lock
+++ b/bun.lock
@@ -28,6 +28,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@playwright/test": "^1.60.0",
         "@tauri-apps/cli": "^2.11.0",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.3.2",
@@ -270,6 +271,8 @@
     "@nodable/entities": ["@nodable/entities@2.1.0", "", {}, "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.127.0", "", {}, "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ=="],
+
+    "@playwright/test": ["@playwright/test@1.60.0", "", { "dependencies": { "playwright": "1.60.0" }, "bin": { "playwright": "cli.js" } }, "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag=="],
 
     "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
 
@@ -1041,6 +1044,10 @@
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
+    "playwright": ["playwright@1.60.0", "", { "dependencies": { "playwright-core": "1.60.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA=="],
+
+    "playwright-core": ["playwright-core@1.60.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA=="],
+
     "postcss": ["postcss@8.5.10", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
@@ -1312,6 +1319,8 @@
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "parse5-htmlparser2-tree-adapter/parse5": ["parse5@6.0.1", "", {}, "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "proxy-agent/lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
 

--- a/e2e/aethon.spec.ts
+++ b/e2e/aethon.spec.ts
@@ -175,6 +175,36 @@ test("steers Command-Enter into the running turn without queuing it", async ({
   );
 });
 
+test("retries failed user sends from the transcript", async ({ page }) => {
+  await waitForAethonReady(page);
+
+  await page.getByRole("button", { name: "New Tab" }).click();
+  await page.evaluate(() => window.__AETHON_E2E__?.failNextSendMessage());
+  await page.locator(".a2ui-chat-input-field").fill("retry me");
+  await page.keyboard.press("Enter");
+
+  await expect(page.locator(".a2ui-chat-delivery-failed")).toHaveText("failed");
+  await expect(page.getByRole("button", { name: "Retry" })).toBeVisible();
+
+  await page.getByRole("button", { name: "Retry" }).click();
+
+  await expect(page.locator(".a2ui-chat-delivery-failed")).toHaveCount(0);
+  await expect
+    .poll(() => getActiveTurnState(page))
+    .toEqual({ waiting: true, queueCount: 0, status: "thinking…" });
+
+  await completeActiveTurn(page);
+  await expect
+    .poll(() => getActiveTurnState(page))
+    .toEqual({ waiting: false, queueCount: 0, status: "ready" });
+
+  const sends = (await getInvokeCalls(page)).filter((c) => c.cmd === "send_message");
+  expect(sends.map((c) => c.args)).toEqual([
+    expect.objectContaining({ message: "retry me", mode: "normal" }),
+    expect.objectContaining({ message: "retry me", mode: "normal" }),
+  ]);
+});
+
 test("steering during an existing follow-up queue preserves the queued turn", async ({
   page,
 }) => {

--- a/e2e/aethon.spec.ts
+++ b/e2e/aethon.spec.ts
@@ -96,6 +96,7 @@ test("queues normal Enter messages behind an in-flight turn and drains cleanly",
   await expect(page.locator(".a2ui-chat-input-queue")).toHaveText("+1");
   await expect(page.locator(".a2ui-tab")).toContainText("+1");
   await expect(page.locator(".a2ui-chat-delivery-queued")).toHaveText("queued");
+  await expect(page.getByRole("button", { name: "Stop + clear" })).toBeVisible();
   await expect
     .poll(() => getActiveTurnState(page))
     .toEqual({ waiting: true, queueCount: 1, status: "thinking…" });

--- a/e2e/aethon.spec.ts
+++ b/e2e/aethon.spec.ts
@@ -87,12 +87,15 @@ test("queues normal Enter messages behind an in-flight turn and drains cleanly",
     .poll(() => getActiveTurnState(page))
     .toEqual({ waiting: true, queueCount: 0, status: "thinking…" });
   await expect(page.getByRole("button", { name: "Stop" })).toBeVisible();
+  await expect(page.getByText("Enter queues")).toBeVisible();
+  await expect(page.getByText("Cmd/Ctrl+Enter steers")).toBeVisible();
 
   await page.locator(".a2ui-chat-input-field").fill("queued prompt");
   await page.keyboard.press("Enter");
 
   await expect(page.locator(".a2ui-chat-input-queue")).toHaveText("+1");
   await expect(page.locator(".a2ui-tab")).toContainText("+1");
+  await expect(page.locator(".a2ui-chat-delivery-queued")).toHaveText("queued");
   await expect
     .poll(() => getActiveTurnState(page))
     .toEqual({ waiting: true, queueCount: 1, status: "thinking…" });
@@ -110,6 +113,7 @@ test("queues normal Enter messages behind an in-flight turn and drains cleanly",
     .toEqual({ waiting: false, queueCount: 0, status: "ready" });
   await expect(page.locator(".a2ui-chat-input-queue")).toHaveCount(0);
   await expect(page.getByRole("button", { name: "Send" })).toBeVisible();
+  await expect(page.getByText("Enter queues")).toHaveCount(0);
 
   const calls = await getInvokeCalls(page);
   const sends = calls.filter((c) => c.cmd === "send_message");
@@ -140,6 +144,7 @@ test("steers Command-Enter into the running turn without queuing it", async ({
 
   await expect(page.locator(".a2ui-chat-input-queue")).toHaveCount(0);
   await expect(page.locator(".a2ui-tab")).not.toContainText("+1");
+  await expect(page.locator(".a2ui-chat-delivery-steered")).toHaveText("steered");
   await expect
     .poll(() => getActiveTurnState(page))
     .toEqual({ waiting: true, queueCount: 0, status: "thinking…" });
@@ -189,6 +194,8 @@ test("steering during an existing follow-up queue preserves the queued turn", as
   );
 
   await expect(page.locator(".a2ui-chat-input-queue")).toHaveText("+1");
+  await expect(page.locator(".a2ui-chat-delivery-queued")).toHaveText("queued");
+  await expect(page.locator(".a2ui-chat-delivery-steered")).toHaveText("steered");
   await expect
     .poll(() => getActiveTurnState(page))
     .toEqual({ waiting: true, queueCount: 1, status: "thinking…" });

--- a/e2e/aethon.spec.ts
+++ b/e2e/aethon.spec.ts
@@ -101,6 +101,25 @@ test("queues normal Enter messages behind an in-flight turn and drains cleanly",
     .poll(() => getActiveTurnState(page))
     .toEqual({ waiting: true, queueCount: 1, status: "thinking…" });
 
+  await page.locator(".a2ui-chat-input-field").fill("second queued prompt");
+  await page.keyboard.press("Enter");
+
+  await expect(page.locator(".a2ui-chat-input-queue")).toHaveText("+2");
+  await expect(page.locator(".a2ui-chat-delivery-queued")).toHaveText([
+    "queued #1",
+    "queued #2",
+  ]);
+  await expect
+    .poll(() => getActiveTurnState(page))
+    .toEqual({ waiting: true, queueCount: 2, status: "thinking…" });
+
+  await completeActiveTurn(page);
+  await expect(page.locator(".a2ui-chat-input-queue")).toHaveText("+1");
+  await expect(page.locator(".a2ui-chat-delivery-queued")).toHaveText("queued");
+  await expect
+    .poll(() => getActiveTurnState(page))
+    .toEqual({ waiting: true, queueCount: 1, status: "thinking…" });
+
   await completeActiveTurn(page);
   await expect(page.locator(".a2ui-chat-input-queue")).toHaveCount(0);
   await expect(page.locator(".a2ui-chat-delivery-queued")).toHaveCount(0);
@@ -123,6 +142,10 @@ test("queues normal Enter messages behind an in-flight turn and drains cleanly",
     expect.arrayContaining([
       expect.objectContaining({ message: "first prompt", mode: "normal" }),
       expect.objectContaining({ message: "queued prompt", mode: "normal" }),
+      expect.objectContaining({
+        message: "second queued prompt",
+        mode: "normal",
+      }),
     ]),
   );
 });

--- a/e2e/aethon.spec.ts
+++ b/e2e/aethon.spec.ts
@@ -102,6 +102,7 @@ test("queues normal Enter messages behind an in-flight turn and drains cleanly",
 
   await completeActiveTurn(page);
   await expect(page.locator(".a2ui-chat-input-queue")).toHaveCount(0);
+  await expect(page.locator(".a2ui-chat-delivery-queued")).toHaveCount(0);
   await expect
     .poll(() => getActiveTurnState(page))
     .toEqual({ waiting: true, queueCount: 0, status: "thinking…" });
@@ -201,6 +202,8 @@ test("steering during an existing follow-up queue preserves the queued turn", as
     .toEqual({ waiting: true, queueCount: 1, status: "thinking…" });
 
   await completeActiveTurn(page);
+  await expect(page.locator(".a2ui-chat-delivery-queued")).toHaveCount(0);
+  await expect(page.locator(".a2ui-chat-delivery-steered")).toHaveText("steered");
   await expect
     .poll(() => getActiveTurnState(page))
     .toEqual({ waiting: true, queueCount: 0, status: "thinking…" });

--- a/e2e/aethon.spec.ts
+++ b/e2e/aethon.spec.ts
@@ -21,6 +21,16 @@ type ActiveTurnState = {
   status?: string;
 };
 
+function isTransientNavigationError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    message.includes("Execution context was destroyed") ||
+    message.includes("Cannot find context with specified id") ||
+    message.includes("Target closed") ||
+    message.includes("Page closed")
+  );
+}
+
 function parseAgentCommandPayload(payload: unknown): AgentCommandPayload {
   if (typeof payload !== "string") return {};
   const parsed: unknown = JSON.parse(payload);
@@ -34,14 +44,21 @@ function parseAgentCommandPayload(payload: unknown): AgentCommandPayload {
 }
 
 async function getActiveTurnState(page: Page): Promise<ActiveTurnState> {
-  return page.evaluate(() => {
-    const state = window.__AETHON_STATE__?.();
-    return {
-      waiting: state?.waiting,
-      queueCount: state?.queueCount,
-      status: state?.status,
-    };
-  });
+  try {
+    return await page.evaluate(() => {
+      const state = window.__AETHON_STATE__?.();
+      return {
+        waiting: state?.waiting,
+        queueCount: state?.queueCount,
+        status: state?.status,
+      };
+    });
+  } catch (error) {
+    if (isTransientNavigationError(error)) {
+      return {};
+    }
+    throw error;
+  }
 }
 
 async function completeActiveTurn(page: Page): Promise<void> {

--- a/e2e/aethon.spec.ts
+++ b/e2e/aethon.spec.ts
@@ -1,0 +1,279 @@
+import { expect, test } from "@playwright/test";
+import type { Page } from "@playwright/test";
+import {
+  ALT_MODEL,
+  DEFAULT_MODEL,
+  PROJECT_ROOT,
+  getInvokeCalls,
+  installAethonHarness,
+  waitForAethonReady,
+} from "./support/aethon-harness";
+
+type AgentCommandPayload = {
+  type?: string;
+  cwd?: string;
+  model?: string;
+};
+
+type ActiveTurnState = {
+  waiting?: boolean;
+  queueCount?: number;
+  status?: string;
+};
+
+function parseAgentCommandPayload(payload: unknown): AgentCommandPayload {
+  if (typeof payload !== "string") return {};
+  const parsed: unknown = JSON.parse(payload);
+  if (!parsed || typeof parsed !== "object") return {};
+  const record = parsed as Record<string, unknown>;
+  return {
+    type: typeof record.type === "string" ? record.type : undefined,
+    cwd: typeof record.cwd === "string" ? record.cwd : undefined,
+    model: typeof record.model === "string" ? record.model : undefined,
+  };
+}
+
+async function getActiveTurnState(page: Page): Promise<ActiveTurnState> {
+  return page.evaluate(() => {
+    const state = window.__AETHON_STATE__?.();
+    return {
+      waiting: state?.waiting,
+      queueCount: state?.queueCount,
+      status: state?.status,
+    };
+  });
+}
+
+async function completeActiveTurn(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    window.__AETHON_E2E__?.completeActiveTurn();
+  });
+}
+
+test.beforeEach(async ({ page }) => {
+  await installAethonHarness(page);
+});
+
+test("boots the real app shell through mocked Tauri IPC", async ({ page }) => {
+  await waitForAethonReady(page);
+
+  await expect(page.locator(".a2ui-tab")).toHaveCount(0);
+  await expect(page.getByRole("heading", { name: "aethon" })).toBeVisible();
+  await expect(page.locator(".ae-file-tree")).toContainText("package.json");
+
+  const calls = await getInvokeCalls(page);
+  expect(calls.map((c) => c.cmd)).toEqual(
+    expect.arrayContaining([
+      "agent_command",
+      "read_config",
+      "read_state",
+      "host_info",
+      "fs_list_dir",
+      "fs_watch_dirs",
+    ]),
+  );
+});
+
+test("queues normal Enter messages behind an in-flight turn and drains cleanly", async ({
+  page,
+}) => {
+  await waitForAethonReady(page);
+
+  await page.getByRole("button", { name: "New Tab" }).click();
+  await page.locator(".a2ui-chat-input-field").fill("first prompt");
+  await page.keyboard.press("Enter");
+
+  await expect
+    .poll(() => getActiveTurnState(page))
+    .toEqual({ waiting: true, queueCount: 0, status: "thinking…" });
+  await expect(page.getByRole("button", { name: "Stop" })).toBeVisible();
+
+  await page.locator(".a2ui-chat-input-field").fill("queued prompt");
+  await page.keyboard.press("Enter");
+
+  await expect(page.locator(".a2ui-chat-input-queue")).toHaveText("+1");
+  await expect(page.locator(".a2ui-tab")).toContainText("+1");
+  await expect
+    .poll(() => getActiveTurnState(page))
+    .toEqual({ waiting: true, queueCount: 1, status: "thinking…" });
+
+  await completeActiveTurn(page);
+  await expect(page.locator(".a2ui-chat-input-queue")).toHaveCount(0);
+  await expect
+    .poll(() => getActiveTurnState(page))
+    .toEqual({ waiting: true, queueCount: 0, status: "thinking…" });
+  await expect(page.getByRole("button", { name: "Stop" })).toBeVisible();
+
+  await completeActiveTurn(page);
+  await expect
+    .poll(() => getActiveTurnState(page))
+    .toEqual({ waiting: false, queueCount: 0, status: "ready" });
+  await expect(page.locator(".a2ui-chat-input-queue")).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Send" })).toBeVisible();
+
+  const calls = await getInvokeCalls(page);
+  const sends = calls.filter((c) => c.cmd === "send_message");
+  expect(sends.map((c) => c.args)).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ message: "first prompt", mode: "normal" }),
+      expect.objectContaining({ message: "queued prompt", mode: "normal" }),
+    ]),
+  );
+});
+
+test("steers Command-Enter into the running turn without queuing it", async ({
+  page,
+}) => {
+  await waitForAethonReady(page);
+
+  await page.getByRole("button", { name: "New Tab" }).click();
+  await page.locator(".a2ui-chat-input-field").fill("first prompt");
+  await page.keyboard.press("Enter");
+  await expect
+    .poll(() => getActiveTurnState(page))
+    .toEqual({ waiting: true, queueCount: 0, status: "thinking…" });
+
+  await page.locator(".a2ui-chat-input-field").fill("steer now");
+  await page.keyboard.press(
+    process.platform === "darwin" ? "Meta+Enter" : "Control+Enter",
+  );
+
+  await expect(page.locator(".a2ui-chat-input-queue")).toHaveCount(0);
+  await expect(page.locator(".a2ui-tab")).not.toContainText("+1");
+  await expect
+    .poll(() => getActiveTurnState(page))
+    .toEqual({ waiting: true, queueCount: 0, status: "thinking…" });
+
+  await completeActiveTurn(page);
+  await expect
+    .poll(() => getActiveTurnState(page))
+    .toEqual({ waiting: false, queueCount: 0, status: "ready" });
+  await expect(page.locator(".a2ui-chat-input-queue")).toHaveCount(0);
+
+  const calls = await getInvokeCalls(page);
+  const tabOpen = calls
+    .filter((c) => c.cmd === "agent_command")
+    .map((c) => parseAgentCommandPayload(c.args.payload))
+    .find((p) => p.type === "tab_open");
+  expect(tabOpen).toMatchObject({
+    cwd: PROJECT_ROOT,
+    model: DEFAULT_MODEL,
+  });
+
+  const sends = calls.filter((c) => c.cmd === "send_message");
+  expect(sends.map((c) => c.args)).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ message: "first prompt", mode: "normal" }),
+      expect.objectContaining({ message: "steer now", mode: "steer" }),
+    ]),
+  );
+});
+
+test("steering during an existing follow-up queue preserves the queued turn", async ({
+  page,
+}) => {
+  await waitForAethonReady(page);
+
+  await page.getByRole("button", { name: "New Tab" }).click();
+  await page.locator(".a2ui-chat-input-field").fill("first prompt");
+  await page.keyboard.press("Enter");
+  await page.locator(".a2ui-chat-input-field").fill("queued prompt");
+  await page.keyboard.press("Enter");
+  await expect
+    .poll(() => getActiveTurnState(page))
+    .toEqual({ waiting: true, queueCount: 1, status: "thinking…" });
+
+  await page.locator(".a2ui-chat-input-field").fill("steer current turn");
+  await page.keyboard.press(
+    process.platform === "darwin" ? "Meta+Enter" : "Control+Enter",
+  );
+
+  await expect(page.locator(".a2ui-chat-input-queue")).toHaveText("+1");
+  await expect
+    .poll(() => getActiveTurnState(page))
+    .toEqual({ waiting: true, queueCount: 1, status: "thinking…" });
+
+  await completeActiveTurn(page);
+  await expect
+    .poll(() => getActiveTurnState(page))
+    .toEqual({ waiting: true, queueCount: 0, status: "thinking…" });
+
+  await completeActiveTurn(page);
+  await expect
+    .poll(() => getActiveTurnState(page))
+    .toEqual({ waiting: false, queueCount: 0, status: "ready" });
+
+  const sends = (await getInvokeCalls(page)).filter((c) => c.cmd === "send_message");
+  expect(sends.map((c) => c.args)).toEqual([
+    expect.objectContaining({ message: "first prompt", mode: "normal" }),
+    expect.objectContaining({ message: "queued prompt", mode: "normal" }),
+    expect.objectContaining({ message: "steer current turn", mode: "steer" }),
+  ]);
+});
+
+test("runs native slash commands without leaving the UI stuck busy", async ({
+  page,
+}) => {
+  await waitForAethonReady(page);
+
+  await page.getByRole("button", { name: "New Tab" }).click();
+  await page.locator(".a2ui-chat-input-field").fill("/context");
+  await page.keyboard.press("Enter");
+
+  await expect(page.getByText("Window: 272,000 tokens")).toBeVisible();
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const state = window.__AETHON_STATE__?.();
+        return { waiting: state?.waiting, status: state?.status };
+      }),
+    )
+    .toEqual({ waiting: false, status: "ready" });
+});
+
+test("switches models through the real picker path and keeps active state aligned", async ({
+  page,
+}) => {
+  await waitForAethonReady(page);
+
+  await page.getByRole("button", { name: "New Tab" }).click();
+  await page.locator(".a2ui-dropdown-trigger").filter({ hasText: "GPT-5.5" }).click();
+  await page.getByRole("option", { name: /qwen3\.6:35b-a3b-coding-nvfp4/ }).click();
+
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const state = window.__AETHON_STATE__?.();
+        return {
+          model: state?.model,
+          active: state?.sidebar?.models?.find((m: { id: string }) => m.id === state?.model)
+            ?.active,
+        };
+      }),
+    )
+    .toEqual({ model: ALT_MODEL, active: true });
+});
+
+test("refreshes visible file-tree folders after fs-tree-changed events", async ({
+  page,
+}) => {
+  await waitForAethonReady(page);
+
+  await page.evaluate(({ root }) => {
+    window.__AETHON_E2E__?.setDir(root, root, [
+      { name: "agent", path: `${root}/agent`, kind: "dir", size: 0, modified: 1 },
+      { name: "src", path: `${root}/src`, kind: "dir", size: 0, modified: 1 },
+      { name: "package.json", path: `${root}/package.json`, kind: "file", size: 42, modified: 1 },
+      {
+        name: "z-e2e-created.txt",
+        path: `${root}/z-e2e-created.txt`,
+        kind: "file",
+        size: 42,
+        modified: 1,
+      },
+    ]);
+    window.__AETHON_E2E__?.emit("fs-tree-changed", { root, dirs: [root] });
+  }, { root: PROJECT_ROOT });
+
+  await expect(page.locator(".ae-file-tree")).toContainText("z-e2e-created.txt");
+});

--- a/e2e/support/aethon-harness.ts
+++ b/e2e/support/aethon-harness.ts
@@ -57,6 +57,7 @@ declare global {
       emit: (event: string, payload: unknown) => void;
       emitAgent: (message: Record<string, unknown>) => void;
       completeActiveTurn: () => void;
+      failNextSendMessage: () => void;
       setDir: (root: string, path: string, entries: FsEntry[]) => void;
       getCalls: () => InvokeCall[];
       clearCalls: () => void;
@@ -86,6 +87,7 @@ export async function installAethonHarness(page: Page): Promise<void> {
       let nextListenerId = 1;
       let model = defaultModel;
       const promptStateByTab = new Map<string, { inFlight: boolean; queued: number }>();
+      let failNextSend = false;
 
       const key = (root: string, path: string) => `${root}\u0000${path}`;
       const stringArg = (value: unknown, fallback = ""): string =>
@@ -363,6 +365,10 @@ export async function installAethonHarness(page: Page): Promise<void> {
             return undefined;
           }
           case "send_message": {
+            if (failNextSend) {
+              failNextSend = false;
+              throw new Error("e2e send failure");
+            }
             const tabId = stringArg(args.tabId, "default");
             const mode = stringArg(args.mode, "normal");
             const turn = promptState(tabId);
@@ -419,6 +425,9 @@ export async function installAethonHarness(page: Page): Promise<void> {
         emit,
         emitAgent,
         completeActiveTurn,
+        failNextSendMessage: () => {
+          failNextSend = true;
+        },
         setDir,
         getCalls: () => calls.slice(),
         clearCalls: () => {

--- a/e2e/support/aethon-harness.ts
+++ b/e2e/support/aethon-harness.ts
@@ -1,0 +1,443 @@
+import type { Page } from "@playwright/test";
+
+export const PROJECT_ROOT = "/repo/aethon";
+export const AETHON_ROOT = "/home/test/.aethon";
+export const DEFAULT_MODEL = "openai-codex/gpt-5.5";
+export const ALT_MODEL = "ollama-localhost/qwen3.6:35b-a3b-coding-nvfp4";
+
+type InvokeCall = {
+  cmd: string;
+  args: Record<string, unknown>;
+};
+
+type FsEntry = {
+  name: string;
+  path: string;
+  kind: "file" | "dir";
+  size: number;
+  modified: number;
+};
+
+type AethonE2eState = {
+  activeTabId?: string;
+  connection?: string;
+  status?: string;
+  waiting?: boolean;
+  queueCount?: number;
+  model?: string;
+  sidebar?: {
+    models?: { id: string; active?: boolean }[];
+  };
+};
+
+type TauriCallback = (event: unknown) => void;
+
+type TauriInternals = {
+  metadata: {
+    currentWindow: { label: string };
+    currentWebview: { label: string };
+  };
+  invoke: (cmd: string, args?: unknown) => Promise<unknown>;
+  transformCallback: (callback: TauriCallback) => number;
+  unregisterCallback: (id: number) => void;
+  runCallback: (id: number, data: unknown) => void;
+  callbacks: Map<number, TauriCallback>;
+  convertFileSrc: (filePath: string) => string;
+};
+
+declare global {
+  interface Window {
+    __AETHON_STATE__?: () => AethonE2eState;
+    __TAURI_INTERNALS__?: TauriInternals;
+    __TAURI_EVENT_PLUGIN_INTERNALS__?: {
+      unregisterListener: (_event: string, id: number) => void;
+    };
+    __AETHON_E2E__?: {
+      calls: InvokeCall[];
+      emit: (event: string, payload: unknown) => void;
+      emitAgent: (message: Record<string, unknown>) => void;
+      completeActiveTurn: () => void;
+      setDir: (root: string, path: string, entries: FsEntry[]) => void;
+      getCalls: () => InvokeCall[];
+      clearCalls: () => void;
+    };
+  }
+}
+
+export async function installAethonHarness(page: Page): Promise<void> {
+  await page.addInitScript(
+    ({ projectRoot, aethonRoot, defaultModel, altModel }) => {
+      type Callback = (event: unknown) => void;
+      type Listener = { event: string; callbackId: number };
+      type Entry = {
+        name: string;
+        path: string;
+        kind: "file" | "dir";
+        size: number;
+        modified: number;
+      };
+
+      const calls: { cmd: string; args: Record<string, unknown> }[] = [];
+      const callbacks = new Map<number, Callback>();
+      const listeners = new Map<number, Listener>();
+      const files = new Map<string, Entry[]>();
+      const stateFiles = new Map<string, string>();
+      let nextCallbackId = 1;
+      let nextListenerId = 1;
+      let model = defaultModel;
+      const promptStateByTab = new Map<string, { inFlight: boolean; queued: number }>();
+
+      const key = (root: string, path: string) => `${root}\u0000${path}`;
+      const stringArg = (value: unknown, fallback = ""): string =>
+        typeof value === "string" ? value : fallback;
+      const entry = (
+        name: string,
+        path: string,
+        kind: "file" | "dir",
+      ): Entry => ({ name, path, kind, size: kind === "file" ? 42 : 0, modified: 1 });
+
+      files.set(key(projectRoot, projectRoot), [
+        entry("agent", `${projectRoot}/agent`, "dir"),
+        entry("src", `${projectRoot}/src`, "dir"),
+        entry("src-tauri", `${projectRoot}/src-tauri`, "dir"),
+        entry("package.json", `${projectRoot}/package.json`, "file"),
+        entry("README.md", `${projectRoot}/README.md`, "file"),
+      ]);
+      files.set(key(projectRoot, `${projectRoot}/src`), [
+        entry("App.tsx", `${projectRoot}/src/App.tsx`, "file"),
+        entry("main.tsx", `${projectRoot}/src/main.tsx`, "file"),
+      ]);
+      files.set(key(aethonRoot, aethonRoot), [
+        entry("extensions", `${aethonRoot}/extensions`, "dir"),
+        entry("sessions", `${aethonRoot}/sessions`, "dir"),
+        entry("config.toml", `${aethonRoot}/config.toml`, "file"),
+      ]);
+
+      stateFiles.set(
+        "projects.json",
+        JSON.stringify({
+          schemaVersion: 3,
+          activeId: "project-aethon",
+          activeWorktreeId: null,
+          activeHostId: "local:test",
+          projects: [
+            {
+              id: "project-aethon",
+              label: "aethon",
+              path: projectRoot,
+              lastUsed: 1,
+              uiExpanded: true,
+              hostId: "local:test",
+            },
+          ],
+          worktreesByProject: {
+            "project-aethon": [
+              {
+                id: "wt-main",
+                projectId: "project-aethon",
+                label: "main",
+                branch: "main",
+                path: projectRoot,
+                isMain: true,
+              },
+            ],
+          },
+        }),
+      );
+
+      const ready = () => ({
+        type: "ready",
+        model,
+        projectRoot,
+        userDir: aethonRoot,
+        models: [
+          { id: defaultModel, label: "GPT-5.5" },
+          { id: altModel, label: "qwen3.6:35b-a3b-coding-nvfp4" },
+        ],
+        tabs: [],
+        discoveredTabs: [],
+        extensionsList: [],
+        failedExtensionsList: [],
+        disabledExtensionsList: [],
+        extensionComponents: {},
+        extensionState: {},
+        extensionStateKeys: [],
+        extensionLayoutPatches: [],
+        extensionThemes: [],
+        extensionSlashCommands: [],
+        extensionKeybindings: [],
+        extensionEventRoutes: [],
+        extensionLayouts: [],
+        extensionFrontendModules: [],
+        piSlashCommands: [],
+      });
+
+      const emit = (event: string, payload: unknown) => {
+        for (const [id, listener] of listeners) {
+          if (listener.event !== event) continue;
+          callbacks.get(listener.callbackId)?.({ id, event, payload });
+        }
+      };
+      const emitAgent = (message: Record<string, unknown>) => {
+        emit("agent-response", JSON.stringify(message));
+      };
+
+      const setDir = (root: string, path: string, entries: Entry[]) => {
+        files.set(key(root, path), entries);
+      };
+      const promptState = (tabId: string) => {
+        const existing = promptStateByTab.get(tabId);
+        if (existing) return existing;
+        const next = { inFlight: false, queued: 0 };
+        promptStateByTab.set(tabId, next);
+        return next;
+      };
+      const completeActiveTurn = () => {
+        const state = window.__AETHON_STATE__?.();
+        const tabId = state?.activeTabId ?? "default";
+        const turn = promptState(tabId);
+        if (!turn.inFlight) return;
+        emitAgent({ type: "response_end", tabId });
+        if (turn.queued > 0) {
+          turn.queued -= 1;
+          queueMicrotask(() =>
+            emitAgent({
+              type: "prompt_started",
+              tabId,
+              source: "queue",
+              queued: turn.queued,
+            }),
+          );
+          return;
+        }
+        turn.inFlight = false;
+      };
+
+      const invoke = (async (cmd: string, rawArgs?: unknown) => {
+        await Promise.resolve();
+        const args =
+          rawArgs && typeof rawArgs === "object"
+            ? (rawArgs as Record<string, unknown>)
+            : {};
+        calls.push({ cmd, args });
+
+        if (cmd === "plugin:event|listen") {
+          const id = nextListenerId++;
+          listeners.set(id, {
+            event: String(args.event),
+            callbackId: Number(args.handler),
+          });
+          return id;
+        }
+        if (cmd === "plugin:event|unlisten") {
+          listeners.delete(Number(args.eventId));
+          return undefined;
+        }
+        if (cmd === "plugin:event|emit") {
+          emit(String(args.event), args.payload);
+          return undefined;
+        }
+
+        switch (cmd) {
+          case "read_config":
+            return {
+              ui: {
+                theme: "ember",
+                fontSize: null,
+                restoreTabs: false,
+                notifyOnCompletion: false,
+                notifyMinDurationSeconds: 8,
+              },
+              agent: { model: defaultModel },
+              shell: {
+                defaultShareMode: "private",
+                autoRestartAgent: true,
+                defaultCommand: null,
+                defaultArgs: [],
+                inheritEnv: true,
+                promptBeforeClose: true,
+              },
+              shortcuts: { newTabKind: "agent" },
+            };
+          case "read_state":
+            return stateFiles.get(stringArg(args.name)) ?? "";
+          case "write_state":
+            stateFiles.set(stringArg(args.name), stringArg(args.content));
+            return undefined;
+          case "host_info":
+            return {
+              id: "local:test",
+              hostname: "halcyon",
+              displayName: "halcyon",
+              fingerprint: "test",
+            };
+          case "aethon_home_dir":
+            return aethonRoot;
+          case "git_status":
+            return { branch: "main", dirty: false, ahead: 0, behind: 0 };
+          case "git_worktrees":
+            return [
+              {
+                id: "wt-main",
+                label: "main",
+                branch: "main",
+                path: projectRoot,
+                active: true,
+                isMain: true,
+              },
+            ];
+          case "gh_repo_overview":
+            return {
+              ghAvailable: true,
+              repo: "utensils/aethon",
+              description: "Aethon e2e harness repository",
+              url: "https://github.com/example/aethon",
+              defaultBranch: "main",
+              stargazerCount: 0,
+              forkCount: 0,
+              openIssuesCount: 0,
+              openPrsCount: 0,
+              pushedAt: "2026-05-24T00:00:00Z",
+            };
+          case "gh_issue_list":
+            return [];
+          case "gh_branch_status":
+            return {
+              branch: "main",
+              defaultBranch: "main",
+              upstream: "origin/main",
+              ahead: 0,
+              behind: 0,
+              pullRequest: null,
+            };
+          case "fs_list_dir": {
+            const root = stringArg(args.root);
+            const path = stringArg(args.path);
+            return files.get(key(root, path)) ?? [];
+          }
+          case "fs_watch_dirs":
+          case "fs_unwatch_root":
+          case "watch_project_extensions":
+          case "unwatch_project_extensions":
+          case "set_extension_menu_items":
+          case "start_agent":
+            return undefined;
+          case "agent_command": {
+            const parsed: unknown = JSON.parse(stringArg(args.payload, "{}"));
+            const payload =
+              parsed && typeof parsed === "object"
+                ? (parsed as {
+                    type?: string;
+                    tabId?: string;
+                    id?: string;
+                    name?: string;
+                    args?: string;
+                  })
+                : {};
+            if (payload.type === "report") {
+              queueMicrotask(() => emitAgent(ready()));
+            }
+            if (payload.type === "set_model" && payload.id) {
+              model = payload.id;
+              queueMicrotask(() =>
+                emitAgent({
+                  type: "model_changed",
+                  tabId: payload.tabId ?? "default",
+                  model,
+                }),
+              );
+            }
+            if (payload.type === "native_slash_command") {
+              queueMicrotask(() =>
+                emitAgent({
+                  type: "native_slash_result",
+                  tabId: payload.tabId ?? "default",
+                  command: payload.name,
+                  message:
+                    payload.name === "context"
+                      ? `## Context\n- Model: ${model}\n- Window: 272,000 tokens`
+                      : `${payload.name ?? "command"} ok`,
+                }),
+              );
+            }
+            return undefined;
+          }
+          case "send_message": {
+            const tabId = stringArg(args.tabId, "default");
+            const mode = stringArg(args.mode, "normal");
+            const turn = promptState(tabId);
+            if (mode === "steer" && turn.inFlight) {
+              return undefined;
+            }
+            if (mode === "normal" && turn.inFlight) {
+              turn.queued += 1;
+              queueMicrotask(() => emitAgent({ type: "queued", tabId }));
+              return undefined;
+            }
+            turn.inFlight = true;
+            queueMicrotask(() =>
+              emitAgent({ type: "prompt_started", tabId, queued: 0 }),
+            );
+            return undefined;
+          }
+          case "updater_available":
+            return false;
+          default:
+            return undefined;
+        }
+      }) satisfies TauriInternals["invoke"];
+
+      window.__TAURI_INTERNALS__ = {
+        metadata: {
+          currentWindow: { label: "main" },
+          currentWebview: { label: "main" },
+        },
+        invoke,
+        transformCallback(callback: Callback) {
+          const id = nextCallbackId++;
+          callbacks.set(id, callback);
+          return id;
+        },
+        unregisterCallback(id: number) {
+          callbacks.delete(id);
+        },
+        runCallback(id: number, data: unknown) {
+          callbacks.get(id)?.(data);
+        },
+        callbacks,
+        convertFileSrc(filePath: string) {
+          return `asset://localhost/${encodeURIComponent(filePath)}`;
+        },
+      };
+      window.__TAURI_EVENT_PLUGIN_INTERNALS__ = {
+        unregisterListener(_event: string, id: number) {
+          listeners.delete(id);
+        },
+      };
+      window.__AETHON_E2E__ = {
+        calls,
+        emit,
+        emitAgent,
+        completeActiveTurn,
+        setDir,
+        getCalls: () => calls.slice(),
+        clearCalls: () => {
+          calls.length = 0;
+        },
+      };
+    },
+    { projectRoot: PROJECT_ROOT, aethonRoot: AETHON_ROOT, defaultModel: DEFAULT_MODEL, altModel: ALT_MODEL },
+  );
+}
+
+export async function waitForAethonReady(page: Page): Promise<void> {
+  await page.goto("/");
+  await page.waitForFunction(() => {
+    const state = window.__AETHON_STATE__?.();
+    return state?.connection === "connected" && state?.status === "ready";
+  });
+}
+
+export async function getInvokeCalls(page: Page): Promise<InvokeCall[]> {
+  return page.evaluate(() => window.__AETHON_E2E__?.getCalls() ?? []);
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview",
     "tauri": "tauri",
     "test": "vitest run",
+    "test:e2e": "playwright test",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "lint": "eslint .",
@@ -40,6 +41,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@playwright/test": "^1.60.0",
     "@tauri-apps/cli": "^2.11.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const port = Number(process.env.VITE_PORT ?? 1420);
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  reporter: [["list"], ["html", { open: "never" }]],
+  use: {
+    baseURL: `http://127.0.0.1:${port}`,
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  webServer: {
+    command: `VITE_PORT=${port} bun run dev -- --host 127.0.0.1`,
+    url: `http://127.0.0.1:${port}`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,7 +4,10 @@ const port = Number(process.env.VITE_PORT ?? 1420);
 
 export default defineConfig({
   testDir: "./e2e",
-  fullyParallel: true,
+  // The harness mocks one Tauri webview per test while sharing a Vite
+  // dev server. Keep tests in a spec serial so a Vite reload in one page
+  // cannot interrupt another page mid-turn.
+  fullyParallel: false,
   reporter: [["list"], ["html", { open: "never" }]],
   use: {
     baseURL: `http://127.0.0.1:${port}`,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import A2UIRenderer, { RegistryComponent } from "./components/A2UIRenderer";
 import { SkillRegistry } from "./skills/SkillRegistry";
 import { SkillRegistryProvider } from "./skills/registry";
 import { defaultLayoutSkill } from "./skills/default-layout";
-import type { A2UIPayload } from "./types/a2ui";
+import type { A2UIPayload, ChatMessage } from "./types/a2ui";
 import { deriveTabActiveFlags, type Tab } from "./types/tab";
 import { dispatchEvent, type EventRouteContext } from "./eventRoutes";
 import { useZoomAndTheme } from "./hooks/useZoomAndTheme";
@@ -990,10 +990,7 @@ export default function App() {
 
   // Build the dispatch context fresh per invocation so handlers see latest
   // state (model list, skills) without re-creating the command registry.
-  function persistLocalChatMessage(
-    msg: { id: string; role: "user" | "agent" | "system"; text?: string },
-    tabId: string,
-  ) {
+  function persistLocalChatMessage(msg: ChatMessage, tabId: string) {
     if (!msg.text) return;
     invoke("agent_command", {
       payload: JSON.stringify({
@@ -1003,6 +1000,7 @@ export default function App() {
           id: msg.id,
           role: msg.role,
           text: msg.text,
+          ...(msg.delivery ? { delivery: msg.delivery } : {}),
           createdAt: Date.now(),
         },
       }),

--- a/src/eventRoutes/chatMessages.test.ts
+++ b/src/eventRoutes/chatMessages.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { handleChatMessages } from "./chatMessages";
+import { buildRouteFixture } from "./testFixtures";
+import { makeEmptyTab } from "../types/tab";
+
+describe("handleChatMessages", () => {
+  it("removes the failed message and resends it", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    const handled = await handleChatMessages(
+      {
+        component: { id: "chat-history", type: "chat-history" },
+        eventType: "retry",
+        data: { messageId: "failed-1", value: "try again" },
+      },
+      ctx,
+    );
+
+    expect(handled).toBe(true);
+    expect(mocks.updateActiveTab).toHaveBeenCalledTimes(1);
+    const updater = mocks.updateActiveTab.mock.calls[0][0];
+    const tab = {
+      ...makeEmptyTab("default", "Tab 1"),
+      messages: [
+        { id: "failed-1", role: "user" as const, text: "try again" },
+        { id: "ok", role: "agent" as const, text: "still here" },
+      ],
+    };
+    expect(updater(tab).messages).toEqual([
+      { id: "ok", role: "agent", text: "still here" },
+    ]);
+    expect(mocks.sendChat).toHaveBeenCalledWith("try again", {
+      mode: "normal",
+    });
+  });
+
+  it("ignores blank retry text", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    const handled = await handleChatMessages(
+      {
+        component: { id: "chat-history", type: "chat-history" },
+        eventType: "retry",
+        data: { messageId: "failed-1", value: "   " },
+      },
+      ctx,
+    );
+
+    expect(handled).toBe(true);
+    expect(mocks.updateActiveTab).not.toHaveBeenCalled();
+    expect(mocks.sendChat).not.toHaveBeenCalled();
+  });
+});

--- a/src/eventRoutes/chatMessages.ts
+++ b/src/eventRoutes/chatMessages.ts
@@ -1,0 +1,26 @@
+import type { EventRouteHandler } from "./types";
+
+export const handleChatMessages: EventRouteHandler = async (
+  { eventType, data },
+  ctx,
+) => {
+  if (eventType !== "retry") return false;
+  const record = data && typeof data === "object" ? data : {};
+  const value =
+    typeof (record as { value?: unknown }).value === "string"
+      ? (record as { value: string }).value
+      : "";
+  const messageId =
+    typeof (record as { messageId?: unknown }).messageId === "string"
+      ? (record as { messageId: string }).messageId
+      : "";
+  if (!value.trim()) return true;
+  if (messageId) {
+    ctx.updateActiveTab((tab) => ({
+      ...tab,
+      messages: tab.messages.filter((message) => message.id !== messageId),
+    }));
+  }
+  await ctx.sendChat(value, { mode: "normal" });
+  return true;
+};

--- a/src/eventRoutes/index.ts
+++ b/src/eventRoutes/index.ts
@@ -29,6 +29,7 @@ import type {
 import { handleShellConsent } from "./shellConsent";
 import { matchesExtensionRoute } from "./extensions";
 import { handleChatInput } from "./chatInput";
+import { handleChatMessages } from "./chatMessages";
 import { handleSettings } from "./settings";
 import { handleSearch } from "./search";
 import { handlePalette } from "./palette";
@@ -85,6 +86,8 @@ export const BUILTIN_ROUTE_TABLE: ReadonlyMap<string, readonly EventRouteHandler
     ["type:search-panel", [handleSearch]],
     ["type:command-palette", [handlePalette]],
     ["type:chat-input", [handleChatInput]],
+    ["type:chat-history", [handleChatMessages]],
+    ["type:main-canvas", [handleChatMessages]],
     ["type:empty-state", [handleEmptyState]],
     // Worktree landing — "Start Session" + "Open in Files" CTAs reuse
     // the sidebar's worktree routes since the destination semantics

--- a/src/hooks/bridgeMessageHandlers/promptStarted.test.ts
+++ b/src/hooks/bridgeMessageHandlers/promptStarted.test.ts
@@ -27,6 +27,32 @@ describe("handlePromptStarted", () => {
     expect(mocks.setState).toHaveBeenCalledTimes(1);
   });
 
+  it("promotes the oldest queued user message when a queued prompt starts", () => {
+    const { ctx, mocks } = buildHandlerFixture({
+      state: { activeTabId: "default" },
+    });
+    handlePromptStarted(
+      { type: "prompt_started", tabId: "default", source: "queue", queued: 1 },
+      ctx,
+    );
+    const [, updater] = mocks.updateTab.mock.calls[0];
+    const out = updater({
+      ...makeEmptyTab("default", "Tab 1"),
+      messages: [
+        { id: "u1", role: "user", text: "running", delivery: "sent" },
+        { id: "u2", role: "user", text: "start me", delivery: "queued" },
+        { id: "u3", role: "user", text: "after me", delivery: "queued" },
+      ],
+      queueCount: 2,
+    });
+    expect(out.queueCount).toBe(1);
+    expect(out.messages).toEqual([
+      { id: "u1", role: "user", text: "running", delivery: "sent" },
+      { id: "u2", role: "user", text: "start me", delivery: "sent" },
+      { id: "u3", role: "user", text: "after me", delivery: "queued" },
+    ]);
+  });
+
   it("schedules a hang-warn notification after hangWarnMs", () => {
     const tabId = "default";
     const { ctx, mocks } = buildHandlerFixture({

--- a/src/hooks/bridgeMessageHandlers/promptStarted.ts
+++ b/src/hooks/bridgeMessageHandlers/promptStarted.ts
@@ -13,11 +13,29 @@ export const handlePromptStarted: BridgeMessageHandler = (data, ctx) => {
   // Record turn start so response_end can compute duration and decide
   // whether to fire the OS completion notification.
   ctx.turnStartedAtRef.current.set(tabId, Date.now());
-  ctx.updateTab(tabId, (tab) => ({
-    ...tab,
-    waiting: true,
-    ...(remaining !== undefined ? { queueCount: remaining } : {}),
-  }));
+  ctx.updateTab(tabId, (tab) => {
+    const next = {
+      ...tab,
+      waiting: true,
+      ...(remaining !== undefined ? { queueCount: remaining } : {}),
+    };
+    if (data.source !== "queue") return next;
+    let promoted = false;
+    return {
+      ...next,
+      messages: next.messages.map((message) => {
+        if (
+          promoted ||
+          message.role !== "user" ||
+          message.delivery !== "queued"
+        ) {
+          return message;
+        }
+        promoted = true;
+        return { ...message, delivery: "sent" as const };
+      }),
+    };
+  });
   if (ctx.stateRef.current.activeTabId === tabId) {
     ctx.setState((prev) => ({ ...prev, status: "thinking…" }));
   }

--- a/src/hooks/bridgeMessageHandlers/queueReset.test.ts
+++ b/src/hooks/bridgeMessageHandlers/queueReset.test.ts
@@ -11,4 +11,12 @@ describe("handleQueueReset", () => {
     const seed = { ...makeEmptyTab("default", "Tab 1"), queueCount: 7 };
     expect(updater(seed).queueCount).toBe(0);
   });
+
+  it("accepts an explicit remaining queue count", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleQueueReset({ type: "queue_reset", tabId: "default", queued: 2 }, ctx);
+    const [, updater] = mocks.updateTab.mock.calls[0];
+    const seed = { ...makeEmptyTab("default", "Tab 1"), queueCount: 7 };
+    expect(updater(seed).queueCount).toBe(2);
+  });
 });

--- a/src/hooks/bridgeMessageHandlers/queueReset.ts
+++ b/src/hooks/bridgeMessageHandlers/queueReset.ts
@@ -6,5 +6,9 @@ import type { BridgeMessageHandler } from "./types";
  *  "queue > 0 keeps Stop" gate. */
 export const handleQueueReset: BridgeMessageHandler = (data, ctx) => {
   const tabId = (data.tabId as string | undefined) ?? "default";
-  ctx.updateTab(tabId, (tab) => ({ ...tab, queueCount: 0 }));
+  const queued =
+    typeof data.queued === "number" && Number.isFinite(data.queued)
+      ? Math.max(0, Math.floor(data.queued))
+      : 0;
+  ctx.updateTab(tabId, (tab) => ({ ...tab, queueCount: queued }));
 };

--- a/src/hooks/bridgeMessageHandlers/ready.test.ts
+++ b/src/hooks/bridgeMessageHandlers/ready.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { handleReady } from "./ready";
 import { buildHandlerFixture } from "./testFixtures";
 import { clearTauriMocks, installTauriMocks } from "../../test/tauriMocks";
+import { makeEmptyTab } from "../../types/tab";
 
 describe("handleReady", () => {
   beforeEach(() => {
@@ -101,6 +102,34 @@ describe("handleReady", () => {
       { id: "claude", label: "Claude", active: true },
       { id: "gpt", label: "GPT", active: false },
     ]);
+  });
+
+  it("does not overwrite an active running turn with ready status", () => {
+    const { ctx, applySetState } = buildHandlerFixture();
+    handleReady(
+      {
+        type: "ready",
+        model: "claude",
+        models: [{ id: "claude", label: "Claude" }],
+      },
+      ctx,
+    );
+    const next = applySetState({
+      activeTabId: "tab-1",
+      waiting: true,
+      queueCount: 2,
+      tabs: [
+        {
+          ...makeEmptyTab("tab-1", "Tab 1"),
+          model: "claude",
+          waiting: true,
+          queueCount: 2,
+        },
+      ],
+      sidebar: {},
+    });
+    expect(next.status).toBe("thinking…");
+    expect(next.connection).toBe("connected");
   });
 
   it("keeps the configured default model ahead of the bridge fallback", () => {

--- a/src/hooks/bridgeMessageHandlers/ready.ts
+++ b/src/hooks/bridgeMessageHandlers/ready.ts
@@ -310,12 +310,17 @@ export const handleReady: BridgeMessageHandler = (data, ctx) => {
     const tabsList = (next.tabs as Tab[] | undefined) ?? [];
     const activeTab = tabsList.find((t) => t.id === activeId);
     const activeModel = activeTab?.model || fallbackModel;
+    const activeTurnBusy =
+      activeTab?.waiting === true ||
+      (activeTab?.queueCount ?? 0) > 0 ||
+      next.waiting === true ||
+      ((next.queueCount as number | undefined) ?? 0) > 0;
     next = {
       ...next,
       ...(projectRoot ? { projectRoot } : {}),
       ...(userDir ? { aethonRoot: userDir } : {}),
       model: activeModel,
-      status: "ready",
+      status: activeTurnBusy ? "thinking…" : "ready",
       connection: "connected",
       recentSessions,
       sidebar: {

--- a/src/hooks/useChat.test.ts
+++ b/src/hooks/useChat.test.ts
@@ -126,6 +126,32 @@ describe("useChat setModel", () => {
     });
   });
 
+  it("marks the local user message failed when send_message rejects", async () => {
+    invoke.mockRejectedValueOnce(new Error("bridge closed"));
+    const { ctx, stateRef } = buildContext();
+    const { result } = renderHook(() => useChat(ctx));
+
+    await act(async () => {
+      await result.current.sendChat("lost in transit");
+    });
+
+    const messages = (stateRef.current.tabs as Tab[])[0].messages;
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: "user",
+          text: "lost in transit",
+          delivery: "failed",
+        }),
+        expect.objectContaining({
+          role: "agent",
+          text: expect.stringContaining("Connection error:"),
+        }),
+      ]),
+    );
+    expect((stateRef.current.tabs as Tab[])[0].waiting).toBe(false);
+  });
+
   it("sends command-enter messages with steer mode", async () => {
     const { ctx, stateRef } = buildContext({ waiting: true });
     const { result } = renderHook(() => useChat(ctx));

--- a/src/hooks/useChat.test.ts
+++ b/src/hooks/useChat.test.ts
@@ -87,7 +87,7 @@ function buildContext(overrides: Record<string, unknown> = {}): {
 
 describe("useChat setModel", () => {
   it("sends normal chat messages with normal mode", async () => {
-    const { ctx } = buildContext();
+    const { ctx, stateRef } = buildContext();
     const { result } = renderHook(() => useChat(ctx));
 
     await act(async () => {
@@ -99,10 +99,35 @@ describe("useChat setModel", () => {
       tabId: "tab-1",
       mode: "normal",
     });
+    expect((stateRef.current.tabs as Tab[])[0].messages.at(-1)).toMatchObject({
+      role: "user",
+      text: "hello",
+      delivery: "sent",
+    });
+  });
+
+  it("marks normal messages as queued while the active prompt is busy", async () => {
+    const { ctx, stateRef } = buildContext({ waiting: true });
+    const { result } = renderHook(() => useChat(ctx));
+
+    await act(async () => {
+      await result.current.sendChat("after this");
+    });
+
+    expect(invoke).toHaveBeenCalledWith("send_message", {
+      message: "after this",
+      tabId: "tab-1",
+      mode: "normal",
+    });
+    expect((stateRef.current.tabs as Tab[])[0].messages.at(-1)).toMatchObject({
+      role: "user",
+      text: "after this",
+      delivery: "queued",
+    });
   });
 
   it("sends command-enter messages with steer mode", async () => {
-    const { ctx } = buildContext();
+    const { ctx, stateRef } = buildContext({ waiting: true });
     const { result } = renderHook(() => useChat(ctx));
 
     await act(async () => {
@@ -113,6 +138,11 @@ describe("useChat setModel", () => {
       message: "look now",
       tabId: "tab-1",
       mode: "steer",
+    });
+    expect((stateRef.current.tabs as Tab[])[0].messages.at(-1)).toMatchObject({
+      role: "user",
+      text: "look now",
+      delivery: "steered",
     });
   });
 

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -262,8 +262,15 @@ export function useChat(ctx: UseChatContext): UseChatActions {
     const mode = options?.mode === "steer" ? "steer" : "normal";
     const tabId =
       (stateRef.current.activeTabId as string | undefined) ?? "default";
+    const wasBusy = stateRef.current.waiting === true;
+    const delivery: ChatMessage["delivery"] =
+      mode === "steer" && wasBusy
+        ? "steered"
+        : mode === "normal" && wasBusy
+          ? "queued"
+          : "sent";
     appendMessage(
-      { id: crypto.randomUUID(), role: "user", text: sendText },
+      { id: crypto.randomUUID(), role: "user", text: sendText, delivery },
       tabId,
     );
     updateTab(tabId, (tab) => ({ ...tab, draft: "", waiting: true }));

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -269,8 +269,9 @@ export function useChat(ctx: UseChatContext): UseChatActions {
         : mode === "normal" && wasBusy
           ? "queued"
           : "sent";
+    const userMessageId = crypto.randomUUID();
     appendMessage(
-      { id: crypto.randomUUID(), role: "user", text: sendText, delivery },
+      { id: userMessageId, role: "user", text: sendText, delivery },
       tabId,
     );
     updateTab(tabId, (tab) => ({ ...tab, draft: "", waiting: true }));
@@ -295,6 +296,14 @@ export function useChat(ctx: UseChatContext): UseChatActions {
     try {
       await invoke("send_message", { message: sendText, tabId, mode });
     } catch (err) {
+      updateTab(tabId, (tab) => ({
+        ...tab,
+        messages: tab.messages.map((message) =>
+          message.id === userMessageId
+            ? { ...message, delivery: "failed" as const }
+            : message,
+        ),
+      }));
       appendMessage(
         {
           id: crypto.randomUUID(),

--- a/src/skills/default-layout/chat.test.tsx
+++ b/src/skills/default-layout/chat.test.tsx
@@ -140,6 +140,19 @@ describe("ChatInput", () => {
     expect(screen.getByText("steered")).toBeTruthy();
   });
 
+  it("numbers queued delivery badges when multiple follow-ups are waiting", () => {
+    renderHistory({
+      messages: [
+        { id: "1", role: "user", text: "running", delivery: "sent" },
+        { id: "2", role: "user", text: "first queued", delivery: "queued" },
+        { id: "3", role: "user", text: "second queued", delivery: "queued" },
+      ],
+    });
+
+    expect(screen.getByText("queued #1")).toBeTruthy();
+    expect(screen.getByText("queued #2")).toBeTruthy();
+  });
+
   it("renders retry actions for failed user messages", () => {
     const { onEvent } = renderHistory({
       messages: [

--- a/src/skills/default-layout/chat.test.tsx
+++ b/src/skills/default-layout/chat.test.tsx
@@ -1,19 +1,36 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { ChatInput } from "./chat";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ChatHistory, ChatInput } from "./chat";
 
-afterEach(() => cleanup());
+class ResizeObserverMock {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+}
 
-function renderInput(onEvent = vi.fn()) {
+beforeEach(() => {
+  vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+function renderInput(
+  onEvent = vi.fn(),
+  props: Record<string, unknown> = {},
+  state: Record<string, unknown> = {},
+) {
   render(
     <ChatInput
       component={{
         id: "chat-input",
         type: "chat-input",
-        props: { value: "", placeholder: "Message" },
+        props: { value: "", placeholder: "Message", ...props },
       }}
-      state={{}}
+      state={state}
       onEvent={onEvent}
     />,
   );
@@ -21,6 +38,20 @@ function renderInput(onEvent = vi.fn()) {
     input: screen.getByPlaceholderText("Message"),
     onEvent,
   };
+}
+
+function renderHistory(state: Record<string, unknown>) {
+  render(
+    <ChatHistory
+      component={{
+        id: "chat-history",
+        type: "chat-history",
+        props: { messages: { $ref: "/messages" } },
+      }}
+      state={state}
+      onEvent={vi.fn()}
+    />,
+  );
 }
 
 describe("ChatInput", () => {
@@ -67,5 +98,28 @@ describe("ChatInput", () => {
     fireEvent.keyDown(input, { key: "Enter", shiftKey: true });
 
     expect(onEvent).not.toHaveBeenCalledWith("submit", expect.any(Object));
+  });
+
+  it("shows the running-turn shortcut hint only when busy", () => {
+    renderInput(vi.fn(), { disabled: { $ref: "/waiting" } }, { waiting: true });
+
+    expect(screen.getByText("Enter queues")).toBeTruthy();
+    expect(screen.getByText("Cmd/Ctrl+Enter steers")).toBeTruthy();
+
+    cleanup();
+    renderInput(vi.fn(), { disabled: { $ref: "/waiting" } }, { waiting: false });
+    expect(screen.queryByText("Enter queues")).toBeNull();
+  });
+
+  it("renders queued and steered delivery badges on user messages", () => {
+    renderHistory({
+      messages: [
+        { id: "1", role: "user", text: "after this", delivery: "queued" },
+        { id: "2", role: "user", text: "look now", delivery: "steered" },
+      ],
+    });
+
+    expect(screen.getByText("queued")).toBeTruthy();
+    expect(screen.getByText("steered")).toBeTruthy();
   });
 });

--- a/src/skills/default-layout/chat.test.tsx
+++ b/src/skills/default-layout/chat.test.tsx
@@ -41,6 +41,7 @@ function renderInput(
 }
 
 function renderHistory(state: Record<string, unknown>) {
+  const onEvent = vi.fn();
   render(
     <ChatHistory
       component={{
@@ -49,9 +50,10 @@ function renderHistory(state: Record<string, unknown>) {
         props: { messages: { $ref: "/messages" } },
       }}
       state={state}
-      onEvent={vi.fn()}
+      onEvent={onEvent}
     />,
   );
+  return { onEvent };
 }
 
 describe("ChatInput", () => {
@@ -121,5 +123,20 @@ describe("ChatInput", () => {
 
     expect(screen.getByText("queued")).toBeTruthy();
     expect(screen.getByText("steered")).toBeTruthy();
+  });
+
+  it("renders retry actions for failed user messages", () => {
+    const { onEvent } = renderHistory({
+      messages: [
+        { id: "1", role: "user", text: "again please", delivery: "failed" },
+      ],
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    expect(onEvent).toHaveBeenCalledWith("retry", {
+      messageId: "1",
+      value: "again please",
+    });
   });
 });

--- a/src/skills/default-layout/chat.test.tsx
+++ b/src/skills/default-layout/chat.test.tsx
@@ -113,6 +113,21 @@ describe("ChatInput", () => {
     expect(screen.queryByText("Enter queues")).toBeNull();
   });
 
+  it("makes stop queue-clearing behavior visible when follow-ups are queued", () => {
+    renderInput(
+      vi.fn(),
+      { disabled: { $ref: "/waiting" }, queueCount: { $ref: "/queueCount" } },
+      { waiting: true, queueCount: 2 },
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Stop + clear" }).getAttribute("title"),
+    ).toBe("Stop the current prompt and clear 2 messages queued");
+    expect(screen.getByText("+2").getAttribute("title")).toBe(
+      "2 messages queued behind the current prompt",
+    );
+  });
+
   it("renders queued and steered delivery badges on user messages", () => {
     renderHistory({
       messages: [

--- a/src/skills/default-layout/chat.tsx
+++ b/src/skills/default-layout/chat.tsx
@@ -311,12 +311,14 @@ const ChatMessageRow = memo(
     tabId,
     className = "a2ui-chat-message",
     prevRole,
+    onEvent,
   }: {
     message: ChatMessage;
     state: Record<string, unknown>;
     tabId?: string;
     className?: string;
     prevRole?: string;
+    onEvent?: BuiltinComponentProps["onEvent"];
   }) {
     const isCanvas = className === "a2ui-canvas-message";
     const roleClass = isCanvas ? "a2ui-canvas-role" : "a2ui-chat-role";
@@ -343,6 +345,20 @@ const ChatMessageRow = memo(
                 {delivery}
               </span>
             )}
+            {delivery === "failed" && message.text && onEvent && (
+              <button
+                type="button"
+                className="a2ui-chat-retry"
+                onClick={() =>
+                  onEvent("retry", {
+                    messageId: message.id,
+                    value: message.text,
+                  })
+                }
+              >
+                Retry
+              </button>
+            )}
           </span>
         )}
         {message.thinking && (
@@ -366,6 +382,7 @@ const ChatMessageRow = memo(
     prev.tabId === next.tabId &&
     prev.className === next.className &&
     prev.prevRole === next.prevRole &&
+    prev.onEvent === next.onEvent &&
     (!next.message.a2ui || prev.state === next.state),
 );
 
@@ -373,6 +390,7 @@ export function ChatHistory({
   component,
   state,
   tabId,
+  onEvent,
 }: BuiltinComponentProps) {
   const props = component.props as {
     messages: { $ref: string };
@@ -487,6 +505,7 @@ export function ChatHistory({
               state={state}
               tabId={tabId}
               prevRole={i > 0 ? visibleMessages[i - 1].role : undefined}
+              onEvent={onEvent}
             />
           ))}
         </>
@@ -504,7 +523,12 @@ export function ChatHistory({
 // feed (history) plus a live "current canvas" subtree if state.canvas is set.
 // ---------------------------------------------------------------------------
 
-export function MainCanvas({ component, state, tabId }: BuiltinComponentProps) {
+export function MainCanvas({
+  component,
+  state,
+  tabId,
+  onEvent,
+}: BuiltinComponentProps) {
   const props = component.props as {
     slot?: string;
     messages?: { $ref: string };
@@ -593,6 +617,7 @@ export function MainCanvas({ component, state, tabId }: BuiltinComponentProps) {
           tabId={tabId}
           className="a2ui-canvas-message"
           prevRole={i > 0 ? visibleMessages[i - 1].role : undefined}
+          onEvent={onEvent}
         />
       ))}
       {liveSubtree && (

--- a/src/skills/default-layout/chat.tsx
+++ b/src/skills/default-layout/chat.tsx
@@ -260,6 +260,16 @@ function deliveryLabel(delivery: ChatMessage["delivery"]): string | null {
   }
 }
 
+function queuedDeliveryLabels(messages: ChatMessage[]): Map<string, string> {
+  const queued = messages.filter(
+    (message) => message.role === "user" && message.delivery === "queued",
+  );
+  if (queued.length <= 1) return new Map();
+  return new Map(
+    queued.map((message, index) => [message.id, `queued #${index + 1}`]),
+  );
+}
+
 function ThinkingBlock({
   children,
   complete = true,
@@ -312,6 +322,7 @@ const ChatMessageRow = memo(
     className = "a2ui-chat-message",
     prevRole,
     onEvent,
+    deliveryText,
   }: {
     message: ChatMessage;
     state: Record<string, unknown>;
@@ -319,6 +330,7 @@ const ChatMessageRow = memo(
     className?: string;
     prevRole?: string;
     onEvent?: BuiltinComponentProps["onEvent"];
+    deliveryText?: string;
   }) {
     const isCanvas = className === "a2ui-canvas-message";
     const roleClass = isCanvas ? "a2ui-canvas-role" : "a2ui-chat-role";
@@ -328,7 +340,9 @@ const ChatMessageRow = memo(
     // Suppress role label for consecutive messages from same sender
     const showRole = prevRole !== message.role;
     const delivery =
-      message.role === "user" ? deliveryLabel(message.delivery) : null;
+      message.role === "user"
+        ? (deliveryText ?? deliveryLabel(message.delivery))
+        : null;
     return (
       <div
         className={`${className} ${message.role}${showRole ? "" : " ae-msg-cont"}`}
@@ -383,6 +397,7 @@ const ChatMessageRow = memo(
     prev.className === next.className &&
     prev.prevRole === next.prevRole &&
     prev.onEvent === next.onEvent &&
+    prev.deliveryText === next.deliveryText &&
     (!next.message.a2ui || prev.state === next.state),
 );
 
@@ -410,6 +425,7 @@ export function ChatHistory({
     () => messages.slice(Math.max(0, messages.length - visibleCount)),
     [messages, visibleCount],
   );
+  const queuedLabels = useMemo(() => queuedDeliveryLabels(messages), [messages]);
   const hiddenCount = Math.max(0, messages.length - visibleMessages.length);
   const emptyHint = props.emptyHint
     ? resolveString(props.emptyHint, state)
@@ -506,6 +522,7 @@ export function ChatHistory({
               tabId={tabId}
               prevRole={i > 0 ? visibleMessages[i - 1].role : undefined}
               onEvent={onEvent}
+              deliveryText={queuedLabels.get(m.id)}
             />
           ))}
         </>
@@ -555,6 +572,7 @@ export function MainCanvas({
     () => messages.slice(Math.max(0, messages.length - visibleCount)),
     [messages, visibleCount],
   );
+  const queuedLabels = useMemo(() => queuedDeliveryLabels(messages), [messages]);
   const hiddenCount = Math.max(0, messages.length - visibleMessages.length);
 
   const live = props.slot ? resolvePointer(state, props.slot) : null;
@@ -618,6 +636,7 @@ export function MainCanvas({
           className="a2ui-canvas-message"
           prevRole={i > 0 ? visibleMessages[i - 1].role : undefined}
           onEvent={onEvent}
+          deliveryText={queuedLabels.get(m.id)}
         />
       ))}
       {liveSubtree && (

--- a/src/skills/default-layout/chat.tsx
+++ b/src/skills/default-layout/chat.tsx
@@ -811,6 +811,13 @@ export function ChatInput({
   const stopTitle = props.stopTitle
     ? resolveString(props.stopTitle, state)
     : "Stop the current prompt";
+  const queuedMessageLabel = `${queueCount} message${queueCount === 1 ? "" : "s"} queued`;
+  const effectiveStopLabel =
+    queueCount > 0 && !props.stopLabel ? "Stop + clear" : stopLabel;
+  const effectiveStopTitle =
+    queueCount > 0
+      ? `Stop the current prompt and clear ${queuedMessageLabel}`
+      : stopTitle;
   const queueBadgeFormat = props.queueBadgeFormat
     ? resolveString(props.queueBadgeFormat, state)
     : "+{n}";
@@ -1241,7 +1248,7 @@ export function ChatInput({
         {queueCount > 0 && (
           <span
             className="a2ui-chat-input-queue"
-            title={`${queueCount} message${queueCount === 1 ? "" : "s"} queued behind the current prompt`}
+            title={`${queuedMessageLabel} behind the current prompt`}
           >
             {queueBadgeFormat.replace("{n}", String(queueCount))}
           </span>
@@ -1251,8 +1258,8 @@ export function ChatInput({
             type="button"
             className="a2ui-chat-input-send a2ui-chat-input-stop"
             onClick={handleStop}
-            title={stopTitle}
-            aria-label={stopLabel}
+            title={effectiveStopTitle}
+            aria-label={effectiveStopLabel}
           >
             <svg
               className="a2ui-chat-input-send-icon"
@@ -1270,7 +1277,9 @@ export function ChatInput({
                 fill="currentColor"
               />
             </svg>
-            <span className="a2ui-chat-input-send-label">{stopLabel}</span>
+            <span className="a2ui-chat-input-send-label">
+              {effectiveStopLabel}
+            </span>
           </button>
         ) : (
           <button

--- a/src/skills/default-layout/chat.tsx
+++ b/src/skills/default-layout/chat.tsx
@@ -247,6 +247,19 @@ function roleBadge(role: string): string {
   return "SYS";
 }
 
+function deliveryLabel(delivery: ChatMessage["delivery"]): string | null {
+  switch (delivery) {
+    case "queued":
+      return "queued";
+    case "steered":
+      return "steered";
+    case "failed":
+      return "failed";
+    default:
+      return null;
+  }
+}
+
 function ThinkingBlock({
   children,
   complete = true,
@@ -312,12 +325,25 @@ const ChatMessageRow = memo(
       : "a2ui-chat-text a2ui-markdown";
     // Suppress role label for consecutive messages from same sender
     const showRole = prevRole !== message.role;
+    const delivery =
+      message.role === "user" ? deliveryLabel(message.delivery) : null;
     return (
       <div
         className={`${className} ${message.role}${showRole ? "" : " ae-msg-cont"}`}
       >
-        {showRole && message.role !== "system" && (
-          <span className={roleClass}>{roleBadge(message.role)}</span>
+        {message.role !== "system" && (showRole || delivery) && (
+          <span className="a2ui-chat-meta">
+            {showRole && (
+              <span className={roleClass}>{roleBadge(message.role)}</span>
+            )}
+            {delivery && (
+              <span
+                className={`a2ui-chat-delivery a2ui-chat-delivery-${delivery}`}
+              >
+                {delivery}
+              </span>
+            )}
+          </span>
         )}
         {message.thinking && (
           <ThinkingBlock complete={Boolean(message.text)}>
@@ -1166,6 +1192,12 @@ export function ChatInput({
           </div>,
           document.body,
         )}
+      {busy && (
+        <div className="a2ui-chat-input-hint">
+          <span>Enter queues</span>
+          <span>Cmd/Ctrl+Enter steers</span>
+        </div>
+      )}
       {/* Wrap the textarea and action button so Send sits INSIDE the
           textarea visually (absolute-positioned, bottom-right). Right
           padding on the textarea makes room for the button so text

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -2306,6 +2306,52 @@ body.ae-resizing-sidebar .a2ui-layout {
   opacity: 0.55;
 }
 
+.a2ui-chat-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  align-self: flex-start;
+}
+
+.a2ui-chat-message.user .a2ui-chat-meta {
+  align-self: flex-end;
+}
+
+.a2ui-chat-delivery {
+  display: inline-flex;
+  align-items: center;
+  height: 18px;
+  padding: 0 7px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  background: var(--bg-elev);
+  font-family: var(--font-mono);
+  font-size: var(--chrome-text-muted);
+  font-weight: 600;
+  line-height: 1;
+  text-transform: lowercase;
+  user-select: none;
+}
+
+.a2ui-chat-delivery-queued {
+  color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 35%, transparent);
+  background: var(--accent-soft);
+}
+
+.a2ui-chat-delivery-steered {
+  color: var(--warning);
+  border-color: color-mix(in srgb, var(--warning) 42%, transparent);
+  background: color-mix(in srgb, var(--warning) 13%, transparent);
+}
+
+.a2ui-chat-delivery-failed {
+  color: var(--danger);
+  border-color: color-mix(in srgb, var(--danger) 42%, transparent);
+  background: color-mix(in srgb, var(--danger) 13%, transparent);
+}
+
 .a2ui-chat-empty {
   color: var(--text-dim);
   text-align: center;
@@ -2458,6 +2504,24 @@ body.ae-resizing-composer * {
   width: 100%;
   height: var(--composer-height, 70px);
   min-height: 46px;
+}
+
+.a2ui-chat-input-hint {
+  display: inline-flex;
+  align-self: flex-end;
+  align-items: center;
+  gap: 8px;
+  margin: 0 8px 3px 0;
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  font-size: var(--chrome-text-muted);
+  line-height: 1;
+  user-select: none;
+}
+
+.a2ui-chat-input-hint span + span {
+  padding-left: 8px;
+  border-left: 1px solid var(--border);
 }
 
 /* Slash command autocomplete — portal-rendered to document.body and

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -2352,6 +2352,27 @@ body.ae-resizing-sidebar .a2ui-layout {
   background: color-mix(in srgb, var(--danger) 13%, transparent);
 }
 
+.a2ui-chat-retry {
+  appearance: none;
+  height: 20px;
+  padding: 0 8px;
+  border: 1px solid color-mix(in srgb, var(--danger) 34%, var(--border));
+  border-radius: 999px;
+  color: var(--text);
+  background: color-mix(in srgb, var(--danger) 10%, var(--bg-elev));
+  font-family: var(--font-mono);
+  font-size: var(--chrome-text-muted);
+  font-weight: 700;
+  line-height: 1;
+  cursor: pointer;
+  user-select: none;
+}
+
+.a2ui-chat-retry:hover {
+  border-color: color-mix(in srgb, var(--danger) 55%, var(--border));
+  background: color-mix(in srgb, var(--danger) 16%, var(--bg-elev));
+}
+
 .a2ui-chat-empty {
   color: var(--text-dim);
   text-align: center;

--- a/src/types/a2ui.ts
+++ b/src/types/a2ui.ts
@@ -291,4 +291,5 @@ export interface ChatMessage {
   text?: string;
   thinking?: string;
   a2ui?: A2UIPayload;
+  delivery?: "sent" | "queued" | "steered" | "failed";
 }

--- a/src/utils/messages.test.ts
+++ b/src/utils/messages.test.ts
@@ -118,6 +118,19 @@ describe("coerceChatMessages", () => {
     ]);
   });
 
+  it("preserves known user delivery states", () => {
+    const out = coerceChatMessages([
+      { id: "q1", role: "user", text: "after this", delivery: "queued" },
+      { id: "s1", role: "user", text: "look now", delivery: "steered" },
+      { id: "x1", role: "user", text: "nope", delivery: "bogus" },
+    ]);
+    expect(out).toEqual([
+      { id: "q1", role: "user", text: "after this", delivery: "queued" },
+      { id: "s1", role: "user", text: "look now", delivery: "steered" },
+      { id: "x1", role: "user", text: "nope" },
+    ]);
+  });
+
   it("rejects unknown roles", () => {
     expect(coerceChatMessages([{ role: "supervisor", text: "x" }])).toEqual([]);
   });

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -65,6 +65,13 @@ export function coerceChatMessages(value: unknown): ChatMessage[] {
       Array.isArray((record.a2ui as { components?: unknown }).components)
         ? (record.a2ui as A2UIPayload)
         : undefined;
+    const delivery =
+      record.delivery === "sent" ||
+      record.delivery === "queued" ||
+      record.delivery === "steered" ||
+      record.delivery === "failed"
+        ? record.delivery
+        : undefined;
     if (!text && !thinking && !a2ui) continue;
     messages.push(
       trimMessage({
@@ -76,6 +83,7 @@ export function coerceChatMessages(value: unknown): ChatMessage[] {
         ...(text ? { text } : {}),
         ...(thinking ? { thinking } : {}),
         ...(a2ui ? { a2ui } : {}),
+        ...(delivery ? { delivery } : {}),
       }),
     );
   }

--- a/tsconfig.e2e.json
+++ b/tsconfig.e2e.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.e2e.tsbuildinfo",
+    "target": "ES2023",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "types": ["node"],
+
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["playwright.config.ts", "e2e/**/*.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.e2e.json" }
   ]
 }


### PR DESCRIPTION
## Summary

This branch hardens Aethon's steering and queued-message behavior with real integration coverage and user-visible chat UX improvements.

### Steering and queued-turn behavior

- Adds a Playwright e2e harness that boots the real React app with mocked Tauri IPC.
- Covers the core steering contract end to end:
  - normal `Enter` while a prompt is running queues a follow-up
  - `Cmd/Ctrl+Enter` steers the active prompt without incrementing the queue
  - steering while follow-ups are already queued preserves queued turns
  - native slash commands do not leave the UI stuck busy
  - model picker changes keep active state aligned
  - file tree refreshes after filesystem change events
- Adds CI wiring for the e2e suite.

### Chat queue UX

- Adds delivery metadata for user messages: `sent`, `queued`, `steered`, and `failed`.
- Shows visible delivery badges for queued, steered, and failed user bubbles.
- Shows busy composer hints: `Enter queues` and `Cmd/Ctrl+Enter steers`.
- Ages queued badges when queued turns actually start so stale `queued` labels do not linger.
- Numbers queued follow-ups as `queued #1`, `queued #2`, etc. when more than one is waiting.
- Makes the Stop button read `Stop + clear` when queued follow-ups exist, matching the existing backend behavior that stop clears the queue.
- Adds a Retry action for failed user sends that removes the failed bubble and resends the same text.

### Failure recovery

- Rolls back queue count when a bridge-side `followUp` call rejects.
- Allows `queue_reset` to carry the remaining queue count instead of only zeroing it.
- Marks local user messages as failed when `send_message` IPC rejects.

## Validation

- `bunx vitest run` passed: 136 files, 987 tests.
- `bun run test:e2e` passed: 8 Playwright tests.
- `bunx tsc -b --noEmit` passed.
- `git diff --check` passed.
- `bunx eslint .` passed with 5 existing warning-only React hook findings in unrelated dashboard/editor/layout files.

## Notes

The ESLint warnings are pre-existing and unrelated to this branch. They are all `react-hooks/set-state-in-effect` warnings in dashboard/editor/layout components outside the steering and queue paths touched here.
