### PR TITLE
fix(tabs): add session rename context menu

### DIFF
--- a/src/eventRoutes/sessionRename.ts
+++ b/src/eventRoutes/sessionRename.ts
@@ -1,0 +1,47 @@
+import type { EventRouteContext } from "./types";
+
+export function renameSessionLabel(
+  ctx: EventRouteContext,
+  tabId: string,
+  label: string,
+): void {
+  applyOptimisticTabLabel(ctx, tabId, label);
+  ctx
+    .invoke("agent_command", {
+      payload: JSON.stringify({
+        type: "set_session_label",
+        tabId,
+        label,
+      }),
+    })
+    .catch((err: unknown) => {
+      ctx.pushNotification({
+        title: "Rename session failed",
+        message: String(err),
+        kind: "error",
+      });
+    });
+}
+
+/** Update an open tab's `label` in App state when renaming a currently
+ *  open session. Empty input restores the auto-derived sequential
+ *  "Tab N" label using the tab's existing index in the array. */
+export function applyOptimisticTabLabel(
+  ctx: EventRouteContext,
+  tabId: string,
+  label: string,
+): void {
+  ctx.setState((prev) => {
+    const tabs =
+      (prev.tabs as { id: string; label: string }[] | undefined) ?? [];
+    const idx = tabs.findIndex((t) => t.id === tabId);
+    if (idx < 0) return prev;
+    const trimmed = label.trim();
+    const fallback = `Tab ${idx + 1}`;
+    const nextLabel = trimmed.length > 0 ? trimmed : fallback;
+    if (tabs[idx].label === nextLabel) return prev;
+    const nextTabs = [...tabs];
+    nextTabs[idx] = { ...nextTabs[idx], label: nextLabel };
+    return { ...prev, tabs: nextTabs };
+  });
+}

--- a/src/eventRoutes/sidebar.ts
+++ b/src/eventRoutes/sidebar.ts
@@ -1,7 +1,8 @@
-import type { EventRouteContext, EventRouteHandler } from "./types";
+import type { EventRouteHandler } from "./types";
 import { extractSessionId } from "../utils/sidebarHistory";
 import type { Tab } from "../types/tab";
 import { restoreSessionFromSelection } from "./sessionRestore";
+import { renameSessionLabel } from "./sessionRename";
 
 interface RecentSessionItem {
   id: string;
@@ -148,50 +149,9 @@ export const handleSidebarRenameSession: EventRouteHandler = (
   const sessionId = extractSessionId(raw);
   const label = typeof selected?.label === "string" ? selected.label : "";
   if (!sessionId) return true;
-  applyOptimisticTabLabel(ctx, sessionId, label);
-  ctx
-    .invoke("agent_command", {
-      payload: JSON.stringify({
-        type: "set_session_label",
-        tabId: sessionId,
-        label,
-      }),
-    })
-    .catch((err: unknown) => {
-      ctx.pushNotification({
-        title: "Rename session failed",
-        message: String(err),
-        kind: "error",
-      });
-    });
+  renameSessionLabel(ctx, sessionId, label);
   return true;
 };
-
-/** Update an open tab's `label` in App state when renaming a currently
- *  open session. Empty input restores the auto-derived sequential
- *  "Tab N" label using the tab's existing index in the array (matches
- *  the original useTabs naming convention so the auto-label fallback
- *  behaviour from `buildSidebarHistory` kicks in). No-op if no tab
- *  matches the id. */
-function applyOptimisticTabLabel(
-  ctx: EventRouteContext,
-  tabId: string,
-  label: string,
-): void {
-  ctx.setState((prev) => {
-    const tabs =
-      (prev.tabs as { id: string; label: string }[] | undefined) ?? [];
-    const idx = tabs.findIndex((t) => t.id === tabId);
-    if (idx < 0) return prev;
-    const trimmed = label.trim();
-    const fallback = `Tab ${idx + 1}`;
-    const nextLabel = trimmed.length > 0 ? trimmed : fallback;
-    if (tabs[idx].label === nextLabel) return prev;
-    const nextTabs = [...tabs];
-    nextTabs[idx] = { ...nextTabs[idx], label: nextLabel };
-    return { ...prev, tabs: nextTabs };
-  });
-}
 
 /** Sidebar disclosure on a project row — toggle the per-project
  *  expanded state so worktrees show/hide nested under the row. */

--- a/src/eventRoutes/tabStrip.test.ts
+++ b/src/eventRoutes/tabStrip.test.ts
@@ -30,6 +30,42 @@ describe("handleTabStrip", () => {
     expect(mocks.closeTab).toHaveBeenCalledWith("tab-4");
   });
 
+  it("rename updates the label and persists it through the bridge", async () => {
+    const { ctx, mocks, applySetState } = buildRouteFixture({
+      state: {
+        tabs: [
+          { id: "tab-4", kind: "agent", label: "Tab 1" },
+          { id: "tab-5", kind: "agent", label: "Tab 2" },
+        ],
+      },
+    });
+    const handled = await handleTabStrip(
+      {
+        component: { id: "header-tabs", type: "tab-strip" },
+        eventType: "rename",
+        data: { tabId: "tab-4", label: "Planning" },
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.invoke).toHaveBeenCalledWith("agent_command", {
+      payload: JSON.stringify({
+        type: "set_session_label",
+        tabId: "tab-4",
+        label: "Planning",
+      }),
+    });
+    const next = applySetState({
+      tabs: [
+        { id: "tab-4", kind: "agent", label: "Tab 1" },
+        { id: "tab-5", kind: "agent", label: "Tab 2" },
+      ],
+    });
+    expect((next.tabs as { id: string; label: string }[])[0].label).toBe(
+      "Planning",
+    );
+  });
+
   it("new spawns a fresh tab", async () => {
     const { ctx, mocks } = buildRouteFixture();
     await handleTabStrip(

--- a/src/eventRoutes/tabStrip.ts
+++ b/src/eventRoutes/tabStrip.ts
@@ -1,5 +1,6 @@
 import type { EventRouteHandler } from "./types";
 import { restoreSessionFromSelection } from "./sessionRestore";
+import { renameSessionLabel } from "./sessionRename";
 
 /** tab-strip: select / close / new. Tab events route by component
  *  *type* — id may vary across layouts (workstation hoists the strip
@@ -12,7 +13,7 @@ export const handleTabStrip: EventRouteHandler = (
 ) => {
   if (component.type !== "tab-strip") return false;
   const sel = data as
-    | { tabId?: string; action?: string; id?: string }
+    | { tabId?: string; action?: string; id?: string; label?: string }
     | undefined;
   if (eventType === "select" && sel?.tabId) {
     ctx.setActiveTab(sel.tabId);
@@ -20,6 +21,11 @@ export const handleTabStrip: EventRouteHandler = (
   }
   if (eventType === "close" && sel?.tabId) {
     ctx.closeTab(sel.tabId);
+    return true;
+  }
+  if (eventType === "rename" && sel?.tabId) {
+    const label = typeof sel.label === "string" ? sel.label : "";
+    renameSessionLabel(ctx, sel.tabId, label);
     return true;
   }
   if (eventType === "new") {

--- a/src/skills/default-layout/shell/tab-strip.test.tsx
+++ b/src/skills/default-layout/shell/tab-strip.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ComponentProps } from "react";
+import { TabStrip } from "./tab-strip";
+import type { A2UIComponent } from "../../../types/a2ui";
+
+afterEach(() => cleanup());
+
+type TabStripOnEvent = ComponentProps<typeof TabStrip>["onEvent"];
+
+function tabStripComponent(): A2UIComponent {
+  return {
+    id: "header-tabs",
+    type: "tab-strip",
+    props: {
+      tabs: { $ref: "/tabs" },
+      activeId: { $ref: "/activeTabId" },
+    },
+  };
+}
+
+function renderTabStrip(onEvent = vi.fn<TabStripOnEvent>()) {
+  render(
+    <TabStrip
+      component={tabStripComponent()}
+      state={{
+        activeTabId: "tab-1",
+        tabs: [
+          { id: "tab-1", label: "Tab 1", kind: "agent" },
+          { id: "shell-1", label: "Shell 1", kind: "shell" },
+        ],
+      }}
+      onEvent={onEvent}
+    />,
+  );
+  return { onEvent };
+}
+
+describe("TabStrip", () => {
+  it("opens tab actions on right-click and emits a rename event", () => {
+    const { onEvent } = renderTabStrip();
+    fireEvent.contextMenu(screen.getByText("Tab 1").closest('[role="tab"]')!);
+
+    fireEvent.change(screen.getByLabelText("Session name"), {
+      target: { value: "Planning" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Rename" }));
+
+    expect(onEvent).toHaveBeenCalledWith("rename", {
+      tabId: "tab-1",
+      label: "Planning",
+    });
+  });
+
+  it("does not select the tab on right-button mouse down", () => {
+    const { onEvent } = renderTabStrip();
+    fireEvent.mouseDown(screen.getByText("Tab 1").closest('[role="tab"]')!, {
+      button: 2,
+    });
+
+    expect(onEvent).not.toHaveBeenCalled();
+  });
+
+  it("continues filtering shell tabs from the top strip", () => {
+    renderTabStrip();
+
+    expect(screen.getByText("Tab 1")).toBeTruthy();
+    expect(screen.queryByText("Shell 1")).toBeNull();
+  });
+});

--- a/src/skills/default-layout/shell/tab-strip.tsx
+++ b/src/skills/default-layout/shell/tab-strip.tsx
@@ -14,11 +14,15 @@
  *   ("new")                 click on the "+" button
  */
 
-import { useMemo } from "react";
+import { useMemo, useState, type MouseEvent } from "react";
 import type { StringValue } from "../../../types/a2ui";
 import { resolveString } from "../../../utils/dataBinding";
 import { resolvePointer } from "../../../utils/jsonPointer";
 import type { BuiltinComponentProps } from "../../../components/A2UIRenderer";
+import {
+  ContextMenu,
+  type ContextMenuItem,
+} from "../../../components/primitives/context-menu";
 
 interface TabStripItem {
   id: string;
@@ -59,6 +63,37 @@ export function TabStrip({ component, state, onEvent }: BuiltinComponentProps) {
     return raw.filter((t) => t.kind !== "shell");
   }, [props.tabs, state]);
   const activeId = props.activeId ? resolveString(props.activeId, state) : "";
+  const [contextMenu, setContextMenu] = useState<{
+    x: number;
+    y: number;
+    tab: TabStripItem;
+  } | null>(null);
+
+  const openTabMenu = (event: MouseEvent, tab: TabStripItem) => {
+    event.preventDefault();
+    event.stopPropagation();
+    setContextMenu({ x: event.clientX, y: event.clientY, tab });
+  };
+
+  const menuItems: ContextMenuItem[] = contextMenu
+    ? [
+        {
+          type: "input",
+          id: "rename-session",
+          label: "Session name",
+          defaultValue: contextMenu.tab.label,
+          submitLabel: "Rename",
+          onSubmit: (label) =>
+            onEvent("rename", { tabId: contextMenu.tab.id, label }),
+        },
+        { type: "separator" },
+        {
+          id: "close-tab",
+          label: "Close tab",
+          onSelect: () => onEvent("close", { tabId: contextMenu.tab.id }),
+        },
+      ]
+    : [];
 
   return (
     <div className="a2ui-tab-strip" role="tablist">
@@ -80,10 +115,12 @@ export function TabStrip({ component, state, onEvent }: BuiltinComponentProps) {
               // mousedown not click so focus doesn't shift away from the
               // chat input first (avoids a stray blur that could submit
               // a draft). The select handler swaps the active tab.
+              if (e.button !== 0) return;
               if ((e.target as HTMLElement).closest(".a2ui-tab-close")) return;
               e.preventDefault();
               onEvent("select", { tabId: t.id });
             }}
+            onContextMenu={(e) => openTabMenu(e, t)}
           >
             {t.waiting ? (
               <span
@@ -127,6 +164,16 @@ export function TabStrip({ component, state, onEvent }: BuiltinComponentProps) {
       >
         +
       </button>
+      <ContextMenu
+        open={!!contextMenu}
+        x={contextMenu?.x ?? 0}
+        y={contextMenu?.y ?? 0}
+        items={menuItems}
+        onClose={() => setContextMenu(null)}
+        ariaLabel="Tab actions"
+        estimatedWidth={320}
+        estimatedHeight={176}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add a right-click context menu to top session tabs with an inline rename control
- route tab-strip rename events through the existing `set_session_label` bridge persistence path
- share optimistic open-tab relabeling between sidebar and tab-strip rename flows

## Validation
- `bunx vitest run src/eventRoutes/tabStrip.test.ts src/eventRoutes/sidebar.test.ts src/skills/default-layout/shell/tab-strip.test.tsx`
- `bunx tsc --noEmit`
- `bun run lint` (passes with existing React compiler warnings)
- `bun run typecheck`
- `bun run test`
- `cargo test --lib -p aethon` from `src-tauri/`
- `cargo clippy --all-targets --all-features -- -D warnings` from `src-tauri/`
- dev-webview smoke check: right-clicked a top tab, saw the Aethon context menu, submitted a session rename, and restored the temporary test label
