### PR TITLE
fix(layout): restore workstation tabs and file tree expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ All notable changes to Aethon. Format loosely follows
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-05-25
+
+### Fixed — Patch release
+
+- **Top tab strip restored.** The workstation layout now gives tabs a
+  dedicated grid row below the header controls, matching the Claudette-style
+  chrome shape and preventing model / appearance controls from covering
+  session tabs.
+- **Stale layout snapshots repaired on ready.** Bridge `ready` hydration now
+  normalizes the default workstation grid back to the canonical
+  header / tabs / canvas / terminal / composer / status rows, so older
+  persisted layout state cannot auto-place tabs at the bottom or hide them.
+- **File tree expansion is stable across refreshes.** Directory refreshes
+  now merge fresh filesystem listings with the existing tree by path, keeping
+  expanded descendants loaded and visible instead of collapsing immediately
+  after expansion.
+- **Files sidebar resize restored.** The right files sidebar now keeps the
+  canonical workstation areas through resize, terminal toggles, layout prefs,
+  and session restore, preventing Monaco/editor tabs from shifting or growing
+  the sidebar unexpectedly.
+
 ## [0.3.0] - 2026-05-24
 
 ### Added — Workstation layout redesign
@@ -575,7 +596,8 @@ error?: string}>`. Backwards compatible: sync callers ignore the
   "Terminal" + "xterm.js · WebGL" badge).
 - **`SPEC.md` checklist** reconciled with what's actually shipped.
 
-[Unreleased]: https://github.com/utensils/aethon/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/utensils/aethon/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/utensils/aethon/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/utensils/aethon/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/utensils/aethon/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/utensils/aethon/releases/tag/v0.1.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aethon",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aethon",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@mariozechner/pi-ai": "^0.70.2",
         "@mariozechner/pi-coding-agent": "^0.70.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aethon",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aethon"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aethon"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 license = "MIT"
 description = "Pi with a face — agent-driven desktop shell with A2UI"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Aethon",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "identifier": "com.utensils.aethon",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
 import { useWindowApi } from "./runtime/windowApi";
 import { useBootConfig } from "./hooks/useBootConfig";
 import { useNotifications } from "./hooks/useNotifications";
-import { useFocus, workstationRows } from "./hooks/useFocus";
+import { useFocus, WORKSTATION_AREAS, workstationRows } from "./hooks/useFocus";
 import { useChat } from "./hooks/useChat";
 import { useFrontendStateMirror } from "./hooks/useFrontendStateMirror";
 import { useUiOverlays } from "./hooks/useUiOverlays";
@@ -169,6 +169,7 @@ export default function App() {
           ...restoredLayout,
           ...(layoutPrefs?.layout ?? {}),
           rows: workstationRows(terminalOpen, terminalHeight),
+          areas: WORKSTATION_AREAS,
         },
       }),
       hasSyncSessionSnapshot: Boolean(restored),
@@ -248,7 +249,13 @@ export default function App() {
             ? { projectModels: snapshot.projectModels }
             : {}),
           ...(Object.keys(restoredLayout).length > 0
-            ? { layout: { ...currentLayout, ...restoredLayout } }
+            ? {
+                layout: {
+                  ...currentLayout,
+                  ...restoredLayout,
+                  areas: WORKSTATION_AREAS,
+                },
+              }
             : {}),
           tabs,
           activeTabId,

--- a/src/eventRoutes/editor.ts
+++ b/src/eventRoutes/editor.ts
@@ -17,6 +17,7 @@
  */
 
 import type { EventRouteContext, EventRouteEvent, EventRouteHandler } from "./types";
+import { WORKSTATION_AREAS } from "../hooks/useFocus";
 
 function asRecord(data: unknown): Record<string, unknown> {
   return data && typeof data === "object" ? (data as Record<string, unknown>) : {};
@@ -118,6 +119,7 @@ export const handleFileTree: EventRouteHandler = (
         layout: {
           ...layout,
           columns: tokens.join(" "),
+          areas: WORKSTATION_AREAS,
           lastRightWidth: `${width}px`,
         },
       };

--- a/src/eventRoutes/sidebar.ts
+++ b/src/eventRoutes/sidebar.ts
@@ -3,6 +3,7 @@ import { extractSessionId } from "../utils/sidebarHistory";
 import type { Tab } from "../types/tab";
 import { restoreSessionFromSelection } from "./sessionRestore";
 import { renameSessionLabel } from "./sessionRename";
+import { WORKSTATION_AREAS } from "../hooks/useFocus";
 
 interface RecentSessionItem {
   id: string;
@@ -42,6 +43,7 @@ export const handleSidebarResize: EventRouteHandler = (
         layout: {
           ...layout,
           columns: tokens.join(" "),
+          areas: WORKSTATION_AREAS,
           lastLeftWidth: `${next}px`,
         },
       };

--- a/src/eventRoutes/terminal.test.ts
+++ b/src/eventRoutes/terminal.test.ts
@@ -62,7 +62,7 @@ describe("handleTerminalPanel", () => {
       state: {
         terminal: { open: true },
         terminalPanel: { activeSubId: "agent-bash" },
-        layout: { rows: "38px minmax(0,1fr) 240px auto auto" },
+        layout: { rows: "38px 38px minmax(0,1fr) 240px auto auto" },
       },
     });
     const handled = await handleTerminalPanel(
@@ -77,7 +77,10 @@ describe("handleTerminalPanel", () => {
     const next = applySetState();
     expect((next.terminalPanel as { height?: number }).height).toBe(360);
     expect((next.layout as { rows?: string }).rows).toBe(
-      "38px minmax(0,1fr) 360px auto auto",
+      "38px 38px minmax(0,1fr) 360px auto auto",
+    );
+    expect((next.layout as { areas?: string[] }).areas).toContain(
+      "sidebar tabs files-sidebar",
     );
   });
 

--- a/src/eventRoutes/terminal.ts
+++ b/src/eventRoutes/terminal.ts
@@ -1,6 +1,7 @@
 import type { EventRouteHandler } from "./types";
 import { cycleShareMode } from "../utils/shareMode";
 import type { Tab } from "../types/tab";
+import { WORKSTATION_AREAS, workstationRows } from "../hooks/useFocus";
 
 const TERMINAL_PANEL_MIN_HEIGHT = 120;
 const TERMINAL_PANEL_MAX_HEIGHT = 720;
@@ -56,7 +57,8 @@ export const handleTerminalPanel: EventRouteHandler = (
           layout: terminal.open
             ? {
                 ...layout,
-                rows: `38px minmax(0,1fr) ${next}px auto auto`,
+                rows: workstationRows(true, next),
+                areas: WORKSTATION_AREAS,
               }
             : layout,
         };

--- a/src/hooks/bridgeMessageHandlers/ready.test.ts
+++ b/src/hooks/bridgeMessageHandlers/ready.test.ts
@@ -3,6 +3,7 @@ import { handleReady } from "./ready";
 import { buildHandlerFixture } from "./testFixtures";
 import { clearTauriMocks, installTauriMocks } from "../../test/tauriMocks";
 import { makeEmptyTab } from "../../types/tab";
+import { defaultLayoutSkill } from "../../skills/default-layout";
 
 describe("handleReady", () => {
   beforeEach(() => {
@@ -219,18 +220,7 @@ describe("handleReady", () => {
         },
       },
     });
-    ctx.bootLayout = {
-      components: [{ id: "root", type: "container" }],
-      state: {
-        layout: {
-          columns: "220px minmax(0,1fr)",
-          areas: ["sidebar header", "sidebar canvas", "sidebar composer"],
-        },
-        sidebar: {
-          extraSections: [],
-        },
-      },
-    };
+    ctx.bootLayout = defaultLayoutSkill.layout!;
     ctx.lastExtensionStateKeysRef.current = new Set([
       "/layout/columns",
       "/layout/areas",
@@ -250,10 +240,63 @@ describe("handleReady", () => {
 
     const next = applySetState();
     expect(next.layout).toMatchObject({
-      columns: "220px minmax(0,1fr)",
-      areas: ["sidebar header", "sidebar canvas", "sidebar composer"],
+      columns: "220px minmax(0,1fr) 360px",
+      rows: "38px 38px minmax(0,1fr) 0px auto auto",
+      areas: [
+        "sidebar header files-sidebar",
+        "sidebar tabs files-sidebar",
+        "sidebar canvas files-sidebar",
+        "sidebar terminal files-sidebar",
+        "sidebar composer files-sidebar",
+        "status status status",
+      ],
     });
     expect(next.sidebar).toMatchObject({ extraSections: [] });
+  });
+
+  it("normalizes stale workstation grid state so the top tab strip has a row", () => {
+    const { ctx, applySetState } = buildHandlerFixture({
+      state: {
+        activeTabId: "default",
+        tabs: [{ id: "default" }],
+        layout: {
+          columns: "220px minmax(0,1fr) 360px",
+          rows: "38px minmax(0,1fr) 0px auto auto",
+          areas: [
+            "sidebar header files-sidebar",
+            "sidebar canvas files-sidebar",
+            "sidebar terminal files-sidebar",
+            "sidebar composer files-sidebar",
+            "status status status",
+          ],
+        },
+      },
+    });
+    ctx.bootLayout = defaultLayoutSkill.layout!;
+
+    handleReady(
+      {
+        type: "ready",
+        model: "claude",
+        models: [],
+        extensionStateKeys: [],
+        tabs: [{ id: "default", model: "claude" }],
+      },
+      ctx,
+    );
+
+    const next = applySetState();
+    expect(next.layout).toMatchObject({
+      rows: "38px 38px minmax(0,1fr) 0px auto auto",
+      areas: [
+        "sidebar header files-sidebar",
+        "sidebar tabs files-sidebar",
+        "sidebar canvas files-sidebar",
+        "sidebar terminal files-sidebar",
+        "sidebar composer files-sidebar",
+        "status status status",
+      ],
+    });
   });
 
   it("calls auto-restore only after projects are loaded", () => {

--- a/src/hooks/bridgeMessageHandlers/ready.ts
+++ b/src/hooks/bridgeMessageHandlers/ready.ts
@@ -5,6 +5,7 @@ import { TAB_MIRROR_KEYS } from "../useTabs";
 import type { Tab } from "../../types/tab";
 import { deepMergeState, layoutPatch } from "../../utils/stateMutation";
 import { deletePointer } from "../../utils/jsonPointer";
+import { WORKSTATION_AREAS, workstationRows } from "../useFocus";
 import type {
   DisabledExtensionRecord,
   ExtensionFailureSummary,
@@ -16,6 +17,41 @@ import type {
   DiscoveredSession,
   ModelDescriptor,
 } from "./types";
+
+function isWorkstationBootLayout(layout: A2UIPayload): boolean {
+  const state = layout.state as
+    | { layout?: { areas?: unknown; rows?: unknown } }
+    | undefined;
+  const areas = state?.layout?.areas;
+  return (
+    Array.isArray(areas) &&
+    areas.some((row) => typeof row === "string" && row.includes("files-sidebar"))
+  );
+}
+
+function terminalHeightFromState(state: Record<string, unknown>): number {
+  const panel = state.terminalPanel as { height?: unknown } | undefined;
+  const height = panel?.height;
+  return typeof height === "number" && Number.isFinite(height) ? height : 240;
+}
+
+function normalizeWorkstationLayout(
+  state: Record<string, unknown>,
+): Record<string, unknown> {
+  const layout = (state.layout as Record<string, unknown> | undefined) ?? {};
+  const terminal = state.terminal as { open?: boolean } | undefined;
+  return {
+    ...state,
+    layout: {
+      ...layout,
+      rows: workstationRows(
+        terminal?.open === true,
+        terminalHeightFromState(state),
+      ),
+      areas: WORKSTATION_AREAS,
+    },
+  };
+}
 
 /** The biggest handler: extension hydration + session restore + model
  *  picker + tabs reconcile. Called whenever the bridge fires `ready` —
@@ -179,6 +215,8 @@ export const handleReady: BridgeMessageHandler = (data, ctx) => {
     Array.isArray(extLayout.components)
       ? extLayout
       : ctx.bootLayout;
+  const shouldNormalizeWorkstationLayout =
+    baseLayout === ctx.bootLayout && isWorkstationBootLayout(baseLayout);
   const patchedLayout = extPatches.reduce<A2UIPayload>(
     (acc, p) => layoutPatch(acc, p.path, p.value),
     baseLayout,
@@ -229,6 +267,14 @@ export const handleReady: BridgeMessageHandler = (data, ctx) => {
       next = deepMergeState(layoutDefaults, next);
     }
     next = deepMergeState(next, extState);
+    if (shouldNormalizeWorkstationLayout) {
+      // Older persisted UI snapshots and project-owned layout state had
+      // no dedicated tabs row. Because layout state uses default-merge
+      // semantics, those stale /layout/areas values otherwise win over
+      // the boot workstation payload on every bridge ready, leaving the
+      // tab-strip to auto-place at the bottom of the grid.
+      next = normalizeWorkstationLayout(next);
+    }
     // Reconcile bridge data onto local tabs without creating visible
     // records from the bridge tab list. With project buckets, bridge
     // state is global but the visible UI bucket is project-scoped; if a

--- a/src/hooks/useFocus.test.ts
+++ b/src/hooks/useFocus.test.ts
@@ -11,6 +11,7 @@ describe("workstationLayout", () => {
     expect(result.columns).toBe("220px minmax(0,1fr) 280px");
     expect(result.areas).toEqual([
       "sidebar header files-sidebar",
+      "sidebar tabs files-sidebar",
       "sidebar canvas files-sidebar",
       "sidebar terminal files-sidebar",
       "sidebar composer files-sidebar",
@@ -27,6 +28,7 @@ describe("workstationLayout", () => {
     expect(result.columns).toBe("220px minmax(0,1fr) 0px");
     expect(result.areas).toEqual([
       "sidebar header files-sidebar",
+      "sidebar tabs files-sidebar",
       "sidebar canvas files-sidebar",
       "sidebar terminal files-sidebar",
       "sidebar composer files-sidebar",
@@ -43,6 +45,7 @@ describe("workstationLayout", () => {
     expect(result.columns).toBe("0px minmax(0,1fr) 280px");
     expect(result.areas).toEqual([
       "sidebar header files-sidebar",
+      "sidebar tabs files-sidebar",
       "sidebar canvas files-sidebar",
       "sidebar terminal files-sidebar",
       "sidebar composer files-sidebar",
@@ -59,6 +62,7 @@ describe("workstationLayout", () => {
     expect(result.columns).toBe("0px minmax(0,1fr) 0px");
     expect(result.areas).toEqual([
       "sidebar header files-sidebar",
+      "sidebar tabs files-sidebar",
       "sidebar canvas files-sidebar",
       "sidebar terminal files-sidebar",
       "sidebar composer files-sidebar",
@@ -103,11 +107,11 @@ describe("workstationLayout", () => {
 
   it("falls back to default widths when current columns missing or malformed", () => {
     expect(workstationLayout({}, true, true).columns).toBe(
-      "220px minmax(0,1fr) 280px",
+      "220px minmax(0,1fr) 360px",
     );
     expect(
       workstationLayout({ columns: "garbage" }, true, true).columns,
-    ).toBe("220px minmax(0,1fr) 280px");
+    ).toBe("220px minmax(0,1fr) 360px");
   });
 
   it("animates hidden chrome tracks with 0px sentinels but preserves memos", () => {
@@ -127,19 +131,19 @@ describe("workstationLayout", () => {
 describe("workstationRows", () => {
   it("uses a fixed terminal track so console toggles can animate", () => {
     expect(workstationRows(false, 240)).toBe(
-      "38px minmax(0,1fr) 0px auto auto",
+      "38px 38px minmax(0,1fr) 0px auto auto",
     );
     expect(workstationRows(true, 360)).toBe(
-      "38px minmax(0,1fr) 360px auto auto",
+      "38px 38px minmax(0,1fr) 360px auto auto",
     );
   });
 
   it("clamps terminal track height", () => {
     expect(workstationRows(true, 10)).toBe(
-      "38px minmax(0,1fr) 120px auto auto",
+      "38px 38px minmax(0,1fr) 120px auto auto",
     );
     expect(workstationRows(true, 900)).toBe(
-      "38px minmax(0,1fr) 720px auto auto",
+      "38px 38px minmax(0,1fr) 720px auto auto",
     );
   });
 });

--- a/src/hooks/useFocus.ts
+++ b/src/hooks/useFocus.ts
@@ -23,8 +23,17 @@ export interface UseFocusActions {
 }
 
 const DEFAULT_LEFT_WIDTH = "220px";
-const DEFAULT_RIGHT_WIDTH = "280px";
+const DEFAULT_RIGHT_WIDTH = "360px";
 const DEFAULT_TERMINAL_HEIGHT = 240;
+
+export const WORKSTATION_AREAS = [
+  "sidebar header files-sidebar",
+  "sidebar tabs files-sidebar",
+  "sidebar canvas files-sidebar",
+  "sidebar terminal files-sidebar",
+  "sidebar composer files-sidebar",
+  "status status status",
+];
 
 function parseWidth(token: string | undefined, fallback: string): string {
   return token && /^\d+px$/.test(token) ? token : fallback;
@@ -113,25 +122,9 @@ export function workstationLayout(
     "minmax(0,1fr)",
     rightVisible ? right : "0px",
   ];
-  const areaCols = ["sidebar", "__center__", "files-sidebar"];
-  const centerIndex = 1;
-
-  const rowFor = (centerName: string) => {
-    const cols = [...areaCols];
-    cols[centerIndex] = centerName;
-    return cols.join(" ");
-  };
-  const statusRow = areaCols.map(() => "status").join(" ");
-
   return {
     columns: parts.join(" "),
-    areas: [
-      rowFor("header"),
-      rowFor("canvas"),
-      rowFor("terminal"),
-      rowFor("composer"),
-      statusRow,
-    ],
+    areas: WORKSTATION_AREAS,
     lastLeftWidth: left,
     lastRightWidth: right,
   };
@@ -152,7 +145,7 @@ export function workstationRows(
   const terminalTrack = terminalOpen
     ? `${Math.max(120, Math.min(720, Math.round(terminalHeight)))}px`
     : "0px";
-  return `38px minmax(0,1fr) ${terminalTrack} auto auto`;
+  return `38px 38px minmax(0,1fr) ${terminalTrack} auto auto`;
 }
 
 /**
@@ -181,6 +174,7 @@ export function useFocus(ctx: UseFocusContext): UseFocusActions {
         layout: {
           ...layout,
           rows: workstationRows(nextOpen, terminalHeightFromState(prev)),
+          areas: WORKSTATION_AREAS,
         },
       };
     });
@@ -256,6 +250,7 @@ export function useFocus(ctx: UseFocusContext): UseFocusActions {
           layout: {
             ...layout,
             rows: workstationRows(true, terminalHeightFromState(prev)),
+            areas: WORKSTATION_AREAS,
           },
         };
       });
@@ -285,6 +280,7 @@ export function useFocus(ctx: UseFocusContext): UseFocusActions {
             layout: {
               ...layout,
               rows: workstationRows(true, terminalHeightFromState(prev)),
+              areas: WORKSTATION_AREAS,
             },
           };
         });

--- a/src/layoutPrefs.test.ts
+++ b/src/layoutPrefs.test.ts
@@ -47,7 +47,6 @@ describe("layoutPrefs", () => {
         columns: "302px minmax(0,1fr) 480px",
         lastLeftWidth: "302px",
         lastRightWidth: "480px",
-        areas: ["header header", "canvas files-sidebar"],
       },
       terminalPanel: { height: 360 },
     });
@@ -86,8 +85,16 @@ describe("layoutPrefs", () => {
     );
     expect(next).toEqual({
       layout: {
-        rows: "38px minmax(0,1fr) 410px auto auto",
+        rows: "38px 38px minmax(0,1fr) 410px auto auto",
         columns: "300px minmax(0,1fr) 500px",
+        areas: [
+          "sidebar header files-sidebar",
+          "sidebar tabs files-sidebar",
+          "sidebar canvas files-sidebar",
+          "sidebar terminal files-sidebar",
+          "sidebar composer files-sidebar",
+          "status status status",
+        ],
       },
       terminal: { open: true },
       terminalPanel: { activeSubId: "agent-bash", height: 410 },
@@ -114,9 +121,17 @@ describe("layoutPrefs", () => {
     expect(next.layout).toEqual(
       expect.objectContaining({
         columns: "220px minmax(0,1fr) 360px",
-        rows: "38px minmax(0,1fr) 0px auto auto",
+        rows: "38px 38px minmax(0,1fr) 0px auto auto",
         sidebarVisible: true,
         filesSidebarVisible: true,
+        areas: [
+          "sidebar header files-sidebar",
+          "sidebar tabs files-sidebar",
+          "sidebar canvas files-sidebar",
+          "sidebar terminal files-sidebar",
+          "sidebar composer files-sidebar",
+          "status status status",
+        ],
       }),
     );
     expect(next.terminalPanel).toEqual({ activeSubId: "agent-bash" });

--- a/src/layoutPrefs.ts
+++ b/src/layoutPrefs.ts
@@ -2,6 +2,7 @@ import {
   readStateWithLocalStorageFallback,
   writeState as writePersistedState,
 } from "./persist";
+import { WORKSTATION_AREAS } from "./hooks/useFocus";
 
 export const LAYOUT_PREFS_FILE = "layout_prefs";
 
@@ -11,7 +12,6 @@ const DEFAULT_RIGHT_WIDTH = "360px";
 const DEFAULT_TERMINAL_HEIGHT = 240;
 const TERMINAL_HEIGHT_MIN = 120;
 const TERMINAL_HEIGHT_MAX = 720;
-
 export interface LayoutPrefs {
   layout?: Record<string, unknown>;
   terminalPanel?: Record<string, unknown>;
@@ -44,14 +44,6 @@ function sanitizeColumns(value: unknown): string | undefined {
     : `${tokens[0]} minmax(0,1fr)`;
 }
 
-function sanitizeAreas(value: unknown): string[] | undefined {
-  if (!Array.isArray(value)) return undefined;
-  const areas = value.filter(
-    (area): area is string => typeof area === "string" && area.trim().length > 0,
-  );
-  return areas.length > 0 ? areas : undefined;
-}
-
 function clampTerminalHeight(value: unknown): number {
   return typeof value === "number" &&
     Number.isFinite(value) &&
@@ -63,7 +55,7 @@ function clampTerminalHeight(value: unknown): number {
 
 function rowsForTerminal(open: unknown, height: unknown): string {
   const track = open === true ? `${clampTerminalHeight(height)}px` : "0px";
-  return `38px minmax(0,1fr) ${track} auto auto`;
+  return `38px 38px minmax(0,1fr) ${track} auto auto`;
 }
 
 export function sanitizeLayoutPrefs(input: unknown): LayoutPrefs | null {
@@ -88,8 +80,6 @@ export function sanitizeLayoutPrefs(input: unknown): LayoutPrefs | null {
     if (isPx(layoutInput.lastRightWidth)) {
       layout.lastRightWidth = layoutInput.lastRightWidth;
     }
-    const areas = sanitizeAreas(layoutInput.areas);
-    if (areas) layout.areas = areas;
     if (Object.keys(layout).length > 0) prefs.layout = layout;
   }
 
@@ -157,6 +147,7 @@ export function mergeLayoutPrefsIntoState(
     layout: {
       ...mergedLayout,
       rows: rowsForTerminal(terminal?.open, mergedTerminalPanel.height),
+      areas: WORKSTATION_AREAS,
     },
     ...(prefs.terminalPanel ? { terminalPanel: mergedTerminalPanel } : {}),
   };
@@ -181,13 +172,7 @@ export function resetLayoutPrefsInState(
       rows: rowsForTerminal(terminal?.open, DEFAULT_TERMINAL_HEIGHT),
       lastLeftWidth: DEFAULT_LEFT_WIDTH,
       lastRightWidth: DEFAULT_RIGHT_WIDTH,
-      areas: [
-        "sidebar header files-sidebar",
-        "sidebar canvas files-sidebar",
-        "sidebar terminal files-sidebar",
-        "sidebar composer files-sidebar",
-        "status status status",
-      ],
+      areas: WORKSTATION_AREAS,
     },
     terminalPanel: terminalRest,
   };

--- a/src/skills/default-layout/layout.test.tsx
+++ b/src/skills/default-layout/layout.test.tsx
@@ -15,9 +15,10 @@ function renderLayout(children: A2UIComponent[]) {
         type: "layout",
         props: {
           columns: "0px minmax(0,1fr) 0px",
-          rows: "38px minmax(0,1fr) 0px auto auto",
+          rows: "38px 38px minmax(0,1fr) 0px auto auto",
           areas: [
             "sidebar header files-sidebar",
+            "sidebar tabs files-sidebar",
             "sidebar canvas files-sidebar",
             "sidebar terminal files-sidebar",
             "sidebar composer files-sidebar",

--- a/src/skills/default-layout/shell/tab-strip.test.tsx
+++ b/src/skills/default-layout/shell/tab-strip.test.tsx
@@ -68,4 +68,19 @@ describe("TabStrip", () => {
     expect(screen.getByText("Tab 1")).toBeTruthy();
     expect(screen.queryByText("Shell 1")).toBeNull();
   });
+
+  it("keeps the new-tab affordance available when no tabs are open", () => {
+    const onEvent = vi.fn<TabStripOnEvent>();
+    render(
+      <TabStrip
+        component={tabStripComponent()}
+        state={{ activeTabId: null, tabs: [] }}
+        onEvent={onEvent}
+      />,
+    );
+
+    expect(screen.queryAllByRole("tab")).toHaveLength(0);
+    fireEvent.click(screen.getByRole("button", { name: "New Tab" }));
+    expect(onEvent).toHaveBeenCalledWith("new");
+  });
 });

--- a/src/skills/default-layout/shell/tab-strip.tsx
+++ b/src/skills/default-layout/shell/tab-strip.tsx
@@ -159,7 +159,7 @@ export function TabStrip({ component, state, onEvent }: BuiltinComponentProps) {
         type="button"
         className="a2ui-tab-new"
         title="New tab (⌘T)"
-        aria-label="New tab"
+        aria-label="New Tab"
         onClick={() => onEvent("new")}
       >
         +

--- a/src/skills/default-layout/sidebar/file-tree.test.tsx
+++ b/src/skills/default-layout/sidebar/file-tree.test.tsx
@@ -266,4 +266,54 @@ describe("FileTreePanel", () => {
       }),
     );
   });
+
+  it("keeps expanded descendants visible when the root listing refreshes", async () => {
+    let fsTreeChangedListener:
+      | ((event: { payload: { root: string; dirs: string[] } }) => void)
+      | undefined;
+    listenMock.mockImplementation((eventName: string, listener) => {
+      if (eventName === "fs-tree-changed") {
+        fsTreeChangedListener = listener as typeof fsTreeChangedListener;
+      }
+      return Promise.resolve(() => {});
+    });
+    invokeMock.mockImplementation((cmd: string, args?: { path?: string }) => {
+      if (cmd !== "fs_list_dir") return Promise.resolve(1);
+      if (args?.path === "/projects/aethon/src") {
+        return Promise.resolve([
+          {
+            name: "App.tsx",
+            path: "/projects/aethon/src/App.tsx",
+            kind: "file",
+          },
+        ]);
+      }
+      return Promise.resolve([
+        { name: "src", path: "/projects/aethon/src", kind: "dir" },
+        {
+          name: "package.json",
+          path: "/projects/aethon/package.json",
+          kind: "file",
+        },
+      ]);
+    });
+
+    render(<FileTreePanel {...panelProps()} />);
+    const srcRow = await waitFor(() => screen.getByText("src"));
+    fireEvent.click(srcRow);
+    await waitFor(() => screen.getByText("App.tsx"));
+
+    act(() => {
+      fsTreeChangedListener?.({
+        payload: { root: "/projects/aethon", dirs: ["/projects/aethon"] },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("App.tsx")).toBeTruthy();
+      expect(
+        screen.getByText("src").closest("li")?.getAttribute("aria-expanded"),
+      ).toBe("true");
+    });
+  });
 });

--- a/src/skills/default-layout/sidebar/file-tree.tsx
+++ b/src/skills/default-layout/sidebar/file-tree.tsx
@@ -93,6 +93,36 @@ function parentDirOf(node: TreeNode): string {
   return slash >= 0 ? node.entry.path.slice(0, slash) : node.entry.path;
 }
 
+function withDepth(node: TreeNode, depth: number): TreeNode {
+  const delta = depth - node.depth;
+  if (delta === 0) return node;
+  const walk = (current: TreeNode): TreeNode => ({
+    ...current,
+    depth: current.depth + delta,
+    children: current.children?.map(walk) ?? current.children,
+  });
+  return walk(node);
+}
+
+function nodesFromEntries(
+  entries: FsEntry[],
+  depth: number,
+  previousChildren?: TreeNode[] | null,
+): TreeNode[] {
+  const previousByPath = new Map(
+    (previousChildren ?? []).map((child) => [child.entry.path, child]),
+  );
+  return entries.map((entry) => {
+    const previous = previousByPath.get(entry.path);
+    if (!previous) return { entry, depth };
+    return {
+      ...withDepth(previous, depth),
+      entry,
+      loadError: undefined,
+    };
+  });
+}
+
 /** Parse the persisted store; tolerate corruption by returning empty. */
 function parseExpandedStore(raw: string): ExpandedStore {
   if (!raw) return { byProject: {} };
@@ -364,7 +394,7 @@ export function FileTreePanel({
             kind: "dir",
           },
           depth: 0,
-          children: entries.map((e) => ({ entry: e, depth: 1 })),
+          children: nodesFromEntries(entries, 1),
         };
         setRoot(rootNode);
         // Hydrate any persisted-expanded folders so the user comes back
@@ -391,10 +421,11 @@ export function FileTreePanel({
                 if (node.entry.path === folderPath) {
                   return {
                     ...node,
-                    children: childEntries.map((e) => ({
-                      entry: e,
-                      depth: node.depth + 1,
-                    })),
+                    children: nodesFromEntries(
+                      childEntries,
+                      node.depth + 1,
+                      node.children,
+                    ),
                   };
                 }
                 if (!node.children) return node;
@@ -426,7 +457,7 @@ export function FileTreePanel({
           root: projectPathRef.current,
           path: node.entry.path,
         });
-        return entries.map((e) => ({ entry: e, depth: node.depth + 1 }));
+        return nodesFromEntries(entries, node.depth + 1, node.children);
       } catch (err) {
         node.loadError = String(err);
         return null;
@@ -553,17 +584,18 @@ export function FileTreePanel({
           if (r.entry.path === folderPath) {
             return {
               ...r,
-              children: entries.map((e) => ({ entry: e, depth: 1 })),
+              children: nodesFromEntries(entries, 1, r.children),
             };
           }
           const walk = (node: TreeNode): TreeNode => {
             if (node.entry.path === folderPath) {
               return {
                 ...node,
-                children: entries.map((e) => ({
-                  entry: e,
-                  depth: node.depth + 1,
-                })),
+                children: nodesFromEntries(
+                  entries,
+                  node.depth + 1,
+                  node.children,
+                ),
               };
             }
             if (!node.children) return node;

--- a/src/skills/default-layout/slots.test.ts
+++ b/src/skills/default-layout/slots.test.ts
@@ -49,17 +49,11 @@ describe("layout-slot catalogue", () => {
 });
 
 describe("inspectLayoutSlotCoverage — built-in layouts", () => {
-  it("workstation fills every canonical slot except `tabs` (hoisted into header)", () => {
+  it("workstation fills every canonical slot", () => {
     const r = inspectLayoutSlotCoverage(workstationPayload);
     expect(r.missingRequired).toEqual([]);
     expect(r.unknownAreasUsed).toEqual([]);
-    // The redesign moves the chrome tab strip into the header container so
-    // only seven of the eight canonical slots are filled. `tabs` is the
-    // missing one — the slot stays canonical, just unused at this layer.
-    // tabs is hoisted into the header container, so it stays canonical
-    // but unfilled at this layer.
-    const expected = [...SLOT_NAMES].filter((s) => s !== "tabs").sort();
-    expect([...r.filledSlots].sort()).toEqual(expected);
+    expect([...r.filledSlots].sort()).toEqual([...SLOT_NAMES].sort());
     // workstation uses {$ref} for `areas` so the inspector tags it.
     expect(r.dynamicAreas).toBe(true);
   });

--- a/src/skills/default-layout/workstation.a2ui.json
+++ b/src/skills/default-layout/workstation.a2ui.json
@@ -23,16 +23,6 @@
           },
           "children": [
             {
-              "id": "header-tabs",
-              "type": "tab-strip",
-              "props": {
-                "visible": { "$ref": "/hasTabs" },
-                "tabs": { "$ref": "/tabs" },
-                "activeId": { "$ref": "/activeTabId" },
-                "inHeader": true
-              }
-            },
-            {
               "id": "header-pill",
               "type": "agent-pulse",
               "props": {
@@ -56,6 +46,16 @@
               "props": {}
             }
           ]
+        },
+        {
+          "id": "header-tabs",
+          "type": "tab-strip",
+          "props": {
+            "area": "tabs",
+            "visible": { "$ref": "/hasTabs" },
+            "tabs": { "$ref": "/tabs" },
+            "activeId": { "$ref": "/activeTabId" }
+          }
         },
         {
           "id": "sidebar-area",
@@ -238,9 +238,10 @@
       "sidebarVisible": true,
       "filesSidebarVisible": true,
       "columns": "220px minmax(0,1fr) 360px",
-      "rows": "38px minmax(0,1fr) 0px auto auto",
+      "rows": "38px 38px minmax(0,1fr) 0px auto auto",
       "areas": [
         "sidebar header files-sidebar",
+        "sidebar tabs files-sidebar",
         "sidebar canvas files-sidebar",
         "sidebar terminal files-sidebar",
         "sidebar composer files-sidebar",

--- a/src/skills/default-layout/workstation.a2ui.json
+++ b/src/skills/default-layout/workstation.a2ui.json
@@ -52,7 +52,6 @@
           "type": "tab-strip",
           "props": {
             "area": "tabs",
-            "visible": { "$ref": "/hasTabs" },
             "tabs": { "$ref": "/tabs" },
             "activeId": { "$ref": "/activeTabId" }
           }

--- a/src/state/sessionUiSnapshot.test.ts
+++ b/src/state/sessionUiSnapshot.test.ts
@@ -49,7 +49,7 @@ describe("sessionUiSnapshot", () => {
       ],
       // Legacy 2-column snapshot upgrades to the new 3-column shape on
       // restore so older sessions still see the right files-sidebar.
-      layout: { sidebarVisible: true, columns: "300px minmax(0,1fr) 280px" },
+      layout: { sidebarVisible: true, columns: "300px minmax(0,1fr) 360px" },
       terminal: { open: true },
       terminalPanel: { activeSubId: "agent-bash", height: 240 },
       projectModels: { "project-1": "anthropic/claude-opus-4-7" },

--- a/src/state/sessionUiSnapshot.ts
+++ b/src/state/sessionUiSnapshot.ts
@@ -88,7 +88,7 @@ function durableLayoutSnapshot(layout: unknown): Record<string, unknown> | undef
         // Legacy snapshot — let the boot payload's default fill in
         // the right column so the redesigned 3-column layout still
         // surfaces on first restore after upgrade.
-        next.columns = `${first} minmax(0,1fr) 280px`;
+        next.columns = `${first} minmax(0,1fr) 360px`;
       }
     }
   }

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -1340,11 +1340,6 @@ body.ae-resizing-sidebar .a2ui-layout {
   max-width: min(46ch, calc(var(--app-viewport-width) - 32px));
 }
 
-.app-header .a2ui-tab-strip {
-  flex: 1 1 24rem;
-  max-width: min(58rem, 58vw);
-}
-
 .app-header .a2ui-dropdown {
   flex-shrink: 0;
 }


### PR DESCRIPTION
## Summary

This patch release branch fixes the workstation tab strip regression and the file tree expansion collapse reported in the app screenshots. It also prepares version 0.3.1 with synced release metadata and changelog notes.

## What changed

- Moved the top tab strip out of the header control row into its own dedicated workstation grid row, so model and appearance controls no longer cover or squeeze tabs.
- Added canonical workstation layout normalization during bridge `ready` hydration, preventing older persisted layout state from auto-placing tabs at the bottom or hiding them.
- Preserved the canonical header / tabs / canvas / terminal / composer / status grid through layout prefs, session restore, sidebar resize, files-sidebar resize, and terminal resize.
- Fixed file-tree refresh merging so expanded directories keep their loaded descendants visible after refresh instead of collapsing immediately.
- Restored right files-sidebar width stability around Monaco/editor tabs and bumped the default/restored right sidebar width to 360px.
- Bumped Aethon to 0.3.1 and updated CHANGELOG links/notes for the patch release.

## Validation

- `bunx tsc --noEmit`
- `bunx vitest run src/hooks/bridgeMessageHandlers/ready.test.ts src/hooks/useFocus.test.ts src/layoutPrefs.test.ts src/state/sessionUiSnapshot.test.ts src/eventRoutes/editor.test.ts src/eventRoutes/sidebar.test.ts src/eventRoutes/terminal.test.ts src/skills/default-layout/sidebar/file-tree.test.tsx src/skills/default-layout/layout.test.tsx src/skills/default-layout/slots.test.ts src/skills/default-layout/shell/tab-strip.test.tsx`
- `bunx vitest run` (137 files, 994 tests)
- `bun run lint` (0 errors; 5 existing react-hooks warnings in unrelated files)
- `bun run version:sync && bun run version:check`

## Release notes

Patch version: `0.3.1`

Changelog now includes the tab strip restoration, stale layout snapshot repair, stable file tree expansion, and files-sidebar resize fix.