### PR TITLE
fix(session): prevent release reload loops

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ concurrency:
 jobs:
   ts:
     name: ts (typecheck + eslint + vitest)
+    env:
+      NODE_OPTIONS: --max-old-space-size=4096
     # macOS for parity with the dev environment + Bun's native target
     # is well-supported here. Linux mirrors the Tauri release target.
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to Aethon. Format loosely follows
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-05-25
+
+### Fixed — Patch release
+
+- **Release reload loop fixed.** Bridge `ready` payloads now include the
+  current project cwd, and frontend hydration only re-announces the active
+  cwd when it differs. This prevents a release-session loop where
+  `ready` handling could repeatedly reload project resources, lag the app,
+  and leave the webview blank until a manual reload.
+- **Tab restore made idempotent.** Ready hydration no longer replays
+  `tab_open` for non-default tabs that the bridge already reported, avoiding
+  duplicate session restore churn after respawns and reloads.
+- **Reload snapshots bounded.** Session UI snapshots now sanitize terminal
+  buffers on load and save, keeping only the latest bounded entries so an
+  oversized saved shell transcript cannot make release recovery sluggish.
+
 ## [0.3.1] - 2026-05-25
 
 ### Fixed — Patch release
@@ -596,7 +612,8 @@ error?: string}>`. Backwards compatible: sync callers ignore the
   "Terminal" + "xterm.js · WebGL" badge).
 - **`SPEC.md` checklist** reconciled with what's actually shipped.
 
-[Unreleased]: https://github.com/utensils/aethon/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/utensils/aethon/compare/v0.3.2...HEAD
+[0.3.2]: https://github.com/utensils/aethon/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/utensils/aethon/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/utensils/aethon/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/utensils/aethon/compare/v0.1.0...v0.2.0

--- a/agent/tab-lifecycle.test.ts
+++ b/agent/tab-lifecycle.test.ts
@@ -249,6 +249,7 @@ describe("emitReady", () => {
     const f = makeFixture({ projectRoot: "/repo/aethon" });
     const rec = fakeRec("anthropic/claude-x");
     rec.id = "tab-1";
+    f.state.currentProjectCwd = "/repo/a";
     f.state.tabs.set("tab-1", rec);
     f.state.tabProjectCwds.set("tab-1", "/repo/a");
 
@@ -257,6 +258,7 @@ describe("emitReady", () => {
     expect(f.sent[0]).toMatchObject({
       type: "ready",
       projectRoot: "/repo/aethon",
+      currentProjectCwd: "/repo/a",
       tabs: [
         {
           id: "tab-1",

--- a/agent/tab-lifecycle.ts
+++ b/agent/tab-lifecycle.ts
@@ -385,6 +385,7 @@ export function emitReady(
     type: "ready",
     model: defaultModelKey(state),
     projectRoot: state.projectRoot,
+    currentProjectCwd: state.currentProjectCwd,
     userDir: state.userDir,
     models: state.cachedModels,
     tabs: [...state.tabs.values()].map((t) => ({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aethon",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aethon",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "dependencies": {
         "@mariozechner/pi-ai": "^0.70.2",
         "@mariozechner/pi-coding-agent": "^0.70.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aethon",
   "private": true,
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aethon"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aethon"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 license = "MIT"
 description = "Pi with a face — agent-driven desktop shell with A2UI"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Aethon",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "identifier": "com.utensils.aethon",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/hooks/bridgeMessageHandlers/ready.test.ts
+++ b/src/hooks/bridgeMessageHandlers/ready.test.ts
@@ -337,6 +337,69 @@ describe("handleReady", () => {
     );
   });
 
+  it("does not re-announce the active project when ready already reports that cwd", () => {
+    const { ctx, mocks } = buildHandlerFixture({
+      state: { activeTabId: "default", tabs: [] },
+    });
+    ctx.projectsRef.current = {
+      activeId: "p1",
+      activeWorktreeId: null,
+      worktreesByProject: {},
+      activeHostId: null,
+      projects: [{ id: "p1", label: "p1", path: "/tmp/p1", lastUsed: 1 }],
+    };
+
+    handleReady(
+      {
+        type: "ready",
+        model: "claude",
+        tabs: [],
+        currentProjectCwd: "/tmp/p1",
+      },
+      ctx,
+    );
+
+    expect(mocks.announceProjectToBridge).not.toHaveBeenCalled();
+  });
+
+  it("re-announces the active worktree cwd, not the project root", () => {
+    const { ctx, mocks } = buildHandlerFixture({
+      state: { activeTabId: "tab-1", tabs: [{ id: "tab-1" }] },
+    });
+    ctx.projectsRef.current = {
+      activeId: "p1",
+      activeWorktreeId: "wt-1",
+      activeHostId: null,
+      projects: [{ id: "p1", label: "p1", path: "/tmp/p1", lastUsed: 1 }],
+      worktreesByProject: {
+        p1: [
+          {
+            id: "wt-1",
+            projectId: "p1",
+            path: "/tmp/p1-fix",
+            branch: "fix/reload",
+            isMain: false,
+          },
+        ],
+      },
+    };
+
+    handleReady(
+      {
+        type: "ready",
+        model: "claude",
+        tabs: [{ id: "tab-1", model: "claude", cwd: "/tmp/other" }],
+        currentProjectCwd: "/tmp/other",
+      },
+      ctx,
+    );
+
+    expect(mocks.announceProjectToBridge).toHaveBeenCalledWith(
+      "tab-1",
+      "/tmp/p1-fix",
+    );
+  });
+
   it("requests transcript replay for non-default open tabs after ready", () => {
     const harness = installTauriMocks();
     const { ctx } = buildHandlerFixture({
@@ -377,6 +440,45 @@ describe("handleReady", () => {
         cwd: "/repo/a",
       }),
     ]);
+  });
+
+  it("does not replay tab_open for non-default tabs already present in bridge ready data", () => {
+    const harness = installTauriMocks();
+    const { ctx } = buildHandlerFixture({
+      state: {
+        activeTabId: "tab-2",
+        tabs: [
+          { id: "default", model: "claude", projectId: "p1" },
+          { id: "tab-2", model: "gpt", projectId: "p1", cwd: "/repo/a" },
+        ],
+      },
+    });
+    ctx.projectsRef.current = {
+      activeId: "p1",
+      activeWorktreeId: null,
+      worktreesByProject: {},
+      activeHostId: null,
+      projects: [{ id: "p1", label: "A", path: "/repo/a", lastUsed: 1 }],
+    };
+
+    handleReady(
+      {
+        type: "ready",
+        model: "claude",
+        currentProjectCwd: "/repo/a",
+        tabs: [
+          { id: "default", model: "claude", cwd: "/repo/a" },
+          { id: "tab-2", model: "gpt", cwd: "/repo/a" },
+        ],
+      },
+      ctx,
+    );
+
+    const tabOpenPayloads = harness.invoke.mock.calls
+      .filter((call) => call[0] === "agent_command")
+      .map((call) => JSON.parse(call[1].payload as string))
+      .filter((payload) => payload.type === "tab_open");
+    expect(tabOpenPayloads).toEqual([]);
   });
 
   it("requests transcript replay for worktree tabs with their tab cwd", () => {

--- a/src/hooks/bridgeMessageHandlers/ready.ts
+++ b/src/hooks/bridgeMessageHandlers/ready.ts
@@ -1,6 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import type { A2UIPayload } from "../../types/a2ui";
-import { activeProject } from "../../projects";
+import { activeCwd, activeProject } from "../../projects";
 import { TAB_MIRROR_KEYS } from "../useTabs";
 import type { Tab } from "../../types/tab";
 import { deepMergeState, layoutPatch } from "../../utils/stateMutation";
@@ -25,7 +25,9 @@ function isWorkstationBootLayout(layout: A2UIPayload): boolean {
   const areas = state?.layout?.areas;
   return (
     Array.isArray(areas) &&
-    areas.some((row) => typeof row === "string" && row.includes("files-sidebar"))
+    areas.some(
+      (row) => typeof row === "string" && row.includes("files-sidebar"),
+    )
   );
 }
 
@@ -67,6 +69,11 @@ export const handleReady: BridgeMessageHandler = (data, ctx) => {
     typeof data.userDir === "string" && data.userDir.length > 0
       ? data.userDir
       : undefined;
+  const currentProjectCwd =
+    typeof data.currentProjectCwd === "string" &&
+    data.currentProjectCwd.length > 0
+      ? data.currentProjectCwd
+      : null;
   // Cache pi's default model so new tabs created before `ready` fires
   // (or before a session's model initialises) can inherit it immediately
   // instead of showing blank "model ▼".
@@ -398,8 +405,12 @@ export const handleReady: BridgeMessageHandler = (data, ctx) => {
   // also restore the tab's previously-selected model so the user
   // doesn't silently send the next prompt to pi's default.
   const localTabs = (ctx.stateRef.current.tabs as Tab[] | undefined) ?? [];
+  const bridgeTabIds = new Set(
+    ((data.tabs as { id: string }[] | undefined) ?? []).map((t) => t.id),
+  );
   for (const t of localTabs) {
     if (t.id === "default") continue;
+    if (bridgeTabIds.has(t.id)) continue;
     // Pass `model` so the new bridge session boots with the same model
     // the user previously selected — no race window. Track in
     // pendingTabOpens so a fast first chat on the restored tab waits
@@ -439,13 +450,14 @@ export const handleReady: BridgeMessageHandler = (data, ctx) => {
   // tab_open for non-default tabs, so when the active tab IS "default"
   // (common: single-tab session) nothing announces. Send an explicit
   // set_project for the active tab so the bridge swaps to the right
-  // project. The bridge short-circuits when cwd matches its
-  // currentProjectCwd so this is harmless on a fresh boot where the
-  // boot effect already announced.
-  const activeProj = activeProject(ctx.projectsRef.current);
-  if (activeProj) {
+  // project. Ready can also be emitted *because* set_project loaded or
+  // refreshed resources, so only announce when the bridge reports a
+  // different cwd. Otherwise a ready -> set_project -> ready loop can
+  // monopolize the release app and blank the webview.
+  const activePath = activeCwd(ctx.projectsRef.current);
+  if (activePath && currentProjectCwd !== activePath) {
     const activeTabId =
       (ctx.stateRef.current.activeTabId as string | undefined) ?? "default";
-    ctx.announceProjectToBridge(activeTabId, activeProj.path);
+    ctx.announceProjectToBridge(activeTabId, activePath);
   }
 };

--- a/src/state/sessionUiSnapshot.test.ts
+++ b/src/state/sessionUiSnapshot.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { makeEmptyTab } from "../types/tab";
 import {
   loadSessionUiSnapshot,
+  parseSessionUiSnapshot,
   saveSessionUiSnapshot,
 } from "./sessionUiSnapshot";
 
@@ -179,5 +180,52 @@ describe("sessionUiSnapshot", () => {
       filesSidebarVisible: false,
       columns: "256px minmax(0,1fr) 0px",
     });
+  });
+
+  it("bounds terminal buffers in reload snapshots", () => {
+    const tab = {
+      ...makeEmptyTab("tab-a", "A"),
+      messages: [{ id: "m1", role: "user" as const, text: "hi" }],
+    };
+    const long = "x".repeat(300 * 1024);
+    saveSessionUiSnapshot({
+      tabs: [tab],
+      activeTabId: "tab-a",
+      terminal: {
+        open: true,
+        buffer: Object.fromEntries(
+          Array.from({ length: 10 }, (_, i) => [`tab-${i}`, `${i}:${long}`]),
+        ),
+      },
+    });
+
+    const restored = loadSessionUiSnapshot();
+    const buffer = (restored?.terminal as { buffer?: Record<string, string> })
+      ?.buffer;
+    expect(Object.keys(buffer ?? {})).toHaveLength(8);
+    expect(buffer?.["tab-9"]).toHaveLength(256 * 1024);
+    expect(buffer?.["tab-0"]).toBeUndefined();
+  });
+
+  it("sanitizes oversized terminal buffers from older disk snapshots on load", () => {
+    const tab = {
+      ...makeEmptyTab("tab-a", "A"),
+      messages: [{ id: "m1", role: "user" as const, text: "hi" }],
+    };
+    const parsed = parseSessionUiSnapshot(
+      JSON.stringify({
+        tabs: [tab],
+        activeTabId: "tab-a",
+        terminal: {
+          open: true,
+          buffer: { "tab-a": "y".repeat(300 * 1024) },
+        },
+        savedAt: 1,
+      }),
+    );
+
+    const buffer = (parsed?.terminal as { buffer?: Record<string, string> })
+      ?.buffer;
+    expect(buffer?.["tab-a"]).toHaveLength(256 * 1024);
   });
 });

--- a/src/state/sessionUiSnapshot.ts
+++ b/src/state/sessionUiSnapshot.ts
@@ -5,6 +5,7 @@ export const SESSION_UI_SNAPSHOT_FILE = "session_ui_snapshot";
 const KEY = "aethon:session-ui-snapshot:v1";
 const MAX_MESSAGES_PER_TAB = 200;
 const MAX_TERMINAL_BUFFER = 256 * 1024;
+const MAX_TERMINAL_BUFFER_ENTRIES = 8;
 
 export interface SessionUiSnapshot {
   activeTabId?: string;
@@ -60,7 +61,9 @@ function shouldPersistTab(tab: Tab): boolean {
   );
 }
 
-function durableLayoutSnapshot(layout: unknown): Record<string, unknown> | undefined {
+function durableLayoutSnapshot(
+  layout: unknown,
+): Record<string, unknown> | undefined {
   if (!layout || typeof layout !== "object") return undefined;
   const input = layout as Record<string, unknown>;
   const next: Record<string, unknown> = {};
@@ -90,6 +93,31 @@ function durableLayoutSnapshot(layout: unknown): Record<string, unknown> | undef
         // surfaces on first restore after upgrade.
         next.columns = `${first} minmax(0,1fr) 360px`;
       }
+    }
+  }
+  return Object.keys(next).length > 0 ? next : undefined;
+}
+
+function durableTerminalSnapshot(
+  terminal: unknown,
+): Record<string, unknown> | undefined {
+  if (!terminal || typeof terminal !== "object") return undefined;
+  const input = terminal as Record<string, unknown>;
+  const next: Record<string, unknown> = {};
+  if (typeof input.open === "boolean") {
+    next.open = input.open;
+  }
+  const buffer = input.buffer;
+  if (buffer && typeof buffer === "object" && !Array.isArray(buffer)) {
+    const entries = Object.entries(buffer as Record<string, unknown>)
+      .filter(
+        (entry): entry is [string, string] =>
+          typeof entry[0] === "string" && typeof entry[1] === "string",
+      )
+      .slice(-MAX_TERMINAL_BUFFER_ENTRIES)
+      .map(([id, value]) => [id, value.slice(-MAX_TERMINAL_BUFFER)]);
+    if (entries.length > 0) {
+      next.buffer = Object.fromEntries(entries);
     }
   }
   return Object.keys(next).length > 0 ? next : undefined;
@@ -147,16 +175,19 @@ export function parseSessionUiSnapshot(raw: string): SessionUiSnapshot | null {
         // pointing at the same file. Validate the shape minimally —
         // `filePath` is the field EditorCanvas actually requires; the
         // rest fall back to safe defaults on the next render.
-        ...(t.kind === "editor" && t.editor && typeof t.editor.filePath === "string"
+        ...(t.kind === "editor" &&
+        t.editor &&
+        typeof t.editor.filePath === "string"
           ? {
               editor: {
                 filePath: t.editor.filePath,
                 ...(typeof t.editor.rootPath === "string" && t.editor.rootPath
                   ? { rootPath: t.editor.rootPath }
                   : {}),
-                language: typeof t.editor.language === "string"
-                  ? t.editor.language
-                  : "plaintext",
+                language:
+                  typeof t.editor.language === "string"
+                    ? t.editor.language
+                    : "plaintext",
                 isDirty: false,
                 ...(typeof t.editor.cursorLine === "number"
                   ? { cursorLine: t.editor.cursorLine }
@@ -170,7 +201,7 @@ export function parseSessionUiSnapshot(raw: string): SessionUiSnapshot | null {
       })),
       activeTabId,
       layout: durableLayoutSnapshot(parsed.layout),
-      terminal: parsed.terminal,
+      terminal: durableTerminalSnapshot(parsed.terminal),
       terminalPanel: parsed.terminalPanel,
       scrollToMatchByTab: parsed.scrollToMatchByTab,
       projectModels:
@@ -210,7 +241,7 @@ export function serializeSessionUiSnapshot(
       tabs,
       activeTabId,
       layout: durableLayoutSnapshot(state.layout),
-      terminal: state.terminal,
+      terminal: durableTerminalSnapshot(state.terminal),
       terminalPanel: state.terminalPanel,
       scrollToMatchByTab: state.scrollToMatchByTab,
       projectModels:


### PR DESCRIPTION
## Summary

This patch release fixes the release-build blank/lag loop observed after sending a GitHub issue to an agent. The bridge now reports its current project cwd in `ready` payloads, and the frontend only re-announces the active cwd when it actually differs. Ready hydration also stops replaying `tab_open` for tabs the bridge already reported, making restore idempotent after respawn/reload.

The patch also bounds persisted terminal buffers on both load and save so an oversized session UI snapshot cannot make release recovery sluggish.

## Release

- Bumps Aethon from `0.3.1` to `0.3.2`.
- Updates `CHANGELOG.md` with the patch release notes and compare links.
- Runs `bun run version:sync` so `package-lock.json`, Tauri config, `Cargo.toml`, and `Cargo.lock` stay in sync with `package.json`.

## Validation

- `bunx vitest run src/state/sessionUiSnapshot.test.ts src/hooks/bridgeMessageHandlers/ready.test.ts agent/tab-lifecycle.test.ts`
- `bunx tsc --noEmit`
- `bunx prettier --check agent/tab-lifecycle.ts agent/tab-lifecycle.test.ts src/hooks/bridgeMessageHandlers/ready.ts src/hooks/bridgeMessageHandlers/ready.test.ts src/state/sessionUiSnapshot.ts src/state/sessionUiSnapshot.test.ts`
- `bun run version:check`
- `check`
