### PR TITLE
fix(tasks): launch issue agents in created worktree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to Aethon. Format loosely follows
 
 ## [Unreleased]
 
+### Fixed
+
+- **Issue worktree task launches.** GitHub issue send-to-agent now targets
+  the newly-created task tab explicitly when forwarding the issue prompt,
+  so the first agent session starts in the fresh worktree and the sent
+  prompt appears in that tab's transcript instead of leaking to the main
+  project context.
+
 ## [0.3.2] - 2026-05-25
 
 ### Fixed — Patch release

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -767,7 +767,7 @@ export default function App() {
         }
       }
       const trimmed = opts.prompt.trim();
-      if (trimmed) await sendChat(trimmed);
+      if (trimmed) await sendChat(trimmed, { tabId });
     },
     [
       activateWorktree,

--- a/src/hooks/useChat.test.ts
+++ b/src/hooks/useChat.test.ts
@@ -106,6 +106,40 @@ describe("useChat setModel", () => {
     });
   });
 
+  it("can send a programmatic prompt to an explicit non-active tab", async () => {
+    const mainTab = { ...makeEmptyTab("main-tab", "Main"), projectId: "p1" };
+    const issueTab = {
+      ...makeEmptyTab("issue-tab", "Issue #86"),
+      projectId: "p1",
+      cwd: "/projects/aethon-fix-86",
+    };
+    const { ctx, stateRef } = buildContext({
+      activeTabId: "main-tab",
+      tabs: [mainTab, issueTab],
+    });
+    const { result } = renderHook(() => useChat(ctx));
+
+    await act(async () => {
+      await result.current.sendChat("work on issue", { tabId: "issue-tab" });
+    });
+
+    expect(invoke).toHaveBeenCalledWith("send_message", {
+      message: "work on issue",
+      tabId: "issue-tab",
+      mode: "normal",
+    });
+    const tabs = stateRef.current.tabs as Tab[];
+    expect(tabs.find((t) => t.id === "main-tab")?.messages).toEqual([]);
+    expect(
+      tabs.find((t) => t.id === "issue-tab")?.messages.at(-1),
+    ).toMatchObject({
+      role: "user",
+      text: "work on issue",
+      delivery: "sent",
+    });
+    expect(tabs.find((t) => t.id === "issue-tab")?.waiting).toBe(true);
+  });
+
   it("marks normal messages as queued while the active prompt is busy", async () => {
     const { ctx, stateRef } = buildContext({ waiting: true });
     const { result } = renderHook(() => useChat(ctx));

--- a/src/hooks/useChat.test.ts
+++ b/src/hooks/useChat.test.ts
@@ -115,6 +115,7 @@ describe("useChat setModel", () => {
     };
     const { ctx, stateRef } = buildContext({
       activeTabId: "main-tab",
+      status: "ready",
       tabs: [mainTab, issueTab],
     });
     const { result } = renderHook(() => useChat(ctx));
@@ -138,6 +139,40 @@ describe("useChat setModel", () => {
       delivery: "sent",
     });
     expect(tabs.find((t) => t.id === "issue-tab")?.waiting).toBe(true);
+    expect(stateRef.current.status).toBe("ready");
+  });
+
+  it("passes explicit non-active slash commands through to the target agent", async () => {
+    const run = vi.fn();
+    const mainTab = { ...makeEmptyTab("main-tab", "Main"), projectId: "p1" };
+    const issueTab = { ...makeEmptyTab("issue-tab", "Issue"), projectId: "p1" };
+    const { ctx, stateRef } = buildContext({
+      activeTabId: "main-tab",
+      tabs: [mainTab, issueTab],
+    });
+    ctx.slashCommandsRef.current = [
+      { name: "clear", description: "Clear chat", run },
+    ];
+    const { result } = renderHook(() => useChat(ctx));
+
+    await act(async () => {
+      await result.current.sendChat("/clear", { tabId: "issue-tab" });
+    });
+
+    expect(run).not.toHaveBeenCalled();
+    expect(invoke).toHaveBeenCalledWith("send_message", {
+      message: "/clear",
+      tabId: "issue-tab",
+      mode: "normal",
+    });
+    const tabs = stateRef.current.tabs as Tab[];
+    expect(tabs.find((t) => t.id === "main-tab")?.messages).toEqual([]);
+    expect(
+      tabs.find((t) => t.id === "issue-tab")?.messages.at(-1),
+    ).toMatchObject({
+      role: "user",
+      text: "/clear",
+    });
   });
 
   it("marks normal messages as queued while the active prompt is busy", async () => {

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -61,7 +61,7 @@ export interface UseChatActions {
   clearChat: () => void;
   sendChat: (
     text: string,
-    options?: { mode?: "normal" | "steer" },
+    options?: { mode?: "normal" | "steer"; tabId?: string },
   ) => Promise<void>;
   setModel: (id: string) => Promise<void>;
   stopPrompt: (explicitTabId?: string) => Promise<void>;
@@ -220,7 +220,7 @@ export function useChat(ctx: UseChatContext): UseChatActions {
 
   async function sendChat(
     text: string,
-    options?: { mode?: "normal" | "steer" },
+    options?: { mode?: "normal" | "steer"; tabId?: string },
   ) {
     const trimmed = text.trim();
     if (!trimmed) return;
@@ -234,7 +234,9 @@ export function useChat(ctx: UseChatContext): UseChatActions {
       const cmd = slashCommandsRef.current.find((c) => c.name === parsed.name);
       if (cmd && !cmd.passthroughToAgent) {
         const slashTabId =
-          (stateRef.current.activeTabId as string | undefined) ?? "default";
+          options?.tabId ??
+          (stateRef.current.activeTabId as string | undefined) ??
+          "default";
         const slashUserMessage = {
           id: crypto.randomUUID(),
           role: "user" as const,
@@ -242,11 +244,13 @@ export function useChat(ctx: UseChatContext): UseChatActions {
         };
         appendMessage(slashUserMessage, slashTabId);
         persistLocalChatMessage(slashUserMessage, slashTabId);
-        // Clear via updateActiveTab — without this, the active tab's
-        // draft still holds the slash text and any subsequent mirror
-        // (clearChat, theme switch, …) writes it back into root.draft,
-        // making the input "stick".
-        updateActiveTab((tab) => ({ ...tab, draft: "" }));
+        // Clear the target tab's draft — without this, the draft still
+        // holds the slash text and any subsequent mirror (clearChat,
+        // theme switch, …) writes it back into root.draft, making the
+        // input "stick". `tabId` is explicit for programmatic launches
+        // that should not depend on whatever tab is active by the time
+        // this async path runs.
+        updateTab(slashTabId, (tab) => ({ ...tab, draft: "" }));
         try {
           await cmd.run(parsed.args, slashContext());
         } catch (err) {
@@ -261,8 +265,17 @@ export function useChat(ctx: UseChatContext): UseChatActions {
     const sendText = trimmed.startsWith("//") ? trimmed.slice(1) : trimmed;
     const mode = options?.mode === "steer" ? "steer" : "normal";
     const tabId =
-      (stateRef.current.activeTabId as string | undefined) ?? "default";
-    const wasBusy = stateRef.current.waiting === true;
+      options?.tabId ??
+      (stateRef.current.activeTabId as string | undefined) ??
+      "default";
+    const activeTabId = stateRef.current.activeTabId as string | undefined;
+    const targetTab = ((stateRef.current.tabs as Tab[] | undefined) ?? []).find(
+      (tab) => tab.id === tabId,
+    );
+    const wasBusy =
+      targetTab?.waiting === true ||
+      ((targetTab === undefined || tabId === activeTabId) &&
+        stateRef.current.waiting === true);
     const delivery: ChatMessage["delivery"] =
       mode === "steer" && wasBusy
         ? "steered"

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -225,6 +225,9 @@ export function useChat(ctx: UseChatContext): UseChatActions {
     const trimmed = text.trim();
     if (!trimmed) return;
 
+    const activeTabId = stateRef.current.activeTabId as string | undefined;
+    const explicitTabId = options?.tabId;
+
     // Client-side slash commands handle UI-only actions (clear, theme, etc.).
     // Unknown slash commands fall through to the agent so pi's own slash
     // command handling and any prompt-template / skill commands still reach
@@ -232,11 +235,13 @@ export function useChat(ctx: UseChatContext): UseChatActions {
     const parsed = parseSlashCommand(trimmed);
     if (parsed) {
       const cmd = slashCommandsRef.current.find((c) => c.name === parsed.name);
-      if (cmd && !cmd.passthroughToAgent) {
-        const slashTabId =
-          options?.tabId ??
-          (stateRef.current.activeTabId as string | undefined) ??
-          "default";
+      // Client slash contexts are active-tab oriented today. If a caller
+      // explicitly targets a different tab, do not echo into that tab while
+      // mutating the active one; pass the slash through to the target agent
+      // instead. Active-tab sends keep the existing local-command behavior.
+      const canRunLocalSlash = !explicitTabId || explicitTabId === activeTabId;
+      if (cmd && !cmd.passthroughToAgent && canRunLocalSlash) {
+        const slashTabId = activeTabId ?? "default";
         const slashUserMessage = {
           id: crypto.randomUUID(),
           role: "user" as const,
@@ -244,13 +249,11 @@ export function useChat(ctx: UseChatContext): UseChatActions {
         };
         appendMessage(slashUserMessage, slashTabId);
         persistLocalChatMessage(slashUserMessage, slashTabId);
-        // Clear the target tab's draft — without this, the draft still
-        // holds the slash text and any subsequent mirror (clearChat,
-        // theme switch, …) writes it back into root.draft, making the
-        // input "stick". `tabId` is explicit for programmatic launches
-        // that should not depend on whatever tab is active by the time
-        // this async path runs.
-        updateTab(slashTabId, (tab) => ({ ...tab, draft: "" }));
+        // Clear via updateActiveTab — without this, the active tab's
+        // draft still holds the slash text and any subsequent mirror
+        // (clearChat, theme switch, …) writes it back into root.draft,
+        // making the input "stick".
+        updateActiveTab((tab) => ({ ...tab, draft: "" }));
         try {
           await cmd.run(parsed.args, slashContext());
         } catch (err) {
@@ -258,17 +261,14 @@ export function useChat(ctx: UseChatContext): UseChatActions {
         }
         return;
       }
-      // Unknown — fall through to send_message. Pi's own command handling on
-      // the agent side may pick it up; if not, the LLM sees the literal text.
+      // Unknown or explicitly non-active target — fall through to
+      // send_message. Pi's own command handling on the agent side may pick it
+      // up; if not, the LLM sees the literal text.
     }
 
     const sendText = trimmed.startsWith("//") ? trimmed.slice(1) : trimmed;
     const mode = options?.mode === "steer" ? "steer" : "normal";
-    const tabId =
-      options?.tabId ??
-      (stateRef.current.activeTabId as string | undefined) ??
-      "default";
-    const activeTabId = stateRef.current.activeTabId as string | undefined;
+    const tabId = explicitTabId ?? activeTabId ?? "default";
     const targetTab = ((stateRef.current.tabs as Tab[] | undefined) ?? []).find(
       (tab) => tab.id === tabId,
     );
@@ -288,11 +288,15 @@ export function useChat(ctx: UseChatContext): UseChatActions {
       tabId,
     );
     updateTab(tabId, (tab) => ({ ...tab, draft: "", waiting: true }));
-    setState((prev) => ({
-      ...prev,
-      status: "thinking…",
-      connection: "connected",
-    }));
+    setState((prev) =>
+      prev.activeTabId === tabId
+        ? {
+            ...prev,
+            status: "thinking…",
+            connection: "connected",
+          }
+        : prev,
+    );
 
     // Wait for any pending tab_open on this tab to land first so the
     // bridge has the right initial model before the chat creates the


### PR DESCRIPTION
## Summary
- route dashboard/issue task launch prompts to the newly-created tab by explicit tab id instead of relying on whichever tab is active after async worktree creation
- keep the issue prompt visible in the target tab transcript and send the bridge `send_message` payload with that tab id
- add coverage for programmatic sends to a non-active tab and document the fix in the changelog

## Verification
- `bun run test src/hooks/useChat.test.ts`
- `bun run typecheck`
- `bun run test`
- `bun run lint` (passes with existing react-hooks/set-state-in-effect warnings)

Closes #86