### PR TITLE
feat: queued-messages popover + inline extension toggle + 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,18 +23,21 @@ All notable changes to Aethon. Format loosely follows
   consistency. Failed-to-load extensions render the switch in a muted
   disabled state.
 - **Extension origin always visible + grouped.** The sidebar's
-  extensions list now sorts entries by origin (project-scoped first,
-  then user-scoped, then npm packages), alphabetical within each
-  group. Disabled rows preserve their origin label (`project ·
-  disabled` instead of just `disabled`) so the user can tell at a
-  glance which scope an extension came from even when every row is
-  toggled off. The auto-injected EXTENSIONS section now splits into
-  per-origin sub-sections — each appears with a qualified title
-  (`extensions · project`, `extensions · user`,
-  `extensions · package`) acting as a visual divider, and empty
-  buckets hide. When only one bucket has entries, the title
-  collapses back to a bare `extensions` so the sidebar reads
-  cleanly in single-scope projects.
+  extensions list now splits into two per-origin sub-sections
+  (`project extensions`, `user extensions`) that act as visible
+  dividers; empty buckets hide. Project-scoped npm packages
+  (`@<project>/<ext>` where the scope matches the active project's
+  basename) fold INTO the project bucket, while unrelated-scope or
+  bare-name packages stay in the user bucket — so `@mold/image-
+  gallery-ui` reads as a project extension under `mold`, but
+  `@brink/current-context-widget` stays user-level. Rows are sorted
+  alphabetically within each group, and each row's hint (`project ·
+  disabled`, `user · disabled`) preserves origin even when toggled
+  off. The group title is always qualified — single-bucket states
+  still read `user extensions` rather than a bare `extensions`, so
+  scope is never ambiguous. Auto-injection skips when an extensions
+  section is declared explicitly in layout JSON, preserving the
+  override path for skills that ship custom rendering.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ All notable changes to Aethon. Format loosely follows
 
 ## [Unreleased]
 
+### Fixed
+
+- **Extension watcher follows cross-project worktree activation (peer-review P2).**
+  `activateWorktree` previously changed `activeId` directly when the
+  selected worktree belonged to a different project, bypassing the
+  unwatch/watch swap that `setActiveProjectById` does. The previous
+  project's `.aethon/extensions/` watcher kept firing while the new
+  project's never installed, so hot-reload silently broke until a
+  later full project switch. The swap is now mirrored in
+  `activateWorktree` whenever the active project id changes.
+- **Restored sessions preserve in-flight messages chronologically (peer-review P2).**
+  `handleSessionHistory`'s merge prepended pending local user prompts
+  ABOVE the restored transcript and dropped any in-flight assistant
+  streaming deltas entirely (the role filter only kept user messages).
+  Restored transcript now lands first, with pending local messages —
+  user prompts AND streaming assistant bubbles — appended after, so
+  ordering stays chronological and live output isn't wiped mid-stream.
+
 ## [0.3.3] - 2026-05-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,29 @@ All notable changes to Aethon. Format loosely follows
   button inside the settings panel's Extensions list for visual
   consistency. Failed-to-load extensions render the switch in a muted
   disabled state.
+- **Extension origin always visible + grouped.** The sidebar's
+  extensions list now sorts entries by origin (project-scoped first,
+  then user-scoped, then npm packages), alphabetical within each
+  group. Disabled rows preserve their origin label (`project ·
+  disabled` instead of just `disabled`) so the user can tell at a
+  glance which scope an extension came from even when every row is
+  toggled off.
+
+### Fixed
+
+- **Queue auto-drain reaches the bridge (peer-review P1).** The
+  optimistic `waiting=true` write inside `useQueuedDispatch` was
+  synchronously visible to `sendChat`, which treated the freshly
+  popped message as a new busy-state submit and re-queued it with a
+  new id, never invoking `send_message`. The drain now pops the head
+  only and lets `sendChat`'s normal-dispatch path flip `waiting` —
+  pop + dispatch setStates batch into one commit so there's still no
+  Send-button flash. Regression test added.
+- **Stop clears the client queue (peer-review P2).** `stopPrompt`
+  now empties the per-tab `queuedMessages` array before sending the
+  bridge `stop` command, so a user who hits the composer's
+  "Stop + clear" button actually clears the queue instead of letting
+  the next queued message drain on the following idle.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,13 @@ All notable changes to Aethon. Format loosely follows
   section is declared explicitly in layout JSON, preserving the
   override path for skills that ship custom rendering.
 
+### Changed
+
+- **`response_end` no longer preserves `waiting` for queued sends.** Pi's
+  `followUp` queue is unused on the new client-held queue path; clearing
+  `waiting` on every turn end is what lets `useQueuedDispatch` see the
+  idle moment and pop the next message.
+
 ### Fixed
 
 - **Queue auto-drain reaches the bridge (peer-review P1).** The
@@ -74,16 +81,6 @@ All notable changes to Aethon. Format loosely follows
   bridge `stop` command, so a user who hits the composer's
   "Stop + clear" button actually clears the queue instead of letting
   the next queued message drain on the following idle.
-
-### Changed
-
-- **`response_end` no longer preserves `waiting` for queued sends.** Pi's
-  `followUp` queue is unused on the new client-held queue path; clearing
-  `waiting` on every turn end is what lets `useQueuedDispatch` see the
-  idle moment and pop the next message.
-
-### Fixed
-
 - **Issue worktree task launches.** GitHub issue send-to-agent now targets
   the newly-created task tab explicitly when forwarding the issue prompt,
   so the first agent session starts in the fresh worktree and the sent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ All notable changes to Aethon. Format loosely follows
   the header offers `Clear queue`, and a new `useQueuedDispatch` hook
   drains the head on every idle transition. Cmd/Ctrl+Enter on the composer
   still ships the current draft as a mid-turn steer.
+- **Inline extension toggle.** Each row in the sidebar's `extensions`
+  section now renders a pill-shaped toggle switch — flip an extension
+  on or off in one click without diving into the right-click menu or
+  the settings panel. The same toggle replaces the Enable/Disable text
+  button inside the settings panel's Extensions list for visual
+  consistency. Failed-to-load extensions render the switch in a muted
+  disabled state.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to Aethon. Format loosely follows
 
 ## [Unreleased]
 
+### Added
+
+- **Queued messages popover + steering (Claudette-style).** Messages typed
+  into the composer while the agent is busy now go to a client-held queue
+  rendered as a popover above the textarea instead of straight to pi's
+  `followUp`. Each queued row carries Edit / Steer / Delete affordances,
+  the header offers `Clear queue`, and a new `useQueuedDispatch` hook
+  drains the head on every idle transition. Cmd/Ctrl+Enter on the composer
+  still ships the current draft as a mid-turn steer.
+
+### Changed
+
+- **`response_end` no longer preserves `waiting` for queued sends.** Pi's
+  `followUp` queue is unused on the new client-held queue path; clearing
+  `waiting` on every turn end is what lets `useQueuedDispatch` see the
+  idle moment and pop the next message.
+
 ### Fixed
 
 - **Issue worktree task launches.** GitHub issue send-to-agent now targets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to Aethon. Format loosely follows
 
 ## [Unreleased]
 
+## [0.3.3] - 2026-05-25
+
 ### Added
 
 - **Queued messages popover + steering (Claudette-style).** Messages typed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,13 @@ All notable changes to Aethon. Format loosely follows
   group. Disabled rows preserve their origin label (`project ·
   disabled` instead of just `disabled`) so the user can tell at a
   glance which scope an extension came from even when every row is
-  toggled off.
+  toggled off. The auto-injected EXTENSIONS section now splits into
+  per-origin sub-sections — each appears with a qualified title
+  (`extensions · project`, `extensions · user`,
+  `extensions · package`) acting as a visual divider, and empty
+  buckets hide. When only one bucket has entries, the title
+  collapses back to a bare `extensions` so the sidebar reads
+  cleanly in single-scope projects.
 
 ### Fixed
 

--- a/agent/dispatcher.ts
+++ b/agent/dispatcher.ts
@@ -258,6 +258,7 @@ export interface InboundMessage {
   type: string;
   content?: string;
   mode?: "normal" | "steer";
+  cwd?: string;
   name?: string;
   args?: string;
   id?: string;
@@ -432,7 +433,14 @@ export async function handleChat(
     return;
   }
   const tabId = msg.tabId ?? "default";
-  const tab = await ensureTab(state, deps, tabId);
+  const cwdOverride =
+    typeof msg.cwd === "string" && msg.cwd.length > 0 ? msg.cwd : undefined;
+  const tab = await ensureTab(
+    state,
+    deps,
+    tabId,
+    cwdOverride ? { cwdOverride } : {},
+  );
   const wantsSteer = msg.mode === "steer";
   if (wantsSteer && tab.promptInFlight) {
     state.currentAgentTabId = tabId;
@@ -1292,6 +1300,7 @@ export async function runDispatcher(
     const record = payload as Record<string, unknown>;
     const role = record.role;
     const text = record.text;
+    const thinking = record.thinking;
     if (role !== "user" && role !== "agent" && role !== "system") {
       deps.send({
         type: "notice",
@@ -1300,11 +1309,13 @@ export async function runDispatcher(
       });
       return;
     }
-    if (typeof text !== "string" || text.length === 0) {
+    const hasText = typeof text === "string" && text.length > 0;
+    const hasThinking = typeof thinking === "string" && thinking.length > 0;
+    if (!hasText && !hasThinking) {
       deps.send({
         type: "notice",
         tabId,
-        message: "local_chat_message: empty text",
+        message: "local_chat_message: empty message",
       });
       return;
     }
@@ -1320,7 +1331,8 @@ export async function runDispatcher(
             ? record.id
             : randomUUID(),
         role,
-        text,
+        ...(hasText ? { text } : {}),
+        ...(hasThinking ? { thinking } : {}),
         ...(localCwd ? { cwd: localCwd } : {}),
         ...(typeof record.createdAt === "number"
           ? { createdAt: record.createdAt }

--- a/agent/session-history.test.ts
+++ b/agent/session-history.test.ts
@@ -53,10 +53,10 @@ describe("parseSessionHistoryLines", () => {
       }),
       JSON.stringify({
         type: "message",
-        id: "tool-1",
+        id: "empty",
         message: {
-          role: "toolResult",
-          content: [{ type: "text", text: "tool output" }],
+          role: "assistant",
+          content: [],
         },
       }),
       "not-json",
@@ -64,7 +64,162 @@ describe("parseSessionHistoryLines", () => {
 
     expect(parseSessionHistoryLines(lines)).toEqual([
       { id: "u1", role: "user", text: "hello" },
-      { id: "a1", role: "agent", text: "Hi there." },
+      {
+        id: "a1",
+        role: "agent",
+        text: "Hi there.",
+        thinking: "hidden reasoning",
+      },
+    ]);
+  });
+
+  it("restores completed tool calls as stable tool-card messages", () => {
+    const lines = [
+      JSON.stringify({
+        type: "message",
+        id: "assistant-tool",
+        message: {
+          role: "assistant",
+          timestamp: 1_000,
+          content: [
+            {
+              type: "toolCall",
+              id: "call-read-1",
+              name: "read",
+              arguments: { path: "src/App.tsx" },
+            },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: "message",
+        id: "result-tool",
+        message: {
+          role: "toolResult",
+          toolCallId: "call-read-1",
+          toolName: "read",
+          content: [{ type: "text", text: "export function App() {}" }],
+          isError: false,
+          timestamp: 2_500,
+        },
+      }),
+    ];
+
+    expect(parseSessionHistoryLines(lines)).toEqual([
+      {
+        id: "restored-tool-call-read-1",
+        role: "agent",
+        a2ui: {
+          components: [
+            {
+              id: "restored-tool-call-read-1",
+              type: "tool-card",
+              props: {
+                title: "read",
+                toolName: "read",
+                description: "src/App.tsx",
+                startedAt: 1_000,
+                endedAt: 2_500,
+              },
+              children: [
+                {
+                  id: "restored-tool-call-read-1-result",
+                  type: "code",
+                  props: {
+                    content: "export function App() {}",
+                    language: "tsx",
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ]);
+  });
+
+  it("preserves failed tool result state when restoring tool cards", () => {
+    const restored = parseSessionHistoryLines([
+      JSON.stringify({
+        type: "message",
+        id: "assistant-tool",
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "call-bash-1",
+              name: "bash",
+              arguments: { command: "false" },
+            },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: "message",
+        id: "result-tool",
+        message: {
+          role: "toolResult",
+          toolCallId: "call-bash-1",
+          toolName: "bash",
+          content: [{ type: "text", text: "Command failed" }],
+          isError: true,
+        },
+      }),
+    ]);
+
+    expect(restored).toHaveLength(1);
+    expect(restored[0].a2ui?.components[0]).toMatchObject({
+      type: "tool-card",
+      props: {
+        title: "bash",
+        toolName: "bash",
+        description: "false",
+        isError: true,
+      },
+    });
+  });
+
+  it("keeps unmatched historical tool calls visible while waiting for a result", () => {
+    const restored = parseSessionHistoryLines([
+      JSON.stringify({
+        type: "message",
+        id: "assistant-tool",
+        message: {
+          role: "assistant",
+          timestamp: 7_000,
+          content: [
+            {
+              type: "toolCall",
+              id: "call-grep-1",
+              name: "grep",
+              arguments: { pattern: "needle", path: "src" },
+            },
+          ],
+        },
+      }),
+    ]);
+
+    expect(restored).toEqual([
+      {
+        id: "restored-tool-call-grep-1",
+        role: "agent",
+        a2ui: {
+          components: [
+            {
+              id: "restored-tool-call-grep-1",
+              type: "tool-card",
+              props: {
+                title: "grep",
+                toolName: "grep",
+                description: "needle in src",
+                startedAt: 7_000,
+              },
+              children: [],
+            },
+          ],
+        },
+      },
     ]);
   });
 

--- a/agent/session-history.test.ts
+++ b/agent/session-history.test.ts
@@ -151,6 +151,67 @@ describe("readSessionTranscript", () => {
     ]);
   });
 
+  it("does not duplicate local prompt snapshots already present in pi history", async () => {
+    const dir = await tempRoot();
+    const path = join(dir, "session.jsonl");
+    await writeFile(
+      path,
+      `${JSON.stringify({
+        type: "message",
+        id: "pi-user",
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "Please work on issue 85" }],
+        },
+      })}\n${JSON.stringify({
+        type: "message",
+        id: "pi-agent",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Working on it" }],
+        },
+      })}\n`,
+    );
+    await appendLocalChatMessage(dir, {
+      id: "local-user",
+      role: "user",
+      text: "Please work on issue 85",
+      createdAt: 1,
+    });
+
+    await expect(readSessionTranscript(dir)).resolves.toEqual([
+      { id: "pi-user", role: "user", text: "Please work on issue 85" },
+      { id: "pi-agent", role: "agent", text: "Working on it" },
+    ]);
+  });
+
+  it("keeps the latest local assistant snapshot for stopped turns", async () => {
+    const dir = await tempRoot();
+    await appendLocalChatMessage(dir, {
+      id: "agent-live",
+      role: "agent",
+      thinking: "Inspecting",
+      createdAt: 1,
+    });
+    await appendLocalChatMessage(dir, {
+      id: "agent-live",
+      role: "agent",
+      thinking: "Inspecting\nReading files",
+      text: "Partial answer",
+      createdAt: 2,
+    });
+
+    await expect(readSessionTranscript(dir)).resolves.toEqual([
+      {
+        id: "agent-live",
+        role: "agent",
+        thinking: "Inspecting\nReading files",
+        text: "Partial answer",
+        createdAt: 2,
+      },
+    ]);
+  });
+
   it("bounds the Aethon-local slash command overlay on append", async () => {
     const dir = await tempRoot();
     await writeFile(

--- a/agent/session-history.ts
+++ b/agent/session-history.ts
@@ -9,6 +9,7 @@ import {
   writeFile,
 } from "node:fs/promises";
 import { join } from "node:path";
+import { summarizeToolArgs, toolCardPayload } from "./tool-card";
 
 const LABEL_FILE = "label.txt";
 const LOCAL_CHAT_FILE = "aethon-chat.jsonl";
@@ -68,6 +69,7 @@ export interface RestoredChatMessage {
   role: "user" | "agent" | "system";
   text?: string;
   thinking?: string;
+  a2ui?: { components: unknown[] };
   createdAt?: number;
   cwd?: string;
 }
@@ -108,6 +110,25 @@ function textFromContent(content: unknown): string {
   return chunks.join("\n").trim();
 }
 
+function thinkingFromContent(content: unknown): string {
+  if (!Array.isArray(content)) return "";
+
+  const chunks: string[] = [];
+  for (const part of content) {
+    if (!part || typeof part !== "object") continue;
+    const record = part as Record<string, unknown>;
+    if (record.type === "thinking" && typeof record.thinking === "string") {
+      chunks.push(record.thinking);
+    } else if (
+      (record.type === "thinking" || record.type === "reasoning") &&
+      typeof record.text === "string"
+    ) {
+      chunks.push(record.text);
+    }
+  }
+  return chunks.join("\n").trim();
+}
+
 function trimText(text: string): string {
   return text.length > MAX_TEXT_CHARS
     ? `${text.slice(0, MAX_TEXT_CHARS - 3)}...`
@@ -118,6 +139,14 @@ function isChatRole(role: unknown): role is RestoredChatMessage["role"] {
   return role === "user" || role === "agent" || role === "system";
 }
 
+function hasA2ui(value: unknown): value is { components: unknown[] } {
+  return (
+    Boolean(value) &&
+    typeof value === "object" &&
+    Array.isArray((value as { components?: unknown }).components)
+  );
+}
+
 export async function appendLocalChatMessage(
   sessionDir: string,
   message: RestoredChatMessage,
@@ -126,7 +155,8 @@ export async function appendLocalChatMessage(
   const text = typeof message.text === "string" ? trimText(message.text) : "";
   const thinking =
     typeof message.thinking === "string" ? trimText(message.thinking) : "";
-  if (!text && !thinking) return;
+  const a2ui = hasA2ui(message.a2ui) ? message.a2ui : undefined;
+  if (!text && !thinking && !a2ui) return;
   await mkdir(sessionDir, { recursive: true });
   const entry = {
     type: "aethon_chat",
@@ -134,6 +164,7 @@ export async function appendLocalChatMessage(
     role: message.role,
     ...(text ? { text } : {}),
     ...(thinking ? { thinking } : {}),
+    ...(a2ui ? { a2ui } : {}),
     createdAt:
       typeof message.createdAt === "number" && Number.isFinite(message.createdAt)
         ? message.createdAt
@@ -181,7 +212,8 @@ function parseLocalChatLines(
     const text = typeof record.text === "string" ? trimText(record.text) : "";
     const thinking =
       typeof record.thinking === "string" ? trimText(record.thinking) : "";
-    if (!text && !thinking) continue;
+    const a2ui = hasA2ui(record.a2ui) ? record.a2ui : undefined;
+    if (!text && !thinking && !a2ui) continue;
     const id =
       typeof record.id === "string" && record.id.length > 0
         ? record.id
@@ -191,6 +223,7 @@ function parseLocalChatLines(
       role: record.role,
       ...(text ? { text } : {}),
       ...(thinking ? { thinking } : {}),
+      ...(a2ui ? { a2ui } : {}),
       ...(typeof record.createdAt === "number"
         ? { createdAt: record.createdAt }
         : {}),
@@ -234,6 +267,7 @@ async function pruneLocalChatFile(path: string): Promise<void> {
           role: m.role,
           ...(m.text ? { text: m.text } : {}),
           ...(m.thinking ? { thinking: m.thinking } : {}),
+          ...(m.a2ui ? { a2ui: m.a2ui } : {}),
           ...(typeof m.createdAt === "number" ? { createdAt: m.createdAt } : {}),
           ...(m.cwd ? { cwd: m.cwd } : {}),
         }),
@@ -247,9 +281,63 @@ async function pruneLocalChatFile(path: string): Promise<void> {
   }
 }
 
-export function parseSessionHistoryLines(lines: Iterable<string>): RestoredChatMessage[] {
+function parseMessageTime(record: Record<string, unknown>, msg: Record<string, unknown>): number | undefined {
+  const candidates = [msg.timestamp, record.timestamp];
+  for (const candidate of candidates) {
+    if (typeof candidate === "number" && Number.isFinite(candidate)) {
+      return candidate;
+    }
+    if (typeof candidate === "string") {
+      const parsed = Date.parse(candidate);
+      if (Number.isFinite(parsed)) return parsed;
+    }
+  }
+  return undefined;
+}
+
+function restoredToolUiId(toolCallId: string): string {
+  const safe = toolCallId.replace(/[^A-Za-z0-9_-]+/g, "-").slice(0, 96);
+  return `restored-tool-${safe || "unknown"}`;
+}
+
+interface RestoredToolCall {
+  messageIndex: number;
+  uiId: string;
+  toolName: string;
+  argsSummary: string;
+  startedAt?: number;
+}
+
+function toolCardMessage(opts: {
+  uiId: string;
+  toolName: string;
+  argsSummary: string;
+  result?: unknown;
+  isError?: boolean;
+  startedAt?: number;
+  endedAt?: number;
+}): RestoredChatMessage {
+  return {
+    id: opts.uiId,
+    role: "agent",
+    a2ui: toolCardPayload({
+      id: opts.uiId,
+      toolName: opts.toolName,
+      argsSummary: opts.argsSummary,
+      ...(opts.result !== undefined ? { result: opts.result } : {}),
+      ...(opts.isError !== undefined ? { isError: opts.isError } : {}),
+      ...(opts.startedAt !== undefined ? { startedAt: opts.startedAt } : {}),
+      ...(opts.endedAt !== undefined ? { endedAt: opts.endedAt } : {}),
+    }),
+  };
+}
+
+export function parseSessionHistoryLines(
+  lines: Iterable<string>,
+): RestoredChatMessage[] {
   const messages: RestoredChatMessage[] = [];
   const seen = new Set<string>();
+  const toolCalls = new Map<string, RestoredToolCall>();
 
   for (const line of lines) {
     const trimmed = line.trim();
@@ -269,6 +357,51 @@ export function parseSessionHistoryLines(lines: Iterable<string>): RestoredChatM
     if (!message || typeof message !== "object") continue;
     const msg = message as Record<string, unknown>;
     const sourceRole = msg.role;
+    if (sourceRole === "toolResult") {
+      const toolCallId =
+        typeof msg.toolCallId === "string" && msg.toolCallId.length > 0
+          ? msg.toolCallId
+          : undefined;
+      const toolName =
+        typeof msg.toolName === "string" && msg.toolName.length > 0
+          ? msg.toolName
+          : "tool";
+      const endedAt = parseMessageTime(record, msg);
+      const result = {
+        content: msg.content,
+      };
+      const isError = msg.isError === true;
+      const cached = toolCallId ? toolCalls.get(toolCallId) : undefined;
+      if (cached) {
+        messages[cached.messageIndex] = toolCardMessage({
+          uiId: cached.uiId,
+          toolName: cached.toolName,
+          argsSummary: cached.argsSummary,
+          result,
+          isError,
+          ...(cached.startedAt !== undefined
+            ? { startedAt: cached.startedAt }
+            : {}),
+          ...(endedAt !== undefined ? { endedAt } : {}),
+        });
+        continue;
+      }
+      const uiId = restoredToolUiId(toolCallId ?? `result-${messages.length}`);
+      if (seen.has(uiId)) continue;
+      seen.add(uiId);
+      messages.push(
+        toolCardMessage({
+          uiId,
+          toolName,
+          argsSummary: "",
+          result,
+          isError,
+          ...(endedAt !== undefined ? { endedAt } : {}),
+        }),
+      );
+      continue;
+    }
+
     const role =
       sourceRole === "user"
         ? "user"
@@ -278,16 +411,60 @@ export function parseSessionHistoryLines(lines: Iterable<string>): RestoredChatM
     if (!role) continue;
 
     const text = textFromContent(msg.content);
-    if (!text) continue;
+    const thinking = role === "agent" ? thinkingFromContent(msg.content) : "";
 
     const id =
       typeof record.id === "string" && record.id.length > 0
         ? record.id
         : `restored-${messages.length}`;
-    if (seen.has(id)) continue;
-    seen.add(id);
+    if ((text || thinking) && !seen.has(id)) {
+      seen.add(id);
+      messages.push({
+        id,
+        role,
+        ...(text ? { text: trimText(text) } : {}),
+        ...(thinking ? { thinking: trimText(thinking) } : {}),
+      });
+    }
 
-    messages.push({ id, role, text: trimText(text) });
+    if (role !== "agent" || !Array.isArray(msg.content)) continue;
+    for (const part of msg.content) {
+      if (!part || typeof part !== "object") continue;
+      const toolCall = part as Record<string, unknown>;
+      if (toolCall.type !== "toolCall") continue;
+      const toolCallId =
+        typeof toolCall.id === "string" && toolCall.id.length > 0
+          ? toolCall.id
+          : undefined;
+      if (!toolCallId || toolCalls.has(toolCallId)) continue;
+      const toolName =
+        typeof toolCall.name === "string" && toolCall.name.length > 0
+          ? toolCall.name
+          : "tool";
+      const args =
+        "arguments" in toolCall ? toolCall.arguments : undefined;
+      const argsSummary = summarizeToolArgs(toolName, args);
+      const startedAt = parseMessageTime(record, msg);
+      const uiId = restoredToolUiId(toolCallId);
+      if (seen.has(uiId)) continue;
+      seen.add(uiId);
+      const messageIndex = messages.length;
+      messages.push(
+        toolCardMessage({
+          uiId,
+          toolName,
+          argsSummary,
+          ...(startedAt !== undefined ? { startedAt } : {}),
+        }),
+      );
+      toolCalls.set(toolCallId, {
+        messageIndex,
+        uiId,
+        toolName,
+        argsSummary,
+        ...(startedAt !== undefined ? { startedAt } : {}),
+      });
+    }
   }
 
   return messages.slice(-MAX_RESTORED_MESSAGES);

--- a/agent/session-history.ts
+++ b/agent/session-history.ts
@@ -67,6 +67,7 @@ export interface RestoredChatMessage {
   id: string;
   role: "user" | "agent" | "system";
   text?: string;
+  thinking?: string;
   createdAt?: number;
   cwd?: string;
 }
@@ -123,13 +124,16 @@ export async function appendLocalChatMessage(
 ): Promise<void> {
   if (!isChatRole(message.role)) return;
   const text = typeof message.text === "string" ? trimText(message.text) : "";
-  if (!text) return;
+  const thinking =
+    typeof message.thinking === "string" ? trimText(message.thinking) : "";
+  if (!text && !thinking) return;
   await mkdir(sessionDir, { recursive: true });
   const entry = {
     type: "aethon_chat",
     id: message.id || randomUUID(),
     role: message.role,
-    text,
+    ...(text ? { text } : {}),
+    ...(thinking ? { thinking } : {}),
     createdAt:
       typeof message.createdAt === "number" && Number.isFinite(message.createdAt)
         ? message.createdAt
@@ -152,7 +156,7 @@ function parseLocalChatLines(
   expectedCwd?: string,
 ): RestoredChatMessage[] {
   const messages: RestoredChatMessage[] = [];
-  const seen = new Set<string>();
+  const seen = new Map<string, number>();
   const targetCwd = normalizeCwd(expectedCwd);
   for (const line of lines) {
     const trimmed = line.trim();
@@ -175,22 +179,30 @@ function parseLocalChatLines(
       continue;
     }
     const text = typeof record.text === "string" ? trimText(record.text) : "";
-    if (!text) continue;
+    const thinking =
+      typeof record.thinking === "string" ? trimText(record.thinking) : "";
+    if (!text && !thinking) continue;
     const id =
       typeof record.id === "string" && record.id.length > 0
         ? record.id
         : `aethon-local-${messages.length}`;
-    if (seen.has(id)) continue;
-    seen.add(id);
-    messages.push({
+    const message = {
       id,
       role: record.role,
-      text,
+      ...(text ? { text } : {}),
+      ...(thinking ? { thinking } : {}),
       ...(typeof record.createdAt === "number"
         ? { createdAt: record.createdAt }
         : {}),
       ...(entryCwd ? { cwd: entryCwd } : {}),
-    });
+    };
+    const existingIndex = seen.get(id);
+    if (existingIndex !== undefined) {
+      messages[existingIndex] = message;
+    } else {
+      seen.set(id, messages.length);
+      messages.push(message);
+    }
   }
   return messages;
 }
@@ -220,7 +232,8 @@ async function pruneLocalChatFile(path: string): Promise<void> {
           type: "aethon_chat",
           id: m.id,
           role: m.role,
-          text: m.text,
+          ...(m.text ? { text: m.text } : {}),
+          ...(m.thinking ? { thinking: m.thinking } : {}),
           ...(typeof m.createdAt === "number" ? { createdAt: m.createdAt } : {}),
           ...(m.cwd ? { cwd: m.cwd } : {}),
         }),
@@ -278,6 +291,34 @@ export function parseSessionHistoryLines(lines: Iterable<string>): RestoredChatM
   }
 
   return messages.slice(-MAX_RESTORED_MESSAGES);
+}
+
+function comparableMessageText(message: RestoredChatMessage): string | undefined {
+  const value = message.text ?? message.thinking;
+  if (typeof value !== "string") return undefined;
+  const normalized = value.replace(/\s+/g, " ").trim();
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function dedupeLocalMessages(
+  piMessages: RestoredChatMessage[],
+  localMessages: RestoredChatMessage[],
+): RestoredChatMessage[] {
+  const seenIds = new Set(piMessages.map((message) => message.id));
+  const seenContent = new Set(
+    piMessages
+      .map((message) => {
+        const text = comparableMessageText(message);
+        return text ? `${message.role}\0${text}` : undefined;
+      })
+      .filter((value): value is string => Boolean(value)),
+  );
+  return localMessages.filter((message) => {
+    if (seenIds.has(message.id)) return false;
+    const text = comparableMessageText(message);
+    if (!text) return true;
+    return !seenContent.has(`${message.role}\0${text}`);
+  });
 }
 
 async function readSessionHeaderCwd(path: string): Promise<string | undefined> {
@@ -476,5 +517,6 @@ export async function readSessionTranscript(
 
   const raw = await readFile(path, "utf8");
   const piMessages = parseSessionHistoryLines(raw.split(/\r?\n/));
-  return [...piMessages, ...localMessages].slice(-MAX_RESTORED_MESSAGES);
+  const localOnly = dedupeLocalMessages(piMessages, localMessages);
+  return [...piMessages, ...localOnly].slice(-MAX_RESTORED_MESSAGES);
 }

--- a/agent/tab-lifecycle.test.ts
+++ b/agent/tab-lifecycle.test.ts
@@ -155,7 +155,9 @@ describe("toolCardPayload", () => {
       id: "tool-c1",
       toolName: "bash",
       argsSummary: "echo hi",
-      running: true,
+      // Running is derived from `startedAt` (set) + `endedAt`
+      // (omitted) on the frontend — no explicit flag in the wire
+      // payload.
       startedAt: 12345,
     });
     expect(payload).toMatchObject({

--- a/agent/tab-lifecycle.ts
+++ b/agent/tab-lifecycle.ts
@@ -535,7 +535,6 @@ function handleSessionEvent(
         id: uiId,
         toolName: ev.toolName,
         argsSummary: summary,
-        running: true,
         startedAt,
       });
       deps.send({ type: "a2ui", tabId, id: uiId, payload });

--- a/agent/tab-lifecycle.ts
+++ b/agent/tab-lifecycle.ts
@@ -27,16 +27,26 @@ import { logger } from "./logger";
 import { extractAgentEndError } from "./agent-errors";
 import { findSessionFileMatchingCwd } from "./session-history";
 import { consumeBashTerminalSnapshot } from "./terminal-stream";
+import {
+  extractToolContent,
+  summarizeToolArgs,
+  toolCardPayload,
+} from "./tool-card";
 import type {
   AethonAgentState,
   RegisteredPiSlashCommand,
   ModelDescriptor,
   TabRecord,
 } from "./state";
+export {
+  extractToolContent,
+  inferToolResultLanguage,
+  summarizeToolArgs,
+  toolCardPayload,
+} from "./tool-card";
 
 const TERMINAL_MAX_BYTES = 64 * 1024;
 const TERMINAL_CHUNK_BYTES = 8 * 1024;
-const MAX_IMAGES_PER_RESULT = 4;
 
 const turnLog = logger.scope("turn");
 
@@ -63,227 +73,6 @@ export function compilePattern(pattern: string): RegExp {
   const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&");
   const withWild = escaped.replace(/\*/g, "[^/]*");
   return new RegExp(`^${withWild}$`);
-}
-
-/** Render a one-line summary of tool args so the card description shows
- *  what the tool was actually invoked with, not just `{...}`. */
-export function summarizeToolArgs(toolName: string, args: unknown): string {
-  if (!args || typeof args !== "object") return "";
-  const a = args as Record<string, unknown>;
-  switch (toolName) {
-    case "read":
-      return [
-        a.path,
-        a.startLine && `lines ${a.startLine}-${a.endLine ?? "end"}`,
-      ]
-        .filter(Boolean)
-        .join(" ");
-    case "bash":
-      return (
-        String(a.command ?? "")
-          .split("\n")[0]
-          ?.slice(0, 200) ?? ""
-      );
-    case "edit":
-    case "write":
-      return String(a.path ?? "");
-    case "grep":
-      return `${a.pattern ?? ""}${a.path ? ` in ${a.path}` : ""}`;
-    case "find":
-      return String(a.pattern ?? a.path ?? "");
-    case "ls":
-      return String(a.path ?? ".");
-    default: {
-      const json = JSON.stringify(args);
-      return json.length > 200 ? json.slice(0, 197) + "…" : json;
-    }
-  }
-}
-
-function truncate(text: string, max: number): string {
-  return text.length > max ? text.slice(0, max - 1) + "…" : text;
-}
-
-const EXTENSION_LANGUAGES: Record<string, string> = {
-  cjs: "javascript",
-  cpp: "cpp",
-  cs: "csharp",
-  cts: "typescript",
-  css: "css",
-  diff: "diff",
-  dockerfile: "dockerfile",
-  go: "go",
-  gql: "graphql",
-  graphql: "graphql",
-  hs: "haskell",
-  html: "html",
-  ini: "ini",
-  java: "java",
-  js: "javascript",
-  json: "json",
-  jsonl: "json",
-  jsx: "jsx",
-  kt: "kotlin",
-  lua: "lua",
-  mjs: "javascript",
-  mts: "typescript",
-  nix: "nix",
-  php: "php",
-  py: "python",
-  rb: "ruby",
-  rs: "rust",
-  scala: "scala",
-  sh: "shell",
-  sql: "sql",
-  swift: "swift",
-  toml: "toml",
-  ts: "typescript",
-  tsx: "tsx",
-  xml: "xml",
-  yaml: "yaml",
-  yml: "yaml",
-  zig: "zig",
-};
-
-function languageFromPath(path: string): string | undefined {
-  const clean = path.trim().replace(/^["'`]|["'`]$/g, "");
-  const base = clean.split(/[\\/]/).pop()?.toLowerCase() ?? "";
-  if (base === "dockerfile" || base.endsWith(".dockerfile"))
-    return "dockerfile";
-  if (base === "makefile") return "make";
-  const ext = /\.([a-z0-9]+)$/.exec(base)?.[1];
-  return ext ? EXTENSION_LANGUAGES[ext] : undefined;
-}
-
-export function inferToolResultLanguage(
-  toolName: string,
-  argsSummary: string,
-  text: string,
-): string {
-  if (toolName === "read" || toolName === "edit" || toolName === "write") {
-    const pathLang = languageFromPath(argsSummary.split(/\s+/)[0] ?? "");
-    if (pathLang) return pathLang;
-  }
-
-  const trimmed = text.trimStart();
-  if (trimmed.startsWith("{") || trimmed.startsWith("[")) return "json";
-  if (trimmed.startsWith("diff --git ") || trimmed.startsWith("--- "))
-    return "diff";
-  return "text";
-}
-
-interface ExtractedImage {
-  data: string;
-  mimeType: string;
-}
-interface ExtractedResult {
-  text: string;
-  images: ExtractedImage[];
-}
-
-/** Pi tool results: walk the content array, pull text for the code-block
- *  child and image data for any `image` primitives. */
-export function extractToolContent(result: unknown): ExtractedResult {
-  const empty: ExtractedResult = { text: "", images: [] };
-  if (result === null || result === undefined) return empty;
-  if (typeof result === "string") return { text: result, images: [] };
-  if (typeof result !== "object") {
-    return { text: String(result), images: [] };
-  }
-  const obj = result as Record<string, unknown>;
-  if (Array.isArray(obj.content)) {
-    const texts: string[] = [];
-    const images: ExtractedImage[] = [];
-    for (const p of obj.content) {
-      if (!p || typeof p !== "object") continue;
-      const part = p as {
-        type?: string;
-        text?: string;
-        data?: string;
-        mimeType?: string;
-      };
-      if (part.type === "text" && typeof part.text === "string") {
-        texts.push(part.text);
-      } else if (
-        part.type === "image" &&
-        typeof part.data === "string" &&
-        typeof part.mimeType === "string"
-      ) {
-        if (images.length < MAX_IMAGES_PER_RESULT) {
-          images.push({ data: part.data, mimeType: part.mimeType });
-        }
-      }
-    }
-    if (texts.length > 0 || images.length > 0) {
-      return { text: texts.join("\n"), images };
-    }
-  }
-  if (typeof obj.text === "string") return { text: obj.text, images: [] };
-  try {
-    return { text: JSON.stringify(result, null, 2), images: [] };
-  } catch {
-    return { text: String(result), images: [] };
-  }
-}
-
-/** Build the A2UI payload for a tool-call card. */
-export function toolCardPayload(opts: {
-  id: string;
-  toolName: string;
-  argsSummary: string;
-  result?: unknown;
-  isError?: boolean;
-  running?: boolean;
-  startedAt?: number;
-  endedAt?: number;
-}) {
-  const { id, toolName, argsSummary, result, isError, startedAt, endedAt } =
-    opts;
-  const children: unknown[] = [];
-  if (result !== undefined) {
-    const extracted = extractToolContent(result);
-    if (extracted.text) {
-      children.push({
-        id: `${id}-result`,
-        type: "code",
-        props: {
-          content: truncate(extracted.text, 1500),
-          language: inferToolResultLanguage(
-            toolName,
-            argsSummary,
-            extracted.text,
-          ),
-        },
-      });
-    }
-    extracted.images.forEach((img, i) => {
-      children.push({
-        id: `${id}-image-${i}`,
-        type: "image",
-        props: {
-          src: `data:${img.mimeType};base64,${img.data}`,
-          alt: `${toolName} image ${i + 1}`,
-        },
-      });
-    });
-  }
-  return {
-    components: [
-      {
-        id,
-        type: "tool-card",
-        props: {
-          title: toolName,
-          toolName,
-          description: argsSummary || undefined,
-          ...(startedAt !== undefined ? { startedAt } : {}),
-          ...(endedAt !== undefined ? { endedAt } : {}),
-          ...(isError ? { isError: true } : {}),
-        },
-        children,
-      },
-    ],
-  };
 }
 
 /** Sanitize a tabId for use as a directory name on disk. */

--- a/agent/tool-card.ts
+++ b/agent/tool-card.ts
@@ -1,0 +1,222 @@
+const MAX_IMAGES_PER_RESULT = 4;
+
+/** Render a one-line summary of tool args so the card description shows
+ *  what the tool was actually invoked with, not just `{...}`. */
+export function summarizeToolArgs(toolName: string, args: unknown): string {
+  if (!args || typeof args !== "object") return "";
+  const a = args as Record<string, unknown>;
+  switch (toolName) {
+    case "read":
+      return [
+        a.path,
+        a.startLine && `lines ${a.startLine}-${a.endLine ?? "end"}`,
+      ]
+        .filter(Boolean)
+        .join(" ");
+    case "bash":
+      return (
+        String(a.command ?? "")
+          .split("\n")[0]
+          ?.slice(0, 200) ?? ""
+      );
+    case "edit":
+    case "write":
+      return String(a.path ?? "");
+    case "grep":
+      return `${a.pattern ?? ""}${a.path ? ` in ${a.path}` : ""}`;
+    case "find":
+      return String(a.pattern ?? a.path ?? "");
+    case "ls":
+      return String(a.path ?? ".");
+    default: {
+      const json = JSON.stringify(args);
+      return json.length > 200 ? json.slice(0, 197) + "…" : json;
+    }
+  }
+}
+
+function truncate(text: string, max: number): string {
+  return text.length > max ? text.slice(0, max - 1) + "…" : text;
+}
+
+const EXTENSION_LANGUAGES: Record<string, string> = {
+  cjs: "javascript",
+  cpp: "cpp",
+  cs: "csharp",
+  cts: "typescript",
+  css: "css",
+  diff: "diff",
+  dockerfile: "dockerfile",
+  go: "go",
+  gql: "graphql",
+  graphql: "graphql",
+  hs: "haskell",
+  html: "html",
+  ini: "ini",
+  java: "java",
+  js: "javascript",
+  json: "json",
+  jsonl: "json",
+  jsx: "jsx",
+  kt: "kotlin",
+  lua: "lua",
+  mjs: "javascript",
+  mts: "typescript",
+  nix: "nix",
+  php: "php",
+  py: "python",
+  rb: "ruby",
+  rs: "rust",
+  scala: "scala",
+  sh: "shell",
+  sql: "sql",
+  swift: "swift",
+  toml: "toml",
+  ts: "typescript",
+  tsx: "tsx",
+  xml: "xml",
+  yaml: "yaml",
+  yml: "yaml",
+  zig: "zig",
+};
+
+function languageFromPath(path: string): string | undefined {
+  const clean = path.trim().replace(/^["'`]|["'`]$/g, "");
+  const base = clean.split(/[\\/]/).pop()?.toLowerCase() ?? "";
+  if (base === "dockerfile" || base.endsWith(".dockerfile"))
+    return "dockerfile";
+  if (base === "makefile") return "make";
+  const ext = /\.([a-z0-9]+)$/.exec(base)?.[1];
+  return ext ? EXTENSION_LANGUAGES[ext] : undefined;
+}
+
+export function inferToolResultLanguage(
+  toolName: string,
+  argsSummary: string,
+  text: string,
+): string {
+  if (toolName === "read" || toolName === "edit" || toolName === "write") {
+    const pathLang = languageFromPath(argsSummary.split(/\s+/)[0] ?? "");
+    if (pathLang) return pathLang;
+  }
+
+  const trimmed = text.trimStart();
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) return "json";
+  if (trimmed.startsWith("diff --git ") || trimmed.startsWith("--- "))
+    return "diff";
+  return "text";
+}
+
+interface ExtractedImage {
+  data: string;
+  mimeType: string;
+}
+interface ExtractedResult {
+  text: string;
+  images: ExtractedImage[];
+}
+
+/** Pi tool results: walk the content array, pull text for the code-block
+ *  child and image data for any `image` primitives. */
+export function extractToolContent(result: unknown): ExtractedResult {
+  const empty: ExtractedResult = { text: "", images: [] };
+  if (result === null || result === undefined) return empty;
+  if (typeof result === "string") return { text: result, images: [] };
+  if (typeof result !== "object") {
+    return { text: String(result), images: [] };
+  }
+  const obj = result as Record<string, unknown>;
+  if (Array.isArray(obj.content)) {
+    const texts: string[] = [];
+    const images: ExtractedImage[] = [];
+    for (const p of obj.content) {
+      if (!p || typeof p !== "object") continue;
+      const part = p as {
+        type?: string;
+        text?: string;
+        data?: string;
+        mimeType?: string;
+      };
+      if (part.type === "text" && typeof part.text === "string") {
+        texts.push(part.text);
+      } else if (
+        part.type === "image" &&
+        typeof part.data === "string" &&
+        typeof part.mimeType === "string"
+      ) {
+        if (images.length < MAX_IMAGES_PER_RESULT) {
+          images.push({ data: part.data, mimeType: part.mimeType });
+        }
+      }
+    }
+    if (texts.length > 0 || images.length > 0) {
+      return { text: texts.join("\n"), images };
+    }
+  }
+  if (typeof obj.text === "string") return { text: obj.text, images: [] };
+  try {
+    return { text: JSON.stringify(result, null, 2), images: [] };
+  } catch {
+    return { text: String(result), images: [] };
+  }
+}
+
+/** Build the A2UI payload for a tool-call card. */
+export function toolCardPayload(opts: {
+  id: string;
+  toolName: string;
+  argsSummary: string;
+  result?: unknown;
+  isError?: boolean;
+  running?: boolean;
+  startedAt?: number;
+  endedAt?: number;
+}) {
+  const { id, toolName, argsSummary, result, isError, startedAt, endedAt } =
+    opts;
+  const children: unknown[] = [];
+  if (result !== undefined) {
+    const extracted = extractToolContent(result);
+    if (extracted.text) {
+      children.push({
+        id: `${id}-result`,
+        type: "code",
+        props: {
+          content: truncate(extracted.text, 1500),
+          language: inferToolResultLanguage(
+            toolName,
+            argsSummary,
+            extracted.text,
+          ),
+        },
+      });
+    }
+    extracted.images.forEach((img, i) => {
+      children.push({
+        id: `${id}-image-${i}`,
+        type: "image",
+        props: {
+          src: `data:${img.mimeType};base64,${img.data}`,
+          alt: `${toolName} image ${i + 1}`,
+        },
+      });
+    });
+  }
+  return {
+    components: [
+      {
+        id,
+        type: "tool-card",
+        props: {
+          title: toolName,
+          toolName,
+          description: argsSummary || undefined,
+          ...(startedAt !== undefined ? { startedAt } : {}),
+          ...(endedAt !== undefined ? { endedAt } : {}),
+          ...(isError ? { isError: true } : {}),
+        },
+        children,
+      },
+    ],
+  };
+}

--- a/agent/tool-card.ts
+++ b/agent/tool-card.ts
@@ -161,14 +161,19 @@ export function extractToolContent(result: unknown): ExtractedResult {
   }
 }
 
-/** Build the A2UI payload for a tool-call card. */
+/** Build the A2UI payload for a tool-call card.
+ *
+ *  The frontend `ToolCard` composite derives the running/done/failed
+ *  state from the `startedAt` and `endedAt` props (running iff
+ *  `startedAt !== undefined && endedAt === undefined`), so callers
+ *  signal "still running" by passing `startedAt` only — no separate
+ *  `running` flag is needed in the wire payload. */
 export function toolCardPayload(opts: {
   id: string;
   toolName: string;
   argsSummary: string;
   result?: unknown;
   isError?: boolean;
-  running?: boolean;
   startedAt?: number;
   endedAt?: number;
 }) {

--- a/e2e/aethon.spec.ts
+++ b/e2e/aethon.spec.ts
@@ -107,12 +107,18 @@ test("queues normal Enter messages behind an in-flight turn and drains cleanly",
   await expect(page.getByText("Enter queues")).toBeVisible();
   await expect(page.getByText("Cmd/Ctrl+Enter steers")).toBeVisible();
 
+  // Stack two prompts while the first turn is still in flight. With
+  // the client-held queue UX, these land in the popover above the
+  // composer — NOT in chat history — and only become history bubbles
+  // once the auto-drain pops them on the next idle.
   await page.locator(".a2ui-chat-input-field").fill("queued prompt");
   await page.keyboard.press("Enter");
 
   await expect(page.locator(".a2ui-chat-input-queue")).toHaveText("+1");
   await expect(page.locator(".a2ui-tab")).toContainText("+1");
-  await expect(page.locator(".a2ui-chat-delivery-queued")).toHaveText("queued");
+  await expect(page.locator(".a2ui-queued-popover")).toBeVisible();
+  await expect(page.locator(".a2ui-queued-message")).toHaveCount(1);
+  await expect(page.locator(".a2ui-queued-content")).toHaveText("queued prompt");
   await expect(page.getByRole("button", { name: "Stop + clear" })).toBeVisible();
   await expect
     .poll(() => getActiveTurnState(page))
@@ -122,34 +128,43 @@ test("queues normal Enter messages behind an in-flight turn and drains cleanly",
   await page.keyboard.press("Enter");
 
   await expect(page.locator(".a2ui-chat-input-queue")).toHaveText("+2");
-  await expect(page.locator(".a2ui-chat-delivery-queued")).toHaveText([
-    "queued #1",
-    "queued #2",
+  await expect(page.locator(".a2ui-queued-message")).toHaveCount(2);
+  await expect(page.locator(".a2ui-queued-content")).toHaveText([
+    "queued prompt",
+    "second queued prompt",
   ]);
   await expect
     .poll(() => getActiveTurnState(page))
     .toEqual({ waiting: true, queueCount: 2, status: "thinking…" });
 
+  // First turn ends → head of queue drains → second user bubble lands
+  // in history, popover shrinks to one row.
   await completeActiveTurn(page);
   await expect(page.locator(".a2ui-chat-input-queue")).toHaveText("+1");
-  await expect(page.locator(".a2ui-chat-delivery-queued")).toHaveText("queued");
+  await expect(page.locator(".a2ui-queued-message")).toHaveCount(1);
+  await expect(page.locator(".a2ui-queued-content")).toHaveText(
+    "second queued prompt",
+  );
   await expect
     .poll(() => getActiveTurnState(page))
     .toEqual({ waiting: true, queueCount: 1, status: "thinking…" });
 
+  // Second turn ends → last queued message drains → popover empties.
   await completeActiveTurn(page);
   await expect(page.locator(".a2ui-chat-input-queue")).toHaveCount(0);
-  await expect(page.locator(".a2ui-chat-delivery-queued")).toHaveCount(0);
+  await expect(page.locator(".a2ui-queued-popover")).toHaveCount(0);
   await expect
     .poll(() => getActiveTurnState(page))
     .toEqual({ waiting: true, queueCount: 0, status: "thinking…" });
   await expect(page.getByRole("button", { name: "Stop" })).toBeVisible();
 
+  // Third turn ends → idle.
   await completeActiveTurn(page);
   await expect
     .poll(() => getActiveTurnState(page))
     .toEqual({ waiting: false, queueCount: 0, status: "ready" });
   await expect(page.locator(".a2ui-chat-input-queue")).toHaveCount(0);
+  await expect(page.locator(".a2ui-queued-popover")).toHaveCount(0);
   await expect(page.getByRole("button", { name: "Send" })).toBeVisible();
   await expect(page.getByText("Enter queues")).toHaveCount(0);
 
@@ -265,15 +280,20 @@ test("steering during an existing follow-up queue preserves the queued turn", as
     process.platform === "darwin" ? "Meta+Enter" : "Control+Enter",
   );
 
+  // Steer mid-turn — adds a steered bubble to history, leaves the
+  // queued message in the popover untouched.
   await expect(page.locator(".a2ui-chat-input-queue")).toHaveText("+1");
-  await expect(page.locator(".a2ui-chat-delivery-queued")).toHaveText("queued");
+  await expect(page.locator(".a2ui-queued-message")).toHaveCount(1);
+  await expect(page.locator(".a2ui-queued-content")).toHaveText("queued prompt");
   await expect(page.locator(".a2ui-chat-delivery-steered")).toHaveText("steered");
   await expect
     .poll(() => getActiveTurnState(page))
     .toEqual({ waiting: true, queueCount: 1, status: "thinking…" });
 
+  // First turn ends → queued message drains; steered bubble stays
+  // as historical record of the mid-turn interjection.
   await completeActiveTurn(page);
-  await expect(page.locator(".a2ui-chat-delivery-queued")).toHaveCount(0);
+  await expect(page.locator(".a2ui-queued-popover")).toHaveCount(0);
   await expect(page.locator(".a2ui-chat-delivery-steered")).toHaveText("steered");
   await expect
     .poll(() => getActiveTurnState(page))
@@ -287,8 +307,8 @@ test("steering during an existing follow-up queue preserves the queued turn", as
   const sends = (await getInvokeCalls(page)).filter((c) => c.cmd === "send_message");
   expect(sends.map((c) => c.args)).toEqual([
     expect.objectContaining({ message: "first prompt", mode: "normal" }),
-    expect.objectContaining({ message: "queued prompt", mode: "normal" }),
     expect.objectContaining({ message: "steer current turn", mode: "steer" }),
+    expect.objectContaining({ message: "queued prompt", mode: "normal" }),
   ]);
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aethon",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aethon",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "@mariozechner/pi-ai": "^0.70.2",
         "@mariozechner/pi-coding-agent": "^0.70.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aethon",
   "private": true,
-  "version": "0.3.2",
+  "version": "0.3.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Aethon dev launcher — finds free ports for Vite and the debug TCP server,
 # writes them to ~/.aethon/dev-info.json so the aethon-debug skill can
-# discover the running instance, then execs `cargo tauri dev`.
+# discover the running instance, then supervises `cargo tauri dev`.
 #
 # Why this exists:
 #   - Tauri requires a fixed devUrl (Vite's `strictPort: true`) so a leaked
@@ -45,7 +45,7 @@ DEBUG_BASE="${AETHON_DEBUG_PORT_BASE:-19433}"
 SANDBOX_ROOT_DIR="${TMPDIR:-/tmp}/aethon-dev"
 
 # Parse our own flags before forwarding the rest to `cargo tauri dev`.
-# Stashed in arrays so we keep ordering for the eventual `exec`.
+# Stashed in arrays so we keep ordering for the eventual launch.
 new_session=0
 clean_action=0
 passthrough_args=()
@@ -190,16 +190,95 @@ cat >"$TMP" <<EOF
 EOF
 mv "$TMP" "$DEV_INFO"
 
-# Cleanup: always remove the discovery file; remove the --new sandbox
-# tree too. INT / TERM forwarded so a SIGINT (Ctrl+C) doesn't leave a
-# stale tree behind on the user's next launch.
+# Cleanup: always remove the discovery file; remove the --new sandbox tree too.
 cleanup() {
   rm -f "$DEV_INFO"
   if [[ -n "$sandbox_dir" && -d "$sandbox_dir" ]]; then
     rm -rf "$sandbox_dir"
   fi
 }
-trap cleanup EXIT INT TERM
+
+child_pid=""
+
+descendant_pids() {
+  local root="$1"
+  local child
+  while read -r child; do
+    [[ -n "$child" ]] || continue
+    descendant_pids "$child"
+    printf '%s\n' "$child"
+  done < <(pgrep -P "$root" 2>/dev/null || true)
+}
+
+signal_child_tree() {
+  local signal="$1"
+  [[ -n "$child_pid" ]] || return 0
+
+  # Prefer a process-group signal when the shell/OS happened to give the child
+  # its own group. This is best-effort; the parent/descendant walk below is the
+  # reliable path for non-interactive shells where background jobs inherit the
+  # wrapper's process group.
+  kill "-$signal" -- "-$child_pid" 2>/dev/null || true
+
+  # macOS fallback: walk descendants by parent PID so Ctrl+C still tears down
+  # Cargo, Tauri, Vite, and the agent sidecar when one layer swallows SIGINT.
+  while read -r pid; do
+    [[ -n "$pid" ]] || continue
+    kill "-$signal" "$pid" 2>/dev/null || true
+  done < <(descendant_pids "$child_pid")
+  kill "-$signal" "$child_pid" 2>/dev/null || true
+}
+
+child_is_running() {
+  [[ -n "$child_pid" ]] || return 1
+  local state
+  state="$(ps -p "$child_pid" -o stat= 2>/dev/null || true)"
+  [[ -n "$state" && "$state" != *Z* ]]
+}
+
+wait_for_child_to_stop() {
+  [[ -n "$child_pid" ]] || return 0
+  local attempts="$1"
+  local i
+  for ((i = 0; i < attempts; i++)); do
+    if ! child_is_running; then
+      return 0
+    fi
+    sleep 0.1
+  done
+  return 1
+}
+
+stop_child_tree() {
+  local first_signal="$1"
+  [[ -n "$child_pid" ]] || return 0
+
+  signal_child_tree "$first_signal"
+  wait_for_child_to_stop 20 && return 0
+
+  signal_child_tree TERM
+  wait_for_child_to_stop 20 && return 0
+
+  signal_child_tree KILL
+}
+
+handle_int() {
+  trap - INT TERM
+  stop_child_tree INT
+  cleanup
+  exit 130
+}
+
+handle_term() {
+  trap - INT TERM
+  stop_child_tree TERM
+  cleanup
+  exit 143
+}
+
+trap cleanup EXIT
+trap handle_int INT
+trap handle_term TERM
 
 export VITE_PORT
 export AETHON_DEBUG_PORT="$DEBUG_PORT"
@@ -212,4 +291,14 @@ if [[ "$VITE_PORT" != "$VITE_BASE" || "$DEBUG_PORT" != "$DEBUG_BASE" ]]; then
   echo "[dev] vite=${VITE_PORT} (was ${VITE_BASE}) debug=${DEBUG_PORT} (was ${DEBUG_BASE})" >&2
 fi
 
-exec cargo tauri dev "$@"
+# Run under supervision so Ctrl+C can escalate through the child tree if one
+# layer ignores SIGINT. Keep job control off; Cargo/Vite should retain normal
+# terminal stdin behavior.
+cargo tauri dev "$@" &
+child_pid=$!
+set +e
+wait "$child_pid"
+status=$?
+set -e
+child_pid=""
+exit "$status"

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -190,95 +190,16 @@ cat >"$TMP" <<EOF
 EOF
 mv "$TMP" "$DEV_INFO"
 
-# Cleanup: always remove the discovery file; remove the --new sandbox tree too.
+# Pre-exec cleanup: only triggers if we exit before exec'ing cargo (e.g.
+# port allocation fails, --help, etc.). The post-exec cleanup path is
+# the watchdog below.
 cleanup() {
   rm -f "$DEV_INFO"
   if [[ -n "$sandbox_dir" && -d "$sandbox_dir" ]]; then
     rm -rf "$sandbox_dir"
   fi
 }
-
-child_pid=""
-
-descendant_pids() {
-  local root="$1"
-  local child
-  while read -r child; do
-    [[ -n "$child" ]] || continue
-    descendant_pids "$child"
-    printf '%s\n' "$child"
-  done < <(pgrep -P "$root" 2>/dev/null || true)
-}
-
-signal_child_tree() {
-  local signal="$1"
-  [[ -n "$child_pid" ]] || return 0
-
-  # Prefer a process-group signal when the shell/OS happened to give the child
-  # its own group. This is best-effort; the parent/descendant walk below is the
-  # reliable path for non-interactive shells where background jobs inherit the
-  # wrapper's process group.
-  kill "-$signal" -- "-$child_pid" 2>/dev/null || true
-
-  # macOS fallback: walk descendants by parent PID so Ctrl+C still tears down
-  # Cargo, Tauri, Vite, and the agent sidecar when one layer swallows SIGINT.
-  while read -r pid; do
-    [[ -n "$pid" ]] || continue
-    kill "-$signal" "$pid" 2>/dev/null || true
-  done < <(descendant_pids "$child_pid")
-  kill "-$signal" "$child_pid" 2>/dev/null || true
-}
-
-child_is_running() {
-  [[ -n "$child_pid" ]] || return 1
-  local state
-  state="$(ps -p "$child_pid" -o stat= 2>/dev/null || true)"
-  [[ -n "$state" && "$state" != *Z* ]]
-}
-
-wait_for_child_to_stop() {
-  [[ -n "$child_pid" ]] || return 0
-  local attempts="$1"
-  local i
-  for ((i = 0; i < attempts; i++)); do
-    if ! child_is_running; then
-      return 0
-    fi
-    sleep 0.1
-  done
-  return 1
-}
-
-stop_child_tree() {
-  local first_signal="$1"
-  [[ -n "$child_pid" ]] || return 0
-
-  signal_child_tree "$first_signal"
-  wait_for_child_to_stop 20 && return 0
-
-  signal_child_tree TERM
-  wait_for_child_to_stop 20 && return 0
-
-  signal_child_tree KILL
-}
-
-handle_int() {
-  trap - INT TERM
-  stop_child_tree INT
-  cleanup
-  exit 130
-}
-
-handle_term() {
-  trap - INT TERM
-  stop_child_tree TERM
-  cleanup
-  exit 143
-}
-
 trap cleanup EXIT
-trap handle_int INT
-trap handle_term TERM
 
 export VITE_PORT
 export AETHON_DEBUG_PORT="$DEBUG_PORT"
@@ -291,14 +212,71 @@ if [[ "$VITE_PORT" != "$VITE_BASE" || "$DEBUG_PORT" != "$DEBUG_BASE" ]]; then
   echo "[dev] vite=${VITE_PORT} (was ${VITE_BASE}) debug=${DEBUG_PORT} (was ${DEBUG_BASE})" >&2
 fi
 
-# Run under supervision so Ctrl+C can escalate through the child tree if one
-# layer ignores SIGINT. Keep job control off; Cargo/Vite should retain normal
-# terminal stdin behavior.
-cargo tauri dev "$@" &
-child_pid=$!
-set +e
-wait "$child_pid"
-status=$?
-set -e
-child_pid=""
-exit "$status"
+# Watchdog: a tiny background process that outlives our `exec` and
+# performs the full session cleanup once cargo has exited.
+#
+# Why a watchdog instead of bash signal traps:
+#   `cargo tauri dev` (via the cargo it spawns, or Vite, or the aethon
+#   binary's pty handling) takes over the terminal's foreground process
+#   group via tcsetpgrp(). After that, Ctrl+C delivers SIGINT to *cargo's*
+#   PG, not to this script's PG, so any `trap INT` we install here is
+#   never invoked. The previous PG-and-pattern teardown was correct in
+#   spirit but the handler that called it was never reached.
+#
+# How this watchdog finds survivors:
+#   AETHON_DEBUG_PORT is exported below and is unique to this dev
+#   session (find_free_port auto-increments per concurrent run). Every
+#   process in the session inherits it in its environment, so a single
+#   `ps -axwwE | grep AETHON_DEBUG_PORT=<port>` sweep catches cargo's
+#   child cargo, the aethon binary, vite, the bun agent, and anything
+#   else they spawned — even orphans whose PPID is now launchd.
+parent_pid=$$
+debug_port="$DEBUG_PORT"
+dev_info_path="$DEV_INFO"
+sandbox_dir_path="$sandbox_dir"
+
+(
+  # Detach the watchdog from stdio + the terminal: it must survive even
+  # after the user's shell prompt returns, and we don't want it to take
+  # SIGINT itself.
+  exec </dev/null >/dev/null 2>&1
+  trap '' INT TERM HUP
+
+  while kill -0 "$parent_pid" 2>/dev/null; do
+    sleep 0.2
+  done
+
+  # Survivor sweep, scoped to processes with our exact debug-port env var
+  # so a second concurrent `dev` instance (on a different port) is
+  # untouched. Excludes our own watchdog PID for paranoia.
+  watchdog_pid=$$
+  sweep_pids() {
+    ps -axwwE 2>/dev/null \
+      | awk -v needle="AETHON_DEBUG_PORT=$debug_port" -v me="$watchdog_pid" \
+          'index($0, needle) && $1 != me { print $1 }'
+  }
+  sweep_round() {
+    local sig="$1" pid
+    while read -r pid; do
+      [[ -n "$pid" ]] || continue
+      kill "-$sig" "$pid" 2>/dev/null || true
+    done < <(sweep_pids)
+  }
+
+  sweep_round INT
+  sleep 0.2
+  sweep_round TERM
+  sleep 0.2
+  sweep_round KILL
+
+  rm -f "$dev_info_path"
+  if [[ -n "$sandbox_dir_path" && -d "$sandbox_dir_path" ]]; then
+    rm -rf "$sandbox_dir_path"
+  fi
+) &
+disown
+
+# Hand the terminal to cargo. After exec, this script's PID *is* cargo —
+# the watchdog watches that PID, and Ctrl+C goes straight to cargo with
+# zero bash signal-routing in the middle.
+exec cargo tauri dev "$@"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aethon"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aethon"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 license = "MIT"
 description = "Pi with a face — agent-driven desktop shell with A2UI"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -376,10 +376,10 @@ fn send_message(
         "mode": mode.unwrap_or_else(|| "normal".to_string()),
         "tabId": tab_id.unwrap_or_else(|| "default".to_string()),
     });
-    if let Some(cwd) = cwd {
-        if !cwd.is_empty() {
-            payload["cwd"] = serde_json::Value::String(cwd);
-        }
+    if let Some(cwd) = cwd
+        && !cwd.is_empty()
+    {
+        payload["cwd"] = serde_json::Value::String(cwd);
     }
     writeln!(stdin, "{}", payload).map_err(|e| format!("write failed: {e}"))?;
     stdin.flush().map_err(|e| format!("flush failed: {e}"))?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -359,6 +359,7 @@ fn send_message(
     message: String,
     tab_id: Option<String>,
     mode: Option<String>,
+    cwd: Option<String>,
     state: State<'_, AgentProcess>,
     app: AppHandle,
 ) -> Result<(), String> {
@@ -369,12 +370,17 @@ fn send_message(
     let stdin = child.stdin.as_mut().ok_or("no stdin")?;
     // tabId routes to a specific pi session; the bridge defaults to
     // "default" when omitted so legacy single-tab callers keep working.
-    let payload = serde_json::json!({
+    let mut payload = serde_json::json!({
         "type": "chat",
         "content": message,
         "mode": mode.unwrap_or_else(|| "normal".to_string()),
         "tabId": tab_id.unwrap_or_else(|| "default".to_string()),
     });
+    if let Some(cwd) = cwd {
+        if !cwd.is_empty() {
+            payload["cwd"] = serde_json::Value::String(cwd);
+        }
+    }
     writeln!(stdin, "{}", payload).map_err(|e| format!("write failed: {e}"))?;
     stdin.flush().map_err(|e| format!("flush failed: {e}"))?;
     Ok(())

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Aethon",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "identifier": "com.utensils.aethon",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import { useBootConfig } from "./hooks/useBootConfig";
 import { useNotifications } from "./hooks/useNotifications";
 import { useFocus, WORKSTATION_AREAS, workstationRows } from "./hooks/useFocus";
 import { useChat } from "./hooks/useChat";
+import { useQueuedDispatch } from "./hooks/useQueuedDispatch";
 import { useFrontendStateMirror } from "./hooks/useFrontendStateMirror";
 import { useUiOverlays } from "./hooks/useUiOverlays";
 import { useUpdater } from "./hooks/useUpdater";
@@ -705,6 +706,10 @@ export default function App() {
     setModel,
     stopPrompt,
     exportActiveChatMarkdown,
+    editQueuedMessage,
+    deleteQueuedMessage,
+    steerQueuedMessage,
+    clearQueuedMessages,
   } = useChat({
     setState,
     stateRef,
@@ -722,6 +727,16 @@ export default function App() {
   // before any of their handlers fire.
   useEffect(() => {
     chatActionsRef.current = { appendSystem };
+  });
+
+  // Drain the per-tab client-side message queues. The hook subscribes to
+  // tabs and re-fires its drain check on every commit; gating happens
+  // inside the hook against `waiting`, `queuedMessages.length`,
+  // `queuedSteeringId`, and a private in-flight set.
+  useQueuedDispatch({
+    tabs: (state.tabs as Tab[] | undefined) ?? [],
+    sendChat,
+    updateTab,
   });
 
   // ---------------------------------------------------------------------
@@ -1192,6 +1207,10 @@ export default function App() {
       sendChat,
       stopPrompt,
       updateActiveTab,
+      editQueuedMessage,
+      deleteQueuedMessage,
+      steerQueuedMessage,
+      clearQueuedMessages,
       newTab,
       newShellTab,
       newEditorTab,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,7 +25,7 @@ import { useChat } from "./hooks/useChat";
 import { useFrontendStateMirror } from "./hooks/useFrontendStateMirror";
 import { useUiOverlays } from "./hooks/useUiOverlays";
 import { useUpdater } from "./hooks/useUpdater";
-import { useProjectOps } from "./hooks/useProjectOps";
+import { useProjectOps, worktreeIdForCwd } from "./hooks/useProjectOps";
 import { useOsEdges } from "./hooks/useOsEdges";
 import type { SlashCommandContext } from "./slashCommands";
 import { readState, writeState } from "./persist";
@@ -606,6 +606,39 @@ export default function App() {
     };
   });
 
+  const syncActiveWorktreeToActiveTab = useCallback(() => {
+    const tabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
+    const activeId = stateRef.current.activeTabId as string | undefined;
+    const active = activeId ? tabs.find((t) => t.id === activeId) : undefined;
+    if (!active || active.kind !== "agent") return;
+    const resolved = worktreeIdForCwd(
+      projectsRef.current,
+      active.cwd,
+      active.projectId,
+    );
+    if (resolved === undefined) return;
+    if (
+      active.projectId &&
+      projectsRef.current.activeId !== active.projectId
+    ) {
+      if (!setActiveProjectById(active.projectId)) return;
+    }
+    if (projectsRef.current.activeWorktreeId !== resolved) {
+      activateWorktree(resolved);
+    }
+  }, [activateWorktree, setActiveProjectById]);
+
+  useEffect(() => {
+    syncActiveWorktreeToActiveTab();
+  }, [
+    syncActiveWorktreeToActiveTab,
+    state.activeTabId,
+    state.activeWorktreeId,
+    state.cwd,
+    state.projects,
+    state.sidebar,
+  ]);
+
   // Lazy project icon discovery — for each project missing an iconUrl,
   // fire discoverIcon and persist the resolved url back to the project
   // record. The in-process cache in src/projectIcons.ts memoizes by
@@ -715,6 +748,12 @@ export default function App() {
         });
         return;
       }
+      // Ensure the project we're launching into is the active one before
+      // selecting a worktree; setActiveProjectById intentionally clears the
+      // active worktree as part of switching buckets.
+      if (projectsRef.current.activeId !== opts.projectId) {
+        setActiveProjectById(opts.projectId);
+      }
       let cwd = project.path;
       if (opts.newWorktree) {
         const branch = (opts.branch ?? "").trim();
@@ -740,6 +779,11 @@ export default function App() {
           return;
         }
         cwd = created;
+        const createdWorktree =
+          projectsRef.current.worktreesByProject[opts.projectId]?.find(
+            (w) => w.path === created,
+          );
+        if (createdWorktree) activateWorktree(createdWorktree.id);
       } else if (opts.worktreeId) {
         // Existing-worktree path — switch the active worktree and use
         // its path as the new tab's cwd.
@@ -750,11 +794,6 @@ export default function App() {
           cwd = wt.path;
           activateWorktree(wt.id);
         }
-      }
-      // Ensure the project we're launching into is the active one so the
-      // new tab lands in the right per-project bucket.
-      if (projectsRef.current.activeId !== opts.projectId) {
-        setActiveProjectById(opts.projectId);
       }
       const tabId = crypto.randomUUID();
       newTab(tabId, undefined, { cwd });
@@ -998,7 +1037,7 @@ export default function App() {
   // Build the dispatch context fresh per invocation so handlers see latest
   // state (model list, skills) without re-creating the command registry.
   function persistLocalChatMessage(msg: ChatMessage, tabId: string) {
-    if (!msg.text) return;
+    if (!msg.text && !msg.thinking) return;
     invoke("agent_command", {
       payload: JSON.stringify({
         type: "local_chat_message",
@@ -1006,7 +1045,8 @@ export default function App() {
         payload: {
           id: msg.id,
           role: msg.role,
-          text: msg.text,
+          ...(msg.text ? { text: msg.text } : {}),
+          ...(msg.thinking ? { thinking: msg.thinking } : {}),
           ...(msg.delivery ? { delivery: msg.delivery } : {}),
           createdAt: Date.now(),
         },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -486,6 +486,7 @@ export default function App() {
     autoRestoreDiscoveredSessions,
     reopenLastClosedTab,
     closeTab,
+    closeTabNow,
   } = useTabs({
     setState,
     stateRef,
@@ -592,6 +593,7 @@ export default function App() {
     unwatchProjectForBridge,
     dispatchTerminalReplay,
     autoRestoreDiscoveredSessions,
+    closeTabNow,
   });
   // Wire forward handles now that the live functions exist. Ref writes
   // happen in commit phase (useEffect) — React disallows ref mutation

--- a/src/eventRoutes/index.ts
+++ b/src/eventRoutes/index.ts
@@ -86,7 +86,12 @@ export const BUILTIN_ROUTE_TABLE: ReadonlyMap<string, readonly EventRouteHandler
     ["type:settings-panel", [handleSettings]],
     ["type:search-panel", [handleSearch]],
     ["type:command-palette", [handlePalette]],
-    ["type:chat-input", [handleChatInput]],
+    // Order matters: handleQueuedMessages runs FIRST and only matches
+    // `queue:*` events, returning false for everything else. That lets
+    // the inlined popover's events route correctly while normal chat
+    // input events (submit / change / cancel) still flow to
+    // handleChatInput unchanged.
+    ["type:chat-input", [handleQueuedMessages, handleChatInput]],
     ["type:chat-history", [handleChatMessages]],
     ["type:main-canvas", [handleChatMessages]],
     ["type:queued-messages-popover", [handleQueuedMessages]],

--- a/src/eventRoutes/index.ts
+++ b/src/eventRoutes/index.ts
@@ -30,6 +30,7 @@ import { handleShellConsent } from "./shellConsent";
 import { matchesExtensionRoute } from "./extensions";
 import { handleChatInput } from "./chatInput";
 import { handleChatMessages } from "./chatMessages";
+import { handleQueuedMessages } from "./queue";
 import { handleSettings } from "./settings";
 import { handleSearch } from "./search";
 import { handlePalette } from "./palette";
@@ -88,6 +89,7 @@ export const BUILTIN_ROUTE_TABLE: ReadonlyMap<string, readonly EventRouteHandler
     ["type:chat-input", [handleChatInput]],
     ["type:chat-history", [handleChatMessages]],
     ["type:main-canvas", [handleChatMessages]],
+    ["type:queued-messages-popover", [handleQueuedMessages]],
     ["type:empty-state", [handleEmptyState]],
     // Worktree landing — "Start Session" + "Open in Files" CTAs reuse
     // the sidebar's worktree routes since the destination semantics

--- a/src/eventRoutes/queue.test.ts
+++ b/src/eventRoutes/queue.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { handleQueuedMessages } from "./queue";
+import { buildRouteFixture } from "./testFixtures";
+import { makeEmptyTab } from "../types/tab";
+
+function fixtureWithActiveAgentTab() {
+  const tab = {
+    ...makeEmptyTab("tab-1", "Tab 1"),
+    queuedMessages: [
+      { id: "q1", content: "first" },
+      { id: "q2", content: "second" },
+    ],
+    queueCount: 2,
+  };
+  return buildRouteFixture({
+    state: { tabs: [tab], activeTabId: "tab-1" },
+  });
+}
+
+const POPOVER = { id: "queued-messages-popover", type: "queued-messages-popover" };
+
+describe("handleQueuedMessages", () => {
+  it("forwards edit events with messageId + content to ctx.editQueuedMessage", async () => {
+    const { ctx, mocks } = fixtureWithActiveAgentTab();
+    const handled = await handleQueuedMessages(
+      {
+        component: POPOVER,
+        eventType: "edit",
+        data: { messageId: "q1", content: "rewritten" },
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.editQueuedMessage).toHaveBeenCalledWith(
+      "tab-1",
+      "q1",
+      "rewritten",
+    );
+  });
+
+  it("forwards delete to ctx.deleteQueuedMessage", async () => {
+    const { ctx, mocks } = fixtureWithActiveAgentTab();
+    const handled = await handleQueuedMessages(
+      { component: POPOVER, eventType: "delete", data: { messageId: "q2" } },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.deleteQueuedMessage).toHaveBeenCalledWith("tab-1", "q2");
+  });
+
+  it("forwards steer to ctx.steerQueuedMessage", async () => {
+    const { ctx, mocks } = fixtureWithActiveAgentTab();
+    const handled = await handleQueuedMessages(
+      { component: POPOVER, eventType: "steer", data: { messageId: "q1" } },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.steerQueuedMessage).toHaveBeenCalledWith("tab-1", "q1");
+  });
+
+  it("forwards clear to ctx.clearQueuedMessages", async () => {
+    const { ctx, mocks } = fixtureWithActiveAgentTab();
+    const handled = await handleQueuedMessages(
+      { component: POPOVER, eventType: "clear" },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.clearQueuedMessages).toHaveBeenCalledWith("tab-1");
+  });
+
+  it("is a no-op when the active tab is not an agent tab", async () => {
+    const shellTab = makeEmptyTab("shell-1", "Shell 1", null, "shell");
+    const { ctx, mocks } = buildRouteFixture({
+      state: { tabs: [shellTab], activeTabId: "shell-1" },
+    });
+    const handled = await handleQueuedMessages(
+      { component: POPOVER, eventType: "clear" },
+      ctx,
+    );
+    expect(handled).toBe(false);
+    expect(mocks.clearQueuedMessages).not.toHaveBeenCalled();
+  });
+
+  it("ignores malformed edit payloads (missing messageId)", async () => {
+    const { ctx, mocks } = fixtureWithActiveAgentTab();
+    const handled = await handleQueuedMessages(
+      { component: POPOVER, eventType: "edit", data: { content: "x" } },
+      ctx,
+    );
+    expect(handled).toBe(false);
+    expect(mocks.editQueuedMessage).not.toHaveBeenCalled();
+  });
+});

--- a/src/eventRoutes/queue.test.ts
+++ b/src/eventRoutes/queue.test.ts
@@ -25,7 +25,7 @@ describe("handleQueuedMessages", () => {
     const handled = await handleQueuedMessages(
       {
         component: POPOVER,
-        eventType: "edit",
+        eventType: "queue:edit",
         data: { messageId: "q1", content: "rewritten" },
       },
       ctx,
@@ -41,7 +41,7 @@ describe("handleQueuedMessages", () => {
   it("forwards delete to ctx.deleteQueuedMessage", async () => {
     const { ctx, mocks } = fixtureWithActiveAgentTab();
     const handled = await handleQueuedMessages(
-      { component: POPOVER, eventType: "delete", data: { messageId: "q2" } },
+      { component: POPOVER, eventType: "queue:delete", data: { messageId: "q2" } },
       ctx,
     );
     expect(handled).toBe(true);
@@ -51,7 +51,7 @@ describe("handleQueuedMessages", () => {
   it("forwards steer to ctx.steerQueuedMessage", async () => {
     const { ctx, mocks } = fixtureWithActiveAgentTab();
     const handled = await handleQueuedMessages(
-      { component: POPOVER, eventType: "steer", data: { messageId: "q1" } },
+      { component: POPOVER, eventType: "queue:steer", data: { messageId: "q1" } },
       ctx,
     );
     expect(handled).toBe(true);
@@ -61,7 +61,7 @@ describe("handleQueuedMessages", () => {
   it("forwards clear to ctx.clearQueuedMessages", async () => {
     const { ctx, mocks } = fixtureWithActiveAgentTab();
     const handled = await handleQueuedMessages(
-      { component: POPOVER, eventType: "clear" },
+      { component: POPOVER, eventType: "queue:clear" },
       ctx,
     );
     expect(handled).toBe(true);
@@ -74,7 +74,7 @@ describe("handleQueuedMessages", () => {
       state: { tabs: [shellTab], activeTabId: "shell-1" },
     });
     const handled = await handleQueuedMessages(
-      { component: POPOVER, eventType: "clear" },
+      { component: POPOVER, eventType: "queue:clear" },
       ctx,
     );
     expect(handled).toBe(false);
@@ -84,7 +84,7 @@ describe("handleQueuedMessages", () => {
   it("ignores malformed edit payloads (missing messageId)", async () => {
     const { ctx, mocks } = fixtureWithActiveAgentTab();
     const handled = await handleQueuedMessages(
-      { component: POPOVER, eventType: "edit", data: { content: "x" } },
+      { component: POPOVER, eventType: "queue:edit", data: { content: "x" } },
       ctx,
     );
     expect(handled).toBe(false);

--- a/src/eventRoutes/queue.ts
+++ b/src/eventRoutes/queue.ts
@@ -1,0 +1,75 @@
+import type { Tab } from "../types/tab";
+import type { EventRouteHandler } from "./types";
+
+/**
+ * `queued-messages-popover` events. The composite lives inside the
+ * composer and emits four event types:
+ *
+ *   - `edit`   { messageId, content }  — replace a queued message body.
+ *   - `delete` { messageId }           — drop a queued message.
+ *   - `steer`  { messageId }           — pop + promote to mid-turn steer.
+ *   - `clear`                          — empty the queue.
+ *
+ * Routes to the active tab's queue (the popover only renders for the
+ * active tab, so we never need an explicit tabId in the payload). Keyed
+ * by `type:queued-messages-popover` so a custom override registered via
+ * `aethon.registerComponent("queued-messages-popover", …)` still routes
+ * through these handlers without an alias entry.
+ */
+function activeTabId(state: Record<string, unknown>): string | undefined {
+  return state.activeTabId as string | undefined;
+}
+
+function activeAgentTab(state: Record<string, unknown>): Tab | undefined {
+  const id = activeTabId(state);
+  if (!id) return undefined;
+  const tabs = (state.tabs as Tab[] | undefined) ?? [];
+  const tab = tabs.find((t) => t.id === id);
+  return tab && tab.kind === "agent" ? tab : undefined;
+}
+
+export const handleQueuedMessages: EventRouteHandler = async (
+  { eventType, data },
+  ctx,
+) => {
+  const tab = activeAgentTab(ctx.stateRef.current);
+  if (!tab) return false;
+  const tabId = tab.id;
+
+  if (eventType === "edit") {
+    const payload = (data ?? {}) as { messageId?: string; content?: string };
+    if (
+      typeof payload.messageId === "string" &&
+      typeof payload.content === "string"
+    ) {
+      ctx.editQueuedMessage(tabId, payload.messageId, payload.content);
+      return true;
+    }
+    return false;
+  }
+
+  if (eventType === "delete") {
+    const payload = (data ?? {}) as { messageId?: string };
+    if (typeof payload.messageId === "string") {
+      ctx.deleteQueuedMessage(tabId, payload.messageId);
+      return true;
+    }
+    return false;
+  }
+
+  if (eventType === "steer") {
+    const payload = (data ?? {}) as { messageId?: string };
+    if (typeof payload.messageId === "string") {
+      await ctx.steerQueuedMessage(tabId, payload.messageId);
+      return true;
+    }
+    return false;
+  }
+
+  if (eventType === "clear") {
+    ctx.clearQueuedMessages(tabId);
+    return true;
+  }
+
+  return false;
+};

--- a/src/eventRoutes/queue.ts
+++ b/src/eventRoutes/queue.ts
@@ -3,18 +3,22 @@ import type { EventRouteHandler } from "./types";
 
 /**
  * `queued-messages-popover` events. The composite lives inside the
- * composer and emits four event types:
+ * composer and emits four event types (prefixed with `queue:` so they
+ * are routable when the popover is mounted inline inside another
+ * composite — events route by host component type, not by the
+ * popover's own identity in that case):
  *
- *   - `edit`   { messageId, content }  — replace a queued message body.
- *   - `delete` { messageId }           — drop a queued message.
- *   - `steer`  { messageId }           — pop + promote to mid-turn steer.
- *   - `clear`                          — empty the queue.
+ *   - `queue:edit`   { messageId, content }  — replace a queued message body.
+ *   - `queue:delete` { messageId }           — drop a queued message.
+ *   - `queue:steer`  { messageId }           — pop + promote to mid-turn steer.
+ *   - `queue:clear`                          — empty the queue.
  *
  * Routes to the active tab's queue (the popover only renders for the
- * active tab, so we never need an explicit tabId in the payload). Keyed
- * by `type:queued-messages-popover` so a custom override registered via
- * `aethon.registerComponent("queued-messages-popover", …)` still routes
- * through these handlers without an alias entry.
+ * active tab, so we never need an explicit tabId in the payload). The
+ * handler is registered under BOTH `type:chat-input` (where it lands
+ * when the default-layout host inlines the popover) AND
+ * `type:queued-messages-popover` (for skill-override mounts that
+ * synthesize a fresh A2UI subtree via RegistryComponent).
  */
 function activeTabId(state: Record<string, unknown>): string | undefined {
   return state.activeTabId as string | undefined;
@@ -32,11 +36,17 @@ export const handleQueuedMessages: EventRouteHandler = async (
   { eventType, data },
   ctx,
 ) => {
+  // Only match queue-namespaced events. The handler is registered
+  // under `type:chat-input` (alongside handleChatInput) so it gets
+  // first crack at events from the inlined popover; non-queue
+  // events fall through to handleChatInput.
+  if (!eventType.startsWith("queue:")) return false;
   const tab = activeAgentTab(ctx.stateRef.current);
   if (!tab) return false;
   const tabId = tab.id;
+  const action = eventType.slice("queue:".length);
 
-  if (eventType === "edit") {
+  if (action === "edit") {
     const payload = (data ?? {}) as { messageId?: string; content?: string };
     if (
       typeof payload.messageId === "string" &&
@@ -48,7 +58,7 @@ export const handleQueuedMessages: EventRouteHandler = async (
     return false;
   }
 
-  if (eventType === "delete") {
+  if (action === "delete") {
     const payload = (data ?? {}) as { messageId?: string };
     if (typeof payload.messageId === "string") {
       ctx.deleteQueuedMessage(tabId, payload.messageId);
@@ -57,7 +67,7 @@ export const handleQueuedMessages: EventRouteHandler = async (
     return false;
   }
 
-  if (eventType === "steer") {
+  if (action === "steer") {
     const payload = (data ?? {}) as { messageId?: string };
     if (typeof payload.messageId === "string") {
       await ctx.steerQueuedMessage(tabId, payload.messageId);
@@ -66,7 +76,7 @@ export const handleQueuedMessages: EventRouteHandler = async (
     return false;
   }
 
-  if (eventType === "clear") {
+  if (action === "clear") {
     ctx.clearQueuedMessages(tabId);
     return true;
   }

--- a/src/eventRoutes/sidebar.test.ts
+++ b/src/eventRoutes/sidebar.test.ts
@@ -7,6 +7,7 @@ import {
   handleSidebarDeleteSession,
   handleSidebarRenameSession,
   handleSidebarSetProjectWorktreeBase,
+  handleSidebarSwitchWorktree,
   handleSidebarToggleExtension,
   handleSectionedSelect,
 } from "./sidebar";
@@ -263,6 +264,75 @@ describe("handleSidebarToggleExtension", () => {
     );
     expect(handled).toBe(false);
     expect(mocks.invoke).not.toHaveBeenCalled();
+  });
+});
+
+describe("handleSidebarSwitchWorktree", () => {
+  const sidebarState = {
+    sidebar: {
+      projects: [
+        {
+          id: "proj-1",
+          label: "aethon",
+          worktrees: [
+            {
+              id: "wt-1",
+              label: "fix/issue",
+              branch: "fix/issue",
+              path: "/repo/aethon-fix-issue",
+              isMain: false,
+            },
+          ],
+        },
+      ],
+    },
+  };
+
+  it("shows the landing when switching to an empty worktree scope", async () => {
+    const { ctx, applySetState } = buildRouteFixture({ state: sidebarState });
+
+    const handled = await handleSidebarSwitchWorktree(
+      {
+        component: { id: "sidebar" },
+        eventType: "switch-worktree",
+        data: { worktreeId: "wt-1" },
+      },
+      ctx,
+    );
+
+    expect(handled).toBe(true);
+    expect(ctx.activateWorktree).toHaveBeenCalledWith("wt-1");
+    expect(applySetState().landing).toMatchObject({
+      kind: "worktree",
+      projectId: "proj-1",
+      worktreeId: "wt-1",
+      path: "/repo/aethon-fix-issue",
+    });
+  });
+
+  it("reveals an existing worktree session instead of covering it with landing", async () => {
+    const { ctx, mocks, applySetState } = buildRouteFixture({
+      state: sidebarState,
+    });
+    mocks.activateWorktree.mockImplementation(() => {
+      ctx.stateRef.current = {
+        ...ctx.stateRef.current,
+        tabs: [{ id: "tab-1", kind: "agent", cwd: "/repo/aethon-fix-issue" }],
+        activeTabId: "tab-1",
+      };
+    });
+
+    const handled = await handleSidebarSwitchWorktree(
+      {
+        component: { id: "sidebar" },
+        eventType: "switch-worktree",
+        data: { worktreeId: "wt-1" },
+      },
+      ctx,
+    );
+
+    expect(handled).toBe(true);
+    expect(applySetState().landing).toBeNull();
   });
 });
 

--- a/src/eventRoutes/sidebar.ts
+++ b/src/eventRoutes/sidebar.ts
@@ -185,12 +185,10 @@ export const handleSidebarCreateWorktree: EventRouteHandler = (
   return true;
 };
 /**
- * switch-worktree: route the user to a landing page for the selected
- * worktree instead of activating it immediately. The landing presents
- * a "Start Session" CTA that fires `start-session`, which is where the
- * actual `activateWorktree` + new-tab flow happens. Pulling the landing
- * in between gives us a place to surface branch metadata (cwd, branch
- * name, GitHub status) before the user commits to a fresh session.
+ * switch-worktree: switch to the selected worktree's session scope and
+ * route the user to its landing page. The landing presents a
+ * "Start Session" CTA that fires `start-session`, which opens a fresh
+ * agent tab inside that already-selected scope.
  */
 export const handleSidebarSwitchWorktree: EventRouteHandler = (
   { eventType, data },
@@ -227,6 +225,26 @@ export const handleSidebarSwitchWorktree: EventRouteHandler = (
   for (const project of sidebar.projects ?? []) {
     const worktree = project.worktrees?.find((w) => w.id === worktreeId);
     if (worktree) {
+      ctx.activateWorktree(worktreeId);
+      const tabs = Array.isArray(ctx.stateRef.current.tabs)
+        ? ctx.stateRef.current.tabs
+        : [];
+      const activeTabId = ctx.stateRef.current.activeTabId;
+      const hasVisibleSession =
+        tabs.length > 0 &&
+        (typeof activeTabId !== "string" ||
+          tabs.some((tab) => {
+            return (
+              tab &&
+              typeof tab === "object" &&
+              "id" in tab &&
+              tab.id === activeTabId
+            );
+          }));
+      if (hasVisibleSession) {
+        ctx.setState((prev) => ({ ...prev, landing: null }));
+        return true;
+      }
       ctx.setState((prev) => ({
         ...prev,
         landing: {

--- a/src/eventRoutes/testFixtures.ts
+++ b/src/eventRoutes/testFixtures.ts
@@ -32,6 +32,10 @@ export interface RouteFixture {
     sendChat: Mock;
     stopPrompt: Mock;
     updateActiveTab: Mock;
+    editQueuedMessage: Mock;
+    deleteQueuedMessage: Mock;
+    steerQueuedMessage: Mock;
+    clearQueuedMessages: Mock;
     newTab: Mock;
     newShellTab: Mock;
     newEditorTab: Mock;
@@ -106,6 +110,10 @@ export function buildRouteFixture(
   const sendChat = vi.fn(() => Promise.resolve());
   const stopPrompt = vi.fn(() => Promise.resolve());
   const updateActiveTab = vi.fn();
+  const editQueuedMessage = vi.fn();
+  const deleteQueuedMessage = vi.fn();
+  const steerQueuedMessage = vi.fn(() => Promise.resolve());
+  const clearQueuedMessages = vi.fn();
   const newTab = vi.fn();
   const newShellTab = vi.fn();
   const newEditorTab = vi.fn();
@@ -160,6 +168,10 @@ export function buildRouteFixture(
     sendChat,
     stopPrompt,
     updateActiveTab,
+    editQueuedMessage,
+    deleteQueuedMessage,
+    steerQueuedMessage,
+    clearQueuedMessages,
     newTab,
     newShellTab,
     newEditorTab,
@@ -233,6 +245,10 @@ export function buildRouteFixture(
       sendChat,
       stopPrompt,
       updateActiveTab,
+      editQueuedMessage,
+      deleteQueuedMessage,
+      steerQueuedMessage,
+      clearQueuedMessages,
       newTab,
       newShellTab,
       newEditorTab,

--- a/src/eventRoutes/types.ts
+++ b/src/eventRoutes/types.ts
@@ -70,6 +70,16 @@ export interface EventRouteContext {
   stopPrompt: (explicitTabId?: string) => Promise<void>;
   updateActiveTab: (updater: (tab: Tab) => Tab) => void;
 
+  // ─── Queue (popover above composer) ─────────────────────────────────
+  editQueuedMessage: (
+    tabId: string,
+    messageId: string,
+    content: string,
+  ) => void;
+  deleteQueuedMessage: (tabId: string, messageId: string) => void;
+  steerQueuedMessage: (tabId: string, messageId: string) => Promise<void>;
+  clearQueuedMessages: (tabId: string) => void;
+
   // ─── Tab / shell actions (from useTabs) ─────────────────────────────
   newTab: (
     tabId?: string,

--- a/src/hooks/bridgeMessageHandlers/promptStarted.test.ts
+++ b/src/hooks/bridgeMessageHandlers/promptStarted.test.ts
@@ -11,7 +11,7 @@ describe("handlePromptStarted", () => {
     vi.useRealTimers();
   });
 
-  it("flips waiting + records turn start + sets active status", () => {
+  it("flips waiting + records turn start + sets active status, deriving queueCount from the client-held queue", () => {
     const { ctx, mocks } = buildHandlerFixture({
       state: { activeTabId: "default" },
     });
@@ -21,10 +21,46 @@ describe("handlePromptStarted", () => {
     );
     expect(ctx.turnStartedAtRef.current.has("default")).toBe(true);
     const [, updater] = mocks.updateTab.mock.calls[0];
-    const out = updater(makeEmptyTab("default", "Tab 1"));
+    // The handler ignores the bridge's stale `queued` field — the
+    // CLIENT now owns the queue, and queueCount mirrors
+    // `tab.queuedMessages.length`. A tab with two queued messages
+    // keeps that count even though the bridge reported 2 (or 0).
+    const seedTab = {
+      ...makeEmptyTab("default", "Tab 1"),
+      queuedMessages: [
+        { id: "q1", content: "later 1" },
+        { id: "q2", content: "later 2" },
+      ],
+      queueCount: 2,
+    };
+    const out = updater(seedTab);
     expect(out.waiting).toBe(true);
     expect(out.queueCount).toBe(2);
     expect(mocks.setState).toHaveBeenCalledTimes(1);
+  });
+
+  it("derives queueCount from the client queue rather than the bridge's stale value", () => {
+    // Regression: previously the handler took the bridge's
+    // `data.queued` and overwrote queueCount with it, which clobbered
+    // a freshly-popped client-side count during auto-drain. The
+    // bridge always reports 0 on the new flow because pi's followUp
+    // queue is unused.
+    const { ctx, mocks } = buildHandlerFixture({
+      state: { activeTabId: "default" },
+    });
+    handlePromptStarted(
+      { type: "prompt_started", tabId: "default", queued: 0 },
+      ctx,
+    );
+    const [, updater] = mocks.updateTab.mock.calls[0];
+    const out = updater({
+      ...makeEmptyTab("default", "Tab 1"),
+      // Simulates a freshly-drained tab: one item remains in the
+      // popover, count stays 1, bridge says 0 (stale) — keep 1.
+      queuedMessages: [{ id: "q1", content: "next" }],
+      queueCount: 1,
+    });
+    expect(out.queueCount).toBe(1);
   });
 
   it("promotes the oldest queued user message when a queued prompt starts", () => {
@@ -43,8 +79,11 @@ describe("handlePromptStarted", () => {
         { id: "u2", role: "user", text: "start me", delivery: "queued" },
         { id: "u3", role: "user", text: "after me", delivery: "queued" },
       ],
-      queueCount: 2,
+      queuedMessages: [{ id: "qm-after", content: "after me" }],
+      queueCount: 1,
     });
+    // queueCount derives from queuedMessages.length — the client
+    // queue has one item left, not two.
     expect(out.queueCount).toBe(1);
     expect(out.messages).toEqual([
       { id: "u1", role: "user", text: "running", delivery: "sent" },

--- a/src/hooks/bridgeMessageHandlers/promptStarted.ts
+++ b/src/hooks/bridgeMessageHandlers/promptStarted.ts
@@ -9,15 +9,22 @@ import type { BridgeMessageHandler } from "./types";
  *  bar text only flips for the active tab. */
 export const handlePromptStarted: BridgeMessageHandler = (data, ctx) => {
   const tabId = (data.tabId as string | undefined) ?? "default";
-  const remaining = (data.queued as number | undefined) ?? undefined;
   // Record turn start so response_end can compute duration and decide
   // whether to fire the OS completion notification.
   ctx.turnStartedAtRef.current.set(tabId, Date.now());
   ctx.updateTab(tabId, (tab) => {
+    // queueCount mirrors the CLIENT-held queue now (Claudette-style
+    // queued-messages popover). The bridge's `data.queued` field came
+    // from pi's followUp queue and is stale on the new flow — frontend
+    // never invokes send_message during a busy turn, so pi's queue
+    // stays empty and overwriting with that 0 would erase items the
+    // user just popped off the client queue. Recompute from
+    // `queuedMessages.length` instead so the badge stays in lockstep
+    // with the popover.
     const next = {
       ...tab,
       waiting: true,
-      ...(remaining !== undefined ? { queueCount: remaining } : {}),
+      queueCount: (tab.queuedMessages ?? []).length,
     };
     if (data.source !== "queue") return next;
     let promoted = false;

--- a/src/hooks/bridgeMessageHandlers/queueReset.test.ts
+++ b/src/hooks/bridgeMessageHandlers/queueReset.test.ts
@@ -1,22 +1,18 @@
 import { describe, expect, it } from "vitest";
 import { handleQueueReset } from "./queueReset";
 import { buildHandlerFixture } from "./testFixtures";
-import { makeEmptyTab } from "../../types/tab";
 
 describe("handleQueueReset", () => {
-  it("zeroes the per-tab queueCount", () => {
+  it("is a no-op — the client-held queue is the source of truth", () => {
+    // pi's followUp queue is unused on the new flow; stopPrompt
+    // clears the client queue directly. Mutating queueCount from a
+    // bridge event would desync the badge from queuedMessages.
     const { ctx, mocks } = buildHandlerFixture();
     handleQueueReset({ type: "queue_reset", tabId: "default" }, ctx);
-    const [, updater] = mocks.updateTab.mock.calls[0];
-    const seed = { ...makeEmptyTab("default", "Tab 1"), queueCount: 7 };
-    expect(updater(seed).queueCount).toBe(0);
-  });
-
-  it("accepts an explicit remaining queue count", () => {
-    const { ctx, mocks } = buildHandlerFixture();
-    handleQueueReset({ type: "queue_reset", tabId: "default", queued: 2 }, ctx);
-    const [, updater] = mocks.updateTab.mock.calls[0];
-    const seed = { ...makeEmptyTab("default", "Tab 1"), queueCount: 7 };
-    expect(updater(seed).queueCount).toBe(2);
+    handleQueueReset(
+      { type: "queue_reset", tabId: "default", queued: 2 },
+      ctx,
+    );
+    expect(mocks.updateTab).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/bridgeMessageHandlers/queueReset.ts
+++ b/src/hooks/bridgeMessageHandlers/queueReset.ts
@@ -1,14 +1,13 @@
 import type { BridgeMessageHandler } from "./types";
 
-/** Bridge dropped this tab's pi follow-up queue (typically on Stop).
- *  Mirror by zeroing the local queueCount so the next response_end
- *  clears `waiting` instead of staying stuck on the
- *  "queue > 0 keeps Stop" gate. */
-export const handleQueueReset: BridgeMessageHandler = (data, ctx) => {
-  const tabId = (data.tabId as string | undefined) ?? "default";
-  const queued =
-    typeof data.queued === "number" && Number.isFinite(data.queued)
-      ? Math.max(0, Math.floor(data.queued))
-      : 0;
-  ctx.updateTab(tabId, (tab) => ({ ...tab, queueCount: queued }));
+/** Bridge `queue_reset` event — emitted when pi drops its followUp
+ *  queue (typically on Stop). On the Claudette-style client-held
+ *  queue path, pi's followUp queue is unused, so this event
+ *  effectively never fires. `tab.queueCount` derives from
+ *  `tab.queuedMessages.length` and is cleared by `stopPrompt`
+ *  directly when the user clicks Stop; mutating queueCount here
+ *  would desync the badge from the popover.
+ *  See: src/types/tab.ts contract on the `queueCount` field. */
+export const handleQueueReset: BridgeMessageHandler = (_data, _ctx) => {
+  // intentionally empty
 };

--- a/src/hooks/bridgeMessageHandlers/queued.test.ts
+++ b/src/hooks/bridgeMessageHandlers/queued.test.ts
@@ -1,15 +1,16 @@
 import { describe, expect, it } from "vitest";
 import { handleQueued } from "./queued";
 import { buildHandlerFixture } from "./testFixtures";
-import { makeEmptyTab } from "../../types/tab";
 
 describe("handleQueued", () => {
-  it("bumps the per-tab queueCount", () => {
+  it("is a no-op so a stray bridge emission cannot desync the client-held queue badge", () => {
+    // Under the client-held queue model, queueCount derives from
+    // queuedMessages.length and bridge-driven mutations would
+    // corrupt that invariant. Frontend never invokes send_message
+    // during a busy turn, so this event effectively never fires —
+    // the handler stays registered as a safety net only.
     const { ctx, mocks } = buildHandlerFixture();
     handleQueued({ type: "queued", tabId: "default" }, ctx);
-    const [tabId, updater] = mocks.updateTab.mock.calls[0];
-    expect(tabId).toBe("default");
-    const seed = { ...makeEmptyTab("default", "Tab 1"), queueCount: 3 };
-    expect(updater(seed).queueCount).toBe(4);
+    expect(mocks.updateTab).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/bridgeMessageHandlers/queued.ts
+++ b/src/hooks/bridgeMessageHandlers/queued.ts
@@ -1,8 +1,14 @@
 import type { BridgeMessageHandler } from "./types";
 
-/** A new chat IPC arrived while a prompt was in flight; pi accepted it
- *  into the followUp queue. Bump the per-tab counter. */
-export const handleQueued: BridgeMessageHandler = (data, ctx) => {
-  const tabId = (data.tabId as string | undefined) ?? "default";
-  ctx.updateTab(tabId, (tab) => ({ ...tab, queueCount: tab.queueCount + 1 }));
+/** Bridge `queued` event — emitted when pi accepts a chat IPC into its
+ *  followUp queue while a prompt is in flight. With the Claudette-style
+ *  client-held queue, the frontend no longer invokes `send_message`
+ *  during a busy turn, so pi's followUp stays empty and this event
+ *  effectively never fires. We keep the handler registered (and as a
+ *  no-op) so a stray emission can't corrupt `queueCount`, which now
+ *  derives strictly from `tab.queuedMessages.length`. Mutating
+ *  queueCount here would desync the badge from the popover.
+ *  See: src/types/tab.ts contract on the `queueCount` field. */
+export const handleQueued: BridgeMessageHandler = (_data, _ctx) => {
+  // intentionally empty
 };

--- a/src/hooks/bridgeMessageHandlers/ready.test.ts
+++ b/src/hooks/bridgeMessageHandlers/ready.test.ts
@@ -400,6 +400,54 @@ describe("handleReady", () => {
     );
   });
 
+  it("re-announces the active tab cwd even when the project worktree selection was cleared", () => {
+    const { ctx, mocks } = buildHandlerFixture({
+      state: {
+        activeTabId: "tab-1",
+        tabs: [
+          {
+            id: "tab-1",
+            kind: "agent",
+            projectId: "p1",
+            cwd: "/tmp/p1-fix",
+          },
+        ],
+      },
+    });
+    ctx.projectsRef.current = {
+      activeId: "p1",
+      activeWorktreeId: null,
+      activeHostId: null,
+      projects: [{ id: "p1", label: "p1", path: "/tmp/p1", lastUsed: 1 }],
+      worktreesByProject: {
+        p1: [
+          {
+            id: "wt-1",
+            projectId: "p1",
+            path: "/tmp/p1-fix",
+            branch: "fix/reload",
+            isMain: false,
+          },
+        ],
+      },
+    };
+
+    handleReady(
+      {
+        type: "ready",
+        model: "claude",
+        tabs: [{ id: "tab-1", model: "claude", cwd: "/tmp/p1-fix" }],
+        currentProjectCwd: "/tmp/p1",
+      },
+      ctx,
+    );
+
+    expect(mocks.announceProjectToBridge).toHaveBeenCalledWith(
+      "tab-1",
+      "/tmp/p1-fix",
+    );
+  });
+
   it("requests transcript replay for non-default open tabs after ready", () => {
     const harness = installTauriMocks();
     const { ctx } = buildHandlerFixture({

--- a/src/hooks/bridgeMessageHandlers/ready.ts
+++ b/src/hooks/bridgeMessageHandlers/ready.ts
@@ -74,6 +74,17 @@ export const handleReady: BridgeMessageHandler = (data, ctx) => {
     data.currentProjectCwd.length > 0
       ? data.currentProjectCwd
       : null;
+  const priorActiveTabId =
+    (ctx.stateRef.current.activeTabId as string | undefined) ?? "default";
+  const priorActiveTab = (
+    (ctx.stateRef.current.tabs as Tab[] | undefined) ?? []
+  ).find((t) => t.id === priorActiveTabId);
+  const priorActiveTabCwd =
+    priorActiveTab?.kind !== "shell" &&
+    typeof priorActiveTab?.cwd === "string" &&
+    priorActiveTab.cwd.length > 0
+      ? priorActiveTab.cwd
+      : null;
   // Cache pi's default model so new tabs created before `ready` fires
   // (or before a session's model initialises) can inherit it immediately
   // instead of showing blank "model ▼".
@@ -454,10 +465,11 @@ export const handleReady: BridgeMessageHandler = (data, ctx) => {
   // refreshed resources, so only announce when the bridge reports a
   // different cwd. Otherwise a ready -> set_project -> ready loop can
   // monopolize the release app and blank the webview.
-  const activePath = activeCwd(ctx.projectsRef.current);
+  const projectActivePath = activeCwd(ctx.projectsRef.current);
+  const activePath = ctx.projectsRef.current.activeWorktreeId
+    ? projectActivePath
+    : (priorActiveTabCwd ?? projectActivePath);
   if (activePath && currentProjectCwd !== activePath) {
-    const activeTabId =
-      (ctx.stateRef.current.activeTabId as string | undefined) ?? "default";
-    ctx.announceProjectToBridge(activeTabId, activePath);
+    ctx.announceProjectToBridge(priorActiveTabId, activePath);
   }
 };

--- a/src/hooks/bridgeMessageHandlers/responseEnd.test.ts
+++ b/src/hooks/bridgeMessageHandlers/responseEnd.test.ts
@@ -24,13 +24,22 @@ describe("handleResponseEnd", () => {
     expect(mocks.maybeFireCompletionNotification).toHaveBeenCalled();
   });
 
-  it("preserves waiting when queueCount > 0", () => {
+  it("clears waiting even when a client-side queue is non-empty", () => {
+    // The client-side queue is drained by useQueuedDispatch on the
+    // waiting=true→false transition, so we MUST clear waiting here —
+    // otherwise the dispatch effect never sees the idle moment and the
+    // queue stalls.
     const { ctx, mocks } = buildHandlerFixture({
       state: { activeTabId: "default" },
     });
     handleResponseEnd({ type: "response_end", tabId: "default" }, ctx);
     const [, updater] = mocks.updateTab.mock.calls[0];
-    const seed = { ...makeEmptyTab("default", "Tab 1"), queueCount: 1, waiting: true };
-    expect(updater(seed)).toEqual(seed);
+    const seed = {
+      ...makeEmptyTab("default", "Tab 1"),
+      queueCount: 1,
+      queuedMessages: [{ id: "q1", content: "next" }],
+      waiting: true,
+    };
+    expect(updater(seed).waiting).toBe(false);
   });
 });

--- a/src/hooks/bridgeMessageHandlers/responseEnd.ts
+++ b/src/hooks/bridgeMessageHandlers/responseEnd.ts
@@ -5,20 +5,14 @@ export const handleResponseEnd: BridgeMessageHandler = (data, ctx) => {
   ctx.activeResponseIdRef.current = null;
   const tabId = (data.tabId as string | undefined) ?? "default";
   flushResponseDeltas(tabId);
-  // Only clear waiting when the queue is actually empty. If pi has a
-  // followUp queued, it will fire agent_start → prompt_started
-  // immediately after this and re-flip waiting; clearing here would
-  // cause a Send-flash.
-  ctx.updateTab(tabId, (tab) => {
-    if (tab.queueCount > 0) return tab;
-    return { ...tab, waiting: false };
-  });
+  // Always clear waiting on response_end. The queue is now held client
+  // side: `useQueuedDispatch` watches the `waiting` transition and
+  // re-flips it to true while popping the head and dispatching the
+  // next message — same render commit, so the Send button doesn't
+  // flash. When the queue is empty, waiting stays false.
+  ctx.updateTab(tabId, (tab) => ({ ...tab, waiting: false }));
   if (ctx.stateRef.current.activeTabId === tabId) {
-    ctx.setState((prev) => {
-      const q = (prev.queueCount as number) ?? 0;
-      if (q > 0) return prev;
-      return { ...prev, status: "ready" };
-    });
+    ctx.setState((prev) => ({ ...prev, status: "ready" }));
   }
   // Clear the hang-warn timer and dismiss this tab's notification (if it
   // appeared). Per-tab id so an unrelated tab's response_end doesn't

--- a/src/hooks/bridgeMessageHandlers/sessionHistory.test.ts
+++ b/src/hooks/bridgeMessageHandlers/sessionHistory.test.ts
@@ -84,4 +84,64 @@ describe("handleSessionHistory", () => {
     const out = updater(makeEmptyTab("default", "Custom label"));
     expect(out.label).toBe("Custom label");
   });
+
+  it("preserves a pending launch prompt when restored history has not recorded it yet", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleSessionHistory(
+      {
+        type: "session_history",
+        tabId: "tab-1",
+        messages: [{ id: "agent-1", role: "agent", text: "Working" }],
+      },
+      ctx,
+    );
+    const [, updater] = mocks.updateTab.mock.calls[0];
+    const tab = makeEmptyTab("tab-1", "Tab 1");
+    const out = updater({
+      ...tab,
+      messages: [
+        {
+          id: "local-prompt",
+          role: "user",
+          text: "Fix issue 85",
+          delivery: "sent",
+        },
+      ],
+    });
+    expect(out.messages).toEqual([
+      expect.objectContaining({
+        id: "local-prompt",
+        role: "user",
+        text: "Fix issue 85",
+      }),
+      expect.objectContaining({ id: "agent-1", role: "agent" }),
+    ]);
+  });
+
+  it("does not duplicate a pending prompt already present in restored history", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleSessionHistory(
+      {
+        type: "session_history",
+        tabId: "tab-1",
+        messages: [{ id: "restored-user", role: "user", text: "Fix issue 85" }],
+      },
+      ctx,
+    );
+    const [, updater] = mocks.updateTab.mock.calls[0];
+    const tab = makeEmptyTab("tab-1", "Tab 1");
+    const out = updater({
+      ...tab,
+      messages: [
+        {
+          id: "local-prompt",
+          role: "user",
+          text: "Fix issue 85",
+          delivery: "sent",
+        },
+      ],
+    });
+    expect(out.messages).toHaveLength(1);
+    expect(out.messages[0]).toMatchObject({ id: "restored-user" });
+  });
 });

--- a/src/hooks/bridgeMessageHandlers/sessionHistory.test.ts
+++ b/src/hooks/bridgeMessageHandlers/sessionHistory.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { handleSessionHistory } from "./sessionHistory";
 import { buildHandlerFixture } from "./testFixtures";
 import { makeEmptyTab } from "../../types/tab";
+import type { ChatMessage } from "../../types/a2ui";
 
 describe("handleSessionHistory", () => {
   it("replaces the tab's messages and triggers a recents resync", () => {
@@ -157,7 +158,7 @@ describe("handleSessionHistory", () => {
         },
       ],
     });
-    expect(out.messages.map((m) => m.id)).toEqual([
+    expect(out.messages.map((m: ChatMessage) => m.id)).toEqual([
       "old-user",
       "old-agent",
       "local-prompt",

--- a/src/hooks/bridgeMessageHandlers/sessionHistory.test.ts
+++ b/src/hooks/bridgeMessageHandlers/sessionHistory.test.ts
@@ -85,7 +85,7 @@ describe("handleSessionHistory", () => {
     expect(out.label).toBe("Custom label");
   });
 
-  it("preserves a pending launch prompt when restored history has not recorded it yet", () => {
+  it("appends a pending launch prompt AFTER the restored transcript so order stays chronological", () => {
     const { ctx, mocks } = buildHandlerFixture();
     handleSessionHistory(
       {
@@ -108,14 +108,88 @@ describe("handleSessionHistory", () => {
         },
       ],
     });
+    // Restored history first, in-flight local message after — the
+    // bug the peer-review caught was the inverse: pending prompts
+    // surfaced ABOVE older restored history, making the transcript
+    // unreadable.
     expect(out.messages).toEqual([
+      expect.objectContaining({ id: "agent-1", role: "agent" }),
       expect.objectContaining({
         id: "local-prompt",
         role: "user",
         text: "Fix issue 85",
       }),
-      expect.objectContaining({ id: "agent-1", role: "agent" }),
     ]);
+  });
+
+  it("preserves in-flight assistant streaming deltas across the restore", () => {
+    // Regression: the merge previously filtered to user messages only,
+    // so an assistant bubble already streaming when session_history
+    // arrived would vanish — the user would watch their answer get
+    // wiped mid-response.
+    const { ctx, mocks } = buildHandlerFixture();
+    handleSessionHistory(
+      {
+        type: "session_history",
+        tabId: "tab-1",
+        messages: [
+          { id: "old-user", role: "user", text: "previous prompt" },
+          { id: "old-agent", role: "agent", text: "previous answer" },
+        ],
+      },
+      ctx,
+    );
+    const [, updater] = mocks.updateTab.mock.calls[0];
+    const tab = makeEmptyTab("tab-1", "Tab 1");
+    const out = updater({
+      ...tab,
+      messages: [
+        {
+          id: "local-prompt",
+          role: "user",
+          text: "what about this",
+          delivery: "sent",
+        },
+        {
+          id: "streaming-agent",
+          role: "agent",
+          text: "I'm thinki",
+        },
+      ],
+    });
+    expect(out.messages.map((m) => m.id)).toEqual([
+      "old-user",
+      "old-agent",
+      "local-prompt",
+      "streaming-agent",
+    ]);
+  });
+
+  it("drops failed local user messages on restore (they are informational once history arrives)", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleSessionHistory(
+      {
+        type: "session_history",
+        tabId: "tab-1",
+        messages: [{ id: "old-user", role: "user", text: "fine" }],
+      },
+      ctx,
+    );
+    const [, updater] = mocks.updateTab.mock.calls[0];
+    const tab = makeEmptyTab("tab-1", "Tab 1");
+    const out = updater({
+      ...tab,
+      messages: [
+        {
+          id: "local-failed",
+          role: "user",
+          text: "lost in transit",
+          delivery: "failed",
+        },
+      ],
+    });
+    expect(out.messages).toHaveLength(1);
+    expect(out.messages[0]).toMatchObject({ id: "old-user" });
   });
 
   it("does not duplicate a pending prompt already present in restored history", () => {

--- a/src/hooks/bridgeMessageHandlers/sessionHistory.ts
+++ b/src/hooks/bridgeMessageHandlers/sessionHistory.ts
@@ -22,6 +22,12 @@ function mergePendingLocalPrompts(
   restored: ChatMessage[],
   current: ChatMessage[],
 ): ChatMessage[] {
+  // Carry pending local messages — both the optimistic user prompts
+  // the user sent before the restored history arrived AND any
+  // assistant streaming deltas already in flight — across the
+  // history hydration so the transcript stays chronological and
+  // live output isn't dropped. Restored transcript first, pending
+  // local appended after.
   const restoredIds = new Set(restored.map((m) => m.id));
   const restoredUserTexts = new Set(
     restored
@@ -30,13 +36,26 @@ function mergePendingLocalPrompts(
       .filter(Boolean),
   );
   const pendingLocal = current.filter((m) => {
-    if (m.role !== "user") return false;
-    if (!m.delivery || m.delivery === "failed") return false;
     if (restoredIds.has(m.id)) return false;
-    const text = typeof m.text === "string" ? m.text.trim() : "";
-    return text.length > 0 && !restoredUserTexts.has(text);
+    if (m.role === "user") {
+      // A failed local user message is informational once history
+      // catches up — the bridge will resend or the user will retry.
+      if (!m.delivery || m.delivery === "failed") return false;
+      const text = typeof m.text === "string" ? m.text.trim() : "";
+      // If the same prompt text already appears in the restored
+      // transcript, treat the local copy as a duplicate (the bridge
+      // recorded it canonically); otherwise keep it.
+      return text.length > 0 && !restoredUserTexts.has(text);
+    }
+    // Keep system + agent messages that don't share an id with
+    // anything in the restored set — those are typically streaming
+    // assistant deltas, system notices about the in-flight turn, or
+    // tool-card payloads the bridge will resolve as the response
+    // continues. Dropping them would erase visible progress the
+    // user just watched land.
+    return true;
   });
-  return pendingLocal.length > 0 ? [...pendingLocal, ...restored] : restored;
+  return pendingLocal.length > 0 ? [...restored, ...pendingLocal] : restored;
 }
 
 export const handleSessionHistory: BridgeMessageHandler = (data, ctx) => {

--- a/src/hooks/bridgeMessageHandlers/sessionHistory.ts
+++ b/src/hooks/bridgeMessageHandlers/sessionHistory.ts
@@ -18,6 +18,27 @@ function shouldReplaceGenericLabel(label: string): boolean {
   return /^Tab \d+$/.test(label) || /^Session [A-Za-z0-9-]+$/.test(label);
 }
 
+function mergePendingLocalPrompts(
+  restored: ChatMessage[],
+  current: ChatMessage[],
+): ChatMessage[] {
+  const restoredIds = new Set(restored.map((m) => m.id));
+  const restoredUserTexts = new Set(
+    restored
+      .filter((m) => m.role === "user" && typeof m.text === "string")
+      .map((m) => m.text?.trim())
+      .filter(Boolean),
+  );
+  const pendingLocal = current.filter((m) => {
+    if (m.role !== "user") return false;
+    if (!m.delivery || m.delivery === "failed") return false;
+    if (restoredIds.has(m.id)) return false;
+    const text = typeof m.text === "string" ? m.text.trim() : "";
+    return text.length > 0 && !restoredUserTexts.has(text);
+  });
+  return pendingLocal.length > 0 ? [...pendingLocal, ...restored] : restored;
+}
+
 export const handleSessionHistory: BridgeMessageHandler = (data, ctx) => {
   const tabId = (data.tabId as string | undefined) ?? "default";
   const messages = coerceChatMessages(data.messages);
@@ -31,7 +52,7 @@ export const handleSessionHistory: BridgeMessageHandler = (data, ctx) => {
       : undefined);
   ctx.updateTab(tabId, (tab) => ({
     ...tab,
-    messages,
+    messages: mergePendingLocalPrompts(messages, tab.messages),
     ...(label
       ? { label }
       : shouldReplaceGenericLabel(tab.label)

--- a/src/hooks/useChat.test.ts
+++ b/src/hooks/useChat.test.ts
@@ -291,6 +291,68 @@ describe("useChat setModel", () => {
     expect(tab.messages.some((m) => m.text === "after this")).toBe(false);
   });
 
+  it("stopPrompt empties the client-held queue (regression: P2 from peer review)", async () => {
+    // The composer's "Stop + clear" button advertises queue clearing.
+    // Without this, queued messages survived the stop and drained on
+    // the next idle, executing prompts the user had just tried to
+    // cancel.
+    const { ctx, stateRef } = buildContext({ waiting: true });
+    const { result } = renderHook(() => useChat(ctx));
+
+    await act(async () => {
+      await result.current.sendChat("a");
+      await result.current.sendChat("b");
+      await result.current.sendChat("c");
+    });
+    expect(
+      (stateRef.current.tabs as Tab[])[0].queuedMessages,
+    ).toHaveLength(3);
+
+    await act(async () => {
+      await result.current.stopPrompt("tab-1");
+    });
+
+    const tab = (stateRef.current.tabs as Tab[])[0];
+    expect(tab.queuedMessages).toEqual([]);
+    expect(tab.queueCount).toBe(0);
+    expect(invoke).toHaveBeenCalledWith("agent_command", {
+      payload: JSON.stringify({ type: "stop", tabId: "tab-1" }),
+    });
+  });
+
+  it("drained queued messages actually reach invoke('send_message') (regression: P1 from peer review)", async () => {
+    // Reproduces the bug Codex flagged: useQueuedDispatch previously
+    // flipped waiting=true *before* calling sendChat. Because the
+    // store mutation is synchronous, sendChat saw the tab as busy
+    // and re-queued the popped message with a fresh id, never
+    // hitting the bridge. The fix pops the head only and lets
+    // sendChat's normal path flip waiting itself.
+    const { ctx, stateRef } = buildContext({ waiting: false });
+    const { result } = renderHook(() => useChat(ctx));
+
+    // Simulate useQueuedDispatch's contract: pop head, hand off to sendChat.
+    act(() => {
+      ctx.updateTab("tab-1", (t) => ({
+        ...t,
+        queuedMessages: [],
+        queueCount: 0,
+      }));
+    });
+    await act(async () => {
+      await result.current.sendChat("drained", { mode: "normal", tabId: "tab-1" });
+    });
+
+    expect(invoke).toHaveBeenCalledWith("send_message", {
+      message: "drained",
+      tabId: "tab-1",
+      mode: "normal",
+    });
+    const tab = (stateRef.current.tabs as Tab[])[0];
+    expect(tab.queuedMessages).toEqual([]);
+    expect(tab.waiting).toBe(true);
+    expect(tab.messages.some((m) => m.text === "drained")).toBe(true);
+  });
+
   it("marks the local user message failed when send_message rejects", async () => {
     invoke.mockRejectedValueOnce(new Error("bridge closed"));
     const { ctx, stateRef } = buildContext();

--- a/src/hooks/useChat.test.ts
+++ b/src/hooks/useChat.test.ts
@@ -222,7 +222,7 @@ describe("useChat setModel", () => {
     const queued = (stateRef.current.tabs as Tab[])[0].queuedMessages;
     expect(queued).toHaveLength(1);
 
-    await act(async () => {
+    act(() => {
       result.current.editQueuedMessage("tab-1", queued[0].id, "rewritten");
     });
     expect((stateRef.current.tabs as Tab[])[0].queuedMessages[0].content).toBe(
@@ -240,7 +240,7 @@ describe("useChat setModel", () => {
     });
     const queued = (stateRef.current.tabs as Tab[])[0].queuedMessages;
 
-    await act(async () => {
+    act(() => {
       result.current.deleteQueuedMessage("tab-1", queued[0].id);
     });
     expect(
@@ -261,7 +261,7 @@ describe("useChat setModel", () => {
       (stateRef.current.tabs as Tab[])[0].queuedMessages,
     ).toHaveLength(3);
 
-    await act(async () => {
+    act(() => {
       result.current.clearQueuedMessages("tab-1");
     });
     expect((stateRef.current.tabs as Tab[])[0].queuedMessages).toEqual([]);

--- a/src/hooks/useChat.test.ts
+++ b/src/hooks/useChat.test.ts
@@ -184,7 +184,94 @@ describe("useChat setModel", () => {
     });
   });
 
-  it("marks normal messages as queued while the active prompt is busy", async () => {
+  it("steerQueuedMessage pops the entry, flips the spinner id, and ships it as steer", async () => {
+    const { ctx, stateRef } = buildContext({ waiting: true });
+    const { result } = renderHook(() => useChat(ctx));
+
+    // Pre-load two queued items.
+    await act(async () => {
+      await result.current.sendChat("first");
+      await result.current.sendChat("second");
+    });
+    const queued = (stateRef.current.tabs as Tab[])[0].queuedMessages;
+    expect(queued.map((m) => m.content)).toEqual(["first", "second"]);
+
+    await act(async () => {
+      await result.current.steerQueuedMessage("tab-1", queued[0].id);
+    });
+
+    // The steered message is no longer in the queue.
+    const finalTab = (stateRef.current.tabs as Tab[])[0];
+    expect(finalTab.queuedMessages.map((m) => m.content)).toEqual(["second"]);
+    // queuedSteeringId clears after the dispatch settles.
+    expect(finalTab.queuedSteeringId).toBeUndefined();
+    expect(invoke).toHaveBeenCalledWith("send_message", {
+      message: "first",
+      tabId: "tab-1",
+      mode: "steer",
+    });
+  });
+
+  it("editQueuedMessage replaces the content of a queued entry in place", async () => {
+    const { ctx, stateRef } = buildContext({ waiting: true });
+    const { result } = renderHook(() => useChat(ctx));
+
+    await act(async () => {
+      await result.current.sendChat("orig");
+    });
+    const queued = (stateRef.current.tabs as Tab[])[0].queuedMessages;
+    expect(queued).toHaveLength(1);
+
+    await act(async () => {
+      result.current.editQueuedMessage("tab-1", queued[0].id, "rewritten");
+    });
+    expect((stateRef.current.tabs as Tab[])[0].queuedMessages[0].content).toBe(
+      "rewritten",
+    );
+  });
+
+  it("deleteQueuedMessage removes the entry from the queue", async () => {
+    const { ctx, stateRef } = buildContext({ waiting: true });
+    const { result } = renderHook(() => useChat(ctx));
+
+    await act(async () => {
+      await result.current.sendChat("drop me");
+      await result.current.sendChat("keep me");
+    });
+    const queued = (stateRef.current.tabs as Tab[])[0].queuedMessages;
+
+    await act(async () => {
+      result.current.deleteQueuedMessage("tab-1", queued[0].id);
+    });
+    expect(
+      (stateRef.current.tabs as Tab[])[0].queuedMessages.map((m) => m.content),
+    ).toEqual(["keep me"]);
+  });
+
+  it("clearQueuedMessages empties the queue", async () => {
+    const { ctx, stateRef } = buildContext({ waiting: true });
+    const { result } = renderHook(() => useChat(ctx));
+
+    await act(async () => {
+      await result.current.sendChat("a");
+      await result.current.sendChat("b");
+      await result.current.sendChat("c");
+    });
+    expect(
+      (stateRef.current.tabs as Tab[])[0].queuedMessages,
+    ).toHaveLength(3);
+
+    await act(async () => {
+      result.current.clearQueuedMessages("tab-1");
+    });
+    expect((stateRef.current.tabs as Tab[])[0].queuedMessages).toEqual([]);
+    expect((stateRef.current.tabs as Tab[])[0].queueCount).toBe(0);
+  });
+
+  it("holds normal messages in the client queue while the active prompt is busy", async () => {
+    // Claudette-style: a busy normal-mode send goes to the popover, not
+    // to the bridge. The user-bubble only enters history once
+    // useQueuedDispatch pops it on idle and re-fires sendChat.
     const { ctx, stateRef } = buildContext({ waiting: true });
     const { result } = renderHook(() => useChat(ctx));
 
@@ -192,16 +279,16 @@ describe("useChat setModel", () => {
       await result.current.sendChat("after this");
     });
 
-    expect(invoke).toHaveBeenCalledWith("send_message", {
-      message: "after this",
-      tabId: "tab-1",
-      mode: "normal",
-    });
-    expect((stateRef.current.tabs as Tab[])[0].messages.at(-1)).toMatchObject({
-      role: "user",
-      text: "after this",
-      delivery: "queued",
-    });
+    expect(invoke).not.toHaveBeenCalledWith(
+      "send_message",
+      expect.objectContaining({ message: "after this" }),
+    );
+    const tab = (stateRef.current.tabs as Tab[])[0];
+    expect(tab.queuedMessages.map((m) => m.content)).toEqual(["after this"]);
+    expect(tab.queueCount).toBe(1);
+    // No user bubble lands in history while queued — the popover owns
+    // the visual representation until drain.
+    expect(tab.messages.some((m) => m.text === "after this")).toBe(false);
   });
 
   it("marks the local user message failed when send_message rejects", async () => {

--- a/src/hooks/useChat.test.ts
+++ b/src/hooks/useChat.test.ts
@@ -128,6 +128,7 @@ describe("useChat setModel", () => {
       message: "work on issue",
       tabId: "issue-tab",
       mode: "normal",
+      cwd: "/projects/aethon-fix-86",
     });
     const tabs = stateRef.current.tabs as Tab[];
     expect(tabs.find((t) => t.id === "main-tab")?.messages).toEqual([]);
@@ -138,6 +139,14 @@ describe("useChat setModel", () => {
       text: "work on issue",
       delivery: "sent",
     });
+    expect(ctx.persistLocalChatMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        role: "user",
+        text: "work on issue",
+        delivery: "sent",
+      }),
+      "issue-tab",
+    );
     expect(tabs.find((t) => t.id === "issue-tab")?.waiting).toBe(true);
     expect(stateRef.current.status).toBe("ready");
   });
@@ -239,6 +248,32 @@ describe("useChat setModel", () => {
       text: "look now",
       delivery: "steered",
     });
+  });
+
+  it("persists streamed assistant snapshots for stopped-turn restore", () => {
+    const { ctx, stateRef } = buildContext();
+    const { result } = renderHook(() => useChat(ctx));
+
+    act(() => {
+      result.current.appendOrAmendAgentText("Inspecting", "agent-1", "tab-1", "thinking");
+      result.current.appendOrAmendAgentText("\nDone", "agent-1", "tab-1", "text");
+    });
+
+    expect((stateRef.current.tabs as Tab[])[0].messages.at(-1)).toMatchObject({
+      id: "agent-1",
+      role: "agent",
+      thinking: "Inspecting",
+      text: "\nDone",
+    });
+    expect(ctx.persistLocalChatMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        id: "agent-1",
+        role: "agent",
+        thinking: "Inspecting",
+        text: "\nDone",
+      }),
+      "tab-1",
+    );
   });
 
   it("optimistically mirrors the selected model into the active tab and picker", async () => {

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -235,6 +235,13 @@ export function useChat(ctx: UseChatContext): UseChatActions {
       explicitTabId ??
       (stateRef.current.activeTabId as string | undefined) ??
       "default";
+    // The composer's Stop button advertises "Stop + clear" when the
+    // queue is non-empty; clear the client-held queue here so a user
+    // who stopped because they wanted *out* of the train can't have
+    // the next queued message drain on the following idle.
+    updateTab(tabId, (tab) =>
+      tab.queuedMessages.length === 0 ? tab : withQueue(tab, []),
+    );
     try {
       await invoke("agent_command", {
         payload: JSON.stringify({ type: "stop", tabId }),

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -6,7 +6,7 @@ import {
 } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import type { ChatMessage } from "../types/a2ui";
-import type { Tab } from "../types/tab";
+import type { QueuedMessage, Tab } from "../types/tab";
 import {
   parseSlashCommand,
   type SlashCommand,
@@ -14,6 +14,17 @@ import {
 } from "../slashCommands";
 import type { NotificationInput } from "./useNotifications";
 import { recomputeModelPicker } from "../utils/modelPicker";
+
+/** Patch `queuedMessages` and the derived `queueCount` together so the
+ *  composer badge can't drift out of sync with the popover list. */
+function withQueue(tab: Tab, next: QueuedMessage[]): Tab {
+  return { ...tab, queuedMessages: next, queueCount: next.length };
+}
+
+/** Tolerant accessor for tabs that pre-date the field. */
+function queueOf(tab: Tab): QueuedMessage[] {
+  return tab.queuedMessages ?? [];
+}
 
 export interface UseChatContext {
   setState: Dispatch<SetStateAction<Record<string, unknown>>>;
@@ -66,6 +77,21 @@ export interface UseChatActions {
   setModel: (id: string) => Promise<void>;
   stopPrompt: (explicitTabId?: string) => Promise<void>;
   exportActiveChatMarkdown: () => Promise<void>;
+  /** Replace the body of a queued message in place. No-op if the id has
+   *  already been drained or removed (e.g. a stale popover click). */
+  editQueuedMessage: (
+    tabId: string,
+    messageId: string,
+    content: string,
+  ) => void;
+  /** Drop a queued message before it ships. No-op for unknown ids. */
+  deleteQueuedMessage: (tabId: string, messageId: string) => void;
+  /** Promote a queued message to a mid-turn steer. Pops it from the queue,
+   *  flips `queuedSteeringId` for the popover spinner, then dispatches via
+   *  `sendChat(..., { mode: "steer" })`. */
+  steerQueuedMessage: (tabId: string, messageId: string) => Promise<void>;
+  /** Empty the queue for a tab. */
+  clearQueuedMessages: (tabId: string) => void;
 }
 
 /**
@@ -284,12 +310,34 @@ export function useChat(ctx: UseChatContext): UseChatActions {
       targetTab?.waiting === true ||
       ((targetTab === undefined || tabId === activeTabId) &&
         stateRef.current.waiting === true);
+
+    // Client-side queue: a normal-mode submit while the agent is busy lands
+    // in `tab.queuedMessages` instead of going to the bridge. The popover
+    // above the composer renders the list, lets the user edit / delete /
+    // promote-to-steer each entry, and `useQueuedDispatch` drains the head
+    // on the next idle. Skipping history here is intentional — Claudette
+    // shows queued items only in the popover, then they enter history as
+    // normal user bubbles once the auto-drain fires.
+    if (
+      mode === "normal" &&
+      wasBusy &&
+      targetTab !== undefined &&
+      targetTab.kind === "agent"
+    ) {
+      const entry: QueuedMessage = {
+        id: crypto.randomUUID(),
+        content: sendText,
+      };
+      updateTab(tabId, (tab) => withQueue(tab, [...queueOf(tab), entry]));
+      // Clear the draft on the originating tab so the textarea empties
+      // even though we didn't ship the message. Mirrors the normal-send
+      // behavior below.
+      updateTab(tabId, (tab) => ({ ...tab, draft: "" }));
+      return;
+    }
+
     const delivery: ChatMessage["delivery"] =
-      mode === "steer" && wasBusy
-        ? "steered"
-        : mode === "normal" && wasBusy
-          ? "queued"
-          : "sent";
+      mode === "steer" && wasBusy ? "steered" : "sent";
     const userMessageId = crypto.randomUUID();
     const userMessage = {
       id: userMessageId,
@@ -466,6 +514,67 @@ export function useChat(ctx: UseChatContext): UseChatActions {
     }
   }
 
+  function editQueuedMessage(
+    tabId: string,
+    messageId: string,
+    content: string,
+  ) {
+    updateTab(tabId, (tab) => {
+      const current = queueOf(tab);
+      if (current.length === 0) return tab;
+      const idx = current.findIndex((m) => m.id === messageId);
+      if (idx < 0) return tab;
+      const next = current.slice();
+      next[idx] = { ...next[idx], content };
+      return withQueue(tab, next);
+    });
+  }
+
+  function deleteQueuedMessage(tabId: string, messageId: string) {
+    updateTab(tabId, (tab) => {
+      const current = queueOf(tab);
+      if (current.length === 0) return tab;
+      const next = current.filter((m) => m.id !== messageId);
+      if (next.length === current.length) return tab;
+      return withQueue(tab, next);
+    });
+  }
+
+  function clearQueuedMessages(tabId: string) {
+    updateTab(tabId, (tab) => {
+      if (queueOf(tab).length === 0) return tab;
+      return withQueue(tab, []);
+    });
+  }
+
+  async function steerQueuedMessage(tabId: string, messageId: string) {
+    const tab = ((stateRef.current.tabs as Tab[] | undefined) ?? []).find(
+      (t) => t.id === tabId,
+    );
+    if (!tab) return;
+    const entry = queueOf(tab).find((m) => m.id === messageId);
+    if (!entry) return;
+    // Pop the message from the queue and flip the spinner id in one render
+    // commit so the popover row replaces itself with the spinner instead
+    // of briefly showing nothing.
+    updateTab(tabId, (t) => ({
+      ...withQueue(
+        t,
+        queueOf(t).filter((m) => m.id !== messageId),
+      ),
+      queuedSteeringId: messageId,
+    }));
+    try {
+      await sendChat(entry.content, { mode: "steer", tabId });
+    } finally {
+      updateTab(tabId, (t) =>
+        t.queuedSteeringId === messageId
+          ? { ...t, queuedSteeringId: undefined }
+          : t,
+      );
+    }
+  }
+
   return {
     activeResponseIdRef,
     turnStartedAtRef,
@@ -478,5 +587,9 @@ export function useChat(ctx: UseChatContext): UseChatActions {
     setModel,
     stopPrompt,
     exportActiveChatMarkdown,
+    editQueuedMessage,
+    deleteQueuedMessage,
+    steerQueuedMessage,
+    clearQueuedMessages,
   };
 }

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -149,28 +149,36 @@ export function useChat(ctx: UseChatContext): UseChatActions {
       const messages = [...tab.messages];
       if (messageId) {
         const idx = messages.findIndex((m) => m.id === messageId);
+        let nextMessage: ChatMessage;
         if (idx >= 0) {
-          messages[idx] = {
+          nextMessage = {
             ...messages[idx],
             [channel]: (messages[idx][channel] ?? "") + delta,
           };
+          messages[idx] = nextMessage;
         } else {
-          messages.push({ id: messageId, role: "agent", [channel]: delta });
+          nextMessage = { id: messageId, role: "agent", [channel]: delta };
+          messages.push(nextMessage);
         }
         activeResponseIdRef.current = messageId;
+        persistLocalChatMessage(nextMessage, id);
         return { ...tab, messages };
       }
       const activeId = activeResponseIdRef.current;
       const last = messages[messages.length - 1];
       if (activeId && last && last.id === activeId && last.role === "agent") {
-        messages[messages.length - 1] = {
+        const nextMessage = {
           ...last,
           [channel]: (last[channel] ?? "") + delta,
         };
+        messages[messages.length - 1] = nextMessage;
+        persistLocalChatMessage(nextMessage, id);
       } else {
         const newId = crypto.randomUUID();
         activeResponseIdRef.current = newId;
-        messages.push({ id: newId, role: "agent", [channel]: delta });
+        const nextMessage = { id: newId, role: "agent" as const, [channel]: delta };
+        messages.push(nextMessage);
+        persistLocalChatMessage(nextMessage, id);
       }
       return { ...tab, messages };
     });
@@ -283,10 +291,13 @@ export function useChat(ctx: UseChatContext): UseChatActions {
           ? "queued"
           : "sent";
     const userMessageId = crypto.randomUUID();
-    appendMessage(
-      { id: userMessageId, role: "user", text: sendText, delivery },
-      tabId,
-    );
+    const userMessage = {
+      id: userMessageId,
+      role: "user" as const,
+      text: sendText,
+      delivery,
+    };
+    appendMessage(userMessage, tabId);
     updateTab(tabId, (tab) => ({ ...tab, draft: "", waiting: true }));
     setState((prev) =>
       prev.activeTabId === tabId
@@ -310,8 +321,18 @@ export function useChat(ctx: UseChatContext): UseChatActions {
         /* ignore */
       }
     }
+    persistLocalChatMessage(userMessage, tabId);
+    const targetCwd =
+      typeof targetTab?.cwd === "string" && targetTab.cwd.length > 0
+        ? targetTab.cwd
+        : undefined;
     try {
-      await invoke("send_message", { message: sendText, tabId, mode });
+      await invoke("send_message", {
+        message: sendText,
+        tabId,
+        mode,
+        ...(targetCwd ? { cwd: targetCwd } : {}),
+      });
     } catch (err) {
       updateTab(tabId, (tab) => ({
         ...tab,

--- a/src/hooks/useExtensionsHydration.test.ts
+++ b/src/hooks/useExtensionsHydration.test.ts
@@ -85,10 +85,11 @@ describe("buildExtensionSidebarItems", () => {
       "/repo/mold",
     );
 
-    // Sorted: project → user → package, alphabetical within each
-    // bucket. Disabled rows preserve their inferred source so the
-    // user can still tell a disabled project-extension apart from a
-    // disabled user-extension.
+    // Sorted: project → user, alphabetical within each bucket.
+    // Disabled rows preserve their inferred source so the user can
+    // still tell a disabled project-extension apart from a disabled
+    // user-extension. Bare-name npm packages fall into "user"
+    // (they have no @scope to indicate project membership).
     expect(items).toEqual([
       {
         id: "ext:mold:gallery",
@@ -112,18 +113,18 @@ describe("buildExtensionSidebarItems", () => {
         kind: "user",
       },
       {
-        id: "ext:user-ext",
-        label: "user-ext",
+        id: "ext:package-ext",
+        label: "package-ext",
         hint: "user",
         active: true,
         kind: "user",
       },
       {
-        id: "ext:package-ext",
-        label: "package-ext",
-        hint: "package",
+        id: "ext:user-ext",
+        label: "user-ext",
+        hint: "user",
         active: true,
-        kind: "package",
+        kind: "user",
       },
     ]);
   });
@@ -188,12 +189,16 @@ describe("buildExtensionSidebarItems", () => {
     );
 
     // Project-directory disabled row for mold is hidden under claudette;
-    // extension-package and user-directory entries stay visible.
-    // Sorted user → package within the visible set.
-    expect(items.map((item) => item.id)).toEqual([
-      "ext-disabled:global-user-ext",
-      "ext-disabled:@mold/repo-gallery",
-    ]);
+    // extension-package and user-directory entries stay visible. With
+    // the two-bucket scheme, neither survivor matches the active
+    // project's basename, so both fall into the user bucket and sort
+    // alphabetically.
+    expect(items.map((item) => item.id).sort()).toEqual(
+      [
+        "ext-disabled:@mold/repo-gallery",
+        "ext-disabled:global-user-ext",
+      ].sort(),
+    );
   });
 
   it("shows disabled project-directory rows when their project IS active", () => {
@@ -351,20 +356,23 @@ describe("buildExtensionSidebarItems", () => {
       "/repo/mold",
       new Set(["mold"]),
     );
-    // Project first, then user, then package. Each group sorted A→Z.
+    // Project first, then user. `@mold/...` npm packages fold INTO
+    // the project bucket because their scope matches the active
+    // project's basename. `@brink/...` stays user (scope unrelated).
+    // Each group sorted A→Z.
     expect(items.map((item) => item.label)).toEqual([
+      "@mold/image-gallery-ui",
+      "@mold/project-background-ui",
       "mold:image-gallery",
       "mold:project-background",
       "@brink/current-context-widget",
-      "@mold/image-gallery-ui",
-      "@mold/project-background-ui",
     ]);
     expect(items.map((item) => item.hint)).toEqual([
       "project",
       "project",
+      "project",
+      "project",
       "user",
-      "package",
-      "package",
     ]);
   });
 
@@ -390,10 +398,13 @@ describe("buildExtensionSidebarItems", () => {
       "/repo/mold",
       new Set(["mold"]),
     );
+    // `@mold/...` folds into project (scope matches active project);
+    // `@brink/...` stays user (unrelated scope). Sort order: project
+    // bucket first, alphabetical within.
     expect(items.map((item) => ({ label: item.label, hint: item.hint }))).toEqual([
+      { label: "@mold/image-gallery-ui", hint: "project · disabled" },
       { label: "mold:image-gallery", hint: "project · disabled" },
       { label: "@brink/current-context-widget", hint: "user · disabled" },
-      { label: "@mold/image-gallery-ui", hint: "package · disabled" },
     ]);
   });
 });

--- a/src/hooks/useExtensionsHydration.test.ts
+++ b/src/hooks/useExtensionsHydration.test.ts
@@ -95,30 +95,35 @@ describe("buildExtensionSidebarItems", () => {
         label: "mold:gallery",
         hint: "project",
         active: true,
+        kind: "project",
       },
       {
         id: "ext-failed:broken-ext",
         label: "broken-ext",
         hint: "user · failed",
         active: false,
+        kind: "user",
       },
       {
         id: "ext-disabled:disabled-ext",
         label: "disabled-ext",
         hint: "user · disabled",
         active: false,
+        kind: "user",
       },
       {
         id: "ext:user-ext",
         label: "user-ext",
         hint: "user",
         active: true,
+        kind: "user",
       },
       {
         id: "ext:package-ext",
         label: "package-ext",
         hint: "package",
         active: true,
+        kind: "package",
       },
     ]);
   });
@@ -139,6 +144,7 @@ describe("buildExtensionSidebarItems", () => {
         // was a bare name.
         hint: "user · disabled · restart",
         active: false,
+        kind: "user",
       },
     ]);
   });

--- a/src/hooks/useExtensionsHydration.test.ts
+++ b/src/hooks/useExtensionsHydration.test.ts
@@ -85,23 +85,15 @@ describe("buildExtensionSidebarItems", () => {
       "/repo/mold",
     );
 
+    // Sorted: project → user → package, alphabetical within each
+    // bucket. Disabled rows preserve their inferred source so the
+    // user can still tell a disabled project-extension apart from a
+    // disabled user-extension.
     expect(items).toEqual([
-      {
-        id: "ext:user-ext",
-        label: "user-ext",
-        hint: "user",
-        active: true,
-      },
       {
         id: "ext:mold:gallery",
         label: "mold:gallery",
         hint: "project",
-        active: true,
-      },
-      {
-        id: "ext:package-ext",
-        label: "package-ext",
-        hint: "package",
         active: true,
       },
       {
@@ -113,8 +105,20 @@ describe("buildExtensionSidebarItems", () => {
       {
         id: "ext-disabled:disabled-ext",
         label: "disabled-ext",
-        hint: "disabled",
+        hint: "user · disabled",
         active: false,
+      },
+      {
+        id: "ext:user-ext",
+        label: "user-ext",
+        hint: "user",
+        active: true,
+      },
+      {
+        id: "ext:package-ext",
+        label: "package-ext",
+        hint: "package",
+        active: true,
       },
     ]);
   });
@@ -130,7 +134,10 @@ describe("buildExtensionSidebarItems", () => {
       {
         id: "ext-disabled:user-ext",
         label: "user-ext",
-        hint: "disabled · restart",
+        // Source is inferred from the still-loaded entry's source so
+        // the row labels its origin even though the disable record
+        // was a bare name.
+        hint: "user · disabled · restart",
         active: false,
       },
     ]);
@@ -176,9 +183,10 @@ describe("buildExtensionSidebarItems", () => {
 
     // Project-directory disabled row for mold is hidden under claudette;
     // extension-package and user-directory entries stay visible.
+    // Sorted user → package within the visible set.
     expect(items.map((item) => item.id)).toEqual([
-      "ext-disabled:@mold/repo-gallery",
       "ext-disabled:global-user-ext",
+      "ext-disabled:@mold/repo-gallery",
     ]);
   });
 
@@ -312,5 +320,74 @@ describe("buildExtensionSidebarItems", () => {
     );
     // mold-scoped package hidden under nyc-real-estate; example stays.
     expect(items.map((item) => item.label)).toEqual(["@example/global-helper"]);
+  });
+
+  it("groups project extensions above user extensions, alphabetically within each group", () => {
+    const items = buildExtensionSidebarItems(
+      [
+        // Deliberately shuffled load order — sort should reset it.
+        { name: "@brink/current-context-widget", source: "directory" },
+        { name: "@mold/project-background-ui", source: "extension-package" },
+        {
+          name: "mold:project-background",
+          source: "project-directory",
+          projectRoot: "/repo/mold",
+        },
+        { name: "@mold/image-gallery-ui", source: "extension-package" },
+        {
+          name: "mold:image-gallery",
+          source: "project-directory",
+          projectRoot: "/repo/mold",
+        },
+      ],
+      [],
+      [],
+      "/repo/mold",
+      new Set(["mold"]),
+    );
+    // Project first, then user, then package. Each group sorted A→Z.
+    expect(items.map((item) => item.label)).toEqual([
+      "mold:image-gallery",
+      "mold:project-background",
+      "@brink/current-context-widget",
+      "@mold/image-gallery-ui",
+      "@mold/project-background-ui",
+    ]);
+    expect(items.map((item) => item.hint)).toEqual([
+      "project",
+      "project",
+      "user",
+      "package",
+      "package",
+    ]);
+  });
+
+  it("preserves source label on disabled rows so 'project' vs 'user' is visible even when all are off", () => {
+    // Mirrors the screenshot the user reported: every extension is
+    // disabled — without source preservation the user couldn't tell
+    // which were project-scoped vs user-scoped.
+    const items = buildExtensionSidebarItems(
+      [],
+      [],
+      [
+        {
+          name: "mold:image-gallery",
+          source: "project-directory",
+          projectRoot: "/repo/mold",
+        },
+        { name: "@brink/current-context-widget", source: "directory" },
+        {
+          name: "@mold/image-gallery-ui",
+          source: "extension-package",
+        },
+      ],
+      "/repo/mold",
+      new Set(["mold"]),
+    );
+    expect(items.map((item) => ({ label: item.label, hint: item.hint }))).toEqual([
+      { label: "mold:image-gallery", hint: "project · disabled" },
+      { label: "@brink/current-context-widget", hint: "user · disabled" },
+      { label: "@mold/image-gallery-ui", hint: "package · disabled" },
+    ]);
   });
 });

--- a/src/hooks/useExtensionsHydration.ts
+++ b/src/hooks/useExtensionsHydration.ts
@@ -47,8 +47,18 @@ export interface DisabledExtensionRecord {
   projectRoot?: string;
 }
 
+/** Canonical source classes used for sidebar grouping + sorting. Maps
+ *  the bridge-side ExtensionSource enum onto three user-visible
+ *  buckets. See `classifyExtensionSource` below for the mapping. */
+export type ExtensionKind = "project" | "user" | "package";
+
 export type ExtensionSidebarItem = SidebarItem & {
   hint?: string;
+  /** Origin bucket. Carried alongside the item so the sidebar can
+   *  split the auto-injected EXTENSIONS section into per-origin
+   *  sub-sections without re-deriving the source from the id prefix
+   *  on every render. */
+  kind?: ExtensionKind;
 };
 
 const CORE_EXTENSION_NAMES = new Set(["default-layout"]);
@@ -103,14 +113,12 @@ export function filterExtensionSummariesByProject<
   });
 }
 
-/** Canonical source classes used for sidebar grouping + sorting. Maps
- *  the bridge-side enum onto three user-visible buckets: project-scoped
- *  (.aethon/extensions inside the active project), user-scoped (the
- *  global ~/.aethon/extensions directory), and packaged (npm). Unknown
+/** Map the bridge-side `ExtensionSource` enum onto the three
+ *  user-visible buckets declared above. Project-scoped =
+ *  `.aethon/extensions` inside the active project, user-scoped = the
+ *  global `~/.aethon/extensions` directory, packaged = npm. Unknown
  *  values fall back to "user" so legacy disabled records (persisted
  *  before source tracking landed) still group sensibly. */
-export type ExtensionKind = "project" | "user" | "package";
-
 export function classifyExtensionSource(
   source: string | undefined,
 ): ExtensionKind {
@@ -298,9 +306,9 @@ export function buildExtensionSidebarItems(
         };
       }),
   ];
-  return decorated
-    .sort(compareSidebarItems)
-    .map(({ kind: _kind, ...item }) => item);
+  // Keep `kind` on the returned items so the sidebar can split into
+  // per-origin sub-sections without re-deriving the source.
+  return decorated.sort(compareSidebarItems);
 }
 
 /** Built-in themes always available. CSS for these lives in src/styles/themes.css —

--- a/src/hooks/useExtensionsHydration.ts
+++ b/src/hooks/useExtensionsHydration.ts
@@ -103,18 +103,53 @@ export function filterExtensionSummariesByProject<
   });
 }
 
-function extensionSourceLabel(source: string): string {
+/** Canonical source classes used for sidebar grouping + sorting. Maps
+ *  the bridge-side enum onto three user-visible buckets: project-scoped
+ *  (.aethon/extensions inside the active project), user-scoped (the
+ *  global ~/.aethon/extensions directory), and packaged (npm). Unknown
+ *  values fall back to "user" so legacy disabled records (persisted
+ *  before source tracking landed) still group sensibly. */
+export type ExtensionKind = "project" | "user" | "package";
+
+export function classifyExtensionSource(
+  source: string | undefined,
+): ExtensionKind {
   switch (source) {
-    case "directory":
-    case "global-directory":
-      return "user";
     case "project-directory":
       return "project";
     case "extension-package":
       return "package";
+    case "directory":
+    case "global-directory":
+      return "user";
     default:
-      return source;
+      return "user";
   }
+}
+
+function extensionSourceLabel(source: string): string {
+  return classifyExtensionSource(source);
+}
+
+/** Sort comparator for the sidebar extensions list. Project-scoped
+ *  rows float to the top (those are the ones the user just enabled
+ *  for the active project and are most likely to be acting on),
+ *  user-scoped come next, then package, with alphabetical ordering
+ *  within each group. */
+const KIND_ORDER: Record<ExtensionKind, number> = {
+  project: 0,
+  user: 1,
+  package: 2,
+};
+
+function compareSidebarItems(
+  a: { kind: ExtensionKind; label: string },
+  b: { kind: ExtensionKind; label: string },
+): number {
+  const ka = KIND_ORDER[a.kind] ?? 99;
+  const kb = KIND_ORDER[b.kind] ?? 99;
+  if (ka !== kb) return ka - kb;
+  return a.label.localeCompare(b.label);
 }
 
 function normalizeDisabledRecord(
@@ -211,7 +246,15 @@ export function buildExtensionSidebarItems(
   // restart). Show it in the disabled bucket so the user sees their
   // pending intent, with a hint that a restart is needed to fully
   // unload it.
-  return [
+  //
+  // We carry a `kind` next to each item just long enough to do the
+  // group-then-alphabetical sort, then strip it when returning the
+  // public ExtensionSidebarItem shape. Disabled records ship the
+  // source through DisabledExtensionRecord.source when it's known —
+  // we fall back to lookup-by-name against the live `loaded` list
+  // so an extension toggled off this session still reads as project /
+  // user / package instead of an unattributed "disabled".
+  const decorated: Array<ExtensionSidebarItem & { kind: ExtensionKind }> = [
     ...scopedLoaded
       .filter((e) => !CORE_EXTENSION_NAMES.has(e.name))
       .filter((e) => !disabledSet.has(e.name))
@@ -220,6 +263,7 @@ export function buildExtensionSidebarItems(
         label: e.name,
         hint: extensionSourceLabel(e.source),
         active: true,
+        kind: classifyExtensionSource(e.source),
       })),
     ...scopedFailed
       .filter((e) => !CORE_EXTENSION_NAMES.has(e.name))
@@ -229,19 +273,34 @@ export function buildExtensionSidebarItems(
         label: e.name,
         hint: `${extensionSourceLabel(e.source)} · failed`,
         active: false,
+        kind: classifyExtensionSource(e.source),
       })),
     ...scopedDisabled
       .filter((d) => !CORE_EXTENSION_NAMES.has(d.name))
       .map((d) => {
         const stillLoaded = loaded.some((e) => e.name === d.name);
+        // Prefer the source persisted with the disabled record; fall
+        // back to the live `loaded` entry for the same name so a
+        // mid-session toggle keeps its origin label, then to "user"
+        // for legacy records that pre-date source tracking.
+        const inferredSource =
+          d.source ?? loaded.find((e) => e.name === d.name)?.source;
+        const kind = classifyExtensionSource(inferredSource);
+        const origin = extensionSourceLabel(inferredSource ?? "directory");
         return {
           id: `ext-disabled:${d.name}`,
           label: d.name,
-          hint: stillLoaded ? "disabled · restart" : "disabled",
+          hint: stillLoaded
+            ? `${origin} · disabled · restart`
+            : `${origin} · disabled`,
           active: false,
+          kind,
         };
       }),
   ];
+  return decorated
+    .sort(compareSidebarItems)
+    .map(({ kind: _kind, ...item }) => item);
 }
 
 /** Built-in themes always available. CSS for these lives in src/styles/themes.css —

--- a/src/hooks/useExtensionsHydration.ts
+++ b/src/hooks/useExtensionsHydration.ts
@@ -47,10 +47,14 @@ export interface DisabledExtensionRecord {
   projectRoot?: string;
 }
 
-/** Canonical source classes used for sidebar grouping + sorting. Maps
- *  the bridge-side ExtensionSource enum onto three user-visible
- *  buckets. See `classifyExtensionSource` below for the mapping. */
-export type ExtensionKind = "project" | "user" | "package";
+/** User-visible scope buckets for the sidebar grouping. Two buckets,
+ *  because the meaningful distinction is "is this scoped to the
+ *  project I'm working on right now?" — packaged npm extensions can
+ *  belong to either group depending on whether their scope matches the
+ *  active project (e.g. `@mold/image-gallery-ui` is project-scoped
+ *  under the `mold` project, but `@brink/current-context-widget` is
+ *  user-level). See `classifyExtensionSource` for the mapping. */
+export type ExtensionKind = "project" | "user";
 
 export type ExtensionSidebarItem = SidebarItem & {
   hint?: string;
@@ -113,41 +117,61 @@ export function filterExtensionSummariesByProject<
   });
 }
 
-/** Map the bridge-side `ExtensionSource` enum onto the three
- *  user-visible buckets declared above. Project-scoped =
- *  `.aethon/extensions` inside the active project, user-scoped = the
- *  global `~/.aethon/extensions` directory, packaged = npm. Unknown
- *  values fall back to "user" so legacy disabled records (persisted
- *  before source tracking landed) still group sensibly. */
+/** Map the bridge-side `ExtensionSource` enum onto the two user-visible
+ *  buckets. Project-scoped covers both `.aethon/extensions` inside the
+ *  active project AND npm packages whose `@scope` matches the active
+ *  project's basename (the `@<project>/<ext>` convention). Everything
+ *  else — global `~/.aethon/extensions`, npm packages with an unrelated
+ *  scope, and legacy disabled records lacking source metadata — falls
+ *  into the user bucket. */
 export function classifyExtensionSource(
   source: string | undefined,
+  options?: {
+    name?: string;
+    activeBasename?: string;
+    knownProjectBasenames?: ReadonlySet<string>;
+  },
 ): ExtensionKind {
-  switch (source) {
-    case "project-directory":
-      return "project";
-    case "extension-package":
-      return "package";
-    case "directory":
-    case "global-directory":
-      return "user";
-    default:
-      return "user";
+  if (source === "project-directory") return "project";
+  if (source === "extension-package") {
+    // `@<project>/<ext>` npm convention — when the npm scope matches
+    // the active project's directory basename, surface it under the
+    // project group. The knownProjectBasenames guard prevents a
+    // random `@<anything>/...` package from masquerading as
+    // project-scoped just because its scope happens to share a name
+    // with no real project.
+    const name = options?.name;
+    const activeBasename = options?.activeBasename;
+    const known = options?.knownProjectBasenames;
+    if (name && activeBasename) {
+      const scope = extractNpmScope(name);
+      if (
+        scope &&
+        scope === activeBasename &&
+        (known?.has(scope) ?? false)
+      ) {
+        return "project";
+      }
+    }
+    return "user";
   }
+  return "user";
 }
 
-function extensionSourceLabel(source: string): string {
-  return classifyExtensionSource(source);
+/** Short label rendered in the per-row hint. Mirrors the `kind` so the
+ *  user can tell scope at a glance — `mold:image-gallery` shows
+ *  `project`, `@brink/current-context-widget` shows `user`. */
+function extensionScopeLabel(kind: ExtensionKind): string {
+  return kind;
 }
 
 /** Sort comparator for the sidebar extensions list. Project-scoped
- *  rows float to the top (those are the ones the user just enabled
- *  for the active project and are most likely to be acting on),
- *  user-scoped come next, then package, with alphabetical ordering
- *  within each group. */
+ *  rows float to the top (those are the ones the user is most likely
+ *  acting on right now), user-scoped come second, alphabetical within
+ *  each group. */
 const KIND_ORDER: Record<ExtensionKind, number> = {
   project: 0,
   user: 1,
-  package: 2,
 };
 
 function compareSidebarItems(
@@ -255,34 +279,50 @@ export function buildExtensionSidebarItems(
   // pending intent, with a hint that a restart is needed to fully
   // unload it.
   //
-  // We carry a `kind` next to each item just long enough to do the
-  // group-then-alphabetical sort, then strip it when returning the
-  // public ExtensionSidebarItem shape. Disabled records ship the
-  // source through DisabledExtensionRecord.source when it's known —
-  // we fall back to lookup-by-name against the live `loaded` list
-  // so an extension toggled off this session still reads as project /
-  // user / package instead of an unattributed "disabled".
+  // Each row carries `kind` so the sidebar can split into per-origin
+  // sub-sections without re-deriving the source on every render.
+  // npm packages can land in either bucket: `@<project>/<ext>` where
+  // <project> matches the active project's basename folds into the
+  // project bucket; everything else (including `@<scope>/...` with an
+  // unrelated scope, plain `package-name`, and `~/.aethon/extensions`
+  // entries) folds into user. Disabled records carry source through
+  // DisabledExtensionRecord.source when known; otherwise we look it
+  // up by name against `loaded` for mid-session toggles.
+  const activePathForClassify =
+    normalizeExtensionProjectPath(activeProjectPath);
+  const activeBasenameForClassify = basenameOfPath(activePathForClassify);
+  const classifyOpts = (name: string) => ({
+    name,
+    activeBasename: activeBasenameForClassify,
+    knownProjectBasenames,
+  });
   const decorated: Array<ExtensionSidebarItem & { kind: ExtensionKind }> = [
     ...scopedLoaded
       .filter((e) => !CORE_EXTENSION_NAMES.has(e.name))
       .filter((e) => !disabledSet.has(e.name))
-      .map((e) => ({
-        id: `ext:${e.name}`,
-        label: e.name,
-        hint: extensionSourceLabel(e.source),
-        active: true,
-        kind: classifyExtensionSource(e.source),
-      })),
+      .map((e) => {
+        const kind = classifyExtensionSource(e.source, classifyOpts(e.name));
+        return {
+          id: `ext:${e.name}`,
+          label: e.name,
+          hint: extensionScopeLabel(kind),
+          active: true,
+          kind,
+        };
+      }),
     ...scopedFailed
       .filter((e) => !CORE_EXTENSION_NAMES.has(e.name))
       .filter((e) => !disabledSet.has(e.name))
-      .map((e) => ({
-        id: `ext-failed:${e.name}`,
-        label: e.name,
-        hint: `${extensionSourceLabel(e.source)} · failed`,
-        active: false,
-        kind: classifyExtensionSource(e.source),
-      })),
+      .map((e) => {
+        const kind = classifyExtensionSource(e.source, classifyOpts(e.name));
+        return {
+          id: `ext-failed:${e.name}`,
+          label: e.name,
+          hint: `${extensionScopeLabel(kind)} · failed`,
+          active: false,
+          kind,
+        };
+      }),
     ...scopedDisabled
       .filter((d) => !CORE_EXTENSION_NAMES.has(d.name))
       .map((d) => {
@@ -293,8 +333,11 @@ export function buildExtensionSidebarItems(
         // for legacy records that pre-date source tracking.
         const inferredSource =
           d.source ?? loaded.find((e) => e.name === d.name)?.source;
-        const kind = classifyExtensionSource(inferredSource);
-        const origin = extensionSourceLabel(inferredSource ?? "directory");
+        const kind = classifyExtensionSource(
+          inferredSource,
+          classifyOpts(d.name),
+        );
+        const origin = extensionScopeLabel(kind);
         return {
           id: `ext-disabled:${d.name}`,
           label: d.name,

--- a/src/hooks/useProjectOps.test.ts
+++ b/src/hooks/useProjectOps.test.ts
@@ -2,7 +2,7 @@
 
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { NO_PROJECT_KEY, type Tab } from "../types/tab";
+import { makeEmptyTab, NO_PROJECT_KEY, type Tab } from "../types/tab";
 import type { ProjectsState } from "../projects";
 import { installTauriMocks, clearTauriMocks } from "../test/tauriMocks";
 import {
@@ -51,6 +51,18 @@ function renderProjectOps(initialProjects: ProjectsState) {
     stateRef.current =
       typeof next === "function" ? next(stateRef.current) : next;
   });
+  const closeTabNow = vi.fn((tabId: string) => {
+    setState((prev: Record<string, unknown>) => {
+      const tabs = ((prev.tabs as Tab[] | undefined) ?? []).filter(
+        (tab) => tab.id !== tabId,
+      );
+      const activeTabId =
+        prev.activeTabId === tabId
+          ? tabs[tabs.length - 1]?.id
+          : (prev.activeTabId as string | undefined);
+      return { ...prev, tabs, activeTabId };
+    });
+  });
   const ctx: UseProjectOpsContext = {
     setState,
     stateRef,
@@ -64,10 +76,11 @@ function renderProjectOps(initialProjects: ProjectsState) {
     unwatchProjectForBridge: vi.fn(),
     dispatchTerminalReplay: vi.fn(),
     autoRestoreDiscoveredSessions: vi.fn(),
+    closeTabNow,
   };
   const rendered = renderHook(() => useProjectOps(ctx));
   projectsRef.current = initialProjects;
-  return { ...rendered, projectsRef, stateRef, setState };
+  return { ...rendered, projectsRef, stateRef, setState, closeTabNow };
 }
 
 describe("projectIdFromBucketKey", () => {
@@ -545,5 +558,98 @@ describe("useProjectOps worktree creation", () => {
     );
     expect(addCalls[0]?.[1]).toMatchObject({ base: "upstream/trunk" });
     expect(addCalls[1]?.[1]).toMatchObject({ base: "release/next" });
+  });
+});
+
+describe("useProjectOps worktree removal", () => {
+  it("closes visible and stored session tabs for the removed worktree", async () => {
+    const harness = installTauriMocks();
+    harness.invoke.mockImplementation((cmd: string) => {
+      if (cmd === "git_worktree_remove") return Promise.resolve(undefined);
+      return Promise.resolve(undefined);
+    });
+    const worktree = {
+      id: "wt-issue",
+      projectId: "project-1",
+      path: "/projects/aethon-fix-issue",
+      branch: "fix/issue",
+      isMain: false,
+    };
+    const initial = makeProjectsState({
+      activeId: "project-1",
+      activeWorktreeId: "wt-issue",
+      worktreesByProject: {
+        "project-1": [
+          {
+            id: "wt-main",
+            projectId: "project-1",
+            path: "/projects/aethon",
+            branch: "main",
+            isMain: true,
+          },
+          worktree,
+        ],
+      },
+    });
+    const { result, projectsRef, stateRef, closeTabNow } =
+      renderProjectOps(initial);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    projectsRef.current = initial;
+    stateRef.current = {
+      activeTabId: "issue-tab",
+      tabs: [
+        {
+          ...makeEmptyTab("issue-tab", "Issue"),
+          messages: [],
+          projectId: "project-1",
+          cwd: "/projects/aethon-fix-issue",
+        },
+        {
+          ...makeEmptyTab("main-tab", "Main"),
+          messages: [],
+          projectId: "project-1",
+          cwd: "/projects/aethon",
+        },
+      ],
+    };
+    result.current.tabBucketsRef.current.set(
+      projectScopeBucketKey("project-1", "wt-issue"),
+      {
+        activeTabId: "hidden-issue-tab",
+        tabs: [
+          {
+            ...makeEmptyTab("hidden-issue-tab", "Hidden issue"),
+            messages: [],
+            projectId: "project-1",
+            cwd: "/projects/aethon-fix-issue/",
+          },
+        ],
+      },
+    );
+
+    await act(async () => {
+      await result.current.removeWorktreeById("wt-issue", { confirmed: true });
+    });
+
+    expect(harness.invoke).toHaveBeenCalledWith("git_worktree_remove", {
+      projectPath: "/projects/aethon",
+      worktreePath: "/projects/aethon-fix-issue",
+      force: false,
+    });
+    expect(closeTabNow).toHaveBeenCalledWith("issue-tab");
+    expect(
+      result.current.tabBucketsRef.current.has(
+        projectScopeBucketKey("project-1", "wt-issue"),
+      ),
+    ).toBe(false);
+    expect(projectsRef.current.activeWorktreeId).toBeNull();
+    expect(
+      projectsRef.current.worktreesByProject["project-1"]?.some(
+        (wt) => wt.id === "wt-issue",
+      ),
+    ).toBe(false);
   });
 });

--- a/src/hooks/useProjectOps.test.ts
+++ b/src/hooks/useProjectOps.test.ts
@@ -8,8 +8,10 @@ import { installTauriMocks, clearTauriMocks } from "../test/tauriMocks";
 import {
   nonEmptyProjectTabs,
   projectIdFromBucketKey,
+  projectScopeBucketKey,
   tabsForProjectBucket,
   useProjectOps,
+  worktreeIdForCwd,
   type UseProjectOpsContext,
 } from "./useProjectOps";
 
@@ -72,6 +74,9 @@ describe("projectIdFromBucketKey", () => {
   it("maps the no-project bucket back to null", () => {
     expect(projectIdFromBucketKey(NO_PROJECT_KEY)).toBeNull();
     expect(projectIdFromBucketKey("project-1")).toBe("project-1");
+    expect(projectIdFromBucketKey("project-1::worktree::wt-1")).toBe(
+      "project-1",
+    );
   });
 });
 
@@ -83,9 +88,12 @@ describe("tabsForProjectBucket", () => {
       { id: "none", projectId: null },
     ] as unknown as Tab[];
 
-    expect(tabsForProjectBucket(tabs, "project-1").map((t) => t.id)).toEqual([
-      "p1",
-    ]);
+    expect(
+      tabsForProjectBucket(
+        tabs,
+        projectScopeBucketKey("project-1", "wt-1"),
+      ).map((t) => t.id),
+    ).toEqual(["p1"]);
     expect(tabsForProjectBucket(tabs, NO_PROJECT_KEY).map((t) => t.id)).toEqual(
       ["none"],
     );
@@ -128,6 +136,156 @@ describe("nonEmptyProjectTabs", () => {
 });
 
 describe("useProjectOps session scoping", () => {
+  it("resolves a session cwd to the matching worktree selection", () => {
+    const projects = makeProjectsState({
+      activeId: "project-1",
+      activeWorktreeId: null,
+      worktreesByProject: {
+        "project-1": [
+          {
+            id: "wt-main",
+            projectId: "project-1",
+            path: "/projects/aethon",
+            branch: "main",
+            isMain: true,
+          },
+          {
+            id: "wt-issue",
+            projectId: "project-1",
+            path: "/projects/aethon-fix-issue",
+            branch: "fix/issue",
+            isMain: false,
+          },
+        ],
+      },
+    });
+
+    expect(worktreeIdForCwd(projects, "/projects/aethon-fix-issue/")).toBe(
+      "wt-issue",
+    );
+    expect(worktreeIdForCwd(projects, "/projects/aethon")).toBeNull();
+    expect(worktreeIdForCwd(projects, "/projects/other")).toBeUndefined();
+  });
+
+  it("marks the child worktree as selected without painting the parent row active", () => {
+    const { result, stateRef } = renderProjectOps(
+      makeProjectsState({
+        activeId: "project-1",
+        activeWorktreeId: null,
+        projects: [
+          {
+            id: "project-1",
+            label: "aethon",
+            path: "/projects/aethon",
+            lastUsed: 1,
+          },
+        ],
+        worktreesByProject: {
+          "project-1": [
+            {
+              id: "wt-main",
+              projectId: "project-1",
+              path: "/projects/aethon",
+              branch: "main",
+              isMain: true,
+            },
+            {
+              id: "wt-issue",
+              projectId: "project-1",
+              path: "/projects/aethon-fix-issue",
+              branch: "fix/issue",
+              isMain: false,
+            },
+          ],
+        },
+      }),
+    );
+
+    act(() => {
+      result.current.activateWorktree("wt-issue");
+    });
+
+    const projects = (
+      stateRef.current.sidebar as {
+        projects?: {
+          active?: boolean;
+          worktrees?: { id: string; active?: boolean }[];
+        }[];
+      }
+    ).projects;
+    expect(projects?.[0]?.active).toBe(false);
+    expect(
+      projects?.[0]?.worktrees?.find((w) => w.id === "wt-issue")?.active,
+    ).toBe(true);
+    expect(stateRef.current.activeProjectId).toBe("project-1");
+  });
+
+  it("keeps project-root and worktree tabs in separate visible buckets", () => {
+    const rootTab = {
+      id: "root-tab",
+      kind: "agent",
+      projectId: "project-1",
+      cwd: "/projects/aethon",
+      messages: [{ id: "m-root", role: "user", text: "root" }],
+      terminalBuffer: "",
+      model: "gpt-5.5",
+    } as unknown as Tab;
+    const worktreeTab = {
+      id: "worktree-tab",
+      kind: "agent",
+      projectId: "project-1",
+      cwd: "/projects/aethon-fix-issue",
+      messages: [{ id: "m-wt", role: "user", text: "worktree" }],
+      terminalBuffer: "",
+      model: "gpt-5.5",
+    } as unknown as Tab;
+    const { result, stateRef, projectsRef } = renderProjectOps(
+      makeProjectsState({
+        activeId: "project-1",
+        activeWorktreeId: null,
+        worktreesByProject: {
+          "project-1": [
+            {
+              id: "wt-issue",
+              projectId: "project-1",
+              path: "/projects/aethon-fix-issue",
+              branch: "fix/issue",
+              isMain: false,
+            },
+          ],
+        },
+      }),
+    );
+    stateRef.current = {
+      ...stateRef.current,
+      tabs: [rootTab],
+      activeTabId: "root-tab",
+    };
+
+    act(() => {
+      result.current.activateWorktree("wt-issue");
+    });
+
+    expect(projectsRef.current.activeWorktreeId).toBe("wt-issue");
+    expect((stateRef.current.tabs as Tab[]).map((t) => t.id)).toEqual([]);
+
+    stateRef.current = {
+      ...stateRef.current,
+      tabs: [worktreeTab],
+      activeTabId: "worktree-tab",
+    };
+
+    act(() => {
+      expect(result.current.setActiveProjectById("project-1")).toBe(true);
+    });
+
+    expect(projectsRef.current.activeWorktreeId).toBeNull();
+    expect((stateRef.current.tabs as Tab[]).map((t) => t.id)).toEqual([
+      "root-tab",
+    ]);
+    expect(stateRef.current.activeTabId).toBe("root-tab");
+  });
+
   it("scopes discovered sessions to the active worktree cwd", () => {
     const { result } = renderProjectOps(
       makeProjectsState({

--- a/src/hooks/useProjectOps.test.ts
+++ b/src/hooks/useProjectOps.test.ts
@@ -299,6 +299,86 @@ describe("useProjectOps session scoping", () => {
     expect(stateRef.current.activeTabId).toBe("root-tab");
   });
 
+  it("swaps the project extensions watcher when a worktree from another project is activated", () => {
+    // Regression: activateWorktree changed activeId directly when the
+    // worktree belonged to a different project than the current one,
+    // skipping the unwatch/watch swap that setActiveProjectById does.
+    // The previous project's `.aethon/extensions/` watcher kept
+    // firing while the new project's never got installed.
+    const initial = makeProjectsState({
+      activeId: "project-1",
+      activeWorktreeId: null,
+      projects: [
+        {
+          id: "project-1",
+          label: "alpha",
+          path: "/projects/alpha",
+          lastUsed: 1,
+        },
+        {
+          id: "project-2",
+          label: "beta",
+          path: "/projects/beta",
+          lastUsed: 1,
+        },
+      ],
+      worktreesByProject: {
+        "project-2": [
+          {
+            id: "wt-beta-feature",
+            projectId: "project-2",
+            path: "/projects/beta-feature",
+            branch: "feat/x",
+            isMain: false,
+          },
+        ],
+      },
+    });
+    const stateRef = ref<Record<string, unknown>>({
+      tabs: [],
+      activeTabId: undefined,
+    });
+    const projectsRef = ref(initial);
+    const setState = vi.fn((next: unknown) => {
+      stateRef.current =
+        typeof next === "function"
+          ? (next as (s: Record<string, unknown>) => Record<string, unknown>)(
+              stateRef.current,
+            )
+          : (next as Record<string, unknown>);
+    });
+    const watchProjectForBridge = vi.fn();
+    const unwatchProjectForBridge = vi.fn();
+    const ctx: UseProjectOpsContext = {
+      setState,
+      stateRef,
+      projectsRef,
+      piDefaultModelRef: ref("gpt-5.5"),
+      gitStatusRef: ref(new Map()),
+      refreshGitStatusFor: vi.fn(() => Promise.resolve()),
+      refreshAllGitStatus: vi.fn(() => Promise.resolve()),
+      announceProjectToBridge: vi.fn(),
+      watchProjectForBridge,
+      unwatchProjectForBridge,
+      dispatchTerminalReplay: vi.fn(),
+      autoRestoreDiscoveredSessions: vi.fn(),
+      closeTabNow: vi.fn(),
+    };
+    const { result } = renderHook(() => useProjectOps(ctx));
+    projectsRef.current = initial;
+
+    act(() => {
+      result.current.activateWorktree("wt-beta-feature");
+    });
+
+    // Previous project's watcher uninstalled, new project's watcher
+    // installed in lockstep.
+    expect(unwatchProjectForBridge).toHaveBeenCalledWith("/projects/alpha");
+    expect(watchProjectForBridge).toHaveBeenCalledWith("/projects/beta");
+    expect(projectsRef.current.activeId).toBe("project-2");
+    expect(projectsRef.current.activeWorktreeId).toBe("wt-beta-feature");
+  });
+
   it("scopes discovered sessions to the active worktree cwd", () => {
     const { result } = renderProjectOps(
       makeProjectsState({

--- a/src/hooks/useProjectOps.ts
+++ b/src/hooks/useProjectOps.ts
@@ -888,15 +888,29 @@ export function useProjectOps(ctx: UseProjectOpsContext): UseProjectOpsActions {
     );
     let activeProjectId = current.activeId;
     let nextCwd: string | null;
+    let nextProjectPath: string | null;
     if (worktreeId) {
       const hit = findProjectOfWorktree(worktreeId);
       if (!hit) return;
       activeProjectId = hit.project.id;
       nextCwd = hit.worktree.path;
+      nextProjectPath = hit.project.path;
     } else {
       const project = activeProject(current);
       nextCwd = project?.path ?? null;
+      nextProjectPath = project?.path ?? null;
     }
+    // Cross-project worktree activation needs to mirror
+    // setActiveProjectById's watcher swap, otherwise the previous
+    // project's `.aethon/extensions` watcher keeps firing (and the
+    // new project's stays uninstalled) until a later full project
+    // switch.
+    const previousActive = activeProject(current);
+    const crossingProjects =
+      activeProjectId !== current.activeId &&
+      previousActive !== undefined &&
+      nextProjectPath !== null &&
+      previousActive.path !== nextProjectPath;
     projectsRef.current = setActiveWorktreeState(
       { ...current, activeId: activeProjectId },
       worktreeId,
@@ -908,6 +922,10 @@ export function useProjectOps(ctx: UseProjectOpsContext): UseProjectOpsActions {
     );
     scheduleProjectsSave();
     announceProjectToBridge(nextTabId ?? "default", nextCwd);
+    if (crossingProjects && previousActive && nextProjectPath) {
+      unwatchProjectForBridge(previousActive.path);
+      watchProjectForBridge(nextProjectPath);
+    }
   }
 
   function tabCwdMatches(tab: Tab, path: string): boolean {

--- a/src/hooks/useProjectOps.ts
+++ b/src/hooks/useProjectOps.ts
@@ -908,7 +908,7 @@ export function useProjectOps(ctx: UseProjectOpsContext): UseProjectOpsActions {
     const previousActive = activeProject(current);
     const crossingProjects =
       activeProjectId !== current.activeId &&
-      previousActive !== undefined &&
+      previousActive != null &&
       nextProjectPath !== null &&
       previousActive.path !== nextProjectPath;
     projectsRef.current = setActiveWorktreeState(

--- a/src/hooks/useProjectOps.ts
+++ b/src/hooks/useProjectOps.ts
@@ -99,6 +99,10 @@ export interface UseProjectOpsContext {
     discovered: DiscoveredSession[],
     knownIds: Set<string>,
   ) => void;
+  /** From useTabs: force-close visible tabs after their backing worktree
+   *  is removed. Worktree deletion is already destructive, so there is
+   *  no separate close confirmation for those session tabs. */
+  closeTabNow: (tabId: string) => void;
 }
 
 export interface UseProjectOpsActions {
@@ -284,6 +288,7 @@ export function useProjectOps(ctx: UseProjectOpsContext): UseProjectOpsActions {
     unwatchProjectForBridge,
     dispatchTerminalReplay,
     autoRestoreDiscoveredSessions,
+    closeTabNow,
   } = ctx;
 
   const projectsLoadedRef = useRef(false);
@@ -905,6 +910,53 @@ export function useProjectOps(ctx: UseProjectOpsContext): UseProjectOpsActions {
     announceProjectToBridge(nextTabId ?? "default", nextCwd);
   }
 
+  function tabCwdMatches(tab: Tab, path: string): boolean {
+    if (tab.kind !== "agent") return false;
+    return normalizeSessionPath(tab.cwd) === normalizeSessionPath(path);
+  }
+
+  function removeStoredTabsForWorktreePath(
+    path: string,
+    removedBucketKey: string,
+  ): void {
+    tabBucketsRef.current.delete(removedBucketKey);
+    for (const [key, bucket] of tabBucketsRef.current.entries()) {
+      const tabs = bucket.tabs.filter((tab) => !tabCwdMatches(tab, path));
+      if (tabs.length === bucket.tabs.length) continue;
+      if (tabs.length === 0) {
+        tabBucketsRef.current.delete(key);
+        continue;
+      }
+      const activeTabId = tabs.some((tab) => tab.id === bucket.activeTabId)
+        ? bucket.activeTabId
+        : tabs[0]?.id;
+      tabBucketsRef.current.set(key, { tabs, activeTabId });
+    }
+  }
+
+  function closeVisibleTabsForWorktreePath(path: string): void {
+    const tabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
+    const closing = tabs
+      .filter((tab) => tabCwdMatches(tab, path))
+      .map((tab) => tab.id);
+    for (const tabId of closing) closeTabNow(tabId);
+  }
+
+  function closeTabsForRemovedWorktree(
+    projectId: string,
+    worktreeId: string,
+    path: string,
+    wasActive: boolean,
+  ): void {
+    closeVisibleTabsForWorktreePath(path);
+    if (wasActive) activateWorktree(null);
+    removeStoredTabsForWorktreePath(
+      path,
+      projectScopeBucketKey(projectId, worktreeId),
+    );
+    syncRecentSessionsToState();
+  }
+
   function resolveWorktreeBaseBranch(
     project: Project,
     explicit?: string,
@@ -1058,7 +1110,12 @@ export function useProjectOps(ctx: UseProjectOpsContext): UseProjectOpsActions {
         worktreePath: worktree.path,
         force: false,
       });
-      // Drop locally + clear active pointer if needed.
+      closeTabsForRemovedWorktree(
+        project.id,
+        worktreeId,
+        worktree.path,
+        projectsRef.current.activeWorktreeId === worktreeId,
+      );
       const list = removeWorktreeFromList(
         projectsRef.current.worktreesByProject[project.id] ?? [],
         worktreeId,
@@ -1068,9 +1125,7 @@ export function useProjectOps(ctx: UseProjectOpsContext): UseProjectOpsActions {
         project.id,
         list,
       );
-      if (projectsRef.current.activeWorktreeId === worktreeId) {
-        projectsRef.current = setActiveWorktreeState(projectsRef.current, null);
-      }
+      syncProjectsToState();
       void persistProjects();
     } catch (err) {
       const msg = String(err);
@@ -1086,6 +1141,12 @@ export function useProjectOps(ctx: UseProjectOpsContext): UseProjectOpsActions {
             worktreePath: worktree.path,
             force: true,
           });
+          closeTabsForRemovedWorktree(
+            project.id,
+            worktreeId,
+            worktree.path,
+            projectsRef.current.activeWorktreeId === worktreeId,
+          );
           const list = removeWorktreeFromList(
             projectsRef.current.worktreesByProject[project.id] ?? [],
             worktreeId,
@@ -1095,6 +1156,7 @@ export function useProjectOps(ctx: UseProjectOpsContext): UseProjectOpsActions {
             project.id,
             list,
           );
+          syncProjectsToState();
           void persistProjects();
           return;
         } catch (e2) {

--- a/src/hooks/useProjectOps.ts
+++ b/src/hooks/useProjectOps.ts
@@ -6,7 +6,7 @@ import {
   type MutableRefObject,
   type SetStateAction,
 } from "react";
-import { NO_PROJECT_KEY, projectBucketKey, type Tab } from "../types/tab";
+import { NO_PROJECT_KEY, type Tab } from "../types/tab";
 import {
   DEFAULT_WORKTREE_BASE_BRANCH,
   activeCwd,
@@ -178,12 +178,25 @@ export interface UseProjectOpsActions {
   ) => { project: Project; worktree: Worktree } | null;
 }
 
+const WORKTREE_BUCKET_SEPARATOR = "::worktree::";
+
 function normalizeSessionPath(path: string | undefined): string {
   return (path ?? "").replace(/[/\\]+$/, "");
 }
 
 export function projectIdFromBucketKey(key: string): string | null {
-  return key === NO_PROJECT_KEY ? null : key;
+  if (key === NO_PROJECT_KEY) return null;
+  return key.split(WORKTREE_BUCKET_SEPARATOR, 1)[0] || null;
+}
+
+export function projectScopeBucketKey(
+  projectId: string | null | undefined,
+  worktreeId: string | null | undefined,
+): string {
+  if (!projectId) return NO_PROJECT_KEY;
+  return worktreeId
+    ? `${projectId}${WORKTREE_BUCKET_SEPARATOR}${worktreeId}`
+    : projectId;
 }
 
 export function tabsForProjectBucket(tabs: Tab[], bucketKey: string): Tab[] {
@@ -209,6 +222,34 @@ export function nonEmptyProjectTabs(tabs: Tab[]): Tab[] {
       tab.terminalBuffer.length > 0
     );
   });
+}
+
+export function worktreeIdForCwd(
+  projects: ProjectsState,
+  cwd: string | undefined,
+  projectId?: string | null,
+): string | null | undefined {
+  const target = normalizeSessionPath(cwd);
+  if (!target) return undefined;
+  const orderedProjectIds = [
+    ...(projectId ? [projectId] : []),
+    ...(projects.activeId && projects.activeId !== projectId
+      ? [projects.activeId]
+      : []),
+    ...projects.projects
+      .map((p) => p.id)
+      .filter((id) => id !== projectId && id !== projects.activeId),
+  ];
+  for (const id of orderedProjectIds) {
+    const project = projects.projects.find((p) => p.id === id);
+    if (!project) continue;
+    if (normalizeSessionPath(project.path) === target) return null;
+    const worktree = (projects.worktreesByProject[id] ?? []).find(
+      (w) => normalizeSessionPath(w.path) === target,
+    );
+    if (worktree) return worktree.isMain ? null : worktree.id;
+  }
+  return undefined;
 }
 
 /**
@@ -425,6 +466,11 @@ export function useProjectOps(ctx: UseProjectOpsContext): UseProjectOpsActions {
         ...sidebar,
         projects: ps.projects.map((p) => {
           const wts = ps.worktreesByProject[p.id] ?? [];
+          const projectIsActive = p.id === ps.activeId;
+          const activeWorktreeBelongsToProject =
+            projectIsActive &&
+            !!ps.activeWorktreeId &&
+            wts.some((w) => w.id === ps.activeWorktreeId && !w.isMain);
           return {
             id: p.id,
             // Basename is what we surface; the absolute path lives
@@ -433,7 +479,7 @@ export function useProjectOps(ctx: UseProjectOpsContext): UseProjectOpsActions {
             label: p.label,
             tooltip: p.path,
             iconUrl: p.iconUrl,
-            active: p.id === ps.activeId,
+            active: projectIsActive && !activeWorktreeBelongsToProject,
             git: gitStatusRef.current.get(p.path),
             expanded: p.uiExpanded === true,
             worktrees: wts.map((w) => ({
@@ -580,7 +626,10 @@ export function useProjectOps(ctx: UseProjectOpsContext): UseProjectOpsActions {
   }
 
   function openProjectByPath(path: string, label?: string): string {
-    const fromKey = projectBucketKey(projectsRef.current.activeId);
+    const fromKey = projectScopeBucketKey(
+      projectsRef.current.activeId,
+      projectsRef.current.activeWorktreeId,
+    );
     const { state: nextProjects, id } = upsertProject(
       projectsRef.current,
       path,
@@ -593,9 +642,13 @@ export function useProjectOps(ctx: UseProjectOpsContext): UseProjectOpsActions {
     // Switch to the project's tab bucket BEFORE notifying the bridge.
     // If this is a brand-new project, the bucket is empty and the empty
     // state composite renders until the user explicitly creates a tab.
-    const nextTabId = switchProjectBucket(fromKey, projectBucketKey(id), {
-      mirrorProjects: true,
-    });
+    const nextTabId = switchProjectBucket(
+      fromKey,
+      projectScopeBucketKey(id, null),
+      {
+        mirrorProjects: true,
+      },
+    );
     scheduleProjectsSave();
     const tabId = nextTabId ?? "default";
     announceProjectToBridge(tabId, path);
@@ -606,8 +659,8 @@ export function useProjectOps(ctx: UseProjectOpsContext): UseProjectOpsActions {
     const ps = projectsRef.current;
     const target = ps.projects.find((p) => p.id === id);
     if (!target) return false;
-    const fromKey = projectBucketKey(ps.activeId);
-    const toKey = projectBucketKey(id);
+    const fromKey = projectScopeBucketKey(ps.activeId, ps.activeWorktreeId);
+    const toKey = projectScopeBucketKey(id, null);
     const previousActive = activeProject(ps);
     projectsRef.current = {
       ...ps,
@@ -639,7 +692,10 @@ export function useProjectOps(ctx: UseProjectOpsContext): UseProjectOpsActions {
   }
 
   function clearActiveProject() {
-    const fromKey = projectBucketKey(projectsRef.current.activeId);
+    const fromKey = projectScopeBucketKey(
+      projectsRef.current.activeId,
+      projectsRef.current.activeWorktreeId,
+    );
     const previousActive = activeProject(projectsRef.current);
     projectsRef.current = {
       ...projectsRef.current,
@@ -656,9 +712,12 @@ export function useProjectOps(ctx: UseProjectOpsContext): UseProjectOpsActions {
   }
 
   function removeProjectById(id: string): boolean {
-    const fromKey = projectBucketKey(projectsRef.current.activeId);
+    const fromKey = projectScopeBucketKey(
+      projectsRef.current.activeId,
+      projectsRef.current.activeWorktreeId,
+    );
     const wasActive = projectsRef.current.activeId === id;
-    const removedKey = projectBucketKey(id);
+    const removedKey = projectScopeBucketKey(id, null);
     const result = removeProject(projectsRef.current, id);
     if (!result.removed) return false;
 
@@ -816,13 +875,34 @@ export function useProjectOps(ctx: UseProjectOpsContext): UseProjectOpsActions {
   }
 
   function activateWorktree(worktreeId: string | null): void {
-    if (projectsRef.current.activeWorktreeId === worktreeId) return;
+    const current = projectsRef.current;
+    if (current.activeWorktreeId === worktreeId) return;
+    const fromKey = projectScopeBucketKey(
+      current.activeId,
+      current.activeWorktreeId,
+    );
+    let activeProjectId = current.activeId;
+    let nextCwd: string | null;
+    if (worktreeId) {
+      const hit = findProjectOfWorktree(worktreeId);
+      if (!hit) return;
+      activeProjectId = hit.project.id;
+      nextCwd = hit.worktree.path;
+    } else {
+      const project = activeProject(current);
+      nextCwd = project?.path ?? null;
+    }
     projectsRef.current = setActiveWorktreeState(
-      projectsRef.current,
+      { ...current, activeId: activeProjectId },
       worktreeId,
     );
-    setState((prev) => ({ ...prev, ...buildProjectsMirror(prev) }));
+    const nextTabId = switchProjectBucket(
+      fromKey,
+      projectScopeBucketKey(activeProjectId, worktreeId),
+      { mirrorProjects: true },
+    );
     scheduleProjectsSave();
+    announceProjectToBridge(nextTabId ?? "default", nextCwd);
   }
 
   function resolveWorktreeBaseBranch(

--- a/src/hooks/useQueuedDispatch.test.ts
+++ b/src/hooks/useQueuedDispatch.test.ts
@@ -17,7 +17,7 @@ function tabWithQueue(
 }
 
 describe("useQueuedDispatch", () => {
-  it("drains the head when waiting transitions false", () => {
+  it("drains the head when waiting transitions false and hands off to sendChat", () => {
     const sendChat = vi.fn(() => Promise.resolve());
     const updateTab = vi.fn();
 
@@ -32,9 +32,13 @@ describe("useQueuedDispatch", () => {
     const next = mutator(idleTab);
     expect(next.queuedMessages).toEqual([]);
     expect(next.queueCount).toBe(0);
-    // Optimistic waiting=true keeps the composer's Stop button asserted
-    // across the drain transition so it doesn't flash Send.
-    expect(next.waiting).toBe(true);
+    // CRITICAL: do NOT pre-flip waiting=true here — sendChat reads
+    // stateRef synchronously, and would see the tab as busy if we
+    // did, routing the popped message right back into the queue.
+    // `sendChat`'s normal-dispatch path will set waiting=true; the
+    // pop + dispatch setStates batch into one render commit, so
+    // there's no visible Send-button flash either.
+    expect(next.waiting).toBe(false);
     expect(sendChat).toHaveBeenCalledWith("go", {
       mode: "normal",
       tabId: "tab-1",

--- a/src/hooks/useQueuedDispatch.test.ts
+++ b/src/hooks/useQueuedDispatch.test.ts
@@ -1,0 +1,141 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useQueuedDispatch } from "./useQueuedDispatch";
+import { makeEmptyTab, type Tab } from "../types/tab";
+
+function tabWithQueue(
+  partial: Partial<Tab> = {},
+  ...queued: { id: string; content: string }[]
+): Tab {
+  return {
+    ...makeEmptyTab("tab-1", "Tab 1"),
+    queuedMessages: queued,
+    queueCount: queued.length,
+    ...partial,
+  };
+}
+
+describe("useQueuedDispatch", () => {
+  it("drains the head when waiting transitions false", async () => {
+    const sendChat = vi.fn(() => Promise.resolve());
+    const updateTab = vi.fn();
+
+    const idleTab = tabWithQueue({ waiting: false }, { id: "q1", content: "go" });
+    renderHook(() =>
+      useQueuedDispatch({ tabs: [idleTab], sendChat, updateTab }),
+    );
+
+    expect(updateTab).toHaveBeenCalledTimes(1);
+    const [tabId, mutator] = updateTab.mock.calls[0];
+    expect(tabId).toBe("tab-1");
+    const next = mutator(idleTab);
+    expect(next.queuedMessages).toEqual([]);
+    expect(next.queueCount).toBe(0);
+    // Optimistic waiting=true keeps the composer's Stop button asserted
+    // across the drain transition so it doesn't flash Send.
+    expect(next.waiting).toBe(true);
+    expect(sendChat).toHaveBeenCalledWith("go", {
+      mode: "normal",
+      tabId: "tab-1",
+    });
+  });
+
+  it("does nothing while the tab is still waiting", () => {
+    const sendChat = vi.fn(() => Promise.resolve());
+    const updateTab = vi.fn();
+    const busy = tabWithQueue({ waiting: true }, { id: "q1", content: "wait" });
+    renderHook(() =>
+      useQueuedDispatch({ tabs: [busy], sendChat, updateTab }),
+    );
+    expect(sendChat).not.toHaveBeenCalled();
+    expect(updateTab).not.toHaveBeenCalled();
+  });
+
+  it("does nothing while a queued steer is in flight", () => {
+    const sendChat = vi.fn(() => Promise.resolve());
+    const updateTab = vi.fn();
+    const tab = tabWithQueue(
+      { waiting: false, queuedSteeringId: "q1" },
+      { id: "q1", content: "steered" },
+    );
+    renderHook(() =>
+      useQueuedDispatch({ tabs: [tab], sendChat, updateTab }),
+    );
+    expect(sendChat).not.toHaveBeenCalled();
+    expect(updateTab).not.toHaveBeenCalled();
+  });
+
+  it("ignores shell tabs even if their queue arrays are populated", () => {
+    const sendChat = vi.fn(() => Promise.resolve());
+    const updateTab = vi.fn();
+    const shell = tabWithQueue(
+      {
+        kind: "shell",
+        waiting: false,
+        shell: {
+          cwd: "/tmp",
+          command: "bash",
+          args: [],
+          shareMode: "private",
+          shellState: "running",
+        },
+      },
+      { id: "q1", content: "x" },
+    );
+    renderHook(() =>
+      useQueuedDispatch({ tabs: [shell], sendChat, updateTab }),
+    );
+    expect(sendChat).not.toHaveBeenCalled();
+  });
+
+  it("tolerates pre-feature tabs lacking queuedMessages", () => {
+    const sendChat = vi.fn(() => Promise.resolve());
+    const updateTab = vi.fn();
+    // Simulate a persisted-from-disk tab that pre-dates the field.
+    const legacyTab = {
+      ...makeEmptyTab("tab-1", "Tab 1"),
+      // Deliberately drop the field so the hook sees undefined.
+      queuedMessages: undefined as unknown as Tab["queuedMessages"],
+    };
+    expect(() => {
+      renderHook(() =>
+        useQueuedDispatch({ tabs: [legacyTab], sendChat, updateTab }),
+      );
+    }).not.toThrow();
+    expect(sendChat).not.toHaveBeenCalled();
+  });
+
+  it("clears the dispatching guard after sendChat resolves so the next drain fires", async () => {
+    const sendChat = vi.fn(() => Promise.resolve());
+    const updateTab = vi.fn();
+
+    // First pass: queue has one item, tab idle.
+    const tabA = tabWithQueue({ waiting: false }, { id: "q1", content: "one" });
+    const { rerender } = renderHook(
+      ({ tabs }: { tabs: Tab[] }) =>
+        useQueuedDispatch({ tabs, sendChat, updateTab }),
+      { initialProps: { tabs: [tabA] } },
+    );
+
+    // Let the sendChat microtask resolve so the dispatching guard clears.
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(sendChat).toHaveBeenCalledTimes(1);
+
+    // Second pass: simulate the agent finishing its turn (waiting flips
+    // back to false) with a new head in the queue. The guard must not
+    // block the second drain.
+    const tabB = tabWithQueue(
+      { waiting: false },
+      { id: "q2", content: "two" },
+    );
+    rerender({ tabs: [tabB] });
+    expect(sendChat).toHaveBeenLastCalledWith("two", {
+      mode: "normal",
+      tabId: "tab-1",
+    });
+  });
+});

--- a/src/hooks/useQueuedDispatch.test.ts
+++ b/src/hooks/useQueuedDispatch.test.ts
@@ -17,7 +17,7 @@ function tabWithQueue(
 }
 
 describe("useQueuedDispatch", () => {
-  it("drains the head when waiting transitions false", async () => {
+  it("drains the head when waiting transitions false", () => {
     const sendChat = vi.fn(() => Promise.resolve());
     const updateTab = vi.fn();
 

--- a/src/hooks/useQueuedDispatch.ts
+++ b/src/hooks/useQueuedDispatch.ts
@@ -1,0 +1,76 @@
+import { useEffect, useRef } from "react";
+import type { Tab } from "../types/tab";
+
+/**
+ * Drains client-held queues. Watches every agent tab's `waiting` flag;
+ * when it transitions to false and the tab still has queued messages,
+ * the head pops and ships through `sendChat(..., { mode: "normal" })`.
+ *
+ * Coupling notes:
+ *
+ * - The pop and the `waiting = true` re-flip happen in a single
+ *   `updateTab` call so React commits them together. Without that, the
+ *   composer would flash Send → Stop on every queue transition.
+ * - `dispatching` tracks the tabs that are currently mid-dispatch
+ *   (sendChat is async). It guards against the effect running again
+ *   after the optimistic update and double-firing the same head.
+ * - `queuedSteeringId` blocks the drain while a manual steer is in
+ *   flight, so a user mashing Send-next-and-Steer doesn't fire two
+ *   chat sends at once.
+ * - The hook intentionally only inspects `kind === "agent"` tabs;
+ *   shell and editor tabs have queue arrays only because they share
+ *   the Tab interface.
+ */
+export interface UseQueuedDispatchParams {
+  tabs: Tab[];
+  sendChat: (
+    text: string,
+    options?: { mode?: "normal" | "steer"; tabId?: string },
+  ) => Promise<void>;
+  updateTab: (tabId: string, mutator: (tab: Tab) => Tab) => void;
+}
+
+export function useQueuedDispatch({
+  tabs,
+  sendChat,
+  updateTab,
+}: UseQueuedDispatchParams): void {
+  const dispatchingRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    for (const tab of tabs) {
+      if (tab.kind !== "agent") continue;
+      if (tab.waiting) continue;
+      // Defensive: persisted tabs created before this feature don't have
+      // queuedMessages on disk. The sessionUiSnapshot loader now seeds
+      // [], but a tab created by the bridge / a hand-crafted state
+      // patch might still arrive without it.
+      const queue = tab.queuedMessages ?? [];
+      if (queue.length === 0) continue;
+      if (tab.queuedSteeringId) continue;
+      if (dispatchingRef.current.has(tab.id)) continue;
+
+      const head = queue[0];
+      dispatchingRef.current.add(tab.id);
+
+      // Optimistic: pop the head AND flip waiting back to true in a
+      // single render commit so the composer button doesn't flash from
+      // Stop → Send → Stop between turns.
+      updateTab(tab.id, (t) => {
+        const current = t.queuedMessages ?? [];
+        if (current.length === 0) return t;
+        const next = current.slice(1);
+        return {
+          ...t,
+          queuedMessages: next,
+          queueCount: next.length,
+          waiting: true,
+        };
+      });
+
+      sendChat(head.content, { mode: "normal", tabId: tab.id }).finally(() => {
+        dispatchingRef.current.delete(tab.id);
+      });
+    }
+  }, [tabs, sendChat, updateTab]);
+}

--- a/src/hooks/useQueuedDispatch.ts
+++ b/src/hooks/useQueuedDispatch.ts
@@ -53,9 +53,15 @@ export function useQueuedDispatch({
       const head = queue[0];
       dispatchingRef.current.add(tab.id);
 
-      // Optimistic: pop the head AND flip waiting back to true in a
-      // single render commit so the composer button doesn't flash from
-      // Stop → Send → Stop between turns.
+      // Pop the head only. `sendChat`'s normal-dispatch path is
+      // responsible for re-flipping `waiting` to true (and the user
+      // message into history). The pop + sendChat's three setState
+      // calls batch into a single render commit, so the composer
+      // doesn't flash Send between turns despite waiting briefly
+      // reading as false in this body. Pre-flipping waiting here
+      // breaks the drain: sendChat reads stateRef synchronously,
+      // sees waiting=true, and routes the popped message right back
+      // into the queue with a new id.
       updateTab(tab.id, (t) => {
         const current = t.queuedMessages ?? [];
         if (current.length === 0) return t;
@@ -64,7 +70,6 @@ export function useQueuedDispatch({
           ...t,
           queuedMessages: next,
           queueCount: next.length,
-          waiting: true,
         };
       });
 

--- a/src/hooks/useQueuedDispatch.ts
+++ b/src/hooks/useQueuedDispatch.ts
@@ -8,12 +8,17 @@ import type { Tab } from "../types/tab";
  *
  * Coupling notes:
  *
- * - The pop and the `waiting = true` re-flip happen in a single
- *   `updateTab` call so React commits them together. Without that, the
- *   composer would flash Send → Stop on every queue transition.
+ * - The hook pops the head ONLY — it deliberately does NOT pre-flip
+ *   `waiting` to true. `sendChat`'s normal-dispatch path is what flips
+ *   waiting; the pop + sendChat's three setState calls batch into a
+ *   single render commit, so the composer doesn't flash Send between
+ *   turns. Pre-flipping waiting here breaks the drain: `sendChat`
+ *   reads `stateRef` synchronously, would see the tab as busy, and
+ *   would route the popped message right back into the queue with a
+ *   new id (caught by peer-review P1).
  * - `dispatching` tracks the tabs that are currently mid-dispatch
  *   (sendChat is async). It guards against the effect running again
- *   after the optimistic update and double-firing the same head.
+ *   while sendChat is awaiting and double-firing the same head.
  * - `queuedSteeringId` blocks the drain while a manual steer is in
  *   flight, so a user mashing Send-next-and-Steer doesn't fire two
  *   chat sends at once.

--- a/src/hooks/useTabs.ts
+++ b/src/hooks/useTabs.ts
@@ -32,6 +32,8 @@ export const TAB_MIRROR_KEYS: (keyof Tab)[] = [
   "draft",
   "waiting",
   "queueCount",
+  "queuedMessages",
+  "queuedSteeringId",
   "canvas",
   "model",
   "cwd",

--- a/src/skills/default-layout/chat.test.tsx
+++ b/src/skills/default-layout/chat.test.tsx
@@ -1,7 +1,9 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { ChatHistory, ChatInput } from "./chat";
+import { ChatHistory, ChatInput, QueuedMessagesPopover } from "./chat";
+import { SkillRegistry } from "../../skills/SkillRegistry";
+import { SkillRegistryProvider } from "../../skills/registry";
 
 class ResizeObserverMock {
   observe = vi.fn();
@@ -23,16 +25,27 @@ function renderInput(
   props: Record<string, unknown> = {},
   state: Record<string, unknown> = {},
 ) {
+  // ChatInput now mounts a `<RegistryComponent type="queued-messages-popover">`
+  // inside itself, which requires the SkillRegistry context. We register the
+  // popover so the production wiring is exercised; tests that pass queued
+  // messages in state see the real popover render path.
+  const registry = new SkillRegistry();
+  registry.register({
+    name: "test-default-layout",
+    components: { "queued-messages-popover": QueuedMessagesPopover },
+  });
   render(
-    <ChatInput
-      component={{
-        id: "chat-input",
-        type: "chat-input",
-        props: { value: "", placeholder: "Message", ...props },
-      }}
-      state={state}
-      onEvent={onEvent}
-    />,
+    <SkillRegistryProvider registry={registry}>
+      <ChatInput
+        component={{
+          id: "chat-input",
+          type: "chat-input",
+          props: { value: "", placeholder: "Message", ...props },
+        }}
+        state={state}
+        onEvent={onEvent}
+      />
+    </SkillRegistryProvider>,
   );
   return {
     input: screen.getByPlaceholderText("Message"),

--- a/src/skills/default-layout/chat.test.tsx
+++ b/src/skills/default-layout/chat.test.tsx
@@ -25,10 +25,13 @@ function renderInput(
   props: Record<string, unknown> = {},
   state: Record<string, unknown> = {},
 ) {
-  // ChatInput now mounts a `<RegistryComponent type="queued-messages-popover">`
-  // inside itself, which requires the SkillRegistry context. We register the
-  // popover so the production wiring is exercised; tests that pass queued
-  // messages in state see the real popover render path.
+  // ChatInput resolves the queued-messages popover via
+  // `useSkillRegistry().resolve(...)` and renders it with
+  // `createElement`, which means the test needs a real SkillRegistry
+  // in context with the popover registered — otherwise the resolver
+  // returns undefined and the popover stays unmounted even when the
+  // test fixture seeds `state.queuedMessages`. Registering it here
+  // exercises the production wiring.
   const registry = new SkillRegistry();
   registry.register({
     name: "test-default-layout",

--- a/src/skills/default-layout/chat.tsx
+++ b/src/skills/default-layout/chat.tsx
@@ -5,7 +5,15 @@
  * that pairs message history with a live-rendered A2UI subtree.
  */
 
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  createElement,
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { createPortal } from "react-dom";
 import ReactMarkdown from "react-markdown";
 import type {
@@ -22,10 +30,9 @@ import {
 } from "../../utils/dataBinding";
 import { resolvePointer } from "../../utils/jsonPointer";
 import { splitThinkingBlocks } from "../../utils/thinkingBlocks";
-import A2UIRenderer, {
-  RegistryComponent,
-} from "../../components/A2UIRenderer";
+import A2UIRenderer from "../../components/A2UIRenderer";
 import type { BuiltinComponentProps } from "../../components/A2UIRenderer";
+import { useSkillRegistry } from "../../skills/SkillRegistry";
 import type { QueuedMessage } from "../../types/tab";
 import { useStickyScroll } from "../../utils/useStickyScroll";
 import { MARKDOWN_COMPONENTS } from "./markdown-adapter";
@@ -720,6 +727,15 @@ export function ChatInput({
   state,
   onEvent,
 }: BuiltinComponentProps) {
+  // Skill-registry lookup for the queued-messages popover so a skill
+  // can override the chrome via `aethon.registerComponent`. We render
+  // it inline (rather than going through RegistryComponent, which
+  // would synthesize a separate A2UI subtree and require the outer
+  // dispatcher's signature) — its events bubble through this
+  // composite's onEvent and route via `type:chat-input` with the
+  // `queue:*` prefix.
+  const skillRegistry = useSkillRegistry();
+  const QueuedPopover = skillRegistry.resolve("queued-messages-popover");
   const props = component.props as {
     value?: StringValue;
     placeholder?: StringValue;
@@ -1153,13 +1169,20 @@ export function ChatInput({
       {/* Queued messages popover. Rendered via the skill registry so a
           skill can swap the chrome by calling
           `aethon.registerComponent("queued-messages-popover", custom)`.
-          The composite hides itself when the queue is empty, so we
-          can mount it unconditionally. */}
-      <RegistryComponent
-        type="queued-messages-popover"
-        state={state}
-        onEvent={onEvent}
-      />
+          The composite hides itself when the queue is empty.
+          `createElement` (rather than `<QueuedPopover .../>` JSX) keeps
+          the react-hooks/component-during-render rule happy — the
+          runtime-resolved component is not a JSX-declared identifier. */}
+      {QueuedPopover
+        ? createElement(QueuedPopover, {
+            component: {
+              id: "queued-messages-popover",
+              type: "queued-messages-popover",
+            },
+            state,
+            onEvent,
+          })
+        : null}
       {slashMatch &&
         menuAnchor &&
         createPortal(
@@ -1631,17 +1654,25 @@ export function QueuedMessagesPopover({
   const steeringId = state.queuedSteeringId as string | undefined;
   if (items.length === 0) return null;
 
+  // Prefix the wire event names so they're unambiguous when they
+  // bubble up through the host composite's onEvent (events route by
+  // type:<host-type>, not by the popover's identity, when this
+  // composite is rendered inline inside another composite — the
+  // common case when a skill hosts the popover inside its own
+  // ChatInput replacement). The `queue:` prefix lets `queue.ts`
+  // route handler match without colliding with the host's own
+  // events.
   const onEdit = (id: string, content: string) => {
-    onEvent("edit", { messageId: id, content });
+    onEvent("queue:edit", { messageId: id, content });
   };
   const onDelete = (id: string) => {
-    onEvent("delete", { messageId: id });
+    onEvent("queue:delete", { messageId: id });
   };
   const onSteer = (id: string) => {
-    onEvent("steer", { messageId: id });
+    onEvent("queue:steer", { messageId: id });
   };
   const onClear = () => {
-    onEvent("clear");
+    onEvent("queue:clear");
   };
 
   return (

--- a/src/skills/default-layout/chat.tsx
+++ b/src/skills/default-layout/chat.tsx
@@ -22,8 +22,11 @@ import {
 } from "../../utils/dataBinding";
 import { resolvePointer } from "../../utils/jsonPointer";
 import { splitThinkingBlocks } from "../../utils/thinkingBlocks";
-import A2UIRenderer from "../../components/A2UIRenderer";
+import A2UIRenderer, {
+  RegistryComponent,
+} from "../../components/A2UIRenderer";
 import type { BuiltinComponentProps } from "../../components/A2UIRenderer";
+import type { QueuedMessage } from "../../types/tab";
 import { useStickyScroll } from "../../utils/useStickyScroll";
 import { MARKDOWN_COMPONENTS } from "./markdown-adapter";
 import { readUiScale } from "./layout";
@@ -1147,6 +1150,16 @@ export function ChatInput({
         title="Drag to resize composer"
         onMouseDown={startComposerResize}
       />
+      {/* Queued messages popover. Rendered via the skill registry so a
+          skill can swap the chrome by calling
+          `aethon.registerComponent("queued-messages-popover", custom)`.
+          The composite hides itself when the queue is empty, so we
+          can mount it unconditionally. */}
+      <RegistryComponent
+        type="queued-messages-popover"
+        state={state}
+        onEvent={onEvent}
+      />
       {slashMatch &&
         menuAnchor &&
         createPortal(
@@ -1327,6 +1340,342 @@ export function ChatInput({
           </button>
         )}
       </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// QueuedMessagesPopover — Claudette-style popover above the composer. Lets
+// the user inspect, edit, delete, or promote-to-steer each message they
+// queued while the agent was busy. Drained automatically by
+// `useQueuedDispatch` on the next idle (head only); the popover only
+// disappears when the queue is empty (zero items renders nothing so the
+// composer stays flush).
+//
+// State contract:
+//   /queuedMessages: QueuedMessage[]            — mirrored from active tab
+//   /queuedSteeringId?: string                  — id mid-steer (spinner)
+//
+// Events emitted:
+//   edit   { messageId, content }
+//   delete { messageId }
+//   steer  { messageId }
+//   clear
+// ---------------------------------------------------------------------------
+
+function ChevronIcon() {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M3 5l5 5 5-5" />
+    </svg>
+  );
+}
+
+function EditIcon() {
+  return (
+    <svg
+      width="13"
+      height="13"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M11 2l3 3-8 8H3v-3l8-8z" />
+    </svg>
+  );
+}
+
+function SteerIcon() {
+  return (
+    <svg
+      width="13"
+      height="13"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M2 8l11-5-4 11-2-5-5-1z" />
+    </svg>
+  );
+}
+
+function DeleteIcon() {
+  return (
+    <svg
+      width="13"
+      height="13"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M3 5h10M6 5V3h4v2M5 5l1 9h4l1-9" />
+    </svg>
+  );
+}
+
+function QueuedSpinner() {
+  return (
+    <svg
+      className="a2ui-queued-spinner"
+      width="13"
+      height="13"
+      viewBox="0 0 16 16"
+      fill="none"
+      aria-hidden="true"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        r="6"
+        stroke="currentColor"
+        strokeOpacity="0.25"
+        strokeWidth="2"
+      />
+      <path
+        d="M14 8a6 6 0 0 0-6-6"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+interface QueuedMessageRowProps {
+  message: QueuedMessage;
+  steering: boolean;
+  onEdit: (id: string, content: string) => void;
+  onDelete: (id: string) => void;
+  onSteer: (id: string) => void;
+}
+
+const QueuedMessageRow = memo(function QueuedMessageRow({
+  message,
+  steering,
+  onEdit,
+  onDelete,
+  onSteer,
+}: QueuedMessageRowProps) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(message.content);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (editing) {
+      // Sync the draft from the latest content whenever editing opens —
+      // covers the case where the row's content changed externally
+      // (auto-dispatch popped a different row, or a remote edit) while
+      // the user was deciding to click Edit. setState-in-effect here is
+      // intentional: we resync the local textarea to authoritative
+      // content the moment the user enters edit mode.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setDraft(message.content);
+      // Focus + select-all so the user can overwrite without clearing
+      // manually. requestAnimationFrame waits one frame so the textarea
+      // is in the DOM before .focus() runs.
+      const handle = requestAnimationFrame(() => {
+        const el = textareaRef.current;
+        if (!el) return;
+        el.focus();
+        el.select();
+      });
+      return () => cancelAnimationFrame(handle);
+    }
+    return undefined;
+  }, [editing, message.content]);
+
+  function commitEdit() {
+    const trimmed = draft.trim();
+    if (!trimmed) {
+      // An empty edit is a delete — Claudette behavior. Don't keep a
+      // blank row in the queue.
+      onDelete(message.id);
+    } else if (trimmed !== message.content) {
+      onEdit(message.id, trimmed);
+    }
+    setEditing(false);
+  }
+
+  function cancelEdit() {
+    setDraft(message.content);
+    setEditing(false);
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      commitEdit();
+      return;
+    }
+    if (e.key === "Escape") {
+      e.preventDefault();
+      cancelEdit();
+      return;
+    }
+  }
+
+  if (editing) {
+    return (
+      <li className="a2ui-queued-message a2ui-queued-message-editing">
+        <div className="a2ui-queued-edit-form">
+          <textarea
+            ref={textareaRef}
+            className="a2ui-queued-edit-textarea"
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={handleKeyDown}
+            rows={2}
+            aria-label="Edit queued message"
+          />
+          <div className="a2ui-queued-edit-buttons">
+            <button
+              type="button"
+              className="a2ui-queued-action a2ui-queued-edit-save"
+              onClick={commitEdit}
+              title="Save (Enter)"
+              aria-label="Save edit"
+            >
+              Save
+            </button>
+            <button
+              type="button"
+              className="a2ui-queued-action a2ui-queued-edit-cancel"
+              onClick={cancelEdit}
+              title="Cancel (Esc)"
+              aria-label="Cancel edit"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      </li>
+    );
+  }
+
+  return (
+    <li className="a2ui-queued-message">
+      <span className="a2ui-queued-icon" aria-hidden="true">
+        <ChevronIcon />
+      </span>
+      <span className="a2ui-queued-content" title={message.content}>
+        {message.content}
+      </span>
+      <div className="a2ui-queued-actions">
+        <button
+          type="button"
+          className="a2ui-queued-action a2ui-queued-edit"
+          onClick={() => setEditing(true)}
+          title="Edit"
+          aria-label="Edit queued message"
+          disabled={steering}
+        >
+          <EditIcon />
+        </button>
+        <button
+          type="button"
+          className="a2ui-queued-action a2ui-queued-steer"
+          onClick={() => onSteer(message.id)}
+          title="Send now as steer"
+          aria-label="Steer this message into the current turn"
+          disabled={steering}
+        >
+          {steering ? <QueuedSpinner /> : <SteerIcon />}
+          <span className="a2ui-queued-steer-label">
+            {steering ? "STEER…" : "STEER"}
+          </span>
+        </button>
+        <button
+          type="button"
+          className="a2ui-queued-action a2ui-queued-delete"
+          onClick={() => onDelete(message.id)}
+          title="Remove from queue"
+          aria-label="Remove from queue"
+          disabled={steering}
+        >
+          <DeleteIcon />
+        </button>
+      </div>
+    </li>
+  );
+});
+
+export function QueuedMessagesPopover({
+  state,
+  onEvent,
+}: BuiltinComponentProps) {
+  // Read straight from root state — useTabs mirrors the active tab's
+  // queuedMessages + queuedSteeringId on switch and per update.
+  const items = (state.queuedMessages as QueuedMessage[] | undefined) ?? [];
+  const steeringId = state.queuedSteeringId as string | undefined;
+  if (items.length === 0) return null;
+
+  const onEdit = (id: string, content: string) => {
+    onEvent("edit", { messageId: id, content });
+  };
+  const onDelete = (id: string) => {
+    onEvent("delete", { messageId: id });
+  };
+  const onSteer = (id: string) => {
+    onEvent("steer", { messageId: id });
+  };
+  const onClear = () => {
+    onEvent("clear");
+  };
+
+  return (
+    <div
+      className="a2ui-queued-popover"
+      role="region"
+      aria-label="Queued messages"
+    >
+      <div className="a2ui-queued-header">
+        <span className="a2ui-queued-label">
+          Queued · {items.length}
+        </span>
+        <button
+          type="button"
+          className="a2ui-queued-clear"
+          onClick={onClear}
+          aria-label="Clear queue"
+          title="Drop every queued message"
+        >
+          Clear queue
+        </button>
+      </div>
+      <ul className="a2ui-queued-list">
+        {items.map((m) => (
+          <QueuedMessageRow
+            key={m.id}
+            message={m}
+            steering={steeringId === m.id}
+            onEdit={onEdit}
+            onDelete={onDelete}
+            onSteer={onSteer}
+          />
+        ))}
+      </ul>
     </div>
   );
 }

--- a/src/skills/default-layout/components.tsx
+++ b/src/skills/default-layout/components.tsx
@@ -32,7 +32,14 @@ export {
 } from "./layout";
 export { Sidebar, filterItems, providerOf } from "./sidebar";
 export { FileTreePanel } from "./sidebar/file-tree";
-export { ChatHistory, ChatInput, MainCanvas, ToolCard, formatToolDuration } from "./chat";
+export {
+  ChatHistory,
+  ChatInput,
+  MainCanvas,
+  QueuedMessagesPopover,
+  ToolCard,
+  formatToolDuration,
+} from "./chat";
 export {
   Terminal,
   observeTerminalTheme,

--- a/src/skills/default-layout/dashboard/issues-section.test.ts
+++ b/src/skills/default-layout/dashboard/issues-section.test.ts
@@ -1,5 +1,83 @@
-import { describe, expect, it } from "vitest";
+// @vitest-environment jsdom
+import { createElement } from "react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { IssuesSection } from "./issues-section";
 import { buildIssueBranch, buildIssuePrompt } from "./issue-task";
+import type { GhIssue } from "../../../ghIssuesCache";
+
+const { getIssues, getIssueDetail, openUrl } = vi.hoisted(() => ({
+  getIssues: vi.fn(),
+  getIssueDetail: vi.fn(),
+  openUrl: vi.fn(),
+}));
+
+vi.mock("../../../ghIssuesCache", () => ({
+  getIssues: (...args: unknown[]) => getIssues(...args),
+  getIssueDetail: (...args: unknown[]) => getIssueDetail(...args),
+  refreshIssues: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-opener", () => ({
+  openUrl: (...args: unknown[]) => openUrl(...args),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const issue: GhIssue = {
+  number: 85,
+  title: "Cannot rename session tab while agent is running",
+  url: "https://github.com/utensils/aethon/issues/85",
+  state: "open",
+  author: "jamesbrink",
+  updatedAt: "2026-05-25T15:00:00Z",
+  labels: [{ name: "bug", color: "d73a4a" }],
+  comments: 0,
+};
+
+function renderIssues(onEvent = vi.fn()) {
+  getIssues.mockResolvedValue([issue]);
+  getIssueDetail.mockResolvedValue({
+    ...issue,
+    body: "Rename should stay available.",
+  });
+  render(
+    createElement(IssuesSection, {
+      component: {
+        id: "issues",
+        type: "issues-section",
+        props: {
+          project: { id: "p1", label: "aethon", path: "/repo/aethon" },
+        },
+      },
+      state: {
+        activeWorktreeId: "wt-current",
+        sidebar: {
+          projects: [
+            {
+              id: "p1",
+              worktrees: [
+                { id: "wt-current", branch: "fix/current", active: true },
+                { id: "wt-other", branch: "fix/issue-85-existing" },
+              ],
+            },
+          ],
+        },
+      },
+      onEvent,
+    }),
+  );
+  return { onEvent };
+}
 
 describe("issues-section task helpers", () => {
   it("builds a descriptive issue branch and avoids loaded collisions", () => {
@@ -98,5 +176,70 @@ describe("issues-section task helpers", () => {
         author: "octo",
       }),
     ).toContain("Please work on GitHub issue #7");
+  });
+});
+
+describe("IssuesSection", () => {
+  it("sends the hover action to a fresh worktree by default", async () => {
+    const { onEvent } = renderIssues();
+
+    await screen.findByText(issue.title);
+    fireEvent.click(screen.getByRole("button", { name: /send issue #85/i }));
+
+    await waitFor(() =>
+      expect(onEvent).toHaveBeenCalledWith(
+        "start-task",
+        expect.objectContaining({
+          projectId: "p1",
+          newWorktree: true,
+          branch: expect.stringMatching(/^fix\/issue-85-/),
+          source: "github-issue",
+          issueNumber: 85,
+        }),
+        "issue-85",
+      ),
+    );
+  });
+
+  it("offers both new-worktree and current-worktree launches in the context menu", async () => {
+    renderIssues();
+
+    await screen.findByText(issue.title);
+    fireEvent.contextMenu(screen.getByText(issue.title).closest("li")!);
+
+    expect(
+      screen.getByRole("menuitem", { name: "Send to agent (new worktree)" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("menuitem", {
+        name: "Send to agent (current worktree/branch)",
+      }),
+    ).toBeTruthy();
+  });
+
+  it("sends context-menu current worktree launches to the active worktree", async () => {
+    const { onEvent } = renderIssues();
+
+    await screen.findByText(issue.title);
+    fireEvent.contextMenu(screen.getByText(issue.title).closest("li")!);
+    fireEvent.click(
+      screen.getByRole("menuitem", {
+        name: "Send to agent (current worktree/branch)",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(onEvent).toHaveBeenCalledWith(
+        "start-task",
+        expect.objectContaining({
+          projectId: "p1",
+          newWorktree: false,
+          worktreeId: "wt-current",
+          source: "github-issue",
+          issueNumber: 85,
+        }),
+        "issue-85",
+      ),
+    );
   });
 });

--- a/src/skills/default-layout/dashboard/issues-section.tsx
+++ b/src/skills/default-layout/dashboard/issues-section.tsx
@@ -4,14 +4,15 @@
  * spec:
  *
  *   - left-click  → open the issue's URL in the OS browser
- *   - right-click → context menu with "Send to agent" (also
+ *   - right-click → context menu with "Send to agent (new worktree)" and
+ *                   "Send to agent (current worktree/branch)" (also
  *                   keyboard-equivalent via the dedicated send button
  *                   on the row hover state).
  *
- * The "send to agent" path fetches the full issue body and emits
+ * The "send to agent" paths fetch the full issue body and emit
  * `start-task` with a markdown-formatted prompt that includes title,
- * url, author, and body. Issue launches always ask the shared task path
- * to create a fresh worktree so each issue starts isolated.
+ * url, author, and body. The default row action asks the shared task
+ * path to create a fresh worktree so each issue starts isolated.
  *
  * Registered as the dashboard component type `issues-section` so
  * extensions can swap it with `aethon.registerComponent`. All data
@@ -91,6 +92,31 @@ function projectWorktreeBranches(
       .flatMap((w) => [w.branch, w.label])
       .filter((v): v is string => typeof v === "string" && v.length > 0),
   );
+}
+
+function currentProjectWorktreeId(
+  state: Record<string, unknown>,
+  projectId: string,
+): string | undefined {
+  const activeWorktreeId =
+    typeof state.activeWorktreeId === "string" &&
+    state.activeWorktreeId.length > 0
+      ? state.activeWorktreeId
+      : undefined;
+  const sidebar =
+    (state.sidebar as
+      | {
+          projects?: {
+            id: string;
+            worktrees?: { id?: string; active?: boolean }[];
+          }[];
+        }
+      | undefined) ?? {};
+  const project = sidebar.projects?.find((p) => p.id === projectId);
+  const worktree =
+    project?.worktrees?.find((w) => w.id && w.id === activeWorktreeId) ??
+    project?.worktrees?.find((w) => w.id && w.active === true);
+  return worktree?.id;
 }
 
 export function IssuesSection({
@@ -182,7 +208,7 @@ export function IssuesSection({
     );
   }, []);
 
-  const sendIssueToAgent = useCallback(
+  const sendIssueToNewWorktree = useCallback(
     async (issue: GhIssue) => {
       if (!project) return;
       setSending(issue.number);
@@ -204,6 +230,36 @@ export function IssuesSection({
             ),
             // Tag the payload so the route handler / tests can spot
             // an issue-originated launch.
+            source: "github-issue",
+            issueNumber: issue.number,
+            issueUrl: issue.url,
+          },
+          `issue-${issue.number}`,
+        );
+      } catch (err) {
+        console.warn("send-to-agent failed:", err);
+      } finally {
+        setSending(null);
+      }
+    },
+    [project, onEvent, state],
+  );
+
+  const sendIssueToCurrentWorktree = useCallback(
+    async (issue: GhIssue) => {
+      if (!project) return;
+      setSending(issue.number);
+      try {
+        const detail = await getIssueDetail(project.path, issue.number);
+        const prompt = buildIssuePrompt(detail);
+        const worktreeId = currentProjectWorktreeId(state, project.id);
+        onEvent(
+          "start-task",
+          {
+            projectId: project.id,
+            prompt,
+            newWorktree: false,
+            worktreeId,
             source: "github-issue",
             issueNumber: issue.number,
             issueUrl: issue.url,
@@ -333,11 +389,11 @@ export function IssuesSection({
                   type="button"
                   className="a2ui-dashboard-issue-send"
                   aria-label={`Send issue #${issue.number} to agent`}
-                  title="Send to agent"
+                  title="Send to agent in new worktree"
                   disabled={isSending}
                   onClick={(e) => {
                     e.stopPropagation();
-                    void sendIssueToAgent(issue);
+                    void sendIssueToNewWorktree(issue);
                   }}
                 >
                   {isSending ? "…" : "→ Agent"}
@@ -373,10 +429,22 @@ export function IssuesSection({
             onClick={() => {
               const m = menu;
               setMenu(null);
-              void sendIssueToAgent(m.issue);
+              void sendIssueToNewWorktree(m.issue);
             }}
           >
-            Send to agent (current worktree)
+            Send to agent (new worktree)
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            className="a2ui-dashboard-issue-menu-item"
+            onClick={() => {
+              const m = menu;
+              setMenu(null);
+              void sendIssueToCurrentWorktree(m.issue);
+            }}
+          >
+            Send to agent (current worktree/branch)
           </button>
           <button
             type="button"

--- a/src/skills/default-layout/index.ts
+++ b/src/skills/default-layout/index.ts
@@ -18,6 +18,7 @@ import {
   Layout,
   MainCanvas,
   MarkdownPreview,
+  QueuedMessagesPopover,
   ShellCanvas,
   Sidebar,
   StatusBar,
@@ -64,6 +65,11 @@ export const defaultLayoutSkill: A2UISkill = {
     sidebar: Sidebar,
     "chat-history": ChatHistory,
     "chat-input": ChatInput,
+    // Popover above the composer listing client-held queued messages
+    // with per-row edit / steer / delete. Drained by `useQueuedDispatch`
+    // on the next idle. Replaceable via
+    // `aethon.registerComponent("queued-messages-popover", custom)`.
+    "queued-messages-popover": QueuedMessagesPopover,
     "status-bar": StatusBar,
     "tab-strip": TabStrip,
     terminal: Terminal,

--- a/src/skills/default-layout/layout.tsx
+++ b/src/skills/default-layout/layout.tsx
@@ -225,7 +225,11 @@ export function StatusBar({ component, state }: BuiltinComponentProps) {
   };
   const projects =
     (resolveValue(state, "/sidebar/projects") as SidebarProj[] | undefined) ?? [];
-  const active = projects.find((p) => p.active === true);
+  const activeProjectId = resolveValue(state, "/activeProjectId");
+  const active =
+    (typeof activeProjectId === "string"
+      ? projects.find((p) => p.id === activeProjectId)
+      : undefined) ?? projects.find((p) => p.active === true);
   const activeWt = active?.worktrees?.find((w) => w.active === true);
   const showChip = props.showProjectChip !== false && !!active;
 

--- a/src/skills/default-layout/settings-panel.tsx
+++ b/src/skills/default-layout/settings-panel.tsx
@@ -651,7 +651,13 @@ function ExtensionsList({
               <ToggleSwitch
                 checked={kind === "enabled"}
                 disabled={kind === "failed"}
-                ariaLabel={`${kind === "disabled" ? "Enable" : "Disable"} extension ${name}`}
+                // Pick the verb from the actual checked state (not just
+                // the explicit "disabled" branch) — otherwise a failed
+                // extension renders unchecked but announces "Disable
+                // extension X" to assistive tech. Matches the sidebar
+                // toggle which keys off `extState.checked` for the
+                // same reason.
+                ariaLabel={`${kind === "enabled" ? "Disable" : "Enable"} extension ${name}`}
                 title={
                   kind === "failed"
                     ? "Extension failed to load — fix the error and reload to re-enable"

--- a/src/skills/default-layout/settings-panel.tsx
+++ b/src/skills/default-layout/settings-panel.tsx
@@ -19,6 +19,7 @@ import type { BuiltinComponentProps } from "../../components/A2UIRenderer";
 import { getConfig, type AethonConfig } from "../../config";
 import { SHARE_MODES, type ShareMode } from "../../utils/shareMode";
 import { DropdownPickerCore } from "./variation-components";
+import { ToggleSwitch } from "./toggle-switch";
 
 interface SettingsState {
   open: boolean;
@@ -637,7 +638,6 @@ function ExtensionsList({
                 ? item.id.slice("ext-disabled:".length)
                 : item.label;
         const canToggle = kind !== "core";
-        const targetDisabled = kind !== "disabled";
         return (
           <li
             key={item.id}
@@ -648,20 +648,26 @@ function ExtensionsList({
               <span className="ae-settings-ext-hint">{item.hint}</span>
             ) : null}
             {canToggle ? (
-              <button
-                type="button"
-                className="ae-settings-secondary ae-settings-ext-action"
-                onClick={() =>
+              <ToggleSwitch
+                checked={kind === "enabled"}
+                disabled={kind === "failed"}
+                ariaLabel={`${kind === "disabled" ? "Enable" : "Disable"} extension ${name}`}
+                title={
+                  kind === "failed"
+                    ? "Extension failed to load — fix the error and reload to re-enable"
+                    : kind === "disabled"
+                      ? `Enable ${name}`
+                      : `Disable ${name}`
+                }
+                onChange={(next) => {
                   onEvent("toggle-extension", {
                     sectionId: "extensions",
                     itemId: item.id,
                     name,
-                    disabled: targetDisabled,
-                  })
-                }
-              >
-                {kind === "disabled" ? "Enable" : "Disable"}
-              </button>
+                    disabled: !next,
+                  });
+                }}
+              />
             ) : (
               <span
                 className="ae-settings-ext-hint"

--- a/src/skills/default-layout/sidebar/file-tree.tsx
+++ b/src/skills/default-layout/sidebar/file-tree.tsx
@@ -994,7 +994,13 @@ export function FileTreePanel({
           git?: { branch?: string };
         }>
       | undefined) ?? [];
-  const activeProject = sidebarProjects.find((p) => p.active === true);
+  const activeProjectId =
+    typeof state["activeProjectId"] === "string"
+      ? state["activeProjectId"]
+      : null;
+  const activeProject =
+    sidebarProjects.find((p) => p.id === activeProjectId) ??
+    sidebarProjects.find((p) => p.active === true);
   const activeWorktree = activeProject?.worktrees?.find(
     (w) => w.active === true,
   );

--- a/src/skills/default-layout/sidebar/index.test.tsx
+++ b/src/skills/default-layout/sidebar/index.test.tsx
@@ -59,13 +59,16 @@ describe("Sidebar extension controls", () => {
               label: "mold-gallery",
               hint: "project",
               active: true,
+              kind: "project",
             },
           ],
         },
       },
     });
 
-    expect(screen.getByText("extensions")).toBeTruthy();
+    // Qualified section title — always present even when only one
+    // bucket has rows so scope is never ambiguous.
+    expect(screen.getByText("project extensions")).toBeTruthy();
     expect(screen.getByText("mold-gallery")).toBeTruthy();
     expect(screen.getByText("project")).toBeTruthy();
   });
@@ -202,7 +205,7 @@ describe("Sidebar extension controls", () => {
     );
   });
 
-  it("splits the auto-injected EXTENSIONS section by origin (project / user / package)", () => {
+  it("splits the auto-injected EXTENSIONS section by origin (project / user)", () => {
     renderSidebar({
       state: {
         sidebar: {
@@ -222,22 +225,21 @@ describe("Sidebar extension controls", () => {
             {
               id: "ext:@brink/widget",
               label: "@brink/widget",
-              hint: "package",
-              kind: "package",
+              hint: "user",
+              kind: "user",
             },
           ],
         },
       },
     });
 
-    // All three subgroup titles appear; the user can tell scope at a
-    // glance even without reading the per-row hints.
-    expect(screen.getByText("extensions · project")).toBeTruthy();
-    expect(screen.getByText("extensions · user")).toBeTruthy();
-    expect(screen.getByText("extensions · package")).toBeTruthy();
+    // Two subgroup titles appear; the user can tell scope at a glance
+    // even without reading the per-row hints.
+    expect(screen.getByText("project extensions")).toBeTruthy();
+    expect(screen.getByText("user extensions")).toBeTruthy();
   });
 
-  it("uses a bare 'extensions' title when only one origin bucket has items", () => {
+  it("keeps the qualified group title even when only one origin bucket has items", () => {
     renderSidebar({
       state: {
         sidebar: {
@@ -253,9 +255,11 @@ describe("Sidebar extension controls", () => {
       },
     });
 
-    // No subgroup qualifier when there's nothing to disambiguate against.
-    expect(screen.getByText("extensions")).toBeTruthy();
-    expect(screen.queryByText("extensions · user")).toBeNull();
+    // Origin label stays so the user can read scope at a glance even
+    // with a single extension loaded — that's exactly when knowing
+    // whether it's a user-level or project-level addition matters.
+    expect(screen.getByText("user extensions")).toBeTruthy();
+    expect(screen.queryByText("project extensions")).toBeNull();
   });
 
   it("does not duplicate a layout-provided extensions section", () => {

--- a/src/skills/default-layout/sidebar/index.test.tsx
+++ b/src/skills/default-layout/sidebar/index.test.tsx
@@ -100,6 +100,102 @@ describe("Sidebar extension controls", () => {
     );
   });
 
+  it("renders an inline toggle switch on each extension row", () => {
+    renderSidebar({
+      state: {
+        sidebar: {
+          extensions: [
+            {
+              id: "ext:mold-gallery",
+              label: "mold-gallery",
+              hint: "project",
+            },
+            {
+              id: "ext-disabled:silenced",
+              label: "silenced",
+              hint: "disabled",
+            },
+            {
+              id: "ext-failed:boom",
+              label: "boom",
+              hint: "load failed",
+            },
+          ],
+        },
+      },
+    });
+
+    const switches = screen.getAllByRole("switch");
+    expect(switches).toHaveLength(3);
+    expect(switches[0].getAttribute("aria-checked")).toBe("true"); // ext: → on
+    expect(switches[1].getAttribute("aria-checked")).toBe("false"); // ext-disabled: → off
+    expect(switches[2].getAttribute("aria-checked")).toBe("false"); // ext-failed: → off
+    expect(switches[2].getAttribute("aria-disabled")).toBe("true"); // failed is interactive-disabled
+  });
+
+  it("flips an enabled extension via the inline toggle without firing the row's select", () => {
+    const { onEvent } = renderSidebar({
+      state: {
+        sidebar: {
+          extensions: [
+            {
+              id: "ext:mold-gallery",
+              label: "mold-gallery",
+              hint: "project",
+            },
+          ],
+        },
+      },
+    });
+
+    fireEvent.click(screen.getByRole("switch"));
+
+    // Toggle emits toggle-extension with the *target* disabled flag.
+    expect(onEvent).toHaveBeenCalledWith(
+      "toggle-extension",
+      {
+        sectionId: "extensions",
+        itemId: "ext:mold-gallery",
+        name: "mold-gallery",
+        disabled: true,
+      },
+      "ext:mold-gallery",
+    );
+    // The outer row's "select" handler must not fire — that would
+    // bounce the user into the extension's pane on every toggle.
+    const selectCalls = onEvent.mock.calls.filter(
+      (call) => call[0] === "select",
+    );
+    expect(selectCalls).toHaveLength(0);
+  });
+
+  it("re-enables a disabled extension via the inline toggle", () => {
+    const { onEvent } = renderSidebar({
+      state: {
+        sidebar: {
+          extensions: [
+            {
+              id: "ext-disabled:silenced",
+              label: "silenced",
+            },
+          ],
+        },
+      },
+    });
+
+    fireEvent.click(screen.getByRole("switch"));
+    expect(onEvent).toHaveBeenCalledWith(
+      "toggle-extension",
+      {
+        sectionId: "extensions",
+        itemId: "ext-disabled:silenced",
+        name: "silenced",
+        disabled: false,
+      },
+      "ext-disabled:silenced",
+    );
+  });
+
   it("does not duplicate a layout-provided extensions section", () => {
     renderSidebar({
       props: {

--- a/src/skills/default-layout/sidebar/index.test.tsx
+++ b/src/skills/default-layout/sidebar/index.test.tsx
@@ -80,6 +80,7 @@ describe("Sidebar extension controls", () => {
               label: "mold-gallery",
               hint: "project",
               active: true,
+              kind: "project",
             },
           ],
         },
@@ -142,6 +143,7 @@ describe("Sidebar extension controls", () => {
               id: "ext:mold-gallery",
               label: "mold-gallery",
               hint: "project",
+              kind: "project",
             },
           ],
         },
@@ -151,6 +153,8 @@ describe("Sidebar extension controls", () => {
     fireEvent.click(screen.getByRole("switch"));
 
     // Toggle emits toggle-extension with the *target* disabled flag.
+    // SectionId reflects the bucket the item lands in (`extensions` for
+    // project, `extensions-user` for user, `extensions-package` for npm).
     expect(onEvent).toHaveBeenCalledWith(
       "toggle-extension",
       {
@@ -177,6 +181,7 @@ describe("Sidebar extension controls", () => {
             {
               id: "ext-disabled:silenced",
               label: "silenced",
+              kind: "user",
             },
           ],
         },
@@ -184,16 +189,73 @@ describe("Sidebar extension controls", () => {
     });
 
     fireEvent.click(screen.getByRole("switch"));
+    // User-bucket items live in the extensions-user sub-section.
     expect(onEvent).toHaveBeenCalledWith(
       "toggle-extension",
       {
-        sectionId: "extensions",
+        sectionId: "extensions-user",
         itemId: "ext-disabled:silenced",
         name: "silenced",
         disabled: false,
       },
       "ext-disabled:silenced",
     );
+  });
+
+  it("splits the auto-injected EXTENSIONS section by origin (project / user / package)", () => {
+    renderSidebar({
+      state: {
+        sidebar: {
+          extensions: [
+            {
+              id: "ext:mold:gallery",
+              label: "mold:gallery",
+              hint: "project",
+              kind: "project",
+            },
+            {
+              id: "ext:user-helper",
+              label: "user-helper",
+              hint: "user",
+              kind: "user",
+            },
+            {
+              id: "ext:@brink/widget",
+              label: "@brink/widget",
+              hint: "package",
+              kind: "package",
+            },
+          ],
+        },
+      },
+    });
+
+    // All three subgroup titles appear; the user can tell scope at a
+    // glance even without reading the per-row hints.
+    expect(screen.getByText("extensions · project")).toBeTruthy();
+    expect(screen.getByText("extensions · user")).toBeTruthy();
+    expect(screen.getByText("extensions · package")).toBeTruthy();
+  });
+
+  it("uses a bare 'extensions' title when only one origin bucket has items", () => {
+    renderSidebar({
+      state: {
+        sidebar: {
+          extensions: [
+            {
+              id: "ext:user-only",
+              label: "user-only",
+              hint: "user",
+              kind: "user",
+            },
+          ],
+        },
+      },
+    });
+
+    // No subgroup qualifier when there's nothing to disambiguate against.
+    expect(screen.getByText("extensions")).toBeTruthy();
+    expect(screen.queryByText("extensions · user")).toBeNull();
   });
 
   it("does not duplicate a layout-provided extensions section", () => {

--- a/src/skills/default-layout/sidebar/index.tsx
+++ b/src/skills/default-layout/sidebar/index.tsx
@@ -300,7 +300,11 @@ export function Sidebar({
       kind = "project";
     } else if (sectionId === "history" && canDeleteHistoryItem(item.id)) {
       kind = "session";
-    } else if (sectionId === "extensions") {
+    } else if (
+      sectionId === "extensions" ||
+      sectionId === "extensions-user" ||
+      sectionId === "extensions-package"
+    ) {
       if (item.id.startsWith("ext:")) {
         kind = "extension-enabled";
         extensionName = item.id.slice("ext:".length);
@@ -586,15 +590,60 @@ export function Sidebar({
     ...(props.sections ?? []),
     ...(extraSections as SidebarSectionExt[]),
   ].some((section) => section.id === "extensions");
+  // Split the auto-injected extensions list into one section per
+  // origin (project / user / package). Each sub-section auto-hides
+  // when empty. Items carry `kind` from buildExtensionSidebarItems;
+  // legacy items lacking the field fall back to "user" so a stale
+  // upstream array still groups sensibly.
   const extensionSections: SidebarSectionExt[] =
     extensionItems.length > 0 && !hasExplicitExtensionSection
-      ? [
-          {
-            id: "extensions",
-            title: "extensions",
-            items: extensionItems,
-          },
-        ]
+      ? (() => {
+          const buckets: Record<
+            "project" | "user" | "package",
+            SidebarItem[]
+          > = { project: [], user: [], package: [] };
+          for (const item of extensionItems) {
+            const kind = ((item as { kind?: string }).kind ?? "user") as
+              | "project"
+              | "user"
+              | "package";
+            (buckets[kind] ?? buckets.user).push(item);
+          }
+          const sections: SidebarSectionExt[] = [];
+          if (buckets.project.length > 0) {
+            sections.push({
+              id: "extensions",
+              title: "extensions · project",
+              items: buckets.project,
+            });
+          }
+          if (buckets.user.length > 0) {
+            sections.push({
+              id: "extensions-user",
+              // When project rows exist, the user/package headers act
+              // as dividers — qualified so the user can read what
+              // each group is at a glance. When there are no project
+              // rows, the first remaining group keeps the bare
+              // "extensions" title so the sidebar reads cleanly.
+              title:
+                buckets.project.length > 0
+                  ? "extensions · user"
+                  : "extensions",
+              items: buckets.user,
+            });
+          }
+          if (buckets.package.length > 0) {
+            sections.push({
+              id: "extensions-package",
+              title:
+                buckets.project.length > 0 || buckets.user.length > 0
+                  ? "extensions · package"
+                  : "extensions",
+              items: buckets.package,
+            });
+          }
+          return sections;
+        })()
       : [];
   const allSections: SidebarSectionExt[] = [
     ...(props.sections ?? []),
@@ -668,10 +717,16 @@ export function Sidebar({
                     // Inline toggle for extension rows — quick on/off
                     // without diving into the right-click menu. The
                     // context menu stays as a secondary affordance.
-                    const extState =
-                      section.id === "extensions"
-                        ? extensionToggleState(item)
-                        : null;
+                    // Match all three auto-injected sub-sections
+                    // (project / user / package) so the toggle shows
+                    // on every extension row regardless of bucket.
+                    const isExtensionsSection =
+                      section.id === "extensions" ||
+                      section.id === "extensions-user" ||
+                      section.id === "extensions-package";
+                    const extState = isExtensionsSection
+                      ? extensionToggleState(item)
+                      : null;
                     const trailingControl = extState ? (
                       <ToggleSwitch
                         checked={extState.checked}

--- a/src/skills/default-layout/sidebar/index.tsx
+++ b/src/skills/default-layout/sidebar/index.tsx
@@ -24,6 +24,7 @@ import {
 } from "../../../utils/sidebarHistory";
 import { AeMarkInline } from "../layout";
 import { ItemRow, type ItemRowProps } from "./item-row";
+import { ToggleSwitch } from "../toggle-switch";
 import {
   SearchableSidebarSection,
   type SidebarSectionExt,
@@ -87,6 +88,36 @@ interface SidebarMenuHandlers {
   renameContextSession: () => void;
   deleteContextSession: () => void;
   toggleContextExtension: (disabled: boolean) => void;
+}
+
+/** Classify an extension item by its id prefix. The bridge encodes the
+ *  state in the id (`ext:` = enabled, `ext-disabled:` = disabled,
+ *  `ext-failed:` = load failed) so the toggle has to invert that to
+ *  drive the switch. Returns null for non-extension items so the caller
+ *  can skip rendering the trailing toggle slot entirely. */
+function extensionToggleState(item: SidebarItem): {
+  name: string;
+  checked: boolean;
+  failed: boolean;
+} | null {
+  if (item.id.startsWith("ext:")) {
+    return { name: item.id.slice("ext:".length), checked: true, failed: false };
+  }
+  if (item.id.startsWith("ext-disabled:")) {
+    return {
+      name: item.id.slice("ext-disabled:".length),
+      checked: false,
+      failed: false,
+    };
+  }
+  if (item.id.startsWith("ext-failed:")) {
+    return {
+      name: item.id.slice("ext-failed:".length),
+      checked: false,
+      failed: true,
+    };
+  }
+  return null;
 }
 
 function buildSidebarMenuItems(
@@ -634,6 +665,39 @@ export function Sidebar({
                       : null;
                     const worktrees = projectItem?.worktrees;
                     const expanded = projectItem?.expanded === true;
+                    // Inline toggle for extension rows — quick on/off
+                    // without diving into the right-click menu. The
+                    // context menu stays as a secondary affordance.
+                    const extState =
+                      section.id === "extensions"
+                        ? extensionToggleState(item)
+                        : null;
+                    const trailingControl = extState ? (
+                      <ToggleSwitch
+                        checked={extState.checked}
+                        disabled={extState.failed}
+                        ariaLabel={`${extState.checked ? "Disable" : "Enable"} extension ${extState.name}`}
+                        title={
+                          extState.failed
+                            ? "Extension failed to load — fix the error and reload to re-enable"
+                            : extState.checked
+                              ? `Disable ${extState.name}`
+                              : `Enable ${extState.name}`
+                        }
+                        onChange={(next) => {
+                          onEvent(
+                            "toggle-extension",
+                            {
+                              sectionId: section.id,
+                              itemId: item.id,
+                              name: extState.name,
+                              disabled: !next,
+                            },
+                            item.id,
+                          );
+                        }}
+                      />
+                    ) : undefined;
                     // Only show the disclosure when there are EXTRA worktrees
                     // beyond the main one — every git repo returns ≥1 entry
                     // (the project's primary checkout), so a 1-element list
@@ -685,6 +749,7 @@ export function Sidebar({
                           // regardless of which rows happen to have
                           // worktrees or uncommitted changes.
                           alignSlots={isProjects}
+                          trailingControl={trailingControl}
                         />
                         {hasExtraWorktrees && expanded
                           ? extraWorktrees.map((wt) => (

--- a/src/skills/default-layout/sidebar/index.tsx
+++ b/src/skills/default-layout/sidebar/index.tsx
@@ -302,8 +302,7 @@ export function Sidebar({
       kind = "session";
     } else if (
       sectionId === "extensions" ||
-      sectionId === "extensions-user" ||
-      sectionId === "extensions-package"
+      sectionId === "extensions-user"
     ) {
       if (item.id.startsWith("ext:")) {
         kind = "extension-enabled";
@@ -591,55 +590,46 @@ export function Sidebar({
     ...(extraSections as SidebarSectionExt[]),
   ].some((section) => section.id === "extensions");
   // Split the auto-injected extensions list into one section per
-  // origin (project / user / package). Each sub-section auto-hides
-  // when empty. Items carry `kind` from buildExtensionSidebarItems;
-  // legacy items lacking the field fall back to "user" so a stale
-  // upstream array still groups sensibly.
+  // origin (project / user). Each sub-section auto-hides when empty.
+  // Items carry `kind` from buildExtensionSidebarItems; legacy items
+  // lacking the field fall back to "user" so a stale upstream array
+  // still groups sensibly. The classifier folds `@<project>/<ext>`
+  // npm packages into the project bucket when the scope matches the
+  // active project's basename — so `@mold/image-gallery-ui` reads as
+  // a project extension under mold, while `@brink/widget` stays user.
   const extensionSections: SidebarSectionExt[] =
     extensionItems.length > 0 && !hasExplicitExtensionSection
       ? (() => {
-          const buckets: Record<
-            "project" | "user" | "package",
-            SidebarItem[]
-          > = { project: [], user: [], package: [] };
+          const buckets: Record<"project" | "user", SidebarItem[]> = {
+            project: [],
+            user: [],
+          };
           for (const item of extensionItems) {
             const kind = ((item as { kind?: string }).kind ?? "user") as
               | "project"
-              | "user"
-              | "package";
+              | "user";
             (buckets[kind] ?? buckets.user).push(item);
           }
+          // Always show the qualified group title so the user can tell
+          // scope at a glance even when only one bucket has rows. The
+          // alternative — collapsing to a bare "extensions" — loses
+          // that information exactly when there's only one extension
+          // loaded, which is when its origin is most informative.
+          const titleFor = (kind: "project" | "user"): string =>
+            kind === "project" ? "project extensions" : "user extensions";
           const sections: SidebarSectionExt[] = [];
           if (buckets.project.length > 0) {
             sections.push({
               id: "extensions",
-              title: "extensions · project",
+              title: titleFor("project"),
               items: buckets.project,
             });
           }
           if (buckets.user.length > 0) {
             sections.push({
               id: "extensions-user",
-              // When project rows exist, the user/package headers act
-              // as dividers — qualified so the user can read what
-              // each group is at a glance. When there are no project
-              // rows, the first remaining group keeps the bare
-              // "extensions" title so the sidebar reads cleanly.
-              title:
-                buckets.project.length > 0
-                  ? "extensions · user"
-                  : "extensions",
+              title: titleFor("user"),
               items: buckets.user,
-            });
-          }
-          if (buckets.package.length > 0) {
-            sections.push({
-              id: "extensions-package",
-              title:
-                buckets.project.length > 0 || buckets.user.length > 0
-                  ? "extensions · package"
-                  : "extensions",
-              items: buckets.package,
             });
           }
           return sections;
@@ -717,13 +707,12 @@ export function Sidebar({
                     // Inline toggle for extension rows — quick on/off
                     // without diving into the right-click menu. The
                     // context menu stays as a secondary affordance.
-                    // Match all three auto-injected sub-sections
-                    // (project / user / package) so the toggle shows
-                    // on every extension row regardless of bucket.
+                    // Match both auto-injected sub-sections
+                    // (project / user) so the toggle shows on every
+                    // extension row regardless of bucket.
                     const isExtensionsSection =
                       section.id === "extensions" ||
-                      section.id === "extensions-user" ||
-                      section.id === "extensions-package";
+                      section.id === "extensions-user";
                     const extState = isExtensionsSection
                       ? extensionToggleState(item)
                       : null;

--- a/src/skills/default-layout/sidebar/item-row.tsx
+++ b/src/skills/default-layout/sidebar/item-row.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import type { A2UIComponent, SidebarItem } from "../../../types/a2ui";
 import type { BuiltinComponentProps } from "../../../components/A2UIRenderer";
 
@@ -28,6 +29,11 @@ export interface ItemRowProps {
    *  label at the same x-coordinate as a sibling project with worktrees.
    *  Other sections (panels, history) leave it off so they stay tight. */
   alignSlots?: boolean;
+  /** Optional trailing control rendered after the hint (e.g. a toggle
+   *  switch for extension rows). Click propagation is the caller's
+   *  responsibility — `ToggleSwitch` already stops propagation so the
+   *  outer row's "select" click doesn't fire on toggle activation. */
+  trailingControl?: ReactNode;
 }
 
 export function ItemRow({
@@ -43,6 +49,7 @@ export function ItemRow({
   disclosure,
   onToggleDisclosure,
   alignSlots,
+  trailingControl,
 }: ItemRowProps) {
   if (item.componentType && renderChildWithState) {
     const synthetic: A2UIComponent = {
@@ -161,6 +168,7 @@ export function ItemRow({
         </span>
       ) : null}
       {hint && <span className="a2ui-sidebar-item-hint">{hint}</span>}
+      {trailingControl}
     </li>
   );
 }

--- a/src/skills/default-layout/toggle-switch.test.tsx
+++ b/src/skills/default-layout/toggle-switch.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ToggleSwitch } from "./toggle-switch";
+
+afterEach(() => cleanup());
+
+describe("ToggleSwitch", () => {
+  it("renders with role=switch and the correct aria-checked", () => {
+    render(
+      <ToggleSwitch
+        checked
+        ariaLabel="Toggle thing"
+        onChange={() => {}}
+      />,
+    );
+    const sw = screen.getByRole("switch", { name: "Toggle thing" });
+    expect(sw.getAttribute("aria-checked")).toBe("true");
+  });
+
+  it("fires onChange with the inverted value on click", () => {
+    const onChange = vi.fn();
+    render(
+      <ToggleSwitch
+        checked={false}
+        ariaLabel="Toggle thing"
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole("switch"));
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  it("activates on Space and Enter", () => {
+    const onChange = vi.fn();
+    render(
+      <ToggleSwitch
+        checked
+        ariaLabel="Toggle thing"
+        onChange={onChange}
+      />,
+    );
+    const sw = screen.getByRole("switch");
+    fireEvent.keyDown(sw, { key: " " });
+    fireEvent.keyDown(sw, { key: "Enter" });
+    expect(onChange).toHaveBeenNthCalledWith(1, false);
+    expect(onChange).toHaveBeenNthCalledWith(2, false);
+  });
+
+  it("ignores activation while disabled", () => {
+    const onChange = vi.fn();
+    render(
+      <ToggleSwitch
+        checked={false}
+        disabled
+        ariaLabel="Toggle thing"
+        onChange={onChange}
+      />,
+    );
+    const sw = screen.getByRole("switch");
+    fireEvent.click(sw);
+    fireEvent.keyDown(sw, { key: " " });
+    expect(onChange).not.toHaveBeenCalled();
+    expect(sw.getAttribute("aria-disabled")).toBe("true");
+  });
+
+  it("stops click propagation so a parent row's click handler does not fire", () => {
+    const onChange = vi.fn();
+    const parentClick = vi.fn();
+    render(
+      <div onClick={parentClick}>
+        <ToggleSwitch
+          checked={false}
+          ariaLabel="Toggle thing"
+          onChange={onChange}
+        />
+      </div>,
+    );
+    fireEvent.click(screen.getByRole("switch"));
+    expect(onChange).toHaveBeenCalled();
+    expect(parentClick).not.toHaveBeenCalled();
+  });
+});

--- a/src/skills/default-layout/toggle-switch.tsx
+++ b/src/skills/default-layout/toggle-switch.tsx
@@ -66,8 +66,13 @@ export function ToggleSwitch({
       aria-checked={checked}
       aria-label={ariaLabel}
       aria-disabled={disabled || undefined}
+      // Pair `disabled` (native semantics for assistive tech +
+      // browser-level focus/click suppression) with `aria-disabled`
+      // (announces the state explicitly). Matches the
+      // `disabled` + `aria-disabled` pattern other primitives in
+      // this codebase use (e.g. context-menu items).
+      disabled={disabled}
       title={title}
-      tabIndex={disabled ? -1 : 0}
       className={classes}
       style={style}
       onClick={handleClick}

--- a/src/skills/default-layout/toggle-switch.tsx
+++ b/src/skills/default-layout/toggle-switch.tsx
@@ -1,0 +1,81 @@
+/**
+ * Pill-shaped toggle switch — used inline in the sidebar's extensions
+ * section and inside the settings-panel Extensions list. Accessible
+ * `role="switch"` semantics: Space / Enter activates, `aria-checked`
+ * mirrors the visual state, focus ring uses the accent.
+ *
+ * The component is controlled: `checked` drives the visual position
+ * and `onChange` fires the next-state value. Callers translate that
+ * into whatever event they need (e.g. `toggle-extension` with the
+ * `disabled` flag set to !next). When `disabled` is true the toggle
+ * renders muted and ignores activation — used for failed extensions
+ * where flipping the switch wouldn't accomplish anything.
+ */
+import type { CSSProperties, KeyboardEvent, MouseEvent } from "react";
+
+export interface ToggleSwitchProps {
+  checked: boolean;
+  onChange: (next: boolean) => void;
+  disabled?: boolean;
+  ariaLabel: string;
+  /** Optional title attribute (native tooltip). */
+  title?: string;
+  /** Optional class hook so callers can target the switch in their own
+   *  styling (e.g. additional spacing inside a row). */
+  className?: string;
+  style?: CSSProperties;
+}
+
+export function ToggleSwitch({
+  checked,
+  onChange,
+  disabled = false,
+  ariaLabel,
+  title,
+  className,
+  style,
+}: ToggleSwitchProps) {
+  const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
+    // The toggle frequently lives inside a clickable parent row (sidebar
+    // items emit "select" on click). Stop propagation so flipping the
+    // switch doesn't double-fire row-level selection.
+    e.stopPropagation();
+    if (disabled) return;
+    onChange(!checked);
+  };
+  const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
+    if (disabled) return;
+    if (e.key === " " || e.key === "Enter") {
+      e.preventDefault();
+      e.stopPropagation();
+      onChange(!checked);
+    }
+  };
+  const classes = [
+    "ae-toggle",
+    checked ? "ae-toggle-on" : "ae-toggle-off",
+    disabled ? "ae-toggle-disabled" : "",
+    className ?? "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={ariaLabel}
+      aria-disabled={disabled || undefined}
+      title={title}
+      tabIndex={disabled ? -1 : 0}
+      className={classes}
+      style={style}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+    >
+      <span className="ae-toggle-track" aria-hidden="true">
+        <span className="ae-toggle-thumb" />
+      </span>
+    </button>
+  );
+}

--- a/src/skills/default-layout/workstation.a2ui.json
+++ b/src/skills/default-layout/workstation.a2ui.json
@@ -88,12 +88,6 @@
                     "actions": [
                       { "id": "open-project", "label": "Open project…" }
                     ]
-                  },
-                  {
-                    "id": "extensions",
-                    "title": "extensions",
-                    "items": { "$ref": "/sidebar/extensions" },
-                    "hideWhenEmpty": true
                   }
                 ],
                 "extraSections": { "$ref": "/sidebar/extraSections" }

--- a/src/skills/default-layout/workstation.a2ui.json
+++ b/src/skills/default-layout/workstation.a2ui.json
@@ -219,6 +219,7 @@
     "draft": "",
     "waiting": false,
     "queueCount": 0,
+    "queuedMessages": [],
     "messages": [],
     "canvas": null,
     "empty": false,

--- a/src/state/sessionUiSnapshot.ts
+++ b/src/state/sessionUiSnapshot.ts
@@ -166,11 +166,14 @@ export function parseSessionUiSnapshot(raw: string): SessionUiSnapshot | null {
         kind: t.kind ?? "agent",
         draft: t.draft ?? "",
         waiting: Boolean(t.waiting),
-        queueCount: typeof t.queueCount === "number" ? t.queueCount : 0,
         // Client-held queue is intentionally NOT restored: queued
         // messages are ephemeral, and a user who closed the app while
         // queue items were pending probably abandoned them. The next
-        // run starts with a clean queue.
+        // run starts with a clean queue. `queueCount` is derived from
+        // `queuedMessages.length`, so zero it in lockstep — otherwise
+        // the composer badge / "Stop + clear" label would read as
+        // non-empty against an empty popover.
+        queueCount: 0,
         queuedMessages: [],
         canvas: t.canvas ?? null,
         model: t.model ?? "",

--- a/src/state/sessionUiSnapshot.ts
+++ b/src/state/sessionUiSnapshot.ts
@@ -167,6 +167,11 @@ export function parseSessionUiSnapshot(raw: string): SessionUiSnapshot | null {
         draft: t.draft ?? "",
         waiting: Boolean(t.waiting),
         queueCount: typeof t.queueCount === "number" ? t.queueCount : 0,
+        // Client-held queue is intentionally NOT restored: queued
+        // messages are ephemeral, and a user who closed the app while
+        // queue items were pending probably abandoned them. The next
+        // run starts with a clean queue.
+        queuedMessages: [],
         canvas: t.canvas ?? null,
         model: t.model ?? "",
         terminalBuffer: t.terminalBuffer ?? "",

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -2722,6 +2722,197 @@ body.ae-resizing-composer * {
   pointer-events: none;
 }
 
+/* ---- Queued messages popover -------------------------------------------- */
+
+/* Lives inside .a2ui-chat-input, between the resize handle and the textarea.
+   Hides itself when the queue is empty (the composite returns null), so the
+   composer stays flush in the normal case. The whole popover is "inside"
+   the composer surface rather than a portal — anchoring follows the input
+   automatically when the user resizes the bottom panel. */
+.a2ui-queued-popover {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 0 0 8px;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg);
+  box-shadow:
+    0 2px 4px rgba(0, 0, 0, 0.08),
+    0 6px 16px rgba(0, 0, 0, 0.12);
+  max-height: 220px;
+  overflow: hidden;
+}
+
+.a2ui-queued-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 0 2px 2px;
+}
+
+.a2ui-queued-label {
+  font-family: var(--font-mono);
+  font-size: var(--chrome-text-muted);
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+
+.a2ui-queued-clear {
+  background: transparent;
+  border: none;
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  font-size: var(--chrome-text-muted);
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+.a2ui-queued-clear:hover {
+  color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.a2ui-queued-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  overflow-y: auto;
+  max-height: 180px;
+}
+
+.a2ui-queued-message {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 30px;
+  padding: 4px 6px;
+  border-radius: 4px;
+  font-size: var(--chrome-text-compact);
+}
+.a2ui-queued-message:hover {
+  background: var(--accent-soft);
+}
+
+.a2ui-queued-icon {
+  color: var(--text-dim);
+  flex: 0 0 auto;
+  display: inline-flex;
+}
+
+.a2ui-queued-content {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text);
+}
+
+.a2ui-queued-actions {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.a2ui-queued-action {
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--text-dim);
+  padding: 4px 6px;
+  border-radius: 4px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-family: var(--font-mono);
+  font-size: var(--chrome-text-compact);
+  line-height: 1;
+}
+.a2ui-queued-action:hover:not(:disabled) {
+  color: var(--text);
+  background: var(--accent-soft);
+}
+.a2ui-queued-action:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.a2ui-queued-steer {
+  color: var(--accent);
+}
+.a2ui-queued-steer:hover:not(:disabled) {
+  color: var(--accent);
+  background: var(--accent-soft);
+}
+.a2ui-queued-steer-label {
+  letter-spacing: 0.06em;
+  font-weight: 600;
+}
+
+.a2ui-queued-spinner {
+  animation: a2ui-queued-spin 0.8s linear infinite;
+}
+
+@keyframes a2ui-queued-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.a2ui-queued-message-editing {
+  background: var(--accent-soft);
+}
+
+.a2ui-queued-edit-form {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  width: 100%;
+}
+
+.a2ui-queued-edit-textarea {
+  width: 100%;
+  min-height: 54px;
+  max-height: 120px;
+  padding: 6px 8px;
+  background: var(--bg-elev);
+  color: var(--text);
+  border: 1px solid var(--accent);
+  border-radius: 4px;
+  font-family: inherit;
+  font-size: inherit;
+  resize: vertical;
+  outline: none;
+}
+
+.a2ui-queued-edit-buttons {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+.a2ui-queued-edit-save {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+.a2ui-queued-edit-save:hover:not(:disabled) {
+  background: var(--accent);
+  color: var(--bg);
+}
+
 /* ---- Status bar --------------------------------------------------------- */
 
 .a2ui-status-bar {

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -2913,6 +2913,76 @@ body.ae-resizing-composer * {
   color: var(--bg);
 }
 
+/* ---- Toggle switch (extensions inline, settings panel) ------------------ */
+
+/* Compact pill switch — amber track when on (matches the accent), the
+   thumb slides between left and right. Inline-friendly: flex: 0 0 auto
+   so it sits beside text without competing for row height. */
+.ae-toggle {
+  appearance: none;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+  outline: none;
+  /* Click target slightly larger than the visual track. */
+  padding: 2px;
+  border-radius: 999px;
+}
+.ae-toggle:focus-visible {
+  box-shadow: 0 0 0 2px var(--accent-soft, rgba(255, 184, 76, 0.32));
+}
+
+.ae-toggle-track {
+  position: relative;
+  display: inline-block;
+  width: 28px;
+  height: 16px;
+  border-radius: 999px;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  transition:
+    background-color 120ms var(--ease-out, ease),
+    border-color 120ms var(--ease-out, ease);
+}
+
+.ae-toggle-thumb {
+  position: absolute;
+  top: 1px;
+  left: 1px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--text-dim);
+  transition:
+    transform 140ms var(--ease-out, ease),
+    background-color 120ms var(--ease-out, ease);
+}
+
+.ae-toggle-on .ae-toggle-track {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+.ae-toggle-on .ae-toggle-thumb {
+  /* Travel = track width (28) - thumb width (12) - left inset (1) - right inset (1) - border (1+1) */
+  transform: translateX(12px);
+  background: var(--bg);
+}
+
+.ae-toggle-disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+.ae-toggle-disabled .ae-toggle-track {
+  background: var(--bg-elev);
+}
+
+.ae-toggle:not(.ae-toggle-disabled):hover .ae-toggle-track {
+  border-color: var(--accent);
+}
+
 /* ---- Status bar --------------------------------------------------------- */
 
 .a2ui-status-bar {

--- a/src/types/tab.ts
+++ b/src/types/tab.ts
@@ -70,7 +70,12 @@ export interface Tab {
   /** Derived: equals `queuedMessages.length`. Kept as a separate field so
    *  the existing `/queueCount` binding (badge in the composer) doesn't
    *  have to re-resolve through the array on every render. Writers must
-   *  set both in lockstep. */
+   *  set both in lockstep — `useChat`'s `withQueue()` helper is the
+   *  canonical writer and guarantees the invariant. Bridge handlers
+   *  for `queued` / `queue_reset` events are intentionally no-ops on
+   *  the new client-held queue path; mutating queueCount without
+   *  touching queuedMessages would desync the composer badge and
+   *  popover row count. */
   queueCount: number;
   /** Client-held queue of unsent user messages. Drained by
    *  `useQueuedDispatch` when the agent goes idle. Rendered as a popover

--- a/src/types/tab.ts
+++ b/src/types/tab.ts
@@ -46,6 +46,18 @@ export interface EditorMeta {
 
 export type TabKind = "agent" | "shell" | "editor";
 
+/**
+ * A user message held on the client-side queue while a turn is in flight.
+ * The popover above the composer renders the list, and the user can edit /
+ * delete / promote-to-steer each entry before `useQueuedDispatch` drains the
+ * head on the next idle. The message only enters chat history once it is
+ * actually dispatched — Claudette-style.
+ */
+export interface QueuedMessage {
+  id: string;
+  content: string;
+}
+
 export interface Tab {
   id: string;
   /** "agent" (chat session) or "shell" (interactive PTY). Default "agent"
@@ -55,7 +67,19 @@ export interface Tab {
   messages: ChatMessage[];
   draft: string;
   waiting: boolean;
+  /** Derived: equals `queuedMessages.length`. Kept as a separate field so
+   *  the existing `/queueCount` binding (badge in the composer) doesn't
+   *  have to re-resolve through the array on every render. Writers must
+   *  set both in lockstep. */
   queueCount: number;
+  /** Client-held queue of unsent user messages. Drained by
+   *  `useQueuedDispatch` when the agent goes idle. Rendered as a popover
+   *  above the composer. Only agent tabs ever populate this. */
+  queuedMessages: QueuedMessage[];
+  /** Id of the queued message currently being promoted via steer. Drives
+   *  the per-row spinner so the user knows the click landed before pi
+   *  acknowledges. Cleared by the dispatch path on success or error. */
+  queuedSteeringId?: string;
   canvas: unknown;
   model: string;
   // Rolling buffer of bash output for this tab. The Terminal component
@@ -123,6 +147,7 @@ export function makeEmptyTab(
     draft: "",
     waiting: false,
     queueCount: 0,
+    queuedMessages: [],
     canvas: null,
     model: "",
     terminalBuffer: "",


### PR DESCRIPTION
## Summary

Two new chrome surfaces and a release bump, plus a clutch of peer-reviewed fixes along the way.

### 1. Queued messages popover + steering (Claudette-style)

- Messages typed while the agent is busy now hold in a **client-side queue** (`tab.queuedMessages: QueuedMessage[]`) instead of going straight to pi's `followUp`. A popover above the composer renders the list with per-row **Edit / Steer / Delete** affordances and a header **Clear queue** action.
- A new `useQueuedDispatch` hook drains the head on every idle transition. `Cmd/Ctrl+Enter` still ships the current draft as a mid-turn steer; per-row Steer pops a specific queued message and promotes it.
- Inline edit: textarea, Enter saves, Esc cancels, an empty save deletes the row. Mid-flight steer shows a spinner per row.
- `responseEnd` no longer preserves `waiting` on `queueCount > 0` — that branch was specific to pi's followUp model and would have prevented the dispatch hook from seeing the idle moment.

### 2. Inline extension toggle (pill switch)

- New reusable `ToggleSwitch` composite — amber track / dark thumb / `role=\"switch\"` semantics / Space + Enter activation / disabled state for failed extensions / click propagation suppressed so toggling doesn't bubble into the row's `select`.
- Mounted on every row in the sidebar's extensions section and inside the settings panel's Extensions list. Replaces the old Enable/Disable text button.

### 3. Extension origin grouping (two buckets)

- Sidebar splits the auto-injected extensions section into **`project extensions`** and **`user extensions`** sub-sections. Empty buckets hide; the qualified group title is always shown (no bare-`extensions` collapse) so scope is never ambiguous.
- New `classifyExtensionSource(source, { name, activeBasename, knownProjectBasenames })` folds `@<project>/<ext>` npm packages into the project bucket when the scope matches the active project's basename. Unrelated scopes / plain `package-name` / `~/.aethon/extensions/` entries stay user.
- Disabled rows preserve their inferred origin (`project · disabled`, `user · disabled`) even when toggled off, including mid-session toggles where the disabled record lacks source metadata.
- Removed the explicit `extensions` section from `workstation.a2ui.json`; the sidebar component's auto-injection owns rendering for the default layout (skills with explicit sections still take precedence).

### 4. Peer-review fixes from two Codex passes

Round one:
- **P1** — `useQueuedDispatch` optimistic `waiting=true` write was synchronously visible to `sendChat`, which re-queued the popped message instead of invoking the bridge. Drain now pops the head only; `sendChat`'s normal path flips `waiting`.
- **P2** — `stopPrompt` now empties `tab.queuedMessages` so the composer's \"Stop + clear\" button actually clears the queue.

Round two:
- **P2** — `activateWorktree` mirrors `setActiveProjectById`'s watcher swap when the selected worktree belongs to a different project, restoring extension hot-reload across cross-project worktree activation.
- **P2** — `handleSessionHistory` appends pending local messages AFTER the restored transcript (was prepending) and preserves in-flight assistant streaming deltas (was filtering them out). Failed local user messages are still dropped on restore.

### 5. Release

- Patch bump to **0.3.3**. `bun run version:sync` propagated through `package-lock.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`.

## Test plan

- [ ] **Queue + steering** — Type three messages while the agent is busy; observe popover above composer with all three. Edit one (Enter saves, Esc cancels). Click Steer on another (spinner, then user bubble with `steered` delivery in transcript). Delete the remaining. Verify auto-drain when agent goes idle.
- [ ] **Cmd/Ctrl+Enter** — Compose new text while busy, press Cmd+Enter; observe `steered` delivery on the user bubble.
- [ ] **Stop clears queue** — Queue 3 messages, press Stop; verify popover empties and no further drains fire on idle.
- [ ] **Inline extension toggle (sidebar)** — Toggle an extension in the sidebar; observe the same effect as right-click → Disable/Enable. Confirm focus ring + Space/Enter activation.
- [ ] **Inline extension toggle (settings panel)** — Same toggle behaviour in Settings → Extensions.
- [ ] **Origin grouping** — In a project with both `@<project>/...` npm packages and unrelated-scope packages, verify the sidebar shows `project extensions` above `user extensions`. Confirm bare `package-name` lands under user.
- [ ] **Single-bucket projects** — In a project with only user-level extensions, header still reads `user extensions` (no collapse).
- [ ] **Cross-project worktree activation** — From project A, activate a worktree under project B; edit a file in project B's `.aethon/extensions/` and confirm it hot-reloads.
- [ ] **Restored session ordering** — Open Aethon with a tab whose session has unflushed history; send a new prompt before the restore lands. Confirm the restored transcript appears first, followed by the new prompt (chronological), and any streaming response continues uninterrupted.
- [ ] **Full automated suite** — `bun test` (1053/1053 currently green) + `bunx tsc --noEmit` + `bunx eslint .`.

Commits on this branch:

```
c662804 fix(projects,sessions): peer-review P2 follow-ups
4b341d0 chore(release): 0.3.3
a8ced36 fix(extensions): two-bucket scope + visible per-origin headers
347f018 feat(extensions): split sidebar list into per-origin sub-sections
5d2c9e9 fix(chat): drain regression + stop-clears-queue; group extensions by origin
1a5099d feat(extensions): inline toggle switch for sidebar rows + settings panel
f0bcb92 feat(chat): client-held queue + per-message steering popover
b9476d1 fix(sessions): restore tool cards from history
340b340 fix(dev): tear down dev process tree on interrupt
ede6788 fix(worktrees): close sessions when removing worktrees
f8147d6 fix(worktrees): scope agent sessions to worktrees
```