### PR TITLE
fix: keep session rename focused while agent runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ All notable changes to Aethon. Format loosely follows
   Restored transcript now lands first, with pending local messages —
   user prompts AND streaming assistant bubbles — appended after, so
   ordering stays chronological and live output isn't wiped mid-stream.
+- **Session tab rename focus.** Tab context-menu rename inputs now keep focus
+  while an agent is running and streaming state updates, so session names can
+  be edited without interruption.
 
 ## [0.3.3] - 2026-05-25
 

--- a/src/components/primitives/context-menu.test.tsx
+++ b/src/components/primitives/context-menu.test.tsx
@@ -1,6 +1,13 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { ContextMenu, type ContextMenuItem } from "./context-menu";
 
 afterEach(() => {
@@ -231,5 +238,88 @@ describe("ContextMenu", () => {
     );
     // Header + note render as non-buttons; only one menuitem present.
     expect(screen.getAllByRole("menuitem")).toHaveLength(1);
+  });
+
+  it("keeps focus in an inline input when parent state re-renders", async () => {
+    const buildItems = (): ContextMenuItem[] => [
+      {
+        type: "input",
+        id: "rename-session",
+        label: "Session name",
+        defaultValue: "Tab 1",
+        onSubmit: () => {},
+      },
+      { type: "separator" },
+      { id: "close-tab", label: "Close tab", onSelect: () => {} },
+    ];
+    const { rerender } = render(
+      <ContextMenu
+        open
+        x={100}
+        y={100}
+        items={buildItems()}
+        onClose={() => {}}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(
+        screen.getByLabelText("Session name"),
+      );
+    });
+
+    fireEvent.change(screen.getByLabelText("Session name"), {
+      target: { value: "Planning" },
+    });
+    rerender(
+      <ContextMenu
+        open
+        x={100}
+        y={100}
+        items={buildItems()}
+        onClose={() => {}}
+      />,
+    );
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 0));
+    });
+
+    const input = screen.getByLabelText("Session name");
+    expect(document.activeElement).toBe(input);
+    expect(input).toHaveProperty("value", "Planning");
+  });
+
+  it("lets Enter submit inline input forms instead of activating a menu item", async () => {
+    const onSubmit = vi.fn();
+    const onClose = vi.fn();
+    const onSelect = vi.fn();
+    render(
+      <ContextMenu
+        open
+        x={100}
+        y={100}
+        items={[
+          {
+            type: "input",
+            id: "rename-session",
+            label: "Session name",
+            defaultValue: "Tab 1",
+            onSubmit,
+          },
+          { id: "close-tab", label: "Close tab", onSelect },
+        ]}
+        onClose={onClose}
+      />,
+    );
+
+    const input = screen.getByLabelText("Session name");
+    await waitFor(() => expect(document.activeElement).toBe(input));
+    fireEvent.change(input, { target: { value: "Planning" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    fireEvent.submit(input.closest("form")!);
+
+    expect(onSubmit).toHaveBeenCalledWith("Planning");
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/primitives/context-menu.test.tsx
+++ b/src/components/primitives/context-menu.test.tsx
@@ -322,4 +322,41 @@ describe("ContextMenu", () => {
     expect(onSelect).not.toHaveBeenCalled();
     expect(onClose).toHaveBeenCalledTimes(1);
   });
+
+  it("clamps virtual focus when items change while the menu remains open", () => {
+    const onAlpha = vi.fn();
+    const onBeta = vi.fn();
+    const onClose = vi.fn();
+    const { rerender } = render(
+      <ContextMenu
+        open
+        x={100}
+        y={100}
+        items={[
+          { id: "alpha", label: "Alpha", onSelect: onAlpha },
+          { id: "beta", label: "Beta", onSelect: onBeta },
+        ]}
+        onClose={onClose}
+      />,
+    );
+
+    const menu = screen.getByRole("menu");
+    fireEvent.keyDown(menu, { key: "ArrowDown" });
+    expect(menu.getAttribute("aria-activedescendant")).toMatch(/i1$/);
+
+    rerender(
+      <ContextMenu
+        open
+        x={100}
+        y={100}
+        items={[{ id: "alpha", label: "Alpha", onSelect: onAlpha }]}
+        onClose={onClose}
+      />,
+    );
+
+    expect(menu.getAttribute("aria-activedescendant")).toMatch(/i0$/);
+    fireEvent.keyDown(menu, { key: "Enter" });
+    expect(onAlpha).toHaveBeenCalledTimes(1);
+    expect(onBeta).not.toHaveBeenCalled();
+  });
 });

--- a/src/components/primitives/context-menu.tsx
+++ b/src/components/primitives/context-menu.tsx
@@ -69,6 +69,18 @@ function isOption(item: ContextMenuItem): item is ContextMenuOption {
   return !("type" in item);
 }
 
+function isInputItem(item: ContextMenuItem): item is ContextMenuInput {
+  return "type" in item && item.type === "input";
+}
+
+function isTextEntryTarget(target: EventTarget | null): boolean {
+  return (
+    target instanceof HTMLInputElement ||
+    target instanceof HTMLTextAreaElement ||
+    target instanceof HTMLSelectElement
+  );
+}
+
 export function ContextMenu({
   open,
   x,
@@ -83,6 +95,7 @@ export function ContextMenu({
   const menuId = useId();
   const menuRef = useRef<HTMLDivElement | null>(null);
   const opener = useRef<Element | null>(null);
+  const wasOpenRef = useRef(false);
   const [focusedIndex, setFocusedIndex] = useState<number | null>(null);
 
   // Indices in `items` that map to focusable buttons (skips separator /
@@ -95,31 +108,41 @@ export function ContextMenu({
     }
     return out;
   }, [items]);
+  const firstFocusableIndex = focusableIndices[0] ?? null;
+  const hasInputItem = useMemo(() => items.some(isInputItem), [items]);
 
   // Capture the originating focus owner + seed the focused item when the
   // menu opens. setState-in-effect is the right shape here: open is a
   // boolean prop coming from the caller and we want to mirror it onto
   // the internal focus state machine, not derive it on every render.
   //
-  // Also move keyboard focus into the menu element itself so the
-  // `onKeyDown={onMenuKey}` on the root receives ArrowUp/ArrowDown/Enter.
-  // Without this, focus stayed on the originating row, the document-level
-  // keyboard listener only caught Esc/Tab, and arrow navigation never
-  // reached the menu — the "advertised keyboard navigation" stayed dead.
+  // Also move keyboard focus into the menu (or its inline input) so
+  // keyboard interactions do not stay on the originating row. Without
+  // this, the document-level keyboard listener only caught Esc/Tab, and
+  // arrow navigation never reached option-only menus — the "advertised
+  // keyboard navigation" stayed dead.
+  //
+  // Run only on closed -> open transitions. Parent chrome (notably the
+  // tab strip while an agent is streaming) can re-render the menu many
+  // times with fresh `items` arrays; re-focusing on every such render
+  // steals focus back from inline rename inputs and makes typing unusable.
   useEffect(() => {
-    if (open) {
-      opener.current = document.activeElement;
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- seed focus on open
-      setFocusedIndex(focusableIndices[0] ?? null);
-      // Defer to the next tick so the menu element is in the DOM.
-      const t = window.setTimeout(() => {
-        menuRef.current?.focus({ preventScroll: true });
-      }, 0);
-      return () => window.clearTimeout(t);
-    } else {
+    if (!open) {
+      wasOpenRef.current = false;
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- clear mirrored focus state on close
       setFocusedIndex(null);
+      return;
     }
-  }, [open, focusableIndices]);
+    if (wasOpenRef.current) return;
+
+    wasOpenRef.current = true;
+    opener.current = document.activeElement;
+    setFocusedIndex(firstFocusableIndex);
+    const firstInput = hasInputItem
+      ? menuRef.current?.querySelector<HTMLElement>("input, textarea, select")
+      : null;
+    (firstInput ?? menuRef.current)?.focus({ preventScroll: true });
+  }, [open, firstFocusableIndex, hasInputItem]);
 
   // Outside click + Esc/Tab dismiss. Listeners only mount while open.
   useEffect(() => {
@@ -191,6 +214,7 @@ export function ContextMenu({
 
   const onMenuKey = useCallback(
     (e: React.KeyboardEvent) => {
+      if (isTextEntryTarget(e.target)) return;
       if (e.key === "ArrowDown") {
         e.preventDefault();
         moveFocus(1);

--- a/src/components/primitives/context-menu.tsx
+++ b/src/components/primitives/context-menu.tsx
@@ -144,6 +144,15 @@ export function ContextMenu({
     (firstInput ?? menuRef.current)?.focus({ preventScroll: true });
   }, [open, firstFocusableIndex, hasInputItem]);
 
+  useEffect(() => {
+    if (!open) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- clamp virtual focus after item list changes without moving DOM focus
+    setFocusedIndex((current) => {
+      if (current === null || focusableIndices.includes(current)) return current;
+      return firstFocusableIndex;
+    });
+  }, [open, focusableIndices, firstFocusableIndex]);
+
   // Outside click + Esc/Tab dismiss. Listeners only mount while open.
   useEffect(() => {
     if (!open) return;
@@ -231,7 +240,7 @@ export function ContextMenu({
         e.preventDefault();
         if (focusedIndex !== null) {
           const it = items[focusedIndex];
-          if (isOption(it) && !it.disabled) {
+          if (it && isOption(it) && !it.disabled) {
             it.onSelect();
             if (!it.keepOpenOnSelect) onClose();
           }

--- a/src/skills/default-layout/shell/tab-strip.test.tsx
+++ b/src/skills/default-layout/shell/tab-strip.test.tsx
@@ -53,6 +53,46 @@ describe("TabStrip", () => {
     });
   });
 
+  it("keeps rename input focused while active agent state re-renders", () => {
+    const onEvent = vi.fn<TabStripOnEvent>();
+    const { rerender } = render(
+      <TabStrip
+        component={tabStripComponent()}
+        state={{
+          activeTabId: "tab-1",
+          tabs: [{ id: "tab-1", label: "Tab 1", kind: "agent", waiting: true }],
+        }}
+        onEvent={onEvent}
+      />,
+    );
+    fireEvent.contextMenu(screen.getByText("Tab 1").closest('[role="tab"]')!);
+    const input = screen.getByLabelText("Session name");
+    input.focus();
+    fireEvent.change(input, { target: { value: "Planning" } });
+
+    rerender(
+      <TabStrip
+        component={tabStripComponent()}
+        state={{
+          activeTabId: "tab-1",
+          tabs: [
+            {
+              id: "tab-1",
+              label: "Tab 1",
+              kind: "agent",
+              waiting: true,
+              queueCount: 1,
+            },
+          ],
+        }}
+        onEvent={onEvent}
+      />,
+    );
+
+    expect(document.activeElement).toBe(input);
+    expect(input).toHaveProperty("value", "Planning");
+  });
+
   it("does not select the tab on right-button mouse down", () => {
     const { onEvent } = renderTabStrip();
     fireEvent.mouseDown(screen.getByText("Tab 1").closest('[role="tab"]')!, {


### PR DESCRIPTION
## Summary

Fixes #85.

When the tab strip re-rendered during an in-flight agent turn, the shared `ContextMenu` focus effect ran again because the caller recreated the `items` array. That effect re-focused the menu root, stealing focus from the tab rename input and making the rename flow unusable while the agent was streaming updates.

This PR updates the context menu focus behavior to:

- Seed focus only on closed → open transitions instead of every render.
- Prefer focusing the inline input when a context menu contains an input item.
- Leave keyboard-menu handling alone while focus is inside a text-entry control, so Enter/arrow keys are handled by the input/form rather than accidentally activating menu items.
- Clamp virtual menu focus when the item list changes while open, without moving DOM focus, so stale `focusedIndex` values cannot produce invalid `aria-activedescendant` values or stale item activation.

## Test coverage

Added regression coverage for both levels involved in the bug:

- `ContextMenu` preserves inline input focus and typed value across parent rerenders with fresh item arrays.
- `ContextMenu` lets Enter submit inline input forms instead of triggering focused menu options.
- `ContextMenu` clamps virtual focus safely when menu items are removed while open.
- `TabStrip` keeps the session rename input focused across active-agent state rerenders (`waiting` / `queueCount` changes), matching the reported running-agent scenario.

## Validation

All validation was run through the Nix devshell:

- `nix develop -c bunx eslint src/components/primitives/context-menu.tsx src/components/primitives/context-menu.test.tsx src/skills/default-layout/shell/tab-strip.test.tsx`
- `nix develop -c bunx vitest run src/components/primitives/context-menu.test.tsx src/skills/default-layout/shell/tab-strip.test.tsx` — 20 tests passed
- `nix develop -c bunx tsc -b --noEmit`
- `nix develop -c bunx vitest run` — 140 files / 1057 tests passed
- `nix develop -c git diff --check`

Note: `nix develop -c bunx eslint .` currently reports 5 warnings in unrelated existing files (`project-dashboard.tsx`, `task-launcher.tsx`, `image-viewer.tsx`, `markdown-preview.tsx`, `layout.tsx`). The files touched by this PR lint clean.

## Copilot review

Addressed the valid Copilot finding about stale virtual focus after item-list updates, replied on the thread with the fix details, and resolved the conversation.
