### PR TITLE
feat(file-tree): show Git status decorations

### DIFF
--- a/src-tauri/src/commands/git.rs
+++ b/src-tauri/src/commands/git.rs
@@ -6,7 +6,7 @@
 //! too hairy to recreate. `pick_project_directory` wraps the dialog
 //! plugin so the JS side doesn't pull in a direct dialog dependency.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use tauri::AppHandle;
 
@@ -32,6 +32,17 @@ pub struct GitStatus {
     dirty: bool,
     ahead: u32,
     behind: u32,
+}
+
+/// One per-file worktree change as reported by `git status --porcelain`.
+/// Paths are normalized to be relative to the active project/worktree root
+/// passed by the frontend (not necessarily the repository top-level).
+#[derive(serde::Serialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct GitFileStatusEntry {
+    pub path: String,
+    pub status: &'static str,
+    pub original_path: Option<String>,
 }
 
 #[tauri::command]
@@ -124,6 +135,157 @@ pub async fn git_status(path: String) -> Result<Option<GitStatus>, String> {
         ahead,
         behind,
     }))
+}
+
+/// Return per-file Git decorations for the active file tree root. `None`
+/// means the directory is not inside a Git worktree; callers should render
+/// the plain filesystem tree in that case.
+#[tauri::command]
+pub async fn git_file_status(root: String) -> Result<Option<Vec<GitFileStatusEntry>>, String> {
+    let dir = PathBuf::from(&root);
+    if !dir.is_dir() {
+        return Ok(None);
+    }
+
+    let inside = env::command("git")
+        .arg("-C")
+        .arg(&dir)
+        .args(["rev-parse", "--is-inside-work-tree"])
+        .output();
+    let inside_ok = match inside {
+        Ok(o) => o.status.success() && String::from_utf8_lossy(&o.stdout).trim() == "true",
+        Err(_) => false,
+    };
+    if !inside_ok {
+        return Ok(None);
+    }
+
+    let top_level = env::command("git")
+        .arg("-C")
+        .arg(&dir)
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .map_err(|e| format!("git rev-parse --show-toplevel: {e}"))?;
+    if !top_level.status.success() {
+        return Ok(None);
+    }
+    let repo_root_raw = PathBuf::from(
+        String::from_utf8_lossy(&top_level.stdout)
+            .trim()
+            .to_string(),
+    );
+    let repo_root = repo_root_raw.canonicalize().unwrap_or(repo_root_raw);
+    let active_root = dir
+        .canonicalize()
+        .map_err(|e| format!("root canonicalize {}: {e}", dir.display()))?;
+
+    // `--porcelain=v1 -z` gives a stable, NUL-delimited format whose paths
+    // are not quoted, so spaces and unusual characters do not need a fragile
+    // line parser. `-- .` scopes the result to the active root when the user
+    // opened a repository subdirectory as the project.
+    let porcelain = env::command("git")
+        .arg("-C")
+        .arg(&active_root)
+        .args([
+            "status",
+            "--porcelain=v1",
+            "-z",
+            "--untracked-files=all",
+            "--renames",
+            "--",
+            ".",
+        ])
+        .output()
+        .map_err(|e| format!("git status: {e}"))?;
+    if !porcelain.status.success() {
+        return Ok(Some(Vec::new()));
+    }
+
+    let entries = parse_git_file_status_porcelain_z(&porcelain.stdout)
+        .into_iter()
+        .filter_map(|mut entry| {
+            entry.path = path_relative_to_active_root(&repo_root, &active_root, &entry.path)?;
+            entry.original_path = entry
+                .original_path
+                .as_deref()
+                .and_then(|p| path_relative_to_active_root(&repo_root, &active_root, p));
+            Some(entry)
+        })
+        .collect();
+    Ok(Some(entries))
+}
+
+fn path_relative_to_active_root(
+    repo_root: &Path,
+    active_root: &Path,
+    git_path: &str,
+) -> Option<String> {
+    let abs = repo_root.join(git_path);
+    let rel = abs.strip_prefix(active_root).ok()?;
+    let s = rel.to_string_lossy().replace('\\', "/");
+    if s.is_empty() { None } else { Some(s) }
+}
+
+fn classify_git_status(x: u8, y: u8) -> Option<&'static str> {
+    if x == b'!' && y == b'!' {
+        return None;
+    }
+    if x == b'?' && y == b'?' {
+        return Some("untracked");
+    }
+    if x == b'U' || y == b'U' || (x == b'A' && y == b'A') || (x == b'D' && y == b'D') {
+        return Some("conflicted");
+    }
+    if x == b'R' || y == b'R' {
+        return Some("renamed");
+    }
+    if x == b'C' || y == b'C' {
+        return Some("copied");
+    }
+    if x == b'D' || y == b'D' {
+        return Some("deleted");
+    }
+    if x == b'A' || y == b'A' {
+        return Some("added");
+    }
+    if x == b'M' || y == b'M' || x == b'T' || y == b'T' {
+        return Some("modified");
+    }
+    if x != b' ' || y != b' ' {
+        return Some("modified");
+    }
+    None
+}
+
+fn parse_git_file_status_porcelain_z(bytes: &[u8]) -> Vec<GitFileStatusEntry> {
+    let mut out = Vec::new();
+    let mut parts = bytes.split(|b| *b == 0).filter(|part| !part.is_empty());
+    while let Some(record) = parts.next() {
+        if record.len() < 4 {
+            continue;
+        }
+        let x = record[0];
+        let y = record[1];
+        let Some(status) = classify_git_status(x, y) else {
+            continue;
+        };
+        // Shape is `XY path`. In `-z` mode, rename/copy records are followed
+        // by a second NUL-delimited path containing the original location.
+        let path = String::from_utf8_lossy(&record[3..]).to_string();
+        let original_path = if x == b'R' || y == b'R' || x == b'C' || y == b'C' {
+            parts
+                .next()
+                .map(|original| String::from_utf8_lossy(original).to_string())
+        } else {
+            None
+        };
+        out.push(GitFileStatusEntry {
+            path,
+            status,
+            original_path,
+        });
+    }
+    out
 }
 
 /// One worktree row as reported by `git worktree list --porcelain`.
@@ -1039,6 +1201,40 @@ mod tests {
         assert_eq!(json["isMain"], serde_json::json!(true));
         assert_eq!(json["path"], serde_json::json!("/x"));
         assert_eq!(json["branch"], serde_json::json!("main"));
+    }
+
+    #[test]
+    fn parses_git_file_status_porcelain_entries() {
+        let text = b" M src/app.ts\0?? src/new file.ts\0A  src/added.ts\0 D src/missing.ts\0";
+        let out = parse_git_file_status_porcelain_z(text);
+        assert_eq!(out.len(), 4);
+        assert_eq!(out[0].path, "src/app.ts");
+        assert_eq!(out[0].status, "modified");
+        assert_eq!(out[1].path, "src/new file.ts");
+        assert_eq!(out[1].status, "untracked");
+        assert_eq!(out[2].status, "added");
+        assert_eq!(out[3].status, "deleted");
+    }
+
+    #[test]
+    fn parses_git_file_status_rename_porcelain_entry() {
+        let text = b"R  src/new.ts\0src/old.ts\0";
+        let out = parse_git_file_status_porcelain_z(text);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].path, "src/new.ts");
+        assert_eq!(out[0].status, "renamed");
+        assert_eq!(out[0].original_path.as_deref(), Some("src/old.ts"));
+    }
+
+    #[test]
+    fn git_file_status_paths_are_relative_to_active_root() {
+        let repo = PathBuf::from("/repo");
+        let active = PathBuf::from("/repo/packages/app");
+        assert_eq!(
+            path_relative_to_active_root(&repo, &active, "packages/app/src/main.ts").as_deref(),
+            Some("src/main.ts")
+        );
+        assert!(path_relative_to_active_root(&repo, &active, "other/file.ts").is_none());
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -888,6 +888,7 @@ pub fn run() {
             commands::fs::fs_open_in_file_manager,
             commands::fs::fs_open_in_default_app,
             commands::git::git_status,
+            commands::git::git_file_status,
             commands::git::git_worktrees,
             commands::git::git_worktree_add,
             commands::git::git_worktree_remove,

--- a/src/skills/default-layout/sidebar/file-tree.test.tsx
+++ b/src/skills/default-layout/sidebar/file-tree.test.tsx
@@ -178,6 +178,37 @@ describe("FileTreePanel", () => {
     expect(screen.getByLabelText("Deleted")).toBeTruthy();
   });
 
+  it("uses the project path separator for synthetic deleted rows", async () => {
+    invokeMock.mockImplementation((cmd: string, args?: { path?: string }) => {
+      if (cmd === "fs_list_dir" && args?.path === "C:\\repo") {
+        return Promise.resolve([
+          { name: "src", path: "C:\\repo\\src", kind: "dir" },
+        ]);
+      }
+      if (cmd === "fs_list_dir" && args?.path === "C:\\repo\\src") {
+        return Promise.resolve([]);
+      }
+      if (cmd === "git_file_status") {
+        return Promise.resolve([{ path: "src/old.ts", status: "deleted" }]);
+      }
+      return Promise.resolve(1);
+    });
+
+    render(
+      <FileTreePanel
+        {...panelProps({
+          state: { project: { path: "C:\\repo", name: "repo" } },
+        })}
+      />,
+    );
+    await waitFor(() => screen.getByText("src"));
+    fireEvent.click(screen.getByText("src"));
+    const deleted = await waitFor(() => screen.getByText("old.ts"));
+    expect(deleted.closest("li")?.getAttribute("title")).toContain(
+      "C:\\repo\\src\\old.ts",
+    );
+  });
+
   it("renders clean Git file trees without decorations", async () => {
     invokeMock.mockImplementation((cmd: string) => {
       if (cmd === "fs_list_dir") {

--- a/src/skills/default-layout/sidebar/file-tree.test.tsx
+++ b/src/skills/default-layout/sidebar/file-tree.test.tsx
@@ -98,6 +98,128 @@ describe("FileTreePanel", () => {
     });
   });
 
+  it("renders Git status decorations for changed files and folders", async () => {
+    invokeMock.mockImplementation((cmd: string, args?: { path?: string }) => {
+      if (cmd === "fs_list_dir" && args?.path === "/projects/aethon") {
+        return Promise.resolve([
+          { name: "src", path: "/projects/aethon/src", kind: "dir" },
+          {
+            name: "README.md",
+            path: "/projects/aethon/README.md",
+            kind: "file",
+          },
+          {
+            name: "package.json",
+            path: "/projects/aethon/package.json",
+            kind: "file",
+          },
+        ]);
+      }
+      if (cmd === "fs_list_dir" && args?.path === "/projects/aethon/src") {
+        return Promise.resolve([
+          {
+            name: "App.tsx",
+            path: "/projects/aethon/src/App.tsx",
+            kind: "file",
+          },
+          {
+            name: "new.ts",
+            path: "/projects/aethon/src/new.ts",
+            kind: "file",
+          },
+        ]);
+      }
+      if (cmd === "git_file_status") {
+        return Promise.resolve([
+          { path: "README.md", status: "modified" },
+          { path: "src/new.ts", status: "untracked" },
+        ]);
+      }
+      return Promise.resolve(1);
+    });
+
+    render(<FileTreePanel {...panelProps()} />);
+    await waitFor(() => screen.getByLabelText("Modified"));
+    expect(screen.getByText("README.md").closest("li")?.className).toContain(
+      "git-status-modified",
+    );
+    expect(screen.getByText("src").closest("li")?.className).toContain(
+      "git-status-descendant",
+    );
+
+    fireEvent.click(screen.getByText("src"));
+    await waitFor(() => screen.getByLabelText("Untracked"));
+    expect(screen.getByText("new.ts").closest("li")?.className).toContain(
+      "git-status-untracked",
+    );
+    expect(screen.queryByLabelText("Added")).toBeNull();
+  });
+
+  it("renders deleted Git entries that are missing from fs_list_dir", async () => {
+    invokeMock.mockImplementation((cmd: string, args?: { path?: string }) => {
+      if (cmd === "fs_list_dir" && args?.path === "/projects/aethon") {
+        return Promise.resolve([
+          { name: "src", path: "/projects/aethon/src", kind: "dir" },
+        ]);
+      }
+      if (cmd === "fs_list_dir" && args?.path === "/projects/aethon/src") {
+        return Promise.resolve([]);
+      }
+      if (cmd === "git_file_status") {
+        return Promise.resolve([{ path: "src/old.ts", status: "deleted" }]);
+      }
+      return Promise.resolve(1);
+    });
+
+    render(<FileTreePanel {...panelProps()} />);
+    await waitFor(() => screen.getByText("src"));
+    fireEvent.click(screen.getByText("src"));
+    await waitFor(() => screen.getByText("old.ts"));
+    expect(screen.getByLabelText("Deleted")).toBeTruthy();
+  });
+
+  it("renders clean Git file trees without decorations", async () => {
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === "fs_list_dir") {
+        return Promise.resolve([
+          {
+            name: "README.md",
+            path: "/projects/aethon/README.md",
+            kind: "file",
+          },
+        ]);
+      }
+      if (cmd === "git_file_status") return Promise.resolve([]);
+      return Promise.resolve(1);
+    });
+
+    render(<FileTreePanel {...panelProps()} />);
+    await waitFor(() => screen.getByText("README.md"));
+    expect(screen.queryByLabelText("Modified")).toBeNull();
+    expect(screen.queryByLabelText("Untracked")).toBeNull();
+  });
+
+  it("renders non-git file trees without decorations", async () => {
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === "fs_list_dir") {
+        return Promise.resolve([
+          {
+            name: "README.md",
+            path: "/projects/aethon/README.md",
+            kind: "file",
+          },
+        ]);
+      }
+      if (cmd === "git_file_status") return Promise.resolve(null);
+      return Promise.resolve(1);
+    });
+
+    render(<FileTreePanel {...panelProps()} />);
+    await waitFor(() => screen.getByText("README.md"));
+    expect(screen.queryByLabelText("Modified")).toBeNull();
+    expect(screen.queryByLabelText("Untracked")).toBeNull();
+  });
+
   it("watches the visible project directories without recursive scans", async () => {
     invokeMock.mockImplementation((cmd: string) => {
       if (cmd === "fs_list_dir") {

--- a/src/skills/default-layout/sidebar/file-tree.tsx
+++ b/src/skills/default-layout/sidebar/file-tree.tsx
@@ -146,7 +146,17 @@ function relativePathFor(rootPath: string, path: string): string | null {
 }
 
 function absolutePathFor(rootPath: string, relativePath: string): string {
-  return `${rootPath.replace(/[\\/]+$/, "")}/${normalizeRelativePath(relativePath)}`;
+  const separator =
+    rootPath.includes("\\") && !rootPath.includes("/") ? "\\" : "/";
+  const normalizedRelative = normalizeRelativePath(relativePath).replace(
+    /\//g,
+    separator,
+  );
+  return `${rootPath.replace(/[\\/]+$/, "")}${separator}${normalizedRelative}`;
+}
+
+function normalizeAbsolutePath(path: string): string {
+  return path.replace(/\\/g, "/").replace(/\/+$/, "");
 }
 
 function parentRelativePath(relativePath: string): string {
@@ -510,6 +520,10 @@ export function FileTreePanel({
   // props pattern would force a re-render dance every time the user
   // expands a folder elsewhere.
   useEffect(() => {
+    if (gitStatusRefreshTimerRef.current) {
+      clearTimeout(gitStatusRefreshTimerRef.current);
+      gitStatusRefreshTimerRef.current = null;
+    }
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setRoot(null);
     setGitStatuses(new Map());
@@ -686,9 +700,11 @@ export function FileTreePanel({
       const deleted =
         parentRel == null ? [] : (deletedChildrenByParent.get(parentRel) ?? []);
       if (deleted.length === 0) return children;
-      const existing = new Set(children.map((child) => child.entry.path));
+      const existing = new Set(
+        children.map((child) => normalizeAbsolutePath(child.entry.path)),
+      );
       const synthetic = deleted
-        .filter((entry) => !existing.has(entry.path))
+        .filter((entry) => !existing.has(normalizeAbsolutePath(entry.path)))
         .map((entry) => ({ entry, depth: node.depth + 1 }));
       return sortTreeNodes([...children, ...synthetic]);
     };

--- a/src/skills/default-layout/sidebar/file-tree.tsx
+++ b/src/skills/default-layout/sidebar/file-tree.tsx
@@ -43,6 +43,51 @@ interface FsEntry {
   kind: "file" | "dir";
 }
 
+type GitFileStatusKind =
+  | "modified"
+  | "added"
+  | "untracked"
+  | "deleted"
+  | "renamed"
+  | "copied"
+  | "conflicted";
+
+interface GitFileStatusEntry {
+  path: string;
+  status: GitFileStatusKind;
+  originalPath?: string | null;
+}
+
+interface GitDecoration {
+  status: GitFileStatusKind;
+  source: "direct" | "descendant";
+}
+
+interface GitStatusMeta {
+  label: string;
+  title: string;
+}
+
+const GIT_STATUS_META: Record<GitFileStatusKind, GitStatusMeta> = {
+  modified: { label: "M", title: "Modified" },
+  added: { label: "A", title: "Added" },
+  untracked: { label: "U", title: "Untracked" },
+  deleted: { label: "D", title: "Deleted" },
+  renamed: { label: "R", title: "Renamed" },
+  copied: { label: "C", title: "Copied" },
+  conflicted: { label: "!", title: "Conflicted" },
+};
+
+const GIT_STATUS_PRIORITY: Record<GitFileStatusKind, number> = {
+  conflicted: 70,
+  deleted: 60,
+  renamed: 50,
+  added: 40,
+  untracked: 30,
+  copied: 20,
+  modified: 10,
+};
+
 /** A node in the in-memory tree. `children` is undefined until the
  *  folder has been loaded; null means "load attempted, no children". */
 interface TreeNode {
@@ -78,6 +123,64 @@ function basename(path: string): string {
       .filter(Boolean)
       .pop() ?? path
   );
+}
+
+function dirname(path: string): string {
+  const slash = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
+  return slash >= 0 ? path.slice(0, slash) : "";
+}
+
+function normalizeRelativePath(path: string): string {
+  return path.replace(/\\/g, "/").replace(/^\/+/, "").replace(/\/+$/, "");
+}
+
+function relativePathFor(rootPath: string, path: string): string | null {
+  if (!rootPath || !path) return null;
+  const root = rootPath.replace(/\\/g, "/").replace(/\/+$/, "");
+  const target = path.replace(/\\/g, "/");
+  if (target === root) return "";
+  if (target.startsWith(`${root}/`)) {
+    return normalizeRelativePath(target.slice(root.length + 1));
+  }
+  return null;
+}
+
+function absolutePathFor(rootPath: string, relativePath: string): string {
+  return `${rootPath.replace(/[\\/]+$/, "")}/${normalizeRelativePath(relativePath)}`;
+}
+
+function parentRelativePath(relativePath: string): string {
+  return dirname(normalizeRelativePath(relativePath)).replace(/^\/+/, "");
+}
+
+function strongerGitStatus(
+  a: GitFileStatusKind | undefined,
+  b: GitFileStatusKind,
+): GitFileStatusKind {
+  if (!a) return b;
+  return GIT_STATUS_PRIORITY[b] > GIT_STATUS_PRIORITY[a] ? b : a;
+}
+
+function sortTreeNodes(nodes: TreeNode[]): TreeNode[] {
+  return [...nodes].sort((a, b) => {
+    if (a.entry.kind !== b.entry.kind) {
+      return a.entry.kind === "dir" ? -1 : 1;
+    }
+    return a.entry.name.toLowerCase().localeCompare(b.entry.name.toLowerCase());
+  });
+}
+
+function gitStatusesFromEntries(
+  entries: GitFileStatusEntry[] | null | undefined,
+): Map<string, GitFileStatusEntry> {
+  const map = new Map<string, GitFileStatusEntry>();
+  if (!Array.isArray(entries)) return map;
+  for (const entry of entries) {
+    const path = normalizeRelativePath(entry.path);
+    if (!path) continue;
+    map.set(path, { ...entry, path });
+  }
+  return map;
 }
 
 /** Return the directory of `node`'s entry: the node itself when it's a
@@ -258,6 +361,9 @@ export function FileTreePanel({
   const [root, setRoot] = useState<TreeNode | null>(null);
   // Set of expanded absolute paths. Driving render, mirror-saved to disk.
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [gitStatuses, setGitStatuses] = useState<
+    Map<string, GitFileStatusEntry>
+  >(new Map());
   const [error, setError] = useState<string>("");
   // Panel chrome state — collapsed header (just shows the "files" row,
   // hides the tree), hidden entirely (panel offscreen), and the panel
@@ -277,6 +383,9 @@ export function FileTreePanel({
   const watchedRootRef = useRef<string>("");
   const refreshDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingRefreshDirsRef = useRef<Set<string>>(new Set());
+  const gitStatusRefreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
 
   useEffect(() => {
     projectPathRef.current = projectPath;
@@ -362,6 +471,38 @@ export function FileTreePanel({
     }, 250);
   }, []);
 
+  const refreshGitStatuses = useCallback(async (rootPath: string) => {
+    if (!rootPath) {
+      setGitStatuses(new Map());
+      return;
+    }
+    try {
+      const entries = await invoke<GitFileStatusEntry[] | null>(
+        "git_file_status",
+        { root: rootPath },
+      );
+      if (projectPathRef.current !== rootPath) return;
+      setGitStatuses(gitStatusesFromEntries(entries));
+    } catch {
+      // Non-git directories, missing git binary, or transient status errors
+      // should never block the file tree; just render without decorations.
+      if (projectPathRef.current === rootPath) setGitStatuses(new Map());
+    }
+  }, []);
+
+  const scheduleGitStatusRefresh = useCallback(
+    (rootPath = projectPathRef.current) => {
+      if (gitStatusRefreshTimerRef.current) {
+        clearTimeout(gitStatusRefreshTimerRef.current);
+      }
+      gitStatusRefreshTimerRef.current = setTimeout(() => {
+        gitStatusRefreshTimerRef.current = null;
+        void refreshGitStatuses(rootPath);
+      }, 180);
+    },
+    [refreshGitStatuses],
+  );
+
   // Fetch the root directory listing whenever the active project changes.
   // The two synchronous setState calls here are intentional: they reset
   // local in-effect state (last project's tree + error) before kicking
@@ -371,6 +512,7 @@ export function FileTreePanel({
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setRoot(null);
+    setGitStatuses(new Map());
     setError("");
     // Reset the expanded set to the new project's persisted entries
     // (or empty when this is the first time the user has opened it).
@@ -397,6 +539,7 @@ export function FileTreePanel({
           children: nodesFromEntries(entries, 1),
         };
         setRoot(rootNode);
+        void refreshGitStatuses(projectPath);
         // Hydrate any persisted-expanded folders so the user comes back
         // to the same view they left. We fetch from the outside in
         // (shorter paths first) so a parent's children land before its
@@ -446,7 +589,7 @@ export function FileTreePanel({
     return () => {
       cancelled = true;
     };
-  }, [projectPath, rootLabel]);
+  }, [projectPath, refreshGitStatuses, rootLabel]);
 
   // Load a folder's children on demand. No-op if already loaded.
   const loadFolderChildren = useCallback(
@@ -497,22 +640,67 @@ export function FileTreePanel({
     [loadFolderChildren, schedulePersist],
   );
 
+  const gitDecorations = useMemo(() => {
+    const direct = new Map<string, GitFileStatusKind>();
+    const descendants = new Map<string, GitFileStatusKind>();
+    for (const [path, entry] of gitStatuses) {
+      direct.set(path, entry.status);
+      const parts = path.split("/").filter(Boolean);
+      for (let i = 1; i < parts.length; i += 1) {
+        const dir = parts.slice(0, i).join("/");
+        descendants.set(
+          dir,
+          strongerGitStatus(descendants.get(dir), entry.status),
+        );
+      }
+    }
+    return { direct, descendants };
+  }, [gitStatuses]);
+
+  const deletedChildrenByParent = useMemo(() => {
+    const byParent = new Map<string, FsEntry[]>();
+    if (!projectPath) return byParent;
+    for (const [path, entry] of gitStatuses) {
+      if (entry.status !== "deleted") continue;
+      const parent = parentRelativePath(path);
+      const children = byParent.get(parent) ?? [];
+      children.push({
+        name: basename(path),
+        path: absolutePathFor(projectPath, path),
+        kind: "file",
+      });
+      byParent.set(parent, children);
+    }
+    return byParent;
+  }, [gitStatuses, projectPath]);
+
   // Flatten the tree into a render list of currently-visible nodes.
   const visibleNodes = useMemo(() => {
     if (!root) return [];
     const out: TreeNode[] = [];
+    const childrenFor = (node: TreeNode): TreeNode[] => {
+      const children = node.children ?? [];
+      const parentRel = projectPath
+        ? relativePathFor(projectPath, node.entry.path)
+        : null;
+      const deleted =
+        parentRel == null ? [] : (deletedChildrenByParent.get(parentRel) ?? []);
+      if (deleted.length === 0) return children;
+      const existing = new Set(children.map((child) => child.entry.path));
+      const synthetic = deleted
+        .filter((entry) => !existing.has(entry.path))
+        .map((entry) => ({ entry, depth: node.depth + 1 }));
+      return sortTreeNodes([...children, ...synthetic]);
+    };
     const walk = (node: TreeNode) => {
       out.push(node);
       if (node.entry.kind !== "dir") return;
       if (!expanded.has(node.entry.path)) return;
-      if (!node.children) return;
-      for (const child of node.children) walk(child);
+      for (const child of childrenFor(node)) walk(child);
     };
-    if (root.children) {
-      for (const child of root.children) walk(child);
-    }
+    for (const child of childrenFor(root)) walk(child);
     return out;
-  }, [root, expanded]);
+  }, [deletedChildrenByParent, expanded, projectPath, root]);
 
   const watchedDirs = useMemo(() => {
     if (!projectPath || hidden) return [];
@@ -603,11 +791,13 @@ export function FileTreePanel({
           };
           return { ...r, children: r.children?.map(walk) ?? undefined };
         });
+        scheduleGitStatusRefresh();
       } catch {
         invalidateFolder(folderPath);
+        scheduleGitStatusRefresh();
       }
     },
-    [invalidateFolder],
+    [invalidateFolder, scheduleGitStatusRefresh],
   );
 
   useEffect(() => {
@@ -698,6 +888,9 @@ export function FileTreePanel({
       }
       if (watchSyncTimerRef.current) clearTimeout(watchSyncTimerRef.current);
       if (refreshDebounceRef.current) clearTimeout(refreshDebounceRef.current);
+      if (gitStatusRefreshTimerRef.current) {
+        clearTimeout(gitStatusRefreshTimerRef.current);
+      }
     };
   }, []);
 
@@ -1134,15 +1327,28 @@ export function FileTreePanel({
       {titleRow}
       {!collapsed && (
         <ul className="ae-file-tree-list">
-          {visibleNodes.map((node) => (
-            <FileTreeRow
-              key={node.entry.path}
-              node={node}
-              expanded={expanded.has(node.entry.path)}
-              onClick={() => onItemClick(node)}
-              onContextMenu={(e) => onRowContextMenu(e, node)}
-            />
-          ))}
+          {visibleNodes.map((node) => {
+            const rel = relativePathFor(projectPath, node.entry.path);
+            const direct =
+              rel == null ? undefined : gitDecorations.direct.get(rel);
+            const descendant =
+              rel == null ? undefined : gitDecorations.descendants.get(rel);
+            const decoration = direct
+              ? ({ status: direct, source: "direct" } as const)
+              : descendant
+                ? ({ status: descendant, source: "descendant" } as const)
+                : undefined;
+            return (
+              <FileTreeRow
+                key={node.entry.path}
+                node={node}
+                expanded={expanded.has(node.entry.path)}
+                decoration={decoration}
+                onClick={() => onItemClick(node)}
+                onContextMenu={(e) => onRowContextMenu(e, node)}
+              />
+            );
+          })}
         </ul>
       )}
       <ContextMenu
@@ -1163,6 +1369,7 @@ export function FileTreePanel({
 interface FileTreeRowProps {
   node: TreeNode;
   expanded: boolean;
+  decoration?: GitDecoration;
   onClick: () => void;
   onContextMenu: (e: React.MouseEvent) => void;
 }
@@ -1170,21 +1377,34 @@ interface FileTreeRowProps {
 function FileTreeRow({
   node,
   expanded,
+  decoration,
   onClick,
   onContextMenu,
 }: FileTreeRowProps) {
   const indent = (node.depth - 1) * 12;
   const isDir = node.entry.kind === "dir";
+  const statusMeta = decoration ? GIT_STATUS_META[decoration.status] : null;
+  const statusTitle = statusMeta
+    ? `${statusMeta.title}${
+        decoration?.source === "descendant" ? " descendant" : ""
+      }`
+    : "";
   return (
     <li
       role="treeitem"
       aria-level={node.depth}
       aria-expanded={isDir ? expanded : undefined}
-      className={`ae-file-tree-row ${isDir ? "is-dir" : "is-file"}`}
+      className={`ae-file-tree-row ${isDir ? "is-dir" : "is-file"}${
+        decoration
+          ? ` has-git-status git-status-${decoration.status} git-status-${decoration.source}`
+          : ""
+      }`}
       style={{ paddingLeft: indent }}
       onClick={onClick}
       onContextMenu={onContextMenu}
-      title={node.entry.path}
+      title={
+        statusTitle ? `${node.entry.path} — ${statusTitle}` : node.entry.path
+      }
     >
       {isDir ? (
         <span className="ae-file-tree-chevron-row" aria-hidden="true">
@@ -1200,6 +1420,15 @@ function FileTreeRow({
         className="ae-file-tree-icon"
       />
       <span className="ae-file-tree-label">{node.entry.name}</span>
+      {statusMeta && (
+        <span
+          className="ae-file-tree-git-decoration"
+          aria-label={statusTitle}
+          title={statusTitle}
+        >
+          {decoration?.source === "descendant" ? "•" : statusMeta.label}
+        </span>
+      )}
       {node.loading && (
         <span className="ae-file-tree-loading" aria-hidden="true">
           …

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -441,6 +441,43 @@ body.ae-resizing-sidebar .ae-file-tree-sidebar-resize-handle {
   overflow: hidden;
   text-overflow: ellipsis;
 }
+.ae-file-tree-row.has-git-status .ae-file-tree-label {
+  color: var(--text);
+}
+.ae-file-tree-row.git-status-deleted .ae-file-tree-label {
+  color: var(--text-dim);
+  text-decoration: line-through;
+}
+.ae-file-tree-git-decoration {
+  flex: 0 0 auto;
+  min-width: 1.2em;
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: var(--chrome-text-muted);
+  line-height: 1;
+  text-align: right;
+  color: var(--accent);
+  opacity: 0.95;
+}
+.ae-file-tree-row.git-status-descendant .ae-file-tree-git-decoration {
+  min-width: auto;
+  opacity: 0.7;
+}
+.ae-file-tree-row.git-status-added .ae-file-tree-git-decoration,
+.ae-file-tree-row.git-status-untracked .ae-file-tree-git-decoration,
+.ae-file-tree-row.git-status-copied .ae-file-tree-git-decoration {
+  color: var(--success, #3fb950);
+}
+.ae-file-tree-row.git-status-deleted .ae-file-tree-git-decoration {
+  color: var(--error);
+}
+.ae-file-tree-row.git-status-renamed .ae-file-tree-git-decoration {
+  color: var(--warn);
+}
+.ae-file-tree-row.git-status-conflicted .ae-file-tree-git-decoration {
+  color: var(--error);
+  font-weight: 700;
+}
 .ae-file-tree-loading {
   opacity: var(--opacity-muted);
 }


### PR DESCRIPTION
## Summary

Implements VS Code-like Git decorations in the project file tree for GitHub issue #93.

### What changed

- Added a new Tauri command, `git_file_status(root)`, that returns a project/worktree-root-relative Git status map.
- Parses `git status --porcelain=v1 -z --renames --untracked-files=all -- .` once per active tree root instead of per row.
- Joins Git status metadata into visible file-tree rows by relative path.
- Renders direct file decorations for:
  - Modified (`M`)
  - Added (`A`)
  - Untracked (`U`)
  - Deleted/missing (`D`)
  - Renamed (`R`)
  - Copied (`C`)
  - Conflicted (`!`)
- Adds folder rollup decorations when descendants have changes.
- Synthesizes missing/deleted file rows when their parent folder is visible.
- Keeps non-git directories rendering normally with no decorations.
- Debounces Git status refreshes after file watcher refreshes to avoid slowing down large repos.

## Testing

- `nix develop -c cargo fmt --manifest-path src-tauri/Cargo.toml`
- `nix develop -c bun install --frozen-lockfile`
- `nix develop -c bun run test src/skills/default-layout/sidebar/file-tree.test.tsx`
- `nix develop -c cargo test --manifest-path src-tauri/Cargo.toml git_file_status`
- `nix develop -c bun run typecheck`
- `nix develop -c bun run lint -- src/skills/default-layout/sidebar/file-tree.tsx src/skills/default-layout/sidebar/file-tree.test.tsx`
  - Passed with existing unrelated warnings in dashboard/editor/layout files.
- `git diff --check`

## Notes

The Git status command intentionally keeps `fs_list_dir` focused on filesystem metadata. The frontend maintains a separate Git status map for the active project/worktree root and decorates rows during render, so directory listing stays simple and the tree avoids per-row Git calls.

Closes #93.
