### PR TITLE
fix(agent): isolate tab-scoped worker processes

### DIFF
--- a/agent/dispatcher.ts
+++ b/agent/dispatcher.ts
@@ -49,6 +49,17 @@ import {
 } from "./session-history";
 import { saveDisabledExtensionsSnapshot } from "./disabled-extensions";
 
+const WORKER_MODE =
+  typeof process.env.AETHON_WORKER_TAB_ID === "string" &&
+  process.env.AETHON_WORKER_TAB_ID.length > 0;
+
+function emitGlobalReady(
+  state: AethonAgentState,
+  deps: { send: (obj: Record<string, unknown>) => void },
+): void {
+  if (!WORKER_MODE) emitReady(state, deps);
+}
+
 export interface DispatcherDeps {
   send: (obj: Record<string, unknown>) => void;
   scheduleStateFileWrite: () => void;
@@ -259,6 +270,7 @@ export interface InboundMessage {
   content?: string;
   mode?: "normal" | "steer";
   cwd?: string;
+  model?: string;
   name?: string;
   args?: string;
   id?: string;
@@ -435,11 +447,17 @@ export async function handleChat(
   const tabId = msg.tabId ?? "default";
   const cwdOverride =
     typeof msg.cwd === "string" && msg.cwd.length > 0 ? msg.cwd : undefined;
+  let initialModel: Model<Api> | undefined;
+  if (typeof msg.model === "string" && msg.model.length > 0) {
+    const [provider, ...rest] = msg.model.split("/");
+    initialModel =
+      state.modelRegistry.find(provider, rest.join("/")) ?? undefined;
+  }
   const tab = await ensureTab(
     state,
     deps,
     tabId,
-    cwdOverride ? { cwdOverride } : {},
+    cwdOverride || initialModel ? { cwdOverride, initialModel } : {},
   );
   const wantsSteer = msg.mode === "steer";
   if (wantsSteer && tab.promptInFlight) {
@@ -590,7 +608,7 @@ export async function runDispatcher(
           break;
         case "report": {
           markFrontendReady(state);
-          emitReady(state, deps);
+          emitGlobalReady(state, deps);
           break;
         }
         case "reload_request": {
@@ -877,7 +895,7 @@ export async function runDispatcher(
           command,
           message: `Session name set: ${nextName}`,
         });
-        emitReady(state, deps);
+        emitGlobalReady(state, deps);
         return;
       }
       case "export": {
@@ -958,7 +976,7 @@ export async function runDispatcher(
       if (result.loaded > 0 || result.failed > 0 || projectChanged) {
         await state.resourceLoader.reload();
         deps.scheduleStateFileWrite();
-        emitReady(state, deps);
+        emitGlobalReady(state, deps);
       }
     }
     const restoreHistory =
@@ -1011,7 +1029,7 @@ export async function runDispatcher(
         state.currentProjectCwd = null;
         await state.resourceLoader.reload();
         deps.scheduleStateFileWrite();
-        emitReady(state, deps);
+        emitGlobalReady(state, deps);
       }
       return;
     }
@@ -1077,7 +1095,7 @@ export async function runDispatcher(
           );
       }
       deps.scheduleStateFileWrite();
-      emitReady(state, deps);
+      emitGlobalReady(state, deps);
       if (projectChanged) {
         logger
           .scope("project-switch")
@@ -1279,7 +1297,7 @@ export async function runDispatcher(
       if (idx >= 0) state.discoveredTabs[idx] = entry;
       else state.discoveredTabs.push(entry);
     }
-    emitReady(state, deps);
+    emitGlobalReady(state, deps);
   }
 
   async function handleLocalChatMessage(

--- a/agent/main.ts
+++ b/agent/main.ts
@@ -97,6 +97,9 @@ async function main(): Promise<void> {
   const releaseMode = process.env.AETHON_RELEASE_MODE === "1";
   const bootLayoutFile = process.env.AETHON_BOOT_LAYOUT_FILE;
   const layoutSlotsFile = process.env.AETHON_LAYOUT_SLOTS_FILE;
+  const workerTabId = process.env.AETHON_WORKER_TAB_ID;
+  const workerCwd = process.env.AETHON_WORKER_CWD;
+  const workerMode = typeof workerTabId === "string" && workerTabId.length > 0;
   const { warnKb, hardKb } = resolveStateLimits(
     process.env.AETHON_STATE_WARN_KB,
     process.env.AETHON_STATE_HARD_KB,
@@ -244,7 +247,7 @@ async function main(): Promise<void> {
   // restores the registries from this snapshot.
   captureProjectExtensionBaseline(state);
 
-  const activeProjectCwd = await readActiveProjectCwd(userDir);
+  const activeProjectCwd = workerCwd ?? (await readActiveProjectCwd(userDir));
   const startupCwd = resolveStartupCwd(
     activeProjectCwd,
     projectRoot,
@@ -267,41 +270,46 @@ async function main(): Promise<void> {
   // Reload so the appendSystemPromptOverride sees the populated extensions.
   await state.resourceLoader.reload();
 
-  // -- Default tab -------------------------------------------------------
-  // Resolve the active project's cwd from disk so the default tab's
-  // session resume is scoped to the right project on first paint —
-  // otherwise a `default` session from a previously-active project
-  // leaks into whatever the user opens next (sessions/default/ is
-  // shared across project buckets).
-  state.tabProjectCwds.set("default", startupCwd);
   const tabDeps = { send };
-  await ensureTab(state, tabDeps, "default");
+  if (!workerMode) {
+    // -- Default tab -------------------------------------------------------
+    // Resolve the active project's cwd from disk so the default tab's
+    // session resume is scoped to the right project on first paint —
+    // otherwise a `default` session from a previously-active project
+    // leaks into whatever the user opens next (sessions/default/ is
+    // shared across project buckets).
+    state.tabProjectCwds.set("default", startupCwd);
+    await ensureTab(state, tabDeps, "default");
 
-  // -- Discover persisted sessions for the "Recent sessions" empty-state -
-  state.discoveredTabs = await discoverPersistedTabs(state);
+    // -- Discover persisted sessions for the "Recent sessions" empty-state -
+    state.discoveredTabs = await discoverPersistedTabs(state);
 
-  scheduleStateFileWrite();
-  emitReady(state, tabDeps);
+    scheduleStateFileWrite();
+    emitReady(state, tabDeps);
 
-  // Replay the default tab's persisted pi session history so all tabs use
-  // the same session_history IPC path. Scope the read by the SAME cwd
-  // `ensureTab` resolved against — when no project is active, both fall
-  // back to the startup cwd. Passing `undefined` here would let the
-  // replay surface the latest JSONL from any cwd while `ensureTab` (which
-  // filters via `findSessionFileMatchingCwd`) created an empty session,
-  // leaving the UI showing a leaked transcript that the agent cannot
-  // continue.
-  readSessionTranscript(tabSessionDir(state, "default"), startupCwd)
-    .then((messages) => {
-      if (messages.length > 0) {
-        send({ type: "session_history", tabId: "default", messages });
-      }
-    })
-    .catch((err: unknown) => {
-      logger
-        .scope("session")
-        .warn(`default tab history replay failed: ${(err as Error).message}`);
-    });
+    // Replay the default tab's persisted pi session history so all tabs use
+    // the same session_history IPC path. Scope the read by the SAME cwd
+    // `ensureTab` resolved against — when no project is active, both fall
+    // back to the startup cwd. Passing `undefined` here would let the
+    // replay surface the latest JSONL from any cwd while `ensureTab` (which
+    // filters via `findSessionFileMatchingCwd`) created an empty session,
+    // leaving the UI showing a leaked transcript that the agent cannot
+    // continue.
+    readSessionTranscript(tabSessionDir(state, "default"), startupCwd)
+      .then((messages) => {
+        if (messages.length > 0) {
+          send({ type: "session_history", tabId: "default", messages });
+        }
+      })
+      .catch((err: unknown) => {
+        logger
+          .scope("session")
+          .warn(`default tab history replay failed: ${(err as Error).message}`);
+      });
+  } else {
+    state.tabProjectCwds.set(workerTabId, startupCwd);
+    scheduleStateFileWrite();
+  }
 
   // -- Run the dispatcher ------------------------------------------------
   const dispatcherDeps = {

--- a/src-tauri/src/commands/extensions.rs
+++ b/src-tauri/src/commands/extensions.rs
@@ -30,7 +30,7 @@ use std::sync::{Arc, Mutex};
 use serde::Deserialize;
 use tauri::{AppHandle, Emitter, Manager, State};
 
-use crate::{AgentProcess, AgentReloadFlag, agent_reload_in_progress, env, project_root};
+use crate::{AgentProcesses, AgentReloadFlag, agent_reload_in_progress, env, project_root};
 
 // ─────────────────────────── menu items ────────────────────────────
 
@@ -471,44 +471,47 @@ fn run_debounce_worker(rx: std::sync::mpsc::Receiver<DebounceMsg>, app: AppHandl
         // Quiet — ask the bridge to drain & respawn. Holds the child
         // alive (`as_mut`, not `take`) so an in-flight prompt's stdin
         // pipe stays open while pi finishes the turn.
-        let state: State<'_, AgentProcess> = app.state();
-        if let Ok(mut guard) = state.0.lock()
-            && let Some(child) = guard.as_mut()
-        {
-            // Capture pid before the mutable borrow on `child.stdin`
-            // so we can log it without the borrow-checker complaining
-            // about overlapping immutable + mutable borrows of `child`.
-            let pid = child.id();
-            let write_result = match child.stdin.as_mut() {
-                Some(stdin) => {
-                    writeln!(stdin, "{{\"type\":\"reload_request\"}}").and_then(|_| stdin.flush())
+        let state: State<'_, AgentProcesses> = app.state();
+        if let Ok(mut guard) = state.children.lock() {
+            let mut kill_keys = Vec::new();
+            for (key, child) in guard.iter_mut() {
+                // Capture pid before the mutable borrow on `child.stdin`
+                // so we can log it without the borrow-checker complaining
+                // about overlapping immutable + mutable borrows of `child`.
+                let pid = child.id();
+                let write_result = match child.stdin.as_mut() {
+                    Some(stdin) => writeln!(stdin, "{{\"type\":\"reload_request\"}}")
+                        .and_then(|_| stdin.flush()),
+                    None => Err(std::io::Error::other("agent stdin closed")),
+                };
+                match write_result {
+                    Ok(()) => {
+                        tracing::info!(
+                            target: "aethon::agent_watch",
+                            key = key,
+                            "asked pid={pid} to reload after {settle}ms settle (last paths={last_paths:?})",
+                        );
+                    }
+                    Err(err) => {
+                        tracing::warn!(
+                            target: "aethon::agent_watch",
+                            key = key,
+                            "reload_request write failed for pid={pid}: {err}; falling back to kill",
+                        );
+                        kill_keys.push(key.clone());
+                    }
                 }
-                None => Err(std::io::Error::other("agent stdin closed")),
-            };
-            match write_result {
-                Ok(()) => {
-                    tracing::info!(
-                        target: "aethon::agent_watch",
-                        "asked pid={pid} to reload after {settle}ms settle (last paths={last_paths:?})",
-                    );
-                }
-                Err(err) => {
-                    // Stdin is closed — child is gone or wedged. Fall
-                    // back to the legacy hard-kill so the next request
-                    // lazily respawns. Mark intentional so the stdout
-                    // reader emits agent-reloaded, not agent-crashed.
-                    tracing::warn!(
-                        target: "aethon::agent_watch",
-                        "reload_request write failed for pid={pid}: {err}; falling back to kill",
-                    );
-                    let reload_flag = agent_reload_in_progress(&app);
-                    reload_flag.store(true, std::sync::atomic::Ordering::Release);
-                    if let Some(mut dead) = guard.take() {
+            }
+            if !kill_keys.is_empty() {
+                let reload_flag = agent_reload_in_progress(&app);
+                for key in kill_keys {
+                    if let Some(mut dead) = guard.remove(&key) {
+                        reload_flag.store(true, std::sync::atomic::Ordering::Release);
                         let _ = dead.kill();
                         let _ = dead.wait();
                     }
-                    let _ = app.emit("agent-reloaded", "");
                 }
+                let _ = app.emit("agent-reloaded", "");
             }
         }
     }
@@ -800,7 +803,7 @@ fn output_tail(stdout: &[u8], stderr: &[u8]) -> String {
 pub async fn install_aethon_extension(
     spec: String,
     app: AppHandle,
-    state: State<'_, AgentProcess>,
+    state: State<'_, AgentProcesses>,
     reload_flag: State<'_, AgentReloadFlag>,
 ) -> Result<String, String> {
     let spec = validate_extension_install_spec(&spec)?;
@@ -847,10 +850,9 @@ pub async fn install_aethon_extension(
     .map_err(|e| format!("install task failed: {e}"))?;
 
     let install_output = install_result?;
-    if let Ok(mut guard) = state.0.lock()
-        && let Some(mut child) = guard.take()
+    if let Ok(mut guard) = state.children.lock()
+        && !guard.is_empty()
     {
-        let pid = child.id();
         // Mark this kill as intentional BEFORE the actual kill — the
         // stdout reader's EOF handler reads this flag to decide whether
         // to fire `agent-crashed`. Without the flag, the EOF supervisor
@@ -860,10 +862,19 @@ pub async fn install_aethon_extension(
         reload_flag
             .0
             .store(true, std::sync::atomic::Ordering::SeqCst);
-        let _ = child.kill();
-        let _ = child.wait();
+        for (key, mut child) in guard.drain() {
+            let pid = child.id();
+            reload_flag
+                .0
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+            let _ = child.kill();
+            let _ = child.wait();
+            tracing::info!(target: "aethon::ext_install", key = key, "killed pid={pid}; will respawn with {spec}");
+        }
+        if let Ok(mut routes) = state.mutation_routes.lock() {
+            routes.clear();
+        }
         let _ = app.emit("agent-reloaded", "");
-        tracing::info!(target: "aethon::ext_install", "killed pid={pid}; will respawn with {spec}");
     }
 
     Ok(if install_output.trim().is_empty() {

--- a/src-tauri/src/commands/extensions.rs
+++ b/src-tauri/src/commands/extensions.rs
@@ -30,7 +30,7 @@ use std::sync::{Arc, Mutex};
 use serde::Deserialize;
 use tauri::{AppHandle, Emitter, Manager, State};
 
-use crate::{AgentProcesses, AgentReloadFlag, agent_reload_in_progress, env, project_root};
+use crate::{AgentProcesses, env, project_root};
 
 // ─────────────────────────── menu items ────────────────────────────
 
@@ -468,13 +468,27 @@ fn run_debounce_worker(rx: std::sync::mpsc::Receiver<DebounceMsg>, app: AppHandl
                 Err(RecvTimeoutError::Disconnected) => return,
             }
         }
-        // Quiet — ask the bridge to drain & respawn. Holds the child
-        // alive (`as_mut`, not `take`) so an in-flight prompt's stdin
-        // pipe stays open while pi finishes the turn.
+        // Quiet — ask each bridge to drain & respawn. Clone the per-child
+        // handles first so a wedged stdin only blocks that bridge, not the
+        // whole process table.
         let state: State<'_, AgentProcesses> = app.state();
-        if let Ok(mut guard) = state.children.lock() {
+        let children: Vec<_> = state
+            .children
+            .lock()
+            .map(|guard| {
+                guard
+                    .iter()
+                    .map(|(key, child)| (key.clone(), Arc::clone(child)))
+                    .collect()
+            })
+            .unwrap_or_default();
+        if !children.is_empty() {
             let mut kill_keys = Vec::new();
-            for (key, child) in guard.iter_mut() {
+            for (key, child) in children {
+                let Ok(mut child) = child.lock() else {
+                    kill_keys.push(key);
+                    continue;
+                };
                 // Capture pid before the mutable borrow on `child.stdin`
                 // so we can log it without the borrow-checker complaining
                 // about overlapping immutable + mutable borrows of `child`.
@@ -503,10 +517,19 @@ fn run_debounce_worker(rx: std::sync::mpsc::Receiver<DebounceMsg>, app: AppHandl
                 }
             }
             if !kill_keys.is_empty() {
-                let reload_flag = agent_reload_in_progress(&app);
+                if let Ok(mut exits) = state.intentional_exits.lock() {
+                    for key in &kill_keys {
+                        exits.insert(key.clone());
+                    }
+                }
+                let mut guard = match state.children.lock() {
+                    Ok(guard) => guard,
+                    Err(_) => return,
+                };
                 for key in kill_keys {
-                    if let Some(mut dead) = guard.remove(&key) {
-                        reload_flag.store(true, std::sync::atomic::Ordering::Release);
+                    if let Some(dead) = guard.remove(&key)
+                        && let Ok(mut dead) = dead.lock()
+                    {
                         let _ = dead.kill();
                         let _ = dead.wait();
                     }
@@ -804,7 +827,6 @@ pub async fn install_aethon_extension(
     spec: String,
     app: AppHandle,
     state: State<'_, AgentProcesses>,
-    reload_flag: State<'_, AgentReloadFlag>,
 ) -> Result<String, String> {
     let spec = validate_extension_install_spec(&spec)?;
     let home = app
@@ -850,26 +872,24 @@ pub async fn install_aethon_extension(
     .map_err(|e| format!("install task failed: {e}"))?;
 
     let install_output = install_result?;
-    if let Ok(mut guard) = state.children.lock()
-        && !guard.is_empty()
-    {
-        // Mark this kill as intentional BEFORE the actual kill — the
-        // stdout reader's EOF handler reads this flag to decide whether
-        // to fire `agent-crashed`. Without the flag, the EOF supervisor
-        // misclassifies the extension-install reload as a crash and the
-        // user sees both a crash toast and the auto-restart on top of
-        // the deliberate `agent-reloaded` flow.
-        reload_flag
-            .0
-            .store(true, std::sync::atomic::Ordering::SeqCst);
-        for (key, mut child) in guard.drain() {
-            let pid = child.id();
-            reload_flag
-                .0
-                .store(true, std::sync::atomic::Ordering::SeqCst);
-            let _ = child.kill();
-            let _ = child.wait();
-            tracing::info!(target: "aethon::ext_install", key = key, "killed pid={pid}; will respawn with {spec}");
+    let children: Vec<_> = state
+        .children
+        .lock()
+        .map(|mut guard| guard.drain().collect())
+        .unwrap_or_default();
+    if !children.is_empty() {
+        if let Ok(mut exits) = state.intentional_exits.lock() {
+            for (key, _) in &children {
+                exits.insert(key.clone());
+            }
+        }
+        for (key, child) in children {
+            if let Ok(mut child) = child.lock() {
+                let pid = child.id();
+                let _ = child.kill();
+                let _ = child.wait();
+                tracing::info!(target: "aethon::ext_install", key = key, "killed pid={pid}; will respawn with {spec}");
+            }
         }
         if let Ok(mut routes) = state.mutation_routes.lock() {
             routes.clear();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -30,7 +30,6 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
-use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex, OnceLock};
 
 use tauri::{AppHandle, Emitter, Manager, State};
@@ -51,9 +50,9 @@ mod debug;
 const GLOBAL_AGENT_KEY: &str = "__global__";
 
 pub(crate) struct AgentProcesses {
-    pub(crate) children: Mutex<HashMap<String, Child>>,
+    pub(crate) children: Mutex<HashMap<String, Arc<Mutex<Child>>>>,
     pub(crate) mutation_routes: Arc<Mutex<HashMap<String, String>>>,
-    intentional_exits: Arc<Mutex<HashSet<String>>>,
+    pub(crate) intentional_exits: Arc<Mutex<HashSet<String>>>,
 }
 
 impl AgentProcesses {
@@ -69,18 +68,6 @@ impl AgentProcesses {
 struct AgentWorker {
     tab_id: String,
     cwd: Option<String>,
-}
-
-/// Shared atomic flag set by the file-watcher debounce worker just
-/// before it kills the bun child for a hot-reload. The stdout reader
-/// checks this on EOF: if true, the kill was intentional (`agent-reloaded`
-/// was already emitted) — reset and stay silent. If false, the child
-/// died unexpectedly and we emit `agent-crashed` so the frontend can
-/// surface a notice + offer auto-restart.
-pub(crate) struct AgentReloadFlag(pub(crate) Arc<AtomicBool>);
-
-pub(crate) fn agent_reload_in_progress(app: &AppHandle) -> Arc<AtomicBool> {
-    Arc::clone(&app.state::<AgentReloadFlag>().0)
 }
 
 /// Find the project root (the directory containing `agent/main.ts`). Tauri
@@ -161,7 +148,7 @@ fn find_sidecar_binary() -> Result<PathBuf, String> {
 /// background thread; each line is emitted as an `agent-response`
 /// Tauri event.
 fn ensure_agent_spawned(
-    guard: &mut HashMap<String, Child>,
+    guard: &mut HashMap<String, Arc<Mutex<Child>>>,
     key: &str,
     app: &AppHandle,
     mutation_routes: Arc<Mutex<HashMap<String, String>>>,
@@ -169,9 +156,13 @@ fn ensure_agent_spawned(
     worker: Option<AgentWorker>,
 ) -> Result<(), String> {
     // Reap a dead child if present — try_wait returns Ok(Some(_)) when exited.
-    if let Some(child) = guard.get_mut(key)
-        && let Ok(Some(status)) = child.try_wait()
-    {
+    let exited_status = guard.get(key).and_then(|child| {
+        child
+            .lock()
+            .ok()
+            .and_then(|mut child| child.try_wait().ok().flatten())
+    });
+    if let Some(status) = exited_status {
         tracing::info!(target: "aethon::agent", key = key, "previous child exited with {status:?}; respawning");
         guard.remove(key);
     }
@@ -299,7 +290,6 @@ fn ensure_agent_spawned(
 
     let stdout = child.stdout.take().ok_or("no stdout on spawned agent")?;
     let app_stdout = app.clone();
-    let reload_flag_stdout = agent_reload_in_progress(app);
     let stderr_tail_for_supervisor = Arc::clone(&stderr_tail);
     let stdout_key = key.to_string();
     let stdout_tab_id = worker.as_ref().map(|w| w.tab_id.clone());
@@ -313,13 +303,11 @@ fn ensure_agent_spawned(
                 Ok(text) => {
                     // Sentinel from the bridge meaning "I'm about to
                     // exit cleanly because the watcher asked me to
-                    // reload." Set the flag BEFORE the EOF arrives so
-                    // the post-loop handler treats it as intentional,
-                    // and emit `agent-reloaded` here so the frontend
-                    // can clear waiting state and respawn lazily.
+                    // reload." Keep that decision local to this child
+                    // so concurrent worker reloads cannot consume a
+                    // shared marker out from under each other.
                     if text.contains("\"_reload_done\"") {
                         saw_reload_done = true;
-                        reload_flag_stdout.store(true, std::sync::atomic::Ordering::Release);
                         let _ = app_stdout.emit("agent-reloaded", "");
                         // Don't forward the sentinel — it's bridge↔
                         // supervisor-internal and would confuse the
@@ -339,17 +327,13 @@ fn ensure_agent_spawned(
         }
         tracing::debug!(target: "aethon::agent", key = stdout_key, "stdout reader for pid={pid} exited");
         // Stdout reader exits when the child closes stdout — i.e. the
-        // child has died. Distinguish intentional kills (hot-reload via
-        // the file watcher, which sets `agent_reload_in_progress` first)
-        // from unexpected crashes. Reset the flag for the next cycle.
+        // child has died. Distinguish intentional per-child exits from
+        // unexpected crashes.
         let intentional_exit = stdout_intentional_exits
             .lock()
             .map(|mut exits| exits.remove(&stdout_key))
             .unwrap_or(false);
-        if intentional_exit
-            || saw_reload_done
-            || reload_flag_stdout.swap(false, std::sync::atomic::Ordering::AcqRel)
-        {
+        if intentional_exit || saw_reload_done {
             // Intentional kill — `agent-reloaded` was already emitted by
             // the watcher; nothing more to do.
             return;
@@ -401,7 +385,7 @@ fn ensure_agent_spawned(
         tracing::debug!(target: "aethon::agent", key = stderr_key, "stderr reader for pid={pid} exited");
     });
 
-    guard.insert(key.to_string(), child);
+    guard.insert(key.to_string(), Arc::new(Mutex::new(child)));
     Ok(())
 }
 
@@ -429,17 +413,20 @@ fn write_agent_payload(
     payload: serde_json::Value,
     worker: Option<AgentWorker>,
 ) -> Result<(), String> {
-    let mut guard = state.children.lock().map_err(|e| e.to_string())?;
-    ensure_agent_spawned(
-        &mut guard,
-        &key,
-        app,
-        Arc::clone(&state.mutation_routes),
-        Arc::clone(&state.intentional_exits),
-        worker,
-    )?;
+    let child = {
+        let mut guard = state.children.lock().map_err(|e| e.to_string())?;
+        ensure_agent_spawned(
+            &mut guard,
+            &key,
+            app,
+            Arc::clone(&state.mutation_routes),
+            Arc::clone(&state.intentional_exits),
+            worker,
+        )?;
+        guard.get(&key).cloned().ok_or("agent not running")?
+    };
 
-    let child = guard.get_mut(&key).ok_or("agent not running")?;
+    let mut child = child.lock().map_err(|e| e.to_string())?;
     let stdin = child.stdin.as_mut().ok_or("no stdin")?;
     writeln!(stdin, "{}", payload).map_err(|e| format!("write failed: {e}"))?;
     stdin.flush().map_err(|e| format!("flush failed: {e}"))?;
@@ -447,13 +434,17 @@ fn write_agent_payload(
 }
 
 fn retire_agent_key(state: &State<'_, AgentProcesses>, key: &str) -> Result<(), String> {
-    let mut guard = state.children.lock().map_err(|e| e.to_string())?;
-    let Some(mut child) = guard.remove(key) else {
+    let child = {
+        let mut guard = state.children.lock().map_err(|e| e.to_string())?;
+        guard.remove(key)
+    };
+    let Some(child) = child else {
         return Ok(());
     };
     if let Ok(mut exits) = state.intentional_exits.lock() {
         exits.insert(key.to_string());
     }
+    let mut child = child.lock().map_err(|e| e.to_string())?;
     let pid = child.id();
     tracing::info!(target: "aethon::agent", key = key, "retiring pid={pid}");
     let _ = child.kill();
@@ -538,18 +529,20 @@ fn send_message(
 }
 
 /// Hard-kill the running agent child. Called by the frontend's hang-warn
-/// notification "Force restart" button. Unlike the file-watcher kill (which
-/// sets `agent_reload_in_progress` so EOF emits `agent-reloaded`), we
-/// intentionally let the crash path fire: the existing `agent-crashed`
-/// handler in App.tsx clears waiting state and (if auto_restart_agent = true)
-/// respawns automatically.
+/// notification "Force restart" button. We intentionally let the crash path
+/// fire: the existing `agent-crashed` handler clears waiting state and (if
+/// auto_restart_agent = true) respawns automatically.
 ///
 /// This bypasses blocked stdin — even if the Node event loop is frozen by
 /// backpressured stdout writes, Rust can still kill the child OS process.
 #[tauri::command]
 fn force_restart_agent(state: State<'_, AgentProcesses>) -> Result<(), String> {
-    let mut guard = state.children.lock().map_err(|e| e.to_string())?;
-    for (key, mut child) in guard.drain() {
+    let children: Vec<_> = {
+        let mut guard = state.children.lock().map_err(|e| e.to_string())?;
+        guard.drain().collect()
+    };
+    for (key, child) in children {
+        let mut child = child.lock().map_err(|e| e.to_string())?;
         let pid = child.id();
         tracing::warn!(target: "aethon::agent", key = key, "force_restart_agent: killing pid={pid}");
         let _ = child.kill();
@@ -564,26 +557,28 @@ fn force_restart_agent(state: State<'_, AgentProcesses>) -> Result<(), String> {
 }
 
 /// Intentional kill-and-respawn for state changes the bridge can't apply
-/// hot (currently: the user toggling an extension via the sidebar). Sets
-/// the supervisor's `agent_reload_in_progress` flag BEFORE killing so the
-/// stdout reader treats EOF as a clean reload (emits `agent-reloaded`,
-/// not `agent-crashed`). The frontend's `agent-reloaded` handler then
-/// invokes `start_agent` and the new bridge boots fresh — for the
+/// hot (currently: the user toggling an extension via the sidebar). Marks
+/// each child key as an intentional exit BEFORE killing so the stdout reader
+/// treats EOF as a clean reload, not `agent-crashed`. The frontend's
+/// `agent-reloaded` handler then invokes `start_agent` and the new bridge
+/// boots fresh — for the
 /// disable-extension case, it reads `disabled-extensions.json` and the
 /// loader honors the user's intent.
 #[tauri::command]
 fn reload_agent(state: State<'_, AgentProcesses>, app: AppHandle) -> Result<(), String> {
-    let mut guard = state.children.lock().map_err(|e| e.to_string())?;
-    // Only set the reload flag when there's actually a child to kill —
-    // the stdout reader thread is what resets the flag on EOF, so
-    // setting it without a child to die would leave it stale and the
-    // next genuine crash would be misclassified as an intentional
-    // reload (no agent-crashed notification).
-    if !guard.is_empty() {
-        let reload_flag = agent_reload_in_progress(&app);
-        for (key, mut child) in guard.drain() {
+    let children: Vec<_> = {
+        let mut guard = state.children.lock().map_err(|e| e.to_string())?;
+        guard.drain().collect()
+    };
+    if !children.is_empty() {
+        if let Ok(mut exits) = state.intentional_exits.lock() {
+            for (key, _) in &children {
+                exits.insert(key.clone());
+            }
+        }
+        for (key, child) in children {
+            let mut child = child.lock().map_err(|e| e.to_string())?;
             let pid = child.id();
-            reload_flag.store(true, std::sync::atomic::Ordering::Release);
             tracing::info!(target: "aethon::agent", key = key, "reload_agent: killing pid={pid}");
             let _ = child.kill();
             let _ = child.wait();
@@ -840,7 +835,6 @@ pub fn run() {
     }
     let builder = builder
         .manage(AgentProcesses::new())
-        .manage(AgentReloadFlag(Arc::new(AtomicBool::new(false))))
         .manage(shell::ShellRegistry::new())
         .manage(commands::fs::FsWatchState::default())
         .manage(window_state::WindowStateStore::new())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -26,7 +26,7 @@
 //! shell tabs live in [`shell`]; debug-only commands and the eval
 //! server live in [`debug`].
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
@@ -48,7 +48,28 @@ mod debug;
 
 // ─────────────────────────── agent process ────────────────────────────
 
-pub(crate) struct AgentProcess(pub(crate) Mutex<Option<Child>>);
+const GLOBAL_AGENT_KEY: &str = "__global__";
+
+pub(crate) struct AgentProcesses {
+    pub(crate) children: Mutex<HashMap<String, Child>>,
+    pub(crate) mutation_routes: Arc<Mutex<HashMap<String, String>>>,
+    intentional_exits: Arc<Mutex<HashSet<String>>>,
+}
+
+impl AgentProcesses {
+    fn new() -> Self {
+        Self {
+            children: Mutex::new(HashMap::new()),
+            mutation_routes: Arc::new(Mutex::new(HashMap::new())),
+            intentional_exits: Arc::new(Mutex::new(HashSet::new())),
+        }
+    }
+}
+
+struct AgentWorker {
+    tab_id: String,
+    cwd: Option<String>,
+}
 
 /// Shared atomic flag set by the file-watcher debounce worker just
 /// before it kills the bun child for a hot-reload. The stdout reader
@@ -139,16 +160,23 @@ fn find_sidecar_binary() -> Result<PathBuf, String> {
 /// packages from `~/.pi/agent/settings.json`. Stdout is read on a
 /// background thread; each line is emitted as an `agent-response`
 /// Tauri event.
-fn ensure_agent_spawned(guard: &mut Option<Child>, app: &AppHandle) -> Result<(), String> {
+fn ensure_agent_spawned(
+    guard: &mut HashMap<String, Child>,
+    key: &str,
+    app: &AppHandle,
+    mutation_routes: Arc<Mutex<HashMap<String, String>>>,
+    intentional_exits: Arc<Mutex<HashSet<String>>>,
+    worker: Option<AgentWorker>,
+) -> Result<(), String> {
     // Reap a dead child if present — try_wait returns Ok(Some(_)) when exited.
-    if let Some(child) = guard.as_mut()
+    if let Some(child) = guard.get_mut(key)
         && let Ok(Some(status)) = child.try_wait()
     {
-        tracing::info!(target: "aethon::agent", "previous child exited with {status:?}; respawning");
-        *guard = None;
+        tracing::info!(target: "aethon::agent", key = key, "previous child exited with {status:?}; respawning");
+        guard.remove(key);
     }
 
-    if guard.is_some() {
+    if guard.contains_key(key) {
         return Ok(());
     }
 
@@ -242,6 +270,14 @@ fn ensure_agent_spawned(guard: &mut Option<Child>, app: &AppHandle) -> Result<()
         command.env("AETHON_STATE_WARN_KB", warn_kb.to_string());
         command.env("AETHON_STATE_HARD_KB", hard_kb.to_string());
     }
+    if let Some(worker) = &worker {
+        command.env("AETHON_WORKER_TAB_ID", &worker.tab_id);
+        if let Some(cwd) = &worker.cwd
+            && !cwd.is_empty()
+        {
+            command.env("AETHON_WORKER_CWD", cwd);
+        }
+    }
 
     let mut child = command
         .stdin(Stdio::piped())
@@ -251,7 +287,7 @@ fn ensure_agent_spawned(guard: &mut Option<Child>, app: &AppHandle) -> Result<()
         .map_err(|e| format!("failed to spawn agent: {e}"))?;
 
     let pid = child.id();
-    tracing::info!(target: "aethon::agent", "spawned pid={pid}");
+    tracing::info!(target: "aethon::agent", key = key, "spawned pid={pid}");
 
     // Tail-buffer of recent stderr lines. When the bun child crashes
     // unexpectedly, the supervisor emits an `agent-crashed` event with
@@ -265,8 +301,13 @@ fn ensure_agent_spawned(guard: &mut Option<Child>, app: &AppHandle) -> Result<()
     let app_stdout = app.clone();
     let reload_flag_stdout = agent_reload_in_progress(app);
     let stderr_tail_for_supervisor = Arc::clone(&stderr_tail);
+    let stdout_key = key.to_string();
+    let stdout_tab_id = worker.as_ref().map(|w| w.tab_id.clone());
+    let stdout_routes = Arc::clone(&mutation_routes);
+    let stdout_intentional_exits = Arc::clone(&intentional_exits);
     std::thread::spawn(move || {
         let reader = BufReader::new(stdout);
+        let mut saw_reload_done = false;
         for line in reader.lines() {
             match line {
                 Ok(text) => {
@@ -277,6 +318,7 @@ fn ensure_agent_spawned(guard: &mut Option<Child>, app: &AppHandle) -> Result<()
                     // and emit `agent-reloaded` here so the frontend
                     // can clear waiting state and respawn lazily.
                     if text.contains("\"_reload_done\"") {
+                        saw_reload_done = true;
                         reload_flag_stdout.store(true, std::sync::atomic::Ordering::Release);
                         let _ = app_stdout.emit("agent-reloaded", "");
                         // Don't forward the sentinel — it's bridge↔
@@ -284,17 +326,30 @@ fn ensure_agent_spawned(guard: &mut Option<Child>, app: &AppHandle) -> Result<()
                         // frontend's agent-response router.
                         continue;
                     }
+                    if let Ok(value) = serde_json::from_str::<serde_json::Value>(&text)
+                        && let Some(mutation_id) = value.get("mutationId").and_then(|v| v.as_str())
+                        && let Ok(mut routes) = stdout_routes.lock()
+                    {
+                        routes.insert(mutation_id.to_string(), stdout_key.clone());
+                    }
                     let _ = app_stdout.emit("agent-response", text);
                 }
                 Err(_) => break,
             }
         }
-        tracing::debug!(target: "aethon::agent", "stdout reader for pid={pid} exited");
+        tracing::debug!(target: "aethon::agent", key = stdout_key, "stdout reader for pid={pid} exited");
         // Stdout reader exits when the child closes stdout — i.e. the
         // child has died. Distinguish intentional kills (hot-reload via
         // the file watcher, which sets `agent_reload_in_progress` first)
         // from unexpected crashes. Reset the flag for the next cycle.
-        if reload_flag_stdout.swap(false, std::sync::atomic::Ordering::AcqRel) {
+        let intentional_exit = stdout_intentional_exits
+            .lock()
+            .map(|mut exits| exits.remove(&stdout_key))
+            .unwrap_or(false);
+        if intentional_exit
+            || saw_reload_done
+            || reload_flag_stdout.swap(false, std::sync::atomic::Ordering::AcqRel)
+        {
             // Intentional kill — `agent-reloaded` was already emitted by
             // the watcher; nothing more to do.
             return;
@@ -309,6 +364,7 @@ fn ensure_agent_spawned(guard: &mut Option<Child>, app: &AppHandle) -> Result<()
             "agent-crashed",
             serde_json::json!({
                 "pid": pid,
+                "tabId": stdout_tab_id,
                 "stderrTail": tail,
             }),
         );
@@ -321,6 +377,7 @@ fn ensure_agent_spawned(guard: &mut Option<Child>, app: &AppHandle) -> Result<()
     let stderr = child.stderr.take().ok_or("no stderr on spawned agent")?;
     let app_stderr = app.clone();
     let stderr_tail_writer = Arc::clone(&stderr_tail);
+    let stderr_key = key.to_string();
     std::thread::spawn(move || {
         let reader = BufReader::new(stderr);
         for line in reader.lines() {
@@ -329,7 +386,7 @@ fn ensure_agent_spawned(guard: &mut Option<Child>, app: &AppHandle) -> Result<()
                     // Bridge stderr — already prefixed by the bridge's logger
                     // since it now emits structured `LEVEL scope: msg` lines.
                     // We forward at info level and let the env filter throttle.
-                    tracing::info!(target: "aethon::agent::stderr", pid = pid, "{text}");
+                    tracing::info!(target: "aethon::agent::stderr", pid = pid, key = stderr_key, "{text}");
                     if let Ok(mut g) = stderr_tail_writer.lock() {
                         if g.len() >= STDERR_TAIL_CAP {
                             g.pop_front();
@@ -341,17 +398,98 @@ fn ensure_agent_spawned(guard: &mut Option<Child>, app: &AppHandle) -> Result<()
                 Err(_) => break,
             }
         }
-        tracing::debug!(target: "aethon::agent", "stderr reader for pid={pid} exited");
+        tracing::debug!(target: "aethon::agent", key = stderr_key, "stderr reader for pid={pid} exited");
     });
 
-    *guard = Some(child);
+    guard.insert(key.to_string(), child);
     Ok(())
 }
 
 #[tauri::command]
-fn start_agent(state: State<'_, AgentProcess>, app: AppHandle) -> Result<(), String> {
-    let mut guard = state.0.lock().map_err(|e| e.to_string())?;
-    ensure_agent_spawned(&mut guard, &app)
+fn start_agent(state: State<'_, AgentProcesses>, app: AppHandle) -> Result<(), String> {
+    let mut guard = state.children.lock().map_err(|e| e.to_string())?;
+    ensure_agent_spawned(
+        &mut guard,
+        GLOBAL_AGENT_KEY,
+        &app,
+        Arc::clone(&state.mutation_routes),
+        Arc::clone(&state.intentional_exits),
+        None,
+    )
+}
+
+fn tab_agent_key(tab_id: &str) -> String {
+    format!("tab:{tab_id}")
+}
+
+fn write_agent_payload(
+    state: &State<'_, AgentProcesses>,
+    app: &AppHandle,
+    key: String,
+    payload: serde_json::Value,
+    worker: Option<AgentWorker>,
+) -> Result<(), String> {
+    let mut guard = state.children.lock().map_err(|e| e.to_string())?;
+    ensure_agent_spawned(
+        &mut guard,
+        &key,
+        app,
+        Arc::clone(&state.mutation_routes),
+        Arc::clone(&state.intentional_exits),
+        worker,
+    )?;
+
+    let child = guard.get_mut(&key).ok_or("agent not running")?;
+    let stdin = child.stdin.as_mut().ok_or("no stdin")?;
+    writeln!(stdin, "{}", payload).map_err(|e| format!("write failed: {e}"))?;
+    stdin.flush().map_err(|e| format!("flush failed: {e}"))?;
+    Ok(())
+}
+
+fn retire_agent_key(state: &State<'_, AgentProcesses>, key: &str) -> Result<(), String> {
+    let mut guard = state.children.lock().map_err(|e| e.to_string())?;
+    let Some(mut child) = guard.remove(key) else {
+        return Ok(());
+    };
+    if let Ok(mut exits) = state.intentional_exits.lock() {
+        exits.insert(key.to_string());
+    }
+    let pid = child.id();
+    tracing::info!(target: "aethon::agent", key = key, "retiring pid={pid}");
+    let _ = child.kill();
+    let _ = child.wait();
+    Ok(())
+}
+
+fn route_payload_key(state: &State<'_, AgentProcesses>, payload: &serde_json::Value) -> String {
+    if payload.get("type").and_then(|v| v.as_str()) == Some("mutation_ack")
+        && let Some(mutation_id) = payload.get("mutationId").and_then(|v| v.as_str())
+        && let Ok(mut routes) = state.mutation_routes.lock()
+        && let Some(key) = routes.remove(mutation_id)
+    {
+        return key;
+    }
+    let tab_scoped = matches!(
+        payload.get("type").and_then(|v| v.as_str()),
+        Some(
+            "a2ui_event"
+                | "chat"
+                | "local_chat_message"
+                | "native_slash_command"
+                | "set_model"
+                | "stop"
+                | "tab_close"
+                | "tab_open"
+        )
+    );
+    if tab_scoped
+        && let Some(tab_id) = payload.get("tabId").and_then(|v| v.as_str())
+        && !tab_id.is_empty()
+        && tab_id != "default"
+    {
+        return tab_agent_key(tab_id);
+    }
+    GLOBAL_AGENT_KEY.to_string()
 }
 
 #[tauri::command]
@@ -360,30 +498,43 @@ fn send_message(
     tab_id: Option<String>,
     mode: Option<String>,
     cwd: Option<String>,
-    state: State<'_, AgentProcess>,
+    model: Option<String>,
+    state: State<'_, AgentProcesses>,
     app: AppHandle,
 ) -> Result<(), String> {
-    let mut guard = state.0.lock().map_err(|e| e.to_string())?;
-    ensure_agent_spawned(&mut guard, &app)?;
-
-    let child = guard.as_mut().ok_or("agent not running")?;
-    let stdin = child.stdin.as_mut().ok_or("no stdin")?;
+    let tab_id = tab_id.unwrap_or_else(|| "default".to_string());
     // tabId routes to a specific pi session; the bridge defaults to
     // "default" when omitted so legacy single-tab callers keep working.
     let mut payload = serde_json::json!({
         "type": "chat",
         "content": message,
         "mode": mode.unwrap_or_else(|| "normal".to_string()),
-        "tabId": tab_id.unwrap_or_else(|| "default".to_string()),
+        "tabId": tab_id,
     });
     if let Some(cwd) = cwd
         && !cwd.is_empty()
     {
         payload["cwd"] = serde_json::Value::String(cwd);
     }
-    writeln!(stdin, "{}", payload).map_err(|e| format!("write failed: {e}"))?;
-    stdin.flush().map_err(|e| format!("flush failed: {e}"))?;
-    Ok(())
+    if let Some(model) = model
+        && !model.is_empty()
+    {
+        payload["model"] = serde_json::Value::String(model);
+    }
+
+    let key = route_payload_key(&state, &payload);
+    let worker = if key == GLOBAL_AGENT_KEY {
+        None
+    } else {
+        Some(AgentWorker {
+            tab_id: payload["tabId"].as_str().unwrap_or("default").to_string(),
+            cwd: payload
+                .get("cwd")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string()),
+        })
+    };
+    write_agent_payload(&state, &app, key, payload, worker)
 }
 
 /// Hard-kill the running agent child. Called by the frontend's hang-warn
@@ -396,17 +547,19 @@ fn send_message(
 /// This bypasses blocked stdin — even if the Node event loop is frozen by
 /// backpressured stdout writes, Rust can still kill the child OS process.
 #[tauri::command]
-fn force_restart_agent(state: State<'_, AgentProcess>) -> Result<(), String> {
-    let mut guard = state.0.lock().map_err(|e| e.to_string())?;
-    if let Some(mut child) = guard.take() {
+fn force_restart_agent(state: State<'_, AgentProcesses>) -> Result<(), String> {
+    let mut guard = state.children.lock().map_err(|e| e.to_string())?;
+    for (key, mut child) in guard.drain() {
         let pid = child.id();
-        tracing::warn!(target: "aethon::agent", "force_restart_agent: killing pid={pid}");
+        tracing::warn!(target: "aethon::agent", key = key, "force_restart_agent: killing pid={pid}");
         let _ = child.kill();
         // Reap the child so it doesn't become a zombie while we wait for
         // the stdout reader thread to detect EOF and emit agent-crashed.
         let _ = child.wait();
     }
-    // If guard is None the agent wasn't running — no-op is correct.
+    if let Ok(mut routes) = state.mutation_routes.lock() {
+        routes.clear();
+    }
     Ok(())
 }
 
@@ -419,20 +572,25 @@ fn force_restart_agent(state: State<'_, AgentProcess>) -> Result<(), String> {
 /// disable-extension case, it reads `disabled-extensions.json` and the
 /// loader honors the user's intent.
 #[tauri::command]
-fn reload_agent(state: State<'_, AgentProcess>, app: AppHandle) -> Result<(), String> {
-    let mut guard = state.0.lock().map_err(|e| e.to_string())?;
+fn reload_agent(state: State<'_, AgentProcesses>, app: AppHandle) -> Result<(), String> {
+    let mut guard = state.children.lock().map_err(|e| e.to_string())?;
     // Only set the reload flag when there's actually a child to kill —
     // the stdout reader thread is what resets the flag on EOF, so
     // setting it without a child to die would leave it stale and the
     // next genuine crash would be misclassified as an intentional
     // reload (no agent-crashed notification).
-    if let Some(mut child) = guard.take() {
-        let pid = child.id();
+    if !guard.is_empty() {
         let reload_flag = agent_reload_in_progress(&app);
-        reload_flag.store(true, std::sync::atomic::Ordering::Release);
-        tracing::info!(target: "aethon::agent", "reload_agent: killing pid={pid}");
-        let _ = child.kill();
-        let _ = child.wait();
+        for (key, mut child) in guard.drain() {
+            let pid = child.id();
+            reload_flag.store(true, std::sync::atomic::Ordering::Release);
+            tracing::info!(target: "aethon::agent", key = key, "reload_agent: killing pid={pid}");
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+        if let Ok(mut routes) = state.mutation_routes.lock() {
+            routes.clear();
+        }
     }
     // Emit agent-reloaded so the frontend re-primes via start_agent.
     // Safe to emit even when no child existed — the listener invokes
@@ -447,16 +605,32 @@ fn reload_agent(state: State<'_, AgentProcess>, app: AppHandle) -> Result<(), St
 #[tauri::command]
 fn agent_command(
     payload: String,
-    state: State<'_, AgentProcess>,
+    state: State<'_, AgentProcesses>,
     app: AppHandle,
 ) -> Result<(), String> {
-    let mut guard = state.0.lock().map_err(|e| e.to_string())?;
-    ensure_agent_spawned(&mut guard, &app)?;
-
-    let child = guard.as_mut().ok_or("agent not running")?;
-    let stdin = child.stdin.as_mut().ok_or("no stdin")?;
-    writeln!(stdin, "{}", payload).map_err(|e| format!("write failed: {e}"))?;
-    stdin.flush().map_err(|e| format!("flush failed: {e}"))?;
+    let payload_value: serde_json::Value =
+        serde_json::from_str(&payload).map_err(|e| format!("invalid agent command: {e}"))?;
+    let key = route_payload_key(&state, &payload_value);
+    let worker = if key == GLOBAL_AGENT_KEY {
+        None
+    } else {
+        payload_value
+            .get("tabId")
+            .and_then(|v| v.as_str())
+            .map(|tab_id| AgentWorker {
+                tab_id: tab_id.to_string(),
+                cwd: payload_value
+                    .get("cwd")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string()),
+            })
+    };
+    let should_retire = payload_value.get("type").and_then(|v| v.as_str()) == Some("tab_close")
+        && key != GLOBAL_AGENT_KEY;
+    write_agent_payload(&state, &app, key.clone(), payload_value, worker)?;
+    if should_retire {
+        retire_agent_key(&state, &key)?;
+    }
     Ok(())
 }
 
@@ -464,25 +638,28 @@ fn agent_command(
 fn dispatch_a2ui_event(
     event: String,
     tab_id: Option<String>,
-    state: State<'_, AgentProcess>,
+    state: State<'_, AgentProcesses>,
     app: AppHandle,
 ) -> Result<(), String> {
-    let mut guard = state.0.lock().map_err(|e| e.to_string())?;
-    ensure_agent_spawned(&mut guard, &app)?;
-
-    let child = guard.as_mut().ok_or("agent not running")?;
-    let stdin = child.stdin.as_mut().ok_or("no stdin")?;
     let event_value: serde_json::Value = serde_json::from_str(&event).map_err(|e| e.to_string())?;
+    let tab_id = tab_id.unwrap_or_else(|| "default".to_string());
     // tabId routes the event (and any handler-fired pi.prompt()) to the
     // originating tab's session instead of always defaulting to "default".
     let payload = serde_json::json!({
         "type": "a2ui_event",
         "event": event_value,
-        "tabId": tab_id.unwrap_or_else(|| "default".to_string()),
+        "tabId": tab_id,
     });
-    writeln!(stdin, "{}", payload).map_err(|e| format!("write failed: {e}"))?;
-    stdin.flush().map_err(|e| format!("flush failed: {e}"))?;
-    Ok(())
+    let key = route_payload_key(&state, &payload);
+    let worker = if key == GLOBAL_AGENT_KEY {
+        None
+    } else {
+        Some(AgentWorker {
+            tab_id: payload["tabId"].as_str().unwrap_or("default").to_string(),
+            cwd: None,
+        })
+    };
+    write_agent_payload(&state, &app, key, payload, worker)
 }
 
 /// Persist an image paste from the clipboard to `~/.aethon/pastes/`.
@@ -662,7 +839,7 @@ pub fn run() {
         }
     }
     let builder = builder
-        .manage(AgentProcess(Mutex::new(None)))
+        .manage(AgentProcesses::new())
         .manage(AgentReloadFlag(Arc::new(AtomicBool::new(false))))
         .manage(shell::ShellRegistry::new())
         .manage(commands::fs::FsWatchState::default())

--- a/src/eventRoutes/notifications.test.ts
+++ b/src/eventRoutes/notifications.test.ts
@@ -38,6 +38,43 @@ describe("handleNotifications", () => {
     expect(mocks.dismissNotification).toHaveBeenCalledWith("n1");
   });
 
+  it("ae-agent-crashed:restart:<tabId> reopens the tab worker", async () => {
+    const { ctx, mocks } = buildRouteFixture({
+      state: {
+        tabs: [
+          {
+            id: "tab-worker",
+            kind: "agent",
+            cwd: "/tmp/project",
+            model: "gpt-5",
+          },
+        ],
+      },
+    });
+    const handled = await handleNotifications(
+      {
+        component: { id: "notification-stack" },
+        eventType: "action",
+        data: {
+          id: "n-worker",
+          action: "ae-agent-crashed:restart:tab-worker",
+        },
+      },
+      ctx,
+    );
+
+    expect(handled).toBe(true);
+    expect(mocks.invoke).toHaveBeenCalledWith("agent_command", {
+      payload: JSON.stringify({
+        type: "tab_open",
+        tabId: "tab-worker",
+        cwd: "/tmp/project",
+        model: "gpt-5",
+      }),
+    });
+    expect(mocks.dismissNotification).toHaveBeenCalledWith("n-worker");
+  });
+
   it("hang-warn:stop:<tabId> stops that tab specifically", async () => {
     const { ctx, mocks } = buildRouteFixture();
     const handled = await handleNotifications(

--- a/src/eventRoutes/notifications.ts
+++ b/src/eventRoutes/notifications.ts
@@ -1,5 +1,25 @@
 import type { EventRouteHandler } from "./types";
 
+function restartAgentForAction(
+  action: string,
+  ctx: Parameters<EventRouteHandler>[1],
+) {
+  const tabPrefix = "ae-agent-crashed:restart:";
+  if (!action.startsWith(tabPrefix)) {
+    return ctx.invoke("start_agent");
+  }
+  const tabId = action.slice(tabPrefix.length);
+  const tab = (
+    (ctx.stateRef.current.tabs as
+      | { id: string; kind?: string; cwd?: string; model?: string }[]
+      | undefined) ?? []
+  ).find((candidate) => candidate.id === tabId && candidate.kind === "agent");
+  const payload: Record<string, unknown> = { type: "tab_open", tabId };
+  if (tab?.cwd) payload.cwd = tab.cwd;
+  if (tab?.model) payload.model = tab.model;
+  return ctx.invoke("agent_command", { payload: JSON.stringify(payload) });
+}
+
 /** General notification-stack handler. Runs AFTER `handleShellConsent`
  *  in the dispatch table — the consent gate has already short-circuited
  *  the three reserved action prefixes (shell-write-, shell-close-,
@@ -41,12 +61,9 @@ export const handleNotifications: EventRouteHandler = (
     } else if (action && action.startsWith("session-delete-")) {
       const allowed = action.startsWith("session-delete-allow:");
       ctx.resolveSessionDeleteConsent(id, allowed);
-    } else if (
-      action &&
-      action.startsWith("ae-agent-crashed:")
-    ) {
-      if (action === "ae-agent-crashed:restart") {
-        ctx.invoke("start_agent").catch((err: unknown) => {
+    } else if (action && action.startsWith("ae-agent-crashed:")) {
+      if (action.startsWith("ae-agent-crashed:restart")) {
+        restartAgentForAction(action, ctx).catch((err: unknown) => {
           console.warn("agent restart failed:", err);
         });
       }

--- a/src/hooks/useChat.test.ts
+++ b/src/hooks/useChat.test.ts
@@ -98,6 +98,7 @@ describe("useChat setModel", () => {
       message: "hello",
       tabId: "tab-1",
       mode: "normal",
+      model: "anthropic/claude-opus-4-7",
     });
     expect((stateRef.current.tabs as Tab[])[0].messages.at(-1)).toMatchObject({
       role: "user",
@@ -129,6 +130,7 @@ describe("useChat setModel", () => {
       tabId: "issue-tab",
       mode: "normal",
       cwd: "/projects/aethon-fix-86",
+      model: "anthropic/claude-opus-4-7",
     });
     const tabs = stateRef.current.tabs as Tab[];
     expect(tabs.find((t) => t.id === "main-tab")?.messages).toEqual([]);
@@ -173,6 +175,7 @@ describe("useChat setModel", () => {
       message: "/clear",
       tabId: "issue-tab",
       mode: "normal",
+      model: "anthropic/claude-opus-4-7",
     });
     const tabs = stateRef.current.tabs as Tab[];
     expect(tabs.find((t) => t.id === "main-tab")?.messages).toEqual([]);
@@ -209,6 +212,7 @@ describe("useChat setModel", () => {
       message: "first",
       tabId: "tab-1",
       mode: "steer",
+      model: "anthropic/claude-opus-4-7",
     });
   });
 
@@ -257,9 +261,7 @@ describe("useChat setModel", () => {
       await result.current.sendChat("b");
       await result.current.sendChat("c");
     });
-    expect(
-      (stateRef.current.tabs as Tab[])[0].queuedMessages,
-    ).toHaveLength(3);
+    expect((stateRef.current.tabs as Tab[])[0].queuedMessages).toHaveLength(3);
 
     act(() => {
       result.current.clearQueuedMessages("tab-1");
@@ -304,9 +306,7 @@ describe("useChat setModel", () => {
       await result.current.sendChat("b");
       await result.current.sendChat("c");
     });
-    expect(
-      (stateRef.current.tabs as Tab[])[0].queuedMessages,
-    ).toHaveLength(3);
+    expect((stateRef.current.tabs as Tab[])[0].queuedMessages).toHaveLength(3);
 
     await act(async () => {
       await result.current.stopPrompt("tab-1");
@@ -339,13 +339,17 @@ describe("useChat setModel", () => {
       }));
     });
     await act(async () => {
-      await result.current.sendChat("drained", { mode: "normal", tabId: "tab-1" });
+      await result.current.sendChat("drained", {
+        mode: "normal",
+        tabId: "tab-1",
+      });
     });
 
     expect(invoke).toHaveBeenCalledWith("send_message", {
       message: "drained",
       tabId: "tab-1",
       mode: "normal",
+      model: "anthropic/claude-opus-4-7",
     });
     const tab = (stateRef.current.tabs as Tab[])[0];
     expect(tab.queuedMessages).toEqual([]);
@@ -391,6 +395,7 @@ describe("useChat setModel", () => {
       message: "look now",
       tabId: "tab-1",
       mode: "steer",
+      model: "anthropic/claude-opus-4-7",
     });
     expect((stateRef.current.tabs as Tab[])[0].messages.at(-1)).toMatchObject({
       role: "user",
@@ -404,8 +409,18 @@ describe("useChat setModel", () => {
     const { result } = renderHook(() => useChat(ctx));
 
     act(() => {
-      result.current.appendOrAmendAgentText("Inspecting", "agent-1", "tab-1", "thinking");
-      result.current.appendOrAmendAgentText("\nDone", "agent-1", "tab-1", "text");
+      result.current.appendOrAmendAgentText(
+        "Inspecting",
+        "agent-1",
+        "tab-1",
+        "thinking",
+      );
+      result.current.appendOrAmendAgentText(
+        "\nDone",
+        "agent-1",
+        "tab-1",
+        "text",
+      );
     });
 
     expect((stateRef.current.tabs as Tab[])[0].messages.at(-1)).toMatchObject({

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -202,7 +202,11 @@ export function useChat(ctx: UseChatContext): UseChatActions {
       } else {
         const newId = crypto.randomUUID();
         activeResponseIdRef.current = newId;
-        const nextMessage = { id: newId, role: "agent" as const, [channel]: delta };
+        const nextMessage = {
+          id: newId,
+          role: "agent" as const,
+          [channel]: delta,
+        };
         messages.push(nextMessage);
         persistLocalChatMessage(nextMessage, id);
       }
@@ -381,12 +385,20 @@ export function useChat(ctx: UseChatContext): UseChatActions {
       typeof targetTab?.cwd === "string" && targetTab.cwd.length > 0
         ? targetTab.cwd
         : undefined;
+    const targetModel =
+      typeof targetTab?.model === "string" && targetTab.model.length > 0
+        ? targetTab.model
+        : typeof stateRef.current.model === "string" &&
+            stateRef.current.model.length > 0
+          ? stateRef.current.model
+          : undefined;
     try {
       await invoke("send_message", {
         message: sendText,
         tabId,
         mode,
         ...(targetCwd ? { cwd: targetCwd } : {}),
+        ...(targetModel ? { model: targetModel } : {}),
       });
     } catch (err) {
       updateTab(tabId, (tab) => ({

--- a/src/hooks/useOsEdges.ts
+++ b/src/hooks/useOsEdges.ts
@@ -105,6 +105,19 @@ export function useOsEdges(ctx: UseOsEdgesContext): void {
   const { bootLayout } = ctx;
 
   useEffect(() => {
+    const restartAgentProcess = (tabId?: string) => {
+      if (!tabId) {
+        return invoke("start_agent");
+      }
+      const tab = ((stateRef.current.tabs as Tab[] | undefined) ?? []).find(
+        (t) => t.id === tabId && t.kind === "agent",
+      );
+      const payload: Record<string, unknown> = { type: "tab_open", tabId };
+      if (tab?.cwd) payload.cwd = tab.cwd;
+      if (tab?.model) payload.model = tab.model;
+      return invoke("agent_command", { payload: JSON.stringify(payload) });
+    };
+
     // The boot sequence (start_agent → boot_layout → report) and the
     // `agent-response` listener live in `useBridgeMessages` — see the
     // call site near the bottom of App.tsx. The remaining listeners
@@ -261,8 +274,11 @@ export function useOsEdges(ctx: UseOsEdgesContext): void {
         };
       });
       const willAutoRestart = autoRestartAgentRef.current;
+      const notificationId = crashedTabId
+        ? `ae-agent-crashed:${crashedTabId}`
+        : "ae-agent-crashed";
       pushNotification({
-        id: "ae-agent-crashed",
+        id: notificationId,
         title: "Agent process exited unexpectedly",
         message: lastLine.slice(0, 200),
         kind: "error",
@@ -273,7 +289,12 @@ export function useOsEdges(ctx: UseOsEdgesContext): void {
         actions: willAutoRestart
           ? [{ label: "Dismiss", action: "ae-agent-crashed:dismiss" }]
           : [
-              { label: "Restart", action: "ae-agent-crashed:restart" },
+              {
+                label: "Restart",
+                action: crashedTabId
+                  ? `ae-agent-crashed:restart:${crashedTabId}`
+                  : "ae-agent-crashed:restart",
+              },
               { label: "Dismiss", action: "ae-agent-crashed:dismiss" },
             ],
       });
@@ -284,7 +305,7 @@ export function useOsEdges(ctx: UseOsEdgesContext): void {
         // priming here means the system-prompt + ready handshake
         // happens up-front.
         window.setTimeout(() => {
-          invoke("start_agent").catch(() => {
+          restartAgentProcess(crashedTabId).catch(() => {
             /* respawn deferred to next user action */
           });
         }, 500);

--- a/src/hooks/useOsEdges.ts
+++ b/src/hooks/useOsEdges.ts
@@ -21,7 +21,9 @@ export interface UseOsEdgesContext {
 
   // ─── Refs from useChat / useBridgeMessages ──────────────────────────
   activeResponseIdRef: MutableRefObject<string | null>;
-  hangWarnTimersRef: MutableRefObject<Map<string, ReturnType<typeof setTimeout>>>;
+  hangWarnTimersRef: MutableRefObject<
+    Map<string, ReturnType<typeof setTimeout>>
+  >;
   hangWarnActiveRef: MutableRefObject<Set<string>>;
   hangWarnNotifId: (tabId: string) => string;
 
@@ -123,9 +125,10 @@ export function useOsEdges(ctx: UseOsEdgesContext): void {
         if (!tabId || typeof content !== "string") return;
         updateTab(tabId, (t) => {
           const next = t.terminalBuffer + content;
-          const trimmed = next.length > TERMINAL_REPLAY_MAX
-            ? next.slice(next.length - TERMINAL_REPLAY_MAX)
-            : next;
+          const trimmed =
+            next.length > TERMINAL_REPLAY_MAX
+              ? next.slice(next.length - TERMINAL_REPLAY_MAX)
+              : next;
           return { ...t, terminalBuffer: trimmed };
         });
         window.dispatchEvent(
@@ -180,7 +183,8 @@ export function useOsEdges(ctx: UseOsEdgesContext): void {
       activeResponseIdRef.current = null;
       for (const h of hangWarnTimersRef.current.values()) clearTimeout(h);
       hangWarnTimersRef.current.clear();
-      for (const tid of hangWarnActiveRef.current) dismissNotification(hangWarnNotifId(tid));
+      for (const tid of hangWarnActiveRef.current)
+        dismissNotification(hangWarnNotifId(tid));
       hangWarnActiveRef.current.clear();
       setStatusFlags({ waiting: false, status: "agent reloaded" });
       // Re-prime the full bridge handshake. A bare start_agent emits the
@@ -207,62 +211,85 @@ export function useOsEdges(ctx: UseOsEdgesContext): void {
     // bun child exits unexpectedly (intentional hot-reload kills go
     // through `agent-reloaded` instead). Clear all per-tab waiting
     // state, surface a notice, and auto-restart per [shell] config.
-    const unlistenCrashed = listen<{ pid?: number; stderrTail?: string[] }>(
-      "agent-crashed",
-      (event) => {
-        const tail = event.payload?.stderrTail ?? [];
-        const lastLine = tail.length > 0 ? tail[tail.length - 1] : "no stderr";
-        activeResponseIdRef.current = null;
+    const unlistenCrashed = listen<{
+      pid?: number;
+      tabId?: string | null;
+      stderrTail?: string[];
+    }>("agent-crashed", (event) => {
+      const tail = event.payload?.stderrTail ?? [];
+      const crashedTabId =
+        typeof event.payload?.tabId === "string" &&
+        event.payload.tabId.length > 0
+          ? event.payload.tabId
+          : undefined;
+      const lastLine = tail.length > 0 ? tail[tail.length - 1] : "no stderr";
+      activeResponseIdRef.current = null;
+      if (crashedTabId) {
+        const h = hangWarnTimersRef.current.get(crashedTabId);
+        if (h !== undefined) clearTimeout(h);
+        hangWarnTimersRef.current.delete(crashedTabId);
+        if (hangWarnActiveRef.current.delete(crashedTabId)) {
+          dismissNotification(hangWarnNotifId(crashedTabId));
+        }
+      } else {
         for (const h of hangWarnTimersRef.current.values()) clearTimeout(h);
         hangWarnTimersRef.current.clear();
-        for (const tid of hangWarnActiveRef.current) dismissNotification(hangWarnNotifId(tid));
+        for (const tid of hangWarnActiveRef.current)
+          dismissNotification(hangWarnNotifId(tid));
         hangWarnActiveRef.current.clear();
-        // Clear waiting/queue across every tab — pi sessions are gone.
-        setState((prev) => {
-          const tabs = ((prev.tabs as Tab[] | undefined) ?? []).map((t) => ({
-            ...t,
-            waiting: false,
-            queueCount: 0,
-          }));
-          return {
-            ...prev,
-            tabs,
-            waiting: false,
-            queueCount: 0,
-            status: "agent crashed",
-          };
-        });
-        const willAutoRestart = autoRestartAgentRef.current;
-        pushNotification({
-          id: "ae-agent-crashed",
-          title: "Agent process exited unexpectedly",
-          message: lastLine.slice(0, 200),
-          kind: "error",
-          // Keep visible until the user dismisses or restart succeeds —
-          // a transient toast would race a user who's away from the
-          // keyboard while a long agent turn died.
-          durationMs: null,
-          actions: willAutoRestart
-            ? [{ label: "Dismiss", action: "ae-agent-crashed:dismiss" }]
-            : [
-                { label: "Restart", action: "ae-agent-crashed:restart" },
-                { label: "Dismiss", action: "ae-agent-crashed:dismiss" },
-              ],
-        });
-        if (willAutoRestart) {
-          // Brief delay so the user actually sees the notice flash
-          // before the next request silently respawns. The next chat
-          // send will respawn anyway via ensure_agent_spawned, but
-          // priming here means the system-prompt + ready handshake
-          // happens up-front.
-          window.setTimeout(() => {
-            invoke("start_agent").catch(() => {
-              /* respawn deferred to next user action */
-            });
-          }, 500);
-        }
-      },
-    );
+      }
+      // Clear waiting/queue for the affected process. A tab worker crash
+      // should not mark unrelated agents idle; the global bridge crash
+      // still clears all because app-wide state is gone.
+      setState((prev) => {
+        const tabs = ((prev.tabs as Tab[] | undefined) ?? []).map((t) =>
+          !crashedTabId || t.id === crashedTabId
+            ? {
+                ...t,
+                waiting: false,
+                queueCount: 0,
+              }
+            : t,
+        );
+        return {
+          ...prev,
+          tabs,
+          ...(!crashedTabId || prev.activeTabId === crashedTabId
+            ? { waiting: false, queueCount: 0 }
+            : {}),
+          status: "agent crashed",
+        };
+      });
+      const willAutoRestart = autoRestartAgentRef.current;
+      pushNotification({
+        id: "ae-agent-crashed",
+        title: "Agent process exited unexpectedly",
+        message: lastLine.slice(0, 200),
+        kind: "error",
+        // Keep visible until the user dismisses or restart succeeds —
+        // a transient toast would race a user who's away from the
+        // keyboard while a long agent turn died.
+        durationMs: null,
+        actions: willAutoRestart
+          ? [{ label: "Dismiss", action: "ae-agent-crashed:dismiss" }]
+          : [
+              { label: "Restart", action: "ae-agent-crashed:restart" },
+              { label: "Dismiss", action: "ae-agent-crashed:dismiss" },
+            ],
+      });
+      if (willAutoRestart) {
+        // Brief delay so the user actually sees the notice flash
+        // before the next request silently respawns. The next chat
+        // send will respawn anyway via ensure_agent_spawned, but
+        // priming here means the system-prompt + ready handshake
+        // happens up-front.
+        window.setTimeout(() => {
+          invoke("start_agent").catch(() => {
+            /* respawn deferred to next user action */
+          });
+        }, 500);
+      }
+    });
 
     // Mirror agent stderr into the chat as a system message — when the bridge
     // dies on startup this is the only signal we have.
@@ -280,8 +307,12 @@ export function useOsEdges(ctx: UseOsEdgesContext): void {
       //      well-known prefixes, not loose substrings).
       const isLeveledFailure = /\b(WARN|ERROR|FATAL)\b/.test(text);
       const isRawCrash =
-        /^(Error|TypeError|ReferenceError|SyntaxError|RangeError|Uncaught|panic:)/i.test(text) ||
-        /\bthrow\s+new\s|\bCannot\s+find\s+(module|package)\b|\bEACCES\b|\bENOENT\b/i.test(text);
+        /^(Error|TypeError|ReferenceError|SyntaxError|RangeError|Uncaught|panic:)/i.test(
+          text,
+        ) ||
+        /\bthrow\s+new\s|\bCannot\s+find\s+(module|package)\b|\bEACCES\b|\bENOENT\b/i.test(
+          text,
+        );
       // Routine extension feedback (size-guard rejections, etc.) goes to bridge
       // logs only — surfacing it to chat would spam the feed when an extension
       // misbehaves on a setInterval.
@@ -344,9 +375,15 @@ export function useOsEdges(ctx: UseOsEdgesContext): void {
           if (activeId) closeTab(activeId);
           break;
         }
-        case "next_tab": nextTab(1); break;
-        case "prev_tab": nextTab(-1); break;
-        case "toggle_terminal": toggleTerminal(); break;
+        case "next_tab":
+          nextTab(1);
+          break;
+        case "prev_tab":
+          nextTab(-1);
+          break;
+        case "toggle_terminal":
+          toggleTerminal();
+          break;
         case "toggle_files": {
           // Forward to the FileTreePanel's hidden window event so the
           // panel toggles regardless of which surface (menu, sidebar
@@ -354,10 +391,18 @@ export function useOsEdges(ctx: UseOsEdgesContext): void {
           window.dispatchEvent(new Event("aethon:toggle-file-tree"));
           break;
         }
-        case "toggle_files_sidebar": toggleFilesSidebar(); break;
-        case "manage_extensions": openSettings("extensions"); break;
-        case "clear_chat": clearChat(); break;
-        case "stop_prompt": void stopPrompt(); break;
+        case "toggle_files_sidebar":
+          toggleFilesSidebar();
+          break;
+        case "manage_extensions":
+          openSettings("extensions");
+          break;
+        case "clear_chat":
+          clearChat();
+          break;
+        case "stop_prompt":
+          void stopPrompt();
+          break;
         case "check_updates": {
           checkForUpdates().catch((err) => {
             appendSystem(`Update check failed: ${err}`);
@@ -395,16 +440,12 @@ export function useOsEdges(ctx: UseOsEdgesContext): void {
     // drop directly onto the panel they want to receive the path.
     const dragDropDisposer = (async () => {
       try {
-        const { getCurrentWebview } = await import(
-          "@tauri-apps/api/webview"
-        );
+        const { getCurrentWebview } = await import("@tauri-apps/api/webview");
         return await getCurrentWebview().onDragDropEvent((evt) => {
           if (evt.payload.type !== "drop") return;
           const paths = evt.payload.paths ?? [];
           if (paths.length === 0) return;
-          const activeId = stateRef.current.activeTabId as
-            | string
-            | undefined;
+          const activeId = stateRef.current.activeTabId as string | undefined;
           if (!activeId) return;
           const tabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
           const tab = tabs.find((t) => t.id === activeId);
@@ -425,9 +466,10 @@ export function useOsEdges(ctx: UseOsEdgesContext): void {
             const elem = document.elementFromPoint(cssX, cssY);
             const inPanel = elem?.closest(".ae-terminal-panel") ?? null;
             if (inPanel) {
-              const tp = (stateRef.current.terminalPanel as
-                | { activeSubId?: string }
-                | undefined) ?? {};
+              const tp =
+                (stateRef.current.terminalPanel as
+                  | { activeSubId?: string }
+                  | undefined) ?? {};
               const subId = tp.activeSubId;
               if (subId && subId !== "agent-bash") {
                 const subTab = tabs.find((t) => t.id === subId);
@@ -528,8 +570,9 @@ export function useOsEdges(ctx: UseOsEdgesContext): void {
         // tokens are orphaned — better than appending to an unrelated
         // tab. The pasted file remains in ~/.aethon/pastes/ for manual
         // recovery.
-        const stillExists = (stateRef.current.tabs as Tab[] | undefined)
-          ?.some((t) => t.id === targetId);
+        const stillExists = (stateRef.current.tabs as Tab[] | undefined)?.some(
+          (t) => t.id === targetId,
+        );
         if (!stillExists) return;
         updateTab(targetId, (t) => ({
           ...t,


### PR DESCRIPTION
## Summary

- Replace the single Tauri-managed agent child with a process table so non-default tabs get dedicated worker bridge processes.
- Add worker-mode bridge boot behavior so tab workers do not emit global ready snapshots while still preserving tab-scoped sessions, cwd, and selected model.
- Route mutation acknowledgements back to the bridge process that emitted them, and scope tab-worker crashes to the affected tab instead of clearing every running agent.
- Update extension reload/install cleanup to drain or kill all active bridge workers intentionally.

## Root Cause

All tab-scoped messages previously shared one Bun/pi bridge process behind `AgentProcess(Mutex<Option<Child>>)`. Even though events carried `tabId`, any long-running turn, blocked bridge, or pi-side serialization could make the focused/active agent effectively gate the others.

## Validation

- `bunx tsc --noEmit`
- `bunx vitest run` (140 files, 1057 tests)
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib` (133 tests)
- `git diff --check`

Runtime dev-webview verification was skipped because no `~/.aethon/dev-info.json` was present, and the debug workflow intentionally avoids targeting an installed/release app.