### PR TITLE
fix(sessions): keep worktree sessions resumable

### DIFF
--- a/src/hooks/bridgeMessageHandlers/ready.test.ts
+++ b/src/hooks/bridgeMessageHandlers/ready.test.ts
@@ -317,6 +317,55 @@ describe("handleReady", () => {
     expect(second.mocks.autoRestoreDiscoveredSessions).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps discovered sessions resumable when the bridge knows a tab the UI lost", () => {
+    const { ctx, mocks, applySetState } = buildHandlerFixture({
+      state: { activeTabId: undefined, tabs: [], sidebar: {} },
+    });
+    const discovered = [
+      {
+        tabId: "lost-tab",
+        lastModified: 1710000000000,
+        cwd: "/repo/aethon-fix",
+      },
+    ];
+    mocks.knownTabIds.mockImplementation((extraTabs?: { id: string }[]) => {
+      const ids = new Set<string>(["default"]);
+      for (const tab of extraTabs ?? []) ids.add(tab.id);
+      return ids;
+    });
+    mocks.recentSessionItems.mockReturnValue([
+      {
+        id: "lost-tab",
+        label: "Lost but resumable",
+        lastModified: "2m ago",
+        cwd: "/repo/aethon-fix",
+      },
+    ]);
+
+    handleReady(
+      {
+        type: "ready",
+        model: "claude",
+        models: [],
+        discoveredTabs: discovered,
+        tabs: [{ id: "lost-tab", model: "claude", cwd: "/repo/aethon-fix" }],
+      },
+      ctx,
+    );
+
+    expect(mocks.knownTabIds).toHaveBeenNthCalledWith(1);
+    expect(mocks.knownTabIds).toHaveBeenNthCalledWith(2, [
+      { id: "lost-tab", model: "claude", cwd: "/repo/aethon-fix" },
+    ]);
+    expect(mocks.recentSessionItems).toHaveBeenCalledWith(
+      discovered,
+      new Set(["default"]),
+    );
+    expect(applySetState().recentSessions).toEqual([
+      expect.objectContaining({ id: "lost-tab" }),
+    ]);
+  });
+
   it("re-announces the active project after a respawn", () => {
     const { ctx, mocks } = buildHandlerFixture({
       state: { activeTabId: "default", tabs: [] },

--- a/src/hooks/bridgeMessageHandlers/ready.ts
+++ b/src/hooks/bridgeMessageHandlers/ready.ts
@@ -214,13 +214,14 @@ export const handleReady: BridgeMessageHandler = (data, ctx) => {
   // records for so the same session isn't listed twice (open AND
   // restorable). Format the lastModified into a "10m ago"-style label
   // for the row's right-hand meta.
-  const knownIds = ctx.knownTabIds(
+  const localKnownIds = ctx.knownTabIds();
+  const bridgeKnownIds = ctx.knownTabIds(
     (data.tabs as { id: string }[] | undefined) ?? [],
   );
   const scopedDiscTabs = ctx.scopedDiscoveredSessions(discTabs);
-  const recentSessions = ctx.recentSessionItems(scopedDiscTabs, knownIds);
+  const recentSessions = ctx.recentSessionItems(scopedDiscTabs, localKnownIds);
   if (ctx.projectsLoadedRef.current) {
-    ctx.autoRestoreDiscoveredSessions(scopedDiscTabs, knownIds);
+    ctx.autoRestoreDiscoveredSessions(scopedDiscTabs, bridgeKnownIds);
   }
   // Restore any extension-supplied layout, then replay queued patches.
   // Falls back to the boot layout when none is reported so a removed /

--- a/src/skills/default-layout/layout.tsx
+++ b/src/skills/default-layout/layout.tsx
@@ -19,6 +19,7 @@ import {
 import type { BuiltinComponentProps } from "../../components/A2UIRenderer";
 import type { BooleanValue, NumberValue, StringValue } from "../../types/a2ui";
 import type { CSSProperties } from "react";
+import { DashboardSessionRow } from "./dashboard/session-row";
 
 // GhBranchStatus / GhPr types come from ../../ghBranchStatusCache so
 // the layout module doesn't re-declare the wire shape. The cache
@@ -498,6 +499,7 @@ export function WorktreeLanding({
 }: BuiltinComponentProps) {
   const props = component.props as {
     landing?: { $ref: string };
+    recentSessions?: { $ref: string } | WorktreeLandingSession[];
   };
   const landing = (() => {
     if (!props.landing) return null;
@@ -516,6 +518,22 @@ export function WorktreeLanding({
   })();
   if (!landing || landing.kind !== "worktree") return null;
 
+  const recentSessions = (() => {
+    const raw = props.recentSessions;
+    if (!raw) return [];
+    const resolved = Array.isArray(raw)
+      ? raw
+      : resolvePointer(state, raw.$ref);
+    if (!Array.isArray(resolved)) return [];
+    const landingPath = normalizeLandingPath(landing.path);
+    return (resolved as WorktreeLandingSession[])
+      .filter((session) => {
+        if (!landingPath) return true;
+        return normalizeLandingPath(session.cwd) === landingPath;
+      })
+      .slice(0, 8);
+  })();
+
   const title = landing.worktreeLabel ?? landing.branch ?? "worktree";
   const projectLabel = landing.projectLabel ?? "";
   const branch = landing.branch ?? "";
@@ -531,9 +549,21 @@ export function WorktreeLanding({
       isMain={isMain}
       worktreeId={landing.worktreeId ?? null}
       projectId={landing.projectId ?? null}
+      recentSessions={recentSessions}
       onEvent={onEvent}
     />
   );
+}
+
+interface WorktreeLandingSession {
+  id: string;
+  label: string;
+  lastModified?: string;
+  cwd?: string;
+}
+
+function normalizeLandingPath(path?: string): string {
+  return (path ?? "").replace(/[/\\]+$/, "");
 }
 
 function WorktreeLandingInner(props: {
@@ -544,13 +574,24 @@ function WorktreeLandingInner(props: {
   isMain: boolean;
   worktreeId: string | null;
   projectId: string | null;
+  recentSessions: WorktreeLandingSession[];
   onEvent: (
     name: string,
     data?: Record<string, unknown>,
     descendantId?: string,
   ) => void;
 }) {
-  const { title, projectLabel, branch, path, isMain, worktreeId, projectId, onEvent } = props;
+  const {
+    title,
+    projectLabel,
+    branch,
+    path,
+    isMain,
+    worktreeId,
+    projectId,
+    recentSessions,
+    onEvent,
+  } = props;
   const [gh, setGh] = useState<GhBranchStatus | null>(null);
   const [ghLoading, setGhLoading] = useState(false);
 
@@ -635,6 +676,42 @@ function WorktreeLandingInner(props: {
             Open in Files
           </button>
         </div>
+        {recentSessions.length > 0 && (
+          <div className="a2ui-worktree-landing-sessions">
+            <h2>Recent sessions</h2>
+            <ul className="a2ui-worktree-landing-session-list">
+              {recentSessions.map((session) => (
+                <DashboardSessionRow
+                  key={session.id}
+                  session={session}
+                  classPrefix="a2ui-worktree-landing"
+                  onRestore={() =>
+                    onEvent(
+                      "restore-session",
+                      {
+                        sessionId: session.id,
+                        label: session.label,
+                        cwd: session.cwd,
+                      },
+                      session.id,
+                    )
+                  }
+                  onDelete={() =>
+                    onEvent(
+                      "delete-session",
+                      {
+                        sessionId: session.id,
+                        label: session.label,
+                        confirmed: true,
+                      },
+                      session.id,
+                    )
+                  }
+                />
+              ))}
+            </ul>
+          </div>
+        )}
         {/* Branch status via `gh` CLI. Silently absent when gh isn't
             installed/authed or the repo has no GitHub remote — the
             block just renders nothing (or "Not on GitHub" when we

--- a/src/skills/default-layout/workstation.a2ui.json
+++ b/src/skills/default-layout/workstation.a2ui.json
@@ -167,7 +167,8 @@
           "props": {
             "area": "canvas",
             "visible": { "$ref": "/landingVisible" },
-            "landing": { "$ref": "/landing" }
+            "landing": { "$ref": "/landing" },
+            "recentSessions": { "$ref": "/recentSessions" }
           }
         },
         {

--- a/src/skills/default-layout/worktree-landing.test.tsx
+++ b/src/skills/default-layout/worktree-landing.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { WorktreeLanding } from "./layout";
+import type { A2UIComponent } from "../../types/a2ui";
+
+vi.mock("../../ghBranchStatusCache", () => ({
+  getGhBranchStatus: vi.fn(() => Promise.resolve(null)),
+}));
+
+afterEach(() => cleanup());
+
+function worktreeLanding(props: Record<string, unknown>): A2UIComponent {
+  return {
+    id: "worktree-landing",
+    type: "worktree-landing",
+    props,
+  };
+}
+
+describe("WorktreeLanding sessions", () => {
+  it("lists resumable sessions for the selected worktree", () => {
+    const onEvent = vi.fn();
+    render(
+      <WorktreeLanding
+        component={worktreeLanding({
+          landing: { $ref: "/landing" },
+          recentSessions: { $ref: "/recentSessions" },
+        })}
+        state={{
+          landing: {
+            kind: "worktree",
+            projectId: "p1",
+            projectLabel: "aethon",
+            worktreeId: "wt-1",
+            worktreeLabel: "fix/session-restore",
+            branch: "fix/session-restore",
+            path: "/repo/aethon-fix",
+          },
+          recentSessions: [
+            {
+              id: "session-wt",
+              label: "Continue the fix",
+              lastModified: "5m ago",
+              cwd: "/repo/aethon-fix/",
+            },
+            {
+              id: "session-main",
+              label: "Main branch work",
+              lastModified: "1h ago",
+              cwd: "/repo/aethon",
+            },
+          ],
+        }}
+        onEvent={onEvent}
+      />,
+    );
+
+    expect(screen.getByText("Recent sessions")).toBeTruthy();
+    expect(screen.getByText("Continue the fix")).toBeTruthy();
+    expect(screen.queryByText("Main branch work")).toBeNull();
+
+    fireEvent.click(screen.getByText("Continue the fix"));
+    expect(onEvent).toHaveBeenCalledWith(
+      "restore-session",
+      {
+        sessionId: "session-wt",
+        label: "Continue the fix",
+        cwd: "/repo/aethon-fix/",
+      },
+      "session-wt",
+    );
+  });
+});

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -1679,20 +1679,91 @@ body.ae-resizing-sidebar .a2ui-layout {
   justify-content: center;
 }
 
-.a2ui-worktree-landing-gh {
+.a2ui-worktree-landing-gh,
+.a2ui-worktree-landing-sessions {
   width: 100%;
   text-align: left;
   border-top: 1px solid var(--border);
   padding-top: var(--space-4);
   margin-top: var(--space-4);
 }
-.a2ui-worktree-landing-gh h2 {
+.a2ui-worktree-landing-gh h2,
+.a2ui-worktree-landing-sessions h2 {
   margin: 0 0 var(--space-2) 0;
   font-size: var(--text-sm);
   font-weight: 600;
   color: var(--text-dim);
   text-transform: uppercase;
   letter-spacing: 0.04em;
+}
+.a2ui-worktree-landing-session-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+.a2ui-worktree-landing-session-list li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background var(--motion-fast) ease;
+}
+.a2ui-worktree-landing-session-list li:hover,
+.a2ui-worktree-landing-session-list li.is-confirming {
+  background: var(--bg-hover);
+}
+.a2ui-worktree-landing-session-list li.is-confirming {
+  cursor: default;
+}
+.a2ui-worktree-landing-session-label {
+  font-size: var(--text-md);
+  color: var(--text);
+  flex: 1 1 auto;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.a2ui-worktree-landing-session-meta {
+  font-size: var(--chrome-text-muted);
+  color: var(--text-dim);
+  flex-shrink: 0;
+}
+.a2ui-worktree-landing-session-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex: 0 0 auto;
+  min-width: max-content;
+}
+.a2ui-worktree-landing-session-delete {
+  display: inline-grid;
+  place-items: center;
+  width: 24px;
+  height: 24px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-dim);
+  cursor: pointer;
+  transition:
+    background var(--motion-fast) var(--ease-out),
+    border-color var(--motion-fast) var(--ease-out),
+    color var(--motion-fast) var(--ease-out);
+}
+.a2ui-worktree-landing-session-delete:hover {
+  background: color-mix(in oklab, var(--error) 10%, transparent);
+  border-color: color-mix(in oklab, var(--error) 26%, var(--border));
+  color: var(--error);
+}
+.a2ui-worktree-landing-session-delete:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
 }
 .a2ui-worktree-landing-gh-list {
   list-style: none;


### PR DESCRIPTION
## Summary
- show resumable session rows directly on the worktree landing, scoped to the selected worktree cwd
- keep discovered sessions visible for restore when the bridge still reports a tab that the React UI bucket lost
- add regression coverage for worktree session listing and the ready-path restore filter

## Root Cause
The session transcripts were still present on disk, but the worktree landing never consumed `/recentSessions`, so an empty worktree page only offered “Start Session” instead of existing sessions to resume. Separately, `ready` built the recent-session filter from local UI tabs plus bridge tabs; after a reload, a bridge-known tab could be filtered out even when the UI had no visible local tab for it.

## Validation
- `bunx vitest run src/hooks/bridgeMessageHandlers/ready.test.ts src/skills/default-layout/worktree-landing.test.tsx src/hooks/useProjectOps.test.ts src/eventRoutes/sidebar.test.ts`
- `bunx vitest run`
- `bun run typecheck`
- `bun run lint` (passes with existing React Hooks warnings)
- `bun run build`
- `git diff --check`
