### PR TITLE
fix(chat): open message links externally

### DIFF
--- a/src/skills/default-layout/chat.test.tsx
+++ b/src/skills/default-layout/chat.test.tsx
@@ -2,6 +2,18 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ChatHistory, ChatInput, QueuedMessagesPopover, ToolCard } from "./chat";
+
+const { openUrl } = vi.hoisted(() => ({
+  openUrl: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-opener", () => ({
+  openUrl: (...args: unknown[]) => openUrl(...args),
+}));
+
+vi.mock("../../components/HighlightedCode", () => ({
+  HighlightedCode: ({ code }: { code: string }) => code,
+}));
 import { SkillRegistry } from "../../skills/SkillRegistry";
 import { SkillRegistryProvider } from "../../skills/registry";
 
@@ -13,6 +25,7 @@ class ResizeObserverMock {
 
 beforeEach(() => {
   vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+  openUrl.mockResolvedValue(undefined);
 });
 
 afterEach(() => {
@@ -242,5 +255,126 @@ describe("ChatInput", () => {
       messageId: "1",
       value: "again please",
     });
+  });
+
+  it("renders bare HTTP URLs as links in user, agent, and system bubbles", () => {
+    renderHistory({
+      messages: [
+        { id: "1", role: "user", text: "see https://example.com/user" },
+        { id: "2", role: "agent", text: "see https://example.com/agent" },
+        { id: "3", role: "system", text: "see https://example.com/system" },
+      ],
+    });
+
+    expect(
+      screen
+        .getByRole("link", { name: "https://example.com/user" })
+        .getAttribute("href"),
+    ).toBe("https://example.com/user");
+    expect(
+      screen
+        .getByRole("link", { name: "https://example.com/agent" })
+        .getAttribute("href"),
+    ).toBe("https://example.com/agent");
+    expect(
+      screen
+        .getByRole("link", { name: "https://example.com/system" })
+        .getAttribute("href"),
+    ).toBe("https://example.com/system");
+  });
+
+  it("opens bare and Markdown links through the external opener", () => {
+    renderHistory({
+      messages: [
+        {
+          id: "1",
+          role: "agent",
+          text: [
+            "Bare https://example.com/bare.",
+            "[Issue](https://github.com/utensils/aethon/issues/94)",
+          ].join(" "),
+        },
+      ],
+    });
+
+    fireEvent.click(screen.getByRole("link", { name: "https://example.com/bare" }));
+    fireEvent.click(screen.getByRole("link", { name: "Issue" }));
+
+    expect(openUrl).toHaveBeenCalledWith("https://example.com/bare");
+    expect(openUrl).toHaveBeenCalledWith(
+      "https://github.com/utensils/aethon/issues/94",
+    );
+  });
+
+  it("does not linkify URLs in inline code or fenced code blocks", () => {
+    renderHistory({
+      messages: [
+        {
+          id: "1",
+          role: "agent",
+          text: [
+            "`https://example.com/code`",
+            "",
+            "```text",
+            "https://example.com/block",
+            "```",
+            "",
+            "https://example.com/plain",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    const links = screen.getAllByRole("link");
+    expect(links).toHaveLength(1);
+    expect(links[0]?.textContent).toBe("https://example.com/plain");
+  });
+
+  it("does not render unsupported Markdown link schemes as anchors", () => {
+    renderHistory({
+      messages: [
+        {
+          id: "1",
+          role: "agent",
+          text: [
+            "[bad](javascript:alert(1))",
+            "[mail](mailto:a@example.com)",
+            "[ok](https://example.com/ok)",
+          ].join(" "),
+        },
+      ],
+    });
+
+    expect(screen.queryByRole("link", { name: "bad" })).toBeNull();
+    expect(screen.queryByRole("link", { name: "mail" })).toBeNull();
+    expect(screen.getByRole("link", { name: "ok" }).getAttribute("href")).toBe(
+      "https://example.com/ok",
+    );
+  });
+
+  it("linkifies text split around thinking blocks", () => {
+    renderHistory({
+      messages: [
+        {
+          id: "1",
+          role: "agent",
+          text: [
+            "before https://example.com/before",
+            "<thinking>check https://example.com/thinking</thinking>",
+            "after https://example.com/after",
+          ].join(" "),
+        },
+      ],
+    });
+
+    expect(
+      screen.getByRole("link", { name: "https://example.com/before" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("link", { name: "https://example.com/thinking" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("link", { name: "https://example.com/after" }),
+    ).toBeTruthy();
   });
 });

--- a/src/skills/default-layout/chat.test.tsx
+++ b/src/skills/default-layout/chat.test.tsx
@@ -297,13 +297,32 @@ describe("ChatInput", () => {
       ],
     });
 
-    fireEvent.click(screen.getByRole("link", { name: "https://example.com/bare" }));
+    fireEvent.click(
+      screen.getByRole("link", { name: "https://example.com/bare" }),
+    );
     fireEvent.click(screen.getByRole("link", { name: "Issue" }));
 
     expect(openUrl).toHaveBeenCalledWith("https://example.com/bare");
     expect(openUrl).toHaveBeenCalledWith(
       "https://github.com/utensils/aethon/issues/94",
     );
+  });
+
+  it("ignores synchronous opener failures from link clicks", () => {
+    openUrl.mockImplementationOnce(() => {
+      throw new Error("opener failed");
+    });
+    renderHistory({
+      messages: [
+        { id: "1", role: "agent", text: "https://example.com/fail" },
+      ],
+    });
+
+    expect(() =>
+      fireEvent.click(
+        screen.getByRole("link", { name: "https://example.com/fail" }),
+      ),
+    ).not.toThrow();
   });
 
   it("does not linkify URLs in inline code or fenced code blocks", () => {

--- a/src/skills/default-layout/chat.tsx
+++ b/src/skills/default-layout/chat.tsx
@@ -35,7 +35,10 @@ import type { BuiltinComponentProps } from "../../components/A2UIRenderer";
 import { useSkillRegistry } from "../../skills/SkillRegistry";
 import type { QueuedMessage } from "../../types/tab";
 import { useStickyScroll } from "../../utils/useStickyScroll";
-import { MARKDOWN_COMPONENTS } from "./markdown-adapter";
+import {
+  CHAT_MARKDOWN_COMPONENTS,
+  MARKDOWN_REMARK_PLUGINS,
+} from "./markdown-adapter";
 import { readUiScale } from "./layout";
 
 // ---------------------------------------------------------------------------
@@ -306,7 +309,10 @@ function ThinkingBlock({
     <details className="a2ui-thinking-block" open={!complete}>
       <summary>{label}</summary>
       <div className="a2ui-thinking-content a2ui-markdown">
-        <ReactMarkdown components={MARKDOWN_COMPONENTS}>
+        <ReactMarkdown
+          components={CHAT_MARKDOWN_COMPONENTS}
+          remarkPlugins={MARKDOWN_REMARK_PLUGINS}
+        >
           {children}
         </ReactMarkdown>
       </div>
@@ -327,7 +333,11 @@ function MarkdownWithThinking({ text }: { text: string }) {
           );
         }
         return (
-          <ReactMarkdown key={index} components={MARKDOWN_COMPONENTS}>
+          <ReactMarkdown
+            key={index}
+            components={CHAT_MARKDOWN_COMPONENTS}
+            remarkPlugins={MARKDOWN_REMARK_PLUGINS}
+          >
             {segment.content}
           </ReactMarkdown>
         );

--- a/src/skills/default-layout/markdown-adapter.tsx
+++ b/src/skills/default-layout/markdown-adapter.tsx
@@ -139,7 +139,11 @@ function remarkLinkBareUrls(): (tree: MarkdownNode) => void {
 }
 
 function openExternalUrl(url: string): void {
-  void Promise.resolve(openUrl(url)).catch(() => undefined);
+  try {
+    void openUrl(url).catch(() => undefined);
+  } catch {
+    // Opener errors are not actionable from chat rendering.
+  }
 }
 
 // eslint-disable-next-line react-refresh/only-export-components -- remark plugin list consumed by ReactMarkdown callers

--- a/src/skills/default-layout/markdown-adapter.tsx
+++ b/src/skills/default-layout/markdown-adapter.tsx
@@ -12,7 +12,140 @@
  * isn't `<pre><pre>...</pre></pre>` (invalid + double-padded).
  */
 
+import { openUrl } from "@tauri-apps/plugin-opener";
 import { HighlightedCode } from "../../components/HighlightedCode";
+
+interface MarkdownNode {
+  type?: string;
+  value?: string;
+  url?: string;
+  children?: MarkdownNode[];
+}
+
+type MarkdownRemarkPlugin = () => (tree: MarkdownNode) => void;
+
+const BARE_HTTP_URL_RE = /\bhttps?:\/\/[^\s<>"'`]+/gi;
+const TRAILING_PUNCTUATION = new Set([".", ",", "!", "?", ":", ";"]);
+const CLOSING_BRACKETS: Record<string, string> = {
+  ")": "(",
+  "]": "[",
+  "}": "{",
+};
+
+function countChar(value: string, char: string): number {
+  return [...value].filter((candidate) => candidate === char).length;
+}
+
+function splitTrailingUrlPunctuation(value: string): {
+  url: string;
+  trailing: string;
+} {
+  let url = value;
+  let trailing = "";
+
+  while (url.length > 0) {
+    const last = url.at(-1);
+    if (!last) break;
+
+    if (TRAILING_PUNCTUATION.has(last)) {
+      trailing = last + trailing;
+      url = url.slice(0, -1);
+      continue;
+    }
+
+    const opening = CLOSING_BRACKETS[last];
+    if (opening && countChar(url, last) > countChar(url, opening)) {
+      trailing = last + trailing;
+      url = url.slice(0, -1);
+      continue;
+    }
+
+    break;
+  }
+
+  return { url, trailing };
+}
+
+function safeHttpUrl(value: string | undefined): string | null {
+  if (!value) return null;
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    return url.href;
+  } catch {
+    return null;
+  }
+}
+
+function linkifyTextNode(node: MarkdownNode): MarkdownNode[] {
+  const value = node.value ?? "";
+  const replacements: MarkdownNode[] = [];
+  let lastIndex = 0;
+
+  BARE_HTTP_URL_RE.lastIndex = 0;
+  for (
+    let match = BARE_HTTP_URL_RE.exec(value);
+    match;
+    match = BARE_HTTP_URL_RE.exec(value)
+  ) {
+    const rawMatch = match[0];
+    const { url, trailing } = splitTrailingUrlPunctuation(rawMatch);
+    const safeUrl = safeHttpUrl(url);
+    if (!safeUrl) continue;
+
+    if (match.index > lastIndex) {
+      replacements.push({
+        type: "text",
+        value: value.slice(lastIndex, match.index),
+      });
+    }
+    replacements.push({
+      type: "link",
+      url: safeUrl,
+      children: [{ type: "text", value: url }],
+    });
+    if (trailing) {
+      replacements.push({ type: "text", value: trailing });
+    }
+    lastIndex = match.index + rawMatch.length;
+  }
+
+  if (replacements.length === 0) return [node];
+  if (lastIndex < value.length) {
+    replacements.push({ type: "text", value: value.slice(lastIndex) });
+  }
+  return replacements;
+}
+
+function linkifyBareUrls(node: MarkdownNode): void {
+  if (!node.children || node.type === "link" || node.type === "linkReference") {
+    return;
+  }
+
+  const nextChildren: MarkdownNode[] = [];
+  for (const child of node.children) {
+    if (child.type === "text") {
+      nextChildren.push(...linkifyTextNode(child));
+      continue;
+    }
+    linkifyBareUrls(child);
+    nextChildren.push(child);
+  }
+  node.children = nextChildren;
+}
+
+function remarkLinkBareUrls(): (tree: MarkdownNode) => void {
+  return (tree) => linkifyBareUrls(tree);
+}
+
+function openExternalUrl(url: string): void {
+  void Promise.resolve(openUrl(url)).catch(() => undefined);
+}
+
+// eslint-disable-next-line react-refresh/only-export-components -- remark plugin list consumed by ReactMarkdown callers
+export const MARKDOWN_REMARK_PLUGINS: MarkdownRemarkPlugin[] = [
+  remarkLinkBareUrls,
+];
 
 // eslint-disable-next-line react-refresh/only-export-components -- helper consumed by the markdown-adapter map below
 export function isHighlightedFenceChild(node: React.ReactNode): boolean {
@@ -49,6 +182,37 @@ export const MARKDOWN_COMPONENTS = {
     }
     return (
       <HighlightedFence code={text} language={langMatch[1]} />
+    );
+  },
+};
+
+// eslint-disable-next-line react-refresh/only-export-components -- chat-specific adapter map for react-markdown; not a component module
+export const CHAT_MARKDOWN_COMPONENTS = {
+  ...MARKDOWN_COMPONENTS,
+  a({
+    children,
+    href,
+    node,
+    ...rest
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { node?: unknown }) {
+    void node;
+    const safeHref = safeHttpUrl(href);
+    if (!safeHref) return <span>{children}</span>;
+
+    return (
+      <a
+        {...rest}
+        href={safeHref}
+        rel="noopener noreferrer"
+        target="_blank"
+        onClick={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          openExternalUrl(safeHref);
+        }}
+      >
+        {children}
+      </a>
     );
   },
 };


### PR DESCRIPTION
## Summary

Fixes #94 by making chat message URLs consistently render as clickable external links.

This PR updates the chat markdown path so:

- bare `http://` and `https://` URLs in chat text are converted into anchors
- existing Markdown links continue to render as anchors
- chat link clicks always call Tauri's opener plugin via `openUrl(...)`
- unsupported/unsafe schemes are rendered as non-link text instead of clickable anchors
- URLs inside inline code and fenced code blocks are not linkified
- thinking-block content uses the same chat link behavior as normal chat text

## Implementation details

- Added a small remark plugin in `markdown-adapter.tsx` that walks Markdown AST text nodes and linkifies bare HTTP(S) URLs.
  - It skips existing links/link references so Markdown links are not double-processed.
  - It naturally avoids inline code/code block nodes because only text nodes are transformed.
  - It trims common trailing sentence punctuation from bare URL matches.
- Added `CHAT_MARKDOWN_COMPONENTS`, a chat-specific markdown component map that extends the shared code/pre renderer with an `a` override.
  - The anchor override accepts only `http:` and `https:` URLs.
  - Clicks call `event.preventDefault()`/`stopPropagation()` and route to `openUrl(safeHref)`.
- Updated chat rendering for both normal text segments and thinking blocks to use the chat-specific components and bare URL remark plugin.
- Left the editor markdown preview on the existing shared `MARKDOWN_COMPONENTS` path so this change is scoped to chat behavior.

## Tests

Added chat renderer coverage for:

- bare HTTP(S) URLs becoming anchors in user, agent, and system bubbles
- bare and Markdown links opening via the mocked Tauri external opener
- URLs in inline code and fenced code blocks not being linkified
- unsupported Markdown link schemes (`javascript:`, `mailto:`) not rendering as anchors
- URL linkification across text split around thinking blocks

Validated locally:

- `nix develop -c bun run typecheck`
- `nix develop -c bun run test`
- `nix develop -c bun run lint`

Note: lint completes with 5 pre-existing `react-hooks/set-state-in-effect` warnings in unrelated files.
