### PR TITLE
fix(sessions): route worktree landing restores

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,31 @@ To run a single test file: `bunx vitest run agent/terminal-stream.test.ts`.
 To run tests matching a name: `bunx vitest run -t "test name pattern"`.
 To run a single Rust test: `cargo test --lib -p aethon -- helpers::test_name`.
 
+## Testing Discipline
+
+Treat bug fixes as TDD by default. Before changing implementation, write or
+tighten a regression test that fails for the reported behavior and proves the
+actual user-visible contract. Run that focused test and confirm it is red, then
+make the smallest fix that turns it green. Do not count a component-only test as
+coverage for an app workflow when the bug crosses component, route table, hook,
+bridge, or persisted-state boundaries; add the test at the layer where the
+contract actually broke, and keep lower-level tests only as supporting coverage.
+
+For UI/session/project/worktree bugs, regression tests must exercise the full
+state transition the user relies on: event dispatch, route handling, active
+project/worktree alignment, tab creation/selection, landing visibility, and any
+session-history restore flags. A test that only verifies a button emits an event
+is not enough if the app also needs to route that event and mutate state. When a
+fix changes a routed event or state mirror, include dispatcher/hook tests that
+would fail if the event fell through, the wrong cwd was selected, or stale UI
+state kept rendering over the restored surface.
+
+Every regression fix should end with the focused red-green test, the nearby test
+slice, and the relevant broader gate (`bunx vitest run`, `bun run typecheck`,
+`bun run lint`, `bun run build`, or `check` depending on blast radius). If a
+gate exits 0 with existing warnings, report those warnings clearly; do not treat
+new warnings as acceptable without addressing or justifying them.
+
 ## Architecture
 
 ### Layer responsibilities

--- a/src/eventRoutes/index.test.ts
+++ b/src/eventRoutes/index.test.ts
@@ -217,6 +217,76 @@ describe("dispatchEvent — chrome composites route by type, not id", () => {
     expect(mocks.newTab).toHaveBeenCalledTimes(1);
   });
 
+  it("worktree landing routes session restore rows through the built-in restore handler", async () => {
+    const { ctx, mocks, applySetState } = buildRouteFixture({
+      state: {
+        landing: {
+          kind: "worktree",
+          worktreeId: "wt-1",
+          path: "/repo/app-fix",
+        },
+        activeProjectId: "p1",
+        projects: [{ id: "p1", path: "/repo/app" }],
+        sidebar: {
+          projects: [
+            {
+              id: "p1",
+              worktrees: [{ id: "wt-1", path: "/repo/app-fix" }],
+            },
+          ],
+        },
+      },
+    });
+    const handled = await dispatchEvent(
+      {
+        component: { id: "worktree-landing", type: "worktree-landing" },
+        eventType: "restore-session",
+        data: {
+          sessionId: "session-1",
+          label: "Continue worktree fix",
+          cwd: "/repo/app-fix",
+        },
+      },
+      ctx,
+    );
+
+    expect(handled).toBe(true);
+    expect(mocks.activateWorktree).toHaveBeenCalledWith("wt-1");
+    expect(mocks.newTab).toHaveBeenCalledWith(
+      "session-1",
+      "Continue worktree fix",
+      {
+        restoredSession: true,
+        cwd: "/repo/app-fix",
+      },
+    );
+    expect(applySetState().landing).toBeNull();
+  });
+
+  it("worktree landing routes inline session delete confirmations", async () => {
+    const { ctx, mocks } = buildRouteFixture({ promptDeleteAllow: true });
+    const handled = await dispatchEvent(
+      {
+        component: { id: "worktree-landing", type: "worktree-landing" },
+        eventType: "delete-session",
+        data: {
+          sessionId: "session-1",
+          label: "Continue worktree fix",
+          confirmed: true,
+        },
+      },
+      ctx,
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(handled).toBe(true);
+    expect(mocks.promptDeleteSessionConfirmation).not.toHaveBeenCalled();
+    expect(mocks.invoke).toHaveBeenCalledWith("delete_session", {
+      tabId: "session-1",
+    });
+  });
+
   it("renamed model-picker instance still routes setModel", async () => {
     const { ctx, mocks } = buildRouteFixture();
     const handled = await dispatchEvent(

--- a/src/eventRoutes/index.ts
+++ b/src/eventRoutes/index.ts
@@ -96,10 +96,11 @@ export const BUILTIN_ROUTE_TABLE: ReadonlyMap<string, readonly EventRouteHandler
     ["type:main-canvas", [handleChatMessages]],
     ["type:queued-messages-popover", [handleQueuedMessages]],
     ["type:empty-state", [handleEmptyState]],
-    // Worktree landing — "Start Session" + "Open in Files" CTAs reuse
-    // the sidebar's worktree routes since the destination semantics
-    // are identical.
+    // Worktree landing — session rows share dashboard restore/delete
+    // semantics; Start Session + Open in Files reuse the sidebar's
+    // worktree routes since their destinations are identical.
     ["type:worktree-landing", [
+      handleProjectsDashboard,
       handleSidebarStartSession,
       handleSidebarOpenWorktreeInFinder,
     ]],

--- a/src/eventRoutes/sessionRestore.ts
+++ b/src/eventRoutes/sessionRestore.ts
@@ -83,6 +83,7 @@ export function restoreSessionFromSelection(
   ctx: EventRouteContext,
   selection: RestoreSelection | undefined,
 ): void {
+  ctx.setState((prev) => ({ ...prev, landing: null }));
   if (!selection?.sessionId) {
     ctx.newTab();
     return;


### PR DESCRIPTION
## Summary
- route `worktree-landing` `restore-session` and `delete-session` events through the existing session restore/delete handlers
- clear stale `/landing` state when restoring a session so the restored chat surface actually becomes visible
- document a stronger TDD/regression discipline in `AGENTS.md` for UI/session/worktree bugs

## Root Cause
The previous PR added the visible recent-session row on the worktree landing, but its test only proved the row emitted `restore-session`. The app route table did not handle that event for `type:worktree-landing`, so clicks fell through. After adding that route, a second regression showed the restored tab could still be hidden because the old worktree landing overlay stayed in `/landing`.

## TDD Evidence
- Added dispatcher-level regressions before implementation:
  - `worktree landing routes session restore rows through the built-in restore handler`
  - `worktree landing routes inline session delete confirmations`
- Confirmed the restore route test failed red before clearing stale `/landing`.
- Implemented the smallest route/state changes to make the tests pass.

## Validation
- `bunx vitest run src/eventRoutes/index.test.ts -t "worktree landing routes session restore"`
- `bunx vitest run src/eventRoutes/index.test.ts src/eventRoutes/dashboard.test.ts src/eventRoutes/sidebar.test.ts src/skills/default-layout/worktree-landing.test.tsx`
- `bunx vitest run`
- `bun run typecheck`
- `bun run lint` (passes with existing React Hooks warnings)
- `bun run build`
- `git diff --check`
