### PR TITLE
fix(dashboard): shorten issue worktree branches

### DIFF
--- a/src/skills/default-layout/dashboard/issue-task.ts
+++ b/src/skills/default-layout/dashboard/issue-task.ts
@@ -68,7 +68,11 @@ function compactIssueBranch(
   maxLength: number,
 ): string {
   if (branch.length <= maxLength) return branch;
-  const clipped = branch.slice(0, maxLength).replace(/-+$/g, "");
+  const rawClipped = branch.slice(0, maxLength);
+  const clipped = rawClipped.replace(/-+$/g, "");
+  if (rawClipped.length !== clipped.length || branch.charAt(maxLength) === "-") {
+    return clipped;
+  }
   const wordBoundary = clipped.lastIndexOf("-");
   if (wordBoundary > protectedLength) {
     return clipped.slice(0, wordBoundary).replace(/-+$/g, "");

--- a/src/skills/default-layout/dashboard/issue-task.ts
+++ b/src/skills/default-layout/dashboard/issue-task.ts
@@ -23,24 +23,57 @@ export function buildIssuePrompt(detail: {
   ].join("\n");
 }
 
+const MAX_ISSUE_BRANCH_LENGTH = 44;
+
 export function buildIssueBranch(
   issue: Pick<GhIssue, "number" | "title"> & Partial<Pick<GhIssue, "labels">>,
   existingBranches: ReadonlySet<string> = new Set(),
 ): string {
   const { prefix, title } = classifyIssueBranch(issue);
-  const slug = title
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .slice(0, 48)
-    .replace(/-+$/g, "");
-  const base = `${prefix}/issue-${issue.number}${slug ? `-${slug}` : ""}`;
+  const slug = slugifyIssueTitle(title);
+  const branchPrefix = `${prefix}/issue-${issue.number}`;
+  const base = compactIssueBranch(
+    `${branchPrefix}${slug ? `-${slug}` : ""}`,
+    branchPrefix.length,
+    MAX_ISSUE_BRANCH_LENGTH,
+  );
   if (!existingBranches.has(base)) return base;
   for (let i = 2; i < 100; i += 1) {
-    const candidate = `${base}-${i}`;
+    const suffix = `-${i}`;
+    const candidate = `${compactIssueBranch(
+      base,
+      branchPrefix.length,
+      MAX_ISSUE_BRANCH_LENGTH - suffix.length,
+    )}${suffix}`;
     if (!existingBranches.has(candidate)) return candidate;
   }
-  return `${base}-${Date.now()}`;
+  const suffix = `-${Date.now()}`;
+  return `${compactIssueBranch(
+    base,
+    branchPrefix.length,
+    MAX_ISSUE_BRANCH_LENGTH - suffix.length,
+  )}${suffix}`;
+}
+
+function slugifyIssueTitle(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function compactIssueBranch(
+  branch: string,
+  protectedLength: number,
+  maxLength: number,
+): string {
+  if (branch.length <= maxLength) return branch;
+  const clipped = branch.slice(0, maxLength).replace(/-+$/g, "");
+  const wordBoundary = clipped.lastIndexOf("-");
+  if (wordBoundary > protectedLength) {
+    return clipped.slice(0, wordBoundary).replace(/-+$/g, "");
+  }
+  return clipped;
 }
 
 function classifyIssueBranch(

--- a/src/skills/default-layout/dashboard/issues-section.test.ts
+++ b/src/skills/default-layout/dashboard/issues-section.test.ts
@@ -105,7 +105,22 @@ describe("issues-section task helpers", () => {
       labels: [{ name: "bug", color: null }],
     });
 
-    expect(branch).toBe("fix/issue-85-cannot-rename-session-tab");
+    expect(branch).toBe("fix/issue-85-cannot-rename-session-tab-while");
+    expect(branch.length).toBeLessThanOrEqual(44);
+  });
+
+  it("keeps collision suffixes within the branch length cap", () => {
+    const base = "fix/issue-85-cannot-rename-session-tab-while";
+    const branch = buildIssueBranch(
+      {
+        number: 85,
+        title: "Cannot rename session tab while agent is running",
+        labels: [{ name: "bug", color: null }],
+      },
+      new Set([base]),
+    );
+
+    expect(branch).toBe("fix/issue-85-cannot-rename-session-tab-2");
     expect(branch.length).toBeLessThanOrEqual(44);
   });
 

--- a/src/skills/default-layout/dashboard/issues-section.test.ts
+++ b/src/skills/default-layout/dashboard/issues-section.test.ts
@@ -98,6 +98,17 @@ describe("issues-section task helpers", () => {
     ).toBe("fix/issue-123-support-origin-main-defaults-3");
   });
 
+  it("caps generated issue branch length at a sidebar-friendly size", () => {
+    const branch = buildIssueBranch({
+      number: 85,
+      title: "Cannot rename session tab while agent is running",
+      labels: [{ name: "bug", color: null }],
+    });
+
+    expect(branch).toBe("fix/issue-85-cannot-rename-session-tab");
+    expect(branch.length).toBeLessThanOrEqual(44);
+  });
+
   it("uses conventional issue titles for branch type and slug", () => {
     expect(
       buildIssueBranch({
@@ -109,7 +120,7 @@ describe("issues-section task helpers", () => {
           { name: "low-priority", color: null },
         ],
       }),
-    ).toBe("feat/issue-213-admin-add-recreate-missing-materialized-views-to");
+    ).toBe("feat/issue-213-admin-add-recreate-missing");
   });
 
   it("falls back to labels when the title has no conventional type", () => {
@@ -119,7 +130,7 @@ describe("issues-section task helpers", () => {
         title: "ACRIS deed not showing on BBL view",
         labels: [{ name: "bug", color: null }],
       }),
-    ).toBe("fix/issue-99-acris-deed-not-showing-on-bbl-view");
+    ).toBe("fix/issue-99-acris-deed-not-showing-on-bbl");
 
     expect(
       buildIssueBranch({
@@ -127,7 +138,7 @@ describe("issues-section task helpers", () => {
         title: "Add dealflow pipeline management tools",
         labels: [{ name: "enhancement", color: null }],
       }),
-    ).toBe("feat/issue-180-add-dealflow-pipeline-management-tools");
+    ).toBe("feat/issue-180-add-dealflow-pipeline");
   });
 
   it("respects non-feature conventional types and labels", () => {


### PR DESCRIPTION
## Summary

- Cap autogenerated GitHub issue worktree branch names by total branch length instead of only capping the title slug segment.
- Keep issue branches readable by trimming at slug word boundaries, e.g. `fix/issue-85-cannot-rename-session-tab` instead of a long truncated sentence.
- Preserve existing collision handling by reserving room for numeric/date suffixes when generated branches already exist.

## Details

The previous branch builder limited only the title slug to 48 characters, then prepended `prefix/issue-<number>-`, producing branch/worktree names around 60+ characters for normal issue titles. Those names flow directly into the default worktree path and sidebar fallback label, making the worktree list noisy and aggressively truncated.

This change introduces a `MAX_ISSUE_BRANCH_LENGTH` cap of 44 characters for the whole generated branch. If a branch must be shortened, it clips at a word boundary after the protected `prefix/issue-<number>` segment. Collision suffixes (`-2`, `-3`, etc.) still work and are included within the cap.

## Testing

- `nix develop -c bunx eslint src/skills/default-layout/dashboard/issue-task.ts src/skills/default-layout/dashboard/issues-section.test.ts`
- `nix develop -c bunx vitest run src/skills/default-layout/dashboard src/eventRoutes/dashboard.test.ts`
- `nix develop -c bunx tsc -b --noEmit`

Closes #89
