### PR TITLE
fix(tool-card): cancel running bash cards on stop

### DIFF
--- a/agent/dispatcher.test.ts
+++ b/agent/dispatcher.test.ts
@@ -12,6 +12,7 @@ import {
   formatSessionStatsMessage,
   handleChat,
   handleSetModel,
+  handleStop,
   unloadProjectExtensions,
 } from "./dispatcher";
 
@@ -64,6 +65,61 @@ function fakeTabRecord(overrides: Partial<TabRecord> = {}): TabRecord {
     ...overrides,
   };
 }
+
+describe("handleStop", () => {
+  it("aborts bash and emits a terminal tool-card update for active tools", async () => {
+    const f = makeFixture();
+    const abort = vi.fn(() => Promise.resolve());
+    const abortBash = vi.fn();
+    const clearQueue = vi.fn();
+    const tab = fakeTabRecord({
+      queuedCount: 3,
+      session: {
+        abort,
+        abortBash,
+        clearQueue,
+      } as unknown as TabRecord["session"],
+      toolArgsCache: new Map([
+        [
+          "call-1",
+          {
+            name: "bash",
+            summary: "sleep 60",
+            uiId: "tool-1-call-1",
+            startedAt: 1_000,
+          },
+        ],
+      ]),
+    });
+    f.state.tabs.set("tab-1", tab);
+
+    handleStop(f.state, f.deps, { type: "stop", tabId: "tab-1" });
+    await Promise.resolve();
+
+    expect(clearQueue).toHaveBeenCalledOnce();
+    expect(abortBash).toHaveBeenCalledOnce();
+    expect(abort).toHaveBeenCalledOnce();
+    expect(tab.queuedCount).toBe(0);
+    expect(f.sent).toContainEqual({ type: "queue_reset", tabId: "tab-1" });
+    expect(f.sent.find((m) => m.type === "a2ui")).toMatchObject({
+      id: "tool-1-call-1",
+      payload: {
+        components: [
+          {
+            props: {
+              status: "cancelled",
+              startedAt: 1_000,
+              endedAt: expect.any(Number),
+            },
+          },
+        ],
+      },
+    });
+    expect(f.sent.find((m) => m.type === "terminal_output")).toMatchObject({
+      content: "\r\n[command cancelled]\r\n",
+    });
+  });
+});
 
 describe("handleChat", () => {
   it("queues normal messages while a prompt is in flight", async () => {

--- a/agent/dispatcher.ts
+++ b/agent/dispatcher.ts
@@ -32,6 +32,7 @@ import { ackMutation, markFrontendReady } from "./mutation-ack";
 import { dismissNotification, notify } from "./notifications";
 import { setState, makeCanvasApi } from "./state-mutation";
 import {
+  cancelRunningToolCards,
   emitReady,
   ensurePickerHasModel,
   ensureTab,
@@ -560,6 +561,44 @@ export async function handleSetModel(
   deps.send({ type: "model_changed", tabId, model: msg.id });
 }
 
+export function handleStop(
+  state: AethonAgentState,
+  deps: DispatcherDeps,
+  msg: InboundMessage,
+): void {
+  const tabId = msg.tabId ?? "default";
+  const tab = state.tabs.get(tabId);
+  if (!tab) return;
+  if (
+    typeof (tab.session as { clearQueue?: () => unknown }).clearQueue ===
+    "function"
+  ) {
+    try {
+      (tab.session as { clearQueue: () => unknown }).clearQueue();
+    } catch {
+      /* best effort */
+    }
+  }
+  tab.queuedCount = 0;
+  deps.send({ type: "queue_reset", tabId });
+  cancelRunningToolCards(deps, tab, tabId);
+  if (
+    typeof (tab.session as { abortBash?: () => unknown }).abortBash ===
+    "function"
+  ) {
+    try {
+      (tab.session as { abortBash: () => unknown }).abortBash();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      deps.send({ type: "error", tabId, message: `abort bash: ${message}` });
+    }
+  }
+  tab.session.abort().catch((err: unknown) => {
+    const message = err instanceof Error ? err.message : String(err);
+    deps.send({ type: "error", tabId, message: `abort: ${message}` });
+  });
+}
+
 /** Run the inbound dispatcher loop. Returns when stdin closes. */
 export async function runDispatcher(
   state: AethonAgentState,
@@ -733,32 +772,6 @@ export async function runDispatcher(
   }
 
   // ---- Per-message handlers -------------------------------------------
-
-  function handleStop(
-    state: AethonAgentState,
-    deps: DispatcherDeps,
-    msg: InboundMessage,
-  ): void {
-    const tabId = msg.tabId ?? "default";
-    const tab = state.tabs.get(tabId);
-    if (!tab) return;
-    if (
-      typeof (tab.session as { clearQueue?: () => unknown }).clearQueue ===
-      "function"
-    ) {
-      try {
-        (tab.session as { clearQueue: () => unknown }).clearQueue();
-      } catch {
-        /* best effort */
-      }
-    }
-    tab.queuedCount = 0;
-    deps.send({ type: "queue_reset", tabId });
-    tab.session.abort().catch((err: unknown) => {
-      const message = err instanceof Error ? err.message : String(err);
-      deps.send({ type: "error", tabId, message: `abort: ${message}` });
-    });
-  }
 
   async function handleNativeSlashCommand(
     state: AethonAgentState,

--- a/agent/state.ts
+++ b/agent/state.ts
@@ -223,6 +223,10 @@ export interface TabRecord {
       /** Epoch ms — when tool_execution_start fired. Used by the M6 P4
        *  `tool-card` component to render a live elapsed-time clock. */
       startedAt?: number;
+      /** Epoch ms — when Aethon synthesized a terminal state before pi
+       *  emitted tool_execution_end (e.g. user pressed Stop). */
+      endedAt?: number;
+      status?: "cancelled";
     }
   >;
   promptInFlight: boolean;

--- a/agent/tab-lifecycle.test.ts
+++ b/agent/tab-lifecycle.test.ts
@@ -5,6 +5,7 @@ import {
   type TabRecord,
 } from "./state";
 import {
+  cancelRunningToolCards,
   compilePattern,
   collectPiSlashCommands,
   emitReady,
@@ -204,6 +205,31 @@ describe("toolCardPayload", () => {
     const root = payload.components[0] as { children: unknown[] };
     const code = root.children[0] as { props: { language: string } };
     expect(code.props.language).toBe("tsx");
+  });
+
+  it("marks cancelled cards as a terminal state", () => {
+    const payload = toolCardPayload({
+      id: "tool-c1",
+      toolName: "bash",
+      argsSummary: "sleep 60",
+      result: "Cancelled by user.",
+      status: "cancelled",
+      startedAt: 1_000,
+      endedAt: 2_500,
+    });
+
+    expect(payload).toMatchObject({
+      components: [
+        {
+          id: "tool-c1",
+          props: {
+            status: "cancelled",
+            startedAt: 1_000,
+            endedAt: 2_500,
+          },
+        },
+      ],
+    });
   });
 
   it("appends image children with data: URLs", () => {
@@ -488,6 +514,82 @@ describe("handleSessionEvent", () => {
 
     const ids = f.sent.filter((m) => m.type === "a2ui").map((m) => m.id);
     expect(ids).toEqual(["tool-1-c1", "tool-1-c1", "tool-2-c1"]);
+  });
+
+  it("cancelRunningToolCards freezes active tool-card timers", () => {
+    const f = makeFixture();
+    const rec = fakeRec();
+    rec.toolArgsCache.set("c1", {
+      name: "bash",
+      summary: "sleep 60",
+      uiId: "tool-1-c1",
+      startedAt: 1_000,
+    });
+
+    const count = cancelRunningToolCards(f.deps, rec, "tab-1");
+
+    expect(count).toBe(1);
+    expect(rec.toolArgsCache.get("c1")).toMatchObject({
+      status: "cancelled",
+      endedAt: expect.any(Number),
+    });
+    const a2uiMsg = f.sent.find((m) => m.type === "a2ui");
+    expect(a2uiMsg).toMatchObject({
+      id: "tool-1-c1",
+      payload: {
+        components: [
+          {
+            id: "tool-1-c1",
+            props: {
+              status: "cancelled",
+              startedAt: 1_000,
+              endedAt: expect.any(Number),
+            },
+          },
+        ],
+      },
+    });
+    expect(f.sent.find((m) => m.type === "terminal_output")).toMatchObject({
+      content: "\r\n[command cancelled]\r\n",
+    });
+  });
+
+  it("tool_execution_end updates a cancelled synthetic card by id", () => {
+    const f = makeFixture();
+    const rec = fakeRec();
+    rec.toolArgsCache.set("c1", {
+      name: "bash",
+      summary: "sleep 60",
+      uiId: "tool-1-c1",
+      startedAt: 1_000,
+    });
+    cancelRunningToolCards(f.deps, rec, "tab-1");
+    const endedAt = rec.toolArgsCache.get("c1")?.endedAt;
+
+    handleSessionEvent(f.state, f.deps, rec, "tab-1", {
+      type: "tool_execution_end",
+      toolCallId: "c1",
+      toolName: "bash",
+      result: "Command aborted",
+      isError: true,
+    });
+
+    const a2uiMessages = f.sent.filter((m) => m.type === "a2ui");
+    expect(a2uiMessages.map((m) => m.id)).toEqual(["tool-1-c1", "tool-1-c1"]);
+    expect(a2uiMessages.at(-1)).toMatchObject({
+      payload: {
+        components: [
+          {
+            props: {
+              status: "cancelled",
+              isError: true,
+              endedAt,
+            },
+          },
+        ],
+      },
+    });
+    expect(rec.toolArgsCache.has("c1")).toBe(false);
   });
 
   it("agent_end clears promptInFlight, sets agentEndFired, emits response_end", () => {

--- a/agent/tab-lifecycle.ts
+++ b/agent/tab-lifecycle.ts
@@ -112,6 +112,47 @@ export function emitBashResult(
   }
 }
 
+/** Stop visible timers for tools that were in-flight when the user aborted.
+ *  Pi normally emits tool_execution_end, but abort paths can terminate the
+ *  turn before that event reaches us. Re-emitting the same tool-card id with
+ *  endedAt freezes the frontend clock immediately; if pi later sends the real
+ *  end event, that result updates the same card instead of duplicating it. */
+export function cancelRunningToolCards(
+  deps: TabLifecycleDeps,
+  rec: TabRecord,
+  tabId: string,
+): number {
+  const endedAt = Date.now();
+  let count = 0;
+  for (const [toolCallId, cached] of rec.toolArgsCache) {
+    if (cached.startedAt === undefined || cached.endedAt !== undefined) {
+      continue;
+    }
+    cached.endedAt = endedAt;
+    cached.status = "cancelled";
+    count += 1;
+    const payload = toolCardPayload({
+      id: cached.uiId,
+      toolName: cached.name,
+      argsSummary: cached.summary,
+      result: "Cancelled by user.",
+      status: "cancelled",
+      startedAt: cached.startedAt,
+      endedAt,
+    });
+    deps.send({ type: "a2ui", tabId, id: cached.uiId, payload });
+    if (cached.name === "bash") {
+      deps.send({
+        type: "terminal_output",
+        tabId,
+        content: "\r\n[command cancelled]\r\n",
+      });
+    }
+    turnLog.debug(`cancelled running tool-card ${toolCallId} tabId=${tabId}`);
+  }
+  return count;
+}
+
 /** Filter the picker to the user's enabledModels patterns from
  *  ~/.pi/agent/settings.json. Always include the current model. */
 export function buildPickerModels(
@@ -593,8 +634,12 @@ function handleSessionEvent(
         argsSummary: cached?.summary ?? "",
         result: ev.result,
         isError: ev.isError,
+        ...(cached?.status !== undefined ? { status: cached.status } : {}),
         ...(cached?.startedAt !== undefined
-          ? { startedAt: cached.startedAt, endedAt: Date.now() }
+          ? {
+              startedAt: cached.startedAt,
+              endedAt: cached.endedAt ?? Date.now(),
+            }
           : {}),
       });
       deps.send({ type: "a2ui", tabId, id: uiId, payload });
@@ -633,6 +678,9 @@ function handleSessionEvent(
         turnLog.warn(log);
       } else {
         turnLog.info(log);
+      }
+      for (const [toolCallId, cached] of rec.toolArgsCache) {
+        if (cached.endedAt !== undefined) rec.toolArgsCache.delete(toolCallId);
       }
       rec.agentEndFired = true;
       rec.promptInFlight = false;

--- a/agent/tool-card.ts
+++ b/agent/tool-card.ts
@@ -174,11 +174,20 @@ export function toolCardPayload(opts: {
   argsSummary: string;
   result?: unknown;
   isError?: boolean;
+  status?: "cancelled";
   startedAt?: number;
   endedAt?: number;
 }) {
-  const { id, toolName, argsSummary, result, isError, startedAt, endedAt } =
-    opts;
+  const {
+    id,
+    toolName,
+    argsSummary,
+    result,
+    isError,
+    status,
+    startedAt,
+    endedAt,
+  } = opts;
   const children: unknown[] = [];
   if (result !== undefined) {
     const extracted = extractToolContent(result);
@@ -219,6 +228,7 @@ export function toolCardPayload(opts: {
           ...(startedAt !== undefined ? { startedAt } : {}),
           ...(endedAt !== undefined ? { endedAt } : {}),
           ...(isError ? { isError: true } : {}),
+          ...(status !== undefined ? { status } : {}),
         },
         children,
       },

--- a/src/skills/default-layout/chat.test.tsx
+++ b/src/skills/default-layout/chat.test.tsx
@@ -16,6 +16,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   cleanup();
   vi.unstubAllGlobals();
 });
@@ -102,7 +103,6 @@ describe("ToolCard", () => {
     vi.advanceTimersByTime(1_000);
 
     expect(screen.getByText("Cancelled in 2.0s")).toBeTruthy();
-    vi.useRealTimers();
   });
 
   it("renders completed and failed terminal states with stable durations", () => {

--- a/src/skills/default-layout/chat.test.tsx
+++ b/src/skills/default-layout/chat.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { ChatHistory, ChatInput, QueuedMessagesPopover } from "./chat";
+import { ChatHistory, ChatInput, QueuedMessagesPopover, ToolCard } from "./chat";
 import { SkillRegistry } from "../../skills/SkillRegistry";
 import { SkillRegistryProvider } from "../../skills/registry";
 
@@ -71,6 +71,66 @@ function renderHistory(state: Record<string, unknown>) {
   );
   return { onEvent };
 }
+
+function renderToolCard(props: Record<string, unknown>) {
+  return render(
+    <ToolCard
+      component={{
+        id: "tool-1",
+        type: "tool-card",
+        props: { title: "bash", description: "sleep 60", ...props },
+      }}
+      state={{}}
+      onEvent={vi.fn()}
+      renderChildren={() => <div>output</div>}
+    />,
+  );
+}
+
+describe("ToolCard", () => {
+  it("shows a cancelled terminal state and freezes elapsed time", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(10_000);
+
+    renderToolCard({ startedAt: 1_000, endedAt: 3_000, status: "cancelled" });
+
+    expect(screen.getByText("Cancelled in 2.0s")).toBeTruthy();
+    expect(screen.queryByText(/long-running/)).toBeNull();
+    expect(screen.getByLabelText("Tool cancelled")).toBeTruthy();
+
+    vi.setSystemTime(30_000);
+    vi.advanceTimersByTime(1_000);
+
+    expect(screen.getByText("Cancelled in 2.0s")).toBeTruthy();
+    vi.useRealTimers();
+  });
+
+  it("renders completed and failed terminal states with stable durations", () => {
+    const { rerender } = renderToolCard({ startedAt: 1_000, endedAt: 2_500 });
+    expect(screen.getByText("Completed in 1.5s")).toBeTruthy();
+
+    rerender(
+      <ToolCard
+        component={{
+          id: "tool-1",
+          type: "tool-card",
+          props: {
+            title: "bash",
+            description: "sleep 60",
+            startedAt: 1_000,
+            endedAt: 2_500,
+            isError: true,
+          },
+        }}
+        state={{}}
+        onEvent={vi.fn()}
+        renderChildren={() => <div>output</div>}
+      />,
+    );
+    expect(screen.getByText("Failed in 1.5s")).toBeTruthy();
+    expect(screen.getByLabelText("Tool failed")).toBeTruthy();
+  });
+});
 
 describe("ChatInput", () => {
   it("submits bare Enter as a normal queued-capable message", () => {

--- a/src/skills/default-layout/chat.tsx
+++ b/src/skills/default-layout/chat.tsx
@@ -71,10 +71,12 @@ export function formatToolDuration(ms: number): string {
 function ToolStatusIcon({
   running,
   isError,
+  isCancelled,
   isLongRunning,
 }: {
   running: boolean;
   isError: boolean;
+  isCancelled: boolean;
   isLongRunning: boolean;
 }) {
   if (running) {
@@ -89,12 +91,15 @@ function ToolStatusIcon({
       </span>
     );
   }
-  if (isError) {
+  if (isError || isCancelled) {
+    const className = isCancelled
+      ? "ae-tool-status-icon ae-tool-status-cancelled"
+      : "ae-tool-status-icon ae-tool-status-error";
     return (
       <span
         role="img"
-        aria-label="Tool failed"
-        className="ae-tool-status-icon ae-tool-status-error"
+        aria-label={isCancelled ? "Tool cancelled" : "Tool failed"}
+        className={className}
       >
         <span aria-hidden="true">✕</span>
       </span>
@@ -126,6 +131,8 @@ export function ToolCard({
     isError?: BooleanValue;
     /** Tool name shown in the title; argsSummary as the description. */
     toolName?: StringValue;
+    /** Terminal state synthesized by the bridge when a turn is aborted. */
+    status?: StringValue;
   };
   const baseTitle = props.title ? resolveString(props.title, state) : "";
   const description = props.description
@@ -138,6 +145,8 @@ export function ToolCard({
     ? resolveNumber(props.endedAt, state)
     : undefined;
   const isError = props.isError ? resolveBoolean(props.isError, state) : false;
+  const status = props.status ? resolveString(props.status, state) : undefined;
+  const isCancelled = status === "cancelled";
   const running = startedAt !== undefined && endedAt === undefined;
 
   // Tick at 4 Hz while running so the clock stays smooth without
@@ -164,9 +173,12 @@ export function ToolCard({
 
   const timeSuffix = useMemo(() => {
     if (running) return formatToolDuration(elapsedMs);
-    if (startedAt !== undefined) return formatToolDuration(elapsedMs);
-    return "";
-  }, [running, startedAt, elapsedMs]);
+    if (startedAt === undefined) return "";
+    const duration = formatToolDuration(elapsedMs);
+    if (isCancelled) return `Cancelled in ${duration}`;
+    if (isError) return `Failed in ${duration}`;
+    return `Completed in ${duration}`;
+  }, [running, startedAt, elapsedMs, isCancelled, isError]);
 
   return (
     <details
@@ -174,11 +186,13 @@ export function ToolCard({
       data-running={running ? "true" : "false"}
       data-long-running={isLongRunning ? "true" : "false"}
       data-error={isError ? "true" : "false"}
+      data-cancelled={isCancelled ? "true" : "false"}
     >
       <summary className="ae-tool-card-summary">
         <ToolStatusIcon
           running={running}
           isError={isError}
+          isCancelled={isCancelled}
           isLongRunning={isLongRunning}
         />
         <span className="ae-tool-card-name">{baseTitle}</span>

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -4294,7 +4294,8 @@ body.ae-resizing-terminal * {
 .ae-tool-card[data-long-running="true"] {
   border-color: color-mix(in oklab, var(--warning, #d18a2c) 55%, var(--border));
 }
-.ae-tool-card[data-error="true"] {
+.ae-tool-card[data-error="true"],
+.ae-tool-card[data-cancelled="true"] {
   border-color: color-mix(in oklab, var(--danger, #c5494a) 55%, var(--border));
 }
 
@@ -4343,7 +4344,8 @@ body.ae-resizing-terminal * {
 .ae-tool-status-done {
   color: var(--text-dim);
 }
-.ae-tool-status-error {
+.ae-tool-status-error,
+.ae-tool-status-cancelled {
   color: var(--danger, #c5494a);
 }
 .ae-tool-status-running {
@@ -4412,7 +4414,8 @@ body.ae-resizing-terminal * {
 .ae-tool-card[data-running="true"] .ae-tool-card-time {
   color: var(--accent);
 }
-.ae-tool-card[data-error="true"] .ae-tool-card-time {
+.ae-tool-card[data-error="true"] .ae-tool-card-time,
+.ae-tool-card[data-cancelled="true"] .ae-tool-card-time {
   color: var(--danger, #c5494a);
 }
 


### PR DESCRIPTION
## Summary

Fixes #92 by ensuring Stop/`Cmd+.` drives both the underlying bash process cancellation path and the visible tool-card terminal state.

Changes included:

- Stop handling now calls `session.abortBash()` when available before aborting the whole session.
- Stop handling synthesizes a final cancelled `tool-card` payload for every active running tool card.
- The synthetic payload reuses the existing tool-card id and includes `endedAt`, so the frontend replaces the running card in place and freezes the elapsed timer immediately.
- If pi later emits the real `tool_execution_end`, Aethon updates the same card id instead of creating a duplicate.
- Tool cards now display explicit terminal labels:
  - `Cancelled in …`
  - `Failed in …`
  - `Completed in …`
- Cancelled cards get a distinct cancelled state/icon styling.

## Verification

Commands run with `nix develop -c`:

- `bunx vitest run agent/tab-lifecycle.test.ts agent/dispatcher.test.ts src/skills/default-layout/chat.test.tsx`
- `bunx vitest run`
- `bunx tsc -b --noEmit`
- `bunx eslint agent/dispatcher.ts agent/dispatcher.test.ts agent/state.ts agent/tab-lifecycle.ts agent/tab-lifecycle.test.ts agent/tool-card.ts src/skills/default-layout/chat.tsx src/skills/default-layout/chat.test.tsx`
- `bunx eslint .` (exited with 0 errors; reported 5 pre-existing warnings in unrelated files: `project-dashboard.tsx`, `task-launcher.tsx`, `image-viewer.tsx`, `markdown-preview.tsx`, `layout.tsx`)

Also ran a low-level bash abort probe through pi's local bash operations:

- started `echo <marker>; sleep 120`
- aborted after 500ms
- verified `pgrep -fl <marker>` returned no orphan marker process

## Notes

This fix intentionally handles the UI state defensively even if pi does not emit `tool_execution_end` on abort. That keeps the visible timer from running forever while preserving the later real end event if it arrives.
