### PR TITLE
fix(session): clear stale restored waiting state

### DIFF
--- a/src/hooks/bridgeMessageHandlers/sessionHistory.test.ts
+++ b/src/hooks/bridgeMessageHandlers/sessionHistory.test.ts
@@ -68,7 +68,9 @@ describe("handleSessionHistory", () => {
     );
     const [, updater] = mocks.updateTab.mock.calls[0];
     const out = updater(makeEmptyTab("default", "Tab 1"));
-    expect(out.label).toBe("Research this application and summarize the cha...");
+    expect(out.label).toBe(
+      "Research this application and summarize the cha...",
+    );
   });
 
   it("does not replace explicit tab labels with restored first messages", () => {
@@ -100,6 +102,7 @@ describe("handleSessionHistory", () => {
     const tab = makeEmptyTab("tab-1", "Tab 1");
     const out = updater({
       ...tab,
+      waiting: true,
       messages: [
         {
           id: "local-prompt",
@@ -144,6 +147,7 @@ describe("handleSessionHistory", () => {
     const tab = makeEmptyTab("tab-1", "Tab 1");
     const out = updater({
       ...tab,
+      waiting: true,
       messages: [
         {
           id: "local-prompt",
@@ -164,6 +168,155 @@ describe("handleSessionHistory", () => {
       "local-prompt",
       "streaming-agent",
     ]);
+    expect(out.waiting).toBe(true);
+  });
+
+  it("drops stale running tool cards when restored history has the completed tool result", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    const toolCallId =
+      "call_bBEjXjY3q5AY7nMBo0Ds8g3w|fc_01a0cf101a3d1343016a14d6465b9c819b8b75c60642c6bd59";
+    handleSessionHistory(
+      {
+        type: "session_history",
+        tabId: "tab-1",
+        messages: [
+          {
+            id: "restored-tool-call_bBEjXjY3q5AY7nMBo0Ds8g3w-fc_01a0cf101a3d1343016a14d6465b9c819b8b75c60642c6bd59",
+            role: "agent",
+            a2ui: {
+              components: [
+                {
+                  id: "restored-tool-call_bBEjXjY3q5AY7nMBo0Ds8g3w-fc_01a0cf101a3d1343016a14d6465b9c819b8b75c60642c6bd59",
+                  type: "tool-card",
+                  props: {
+                    title: "bash",
+                    toolName: "bash",
+                    description: "PR=$(gh pr view --json number -q .number)",
+                    startedAt: 1_000,
+                    endedAt: 2_000,
+                  },
+                  children: [
+                    {
+                      id: "result",
+                      type: "code",
+                      props: { content: "done" },
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+      },
+      ctx,
+    );
+    const [, updater] = mocks.updateTab.mock.calls[0];
+    const tab = makeEmptyTab("tab-1", "Tab 1");
+    const out = updater({
+      ...tab,
+      waiting: true,
+      messages: [
+        {
+          id: `tool-16-${toolCallId}`,
+          role: "agent",
+          a2ui: {
+            components: [
+              {
+                id: `tool-16-${toolCallId}`,
+                type: "tool-card",
+                props: {
+                  title: "bash",
+                  toolName: "bash",
+                  description: "PR=$(gh pr view --json number -q .number)",
+                  startedAt: 1_000,
+                },
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    expect(out.messages).toHaveLength(1);
+    expect(out.messages[0].id).toBe(
+      "restored-tool-call_bBEjXjY3q5AY7nMBo0Ds8g3w-fc_01a0cf101a3d1343016a14d6465b9c819b8b75c60642c6bd59",
+    );
+    expect(out.waiting).toBe(false);
+  });
+
+  it("drops restored duplicate assistant text and completed tool cards so reloads do not look busy", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleSessionHistory(
+      {
+        type: "session_history",
+        tabId: "tab-1",
+        messages: [
+          {
+            id: "restored-thinking",
+            role: "agent",
+            thinking: "Monitoring requests",
+          },
+          {
+            id: "restored-tool-call_dupe",
+            role: "agent",
+            a2ui: {
+              components: [
+                {
+                  id: "restored-tool-call_dupe",
+                  type: "tool-card",
+                  props: {
+                    title: "bash",
+                    toolName: "bash",
+                    description: "gh pr view --json number",
+                    startedAt: 1_000,
+                    endedAt: 2_000,
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      ctx,
+    );
+    const [, updater] = mocks.updateTab.mock.calls[0];
+    const tab = makeEmptyTab("tab-1", "Tab 1");
+    const out = updater({
+      ...tab,
+      waiting: true,
+      messages: [
+        {
+          id: "local-thinking",
+          role: "agent",
+          thinking: "Monitoring requests",
+        },
+        {
+          id: "tool-16-call_dupe",
+          role: "agent",
+          a2ui: {
+            components: [
+              {
+                id: "tool-16-call_dupe",
+                type: "tool-card",
+                props: {
+                  title: "bash",
+                  toolName: "bash",
+                  description: "gh pr view --json number",
+                  startedAt: 1_000,
+                  endedAt: 2_000,
+                },
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    expect(out.messages.map((m: ChatMessage) => m.id)).toEqual([
+      "restored-thinking",
+      "restored-tool-call_dupe",
+    ]);
+    expect(out.waiting).toBe(false);
   });
 
   it("drops failed local user messages on restore (they are informational once history arrives)", () => {

--- a/src/hooks/bridgeMessageHandlers/sessionHistory.ts
+++ b/src/hooks/bridgeMessageHandlers/sessionHistory.ts
@@ -1,5 +1,5 @@
 import { coerceChatMessages } from "../../utils/messages";
-import type { ChatMessage } from "../../types/a2ui";
+import type { A2UIComponent, ChatMessage } from "../../types/a2ui";
 import type { BridgeMessageHandler } from "./types";
 
 function firstUserMessageLabel(messages: ChatMessage[]): string | undefined {
@@ -18,10 +18,106 @@ function shouldReplaceGenericLabel(label: string): boolean {
   return /^Tab \d+$/.test(label) || /^Session [A-Za-z0-9-]+$/.test(label);
 }
 
+function toolCardComponents(message: ChatMessage): A2UIComponent[] {
+  return (message.a2ui?.components ?? []).filter(
+    (component): component is A2UIComponent =>
+      component?.type === "tool-card" && typeof component.id === "string",
+  );
+}
+
+function normalizeToolCallId(value: string): string {
+  return value.replace(/[^A-Za-z0-9_-]+/g, "-").slice(0, 96);
+}
+
+function toolCardIdentity(component: A2UIComponent): string | undefined {
+  const id = component.id;
+  if (id.startsWith("restored-tool-")) {
+    return id.slice("restored-tool-".length);
+  }
+  const liveMatch = /^tool-\d+-(.+)$/.exec(id);
+  if (liveMatch) {
+    return normalizeToolCallId(liveMatch[1]);
+  }
+  return undefined;
+}
+
+function completedRestoredToolIdentities(restored: ChatMessage[]): Set<string> {
+  const identities = new Set<string>();
+  for (const message of restored) {
+    for (const component of toolCardComponents(message)) {
+      const identity = toolCardIdentity(component);
+      if (
+        identity &&
+        component.props?.startedAt !== undefined &&
+        component.props.endedAt !== undefined
+      ) {
+        identities.add(identity);
+      }
+    }
+  }
+  return identities;
+}
+
+function isDuplicateCompletedToolCard(
+  message: ChatMessage,
+  completedTools: ReadonlySet<string>,
+): boolean {
+  const toolCards = toolCardComponents(message);
+  if (toolCards.length === 0) return false;
+  return toolCards.every((component) => {
+    const identity = toolCardIdentity(component);
+    return Boolean(identity && completedTools.has(identity));
+  });
+}
+
+function isLivePendingMessage(message: ChatMessage): boolean {
+  if (message.role === "user") {
+    return message.delivery === "sent" || message.delivery === "steered";
+  }
+  if (message.role !== "agent") return false;
+  if (message.text || message.thinking) return true;
+  return toolCardComponents(message).some(
+    (component) =>
+      component.props?.startedAt !== undefined &&
+      component.props.endedAt === undefined,
+  );
+}
+
+function agentContentSignatures(message: ChatMessage): string[] {
+  if (message.role !== "agent" || message.a2ui) return [];
+  const signatures: string[] = [];
+  const text = message.text?.replace(/\s+/g, " ").trim();
+  if (text) signatures.push(`text:${text}`);
+  const thinking = message.thinking?.replace(/\s+/g, " ").trim();
+  if (thinking) signatures.push(`thinking:${thinking}`);
+  return signatures;
+}
+
+function restoredAgentContentSignatures(restored: ChatMessage[]): Set<string> {
+  const signatures = new Set<string>();
+  for (const message of restored) {
+    for (const signature of agentContentSignatures(message)) {
+      signatures.add(signature);
+    }
+  }
+  return signatures;
+}
+
+function isDuplicateRestoredAgentContent(
+  message: ChatMessage,
+  restoredAgentContent: ReadonlySet<string>,
+): boolean {
+  const signatures = agentContentSignatures(message);
+  return (
+    signatures.length > 0 &&
+    signatures.every((signature) => restoredAgentContent.has(signature))
+  );
+}
+
 function mergePendingLocalPrompts(
   restored: ChatMessage[],
   current: ChatMessage[],
-): ChatMessage[] {
+): { messages: ChatMessage[]; hasLivePending: boolean } {
   // Carry pending local messages — both the optimistic user prompts
   // the user sent before the restored history arrived AND any
   // assistant streaming deltas already in flight — across the
@@ -29,6 +125,8 @@ function mergePendingLocalPrompts(
   // live output isn't dropped. Restored transcript first, pending
   // local appended after.
   const restoredIds = new Set(restored.map((m) => m.id));
+  const completedTools = completedRestoredToolIdentities(restored);
+  const restoredAgentContent = restoredAgentContentSignatures(restored);
   const restoredUserTexts = new Set(
     restored
       .filter((m) => m.role === "user" && typeof m.text === "string")
@@ -37,6 +135,8 @@ function mergePendingLocalPrompts(
   );
   const pendingLocal = current.filter((m) => {
     if (restoredIds.has(m.id)) return false;
+    if (isDuplicateCompletedToolCard(m, completedTools)) return false;
+    if (isDuplicateRestoredAgentContent(m, restoredAgentContent)) return false;
     if (m.role === "user") {
       // A failed local user message is informational once history
       // catches up — the bridge will resend or the user will retry.
@@ -55,7 +155,11 @@ function mergePendingLocalPrompts(
     // user just watched land.
     return true;
   });
-  return pendingLocal.length > 0 ? [...restored, ...pendingLocal] : restored;
+  return {
+    messages:
+      pendingLocal.length > 0 ? [...restored, ...pendingLocal] : restored,
+    hasLivePending: pendingLocal.some(isLivePendingMessage),
+  };
 }
 
 export const handleSessionHistory: BridgeMessageHandler = (data, ctx) => {
@@ -69,14 +173,18 @@ export const handleSessionHistory: BridgeMessageHandler = (data, ctx) => {
     (session?.firstUserMessage
       ? session.firstUserMessage.replace(/\s+/g, " ").trim()
       : undefined);
-  ctx.updateTab(tabId, (tab) => ({
-    ...tab,
-    messages: mergePendingLocalPrompts(messages, tab.messages),
-    ...(label
-      ? { label }
-      : shouldReplaceGenericLabel(tab.label)
-        ? { label: firstUserMessageLabel(messages) ?? tab.label }
-        : {}),
-  }));
+  ctx.updateTab(tabId, (tab) => {
+    const merged = mergePendingLocalPrompts(messages, tab.messages);
+    return {
+      ...tab,
+      messages: merged.messages,
+      waiting: merged.hasLivePending ? tab.waiting : false,
+      ...(label
+        ? { label }
+        : shouldReplaceGenericLabel(tab.label)
+          ? { label: firstUserMessageLabel(messages) ?? tab.label }
+          : {}),
+    };
+  });
   ctx.syncRecentSessionsToState();
 };

--- a/src/state/sessionUiSnapshot.test.ts
+++ b/src/state/sessionUiSnapshot.test.ts
@@ -70,6 +70,34 @@ describe("sessionUiSnapshot", () => {
     expect(loadSessionUiSnapshot()?.activeTabId).toBe("tab-a");
   });
 
+  it("does not restore agent tabs as waiting after an app restart", () => {
+    const parsed = parseSessionUiSnapshot(
+      JSON.stringify({
+        tabs: [
+          {
+            ...makeEmptyTab("tab-a", "A"),
+            waiting: true,
+            queueCount: 3,
+            queuedMessages: [{ id: "queued", content: "next" }],
+            messages: [
+              { id: "m1", role: "user", text: "fix it" },
+              { id: "m2", role: "agent", thinking: "Monitoring requests" },
+            ],
+          },
+        ],
+        activeTabId: "tab-a",
+        savedAt: 1,
+      }),
+    );
+
+    expect(parsed?.tabs[0]).toMatchObject({
+      id: "tab-a",
+      waiting: false,
+      queueCount: 0,
+      queuedMessages: [],
+    });
+  });
+
   it("drops shell tabs from the reload snapshot", () => {
     saveSessionUiSnapshot({
       tabs: [

--- a/src/state/sessionUiSnapshot.ts
+++ b/src/state/sessionUiSnapshot.ts
@@ -165,7 +165,10 @@ export function parseSessionUiSnapshot(raw: string): SessionUiSnapshot | null {
         ...t,
         kind: t.kind ?? "agent",
         draft: t.draft ?? "",
-        waiting: Boolean(t.waiting),
+        // Waiting is process-local state. After an app restart there is no
+        // still-attached prompt runner behind this tab, so restoring it as
+        // busy leaves the UI stuck in "thinking..." with a dead stop button.
+        waiting: false,
         // Client-held queue is intentionally NOT restored: queued
         // messages are ephemeral, and a user who closed the app while
         // queue items were pending probably abandoned them. The next


### PR DESCRIPTION
## Summary

- Clear stale restored tool-card artifacts when canonical session history already has the completed tool result.
- Drop duplicate restored assistant text/thinking bubbles so reload hydration does not keep old UI-only work alive.
- Treat `waiting` as process-local state and never restore it from the session UI snapshot after app restart.

## Root Cause

Reload hydration merged canonical pi session history with locally persisted UI messages by ID only. Restored tool cards and live/local tool cards use different IDs for the same tool call, so duplicate local cards could survive. Completed local tool cards and duplicate thinking bubbles could then make the tab look like it still had live work. Separately, the app snapshot parser restored `waiting: true`, which revived a dead in-flight state after the process was gone.

## Validation

- `bunx vitest run src/hooks/bridgeMessageHandlers/sessionHistory.test.ts src/state/sessionUiSnapshot.test.ts`
- `bunx vitest run src/hooks/bridgeMessageHandlers/sessionHistory.test.ts agent/session-history.test.ts src/utils/messages.test.ts src/state/sessionUiSnapshot.test.ts src/hooks/bridgeMessageHandlers/ready.test.ts`
- `bunx vitest run`
- `bun run typecheck`
- `bun run lint` (passes with existing React Hooks warnings outside this patch)
- `bun run build`
- `git diff --check`
