### PR TITLE
fix(worktree): recover dangling git worktrees from the UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ All notable changes to Aethon. Format loosely follows
 
 ### Fixed
 
+- **Dangling worktrees are recoverable from the UI.** When a git worktree
+  was pruned externally (manual `git worktree remove`, crashed `add`),
+  Aethon's projects.json kept the row but every git invocation in the
+  dir failed — the landing card mislabeled it as "No GitHub remote
+  detected" and the delete button bounced with "worktree not tracked".
+  The `gh_branch_status` IPC now carries an explicit `worktreeBroken`
+  flag (set via a hermetic `.git`-marker check before any git/gh
+  shell-out), the landing renders a "no longer tracked by git" message
+  instead, and `removeWorktreeById` falls through to a new
+  `git_worktree_remove_orphan` Rust command that validates the path
+  points into this project's `.git/worktrees/` before trashing the
+  leftover folder. `migrateProjects` also clears a dangling
+  `activeWorktreeId` at load so a freshly-restarted app doesn't land
+  on a dead worktree.
 - **Extension watcher follows cross-project worktree activation (peer-review P2).**
   `activateWorktree` previously changed `activeId` directly when the
   selected worktree belonged to a different project, bypassing the

--- a/src-tauri/src/commands/git.rs
+++ b/src-tauri/src/commands/git.rs
@@ -484,6 +484,80 @@ pub async fn git_worktree_remove(
     Ok(())
 }
 
+/// Remove a worktree that git no longer tracks (registry pruned, dir
+/// left behind). The strict `git_worktree_remove` refuses these paths —
+/// this is the recovery escape hatch. Verifies the target genuinely
+/// looks like an orphan of the given project before touching disk:
+/// not in `git worktree list`, `.git` marker points into
+/// `<project>/.git/worktrees/`, and the target is not the project root.
+/// Sends the directory to the OS trash (never `unlink`) and runs
+/// `git worktree prune` to clear any stale registry residue.
+#[tauri::command]
+pub async fn git_worktree_remove_orphan(
+    project_path: String,
+    worktree_path: String,
+) -> Result<(), String> {
+    let project = PathBuf::from(&project_path);
+    let target = PathBuf::from(&worktree_path);
+    if project == target {
+        return Err("cannot remove the main worktree".to_string());
+    }
+    // Refuse if git already knows about this path — caller should use
+    // `git_worktree_remove` (with `force=true` if dirty).
+    let list = git_worktrees(project_path.clone()).await?;
+    let canonical = std::fs::canonicalize(&worktree_path)
+        .ok()
+        .map(|p| p.to_string_lossy().to_string());
+    let still_tracked = list.iter().any(|w| {
+        w.path == worktree_path || canonical.as_deref().is_some_and(|c| c == w.path)
+    });
+    if still_tracked {
+        return Err("worktree is still tracked by git; use git_worktree_remove instead".to_string());
+    }
+    // Authorize the path: the `.git` marker must point into this
+    // project's `.git/worktrees/` directory. Anything else (a plain
+    // folder the user typed in by accident, an unrelated worktree
+    // from another repo) is refused.
+    let marker = target.join(".git");
+    if !marker.is_file() {
+        return Err(format!(
+            "not an orphan worktree: {worktree_path} has no .git marker file"
+        ));
+    }
+    let contents = std::fs::read_to_string(&marker)
+        .map_err(|e| format!("read .git marker: {e}"))?;
+    let gitdir = contents
+        .lines()
+        .next()
+        .and_then(|l| l.strip_prefix("gitdir:").map(str::trim))
+        .ok_or_else(|| format!("not an orphan worktree: {worktree_path} has malformed .git"))?;
+    // Canonicalize project so a symlinked tmpdir (macOS `/var` →
+    // `/private/var`) doesn't cause a false-negative. Git writes the
+    // physical path into `.git`, so `gitdir` is already resolved.
+    let project_canon = std::fs::canonicalize(&project)
+        .map_err(|e| format!("resolve project path: {e}"))?;
+    let expected_prefix = project_canon.join(".git").join("worktrees");
+    if !PathBuf::from(gitdir).starts_with(&expected_prefix) {
+        return Err(format!(
+            "not tracked by this project: {worktree_path} .git points outside {}",
+            expected_prefix.display()
+        ));
+    }
+    // `git worktree prune` clears any stale registry residue (the
+    // gitdir target may or may not still exist).
+    let _ = env::command("git")
+        .arg("-C")
+        .arg(&project)
+        .args(["worktree", "prune"])
+        .output();
+    // Send the dir to the OS trash. Mirrors `commands::fs::fs_delete`
+    // — never `unlink`, never permanent.
+    if target.exists() {
+        trash::delete(&target).map_err(|e| format!("trash {worktree_path}: {e}"))?;
+    }
+    Ok(())
+}
+
 /// List local branches with a `current` flag for the active branch.
 /// Used by the "create worktree from existing branch" picker.
 #[tauri::command]
@@ -547,6 +621,13 @@ pub struct GhBranchStatus {
     /// PRs whose head is the requested branch. Includes open + recently
     /// closed PRs so users see merge state when the branch is gone.
     pub prs: Vec<GhPr>,
+    /// True when the worktree directory still exists on disk but its
+    /// `.git` file points to a `.git/worktrees/<name>/` entry that's
+    /// been pruned externally. Distinct from `gh_available=false`
+    /// (gh missing) and `repo=None` (no GitHub remote) — those are
+    /// healthy states, this one means the user should clean up the
+    /// stale entry.
+    pub worktree_broken: bool,
 }
 
 #[derive(serde::Serialize, Debug, Clone)]
@@ -573,10 +654,40 @@ pub async fn gh_branch_status(
     Ok(gh_branch_status_inner(&project_path, &branch))
 }
 
+/// Detect a worktree whose on-disk `.git` file points to a pruned
+/// `.git/worktrees/<name>/` entry. Hermetic — no git process spawn,
+/// no network. Returns false for a plain (non-worktree) directory or
+/// a healthy repo.
+fn worktree_is_dangling(dir: &std::path::Path) -> bool {
+    let marker = dir.join(".git");
+    if !marker.is_file() {
+        return false;
+    }
+    let Ok(contents) = std::fs::read_to_string(&marker) else {
+        return false;
+    };
+    let Some(target) = contents
+        .lines()
+        .next()
+        .and_then(|l| l.strip_prefix("gitdir:").map(str::trim))
+    else {
+        return false;
+    };
+    !std::path::Path::new(target).exists()
+}
+
 fn gh_branch_status_inner(project_path: &str, branch: &str) -> GhBranchStatus {
     let mut status = GhBranchStatus::default();
     let dir = PathBuf::from(project_path);
     if !dir.is_dir() || branch.is_empty() {
+        return status;
+    }
+    // 0. Short-circuit on a dangling worktree (registry pruned, dir
+    //    still on disk). Every git invocation below would fail; we'd
+    //    end up with `gh_available=true, repo=None` and the landing
+    //    would mislabel it as "no GitHub remote".
+    if worktree_is_dangling(&dir) {
+        status.worktree_broken = true;
         return status;
     }
     // 1. gh available + authed?
@@ -1364,6 +1475,74 @@ mod tests {
         assert!(list.is_empty());
     }
 
+    #[test]
+    fn worktree_is_dangling_detects_missing_gitdir_target() {
+        // A worktree dir whose `.git` file points to a `.git/worktrees/<name>/`
+        // entry that was pruned externally — the exact shape this fix
+        // exists to recover from. The check must be hermetic (no git
+        // invocation) so it runs before `gh auth status` in the status
+        // probe.
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            dir.path().join(".git"),
+            "gitdir: /var/empty/aethon-test-no-such-worktree-dir\n",
+        )
+        .expect("write .git");
+        assert!(worktree_is_dangling(dir.path()));
+    }
+
+    #[test]
+    fn worktree_is_dangling_returns_false_for_normal_repo() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        init_repo(dir.path());
+        assert!(!worktree_is_dangling(dir.path()));
+    }
+
+    #[test]
+    fn worktree_is_dangling_returns_false_for_plain_directory() {
+        // No `.git` at all — caller is asking about a plain folder, not
+        // a worktree. We don't want to mis-label it as "broken".
+        let dir = tempfile::tempdir().expect("tempdir");
+        assert!(!worktree_is_dangling(dir.path()));
+    }
+
+    #[test]
+    fn worktree_is_dangling_returns_false_when_gitdir_target_exists() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let target = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            dir.path().join(".git"),
+            format!("gitdir: {}\n", target.path().display()),
+        )
+        .expect("write .git");
+        assert!(!worktree_is_dangling(dir.path()));
+    }
+
+    #[test]
+    fn gh_branch_status_marks_dangling_worktree() {
+        // End-to-end on the inner helper. No `gh` invocation, no
+        // network — the dangling check must short-circuit before
+        // `gh auth status`.
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            dir.path().join(".git"),
+            "gitdir: /var/empty/aethon-test-no-such-worktree-dir\n",
+        )
+        .expect("write .git");
+        let s = gh_branch_status_inner(&dir.path().to_string_lossy(), "main");
+        assert!(s.worktree_broken, "expected worktree_broken=true");
+        assert!(!s.gh_available);
+        assert!(s.repo.is_none());
+    }
+
+    #[test]
+    fn gh_branch_status_does_not_mark_healthy_repo_broken() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        init_repo(dir.path());
+        let s = gh_branch_status_inner(&dir.path().to_string_lossy(), "main");
+        assert!(!s.worktree_broken);
+    }
+
     #[tokio::test]
     async fn list_returns_main_worktree_for_fresh_repo() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -1400,6 +1579,114 @@ mod tests {
             .expect("worktree remove");
         let after = git_worktrees(project_path).await.expect("list after");
         assert_eq!(after.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn remove_orphan_drops_pruned_worktree() {
+        // Simulate the dangling state: a worktree was created, then
+        // its `.git/worktrees/<name>/` entry was pruned externally,
+        // but the on-disk dir survives.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let parent = tempfile::tempdir().expect("tempdir");
+        init_repo(dir.path());
+        let project_path = dir.path().to_string_lossy().to_string();
+        let target = parent.path().join("orphan");
+        let target_str = target.to_string_lossy().to_string();
+        git_worktree_add(
+            project_path.clone(),
+            target_str.clone(),
+            "orphan".to_string(),
+            None,
+        )
+        .await
+        .expect("worktree add");
+        // Manually prune the registry entry. Leaves the on-disk dir
+        // intact with a now-dangling `.git` marker file.
+        std::fs::remove_dir_all(dir.path().join(".git/worktrees/orphan"))
+            .expect("remove registry entry");
+        // Sanity: strict remove must refuse.
+        let err = git_worktree_remove(project_path.clone(), target_str.clone(), false)
+            .await
+            .expect_err("strict remove must refuse a pruned worktree");
+        assert!(
+            err.contains("not tracked"),
+            "expected 'not tracked' in strict remove err, got: {err}"
+        );
+        // The orphan path cleans it up.
+        git_worktree_remove_orphan(project_path.clone(), target_str.clone())
+            .await
+            .expect("orphan remove");
+        // On-disk dir is gone (sent to trash by `trash::delete`; the
+        // assertion is that the path is no longer reachable).
+        assert!(
+            !target.exists(),
+            "orphan dir should be gone after remove_orphan"
+        );
+    }
+
+    #[tokio::test]
+    async fn remove_orphan_refuses_live_worktree() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let parent = tempfile::tempdir().expect("tempdir");
+        init_repo(dir.path());
+        let project_path = dir.path().to_string_lossy().to_string();
+        let target = parent.path().join("alive");
+        let target_str = target.to_string_lossy().to_string();
+        git_worktree_add(
+            project_path.clone(),
+            target_str.clone(),
+            "alive".to_string(),
+            None,
+        )
+        .await
+        .expect("worktree add");
+        let err = git_worktree_remove_orphan(project_path, target_str)
+            .await
+            .expect_err("must refuse a live worktree");
+        assert!(
+            err.contains("still tracked") || err.contains("not orphaned"),
+            "got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn remove_orphan_refuses_main_worktree() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        init_repo(dir.path());
+        let project_path = dir.path().to_string_lossy().to_string();
+        let err = git_worktree_remove_orphan(project_path.clone(), project_path)
+            .await
+            .expect_err("must refuse main worktree");
+        assert!(err.contains("main") || err.contains("still tracked"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn remove_orphan_refuses_unrelated_path() {
+        // Defense in depth: even with a dangling `.git`-marker shape,
+        // a path outside the project tree (no `gitdir:` pointing into
+        // `<project>/.git/worktrees/`) must be refused. Stops a buggy
+        // caller from trashing arbitrary directories.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let unrelated = tempfile::tempdir().expect("tempdir");
+        init_repo(dir.path());
+        let project_path = dir.path().to_string_lossy().to_string();
+        std::fs::write(
+            unrelated.path().join(".git"),
+            "gitdir: /var/empty/no-such-thing\n",
+        )
+        .expect("write fake .git");
+        let err = git_worktree_remove_orphan(
+            project_path,
+            unrelated.path().to_string_lossy().to_string(),
+        )
+        .await
+        .expect_err("must refuse unrelated path");
+        assert!(
+            err.contains("not an orphan") || err.contains("not tracked by this project"),
+            "got: {err}"
+        );
+        // And the dir must still exist — we didn't touch it.
+        assert!(unrelated.path().exists());
     }
 
     #[tokio::test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -892,6 +892,7 @@ pub fn run() {
             commands::git::git_worktrees,
             commands::git::git_worktree_add,
             commands::git::git_worktree_remove,
+            commands::git::git_worktree_remove_orphan,
             commands::git::git_branch_list,
             commands::git::gh_branch_status,
             commands::git::gh_repo_overview,

--- a/src/ghBranchStatusCache.test.ts
+++ b/src/ghBranchStatusCache.test.ts
@@ -24,6 +24,7 @@ function makeStatus(over: Partial<GhBranchStatus> = {}): GhBranchStatus {
     repo: "owner/repo",
     pushed: true,
     prs: [],
+    worktreeBroken: false,
     ...over,
   };
 }

--- a/src/ghBranchStatusCache.ts
+++ b/src/ghBranchStatusCache.ts
@@ -26,6 +26,11 @@ export interface GhBranchStatus {
   repo: string | null;
   pushed: boolean;
   prs: GhPr[];
+  /** True when the worktree dir's `.git` marker points to a pruned
+   *  `.git/worktrees/<name>/` entry. Distinct from `ghAvailable=false`
+   *  (gh missing) and `repo=null` (no GitHub remote) — those are
+   *  healthy states. */
+  worktreeBroken: boolean;
 }
 
 /** How long a successful cache entry remains valid. 60s is short

--- a/src/hooks/useProjectOps.test.ts
+++ b/src/hooks/useProjectOps.test.ts
@@ -732,4 +732,182 @@ describe("useProjectOps worktree removal", () => {
       ),
     ).toBe(false);
   });
+
+  it("falls through to the orphan command when git reports 'worktree not tracked'", async () => {
+    const harness = installTauriMocks();
+    harness.invoke.mockImplementation((cmd: string) => {
+      if (cmd === "git_worktree_remove")
+        return Promise.reject(
+          new Error("worktree not tracked: /projects/aethon-fix-issue"),
+        );
+      if (cmd === "git_worktree_remove_orphan") return Promise.resolve(undefined);
+      return Promise.resolve(undefined);
+    });
+    const confirmSpy = vi
+      .spyOn(window, "confirm")
+      .mockReturnValue(true);
+    const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
+    try {
+      const initial = makeProjectsState({
+        activeId: "project-1",
+        activeWorktreeId: "wt-issue",
+        worktreesByProject: {
+          "project-1": [
+            {
+              id: "wt-main",
+              projectId: "project-1",
+              path: "/projects/aethon",
+              branch: "main",
+              isMain: true,
+            },
+            {
+              id: "wt-issue",
+              projectId: "project-1",
+              path: "/projects/aethon-fix-issue",
+              branch: "fix/issue",
+              isMain: false,
+            },
+          ],
+        },
+      });
+      const { result, projectsRef } = renderProjectOps(initial);
+      await act(async () => {
+        await Promise.resolve();
+      });
+      projectsRef.current = initial;
+      await act(async () => {
+        await result.current.removeWorktreeById("wt-issue", { confirmed: true });
+      });
+      expect(confirmSpy).toHaveBeenCalledTimes(1);
+      expect(harness.invoke).toHaveBeenCalledWith("git_worktree_remove_orphan", {
+        projectPath: "/projects/aethon",
+        worktreePath: "/projects/aethon-fix-issue",
+      });
+      expect(alertSpy).not.toHaveBeenCalled();
+      expect(
+        projectsRef.current.worktreesByProject["project-1"]?.some(
+          (wt) => wt.id === "wt-issue",
+        ),
+      ).toBe(false);
+    } finally {
+      confirmSpy.mockRestore();
+      alertSpy.mockRestore();
+    }
+  });
+
+  it("aborts cleanly if the user declines the orphan confirmation", async () => {
+    const harness = installTauriMocks();
+    harness.invoke.mockImplementation((cmd: string) => {
+      if (cmd === "git_worktree_remove")
+        return Promise.reject(
+          new Error("worktree not tracked: /projects/aethon-fix-issue"),
+        );
+      return Promise.resolve(undefined);
+    });
+    const confirmSpy = vi
+      .spyOn(window, "confirm")
+      .mockReturnValue(false);
+    const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
+    try {
+      const initial = makeProjectsState({
+        activeId: "project-1",
+        worktreesByProject: {
+          "project-1": [
+            {
+              id: "wt-main",
+              projectId: "project-1",
+              path: "/projects/aethon",
+              branch: "main",
+              isMain: true,
+            },
+            {
+              id: "wt-issue",
+              projectId: "project-1",
+              path: "/projects/aethon-fix-issue",
+              branch: "fix/issue",
+              isMain: false,
+            },
+          ],
+        },
+      });
+      const { result, projectsRef } = renderProjectOps(initial);
+      await act(async () => {
+        await Promise.resolve();
+      });
+      projectsRef.current = initial;
+      await act(async () => {
+        await result.current.removeWorktreeById("wt-issue", { confirmed: true });
+      });
+      expect(harness.invoke).not.toHaveBeenCalledWith(
+        "git_worktree_remove_orphan",
+        expect.anything(),
+      );
+      expect(alertSpy).not.toHaveBeenCalled();
+      // Row remains visible so the user can try again later.
+      expect(
+        projectsRef.current.worktreesByProject["project-1"]?.some(
+          (wt) => wt.id === "wt-issue",
+        ),
+      ).toBe(true);
+    } finally {
+      confirmSpy.mockRestore();
+      alertSpy.mockRestore();
+    }
+  });
+
+  it("alerts when the orphan command itself fails", async () => {
+    const harness = installTauriMocks();
+    harness.invoke.mockImplementation((cmd: string) => {
+      if (cmd === "git_worktree_remove")
+        return Promise.reject(new Error("worktree not tracked: x"));
+      if (cmd === "git_worktree_remove_orphan")
+        return Promise.reject(new Error("trash: permission denied"));
+      return Promise.resolve(undefined);
+    });
+    const confirmSpy = vi
+      .spyOn(window, "confirm")
+      .mockReturnValue(true);
+    const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
+    try {
+      const initial = makeProjectsState({
+        activeId: "project-1",
+        worktreesByProject: {
+          "project-1": [
+            {
+              id: "wt-main",
+              projectId: "project-1",
+              path: "/projects/aethon",
+              branch: "main",
+              isMain: true,
+            },
+            {
+              id: "wt-issue",
+              projectId: "project-1",
+              path: "/projects/aethon-fix-issue",
+              branch: "fix/issue",
+              isMain: false,
+            },
+          ],
+        },
+      });
+      const { result, projectsRef } = renderProjectOps(initial);
+      await act(async () => {
+        await Promise.resolve();
+      });
+      projectsRef.current = initial;
+      await act(async () => {
+        await result.current.removeWorktreeById("wt-issue", { confirmed: true });
+      });
+      expect(alertSpy).toHaveBeenCalled();
+      // Row stays so a follow-up attempt is possible.
+      expect(
+        projectsRef.current.worktreesByProject["project-1"]?.some(
+          (wt) => wt.id === "wt-issue",
+        ),
+      ).toBe(true);
+    } finally {
+      confirmSpy.mockRestore();
+      alertSpy.mockRestore();
+    }
+  });
 });

--- a/src/hooks/useProjectOps.ts
+++ b/src/hooks/useProjectOps.ts
@@ -28,6 +28,7 @@ import {
   gitBranchList,
   gitWorktreeAdd,
   gitWorktreeRemove,
+  gitWorktreeRemoveOrphan,
   gitWorktrees,
   newPendingWorktree,
   reconcileWorktrees,
@@ -1158,6 +1159,43 @@ export function useProjectOps(ctx: UseProjectOpsContext): UseProjectOpsActions {
             projectPath: project.path,
             worktreePath: worktree.path,
             force: true,
+          });
+          closeTabsForRemovedWorktree(
+            project.id,
+            worktreeId,
+            worktree.path,
+            projectsRef.current.activeWorktreeId === worktreeId,
+          );
+          const list = removeWorktreeFromList(
+            projectsRef.current.worktreesByProject[project.id] ?? [],
+            worktreeId,
+          );
+          projectsRef.current = setProjectWorktrees(
+            projectsRef.current,
+            project.id,
+            list,
+          );
+          syncProjectsToState();
+          void persistProjects();
+          return;
+        } catch (e2) {
+          window.alert(`Failed: ${String(e2)}`);
+          return;
+        }
+      }
+      // Orphan recovery: git no longer tracks this worktree (registry
+      // pruned externally), but Aethon still has the row. Offer the
+      // user a one-click cleanup via the orphan command.
+      if (msg.includes("worktree not tracked")) {
+        const ok = window.confirm(
+          `Aethon has this worktree but git no longer tracks it. ` +
+            `Remove the leftover folder and forget the entry?`,
+        );
+        if (!ok) return;
+        try {
+          await gitWorktreeRemoveOrphan({
+            projectPath: project.path,
+            worktreePath: worktree.path,
           });
           closeTabsForRemovedWorktree(
             project.id,

--- a/src/projects.test.ts
+++ b/src/projects.test.ts
@@ -170,6 +170,41 @@ describe("migrateProjects", () => {
     });
     expect(out.worktreesByProject.a).toHaveLength(1);
   });
+
+  it("clears activeWorktreeId when it points to a worktree no longer in worktreesByProject", () => {
+    const out = migrateProjects({
+      schemaVersion: 3,
+      projects: [{ id: "a", label: "a", path: "/a", lastUsed: 1 }],
+      activeId: "a",
+      activeWorktreeId: "wt-ghost",
+      activeHostId: "local:abc",
+      worktreesByProject: {
+        a: [{ id: "wt-main", projectId: "a", path: "/a", branch: "main", isMain: true }],
+      },
+    });
+    expect(out.activeWorktreeId).toBeNull();
+    // Row stays visible so the user can see and remove it via the
+    // orphan delete flow. The dangling *active id* is the part that
+    // freezes the UI; the row itself is informational.
+    expect(out.worktreesByProject.a).toHaveLength(1);
+  });
+
+  it("keeps activeWorktreeId when it resolves to a loaded worktree", () => {
+    const out = migrateProjects({
+      schemaVersion: 3,
+      projects: [{ id: "a", label: "a", path: "/a", lastUsed: 1 }],
+      activeId: "a",
+      activeWorktreeId: "wt-2",
+      activeHostId: "local:abc",
+      worktreesByProject: {
+        a: [
+          { id: "wt-1", projectId: "a", path: "/a", branch: "main", isMain: true },
+          { id: "wt-2", projectId: "a", path: "/a-wt", branch: "feat", isMain: false },
+        ],
+      },
+    });
+    expect(out.activeWorktreeId).toBe("wt-2");
+  });
 });
 
 describe("setProjectUiExpanded", () => {

--- a/src/projects.ts
+++ b/src/projects.ts
@@ -150,8 +150,19 @@ export function migrateProjects(
       );
     }
   }
-  const activeWorktreeId =
+  // Drop a dangling activeWorktreeId so a pruned-but-recorded worktree
+  // doesn't freeze the landing on next boot. Symmetric with the
+  // `activeId` check above. The row itself stays in `worktreesByProject`
+  // — `removeWorktreeById` can clean it up via the orphan path.
+  const rawActiveWorktreeId =
     typeof v2.activeWorktreeId === "string" ? v2.activeWorktreeId : null;
+  const activeWorktreeId =
+    rawActiveWorktreeId &&
+    Object.values(worktreesByProject)
+      .flat()
+      .some((w) => w.id === rawActiveWorktreeId)
+      ? rawActiveWorktreeId
+      : null;
   const v3 = parsed as PersistedV3;
   const activeHostId =
     typeof v3.activeHostId === "string" && v3.activeHostId.length > 0

--- a/src/skills/default-layout/layout.tsx
+++ b/src/skills/default-layout/layout.tsx
@@ -736,6 +736,20 @@ function GhBranchStatusBlock(props: {
       </div>
     );
   }
+  // Surface a dangling worktree before the gh-availability check —
+  // every git invocation in the dir would have failed, so this is the
+  // accurate label, not "no GitHub remote".
+  if (status?.worktreeBroken) {
+    return (
+      <div className="a2ui-worktree-landing-gh">
+        <h2>Worktree status</h2>
+        <p className="a2ui-empty-state-subtitle">
+          This worktree is no longer tracked by git. Use the delete
+          button in the sidebar to remove the leftover folder.
+        </p>
+      </div>
+    );
+  }
   // Silent fall-through when gh isn't available — don't show a noisy
   // "install gh" prompt. The landing should still feel useful without
   // the integration.

--- a/src/skills/default-layout/worktree-landing.test.tsx
+++ b/src/skills/default-layout/worktree-landing.test.tsx
@@ -1,12 +1,14 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { WorktreeLanding } from "./layout";
 import type { A2UIComponent } from "../../types/a2ui";
+import type { GhBranchStatus } from "../../ghBranchStatusCache";
 
+const ghMock = vi.fn(() => Promise.resolve(null as GhBranchStatus | null));
 vi.mock("../../ghBranchStatusCache", () => ({
-  getGhBranchStatus: vi.fn(() => Promise.resolve(null)),
+  getGhBranchStatus: (...args: unknown[]) => ghMock(...(args as [])),
 }));
 
 afterEach(() => cleanup());
@@ -71,5 +73,75 @@ describe("WorktreeLanding sessions", () => {
       },
       "session-wt",
     );
+  });
+});
+
+describe("WorktreeLanding gh branch status", () => {
+  it("renders a broken-worktree notice when worktreeBroken is true", async () => {
+    ghMock.mockResolvedValueOnce({
+      ghAvailable: false,
+      repo: null,
+      pushed: false,
+      prs: [],
+      worktreeBroken: true,
+    });
+    render(
+      <WorktreeLanding
+        component={worktreeLanding({
+          landing: { $ref: "/landing" },
+          recentSessions: { $ref: "/recentSessions" },
+        })}
+        state={{
+          landing: {
+            kind: "worktree",
+            projectId: "p1",
+            projectLabel: "aethon",
+            worktreeId: "wt-broken",
+            worktreeLabel: "fix/orphan",
+            branch: "fix/orphan",
+            path: "/repo/aethon-broken",
+          },
+          recentSessions: [],
+        }}
+        onEvent={vi.fn()}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByText(/no longer tracked by git/i)).toBeTruthy(),
+    );
+  });
+
+  it("does not render the gh status block when worktreeBroken is false and gh is unavailable", async () => {
+    ghMock.mockResolvedValueOnce({
+      ghAvailable: false,
+      repo: null,
+      pushed: false,
+      prs: [],
+      worktreeBroken: false,
+    });
+    render(
+      <WorktreeLanding
+        component={worktreeLanding({
+          landing: { $ref: "/landing" },
+          recentSessions: { $ref: "/recentSessions" },
+        })}
+        state={{
+          landing: {
+            kind: "worktree",
+            projectId: "p1",
+            projectLabel: "aethon",
+            worktreeId: "wt-healthy",
+            worktreeLabel: "main",
+            branch: "main",
+            path: "/repo/aethon",
+          },
+          recentSessions: [],
+        }}
+        onEvent={vi.fn()}
+      />,
+    );
+    // Wait one tick so the effect runs.
+    await waitFor(() => expect(ghMock).toHaveBeenCalled());
+    expect(screen.queryByText(/no longer tracked|branch status/i)).toBeNull();
   });
 });

--- a/src/worktrees.ts
+++ b/src/worktrees.ts
@@ -190,6 +190,19 @@ export async function gitWorktreeRemove(args: {
   });
 }
 
+/** Recovery path for a worktree git no longer tracks. The Rust command
+ *  guards the path (must be a `.git`-marker file pointing into this
+ *  project's `.git/worktrees/`) before trashing. */
+export async function gitWorktreeRemoveOrphan(args: {
+  projectPath: string;
+  worktreePath: string;
+}): Promise<void> {
+  await invoke("git_worktree_remove_orphan", {
+    projectPath: args.projectPath,
+    worktreePath: args.worktreePath,
+  });
+}
+
 export async function gitBranchList(
   projectPath: string,
 ): Promise<GitBranchInfo[]> {


### PR DESCRIPTION
## Summary

- Surfaces an explicit `worktreeBroken` signal from `gh_branch_status` so the worktree landing card shows "no longer tracked by git" instead of mislabeling pruned worktrees as "No GitHub remote detected".
- Adds `git_worktree_remove_orphan` Rust command + a one-confirm fallback in `removeWorktreeById` so the in-app delete button can clean up a worktree git no longer tracks (validates the path's `.git` marker points into this project's `.git/worktrees/` before trashing).
- `migrateProjects` clears a dangling `activeWorktreeId` at load so a restart can't pin the UI to a dead worktree; the row stays visible in `worktreesByProject` so the user can remove it via the new orphan path.

## Why

Discovered when PR #100 (`fix/issue-89-…`) merged: the worktree directory survived on disk, its `.git` file pointed to a now-missing `.git/worktrees/aethon-fix-issue-89-…` entry, and Aethon offered no way out — every git command failed, so the landing claimed "No GitHub remote detected" and the delete button errored with `worktree not tracked: …`. Three independent registries (git's `.git/worktrees/`, `projects.json`'s `worktreesByProject`, `activeWorktreeId`) had drifted out of sync with no reconciler.

## Test plan

- [x] `cargo test --lib` — 146/146, including 7 new tests covering the dangling-worktree sentinel, `gh_branch_status` short-circuit, and the orphan command's refuse-live/main/unrelated/path-escape guards.
- [x] `bunx vitest run` — 1091/1091, including 3 new `migrateProjects` cases, 3 new `removeWorktreeById` orphan-fallback cases, and 2 new `WorktreeLanding` render cases.
- [x] `check` devshell helper — exit 0 (clippy + tsc + ESLint + Rust tests + vitest).
- [ ] Manual repro on the actual user-reported branch: dev build, click delete on a dangling worktree row → one confirmation → row + folder gone, no other UI state drift.

## Out of scope

- `pushNotification` migration of `window.alert/confirm` in `useProjectOps.ts`.
- Periodic background reconciliation that drops `worktreesByProject` rows whose paths no longer exist on disk.
- Cleanup of orphaned local branches (different data model — branches live in git, not projects.json).