### PR TITLE
fix(chat): steer latest queued message from empty composer

### DIFF
--- a/src/eventRoutes/chatInput.test.ts
+++ b/src/eventRoutes/chatInput.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { handleChatInput } from "./chatInput";
 import { buildRouteFixture } from "./testFixtures";
+import { makeEmptyTab } from "../types/tab";
 
 describe("handleChatInput", () => {
   it("submit forwards value to sendChat as a normal message", async () => {
@@ -29,6 +30,57 @@ describe("handleChatInput", () => {
     );
     expect(handled).toBe(true);
     expect(mocks.sendChat).toHaveBeenCalledWith("look now", { mode: "steer" });
+  });
+
+  it("empty command-enter promotes the only queued message to steering", async () => {
+    const tab = {
+      ...makeEmptyTab("tab-1", "Tab 1"),
+      queuedMessages: [{ id: "q1", content: "after this" }],
+      queueCount: 1,
+    };
+    const { ctx, mocks } = buildRouteFixture({
+      state: { activeTabId: "tab-1", tabs: [tab] },
+    });
+
+    const handled = await handleChatInput(
+      {
+        component: { id: "chat-input" },
+        eventType: "submit",
+        data: { value: "", mode: "steer" },
+      },
+      ctx,
+    );
+
+    expect(handled).toBe(true);
+    expect(mocks.steerQueuedMessage).toHaveBeenCalledWith("tab-1", "q1");
+    expect(mocks.sendChat).not.toHaveBeenCalled();
+  });
+
+  it("empty command-enter promotes the newest queued message to steering", async () => {
+    const tab = {
+      ...makeEmptyTab("tab-1", "Tab 1"),
+      queuedMessages: [
+        { id: "q1", content: "first queued" },
+        { id: "q2", content: "bottom-most queued" },
+      ],
+      queueCount: 2,
+    };
+    const { ctx, mocks } = buildRouteFixture({
+      state: { activeTabId: "tab-1", tabs: [tab] },
+    });
+
+    const handled = await handleChatInput(
+      {
+        component: { id: "chat-input" },
+        eventType: "submit",
+        data: { value: "   ", mode: "steer" },
+      },
+      ctx,
+    );
+
+    expect(handled).toBe(true);
+    expect(mocks.steerQueuedMessage).toHaveBeenCalledWith("tab-1", "q2");
+    expect(mocks.sendChat).not.toHaveBeenCalled();
   });
 
   it("change persists draft into the active tab record", async () => {

--- a/src/eventRoutes/chatInput.ts
+++ b/src/eventRoutes/chatInput.ts
@@ -1,4 +1,17 @@
+import type { QueuedMessage, Tab } from "../types/tab";
 import type { EventRouteHandler } from "./types";
+
+function newestQueuedMessage(
+  state: Record<string, unknown>,
+): { tabId: string; message: QueuedMessage } | null {
+  const tabId = state.activeTabId as string | undefined;
+  if (!tabId) return null;
+  const tabs = (state.tabs as Tab[] | undefined) ?? [];
+  const tab = tabs.find((t) => t.id === tabId);
+  if (!tab || tab.kind !== "agent") return null;
+  const message = (tab.queuedMessages ?? []).at(-1);
+  return message ? { tabId, message } : null;
+}
 
 /** chat-input: submit forwards to native sendChat (replacing the
  *  bridge round-trip), change persists the unsent draft into the
@@ -16,6 +29,13 @@ export const handleChatInput: EventRouteHandler = async (
       (data as { mode?: unknown } | undefined)?.mode === "steer"
         ? "steer"
         : "normal";
+    if (mode === "steer" && value.trim().length === 0) {
+      const queued = newestQueuedMessage(ctx.stateRef.current);
+      if (queued) {
+        await ctx.steerQueuedMessage(queued.tabId, queued.message.id);
+      }
+      return true;
+    }
     await ctx.sendChat(value, { mode });
     return true;
   }

--- a/src/skills/default-layout/chat.test.tsx
+++ b/src/skills/default-layout/chat.test.tsx
@@ -182,6 +182,37 @@ describe("ChatInput", () => {
     });
   });
 
+  it("submits empty command-enter when queued messages can be steered", () => {
+    const { input, onEvent } = renderInput(
+      vi.fn(),
+      { disabled: { $ref: "/waiting" }, queueCount: { $ref: "/queueCount" } },
+      {
+        waiting: true,
+        queueCount: 1,
+        queuedMessages: [{ id: "q1", content: "latest queued" }],
+      },
+    );
+
+    fireEvent.keyDown(input, { key: "Enter", metaKey: true });
+
+    expect(onEvent).toHaveBeenLastCalledWith("submit", {
+      value: "",
+      mode: "steer",
+    });
+  });
+
+  it("does not submit empty command-enter without queued messages", () => {
+    const { input, onEvent } = renderInput(
+      vi.fn(),
+      { disabled: { $ref: "/waiting" }, queueCount: { $ref: "/queueCount" } },
+      { waiting: true, queueCount: 0, queuedMessages: [] },
+    );
+
+    fireEvent.keyDown(input, { key: "Enter", metaKey: true });
+
+    expect(onEvent).not.toHaveBeenCalledWith("submit", expect.any(Object));
+  });
+
   it("does not submit shift-enter", () => {
     const { input, onEvent } = renderInput();
 
@@ -215,6 +246,7 @@ describe("ChatInput", () => {
     expect(screen.getByText("+2").getAttribute("title")).toBe(
       "2 messages queued behind the current prompt",
     );
+    expect(screen.getByText("Cmd/Ctrl+Enter steers latest queued")).toBeTruthy();
   });
 
   it("renders queued and steered delivery badges on user messages", () => {

--- a/src/skills/default-layout/chat.tsx
+++ b/src/skills/default-layout/chat.tsx
@@ -864,6 +864,9 @@ export function ChatInput({
   const queueCount = props.queueCount
     ? resolveNumber(props.queueCount, state)
     : 0;
+  const queuedMessages =
+    (state.queuedMessages as QueuedMessage[] | undefined) ?? [];
+  const canSteerQueuedMessage = queuedMessages.length > 0 || queueCount > 0;
   const sendLabel = props.sendLabel
     ? resolveString(props.sendLabel, state)
     : "Send";
@@ -1085,7 +1088,12 @@ export function ChatInput({
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     const submit = (mode: "normal" | "steer") => {
       const v = (e.target as HTMLTextAreaElement).value;
-      if (v.trim().length === 0) return;
+      if (v.trim().length === 0) {
+        if (mode === "steer" && canSteerQueuedMessage) {
+          onEvent("submit", { value: "", mode });
+        }
+        return;
+      }
       commitDraft(v);
       onEvent("submit", { value: v, mode });
     };
@@ -1306,7 +1314,11 @@ export function ChatInput({
       {busy && (
         <div className="a2ui-chat-input-hint">
           <span>Enter queues</span>
-          <span>Cmd/Ctrl+Enter steers</span>
+          <span>
+            {canSteerQueuedMessage
+              ? "Cmd/Ctrl+Enter steers latest queued"
+              : "Cmd/Ctrl+Enter steers"}
+          </span>
         </div>
       )}
       {/* Wrap the textarea and action button so Send sits INSIDE the


### PR DESCRIPTION
## Summary

Closes #91.

This updates the busy composer shortcut so `Cmd/Ctrl+Enter` with an empty composer promotes the newest queued follow-up message into an immediate steer.

## What changed

- Allows `ChatInput` to emit a steer submit with an empty value when queued messages exist.
- Routes empty steer submits to `steerQueuedMessage` instead of `sendChat`, selecting the bottom-most/newest queued item.
- Leaves existing behavior unchanged when the composer has text: `Cmd/Ctrl+Enter` steers that text.
- Leaves empty composer behavior unchanged when no queue exists: no-op.
- Updates the busy hint to say `Cmd/Ctrl+Enter steers latest queued` when queued messages are present.

## Why this avoids duplicate follow-ups

The existing `steerQueuedMessage` path already removes the queued entry before sending it as `mode: "steer"`, then clears the row spinner after dispatch settles. Reusing that path means the promoted message is no longer in the client-held queue and will not drain later as a normal follow-up.

## Tests

- `bunx vitest run src/skills/default-layout/chat.test.tsx src/eventRoutes/chatInput.test.ts`
- `bunx vitest run src/eventRoutes/chatInput.test.ts src/eventRoutes/queue.test.ts src/eventRoutes/index.test.ts src/hooks/useChat.test.ts src/hooks/useQueuedDispatch.test.ts src/skills/default-layout/chat.test.tsx`
- `bunx tsc -b --noEmit`
- `bunx eslint src/eventRoutes/chatInput.ts src/eventRoutes/chatInput.test.ts src/skills/default-layout/chat.tsx src/skills/default-layout/chat.test.tsx`
- `bunx vitest run`

Note: full vitest passes with existing test-suite warning/log noise around mocked extension loading, localStorage, and canvas context support.
