### PR TITLE
refactor(sidebar): split file tree panel

### DIFF
--- a/src/skills/default-layout/sidebar/file-tree.test.tsx
+++ b/src/skills/default-layout/sidebar/file-tree.test.tsx
@@ -362,6 +362,46 @@ describe("FileTreePanel", () => {
     ).toBeTruthy();
   });
 
+  it("closes an open context menu when the project changes", async () => {
+    invokeMock.mockImplementation((cmd: string, args?: { path?: string }) => {
+      if (cmd === "fs_list_dir" && args?.path === "/projects/aethon") {
+        return Promise.resolve([
+          {
+            name: "App.tsx",
+            path: "/projects/aethon/src/App.tsx",
+            kind: "file",
+          },
+        ]);
+      }
+      if (cmd === "fs_list_dir" && args?.path === "/projects/other") {
+        return Promise.resolve([
+          {
+            name: "README.md",
+            path: "/projects/other/README.md",
+            kind: "file",
+          },
+        ]);
+      }
+      return Promise.resolve([]);
+    });
+    const { rerender } = render(<FileTreePanel {...panelProps()} />);
+    const row = await waitFor(() => screen.getByText("App.tsx"));
+    fireEvent.contextMenu(row);
+    expect(screen.getByRole("menuitem", { name: /New File…/ })).toBeTruthy();
+
+    rerender(
+      <FileTreePanel
+        {...panelProps({
+          state: { project: { path: "/projects/other", name: "other" } },
+        })}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByRole("menuitem", { name: /New File…/ })).toBeNull();
+    });
+  });
+
   it("creates a file via the New File menu and opens it", async () => {
     invokeMock.mockResolvedValueOnce([
       { name: "src", path: "/projects/aethon/src", kind: "dir" },

--- a/src/skills/default-layout/sidebar/file-tree.tsx
+++ b/src/skills/default-layout/sidebar/file-tree.tsx
@@ -2,302 +2,42 @@
  * FileTreePanel — sidebar section that browses the active project's
  * working directory tree and opens files in editor tabs.
  *
- * Design:
- *
- *   - Lazy: a folder's children are only fetched the first time the user
- *     expands it. The render is a flat list of currently-visible nodes
- *     (recursive flattening from the in-memory tree) so the DOM stays
- *     small even on huge repos.
- *   - State-local: expand-state lives in this component and is persisted
- *     to `~/.aethon/file-tree.json` per-project so reopening Aethon
- *     restores the prior view.
- *   - Single-click on a file fires a `file-tree-open` event with the
- *     absolute file path. The eventRoutes/editor handler opens (or
- *     focuses) an editor tab for that path.
- *   - Right-click is reserved for the context menu landed in phase 5.
- *
- * Why not lean on the existing Sidebar section system: the sidebar's
- * flat-item model can't express hierarchy + expand/collapse + lazy
- * loading without contorting `SidebarItem`. A dedicated composite is
- * smaller surface and easier to swap out via `aethon.registerComponent`.
+ * The component is intentionally a thin render shell. Tree loading and
+ * persistence live in useFileTreeData, file watching in useFileTreeWatch,
+ * prefs in useFileTreePrefs, and context-menu operations in fileTreeActions.
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { invoke } from "@tauri-apps/api/core";
-import { listen } from "@tauri-apps/api/event";
-import { readState, writeState } from "../../../persist";
 import {
-  ContextMenu,
-  type ContextMenuItem,
-} from "../../../components/primitives/context-menu";
+  useEffect,
+  useMemo,
+  useState,
+  type CSSProperties,
+  type MouseEvent as ReactMouseEvent,
+} from "react";
+import { invoke } from "@tauri-apps/api/core";
+
 import { FileIcon } from "../../../components/file-icon";
 import type { BuiltinComponentProps } from "../../../components/A2UIRenderer";
+import { ContextMenu } from "../../../components/primitives/context-menu";
+import { useFileTreeActions } from "./fileTreeActions";
 import {
-  visibleChangedDirs,
-  type FsTreeChangedPayload,
-} from "./file-tree-watch";
-
-interface FsEntry {
-  name: string;
-  path: string;
-  kind: "file" | "dir";
-}
-
-type GitFileStatusKind =
-  | "modified"
-  | "added"
-  | "untracked"
-  | "deleted"
-  | "renamed"
-  | "copied"
-  | "conflicted";
-
-interface GitFileStatusEntry {
-  path: string;
-  status: GitFileStatusKind;
-  originalPath?: string | null;
-}
-
-interface GitDecoration {
-  status: GitFileStatusKind;
-  source: "direct" | "descendant";
-}
-
-interface GitStatusMeta {
-  label: string;
-  title: string;
-}
-
-const GIT_STATUS_META: Record<GitFileStatusKind, GitStatusMeta> = {
-  modified: { label: "M", title: "Modified" },
-  added: { label: "A", title: "Added" },
-  untracked: { label: "U", title: "Untracked" },
-  deleted: { label: "D", title: "Deleted" },
-  renamed: { label: "R", title: "Renamed" },
-  copied: { label: "C", title: "Copied" },
-  conflicted: { label: "!", title: "Conflicted" },
-};
-
-const GIT_STATUS_PRIORITY: Record<GitFileStatusKind, number> = {
-  conflicted: 70,
-  deleted: 60,
-  renamed: 50,
-  added: 40,
-  untracked: 30,
-  copied: 20,
-  modified: 10,
-};
-
-/** A node in the in-memory tree. `children` is undefined until the
- *  folder has been loaded; null means "load attempted, no children". */
-interface TreeNode {
-  entry: FsEntry;
-  depth: number;
-  children?: TreeNode[] | null;
-  loading?: boolean;
-  loadError?: string;
-}
-
-interface EditorTabShape {
-  id?: string;
-  kind?: string;
-  editor?: {
-    rootPath?: string;
-  };
-}
-
-/** Persisted expand-state. Each project keeps its own set of expanded
- *  absolute paths so reopening lands on the prior view. Capped per
- *  project to bound the persisted file's size. */
-interface ExpandedStore {
-  byProject: Record<string, string[]>;
-}
-
-const EXPAND_STATE_FILE = "file-tree.json";
-const EXPANDED_CAP_PER_PROJECT = 200;
-
-function basename(path: string): string {
-  return (
-    path
-      .split(/[/\\]+/)
-      .filter(Boolean)
-      .pop() ?? path
-  );
-}
-
-function dirname(path: string): string {
-  const slash = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
-  return slash >= 0 ? path.slice(0, slash) : "";
-}
-
-function normalizeRelativePath(path: string): string {
-  return path.replace(/\\/g, "/").replace(/^\/+/, "").replace(/\/+$/, "");
-}
-
-function relativePathFor(rootPath: string, path: string): string | null {
-  if (!rootPath || !path) return null;
-  const root = rootPath.replace(/\\/g, "/").replace(/\/+$/, "");
-  const target = path.replace(/\\/g, "/");
-  if (target === root) return "";
-  if (target.startsWith(`${root}/`)) {
-    return normalizeRelativePath(target.slice(root.length + 1));
-  }
-  return null;
-}
-
-function absolutePathFor(rootPath: string, relativePath: string): string {
-  const separator =
-    rootPath.includes("\\") && !rootPath.includes("/") ? "\\" : "/";
-  const normalizedRelative = normalizeRelativePath(relativePath).replace(
-    /\//g,
-    separator,
-  );
-  return `${rootPath.replace(/[\\/]+$/, "")}${separator}${normalizedRelative}`;
-}
-
-function normalizeAbsolutePath(path: string): string {
-  return path.replace(/\\/g, "/").replace(/\/+$/, "");
-}
-
-function parentRelativePath(relativePath: string): string {
-  return dirname(normalizeRelativePath(relativePath)).replace(/^\/+/, "");
-}
-
-function strongerGitStatus(
-  a: GitFileStatusKind | undefined,
-  b: GitFileStatusKind,
-): GitFileStatusKind {
-  if (!a) return b;
-  return GIT_STATUS_PRIORITY[b] > GIT_STATUS_PRIORITY[a] ? b : a;
-}
-
-function sortTreeNodes(nodes: TreeNode[]): TreeNode[] {
-  return [...nodes].sort((a, b) => {
-    if (a.entry.kind !== b.entry.kind) {
-      return a.entry.kind === "dir" ? -1 : 1;
-    }
-    return a.entry.name.toLowerCase().localeCompare(b.entry.name.toLowerCase());
-  });
-}
-
-function gitStatusesFromEntries(
-  entries: GitFileStatusEntry[] | null | undefined,
-): Map<string, GitFileStatusEntry> {
-  const map = new Map<string, GitFileStatusEntry>();
-  if (!Array.isArray(entries)) return map;
-  for (const entry of entries) {
-    const path = normalizeRelativePath(entry.path);
-    if (!path) continue;
-    map.set(path, { ...entry, path });
-  }
-  return map;
-}
-
-/** Return the directory of `node`'s entry: the node itself when it's a
- *  folder, the containing folder when it's a file. Used by the
- *  context menu's New File / New Folder actions to anchor at the
- *  right location regardless of which row the user right-clicked. */
-function parentDirOf(node: TreeNode): string {
-  if (node.entry.kind === "dir") return node.entry.path;
-  const slash = Math.max(
-    node.entry.path.lastIndexOf("/"),
-    node.entry.path.lastIndexOf("\\"),
-  );
-  return slash >= 0 ? node.entry.path.slice(0, slash) : node.entry.path;
-}
-
-function withDepth(node: TreeNode, depth: number): TreeNode {
-  const delta = depth - node.depth;
-  if (delta === 0) return node;
-  const walk = (current: TreeNode): TreeNode => ({
-    ...current,
-    depth: current.depth + delta,
-    children: current.children?.map(walk) ?? current.children,
-  });
-  return walk(node);
-}
-
-function nodesFromEntries(
-  entries: FsEntry[],
-  depth: number,
-  previousChildren?: TreeNode[] | null,
-): TreeNode[] {
-  const previousByPath = new Map(
-    (previousChildren ?? []).map((child) => [child.entry.path, child]),
-  );
-  return entries.map((entry) => {
-    const previous = previousByPath.get(entry.path);
-    if (!previous) return { entry, depth };
-    return {
-      ...withDepth(previous, depth),
-      entry,
-      loadError: undefined,
-    };
-  });
-}
-
-/** Parse the persisted store; tolerate corruption by returning empty. */
-function parseExpandedStore(raw: string): ExpandedStore {
-  if (!raw) return { byProject: {} };
-  try {
-    const parsed: unknown = JSON.parse(raw);
-    if (
-      parsed &&
-      typeof parsed === "object" &&
-      "byProject" in parsed &&
-      typeof parsed.byProject === "object"
-    ) {
-      const map = parsed.byProject as Record<string, unknown>;
-      const cleaned: Record<string, string[]> = {};
-      for (const [projectPath, list] of Object.entries(map)) {
-        if (Array.isArray(list)) {
-          cleaned[projectPath] = list.filter(
-            (p): p is string => typeof p === "string",
-          );
-        }
-      }
-      return { byProject: cleaned };
-    }
-  } catch {
-    /* fall through */
-  }
-  return { byProject: {} };
-}
-
-interface ProjectShape {
-  path?: string;
-  name?: string;
-}
-
-interface ContextMenuState {
-  x: number;
-  y: number;
-  node: TreeNode;
-}
-
-const PANEL_PREFS_FILE = "file-tree-prefs.json";
-const PANEL_HEIGHT_DEFAULT = 280;
-const PANEL_HEIGHT_MIN = 120;
-const PANEL_HEIGHT_MAX = 1200;
-const SIDEBAR_WIDTH_MIN = 220;
-const SIDEBAR_WIDTH_MAX = 640;
-
-interface PanelPrefs {
-  collapsed?: boolean;
-  hidden?: boolean;
-  height?: number;
-}
-
-function readPanelPrefs(raw: string): PanelPrefs {
-  if (!raw) return {};
-  try {
-    const v = JSON.parse(raw);
-    if (v && typeof v === "object") return v as PanelPrefs;
-  } catch {
-    /* fall through */
-  }
-  return {};
-}
+  GIT_STATUS_META,
+  basename,
+  relativePathFor,
+  type EditorTabShape,
+  type GitDecoration,
+  type ProjectShape,
+  type TreeNode,
+} from "./fileTreeModel";
+import { useFileTreeData } from "./useFileTreeData";
+import {
+  PANEL_HEIGHT_MAX,
+  PANEL_HEIGHT_MIN,
+  SIDEBAR_WIDTH_MAX,
+  SIDEBAR_WIDTH_MIN,
+  useFileTreePrefs,
+} from "./useFileTreePrefs";
+import { useFileTreeWatch } from "./useFileTreeWatch";
 
 export function FileTreePanel({
   component,
@@ -307,10 +47,8 @@ export function FileTreePanel({
   const componentProps =
     (component.props as { embed?: string } | undefined) ?? {};
   // When `embed === "right-sidebar"` the file tree fills its parent grid
-  // cell vertically — the parent area controls height, so the internal
-  // resize handle + hide button are dropped. The "left-stack" default
-  // (no embed prop) keeps the legacy resize-as-bottom-panel behavior
-  // for custom layouts still using the old shape.
+  // cell vertically. Legacy left-stack layouts keep the resizable bottom
+  // panel behavior.
   const embedMode = componentProps.embed ?? "left-stack";
   const fillsContainer = embedMode === "right-sidebar";
   const project = state["project"] as ProjectShape | undefined;
@@ -338,15 +76,8 @@ export function FileTreePanel({
     };
   }, [activeEditorRoot, aethonRoot, project?.path]);
 
-  // Honor the active worktree when one is selected — `/activeWorktreeId`
-  // is mirrored onto root state by useProjectOps. The file tree should
-  // reflect whichever cwd new tabs would inherit so user mental model
-  // stays "file panel = where I'm working." Falls back to the project
-  // root when no worktree is active. When no project is active, browse
-  // the active editor tab's root (e.g. ~/.aethon from Settings) or the
-  // Aethon home dir for the dashboard.
   const activeWorktreeId = (state["activeWorktreeId"] as string | null) ?? null;
-  const projectPath = (() => {
+  const projectPath = useMemo(() => {
     if (activeWorktreeId) {
       const sidebar = state["sidebar"] as
         | {
@@ -363,369 +94,37 @@ export function FileTreePanel({
       }
     }
     return project?.path ?? activeEditorRoot ?? aethonRoot;
-  })();
+  }, [activeEditorRoot, activeWorktreeId, aethonRoot, project?.path, state]);
   const rootLabel = (project?.name ?? basename(projectPath)) || "files";
 
-  // Root node represents the project's working directory. Children are
-  // loaded eagerly on mount; switching projects swaps roots.
-  const [root, setRoot] = useState<TreeNode | null>(null);
-  // Set of expanded absolute paths. Driving render, mirror-saved to disk.
-  const [expanded, setExpanded] = useState<Set<string>>(new Set());
-  const [gitStatuses, setGitStatuses] = useState<
-    Map<string, GitFileStatusEntry>
-  >(new Map());
-  const [error, setError] = useState<string>("");
-  // Panel chrome state — collapsed header (just shows the "files" row,
-  // hides the tree), hidden entirely (panel offscreen), and the panel
-  // height when expanded (drag handle resizes; clamped to a sensible
-  // range so it can't squeeze the rest of the sidebar). Persisted to
-  // ~/.aethon/file-tree-prefs.json.
-  const [collapsed, setCollapsed] = useState<boolean>(false);
-  const [hidden, setHidden] = useState<boolean>(false);
-  const [height, setHeight] = useState<number>(PANEL_HEIGHT_DEFAULT);
-  const prefsHydrated = useRef<boolean>(false);
-  const prefsSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
-  const expandedStoreRef = useRef<ExpandedStore>({ byProject: {} });
-  const projectPathRef = useRef<string>(projectPath);
-  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const watchSyncTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const watchedRootRef = useRef<string>("");
-  const refreshDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const pendingRefreshDirsRef = useRef<Set<string>>(new Set());
-  const gitStatusRefreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
-    null,
-  );
+  const { collapsed, hidden, height, setCollapsed, setHidden, setHeight } =
+    useFileTreePrefs();
+  const {
+    error,
+    expanded,
+    gitDecorations,
+    projectPathRef,
+    refreshFolder,
+    root,
+    toggleFolder,
+    visibleNodes,
+    watchedDirs,
+  } = useFileTreeData({ hidden, projectPath, rootLabel });
 
-  useEffect(() => {
-    projectPathRef.current = projectPath;
-  }, [projectPath]);
+  useFileTreeWatch({
+    projectPath,
+    projectPathRef,
+    refreshFolder,
+    watchedDirs,
+  });
 
-  // Hydrate the persisted expand-state once on mount. Tauri's read_state
-  // returns "" when the file doesn't exist (clean first-run).
-  useEffect(() => {
-    let cancelled = false;
-    void readState(EXPAND_STATE_FILE).then((raw) => {
-      if (cancelled) return;
-      const parsed = parseExpandedStore(raw);
-      expandedStoreRef.current = parsed;
-      if (projectPathRef.current) {
-        const prior = parsed.byProject[projectPathRef.current];
-        if (prior?.length) setExpanded(new Set(prior));
-      }
+  const { contextMenu, fileTreeMenuItems, openContextMenu, setContextMenu } =
+    useFileTreeActions({
+      onEvent,
+      projectPath,
+      projectPathRef,
+      refreshFolder,
     });
-    void readState(PANEL_PREFS_FILE).then((raw) => {
-      if (cancelled) return;
-      const prefs = readPanelPrefs(raw);
-      if (typeof prefs.collapsed === "boolean") setCollapsed(prefs.collapsed);
-      if (typeof prefs.hidden === "boolean") setHidden(prefs.hidden);
-      if (
-        typeof prefs.height === "number" &&
-        prefs.height >= PANEL_HEIGHT_MIN &&
-        prefs.height <= PANEL_HEIGHT_MAX
-      ) {
-        setHeight(prefs.height);
-      }
-      prefsHydrated.current = true;
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  // Persist panel prefs (collapsed / hidden / height) whenever they
-  // change after the initial hydrate. Debounced because the drag
-  // handle fires height updates on every mousemove.
-  useEffect(() => {
-    if (!prefsHydrated.current) return;
-    if (prefsSaveTimerRef.current) clearTimeout(prefsSaveTimerRef.current);
-    prefsSaveTimerRef.current = setTimeout(() => {
-      void writeState(
-        PANEL_PREFS_FILE,
-        JSON.stringify({ collapsed, hidden, height }),
-      );
-    }, 200);
-  }, [collapsed, hidden, height]);
-
-  // Listen for the global `aethon:toggle-file-tree` event so the panels
-  // sidebar item / a future keybinding can hide-and-show the panel from
-  // the outside without prop drilling.
-  useEffect(() => {
-    const toggle = () => setHidden((h) => !h);
-    const resetPrefs = () => {
-      setCollapsed(false);
-      setHidden(false);
-      setHeight(PANEL_HEIGHT_DEFAULT);
-    };
-    window.addEventListener("aethon:toggle-file-tree", toggle);
-    window.addEventListener("aethon:reset-file-tree-prefs", resetPrefs);
-    return () => {
-      window.removeEventListener("aethon:toggle-file-tree", toggle);
-      window.removeEventListener("aethon:reset-file-tree-prefs", resetPrefs);
-    };
-  }, []);
-
-  // Schedule a debounced persist whenever the active project's expand
-  // set changes. Debounce avoids hammering disk during rapid expand/collapse.
-  const schedulePersist = useCallback((next: Set<string>) => {
-    const projectKey = projectPathRef.current;
-    if (!projectKey) return;
-    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
-    saveTimerRef.current = setTimeout(() => {
-      const list = [...next].slice(0, EXPANDED_CAP_PER_PROJECT);
-      expandedStoreRef.current.byProject[projectKey] = list;
-      void writeState(
-        EXPAND_STATE_FILE,
-        JSON.stringify(expandedStoreRef.current),
-      );
-    }, 250);
-  }, []);
-
-  const refreshGitStatuses = useCallback(async (rootPath: string) => {
-    if (!rootPath) {
-      setGitStatuses(new Map());
-      return;
-    }
-    try {
-      const entries = await invoke<GitFileStatusEntry[] | null>(
-        "git_file_status",
-        { root: rootPath },
-      );
-      if (projectPathRef.current !== rootPath) return;
-      setGitStatuses(gitStatusesFromEntries(entries));
-    } catch {
-      // Non-git directories, missing git binary, or transient status errors
-      // should never block the file tree; just render without decorations.
-      if (projectPathRef.current === rootPath) setGitStatuses(new Map());
-    }
-  }, []);
-
-  const scheduleGitStatusRefresh = useCallback(
-    (rootPath = projectPathRef.current) => {
-      if (gitStatusRefreshTimerRef.current) {
-        clearTimeout(gitStatusRefreshTimerRef.current);
-      }
-      gitStatusRefreshTimerRef.current = setTimeout(() => {
-        gitStatusRefreshTimerRef.current = null;
-        void refreshGitStatuses(rootPath);
-      }, 180);
-    },
-    [refreshGitStatuses],
-  );
-
-  // Fetch the root directory listing whenever the active project changes.
-  // The two synchronous setState calls here are intentional: they reset
-  // local in-effect state (last project's tree + error) before kicking
-  // off the async fetch for the new root. Splitting into a derived-from-
-  // props pattern would force a re-render dance every time the user
-  // expands a folder elsewhere.
-  useEffect(() => {
-    if (gitStatusRefreshTimerRef.current) {
-      clearTimeout(gitStatusRefreshTimerRef.current);
-      gitStatusRefreshTimerRef.current = null;
-    }
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setRoot(null);
-    setGitStatuses(new Map());
-    setError("");
-    // Reset the expanded set to the new project's persisted entries
-    // (or empty when this is the first time the user has opened it).
-    // Without this, switching projects would carry the previous
-    // project's expanded paths over — collapsed visually in the tree
-    // but still present in the set, so the next toggle would write
-    // them back into the wrong project's persist slot.
-    setExpanded(new Set(expandedStoreRef.current.byProject[projectPath] ?? []));
-    if (!projectPath) return;
-    let cancelled = false;
-    void invoke<FsEntry[]>("fs_list_dir", {
-      root: projectPath,
-      path: projectPath,
-    })
-      .then(async (entries) => {
-        if (cancelled) return;
-        const rootNode: TreeNode = {
-          entry: {
-            name: rootLabel,
-            path: projectPath,
-            kind: "dir",
-          },
-          depth: 0,
-          children: nodesFromEntries(entries, 1),
-        };
-        setRoot(rootNode);
-        void refreshGitStatuses(projectPath);
-        // Hydrate any persisted-expanded folders so the user comes back
-        // to the same view they left. We fetch from the outside in
-        // (shorter paths first) so a parent's children land before its
-        // descendants get their refreshFolder call. Capped against the
-        // currently-known set so we don't try to load arbitrary paths
-        // that no longer exist.
-        const expandedNow =
-          expandedStoreRef.current.byProject[projectPath] ?? [];
-        if (expandedNow.length === 0) return;
-        const ordered = [...expandedNow].sort((a, b) => a.length - b.length);
-        for (const folderPath of ordered) {
-          if (cancelled) return;
-          try {
-            const childEntries = await invoke<FsEntry[]>("fs_list_dir", {
-              root: projectPath,
-              path: folderPath,
-            });
-            if (cancelled) return;
-            setRoot((r) => {
-              if (!r) return r;
-              const walk = (node: TreeNode): TreeNode => {
-                if (node.entry.path === folderPath) {
-                  return {
-                    ...node,
-                    children: nodesFromEntries(
-                      childEntries,
-                      node.depth + 1,
-                      node.children,
-                    ),
-                  };
-                }
-                if (!node.children) return node;
-                return { ...node, children: node.children.map(walk) };
-              };
-              return { ...r, children: r.children?.map(walk) ?? undefined };
-            });
-          } catch {
-            // Folder may have been deleted since last persist; skip it
-            // silently — the user can re-expand if they want.
-          }
-        }
-      })
-      .catch((err: unknown) => {
-        if (cancelled) return;
-        setError(String(err));
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [projectPath, refreshGitStatuses, rootLabel]);
-
-  // Load a folder's children on demand. No-op if already loaded.
-  const loadFolderChildren = useCallback(
-    async (node: TreeNode): Promise<TreeNode[] | null> => {
-      if (!projectPathRef.current) return null;
-      try {
-        const entries = await invoke<FsEntry[]>("fs_list_dir", {
-          root: projectPathRef.current,
-          path: node.entry.path,
-        });
-        return nodesFromEntries(entries, node.depth + 1, node.children);
-      } catch (err) {
-        node.loadError = String(err);
-        return null;
-      }
-    },
-    [],
-  );
-
-  // Toggle expand/collapse. Loading is fire-and-forget — the click
-  // returns immediately and the tree re-renders when children arrive.
-  const toggleFolder = useCallback(
-    (node: TreeNode) => {
-      const path = node.entry.path;
-      setExpanded((prev) => {
-        const next = new Set(prev);
-        if (next.has(path)) {
-          next.delete(path);
-        } else {
-          next.add(path);
-          if (node.children === undefined) {
-            // Trigger lazy load. Mutating the existing root in place is
-            // fine here because the new Set() above is what React reacts
-            // to; the tree mutation just amends the in-memory cache.
-            node.loading = true;
-            void loadFolderChildren(node).then((kids) => {
-              node.children = kids;
-              node.loading = false;
-              // Bump the root reference so React notices the mutation.
-              setRoot((r) => (r ? { ...r } : r));
-            });
-          }
-        }
-        schedulePersist(next);
-        return next;
-      });
-    },
-    [loadFolderChildren, schedulePersist],
-  );
-
-  const gitDecorations = useMemo(() => {
-    const direct = new Map<string, GitFileStatusKind>();
-    const descendants = new Map<string, GitFileStatusKind>();
-    for (const [path, entry] of gitStatuses) {
-      direct.set(path, entry.status);
-      const parts = path.split("/").filter(Boolean);
-      for (let i = 1; i < parts.length; i += 1) {
-        const dir = parts.slice(0, i).join("/");
-        descendants.set(
-          dir,
-          strongerGitStatus(descendants.get(dir), entry.status),
-        );
-      }
-    }
-    return { direct, descendants };
-  }, [gitStatuses]);
-
-  const deletedChildrenByParent = useMemo(() => {
-    const byParent = new Map<string, FsEntry[]>();
-    if (!projectPath) return byParent;
-    for (const [path, entry] of gitStatuses) {
-      if (entry.status !== "deleted") continue;
-      const parent = parentRelativePath(path);
-      const children = byParent.get(parent) ?? [];
-      children.push({
-        name: basename(path),
-        path: absolutePathFor(projectPath, path),
-        kind: "file",
-      });
-      byParent.set(parent, children);
-    }
-    return byParent;
-  }, [gitStatuses, projectPath]);
-
-  // Flatten the tree into a render list of currently-visible nodes.
-  const visibleNodes = useMemo(() => {
-    if (!root) return [];
-    const out: TreeNode[] = [];
-    const childrenFor = (node: TreeNode): TreeNode[] => {
-      const children = node.children ?? [];
-      const parentRel = projectPath
-        ? relativePathFor(projectPath, node.entry.path)
-        : null;
-      const deleted =
-        parentRel == null ? [] : (deletedChildrenByParent.get(parentRel) ?? []);
-      if (deleted.length === 0) return children;
-      const existing = new Set(
-        children.map((child) => normalizeAbsolutePath(child.entry.path)),
-      );
-      const synthetic = deleted
-        .filter((entry) => !existing.has(normalizeAbsolutePath(entry.path)))
-        .map((entry) => ({ entry, depth: node.depth + 1 }));
-      return sortTreeNodes([...children, ...synthetic]);
-    };
-    const walk = (node: TreeNode) => {
-      out.push(node);
-      if (node.entry.kind !== "dir") return;
-      if (!expanded.has(node.entry.path)) return;
-      for (const child of childrenFor(node)) walk(child);
-    };
-    for (const child of childrenFor(root)) walk(child);
-    return out;
-  }, [deletedChildrenByParent, expanded, projectPath, root]);
-
-  const watchedDirs = useMemo(() => {
-    if (!projectPath || hidden) return [];
-    const dirs = new Set<string>([projectPath]);
-    for (const p of expanded) {
-      dirs.add(p);
-    }
-    return [...dirs].sort();
-  }, [expanded, hidden, projectPath]);
 
   const onItemClick = (node: TreeNode) => {
     if (node.entry.kind === "dir") {
@@ -738,357 +137,16 @@ export function FileTreePanel({
     });
   };
 
-  const onRowContextMenu = (e: React.MouseEvent, node: TreeNode) => {
-    e.preventDefault();
-    e.stopPropagation();
-    // Raw client coords; the ContextMenu primitive clamps + corrects
-    // for WebKit zoom-frame drift before positioning.
-    setContextMenu({ x: e.clientX, y: e.clientY, node });
-  };
-
-  // Pop a folder out of the tree's children cache so the next expand
-  // re-fetches it. Used after create/rename/delete so the tree reflects
-  // the new state without a full reload.
-  const invalidateFolder = useCallback((folderPath: string) => {
-    setRoot((r) => {
-      if (!r) return r;
-      const next = { ...r };
-      const walk = (node: TreeNode): TreeNode => {
-        if (node.entry.path === folderPath) {
-          return { ...node, children: undefined };
-        }
-        if (!node.children) return node;
-        return {
-          ...node,
-          children: node.children.map(walk),
-        };
-      };
-      next.children = next.children?.map(walk);
-      return next;
-    });
-  }, []);
-
-  // Re-fetch a folder's children inline (used after operations land —
-  // skips collapse+expand UX and just updates the visible tree).
-  // Handles the root case: when `folderPath === root.entry.path`, the
-  // walk's mapper would never see the root itself (it only iterates
-  // `r.children`). We special-case at the top so create/rename/delete
-  // on root-level items still refreshes the listing.
-  const refreshFolder = useCallback(
-    async (folderPath: string) => {
-      if (!projectPathRef.current) return;
-      try {
-        const entries = await invoke<FsEntry[]>("fs_list_dir", {
-          root: projectPathRef.current,
-          path: folderPath,
-        });
-        setRoot((r) => {
-          if (!r) return r;
-          // Root case: replace the root's children directly.
-          if (r.entry.path === folderPath) {
-            return {
-              ...r,
-              children: nodesFromEntries(entries, 1, r.children),
-            };
-          }
-          const walk = (node: TreeNode): TreeNode => {
-            if (node.entry.path === folderPath) {
-              return {
-                ...node,
-                children: nodesFromEntries(
-                  entries,
-                  node.depth + 1,
-                  node.children,
-                ),
-              };
-            }
-            if (!node.children) return node;
-            return { ...node, children: node.children.map(walk) };
-          };
-          return { ...r, children: r.children?.map(walk) ?? undefined };
-        });
-        scheduleGitStatusRefresh();
-      } catch {
-        invalidateFolder(folderPath);
-        scheduleGitStatusRefresh();
-      }
-    },
-    [invalidateFolder, scheduleGitStatusRefresh],
-  );
-
-  useEffect(() => {
-    if (watchSyncTimerRef.current) clearTimeout(watchSyncTimerRef.current);
-    const previousRoot = watchedRootRef.current;
-    if (!projectPath || watchedDirs.length === 0) {
-      if (previousRoot) {
-        watchedRootRef.current = "";
-        void invoke("fs_unwatch_root", { root: previousRoot }).catch(() => {
-          /* best-effort cleanup */
-        });
-      }
-      return;
-    }
-    watchedRootRef.current = projectPath;
-    watchSyncTimerRef.current = setTimeout(() => {
-      if (previousRoot && previousRoot !== projectPath) {
-        void invoke("fs_unwatch_root", { root: previousRoot }).catch(() => {
-          /* best-effort cleanup */
-        });
-      }
-      void invoke("fs_watch_dirs", {
-        root: projectPath,
-        dirs: watchedDirs,
-      }).catch(() => {
-        /* File watching is an enhancement; manual tree ops still refresh. */
-      });
-    }, 150);
-    return () => {
-      if (watchSyncTimerRef.current) {
-        clearTimeout(watchSyncTimerRef.current);
-        watchSyncTimerRef.current = null;
-      }
-    };
-  }, [projectPath, watchedDirs]);
-
-  useEffect(() => {
-    if (!projectPath) return;
-    let disposed = false;
-    let unlisten: (() => void) | undefined;
-    const pendingRefreshDirs = pendingRefreshDirsRef.current;
-    void listen<FsTreeChangedPayload>("fs-tree-changed", (event) => {
-      if (disposed || event.payload.root !== projectPathRef.current) return;
-      for (const dir of event.payload.dirs) {
-        pendingRefreshDirs.add(dir);
-      }
-      if (refreshDebounceRef.current) return;
-      refreshDebounceRef.current = setTimeout(() => {
-        refreshDebounceRef.current = null;
-        const dirs = visibleChangedDirs(
-          {
-            root: event.payload.root,
-            dirs: [...pendingRefreshDirs],
-          },
-          projectPathRef.current,
-          watchedDirs,
-        );
-        pendingRefreshDirs.clear();
-        for (const dir of dirs) {
-          void refreshFolder(dir);
-        }
-      }, 120);
-    }).then((fn) => {
-      if (disposed) {
-        fn();
-        return;
-      }
-      unlisten = fn;
-    });
-    return () => {
-      disposed = true;
-      if (refreshDebounceRef.current) {
-        clearTimeout(refreshDebounceRef.current);
-        refreshDebounceRef.current = null;
-      }
-      pendingRefreshDirs.clear();
-      unlisten?.();
-    };
-  }, [projectPath, refreshFolder, watchedDirs]);
-
-  useEffect(() => {
-    return () => {
-      const rootToUnwatch = watchedRootRef.current;
-      if (rootToUnwatch) {
-        void invoke("fs_unwatch_root", { root: rootToUnwatch }).catch(() => {
-          /* best-effort cleanup */
-        });
-      }
-      if (watchSyncTimerRef.current) clearTimeout(watchSyncTimerRef.current);
-      if (refreshDebounceRef.current) clearTimeout(refreshDebounceRef.current);
-      if (gitStatusRefreshTimerRef.current) {
-        clearTimeout(gitStatusRefreshTimerRef.current);
-      }
-    };
-  }, []);
-
-  const closeContextMenu = () => setContextMenu(null);
-
-  const onContextNewFile = async () => {
-    if (!contextMenu) return;
-    const parentPath = parentDirOf(contextMenu.node);
-    closeContextMenu();
-    const name = window.prompt("New file name");
-    if (!name) return;
-    const target = `${parentPath.replace(/\/$/, "")}/${name}`;
-    try {
-      await invoke("fs_create_file", {
-        root: projectPathRef.current,
-        path: target,
-      });
-      await refreshFolder(parentPath);
-      onEvent("file-tree-open", {
-        filePath: target,
-        rootPath: projectPathRef.current,
-      });
-    } catch (err) {
-      window.alert(`Failed to create file: ${String(err)}`);
-    }
-  };
-
-  const onContextNewFolder = async () => {
-    if (!contextMenu) return;
-    const parentPath = parentDirOf(contextMenu.node);
-    closeContextMenu();
-    const name = window.prompt("New folder name");
-    if (!name) return;
-    const target = `${parentPath.replace(/\/$/, "")}/${name}`;
-    try {
-      await invoke("fs_create_dir", {
-        root: projectPathRef.current,
-        path: target,
-      });
-      await refreshFolder(parentPath);
-    } catch (err) {
-      window.alert(`Failed to create folder: ${String(err)}`);
-    }
-  };
-
-  const onContextRename = async () => {
-    if (!contextMenu) return;
-    const node = contextMenu.node;
-    closeContextMenu();
-    const name = window.prompt("Rename to", node.entry.name);
-    if (!name || name === node.entry.name) return;
-    const dirIdx = Math.max(
-      node.entry.path.lastIndexOf("/"),
-      node.entry.path.lastIndexOf("\\"),
-    );
-    const parentPath =
-      dirIdx >= 0 ? node.entry.path.slice(0, dirIdx) : node.entry.path;
-    const target = `${parentPath}/${name}`;
-    try {
-      await invoke("fs_rename", {
-        root: projectPathRef.current,
-        from: node.entry.path,
-        to: target,
-      });
-      // Tell App-level routes about the rename so any open editor tab
-      // backed by the old path (or any descendant when renaming a
-      // folder) updates its filePath + label. Without this the next
-      // Cmd+S on a renamed-file's editor tab would write to the
-      // pre-rename location and resurrect the old file.
-      onEvent("file-tree-rename", {
-        from: node.entry.path,
-        to: target,
-        kind: node.entry.kind,
-      });
-      await refreshFolder(parentPath);
-    } catch (err) {
-      window.alert(`Rename failed: ${String(err)}`);
-    }
-  };
-
-  const onContextDelete = async () => {
-    if (!contextMenu) return;
-    const node = contextMenu.node;
-    closeContextMenu();
-    if (!window.confirm(`Move "${node.entry.name}" to the trash?`)) return;
-    const dirIdx = Math.max(
-      node.entry.path.lastIndexOf("/"),
-      node.entry.path.lastIndexOf("\\"),
-    );
-    const parentPath =
-      dirIdx >= 0 ? node.entry.path.slice(0, dirIdx) : node.entry.path;
-    try {
-      await invoke("fs_delete", {
-        root: projectPathRef.current,
-        path: node.entry.path,
-      });
-      // Notify the App-level routes so any open editor tab backed by
-      // the deleted path (or any descendant when deleting a folder)
-      // closes and drops its Monaco buffer. Without this, Cmd+S on a
-      // stale buffer would resurrect the trashed file.
-      onEvent("file-tree-delete", {
-        path: node.entry.path,
-        kind: node.entry.kind,
-      });
-      await refreshFolder(parentPath);
-    } catch (err) {
-      window.alert(`Delete failed: ${String(err)}`);
-    }
-  };
-
-  const onContextCopyPath = async () => {
-    if (!contextMenu) return;
-    const path = contextMenu.node.entry.path;
-    closeContextMenu();
-    try {
-      await navigator.clipboard.writeText(path);
-    } catch {
-      window.alert(path);
-    }
-  };
-
-  const onContextCopyRelativePath = async () => {
-    if (!contextMenu) return;
-    const root = projectPathRef.current.replace(/\/+$/, "");
-    const path = contextMenu.node.entry.path;
-    const rel = path.startsWith(root + "/")
-      ? path.slice(root.length + 1)
-      : path;
-    closeContextMenu();
-    try {
-      await navigator.clipboard.writeText(rel);
-    } catch {
-      window.alert(rel);
-    }
-  };
-
-  const onContextRevealInFinder = async () => {
-    if (!contextMenu) return;
-    const path = contextMenu.node.entry.path;
-    closeContextMenu();
-    // Rust command requires `root` so paths are gated by the active
-    // project root (matches the read/write/delete commands).
-    try {
-      await invoke("fs_reveal_in_file_manager", {
-        root: projectPath,
-        path,
-      });
-    } catch (err) {
-      window.alert(`Reveal failed: ${String(err)}`);
-    }
-  };
-
-  const onContextOpenWithDefault = async () => {
-    if (!contextMenu) return;
-    const path = contextMenu.node.entry.path;
-    closeContextMenu();
-    try {
-      await invoke("fs_open_in_default_app", {
-        root: projectPath,
-        path,
-      });
-    } catch (err) {
-      window.alert(`Open failed: ${String(err)}`);
-    }
-  };
-
   if (hidden) {
-    // Panel toggled off. Render nothing so the flex container collapses
-    // and other sidebar sections claim the space. The toggle event
-    // brings it back without losing collapsed/height prefs.
     return null;
   }
 
-  const startResize = (e: React.MouseEvent) => {
+  const startResize = (e: ReactMouseEvent) => {
     e.preventDefault();
     const startY = e.clientY;
     const startHeight = height;
     document.body.classList.add("ae-resizing-sidebar");
     const onMove = (ev: MouseEvent) => {
-      // Drag handle sits at the TOP of the panel — dragging UP grows
-      // the panel (decreasing the panel's flex-basis is reversed
-      // compared to a bottom handle).
       const dy = startY - ev.clientY;
       const next = Math.max(
         PANEL_HEIGHT_MIN,
@@ -1105,7 +163,7 @@ export function FileTreePanel({
     document.addEventListener("mouseup", onUp);
   };
 
-  const startSidebarResize = (e: React.MouseEvent) => {
+  const startSidebarResize = (e: ReactMouseEvent) => {
     e.preventDefault();
     const startX = e.clientX;
     const host = (e.currentTarget as HTMLElement).closest(".ae-file-tree");
@@ -1141,53 +199,6 @@ export function FileTreePanel({
     />
   ) : null;
 
-  // Items array for the right-click menu. Memoizing on the contextMenu
-  // identity is enough here — handlers reference state via closures and
-  // close over a stable `contextMenu` per render, so changing the menu
-  // target rebuilds the items, and `setContextMenu(null)` collapses
-  // them to an empty list.
-  const fileTreeMenuItems: ContextMenuItem[] = contextMenu
-    ? [
-        { id: "new-file", label: "New File…", onSelect: onContextNewFile },
-        {
-          id: "new-folder",
-          label: "New Folder…",
-          onSelect: onContextNewFolder,
-        },
-        { type: "separator" },
-        {
-          id: "reveal-in-finder",
-          label: "Reveal in File Manager",
-          onSelect: onContextRevealInFinder,
-        },
-        {
-          id: "open-with-default",
-          label: "Open with default app",
-          disabled: contextMenu.node.entry.kind !== "file",
-          onSelect: onContextOpenWithDefault,
-        },
-        { type: "separator" },
-        { id: "rename", label: "Rename…", onSelect: onContextRename },
-        {
-          id: "delete",
-          label: "Move to Trash…",
-          danger: true,
-          onSelect: onContextDelete,
-        },
-        { type: "separator" },
-        { id: "copy-path", label: "Copy Path", onSelect: onContextCopyPath },
-        {
-          id: "copy-rel",
-          label: "Copy Relative Path",
-          onSelect: onContextCopyRelativePath,
-        },
-      ]
-    : [];
-
-  // Project label + active worktree branch — shown in the panel header
-  // so the user always knows whose files they're looking at without
-  // hopping up to the sidebar projects list. Derived from the same
-  // /sidebar/projects path the sidebar reads from.
   const sidebarProjects =
     ((state.sidebar as Record<string, unknown> | undefined)?.projects as
       | Array<{
@@ -1251,14 +262,22 @@ export function FileTreePanel({
     </div>
   );
 
-  // In right-sidebar embed, the grid cell controls height — fill it.
-  // In legacy left-stack mode, use the resizable flex-basis pattern so
-  // custom layouts that haven't migrated keep working.
-  const panelStyle: React.CSSProperties = fillsContainer
+  const panelStyle: CSSProperties = fillsContainer
     ? { flex: "1 1 auto", minHeight: 0 }
     : collapsed
       ? { flex: "0 0 auto" }
       : { flex: `0 0 ${height}px` };
+
+  const resizeHandle =
+    !collapsed && !fillsContainer ? (
+      <div
+        className="ae-file-tree-resize-handle"
+        role="separator"
+        aria-orientation="horizontal"
+        aria-label="Resize files panel"
+        onMouseDown={startResize}
+      />
+    ) : null;
 
   if (!projectPath) {
     return (
@@ -1267,15 +286,7 @@ export function FileTreePanel({
         style={panelStyle}
       >
         {sidebarResizeHandle}
-        {!collapsed && !fillsContainer && (
-          <div
-            className="ae-file-tree-resize-handle"
-            role="separator"
-            aria-orientation="horizontal"
-            aria-label="Resize files panel"
-            onMouseDown={startResize}
-          />
-        )}
+        {resizeHandle}
         {titleRow}
         {!collapsed && <div className="a2ui-sidebar-empty">no project</div>}
       </div>
@@ -1288,15 +299,7 @@ export function FileTreePanel({
         style={panelStyle}
       >
         {sidebarResizeHandle}
-        {!collapsed && !fillsContainer && (
-          <div
-            className="ae-file-tree-resize-handle"
-            role="separator"
-            aria-orientation="horizontal"
-            aria-label="Resize files panel"
-            onMouseDown={startResize}
-          />
-        )}
+        {resizeHandle}
         {titleRow}
         {!collapsed && <div className="ae-file-tree-error">{error}</div>}
       </div>
@@ -1309,15 +312,7 @@ export function FileTreePanel({
         style={panelStyle}
       >
         {sidebarResizeHandle}
-        {!collapsed && !fillsContainer && (
-          <div
-            className="ae-file-tree-resize-handle"
-            role="separator"
-            aria-orientation="horizontal"
-            aria-label="Resize files panel"
-            onMouseDown={startResize}
-          />
-        )}
+        {resizeHandle}
         {titleRow}
         {!collapsed && <div className="a2ui-sidebar-empty">loading…</div>}
       </div>
@@ -1331,15 +326,7 @@ export function FileTreePanel({
       style={panelStyle}
     >
       {sidebarResizeHandle}
-      {!collapsed && !fillsContainer && (
-        <div
-          className="ae-file-tree-resize-handle"
-          role="separator"
-          aria-orientation="horizontal"
-          aria-label="Resize files panel"
-          onMouseDown={startResize}
-        />
-      )}
+      {resizeHandle}
       {titleRow}
       {!collapsed && (
         <ul className="ae-file-tree-list">
@@ -1361,7 +348,7 @@ export function FileTreePanel({
                 expanded={expanded.has(node.entry.path)}
                 decoration={decoration}
                 onClick={() => onItemClick(node)}
-                onContextMenu={(e) => onRowContextMenu(e, node)}
+                onContextMenu={(e) => openContextMenu(e, node)}
               />
             );
           })}
@@ -1387,7 +374,7 @@ interface FileTreeRowProps {
   expanded: boolean;
   decoration?: GitDecoration;
   onClick: () => void;
-  onContextMenu: (e: React.MouseEvent) => void;
+  onContextMenu: (e: ReactMouseEvent) => void;
 }
 
 function FileTreeRow({

--- a/src/skills/default-layout/sidebar/fileTreeActions.ts
+++ b/src/skills/default-layout/sidebar/fileTreeActions.ts
@@ -1,0 +1,259 @@
+import {
+  useCallback,
+  useMemo,
+  useState,
+  type MouseEvent,
+  type RefObject,
+} from "react";
+import { invoke } from "@tauri-apps/api/core";
+
+import type { ContextMenuItem } from "../../../components/primitives/context-menu";
+import {
+  parentDirOf,
+  type ContextMenuState,
+  type TreeNode,
+} from "./fileTreeModel";
+
+interface UseFileTreeActionsArgs {
+  onEvent: (eventType: string, payload?: unknown) => void;
+  projectPath: string;
+  projectPathRef: RefObject<string>;
+  refreshFolder: (folderPath: string) => Promise<void>;
+}
+
+function useFileTreeActions({
+  onEvent,
+  projectPath,
+  projectPathRef,
+  refreshFolder,
+}: UseFileTreeActionsArgs) {
+  const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
+  const closeContextMenu = useCallback(() => setContextMenu(null), []);
+
+  const openContextMenu = useCallback((e: MouseEvent, node: TreeNode) => {
+    e.preventDefault();
+    e.stopPropagation();
+    // Raw client coords; the ContextMenu primitive clamps + corrects
+    // for WebKit zoom-frame drift before positioning.
+    setContextMenu({ x: e.clientX, y: e.clientY, node });
+  }, []);
+
+  const onContextNewFile = useCallback(async () => {
+    if (!contextMenu) return;
+    const parentPath = parentDirOf(contextMenu.node);
+    closeContextMenu();
+    const name = window.prompt("New file name");
+    if (!name) return;
+    const target = `${parentPath.replace(/\/$/, "")}/${name}`;
+    try {
+      await invoke("fs_create_file", {
+        root: projectPathRef.current,
+        path: target,
+      });
+      await refreshFolder(parentPath);
+      onEvent("file-tree-open", {
+        filePath: target,
+        rootPath: projectPathRef.current,
+      });
+    } catch (err) {
+      window.alert(`Failed to create file: ${String(err)}`);
+    }
+  }, [closeContextMenu, contextMenu, onEvent, projectPathRef, refreshFolder]);
+
+  const onContextNewFolder = useCallback(async () => {
+    if (!contextMenu) return;
+    const parentPath = parentDirOf(contextMenu.node);
+    closeContextMenu();
+    const name = window.prompt("New folder name");
+    if (!name) return;
+    const target = `${parentPath.replace(/\/$/, "")}/${name}`;
+    try {
+      await invoke("fs_create_dir", {
+        root: projectPathRef.current,
+        path: target,
+      });
+      await refreshFolder(parentPath);
+    } catch (err) {
+      window.alert(`Failed to create folder: ${String(err)}`);
+    }
+  }, [closeContextMenu, contextMenu, projectPathRef, refreshFolder]);
+
+  const onContextRename = useCallback(async () => {
+    if (!contextMenu) return;
+    const node = contextMenu.node;
+    closeContextMenu();
+    const name = window.prompt("Rename to", node.entry.name);
+    if (!name || name === node.entry.name) return;
+    const dirIdx = Math.max(
+      node.entry.path.lastIndexOf("/"),
+      node.entry.path.lastIndexOf("\\"),
+    );
+    const parentPath =
+      dirIdx >= 0 ? node.entry.path.slice(0, dirIdx) : node.entry.path;
+    const target = `${parentPath}/${name}`;
+    try {
+      await invoke("fs_rename", {
+        root: projectPathRef.current,
+        from: node.entry.path,
+        to: target,
+      });
+      onEvent("file-tree-rename", {
+        from: node.entry.path,
+        to: target,
+        kind: node.entry.kind,
+      });
+      await refreshFolder(parentPath);
+    } catch (err) {
+      window.alert(`Rename failed: ${String(err)}`);
+    }
+  }, [closeContextMenu, contextMenu, onEvent, projectPathRef, refreshFolder]);
+
+  const onContextDelete = useCallback(async () => {
+    if (!contextMenu) return;
+    const node = contextMenu.node;
+    closeContextMenu();
+    if (!window.confirm(`Move "${node.entry.name}" to the trash?`)) return;
+    const dirIdx = Math.max(
+      node.entry.path.lastIndexOf("/"),
+      node.entry.path.lastIndexOf("\\"),
+    );
+    const parentPath =
+      dirIdx >= 0 ? node.entry.path.slice(0, dirIdx) : node.entry.path;
+    try {
+      await invoke("fs_delete", {
+        root: projectPathRef.current,
+        path: node.entry.path,
+      });
+      onEvent("file-tree-delete", {
+        path: node.entry.path,
+        kind: node.entry.kind,
+      });
+      await refreshFolder(parentPath);
+    } catch (err) {
+      window.alert(`Delete failed: ${String(err)}`);
+    }
+  }, [closeContextMenu, contextMenu, onEvent, projectPathRef, refreshFolder]);
+
+  const onContextCopyPath = useCallback(async () => {
+    if (!contextMenu) return;
+    const path = contextMenu.node.entry.path;
+    closeContextMenu();
+    try {
+      await navigator.clipboard.writeText(path);
+    } catch {
+      window.alert(path);
+    }
+  }, [closeContextMenu, contextMenu]);
+
+  const onContextCopyRelativePath = useCallback(async () => {
+    if (!contextMenu) return;
+    const root = projectPathRef.current.replace(/\/+$/, "");
+    const path = contextMenu.node.entry.path;
+    const rel = path.startsWith(root + "/")
+      ? path.slice(root.length + 1)
+      : path;
+    closeContextMenu();
+    try {
+      await navigator.clipboard.writeText(rel);
+    } catch {
+      window.alert(rel);
+    }
+  }, [closeContextMenu, contextMenu, projectPathRef]);
+
+  const onContextRevealInFinder = useCallback(async () => {
+    if (!contextMenu) return;
+    const path = contextMenu.node.entry.path;
+    closeContextMenu();
+    try {
+      await invoke("fs_reveal_in_file_manager", {
+        root: projectPath,
+        path,
+      });
+    } catch (err) {
+      window.alert(`Reveal failed: ${String(err)}`);
+    }
+  }, [closeContextMenu, contextMenu, projectPath]);
+
+  const onContextOpenWithDefault = useCallback(async () => {
+    if (!contextMenu) return;
+    const path = contextMenu.node.entry.path;
+    closeContextMenu();
+    try {
+      await invoke("fs_open_in_default_app", {
+        root: projectPath,
+        path,
+      });
+    } catch (err) {
+      window.alert(`Open failed: ${String(err)}`);
+    }
+  }, [closeContextMenu, contextMenu, projectPath]);
+
+  const fileTreeMenuItems: ContextMenuItem[] = useMemo(
+    () =>
+      contextMenu
+        ? [
+            {
+              id: "new-file",
+              label: "New File…",
+              onSelect: onContextNewFile,
+            },
+            {
+              id: "new-folder",
+              label: "New Folder…",
+              onSelect: onContextNewFolder,
+            },
+            { type: "separator" },
+            {
+              id: "reveal-in-finder",
+              label: "Reveal in File Manager",
+              onSelect: onContextRevealInFinder,
+            },
+            {
+              id: "open-with-default",
+              label: "Open with default app",
+              disabled: contextMenu.node.entry.kind !== "file",
+              onSelect: onContextOpenWithDefault,
+            },
+            { type: "separator" },
+            { id: "rename", label: "Rename…", onSelect: onContextRename },
+            {
+              id: "delete",
+              label: "Move to Trash…",
+              danger: true,
+              onSelect: onContextDelete,
+            },
+            { type: "separator" },
+            {
+              id: "copy-path",
+              label: "Copy Path",
+              onSelect: onContextCopyPath,
+            },
+            {
+              id: "copy-rel",
+              label: "Copy Relative Path",
+              onSelect: onContextCopyRelativePath,
+            },
+          ]
+        : [],
+    [
+      contextMenu,
+      onContextCopyPath,
+      onContextCopyRelativePath,
+      onContextDelete,
+      onContextNewFile,
+      onContextNewFolder,
+      onContextOpenWithDefault,
+      onContextRename,
+      onContextRevealInFinder,
+    ],
+  );
+
+  return {
+    contextMenu,
+    fileTreeMenuItems,
+    openContextMenu,
+    setContextMenu,
+  };
+}
+
+export { useFileTreeActions };

--- a/src/skills/default-layout/sidebar/fileTreeActions.ts
+++ b/src/skills/default-layout/sidebar/fileTreeActions.ts
@@ -28,19 +28,29 @@ function useFileTreeActions({
   refreshFolder,
 }: UseFileTreeActionsArgs) {
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
+  const activeContextMenu =
+    contextMenu?.rootPath === projectPath ? contextMenu : null;
   const closeContextMenu = useCallback(() => setContextMenu(null), []);
 
-  const openContextMenu = useCallback((e: MouseEvent, node: TreeNode) => {
-    e.preventDefault();
-    e.stopPropagation();
-    // Raw client coords; the ContextMenu primitive clamps + corrects
-    // for WebKit zoom-frame drift before positioning.
-    setContextMenu({ x: e.clientX, y: e.clientY, node });
-  }, []);
+  const openContextMenu = useCallback(
+    (e: MouseEvent, node: TreeNode) => {
+      e.preventDefault();
+      e.stopPropagation();
+      // Raw client coords; the ContextMenu primitive clamps + corrects
+      // for WebKit zoom-frame drift before positioning.
+      setContextMenu({
+        rootPath: projectPath,
+        x: e.clientX,
+        y: e.clientY,
+        node,
+      });
+    },
+    [projectPath],
+  );
 
   const onContextNewFile = useCallback(async () => {
-    if (!contextMenu) return;
-    const parentPath = parentDirOf(contextMenu.node);
+    if (!activeContextMenu) return;
+    const parentPath = parentDirOf(activeContextMenu.node);
     closeContextMenu();
     const name = window.prompt("New file name");
     if (!name) return;
@@ -58,11 +68,17 @@ function useFileTreeActions({
     } catch (err) {
       window.alert(`Failed to create file: ${String(err)}`);
     }
-  }, [closeContextMenu, contextMenu, onEvent, projectPathRef, refreshFolder]);
+  }, [
+    activeContextMenu,
+    closeContextMenu,
+    onEvent,
+    projectPathRef,
+    refreshFolder,
+  ]);
 
   const onContextNewFolder = useCallback(async () => {
-    if (!contextMenu) return;
-    const parentPath = parentDirOf(contextMenu.node);
+    if (!activeContextMenu) return;
+    const parentPath = parentDirOf(activeContextMenu.node);
     closeContextMenu();
     const name = window.prompt("New folder name");
     if (!name) return;
@@ -76,11 +92,11 @@ function useFileTreeActions({
     } catch (err) {
       window.alert(`Failed to create folder: ${String(err)}`);
     }
-  }, [closeContextMenu, contextMenu, projectPathRef, refreshFolder]);
+  }, [activeContextMenu, closeContextMenu, projectPathRef, refreshFolder]);
 
   const onContextRename = useCallback(async () => {
-    if (!contextMenu) return;
-    const node = contextMenu.node;
+    if (!activeContextMenu) return;
+    const node = activeContextMenu.node;
     closeContextMenu();
     const name = window.prompt("Rename to", node.entry.name);
     if (!name || name === node.entry.name) return;
@@ -106,11 +122,17 @@ function useFileTreeActions({
     } catch (err) {
       window.alert(`Rename failed: ${String(err)}`);
     }
-  }, [closeContextMenu, contextMenu, onEvent, projectPathRef, refreshFolder]);
+  }, [
+    activeContextMenu,
+    closeContextMenu,
+    onEvent,
+    projectPathRef,
+    refreshFolder,
+  ]);
 
   const onContextDelete = useCallback(async () => {
-    if (!contextMenu) return;
-    const node = contextMenu.node;
+    if (!activeContextMenu) return;
+    const node = activeContextMenu.node;
     closeContextMenu();
     if (!window.confirm(`Move "${node.entry.name}" to the trash?`)) return;
     const dirIdx = Math.max(
@@ -132,23 +154,29 @@ function useFileTreeActions({
     } catch (err) {
       window.alert(`Delete failed: ${String(err)}`);
     }
-  }, [closeContextMenu, contextMenu, onEvent, projectPathRef, refreshFolder]);
+  }, [
+    activeContextMenu,
+    closeContextMenu,
+    onEvent,
+    projectPathRef,
+    refreshFolder,
+  ]);
 
   const onContextCopyPath = useCallback(async () => {
-    if (!contextMenu) return;
-    const path = contextMenu.node.entry.path;
+    if (!activeContextMenu) return;
+    const path = activeContextMenu.node.entry.path;
     closeContextMenu();
     try {
       await navigator.clipboard.writeText(path);
     } catch {
       window.alert(path);
     }
-  }, [closeContextMenu, contextMenu]);
+  }, [activeContextMenu, closeContextMenu]);
 
   const onContextCopyRelativePath = useCallback(async () => {
-    if (!contextMenu) return;
+    if (!activeContextMenu) return;
     const root = projectPathRef.current.replace(/\/+$/, "");
-    const path = contextMenu.node.entry.path;
+    const path = activeContextMenu.node.entry.path;
     const rel = path.startsWith(root + "/")
       ? path.slice(root.length + 1)
       : path;
@@ -158,11 +186,11 @@ function useFileTreeActions({
     } catch {
       window.alert(rel);
     }
-  }, [closeContextMenu, contextMenu, projectPathRef]);
+  }, [activeContextMenu, closeContextMenu, projectPathRef]);
 
   const onContextRevealInFinder = useCallback(async () => {
-    if (!contextMenu) return;
-    const path = contextMenu.node.entry.path;
+    if (!activeContextMenu) return;
+    const path = activeContextMenu.node.entry.path;
     closeContextMenu();
     try {
       await invoke("fs_reveal_in_file_manager", {
@@ -172,11 +200,11 @@ function useFileTreeActions({
     } catch (err) {
       window.alert(`Reveal failed: ${String(err)}`);
     }
-  }, [closeContextMenu, contextMenu, projectPath]);
+  }, [activeContextMenu, closeContextMenu, projectPath]);
 
   const onContextOpenWithDefault = useCallback(async () => {
-    if (!contextMenu) return;
-    const path = contextMenu.node.entry.path;
+    if (!activeContextMenu) return;
+    const path = activeContextMenu.node.entry.path;
     closeContextMenu();
     try {
       await invoke("fs_open_in_default_app", {
@@ -186,11 +214,11 @@ function useFileTreeActions({
     } catch (err) {
       window.alert(`Open failed: ${String(err)}`);
     }
-  }, [closeContextMenu, contextMenu, projectPath]);
+  }, [activeContextMenu, closeContextMenu, projectPath]);
 
   const fileTreeMenuItems: ContextMenuItem[] = useMemo(
     () =>
-      contextMenu
+      activeContextMenu
         ? [
             {
               id: "new-file",
@@ -211,7 +239,7 @@ function useFileTreeActions({
             {
               id: "open-with-default",
               label: "Open with default app",
-              disabled: contextMenu.node.entry.kind !== "file",
+              disabled: activeContextMenu.node.entry.kind !== "file",
               onSelect: onContextOpenWithDefault,
             },
             { type: "separator" },
@@ -236,7 +264,7 @@ function useFileTreeActions({
           ]
         : [],
     [
-      contextMenu,
+      activeContextMenu,
       onContextCopyPath,
       onContextCopyRelativePath,
       onContextDelete,
@@ -249,7 +277,7 @@ function useFileTreeActions({
   );
 
   return {
-    contextMenu,
+    contextMenu: activeContextMenu,
     fileTreeMenuItems,
     openContextMenu,
     setContextMenu,

--- a/src/skills/default-layout/sidebar/fileTreeModel.test.ts
+++ b/src/skills/default-layout/sidebar/fileTreeModel.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  deletedChildrenByParentFromStatuses,
+  gitDecorationsFromStatuses,
+  gitStatusesFromEntries,
+  nodesFromEntries,
+  parseExpandedStore,
+  visibleTreeNodes,
+  watchedDirsFor,
+  type GitFileStatusEntry,
+  type TreeNode,
+} from "./fileTreeModel";
+
+describe("fileTreeModel", () => {
+  it("normalizes persisted expand-state and tolerates bad input", () => {
+    expect(parseExpandedStore("not json")).toEqual({ byProject: {} });
+    expect(
+      parseExpandedStore(
+        JSON.stringify({
+          byProject: {
+            "/repo": ["/repo/src", 123, "/repo/tests"],
+          },
+        }),
+      ),
+    ).toEqual({
+      byProject: {
+        "/repo": ["/repo/src", "/repo/tests"],
+      },
+    });
+  });
+
+  it("preserves loaded descendants when entries are refreshed", () => {
+    const previous: TreeNode[] = [
+      {
+        entry: { name: "src", path: "/repo/src", kind: "dir" },
+        depth: 1,
+        children: [
+          {
+            entry: { name: "App.tsx", path: "/repo/src/App.tsx", kind: "file" },
+            depth: 2,
+          },
+        ],
+      },
+    ];
+
+    expect(
+      nodesFromEntries(
+        [{ name: "src", path: "/repo/src", kind: "dir" }],
+        1,
+        previous,
+      )[0]?.children?.[0]?.entry.path,
+    ).toBe("/repo/src/App.tsx");
+  });
+
+  it("derives direct and strongest descendant Git decorations", () => {
+    const statuses = gitStatusesFromEntries([
+      { path: "src/App.tsx", status: "modified" },
+      { path: "src/conflict.ts", status: "conflicted" },
+    ] satisfies GitFileStatusEntry[]);
+
+    const decorations = gitDecorationsFromStatuses(statuses);
+
+    expect(decorations.direct.get("src/App.tsx")).toBe("modified");
+    expect(decorations.descendants.get("src")).toBe("conflicted");
+  });
+
+  it("adds synthetic deleted entries to visible expanded folders", () => {
+    const root: TreeNode = {
+      entry: { name: "repo", path: "/repo", kind: "dir" },
+      depth: 0,
+      children: [
+        { entry: { name: "src", path: "/repo/src", kind: "dir" }, depth: 1 },
+      ],
+    };
+    const statuses = gitStatusesFromEntries([
+      { path: "src/old.ts", status: "deleted" },
+    ] satisfies GitFileStatusEntry[]);
+    const deletedChildrenByParent = deletedChildrenByParentFromStatuses(
+      statuses,
+      "/repo",
+    );
+
+    expect(
+      visibleTreeNodes({
+        deletedChildrenByParent,
+        expanded: new Set(["/repo/src"]),
+        projectPath: "/repo",
+        root,
+      }).map((node) => node.entry.path),
+    ).toEqual(["/repo/src", "/repo/src/old.ts"]);
+  });
+
+  it("watches only visible roots and expanded folders", () => {
+    expect(
+      watchedDirsFor({
+        expanded: new Set(["/repo/src"]),
+        hidden: false,
+        projectPath: "/repo",
+      }),
+    ).toEqual(["/repo", "/repo/src"]);
+    expect(
+      watchedDirsFor({
+        expanded: new Set(["/repo/src"]),
+        hidden: true,
+        projectPath: "/repo",
+      }),
+    ).toEqual([]);
+  });
+});

--- a/src/skills/default-layout/sidebar/fileTreeModel.ts
+++ b/src/skills/default-layout/sidebar/fileTreeModel.ts
@@ -60,6 +60,7 @@ interface ProjectShape {
 }
 
 interface ContextMenuState {
+  rootPath: string;
   x: number;
   y: number;
   node: TreeNode;

--- a/src/skills/default-layout/sidebar/fileTreeModel.ts
+++ b/src/skills/default-layout/sidebar/fileTreeModel.ts
@@ -1,0 +1,365 @@
+interface FsEntry {
+  name: string;
+  path: string;
+  kind: "file" | "dir";
+}
+
+type GitFileStatusKind =
+  | "modified"
+  | "added"
+  | "untracked"
+  | "deleted"
+  | "renamed"
+  | "copied"
+  | "conflicted";
+
+interface GitFileStatusEntry {
+  path: string;
+  status: GitFileStatusKind;
+  originalPath?: string | null;
+}
+
+interface GitDecoration {
+  status: GitFileStatusKind;
+  source: "direct" | "descendant";
+}
+
+interface GitStatusMeta {
+  label: string;
+  title: string;
+}
+
+/** A node in the in-memory tree. `children` is undefined until the
+ *  folder has been loaded; null means "load attempted, no children". */
+interface TreeNode {
+  entry: FsEntry;
+  depth: number;
+  children?: TreeNode[] | null;
+  loading?: boolean;
+  loadError?: string;
+}
+
+interface EditorTabShape {
+  id?: string;
+  kind?: string;
+  editor?: {
+    rootPath?: string;
+  };
+}
+
+/** Persisted expand-state. Each project keeps its own set of expanded
+ *  absolute paths so reopening lands on the prior view. Capped per
+ *  project to bound the persisted file's size. */
+interface ExpandedStore {
+  byProject: Record<string, string[]>;
+}
+
+interface ProjectShape {
+  path?: string;
+  name?: string;
+}
+
+interface ContextMenuState {
+  x: number;
+  y: number;
+  node: TreeNode;
+}
+
+interface GitDecorations {
+  direct: Map<string, GitFileStatusKind>;
+  descendants: Map<string, GitFileStatusKind>;
+}
+
+const GIT_STATUS_META: Record<GitFileStatusKind, GitStatusMeta> = {
+  modified: { label: "M", title: "Modified" },
+  added: { label: "A", title: "Added" },
+  untracked: { label: "U", title: "Untracked" },
+  deleted: { label: "D", title: "Deleted" },
+  renamed: { label: "R", title: "Renamed" },
+  copied: { label: "C", title: "Copied" },
+  conflicted: { label: "!", title: "Conflicted" },
+};
+
+const GIT_STATUS_PRIORITY: Record<GitFileStatusKind, number> = {
+  conflicted: 70,
+  deleted: 60,
+  renamed: 50,
+  added: 40,
+  untracked: 30,
+  copied: 20,
+  modified: 10,
+};
+
+const EXPAND_STATE_FILE = "file-tree.json";
+const EXPANDED_CAP_PER_PROJECT = 200;
+
+function basename(path: string): string {
+  return (
+    path
+      .split(/[/\\]+/)
+      .filter(Boolean)
+      .pop() ?? path
+  );
+}
+
+function dirname(path: string): string {
+  const slash = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
+  return slash >= 0 ? path.slice(0, slash) : "";
+}
+
+function normalizeRelativePath(path: string): string {
+  return path.replace(/\\/g, "/").replace(/^\/+/, "").replace(/\/+$/, "");
+}
+
+function relativePathFor(rootPath: string, path: string): string | null {
+  if (!rootPath || !path) return null;
+  const root = rootPath.replace(/\\/g, "/").replace(/\/+$/, "");
+  const target = path.replace(/\\/g, "/");
+  if (target === root) return "";
+  if (target.startsWith(`${root}/`)) {
+    return normalizeRelativePath(target.slice(root.length + 1));
+  }
+  return null;
+}
+
+function absolutePathFor(rootPath: string, relativePath: string): string {
+  const separator =
+    rootPath.includes("\\") && !rootPath.includes("/") ? "\\" : "/";
+  const normalizedRelative = normalizeRelativePath(relativePath).replace(
+    /\//g,
+    separator,
+  );
+  return `${rootPath.replace(/[\\/]+$/, "")}${separator}${normalizedRelative}`;
+}
+
+function normalizeAbsolutePath(path: string): string {
+  return path.replace(/\\/g, "/").replace(/\/+$/, "");
+}
+
+function parentRelativePath(relativePath: string): string {
+  return dirname(normalizeRelativePath(relativePath)).replace(/^\/+/, "");
+}
+
+function strongerGitStatus(
+  a: GitFileStatusKind | undefined,
+  b: GitFileStatusKind,
+): GitFileStatusKind {
+  if (!a) return b;
+  return GIT_STATUS_PRIORITY[b] > GIT_STATUS_PRIORITY[a] ? b : a;
+}
+
+function sortTreeNodes(nodes: TreeNode[]): TreeNode[] {
+  return [...nodes].sort((a, b) => {
+    if (a.entry.kind !== b.entry.kind) {
+      return a.entry.kind === "dir" ? -1 : 1;
+    }
+    return a.entry.name.toLowerCase().localeCompare(b.entry.name.toLowerCase());
+  });
+}
+
+function gitStatusesFromEntries(
+  entries: GitFileStatusEntry[] | null | undefined,
+): Map<string, GitFileStatusEntry> {
+  const map = new Map<string, GitFileStatusEntry>();
+  if (!Array.isArray(entries)) return map;
+  for (const entry of entries) {
+    const path = normalizeRelativePath(entry.path);
+    if (!path) continue;
+    map.set(path, { ...entry, path });
+  }
+  return map;
+}
+
+/** Return the directory of `node`'s entry: the node itself when it's a
+ *  folder, the containing folder when it's a file. Used by the
+ *  context menu's New File / New Folder actions to anchor at the
+ *  right location regardless of which row the user right-clicked. */
+function parentDirOf(node: TreeNode): string {
+  if (node.entry.kind === "dir") return node.entry.path;
+  const slash = Math.max(
+    node.entry.path.lastIndexOf("/"),
+    node.entry.path.lastIndexOf("\\"),
+  );
+  return slash >= 0 ? node.entry.path.slice(0, slash) : node.entry.path;
+}
+
+function withDepth(node: TreeNode, depth: number): TreeNode {
+  const delta = depth - node.depth;
+  if (delta === 0) return node;
+  const walk = (current: TreeNode): TreeNode => ({
+    ...current,
+    depth: current.depth + delta,
+    children: current.children?.map(walk) ?? current.children,
+  });
+  return walk(node);
+}
+
+function nodesFromEntries(
+  entries: FsEntry[],
+  depth: number,
+  previousChildren?: TreeNode[] | null,
+): TreeNode[] {
+  const previousByPath = new Map(
+    (previousChildren ?? []).map((child) => [child.entry.path, child]),
+  );
+  return entries.map((entry) => {
+    const previous = previousByPath.get(entry.path);
+    if (!previous) return { entry, depth };
+    return {
+      ...withDepth(previous, depth),
+      entry,
+      loadError: undefined,
+    };
+  });
+}
+
+/** Parse the persisted store; tolerate corruption by returning empty. */
+function parseExpandedStore(raw: string): ExpandedStore {
+  if (!raw) return { byProject: {} };
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      "byProject" in parsed &&
+      typeof parsed.byProject === "object"
+    ) {
+      const map = parsed.byProject as Record<string, unknown>;
+      const cleaned: Record<string, string[]> = {};
+      for (const [projectPath, list] of Object.entries(map)) {
+        if (Array.isArray(list)) {
+          cleaned[projectPath] = list.filter(
+            (p): p is string => typeof p === "string",
+          );
+        }
+      }
+      return { byProject: cleaned };
+    }
+  } catch {
+    /* fall through */
+  }
+  return { byProject: {} };
+}
+
+function gitDecorationsFromStatuses(
+  gitStatuses: Map<string, GitFileStatusEntry>,
+): GitDecorations {
+  const direct = new Map<string, GitFileStatusKind>();
+  const descendants = new Map<string, GitFileStatusKind>();
+  for (const [path, entry] of gitStatuses) {
+    direct.set(path, entry.status);
+    const parts = path.split("/").filter(Boolean);
+    for (let i = 1; i < parts.length; i += 1) {
+      const dir = parts.slice(0, i).join("/");
+      descendants.set(
+        dir,
+        strongerGitStatus(descendants.get(dir), entry.status),
+      );
+    }
+  }
+  return { direct, descendants };
+}
+
+function deletedChildrenByParentFromStatuses(
+  gitStatuses: Map<string, GitFileStatusEntry>,
+  projectPath: string,
+): Map<string, FsEntry[]> {
+  const byParent = new Map<string, FsEntry[]>();
+  if (!projectPath) return byParent;
+  for (const [path, entry] of gitStatuses) {
+    if (entry.status !== "deleted") continue;
+    const parent = parentRelativePath(path);
+    const children = byParent.get(parent) ?? [];
+    children.push({
+      name: basename(path),
+      path: absolutePathFor(projectPath, path),
+      kind: "file",
+    });
+    byParent.set(parent, children);
+  }
+  return byParent;
+}
+
+function visibleTreeNodes({
+  root,
+  expanded,
+  projectPath,
+  deletedChildrenByParent,
+}: {
+  root: TreeNode | null;
+  expanded: Set<string>;
+  projectPath: string;
+  deletedChildrenByParent: Map<string, FsEntry[]>;
+}): TreeNode[] {
+  if (!root) return [];
+  const out: TreeNode[] = [];
+  const childrenFor = (node: TreeNode): TreeNode[] => {
+    const children = node.children ?? [];
+    const parentRel = projectPath
+      ? relativePathFor(projectPath, node.entry.path)
+      : null;
+    const deleted =
+      parentRel == null ? [] : (deletedChildrenByParent.get(parentRel) ?? []);
+    if (deleted.length === 0) return children;
+    const existing = new Set(
+      children.map((child) => normalizeAbsolutePath(child.entry.path)),
+    );
+    const synthetic = deleted
+      .filter((entry) => !existing.has(normalizeAbsolutePath(entry.path)))
+      .map((entry) => ({ entry, depth: node.depth + 1 }));
+    return sortTreeNodes([...children, ...synthetic]);
+  };
+  const walk = (node: TreeNode) => {
+    out.push(node);
+    if (node.entry.kind !== "dir") return;
+    if (!expanded.has(node.entry.path)) return;
+    for (const child of childrenFor(node)) walk(child);
+  };
+  for (const child of childrenFor(root)) walk(child);
+  return out;
+}
+
+function watchedDirsFor({
+  projectPath,
+  expanded,
+  hidden,
+}: {
+  projectPath: string;
+  expanded: Set<string>;
+  hidden: boolean;
+}): string[] {
+  if (!projectPath || hidden) return [];
+  const dirs = new Set<string>([projectPath]);
+  for (const p of expanded) {
+    dirs.add(p);
+  }
+  return [...dirs].sort();
+}
+
+export {
+  EXPANDED_CAP_PER_PROJECT,
+  EXPAND_STATE_FILE,
+  GIT_STATUS_META,
+  basename,
+  deletedChildrenByParentFromStatuses,
+  gitDecorationsFromStatuses,
+  gitStatusesFromEntries,
+  nodesFromEntries,
+  parentDirOf,
+  parseExpandedStore,
+  relativePathFor,
+  visibleTreeNodes,
+  watchedDirsFor,
+};
+
+export type {
+  ContextMenuState,
+  EditorTabShape,
+  ExpandedStore,
+  FsEntry,
+  GitDecoration,
+  GitFileStatusEntry,
+  GitFileStatusKind,
+  ProjectShape,
+  TreeNode,
+};

--- a/src/skills/default-layout/sidebar/useFileTreeData.ts
+++ b/src/skills/default-layout/sidebar/useFileTreeData.ts
@@ -62,6 +62,15 @@ function useFileTreeData({
     };
   }, []);
 
+  useEffect(() => {
+    return () => {
+      if (saveTimerRef.current) {
+        clearTimeout(saveTimerRef.current);
+        saveTimerRef.current = null;
+      }
+    };
+  }, []);
+
   const schedulePersist = useCallback((next: Set<string>) => {
     const projectKey = projectPathRef.current;
     if (!projectKey) return;

--- a/src/skills/default-layout/sidebar/useFileTreeData.ts
+++ b/src/skills/default-layout/sidebar/useFileTreeData.ts
@@ -1,0 +1,338 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+
+import { readState, writeState } from "../../../persist";
+import {
+  EXPANDED_CAP_PER_PROJECT,
+  EXPAND_STATE_FILE,
+  deletedChildrenByParentFromStatuses,
+  gitDecorationsFromStatuses,
+  gitStatusesFromEntries,
+  nodesFromEntries,
+  parseExpandedStore,
+  visibleTreeNodes,
+  watchedDirsFor,
+  type ExpandedStore,
+  type FsEntry,
+  type GitFileStatusEntry,
+  type TreeNode,
+} from "./fileTreeModel";
+
+interface UseFileTreeDataArgs {
+  hidden: boolean;
+  projectPath: string;
+  rootLabel: string;
+}
+
+function useFileTreeData({
+  hidden,
+  projectPath,
+  rootLabel,
+}: UseFileTreeDataArgs) {
+  const [root, setRoot] = useState<TreeNode | null>(null);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [gitStatuses, setGitStatuses] = useState<
+    Map<string, GitFileStatusEntry>
+  >(new Map());
+  const [error, setError] = useState<string>("");
+  const expandedStoreRef = useRef<ExpandedStore>({ byProject: {} });
+  const projectPathRef = useRef<string>(projectPath);
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const gitStatusRefreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+
+  useEffect(() => {
+    projectPathRef.current = projectPath;
+  }, [projectPath]);
+
+  useEffect(() => {
+    let cancelled = false;
+    void readState(EXPAND_STATE_FILE).then((raw) => {
+      if (cancelled) return;
+      const parsed = parseExpandedStore(raw);
+      expandedStoreRef.current = parsed;
+      if (projectPathRef.current) {
+        const prior = parsed.byProject[projectPathRef.current];
+        if (prior?.length) setExpanded(new Set(prior));
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const schedulePersist = useCallback((next: Set<string>) => {
+    const projectKey = projectPathRef.current;
+    if (!projectKey) return;
+    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    saveTimerRef.current = setTimeout(() => {
+      const list = [...next].slice(0, EXPANDED_CAP_PER_PROJECT);
+      expandedStoreRef.current.byProject[projectKey] = list;
+      void writeState(
+        EXPAND_STATE_FILE,
+        JSON.stringify(expandedStoreRef.current),
+      );
+    }, 250);
+  }, []);
+
+  const refreshGitStatuses = useCallback(async (rootPath: string) => {
+    if (!rootPath) {
+      setGitStatuses(new Map());
+      return;
+    }
+    try {
+      const entries = await invoke<GitFileStatusEntry[] | null>(
+        "git_file_status",
+        { root: rootPath },
+      );
+      if (projectPathRef.current !== rootPath) return;
+      setGitStatuses(gitStatusesFromEntries(entries));
+    } catch {
+      // Non-git directories, missing git binary, or transient status errors
+      // should never block the file tree; just render without decorations.
+      if (projectPathRef.current === rootPath) setGitStatuses(new Map());
+    }
+  }, []);
+
+  const scheduleGitStatusRefresh = useCallback(
+    (rootPath = projectPathRef.current) => {
+      if (gitStatusRefreshTimerRef.current) {
+        clearTimeout(gitStatusRefreshTimerRef.current);
+      }
+      gitStatusRefreshTimerRef.current = setTimeout(() => {
+        gitStatusRefreshTimerRef.current = null;
+        void refreshGitStatuses(rootPath);
+      }, 180);
+    },
+    [refreshGitStatuses],
+  );
+
+  // Fetch the root directory listing whenever the active project changes.
+  useEffect(() => {
+    if (gitStatusRefreshTimerRef.current) {
+      clearTimeout(gitStatusRefreshTimerRef.current);
+      gitStatusRefreshTimerRef.current = null;
+    }
+    // Reset the previous project's tree synchronously so stale rows never
+    // render under the new root while the async listing loads.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setRoot(null);
+    setGitStatuses(new Map());
+    setError("");
+    setExpanded(new Set(expandedStoreRef.current.byProject[projectPath] ?? []));
+    if (!projectPath) return;
+    let cancelled = false;
+    void invoke<FsEntry[]>("fs_list_dir", {
+      root: projectPath,
+      path: projectPath,
+    })
+      .then(async (entries) => {
+        if (cancelled) return;
+        const rootNode: TreeNode = {
+          entry: {
+            name: rootLabel,
+            path: projectPath,
+            kind: "dir",
+          },
+          depth: 0,
+          children: nodesFromEntries(entries, 1),
+        };
+        setRoot(rootNode);
+        void refreshGitStatuses(projectPath);
+
+        const expandedNow =
+          expandedStoreRef.current.byProject[projectPath] ?? [];
+        if (expandedNow.length === 0) return;
+        const ordered = [...expandedNow].sort((a, b) => a.length - b.length);
+        for (const folderPath of ordered) {
+          if (cancelled) return;
+          try {
+            const childEntries = await invoke<FsEntry[]>("fs_list_dir", {
+              root: projectPath,
+              path: folderPath,
+            });
+            if (cancelled) return;
+            setRoot((r) => {
+              if (!r) return r;
+              const walk = (node: TreeNode): TreeNode => {
+                if (node.entry.path === folderPath) {
+                  return {
+                    ...node,
+                    children: nodesFromEntries(
+                      childEntries,
+                      node.depth + 1,
+                      node.children,
+                    ),
+                  };
+                }
+                if (!node.children) return node;
+                return { ...node, children: node.children.map(walk) };
+              };
+              return { ...r, children: r.children?.map(walk) ?? undefined };
+            });
+          } catch {
+            // Folder may have been deleted since last persist; skip it
+            // silently — the user can re-expand if they want.
+          }
+        }
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(String(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [projectPath, refreshGitStatuses, rootLabel]);
+
+  const loadFolderChildren = useCallback(
+    async (node: TreeNode): Promise<TreeNode[] | null> => {
+      if (!projectPathRef.current) return null;
+      try {
+        const entries = await invoke<FsEntry[]>("fs_list_dir", {
+          root: projectPathRef.current,
+          path: node.entry.path,
+        });
+        return nodesFromEntries(entries, node.depth + 1, node.children);
+      } catch (err) {
+        node.loadError = String(err);
+        return null;
+      }
+    },
+    [],
+  );
+
+  const toggleFolder = useCallback(
+    (node: TreeNode) => {
+      const path = node.entry.path;
+      setExpanded((prev) => {
+        const next = new Set(prev);
+        if (next.has(path)) {
+          next.delete(path);
+        } else {
+          next.add(path);
+          if (node.children === undefined) {
+            node.loading = true;
+            void loadFolderChildren(node).then((kids) => {
+              node.children = kids;
+              node.loading = false;
+              setRoot((r) => (r ? { ...r } : r));
+            });
+          }
+        }
+        schedulePersist(next);
+        return next;
+      });
+    },
+    [loadFolderChildren, schedulePersist],
+  );
+
+  const gitDecorations = useMemo(
+    () => gitDecorationsFromStatuses(gitStatuses),
+    [gitStatuses],
+  );
+
+  const deletedChildrenByParent = useMemo(
+    () => deletedChildrenByParentFromStatuses(gitStatuses, projectPath),
+    [gitStatuses, projectPath],
+  );
+
+  const visibleNodes = useMemo(
+    () =>
+      visibleTreeNodes({
+        deletedChildrenByParent,
+        expanded,
+        projectPath,
+        root,
+      }),
+    [deletedChildrenByParent, expanded, projectPath, root],
+  );
+
+  const watchedDirs = useMemo(
+    () => watchedDirsFor({ expanded, hidden, projectPath }),
+    [expanded, hidden, projectPath],
+  );
+
+  const invalidateFolder = useCallback((folderPath: string) => {
+    setRoot((r) => {
+      if (!r) return r;
+      const next = { ...r };
+      const walk = (node: TreeNode): TreeNode => {
+        if (node.entry.path === folderPath) {
+          return { ...node, children: undefined };
+        }
+        if (!node.children) return node;
+        return {
+          ...node,
+          children: node.children.map(walk),
+        };
+      };
+      next.children = next.children?.map(walk);
+      return next;
+    });
+  }, []);
+
+  const refreshFolder = useCallback(
+    async (folderPath: string) => {
+      if (!projectPathRef.current) return;
+      try {
+        const entries = await invoke<FsEntry[]>("fs_list_dir", {
+          root: projectPathRef.current,
+          path: folderPath,
+        });
+        setRoot((r) => {
+          if (!r) return r;
+          if (r.entry.path === folderPath) {
+            return {
+              ...r,
+              children: nodesFromEntries(entries, 1, r.children),
+            };
+          }
+          const walk = (node: TreeNode): TreeNode => {
+            if (node.entry.path === folderPath) {
+              return {
+                ...node,
+                children: nodesFromEntries(
+                  entries,
+                  node.depth + 1,
+                  node.children,
+                ),
+              };
+            }
+            if (!node.children) return node;
+            return { ...node, children: node.children.map(walk) };
+          };
+          return { ...r, children: r.children?.map(walk) ?? undefined };
+        });
+        scheduleGitStatusRefresh();
+      } catch {
+        invalidateFolder(folderPath);
+        scheduleGitStatusRefresh();
+      }
+    },
+    [invalidateFolder, scheduleGitStatusRefresh],
+  );
+
+  useEffect(() => {
+    return () => {
+      if (gitStatusRefreshTimerRef.current) {
+        clearTimeout(gitStatusRefreshTimerRef.current);
+      }
+    };
+  }, []);
+
+  return {
+    error,
+    expanded,
+    gitDecorations,
+    projectPathRef,
+    refreshFolder,
+    root,
+    toggleFolder,
+    visibleNodes,
+    watchedDirs,
+  };
+}
+
+export { useFileTreeData };

--- a/src/skills/default-layout/sidebar/useFileTreePrefs.ts
+++ b/src/skills/default-layout/sidebar/useFileTreePrefs.ts
@@ -1,0 +1,105 @@
+import { useEffect, useRef, useState } from "react";
+
+import { readState, writeState } from "../../../persist";
+
+const PANEL_PREFS_FILE = "file-tree-prefs.json";
+const PANEL_HEIGHT_DEFAULT = 280;
+const PANEL_HEIGHT_MIN = 120;
+const PANEL_HEIGHT_MAX = 1200;
+const SIDEBAR_WIDTH_MIN = 220;
+const SIDEBAR_WIDTH_MAX = 640;
+
+interface PanelPrefs {
+  collapsed?: boolean;
+  hidden?: boolean;
+  height?: number;
+}
+
+function readPanelPrefs(raw: string): PanelPrefs {
+  if (!raw) return {};
+  try {
+    const v = JSON.parse(raw);
+    if (v && typeof v === "object") return v as PanelPrefs;
+  } catch {
+    /* fall through */
+  }
+  return {};
+}
+
+function useFileTreePrefs() {
+  const [collapsed, setCollapsed] = useState<boolean>(false);
+  const [hidden, setHidden] = useState<boolean>(false);
+  const [height, setHeight] = useState<number>(PANEL_HEIGHT_DEFAULT);
+  const prefsHydrated = useRef<boolean>(false);
+  const prefsSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void readState(PANEL_PREFS_FILE).then((raw) => {
+      if (cancelled) return;
+      const prefs = readPanelPrefs(raw);
+      if (typeof prefs.collapsed === "boolean") setCollapsed(prefs.collapsed);
+      if (typeof prefs.hidden === "boolean") setHidden(prefs.hidden);
+      if (
+        typeof prefs.height === "number" &&
+        prefs.height >= PANEL_HEIGHT_MIN &&
+        prefs.height <= PANEL_HEIGHT_MAX
+      ) {
+        setHeight(prefs.height);
+      }
+      prefsHydrated.current = true;
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Persist panel prefs after hydration. The save is debounced because the
+  // drag handle fires height updates on every mousemove.
+  useEffect(() => {
+    if (!prefsHydrated.current) return;
+    if (prefsSaveTimerRef.current) clearTimeout(prefsSaveTimerRef.current);
+    prefsSaveTimerRef.current = setTimeout(() => {
+      void writeState(
+        PANEL_PREFS_FILE,
+        JSON.stringify({ collapsed, hidden, height }),
+      );
+    }, 200);
+  }, [collapsed, hidden, height]);
+
+  useEffect(() => {
+    const toggle = () => setHidden((h) => !h);
+    const resetPrefs = () => {
+      setCollapsed(false);
+      setHidden(false);
+      setHeight(PANEL_HEIGHT_DEFAULT);
+    };
+    window.addEventListener("aethon:toggle-file-tree", toggle);
+    window.addEventListener("aethon:reset-file-tree-prefs", resetPrefs);
+    return () => {
+      window.removeEventListener("aethon:toggle-file-tree", toggle);
+      window.removeEventListener("aethon:reset-file-tree-prefs", resetPrefs);
+    };
+  }, []);
+
+  return {
+    collapsed,
+    hidden,
+    height,
+    setCollapsed,
+    setHidden,
+    setHeight,
+  };
+}
+
+export {
+  PANEL_HEIGHT_DEFAULT,
+  PANEL_HEIGHT_MAX,
+  PANEL_HEIGHT_MIN,
+  SIDEBAR_WIDTH_MAX,
+  SIDEBAR_WIDTH_MIN,
+  readPanelPrefs,
+  useFileTreePrefs,
+};
+
+export type { PanelPrefs };

--- a/src/skills/default-layout/sidebar/useFileTreePrefs.ts
+++ b/src/skills/default-layout/sidebar/useFileTreePrefs.ts
@@ -54,6 +54,15 @@ function useFileTreePrefs() {
     };
   }, []);
 
+  useEffect(() => {
+    return () => {
+      if (prefsSaveTimerRef.current) {
+        clearTimeout(prefsSaveTimerRef.current);
+        prefsSaveTimerRef.current = null;
+      }
+    };
+  }, []);
+
   // Persist panel prefs after hydration. The save is debounced because the
   // drag handle fires height updates on every mousemove.
   useEffect(() => {

--- a/src/skills/default-layout/sidebar/useFileTreeWatch.ts
+++ b/src/skills/default-layout/sidebar/useFileTreeWatch.ts
@@ -1,0 +1,120 @@
+import { useEffect, useRef, type RefObject } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+
+import {
+  visibleChangedDirs,
+  type FsTreeChangedPayload,
+} from "./file-tree-watch";
+
+interface UseFileTreeWatchArgs {
+  projectPath: string;
+  projectPathRef: RefObject<string>;
+  refreshFolder: (folderPath: string) => Promise<void>;
+  watchedDirs: string[];
+}
+
+function useFileTreeWatch({
+  projectPath,
+  projectPathRef,
+  refreshFolder,
+  watchedDirs,
+}: UseFileTreeWatchArgs) {
+  const watchSyncTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const watchedRootRef = useRef<string>("");
+  const refreshDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingRefreshDirsRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (watchSyncTimerRef.current) clearTimeout(watchSyncTimerRef.current);
+    const previousRoot = watchedRootRef.current;
+    if (!projectPath || watchedDirs.length === 0) {
+      if (previousRoot) {
+        watchedRootRef.current = "";
+        void invoke("fs_unwatch_root", { root: previousRoot }).catch(() => {
+          /* best-effort cleanup */
+        });
+      }
+      return;
+    }
+    watchedRootRef.current = projectPath;
+    watchSyncTimerRef.current = setTimeout(() => {
+      if (previousRoot && previousRoot !== projectPath) {
+        void invoke("fs_unwatch_root", { root: previousRoot }).catch(() => {
+          /* best-effort cleanup */
+        });
+      }
+      void invoke("fs_watch_dirs", {
+        root: projectPath,
+        dirs: watchedDirs,
+      }).catch(() => {
+        /* File watching is an enhancement; manual tree ops still refresh. */
+      });
+    }, 150);
+    return () => {
+      if (watchSyncTimerRef.current) {
+        clearTimeout(watchSyncTimerRef.current);
+        watchSyncTimerRef.current = null;
+      }
+    };
+  }, [projectPath, watchedDirs]);
+
+  useEffect(() => {
+    if (!projectPath) return;
+    let disposed = false;
+    let unlisten: (() => void) | undefined;
+    const pendingRefreshDirs = pendingRefreshDirsRef.current;
+    void listen<FsTreeChangedPayload>("fs-tree-changed", (event) => {
+      if (disposed || event.payload.root !== projectPathRef.current) return;
+      for (const dir of event.payload.dirs) {
+        pendingRefreshDirs.add(dir);
+      }
+      if (refreshDebounceRef.current) return;
+      refreshDebounceRef.current = setTimeout(() => {
+        refreshDebounceRef.current = null;
+        const dirs = visibleChangedDirs(
+          {
+            root: event.payload.root,
+            dirs: [...pendingRefreshDirs],
+          },
+          projectPathRef.current,
+          watchedDirs,
+        );
+        pendingRefreshDirs.clear();
+        for (const dir of dirs) {
+          void refreshFolder(dir);
+        }
+      }, 120);
+    }).then((fn) => {
+      if (disposed) {
+        fn();
+        return;
+      }
+      unlisten = fn;
+    });
+    return () => {
+      disposed = true;
+      if (refreshDebounceRef.current) {
+        clearTimeout(refreshDebounceRef.current);
+        refreshDebounceRef.current = null;
+      }
+      pendingRefreshDirs.clear();
+      unlisten?.();
+    };
+  }, [projectPath, projectPathRef, refreshFolder, watchedDirs]);
+
+  useEffect(() => {
+    return () => {
+      const rootToUnwatch = watchedRootRef.current;
+      if (rootToUnwatch) {
+        void invoke("fs_unwatch_root", { root: rootToUnwatch }).catch(() => {
+          /* best-effort cleanup */
+        });
+      }
+      if (watchSyncTimerRef.current) clearTimeout(watchSyncTimerRef.current);
+      if (refreshDebounceRef.current) clearTimeout(refreshDebounceRef.current);
+    };
+  }, []);
+}
+
+export { useFileTreeWatch };


### PR DESCRIPTION
## Summary
- Split the default-layout file tree panel into focused model, data, watcher, prefs, and action modules.
- Kept `FileTreePanel` as a thin render shell for project/header derivation, resize chrome, rows, and the context menu portal.
- Added pure model coverage for expand-state parsing, refresh preservation, Git decoration derivation, synthetic deleted rows, and watched-directory selection.

## Validation
- `bunx vitest run src/skills/default-layout/sidebar/file-tree.test.tsx src/skills/default-layout/sidebar/fileTreeModel.test.ts`
- `bun run typecheck`
- `bun run build`
- `bunx vitest run`
- `bun run lint` (exit 0; existing unrelated 5 React hook warnings)
- `git diff --check`
- `bun run check` (exit 0; same existing lint warning report)