### PR TITLE
fix(agent): address dispatcher review findings

### DIFF
--- a/agent/a2uiEvents.ts
+++ b/agent/a2uiEvents.ts
@@ -1,6 +1,10 @@
 import type { AethonApi } from "./aethon-api";
 import type { AethonAgentState, PiHandlerCtx, TabRecord } from "./state";
-import type { DispatcherDeps, InboundMessage } from "./dispatcherTypes";
+import {
+  maybeExitForReload,
+  type DispatcherDeps,
+  type InboundMessage,
+} from "./dispatcherTypes";
 import { setState, makeCanvasApi } from "./state-mutation";
 import { ensureTab, modelKey } from "./tab-lifecycle";
 
@@ -101,6 +105,7 @@ function buildPiHandlerCtx(
         if (state.currentAgentTabId === handlerTabId) {
           state.currentAgentTabId = undefined;
         }
+        maybeExitForReload(state, deps);
       }
     },
     notify(message: string) {

--- a/agent/dispatcher.test.ts
+++ b/agent/dispatcher.test.ts
@@ -5,6 +5,7 @@ import {
   type ProjectBaselineSnapshot,
   type TabRecord,
 } from "./state";
+import { handleA2UIEvent } from "./a2uiEvents";
 import {
   captureProjectExtensionBaseline,
   dispatchInboundMessage,
@@ -16,6 +17,8 @@ import {
   handleStop,
   unloadProjectExtensions,
 } from "./dispatcher";
+import { handleSetExtensionDisabled } from "./extensionControl";
+import { projectDisplayName } from "./projectLifecycle";
 
 const baseOpts: AethonAgentStateOptions = {
   userDir: "/tmp/aethon-test",
@@ -188,6 +191,53 @@ describe("handleStop", () => {
     expect(f.sent.find((m) => m.type === "terminal_output")).toMatchObject({
       content: "\r\n[command cancelled]\r\n",
     });
+  });
+});
+
+describe("handleA2UIEvent", () => {
+  it("drains a pending reload after a handler-started prompt ends", async () => {
+    const f = makeFixture();
+    let resolvePrompt: (() => void) | undefined;
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => {
+      return undefined as never;
+    }) satisfies typeof process.exit);
+    const tab = fakeTabRecord({
+      session: {
+        prompt: () =>
+          new Promise<void>((resolve) => {
+            resolvePrompt = resolve;
+          }),
+      } as unknown as TabRecord["session"],
+    });
+    f.state.tabs.set("tab-1", tab);
+    f.state.a2uiEventHandlers.push({
+      match: { componentType: "button", eventType: "click" },
+      handler: (_ev, ctx) => ctx.pi.prompt("from handler"),
+    });
+
+    await handleA2UIEvent(f.state, f.deps, fakeAethonApi(), {
+      type: "a2ui_event",
+      tabId: "tab-1",
+      event: { componentType: "button", eventType: "click" },
+    });
+
+    await vi.waitFor(() => {
+      expect(tab.promptInFlight).toBe(true);
+      expect(f.sent).toContainEqual({
+        type: "prompt_started",
+        tabId: "tab-1",
+        source: "handler",
+      });
+    });
+    f.state.reloadPending = true;
+    resolvePrompt?.();
+
+    await vi.waitFor(() => {
+      expect(tab.promptInFlight).toBe(false);
+      expect(f.sent).toContainEqual({ type: "_reload_done" });
+      expect(exit).toHaveBeenCalledWith(0);
+    });
+    exit.mockRestore();
   });
 });
 
@@ -462,6 +512,37 @@ describe("handleSetModel", () => {
       tabId: "tab-1",
       message: "set_model: provider offline",
     });
+  });
+});
+
+describe("handleSetExtensionDisabled", () => {
+  it("emits the best-known source for extension-package toggles", async () => {
+    const f = makeFixture();
+    f.state.disabledExtensions.add("pkg-ext");
+    f.state.disabledExtensionMeta.set("pkg-ext", {
+      source: "extension-package",
+    });
+
+    await handleSetExtensionDisabled(f.state, f.deps, f.deps, {
+      type: "set_extension_disabled",
+      name: "pkg-ext",
+      disabled: false,
+    });
+
+    expect(f.sent).toContainEqual({
+      type: "extension_lifecycle",
+      name: "pkg-ext",
+      source: "extension-package",
+      status: "enabled",
+    });
+  });
+});
+
+describe("projectDisplayName", () => {
+  it("handles POSIX, Windows, mixed, and trailing separators", () => {
+    expect(projectDisplayName("/Users/me/project/")).toBe("project");
+    expect(projectDisplayName("C:\\Users\\me\\project")).toBe("project");
+    expect(projectDisplayName("C:\\Users/me\\project\\")).toBe("project");
   });
 });
 

--- a/agent/extensionControl.ts
+++ b/agent/extensionControl.ts
@@ -1,7 +1,16 @@
 import type { AethonAgentState } from "./state";
+import type { ExtensionSource } from "./state";
 import type { DispatcherDeps, InboundMessage } from "./dispatcherTypes";
 import { saveDisabledExtensionsSnapshot } from "./disabled-extensions";
 import { notify } from "./notifications";
+
+function extensionLifecycleSource(
+  loadedSource: ExtensionSource | undefined,
+  failureSource: ExtensionSource | undefined,
+  priorSource: ExtensionSource | undefined,
+): ExtensionSource {
+  return loadedSource ?? failureSource ?? priorSource ?? "directory";
+}
 
 export async function handleSetExtensionDisabled(
   state: AethonAgentState,
@@ -30,6 +39,13 @@ export async function handleSetExtensionDisabled(
   // Snapshot the prior meta so a save failure can restore both the
   // name and any metadata we'd just dropped/added.
   const priorMeta = state.disabledExtensionMeta.get(name);
+  const loadedSource = state.loadedExtensions.get(name);
+  const failureInfo = state.loadFailures.get(name);
+  const lifecycleSource = extensionLifecycleSource(
+    loadedSource,
+    failureInfo?.source,
+    priorMeta?.source,
+  );
   if (disabled) {
     state.disabledExtensions.add(name);
     // Capture source + projectRoot from the live loader registries.
@@ -40,8 +56,6 @@ export async function handleSetExtensionDisabled(
     // from both is preserved with its previous meta (if any) — we
     // never wipe a known scope just because the user toggled while
     // a different project was active.
-    const loadedSource = state.loadedExtensions.get(name);
-    const failureInfo = state.loadFailures.get(name);
     if (loadedSource) {
       const projectRoot =
         loadedSource === "project-directory"
@@ -104,13 +118,13 @@ export async function handleSetExtensionDisabled(
   }
   // Surface the change to the frontend immediately. The loaded set
   // doesn't change until restart; the sidebar shows a `(disabled)` row
-  // by deriving from `loadedExtensions ∩ ¬disabledExtensions` plus the
-  // explicit disabled list. We re-emit the lifecycle event so the
-  // hydration handler can move the row to the right bucket.
+  // by deriving from `loadedExtensions` plus the explicit disabled list.
+  // Re-emitting the lifecycle event gives layouts and the default system
+  // message handler immediate feedback before the bridge restart.
   deps.send({
     type: "extension_lifecycle",
     name,
-    source: "directory",
+    source: lifecycleSource,
     status: disabled ? "disabled" : "enabled",
   });
   // Notify the user before signalling the bridge restart so the toast

--- a/agent/projectLifecycle.ts
+++ b/agent/projectLifecycle.ts
@@ -10,6 +10,12 @@ import { patchLayoutTree } from "./layout-manager";
 import { logger } from "./logger";
 import { dismissNotification, notify } from "./notifications";
 
+export function projectDisplayName(cwd: string): string {
+  const trimmed = cwd.replace(/[\\/]+$/, "");
+  if (!trimmed) return cwd;
+  return trimmed.split(/[\\/]+/).pop() || cwd;
+}
+
 /** Capture a baseline snapshot of every registry an extension can write
  *  into. Captured AFTER user-level + extension-package + pi-extension
  *  loaders run, BEFORE any project-directory extension runs.
@@ -241,7 +247,7 @@ export async function handleSetProject(
       .scope("project-switch")
       .info(`set_project unload took ${Date.now() - t0}ms (cwd=${cwd})`);
   }
-  const projectName = cwd.split("/").pop() || cwd;
+  const projectName = projectDisplayName(cwd);
   const loadingNoticeId = `aethon:loading-project-ext:${cwd}`;
   const loadingNoticeTimer = projectChanged
     ? setTimeout(() => {


### PR DESCRIPTION
## Summary

- addresses four late Copilot findings from merged PR #110
- drains pending bridge reloads after handler-started A2UI prompts finish
- preserves accurate extension lifecycle source metadata for toggle events
- makes project loading notices display correctly for POSIX, Windows, mixed, and trailing-separator paths
- updates the extension toggle comment to match the current frontend lifecycle behavior

## Validation

- `bunx vitest run agent/dispatcher.test.ts`
- `bunx vitest run agent/dispatcher.test.ts agent/extension-loader.test.ts agent/disabled-extensions.test.ts src/hooks/bridgeMessageHandlers/extensionLifecycle.test.ts`
- `bun run typecheck`
- `bun run lint` (exits 0 with the existing 5 unrelated React hook warnings)
- `bunx vitest run` (145 files / 1117 tests)
- `bun run build` (passes with existing Vite chunk-size warning)
- `git diff --check`
- `bun run check`

Fixes follow-up review items from #110.
