### PR TITLE
refactor(app): split frontend orchestration hooks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,35 +1,29 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import A2UIRenderer, { RegistryComponent } from "./components/A2UIRenderer";
 import { SkillRegistry } from "./skills/SkillRegistry";
 import { SkillRegistryProvider } from "./skills/registry";
 import { defaultLayoutSkill } from "./skills/default-layout";
-import type { A2UIPayload, ChatMessage } from "./types/a2ui";
+import type { A2UIPayload } from "./types/a2ui";
 import type { Tab } from "./types/tab";
-import { dispatchEvent } from "./eventRoutes";
 import { useZoomAndTheme } from "./hooks/useZoomAndTheme";
 import { useShellConsent } from "./hooks/useShellConsent";
 import { useHostInfo } from "./hooks/useHostInfo";
 import { useProjects } from "./hooks/useProjects";
-import { discoverIcon } from "./projectIcons";
 import { useTabNavigation } from "./hooks/useTabNavigation";
 import { useTabs } from "./hooks/useTabs";
 import { useExtensionsHydration } from "./hooks/useExtensionsHydration";
-import { useBridgeMessages } from "./hooks/useBridgeMessages";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
 import { useWindowApi } from "./runtime/windowApi";
 import { useBootConfig } from "./hooks/useBootConfig";
-import {
-  useNotifications,
-  type NotificationInput,
-} from "./hooks/useNotifications";
+import { useNotifications } from "./hooks/useNotifications";
 import { useFocus } from "./hooks/useFocus";
 import { useChat } from "./hooks/useChat";
 import { useQueuedDispatch } from "./hooks/useQueuedDispatch";
 import { useFrontendStateMirror } from "./hooks/useFrontendStateMirror";
 import { useUiOverlays } from "./hooks/useUiOverlays";
 import { useUpdater } from "./hooks/useUpdater";
-import { useProjectOps, worktreeIdForCwd } from "./hooks/useProjectOps";
+import { useProjectOps } from "./hooks/useProjectOps";
 import { useOsEdges } from "./hooks/useOsEdges";
 import {
   buildInitialAppStore,
@@ -37,15 +31,14 @@ import {
 } from "./hooks/useSessionPersistence";
 import { useDerivedRenderState } from "./hooks/useDerivedRenderState";
 import { useTaskLauncher } from "./hooks/useTaskLauncher";
-import { useAppEventRouteContext } from "./hooks/useAppEventRouteContext";
-import type { SlashCommandContext } from "./slashCommands";
+import { useAppEventRouting } from "./hooks/useAppEventRouting";
+import { useAppStateRefs } from "./hooks/useAppStateRefs";
+import { useProjectModelRecorder } from "./hooks/useProjectModelRecorder";
+import { useProjectSyncEffects } from "./hooks/useProjectSyncEffects";
+import { useAppSlashCommandContext } from "./hooks/useAppSlashCommandContext";
+import { useAppBridgeMessages } from "./hooks/useAppBridgeMessages";
 import { writeState } from "./persist";
 import { useAppState } from "./state/appStore";
-import {
-  activeProject,
-  emptyProjectsState,
-  type ProjectsState,
-} from "./projects";
 import pkg from "../package.json" with { type: "json" };
 // Vite resolves `?url` imports to a hashed asset URL at build time. Injecting
 // the URL into layout state lets the header bind via `{"$ref": "/logoUrl"}`
@@ -101,74 +94,23 @@ export default function App() {
   // window.aethon.registerSkill(skill) and switch to its layout.
   const [layout, setLayout] = useState<A2UIPayload>(BOOT_LAYOUT);
 
-  // Latest state, kept in a ref so the aethon-debug skill can read it via
-  // `window.__AETHON_STATE__()` without going through React's state
-  // lifecycle. Synced in commit phase — handlers see the latest state
-  // because they only dereference after the next render commits.
-  const stateRef = useRef(appStore.getState());
-  useEffect(() => {
-    stateRef.current = appStore.getState();
-    return appStore.subscribe(() => {
-      stateRef.current = appStore.getState();
-    });
-  }, [appStore]);
+  const {
+    stateRef,
+    projectsRef,
+    piDefaultModelRef,
+    hangWarnActiveRef,
+    hangWarnTimersRef,
+    projectOpsHandleRef,
+    projectsHandleRef,
+    pushNotificationRef,
+    chatActionsRef,
+  } = useAppStateRefs(appStore);
 
   useSessionPersistence({ appStore, hasSyncSessionSnapshot });
 
-  function recordProjectModel(model: string, tabId?: string) {
-    if (!model.trim()) return;
-    setState((prev) => {
-      const tabs = (prev.tabs as Tab[] | undefined) ?? [];
-      const targetId =
-        tabId ?? (prev.activeTabId as string | undefined) ?? undefined;
-      const tab = targetId ? tabs.find((t) => t.id === targetId) : undefined;
-      const projectId = tab?.projectId ?? null;
-      if (!projectId) return prev;
-      const projectModels =
-        (prev.projectModels as Record<string, string> | undefined) ?? {};
-      if (projectModels[projectId] === model) return prev;
-      return {
-        ...prev,
-        projectModels: { ...projectModels, [projectId]: model },
-      };
-    });
-  }
+  const recordProjectModel = useProjectModelRecorder(setState);
 
-  // ---------------------------------------------------------------------
-  // App-owned shared refs — owned here (rather than inside their primary
-  // hook) so multiple hooks can read/write the same object without
-  // construction-order dependencies. Each gets a one-line ownership note.
-  // ---------------------------------------------------------------------
-  // Project list — useTabs reads it for new-tab cwd inheritance,
-  // useProjectOps mutates it. Shared via the same MutableRefObject.
-  const projectsRef = useRef<ProjectsState>(emptyProjectsState());
-  // Pi default model from `ready` — useTabs reads it for new-tab model
-  // inheritance, the bridge `ready` handler writes it.
-  const piDefaultModelRef = useRef<string>("");
-  // Hang-warn timers/active set — useBridgeMessages owns scheduling,
-  // useOsEdges clears them on supervisor signals.
   const hangWarnNotifId = (tabId: string) => `ae-hang-warn:${tabId}`;
-  const hangWarnActiveRef = useRef<Set<string>>(new Set());
-  const hangWarnTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(
-    new Map(),
-  );
-
-  // Forward handles populated below as hooks construct. Lets earlier
-  // hooks (useTabs / useProjects / useZoomAndTheme / useShellConsent)
-  // call into later hooks (useProjectOps / useNotifications / useChat)
-  // once they exist. Each handle is a no-op until wired.
-  const projectOpsHandleRef = useRef({
-    clearActiveProject: () => {},
-    setActiveProjectById: (_id: string): boolean => false,
-  });
-  const projectsHandleRef = useRef({
-    getPaths: (): string[] => [],
-    onGitStatusChanged: () => {},
-  });
-  const pushNotificationRef = useRef<(n: NotificationInput) => void>(() => {});
-  const chatActionsRef = useRef({
-    appendSystem: (_text: string) => {},
-  });
 
   // ---------------------------------------------------------------------
   // Boot config: read ~/.aethon/config.toml + persisted theme/zoom/sidebar
@@ -385,60 +327,14 @@ export default function App() {
     };
   });
 
-  const syncActiveWorktreeToActiveTab = useCallback(() => {
-    const tabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
-    const activeId = stateRef.current.activeTabId as string | undefined;
-    const active = activeId ? tabs.find((t) => t.id === activeId) : undefined;
-    if (!active || active.kind !== "agent") return;
-    const resolved = worktreeIdForCwd(
-      projectsRef.current,
-      active.cwd,
-      active.projectId,
-    );
-    if (resolved === undefined) return;
-    if (
-      active.projectId &&
-      projectsRef.current.activeId !== active.projectId
-    ) {
-      if (!setActiveProjectById(active.projectId)) return;
-    }
-    if (projectsRef.current.activeWorktreeId !== resolved) {
-      activateWorktree(resolved);
-    }
-  }, [activateWorktree, setActiveProjectById]);
-
-  useEffect(() => {
-    syncActiveWorktreeToActiveTab();
-  }, [
-    syncActiveWorktreeToActiveTab,
-    state.activeTabId,
-    state.activeWorktreeId,
-    state.cwd,
-    state.projects,
-    state.sidebar,
-  ]);
-
-  // Lazy project icon discovery — for each project missing an iconUrl,
-  // fire discoverIcon and persist the resolved url back to the project
-  // record. The in-process cache in src/projectIcons.ts memoizes by
-  // path so this effect is idempotent across re-runs. Runs whenever
-  // the projects list shape changes (new project, refresh, host swap).
-  const discoverIconsForProjects = useCallback(() => {
-    const ps = projectsRef.current.projects;
-    for (const project of ps) {
-      if (project.iconUrl) continue;
-      void (async () => {
-        const url = await discoverIcon(project);
-        if (!url) return;
-        if (!projectsRef.current.projects.some((p) => p.id === project.id))
-          return;
-        setProjectIconUrl(project.id, url);
-      })();
-    }
-  }, [setProjectIconUrl]);
-  useEffect(() => {
-    discoverIconsForProjects();
-  }, [discoverIconsForProjects, state.projects]);
+  useProjectSyncEffects({
+    state,
+    stateRef,
+    projectsRef,
+    setActiveProjectById,
+    activateWorktree,
+    setProjectIconUrl,
+  });
 
   // ---------------------------------------------------------------------
   // Toast stack + OS completion notification. Owned by useNotifications.
@@ -463,6 +359,45 @@ export default function App() {
   // their own handlers, which run after the first commit.
   useEffect(() => {
     pushNotificationRef.current = pushNotification;
+  });
+
+  // ---------------------------------------------------------------------
+  // Focus + chrome toggles — terminal panel, composer/terminal focus
+  // shuttle, sidebar toggle.
+  // ---------------------------------------------------------------------
+  const {
+    toggleTerminal,
+    toggleTerminalAndFocus,
+    toggleFocusComposerTerminal,
+    focusActiveContextInput,
+    toggleSidebar,
+    toggleFilesSidebar,
+  } = useFocus({ setState, stateRef });
+
+  const { slashContext, persistLocalChatMessage } = useAppSlashCommandContext({
+    bootLayout: BOOT_LAYOUT,
+    setState,
+    setLayout,
+    stateRef,
+    projectsRef,
+    layoutCatalogueRef,
+    registry,
+    appendMessage: (msg, tabId) =>
+      chatActionsRef.current.appendMessage(msg, tabId),
+    pushNotification,
+    clearChat: () => chatActionsRef.current.clearChat(),
+    setTheme,
+    listThemes,
+    setModel: (id) => chatActionsRef.current.setModel(id),
+    toggleTerminal,
+    toggleSidebar,
+    toggleFilesSidebar,
+    activateLayoutById,
+    openProjectFromPicker,
+    openProjectByPath,
+    setActiveProjectById,
+    clearActiveProject,
+    removeProjectById,
   });
 
   // ---------------------------------------------------------------------
@@ -502,7 +437,12 @@ export default function App() {
   // useExtensionsHydration's appendSystem-via-stub becomes the live one
   // before any of their handlers fire.
   useEffect(() => {
-    chatActionsRef.current = { appendSystem };
+    chatActionsRef.current = {
+      appendMessage,
+      appendSystem,
+      clearChat,
+      setModel,
+    };
   });
 
   // Drain the per-tab client-side message queues. The hook subscribes to
@@ -527,19 +467,6 @@ export default function App() {
     pendingTabOpens,
     sendChat,
   });
-
-  // ---------------------------------------------------------------------
-  // Focus + chrome toggles — terminal panel, composer/terminal focus
-  // shuttle, sidebar toggle.
-  // ---------------------------------------------------------------------
-  const {
-    toggleTerminal,
-    toggleTerminalAndFocus,
-    toggleFocusComposerTerminal,
-    focusActiveContextInput,
-    toggleSidebar,
-    toggleFilesSidebar,
-  } = useFocus({ setState, stateRef });
 
   // Updater (Cmd menu / tray "Check for Updates" + agent-driven path).
   const { checkForUpdates } = useUpdater({ appendSystem });
@@ -594,7 +521,7 @@ export default function App() {
   // (start_agent → boot_layout → report), and routes every
   // `agent-response` event through the per-type handler registry under
   // src/hooks/bridgeMessageHandlers/.
-  useBridgeMessages({
+  useAppBridgeMessages({
     bootLayout: BOOT_LAYOUT,
     onBootError: (err) => {
       appendMessage({
@@ -604,48 +531,46 @@ export default function App() {
       });
       setStatusFlags({ status: "error" });
     },
-    ctx: {
-      setState,
-      setLayout,
-      stateRef,
-      registry,
-      piDefaultModelRef,
-      allDiscoveredSessionsRef,
-      projectsRef,
-      projectsLoadedRef,
-      activeResponseIdRef,
-      hangWarnTimersRef,
-      hangWarnActiveRef,
-      turnStartedAtRef,
-      lastExtensionStateKeysRef,
-      pendingTabOpens,
-      updateTab,
-      updateActiveTab,
-      dispatchTerminalReplay,
-      autoRestoreDiscoveredSessions,
-      hydrateThemes,
-      hydrateExtensions,
-      hydrateSlashCommands,
-      hydrateKeybindings,
-      hydrateEventRoutes,
-      hydrateExtensionLayouts,
-      hydrateFrontendModules,
-      announceProjectToBridge,
-      appendMessage,
-      persistLocalChatMessage,
-      recordProjectModel,
-      appendOrAmendAgentText,
-      setStatusFlags,
-      pushNotification,
-      dismissNotification,
-      maybeFireCompletionNotification,
-      knownTabIds,
-      scopedDiscoveredSessions,
-      recentSessionItems,
-      syncRecentSessionsToState,
-      routeShellWrite,
-      startTaskInProject,
-    },
+    setState,
+    setLayout,
+    stateRef,
+    registry,
+    piDefaultModelRef,
+    allDiscoveredSessionsRef,
+    projectsRef,
+    projectsLoadedRef,
+    activeResponseIdRef,
+    hangWarnTimersRef,
+    hangWarnActiveRef,
+    turnStartedAtRef,
+    lastExtensionStateKeysRef,
+    pendingTabOpens,
+    updateTab,
+    updateActiveTab,
+    dispatchTerminalReplay,
+    autoRestoreDiscoveredSessions,
+    hydrateThemes,
+    hydrateExtensions,
+    hydrateSlashCommands,
+    hydrateKeybindings,
+    hydrateEventRoutes,
+    hydrateExtensionLayouts,
+    hydrateFrontendModules,
+    announceProjectToBridge,
+    appendMessage,
+    persistLocalChatMessage,
+    recordProjectModel,
+    appendOrAmendAgentText,
+    setStatusFlags,
+    pushNotification,
+    dismissNotification,
+    maybeFireCompletionNotification,
+    knownTabIds,
+    scopedDiscoveredSessions,
+    recentSessionItems,
+    syncRecentSessionsToState,
+    routeShellWrite,
+    startTaskInProject,
   });
 
   // Global keyboard shortcuts. Lives in useKeyboardShortcuts which
@@ -743,136 +668,6 @@ export default function App() {
     checkForUpdates,
   });
 
-  // Build the dispatch context fresh per invocation so handlers see latest
-  // state (model list, skills) without re-creating the command registry.
-  function persistLocalChatMessage(msg: ChatMessage, tabId: string) {
-    if (!msg.text && !msg.thinking) return;
-    invoke("agent_command", {
-      payload: JSON.stringify({
-        type: "local_chat_message",
-        tabId,
-        payload: {
-          id: msg.id,
-          role: msg.role,
-          ...(msg.text ? { text: msg.text } : {}),
-          ...(msg.thinking ? { thinking: msg.thinking } : {}),
-          ...(msg.delivery ? { delivery: msg.delivery } : {}),
-          createdAt: Date.now(),
-        },
-      }),
-    }).catch(() => {
-      /* bridge gone — visible state remains in-memory until reload */
-    });
-  }
-
-  function slashContext(): SlashCommandContext {
-    return {
-      appendSystem: (text: string) => {
-        const tabId =
-          (stateRef.current.activeTabId as string | undefined) ?? "default";
-        const msg = { id: crypto.randomUUID(), role: "system" as const, text };
-        appendMessage(msg, tabId);
-        persistLocalChatMessage(msg, tabId);
-      },
-      notify: (input) => {
-        pushNotification(input);
-      },
-      clearChat,
-      setTheme,
-      listThemes,
-      setModel,
-      resetLayout: () => setLayout(BOOT_LAYOUT),
-      listExtensions: () => registry.list().map((s) => s.name),
-      installExtension: async (spec: string) => {
-        return await invoke<string>("install_aethon_extension", { spec });
-      },
-      listModels: () => {
-        const sidebar =
-          (stateRef.current.sidebar as Record<string, unknown>) ?? {};
-        return (
-          (sidebar.models as {
-            id: string;
-            label: string;
-            active?: boolean;
-          }[]) ?? []
-        );
-      },
-      toggleTerminal,
-      toggleSidebar,
-      toggleFilesSidebar,
-      activateLayout: activateLayoutById,
-      listLayouts: () =>
-        layoutCatalogueRef.current.map((l) => ({
-          id: l.id,
-          name: l.name,
-          description: l.description,
-        })),
-      pickProject: openProjectFromPicker,
-      openProject: (path: string, label?: string) =>
-        openProjectByPath(path, label),
-      setActiveProject: setActiveProjectById,
-      clearProject: clearActiveProject,
-      removeProject: removeProjectById,
-      listProjects: () =>
-        projectsRef.current.projects.map((p) => ({
-          id: p.id,
-          label: p.label,
-          path: p.path,
-        })),
-      reloadAgent: async () => {
-        await invoke("reload_agent");
-      },
-      runNativeCommand: async (name: string, args: string) => {
-        const activeId = stateRef.current.activeTabId;
-        const tabId =
-          typeof activeId === "string" && activeId.length > 0
-            ? activeId
-            : "default";
-        await invoke("agent_command", {
-          payload: JSON.stringify({
-            type: "native_slash_command",
-            tabId,
-            name,
-            args,
-          }),
-        });
-      },
-      renameSession: async (tabId: string, label: string) => {
-        // Optimistic in-memory update so the open-tab row in the sidebar
-        // history (and the top tab strip + palette) reflect the new
-        // label immediately. The bridge persists label.txt; on the next
-        // ready re-emit the closed-session bucket also picks it up.
-        setState((prev) => {
-          const tabs = (prev.tabs as Tab[] | undefined) ?? [];
-          const idx = tabs.findIndex((t) => t.id === tabId);
-          if (idx < 0) return prev;
-          const trimmed = label.trim();
-          const fallback = `Tab ${idx + 1}`;
-          const nextLabel = trimmed.length > 0 ? trimmed : fallback;
-          if (tabs[idx].label === nextLabel) return prev;
-          const next = [...tabs];
-          next[idx] = { ...next[idx], label: nextLabel };
-          return { ...prev, tabs: next };
-        });
-        await invoke("agent_command", {
-          payload: JSON.stringify({
-            type: "set_session_label",
-            tabId,
-            label,
-          }),
-        });
-      },
-      activeTabId: () => {
-        const id = stateRef.current.activeTabId;
-        return typeof id === "string" && id.length > 0 ? id : null;
-      },
-      activeProject: () => {
-        const a = activeProject(projectsRef.current);
-        return a ? { id: a.id, label: a.label, path: a.path } : null;
-      },
-    };
-  }
-
   // Intercept events from layout-level components before they reach
   // the agent. The layout speaks A2UI, but a few interactions need to
   // drive native APIs (Tauri IPC for chat send, model picker) — the
@@ -880,7 +675,7 @@ export default function App() {
   // precedence layers, in order: shell-consent reserved prefixes
   // (security boundary), extension event-routes (extensibility),
   // built-in route table.
-  const eventRouteCtx = useAppEventRouteContext({
+  const onEvent = useAppEventRouting({
     setState,
     stateRef,
     extensionEventRoutesRef,
@@ -948,17 +743,6 @@ export default function App() {
     invoke,
     writeState,
   });
-
-  const onEvent = useMemo(
-    () =>
-      (
-        component: { id: string; type?: string },
-        eventType: string,
-        data?: unknown,
-      ) =>
-        dispatchEvent({ component, eventType, data }, eventRouteCtx),
-    [eventRouteCtx],
-  );
 
   const {
     renderState,

--- a/src/hooks/useAppBridgeMessages.ts
+++ b/src/hooks/useAppBridgeMessages.ts
@@ -1,0 +1,19 @@
+import {
+  useBridgeMessages,
+  type UseBridgeMessagesOptions,
+} from "./useBridgeMessages";
+
+export type UseAppBridgeMessagesOptions = UseBridgeMessagesOptions["ctx"] &
+  Pick<UseBridgeMessagesOptions, "bootLayout" | "onBootError">;
+
+export function useAppBridgeMessages({
+  bootLayout,
+  onBootError,
+  ...ctx
+}: UseAppBridgeMessagesOptions): void {
+  useBridgeMessages({
+    bootLayout,
+    onBootError,
+    ctx,
+  });
+}

--- a/src/hooks/useAppEventRouting.ts
+++ b/src/hooks/useAppEventRouting.ts
@@ -1,0 +1,24 @@
+import { useMemo } from "react";
+import { dispatchEvent, type EventRouteContext } from "../eventRoutes";
+import { useAppEventRouteContext } from "./useAppEventRouteContext";
+
+export function useAppEventRouting(
+  options: EventRouteContext,
+): (
+  component: { id: string; type?: string },
+  eventType: string,
+  data?: unknown,
+) => Promise<boolean> {
+  const eventRouteCtx = useAppEventRouteContext(options);
+
+  return useMemo(
+    () =>
+      (
+        component: { id: string; type?: string },
+        eventType: string,
+        data?: unknown,
+      ) =>
+        dispatchEvent({ component, eventType, data }, eventRouteCtx),
+    [eventRouteCtx],
+  );
+}

--- a/src/hooks/useAppSlashCommandContext.test.ts
+++ b/src/hooks/useAppSlashCommandContext.test.ts
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SkillRegistry } from "../skills/SkillRegistry";
+import type { ProjectsState } from "../projects";
+import { useAppSlashCommandContext } from "./useAppSlashCommandContext";
+
+const invokeMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: invokeMock,
+}));
+
+const ref = <T>(value: T) => ({ current: value });
+
+function makeProjects(): ProjectsState {
+  return {
+    projects: [
+      {
+        id: "project-1",
+        label: "Aethon",
+        path: "/repo/aethon",
+        lastUsed: 1,
+      },
+    ],
+    activeId: "project-1",
+    activeWorktreeId: null,
+    worktreesByProject: {},
+    activeHostId: null,
+  };
+}
+
+describe("useAppSlashCommandContext", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    invokeMock.mockResolvedValue(undefined);
+  });
+
+  it("persists slash command system output to the active tab", () => {
+    const appendMessage = vi.fn();
+    const { result } = renderHook(() =>
+      useAppSlashCommandContext({
+        bootLayout: { components: [] },
+        setState: vi.fn(),
+        setLayout: vi.fn(),
+        stateRef: ref({ activeTabId: "tab-1" }),
+        projectsRef: ref(makeProjects()),
+        layoutCatalogueRef: ref([
+          {
+            id: "workstation",
+            name: "Workstation",
+            payload: { components: [] },
+          },
+        ]),
+        registry: new SkillRegistry(),
+        appendMessage,
+        pushNotification: vi.fn(() => "toast-1"),
+        clearChat: vi.fn(),
+        setTheme: vi.fn(),
+        listThemes: vi.fn(() => []),
+        setModel: vi.fn(() => Promise.resolve()),
+        toggleTerminal: vi.fn(),
+        toggleSidebar: vi.fn(),
+        toggleFilesSidebar: vi.fn(),
+        activateLayoutById: vi.fn(() => true),
+        openProjectFromPicker: vi.fn(() => Promise.resolve(null)),
+        openProjectByPath: vi.fn((path: string) => path),
+        setActiveProjectById: vi.fn(() => true),
+        clearActiveProject: vi.fn(),
+        removeProjectById: vi.fn(() => true),
+      }),
+    );
+
+    act(() => {
+      result.current.slashContext().appendSystem("Theme set to Paper.");
+    });
+
+    expect(appendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        role: "system",
+        text: "Theme set to Paper.",
+      }),
+      "tab-1",
+    );
+    const payload = JSON.parse(invokeMock.mock.calls[0]?.[1]?.payload);
+    expect(payload).toMatchObject({
+      type: "local_chat_message",
+      tabId: "tab-1",
+      payload: {
+        role: "system",
+        text: "Theme set to Paper.",
+      },
+    });
+  });
+
+  it("does not persist empty local chat messages", () => {
+    const { result } = renderHook(() =>
+      useAppSlashCommandContext({
+        bootLayout: { components: [] },
+        setState: vi.fn(),
+        setLayout: vi.fn(),
+        stateRef: ref({}),
+        projectsRef: ref(makeProjects()),
+        layoutCatalogueRef: ref([]),
+        registry: new SkillRegistry(),
+        appendMessage: vi.fn(),
+        pushNotification: vi.fn(() => "toast-1"),
+        clearChat: vi.fn(),
+        setTheme: vi.fn(),
+        listThemes: vi.fn(() => []),
+        setModel: vi.fn(() => Promise.resolve()),
+        toggleTerminal: vi.fn(),
+        toggleSidebar: vi.fn(),
+        toggleFilesSidebar: vi.fn(),
+        activateLayoutById: vi.fn(() => true),
+        openProjectFromPicker: vi.fn(() => Promise.resolve(null)),
+        openProjectByPath: vi.fn((path: string) => path),
+        setActiveProjectById: vi.fn(() => true),
+        clearActiveProject: vi.fn(),
+        removeProjectById: vi.fn(() => true),
+      }),
+    );
+
+    act(() => {
+      result.current.persistLocalChatMessage(
+        { id: "m1", role: "system" },
+        "tab-1",
+      );
+    });
+
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useAppSlashCommandContext.ts
+++ b/src/hooks/useAppSlashCommandContext.ts
@@ -1,0 +1,223 @@
+import {
+  useCallback,
+  type Dispatch,
+  type MutableRefObject,
+  type SetStateAction,
+} from "react";
+import { invoke } from "@tauri-apps/api/core";
+import type { A2UIPayload, ChatMessage } from "../types/a2ui";
+import type { Tab } from "../types/tab";
+import { activeProject, type ProjectsState } from "../projects";
+import type { SlashCommandContext } from "../slashCommands";
+import type { SkillRegistry } from "../skills/SkillRegistry";
+import type { LayoutCatalogueEntry } from "../skills/default-layout";
+import type { NotificationInput } from "./useNotifications";
+
+export interface UseAppSlashCommandContextOptions {
+  bootLayout: A2UIPayload;
+  setState: Dispatch<SetStateAction<Record<string, unknown>>>;
+  setLayout: Dispatch<SetStateAction<A2UIPayload>>;
+  stateRef: MutableRefObject<Record<string, unknown>>;
+  projectsRef: MutableRefObject<ProjectsState>;
+  layoutCatalogueRef: MutableRefObject<LayoutCatalogueEntry[]>;
+  registry: SkillRegistry;
+  appendMessage: (msg: ChatMessage, tabId?: string) => void;
+  pushNotification: (n: NotificationInput) => string;
+  clearChat: () => void;
+  setTheme: (id: string) => void;
+  listThemes: () => { id: string; label: string }[];
+  setModel: (id: string) => Promise<void>;
+  toggleTerminal: () => void;
+  toggleSidebar: () => void;
+  toggleFilesSidebar: () => void;
+  activateLayoutById: (id: string) => boolean;
+  openProjectFromPicker: () => Promise<string | null>;
+  openProjectByPath: (path: string, label?: string) => string;
+  setActiveProjectById: (id: string) => boolean;
+  clearActiveProject: () => void;
+  removeProjectById: (id: string) => boolean;
+}
+
+export interface AppSlashCommandContextResult {
+  slashContext: () => SlashCommandContext;
+  persistLocalChatMessage: (msg: ChatMessage, tabId: string) => void;
+}
+
+export function useAppSlashCommandContext({
+  bootLayout,
+  setState,
+  setLayout,
+  stateRef,
+  projectsRef,
+  layoutCatalogueRef,
+  registry,
+  appendMessage,
+  pushNotification,
+  clearChat,
+  setTheme,
+  listThemes,
+  setModel,
+  toggleTerminal,
+  toggleSidebar,
+  toggleFilesSidebar,
+  activateLayoutById,
+  openProjectFromPicker,
+  openProjectByPath,
+  setActiveProjectById,
+  clearActiveProject,
+  removeProjectById,
+}: UseAppSlashCommandContextOptions): AppSlashCommandContextResult {
+  const persistLocalChatMessage = useCallback(
+    (msg: ChatMessage, tabId: string) => {
+      if (!msg.text && !msg.thinking) return;
+      invoke("agent_command", {
+        payload: JSON.stringify({
+          type: "local_chat_message",
+          tabId,
+          payload: {
+            id: msg.id,
+            role: msg.role,
+            ...(msg.text ? { text: msg.text } : {}),
+            ...(msg.thinking ? { thinking: msg.thinking } : {}),
+            ...(msg.delivery ? { delivery: msg.delivery } : {}),
+            createdAt: Date.now(),
+          },
+        }),
+      }).catch(() => {
+        /* bridge gone — visible state remains in-memory until reload */
+      });
+    },
+    [],
+  );
+
+  const slashContext = useCallback(
+    (): SlashCommandContext => ({
+      appendSystem: (text: string) => {
+        const tabId =
+          (stateRef.current.activeTabId as string | undefined) ?? "default";
+        const msg = { id: crypto.randomUUID(), role: "system" as const, text };
+        appendMessage(msg, tabId);
+        persistLocalChatMessage(msg, tabId);
+      },
+      notify: (input) => {
+        pushNotification(input);
+      },
+      clearChat,
+      setTheme,
+      listThemes,
+      setModel,
+      resetLayout: () => setLayout(bootLayout),
+      listExtensions: () => registry.list().map((s) => s.name),
+      installExtension: async (spec: string) => {
+        return await invoke<string>("install_aethon_extension", { spec });
+      },
+      listModels: () => {
+        const sidebar =
+          (stateRef.current.sidebar as Record<string, unknown>) ?? {};
+        return (
+          (sidebar.models as {
+            id: string;
+            label: string;
+            active?: boolean;
+          }[]) ?? []
+        );
+      },
+      toggleTerminal,
+      toggleSidebar,
+      toggleFilesSidebar,
+      activateLayout: activateLayoutById,
+      listLayouts: () =>
+        layoutCatalogueRef.current.map((l) => ({
+          id: l.id,
+          name: l.name,
+          description: l.description,
+        })),
+      pickProject: openProjectFromPicker,
+      openProject: (path: string, label?: string) =>
+        openProjectByPath(path, label),
+      setActiveProject: setActiveProjectById,
+      clearProject: clearActiveProject,
+      removeProject: removeProjectById,
+      listProjects: () =>
+        projectsRef.current.projects.map((p) => ({
+          id: p.id,
+          label: p.label,
+          path: p.path,
+        })),
+      reloadAgent: async () => {
+        await invoke("reload_agent");
+      },
+      runNativeCommand: async (name: string, args: string) => {
+        const activeId = stateRef.current.activeTabId;
+        const tabId =
+          typeof activeId === "string" && activeId.length > 0
+            ? activeId
+            : "default";
+        await invoke("agent_command", {
+          payload: JSON.stringify({
+            type: "native_slash_command",
+            tabId,
+            name,
+            args,
+          }),
+        });
+      },
+      renameSession: async (tabId: string, label: string) => {
+        setState((prev) => {
+          const tabs = (prev.tabs as Tab[] | undefined) ?? [];
+          const idx = tabs.findIndex((t) => t.id === tabId);
+          if (idx < 0) return prev;
+          const trimmed = label.trim();
+          const fallback = `Tab ${idx + 1}`;
+          const nextLabel = trimmed.length > 0 ? trimmed : fallback;
+          if (tabs[idx].label === nextLabel) return prev;
+          const next = [...tabs];
+          next[idx] = { ...next[idx], label: nextLabel };
+          return { ...prev, tabs: next };
+        });
+        await invoke("agent_command", {
+          payload: JSON.stringify({
+            type: "set_session_label",
+            tabId,
+            label,
+          }),
+        });
+      },
+      activeTabId: () => {
+        const id = stateRef.current.activeTabId;
+        return typeof id === "string" && id.length > 0 ? id : null;
+      },
+      activeProject: () => {
+        const a = activeProject(projectsRef.current);
+        return a ? { id: a.id, label: a.label, path: a.path } : null;
+      },
+    }),
+    [
+      activateLayoutById,
+      appendMessage,
+      bootLayout,
+      clearActiveProject,
+      clearChat,
+      layoutCatalogueRef,
+      listThemes,
+      openProjectByPath,
+      openProjectFromPicker,
+      persistLocalChatMessage,
+      projectsRef,
+      pushNotification,
+      registry,
+      removeProjectById,
+      setActiveProjectById,
+      setLayout,
+      setModel,
+      setState,
+      setTheme,
+      stateRef,
+      toggleFilesSidebar,
+      toggleSidebar,
+      toggleTerminal,
+    ],
+  );
+
+  return { slashContext, persistLocalChatMessage };
+}

--- a/src/hooks/useAppStateRefs.ts
+++ b/src/hooks/useAppStateRefs.ts
@@ -1,0 +1,71 @@
+import { useEffect, useRef, type MutableRefObject } from "react";
+import type { ChatMessage } from "../types/a2ui";
+import { emptyProjectsState, type ProjectsState } from "../projects";
+import type { AppStore } from "../state/appStore";
+import type { NotificationInput } from "./useNotifications";
+
+export interface ProjectOpsHandle {
+  clearActiveProject: () => void;
+  setActiveProjectById: (id: string) => boolean;
+}
+
+export interface ProjectsHandle {
+  getPaths: () => string[];
+  onGitStatusChanged: () => void;
+}
+
+export interface ChatActionsHandle {
+  appendMessage: (msg: ChatMessage, tabId?: string) => void;
+  appendSystem: (text: string) => void;
+  clearChat: () => void;
+  setModel: (id: string) => Promise<void>;
+}
+
+export interface AppStateRefs {
+  stateRef: MutableRefObject<Record<string, unknown>>;
+  projectsRef: MutableRefObject<ProjectsState>;
+  piDefaultModelRef: MutableRefObject<string>;
+  hangWarnActiveRef: MutableRefObject<Set<string>>;
+  hangWarnTimersRef: MutableRefObject<
+    Map<string, ReturnType<typeof setTimeout>>
+  >;
+  projectOpsHandleRef: MutableRefObject<ProjectOpsHandle>;
+  projectsHandleRef: MutableRefObject<ProjectsHandle>;
+  pushNotificationRef: MutableRefObject<(n: NotificationInput) => void>;
+  chatActionsRef: MutableRefObject<ChatActionsHandle>;
+}
+
+export function useAppStateRefs(appStore: AppStore): AppStateRefs {
+  const stateRef = useRef(appStore.getState());
+  useEffect(() => {
+    stateRef.current = appStore.getState();
+    return appStore.subscribe(() => {
+      stateRef.current = appStore.getState();
+    });
+  }, [appStore]);
+
+  return {
+    stateRef,
+    projectsRef: useRef<ProjectsState>(emptyProjectsState()),
+    piDefaultModelRef: useRef<string>(""),
+    hangWarnActiveRef: useRef<Set<string>>(new Set()),
+    hangWarnTimersRef: useRef<Map<string, ReturnType<typeof setTimeout>>>(
+      new Map(),
+    ),
+    projectOpsHandleRef: useRef<ProjectOpsHandle>({
+      clearActiveProject: () => {},
+      setActiveProjectById: () => false,
+    }),
+    projectsHandleRef: useRef<ProjectsHandle>({
+      getPaths: () => [],
+      onGitStatusChanged: () => {},
+    }),
+    pushNotificationRef: useRef<(n: NotificationInput) => void>(() => {}),
+    chatActionsRef: useRef<ChatActionsHandle>({
+      appendMessage: () => {},
+      appendSystem: () => {},
+      clearChat: () => {},
+      setModel: async () => {},
+    }),
+  };
+}

--- a/src/hooks/useProjectModelRecorder.test.ts
+++ b/src/hooks/useProjectModelRecorder.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useProjectModelRecorder } from "./useProjectModelRecorder";
+import { makeEmptyTab } from "../types/tab";
+
+describe("useProjectModelRecorder", () => {
+  it("records the active tab model under its project id", () => {
+    let state: Record<string, unknown> = {
+      activeTabId: "tab-1",
+      tabs: [
+        {
+          ...makeEmptyTab("tab-1", "Aethon"),
+          projectId: "project-1",
+        },
+      ],
+      projectModels: {},
+    };
+    const setState = (
+      next: typeof state | ((prev: typeof state) => typeof state),
+    ) => {
+      state = typeof next === "function" ? next(state) : next;
+    };
+    const { result } = renderHook(() => useProjectModelRecorder(setState));
+
+    act(() => {
+      result.current("gpt-5.1");
+    });
+
+    expect(state.projectModels).toEqual({ "project-1": "gpt-5.1" });
+  });
+
+  it("ignores blank models and tabs without projects", () => {
+    let state: Record<string, unknown> = {
+      activeTabId: "tab-1",
+      tabs: [
+        {
+          ...makeEmptyTab("tab-1", "No project"),
+          projectId: null,
+        },
+      ],
+      projectModels: {},
+    };
+    const setState = (
+      next: typeof state | ((prev: typeof state) => typeof state),
+    ) => {
+      state = typeof next === "function" ? next(state) : next;
+    };
+    const { result } = renderHook(() => useProjectModelRecorder(setState));
+
+    act(() => {
+      result.current("   ");
+      result.current("gpt-5.1");
+    });
+
+    expect(state.projectModels).toEqual({});
+  });
+});

--- a/src/hooks/useProjectModelRecorder.ts
+++ b/src/hooks/useProjectModelRecorder.ts
@@ -1,0 +1,28 @@
+import { useCallback, type Dispatch, type SetStateAction } from "react";
+import type { Tab } from "../types/tab";
+
+export function useProjectModelRecorder(
+  setState: Dispatch<SetStateAction<Record<string, unknown>>>,
+): (model: string, tabId?: string) => void {
+  return useCallback(
+    (model: string, tabId?: string) => {
+      if (!model.trim()) return;
+      setState((prev) => {
+        const tabs = (prev.tabs as Tab[] | undefined) ?? [];
+        const targetId =
+          tabId ?? (prev.activeTabId as string | undefined) ?? undefined;
+        const tab = targetId ? tabs.find((t) => t.id === targetId) : undefined;
+        const projectId = tab?.projectId ?? null;
+        if (!projectId) return prev;
+        const projectModels =
+          (prev.projectModels as Record<string, string> | undefined) ?? {};
+        if (projectModels[projectId] === model) return prev;
+        return {
+          ...prev,
+          projectModels: { ...projectModels, [projectId]: model },
+        };
+      });
+    },
+    [setState],
+  );
+}

--- a/src/hooks/useProjectSyncEffects.test.ts
+++ b/src/hooks/useProjectSyncEffects.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { ProjectsState } from "../projects";
+import { makeEmptyTab } from "../types/tab";
+import { useProjectSyncEffects } from "./useProjectSyncEffects";
+
+const discoverIconMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../projectIcons", () => ({
+  discoverIcon: discoverIconMock,
+}));
+
+const ref = <T>(value: T) => ({ current: value });
+
+function makeProjects(): ProjectsState {
+  return {
+    projects: [
+      {
+        id: "project-1",
+        label: "Aethon",
+        path: "/repo/aethon",
+        lastUsed: 1,
+      },
+    ],
+    activeId: null,
+    activeWorktreeId: null,
+    worktreesByProject: {
+      "project-1": [
+        {
+          id: "wt-main",
+          projectId: "project-1",
+          path: "/repo/aethon",
+          branch: "main",
+          isMain: true,
+        },
+        {
+          id: "wt-task",
+          projectId: "project-1",
+          path: "/repo/aethon-task",
+          branch: "feat/task",
+          isMain: false,
+        },
+      ],
+    },
+    activeHostId: null,
+  };
+}
+
+describe("useProjectSyncEffects", () => {
+  it("syncs the active project and worktree from the active agent tab", async () => {
+    const projectsRef = ref(makeProjects());
+    const stateRef = ref<Record<string, unknown>>({
+      activeTabId: "tab-1",
+      tabs: [
+        {
+          ...makeEmptyTab("tab-1", "Task", "project-1"),
+          projectId: "project-1",
+          cwd: "/repo/aethon-task",
+        },
+      ],
+    });
+    const setActiveProjectById = vi.fn((id: string) => {
+      projectsRef.current.activeId = id;
+      return true;
+    });
+    const activateWorktree = vi.fn((id: string | null) => {
+      projectsRef.current.activeWorktreeId = id;
+    });
+
+    renderHook(() =>
+      useProjectSyncEffects({
+        state: stateRef.current,
+        stateRef,
+        projectsRef,
+        setActiveProjectById,
+        activateWorktree,
+        setProjectIconUrl: vi.fn(),
+      }),
+    );
+
+    await waitFor(() => {
+      expect(setActiveProjectById).toHaveBeenCalledWith("project-1");
+      expect(activateWorktree).toHaveBeenCalledWith("wt-task");
+    });
+  });
+
+  it("discovers missing project icons and ignores stale projects", async () => {
+    discoverIconMock.mockResolvedValueOnce("file:///repo/aethon/icon.png");
+    const projectsRef = ref(makeProjects());
+    const setProjectIconUrl = vi.fn();
+
+    renderHook(() =>
+      useProjectSyncEffects({
+        state: { projects: projectsRef.current.projects },
+        stateRef: ref({}),
+        projectsRef,
+        setActiveProjectById: vi.fn(),
+        activateWorktree: vi.fn(),
+        setProjectIconUrl,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(setProjectIconUrl).toHaveBeenCalledWith(
+        "project-1",
+        "file:///repo/aethon/icon.png",
+      );
+    });
+  });
+});

--- a/src/hooks/useProjectSyncEffects.test.ts
+++ b/src/hooks/useProjectSyncEffects.test.ts
@@ -139,6 +139,7 @@ describe("useProjectSyncEffects", () => {
     projectsRef.current.projects = [];
     await act(async () => {
       resolveIcon("file:///repo/aethon/icon.png");
+      await Promise.resolve();
     });
 
     expect(setProjectIconUrl).not.toHaveBeenCalled();

--- a/src/hooks/useProjectSyncEffects.test.ts
+++ b/src/hooks/useProjectSyncEffects.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { ProjectsState } from "../projects";
 import { makeEmptyTab } from "../types/tab";
@@ -86,7 +86,7 @@ describe("useProjectSyncEffects", () => {
     });
   });
 
-  it("discovers missing project icons and ignores stale projects", async () => {
+  it("discovers missing project icons", async () => {
     discoverIconMock.mockResolvedValueOnce("file:///repo/aethon/icon.png");
     const projectsRef = ref(makeProjects());
     const setProjectIconUrl = vi.fn();
@@ -108,5 +108,39 @@ describe("useProjectSyncEffects", () => {
         "file:///repo/aethon/icon.png",
       );
     });
+  });
+
+  it("ignores icon results for stale projects", async () => {
+    let resolveIcon: (value: string | null) => void = () => {};
+    discoverIconMock.mockImplementationOnce(
+      () =>
+        new Promise<string | null>((resolve) => {
+          resolveIcon = resolve;
+        }),
+    );
+    const projectsRef = ref(makeProjects());
+    const setProjectIconUrl = vi.fn();
+
+    renderHook(() =>
+      useProjectSyncEffects({
+        state: { projects: projectsRef.current.projects },
+        stateRef: ref({}),
+        projectsRef,
+        setActiveProjectById: vi.fn(),
+        activateWorktree: vi.fn(),
+        setProjectIconUrl,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(discoverIconMock).toHaveBeenCalled();
+    });
+
+    projectsRef.current.projects = [];
+    await act(async () => {
+      resolveIcon("file:///repo/aethon/icon.png");
+    });
+
+    expect(setProjectIconUrl).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/useProjectSyncEffects.ts
+++ b/src/hooks/useProjectSyncEffects.ts
@@ -1,0 +1,72 @@
+import { useCallback, useEffect, type MutableRefObject } from "react";
+import type { ProjectsState } from "../projects";
+import { discoverIcon } from "../projectIcons";
+import type { Tab } from "../types/tab";
+import { worktreeIdForCwd } from "./useProjectOps";
+
+export interface UseProjectSyncEffectsOptions {
+  state: Record<string, unknown>;
+  stateRef: MutableRefObject<Record<string, unknown>>;
+  projectsRef: MutableRefObject<ProjectsState>;
+  setActiveProjectById: (id: string) => boolean;
+  activateWorktree: (worktreeId: string | null) => void;
+  setProjectIconUrl: (projectId: string, iconUrl: string) => void;
+}
+
+export function useProjectSyncEffects({
+  state,
+  stateRef,
+  projectsRef,
+  setActiveProjectById,
+  activateWorktree,
+  setProjectIconUrl,
+}: UseProjectSyncEffectsOptions): void {
+  const syncActiveWorktreeToActiveTab = useCallback(() => {
+    const tabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
+    const activeId = stateRef.current.activeTabId as string | undefined;
+    const active = activeId ? tabs.find((t) => t.id === activeId) : undefined;
+    if (!active || active.kind !== "agent") return;
+    const resolved = worktreeIdForCwd(
+      projectsRef.current,
+      active.cwd,
+      active.projectId,
+    );
+    if (resolved === undefined) return;
+    if (active.projectId && projectsRef.current.activeId !== active.projectId) {
+      if (!setActiveProjectById(active.projectId)) return;
+    }
+    if (projectsRef.current.activeWorktreeId !== resolved) {
+      activateWorktree(resolved);
+    }
+  }, [activateWorktree, projectsRef, setActiveProjectById, stateRef]);
+
+  useEffect(() => {
+    syncActiveWorktreeToActiveTab();
+  }, [
+    syncActiveWorktreeToActiveTab,
+    state.activeTabId,
+    state.activeWorktreeId,
+    state.cwd,
+    state.projects,
+    state.sidebar,
+  ]);
+
+  const discoverIconsForProjects = useCallback(() => {
+    const ps = projectsRef.current.projects;
+    for (const project of ps) {
+      if (project.iconUrl) continue;
+      void (async () => {
+        const url = await discoverIcon(project);
+        if (!url) return;
+        if (!projectsRef.current.projects.some((p) => p.id === project.id)) {
+          return;
+        }
+        setProjectIconUrl(project.id, url);
+      })();
+    }
+  }, [projectsRef, setProjectIconUrl]);
+
+  useEffect(() => {
+    discoverIconsForProjects();
+  }, [discoverIconsForProjects, state.projects]);
+}


### PR DESCRIPTION
## Summary
- Split App-owned shared refs, project model recording, project/worktree sync, slash command context, bridge message wiring, and event routing into focused hooks.
- Kept App as the construction-order shell while preserving the existing hook/ref choreography through explicit live refs.
- Added regression coverage for project model persistence, active-tab worktree sync and icon discovery, and slash-context local message persistence.

## Validation
- bunx vitest run src/hooks/useProjectModelRecorder.test.ts src/hooks/useProjectSyncEffects.test.ts src/hooks/useAppSlashCommandContext.test.ts
- bunx vitest run src/hooks/useChat.test.ts src/hooks/useProjectOps.test.ts src/hooks/useTaskLauncher.test.ts src/hooks/useDerivedRenderState.test.ts src/hooks/useKeyboardShortcuts.test.tsx src/eventRoutes/dispatchEvent.test.ts src/eventRoutes/sidebar.test.ts src/eventRoutes/dashboard.test.ts
- bun run typecheck
- bun run lint (passes with the same 5 existing react-hooks/set-state-in-effect warnings in dashboard/editor/layout files)
- bunx vitest run
- bun run build (passes with existing Vite chunk-size warning)
- git diff --check
- bun run check (passes; repeats the same 5 existing lint warnings under the warnings-only step)
