### PR TITLE
refactor(tauri): split shell bootstrap modules

### DIFF
--- a/src-tauri/src/agent_commands.rs
+++ b/src-tauri/src/agent_commands.rs
@@ -1,0 +1,191 @@
+use tauri::{AppHandle, Emitter, State};
+
+use crate::agent_process::{
+    AgentProcesses, AgentWorker, GLOBAL_AGENT_KEY, ensure_global_agent, retire_agent_key,
+    route_payload_key, write_agent_payload,
+};
+
+#[tauri::command]
+pub(crate) fn start_agent(state: State<'_, AgentProcesses>, app: AppHandle) -> Result<(), String> {
+    ensure_global_agent(&state, &app)
+}
+
+#[tauri::command]
+pub(crate) fn send_message(
+    message: String,
+    tab_id: Option<String>,
+    mode: Option<String>,
+    cwd: Option<String>,
+    model: Option<String>,
+    state: State<'_, AgentProcesses>,
+    app: AppHandle,
+) -> Result<(), String> {
+    let tab_id = tab_id.unwrap_or_else(|| "default".to_string());
+    let mut payload = serde_json::json!({
+        "type": "chat",
+        "content": message,
+        "mode": mode.unwrap_or_else(|| "normal".to_string()),
+        "tabId": tab_id,
+    });
+    if let Some(cwd) = cwd
+        && !cwd.is_empty()
+    {
+        payload["cwd"] = serde_json::Value::String(cwd);
+    }
+    if let Some(model) = model
+        && !model.is_empty()
+    {
+        payload["model"] = serde_json::Value::String(model);
+    }
+
+    let key = route_payload_key(&state, &payload);
+    let worker = worker_for_payload(&key, &payload, true);
+    write_agent_payload(&state, &app, key, payload, worker)
+}
+
+/// Hard-kill the running agent child. Called by the frontend's hang-warn
+/// notification "Force restart" button. We intentionally let the crash path
+/// fire: the existing `agent-crashed` handler clears waiting state and (if
+/// auto_restart_agent = true) respawns automatically.
+#[tauri::command]
+pub(crate) fn force_restart_agent(state: State<'_, AgentProcesses>) -> Result<(), String> {
+    let children: Vec<_> = {
+        let mut guard = state.children.lock().map_err(|e| e.to_string())?;
+        guard.drain().collect()
+    };
+    for (key, child) in children {
+        let mut child = child.lock().map_err(|e| e.to_string())?;
+        let pid = child.id();
+        tracing::warn!(target: "aethon::agent", key = key, "force_restart_agent: killing pid={pid}");
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+    if let Ok(mut routes) = state.mutation_routes.lock() {
+        routes.clear();
+    }
+    Ok(())
+}
+
+/// Intentional kill-and-respawn for state changes the bridge can't apply
+/// hot (currently: the user toggling an extension via the sidebar).
+#[tauri::command]
+pub(crate) fn reload_agent(state: State<'_, AgentProcesses>, app: AppHandle) -> Result<(), String> {
+    let children: Vec<_> = {
+        let mut guard = state.children.lock().map_err(|e| e.to_string())?;
+        guard.drain().collect()
+    };
+    if !children.is_empty() {
+        if let Ok(mut exits) = state.intentional_exits.lock() {
+            for (key, _) in &children {
+                exits.insert(key.clone());
+            }
+        }
+        for (key, child) in children {
+            let mut child = child.lock().map_err(|e| e.to_string())?;
+            let pid = child.id();
+            tracing::info!(target: "aethon::agent", key = key, "reload_agent: killing pid={pid}");
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+        if let Ok(mut routes) = state.mutation_routes.lock() {
+            routes.clear();
+        }
+    }
+    let _ = app.emit("agent-reloaded", "extension-toggle");
+    Ok(())
+}
+
+/// Forward an arbitrary JSON payload to the agent's stdin. Used by the model
+/// picker and runtime controls that are not wrapped in `dispatch_a2ui_event`.
+#[tauri::command]
+pub(crate) fn agent_command(
+    payload: String,
+    state: State<'_, AgentProcesses>,
+    app: AppHandle,
+) -> Result<(), String> {
+    let payload_value: serde_json::Value =
+        serde_json::from_str(&payload).map_err(|e| format!("invalid agent command: {e}"))?;
+    let key = route_payload_key(&state, &payload_value);
+    let worker = worker_for_payload(&key, &payload_value, true);
+    let should_retire = payload_value.get("type").and_then(|v| v.as_str()) == Some("tab_close")
+        && key != GLOBAL_AGENT_KEY;
+    write_agent_payload(&state, &app, key.clone(), payload_value, worker)?;
+    if should_retire {
+        retire_agent_key(&state, &key)?;
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub(crate) fn dispatch_a2ui_event(
+    event: String,
+    tab_id: Option<String>,
+    state: State<'_, AgentProcesses>,
+    app: AppHandle,
+) -> Result<(), String> {
+    let event_value: serde_json::Value = serde_json::from_str(&event).map_err(|e| e.to_string())?;
+    let tab_id = tab_id.unwrap_or_else(|| "default".to_string());
+    let payload = serde_json::json!({
+        "type": "a2ui_event",
+        "event": event_value,
+        "tabId": tab_id,
+    });
+    let key = route_payload_key(&state, &payload);
+    let worker = worker_for_payload(&key, &payload, false);
+    write_agent_payload(&state, &app, key, payload, worker)
+}
+
+fn worker_for_payload(
+    key: &str,
+    payload: &serde_json::Value,
+    include_cwd: bool,
+) -> Option<AgentWorker> {
+    if key == GLOBAL_AGENT_KEY {
+        return None;
+    }
+    let tab_id = payload.get("tabId").and_then(|v| v.as_str())?;
+    Some(AgentWorker {
+        tab_id: tab_id.to_string(),
+        cwd: include_cwd
+            .then(|| {
+                payload
+                    .get("cwd")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string())
+            })
+            .flatten(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::worker_for_payload;
+
+    #[test]
+    fn worker_context_carries_tab_and_optional_cwd() {
+        let payload = serde_json::json!({
+            "type": "chat",
+            "tabId": "tab-1",
+            "cwd": "/tmp/project",
+        });
+
+        let worker = worker_for_payload("tab:tab-1", &payload, true).expect("worker");
+
+        assert_eq!(worker.tab_id, "tab-1");
+        assert_eq!(worker.cwd.as_deref(), Some("/tmp/project"));
+    }
+
+    #[test]
+    fn event_worker_does_not_inherit_cwd() {
+        let payload = serde_json::json!({
+            "type": "a2ui_event",
+            "tabId": "tab-1",
+            "cwd": "/tmp/project",
+        });
+
+        let worker = worker_for_payload("tab:tab-1", &payload, false).expect("worker");
+
+        assert_eq!(worker.tab_id, "tab-1");
+        assert_eq!(worker.cwd, None);
+    }
+}

--- a/src-tauri/src/agent_process.rs
+++ b/src-tauri/src/agent_process.rs
@@ -1,0 +1,403 @@
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::sync::{Arc, Mutex};
+
+use tauri::{AppHandle, Emitter, Manager, State};
+
+use crate::helpers::parse_config_toml;
+use crate::{env, helpers};
+
+pub(crate) const GLOBAL_AGENT_KEY: &str = "__global__";
+
+pub(crate) struct AgentProcesses {
+    pub(crate) children: Mutex<HashMap<String, Arc<Mutex<Child>>>>,
+    pub(crate) mutation_routes: Arc<Mutex<HashMap<String, String>>>,
+    pub(crate) intentional_exits: Arc<Mutex<HashSet<String>>>,
+}
+
+impl AgentProcesses {
+    pub(crate) fn new() -> Self {
+        Self {
+            children: Mutex::new(HashMap::new()),
+            mutation_routes: Arc::new(Mutex::new(HashMap::new())),
+            intentional_exits: Arc::new(Mutex::new(HashSet::new())),
+        }
+    }
+}
+
+pub(crate) struct AgentWorker {
+    pub(crate) tab_id: String,
+    pub(crate) cwd: Option<String>,
+}
+
+/// Find the project root (the directory containing `agent/main.ts`). Tauri
+/// launches the dev binary with cwd set to `src-tauri/`, but our agent script
+/// lives one level up, so a naive relative path resolves to the wrong place.
+/// Walk up from cwd until we find the marker; fall back to cwd if nothing
+/// matches.
+pub(crate) fn project_root() -> PathBuf {
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let mut dir: &Path = &cwd;
+    for _ in 0..6 {
+        if dir.join("agent").join("main.ts").exists() {
+            return dir.to_path_buf();
+        }
+        match dir.parent() {
+            Some(p) => dir = p,
+            None => break,
+        }
+    }
+    cwd
+}
+
+/// Locate the bundled `aethon-agent` sidecar binary. Tauri's externalBin
+/// mechanism places sidecars next to the main executable on each platform
+/// (e.g. `Aethon.app/Contents/MacOS/aethon-agent-aarch64-apple-darwin`).
+/// Returns Err with a descriptive message when none of the candidate paths
+/// exist; the caller falls back to `bun run` in dev or surfaces the error
+/// in release.
+fn find_sidecar_binary() -> Result<PathBuf, String> {
+    let exe = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
+    let exe_dir = exe
+        .parent()
+        .ok_or("current_exe has no parent dir")?
+        .to_path_buf();
+    let triple = env!("AETHON_TARGET_TRIPLE");
+    // Tauri's externalBin strips the triple suffix before placing the file
+    // alongside the main exe. Check the stripped variant first, then the raw
+    // triple form for direct target/release runs.
+    let ext = std::env::consts::EXE_SUFFIX;
+    let candidates = [
+        exe_dir.join(format!("aethon-agent{ext}")),
+        exe_dir.join(format!("aethon-agent-{triple}{ext}")),
+    ];
+    for path in &candidates {
+        if path.exists() {
+            return Ok(path.clone());
+        }
+    }
+    Err(format!(
+        "aethon-agent sidecar not found next to {} (looked for: {})",
+        exe.display(),
+        candidates
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", "),
+    ))
+}
+
+/// Spawn the agent if no live child is held. Idempotent. Callers own the
+/// mutex around this. In dev (`debug_assertions`) we run `bun run
+/// agent/main.ts` from the project root. In release we run the bundled
+/// `aethon-agent` sidecar and enrich its env with docs, layout, user-state,
+/// and PATH information.
+fn ensure_agent_spawned(
+    guard: &mut HashMap<String, Arc<Mutex<Child>>>,
+    key: &str,
+    app: &AppHandle,
+    mutation_routes: Arc<Mutex<HashMap<String, String>>>,
+    intentional_exits: Arc<Mutex<HashSet<String>>>,
+    worker: Option<AgentWorker>,
+) -> Result<(), String> {
+    let exited_status = guard.get(key).and_then(|child| {
+        child
+            .lock()
+            .ok()
+            .and_then(|mut child| child.try_wait().ok().flatten())
+    });
+    if let Some(status) = exited_status {
+        tracing::info!(target: "aethon::agent", key = key, "previous child exited with {status:?}; respawning");
+        guard.remove(key);
+    }
+
+    if guard.contains_key(key) {
+        return Ok(());
+    }
+
+    let mut command = if cfg!(debug_assertions) {
+        let root = project_root();
+        let docs_dir = root.join("docs").join("aethon-agent");
+        let boot_layout_file = root
+            .join("src")
+            .join("skills")
+            .join("default-layout")
+            .join("workstation.a2ui.json");
+        let layout_slots_file = root
+            .join("src")
+            .join("skills")
+            .join("default-layout")
+            .join("slots.json");
+        let mut c = env::command("bun");
+        c.current_dir(&root).arg("run").arg("agent/main.ts");
+        c.env("AETHON_RELEASE_MODE", "0");
+        c.env("AETHON_PROJECT_ROOT", &root);
+        c.env("AETHON_DOCS_DIR", &docs_dir);
+        c.env("AETHON_BOOT_LAYOUT_FILE", &boot_layout_file);
+        c.env("AETHON_LAYOUT_SLOTS_FILE", &layout_slots_file);
+        c
+    } else {
+        let bin = find_sidecar_binary()?;
+        let resource_dir = app
+            .path()
+            .resource_dir()
+            .map_err(|e| format!("resource_dir: {e}"))?;
+        let pi_dir = resource_dir.join("pi");
+        let docs_dir = resource_dir.join("docs").join("aethon-agent");
+        let boot_layout_file = resource_dir
+            .join("skills")
+            .join("default-layout")
+            .join("workstation.a2ui.json");
+        let layout_slots_file = resource_dir
+            .join("skills")
+            .join("default-layout")
+            .join("slots.json");
+        let mut c = Command::new(&bin);
+        c.env("PI_PACKAGE_DIR", &pi_dir);
+        c.env("AETHON_RELEASE_MODE", "1");
+        c.env("AETHON_DOCS_DIR", &docs_dir);
+        c.env("AETHON_BOOT_LAYOUT_FILE", &boot_layout_file);
+        c.env("AETHON_LAYOUT_SLOTS_FILE", &layout_slots_file);
+        if let Some(path) = env::resolved_login_path() {
+            c.env("PATH", path);
+        }
+        c
+    };
+
+    if let Ok(home) = app.path().home_dir() {
+        let user_dir =
+            helpers::aethon_dir(Some(home.clone())).unwrap_or_else(|| home.join(".aethon"));
+        let state_file = user_dir.join("state.json");
+        let sessions_dir = user_dir.join("sessions");
+        command.env("AETHON_USER_DIR", &user_dir);
+        command.env("AETHON_STATE_FILE", &state_file);
+        command.env("AETHON_SESSIONS_DIR", &sessions_dir);
+
+        let cfg_path = user_dir.join("config.toml");
+        let raw = std::fs::read_to_string(&cfg_path).unwrap_or_default();
+        let cfg_json = parse_config_toml(&raw);
+        let warn_kb = cfg_json["extensions"]["stateWarnKb"].as_u64().unwrap_or(64);
+        let hard_kb = cfg_json["extensions"]["stateHardKb"]
+            .as_u64()
+            .unwrap_or(512);
+        command.env("AETHON_STATE_WARN_KB", warn_kb.to_string());
+        command.env("AETHON_STATE_HARD_KB", hard_kb.to_string());
+    }
+    if let Some(worker) = &worker {
+        command.env("AETHON_WORKER_TAB_ID", &worker.tab_id);
+        if let Some(cwd) = &worker.cwd
+            && !cwd.is_empty()
+        {
+            command.env("AETHON_WORKER_CWD", cwd);
+        }
+    }
+
+    let mut child = command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("failed to spawn agent: {e}"))?;
+
+    let pid = child.id();
+    tracing::info!(target: "aethon::agent", key = key, "spawned pid={pid}");
+
+    let stderr_tail: Arc<Mutex<VecDeque<String>>> =
+        Arc::new(Mutex::new(VecDeque::with_capacity(32)));
+    const STDERR_TAIL_CAP: usize = 32;
+
+    let stdout = child.stdout.take().ok_or("no stdout on spawned agent")?;
+    let app_stdout = app.clone();
+    let stderr_tail_for_supervisor = Arc::clone(&stderr_tail);
+    let stdout_key = key.to_string();
+    let stdout_tab_id = worker.as_ref().map(|w| w.tab_id.clone());
+    let stdout_routes = Arc::clone(&mutation_routes);
+    let stdout_intentional_exits = Arc::clone(&intentional_exits);
+    std::thread::spawn(move || {
+        let reader = BufReader::new(stdout);
+        let mut saw_reload_done = false;
+        for line in reader.lines() {
+            match line {
+                Ok(text) => {
+                    if text.contains("\"_reload_done\"") {
+                        saw_reload_done = true;
+                        let _ = app_stdout.emit("agent-reloaded", "");
+                        continue;
+                    }
+                    if let Ok(value) = serde_json::from_str::<serde_json::Value>(&text)
+                        && let Some(mutation_id) = value.get("mutationId").and_then(|v| v.as_str())
+                        && let Ok(mut routes) = stdout_routes.lock()
+                    {
+                        routes.insert(mutation_id.to_string(), stdout_key.clone());
+                    }
+                    let _ = app_stdout.emit("agent-response", text);
+                }
+                Err(_) => break,
+            }
+        }
+        tracing::debug!(target: "aethon::agent", key = stdout_key, "stdout reader for pid={pid} exited");
+        let intentional_exit = stdout_intentional_exits
+            .lock()
+            .map(|mut exits| exits.remove(&stdout_key))
+            .unwrap_or(false);
+        if intentional_exit || saw_reload_done {
+            return;
+        }
+        let tail: Vec<String> = match stderr_tail_for_supervisor.lock() {
+            Ok(g) => g.iter().cloned().collect(),
+            Err(_) => Vec::new(),
+        };
+        let _ = app_stdout.emit(
+            "agent-crashed",
+            serde_json::json!({
+                "pid": pid,
+                "tabId": stdout_tab_id,
+                "stderrTail": tail,
+            }),
+        );
+    });
+
+    let stderr = child.stderr.take().ok_or("no stderr on spawned agent")?;
+    let app_stderr = app.clone();
+    let stderr_tail_writer = Arc::clone(&stderr_tail);
+    let stderr_key = key.to_string();
+    std::thread::spawn(move || {
+        let reader = BufReader::new(stderr);
+        for line in reader.lines() {
+            match line {
+                Ok(text) => {
+                    tracing::info!(target: "aethon::agent::stderr", pid = pid, key = stderr_key, "{text}");
+                    if let Ok(mut g) = stderr_tail_writer.lock() {
+                        if g.len() >= STDERR_TAIL_CAP {
+                            g.pop_front();
+                        }
+                        g.push_back(text.clone());
+                    }
+                    let _ = app_stderr.emit("agent-stderr", text);
+                }
+                Err(_) => break,
+            }
+        }
+        tracing::debug!(target: "aethon::agent", key = stderr_key, "stderr reader for pid={pid} exited");
+    });
+
+    guard.insert(key.to_string(), Arc::new(Mutex::new(child)));
+    Ok(())
+}
+
+pub(crate) fn tab_agent_key(tab_id: &str) -> String {
+    format!("tab:{tab_id}")
+}
+
+pub(crate) fn write_agent_payload(
+    state: &State<'_, AgentProcesses>,
+    app: &AppHandle,
+    key: String,
+    payload: serde_json::Value,
+    worker: Option<AgentWorker>,
+) -> Result<(), String> {
+    let child = {
+        let mut guard = state.children.lock().map_err(|e| e.to_string())?;
+        ensure_agent_spawned(
+            &mut guard,
+            &key,
+            app,
+            Arc::clone(&state.mutation_routes),
+            Arc::clone(&state.intentional_exits),
+            worker,
+        )?;
+        guard.get(&key).cloned().ok_or("agent not running")?
+    };
+
+    let mut child = child.lock().map_err(|e| e.to_string())?;
+    let stdin = child.stdin.as_mut().ok_or("no stdin")?;
+    use std::io::Write;
+    writeln!(stdin, "{}", payload).map_err(|e| format!("write failed: {e}"))?;
+    stdin.flush().map_err(|e| format!("flush failed: {e}"))?;
+    Ok(())
+}
+
+pub(crate) fn ensure_global_agent(
+    state: &State<'_, AgentProcesses>,
+    app: &AppHandle,
+) -> Result<(), String> {
+    let mut guard = state.children.lock().map_err(|e| e.to_string())?;
+    ensure_agent_spawned(
+        &mut guard,
+        GLOBAL_AGENT_KEY,
+        app,
+        Arc::clone(&state.mutation_routes),
+        Arc::clone(&state.intentional_exits),
+        None,
+    )
+}
+
+pub(crate) fn retire_agent_key(state: &State<'_, AgentProcesses>, key: &str) -> Result<(), String> {
+    let child = {
+        let mut guard = state.children.lock().map_err(|e| e.to_string())?;
+        guard.remove(key)
+    };
+    let Some(child) = child else {
+        return Ok(());
+    };
+    if let Ok(mut exits) = state.intentional_exits.lock() {
+        exits.insert(key.to_string());
+    }
+    let mut child = child.lock().map_err(|e| e.to_string())?;
+    let pid = child.id();
+    tracing::info!(target: "aethon::agent", key = key, "retiring pid={pid}");
+    let _ = child.kill();
+    let _ = child.wait();
+    Ok(())
+}
+
+pub(crate) fn route_payload_key(
+    state: &State<'_, AgentProcesses>,
+    payload: &serde_json::Value,
+) -> String {
+    if payload.get("type").and_then(|v| v.as_str()) == Some("mutation_ack")
+        && let Some(mutation_id) = payload.get("mutationId").and_then(|v| v.as_str())
+        && let Ok(mut routes) = state.mutation_routes.lock()
+        && let Some(key) = routes.remove(mutation_id)
+    {
+        return key;
+    }
+    let tab_scoped = matches!(
+        payload.get("type").and_then(|v| v.as_str()),
+        Some(
+            "a2ui_event"
+                | "chat"
+                | "local_chat_message"
+                | "native_slash_command"
+                | "set_model"
+                | "stop"
+                | "tab_close"
+                | "tab_open"
+        )
+    );
+    if tab_scoped
+        && let Some(tab_id) = payload.get("tabId").and_then(|v| v.as_str())
+        && !tab_id.is_empty()
+        && tab_id != "default"
+    {
+        return tab_agent_key(tab_id);
+    }
+    GLOBAL_AGENT_KEY.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{GLOBAL_AGENT_KEY, tab_agent_key};
+
+    #[test]
+    fn global_agent_key_is_stable() {
+        assert_eq!(GLOBAL_AGENT_KEY, "__global__");
+    }
+
+    #[test]
+    fn tab_agent_key_keeps_tab_prefix() {
+        assert_eq!(tab_agent_key("abc"), "tab:abc");
+    }
+}

--- a/src-tauri/src/commands/extensions.rs
+++ b/src-tauri/src/commands/extensions.rs
@@ -30,7 +30,8 @@ use std::sync::{Arc, Mutex};
 use serde::Deserialize;
 use tauri::{AppHandle, Emitter, Manager, State};
 
-use crate::{AgentProcesses, env, project_root};
+use crate::agent_process::{AgentProcesses, project_root};
+use crate::env;
 
 // ─────────────────────────── menu items ────────────────────────────
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,14 +2,13 @@
 //!
 //! The thin Rust crust. Owns:
 //!
-//! - The `bun`/sidecar agent child + its stdout/stderr supervisors.
-//! - The agent IPC commands (`start_agent`, `send_message`,
-//!   `agent_command`, `dispatch_a2ui_event`, `force_restart_agent`).
-//! - The clipboard-paste persistence command (`save_paste_image`).
-//! - Tracing/logging initialization and the `~/.aethon/logs/` rotator.
-//! - `run()` — the `tauri::Builder` registration that wires every
+//! - The Tauri builder setup that wires every
 //!   command from the [`commands`] submodule + [`shell`] PTY module
 //!   into the invoke handler.
+//! - The `bun`/sidecar agent child and IPC commands live in
+//!   [`agent_process`] + [`agent_commands`].
+//! - Clipboard image paste persistence lives in [`paste`].
+//! - Tracing/logging initialization lives in [`logging`].
 //!
 //! Concern-grouped IPC commands live in [`commands`]:
 //!
@@ -26,790 +25,29 @@
 //! shell tabs live in [`shell`]; debug-only commands and the eval
 //! server live in [`debug`].
 
-use std::collections::{HashMap, HashSet, VecDeque};
-use std::io::{BufRead, BufReader, Write};
-use std::path::{Path, PathBuf};
-use std::process::{Child, Command, Stdio};
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::Arc;
 
-use tauri::{AppHandle, Emitter, Manager, State};
+use tauri::{Emitter, Manager};
 
+mod agent_commands;
+pub(crate) mod agent_process;
 mod commands;
 mod env;
 mod helpers;
+mod logging;
+mod paste;
 mod server;
 mod shell;
 mod window_state;
-use helpers::{parse_config_toml, sanitize_filename_segment};
 
 #[cfg(debug_assertions)]
 mod debug;
-
-// ─────────────────────────── agent process ────────────────────────────
-
-const GLOBAL_AGENT_KEY: &str = "__global__";
-
-pub(crate) struct AgentProcesses {
-    pub(crate) children: Mutex<HashMap<String, Arc<Mutex<Child>>>>,
-    pub(crate) mutation_routes: Arc<Mutex<HashMap<String, String>>>,
-    pub(crate) intentional_exits: Arc<Mutex<HashSet<String>>>,
-}
-
-impl AgentProcesses {
-    fn new() -> Self {
-        Self {
-            children: Mutex::new(HashMap::new()),
-            mutation_routes: Arc::new(Mutex::new(HashMap::new())),
-            intentional_exits: Arc::new(Mutex::new(HashSet::new())),
-        }
-    }
-}
-
-struct AgentWorker {
-    tab_id: String,
-    cwd: Option<String>,
-}
-
-/// Find the project root (the directory containing `agent/main.ts`). Tauri
-/// launches the dev binary with cwd set to `src-tauri/`, but our agent script
-/// lives one level up, so a naive relative path resolves to the wrong place.
-/// Walk up from cwd until we find the marker; fall back to cwd if nothing
-/// matches.
-pub(crate) fn project_root() -> PathBuf {
-    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-    let mut dir: &Path = &cwd;
-    for _ in 0..6 {
-        if dir.join("agent").join("main.ts").exists() {
-            return dir.to_path_buf();
-        }
-        match dir.parent() {
-            Some(p) => dir = p,
-            None => break,
-        }
-    }
-    cwd
-}
-
-/// Locate the bundled `aethon-agent` sidecar binary. Tauri's externalBin
-/// mechanism places sidecars next to the main executable on each platform
-/// (e.g. `Aethon.app/Contents/MacOS/aethon-agent-aarch64-apple-darwin`).
-/// Returns Err with a descriptive message when none of the candidate paths
-/// exist — the caller falls back to `bun run` in dev or surfaces the error
-/// in release.
-///
-/// The sidecar suffix is the host's Rust target triple at build time; we
-/// read it from the `TARGET` env var Cargo sets during `build.rs` (see
-/// `src-tauri/build.rs`) so the same binary works no matter what triple
-/// the running machine reports.
-fn find_sidecar_binary() -> Result<PathBuf, String> {
-    let exe = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
-    let exe_dir = exe
-        .parent()
-        .ok_or("current_exe has no parent dir")?
-        .to_path_buf();
-    let triple = env!("AETHON_TARGET_TRIPLE");
-    // Tauri's externalBin strips the triple suffix before placing the file
-    // alongside the main exe (so users see `aethon-agent`, not the full
-    // triple name). On Windows both the stripped and triple-suffixed
-    // names get a `.exe` extension. Check the stripped variant first
-    // (the one the bundler actually produces), then the raw triple
-    // form as a fallback for builds where the script ran but bundling
-    // didn't (e.g. running the dev exe straight out of target/release).
-    let ext = std::env::consts::EXE_SUFFIX; // "" on unix, ".exe" on windows
-    let candidates = [
-        exe_dir.join(format!("aethon-agent{ext}")),
-        exe_dir.join(format!("aethon-agent-{triple}{ext}")),
-    ];
-    for path in &candidates {
-        if path.exists() {
-            return Ok(path.clone());
-        }
-    }
-    Err(format!(
-        "aethon-agent sidecar not found next to {} (looked for: {})",
-        exe.display(),
-        candidates
-            .iter()
-            .map(|p| p.display().to_string())
-            .collect::<Vec<_>>()
-            .join(", "),
-    ))
-}
-
-/// Spawn the agent if no live child is held. Idempotent. Callers own the
-/// mutex around this. In dev (`debug_assertions`) we run `bun run
-/// agent/main.ts` from the project root so source edits hot-reload via
-/// the watcher in `commands/extensions.rs`. In release we run the compiled
-/// `aethon-agent` sidecar bundled by Tauri, with `PI_PACKAGE_DIR` set to
-/// the shipped pi metadata so `pi-coding-agent`'s package.json read at
-/// module load doesn't fail, plus an enriched PATH (see
-/// `env::resolved_login_path`) so pi can find npm/git when scanning user
-/// packages from `~/.pi/agent/settings.json`. Stdout is read on a
-/// background thread; each line is emitted as an `agent-response`
-/// Tauri event.
-fn ensure_agent_spawned(
-    guard: &mut HashMap<String, Arc<Mutex<Child>>>,
-    key: &str,
-    app: &AppHandle,
-    mutation_routes: Arc<Mutex<HashMap<String, String>>>,
-    intentional_exits: Arc<Mutex<HashSet<String>>>,
-    worker: Option<AgentWorker>,
-) -> Result<(), String> {
-    // Reap a dead child if present — try_wait returns Ok(Some(_)) when exited.
-    let exited_status = guard.get(key).and_then(|child| {
-        child
-            .lock()
-            .ok()
-            .and_then(|mut child| child.try_wait().ok().flatten())
-    });
-    if let Some(status) = exited_status {
-        tracing::info!(target: "aethon::agent", key = key, "previous child exited with {status:?}; respawning");
-        guard.remove(key);
-    }
-
-    if guard.contains_key(key) {
-        return Ok(());
-    }
-
-    // Docs live under `<project>/docs/aethon-agent/` in dev and under
-    // `<resource_dir>/docs/aethon-agent/` in release (declared as a Tauri
-    // resource bundle entry). The agent reads them via its `read` tool to
-    // get an authoritative reference for the A2UI primitives and the
-    // globalThis.aethon API surface — without them, the model would have to
-    // rely on training data, which lags this codebase.
-    let mut command = if cfg!(debug_assertions) {
-        let root = project_root();
-        let docs_dir = root.join("docs").join("aethon-agent");
-        let boot_layout_file = root
-            .join("src")
-            .join("skills")
-            .join("default-layout")
-            .join("workstation.a2ui.json");
-        let layout_slots_file = root
-            .join("src")
-            .join("skills")
-            .join("default-layout")
-            .join("slots.json");
-        let mut c = env::command("bun");
-        c.current_dir(&root).arg("run").arg("agent/main.ts");
-        c.env("AETHON_RELEASE_MODE", "0");
-        c.env("AETHON_PROJECT_ROOT", &root);
-        c.env("AETHON_DOCS_DIR", &docs_dir);
-        c.env("AETHON_BOOT_LAYOUT_FILE", &boot_layout_file);
-        c.env("AETHON_LAYOUT_SLOTS_FILE", &layout_slots_file);
-        c
-    } else {
-        let bin = find_sidecar_binary()?;
-        // pi-coding-agent reads its own package.json at module load. The
-        // shipped copy lives in Tauri's resource dir at `pi/package.json`
-        // (see tauri.conf.json `bundle.resources`); pi honors
-        // PI_PACKAGE_DIR for the lookup, so point it there.
-        let resource_dir = app
-            .path()
-            .resource_dir()
-            .map_err(|e| format!("resource_dir: {e}"))?;
-        let pi_dir = resource_dir.join("pi");
-        let docs_dir = resource_dir.join("docs").join("aethon-agent");
-        let boot_layout_file = resource_dir
-            .join("skills")
-            .join("default-layout")
-            .join("workstation.a2ui.json");
-        let layout_slots_file = resource_dir
-            .join("skills")
-            .join("default-layout")
-            .join("slots.json");
-        let mut c = Command::new(&bin);
-        c.env("PI_PACKAGE_DIR", &pi_dir);
-        c.env("AETHON_RELEASE_MODE", "1");
-        c.env("AETHON_DOCS_DIR", &docs_dir);
-        c.env("AETHON_BOOT_LAYOUT_FILE", &boot_layout_file);
-        c.env("AETHON_LAYOUT_SLOTS_FILE", &layout_slots_file);
-        // Bundled .app launches inherit launchd's minimal PATH on macOS, so
-        // pi's `npm root -g` (run when resolving user packages from
-        // ~/.pi/agent/settings.json) fails with ENOENT. Source the user's
-        // login shell once to recover the real PATH and inject it.
-        if let Some(path) = env::resolved_login_path() {
-            c.env("PATH", path);
-        }
-        c
-    };
-    // User dir is the same in both modes; the bridge writes its live state
-    // snapshot here so a `cat $AETHON_STATE_FILE` always reflects the
-    // current registrations without having to evaluate JS in the webview.
-    if let Ok(home) = app.path().home_dir() {
-        // helpers::aethon_dir honors AETHON_USER_DIR so `scripts/dev.sh --new`
-        // can route a session into a tmp sandbox without breaking the
-        // signal chain into the bridge.
-        let user_dir =
-            helpers::aethon_dir(Some(home.clone())).unwrap_or_else(|| home.join(".aethon"));
-        let state_file = user_dir.join("state.json");
-        let sessions_dir = user_dir.join("sessions");
-        command.env("AETHON_USER_DIR", &user_dir);
-        command.env("AETHON_STATE_FILE", &state_file);
-        command.env("AETHON_SESSIONS_DIR", &sessions_dir);
-        // Read [extensions] state_warn_kb / state_hard_kb from
-        // ~/.aethon/config.toml and pass to the bridge as env vars. We
-        // re-parse on every spawn so a config edit picks up on next
-        // bridge restart without a full app reboot.
-        let cfg_path = user_dir.join("config.toml");
-        let raw = std::fs::read_to_string(&cfg_path).unwrap_or_default();
-        let cfg_json = parse_config_toml(&raw);
-        let warn_kb = cfg_json["extensions"]["stateWarnKb"].as_u64().unwrap_or(64);
-        let hard_kb = cfg_json["extensions"]["stateHardKb"]
-            .as_u64()
-            .unwrap_or(512);
-        command.env("AETHON_STATE_WARN_KB", warn_kb.to_string());
-        command.env("AETHON_STATE_HARD_KB", hard_kb.to_string());
-    }
-    if let Some(worker) = &worker {
-        command.env("AETHON_WORKER_TAB_ID", &worker.tab_id);
-        if let Some(cwd) = &worker.cwd
-            && !cwd.is_empty()
-        {
-            command.env("AETHON_WORKER_CWD", cwd);
-        }
-    }
-
-    let mut child = command
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .map_err(|e| format!("failed to spawn agent: {e}"))?;
-
-    let pid = child.id();
-    tracing::info!(target: "aethon::agent", key = key, "spawned pid={pid}");
-
-    // Tail-buffer of recent stderr lines. When the bun child crashes
-    // unexpectedly, the supervisor emits an `agent-crashed` event with
-    // the last few lines so the frontend can surface a useful error
-    // notice rather than a generic "process exited" toast.
-    let stderr_tail: Arc<Mutex<VecDeque<String>>> =
-        Arc::new(Mutex::new(VecDeque::with_capacity(32)));
-    const STDERR_TAIL_CAP: usize = 32;
-
-    let stdout = child.stdout.take().ok_or("no stdout on spawned agent")?;
-    let app_stdout = app.clone();
-    let stderr_tail_for_supervisor = Arc::clone(&stderr_tail);
-    let stdout_key = key.to_string();
-    let stdout_tab_id = worker.as_ref().map(|w| w.tab_id.clone());
-    let stdout_routes = Arc::clone(&mutation_routes);
-    let stdout_intentional_exits = Arc::clone(&intentional_exits);
-    std::thread::spawn(move || {
-        let reader = BufReader::new(stdout);
-        let mut saw_reload_done = false;
-        for line in reader.lines() {
-            match line {
-                Ok(text) => {
-                    // Sentinel from the bridge meaning "I'm about to
-                    // exit cleanly because the watcher asked me to
-                    // reload." Keep that decision local to this child
-                    // so concurrent worker reloads cannot consume a
-                    // shared marker out from under each other.
-                    if text.contains("\"_reload_done\"") {
-                        saw_reload_done = true;
-                        let _ = app_stdout.emit("agent-reloaded", "");
-                        // Don't forward the sentinel — it's bridge↔
-                        // supervisor-internal and would confuse the
-                        // frontend's agent-response router.
-                        continue;
-                    }
-                    if let Ok(value) = serde_json::from_str::<serde_json::Value>(&text)
-                        && let Some(mutation_id) = value.get("mutationId").and_then(|v| v.as_str())
-                        && let Ok(mut routes) = stdout_routes.lock()
-                    {
-                        routes.insert(mutation_id.to_string(), stdout_key.clone());
-                    }
-                    let _ = app_stdout.emit("agent-response", text);
-                }
-                Err(_) => break,
-            }
-        }
-        tracing::debug!(target: "aethon::agent", key = stdout_key, "stdout reader for pid={pid} exited");
-        // Stdout reader exits when the child closes stdout — i.e. the
-        // child has died. Distinguish intentional per-child exits from
-        // unexpected crashes.
-        let intentional_exit = stdout_intentional_exits
-            .lock()
-            .map(|mut exits| exits.remove(&stdout_key))
-            .unwrap_or(false);
-        if intentional_exit || saw_reload_done {
-            // Intentional kill — `agent-reloaded` was already emitted by
-            // the watcher; nothing more to do.
-            return;
-        }
-        // Unexpected exit. Surface a notice with stderr tail so the
-        // user sees something actionable.
-        let tail: Vec<String> = match stderr_tail_for_supervisor.lock() {
-            Ok(g) => g.iter().cloned().collect(),
-            Err(_) => Vec::new(),
-        };
-        let _ = app_stdout.emit(
-            "agent-crashed",
-            serde_json::json!({
-                "pid": pid,
-                "tabId": stdout_tab_id,
-                "stderrTail": tail,
-            }),
-        );
-    });
-
-    // Capture stderr too — when the agent crashes inside Tauri's spawn env,
-    // stderr is the only visible signal. Lines are mirrored to Rust's stderr
-    // and forwarded to the frontend as `agent-stderr` events for the
-    // aethon-debug skill / status bar to surface.
-    let stderr = child.stderr.take().ok_or("no stderr on spawned agent")?;
-    let app_stderr = app.clone();
-    let stderr_tail_writer = Arc::clone(&stderr_tail);
-    let stderr_key = key.to_string();
-    std::thread::spawn(move || {
-        let reader = BufReader::new(stderr);
-        for line in reader.lines() {
-            match line {
-                Ok(text) => {
-                    // Bridge stderr — already prefixed by the bridge's logger
-                    // since it now emits structured `LEVEL scope: msg` lines.
-                    // We forward at info level and let the env filter throttle.
-                    tracing::info!(target: "aethon::agent::stderr", pid = pid, key = stderr_key, "{text}");
-                    if let Ok(mut g) = stderr_tail_writer.lock() {
-                        if g.len() >= STDERR_TAIL_CAP {
-                            g.pop_front();
-                        }
-                        g.push_back(text.clone());
-                    }
-                    let _ = app_stderr.emit("agent-stderr", text);
-                }
-                Err(_) => break,
-            }
-        }
-        tracing::debug!(target: "aethon::agent", key = stderr_key, "stderr reader for pid={pid} exited");
-    });
-
-    guard.insert(key.to_string(), Arc::new(Mutex::new(child)));
-    Ok(())
-}
-
-#[tauri::command]
-fn start_agent(state: State<'_, AgentProcesses>, app: AppHandle) -> Result<(), String> {
-    let mut guard = state.children.lock().map_err(|e| e.to_string())?;
-    ensure_agent_spawned(
-        &mut guard,
-        GLOBAL_AGENT_KEY,
-        &app,
-        Arc::clone(&state.mutation_routes),
-        Arc::clone(&state.intentional_exits),
-        None,
-    )
-}
-
-fn tab_agent_key(tab_id: &str) -> String {
-    format!("tab:{tab_id}")
-}
-
-fn write_agent_payload(
-    state: &State<'_, AgentProcesses>,
-    app: &AppHandle,
-    key: String,
-    payload: serde_json::Value,
-    worker: Option<AgentWorker>,
-) -> Result<(), String> {
-    let child = {
-        let mut guard = state.children.lock().map_err(|e| e.to_string())?;
-        ensure_agent_spawned(
-            &mut guard,
-            &key,
-            app,
-            Arc::clone(&state.mutation_routes),
-            Arc::clone(&state.intentional_exits),
-            worker,
-        )?;
-        guard.get(&key).cloned().ok_or("agent not running")?
-    };
-
-    let mut child = child.lock().map_err(|e| e.to_string())?;
-    let stdin = child.stdin.as_mut().ok_or("no stdin")?;
-    writeln!(stdin, "{}", payload).map_err(|e| format!("write failed: {e}"))?;
-    stdin.flush().map_err(|e| format!("flush failed: {e}"))?;
-    Ok(())
-}
-
-fn retire_agent_key(state: &State<'_, AgentProcesses>, key: &str) -> Result<(), String> {
-    let child = {
-        let mut guard = state.children.lock().map_err(|e| e.to_string())?;
-        guard.remove(key)
-    };
-    let Some(child) = child else {
-        return Ok(());
-    };
-    if let Ok(mut exits) = state.intentional_exits.lock() {
-        exits.insert(key.to_string());
-    }
-    let mut child = child.lock().map_err(|e| e.to_string())?;
-    let pid = child.id();
-    tracing::info!(target: "aethon::agent", key = key, "retiring pid={pid}");
-    let _ = child.kill();
-    let _ = child.wait();
-    Ok(())
-}
-
-fn route_payload_key(state: &State<'_, AgentProcesses>, payload: &serde_json::Value) -> String {
-    if payload.get("type").and_then(|v| v.as_str()) == Some("mutation_ack")
-        && let Some(mutation_id) = payload.get("mutationId").and_then(|v| v.as_str())
-        && let Ok(mut routes) = state.mutation_routes.lock()
-        && let Some(key) = routes.remove(mutation_id)
-    {
-        return key;
-    }
-    let tab_scoped = matches!(
-        payload.get("type").and_then(|v| v.as_str()),
-        Some(
-            "a2ui_event"
-                | "chat"
-                | "local_chat_message"
-                | "native_slash_command"
-                | "set_model"
-                | "stop"
-                | "tab_close"
-                | "tab_open"
-        )
-    );
-    if tab_scoped
-        && let Some(tab_id) = payload.get("tabId").and_then(|v| v.as_str())
-        && !tab_id.is_empty()
-        && tab_id != "default"
-    {
-        return tab_agent_key(tab_id);
-    }
-    GLOBAL_AGENT_KEY.to_string()
-}
-
-#[tauri::command]
-fn send_message(
-    message: String,
-    tab_id: Option<String>,
-    mode: Option<String>,
-    cwd: Option<String>,
-    model: Option<String>,
-    state: State<'_, AgentProcesses>,
-    app: AppHandle,
-) -> Result<(), String> {
-    let tab_id = tab_id.unwrap_or_else(|| "default".to_string());
-    // tabId routes to a specific pi session; the bridge defaults to
-    // "default" when omitted so legacy single-tab callers keep working.
-    let mut payload = serde_json::json!({
-        "type": "chat",
-        "content": message,
-        "mode": mode.unwrap_or_else(|| "normal".to_string()),
-        "tabId": tab_id,
-    });
-    if let Some(cwd) = cwd
-        && !cwd.is_empty()
-    {
-        payload["cwd"] = serde_json::Value::String(cwd);
-    }
-    if let Some(model) = model
-        && !model.is_empty()
-    {
-        payload["model"] = serde_json::Value::String(model);
-    }
-
-    let key = route_payload_key(&state, &payload);
-    let worker = if key == GLOBAL_AGENT_KEY {
-        None
-    } else {
-        Some(AgentWorker {
-            tab_id: payload["tabId"].as_str().unwrap_or("default").to_string(),
-            cwd: payload
-                .get("cwd")
-                .and_then(|v| v.as_str())
-                .map(|s| s.to_string()),
-        })
-    };
-    write_agent_payload(&state, &app, key, payload, worker)
-}
-
-/// Hard-kill the running agent child. Called by the frontend's hang-warn
-/// notification "Force restart" button. We intentionally let the crash path
-/// fire: the existing `agent-crashed` handler clears waiting state and (if
-/// auto_restart_agent = true) respawns automatically.
-///
-/// This bypasses blocked stdin — even if the Node event loop is frozen by
-/// backpressured stdout writes, Rust can still kill the child OS process.
-#[tauri::command]
-fn force_restart_agent(state: State<'_, AgentProcesses>) -> Result<(), String> {
-    let children: Vec<_> = {
-        let mut guard = state.children.lock().map_err(|e| e.to_string())?;
-        guard.drain().collect()
-    };
-    for (key, child) in children {
-        let mut child = child.lock().map_err(|e| e.to_string())?;
-        let pid = child.id();
-        tracing::warn!(target: "aethon::agent", key = key, "force_restart_agent: killing pid={pid}");
-        let _ = child.kill();
-        // Reap the child so it doesn't become a zombie while we wait for
-        // the stdout reader thread to detect EOF and emit agent-crashed.
-        let _ = child.wait();
-    }
-    if let Ok(mut routes) = state.mutation_routes.lock() {
-        routes.clear();
-    }
-    Ok(())
-}
-
-/// Intentional kill-and-respawn for state changes the bridge can't apply
-/// hot (currently: the user toggling an extension via the sidebar). Marks
-/// each child key as an intentional exit BEFORE killing so the stdout reader
-/// treats EOF as a clean reload, not `agent-crashed`. The frontend's
-/// `agent-reloaded` handler then invokes `start_agent` and the new bridge
-/// boots fresh — for the
-/// disable-extension case, it reads `disabled-extensions.json` and the
-/// loader honors the user's intent.
-#[tauri::command]
-fn reload_agent(state: State<'_, AgentProcesses>, app: AppHandle) -> Result<(), String> {
-    let children: Vec<_> = {
-        let mut guard = state.children.lock().map_err(|e| e.to_string())?;
-        guard.drain().collect()
-    };
-    if !children.is_empty() {
-        if let Ok(mut exits) = state.intentional_exits.lock() {
-            for (key, _) in &children {
-                exits.insert(key.clone());
-            }
-        }
-        for (key, child) in children {
-            let mut child = child.lock().map_err(|e| e.to_string())?;
-            let pid = child.id();
-            tracing::info!(target: "aethon::agent", key = key, "reload_agent: killing pid={pid}");
-            let _ = child.kill();
-            let _ = child.wait();
-        }
-        if let Ok(mut routes) = state.mutation_routes.lock() {
-            routes.clear();
-        }
-    }
-    // Emit agent-reloaded so the frontend re-primes via start_agent.
-    // Safe to emit even when no child existed — the listener invokes
-    // start_agent which is a no-op if the agent is already absent.
-    let _ = app.emit("agent-reloaded", "extension-toggle");
-    Ok(())
-}
-
-/// Forward an arbitrary JSON payload to the agent's stdin. Used by the model
-/// picker and any future runtime controls that aren't wrapped in
-/// `dispatch_a2ui_event`.
-#[tauri::command]
-fn agent_command(
-    payload: String,
-    state: State<'_, AgentProcesses>,
-    app: AppHandle,
-) -> Result<(), String> {
-    let payload_value: serde_json::Value =
-        serde_json::from_str(&payload).map_err(|e| format!("invalid agent command: {e}"))?;
-    let key = route_payload_key(&state, &payload_value);
-    let worker = if key == GLOBAL_AGENT_KEY {
-        None
-    } else {
-        payload_value
-            .get("tabId")
-            .and_then(|v| v.as_str())
-            .map(|tab_id| AgentWorker {
-                tab_id: tab_id.to_string(),
-                cwd: payload_value
-                    .get("cwd")
-                    .and_then(|v| v.as_str())
-                    .map(|s| s.to_string()),
-            })
-    };
-    let should_retire = payload_value.get("type").and_then(|v| v.as_str()) == Some("tab_close")
-        && key != GLOBAL_AGENT_KEY;
-    write_agent_payload(&state, &app, key.clone(), payload_value, worker)?;
-    if should_retire {
-        retire_agent_key(&state, &key)?;
-    }
-    Ok(())
-}
-
-#[tauri::command]
-fn dispatch_a2ui_event(
-    event: String,
-    tab_id: Option<String>,
-    state: State<'_, AgentProcesses>,
-    app: AppHandle,
-) -> Result<(), String> {
-    let event_value: serde_json::Value = serde_json::from_str(&event).map_err(|e| e.to_string())?;
-    let tab_id = tab_id.unwrap_or_else(|| "default".to_string());
-    // tabId routes the event (and any handler-fired pi.prompt()) to the
-    // originating tab's session instead of always defaulting to "default".
-    let payload = serde_json::json!({
-        "type": "a2ui_event",
-        "event": event_value,
-        "tabId": tab_id,
-    });
-    let key = route_payload_key(&state, &payload);
-    let worker = if key == GLOBAL_AGENT_KEY {
-        None
-    } else {
-        Some(AgentWorker {
-            tab_id: payload["tabId"].as_str().unwrap_or("default").to_string(),
-            cwd: None,
-        })
-    };
-    write_agent_payload(&state, &app, key, payload, worker)
-}
-
-/// Persist an image paste from the clipboard to `~/.aethon/pastes/`.
-/// Returns the absolute path so the frontend can insert it into the
-/// draft as an `@<path>` token — the agent's existing read tool can
-/// then pick the image up via the path. Why not pass bytes inline to
-/// the agent: pi's bridge protocol is line-delimited JSON over stdin;
-/// shipping a 1–2 MiB base64 blob per paste would balloon a single
-/// message into a multi-MB write that competes with normal traffic.
-/// Persisting + path-passing is the same pattern the agent uses for
-/// any other read input.
-#[tauri::command]
-fn save_paste_image(
-    bytes: Vec<u8>,
-    extension: Option<String>,
-    app: AppHandle,
-) -> Result<String, String> {
-    if bytes.is_empty() {
-        return Err("save_paste_image: empty payload".to_string());
-    }
-    if bytes.len() > 32 * 1024 * 1024 {
-        return Err("save_paste_image: payload exceeds 32 MiB".to_string());
-    }
-    let home = app
-        .path()
-        .home_dir()
-        .map_err(|e| format!("home_dir: {e}"))?;
-    let dir = helpers::aethon_dir(Some(home))
-        .ok_or_else(|| "aethon dir unresolved".to_string())?
-        .join("pastes");
-    std::fs::create_dir_all(&dir).map_err(|e| format!("create_dir_all: {e}"))?;
-    let ext = extension
-        .as_deref()
-        .filter(|e| !e.is_empty())
-        .map(sanitize_filename_segment)
-        .filter(|e| !e.is_empty())
-        .unwrap_or_else(|| "png".to_string());
-    let id = uuid::Uuid::new_v4().simple().to_string();
-    let path = dir.join(format!("{id}.{ext}"));
-    std::fs::write(&path, bytes).map_err(|e| format!("write: {e}"))?;
-    Ok(path.to_string_lossy().to_string())
-}
-
-// ─────────────────────────── tracing ────────────────────────────
-
-/// Keep the non-blocking file appender's WorkerGuard alive for the
-/// process lifetime. Dropping the guard flushes pending writes; when
-/// `init_tracing` returns, the local guard would be dropped and the
-/// background thread would exit before any non-trivial logging
-/// happens. Stash it here.
-static LOG_GUARD: OnceLock<tracing_appender::non_blocking::WorkerGuard> = OnceLock::new();
-
-/// `~/.aethon/logs/` — same parent as state.json + projects.json so a
-/// user troubleshooting an issue finds everything in one place. Created
-/// at boot so the appender doesn't fail on a fresh install.
-fn log_dir() -> Option<PathBuf> {
-    let home = std::env::var_os("HOME").map(PathBuf::from);
-    let dir = helpers::aethon_dir(home)?.join("logs");
-    if let Err(e) = std::fs::create_dir_all(&dir) {
-        eprintln!("[init_tracing] mkdir {}: {e}", dir.display());
-        return None;
-    }
-    Some(dir)
-}
-
-/// Prune log files older than `RETENTION_DAYS`. `tracing-appender`'s
-/// daily rotation produces files named `aethon.YYYY-MM-DD`; matching by
-/// that prefix lets us coexist with the bridge's own log files in the
-/// same directory without touching them.
-const RETENTION_DAYS: u64 = 7;
-fn prune_old_logs(dir: &Path) {
-    let cutoff = match std::time::SystemTime::now().checked_sub(std::time::Duration::from_secs(
-        RETENTION_DAYS * 24 * 60 * 60,
-    )) {
-        Some(t) => t,
-        None => return,
-    };
-    let entries = match std::fs::read_dir(dir) {
-        Ok(e) => e,
-        Err(_) => return,
-    };
-    for entry in entries.flatten() {
-        let name = entry.file_name();
-        let name_str = match name.to_str() {
-            Some(s) => s,
-            None => continue,
-        };
-        // Only prune our own log files — leave bridge logs and anything
-        // else alone.
-        if !name_str.starts_with("aethon.") {
-            continue;
-        }
-        let modified = entry.metadata().ok().and_then(|m| m.modified().ok());
-        if let Some(t) = modified
-            && t < cutoff
-        {
-            let _ = std::fs::remove_file(entry.path());
-        }
-    }
-}
-
-/// Initialize the `tracing` subscriber. Called from `run()` before any
-/// log call so module-load output is captured. Honors `AETHON_LOG`
-/// (preferred — keeps the namespace ours) and falls back to `RUST_LOG`.
-/// Default level is `info` in dev and `warn` in release so noisy
-/// `[agent-watch]` chatter doesn't show in shipped binaries.
-///
-/// Logs go to BOTH stderr (so the dev terminal sees them in real time)
-/// AND a daily-rotating file at `~/.aethon/logs/aethon.YYYY-MM-DD` (so
-/// release users have a paper trail for crashes / weird behavior).
-/// Files older than `RETENTION_DAYS` are pruned at startup.
-fn init_tracing() {
-    use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt};
-    let default_level = if cfg!(debug_assertions) {
-        "info"
-    } else {
-        "warn"
-    };
-    let filter = EnvFilter::try_from_env("AETHON_LOG")
-        .or_else(|_| EnvFilter::try_from_default_env())
-        .unwrap_or_else(|_| EnvFilter::new(default_level));
-
-    let stderr_layer = fmt::layer().with_target(true).with_writer(std::io::stderr);
-
-    // File layer is best-effort: if the home dir isn't reachable or the
-    // appender fails to start, we still get stderr logging.
-    let file_layer = log_dir().and_then(|dir| {
-        prune_old_logs(&dir);
-        let file_appender = tracing_appender::rolling::daily(&dir, "aethon");
-        let (writer, guard) = tracing_appender::non_blocking(file_appender);
-        // Stash the guard so writes don't get lost on shutdown.
-        LOG_GUARD.set(guard).ok()?;
-        Some(
-            fmt::layer()
-                .with_target(true)
-                .with_ansi(false) // No color codes in the file
-                .with_writer(writer),
-        )
-    });
-
-    let subscriber = tracing_subscriber::registry()
-        .with(filter)
-        .with(stderr_layer);
-    let _ = if let Some(file) = file_layer {
-        subscriber.with(file).try_init()
-    } else {
-        subscriber.try_init()
-    };
-}
 
 // ─────────────────────────── run ────────────────────────────
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    init_tracing();
+    logging::init_tracing();
     let mut builder = tauri::Builder::default();
     builder = builder.plugin(tauri_plugin_process::init());
     builder = builder.plugin(tauri_plugin_opener::init());
@@ -834,7 +72,7 @@ pub fn run() {
         }
     }
     let builder = builder
-        .manage(AgentProcesses::new())
+        .manage(agent_process::AgentProcesses::new())
         .manage(shell::ShellRegistry::new())
         .manage(commands::fs::FsWatchState::default())
         .manage(window_state::WindowStateStore::new())
@@ -854,13 +92,13 @@ pub fn run() {
             _ => {}
         })
         .invoke_handler(tauri::generate_handler![
-            start_agent,
-            send_message,
-            agent_command,
-            force_restart_agent,
-            reload_agent,
-            dispatch_a2ui_event,
-            save_paste_image,
+            agent_commands::start_agent,
+            agent_commands::send_message,
+            agent_commands::agent_command,
+            agent_commands::force_restart_agent,
+            agent_commands::reload_agent,
+            agent_commands::dispatch_a2ui_event,
+            paste::save_paste_image,
             commands::config::read_state,
             commands::config::write_state,
             commands::config::read_config,
@@ -1002,5 +240,24 @@ mod tests {
             src.contains("commands::extensions::set_extension_menu_items"),
             "set_extension_menu_items must be registered in the invoke_handler list",
         );
+    }
+
+    #[test]
+    fn extracted_shell_commands_are_wired_to_handler() {
+        let src = include_str!("lib.rs");
+        for command in [
+            "agent_commands::start_agent",
+            "agent_commands::send_message",
+            "agent_commands::agent_command",
+            "agent_commands::force_restart_agent",
+            "agent_commands::reload_agent",
+            "agent_commands::dispatch_a2ui_event",
+            "paste::save_paste_image",
+        ] {
+            assert!(
+                src.contains(command),
+                "{command} must stay registered in the invoke_handler list",
+            );
+        }
     }
 }

--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -11,14 +11,15 @@ const RETENTION_DAYS: u64 = 7;
 
 /// `~/.aethon/logs/` — same parent as state.json + projects.json so a user
 /// troubleshooting an issue finds everything in one place.
-fn log_dir() -> Option<PathBuf> {
+fn log_dir() -> Result<Option<PathBuf>, String> {
     let home = std::env::var_os("HOME").map(PathBuf::from);
-    let dir = helpers::aethon_dir(home)?.join("logs");
+    let Some(dir) = helpers::aethon_dir(home).map(|dir| dir.join("logs")) else {
+        return Ok(None);
+    };
     if let Err(e) = std::fs::create_dir_all(&dir) {
-        eprintln!("[init_tracing] mkdir {}: {e}", dir.display());
-        return None;
+        return Err(format!("mkdir {}: {e}", dir.display()));
     }
-    Some(dir)
+    Ok(Some(dir))
 }
 
 /// Prune old `aethon.YYYY-MM-DD` files without touching bridge logs or any
@@ -67,18 +68,25 @@ pub(crate) fn init_tracing() {
 
     let stderr_layer = fmt::layer().with_target(true).with_writer(std::io::stderr);
 
-    let file_layer = log_dir().and_then(|dir| {
-        prune_old_logs(&dir);
-        let file_appender = tracing_appender::rolling::daily(&dir, "aethon");
-        let (writer, guard) = tracing_appender::non_blocking(file_appender);
-        LOG_GUARD.set(guard).ok()?;
-        Some(
-            fmt::layer()
-                .with_target(true)
-                .with_ansi(false)
-                .with_writer(writer),
-        )
-    });
+    let mut log_dir_error = None;
+    let file_layer = match log_dir() {
+        Ok(Some(dir)) => {
+            prune_old_logs(&dir);
+            let file_appender = tracing_appender::rolling::daily(&dir, "aethon");
+            let (writer, guard) = tracing_appender::non_blocking(file_appender);
+            LOG_GUARD.set(guard).ok().map(|_| {
+                fmt::layer()
+                    .with_target(true)
+                    .with_ansi(false)
+                    .with_writer(writer)
+            })
+        }
+        Ok(None) => None,
+        Err(err) => {
+            log_dir_error = Some(err);
+            None
+        }
+    };
 
     let subscriber = tracing_subscriber::registry()
         .with(filter)
@@ -88,6 +96,9 @@ pub(crate) fn init_tracing() {
     } else {
         subscriber.try_init()
     };
+    if let Some(err) = log_dir_error {
+        tracing::warn!(target: "aethon::logging", "log file setup skipped: {err}");
+    }
 }
 
 #[cfg(test)]
@@ -97,5 +108,13 @@ mod tests {
     #[test]
     fn log_retention_stays_one_week() {
         assert_eq!(RETENTION_DAYS, 7);
+    }
+
+    #[test]
+    fn logging_errors_stay_on_tracing_pipeline() {
+        let src = include_str!("logging.rs");
+
+        assert!(!src.contains(concat!("e", "println!")));
+        assert!(src.contains("log file setup skipped"));
     }
 }

--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -1,0 +1,101 @@
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+use crate::helpers;
+
+/// Keep the non-blocking file appender's WorkerGuard alive for the process
+/// lifetime. Dropping it flushes pending writes and exits the logging thread.
+static LOG_GUARD: OnceLock<tracing_appender::non_blocking::WorkerGuard> = OnceLock::new();
+
+const RETENTION_DAYS: u64 = 7;
+
+/// `~/.aethon/logs/` — same parent as state.json + projects.json so a user
+/// troubleshooting an issue finds everything in one place.
+fn log_dir() -> Option<PathBuf> {
+    let home = std::env::var_os("HOME").map(PathBuf::from);
+    let dir = helpers::aethon_dir(home)?.join("logs");
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        eprintln!("[init_tracing] mkdir {}: {e}", dir.display());
+        return None;
+    }
+    Some(dir)
+}
+
+/// Prune old `aethon.YYYY-MM-DD` files without touching bridge logs or any
+/// other troubleshooting artifacts in the same directory.
+fn prune_old_logs(dir: &Path) {
+    let cutoff = match std::time::SystemTime::now().checked_sub(std::time::Duration::from_secs(
+        RETENTION_DAYS * 24 * 60 * 60,
+    )) {
+        Some(t) => t,
+        None => return,
+    };
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name_str = match name.to_str() {
+            Some(s) => s,
+            None => continue,
+        };
+        if !name_str.starts_with("aethon.") {
+            continue;
+        }
+        let modified = entry.metadata().ok().and_then(|m| m.modified().ok());
+        if let Some(t) = modified
+            && t < cutoff
+        {
+            let _ = std::fs::remove_file(entry.path());
+        }
+    }
+}
+
+/// Initialize the `tracing` subscriber. Honors `AETHON_LOG` first, then
+/// `RUST_LOG`, and logs to both stderr and a daily rotating file.
+pub(crate) fn init_tracing() {
+    use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt};
+    let default_level = if cfg!(debug_assertions) {
+        "info"
+    } else {
+        "warn"
+    };
+    let filter = EnvFilter::try_from_env("AETHON_LOG")
+        .or_else(|_| EnvFilter::try_from_default_env())
+        .unwrap_or_else(|_| EnvFilter::new(default_level));
+
+    let stderr_layer = fmt::layer().with_target(true).with_writer(std::io::stderr);
+
+    let file_layer = log_dir().and_then(|dir| {
+        prune_old_logs(&dir);
+        let file_appender = tracing_appender::rolling::daily(&dir, "aethon");
+        let (writer, guard) = tracing_appender::non_blocking(file_appender);
+        LOG_GUARD.set(guard).ok()?;
+        Some(
+            fmt::layer()
+                .with_target(true)
+                .with_ansi(false)
+                .with_writer(writer),
+        )
+    });
+
+    let subscriber = tracing_subscriber::registry()
+        .with(filter)
+        .with(stderr_layer);
+    let _ = if let Some(file) = file_layer {
+        subscriber.with(file).try_init()
+    } else {
+        subscriber.try_init()
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RETENTION_DAYS;
+
+    #[test]
+    fn log_retention_stays_one_week() {
+        assert_eq!(RETENTION_DAYS, 7);
+    }
+}

--- a/src-tauri/src/paste.rs
+++ b/src-tauri/src/paste.rs
@@ -1,0 +1,57 @@
+use tauri::{AppHandle, Manager};
+
+use crate::helpers::{self, sanitize_filename_segment};
+
+/// Persist an image paste from the clipboard to `~/.aethon/pastes/`.
+/// Returns the absolute path so the frontend can insert it into the
+/// draft as an `@<path>` token and let the agent read it like any other file.
+#[tauri::command]
+pub(crate) fn save_paste_image(
+    bytes: Vec<u8>,
+    extension: Option<String>,
+    app: AppHandle,
+) -> Result<String, String> {
+    if bytes.is_empty() {
+        return Err("save_paste_image: empty payload".to_string());
+    }
+    if bytes.len() > 32 * 1024 * 1024 {
+        return Err("save_paste_image: payload exceeds 32 MiB".to_string());
+    }
+    let home = app
+        .path()
+        .home_dir()
+        .map_err(|e| format!("home_dir: {e}"))?;
+    let dir = helpers::aethon_dir(Some(home))
+        .ok_or_else(|| "aethon dir unresolved".to_string())?
+        .join("pastes");
+    std::fs::create_dir_all(&dir).map_err(|e| format!("create_dir_all: {e}"))?;
+    let ext = sanitize_extension(extension.as_deref());
+    let id = uuid::Uuid::new_v4().simple().to_string();
+    let path = dir.join(format!("{id}.{ext}"));
+    std::fs::write(&path, bytes).map_err(|e| format!("write: {e}"))?;
+    Ok(path.to_string_lossy().to_string())
+}
+
+fn sanitize_extension(extension: Option<&str>) -> String {
+    extension
+        .filter(|e| !e.is_empty())
+        .map(sanitize_filename_segment)
+        .filter(|e| !e.is_empty())
+        .unwrap_or_else(|| "png".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sanitize_extension;
+
+    #[test]
+    fn sanitize_extension_defaults_empty_values_to_png() {
+        assert_eq!(sanitize_extension(None), "png");
+        assert_eq!(sanitize_extension(Some("")), "png");
+    }
+
+    #[test]
+    fn sanitize_extension_removes_unsafe_path_parts() {
+        assert_eq!(sanitize_extension(Some("../jpeg")), "jpeg");
+    }
+}


### PR DESCRIPTION
## Summary

This refactor trims `src-tauri/src/lib.rs` back into a Tauri builder shell and moves the mixed bootstrap concerns into focused modules:

- `agent_process.rs` now owns the agent child table, sidecar lookup, spawn environment, stdout/stderr reader threads, mutation routing, and project-root discovery.
- `agent_commands.rs` now owns the Tauri IPC commands for starting, messaging, dispatching A2UI events, and restarting/reloading the agent.
- `paste.rs` now owns clipboard image persistence through `save_paste_image`.
- `logging.rs` now owns tracing initialization, log directory setup, and retention pruning.
- `lib.rs` keeps plugin registration, managed state registration, invoke handler wiring, setup hooks, window state persistence hooks, and server boot.

The command names and runtime behavior are preserved; only the implementation modules and handler paths changed. `commands/extensions.rs` now imports `AgentProcesses` and `project_root` from `agent_process` so the watcher/install flows keep using the same process table.

## Regression Coverage

Added focused structural/unit coverage for the extracted seams:

- command-handler wiring for the moved agent and paste commands in `lib.rs`
- stable global/tab agent keys in `agent_process.rs`
- worker context routing in `agent_commands.rs`, including preserving chat cwd while keeping event dispatch cwd-free
- paste extension sanitization defaults
- logging retention constant

## Validation

- `cargo test --lib -p aethon` — 157 passed
- `cargo clippy --lib -p aethon -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `bun run check` — passed; reported the existing 5 frontend React lint warnings already present on main
- `bun run build` — passed; reported the existing Vite chunk-size warning
