### PR TITLE
refactor(tabs): split useTabs into tabOps/ submodules

### DIFF
--- a/src/hooks/tabOps/agentTab.ts
+++ b/src/hooks/tabOps/agentTab.ts
@@ -1,0 +1,147 @@
+import type { Dispatch, MutableRefObject, SetStateAction } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { makeEmptyTab, type Tab } from "../../types/tab";
+import type { ProjectsState } from "../../projects";
+import { recomputeModelPicker } from "../../utils/modelPicker";
+import { TAB_MIRROR_KEYS } from "./constants";
+import {
+  cwdForNewTab,
+  modelForNewProjectTab,
+  sessionLabelFromMessages,
+} from "./helpers";
+
+export interface NewTabDeps {
+  setState: Dispatch<SetStateAction<Record<string, unknown>>>;
+  stateRef: MutableRefObject<Record<string, unknown>>;
+  projectsRef: MutableRefObject<ProjectsState>;
+  piDefaultModelRef: MutableRefObject<string>;
+  pendingTabOpens: MutableRefObject<Map<string, Promise<unknown>>>;
+  appendSystem: (text: string) => void;
+  dispatchTerminalReplay: (buffer: string) => void;
+}
+
+/** Build the agent-tab creator. Owns the heavy lifting around restoring
+ *  a tab by id (so the bridge's SessionManager.continueRecent picks up
+ *  the persisted JSONL session for that id), inheriting model + cwd
+ *  from project scope, and seeding a scroll-to-match target for the
+ *  search-hit empty-state path. */
+export function useNewTab(deps: NewTabDeps) {
+  const {
+    setState,
+    stateRef,
+    projectsRef,
+    piDefaultModelRef,
+    pendingTabOpens,
+    appendSystem,
+    dispatchTerminalReplay,
+  } = deps;
+
+  return function newTab(
+    restoreId?: string,
+    restoreLabel?: string,
+    options?: {
+      restoredSession?: boolean;
+      cwd?: string;
+      scrollToMatch?: string;
+    },
+  ): void {
+    // restoreId lets the caller open a tab with a specific tabId so the
+    // bridge's SessionManager.continueRecent picks up the persisted
+    // session for that id. Used by the empty-state's "Recent sessions"
+    // list. Omitted for normal new-tab gestures (Cmd+T, +, menu).
+    const id = restoreId ?? crypto.randomUUID();
+    // Search-hit scroll target. Stored in /scrollToMatchByTab/<id> so
+    // ChatHistory picks it up once the bridge replays messages. Null
+    // out the entry after a few seconds so a user who scrolls away
+    // doesn't keep getting yanked back.
+    const scrollToMatch = options?.scrollToMatch;
+    if (scrollToMatch) {
+      setState((prev) => {
+        const cur =
+          (prev.scrollToMatchByTab as Record<string, string> | undefined) ?? {};
+        return {
+          ...prev,
+          scrollToMatchByTab: { ...cur, [id]: scrollToMatch },
+        };
+      });
+      window.setTimeout(() => {
+        setState((prev) => {
+          const cur =
+            (prev.scrollToMatchByTab as Record<string, string> | undefined) ??
+            {};
+          if (!(id in cur)) return prev;
+          const next = { ...cur };
+          delete next[id];
+          return { ...prev, scrollToMatchByTab: next };
+        });
+      }, 5000);
+    }
+    // Project-scoped model default: new tabs in a project should use
+    // the last model selected in that project, then the visible/global
+    // model, then pi's ready-reported default.
+    const projectId = projectsRef.current.activeId;
+    const inheritedCwd =
+      options?.cwd ??
+      cwdForNewTab(projectsRef.current, stateRef.current) ??
+      undefined;
+    const inheritedModel = modelForNewProjectTab(
+      stateRef.current,
+      projectId,
+      piDefaultModelRef.current,
+    );
+    const existingSessionLabel = restoreId
+      ? sessionLabelFromMessages(
+          ((stateRef.current.tabs as Tab[] | undefined) ?? []).find(
+            (t) => t.id === restoreId,
+          )?.messages ?? [],
+        )
+      : undefined;
+    setState((prev) => {
+      const tabs = ((prev.tabs as Tab[] | undefined) ?? []).slice();
+      const label =
+        restoreLabel ?? existingSessionLabel ?? `Tab ${tabs.length + 1}`;
+      const tab: Tab = {
+        ...makeEmptyTab(id, label, projectId),
+        model: inheritedModel,
+        ...(inheritedCwd ? { cwd: inheritedCwd } : {}),
+      };
+      tabs.push(tab);
+      const result: Record<string, unknown> = {
+        ...prev,
+        tabs,
+        activeTabId: id,
+        empty: false,
+        hasTabs: true,
+      };
+      const tabRec = tab as unknown as Record<string, unknown>;
+      for (const key of TAB_MIRROR_KEYS) {
+        result[key as string] = tabRec[key as string];
+      }
+      result.sidebar = recomputeModelPicker(
+        prev.sidebar as Record<string, unknown> | undefined,
+        tab.model,
+      );
+      return result;
+    });
+    // Clear the shared xterm so it doesn't keep showing the previous
+    // tab's scrollback until the next switch / output event.
+    dispatchTerminalReplay("");
+    const opening = invoke("agent_command", {
+      payload: JSON.stringify({
+        type: "tab_open",
+        tabId: id,
+        ...(inheritedModel ? { model: inheritedModel } : {}),
+        ...(inheritedCwd ? { cwd: inheritedCwd } : {}),
+        ...(options?.restoredSession ? { restoreHistory: true } : {}),
+      }),
+    });
+    pendingTabOpens.current.set(id, opening);
+    opening
+      .catch((err) => {
+        appendSystem(`Failed to open tab: ${err}`);
+      })
+      .finally(() => {
+        pendingTabOpens.current.delete(id);
+      });
+  };
+}

--- a/src/hooks/tabOps/autoRestore.ts
+++ b/src/hooks/tabOps/autoRestore.ts
@@ -1,0 +1,66 @@
+import type { MutableRefObject } from "react";
+import type { Tab } from "../../types/tab";
+import { getConfig } from "../../config";
+import { sessionLabel } from "./helpers";
+import type { DiscoveredSession, NotificationInput } from "./types";
+
+export interface AutoRestoreDeps {
+  stateRef: MutableRefObject<Record<string, unknown>>;
+  autoRestoredSessionIdsRef: MutableRefObject<Set<string>>;
+  pushNotification: (n: NotificationInput) => void;
+  /** agent-tab creator. Auto-restore opens up to 8 oldest-first so the
+   *  most-recent session ends up active in the tab strip. */
+  newTab: (
+    restoreId: string,
+    restoreLabel?: string,
+    options?: { restoredSession?: boolean; cwd?: string },
+  ) => void;
+}
+
+/** Build the boot-time auto-restore action. Reads `ui.restoreTabs`
+ *  from `aethon.toml`; bails silently when the user disabled it. The
+ *  config read is intentionally lazy (per call) so a settings-panel
+ *  toggle takes effect on the next discovery wave without rebuild. */
+export function useAutoRestoreDiscoveredSessions(deps: AutoRestoreDeps) {
+  const { stateRef, autoRestoredSessionIdsRef, pushNotification, newTab } =
+    deps;
+
+  return function autoRestoreDiscoveredSessions(
+    discovered: DiscoveredSession[],
+    knownIds: Set<string>,
+  ): void {
+    if (discovered.length === 0) return;
+    getConfig()
+      .then((config) => {
+        if (!config.ui.restoreTabs) return;
+        const liveIds = new Set([
+          ...knownIds,
+          ...((stateRef.current.tabs as Tab[] | undefined) ?? []).map(
+            (t) => t.id,
+          ),
+        ]);
+        const toRestore = discovered
+          .filter((d) => !liveIds.has(d.tabId))
+          .filter((d) => !autoRestoredSessionIdsRef.current.has(d.tabId))
+          .slice(0, 8);
+        if (toRestore.length === 0) return;
+        // Open oldest first so the most recent session ends up active.
+        for (const session of [...toRestore].reverse()) {
+          autoRestoredSessionIdsRef.current.add(session.tabId);
+          newTab(session.tabId, sessionLabel(session), {
+            restoredSession: true,
+            ...(session.cwd ? { cwd: session.cwd } : {}),
+          });
+        }
+        pushNotification({
+          id: "ae-auto-restore-tabs",
+          title: `Restored ${toRestore.length} session${toRestore.length === 1 ? "" : "s"}`,
+          kind: "success",
+          durationMs: 3000,
+        });
+      })
+      .catch(() => {
+        /* config read already logs; manual restore remains available */
+      });
+  };
+}

--- a/src/hooks/tabOps/closeTab.ts
+++ b/src/hooks/tabOps/closeTab.ts
@@ -1,0 +1,278 @@
+import type { Dispatch, MutableRefObject, SetStateAction } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import type { ClosedTabEntry, Tab } from "../../types/tab";
+import type { ProjectsState } from "../../projects";
+import { disposeEditorBuffer } from "../../monaco/editor-buffers";
+import { recomputeModelPicker } from "../../utils/modelPicker";
+import { CLOSED_TAB_STACK_MAX, TAB_MIRROR_KEYS } from "./constants";
+import { recentSessionItemFromClosedTab } from "./helpers";
+
+export interface CloseTabDeps {
+  setState: Dispatch<SetStateAction<Record<string, unknown>>>;
+  stateRef: MutableRefObject<Record<string, unknown>>;
+  projectsRef: MutableRefObject<ProjectsState>;
+  promptCloseShellTabConfirmation: (tabLabel: string) => Promise<boolean>;
+  shellPromptBeforeCloseRef: MutableRefObject<boolean>;
+  dispatchTerminalReplay: (buffer: string) => void;
+  closedTabsRef: MutableRefObject<ClosedTabEntry[]>;
+  /** Bucket switching — the reopen flow needs to land closed tabs back
+   *  in their original project bucket, even when the user is currently
+   *  in a different one. */
+  clearActiveProject: () => void;
+  setActiveProjectById: (id: string) => boolean;
+  /** New-tab factories — the reopen flow calls back into the per-kind
+   *  creators rather than re-implementing them here. */
+  newTab: (
+    restoreId?: string,
+    restoreLabel?: string,
+    options?: { restoredSession?: boolean; cwd?: string },
+  ) => void;
+  newShellTab: (options?: {
+    command?: string;
+    args?: string[];
+    cwd?: string;
+  }) => void;
+  newEditorTab: (filePath: string, opts?: { rootPath?: string }) => void;
+}
+
+export interface CloseTabActions {
+  pushClosedTab: (tab: Tab) => void;
+  reopenLastClosedTab: () => void;
+  closeTab: (tabId: string) => void;
+  closeTabNow: (tabId: string) => void;
+  closeEditorTabsForPath: (path: string, kind: string) => void;
+}
+
+/** Close + reopen family. Owns the closed-tab undo stack, the
+ *  dirty-buffer / running-shell confirm prompts, the bridge
+ *  `tab_close` / `shell_close` teardown, and the Monaco buffer
+ *  disposal for closed editor tabs.
+ *
+ *  `closeEditorTabsForPath` lives here (rather than in
+ *  `editorTab.ts`) because it routes through `closeTab` to honor the
+ *  dirty-buffer confirm prompt — a folder delete with unsaved edits
+ *  inside it can't silently destroy the in-memory buffer. */
+export function useCloseTabActions(deps: CloseTabDeps): CloseTabActions {
+  const {
+    setState,
+    stateRef,
+    projectsRef,
+    promptCloseShellTabConfirmation,
+    shellPromptBeforeCloseRef,
+    dispatchTerminalReplay,
+    closedTabsRef,
+    clearActiveProject,
+    setActiveProjectById,
+    newTab,
+    newShellTab,
+    newEditorTab,
+  } = deps;
+
+  function pushClosedTab(tab: Tab): void {
+    const entry: ClosedTabEntry = {
+      id: tab.id,
+      kind: tab.kind,
+      label: tab.label,
+      projectId: tab.projectId,
+      ...(tab.kind === "shell" && tab.shell
+        ? {
+            cwd: tab.shell.cwd,
+            command: tab.shell.command,
+            args: tab.shell.args,
+          }
+        : {}),
+      ...(tab.kind === "agent" && tab.cwd ? { cwd: tab.cwd } : {}),
+      ...(tab.kind === "editor" && tab.editor
+        ? { filePath: tab.editor.filePath }
+        : {}),
+    };
+    closedTabsRef.current.push(entry);
+    if (closedTabsRef.current.length > CLOSED_TAB_STACK_MAX) {
+      closedTabsRef.current.splice(
+        0,
+        closedTabsRef.current.length - CLOSED_TAB_STACK_MAX,
+      );
+    }
+  }
+
+  /** Reopen the most-recently-closed tab. Agent tabs reopen with the
+   *  *original* tabId — that's the cue for the bridge's
+   *  SessionManager.continueRecent to pick up the persisted JSONL session
+   *  under `~/.aethon/sessions/<tabId>/`. Shell tabs spawn a fresh PTY
+   *  at the original cwd. No-op on empty stack. */
+  function reopenLastClosedTab(): void {
+    const entry = closedTabsRef.current.pop();
+    if (!entry) return;
+    // If the closed tab belongs to a different project bucket than
+    // the active one, switch to that bucket first so the new tab
+    // lands in its original project's tab list.
+    const activeId = projectsRef.current.activeId;
+    if (entry.projectId !== activeId) {
+      if (entry.projectId === null) {
+        clearActiveProject();
+      } else {
+        setActiveProjectById(entry.projectId);
+      }
+    }
+    if (entry.kind === "shell") {
+      newShellTab({
+        ...(entry.command ? { command: entry.command } : {}),
+        ...(entry.args ? { args: entry.args } : {}),
+        ...(entry.cwd ? { cwd: entry.cwd } : {}),
+      });
+    } else if (entry.kind === "editor" && entry.filePath) {
+      // Re-open the same file. EditorCanvas reads it from disk on mount;
+      // unsaved buffer state is intentionally not preserved across close.
+      newEditorTab(entry.filePath);
+    } else {
+      newTab(entry.id, entry.label, {
+        restoredSession: true,
+        ...(entry.cwd ? { cwd: entry.cwd } : {}),
+      });
+    }
+  }
+
+  /** Close a tab, prompting for confirmation when closing a running
+   *  shell tab and `[shell] prompt_before_close` is true. Editor tabs
+   *  with unsaved changes get a lightweight native confirm prompt so
+   *  Cmd+W on a dirty file can't silently throw work away. */
+  function closeTab(tabId: string): void {
+    const tabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
+    const closing = tabs.find((t) => t.id === tabId);
+    if (
+      closing?.kind === "shell" &&
+      closing.shell?.shellState === "running" &&
+      shellPromptBeforeCloseRef.current
+    ) {
+      void promptCloseShellTabConfirmation(closing.label).then((allowed) => {
+        if (!allowed) return;
+        closeTabNow(tabId);
+      });
+      return;
+    }
+    if (closing?.kind === "editor" && closing.editor?.isDirty) {
+      const ok = window.confirm(
+        `"${closing.label}" has unsaved changes. Close without saving?`,
+      );
+      if (!ok) return;
+    }
+    closeTabNow(tabId);
+  }
+
+  function closeTabNow(tabId: string): void {
+    const tabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
+    if (tabs.length === 0) return;
+    const closing = tabs.find((t) => t.id === tabId);
+    const closedKind = closing?.kind;
+    if (closing) pushClosedTab(closing);
+    let nextBuffer = "";
+    let switched = false;
+    let becameEmpty = false;
+    setState((prev) => {
+      const list = ((prev.tabs as Tab[] | undefined) ?? []).filter(
+        (t) => t.id !== tabId,
+      );
+      let activeTabId = prev.activeTabId as string | undefined;
+      if (activeTabId === tabId) {
+        activeTabId = list.length > 0 ? list[list.length - 1].id : undefined;
+        switched = true;
+      }
+      const result: Record<string, unknown> = {
+        ...prev,
+        tabs: list,
+        activeTabId,
+      };
+      if (closing) {
+        const closedSession = recentSessionItemFromClosedTab(
+          closing,
+          projectsRef.current,
+        );
+        if (closedSession) {
+          const recent =
+            (prev.recentSessions as { id: string }[] | undefined) ?? [];
+          result.recentSessions = [
+            closedSession,
+            ...recent.filter((s) => s.id !== closedSession.id),
+          ].slice(0, 16);
+        }
+      }
+      if (list.length === 0) {
+        becameEmpty = true;
+        for (const key of TAB_MIRROR_KEYS) {
+          result[key as string] = undefined;
+        }
+        result.empty = true;
+        result.hasTabs = false;
+      } else {
+        const target = list.find((t) => t.id === activeTabId)!;
+        nextBuffer = target.terminalBuffer ?? "";
+        const targetRec = target as unknown as Record<string, unknown>;
+        for (const key of TAB_MIRROR_KEYS) {
+          result[key as string] = targetRec[key as string];
+        }
+        result.sidebar = recomputeModelPicker(
+          prev.sidebar as Record<string, unknown> | undefined,
+          target.model,
+        );
+        result.empty = false;
+        result.hasTabs = true;
+      }
+      return result;
+    });
+    if (switched) dispatchTerminalReplay(nextBuffer);
+    // Tear down bridge session whether we became empty or not — both
+    // paths fire tab_close and the bridge no-ops on unknown tab ids.
+    void becameEmpty;
+    invoke("agent_command", {
+      payload: JSON.stringify({ type: "tab_close", tabId }),
+    }).catch(() => {
+      /* ignore — UI already closed */
+    });
+    // M6 P1: shell tabs own a PTY in the Rust shell registry. Close
+    // it too so the child process is reaped and the reader thread
+    // joins (no zombies on tab close).
+    if (closedKind === "shell") {
+      invoke("shell_close", { tabId }).catch(() => {
+        /* idempotent — already torn down by natural exit */
+      });
+    }
+    // Editor tabs own a Monaco model. Dispose it explicitly here so a
+    // closed tab doesn't leak — the buffer cache is intentionally
+    // long-lived across hidden project buckets (a tab the user can
+    // still come back to keeps its unsaved buffer), so we can't rely
+    // on a "tab not visible" prune.
+    if (closedKind === "editor") {
+      disposeEditorBuffer(tabId);
+    }
+  }
+
+  /** Close every editor tab whose filePath matches `path` (or is a
+   *  descendant when `kind === "dir"`). Imported by the file-tree's
+   *  delete action so a moved-to-Trash file can't be resurrected by a
+   *  later Cmd+S on the still-open buffer. Routes through `closeTab`
+   *  (not `closeTabNow`) so the dirty-buffer confirm prompt still fires
+   *  per-tab — a folder delete with unsaved edits inside it can't
+   *  silently destroy the in-memory buffer. */
+  function closeEditorTabsForPath(path: string, kind: string): void {
+    if (!path) return;
+    const prefix = `${path.replace(/\/+$/, "")}/`;
+    const tabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
+    for (const tab of tabs) {
+      if (tab.kind !== "editor" || !tab.editor) continue;
+      const current = tab.editor.filePath;
+      const match =
+        kind === "dir"
+          ? current === path || current.startsWith(prefix)
+          : current === path;
+      if (match) closeTab(tab.id);
+    }
+  }
+
+  return {
+    pushClosedTab,
+    reopenLastClosedTab,
+    closeTab,
+    closeTabNow,
+    closeEditorTabsForPath,
+  };
+}

--- a/src/hooks/tabOps/constants.ts
+++ b/src/hooks/tabOps/constants.ts
@@ -1,0 +1,47 @@
+import type { ShellMeta, Tab } from "../../types/tab";
+
+/** Per-tab terminal buffer cap. Bash output bursts can be huge; without
+ *  a ceiling the buffer would grow forever and slow tab switches as the
+ *  replay payload grows. Exported so bridge / shell-output handlers
+ *  outside the useTabs hook trim against the same limit. */
+export const TERMINAL_REPLAY_MAX = 256 * 1024;
+
+/** Tab fields that ride along on the root state. Bound by layout JSON
+ *  via `$ref` so /messages, /draft, etc. always reflect the active
+ *  tab without per-binding rewrites on every render. */
+export const TAB_MIRROR_KEYS: (keyof Tab)[] = [
+  "messages",
+  "draft",
+  "waiting",
+  "queueCount",
+  "queuedMessages",
+  "queuedSteeringId",
+  "canvas",
+  "model",
+  "cwd",
+  // M6 P1: shell-tab fields. The "kind" + "shell" mirror lets layouts
+  // bind `visible: { $ref: "/kind" }`-style toggles without running a
+  // full /tabs/<idx> lookup on every render.
+  "kind",
+  "shell",
+  // Editor-tab metadata mirror — the EditorCanvas composite reads
+  // /editor/filePath, /editor/language, /editor/isDirty, /editor/cursorLine
+  // via $ref so the status strip + dirty dot reflect the active editor
+  // tab without a /tabs/<idx>/editor walk per render.
+  "editor",
+];
+
+/** Closed-tab undo stack ceiling. The most-recent 10 closed tabs are
+ *  reopenable via Cmd+Shift+T; older entries fall off so an open-and-
+ *  close storm can't grow the ref unboundedly. */
+export const CLOSED_TAB_STACK_MAX = 10;
+
+/** ShareMode values accepted by `applyShareModeToTab`. Mirrors the Rust
+ *  `ShareMode` enum (shell/sharemode.rs); kept in sync by hand because a
+ *  full TS-side codegen pipeline isn't worth it for four values. */
+export const VALID_SHARE_MODES: ShellMeta["shareMode"][] = [
+  "private",
+  "read",
+  "read-write",
+  "read-write-trusted",
+];

--- a/src/hooks/tabOps/editorTab.ts
+++ b/src/hooks/tabOps/editorTab.ts
@@ -1,0 +1,185 @@
+import type { Dispatch, MutableRefObject, SetStateAction } from "react";
+import { makeEmptyTab, type EditorMeta, type Tab } from "../../types/tab";
+import type { ProjectsState } from "../../projects";
+import { languageFromPath } from "../../monaco/language-detection";
+import { TAB_MIRROR_KEYS } from "./constants";
+import { editorLabelForPath } from "./helpers";
+
+export interface EditorTabDeps {
+  setState: Dispatch<SetStateAction<Record<string, unknown>>>;
+  stateRef: MutableRefObject<Record<string, unknown>>;
+  projectsRef: MutableRefObject<ProjectsState>;
+  /** mutations.setActiveTab — focuses the existing tab when the user
+   *  re-opens a file that's already mounted. */
+  setActiveTab: (tabId: string) => void;
+  /** mutations.updateTab — drives `updateEditorMeta` so dirty/cursor
+   *  patches flow through the same mirror path as other writes. */
+  updateTab: (tabId: string, mutator: (tab: Tab) => Tab) => void;
+}
+
+export interface EditorTabActions {
+  newEditorTab: (filePath: string, opts?: { rootPath?: string }) => void;
+  updateEditorMeta: (tabId: string, patch: Partial<EditorMeta>) => void;
+  toggleEditorPreview: () => void;
+  renameEditorTabsForPath: (from: string, to: string, kind: string) => void;
+}
+
+/** Editor-tab creation + edits. `closeEditorTabsForPath` lives next
+ *  to the close family in `closeTab.ts` because it routes through
+ *  `closeTab` to honor the dirty-buffer confirm prompt. */
+export function useEditorTabActions(deps: EditorTabDeps): EditorTabActions {
+  const { setState, stateRef, projectsRef, setActiveTab, updateTab } = deps;
+
+  /** Open (or focus) an editor tab for the supplied absolute path. If a
+   *  tab for the same path already exists in the current project bucket,
+   *  switch to it instead of creating a duplicate. */
+  function newEditorTab(
+    filePath: string,
+    opts: { rootPath?: string } = {},
+  ): void {
+    if (!filePath) return;
+    const rootPath = opts.rootPath;
+    const tabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
+    const existing = tabs.find(
+      (t) =>
+        t.kind === "editor" &&
+        t.editor?.filePath === filePath &&
+        (t.editor.rootPath ?? "") === (rootPath ?? ""),
+    );
+    if (existing) {
+      setActiveTab(existing.id);
+      return;
+    }
+    const id = crypto.randomUUID();
+    const projectId = projectsRef.current.activeId;
+    const language = languageFromPath(filePath);
+    const tab: Tab = {
+      ...makeEmptyTab(id, editorLabelForPath(filePath), projectId, "editor"),
+      editor: {
+        filePath,
+        ...(rootPath ? { rootPath } : {}),
+        language,
+        isDirty: false,
+      },
+    };
+    setState((prev) => {
+      const list = ((prev.tabs as Tab[] | undefined) ?? []).slice();
+      list.push(tab);
+      const tabRec = tab as unknown as Record<string, unknown>;
+      const result: Record<string, unknown> = {
+        ...prev,
+        tabs: list,
+        activeTabId: id,
+        hasTabs: true,
+        empty: false,
+      };
+      for (const key of TAB_MIRROR_KEYS) {
+        result[key as string] = tabRec[key as string];
+      }
+      return result;
+    });
+  }
+
+  /** Patch the active editor tab's metadata (dirty flag, cursor). Cheap
+   *  no-op if the tab is missing or not an editor tab. */
+  function updateEditorMeta(tabId: string, patch: Partial<EditorMeta>): void {
+    updateTab(tabId, (t) => {
+      if (t.kind !== "editor" || !t.editor) return t;
+      const merged = { ...t.editor, ...patch };
+      // Skip the setState if nothing meaningful changed — guards against
+      // re-render storms from Monaco's cursorPosition events on every key.
+      const samePath = merged.filePath === t.editor.filePath;
+      const sameLang = merged.language === t.editor.language;
+      const sameDirty = merged.isDirty === t.editor.isDirty;
+      const sameLine = merged.cursorLine === t.editor.cursorLine;
+      const sameCol = merged.cursorColumn === t.editor.cursorColumn;
+      if (samePath && sameLang && sameDirty && sameLine && sameCol) return t;
+      return { ...t, editor: merged };
+    });
+  }
+
+  /** Toggle the active editor tab's markdown preview mode. No-op when
+   *  the active tab isn't an editor tab or isn't a markdown file. */
+  function toggleEditorPreview(): void {
+    const activeId = stateRef.current.activeTabId as string | undefined;
+    if (!activeId) return;
+    const tabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
+    const tab = tabs.find((t) => t.id === activeId);
+    if (!tab || tab.kind !== "editor" || !tab.editor) return;
+    if (tab.editor.language !== "markdown") return;
+    updateEditorMeta(activeId, {
+      previewMode: !tab.editor.previewMode,
+      previewRefreshKey: (tab.editor.previewRefreshKey ?? 0) + 1,
+    });
+  }
+
+  /** Reconcile open editor tabs after an on-disk rename. For files,
+   *  match the exact path and rewrite filePath + label. For folders,
+   *  rewrite any tab whose path is rooted at the old folder. Imported
+   *  by the file-tree's rename context-menu action. */
+  function renameEditorTabsForPath(
+    from: string,
+    to: string,
+    kind: string,
+  ): void {
+    if (!from || !to || from === to) return;
+    const prefix = `${from.replace(/\/+$/, "")}/`;
+    setState((prev) => {
+      const tabs = ((prev.tabs as Tab[] | undefined) ?? []).slice();
+      let changed = false;
+      const next = tabs.map((tab) => {
+        if (tab.kind !== "editor" || !tab.editor) return tab;
+        const current = tab.editor.filePath;
+        let nextPath: string | null = null;
+        if (kind === "dir") {
+          if (current.startsWith(prefix)) {
+            nextPath = `${to.replace(/\/+$/, "")}/${current.slice(prefix.length)}`;
+          } else if (current === from) {
+            nextPath = to;
+          }
+        } else if (current === from) {
+          nextPath = to;
+        }
+        if (!nextPath) return tab;
+        changed = true;
+        // Recompute the tab label too — Cmd+P/file-tree both expect the
+        // basename to track the path. Language id intentionally stays
+        // put since Shiki keeps grammars by file extension, which is
+        // usually what changed during a rename.
+        const renamed: Tab = {
+          ...tab,
+          label: editorLabelForPath(nextPath),
+          editor: {
+            ...tab.editor,
+            filePath: nextPath,
+            language: languageFromPath(nextPath),
+          },
+        };
+        return renamed;
+      });
+      if (!changed) return prev;
+      const result: Record<string, unknown> = { ...prev, tabs: next };
+      // Mirror the active tab's updated editor field into the root
+      // state so Monaco's EditorCanvas (which reads tabs via $ref) sees
+      // the new path on its next render.
+      const activeId = prev.activeTabId as string | undefined;
+      if (activeId) {
+        const active = next.find((t) => t.id === activeId);
+        if (active) {
+          const rec = active as unknown as Record<string, unknown>;
+          for (const key of TAB_MIRROR_KEYS) {
+            result[key as string] = rec[key as string];
+          }
+        }
+      }
+      return result;
+    });
+  }
+
+  return {
+    newEditorTab,
+    updateEditorMeta,
+    toggleEditorPreview,
+    renameEditorTabsForPath,
+  };
+}

--- a/src/hooks/tabOps/helpers.ts
+++ b/src/hooks/tabOps/helpers.ts
@@ -1,0 +1,102 @@
+import type { Tab } from "../../types/tab";
+import { activeCwd, type ProjectsState } from "../../projects";
+import type { DiscoveredSession } from "./types";
+
+/** Tab-strip label for a bridge-discovered persistent session. Prefers
+ *  an explicit `customLabel` from the bridge, then the first user
+ *  message (whitespace-collapsed), then a synthetic `Session <prefix>`.
+ *  Truncation is the bridge's responsibility — pi already trims long
+ *  first-message previews. */
+export function sessionLabel(session: DiscoveredSession): string {
+  if (session.customLabel) return session.customLabel;
+  if (session.firstUserMessage) {
+    return session.firstUserMessage.replace(/\s+/g, " ").trim();
+  }
+  return `Session ${session.tabId.slice(0, 8)}`;
+}
+
+/** Derive a friendly tab label from the first user message in the tab's
+ *  chat history. Returns undefined when there's no user message yet so
+ *  the caller can fall back to the synthetic `Tab N` label. Truncates at
+ *  48 characters with an ellipsis. */
+export function sessionLabelFromMessages(
+  messages: Tab["messages"],
+): string | undefined {
+  const first = messages.find(
+    (m) =>
+      m.role === "user" &&
+      typeof m.text === "string" &&
+      m.text.trim().length > 0,
+  );
+  const text = first?.text?.replace(/\s+/g, " ").trim();
+  if (!text) return undefined;
+  return text.length > 48 ? `${text.slice(0, 47)}...` : text;
+}
+
+/** Resolve the model id a freshly-opened tab should inherit. Falls
+ *  through: project-scoped override → globally-visible model → pi's
+ *  ready-reported default. Trimmed because user-typed model ids
+ *  occasionally carry trailing whitespace. */
+export function modelForNewProjectTab(
+  state: Record<string, unknown>,
+  activeProjectId: string | null,
+  fallbackModel: string,
+): string {
+  const projectModels =
+    (state.projectModels as Record<string, string> | undefined) ?? {};
+  const projectModel = activeProjectId ? projectModels[activeProjectId] : "";
+  return (
+    projectModel ||
+    (state.model as string | undefined) ||
+    fallbackModel
+  ).trim();
+}
+
+/** Resolve the cwd a freshly-opened tab should inherit. Active project
+ *  wins; falls back to the dev-only `projectRoot` snapshot, then to the
+ *  bundled `aethonRoot`. Returns null when nothing is available so the
+ *  caller knows to omit `cwd` from the bridge payload. */
+export function cwdForNewTab(
+  projects: ProjectsState,
+  appState: Record<string, unknown>,
+): string | null {
+  const projectCwd = activeCwd(projects);
+  if (projectCwd) return projectCwd;
+  const projectRoot = appState.projectRoot;
+  if (typeof projectRoot === "string" && projectRoot.length > 0) {
+    return projectRoot;
+  }
+  const aethonRoot = appState.aethonRoot;
+  return typeof aethonRoot === "string" && aethonRoot.length > 0
+    ? aethonRoot
+    : null;
+}
+
+/** Project a closed agent tab into a `recentSessions` entry so the
+ *  empty-state's history list can offer to restore it. Returns null
+ *  for non-agent tabs and for empty conversations (nothing to label). */
+export function recentSessionItemFromClosedTab(
+  tab: Tab,
+  projects: ProjectsState,
+): { id: string; label: string; lastModified: string; cwd?: string } | null {
+  if (tab.kind !== "agent" || tab.messages.length === 0) return null;
+  const fallbackProjectPath = tab.projectId
+    ? projects.projects.find((p) => p.id === tab.projectId)?.path
+    : undefined;
+  const cwd = tab.cwd ?? fallbackProjectPath;
+  return {
+    id: tab.id,
+    label: sessionLabelFromMessages(tab.messages) ?? tab.label,
+    lastModified: "now",
+    ...(cwd ? { cwd } : {}),
+  };
+}
+
+/** Compute an editor tab's label from its absolute path: just the
+ *  basename, since the full path is shown in the editor status strip.
+ *  Handles both POSIX and Windows separators because the underlying
+ *  paths come from native Tauri commands. */
+export function editorLabelForPath(filePath: string): string {
+  const slash = Math.max(filePath.lastIndexOf("/"), filePath.lastIndexOf("\\"));
+  return slash >= 0 ? filePath.slice(slash + 1) : filePath;
+}

--- a/src/hooks/tabOps/mutations.ts
+++ b/src/hooks/tabOps/mutations.ts
@@ -1,0 +1,164 @@
+import type { Dispatch, MutableRefObject, SetStateAction } from "react";
+import type { ShellMeta, Tab } from "../../types/tab";
+import { recomputeModelPicker } from "../../utils/modelPicker";
+import { TAB_MIRROR_KEYS, VALID_SHARE_MODES } from "./constants";
+
+/** Tell the shared xterm panel to clear and replay a tab's terminal
+ *  buffer. Microtask deferral so xterm's mount-once useEffect has
+ *  resolved before we try to write to it. Defined as a free function
+ *  because it has no closure dependencies — every other tab action
+ *  here just calls into it. */
+export function dispatchTerminalReplay(buffer: string): void {
+  Promise.resolve().then(() => {
+    window.dispatchEvent(
+      new CustomEvent("aethon:terminal-replay", { detail: buffer }),
+    );
+  });
+}
+
+export interface MutationsDeps {
+  setState: Dispatch<SetStateAction<Record<string, unknown>>>;
+  stateRef: MutableRefObject<Record<string, unknown>>;
+}
+
+export interface MutationsActions {
+  updateTab: (tabId: string, mutator: (tab: Tab) => Tab) => void;
+  updateActiveTab: (mutator: (tab: Tab) => Tab) => void;
+  applyShareModeToTab: (tabId: string, mode: string) => void;
+  setActiveTab: (tabId: string) => void;
+  setActiveSubTab: (subId: string) => void;
+}
+
+/** Mirror writes + active-tab switching. These are the lowest-level
+ *  tab mutations — everything else builds on `updateTab` /
+ *  `updateActiveTab` (which copy TAB_MIRROR_KEYS into the root state
+ *  for layout `$ref` bindings) and on `setActiveTab` (which both
+ *  switches the active id and triggers a terminal replay). */
+export function useMutations(deps: MutationsDeps): MutationsActions {
+  const { setState, stateRef } = deps;
+
+  function updateTab(tabId: string, mutator: (tab: Tab) => Tab): void {
+    setState((prev) => {
+      const tabs = ((prev.tabs as Tab[] | undefined) ?? []).slice();
+      const idx = tabs.findIndex((t) => t.id === tabId);
+      if (idx < 0) return prev;
+      const next = mutator(tabs[idx]);
+      tabs[idx] = next;
+      const result: Record<string, unknown> = { ...prev, tabs };
+      if (prev.activeTabId === tabId) {
+        const nextRec = next as unknown as Record<string, unknown>;
+        for (const key of TAB_MIRROR_KEYS) {
+          result[key as string] = nextRec[key as string];
+        }
+      }
+      return result;
+    });
+  }
+
+  function updateActiveTab(mutator: (tab: Tab) => Tab): void {
+    setState((prev) => {
+      const activeId = prev.activeTabId as string | undefined;
+      if (!activeId) return prev;
+      const tabs = ((prev.tabs as Tab[] | undefined) ?? []).slice();
+      const idx = tabs.findIndex((t) => t.id === activeId);
+      if (idx < 0) return prev;
+      const next = mutator(tabs[idx]);
+      tabs[idx] = next;
+      const result: Record<string, unknown> = { ...prev, tabs };
+      const nextRec = next as unknown as Record<string, unknown>;
+      for (const key of TAB_MIRROR_KEYS) {
+        result[key as string] = nextRec[key as string];
+      }
+      return result;
+    });
+  }
+
+  /** Mirror a share-mode change from the Rust source-of-truth into the
+   *  React Tab record. Cheap no-op if the tab doesn't exist or isn't a
+   *  shell tab. The Rust side enforces the actual privacy boundary —
+   *  this just keeps the badge UI honest. */
+  function applyShareModeToTab(tabId: string, mode: string): void {
+    if (!tabId) return;
+    if (!VALID_SHARE_MODES.includes(mode as ShellMeta["shareMode"])) return;
+    updateTab(tabId, (t) => {
+      if (t.kind !== "shell" || !t.shell) return t;
+      if (t.shell.shareMode === mode) return t;
+      return {
+        ...t,
+        shell: {
+          ...t.shell,
+          shareMode: mode as ShellMeta["shareMode"],
+        },
+      };
+    });
+  }
+
+  /** Switch the active tab. Re-mirrors the new tab's view to the root
+   *  keys so layout bindings update without per-key refresh, plus
+   *  dispatches a terminal replay so the shared xterm clears and
+   *  re-writes the new tab's buffered output. */
+  function setActiveTab(tabId: string): void {
+    let nextBuffer = "";
+    setState((prev) => {
+      const tabs = (prev.tabs as Tab[] | undefined) ?? [];
+      const target = tabs.find((t) => t.id === tabId);
+      if (!target) return prev;
+      nextBuffer = target.terminalBuffer ?? "";
+      const result: Record<string, unknown> = { ...prev, activeTabId: tabId };
+      const targetRec = target as unknown as Record<string, unknown>;
+      for (const key of TAB_MIRROR_KEYS) {
+        result[key as string] = targetRec[key as string];
+      }
+      result.sidebar = recomputeModelPicker(
+        prev.sidebar as Record<string, unknown> | undefined,
+        target.model,
+      );
+      // Selecting any tab clears a worktree-landing override so the
+      // chat canvas can render. Without this, clicking a tab while the
+      // landing was visible would leave the landing stuck on top.
+      result.landing = null;
+      return result;
+    });
+    dispatchTerminalReplay(nextBuffer);
+  }
+
+  /** Switch which sub-tab is active in the bottom terminal panel. Sub-tab
+   *  id is either "agent-bash" or a shell tab id from /tabs. Auto-opens
+   *  the panel if hidden. When switching back to agent-bash, replay the
+   *  active agent tab's terminalBuffer so the freshly-mounted Terminal
+   *  composite sees its content. */
+  function setActiveSubTab(subId: string): void {
+    setState((prev) => {
+      const panel =
+        (prev.terminalPanel as { activeSubId?: string } | undefined) ?? {};
+      const term = (prev.terminal as { open?: boolean } | undefined) ?? {};
+      if (panel.activeSubId === subId && term.open === true) {
+        return prev;
+      }
+      return {
+        ...prev,
+        terminalPanel: { ...panel, activeSubId: subId },
+        terminal: { ...term, open: true },
+      };
+    });
+    if (subId === "agent-bash") {
+      requestAnimationFrame(() => {
+        const tabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
+        const activeId = stateRef.current.activeTabId as string | undefined;
+        const active = activeId
+          ? tabs.find((t) => t.id === activeId)
+          : undefined;
+        const buffer = active?.terminalBuffer ?? "";
+        dispatchTerminalReplay(buffer);
+      });
+    }
+  }
+
+  return {
+    updateTab,
+    updateActiveTab,
+    applyShareModeToTab,
+    setActiveTab,
+    setActiveSubTab,
+  };
+}

--- a/src/hooks/tabOps/shellTab.ts
+++ b/src/hooks/tabOps/shellTab.ts
@@ -1,0 +1,121 @@
+import type { Dispatch, MutableRefObject, SetStateAction } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { makeEmptyTab, type ShellMeta, type Tab } from "../../types/tab";
+import type { ProjectsState } from "../../projects";
+import { cwdForNewTab } from "./helpers";
+
+export interface NewShellTabDeps {
+  setState: Dispatch<SetStateAction<Record<string, unknown>>>;
+  stateRef: MutableRefObject<Record<string, unknown>>;
+  projectsRef: MutableRefObject<ProjectsState>;
+  appendSystem: (text: string) => void;
+  /** Live config refs — populated by the boot config effect and the
+   *  settings-panel apply path; read via `.current` at open time. */
+  defaultShareModeRef: MutableRefObject<ShellMeta["shareMode"]>;
+  shellDefaultCommandRef: MutableRefObject<string | null>;
+  shellDefaultArgsRef: MutableRefObject<string[]>;
+  shellInheritEnvRef: MutableRefObject<boolean>;
+  /** Callback into mutations.updateTab — patches the tab's shellState
+   *  on bridge success/failure without re-implementing the mirror dance. */
+  updateTab: (tabId: string, mutator: (tab: Tab) => Tab) => void;
+}
+
+/** Build the shell-tab creator. Shell tabs live in the bottom panel as
+ *  sub-tabs, NOT the top tab strip, so opening one promotes it to the
+ *  panel's `activeSubId` and forces the panel open — but never touches
+ *  `/activeTabId`. The Rust side seeds the configured share mode
+ *  atomically inside `shell_open` so a non-private default pins the
+ *  privacy floor at total_appended=0 (the user sees the login banner). */
+export function useNewShellTab(deps: NewShellTabDeps) {
+  const {
+    setState,
+    stateRef,
+    projectsRef,
+    appendSystem,
+    defaultShareModeRef,
+    shellDefaultCommandRef,
+    shellDefaultArgsRef,
+    shellInheritEnvRef,
+    updateTab,
+  } = deps;
+
+  return function newShellTab(options?: {
+    command?: string;
+    args?: string[];
+    cwd?: string;
+  }): void {
+    const id = crypto.randomUUID();
+    const inheritedCwd =
+      options?.cwd ??
+      cwdForNewTab(projectsRef.current, stateRef.current) ??
+      undefined;
+    const seedShareMode = defaultShareModeRef.current;
+    const resolvedCommand =
+      options?.command ?? shellDefaultCommandRef.current ?? undefined;
+    const resolvedArgs =
+      options?.args ??
+      (shellDefaultArgsRef.current.length > 0
+        ? shellDefaultArgsRef.current
+        : undefined);
+    const inheritEnv = shellInheritEnvRef.current;
+    setState((prev) => {
+      const tabs = ((prev.tabs as Tab[] | undefined) ?? []).slice();
+      const label = `Shell ${tabs.filter((t) => t.kind === "shell").length + 1}`;
+      const projectId = projectsRef.current.activeId;
+      const tab: Tab = {
+        ...makeEmptyTab(id, label, projectId, "shell"),
+        shell: {
+          cwd: inheritedCwd ?? "",
+          command: resolvedCommand ?? "",
+          args: resolvedArgs ?? [],
+          shareMode: seedShareMode,
+          shellState: "starting",
+        },
+      };
+      tabs.push(tab);
+      // M6 restructure: shells live in the bottom panel as sub-tabs,
+      // not the top tab strip. Don't promote to /activeTabId — that
+      // stays on the user's agent tab. Instead, open the panel and
+      // make this shell the active sub-tab so the user sees it.
+      const panel =
+        (prev.terminalPanel as { activeSubId?: string } | undefined) ?? {};
+      const term = (prev.terminal as { open?: boolean } | undefined) ?? {};
+      return {
+        ...prev,
+        tabs,
+        terminalPanel: { ...panel, activeSubId: id },
+        terminal: { ...term, open: true },
+      };
+    });
+    invoke("shell_open", {
+      args: {
+        tabId: id,
+        ...(resolvedCommand ? { command: resolvedCommand } : {}),
+        ...(resolvedArgs ? { args: resolvedArgs } : {}),
+        ...(inheritedCwd ? { cwd: inheritedCwd } : {}),
+        // Seed the share mode atomically inside shell_open so the
+        // privacy floor pins at total_appended=0 — every byte from the
+        // first prompt forward is visible to the agent when the user
+        // configured a non-private default. Applying the mode post-open
+        // would race the login banner and pin it below the floor.
+        ...(seedShareMode !== "private" ? { shareMode: seedShareMode } : {}),
+        ...(inheritEnv === false ? { inheritEnv: false } : {}),
+      },
+    })
+      .then(() => {
+        updateTab(id, (t) => ({
+          ...t,
+          shell: t.shell ? { ...t.shell, shellState: "running" } : t.shell,
+        }));
+      })
+      .catch((err: unknown) => {
+        appendSystem(`Failed to open shell tab: ${String(err)}`);
+        updateTab(id, (t) => ({
+          ...t,
+          shell: t.shell
+            ? { ...t.shell, shellState: "exited", exitCode: -1 }
+            : t.shell,
+        }));
+      });
+  };
+}

--- a/src/hooks/tabOps/types.ts
+++ b/src/hooks/tabOps/types.ts
@@ -92,7 +92,7 @@ export interface UseTabsActions {
   /** Toggle the active editor tab's markdown preview mode (Cmd+Shift+V). */
   toggleEditorPreview: () => void;
   /** Reconcile open editor tabs after a rename. See implementation
-   *  notes inside tabOps/closeTab.ts. */
+   *  notes inside tabOps/editorTab.ts. */
   renameEditorTabsForPath: (from: string, to: string, kind: string) => void;
   /** Close any open editor tabs whose filePath matches `path` (or is
    *  a descendant when `kind === "dir"`). See implementation notes

--- a/src/hooks/tabOps/types.ts
+++ b/src/hooks/tabOps/types.ts
@@ -1,0 +1,110 @@
+import type { Dispatch, MutableRefObject, SetStateAction } from "react";
+import type { EditorMeta, ShellMeta, Tab } from "../../types/tab";
+import type { ProjectsState } from "../../projects";
+
+/** Bridge-discovered persistent session awaiting restore.
+ *  Surfaced by useProjectOps; useTabs.autoRestoreDiscoveredSessions
+ *  consumes them to pre-open recent tabs on boot. */
+export interface DiscoveredSession {
+  tabId: string;
+  lastModified: number;
+  cwd?: string;
+  firstUserMessage?: string;
+  customLabel?: string;
+}
+
+/** Subset of the notification payload useTabs actually emits.
+ *  Mirrors `pushNotification` from useNotifications without
+ *  importing the full type — keeps the deps surface narrow. */
+export interface NotificationInput {
+  id: string;
+  title: string;
+  message?: string;
+  kind?: "info" | "success" | "warning" | "error";
+  durationMs?: number | null;
+}
+
+export interface UseTabsContext {
+  setState: Dispatch<SetStateAction<Record<string, unknown>>>;
+  stateRef: MutableRefObject<Record<string, unknown>>;
+  pushNotification: (n: NotificationInput) => void;
+  appendSystem: (text: string) => void;
+  /** Resolves true on Allow / false on Cancel|dismiss. Drives the
+   *  prompt-before-close gate for running shell tabs. */
+  promptCloseShellTabConfirmation: (tabLabel: string) => Promise<boolean>;
+  /** Live ref to projects state so newTab/newShellTab inherit the active
+   *  project's path as cwd. Project bucket swap stays in App.tsx. */
+  projectsRef: MutableRefObject<ProjectsState>;
+  /** Default model id from pi `ready`. New tabs inherit this when no per-
+   *  tab model has been set, preventing a blank picker on race startup. */
+  piDefaultModelRef: MutableRefObject<string>;
+  /** Reopen-flow callbacks: when the closed tab belongs to a different
+   *  project bucket, switch buckets first so it lands in the correct
+   *  visible tab list. */
+  clearActiveProject: () => void;
+  setActiveProjectById: (id: string) => boolean;
+  /** Live shell config from getConfig() — set by the boot config effect
+   *  and the settings panel apply path. The hook reads via `.current`. */
+  defaultShareModeRef: MutableRefObject<ShellMeta["shareMode"]>;
+  shellDefaultCommandRef: MutableRefObject<string | null>;
+  shellDefaultArgsRef: MutableRefObject<string[]>;
+  shellInheritEnvRef: MutableRefObject<boolean>;
+  shellPromptBeforeCloseRef: MutableRefObject<boolean>;
+}
+
+export interface UseTabsActions {
+  /** In-flight tab_open promises keyed by tabId. sendChat awaits this so
+   *  the bridge can't race-create the tab via the chat path. */
+  pendingTabOpens: MutableRefObject<Map<string, Promise<unknown>>>;
+  /** Tab ids the auto-restore path has already opened in this session.
+   *  Prevents a second restore wave from re-opening the same tab. */
+  autoRestoredSessionIdsRef: MutableRefObject<Set<string>>;
+
+  updateTab: (tabId: string, mutator: (tab: Tab) => Tab) => void;
+  updateActiveTab: (mutator: (tab: Tab) => Tab) => void;
+  applyShareModeToTab: (tabId: string, mode: string) => void;
+
+  dispatchTerminalReplay: (buffer: string) => void;
+  setActiveTab: (tabId: string) => void;
+  setActiveSubTab: (subId: string) => void;
+
+  newTab: (
+    restoreId?: string,
+    restoreLabel?: string,
+    options?: {
+      restoredSession?: boolean;
+      cwd?: string;
+      scrollToMatch?: string;
+    },
+  ) => void;
+  newShellTab: (options?: {
+    command?: string;
+    args?: string[];
+    cwd?: string;
+  }) => void;
+  /** Open (or focus, if already open) an editor tab for `filePath`.
+   *  `filePath` must be inside the active project; the EditorCanvas
+   *  composite handles the actual fs_read_file call on mount. */
+  newEditorTab: (filePath: string, opts?: { rootPath?: string }) => void;
+  /** Set the dirty flag + cursor on the active editor tab. Used by
+   *  EditorCanvas to mirror Monaco's model state back to the layout. */
+  updateEditorMeta: (tabId: string, patch: Partial<EditorMeta>) => void;
+  /** Toggle the active editor tab's markdown preview mode (Cmd+Shift+V). */
+  toggleEditorPreview: () => void;
+  /** Reconcile open editor tabs after a rename. See implementation
+   *  notes inside tabOps/closeTab.ts. */
+  renameEditorTabsForPath: (from: string, to: string, kind: string) => void;
+  /** Close any open editor tabs whose filePath matches `path` (or is
+   *  a descendant when `kind === "dir"`). See implementation notes
+   *  inside tabOps/closeTab.ts. */
+  closeEditorTabsForPath: (path: string, kind: string) => void;
+  autoRestoreDiscoveredSessions: (
+    discovered: DiscoveredSession[],
+    knownIds: Set<string>,
+  ) => void;
+
+  pushClosedTab: (tab: Tab) => void;
+  reopenLastClosedTab: () => void;
+  closeTab: (tabId: string) => void;
+  closeTabNow: (tabId: string) => void;
+}

--- a/src/hooks/useTabs.ts
+++ b/src/hooks/useTabs.ts
@@ -1,238 +1,47 @@
-import {
-  useRef,
-  type Dispatch,
-  type MutableRefObject,
-  type SetStateAction,
-} from "react";
-import { invoke } from "@tauri-apps/api/core";
-import {
-  type ClosedTabEntry,
-  type EditorMeta,
-  type ShellMeta,
-  type Tab,
-  makeEmptyTab,
-} from "../types/tab";
-import { languageFromPath } from "../monaco/language-detection";
-import { disposeEditorBuffer } from "../monaco/editor-buffers";
-import { activeCwd, type ProjectsState } from "../projects";
-import { getConfig } from "../config";
-import { recomputeModelPicker } from "../utils/modelPicker";
+import { useRef } from "react";
+import type { ClosedTabEntry } from "../types/tab";
+import { useMutations, dispatchTerminalReplay } from "./tabOps/mutations";
+import { useNewTab } from "./tabOps/agentTab";
+import { useNewShellTab } from "./tabOps/shellTab";
+import { useEditorTabActions } from "./tabOps/editorTab";
+import { useCloseTabActions } from "./tabOps/closeTab";
+import { useAutoRestoreDiscoveredSessions } from "./tabOps/autoRestore";
+import type { UseTabsActions, UseTabsContext } from "./tabOps/types";
 
-/** Per-tab terminal buffer cap. Bash output bursts can be huge; without
- *  a ceiling the buffer would grow forever and slow tab switches as the
- *  replay payload grows. Exported so bridge / shell-output handlers
- *  outside this hook trim against the same limit. */
-export const TERMINAL_REPLAY_MAX = 256 * 1024;
-
-/** Tab fields that ride along on the root state. Bound by layout JSON
- *  via `$ref` so /messages, /draft, etc. always reflect the active
- *  tab without per-binding rewrites on every render. */
-export const TAB_MIRROR_KEYS: (keyof Tab)[] = [
-  "messages",
-  "draft",
-  "waiting",
-  "queueCount",
-  "queuedMessages",
-  "queuedSteeringId",
-  "canvas",
-  "model",
-  "cwd",
-  // M6 P1: shell-tab fields. The "kind" + "shell" mirror lets layouts
-  // bind `visible: { $ref: "/kind" }`-style toggles without running a
-  // full /tabs/<idx> lookup on every render.
-  "kind",
-  "shell",
-  // Editor-tab metadata mirror — the EditorCanvas composite reads
-  // /editor/filePath, /editor/language, /editor/isDirty, /editor/cursorLine
-  // via $ref so the status strip + dirty dot reflect the active editor
-  // tab without a /tabs/<idx>/editor walk per render.
-  "editor",
-];
-
-const CLOSED_TAB_STACK_MAX = 10;
-const VALID_SHARE_MODES: ShellMeta["shareMode"][] = [
-  "private",
-  "read",
-  "read-write",
-  "read-write-trusted",
-];
-
-function sessionLabel(session: DiscoveredSession): string {
-  if (session.customLabel) return session.customLabel;
-  if (session.firstUserMessage) {
-    return session.firstUserMessage.replace(/\s+/g, " ").trim();
-  }
-  return `Session ${session.tabId.slice(0, 8)}`;
-}
-
-function sessionLabelFromMessages(
-  messages: Tab["messages"],
-): string | undefined {
-  const first = messages.find(
-    (m) =>
-      m.role === "user" &&
-      typeof m.text === "string" &&
-      m.text.trim().length > 0,
-  );
-  const text = first?.text?.replace(/\s+/g, " ").trim();
-  if (!text) return undefined;
-  return text.length > 48 ? `${text.slice(0, 47)}...` : text;
-}
-
-export function modelForNewProjectTab(
-  state: Record<string, unknown>,
-  activeProjectId: string | null,
-  fallbackModel: string,
-): string {
-  const projectModels =
-    (state.projectModels as Record<string, string> | undefined) ?? {};
-  const projectModel = activeProjectId ? projectModels[activeProjectId] : "";
-  return (
-    projectModel ||
-    (state.model as string | undefined) ||
-    fallbackModel
-  ).trim();
-}
-
-export function cwdForNewTab(
-  projects: ProjectsState,
-  appState: Record<string, unknown>,
-): string | null {
-  const projectCwd = activeCwd(projects);
-  if (projectCwd) return projectCwd;
-  const projectRoot = appState.projectRoot;
-  if (typeof projectRoot === "string" && projectRoot.length > 0) {
-    return projectRoot;
-  }
-  const aethonRoot = appState.aethonRoot;
-  return typeof aethonRoot === "string" && aethonRoot.length > 0
-    ? aethonRoot
-    : null;
-}
-
-export function recentSessionItemFromClosedTab(
-  tab: Tab,
-  projects: ProjectsState,
-): { id: string; label: string; lastModified: string; cwd?: string } | null {
-  if (tab.kind !== "agent" || tab.messages.length === 0) return null;
-  const fallbackProjectPath = tab.projectId
-    ? projects.projects.find((p) => p.id === tab.projectId)?.path
-    : undefined;
-  const cwd = tab.cwd ?? fallbackProjectPath;
-  return {
-    id: tab.id,
-    label: sessionLabelFromMessages(tab.messages) ?? tab.label,
-    lastModified: "now",
-    ...(cwd ? { cwd } : {}),
-  };
-}
-
-interface DiscoveredSession {
-  tabId: string;
-  lastModified: number;
-  cwd?: string;
-  firstUserMessage?: string;
-  customLabel?: string;
-}
-
-interface NotificationInput {
-  id: string;
-  title: string;
-  message?: string;
-  kind?: "info" | "success" | "warning" | "error";
-  durationMs?: number | null;
-}
-
-export interface UseTabsContext {
-  setState: Dispatch<SetStateAction<Record<string, unknown>>>;
-  stateRef: MutableRefObject<Record<string, unknown>>;
-  pushNotification: (n: NotificationInput) => void;
-  appendSystem: (text: string) => void;
-  /** Resolves true on Allow / false on Cancel|dismiss. Drives the
-   *  prompt-before-close gate for running shell tabs. */
-  promptCloseShellTabConfirmation: (tabLabel: string) => Promise<boolean>;
-  /** Live ref to projects state so newTab/newShellTab inherit the active
-   *  project's path as cwd. Project bucket swap stays in App.tsx. */
-  projectsRef: MutableRefObject<ProjectsState>;
-  /** Default model id from pi `ready`. New tabs inherit this when no per-
-   *  tab model has been set, preventing a blank picker on race startup. */
-  piDefaultModelRef: MutableRefObject<string>;
-  /** Reopen-flow callbacks: when the closed tab belongs to a different
-   *  project bucket, switch buckets first so it lands in the correct
-   *  visible tab list. */
-  clearActiveProject: () => void;
-  setActiveProjectById: (id: string) => boolean;
-  /** Live shell config from getConfig() — set by the boot config effect
-   *  and the settings panel apply path. The hook reads via `.current`. */
-  defaultShareModeRef: MutableRefObject<ShellMeta["shareMode"]>;
-  shellDefaultCommandRef: MutableRefObject<string | null>;
-  shellDefaultArgsRef: MutableRefObject<string[]>;
-  shellInheritEnvRef: MutableRefObject<boolean>;
-  shellPromptBeforeCloseRef: MutableRefObject<boolean>;
-}
-
-export interface UseTabsActions {
-  /** In-flight tab_open promises keyed by tabId. sendChat awaits this so
-   *  the bridge can't race-create the tab via the chat path. */
-  pendingTabOpens: MutableRefObject<Map<string, Promise<unknown>>>;
-  /** Tab ids the auto-restore path has already opened in this session.
-   *  Prevents a second restore wave from re-opening the same tab. */
-  autoRestoredSessionIdsRef: MutableRefObject<Set<string>>;
-
-  updateTab: (tabId: string, mutator: (tab: Tab) => Tab) => void;
-  updateActiveTab: (mutator: (tab: Tab) => Tab) => void;
-  applyShareModeToTab: (tabId: string, mode: string) => void;
-
-  dispatchTerminalReplay: (buffer: string) => void;
-  setActiveTab: (tabId: string) => void;
-  setActiveSubTab: (subId: string) => void;
-
-  newTab: (
-    restoreId?: string,
-    restoreLabel?: string,
-    options?: {
-      restoredSession?: boolean;
-      cwd?: string;
-      scrollToMatch?: string;
-    },
-  ) => void;
-  newShellTab: (options?: {
-    command?: string;
-    args?: string[];
-    cwd?: string;
-  }) => void;
-  /** Open (or focus, if already open) an editor tab for `filePath`.
-   *  `filePath` must be inside the active project; the EditorCanvas
-   *  composite handles the actual fs_read_file call on mount. */
-  newEditorTab: (filePath: string, opts?: { rootPath?: string }) => void;
-  /** Set the dirty flag + cursor on the active editor tab. Used by
-   *  EditorCanvas to mirror Monaco's model state back to the layout. */
-  updateEditorMeta: (tabId: string, patch: Partial<EditorMeta>) => void;
-  /** Toggle the active editor tab's markdown preview mode (Cmd+Shift+V). */
-  toggleEditorPreview: () => void;
-  /** Reconcile open editor tabs after a rename. See implementation
-   *  notes inside useTabs. */
-  renameEditorTabsForPath: (from: string, to: string, kind: string) => void;
-  /** Close any open editor tabs whose filePath matches `path` (or is
-   *  a descendant when `kind === "dir"`). See implementation notes
-   *  inside useTabs. */
-  closeEditorTabsForPath: (path: string, kind: string) => void;
-  autoRestoreDiscoveredSessions: (
-    discovered: DiscoveredSession[],
-    knownIds: Set<string>,
-  ) => void;
-
-  pushClosedTab: (tab: Tab) => void;
-  reopenLastClosedTab: () => void;
-  closeTab: (tabId: string) => void;
-  closeTabNow: (tabId: string) => void;
-}
+export { TAB_MIRROR_KEYS, TERMINAL_REPLAY_MAX } from "./tabOps/constants";
+export {
+  cwdForNewTab,
+  modelForNewProjectTab,
+  recentSessionItemFromClosedTab,
+} from "./tabOps/helpers";
+export type { UseTabsActions, UseTabsContext } from "./tabOps/types";
 
 /**
- * Tab lifecycle: create (newTab/newShellTab), switch (setActiveTab/
- * setActiveSubTab), update (updateTab/updateActiveTab), close
- * (closeTab/closeTabNow), and undo-close (pushClosedTab/
- * reopenLastClosedTab).
+ * Tab lifecycle: create (newTab/newShellTab/newEditorTab), switch
+ * (setActiveTab/setActiveSubTab), update (updateTab/updateActiveTab),
+ * close (closeTab/closeTabNow), and undo-close
+ * (pushClosedTab/reopenLastClosedTab).
+ *
+ * This file is the facade. The actual implementation lives under
+ * `./tabOps/`:
+ *
+ * - `constants` — TAB_MIRROR_KEYS, TERMINAL_REPLAY_MAX, plus private caps
+ * - `types`     — UseTabsContext, UseTabsActions, DiscoveredSession,
+ *                 NotificationInput
+ * - `helpers`   — pure data helpers (session labels, model/cwd resolution,
+ *                 recentSessions projection, editorLabelForPath)
+ * - `mutations` — `updateTab` / `updateActiveTab` (mirror-write the active
+ *                 tab's TAB_MIRROR_KEYS into the root state) and the
+ *                 active-tab + sub-tab switchers
+ * - `agentTab`  — `newTab` (the agent-tab creator with bridge `tab_open`)
+ * - `shellTab`  — `newShellTab` (panel-only, seeds share mode atomically)
+ * - `editorTab` — `newEditorTab`, edits, and rename reconciliation
+ * - `closeTab`  — close + reopen, bridge `tab_close`, Monaco buffer
+ *                 disposal, and the path-based bulk close
+ *                 (`closeEditorTabsForPath`) routed through `closeTab`
+ *                 to honor the dirty-buffer confirm prompt
+ * - `autoRestore` — boot-time discovered-session restore (≤ 8, oldest
+ *                   first so the newest lands active)
  *
  * The hook keeps its state local in refs; project bucket swap and
  * orchestration-level wiring (chat-input dispatch, sidebar history,
@@ -246,752 +55,93 @@ export interface UseTabsActions {
  * tabs mutation that produced them.
  */
 export function useTabs(ctx: UseTabsContext): UseTabsActions {
-  const {
-    setState,
-    stateRef,
-    pushNotification,
-    appendSystem,
-    promptCloseShellTabConfirmation,
-    projectsRef,
-    piDefaultModelRef,
-    clearActiveProject,
-    setActiveProjectById,
-    defaultShareModeRef,
-    shellDefaultCommandRef,
-    shellDefaultArgsRef,
-    shellInheritEnvRef,
-    shellPromptBeforeCloseRef,
-  } = ctx;
-
   const pendingTabOpens = useRef(new Map<string, Promise<unknown>>());
   const closedTabsRef = useRef<ClosedTabEntry[]>([]);
   const autoRestoredSessionIdsRef = useRef(new Set<string>());
 
-  function updateTab(tabId: string, mutator: (tab: Tab) => Tab) {
-    setState((prev) => {
-      const tabs = ((prev.tabs as Tab[] | undefined) ?? []).slice();
-      const idx = tabs.findIndex((t) => t.id === tabId);
-      if (idx < 0) return prev;
-      const next = mutator(tabs[idx]);
-      tabs[idx] = next;
-      const result: Record<string, unknown> = { ...prev, tabs };
-      if (prev.activeTabId === tabId) {
-        const nextRec = next as unknown as Record<string, unknown>;
-        for (const key of TAB_MIRROR_KEYS) {
-          result[key as string] = nextRec[key as string];
-        }
-      }
-      return result;
-    });
-  }
+  // Mirror writes + active-tab switching come first; they have no
+  // dependencies beyond setState/stateRef and everything else calls
+  // back into them.
+  const mutations = useMutations({
+    setState: ctx.setState,
+    stateRef: ctx.stateRef,
+  });
 
-  function updateActiveTab(mutator: (tab: Tab) => Tab) {
-    setState((prev) => {
-      const activeId = prev.activeTabId as string | undefined;
-      if (!activeId) return prev;
-      const tabs = ((prev.tabs as Tab[] | undefined) ?? []).slice();
-      const idx = tabs.findIndex((t) => t.id === activeId);
-      if (idx < 0) return prev;
-      const next = mutator(tabs[idx]);
-      tabs[idx] = next;
-      const result: Record<string, unknown> = { ...prev, tabs };
-      const nextRec = next as unknown as Record<string, unknown>;
-      for (const key of TAB_MIRROR_KEYS) {
-        result[key as string] = nextRec[key as string];
-      }
-      return result;
-    });
-  }
+  const newTab = useNewTab({
+    setState: ctx.setState,
+    stateRef: ctx.stateRef,
+    projectsRef: ctx.projectsRef,
+    piDefaultModelRef: ctx.piDefaultModelRef,
+    pendingTabOpens,
+    appendSystem: ctx.appendSystem,
+    dispatchTerminalReplay,
+  });
 
-  /** Mirror a share-mode change from the Rust source-of-truth into the
-   *  React Tab record. Cheap no-op if the tab doesn't exist or isn't a
-   *  shell tab. The Rust side enforces the actual privacy boundary —
-   *  this just keeps the badge UI honest. */
-  function applyShareModeToTab(tabId: string, mode: string) {
-    if (!tabId) return;
-    if (!VALID_SHARE_MODES.includes(mode as ShellMeta["shareMode"])) return;
-    updateTab(tabId, (t) => {
-      if (t.kind !== "shell" || !t.shell) return t;
-      if (t.shell.shareMode === mode) return t;
-      return {
-        ...t,
-        shell: {
-          ...t.shell,
-          shareMode: mode as ShellMeta["shareMode"],
-        },
-      };
-    });
-  }
+  const newShellTab = useNewShellTab({
+    setState: ctx.setState,
+    stateRef: ctx.stateRef,
+    projectsRef: ctx.projectsRef,
+    appendSystem: ctx.appendSystem,
+    defaultShareModeRef: ctx.defaultShareModeRef,
+    shellDefaultCommandRef: ctx.shellDefaultCommandRef,
+    shellDefaultArgsRef: ctx.shellDefaultArgsRef,
+    shellInheritEnvRef: ctx.shellInheritEnvRef,
+    updateTab: mutations.updateTab,
+  });
 
-  /** Tell the shared xterm panel to clear and replay a tab's terminal
-   *  buffer. Microtask deferral so xterm's mount-once useEffect has
-   *  resolved before we try to write to it. */
-  function dispatchTerminalReplay(buffer: string) {
-    Promise.resolve().then(() => {
-      window.dispatchEvent(
-        new CustomEvent("aethon:terminal-replay", { detail: buffer }),
-      );
-    });
-  }
+  const editor = useEditorTabActions({
+    setState: ctx.setState,
+    stateRef: ctx.stateRef,
+    projectsRef: ctx.projectsRef,
+    setActiveTab: mutations.setActiveTab,
+    updateTab: mutations.updateTab,
+  });
 
-  /** Switch the active tab. Re-mirrors the new tab's view to the root
-   *  keys so layout bindings update without per-key refresh, plus
-   *  dispatches a terminal replay so the shared xterm clears and
-   *  re-writes the new tab's buffered output. */
-  function setActiveTab(tabId: string) {
-    let nextBuffer = "";
-    setState((prev) => {
-      const tabs = (prev.tabs as Tab[] | undefined) ?? [];
-      const target = tabs.find((t) => t.id === tabId);
-      if (!target) return prev;
-      nextBuffer = target.terminalBuffer ?? "";
-      const result: Record<string, unknown> = { ...prev, activeTabId: tabId };
-      const targetRec = target as unknown as Record<string, unknown>;
-      for (const key of TAB_MIRROR_KEYS) {
-        result[key as string] = targetRec[key as string];
-      }
-      result.sidebar = recomputeModelPicker(
-        prev.sidebar as Record<string, unknown> | undefined,
-        target.model,
-      );
-      // Selecting any tab clears a worktree-landing override so the
-      // chat canvas can render. Without this, clicking a tab while the
-      // landing was visible would leave the landing stuck on top.
-      result.landing = null;
-      return result;
-    });
-    dispatchTerminalReplay(nextBuffer);
-  }
+  // closeTab + closeEditorTabsForPath need the per-kind creators
+  // (reopen routes back through newTab / newShellTab / newEditorTab),
+  // so this factory runs *after* them.
+  const close = useCloseTabActions({
+    setState: ctx.setState,
+    stateRef: ctx.stateRef,
+    projectsRef: ctx.projectsRef,
+    promptCloseShellTabConfirmation: ctx.promptCloseShellTabConfirmation,
+    shellPromptBeforeCloseRef: ctx.shellPromptBeforeCloseRef,
+    dispatchTerminalReplay,
+    closedTabsRef,
+    clearActiveProject: ctx.clearActiveProject,
+    setActiveProjectById: ctx.setActiveProjectById,
+    newTab,
+    newShellTab,
+    newEditorTab: editor.newEditorTab,
+  });
 
-  /** Switch which sub-tab is active in the bottom terminal panel. Sub-tab
-   *  id is either "agent-bash" or a shell tab id from /tabs. Auto-opens
-   *  the panel if hidden. When switching back to agent-bash, replay the
-   *  active agent tab's terminalBuffer so the freshly-mounted Terminal
-   *  composite sees its content. */
-  function setActiveSubTab(subId: string) {
-    setState((prev) => {
-      const panel =
-        (prev.terminalPanel as { activeSubId?: string } | undefined) ?? {};
-      const term = (prev.terminal as { open?: boolean } | undefined) ?? {};
-      if (panel.activeSubId === subId && term.open === true) {
-        return prev;
-      }
-      return {
-        ...prev,
-        terminalPanel: { ...panel, activeSubId: subId },
-        terminal: { ...term, open: true },
-      };
-    });
-    if (subId === "agent-bash") {
-      requestAnimationFrame(() => {
-        const tabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
-        const activeId = stateRef.current.activeTabId as string | undefined;
-        const active = activeId
-          ? tabs.find((t) => t.id === activeId)
-          : undefined;
-        const buffer = active?.terminalBuffer ?? "";
-        dispatchTerminalReplay(buffer);
-      });
-    }
-  }
-
-  function newTab(
-    restoreId?: string,
-    restoreLabel?: string,
-    options?: {
-      restoredSession?: boolean;
-      cwd?: string;
-      scrollToMatch?: string;
-    },
-  ) {
-    // restoreId lets the caller open a tab with a specific tabId so the
-    // bridge's SessionManager.continueRecent picks up the persisted
-    // session for that id. Used by the empty-state's "Recent sessions"
-    // list. Omitted for normal new-tab gestures (Cmd+T, +, menu).
-    const id = restoreId ?? crypto.randomUUID();
-    // Search-hit scroll target. Stored in /scrollToMatchByTab/<id> so
-    // ChatHistory picks it up once the bridge replays messages. Null
-    // out the entry after a few seconds so a user who scrolls away
-    // doesn't keep getting yanked back.
-    const scrollToMatch = options?.scrollToMatch;
-    if (scrollToMatch) {
-      setState((prev) => {
-        const cur =
-          (prev.scrollToMatchByTab as Record<string, string> | undefined) ?? {};
-        return {
-          ...prev,
-          scrollToMatchByTab: { ...cur, [id]: scrollToMatch },
-        };
-      });
-      window.setTimeout(() => {
-        setState((prev) => {
-          const cur =
-            (prev.scrollToMatchByTab as Record<string, string> | undefined) ??
-            {};
-          if (!(id in cur)) return prev;
-          const next = { ...cur };
-          delete next[id];
-          return { ...prev, scrollToMatchByTab: next };
-        });
-      }, 5000);
-    }
-    // Project-scoped model default: new tabs in a project should use
-    // the last model selected in that project, then the visible/global
-    // model, then pi's ready-reported default.
-    const projectId = projectsRef.current.activeId;
-    const inheritedCwd =
-      options?.cwd ??
-      cwdForNewTab(projectsRef.current, stateRef.current) ??
-      undefined;
-    const inheritedModel = modelForNewProjectTab(
-      stateRef.current,
-      projectId,
-      piDefaultModelRef.current,
-    );
-    const existingSessionLabel = restoreId
-      ? sessionLabelFromMessages(
-          ((stateRef.current.tabs as Tab[] | undefined) ?? []).find(
-            (t) => t.id === restoreId,
-          )?.messages ?? [],
-        )
-      : undefined;
-    setState((prev) => {
-      const tabs = ((prev.tabs as Tab[] | undefined) ?? []).slice();
-      const label =
-        restoreLabel ?? existingSessionLabel ?? `Tab ${tabs.length + 1}`;
-      const tab: Tab = {
-        ...makeEmptyTab(id, label, projectId),
-        model: inheritedModel,
-        ...(inheritedCwd ? { cwd: inheritedCwd } : {}),
-      };
-      tabs.push(tab);
-      const result: Record<string, unknown> = {
-        ...prev,
-        tabs,
-        activeTabId: id,
-        empty: false,
-        hasTabs: true,
-      };
-      const tabRec = tab as unknown as Record<string, unknown>;
-      for (const key of TAB_MIRROR_KEYS) {
-        result[key as string] = tabRec[key as string];
-      }
-      result.sidebar = recomputeModelPicker(
-        prev.sidebar as Record<string, unknown> | undefined,
-        tab.model,
-      );
-      return result;
-    });
-    // Clear the shared xterm so it doesn't keep showing the previous
-    // tab's scrollback until the next switch / output event.
-    dispatchTerminalReplay("");
-    const opening = invoke("agent_command", {
-      payload: JSON.stringify({
-        type: "tab_open",
-        tabId: id,
-        ...(inheritedModel ? { model: inheritedModel } : {}),
-        ...(inheritedCwd ? { cwd: inheritedCwd } : {}),
-        ...(options?.restoredSession ? { restoreHistory: true } : {}),
-      }),
-    });
-    pendingTabOpens.current.set(id, opening);
-    opening
-      .catch((err) => {
-        appendSystem(`Failed to open tab: ${err}`);
-      })
-      .finally(() => {
-        pendingTabOpens.current.delete(id);
-      });
-  }
-
-  function newShellTab(options?: {
-    command?: string;
-    args?: string[];
-    cwd?: string;
-  }) {
-    const id = crypto.randomUUID();
-    const inheritedCwd =
-      options?.cwd ??
-      cwdForNewTab(projectsRef.current, stateRef.current) ??
-      undefined;
-    const seedShareMode = defaultShareModeRef.current;
-    const resolvedCommand =
-      options?.command ?? shellDefaultCommandRef.current ?? undefined;
-    const resolvedArgs =
-      options?.args ??
-      (shellDefaultArgsRef.current.length > 0
-        ? shellDefaultArgsRef.current
-        : undefined);
-    const inheritEnv = shellInheritEnvRef.current;
-    setState((prev) => {
-      const tabs = ((prev.tabs as Tab[] | undefined) ?? []).slice();
-      const label = `Shell ${tabs.filter((t) => t.kind === "shell").length + 1}`;
-      const projectId = projectsRef.current.activeId;
-      const tab: Tab = {
-        ...makeEmptyTab(id, label, projectId, "shell"),
-        shell: {
-          cwd: inheritedCwd ?? "",
-          command: resolvedCommand ?? "",
-          args: resolvedArgs ?? [],
-          shareMode: seedShareMode,
-          shellState: "starting",
-        },
-      };
-      tabs.push(tab);
-      // M6 restructure: shells live in the bottom panel as sub-tabs,
-      // not the top tab strip. Don't promote to /activeTabId — that
-      // stays on the user's agent tab. Instead, open the panel and
-      // make this shell the active sub-tab so the user sees it.
-      const panel =
-        (prev.terminalPanel as { activeSubId?: string } | undefined) ?? {};
-      const term = (prev.terminal as { open?: boolean } | undefined) ?? {};
-      return {
-        ...prev,
-        tabs,
-        terminalPanel: { ...panel, activeSubId: id },
-        terminal: { ...term, open: true },
-      };
-    });
-    invoke("shell_open", {
-      args: {
-        tabId: id,
-        ...(resolvedCommand ? { command: resolvedCommand } : {}),
-        ...(resolvedArgs ? { args: resolvedArgs } : {}),
-        ...(inheritedCwd ? { cwd: inheritedCwd } : {}),
-        // Seed the share mode atomically inside shell_open so the
-        // privacy floor pins at total_appended=0 — every byte from the
-        // first prompt forward is visible to the agent when the user
-        // configured a non-private default. Applying the mode post-open
-        // would race the login banner and pin it below the floor.
-        ...(seedShareMode !== "private" ? { shareMode: seedShareMode } : {}),
-        ...(inheritEnv === false ? { inheritEnv: false } : {}),
-      },
-    })
-      .then(() => {
-        updateTab(id, (t) => ({
-          ...t,
-          shell: t.shell ? { ...t.shell, shellState: "running" } : t.shell,
-        }));
-      })
-      .catch((err: unknown) => {
-        appendSystem(`Failed to open shell tab: ${String(err)}`);
-        updateTab(id, (t) => ({
-          ...t,
-          shell: t.shell
-            ? { ...t.shell, shellState: "exited", exitCode: -1 }
-            : t.shell,
-        }));
-      });
-  }
-
-  /** Compute a tab label from a file path: just the basename, since the
-   *  full path is shown in the editor status strip. */
-  function editorLabelForPath(filePath: string): string {
-    const slash = Math.max(
-      filePath.lastIndexOf("/"),
-      filePath.lastIndexOf("\\"),
-    );
-    return slash >= 0 ? filePath.slice(slash + 1) : filePath;
-  }
-
-  /** Open (or focus) an editor tab for the supplied absolute path. If a
-   *  tab for the same path already exists in the current project bucket,
-   *  switch to it instead of creating a duplicate. */
-  function newEditorTab(filePath: string, opts: { rootPath?: string } = {}) {
-    if (!filePath) return;
-    const rootPath = opts.rootPath;
-    const tabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
-    const existing = tabs.find(
-      (t) =>
-        t.kind === "editor" &&
-        t.editor?.filePath === filePath &&
-        (t.editor.rootPath ?? "") === (rootPath ?? ""),
-    );
-    if (existing) {
-      setActiveTab(existing.id);
-      return;
-    }
-    const id = crypto.randomUUID();
-    const projectId = projectsRef.current.activeId;
-    const language = languageFromPath(filePath);
-    const tab: Tab = {
-      ...makeEmptyTab(id, editorLabelForPath(filePath), projectId, "editor"),
-      editor: {
-        filePath,
-        ...(rootPath ? { rootPath } : {}),
-        language,
-        isDirty: false,
-      },
-    };
-    setState((prev) => {
-      const list = ((prev.tabs as Tab[] | undefined) ?? []).slice();
-      list.push(tab);
-      const tabRec = tab as unknown as Record<string, unknown>;
-      const result: Record<string, unknown> = {
-        ...prev,
-        tabs: list,
-        activeTabId: id,
-        hasTabs: true,
-        empty: false,
-      };
-      for (const key of TAB_MIRROR_KEYS) {
-        result[key as string] = tabRec[key as string];
-      }
-      return result;
-    });
-  }
-
-  /** Close every editor tab whose filePath matches `path` (or is a
-   *  descendant when `kind === "dir"`). Imported by the file-tree's
-   *  delete action so a moved-to-Trash file can't be resurrected by a
-   *  later Cmd+S on the still-open buffer. Routes through `closeTab`
-   *  (not `closeTabNow`) so the dirty-buffer confirm prompt still fires
-   *  per-tab — a folder delete with unsaved edits inside it can't
-   *  silently destroy the in-memory buffer. */
-  function closeEditorTabsForPath(path: string, kind: string) {
-    if (!path) return;
-    const prefix = `${path.replace(/\/+$/, "")}/`;
-    const tabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
-    for (const tab of tabs) {
-      if (tab.kind !== "editor" || !tab.editor) continue;
-      const current = tab.editor.filePath;
-      const match =
-        kind === "dir"
-          ? current === path || current.startsWith(prefix)
-          : current === path;
-      if (match) closeTab(tab.id);
-    }
-  }
-
-  /** Reconcile open editor tabs after an on-disk rename. For files,
-   *  match the exact path and rewrite filePath + label. For folders,
-   *  rewrite any tab whose path is rooted at the old folder. Imported
-   *  by the file-tree's rename context-menu action. */
-  function renameEditorTabsForPath(from: string, to: string, kind: string) {
-    if (!from || !to || from === to) return;
-    const prefix = `${from.replace(/\/+$/, "")}/`;
-    setState((prev) => {
-      const tabs = ((prev.tabs as Tab[] | undefined) ?? []).slice();
-      let changed = false;
-      const next = tabs.map((tab) => {
-        if (tab.kind !== "editor" || !tab.editor) return tab;
-        const current = tab.editor.filePath;
-        let nextPath: string | null = null;
-        if (kind === "dir") {
-          if (current.startsWith(prefix)) {
-            nextPath = `${to.replace(/\/+$/, "")}/${current.slice(prefix.length)}`;
-          } else if (current === from) {
-            nextPath = to;
-          }
-        } else if (current === from) {
-          nextPath = to;
-        }
-        if (!nextPath) return tab;
-        changed = true;
-        // Recompute the tab label too — Cmd+P/file-tree both expect the
-        // basename to track the path. Language id intentionally stays
-        // put since Shiki keeps grammars by file extension, which is
-        // usually what changed during a rename.
-        const renamed: Tab = {
-          ...tab,
-          label: editorLabelForPath(nextPath),
-          editor: {
-            ...tab.editor,
-            filePath: nextPath,
-            language: languageFromPath(nextPath),
-          },
-        };
-        return renamed;
-      });
-      if (!changed) return prev;
-      const result: Record<string, unknown> = { ...prev, tabs: next };
-      // Mirror the active tab's updated editor field into the root
-      // state so Monaco's EditorCanvas (which reads tabs via $ref) sees
-      // the new path on its next render.
-      const activeId = prev.activeTabId as string | undefined;
-      if (activeId) {
-        const active = next.find((t) => t.id === activeId);
-        if (active) {
-          const rec = active as unknown as Record<string, unknown>;
-          for (const key of TAB_MIRROR_KEYS) {
-            result[key as string] = rec[key as string];
-          }
-        }
-      }
-      return result;
-    });
-  }
-
-  /** Toggle the active editor tab's markdown preview mode. No-op when
-   *  the active tab isn't an editor tab or isn't a markdown file. */
-  function toggleEditorPreview() {
-    const activeId = stateRef.current.activeTabId as string | undefined;
-    if (!activeId) return;
-    const tabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
-    const tab = tabs.find((t) => t.id === activeId);
-    if (!tab || tab.kind !== "editor" || !tab.editor) return;
-    if (tab.editor.language !== "markdown") return;
-    updateEditorMeta(activeId, {
-      previewMode: !tab.editor.previewMode,
-      previewRefreshKey: (tab.editor.previewRefreshKey ?? 0) + 1,
-    });
-  }
-
-  /** Patch the active editor tab's metadata (dirty flag, cursor). Cheap
-   *  no-op if the tab is missing or not an editor tab. */
-  function updateEditorMeta(tabId: string, patch: Partial<EditorMeta>) {
-    updateTab(tabId, (t) => {
-      if (t.kind !== "editor" || !t.editor) return t;
-      const merged = { ...t.editor, ...patch };
-      // Skip the setState if nothing meaningful changed — guards against
-      // re-render storms from Monaco's cursorPosition events on every key.
-      const samePath = merged.filePath === t.editor.filePath;
-      const sameLang = merged.language === t.editor.language;
-      const sameDirty = merged.isDirty === t.editor.isDirty;
-      const sameLine = merged.cursorLine === t.editor.cursorLine;
-      const sameCol = merged.cursorColumn === t.editor.cursorColumn;
-      if (samePath && sameLang && sameDirty && sameLine && sameCol) return t;
-      return { ...t, editor: merged };
-    });
-  }
-
-  function autoRestoreDiscoveredSessions(
-    discovered: DiscoveredSession[],
-    knownIds: Set<string>,
-  ) {
-    if (discovered.length === 0) return;
-    getConfig()
-      .then((config) => {
-        if (!config.ui.restoreTabs) return;
-        const liveIds = new Set([
-          ...knownIds,
-          ...((stateRef.current.tabs as Tab[] | undefined) ?? []).map(
-            (t) => t.id,
-          ),
-        ]);
-        const toRestore = discovered
-          .filter((d) => !liveIds.has(d.tabId))
-          .filter((d) => !autoRestoredSessionIdsRef.current.has(d.tabId))
-          .slice(0, 8);
-        if (toRestore.length === 0) return;
-        // Open oldest first so the most recent session ends up active.
-        for (const session of [...toRestore].reverse()) {
-          autoRestoredSessionIdsRef.current.add(session.tabId);
-          newTab(session.tabId, sessionLabel(session), {
-            restoredSession: true,
-            ...(session.cwd ? { cwd: session.cwd } : {}),
-          });
-        }
-        pushNotification({
-          id: "ae-auto-restore-tabs",
-          title: `Restored ${toRestore.length} session${toRestore.length === 1 ? "" : "s"}`,
-          kind: "success",
-          durationMs: 3000,
-        });
-      })
-      .catch(() => {
-        /* config read already logs; manual restore remains available */
-      });
-  }
-
-  function pushClosedTab(tab: Tab) {
-    const entry: ClosedTabEntry = {
-      id: tab.id,
-      kind: tab.kind,
-      label: tab.label,
-      projectId: tab.projectId,
-      ...(tab.kind === "shell" && tab.shell
-        ? {
-            cwd: tab.shell.cwd,
-            command: tab.shell.command,
-            args: tab.shell.args,
-          }
-        : {}),
-      ...(tab.kind === "agent" && tab.cwd ? { cwd: tab.cwd } : {}),
-      ...(tab.kind === "editor" && tab.editor
-        ? { filePath: tab.editor.filePath }
-        : {}),
-    };
-    closedTabsRef.current.push(entry);
-    if (closedTabsRef.current.length > CLOSED_TAB_STACK_MAX) {
-      closedTabsRef.current.splice(
-        0,
-        closedTabsRef.current.length - CLOSED_TAB_STACK_MAX,
-      );
-    }
-  }
-
-  /** Reopen the most-recently-closed tab. Agent tabs reopen with the
-   *  *original* tabId — that's the cue for the bridge's
-   *  SessionManager.continueRecent to pick up the persisted JSONL session
-   *  under `~/.aethon/sessions/<tabId>/`. Shell tabs spawn a fresh PTY
-   *  at the original cwd. No-op on empty stack. */
-  function reopenLastClosedTab() {
-    const entry = closedTabsRef.current.pop();
-    if (!entry) return;
-    // If the closed tab belongs to a different project bucket than
-    // the active one, switch to that bucket first so the new tab
-    // lands in its original project's tab list.
-    const activeId = projectsRef.current.activeId;
-    if (entry.projectId !== activeId) {
-      if (entry.projectId === null) {
-        clearActiveProject();
-      } else {
-        setActiveProjectById(entry.projectId);
-      }
-    }
-    if (entry.kind === "shell") {
-      newShellTab({
-        ...(entry.command ? { command: entry.command } : {}),
-        ...(entry.args ? { args: entry.args } : {}),
-        ...(entry.cwd ? { cwd: entry.cwd } : {}),
-      });
-    } else if (entry.kind === "editor" && entry.filePath) {
-      // Re-open the same file. EditorCanvas reads it from disk on mount;
-      // unsaved buffer state is intentionally not preserved across close.
-      newEditorTab(entry.filePath);
-    } else {
-      newTab(entry.id, entry.label, {
-        restoredSession: true,
-        ...(entry.cwd ? { cwd: entry.cwd } : {}),
-      });
-    }
-  }
-
-  /** Close a tab, prompting for confirmation when closing a running
-   *  shell tab and `[shell] prompt_before_close` is true. Editor tabs
-   *  with unsaved changes get a lightweight native confirm prompt so
-   *  Cmd+W on a dirty file can't silently throw work away. */
-  function closeTab(tabId: string) {
-    const tabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
-    const closing = tabs.find((t) => t.id === tabId);
-    if (
-      closing?.kind === "shell" &&
-      closing.shell?.shellState === "running" &&
-      shellPromptBeforeCloseRef.current
-    ) {
-      void promptCloseShellTabConfirmation(closing.label).then((allowed) => {
-        if (!allowed) return;
-        closeTabNow(tabId);
-      });
-      return;
-    }
-    if (closing?.kind === "editor" && closing.editor?.isDirty) {
-      const ok = window.confirm(
-        `"${closing.label}" has unsaved changes. Close without saving?`,
-      );
-      if (!ok) return;
-    }
-    closeTabNow(tabId);
-  }
-
-  function closeTabNow(tabId: string) {
-    const tabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
-    if (tabs.length === 0) return;
-    const closing = tabs.find((t) => t.id === tabId);
-    const closedKind = closing?.kind;
-    if (closing) pushClosedTab(closing);
-    let nextBuffer = "";
-    let switched = false;
-    let becameEmpty = false;
-    setState((prev) => {
-      const list = ((prev.tabs as Tab[] | undefined) ?? []).filter(
-        (t) => t.id !== tabId,
-      );
-      let activeTabId = prev.activeTabId as string | undefined;
-      if (activeTabId === tabId) {
-        activeTabId = list.length > 0 ? list[list.length - 1].id : undefined;
-        switched = true;
-      }
-      const result: Record<string, unknown> = {
-        ...prev,
-        tabs: list,
-        activeTabId,
-      };
-      if (closing) {
-        const closedSession = recentSessionItemFromClosedTab(
-          closing,
-          projectsRef.current,
-        );
-        if (closedSession) {
-          const recent =
-            (prev.recentSessions as { id: string }[] | undefined) ?? [];
-          result.recentSessions = [
-            closedSession,
-            ...recent.filter((s) => s.id !== closedSession.id),
-          ].slice(0, 16);
-        }
-      }
-      if (list.length === 0) {
-        becameEmpty = true;
-        for (const key of TAB_MIRROR_KEYS) {
-          result[key as string] = undefined;
-        }
-        result.empty = true;
-        result.hasTabs = false;
-      } else {
-        const target = list.find((t) => t.id === activeTabId)!;
-        nextBuffer = target.terminalBuffer ?? "";
-        const targetRec = target as unknown as Record<string, unknown>;
-        for (const key of TAB_MIRROR_KEYS) {
-          result[key as string] = targetRec[key as string];
-        }
-        result.sidebar = recomputeModelPicker(
-          prev.sidebar as Record<string, unknown> | undefined,
-          target.model,
-        );
-        result.empty = false;
-        result.hasTabs = true;
-      }
-      return result;
-    });
-    if (switched) dispatchTerminalReplay(nextBuffer);
-    // Tear down bridge session whether we became empty or not — both
-    // paths fire tab_close and the bridge no-ops on unknown tab ids.
-    void becameEmpty;
-    invoke("agent_command", {
-      payload: JSON.stringify({ type: "tab_close", tabId }),
-    }).catch(() => {
-      /* ignore — UI already closed */
-    });
-    // M6 P1: shell tabs own a PTY in the Rust shell registry. Close
-    // it too so the child process is reaped and the reader thread
-    // joins (no zombies on tab close).
-    if (closedKind === "shell") {
-      invoke("shell_close", { tabId }).catch(() => {
-        /* idempotent — already torn down by natural exit */
-      });
-    }
-    // Editor tabs own a Monaco model. Dispose it explicitly here so a
-    // closed tab doesn't leak — the buffer cache is intentionally
-    // long-lived across hidden project buckets (a tab the user can
-    // still come back to keeps its unsaved buffer), so we can't rely
-    // on a "tab not visible" prune.
-    if (closedKind === "editor") {
-      disposeEditorBuffer(tabId);
-    }
-  }
+  const autoRestoreDiscoveredSessions = useAutoRestoreDiscoveredSessions({
+    stateRef: ctx.stateRef,
+    autoRestoredSessionIdsRef,
+    pushNotification: ctx.pushNotification,
+    newTab,
+  });
 
   return {
     pendingTabOpens,
     autoRestoredSessionIdsRef,
-    updateTab,
-    updateActiveTab,
-    applyShareModeToTab,
+    updateTab: mutations.updateTab,
+    updateActiveTab: mutations.updateActiveTab,
+    applyShareModeToTab: mutations.applyShareModeToTab,
     dispatchTerminalReplay,
-    setActiveTab,
-    setActiveSubTab,
+    setActiveTab: mutations.setActiveTab,
+    setActiveSubTab: mutations.setActiveSubTab,
     newTab,
     newShellTab,
-    newEditorTab,
-    updateEditorMeta,
-    toggleEditorPreview,
-    renameEditorTabsForPath,
-    closeEditorTabsForPath,
+    newEditorTab: editor.newEditorTab,
+    updateEditorMeta: editor.updateEditorMeta,
+    toggleEditorPreview: editor.toggleEditorPreview,
+    renameEditorTabsForPath: editor.renameEditorTabsForPath,
+    closeEditorTabsForPath: close.closeEditorTabsForPath,
     autoRestoreDiscoveredSessions,
-    pushClosedTab,
-    reopenLastClosedTab,
-    closeTab,
-    closeTabNow,
+    pushClosedTab: close.pushClosedTab,
+    reopenLastClosedTab: close.reopenLastClosedTab,
+    closeTab: close.closeTab,
+    closeTabNow: close.closeTabNow,
   };
 }


### PR DESCRIPTION
## Summary

\`src/hooks/useTabs.ts\` (997 LOC) was the frontend's biggest state knot —
agent / shell / editor tab lifecycle, root-state mirror writes, terminal
replay dispatch, auto-restore, close+reopen, Monaco buffer cleanup, and
bridge invokes were all in one closure. Retired by splitting into a thin
facade plus nine focused submodules, same pattern as the existing
\`projectOps/\` directory.

### Layout

\`\`\`
src/hooks/useTabs.ts                — facade (147 LOC)
src/hooks/tabOps/types.ts           — UseTabsContext, UseTabsActions,
                                      DiscoveredSession, NotificationInput
src/hooks/tabOps/constants.ts       — TAB_MIRROR_KEYS, TERMINAL_REPLAY_MAX,
                                      CLOSED_TAB_STACK_MAX, VALID_SHARE_MODES
src/hooks/tabOps/helpers.ts         — pure data helpers (session labels,
                                      model/cwd resolution, recentSessions
                                      projection, editorLabelForPath)
src/hooks/tabOps/mutations.ts       — useMutations + dispatchTerminalReplay
                                      (updateTab, updateActiveTab,
                                      applyShareModeToTab, setActiveTab,
                                      setActiveSubTab)
src/hooks/tabOps/agentTab.ts        — useNewTab (agent-tab creation with
                                      bridge tab_open + scroll-to-match seed)
src/hooks/tabOps/shellTab.ts        — useNewShellTab (panel-only, seeds
                                      share mode atomically inside shell_open)
src/hooks/tabOps/editorTab.ts       — useEditorTabActions (newEditorTab,
                                      updateEditorMeta, toggleEditorPreview,
                                      renameEditorTabsForPath)
src/hooks/tabOps/closeTab.ts        — useCloseTabActions (closeTab,
                                      closeTabNow, pushClosedTab,
                                      reopenLastClosedTab, plus
                                      closeEditorTabsForPath which lives
                                      here so the bulk-close honors the
                                      dirty-buffer confirm prompt)
src/hooks/tabOps/autoRestore.ts     — useAutoRestoreDiscoveredSessions
\`\`\`

### Public-surface guarantee

Every import path from outside \`useTabs.ts\` stays identical because the
facade re-exports:

- **Constants** — \`TAB_MIRROR_KEYS\` (consumed by \`bridgeMessageHandlers/{ready,statePatch,tabClosed}\`,
  \`projectOps/tabBuckets\`, \`useSessionPersistence\`),
  \`TERMINAL_REPLAY_MAX\` (consumed by \`bridgeMessageHandlers/terminalOutput\`,
  \`useOsEdges\`)
- **Hook + interfaces** — \`useTabs\`, \`UseTabsContext\`, \`UseTabsActions\` (App.tsx)
- **Pure helpers** — \`cwdForNewTab\`, \`modelForNewProjectTab\`,
  \`recentSessionItemFromClosedTab\` (used by \`useTabs.test.ts\`)

\`useTabs.test.ts\` is **untouched** — it imports the three pure helpers
from \`./useTabs\` and they keep resolving through the facade re-export.

### Why \`useX\` factory naming

The per-concern factories (\`useMutations\`, \`useNewTab\`, ...) are named
\`useX\` to match the existing \`projectOps/\` convention
(\`useProjectStore\`, \`useWorktreeOperations\`). React's lint rule trusts
the hook-naming convention when refs are passed in; without it, every
factory call triggers \`react-hooks/refs\` ("Passing a ref to a function
may read its value during render"), a false positive for the
factory-stores-refs-but-doesn't-deref-during-render pattern.

### Where \`closeEditorTabsForPath\` lives

It's a close-family operation (acts on editor tabs, but routes through
\`closeTab\` to honor the dirty-buffer confirm prompt), so it sits in
\`closeTab.ts\` next to \`closeTab\` rather than in \`editorTab.ts\`. That
also breaks what would otherwise be a circular dependency: the reopen
flow in \`closeTab.ts\` calls \`newEditorTab\`, so \`closeTab\` depends on
\`editorTab\`; if \`closeEditorTabsForPath\` were in \`editorTab.ts\` it
would need \`closeTab\`, completing the cycle.

### Verification

\`\`\`
bunx tsc --noEmit                 clean
bunx eslint . --max-warnings=5    5 pre-existing warnings (none from this PR)
bunx vitest run                   148/148 files, 1124/1124 tests
cargo test --lib                  158/158 (Rust untouched)
\`\`\`

### Test plan

- [x] tsc / eslint / vitest pass
- [x] cargo tests still pass (Rust shell untouched)
- [x] dev build smoke: open agent tab, shell tab, editor tab, close
      each, reopen via Cmd+Shift+T, drag-rename a file, delete a folder
      with an open editor tab inside — exercises every action in the split