### PR TITLE
refactor(worktree-ops): split worktreeOperations into focused submodules

### DIFF
--- a/src/hooks/projectOps/worktreeOperations.ts
+++ b/src/hooks/projectOps/worktreeOperations.ts
@@ -1,638 +1,158 @@
-import type { MutableRefObject } from "react";
 import {
-  DEFAULT_WORKTREE_BASE_BRANCH,
-  activeProject,
-  setActiveWorktree as setActiveWorktreeState,
-  setProjectIconUrl as setProjectIconUrlState,
-  setProjectUiExpanded,
-  setProjectWorktreeBaseBranch as setProjectWorktreeBaseBranchState,
-  setProjectWorktrees,
-  type Project,
-  type ProjectsState,
-} from "../../projects";
-import type { Tab } from "../../types/tab";
-import { pickWorktreeName } from "../../worktreeNames";
+  createWorktreeForProject,
+  createWorktreeWithParams,
+  fetchBranches,
+  refreshProjectWorktrees,
+  retryPendingWorktree,
+} from "./worktreeOps/git";
+import { makeProjectLookups } from "./worktreeOps/lookups";
+import { removeWorktreeById } from "./worktreeOps/remove";
 import {
-  gitBranchList,
-  gitWorktreeAdd,
-  gitWorktreeRemove,
-  gitWorktreeRemoveOrphan,
-  gitWorktrees,
-  newPendingWorktree,
-  reconcileWorktrees,
-  removeWorktreeFromList,
-  updateWorktreePendingState,
-  type Worktree,
-} from "../../worktrees";
-import { normalizeSessionPath, projectScopeBucketKey } from "./tabBuckets";
-import type { TabBucket } from "./types";
+  activateWorktree,
+  dismissPendingWorktree,
+  renameProject,
+  renameWorktree,
+  setProjectExpanded,
+  setProjectIconUrl,
+  setProjectWorktreeBaseBranch,
+} from "./worktreeOps/state";
+import type {
+  WorktreeOperationDeps,
+  WorktreeOperations,
+} from "./worktreeOps/types";
 
-interface WorktreeOperationDeps {
-  projectsRef: MutableRefObject<ProjectsState>;
-  stateRef: MutableRefObject<Record<string, unknown>>;
-  tabBucketsRef: MutableRefObject<Map<string, TabBucket>>;
-  syncProjectsToState: () => void;
-  persistProjects: () => Promise<void>;
-  scheduleProjectsSave: (delayMs?: number) => void;
-  syncRecentSessionsToState: () => void;
-  switchProjectBucket: (
-    fromKey: string,
-    toKey: string,
-    opts?: { mirrorProjects?: boolean },
-  ) => string | undefined;
-  setActiveProjectById: (id: string) => boolean;
-  announceProjectToBridge: (tabId: string, path: string | null) => void;
-  watchProjectForBridge: (path: string) => void;
-  unwatchProjectForBridge: (path: string) => void;
-  closeTabNow: (tabId: string) => void;
-}
-
-export interface WorktreeOperations {
-  setProjectExpanded: (projectId: string, expanded: boolean) => void;
-  setProjectIconUrl: (projectId: string, iconUrl: string | null) => void;
-  refreshProjectWorktrees: (projectId: string) => Promise<void>;
-  activateWorktree: (worktreeId: string | null) => void;
-  createWorktreeForProject: (projectId: string) => Promise<void>;
-  createWorktreeWithParams: (opts: {
-    projectId: string;
-    branch: string;
-    targetPath?: string;
-    baseBranch?: string;
-  }) => Promise<string | null>;
-  removeWorktreeById: (
-    worktreeId: string,
-    opts?: { confirmed?: boolean },
-  ) => Promise<void>;
-  dismissPendingWorktree: (worktreeId: string) => void;
-  retryPendingWorktree: (worktreeId: string) => Promise<void>;
-  renameWorktree: (worktreeId: string, label: string) => void;
-  fetchBranches: (projectId: string) => Promise<string[]>;
-  renameProject: (projectId: string, label: string) => void;
-  setProjectWorktreeBaseBranch: (
-    projectId: string,
-    baseBranch: string | null,
-  ) => void;
-  findProjectOfWorktree: (
-    worktreeId: string,
-  ) => { project: Project; worktree: Worktree } | null;
-}
+export type { WorktreeOperationDeps, WorktreeOperations };
 
 export function useWorktreeOperations(
   deps: WorktreeOperationDeps,
 ): WorktreeOperations {
-  const {
-    projectsRef,
-    stateRef,
-    tabBucketsRef,
-    syncProjectsToState,
-    persistProjects,
-    scheduleProjectsSave,
-    syncRecentSessionsToState,
-    switchProjectBucket,
-    setActiveProjectById,
-    announceProjectToBridge,
-    watchProjectForBridge,
-    unwatchProjectForBridge,
-    closeTabNow,
-  } = deps;
+  const lookups = makeProjectLookups(deps.projectsRef);
 
-  function findProject(id: string): Project | null {
-    return projectsRef.current.projects.find((p) => p.id === id) ?? null;
-  }
-
-  function findProjectOfWorktree(
-    worktreeId: string,
-  ): { project: Project; worktree: Worktree } | null {
-    const wbp = projectsRef.current.worktreesByProject;
-    for (const [pid, list] of Object.entries(wbp)) {
-      const wt = list.find((w) => w.id === worktreeId);
-      if (wt) {
-        const project = findProject(pid);
-        if (project) return { project, worktree: wt };
-      }
-    }
-    return null;
-  }
-
-  async function refreshProjectWorktrees(projectId: string): Promise<void> {
-    const project = findProject(projectId);
-    if (!project) return;
-    try {
-      const listing = await gitWorktrees(project.path);
-      const prior = projectsRef.current.worktreesByProject[projectId] ?? [];
-      const next = reconcileWorktrees(projectId, prior, listing);
-      let nextState = setProjectWorktrees(projectsRef.current, projectId, next);
-      const activeWorktreeId = nextState.activeWorktreeId;
-      if (
-        nextState.activeId === projectId &&
-        activeWorktreeId &&
-        !next.some((w) => w.id === activeWorktreeId)
-      ) {
-        nextState = { ...nextState, activeWorktreeId: null };
-      }
-      projectsRef.current = nextState;
-      void persistProjects();
-    } catch {
-      // Project may not be a git repo; keep the prior list intact.
-    }
-  }
-
-  function setProjectExpanded(projectId: string, expanded: boolean): void {
-    projectsRef.current = setProjectUiExpanded(
-      projectsRef.current,
-      projectId,
-      expanded,
-    );
-    if (expanded && !projectsRef.current.worktreesByProject[projectId]) {
-      void refreshProjectWorktrees(projectId);
-    }
-    syncProjectsToState();
-    scheduleProjectsSave();
-  }
-
-  function setProjectIconUrl(projectId: string, iconUrl: string | null): void {
-    const next = setProjectIconUrlState(
-      projectsRef.current,
-      projectId,
-      iconUrl,
-    );
-    if (next === projectsRef.current) return;
-    projectsRef.current = next;
-    void persistProjects();
-  }
-
-  function activateWorktree(worktreeId: string | null): void {
-    const current = projectsRef.current;
-    if (current.activeWorktreeId === worktreeId) return;
-    const fromKey = projectScopeBucketKey(
-      current.activeId,
-      current.activeWorktreeId,
-    );
-    let activeProjectId = current.activeId;
-    let nextCwd: string | null;
-    let nextProjectPath: string | null;
-    if (worktreeId) {
-      const hit = findProjectOfWorktree(worktreeId);
-      if (!hit) return;
-      activeProjectId = hit.project.id;
-      nextCwd = hit.worktree.path;
-      nextProjectPath = hit.project.path;
-    } else {
-      const project = activeProject(current);
-      nextCwd = project?.path ?? null;
-      nextProjectPath = project?.path ?? null;
-    }
-    const previousActive = activeProject(current);
-    const crossingProjects =
-      activeProjectId !== current.activeId &&
-      previousActive != null &&
-      nextProjectPath !== null &&
-      previousActive.path !== nextProjectPath;
-    projectsRef.current = setActiveWorktreeState(
-      { ...current, activeId: activeProjectId },
+  const activateWorktreeBound = (worktreeId: string | null): void =>
+    activateWorktree(
+      {
+        projectsRef: deps.projectsRef,
+        syncProjectsToState: deps.syncProjectsToState,
+        persistProjects: deps.persistProjects,
+        scheduleProjectsSave: deps.scheduleProjectsSave,
+        lookups,
+        switchProjectBucket: deps.switchProjectBucket,
+        announceProjectToBridge: deps.announceProjectToBridge,
+        watchProjectForBridge: deps.watchProjectForBridge,
+        unwatchProjectForBridge: deps.unwatchProjectForBridge,
+      },
       worktreeId,
     );
-    const nextTabId = switchProjectBucket(
-      fromKey,
-      projectScopeBucketKey(activeProjectId, worktreeId),
-      { mirrorProjects: true },
-    );
-    scheduleProjectsSave();
-    announceProjectToBridge(nextTabId ?? "default", nextCwd);
-    if (crossingProjects && previousActive && nextProjectPath) {
-      unwatchProjectForBridge(previousActive.path);
-      watchProjectForBridge(nextProjectPath);
-    }
-  }
 
-  function tabCwdMatches(tab: Tab, path: string): boolean {
-    if (tab.kind !== "agent") return false;
-    return normalizeSessionPath(tab.cwd) === normalizeSessionPath(path);
-  }
+  const refreshDeps = {
+    projectsRef: deps.projectsRef,
+    lookups,
+    persistProjects: deps.persistProjects,
+  };
 
-  function removeStoredTabsForWorktreePath(
-    path: string,
-    removedBucketKey: string,
-  ): void {
-    tabBucketsRef.current.delete(removedBucketKey);
-    for (const [key, bucket] of tabBucketsRef.current.entries()) {
-      const tabs = bucket.tabs.filter((tab) => !tabCwdMatches(tab, path));
-      if (tabs.length === bucket.tabs.length) continue;
-      if (tabs.length === 0) {
-        tabBucketsRef.current.delete(key);
-        continue;
-      }
-      const activeTabId = tabs.some((tab) => tab.id === bucket.activeTabId)
-        ? bucket.activeTabId
-        : tabs[0]?.id;
-      tabBucketsRef.current.set(key, { tabs, activeTabId });
-    }
-  }
+  const gitDeps = {
+    projectsRef: deps.projectsRef,
+    lookups,
+    syncProjectsToState: deps.syncProjectsToState,
+    persistProjects: deps.persistProjects,
+    setActiveProjectById: deps.setActiveProjectById,
+    activateWorktree: activateWorktreeBound,
+  };
 
-  function closeVisibleTabsForWorktreePath(path: string): void {
-    const tabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
-    const closing = tabs
-      .filter((tab) => tabCwdMatches(tab, path))
-      .map((tab) => tab.id);
-    for (const tabId of closing) closeTabNow(tabId);
-  }
-
-  function closeTabsForRemovedWorktree(
-    projectId: string,
-    worktreeId: string,
-    path: string,
-    wasActive: boolean,
-  ): void {
-    closeVisibleTabsForWorktreePath(path);
-    if (wasActive) activateWorktree(null);
-    removeStoredTabsForWorktreePath(
-      path,
-      projectScopeBucketKey(projectId, worktreeId),
-    );
-    syncRecentSessionsToState();
-  }
-
-  function resolveWorktreeBaseBranch(
-    project: Project,
-    explicit?: string,
-  ): string {
-    const trimmed = explicit?.trim();
-    if (trimmed) return trimmed;
-    return project.worktreeBaseBranch?.trim() || DEFAULT_WORKTREE_BASE_BRANCH;
-  }
-
-  function navigateToWorktree(projectId: string, worktreeId: string): void {
-    if (projectsRef.current.activeId !== projectId) {
-      setActiveProjectById(projectId);
-    }
-    projectsRef.current = setProjectUiExpanded(
-      projectsRef.current,
-      projectId,
-      true,
-    );
-    activateWorktree(worktreeId);
-  }
-
-  function defaultWorktreePath(projectPath: string, branch: string): string {
-    const safe = branch.replace(/[^a-z0-9._-]/gi, "-");
-    return `${projectPath.replace(/\/$/, "")}-${safe}`;
-  }
-
-  async function createWorktreeForProject(projectId: string): Promise<void> {
-    const project = findProject(projectId);
-    if (!project) return;
-    const taken = new Set<string>();
-    for (const w of projectsRef.current.worktreesByProject[projectId] ?? []) {
-      if (w.branch) taken.add(w.branch);
-      if (w.label) taken.add(w.label);
-    }
-    try {
-      const branches = await gitBranchList(project.path);
-      for (const b of branches) taken.add(b.name);
-    } catch {
-      // Branch list failed; random naming remains good enough.
-    }
-    const branch = pickWorktreeName(taken);
-    await createWorktreeWithParams({ projectId, branch });
-  }
-
-  async function createWorktreeWithParams(opts: {
-    projectId: string;
-    branch: string;
-    targetPath?: string;
-    baseBranch?: string;
-  }): Promise<string | null> {
-    const project = findProject(opts.projectId);
-    if (!project) return null;
-    const branch = opts.branch.trim();
-    if (!branch) return null;
-    const targetPath =
-      opts.targetPath?.trim() || defaultWorktreePath(project.path, branch);
-    const pending = newPendingWorktree(opts.projectId, branch, targetPath);
-    const baseBranch = resolveWorktreeBaseBranch(project, opts.baseBranch);
-    const before = projectsRef.current.worktreesByProject[opts.projectId] ?? [];
-    projectsRef.current = setProjectWorktrees(
-      projectsRef.current,
-      opts.projectId,
-      [...before, pending],
-    );
-    syncProjectsToState();
-    projectsRef.current = setProjectWorktrees(
-      projectsRef.current,
-      opts.projectId,
-      updateWorktreePendingState(
-        projectsRef.current.worktreesByProject[opts.projectId] ?? [],
-        pending.id,
-        "starting",
-      ),
-    );
-    syncProjectsToState();
-    try {
-      const created = await gitWorktreeAdd({
-        projectPath: project.path,
-        targetPath,
-        branch,
-        base: baseBranch,
-      });
-      projectsRef.current = setProjectWorktrees(
-        projectsRef.current,
-        opts.projectId,
-        updateWorktreePendingState(
-          projectsRef.current.worktreesByProject[opts.projectId] ?? [],
-          pending.id,
-          "succeeded",
-        ),
-      );
-      await refreshProjectWorktrees(opts.projectId);
-      const list = projectsRef.current.worktreesByProject[opts.projectId] ?? [];
-      const live = list.find(
-        (w) =>
-          w.id === pending.id ||
-          w.path === created.path ||
-          w.path === targetPath,
-      );
-      navigateToWorktree(opts.projectId, live?.id ?? pending.id);
-      return live?.path ?? created.path ?? targetPath;
-    } catch (err) {
-      projectsRef.current = setProjectWorktrees(
-        projectsRef.current,
-        opts.projectId,
-        updateWorktreePendingState(
-          projectsRef.current.worktreesByProject[opts.projectId] ?? [],
-          pending.id,
-          "failed",
-          String(err),
-        ),
-      );
-      syncProjectsToState();
-      return null;
-    }
-  }
-
-  async function removeWorktreeById(
-    worktreeId: string,
-    opts: { confirmed?: boolean } = {},
-  ): Promise<void> {
-    const hit = findProjectOfWorktree(worktreeId);
-    if (!hit) return;
-    const { project, worktree } = hit;
-    if (worktree.isMain) {
-      window.alert("Cannot remove the main worktree");
-      return;
-    }
-    const label = worktree.label ?? worktree.branch ?? "worktree";
-    if (opts.confirmed !== true) {
-      const ok = window.confirm(`Remove worktree '${label}'?`);
-      if (!ok) return;
-    }
-    try {
-      await gitWorktreeRemove({
-        projectPath: project.path,
-        worktreePath: worktree.path,
-        force: false,
-      });
-      closeTabsForRemovedWorktree(
-        project.id,
-        worktreeId,
-        worktree.path,
-        projectsRef.current.activeWorktreeId === worktreeId,
-      );
-      const list = removeWorktreeFromList(
-        projectsRef.current.worktreesByProject[project.id] ?? [],
-        worktreeId,
-      );
-      projectsRef.current = setProjectWorktrees(
-        projectsRef.current,
-        project.id,
-        list,
-      );
-      syncProjectsToState();
-      void persistProjects();
-    } catch (err) {
-      const msg = String(err);
-      if (msg.includes("dirty") || msg.includes("modified")) {
-        const forced = window.confirm(
-          `${msg}\n\nForce-remove anyway? Uncommitted changes will be lost.`,
-        );
-        if (!forced) return;
-        try {
-          await gitWorktreeRemove({
-            projectPath: project.path,
-            worktreePath: worktree.path,
-            force: true,
-          });
-          closeTabsForRemovedWorktree(
-            project.id,
-            worktreeId,
-            worktree.path,
-            projectsRef.current.activeWorktreeId === worktreeId,
-          );
-          const list = removeWorktreeFromList(
-            projectsRef.current.worktreesByProject[project.id] ?? [],
-            worktreeId,
-          );
-          projectsRef.current = setProjectWorktrees(
-            projectsRef.current,
-            project.id,
-            list,
-          );
-          syncProjectsToState();
-          void persistProjects();
-          return;
-        } catch (e2) {
-          window.alert(`Failed: ${String(e2)}`);
-          return;
-        }
-      }
-      if (msg.includes("worktree not tracked")) {
-        const ok = window.confirm(
-          `Aethon has this worktree but git no longer tracks it. ` +
-            `Remove the leftover folder and forget the entry?`,
-        );
-        if (!ok) return;
-        try {
-          await gitWorktreeRemoveOrphan({
-            projectPath: project.path,
-            worktreePath: worktree.path,
-          });
-          closeTabsForRemovedWorktree(
-            project.id,
-            worktreeId,
-            worktree.path,
-            projectsRef.current.activeWorktreeId === worktreeId,
-          );
-          const list = removeWorktreeFromList(
-            projectsRef.current.worktreesByProject[project.id] ?? [],
-            worktreeId,
-          );
-          projectsRef.current = setProjectWorktrees(
-            projectsRef.current,
-            project.id,
-            list,
-          );
-          syncProjectsToState();
-          void persistProjects();
-          return;
-        } catch (e2) {
-          window.alert(`Failed: ${String(e2)}`);
-          return;
-        }
-      }
-      window.alert(`Failed: ${msg}`);
-    }
-  }
-
-  function dismissPendingWorktree(worktreeId: string): void {
-    const hit = findProjectOfWorktree(worktreeId);
-    if (!hit) return;
-    const list = removeWorktreeFromList(
-      projectsRef.current.worktreesByProject[hit.project.id] ?? [],
+  const dismissPendingWorktreeBound = (worktreeId: string): void =>
+    dismissPendingWorktree(
+      {
+        projectsRef: deps.projectsRef,
+        persistProjects: deps.persistProjects,
+        lookups,
+      },
       worktreeId,
     );
-    projectsRef.current = setProjectWorktrees(
-      projectsRef.current,
-      hit.project.id,
-      list,
-    );
-    void persistProjects();
-  }
-
-  async function retryPendingWorktree(worktreeId: string): Promise<void> {
-    const hit = findProjectOfWorktree(worktreeId);
-    if (!hit || !hit.worktree.branch) return;
-    dismissPendingWorktree(worktreeId);
-    const pending = newPendingWorktree(
-      hit.project.id,
-      hit.worktree.branch,
-      hit.worktree.path,
-    );
-    projectsRef.current = setProjectWorktrees(
-      projectsRef.current,
-      hit.project.id,
-      [
-        ...(projectsRef.current.worktreesByProject[hit.project.id] ?? []),
-        pending,
-      ],
-    );
-    syncProjectsToState();
-    projectsRef.current = setProjectWorktrees(
-      projectsRef.current,
-      hit.project.id,
-      updateWorktreePendingState(
-        projectsRef.current.worktreesByProject[hit.project.id] ?? [],
-        pending.id,
-        "starting",
-      ),
-    );
-    syncProjectsToState();
-    try {
-      await gitWorktreeAdd({
-        projectPath: hit.project.path,
-        targetPath: hit.worktree.path,
-        branch: hit.worktree.branch,
-        base: resolveWorktreeBaseBranch(hit.project),
-      });
-      projectsRef.current = setProjectWorktrees(
-        projectsRef.current,
-        hit.project.id,
-        updateWorktreePendingState(
-          projectsRef.current.worktreesByProject[hit.project.id] ?? [],
-          pending.id,
-          "succeeded",
-        ),
-      );
-      await refreshProjectWorktrees(hit.project.id);
-      const list = projectsRef.current.worktreesByProject[hit.project.id] ?? [];
-      const live = list.find(
-        (w) => w.id === pending.id || w.path === hit.worktree.path,
-      );
-      navigateToWorktree(hit.project.id, live?.id ?? pending.id);
-    } catch (err) {
-      projectsRef.current = setProjectWorktrees(
-        projectsRef.current,
-        hit.project.id,
-        updateWorktreePendingState(
-          projectsRef.current.worktreesByProject[hit.project.id] ?? [],
-          pending.id,
-          "failed",
-          String(err),
-        ),
-      );
-      syncProjectsToState();
-    }
-  }
-
-  function renameWorktree(worktreeId: string, label: string): void {
-    const hit = findProjectOfWorktree(worktreeId);
-    if (!hit) return;
-    const trimmed = label.trim();
-    const next: Worktree[] = (
-      projectsRef.current.worktreesByProject[hit.project.id] ?? []
-    ).map((w) =>
-      w.id === worktreeId
-        ? { ...w, label: trimmed.length > 0 ? trimmed : undefined }
-        : w,
-    );
-    projectsRef.current = setProjectWorktrees(
-      projectsRef.current,
-      hit.project.id,
-      next,
-    );
-    void persistProjects();
-  }
-
-  async function fetchBranches(projectId: string): Promise<string[]> {
-    const project = findProject(projectId);
-    if (!project) return [];
-    try {
-      const list = await gitBranchList(project.path);
-      return list.map((b) => b.name);
-    } catch {
-      return [];
-    }
-  }
-
-  function renameProject(projectId: string, label: string): void {
-    const trimmed = label.trim();
-    if (!trimmed) return;
-    const ps = projectsRef.current;
-    projectsRef.current = {
-      ...ps,
-      projects: ps.projects.map((p) =>
-        p.id === projectId ? { ...p, label: trimmed } : p,
-      ),
-    };
-    void persistProjects();
-  }
-
-  function setProjectWorktreeBaseBranch(
-    projectId: string,
-    baseBranch: string | null,
-  ): void {
-    const next = setProjectWorktreeBaseBranchState(
-      projectsRef.current,
-      projectId,
-      baseBranch,
-    );
-    if (next === projectsRef.current) return;
-    projectsRef.current = next;
-    void persistProjects();
-  }
 
   return {
-    setProjectExpanded,
-    setProjectIconUrl,
-    refreshProjectWorktrees,
-    activateWorktree,
-    createWorktreeForProject,
-    createWorktreeWithParams,
-    removeWorktreeById,
-    dismissPendingWorktree,
-    retryPendingWorktree,
-    renameWorktree,
-    setProjectWorktreeBaseBranch,
-    fetchBranches,
-    renameProject,
-    findProjectOfWorktree,
+    setProjectExpanded: (projectId, expanded) =>
+      setProjectExpanded(
+        {
+          projectsRef: deps.projectsRef,
+          syncProjectsToState: deps.syncProjectsToState,
+          persistProjects: deps.persistProjects,
+          scheduleProjectsSave: deps.scheduleProjectsSave,
+          onFirstExpand: (id) => {
+            void refreshProjectWorktrees(refreshDeps, id);
+          },
+        },
+        projectId,
+        expanded,
+      ),
+    setProjectIconUrl: (projectId, iconUrl) =>
+      setProjectIconUrl(
+        {
+          projectsRef: deps.projectsRef,
+          persistProjects: deps.persistProjects,
+        },
+        projectId,
+        iconUrl,
+      ),
+    refreshProjectWorktrees: (projectId) =>
+      refreshProjectWorktrees(refreshDeps, projectId),
+    activateWorktree: activateWorktreeBound,
+    createWorktreeForProject: (projectId) =>
+      createWorktreeForProject(gitDeps, projectId),
+    createWorktreeWithParams: (opts) =>
+      createWorktreeWithParams(gitDeps, opts),
+    removeWorktreeById: (worktreeId, opts) =>
+      removeWorktreeById(
+        {
+          projectsRef: deps.projectsRef,
+          lookups,
+          syncProjectsToState: deps.syncProjectsToState,
+          persistProjects: deps.persistProjects,
+          tabCleanupDeps: {
+            stateRef: deps.stateRef,
+            tabBucketsRef: deps.tabBucketsRef,
+            syncRecentSessionsToState: deps.syncRecentSessionsToState,
+            closeTabNow: deps.closeTabNow,
+            activateWorktree: activateWorktreeBound,
+          },
+        },
+        worktreeId,
+        opts,
+      ),
+    dismissPendingWorktree: dismissPendingWorktreeBound,
+    retryPendingWorktree: (worktreeId) =>
+      retryPendingWorktree(
+        { ...gitDeps, dismissPendingWorktree: dismissPendingWorktreeBound },
+        worktreeId,
+      ),
+    renameWorktree: (worktreeId, label) =>
+      renameWorktree(
+        {
+          projectsRef: deps.projectsRef,
+          persistProjects: deps.persistProjects,
+          lookups,
+        },
+        worktreeId,
+        label,
+      ),
+    fetchBranches: (projectId) => fetchBranches({ lookups }, projectId),
+    renameProject: (projectId, label) =>
+      renameProject(
+        {
+          projectsRef: deps.projectsRef,
+          persistProjects: deps.persistProjects,
+        },
+        projectId,
+        label,
+      ),
+    setProjectWorktreeBaseBranch: (projectId, baseBranch) =>
+      setProjectWorktreeBaseBranch(
+        {
+          projectsRef: deps.projectsRef,
+          persistProjects: deps.persistProjects,
+        },
+        projectId,
+        baseBranch,
+      ),
+    findProjectOfWorktree: lookups.findProjectOfWorktree,
   };
 }

--- a/src/hooks/projectOps/worktreeOps/bridgeWatch.ts
+++ b/src/hooks/projectOps/worktreeOps/bridgeWatch.ts
@@ -1,0 +1,22 @@
+import type { Project } from "../../../projects";
+
+interface BridgeWatchDeps {
+  watchProjectForBridge: (path: string) => void;
+  unwatchProjectForBridge: (path: string) => void;
+}
+
+/**
+ * When activating a worktree crosses project boundaries, swap the
+ * bridge file-watch from the previous project root to the next one.
+ * Caller owns the decision to invoke this — see activateWorktree.
+ */
+export function swapProjectWatch(
+  previousActive: Project | null,
+  nextProjectPath: string | null,
+  deps: BridgeWatchDeps,
+): void {
+  if (!previousActive || !nextProjectPath) return;
+  if (previousActive.path === nextProjectPath) return;
+  deps.unwatchProjectForBridge(previousActive.path);
+  deps.watchProjectForBridge(nextProjectPath);
+}

--- a/src/hooks/projectOps/worktreeOps/git.ts
+++ b/src/hooks/projectOps/worktreeOps/git.ts
@@ -1,0 +1,278 @@
+import type { MutableRefObject } from "react";
+import {
+  DEFAULT_WORKTREE_BASE_BRANCH,
+  setProjectUiExpanded,
+  setProjectWorktrees,
+  type Project,
+  type ProjectsState,
+} from "../../../projects";
+import { pickWorktreeName } from "../../../worktreeNames";
+import {
+  gitBranchList,
+  gitWorktreeAdd,
+  gitWorktrees,
+  newPendingWorktree,
+  reconcileWorktrees,
+  updateWorktreePendingState,
+} from "../../../worktrees";
+import type { ProjectLookups } from "./types";
+
+interface GitDeps {
+  projectsRef: MutableRefObject<ProjectsState>;
+  lookups: ProjectLookups;
+  syncProjectsToState: () => void;
+  persistProjects: () => Promise<void>;
+  setActiveProjectById: (id: string) => boolean;
+  activateWorktree: (worktreeId: string | null) => void;
+}
+
+export function resolveWorktreeBaseBranch(
+  project: Project,
+  explicit?: string,
+): string {
+  const trimmed = explicit?.trim();
+  if (trimmed) return trimmed;
+  return project.worktreeBaseBranch?.trim() || DEFAULT_WORKTREE_BASE_BRANCH;
+}
+
+export function defaultWorktreePath(
+  projectPath: string,
+  branch: string,
+): string {
+  const safe = branch.replace(/[^a-z0-9._-]/gi, "-");
+  return `${projectPath.replace(/\/$/, "")}-${safe}`;
+}
+
+export function navigateToWorktree(
+  deps: Pick<
+    GitDeps,
+    "projectsRef" | "setActiveProjectById" | "activateWorktree"
+  >,
+  projectId: string,
+  worktreeId: string,
+): void {
+  if (deps.projectsRef.current.activeId !== projectId) {
+    deps.setActiveProjectById(projectId);
+  }
+  deps.projectsRef.current = setProjectUiExpanded(
+    deps.projectsRef.current,
+    projectId,
+    true,
+  );
+  deps.activateWorktree(worktreeId);
+}
+
+export async function refreshProjectWorktrees(
+  deps: Pick<GitDeps, "projectsRef" | "lookups" | "persistProjects">,
+  projectId: string,
+): Promise<void> {
+  const project = deps.lookups.findProject(projectId);
+  if (!project) return;
+  try {
+    const listing = await gitWorktrees(project.path);
+    const prior = deps.projectsRef.current.worktreesByProject[projectId] ?? [];
+    const next = reconcileWorktrees(projectId, prior, listing);
+    let nextState = setProjectWorktrees(
+      deps.projectsRef.current,
+      projectId,
+      next,
+    );
+    const activeWorktreeId = nextState.activeWorktreeId;
+    if (
+      nextState.activeId === projectId &&
+      activeWorktreeId &&
+      !next.some((w) => w.id === activeWorktreeId)
+    ) {
+      nextState = { ...nextState, activeWorktreeId: null };
+    }
+    deps.projectsRef.current = nextState;
+    void deps.persistProjects();
+  } catch {
+    // Project may not be a git repo; keep the prior list intact.
+  }
+}
+
+export async function fetchBranches(
+  deps: Pick<GitDeps, "lookups">,
+  projectId: string,
+): Promise<string[]> {
+  const project = deps.lookups.findProject(projectId);
+  if (!project) return [];
+  try {
+    const list = await gitBranchList(project.path);
+    return list.map((b) => b.name);
+  } catch {
+    return [];
+  }
+}
+
+export async function createWorktreeForProject(
+  deps: GitDeps,
+  projectId: string,
+): Promise<void> {
+  const project = deps.lookups.findProject(projectId);
+  if (!project) return;
+  const taken = new Set<string>();
+  for (const w of deps.projectsRef.current.worktreesByProject[projectId] ??
+    []) {
+    if (w.branch) taken.add(w.branch);
+    if (w.label) taken.add(w.label);
+  }
+  try {
+    const branches = await gitBranchList(project.path);
+    for (const b of branches) taken.add(b.name);
+  } catch {
+    // Branch list failed; random naming remains good enough.
+  }
+  const branch = pickWorktreeName(taken);
+  await createWorktreeWithParams(deps, { projectId, branch });
+}
+
+export async function createWorktreeWithParams(
+  deps: GitDeps,
+  opts: {
+    projectId: string;
+    branch: string;
+    targetPath?: string;
+    baseBranch?: string;
+  },
+): Promise<string | null> {
+  const project = deps.lookups.findProject(opts.projectId);
+  if (!project) return null;
+  const branch = opts.branch.trim();
+  if (!branch) return null;
+  const targetPath =
+    opts.targetPath?.trim() || defaultWorktreePath(project.path, branch);
+  const pending = newPendingWorktree(opts.projectId, branch, targetPath);
+  const baseBranch = resolveWorktreeBaseBranch(project, opts.baseBranch);
+  const before =
+    deps.projectsRef.current.worktreesByProject[opts.projectId] ?? [];
+  deps.projectsRef.current = setProjectWorktrees(
+    deps.projectsRef.current,
+    opts.projectId,
+    [...before, pending],
+  );
+  deps.syncProjectsToState();
+  deps.projectsRef.current = setProjectWorktrees(
+    deps.projectsRef.current,
+    opts.projectId,
+    updateWorktreePendingState(
+      deps.projectsRef.current.worktreesByProject[opts.projectId] ?? [],
+      pending.id,
+      "starting",
+    ),
+  );
+  deps.syncProjectsToState();
+  try {
+    const created = await gitWorktreeAdd({
+      projectPath: project.path,
+      targetPath,
+      branch,
+      base: baseBranch,
+    });
+    deps.projectsRef.current = setProjectWorktrees(
+      deps.projectsRef.current,
+      opts.projectId,
+      updateWorktreePendingState(
+        deps.projectsRef.current.worktreesByProject[opts.projectId] ?? [],
+        pending.id,
+        "succeeded",
+      ),
+    );
+    await refreshProjectWorktrees(deps, opts.projectId);
+    const list =
+      deps.projectsRef.current.worktreesByProject[opts.projectId] ?? [];
+    const live = list.find(
+      (w) =>
+        w.id === pending.id ||
+        w.path === created.path ||
+        w.path === targetPath,
+    );
+    navigateToWorktree(deps, opts.projectId, live?.id ?? pending.id);
+    return live?.path ?? created.path ?? targetPath;
+  } catch (err) {
+    deps.projectsRef.current = setProjectWorktrees(
+      deps.projectsRef.current,
+      opts.projectId,
+      updateWorktreePendingState(
+        deps.projectsRef.current.worktreesByProject[opts.projectId] ?? [],
+        pending.id,
+        "failed",
+        String(err),
+      ),
+    );
+    deps.syncProjectsToState();
+    return null;
+  }
+}
+
+export async function retryPendingWorktree(
+  deps: GitDeps & { dismissPendingWorktree: (worktreeId: string) => void },
+  worktreeId: string,
+): Promise<void> {
+  const hit = deps.lookups.findProjectOfWorktree(worktreeId);
+  if (!hit || !hit.worktree.branch) return;
+  deps.dismissPendingWorktree(worktreeId);
+  const pending = newPendingWorktree(
+    hit.project.id,
+    hit.worktree.branch,
+    hit.worktree.path,
+  );
+  deps.projectsRef.current = setProjectWorktrees(
+    deps.projectsRef.current,
+    hit.project.id,
+    [
+      ...(deps.projectsRef.current.worktreesByProject[hit.project.id] ?? []),
+      pending,
+    ],
+  );
+  deps.syncProjectsToState();
+  deps.projectsRef.current = setProjectWorktrees(
+    deps.projectsRef.current,
+    hit.project.id,
+    updateWorktreePendingState(
+      deps.projectsRef.current.worktreesByProject[hit.project.id] ?? [],
+      pending.id,
+      "starting",
+    ),
+  );
+  deps.syncProjectsToState();
+  try {
+    await gitWorktreeAdd({
+      projectPath: hit.project.path,
+      targetPath: hit.worktree.path,
+      branch: hit.worktree.branch,
+      base: resolveWorktreeBaseBranch(hit.project),
+    });
+    deps.projectsRef.current = setProjectWorktrees(
+      deps.projectsRef.current,
+      hit.project.id,
+      updateWorktreePendingState(
+        deps.projectsRef.current.worktreesByProject[hit.project.id] ?? [],
+        pending.id,
+        "succeeded",
+      ),
+    );
+    await refreshProjectWorktrees(deps, hit.project.id);
+    const list =
+      deps.projectsRef.current.worktreesByProject[hit.project.id] ?? [];
+    const live = list.find(
+      (w) => w.id === pending.id || w.path === hit.worktree.path,
+    );
+    navigateToWorktree(deps, hit.project.id, live?.id ?? pending.id);
+  } catch (err) {
+    deps.projectsRef.current = setProjectWorktrees(
+      deps.projectsRef.current,
+      hit.project.id,
+      updateWorktreePendingState(
+        deps.projectsRef.current.worktreesByProject[hit.project.id] ?? [],
+        pending.id,
+        "failed",
+        String(err),
+      ),
+    );
+    deps.syncProjectsToState();
+  }
+}
+
+export type { GitDeps };

--- a/src/hooks/projectOps/worktreeOps/lookups.ts
+++ b/src/hooks/projectOps/worktreeOps/lookups.ts
@@ -1,0 +1,28 @@
+import type { MutableRefObject } from "react";
+import type { Project, ProjectsState } from "../../../projects";
+import type { Worktree } from "../../../worktrees";
+import type { ProjectLookups } from "./types";
+
+export function makeProjectLookups(
+  projectsRef: MutableRefObject<ProjectsState>,
+): ProjectLookups {
+  function findProject(id: string): Project | null {
+    return projectsRef.current.projects.find((p) => p.id === id) ?? null;
+  }
+
+  function findProjectOfWorktree(
+    worktreeId: string,
+  ): { project: Project; worktree: Worktree } | null {
+    const wbp = projectsRef.current.worktreesByProject;
+    for (const [pid, list] of Object.entries(wbp)) {
+      const wt = list.find((w) => w.id === worktreeId);
+      if (wt) {
+        const project = findProject(pid);
+        if (project) return { project, worktree: wt };
+      }
+    }
+    return null;
+  }
+
+  return { findProject, findProjectOfWorktree };
+}

--- a/src/hooks/projectOps/worktreeOps/prompts.ts
+++ b/src/hooks/projectOps/worktreeOps/prompts.ts
@@ -1,0 +1,30 @@
+// Worktree-removal UX prompts. Kept as window.confirm / window.alert
+// to preserve existing behavior; the host renderer does not yet have a
+// confirm-dialog wired through useNotifications for these flows. A
+// follow-up issue tracks swapping to the project's notification +
+// AskUserConfirm pattern.
+
+export function alertCannotRemoveMain(): void {
+  window.alert("Cannot remove the main worktree");
+}
+
+export function confirmRemoveWorktree(label: string): boolean {
+  return window.confirm(`Remove worktree '${label}'?`);
+}
+
+export function confirmForceRemove(message: string): boolean {
+  return window.confirm(
+    `${message}\n\nForce-remove anyway? Uncommitted changes will be lost.`,
+  );
+}
+
+export function confirmOrphanCleanup(): boolean {
+  return window.confirm(
+    `Aethon has this worktree but git no longer tracks it. ` +
+      `Remove the leftover folder and forget the entry?`,
+  );
+}
+
+export function alertFailure(message: string): void {
+  window.alert(`Failed: ${message}`);
+}

--- a/src/hooks/projectOps/worktreeOps/remove.ts
+++ b/src/hooks/projectOps/worktreeOps/remove.ts
@@ -1,0 +1,108 @@
+import type { MutableRefObject } from "react";
+import type { ProjectsState } from "../../../projects";
+import {
+  gitWorktreeRemove,
+  gitWorktreeRemoveOrphan,
+} from "../../../worktrees";
+import {
+  alertCannotRemoveMain,
+  alertFailure,
+  confirmForceRemove,
+  confirmOrphanCleanup,
+  confirmRemoveWorktree,
+} from "./prompts";
+import { applyWorktreeRemoval } from "./state";
+import { closeTabsForRemovedWorktree } from "./tabCleanup";
+import type { ProjectLookups, WorktreeOperationDeps } from "./types";
+
+interface RemoveDeps {
+  projectsRef: MutableRefObject<ProjectsState>;
+  lookups: ProjectLookups;
+  syncProjectsToState: () => void;
+  persistProjects: () => Promise<void>;
+  tabCleanupDeps: {
+    stateRef: WorktreeOperationDeps["stateRef"];
+    tabBucketsRef: WorktreeOperationDeps["tabBucketsRef"];
+    syncRecentSessionsToState: WorktreeOperationDeps["syncRecentSessionsToState"];
+    closeTabNow: WorktreeOperationDeps["closeTabNow"];
+    activateWorktree: (worktreeId: string | null) => void;
+  };
+}
+
+export async function removeWorktreeById(
+  deps: RemoveDeps,
+  worktreeId: string,
+  opts: { confirmed?: boolean } = {},
+): Promise<void> {
+  const hit = deps.lookups.findProjectOfWorktree(worktreeId);
+  if (!hit) return;
+  const { project, worktree } = hit;
+  if (worktree.isMain) {
+    alertCannotRemoveMain();
+    return;
+  }
+  const label = worktree.label ?? worktree.branch ?? "worktree";
+  if (opts.confirmed !== true) {
+    if (!confirmRemoveWorktree(label)) return;
+  }
+
+  const applyRemoval = (): void => {
+    closeTabsForRemovedWorktree(
+      deps.tabCleanupDeps,
+      project.id,
+      worktreeId,
+      worktree.path,
+      deps.projectsRef.current.activeWorktreeId === worktreeId,
+    );
+    applyWorktreeRemoval(
+      {
+        projectsRef: deps.projectsRef,
+        syncProjectsToState: deps.syncProjectsToState,
+        persistProjects: deps.persistProjects,
+      },
+      project.id,
+      worktreeId,
+    );
+  };
+
+  try {
+    await gitWorktreeRemove({
+      projectPath: project.path,
+      worktreePath: worktree.path,
+      force: false,
+    });
+    applyRemoval();
+  } catch (err) {
+    const msg = String(err);
+    if (msg.includes("dirty") || msg.includes("modified")) {
+      if (!confirmForceRemove(msg)) return;
+      try {
+        await gitWorktreeRemove({
+          projectPath: project.path,
+          worktreePath: worktree.path,
+          force: true,
+        });
+        applyRemoval();
+        return;
+      } catch (e2) {
+        alertFailure(String(e2));
+        return;
+      }
+    }
+    if (msg.includes("worktree not tracked")) {
+      if (!confirmOrphanCleanup()) return;
+      try {
+        await gitWorktreeRemoveOrphan({
+          projectPath: project.path,
+          worktreePath: worktree.path,
+        });
+        applyRemoval();
+        return;
+      } catch (e2) {
+        alertFailure(String(e2));
+        return;
+      }
+    }
+    alertFailure(msg);
+  }
+}

--- a/src/hooks/projectOps/worktreeOps/state.ts
+++ b/src/hooks/projectOps/worktreeOps/state.ts
@@ -1,0 +1,225 @@
+import type { MutableRefObject } from "react";
+import {
+  activeProject,
+  setActiveWorktree as setActiveWorktreeState,
+  setProjectIconUrl as setProjectIconUrlState,
+  setProjectUiExpanded,
+  setProjectWorktreeBaseBranch as setProjectWorktreeBaseBranchState,
+  setProjectWorktrees,
+  type ProjectsState,
+} from "../../../projects";
+import {
+  removeWorktreeFromList,
+  type Worktree,
+} from "../../../worktrees";
+import { projectScopeBucketKey } from "../tabBuckets";
+import { swapProjectWatch } from "./bridgeWatch";
+import type { ProjectLookups } from "./types";
+
+interface StateMutationDeps {
+  projectsRef: MutableRefObject<ProjectsState>;
+  syncProjectsToState: () => void;
+  persistProjects: () => Promise<void>;
+  scheduleProjectsSave: (delayMs?: number) => void;
+}
+
+interface ActivateWorktreeDeps extends StateMutationDeps {
+  lookups: ProjectLookups;
+  switchProjectBucket: (
+    fromKey: string,
+    toKey: string,
+    opts?: { mirrorProjects?: boolean },
+  ) => string | undefined;
+  announceProjectToBridge: (tabId: string, path: string | null) => void;
+  watchProjectForBridge: (path: string) => void;
+  unwatchProjectForBridge: (path: string) => void;
+}
+
+interface RefreshDeps extends StateMutationDeps {
+  lookups: ProjectLookups;
+}
+
+export function setProjectExpanded(
+  deps: StateMutationDeps & { onFirstExpand: (projectId: string) => void },
+  projectId: string,
+  expanded: boolean,
+): void {
+  deps.projectsRef.current = setProjectUiExpanded(
+    deps.projectsRef.current,
+    projectId,
+    expanded,
+  );
+  if (expanded && !deps.projectsRef.current.worktreesByProject[projectId]) {
+    deps.onFirstExpand(projectId);
+  }
+  deps.syncProjectsToState();
+  deps.scheduleProjectsSave();
+}
+
+export function setProjectIconUrl(
+  deps: Pick<StateMutationDeps, "projectsRef" | "persistProjects">,
+  projectId: string,
+  iconUrl: string | null,
+): void {
+  const next = setProjectIconUrlState(
+    deps.projectsRef.current,
+    projectId,
+    iconUrl,
+  );
+  if (next === deps.projectsRef.current) return;
+  deps.projectsRef.current = next;
+  void deps.persistProjects();
+}
+
+export function activateWorktree(
+  deps: ActivateWorktreeDeps,
+  worktreeId: string | null,
+): void {
+  const current = deps.projectsRef.current;
+  if (current.activeWorktreeId === worktreeId) return;
+  const fromKey = projectScopeBucketKey(
+    current.activeId,
+    current.activeWorktreeId,
+  );
+  let activeProjectId = current.activeId;
+  let nextCwd: string | null;
+  let nextProjectPath: string | null;
+  if (worktreeId) {
+    const hit = deps.lookups.findProjectOfWorktree(worktreeId);
+    if (!hit) return;
+    activeProjectId = hit.project.id;
+    nextCwd = hit.worktree.path;
+    nextProjectPath = hit.project.path;
+  } else {
+    const project = activeProject(current);
+    nextCwd = project?.path ?? null;
+    nextProjectPath = project?.path ?? null;
+  }
+  const previousActive = activeProject(current);
+  const crossingProjects =
+    activeProjectId !== current.activeId &&
+    previousActive != null &&
+    nextProjectPath !== null &&
+    previousActive.path !== nextProjectPath;
+  deps.projectsRef.current = setActiveWorktreeState(
+    { ...current, activeId: activeProjectId },
+    worktreeId,
+  );
+  const nextTabId = deps.switchProjectBucket(
+    fromKey,
+    projectScopeBucketKey(activeProjectId, worktreeId),
+    { mirrorProjects: true },
+  );
+  deps.scheduleProjectsSave();
+  deps.announceProjectToBridge(nextTabId ?? "default", nextCwd);
+  if (crossingProjects) {
+    swapProjectWatch(previousActive, nextProjectPath, {
+      watchProjectForBridge: deps.watchProjectForBridge,
+      unwatchProjectForBridge: deps.unwatchProjectForBridge,
+    });
+  }
+}
+
+export function dismissPendingWorktree(
+  deps: Pick<StateMutationDeps, "projectsRef" | "persistProjects"> & {
+    lookups: ProjectLookups;
+  },
+  worktreeId: string,
+): void {
+  const hit = deps.lookups.findProjectOfWorktree(worktreeId);
+  if (!hit) return;
+  const list = removeWorktreeFromList(
+    deps.projectsRef.current.worktreesByProject[hit.project.id] ?? [],
+    worktreeId,
+  );
+  deps.projectsRef.current = setProjectWorktrees(
+    deps.projectsRef.current,
+    hit.project.id,
+    list,
+  );
+  void deps.persistProjects();
+}
+
+export function renameWorktree(
+  deps: Pick<StateMutationDeps, "projectsRef" | "persistProjects"> & {
+    lookups: ProjectLookups;
+  },
+  worktreeId: string,
+  label: string,
+): void {
+  const hit = deps.lookups.findProjectOfWorktree(worktreeId);
+  if (!hit) return;
+  const trimmed = label.trim();
+  const next: Worktree[] = (
+    deps.projectsRef.current.worktreesByProject[hit.project.id] ?? []
+  ).map((w) =>
+    w.id === worktreeId
+      ? { ...w, label: trimmed.length > 0 ? trimmed : undefined }
+      : w,
+  );
+  deps.projectsRef.current = setProjectWorktrees(
+    deps.projectsRef.current,
+    hit.project.id,
+    next,
+  );
+  void deps.persistProjects();
+}
+
+export function renameProject(
+  deps: Pick<StateMutationDeps, "projectsRef" | "persistProjects">,
+  projectId: string,
+  label: string,
+): void {
+  const trimmed = label.trim();
+  if (!trimmed) return;
+  const ps = deps.projectsRef.current;
+  deps.projectsRef.current = {
+    ...ps,
+    projects: ps.projects.map((p) =>
+      p.id === projectId ? { ...p, label: trimmed } : p,
+    ),
+  };
+  void deps.persistProjects();
+}
+
+export function setProjectWorktreeBaseBranch(
+  deps: Pick<StateMutationDeps, "projectsRef" | "persistProjects">,
+  projectId: string,
+  baseBranch: string | null,
+): void {
+  const next = setProjectWorktreeBaseBranchState(
+    deps.projectsRef.current,
+    projectId,
+    baseBranch,
+  );
+  if (next === deps.projectsRef.current) return;
+  deps.projectsRef.current = next;
+  void deps.persistProjects();
+}
+
+/**
+ * Apply a removed-worktree state snapshot (drop the row, sync mirror,
+ * persist). Used by remove flows after the git operation succeeds.
+ */
+export function applyWorktreeRemoval(
+  deps: Pick<
+    StateMutationDeps,
+    "projectsRef" | "syncProjectsToState" | "persistProjects"
+  >,
+  projectId: string,
+  worktreeId: string,
+): void {
+  const list = removeWorktreeFromList(
+    deps.projectsRef.current.worktreesByProject[projectId] ?? [],
+    worktreeId,
+  );
+  deps.projectsRef.current = setProjectWorktrees(
+    deps.projectsRef.current,
+    projectId,
+    list,
+  );
+  deps.syncProjectsToState();
+  void deps.persistProjects();
+}
+
+export { type StateMutationDeps, type ActivateWorktreeDeps, type RefreshDeps };

--- a/src/hooks/projectOps/worktreeOps/tabCleanup.ts
+++ b/src/hooks/projectOps/worktreeOps/tabCleanup.ts
@@ -1,0 +1,66 @@
+import type { MutableRefObject } from "react";
+import type { Tab } from "../../../types/tab";
+import { normalizeSessionPath, projectScopeBucketKey } from "../tabBuckets";
+import type { TabBucket } from "../types";
+
+interface TabCleanupDeps {
+  stateRef: MutableRefObject<Record<string, unknown>>;
+  tabBucketsRef: MutableRefObject<Map<string, TabBucket>>;
+  syncRecentSessionsToState: () => void;
+  closeTabNow: (tabId: string) => void;
+  activateWorktree: (worktreeId: string | null) => void;
+}
+
+function tabCwdMatches(tab: Tab, path: string): boolean {
+  if (tab.kind !== "agent") return false;
+  return normalizeSessionPath(tab.cwd) === normalizeSessionPath(path);
+}
+
+function removeStoredTabsForWorktreePath(
+  tabBucketsRef: MutableRefObject<Map<string, TabBucket>>,
+  path: string,
+  removedBucketKey: string,
+): void {
+  tabBucketsRef.current.delete(removedBucketKey);
+  for (const [key, bucket] of tabBucketsRef.current.entries()) {
+    const tabs = bucket.tabs.filter((tab) => !tabCwdMatches(tab, path));
+    if (tabs.length === bucket.tabs.length) continue;
+    if (tabs.length === 0) {
+      tabBucketsRef.current.delete(key);
+      continue;
+    }
+    const activeTabId = tabs.some((tab) => tab.id === bucket.activeTabId)
+      ? bucket.activeTabId
+      : tabs[0]?.id;
+    tabBucketsRef.current.set(key, { tabs, activeTabId });
+  }
+}
+
+function closeVisibleTabsForWorktreePath(
+  stateRef: MutableRefObject<Record<string, unknown>>,
+  closeTabNow: (tabId: string) => void,
+  path: string,
+): void {
+  const tabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
+  const closing = tabs
+    .filter((tab) => tabCwdMatches(tab, path))
+    .map((tab) => tab.id);
+  for (const tabId of closing) closeTabNow(tabId);
+}
+
+export function closeTabsForRemovedWorktree(
+  deps: TabCleanupDeps,
+  projectId: string,
+  worktreeId: string,
+  path: string,
+  wasActive: boolean,
+): void {
+  closeVisibleTabsForWorktreePath(deps.stateRef, deps.closeTabNow, path);
+  if (wasActive) deps.activateWorktree(null);
+  removeStoredTabsForWorktreePath(
+    deps.tabBucketsRef,
+    path,
+    projectScopeBucketKey(projectId, worktreeId),
+  );
+  deps.syncRecentSessionsToState();
+}

--- a/src/hooks/projectOps/worktreeOps/types.ts
+++ b/src/hooks/projectOps/worktreeOps/types.ts
@@ -1,0 +1,61 @@
+import type { MutableRefObject } from "react";
+import type { Project, ProjectsState } from "../../../projects";
+import type { Worktree } from "../../../worktrees";
+import type { TabBucket } from "../types";
+
+export interface WorktreeOperationDeps {
+  projectsRef: MutableRefObject<ProjectsState>;
+  stateRef: MutableRefObject<Record<string, unknown>>;
+  tabBucketsRef: MutableRefObject<Map<string, TabBucket>>;
+  syncProjectsToState: () => void;
+  persistProjects: () => Promise<void>;
+  scheduleProjectsSave: (delayMs?: number) => void;
+  syncRecentSessionsToState: () => void;
+  switchProjectBucket: (
+    fromKey: string,
+    toKey: string,
+    opts?: { mirrorProjects?: boolean },
+  ) => string | undefined;
+  setActiveProjectById: (id: string) => boolean;
+  announceProjectToBridge: (tabId: string, path: string | null) => void;
+  watchProjectForBridge: (path: string) => void;
+  unwatchProjectForBridge: (path: string) => void;
+  closeTabNow: (tabId: string) => void;
+}
+
+export interface WorktreeOperations {
+  setProjectExpanded: (projectId: string, expanded: boolean) => void;
+  setProjectIconUrl: (projectId: string, iconUrl: string | null) => void;
+  refreshProjectWorktrees: (projectId: string) => Promise<void>;
+  activateWorktree: (worktreeId: string | null) => void;
+  createWorktreeForProject: (projectId: string) => Promise<void>;
+  createWorktreeWithParams: (opts: {
+    projectId: string;
+    branch: string;
+    targetPath?: string;
+    baseBranch?: string;
+  }) => Promise<string | null>;
+  removeWorktreeById: (
+    worktreeId: string,
+    opts?: { confirmed?: boolean },
+  ) => Promise<void>;
+  dismissPendingWorktree: (worktreeId: string) => void;
+  retryPendingWorktree: (worktreeId: string) => Promise<void>;
+  renameWorktree: (worktreeId: string, label: string) => void;
+  fetchBranches: (projectId: string) => Promise<string[]>;
+  renameProject: (projectId: string, label: string) => void;
+  setProjectWorktreeBaseBranch: (
+    projectId: string,
+    baseBranch: string | null,
+  ) => void;
+  findProjectOfWorktree: (
+    worktreeId: string,
+  ) => { project: Project; worktree: Worktree } | null;
+}
+
+export interface ProjectLookups {
+  findProject: (id: string) => Project | null;
+  findProjectOfWorktree: (
+    worktreeId: string,
+  ) => { project: Project; worktree: Worktree } | null;
+}


### PR DESCRIPTION
## Summary

`src/hooks/projectOps/worktreeOperations.ts` (638 LOC) mixed git worktree
operations, project state mutation, tab cleanup, persistence, bridge
watch updates, and `window.confirm` / `window.alert` UX. Following the
precedent in #114-#118, the file becomes a thin facade hook over
single-concern submodules under `src/hooks/projectOps/worktreeOps/`.

Public surface is unchanged: `useWorktreeOperations`, `WorktreeOperations`,
and `WorktreeOperationDeps` all remain importable from
`./worktreeOperations`. The sole consumer (`useProjectOps.ts`) is
untouched.

## Structure

| File | LOC | Concern |
| --- | --: | --- |
| `worktreeOps/types.ts` | 61 | Shared interfaces (`WorktreeOperationDeps`, `WorktreeOperations`, `ProjectLookups`) |
| `worktreeOps/lookups.ts` | 28 | `findProject` / `findProjectOfWorktree` over `projectsRef` |
| `worktreeOps/prompts.ts` | 30 | `window.confirm` / `window.alert` wrappers (preserved as-is) |
| `worktreeOps/bridgeWatch.ts` | 22 | `swapProjectWatch` cross-project file-watch handoff |
| `worktreeOps/tabCleanup.ts` | 66 | Close + drop tabs scoped to a removed worktree |
| `worktreeOps/state.ts` | 225 | Pure state mutations (`activateWorktree`, `setProjectExpanded`, `renameWorktree`, `setProjectWorktreeBaseBranch`, `dismissPendingWorktree`, `applyWorktreeRemoval`, ...) |
| `worktreeOps/git.ts` | 278 | Git command wrappers + orchestration (`refreshProjectWorktrees`, `createWorktreeForProject`, `createWorktreeWithParams`, `retryPendingWorktree`, `fetchBranches`, helpers) |
| `worktreeOps/remove.ts` | 108 | `removeWorktreeById` orchestrator (composes git + prompts + tabCleanup + state) |
| `worktreeOperations.ts` (facade) | 158 | `useWorktreeOperations` hook composing the submodules |

Before: 638 LOC in one file. After: 158-LOC facade + 7 submodules
(818 LOC total in the new directory). The growth is the cost of narrow
per-module `Deps` interfaces and explicit composition.

## Public-surface guarantee

`src/hooks/projectOps/worktreeOperations.ts` continues to export:

- `useWorktreeOperations(deps): WorktreeOperations` — the factory hook
- `type WorktreeOperationDeps` — re-exported from `worktreeOps/types`
- `type WorktreeOperations` — re-exported from `worktreeOps/types`

The single consumer, `src/hooks/useProjectOps.ts`, imports
`useWorktreeOperations` from `./projectOps/worktreeOperations` and is
unchanged.

## Design notes

- Each submodule has a narrow `Deps` interface — only the slice it
  actually reads or mutates. `state.ts` mutations don't see
  `closeTabNow`; `git.ts` orchestrations don't see `stateRef`;
  `remove.ts` carries a focused `tabCleanupDeps` subgroup.
- `removeWorktreeById` stays as a single orchestrator in `remove.ts`
  because the dirty-worktree / orphaned-worktree branches all share the
  same post-success cleanup (`applyRemoval`). Splitting per error path
  would duplicate the close+drop+persist sequence.
- `activateWorktree` lives in `state.ts` because it is fundamentally a
  state mutation + bucket switch. `bridgeWatch.swapProjectWatch` is its
  only side-effect outside the projects ref.
- `retryPendingWorktree` calls the bound `dismissPendingWorktree` from
  the facade to preserve the exact behavior of the original (clear row,
  re-add through the pending state machine).
- **`window.confirm` / `window.alert` is preserved as-is** in
  `prompts.ts`. The project's `useNotifications` + `AskUserConfirm`
  pattern would be a better fit, but swapping it is a behavior change
  and out of scope for this pure refactor. Filed for follow-up.

## Verification

Run from the worktree:

- [x] `bunx tsc --noEmit` — clean
- [x] `bunx eslint src/` — 0 errors, 5 warnings (pre-existing baseline; no new warnings introduced)
- [x] `bunx vitest run` — 148 files, 1124 / 1124 tests passing
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib` — 158 / 158
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings` — clean
- [x] `treefmt` — clean (one unrelated CHANGELOG re-flow reverted)

## Test plan

- [ ] Open a project with at least one attached worktree from the sidebar
- [ ] Add a new worktree (random name) and confirm pending → succeeded state and auto-navigation
- [ ] Add a worktree with explicit branch + base via the task-launcher composer
- [ ] Remove a worktree from the sidebar context menu → confirm prompt, tab cleanup runs, projects.json persists, bridge watch swaps to the remaining active project
- [ ] Force-remove a dirty worktree (modify a file inside it first) → confirm the secondary prompt
- [ ] Rename a worktree label inline → persists to projects.json
- [ ] Retry a failed pending worktree (point at an invalid base branch first) → pending row re-enters the state machine