### PR TITLE
fix(updater): stop UpdateBanner floating over the title bar + tab strip

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -765,25 +765,25 @@ export default function App() {
   } = useDerivedRenderState({ state, buildSidebarHistory, hostInfo });
 
   return (
-    <>
-      <UpdateBanner
-        state={updaterState}
-        onInstallNow={installNow}
-        onDismiss={dismiss}
-        onRetry={retryInstall}
-      />
-      <AppRoot
-        registry={registry}
-        layout={layout}
-        renderState={renderState}
-        setState={setState}
-        onEvent={onEvent}
-        activeTabId={state.activeTabId as string | undefined}
-        notificationsOpen={notificationsOpen}
-        paletteOpen={paletteOpen}
-        settingsOpen={settingsOpen}
-        searchOpen={searchOpen}
-      />
-    </>
+    <AppRoot
+      registry={registry}
+      layout={layout}
+      renderState={renderState}
+      setState={setState}
+      onEvent={onEvent}
+      activeTabId={state.activeTabId as string | undefined}
+      notificationsOpen={notificationsOpen}
+      paletteOpen={paletteOpen}
+      settingsOpen={settingsOpen}
+      searchOpen={searchOpen}
+      topBanner={
+        <UpdateBanner
+          state={updaterState}
+          onInstallNow={installNow}
+          onDismiss={dismiss}
+          onRetry={retryInstall}
+        />
+      }
+    />
   );
 }

--- a/src/app/AppRoot.tsx
+++ b/src/app/AppRoot.tsx
@@ -1,4 +1,4 @@
-import type { Dispatch, SetStateAction } from "react";
+import type { Dispatch, ReactNode, SetStateAction } from "react";
 import A2UIRenderer, {
   RegistryComponent,
   type A2UIEventHandler,
@@ -18,6 +18,10 @@ export interface AppRootProps {
   paletteOpen: boolean;
   settingsOpen: boolean;
   searchOpen: boolean;
+  /** Optional banner row rendered above the layout. Sits in flow as the
+   *  first flex child of `.app` so it pushes the rest of the chrome
+   *  down instead of floating over it. */
+  topBanner?: ReactNode;
 }
 
 /** App-root render. The four overlays mount through `RegistryComponent`
@@ -38,10 +42,12 @@ export function AppRoot({
   paletteOpen,
   settingsOpen,
   searchOpen,
+  topBanner,
 }: AppRootProps) {
   return (
     <SkillRegistryProvider registry={registry}>
       <div className="app">
+        {topBanner}
         <A2UIRenderer
           payload={layout}
           state={renderState}

--- a/src/components/UpdateBanner.module.css
+++ b/src/components/UpdateBanner.module.css
@@ -1,26 +1,21 @@
 .banner {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  z-index: 4000;
+  flex: 0 0 auto;
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  padding: 0.5rem 0.9rem;
+  padding: 0.4rem 0.9rem;
   background: var(
     --update-banner-bg,
-    var(--surface-2, color-mix(in srgb, var(--accent) 12%, transparent))
+    color-mix(in srgb, var(--accent) 14%, var(--surface-2, transparent))
   );
   color: var(--update-banner-fg, var(--text, currentColor));
   border-bottom: 1px solid
     var(
       --update-banner-border,
-      color-mix(in srgb, var(--accent) 25%, transparent)
+      color-mix(in srgb, var(--accent) 30%, transparent)
     );
   font-size: 0.85rem;
   line-height: 1.3;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
   -webkit-app-region: no-drag;
 }
 
@@ -36,8 +31,9 @@
 }
 
 .version {
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
   font-weight: 600;
-  letter-spacing: 0.02em;
+  letter-spacing: 0;
 }
 
 .actions {


### PR DESCRIPTION
## Summary

UpdateBanner used `position: fixed; top: 0`, so when an update was pending it floated on top of the first row of webview content — overlapping the title-bar label, the tab strip, and the right-hand sidebar header. Install/Dismiss landed on top of sidebar items.

## Fix

Move `<UpdateBanner>` INTO `.app` as the first flex child via a new `topBanner` prop on `AppRoot`. `.app` is already a flex column at the webview height, so the banner takes its natural row and pushes everything below it down — no overlap, no second flex shell, no `--app-viewport-height` math.

When no update is pending, `<UpdateBanner>` returns `null` and the tree is identical to before.

Also polished while in here:
- Dropped `position: fixed` / `top` / `left` / `right` / `z-index` / `box-shadow`.
- Tightened vertical padding (0.5rem → 0.4rem) so the row reads as chrome, not a hero callout.
- Version string in monospace so long nightly hashes (`v0.4.0-dev.44.gcb7f0a0`) read as tokens, not prose.

## Before

User screenshot showed banner text "Aethon Nightly v0.4.0-dev.44.gcb7f0a0 is available" overlapping with the macOS title "Aethon" and the tab strip's "v0.4.0-dev.43.gf29fb07", with Install Now / Dismiss buttons sitting on top of the sidebar's ".aethon" folder header.

## Test plan

- [ ] CI green (tsc + eslint + vitest + clippy + cargo test + e2e)
- [ ] After merge: trigger a nightly check, confirm banner sits ABOVE the tab strip in a clean row that pushes the rest of the layout down