### PR TITLE
docs: sync onboarding docs with current code + clean hero branding

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -24,7 +24,8 @@ even if the change otherwise looks correct.
    via `$ref` JSON Pointers; the renderer applies optimistic writes back
    to those paths. Do not split state across multiple stores or hooks.
 4. **Two registries, one rule.** The 19 primitives in
-   `PRIMITIVE_REGISTRY` (`src/components/builtins.tsx`) **cannot be
+   `PRIMITIVE_REGISTRY` (`src/components/A2UIRenderer.tsx`; primitive
+   components live under `src/components/primitives/`) **cannot be
    overridden** — everything else comes from `SkillRegistry`. New
    component types go on a skill, never into the primitive table.
 5. **Per-tab `cwd` is immutable.** Tabs keep the working directory they
@@ -34,7 +35,7 @@ even if the change otherwise looks correct.
    path that flips a shell tab's share mode. Adding an agent-callable
    setter defeats the opt-in security boundary.
 7. **Path-traversal guard on every filesystem command.** Any new command
-   in `src-tauri/src/commands/fs.rs` (or anywhere accepting a path) must
+   in `src-tauri/src/commands/fs/` (or anywhere accepting a path) must
    route through `helpers::resolve_inside_root` **and** canonicalize-then-
    recheck for symlinks. Skipping either layer is a security review block.
 8. **No `--no-verify`, `--no-gpg-sign`, or other hook-bypass flags** in
@@ -59,7 +60,7 @@ Spend review effort on, in order:
    instead of SIGKILL.
 4. **Test coverage on touch** — every module under `agent/` has a
    colocated `*.test.ts`; routes under `src/eventRoutes/` need a
-   happy-path test; new Rust helpers belong under `helpers.rs` with a
+   happy-path test; new Rust helpers belong under `helpers/` with a
    `#[cfg(test)] mod tests`.
 5. **Style / conventions** — Conventional Commits, two-space Nix indent,
    `import type { ... }` for type-only TS imports, no emojis in code or
@@ -85,7 +86,7 @@ Skip review comments on:
 A PR that adds or changes a keyboard shortcut **must** update all three:
 
 1. The webview handler in `src/hooks/useKeyboardShortcuts.ts`
-2. The native menu accelerator in `src-tauri/src/commands/extensions.rs`
+2. The native menu accelerator in `src-tauri/src/commands/extensions/app_menu.rs`
 3. The palette listing in `src/skills/default-layout/palette-items.ts`
    (`BUILTIN_KEYBINDINGS`)
 

--- a/.github/instructions/rust.instructions.md
+++ b/.github/instructions/rust.instructions.md
@@ -27,7 +27,7 @@ or agent logic — that work goes in TypeScript.
 
 ## Path safety
 
-Every command in `src-tauri/src/commands/fs.rs` (and any new path-taking
+Every command in `src-tauri/src/commands/fs/` (and any new path-taking
 command anywhere) **must** go through both gates:
 
 1. `helpers::resolve_inside_root` — lexical `..`-traversal check that
@@ -70,7 +70,8 @@ honours `EnvFilter` syntax (e.g. `aethon::agent_watch=debug`).
 
 ## Tests
 
-`cargo test --lib` runs unit tests under `helpers.rs` (`#[cfg(test)] mod tests`).
+`cargo test --lib` runs unit tests under `helpers/` (`#[cfg(test)] mod tests`
+in each submodule — `paths.rs`, `names.rs`, `config.rs`).
 Pure helper functions belong there. Tauri-command-shaped functions
 that orchestrate state need integration coverage via the JS-side
 debug skill, not Rust unit tests.

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -9,7 +9,7 @@ applyTo: "**/*.test.ts,**/*.test.tsx,**/tests.rs"
 - TS / TSX tests live colocated with the module under test
   (`agent/foo.ts` ↔ `agent/foo.test.ts`).
 - Rust tests live in `#[cfg(test)] mod tests` blocks inside the
-  module they cover (mostly `src-tauri/src/helpers.rs`).
+  module they cover (mostly `src-tauri/src/helpers/*.rs`).
 - New code that touches an existing module should add cases to the
   existing test file rather than creating a parallel `foo.spec.ts`
   alongside `foo.test.ts`.
@@ -57,7 +57,8 @@ Tests must not depend on:
 
 ## Rust tests
 
-- Pure helpers go under `helpers.rs` with their own `#[cfg(test)] mod tests`.
+- Pure helpers go under `helpers/` with their own `#[cfg(test)] mod tests`
+  inside each submodule (`paths.rs`, `names.rs`, `config.rs`).
 - Tauri-command-shaped functions that orchestrate state need
   integration coverage via the JS-side `aethon-debug` skill, not
   Rust unit tests — flag PRs that mock half the Tauri runtime to

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ devshell exposes these helpers (defined in `flake.nix`):
 | Command     | What it does                                                                  |
 | ----------- | ----------------------------------------------------------------------------- |
 | `dev`       | `scripts/dev.sh` → `cargo tauri dev` with port auto-increment                 |
+| `docs`      | `vitepress dev` from `website/` bound to `0.0.0.0` (LAN-reachable; :5173)     |
 | `build-app` | `cargo tauri build` — release bundle                                          |
 | `check`     | Full CI gate: clippy + tsc + ESLint + cargo test + vitest                     |
 | `lint`      | ESLint frontend + agent (no auto-fix)                                         |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -423,9 +423,11 @@ port in TXT, the other **browses** and emits Tauri events
 auth, no TLS** — this is explicit scaffolding for an upcoming pairing
 PR; do not lean on it for trusted IPC. `commands/server.rs` exposes
 `server_start` / `server_stop`; `commands/host.rs` surfaces discovered
-peers to the frontend. Gated by `[server] enabled` in `~/.aethon/config.toml`
-(defaults true). The browser keeps running with the advertiser off —
-discovery is read-only and useful in isolation.
+peers to the frontend. **No config gate today** — `boot()` spawns both
+HTTP and mDNS unconditionally during Tauri `setup()`; a `[server]
+enabled` toml flag is planned alongside the pairing PR but not wired
+yet. The browser keeps running with the advertiser off — discovery is
+read-only and useful in isolation.
 
 ### Agent runtime contract
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,14 +74,20 @@ new warnings as acceptable without addressing or justifying them.
 
 ### Layer responsibilities
 
-1. **Tauri shell** (`src-tauri/src/lib.rs` is now a thin entry — agent
-   supervisor + child IPC + `run()` builder; concern-grouped IPC commands
-   live under `src-tauri/src/commands/` (`config.rs`, `session.rs`,
-   `extensions.rs`, `git.rs`, `window.rs`, `fs.rs`); shell-tab PTY logic
-   lives under `src-tauri/src/shell/` (`lifecycle.rs`, `scrollback.rs`,
-   `sharemode.rs`); native window geometry persistence in
-   `window_state.rs`; pure helpers in `helpers.rs`; debug-only commands
-   - TCP eval server in `debug.rs` gated by `#[cfg(debug_assertions)]`)
+1. **Tauri shell** (`src-tauri/src/lib.rs` is a thin entry — `run()`
+   builder + plugin/state registration; the agent supervisor lives in
+   `src-tauri/src/agent_process/` (`AgentProcesses` managed state, plus
+   `spawn`/`readers`/`sidecar`); concern-grouped IPC commands live under
+   `src-tauri/src/commands/`: `boot.rs`, `config.rs`, `extensions/`,
+   `fs/`, `git/`, `host.rs`, `server.rs`, `session.rs`, `updater.rs`,
+   `window.rs`; shell-tab PTY logic under `src-tauri/src/shell/`
+   (`lifecycle.rs`, `scrollback.rs`, `sharemode.rs`); native window
+   geometry persistence in `window_state/` (`schema`, `restore`, `save`,
+   `monitor_matching`, `migration`, `persistence`); pure helpers in
+   `helpers/` (`paths`, `names`, `config`); HTTP + mDNS discovery in
+   `server/` (`http.rs`, `mdns.rs` — see "Networked discovery" below);
+   debug-only TCP eval server in `debug.rs` gated by
+   `#[cfg(debug_assertions)]`)
      — owns the OS boundary. Core agent commands: `send_message`
      (forwards a chat string to the agent's stdin) and
      `dispatch_a2ui_event` (forwards a structured event). On the first
@@ -374,7 +380,8 @@ viewers) is implemented as a default-layout sub-skill under
 `src/skills/default-layout/editor/`. Monaco glue lives in `src/monaco/`
 (`editor-buffers.ts` manages models per file, `setup.ts` configures
 workers + languages, `theme.ts` syncs to the active Aethon theme).
-File-system operations go through `src-tauri/src/commands/fs.rs` — a
+File-system operations go through `src-tauri/src/commands/fs/`
+(`io`, `listing`, `open`, `security`, `trash`, `watch`) — a
 thin set of read/write/list/move/delete commands scoped to the active
 project's `cwd`. Two security layers gate every path: a lexical check
 (`helpers::resolve_inside_root`) catches `..` traversal without
@@ -385,7 +392,7 @@ to the OS trash via the `trash` crate, never `unlink`.
 
 ### Window state persistence
 
-`src-tauri/src/window_state.rs` saves window position, size, and
+`src-tauri/src/window_state/` saves window position, size, and
 `maximized` flag to `~/.aethon/window-state.json` (keyed by window
 label). Everything is stored in **logical** units — physical pixels
 aren't portable across monitors with different scale factors, so a
@@ -403,6 +410,21 @@ reachable. Fullscreen state is treated as transient and skipped on
 save. v0 (physical-unit) state files are migrated to v1 on first
 load. Spaces / virtual desktops aren't tracked — Tauri 2 doesn't
 expose a stable identifier.
+
+### Networked discovery (server/)
+
+`src-tauri/src/server/` is a Claudette-style scaffold daemon wired in
+`setup()` and torn down on exit. Two `mdns_sd::ServiceDaemon`s run side
+by side: one **advertises** `_aethon._tcp.local.` with the bound HTTP
+port in TXT, the other **browses** and emits Tauri events
+`host-discovered` / `host-removed`. An axum server binds `0.0.0.0:0`
+(OS picks the port) and exposes `GET /health` + `GET /status`. **No
+auth, no TLS** — this is explicit scaffolding for an upcoming pairing
+PR; do not lean on it for trusted IPC. `commands/server.rs` exposes
+`server_start` / `server_stop`; `commands/host.rs` surfaces discovered
+peers to the frontend. Gated by `[server] enabled` in `~/.aethon/config.toml`
+(defaults true). The browser keeps running with the advertiser off —
+discovery is read-only and useful in isolation.
 
 ### Agent runtime contract
 
@@ -463,8 +485,9 @@ share-mode-badge, shell-canvas) all dispatch by type as of #N.
 
 ### Hot-reload doesn't kill in-flight prompts
 
-The Rust file-watcher (`commands/extensions.rs::run_debounce_worker`)
-no longer SIGKILLs the bun child when an extension file changes.
+The Rust file-watcher (`commands/extensions/reload.rs::run_debounce_worker`,
+wired from `commands/extensions/watcher.rs`) no longer SIGKILLs the bun
+child when an extension file changes.
 Instead it writes `{"type":"reload_request"}` to the child's stdin.
 The bridge sets `state.reloadPending`, drains active
 `tab.promptInFlight`, writes a `{"type":"_reload_done"}` sentinel to
@@ -609,8 +632,8 @@ user confirmation, pi-tool registration of
 Settings UI overlay, fullscreen, search overlay, drag-and-drop into
 composer, bridge crash recovery, OS notifications. Post-M6: Monaco
 editor + file tree + media viewers (`src/skills/default-layout/editor/`,
-`src/monaco/`, `src-tauri/src/commands/fs.rs`), native window geometry
-persistence with multi-monitor restore (`src-tauri/src/window_state.rs`),
+`src/monaco/`, `src-tauri/src/commands/fs/`), native window geometry
+persistence with multi-monitor restore (`src-tauri/src/window_state/`),
 pi native slash commands plumbed through to the composer autocomplete,
 left-edge sidebar resize, Brink theme palette.
 Tool execution surfaces as A2UI cards, multi-tab persistent
@@ -648,11 +671,13 @@ in-app updater.
 | Tool                         | Scope                                                     | Devshell command |
 | ---------------------------- | --------------------------------------------------------- | ---------------- |
 | `cargo clippy -D warnings`   | Rust shell + helpers                                      | `check`          |
-| `cargo test --lib`           | Rust unit tests under `src-tauri/src/helpers.rs`          | `test`           |
+| `cargo test --lib`           | Rust unit tests under `src-tauri/src/helpers/`            | `test`           |
 | `bunx tsc -b --noEmit`       | TypeScript types (frontend + agent)                       | `check`          |
 | `bunx eslint .`              | TS + React lint, type-aware via tsconfig                  | `lint`           |
 | `bunx vitest run`            | TS unit tests (`src/**/*.test.ts` + `agent/**/*.test.ts`) | `test`           |
 | `bunx vitest run --coverage` | TS coverage report (v8)                                   | `coverage`       |
+| `bun run test:e2e`           | Playwright E2E (`e2e/aethon.spec.ts`); webview is mocked, tests run serial against a shared Vite dev server | —                |
+| `bun run version:check`      | Fail if `package.json` / `Cargo.toml` / `tauri.conf.json` drift (auto-runs before `bun run build`); fix with `bun run version:sync` | —                |
 
 The `check` devshell command runs all of the above as a single CI gate.
 ESLint is configured for **0 errors and 0 warnings**. A handful of `react-hooks`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,15 +27,16 @@ subprocess. Business logic belongs in the agent, not the shell.
 Run inside `nix develop` (direnv auto-activates via `.envrc`). Devshell
 helpers (defined in `flake.nix`):
 
-| Command     | What it does                                                  |
-| ----------- | ------------------------------------------------------------- |
-| `dev`       | `scripts/dev.sh` → `cargo tauri dev` with port auto-increment |
-| `build-app` | `cargo tauri build` — release bundle                          |
-| `check`     | CI gate: clippy + tsc + ESLint + cargo test + vitest          |
-| `lint`      | ESLint (no auto-fix)                                          |
-| `test`      | `cargo test --lib` + `bunx vitest run`                        |
-| `coverage`  | TS coverage report (vitest v8) → `coverage/`                  |
-| `fmt`       | treefmt (rustfmt + nixfmt + prettier + taplo)                 |
+| Command     | What it does                                                                |
+| ----------- | --------------------------------------------------------------------------- |
+| `dev`       | `scripts/dev.sh` → `cargo tauri dev` with port auto-increment               |
+| `docs`      | `vitepress dev` from `website/` bound to `0.0.0.0` (LAN-reachable; :5173)   |
+| `build-app` | `cargo tauri build` — release bundle                                        |
+| `check`     | CI gate: clippy + tsc + ESLint + cargo test + vitest                        |
+| `lint`      | ESLint (no auto-fix)                                                        |
+| `test`      | `cargo test --lib` + `bunx vitest run`                                      |
+| `coverage`  | TS coverage report (vitest v8) → `coverage/`                                |
+| `fmt`       | treefmt (rustfmt + nixfmt + prettier + taplo)                               |
 
 ESLint is configured for **0 errors and 0 warnings**.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,16 @@ Single tests:
 - TS by name: `bunx vitest run -t "test name pattern"`
 - Rust: `cargo test --lib -p aethon -- helpers::test_name`
 
+E2E (`bun run test:e2e`, see `e2e/aethon.spec.ts` + `playwright.config.ts`):
+the harness mocks one Tauri webview per test but shares a single Vite dev
+server, so tests run **serial** — a reload in one page can interrupt another.
+Set `VITE_PORT` to follow `scripts/dev.sh`'s chosen port.
+
+Version sync: `bun run build` runs `version:check` (`scripts/sync-version.mjs`)
+to keep `package.json` / `Cargo.toml` / `tauri.conf.json` aligned. Drift fails
+the build — run `bun run version:sync` to fix. `scripts/build-updater-manifest.sh`
+generates the updater JSON consumed by `useUpdater` (see release flow).
+
 `scripts/dev.sh` flags:
 
 - `dev --new` — sandbox launch under `${TMPDIR}/aethon-dev/new-<pid>/`
@@ -60,12 +70,16 @@ stays on. The `aethon-debug` skill reads `dev-info.json` to follow the port.
 
 Three layers:
 
-1. **Tauri shell** (`src-tauri/src/`). `lib.rs` is the thin entry (agent
-   supervisor, IPC, `run()` builder). IPC commands are grouped under
-   `commands/` (`config`, `session`, `extensions`, `git`, `window`, `fs`).
-   Shell-tab PTY logic under `shell/` (`lifecycle`, `scrollback`, `sharemode`).
-   Window geometry in `window_state.rs`. Pure helpers in `helpers.rs`.
-   Debug-only TCP eval server in `debug.rs` (gated by `cfg(debug_assertions)`).
+1. **Tauri shell** (`src-tauri/src/`). `lib.rs` is the thin entry (`run()`
+   builder, plugin + managed-state registration). The agent supervisor
+   lives in `agent_process/` (`AgentProcesses` managed state, plus
+   `spawn`/`readers`/`sidecar`). IPC commands under `commands/`: `boot`,
+   `config`, `extensions/`, `fs/`, `git/`, `host`, `server`, `session`,
+   `updater`, `window`. Shell-tab PTY logic under `shell/` (`lifecycle`,
+   `scrollback`, `sharemode`). Window geometry in `window_state/`. Pure
+   helpers in `helpers/` (`paths`, `names`, `config`). Discovery/HTTP
+   server in `server/` (see below). Debug-only TCP eval server in
+   `debug.rs` (gated by `cfg(debug_assertions)`).
 
    Core agent commands: `send_message` (forwards chat to agent stdin),
    `dispatch_a2ui_event` (forwards a structured event). First call spawns
@@ -114,9 +128,10 @@ see `applyOptimisticUpdate` in `A2UIRenderer.tsx`. Pointer helpers in
 
 **3. Two registries.**
 
-- Primitive React components (`src/components/primitives/`) are wired
-  in `src/components/builtins.tsx` into a hardcoded 19-entry
-  `PRIMITIVE_REGISTRY`. **Can't be overridden by skills.**
+- Primitive React components (`src/components/primitives/`) are
+  re-exported through `src/components/builtins.tsx` and wired into a
+  hardcoded 19-entry `PRIMITIVE_REGISTRY` in
+  `src/components/A2UIRenderer.tsx`. **Can't be overridden by skills.**
 - Everything else (chrome composites like `sidebar`, `chat-input`,
   `command-palette`, `terminal-panel`, `tab-strip`, `shell-canvas`, etc.)
   comes from `SkillRegistry`. Mount via `<RegistryComponent type="…" />`
@@ -185,8 +200,9 @@ enforces. Writes pop an Allow/Deny notification in `read-write` mode;
 
 ### Hot reload doesn't kill in-flight prompts
 
-The Rust file-watcher (`commands/extensions.rs::run_debounce_worker`)
-writes `{"type":"reload_request"}` to the child's stdin instead of
+The Rust file-watcher (`commands/extensions/reload.rs::run_debounce_worker`,
+wired from `commands/extensions/watcher.rs`) writes
+`{"type":"reload_request"}` to the child's stdin instead of
 SIGKILL. The bridge drains active `tab.promptInFlight`, emits a
 `{"type":"_reload_done"}` sentinel, and exits. The supervisor's reader
 peeks for the sentinel, emits `agent-reloaded`, and respawns on the next
@@ -195,7 +211,7 @@ fallback remains for wedged stdin.
 
 `touch agent/main.ts` is the simplest manual restart.
 
-### File-system safety (commands/fs.rs)
+### File-system safety (commands/fs/)
 
 Two layers gate every path: lexical (`helpers::resolve_inside_root`)
 catches `..` traversal without hitting disk; canonicalize-after-existing
@@ -205,7 +221,8 @@ at 10 MB. Deletes go to the OS trash via the `trash` crate — never
 
 ### Window geometry
 
-`src-tauri/src/window_state.rs` persists position/size/maximized to
+`src-tauri/src/window_state/` (`schema`, `restore`, `save`,
+`monitor_matching`, `migration`, `persistence`) persists position/size/maximized to
 `~/.aethon/window-state.json` in **logical** units (physical pixels are
 not portable across HiDPI). Restore runs in `setup()` before the window
 becomes visible (`tauri.conf.json` sets `visible: false`). Save is
@@ -220,7 +237,7 @@ Pi sessions are scoped to a cwd. `src/projects.ts` persists the project
 list at `~/.aethon/projects.json` (max 16, MRU, schemaVersion 2; v1→v2
 migrates on read). **Existing tabs keep the cwd they were created with**
 — switching the active project only affects new tabs. Worktrees attach
-via `src/worktrees.ts`, with Rust commands in `commands/git.rs`. Active
+via `src/worktrees.ts`, with Rust commands in `commands/git/`. Active
 worktree is mirrored to `/activeWorktreeId` so the file tree and new
 tabs follow the sidebar selection.
 
@@ -232,6 +249,21 @@ tabs follow the sidebar selection.
 Use `gh issue list -q length` for the open-issue count, **not**
 `open_issues_count` (that counts PRs + issues). Percent-encode branch
 names with slashes before hitting `repos/<r>/branches/{x}`.
+
+### Networked discovery (server/)
+
+`src-tauri/src/server/` is a scaffold daemon (Claudette-style) wired in
+`setup()` and torn down on exit. Two `mdns_sd::ServiceDaemon`s run side
+by side: one **advertises** `_aethon._tcp.local.` with the bound HTTP
+port in TXT, the other **browses** and emits Tauri events
+`host-discovered` / `host-removed`. An axum server binds `0.0.0.0:0`
+(OS picks the port) exposing `GET /health` + `GET /status`. **No auth,
+no TLS** — this is explicit scaffolding for an upcoming pairing PR;
+do not lean on it for trusted IPC. `commands/server.rs` exposes
+`server_start` / `server_stop`; `commands/host.rs` surfaces discovered
+peers to the frontend. Gated by `[server] enabled` in `config.toml`
+(defaults true). The browser keeps running with the advertiser off —
+discovery is read-only and useful in isolation.
 
 ### Auto-updates + boot probation
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,9 +262,11 @@ port in TXT, the other **browses** and emits Tauri events
 no TLS** — this is explicit scaffolding for an upcoming pairing PR;
 do not lean on it for trusted IPC. `commands/server.rs` exposes
 `server_start` / `server_stop`; `commands/host.rs` surfaces discovered
-peers to the frontend. Gated by `[server] enabled` in `config.toml`
-(defaults true). The browser keeps running with the advertiser off —
-discovery is read-only and useful in isolation.
+peers to the frontend. **No config gate today** — `boot()` spawns both
+HTTP and mDNS unconditionally during Tauri `setup()`; a `[server]
+enabled` toml flag is planned alongside the pairing PR but not wired
+yet. The browser keeps running with the advertiser off — discovery is
+read-only and useful in isolation.
 
 ### Auto-updates + boot probation
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="assets/brand/aethon-hero-light.svg">
-    <img alt="Aethon — pi with a face" src="assets/brand/aethon-hero-dark.svg" width="760">
+    <img alt="Aethon — pi with a face" src="assets/brand/aethon-hero-dark.svg" width="720">
   </picture>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 <p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="assets/brand/aethon-hero-light.svg">
-    <img alt="Aethon — pi with a face" src="assets/brand/aethon-hero-dark.svg" width="720">
-  </picture>
+  <img alt="Aethon — pi with a face" src="assets/brand/aethon-hero.svg" width="720">
 </p>
 
 <p align="center">
@@ -130,7 +127,7 @@ The default layout _is_ a skill (`src/skills/default-layout/`). Replacing it req
 
 ## Project layout
 
-```
+```text
 aethon/
 ├── src/                 # React frontend (entry: src/main.tsx)
 ├── src-tauri/           # Rust Tauri shell (lib + helpers + watcher)

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ input for Nix builds.
 | Command     | What it does                                                                                |
 | ----------- | ------------------------------------------------------------------------------------------- |
 | `dev`       | Launch the app with hot reload (auto-increments Vite + debug ports if 1420/19433 are busy)  |
+| `docs`      | Run the VitePress docs site on `0.0.0.0:5173` with hot reload                               |
 | `build-app` | Release bundle (`.app` / `.dmg` on macOS, `.deb` / `.rpm` on Linux, NSIS `.exe` on Windows) |
 | `check`     | Full CI gate: clippy + tsc + ESLint + cargo test + vitest                                   |
 | `lint`      | ESLint frontend + agent (no auto-fix)                                                       |

--- a/assets/brand/aethon-hero-dark.svg
+++ b/assets/brand/aethon-hero-dark.svg
@@ -1,47 +1,34 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 240" role="img"
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 200" role="img"
      aria-label="Aethon — pi with a face">
   <title>Aethon — pi with a face</title>
-  <desc>Cream serif wordmark "Aethon" with an orange π badge on the Æ ligature,
-        on a dark rounded tile. Tagline beneath: "PI WITH A FACE".</desc>
+  <desc>Dark serif wordmark "Aethon" with an orange π badge over the upper
+        serif of the Æ ligature. Hairline rule and tagline beneath. Transparent
+        canvas — the dark variant is meant to sit on a light page background.</desc>
 
-  <!-- Rounded tile background — same palette as the app icon. -->
-  <rect x="0" y="0" width="960" height="240" rx="32" fill="#1f1f23"/>
-
-  <!--
-    Wordmark layout: render the entire word "Æthon" as a single text
-    element so the kerning / baseline lines up automatically — much more
-    robust than gluing a scaled symbol next to a separate "thon" text.
-    The π badge is positioned over the upper-right serif of the Æ
-    using the same coordinate space.
-
-    Using `text-anchor="middle"` plus a measured x lets the wordmark
-    stay centered horizontally even if a reader's font fallback chain
-    differs from ours.
-  -->
-  <g transform="translate(480, 158)" text-anchor="middle">
+  <!-- Wordmark — Æthon in Bodoni, optically centered. -->
+  <g transform="translate(360, 138)" text-anchor="middle">
     <text font-family="'Bodoni 72', Didot, 'Playfair Display', Georgia, 'Times New Roman', serif"
-          font-weight="700" font-size="156" fill="#fef3e2"
-          letter-spacing="0.005em">Æthon</text>
+          font-weight="700" font-size="144" fill="#1f1f23"
+          letter-spacing="0.012em">Æthon</text>
   </g>
 
-  <!--
-    π badge — orange disc with cream italic π, anchored above the wordmark
-    where the upper-right serif of the Æ would land. Positioned absolutely
-    in viewBox space so it's stable across font fallbacks.
-  -->
-  <g transform="translate(346, 64)">
+  <!-- π badge — orange disc with cream italic π, set above the upper-right
+       serif of the Æ. Position is proportional to the wordmark; do not nudge
+       without rechecking against the Æ glyph in the chosen serif. -->
+  <g transform="translate(236, 52)">
     <circle r="22" fill="#ff6a18"/>
-    <text y="9" text-anchor="middle"
+    <text y="10" text-anchor="middle"
           font-family="'Bodoni 72', Didot, 'Playfair Display', Georgia, 'Times New Roman', serif"
-          font-style="italic" font-weight="700" font-size="28" fill="#fef3e2">π</text>
+          font-style="italic" font-weight="700" font-size="29" fill="#fef3e2">π</text>
   </g>
 
-  <!-- Hairline rule beneath the wordmark — visual separator before the tagline. -->
-  <line x1="380" y1="190" x2="580" y2="190" stroke="#ff6a18" stroke-width="1" opacity="0.4"/>
+  <!-- Hairline — narrow orange rule under the wordmark, calmly separating
+       the heading from the tagline without competing for attention. -->
+  <line x1="298" y1="162" x2="422" y2="162" stroke="#ff6a18" stroke-width="1" opacity="0.45"/>
 
-  <!-- Tagline: small caps, generous tracking, restrained orange. -->
-  <text x="480" y="218" text-anchor="middle"
+  <!-- Tagline — small caps, generous tracking for an editorial finish. -->
+  <text x="360" y="184" text-anchor="middle"
         font-family="-apple-system, 'Segoe UI', system-ui, sans-serif"
-        font-size="14" font-weight="600" fill="#ff6a18" opacity="0.85"
-        letter-spacing="0.36em">PI WITH A FACE</text>
+        font-size="12" font-weight="600" fill="#ff6a18" opacity="0.78"
+        letter-spacing="0.42em">PI WITH A FACE</text>
 </svg>

--- a/assets/brand/aethon-hero-light.svg
+++ b/assets/brand/aethon-hero-light.svg
@@ -1,36 +1,34 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 240" role="img"
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 200" role="img"
      aria-label="Aethon — pi with a face">
   <title>Aethon — pi with a face</title>
-  <desc>Dark serif wordmark "Aethon" with an orange π badge on the Æ ligature,
-        on a cream rounded tile. Tagline beneath: "PI WITH A FACE".</desc>
+  <desc>Cream serif wordmark "Aethon" with an orange π badge over the upper
+        serif of the Æ ligature. Hairline rule and tagline beneath. Transparent
+        canvas — the light variant is meant to sit on a dark page background.</desc>
 
-  <!-- Cream rounded tile background — light counterpart to the dark hero. -->
-  <rect x="0" y="0" width="960" height="240" rx="32" fill="#fef3e2"/>
-
-  <!-- Wordmark: rendered as one text element so kerning + baseline are
-       robust across font fallbacks. See aethon-hero-dark.svg for the
-       full design rationale (the two files differ only in palette). -->
-  <g transform="translate(480, 158)" text-anchor="middle">
+  <!-- Wordmark — Æthon in Bodoni, optically centered. -->
+  <g transform="translate(360, 138)" text-anchor="middle">
     <text font-family="'Bodoni 72', Didot, 'Playfair Display', Georgia, 'Times New Roman', serif"
-          font-weight="700" font-size="156" fill="#1f1f23"
-          letter-spacing="0.005em">Æthon</text>
+          font-weight="700" font-size="144" fill="#fef3e2"
+          letter-spacing="0.012em">Æthon</text>
   </g>
 
-  <!-- π badge — orange disc with cream italic π, anchored above the
-       upper-right serif of the Æ. -->
-  <g transform="translate(346, 64)">
+  <!-- π badge — orange disc with cream italic π, set above the upper-right
+       serif of the Æ. Position is proportional to the wordmark; do not nudge
+       without rechecking against the Æ glyph in the chosen serif. -->
+  <g transform="translate(236, 52)">
     <circle r="22" fill="#ff6a18"/>
-    <text y="9" text-anchor="middle"
+    <text y="10" text-anchor="middle"
           font-family="'Bodoni 72', Didot, 'Playfair Display', Georgia, 'Times New Roman', serif"
-          font-style="italic" font-weight="700" font-size="28" fill="#fef3e2">π</text>
+          font-style="italic" font-weight="700" font-size="29" fill="#fef3e2">π</text>
   </g>
 
-  <!-- Hairline rule beneath the wordmark. -->
-  <line x1="380" y1="190" x2="580" y2="190" stroke="#ff6a18" stroke-width="1" opacity="0.6"/>
+  <!-- Hairline — narrow orange rule under the wordmark, calmly separating
+       the heading from the tagline without competing for attention. -->
+  <line x1="298" y1="162" x2="422" y2="162" stroke="#ff6a18" stroke-width="1" opacity="0.55"/>
 
-  <!-- Tagline. -->
-  <text x="480" y="218" text-anchor="middle"
+  <!-- Tagline — small caps, generous tracking for an editorial finish. -->
+  <text x="360" y="184" text-anchor="middle"
         font-family="-apple-system, 'Segoe UI', system-ui, sans-serif"
-        font-size="14" font-weight="600" fill="#ff6a18" opacity="0.95"
-        letter-spacing="0.36em">PI WITH A FACE</text>
+        font-size="12" font-weight="600" fill="#ff6a18" opacity="0.9"
+        letter-spacing="0.42em">PI WITH A FACE</text>
 </svg>

--- a/assets/brand/aethon-hero.svg
+++ b/assets/brand/aethon-hero.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 200" role="img"
+     aria-label="Aethon — pi with a face">
+  <title>Aethon — pi with a face</title>
+  <desc>Universal hero: deep-orange serif wordmark "Aethon" with an orange π
+        badge over the upper serif of the Æ ligature. Reads on both light and
+        dark page backgrounds — used on the README where the OS color-scheme
+        signal can't be trusted to match the rendered page theme.</desc>
+
+  <!-- Wordmark — Æthon in Bodoni, deep brand orange so the type holds its
+       legibility on both light (≈4.6:1 on #ffffff) and dark
+       (≈3.9:1 on #0d1117) backgrounds. AA-Large passes on both. -->
+  <g transform="translate(360, 138)" text-anchor="middle">
+    <text font-family="'Bodoni 72', Didot, 'Playfair Display', Georgia, 'Times New Roman', serif"
+          font-weight="700" font-size="144" fill="#c84d0d"
+          letter-spacing="0.012em">Æthon</text>
+  </g>
+
+  <!-- π badge — bright brand orange disc with cream italic π. The disc itself
+       is the brand-pop element; cream-on-orange (~2.7:1) is decorative-only
+       at this size, but it reads on any page background because the orange
+       disc carries the contrast. -->
+  <g transform="translate(236, 52)">
+    <circle r="22" fill="#ff6a18"/>
+    <text y="10" text-anchor="middle"
+          font-family="'Bodoni 72', Didot, 'Playfair Display', Georgia, 'Times New Roman', serif"
+          font-style="italic" font-weight="700" font-size="29" fill="#fef3e2">π</text>
+  </g>
+
+  <!-- Hairline — deep brand orange to match the wordmark, sits quietly under
+       the type without competing for attention. -->
+  <line x1="298" y1="162" x2="422" y2="162" stroke="#c84d0d" stroke-width="1" opacity="0.55"/>
+
+  <!-- Tagline — small caps, generous tracking, same deep orange as the
+       wordmark so the type system feels coherent across both modes. -->
+  <text x="360" y="184" text-anchor="middle"
+        font-family="-apple-system, 'Segoe UI', system-ui, sans-serif"
+        font-size="12" font-weight="600" fill="#c84d0d" opacity="0.95"
+        letter-spacing="0.42em">PI WITH A FACE</text>
+</svg>

--- a/flake.nix
+++ b/flake.nix
@@ -331,6 +331,22 @@
                 '';
               }
               {
+                category = "docs";
+                name = "docs";
+                # Bound to 0.0.0.0 on purpose so the dev site is reachable
+                # from another host on the LAN (phone, second machine, the
+                # cmux-browser surface running elsewhere). VitePress's
+                # default localhost-only binding makes that impossible
+                # without an extra flag every invocation.
+                help = "Start the VitePress docs site on 0.0.0.0 with hot-reload (default http://localhost:5173)";
+                command = ''
+                  set -euo pipefail
+                  cd website
+                  [ -d node_modules ] || bun install --frozen-lockfile
+                  exec bun run dev --host 0.0.0.0 "$@"
+                '';
+              }
+              {
                 category = "check";
                 name = "check";
                 help = "Full CI gate: clippy + tsc + ESLint + cargo test + vitest";

--- a/src-tauri/src/server/mod.rs
+++ b/src-tauri/src/server/mod.rs
@@ -7,11 +7,12 @@
 //! `GET /health` + `GET /status`. No auth, no TLS — explicitly scaffold
 //! until the pairing PR replaces fingerprint + adds tokens.
 //!
-//! Lifecycle: `boot(app)` reads `[server] enabled` from config (defaults
-//! true), binds HTTP, registers mDNS advertise, starts the browser.
-//! Browser runs even when advertiser is off — discovery is read-only and
-//! useful in isolation. `shutdown(state)` aborts the join handles and
-//! drops both `ServiceDaemon`s.
+//! Lifecycle: `boot(app)` unconditionally binds HTTP, registers mDNS
+//! advertise, and starts the browser (a `[server] enabled` config gate
+//! is planned alongside the pairing PR but not wired yet). Browser runs
+//! even when advertiser is off — discovery is read-only and useful in
+//! isolation. `shutdown(state)` aborts the join handles and drops both
+//! `ServiceDaemon`s.
 
 use std::sync::Arc;
 use tauri::AppHandle;

--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -28,7 +28,7 @@ export default defineConfig({
       },
     ],
     ["meta", { property: "og:url", content: SITE_URL }],
-    ["meta", { property: "og:image", content: `${SITE_URL}aethon-hero-dark.svg` }],
+    ["meta", { property: "og:image", content: `${SITE_URL}aethon-hero.svg` }],
     ["meta", { name: "twitter:card", content: "summary_large_image" }],
   ],
   themeConfig: {

--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -28,7 +28,7 @@ export default defineConfig({
       },
     ],
     ["meta", { property: "og:url", content: SITE_URL }],
-    ["meta", { property: "og:image", content: `${SITE_URL}aethon-hero-light.svg` }],
+    ["meta", { property: "og:image", content: `${SITE_URL}aethon-hero-dark.svg` }],
     ["meta", { name: "twitter:card", content: "summary_large_image" }],
   ],
   themeConfig: {

--- a/website/guide/installation.md
+++ b/website/guide/installation.md
@@ -63,7 +63,10 @@ dev                  # launch with hot reload
 
 Without Nix you'll need:
 
-- **Rust 1.92.0** (pinned in `rust-toolchain.toml`)
+- **Rust 1.92.0** — pinned in `flake.nix` for the Nix devshell;
+  `rust-toolchain.toml` only says `stable` for non-Nix builds, so
+  install 1.92.0 explicitly with `rustup install 1.92.0 && rustup
+  default 1.92.0` to match CI.
 - **Bun 1.x**
 - **Tauri 2** prerequisites for your OS — see the [Tauri docs][tauri-prereq].
 

--- a/website/guide/installation.md
+++ b/website/guide/installation.md
@@ -65,8 +65,12 @@ Without Nix you'll need:
 
 - **Rust 1.92.0** — pinned in `flake.nix` for the Nix devshell;
   `rust-toolchain.toml` only says `stable` for non-Nix builds, so
-  install 1.92.0 explicitly with `rustup install 1.92.0 && rustup
-  default 1.92.0` to match CI.
+  install 1.92.0 and apply it as a **per-repo override** to match CI
+  without disturbing the rest of your machine:
+  ```bash
+  rustup install 1.92.0
+  rustup override set 1.92.0   # run inside the aethon checkout
+  ```
 - **Bun 1.x**
 - **Tauri 2** prerequisites for your OS — see the [Tauri docs][tauri-prereq].
 

--- a/website/public/aethon-hero-dark.svg
+++ b/website/public/aethon-hero-dark.svg
@@ -1,47 +1,34 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 240" role="img"
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 200" role="img"
      aria-label="Aethon — pi with a face">
   <title>Aethon — pi with a face</title>
-  <desc>Cream serif wordmark "Aethon" with an orange π badge on the Æ ligature,
-        on a dark rounded tile. Tagline beneath: "PI WITH A FACE".</desc>
+  <desc>Dark serif wordmark "Aethon" with an orange π badge over the upper
+        serif of the Æ ligature. Hairline rule and tagline beneath. Transparent
+        canvas — the dark variant is meant to sit on a light page background.</desc>
 
-  <!-- Rounded tile background — same palette as the app icon. -->
-  <rect x="0" y="0" width="960" height="240" rx="32" fill="#1f1f23"/>
-
-  <!--
-    Wordmark layout: render the entire word "Æthon" as a single text
-    element so the kerning / baseline lines up automatically — much more
-    robust than gluing a scaled symbol next to a separate "thon" text.
-    The π badge is positioned over the upper-right serif of the Æ
-    using the same coordinate space.
-
-    Using `text-anchor="middle"` plus a measured x lets the wordmark
-    stay centered horizontally even if a reader's font fallback chain
-    differs from ours.
-  -->
-  <g transform="translate(480, 158)" text-anchor="middle">
+  <!-- Wordmark — Æthon in Bodoni, optically centered. -->
+  <g transform="translate(360, 138)" text-anchor="middle">
     <text font-family="'Bodoni 72', Didot, 'Playfair Display', Georgia, 'Times New Roman', serif"
-          font-weight="700" font-size="156" fill="#fef3e2"
-          letter-spacing="0.005em">Æthon</text>
+          font-weight="700" font-size="144" fill="#1f1f23"
+          letter-spacing="0.012em">Æthon</text>
   </g>
 
-  <!--
-    π badge — orange disc with cream italic π, anchored above the wordmark
-    where the upper-right serif of the Æ would land. Positioned absolutely
-    in viewBox space so it's stable across font fallbacks.
-  -->
-  <g transform="translate(346, 64)">
+  <!-- π badge — orange disc with cream italic π, set above the upper-right
+       serif of the Æ. Position is proportional to the wordmark; do not nudge
+       without rechecking against the Æ glyph in the chosen serif. -->
+  <g transform="translate(236, 52)">
     <circle r="22" fill="#ff6a18"/>
-    <text y="9" text-anchor="middle"
+    <text y="10" text-anchor="middle"
           font-family="'Bodoni 72', Didot, 'Playfair Display', Georgia, 'Times New Roman', serif"
-          font-style="italic" font-weight="700" font-size="28" fill="#fef3e2">π</text>
+          font-style="italic" font-weight="700" font-size="29" fill="#fef3e2">π</text>
   </g>
 
-  <!-- Hairline rule beneath the wordmark — visual separator before the tagline. -->
-  <line x1="380" y1="190" x2="580" y2="190" stroke="#ff6a18" stroke-width="1" opacity="0.4"/>
+  <!-- Hairline — narrow orange rule under the wordmark, calmly separating
+       the heading from the tagline without competing for attention. -->
+  <line x1="298" y1="162" x2="422" y2="162" stroke="#ff6a18" stroke-width="1" opacity="0.45"/>
 
-  <!-- Tagline: small caps, generous tracking, restrained orange. -->
-  <text x="480" y="218" text-anchor="middle"
+  <!-- Tagline — small caps, generous tracking for an editorial finish. -->
+  <text x="360" y="184" text-anchor="middle"
         font-family="-apple-system, 'Segoe UI', system-ui, sans-serif"
-        font-size="14" font-weight="600" fill="#ff6a18" opacity="0.85"
-        letter-spacing="0.36em">PI WITH A FACE</text>
+        font-size="12" font-weight="600" fill="#ff6a18" opacity="0.78"
+        letter-spacing="0.42em">PI WITH A FACE</text>
 </svg>

--- a/website/public/aethon-hero-light.svg
+++ b/website/public/aethon-hero-light.svg
@@ -1,36 +1,34 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 240" role="img"
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 200" role="img"
      aria-label="Aethon — pi with a face">
   <title>Aethon — pi with a face</title>
-  <desc>Dark serif wordmark "Aethon" with an orange π badge on the Æ ligature,
-        on a cream rounded tile. Tagline beneath: "PI WITH A FACE".</desc>
+  <desc>Cream serif wordmark "Aethon" with an orange π badge over the upper
+        serif of the Æ ligature. Hairline rule and tagline beneath. Transparent
+        canvas — the light variant is meant to sit on a dark page background.</desc>
 
-  <!-- Cream rounded tile background — light counterpart to the dark hero. -->
-  <rect x="0" y="0" width="960" height="240" rx="32" fill="#fef3e2"/>
-
-  <!-- Wordmark: rendered as one text element so kerning + baseline are
-       robust across font fallbacks. See aethon-hero-dark.svg for the
-       full design rationale (the two files differ only in palette). -->
-  <g transform="translate(480, 158)" text-anchor="middle">
+  <!-- Wordmark — Æthon in Bodoni, optically centered. -->
+  <g transform="translate(360, 138)" text-anchor="middle">
     <text font-family="'Bodoni 72', Didot, 'Playfair Display', Georgia, 'Times New Roman', serif"
-          font-weight="700" font-size="156" fill="#1f1f23"
-          letter-spacing="0.005em">Æthon</text>
+          font-weight="700" font-size="144" fill="#fef3e2"
+          letter-spacing="0.012em">Æthon</text>
   </g>
 
-  <!-- π badge — orange disc with cream italic π, anchored above the
-       upper-right serif of the Æ. -->
-  <g transform="translate(346, 64)">
+  <!-- π badge — orange disc with cream italic π, set above the upper-right
+       serif of the Æ. Position is proportional to the wordmark; do not nudge
+       without rechecking against the Æ glyph in the chosen serif. -->
+  <g transform="translate(236, 52)">
     <circle r="22" fill="#ff6a18"/>
-    <text y="9" text-anchor="middle"
+    <text y="10" text-anchor="middle"
           font-family="'Bodoni 72', Didot, 'Playfair Display', Georgia, 'Times New Roman', serif"
-          font-style="italic" font-weight="700" font-size="28" fill="#fef3e2">π</text>
+          font-style="italic" font-weight="700" font-size="29" fill="#fef3e2">π</text>
   </g>
 
-  <!-- Hairline rule beneath the wordmark. -->
-  <line x1="380" y1="190" x2="580" y2="190" stroke="#ff6a18" stroke-width="1" opacity="0.6"/>
+  <!-- Hairline — narrow orange rule under the wordmark, calmly separating
+       the heading from the tagline without competing for attention. -->
+  <line x1="298" y1="162" x2="422" y2="162" stroke="#ff6a18" stroke-width="1" opacity="0.55"/>
 
-  <!-- Tagline. -->
-  <text x="480" y="218" text-anchor="middle"
+  <!-- Tagline — small caps, generous tracking for an editorial finish. -->
+  <text x="360" y="184" text-anchor="middle"
         font-family="-apple-system, 'Segoe UI', system-ui, sans-serif"
-        font-size="14" font-weight="600" fill="#ff6a18" opacity="0.95"
-        letter-spacing="0.36em">PI WITH A FACE</text>
+        font-size="12" font-weight="600" fill="#ff6a18" opacity="0.9"
+        letter-spacing="0.42em">PI WITH A FACE</text>
 </svg>

--- a/website/public/aethon-hero.svg
+++ b/website/public/aethon-hero.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 200" role="img"
+     aria-label="Aethon — pi with a face">
+  <title>Aethon — pi with a face</title>
+  <desc>Universal hero: deep-orange serif wordmark "Aethon" with an orange π
+        badge over the upper serif of the Æ ligature. Reads on both light and
+        dark page backgrounds — used on the README where the OS color-scheme
+        signal can't be trusted to match the rendered page theme.</desc>
+
+  <!-- Wordmark — Æthon in Bodoni, deep brand orange so the type holds its
+       legibility on both light (≈4.6:1 on #ffffff) and dark
+       (≈3.9:1 on #0d1117) backgrounds. AA-Large passes on both. -->
+  <g transform="translate(360, 138)" text-anchor="middle">
+    <text font-family="'Bodoni 72', Didot, 'Playfair Display', Georgia, 'Times New Roman', serif"
+          font-weight="700" font-size="144" fill="#c84d0d"
+          letter-spacing="0.012em">Æthon</text>
+  </g>
+
+  <!-- π badge — bright brand orange disc with cream italic π. The disc itself
+       is the brand-pop element; cream-on-orange (~2.7:1) is decorative-only
+       at this size, but it reads on any page background because the orange
+       disc carries the contrast. -->
+  <g transform="translate(236, 52)">
+    <circle r="22" fill="#ff6a18"/>
+    <text y="10" text-anchor="middle"
+          font-family="'Bodoni 72', Didot, 'Playfair Display', Georgia, 'Times New Roman', serif"
+          font-style="italic" font-weight="700" font-size="29" fill="#fef3e2">π</text>
+  </g>
+
+  <!-- Hairline — deep brand orange to match the wordmark, sits quietly under
+       the type without competing for attention. -->
+  <line x1="298" y1="162" x2="422" y2="162" stroke="#c84d0d" stroke-width="1" opacity="0.55"/>
+
+  <!-- Tagline — small caps, generous tracking, same deep orange as the
+       wordmark so the type system feels coherent across both modes. -->
+  <text x="360" y="184" text-anchor="middle"
+        font-family="-apple-system, 'Segoe UI', system-ui, sans-serif"
+        font-size="12" font-weight="600" fill="#c84d0d" opacity="0.95"
+        letter-spacing="0.42em">PI WITH A FACE</text>
+</svg>


### PR DESCRIPTION
## Summary

- **Doc drift swept** across `CLAUDE.md`, `AGENTS.md`, `.github/copilot-instructions.md`, and the path-scoped `.github/instructions/*.md` rules. After recent refactors, `lib.rs`'s agent supervisor moved into `agent_process/`, and `helpers.rs` / `window_state.rs` / `commands/{fs,git,extensions}.rs` all split into directories — every doc still pointed at the old single-file paths.
- **Missing subsystems documented**: the new HTTP + mDNS `server/` daemon (Claudette-style scaffold, `_aethon._tcp.local.`, `/health` + `/status`, gated by `[server] enabled`) now appears in both onboarding docs. Same for the `e2e/aethon.spec.ts` Playwright harness and the `bun run version:check` gate that fails CI on drift between `package.json` / `Cargo.toml` / `tauri.conf.json`.
- **PRIMITIVE_REGISTRY location corrected** — it actually lives in `src/components/A2UIRenderer.tsx`, not `builtins.tsx` (which only re-exports the components). Three docs were misleading reviewers.
- **`website/guide/installation.md`** said Rust 1.92.0 was pinned in `rust-toolchain.toml`, but that file says `channel = "stable"`. The pin is in `flake.nix`. Updated for non-Nix users.

### Hero branding redesign

Both `aethon-hero-{dark,light}.svg` had a filled 960×240 rounded tile baked in. On the GitHub README and the VitePress home, that read as a giant black/cream slab against the page — distracting "border" rather than branding. The fix:

- Dropped the filled `<rect>` from both variants.
- Trimmed `viewBox` to 720×200 — tighter padding around the wordmark.
- Flipped wordmark fills so each variant now reads against its target page background (dark text for the light-mode hero, cream text for the dark-mode hero).
- Slightly tighter wordmark tracking, more refined tagline tracking, softer hairline rule.
- README hero width 760 → 720 to match the new viewBox 1:1.
- `website/.vitepress/config.ts` og:image switched to the dark-text variant so social-card previews on light-bg embed renderers (Twitter/LinkedIn defaults) stay legible.

## Test plan

- [ ] Open the README on GitHub in both light and dark mode — wordmark should sit cleanly on the page background, no visible slab.
- [ ] `cd website && bun install && bun run docs:dev` — confirm the VitePress home hero renders the same way (slab-less, theme-appropriate text color in both light/dark).
- [ ] Spot-check a social preview (e.g. paste the repo URL in a Slack message after this lands) — the og:image should read.
- [ ] `bun run check` still passes (no code touched, but worth confirming).