### PR TITLE
fix(devshell): resolve nightly tools from launch-safe PATH

### DIFF
--- a/src-tauri/src/devshell/detect.rs
+++ b/src-tauri/src/devshell/detect.rs
@@ -15,6 +15,8 @@
 
 use std::path::{Path, PathBuf};
 
+use crate::env;
+
 /// What kind of devshell, if any, a project root has.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DevshellKind {
@@ -84,10 +86,10 @@ pub struct RealProbe;
 
 impl BinProbe for RealProbe {
     fn has_direnv(&self) -> bool {
-        which_on_path("direnv").is_some()
+        which_on_tool_path("direnv").is_some()
     }
     fn has_nix(&self) -> bool {
-        which_on_path("nix").is_some()
+        which_on_tool_path("nix").is_some()
     }
 }
 
@@ -151,19 +153,12 @@ fn envrc_uses_nix(envrc: &Path) -> bool {
     false
 }
 
-/// Minimal `which`. We don't need the full `which` crate's surface —
-/// just check whether PATH yields an executable file by name. Returns
-/// the resolved path so callers can pin the resolver (avoids picking
-/// up a different `nix` mid-session if PATH mutates).
-pub fn which_on_path(name: &str) -> Option<PathBuf> {
-    let path = std::env::var_os("PATH")?;
-    for dir in std::env::split_paths(&path) {
-        let candidate = dir.join(name);
-        if is_executable(&candidate) {
-            return Some(candidate);
-        }
-    }
-    None
+/// Resolve a tool through Aethon's launch-safe tool lookup. Release
+/// builds are commonly launched from Finder / Dock with a skeletal
+/// PATH, so checking only `std::env::var("PATH")` misses Nix and
+/// direnv installs that are otherwise available in a login shell.
+pub fn which_on_tool_path(name: &str) -> Option<PathBuf> {
+    env::resolve_program(name).filter(|candidate| is_executable(candidate))
 }
 
 #[cfg(unix)]
@@ -405,5 +400,21 @@ mod tests {
         assert_eq!(DetectMode::from_str("nix-shell"), DetectMode::NixShell);
         assert_eq!(DetectMode::from_str("auto"), DetectMode::Auto);
         assert_eq!(DetectMode::from_str("yolo"), DetectMode::Auto);
+    }
+
+    #[test]
+    fn real_probe_uses_launch_safe_tool_lookup() {
+        assert_eq!(
+            RealProbe.has_nix(),
+            env::resolve_program("nix")
+                .as_deref()
+                .is_some_and(is_executable)
+        );
+        assert_eq!(
+            RealProbe.has_direnv(),
+            env::resolve_program("direnv")
+                .as_deref()
+                .is_some_and(is_executable)
+        );
     }
 }

--- a/src-tauri/src/devshell/resolve.rs
+++ b/src-tauri/src/devshell/resolve.rs
@@ -23,6 +23,8 @@ use tokio::io::AsyncReadExt;
 use tokio::process::Command;
 use tokio::time::timeout;
 
+use crate::env;
+
 use super::detect::DevshellKind;
 
 /// Per-resolver wall-clock timeout. A cold `nix print-dev-env --json`
@@ -66,15 +68,15 @@ pub async fn resolve(root: &Path, kind: DevshellKind) -> Result<ResolvedEnv, Str
 }
 
 async fn resolve_direnv(root: &Path) -> Result<BTreeMap<String, String>, String> {
-    let mut cmd = Command::new("direnv");
+    let mut cmd = env::tokio_command("direnv");
     cmd.arg("exec")
         .arg(root)
         .arg("env")
         .arg("-0")
         .current_dir(root)
         // Inherit the host env so direnv can find its own state dir,
-        // PATH, etc. The resolver subprocess sees the same env the
-        // Aethon process did at launch.
+        // while env::tokio_command supplies Aethon's launch-safe PATH
+        // for locating direnv and any tools it shells out to.
         .env("DIRENV_LOG_FORMAT", "")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
@@ -83,7 +85,7 @@ async fn resolve_direnv(root: &Path) -> Result<BTreeMap<String, String>, String>
 }
 
 async fn resolve_flake(root: &Path) -> Result<BTreeMap<String, String>, String> {
-    let mut cmd = Command::new("nix");
+    let mut cmd = env::tokio_command("nix");
     cmd.arg("print-dev-env")
         .arg("--json")
         // The `--accept-flake-config` flag matches what users routinely
@@ -98,7 +100,7 @@ async fn resolve_flake(root: &Path) -> Result<BTreeMap<String, String>, String> 
 }
 
 async fn resolve_shell_nix(root: &Path) -> Result<BTreeMap<String, String>, String> {
-    let mut cmd = Command::new("nix-shell");
+    let mut cmd = env::tokio_command("nix-shell");
     cmd.arg("--run")
         .arg("env -0")
         .current_dir(root)

--- a/src-tauri/src/env.rs
+++ b/src-tauri/src/env.rs
@@ -110,6 +110,10 @@ pub(crate) fn resolved_tool_path() -> String {
         .clone()
 }
 
+pub(crate) fn warm_resolved_tool_path() {
+    let _ = resolved_tool_path();
+}
+
 pub(crate) fn resolved_login_path() -> Option<String> {
     let path = resolved_tool_path();
     if path.is_empty() { None } else { Some(path) }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -289,6 +289,12 @@ pub fn run() {
             let server_state = app.state::<Arc<server::ServerState>>().inner().clone();
             server::boot(app.handle().clone(), server_state);
 
+            // Release app launches can start with a skeletal PATH. Warm
+            // the launch-safe tool path off the setup thread so the
+            // first devshell status/probe IPC does not pay for the
+            // login-shell PATH lookup.
+            tauri::async_runtime::spawn_blocking(env::warm_resolved_tool_path);
+
             // Devshell cache: point at `~/.aethon/devshell-cache/` and
             // GC anything older than 30 days. The cache is otherwise
             // entirely lazy — no resolves happen until a shell open


### PR DESCRIPTION
## Summary

Fix nightly/release devshell detection by routing the Rust devshell detector and resolver through Aethon's launch-safe tool lookup instead of the raw process `PATH`.

## Root Cause

Nightly builds are commonly launched by macOS desktop services rather than an interactive shell. That gives the Aethon process a skeletal `PATH`, so the devshell detector could miss `direnv`, `nix`, or `nix-shell` even when they are available from the user's login shell or standard Nix/Homebrew locations.

The agent process already used Aethon's `env::resolved_login_path()` path enrichment in release mode, but the devshell code path bypassed the shared helper:

- `RealProbe` checked binary availability with its own raw-`PATH` `which` implementation.
- The resolver spawned `Command::new("direnv")`, `Command::new("nix")`, and `Command::new("nix-shell")` directly.

As a result, the app could spawn the agent successfully while the devshell resolver decided no devshell was available, causing bash-tool commands to inherit the host environment.

## Changes

- Update `src-tauri/src/devshell/detect.rs` so `RealProbe` checks `direnv` and `nix` via `env::resolve_program`.
- Update `src-tauri/src/devshell/resolve.rs` so `direnv exec`, `nix print-dev-env`, and `nix-shell` are spawned with `env::tokio_command`, which applies the launch-safe PATH.
- Pre-warm the launch-safe tool PATH from app setup on a blocking background task so the first devshell status/probe IPC does not pay for the login-shell lookup.
- Add regression coverage asserting the real devshell probe follows the shared launch-safe resolver.

## User Impact

Nightly/release Aethon builds should now detect and apply Nix devshells and direnv-backed devshells even when the app is launched outside a terminal. Agent bash commands should inherit the resolved project devshell environment instead of reporting unset `IN_NIX_SHELL`, `DIRENV_DIR`, or missing devshell tools due only to the launch environment.

## Validation

- `nix develop -c cargo test --lib devshell`
- `nix develop -c cargo test --lib`
- `nix develop -c cargo clippy --lib -- -D warnings`
- `git diff --check`

Note: `nix develop` emitted the existing `devshell-env.bash` store-path context warning during test runs, but all validation commands passed.
