### PR TITLE
feat: add auth profile login support

### DIFF
--- a/agent/auth-profiles/index.ts
+++ b/agent/auth-profiles/index.ts
@@ -16,6 +16,7 @@ export type { AuthProfileProvider, AuthProfilesSnapshot } from "./manager";
 export {
   authProfileServicesForTab,
   authProfilesSnapshot,
+  defaultProfileIdForTab,
   emitAuthProfiles,
   handleAuthProfileMessage,
   loadAuthProfiles,

--- a/agent/auth-profiles/index.ts
+++ b/agent/auth-profiles/index.ts
@@ -1,0 +1,24 @@
+export type {
+  AuthProfileKind,
+  AuthProfileMeta,
+  AuthProfilesState,
+} from "./store";
+export {
+  authProfileAuthPath,
+  authProfilesDir,
+  authProfilesStatePath,
+  createProfileMeta,
+  loadAuthProfilesState,
+  saveAuthProfilesState,
+  sanitizeProfileId,
+} from "./store";
+export type { AuthProfileProvider, AuthProfilesSnapshot } from "./manager";
+export {
+  authProfileServicesForTab,
+  authProfilesSnapshot,
+  emitAuthProfiles,
+  handleAuthProfileMessage,
+  loadAuthProfiles,
+  modelRegistryForModelId,
+  saveAuthProfiles,
+} from "./manager";

--- a/agent/auth-profiles/index.ts
+++ b/agent/auth-profiles/index.ts
@@ -10,6 +10,7 @@ export {
   createProfileMeta,
   loadAuthProfilesState,
   saveAuthProfilesState,
+  isSafeProfileId,
   sanitizeProfileId,
 } from "./store";
 export type { AuthProfileProvider, AuthProfilesSnapshot } from "./manager";

--- a/agent/auth-profiles/manager.test.ts
+++ b/agent/auth-profiles/manager.test.ts
@@ -1,0 +1,127 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  AuthStorage,
+  ModelRegistry,
+  SettingsManager,
+} from "@mariozechner/pi-coding-agent";
+import type { Api, Model } from "@mariozechner/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AethonAgentState } from "../state";
+import type { DispatcherDeps } from "../dispatcherTypes";
+import {
+  authProfileServicesForTab,
+  defaultProfileIdForTab,
+  handleAuthProfileMessage,
+} from "./manager";
+import {
+  createProfileMeta,
+  loadAuthProfilesState,
+  upsertProfileMeta,
+} from "./store";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function tempUserDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "aethon-auth-manager-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function makeState(userDir = tempUserDir()): AethonAgentState {
+  const authStorage = AuthStorage.inMemory();
+  return {
+    userDir,
+    authStorage,
+    modelRegistry: ModelRegistry.inMemory(authStorage),
+    settingsManager: SettingsManager.inMemory(),
+    authProfiles: loadAuthProfilesState(userDir),
+    authProfileServices: new Map(),
+    tabAuthProfileIds: new Map(),
+  } as unknown as AethonAgentState;
+}
+
+function addProfile(
+  state: AethonAgentState,
+  providerId: string,
+  label = providerId,
+): string {
+  const profile = createProfileMeta(state.authProfiles, {
+    providerId,
+    label,
+    kind: "oauth",
+    now: 1,
+  });
+  state.authProfiles = upsertProfileMeta(state.authProfiles, profile);
+  state.authProfiles.defaultByProvider[providerId] = profile.id;
+  return profile.id;
+}
+
+describe("auth profile manager", () => {
+  it("applies the default auth profile for tabs opened without an explicit model", () => {
+    const state = makeState();
+    const profileId = addProfile(state, "anthropic", "Claude Pro");
+    state.settingsManager.setDefaultProvider("anthropic");
+
+    const services = authProfileServicesForTab(state, "default");
+
+    expect(defaultProfileIdForTab(state)).toBe(profileId);
+    expect(state.tabAuthProfileIds.get("default")).toBe(profileId);
+    expect(services.authStorage).not.toBe(state.authStorage);
+    expect(services.modelRegistry).not.toBe(state.modelRegistry);
+  });
+
+  it("uses the model provider default when a tab opens with an explicit model", () => {
+    const state = makeState();
+    const profileId = addProfile(state, "anthropic", "Claude Pro");
+    const model = {
+      provider: "anthropic",
+      id: "claude-sonnet-4-5",
+    } as Model<Api>;
+
+    expect(defaultProfileIdForTab(state, model)).toBe(profileId);
+  });
+
+  it("uses the only configured default when startup has no model or settings provider yet", () => {
+    const state = makeState();
+    const profileId = addProfile(state, "anthropic", "Claude Pro");
+
+    expect(defaultProfileIdForTab(state)).toBe(profileId);
+  });
+
+  it("persists OAuth placeholder removal when login fails", async () => {
+    const userDir = tempUserDir();
+    const state = makeState(userDir);
+    const sent: unknown[] = [];
+    const deps = {
+      send: (message: unknown) => sent.push(message),
+    } as DispatcherDeps;
+
+    await handleAuthProfileMessage(state, deps, {
+      type: "auth_profile_login_start",
+      providerId: "not-a-provider",
+      label: "Broken OAuth",
+    });
+
+    await vi.waitFor(() => {
+      expect(loadAuthProfilesState(userDir).profiles).toHaveLength(0);
+    });
+    expect(state.authProfiles.profiles).toHaveLength(0);
+    expect(
+      sent.some(
+        (message) =>
+          typeof message === "object" &&
+          message !== null &&
+          (message as { type?: string }).type === "auth_profile_login_event" &&
+          (message as { event?: { ok?: boolean } }).event?.ok === false,
+      ),
+    ).toBe(true);
+  });
+});

--- a/agent/auth-profiles/manager.test.ts
+++ b/agent/auth-profiles/manager.test.ts
@@ -14,6 +14,7 @@ import {
   authProfileServicesForTab,
   defaultProfileIdForTab,
   handleAuthProfileMessage,
+  modelRegistryForModelId,
 } from "./manager";
 import {
   createProfileMeta,
@@ -123,5 +124,29 @@ describe("auth profile manager", () => {
           (message as { event?: { ok?: boolean } }).event?.ok === false,
       ),
     ).toBe(true);
+  });
+
+  it("falls back to the global model registry for stale or unsafe profile ids", () => {
+    const state = makeState();
+    state.tabAuthProfileIds.set("tab-1", "../escape");
+    state.authProfiles.defaultByProvider.anthropic = "../escape";
+
+    expect(modelRegistryForModelId(state, "tab-1", "anthropic/claude")).toBe(
+      state.modelRegistry,
+    );
+  });
+
+  it("rejects deleting unknown or unsafe profile ids before removing files", async () => {
+    const state = makeState();
+    const deps = {
+      send: vi.fn(),
+    } as unknown as DispatcherDeps;
+
+    await expect(
+      handleAuthProfileMessage(state, deps, {
+        type: "auth_profile_delete",
+        profileId: "../escape",
+      }),
+    ).rejects.toThrow(/unknown profileId/);
   });
 });

--- a/agent/auth-profiles/manager.ts
+++ b/agent/auth-profiles/manager.ts
@@ -73,9 +73,7 @@ export function authProfileServicesForTab(
 ): AuthProfileServices {
   const profileId =
     state.tabAuthProfileIds.get(tabId) ??
-    (initialModel
-      ? state.authProfiles.defaultByProvider[initialModel.provider]
-      : undefined);
+    defaultProfileIdForTab(state, initialModel);
   if (!profileId) {
     return {
       authStorage: state.authStorage,
@@ -92,6 +90,31 @@ export function authProfileServicesForTab(
   }
   state.tabAuthProfileIds.set(tabId, profile.id);
   return servicesForProfile(state, profile.id);
+}
+
+export function defaultProfileIdForTab(
+  state: AethonAgentState,
+  initialModel?: Model<Api>,
+): string | undefined {
+  const candidates = [
+    initialModel?.provider,
+    state.settingsManager?.getDefaultProvider(),
+    providerFromModelId(state.settingsManager?.getDefaultModel()),
+  ];
+  for (const providerId of candidates) {
+    if (!providerId) continue;
+    const profileId = state.authProfiles.defaultByProvider[providerId];
+    if (profileId) return profileId;
+  }
+  const defaults = Object.values(state.authProfiles.defaultByProvider);
+  return defaults.length === 1 ? defaults[0] : undefined;
+}
+
+function providerFromModelId(modelId: string | undefined): string | undefined {
+  if (!modelId) return undefined;
+  const slash = modelId.indexOf("/");
+  if (slash <= 0) return undefined;
+  return modelId.slice(0, slash);
 }
 
 export function modelRegistryForModelId(
@@ -315,6 +338,7 @@ function handleOAuthStart(
     .catch((err: unknown) => {
       pendingOAuth.delete(challengeId);
       removeProfile(state, meta.id);
+      saveAuthProfiles(state);
       const message = err instanceof Error ? err.message : String(err);
       deps.send({
         type: "auth_profile_login_event",
@@ -344,6 +368,7 @@ function handleOAuthCancel(
   pending.controller.abort();
   pendingOAuth.delete(challengeId);
   removeProfile(state, pending.profileId);
+  saveAuthProfiles(state);
   emitAuthProfiles(state, deps);
 }
 

--- a/agent/auth-profiles/manager.ts
+++ b/agent/auth-profiles/manager.ts
@@ -14,6 +14,7 @@ import {
   authProfileAuthPath,
   createProfileMeta,
   deleteProfileFiles,
+  isSafeProfileId,
   loadAuthProfilesState,
   saveAuthProfilesState,
   type AuthProfileMeta,
@@ -126,7 +127,7 @@ export function modelRegistryForModelId(
   const profileId =
     state.tabAuthProfileIds.get(tabId) ??
     state.authProfiles.defaultByProvider[provider];
-  return profileId
+  return profileId && findProfile(state, profileId)
     ? servicesForProfile(state, profileId).modelRegistry
     : state.modelRegistry;
 }
@@ -180,6 +181,9 @@ function servicesForProfile(
   state: AethonAgentState,
   profileId: string,
 ): AuthProfileServices {
+  if (!isSafeProfileId(profileId)) {
+    throw new Error(`Invalid auth profile id: ${profileId}`);
+  }
   const cached = state.authProfileServices.get(profileId);
   if (cached) return cached;
   const authPath = authProfileAuthPath(state.userDir, profileId);
@@ -454,7 +458,8 @@ function handleDelete(
   msg: InboundMessage,
 ): void {
   const profileId = stringField(msg.profileId);
-  if (!profileId) throw new Error("auth_profile_delete: profileId required");
+  const profile = findProfile(state, profileId);
+  if (!profile) throw new Error("auth_profile_delete: unknown profileId");
   for (const [tabId, activeProfileId] of state.tabAuthProfileIds) {
     if (activeProfileId !== profileId) continue;
     const tab = state.tabs.get(tabId);
@@ -468,6 +473,8 @@ function handleDelete(
 }
 
 function removeProfile(state: AethonAgentState, profileId: string): void {
+  const profile = findProfile(state, profileId);
+  if (!profile) return;
   state.authProfiles = {
     ...state.authProfiles,
     profiles: state.authProfiles.profiles.filter((p) => p.id !== profileId),
@@ -482,6 +489,14 @@ function removeProfile(state: AethonAgentState, profileId: string): void {
   }
   state.authProfileServices.delete(profileId);
   deleteProfileFiles(state.userDir, profileId);
+}
+
+function findProfile(
+  state: AethonAgentState,
+  profileId: string,
+): AuthProfileMeta | undefined {
+  if (!profileId || !isSafeProfileId(profileId)) return undefined;
+  return state.authProfiles.profiles.find((p) => p.id === profileId);
 }
 
 function markProfileUsed(state: AethonAgentState, profileId: string): void {

--- a/agent/auth-profiles/manager.ts
+++ b/agent/auth-profiles/manager.ts
@@ -1,0 +1,475 @@
+import { randomUUID } from "node:crypto";
+import { mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import {
+  AuthStorage,
+  ModelRegistry,
+} from "@mariozechner/pi-coding-agent";
+import type { Api, Model } from "@mariozechner/pi-ai";
+import type { AethonAgentState } from "../state";
+import type { DispatcherDeps, InboundMessage } from "../dispatcherTypes";
+import { emitGlobalReady } from "../dispatcherTypes";
+import { ensureTab } from "../tab-lifecycle";
+import {
+  authProfileAuthPath,
+  createProfileMeta,
+  deleteProfileFiles,
+  loadAuthProfilesState,
+  saveAuthProfilesState,
+  type AuthProfileMeta,
+  type AuthProfilesState,
+} from "./store";
+
+export interface AuthProfileServices {
+  authStorage: AuthStorage;
+  modelRegistry: ModelRegistry;
+}
+
+export interface AuthProfileProvider {
+  id: string;
+  label: string;
+  kind: "oauth" | "api_key";
+  configured: boolean;
+  modelCount: number;
+}
+
+export interface AuthProfilesSnapshot {
+  profiles: AuthProfileMeta[];
+  defaultByProvider: Record<string, string>;
+  providers: AuthProfileProvider[];
+  activeByTab: Record<string, string>;
+}
+
+interface PendingOAuth {
+  profileId: string;
+  providerId: string;
+  controller: AbortController;
+  resolvePrompt?: (value: string) => void;
+}
+
+const pendingOAuth = new Map<string, PendingOAuth>();
+
+export function loadAuthProfiles(userDir: string): AuthProfilesState {
+  return loadAuthProfilesState(userDir);
+}
+
+export function saveAuthProfiles(state: AethonAgentState): void {
+  saveAuthProfilesState(state.userDir, state.authProfiles);
+}
+
+export function authProfilesSnapshot(state: AethonAgentState): AuthProfilesSnapshot {
+  return {
+    profiles: state.authProfiles.profiles,
+    defaultByProvider: state.authProfiles.defaultByProvider,
+    providers: authProfileProviders(state),
+    activeByTab: Object.fromEntries(state.tabAuthProfileIds),
+  };
+}
+
+export function authProfileServicesForTab(
+  state: AethonAgentState,
+  tabId: string,
+  initialModel?: Model<Api>,
+): AuthProfileServices {
+  const profileId =
+    state.tabAuthProfileIds.get(tabId) ??
+    (initialModel
+      ? state.authProfiles.defaultByProvider[initialModel.provider]
+      : undefined);
+  if (!profileId) {
+    return {
+      authStorage: state.authStorage,
+      modelRegistry: state.modelRegistry,
+    };
+  }
+  const profile = state.authProfiles.profiles.find((p) => p.id === profileId);
+  if (!profile) {
+    state.tabAuthProfileIds.delete(tabId);
+    return {
+      authStorage: state.authStorage,
+      modelRegistry: state.modelRegistry,
+    };
+  }
+  state.tabAuthProfileIds.set(tabId, profile.id);
+  return servicesForProfile(state, profile.id);
+}
+
+export function modelRegistryForModelId(
+  state: AethonAgentState,
+  tabId: string,
+  modelId: string,
+): ModelRegistry {
+  const [provider] = modelId.split("/");
+  const profileId =
+    state.tabAuthProfileIds.get(tabId) ??
+    state.authProfiles.defaultByProvider[provider];
+  return profileId
+    ? servicesForProfile(state, profileId).modelRegistry
+    : state.modelRegistry;
+}
+
+export async function handleAuthProfileMessage(
+  state: AethonAgentState,
+  deps: DispatcherDeps,
+  msg: InboundMessage,
+): Promise<boolean> {
+  switch (msg.type) {
+    case "auth_profiles_list":
+      emitAuthProfiles(state, deps);
+      return true;
+    case "auth_profile_api_key_save":
+      handleApiKeySave(state, deps, msg);
+      return true;
+    case "auth_profile_login_start":
+      handleOAuthStart(state, deps, msg);
+      return true;
+    case "auth_profile_oauth_input":
+      handleOAuthInput(msg);
+      return true;
+    case "auth_profile_oauth_cancel":
+      handleOAuthCancel(state, deps, msg);
+      return true;
+    case "auth_profile_use_for_tab":
+      await handleUseForTab(state, deps, msg);
+      return true;
+    case "auth_profile_set_default":
+      handleSetDefault(state, deps, msg);
+      return true;
+    case "auth_profile_rename":
+      handleRename(state, deps, msg);
+      return true;
+    case "auth_profile_delete":
+      handleDelete(state, deps, msg);
+      return true;
+    default:
+      return false;
+  }
+}
+
+export function emitAuthProfiles(
+  state: AethonAgentState,
+  deps: Pick<DispatcherDeps, "send">,
+): void {
+  deps.send({ type: "auth_profiles", authProfiles: authProfilesSnapshot(state) });
+}
+
+function servicesForProfile(
+  state: AethonAgentState,
+  profileId: string,
+): AuthProfileServices {
+  const cached = state.authProfileServices.get(profileId);
+  if (cached) return cached;
+  const authPath = authProfileAuthPath(state.userDir, profileId);
+  mkdirSync(dirname(authPath), { recursive: true });
+  const authStorage = AuthStorage.create(authPath);
+  const modelRegistry = ModelRegistry.create(authStorage);
+  const services = { authStorage, modelRegistry };
+  state.authProfileServices.set(profileId, services);
+  return services;
+}
+
+function authProfileProviders(state: AethonAgentState): AuthProfileProvider[] {
+  if (!state.authStorage || !state.modelRegistry) return [];
+  const oauthIds = new Map(
+    state.authStorage.getOAuthProviders().map((p) => [p.id, p.name]),
+  );
+  const modelCounts = new Map<string, number>();
+  for (const model of state.modelRegistry.getAll()) {
+    modelCounts.set(model.provider, (modelCounts.get(model.provider) ?? 0) + 1);
+  }
+  const ids = new Set([...oauthIds.keys(), ...modelCounts.keys()]);
+  return [...ids]
+    .map((id) => ({
+      id,
+      label: state.modelRegistry.getProviderDisplayName(id) || oauthIds.get(id) || id,
+      kind: oauthIds.has(id) ? ("oauth" as const) : ("api_key" as const),
+      configured: state.modelRegistry.getProviderAuthStatus(id).configured,
+      modelCount: modelCounts.get(id) ?? 0,
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label));
+}
+
+function handleApiKeySave(
+  state: AethonAgentState,
+  deps: DispatcherDeps,
+  msg: InboundMessage,
+): void {
+  const providerId = stringField(msg.providerId);
+  const key = stringField(msg.key);
+  if (!providerId || !key) throw new Error("auth_profile_api_key_save: providerId and key required");
+  const meta = createProfileMeta(state.authProfiles, {
+    providerId,
+    label: stringField(msg.label) || providerId,
+    kind: "api_key",
+  });
+  const services = servicesForProfile(state, meta.id);
+  services.authStorage.set(providerId, { type: "api_key", key });
+  state.authProfiles = {
+    ...state.authProfiles,
+    profiles: [...state.authProfiles.profiles, meta],
+  };
+  if (!state.authProfiles.defaultByProvider[providerId]) {
+    state.authProfiles.defaultByProvider[providerId] = meta.id;
+  }
+  saveAuthProfiles(state);
+  state.authProfileServices.delete(meta.id);
+  emitAuthProfiles(state, deps);
+}
+
+function handleOAuthStart(
+  state: AethonAgentState,
+  deps: DispatcherDeps,
+  msg: InboundMessage,
+): void {
+  const providerId = stringField(msg.providerId);
+  if (!providerId) throw new Error("auth_profile_login_start: providerId required");
+  const meta = createProfileMeta(state.authProfiles, {
+    providerId,
+    label: stringField(msg.label) || providerId,
+    kind: "oauth",
+  });
+  state.authProfiles = {
+    ...state.authProfiles,
+    profiles: [...state.authProfiles.profiles, meta],
+  };
+  saveAuthProfiles(state);
+  const services = servicesForProfile(state, meta.id);
+  const challengeId = randomUUID();
+  const pending: PendingOAuth = {
+    profileId: meta.id,
+    providerId,
+    controller: new AbortController(),
+  };
+  pendingOAuth.set(challengeId, pending);
+  deps.send({
+    type: "auth_profile_login_event",
+    event: { type: "started", challengeId, profileId: meta.id, providerId },
+  });
+  void services.authStorage
+    .login(providerId, {
+      signal: pending.controller.signal,
+      onAuth: ({ url, instructions }) => {
+        deps.send({
+          type: "auth_profile_login_event",
+          event: { type: "auth", challengeId, profileId: meta.id, providerId, url, instructions },
+        });
+      },
+      onProgress: (message) => {
+        deps.send({
+          type: "auth_profile_login_event",
+          event: { type: "progress", challengeId, profileId: meta.id, providerId, message },
+        });
+      },
+      onPrompt: ({ message, placeholder, allowEmpty }) =>
+        new Promise<string>((resolve) => {
+          pending.resolvePrompt = resolve;
+          deps.send({
+            type: "auth_profile_login_event",
+            event: {
+              type: "prompt",
+              challengeId,
+              profileId: meta.id,
+              providerId,
+              message,
+              placeholder,
+              allowEmpty,
+            },
+          });
+        }),
+      onManualCodeInput: () =>
+        new Promise<string>((resolve) => {
+          pending.resolvePrompt = resolve;
+          deps.send({
+            type: "auth_profile_login_event",
+            event: {
+              type: "prompt",
+              challengeId,
+              profileId: meta.id,
+              providerId,
+              message: "Paste the authorization code or callback URL.",
+              allowEmpty: false,
+            },
+          });
+        }),
+    })
+    .then(() => {
+      pendingOAuth.delete(challengeId);
+      const now = Date.now();
+      state.authProfiles = {
+        ...state.authProfiles,
+        profiles: state.authProfiles.profiles.map((p) =>
+          p.id === meta.id ? { ...p, updatedAt: now, lastUsedAt: now } : p,
+        ),
+      };
+      if (!state.authProfiles.defaultByProvider[providerId]) {
+        state.authProfiles.defaultByProvider[providerId] = meta.id;
+      }
+      saveAuthProfiles(state);
+      state.authProfileServices.delete(meta.id);
+      deps.send({
+        type: "auth_profile_login_event",
+        event: { type: "complete", challengeId, profileId: meta.id, providerId, ok: true },
+      });
+      emitAuthProfiles(state, deps);
+    })
+    .catch((err: unknown) => {
+      pendingOAuth.delete(challengeId);
+      removeProfile(state, meta.id);
+      const message = err instanceof Error ? err.message : String(err);
+      deps.send({
+        type: "auth_profile_login_event",
+        event: { type: "complete", challengeId, profileId: meta.id, providerId, ok: false, error: message },
+      });
+      emitAuthProfiles(state, deps);
+    });
+}
+
+function handleOAuthInput(msg: InboundMessage): void {
+  const challengeId = stringField(msg.challengeId);
+  const pending = challengeId ? pendingOAuth.get(challengeId) : undefined;
+  if (!pending?.resolvePrompt) return;
+  const resolve = pending.resolvePrompt;
+  pending.resolvePrompt = undefined;
+  resolve(stringField(msg.value));
+}
+
+function handleOAuthCancel(
+  state: AethonAgentState,
+  deps: DispatcherDeps,
+  msg: InboundMessage,
+): void {
+  const challengeId = stringField(msg.challengeId);
+  const pending = challengeId ? pendingOAuth.get(challengeId) : undefined;
+  if (!pending) return;
+  pending.controller.abort();
+  pendingOAuth.delete(challengeId);
+  removeProfile(state, pending.profileId);
+  emitAuthProfiles(state, deps);
+}
+
+async function handleUseForTab(
+  state: AethonAgentState,
+  deps: DispatcherDeps,
+  msg: InboundMessage,
+): Promise<void> {
+  const tabId = stringField(msg.tabId) || "default";
+  const profileId = stringField(msg.profileId);
+  const profile = profileId
+    ? state.authProfiles.profiles.find((p) => p.id === profileId)
+    : undefined;
+  if (!profile) throw new Error("auth_profile_use_for_tab: unknown profileId");
+  const existing = state.tabs.get(tabId);
+  if (existing?.promptInFlight) {
+    deps.send({
+      type: "notice",
+      tabId,
+      message: "agent busy — stop the current prompt before switching accounts",
+    });
+    return;
+  }
+  const previousModel = existing?.session.model;
+  const cwd = state.tabProjectCwds.get(tabId);
+  state.tabs.delete(tabId);
+  state.tabAuthProfileIds.set(tabId, profile.id);
+  const services = servicesForProfile(state, profile.id);
+  const nextModel =
+    previousModel && services.modelRegistry.find(previousModel.provider, previousModel.id);
+  const rec = await ensureTab(state, deps, tabId, {
+    cwdOverride: cwd,
+    initialModel: nextModel || previousModel,
+  });
+  markProfileUsed(state, profile.id);
+  deps.send({
+    type: "auth_profile_changed",
+    tabId,
+    profileId: profile.id,
+    model: rec.session.model
+      ? `${rec.session.model.provider}/${rec.session.model.id}`
+      : "",
+  });
+  emitAuthProfiles(state, deps);
+  emitGlobalReady(state, deps);
+}
+
+function handleSetDefault(
+  state: AethonAgentState,
+  deps: DispatcherDeps,
+  msg: InboundMessage,
+): void {
+  const profileId = stringField(msg.profileId);
+  const profile = state.authProfiles.profiles.find((p) => p.id === profileId);
+  if (!profile) throw new Error("auth_profile_set_default: unknown profileId");
+  state.authProfiles.defaultByProvider[profile.providerId] = profile.id;
+  saveAuthProfiles(state);
+  emitAuthProfiles(state, deps);
+}
+
+function handleRename(
+  state: AethonAgentState,
+  deps: DispatcherDeps,
+  msg: InboundMessage,
+): void {
+  const profileId = stringField(msg.profileId);
+  const label = stringField(msg.label).trim();
+  if (!label) throw new Error("auth_profile_rename: label required");
+  const now = Date.now();
+  state.authProfiles = {
+    ...state.authProfiles,
+    profiles: state.authProfiles.profiles.map((p) =>
+      p.id === profileId ? { ...p, label, updatedAt: now } : p,
+    ),
+  };
+  saveAuthProfiles(state);
+  emitAuthProfiles(state, deps);
+}
+
+function handleDelete(
+  state: AethonAgentState,
+  deps: DispatcherDeps,
+  msg: InboundMessage,
+): void {
+  const profileId = stringField(msg.profileId);
+  if (!profileId) throw new Error("auth_profile_delete: profileId required");
+  for (const [tabId, activeProfileId] of state.tabAuthProfileIds) {
+    if (activeProfileId !== profileId) continue;
+    const tab = state.tabs.get(tabId);
+    if (tab?.promptInFlight) {
+      throw new Error("Cannot delete an account while one of its sessions is running.");
+    }
+  }
+  removeProfile(state, profileId);
+  saveAuthProfiles(state);
+  emitAuthProfiles(state, deps);
+}
+
+function removeProfile(state: AethonAgentState, profileId: string): void {
+  state.authProfiles = {
+    ...state.authProfiles,
+    profiles: state.authProfiles.profiles.filter((p) => p.id !== profileId),
+    defaultByProvider: Object.fromEntries(
+      Object.entries(state.authProfiles.defaultByProvider).filter(
+        ([, id]) => id !== profileId,
+      ),
+    ),
+  };
+  for (const [tabId, id] of state.tabAuthProfileIds) {
+    if (id === profileId) state.tabAuthProfileIds.delete(tabId);
+  }
+  state.authProfileServices.delete(profileId);
+  deleteProfileFiles(state.userDir, profileId);
+}
+
+function markProfileUsed(state: AethonAgentState, profileId: string): void {
+  const now = Date.now();
+  state.authProfiles = {
+    ...state.authProfiles,
+    profiles: state.authProfiles.profiles.map((p) =>
+      p.id === profileId ? { ...p, lastUsedAt: now, updatedAt: now } : p,
+    ),
+  };
+  saveAuthProfiles(state);
+}
+
+function stringField(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}

--- a/agent/auth-profiles/store.test.ts
+++ b/agent/auth-profiles/store.test.ts
@@ -1,10 +1,13 @@
-import { mkdtempSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { describe, expect, it } from "vitest";
 import {
   authProfileAuthPath,
+  authProfilesStatePath,
   createProfileMeta,
+  deleteProfileFiles,
+  isSafeProfileId,
   loadAuthProfilesState,
   saveAuthProfilesState,
   upsertProfileMeta,
@@ -52,5 +55,74 @@ describe("auth profile store", () => {
       authProfileAuthPath(userDir, second.id),
     );
     expect(authProfileAuthPath(userDir, first.id)).toMatch(/auth\.json$/);
+  });
+
+  it("falls back to an empty state when profiles.json is corrupt", () => {
+    const userDir = mkdtempSync(join(tmpdir(), "aethon-auth-"));
+    mkdirSync(dirname(authProfilesStatePath(userDir)), { recursive: true });
+    writeFileSync(authProfilesStatePath(userDir), "{not json");
+
+    expect(loadAuthProfilesState(userDir)).toEqual({
+      version: 1,
+      profiles: [],
+      defaultByProvider: {},
+    });
+  });
+
+  it("ignores unsafe profile ids when loading metadata", () => {
+    const userDir = mkdtempSync(join(tmpdir(), "aethon-auth-"));
+    mkdirSync(dirname(authProfilesStatePath(userDir)), { recursive: true });
+    writeFileSync(
+      authProfilesStatePath(userDir),
+      JSON.stringify({
+        version: 1,
+        profiles: [
+          {
+            id: "../escape",
+            providerId: "anthropic",
+            label: "bad",
+            kind: "oauth",
+            createdAt: 1,
+            updatedAt: 1,
+          },
+          {
+            id: "anthropic-safe",
+            providerId: "anthropic",
+            label: "safe",
+            kind: "oauth",
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        ],
+        defaultByProvider: {
+          anthropic: "../escape",
+          openai: 123,
+        },
+      }),
+    );
+
+    expect(loadAuthProfilesState(userDir)).toEqual({
+      version: 1,
+      profiles: [
+        expect.objectContaining({
+          id: "anthropic-safe",
+          providerId: "anthropic",
+        }),
+      ],
+      defaultByProvider: {},
+    });
+  });
+
+  it("rejects unsafe profile ids before filesystem operations", () => {
+    const userDir = mkdtempSync(join(tmpdir(), "aethon-auth-"));
+
+    expect(isSafeProfileId("anthropic-claude-pro_2")).toBe(true);
+    expect(isSafeProfileId("../escape")).toBe(false);
+    expect(() => authProfileAuthPath(userDir, "../escape")).toThrow(
+      /Invalid auth profile id/,
+    );
+    expect(() => deleteProfileFiles(userDir, "../escape")).toThrow(
+      /Invalid auth profile id/,
+    );
   });
 });

--- a/agent/auth-profiles/store.test.ts
+++ b/agent/auth-profiles/store.test.ts
@@ -1,0 +1,56 @@
+import { mkdtempSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, expect, it } from "vitest";
+import {
+  authProfileAuthPath,
+  createProfileMeta,
+  loadAuthProfilesState,
+  saveAuthProfilesState,
+  upsertProfileMeta,
+} from "./store";
+
+describe("auth profile store", () => {
+  it("persists profile metadata without credential values", () => {
+    const userDir = mkdtempSync(join(tmpdir(), "aethon-auth-"));
+    let state = loadAuthProfilesState(userDir);
+    const profile = createProfileMeta(state, {
+      providerId: "anthropic",
+      label: "work",
+      kind: "oauth",
+      now: 1,
+    });
+    state = upsertProfileMeta(state, profile);
+    state.defaultByProvider.anthropic = profile.id;
+    saveAuthProfilesState(userDir, state);
+
+    const raw = readFileSync(join(userDir, "auth", "profiles.json"), "utf8");
+    expect(raw).not.toContain("access");
+    expect(raw).not.toContain("refresh");
+    expect(loadAuthProfilesState(userDir)).toEqual(state);
+  });
+
+  it("allocates separate pi-compatible auth paths for accounts", () => {
+    const userDir = mkdtempSync(join(tmpdir(), "aethon-auth-"));
+    const initial = loadAuthProfilesState(userDir);
+    const first = createProfileMeta(initial, {
+      providerId: "anthropic",
+      label: "Claude Pro",
+      kind: "oauth",
+      now: 1,
+    });
+    const second = createProfileMeta(upsertProfileMeta(initial, first), {
+      providerId: "anthropic",
+      label: "Claude Pro",
+      kind: "oauth",
+      now: 2,
+    });
+
+    expect(first.id).toBe("anthropic-claude-pro");
+    expect(second.id).toBe("anthropic-claude-pro-2");
+    expect(authProfileAuthPath(userDir, first.id)).not.toBe(
+      authProfileAuthPath(userDir, second.id),
+    );
+    expect(authProfileAuthPath(userDir, first.id)).toMatch(/auth\.json$/);
+  });
+});

--- a/agent/auth-profiles/store.ts
+++ b/agent/auth-profiles/store.ts
@@ -34,6 +34,7 @@ export function authProfilesStatePath(userDir: string): string {
 }
 
 export function authProfileAuthPath(userDir: string, profileId: string): string {
+  assertSafeProfileId(profileId);
   return join(authProfilesDir(userDir), "profiles", profileId, "auth.json");
 }
 
@@ -47,17 +48,38 @@ export function sanitizeProfileId(input: string): string {
   return slug || "account";
 }
 
+export function isSafeProfileId(input: string): boolean {
+  return /^[a-z0-9_-]{1,80}$/.test(input);
+}
+
+function assertSafeProfileId(profileId: string): void {
+  if (!isSafeProfileId(profileId)) {
+    throw new Error(`Invalid auth profile id: ${profileId}`);
+  }
+}
+
 export function loadAuthProfilesState(userDir: string): AuthProfilesState {
   const path = authProfilesStatePath(userDir);
   if (!existsSync(path)) return { ...EMPTY_STATE, defaultByProvider: {} };
-  const raw = readFileSync(path, "utf8");
-  const parsed = JSON.parse(raw) as Partial<AuthProfilesState>;
+  let parsed: Partial<AuthProfilesState>;
+  try {
+    parsed = JSON.parse(readFileSync(path, "utf8")) as Partial<AuthProfilesState>;
+  } catch {
+    return { ...EMPTY_STATE, defaultByProvider: {} };
+  }
   const profiles = Array.isArray(parsed.profiles)
     ? parsed.profiles.filter(isProfileMeta)
     : [];
   const ids = new Set(profiles.map((p) => p.id));
   const defaultByProvider: Record<string, string> = {};
-  for (const [provider, profileId] of Object.entries(parsed.defaultByProvider ?? {})) {
+  const defaults =
+    parsed.defaultByProvider &&
+    typeof parsed.defaultByProvider === "object" &&
+    !Array.isArray(parsed.defaultByProvider)
+      ? parsed.defaultByProvider
+      : {};
+  for (const [provider, profileId] of Object.entries(defaults)) {
+    if (typeof profileId !== "string") continue;
     if (ids.has(profileId)) defaultByProvider[provider] = profileId;
   }
   return { version: 1, profiles, defaultByProvider };
@@ -104,6 +126,7 @@ export function upsertProfileMeta(
 }
 
 export function deleteProfileFiles(userDir: string, profileId: string): void {
+  assertSafeProfileId(profileId);
   rmSync(join(authProfilesDir(userDir), "profiles", profileId), {
     recursive: true,
     force: true,
@@ -115,6 +138,7 @@ function isProfileMeta(value: unknown): value is AuthProfileMeta {
   const rec = value as Record<string, unknown>;
   return (
     typeof rec.id === "string" &&
+    isSafeProfileId(rec.id) &&
     typeof rec.providerId === "string" &&
     typeof rec.label === "string" &&
     (rec.kind === "oauth" || rec.kind === "api_key") &&

--- a/agent/auth-profiles/store.ts
+++ b/agent/auth-profiles/store.ts
@@ -1,0 +1,124 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+export type AuthProfileKind = "oauth" | "api_key";
+
+export interface AuthProfileMeta {
+  id: string;
+  providerId: string;
+  label: string;
+  kind: AuthProfileKind;
+  createdAt: number;
+  updatedAt: number;
+  lastUsedAt?: number;
+}
+
+export interface AuthProfilesState {
+  version: 1;
+  profiles: AuthProfileMeta[];
+  defaultByProvider: Record<string, string>;
+}
+
+const EMPTY_STATE: AuthProfilesState = {
+  version: 1,
+  profiles: [],
+  defaultByProvider: {},
+};
+
+export function authProfilesDir(userDir: string): string {
+  return join(userDir, "auth");
+}
+
+export function authProfilesStatePath(userDir: string): string {
+  return join(authProfilesDir(userDir), "profiles.json");
+}
+
+export function authProfileAuthPath(userDir: string, profileId: string): string {
+  return join(authProfilesDir(userDir), "profiles", profileId, "auth.json");
+}
+
+export function sanitizeProfileId(input: string): string {
+  const slug = input
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48);
+  return slug || "account";
+}
+
+export function loadAuthProfilesState(userDir: string): AuthProfilesState {
+  const path = authProfilesStatePath(userDir);
+  if (!existsSync(path)) return { ...EMPTY_STATE, defaultByProvider: {} };
+  const raw = readFileSync(path, "utf8");
+  const parsed = JSON.parse(raw) as Partial<AuthProfilesState>;
+  const profiles = Array.isArray(parsed.profiles)
+    ? parsed.profiles.filter(isProfileMeta)
+    : [];
+  const ids = new Set(profiles.map((p) => p.id));
+  const defaultByProvider: Record<string, string> = {};
+  for (const [provider, profileId] of Object.entries(parsed.defaultByProvider ?? {})) {
+    if (ids.has(profileId)) defaultByProvider[provider] = profileId;
+  }
+  return { version: 1, profiles, defaultByProvider };
+}
+
+export function saveAuthProfilesState(userDir: string, state: AuthProfilesState): void {
+  const path = authProfilesStatePath(userDir);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(state, null, 2));
+}
+
+export function createProfileMeta(
+  state: AuthProfilesState,
+  input: {
+    providerId: string;
+    label: string;
+    kind: AuthProfileKind;
+    now?: number;
+  },
+): AuthProfileMeta {
+  const now = input.now ?? Date.now();
+  const base = sanitizeProfileId(`${input.providerId}-${input.label}`);
+  const used = new Set(state.profiles.map((p) => p.id));
+  let id = base;
+  for (let i = 2; used.has(id); i += 1) id = `${base}-${i}`;
+  return {
+    id,
+    providerId: input.providerId,
+    label: input.label.trim() || input.providerId,
+    kind: input.kind,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+export function upsertProfileMeta(
+  state: AuthProfilesState,
+  meta: AuthProfileMeta,
+): AuthProfilesState {
+  const profiles = state.profiles.filter((p) => p.id !== meta.id);
+  profiles.push(meta);
+  profiles.sort((a, b) => a.providerId.localeCompare(b.providerId) || a.label.localeCompare(b.label));
+  return { ...state, profiles };
+}
+
+export function deleteProfileFiles(userDir: string, profileId: string): void {
+  rmSync(join(authProfilesDir(userDir), "profiles", profileId), {
+    recursive: true,
+    force: true,
+  });
+}
+
+function isProfileMeta(value: unknown): value is AuthProfileMeta {
+  if (!value || typeof value !== "object") return false;
+  const rec = value as Record<string, unknown>;
+  return (
+    typeof rec.id === "string" &&
+    typeof rec.providerId === "string" &&
+    typeof rec.label === "string" &&
+    (rec.kind === "oauth" || rec.kind === "api_key") &&
+    typeof rec.createdAt === "number" &&
+    typeof rec.updatedAt === "number"
+  );
+}

--- a/agent/chat.ts
+++ b/agent/chat.ts
@@ -7,6 +7,7 @@ import {
   ensurePickerHasModel,
   ensureTab,
 } from "./tab-lifecycle";
+import { modelRegistryForModelId } from "./auth-profiles";
 
 export async function handleChat(
   state: AethonAgentState,
@@ -24,7 +25,10 @@ export async function handleChat(
   if (typeof msg.model === "string" && msg.model.length > 0) {
     const [provider, ...rest] = msg.model.split("/");
     initialModel =
-      state.modelRegistry.find(provider, rest.join("/")) ?? undefined;
+      modelRegistryForModelId(state, tabId, msg.model).find(
+        provider,
+        rest.join("/"),
+      ) ?? undefined;
   }
   const tab = await ensureTab(
     state,
@@ -107,7 +111,10 @@ export async function handleSetModel(
   }
   const [provider, ...rest] = msg.id.split("/");
   const id = rest.join("/");
-  const next = state.modelRegistry.find(provider, id);
+  const next = modelRegistryForModelId(state, tabId, msg.id).find(
+    provider,
+    id,
+  );
   if (!next) {
     deps.send({
       type: "error",

--- a/agent/dispatcher.ts
+++ b/agent/dispatcher.ts
@@ -15,6 +15,7 @@ import { ackMutation, markFrontendReady } from "./mutation-ack";
 import { onDevshellEvent } from "./devshell";
 import { handleNativeSlashCommand } from "./nativeSlash";
 import { handleSetProject } from "./projectLifecycle";
+import { handleAuthProfileMessage } from "./auth-profiles";
 import {
   handleLocalChatMessage,
   handleSetSessionLabel,
@@ -68,6 +69,8 @@ export async function dispatchInboundMessage(
 ): Promise<void> {
   const notifDeps = { send: deps.send };
   try {
+    if (await handleAuthProfileMessage(state, deps, msg)) return;
+
     switch (msg.type) {
       case "chat":
         await handleChat(state, deps, msg);

--- a/agent/dispatcherTypes.ts
+++ b/agent/dispatcherTypes.ts
@@ -42,6 +42,11 @@ export interface InboundMessage {
   mutationId?: string;
   success?: boolean;
   error?: string;
+  providerId?: string;
+  profileId?: string;
+  label?: string;
+  key?: string;
+  challengeId?: string;
   event?: {
     componentId?: string;
     componentType?: string;

--- a/agent/main.ts
+++ b/agent/main.ts
@@ -65,6 +65,7 @@ import {
   type LayoutSlotsCatalogue,
 } from "./state";
 import { buildAethonApi } from "./aethon-api";
+import { loadAuthProfiles } from "./auth-profiles";
 import {
   getRuntimeSnapshot,
   scheduleStateFileWrite as scheduleStateFileWriteImpl,
@@ -124,6 +125,7 @@ async function main(): Promise<void> {
   state.authStorage = AuthStorage.create();
   state.modelRegistry = ModelRegistry.create(state.authStorage);
   state.settingsManager = SettingsManager.create(process.cwd());
+  state.authProfiles = loadAuthProfiles(state.userDir);
 
   // -- User's persisted "disabled extensions" list -----------------------
   // Read before any extension load so the loader honors it on first pass.

--- a/agent/state.ts
+++ b/agent/state.ts
@@ -20,6 +20,10 @@ import type {
 } from "@mariozechner/pi-coding-agent";
 import { AsyncLocalStorage } from "node:async_hooks";
 import type { BashTerminalStreamState } from "./terminal-stream";
+import type {
+  AuthProfileServices,
+  AuthProfilesState,
+} from "./auth-profiles";
 
 // ---------------------------------------------------------------------------
 // Shared types — extracted from the original main.ts
@@ -327,6 +331,12 @@ export class AethonAgentState {
   modelRegistry!: ModelRegistry;
   settingsManager!: SettingsManager;
   resourceLoader!: DefaultResourceLoader;
+  authProfiles: AuthProfilesState = {
+    version: 1,
+    profiles: [],
+    defaultByProvider: {},
+  };
+  readonly authProfileServices = new Map<string, AuthProfileServices>();
 
   // -- Layout (loaded synchronously at boot from $AETHON_BOOT_LAYOUT_FILE) -
   bootLayout: unknown = undefined;
@@ -335,6 +345,7 @@ export class AethonAgentState {
   // -- Tabs / sessions -----------------------------------------------------
   readonly tabs = new Map<string, TabRecord>();
   readonly tabProjectCwds = new Map<string, string>();
+  readonly tabAuthProfileIds = new Map<string, string>();
   /** Tab whose pi turn is currently running. Set when a chat / handler
    *  prompt is dispatched; cleared on agent_end. Used by setState so
    *  direct globalThis.aethon.setState calls from the agent or extensions

--- a/agent/tab-lifecycle/lifecycle.ts
+++ b/agent/tab-lifecycle/lifecycle.ts
@@ -5,9 +5,9 @@
  * scoped to the tab's cwd. The per-tab subscriber is wired in here so
  * `handleSessionEvent` (in `./events.ts`) carries the routing context.
  *
- * Sessions share authStorage / modelRegistry / settingsManager /
- * resourceLoader so they all see the same models and extension surface
- * — only message history and active turn are isolated.
+ * Sessions usually share authStorage / modelRegistry / settingsManager /
+ * resourceLoader. Tabs with an auth profile get isolated auth/model services
+ * so one desktop session can switch between multiple signed-in accounts.
  */
 
 import { mkdirSync } from "node:fs";
@@ -22,6 +22,7 @@ import { buildDashboardTools } from "../dashboard-tools";
 import { buildDevshellSpawnHook, ensureFetched as ensureDevshellFetched } from "../devshell";
 import { wrapWithSourceGuard } from "../source-guard";
 import { logger } from "../logger";
+import { authProfileServicesForTab } from "../auth-profiles";
 import { findSessionFileMatchingCwd } from "../session-history";
 import type { AethonAgentState, TabRecord } from "../state";
 import { handleSessionEvent } from "./events";
@@ -103,10 +104,15 @@ export async function ensureTab(
   const devshellBashTool = createBashToolDefinition(resolvedCwd, {
     spawnHook: buildDevshellSpawnHook(state, deps),
   });
+  const authServices = authProfileServicesForTab(
+    state,
+    tabId,
+    options.initialModel,
+  );
 
   const { session } = await createAgentSession({
-    authStorage: state.authStorage,
-    modelRegistry: state.modelRegistry,
+    authStorage: authServices.authStorage,
+    modelRegistry: authServices.modelRegistry,
     settingsManager: state.settingsManager,
     sessionManager,
     resourceLoader: state.resourceLoader,

--- a/agent/tab-lifecycle/ready-handshake.ts
+++ b/agent/tab-lifecycle/ready-handshake.ts
@@ -11,6 +11,7 @@
  */
 
 import type { AethonAgentState } from "../state";
+import { authProfilesSnapshot } from "../auth-profiles";
 import { defaultModelKey } from "./models";
 import { refreshPiSlashCommands } from "./slash-commands";
 import type { TabLifecycleDeps } from "./utils";
@@ -32,10 +33,12 @@ export function emitReady(
     currentProjectCwd: state.currentProjectCwd,
     userDir: state.userDir,
     models: state.cachedModels,
+    authProfiles: authProfilesSnapshot(state),
     tabs: [...state.tabs.values()].map((t) => ({
       id: t.id,
       model: t.session.model ? modelKey(t.session.model) : "",
       cwd: state.tabProjectCwds.get(t.id),
+      authProfileId: state.tabAuthProfileIds.get(t.id),
     })),
     extensionComponents: Object.fromEntries(state.extensionComponents),
     extensionState: state.extensionStateTree,

--- a/agent/tabs.ts
+++ b/agent/tabs.ts
@@ -12,6 +12,7 @@ import {
 } from "./session-history";
 import { ensureTab, tabSessionDir } from "./tab-lifecycle";
 import { unloadProjectExtensions } from "./projectLifecycle";
+import { modelRegistryForModelId } from "./auth-profiles";
 
 export async function handleTabOpen(
   state: AethonAgentState,
@@ -24,12 +25,19 @@ export async function handleTabOpen(
     deps.send({ type: "error", message: "tab_open: missing tabId" });
     return;
   }
+  const authProfileId = (msg as { authProfileId?: unknown }).authProfileId;
+  if (typeof authProfileId === "string" && authProfileId.length > 0) {
+    state.tabAuthProfileIds.set(tabId, authProfileId);
+  }
   const modelId = (msg as { model?: unknown }).model;
   let initialModel: Model<Api> | undefined;
   if (typeof modelId === "string" && modelId.length > 0) {
     const [provider, ...rest] = modelId.split("/");
     initialModel =
-      state.modelRegistry.find(provider, rest.join("/")) ?? undefined;
+      modelRegistryForModelId(state, tabId, modelId).find(
+        provider,
+        rest.join("/"),
+      ) ?? undefined;
   }
   const cwdField = (msg as { cwd?: unknown }).cwd;
   const cwdOverride =
@@ -104,6 +112,7 @@ export function handleTabClose(
   }
   state.tabs.delete(tabId);
   state.tabProjectCwds.delete(tabId);
+  state.tabAuthProfileIds.delete(tabId);
   if (state.currentAgentTabId === tabId) {
     state.currentAgentTabId = undefined;
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -800,6 +800,7 @@ export default function App() {
     paletteOpen,
     settingsOpen,
     searchOpen,
+    authProfilesOpen,
   } = useDerivedRenderState({ state, buildSidebarHistory, hostInfo });
 
   return (
@@ -814,6 +815,7 @@ export default function App() {
       paletteOpen={paletteOpen}
       settingsOpen={settingsOpen}
       searchOpen={searchOpen}
+      authProfilesOpen={authProfilesOpen}
       topBanner={
         <UpdateBanner
           state={updaterState}

--- a/src/app/AppRoot.tsx
+++ b/src/app/AppRoot.tsx
@@ -18,6 +18,7 @@ export interface AppRootProps {
   paletteOpen: boolean;
   settingsOpen: boolean;
   searchOpen: boolean;
+  authProfilesOpen: boolean;
   /** Optional banner row rendered above the layout. Sits in flow as the
    *  first flex child of `.app` so it pushes the rest of the chrome
    *  down instead of floating over it. */
@@ -42,6 +43,7 @@ export function AppRoot({
   paletteOpen,
   settingsOpen,
   searchOpen,
+  authProfilesOpen,
   topBanner,
 }: AppRootProps) {
   return (
@@ -82,6 +84,14 @@ export function AppRoot({
         {searchOpen && (
           <RegistryComponent
             type="search-panel"
+            state={renderState}
+            onEvent={onEvent}
+            tabId={activeTabId}
+          />
+        )}
+        {authProfilesOpen && (
+          <RegistryComponent
+            type="auth-profile-panel"
             state={renderState}
             onEvent={onEvent}
             tabId={activeTabId}

--- a/src/auth-profiles/commands.ts
+++ b/src/auth-profiles/commands.ts
@@ -1,0 +1,13 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export async function sendAuthProfileCommand(
+  payload: Record<string, unknown>,
+): Promise<void> {
+  await invoke("agent_command", {
+    payload: JSON.stringify(payload),
+  });
+}
+
+export async function requestAuthProfiles(): Promise<void> {
+  await sendAuthProfileCommand({ type: "auth_profiles_list" });
+}

--- a/src/auth-profiles/index.ts
+++ b/src/auth-profiles/index.ts
@@ -1,0 +1,2 @@
+export * from "./types";
+export * from "./commands";

--- a/src/auth-profiles/types.ts
+++ b/src/auth-profiles/types.ts
@@ -1,0 +1,54 @@
+export type AuthProfileKind = "oauth" | "api_key";
+
+export interface AuthProfileMeta {
+  id: string;
+  providerId: string;
+  label: string;
+  kind: AuthProfileKind;
+  createdAt: number;
+  updatedAt: number;
+  lastUsedAt?: number;
+}
+
+export interface AuthProfileProvider {
+  id: string;
+  label: string;
+  kind: AuthProfileKind;
+  configured: boolean;
+  modelCount: number;
+}
+
+export interface AuthProfilesSnapshot {
+  profiles: AuthProfileMeta[];
+  defaultByProvider: Record<string, string>;
+  providers: AuthProfileProvider[];
+  activeByTab: Record<string, string>;
+}
+
+export interface AuthProfileLoginEvent {
+  type: "started" | "auth" | "progress" | "prompt" | "complete";
+  challengeId: string;
+  profileId: string;
+  providerId: string;
+  url?: string;
+  instructions?: string;
+  message?: string;
+  placeholder?: string;
+  allowEmpty?: boolean;
+  ok?: boolean;
+  error?: string;
+}
+
+export interface AuthProfilesUiState extends AuthProfilesSnapshot {
+  modal?: {
+    open?: boolean;
+  };
+  login?: AuthProfileLoginEvent;
+}
+
+export const EMPTY_AUTH_PROFILES: AuthProfilesSnapshot = {
+  profiles: [],
+  defaultByProvider: {},
+  providers: [],
+  activeByTab: {},
+};

--- a/src/eventRoutes/authProfiles.test.ts
+++ b/src/eventRoutes/authProfiles.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { handleAuthProfiles } from "./authProfiles";
+import { buildRouteFixture } from "./testFixtures";
+
+describe("handleAuthProfiles", () => {
+  it("closes the auth profiles modal on close events", async () => {
+    const { ctx, applySetState } = buildRouteFixture({
+      state: {
+        authProfiles: {
+          profiles: [{ id: "anthropic-work", label: "Work" }],
+          defaultByProvider: { anthropic: "anthropic-work" },
+          providers: [],
+          activeByTab: { default: "anthropic-work" },
+          modal: { open: true },
+        },
+      },
+    });
+
+    const handled = await handleAuthProfiles(
+      { component: { id: "auth-profile-panel" }, eventType: "close" },
+      ctx,
+    );
+
+    expect(handled).toBe(true);
+    expect(applySetState().authProfiles).toMatchObject({
+      profiles: [{ id: "anthropic-work", label: "Work" }],
+      defaultByProvider: { anthropic: "anthropic-work" },
+      activeByTab: { default: "anthropic-work" },
+      modal: { open: false },
+    });
+  });
+
+  it("returns false for non-close events", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+
+    const handled = await handleAuthProfiles(
+      { component: { id: "auth-profile-panel" }, eventType: "submit" },
+      ctx,
+    );
+
+    expect(handled).toBe(false);
+    expect(mocks.setState).not.toHaveBeenCalled();
+  });
+});

--- a/src/eventRoutes/authProfiles.ts
+++ b/src/eventRoutes/authProfiles.ts
@@ -1,0 +1,17 @@
+import type { EventRouteHandler } from "./types";
+
+export const handleAuthProfiles: EventRouteHandler = ({ eventType }, ctx) => {
+  if (eventType !== "close") return false;
+  ctx.setState((prev) => ({
+    ...prev,
+    authProfiles: {
+      profiles: [],
+      defaultByProvider: {},
+      providers: [],
+      activeByTab: {},
+      ...(prev.authProfiles ?? {}),
+      modal: { open: false },
+    },
+  }));
+  return true;
+};

--- a/src/eventRoutes/index.ts
+++ b/src/eventRoutes/index.ts
@@ -32,6 +32,7 @@ import { handleChatInput } from "./chatInput";
 import { handleChatMessages } from "./chatMessages";
 import { handleQueuedMessages } from "./queue";
 import { handleSettings } from "./settings";
+import { handleAuthProfiles } from "./authProfiles";
 import { handleSearch } from "./search";
 import { handlePalette } from "./palette";
 import { handleNotifications } from "./notifications";
@@ -84,6 +85,7 @@ export const BUILTIN_ROUTE_TABLE: ReadonlyMap<string, readonly EventRouteHandler
     // top-precedence gate; the general handler runs here.
     ["type:notification-stack", [handleNotifications]],
     ["type:settings-panel", [handleSettings]],
+    ["type:auth-profile-panel", [handleAuthProfiles]],
     ["type:search-panel", [handleSearch]],
     ["type:command-palette", [handlePalette]],
     // Order matters: handleQueuedMessages runs FIRST and only matches

--- a/src/hooks/bridgeMessageHandlers/authProfiles.test.ts
+++ b/src/hooks/bridgeMessageHandlers/authProfiles.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import { makeEmptyTab } from "../../types/tab";
+import {
+  handleAuthProfileChanged,
+  handleAuthProfiles,
+} from "./authProfiles";
+import { buildHandlerFixture } from "./testFixtures";
+
+describe("auth profile bridge handlers", () => {
+  it("hydrates auth profiles and mirrors active profile ids onto tabs", () => {
+    const tab = makeEmptyTab("default", "Tab 1");
+    const { ctx, applySetState } = buildHandlerFixture({
+      state: {
+        tabs: [tab],
+        authProfiles: {
+          profiles: [],
+          defaultByProvider: {},
+          providers: [],
+          activeByTab: {},
+          modal: { open: true },
+        },
+      },
+    });
+
+    handleAuthProfiles(
+      {
+        type: "auth_profiles",
+        authProfiles: {
+          profiles: [
+            {
+              id: "anthropic-work",
+              providerId: "anthropic",
+              label: "Work",
+              kind: "oauth",
+              createdAt: 1,
+              updatedAt: 1,
+            },
+          ],
+          defaultByProvider: {
+            anthropic: "anthropic-work",
+            invalid: 123,
+          },
+          providers: [
+            {
+              id: "anthropic",
+              label: "Anthropic",
+              kind: "oauth",
+              configured: true,
+              modelCount: 2,
+            },
+          ],
+          activeByTab: {
+            default: "anthropic-work",
+            ignored: null,
+          },
+        },
+      },
+      ctx,
+    );
+
+    expect(applySetState()).toMatchObject({
+      tabs: [{ id: "default", authProfileId: "anthropic-work" }],
+      authProfiles: {
+        profiles: [{ id: "anthropic-work", providerId: "anthropic" }],
+        defaultByProvider: { anthropic: "anthropic-work" },
+        providers: [{ id: "anthropic", configured: true }],
+        activeByTab: { default: "anthropic-work" },
+        modal: { open: true },
+      },
+    });
+  });
+
+  it("rejects array maps while hydrating auth profile snapshots", () => {
+    const { ctx, applySetState } = buildHandlerFixture({
+      state: { tabs: [makeEmptyTab("default", "Tab 1")] },
+    });
+
+    handleAuthProfiles(
+      {
+        type: "auth_profiles",
+        authProfiles: {
+          profiles: [],
+          defaultByProvider: ["anthropic-work"],
+          providers: [],
+          activeByTab: ["anthropic-work"],
+        },
+      },
+      ctx,
+    );
+
+    expect(applySetState()).toMatchObject({
+      tabs: [{ id: "default", authProfileId: undefined }],
+      authProfiles: {
+        defaultByProvider: {},
+        activeByTab: {},
+      },
+    });
+  });
+
+  it("records auth profile changes in the tab and snapshot activeByTab map", () => {
+    const { ctx, mocks, applySetState } = buildHandlerFixture({
+      state: {
+        authProfiles: {
+          profiles: [],
+          defaultByProvider: {},
+          providers: [],
+          activeByTab: {},
+        },
+      },
+    });
+
+    handleAuthProfileChanged(
+      {
+        type: "auth_profile_changed",
+        tabId: "default",
+        profileId: "anthropic-work",
+        model: "anthropic/claude-sonnet-4-5",
+      },
+      ctx,
+    );
+
+    expect(mocks.updateTab).toHaveBeenCalledWith("default", expect.any(Function));
+    const updater = mocks.updateTab.mock.calls[0]?.[1] as (
+      tab: ReturnType<typeof makeEmptyTab>,
+    ) => ReturnType<typeof makeEmptyTab>;
+    expect(updater(makeEmptyTab("default", "Tab 1"))).toMatchObject({
+      authProfileId: "anthropic-work",
+      model: "anthropic/claude-sonnet-4-5",
+    });
+    expect(applySetState().authProfiles).toMatchObject({
+      activeByTab: { default: "anthropic-work" },
+    });
+  });
+});

--- a/src/hooks/bridgeMessageHandlers/authProfiles.ts
+++ b/src/hooks/bridgeMessageHandlers/authProfiles.ts
@@ -1,0 +1,122 @@
+import { openUrl } from "@tauri-apps/plugin-opener";
+import type {
+  AuthProfileLoginEvent,
+  AuthProfilesSnapshot,
+} from "../../auth-profiles";
+import type { Tab } from "../../types/tab";
+import type { BridgeMessageHandler } from "./types";
+
+type AuthProfilesState = AuthProfilesSnapshot & {
+  modal?: { open?: boolean };
+  login?: AuthProfileLoginEvent;
+};
+
+function snapshotFrom(value: unknown): AuthProfilesSnapshot | null {
+  if (!value || typeof value !== "object") return null;
+  const rec = value as Partial<AuthProfilesSnapshot>;
+  return {
+    profiles: Array.isArray(rec.profiles) ? rec.profiles : [],
+    defaultByProvider:
+      rec.defaultByProvider && typeof rec.defaultByProvider === "object"
+        ? rec.defaultByProvider
+        : {},
+    providers: Array.isArray(rec.providers) ? rec.providers : [],
+    activeByTab:
+      rec.activeByTab && typeof rec.activeByTab === "object"
+        ? rec.activeByTab
+        : {},
+  };
+}
+
+export const handleAuthProfiles: BridgeMessageHandler = (message, ctx) => {
+  const snapshot = snapshotFrom(message.authProfiles);
+  if (!snapshot) return;
+  ctx.setState((prev) => {
+    const current = (prev.authProfiles as AuthProfilesState | undefined) ?? {
+      profiles: [],
+      defaultByProvider: {},
+      providers: [],
+      activeByTab: {},
+    };
+    const tabs = ((prev.tabs as Tab[] | undefined) ?? []).map((tab) => ({
+      ...tab,
+      authProfileId: snapshot.activeByTab[tab.id],
+    }));
+    return {
+      ...prev,
+      tabs,
+      authProfiles: {
+        ...snapshot,
+        modal: current.modal,
+        login: current.login,
+      },
+    };
+  });
+};
+
+export const handleAuthProfileLoginEvent: BridgeMessageHandler = (
+  message,
+  ctx,
+) => {
+  const event = message.event as AuthProfileLoginEvent | undefined;
+  if (!event?.type || !event.challengeId) return;
+  if (event.type === "auth" && event.url) {
+    openUrl(event.url).catch((err: unknown) => {
+      ctx.pushNotification({
+        title: "Open login URL failed",
+        message: String(err),
+        kind: "error",
+      });
+    });
+  }
+  if (event.type === "complete") {
+    ctx.pushNotification({
+      title: event.ok ? "Account added" : "Login failed",
+      message: event.error,
+      kind: event.ok ? "success" : "error",
+    });
+  }
+  ctx.setState((prev) => {
+    const current = (prev.authProfiles as AuthProfilesState | undefined) ?? {};
+    return {
+      ...prev,
+      authProfiles: {
+        profiles: [],
+        defaultByProvider: {},
+        providers: [],
+        activeByTab: {},
+        ...current,
+        login: event,
+      },
+    };
+  });
+};
+
+export const handleAuthProfileChanged: BridgeMessageHandler = (message, ctx) => {
+  const tabId = typeof message.tabId === "string" ? message.tabId : undefined;
+  const profileId =
+    typeof message.profileId === "string" ? message.profileId : undefined;
+  const model = typeof message.model === "string" ? message.model : undefined;
+  if (!tabId || !profileId) return;
+  ctx.updateTab(tabId, (tab) => ({
+    ...tab,
+    authProfileId: profileId,
+    ...(model ? { model } : {}),
+  }));
+  ctx.setState((prev) => ({
+    ...prev,
+    authProfiles: {
+      ...(prev.authProfiles ?? {
+          profiles: [],
+          defaultByProvider: {},
+          providers: [],
+          activeByTab: {},
+        }),
+      activeByTab: {
+        ...((prev.authProfiles as AuthProfilesState | undefined)
+          ?.activeByTab ?? {}),
+        [tabId]: profileId,
+      },
+    },
+  }));
+};

--- a/src/hooks/bridgeMessageHandlers/authProfiles.ts
+++ b/src/hooks/bridgeMessageHandlers/authProfiles.ts
@@ -1,6 +1,8 @@
 import { openUrl } from "@tauri-apps/plugin-opener";
 import type {
   AuthProfileLoginEvent,
+  AuthProfileMeta,
+  AuthProfileProvider,
   AuthProfilesSnapshot,
 } from "../../auth-profiles";
 import type { Tab } from "../../types/tab";
@@ -13,19 +15,52 @@ type AuthProfilesState = AuthProfilesSnapshot & {
 
 function snapshotFrom(value: unknown): AuthProfilesSnapshot | null {
   if (!value || typeof value !== "object") return null;
-  const rec = value as Partial<AuthProfilesSnapshot>;
+  const rec = value as Record<string, unknown>;
   return {
-    profiles: Array.isArray(rec.profiles) ? rec.profiles : [],
-    defaultByProvider:
-      rec.defaultByProvider && typeof rec.defaultByProvider === "object"
-        ? rec.defaultByProvider
-        : {},
-    providers: Array.isArray(rec.providers) ? rec.providers : [],
-    activeByTab:
-      rec.activeByTab && typeof rec.activeByTab === "object"
-        ? rec.activeByTab
-        : {},
+    profiles: Array.isArray(rec.profiles)
+      ? rec.profiles.filter(isProfileMeta)
+      : [],
+    defaultByProvider: stringRecord(rec.defaultByProvider),
+    providers: Array.isArray(rec.providers)
+      ? rec.providers.filter(isProfileProvider)
+      : [],
+    activeByTab: stringRecord(rec.activeByTab),
   };
+}
+
+function stringRecord(value: unknown): Record<string, string> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  return Object.fromEntries(
+    Object.entries(value).filter(
+      (entry): entry is [string, string] =>
+        typeof entry[0] === "string" && typeof entry[1] === "string",
+    ),
+  );
+}
+
+function isProfileMeta(value: unknown): value is AuthProfileMeta {
+  if (!value || typeof value !== "object") return false;
+  const rec = value as Partial<AuthProfileMeta>;
+  return (
+    typeof rec.id === "string" &&
+    typeof rec.providerId === "string" &&
+    typeof rec.label === "string" &&
+    (rec.kind === "oauth" || rec.kind === "api_key") &&
+    typeof rec.createdAt === "number" &&
+    typeof rec.updatedAt === "number"
+  );
+}
+
+function isProfileProvider(value: unknown): value is AuthProfileProvider {
+  if (!value || typeof value !== "object") return false;
+  const rec = value as Partial<AuthProfileProvider>;
+  return (
+    typeof rec.id === "string" &&
+    typeof rec.label === "string" &&
+    (rec.kind === "oauth" || rec.kind === "api_key") &&
+    typeof rec.configured === "boolean" &&
+    typeof rec.modelCount === "number"
+  );
 }
 
 export const handleAuthProfiles: BridgeMessageHandler = (message, ctx) => {

--- a/src/hooks/bridgeMessageHandlers/index.ts
+++ b/src/hooks/bridgeMessageHandlers/index.ts
@@ -9,6 +9,11 @@
  *  The hook (useBridgeMessages) does the lookup; an unknown type is a
  *  silent no-op (matches the previous switch-statement fall-through). */
 import type { BridgeMessageHandler } from "./types";
+import {
+  handleAuthProfileChanged,
+  handleAuthProfileLoginEvent,
+  handleAuthProfiles,
+} from "./authProfiles";
 import { handleA2ui } from "./a2ui";
 import { handleError } from "./error";
 import { handleExtensionComponents } from "./extensionComponents";
@@ -50,6 +55,9 @@ export const bridgeMessageHandlers: Readonly<
   Record<string, BridgeMessageHandler>
 > = Object.freeze({
   a2ui: handleA2ui,
+  auth_profile_changed: handleAuthProfileChanged,
+  auth_profile_login_event: handleAuthProfileLoginEvent,
+  auth_profiles: handleAuthProfiles,
   error: handleError,
   extension_components: handleExtensionComponents,
   extension_event_routes: handleExtensionEventRoutes,

--- a/src/hooks/bridgeMessageHandlers/ready.ts
+++ b/src/hooks/bridgeMessageHandlers/ready.ts
@@ -3,6 +3,10 @@ import type { A2UIPayload } from "../../types/a2ui";
 import { activeCwd, activeProject } from "../../projects";
 import { TAB_MIRROR_KEYS } from "../useTabs";
 import type { Tab } from "../../types/tab";
+import {
+  EMPTY_AUTH_PROFILES,
+  type AuthProfilesSnapshot,
+} from "../../auth-profiles";
 import { deepMergeState, layoutPatch } from "../../utils/stateMutation";
 import { deletePointer } from "../../utils/jsonPointer";
 import { WORKSTATION_AREAS, workstationRows } from "../useFocus";
@@ -164,6 +168,9 @@ export const handleReady: BridgeMessageHandler = (data, ctx) => {
   const extStateKeys = (data.extensionStateKeys as string[] | undefined) ?? [];
   const discTabs =
     (data.discoveredTabs as DiscoveredSession[] | undefined) ?? [];
+  const authProfiles =
+    (data.authProfiles as AuthProfilesSnapshot | undefined) ??
+    EMPTY_AUTH_PROFILES;
   ctx.allDiscoveredSessionsRef.current = discTabs;
   // Hydrate extension themes BEFORE the layout state merge below so
   // /sidebar/themes carries the full list (built-ins + extension) when
@@ -311,7 +318,7 @@ export const handleReady: BridgeMessageHandler = (data, ctx) => {
       const localTabs = ((next.tabs as Tab[] | undefined) ?? []).slice();
       const bridgeTabs =
         (data.tabs as
-          | { id: string; model: string; cwd?: string }[]
+          | { id: string; model: string; cwd?: string; authProfileId?: string }[]
           | undefined) ?? [];
       const tabReplay =
         (data.extensionTabState as
@@ -337,6 +344,9 @@ export const handleReady: BridgeMessageHandler = (data, ctx) => {
         }
         if (bt?.cwd && !localTabs[i].cwd) {
           localTabs[i] = { ...localTabs[i], cwd: bt.cwd };
+        }
+        if (bt?.authProfileId) {
+          localTabs[i] = { ...localTabs[i], authProfileId: bt.authProfileId };
         }
       }
       // Apply the bridge's per-tab replay over each tab record. prev
@@ -388,6 +398,7 @@ export const handleReady: BridgeMessageHandler = (data, ctx) => {
       status: activeTurnBusy ? "thinking…" : "ready",
       connection: "connected",
       recentSessions,
+      authProfiles,
       sidebar: {
         ...(next.sidebar ?? {}),
         models: models.map((m) => ({
@@ -442,6 +453,7 @@ export const handleReady: BridgeMessageHandler = (data, ctx) => {
         tabId: t.id,
         ...(t.model ? { model: t.model } : {}),
         ...(restoredCwd ? { cwd: restoredCwd } : {}),
+        ...(t.authProfileId ? { authProfileId: t.authProfileId } : {}),
         restoreHistory: true,
       }),
     });

--- a/src/hooks/bridgeMessageHandlers/sessionHistory.test.ts
+++ b/src/hooks/bridgeMessageHandlers/sessionHistory.test.ts
@@ -319,6 +319,58 @@ describe("handleSessionHistory", () => {
     expect(out.waiting).toBe(false);
   });
 
+  it("drops plain-text tool output copies from restored session history", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleSessionHistory(
+      {
+        type: "session_history",
+        tabId: "tab-1",
+        messages: [
+          {
+            id: "tool-card",
+            role: "agent",
+            a2ui: {
+              components: [
+                {
+                  id: "restored-tool-call_1",
+                  type: "tool-card",
+                  props: {
+                    title: "bash",
+                    toolName: "bash",
+                    startedAt: 1_000,
+                    endedAt: 2_000,
+                  },
+                  children: [
+                    {
+                      id: "result",
+                      type: "code",
+                      props: {
+                        content:
+                          "IN_NIX_SHELL=impure DEVSHELL_DIR=/nix/store/example",
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+          {
+            id: "plain-copy",
+            role: "agent",
+            text: "IN_NIX_SHELL=impure DEVSHELL_DIR=/nix/store/example",
+          },
+        ],
+      },
+      ctx,
+    );
+    const [, updater] = mocks.updateTab.mock.calls[0];
+    const out = updater(makeEmptyTab("tab-1", "Tab 1"));
+
+    expect(out.messages.map((message: ChatMessage) => message.id)).toEqual([
+      "tool-card",
+    ]);
+  });
+
   it("drops failed local user messages on restore (they are informational once history arrives)", () => {
     const { ctx, mocks } = buildHandlerFixture();
     handleSessionHistory(

--- a/src/hooks/bridgeMessageHandlers/sessionHistory.ts
+++ b/src/hooks/bridgeMessageHandlers/sessionHistory.ts
@@ -1,4 +1,7 @@
-import { coerceChatMessages } from "../../utils/messages";
+import {
+  coerceChatMessages,
+  dedupeToolResultTextMessages,
+} from "../../utils/messages";
 import type { A2UIComponent, ChatMessage } from "../../types/a2ui";
 import type { BridgeMessageHandler } from "./types";
 
@@ -164,7 +167,9 @@ function mergePendingLocalPrompts(
 
 export const handleSessionHistory: BridgeMessageHandler = (data, ctx) => {
   const tabId = (data.tabId as string | undefined) ?? "default";
-  const messages = coerceChatMessages(data.messages);
+  const messages = dedupeToolResultTextMessages(
+    coerceChatMessages(data.messages),
+  );
   const session = ctx.allDiscoveredSessionsRef.current.find(
     (s) => s.tabId === tabId,
   );
@@ -174,10 +179,13 @@ export const handleSessionHistory: BridgeMessageHandler = (data, ctx) => {
       ? session.firstUserMessage.replace(/\s+/g, " ").trim()
       : undefined);
   ctx.updateTab(tabId, (tab) => {
-    const merged = mergePendingLocalPrompts(messages, tab.messages);
+    const merged = mergePendingLocalPrompts(
+      messages,
+      dedupeToolResultTextMessages(tab.messages),
+    );
     return {
       ...tab,
-      messages: merged.messages,
+      messages: dedupeToolResultTextMessages(merged.messages),
       waiting: merged.hasLivePending ? tab.waiting : false,
       ...(label
         ? { label }

--- a/src/hooks/useAppSlashCommandContext.ts
+++ b/src/hooks/useAppSlashCommandContext.ts
@@ -12,6 +12,7 @@ import type { SlashCommandContext } from "../slashCommands";
 import type { SkillRegistry } from "../skills/SkillRegistry";
 import type { LayoutCatalogueEntry } from "../skills/default-layout";
 import type { NotificationInput } from "./useNotifications";
+import type { AuthProfilesUiState } from "../auth-profiles";
 
 export interface UseAppSlashCommandContextOptions {
   bootLayout: A2UIPayload;
@@ -121,6 +122,71 @@ export function useAppSlashCommandContext({
             active?: boolean;
           }[]) ?? []
         );
+      },
+      openLogin: () => {
+        setState((prev) => ({
+          ...prev,
+          authProfiles: {
+            profiles: [],
+            defaultByProvider: {},
+            providers: [],
+            activeByTab: {},
+            ...(prev.authProfiles ?? {}),
+            modal: { open: true },
+          },
+        }));
+        void invoke("agent_command", {
+          payload: JSON.stringify({ type: "auth_profiles_list" }),
+        });
+      },
+      listAuthProfiles: () => {
+        const auth =
+          (stateRef.current.authProfiles as AuthProfilesUiState | undefined) ??
+          undefined;
+        const activeId = stateRef.current.activeTabId as string | undefined;
+        return (auth?.profiles ?? []).map((p) => ({
+          id: p.id,
+          label: p.label,
+          providerId: p.providerId,
+          kind: p.kind,
+          active: !!activeId && auth?.activeByTab?.[activeId] === p.id,
+          default: auth?.defaultByProvider?.[p.providerId] === p.id,
+        }));
+      },
+      useAuthProfile: async (idOrLabel: string) => {
+        const auth =
+          (stateRef.current.authProfiles as AuthProfilesUiState | undefined) ??
+          undefined;
+        const profile = (auth?.profiles ?? []).find(
+          (p) => p.id === idOrLabel || p.label === idOrLabel,
+        );
+        if (!profile) throw new Error(`Unknown account: ${idOrLabel}`);
+        const activeId = stateRef.current.activeTabId;
+        await invoke("agent_command", {
+          payload: JSON.stringify({
+            type: "auth_profile_use_for_tab",
+            tabId:
+              typeof activeId === "string" && activeId.length > 0
+                ? activeId
+                : "default",
+            profileId: profile.id,
+          }),
+        });
+      },
+      setDefaultAuthProfile: async (idOrLabel: string) => {
+        const auth =
+          (stateRef.current.authProfiles as AuthProfilesUiState | undefined) ??
+          undefined;
+        const profile = (auth?.profiles ?? []).find(
+          (p) => p.id === idOrLabel || p.label === idOrLabel,
+        );
+        if (!profile) throw new Error(`Unknown account: ${idOrLabel}`);
+        await invoke("agent_command", {
+          payload: JSON.stringify({
+            type: "auth_profile_set_default",
+            profileId: profile.id,
+          }),
+        });
       },
       toggleTerminal,
       toggleSidebar,

--- a/src/hooks/useDerivedRenderState.ts
+++ b/src/hooks/useDerivedRenderState.ts
@@ -33,6 +33,7 @@ export interface DerivedRenderStateResult {
   paletteOpen: boolean;
   settingsOpen: boolean;
   searchOpen: boolean;
+  authProfilesOpen: boolean;
 }
 
 export function useDerivedRenderState({
@@ -157,6 +158,10 @@ export function useDerivedRenderState({
   const searchOpen = Boolean(
     (renderRecord.search as { open?: boolean } | undefined)?.open,
   );
+  const authProfilesOpen = Boolean(
+    (renderRecord.authProfiles as { modal?: { open?: boolean } } | undefined)
+      ?.modal?.open,
+  );
 
   return {
     renderState,
@@ -164,5 +169,6 @@ export function useDerivedRenderState({
     paletteOpen,
     settingsOpen,
     searchOpen,
+    authProfilesOpen,
   };
 }

--- a/src/hooks/useSessionPersistence.test.tsx
+++ b/src/hooks/useSessionPersistence.test.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getConfig, type AethonConfig } from "../config";
+import { readState, writeState } from "../persist";
+import { createAppStore } from "../state/appStore";
+import { useSessionPersistence } from "./useSessionPersistence";
+
+vi.mock("../config", () => ({
+  getConfig: vi.fn(),
+}));
+
+vi.mock("../persist", () => ({
+  readState: vi.fn(),
+  writeState: vi.fn(() => Promise.resolve(true)),
+}));
+
+vi.mock("../layoutPrefs", () => ({
+  loadLayoutPrefsFromDisk: vi.fn(() => Promise.resolve(null)),
+  loadLayoutPrefsSync: vi.fn(() => null),
+  mergeLayoutPrefsIntoState: vi.fn((state) => state),
+  saveLayoutPrefs: vi.fn(() => Promise.resolve()),
+}));
+
+const defaultConfig: AethonConfig = {
+  ui: {
+    theme: null,
+    fontSize: null,
+    restoreTabs: false,
+    notifyOnCompletion: true,
+    notifyMinDurationSeconds: 8,
+  },
+  agent: { model: null },
+  shell: {
+    defaultShareMode: "private",
+    autoRestartAgent: true,
+    defaultCommand: null,
+    defaultArgs: [],
+    inheritEnv: true,
+    promptBeforeClose: true,
+  },
+  shortcuts: { newTabKind: "agent" },
+  updates: { channel: "stable", disableAutoCheck: false },
+  devshell: {
+    enabled: "auto",
+    mode: "auto",
+    cacheTtlHours: 720,
+    refreshOnLockfileChange: true,
+  },
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useSessionPersistence", () => {
+  it("does not restore durable session snapshots when restore_tabs is disabled", async () => {
+    vi.mocked(getConfig).mockResolvedValue(defaultConfig);
+    vi.mocked(readState).mockResolvedValue(
+      JSON.stringify({
+        tabs: [
+          {
+            id: "stale-tab",
+            label: "Stale",
+            messages: [{ id: "m1", role: "user", text: "old context" }],
+          },
+        ],
+        activeTabId: "stale-tab",
+        savedAt: 1,
+      }),
+    );
+    const appStore = createAppStore({
+      tabs: [],
+      activeTabId: null,
+      layout: {},
+      terminalPanel: {},
+    });
+
+    renderHook(() =>
+      useSessionPersistence({
+        appStore,
+        hasSyncSessionSnapshot: false,
+      }),
+    );
+
+    await waitFor(() => expect(getConfig).toHaveBeenCalled());
+    expect(readState).not.toHaveBeenCalled();
+    expect(appStore.getState().tabs).toEqual([]);
+  });
+
+  it("restores durable session snapshots when restore_tabs is enabled", async () => {
+    vi.mocked(getConfig).mockResolvedValue({
+      ...defaultConfig,
+      ui: { ...defaultConfig.ui, restoreTabs: true },
+    });
+    vi.mocked(readState).mockResolvedValue(
+      JSON.stringify({
+        tabs: [
+          {
+            id: "restored-tab",
+            label: "Restored",
+            messages: [{ id: "m1", role: "user", text: "old context" }],
+          },
+        ],
+        activeTabId: "restored-tab",
+        savedAt: 1,
+      }),
+    );
+    const appStore = createAppStore({
+      tabs: [],
+      activeTabId: null,
+      layout: {},
+      terminalPanel: {},
+    });
+
+    renderHook(() =>
+      useSessionPersistence({
+        appStore,
+        hasSyncSessionSnapshot: false,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(appStore.getState().activeTabId).toBe("restored-tab");
+    });
+    expect(readState).toHaveBeenCalledWith("session_ui_snapshot");
+    expect(writeState).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useSessionPersistence.ts
+++ b/src/hooks/useSessionPersistence.ts
@@ -11,6 +11,7 @@ import {
 } from "../state/sessionUiSnapshot";
 import { createAppStore, type AppStore } from "../state/appStore";
 import { readState, writeState } from "../persist";
+import { getConfig } from "../config";
 import {
   loadLayoutPrefsFromDisk,
   loadLayoutPrefsSync,
@@ -219,9 +220,17 @@ export function useSessionPersistence({
     if (hasSyncSessionSnapshot) {
       startPersistence();
     } else {
-      readState(SESSION_UI_SNAPSHOT_FILE)
-        .then((raw) => {
+      getConfig()
+        .then((config) => {
           if (cancelled) return;
+          if (!config.ui.restoreTabs) {
+            startPersistence();
+            return;
+          }
+          return readState(SESSION_UI_SNAPSHOT_FILE);
+        })
+        .then((raw) => {
+          if (cancelled || raw === undefined) return;
           const snapshot = parseSessionUiSnapshot(raw);
           if (snapshot) restoreSessionUiSnapshot(snapshot);
           startPersistence();

--- a/src/skills/default-layout/auth-profile-panel.tsx
+++ b/src/skills/default-layout/auth-profile-panel.tsx
@@ -1,0 +1,274 @@
+import { useMemo, useState } from "react";
+import type { BuiltinComponentProps } from "../../components/A2UIRenderer";
+import {
+  EMPTY_AUTH_PROFILES,
+  sendAuthProfileCommand,
+  type AuthProfileLoginEvent,
+  type AuthProfileProvider,
+  type AuthProfilesUiState,
+} from "../../auth-profiles";
+
+function readAuthProfiles(state: Record<string, unknown>): AuthProfilesUiState {
+  return {
+    ...EMPTY_AUTH_PROFILES,
+    ...((state.authProfiles as AuthProfilesUiState | undefined) ?? {}),
+  };
+}
+
+export function AuthProfilePanel({
+  state,
+  onEvent,
+  tabId,
+}: BuiltinComponentProps) {
+  const auth = readAuthProfiles(state);
+  const [providerId, setProviderId] = useState("");
+  const [label, setLabel] = useState("");
+  const [apiKey, setApiKey] = useState("");
+  const [promptValue, setPromptValue] = useState("");
+
+  const providers = auth.providers;
+  const selectedProvider =
+    providers.find((p) => p.id === providerId) ?? providers[0];
+  const activeTabId =
+    tabId ??
+    (typeof state.activeTabId === "string" ? state.activeTabId : "default");
+  const activeProfileId = auth.activeByTab[activeTabId];
+
+  const groupedProfiles = useMemo(
+    () =>
+      auth.profiles.map((profile) => ({
+        ...profile,
+        provider:
+          providers.find((p) => p.id === profile.providerId) ??
+          ({
+            id: profile.providerId,
+            label: profile.providerId,
+            kind: profile.kind,
+            configured: false,
+            modelCount: 0,
+          } satisfies AuthProfileProvider),
+      })),
+    [auth.profiles, providers],
+  );
+
+  const startLogin = async () => {
+    if (!selectedProvider) return;
+    await sendAuthProfileCommand({
+      type:
+        selectedProvider.kind === "oauth"
+          ? "auth_profile_login_start"
+          : "auth_profile_api_key_save",
+      providerId: selectedProvider.id,
+      label: label.trim() || selectedProvider.label,
+      ...(selectedProvider.kind === "api_key" ? { key: apiKey } : {}),
+    });
+    if (selectedProvider.kind === "api_key") {
+      setApiKey("");
+      setLabel("");
+    }
+  };
+
+  const activateProfile = (profileId: string) =>
+    sendAuthProfileCommand({
+      type: "auth_profile_use_for_tab",
+      tabId: activeTabId,
+      profileId,
+    });
+
+  const setDefault = (profileId: string) =>
+    sendAuthProfileCommand({ type: "auth_profile_set_default", profileId });
+
+  const deleteProfile = (profileId: string) =>
+    sendAuthProfileCommand({ type: "auth_profile_delete", profileId });
+
+  const submitPrompt = async (event: AuthProfileLoginEvent) => {
+    await sendAuthProfileCommand({
+      type: "auth_profile_oauth_input",
+      challengeId: event.challengeId,
+      value: promptValue,
+    });
+    setPromptValue("");
+  };
+
+  if (!auth.modal?.open) return null;
+
+  return (
+    <div
+      className="ae-settings-overlay"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onEvent("close");
+      }}
+    >
+      <div
+        className="ae-settings-panel ae-auth-panel"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Accounts"
+      >
+        <header className="ae-settings-header">
+          <h2>Accounts</h2>
+          <button
+            type="button"
+            className="ae-settings-close"
+            aria-label="Close"
+            onClick={() => onEvent("close")}
+          >
+            ×
+          </button>
+        </header>
+
+        <div className="ae-settings-body">
+          <section className="ae-settings-section">
+            <h3 className="ae-settings-section-title">Add Account</h3>
+            <div className="ae-auth-add">
+              <select
+                className="ae-settings-input"
+                value={selectedProvider?.id ?? ""}
+                onChange={(e) => setProviderId(e.target.value)}
+              >
+                {providers.map((provider) => (
+                  <option key={provider.id} value={provider.id}>
+                    {provider.label}
+                  </option>
+                ))}
+              </select>
+              <input
+                className="ae-settings-input"
+                value={label}
+                placeholder="Account label"
+                onChange={(e) => setLabel(e.target.value)}
+              />
+              {selectedProvider?.kind === "api_key" && (
+                <input
+                  className="ae-settings-input"
+                  type="password"
+                  value={apiKey}
+                  placeholder="API key"
+                  onChange={(e) => setApiKey(e.target.value)}
+                />
+              )}
+              <button
+                type="button"
+                className="ae-settings-primary"
+                disabled={
+                  !selectedProvider ||
+                  (selectedProvider.kind === "api_key" && !apiKey.trim())
+                }
+                onClick={() => void startLogin()}
+              >
+                {selectedProvider?.kind === "oauth" ? "Login" : "Save Key"}
+              </button>
+            </div>
+            <LoginStatus
+              event={auth.login}
+              value={promptValue}
+              onChange={setPromptValue}
+              onSubmit={submitPrompt}
+            />
+          </section>
+
+          <section className="ae-settings-section">
+            <h3 className="ae-settings-section-title">Stored Accounts</h3>
+            {groupedProfiles.length === 0 ? (
+              <p className="ae-settings-note">No accounts stored yet.</p>
+            ) : (
+              <ul className="ae-auth-list">
+                {groupedProfiles.map((profile) => {
+                  const isActive = activeProfileId === profile.id;
+                  const isDefault =
+                    auth.defaultByProvider[profile.providerId] === profile.id;
+                  return (
+                    <li key={profile.id} className="ae-auth-row">
+                      <div className="ae-auth-row-main">
+                        <strong>{profile.label}</strong>
+                        <span>
+                          {profile.provider.label} · {profile.kind}
+                          {isActive ? " · active" : ""}
+                          {isDefault ? " · default" : ""}
+                        </span>
+                      </div>
+                      <div className="ae-auth-row-actions">
+                        <button
+                          type="button"
+                          className="ae-settings-secondary"
+                          disabled={isActive}
+                          onClick={() => void activateProfile(profile.id)}
+                        >
+                          Use
+                        </button>
+                        <button
+                          type="button"
+                          className="ae-settings-secondary"
+                          disabled={isDefault}
+                          onClick={() => void setDefault(profile.id)}
+                        >
+                          Default
+                        </button>
+                        <button
+                          type="button"
+                          className="ae-settings-secondary"
+                          onClick={() => void deleteProfile(profile.id)}
+                        >
+                          Delete
+                        </button>
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function LoginStatus({
+  event,
+  value,
+  onChange,
+  onSubmit,
+}: {
+  event?: AuthProfileLoginEvent;
+  value: string;
+  onChange: (value: string) => void;
+  onSubmit: (event: AuthProfileLoginEvent) => Promise<void>;
+}) {
+  if (!event) return null;
+  if (event.type === "prompt") {
+    return (
+      <div className="ae-auth-login">
+        <p className="ae-settings-note">{event.message}</p>
+        <div className="ae-auth-add">
+          <input
+            className="ae-settings-input"
+            value={value}
+            placeholder={event.placeholder ?? "Code or callback URL"}
+            onChange={(e) => onChange(e.target.value)}
+          />
+          <button
+            type="button"
+            className="ae-settings-primary"
+            disabled={!event.allowEmpty && !value.trim()}
+            onClick={() => void onSubmit(event)}
+          >
+            Continue
+          </button>
+        </div>
+      </div>
+    );
+  }
+  if (event.type === "auth" && event.url) {
+    return (
+      <p className="ae-settings-note">
+        Browser login opened. If it did not, open the provider login URL from
+        your browser.
+      </p>
+    );
+  }
+  if (event.message || event.error) {
+    return <p className="ae-settings-note">{event.error ?? event.message}</p>;
+  }
+  return null;
+}

--- a/src/skills/default-layout/components.tsx
+++ b/src/skills/default-layout/components.tsx
@@ -47,3 +47,4 @@ export {
 } from "./terminal";
 export { ShellCanvas, TabStrip, TerminalPanel } from "./shell";
 export { EditorCanvas, ImageViewer, MarkdownPreview } from "./editor";
+export { AuthProfilePanel } from "./auth-profile-panel";

--- a/src/skills/default-layout/index.ts
+++ b/src/skills/default-layout/index.ts
@@ -26,6 +26,7 @@ import {
   Terminal,
   TerminalPanel,
   ToolCard,
+  AuthProfilePanel,
 } from "./components";
 import {
   AgentStatusPill,
@@ -119,6 +120,7 @@ export const defaultLayoutSkill: A2UISkill = {
     "command-palette": CommandPalette,
     "notification-stack": NotificationStack,
     "settings-panel": SettingsPanel,
+    "auth-profile-panel": AuthProfilePanel,
     "search-panel": SearchPanel,
     // M6 P2: shell tab share-mode badge — extracted as its own
     // registerable component so a skill can replace it (e.g. with a

--- a/src/slashCommands.test.ts
+++ b/src/slashCommands.test.ts
@@ -70,6 +70,7 @@ describe("buildBuiltinSlashCommands", () => {
       "help",
       "theme",
       "model",
+      "login",
       "context",
       "session",
       "compact",
@@ -114,6 +115,10 @@ describe("buildBuiltinSlashCommands", () => {
         return Promise.resolve("installed output");
       },
       listModels: () => [],
+      openLogin: () => {},
+      listAuthProfiles: () => [],
+      useAuthProfile: () => Promise.resolve(),
+      setDefaultAuthProfile: () => Promise.resolve(),
       toggleTerminal: () => {},
       toggleSidebar: () => {},
       toggleFilesSidebar: () => {},
@@ -156,6 +161,10 @@ describe("buildBuiltinSlashCommands", () => {
       listExtensions: () => [],
       installExtension: () => Promise.resolve(""),
       listModels: () => [],
+      openLogin: () => {},
+      listAuthProfiles: () => [],
+      useAuthProfile: () => Promise.resolve(),
+      setDefaultAuthProfile: () => Promise.resolve(),
       toggleTerminal: () => {},
       toggleSidebar: () => {},
       toggleFilesSidebar: () => {},
@@ -183,6 +192,61 @@ describe("buildBuiltinSlashCommands", () => {
     expect(calls).toEqual([{ tabId: "tab-7", label: "Refactor pass" }]);
   });
 
+  it("/login opens the account manager and can switch accounts", async () => {
+    let opened = 0;
+    const calls: string[] = [];
+    const ctx: SlashCommandContext = {
+      appendSystem: () => {},
+      notify: () => {},
+      clearChat: () => {},
+      setTheme: () => {},
+      listThemes: () => [],
+      setModel: async () => {},
+      resetLayout: () => {},
+      listExtensions: () => [],
+      installExtension: () => Promise.resolve(""),
+      listModels: () => [],
+      openLogin: () => {
+        opened += 1;
+      },
+      listAuthProfiles: () => [],
+      useAuthProfile: (id) => {
+        calls.push(`use:${id}`);
+        return Promise.resolve();
+      },
+      setDefaultAuthProfile: (id) => {
+        calls.push(`default:${id}`);
+        return Promise.resolve();
+      },
+      toggleTerminal: () => {},
+      toggleSidebar: () => {},
+      toggleFilesSidebar: () => {},
+      activateLayout: () => false,
+      listLayouts: () => [],
+      pickProject: () => Promise.resolve(null),
+      openProject: () => "",
+      setActiveProject: () => false,
+      clearProject: () => {},
+      removeProject: () => false,
+      listProjects: () => [],
+      activeProject: () => null,
+      reloadAgent: () => Promise.resolve(),
+      runNativeCommand: () => Promise.resolve(),
+      renameSession: () => Promise.resolve(),
+      activeTabId: () => "tab-7",
+    };
+    const login = buildBuiltinSlashCommands().find(
+      (c) => c.name === "login",
+    )!;
+
+    await login.run("", ctx);
+    await login.run("use claude-work", ctx);
+    await login.run("default claude-home", ctx);
+
+    expect(opened).toBe(1);
+    expect(calls).toEqual(["use:claude-work", "default:claude-home"]);
+  });
+
   it("/reload calls reloadAgent and toasts", async () => {
     let reloadCalls = 0;
     const titles: string[] = [];
@@ -197,6 +261,10 @@ describe("buildBuiltinSlashCommands", () => {
       listExtensions: () => [],
       installExtension: () => Promise.resolve(""),
       listModels: () => [],
+      openLogin: () => {},
+      listAuthProfiles: () => [],
+      useAuthProfile: () => Promise.resolve(),
+      setDefaultAuthProfile: () => Promise.resolve(),
       toggleTerminal: () => {},
       toggleSidebar: () => {},
       toggleFilesSidebar: () => {},
@@ -239,6 +307,10 @@ describe("buildBuiltinSlashCommands", () => {
       listExtensions: () => [],
       installExtension: () => Promise.resolve(""),
       listModels: () => [],
+      openLogin: () => {},
+      listAuthProfiles: () => [],
+      useAuthProfile: () => Promise.resolve(),
+      setDefaultAuthProfile: () => Promise.resolve(),
       toggleTerminal: () => {},
       toggleSidebar: () => {},
       toggleFilesSidebar: () => {},
@@ -279,6 +351,10 @@ describe("buildBuiltinSlashCommands", () => {
       listExtensions: () => [],
       installExtension: () => Promise.resolve(""),
       listModels: () => [],
+      openLogin: () => {},
+      listAuthProfiles: () => [],
+      useAuthProfile: () => Promise.resolve(),
+      setDefaultAuthProfile: () => Promise.resolve(),
       toggleTerminal: () => {},
       toggleSidebar: () => {},
       toggleFilesSidebar: () => {},

--- a/src/slashCommands.ts
+++ b/src/slashCommands.ts
@@ -34,6 +34,17 @@ export interface SlashCommandContext {
   listExtensions: () => string[];
   installExtension: (spec: string) => Promise<string>;
   listModels: () => { id: string; label: string; active?: boolean }[];
+  openLogin: () => void;
+  listAuthProfiles: () => {
+    id: string;
+    label: string;
+    providerId: string;
+    kind: "oauth" | "api_key";
+    active?: boolean;
+    default?: boolean;
+  }[];
+  useAuthProfile: (idOrLabel: string) => Promise<void>;
+  setDefaultAuthProfile: (idOrLabel: string) => Promise<void>;
   toggleTerminal: () => void;
   // Show / hide / toggle the sidebar. State changes propagate via the
   // /layout/sidebarVisible / /layout/columns / /layout/areas $refs the
@@ -165,6 +176,66 @@ export function buildBuiltinSlashCommands(): SlashCommand[] {
           return;
         }
         await ctx.setModel(id);
+      },
+    },
+    {
+      name: "login",
+      description: "Manage stored provider accounts",
+      usage: "[list|use <account>|default <account>]",
+      run: async (args, ctx) => {
+        const [subcommand, ...rest] = args.trim().split(/\s+/);
+        const target = rest.join(" ").trim();
+        if (!subcommand) {
+          ctx.openLogin();
+          return;
+        }
+        if (subcommand === "list") {
+          const profiles = ctx.listAuthProfiles();
+          const list = profiles
+            .map((p) => {
+              const flags = [
+                p.active ? "active" : "",
+                p.default ? "default" : "",
+              ].filter(Boolean);
+              return `- \`${p.id}\` — ${p.label} (${p.providerId}, ${p.kind}${flags.length ? `, ${flags.join(", ")}` : ""})`;
+            })
+            .join("\n");
+          ctx.appendSystem(
+            profiles.length > 0
+              ? `Stored accounts:\n${list}`
+              : "No stored accounts yet. Run `/login` to add one.",
+          );
+          return;
+        }
+        if (subcommand === "use") {
+          if (!target) {
+            ctx.notify({
+              title: "Missing account",
+              message: "Usage: /login use <account>",
+              kind: "error",
+            });
+            return;
+          }
+          await ctx.useAuthProfile(target);
+          return;
+        }
+        if (subcommand === "default") {
+          if (!target) {
+            ctx.notify({
+              title: "Missing account",
+              message: "Usage: /login default <account>",
+              kind: "error",
+            });
+            return;
+          }
+          await ctx.setDefaultAuthProfile(target);
+          return;
+        }
+        ctx.notify({
+          title: `Unknown login command: ${subcommand}`,
+          message: "Usage: /login [list|use <account>|default <account>]",
+          kind: "error",
+        });
       },
     },
     {

--- a/src/state/sessionUiSnapshot.test.ts
+++ b/src/state/sessionUiSnapshot.test.ts
@@ -70,6 +70,90 @@ describe("sessionUiSnapshot", () => {
     expect(loadSessionUiSnapshot()?.activeTabId).toBe("tab-a");
   });
 
+  it("does not restore persistent localStorage snapshots synchronously", () => {
+    const localStorage =
+      window.localStorage ??
+      (() => {
+        const values = new Map<string, string>();
+        return {
+          get length() {
+            return values.size;
+          },
+          clear: () => values.clear(),
+          getItem: (key: string) => values.get(key) ?? null,
+          key: (index: number) => [...values.keys()][index] ?? null,
+          removeItem: (key: string) => {
+            values.delete(key);
+          },
+          setItem: (key: string, value: string) => {
+            values.set(key, value);
+          },
+        } as Storage;
+      })();
+    const tab = {
+      ...makeEmptyTab("tab-a", "A"),
+      messages: [{ id: "m1", role: "user" as const, text: "hi" }],
+    };
+    localStorage.setItem(
+      "aethon:session-ui-snapshot:v1",
+      JSON.stringify({
+        tabs: [tab],
+        activeTabId: "tab-a",
+        savedAt: 1,
+      }),
+    );
+
+    expect(loadSessionUiSnapshot()).toBeNull();
+  });
+
+  it("dedupes plain-text copies of rendered tool output on restore", () => {
+    const parsed = parseSessionUiSnapshot(
+      JSON.stringify({
+        tabs: [
+          {
+            ...makeEmptyTab("tab-a", "A"),
+            messages: [
+              {
+                id: "tool-card",
+                role: "agent",
+                a2ui: {
+                  components: [
+                    {
+                      id: "restored-tool-call_1",
+                      type: "tool-card",
+                      props: { title: "bash", toolName: "bash" },
+                      children: [
+                        {
+                          id: "result",
+                          type: "code",
+                          props: {
+                            content:
+                              "IN_NIX_SHELL=impure DEVSHELL_DIR=/nix/store/example",
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                },
+              },
+              {
+                id: "plain-copy",
+                role: "agent",
+                text: "IN_NIX_SHELL=impure DEVSHELL_DIR=/nix/store/example",
+              },
+            ],
+          },
+        ],
+        activeTabId: "tab-a",
+        savedAt: 1,
+      }),
+    );
+
+    expect(parsed?.tabs[0].messages.map((message) => message.id)).toEqual([
+      "tool-card",
+    ]);
+  });
+
   it("does not restore agent tabs as waiting after an app restart", () => {
     const parsed = parseSessionUiSnapshot(
       JSON.stringify({

--- a/src/state/sessionUiSnapshot.ts
+++ b/src/state/sessionUiSnapshot.ts
@@ -1,4 +1,5 @@
 import type { Tab } from "../types/tab";
+import { dedupeToolResultTextMessages } from "../utils/messages";
 
 export const SESSION_UI_SNAPSHOT_FILE = "session_ui_snapshot";
 
@@ -27,19 +28,12 @@ function canUseSessionStorage(): boolean {
   );
 }
 
-function canUseLocalStorage(): boolean {
-  return (
-    typeof window !== "undefined" &&
-    typeof window.localStorage?.getItem === "function" &&
-    typeof window.localStorage?.setItem === "function" &&
-    typeof window.localStorage?.removeItem === "function"
-  );
-}
-
 function trimTab(tab: Tab): Tab {
   return {
     ...tab,
-    messages: tab.messages.slice(-MAX_MESSAGES_PER_TAB),
+    messages: dedupeToolResultTextMessages(tab.messages).slice(
+      -MAX_MESSAGES_PER_TAB,
+    ),
     terminalBuffer: tab.terminalBuffer.slice(-MAX_TERMINAL_BUFFER),
   };
 }
@@ -124,18 +118,9 @@ function durableTerminalSnapshot(
 }
 
 export function loadSessionUiSnapshot(): SessionUiSnapshot | null {
-  const candidates: string[] = [];
   if (canUseSessionStorage()) {
     const raw = window.sessionStorage.getItem(KEY);
-    if (raw) candidates.push(raw);
-  }
-  if (canUseLocalStorage()) {
-    const raw = window.localStorage.getItem(KEY);
-    if (raw) candidates.push(raw);
-  }
-  for (const raw of candidates) {
-    const parsed = parseSessionUiSnapshot(raw);
-    if (parsed) return parsed;
+    if (raw) return parseSessionUiSnapshot(raw);
   }
   return null;
 }
@@ -164,6 +149,7 @@ export function parseSessionUiSnapshot(raw: string): SessionUiSnapshot | null {
       tabs: tabs.map((t) => ({
         ...t,
         kind: t.kind ?? "agent",
+        messages: dedupeToolResultTextMessages(t.messages),
         draft: t.draft ?? "",
         // Waiting is process-local state. After an app restart there is no
         // still-attached prompt runner behind this tab, so restoring it as
@@ -277,12 +263,10 @@ export function saveSessionUiSnapshot(
   try {
     if (serialized === null) {
       if (canUseSessionStorage()) window.sessionStorage.removeItem(KEY);
-      if (canUseLocalStorage()) window.localStorage.removeItem(KEY);
       persistDisk?.("");
       return;
     }
     if (canUseSessionStorage()) window.sessionStorage.setItem(KEY, serialized);
-    if (canUseLocalStorage()) window.localStorage.setItem(KEY, serialized);
     persistDisk?.(serialized);
   } catch {
     /* best-effort; quota or privacy settings should not break the app */

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -4180,6 +4180,72 @@ body.ae-resizing-terminal * {
   background: color-mix(in oklab, var(--accent) 8%, transparent);
 }
 
+.ae-auth-panel {
+  width: min(760px, 92vw);
+}
+.ae-auth-add {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  align-items: center;
+}
+.ae-auth-add .ae-settings-input {
+  min-width: min(220px, 100%);
+}
+.ae-auth-login {
+  margin-top: var(--space-3);
+  padding: var(--space-3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: color-mix(in oklab, var(--accent) 5%, transparent);
+}
+.ae-auth-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.ae-auth-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: var(--space-3);
+  align-items: center;
+  padding: var(--space-3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-elev);
+}
+.ae-auth-row-main {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.ae-auth-row-main strong,
+.ae-auth-row-main span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ae-auth-row-main span {
+  color: var(--text-dim);
+  font-size: var(--chrome-text-muted);
+}
+.ae-auth-row-actions {
+  display: flex;
+  gap: var(--space-2);
+}
+@media (max-width: 640px) {
+  .ae-auth-row {
+    grid-template-columns: 1fr;
+  }
+  .ae-auth-row-actions {
+    flex-wrap: wrap;
+  }
+}
+
 /* =============================================================================
    Cross-session search overlay (Cmd+Shift+F). Modeled after the
    command palette but with a results pane sized for snippets.

--- a/src/types/tab.ts
+++ b/src/types/tab.ts
@@ -101,6 +101,8 @@ export interface Tab {
   // Immutable working directory the bridge session was created with.
   // For worktree sessions this is the worktree path, not the project root.
   cwd?: string;
+  /** Auth profile id selected for this agent session, if any. */
+  authProfileId?: string;
   /** Present iff kind === "shell". */
   shell?: ShellMeta;
   /** Present iff kind === "editor". */

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -43,6 +43,48 @@ export function trimMessage(m: ChatMessage): ChatMessage {
   return out;
 }
 
+function normalizedText(value: string): string {
+  return value.replace(/\r\n/g, "\n").trim();
+}
+
+function toolResultTexts(message: ChatMessage): string[] {
+  const components = message.a2ui?.components ?? [];
+  const texts: string[] = [];
+  for (const component of components) {
+    if (component.type !== "tool-card") continue;
+    for (const child of component.children ?? []) {
+      if (child.type !== "code") continue;
+      const content = child.props?.content;
+      if (typeof content === "string" && content.trim().length > 0) {
+        texts.push(normalizedText(content));
+      }
+    }
+  }
+  return texts;
+}
+
+export function dedupeToolResultTextMessages(
+  messages: ChatMessage[],
+): ChatMessage[] {
+  const toolOutputs = new Set<string>();
+  const out: ChatMessage[] = [];
+  for (const message of messages) {
+    const outputs = toolResultTexts(message);
+    if (outputs.length > 0) {
+      for (const output of outputs) toolOutputs.add(output);
+      out.push(message);
+      continue;
+    }
+    const text =
+      message.role === "agent" && message.text
+        ? normalizedText(message.text)
+        : "";
+    if (text && toolOutputs.has(text)) continue;
+    out.push(message);
+  }
+  return out;
+}
+
 export function coerceChatMessages(value: unknown): ChatMessage[] {
   if (!Array.isArray(value)) return [];
   const messages: ChatMessage[] = [];


### PR DESCRIPTION
## Summary

Adds the auth profile login flow for Aethon so users can store multiple accounts, switch the active account per tab/session, and keep provider defaults across launches. The branch includes the original `/login` profile work plus follow-up hardening from UAT and peer review.

## What changed

- Added auth profile persistence under the Aethon user dir with separate pi-compatible auth stores per profile.
- Added frontend account management UI and bridge messages for listing, saving API keys, starting OAuth login, cancelling/login prompts, selecting a profile for a tab, setting provider defaults, renaming, and deleting profiles.
- Scoped model/auth services per tab so switching a Claude Pro account does not mutate the global auth store.
- Applied provider defaults when a tab is created without an explicit initial model, including startup/default tabs.
- Persisted failed/cancelled OAuth placeholder cleanup so stale no-credential profiles do not reappear after restart.
- Fixed session UI restore behavior so durable disk snapshots respect `[ui] restore_tabs = false`; same-webview sessionStorage restore still supports HMR/reload continuity.
- Deduped plain-text copies of rendered tool-card output when restoring snapshots/history, preventing stale bash/devshell output from showing as an oversized unformatted assistant paragraph.

## Root cause notes

- Peer review correctly caught that `authProfileServicesForTab()` only consulted `defaultByProvider` when an `initialModel` was supplied. Startup/default tabs often have no explicit model at that point, so they fell back to global auth and ignored the user's default account.
- OAuth start writes placeholder profile metadata before the external login flow begins. The failure/cancel paths removed it from memory but did not save the profile store afterward, allowing stale account metadata to reload.
- The UAT formatting/context issue came from durable `session_ui_snapshot` restore bypassing the `restore_tabs` setting. The visible UI could show an older restored transcript while the underlying pi session only had the newer prompt, which made context appear lost. The malformed paragraph was a duplicate plain-text copy of tool output that was already rendered as a tool card.

## Validation

- `bunx vitest run agent/auth-profiles/manager.test.ts src/state/sessionUiSnapshot.test.ts src/hooks/bridgeMessageHandlers/sessionHistory.test.ts src/hooks/useSessionPersistence.test.tsx`
- `bun run typecheck`
- `bun run lint` (passes with the existing 5 React hook warnings in dashboard/editor files)
- `bunx vitest run`
- `bun run build`
- `check` (version check, cargo clippy, TypeScript, ESLint warning pass, cargo test --lib, Vitest)

## Notes

The existing lint warnings are unrelated to this branch and are still limited to:

- `src/skills/default-layout/dashboard/project-dashboard.tsx`
- `src/skills/default-layout/dashboard/task-launcher.tsx`
- `src/skills/default-layout/editor/image-viewer.tsx`
- `src/skills/default-layout/editor/markdown-preview.tsx`
- `src/skills/default-layout/layout/worktree-landing.tsx`
