### PR TITLE
feat: add voice-to-text input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,16 +85,18 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri -> target
-      - name: Install Linux build deps (webkit2gtk, gtk closure)
+      - name: Install Linux build deps (webkit2gtk, gtk, ALSA closure)
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install --no-install-recommends -y \
+            libasound2-dev \
             libwebkit2gtk-4.1-dev \
             libgtk-3-dev \
             libayatana-appindicator3-dev \
             librsvg2-dev \
             libsoup-3.0-dev \
+            pkg-config \
             patchelf
       - name: Setup Bun (build.rs runs `bun build --compile`)
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -296,6 +296,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install --no-install-recommends -y \
             build-essential \
+            libasound2-dev \
             libayatana-appindicator3-dev \
             libgtk-3-dev \
             librsvg2-dev \

--- a/flake.nix
+++ b/flake.nix
@@ -121,6 +121,7 @@
             pkgs.libsoup_3
             pkgs.glib
             pkgs.glib-networking
+            pkgs.alsa-lib
             pkgs.openssl
             pkgs.libayatana-appindicator
             pkgs.gsettings-desktop-schemas

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -10,6 +10,10 @@
 #     port shifting in lockstep so multiple dev instances don't collide.
 #   - The skill needs to know the actual debug port without the user
 #     typing it. dev-info.json gives it a single discovery file.
+#   - On macOS, Apple Speech and microphone permissions require a real
+#     responsible .app process. This script passes a custom Tauri runner
+#     that wraps the debug binary in a signed "Aethon Dev.app" and launches
+#     it through Launch Services, matching Claudette's TCC-safe dev path.
 #
 # Flags:
 #   --new       Spin up a fresh user — points AETHON_USER_DIR at a
@@ -36,6 +40,7 @@
 #   VITE_PORT                  the chosen Vite port (vite.config.ts honors this)
 #   AETHON_DEBUG_PORT          the chosen debug port (src-tauri/src/debug.rs honors this)
 #   AETHON_USER_DIR            (--new only) per-PID tmp ~/.aethon override
+#   AETHON_PROJECT_ROOT        repo root forwarded through the macOS .app runner
 #   TAURI_CONFIG               JSON patch overriding devUrl so Tauri loads the right port
 
 set -euo pipefail
@@ -203,6 +208,7 @@ trap cleanup EXIT
 
 export VITE_PORT
 export AETHON_DEBUG_PORT="$DEBUG_PORT"
+export AETHON_PROJECT_ROOT="$(pwd)"
 # Tauri reads TAURI_CONFIG as a JSON patch merged over tauri.conf.json,
 # so we override devUrl to point at the actually-bound Vite port. Stays
 # in sync with --port semantics from older Tauri without the dependency.
@@ -276,7 +282,12 @@ sandbox_dir_path="$sandbox_dir"
 ) &
 disown
 
+runner_args=()
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  runner_args=(--runner "$(pwd)/scripts/macos-dev-app-runner.sh")
+fi
+
 # Hand the terminal to cargo. After exec, this script's PID *is* cargo —
 # the watchdog watches that PID, and Ctrl+C goes straight to cargo with
 # zero bash signal-routing in the middle.
-exec cargo tauri dev "$@"
+exec cargo tauri dev "${runner_args[@]}" "$@"

--- a/scripts/macos-dev-app-runner.sh
+++ b/scripts/macos-dev-app-runner.sh
@@ -1,0 +1,315 @@
+#!/usr/bin/env bash
+# cargo-tauri runner for macOS development builds.
+#
+# macOS TCC attributes microphone and speech-recognition prompts to the
+# responsible process. When `cargo tauri dev` execs the debug binary directly,
+# that process is the terminal, whose Info.plist does not contain Aethon's
+# privacy strings. Wrap the debug binary in a signed .app and launch it via
+# Launch Services so Apple Speech sees Aethon as the responsible app.
+if [ -z "${BASH_VERSION:-}" ]; then
+  exec /usr/bin/env bash "$0" "$@"
+fi
+
+set -euo pipefail
+
+if [ "$#" -lt 1 ]; then
+  echo "usage: macos-dev-app-runner.sh <binary>|run [cargo/app args...]" >&2
+  exit 64
+fi
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+
+if [ -f "$1" ]; then
+  binary="$1"
+  shift
+  app_args=("$@")
+else
+  if [ "$1" != "run" ]; then
+    echo "unsupported Tauri runner command: $1" >&2
+    exit 64
+  fi
+  shift
+
+  build_args=(build --manifest-path "$repo_root/src-tauri/Cargo.toml")
+  app_args=()
+  profile=debug
+  target_triple=""
+  in_app_args=false
+
+  while [ "$#" -gt 0 ]; do
+    if [ "$in_app_args" = true ]; then
+      app_args+=("$1")
+      shift
+      continue
+    fi
+
+    case "$1" in
+      --)
+        in_app_args=true
+        shift
+        ;;
+      --release)
+        profile=release
+        build_args+=("$1")
+        shift
+        ;;
+      --target)
+        if [ "$#" -lt 2 ]; then
+          echo "missing value for --target" >&2
+          exit 64
+        fi
+        build_args+=("$1" "$2")
+        target_triple="$2"
+        shift 2
+        ;;
+      --target=*)
+        build_args+=("$1")
+        target_triple="${1#--target=}"
+        shift
+        ;;
+      *)
+        build_args+=("$1")
+        shift
+        ;;
+    esac
+  done
+
+  cargo "${build_args[@]}"
+
+  target_dir="${CARGO_TARGET_DIR:-$repo_root/src-tauri/target}"
+  if [[ "$target_dir" != /* ]]; then
+    target_dir="$repo_root/src-tauri/$target_dir"
+  fi
+
+  if [ -n "$target_triple" ]; then
+    binary="$target_dir/$target_triple/$profile/aethon"
+  else
+    binary="$target_dir/$profile/aethon"
+  fi
+fi
+
+if [ ! -f "$binary" ]; then
+  echo "built binary not found: $binary" >&2
+  exit 66
+fi
+
+binary_dir="$(cd "$(dirname "$binary")" && pwd)"
+bundle_dir="${AETHON_DEV_APP_BUNDLE:-$binary_dir/Aethon Dev.app}"
+contents_dir="$bundle_dir/Contents"
+macos_dir="$contents_dir/MacOS"
+resources_dir="$contents_dir/Resources"
+bundle_executable="$macos_dir/aethon"
+managed_app_pids=()
+
+launched_app_pids() {
+  ps -axo pid=,command= | while read -r pid command; do
+    if [ -z "$pid" ] || [ "$pid" = "$$" ]; then
+      continue
+    fi
+    case "$command" in
+      *"$bundle_executable"*) printf '%s\n' "$pid" ;;
+    esac
+  done
+}
+
+terminate_app_pids() {
+  if [ "$#" -eq 0 ]; then
+    return 0
+  fi
+
+  local pids=("$@")
+  local remaining=()
+  local pid
+  local _
+
+  kill "${pids[@]}" 2>/dev/null || true
+
+  for _ in {1..50}; do
+    remaining=()
+    for pid in "${pids[@]}"; do
+      if kill -0 "$pid" 2>/dev/null; then
+        remaining+=("$pid")
+      fi
+    done
+
+    if [ "${#remaining[@]}" -eq 0 ]; then
+      return 0
+    fi
+
+    sleep 0.1
+  done
+
+  if [ "${#remaining[@]}" -gt 0 ]; then
+    kill -9 "${remaining[@]}" 2>/dev/null || true
+  fi
+}
+
+terminate_launched_app() {
+  local pids=()
+  local pid
+  while IFS= read -r pid; do
+    [ -n "$pid" ] && pids+=("$pid")
+  done < <(launched_app_pids)
+
+  if [ "${#pids[@]}" -gt 0 ]; then
+    terminate_app_pids "${pids[@]}"
+  fi
+}
+
+terminate_managed_app() {
+  if [ "${#managed_app_pids[@]}" -gt 0 ]; then
+    terminate_app_pids "${managed_app_pids[@]}"
+  else
+    terminate_launched_app
+  fi
+}
+
+# If the previous dev runner was killed during a rebuild, the launched .app can
+# survive after `open -W` exits. Clear that stale copy before launching.
+terminate_launched_app
+
+mkdir -p "$macos_dir" "$resources_dir"
+rm -f "$bundle_executable"
+cp "$binary" "$bundle_executable"
+chmod +x "$bundle_executable"
+
+# Mirror Tauri externalBin + resource staging into the dev .app so debug runs
+# launched from `/` behave like release bundles for sidecar/resource lookups.
+host_triple="$(rustc -vV 2>/dev/null | awk '/host:/ {print $2}')"
+staged_dir="$repo_root/src-tauri/binaries"
+if [ -n "$host_triple" ] && [ -d "$staged_dir" ]; then
+  shopt -s nullglob
+  for staged in "$staged_dir"/*-"$host_triple"; do
+    base="$(basename "$staged")"
+    stripped="${base%-$host_triple}"
+    dest="$macos_dir/$stripped"
+    rm -f "$dest"
+    cp "$staged" "$dest"
+    chmod +x "$dest"
+    echo "▸ Mirrored sidecar ${base} → MacOS/${stripped}"
+  done
+  shopt -u nullglob
+
+  if [ -f "$staged_dir/pi/package.json" ]; then
+    resource_pi_dir="$resources_dir/pi"
+    mkdir -p "$resource_pi_dir"
+    cp "$staged_dir/pi/package.json" "$resource_pi_dir/package.json"
+    echo "▸ Mirrored pi/package.json → Resources/pi/"
+  fi
+fi
+
+cat >"$contents_dir/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>aethon</string>
+  <key>CFBundleIdentifier</key>
+  <string>com.utensils.aethon.dev</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>Aethon Dev</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>0.0.0-dev</string>
+  <key>CFBundleVersion</key>
+  <string>0</string>
+  <key>LSMinimumSystemVersion</key>
+  <string>11.0</string>
+  <key>NSHighResolutionCapable</key>
+  <true/>
+  <key>NSMicrophoneUsageDescription</key>
+  <string>Aethon uses the microphone for voice input in chat prompts.</string>
+  <key>NSSpeechRecognitionUsageDescription</key>
+  <string>Aethon uses speech recognition to convert voice input into chat prompt text.</string>
+</dict>
+</plist>
+PLIST
+
+if command -v xattr >/dev/null 2>&1; then
+  xattr -dr com.apple.quarantine "$bundle_dir" 2>/dev/null || true
+fi
+
+if command -v codesign >/dev/null 2>&1; then
+  echo "▸ Signing $bundle_dir with src-tauri/Entitlements.plist"
+  codesign --force --deep --sign - \
+    --entitlements "$repo_root/src-tauri/Entitlements.plist" \
+    "$bundle_dir"
+fi
+
+log_dir="$(mktemp -d)"
+stdout_fifo="$log_dir/stdout"
+stderr_fifo="$log_dir/stderr"
+mkfifo "$stdout_fifo" "$stderr_fifo"
+
+cleanup() {
+  terminate_managed_app
+  rm -rf "$log_dir"
+  if [ -n "${open_pid:-}" ] && kill -0 "$open_pid" 2>/dev/null; then
+    kill "$open_pid" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT TERM
+
+cat "$stdout_fifo" &
+cat_stdout_pid=$!
+cat "$stderr_fifo" >&2 &
+cat_stderr_pid=$!
+
+env_args=()
+for var in \
+  VITE_PORT AETHON_DEBUG_PORT AETHON_USER_DIR AETHON_PROJECT_ROOT \
+  RUST_LOG RUST_BACKTRACE; do
+  if [ -n "${!var:-}" ]; then
+    env_args+=(--env "$var=${!var}")
+  fi
+done
+
+echo "▸ Launching $bundle_dir via Launch Services"
+open_argv=(open -n -W -a "$bundle_dir" --stdout "$stdout_fifo" --stderr "$stderr_fifo")
+if [ "${#env_args[@]}" -gt 0 ]; then
+  open_argv+=("${env_args[@]}")
+fi
+open_argv+=(--args)
+if [ "${#app_args[@]}" -gt 0 ]; then
+  open_argv+=("${app_args[@]}")
+fi
+"${open_argv[@]}" &
+open_pid=$!
+
+for _ in {1..50}; do
+  while IFS= read -r pid; do
+    already_managed=false
+    if [ "${#managed_app_pids[@]}" -gt 0 ]; then
+      for managed_pid in "${managed_app_pids[@]}"; do
+        if [ "$managed_pid" = "$pid" ]; then
+          already_managed=true
+          break
+        fi
+      done
+    fi
+
+    if [ "$already_managed" = false ]; then
+      managed_app_pids+=("$pid")
+    fi
+  done < <(launched_app_pids)
+
+  if [ "${#managed_app_pids[@]}" -gt 0 ] || ! kill -0 "$open_pid" 2>/dev/null; then
+    break
+  fi
+
+  sleep 0.1
+done
+
+wait "$open_pid"
+exit_code=$?
+
+wait "$cat_stdout_pid" "$cat_stderr_pid" 2>/dev/null || true
+
+exit "$exit_code"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -12,15 +12,24 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 name = "aethon"
 version = "0.3.3"
 dependencies = [
+ "async-trait",
  "axum",
  "base64 0.22.1",
+ "candle-core",
+ "candle-nn",
+ "candle-transformers",
  "chrono",
+ "cpal",
+ "futures-util",
  "gethostname",
+ "hound",
  "libc",
  "mdns-sd",
  "notify",
+ "parking_lot",
  "portable-pty",
  "reqwest 0.12.28",
+ "rubato",
  "serde",
  "serde_json",
  "sha1",
@@ -32,6 +41,7 @@ dependencies = [
  "tauri-plugin-process",
  "tauri-plugin-updater",
  "tempfile",
+ "tokenizers",
  "tokio",
  "toml 0.8.23",
  "toml_edit 0.22.27",
@@ -41,6 +51,21 @@ dependencies = [
  "trash",
  "url",
  "uuid",
+ "windows 0.61.3",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -65,6 +90,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
 dependencies = [
  "alloc-no-stdlib",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "alsa"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812947049edcd670a82cd5c73c3661d2e58468577ba8489de58e1a73c04cbd5d"
+dependencies = [
+ "alsa-sys",
+ "bitflags 2.11.1",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "alsa-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad7569085a265dd3f607ebecce7458eaab2132a84393534c95b18dcbc3f31e04"
+dependencies = [
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -252,6 +305,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "audio-core"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ebbf82d06013f4c41fe71303feb980cddd78496d904d06be627972de51a24"
+
+[[package]]
+name = "audioadapter"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91f87b70b051c5866680ad79f6743a42ccab264c009d1a71f4d33a3872ae60c8"
+dependencies = [
+ "audio-core",
+ "num-traits",
+]
+
+[[package]]
+name = "audioadapter-buffers"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9097d67933fb083d382ce980430afdb758aada60846010aee6be068c06cef0ca"
+dependencies = [
+ "audioadapter",
+ "audioadapter-sample",
+ "num-traits",
+]
+
+[[package]]
+name = "audioadapter-sample"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ab94f2bc04a14e1f49ee5f222f66460e8a1b51627bdfedf34eed394d747938"
+dependencies = [
+ "audio-core",
+ "num-traits",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,6 +404,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -353,6 +449,12 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
 ]
+
+[[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "block-buffer"
@@ -417,6 +519,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "byteorder"
@@ -468,6 +584,95 @@ dependencies = [
 ]
 
 [[package]]
+name = "candle-core"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c15b675b80d994b2eadb20a4bbe434eabeb454eac3ee5e2b4cf6f147ee9be091"
+dependencies = [
+ "byteorder",
+ "candle-metal-kernels",
+ "candle-ug",
+ "float8",
+ "gemm 0.19.0",
+ "half",
+ "libm",
+ "memmap2",
+ "num-traits",
+ "num_cpus",
+ "objc2-foundation",
+ "objc2-metal",
+ "rand 0.9.4",
+ "rand_distr",
+ "rayon",
+ "safetensors 0.7.0",
+ "thiserror 2.0.18",
+ "yoke 0.8.2",
+ "zip 7.2.0",
+]
+
+[[package]]
+name = "candle-metal-kernels"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fdfe9d06de16ce49961e49084e5b79a75a9bdf157246e7c7b6328e87a7aa25d"
+dependencies = [
+ "half",
+ "objc2",
+ "objc2-foundation",
+ "objc2-metal",
+ "once_cell",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "candle-nn"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3045fa9e7aef8567d209a27d56b692f60b96f4d0569f4c3011f8ca6715c65e03"
+dependencies = [
+ "candle-core",
+ "candle-metal-kernels",
+ "half",
+ "libc",
+ "num-traits",
+ "objc2-metal",
+ "rayon",
+ "safetensors 0.7.0",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "candle-transformers"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b538ec4aa807c416a2ddd3621044888f188827862e2a6fcacba4738e89795d01"
+dependencies = [
+ "byteorder",
+ "candle-core",
+ "candle-nn",
+ "fancy-regex",
+ "num-traits",
+ "rand 0.9.4",
+ "rayon",
+ "serde",
+ "serde_json",
+ "serde_plain",
+ "tracing",
+]
+
+[[package]]
+name = "candle-ug"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c22d62be69068bf58987a45f690612739d8d2ea1bf508c1b87dc6815a019575d"
+dependencies = [
+ "ug",
+ "ug-metal",
+]
+
+[[package]]
 name = "cargo-platform"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -498,6 +703,15 @@ checksum = "374b7c592d9c00c1f4972ea58390ac6b18cbb6ab79011f3bdc90a0b82ca06b77"
 dependencies = [
  "serde",
  "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -578,6 +792,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "serde",
+ "static_assertions",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -594,6 +823,16 @@ checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
  "time",
  "version_check",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -619,9 +858,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.11.1",
- "core-foundation",
- "core-graphics-types",
+ "core-foundation 0.10.1",
+ "core-graphics-types 0.2.0",
  "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
  "libc",
 ]
 
@@ -632,8 +882,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.11.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
+]
+
+[[package]]
+name = "coreaudio-rs"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5d7dca3ebcf65a035582c9ad4385371a9d9ee6537474d2a278f4e1e475bb58"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+ "objc2-audio-toolbox",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "cpal"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8942da362c0f0d895d7cac616263f2f9424edc5687364dfd1d25ef7eba506d7"
+dependencies = [
+ "alsa",
+ "coreaudio-rs",
+ "dasp_sample",
+ "jni 0.21.1",
+ "js-sys",
+ "libc",
+ "mach2",
+ "ndk",
+ "ndk-context",
+ "num-derive",
+ "num-traits",
+ "objc2",
+ "objc2-audio-toolbox",
+ "objc2-avf-audio",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -664,10 +958,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -720,12 +1039,36 @@ checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -743,14 +1086,40 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "dary_heap"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "dasp_sample"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
 name = "dbus"
@@ -781,6 +1150,37 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
  "syn 2.0.117",
 ]
 
@@ -955,6 +1355,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "dyn-stack"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c4713e43e2886ba72b8271aa66c93d722116acf7a75555cce11dcde84388fe8"
+dependencies = [
+ "bytemuck",
+ "dyn-stack-macros",
+]
+
+[[package]]
+name = "dyn-stack-macros"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
 name = "embed-resource"
 version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -979,6 +1401,18 @@ name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "enumflags2"
@@ -1029,6 +1463,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "esaxx-rs"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1047,6 +1487,17 @@ checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener",
  "pin-project-lite",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1110,6 +1561,18 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "float8"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719a903cc23e4a89e87962c2a80fdb45cdaad0983a89bd150bb57b4c8571a7d5"
+dependencies = [
+ "half",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_distr",
 ]
 
 [[package]]
@@ -1370,6 +1833,244 @@ dependencies = [
 ]
 
 [[package]]
+name = "gemm"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab96b703d31950f1aeddded248bc95543c9efc7ac9c4a21fda8703a83ee35451"
+dependencies = [
+ "dyn-stack",
+ "gemm-c32 0.18.2",
+ "gemm-c64 0.18.2",
+ "gemm-common 0.18.2",
+ "gemm-f16 0.18.2",
+ "gemm-f32 0.18.2",
+ "gemm-f64 0.18.2",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa0673db364b12263d103b68337a68fbecc541d6f6b61ba72fe438654709eacb"
+dependencies = [
+ "dyn-stack",
+ "gemm-c32 0.19.0",
+ "gemm-c64 0.19.0",
+ "gemm-common 0.19.0",
+ "gemm-f16 0.19.0",
+ "gemm-f32 0.19.0",
+ "gemm-f64 0.19.0",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c32"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6db9fd9f40421d00eea9dd0770045a5603b8d684654816637732463f4073847"
+dependencies = [
+ "dyn-stack",
+ "gemm-common 0.18.2",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c32"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "086936dbdcb99e37aad81d320f98f670e53c1e55a98bee70573e83f95beb128c"
+dependencies = [
+ "dyn-stack",
+ "gemm-common 0.19.0",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c64"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfcad8a3d35a43758330b635d02edad980c1e143dc2f21e6fd25f9e4eada8edf"
+dependencies = [
+ "dyn-stack",
+ "gemm-common 0.18.2",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c64"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20c8aeeeec425959bda4d9827664029ba1501a90a0d1e6228e48bef741db3a3f"
+dependencies = [
+ "dyn-stack",
+ "gemm-common 0.19.0",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-common"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a352d4a69cbe938b9e2a9cb7a3a63b7e72f9349174a2752a558a8a563510d0f3"
+dependencies = [
+ "bytemuck",
+ "dyn-stack",
+ "half",
+ "libm",
+ "num-complex",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "pulp 0.21.5",
+ "raw-cpuid",
+ "rayon",
+ "seq-macro",
+ "sysctl",
+]
+
+[[package]]
+name = "gemm-common"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88027625910cc9b1085aaaa1c4bc46bb3a36aad323452b33c25b5e4e7c8e2a3e"
+dependencies = [
+ "bytemuck",
+ "dyn-stack",
+ "half",
+ "libm",
+ "num-complex",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "pulp 0.22.2",
+ "raw-cpuid",
+ "rayon",
+ "seq-macro",
+ "sysctl",
+]
+
+[[package]]
+name = "gemm-f16"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff95ae3259432f3c3410eaa919033cd03791d81cebd18018393dc147952e109"
+dependencies = [
+ "dyn-stack",
+ "gemm-common 0.18.2",
+ "gemm-f32 0.18.2",
+ "half",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "rayon",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f16"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3df7a55202e6cd6739d82ae3399c8e0c7e1402859b30e4cb780e61525d9486e"
+dependencies = [
+ "dyn-stack",
+ "gemm-common 0.19.0",
+ "gemm-f32 0.19.0",
+ "half",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "rayon",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f32"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc8d3d4385393304f407392f754cd2dc4b315d05063f62cf09f47b58de276864"
+dependencies = [
+ "dyn-stack",
+ "gemm-common 0.18.2",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f32"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e0b8c9da1fbec6e3e3ab2ce6bc259ef18eb5f6f0d3e4edf54b75f9fd41a81c"
+dependencies = [
+ "dyn-stack",
+ "gemm-common 0.19.0",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f64"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35b2a4f76ce4b8b16eadc11ccf2e083252d8237c1b589558a49b0183545015bd"
+dependencies = [
+ "dyn-stack",
+ "gemm-common 0.18.2",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f64"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "056131e8f2a521bfab322f804ccd652520c79700d81209e9d9275bbdecaadc6a"
+dependencies = [
+ "dyn-stack",
+ "gemm-common 0.19.0",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1578,6 +2279,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "crunchy",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_distr",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1590,6 +2306,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1621,6 +2350,12 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hound"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
 
 [[package]]
 name = "html5ever"
@@ -1780,7 +2515,7 @@ dependencies = [
  "displaydoc",
  "potential_utf",
  "utf8_iter",
- "yoke",
+ "yoke 0.8.2",
  "zerofrom",
  "zerovec",
 ]
@@ -1847,7 +2582,7 @@ dependencies = [
  "displaydoc",
  "icu_locale_core",
  "writeable",
- "yoke",
+ "yoke 0.8.2",
  "zerofrom",
  "zerotrie",
  "zerovec",
@@ -1981,6 +2716,15 @@ checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
 dependencies = [
  "is-docker",
  "once_cell",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -2183,7 +2927,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e9ec52138abedcc58dc17a7c6c0c00a2bdb4f3427c7f63fa97fd0d859155caf"
 dependencies = [
  "gtk-sys",
- "libloading",
+ "libloading 0.7.4",
  "once_cell",
 ]
 
@@ -2211,6 +2955,22 @@ dependencies = [
  "cfg-if",
  "winapi",
 ]
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -2270,6 +3030,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "macro_rules_attribute"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65049d7923698040cd0b1ddcced9b0eb14dd22c5f86ae59c3740eab64a676520"
+dependencies = [
+ "macro_rules_attribute-proc_macro",
+ "paste",
+]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
+
+[[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2316,6 +3110,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2325,10 +3129,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "metal"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
+dependencies = [
+ "bitflags 2.11.1",
+ "block",
+ "core-graphics-types 0.1.3",
+ "foreign-types",
+ "log",
+ "objc",
+ "paste",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "minisign-verify"
@@ -2356,6 +3181,28 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "monostate"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3341a273f6c9d5bef1908f17b7267bbab0e95c9bf69a0d4dcf8e9e1b2c76ef67"
+dependencies = [
+ "monostate-impl",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "monostate-impl"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2395,6 +3242,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
 name = "ndk-sys"
 version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2419,6 +3272,16 @@ dependencies = [
  "cfg-if",
  "cfg_aliases 0.1.1",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -2472,10 +3335,86 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "bytemuck",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2484,6 +3423,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -2506,6 +3456,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
 ]
 
 [[package]]
@@ -2532,6 +3491,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-audio-toolbox"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6948501a91121d6399b79abaa33a8aa4ea7857fe019f341b8c23ad6e81b79b08"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+ "objc2",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-avf-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a380031deed8e99db00065c45937da434ca987c034e13b87e4441f9e4090be"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-cloud-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2540,6 +3524,29 @@ dependencies = [
  "bitflags 2.11.1",
  "objc2",
  "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1eebcea8b0dbff5f7c8504f3107c68fc061a3eb44932051c8cf8a68d969c3b2"
+dependencies = [
+ "dispatch2",
+ "objc2",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
 ]
 
 [[package]]
@@ -2559,7 +3566,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.1",
+ "block2",
  "dispatch2",
+ "libc",
  "objc2",
 ]
 
@@ -2648,6 +3657,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-osa-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2721,6 +3744,28 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "onig"
+version = "6.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "open"
@@ -2823,6 +3868,12 @@ dependencies = [
  "smallvec",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pathdiff"
@@ -3152,6 +4203,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulp"
+version = "0.21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b86df24f0a7ddd5e4b95c94fc9ed8a98f1ca94d3b01bdce2824097e7835907"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "libm",
+ "num-complex",
+ "reborrow",
+ "version_check",
+]
+
+[[package]]
+name = "pulp"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e205bb30d5b916c55e584c22201771bcf2bad9aabd5d4127f38387140c38632"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "libm",
+ "num-complex",
+ "paste",
+ "pulp-wasm-simd-flag",
+ "raw-cpuid",
+ "reborrow",
+ "version_check",
+]
+
+[[package]]
+name = "pulp-wasm-simd-flag"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40e24eee682d89fb193496edf918a7f407d30175b2e785fe057e4392dfd182e0"
+
+[[package]]
 name = "quick-xml"
 version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3290,10 +4378,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_distr"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
+dependencies = [
+ "num-traits",
+ "rand 0.9.4",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
 name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-cond"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
+dependencies = [
+ "either",
+ "itertools",
+ "rayon",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "reborrow"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
 
 [[package]]
 name = "redox_syscall"
@@ -3382,6 +4526,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -3401,12 +4546,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots",
 ]
@@ -3446,7 +4593,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -3486,6 +4633,20 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rubato"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce96ead1a91f7895704a9f08ea5947dfc8bd7c1f2936a22295b655ec67e5c6ef"
+dependencies = [
+ "audioadapter",
+ "audioadapter-buffers",
+ "num-integer",
+ "num-traits",
+ "visibility",
+ "windowfunctions",
 ]
 
 [[package]]
@@ -3558,7 +4719,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni 0.22.4",
  "log",
@@ -3601,6 +4762,27 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safetensors"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44560c11236a6130a46ce36c836a62936dc81ebf8c36a37947423571be0e55b6"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "safetensors"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "675656c1eabb620b921efea4f9199f97fc86e36dd6ffd1fbbe48d0f59a4987f5"
+dependencies = [
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "same-file"
@@ -3684,7 +4866,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.11.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -3728,6 +4910,12 @@ dependencies = [
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
@@ -3807,6 +4995,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_plain"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3872,7 +5069,7 @@ version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf2ebbe86054f9b45bc3881e865683ccfaccce97b9b4cb53f3039d67f355a334"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4101,10 +5298,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "spm_precompiled"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326"
+dependencies = [
+ "base64 0.13.1",
+ "nom",
+ "serde",
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_cache"
@@ -4201,6 +5416,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysctl"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01198a2debb237c62b6826ec7081082d951f46dbb64b0e8c7649a452230d1dfc"
+dependencies = [
+ "bitflags 2.11.1",
+ "byteorder",
+ "enum-as-inner",
+ "libc",
+ "thiserror 1.0.69",
+ "walkdir",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4221,7 +5450,7 @@ checksum = "1cf65722394c2ac443e80120064987f8914ee1d4e4e36e63cdf10f2990f01159"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dbus",
@@ -4533,7 +5762,7 @@ dependencies = [
  "tokio",
  "url",
  "windows-sys 0.60.2",
- "zip",
+ "zip 4.6.1",
 ]
 
 [[package]]
@@ -4775,6 +6004,39 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokenizers"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
+dependencies = [
+ "ahash",
+ "aho-corasick",
+ "compact_str",
+ "dary_heap",
+ "derive_builder",
+ "esaxx-rs",
+ "getrandom 0.3.4",
+ "itertools",
+ "log",
+ "macro_rules_attribute",
+ "monostate",
+ "onig",
+ "paste",
+ "rand 0.9.4",
+ "rayon",
+ "rayon-cond",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "spm_precompiled",
+ "thiserror 2.0.18",
+ "unicode-normalization-alignments",
+ "unicode-segmentation",
+ "unicode_categories",
+]
 
 [[package]]
 name = "tokio"
@@ -5132,6 +6394,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5152,6 +6420,41 @@ dependencies = [
  "memoffset",
  "tempfile",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ug"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76b761acf8af3494640d826a8609e2265e19778fb43306c7f15379c78c9b05b0"
+dependencies = [
+ "gemm 0.18.2",
+ "half",
+ "libloading 0.8.9",
+ "memmap2",
+ "num",
+ "num-traits",
+ "num_cpus",
+ "rayon",
+ "safetensors 0.4.5",
+ "serde",
+ "thiserror 1.0.69",
+ "tracing",
+ "yoke 0.7.5",
+]
+
+[[package]]
+name = "ug-metal"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7adf545a99a086d362efc739e7cf4317c18cbeda22706000fd434d70ea3d95"
+dependencies = [
+ "half",
+ "metal",
+ "objc",
+ "serde",
+ "thiserror 1.0.69",
+ "ug",
 ]
 
 [[package]]
@@ -5202,6 +6505,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-normalization-alignments"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5212,6 +6524,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "untrusted"
@@ -5291,6 +6609,17 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "visibility"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "vswhom"
@@ -5430,6 +6759,19 @@ dependencies = [
  "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -5631,6 +6973,15 @@ dependencies = [
  "raw-window-handle",
  "windows-sys 0.59.0",
  "windows-version",
+]
+
+[[package]]
+name = "windowfunctions"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90628d739333b7c5d2ee0b70210b97b8cddc38440c682c96fd9e2c24c2db5f3a"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -6363,13 +7714,37 @@ dependencies = [
 
 [[package]]
 name = "yoke"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive 0.7.5",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
- "yoke-derive",
+ "yoke-derive 0.8.2",
  "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
 ]
 
 [[package]]
@@ -6499,7 +7874,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
- "yoke",
+ "yoke 0.8.2",
  "zerofrom",
 ]
 
@@ -6509,7 +7884,7 @@ version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
- "yoke",
+ "yoke 0.8.2",
  "zerofrom",
  "zerovec-derive",
 ]
@@ -6535,6 +7910,18 @@ dependencies = [
  "crc32fast",
  "indexmap 2.14.0",
  "memchr",
+]
+
+[[package]]
+name = "zip"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
+dependencies = [
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
+ "typed-path",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,6 +29,8 @@ tokio = { version = "1.52.1", features = [
   "io-util",
   "time",
   "sync",
+  "fs",
+  "rt",
   "process",
   "macros",
 ] }
@@ -57,10 +59,48 @@ url = "2"
 reqwest = { version = "0.12", default-features = false, features = [
   "rustls-tls",
   "json",
+  "stream",
 ] }
+async-trait = "0.1"
+futures-util = "0.3"
+parking_lot = "0.12"
+cpal = { version = "0.17", optional = true }
+candle-core = { version = "=0.9.2", optional = true }
+candle-nn = { version = "=0.9.2", optional = true }
+candle-transformers = { version = "=0.9.2", optional = true }
+tokenizers = { version = "0.22", default-features = false, features = ["onig"], optional = true }
+rubato = { version = "2", default-features = false, optional = true }
+hound = { version = "3", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+candle-core = { version = "=0.9.2", features = ["metal"], optional = true }
+candle-nn = { version = "=0.9.2", features = ["metal"], optional = true }
+candle-transformers = { version = "=0.9.2", features = ["metal"], optional = true }
+
+[target.'cfg(windows)'.dependencies]
+windows = { version = "0.61", features = [
+  "Win32_Foundation",
+  "Win32_System_Com",
+  "Win32_System_Threading",
+  "Win32_System_Variant",
+  "Win32_Media_Audio",
+  "Win32_Media_Speech",
+] }
+
+[features]
+default = ["voice"]
+voice = [
+  "dep:cpal",
+  "dep:candle-core",
+  "dep:candle-nn",
+  "dep:candle-transformers",
+  "dep:tokenizers",
+  "dep:rubato",
+  "dep:hound",
+]
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/Entitlements.plist
+++ b/src-tauri/Entitlements.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.device.audio-input</key>
+  <true/>
+  <key>com.apple.security.personal-information.speech-recognition</key>
+  <true/>
+</dict>
+</plist>

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>NSMicrophoneUsageDescription</key>
+  <string>Aethon uses the microphone for voice input in chat prompts.</string>
+  <key>NSSpeechRecognitionUsageDescription</key>
+  <string>Aethon uses speech recognition to convert voice input into chat prompt text.</string>
+</dict>
+</plist>

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,5 +1,7 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::SystemTime;
+#[cfg(target_os = "macos")]
+use std::{env, process::Command};
 
 /// Returns true if any agent source / build input is newer than `target`.
 /// Walks `agent/` recursively and checks the lockfile + package.json so
@@ -44,6 +46,11 @@ fn main() {
     println!("cargo:rustc-check-cfg=cfg(desktop)");
     println!("cargo:rustc-check-cfg=cfg(mobile)");
 
+    #[cfg(target_os = "macos")]
+    if std::env::var_os("CARGO_FEATURE_VOICE").is_some() {
+        compile_platform_speech_swift();
+    }
+
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
     let project_root = Path::new(&manifest_dir).parent().unwrap().to_path_buf();
     let has_repo_sidecar_inputs =
@@ -73,6 +80,95 @@ fn main() {
         );
         println!("cargo:warning=skipping tauri bundle metadata generation for crate packaging");
     }
+}
+
+#[cfg(target_os = "macos")]
+fn compile_platform_speech_swift() {
+    let swiftc_available = Command::new("xcrun")
+        .args(["--find", "swiftc"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    if !swiftc_available {
+        println!(
+            "cargo:warning=swiftc not found; skipping Apple Speech Swift bridge. Full Tauri builds require Xcode."
+        );
+        return;
+    }
+
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("manifest dir"));
+    let out_dir = PathBuf::from(env::var("OUT_DIR").expect("out dir"));
+    let source = manifest_dir.join("macos").join("PlatformSpeech.swift");
+    let library = out_dir.join("libaethon_platform_speech.a");
+    let sdk_path = command_stdout("xcrun", &["--sdk", "macosx", "--show-sdk-path"]);
+    let target = swift_target();
+
+    let status = Command::new("xcrun")
+        .args([
+            "swiftc",
+            "-parse-as-library",
+            "-O",
+            "-emit-library",
+            "-static",
+        ])
+        .args(["-sdk", sdk_path.trim()])
+        .args(["-target", &target])
+        .arg(&source)
+        .arg("-o")
+        .arg(&library)
+        .status()
+        .expect("failed to invoke swiftc for PlatformSpeech.swift");
+    assert!(status.success(), "swiftc failed for PlatformSpeech.swift");
+
+    println!("cargo:rerun-if-changed={}", source.display());
+    println!("cargo:rustc-link-search=native={}", out_dir.display());
+    println!(
+        "cargo:rustc-link-search=native={}",
+        swift_runtime_path().display()
+    );
+    println!(
+        "cargo:rustc-link-search=framework={}/System/Library/Frameworks",
+        sdk_path.trim()
+    );
+    println!("cargo:rustc-link-lib=static=aethon_platform_speech");
+    println!("cargo:rustc-link-lib=framework=Speech");
+    println!("cargo:rustc-link-lib=framework=AVFoundation");
+    println!("cargo:rustc-link-lib=framework=Foundation");
+}
+
+#[cfg(target_os = "macos")]
+fn swift_target() -> String {
+    let target = env::var("TARGET").expect("target triple");
+    let arch = if target.starts_with("aarch64") {
+        "arm64"
+    } else if target.starts_with("x86_64") {
+        "x86_64"
+    } else {
+        panic!("unsupported macOS target for Swift bridge: {target}");
+    };
+    format!("{arch}-apple-macosx11.0")
+}
+
+#[cfg(target_os = "macos")]
+fn command_stdout(program: &str, args: &[&str]) -> String {
+    let output = Command::new(program)
+        .args(args)
+        .output()
+        .unwrap_or_else(|err| panic!("failed to run {program}: {err}"));
+    assert!(
+        output.status.success(),
+        "{program} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).expect("utf8 command output")
+}
+
+#[cfg(target_os = "macos")]
+fn swift_runtime_path() -> PathBuf {
+    let swiftc = PathBuf::from(command_stdout("xcrun", &["--find", "swiftc"]).trim());
+    let bin = swiftc.parent().expect("swiftc bin dir");
+    let toolchain_usr = bin.parent().expect("Swift toolchain usr dir");
+    toolchain_usr.join("lib").join("swift").join("macosx")
 }
 
 /// Compile `agent/main.ts` into a self-contained `bun build --compile`

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,4 +1,6 @@
-use std::path::{Path, PathBuf};
+use std::path::Path;
+#[cfg(target_os = "macos")]
+use std::path::PathBuf;
 use std::time::SystemTime;
 #[cfg(target_os = "macos")]
 use std::{env, process::Command};

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -90,10 +90,9 @@ fn compile_platform_speech_swift() {
         .map(|o| o.status.success())
         .unwrap_or(false);
     if !swiftc_available {
-        println!(
-            "cargo:warning=swiftc not found; skipping Apple Speech Swift bridge. Full Tauri builds require Xcode."
+        panic!(
+            "swiftc not found; the default voice feature requires Xcode/Swift to build the Apple Speech bridge on macOS. Install Xcode command line tools or build with --no-default-features."
         );
-        return;
     }
 
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("manifest dir"));

--- a/src-tauri/macos/PlatformSpeech.swift
+++ b/src-tauri/macos/PlatformSpeech.swift
@@ -126,7 +126,7 @@ private func platformSpeechStatus(prepare: Bool) -> AethonPlatformSpeechStatus {
 private func tccPreflightFailureMessage() -> String? {
     let bundle = Bundle.main
     if bundle.bundleURL.pathExtension.lowercased() != "app" {
-        return "Apple Speech permissions require Aethon to run from a macOS .app bundle. Start Aethon with the dev helper (scripts/dev.sh) or a packaged build."
+        return "Apple Speech permissions require Aethon to run from a macOS .app bundle. Start Aethon with the Nix dev helper (`dev`), scripts/dev.sh, or a packaged build."
     }
 
     let infoDictionary = bundle.infoDictionary ?? [:]

--- a/src-tauri/macos/PlatformSpeech.swift
+++ b/src-tauri/macos/PlatformSpeech.swift
@@ -1,0 +1,385 @@
+import AVFoundation
+import Darwin
+import Foundation
+import Speech
+
+private let statusReady: Int32 = 0
+private let statusNeedsMicrophonePermission: Int32 = 1
+private let statusNeedsSpeechPermission: Int32 = 2
+private let statusEngineUnavailable: Int32 = 3
+private let statusUnavailable: Int32 = 4
+private let statusNeedsAssets: Int32 = 5
+
+private let engineNone: Int32 = 0
+private let engineSpeechAnalyzer: Int32 = 1
+private let engineSFSpeech: Int32 = 2
+
+public struct AethonPlatformSpeechStatus {
+    public var code: Int32
+    public var engine: Int32
+    public var message: UnsafeMutablePointer<CChar>?
+}
+
+public struct AethonPlatformSpeechTranscription {
+    public var code: Int32
+    public var engine: Int32
+    public var text: UnsafeMutablePointer<CChar>?
+    public var message: UnsafeMutablePointer<CChar>?
+}
+
+@_cdecl("aethon_platform_speech_status")
+public func aethon_platform_speech_status(
+    _ code: UnsafeMutablePointer<Int32>?,
+    _ engine: UnsafeMutablePointer<Int32>?,
+    _ message: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?
+) {
+    writeStatus(platformSpeechStatus(prepare: false), code, engine, message)
+}
+
+@_cdecl("aethon_platform_speech_prepare")
+public func aethon_platform_speech_prepare(
+    _ code: UnsafeMutablePointer<Int32>?,
+    _ engine: UnsafeMutablePointer<Int32>?,
+    _ message: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?
+) {
+    writeStatus(platformSpeechStatus(prepare: true), code, engine, message)
+}
+
+@_cdecl("aethon_platform_speech_transcribe_file")
+public func aethon_platform_speech_transcribe_file(
+    _ pathPointer: UnsafePointer<CChar>?,
+    _ code: UnsafeMutablePointer<Int32>?,
+    _ engine: UnsafeMutablePointer<Int32>?,
+    _ text: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?,
+    _ message: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?
+) {
+    guard let pathPointer else {
+        writeTranscription(transcriptionError(
+            statusUnavailable,
+            engineNone,
+            "Missing audio file path for platform speech transcription."
+        ), code, engine, text, message)
+        return
+    }
+
+    let path = String(cString: pathPointer)
+    let url = URL(fileURLWithPath: path)
+    let status = platformSpeechStatus(prepare: true)
+    guard status.code == statusReady else {
+        writeTranscription(AethonPlatformSpeechTranscription(
+            code: status.code,
+            engine: status.engine,
+            text: nil,
+            message: status.message
+        ), code, engine, text, message)
+        return
+    }
+    aethon_platform_speech_free_string(status.message)
+
+    writeTranscription(transcribeWithSFSpeech(url: url), code, engine, text, message)
+}
+
+@_cdecl("aethon_platform_speech_free_string")
+public func aethon_platform_speech_free_string(_ pointer: UnsafeMutablePointer<CChar>?) {
+    if let pointer {
+        free(pointer)
+    }
+}
+
+private let activeSpeechTaskLock = NSLock()
+private var activeSpeechTask: SFSpeechRecognitionTask?
+
+@_cdecl("aethon_platform_speech_cancel")
+public func aethon_platform_speech_cancel() {
+    activeSpeechTaskLock.lock()
+    defer { activeSpeechTaskLock.unlock() }
+    activeSpeechTask?.cancel()
+    activeSpeechTask = nil
+}
+
+private func platformSpeechStatus(prepare: Bool) -> AethonPlatformSpeechStatus {
+    if let preflightFailure = tccPreflightFailureMessage() {
+        return status(statusEngineUnavailable, engineNone, preflightFailure)
+    }
+
+    let microphoneStatus = microphoneAuthorizationStatus(prepare: prepare)
+    if microphoneStatus != .authorized {
+        return status(
+            statusNeedsMicrophonePermission,
+            engineNone,
+            microphonePermissionMessage(microphoneStatus)
+        )
+    }
+
+    let speechStatus = speechAuthorizationStatus(prepare: prepare)
+    if speechStatus != .authorized {
+        return status(
+            statusNeedsSpeechPermission,
+            engineNone,
+            speechPermissionMessage(speechStatus)
+        )
+    }
+
+    return sfSpeechStatus()
+}
+
+private func tccPreflightFailureMessage() -> String? {
+    let bundle = Bundle.main
+    if bundle.bundleURL.pathExtension.lowercased() != "app" {
+        return "Apple Speech permissions require Aethon to run from a macOS .app bundle. Start Aethon with the dev helper (scripts/dev.sh) or a packaged build."
+    }
+
+    let infoDictionary = bundle.infoDictionary ?? [:]
+    if usageDescriptionValue("NSMicrophoneUsageDescription", in: infoDictionary) == nil {
+        return "App bundle is missing NSMicrophoneUsageDescription. Rebuild Aethon so macOS can show the required privacy prompt."
+    }
+    if usageDescriptionValue("NSSpeechRecognitionUsageDescription", in: infoDictionary) == nil {
+        return "App bundle is missing NSSpeechRecognitionUsageDescription. Rebuild Aethon so macOS can show the required privacy prompt."
+    }
+    return nil
+}
+
+private func usageDescriptionValue(
+    _ key: String,
+    in infoDictionary: [String: Any]
+) -> String? {
+    guard let value = infoDictionary[key] as? String else {
+        return nil
+    }
+    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? nil : trimmed
+}
+
+private func microphoneAuthorizationStatus(prepare: Bool) -> AVAuthorizationStatus {
+    let current = AVCaptureDevice.authorizationStatus(for: .audio)
+    guard prepare, current == .notDetermined else {
+        return current
+    }
+
+    let semaphore = DispatchSemaphore(value: 0)
+    AVCaptureDevice.requestAccess(for: .audio) { _ in
+        semaphore.signal()
+    }
+    semaphore.wait()
+    return AVCaptureDevice.authorizationStatus(for: .audio)
+}
+
+private func speechAuthorizationStatus(prepare: Bool) -> SFSpeechRecognizerAuthorizationStatus {
+    let current = SFSpeechRecognizer.authorizationStatus()
+    guard prepare, current == .notDetermined else {
+        return current
+    }
+
+    let semaphore = DispatchSemaphore(value: 0)
+    SFSpeechRecognizer.requestAuthorization { _ in
+        semaphore.signal()
+    }
+    semaphore.wait()
+    return SFSpeechRecognizer.authorizationStatus()
+}
+
+private func sfSpeechStatus() -> AethonPlatformSpeechStatus {
+    guard let recognizer = SFSpeechRecognizer(locale: Locale.current) else {
+        return status(
+            statusEngineUnavailable,
+            engineSFSpeech,
+            "Apple Speech does not support the current locale."
+        )
+    }
+    guard recognizer.isAvailable else {
+        return status(
+            statusEngineUnavailable,
+            engineSFSpeech,
+            "Apple Speech recognition is not currently available."
+        )
+    }
+    return status(statusReady, engineSFSpeech, "Ready via Apple Speech")
+}
+
+private func transcribeWithSFSpeech(url: URL) -> AethonPlatformSpeechTranscription {
+    guard let recognizer = SFSpeechRecognizer(locale: Locale.current) else {
+        return transcriptionError(
+            statusEngineUnavailable,
+            engineSFSpeech,
+            "Apple Speech does not support the current locale."
+        )
+    }
+    guard recognizer.isAvailable else {
+        return transcriptionError(
+            statusEngineUnavailable,
+            engineSFSpeech,
+            "Apple Speech recognition is not currently available."
+        )
+    }
+
+    let request = SFSpeechURLRecognitionRequest(url: url)
+    request.shouldReportPartialResults = false
+
+    let semaphore = DispatchSemaphore(value: 0)
+    let lock = NSLock()
+    var transcript = ""
+    var failure: String?
+    var completed = false
+    var task: SFSpeechRecognitionTask?
+
+    task = recognizer.recognitionTask(with: request) { result, error in
+        lock.lock()
+        defer { lock.unlock() }
+
+        if let result {
+            transcript = result.bestTranscription.formattedString
+            if result.isFinal && !completed {
+                completed = true
+                semaphore.signal()
+            }
+        }
+
+        if let error, !completed {
+            failure = friendlySFSpeechErrorMessage(error)
+            completed = true
+            semaphore.signal()
+        }
+    }
+
+    activeSpeechTaskLock.lock()
+    activeSpeechTask = task
+    activeSpeechTaskLock.unlock()
+
+    // Only clear the global if it still points at our task — a newer
+    // overlapping transcription may have replaced it, and clobbering its
+    // registration would silently break cancellation for that newer call.
+    let clearIfStillOurs = {
+        activeSpeechTaskLock.lock()
+        if activeSpeechTask === task {
+            activeSpeechTask = nil
+        }
+        activeSpeechTaskLock.unlock()
+    }
+
+    let timeout = DispatchTime.now() + .seconds(90)
+    if semaphore.wait(timeout: timeout) == .timedOut {
+        clearIfStillOurs()
+        task?.cancel()
+        return transcriptionError(
+            statusEngineUnavailable,
+            engineSFSpeech,
+            "Transcription timed out. Try a shorter recording."
+        )
+    }
+
+    clearIfStillOurs()
+    task?.cancel()
+    lock.lock()
+    let finalTranscript = transcript
+    let finalFailure = failure
+    lock.unlock()
+
+    if let finalFailure {
+        return transcriptionError(statusEngineUnavailable, engineSFSpeech, finalFailure)
+    }
+    return transcriptionSuccess(engineSFSpeech, finalTranscript)
+}
+
+private func friendlySFSpeechErrorMessage(_ error: Error) -> String {
+    let nsError = error as NSError
+    // kAFAssistantErrorDomain code 1110 ("No speech detected") is common when
+    // the user holds the mic too far away or stops recording before speaking.
+    if nsError.domain == "kAFAssistantErrorDomain" {
+        switch nsError.code {
+        case 1110:
+            return "No speech detected. Try again closer to the microphone."
+        case 1101, 1107:
+            return "Speech recognition was interrupted. Try again."
+        default:
+            break
+        }
+    }
+    return error.localizedDescription
+}
+
+private func writeStatus(
+    _ status: AethonPlatformSpeechStatus,
+    _ code: UnsafeMutablePointer<Int32>?,
+    _ engine: UnsafeMutablePointer<Int32>?,
+    _ message: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?
+) {
+    code?.pointee = status.code
+    engine?.pointee = status.engine
+    message?.pointee = status.message
+}
+
+private func writeTranscription(
+    _ transcription: AethonPlatformSpeechTranscription,
+    _ code: UnsafeMutablePointer<Int32>?,
+    _ engine: UnsafeMutablePointer<Int32>?,
+    _ text: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?,
+    _ message: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?
+) {
+    code?.pointee = transcription.code
+    engine?.pointee = transcription.engine
+    text?.pointee = transcription.text
+    message?.pointee = transcription.message
+}
+
+private func status(
+    _ code: Int32,
+    _ engine: Int32,
+    _ message: String
+) -> AethonPlatformSpeechStatus {
+    AethonPlatformSpeechStatus(code: code, engine: engine, message: copyCString(message))
+}
+
+private func transcriptionSuccess(
+    _ engine: Int32,
+    _ text: String
+) -> AethonPlatformSpeechTranscription {
+    AethonPlatformSpeechTranscription(
+        code: statusReady,
+        engine: engine,
+        text: copyCString(text),
+        message: copyCString(engine == engineSpeechAnalyzer ? "Apple SpeechAnalyzer" : "Apple Speech")
+    )
+}
+
+private func transcriptionError(
+    _ code: Int32,
+    _ engine: Int32,
+    _ message: String
+) -> AethonPlatformSpeechTranscription {
+    AethonPlatformSpeechTranscription(
+        code: code,
+        engine: engine,
+        text: nil,
+        message: copyCString(message)
+    )
+}
+
+private func copyCString(_ value: String) -> UnsafeMutablePointer<CChar>? {
+    strdup(value)
+}
+
+private func microphonePermissionMessage(_ status: AVAuthorizationStatus) -> String {
+    switch status {
+    case .notDetermined:
+        "Needs Microphone permission"
+    case .denied, .restricted:
+        "Needs Microphone permission"
+    case .authorized:
+        "Microphone permission granted"
+    @unknown default:
+        "Microphone permission status is unknown"
+    }
+}
+
+private func speechPermissionMessage(_ status: SFSpeechRecognizerAuthorizationStatus) -> String {
+    switch status {
+    case .notDetermined:
+        "Needs Speech Recognition permission"
+    case .denied, .restricted:
+        "Needs Speech Recognition permission"
+    case .authorized:
+        "Speech Recognition permission granted"
+    @unknown default:
+        "Speech Recognition permission status is unknown"
+    }
+}

--- a/src-tauri/src/agent_process/sidecar.rs
+++ b/src-tauri/src/agent_process/sidecar.rs
@@ -73,28 +73,42 @@ pub(super) fn find_sidecar_binary() -> Result<PathBuf, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
     use tempfile::tempdir;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn restore_project_root(previous: Option<std::ffi::OsString>) {
+        match previous {
+            Some(value) => unsafe { std::env::set_var("AETHON_PROJECT_ROOT", value) },
+            None => unsafe { std::env::remove_var("AETHON_PROJECT_ROOT") },
+        }
+    }
 
     #[test]
     fn project_root_honors_valid_env_override() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
         let dir = tempdir().expect("tempdir");
         let agent_dir = dir.path().join("agent");
         std::fs::create_dir_all(&agent_dir).expect("agent dir");
         std::fs::write(agent_dir.join("main.ts"), "").expect("main marker");
 
+        let previous = std::env::var_os("AETHON_PROJECT_ROOT");
         unsafe { std::env::set_var("AETHON_PROJECT_ROOT", dir.path()) };
         let got = project_root();
-        unsafe { std::env::remove_var("AETHON_PROJECT_ROOT") };
+        restore_project_root(previous);
 
         assert_eq!(got, dir.path());
     }
 
     #[test]
     fn project_root_ignores_invalid_env_override() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
         let dir = tempdir().expect("tempdir");
+        let previous = std::env::var_os("AETHON_PROJECT_ROOT");
         unsafe { std::env::set_var("AETHON_PROJECT_ROOT", dir.path()) };
         let got = project_root();
-        unsafe { std::env::remove_var("AETHON_PROJECT_ROOT") };
+        restore_project_root(previous);
 
         assert_ne!(got, dir.path());
     }

--- a/src-tauri/src/agent_process/sidecar.rs
+++ b/src-tauri/src/agent_process/sidecar.rs
@@ -12,6 +12,13 @@ use std::path::{Path, PathBuf};
 /// Walk up from cwd until we find the marker; fall back to cwd if nothing
 /// matches.
 pub(crate) fn project_root() -> PathBuf {
+    if let Some(path) = std::env::var_os("AETHON_PROJECT_ROOT") {
+        let path = PathBuf::from(path);
+        if path.join("agent").join("main.ts").exists() {
+            return path;
+        }
+    }
+
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     let mut dir: &Path = &cwd;
     for _ in 0..6 {
@@ -61,4 +68,34 @@ pub(super) fn find_sidecar_binary() -> Result<PathBuf, String> {
             .collect::<Vec<_>>()
             .join(", "),
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn project_root_honors_valid_env_override() {
+        let dir = tempdir().expect("tempdir");
+        let agent_dir = dir.path().join("agent");
+        std::fs::create_dir_all(&agent_dir).expect("agent dir");
+        std::fs::write(agent_dir.join("main.ts"), "").expect("main marker");
+
+        unsafe { std::env::set_var("AETHON_PROJECT_ROOT", dir.path()) };
+        let got = project_root();
+        unsafe { std::env::remove_var("AETHON_PROJECT_ROOT") };
+
+        assert_eq!(got, dir.path());
+    }
+
+    #[test]
+    fn project_root_ignores_invalid_env_override() {
+        let dir = tempdir().expect("tempdir");
+        unsafe { std::env::set_var("AETHON_PROJECT_ROOT", dir.path()) };
+        let got = project_root();
+        unsafe { std::env::remove_var("AETHON_PROJECT_ROOT") };
+
+        assert_ne!(got, dir.path());
+    }
 }

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -147,6 +147,7 @@ pub fn write_config(config: serde_json::Value, app: AppHandle) -> Result<(), Str
     let agent = config.get("agent").and_then(|v| v.as_object());
     let shell = config.get("shell").and_then(|v| v.as_object());
     let shortcuts = config.get("shortcuts").and_then(|v| v.as_object());
+    let voice = config.get("voice").and_then(|v| v.as_object());
     let updates = config.get("updates").and_then(|v| v.as_object());
     let devshell = config.get("devshell").and_then(|v| v.as_object());
 
@@ -204,6 +205,14 @@ pub fn write_config(config: serde_json::Value, app: AppHandle) -> Result<(), Str
         .and_then(|m| m.get("newTabKind"))
         .and_then(|v| v.as_str())
         .map(|s| helpers::normalize_new_tab_kind(Some(s)));
+    let voice_toggle_hotkey = voice
+        .and_then(|m| m.get("toggleHotkey"))
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty());
+    let voice_hold_hotkey = voice
+        .and_then(|m| m.get("holdHotkey"))
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty());
     let update_channel = updates
         .and_then(|m| m.get("channel"))
         .and_then(|v| v.as_str())
@@ -310,6 +319,13 @@ pub fn write_config(config: serde_json::Value, app: AppHandle) -> Result<(), Str
                 shortcuts_table.remove("new_tab_kind");
             }
         }
+    }
+
+    // ── [voice] ──
+    {
+        let voice_table = ensure_table(&mut doc, "voice");
+        set_or_clear_str(voice_table, "toggle_hotkey", voice_toggle_hotkey);
+        set_or_clear_str(voice_table, "hold_hotkey", voice_hold_hotkey);
     }
 
     // ── [updates] ──

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -29,4 +29,5 @@ pub mod host;
 pub mod server;
 pub mod session;
 pub mod updater;
+pub mod voice;
 pub mod window;

--- a/src-tauri/src/commands/voice.rs
+++ b/src-tauri/src/commands/voice.rs
@@ -1,0 +1,236 @@
+// Real implementations (compiled when the `voice` feature is enabled).
+#[cfg(feature = "voice")]
+use std::time::Instant;
+
+#[cfg(feature = "voice")]
+use tauri::{AppHandle, State};
+#[cfg(all(feature = "voice", debug_assertions))]
+use {serde::Serialize, tauri::Emitter};
+
+#[cfg(feature = "voice")]
+use crate::voice::{VoiceProviderInfo, VoiceProviderRegistry, VoiceSettings};
+
+#[cfg(feature = "voice")]
+fn open_voice_settings(app: &AppHandle) -> Result<VoiceSettings, String> {
+    let path = crate::commands::config::aethon_state_path(app, "voice.json")?;
+    VoiceSettings::open(&path)
+}
+
+#[cfg(feature = "voice")]
+#[tauri::command]
+pub async fn voice_list_providers(
+    app: AppHandle,
+    voice: State<'_, VoiceProviderRegistry>,
+) -> Result<Vec<VoiceProviderInfo>, String> {
+    let settings = open_voice_settings(&app)?;
+    Ok(voice.list_providers(&settings))
+}
+
+#[cfg(feature = "voice")]
+#[tauri::command]
+pub async fn voice_set_selected_provider(
+    provider_id: Option<String>,
+    app: AppHandle,
+    voice: State<'_, VoiceProviderRegistry>,
+) -> Result<(), String> {
+    let settings = open_voice_settings(&app)?;
+    voice.set_selected_provider(&settings, provider_id.as_deref())
+}
+
+#[cfg(feature = "voice")]
+#[tauri::command]
+pub async fn voice_set_provider_enabled(
+    provider_id: String,
+    enabled: bool,
+    app: AppHandle,
+    voice: State<'_, VoiceProviderRegistry>,
+) -> Result<(), String> {
+    let settings = open_voice_settings(&app)?;
+    voice.set_enabled(&settings, &provider_id, enabled)
+}
+
+#[cfg(feature = "voice")]
+#[tauri::command]
+pub async fn voice_prepare_provider(
+    provider_id: String,
+    app: AppHandle,
+    voice: State<'_, VoiceProviderRegistry>,
+) -> Result<VoiceProviderInfo, String> {
+    let state_path = crate::commands::config::aethon_state_path(&app, "voice.json")?;
+    voice
+        .prepare_provider(&app, &state_path, &provider_id)
+        .await
+}
+
+#[cfg(feature = "voice")]
+#[tauri::command]
+pub async fn voice_remove_provider_model(
+    provider_id: String,
+    app: AppHandle,
+    voice: State<'_, VoiceProviderRegistry>,
+) -> Result<VoiceProviderInfo, String> {
+    let state_path = crate::commands::config::aethon_state_path(&app, "voice.json")?;
+    voice.remove_provider_model(&state_path, &provider_id).await
+}
+
+#[cfg(all(feature = "voice", debug_assertions))]
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct VoiceStartLatencyEvent {
+    total_ms: u128,
+    stream_open_ms: u128,
+}
+
+#[cfg(feature = "voice")]
+#[tauri::command]
+#[tracing::instrument(
+    target = "aethon::voice",
+    skip(app, voice),
+    fields(
+        provider_id = tracing::field::Empty,
+        total_ms = tracing::field::Empty,
+        stream_open_ms = tracing::field::Empty,
+    ),
+    err,
+)]
+pub async fn voice_start_recording(
+    provider_id: Option<String>,
+    app: AppHandle,
+    voice: State<'_, VoiceProviderRegistry>,
+) -> Result<(), String> {
+    let t0 = Instant::now();
+    let resolved_provider_id = {
+        let settings = open_voice_settings(&app)?;
+        voice.resolve_provider_id(&settings, provider_id.as_deref())?
+    };
+    let span = tracing::Span::current();
+    span.record("provider_id", resolved_provider_id.as_str());
+    let latency = voice
+        .start_recording(
+            &crate::commands::config::aethon_state_path(&app, "voice.json")?,
+            &resolved_provider_id,
+            Some(app.clone()),
+        )
+        .await?;
+    let total_ms = t0.elapsed().as_millis() as u64;
+    let stream_open_ms = latency.stream_open_ms as u64;
+    span.record("total_ms", total_ms);
+    span.record("stream_open_ms", stream_open_ms);
+    tracing::info!(
+        target: "aethon::voice",
+        total_ms,
+        stream_open_ms,
+        "voice start recording latency"
+    );
+    #[cfg(debug_assertions)]
+    {
+        let _ = app.emit(
+            "voice://debug/start_latency",
+            VoiceStartLatencyEvent {
+                total_ms: total_ms as u128,
+                stream_open_ms: latency.stream_open_ms,
+            },
+        );
+    }
+    #[cfg(not(debug_assertions))]
+    let _ = app;
+    Ok(())
+}
+
+#[cfg(feature = "voice")]
+#[tauri::command]
+pub async fn voice_stop_and_transcribe(
+    provider_id: Option<String>,
+    app: AppHandle,
+    voice: State<'_, VoiceProviderRegistry>,
+) -> Result<String, String> {
+    let provider_id = {
+        let settings = open_voice_settings(&app)?;
+        voice.resolve_provider_id(&settings, provider_id.as_deref())?
+    };
+    voice.stop_and_transcribe(&provider_id).await
+}
+
+#[cfg(feature = "voice")]
+#[tauri::command]
+pub async fn voice_cancel_recording(
+    provider_id: Option<String>,
+    app: AppHandle,
+    voice: State<'_, VoiceProviderRegistry>,
+) -> Result<(), String> {
+    let provider_id = {
+        let settings = open_voice_settings(&app)?;
+        voice.resolve_provider_id(&settings, provider_id.as_deref())?
+    };
+    voice.cancel_recording(&provider_id).await
+}
+
+// Shim implementations (compiled when the `voice` feature is disabled).
+// These preserve the JS binding surface — including parameter names — so the
+// frontend's existing invoke args still deserialize cleanly and callers get
+// the intended VOICE_NOT_BUILT error instead of a Tauri arg-parse failure.
+#[cfg(not(feature = "voice"))]
+const VOICE_NOT_BUILT: &str = "voice support not built into this binary";
+
+#[cfg(not(feature = "voice"))]
+#[tauri::command]
+pub async fn voice_list_providers() -> Result<Vec<serde_json::Value>, String> {
+    Err(VOICE_NOT_BUILT.into())
+}
+
+#[cfg(not(feature = "voice"))]
+#[tauri::command]
+pub async fn voice_set_selected_provider(
+    #[allow(unused_variables)] provider_id: Option<String>,
+) -> Result<(), String> {
+    Err(VOICE_NOT_BUILT.into())
+}
+
+#[cfg(not(feature = "voice"))]
+#[tauri::command]
+pub async fn voice_set_provider_enabled(
+    #[allow(unused_variables)] provider_id: String,
+    #[allow(unused_variables)] enabled: bool,
+) -> Result<(), String> {
+    Err(VOICE_NOT_BUILT.into())
+}
+
+#[cfg(not(feature = "voice"))]
+#[tauri::command]
+pub async fn voice_prepare_provider(
+    #[allow(unused_variables)] provider_id: String,
+) -> Result<serde_json::Value, String> {
+    Err(VOICE_NOT_BUILT.into())
+}
+
+#[cfg(not(feature = "voice"))]
+#[tauri::command]
+pub async fn voice_remove_provider_model(
+    #[allow(unused_variables)] provider_id: String,
+) -> Result<serde_json::Value, String> {
+    Err(VOICE_NOT_BUILT.into())
+}
+
+#[cfg(not(feature = "voice"))]
+#[tauri::command]
+pub async fn voice_start_recording(
+    #[allow(unused_variables)] provider_id: Option<String>,
+) -> Result<(), String> {
+    Err(VOICE_NOT_BUILT.into())
+}
+
+#[cfg(not(feature = "voice"))]
+#[tauri::command]
+pub async fn voice_stop_and_transcribe(
+    #[allow(unused_variables)] provider_id: Option<String>,
+) -> Result<String, String> {
+    Err(VOICE_NOT_BUILT.into())
+}
+
+#[cfg(not(feature = "voice"))]
+#[tauri::command]
+pub async fn voice_cancel_recording(
+    #[allow(unused_variables)] provider_id: Option<String>,
+) -> Result<(), String> {
+    Err(VOICE_NOT_BUILT.into())
+}

--- a/src-tauri/src/helpers/config.rs
+++ b/src-tauri/src/helpers/config.rs
@@ -74,6 +74,12 @@ pub struct ShortcutsConfig {
 }
 
 #[derive(Default, Deserialize)]
+pub struct VoiceConfig {
+    pub toggle_hotkey: Option<String>,
+    pub hold_hotkey: Option<String>,
+}
+
+#[derive(Default, Deserialize)]
 pub struct UpdatesConfig {
     /// Which release channel the auto-updater checks. Allowed values:
     /// `"stable"` (default) tracks `releases/latest`; `"nightly"`
@@ -136,6 +142,8 @@ pub struct AethonConfig {
     pub shell: ShellConfig,
     #[serde(default)]
     pub shortcuts: ShortcutsConfig,
+    #[serde(default)]
+    pub voice: VoiceConfig,
     #[serde(default)]
     pub extensions: ExtensionsConfig,
     #[serde(default)]
@@ -200,6 +208,17 @@ pub fn normalize_new_tab_kind(input: Option<&str>) -> &'static str {
         Some("shell") => "shell",
         // Includes Some("agent"), Some(<unknown>), and None.
         _ => "agent",
+    }
+}
+
+pub fn default_voice_hold_hotkey() -> Option<&'static str> {
+    #[cfg(target_os = "macos")]
+    {
+        Some("AltRight")
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        None
     }
 }
 
@@ -278,6 +297,10 @@ pub fn parse_config_toml(input: &str) -> serde_json::Value {
         },
         "shortcuts": {
             "newTabKind": new_tab_kind,
+        },
+        "voice": {
+            "toggleHotkey": cfg.voice.toggle_hotkey.unwrap_or_else(|| "mod+shift+m".to_string()),
+            "holdHotkey": cfg.voice.hold_hotkey.or_else(|| default_voice_hold_hotkey().map(str::to_string)),
         },
         "extensions": {
             "stateWarnKb": state_warn_kb,
@@ -444,6 +467,28 @@ mod tests {
         assert_eq!(v["shortcuts"]["newTabKind"], "shell");
         let v = parse_config_toml("[shortcuts]\nnew_tab_kind = \"yolo\"\n");
         assert_eq!(v["shortcuts"]["newTabKind"], "agent");
+    }
+
+    #[test]
+    fn parse_config_toml_voice_defaults_are_stable() {
+        let v = parse_config_toml("");
+        assert_eq!(v["voice"]["toggleHotkey"], "mod+shift+m");
+        #[cfg(target_os = "macos")]
+        assert_eq!(v["voice"]["holdHotkey"], "AltRight");
+        #[cfg(not(target_os = "macos"))]
+        assert_eq!(v["voice"]["holdHotkey"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn parse_config_toml_extracts_voice_hotkeys() {
+        let v = parse_config_toml(
+            r#"[voice]
+toggle_hotkey = "mod+alt+v"
+hold_hotkey = "AltRight"
+"#,
+        );
+        assert_eq!(v["voice"]["toggleHotkey"], "mod+alt+v");
+        assert_eq!(v["voice"]["holdHotkey"], "AltRight");
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -38,9 +38,13 @@ mod env;
 mod helpers;
 mod logging;
 mod paste;
+#[cfg(feature = "voice")]
+mod platform_speech;
 mod server;
 mod shell;
 mod updater_state;
+#[cfg(feature = "voice")]
+mod voice;
 mod window_state;
 
 #[cfg(debug_assertions)]
@@ -127,7 +131,12 @@ pub fn run() {
         .manage(window_state::WindowStateStore::new())
         .manage(updater_state::UpdaterState::new())
         .manage(Arc::new(server::ServerState::new()))
-        .manage(devshell::DevshellCache::shared())
+        .manage(devshell::DevshellCache::shared());
+    #[cfg(feature = "voice")]
+    let builder = builder.manage(voice::VoiceProviderRegistry::new(
+        voice::VoiceProviderRegistry::default_model_root(),
+    ));
+    let builder = builder
         .on_window_event(|window, event| match event {
             tauri::WindowEvent::Resized(_) | tauri::WindowEvent::Moved(_) => {
                 window_state::schedule_save(
@@ -198,6 +207,14 @@ pub fn run() {
             commands::window::toggle_devtools,
             commands::updater::check_for_updates_with_channel,
             commands::updater::install_pending_update,
+            commands::voice::voice_list_providers,
+            commands::voice::voice_set_selected_provider,
+            commands::voice::voice_set_provider_enabled,
+            commands::voice::voice_prepare_provider,
+            commands::voice::voice_remove_provider_model,
+            commands::voice::voice_start_recording,
+            commands::voice::voice_stop_and_transcribe,
+            commands::voice::voice_cancel_recording,
             commands::boot::boot_stage,
             commands::boot::boot_ok,
             commands::devshell::devshell_status,

--- a/src-tauri/src/platform_speech.rs
+++ b/src-tauri/src/platform_speech.rs
@@ -1,0 +1,971 @@
+// The platform speech bridge gives the cross-platform `voice.rs` a single
+// trait it can lean on regardless of whether the host OS exposes a native
+// recognizer (macOS Apple Speech, Windows SAPI 5.4), or only a stub
+// fallback (Linux for now). Each `#[cfg(...)]` impl block below shares the
+// trait definition so callers in voice.rs do not need any per-OS branching
+// once they hold a `&dyn PlatformSpeechEngine`.
+//
+// The macOS path links to a small Swift static library (see build.rs) that
+// drives `SFSpeechRecognizer` / `SpeechAnalyzer`. The Windows path drives
+// SAPI 5.4 directly via COM through the `windows` crate — no .NET, no
+// PowerShell shell-out, no extra runtime. Both feed the same captured-
+// audio buffer produced by `CpalAudioRecorder`, written to a temporary
+// 16-bit PCM WAV before the engine reads it back.
+
+#[cfg(any(target_os = "macos", windows))]
+use std::path::Path;
+
+use crate::voice::CapturedAudio;
+
+// The non-Ready/non-Unavailable variants are only constructed on macOS via
+// availability_from_native(). Keeping the full enum cross-platform avoids
+// cfg-gating every match arm in voice.rs.
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum PlatformSpeechAvailabilityStatus {
+    Ready,
+    NeedsMicrophonePermission,
+    NeedsSpeechPermission,
+    NeedsAssets,
+    EngineUnavailable,
+    Unavailable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PlatformSpeechAvailability {
+    pub status: PlatformSpeechAvailabilityStatus,
+    pub engine_label: Option<String>,
+    pub message: String,
+}
+
+impl PlatformSpeechAvailability {
+    // Test constructors used only by the macOS/Windows-gated
+    // platform-speech tests — gate them the same way so they aren't dead
+    // code on Linux, where `cargo test --no-run` compiles test targets
+    // under `-Dwarnings`.
+    #[cfg(all(test, any(target_os = "macos", windows)))]
+    pub(crate) fn ready(engine_label: &str) -> Self {
+        Self {
+            status: PlatformSpeechAvailabilityStatus::Ready,
+            engine_label: Some(engine_label.to_string()),
+            message: format!("Ready via {engine_label}"),
+        }
+    }
+
+    #[cfg(all(test, any(target_os = "macos", windows)))]
+    pub(crate) fn needs_speech_permission(message: &str) -> Self {
+        Self {
+            status: PlatformSpeechAvailabilityStatus::NeedsSpeechPermission,
+            engine_label: None,
+            message: message.to_string(),
+        }
+    }
+
+    // Windows-only — the SAPI bridge advertises Ready up front; the
+    // EngineUnavailable variants are reserved for the macOS native
+    // status path or future probes that decide they need to gate the
+    // provider before the user clicks the mic.
+    #[cfg(windows)]
+    fn ready_now(engine_label: &str, message: impl Into<String>) -> Self {
+        Self {
+            status: PlatformSpeechAvailabilityStatus::Ready,
+            engine_label: Some(engine_label.to_string()),
+            message: message.into(),
+        }
+    }
+
+    // Only the Linux/other-OS stub uses this — both macOS and Windows have
+    // real engines that surface concrete states. Gated tightly so dead-code
+    // lint stays quiet under `-Dwarnings` on platforms that never reach it.
+    #[cfg(not(any(target_os = "macos", windows)))]
+    fn unavailable(message: impl Into<String>) -> Self {
+        Self {
+            status: PlatformSpeechAvailabilityStatus::Unavailable,
+            engine_label: None,
+            message: message.into(),
+        }
+    }
+}
+
+pub(crate) trait PlatformSpeechEngine: Send + Sync {
+    fn availability(&self) -> PlatformSpeechAvailability;
+    // Only the macOS implementation actually triggers TCC permission prompts;
+    // the Windows + cross-platform fallbacks reuse availability(). Allowed-as-
+    // dead in the test build path that exercises only macOS-style flows.
+    #[allow(dead_code)]
+    fn prepare(&self) -> PlatformSpeechAvailability;
+    fn transcribe(&self, audio: CapturedAudio) -> Result<String, String>;
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct DefaultPlatformSpeechEngine;
+
+impl DefaultPlatformSpeechEngine {
+    pub(crate) fn new() -> Self {
+        Self
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl PlatformSpeechEngine for DefaultPlatformSpeechEngine {
+    fn availability(&self) -> PlatformSpeechAvailability {
+        native_status(false)
+    }
+
+    fn prepare(&self) -> PlatformSpeechAvailability {
+        native_status(true)
+    }
+
+    fn transcribe(&self, audio: CapturedAudio) -> Result<String, String> {
+        let wav_path = temp_wav_path();
+        write_wav(&wav_path, &audio)?;
+        let result = transcribe_wav_path(&wav_path);
+        let _ = std::fs::remove_file(&wav_path);
+        result
+    }
+}
+
+#[cfg(windows)]
+impl PlatformSpeechEngine for DefaultPlatformSpeechEngine {
+    fn availability(&self) -> PlatformSpeechAvailability {
+        windows_speech::availability()
+    }
+
+    fn prepare(&self) -> PlatformSpeechAvailability {
+        // Windows does not have a TCC-style "prepare" prompt the way macOS
+        // does — microphone permission is granted/denied at the OS level
+        // through Settings → Privacy → Microphone, and SAPI consumes the
+        // WAV file directly without re-asking. Returning the static
+        // availability keeps the trait shape symmetric with macOS.
+        windows_speech::availability()
+    }
+
+    fn transcribe(&self, audio: CapturedAudio) -> Result<String, String> {
+        let wav_path = temp_wav_path();
+        write_wav(&wav_path, &audio)?;
+        let sample_count = audio.samples.len();
+        let sample_rate = audio.sample_rate;
+        let result = windows_speech::transcribe_wav_path(&wav_path);
+        if let Err(error) = &result {
+            // Funnel everything we know about the failure through the global
+            // tracing pipeline (`aethon::logging`). The daily-rotated log
+            // file under Settings → Diagnostics → Open log directory captures
+            // the structured fields, so no parallel debug-file scheme.
+            tracing::warn!(
+                target: "aethon::voice::platform_speech::windows",
+                sample_count,
+                sample_rate,
+                wav = %wav_path.display(),
+                error = %error,
+                "Windows system dictation failed",
+            );
+        }
+        // Always clean up the temp WAV. The daily log holds the diagnostic
+        // context now that we route through tracing — keeping multi-MB WAVs
+        // around per failure was a debugging crutch, not a feature.
+        let _ = std::fs::remove_file(&wav_path);
+        result
+    }
+}
+
+#[cfg(not(any(target_os = "macos", windows)))]
+impl PlatformSpeechEngine for DefaultPlatformSpeechEngine {
+    fn availability(&self) -> PlatformSpeechAvailability {
+        PlatformSpeechAvailability::unavailable(
+            "Native platform dictation is not implemented on this OS yet. Use the offline Distil-Whisper provider in Voice settings.",
+        )
+    }
+
+    fn prepare(&self) -> PlatformSpeechAvailability {
+        self.availability()
+    }
+
+    fn transcribe(&self, _audio: CapturedAudio) -> Result<String, String> {
+        Err("Native platform dictation is not implemented on this OS yet.".to_string())
+    }
+}
+
+#[cfg(any(target_os = "macos", windows))]
+fn temp_wav_path() -> std::path::PathBuf {
+    std::env::temp_dir().join(format!(
+        "aethon-platform-speech-{}-{}.wav",
+        std::process::id(),
+        uuid::Uuid::new_v4()
+    ))
+}
+
+#[cfg(any(target_os = "macos", windows))]
+fn write_wav(path: &Path, audio: &CapturedAudio) -> Result<(), String> {
+    let spec = hound::WavSpec {
+        channels: 1,
+        sample_rate: audio.sample_rate,
+        bits_per_sample: 16,
+        sample_format: hound::SampleFormat::Int,
+    };
+    let mut writer = hound::WavWriter::create(path, spec)
+        .map_err(|e| format!("Failed to create platform speech audio file: {e}"))?;
+    for sample in &audio.samples {
+        let sample = sample.clamp(-1.0, 1.0);
+        let pcm = (sample * i16::MAX as f32).round() as i16;
+        writer
+            .write_sample(pcm)
+            .map_err(|e| format!("Failed to write platform speech audio: {e}"))?;
+    }
+    writer
+        .finalize()
+        .map_err(|e| format!("Failed to finalize platform speech audio: {e}"))
+}
+
+#[cfg(target_os = "macos")]
+fn native_status(prepare: bool) -> PlatformSpeechAvailability {
+    let mut code = 4_i32;
+    let mut engine = 0_i32;
+    let mut message = std::ptr::null_mut();
+    if prepare {
+        unsafe { aethon_platform_speech_prepare(&mut code, &mut engine, &mut message) };
+    } else {
+        unsafe { aethon_platform_speech_status(&mut code, &mut engine, &mut message) };
+    }
+    let message = unsafe { take_c_string(message) }
+        .unwrap_or_else(|| "Apple speech status unavailable".to_string());
+    availability_from_native(code, engine, message)
+}
+
+#[cfg(target_os = "macos")]
+fn transcribe_wav_path(path: &Path) -> Result<String, String> {
+    use std::ffi::CString;
+
+    let path = CString::new(path.display().to_string())
+        .map_err(|_| "Platform speech audio path contains an interior nul byte".to_string())?;
+    let mut code = 4_i32;
+    let mut engine = 0_i32;
+    let mut text_ptr = std::ptr::null_mut();
+    let mut message_ptr = std::ptr::null_mut();
+    unsafe {
+        aethon_platform_speech_transcribe_file(
+            path.as_ptr(),
+            &mut code,
+            &mut engine,
+            &mut text_ptr,
+            &mut message_ptr,
+        )
+    };
+    let text = unsafe { take_c_string(text_ptr) }.unwrap_or_default();
+    let message =
+        unsafe { take_c_string(message_ptr) }.unwrap_or_else(|| engine_label(engine).to_string());
+
+    if code == 0 { Ok(text) } else { Err(message) }
+}
+
+#[cfg(target_os = "macos")]
+fn availability_from_native(code: i32, engine: i32, message: String) -> PlatformSpeechAvailability {
+    let status = match code {
+        0 => PlatformSpeechAvailabilityStatus::Ready,
+        1 => PlatformSpeechAvailabilityStatus::NeedsMicrophonePermission,
+        2 => PlatformSpeechAvailabilityStatus::NeedsSpeechPermission,
+        5 => PlatformSpeechAvailabilityStatus::NeedsAssets,
+        3 => PlatformSpeechAvailabilityStatus::EngineUnavailable,
+        _ => PlatformSpeechAvailabilityStatus::Unavailable,
+    };
+    PlatformSpeechAvailability {
+        status,
+        engine_label: match engine {
+            1 | 2 => Some(engine_label(engine).to_string()),
+            _ => None,
+        },
+        message,
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn engine_label(engine: i32) -> &'static str {
+    match engine {
+        1 => "Apple SpeechAnalyzer",
+        2 => "Apple Speech",
+        _ => "Apple Speech",
+    }
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn take_c_string(pointer: *mut std::ffi::c_char) -> Option<String> {
+    if pointer.is_null() {
+        return None;
+    }
+    let value = unsafe { std::ffi::CStr::from_ptr(pointer) }
+        .to_string_lossy()
+        .into_owned();
+    unsafe { aethon_platform_speech_free_string(pointer) };
+    Some(value)
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) fn cancel_active_transcription() {
+    unsafe { aethon_platform_speech_cancel() };
+}
+
+#[cfg(target_os = "macos")]
+unsafe extern "C" {
+    fn aethon_platform_speech_status(
+        code: *mut i32,
+        engine: *mut i32,
+        message: *mut *mut std::ffi::c_char,
+    );
+    fn aethon_platform_speech_prepare(
+        code: *mut i32,
+        engine: *mut i32,
+        message: *mut *mut std::ffi::c_char,
+    );
+    fn aethon_platform_speech_transcribe_file(
+        path: *const std::ffi::c_char,
+        code: *mut i32,
+        engine: *mut i32,
+        text: *mut *mut std::ffi::c_char,
+        message: *mut *mut std::ffi::c_char,
+    );
+    fn aethon_platform_speech_free_string(pointer: *mut std::ffi::c_char);
+    fn aethon_platform_speech_cancel();
+}
+
+// Windows speech recognition bridge — drives SAPI 5.4's in-process
+// recognizer (`SpInprocRecognizer`) directly via COM through the
+// `windows` crate. SAPI 5.4 ships with every Windows install since 7
+// (no .NET, no PowerShell, no extra runtime), accepts arbitrary WAV
+// files via `ISpStream::BindToFile`, and surfaces real HRESULT codes
+// for diagnosis.
+//
+// Earlier iterations shelled out to `powershell.exe` +
+// `System.Speech.Recognition.SpeechRecognitionEngine`, but the .NET
+// path on Windows ARM64 / under emulation was unreliable: the
+// recognizer would throw "No audio input is supplied to this
+// recognizer" mid-call after a successful `SetInputToWaveFile`,
+// because the implicitly-opened FileStream got closed before
+// `Recognize()` consumed it. Owning the COM lifecycle ourselves
+// removes that whole class of bug — we keep `ISpStream` alive across
+// the full recognition loop and the recognizer can't lose it.
+//
+// Threading: COM is initialized as Apartment Threaded (STA) on the
+// caller thread. Voice transcription runs inside `tokio::task::
+// spawn_blocking` (see `voice.rs::stop_platform_recording`), so this
+// thread is dedicated to the call and tearing it down on return is
+// safe. The COM cleanup sentinel below ensures `CoUninitialize` runs
+// on every exit path including panics.
+#[cfg(windows)]
+mod windows_speech {
+    use std::ffi::OsStr;
+    use std::os::windows::ffi::OsStrExt;
+    use std::path::Path;
+    use std::time::{Duration, Instant};
+
+    use windows::Win32::Foundation::{S_FALSE, WAIT_FAILED, WAIT_OBJECT_0, WAIT_TIMEOUT};
+    use windows::Win32::Media::Speech::{
+        ISpRecoGrammar, ISpRecoResult, ISpRecognizer, ISpStream, SPEI_END_SR_STREAM,
+        SPEI_FALSE_RECOGNITION, SPEI_RECOGNITION, SPEVENT, SPFM_OPEN_READONLY, SPLO_STATIC,
+        SPRS_ACTIVE, SPRST_ACTIVE_ALWAYS, SPRST_INACTIVE, SpInprocRecognizer, SpStream,
+    };
+    use windows::Win32::System::Com::{
+        CLSCTX_ALL, COINIT_APARTMENTTHREADED, CoCreateInstance, CoInitializeEx, CoTaskMemFree,
+        CoUninitialize,
+    };
+    use windows::Win32::System::Threading::WaitForSingleObject;
+    use windows::core::{Interface, PCWSTR, PWSTR};
+
+    use super::PlatformSpeechAvailability;
+
+    // The SAPI event loop polls for events at ~30 Hz (33 ms wait interval).
+    // Each iteration: WaitForSingleObject → drain GetEvents → loop. That
+    // keeps end-of-stream latency low without spinning the CPU.
+    const EVENT_POLL_WAIT_MS: u32 = 33;
+    // Hard ceiling on the recognizer event loop. The Rust caller wraps
+    // `transcribe()` in `tokio::time::timeout(transcription_timeout)`
+    // (90 s by default), so this is just belt-and-suspenders against an
+    // engine that never emits SPEI_END_SR_STREAM after consuming the WAV.
+    const RECOGNITION_DEADLINE: Duration = Duration::from_secs(120);
+
+    // SAPI's `SPFEI()` macro maps an event ID to a 64-bit interest mask.
+    // The two reserved bits below (`SPFEI_FLAGCHECK` in the C++ headers)
+    // are required so the recognizer can distinguish "no interest set"
+    // from a literal 0 mask — without them, SetInterest is a no-op.
+    const SPFEI_FLAGCHECK: u64 = (1u64 << 30) | (1u64 << 33);
+
+    /// Convert a `SPEVENTENUM` event id into the bit mask
+    /// `ISpEventSource::SetInterest` expects. Mirrors the C++ `SPFEI`
+    /// macro 1-to-1.
+    const fn spfei(event_id: i32) -> u64 {
+        SPFEI_FLAGCHECK | (1u64 << event_id)
+    }
+
+    pub(super) fn availability() -> PlatformSpeechAvailability {
+        // SAPI 5.4 is bundled with every Windows install since 7, and the
+        // `SpInprocRecognizer` CLSID is registered out of the box. We
+        // could probe by calling `CoCreateInstance` here, but that costs
+        // ~30 ms of COM initialization on every Settings refresh and the
+        // trait contract is "report what looks ready and surface real
+        // errors during `transcribe()`." Match the macOS pattern.
+        PlatformSpeechAvailability::ready_now(
+            "Windows SAPI",
+            "Ready via Windows Speech API (SAPI 5.4 — no setup required)",
+        )
+    }
+
+    pub(super) fn transcribe_wav_path(wav_path: &Path) -> Result<String, String> {
+        // Pre-flight check: if the WAV doesn't exist or is smaller than a
+        // minimal RIFF header, the recognizer's error would surface as a
+        // generic "audio input unavailable" — fail loudly here instead.
+        match std::fs::metadata(wav_path) {
+            Ok(metadata) if metadata.len() < 44 => {
+                let len = metadata.len();
+                tracing::error!(
+                    target: "aethon::voice::platform_speech::windows",
+                    wav = %wav_path.display(),
+                    bytes = len,
+                    "Recorded WAV is shorter than a RIFF header — audio capture produced no usable data",
+                );
+                return Err(
+                    "Couldn't load the recorded audio. Try recording again — see Settings → Diagnostics for details."
+                        .to_string(),
+                );
+            }
+            Err(err) => {
+                tracing::error!(
+                    target: "aethon::voice::platform_speech::windows",
+                    wav = %wav_path.display(),
+                    error = %err,
+                    "Recorded WAV is not readable",
+                );
+                return Err(
+                    "Couldn't load the recorded audio. Try recording again — see Settings → Diagnostics for details."
+                        .to_string(),
+                );
+            }
+            _ => {}
+        }
+
+        let _com = ComApartment::initialize().map_err(|hr| {
+            tracing::error!(
+                target: "aethon::voice::platform_speech::windows",
+                hresult = %format!("0x{:08x}", hr),
+                "CoInitializeEx failed",
+            );
+            user_facing_error(&format!("CoInitializeEx HRESULT 0x{hr:08x}"))
+        })?;
+
+        match unsafe { transcribe_with_sapi(wav_path) } {
+            Ok(text) => Ok(text),
+            Err(SapiError {
+                stage,
+                hresult,
+                message,
+            }) => {
+                tracing::error!(
+                    target: "aethon::voice::platform_speech::windows",
+                    wav = %wav_path.display(),
+                    stage = %stage,
+                    hresult = %format!("0x{hresult:08x}"),
+                    detail = %message,
+                    "SAPI transcription failed",
+                );
+                Err(user_facing_error_for_hresult(stage, hresult))
+            }
+        }
+    }
+
+    /// Owned COM-apartment guard. `CoInitializeEx` returns `S_FALSE` on
+    /// nested calls (already initialized on this thread) — we only call
+    /// `CoUninitialize` when WE were the call that initialized, otherwise
+    /// we'd tear down a higher caller's apartment. The Drop impl runs on
+    /// every exit path including panics, which the previous `let _ =
+    /// CoUninitialize();` at the bottom of a function did NOT.
+    struct ComApartment {
+        owns: bool,
+    }
+
+    impl ComApartment {
+        fn initialize() -> Result<Self, u32> {
+            let hr = unsafe { CoInitializeEx(None, COINIT_APARTMENTTHREADED) };
+            // `HRESULT::is_ok()` returns true for any non-negative status,
+            // which includes both S_OK *and* S_FALSE — the previous
+            // ordering made the S_FALSE arm dead code. Check S_FALSE
+            // first so a nested-init caller doesn't tear down a parent's
+            // apartment when our guard drops.
+            if hr == S_FALSE {
+                // Apartment was already initialized on this thread by an
+                // earlier caller — we ride along without owning the
+                // uninit, so Drop becomes a no-op.
+                Ok(Self { owns: false })
+            } else if hr.is_ok() {
+                Ok(Self { owns: true })
+            } else {
+                Err(hr.0 as u32)
+            }
+        }
+    }
+
+    impl Drop for ComApartment {
+        fn drop(&mut self) {
+            if self.owns {
+                unsafe { CoUninitialize() };
+            }
+        }
+    }
+
+    /// Structured error from the SAPI call site — `stage` names which step
+    /// failed (so the daily log is greppable), `hresult` is the raw COM
+    /// status, and `message` is the formatted `windows::core::Error`
+    /// description for the log line.
+    struct SapiError {
+        stage: &'static str,
+        hresult: u32,
+        message: String,
+    }
+
+    impl SapiError {
+        fn from_windows(stage: &'static str, err: windows::core::Error) -> Self {
+            Self {
+                stage,
+                hresult: err.code().0 as u32,
+                message: err.message(),
+            }
+        }
+    }
+
+    /// Drive a single recognition pass against the WAV. All the COM
+    /// interfaces are kept in scope until the function returns so their
+    /// Drop calls Release in the correct order: grammar → context →
+    /// recognizer → stream. The COM apartment guard above outlives all
+    /// of them via the caller's stack frame.
+    unsafe fn transcribe_with_sapi(wav_path: &Path) -> Result<String, SapiError> {
+        let recognizer: ISpRecognizer =
+            unsafe { CoCreateInstance(&SpInprocRecognizer, None, CLSCTX_ALL) }
+                .map_err(|e| SapiError::from_windows("CoCreateInstance(SpInprocRecognizer)", e))?;
+
+        let stream: ISpStream = unsafe { CoCreateInstance(&SpStream, None, CLSCTX_ALL) }
+            .map_err(|e| SapiError::from_windows("CoCreateInstance(SpStream)", e))?;
+
+        // Bind the stream to the WAV file on disk. Passing `None` for both
+        // the format ID and `WAVEFORMATEX` lets SAPI parse the RIFF header
+        // itself — exactly the behaviour we want, vs. having to hand-tune
+        // a `WAVEFORMATEX` that matches what we wrote.
+        let mut path_w: Vec<u16> = OsStr::new(wav_path)
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect();
+        unsafe {
+            stream.BindToFile(
+                PCWSTR(path_w.as_mut_ptr()),
+                SPFM_OPEN_READONLY,
+                None,
+                None,
+                0,
+            )
+        }
+        .map_err(|e| SapiError::from_windows("ISpStream::BindToFile", e))?;
+
+        unsafe { recognizer.SetInput(&stream, false) }
+            .map_err(|e| SapiError::from_windows("ISpRecognizer::SetInput", e))?;
+
+        let context = unsafe { recognizer.CreateRecoContext() }
+            .map_err(|e| SapiError::from_windows("ISpRecognizer::CreateRecoContext", e))?;
+
+        unsafe { context.SetNotifyWin32Event() }
+            .map_err(|e| SapiError::from_windows("ISpRecoContext::SetNotifyWin32Event", e))?;
+
+        let event_handle = unsafe { context.GetNotifyEventHandle() };
+        if event_handle.0.is_null() {
+            return Err(SapiError {
+                stage: "ISpRecoContext::GetNotifyEventHandle",
+                hresult: 0,
+                message: "GetNotifyEventHandle returned a null HANDLE".to_string(),
+            });
+        }
+
+        let interest_mask = spfei(SPEI_RECOGNITION.0)
+            | spfei(SPEI_END_SR_STREAM.0)
+            | spfei(SPEI_FALSE_RECOGNITION.0);
+        unsafe { context.SetInterest(interest_mask, interest_mask) }
+            .map_err(|e| SapiError::from_windows("ISpRecoContext::SetInterest", e))?;
+
+        let grammar: ISpRecoGrammar = unsafe { context.CreateGrammar(0) }
+            .map_err(|e| SapiError::from_windows("ISpRecoContext::CreateGrammar", e))?;
+
+        unsafe { grammar.LoadDictation(PCWSTR::null(), SPLO_STATIC) }
+            .map_err(|e| SapiError::from_windows("ISpRecoGrammar::LoadDictation", e))?;
+
+        unsafe { grammar.SetDictationState(SPRS_ACTIVE) }
+            .map_err(|e| SapiError::from_windows("ISpRecoGrammar::SetDictationState", e))?;
+
+        unsafe { recognizer.SetRecoState(SPRST_ACTIVE_ALWAYS) }
+            .map_err(|e| SapiError::from_windows("ISpRecognizer::SetRecoState(ACTIVE)", e))?;
+
+        // Pull the transcript out of the event stream. Each phrase ends
+        // with an `SPEI_RECOGNITION` event whose `lParam` is an
+        // `ISpRecoResult*`; the WAV-exhausted condition fires
+        // `SPEI_END_SR_STREAM`. False recognitions (engine couldn't decide
+        // what was said) are gathered by `SPEI_FALSE_RECOGNITION` so we
+        // can include them with low confidence rather than dropping
+        // mumbled audio entirely.
+        let mut transcript = String::new();
+        let started = Instant::now();
+        loop {
+            if started.elapsed() > RECOGNITION_DEADLINE {
+                tracing::warn!(
+                    target: "aethon::voice::platform_speech::windows",
+                    "SAPI event loop hit RECOGNITION_DEADLINE without SPEI_END_SR_STREAM",
+                );
+                break;
+            }
+
+            let wait = unsafe { WaitForSingleObject(event_handle, EVENT_POLL_WAIT_MS) };
+            // Three distinct outcomes:
+            //   * WAIT_OBJECT_0 — handle signaled; drain events below.
+            //   * WAIT_TIMEOUT  — recognizer is mid-utterance and just
+            //                    hasn't emitted yet; loop on the outer
+            //                    `RECOGNITION_DEADLINE` budget.
+            //   * Anything else — WAIT_FAILED (GetLastError-bearing) or
+            //                    WAIT_ABANDONED. Log and bail; spinning
+            //                    here would mask a real OS-level fault
+            //                    until the deadline.
+            match wait {
+                WAIT_OBJECT_0 => {}
+                WAIT_TIMEOUT => continue,
+                other => {
+                    return Err(SapiError {
+                        stage: "WaitForSingleObject(ISpRecoContext event)",
+                        hresult: if other == WAIT_FAILED { 0 } else { other.0 },
+                        message: format!(
+                            "WaitForSingleObject returned unexpected status {:#x}",
+                            other.0
+                        ),
+                    });
+                }
+            }
+
+            let mut done = false;
+            loop {
+                let mut event = SPEVENT::default();
+                let mut fetched = 0u32;
+                // GetEvents returns Err on a real COM failure; on success
+                // (including "no events available right now") it returns
+                // Ok and fetched stays 0. Match on the Result directly —
+                // the previous chain compared an HRESULT alongside Err
+                // which was both redundant and harder to follow.
+                if let Err(err) = unsafe { context.GetEvents(1, &mut event, &mut fetched) } {
+                    return Err(SapiError::from_windows("ISpRecoContext::GetEvents", err));
+                }
+                if fetched == 0 {
+                    break;
+                }
+
+                // _bitfield packs `eEventId` in the low 16 bits and
+                // `elParamType` in the next 16 bits. We only need the
+                // event id to dispatch.
+                let event_id = (event._bitfield & 0xFFFF) as i32;
+                if event_id == SPEI_RECOGNITION.0 || event_id == SPEI_FALSE_RECOGNITION.0 {
+                    if let Some(text) = unsafe { extract_recognition_text(&event) } {
+                        let trimmed = text.trim();
+                        if !trimmed.is_empty() {
+                            if !transcript.is_empty() {
+                                transcript.push(' ');
+                            }
+                            transcript.push_str(trimmed);
+                        }
+                    }
+                } else if event_id == SPEI_END_SR_STREAM.0 {
+                    done = true;
+                }
+
+                // Release any lParam that holds an IUnknown*. SAPI's C++
+                // SDK ships an `SPCLEAREVENT` macro that does this; we
+                // inline the equivalent. `elParamType` lives in the upper
+                // 16 bits of `_bitfield`. Type 1 (`SPET_LPARAM_IS_OBJECT`)
+                // means lParam is an IUnknown*.
+                let elparam_type = (event._bitfield >> 16) & 0xFFFF;
+                if elparam_type == 1 && event.lParam.0 != 0 {
+                    let raw = event.lParam.0 as *mut std::ffi::c_void;
+                    if !raw.is_null() {
+                        let unknown = unsafe { windows::core::IUnknown::from_raw(raw) };
+                        drop(unknown); // Release happens via Drop
+                    }
+                }
+            }
+
+            if done {
+                break;
+            }
+        }
+
+        // SetRecoState(SPRST_INACTIVE) flushes any in-flight recognizer
+        // state so the next call (recognizer/grammar/context drop below)
+        // doesn't race against the engine still processing audio.
+        let _ = unsafe { recognizer.SetRecoState(SPRST_INACTIVE) };
+
+        // grammar / context / recognizer / stream all drop here in
+        // reverse order of construction.
+        drop(grammar);
+        drop(context);
+        drop(recognizer);
+        drop(stream);
+        // Touch path_w so it stays alive through the `BindToFile` call —
+        // BindToFile copies the path, but make the lifetime explicit.
+        path_w.clear();
+
+        if transcript.is_empty() {
+            // Empty transcript on a successful event loop = recognizer
+            // saw audio but couldn't match a phrase. Same UX as the
+            // macOS path (`stop_platform_recording` rejects empty).
+            // Leave the empty string so `voice.rs` produces the
+            // standard "No speech was recognized" error.
+        }
+
+        Ok(transcript)
+    }
+
+    /// Pull the recognized text out of an `SPEI_RECOGNITION` /
+    /// `SPEI_FALSE_RECOGNITION` event. `lParam` holds an
+    /// `ISpRecoResult*`; `GetText(0, 0xFFFFFFFF, true, ...)` returns the
+    /// full phrase. Caller is responsible for releasing the result via
+    /// the SPCLEAREVENT logic in the dispatch loop.
+    unsafe fn extract_recognition_text(event: &SPEVENT) -> Option<String> {
+        if event.lParam.0 == 0 {
+            return None;
+        }
+        let raw = event.lParam.0 as *mut std::ffi::c_void;
+        // `from_raw` takes ownership of one reference. We need to keep the
+        // event's reference intact for the dispatcher's SPCLEAREVENT
+        // cleanup, so AddRef before borrowing.
+        let unknown = unsafe { windows::core::IUnknown::from_raw_borrowed(&raw) }?;
+        let result: ISpRecoResult = unknown.cast().ok()?;
+
+        let mut text_ptr = PWSTR::null();
+        let hr = unsafe { result.GetText(0, u32::MAX, true, &mut text_ptr, None) };
+        if hr.is_err() || text_ptr.is_null() {
+            return None;
+        }
+
+        let text = unsafe { text_ptr.to_string().ok() };
+        unsafe { CoTaskMemFree(Some(text_ptr.as_ptr() as *const _)) };
+        text
+    }
+
+    /// One-line, actionable user-facing error string. The raw HRESULT and
+    /// stage name still flow into the daily log via the `tracing::error!`
+    /// at the call site; this is only the toolbar pill copy.
+    ///
+    /// Public so the test module can pin the contract that every message
+    /// is short, single-line, and free of HRESULT codes / type names.
+    pub(super) fn user_facing_error(detail: &str) -> String {
+        // Most callers go through `user_facing_error_for_hresult`; this
+        // string-based variant only handles the rare CoInitializeEx
+        // failure where we don't yet have a structured stage.
+        if detail.contains("CoInitializeEx") {
+            "Couldn't initialize Windows COM for speech recognition. Restart Aethon; if it persists, switch to the offline Distil-Whisper provider in Voice settings.".to_string()
+        } else {
+            "Speech recognition failed. See Settings → Diagnostics → Open log directory for details.".to_string()
+        }
+    }
+
+    /// Map a SAPI failure stage + HRESULT to a short user-facing string.
+    /// The most common failures get tailored copy with a concrete next
+    /// step; everything else falls through to the generic "see
+    /// diagnostics log" pointer.
+    pub(super) fn user_facing_error_for_hresult(stage: &str, hresult: u32) -> String {
+        // SPERR_NOT_FOUND (0x8004503A) — no recognizer installed for the
+        // requested locale. Fires from `CoCreateInstance(SpInprocRecognizer)`
+        // when the OS has no speech engine registered.
+        const SPERR_NOT_FOUND: u32 = 0x8004503A;
+        // SPERR_AUDIO_BUFFER_OVERFLOW (0x8004502A) and friends mean the
+        // audio source isn't producing data the recognizer can consume.
+        const SPERR_UNINITIALIZED: u32 = 0x80045028;
+        // CLASS_E_CLASSNOTAVAILABLE (0x80040111) — SAPI not installed.
+        const CLASS_E_CLASSNOTAVAILABLE: u32 = 0x80040111;
+        // REGDB_E_CLASSNOTREG (0x80040154) — same as above on most boxes.
+        const REGDB_E_CLASSNOTREG: u32 = 0x80040154;
+        // E_OUTOFMEMORY (0x8007000E) and E_ACCESSDENIED (0x80070005) get
+        // their own messages so users have something to act on.
+        const E_OUTOFMEMORY: u32 = 0x8007000E;
+        const E_ACCESSDENIED: u32 = 0x80070005;
+
+        match hresult {
+            SPERR_NOT_FOUND => {
+                "Windows speech recognizer is not installed. Add a Speech Recognizer language pack in Windows Settings → Time & language → Speech.".to_string()
+            }
+            CLASS_E_CLASSNOTAVAILABLE | REGDB_E_CLASSNOTREG => {
+                "Windows Speech API (SAPI) is not registered on this machine. Switch to the offline Distil-Whisper provider in Voice settings.".to_string()
+            }
+            SPERR_UNINITIALIZED => {
+                "Windows speech recognizer reported its audio input was not initialized. Try recording again — see Settings → Diagnostics for details.".to_string()
+            }
+            E_ACCESSDENIED => {
+                "Windows denied access to the recorded audio file. Check antivirus / sandbox settings, then try again.".to_string()
+            }
+            E_OUTOFMEMORY => {
+                "Windows speech recognizer ran out of memory. Try a shorter recording.".to_string()
+            }
+            _ if stage.starts_with("ISpStream::BindToFile") => {
+                "Couldn't load the recorded audio. Try recording again — see Settings → Diagnostics for details.".to_string()
+            }
+            _ => {
+                "Speech recognition failed. See Settings → Diagnostics → Open log directory for details.".to_string()
+            }
+        }
+    }
+}
+
+// On Windows, voice.rs reaches for `cancel_active_transcription` from the
+// shared platform-speech surface. The native SAPI path has no cooperative-
+// cancel hook reachable from outside the recognition thread — the
+// `RECOGNITION_DEADLINE` event-loop ceiling and the outer `transcription_
+// timeout` in `voice.rs::stop_platform_recording` together cover the
+// runaway-engine case.
+#[cfg(windows)]
+pub(crate) fn cancel_active_transcription() {}
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn platform_speech_bridge_reports_status_without_prompt() {
+        let availability = DefaultPlatformSpeechEngine::new().availability();
+
+        assert!(!availability.message.trim().is_empty());
+    }
+
+    #[test]
+    fn platform_speech_bridge_refuses_unbundled_permission_prompts() {
+        let availability = DefaultPlatformSpeechEngine::new().prepare();
+
+        assert_eq!(
+            availability.status,
+            PlatformSpeechAvailabilityStatus::EngineUnavailable
+        );
+        assert!(availability.message.contains(".app bundle"));
+    }
+
+    #[test]
+    #[ignore = "requires AETHON_PLATFORM_SPEECH_SAMPLE_WAV and macOS speech permissions"]
+    fn ignored_platform_speech_transcribes_fixture_wav() {
+        let sample_path = std::env::var_os("AETHON_PLATFORM_SPEECH_SAMPLE_WAV")
+            .map(std::path::PathBuf::from)
+            .expect("set AETHON_PLATFORM_SPEECH_SAMPLE_WAV to a short speech WAV");
+
+        let transcript = transcribe_wav_path(&sample_path).expect("transcribe fixture");
+
+        assert!(!transcript.trim().is_empty());
+    }
+}
+
+#[cfg(all(test, windows))]
+mod windows_tests {
+    use super::*;
+
+    #[test]
+    fn windows_availability_reports_ready_via_sapi() {
+        // SAPI 5.4 is bundled with every Windows install; the trait
+        // contract is "advertise Ready and let `transcribe()` surface
+        // real failures." Nothing to probe here.
+        let availability = DefaultPlatformSpeechEngine::new().availability();
+
+        assert_eq!(
+            availability.status,
+            PlatformSpeechAvailabilityStatus::Ready,
+            "expected Ready on Windows (got {availability:?})",
+        );
+        assert_eq!(availability.engine_label.as_deref(), Some("Windows SAPI"));
+        assert!(
+            !availability.message.is_empty(),
+            "availability message must populate the toolbar / Voice panel",
+        );
+    }
+
+    #[test]
+    fn windows_user_facing_messages_are_short_and_clean() {
+        // The toolbar pill renders the user-facing string verbatim. Every
+        // message we can produce must stay one line and short enough to
+        // fit the 280px / 32vw error pill without ellipsizing the
+        // actionable bit. HRESULT codes and stage names belong in the
+        // tracing log, never the pill.
+        let hresults = [
+            ("CoCreateInstance(SpInprocRecognizer)", 0x8004503Au32), // SPERR_NOT_FOUND
+            ("CoCreateInstance(SpInprocRecognizer)", 0x80040111u32), // CLASS_E_CLASSNOTAVAILABLE
+            ("CoCreateInstance(SpInprocRecognizer)", 0x80040154u32), // REGDB_E_CLASSNOTREG
+            ("ISpStream::BindToFile", 0x80070003u32),                // ERROR_PATH_NOT_FOUND
+            ("ISpStream::BindToFile", 0x80070005u32),                // E_ACCESSDENIED
+            ("ISpRecognizer::SetInput", 0x80045028u32),              // SPERR_UNINITIALIZED
+            ("ISpRecognizer::SetRecoState(ACTIVE)", 0x8007000Eu32),  // E_OUTOFMEMORY
+            ("ISpRecoContext::CreateGrammar", 0x8000_0000u32),       // unknown HRESULT
+        ];
+        for (stage, hr) in hresults {
+            let pill = windows_speech::user_facing_error_for_hresult(stage, hr);
+            assert!(
+                !pill.contains('\n'),
+                "user-facing message must be single line: {pill:?}",
+            );
+            assert!(
+                pill.len() < 220,
+                "user-facing message too long ({}): {pill:?}",
+                pill.len(),
+            );
+            assert!(
+                !pill.contains("0x") && !pill.contains("HRESULT"),
+                "user-facing message leaked HRESULT detail: {pill:?}",
+            );
+            assert!(
+                !pill.contains("ISp") && !pill.contains("CoCreateInstance"),
+                "user-facing message leaked SAPI/COM symbol names: {pill:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn windows_user_facing_messages_match_known_hresults() {
+        // Pin the specific copy for the user-impacting failures so a
+        // refactor doesn't silently replace the actionable hint with the
+        // generic fallback. Anything not pinned here is allowed to drift
+        // — these three are the failures users can fix themselves.
+        let pill = windows_speech::user_facing_error_for_hresult(
+            "CoCreateInstance(SpInprocRecognizer)",
+            0x8004503A, // SPERR_NOT_FOUND
+        );
+        assert!(
+            pill.contains("Speech Recognizer language pack"),
+            "missing recognizer must point users at the language-pack install: {pill:?}",
+        );
+
+        let pill = windows_speech::user_facing_error_for_hresult(
+            "CoCreateInstance(SpInprocRecognizer)",
+            0x80040154, // REGDB_E_CLASSNOTREG
+        );
+        assert!(
+            pill.contains("Distil-Whisper"),
+            "SAPI-not-registered must offer the offline fallback: {pill:?}",
+        );
+
+        let pill =
+            windows_speech::user_facing_error_for_hresult("ISpStream::BindToFile", 0x80070005);
+        assert!(
+            pill.contains("denied"),
+            "E_ACCESSDENIED on the WAV must mention access denial: {pill:?}",
+        );
+    }
+
+    #[test]
+    fn windows_unknown_hresult_falls_back_to_diagnostics_pointer() {
+        // Anything we haven't mapped should still send the user to
+        // Settings → Diagnostics rather than dump the raw error. Pin
+        // this so a future contributor adding HRESULT cases doesn't
+        // accidentally remove the safety net.
+        let pill =
+            windows_speech::user_facing_error_for_hresult("ISpRecoContext::GetEvents", 0xDEADBEEF);
+        assert!(pill.contains("Settings → Diagnostics"));
+    }
+
+    #[test]
+    fn windows_coinit_failure_message_mentions_distil_whisper_fallback() {
+        // CoInitializeEx failure is unrecoverable from inside the
+        // recognizer call, so the only useful next step is the offline
+        // provider. Pin the copy that says so.
+        let pill = windows_speech::user_facing_error("CoInitializeEx HRESULT 0x80004005");
+        assert!(pill.contains("Distil-Whisper"));
+        assert!(!pill.contains("HRESULT"));
+    }
+}

--- a/src-tauri/src/voice.rs
+++ b/src-tauri/src/voice.rs
@@ -357,6 +357,7 @@ pub struct VoiceProviderRegistry {
     backend_checker: Arc<dyn CandleBackendChecker>,
     transcription_timeout: Duration,
     active_distil_cancel: Mutex<Option<Arc<AtomicBool>>>,
+    active_downloads: Mutex<std::collections::HashSet<String>>,
 }
 
 fn compute_rms(samples: &[f32]) -> f32 {
@@ -491,6 +492,7 @@ impl VoiceProviderRegistry {
             backend_checker,
             transcription_timeout,
             active_distil_cancel: Mutex::new(None),
+            active_downloads: Mutex::new(std::collections::HashSet::new()),
         }
     }
 
@@ -1073,6 +1075,7 @@ impl VoiceProvider for DistilWhisperCandleProvider {
             .get_app_setting(&model_status_key(self.id()))
             .ok()
             .flatten();
+        let downloading = registry.active_downloads.lock().contains(self.id());
         let installed = distil_model_ready(&cache_path);
         let backend_status = registry.ensure_candle_backend_ready();
 
@@ -1082,47 +1085,46 @@ impl VoiceProvider for DistilWhisperCandleProvider {
             Err(err) => format!("Unavailable: {err}"),
         });
 
-        let (status, status_label, setup_required, error) =
-            if model_status.as_deref() == Some("downloading") {
-                (
-                    VoiceProviderStatus::Downloading,
-                    "Downloading model".to_string(),
-                    true,
-                    None,
-                )
-            } else if let Err(err) = &backend_status {
-                (
-                    VoiceProviderStatus::EngineUnavailable,
-                    "Voice engine unavailable".to_string(),
-                    false,
-                    Some(err.clone()),
-                )
-            } else if installed {
-                let backend = backend_status.expect("backend availability checked");
-                (
-                    VoiceProviderStatus::Ready,
-                    format!("{DISTIL_READY_MESSAGE} ({})", backend.label()),
-                    false,
-                    None,
-                )
-            } else if model_status
-                .as_deref()
-                .is_some_and(|status| status.starts_with("error:"))
-            {
-                (
-                    VoiceProviderStatus::Error,
-                    "Download failed".to_string(),
-                    true,
-                    model_status.map(|s| s.trim_start_matches("error:").to_string()),
-                )
-            } else {
-                (
-                    VoiceProviderStatus::NeedsSetup,
-                    "Download required".to_string(),
-                    true,
-                    None,
-                )
-            };
+        let (status, status_label, setup_required, error) = if downloading {
+            (
+                VoiceProviderStatus::Downloading,
+                "Downloading model".to_string(),
+                true,
+                None,
+            )
+        } else if let Err(err) = &backend_status {
+            (
+                VoiceProviderStatus::EngineUnavailable,
+                "Voice engine unavailable".to_string(),
+                false,
+                Some(err.clone()),
+            )
+        } else if installed {
+            let backend = backend_status.expect("backend availability checked");
+            (
+                VoiceProviderStatus::Ready,
+                format!("{DISTIL_READY_MESSAGE} ({})", backend.label()),
+                false,
+                None,
+            )
+        } else if model_status
+            .as_deref()
+            .is_some_and(|status| status.starts_with("error:"))
+        {
+            (
+                VoiceProviderStatus::Error,
+                "Download failed".to_string(),
+                true,
+                model_status.map(|s| s.trim_start_matches("error:").to_string()),
+            )
+        } else {
+            (
+                VoiceProviderStatus::NeedsSetup,
+                "Download required".to_string(),
+                true,
+                None,
+            )
+        };
 
         VoiceProviderInfo {
             metadata,
@@ -1147,12 +1149,24 @@ impl VoiceProvider for DistilWhisperCandleProvider {
             .await
             .map_err(|e| format!("Failed to create model cache: {e}"))?;
         {
+            let mut active_downloads = registry.active_downloads.lock();
+            if !active_downloads.insert(self.id().to_string()) {
+                let db = VoiceSettings::open(db_path).map_err(|e| e.to_string())?;
+                return Ok(self.status(registry, &db));
+            }
+        }
+        let active_download = ActiveDownloadGuard {
+            registry,
+            provider_id: self.id(),
+        };
+        {
             let db = VoiceSettings::open(db_path).map_err(|e| e.to_string())?;
-            db.set_app_setting(&model_status_key(self.id()), "downloading")
-                .map_err(|e| e.to_string())?;
+            let info = self.status(registry, &db);
+            let _ = app.emit("voice-provider-status", &info);
         }
 
         let result = download_distil_model(app, self.id(), &cache_path).await;
+        drop(active_download);
         match result {
             Ok(()) => {
                 let db = VoiceSettings::open(db_path).map_err(|e| e.to_string())?;
@@ -1175,6 +1189,20 @@ impl VoiceProvider for DistilWhisperCandleProvider {
                 Err(err)
             }
         }
+    }
+}
+
+struct ActiveDownloadGuard<'a> {
+    registry: &'a VoiceProviderRegistry,
+    provider_id: &'static str,
+}
+
+impl Drop for ActiveDownloadGuard<'_> {
+    fn drop(&mut self) {
+        self.registry
+            .active_downloads
+            .lock()
+            .remove(self.provider_id);
     }
 }
 
@@ -3203,5 +3231,47 @@ mod tests {
                 .expect("get model status"),
             Some("not-installed".to_string())
         );
+    }
+
+    #[test]
+    fn stale_downloading_state_does_not_hide_download_action_after_restart() {
+        let (_db_dir, db_path) = test_db_path();
+        let model_dir = tempdir().expect("model dir");
+        let db = open_test_db(&db_path);
+        db.set_app_setting(&model_status_key(DISTIL_ID), "downloading")
+            .expect("set stale downloading");
+
+        let registry = VoiceProviderRegistry::new(model_dir.path().to_path_buf());
+        let provider = registry
+            .list_providers(&db)
+            .into_iter()
+            .find(|provider| provider.metadata.id == DISTIL_ID)
+            .expect("distil provider");
+
+        assert_eq!(provider.status, VoiceProviderStatus::NeedsSetup);
+        assert_eq!(provider.status_label, "Download required");
+        assert!(provider.setup_required);
+    }
+
+    #[test]
+    fn active_download_state_is_runtime_only() {
+        let (_db_dir, db_path) = test_db_path();
+        let model_dir = tempdir().expect("model dir");
+        let db = open_test_db(&db_path);
+        let registry = VoiceProviderRegistry::new(model_dir.path().to_path_buf());
+        registry
+            .active_downloads
+            .lock()
+            .insert(DISTIL_ID.to_string());
+
+        let provider = registry
+            .list_providers(&db)
+            .into_iter()
+            .find(|provider| provider.metadata.id == DISTIL_ID)
+            .expect("distil provider");
+
+        assert_eq!(provider.status, VoiceProviderStatus::Downloading);
+        assert_eq!(provider.status_label, "Downloading model");
+        assert!(provider.setup_required);
     }
 }

--- a/src-tauri/src/voice.rs
+++ b/src-tauri/src/voice.rs
@@ -1,0 +1,3207 @@
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, OnceLock};
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use candle_core::{D, Device, IndexOp, Tensor};
+use candle_nn::{VarBuilder, ops::softmax};
+use candle_transformers::models::whisper::{self as whisper, Config, audio};
+use cpal::Sample;
+use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+use futures_util::StreamExt;
+use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter};
+use tokenizers::Tokenizer;
+use tokio::io::AsyncWriteExt;
+use tokio::task::AbortHandle;
+
+#[cfg(any(target_os = "macos", windows))]
+use crate::platform_speech::PlatformSpeechAvailability;
+use crate::platform_speech::{
+    DefaultPlatformSpeechEngine, PlatformSpeechAvailabilityStatus, PlatformSpeechEngine,
+};
+
+const SELECTED_PROVIDER_KEY: &str = "voice:selected_provider";
+const AUTO_PROVIDER_KEY: &str = "voice:auto_provider";
+const PLATFORM_ID: &str = "voice-platform-system";
+const DISTIL_ID: &str = "voice-distil-whisper-candle";
+const DISTIL_CACHE_DIR: &str = "distil-whisper-large-v3";
+const DISTIL_READY_MESSAGE: &str = "Ready for offline transcription";
+const TARGET_SAMPLE_RATE: u32 = whisper::SAMPLE_RATE as u32;
+// Hard ceiling on a single Distil-Whisper transcription pass. On macOS
+// Metal the 756M-param `distil-large-v3` model handles a 30 s clip in a
+// few seconds; on CPU (Linux + Windows, including ARM64) the same
+// workload is an order of magnitude slower because Candle loads weights
+// in F32 with no GPU acceleration. The previous 90 s blanket timeout
+// was tuned for Metal and routinely fired on CPU even for a single
+// segment of speech, surfacing as "Voice transcription timed out after
+// 90 seconds" with the recording silently discarded. Split the default
+// so each platform's actual hardware floor governs the cap, and the
+// CPU-side ceiling (5 min) gives breathing room for ARM64 Windows
+// users transcribing more than a sentence.
+#[cfg(target_os = "macos")]
+const DISTIL_TRANSCRIPTION_TIMEOUT: Duration = Duration::from_secs(90);
+#[cfg(not(target_os = "macos"))]
+const DISTIL_TRANSCRIPTION_TIMEOUT: Duration = Duration::from_secs(300);
+const MIN_SIGNAL_PEAK: f32 = 0.001;
+const DISTIL_MODEL_FILES: [(&str, Option<u64>); 5] = [
+    ("config.json", None),
+    ("generation_config.json", None),
+    ("preprocessor_config.json", None),
+    ("tokenizer.json", None),
+    ("model.safetensors", Some(100_000_000)),
+];
+const WHISPER_LANGUAGE_CODES: [&str; 99] = [
+    "en", "zh", "de", "es", "ru", "ko", "fr", "ja", "pt", "tr", "pl", "ca", "nl", "ar", "sv", "it",
+    "id", "hi", "fi", "vi", "he", "uk", "el", "ms", "cs", "ro", "da", "hu", "ta", "no", "th", "ur",
+    "hr", "bg", "lt", "la", "mi", "ml", "cy", "sk", "te", "fa", "lv", "bn", "sr", "az", "sl", "kn",
+    "et", "mk", "br", "eu", "is", "hy", "ne", "mn", "bs", "kk", "sq", "sw", "gl", "mr", "pa", "si",
+    "km", "sn", "yo", "so", "af", "oc", "ka", "be", "tg", "sd", "gu", "am", "yi", "lo", "uz", "fo",
+    "ht", "ps", "tk", "nn", "mt", "sa", "lb", "my", "bo", "tl", "mg", "as", "tt", "haw", "ln",
+    "ha", "ba", "jw", "su",
+];
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+struct VoiceSettingsData {
+    settings: std::collections::BTreeMap<String, String>,
+}
+
+pub struct VoiceSettings {
+    path: PathBuf,
+    data: Mutex<VoiceSettingsData>,
+}
+
+impl VoiceSettings {
+    pub fn open(path: &Path) -> Result<Self, String> {
+        let data = match std::fs::read_to_string(path) {
+            Ok(raw) => serde_json::from_str(&raw).unwrap_or_default(),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => VoiceSettingsData::default(),
+            Err(err) => return Err(format!("read {}: {err}", path.display())),
+        };
+        Ok(Self {
+            path: path.to_path_buf(),
+            data: Mutex::new(data),
+        })
+    }
+
+    pub fn get_app_setting(&self, key: &str) -> Result<Option<String>, String> {
+        Ok(self.data.lock().settings.get(key).cloned())
+    }
+
+    pub fn set_app_setting(&self, key: &str, value: &str) -> Result<(), String> {
+        {
+            let mut data = self.data.lock();
+            data.settings.insert(key.to_string(), value.to_string());
+            self.persist_locked(&data)?;
+        }
+        Ok(())
+    }
+
+    pub fn delete_app_setting(&self, key: &str) -> Result<(), String> {
+        {
+            let mut data = self.data.lock();
+            data.settings.remove(key);
+            self.persist_locked(&data)?;
+        }
+        Ok(())
+    }
+
+    fn persist_locked(&self, data: &VoiceSettingsData) -> Result<(), String> {
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("create {}: {e}", parent.display()))?;
+        }
+        let tmp = self.path.with_extension("json.tmp");
+        let raw = serde_json::to_string_pretty(data).map_err(|e| e.to_string())?;
+        std::fs::write(&tmp, raw).map_err(|e| format!("write {}: {e}", tmp.display()))?;
+        std::fs::rename(&tmp, &self.path)
+            .map_err(|e| format!("rename {}: {e}", self.path.display()))
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum VoiceProviderKind {
+    Platform,
+    LocalModel,
+    External,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum VoiceProviderStatus {
+    Ready,
+    NeedsSetup,
+    Downloading,
+    EngineUnavailable,
+    Unavailable,
+    Error,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum VoiceRecordingMode {
+    Native,
+    Webview,
+}
+
+/// Payload emitted on the `voice://level` Tauri event at ~30 Hz during recording.
+/// `level` is linear RMS of the mic buffer window, clamped to [0.0, 1.0].
+/// Full-scale sine wave ≈ 0.707; typical speech 0.05–0.3; silence < 0.01.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VoiceLevelPayload {
+    pub level: f32,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VoiceProviderMetadata {
+    pub id: String,
+    pub name: String,
+    pub description: String,
+    pub kind: VoiceProviderKind,
+    pub recording_mode: VoiceRecordingMode,
+    pub privacy_label: String,
+    pub offline: bool,
+    pub download_required: bool,
+    pub model_size_label: Option<String>,
+    pub cache_path: Option<String>,
+    pub accelerator_label: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VoiceProviderInfo {
+    #[serde(flatten)]
+    pub metadata: VoiceProviderMetadata,
+    pub status: VoiceProviderStatus,
+    pub status_label: String,
+    pub enabled: bool,
+    pub selected: bool,
+    pub setup_required: bool,
+    pub can_remove_model: bool,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VoiceDownloadProgress {
+    pub provider_id: String,
+    pub filename: String,
+    pub downloaded_bytes: u64,
+    pub total_bytes: Option<u64>,
+    pub overall_downloaded_bytes: u64,
+    pub overall_total_bytes: Option<u64>,
+    pub percent: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VoiceErrorEvent {
+    pub provider_id: Option<String>,
+    pub message: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CapturedAudio {
+    pub(crate) samples: Vec<f32>,
+    pub(crate) sample_rate: u32,
+}
+
+/// Cancels the level-emitter Tokio task when dropped.
+struct LevelTask(AbortHandle);
+
+impl Drop for LevelTask {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
+struct RecordingSession {
+    samples: Arc<Mutex<Vec<f32>>>,
+    stream_error: Arc<Mutex<Option<String>>>,
+    sample_rate: u32,
+    _stream: Option<cpal::Stream>,
+    /// Kept alive to abort the level-emitter task when recording stops.
+    _level_task: Option<LevelTask>,
+}
+
+impl RecordingSession {
+    #[cfg(test)]
+    fn from_samples(samples: Vec<f32>, sample_rate: u32) -> Self {
+        Self {
+            samples: Arc::new(Mutex::new(samples)),
+            stream_error: Arc::new(Mutex::new(None)),
+            sample_rate,
+            _stream: None,
+            _level_task: None,
+        }
+    }
+
+    #[cfg(test)]
+    fn from_samples_with_stream_error(
+        samples: Vec<f32>,
+        sample_rate: u32,
+        stream_error: impl Into<String>,
+    ) -> Self {
+        Self {
+            samples: Arc::new(Mutex::new(samples)),
+            stream_error: Arc::new(Mutex::new(Some(stream_error.into()))),
+            sample_rate,
+            _stream: None,
+            _level_task: None,
+        }
+    }
+
+    fn finish(self) -> Result<CapturedAudio, String> {
+        drop(self._stream);
+        if let Some(err) = self.stream_error.lock().clone() {
+            return Err(format!("Microphone input failed: {err}"));
+        }
+        let samples = self.samples.lock().clone();
+        Ok(CapturedAudio {
+            samples: resample_to_target_rate(&samples, self.sample_rate),
+            sample_rate: TARGET_SAMPLE_RATE,
+        })
+    }
+}
+
+trait AudioRecorder: Send + Sync {
+    fn start(&self) -> Result<RecordingSession, String>;
+}
+
+trait VoiceTranscriber: Send + Sync {
+    fn transcribe(
+        &self,
+        cache_path: &Path,
+        audio: CapturedAudio,
+        cancel: &Arc<AtomicBool>,
+    ) -> Result<String, String>;
+}
+
+struct CpalAudioRecorder;
+
+struct CandleWhisperTranscriber;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CandleBackend {
+    #[cfg(target_os = "macos")]
+    Metal,
+    #[cfg(not(target_os = "macos"))]
+    Cpu,
+}
+
+impl CandleBackend {
+    fn label(self) -> &'static str {
+        match self {
+            #[cfg(target_os = "macos")]
+            Self::Metal => "Metal",
+            #[cfg(not(target_os = "macos"))]
+            Self::Cpu => "CPU",
+        }
+    }
+
+    fn accelerator_label(self) -> &'static str {
+        match self {
+            #[cfg(target_os = "macos")]
+            Self::Metal => "Metal via Candle",
+            #[cfg(not(target_os = "macos"))]
+            Self::Cpu => "CPU via Candle",
+        }
+    }
+}
+
+trait CandleBackendChecker: Send + Sync {
+    fn ready_backend(&self) -> Result<CandleBackend, String>;
+}
+
+struct DefaultCandleBackendChecker;
+
+impl CandleBackendChecker for DefaultCandleBackendChecker {
+    fn ready_backend(&self) -> Result<CandleBackend, String> {
+        ensure_candle_backend_ready()
+    }
+}
+
+#[async_trait]
+pub trait VoiceProvider: Send + Sync {
+    fn id(&self) -> &'static str;
+    fn metadata(&self, registry: &VoiceProviderRegistry) -> VoiceProviderMetadata;
+    fn status(&self, registry: &VoiceProviderRegistry, db: &VoiceSettings) -> VoiceProviderInfo;
+    async fn prepare(
+        &self,
+        registry: &VoiceProviderRegistry,
+        app: &AppHandle,
+        db_path: &Path,
+    ) -> Result<VoiceProviderInfo, String>;
+}
+
+/// Timing data returned from a successful `start_recording` call.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VoiceStartLatency {
+    /// Milliseconds spent opening the cpal input stream.
+    pub stream_open_ms: u128,
+}
+
+pub struct VoiceProviderRegistry {
+    model_root: PathBuf,
+    active_recording: Mutex<Option<RecordingSession>>,
+    recorder: Arc<dyn AudioRecorder>,
+    transcriber: Arc<dyn VoiceTranscriber>,
+    platform_speech: Arc<dyn PlatformSpeechEngine>,
+    backend_checker: Arc<dyn CandleBackendChecker>,
+    transcription_timeout: Duration,
+    active_distil_cancel: Mutex<Option<Arc<AtomicBool>>>,
+}
+
+fn compute_rms(samples: &[f32]) -> f32 {
+    if samples.is_empty() {
+        return 0.0;
+    }
+    let sum_sq: f32 = samples.iter().map(|s| s * s).sum();
+    (sum_sq / samples.len() as f32).sqrt().min(1.0)
+}
+
+/// Spawn a Tokio task that emits `voice://level` events at ~30 Hz.
+///
+/// The task reads samples accumulated since its last tick, computes RMS
+/// over that window, and emits a normalized [0.0, 1.0] level. The first
+/// three ticks are suppressed so the buffer has time to fill before the
+/// frontend sees any signal (avoids a flash of empty bars at recording start).
+///
+/// Returns an `AbortHandle`; store it in a `LevelTask` so the task is
+/// cancelled automatically when recording stops.
+fn spawn_level_emitter(app: AppHandle, samples: Arc<Mutex<Vec<f32>>>) -> AbortHandle {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(std::time::Duration::from_millis(33));
+        let mut offset = 0usize;
+        let mut tick = 0u8;
+        loop {
+            interval.tick().await;
+            let (level, new_offset) = {
+                let s = samples.lock();
+                let window = &s[offset.min(s.len())..];
+                let rms = compute_rms(window);
+                (rms, s.len())
+            };
+            offset = new_offset;
+            tick = tick.saturating_add(1);
+            if tick > 3 {
+                let _ = app.emit("voice://level", VoiceLevelPayload { level });
+            }
+        }
+    })
+    .abort_handle()
+}
+
+impl VoiceProviderRegistry {
+    pub fn new(model_root: PathBuf) -> Self {
+        Self::with_runtime(
+            model_root,
+            Arc::new(CpalAudioRecorder),
+            Arc::new(CandleWhisperTranscriber),
+        )
+    }
+
+    fn with_runtime(
+        model_root: PathBuf,
+        recorder: Arc<dyn AudioRecorder>,
+        transcriber: Arc<dyn VoiceTranscriber>,
+    ) -> Self {
+        Self::with_runtime_and_timeout(
+            model_root,
+            recorder,
+            transcriber,
+            DISTIL_TRANSCRIPTION_TIMEOUT,
+        )
+    }
+
+    fn with_runtime_and_timeout(
+        model_root: PathBuf,
+        recorder: Arc<dyn AudioRecorder>,
+        transcriber: Arc<dyn VoiceTranscriber>,
+        transcription_timeout: Duration,
+    ) -> Self {
+        Self::with_runtime_backend_and_timeout(
+            model_root,
+            recorder,
+            transcriber,
+            Arc::new(DefaultPlatformSpeechEngine::new()),
+            Arc::new(DefaultCandleBackendChecker),
+            transcription_timeout,
+        )
+    }
+
+    // Consumed only by the macOS/Windows-gated platform-speech tests;
+    // gate the helper the same way so it isn't dead code on Linux, where
+    // `cargo test --no-run` compiles test targets under `-Dwarnings`.
+    #[cfg(all(test, any(target_os = "macos", windows)))]
+    fn with_platform_runtime(
+        model_root: PathBuf,
+        recorder: Arc<dyn AudioRecorder>,
+        transcriber: Arc<dyn VoiceTranscriber>,
+        platform_speech: Arc<dyn PlatformSpeechEngine>,
+    ) -> Self {
+        Self::with_runtime_backend_and_timeout(
+            model_root,
+            recorder,
+            transcriber,
+            platform_speech,
+            Arc::new(DefaultCandleBackendChecker),
+            DISTIL_TRANSCRIPTION_TIMEOUT,
+        )
+    }
+
+    #[cfg(test)]
+    fn with_runtime_and_backend(
+        model_root: PathBuf,
+        recorder: Arc<dyn AudioRecorder>,
+        transcriber: Arc<dyn VoiceTranscriber>,
+        backend_checker: Arc<dyn CandleBackendChecker>,
+    ) -> Self {
+        Self::with_runtime_backend_and_timeout(
+            model_root,
+            recorder,
+            transcriber,
+            Arc::new(DefaultPlatformSpeechEngine::new()),
+            backend_checker,
+            DISTIL_TRANSCRIPTION_TIMEOUT,
+        )
+    }
+
+    fn with_runtime_backend_and_timeout(
+        model_root: PathBuf,
+        recorder: Arc<dyn AudioRecorder>,
+        transcriber: Arc<dyn VoiceTranscriber>,
+        platform_speech: Arc<dyn PlatformSpeechEngine>,
+        backend_checker: Arc<dyn CandleBackendChecker>,
+        transcription_timeout: Duration,
+    ) -> Self {
+        Self {
+            model_root,
+            active_recording: Mutex::new(None),
+            recorder,
+            transcriber,
+            platform_speech,
+            backend_checker,
+            transcription_timeout,
+            active_distil_cancel: Mutex::new(None),
+        }
+    }
+
+    pub fn default_model_root() -> PathBuf {
+        crate::helpers::aethon_dir(std::env::var_os("HOME").map(PathBuf::from))
+            .unwrap_or_else(|| PathBuf::from(".aethon"))
+            .join("models")
+            .join("voice")
+    }
+
+    pub fn distil_cache_path(&self) -> PathBuf {
+        self.model_root.join(DISTIL_CACHE_DIR)
+    }
+
+    pub fn list_providers(&self, db: &VoiceSettings) -> Vec<VoiceProviderInfo> {
+        vec![
+            PlatformVoiceProvider.status(self, db),
+            DistilWhisperCandleProvider.status(self, db),
+        ]
+    }
+
+    pub fn set_selected_provider(
+        &self,
+        db: &VoiceSettings,
+        provider_id: Option<&str>,
+    ) -> Result<(), String> {
+        if let Some(provider_id) = provider_id {
+            self.ensure_known(provider_id)?;
+            db.set_app_setting(SELECTED_PROVIDER_KEY, provider_id)
+                .map_err(|e| e.to_string())?;
+        } else {
+            db.delete_app_setting(SELECTED_PROVIDER_KEY)
+                .map_err(|e| e.to_string())?;
+        }
+        Ok(())
+    }
+
+    pub fn set_enabled(
+        &self,
+        db: &VoiceSettings,
+        provider_id: &str,
+        enabled: bool,
+    ) -> Result<(), String> {
+        self.ensure_known(provider_id)?;
+        db.set_app_setting(
+            &enabled_key(provider_id),
+            if enabled { "true" } else { "false" },
+        )
+        .map_err(|e| e.to_string())
+    }
+
+    pub async fn prepare_provider(
+        &self,
+        app: &AppHandle,
+        db_path: &Path,
+        provider_id: &str,
+    ) -> Result<VoiceProviderInfo, String> {
+        match provider_id {
+            PLATFORM_ID => PlatformVoiceProvider.prepare(self, app, db_path).await,
+            DISTIL_ID => {
+                DistilWhisperCandleProvider
+                    .prepare(self, app, db_path)
+                    .await
+            }
+            _ => Err(format!("Unknown voice provider: {provider_id}")),
+        }
+    }
+
+    pub async fn remove_provider_model(
+        &self,
+        db_path: &Path,
+        provider_id: &str,
+    ) -> Result<VoiceProviderInfo, String> {
+        self.ensure_known(provider_id)?;
+        if provider_id != DISTIL_ID {
+            return Err("This provider does not use a removable local model".to_string());
+        }
+
+        let path = self.distil_cache_path();
+        if tokio::fs::try_exists(&path)
+            .await
+            .map_err(|e| e.to_string())?
+        {
+            tokio::fs::remove_dir_all(&path)
+                .await
+                .map_err(|e| format!("Failed to remove model cache: {e}"))?;
+        }
+        let db = VoiceSettings::open(db_path).map_err(|e| e.to_string())?;
+        db.set_app_setting(&model_status_key(provider_id), "not-installed")
+            .map_err(|e| e.to_string())?;
+        Ok(DistilWhisperCandleProvider.status(self, &db))
+    }
+
+    pub async fn start_recording(
+        &self,
+        db_path: &Path,
+        provider_id: &str,
+        app: Option<AppHandle>,
+    ) -> Result<VoiceStartLatency, String> {
+        self.ensure_known(provider_id)?;
+        let stream_open_ms = match provider_id {
+            PLATFORM_ID => self.start_platform_recording(db_path, app).await,
+            DISTIL_ID => self.start_distil_recording(db_path, app).await,
+            _ => Err(format!("Unknown voice provider: {provider_id}")),
+        }?;
+        Ok(VoiceStartLatency { stream_open_ms })
+    }
+
+    pub async fn stop_and_transcribe(&self, provider_id: &str) -> Result<String, String> {
+        self.ensure_known(provider_id)?;
+        match provider_id {
+            PLATFORM_ID => self.stop_platform_recording().await,
+            DISTIL_ID => self.stop_distil_recording().await,
+            _ => Err(format!("Unknown voice provider: {provider_id}")),
+        }
+    }
+
+    pub async fn cancel_recording(&self, provider_id: &str) -> Result<(), String> {
+        self.ensure_known(provider_id)?;
+        match provider_id {
+            PLATFORM_ID => self.cancel_platform_recording().await,
+            DISTIL_ID => self.cancel_distil_recording().await,
+            _ => Err(format!("Unknown voice provider: {provider_id}")),
+        }
+    }
+
+    async fn start_platform_recording(
+        &self,
+        db_path: &Path,
+        app: Option<AppHandle>,
+    ) -> Result<u128, String> {
+        {
+            let db = VoiceSettings::open(db_path).map_err(|e| e.to_string())?;
+            if !self.enabled(&db, PLATFORM_ID) {
+                return Err("System dictation is disabled".to_string());
+            }
+            let platform_speech = Arc::clone(&self.platform_speech);
+            let availability = tokio::task::spawn_blocking(move || platform_speech.prepare())
+                .await
+                .map_err(|e| format!("System dictation permission task failed: {e}"))?;
+            if availability.status != PlatformSpeechAvailabilityStatus::Ready {
+                return Err(availability.message);
+            }
+        }
+
+        let mut active = self.active_recording.lock();
+        if active.is_some() {
+            return Err("Voice recording is already active".to_string());
+        }
+        let t_stream = Instant::now();
+        let mut session = self.recorder.start()?;
+        let stream_open_ms = t_stream.elapsed().as_millis();
+        if let Some(app) = app {
+            let abort = spawn_level_emitter(app, Arc::clone(&session.samples));
+            session._level_task = Some(LevelTask(abort));
+        }
+        *active = Some(session);
+        Ok(stream_open_ms)
+    }
+
+    async fn stop_platform_recording(&self) -> Result<String, String> {
+        let session = self
+            .active_recording
+            .lock()
+            .take()
+            .ok_or_else(|| "No voice recording is active".to_string())?;
+        let audio = session.finish()?;
+        if audio.samples.is_empty() {
+            return Err("No audio was captured".to_string());
+        }
+        validate_captured_audio(&audio)?;
+
+        let platform_speech = Arc::clone(&self.platform_speech);
+        let timeout = self.transcription_timeout;
+        let task = tokio::task::spawn_blocking(move || platform_speech.transcribe(audio));
+        let transcript = tokio::time::timeout(timeout, task)
+            .await
+            .map_err(|_| {
+                format!(
+                    "System dictation timed out after {} seconds. Try a shorter recording.",
+                    timeout.as_secs()
+                )
+            })?
+            .map_err(|e| format!("System dictation task failed: {e}"))??;
+        let transcript = transcript.trim().to_string();
+        if transcript.is_empty() {
+            return Err(
+                "No speech was recognized. Try again closer to the microphone.".to_string(),
+            );
+        }
+        Ok(transcript)
+    }
+
+    async fn cancel_platform_recording(&self) -> Result<(), String> {
+        let _ = self.active_recording.lock().take();
+        // Each platform with a real engine bridge gets a chance to drop any
+        // in-flight recognition request. macOS forwards to the Speech
+        // framework's `taskHint` cancel API; the Windows bridge has no
+        // cooperative cancel hook, so it's a no-op there. Linux currently
+        // has no native bridge at all.
+        #[cfg(target_os = "macos")]
+        crate::platform_speech::cancel_active_transcription();
+        #[cfg(windows)]
+        crate::platform_speech::cancel_active_transcription();
+        Ok(())
+    }
+
+    async fn start_distil_recording(
+        &self,
+        db_path: &Path,
+        app: Option<AppHandle>,
+    ) -> Result<u128, String> {
+        {
+            let db = VoiceSettings::open(db_path).map_err(|e| e.to_string())?;
+            if !self.enabled(&db, DISTIL_ID) {
+                return Err("Distil-Whisper voice input is disabled".to_string());
+            }
+            if !distil_model_ready(&self.distil_cache_path()) {
+                return Err("Download the Distil-Whisper model before recording".to_string());
+            }
+            self.ensure_candle_backend_ready()?;
+        }
+
+        let mut active = self.active_recording.lock();
+        if active.is_some() {
+            return Err("Voice recording is already active".to_string());
+        }
+        let t_stream = Instant::now();
+        let mut session = self.recorder.start()?;
+        let stream_open_ms = t_stream.elapsed().as_millis();
+        if let Some(app) = app {
+            let abort = spawn_level_emitter(app, Arc::clone(&session.samples));
+            session._level_task = Some(LevelTask(abort));
+        }
+        *active = Some(session);
+        Ok(stream_open_ms)
+    }
+
+    async fn stop_distil_recording(&self) -> Result<String, String> {
+        let session = self
+            .active_recording
+            .lock()
+            .take()
+            .ok_or_else(|| "No voice recording is active".to_string())?;
+        let audio = session.finish()?;
+        if audio.samples.is_empty() {
+            return Err("No audio was captured".to_string());
+        }
+        validate_captured_audio(&audio)?;
+
+        let cancel = Arc::new(AtomicBool::new(false));
+        *self.active_distil_cancel.lock() = Some(Arc::clone(&cancel));
+
+        let cache_path = self.distil_cache_path();
+        let transcriber = Arc::clone(&self.transcriber);
+        let timeout = self.transcription_timeout;
+        let cancel_for_task = Arc::clone(&cancel);
+        let task = tokio::task::spawn_blocking(move || {
+            transcriber.transcribe(&cache_path, audio, &cancel_for_task)
+        });
+        let result = tokio::time::timeout(timeout, task).await;
+
+        // On timeout, signal the worker to bail at its next cancel poll so it
+        // doesn't keep grinding on a transcript that's already been discarded.
+        if result.is_err() {
+            cancel.store(true, Ordering::Relaxed);
+        }
+
+        // Vacate our slot in the registry, but only if a newer transcription
+        // hasn't already replaced it.
+        {
+            let mut active = self.active_distil_cancel.lock();
+            if active.as_ref().is_some_and(|a| Arc::ptr_eq(a, &cancel)) {
+                *active = None;
+            }
+        }
+
+        let transcript = result
+            .map_err(|_| timeout_error_message(timeout))?
+            .map_err(|e| format!("Voice transcription task failed: {e}"))??;
+        let transcript = transcript.trim().to_string();
+        if transcript.is_empty() {
+            return Err(
+                "No speech was recognized. Try again closer to the microphone.".to_string(),
+            );
+        }
+        Ok(transcript)
+    }
+
+    async fn cancel_distil_recording(&self) -> Result<(), String> {
+        if let Some(cancel) = self.active_distil_cancel.lock().clone() {
+            cancel.store(true, Ordering::Relaxed);
+        }
+        let _ = self.active_recording.lock().take();
+        Ok(())
+    }
+
+    fn ensure_known(&self, provider_id: &str) -> Result<(), String> {
+        match provider_id {
+            PLATFORM_ID | DISTIL_ID => Ok(()),
+            _ => Err(format!("Unknown voice provider: {provider_id}")),
+        }
+    }
+
+    fn selected_provider(&self, db: &VoiceSettings) -> Option<String> {
+        db.get_app_setting(SELECTED_PROVIDER_KEY).ok().flatten()
+    }
+
+    fn auto_provider_enabled(&self, db: &VoiceSettings) -> bool {
+        db.get_app_setting(AUTO_PROVIDER_KEY)
+            .ok()
+            .flatten()
+            .map(|v| v != "false")
+            .unwrap_or(true)
+    }
+
+    fn enabled(&self, db: &VoiceSettings, provider_id: &str) -> bool {
+        db.get_app_setting(&enabled_key(provider_id))
+            .ok()
+            .flatten()
+            .map(|v| v != "false")
+            .unwrap_or(true)
+    }
+
+    fn ensure_candle_backend_ready(&self) -> Result<CandleBackend, String> {
+        self.backend_checker.ready_backend()
+    }
+
+    pub(crate) fn resolve_provider_id(
+        &self,
+        db: &VoiceSettings,
+        requested: Option<&str>,
+    ) -> Result<String, String> {
+        if let Some(requested) = requested {
+            self.ensure_known(requested)?;
+            return Ok(requested.to_string());
+        }
+        if let Some(selected) = self.selected_provider(db) {
+            self.ensure_known(&selected)?;
+            return Ok(selected);
+        }
+        if self.auto_provider_enabled(db) {
+            return Ok(PLATFORM_ID.to_string());
+        }
+        Err("No voice provider is selected".to_string())
+    }
+}
+
+struct PlatformVoiceProvider;
+
+// The platform provider has a real native bridge on macOS (Apple Speech via
+// Swift FFI) and on Windows (SAPI 5.4 via the `windows` crate's COM
+// bindings). Both platforms ride the `Native` recording-mode path: cpal
+// captures the audio, the trait runs transcription on the captured WAV.
+// Linux has no native bridge yet and falls back to the webview Web Speech
+// API, which is what the `Webview` mode signals to the frontend.
+#[cfg(any(target_os = "macos", windows))]
+fn platform_recording_mode() -> VoiceRecordingMode {
+    VoiceRecordingMode::Native
+}
+
+#[cfg(not(any(target_os = "macos", windows)))]
+fn platform_recording_mode() -> VoiceRecordingMode {
+    VoiceRecordingMode::Webview
+}
+
+#[cfg(target_os = "macos")]
+fn platform_description() -> &'static str {
+    "Uses native Apple Speech recognition through the operating system. Requires Microphone and Speech Recognition permission."
+}
+
+#[cfg(windows)]
+fn platform_description() -> &'static str {
+    "Uses the Windows Speech API (SAPI 5.4) via in-process COM. \
+     Captured audio is transcribed locally — no network round-trip, no extra runtime. \
+     Install a Speech Recognizer language pack via Settings → Time & language → Speech \
+     if transcription returns no text."
+}
+
+#[cfg(not(any(target_os = "macos", windows)))]
+fn platform_description() -> &'static str {
+    "Uses the webview or operating system speech recognition surface when available. Requires microphone and speech recognition permission."
+}
+
+#[cfg(target_os = "macos")]
+fn platform_privacy_label() -> &'static str {
+    "Uses Apple Speech services; offline behavior varies by OS language support"
+}
+
+#[cfg(windows)]
+fn platform_privacy_label() -> &'static str {
+    "Local Windows SAPI recognition; audio stays on this machine"
+}
+
+#[cfg(not(any(target_os = "macos", windows)))]
+fn platform_privacy_label() -> &'static str {
+    "Uses platform services; offline behavior varies by OS"
+}
+
+#[cfg(target_os = "macos")]
+fn platform_accelerator_label() -> &'static str {
+    "Apple Speech"
+}
+
+#[cfg(windows)]
+fn platform_accelerator_label() -> &'static str {
+    "Windows SAPI"
+}
+
+#[cfg(not(any(target_os = "macos", windows)))]
+fn platform_accelerator_label() -> &'static str {
+    "No setup"
+}
+
+#[cfg(any(target_os = "macos", windows))]
+fn platform_status_from_availability(
+    availability: PlatformSpeechAvailability,
+) -> (VoiceProviderStatus, String, bool, Option<String>) {
+    match availability.status {
+        PlatformSpeechAvailabilityStatus::Ready => (
+            VoiceProviderStatus::Ready,
+            availability.message,
+            false,
+            None,
+        ),
+        PlatformSpeechAvailabilityStatus::NeedsMicrophonePermission
+        | PlatformSpeechAvailabilityStatus::NeedsSpeechPermission
+        | PlatformSpeechAvailabilityStatus::NeedsAssets => (
+            VoiceProviderStatus::NeedsSetup,
+            availability.message.clone(),
+            true,
+            Some(availability.message),
+        ),
+        PlatformSpeechAvailabilityStatus::EngineUnavailable => (
+            VoiceProviderStatus::EngineUnavailable,
+            "System dictation engine unavailable".to_string(),
+            false,
+            Some(availability.message),
+        ),
+        PlatformSpeechAvailabilityStatus::Unavailable => (
+            VoiceProviderStatus::Unavailable,
+            availability.message.clone(),
+            false,
+            Some(availability.message),
+        ),
+    }
+}
+
+#[async_trait]
+impl VoiceProvider for PlatformVoiceProvider {
+    fn id(&self) -> &'static str {
+        PLATFORM_ID
+    }
+
+    fn metadata(&self, _registry: &VoiceProviderRegistry) -> VoiceProviderMetadata {
+        VoiceProviderMetadata {
+            id: self.id().to_string(),
+            name: "System dictation".to_string(),
+            description: platform_description().to_string(),
+            kind: VoiceProviderKind::Platform,
+            recording_mode: platform_recording_mode(),
+            privacy_label: platform_privacy_label().to_string(),
+            offline: false,
+            download_required: false,
+            model_size_label: None,
+            cache_path: None,
+            accelerator_label: Some(platform_accelerator_label().to_string()),
+        }
+    }
+
+    fn status(&self, registry: &VoiceProviderRegistry, db: &VoiceSettings) -> VoiceProviderInfo {
+        let enabled = registry.enabled(db, self.id());
+        // macOS + Windows ride the same trait-based status path: the real
+        // engine reports Ready / NeedsSetup / EngineUnavailable from a
+        // platform-native check. Linux has no native bridge, so we keep
+        // the legacy "ready when the webview's Web Speech API is around"
+        // shape — the frontend's `useVoiceInput` sees this and falls
+        // through to `webkitSpeechRecognition`.
+        #[cfg(any(target_os = "macos", windows))]
+        let (status, status_label, setup_required, error) = if !enabled {
+            (
+                VoiceProviderStatus::Unavailable,
+                "Disabled".to_string(),
+                false,
+                None,
+            )
+        } else {
+            platform_status_from_availability(registry.platform_speech.availability())
+        };
+        #[cfg(not(any(target_os = "macos", windows)))]
+        let (status, status_label, setup_required, error) = if enabled {
+            (
+                VoiceProviderStatus::Ready,
+                "Ready when webview speech recognition and OS permissions are available"
+                    .to_string(),
+                false,
+                None,
+            )
+        } else {
+            (
+                VoiceProviderStatus::Unavailable,
+                "Disabled".to_string(),
+                false,
+                None,
+            )
+        };
+        VoiceProviderInfo {
+            metadata: self.metadata(registry),
+            status,
+            status_label,
+            enabled,
+            selected: registry.selected_provider(db).as_deref() == Some(self.id()),
+            setup_required,
+            can_remove_model: false,
+            error,
+        }
+    }
+
+    async fn prepare(
+        &self,
+        registry: &VoiceProviderRegistry,
+        _app: &AppHandle,
+        db_path: &Path,
+    ) -> Result<VoiceProviderInfo, String> {
+        // macOS uses prepare() to drive the TCC permission dialogs;
+        // Windows uses it as a (cheap, no-op today) revalidation that
+        // SAPI is still reachable. Both go through the trait so tests
+        // can substitute a fake engine. Linux has no engine here.
+        #[cfg(any(target_os = "macos", windows))]
+        {
+            let _ = registry.platform_speech.prepare();
+        }
+        let db = VoiceSettings::open(db_path).map_err(|e| e.to_string())?;
+        Ok(self.status(registry, &db))
+    }
+}
+
+struct DistilWhisperCandleProvider;
+
+#[async_trait]
+impl VoiceProvider for DistilWhisperCandleProvider {
+    fn id(&self) -> &'static str {
+        DISTIL_ID
+    }
+
+    fn metadata(&self, registry: &VoiceProviderRegistry) -> VoiceProviderMetadata {
+        let cache_path = registry.distil_cache_path();
+        VoiceProviderMetadata {
+            id: self.id().to_string(),
+            name: "Distil-Whisper Large v3".to_string(),
+            description: "Private offline transcription using distil-whisper/distil-large-v3 through the native provider interface.".to_string(),
+            kind: VoiceProviderKind::LocalModel,
+            recording_mode: VoiceRecordingMode::Native,
+            privacy_label: "Private after download; audio stays local".to_string(),
+            offline: true,
+            download_required: true,
+            model_size_label: Some("About 1.5 GB plus tokenizer/config files".to_string()),
+            cache_path: Some(cache_path.display().to_string()),
+            accelerator_label: None,
+        }
+    }
+
+    fn status(&self, registry: &VoiceProviderRegistry, db: &VoiceSettings) -> VoiceProviderInfo {
+        let enabled = registry.enabled(db, self.id());
+        if !enabled {
+            return VoiceProviderInfo {
+                metadata: self.metadata(registry),
+                status: VoiceProviderStatus::Unavailable,
+                status_label: "Disabled".to_string(),
+                enabled: false,
+                selected: false,
+                setup_required: false,
+                can_remove_model: false,
+                error: None,
+            };
+        }
+
+        let cache_path = registry.distil_cache_path();
+        let model_status = db
+            .get_app_setting(&model_status_key(self.id()))
+            .ok()
+            .flatten();
+        let installed = distil_model_ready(&cache_path);
+        let backend_status = registry.ensure_candle_backend_ready();
+
+        let mut metadata = self.metadata(registry);
+        metadata.accelerator_label = Some(match &backend_status {
+            Ok(backend) => backend.accelerator_label().to_string(),
+            Err(err) => format!("Unavailable: {err}"),
+        });
+
+        let (status, status_label, setup_required, error) =
+            if model_status.as_deref() == Some("downloading") {
+                (
+                    VoiceProviderStatus::Downloading,
+                    "Downloading model".to_string(),
+                    true,
+                    None,
+                )
+            } else if let Err(err) = &backend_status {
+                (
+                    VoiceProviderStatus::EngineUnavailable,
+                    "Voice engine unavailable".to_string(),
+                    false,
+                    Some(err.clone()),
+                )
+            } else if installed {
+                let backend = backend_status.expect("backend availability checked");
+                (
+                    VoiceProviderStatus::Ready,
+                    format!("{DISTIL_READY_MESSAGE} ({})", backend.label()),
+                    false,
+                    None,
+                )
+            } else if model_status
+                .as_deref()
+                .is_some_and(|status| status.starts_with("error:"))
+            {
+                (
+                    VoiceProviderStatus::Error,
+                    "Download failed".to_string(),
+                    true,
+                    model_status.map(|s| s.trim_start_matches("error:").to_string()),
+                )
+            } else {
+                (
+                    VoiceProviderStatus::NeedsSetup,
+                    "Download required".to_string(),
+                    true,
+                    None,
+                )
+            };
+
+        VoiceProviderInfo {
+            metadata,
+            status,
+            status_label,
+            enabled,
+            selected: registry.selected_provider(db).as_deref() == Some(self.id()),
+            setup_required,
+            can_remove_model: installed,
+            error,
+        }
+    }
+
+    async fn prepare(
+        &self,
+        registry: &VoiceProviderRegistry,
+        app: &AppHandle,
+        db_path: &Path,
+    ) -> Result<VoiceProviderInfo, String> {
+        let cache_path = registry.distil_cache_path();
+        tokio::fs::create_dir_all(&cache_path)
+            .await
+            .map_err(|e| format!("Failed to create model cache: {e}"))?;
+        {
+            let db = VoiceSettings::open(db_path).map_err(|e| e.to_string())?;
+            db.set_app_setting(&model_status_key(self.id()), "downloading")
+                .map_err(|e| e.to_string())?;
+        }
+
+        let result = download_distil_model(app, self.id(), &cache_path).await;
+        match result {
+            Ok(()) => {
+                let db = VoiceSettings::open(db_path).map_err(|e| e.to_string())?;
+                db.set_app_setting(&model_status_key(self.id()), "installed")
+                    .map_err(|e| e.to_string())?;
+                let info = self.status(registry, &db);
+                let _ = app.emit("voice-provider-status", &info);
+                Ok(info)
+            }
+            Err(err) => {
+                let db = VoiceSettings::open(db_path).map_err(|e| e.to_string())?;
+                let _ = db.set_app_setting(&model_status_key(self.id()), &format!("error:{err}"));
+                let _ = app.emit(
+                    "voice-error",
+                    VoiceErrorEvent {
+                        provider_id: Some(self.id().to_string()),
+                        message: err.clone(),
+                    },
+                );
+                Err(err)
+            }
+        }
+    }
+}
+
+fn enabled_key(provider_id: &str) -> String {
+    format!("voice:{provider_id}:enabled")
+}
+
+fn model_status_key(provider_id: &str) -> String {
+    format!("voice:{provider_id}:model_status")
+}
+
+fn distil_model_ready(cache_path: &Path) -> bool {
+    DISTIL_MODEL_FILES.iter().all(|(filename, min_size)| {
+        let path = cache_path.join(filename);
+        if let Some(min_size) = min_size {
+            path.metadata().is_ok_and(|m| m.len() >= *min_size)
+        } else {
+            path.is_file()
+        }
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn select_candle_device() -> Result<(Device, CandleBackend), String> {
+    if !candle_core::utils::metal_is_available() {
+        return Err(
+            "Candle Metal is not available in this macOS build. Rebuild the app with candle-core/metal enabled."
+                .to_string(),
+        );
+    }
+
+    let device = Device::new_metal(0)
+        .map_err(|e| format!("Failed to initialize Candle Metal device: {e}"))?;
+    Ok((device, CandleBackend::Metal))
+}
+
+#[cfg(not(target_os = "macos"))]
+fn select_candle_device() -> Result<(Device, CandleBackend), String> {
+    Ok((Device::Cpu, CandleBackend::Cpu))
+}
+
+fn ensure_candle_backend_ready() -> Result<CandleBackend, String> {
+    static BACKEND_READY: OnceLock<Result<CandleBackend, String>> = OnceLock::new();
+
+    BACKEND_READY
+        .get_or_init(check_candle_backend_ready)
+        .clone()
+}
+
+fn check_candle_backend_ready() -> Result<CandleBackend, String> {
+    let (device, backend) = select_candle_device()?;
+    verify_candle_whisper_backend_for(&device, backend)?;
+    Ok(backend)
+}
+
+fn verify_candle_whisper_backend_for(
+    device: &Device,
+    backend: CandleBackend,
+) -> Result<(), String> {
+    verify_candle_whisper_backend(device)
+        .map_err(|err| format!("Candle {} Whisper backend failed {err}", backend.label()))
+}
+
+fn verify_candle_whisper_backend(device: &Device) -> Result<(), String> {
+    probe_candle_whisper_op("conv1d", || {
+        let input = Tensor::new(
+            &[[
+                [0.1_f32, 0.2, -0.1, 0.0, 0.3, -0.3, 0.4, 0.5],
+                [0.5_f32, -0.4, 0.3, -0.2, 0.1, 0.0, -0.1, 0.2],
+            ]],
+            device,
+        )?;
+        let kernel = Tensor::new(
+            &[
+                [[0.2_f32, 0.1, -0.1], [0.0_f32, 0.3, 0.2]],
+                [[-0.2_f32, 0.4, 0.1], [0.1_f32, -0.3, 0.2]],
+            ],
+            device,
+        )?;
+        let output = input.conv1d(&kernel, 1, 1, 1, 1)?;
+        let _ = output.to_vec3::<f32>()?;
+        Ok(())
+    })?;
+    probe_candle_whisper_op("gelu", || {
+        let output = Tensor::new(&[-1.0_f32, 0.0, 1.0, 2.0], device)?.gelu()?;
+        let _ = output.to_vec1::<f32>()?;
+        Ok(())
+    })?;
+    probe_candle_whisper_op("layer_norm", || {
+        let xs = Tensor::new(&[[1.0_f32, 2.0], [3.0, 4.0]], device)?;
+        let alpha = Tensor::new(&[1.0_f32, 1.0], device)?;
+        let beta = Tensor::new(&[0.0_f32, 0.0], device)?;
+        let output = candle_nn::ops::layer_norm(&xs, &alpha, &beta, 1e-5)?;
+        let _ = output.to_vec2::<f32>()?;
+        Ok(())
+    })?;
+    probe_candle_whisper_op("softmax", || {
+        let logits = Tensor::new(&[[1.0_f32, 2.0, 3.0]], device)?;
+        let output = softmax(&logits, D::Minus1)?;
+        let _ = output.to_vec2::<f32>()?;
+        Ok(())
+    })?;
+    probe_candle_whisper_op("matmul", || {
+        let lhs = Tensor::new(&[[1.0_f32, 2.0, 3.0], [4.0, 5.0, 6.0]], device)?;
+        let rhs = Tensor::new(&[[1.0_f32, 2.0], [3.0, 4.0], [5.0, 6.0]], device)?;
+        let output = lhs.matmul(&rhs)?;
+        let _ = output.to_vec2::<f32>()?;
+        Ok(())
+    })?;
+    probe_candle_whisper_op("broadcast_add", || {
+        let matrix = Tensor::new(&[[1.0_f32, 2.0, 3.0], [4.0, 5.0, 6.0]], device)?;
+        let bias = Tensor::new(&[0.5_f32, -0.5, 1.0], device)?;
+        let output = matrix.broadcast_add(&bias)?;
+        let _ = output.to_vec2::<f32>()?;
+        Ok(())
+    })?;
+    probe_candle_whisper_op("index_select", || {
+        let source = Tensor::new(&[[1.0_f32, 2.0], [3.0, 4.0], [5.0, 6.0]], device)?;
+        let indexes = Tensor::new(&[2_u32, 0], device)?;
+        let output = source.index_select(&indexes, 0)?;
+        let _ = output.to_vec2::<f32>()?;
+        Ok(())
+    })?;
+    probe_candle_whisper_op("scalar_readback", || {
+        let value = Tensor::new(&[42.0_f32], device)?.i(0)?.to_scalar::<f32>()?;
+        if (value - 42.0).abs() > f32::EPSILON {
+            return Err(candle_core::Error::Msg(format!(
+                "expected 42.0, got {value}"
+            )));
+        }
+        Ok(())
+    })
+}
+
+fn probe_candle_whisper_op(
+    op: &'static str,
+    run: impl FnOnce() -> candle_core::Result<()>,
+) -> Result<(), String> {
+    run().map_err(|e| format!("{op}: {e}"))
+}
+
+/// Format the user-visible message when Distil-Whisper hits its
+/// hard timeout. On CPU platforms (Linux + Windows) the ceiling is
+/// already 5× the macOS Metal default, so a timeout almost certainly
+/// means the workload is too big for CPU inference rather than a stuck
+/// worker — pivot the user toward the always-faster platform provider
+/// (SAPI on Windows, Apple Speech on macOS) instead of asking them to
+/// "try again."
+fn timeout_error_message(timeout: Duration) -> String {
+    #[cfg(target_os = "macos")]
+    let suggestion = "Try a shorter recording or switch to System dictation in Voice settings.";
+    #[cfg(target_os = "windows")]
+    let suggestion = "On CPU this model is slow on long clips — try a shorter recording or switch to System dictation (Windows SAPI) in Voice settings.";
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    let suggestion = "Try a shorter recording or check the selected voice provider.";
+    format!(
+        "Voice transcription timed out after {} seconds. {}",
+        timeout.as_secs(),
+        suggestion
+    )
+}
+
+fn validate_captured_audio(audio: &CapturedAudio) -> Result<(), String> {
+    let peak = audio
+        .samples
+        .iter()
+        .fold(0.0_f32, |peak, sample| peak.max(sample.abs()));
+    if peak < MIN_SIGNAL_PEAK {
+        return Err("No speech was detected. Check microphone input and try again.".to_string());
+    }
+    Ok(())
+}
+
+fn normalize_interleaved_f32(input: &[f32], channels: u16) -> Vec<f32> {
+    normalize_interleaved_samples(input, channels)
+}
+
+fn normalize_interleaved_f64(input: &[f64], channels: u16) -> Vec<f32> {
+    normalize_interleaved_samples(input, channels)
+}
+
+fn normalize_interleaved_i8(input: &[i8], channels: u16) -> Vec<f32> {
+    normalize_interleaved_samples(input, channels)
+}
+
+fn normalize_interleaved_i16(input: &[i16], channels: u16) -> Vec<f32> {
+    normalize_interleaved_samples(input, channels)
+}
+
+fn normalize_interleaved_i24(input: &[cpal::I24], channels: u16) -> Vec<f32> {
+    normalize_interleaved_samples(input, channels)
+}
+
+fn normalize_interleaved_i32(input: &[i32], channels: u16) -> Vec<f32> {
+    normalize_interleaved_samples(input, channels)
+}
+
+fn normalize_interleaved_i64(input: &[i64], channels: u16) -> Vec<f32> {
+    normalize_interleaved_samples(input, channels)
+}
+
+fn normalize_interleaved_u8(input: &[u8], channels: u16) -> Vec<f32> {
+    normalize_interleaved_samples(input, channels)
+}
+
+fn normalize_interleaved_u16(input: &[u16], channels: u16) -> Vec<f32> {
+    normalize_interleaved_samples(input, channels)
+}
+
+fn normalize_interleaved_u24(input: &[cpal::U24], channels: u16) -> Vec<f32> {
+    normalize_interleaved_samples(input, channels)
+}
+
+fn normalize_interleaved_u32(input: &[u32], channels: u16) -> Vec<f32> {
+    normalize_interleaved_samples(input, channels)
+}
+
+fn normalize_interleaved_u64(input: &[u64], channels: u16) -> Vec<f32> {
+    normalize_interleaved_samples(input, channels)
+}
+
+fn normalize_interleaved_samples<T>(input: &[T], channels: u16) -> Vec<f32>
+where
+    T: cpal::Sample + Copy,
+    f64: cpal::FromSample<T>,
+{
+    mix_interleaved_to_mono(input, channels, |sample| {
+        f64::from_sample(sample).clamp(-1.0, 1.0) as f32
+    })
+}
+
+fn mix_interleaved_to_mono<T>(
+    input: &[T],
+    channels: u16,
+    mut convert: impl FnMut(T) -> f32,
+) -> Vec<f32>
+where
+    T: Copy,
+{
+    let channel_count = usize::from(channels.max(1));
+    input
+        .chunks(channel_count)
+        .map(|frame| frame.iter().copied().map(&mut convert).sum::<f32>() / frame.len() as f32)
+        .collect()
+}
+
+fn resample_to_target_rate(samples: &[f32], sample_rate: u32) -> Vec<f32> {
+    if samples.is_empty() || sample_rate == TARGET_SAMPLE_RATE {
+        return samples.to_vec();
+    }
+
+    let output_len =
+        (samples.len() as u64 * u64::from(TARGET_SAMPLE_RATE) / u64::from(sample_rate)).max(1);
+    let ratio = sample_rate as f64 / TARGET_SAMPLE_RATE as f64;
+    (0..output_len)
+        .map(|out_index| {
+            let source = out_index as f64 * ratio;
+            let left = source.floor() as usize;
+            let right = (left + 1).min(samples.len() - 1);
+            let frac = (source - left as f64) as f32;
+            samples[left] * (1.0 - frac) + samples[right] * frac
+        })
+        .collect()
+}
+
+impl AudioRecorder for CpalAudioRecorder {
+    fn start(&self) -> Result<RecordingSession, String> {
+        let host = cpal::default_host();
+        let device = host
+            .default_input_device()
+            .ok_or_else(|| "No default microphone input device is available".to_string())?;
+        let supported_config = device
+            .default_input_config()
+            .map_err(|e| format!("Failed to read microphone input config: {e}"))?;
+        let sample_rate = supported_config.sample_rate();
+        let channels = supported_config.channels();
+        let stream_config: cpal::StreamConfig = supported_config.clone().into();
+        let samples = Arc::new(Mutex::new(Vec::<f32>::new()));
+        let stream_error = Arc::new(Mutex::new(None));
+
+        macro_rules! build_input_stream {
+            ($sample_ty:ty, $normalize:path) => {{
+                let samples = Arc::clone(&samples);
+                let stream_error = Arc::clone(&stream_error);
+                device.build_input_stream(
+                    &stream_config,
+                    move |data: &[$sample_ty], _| {
+                        samples.lock().extend($normalize(data, channels));
+                    },
+                    move |err| {
+                        *stream_error.lock() = Some(err.to_string());
+                        tracing::warn!(target: "aethon::voice", error = %err, "input stream error");
+                    },
+                    None,
+                )
+            }};
+        }
+
+        let stream = match supported_config.sample_format() {
+            cpal::SampleFormat::I8 => build_input_stream!(i8, normalize_interleaved_i8),
+            cpal::SampleFormat::I16 => build_input_stream!(i16, normalize_interleaved_i16),
+            cpal::SampleFormat::I24 => build_input_stream!(cpal::I24, normalize_interleaved_i24),
+            cpal::SampleFormat::I32 => build_input_stream!(i32, normalize_interleaved_i32),
+            cpal::SampleFormat::I64 => build_input_stream!(i64, normalize_interleaved_i64),
+            cpal::SampleFormat::U8 => build_input_stream!(u8, normalize_interleaved_u8),
+            cpal::SampleFormat::U16 => build_input_stream!(u16, normalize_interleaved_u16),
+            cpal::SampleFormat::U24 => build_input_stream!(cpal::U24, normalize_interleaved_u24),
+            cpal::SampleFormat::U32 => build_input_stream!(u32, normalize_interleaved_u32),
+            cpal::SampleFormat::U64 => build_input_stream!(u64, normalize_interleaved_u64),
+            cpal::SampleFormat::F32 => build_input_stream!(f32, normalize_interleaved_f32),
+            cpal::SampleFormat::F64 => build_input_stream!(f64, normalize_interleaved_f64),
+            other => {
+                return Err(format!("Unsupported microphone sample format: {other:?}"));
+            }
+        }
+        .map_err(|e| format!("Failed to open microphone input stream: {e}"))?;
+        stream
+            .play()
+            .map_err(|e| format!("Failed to start microphone input stream: {e}"))?;
+
+        Ok(RecordingSession {
+            samples,
+            stream_error,
+            sample_rate,
+            _stream: Some(stream),
+            _level_task: None,
+        })
+    }
+}
+
+impl VoiceTranscriber for CandleWhisperTranscriber {
+    fn transcribe(
+        &self,
+        cache_path: &Path,
+        captured: CapturedAudio,
+        cancel: &Arc<AtomicBool>,
+    ) -> Result<String, String> {
+        transcribe_distil_whisper(cache_path, captured, cancel)
+    }
+}
+
+enum WhisperModel {
+    Normal(whisper::model::Whisper),
+}
+
+impl WhisperModel {
+    fn config(&self) -> &Config {
+        match self {
+            Self::Normal(model) => &model.config,
+        }
+    }
+
+    fn encoder_forward(&mut self, input: &Tensor, flush: bool) -> candle_core::Result<Tensor> {
+        match self {
+            Self::Normal(model) => model.encoder.forward(input, flush),
+        }
+    }
+
+    fn decoder_forward(
+        &mut self,
+        input: &Tensor,
+        audio_features: &Tensor,
+        flush: bool,
+    ) -> candle_core::Result<Tensor> {
+        match self {
+            Self::Normal(model) => model.decoder.forward(input, audio_features, flush),
+        }
+    }
+
+    fn decoder_final_linear(&self, input: &Tensor) -> candle_core::Result<Tensor> {
+        match self {
+            Self::Normal(model) => model.decoder.final_linear(input),
+        }
+    }
+}
+
+struct WhisperDecoder {
+    model: WhisperModel,
+    tokenizer: Tokenizer,
+    suppress_tokens: Tensor,
+    sot_token: u32,
+    transcribe_token: u32,
+    eot_token: u32,
+    no_speech_token: Option<u32>,
+    no_timestamps_token: u32,
+    language_token: Option<u32>,
+}
+
+struct WhisperDecodingResult {
+    text: String,
+    avg_logprob: f64,
+    no_speech_prob: f64,
+}
+
+impl WhisperDecoder {
+    fn new(model: WhisperModel, tokenizer: Tokenizer, device: &Device) -> Result<Self, String> {
+        let no_timestamps_token = token_id(&tokenizer, whisper::NO_TIMESTAMPS_TOKEN)?;
+        let suppress_tokens = (0..model.config().vocab_size as u32)
+            .map(|index| {
+                if model.config().suppress_tokens.contains(&index) {
+                    f32::NEG_INFINITY
+                } else {
+                    0.0
+                }
+            })
+            .collect::<Vec<_>>();
+        let suppress_tokens = Tensor::new(suppress_tokens.as_slice(), device)
+            .map_err(|e| format!("Failed to build Whisper token suppression mask: {e}"))?;
+
+        Ok(Self {
+            sot_token: token_id(&tokenizer, whisper::SOT_TOKEN)?,
+            transcribe_token: token_id(&tokenizer, whisper::TRANSCRIBE_TOKEN)?,
+            eot_token: token_id(&tokenizer, whisper::EOT_TOKEN)?,
+            no_speech_token: whisper::NO_SPEECH_TOKENS
+                .iter()
+                .find_map(|token| token_id(&tokenizer, token).ok()),
+            no_timestamps_token,
+            language_token: None,
+            model,
+            tokenizer,
+            suppress_tokens,
+        })
+    }
+
+    fn run(&mut self, mel: &Tensor, cancel: &Arc<AtomicBool>) -> Result<String, String> {
+        if self.language_token.is_none() {
+            self.language_token = self.detect_language_token(mel)?;
+        }
+        let (_, _, content_frames) = mel
+            .dims3()
+            .map_err(|e| format!("Invalid Whisper mel tensor: {e}"))?;
+        let mut seek = 0;
+        let mut text = String::new();
+
+        while seek < content_frames {
+            if cancel.load(Ordering::Relaxed) {
+                return Err("Transcription cancelled.".to_string());
+            }
+            let segment_size = usize::min(content_frames - seek, whisper::N_FRAMES);
+            let segment = mel
+                .narrow(2, seek, segment_size)
+                .map_err(|e| format!("Failed to slice Whisper mel segment: {e}"))?;
+            let decoded = self.decode(&segment, cancel)?;
+            if decoded.no_speech_prob > whisper::NO_SPEECH_THRESHOLD
+                && decoded.avg_logprob < whisper::LOGPROB_THRESHOLD
+            {
+                seek += segment_size;
+                continue;
+            }
+            if !decoded.text.trim().is_empty() {
+                if !text.is_empty() {
+                    text.push(' ');
+                }
+                text.push_str(decoded.text.trim());
+            }
+            seek += segment_size;
+        }
+
+        Ok(text.trim().to_string())
+    }
+
+    fn detect_language_token(&mut self, mel: &Tensor) -> Result<Option<u32>, String> {
+        let language_token_ids = WHISPER_LANGUAGE_CODES
+            .iter()
+            .filter_map(|code| self.tokenizer.token_to_id(&format!("<|{code}|>")))
+            .collect::<Vec<_>>();
+        if language_token_ids.is_empty() {
+            return Ok(None);
+        }
+
+        let (_, _, seq_len) = mel
+            .dims3()
+            .map_err(|e| format!("Invalid Whisper mel tensor: {e}"))?;
+        let mel = mel
+            .narrow(
+                2,
+                0,
+                usize::min(seq_len, self.model.config().max_source_positions),
+            )
+            .map_err(|e| format!("Failed to slice Whisper language mel segment: {e}"))?;
+        let audio_features = self
+            .model
+            .encoder_forward(&mel, true)
+            .map_err(|e| format!("Whisper language encoder failed: {e}"))?;
+        let tokens = Tensor::new(&[[self.sot_token]], mel.device())
+            .map_err(|e| format!("Failed to build Whisper language token tensor: {e}"))?;
+        let token_ids = Tensor::new(language_token_ids.as_slice(), mel.device())
+            .map_err(|e| format!("Failed to build Whisper language token list: {e}"))?;
+        let decoded = self
+            .model
+            .decoder_forward(&tokens, &audio_features, true)
+            .map_err(|e| format!("Whisper language decoder failed: {e}"))?;
+        let logits = self
+            .model
+            .decoder_final_linear(
+                &decoded
+                    .i(..1)
+                    .map_err(|e| format!("Failed to slice Whisper language logits: {e}"))?,
+            )
+            .and_then(|logits| logits.i(0))
+            .and_then(|logits| logits.i(0))
+            .and_then(|logits| logits.index_select(&token_ids, 0))
+            .map_err(|e| format!("Whisper language logits failed: {e}"))?;
+        let probs = softmax(&logits, D::Minus1)
+            .map_err(|e| format!("Whisper language softmax failed: {e}"))?;
+        let values = probs
+            .to_vec1::<f32>()
+            .map_err(|e| format!("Failed to read Whisper language probabilities: {e}"))?;
+        values
+            .iter()
+            .enumerate()
+            .max_by(|(_, left), (_, right)| left.total_cmp(right))
+            .map(|(index, _)| Some(language_token_ids[index]))
+            .ok_or_else(|| "Whisper returned no language probabilities".to_string())
+    }
+
+    fn decode(
+        &mut self,
+        mel: &Tensor,
+        cancel: &Arc<AtomicBool>,
+    ) -> Result<WhisperDecodingResult, String> {
+        let audio_features = self
+            .model
+            .encoder_forward(mel, true)
+            .map_err(|e| format!("Whisper encoder failed: {e}"))?;
+        let mut tokens = decoder_prompt_tokens(
+            self.sot_token,
+            self.language_token,
+            self.transcribe_token,
+            self.no_timestamps_token,
+        );
+        let sample_len = self.model.config().max_target_positions / 2;
+        let mut sum_logprob = 0.0_f64;
+        let mut generated_tokens = 0_usize;
+        let mut no_speech_prob = f64::NAN;
+
+        for index in 0..sample_len {
+            if cancel.load(Ordering::Relaxed) {
+                return Err("Transcription cancelled.".to_string());
+            }
+            let tokens_tensor = Tensor::new(tokens.as_slice(), mel.device())
+                .and_then(|tensor| tensor.unsqueeze(0))
+                .map_err(|e| format!("Failed to build Whisper token tensor: {e}"))?;
+            let decoded = self
+                .model
+                .decoder_forward(&tokens_tensor, &audio_features, index == 0)
+                .map_err(|e| format!("Whisper decoder failed: {e}"))?;
+            if index == 0
+                && let Some(no_speech_token) = self.no_speech_token
+            {
+                let logits =
+                    self.model
+                        .decoder_final_linear(&decoded.i(..1).map_err(|e| {
+                            format!("Failed to slice Whisper no-speech logits: {e}")
+                        })?)
+                        .and_then(|logits| logits.i(0))
+                        .and_then(|logits| logits.i(0))
+                        .map_err(|e| format!("Whisper no-speech logits failed: {e}"))?;
+                no_speech_prob = softmax(&logits, D::Minus1)
+                    .and_then(|probs| probs.i(no_speech_token as usize))
+                    .and_then(|prob| prob.to_scalar::<f32>())
+                    .map_err(|e| format!("Whisper no-speech probability failed: {e}"))?
+                    as f64;
+            }
+            let (_, seq_len, _) = decoded
+                .dims3()
+                .map_err(|e| format!("Invalid Whisper decoder output: {e}"))?;
+            let logits = self
+                .model
+                .decoder_final_linear(
+                    &decoded
+                        .i((..1, seq_len - 1..))
+                        .map_err(|e| format!("Failed to slice Whisper logits: {e}"))?,
+                )
+                .and_then(|logits| logits.i(0))
+                .and_then(|logits| logits.i(0))
+                .and_then(|logits| logits.broadcast_add(&self.suppress_tokens))
+                .map_err(|e| format!("Whisper logits failed: {e}"))?;
+            let (next_token, next_prob) = greedy_token_with_prob(&logits)?;
+            tokens.push(next_token);
+            if next_token == self.eot_token {
+                break;
+            }
+            generated_tokens += 1;
+            if next_prob > 0.0 {
+                sum_logprob += next_prob.ln();
+            }
+        }
+
+        let text = self
+            .tokenizer
+            .decode(&tokens, true)
+            .map(|text| text.trim().to_string())
+            .map_err(|e| format!("Failed to decode Whisper tokens: {e}"))?;
+        Ok(WhisperDecodingResult {
+            text,
+            avg_logprob: sum_logprob / generated_tokens.max(1) as f64,
+            no_speech_prob,
+        })
+    }
+}
+
+fn decoder_prompt_tokens(
+    sot_token: u32,
+    language_token: Option<u32>,
+    transcribe_token: u32,
+    no_timestamps_token: u32,
+) -> Vec<u32> {
+    let mut tokens = vec![sot_token];
+    if let Some(language_token) = language_token {
+        tokens.push(language_token);
+    }
+    tokens.push(transcribe_token);
+    tokens.push(no_timestamps_token);
+    tokens
+}
+
+fn greedy_token_with_prob(logits: &Tensor) -> Result<(u32, f64), String> {
+    let probs = softmax(logits, D::Minus1).map_err(|e| format!("Whisper softmax failed: {e}"))?;
+    let values = probs
+        .to_vec1::<f32>()
+        .map_err(|e| format!("Failed to read Whisper logits: {e}"))?;
+    values
+        .iter()
+        .enumerate()
+        .max_by(|(_, left), (_, right)| left.total_cmp(right))
+        .map(|(index, prob)| (index as u32, f64::from(*prob)))
+        .ok_or_else(|| "Whisper returned no token logits".to_string())
+}
+
+fn token_id(tokenizer: &Tokenizer, token: &str) -> Result<u32, String> {
+    tokenizer
+        .token_to_id(token)
+        .ok_or_else(|| format!("Whisper tokenizer is missing token {token}"))
+}
+
+fn transcribe_distil_whisper(
+    cache_path: &Path,
+    captured: CapturedAudio,
+    cancel: &Arc<AtomicBool>,
+) -> Result<String, String> {
+    if captured.sample_rate != TARGET_SAMPLE_RATE {
+        return Err(format!(
+            "Expected {TARGET_SAMPLE_RATE} Hz audio, got {} Hz",
+            captured.sample_rate
+        ));
+    }
+    if !distil_model_ready(cache_path) {
+        return Err("Distil-Whisper model files are incomplete".to_string());
+    }
+
+    let config_path = cache_path.join("config.json");
+    let tokenizer_path = cache_path.join("tokenizer.json");
+    let weights_path = cache_path.join("model.safetensors");
+    let config: Config = serde_json::from_str(
+        &std::fs::read_to_string(&config_path)
+            .map_err(|e| format!("Failed to read Whisper config: {e}"))?,
+    )
+    .map_err(|e| format!("Failed to parse Whisper config: {e}"))?;
+    let tokenizer = Tokenizer::from_file(&tokenizer_path)
+        .map_err(|e| format!("Failed to load tokenizer: {e}"))?;
+    let backend = ensure_candle_backend_ready()?;
+    let (device, _) = select_candle_device()?;
+    let backend_label = backend.label();
+    let mel_filters = build_mel_filters(config.num_mel_bins);
+    let mel = audio::pcm_to_mel(&config, &captured.samples, &mel_filters);
+    let mel_len = mel.len() / config.num_mel_bins;
+    let mel = Tensor::from_vec(mel, (1, config.num_mel_bins, mel_len), &device)
+        .map_err(|e| format!("Failed to build Whisper mel tensor on {backend_label}: {e}"))?;
+    let var_builder =
+        unsafe { VarBuilder::from_mmaped_safetensors(&[weights_path], whisper::DTYPE, &device) }
+            .map_err(|e| format!("Failed to load Whisper weights on {backend_label}: {e}"))?;
+    let model = whisper::model::Whisper::load(&var_builder, config)
+        .map_err(|e| format!("Failed to initialize Whisper model on {backend_label}: {e}"))?;
+    let mut decoder = WhisperDecoder::new(WhisperModel::Normal(model), tokenizer, &device)?;
+    decoder
+        .run(&mel, cancel)
+        .map_err(|e| format!("Whisper transcription failed on {backend_label}: {e}"))
+}
+
+fn build_mel_filters(num_mel_bins: usize) -> Vec<f32> {
+    let freq_bins = whisper::N_FFT / 2 + 1;
+    let min_mel = hz_to_mel(0.0);
+    let max_mel = hz_to_mel(TARGET_SAMPLE_RATE as f32 / 2.0);
+    let mel_points = (0..num_mel_bins + 2)
+        .map(|index| {
+            let fraction = index as f32 / (num_mel_bins + 1) as f32;
+            mel_to_hz(min_mel + fraction * (max_mel - min_mel))
+        })
+        .collect::<Vec<_>>();
+    let fft_freqs = (0..freq_bins)
+        .map(|index| index as f32 * TARGET_SAMPLE_RATE as f32 / whisper::N_FFT as f32)
+        .collect::<Vec<_>>();
+    let mut filters = vec![0.0; num_mel_bins * freq_bins];
+
+    for mel_index in 0..num_mel_bins {
+        let left = mel_points[mel_index];
+        let center = mel_points[mel_index + 1];
+        let right = mel_points[mel_index + 2];
+        for (freq_index, freq) in fft_freqs.iter().copied().enumerate() {
+            let value = if freq < left || freq > right {
+                0.0
+            } else if freq <= center {
+                (freq - left) / (center - left)
+            } else {
+                (right - freq) / (right - center)
+            };
+            filters[mel_index * freq_bins + freq_index] = value.max(0.0);
+        }
+    }
+
+    filters
+}
+
+fn hz_to_mel(hz: f32) -> f32 {
+    2595.0 * (1.0 + hz / 700.0).log10()
+}
+
+fn mel_to_hz(mel: f32) -> f32 {
+    700.0 * (10_f32.powf(mel / 2595.0) - 1.0)
+}
+
+async fn download_distil_model(
+    app: &AppHandle,
+    provider_id: &str,
+    cache_path: &Path,
+) -> Result<(), String> {
+    let known_total = DISTIL_MODEL_FILES
+        .iter()
+        .filter_map(|(_, size)| *size)
+        .sum::<u64>();
+    let mut overall_downloaded = 0_u64;
+    let client = reqwest::Client::new();
+
+    for (filename, known_size) in DISTIL_MODEL_FILES {
+        let destination = cache_path.join(filename);
+        if destination.is_file() {
+            overall_downloaded += destination.metadata().map(|m| m.len()).unwrap_or(0);
+            continue;
+        }
+
+        let url = format!(
+            "https://huggingface.co/distil-whisper/distil-large-v3/resolve/main/{filename}"
+        );
+        let response = client
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| format!("Failed to download {filename}: {e}"))?
+            .error_for_status()
+            .map_err(|e| format!("Failed to download {filename}: {e}"))?;
+
+        let total = response.content_length().or(known_size);
+        let part_path = destination.with_extension("part");
+        let mut file = tokio::fs::File::create(&part_path)
+            .await
+            .map_err(|e| format!("Failed to write {filename}: {e}"))?;
+        let mut stream = response.bytes_stream();
+        let mut downloaded = 0_u64;
+
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.map_err(|e| format!("Failed while downloading {filename}: {e}"))?;
+            file.write_all(&chunk)
+                .await
+                .map_err(|e| format!("Failed to write {filename}: {e}"))?;
+            downloaded += chunk.len() as u64;
+            let denominator = known_total.max(total.unwrap_or(0));
+            let percent = if denominator > 0 {
+                Some(((overall_downloaded + downloaded) as f64 / denominator as f64).min(1.0))
+            } else {
+                None
+            };
+            let _ = app.emit(
+                "voice-download-progress",
+                VoiceDownloadProgress {
+                    provider_id: provider_id.to_string(),
+                    filename: filename.to_string(),
+                    downloaded_bytes: downloaded,
+                    total_bytes: total,
+                    overall_downloaded_bytes: overall_downloaded + downloaded,
+                    overall_total_bytes: if known_total > 0 {
+                        Some(known_total)
+                    } else {
+                        None
+                    },
+                    percent,
+                },
+            );
+        }
+        file.flush()
+            .await
+            .map_err(|e| format!("Failed to flush {filename}: {e}"))?;
+        tokio::fs::rename(&part_path, &destination)
+            .await
+            .map_err(|e| format!("Failed to finalize {filename}: {e}"))?;
+        overall_downloaded += downloaded;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tempfile::tempdir;
+
+    fn test_db_path() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempdir().expect("tempdir");
+        let db_path = dir.path().join("voice.json");
+        let db = VoiceSettings::open(&db_path).expect("open db");
+        drop(db);
+        (dir, db_path)
+    }
+
+    fn open_test_db(path: &Path) -> VoiceSettings {
+        VoiceSettings::open(path).expect("open db")
+    }
+
+    fn write_complete_distil_model(cache_path: &Path) {
+        std::fs::create_dir_all(cache_path).expect("create model cache");
+        std::fs::write(cache_path.join("tokenizer.json"), "{}").expect("write tokenizer");
+        std::fs::write(cache_path.join("config.json"), "{}").expect("write config");
+        std::fs::write(cache_path.join("generation_config.json"), "{}")
+            .expect("write generation config");
+        std::fs::write(cache_path.join("preprocessor_config.json"), "{}")
+            .expect("write preprocessor config");
+        let model_file =
+            std::fs::File::create(cache_path.join("model.safetensors")).expect("create model");
+        model_file.set_len(100_000_001).expect("size model");
+    }
+
+    #[cfg(target_os = "macos")]
+    fn run_minimal_whisper_forward(device: &Device) -> Result<(), String> {
+        let config = Config {
+            num_mel_bins: 4,
+            max_source_positions: 4,
+            d_model: 8,
+            encoder_attention_heads: 2,
+            encoder_layers: 1,
+            vocab_size: 16,
+            max_target_positions: 4,
+            decoder_attention_heads: 2,
+            decoder_layers: 1,
+            suppress_tokens: Vec::new(),
+        };
+        let vb = VarBuilder::zeros(whisper::DTYPE, device);
+        let mut model = whisper::model::Whisper::load(&vb, config.clone())
+            .map_err(|e| format!("load minimal whisper: {e}"))?;
+        let mel = Tensor::zeros(
+            (1, config.num_mel_bins, config.max_source_positions * 2),
+            whisper::DTYPE,
+            device,
+        )
+        .map_err(|e| format!("build minimal mel: {e}"))?;
+        let audio_features = model
+            .encoder
+            .forward(&mel, true)
+            .map_err(|e| format!("minimal encoder forward: {e}"))?;
+        let tokens =
+            Tensor::new(&[[1_u32]], device).map_err(|e| format!("build minimal tokens: {e}"))?;
+        let decoded = model
+            .decoder
+            .forward(&tokens, &audio_features, true)
+            .map_err(|e| format!("minimal decoder forward: {e}"))?;
+        let logits = model
+            .decoder
+            .final_linear(&decoded)
+            .map_err(|e| format!("minimal decoder logits: {e}"))?;
+        let _ = logits
+            .to_vec3::<f32>()
+            .map_err(|e| format!("read minimal logits: {e}"))?;
+        Ok(())
+    }
+
+    fn read_wav_fixture(path: &Path) -> Result<CapturedAudio, String> {
+        let mut reader =
+            hound::WavReader::open(path).map_err(|e| format!("Failed to open WAV fixture: {e}"))?;
+        let spec = reader.spec();
+        if spec.channels == 0 {
+            return Err("WAV fixture has no audio channels".to_string());
+        }
+
+        let samples = match (spec.sample_format, spec.bits_per_sample) {
+            (hound::SampleFormat::Float, 32) => {
+                let samples = reader
+                    .samples::<f32>()
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(|e| format!("Failed to read f32 WAV samples: {e}"))?;
+                normalize_interleaved_f32(&samples, spec.channels)
+            }
+            (hound::SampleFormat::Int, 16) => {
+                let samples = reader
+                    .samples::<i16>()
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(|e| format!("Failed to read i16 WAV samples: {e}"))?;
+                normalize_interleaved_i16(&samples, spec.channels)
+            }
+            (hound::SampleFormat::Int, 24 | 32) => {
+                let samples = reader
+                    .samples::<i32>()
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(|e| format!("Failed to read i32 WAV samples: {e}"))?;
+                normalize_interleaved_i32(&samples, spec.channels)
+            }
+            (sample_format, bits) => {
+                return Err(format!(
+                    "Unsupported WAV fixture format: {sample_format:?} {bits}-bit"
+                ));
+            }
+        };
+
+        Ok(CapturedAudio {
+            samples: resample_to_target_rate(&samples, spec.sample_rate),
+            sample_rate: TARGET_SAMPLE_RATE,
+        })
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn candle_metal_feature_is_enabled_on_macos() {
+        assert!(candle_core::utils::metal_is_available());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn candle_metal_layer_norm_runs_on_macos() {
+        let device = Device::new_metal(0).expect("metal device");
+        let xs = Tensor::new(&[[1.0_f32, 2.0], [3.0, 4.0]], &device).expect("input tensor");
+        let alpha = Tensor::new(&[1.0_f32, 1.0], &device).expect("alpha tensor");
+        let beta = Tensor::new(&[0.0_f32, 0.0], &device).expect("beta tensor");
+
+        candle_nn::ops::layer_norm(&xs, &alpha, &beta, 1e-5).expect("metal layer norm should run");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn candle_metal_whisper_ops_probe_runs_on_macos() {
+        let device = Device::new_metal(0).expect("metal device");
+
+        verify_candle_whisper_backend(&device).expect("metal whisper op probe should run");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn minimal_whisper_forward_runs_on_selected_metal_backend() {
+        let device = Device::new_metal(0).expect("metal device");
+
+        run_minimal_whisper_forward(&device).expect("minimal whisper forward should run");
+    }
+
+    #[test]
+    fn distil_provider_reports_engine_unavailable_when_backend_probe_fails() {
+        let (_db_dir, db_path) = test_db_path();
+        let model_dir = tempdir().expect("model dir");
+        write_complete_distil_model(&model_dir.path().join(DISTIL_CACHE_DIR));
+        let db = open_test_db(&db_path);
+        let registry = VoiceProviderRegistry::with_runtime_and_backend(
+            model_dir.path().to_path_buf(),
+            Arc::new(FakeRecorder::new(vec![0.1])),
+            Arc::new(FakeTranscriber::ok("ignored")),
+            Arc::new(FakeBackendChecker::err(
+                "Candle Metal Whisper backend failed layer_norm: test failure",
+            )),
+        );
+
+        let provider = registry
+            .list_providers(&db)
+            .into_iter()
+            .find(|provider| provider.metadata.id == DISTIL_ID)
+            .expect("distil provider");
+
+        assert_eq!(provider.status, VoiceProviderStatus::EngineUnavailable);
+        assert!(!provider.setup_required);
+        assert!(
+            provider
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("failed layer_norm"))
+        );
+    }
+
+    #[test]
+    fn distil_provider_skips_backend_probe_when_disabled() {
+        let (_db_dir, db_path) = test_db_path();
+        let model_dir = tempdir().expect("model dir");
+        let db = open_test_db(&db_path);
+        db.set_app_setting(&enabled_key(DISTIL_ID), "false")
+            .expect("disable");
+        let checker = Arc::new(CountingBackendChecker::new());
+        let registry = VoiceProviderRegistry::with_runtime_and_backend(
+            model_dir.path().to_path_buf(),
+            Arc::new(FakeRecorder::new(vec![0.1])),
+            Arc::new(FakeTranscriber::ok("ignored")),
+            checker.clone(),
+        );
+
+        let provider = registry
+            .list_providers(&db)
+            .into_iter()
+            .find(|p| p.metadata.id == DISTIL_ID)
+            .expect("distil provider");
+
+        assert_eq!(provider.status, VoiceProviderStatus::Unavailable);
+        assert_eq!(
+            checker.call_count(),
+            0,
+            "backend probe should not be called for disabled provider"
+        );
+        assert!(provider.metadata.accelerator_label.is_none());
+    }
+
+    #[test]
+    #[ignore = "requires local Distil-Whisper cache and AETHON_VOICE_SAMPLE_WAV"]
+    fn ignored_real_model_probe_transcribes_fixture_wav() {
+        let cache_path = std::env::var_os("CLAUDETTE_VOICE_MODEL_CACHE")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| {
+                PathBuf::from("/Users/jamesbrink/.aethon/models/voice/distil-whisper-large-v3")
+            });
+        let sample_path = std::env::var_os("AETHON_VOICE_SAMPLE_WAV")
+            .map(PathBuf::from)
+            .expect("set AETHON_VOICE_SAMPLE_WAV to a short speech WAV");
+        let audio = read_wav_fixture(&sample_path).expect("read speech wav");
+
+        let cancel = Arc::new(AtomicBool::new(false));
+        let transcript =
+            transcribe_distil_whisper(&cache_path, audio, &cancel).expect("transcribe fixture");
+
+        assert!(!transcript.trim().is_empty());
+    }
+
+    struct FakeRecorder {
+        starts: AtomicUsize,
+        samples: Vec<f32>,
+        sample_rate: u32,
+        stream_error: Option<String>,
+    }
+
+    impl FakeRecorder {
+        fn new(samples: Vec<f32>) -> Self {
+            Self {
+                starts: AtomicUsize::new(0),
+                samples,
+                sample_rate: TARGET_SAMPLE_RATE,
+                stream_error: None,
+            }
+        }
+
+        fn new_with_stream_error(samples: Vec<f32>, stream_error: impl Into<String>) -> Self {
+            Self {
+                starts: AtomicUsize::new(0),
+                samples,
+                sample_rate: TARGET_SAMPLE_RATE,
+                stream_error: Some(stream_error.into()),
+            }
+        }
+    }
+
+    impl AudioRecorder for FakeRecorder {
+        fn start(&self) -> Result<RecordingSession, String> {
+            self.starts.fetch_add(1, Ordering::Relaxed);
+            if let Some(stream_error) = &self.stream_error {
+                return Ok(RecordingSession::from_samples_with_stream_error(
+                    self.samples.clone(),
+                    self.sample_rate,
+                    stream_error.clone(),
+                ));
+            }
+            Ok(RecordingSession::from_samples(
+                self.samples.clone(),
+                self.sample_rate,
+            ))
+        }
+    }
+
+    struct FakeTranscriber {
+        calls: AtomicUsize,
+        result: Mutex<Result<String, String>>,
+        sleep_for: std::time::Duration,
+    }
+
+    impl FakeTranscriber {
+        fn ok(text: &str) -> Self {
+            Self {
+                calls: AtomicUsize::new(0),
+                result: Mutex::new(Ok(text.to_string())),
+                sleep_for: std::time::Duration::ZERO,
+            }
+        }
+
+        fn err(message: &str) -> Self {
+            Self {
+                calls: AtomicUsize::new(0),
+                result: Mutex::new(Err(message.to_string())),
+                sleep_for: std::time::Duration::ZERO,
+            }
+        }
+
+        fn slow(text: &str, sleep_for: std::time::Duration) -> Self {
+            Self {
+                calls: AtomicUsize::new(0),
+                result: Mutex::new(Ok(text.to_string())),
+                sleep_for,
+            }
+        }
+    }
+
+    impl VoiceTranscriber for FakeTranscriber {
+        fn transcribe(
+            &self,
+            _cache_path: &Path,
+            _audio: CapturedAudio,
+            cancel: &Arc<AtomicBool>,
+        ) -> Result<String, String> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            // Poll the cancel flag at coarse intervals to mirror how the real
+            // Whisper decoder checks between segments — lets tests exercise the
+            // cancellation path without changing the production loop.
+            let step = std::time::Duration::from_millis(10);
+            let mut remaining = self.sleep_for;
+            while remaining > std::time::Duration::ZERO {
+                if cancel.load(Ordering::Relaxed) {
+                    return Err("Transcription cancelled.".to_string());
+                }
+                let nap = std::cmp::min(step, remaining);
+                std::thread::sleep(nap);
+                remaining = remaining.saturating_sub(nap);
+            }
+            self.result.lock().clone()
+        }
+    }
+
+    struct FakeBackendChecker {
+        result: Result<CandleBackend, String>,
+    }
+
+    impl FakeBackendChecker {
+        fn err(message: &str) -> Self {
+            Self {
+                result: Err(message.to_string()),
+            }
+        }
+    }
+
+    impl CandleBackendChecker for FakeBackendChecker {
+        fn ready_backend(&self) -> Result<CandleBackend, String> {
+            self.result.clone()
+        }
+    }
+
+    struct CountingBackendChecker {
+        calls: AtomicUsize,
+    }
+
+    impl CountingBackendChecker {
+        fn new() -> Self {
+            Self {
+                calls: AtomicUsize::new(0),
+            }
+        }
+
+        fn call_count(&self) -> usize {
+            self.calls.load(Ordering::Relaxed)
+        }
+    }
+
+    impl CandleBackendChecker for CountingBackendChecker {
+        fn ready_backend(&self) -> Result<CandleBackend, String> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            #[cfg(target_os = "macos")]
+            return Ok(CandleBackend::Metal);
+            #[cfg(not(target_os = "macos"))]
+            return Ok(CandleBackend::Cpu);
+        }
+    }
+
+    #[cfg(any(target_os = "macos", windows))]
+    struct PrepareGate {
+        entered: std::sync::mpsc::Sender<()>,
+        release: Mutex<Option<std::sync::mpsc::Receiver<()>>>,
+    }
+
+    #[cfg(any(target_os = "macos", windows))]
+    struct FakePlatformSpeechEngine {
+        availability: PlatformSpeechAvailability,
+        prepare_availability: PlatformSpeechAvailability,
+        transcript: Mutex<Result<String, String>>,
+        prepare_gate: Option<PrepareGate>,
+        prepare_calls: AtomicUsize,
+        calls: AtomicUsize,
+    }
+
+    #[cfg(any(target_os = "macos", windows))]
+    impl FakePlatformSpeechEngine {
+        fn ready(engine_label: &str) -> Self {
+            let availability = PlatformSpeechAvailability::ready(engine_label);
+            Self {
+                availability: availability.clone(),
+                prepare_availability: availability,
+                transcript: Mutex::new(Ok("platform transcript".to_string())),
+                prepare_gate: None,
+                prepare_calls: AtomicUsize::new(0),
+                calls: AtomicUsize::new(0),
+            }
+        }
+
+        fn needs_speech_permission() -> Self {
+            let availability = PlatformSpeechAvailability::needs_speech_permission(
+                "Needs Speech Recognition permission",
+            );
+            Self {
+                availability: availability.clone(),
+                prepare_availability: availability,
+                transcript: Mutex::new(Ok("ignored".to_string())),
+                prepare_gate: None,
+                prepare_calls: AtomicUsize::new(0),
+                calls: AtomicUsize::new(0),
+            }
+        }
+
+        fn needs_speech_permission_then_ready() -> Self {
+            Self {
+                availability: PlatformSpeechAvailability::needs_speech_permission(
+                    "Needs Speech Recognition permission",
+                ),
+                prepare_availability: PlatformSpeechAvailability::ready("Apple Speech"),
+                transcript: Mutex::new(Ok("ignored".to_string())),
+                prepare_gate: None,
+                prepare_calls: AtomicUsize::new(0),
+                calls: AtomicUsize::new(0),
+            }
+        }
+
+        fn with_prepare_gate(
+            mut self,
+            entered: std::sync::mpsc::Sender<()>,
+            release: std::sync::mpsc::Receiver<()>,
+        ) -> Self {
+            self.prepare_gate = Some(PrepareGate {
+                entered,
+                release: Mutex::new(Some(release)),
+            });
+            self
+        }
+    }
+
+    #[cfg(any(target_os = "macos", windows))]
+    impl PlatformSpeechEngine for FakePlatformSpeechEngine {
+        fn availability(&self) -> PlatformSpeechAvailability {
+            self.availability.clone()
+        }
+
+        fn prepare(&self) -> PlatformSpeechAvailability {
+            self.prepare_calls.fetch_add(1, Ordering::Relaxed);
+            if let Some(gate) = &self.prepare_gate {
+                let _ = gate.entered.send(());
+                if let Some(release) = gate.release.lock().take() {
+                    let _ = release.recv();
+                }
+            }
+            self.prepare_availability.clone()
+        }
+
+        fn transcribe(&self, _audio: CapturedAudio) -> Result<String, String> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            self.transcript.lock().clone()
+        }
+    }
+
+    #[test]
+    fn distil_cache_path_uses_provider_specific_directory() {
+        let root = PathBuf::from("/tmp/aethon-test-models");
+        let registry = VoiceProviderRegistry::new(root.clone());
+
+        assert_eq!(
+            registry.distil_cache_path(),
+            root.join("distil-whisper-large-v3")
+        );
+    }
+
+    #[test]
+    fn selected_provider_is_persisted_and_reflected_in_status() {
+        let (_dir, db_path) = test_db_path();
+        let db = open_test_db(&db_path);
+        let registry = VoiceProviderRegistry::new(PathBuf::from("/tmp/models"));
+
+        registry
+            .set_selected_provider(&db, Some(DISTIL_ID))
+            .expect("set selected provider");
+
+        let providers = registry.list_providers(&db);
+        assert!(
+            providers
+                .iter()
+                .any(|provider| provider.metadata.id == DISTIL_ID && provider.selected)
+        );
+        assert!(
+            providers
+                .iter()
+                .any(|provider| provider.metadata.id == PLATFORM_ID && !provider.selected)
+        );
+    }
+
+    #[test]
+    fn disabled_provider_reports_unavailable() {
+        let (_dir, db_path) = test_db_path();
+        let db = open_test_db(&db_path);
+        let registry = VoiceProviderRegistry::new(PathBuf::from("/tmp/models"));
+
+        registry
+            .set_enabled(&db, PLATFORM_ID, false)
+            .expect("disable platform provider");
+
+        let provider = registry
+            .list_providers(&db)
+            .into_iter()
+            .find(|provider| provider.metadata.id == PLATFORM_ID)
+            .expect("platform provider");
+        assert_eq!(provider.status, VoiceProviderStatus::Unavailable);
+        assert!(!provider.enabled);
+        assert!(!provider.setup_required);
+    }
+
+    #[cfg(any(target_os = "macos", windows))]
+    #[test]
+    fn platform_provider_ready_when_native_engine_ready() {
+        let (_dir, db_path) = test_db_path();
+        let db = open_test_db(&db_path);
+        let registry = VoiceProviderRegistry::with_platform_runtime(
+            PathBuf::from("/tmp/models"),
+            Arc::new(FakeRecorder::new(vec![0.1])),
+            Arc::new(FakeTranscriber::ok("ignored")),
+            Arc::new(FakePlatformSpeechEngine::ready("Test Engine")),
+        );
+
+        let provider = registry
+            .list_providers(&db)
+            .into_iter()
+            .find(|provider| provider.metadata.id == PLATFORM_ID)
+            .expect("platform provider");
+
+        assert_eq!(provider.status, VoiceProviderStatus::Ready);
+        assert!(provider.enabled);
+        assert!(!provider.setup_required);
+        assert_eq!(provider.metadata.recording_mode, VoiceRecordingMode::Native);
+        assert!(provider.status_label.contains("Test Engine"));
+    }
+
+    #[cfg(any(target_os = "macos", windows))]
+    #[test]
+    fn platform_provider_reports_setup_required_for_speech_permission() {
+        let (_dir, db_path) = test_db_path();
+        let db = open_test_db(&db_path);
+        let registry = VoiceProviderRegistry::with_platform_runtime(
+            PathBuf::from("/tmp/models"),
+            Arc::new(FakeRecorder::new(vec![0.1])),
+            Arc::new(FakeTranscriber::ok("ignored")),
+            Arc::new(FakePlatformSpeechEngine::needs_speech_permission()),
+        );
+
+        registry
+            .set_selected_provider(&db, Some(PLATFORM_ID))
+            .expect("select platform provider");
+
+        let provider = registry
+            .list_providers(&db)
+            .into_iter()
+            .find(|provider| provider.metadata.id == PLATFORM_ID)
+            .expect("platform provider");
+
+        assert_eq!(provider.status, VoiceProviderStatus::NeedsSetup);
+        assert!(provider.enabled);
+        assert!(provider.selected);
+        assert!(provider.setup_required);
+        assert!(
+            provider
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("Speech Recognition"))
+        );
+    }
+
+    #[test]
+    fn missing_distil_model_requires_setup() {
+        let (_db_dir, db_path) = test_db_path();
+        let model_dir = tempdir().expect("model dir");
+        let db = open_test_db(&db_path);
+        let registry = VoiceProviderRegistry::new(model_dir.path().to_path_buf());
+
+        let provider = registry
+            .list_providers(&db)
+            .into_iter()
+            .find(|provider| provider.metadata.id == DISTIL_ID)
+            .expect("distil provider");
+
+        assert_eq!(provider.status, VoiceProviderStatus::NeedsSetup);
+        assert!(provider.setup_required);
+        assert!(!provider.can_remove_model);
+    }
+
+    #[test]
+    fn complete_distil_model_reports_ready() {
+        let (_db_dir, db_path) = test_db_path();
+        let model_dir = tempdir().expect("model dir");
+        let cache_path = model_dir.path().join(DISTIL_CACHE_DIR);
+        write_complete_distil_model(&cache_path);
+
+        let db = open_test_db(&db_path);
+        let registry = VoiceProviderRegistry::new(model_dir.path().to_path_buf());
+        let provider = registry
+            .list_providers(&db)
+            .into_iter()
+            .find(|provider| provider.metadata.id == DISTIL_ID)
+            .expect("distil provider");
+
+        assert_eq!(provider.status, VoiceProviderStatus::Ready);
+        assert!(!provider.setup_required);
+        assert!(provider.can_remove_model);
+        assert_eq!(provider.error, None);
+    }
+
+    #[test]
+    fn incomplete_distil_manifest_requires_setup() {
+        let (_db_dir, db_path) = test_db_path();
+        let model_dir = tempdir().expect("model dir");
+        let cache_path = model_dir.path().join(DISTIL_CACHE_DIR);
+        std::fs::create_dir_all(&cache_path).expect("create model cache");
+        std::fs::write(cache_path.join("tokenizer.json"), "{}").expect("write tokenizer");
+        std::fs::write(cache_path.join("config.json"), "{}").expect("write config");
+        let model_file =
+            std::fs::File::create(cache_path.join("model.safetensors")).expect("create model");
+        model_file.set_len(100_000_001).expect("size model");
+
+        let db = open_test_db(&db_path);
+        let registry = VoiceProviderRegistry::new(model_dir.path().to_path_buf());
+        let provider = registry
+            .list_providers(&db)
+            .into_iter()
+            .find(|provider| provider.metadata.id == DISTIL_ID)
+            .expect("distil provider");
+
+        assert_eq!(provider.status, VoiceProviderStatus::NeedsSetup);
+        assert!(provider.setup_required);
+        assert!(!provider.can_remove_model);
+    }
+
+    #[test]
+    fn sample_conversion_handles_formats_and_channels() {
+        assert_eq!(normalize_interleaved_f32(&[], 1), Vec::<f32>::new());
+        assert_eq!(
+            normalize_interleaved_f32(&[0.5, -0.25], 1),
+            vec![0.5, -0.25]
+        );
+        assert_eq!(
+            normalize_interleaved_i16(&[i16::MAX, i16::MIN], 2),
+            vec![(-1.0 + 0.9999695) / 2.0]
+        );
+        assert_eq!(
+            normalize_interleaved_u16(&[u16::MIN, u16::MAX], 2),
+            vec![(-1.0 + 0.9999695) / 2.0]
+        );
+        assert_eq!(
+            normalize_interleaved_i32(&[i32::MAX, i32::MIN], 2),
+            vec![(1.0 + -1.0) / 2.0]
+        );
+        assert_eq!(
+            normalize_interleaved_u8(&[u8::MIN, u8::MAX], 2),
+            vec![(-1.0 + 0.9921875) / 2.0]
+        );
+        assert_eq!(normalize_interleaved_f64(&[1.5, -1.5], 2), vec![0.0]);
+    }
+
+    #[test]
+    fn decoder_prompt_includes_language_token_when_available() {
+        assert_eq!(decoder_prompt_tokens(1, Some(2), 3, 4), vec![1, 2, 3, 4]);
+        assert_eq!(decoder_prompt_tokens(1, None, 3, 4), vec![1, 3, 4]);
+    }
+
+    #[test]
+    fn resample_to_target_rate_keeps_target_rate_unchanged() {
+        let samples = vec![0.0, 0.5, 1.0];
+        assert_eq!(
+            resample_to_target_rate(&samples, TARGET_SAMPLE_RATE),
+            samples
+        );
+    }
+
+    #[tokio::test]
+    async fn start_distil_recording_rejects_disabled_provider() {
+        let (_db_dir, db_path) = test_db_path();
+        let model_dir = tempdir().expect("model dir");
+        write_complete_distil_model(&model_dir.path().join(DISTIL_CACHE_DIR));
+        let db = open_test_db(&db_path);
+        db.set_app_setting(&enabled_key(DISTIL_ID), "false")
+            .expect("disable provider");
+        drop(db);
+
+        let registry = VoiceProviderRegistry::with_runtime(
+            model_dir.path().to_path_buf(),
+            Arc::new(FakeRecorder::new(vec![0.1])),
+            Arc::new(FakeTranscriber::ok("ignored")),
+        );
+
+        let err = registry
+            .start_recording(&db_path, DISTIL_ID, None)
+            .await
+            .expect_err("disabled provider should not record");
+        assert!(err.contains("disabled"));
+    }
+
+    #[tokio::test]
+    async fn start_distil_recording_rejects_missing_model() {
+        let (_db_dir, db_path) = test_db_path();
+        let model_dir = tempdir().expect("model dir");
+        let registry = VoiceProviderRegistry::with_runtime(
+            model_dir.path().to_path_buf(),
+            Arc::new(FakeRecorder::new(vec![0.1])),
+            Arc::new(FakeTranscriber::ok("ignored")),
+        );
+
+        let err = registry
+            .start_recording(&db_path, DISTIL_ID, None)
+            .await
+            .expect_err("missing model should not record");
+        assert!(err.contains("Download"));
+    }
+
+    #[tokio::test]
+    async fn start_distil_recording_rejects_already_active_recording() {
+        let (_db_dir, db_path) = test_db_path();
+        let model_dir = tempdir().expect("model dir");
+        write_complete_distil_model(&model_dir.path().join(DISTIL_CACHE_DIR));
+        let recorder = Arc::new(FakeRecorder::new(vec![0.1]));
+        let registry = VoiceProviderRegistry::with_runtime(
+            model_dir.path().to_path_buf(),
+            recorder.clone(),
+            Arc::new(FakeTranscriber::ok("ignored")),
+        );
+
+        registry
+            .start_recording(&db_path, DISTIL_ID, None)
+            .await
+            .expect("first recording starts");
+        let err = registry
+            .start_recording(&db_path, DISTIL_ID, None)
+            .await
+            .expect_err("second recording should fail");
+
+        assert!(err.contains("already active"));
+        assert_eq!(recorder.starts.load(Ordering::Relaxed), 1);
+    }
+
+    #[cfg(any(target_os = "macos", windows))]
+    #[tokio::test]
+    async fn start_platform_recording_prepares_permission_on_user_action() {
+        let (_db_dir, db_path) = test_db_path();
+        let platform_engine =
+            Arc::new(FakePlatformSpeechEngine::needs_speech_permission_then_ready());
+        let recorder = Arc::new(FakeRecorder::new(vec![0.1, 0.2, 0.3]));
+        let registry = VoiceProviderRegistry::with_platform_runtime(
+            PathBuf::from("/tmp/models"),
+            recorder.clone(),
+            Arc::new(FakeTranscriber::ok("ignored")),
+            platform_engine.clone(),
+        );
+
+        let db = open_test_db(&db_path);
+        let provider = registry
+            .list_providers(&db)
+            .into_iter()
+            .find(|provider| provider.metadata.id == PLATFORM_ID)
+            .expect("platform provider");
+        assert_eq!(provider.status, VoiceProviderStatus::NeedsSetup);
+        assert_eq!(platform_engine.prepare_calls.load(Ordering::Relaxed), 0);
+        drop(db);
+
+        registry
+            .start_recording(&db_path, PLATFORM_ID, None)
+            .await
+            .expect("platform recording starts after prepare");
+
+        assert_eq!(platform_engine.prepare_calls.load(Ordering::Relaxed), 1);
+        assert_eq!(recorder.starts.load(Ordering::Relaxed), 1);
+    }
+
+    #[cfg(any(target_os = "macos", windows))]
+    #[tokio::test(flavor = "current_thread")]
+    async fn start_platform_recording_prepares_permission_off_runtime_thread() {
+        let (_db_dir, db_path) = test_db_path();
+        let (entered_tx, entered_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let release_watchdog = release_tx.clone();
+        let released = Arc::new(AtomicBool::new(false));
+        let watchdog_released = Arc::clone(&released);
+        let watchdog = std::thread::spawn(move || {
+            if entered_rx.recv_timeout(Duration::from_secs(5)).is_ok() {
+                for _ in 0..50 {
+                    if watchdog_released.load(Ordering::Relaxed) {
+                        return;
+                    }
+                    std::thread::sleep(Duration::from_millis(20));
+                }
+                let _ = release_watchdog.send(());
+            }
+        });
+
+        let platform_engine = Arc::new(
+            FakePlatformSpeechEngine::needs_speech_permission_then_ready()
+                .with_prepare_gate(entered_tx, release_rx),
+        );
+        let registry = Arc::new(VoiceProviderRegistry::with_platform_runtime(
+            PathBuf::from("/tmp/models"),
+            Arc::new(FakeRecorder::new(vec![0.1, 0.2, 0.3])),
+            Arc::new(FakeTranscriber::ok("ignored")),
+            platform_engine,
+        ));
+
+        let start_registry = Arc::clone(&registry);
+        let handle = tokio::spawn(async move {
+            start_registry
+                .start_recording(&db_path, PLATFORM_ID, None)
+                .await
+        });
+
+        let liveness = tokio::spawn(async {
+            tokio::task::yield_now().await;
+        });
+        tokio::time::timeout(Duration::from_secs(1), liveness)
+            .await
+            .expect("async runtime must stay live while permission prepare is pending")
+            .expect("liveness task joined");
+
+        assert!(
+            !handle.is_finished(),
+            "recording start must still be waiting for permission prepare"
+        );
+        released.store(true, Ordering::Relaxed);
+        release_tx.send(()).expect("release permission prepare");
+        handle
+            .await
+            .expect("recording task joined")
+            .expect("platform recording starts after prepare");
+        watchdog.join().expect("watchdog joined");
+    }
+
+    #[cfg(any(target_os = "macos", windows))]
+    #[tokio::test]
+    async fn start_then_stop_platform_recording_returns_transcript() {
+        let (_db_dir, db_path) = test_db_path();
+        let platform_engine = Arc::new(FakePlatformSpeechEngine::ready("Test Engine"));
+        *platform_engine.transcript.lock() = Ok("spoken platform words".to_string());
+        let registry = VoiceProviderRegistry::with_platform_runtime(
+            PathBuf::from("/tmp/models"),
+            Arc::new(FakeRecorder::new(vec![0.1, 0.2, 0.3])),
+            Arc::new(FakeTranscriber::ok("ignored")),
+            platform_engine.clone(),
+        );
+
+        registry
+            .start_recording(&db_path, PLATFORM_ID, None)
+            .await
+            .expect("platform recording starts");
+        let transcript = registry
+            .stop_and_transcribe(PLATFORM_ID)
+            .await
+            .expect("platform transcribes");
+
+        assert_eq!(transcript, "spoken platform words");
+        assert_eq!(platform_engine.calls.load(Ordering::Relaxed), 1);
+    }
+
+    #[cfg(any(target_os = "macos", windows))]
+    #[tokio::test]
+    async fn cancel_drops_active_platform_recording() {
+        let (_db_dir, db_path) = test_db_path();
+        let platform_engine = Arc::new(FakePlatformSpeechEngine::ready("Test Engine"));
+        let registry = VoiceProviderRegistry::with_platform_runtime(
+            PathBuf::from("/tmp/models"),
+            Arc::new(FakeRecorder::new(vec![0.1, 0.2, 0.3])),
+            Arc::new(FakeTranscriber::ok("ignored")),
+            platform_engine.clone(),
+        );
+
+        registry
+            .start_recording(&db_path, PLATFORM_ID, None)
+            .await
+            .expect("platform recording starts");
+        registry
+            .cancel_recording(PLATFORM_ID)
+            .await
+            .expect("cancel platform recording");
+
+        let err = registry
+            .stop_and_transcribe(PLATFORM_ID)
+            .await
+            .expect_err("cancelled platform recording should be gone");
+        assert!(err.contains("No voice recording is active"));
+        assert_eq!(platform_engine.calls.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn stop_without_recording_returns_clear_error() {
+        let registry = VoiceProviderRegistry::with_runtime(
+            PathBuf::from("/tmp/models"),
+            Arc::new(FakeRecorder::new(vec![0.1])),
+            Arc::new(FakeTranscriber::ok("ignored")),
+        );
+
+        let err = registry
+            .stop_and_transcribe(DISTIL_ID)
+            .await
+            .expect_err("stop without recording should fail");
+        assert!(err.contains("No voice recording is active"));
+    }
+
+    #[tokio::test]
+    async fn cancel_drops_active_recording() {
+        let (_db_dir, db_path) = test_db_path();
+        let model_dir = tempdir().expect("model dir");
+        write_complete_distil_model(&model_dir.path().join(DISTIL_CACHE_DIR));
+        let transcriber = Arc::new(FakeTranscriber::ok("ignored"));
+        let registry = VoiceProviderRegistry::with_runtime(
+            model_dir.path().to_path_buf(),
+            Arc::new(FakeRecorder::new(vec![0.1])),
+            transcriber.clone(),
+        );
+
+        registry
+            .start_recording(&db_path, DISTIL_ID, None)
+            .await
+            .expect("recording starts");
+        registry
+            .cancel_recording(DISTIL_ID)
+            .await
+            .expect("cancel recording");
+
+        let err = registry
+            .stop_and_transcribe(DISTIL_ID)
+            .await
+            .expect_err("cancelled recording should be gone");
+        assert!(err.contains("No voice recording is active"));
+        assert_eq!(transcriber.calls.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn cancel_during_distil_transcription_returns_early() {
+        let (_db_dir, db_path) = test_db_path();
+        let model_dir = tempdir().expect("model dir");
+        write_complete_distil_model(&model_dir.path().join(DISTIL_CACHE_DIR));
+        let transcriber = Arc::new(FakeTranscriber::slow(
+            "would have transcribed",
+            Duration::from_secs(5),
+        ));
+        let registry = Arc::new(VoiceProviderRegistry::with_runtime(
+            model_dir.path().to_path_buf(),
+            Arc::new(FakeRecorder::new(vec![0.1, 0.2, 0.3])),
+            transcriber.clone(),
+        ));
+
+        registry
+            .start_recording(&db_path, DISTIL_ID, None)
+            .await
+            .expect("recording starts");
+
+        let stop_registry = Arc::clone(&registry);
+        let stop_handle =
+            tokio::spawn(async move { stop_registry.stop_and_transcribe(DISTIL_ID).await });
+
+        // Give the spawn_blocking worker a moment to enter its sleep loop.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let cancel_started = std::time::Instant::now();
+        registry
+            .cancel_recording(DISTIL_ID)
+            .await
+            .expect("cancel succeeds");
+
+        let result = stop_handle.await.expect("stop task joined");
+        let elapsed = cancel_started.elapsed();
+
+        let err = result.expect_err("transcription should be cancelled");
+        assert!(
+            err.contains("cancelled"),
+            "expected cancellation error, got: {err}"
+        );
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "expected fast return after cancel, took {elapsed:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn start_then_stop_returns_fake_transcript() {
+        let (_db_dir, db_path) = test_db_path();
+        let model_dir = tempdir().expect("model dir");
+        write_complete_distil_model(&model_dir.path().join(DISTIL_CACHE_DIR));
+        let transcriber = Arc::new(FakeTranscriber::ok("hello from test"));
+        let registry = VoiceProviderRegistry::with_runtime(
+            model_dir.path().to_path_buf(),
+            Arc::new(FakeRecorder::new(vec![0.1, 0.2, 0.3])),
+            transcriber.clone(),
+        );
+
+        registry
+            .start_recording(&db_path, DISTIL_ID, None)
+            .await
+            .expect("recording starts");
+        let transcript = registry
+            .stop_and_transcribe(DISTIL_ID)
+            .await
+            .expect("transcribes");
+
+        assert_eq!(transcript, "hello from test");
+        assert_eq!(transcriber.calls.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn recorder_stream_error_returns_clear_error_before_transcription() {
+        let (_db_dir, db_path) = test_db_path();
+        let model_dir = tempdir().expect("model dir");
+        write_complete_distil_model(&model_dir.path().join(DISTIL_CACHE_DIR));
+        let transcriber = Arc::new(FakeTranscriber::ok("ignored"));
+        let registry = VoiceProviderRegistry::with_runtime(
+            model_dir.path().to_path_buf(),
+            Arc::new(FakeRecorder::new_with_stream_error(
+                vec![0.1, 0.2, 0.3],
+                "device disconnected",
+            )),
+            transcriber.clone(),
+        );
+
+        registry
+            .start_recording(&db_path, DISTIL_ID, None)
+            .await
+            .expect("recording starts");
+        let err = registry
+            .stop_and_transcribe(DISTIL_ID)
+            .await
+            .expect_err("stream error should fail");
+
+        assert!(err.contains("device disconnected"));
+        assert_eq!(transcriber.calls.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn silent_recording_rejects_before_transcription() {
+        let (_db_dir, db_path) = test_db_path();
+        let model_dir = tempdir().expect("model dir");
+        write_complete_distil_model(&model_dir.path().join(DISTIL_CACHE_DIR));
+        let transcriber = Arc::new(FakeTranscriber::ok("ignored"));
+        let registry = VoiceProviderRegistry::with_runtime(
+            model_dir.path().to_path_buf(),
+            Arc::new(FakeRecorder::new(vec![0.0; TARGET_SAMPLE_RATE as usize])),
+            transcriber.clone(),
+        );
+
+        registry
+            .start_recording(&db_path, DISTIL_ID, None)
+            .await
+            .expect("recording starts");
+        let err = registry
+            .stop_and_transcribe(DISTIL_ID)
+            .await
+            .expect_err("silent recording should fail");
+
+        assert!(err.contains("No speech"));
+        assert_eq!(transcriber.calls.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn empty_transcript_returns_clear_error() {
+        let (_db_dir, db_path) = test_db_path();
+        let model_dir = tempdir().expect("model dir");
+        write_complete_distil_model(&model_dir.path().join(DISTIL_CACHE_DIR));
+        let registry = VoiceProviderRegistry::with_runtime(
+            model_dir.path().to_path_buf(),
+            Arc::new(FakeRecorder::new(vec![0.1, 0.2, 0.3])),
+            Arc::new(FakeTranscriber::ok("   ")),
+        );
+
+        registry
+            .start_recording(&db_path, DISTIL_ID, None)
+            .await
+            .expect("recording starts");
+        let err = registry
+            .stop_and_transcribe(DISTIL_ID)
+            .await
+            .expect_err("empty transcript should fail");
+
+        assert!(err.contains("No speech"));
+    }
+
+    #[tokio::test]
+    async fn transcription_timeout_returns_clear_error() {
+        let (_db_dir, db_path) = test_db_path();
+        let model_dir = tempdir().expect("model dir");
+        write_complete_distil_model(&model_dir.path().join(DISTIL_CACHE_DIR));
+        let registry = VoiceProviderRegistry::with_runtime_and_timeout(
+            model_dir.path().to_path_buf(),
+            Arc::new(FakeRecorder::new(vec![0.1, 0.2, 0.3])),
+            Arc::new(FakeTranscriber::slow(
+                "late transcript",
+                std::time::Duration::from_millis(50),
+            )),
+            std::time::Duration::from_millis(5),
+        );
+
+        registry
+            .start_recording(&db_path, DISTIL_ID, None)
+            .await
+            .expect("recording starts");
+        let err = registry
+            .stop_and_transcribe(DISTIL_ID)
+            .await
+            .expect_err("slow transcription should time out");
+
+        assert!(err.contains("timed out"));
+        // Platform-aware suggestion: don't make CPU users blindly retry —
+        // route them to the platform provider that's actually fast on
+        // their hardware. The macOS variant already pointed at System
+        // dictation; bring Windows users along too.
+        #[cfg(target_os = "windows")]
+        assert!(
+            err.contains("Windows SAPI") || err.contains("System dictation"),
+            "Windows timeout must point at the SAPI provider: {err}",
+        );
+        #[cfg(target_os = "macos")]
+        assert!(
+            err.contains("System dictation"),
+            "macOS timeout must point at the platform provider: {err}",
+        );
+    }
+
+    #[test]
+    fn timeout_error_message_renders_platform_specific_hint() {
+        // Pin the contract directly — a refactor that drops the
+        // platform-specific suggestion would silently regress.
+        let msg = timeout_error_message(std::time::Duration::from_secs(300));
+        assert!(msg.starts_with("Voice transcription timed out after 300 seconds"));
+        #[cfg(target_os = "windows")]
+        {
+            assert!(msg.contains("CPU"));
+            assert!(msg.contains("System dictation"));
+        }
+        #[cfg(target_os = "macos")]
+        assert!(msg.contains("System dictation"));
+    }
+
+    #[test]
+    fn distil_transcription_timeout_default_matches_platform_hardware() {
+        // macOS hits Metal so the small ceiling is fine; CPU platforms
+        // need much more headroom for distil-whisper-large-v3 to chew
+        // through a multi-segment clip. Pin both so a future "let's just
+        // bump the macOS default to be safe" doesn't silently slow down
+        // failure detection on the platform that doesn't need it.
+        #[cfg(target_os = "macos")]
+        assert_eq!(
+            DISTIL_TRANSCRIPTION_TIMEOUT,
+            std::time::Duration::from_secs(90)
+        );
+        #[cfg(not(target_os = "macos"))]
+        assert!(
+            DISTIL_TRANSCRIPTION_TIMEOUT >= std::time::Duration::from_secs(180),
+            "CPU transcription timeout must be >= 180 s; was {:?}",
+            DISTIL_TRANSCRIPTION_TIMEOUT,
+        );
+    }
+
+    #[tokio::test]
+    async fn transcription_error_does_not_poison_later_recordings() {
+        let (_db_dir, db_path) = test_db_path();
+        let model_dir = tempdir().expect("model dir");
+        write_complete_distil_model(&model_dir.path().join(DISTIL_CACHE_DIR));
+        let transcriber = Arc::new(FakeTranscriber::err("boom"));
+        let registry = VoiceProviderRegistry::with_runtime(
+            model_dir.path().to_path_buf(),
+            Arc::new(FakeRecorder::new(vec![0.1])),
+            transcriber.clone(),
+        );
+
+        registry
+            .start_recording(&db_path, DISTIL_ID, None)
+            .await
+            .expect("recording starts");
+        let err = registry
+            .stop_and_transcribe(DISTIL_ID)
+            .await
+            .expect_err("fake transcriber fails");
+        assert_eq!(err, "boom");
+
+        *transcriber.result.lock() = Ok("recovered".to_string());
+        registry
+            .start_recording(&db_path, DISTIL_ID, None)
+            .await
+            .expect("recording can start again");
+        let transcript = registry
+            .stop_and_transcribe(DISTIL_ID)
+            .await
+            .expect("later transcription succeeds");
+        assert_eq!(transcript, "recovered");
+    }
+
+    #[tokio::test]
+    async fn remove_distil_model_clears_cache_and_status() {
+        let (_db_dir, db_path) = test_db_path();
+        let model_dir = tempdir().expect("model dir");
+        let cache_path = model_dir.path().join(DISTIL_CACHE_DIR);
+        write_complete_distil_model(&cache_path);
+        let db = open_test_db(&db_path);
+        db.set_app_setting(&model_status_key(DISTIL_ID), "installed")
+            .expect("set model status");
+        drop(db);
+
+        let registry = VoiceProviderRegistry::new(model_dir.path().to_path_buf());
+        let provider = registry
+            .remove_provider_model(&db_path, DISTIL_ID)
+            .await
+            .expect("remove model");
+
+        assert!(!cache_path.exists());
+        assert_eq!(provider.status, VoiceProviderStatus::NeedsSetup);
+        let db = open_test_db(&db_path);
+        assert_eq!(
+            db.get_app_setting(&model_status_key(DISTIL_ID))
+                .expect("get model status"),
+            Some("not-installed".to_string())
+        );
+    }
+}

--- a/src-tauri/src/voice.rs
+++ b/src-tauri/src/voice.rs
@@ -497,7 +497,10 @@ impl VoiceProviderRegistry {
     }
 
     pub fn default_model_root() -> PathBuf {
-        crate::helpers::aethon_dir(std::env::var_os("HOME").map(PathBuf::from))
+        let home = std::env::var_os("HOME")
+            .or_else(|| std::env::var_os("USERPROFILE"))
+            .map(PathBuf::from);
+        crate::helpers::aethon_dir(home)
             .unwrap_or_else(|| PathBuf::from(".aethon"))
             .join("models")
             .join("voice")

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -52,7 +52,9 @@
       "icons/icon.png"
     ],
     "macOS": {
-      "minimumSystemVersion": "11.0"
+      "minimumSystemVersion": "11.0",
+      "entitlements": "Entitlements.plist",
+      "infoPlist": "Info.plist"
     },
     "createUpdaterArtifacts": true
   },

--- a/src/config.ts
+++ b/src/config.ts
@@ -52,6 +52,10 @@ export interface AethonConfig {
      *  through to `"agent"`. */
     newTabKind: "agent" | "shell";
   };
+  voice: {
+    toggleHotkey: string | null;
+    holdHotkey: string | null;
+  };
   updates: {
     /** Release channel the auto-updater follows. `"stable"` (default)
      *  tracks `releases/latest`; `"nightly"` follows the `nightly`
@@ -95,6 +99,14 @@ const DEFAULTS: AethonConfig = {
     promptBeforeClose: true,
   },
   shortcuts: { newTabKind: "agent" },
+  voice: {
+    toggleHotkey: "mod+shift+m",
+    holdHotkey:
+      typeof navigator !== "undefined" &&
+      (/Mac/.test(navigator.platform) || /Mac OS X/.test(navigator.userAgent))
+        ? "AltRight"
+        : null,
+  },
   updates: { channel: "stable", disableAutoCheck: false },
   devshell: {
     enabled: "auto",
@@ -178,6 +190,18 @@ export function getConfig(): Promise<AethonConfig> {
         shortcuts: {
           newTabKind:
             obj?.shortcuts?.newTabKind === "shell" ? "shell" : "agent",
+        },
+        voice: {
+          toggleHotkey:
+            typeof obj?.voice?.toggleHotkey === "string"
+              ? obj.voice.toggleHotkey
+              : DEFAULTS.voice.toggleHotkey,
+          holdHotkey:
+            typeof obj?.voice?.holdHotkey === "string"
+              ? obj.voice.holdHotkey
+              : obj?.voice?.holdHotkey === null
+                ? null
+                : DEFAULTS.voice.holdHotkey,
         },
         updates: {
           channel:

--- a/src/eventRoutes/chatInput.test.ts
+++ b/src/eventRoutes/chatInput.test.ts
@@ -107,6 +107,27 @@ describe("handleChatInput", () => {
     expect(mocks.stopPrompt).toHaveBeenCalledTimes(1);
   });
 
+  it("voice setup opens settings focused on the voice section", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    const handled = await handleChatInput(
+      {
+        component: { id: "chat-input" },
+        eventType: "voice:setup",
+        data: { providerId: "voice-distil-whisper" },
+      },
+      ctx,
+    );
+
+    expect(handled).toBe(true);
+    expect(mocks.setState).toHaveBeenCalledTimes(1);
+    expect(ctx.stateRef.current.settings).toEqual({
+      open: true,
+      pending: null,
+      focusSection: "voice",
+      focusProviderId: "voice-distil-whisper",
+    });
+  });
+
   // Wrong-id rejection is no longer the handler's responsibility — the
   // route table dispatches by `type:chat-input`, so a non-chat-input
   // event simply never reaches this handler. See index.test.ts for the

--- a/src/eventRoutes/chatInput.ts
+++ b/src/eventRoutes/chatInput.ts
@@ -52,5 +52,19 @@ export const handleChatInput: EventRouteHandler = async (
     await ctx.stopPrompt();
     return true;
   }
+  if (eventType === "voice:setup") {
+    const providerId =
+      (data as { providerId?: string | null } | undefined)?.providerId ?? null;
+    ctx.setState((prev) => ({
+      ...prev,
+      settings: {
+        open: true,
+        pending: null,
+        focusSection: "voice",
+        focusProviderId: providerId,
+      },
+    }));
+    return true;
+  }
   return false;
 };

--- a/src/hooks/uiOverlays/settings.ts
+++ b/src/hooks/uiOverlays/settings.ts
@@ -48,6 +48,9 @@ export function useSettingsOverlay(ctx: SettingsOverlayContext) {
       agent: unknown;
       shell: unknown;
       shortcuts: unknown;
+      voice: unknown;
+      updates: unknown;
+      devshell: unknown;
     }>,
   ) {
     setState((prev) => {
@@ -102,11 +105,19 @@ export function useSettingsOverlay(ctx: SettingsOverlayContext) {
         ...(live?.shortcuts ?? {}),
         ...((pending as { shortcuts?: object }).shortcuts ?? {}),
       },
+      voice: {
+        ...(live?.voice ?? {}),
+        ...((pending as { voice?: object }).voice ?? {}),
+      },
       // Likewise for `[updates]` — preserve channel + auto-check settings
       // across saves of unrelated sections.
       updates: {
         ...(live?.updates ?? {}),
         ...((pending as { updates?: object }).updates ?? {}),
+      },
+      devshell: {
+        ...(live?.devshell ?? {}),
+        ...((pending as { devshell?: object }).devshell ?? {}),
       },
     };
     try {

--- a/src/hooks/useBootConfig.ts
+++ b/src/hooks/useBootConfig.ts
@@ -109,6 +109,14 @@ export function useBootConfig(ctx: UseBootConfigContext): UseBootConfigActions {
     shortcutsNewTabKindRef.current = fresh.shortcuts.newTabKind;
     updateChannelRef.current = fresh.updates.channel;
     disableAutoCheckRef.current = fresh.updates.disableAutoCheck;
+    setState((prev) => ({
+      ...prev,
+      voice: {
+        ...(prev.voice as object | undefined),
+        toggleHotkey: fresh.voice.toggleHotkey,
+        holdHotkey: fresh.voice.holdHotkey,
+      },
+    }));
     if (fresh.agent.model) {
       piDefaultModelRef.current = fresh.agent.model;
       setState((prev) => ({
@@ -187,6 +195,14 @@ export function useBootConfig(ctx: UseBootConfigContext): UseBootConfigActions {
       // the configured channel.
       updateChannelRef.current = config.updates.channel;
       disableAutoCheckRef.current = config.updates.disableAutoCheck;
+      setState((prev) => ({
+        ...prev,
+        voice: {
+          ...(prev.voice as object | undefined),
+          toggleHotkey: config.voice.toggleHotkey,
+          holdHotkey: config.voice.holdHotkey,
+        },
+      }));
 
       // [agent] model: when set, seed the picker default for this
       // session. Only applied if no per-session model has been saved

--- a/src/hooks/useSessionPersistence.test.tsx
+++ b/src/hooks/useSessionPersistence.test.tsx
@@ -41,6 +41,10 @@ const defaultConfig: AethonConfig = {
     promptBeforeClose: true,
   },
   shortcuts: { newTabKind: "agent" },
+  voice: {
+    toggleHotkey: "mod+shift+m",
+    holdHotkey: null,
+  },
   updates: { channel: "stable", disableAutoCheck: false },
   devshell: {
     enabled: "auto",

--- a/src/hooks/useVoiceHotkey.test.ts
+++ b/src/hooks/useVoiceHotkey.test.ts
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+import {
+  createVoiceHotkeyHandlers,
+  formatHoldHotkey,
+  formatToggleHotkey,
+  matchesToggle,
+} from "./useVoiceHotkey";
+import type { VoiceInputController } from "./useVoiceInput";
+
+function keyEvent(init: KeyboardEventInit): KeyboardEvent {
+  return new KeyboardEvent("keydown", {
+    key: "m",
+    code: "KeyM",
+    metaKey: true,
+    shiftKey: true,
+    bubbles: true,
+    cancelable: true,
+    ...init,
+  });
+}
+
+function voice(state: VoiceInputController["state"]): VoiceInputController {
+  return {
+    state,
+    elapsedSeconds: 0,
+    interimTranscript: "",
+    error: null,
+    activeProvider: null,
+    webSpeechSupported: false,
+    start: vi.fn(() => Promise.resolve()),
+    stop: vi.fn(),
+    cancel: vi.fn(),
+  };
+}
+
+describe("voice hotkeys", () => {
+  it("matches the default toggle combo exactly", () => {
+    expect(matchesToggle(keyEvent({}), "mod+shift+m")).toBe(true);
+    expect(matchesToggle(keyEvent({ shiftKey: false }), "mod+shift+m")).toBe(
+      false,
+    );
+    expect(matchesToggle(keyEvent({ altKey: true }), "mod+shift+m")).toBe(
+      false,
+    );
+  });
+
+  it("formats toggle and hold bindings for settings labels", () => {
+    expect(formatToggleHotkey("mod+shift+m", true)).toBe("⌘⇧M");
+    expect(formatToggleHotkey("mod+shift+m", false)).toBe("Ctrl+Shift+M");
+    expect(formatHoldHotkey("AltRight", true)).toBe("Right ⌥");
+  });
+
+  it("toggle starts from idle, stops from recording, and cancels in-flight states", () => {
+    const idle = voice("idle");
+    const idleHandlers = createVoiceHotkeyHandlers(
+      () => idle,
+      "mod+shift+m",
+      null,
+    );
+    idleHandlers.onKeyDown(keyEvent({}));
+    expect(idle.start).toHaveBeenCalledTimes(1);
+
+    const recording = voice("recording");
+    const recordingHandlers = createVoiceHotkeyHandlers(
+      () => recording,
+      "mod+shift+m",
+      null,
+    );
+    recordingHandlers.onKeyDown(keyEvent({}));
+    expect(recording.stop).toHaveBeenCalledTimes(1);
+
+    const starting = voice("starting");
+    const startingHandlers = createVoiceHotkeyHandlers(
+      () => starting,
+      "mod+shift+m",
+      null,
+    );
+    startingHandlers.onKeyDown(keyEvent({}));
+    expect(starting.cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("hold-to-talk starts on keydown and stops on keyup", () => {
+    const current = voice("idle");
+    const handlers = createVoiceHotkeyHandlers(
+      () => current,
+      null,
+      "code:AltRight",
+    );
+
+    handlers.onKeyDown(
+      keyEvent({
+        key: "Alt",
+        code: "AltRight",
+        metaKey: false,
+        shiftKey: false,
+        altKey: true,
+      }),
+    );
+    expect(current.start).toHaveBeenCalledTimes(1);
+
+    current.state = "recording";
+    handlers.onKeyUp(
+      keyEvent({
+        key: "Alt",
+        code: "AltRight",
+        metaKey: false,
+        shiftKey: false,
+        altKey: false,
+      }),
+    );
+    expect(current.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not start while input is blocked", () => {
+    const current = voice("idle");
+    const handlers = createVoiceHotkeyHandlers(
+      () => current,
+      "mod+shift+m",
+      "code:AltRight",
+      () => true,
+    );
+
+    handlers.onKeyDown(keyEvent({}));
+    handlers.onKeyDown(
+      keyEvent({
+        key: "Alt",
+        code: "AltRight",
+        metaKey: false,
+        shiftKey: false,
+        altKey: true,
+      }),
+    );
+
+    expect(current.start).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useVoiceHotkey.ts
+++ b/src/hooks/useVoiceHotkey.ts
@@ -1,0 +1,241 @@
+import { useEffect, useLayoutEffect, useRef } from "react";
+import type { VoiceInputController } from "./useVoiceInput";
+
+// Re-export so existing call sites (KeyboardSettings, tests) keep working.
+export {
+  DEFAULT_TOGGLE_HOTKEY,
+  DEFAULT_HOLD_HOTKEY_MAC,
+  getDefaultHoldHotkey,
+} from "../utils/voiceHotkeys";
+
+/** Detect AltGr — Right Alt on most non-US layouts produces this and is used
+ * to type common characters. We must never treat AltGr presses as hotkey
+ * activations. */
+function isAltGr(e: KeyboardEvent): boolean {
+  if (e.key === "AltGraph") return true;
+  // Some browsers/OSes report AltGr as Ctrl+Alt with code AltRight.
+  if (typeof e.getModifierState === "function" && e.getModifierState("AltGraph")) return true;
+  return e.code === "AltRight" && e.ctrlKey && e.altKey;
+}
+
+type VoiceHandle = Pick<VoiceInputController, "state" | "start" | "stop" | "cancel">;
+
+/** Normalize a key name for use in the `+`-delimited combo format.
+ * "+" itself becomes "plus" so the serialized combo stays unambiguous
+ * (otherwise "mod+shift+" + "+" would split into a stray empty segment). */
+export function normalizeToggleKey(key: string): string {
+  if (key === "+") return "plus";
+  return key.toLowerCase();
+}
+
+/** Check if a keyboard event matches a stored toggle combo like "mod+shift+m". */
+export function matchesToggle(e: KeyboardEvent, hotkey: string): boolean {
+  const parts = hotkey.toLowerCase().split("+");
+  const key = parts[parts.length - 1];
+  if (!key || normalizeToggleKey(e.key) !== key) return false;
+  const wantsMod = parts.includes("mod");
+  const wantsShift = parts.includes("shift");
+  const wantsAlt = parts.includes("alt");
+  const hasMod = e.metaKey || e.ctrlKey;
+  return wantsMod === hasMod && wantsShift === e.shiftKey && wantsAlt === e.altKey;
+}
+
+/** Human-readable display of a toggle hotkey string (e.g. "mod+shift+m" → "⌘⇧M"). */
+export function formatToggleHotkey(hotkey: string | null, isMac: boolean): string {
+  if (!hotkey) return "—";
+  return hotkey
+    .split("+")
+    .map((part) => {
+      if (part === "mod") return isMac ? "⌘" : "Ctrl";
+      if (part === "shift") return isMac ? "⇧" : "Shift";
+      if (part === "alt") return isMac ? "⌥" : "Alt";
+      return part.length === 1 ? part.toUpperCase() : part;
+    })
+    .join(isMac ? "" : "+");
+}
+
+const HOLD_KEY_DISPLAY: Record<string, { mac: string; other: string }> = {
+  AltRight: { mac: "Right ⌥", other: "Right Alt" },
+  AltLeft: { mac: "Left ⌥", other: "Left Alt" },
+  ControlRight: { mac: "Right ⌃", other: "Right Ctrl" },
+  ControlLeft: { mac: "Left ⌃", other: "Left Ctrl" },
+  ShiftRight: { mac: "Right ⇧", other: "Right Shift" },
+  ShiftLeft: { mac: "Left ⇧", other: "Left Shift" },
+  MetaRight: { mac: "Right ⌘", other: "Right Meta" },
+  MetaLeft: { mac: "Left ⌘", other: "Left Meta" },
+  Space: { mac: "Space", other: "Space" },
+  F13: { mac: "F13", other: "F13" },
+  F14: { mac: "F14", other: "F14" },
+  F15: { mac: "F15", other: "F15" },
+};
+
+/** Human-readable display of a hold key code (e.g. "AltRight" → "Right ⌥"). */
+export function formatHoldHotkey(code: string | null, isMac: boolean): string {
+  if (!code) return "—";
+  const entry = HOLD_KEY_DISPLAY[code];
+  if (entry) return isMac ? entry.mac : entry.other;
+  return code.replace(/^(?:Key|Digit)/, "");
+}
+
+/**
+ * Factory that produces the raw event handlers for the voice hotkey state machine.
+ * Exported so tests can exercise the logic without mounting a React component.
+ *
+ * The hold-to-talk state is tracked in a closure variable shared across the
+ * three returned handlers, so they must all be created together and used as a set.
+ */
+export function createVoiceHotkeyHandlers(
+  getVoice: () => VoiceHandle,
+  toggleHotkey: string | null,
+  holdBinding: string | null,
+  /** Returns true when the hotkey should not fire START actions (e.g. a modal
+   * or settings panel is open). Stop/cancel/release actions still run so an
+   * in-flight recording can always be ended. */
+  isInputBlocked: () => boolean = () => false,
+): {
+  onKeyDown: (e: KeyboardEvent) => void;
+  onKeyUp: (e: KeyboardEvent) => void;
+  onBlur: () => void;
+} {
+  let holdActive = false;
+  const holdCode = holdBindingToCode(holdBinding);
+
+  return {
+    onKeyDown(e: KeyboardEvent) {
+      // Suppress repeated keydowns. Toggle and hold-to-talk both fire once per
+      // physical press, so OS key-repeat events should be eaten — otherwise
+      // a printable toggle binding (e.g. user rebinds to a single letter)
+      // would leak repeated characters into the focused input on hold.
+      if (e.repeat) {
+        if (holdCode && e.code === holdCode && holdActive) e.preventDefault();
+        if (toggleHotkey && matchesToggle(e, toggleHotkey)) e.preventDefault();
+        return;
+      }
+
+      const v = getVoice();
+
+      if (toggleHotkey && matchesToggle(e, toggleHotkey)) {
+        e.preventDefault();
+        if (v.state === "recording") {
+          v.stop();
+        } else if (v.state === "starting" || v.state === "transcribing") {
+          v.cancel();
+        } else if (!isInputBlocked()) {
+          // idle, setup-required, or error — try start (only when no overlay
+          // owns input focus). Mirrors the mic button's catchall: from
+          // setup-required, start() re-runs the provider check (now
+          // succeeding after the user granted perms); from error it clears
+          // the error and re-attempts.
+          void v.start();
+        }
+        return;
+      }
+
+      // Reject AltGr presses outright — Right Alt acts as AltGr on most
+      // non-US layouts and is used to type @, {}, ñ, ç, etc. Triggering
+      // hold-to-talk on those would break normal text entry.
+      if (holdCode && e.code === holdCode && isAltGr(e)) return;
+
+      if (
+        holdBinding &&
+        holdBindingMatchesEvent(holdBinding, e) &&
+        !holdActive &&
+        v.state !== "recording" &&
+        v.state !== "starting" &&
+        v.state !== "transcribing" &&
+        !isInputBlocked()
+      ) {
+        e.preventDefault();
+        holdActive = true;
+        void v.start();
+      }
+    },
+
+    onKeyUp(e: KeyboardEvent) {
+      if (!holdCode || !holdActive || e.code !== holdCode) return;
+      holdActive = false;
+      const v = getVoice();
+      if (v.state === "recording" || v.state === "starting") {
+        v.stop();
+      }
+    },
+
+    // Window blur (e.g. Cmd+Tab away while holding the key): clear the
+    // hold-state flag so a stale keyup arriving later is a no-op. The
+    // actual recording stop is handled centrally by useVoiceInput so it
+    // applies regardless of how the recording was started (mic button,
+    // toggle hotkey, hold-to-talk).
+    onBlur() {
+      holdActive = false;
+    },
+  };
+}
+
+/**
+ * Registers global keyboard shortcuts for voice input:
+ * - Toggle hotkey (default Cmd/Ctrl+Shift+M): start/stop recording.
+ * - Hold hotkey (default Right Alt/Option): hold to record, release to transcribe.
+ *
+ * Listeners are re-registered only when the hotkey config changes, not on
+ * every voice state update (voice state is read via a ref at handler time).
+ */
+export function useVoiceHotkey(
+  voice: VoiceInputController,
+  toggleHotkey: string | null,
+  holdHotkey: string | null,
+  isInputBlocked: () => boolean = () => false,
+): void {
+  const voiceRef = useRef<VoiceInputController>(voice);
+
+  // Keep the ref in sync after every render so event handlers always read
+  // the latest voice state without being re-registered on every state change.
+  // useLayoutEffect (not render-time assignment) satisfies the React Compiler's
+  // requirement that refs are only mutated outside of render.
+  useLayoutEffect(() => {
+    voiceRef.current = voice;
+  });
+
+  useEffect(() => {
+    const toggleBinding = toggleHotkey;
+    const holdBinding = holdHotkey ? `code:${holdHotkey}` : null;
+    const { onKeyDown, onKeyUp, onBlur } = createVoiceHotkeyHandlers(
+      () => voiceRef.current,
+      toggleBinding,
+      holdBinding,
+      isInputBlocked,
+    );
+    window.addEventListener("keydown", onKeyDown);
+    window.addEventListener("keyup", onKeyUp);
+    window.addEventListener("blur", onBlur);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("keyup", onKeyUp);
+      window.removeEventListener("blur", onBlur);
+    };
+  }, [toggleHotkey, holdHotkey, isInputBlocked]);
+}
+
+function holdBindingMatchesEvent(binding: string, e: KeyboardEvent): boolean {
+  if (binding.startsWith("code:")) {
+    return e.code === binding.slice("code:".length);
+  }
+  if (binding.includes("+")) {
+    const parts = binding.toLowerCase().split("+");
+    const key = parts.at(-1);
+    if (!key) return false;
+    return (
+      normalizeToggleKey(e.key) === key &&
+      parts.includes("mod") === (e.metaKey || e.ctrlKey) &&
+      parts.includes("shift") === e.shiftKey &&
+      parts.includes("alt") === e.altKey
+    );
+  }
+  return e.code === binding;
+}
+
+function holdBindingToCode(binding: string | null): string | null {
+  if (!binding) return null;
+  const finalPart = binding.split("+").at(-1);
+  if (!finalPart) return null;
+  return finalPart.startsWith("code:") ? finalPart.slice("code:".length) : finalPart;
+}

--- a/src/hooks/useVoiceInput.test.ts
+++ b/src/hooks/useVoiceInput.test.ts
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { VoiceProviderInfo } from "../types/voice";
+import { useVoiceInput } from "./useVoiceInput";
+
+const service = vi.hoisted(() => ({
+  listVoiceProviders: vi.fn(),
+  startVoiceRecording: vi.fn(),
+  stopAndTranscribeVoice: vi.fn(),
+  cancelVoiceRecording: vi.fn(),
+}));
+
+vi.mock("../services/voice", () => service);
+
+function provider(
+  overrides: Partial<VoiceProviderInfo> & Pick<VoiceProviderInfo, "id">,
+): VoiceProviderInfo {
+  return {
+    name: overrides.id,
+    description: "",
+    kind: "platform",
+    recordingMode: "native",
+    privacyLabel: "",
+    offline: false,
+    downloadRequired: false,
+    modelSizeLabel: null,
+    cachePath: null,
+    acceleratorLabel: null,
+    status: "ready",
+    statusLabel: "Ready",
+    enabled: true,
+    selected: true,
+    setupRequired: false,
+    canRemoveModel: false,
+    error: null,
+    ...overrides,
+    id: overrides.id,
+  };
+}
+
+describe("useVoiceInput", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service.listVoiceProviders.mockResolvedValue([
+      provider({ id: "voice-platform-system" }),
+    ]);
+    service.startVoiceRecording.mockResolvedValue(undefined);
+    service.stopAndTranscribeVoice.mockResolvedValue("hello world");
+    service.cancelVoiceRecording.mockResolvedValue(undefined);
+  });
+
+  it("starts and stops a native provider, inserting the final transcript", async () => {
+    const onTranscript = vi.fn();
+    const onNeedsSetup = vi.fn();
+    const { result } = renderHook(() =>
+      useVoiceInput(onTranscript, onNeedsSetup),
+    );
+
+    await act(async () => {
+      await result.current.start();
+    });
+
+    expect(result.current.state).toBe("recording");
+    expect(service.startVoiceRecording).toHaveBeenCalledWith(
+      "voice-platform-system",
+    );
+
+    act(() => {
+      result.current.stop();
+    });
+
+    await waitFor(() => expect(result.current.state).toBe("idle"));
+    expect(service.stopAndTranscribeVoice).toHaveBeenCalledWith(
+      "voice-platform-system",
+    );
+    expect(onTranscript).toHaveBeenCalledWith("hello world");
+  });
+
+  it("routes setup-required native providers to settings", async () => {
+    service.listVoiceProviders.mockResolvedValueOnce([
+      provider({
+        id: "voice-platform-system",
+        status: "needs-setup",
+        selected: true,
+        setupRequired: true,
+        statusLabel: "Permission required",
+      }),
+    ]);
+    service.startVoiceRecording.mockRejectedValueOnce("permission denied");
+    const onNeedsSetup = vi.fn();
+    const { result } = renderHook(() => useVoiceInput(vi.fn(), onNeedsSetup));
+
+    await act(async () => {
+      await result.current.start();
+    });
+
+    expect(result.current.state).toBe("setup-required");
+    expect(onNeedsSetup).toHaveBeenCalledWith("voice-platform-system");
+    expect(service.startVoiceRecording).toHaveBeenCalledWith(
+      "voice-platform-system",
+    );
+  });
+
+  it("cancels an active native recording", async () => {
+    const { result } = renderHook(() => useVoiceInput(vi.fn(), vi.fn()));
+
+    await act(async () => {
+      await result.current.start();
+    });
+    act(() => {
+      result.current.cancel();
+    });
+
+    expect(result.current.state).toBe("idle");
+    expect(service.cancelVoiceRecording).toHaveBeenCalledWith(
+      "voice-platform-system",
+    );
+  });
+});

--- a/src/hooks/useVoiceInput.ts
+++ b/src/hooks/useVoiceInput.ts
@@ -1,0 +1,396 @@
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import {
+  cancelVoiceRecording,
+  listVoiceProviders,
+  startVoiceRecording,
+  stopAndTranscribeVoice,
+} from "../services/voice";
+import type { VoiceProviderInfo } from "../types/voice";
+import {
+  PLATFORM_VOICE_PROVIDER_ID,
+  chooseVoiceProvider,
+  describeSpeechRecognitionError,
+  isNativeVoiceProvider,
+} from "../utils/voice";
+
+type VoiceState =
+  | "idle"
+  | "starting"
+  | "setup-required"
+  | "recording"
+  | "transcribing"
+  | "error";
+
+interface SpeechRecognitionAlternativeLike {
+  transcript: string;
+}
+
+interface SpeechRecognitionResultLike {
+  isFinal: boolean;
+  length: number;
+  item(index: number): SpeechRecognitionAlternativeLike;
+}
+
+interface SpeechRecognitionResultListLike {
+  length: number;
+  item(index: number): SpeechRecognitionResultLike;
+}
+
+interface SpeechRecognitionEventLike extends Event {
+  resultIndex: number;
+  results: SpeechRecognitionResultListLike;
+}
+
+interface SpeechRecognitionErrorEventLike extends Event {
+  error: string;
+  message?: string;
+}
+
+interface SpeechRecognitionLike extends EventTarget {
+  continuous: boolean;
+  interimResults: boolean;
+  lang: string;
+  onstart: (() => void) | null;
+  onresult: ((event: SpeechRecognitionEventLike) => void) | null;
+  onerror: ((event: SpeechRecognitionErrorEventLike) => void) | null;
+  onend: (() => void) | null;
+  start(): void;
+  stop(): void;
+  abort(): void;
+}
+
+interface SpeechRecognitionConstructor {
+  new (): SpeechRecognitionLike;
+}
+
+interface SpeechRecognitionWindow extends Window {
+  SpeechRecognition?: SpeechRecognitionConstructor;
+  webkitSpeechRecognition?: SpeechRecognitionConstructor;
+}
+
+function isMacPlatform(): boolean {
+  if (typeof navigator === "undefined") return false;
+  return /Mac/.test(navigator.platform) || /Mac OS X/.test(navigator.userAgent);
+}
+
+export interface VoiceInputController {
+  state: VoiceState;
+  elapsedSeconds: number;
+  interimTranscript: string;
+  error: string | null;
+  activeProvider: VoiceProviderInfo | null;
+  webSpeechSupported: boolean;
+  start: () => Promise<void>;
+  stop: () => void;
+  cancel: () => void;
+}
+
+export function useVoiceInput(
+  onTranscript: (transcript: string) => void,
+  onNeedsSetup: (providerId: string) => void,
+): VoiceInputController {
+  const [state, setState] = useState<VoiceState>("idle");
+  const [elapsedSeconds, setElapsedSeconds] = useState(0);
+  const [interimTranscript, setInterimTranscript] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [activeProvider, setActiveProvider] = useState<VoiceProviderInfo | null>(null);
+  const recognitionRef = useRef<SpeechRecognitionLike | null>(null);
+  const nativeProviderRef = useRef<string | null>(null);
+  const transcribingProviderRef = useRef<string | null>(null);
+  const nativeRequestIdRef = useRef(0);
+  const finalTranscriptRef = useRef("");
+  const cancelledRef = useRef(false);
+  const platformSpeechDisabled = useMemo(() => isMacPlatform(), []);
+
+  const Recognition = useMemo(() => {
+    if (platformSpeechDisabled) return undefined;
+    if (typeof window === "undefined") return undefined;
+    const speechWindow = window as SpeechRecognitionWindow;
+    return speechWindow.SpeechRecognition ?? speechWindow.webkitSpeechRecognition;
+  }, [platformSpeechDisabled]);
+
+  // Whether the in-webview Web Speech API is usable. Forced false on
+  // macOS because we route through the native Apple Speech / Candle
+  // providers there. Consumers should NOT use this as a proxy for
+  // "voice input is available" — native providers cover macOS even
+  // when this is false.
+  const webSpeechSupported = Boolean(Recognition) && !platformSpeechDisabled;
+
+  useEffect(() => {
+    if (state !== "recording") return;
+    const started = Date.now();
+    const interval = window.setInterval(() => {
+      setElapsedSeconds(Math.floor((Date.now() - started) / 1000));
+    }, 250);
+    return () => window.clearInterval(interval);
+  }, [state]);
+
+  // Auto-dismiss transient transcription errors so the toolbar doesn't keep
+  // displaying a stale message after the user has moved on. Setup-required
+  // states stay visible because they require user action.
+  useEffect(() => {
+    if (state !== "error") return;
+    const timeout = window.setTimeout(() => {
+      setState("idle");
+      setError(null);
+    }, 6000);
+    return () => window.clearTimeout(timeout);
+  }, [state, error]);
+
+  const cancel = useCallback(() => {
+    cancelledRef.current = true;
+    nativeRequestIdRef.current += 1;
+    recognitionRef.current?.abort();
+    recognitionRef.current = null;
+    if (nativeProviderRef.current) {
+      void cancelVoiceRecording(nativeProviderRef.current);
+      nativeProviderRef.current = null;
+    }
+    if (transcribingProviderRef.current) {
+      void cancelVoiceRecording(transcribingProviderRef.current);
+      transcribingProviderRef.current = null;
+    }
+    finalTranscriptRef.current = "";
+    setInterimTranscript("");
+    setError(null);
+    setActiveProvider(null);
+    setState("idle");
+  }, []);
+
+  useEffect(() => cancel, [cancel]);
+
+  const start = useCallback(async () => {
+    nativeRequestIdRef.current += 1;
+    setError(null);
+    setInterimTranscript("");
+    setActiveProvider(null);
+    finalTranscriptRef.current = "";
+    cancelledRef.current = false;
+    // Immediate UI feedback before any awaits — without this, the user
+    // sees no change between clicking the mic and the OS permission
+    // prompt appearing (cold-start CoreAudio + TCC verification can
+    // take a couple of seconds on a fresh-signed build), and may
+    // assume the click did nothing and click again.
+    setState("starting");
+
+    let providers: VoiceProviderInfo[];
+    try {
+      providers = await listVoiceProviders();
+    } catch (err) {
+      setError(String(err));
+      setState("error");
+      return;
+    }
+
+    const provider = chooseVoiceProvider(providers);
+    setActiveProvider(provider);
+
+    if (!provider) {
+      const hasEnabledProvider = providers.some((candidate) => candidate.enabled);
+      setError(
+        hasEnabledProvider
+          ? "No ready voice provider is available. Open Voice settings to finish voice setup."
+          : "No enabled voice provider is ready. Open Voice settings to enable System dictation or set up an offline provider.",
+      );
+      setState("error");
+      return;
+    }
+
+    if (isNativeVoiceProvider(provider)) {
+      const providerMessage = provider.error ?? provider.statusLabel;
+      if (provider.status === "engine-unavailable" || provider.status === "error") {
+        setError(providerMessage);
+        setState("error");
+        return;
+      }
+      const canRequestPlatformPermission =
+        provider.id === PLATFORM_VOICE_PROVIDER_ID &&
+        provider.status === "needs-setup";
+      if (
+        !canRequestPlatformPermission &&
+        (provider.setupRequired || provider.status !== "ready")
+      ) {
+        setError(providerMessage);
+        setState("setup-required");
+        onNeedsSetup(provider.id);
+        return;
+      }
+
+      try {
+        await startVoiceRecording(provider.id);
+      } catch (err) {
+        setError(String(err));
+        if (canRequestPlatformPermission) {
+          setState("setup-required");
+          onNeedsSetup(provider.id);
+        } else {
+          setState("error");
+        }
+        return;
+      }
+
+      // If cancel() (or blur) fired during the await, the recording must not
+      // be allowed to become active — roll the native provider back rather
+      // than letting the mic stay hot in the background.
+      if (cancelledRef.current) {
+        void cancelVoiceRecording(provider.id);
+        return;
+      }
+
+      nativeProviderRef.current = provider.id;
+      setElapsedSeconds(0);
+      setState("recording");
+      return;
+    }
+
+    if (provider.id !== PLATFORM_VOICE_PROVIDER_ID) {
+      setError(provider.error ?? provider.statusLabel ?? "This voice provider is not available.");
+      setState("error");
+      return;
+    }
+
+    if (!provider.enabled || provider.status !== "ready") {
+      setError(provider.error ?? provider.statusLabel);
+      setState("error");
+      return;
+    }
+
+    if (platformSpeechDisabled) {
+      setError("System dictation is disabled on macOS because it can crash the app before permission errors are recoverable.");
+      setState("error");
+      return;
+    }
+
+    if (!Recognition) {
+      // Linux/Windows webviews typically don't expose the Web Speech API.
+      // Rust reports the platform provider as "ready" because it has no
+      // way to introspect webview capabilities, so we treat the missing
+      // engine as setup-required here and route the user to Plugins
+      // settings where they can enable the offline Whisper provider.
+      setError(
+        "System dictation isn't available in this webview. Switch to an offline voice provider in Voice settings.",
+      );
+      setState("setup-required");
+      onNeedsSetup(provider.id);
+      return;
+    }
+
+    const recognition = new Recognition();
+    recognition.continuous = true;
+    recognition.interimResults = true;
+    recognition.lang = navigator.language || "en-US";
+    recognition.onstart = () => {
+      setElapsedSeconds(0);
+      setState("recording");
+    };
+    recognition.onresult = (event) => {
+      let interim = "";
+      for (let index = event.resultIndex; index < event.results.length; index += 1) {
+        const result = event.results.item(index);
+        const transcript = result.length > 0 ? result.item(0).transcript : "";
+        if (result.isFinal) finalTranscriptRef.current += transcript;
+        else interim += transcript;
+      }
+      setInterimTranscript(interim.trim());
+    };
+    recognition.onerror = (event) => {
+      if (cancelledRef.current) return;
+      setError(describeSpeechRecognitionError(event));
+      setState("error");
+    };
+    recognition.onend = () => {
+      recognitionRef.current = null;
+      if (cancelledRef.current) return;
+      setState("transcribing");
+      const transcript = finalTranscriptRef.current.trim();
+      finalTranscriptRef.current = "";
+      setInterimTranscript("");
+      if (transcript) onTranscript(transcript);
+      setState("idle");
+    };
+    recognitionRef.current = recognition;
+
+    try {
+      recognition.start();
+    } catch (err) {
+      recognitionRef.current = null;
+      setError(String(err));
+      setState("error");
+    }
+  }, [Recognition, onNeedsSetup, onTranscript, platformSpeechDisabled]);
+
+  const stop = useCallback(() => {
+    if (nativeProviderRef.current) {
+      const providerId = nativeProviderRef.current;
+      nativeProviderRef.current = null;
+      const requestId = nativeRequestIdRef.current + 1;
+      nativeRequestIdRef.current = requestId;
+      transcribingProviderRef.current = providerId;
+      setState("transcribing");
+      void stopAndTranscribeVoice(providerId)
+        .then((transcript) => {
+          transcribingProviderRef.current = null;
+          if (
+            cancelledRef.current ||
+            nativeRequestIdRef.current !== requestId
+          ) {
+            return;
+          }
+          const normalized = transcript.trim();
+          if (normalized) onTranscript(normalized);
+          setState("idle");
+        })
+        .catch((err) => {
+          transcribingProviderRef.current = null;
+          if (
+            cancelledRef.current ||
+            nativeRequestIdRef.current !== requestId
+          ) {
+            return;
+          }
+          setError(String(err));
+          setState("error");
+        });
+      return;
+    }
+
+    if (!recognitionRef.current) return;
+    setState("transcribing");
+    recognitionRef.current.stop();
+  }, [onTranscript]);
+
+  // Stop any active recording when the window loses focus, regardless of how
+  // it was started (mic button, toggle hotkey, hold-to-talk). Without this,
+  // a Cmd+Tab away would leave the mic hot in the background.
+  //
+  // We must distinguish "starting" from "recording": during the brief window
+  // between user trigger and startVoiceRecording resolving, nativeProviderRef
+  // is still null and stop() is a no-op. cancel() flips cancelledRef so the
+  // in-flight start() rolls itself back after its await. State is read via a
+  // ref so the listener doesn't need to be re-registered on every transition.
+  const stateRef = useRef(state);
+  useLayoutEffect(() => {
+    stateRef.current = state;
+  });
+
+  useEffect(() => {
+    const onBlur = () => {
+      if (stateRef.current === "starting") cancel();
+      else stop();
+    };
+    window.addEventListener("blur", onBlur);
+    return () => window.removeEventListener("blur", onBlur);
+  }, [stop, cancel]);
+
+  return {
+    state,
+    elapsedSeconds,
+    interimTranscript,
+    error,
+    activeProvider,
+    webSpeechSupported,
+    start,
+    stop,
+    cancel,
+  };
+}

--- a/src/services/voice.test.ts
+++ b/src/services/voice.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { installTauriMocks, clearTauriMocks } from "../test/tauriMocks";
+import {
+  cancelVoiceRecording,
+  listVoiceProviders,
+  prepareVoiceProvider,
+  removeVoiceProviderModel,
+  setSelectedVoiceProvider,
+  setVoiceProviderEnabled,
+  startVoiceRecording,
+  stopAndTranscribeVoice,
+} from "./voice";
+
+describe("voice service", () => {
+  let harness: ReturnType<typeof installTauriMocks>;
+
+  beforeEach(() => {
+    harness = installTauriMocks();
+  });
+
+  afterEach(() => {
+    clearTauriMocks();
+  });
+
+  it("invokes provider list without extra payload", async () => {
+    harness.invoke.mockResolvedValueOnce([]);
+
+    await expect(listVoiceProviders()).resolves.toEqual([]);
+
+    expect(harness.invoke).toHaveBeenCalledWith("voice_list_providers");
+  });
+
+  it("serializes selected and enabled provider mutations", async () => {
+    await setSelectedVoiceProvider("voice-distil-whisper");
+    await setSelectedVoiceProvider(null);
+    await setVoiceProviderEnabled("voice-platform-system", false);
+
+    expect(harness.invoke).toHaveBeenNthCalledWith(
+      1,
+      "voice_set_selected_provider",
+      { providerId: "voice-distil-whisper" },
+    );
+    expect(harness.invoke).toHaveBeenNthCalledWith(
+      2,
+      "voice_set_selected_provider",
+      { providerId: null },
+    );
+    expect(harness.invoke).toHaveBeenNthCalledWith(
+      3,
+      "voice_set_provider_enabled",
+      { providerId: "voice-platform-system", enabled: false },
+    );
+  });
+
+  it("serializes setup and model removal actions", async () => {
+    await prepareVoiceProvider("voice-distil-whisper");
+    await removeVoiceProviderModel("voice-distil-whisper");
+
+    expect(harness.invoke).toHaveBeenNthCalledWith(
+      1,
+      "voice_prepare_provider",
+      { providerId: "voice-distil-whisper" },
+    );
+    expect(harness.invoke).toHaveBeenNthCalledWith(
+      2,
+      "voice_remove_provider_model",
+      { providerId: "voice-distil-whisper" },
+    );
+  });
+
+  it("passes null provider ids for default recording commands", async () => {
+    harness.invoke.mockResolvedValueOnce(undefined);
+    harness.invoke.mockResolvedValueOnce("hello");
+    harness.invoke.mockResolvedValueOnce(undefined);
+
+    await startVoiceRecording();
+    await expect(stopAndTranscribeVoice()).resolves.toBe("hello");
+    await cancelVoiceRecording();
+
+    expect(harness.invoke).toHaveBeenNthCalledWith(
+      1,
+      "voice_start_recording",
+      { providerId: null },
+    );
+    expect(harness.invoke).toHaveBeenNthCalledWith(
+      2,
+      "voice_stop_and_transcribe",
+      { providerId: null },
+    );
+    expect(harness.invoke).toHaveBeenNthCalledWith(
+      3,
+      "voice_cancel_recording",
+      { providerId: null },
+    );
+  });
+
+  it("passes explicit provider ids for recording commands", async () => {
+    await startVoiceRecording("voice-platform-system");
+    await stopAndTranscribeVoice("voice-platform-system");
+    await cancelVoiceRecording("voice-platform-system");
+
+    expect(harness.invoke).toHaveBeenNthCalledWith(
+      1,
+      "voice_start_recording",
+      { providerId: "voice-platform-system" },
+    );
+    expect(harness.invoke).toHaveBeenNthCalledWith(
+      2,
+      "voice_stop_and_transcribe",
+      { providerId: "voice-platform-system" },
+    );
+    expect(harness.invoke).toHaveBeenNthCalledWith(
+      3,
+      "voice_cancel_recording",
+      { providerId: "voice-platform-system" },
+    );
+  });
+});

--- a/src/services/voice.ts
+++ b/src/services/voice.ts
@@ -1,0 +1,47 @@
+import { invoke } from "@tauri-apps/api/core";
+import type { VoiceProviderInfo } from "../types/voice";
+
+export function listVoiceProviders(): Promise<VoiceProviderInfo[]> {
+  return invoke("voice_list_providers");
+}
+
+export function setSelectedVoiceProvider(
+  providerId: string | null,
+): Promise<void> {
+  return invoke("voice_set_selected_provider", { providerId });
+}
+
+export function setVoiceProviderEnabled(
+  providerId: string,
+  enabled: boolean,
+): Promise<void> {
+  return invoke("voice_set_provider_enabled", { providerId, enabled });
+}
+
+export function prepareVoiceProvider(
+  providerId: string,
+): Promise<VoiceProviderInfo> {
+  return invoke("voice_prepare_provider", { providerId });
+}
+
+export function removeVoiceProviderModel(
+  providerId: string,
+): Promise<VoiceProviderInfo> {
+  return invoke("voice_remove_provider_model", { providerId });
+}
+
+export function startVoiceRecording(
+  providerId?: string,
+): Promise<void> {
+  return invoke("voice_start_recording", { providerId: providerId ?? null });
+}
+
+export function stopAndTranscribeVoice(
+  providerId?: string,
+): Promise<string> {
+  return invoke("voice_stop_and_transcribe", { providerId: providerId ?? null });
+}
+
+export function cancelVoiceRecording(providerId?: string): Promise<void> {
+  return invoke("voice_cancel_recording", { providerId: providerId ?? null });
+}

--- a/src/skills/default-layout/chat-input.tsx
+++ b/src/skills/default-layout/chat-input.tsx
@@ -2,6 +2,7 @@ import {
   createElement,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
   type ChangeEvent,
@@ -140,14 +141,18 @@ export function ChatInput({
   const voiceConfig = (state.voice as
     | { toggleHotkey?: string | null; holdHotkey?: string | null }
     | undefined) ?? { toggleHotkey: "mod+shift+m", holdHotkey: null };
+  const settings = state.settings as { open?: boolean } | undefined;
+  const palette = state.commandPalette as { open?: boolean } | undefined;
+  const search = state.search as { open?: boolean } | undefined;
+  const voiceInputBlocked =
+    !!settings?.open || !!palette?.open || !!search?.open;
+  const voiceInputBlockedRef = useRef(voiceInputBlocked);
+  useLayoutEffect(() => {
+    voiceInputBlockedRef.current = voiceInputBlocked;
+  }, [voiceInputBlocked]);
   const isVoiceInputBlocked = useCallback(
-    () => {
-      const settings = state.settings as { open?: boolean } | undefined;
-      const palette = state.commandPalette as { open?: boolean } | undefined;
-      const search = state.search as { open?: boolean } | undefined;
-      return !!settings?.open || !!palette?.open || !!search?.open;
-    },
-    [state],
+    () => voiceInputBlockedRef.current,
+    [],
   );
   useVoiceHotkey(
     voice,

--- a/src/skills/default-layout/chat-input.tsx
+++ b/src/skills/default-layout/chat-input.tsx
@@ -1,6 +1,9 @@
 import {
   createElement,
+  useCallback,
+  useEffect,
   useRef,
+  useState,
   type ChangeEvent,
   type CSSProperties,
   type KeyboardEvent,
@@ -21,6 +24,13 @@ import type { QueuedMessage } from "../../types/tab";
 import { SlashPicker } from "./slash-picker";
 import { useComposerResize } from "./use-composer-resize";
 import { useDraftCommit } from "./use-draft-commit";
+import { useVoiceHotkey } from "../../hooks/useVoiceHotkey";
+import { useVoiceInput } from "../../hooks/useVoiceInput";
+import {
+  insertTranscriptAtSelection,
+  shouldOpenVoiceSettingsForError,
+} from "../../utils/voice";
+import { VoiceMeter } from "./voice-meter";
 import {
   type ArgMatch,
   type CommandMatch,
@@ -98,7 +108,81 @@ export function ChatInput({
     state,
   });
   const inputContainerRef = useRef<HTMLDivElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
   const { composerHeight, startComposerResize } = useComposerResize();
+  const insertTranscript = useCallback(
+    (transcript: string) => {
+      const textarea = textareaRef.current;
+      const start = textarea?.selectionStart ?? value.length;
+      const end = textarea?.selectionEnd ?? value.length;
+      const next = insertTranscriptAtSelection(
+        textarea?.value ?? value,
+        transcript,
+        start,
+        end,
+      );
+      setValue(next.text);
+      commitDraft(next.text);
+      requestAnimationFrame(() => {
+        const current = textareaRef.current;
+        if (!current) return;
+        current.focus();
+        current.selectionStart = current.selectionEnd = next.cursor;
+      });
+    },
+    [commitDraft, setValue, value],
+  );
+  const voice = useVoiceInput(insertTranscript, (providerId) => {
+    onEvent("voice:setup", { providerId });
+  });
+  const voiceState = voice.state;
+  const cancelVoice = voice.cancel;
+  const voiceConfig = (state.voice as
+    | { toggleHotkey?: string | null; holdHotkey?: string | null }
+    | undefined) ?? { toggleHotkey: "mod+shift+m", holdHotkey: null };
+  const isVoiceInputBlocked = useCallback(
+    () => {
+      const settings = state.settings as { open?: boolean } | undefined;
+      const palette = state.commandPalette as { open?: boolean } | undefined;
+      const search = state.search as { open?: boolean } | undefined;
+      return !!settings?.open || !!palette?.open || !!search?.open;
+    },
+    [state],
+  );
+  useVoiceHotkey(
+    voice,
+    voiceConfig.toggleHotkey ?? "mod+shift+m",
+    voiceConfig.holdHotkey ?? null,
+    isVoiceInputBlocked,
+  );
+  const [reducedMotion, setReducedMotion] = useState(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return false;
+    return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  });
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const onChange = (event: MediaQueryListEvent) =>
+      setReducedMotion(event.matches);
+    mq.addEventListener?.("change", onChange);
+    return () => mq.removeEventListener?.("change", onChange);
+  }, []);
+  useEffect(() => {
+    if (voiceState !== "recording") return;
+    const onKey = (event: globalThis.KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      cancelVoice();
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, [voiceState, cancelVoice]);
+  const useDynamicMeter =
+    !reducedMotion && voice.activeProvider?.recordingMode === "native";
+  const voiceErrorOpensSettings = shouldOpenVoiceSettingsForError(
+    voice.activeProvider,
+  );
 
   const insertMatch = (m: PickerMatch) => {
     const text =
@@ -124,6 +208,9 @@ export function ChatInput({
 
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     const submit = (mode: "normal" | "steer") => {
+      if (voice.state === "recording" || voice.state === "starting") {
+        voice.cancel();
+      }
       const v = (e.target as HTMLTextAreaElement).value;
       if (v.trim().length === 0) {
         if (mode === "steer" && canSteerQueuedMessage) {
@@ -192,6 +279,9 @@ export function ChatInput({
 
   const handleClick = () => {
     if (value.trim().length > 0) {
+      if (voice.state === "recording" || voice.state === "starting") {
+        voice.cancel();
+      }
       commitDraft(value);
       onEvent("submit", { value, mode: "normal" });
     }
@@ -245,6 +335,7 @@ export function ChatInput({
       )}
       <div className="a2ui-chat-input-field-wrap">
         <textarea
+          ref={textareaRef}
           className="a2ui-chat-input-field"
           placeholder={placeholder}
           value={value}
@@ -259,6 +350,41 @@ export function ChatInput({
             {queueBadgeFormat.replace("{n}", String(queueCount))}
           </span>
         )}
+        <VoiceStatus
+          voice={voice}
+          useDynamicMeter={useDynamicMeter}
+          errorOpensSettings={voiceErrorOpensSettings}
+          onOpenSettings={() =>
+            onEvent("voice:setup", { providerId: voice.activeProvider?.id })
+          }
+        />
+        <button
+          type="button"
+          className={`a2ui-chat-input-voice ${voice.state === "recording" ? "a2ui-chat-input-voice-recording" : ""} ${
+            voice.state === "starting" || voice.state === "transcribing"
+              ? "a2ui-chat-input-voice-busy"
+              : ""
+          }`}
+          onClick={() => {
+            if (voice.state === "recording") voice.stop();
+            else if (voice.state === "starting" || voice.state === "transcribing") {
+              voice.cancel();
+            } else {
+              void voice.start();
+            }
+          }}
+          disabled={busy}
+          aria-label={voiceButtonLabel(voice.state)}
+          title={voiceButtonLabel(voice.state)}
+        >
+          {voice.state === "starting" || voice.state === "transcribing" ? (
+            <SpinnerIcon />
+          ) : voice.state === "recording" ? (
+            <StopVoiceIcon />
+          ) : (
+            <MicIcon />
+          )}
+        </button>
         {busy ? (
           <button
             type="button"
@@ -315,5 +441,126 @@ export function ChatInput({
         )}
       </div>
     </div>
+  );
+}
+
+type VoiceView = ReturnType<typeof useVoiceInput>;
+
+function VoiceStatus({
+  voice,
+  useDynamicMeter,
+  errorOpensSettings,
+  onOpenSettings,
+}: {
+  voice: VoiceView;
+  useDynamicMeter: boolean;
+  errorOpensSettings: boolean;
+  onOpenSettings: () => void;
+}) {
+  if (voice.state === "recording") {
+    return (
+      <div className="a2ui-chat-input-voice-status">
+        <VoiceMeter
+          elapsedSeconds={voice.elapsedSeconds}
+          useDynamicMeter={useDynamicMeter}
+        />
+      </div>
+    );
+  }
+  if (voice.state === "starting" || voice.state === "transcribing") {
+    return (
+      <div className="a2ui-chat-input-voice-status" aria-live="polite">
+        <SpinnerIcon />
+        <span>
+          {voice.state === "starting"
+            ? "Starting..."
+            : voice.activeProvider?.name
+              ? `Transcribing with ${voice.activeProvider.name}`
+              : "Transcribing..."}
+        </span>
+      </div>
+    );
+  }
+  if (voice.state === "error" && voice.error) {
+    return (
+      <button
+        type="button"
+        className="a2ui-chat-input-voice-error"
+        onClick={errorOpensSettings ? onOpenSettings : voice.cancel}
+        title={voice.error}
+      >
+        <span aria-hidden="true">!</span>
+        <span>{voice.error}</span>
+      </button>
+    );
+  }
+  if (voice.state === "setup-required" && voice.error) {
+    return (
+      <button
+        type="button"
+        className="a2ui-chat-input-voice-error"
+        onClick={onOpenSettings}
+        title={voice.error}
+      >
+        <span aria-hidden="true">!</span>
+        <span>{voice.error}</span>
+      </button>
+    );
+  }
+  return null;
+}
+
+function voiceButtonLabel(state: VoiceView["state"]): string {
+  if (state === "recording") return "Stop voice input";
+  if (state === "starting") return "Cancel voice input";
+  if (state === "transcribing") return "Cancel transcription";
+  return "Voice input";
+}
+
+function MicIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" aria-hidden="true">
+      <path
+        d="M8 2.25a2.25 2.25 0 0 0-2.25 2.25V8a2.25 2.25 0 0 0 4.5 0V4.5A2.25 2.25 0 0 0 8 2.25Z"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.45"
+      />
+      <path
+        d="M3.75 7.25V8a4.25 4.25 0 0 0 8.5 0v-.75M8 12.25v1.5M5.75 13.75h4.5"
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeWidth="1.45"
+      />
+    </svg>
+  );
+}
+
+function StopVoiceIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 16 16" aria-hidden="true">
+      <rect x="3.5" y="3.5" width="9" height="9" rx="1.5" fill="currentColor" />
+    </svg>
+  );
+}
+
+function SpinnerIcon() {
+  return (
+    <svg
+      className="a2ui-chat-input-voice-spinner"
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      aria-hidden="true"
+    >
+      <path
+        d="M8 2.25a5.75 5.75 0 1 1-5.16 3.22"
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeWidth="1.7"
+      />
+    </svg>
   );
 }

--- a/src/skills/default-layout/palette-items.test.ts
+++ b/src/skills/default-layout/palette-items.test.ts
@@ -80,6 +80,7 @@ describe("selectPaletteItems", () => {
     expect(keys.some((k) => k.id === "keybind:ext:ctrl+g")).toBe(true);
     expect(keys.some((k) => k.id === "keybind:builtin:meta+k")).toBe(true);
     expect(keys.some((k) => k.id === "keybind:builtin:meta+.")).toBe(true);
+    expect(keys.some((k) => k.id === "keybind:builtin:meta+shift+m")).toBe(true);
     // Built-in count matches the catalogue.
     const builtinCount = keys.filter((k) =>
       k.id.startsWith("keybind:builtin:"),

--- a/src/skills/default-layout/palette-items.ts
+++ b/src/skills/default-layout/palette-items.ts
@@ -88,6 +88,7 @@ export const BUILTIN_KEYBINDINGS: BuiltinKeybinding[] = [
   { combo: "meta+d", description: "Toggle right sidebar (files)" },
   { combo: "meta+k", description: "Clear chat" },
   { combo: "meta+.", description: "Stop current prompt" },
+  { combo: "meta+shift+m", description: "Toggle voice input" },
   { combo: "meta+=", description: "Zoom in" },
   { combo: "meta+-", description: "Zoom out" },
   { combo: "meta+shift+0", description: "Reset zoom" },

--- a/src/skills/default-layout/settings-panel/hooks.ts
+++ b/src/skills/default-layout/settings-panel/hooks.ts
@@ -42,6 +42,7 @@ export function useEffectiveConfig(
       agent: { ...snapshot.agent, ...(p.agent ?? {}) },
       shell: { ...snapshot.shell, ...(p.shell ?? {}) },
       shortcuts: { ...snapshot.shortcuts, ...(p.shortcuts ?? {}) },
+      voice: { ...snapshot.voice, ...(p.voice ?? {}) },
       updates: { ...snapshot.updates, ...(p.updates ?? {}) },
       devshell: { ...snapshot.devshell, ...(p.devshell ?? {}) },
     };

--- a/src/skills/default-layout/settings-panel/panel.tsx
+++ b/src/skills/default-layout/settings-panel/panel.tsx
@@ -11,9 +11,19 @@
 // tab state.
 
 import { invoke } from "@tauri-apps/api/core";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { openUrl } from "@tauri-apps/plugin-opener";
+import { useCallback, useEffect, useState } from "react";
 import type { BuiltinComponentProps } from "../../../components/A2UIRenderer";
 import type { AethonConfig } from "../../../config";
+import {
+  listVoiceProviders,
+  prepareVoiceProvider,
+  removeVoiceProviderModel,
+  setSelectedVoiceProvider,
+  setVoiceProviderEnabled,
+} from "../../../services/voice";
+import type { VoiceDownloadProgress, VoiceProviderInfo } from "../../../types/voice";
 import { SHARE_MODES, type ShareMode } from "../../../utils/shareMode";
 import { ANSI_PREVIEW_KEYS, BUILTIN_THEMES } from "./constants";
 import { ExtensionsList } from "./extensions-list";
@@ -302,6 +312,42 @@ export function SettingsPanel({ state, onEvent }: BuiltinComponentProps) {
               </div>
             </Section>
 
+            <Section id="voice" title="Voice">
+              <Field label="Toggle hotkey">
+                <input
+                  type="text"
+                  className="ae-settings-input"
+                  value={eff.voice.toggleHotkey ?? ""}
+                  placeholder="mod+shift+m"
+                  onChange={(e) =>
+                    update({
+                      voice: {
+                        ...eff.voice,
+                        toggleHotkey: e.target.value || null,
+                      },
+                    })
+                  }
+                />
+              </Field>
+              <Field label="Hold-to-talk key">
+                <input
+                  type="text"
+                  className="ae-settings-input"
+                  value={eff.voice.holdHotkey ?? ""}
+                  placeholder="AltRight"
+                  onChange={(e) =>
+                    update({
+                      voice: {
+                        ...eff.voice,
+                        holdHotkey: e.target.value || null,
+                      },
+                    })
+                  }
+                />
+              </Field>
+              <VoiceProviders />
+            </Section>
+
             <Section id="updater" title="Updater">
               <Field label="Release channel">
                 <select
@@ -507,6 +553,166 @@ function Field(props: { label: string; children: React.ReactNode }) {
       <span className="ae-settings-field-label">{props.label}</span>
       <span className="ae-settings-field-control">{props.children}</span>
     </label>
+  );
+}
+
+function VoiceProviders() {
+  const [providers, setProviders] = useState<VoiceProviderInfo[] | null>(null);
+  const [busyProvider, setBusyProvider] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [progress, setProgress] = useState<VoiceDownloadProgress | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      setError(null);
+      setProviders(await listVoiceProviders());
+    } catch (err) {
+      setError(String(err));
+      setProviders([]);
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    listVoiceProviders()
+      .then((nextProviders) => {
+        if (cancelled) return;
+        setError(null);
+        setProviders(nextProviders);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(String(err));
+        setProviders([]);
+      });
+    let unlistenProgress: UnlistenFn | undefined;
+    let unlistenStatus: UnlistenFn | undefined;
+    const progressPromise = listen<VoiceDownloadProgress>(
+      "voice-download-progress",
+      (event) => setProgress(event.payload),
+    ).then((fn) => {
+      unlistenProgress = fn;
+    });
+    const statusPromise = listen<VoiceProviderInfo>(
+      "voice-provider-status",
+      (event) => {
+        setProviders((current) =>
+          (current ?? []).map((provider) =>
+            provider.id === event.payload.id ? event.payload : provider,
+          ),
+        );
+      },
+    ).then((fn) => {
+      unlistenStatus = fn;
+    });
+    return () => {
+      cancelled = true;
+      progressPromise.then(() => unlistenProgress?.());
+      statusPromise.then(() => unlistenStatus?.());
+    };
+  }, []);
+
+  const run = async (providerId: string, task: () => Promise<unknown>) => {
+    setBusyProvider(providerId);
+    setError(null);
+    try {
+      await task();
+      await refresh();
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setBusyProvider(null);
+      setProgress(null);
+    }
+  };
+
+  if (!providers) return <p className="ae-settings-note">Loading voice providers...</p>;
+
+  return (
+    <div className="ae-voice-provider-list">
+      {error ? <p className="ae-settings-note ae-voice-error">{error}</p> : null}
+      {providers.map((provider) => {
+        const isBusy = busyProvider === provider.id;
+        const providerProgress =
+          progress?.providerId === provider.id ? progress : null;
+        return (
+          <div key={provider.id} className="ae-voice-provider-card">
+            <div className="ae-voice-provider-head">
+              <div>
+                <strong>{provider.name}</strong>
+                <p>{provider.description}</p>
+              </div>
+              <label>
+                <input
+                  type="radio"
+                  name="voice-provider"
+                  checked={provider.selected}
+                  disabled={!provider.enabled}
+                  onChange={() =>
+                    run(provider.id, () => setSelectedVoiceProvider(provider.id))
+                  }
+                />
+                Use
+              </label>
+            </div>
+            <div className="ae-voice-provider-meta">
+              <span>{provider.statusLabel}</span>
+              <span>{provider.privacyLabel}</span>
+              {provider.modelSizeLabel ? <span>{provider.modelSizeLabel}</span> : null}
+              {provider.acceleratorLabel ? <span>{provider.acceleratorLabel}</span> : null}
+              {provider.cachePath ? <code>{provider.cachePath}</code> : null}
+            </div>
+            {provider.error ? (
+              <p className="ae-settings-note ae-voice-error">{provider.error}</p>
+            ) : null}
+            {providerProgress ? (
+              <p className="ae-settings-note">
+                Downloading {providerProgress.filename}:{" "}
+                {providerProgress.percent !== null
+                  ? `${Math.round(providerProgress.percent)}%`
+                  : `${providerProgress.overallDownloadedBytes} bytes`}
+              </p>
+            ) : null}
+            <div className="ae-voice-provider-actions">
+              <button
+                type="button"
+                className="ae-settings-secondary"
+                disabled={isBusy}
+                onClick={() =>
+                  run(provider.id, () =>
+                    setVoiceProviderEnabled(provider.id, !provider.enabled),
+                  )
+                }
+              >
+                {provider.enabled ? "Disable" : "Enable"}
+              </button>
+              {provider.setupRequired ? (
+                <button
+                  type="button"
+                  className="ae-settings-secondary"
+                  disabled={isBusy}
+                  onClick={() => run(provider.id, () => prepareVoiceProvider(provider.id))}
+                >
+                  {provider.downloadRequired ? "Download model" : "Set up permissions"}
+                </button>
+              ) : null}
+              {provider.canRemoveModel ? (
+                <button
+                  type="button"
+                  className="ae-settings-secondary"
+                  disabled={isBusy}
+                  onClick={() =>
+                    run(provider.id, () => removeVoiceProviderModel(provider.id))
+                  }
+                >
+                  Remove model
+                </button>
+              ) : null}
+            </div>
+          </div>
+        );
+      })}
+    </div>
   );
 }
 

--- a/src/skills/default-layout/settings-panel/panel.tsx
+++ b/src/skills/default-layout/settings-panel/panel.tsx
@@ -24,6 +24,7 @@ import {
   setVoiceProviderEnabled,
 } from "../../../services/voice";
 import type { VoiceDownloadProgress, VoiceProviderInfo } from "../../../types/voice";
+import { formatVoiceDownloadProgress } from "../../../utils/voice";
 import { SHARE_MODES, type ShareMode } from "../../../utils/shareMode";
 import { ANSI_PREVIEW_KEYS, BUILTIN_THEMES } from "./constants";
 import { ExtensionsList } from "./extensions-list";
@@ -613,6 +614,7 @@ function VoiceProviders() {
   }, []);
 
   const run = async (providerId: string, task: () => Promise<unknown>) => {
+    if (busyProvider === providerId) return;
     setBusyProvider(providerId);
     setError(null);
     try {
@@ -620,6 +622,7 @@ function VoiceProviders() {
       await refresh();
     } catch (err) {
       setError(String(err));
+      await refresh();
     } finally {
       setBusyProvider(null);
       setProgress(null);
@@ -635,6 +638,8 @@ function VoiceProviders() {
         const isBusy = busyProvider === provider.id;
         const providerProgress =
           progress?.providerId === provider.id ? progress : null;
+        const isDownloading =
+          provider.status === "downloading" || providerProgress !== null;
         return (
           <div key={provider.id} className="ae-voice-provider-card">
             <div className="ae-voice-provider-head">
@@ -668,16 +673,14 @@ function VoiceProviders() {
             {providerProgress ? (
               <p className="ae-settings-note">
                 Downloading {providerProgress.filename}:{" "}
-                {providerProgress.percent !== null
-                  ? `${Math.round(providerProgress.percent)}%`
-                  : `${providerProgress.overallDownloadedBytes} bytes`}
+                {formatVoiceDownloadProgress(providerProgress)}
               </p>
             ) : null}
             <div className="ae-voice-provider-actions">
               <button
                 type="button"
                 className="ae-settings-secondary"
-                disabled={isBusy}
+                disabled={isBusy || isDownloading}
                 onClick={() =>
                   run(provider.id, () =>
                     setVoiceProviderEnabled(provider.id, !provider.enabled),
@@ -690,10 +693,14 @@ function VoiceProviders() {
                 <button
                   type="button"
                   className="ae-settings-secondary"
-                  disabled={isBusy}
+                  disabled={isBusy || isDownloading}
                   onClick={() => run(provider.id, () => prepareVoiceProvider(provider.id))}
                 >
-                  {provider.downloadRequired ? "Download model" : "Set up permissions"}
+                  {isDownloading
+                    ? "Downloading..."
+                    : provider.downloadRequired
+                      ? "Download model"
+                      : "Set up permissions"}
                 </button>
               ) : null}
               {provider.canRemoveModel ? (

--- a/src/skills/default-layout/voice-meter.tsx
+++ b/src/skills/default-layout/voice-meter.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useRef, useState } from "react";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+
+interface VoiceMeterProps {
+  elapsedSeconds: number;
+  /**
+   * When true, subscribe to `voice://level` and animate the bars from RMS.
+   * When false, render static mid-range bars — used for `prefers-reduced-motion`
+   * and for webview-driven providers (Web Speech API) that don't emit levels.
+   */
+  useDynamicMeter: boolean;
+}
+
+/**
+ * Live VU meter for the chat composer's recording indicator. Owns its own
+ * level-event subscription so 30 Hz updates re-render only this component
+ * rather than the ~1k-line `ChatInputArea` parent.
+ */
+export function VoiceMeter({ elapsedSeconds, useDynamicMeter }: VoiceMeterProps) {
+  const [vuLevel, setVuLevel] = useState(0);
+  const smoothedRef = useRef(0);
+
+  useEffect(() => {
+    if (!useDynamicMeter) return;
+    smoothedRef.current = 0;
+    let unlistenFn: UnlistenFn | undefined;
+    const promise = listen<{ level: number }>("voice://level", (event) => {
+      const raw = event.payload.level;
+      smoothedRef.current = 0.6 * smoothedRef.current + 0.4 * raw;
+      setVuLevel(smoothedRef.current);
+    }).then((fn) => {
+      unlistenFn = fn;
+    });
+    return () => {
+      promise.then(() => unlistenFn?.());
+      smoothedRef.current = 0;
+    };
+  }, [useDynamicMeter]);
+
+  // Perceptual mapping: sqrt expands quiet speech, the noise gate ignores
+  // ambient hiss, and saturating at RMS=0.4 leaves headroom for loud peaks
+  // while letting typical speech (RMS 0.05–0.15) reach the middle of the bar
+  // range. Static fallback when dynamic mode is disabled.
+  const barMin = 4;
+  const barRange = 10; // 4–14 px
+  let center: number;
+  let outer: number;
+  if (!useDynamicMeter) {
+    center = 8;
+    outer = 8;
+  } else {
+    const noiseFloor = 0.002;
+    const saturation = 0.4;
+    const perceptual =
+      vuLevel <= noiseFloor
+        ? 0
+        : Math.min(Math.sqrt(vuLevel / saturation), 1);
+    center = barMin + perceptual * barRange;
+    outer = barMin + perceptual * barRange * 0.85;
+  }
+
+  return (
+    <div className="a2ui-voice-recording-status" aria-live="polite">
+      <span className="a2ui-voice-waveform" aria-hidden="true">
+        <span style={{ height: `${outer}px` }} />
+        <span style={{ height: `${center}px` }} />
+        <span style={{ height: `${outer}px` }} />
+      </span>
+      <span>{formatElapsedSeconds(elapsedSeconds)}</span>
+    </div>
+  );
+}
+
+function formatElapsedSeconds(totalSeconds: number): string {
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+}

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -2728,7 +2728,7 @@ body.ae-resizing-composer * {
   /* Right padding clears the absolute-positioned Send button so text
      doesn't run under it. Bottom padding clears the Send button when
      the user types multiple lines. */
-  padding: 10px 48px 10px 14px;
+  padding: 10px 86px 10px 14px;
   font: inherit;
   outline: none;
   line-height: 1.5;
@@ -2764,6 +2764,85 @@ body.ae-resizing-composer * {
     transform var(--motion-fast) var(--ease-out),
     opacity var(--motion-fast) var(--ease-out),
     box-shadow var(--motion-fast) var(--ease-out);
+}
+
+.a2ui-chat-input-voice {
+  position: absolute;
+  right: 44px;
+  bottom: 8px;
+  width: 30px;
+  height: 30px;
+  background: var(--bg-active);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition:
+    background var(--motion-fast) var(--ease-out),
+    transform var(--motion-fast) var(--ease-out),
+    border-color var(--motion-fast) var(--ease-out);
+}
+.a2ui-chat-input-voice:hover:not(:disabled) {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+}
+.a2ui-chat-input-voice:disabled {
+  opacity: var(--opacity-disabled);
+  cursor: not-allowed;
+}
+.a2ui-chat-input-voice-recording {
+  color: var(--danger, #ef4444);
+  border-color: color-mix(in srgb, currentColor 60%, transparent);
+}
+.a2ui-chat-input-voice-spinner {
+  animation: a2ui-voice-spin 0.9s linear infinite;
+}
+.a2ui-chat-input-voice-status,
+.a2ui-chat-input-voice-error {
+  position: absolute;
+  right: 82px;
+  bottom: 12px;
+  max-width: min(340px, calc(100% - 120px));
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-dim);
+  font-size: var(--chrome-text-compact);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.a2ui-chat-input-voice-error {
+  border: 0;
+  background: transparent;
+  color: var(--danger, #ef4444);
+  padding: 0;
+  cursor: pointer;
+}
+.a2ui-chat-input-voice-error span:last-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.a2ui-voice-recording-status,
+.a2ui-voice-waveform {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+.a2ui-voice-waveform span {
+  width: 3px;
+  border-radius: 999px;
+  background: currentColor;
+  transition: height 80ms linear;
+}
+@keyframes a2ui-voice-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 .a2ui-chat-input-send:hover:not(:disabled) {
   background: color-mix(in srgb, var(--accent) 90%, white);
@@ -2810,13 +2889,58 @@ body.ae-resizing-composer * {
   background: var(--accent-soft);
 }
 
+.ae-voice-provider-list {
+  display: grid;
+  gap: 10px;
+}
+.ae-voice-provider-card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 10px;
+  background: var(--bg-elev);
+}
+.ae-voice-provider-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: flex-start;
+}
+.ae-voice-provider-head p {
+  margin: 4px 0 0;
+  color: var(--text-dim);
+  font-size: var(--chrome-text-compact);
+}
+.ae-voice-provider-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 8px;
+  color: var(--text-dim);
+  font-size: var(--chrome-text-compact);
+}
+.ae-voice-provider-meta span,
+.ae-voice-provider-meta code {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 2px 6px;
+}
+.ae-voice-provider-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 10px;
+}
+.ae-voice-error {
+  color: var(--danger, #ef4444);
+}
+
 /* Queue badge — sits inside the wrap, to the left of the send button.
    Shows "+N" when the user has stacked messages behind an in-flight
    prompt via pi's followUp. Subdued so it informs without competing
    with the action buttons. */
 .a2ui-chat-input-queue {
   position: absolute;
-  right: 46px;
+  right: 82px;
   bottom: 12px;
   padding: 2px 8px;
   border-radius: 999px;

--- a/src/types/voice.ts
+++ b/src/types/voice.ts
@@ -1,0 +1,42 @@
+export type VoiceProviderKind = "platform" | "local-model" | "external";
+
+export type VoiceRecordingMode = "native" | "webview";
+
+export type VoiceProviderStatus =
+  | "ready"
+  | "needs-setup"
+  | "downloading"
+  | "engine-unavailable"
+  | "unavailable"
+  | "error";
+
+export interface VoiceProviderInfo {
+  id: string;
+  name: string;
+  description: string;
+  kind: VoiceProviderKind;
+  recordingMode: VoiceRecordingMode;
+  privacyLabel: string;
+  offline: boolean;
+  downloadRequired: boolean;
+  modelSizeLabel: string | null;
+  cachePath: string | null;
+  acceleratorLabel: string | null;
+  status: VoiceProviderStatus;
+  statusLabel: string;
+  enabled: boolean;
+  selected: boolean;
+  setupRequired: boolean;
+  canRemoveModel: boolean;
+  error: string | null;
+}
+
+export interface VoiceDownloadProgress {
+  providerId: string;
+  filename: string;
+  downloadedBytes: number;
+  totalBytes: number | null;
+  overallDownloadedBytes: number;
+  overallTotalBytes: number | null;
+  percent: number | null;
+}

--- a/src/utils/voice.test.ts
+++ b/src/utils/voice.test.ts
@@ -4,6 +4,7 @@ import {
   PLATFORM_VOICE_PROVIDER_ID,
   chooseVoiceProvider,
   describeSpeechRecognitionError,
+  formatVoiceDownloadProgress,
   insertTranscriptAtSelection,
   shouldOpenVoiceSettingsForError,
 } from "./voice";
@@ -82,6 +83,31 @@ describe("voice helpers", () => {
       text: "tests now",
       cursor: 5,
     });
+  });
+
+  it("formats backend download fractions as user-facing percentages", () => {
+    expect(
+      formatVoiceDownloadProgress({
+        providerId: "voice-distil-whisper",
+        filename: "model.safetensors",
+        downloadedBytes: 250,
+        totalBytes: 1000,
+        overallDownloadedBytes: 250,
+        overallTotalBytes: 1000,
+        percent: 0.25,
+      }),
+    ).toBe("25%");
+    expect(
+      formatVoiceDownloadProgress({
+        providerId: "voice-distil-whisper",
+        filename: "model.safetensors",
+        downloadedBytes: 250,
+        totalBytes: null,
+        overallDownloadedBytes: 250,
+        overallTotalBytes: null,
+        percent: null,
+      }),
+    ).toBe("250 bytes");
   });
 
   it("opens settings for setup and engine errors", () => {

--- a/src/utils/voice.test.ts
+++ b/src/utils/voice.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import type { VoiceProviderInfo } from "../types/voice";
+import {
+  PLATFORM_VOICE_PROVIDER_ID,
+  chooseVoiceProvider,
+  describeSpeechRecognitionError,
+  insertTranscriptAtSelection,
+  shouldOpenVoiceSettingsForError,
+} from "./voice";
+
+function provider(
+  overrides: Partial<VoiceProviderInfo> & Pick<VoiceProviderInfo, "id">,
+): VoiceProviderInfo {
+  return {
+    name: overrides.id,
+    description: "",
+    kind: "platform",
+    recordingMode: "native",
+    privacyLabel: "",
+    offline: false,
+    downloadRequired: false,
+    modelSizeLabel: null,
+    cachePath: null,
+    acceleratorLabel: null,
+    status: "ready",
+    statusLabel: "Ready",
+    enabled: true,
+    selected: false,
+    setupRequired: false,
+    canRemoveModel: false,
+    error: null,
+    ...overrides,
+    id: overrides.id,
+  };
+}
+
+describe("voice helpers", () => {
+  it("prefers the selected ready provider", () => {
+    const selected = provider({
+      id: "voice-platform-system",
+      selected: true,
+    });
+
+    expect(
+      chooseVoiceProvider([
+        provider({ id: "voice-distil-whisper", kind: "local-model" }),
+        selected,
+      ]),
+    ).toBe(selected);
+  });
+
+  it("falls back to ready local model before platform provider", () => {
+    const local = provider({
+      id: "voice-distil-whisper",
+      kind: "local-model",
+    });
+
+    expect(
+      chooseVoiceProvider([
+        provider({ id: PLATFORM_VOICE_PROVIDER_ID }),
+        local,
+      ]),
+    ).toBe(local);
+  });
+
+  it("returns setup-required providers when nothing is ready", () => {
+    const setup = provider({
+      id: PLATFORM_VOICE_PROVIDER_ID,
+      status: "needs-setup",
+      setupRequired: true,
+    });
+
+    expect(chooseVoiceProvider([setup])).toBe(setup);
+  });
+
+  it("inserts transcripts at textarea selection with natural spacing", () => {
+    expect(insertTranscriptAtSelection("run now", "tests", 3, 3)).toEqual({
+      text: "run tests now",
+      cursor: 9,
+    });
+    expect(insertTranscriptAtSelection("run now", "tests", 0, 3)).toEqual({
+      text: "tests now",
+      cursor: 5,
+    });
+  });
+
+  it("opens settings for setup and engine errors", () => {
+    expect(
+      shouldOpenVoiceSettingsForError(
+        provider({ id: PLATFORM_VOICE_PROVIDER_ID, setupRequired: true }),
+      ),
+    ).toBe(true);
+    expect(
+      shouldOpenVoiceSettingsForError(
+        provider({ id: "voice-distil-whisper", status: "engine-unavailable" }),
+      ),
+    ).toBe(true);
+    expect(shouldOpenVoiceSettingsForError(provider({ id: "ready" }))).toBe(
+      false,
+    );
+  });
+
+  it("describes common speech recognition errors in plain English", () => {
+    expect(
+      describeSpeechRecognitionError({ error: "not-allowed" }),
+    ).toContain("Microphone and Speech Recognition permission");
+    expect(describeSpeechRecognitionError({ error: "no-speech" })).toContain(
+      "No speech was detected",
+    );
+    expect(describeSpeechRecognitionError({ message: "boom" })).toBe(
+      "System dictation failed: boom",
+    );
+  });
+});

--- a/src/utils/voice.ts
+++ b/src/utils/voice.ts
@@ -1,4 +1,4 @@
-import type { VoiceProviderInfo } from "../types/voice";
+import type { VoiceDownloadProgress, VoiceProviderInfo } from "../types/voice";
 
 export const PLATFORM_VOICE_PROVIDER_ID = "voice-platform-system";
 
@@ -67,6 +67,15 @@ export function insertTranscriptAtSelection(
     text: nextText,
     cursor: before.length + insertion.length,
   };
+}
+
+export function formatVoiceDownloadProgress(
+  progress: VoiceDownloadProgress,
+): string {
+  if (progress.percent !== null) {
+    return `${Math.round(progress.percent * 100)}%`;
+  }
+  return `${progress.overallDownloadedBytes} bytes`;
 }
 
 export function describeSpeechRecognitionError(

--- a/src/utils/voice.ts
+++ b/src/utils/voice.ts
@@ -1,0 +1,105 @@
+import type { VoiceProviderInfo } from "../types/voice";
+
+export const PLATFORM_VOICE_PROVIDER_ID = "voice-platform-system";
+
+export interface SpeechRecognitionErrorLike {
+  error?: string;
+  message?: string;
+}
+
+export function chooseVoiceProvider(
+  providers: VoiceProviderInfo[],
+): VoiceProviderInfo | null {
+  const selected = providers.find(
+    (provider) => provider.selected && provider.enabled,
+  );
+  if (selected) {
+    return selected;
+  }
+
+  const readyLocal = providers.find(
+    (provider) =>
+      provider.kind === "local-model" &&
+      provider.enabled &&
+      provider.status === "ready",
+  );
+  const platform = providers.find(
+    (provider) =>
+      provider.id === PLATFORM_VOICE_PROVIDER_ID &&
+      provider.enabled &&
+      provider.status === "ready",
+  );
+  const setupRequired = providers.find(
+    (provider) => provider.enabled && provider.setupRequired,
+  );
+  return readyLocal ?? platform ?? setupRequired ?? null;
+}
+
+export function isNativeVoiceProvider(provider: VoiceProviderInfo): boolean {
+  return provider.recordingMode === "native";
+}
+
+export function shouldOpenVoiceSettingsForError(
+  provider: VoiceProviderInfo | null,
+): boolean {
+  if (!provider) return false;
+  return (
+    provider.setupRequired ||
+    provider.status === "needs-setup" ||
+    provider.status === "engine-unavailable" ||
+    provider.status === "error"
+  );
+}
+
+export function insertTranscriptAtSelection(
+  text: string,
+  transcript: string,
+  start: number,
+  end: number,
+): { text: string; cursor: number } {
+  const before = text.slice(0, start);
+  const after = text.slice(end);
+  const needsLeadingSpace = before.length > 0 && !/\s$/.test(before);
+  const needsTrailingSpace = after.length > 0 && !/^\s/.test(after);
+  const insertion = `${needsLeadingSpace ? " " : ""}${transcript}${needsTrailingSpace ? " " : ""}`;
+  const nextText = before + insertion + after;
+  return {
+    text: nextText,
+    cursor: before.length + insertion.length,
+  };
+}
+
+export function describeSpeechRecognitionError(
+  event: SpeechRecognitionErrorLike,
+): string {
+  const error = event.error?.trim() ?? "";
+  const message = event.message?.trim() ?? "";
+  const detail = message || error;
+  const normalized = `${error} ${message}`.toLowerCase();
+
+  if (
+    error === "not-allowed" ||
+    error === "service-not-allowed" ||
+    normalized.includes("permission")
+  ) {
+    return "System dictation needs Microphone and Speech Recognition permission. Enable both for Aethon in System Settings, then restart the app.";
+  }
+
+  if (error === "audio-capture") {
+    return "System dictation could not access a microphone. Check your input device and microphone permission.";
+  }
+
+  if (error === "network") {
+    return "System dictation could not reach the platform speech recognition service. Try again, or use an offline provider when available.";
+  }
+
+  if (error === "no-speech") {
+    return "No speech was detected. Try again closer to the microphone.";
+  }
+
+  if (error === "language-not-supported") {
+    return "System dictation does not support the current input language.";
+  }
+
+  return detail ? `System dictation failed: ${detail}` : "System dictation failed.";
+}

--- a/src/utils/voiceHotkeys.ts
+++ b/src/utils/voiceHotkeys.ts
@@ -1,0 +1,24 @@
+/** Voice hotkey constants and platform helpers.
+ *
+ * This file is intentionally small and dependency-free (no React, no Zustand)
+ * so it can be imported by both the hook (`useVoiceHotkey.ts`) and the
+ * settings slice (`settingsSlice.ts`) without creating a circular dependency.
+ */
+
+export const DEFAULT_TOGGLE_HOTKEY = "mod+shift+m";
+
+/** macOS-only default hold key. On Windows/Linux the same physical key is
+ * frequently bound to AltGr (used to type @, {}, ñ, ç, etc.), so binding
+ * voice input to it would break common text entry. Use null elsewhere and
+ * let users opt in via Settings → Keyboard. */
+export const DEFAULT_HOLD_HOTKEY_MAC = "AltRight";
+
+export function isMacPlatform(): boolean {
+  if (typeof navigator === "undefined") return false;
+  return /Mac/.test(navigator.platform) || /Mac OS X/.test(navigator.userAgent);
+}
+
+/** Platform-aware default for the hold-to-talk key. */
+export function getDefaultHoldHotkey(): string | null {
+  return isMacPlatform() ? DEFAULT_HOLD_HOTKEY_MAC : null;
+}


### PR DESCRIPTION
## Summary

Adds Claudette-style voice-to-text support to Aethon across the Rust shell and default-layout UI. The branch includes native macOS system dictation, an offline Distil-Whisper/Candle provider, provider settings, composer controls, hotkeys, VU levels, and no-feature shims for builds without voice support.

## What changed

- Added a default `voice` Cargo feature and the native Rust voice backend, including provider resolution, recording lifecycle, audio validation, provider preparation, local model cache detection, cancellation, timeout handling, and Tauri IPC commands.
- Added macOS system speech support through a Swift bridge, with build script wiring, Info.plist usage strings, entitlements, and Tauri config references.
- Added offline Distil-Whisper provider support with model download/progress events, Candle backend checks, local cache metadata, removal, and transcribe lifecycle plumbing.
- Persisted voice provider state in `~/.aethon/voice.json`, while keeping user-editable voice hotkeys in config.
- Integrated voice input into the registered `chat-input` composite with a mic button, status UI, VU meter, transcript insertion at the current textarea selection, Esc/blur/submit cancellation paths, and toggle/hold hotkeys.
- Added a Settings Voice section for provider selection, enable/disable, preparation/download/removal, provider labels, download progress, and hotkey editing.
- Updated the Nix dev helper path so macOS voice permissions work from the devshell `dev` command by launching through a temporary `.app` bundle runner instead of a raw binary.
- Fixed offline model download UX after the initial implementation: backend progress fractions now render as real percentages, active downloads disable duplicate actions, and stale persisted `downloading` state no longer survives app restarts.

## Root cause / follow-up fixes

The first implementation had two dev-facing gaps that showed up immediately in the settings UI:

- macOS Speech permissions require an app bundle identity, so `cargo tauri dev` needed to go through the same style of development app runner Claudette uses.
- Distil-Whisper download progress was emitted as a `0.0..1.0` fraction but rendered as if it were already `0..100`, which made progress appear stuck at `0%`. The backend also persisted `downloading`, which could leave the provider stuck after a killed dev session.

Both are addressed in this branch.

## Validation

- `bunx vitest run src/utils/voice.test.ts src/services/voice.test.ts src/hooks/useVoiceHotkey.test.ts src/hooks/useVoiceInput.test.ts src/eventRoutes/chatInput.test.ts`
- `bun run typecheck`
- `bun run lint` (exits 0; existing unrelated React hook warnings remain in dashboard/editor files)
- `cargo fmt --all --check`
- `cargo test --lib -p aethon downloading`
- `cargo test --lib -p aethon active_download_state_is_runtime_only`
- `cargo check -p aethon --features voice`
- `nix develop -c dev --help` to confirm the devshell helper routes through `scripts/dev.sh`

## Notes

I did not force a full 1.5 GB model download as part of validation. The PR validates the progress rendering, stale state handling, command wiring, and compile/test paths around the download flow.