### PR TITLE
fix(updater): foreground app after update relaunch

### DIFF
--- a/src-tauri/src/boot_probation.rs
+++ b/src-tauri/src/boot_probation.rs
@@ -286,6 +286,19 @@ pub fn acknowledge_boot(data_dir: &Path, state: &Arc<BootProbationState>) -> Res
     }
 }
 
+/// True when the current launch is part of the post-update probation
+/// window. Setup uses this to restore Aethon to the foreground after
+/// the updater relaunches the newly-installed app.
+pub fn has_pending_probation(data_dir: &Path) -> bool {
+    let path = sentinel_path(data_dir);
+    let _guard = PROBATION_FILE_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    read_probation_path(&path)
+        .map(|probation| matches!(probation.status, ProbationStatus::Pending))
+        .unwrap_or(false)
+}
+
 pub fn start_monitor(app: AppHandle, state: Arc<BootProbationState>, data_dir: PathBuf) {
     let path = sentinel_path(&data_dir);
     let _guard = PROBATION_FILE_LOCK
@@ -1031,6 +1044,20 @@ mod tests {
 
         assert!(state.is_acknowledged());
         assert!(!sentinel_path(tmp.path()).exists());
+    }
+
+    #[test]
+    fn pending_probation_marks_post_update_launch() {
+        let tmp = tempdir().unwrap();
+        assert!(!has_pending_probation(tmp.path()));
+
+        let mut probation = sample_probation(tmp.path(), None);
+        write_probation(tmp.path(), &probation).unwrap();
+        assert!(has_pending_probation(tmp.path()));
+
+        probation.status = ProbationStatus::RollbackInProgress;
+        write_probation(tmp.path(), &probation).unwrap();
+        assert!(!has_pending_probation(tmp.path()));
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -253,9 +253,11 @@ pub fn run() {
             // that the frontend cancels via `boot_ok` once it reaches a
             // healthy render. Both calls are no-ops when there's no
             // sentinel/report on disk — they don't slow normal launches.
+            let mut activate_after_update = false;
             if let Ok(home) = app.path().home_dir()
                 && let Some(data_dir) = helpers::aethon_dir(Some(home))
             {
+                activate_after_update = boot_probation::has_pending_probation(&data_dir);
                 boot_probation::show_pending_report(app.handle(), &data_dir);
                 let boot_state =
                     Arc::clone(&app.state::<updater_state::UpdaterState>().boot_probation);
@@ -292,12 +294,20 @@ pub fn run() {
             // primary monitor", replacing the previous hardcoded
             // `maximize()` that worked around the unreliable manifest
             // `"maximized": true` on macOS.
-            if let Err(err) = window_state::restore_on_setup(app.handle()) {
+            if let Err(err) = window_state::restore_on_setup(app.handle(), activate_after_update) {
                 tracing::warn!(target: "aethon::window_state", "restore failed: {err}");
                 // Best-effort: show the window anyway so a corrupt
                 // state file can never strand the user.
                 if let Some(w) = app.get_webview_window("main") {
+                    if activate_after_update {
+                        #[cfg(target_os = "macos")]
+                        let _ = app.handle().show();
+                        let _ = w.unminimize();
+                    }
                     let _ = w.show();
+                    if activate_after_update {
+                        let _ = w.set_focus();
+                    }
                 }
             }
             // Built-in HTTP + mDNS server. Failures inside `boot` are
@@ -370,5 +380,19 @@ mod tests {
                 "{command} must stay registered in the invoke_handler list",
             );
         }
+    }
+
+    #[test]
+    fn update_probation_launch_activates_restored_window() {
+        let src = include_str!("lib.rs");
+        let sentinel_pos = src.find("has_pending_probation(&data_dir)").unwrap();
+        let restore_pos = src
+            .find("restore_on_setup(app.handle(), activate_after_update)")
+            .unwrap();
+
+        assert!(
+            sentinel_pos < restore_pos,
+            "setup must detect a post-update probation launch before restoring the main window so updater relaunches come back to the foreground",
+        );
     }
 }

--- a/src-tauri/src/window_state/restore.rs
+++ b/src-tauri/src/window_state/restore.rs
@@ -69,12 +69,12 @@ pub fn restore_on_setup(app: &AppHandle, activate_after_show: bool) -> Result<()
     Ok(())
 }
 
-fn show_main_window(app: &AppHandle, window: &tauri::WebviewWindow, activate: bool) {
+fn show_main_window(_app: &AppHandle, window: &tauri::WebviewWindow, activate: bool) {
     if activate {
         // Cmd+H on macOS hides the app at the application level;
         // showing/focusing the webview alone does not unhide it.
         #[cfg(target_os = "macos")]
-        let _ = app.show();
+        let _ = _app.show();
         let _ = window.unminimize();
     }
     if let Err(e) = window.show() {
@@ -265,7 +265,7 @@ mod tests {
     #[test]
     fn update_launch_activation_shows_unminimizes_and_focuses() {
         let src = include_str!("restore.rs");
-        let app_show_pos = src.find("let _ = app.show()").unwrap();
+        let app_show_pos = src.find("let _ = _app.show()").unwrap();
         let unminimize_pos = src.find("window.unminimize()").unwrap();
         let show_pos = src.find("window.show()").unwrap();
         let focus_pos = src.find("window.set_focus()").unwrap();

--- a/src-tauri/src/window_state/restore.rs
+++ b/src-tauri/src/window_state/restore.rs
@@ -20,8 +20,10 @@ const CLAMP_MARGIN_Y: f64 = 40.0;
 
 /// Apply persisted geometry before the window is shown. First launch
 /// falls back to maximized on the primary monitor. Always shows the
-/// window so a partial failure can't strand the user.
-pub fn restore_on_setup(app: &AppHandle) -> Result<(), String> {
+/// window so a partial failure can't strand the user. When
+/// `activate_after_show` is true, the main window is also brought to
+/// the foreground after an updater relaunch.
+pub fn restore_on_setup(app: &AppHandle, activate_after_show: bool) -> Result<(), String> {
     let store = load_store(app);
     let Some(window) = app.get_webview_window(MAIN_LABEL) else {
         tracing::warn!(target: "aethon::window_state", "main window not found at setup");
@@ -63,10 +65,24 @@ pub fn restore_on_setup(app: &AppHandle) -> Result<(), String> {
         tracing::warn!(target: "aethon::window_state", "default maximize: {e}");
     }
 
+    show_main_window(app, &window, activate_after_show);
+    Ok(())
+}
+
+fn show_main_window(app: &AppHandle, window: &tauri::WebviewWindow, activate: bool) {
+    if activate {
+        // Cmd+H on macOS hides the app at the application level;
+        // showing/focusing the webview alone does not unhide it.
+        #[cfg(target_os = "macos")]
+        let _ = app.show();
+        let _ = window.unminimize();
+    }
     if let Err(e) = window.show() {
         tracing::warn!(target: "aethon::window_state", "show: {e}");
     }
-    Ok(())
+    if activate && let Err(e) = window.set_focus() {
+        tracing::warn!(target: "aethon::window_state", "set_focus: {e}");
+    }
 }
 
 /// Compute the bounds the window should restore to, given the saved
@@ -244,5 +260,19 @@ mod tests {
         // should translate as if `near_window` was picked — dx = 0.
         assert!(approx_eq(out.x, 100.0));
         assert!(approx_eq(out.y, 100.0));
+    }
+
+    #[test]
+    fn update_launch_activation_shows_unminimizes_and_focuses() {
+        let src = include_str!("restore.rs");
+        let app_show_pos = src.find("let _ = app.show()").unwrap();
+        let unminimize_pos = src.find("window.unminimize()").unwrap();
+        let show_pos = src.find("window.show()").unwrap();
+        let focus_pos = src.find("window.set_focus()").unwrap();
+
+        assert!(
+            app_show_pos < unminimize_pos && unminimize_pos < show_pos && show_pos < focus_pos,
+            "post-update activation must unhide the app, unminimize/show the window, then focus it",
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Detect post-update launches from the boot-probation sentinel before setup restores the main window.
- When that sentinel is present, unhide the macOS app, unminimize/show the main window, and focus it after geometry restoration.
- Preserve ordinary launch behavior by only activating the window for update-probation boots, with a fallback path for corrupt window-state restore failures.

## Root cause

The updater restart brought the new release process back, but setup only showed the restored webview window. On macOS, especially after app-level hiding/backgrounding, showing the webview is not enough to reactivate the application, so the new build could remain behind other apps.

## Validation

- cargo fmt --manifest-path src-tauri/Cargo.toml
- cargo test --manifest-path src-tauri/Cargo.toml --lib pending_probation_marks_post_update_launch
- cargo test --manifest-path src-tauri/Cargo.toml --lib update_launch_activation_shows_unminimizes_and_focuses
- cargo test --manifest-path src-tauri/Cargo.toml --lib update_probation_launch_activates_restored_window
- cargo test --manifest-path src-tauri/Cargo.toml --lib boot_probation
- cargo test --manifest-path src-tauri/Cargo.toml --lib window_state::restore
- cargo test --manifest-path src-tauri/Cargo.toml --lib
- git diff --check