### PR TITLE
fix(agent): retry transient transport failures

### DIFF
--- a/agent/agent-errors.test.ts
+++ b/agent/agent-errors.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { extractAgentEndError } from "./agent-errors";
+import { extractAgentEndError, isRetryableAgentEndError } from "./agent-errors";
 
 describe("extractAgentEndError", () => {
   it("returns undefined for an empty or missing list", () => {
@@ -51,5 +51,21 @@ describe("extractAgentEndError", () => {
         { role: "assistant", stopReason: "error", errorMessage: "boom" },
       ]),
     ).toBe("boom");
+  });
+});
+
+describe("isRetryableAgentEndError", () => {
+  it("classifies transient websocket closures as retryable", () => {
+    expect(
+      isRetryableAgentEndError("WebSocket closed 1006 Connection ended"),
+    ).toBe(true);
+  });
+
+  it("does not classify account/configuration errors as retryable", () => {
+    expect(
+      isRetryableAgentEndError(
+        "Your credit balance is too low to access the Anthropic API.",
+      ),
+    ).toBe(false);
   });
 });

--- a/agent/agent-errors.ts
+++ b/agent/agent-errors.ts
@@ -31,3 +31,10 @@ export function extractAgentEndError(
   }
   return undefined;
 }
+
+const RETRYABLE_AGENT_ERROR_RE =
+  /overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|network.?error|connection.?error|connection.?refused|connection.?lost|connection.?ended|websocket.?closed|1006|other side closed|fetch failed|upstream.?connect|reset before headers|socket hang up|ended without|http2 request did not get a response|timed? out|timeout|terminated|retry delay/i;
+
+export function isRetryableAgentEndError(message: string): boolean {
+  return RETRYABLE_AGENT_ERROR_RE.test(message);
+}

--- a/agent/tab-lifecycle.test.ts
+++ b/agent/tab-lifecycle.test.ts
@@ -16,6 +16,7 @@ import {
   modelDescriptor,
   modelKey,
   refreshPiSlashCommands,
+  installAethonRetryClassifier,
   summarizeToolArgs,
   tabSessionDir,
   toolCardPayload,
@@ -607,9 +608,94 @@ describe("handleSessionEvent", () => {
     expect(f.sent.find((m) => m.type === "response_end")).toBeDefined();
   });
 
+  it("agent_end during auto-retry keeps the turn in-flight and suppresses the transient error", () => {
+    const f = makeFixture();
+    const rec = fakeRec();
+    rec.promptInFlight = true;
+    rec.session = {
+      ...rec.session,
+      isRetrying: true,
+    } as TabRecord["session"];
+    f.state.currentAgentTabId = "tab-1";
+
+    handleSessionEvent(f.state, f.deps, rec, "tab-1", {
+      type: "agent_end",
+      messages: [
+        {
+          role: "assistant",
+          stopReason: "error",
+          errorMessage: "WebSocket closed 1006 Connection ended",
+        },
+      ],
+    });
+
+    expect(rec.promptInFlight).toBe(true);
+    expect(rec.agentEndFired).toBe(false);
+    expect(f.state.currentAgentTabId).toBe("tab-1");
+    expect(f.sent.some((m) => m.type === "error")).toBe(false);
+    expect(f.sent.some((m) => m.type === "response_end")).toBe(false);
+  });
+
+  it("agent_end during auto-retry surfaces non-retryable failures and ends the turn", () => {
+    const f = makeFixture();
+    const rec = fakeRec();
+    rec.promptInFlight = true;
+    rec.session = {
+      ...rec.session,
+      isRetrying: true,
+    } as TabRecord["session"];
+    f.state.currentAgentTabId = "tab-1";
+
+    handleSessionEvent(f.state, f.deps, rec, "tab-1", {
+      type: "agent_end",
+      messages: [
+        {
+          role: "assistant",
+          stopReason: "error",
+          errorMessage:
+            "Authentication failed for openai-codex. Run /login openai-codex.",
+        },
+      ],
+    });
+
+    expect(f.sent[0]).toMatchObject({
+      type: "error",
+      tabId: "tab-1",
+      message: "Authentication failed for openai-codex. Run /login openai-codex.",
+    });
+    expect(f.sent[1]).toMatchObject({ type: "response_end", tabId: "tab-1" });
+    expect(rec.promptInFlight).toBe(false);
+    expect(rec.agentEndFired).toBe(true);
+    expect(f.state.currentAgentTabId).toBeUndefined();
+  });
+
+  it("auto_retry_start keeps the tab busy and tells the frontend a retry is underway", () => {
+    const f = makeFixture();
+    const rec = fakeRec();
+
+    handleSessionEvent(f.state, f.deps, rec, "tab-1", {
+      type: "auto_retry_start",
+      attempt: 1,
+      maxAttempts: 3,
+      delayMs: 2_000,
+      errorMessage: "WebSocket closed 1006 Connection ended",
+    });
+
+    expect(rec.promptInFlight).toBe(true);
+    expect(rec.agentEndFired).toBe(false);
+    expect(f.state.currentAgentTabId).toBe("tab-1");
+    expect(f.sent[0]).toMatchObject({
+      type: "notice",
+      tabId: "tab-1",
+      message: "Transient provider error; retrying 1/3 in 2s.",
+    });
+  });
+
   it("auto_retry_end with !success emits an error message", () => {
     const f = makeFixture();
     const rec = fakeRec();
+    rec.promptInFlight = true;
+    f.state.currentAgentTabId = "tab-1";
     handleSessionEvent(f.state, f.deps, rec, "tab-1", {
       type: "auto_retry_end",
       success: false,
@@ -619,6 +705,10 @@ describe("handleSessionEvent", () => {
       type: "error",
       message: "auto-retry exhausted: rate limit",
     });
+    expect(f.sent[1]).toMatchObject({ type: "response_end", tabId: "tab-1" });
+    expect(rec.promptInFlight).toBe(false);
+    expect(rec.agentEndFired).toBe(true);
+    expect(f.state.currentAgentTabId).toBeUndefined();
   });
 
   it("auto_retry_end with success is a no-op", () => {
@@ -629,5 +719,32 @@ describe("handleSessionEvent", () => {
       success: true,
     });
     expect(f.sent).toHaveLength(0);
+  });
+
+  it("extends pi's retry classifier for websocket 1006 transport drops", () => {
+    const session = {
+      _isRetryableError: (message: { errorMessage?: string }) =>
+        message.errorMessage === "upstream retryable",
+    };
+    installAethonRetryClassifier(session);
+
+    expect(
+      session._isRetryableError({
+        stopReason: "error",
+        errorMessage: "upstream retryable",
+      }),
+    ).toBe(true);
+    expect(
+      session._isRetryableError({
+        stopReason: "error",
+        errorMessage: "WebSocket closed 1006 Connection ended",
+      }),
+    ).toBe(true);
+    expect(
+      session._isRetryableError({
+        stopReason: "error",
+        errorMessage: "Your credit balance is too low",
+      }),
+    ).toBe(false);
   });
 });

--- a/agent/tab-lifecycle/events.ts
+++ b/agent/tab-lifecycle/events.ts
@@ -16,7 +16,10 @@
  *    the turn UI, even on error.
  */
 
-import { extractAgentEndError } from "../agent-errors";
+import {
+  extractAgentEndError,
+  isRetryableAgentEndError,
+} from "../agent-errors";
 import { logger } from "../logger";
 import type { AethonAgentState, TabRecord } from "../state";
 import { consumeBashTerminalSnapshot } from "../terminal-stream";
@@ -197,7 +200,12 @@ export function handleSessionEvent(
     case "agent_end": {
       const messages = (event as { messages?: unknown[] }).messages;
       const failedMessage = extractAgentEndError(messages);
-      if (failedMessage) {
+      const retrying =
+        (rec.session as { isRetrying?: boolean } | undefined)?.isRetrying === true;
+      const retryableFailure =
+        failedMessage !== undefined && isRetryableAgentEndError(failedMessage);
+      const keepTurnOpenForRetry = retrying && retryableFailure;
+      if (failedMessage && !keepTurnOpenForRetry) {
         deps.send({ type: "error", tabId, message: failedMessage });
       }
       const startMs = state.turnStartTimes.get(tabId);
@@ -221,12 +229,36 @@ export function handleSessionEvent(
       for (const [toolCallId, cached] of rec.toolArgsCache) {
         if (cached.endedAt !== undefined) rec.toolArgsCache.delete(toolCallId);
       }
-      rec.agentEndFired = true;
-      rec.promptInFlight = false;
-      if (state.currentAgentTabId === tabId) {
-        state.currentAgentTabId = undefined;
+      if (!keepTurnOpenForRetry) {
+        rec.agentEndFired = true;
+        rec.promptInFlight = false;
+        if (state.currentAgentTabId === tabId) {
+          state.currentAgentTabId = undefined;
+        }
+        deps.send({ type: "response_end", tabId });
       }
-      deps.send({ type: "response_end", tabId });
+      break;
+    }
+    case "auto_retry_start": {
+      const ev = event as {
+        attempt?: number;
+        maxAttempts?: number;
+        delayMs?: number;
+        errorMessage?: string;
+      };
+      rec.promptInFlight = true;
+      rec.agentEndFired = false;
+      state.currentAgentTabId = tabId;
+      deps.send({
+        type: "notice",
+        tabId,
+        message: `Transient provider error; retrying ${
+          ev.attempt ?? "?"
+        }/${ev.maxAttempts ?? "?"} in ${Math.max(
+          0,
+          Math.round((ev.delayMs ?? 0) / 1000),
+        )}s.`,
+      });
       break;
     }
     case "auto_retry_end": {
@@ -237,6 +269,12 @@ export function handleSessionEvent(
           tabId,
           message: `auto-retry exhausted: ${ev.finalError}`,
         });
+        rec.agentEndFired = true;
+        rec.promptInFlight = false;
+        if (state.currentAgentTabId === tabId) {
+          state.currentAgentTabId = undefined;
+        }
+        deps.send({ type: "response_end", tabId });
       }
       break;
     }

--- a/agent/tab-lifecycle/index.ts
+++ b/agent/tab-lifecycle/index.ts
@@ -15,6 +15,7 @@
  *  - slash-commands.ts — collectPiSlashCommands / refreshPiSlashCommands
  *  - ready-handshake.ts — emitReady (startup payload)
  *  - events.ts         — handleSessionEvent (per-turn state machine)
+ *  - retry.ts          — Aethon-specific transient provider retry classifier
  *  - lifecycle.ts      — ensureTab + EnsureTabOptions
  */
 
@@ -45,5 +46,6 @@ export {
 } from "./slash-commands";
 export { emitReady } from "./ready-handshake";
 export { handleSessionEvent } from "./events";
+export { installAethonRetryClassifier } from "./retry";
 export type { EnsureTabOptions } from "./lifecycle";
 export { ensureTab } from "./lifecycle";

--- a/agent/tab-lifecycle/lifecycle.ts
+++ b/agent/tab-lifecycle/lifecycle.ts
@@ -26,6 +26,7 @@ import { authProfileServicesForTab } from "../auth-profiles";
 import { findSessionFileMatchingCwd } from "../session-history";
 import type { AethonAgentState, TabRecord } from "../state";
 import { handleSessionEvent } from "./events";
+import { installAethonRetryClassifier } from "./retry";
 import {
   buildPickerModels,
   ensurePickerHasModel,
@@ -123,6 +124,7 @@ export async function ensureTab(
     ],
     ...(options.initialModel ? { model: options.initialModel } : {}),
   });
+  installAethonRetryClassifier(session);
   wrapWithSourceGuard(session.agent, state.projectRoot);
 
   const rec: TabRecord = {

--- a/agent/tab-lifecycle/retry.ts
+++ b/agent/tab-lifecycle/retry.ts
@@ -1,0 +1,20 @@
+import { isRetryableAgentEndError } from "../agent-errors";
+
+interface RetryClassifierSession {
+  _isRetryableError?: (message: {
+    stopReason?: string;
+    errorMessage?: string;
+  }) => boolean;
+}
+
+export function installAethonRetryClassifier(session: unknown): void {
+  const target = session as RetryClassifierSession;
+  if (typeof target._isRetryableError !== "function") return;
+
+  const upstream = target._isRetryableError.bind(session);
+  target._isRetryableError = (message) =>
+    upstream(message) ||
+    (message.stopReason === "error" &&
+      typeof message.errorMessage === "string" &&
+      isRetryableAgentEndError(message.errorMessage));
+}


### PR DESCRIPTION
## Summary

- Extend pi's retry classifier for transient transport failures like `WebSocket closed 1006 Connection ended`.
- Keep Aethon's turn UI in-flight while pi auto-retries a retryable transport error instead of surfacing the first transient error and stopping the tab.
- Surface non-retryable failures during a retry attempt, such as auth/account errors, and emit `response_end` exactly once so the tab does not hang.
- Add regression coverage for the WebSocket 1006 case, retry start/end state transitions, and the non-retryable-failure-during-retry edge case found by Codex peer review.

## Why

Sometimes provider transport drops arrive as a normal `agent_end` with `stopReason: "error"`, for example `WebSocket closed 1006 Connection ended`. Pi already has an auto-retry loop, but Aethon was treating that intermediate `agent_end` as terminal. The user saw the transient transport error and the agent appeared to stop instead of gracefully retrying.

## Validation

- `bunx vitest run agent/agent-errors.test.ts agent/tab-lifecycle.test.ts`
- `bunx vitest run agent/agent-errors.test.ts agent/tab-lifecycle.test.ts agent/dispatcher.test.ts`
- `bun run typecheck`
- `git diff --check`
- Codex peer review before push; addressed moderate finding about non-retryable retry-attempt failures being hidden.

## Notes

This is a scoped compatibility patch around pi's private `_isRetryableError` classifier. It preserves upstream retry decisions first, adds Aethon's WebSocket 1006 classification, and no-ops if the private method disappears in a future pi release.