### PR TITLE
fix: reconcile terminal cards and queued controls

### DIFF
--- a/src/eventRoutes/index.test.ts
+++ b/src/eventRoutes/index.test.ts
@@ -12,6 +12,7 @@
 import { describe, expect, it } from "vitest";
 import { dispatchEvent } from "./index";
 import { buildRouteFixture } from "./testFixtures";
+import { makeEmptyTab } from "../types/tab";
 
 describe("dispatchEvent — precedence contract", () => {
   it("Layer 1 wins over Layer 2: shell-write-allow runs even when an extension matches notification-stack", async () => {
@@ -313,5 +314,28 @@ describe("dispatchEvent — chrome composites route by type, not id", () => {
     );
     expect(handled).toBe(true);
     expect(mocks.sendChat).toHaveBeenCalledWith("hello", { mode: "normal" });
+  });
+
+  it("inlined queued popover events still route through the chat-input host", async () => {
+    const tab = {
+      ...makeEmptyTab("tab-1", "Tab 1"),
+      queuedMessages: [{ id: "q1", content: "follow up" }],
+      queueCount: 1,
+    };
+    const { ctx, mocks } = buildRouteFixture({
+      state: { activeTabId: "tab-1", tabs: [tab] },
+    });
+    const handled = await dispatchEvent(
+      {
+        component: { id: "chat-input", type: "chat-input" },
+        eventType: "queue:steer",
+        data: { messageId: "q1" },
+      },
+      ctx,
+    );
+
+    expect(handled).toBe(true);
+    expect(mocks.steerQueuedMessage).toHaveBeenCalledWith("tab-1", "q1");
+    expect(mocks.sendChat).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/bridgeMessageHandlers/a2ui.test.ts
+++ b/src/hooks/bridgeMessageHandlers/a2ui.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { handleA2ui } from "./a2ui";
 import { buildHandlerFixture } from "./testFixtures";
 import { makeEmptyTab } from "../../types/tab";
+import type { ChatMessage } from "../../types/a2ui";
 
 describe("handleA2ui", () => {
   it("appends an a2ui bubble and flips waiting on done", () => {
@@ -26,5 +27,66 @@ describe("handleA2ui", () => {
     const [, updater] = mocks.updateTab.mock.calls[0];
     expect(updater(makeEmptyTab("default", "Tab 1")).waiting).toBe(false);
     expect(mocks.setStatusFlags).toHaveBeenCalledWith({ status: "ready" });
+  });
+
+  it("replaces a stale running terminal tool card when the final event has a sibling id", () => {
+    const runningId =
+      "tool-1-call_run-fc_01a0cf101a3d1343016a14d6465b9c819b8b75c60642c6bd59";
+    const finalId =
+      "tool-2-call_run-fc_01a0cf101a3d1343016a14d6465b9c819b8b75c60642c6bd59";
+    const tab = {
+      ...makeEmptyTab("tab-1", "Tab 1"),
+      messages: [
+        {
+          id: runningId,
+          role: "agent",
+          a2ui: {
+            components: [
+              {
+                id: runningId,
+                type: "tool-card",
+                props: {
+                  title: "bash",
+                  toolName: "bash",
+                  description: "sleep 60",
+                  startedAt: 1_000,
+                },
+              },
+            ],
+          },
+        } satisfies ChatMessage,
+      ],
+    };
+    const { ctx, mocks } = buildHandlerFixture({
+      state: { activeTabId: "tab-1", tabs: [tab] },
+    });
+    const payload = {
+      components: [
+        {
+          id: finalId,
+          type: "tool-card",
+          props: {
+            title: "bash",
+            toolName: "bash",
+            description: "sleep 60",
+            startedAt: 1_000,
+            endedAt: 2_000,
+            isError: true,
+          },
+        },
+      ],
+    };
+
+    handleA2ui({ type: "a2ui", payload, id: finalId, tabId: "tab-1" }, ctx);
+
+    expect(mocks.appendMessage).not.toHaveBeenCalled();
+    const [, updater] = mocks.updateTab.mock.calls[0];
+    const out = updater(tab);
+    expect(out.messages).toHaveLength(1);
+    expect(out.messages[0]).toMatchObject({
+      id: finalId,
+      role: "agent",
+      a2ui: payload,
+    });
   });
 });

--- a/src/hooks/bridgeMessageHandlers/a2ui.ts
+++ b/src/hooks/bridgeMessageHandlers/a2ui.ts
@@ -1,12 +1,65 @@
 import type { A2UIPayload } from "../../types/a2ui";
+import type { Tab } from "../../types/tab";
+import { toolCardIdentityFromId } from "../../utils/toolCardIdentity";
 import type { BridgeMessageHandler } from "./types";
+
+function completedToolCardIdentity(payload: A2UIPayload): string | undefined {
+  const toolCards = (payload.components ?? []).filter(
+    (component) =>
+      component?.type === "tool-card" && typeof component.id === "string",
+  );
+  if (toolCards.length !== 1) return undefined;
+  const component = toolCards[0];
+  if (component.props?.startedAt === undefined) return undefined;
+  if (component.props.endedAt === undefined) return undefined;
+  return toolCardIdentityFromId(component.id);
+}
+
+function replacesRunningToolCard(
+  tab: Tab | undefined,
+  incomingMessageId: string,
+  identity: string | undefined,
+): boolean {
+  if (!tab || !identity) return false;
+  return tab.messages.some((message) => {
+    if (message.id === incomingMessageId) return false;
+    const toolCards = message.a2ui?.components ?? [];
+    return toolCards.some((component) => {
+      if (component?.type !== "tool-card") return false;
+      if (typeof component.id !== "string") return false;
+      if (component.props?.startedAt === undefined) return false;
+      if (component.props.endedAt !== undefined) return false;
+      return toolCardIdentityFromId(component.id) === identity;
+    });
+  });
+}
 
 export const handleA2ui: BridgeMessageHandler = (data, ctx) => {
   const payload = data.payload as A2UIPayload | undefined;
   const id = (data.id as string) || crypto.randomUUID();
   const tabId = (data.tabId as string | undefined) ?? "default";
   if (payload) {
-    ctx.appendMessage({ id, role: "agent", a2ui: payload }, tabId);
+    const tabs = (ctx.stateRef.current.tabs as Tab[] | undefined) ?? [];
+    const tab = tabs.find((t) => t.id === tabId);
+    const identity = completedToolCardIdentity(payload);
+    if (replacesRunningToolCard(tab, id, identity)) {
+      ctx.updateTab(tabId, (current) => ({
+        ...current,
+        messages: current.messages.map((message) => {
+          const matches = (message.a2ui?.components ?? []).some(
+            (component) =>
+              component?.type === "tool-card" &&
+              typeof component.id === "string" &&
+              component.props?.startedAt !== undefined &&
+              component.props.endedAt === undefined &&
+              toolCardIdentityFromId(component.id) === identity,
+          );
+          return matches ? { id, role: "agent", a2ui: payload } : message;
+        }),
+      }));
+    } else {
+      ctx.appendMessage({ id, role: "agent", a2ui: payload }, tabId);
+    }
   }
   if (data.done) {
     ctx.updateTab(tabId, (tab) => ({ ...tab, waiting: false }));

--- a/src/hooks/bridgeMessageHandlers/sessionHistory.ts
+++ b/src/hooks/bridgeMessageHandlers/sessionHistory.ts
@@ -2,6 +2,7 @@ import {
   coerceChatMessages,
   dedupeToolResultTextMessages,
 } from "../../utils/messages";
+import { toolCardIdentityFromId } from "../../utils/toolCardIdentity";
 import type { A2UIComponent, ChatMessage } from "../../types/a2ui";
 import type { BridgeMessageHandler } from "./types";
 
@@ -28,20 +29,8 @@ function toolCardComponents(message: ChatMessage): A2UIComponent[] {
   );
 }
 
-function normalizeToolCallId(value: string): string {
-  return value.replace(/[^A-Za-z0-9_-]+/g, "-").slice(0, 96);
-}
-
 function toolCardIdentity(component: A2UIComponent): string | undefined {
-  const id = component.id;
-  if (id.startsWith("restored-tool-")) {
-    return id.slice("restored-tool-".length);
-  }
-  const liveMatch = /^tool-\d+-(.+)$/.exec(id);
-  if (liveMatch) {
-    return normalizeToolCallId(liveMatch[1]);
-  }
-  return undefined;
+  return toolCardIdentityFromId(component.id);
 }
 
 function completedRestoredToolIdentities(restored: ChatMessage[]): Set<string> {

--- a/src/utils/toolCardIdentity.ts
+++ b/src/utils/toolCardIdentity.ts
@@ -1,0 +1,14 @@
+export function normalizeToolCallId(value: string): string {
+  return value.replace(/[^A-Za-z0-9_-]+/g, "-").slice(0, 96);
+}
+
+export function toolCardIdentityFromId(id: string): string | undefined {
+  if (id.startsWith("restored-tool-")) {
+    return id.slice("restored-tool-".length);
+  }
+  const liveMatch = /^tool-\d+-(.+)$/.exec(id);
+  if (liveMatch) {
+    return normalizeToolCallId(liveMatch[1]);
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Summary
- replace stale running terminal tool cards when a cancelled/failed final card arrives with a sibling tool-card id
- keep the completed/cancelled card in the same transcript slot so killed tasks stop showing a second live timer
- add regression coverage for queue/steer events emitted from the inlined composer popover

## Diagnostics
- The release hang was handled in #144 and its Nightly Build has completed successfully.
- This follow-up addresses the two UI regressions from the screenshots: duplicate long-running terminal cards after cancellation and queued/steer controls routed through UI mounted over the composer.

## Tests
- nix develop -c bunx vitest run src/hooks/bridgeMessageHandlers/a2ui.test.ts src/eventRoutes/index.test.ts src/eventRoutes/chatInput.test.ts src/eventRoutes/queue.test.ts src/extensions/default-layout/chat.test.tsx
- nix develop -c bun run typecheck
- nix develop -c bunx vitest run src/hooks/useChat.test.ts src/hooks/useQueuedDispatch.test.ts src/hooks/bridgeMessageHandlers/sessionHistory.test.ts
- nix develop -c check

## Notes
- `check` still reports the existing 5 React hook warnings in dashboard/editor/worktree landing files; no new warnings were introduced.