### PR TITLE
fix: autosave settings edits live

### DIFF
--- a/src/eventRoutes/settings.test.ts
+++ b/src/eventRoutes/settings.test.ts
@@ -28,7 +28,7 @@ describe("handleSettings", () => {
     expect(mocks.applySettingsPatch).toHaveBeenCalledWith({ theme: "dark" });
   });
 
-  it("save commits via saveSettings", async () => {
+  it("save flushes any pending autosave for legacy settings components", async () => {
     const { ctx, mocks } = buildRouteFixture();
     const handled = await handleSettings(
       { component: { id: "settings-panel" }, eventType: "save" },

--- a/src/extensions/default-layout/settings-panel/hooks.ts
+++ b/src/extensions/default-layout/settings-panel/hooks.ts
@@ -27,8 +27,8 @@ export function useConfigSnapshot(open: boolean): AethonConfig | null {
 }
 
 /**
- * Merge `pending` (unsaved edits) on top of the live snapshot. Form
- * bindings read from this; Save / cancel manipulate `pending`.
+ * Merge `pending` (live edits over the loaded config) on top of the
+ * snapshot. Form bindings read from this while autosave catches up.
  */
 export function useEffectiveConfig(
   snapshot: AethonConfig | null,

--- a/src/extensions/default-layout/settings-panel/panel.test.tsx
+++ b/src/extensions/default-layout/settings-panel/panel.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SettingsPanel } from "./panel";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(() => Promise.resolve(() => {})),
+}));
+
+vi.mock("@tauri-apps/plugin-opener", () => ({
+  openUrl: vi.fn(),
+}));
+
+vi.mock("../../../config", () => ({
+  getConfig: vi.fn(() =>
+    Promise.resolve({
+      ui: {
+        theme: "ember",
+        fontSize: 14,
+        restoreTabs: false,
+        notifyOnCompletion: true,
+        notifyMinDurationSeconds: 8,
+      },
+      agent: { model: null },
+      shell: {
+        defaultShareMode: "private",
+        autoRestartAgent: true,
+        defaultCommand: null,
+        defaultArgs: [],
+        inheritEnv: true,
+        promptBeforeClose: true,
+      },
+      shortcuts: { newTabKind: "agent" },
+      voice: { toggleHotkey: "mod+shift+m", holdHotkey: "AltRight" },
+      updates: { channel: "stable", disableAutoCheck: false },
+      devshell: {
+        enabled: "auto",
+        mode: "auto",
+        cacheTtlHours: 720,
+        refreshOnLockfileChange: true,
+      },
+    }),
+  ),
+}));
+
+vi.mock("../../../services/voice", () => ({
+  listVoiceProviders: vi.fn(() => Promise.resolve([])),
+  prepareVoiceProvider: vi.fn(),
+  removeVoiceProviderModel: vi.fn(),
+  setSelectedVoiceProvider: vi.fn(),
+  setVoiceProviderEnabled: vi.fn(),
+}));
+
+describe("SettingsPanel", () => {
+  beforeEach(() => {
+    window.requestAnimationFrame = (callback: FrameRequestCallback) => {
+      callback(0);
+      return 0;
+    };
+    window.cancelAnimationFrame = vi.fn();
+  });
+
+  afterEach(() => cleanup());
+
+  it("renders as a live settings dialog without a save footer or stale save copy", async () => {
+    render(
+      <SettingsPanel
+        component={{ id: "settings-panel", type: "settings-panel" }}
+        state={{
+          settings: { open: true, pending: null, saveStatus: "saved" },
+          sidebar: { models: [] },
+        }}
+        onEvent={vi.fn()}
+      />,
+    );
+
+    const dialog = screen.getByRole("dialog", { name: "Settings" });
+    expect(dialog.classList.contains("ae-settings-panel")).toBe(true);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Theme")).toBeTruthy();
+    });
+
+    expect(screen.queryByRole("button", { name: "Save" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Cancel" })).toBeNull();
+    expect(screen.queryByText(/Save button/i)).toBeNull();
+    expect(
+      screen.getByText("Saved").classList.contains("ae-settings-save-state"),
+    ).toBe(true);
+  });
+});

--- a/src/extensions/default-layout/settings-panel/panel.tsx
+++ b/src/extensions/default-layout/settings-panel/panel.tsx
@@ -1,10 +1,11 @@
-// Settings overlay (M6 P3). Cmd+, opens. Form-based editor for the
-// most-used `~/.aethon/config.toml` keys; advanced power-user editing
-// is a click away via the "Open config.toml" button.
+// Settings overlay. Cmd+, opens. Live editor for the most-used
+// `~/.aethon/config.toml` keys; advanced power-user editing is a click
+// away via the "Open config.toml" button.
 //
 // State contract (`/settings` slice on the main state object):
 //   { open: boolean, focusSection: string | null,
-//     pending: Partial<AethonConfig> | null }
+//     pending: Partial<AethonConfig> | null,
+//     saveStatus: "idle" | "saving" | "saved" | "error" }
 //
 // The panel reads the current config state via `getConfig()` on mount
 // so the form reflects what's actually on disk, not stale in-memory
@@ -49,8 +50,7 @@ export function SettingsPanel({ state, onEvent }: BuiltinComponentProps) {
   const update = (patch: Partial<AethonConfig>) => {
     onEvent("update", { patch });
   };
-  const save = () => onEvent("save");
-  const cancel = () => onEvent("close");
+  const close = () => onEvent("close");
   // `aethon_home_dir` returns the *Aethon* dir (`~/.aethon`), not the
   // user's home — joining another `/.aethon/` produces a wrong nested
   // path that the agent never reads. Append the bare filename only.
@@ -71,7 +71,7 @@ export function SettingsPanel({ state, onEvent }: BuiltinComponentProps) {
     <div
       className="ae-settings-overlay"
       onMouseDown={(e) => {
-        if (e.target === e.currentTarget) cancel();
+        if (e.target === e.currentTarget) close();
       }}
     >
       <div
@@ -82,11 +82,12 @@ export function SettingsPanel({ state, onEvent }: BuiltinComponentProps) {
       >
         <header className="ae-settings-header">
           <h2>Settings</h2>
+          <SaveState settings={settings} />
           <button
             type="button"
             className="ae-settings-close"
             aria-label="Close"
-            onClick={cancel}
+            onClick={close}
           >
             ×
           </button>
@@ -496,7 +497,7 @@ export function SettingsPanel({ state, onEvent }: BuiltinComponentProps) {
             <Section id="advanced" title="Advanced">
               <p className="ae-settings-note">
                 For keys not surfaced here, edit{" "}
-                <code>~/.aethon/config.toml</code> directly. The Save button
+                <code>~/.aethon/config.toml</code> directly. Aethon
                 round-trips comments and unknown keys, so hand edits survive.
               </p>
               <button
@@ -516,26 +517,31 @@ export function SettingsPanel({ state, onEvent }: BuiltinComponentProps) {
             </Section>
           </div>
         )}
-
-        <footer className="ae-settings-footer">
-          <button
-            type="button"
-            className="ae-settings-secondary"
-            onClick={cancel}
-          >
-            Cancel
-          </button>
-          <button
-            type="button"
-            className="ae-settings-primary"
-            onClick={save}
-            disabled={!eff || settings.pending === null}
-          >
-            Save
-          </button>
-        </footer>
       </div>
     </div>
+  );
+}
+
+function SaveState({
+  settings,
+}: {
+  settings: ReturnType<typeof readSettingsState>;
+}) {
+  if (settings.saveStatus === "idle") return null;
+  const label =
+    settings.saveStatus === "saving"
+      ? "Saving..."
+      : settings.saveStatus === "error"
+        ? "Save failed"
+        : "Saved";
+  return (
+    <span
+      className={`ae-settings-save-state ae-settings-save-state--${settings.saveStatus}`}
+      aria-live="polite"
+      title={settings.saveError ?? undefined}
+    >
+      {label}
+    </span>
   );
 }
 

--- a/src/extensions/default-layout/settings-panel/state.ts
+++ b/src/extensions/default-layout/settings-panel/state.ts
@@ -4,22 +4,26 @@
 //
 // Contract:
 //   { open: boolean, focusSection: string | null,
-//     pending: Partial<AethonConfig> | null }
+//     pending: Partial<AethonConfig> | null,
+//     saveStatus: "idle" | "saving" | "saved" | "error",
+//     saveError: string | null }
 //
-// `pending` mirrors the user's unsaved edits — the form binds form
-// controls to it via $ref-style optimistic writes, so the user sees
-// changes apply live. Save serialises `pending` and invokes the Tauri
-// `write_config` command; Cancel discards `pending`.
+// `pending` mirrors live edits over the config snapshot so controls
+// never snap back while the panel stays open. The overlay hook
+// debounces writes through the same config round-trip path used by
+// legacy Save events and tracks write state separately in `saveStatus`.
 
 import type { AethonConfig } from "../../../config";
 
 export interface SettingsState {
   open: boolean;
   focusSection: string | null;
-  /** User's unsaved edits. Null when the panel hasn't loaded the
-   *  config yet OR the user hasn't touched anything. The form reads
-   *  from `pending` first, falling back to the config snapshot. */
+  /** User's live edits over the loaded config snapshot. Null when the
+   *  panel hasn't loaded the config yet OR the user hasn't touched
+   *  anything this open session. */
   pending: Partial<AethonConfig> | null;
+  saveStatus: "idle" | "saving" | "saved" | "error";
+  saveError: string | null;
 }
 
 export function readSettingsState(state: Record<string, unknown>): SettingsState {
@@ -29,5 +33,12 @@ export function readSettingsState(state: Record<string, unknown>): SettingsState
     focusSection:
       typeof s.focusSection === "string" ? s.focusSection : null,
     pending: (s.pending as Partial<AethonConfig> | null) ?? null,
+    saveStatus:
+      s.saveStatus === "saving" ||
+      s.saveStatus === "saved" ||
+      s.saveStatus === "error"
+        ? s.saveStatus
+        : "idle",
+    saveError: typeof s.saveError === "string" ? s.saveError : null,
   };
 }

--- a/src/hooks/uiOverlays/settings.test.ts
+++ b/src/hooks/uiOverlays/settings.test.ts
@@ -1,13 +1,49 @@
 // @vitest-environment jsdom
-import { describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Dispatch, MutableRefObject, SetStateAction } from "react";
+import { invoke } from "@tauri-apps/api/core";
 
-import { useSettingsOverlay } from "./settings";
+import { useSettingsOverlay, SETTINGS_AUTOSAVE_DELAY_MS } from "./settings";
 import type { UseUiOverlaysContext } from "./types";
+import { clearConfigCache, getConfig, type AethonConfig } from "../../config";
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn(),
 }));
+
+vi.mock("../../config", () => ({
+  clearConfigCache: vi.fn(),
+  getConfig: vi.fn(),
+}));
+
+const baseConfig: AethonConfig = {
+  ui: {
+    theme: "ember",
+    fontSize: 14,
+    restoreTabs: false,
+    notifyOnCompletion: true,
+    notifyMinDurationSeconds: 8,
+  },
+  agent: { model: "openai/gpt-5.5" },
+  shell: {
+    defaultShareMode: "private",
+    autoRestartAgent: true,
+    defaultCommand: null,
+    defaultArgs: [],
+    inheritEnv: true,
+    promptBeforeClose: true,
+  },
+  shortcuts: { newTabKind: "agent" },
+  voice: { toggleHotkey: "mod+shift+m", holdHotkey: "AltRight" },
+  updates: { channel: "nightly", disableAutoCheck: false },
+  devshell: {
+    enabled: "auto",
+    mode: "auto",
+    cacheTtlHours: 720,
+    refreshOnLockfileChange: true,
+  },
+};
 
 function buildContext(initialState: Record<string, unknown>): {
   ctx: Pick<
@@ -34,6 +70,19 @@ function buildContext(initialState: Record<string, unknown>): {
 }
 
 describe("useSettingsOverlay", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.mocked(invoke).mockReset();
+    vi.mocked(invoke).mockResolvedValue(undefined);
+    vi.mocked(getConfig).mockReset();
+    vi.mocked(getConfig).mockResolvedValue(baseConfig);
+    vi.mocked(clearConfigCache).mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("preserves the focused settings section while applying pending patches", () => {
     const { ctx, stateRef } = buildContext({
       settings: {
@@ -43,14 +92,105 @@ describe("useSettingsOverlay", () => {
       },
     });
 
-    const settings = useSettingsOverlay(ctx);
+    const { result } = renderHook(() => useSettingsOverlay(ctx));
 
-    settings.applySettingsPatch({ ui: { theme: "aether" } });
+    act(() => {
+      result.current.applySettingsPatch({ ui: { theme: "aether" } });
+    });
 
     expect(stateRef.current.settings).toEqual({
       open: true,
       pending: { ui: { theme: "aether" } },
       focusSection: "extensions",
+      saveStatus: "saving",
+      saveError: null,
+    });
+  });
+
+  it("debounces live settings writes and persists the latest merged config", async () => {
+    const { ctx } = buildContext({
+      settings: { open: true, pending: null, focusSection: "appearance" },
+    });
+    const { result } = renderHook(() => useSettingsOverlay(ctx));
+
+    act(() => {
+      result.current.applySettingsPatch({ ui: { theme: "aether" } });
+      result.current.applySettingsPatch({
+        ui: { theme: "aether", fontSize: 18 },
+      });
+    });
+
+    await vi.advanceTimersByTimeAsync(SETTINGS_AUTOSAVE_DELAY_MS - 1);
+    expect(invoke).not.toHaveBeenCalledWith("write_config", expect.anything());
+
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(invoke).toHaveBeenCalledWith("write_config", {
+      config: expect.objectContaining({
+        ui: expect.objectContaining({ theme: "aether", fontSize: 18 }),
+        shortcuts: baseConfig.shortcuts,
+        updates: baseConfig.updates,
+        voice: baseConfig.voice,
+        devshell: baseConfig.devshell,
+      }),
+    });
+  });
+
+  it("reapplies fresh config after autosave without closing settings", async () => {
+    const fresh = {
+      ...baseConfig,
+      ui: { ...baseConfig.ui, theme: "brink" },
+    };
+    vi.mocked(getConfig)
+      .mockResolvedValueOnce(baseConfig)
+      .mockResolvedValueOnce(fresh);
+    const { ctx, stateRef } = buildContext({
+      settings: { open: true, pending: null, focusSection: null },
+    });
+    const { result } = renderHook(() => useSettingsOverlay(ctx));
+
+    act(() => {
+      result.current.applySettingsPatch({ ui: { theme: "brink" } });
+    });
+    await vi.advanceTimersByTimeAsync(SETTINGS_AUTOSAVE_DELAY_MS);
+
+    expect(clearConfigCache).toHaveBeenCalledTimes(1);
+    expect(ctx.reapplyConfig).toHaveBeenCalledWith(fresh);
+    expect(stateRef.current.settings).toEqual({
+      open: true,
+      pending: { ui: { theme: "brink" } },
+      focusSection: null,
+      saveStatus: "saved",
+      saveError: null,
+    });
+  });
+
+  it("keeps the dialog open and the current edits visible when autosave fails", async () => {
+    vi.mocked(invoke).mockRejectedValueOnce(new Error("disk full"));
+    const { ctx, stateRef } = buildContext({
+      settings: { open: true, pending: null, focusSection: null },
+    });
+    const { result } = renderHook(() => useSettingsOverlay(ctx));
+
+    act(() => {
+      result.current.applySettingsPatch({ ui: { theme: "paper" } });
+    });
+    await vi.advanceTimersByTimeAsync(SETTINGS_AUTOSAVE_DELAY_MS);
+
+    expect(ctx.pushNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "ae-settings-save-failed",
+        title: "Failed to save settings",
+        kind: "error",
+      }),
+    );
+    expect(stateRef.current.settings).toEqual({
+      open: true,
+      pending: { ui: { theme: "paper" } },
+      focusSection: null,
+      saveStatus: "error",
+      saveError: "Error: disk full",
     });
   });
 });

--- a/src/hooks/uiOverlays/settings.test.ts
+++ b/src/hooks/uiOverlays/settings.test.ts
@@ -193,4 +193,95 @@ describe("useSettingsOverlay", () => {
       saveError: "Error: disk full",
     });
   });
+
+  it("reopens settings with current edits when a close-triggered flush fails", async () => {
+    vi.mocked(invoke).mockRejectedValueOnce(new Error("permission denied"));
+    const { ctx, stateRef } = buildContext({
+      settings: {
+        open: true,
+        pending: { ui: { theme: "aether" } },
+        focusSection: "appearance",
+        saveStatus: "saving",
+        saveError: null,
+      },
+    });
+    const { result } = renderHook(() => useSettingsOverlay(ctx));
+
+    await act(async () => {
+      result.current.closeSettings();
+      await Promise.resolve();
+    });
+
+    expect(ctx.pushNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "ae-settings-save-failed",
+        title: "Failed to save settings",
+        kind: "error",
+      }),
+    );
+    expect(stateRef.current.settings).toEqual({
+      open: true,
+      pending: { ui: { theme: "aether" } },
+      focusSection: "appearance",
+      saveStatus: "error",
+      saveError: "Error: permission denied",
+    });
+  });
+
+  it("serializes overlapping autosaves so older writes cannot overwrite newer edits", async () => {
+    let resolveFirst: (() => void) | undefined;
+    let resolveSecond: (() => void) | undefined;
+    vi.mocked(invoke)
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirst = () => resolve(undefined);
+          }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveSecond = () => resolve(undefined);
+          }),
+      );
+    const { ctx } = buildContext({
+      settings: { open: true, pending: null, focusSection: null },
+    });
+    const { result } = renderHook(() => useSettingsOverlay(ctx));
+
+    act(() => {
+      result.current.applySettingsPatch({ ui: { theme: "paper" } });
+    });
+    await vi.advanceTimersByTimeAsync(SETTINGS_AUTOSAVE_DELAY_MS);
+
+    act(() => {
+      result.current.applySettingsPatch({ ui: { theme: "brink" } });
+    });
+    await vi.advanceTimersByTimeAsync(SETTINGS_AUTOSAVE_DELAY_MS);
+
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(invoke).toHaveBeenNthCalledWith(1, "write_config", {
+      config: expect.objectContaining({
+        ui: expect.objectContaining({ theme: "paper" }),
+      }),
+    });
+
+    await act(async () => {
+      resolveFirst?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(invoke).toHaveBeenCalledTimes(2);
+    expect(invoke).toHaveBeenNthCalledWith(2, "write_config", {
+      config: expect.objectContaining({
+        ui: expect.objectContaining({ theme: "brink" }),
+      }),
+    });
+
+    await act(async () => {
+      resolveSecond?.();
+      await Promise.resolve();
+    });
+  });
 });

--- a/src/hooks/uiOverlays/settings.ts
+++ b/src/hooks/uiOverlays/settings.ts
@@ -273,7 +273,7 @@ export function useSettingsOverlay(ctx: SettingsOverlayContext) {
                   ? cur.focusSection
                   : null,
             saveStatus: "error",
-            saveError: err instanceof Error ? String(err) : String(err),
+            saveError: String(err),
           },
         };
       });

--- a/src/hooks/uiOverlays/settings.ts
+++ b/src/hooks/uiOverlays/settings.ts
@@ -1,6 +1,9 @@
 import { invoke } from "@tauri-apps/api/core";
+import { useEffect, useRef } from "react";
 import { clearConfigCache, getConfig, type AethonConfig } from "../../config";
 import type { UseUiOverlaysContext } from "./types";
+
+export const SETTINGS_AUTOSAVE_DELAY_MS = 350;
 
 type SettingsOverlayContext = Pick<
   UseUiOverlaysContext,
@@ -9,10 +12,19 @@ type SettingsOverlayContext = Pick<
 
 export function useSettingsOverlay(ctx: SettingsOverlayContext) {
   const { setState, stateRef, reapplyConfig, pushNotification } = ctx;
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const saveGenerationRef = useRef(0);
+
+  useEffect(
+    () => () => {
+      if (saveTimerRef.current) window.clearTimeout(saveTimerRef.current);
+    },
+    [],
+  );
 
   /** Toggle the Settings panel. Loads the on-disk config on open via
    *  `getConfig()`, exposes form bindings via `/settings/pending`, and
-   *  writes back via the `write_config` Tauri command on Save. */
+   *  autosaves edits through the `write_config` Tauri command. */
   function openSettings(section?: string) {
     setState((prev) => ({
       ...prev,
@@ -20,6 +32,8 @@ export function useSettingsOverlay(ctx: SettingsOverlayContext) {
         open: true,
         pending: null,
         focusSection: section ?? null,
+        saveStatus: "idle",
+        saveError: null,
       },
     }));
   }
@@ -29,19 +43,41 @@ export function useSettingsOverlay(ctx: SettingsOverlayContext) {
       const cur = (prev.settings as { open?: boolean } | undefined) ?? {};
       return {
         ...prev,
-        settings: { open: !cur.open, pending: null, focusSection: null },
+        settings: {
+          open: !cur.open,
+          pending: null,
+          focusSection: null,
+          saveStatus: "idle",
+          saveError: null,
+        },
       };
     });
   }
 
   function closeSettings() {
-    setState((prev) => ({
-      ...prev,
-      settings: { open: false, pending: null, focusSection: null },
-    }));
+    const cur =
+      (stateRef.current.settings as
+        | {
+            pending?: Record<string, unknown> | null;
+            saveStatus?: string;
+          }
+        | undefined) ?? {};
+    if (cur.pending && cur.saveStatus !== "saved") void saveSettings();
+    setState((prev) => {
+      const settings = isPlainObject(prev.settings) ? prev.settings : {};
+      return {
+        ...prev,
+        settings: {
+          ...settings,
+          open: false,
+          focusSection: null,
+        },
+      };
+    });
   }
 
-  /** Apply a partial AethonConfig patch to `/settings/pending`. */
+  /** Apply a partial AethonConfig patch to `/settings/pending` and
+   *  schedule a debounced autosave. */
   function applySettingsPatch(
     patch: Partial<{
       ui: unknown;
@@ -62,7 +98,7 @@ export function useSettingsOverlay(ctx: SettingsOverlayContext) {
               focusSection?: string | null;
             }
           | undefined) ?? {};
-      const merged = { ...(cur.pending ?? {}), ...patch };
+      const merged = mergeConfigPatch(cur.pending ?? {}, patch);
       return {
         ...prev,
         settings: {
@@ -70,19 +106,32 @@ export function useSettingsOverlay(ctx: SettingsOverlayContext) {
           pending: merged,
           focusSection:
             typeof cur.focusSection === "string" ? cur.focusSection : null,
+          saveStatus: "saving",
+          saveError: null,
         },
       };
     });
+    scheduleSettingsSave();
   }
 
   /** Save pending settings, then re-prime the cached config so runtime
    *  theme/font/defaults update without a page reload. */
   async function saveSettings() {
+    if (saveTimerRef.current) {
+      window.clearTimeout(saveTimerRef.current);
+      saveTimerRef.current = null;
+    }
     const cur =
       (stateRef.current.settings as
-        | { open?: boolean; pending?: Record<string, unknown> | null }
+        | {
+            open?: boolean;
+            pending?: Record<string, unknown> | null;
+            focusSection?: string | null;
+          }
         | undefined) ?? {};
     const pending = cur.pending ?? {};
+    if (Object.keys(pending).length === 0) return;
+    const saveGeneration = ++saveGenerationRef.current;
     let live: AethonConfig | null = null;
     try {
       live = await getConfig();
@@ -129,12 +178,32 @@ export function useSettingsOverlay(ctx: SettingsOverlayContext) {
       } catch (err) {
         console.warn("settings save: re-read failed:", err);
       }
-      pushNotification({
-        id: "ae-settings-saved",
-        title: "Settings saved",
-        kind: "success",
-        durationMs: 2000,
-      });
+      if (saveGeneration === saveGenerationRef.current) {
+        setState((prev) => {
+          const latest =
+            (prev.settings as
+              | {
+                  open?: boolean;
+                  pending?: Record<string, unknown> | null;
+                  focusSection?: string | null;
+                }
+              | undefined) ?? {};
+          const visiblePending = latest.pending ?? pending;
+          return {
+            ...prev,
+            settings: {
+              open: !!latest.open,
+              pending: latest.open ? visiblePending : null,
+              focusSection:
+                typeof latest.focusSection === "string"
+                  ? latest.focusSection
+                  : null,
+              saveStatus: "saved",
+              saveError: null,
+            },
+          };
+        });
+      }
     } catch (err) {
       pushNotification({
         id: "ae-settings-save-failed",
@@ -143,9 +212,39 @@ export function useSettingsOverlay(ctx: SettingsOverlayContext) {
         kind: "error",
         durationMs: 4000,
       });
+      setState((prev) => {
+        const latest =
+          (prev.settings as
+            | {
+                open?: boolean;
+                pending?: Record<string, unknown> | null;
+                focusSection?: string | null;
+              }
+            | undefined) ?? {};
+        return {
+          ...prev,
+          settings: {
+            open: !!latest.open,
+            pending: latest.pending ?? pending,
+            focusSection:
+              typeof latest.focusSection === "string"
+                ? latest.focusSection
+                : null,
+            saveStatus: "error",
+            saveError: err instanceof Error ? String(err) : String(err),
+          },
+        };
+      });
       return;
     }
-    closeSettings();
+  }
+
+  function scheduleSettingsSave() {
+    if (saveTimerRef.current) window.clearTimeout(saveTimerRef.current);
+    saveTimerRef.current = window.setTimeout(() => {
+      saveTimerRef.current = null;
+      void saveSettings();
+    }, SETTINGS_AUTOSAVE_DELAY_MS);
   }
 
   return {
@@ -155,4 +254,23 @@ export function useSettingsOverlay(ctx: SettingsOverlayContext) {
     applySettingsPatch,
     saveSettings,
   };
+}
+
+function mergeConfigPatch(
+  pending: Record<string, unknown>,
+  patch: Record<string, unknown>,
+): Record<string, unknown> {
+  const merged = { ...pending };
+  for (const [key, value] of Object.entries(patch)) {
+    const previous = merged[key];
+    merged[key] =
+      isPlainObject(previous) && isPlainObject(value)
+        ? { ...previous, ...value }
+        : value;
+  }
+  return merged;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/src/hooks/uiOverlays/settings.ts
+++ b/src/hooks/uiOverlays/settings.ts
@@ -14,6 +14,9 @@ export function useSettingsOverlay(ctx: SettingsOverlayContext) {
   const { setState, stateRef, reapplyConfig, pushNotification } = ctx;
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const saveGenerationRef = useRef(0);
+  const saveInFlightRef = useRef<Promise<void> | null>(null);
+  const saveQueuedRef = useRef(false);
+  const reopenOnFailureRef = useRef(false);
 
   useEffect(
     () => () => {
@@ -62,7 +65,9 @@ export function useSettingsOverlay(ctx: SettingsOverlayContext) {
             saveStatus?: string;
           }
         | undefined) ?? {};
-    if (cur.pending && cur.saveStatus !== "saved") void saveSettings();
+    if (cur.pending && cur.saveStatus !== "saved") {
+      void saveSettings({ reopenOnFailure: true });
+    }
     setState((prev) => {
       const settings = isPlainObject(prev.settings) ? prev.settings : {};
       return {
@@ -116,11 +121,33 @@ export function useSettingsOverlay(ctx: SettingsOverlayContext) {
 
   /** Save pending settings, then re-prime the cached config so runtime
    *  theme/font/defaults update without a page reload. */
-  async function saveSettings() {
+  async function saveSettings(options?: { reopenOnFailure?: boolean }) {
     if (saveTimerRef.current) {
       window.clearTimeout(saveTimerRef.current);
       saveTimerRef.current = null;
     }
+    if (options?.reopenOnFailure) reopenOnFailureRef.current = true;
+    if (saveInFlightRef.current) {
+      saveQueuedRef.current = true;
+      return saveInFlightRef.current;
+    }
+    const run = drainSettingsSaves();
+    saveInFlightRef.current = run;
+    try {
+      await run;
+    } finally {
+      if (saveInFlightRef.current === run) saveInFlightRef.current = null;
+    }
+  }
+
+  async function drainSettingsSaves() {
+    do {
+      saveQueuedRef.current = false;
+      await saveSettingsSnapshot();
+    } while (saveQueuedRef.current);
+  }
+
+  async function saveSettingsSnapshot() {
     const cur =
       (stateRef.current.settings as
         | {
@@ -131,6 +158,7 @@ export function useSettingsOverlay(ctx: SettingsOverlayContext) {
         | undefined) ?? {};
     const pending = cur.pending ?? {};
     if (Object.keys(pending).length === 0) return;
+    const pendingSnapshot = cloneConfigPatch(pending);
     const saveGeneration = ++saveGenerationRef.current;
     let live: AethonConfig | null = null;
     try {
@@ -139,34 +167,37 @@ export function useSettingsOverlay(ctx: SettingsOverlayContext) {
       console.warn("settings save: getConfig failed:", err);
     }
     const merged = {
-      ui: { ...(live?.ui ?? {}), ...((pending as { ui?: object }).ui ?? {}) },
+      ui: {
+        ...(live?.ui ?? {}),
+        ...((pendingSnapshot as { ui?: object }).ui ?? {}),
+      },
       agent: {
         ...(live?.agent ?? {}),
-        ...((pending as { agent?: object }).agent ?? {}),
+        ...((pendingSnapshot as { agent?: object }).agent ?? {}),
       },
       shell: {
         ...(live?.shell ?? {}),
-        ...((pending as { shell?: object }).shell ?? {}),
+        ...((pendingSnapshot as { shell?: object }).shell ?? {}),
       },
       // Always include `shortcuts` so `[shortcuts] new_tab_kind` survives
       // any other Settings save. write_config drops sections it doesn't see.
       shortcuts: {
         ...(live?.shortcuts ?? {}),
-        ...((pending as { shortcuts?: object }).shortcuts ?? {}),
+        ...((pendingSnapshot as { shortcuts?: object }).shortcuts ?? {}),
       },
       voice: {
         ...(live?.voice ?? {}),
-        ...((pending as { voice?: object }).voice ?? {}),
+        ...((pendingSnapshot as { voice?: object }).voice ?? {}),
       },
       // Likewise for `[updates]` — preserve channel + auto-check settings
       // across saves of unrelated sections.
       updates: {
         ...(live?.updates ?? {}),
-        ...((pending as { updates?: object }).updates ?? {}),
+        ...((pendingSnapshot as { updates?: object }).updates ?? {}),
       },
       devshell: {
         ...(live?.devshell ?? {}),
-        ...((pending as { devshell?: object }).devshell ?? {}),
+        ...((pendingSnapshot as { devshell?: object }).devshell ?? {}),
       },
     };
     try {
@@ -178,7 +209,14 @@ export function useSettingsOverlay(ctx: SettingsOverlayContext) {
       } catch (err) {
         console.warn("settings save: re-read failed:", err);
       }
-      if (saveGeneration === saveGenerationRef.current) {
+      const latestPending = readCurrentPending(stateRef.current);
+      if (!sameConfigPatch(latestPending, pendingSnapshot)) {
+        saveQueuedRef.current = true;
+      }
+      if (
+        saveGeneration === saveGenerationRef.current &&
+        !saveQueuedRef.current
+      ) {
         setState((prev) => {
           const latest =
             (prev.settings as
@@ -188,7 +226,7 @@ export function useSettingsOverlay(ctx: SettingsOverlayContext) {
                   focusSection?: string | null;
                 }
               | undefined) ?? {};
-          const visiblePending = latest.pending ?? pending;
+          const visiblePending = latest.pending ?? pendingSnapshot;
           return {
             ...prev,
             settings: {
@@ -221,15 +259,19 @@ export function useSettingsOverlay(ctx: SettingsOverlayContext) {
                 focusSection?: string | null;
               }
             | undefined) ?? {};
+        const shouldReopen = reopenOnFailureRef.current;
+        reopenOnFailureRef.current = false;
         return {
           ...prev,
           settings: {
-            open: !!latest.open,
-            pending: latest.pending ?? pending,
+            open: shouldReopen ? true : !!latest.open,
+            pending: latest.pending ?? pendingSnapshot,
             focusSection:
               typeof latest.focusSection === "string"
                 ? latest.focusSection
-                : null,
+                : typeof cur.focusSection === "string"
+                  ? cur.focusSection
+                  : null,
             saveStatus: "error",
             saveError: err instanceof Error ? String(err) : String(err),
           },
@@ -237,6 +279,7 @@ export function useSettingsOverlay(ctx: SettingsOverlayContext) {
       });
       return;
     }
+    if (!saveQueuedRef.current) reopenOnFailureRef.current = false;
   }
 
   function scheduleSettingsSave() {
@@ -273,4 +316,24 @@ function mergeConfigPatch(
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readCurrentPending(
+  state: Record<string, unknown>,
+): Record<string, unknown> {
+  const settings = isPlainObject(state.settings) ? state.settings : {};
+  return isPlainObject(settings.pending) ? settings.pending : {};
+}
+
+function sameConfigPatch(
+  a: Record<string, unknown>,
+  b: Record<string, unknown>,
+): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+function cloneConfigPatch(
+  patch: Record<string, unknown>,
+): Record<string, unknown> {
+  return JSON.parse(JSON.stringify(patch)) as Record<string, unknown>;
 }

--- a/src/hooks/uiOverlays/types.ts
+++ b/src/hooks/uiOverlays/types.ts
@@ -67,6 +67,9 @@ export interface UseUiOverlaysActions {
       agent: unknown;
       shell: unknown;
       shortcuts: unknown;
+      voice: unknown;
+      updates: unknown;
+      devshell: unknown;
     }>,
   ) => void;
   saveSettings: () => Promise<void>;

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -4111,7 +4111,7 @@ body.ae-resizing-terminal * {
   background: var(--bg-elev);
   border: 1px solid var(--border);
   border-radius: 12px;
-  width: min(640px, 90vw);
+  width: min(860px, 94vw);
   max-height: 85vh;
   display: flex;
   flex-direction: column;
@@ -4128,6 +4128,15 @@ body.ae-resizing-terminal * {
   margin: 0;
   font-size: 1.05rem;
   flex: 1 1 auto;
+}
+.ae-settings-save-state {
+  color: var(--text-dim);
+  font-size: var(--chrome-text-muted);
+  margin-right: var(--space-3);
+  white-space: nowrap;
+}
+.ae-settings-save-state--error {
+  color: var(--error);
 }
 .ae-settings-close {
   background: transparent;
@@ -4302,6 +4311,24 @@ body.ae-resizing-terminal * {
 }
 .ae-settings-secondary:hover {
   background: color-mix(in oklab, var(--accent) 8%, transparent);
+}
+
+@media (max-width: 720px) {
+  .ae-settings-panel {
+    width: min(96vw, 860px);
+  }
+  .ae-settings-field {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .ae-settings-field-control,
+  .ae-settings-input,
+  .ae-settings-model-picker,
+  .ae-settings-model-picker .ae-settings-input {
+    width: 100%;
+    min-width: 0;
+  }
 }
 
 .ae-auth-panel {


### PR DESCRIPTION
## Summary

- widen the Settings dialog and remove the old Save/Cancel footer
- make settings edits update immediately and persist through a debounced live autosave path
- preserve the existing `write_config` round-trip so comments, unknown TOML sections, and hand edits survive
- add header save status (`Saving...`, `Saved`, `Save failed`) instead of a blocking save workflow
- serialize autosaves so older writes cannot land after newer edits, and reopen with edits intact if a close-triggered flush fails

## Validation

- `nix develop -c bunx vitest run src/hooks/uiOverlays/settings.test.ts`
- `nix develop -c bunx vitest run src/hooks/uiOverlays/settings.test.ts src/eventRoutes/settings.test.ts src/extensions/default-layout/settings-panel/panel.test.tsx src/hooks/useKeyboardShortcuts.test.tsx src/eventRoutes/index.test.ts`
- `nix develop -c bun run typecheck`
- `nix develop -c bun run lint` (passes with the existing unrelated React hook warnings)
- `nix develop -c check`

## Notes

A Codex peer review found two race cases after the first commit: failed close-triggered flushes could hide unsaved edits, and overlapping autosaves could write stale config out of order. The second commit adds regression coverage and serializes the autosave queue.