### PR TITLE
fix(extensions): prune stale disabled project records

### DIFF
--- a/agent/extension-loader.test.ts
+++ b/agent/extension-loader.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  readFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -8,11 +14,13 @@ import {
   type AethonExtensionApi,
   type ExtensionSource,
 } from "./state";
+import { disabledExtensionsFile } from "./disabled-extensions";
 import {
   RESERVED_THEME_IDS,
   discoverPersistedTabs,
   loadAethonExtensionDirectory,
   loadAethonExtensions,
+  loadProjectAethonExtensions,
   normalizeTheme,
   projectExtensionDisplayName,
 } from "./extension-loader";
@@ -290,6 +298,140 @@ describe("loadAethonExtensions", () => {
       expect(failuresAfterSecond).toBe(1);
     } finally {
       rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("loadProjectAethonExtensions", () => {
+  it("prunes disabled project-extension records whose files were removed", async () => {
+    const workspace = mkdtempSync(join(tmpdir(), "aethon-proj-"));
+    const projectRoot = join(workspace, "mold");
+    try {
+      const extDir = join(projectRoot, ".aethon", "extensions");
+      mkdirSync(join(projectRoot, ".git"), { recursive: true });
+      mkdirSync(extDir, { recursive: true });
+      writeFileSync(
+        join(extDir, "kept.mjs"),
+        `export function register() { throw new Error("should be disabled"); }`,
+      );
+      mkdirSync(join(extDir, "packaged-extension"), { recursive: true });
+      const f = makeFixture(workspace);
+      f.state.disabledExtensions.add("mold:kept");
+      f.state.disabledExtensions.add("mold:stale");
+      f.state.disabledExtensionMeta.set("mold:kept", {
+        source: "project-directory",
+        projectRoot,
+      });
+      f.state.disabledExtensionMeta.set("mold:stale", {
+        source: "project-directory",
+        projectRoot,
+      });
+
+      const result = await loadProjectAethonExtensions(
+        f.state,
+        f.deps,
+        projectRoot,
+        { registerComponent() {} } as unknown as AethonExtensionApi,
+        new Map(),
+        new Set(),
+        new Set(),
+      );
+
+      expect(result.prunedDisabled).toBe(1);
+      expect(f.state.disabledExtensions.has("mold:kept")).toBe(true);
+      expect(f.state.disabledExtensions.has("mold:stale")).toBe(false);
+      expect(f.sent).toContainEqual(
+        expect.objectContaining({
+          type: "extension_lifecycle",
+          name: "mold:kept",
+          status: "disabled",
+        }),
+      );
+      expect(
+        JSON.parse(readFileSync(disabledExtensionsFile(workspace), "utf8")),
+      ).toEqual({
+        disabled: [
+          {
+            name: "mold:kept",
+            source: "project-directory",
+            projectRoot,
+          },
+        ],
+      });
+    } finally {
+      rmSync(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it("prunes legacy project-looking disabled records after scanning that project", async () => {
+    const workspace = mkdtempSync(join(tmpdir(), "aethon-proj-"));
+    const projectRoot = join(workspace, "mold");
+    try {
+      const extDir = join(projectRoot, ".aethon", "extensions");
+      mkdirSync(join(projectRoot, ".git"), { recursive: true });
+      mkdirSync(extDir, { recursive: true });
+      writeFileSync(
+        join(extDir, "present.mjs"),
+        `export function register() { throw new Error("should be disabled"); }`,
+      );
+      const f = makeFixture(workspace);
+      f.state.disabledExtensions.add("mold:present");
+      f.state.disabledExtensions.add("mold:removed");
+      f.state.disabledExtensions.add("@mold/package-ui");
+      f.state.disabledExtensionMeta.set("@mold/package-ui", {
+        source: "extension-package",
+      });
+
+      const result = await loadProjectAethonExtensions(
+        f.state,
+        f.deps,
+        projectRoot,
+        { registerComponent() {} } as unknown as AethonExtensionApi,
+        new Map(),
+        new Set(),
+        new Set(),
+      );
+
+      expect(result.prunedDisabled).toBe(1);
+      expect([...f.state.disabledExtensions].sort()).toEqual([
+        "@mold/package-ui",
+        "mold:present",
+      ]);
+    } finally {
+      rmSync(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps disabled records for project scopes that were not scanned", async () => {
+    const workspace = mkdtempSync(join(tmpdir(), "aethon-proj-"));
+    const projectRoot = join(workspace, "mold");
+    try {
+      const extDir = join(projectRoot, ".aethon", "extensions");
+      mkdirSync(join(projectRoot, ".git"), { recursive: true });
+      mkdirSync(extDir, { recursive: true });
+      const f = makeFixture(workspace);
+      f.state.disabledExtensions.add("mold/nested:nested-ext");
+      f.state.disabledExtensionMeta.set("mold/nested:nested-ext", {
+        source: "project-directory",
+        projectRoot,
+      });
+
+      const result = await loadProjectAethonExtensions(
+        f.state,
+        f.deps,
+        projectRoot,
+        { registerComponent() {} } as unknown as AethonExtensionApi,
+        new Map(),
+        new Set(),
+        new Set(),
+      );
+
+      expect(result.prunedDisabled).toBe(0);
+      expect(f.state.disabledExtensions.has("mold/nested:nested-ext")).toBe(
+        true,
+      );
+    } finally {
+      rmSync(workspace, { recursive: true, force: true });
     }
   });
 });

--- a/agent/extension-loader/directory.ts
+++ b/agent/extension-loader/directory.ts
@@ -18,9 +18,13 @@
  */
 
 import { readdir } from "node:fs/promises";
-import { basename, dirname, join, relative } from "node:path";
+import { basename, dirname, join, relative, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
-import { findProjectExtensionDirs } from "../project-extensions";
+import {
+  findProjectExtensionDirs,
+  findProjectRoot,
+} from "../project-extensions";
+import { saveDisabledExtensionsSnapshot } from "../disabled-extensions";
 import { logger } from "../logger";
 import type {
   AethonAgentState,
@@ -56,6 +60,7 @@ interface LoadDirectoryOptions {
   failedFiles?: Set<string>;
   onLoaded?: (name: string) => void;
   onProjectLoaded?: (name: string, projectRoot: string) => void;
+  onDiscovered?: (name: string) => void;
   onFailure?: (failure: {
     name: string;
     source: Extract<ExtensionSource, "directory" | "project-directory">;
@@ -86,19 +91,21 @@ export async function loadAethonExtensionDirectory(
   // Parallelize import; keep register() sequential so registrations against
   // shared maps (handler dedupe, theme/component registries) stay
   // deterministic.
-  const allCandidates = entries
+  const filesystemCandidates = entries
     .filter((name) => /\.(ts|js|mjs)$/.test(name))
     .map((name) => ({
       name,
       file: join(options.dir, name),
       displayName:
         options.displayName?.(name) ?? name.replace(/\.(ts|js|mjs)$/, ""),
-    }))
-    .filter(
-      (c) =>
-        !options.loadedFiles?.has(c.file) &&
-        !options.failedFiles?.has(c.file),
-    );
+    }));
+  for (const c of filesystemCandidates) {
+    options.onDiscovered?.(c.displayName);
+  }
+  const allCandidates = filesystemCandidates.filter(
+    (c) =>
+      !options.loadedFiles?.has(c.file) && !options.failedFiles?.has(c.file),
+  );
 
   // Honor the user's "disabled" list: emit a `disabled` lifecycle event
   // (so the sidebar can surface the row + the failure registry knows
@@ -224,6 +231,92 @@ export async function loadAethonExtensions(
   });
 }
 
+function projectDisplayPrefix(projectRoot: string, extensionDir: string): string {
+  const scopeDir = dirname(dirname(extensionDir));
+  const rootName = basename(projectRoot) || "project";
+  const scope = relative(projectRoot, scopeDir).replace(/\\/g, "/");
+  return scope && !scope.startsWith("..")
+    ? `${rootName}/${scope}:`
+    : `${rootName}:`;
+}
+
+function matchesProjectDisplayName(
+  name: string,
+  projectRoot: string,
+  scannedPrefixes: ReadonlySet<string>,
+): boolean {
+  if ([...scannedPrefixes].some((prefix) => name.startsWith(prefix))) {
+    return true;
+  }
+  // If the whole extension directory disappeared, there are no scanned
+  // prefixes. In that case only root-level legacy display names are safe to
+  // treat as belonging to this project; nested scope names could refer to a
+  // sibling cwd that was not part of the current scan.
+  if (scannedPrefixes.size === 0) {
+    const rootName = basename(projectRoot) || "project";
+    return name.startsWith(`${rootName}:`);
+  }
+  return false;
+}
+
+async function pruneStaleDisabledProjectExtensions(
+  state: AethonAgentState,
+  projectRoot: string,
+  discoveredNames: ReadonlySet<string>,
+  scannedPrefixes: ReadonlySet<string>,
+): Promise<number> {
+  const normalizedProjectRoot = resolve(projectRoot);
+  const stale: string[] = [];
+  for (const name of state.disabledExtensions) {
+    if (discoveredNames.has(name)) continue;
+    const meta = state.disabledExtensionMeta.get(name);
+    if (meta) {
+      if (meta.source !== "project-directory") continue;
+      if (meta.projectRoot && resolve(meta.projectRoot) !== normalizedProjectRoot) {
+        continue;
+      }
+      if (matchesProjectDisplayName(name, projectRoot, scannedPrefixes)) {
+        stale.push(name);
+      }
+      continue;
+    }
+    // Legacy entries predate source/projectRoot metadata. Prune only names
+    // that match the active project's display-name prefix so package/user
+    // disabled entries are not removed just because a project scan ran.
+    if (matchesProjectDisplayName(name, projectRoot, scannedPrefixes)) {
+      stale.push(name);
+    }
+  }
+  if (stale.length === 0) return 0;
+  const priorNames = new Set(state.disabledExtensions);
+  const priorMeta = new Map(state.disabledExtensionMeta);
+  for (const name of stale) {
+    state.disabledExtensions.delete(name);
+    state.disabledExtensionMeta.delete(name);
+  }
+  try {
+    await saveDisabledExtensionsSnapshot(state.userDir, {
+      names: state.disabledExtensions,
+      meta: state.disabledExtensionMeta,
+    });
+    logger
+      .scope("disabled-ext")
+      .info(`pruned stale project disabled extensions: ${stale.join(", ")}`);
+    return stale.length;
+  } catch (err) {
+    state.disabledExtensions.clear();
+    for (const name of priorNames) state.disabledExtensions.add(name);
+    state.disabledExtensionMeta.clear();
+    for (const [name, meta] of priorMeta) {
+      state.disabledExtensionMeta.set(name, meta);
+    }
+    logger
+      .scope("disabled-ext")
+      .warn(`prune stale disabled extensions: ${(err as Error).message}`);
+    return 0;
+  }
+}
+
 export async function loadProjectAethonExtensions(
   state: AethonAgentState,
   deps: ExtensionLoaderDeps,
@@ -233,8 +326,11 @@ export async function loadProjectAethonExtensions(
   loadedFiles: Set<string>,
   failedFiles: Set<string>,
   hooks?: LoadHooks,
-): Promise<{ loaded: number; failed: number }> {
+): Promise<{ loaded: number; failed: number; prunedDisabled: number }> {
   const dirs = await findProjectExtensionDirs(cwd);
+  const projectRoot = dirs[0]?.projectRoot ?? (await findProjectRoot(cwd));
+  const discoveredNames = new Set<string>();
+  const scannedPrefixes = new Set<string>();
   const before = loadedFiles.size;
   // Count failures observed in THIS call so the caller can reload prompt
   // resources even when zero extensions loaded — without this, a project
@@ -253,7 +349,8 @@ export async function loadProjectAethonExtensions(
           failedThisCall += 1;
         },
   };
-  for (const { projectRoot, extensionDir } of dirs) {
+  for (const { projectRoot: dirProjectRoot, extensionDir } of dirs) {
+    scannedPrefixes.add(projectDisplayPrefix(dirProjectRoot, extensionDir));
     await loadAethonExtensionDirectory(state, deps, api, registry, {
       dir: extensionDir,
       source: "project-directory",
@@ -261,14 +358,27 @@ export async function loadProjectAethonExtensions(
       loadedFiles,
       failedFiles,
       displayName: (name) =>
-        projectExtensionDisplayName(projectRoot, extensionDir, name),
+        projectExtensionDisplayName(dirProjectRoot, extensionDir, name),
+      onDiscovered: (name) => {
+        discoveredNames.add(name);
+      },
       onLoaded: (name) => {
         wrappedHooks.onLoaded?.(name);
-        wrappedHooks.onProjectLoaded?.(name, projectRoot);
+        wrappedHooks.onProjectLoaded?.(name, dirProjectRoot);
       },
       onFailure: (failure) =>
-        wrappedHooks.onFailure({ ...failure, projectRoot }),
+        wrappedHooks.onFailure({ ...failure, projectRoot: dirProjectRoot }),
     });
   }
-  return { loaded: loadedFiles.size - before, failed: failedThisCall };
+  const prunedDisabled = await pruneStaleDisabledProjectExtensions(
+    state,
+    projectRoot,
+    discoveredNames,
+    scannedPrefixes,
+  );
+  return {
+    loaded: loadedFiles.size - before,
+    failed: failedThisCall,
+    prunedDisabled,
+  };
 }

--- a/agent/project-extensions.ts
+++ b/agent/project-extensions.ts
@@ -35,6 +35,14 @@ async function nearestGitRoot(start: string): Promise<string | null> {
   }
 }
 
+/** Resolve the nearest project root for a cwd using the same rules as
+ *  project extension discovery. Falls back to the normalized starting
+ *  directory when no `.git` marker is found. */
+export async function findProjectRoot(cwd: string): Promise<string> {
+  const start = await normalizeStartDirectory(cwd);
+  return (await nearestGitRoot(start)) ?? start;
+}
+
 async function normalizeStartDirectory(cwd: string): Promise<string> {
   const start = resolve(cwd);
   try {
@@ -54,7 +62,7 @@ export async function findProjectExtensionDirs(
   cwd: string,
 ): Promise<ProjectExtensionDir[]> {
   const start = await normalizeStartDirectory(cwd);
-  const root = (await nearestGitRoot(start)) ?? start;
+  const root = await findProjectRoot(start);
   const dirs: ProjectExtensionDir[] = [];
   let dir = start;
 

--- a/agent/projectLifecycle.ts
+++ b/agent/projectLifecycle.ts
@@ -278,11 +278,16 @@ export async function handleSetProject(
     logger
       .scope("project-switch")
       .info(
-        `set_project load took ${Date.now() - tLoad}ms (loaded=${result.loaded} failed=${result.failed})`,
+        `set_project load took ${Date.now() - tLoad}ms (loaded=${result.loaded} failed=${result.failed} prunedDisabled=${result.prunedDisabled})`,
       );
   }
   state.currentProjectCwd = cwd;
-  if (result.loaded > 0 || result.failed > 0 || projectChanged) {
+  if (
+    result.loaded > 0 ||
+    result.failed > 0 ||
+    result.prunedDisabled > 0 ||
+    projectChanged
+  ) {
     const tReload = Date.now();
     await state.resourceLoader.reload();
     if (projectChanged) {

--- a/agent/tabs.ts
+++ b/agent/tabs.ts
@@ -58,7 +58,12 @@ export async function handleTabOpen(
       deps.loadHooks,
     );
     state.currentProjectCwd = cwdOverride;
-    if (result.loaded > 0 || result.failed > 0 || projectChanged) {
+    if (
+      result.loaded > 0 ||
+      result.failed > 0 ||
+      result.prunedDisabled > 0 ||
+      projectChanged
+    ) {
       await state.resourceLoader.reload();
       deps.scheduleStateFileWrite();
       emitGlobalReady(state, deps);


### PR DESCRIPTION
## Summary

Fixes #142 by reconciling persisted disabled project-local extension records with the project extensions discovered during reload/project scans.

When a loose project extension file is removed, Aethon now prunes the corresponding disabled record automatically instead of leaving stale entries visible until the user attempts to re-enable them.

## Details

- Tracks project-local extension display names before disabled filtering so disabled-but-existing files are considered discovered.
- Prunes disabled records only when the active scan can prove they are stale:
  - project-directory records with matching project roots and display-name scope
  - legacy metadata-less records that match the active project's display-name prefix
- Preserves unrelated disabled records:
  - npm/package extension records such as `@mold/...`
  - user/global extension records
  - nested project scope records when that nested scope was not part of the current scan
- Persists the cleaned `disabled-extensions.json` snapshot after pruning.
- Causes ready/system-prompt hydration to refresh when pruning changes disabled state.

## Testing

- `bunx vitest run agent/dispatcher.test.ts agent/extension-loader.test.ts agent/project-extensions.test.ts`
- `bun run typecheck`
- `bun run lint` exits 0 with existing unrelated React hook warnings in default-layout dashboard/editor files.

## Notes

This matches the behavior users expected during extension migration: removed loose project-local extensions disappear from the disabled list during normal reload/project extension discovery, without requiring a UI re-enable attempt.
