### PR TITLE
fix: clear updater banner from mac controls

### DIFF
--- a/src/components/UpdateBanner.module.css
+++ b/src/components/UpdateBanner.module.css
@@ -19,6 +19,10 @@
   -webkit-app-region: no-drag;
 }
 
+[data-platform="mac"] .banner {
+  padding-left: max(94px, 0.9rem);
+}
+
 .message {
   flex: 1 1 auto;
   white-space: nowrap;

--- a/src/components/UpdateBanner.test.ts
+++ b/src/components/UpdateBanner.test.ts
@@ -1,0 +1,73 @@
+// @ts-expect-error - app tsconfig omits Node types; Vitest runs this file in Node.
+import { readFileSync } from "node:fs";
+// @ts-expect-error - app tsconfig omits Node types; Vitest runs this file in Node.
+import { dirname, join } from "node:path";
+// @ts-expect-error - app tsconfig omits Node types; Vitest runs this file in Node.
+import { fileURLToPath } from "node:url";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import type { UpdaterStateView } from "../hooks/useUpdater";
+import { UpdateBanner } from "./UpdateBanner";
+
+vi.mock("@tauri-apps/plugin-opener", () => ({
+  openUrl: vi.fn(() => Promise.resolve()),
+}));
+
+const here = dirname(fileURLToPath(import.meta.url));
+const css = readFileSync(join(here, "UpdateBanner.module.css"), "utf8");
+
+const baseState: UpdaterStateView = {
+  available: true,
+  version: "0.4.0-dev.66.g4e64993",
+  body: null,
+  channel: "nightly",
+  disableAutoCheck: false,
+  downloading: false,
+  preparing: null,
+  progress: 0,
+  error: null,
+  dismissed: false,
+};
+
+describe("UpdateBanner stylesheet", () => {
+  it("reserves macOS overlay titlebar space for the traffic lights", () => {
+    expect(css).toMatch(/\[data-platform="mac"\]\s+\.banner\s*\{/);
+    expect(css).toMatch(/padding-left:\s*max\(94px,\s*0\.9rem\)/);
+  });
+});
+
+describe("UpdateBanner", () => {
+  const render = (state: UpdaterStateView) =>
+    renderToStaticMarkup(
+      createElement(UpdateBanner, {
+        state,
+        onInstallNow: vi.fn(),
+        onDismiss: vi.fn(),
+        onRetry: vi.fn(),
+      }),
+    );
+
+  it("renders the available nightly update controls", () => {
+    const html = render(baseState);
+
+    expect(html).toContain("Aethon Nightly");
+    expect(html).toContain("v0.4.0-dev.66.g4e64993");
+    expect(html).toContain("Install Now");
+    expect(html).toContain("Dismiss");
+  });
+
+  it("renders the download progress view without install controls", () => {
+    const html = render({
+      ...baseState,
+      downloading: true,
+      preparing: "downloading",
+      progress: 42,
+    });
+
+    expect(html).toContain("Downloading update");
+    expect(html).toContain("42%");
+    expect(html).toContain("width:42%");
+    expect(html).not.toContain("Install Now");
+  });
+});

--- a/src/hooks/useUpdater.test.tsx
+++ b/src/hooks/useUpdater.test.tsx
@@ -1,6 +1,22 @@
 // @vitest-environment jsdom
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { UpdaterStateView } from "./useUpdater";
+
+declare global {
+  interface Window {
+    __AETHON_UPDATER_DEBUG__?: {
+      show: (patch?: Partial<UpdaterStateView>) => void;
+      hide: () => void;
+      progress: (
+        progress: number,
+        preparing?: UpdaterStateView["preparing"],
+      ) => void;
+      error: (message: string) => void;
+      state: () => UpdaterStateView;
+    };
+  }
+}
 
 const invoke = vi.fn((cmd: string, _args?: unknown) => {
   if (cmd === "updater_available") return Promise.resolve(true);
@@ -31,6 +47,7 @@ describe("useUpdater", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.stubEnv("DEV", false);
+    delete window.__AETHON_UPDATER_DEBUG__;
     invoke.mockClear();
     listen.mockClear();
     getConfig.mockClear();
@@ -39,7 +56,7 @@ describe("useUpdater", () => {
   it("does not restart the production auto-check when parent callbacks change identity", async () => {
     const { useUpdater } = await import("./useUpdater");
 
-    const { rerender } = renderHook(
+    const { rerender, unmount } = renderHook(
       ({ tick }: { tick: number }) =>
         useUpdater({
           appendSystem: vi.fn((_text: string) => tick),
@@ -68,5 +85,63 @@ describe("useUpdater", () => {
         ([cmd]) => cmd === "check_for_updates_with_channel",
       ),
     ).toHaveLength(1);
+
+    unmount();
+  });
+
+  it("exposes a dev-only updater debug control for visual verification", async () => {
+    vi.stubEnv("DEV", true);
+    const { useUpdater } = await import("./useUpdater");
+
+    const { result, unmount } = renderHook(() =>
+      useUpdater({ appendSystem: vi.fn() }),
+    );
+
+    await waitFor(() => expect(window.__AETHON_UPDATER_DEBUG__).toBeDefined());
+
+    act(() => {
+      window.__AETHON_UPDATER_DEBUG__?.show({
+        version: "debug-version",
+        channel: "nightly",
+      });
+    });
+
+    await waitFor(() =>
+      expect(result.current.state).toMatchObject({
+        available: true,
+        version: "debug-version",
+        channel: "nightly",
+        downloading: false,
+        dismissed: false,
+      }),
+    );
+
+    act(() => {
+      window.__AETHON_UPDATER_DEBUG__?.progress(42, "downloading");
+    });
+
+    await waitFor(() =>
+      expect(result.current.state).toMatchObject({
+        available: true,
+        downloading: true,
+        preparing: "downloading",
+        progress: 42,
+      }),
+    );
+
+    act(() => {
+      window.__AETHON_UPDATER_DEBUG__?.hide();
+    });
+
+    await waitFor(() =>
+      expect(result.current.state).toMatchObject({
+        available: false,
+        downloading: false,
+        progress: 0,
+      }),
+    );
+
+    unmount();
+    expect(window.__AETHON_UPDATER_DEBUG__).toBeUndefined();
   });
 });

--- a/src/hooks/useUpdater.ts
+++ b/src/hooks/useUpdater.ts
@@ -61,6 +61,23 @@ export interface UseUpdaterActions {
   setDisableAutoCheck: (next: boolean) => void;
 }
 
+interface UpdaterDebugControl {
+  show: (patch?: Partial<UpdaterStateView>) => void;
+  hide: () => void;
+  progress: (
+    progress: number,
+    preparing?: UpdaterStateView["preparing"],
+  ) => void;
+  error: (message: string) => void;
+  state: () => UpdaterStateView;
+}
+
+declare global {
+  interface Window {
+    __AETHON_UPDATER_DEBUG__?: UpdaterDebugControl;
+  }
+}
+
 const INITIAL_STATE: UpdaterStateView = {
   available: false,
   version: null,
@@ -124,6 +141,60 @@ export function useUpdater(ctx: UseUpdaterContext): {
     },
     [setState],
   );
+
+  useEffect(() => {
+    if (!import.meta.env.DEV) return;
+    window.__AETHON_UPDATER_DEBUG__ = {
+      show: (patch = {}) => {
+        update({
+          available: true,
+          version: "0.4.0-dev.66.g4e64993",
+          body: null,
+          channel: "nightly",
+          downloading: false,
+          preparing: null,
+          progress: 0,
+          error: null,
+          dismissed: false,
+          ...patch,
+        });
+      },
+      hide: () => {
+        update({
+          available: false,
+          downloading: false,
+          preparing: null,
+          progress: 0,
+          error: null,
+          dismissed: false,
+        });
+      },
+      progress: (progress, preparing = "downloading") => {
+        update({
+          available: true,
+          downloading: true,
+          preparing,
+          progress,
+          error: null,
+          dismissed: false,
+        });
+      },
+      error: (message) => {
+        update({
+          available: true,
+          downloading: false,
+          preparing: null,
+          progress: 0,
+          error: message,
+          dismissed: false,
+        });
+      },
+      state: () => stateRef.current,
+    };
+    return () => {
+      delete window.__AETHON_UPDATER_DEBUG__;
+    };
+  }, [update]);
 
   // Channel changes from settings UI: persist the runtime view + trigger
   // a fresh check against the new endpoint.


### PR DESCRIPTION
## Summary

- Reserve macOS overlay-titlebar space for the updater banner so the message no longer renders under the traffic-light controls.
- Add a dev-only `window.__AETHON_UPDATER_DEBUG__` helper for forcing available, progress, error, and hidden updater states in the running dev webview.
- Cover the available and download-progress banner states, the macOS clearance CSS, and the dev visual toggle with focused regression tests.

## Root Cause

The updater banner is mounted above the A2UI layout as app chrome, so it did not inherit the sidebar title row's macOS traffic-light padding. When an update was available, the banner text started at the far-left edge and collided visually with the native window controls.

## Validation

- Visually verified in the running dev Aethon app via the debug webview helper:
  - available update banner
  - download progress banner at 42%
- `bunx vitest run src/components/UpdateBanner.test.ts src/hooks/useUpdater.test.tsx`
- `bun run typecheck`
- `bun run lint` (passes with 7 pre-existing React hook warnings in unrelated files)
