### PR TITLE
fix: use project icons on overview surfaces

### DIFF
--- a/src/eventRoutes/sidebar.test.ts
+++ b/src/eventRoutes/sidebar.test.ts
@@ -275,6 +275,7 @@ describe("handleSidebarSwitchWorktree", () => {
         {
           id: "proj-1",
           label: "aethon",
+          iconUrl: "asset://localhost/project-icons/aethon.png",
           worktrees: [
             {
               id: "wt-1",
@@ -306,6 +307,7 @@ describe("handleSidebarSwitchWorktree", () => {
     expect(applySetState().landing).toMatchObject({
       kind: "worktree",
       projectId: "proj-1",
+      iconUrl: "asset://localhost/project-icons/aethon.png",
       worktreeId: "wt-1",
       path: "/repo/aethon-fix-issue",
     });

--- a/src/eventRoutes/sidebar/worktree.ts
+++ b/src/eventRoutes/sidebar/worktree.ts
@@ -40,6 +40,7 @@ export const handleSidebarSwitchWorktree: EventRouteHandler = (
           projects?: {
             id: string;
             label: string;
+            iconUrl?: string;
             worktrees?: {
               id: string;
               label?: string;
@@ -85,6 +86,7 @@ export const handleSidebarSwitchWorktree: EventRouteHandler = (
           kind: "worktree",
           projectId: project.id,
           projectLabel: project.label,
+          iconUrl: project.iconUrl,
           worktreeId: worktree.id,
           worktreeLabel: worktree.label,
           branch: worktree.branch,

--- a/src/extensions/default-layout/dashboard/project-dashboard.test.tsx
+++ b/src/extensions/default-layout/dashboard/project-dashboard.test.tsx
@@ -26,13 +26,20 @@ function dashboard(props: Record<string, unknown>): A2UIComponent {
   };
 }
 
-function renderDashboard(onEvent = vi.fn()) {
+function renderDashboard(
+  onEvent = vi.fn(),
+  project: Record<string, unknown> = {
+    id: "p1",
+    label: "aethon",
+    path: "/repo",
+  },
+) {
   const registry = new ExtensionRegistry();
-  render(
+  const result = render(
     <ExtensionRegistryProvider registry={registry}>
       <ProjectDashboard
         component={dashboard({
-          project: { id: "p1", label: "aethon", path: "/repo" },
+          project,
           worktrees: [
             {
               id: "main",
@@ -57,8 +64,26 @@ function renderDashboard(onEvent = vi.fn()) {
       />
     </ExtensionRegistryProvider>,
   );
-  return { onEvent };
+  return { onEvent, ...result };
 }
+
+describe("ProjectDashboard project icon", () => {
+  it("uses the discovered project icon in the hero when one is available", () => {
+    const { container } = renderDashboard(vi.fn(), {
+      id: "p1",
+      label: "Claudette",
+      path: "/repo/claudette",
+      iconUrl: "asset://localhost/project-icons/claudette.png",
+    });
+
+    const hero = container.querySelector(".a2ui-project-dashboard-hero")!;
+    const image = hero.querySelector("img");
+    expect(image?.getAttribute("src")).toBe(
+      "asset://localhost/project-icons/claudette.png",
+    );
+    expect(hero.querySelector("svg")).toBeNull();
+  });
+});
 
 describe("ProjectDashboard worktree removal", () => {
   it("opens inline confirmation from a worktree remove icon", () => {

--- a/src/extensions/default-layout/dashboard/project-dashboard.tsx
+++ b/src/extensions/default-layout/dashboard/project-dashboard.tsx
@@ -169,7 +169,16 @@ export function ProjectDashboard({
       <div className="a2ui-project-dashboard-card">
         <header className="a2ui-project-dashboard-header">
           <div className="a2ui-project-dashboard-hero" aria-hidden="true">
-            <AeMarkInline size={48} radius={10} />
+            {project.iconUrl ? (
+              <img
+                src={project.iconUrl}
+                alt=""
+                className="a2ui-project-dashboard-icon"
+                loading="lazy"
+              />
+            ) : (
+              <AeMarkInline size={48} radius={10} />
+            )}
           </div>
           <div className="a2ui-project-dashboard-header-text">
             <h1 className="a2ui-project-dashboard-title">{project.label}</h1>

--- a/src/extensions/default-layout/layout/worktree-landing.tsx
+++ b/src/extensions/default-layout/layout/worktree-landing.tsx
@@ -74,10 +74,12 @@ export function WorktreeLanding({
   const branch = landing.branch ?? "";
   const path = landing.path ?? "";
   const isMain = landing.isMain === true;
+  const sidebarIconUrl = projectIconUrlFromSidebar(state, landing.projectId);
+  const iconUrl = sidebarIconUrl ?? landing.iconUrl;
 
   return (
     <WorktreeLandingInner
-      iconUrl={landing.iconUrl}
+      iconUrl={iconUrl}
       title={title}
       projectLabel={projectLabel}
       branch={branch}
@@ -96,6 +98,18 @@ interface WorktreeLandingSession {
   label: string;
   lastModified?: string;
   cwd?: string;
+}
+
+function projectIconUrlFromSidebar(
+  state: Record<string, unknown>,
+  projectId?: string,
+): string | undefined {
+  if (!projectId) return undefined;
+  const sidebar = state.sidebar as
+    | { projects?: Array<{ id?: string; iconUrl?: unknown }> }
+    | undefined;
+  const project = sidebar?.projects?.find((p) => p.id === projectId);
+  return typeof project?.iconUrl === "string" ? project.iconUrl : undefined;
 }
 
 function normalizeLandingPath(path?: string): string {

--- a/src/extensions/default-layout/layout/worktree-landing.tsx
+++ b/src/extensions/default-layout/layout/worktree-landing.tsx
@@ -43,6 +43,7 @@ export function WorktreeLanding({
       kind?: string;
       projectId?: string;
       projectLabel?: string;
+      iconUrl?: string;
       worktreeId?: string;
       worktreeLabel?: string;
       branch?: string;
@@ -76,6 +77,7 @@ export function WorktreeLanding({
 
   return (
     <WorktreeLandingInner
+      iconUrl={landing.iconUrl}
       title={title}
       projectLabel={projectLabel}
       branch={branch}
@@ -101,6 +103,7 @@ function normalizeLandingPath(path?: string): string {
 }
 
 function WorktreeLandingInner(props: {
+  iconUrl?: string;
   title: string;
   projectLabel: string;
   branch: string;
@@ -116,6 +119,7 @@ function WorktreeLandingInner(props: {
   ) => void;
 }) {
   const {
+    iconUrl,
     title,
     projectLabel,
     branch,
@@ -163,7 +167,16 @@ function WorktreeLandingInner(props: {
     <div className="a2ui-empty-state a2ui-worktree-landing">
       <div className="a2ui-empty-state-card">
         <div className="a2ui-empty-state-hero" aria-hidden="true">
-          <AeMarkInline size={64} radius={12} />
+          {iconUrl ? (
+            <img
+              src={iconUrl}
+              alt=""
+              className="a2ui-worktree-landing-icon"
+              loading="lazy"
+            />
+          ) : (
+            <AeMarkInline size={64} radius={12} />
+          )}
         </div>
         <h1 className="a2ui-empty-state-title">{title}</h1>
         <p className="a2ui-empty-state-subtitle">

--- a/src/extensions/default-layout/worktree-landing.test.tsx
+++ b/src/extensions/default-layout/worktree-landing.test.tsx
@@ -54,6 +54,69 @@ describe("WorktreeLanding sessions", () => {
     expect(hero.querySelector("svg")).toBeNull();
   });
 
+  it("derives the project icon from live sidebar state", () => {
+    const { container, rerender } = render(
+      <WorktreeLanding
+        component={worktreeLanding({
+          landing: { $ref: "/landing" },
+          recentSessions: { $ref: "/recentSessions" },
+        })}
+        state={{
+          landing: {
+            kind: "worktree",
+            projectId: "p1",
+            projectLabel: "Claudette",
+            worktreeId: "wt-1",
+            worktreeLabel: "feat/phaethon",
+            branch: "feat/phaethon",
+            path: "/repo/claudette-feat-phaethon",
+          },
+          sidebar: { projects: [{ id: "p1" }] },
+          recentSessions: [],
+        }}
+        onEvent={vi.fn()}
+      />,
+    );
+
+    expect(container.querySelector(".a2ui-empty-state-hero img")).toBeNull();
+
+    rerender(
+      <WorktreeLanding
+        component={worktreeLanding({
+          landing: { $ref: "/landing" },
+          recentSessions: { $ref: "/recentSessions" },
+        })}
+        state={{
+          landing: {
+            kind: "worktree",
+            projectId: "p1",
+            projectLabel: "Claudette",
+            worktreeId: "wt-1",
+            worktreeLabel: "feat/phaethon",
+            branch: "feat/phaethon",
+            path: "/repo/claudette-feat-phaethon",
+          },
+          sidebar: {
+            projects: [
+              {
+                id: "p1",
+                iconUrl: "asset://localhost/project-icons/claudette.png",
+              },
+            ],
+          },
+          recentSessions: [],
+        }}
+        onEvent={vi.fn()}
+      />,
+    );
+
+    expect(
+      container
+        .querySelector(".a2ui-empty-state-hero img")
+        ?.getAttribute("src"),
+    ).toBe("asset://localhost/project-icons/claudette.png");
+  });
+
   it("lists resumable sessions for the selected worktree", () => {
     const onEvent = vi.fn();
     render(

--- a/src/extensions/default-layout/worktree-landing.test.tsx
+++ b/src/extensions/default-layout/worktree-landing.test.tsx
@@ -22,6 +22,38 @@ function worktreeLanding(props: Record<string, unknown>): A2UIComponent {
 }
 
 describe("WorktreeLanding sessions", () => {
+  it("uses the parent project's discovered icon when one is available", () => {
+    const { container } = render(
+      <WorktreeLanding
+        component={worktreeLanding({
+          landing: { $ref: "/landing" },
+          recentSessions: { $ref: "/recentSessions" },
+        })}
+        state={{
+          landing: {
+            kind: "worktree",
+            projectId: "p1",
+            projectLabel: "Claudette",
+            iconUrl: "asset://localhost/project-icons/claudette.png",
+            worktreeId: "wt-1",
+            worktreeLabel: "feat/phaethon",
+            branch: "feat/phaethon",
+            path: "/repo/claudette-feat-phaethon",
+          },
+          recentSessions: [],
+        }}
+        onEvent={vi.fn()}
+      />,
+    );
+
+    const hero = container.querySelector(".a2ui-empty-state-hero")!;
+    const image = hero.querySelector("img");
+    expect(image?.getAttribute("src")).toBe(
+      "asset://localhost/project-icons/claudette.png",
+    );
+    expect(hero.querySelector("svg")).toBeNull();
+  });
+
   it("lists resumable sessions for the selected worktree", () => {
     const onEvent = vi.fn();
     render(

--- a/src/hooks/tabOps/mutations.test.ts
+++ b/src/hooks/tabOps/mutations.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import type { SetStateAction } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { OVERVIEW_TAB_ID } from "../../types/tab";
+import { makeEmptyTab } from "../../types/tab";
+import { useMutations } from "./mutations";
+
+function setup(state: Record<string, unknown>) {
+  const stateRef = { current: state };
+  const setState = vi.fn((updater: SetStateAction<Record<string, unknown>>) => {
+    if (typeof updater === "function") {
+      stateRef.current = updater(stateRef.current);
+    } else {
+      stateRef.current = updater;
+    }
+  });
+  const { result } = renderHook(() => useMutations({ stateRef, setState }));
+  return { actions: result.current, stateRef, setState };
+}
+
+describe("useMutations setActiveTab", () => {
+  it("activates the overview sentinel even though it is not a real tab", () => {
+    const tab = makeEmptyTab("tab-1", "Session", null, "agent");
+    const { actions, stateRef, setState } = setup({
+      tabs: [tab],
+      activeTabId: "tab-1",
+      landing: { kind: "worktree", worktreeId: "wt-1" },
+      messages: [{ role: "user", text: "hello" }],
+    });
+
+    act(() => actions.setActiveTab(OVERVIEW_TAB_ID));
+
+    expect(setState).toHaveBeenCalledTimes(1);
+    expect(stateRef.current.activeTabId).toBe(OVERVIEW_TAB_ID);
+    expect(stateRef.current.landing).toBeNull();
+    expect(stateRef.current.messages).toEqual([{ role: "user", text: "hello" }]);
+  });
+});

--- a/src/hooks/tabOps/mutations.ts
+++ b/src/hooks/tabOps/mutations.ts
@@ -1,5 +1,6 @@
 import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 import type { ShellMeta, Tab } from "../../types/tab";
+import { OVERVIEW_TAB_ID } from "../../types/tab";
 import { recomputeModelPicker } from "../../utils/modelPicker";
 import { TAB_MIRROR_KEYS, VALID_SHARE_MODES } from "./constants";
 
@@ -98,6 +99,16 @@ export function useMutations(deps: MutationsDeps): MutationsActions {
    *  dispatches a terminal replay so the shared xterm clears and
    *  re-writes the new tab's buffered output. */
   function setActiveTab(tabId: string): void {
+    if (tabId === OVERVIEW_TAB_ID) {
+      setState((prev) => {
+        if (prev.activeTabId === OVERVIEW_TAB_ID && prev.landing == null) {
+          return prev;
+        }
+        return { ...prev, activeTabId: OVERVIEW_TAB_ID, landing: null };
+      });
+      dispatchTerminalReplay("");
+      return;
+    }
     let nextBuffer = "";
     setState((prev) => {
       const tabs = (prev.tabs as Tab[] | undefined) ?? [];

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -1937,6 +1937,14 @@ body.ae-resizing-sidebar .a2ui-layout {
   filter: drop-shadow(var(--shadow-1));
 }
 
+.a2ui-worktree-landing-icon {
+  width: 64px;
+  height: 64px;
+  border-radius: var(--radius-lg);
+  object-fit: cover;
+  display: block;
+}
+
 .a2ui-empty-state-title {
   margin: 0;
   font-size: 1.5rem;
@@ -6358,6 +6366,13 @@ button.a2ui-gh-stat:hover {
   border-radius: var(--radius-lg);
   background: var(--accent-soft);
   box-shadow: 0 0 0 1px var(--accent-soft);
+}
+.a2ui-project-dashboard-icon {
+  width: 48px;
+  height: 48px;
+  border-radius: var(--radius-md);
+  object-fit: cover;
+  display: block;
 }
 .a2ui-project-dashboard-header-text {
   display: flex;


### PR DESCRIPTION
## Summary
- render discovered project icons in the active project dashboard hero instead of the default Aethon mark when `project.iconUrl` is available
- carry the same parent project `iconUrl` into worktree landing state and render it in the worktree hero
- allow keyboard tab cycling to activate the overview sentinel through the shared `setActiveTab` path

## Root cause
The sidebar and project cards already used the discovered project `iconUrl`, but the project dashboard and worktree landing had separate Aethon-mark fallbacks. Worktree landing also rebuilt its own landing payload from sidebar state without preserving the parent project icon. Separately, tab cycling computed the overview sentinel correctly, but the low-level tab mutation ignored it because overview is not a real tab in `/tabs`.

## User impact
Project and worktree overview surfaces now match the sidebar icon identity, while the host/global overview keeps the Aethon branding. Cmd+Shift+[ / Cmd+Shift+] can land on and leave the overview pseudo-tab reliably.

## Validation
- `bunx vitest run src/extensions/default-layout/dashboard/project-dashboard.test.tsx src/extensions/default-layout/worktree-landing.test.tsx src/eventRoutes/sidebar.test.ts src/hooks/tabOps/mutations.test.ts src/hooks/useTabNavigation.test.ts`
- `bun run typecheck`
- `bun run lint` exits 0 with 7 existing warnings in project-dashboard, task-launcher, image-viewer, markdown-preview, worktree-landing, usePersistEditorTabs, and useRestoreShellTabs