### PR TITLE
fix: derive project dashboard icon live

### DIFF
--- a/src/extensions/default-layout/dashboard/project-dashboard.test.tsx
+++ b/src/extensions/default-layout/dashboard/project-dashboard.test.tsx
@@ -33,6 +33,7 @@ function renderDashboard(
     label: "aethon",
     path: "/repo",
   },
+  state: Record<string, unknown> = {},
 ) {
   const registry = new ExtensionRegistry();
   const result = render(
@@ -59,7 +60,7 @@ function renderDashboard(
           widgets: [],
           otherProjects: [],
         })}
-        state={{}}
+        state={state}
         onEvent={onEvent}
       />
     </ExtensionRegistryProvider>,
@@ -82,6 +83,57 @@ describe("ProjectDashboard project icon", () => {
       "asset://localhost/project-icons/claudette.png",
     );
     expect(hero.querySelector("svg")).toBeNull();
+  });
+
+  it("derives the project icon from live sidebar state", () => {
+    const { container, rerender } = renderDashboard(
+      vi.fn(),
+      {
+        id: "p1",
+        label: "nyc-real-estate",
+        path: "/repo/nyc-real-estate",
+      },
+      {
+        sidebar: { projects: [{ id: "p1" }] },
+      },
+    );
+
+    expect(container.querySelector(".a2ui-project-dashboard-hero img")).toBeNull();
+
+    rerender(
+      <ExtensionRegistryProvider registry={new ExtensionRegistry()}>
+        <ProjectDashboard
+          component={dashboard({
+            project: {
+              id: "p1",
+              label: "nyc-real-estate",
+              path: "/repo/nyc-real-estate",
+            },
+            worktrees: [],
+            recentSessions: [],
+            widgets: [],
+            otherProjects: [],
+          })}
+          state={{
+            sidebar: {
+              projects: [
+                {
+                  id: "p1",
+                  iconUrl: "asset://localhost/project-icons/nyc-real-estate.png",
+                },
+              ],
+            },
+          }}
+          onEvent={vi.fn()}
+        />
+      </ExtensionRegistryProvider>,
+    );
+
+    expect(
+      container
+        .querySelector(".a2ui-project-dashboard-hero img")
+        ?.getAttribute("src"),
+    ).toBe("asset://localhost/project-icons/nyc-real-estate.png");
   });
 });
 

--- a/src/extensions/default-layout/dashboard/project-dashboard.tsx
+++ b/src/extensions/default-layout/dashboard/project-dashboard.tsx
@@ -77,6 +77,18 @@ function resolveArray<T>(v: unknown, state: Record<string, unknown>): T[] {
   return Array.isArray(v) ? (v as T[]) : [];
 }
 
+function projectIconUrlFromSidebar(
+  state: Record<string, unknown>,
+  projectId?: string,
+): string | undefined {
+  if (!projectId) return undefined;
+  const sidebar = state.sidebar as
+    | { projects?: Array<{ id?: string; iconUrl?: unknown }> }
+    | undefined;
+  const project = sidebar?.projects?.find((p) => p.id === projectId);
+  return typeof project?.iconUrl === "string" ? project.iconUrl : undefined;
+}
+
 export function ProjectDashboard({
   component,
   state,
@@ -163,15 +175,16 @@ export function ProjectDashboard({
   const overviewData = overview?.path === project?.path ? overview?.data : null;
 
   if (!project) return null;
+  const iconUrl = projectIconUrlFromSidebar(state, project.id) ?? project.iconUrl;
 
   return (
     <div className="a2ui-project-dashboard">
       <div className="a2ui-project-dashboard-card">
         <header className="a2ui-project-dashboard-header">
           <div className="a2ui-project-dashboard-hero" aria-hidden="true">
-            {project.iconUrl ? (
+            {iconUrl ? (
               <img
-                src={project.iconUrl}
+                src={iconUrl}
                 alt=""
                 className="a2ui-project-dashboard-icon"
                 loading="lazy"


### PR DESCRIPTION
## Summary
- make the project dashboard hero derive its icon from live `/sidebar/projects` state before falling back to `project.iconUrl`
- add a rerender regression proving an already-visible dashboard updates when async icon discovery syncs the sidebar

## Root cause
The active `/project` mirror only carries id, label, path, and worktree base branch. Discovered project logos live on `/sidebar/projects`, so the dashboard kept rendering the Aethon mark even after the sidebar and worktree landing had the correct project icon.

## User impact
The project overview now uses the same discovered project icon as the sidebar and worktree overview surfaces. Host/global overview branding is unchanged.

## Validation
- `bunx vitest run src/extensions/default-layout/dashboard/project-dashboard.test.tsx` (red before the fix, green after)
- `bunx vitest run src/extensions/default-layout/dashboard/project-dashboard.test.tsx src/extensions/default-layout/worktree-landing.test.tsx`
- `bun run typecheck`
- `bun run lint` exits 0 with the existing 7 warnings in project-dashboard, task-launcher, image-viewer, markdown-preview, worktree-landing, usePersistEditorTabs, and useRestoreShellTabs