### PR TITLE
feat(git): watch .git for realtime file-tree + VCS refresh

### DIFF
--- a/src-tauri/src/commands/git/mod.rs
+++ b/src-tauri/src/commands/git/mod.rs
@@ -13,4 +13,7 @@ pub mod picker;
 pub mod status;
 #[cfg(test)]
 pub(crate) mod test_support;
+pub mod watch;
 pub mod worktrees;
+
+pub use watch::GitWatchState;

--- a/src-tauri/src/commands/git/watch.rs
+++ b/src-tauri/src/commands/git/watch.rs
@@ -1,0 +1,289 @@
+//! Git-state watcher. The file-tree watcher in [`crate::commands::fs::watch`]
+//! only watches working-tree directories, so git operations that touch *only*
+//! `.git/` (commit, stage, branch switch, stash) — especially ones run in an
+//! external terminal — never fire `fs-tree-changed`, leaving the file-tree
+//! decorations and the `/vcs` slice stale until the next poll or manual
+//! refresh.
+//!
+//! This watcher closes that gap: it resolves the active root's git directory
+//! (worktree-aware) and watches `HEAD`/`index`/`refs`/`packed-refs` for
+//! changes, emitting a debounced `git-state-changed` event so both surfaces
+//! repaint within a couple hundred milliseconds of any git operation.
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, mpsc};
+use std::thread;
+use std::time::Duration;
+
+use tauri::Emitter;
+
+use crate::env;
+
+/// Git writes several files per operation (HEAD, index, a ref, sometimes
+/// packed-refs); coalesce a touch longer than the fs watcher's 120ms so a
+/// single commit produces one event, not three.
+const GIT_DEBOUNCE_MS: u64 = 180;
+
+struct GitWatchHandle {
+    #[allow(dead_code)]
+    watcher: notify::RecommendedWatcher,
+    watched: HashSet<PathBuf>,
+}
+
+#[derive(Default)]
+pub struct GitWatchState {
+    roots: Mutex<HashMap<String, GitWatchHandle>>,
+}
+
+#[derive(Clone, serde::Serialize)]
+struct GitStateChanged {
+    root: String,
+}
+
+fn is_interesting_fs_event(kind: &notify::EventKind) -> bool {
+    use notify::EventKind;
+    matches!(
+        kind,
+        EventKind::Any | EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
+    )
+}
+
+/// Resolve a git path (possibly relative to `root`, as `git rev-parse` emits
+/// for a plain checkout) into an absolute path.
+fn absolutize(root: &Path, raw: &str) -> PathBuf {
+    let p = PathBuf::from(raw.trim());
+    if p.is_absolute() { p } else { root.join(p) }
+}
+
+/// Resolve the set of directories to watch for git-state changes under `root`.
+///
+/// Watches (non-recursively, so notify fires on direct children):
+/// - the per-worktree git dir — catches `HEAD`, `index`, `MERGE_HEAD`,
+///   `ORIG_HEAD`;
+/// - the shared common dir — catches `packed-refs`;
+/// - `<common>/refs/heads` — catches the branch ref bump on commit / switch.
+///
+/// For a plain checkout the git dir and common dir are the same `.git`, so the
+/// result dedupes to `{.git, .git/refs/heads}`. For a linked worktree they
+/// differ — the per-worktree dir holds HEAD/index while refs live in the shared
+/// dir — which is the case that actually breaks today. Non-existent paths are
+/// dropped so `notify::watch` never errors on them.
+fn resolve_git_watch_targets(root: &Path) -> Vec<PathBuf> {
+    let out = env::command("git")
+        .arg("-C")
+        .arg(root)
+        .args(["rev-parse", "--git-dir", "--git-common-dir"])
+        .output();
+    let Ok(out) = out else {
+        return Vec::new();
+    };
+    if !out.status.success() {
+        return Vec::new();
+    }
+    let text = String::from_utf8_lossy(&out.stdout);
+    let mut lines = text.lines();
+    let git_dir = lines.next().map(|l| absolutize(root, l));
+    // `--git-common-dir` echoes the git dir verbatim when there's no separate
+    // common dir, so a missing second line falls back to the git dir.
+    let common_dir = lines
+        .next()
+        .map(|l| absolutize(root, l))
+        .or_else(|| git_dir.clone());
+
+    let mut targets: Vec<PathBuf> = Vec::new();
+    let mut push = |p: PathBuf| {
+        if p.is_dir() && !targets.contains(&p) {
+            targets.push(p);
+        }
+    };
+    if let Some(dir) = git_dir {
+        push(dir);
+    }
+    if let Some(common) = common_dir {
+        push(common.join("refs").join("heads"));
+        push(common);
+    }
+    targets
+}
+
+/// Watch the active project/worktree's git directory for state changes. Emits a
+/// debounced `git-state-changed` event keyed by `root`. Re-calling replaces the
+/// watcher for `root`. A root whose git dir can't be resolved (not a repo) is a
+/// no-op, mirroring the silent-degrade contract of the status commands.
+#[tauri::command]
+pub fn git_watch_root(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, GitWatchState>,
+    root: String,
+) -> Result<usize, String> {
+    use notify::{RecursiveMode, Watcher};
+
+    let targets = resolve_git_watch_targets(Path::new(&root));
+    let mut roots = state.roots.lock().map_err(|e| e.to_string())?;
+    if targets.is_empty() {
+        // Not a git repo (or git missing): drop any stale handle and bail.
+        roots.remove(&root);
+        return Ok(0);
+    }
+    let requested: HashSet<PathBuf> = targets.into_iter().collect();
+
+    let handle = if let Some(handle) = roots.get_mut(&root) {
+        handle
+    } else {
+        let (tx, rx) = mpsc::channel::<()>();
+        let emit_root = root.clone();
+        thread::spawn(move || {
+            // Block until the first event, then coalesce a burst so a single
+            // git operation emits one `git-state-changed`.
+            while rx.recv().is_ok() {
+                while rx
+                    .recv_timeout(Duration::from_millis(GIT_DEBOUNCE_MS))
+                    .is_ok()
+                {}
+                let _ = app.emit(
+                    "git-state-changed",
+                    GitStateChanged {
+                        root: emit_root.clone(),
+                    },
+                );
+            }
+        });
+
+        let watcher_tx = tx.clone();
+        let watcher = notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
+            let Ok(event) = res else {
+                return;
+            };
+            if !is_interesting_fs_event(&event.kind) {
+                return;
+            }
+            let _ = watcher_tx.send(());
+        })
+        .map_err(|e| format!("create git watcher: {e}"))?;
+        roots.insert(
+            root.clone(),
+            GitWatchHandle {
+                watcher,
+                watched: HashSet::new(),
+            },
+        );
+        roots
+            .get_mut(&root)
+            .ok_or_else(|| "git watcher registration failed".to_string())?
+    };
+
+    let stale: Vec<PathBuf> = handle.watched.difference(&requested).cloned().collect();
+    for dir in stale {
+        let _ = handle.watcher.unwatch(&dir);
+        handle.watched.remove(&dir);
+    }
+    for dir in &requested {
+        if handle.watched.contains(dir) {
+            continue;
+        }
+        handle
+            .watcher
+            .watch(dir, RecursiveMode::NonRecursive)
+            .map_err(|e| format!("watch {}: {e}", dir.display()))?;
+        handle.watched.insert(dir.clone());
+    }
+
+    Ok(handle.watched.len())
+}
+
+#[tauri::command]
+pub fn git_unwatch_root(
+    state: tauri::State<'_, GitWatchState>,
+    root: String,
+) -> Result<(), String> {
+    let mut roots = state.roots.lock().map_err(|e| e.to_string())?;
+    roots.remove(&root);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::git::test_support::init_repo;
+
+    fn canon(p: &Path) -> PathBuf {
+        std::fs::canonicalize(p).unwrap_or_else(|_| p.to_path_buf())
+    }
+
+    #[test]
+    fn resolves_plain_checkout_targets() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        init_repo(root);
+
+        let targets: Vec<PathBuf> = resolve_git_watch_targets(root)
+            .into_iter()
+            .map(|p| canon(&p))
+            .collect();
+
+        let git_dir = canon(&root.join(".git"));
+        let refs_heads = canon(&root.join(".git/refs/heads"));
+        assert!(
+            targets.contains(&git_dir),
+            "plain checkout should watch .git (HEAD/index); got {targets:?}"
+        );
+        assert!(
+            targets.contains(&refs_heads),
+            "plain checkout should watch .git/refs/heads; got {targets:?}"
+        );
+    }
+
+    #[test]
+    fn resolves_worktree_targets_to_per_worktree_and_shared_dirs() {
+        // Keep both the main checkout and the linked worktree inside one
+        // tempdir so the worktree path is unique per run and auto-cleaned —
+        // a sibling in shared /tmp would leak and collide across parallel
+        // `cargo test` runs.
+        let tmp = tempfile::tempdir().unwrap();
+        let main = tmp.path().join("main");
+        std::fs::create_dir(&main).unwrap();
+        let main = main.as_path();
+        init_repo(main);
+
+        // Create a linked worktree on a new branch — `.git` there is a *file*
+        // pointing at `<main>/.git/worktrees/<name>`, with HEAD/index local and
+        // refs shared. This is the screenshot's exact case.
+        let wt = tmp.path().join("wt-feature");
+        let add = std::process::Command::new("git")
+            .arg("-C")
+            .arg(main)
+            .args(["worktree", "add", "-q", "-b", "feature"])
+            .arg(&wt)
+            .status()
+            .expect("git worktree add");
+        assert!(add.success(), "worktree add failed: {add}");
+
+        let targets: Vec<PathBuf> = resolve_git_watch_targets(&wt)
+            .into_iter()
+            .map(|p| canon(&p))
+            .collect();
+
+        let per_worktree = canon(&main.join(".git/worktrees/wt-feature"));
+        let shared = canon(&main.join(".git"));
+        let shared_refs = canon(&main.join(".git/refs/heads"));
+        assert!(
+            targets.contains(&per_worktree),
+            "worktree should watch its own git dir (HEAD/index); got {targets:?}"
+        );
+        assert!(
+            targets.contains(&shared),
+            "worktree should watch the shared common dir (packed-refs); got {targets:?}"
+        );
+        assert!(
+            targets.contains(&shared_refs),
+            "worktree should watch shared refs/heads; got {targets:?}"
+        );
+    }
+
+    #[test]
+    fn non_repo_resolves_to_nothing() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(resolve_git_watch_targets(tmp.path()).is_empty());
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -128,6 +128,7 @@ pub fn run() {
         .manage(agent_process::AgentProcesses::new())
         .manage(shell::ShellRegistry::new())
         .manage(commands::fs::FsWatchState::default())
+        .manage(commands::git::GitWatchState::default())
         .manage(window_state::WindowStateStore::new())
         .manage(updater_state::UpdaterState::new())
         .manage(Arc::new(server::ServerState::new()))
@@ -191,6 +192,8 @@ pub fn run() {
             commands::git::status::git_status,
             commands::git::status::git_file_status,
             commands::git::status::git_ignored_paths,
+            commands::git::watch::git_watch_root,
+            commands::git::watch::git_unwatch_root,
             commands::git::diff::git_file_diff_hunks,
             commands::git::diff::git_show_head,
             commands::git::diff::git_diff_stat,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import { useDevshell, type DevshellEntry } from "./hooks/useDevshell";
 import { activeCwd as projectsActiveCwd, type ProjectsState } from "./projects";
 import { useProjects } from "./hooks/useProjects";
 import { useVcsStatus } from "./hooks/useVcsStatus";
+import { useGitWatch } from "./hooks/useGitWatch";
 import { useTabNavigation } from "./hooks/useTabNavigation";
 import { useTabs } from "./hooks/useTabs";
 import { useRestoreShellTabs } from "./hooks/useRestoreShellTabs";
@@ -258,6 +259,7 @@ export default function App() {
     return null;
   })();
   useVcsStatus({ activeRoot: vcsActiveRoot, setState });
+  useGitWatch(vcsActiveRoot);
 
   // ---------------------------------------------------------------------
   // Tab lifecycle (create / switch / update / close / undo-close), the

--- a/src/extensions/default-layout/sidebar/file-tree.test.tsx
+++ b/src/extensions/default-layout/sidebar/file-tree.test.tsx
@@ -770,6 +770,92 @@ describe("FileTreePanel", () => {
     });
   });
 
+  it("refreshes git decorations when a git-state-changed event fires for the root", async () => {
+    let gitStateListener:
+      | ((event: { payload: { root: string } }) => void)
+      | undefined;
+    listenMock.mockImplementation((eventName: string, listener) => {
+      if (eventName === "git-state-changed") {
+        gitStateListener = listener as typeof gitStateListener;
+      }
+      return Promise.resolve(() => {});
+    });
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === "fs_list_dir") {
+        return Promise.resolve([
+          { name: "src", path: "/projects/aethon/src", kind: "dir" },
+        ]);
+      }
+      if (cmd === "git_file_status") return Promise.resolve([]);
+      if (cmd === "git_ignored_paths") return Promise.resolve([]);
+      return Promise.resolve(1);
+    });
+
+    render(<FileTreePanel {...panelProps()} />);
+    await waitFor(() => screen.getByText("src"));
+    await waitFor(() =>
+      expect(
+        invokeMock.mock.calls.some((c) => c[0] === "git_file_status"),
+      ).toBe(true),
+    );
+    const before = invokeMock.mock.calls.filter(
+      (c) => c[0] === "git_file_status",
+    ).length;
+
+    // External `git commit`: only `.git/` changed, so no fs-tree-changed —
+    // the git watcher's git-state-changed must drive the decoration refresh.
+    act(() => {
+      gitStateListener?.({ payload: { root: "/projects/aethon" } });
+    });
+
+    await waitFor(() =>
+      expect(
+        invokeMock.mock.calls.filter((c) => c[0] === "git_file_status").length,
+      ).toBeGreaterThan(before),
+    );
+  });
+
+  it("ignores git-state-changed events for a different root", async () => {
+    let gitStateListener:
+      | ((event: { payload: { root: string } }) => void)
+      | undefined;
+    listenMock.mockImplementation((eventName: string, listener) => {
+      if (eventName === "git-state-changed") {
+        gitStateListener = listener as typeof gitStateListener;
+      }
+      return Promise.resolve(() => {});
+    });
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === "fs_list_dir") {
+        return Promise.resolve([
+          { name: "src", path: "/projects/aethon/src", kind: "dir" },
+        ]);
+      }
+      if (cmd === "git_file_status") return Promise.resolve([]);
+      if (cmd === "git_ignored_paths") return Promise.resolve([]);
+      return Promise.resolve(1);
+    });
+
+    render(<FileTreePanel {...panelProps()} />);
+    await waitFor(() => screen.getByText("src"));
+    await waitFor(() =>
+      expect(
+        invokeMock.mock.calls.some((c) => c[0] === "git_file_status"),
+      ).toBe(true),
+    );
+    const before = invokeMock.mock.calls.filter(
+      (c) => c[0] === "git_file_status",
+    ).length;
+
+    act(() => {
+      gitStateListener?.({ payload: { root: "/projects/other" } });
+    });
+    await new Promise((r) => setTimeout(r, 220));
+    expect(
+      invokeMock.mock.calls.filter((c) => c[0] === "git_file_status").length,
+    ).toBe(before);
+  });
+
   it("reveals a nested file on aethon:reveal-in-tree", async () => {
     // jsdom doesn't define scrollIntoView; install a spy so the reveal
     // effect is safe and observable.

--- a/src/extensions/default-layout/sidebar/useFileTreeData.ts
+++ b/src/extensions/default-layout/sidebar/useFileTreeData.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 
 import { readState, writeState } from "../../../persist";
 import {
@@ -25,6 +26,11 @@ import {
 /** Bound expand-all so a deep / huge tree can't fan out into thousands of
  *  fs_list_dir calls. Mirrors the persisted-expand cap. */
 const EXPAND_ALL_MAX_DEPTH = 8;
+
+/** Backstop poll for git decorations, mirroring `useVcsStatus`. The
+ *  `git-state-changed` event is the fast path; this heals a dropped notify
+ *  event so badges never stick stale indefinitely. */
+const GIT_STATUS_POLL_MS = 20_000;
 
 interface UseFileTreeDataArgs {
   hidden: boolean;
@@ -207,6 +213,37 @@ function useFileTreeData({
       cancelled = true;
     };
   }, [projectPath, refreshGitStatuses, rootLabel]);
+
+  // Git-decoration refresh that the working-tree fs watcher can't drive. The
+  // file tree's primary refresh is `useFileTreeWatch`, which only fires on
+  // working-tree file changes — git operations that touch *only* `.git/`
+  // (commit, stage, branch switch, stash, incl. ones run in an external
+  // terminal) never trip it, so decorations would stay stale indefinitely.
+  // The Rust git watcher's `git-state-changed` event is the instant path; a
+  // focus + 20s poll backstops a dropped notify event so badges self-heal.
+  useEffect(() => {
+    if (!projectPath) return;
+    let disposed = false;
+    let unlisten: (() => void) | undefined;
+    void listen<{ root: string }>("git-state-changed", (event) => {
+      if (disposed || event.payload.root !== projectPathRef.current) return;
+      scheduleGitStatusRefresh(projectPathRef.current);
+    }).then((fn) => {
+      if (disposed) fn();
+      else unlisten = fn;
+    });
+    const refresh = () => {
+      if (projectPathRef.current) void refreshGitStatuses(projectPathRef.current);
+    };
+    window.addEventListener("focus", refresh);
+    const interval = window.setInterval(refresh, GIT_STATUS_POLL_MS);
+    return () => {
+      disposed = true;
+      window.removeEventListener("focus", refresh);
+      window.clearInterval(interval);
+      unlisten?.();
+    };
+  }, [projectPath, refreshGitStatuses, scheduleGitStatusRefresh]);
 
   const loadFolderChildren = useCallback(
     async (node: TreeNode): Promise<TreeNode[] | null> => {

--- a/src/hooks/useGitWatch.test.ts
+++ b/src/hooks/useGitWatch.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+/**
+ * useGitWatch owns the Rust git-state watcher lifecycle: it starts a watcher
+ * for the active project/worktree root and tears it down when the root changes
+ * or the hook unmounts. These tests assert the start/stop invoke contract.
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+
+const { invokeMock } = vi.hoisted(() => ({ invokeMock: vi.fn() }));
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: invokeMock }));
+
+import { useGitWatch } from "./useGitWatch";
+
+beforeEach(() => {
+  invokeMock.mockReset();
+  invokeMock.mockResolvedValue(undefined);
+});
+
+describe("useGitWatch", () => {
+  it("does nothing for a null root", () => {
+    renderHook(() => useGitWatch(null));
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it("starts a watcher for the active root", async () => {
+    renderHook(() => useGitWatch("/repo"));
+    await waitFor(() =>
+      expect(invokeMock).toHaveBeenCalledWith("git_watch_root", {
+        root: "/repo",
+      }),
+    );
+  });
+
+  it("unwatches the prior root when the root changes", async () => {
+    const { rerender } = renderHook(
+      ({ root }: { root: string | null }) => useGitWatch(root),
+      { initialProps: { root: "/repo-a" } },
+    );
+    await waitFor(() =>
+      expect(invokeMock).toHaveBeenCalledWith("git_watch_root", {
+        root: "/repo-a",
+      }),
+    );
+    rerender({ root: "/repo-b" });
+    await waitFor(() =>
+      expect(invokeMock).toHaveBeenCalledWith("git_unwatch_root", {
+        root: "/repo-a",
+      }),
+    );
+    await waitFor(() =>
+      expect(invokeMock).toHaveBeenCalledWith("git_watch_root", {
+        root: "/repo-b",
+      }),
+    );
+  });
+
+  it("unwatches on unmount", async () => {
+    const { unmount } = renderHook(() => useGitWatch("/repo"));
+    await waitFor(() =>
+      expect(invokeMock).toHaveBeenCalledWith("git_watch_root", {
+        root: "/repo",
+      }),
+    );
+    unmount();
+    await waitFor(() =>
+      expect(invokeMock).toHaveBeenCalledWith("git_unwatch_root", {
+        root: "/repo",
+      }),
+    );
+  });
+});

--- a/src/hooks/useGitWatch.ts
+++ b/src/hooks/useGitWatch.ts
@@ -1,0 +1,52 @@
+import { useEffect, useRef } from "react";
+import { invoke } from "@tauri-apps/api/core";
+
+/**
+ * useGitWatch — owns the Rust git-state watcher lifecycle for the active
+ * project/worktree root. The watcher watches the resolved git directory
+ * (worktree-aware: HEAD/index plus shared refs) and emits `git-state-changed`,
+ * which `useVcsStatus` and the file tree listen for to repaint immediately
+ * after any git operation — including ones run in an external terminal that
+ * only touch `.git/` and so never fire the working-tree `fs-tree-changed`
+ * watcher.
+ *
+ * Lifecycle mirrors `useFileTreeWatch`: start on root change, unwatch the prior
+ * root, and unwatch on unmount. All calls are best-effort — a non-repo root is
+ * a Rust-side no-op, and a missing git binary degrades silently.
+ */
+export function useGitWatch(activeRoot: string | null): void {
+  const watchedRootRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!activeRoot) {
+      const prev = watchedRootRef.current;
+      if (prev) {
+        watchedRootRef.current = null;
+        void invoke("git_unwatch_root", { root: prev }).catch(() => {
+          /* best-effort cleanup */
+        });
+      }
+      return;
+    }
+
+    const prev = watchedRootRef.current;
+    if (prev && prev !== activeRoot) {
+      void invoke("git_unwatch_root", { root: prev }).catch(() => {
+        /* best-effort cleanup */
+      });
+    }
+    watchedRootRef.current = activeRoot;
+    void invoke("git_watch_root", { root: activeRoot }).catch(() => {
+      /* Git watching is an enhancement; the poll backstop still refreshes. */
+    });
+
+    return () => {
+      void invoke("git_unwatch_root", { root: activeRoot }).catch(() => {
+        /* best-effort cleanup */
+      });
+      if (watchedRootRef.current === activeRoot) {
+        watchedRootRef.current = null;
+      }
+    };
+  }, [activeRoot]);
+}

--- a/src/hooks/useVcsStatus.test.ts
+++ b/src/hooks/useVcsStatus.test.ts
@@ -258,6 +258,42 @@ describe("useVcsStatus", () => {
     );
   });
 
+  it("re-ticks after the in-flight poll when a git event arrives mid-poll", async () => {
+    // Hold the first poll in-flight (awaiting gh) so the git-state-changed
+    // event lands while `polling` is true — the dropped-event race.
+    let releaseGh: () => void = () => {};
+    const ghGate = new Promise<null>((res) => {
+      releaseGh = () => res(null);
+    });
+    invokeMock.mockImplementation((cmd: string) =>
+      cmd === "git_status"
+        ? Promise.resolve({ branch: "main", ahead: 0, behind: 0, dirty: false })
+        : Promise.resolve(cmd === "git_file_status" ? [] : null),
+    );
+    branchMock.mockReturnValueOnce(ghGate).mockResolvedValue(null);
+    checksMock.mockResolvedValue(null);
+    const h = makeSetState();
+    renderHook(() =>
+      useVcsStatus({ activeRoot: "/repo", setState: h.setState }),
+    );
+    // The first poll has read git status and is now awaiting gh.
+    await waitFor(() => expect(branchMock).toHaveBeenCalledTimes(1));
+    const before = invokeMock.mock.calls.filter(
+      (c) => c[0] === "git_status",
+    ).length;
+
+    // External commit while the poll is mid-flight: the event must not be
+    // swallowed by the in-flight guard.
+    emitGitStateChanged("/repo");
+    releaseGh();
+
+    await waitFor(() =>
+      expect(
+        invokeMock.mock.calls.filter((c) => c[0] === "git_status").length,
+      ).toBeGreaterThan(before),
+    );
+  });
+
   it("ignores git-state-changed events for a different root", async () => {
     invokeMock.mockImplementation((cmd: string) =>
       cmd === "git_status"

--- a/src/hooks/useVcsStatus.test.ts
+++ b/src/hooks/useVcsStatus.test.ts
@@ -8,15 +8,32 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
 
-const { invokeMock, branchMock, checksMock } = vi.hoisted(() => ({
-  invokeMock: vi.fn(),
-  branchMock: vi.fn(),
-  checksMock: vi.fn(),
-}));
+const { invokeMock, branchMock, checksMock, listenMock, gitEventHandlers } =
+  vi.hoisted(() => {
+    const gitEventHandlers: Array<(e: { payload: unknown }) => void> = [];
+    return {
+      invokeMock: vi.fn(),
+      branchMock: vi.fn(),
+      checksMock: vi.fn(),
+      gitEventHandlers,
+      listenMock: vi.fn(
+        (event: string, handler: (e: { payload: unknown }) => void) => {
+          if (event === "git-state-changed") gitEventHandlers.push(handler);
+          return Promise.resolve(() => {});
+        },
+      ),
+    };
+  });
 
 vi.mock("@tauri-apps/api/core", () => ({ invoke: invokeMock }));
+vi.mock("@tauri-apps/api/event", () => ({ listen: listenMock }));
 vi.mock("../ghBranchStatusCache", () => ({ getGhBranchStatus: branchMock }));
 vi.mock("../ghChecksCache", () => ({ getGhChecks: checksMock }));
+
+/** Fire a `git-state-changed` event at every handler the hook registered. */
+function emitGitStateChanged(root: string) {
+  for (const h of gitEventHandlers) h({ payload: { root } });
+}
 
 import { useVcsStatus, type VcsSlice } from "./useVcsStatus";
 
@@ -38,6 +55,8 @@ beforeEach(() => {
   invokeMock.mockReset();
   branchMock.mockReset();
   checksMock.mockReset();
+  listenMock.mockClear();
+  gitEventHandlers.length = 0;
 });
 
 describe("useVcsStatus", () => {
@@ -210,5 +229,57 @@ describe("useVcsStatus", () => {
     // gh is reachable (so ghAvailable stays true) but there are no checks.
     expect(vcs.ghAvailable).toBe(true);
     expect(vcs.ci).toBeNull();
+  });
+
+  it("re-ticks when a git-state-changed event fires for the active root", async () => {
+    invokeMock.mockImplementation((cmd: string) =>
+      cmd === "git_status"
+        ? Promise.resolve({ branch: "main", ahead: 0, behind: 0, dirty: false })
+        : Promise.resolve(cmd === "git_file_status" ? [] : null),
+    );
+    branchMock.mockResolvedValue(null);
+    checksMock.mockResolvedValue(null);
+    const h = makeSetState();
+    renderHook(() =>
+      useVcsStatus({ activeRoot: "/repo", setState: h.setState }),
+    );
+    await waitFor(() => expect(h.vcs()?.loading).toBe(false));
+    const before = invokeMock.mock.calls.filter(
+      (c) => c[0] === "git_status",
+    ).length;
+
+    // Simulate an external `git commit`: only `.git/` changed, so the
+    // watcher emits git-state-changed and the hook must re-poll.
+    emitGitStateChanged("/repo");
+    await waitFor(() =>
+      expect(
+        invokeMock.mock.calls.filter((c) => c[0] === "git_status").length,
+      ).toBeGreaterThan(before),
+    );
+  });
+
+  it("ignores git-state-changed events for a different root", async () => {
+    invokeMock.mockImplementation((cmd: string) =>
+      cmd === "git_status"
+        ? Promise.resolve({ branch: "main", ahead: 0, behind: 0, dirty: false })
+        : Promise.resolve(cmd === "git_file_status" ? [] : null),
+    );
+    branchMock.mockResolvedValue(null);
+    checksMock.mockResolvedValue(null);
+    const h = makeSetState();
+    renderHook(() =>
+      useVcsStatus({ activeRoot: "/repo", setState: h.setState }),
+    );
+    await waitFor(() => expect(h.vcs()?.loading).toBe(false));
+    const before = invokeMock.mock.calls.filter(
+      (c) => c[0] === "git_status",
+    ).length;
+
+    emitGitStateChanged("/other-repo");
+    // Give any erroneous tick a chance to fire before asserting no-op.
+    await new Promise((r) => setTimeout(r, 30));
+    expect(
+      invokeMock.mock.calls.filter((c) => c[0] === "git_status").length,
+    ).toBe(before);
   });
 });

--- a/src/hooks/useVcsStatus.ts
+++ b/src/hooks/useVcsStatus.ts
@@ -206,6 +206,13 @@ export function useVcsStatus({ activeRoot, setState }: UseVcsStatusContext): voi
     // leave the new root's /vcs stuck on the loading shell until the next
     // interval/focus fire.
     let polling = false;
+    // Coalesce ticks requested mid-poll. A `git-state-changed` event (or a
+    // focus / interval fire) that lands while a poll is in flight would be
+    // dropped by the `polling` guard — and if that poll already read git
+    // status before the external commit, it writes stale `/vcs` data the
+    // fast path never corrects until the next interval. Instead, remember the
+    // request and run exactly one follow-up when the current poll settles.
+    let rerun = false;
 
     // The effect re-runs (and cleans up) whenever activeRoot changes, so the
     // `cancelled` flag alone guards against a stale root's late response
@@ -233,7 +240,11 @@ export function useVcsStatus({ activeRoot, setState }: UseVcsStatusContext): voi
     });
 
     const tick = async () => {
-      if (cancelled || polling) return;
+      if (cancelled) return;
+      if (polling) {
+        rerun = true;
+        return;
+      }
       const root = activeRoot;
       polling = true;
       try {
@@ -300,6 +311,10 @@ export function useVcsStatus({ activeRoot, setState }: UseVcsStatusContext): voi
         });
       } finally {
         polling = false;
+        if (rerun && !cancelled) {
+          rerun = false;
+          void tick();
+        }
       }
     };
 

--- a/src/hooks/useVcsStatus.ts
+++ b/src/hooks/useVcsStatus.ts
@@ -20,6 +20,7 @@
  */
 import { useEffect, type Dispatch, type SetStateAction } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 
 import { getGhBranchStatus, type GhPr } from "../ghBranchStatusCache";
 import { getGhChecks, type GhCheckRun } from "../ghChecksCache";
@@ -307,10 +308,24 @@ export function useVcsStatus({ activeRoot, setState }: UseVcsStatusContext): voi
     window.addEventListener("focus", onFocus);
     const interval = window.setInterval(() => void tick(), POLL_INTERVAL_MS);
 
+    // Event-driven refresh: the Rust git watcher fires `git-state-changed`
+    // when this root's `.git/` mutates (commit, stage, branch switch — incl.
+    // ones run in an external terminal), so we repaint within a couple hundred
+    // milliseconds instead of waiting up to 20s for the next interval tick.
+    let unlisten: (() => void) | undefined;
+    void listen<{ root: string }>("git-state-changed", (event) => {
+      if (cancelled || event.payload.root !== activeRoot) return;
+      void tick();
+    }).then((fn) => {
+      if (cancelled) fn();
+      else unlisten = fn;
+    });
+
     return () => {
       cancelled = true;
       window.removeEventListener("focus", onFocus);
       window.clearInterval(interval);
+      unlisten?.();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeRoot]);


### PR DESCRIPTION
## Problem

The file-tree git decorations (the `M` badges) went **stale indefinitely** after git operations performed outside the app — a `git commit`/`add`/branch-switch in an external terminal left the working tree clean yet the tree kept painting `M` badges.

**Root cause: nothing watched `.git/`.** The only filesystem watcher (`fs_watch_dirs`) is non-recursive over expanded working-tree folders and never watches `.git/`. Git operations that touch only `.git/` (commit, stage, branch switch, stash) don't change working-tree files, so no `fs-tree-changed` fired and `scheduleGitStatusRefresh` was never called. `useFileTreeData` had no timer/focus poll at all, so decorations stuck until a manual Refresh. The VCS header (`useVcsStatus`, 20s + focus poll) self-healed — that asymmetry was the bug.

Worktrees made it worse: `.git` is a *file* pointing at `…/.git/worktrees/<name>/`, with HEAD/index there and refs in the shared common dir.

## Fix

- **`commands/git/watch.rs`** — worktree-aware `.git` watcher: resolves git-dir + common-dir via `git rev-parse`, watches `HEAD`/`index`/`refs/heads`/`packed-refs` non-recursively, emits a debounced `git-state-changed` event. New `git_watch_root` / `git_unwatch_root` commands + `GitWatchState`.
- **`useGitWatch.ts`** — lifecycle hook (start/stop per active root), mounted beside `useVcsStatus`.
- **`useVcsStatus.ts`** — listens for `git-state-changed` → instant `tick()`; coalesces ticks requested mid-poll so an event landing during an in-flight poll isn't dropped (race caught in review).
- **`useFileTreeData.ts`** — listens → `scheduleGitStatusRefresh`, plus a focus + 20s backstop poll so a dropped notify event still self-heals.

## Testing

- TDD throughout: Rust resolution unit tests (plain checkout, **linked worktree**, non-repo) and TS listener / backstop / mid-poll-race tests precede each change.
- Full `check` gate green: 1500 tests (clippy + tsc + ESLint + cargo test + vitest).
- Verified live against the running dev build: external staging (`.git/index`-only) and commit each fired exactly one `git-state-changed`; the active worktree generated events through `useGitWatch`, confirming worktree resolution live.
- Two rounds of codex review; final review clean.