### PR TITLE
perf(chat): stop A2UI rows reconciling on every streamed token

### DIFF
--- a/src/extensions/default-layout/chat.test.tsx
+++ b/src/extensions/default-layout/chat.test.tsx
@@ -448,11 +448,11 @@ describe("ChatInput", () => {
 describe("ChatHistory render isolation", () => {
   // Perf regression guard (#159): streaming a new message rewrites the
   // top-level `messages`/`tabs` keys on every token, producing a fresh root
-  // state object. An already-rendered A2UI row must NOT reconcile on that
-  // churn — ChatHistory hands rows a slice with the volatile keys stripped, so
-  // the row memo's `prev.state === next.state` check still bails. Passing the
-  // full root state instead (the old behavior) re-renders every A2UI row per
-  // token, which is the scroll/stream lag this test pins down.
+  // state object. Rows still receive the full root state, but the row memo
+  // compares it with `shallowEqualExcept`, ignoring those volatile keys — so an
+  // already-rendered A2UI row bails and does NOT reconcile on that churn. A
+  // plain `prev.state === next.state` check (the old behavior) re-renders every
+  // A2UI row per token, which is the scroll/stream lag this test pins down.
   it("does not re-render an existing A2UI row when another message is appended", () => {
     let spyRenders = 0;
     function SpyCard({ component }: BuiltinComponentProps) {

--- a/src/extensions/default-layout/chat.test.tsx
+++ b/src/extensions/default-layout/chat.test.tsx
@@ -16,6 +16,7 @@ vi.mock("../../components/HighlightedCode", () => ({
 }));
 import { ExtensionRegistry } from "../ExtensionRegistry";
 import { ExtensionRegistryProvider } from "../ExtensionRegistryProvider";
+import type { BuiltinComponentProps } from "../../components/A2UIRenderer";
 
 class ResizeObserverMock {
   observe = vi.fn();
@@ -441,5 +442,72 @@ describe("ChatInput", () => {
     expect(
       screen.getByRole("link", { name: "https://example.com/after" }),
     ).toBeTruthy();
+  });
+});
+
+describe("ChatHistory render isolation", () => {
+  // Perf regression guard (#159): streaming a new message rewrites the
+  // top-level `messages`/`tabs` keys on every token, producing a fresh root
+  // state object. An already-rendered A2UI row must NOT reconcile on that
+  // churn — ChatHistory hands rows a slice with the volatile keys stripped, so
+  // the row memo's `prev.state === next.state` check still bails. Passing the
+  // full root state instead (the old behavior) re-renders every A2UI row per
+  // token, which is the scroll/stream lag this test pins down.
+  it("does not re-render an existing A2UI row when another message is appended", () => {
+    let spyRenders = 0;
+    function SpyCard({ component }: BuiltinComponentProps) {
+      spyRenders += 1;
+      return <div data-testid="spy-card">{component.id}</div>;
+    }
+    const registry = new ExtensionRegistry();
+    registry.register({
+      name: "test-spy",
+      components: { "spy-card": SpyCard },
+    });
+
+    // Stable reference across both renders — mirrors how the bridge keeps an
+    // already-delivered tool-card message object identity-stable.
+    const a2uiMessage = {
+      id: "tool-1",
+      role: "agent" as const,
+      a2ui: { components: [{ id: "spy-1", type: "spy-card" }] },
+    };
+
+    // Stable onEvent — the row memo also keys on its identity, so a fresh
+    // function per render would mask the slice-stability we're testing.
+    const onEvent = vi.fn();
+    const renderWith = (state: Record<string, unknown>) => (
+      <ExtensionRegistryProvider registry={registry}>
+        <ChatHistory
+          component={{
+            id: "chat-history",
+            type: "chat-history",
+            props: { messages: { $ref: "/messages" } },
+          }}
+          state={state}
+          onEvent={onEvent}
+        />
+      </ExtensionRegistryProvider>
+    );
+
+    const { rerender } = render(
+      renderWith({ messages: [a2uiMessage], theme: "dark" }),
+    );
+    expect(screen.getByTestId("spy-card")).toBeTruthy();
+    // A2UIRenderer's mount re-sync effect can render the card more than once;
+    // take whatever the settled count is as the baseline.
+    const baseline = spyRenders;
+
+    // New top-level state object with a fresh `messages` array (as setState
+    // produces per token), but the A2UI message and every retained key are
+    // unchanged. The row must not reconcile.
+    rerender(
+      renderWith({
+        messages: [a2uiMessage, { id: "t2", role: "agent", text: "hi" }],
+        theme: "dark",
+      }),
+    );
+
+    expect(spyRenders).toBe(baseline);
   });
 });

--- a/src/extensions/default-layout/message-list.tsx
+++ b/src/extensions/default-layout/message-list.tsx
@@ -26,6 +26,39 @@ import {
 const INITIAL_VISIBLE_MESSAGES = 160;
 const MESSAGE_PAGE_SIZE = 120;
 
+// Top-level state keys that change identity on every streamed token — the
+// active tab's `messages` array and the `tabs` array that nests it (both
+// rewritten by `updateTab` / TAB_MIRROR_KEYS on each delta). Historical chat
+// rows never read these, so the row memo can ignore them: an already-rendered
+// A2UI row stays put across a streaming turn instead of reconciling the whole
+// list on every token (#159 chat-lag fix).
+const VOLATILE_ROW_STATE_KEYS: ReadonlySet<string> = new Set([
+  "messages",
+  "tabs",
+]);
+
+/** Shallow equality of two state records, ignoring `exclude`d keys. Lets the
+ *  chat-row memo bail when only the per-token-volatile `messages`/`tabs` keys
+ *  changed. Cheap (a ~15-key reference scan) and only reached after the
+ *  cheaper message/onEvent identity checks already passed. */
+function shallowEqualExcept(
+  a: Record<string, unknown>,
+  b: Record<string, unknown>,
+  exclude: ReadonlySet<string>,
+): boolean {
+  if (a === b) return true;
+  for (const key of Object.keys(a)) {
+    if (exclude.has(key)) continue;
+    if (!Object.is(a[key], b[key])) return false;
+  }
+  // Catch retained keys that exist only in `b` (added since the last render).
+  for (const key of Object.keys(b)) {
+    if (exclude.has(key)) continue;
+    if (!(key in a)) return false;
+  }
+  return true;
+}
+
 function TypingIndicator() {
   return (
     <div
@@ -222,7 +255,8 @@ const ChatMessageRow = memo(
     prev.prevRole === next.prevRole &&
     prev.onEvent === next.onEvent &&
     prev.deliveryText === next.deliveryText &&
-    (!next.message.a2ui || prev.state === next.state),
+    (!next.message.a2ui ||
+      shallowEqualExcept(prev.state, next.state, VOLATILE_ROW_STATE_KEYS)),
 );
 
 function useMessageWindow(messages: ChatMessage[]) {


### PR DESCRIPTION
## Summary

First of several PRs addressing chat-rendering lag and the agent-worker
findings in #159. This one targets the dominant cause of streaming/scroll
lag in the chat view.

**Root cause:** every streamed token rewrites the active tab's `messages`
array and the `tabs` array that nests it (`updateTab` + `TAB_MIRROR_KEYS`),
producing a fresh root-state object. The `ChatMessageRow` memo keyed on raw
`state` identity (`prev.state === next.state`), so **every A2UI tool-card row
reconciled on every token** — and a long session is mostly A2UI rows. That
re-rendered (and re-diffed) the whole visible list per token.

**Fix:** the row memo now compares state with a shallow-equal that ignores the
per-token-volatile `messages`/`tabs` keys (which historical rows never read),
so already-rendered A2UI rows bail during streaming. The actively-streaming
row still updates because its own `message` object identity changes.

Cheap: the extra comparison is a ~15-key reference scan, only reached after the
cheaper `message`/`onEvent` identity checks already passed.

## Test

Adds a render-isolation regression test: pushing a new message must not
re-render an existing A2UI row. Confirmed it fails on the old behavior
(re-render count increments) and passes with the fix.

`bunx tsc --noEmit`, `bunx eslint .` (no new warnings), and the full
`bunx vitest run` (1501 tests) all pass.

## Scope / follow-ups

This is the high-value, low-risk slice. Remaining #159 work lands in separate
PRs: message-list virtualization (react-virtuoso, subsumes the sticky-scroll
observer), agent-worker telemetry + idle retirement, mDNS/updater/poll noise
gates, and project-icon externalization.

Refs #159