### PR TITLE
perf(chat): virtualize the message list with react-virtuoso

### DIFF
--- a/.claude/skills/aethon-debug/scripts/debug-agent-new-tab.sh
+++ b/.claude/skills/aethon-debug/scripts/debug-agent-new-tab.sh
@@ -35,11 +35,23 @@ if (!cwd) return "ERROR: no cwd resolvable";
 //      gets bound to that cwd, threading the devshell env through
 //      pi's BashSpawnHook).
 const tab = { id: "${TAB_ID}", kind: "agent", cwd, label: "UAT", messages: [], draft: "", waiting: false, queuedMessages: [], queueCount: 0, canvas: null };
+// \`tabs\` is an ARRAY in central state (see useTabs / tabOps). Append the new
+// tab and mirror its fields onto the root (TAB_MIRROR_KEYS) so layout \$refs
+// like /messages, /draft, /kind resolve for the freshly-active tab.
+const __s = window.__AETHON_STATE__();
+const __tabs = [...((__s.tabs ?? []).filter(t => t.id !== "${TAB_ID}")), tab];
 window.__AETHON_SET_STATE__({
-  ...window.__AETHON_STATE__(),
-  tabs: { ...(window.__AETHON_STATE__().tabs ?? {}), "${TAB_ID}": tab },
+  ...__s,
+  tabs: __tabs,
   activeTabId: "${TAB_ID}",
   hasTabs: true,
+  messages: tab.messages,
+  draft: tab.draft,
+  waiting: tab.waiting,
+  queueCount: tab.queueCount,
+  queuedMessages: tab.queuedMessages,
+  canvas: tab.canvas,
+  kind: tab.kind,
 });
 await inv("agent_command", { payload: JSON.stringify({ type: "tab_open", tabId: "${TAB_ID}", cwd }) });
 return "${TAB_ID}";

--- a/bun.lock
+++ b/bun.lock
@@ -23,6 +23,7 @@
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-markdown": "^10.1.0",
+        "react-virtuoso": "^4.18.7",
         "shiki": "^4",
         "typebox": "^1.1.34",
       },
@@ -1072,6 +1073,8 @@
     "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
     "react-markdown": ["react-markdown@10.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "html-url-attributes": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "unified": "^11.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" }, "peerDependencies": { "@types/react": ">=18", "react": ">=18" } }, "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ=="],
+
+    "react-virtuoso": ["react-virtuoso@4.18.7", "", { "peerDependencies": { "react": ">=16 || >=17 || >= 18 || >= 19", "react-dom": ">=16 || >=17 || >= 18 || >=19" } }, "sha512-xNF5zDGEEIMB7cKwcen/pLig0YDf6OnfFrVgKFa7sHPf9fRem0CaLshyObbBcP88jzn0enavL39EgplgdyT21g=="],
 
     "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-markdown": "^10.1.0",
+    "react-virtuoso": "^4.18.7",
     "shiki": "^4",
     "typebox": "^1.1.34"
   },

--- a/src/extensions/default-layout/chat.test.tsx
+++ b/src/extensions/default-layout/chat.test.tsx
@@ -14,6 +14,35 @@ vi.mock("@tauri-apps/plugin-opener", () => ({
 vi.mock("../../components/HighlightedCode", () => ({
   HighlightedCode: ({ code }: { code: string }) => code,
 }));
+
+// jsdom measures every element as 0px, so the real Virtuoso virtualizes down to
+// nothing. Render all rows synchronously here — scroll/measurement behavior is
+// verified live in the app, while these tests assert row content + memoization.
+vi.mock("react-virtuoso", () => ({
+  Virtuoso: ({
+    data = [],
+    itemContent,
+    components,
+    context,
+    className,
+  }: {
+    data?: Array<{ id?: string }>;
+    itemContent: (index: number, item: unknown) => React.ReactNode;
+    components?: { Footer?: (props: { context?: unknown }) => React.ReactNode };
+    context?: unknown;
+    className?: string;
+  }) => {
+    const Footer = components?.Footer;
+    return (
+      <div className={className} data-testid="virtuoso-mock">
+        {data.map((item, index) => (
+          <div key={item.id ?? index}>{itemContent(index, item)}</div>
+        ))}
+        {Footer ? <Footer context={context} /> : null}
+      </div>
+    );
+  },
+}));
 import { ExtensionRegistry } from "../ExtensionRegistry";
 import { ExtensionRegistryProvider } from "../ExtensionRegistryProvider";
 import type { BuiltinComponentProps } from "../../components/A2UIRenderer";

--- a/src/extensions/default-layout/message-list.tsx
+++ b/src/extensions/default-layout/message-list.tsx
@@ -370,12 +370,18 @@ function VirtualMessageList({
         data={messages}
         computeItemKey={(_index, m) => m.id}
         itemContent={itemContent}
-        // Open scrolled to the newest message. Do NOT also pass
-        // `initialItemCount` here: combined with a bottom `initialTopMostItemIndex`
-        // Virtuoso requests rows past the end of `data` and feeds `undefined`
-        // into computeItemKey, crashing on m.id for any restored 2+ message chat
-        // (see message-list.virtuoso.test.tsx).
-        initialTopMostItemIndex={Math.max(0, messages.length - 1)}
+        // Open scrolled to the BOTTOM of the newest message. `align: "end"`
+        // pins the last item's bottom to the viewport bottom — a bare index
+        // aligns it to the top, so a tall final message would open at its start
+        // instead of the latest content (the old scrollTop=scrollHeight
+        // contract). Do NOT also pass `initialItemCount`: combined with a bottom
+        // index Virtuoso requests rows past the end of `data` and feeds
+        // `undefined` into computeItemKey, crashing on m.id for any restored 2+
+        // message chat (see message-list.virtuoso.test.tsx).
+        initialTopMostItemIndex={{
+          index: Math.max(0, messages.length - 1),
+          align: "end",
+        }}
         followOutput="auto"
         atBottomThreshold={DEFAULT_AT_BOTTOM_THRESHOLD}
         atBottomStateChange={setIsAtBottom}

--- a/src/extensions/default-layout/message-list.tsx
+++ b/src/extensions/default-layout/message-list.tsx
@@ -23,12 +23,6 @@ import {
   MARKDOWN_REMARK_PLUGINS,
 } from "./markdown-adapter";
 
-// Render a chunk of the newest rows on first paint before Virtuoso has
-// measured anything, so a restored session isn't briefly blank. Virtuoso
-// virtualizes normally once real heights are known. (jsdom never measures, so
-// chat.test.tsx mocks Virtuoso to render rows directly.)
-const INITIAL_ITEM_COUNT = 24;
-
 // Distance (px) from the bottom still treated as "at the bottom" for follow +
 // the scroll-to-bottom pill. Matches the old StickyScrollController default.
 const DEFAULT_AT_BOTTOM_THRESHOLD = 60;
@@ -360,6 +354,13 @@ function VirtualMessageList({
     [state, tabId, rowClassName, flashIndex, messages, onEvent, queuedLabels],
   );
 
+  // Only wire `context`/`components` when there's a footer. Passing
+  // `components={undefined}` explicitly trips Virtuoso's internal
+  // `components.EmptyPlaceholder` access, so omit the props entirely otherwise.
+  const footerProps = footerContext
+    ? { context: footerContext, components: { Footer: CanvasFooter } }
+    : {};
+
   return (
     <div className="a2ui-msg-list-shell">
       <Virtuoso
@@ -369,13 +370,16 @@ function VirtualMessageList({
         data={messages}
         computeItemKey={(_index, m) => m.id}
         itemContent={itemContent}
+        // Open scrolled to the newest message. Do NOT also pass
+        // `initialItemCount` here: combined with a bottom `initialTopMostItemIndex`
+        // Virtuoso requests rows past the end of `data` and feeds `undefined`
+        // into computeItemKey, crashing on m.id for any restored 2+ message chat
+        // (see message-list.virtuoso.test.tsx).
         initialTopMostItemIndex={Math.max(0, messages.length - 1)}
-        initialItemCount={Math.min(messages.length, INITIAL_ITEM_COUNT)}
         followOutput="auto"
         atBottomThreshold={DEFAULT_AT_BOTTOM_THRESHOLD}
         atBottomStateChange={setIsAtBottom}
-        context={footerContext}
-        components={footerContext ? { Footer: CanvasFooter } : undefined}
+        {...footerProps}
       />
       <ScrollToBottomPill
         visible={!isAtBottom && messages.length > 0}

--- a/src/extensions/default-layout/message-list.tsx
+++ b/src/extensions/default-layout/message-list.tsx
@@ -1,12 +1,13 @@
 import {
   memo,
+  useCallback,
   useEffect,
   useMemo,
   useRef,
   useState,
-  type RefObject,
 } from "react";
 import ReactMarkdown from "react-markdown";
+import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
 import type {
   A2UIComponent,
   ChatMessage,
@@ -17,14 +18,20 @@ import type { BuiltinComponentProps } from "../../components/A2UIRenderer";
 import { resolveString } from "../../utils/dataBinding";
 import { resolvePointer } from "../../utils/jsonPointer";
 import { splitThinkingBlocks } from "../../utils/thinkingBlocks";
-import { useStickyScroll } from "../../utils/useStickyScroll";
 import {
   CHAT_MARKDOWN_COMPONENTS,
   MARKDOWN_REMARK_PLUGINS,
 } from "./markdown-adapter";
 
-const INITIAL_VISIBLE_MESSAGES = 160;
-const MESSAGE_PAGE_SIZE = 120;
+// Render a chunk of the newest rows on first paint before Virtuoso has
+// measured anything, so a restored session isn't briefly blank. Virtuoso
+// virtualizes normally once real heights are known. (jsdom never measures, so
+// chat.test.tsx mocks Virtuoso to render rows directly.)
+const INITIAL_ITEM_COUNT = 24;
+
+// Distance (px) from the bottom still treated as "at the bottom" for follow +
+// the scroll-to-bottom pill. Matches the old StickyScrollController default.
+const DEFAULT_AT_BOTTOM_THRESHOLD = 60;
 
 // Top-level state keys that change identity on every streamed token — the
 // active tab's `messages` array and the `tabs` array that nests it (both
@@ -259,119 +266,128 @@ const ChatMessageRow = memo(
       shallowEqualExcept(prev.state, next.state, VOLATILE_ROW_STATE_KEYS)),
 );
 
-function useMessageWindow(messages: ChatMessage[]) {
-  const [visibleCount, setVisibleCount] = useState(INITIAL_VISIBLE_MESSAGES);
-  const visibleMessages = useMemo(
-    () => messages.slice(Math.max(0, messages.length - visibleCount)),
-    [messages, visibleCount],
-  );
-  const hiddenCount = Math.max(0, messages.length - visibleMessages.length);
-
-  useEffect(() => {
-    if (messages.length < visibleCount) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- reset pagination when history shrinks after tab switch or clear
-      setVisibleCount(INITIAL_VISIBLE_MESSAGES);
-    }
-  }, [messages.length, visibleCount]);
-
-  return {
-    visibleCount,
-    visibleMessages,
-    hiddenCount,
-    loadOlder: () =>
-      setVisibleCount((n) => Math.min(messages.length, n + MESSAGE_PAGE_SIZE)),
-    showFrom: Math.max(0, messages.length - visibleMessages.length),
-    setVisibleCount,
-  };
+// Footer riding below the last message inside Virtuoso's scroller, so the live
+// canvas subtree + typing indicator scroll and follow with the messages. Passed
+// dynamic data via Virtuoso's `context` so its component identity stays stable.
+interface CanvasFooterContext {
+  liveSubtree: { components: A2UIComponent[] } | null;
+  showTyping: boolean;
+  state: Record<string, unknown>;
+  tabId?: string;
 }
 
-interface MessageListProps {
+function CanvasFooter({ context }: { context?: CanvasFooterContext }) {
+  if (!context) return null;
+  const { liveSubtree, showTyping, state, tabId } = context;
+  if (!liveSubtree && !showTyping) return null;
+  return (
+    <>
+      {liveSubtree && (
+        <div className="a2ui-canvas-live">
+          <A2UIRenderer payload={liveSubtree} state={state} tabId={tabId} />
+        </div>
+      )}
+      {showTyping && <TypingIndicator />}
+    </>
+  );
+}
+
+interface VirtualMessageListProps {
   messages: ChatMessage[];
   state: Record<string, unknown>;
   tabId?: string;
   onEvent?: BuiltinComponentProps["onEvent"];
   rowClassName?: string;
-  containerRef: RefObject<HTMLElement | null>;
+  /** Class for Virtuoso's scroller — the former scroll container. */
+  className: string;
   scrollToMatch?: string;
+  footerContext?: CanvasFooterContext;
 }
 
-function MessageList({
+/** Virtualized chat feed. Replaces the old hand-rolled window + useStickyScroll:
+ *  Virtuoso mounts only the visible rows (long histories no longer pin 160+
+ *  markdown subtrees in the DOM) and owns stick-to-bottom via `followOutput`,
+ *  the at-bottom signal for the pill, and index scrolling for search matches. */
+function VirtualMessageList({
   messages,
   state,
   tabId,
   onEvent,
   rowClassName = "a2ui-chat-message",
-  containerRef,
+  className,
   scrollToMatch,
-}: MessageListProps) {
-  const { visibleMessages, hiddenCount, loadOlder, showFrom, setVisibleCount } =
-    useMessageWindow(messages);
-  const queuedLabels = useMemo(() => queuedDeliveryLabels(messages), [messages]);
+  footerContext,
+}: VirtualMessageListProps) {
+  const virtuosoRef = useRef<VirtuosoHandle>(null);
+  const [isAtBottom, setIsAtBottom] = useState(true);
+  const [flashIndex, setFlashIndex] = useState<number | null>(null);
   const prevScrollToMatch = useRef<string | undefined>(undefined);
+  const queuedLabels = useMemo(() => queuedDeliveryLabels(messages), [messages]);
 
+  // Jump to the newest message matching the search needle and flash it. Virtuoso
+  // mounts the target row even when it's far offscreen, so no DOM walk is needed.
   useEffect(() => {
-    const el = containerRef.current;
-    if (!el || !scrollToMatch || scrollToMatch === prevScrollToMatch.current) {
-      return;
-    }
+    if (!scrollToMatch || scrollToMatch === prevScrollToMatch.current) return;
     prevScrollToMatch.current = scrollToMatch;
     const needle = scrollToMatch.toLowerCase();
     const idx = messages.findIndex((m) =>
       (m.text ?? "").toLowerCase().includes(needle),
     );
     if (idx < 0) return;
-    const scrollRowIntoView = (offset: number) => {
-      const row = el.querySelectorAll(`.${rowClassName}`)[offset];
-      if (row instanceof HTMLElement) {
-        row.scrollIntoView({ block: "center", behavior: "auto" });
-        row.classList.add("a2ui-chat-message-flash");
-        window.setTimeout(
-          () => row.classList.remove("a2ui-chat-message-flash"),
-          1200,
-        );
-      }
-    };
-    if (idx < showFrom) {
-      window.setTimeout(() => {
-        setVisibleCount(messages.length - idx);
-        scrollRowIntoView(0);
-      }, 0);
-    } else {
-      scrollRowIntoView(idx - showFrom);
-    }
-  }, [
-    containerRef,
-    messages,
-    rowClassName,
-    scrollToMatch,
-    setVisibleCount,
-    showFrom,
-  ]);
+    virtuosoRef.current?.scrollToIndex({ index: idx, align: "center" });
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- transient flash driven by an external search action (the same effect also imperatively scrolls); not derivable during render
+    setFlashIndex(idx);
+    const timer = window.setTimeout(() => setFlashIndex(null), 1200);
+    return () => window.clearTimeout(timer);
+  }, [messages, scrollToMatch]);
+
+  const itemContent = useCallback(
+    (index: number, m: ChatMessage) => (
+      <ChatMessageRow
+        message={m}
+        state={state}
+        tabId={tabId}
+        className={
+          index === flashIndex
+            ? `${rowClassName} a2ui-chat-message-flash`
+            : rowClassName
+        }
+        prevRole={index > 0 ? messages[index - 1].role : undefined}
+        onEvent={onEvent}
+        deliveryText={queuedLabels.get(m.id)}
+      />
+    ),
+    [state, tabId, rowClassName, flashIndex, messages, onEvent, queuedLabels],
+  );
 
   return (
-    <>
-      {hiddenCount > 0 && (
-        <button
-          type="button"
-          className="a2ui-chat-load-older"
-          onClick={loadOlder}
-        >
-          Load older messages ({hiddenCount})
-        </button>
-      )}
-      {visibleMessages.map((m, i) => (
-        <ChatMessageRow
-          key={m.id}
-          message={m}
-          state={state}
-          tabId={tabId}
-          className={rowClassName}
-          prevRole={i > 0 ? visibleMessages[i - 1].role : undefined}
-          onEvent={onEvent}
-          deliveryText={queuedLabels.get(m.id)}
-        />
-      ))}
-    </>
+    <div className="a2ui-msg-list-shell">
+      <Virtuoso
+        ref={virtuosoRef}
+        className={className}
+        style={{ flex: 1, minHeight: 0 }}
+        data={messages}
+        computeItemKey={(_index, m) => m.id}
+        itemContent={itemContent}
+        initialTopMostItemIndex={Math.max(0, messages.length - 1)}
+        initialItemCount={Math.min(messages.length, INITIAL_ITEM_COUNT)}
+        followOutput="auto"
+        atBottomThreshold={DEFAULT_AT_BOTTOM_THRESHOLD}
+        atBottomStateChange={setIsAtBottom}
+        context={footerContext}
+        components={footerContext ? { Footer: CanvasFooter } : undefined}
+      />
+      <ScrollToBottomPill
+        visible={!isAtBottom && messages.length > 0}
+        onClick={() =>
+          virtuosoRef.current?.scrollToIndex({
+            index: messages.length - 1,
+            align: "end",
+            behavior: "auto",
+          })
+        }
+      />
+    </div>
   );
 }
 
@@ -386,10 +402,6 @@ export function ChatHistory({
     emptyHint?: StringValue;
   };
 
-  const listRef = useRef<HTMLDivElement>(null);
-  const { isAtBottom, scrollToBottom, handleContentChanged } =
-    useStickyScroll(listRef);
-
   const messages = useMemo(
     () => (resolvePointer(state, props.messages.$ref) as ChatMessage[]) || [],
     [props.messages.$ref, state],
@@ -402,33 +414,23 @@ export function ChatHistory({
     (state.scrollToMatchByTab as Record<string, string> | undefined) ?? {};
   const scrollToMatch = tabId ? scrollToMatchByTab[tabId] : undefined;
 
-  const prevLength = useRef(messages.length);
-  useEffect(() => {
-    if (messages.length !== prevLength.current) {
-      prevLength.current = messages.length;
-      handleContentChanged();
-    }
-  }, [messages.length, handleContentChanged]);
+  if (messages.length === 0) {
+    return (
+      <div className="a2ui-chat-history a2ui-chat-history-empty">
+        <div className="a2ui-chat-empty">{emptyHint}</div>
+      </div>
+    );
+  }
 
   return (
-    <div className="a2ui-chat-history" ref={listRef}>
-      {messages.length === 0 ? (
-        <div className="a2ui-chat-empty">{emptyHint}</div>
-      ) : (
-        <MessageList
-          messages={messages}
-          state={state}
-          tabId={tabId}
-          onEvent={onEvent}
-          containerRef={listRef}
-          scrollToMatch={scrollToMatch}
-        />
-      )}
-      <ScrollToBottomPill
-        visible={!isAtBottom && messages.length > 0}
-        onClick={scrollToBottom}
-      />
-    </div>
+    <VirtualMessageList
+      className="a2ui-chat-history"
+      messages={messages}
+      state={state}
+      tabId={tabId}
+      onEvent={onEvent}
+      scrollToMatch={scrollToMatch}
+    />
   );
 }
 
@@ -463,53 +465,46 @@ export function MainCanvas({
     ? resolveString(props.emptyHint, state)
     : "The agent's canvas is empty. Send a message to populate it.";
 
-  const listRef = useRef<HTMLElement>(null);
-  const { isAtBottom, scrollToBottom, handleContentChanged } =
-    useStickyScroll(listRef);
+  // Non-chat canvas: the agent fully owns this surface, no message feed.
+  if (!chatMode) {
+    return (
+      <main className="a2ui-canvas a2ui-canvas-bare">
+        {liveSubtree && (
+          <div className="a2ui-canvas-live">
+            <A2UIRenderer payload={liveSubtree} state={state} tabId={tabId} />
+          </div>
+        )}
+      </main>
+    );
+  }
 
-  const prevLength = useRef(messages.length);
-  const prevLive = useRef(liveSubtree);
-  useEffect(() => {
-    const lengthChanged = messages.length !== prevLength.current;
-    const liveChanged = liveSubtree !== prevLive.current;
-    prevLength.current = messages.length;
-    prevLive.current = liveSubtree;
-    if (lengthChanged || liveChanged) handleContentChanged();
-  }, [messages.length, liveSubtree, handleContentChanged]);
+  // Empty chat canvas with nothing live yet — just the hint.
+  if (messages.length === 0 && !liveSubtree) {
+    return (
+      <main className="a2ui-canvas a2ui-canvas-empty-host">
+        <div className="a2ui-canvas-empty">{emptyHint}</div>
+      </main>
+    );
+  }
+
+  const footerContext: CanvasFooterContext = {
+    liveSubtree,
+    showTyping: state.waiting === true && !liveSubtree && messages.length > 0,
+    state,
+    tabId,
+  };
 
   return (
-    <main
-      className={chatMode ? "a2ui-canvas" : "a2ui-canvas a2ui-canvas-bare"}
-      ref={listRef}
-    >
-      {chatMode && messages.length === 0 && !liveSubtree && (
-        <div className="a2ui-canvas-empty">{emptyHint}</div>
-      )}
-      {chatMode && (
-        <MessageList
-          messages={messages}
-          state={state}
-          tabId={tabId}
-          onEvent={onEvent}
-          rowClassName="a2ui-canvas-message"
-          containerRef={listRef}
-        />
-      )}
-      {liveSubtree && (
-        <div className="a2ui-canvas-live">
-          <A2UIRenderer payload={liveSubtree} state={state} tabId={tabId} />
-        </div>
-      )}
-      {chatMode &&
-        state.waiting === true &&
-        !liveSubtree &&
-        messages.length > 0 && <TypingIndicator />}
-      {chatMode && (
-        <ScrollToBottomPill
-          visible={!isAtBottom && (messages.length > 0 || !!liveSubtree)}
-          onClick={scrollToBottom}
-        />
-      )}
+    <main className="a2ui-canvas a2ui-canvas-host">
+      <VirtualMessageList
+        className="a2ui-canvas-scroller"
+        rowClassName="a2ui-canvas-message"
+        messages={messages}
+        state={state}
+        tabId={tabId}
+        onEvent={onEvent}
+        footerContext={footerContext}
+      />
     </main>
   );
 }

--- a/src/extensions/default-layout/message-list.tsx
+++ b/src/extensions/default-layout/message-list.tsx
@@ -368,6 +368,13 @@ function VirtualMessageList({
     ? { context: footerContext, components: { Footer: CanvasFooter } }
     : {};
 
+  // The canvas can be scrollable with zero messages (a live subtree / typing
+  // indicator in the Footer), so the pill must consider footer content too.
+  const hasFooterContent = Boolean(
+    footerContext && (footerContext.liveSubtree || footerContext.showTyping),
+  );
+  const hasContent = messages.length > 0 || hasFooterContent;
+
   return (
     <div className="a2ui-msg-list-shell">
       <Virtuoso
@@ -395,13 +402,12 @@ function VirtualMessageList({
         {...footerProps}
       />
       <ScrollToBottomPill
-        visible={!isAtBottom && messages.length > 0}
+        visible={!isAtBottom && hasContent}
         onClick={() =>
-          virtuosoRef.current?.scrollToIndex({
-            index: messages.length - 1,
-            align: "end",
-            behavior: "auto",
-          })
+          // Scroll to the true bottom of the scroller, which includes the
+          // Footer (live subtree / typing indicator) — scrollToIndex(last)
+          // would stop at the last message, above a footer-only response.
+          virtuosoRef.current?.scrollTo({ top: Number.MAX_SAFE_INTEGER })
         }
       />
     </div>

--- a/src/extensions/default-layout/message-list.tsx
+++ b/src/extensions/default-layout/message-list.tsx
@@ -337,19 +337,26 @@ function VirtualMessageList({
 
   const itemContent = useCallback(
     (index: number, m: ChatMessage) => (
-      <ChatMessageRow
-        message={m}
-        state={state}
-        tabId={tabId}
-        className={
-          index === flashIndex
-            ? `${rowClassName} a2ui-chat-message-flash`
-            : rowClassName
-        }
-        prevRole={index > 0 ? messages[index - 1].role : undefined}
-        onEvent={onEvent}
-        deliveryText={queuedLabels.get(m.id)}
-      />
+      // flow-root establishes a BFC so the row's vertical margins (role-change
+      // spacing, etc.) are CONTAINED in this wrapper rather than collapsing
+      // through it. Virtuoso measures the wrapper, so the margins are counted —
+      // bare margins on the row would escape measurement and drift the
+      // follow-to-bottom / scrollToIndex offsets in long transcripts.
+      <div className="a2ui-msg-row">
+        <ChatMessageRow
+          message={m}
+          state={state}
+          tabId={tabId}
+          className={
+            index === flashIndex
+              ? `${rowClassName} a2ui-chat-message-flash`
+              : rowClassName
+          }
+          prevRole={index > 0 ? messages[index - 1].role : undefined}
+          onEvent={onEvent}
+          deliveryText={queuedLabels.get(m.id)}
+        />
+      </div>
     ),
     [state, tabId, rowClassName, flashIndex, messages, onEvent, queuedLabels],
   );

--- a/src/extensions/default-layout/message-list.virtuoso.test.tsx
+++ b/src/extensions/default-layout/message-list.virtuoso.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+//
+// Integration guard for the REAL react-virtuoso wiring (chat.test.tsx mocks
+// Virtuoso, so it can't catch measurement/prop-combination bugs). Codex caught
+// a P1 here: pairing `initialItemCount` with a bottom `initialTopMostItemIndex`
+// makes Virtuoso request rows past the end of `data` and pass `undefined` into
+// computeItemKey, crashing on `m.id` whenever a 2+ message transcript mounts
+// (session restore, opening any existing chat). This pins that it stays fixed.
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ChatHistory, MainCanvas } from "./chat";
+
+vi.mock("../../components/HighlightedCode", () => ({
+  HighlightedCode: ({ code }: { code: string }) => code,
+}));
+
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeEach(() => {
+  vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+function renderChat(count: number) {
+  const messages = Array.from({ length: count }, (_, i) => ({
+    id: `m${i}`,
+    role: i % 2 === 0 ? "user" : "agent",
+    text: `message ${i}`,
+  }));
+  return render(
+    <ChatHistory
+      component={{
+        id: "chat-history",
+        type: "chat-history",
+        props: { messages: { $ref: "/messages" } },
+      }}
+      state={{ messages }}
+      onEvent={vi.fn()}
+    />,
+  );
+}
+
+describe("ChatHistory + real Virtuoso", () => {
+  it("mounts a multi-message transcript without crashing computeItemKey", () => {
+    // The pre-fix prop combination threw TypeError on m.id here.
+    expect(() => renderChat(50)).not.toThrow();
+  });
+
+  it("mounts a single-message transcript without crashing", () => {
+    expect(() => renderChat(1)).not.toThrow();
+  });
+
+  it("mounts MainCanvas (Virtuoso + footer) without crashing", () => {
+    const messages = Array.from({ length: 30 }, (_, i) => ({
+      id: `c${i}`,
+      role: i % 2 === 0 ? "user" : "agent",
+      text: `canvas message ${i}`,
+    }));
+    expect(() =>
+      render(
+        <MainCanvas
+          component={{
+            id: "main-canvas",
+            type: "main-canvas",
+            props: { messages: { $ref: "/messages" } },
+          }}
+          state={{ messages, waiting: false }}
+          onEvent={vi.fn()}
+        />,
+      ),
+    ).not.toThrow();
+  });
+
+  it("renders the empty-state hint without Virtuoso", () => {
+    const { getByText } = render(
+      <ChatHistory
+        component={{
+          id: "chat-history",
+          type: "chat-history",
+          props: {
+            messages: { $ref: "/messages" },
+            emptyHint: "Start a conversation.",
+          },
+        }}
+        state={{ messages: [] }}
+        onEvent={vi.fn()}
+      />,
+    );
+    expect(getByText("Start a conversation.")).toBeTruthy();
+  });
+});

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -1881,6 +1881,32 @@ body.ae-resizing-sidebar .a2ui-layout {
   background: var(--bg);
 }
 
+/* Virtualized canvas: the <main> is a non-scrolling flex host; Virtuoso
+   (.a2ui-canvas-scroller) owns the scroll. Padding moves onto the scroller;
+   inter-row gap becomes per-row margin since Virtuoso's items aren't flex
+   children. */
+.a2ui-canvas-host {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  width: 100%;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  padding: 0;
+  gap: 0;
+}
+
+.a2ui-canvas-empty-host {
+  overflow: hidden;
+}
+
+.a2ui-canvas-scroller {
+  overscroll-behavior: none;
+  padding: 16px 20px 12px;
+  background: var(--bg);
+}
+
 .a2ui-canvas-empty {
   margin: auto;
   color: var(--text-dim);
@@ -2705,19 +2731,42 @@ body.ae-resizing-sidebar .a2ui-layout {
   margin-top: 12px;
 }
 
-/* Standalone chat-history (used when sidebars or panels need a feed). */
+/* Shell: a non-scrolling flex slot that hosts the Virtuoso scroller plus the
+   floating scroll-to-bottom pill (now absolutely positioned over the list
+   instead of a sticky flex child of the scroll container). */
+.a2ui-msg-list-shell {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+}
 
+/* Standalone chat-history (used when sidebars or panels need a feed). With
+   virtualization this class lands on Virtuoso's scroller; Virtuoso supplies
+   the overflow + height, so we only add chrome (padding, no-bounce). */
 .a2ui-chat-history {
+  overscroll-behavior: none;
+  padding: 12px 12px 8px;
+  contain: layout style;
+}
+
+/* Empty state renders without Virtuoso, so it keeps the old centering box. */
+.a2ui-chat-history-empty {
   display: flex;
   flex-direction: column;
   flex: 1;
   min-width: 0;
   min-height: 0;
   overflow-y: auto;
-  overscroll-behavior: none;
-  padding: 12px 12px 8px;
-  gap: 4px;
-  contain: layout style;
+}
+
+/* Virtuoso lays items out in normal flow (not a flex column), so the old
+   container `gap` no longer applies — restore inter-message spacing per row. */
+.a2ui-chat-message,
+.a2ui-canvas-message {
+  margin-bottom: 4px;
 }
 
 .a2ui-chat-load-older {
@@ -2905,9 +2954,10 @@ body.ae-resizing-sidebar .a2ui-layout {
 /* Scroll-to-bottom pill — uses position:sticky so it floats at the bottom
    of the flex container without needing absolute/fixed positioning. */
 .a2ui-scroll-to-bottom {
-  position: sticky;
+  position: absolute;
   bottom: 10px;
-  align-self: center;
+  left: 50%;
+  transform: translateX(-50%);
   background: var(--accent);
   color: var(--btn-text, var(--bg));
   border: none;
@@ -2920,8 +2970,6 @@ body.ae-resizing-sidebar .a2ui-layout {
   z-index: 10;
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.35);
   animation: a2ui-pill-in 0.15s ease both;
-  flex-shrink: 0;
-  margin-top: 4px;
 }
 
 .a2ui-scroll-to-bottom:hover {
@@ -2931,11 +2979,11 @@ body.ae-resizing-sidebar .a2ui-layout {
 @keyframes a2ui-pill-in {
   from {
     opacity: 0;
-    transform: translateY(6px);
+    transform: translate(-50%, 6px);
   }
   to {
     opacity: 1;
-    transform: translateY(0);
+    transform: translate(-50%, 0);
   }
 }
 

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -2762,11 +2762,12 @@ body.ae-resizing-sidebar .a2ui-layout {
   overflow-y: auto;
 }
 
-/* Virtuoso lays items out in normal flow (not a flex column), so the old
-   container `gap` no longer applies — restore inter-message spacing per row. */
-.a2ui-chat-message,
-.a2ui-canvas-message {
-  margin-bottom: 4px;
+/* Per-row wrapper inside Virtuoso's measured item. `flow-root` contains the
+   row's vertical margins (role-change spacing) so they're included in the
+   measured height — otherwise they escape and Virtuoso's offsets drift in long
+   transcripts. Replaces the old flex-container `gap`. */
+.a2ui-msg-row {
+  display: flow-root;
 }
 
 .a2ui-chat-load-older {

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -2762,12 +2762,16 @@ body.ae-resizing-sidebar .a2ui-layout {
   overflow-y: auto;
 }
 
-/* Per-row wrapper inside Virtuoso's measured item. `flow-root` contains the
-   row's vertical margins (role-change spacing) so they're included in the
-   measured height — otherwise they escape and Virtuoso's offsets drift in long
-   transcripts. Replaces the old flex-container `gap`. */
+/* Per-row wrapper inside Virtuoso's measured item. A flex column does two
+   jobs: (1) flex items' vertical margins are contained in the measured height
+   (no margin-collapse escaping the wrapper), so Virtuoso's offsets stay
+   accurate in long transcripts; (2) it re-establishes the flex context the
+   rows' `align-self` rules need (user bubbles right-aligned, system centered,
+   agent stretched) now that rows are no longer direct children of the
+   scroll column. Replaces the old flex-container `gap`. */
 .a2ui-msg-row {
-  display: flow-root;
+  display: flex;
+  flex-direction: column;
 }
 
 .a2ui-chat-load-older {


### PR DESCRIPTION
## Summary

Stacked on #162. Replaces the hand-rolled 160-row window + `useStickyScroll`
observer with **react-virtuoso**, so only the visible chat rows mount. Combined
with #162 (per-token reconcile fix), this removes the remaining scroll/stream
lag — long histories no longer pin 100+ markdown subtrees in the DOM.

## What changed

- `ChatHistory` + `MainCanvas` render through a shared `VirtualMessageList`.
  Virtuoso owns stick-to-bottom (`followOutput`), the at-bottom signal for the
  scroll-to-bottom pill (`atBottomStateChange`), and `scrollToIndex` for search
  matches. `useStickyScroll` / `useMessageWindow` / the load-older pagination
  are retired from the chat path.
- The canvas live-subtree + typing indicator ride in Virtuoso's `Footer` so
  they follow with the feed.
- CSS: the `<main>` / wrapper become non-scrolling flex hosts; Virtuoso owns the
  scroller. Each row is wrapped in `.a2ui-msg-row` (flex column) so the rows'
  `align-self` alignment + margins survive the restructuring (see below).

## Review fixes (codex)

Codex review caught several real, browser-only integration bugs that jsdom
tests can't (each empirically confirmed + fixed):

- **P1 crash:** `initialItemCount` + a bottom `initialTopMostItemIndex` made
  Virtuoso request rows past the end of `data` → `undefined` into
  `computeItemKey` → threw on `m.id` for any restored 2+ message chat. Dropped
  `initialItemCount`.
- **Open at bottom:** use `{ index, align: "end" }` so a tall final message
  opens at the latest content, not its top.
- **Measurement + alignment:** rows are no longer flex children of the scroller,
  so their margins escaped Virtuoso's height measurement (offset drift) and
  `align-self` died (user bubbles went full-width). The `.a2ui-msg-row` flex
  wrapper fixes both.
- **Footer-only pill:** a live-canvas response with zero messages now still
  shows the scroll-to-latest pill and scrolls to the true bottom (incl. Footer).

## Tests

`message-list.virtuoso.test.tsx` is a new integration guard that renders
`ChatHistory` + `MainCanvas` through the **real** (unmocked) Virtuoso to pin the
crash class; `chat.test.tsx` mocks Virtuoso (jsdom measures 0px) for content +
the render-isolation memo guard. Full suite green (1505 tests), tsc + ESLint
clean.

Also fixes the `debug-agent-new-tab` skill helper (it spread `tabs` as an
object map; this codebase uses an array).

Refs #159