### PR TITLE
feat(agent): release-safe worker telemetry + agent_diagnostics IPC (#159)

### DIFF
--- a/.claude/skills/aethon-debug/scripts/debug-agent-diag.sh
+++ b/.claude/skills/aethon-debug/scripts/debug-agent-diag.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Dump the agent-worker diagnostics table (#159): one row per live
+# aethon-agent worker — key (__global__ / tab:<id>), tab id, cwd,
+# pid, alive, ms since spawn, ms since last activity, prompt-in-flight,
+# and a friendly session label. Read-only.
+#
+# Use it to map a hot PID (from `top` / Activity Monitor) back to a tab
+# and see whether it's mid-prompt or idle.
+#
+# Usage:
+#   debug-agent-diag.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "${SCRIPT_DIR}/debug-invoke.sh" agent_diagnostics

--- a/src-tauri/src/agent_commands.rs
+++ b/src-tauri/src/agent_commands.rs
@@ -68,6 +68,11 @@ pub(crate) fn force_restart_agent(state: State<'_, AgentProcesses>) -> Result<()
     if let Ok(mut routes) = state.mutation_routes.lock() {
         routes.clear();
     }
+    // Children were drained; drop their diagnostics rows so agent_diagnostics
+    // never reports a worker that no longer exists. They re-register on respawn.
+    if let Ok(mut meta) = state.meta.lock() {
+        meta.clear();
+    }
     Ok(())
 }
 
@@ -94,6 +99,11 @@ pub(crate) fn reload_agent(state: State<'_, AgentProcesses>, app: AppHandle) -> 
         }
         if let Ok(mut routes) = state.mutation_routes.lock() {
             routes.clear();
+        }
+        // Match the drained children: clear stale diagnostics rows so
+        // agent_diagnostics stays "one row per live worker".
+        if let Ok(mut meta) = state.meta.lock() {
+            meta.clear();
         }
     }
     let _ = app.emit("agent-reloaded", "extension-toggle");

--- a/src-tauri/src/agent_commands.rs
+++ b/src-tauri/src/agent_commands.rs
@@ -1,8 +1,13 @@
+use std::collections::HashMap;
+use std::process::Child;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
 use tauri::{AppHandle, Emitter, State};
 
 use crate::agent_process::{
-    AgentProcesses, AgentWorker, GLOBAL_AGENT_KEY, ensure_global_agent, retire_agent_key,
-    route_payload_key, write_agent_payload,
+    AgentProcesses, AgentWorker, GLOBAL_AGENT_KEY, WorkerMeta, ensure_global_agent,
+    retire_agent_key, route_payload_key, write_agent_payload,
 };
 
 #[tauri::command]
@@ -135,6 +140,85 @@ pub(crate) fn dispatch_a2ui_event(
     write_agent_payload(&state, &app, key, payload, worker)
 }
 
+/// Read-only per-worker diagnostic row. Maps a live `aethon-agent` PID back to
+/// its key / tab / cwd plus idle + prompt state, so a release build (no debug
+/// webview hooks) can answer "which agent is hot and why" (#159 acceptance
+/// criterion). All timing is relative ("ms ago") from monotonic clocks.
+#[derive(serde::Serialize)]
+pub(crate) struct AgentDiagnostic {
+    pub(crate) key: String,
+    pub(crate) tab_id: Option<String>,
+    pub(crate) cwd: Option<String>,
+    pub(crate) pid: u32,
+    pub(crate) alive: bool,
+    pub(crate) spawned_ms_ago: u128,
+    pub(crate) last_activity_ms_ago: u128,
+    pub(crate) prompt_in_flight: bool,
+    pub(crate) session_label: String,
+}
+
+/// Human-friendly label for a worker: "global" for the shared agent, otherwise
+/// the cwd basename (project/worktree name) falling back to the tab id.
+fn session_label_for(key: &str, meta: &WorkerMeta) -> String {
+    if key == GLOBAL_AGENT_KEY {
+        return "global".to_string();
+    }
+    if let Some(cwd) = meta.cwd.as_deref()
+        && let Some(name) = cwd.rsplit(['/', '\\']).find(|s| !s.is_empty())
+    {
+        return name.to_string();
+    }
+    meta.tab_id
+        .clone()
+        .unwrap_or_else(|| key.trim_start_matches("tab:").to_string())
+}
+
+#[tauri::command]
+pub(crate) fn agent_diagnostics(
+    state: State<'_, AgentProcesses>,
+) -> Result<Vec<AgentDiagnostic>, String> {
+    // Snapshot child handles, then release the `children` lock before probing
+    // liveness so we never hold it across a per-child `try_wait`.
+    let children: Vec<(String, Arc<Mutex<Child>>)> = {
+        let guard = state.children.lock().map_err(|e| e.to_string())?;
+        guard
+            .iter()
+            .map(|(k, c)| (k.clone(), Arc::clone(c)))
+            .collect()
+    };
+    let alive: HashMap<String, bool> = children
+        .into_iter()
+        .map(|(k, child)| {
+            let running = child
+                .lock()
+                .ok()
+                .and_then(|mut c| c.try_wait().ok())
+                .map(|exit| exit.is_none())
+                .unwrap_or(false);
+            (k, running)
+        })
+        .collect();
+
+    let now = Instant::now();
+    let map = state.meta.lock().map_err(|e| e.to_string())?;
+    let mut rows: Vec<AgentDiagnostic> = map
+        .iter()
+        .map(|(key, m)| AgentDiagnostic {
+            key: key.clone(),
+            tab_id: m.tab_id.clone(),
+            cwd: m.cwd.clone(),
+            pid: m.pid,
+            alive: alive.get(key).copied().unwrap_or(false),
+            spawned_ms_ago: now.duration_since(m.spawned_at).as_millis(),
+            last_activity_ms_ago: now.duration_since(m.last_activity).as_millis(),
+            prompt_in_flight: m.prompt_in_flight,
+            session_label: session_label_for(key, m),
+        })
+        .collect();
+    rows.sort_by(|a, b| a.key.cmp(&b.key));
+    Ok(rows)
+}
+
 fn worker_for_payload(
     key: &str,
     payload: &serde_json::Value,
@@ -159,7 +243,44 @@ fn worker_for_payload(
 
 #[cfg(test)]
 mod tests {
-    use super::worker_for_payload;
+    use super::{GLOBAL_AGENT_KEY, WorkerMeta, session_label_for, worker_for_payload};
+    use std::time::Instant;
+
+    fn meta(tab_id: Option<&str>, cwd: Option<&str>) -> WorkerMeta {
+        let now = Instant::now();
+        WorkerMeta {
+            tab_id: tab_id.map(str::to_string),
+            cwd: cwd.map(str::to_string),
+            pid: 1,
+            spawned_at: now,
+            last_activity: now,
+            prompt_in_flight: false,
+        }
+    }
+
+    #[test]
+    fn session_label_uses_global_cwd_basename_then_tab() {
+        assert_eq!(
+            session_label_for(GLOBAL_AGENT_KEY, &meta(None, None)),
+            "global"
+        );
+        assert_eq!(
+            session_label_for(
+                "tab:abc",
+                &meta(Some("abc"), Some("/Users/x/Projects/aethon/"))
+            ),
+            "aethon",
+        );
+        assert_eq!(
+            session_label_for("tab:abc", &meta(Some("abc"), None)),
+            "abc"
+        );
+    }
+
+    #[test]
+    fn session_label_falls_back_to_key_without_tab() {
+        assert_eq!(session_label_for("tab:xyz", &meta(None, None)), "xyz");
+    }
 
     #[test]
     fn worker_context_carries_tab_and_optional_cwd() {

--- a/src-tauri/src/agent_process/mod.rs
+++ b/src-tauri/src/agent_process/mod.rs
@@ -28,7 +28,7 @@ mod sidecar;
 mod spawn;
 
 pub(crate) use process::{
-    AgentProcesses, AgentWorker, GLOBAL_AGENT_KEY, ensure_global_agent, retire_agent_key,
-    route_payload_key, write_agent_payload,
+    AgentProcesses, AgentWorker, GLOBAL_AGENT_KEY, WorkerMeta, ensure_global_agent,
+    retire_agent_key, route_payload_key, write_agent_payload,
 };
 pub(crate) use sidecar::project_root;

--- a/src-tauri/src/agent_process/process.rs
+++ b/src-tauri/src/agent_process/process.rs
@@ -54,14 +54,16 @@ impl AgentProcesses {
     }
 }
 
-/// Outbound message types that begin an agent turn — used to flip
-/// `prompt_in_flight` true the instant we forward a prompt, before the bridge
-/// echoes `prompt_started`. Idle-retirement (Phase 5) keys off this flag.
+/// Whether an outbound payload begins a real agent turn — used to flip
+/// `prompt_in_flight` true the instant we forward it, before the bridge echoes
+/// `prompt_started`. ONLY `chat` qualifies: it's the one type guaranteed to be
+/// bracketed by `prompt_started`/`response_end`, so the flag is always cleared.
+/// `local_chat_message` (persist-only) and `native_slash_command` (emits
+/// `notice`/`native_slash_result`, no `response_end`) must NOT set it, or the
+/// worker would read as permanently mid-prompt. They still bump `last_activity`
+/// via the write path. Idle-retirement (Phase 5) keys off this flag.
 pub(crate) fn payload_starts_prompt(payload: &serde_json::Value) -> bool {
-    matches!(
-        payload.get("type").and_then(|v| v.as_str()),
-        Some("chat" | "local_chat_message" | "native_slash_command")
-    )
+    payload.get("type").and_then(|v| v.as_str()) == Some("chat")
 }
 
 /// Record activity against a worker key: bump `last_activity` and, when given,
@@ -218,11 +220,20 @@ mod tests {
     }
 
     #[test]
-    fn prompt_starting_types_are_recognized() {
-        for ty in ["chat", "local_chat_message", "native_slash_command"] {
-            assert!(payload_starts_prompt(&serde_json::json!({ "type": ty })));
-        }
-        for ty in ["a2ui_event", "set_model", "tab_open", "report"] {
+    fn only_chat_starts_a_prompt() {
+        assert!(payload_starts_prompt(
+            &serde_json::json!({ "type": "chat" })
+        ));
+        // These reach the bridge but never produce a response_end, so they must
+        // not latch prompt_in_flight (codex P2).
+        for ty in [
+            "local_chat_message",
+            "native_slash_command",
+            "a2ui_event",
+            "set_model",
+            "tab_open",
+            "report",
+        ] {
             assert!(!payload_starts_prompt(&serde_json::json!({ "type": ty })));
         }
     }

--- a/src-tauri/src/agent_process/process.rs
+++ b/src-tauri/src/agent_process/process.rs
@@ -15,6 +15,7 @@
 use std::collections::{HashMap, HashSet};
 use std::process::Child;
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
 use tauri::{AppHandle, State};
 
@@ -22,10 +23,24 @@ use super::spawn::ensure_agent_spawned;
 
 pub(crate) const GLOBAL_AGENT_KEY: &str = "__global__";
 
+/// Per-worker diagnostic metadata, keyed alongside `children`. Lets a
+/// release-safe `agent_diagnostics` command map a live `aethon-agent` PID back
+/// to its key / tab / cwd and report idle + prompt state (#159). `Instant`s are
+/// monotonic and reported as "ms ago" so no wall-clock serialization is needed.
+pub(crate) struct WorkerMeta {
+    pub(crate) tab_id: Option<String>,
+    pub(crate) cwd: Option<String>,
+    pub(crate) pid: u32,
+    pub(crate) spawned_at: Instant,
+    pub(crate) last_activity: Instant,
+    pub(crate) prompt_in_flight: bool,
+}
+
 pub(crate) struct AgentProcesses {
     pub(crate) children: Mutex<HashMap<String, Arc<Mutex<Child>>>>,
     pub(crate) mutation_routes: Arc<Mutex<HashMap<String, String>>>,
     pub(crate) intentional_exits: Arc<Mutex<HashSet<String>>>,
+    pub(crate) meta: Arc<Mutex<HashMap<String, WorkerMeta>>>,
 }
 
 impl AgentProcesses {
@@ -34,6 +49,34 @@ impl AgentProcesses {
             children: Mutex::new(HashMap::new()),
             mutation_routes: Arc::new(Mutex::new(HashMap::new())),
             intentional_exits: Arc::new(Mutex::new(HashSet::new())),
+            meta: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+}
+
+/// Outbound message types that begin an agent turn — used to flip
+/// `prompt_in_flight` true the instant we forward a prompt, before the bridge
+/// echoes `prompt_started`. Idle-retirement (Phase 5) keys off this flag.
+pub(crate) fn payload_starts_prompt(payload: &serde_json::Value) -> bool {
+    matches!(
+        payload.get("type").and_then(|v| v.as_str()),
+        Some("chat" | "local_chat_message" | "native_slash_command")
+    )
+}
+
+/// Record activity against a worker key: bump `last_activity` and, when given,
+/// set `prompt_in_flight`. No-op if the key has no meta entry yet.
+pub(crate) fn touch_worker_activity(
+    meta: &Arc<Mutex<HashMap<String, WorkerMeta>>>,
+    key: &str,
+    prompt_in_flight: Option<bool>,
+) {
+    if let Ok(mut map) = meta.lock()
+        && let Some(entry) = map.get_mut(key)
+    {
+        entry.last_activity = Instant::now();
+        if let Some(flag) = prompt_in_flight {
+            entry.prompt_in_flight = flag;
         }
     }
 }
@@ -62,16 +105,25 @@ pub(crate) fn write_agent_payload(
             app,
             Arc::clone(&state.mutation_routes),
             Arc::clone(&state.intentional_exits),
+            Arc::clone(&state.meta),
             worker,
         )?;
         guard.get(&key).cloned().ok_or("agent not running")?
     };
 
-    let mut child = child.lock().map_err(|e| e.to_string())?;
-    let stdin = child.stdin.as_mut().ok_or("no stdin")?;
-    use std::io::Write;
-    writeln!(stdin, "{}", payload).map_err(|e| format!("write failed: {e}"))?;
-    stdin.flush().map_err(|e| format!("flush failed: {e}"))?;
+    let prompt_flag = payload_starts_prompt(&payload).then_some(true);
+
+    {
+        let mut child = child.lock().map_err(|e| e.to_string())?;
+        let stdin = child.stdin.as_mut().ok_or("no stdin")?;
+        use std::io::Write;
+        writeln!(stdin, "{}", payload).map_err(|e| format!("write failed: {e}"))?;
+        stdin.flush().map_err(|e| format!("flush failed: {e}"))?;
+    }
+
+    // Inbound traffic counts as activity; a forwarded prompt also marks the
+    // worker busy so the idle sweep won't retire it mid-turn.
+    touch_worker_activity(&state.meta, &key, prompt_flag);
     Ok(())
 }
 
@@ -86,6 +138,7 @@ pub(crate) fn ensure_global_agent(
         app,
         Arc::clone(&state.mutation_routes),
         Arc::clone(&state.intentional_exits),
+        Arc::clone(&state.meta),
         None,
     )
 }
@@ -95,6 +148,9 @@ pub(crate) fn retire_agent_key(state: &State<'_, AgentProcesses>, key: &str) -> 
         let mut guard = state.children.lock().map_err(|e| e.to_string())?;
         guard.remove(key)
     };
+    if let Ok(mut map) = state.meta.lock() {
+        map.remove(key);
+    }
     let Some(child) = child else {
         return Ok(());
     };
@@ -145,7 +201,11 @@ pub(crate) fn route_payload_key(
 
 #[cfg(test)]
 mod tests {
-    use super::{GLOBAL_AGENT_KEY, tab_agent_key};
+    use super::{
+        Arc, GLOBAL_AGENT_KEY, HashMap, Instant, Mutex, WorkerMeta, payload_starts_prompt,
+        tab_agent_key, touch_worker_activity,
+    };
+    use std::time::Duration;
 
     #[test]
     fn global_agent_key_is_stable() {
@@ -155,5 +215,65 @@ mod tests {
     #[test]
     fn tab_agent_key_keeps_tab_prefix() {
         assert_eq!(tab_agent_key("abc"), "tab:abc");
+    }
+
+    #[test]
+    fn prompt_starting_types_are_recognized() {
+        for ty in ["chat", "local_chat_message", "native_slash_command"] {
+            assert!(payload_starts_prompt(&serde_json::json!({ "type": ty })));
+        }
+        for ty in ["a2ui_event", "set_model", "tab_open", "report"] {
+            assert!(!payload_starts_prompt(&serde_json::json!({ "type": ty })));
+        }
+    }
+
+    fn meta_with_stale_entry(key: &str) -> Arc<Mutex<HashMap<String, WorkerMeta>>> {
+        let stale = Instant::now()
+            .checked_sub(Duration::from_secs(30))
+            .expect("instant in range");
+        let mut map = HashMap::new();
+        map.insert(
+            key.to_string(),
+            WorkerMeta {
+                tab_id: Some("t".into()),
+                cwd: None,
+                pid: 1,
+                spawned_at: stale,
+                last_activity: stale,
+                prompt_in_flight: true,
+            },
+        );
+        Arc::new(Mutex::new(map))
+    }
+
+    #[test]
+    fn touch_bumps_activity_and_sets_prompt_flag() {
+        let meta = meta_with_stale_entry("tab:x");
+        let before = meta.lock().unwrap().get("tab:x").unwrap().last_activity;
+
+        touch_worker_activity(&meta, "tab:x", Some(false));
+
+        let entry_guard = meta.lock().unwrap();
+        let entry = entry_guard.get("tab:x").unwrap();
+        assert!(entry.last_activity > before, "last_activity should advance");
+        assert!(
+            !entry.prompt_in_flight,
+            "flag should clear when Some(false)"
+        );
+    }
+
+    #[test]
+    fn touch_without_flag_leaves_prompt_state() {
+        let meta = meta_with_stale_entry("tab:x");
+        touch_worker_activity(&meta, "tab:x", None);
+        assert!(meta.lock().unwrap().get("tab:x").unwrap().prompt_in_flight);
+    }
+
+    #[test]
+    fn touch_unknown_key_is_a_noop() {
+        let meta = meta_with_stale_entry("tab:x");
+        touch_worker_activity(&meta, "tab:missing", Some(false));
+        // Existing entry untouched, no panic for the missing key.
+        assert!(meta.lock().unwrap().get("tab:x").unwrap().prompt_in_flight);
     }
 }

--- a/src-tauri/src/agent_process/readers.rs
+++ b/src-tauri/src/agent_process/readers.rs
@@ -22,6 +22,8 @@ use std::sync::{Arc, Mutex};
 
 use tauri::{AppHandle, Emitter};
 
+use super::process::{WorkerMeta, touch_worker_activity};
+
 pub(super) const STDERR_TAIL_CAP: usize = 32;
 
 /// Inputs for the stdout reader thread. Bundled into a struct so the
@@ -35,6 +37,7 @@ pub(super) struct StdoutReaderCtx {
     pub(super) tab_id: Option<String>,
     pub(super) mutation_routes: Arc<Mutex<HashMap<String, String>>>,
     pub(super) intentional_exits: Arc<Mutex<HashSet<String>>>,
+    pub(super) meta: Arc<Mutex<HashMap<String, WorkerMeta>>>,
     pub(super) stderr_tail: Arc<Mutex<VecDeque<String>>>,
 }
 
@@ -47,6 +50,7 @@ pub(super) fn spawn_stdout_reader(ctx: StdoutReaderCtx) {
         tab_id,
         mutation_routes,
         intentional_exits,
+        meta,
         stderr_tail,
     } = ctx;
     std::thread::spawn(move || {
@@ -60,11 +64,21 @@ pub(super) fn spawn_stdout_reader(ctx: StdoutReaderCtx) {
                         let _ = app.emit("agent-reloaded", "");
                         continue;
                     }
-                    if let Ok(value) = serde_json::from_str::<serde_json::Value>(&text)
-                        && let Some(mutation_id) = value.get("mutationId").and_then(|v| v.as_str())
-                        && let Ok(mut routes) = mutation_routes.lock()
-                    {
-                        routes.insert(mutation_id.to_string(), key.clone());
+                    if let Ok(value) = serde_json::from_str::<serde_json::Value>(&text) {
+                        if let Some(mutation_id) = value.get("mutationId").and_then(|v| v.as_str())
+                            && let Ok(mut routes) = mutation_routes.lock()
+                        {
+                            routes.insert(mutation_id.to_string(), key.clone());
+                        }
+                        // Any output is activity; the turn-lifecycle events flip
+                        // prompt_in_flight so the idle sweep (Phase 5) and
+                        // diagnostics reflect whether the worker is mid-turn.
+                        let prompt_flag = match value.get("type").and_then(|v| v.as_str()) {
+                            Some("prompt_started") => Some(true),
+                            Some("response_end") => Some(false),
+                            _ => None,
+                        };
+                        touch_worker_activity(&meta, &key, prompt_flag);
                     }
                     let _ = app.emit("agent-response", text);
                 }

--- a/src-tauri/src/agent_process/readers.rs
+++ b/src-tauri/src/agent_process/readers.rs
@@ -64,22 +64,24 @@ pub(super) fn spawn_stdout_reader(ctx: StdoutReaderCtx) {
                         let _ = app.emit("agent-reloaded", "");
                         continue;
                     }
+                    // Any stdout line is activity — including non-JSON noise
+                    // (startup banners, panics) — so bump last_activity
+                    // unconditionally. Only parsed turn-lifecycle events flip
+                    // prompt_in_flight (idle sweep + diagnostics read both).
+                    let mut prompt_flag = None;
                     if let Ok(value) = serde_json::from_str::<serde_json::Value>(&text) {
                         if let Some(mutation_id) = value.get("mutationId").and_then(|v| v.as_str())
                             && let Ok(mut routes) = mutation_routes.lock()
                         {
                             routes.insert(mutation_id.to_string(), key.clone());
                         }
-                        // Any output is activity; the turn-lifecycle events flip
-                        // prompt_in_flight so the idle sweep (Phase 5) and
-                        // diagnostics reflect whether the worker is mid-turn.
-                        let prompt_flag = match value.get("type").and_then(|v| v.as_str()) {
+                        prompt_flag = match value.get("type").and_then(|v| v.as_str()) {
                             Some("prompt_started") => Some(true),
                             Some("response_end") => Some(false),
                             _ => None,
                         };
-                        touch_worker_activity(&meta, &key, prompt_flag);
                     }
+                    touch_worker_activity(&meta, &key, prompt_flag);
                     let _ = app.emit("agent-response", text);
                 }
                 Err(_) => break,

--- a/src-tauri/src/agent_process/spawn.rs
+++ b/src-tauri/src/agent_process/spawn.rs
@@ -17,7 +17,9 @@ use tauri::{AppHandle, Manager};
 use crate::helpers::parse_config_toml;
 use crate::{env, helpers};
 
-use super::process::AgentWorker;
+use std::time::Instant;
+
+use super::process::{AgentWorker, WorkerMeta};
 use super::readers::{
     STDERR_TAIL_CAP, StderrReaderCtx, StdoutReaderCtx, spawn_stderr_reader, spawn_stdout_reader,
 };
@@ -34,6 +36,7 @@ pub(super) fn ensure_agent_spawned(
     app: &AppHandle,
     mutation_routes: Arc<Mutex<HashMap<String, String>>>,
     intentional_exits: Arc<Mutex<HashSet<String>>>,
+    meta: Arc<Mutex<HashMap<String, WorkerMeta>>>,
     worker: Option<AgentWorker>,
 ) -> Result<(), String> {
     let exited_status = guard.get(key).and_then(|child| {
@@ -77,6 +80,7 @@ pub(super) fn ensure_agent_spawned(
         tab_id: worker.as_ref().map(|w| w.tab_id.clone()),
         mutation_routes,
         intentional_exits,
+        meta: Arc::clone(&meta),
         stderr_tail: Arc::clone(&stderr_tail),
     });
 
@@ -104,6 +108,27 @@ pub(super) fn ensure_agent_spawned(
             key = key,
             "failed to inject initial handshake: {e}"
         );
+    }
+
+    {
+        let now = Instant::now();
+        let (tab_id, cwd) = worker
+            .as_ref()
+            .map(|w| (Some(w.tab_id.clone()), w.cwd.clone()))
+            .unwrap_or((None, None));
+        if let Ok(mut map) = meta.lock() {
+            map.insert(
+                key.to_string(),
+                WorkerMeta {
+                    tab_id,
+                    cwd,
+                    pid,
+                    spawned_at: now,
+                    last_activity: now,
+                    prompt_in_flight: false,
+                },
+            );
+        }
     }
 
     guard.insert(key.to_string(), Arc::new(Mutex::new(child)));

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -158,6 +158,7 @@ pub fn run() {
             agent_commands::agent_command,
             agent_commands::force_restart_agent,
             agent_commands::reload_agent,
+            agent_commands::agent_diagnostics,
             agent_commands::dispatch_a2ui_event,
             paste::save_paste_image,
             commands::config::read_state,
@@ -384,6 +385,7 @@ mod tests {
             "agent_commands::agent_command",
             "agent_commands::force_restart_agent",
             "agent_commands::reload_agent",
+            "agent_commands::agent_diagnostics",
             "agent_commands::dispatch_a2ui_event",
             "paste::save_paste_image",
         ] {


### PR DESCRIPTION
## Summary

The #159 investigation found multiple `aethon-agent` workers staying hot, but
the running release exposes no debug hooks to map a PID back to a tab — so the
root cause couldn't be confirmed live. This adds that diagnostic, which is both
an explicit #159 acceptance criterion and the prerequisite for the idle-
retirement / orphan-reconcile work (next PR keys off this metadata).

## What changed

- **`WorkerMeta`** tracked alongside each agent child: `tab_id`, `cwd`, `pid`,
  `spawned_at`, `last_activity`, `prompt_in_flight`. Inserted on spawn, removed
  on retire. `last_activity` bumps on every inbound write and every stdout line;
  `prompt_in_flight` flips true on a forwarded `chat` / bridge `prompt_started`
  and false on `response_end`.
- **`agent_diagnostics`** — read-only IPC returning one row per worker:
  `{ key, tab_id, cwd, pid, alive, spawned_ms_ago, last_activity_ms_ago,
  prompt_in_flight, session_label }`. `alive` is probed via `try_wait` after
  releasing the `children` lock; timing is monotonic ("ms ago"), no wall-clock.
- Registered in the invoke handler + ACL self-check list.
- **`debug-agent-diag.sh`** skill wrapper to dump the table while debugging.

## Review fix (codex)

- **P2:** only `chat` latches `prompt_in_flight`. `local_chat_message`
  (persist-only) and `native_slash_command` (emits `notice`/`native_slash_result`)
  never send `response_end`, so latching them would leave a worker reading as
  permanently mid-prompt. They still bump `last_activity`.

## Tests

Unit tests for `payload_starts_prompt`, `touch_worker_activity` (bump / flag
set / clear / unknown-key no-op), and `session_label_for`. Full `cargo test`
(327) + clippy clean.

## How to use

With a dev build running: `agent_diagnostics` (via the skill's
`debug-agent-diag.sh`, or `invoke`) maps each hot PID from `top` back to
`__global__` / `tab:<id>` + cwd + idle time + turn state.

Refs #159