### PR TITLE
feat(agent): idle worker retirement + orphan reconcile (#159)

### DIFF
--- a/src-tauri/src/agent_commands.rs
+++ b/src-tauri/src/agent_commands.rs
@@ -1,14 +1,19 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::process::Child;
 use std::sync::{Arc, Mutex};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use tauri::{AppHandle, Emitter, State};
 
 use crate::agent_process::{
     AgentProcesses, AgentWorker, GLOBAL_AGENT_KEY, WorkerMeta, ensure_global_agent,
-    retire_agent_key, route_payload_key, write_agent_payload,
+    keys_to_reconcile, retire_agent_key, route_payload_key, write_agent_payload,
 };
+
+/// Grace period before a worker is eligible for orphan reconciliation, so a
+/// tab the frontend just opened (but hasn't yet included in its reported live
+/// set) isn't killed mid-handshake.
+const RECONCILE_MIN_AGE: Duration = Duration::from_secs(10);
 
 #[tauri::command]
 pub(crate) fn start_agent(state: State<'_, AgentProcesses>, app: AppHandle) -> Result<(), String> {
@@ -227,6 +232,26 @@ pub(crate) fn agent_diagnostics(
         .collect();
     rows.sort_by(|a, b| a.key.cmp(&b.key));
     Ok(rows)
+}
+
+/// Retire per-tab workers whose tab no longer exists in the frontend's live
+/// set — a safety net for a dropped `tab_close` or a worker left over from a
+/// previous crash that session-restore didn't re-adopt. The frontend owns the
+/// authoritative tab list and calls this on a low cadence + after restore.
+/// Returns the keys retired (for observability/tests). The global agent and
+/// just-spawned workers (younger than [`RECONCILE_MIN_AGE`]) are never touched.
+#[tauri::command]
+pub(crate) fn reconcile_agent_workers(
+    live_tab_ids: Vec<String>,
+    state: State<'_, AgentProcesses>,
+) -> Result<Vec<String>, String> {
+    let live: HashSet<String> = live_tab_ids.into_iter().collect();
+    let keys = keys_to_reconcile(&state.meta, &live, Instant::now(), RECONCILE_MIN_AGE);
+    for key in &keys {
+        tracing::info!(target: "aethon::agent", key = key.as_str(), "reconcile-retiring orphaned worker");
+        retire_agent_key(&state, key)?;
+    }
+    Ok(keys)
 }
 
 fn worker_for_payload(

--- a/src-tauri/src/agent_process/mod.rs
+++ b/src-tauri/src/agent_process/mod.rs
@@ -26,9 +26,11 @@ mod process;
 mod readers;
 mod sidecar;
 mod spawn;
+mod sweep;
 
 pub(crate) use process::{
     AgentProcesses, AgentWorker, GLOBAL_AGENT_KEY, WorkerMeta, ensure_global_agent,
-    retire_agent_key, route_payload_key, write_agent_payload,
+    keys_to_reconcile, retire_agent_key, route_payload_key, write_agent_payload,
 };
 pub(crate) use sidecar::project_root;
+pub(crate) use sweep::spawn_idle_sweep;

--- a/src-tauri/src/agent_process/process.rs
+++ b/src-tauri/src/agent_process/process.rs
@@ -120,9 +120,12 @@ pub(crate) fn idle_keys_to_retire(
 
 /// Worker keys to retire because their tab no longer exists in the frontend's
 /// live set — a safety net for a dropped `tab_close` or a post-crash straggler.
-/// Only `tab:<id>` workers (never global), only those whose tab id is absent
-/// from `live_tab_ids`, and only those older than `min_age` so a worker the
-/// frontend just spawned but hasn't reported in its set yet isn't killed.
+/// Retires only a `tab:<id>` worker that is ALL of: not the global agent; not
+/// mid-prompt (don't kill an in-flight turn); older than `min_age` (so a worker
+/// the frontend just spawned but hasn't reported yet survives); and whose tab
+/// id is absent from `live_tab_ids`. `live_tab_ids` must span every project
+/// bucket, not just the active one — tabs are project-scoped (see
+/// `useAgentWorkerReconcile`).
 pub(crate) fn keys_to_reconcile(
     meta: &Arc<Mutex<HashMap<String, WorkerMeta>>>,
     live_tab_ids: &HashSet<String>,
@@ -135,6 +138,7 @@ pub(crate) fn keys_to_reconcile(
     map.iter()
         .filter(|(key, m)| {
             *key != GLOBAL_AGENT_KEY
+                && !m.prompt_in_flight
                 && now.duration_since(m.spawned_at) >= min_age
                 && m.tab_id
                     .as_deref()
@@ -378,6 +382,10 @@ mod tests {
             tab_agent_key("live"),
             worker_aged("live", Duration::from_secs(30)),
         );
+        // Orphaned + aged but mid-prompt → keep (don't kill an in-flight turn).
+        let mut busy_orphan = worker_aged("busy", Duration::from_secs(30));
+        busy_orphan.prompt_in_flight = true;
+        map.insert(tab_agent_key("busy"), busy_orphan);
         // Global is never reconciled.
         map.insert(
             GLOBAL_AGENT_KEY.to_string(),

--- a/src-tauri/src/agent_process/process.rs
+++ b/src-tauri/src/agent_process/process.rs
@@ -15,7 +15,7 @@
 use std::collections::{HashMap, HashSet};
 use std::process::Child;
 use std::sync::{Arc, Mutex};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use tauri::{AppHandle, State};
 
@@ -81,6 +81,67 @@ pub(crate) fn touch_worker_activity(
             entry.prompt_in_flight = flag;
         }
     }
+}
+
+/// Should this worker be retired by the idle sweep? Pure so the policy is
+/// testable without spawning processes. Never retires the global agent or a
+/// worker that's mid-prompt; otherwise retires once idle past `ttl`.
+pub(crate) fn should_retire_idle(
+    key: &str,
+    meta: &WorkerMeta,
+    now: Instant,
+    ttl: Duration,
+) -> bool {
+    if key == GLOBAL_AGENT_KEY {
+        return false;
+    }
+    if meta.prompt_in_flight {
+        return false;
+    }
+    now.duration_since(meta.last_activity) >= ttl
+}
+
+/// Collect the worker keys the idle sweep should retire this tick. Snapshots
+/// under the meta lock and returns owned keys so the caller can retire them
+/// after releasing the lock (retirement re-locks meta + children).
+pub(crate) fn idle_keys_to_retire(
+    meta: &Arc<Mutex<HashMap<String, WorkerMeta>>>,
+    now: Instant,
+    ttl: Duration,
+) -> Vec<String> {
+    let Ok(map) = meta.lock() else {
+        return Vec::new();
+    };
+    map.iter()
+        .filter(|(key, m)| should_retire_idle(key, m, now, ttl))
+        .map(|(key, _)| key.clone())
+        .collect()
+}
+
+/// Worker keys to retire because their tab no longer exists in the frontend's
+/// live set — a safety net for a dropped `tab_close` or a post-crash straggler.
+/// Only `tab:<id>` workers (never global), only those whose tab id is absent
+/// from `live_tab_ids`, and only those older than `min_age` so a worker the
+/// frontend just spawned but hasn't reported in its set yet isn't killed.
+pub(crate) fn keys_to_reconcile(
+    meta: &Arc<Mutex<HashMap<String, WorkerMeta>>>,
+    live_tab_ids: &HashSet<String>,
+    now: Instant,
+    min_age: Duration,
+) -> Vec<String> {
+    let Ok(map) = meta.lock() else {
+        return Vec::new();
+    };
+    map.iter()
+        .filter(|(key, m)| {
+            *key != GLOBAL_AGENT_KEY
+                && now.duration_since(m.spawned_at) >= min_age
+                && m.tab_id
+                    .as_deref()
+                    .is_some_and(|t| !live_tab_ids.contains(t))
+        })
+        .map(|(key, _)| key.clone())
+        .collect()
 }
 
 pub(crate) struct AgentWorker {
@@ -204,10 +265,131 @@ pub(crate) fn route_payload_key(
 #[cfg(test)]
 mod tests {
     use super::{
-        Arc, GLOBAL_AGENT_KEY, HashMap, Instant, Mutex, WorkerMeta, payload_starts_prompt,
-        tab_agent_key, touch_worker_activity,
+        Arc, GLOBAL_AGENT_KEY, HashMap, HashSet, Instant, Mutex, WorkerMeta, idle_keys_to_retire,
+        keys_to_reconcile, payload_starts_prompt, should_retire_idle, tab_agent_key,
+        touch_worker_activity,
     };
     use std::time::Duration;
+
+    fn worker_aged(tab_id: &str, age: Duration) -> WorkerMeta {
+        let spawned = Instant::now().checked_sub(age).expect("instant in range");
+        WorkerMeta {
+            tab_id: Some(tab_id.into()),
+            cwd: None,
+            pid: 1,
+            spawned_at: spawned,
+            last_activity: spawned,
+            prompt_in_flight: false,
+        }
+    }
+
+    fn worker(prompt_in_flight: bool, idle: Duration) -> WorkerMeta {
+        let last = Instant::now().checked_sub(idle).expect("instant in range");
+        WorkerMeta {
+            tab_id: Some("t".into()),
+            cwd: None,
+            pid: 1,
+            spawned_at: last,
+            last_activity: last,
+            prompt_in_flight,
+        }
+    }
+
+    #[test]
+    fn idle_tab_worker_past_ttl_is_retired() {
+        let ttl = Duration::from_secs(60);
+        let now = Instant::now();
+        assert!(should_retire_idle(
+            "tab:x",
+            &worker(false, Duration::from_secs(120)),
+            now,
+            ttl
+        ));
+    }
+
+    #[test]
+    fn fresh_or_busy_or_global_workers_are_kept() {
+        let ttl = Duration::from_secs(60);
+        let now = Instant::now();
+        // Recently active.
+        assert!(!should_retire_idle(
+            "tab:x",
+            &worker(false, Duration::from_secs(5)),
+            now,
+            ttl
+        ));
+        // Mid-prompt, even if idle clock would otherwise trip.
+        assert!(!should_retire_idle(
+            "tab:x",
+            &worker(true, Duration::from_secs(120)),
+            now,
+            ttl
+        ));
+        // The global agent is never swept.
+        assert!(!should_retire_idle(
+            GLOBAL_AGENT_KEY,
+            &worker(false, Duration::from_secs(9999)),
+            now,
+            ttl
+        ));
+    }
+
+    #[test]
+    fn idle_keys_collects_only_eligible() {
+        let mut map = HashMap::new();
+        map.insert(
+            "tab:idle".to_string(),
+            worker(false, Duration::from_secs(120)),
+        );
+        map.insert(
+            "tab:busy".to_string(),
+            worker(true, Duration::from_secs(120)),
+        );
+        map.insert(
+            "tab:fresh".to_string(),
+            worker(false, Duration::from_secs(1)),
+        );
+        map.insert(
+            GLOBAL_AGENT_KEY.to_string(),
+            worker(false, Duration::from_secs(120)),
+        );
+        let meta = Arc::new(Mutex::new(map));
+
+        let keys = idle_keys_to_retire(&meta, Instant::now(), Duration::from_secs(60));
+
+        assert_eq!(keys, vec!["tab:idle".to_string()]);
+    }
+
+    #[test]
+    fn reconcile_retires_only_aged_orphan_tab_workers() {
+        let mut map = HashMap::new();
+        // Orphaned (tab gone) and old enough → retire.
+        map.insert(
+            tab_agent_key("gone"),
+            worker_aged("gone", Duration::from_secs(30)),
+        );
+        // Orphaned but just spawned → keep (frontend may not have reported it).
+        map.insert(
+            tab_agent_key("new"),
+            worker_aged("new", Duration::from_secs(1)),
+        );
+        // Still live → keep.
+        map.insert(
+            tab_agent_key("live"),
+            worker_aged("live", Duration::from_secs(30)),
+        );
+        // Global is never reconciled.
+        map.insert(
+            GLOBAL_AGENT_KEY.to_string(),
+            worker_aged("ignored", Duration::from_secs(30)),
+        );
+        let meta = Arc::new(Mutex::new(map));
+        let live: HashSet<String> = ["live".to_string()].into_iter().collect();
+
+        let keys = keys_to_reconcile(&meta, &live, Instant::now(), Duration::from_secs(10));
+
+        assert_eq!(keys, vec![tab_agent_key("gone")]);
+    }
 
     #[test]
     fn global_agent_key_is_stable() {

--- a/src-tauri/src/agent_process/sweep.rs
+++ b/src-tauri/src/agent_process/sweep.rs
@@ -1,0 +1,67 @@
+//! Idle per-tab worker retirement (#159).
+//!
+//! A background thread wakes every [`SWEEP_INTERVAL`] and retires any
+//! `tab:<id>` worker that has sat idle — no prompt in flight, no inbound or
+//! outbound traffic — longer than the configured TTL. The global agent is never
+//! swept. Retired workers respawn lazily from their persisted pi session on the
+//! next message (`ensure_agent_spawned` is idempotent), so this is transparent
+//! to the user: it just stops finished, untouched tabs from holding a hot
+//! `aethon-agent` child indefinitely.
+//!
+//! The TTL is read from `[agent] idle_retire_minutes` each tick so a Settings
+//! change takes effect without a restart; `0` disables the sweep.
+
+use std::time::{Duration, Instant};
+
+use tauri::{AppHandle, Manager};
+
+use crate::helpers::{self, parse_config_toml};
+
+use super::process::{AgentProcesses, idle_keys_to_retire, retire_agent_key};
+
+/// How often the sweep wakes. Coarse on purpose — retirement is a cleanup, not
+/// a latency-sensitive path, and a 60s cadence keeps the wakeup cost trivial.
+const SWEEP_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Spawn the idle-retirement sweep. Plain OS thread (no async needed): it
+/// sleeps, then reaches managed state via the cloned `AppHandle` — the same
+/// pattern the extension-reload debounce worker uses.
+pub(crate) fn spawn_idle_sweep(app: AppHandle) {
+    std::thread::spawn(move || {
+        loop {
+            std::thread::sleep(SWEEP_INTERVAL);
+            sweep_once(&app);
+        }
+    });
+}
+
+/// Resolve the configured idle TTL, or `None` when retirement is disabled
+/// (`idle_retire_minutes = 0`). Read fresh each tick so Settings edits apply
+/// live.
+fn configured_ttl(app: &AppHandle) -> Option<Duration> {
+    let home = app.path().home_dir().ok()?;
+    let user_dir = helpers::aethon_dir(Some(home.clone())).unwrap_or_else(|| home.join(".aethon"));
+    let raw = std::fs::read_to_string(user_dir.join("config.toml")).unwrap_or_default();
+    let minutes = parse_config_toml(&raw)["agent"]["idleRetireMinutes"]
+        .as_u64()
+        .unwrap_or(15);
+    (minutes > 0).then(|| Duration::from_secs(minutes * 60))
+}
+
+fn sweep_once(app: &AppHandle) {
+    let Some(ttl) = configured_ttl(app) else {
+        return;
+    };
+    let state = app.state::<AgentProcesses>();
+    let keys = idle_keys_to_retire(&state.meta, Instant::now(), ttl);
+    for key in keys {
+        match retire_agent_key(&state, &key) {
+            Ok(()) => {
+                tracing::info!(target: "aethon::agent", key = key.as_str(), "idle-retired worker")
+            }
+            Err(e) => {
+                tracing::warn!(target: "aethon::agent", key = key.as_str(), "idle retire failed: {e}")
+            }
+        }
+    }
+}

--- a/src-tauri/src/agent_process/sweep.rs
+++ b/src-tauri/src/agent_process/sweep.rs
@@ -8,10 +8,13 @@
 //! to the user: it just stops finished, untouched tabs from holding a hot
 //! `aethon-agent` child indefinitely.
 //!
-//! The TTL is read from `[agent] idle_retire_minutes` each tick so a Settings
-//! change takes effect without a restart; `0` disables the sweep.
+//! The TTL comes from `[agent] idle_retire_minutes`; it's re-read only when
+//! `config.toml`'s mtime changes (so a Settings edit applies without a restart,
+//! but we don't re-parse from disk every minute for the app's lifetime). `0`
+//! disables the sweep.
 
-use std::time::{Duration, Instant};
+use std::path::PathBuf;
+use std::time::{Duration, Instant, SystemTime};
 
 use tauri::{AppHandle, Manager};
 
@@ -28,30 +31,52 @@ const SWEEP_INTERVAL: Duration = Duration::from_secs(60);
 /// pattern the extension-reload debounce worker uses.
 pub(crate) fn spawn_idle_sweep(app: AppHandle) {
     std::thread::spawn(move || {
+        // (config mtime seen, resolved ttl) — avoids re-reading + re-parsing
+        // config.toml every tick; only re-parse when the file actually changes.
+        let mut ttl_cache: Option<(SystemTime, Option<Duration>)> = None;
         loop {
             std::thread::sleep(SWEEP_INTERVAL);
-            sweep_once(&app);
+            let Some(ttl) = resolve_ttl_cached(&app, &mut ttl_cache) else {
+                continue;
+            };
+            sweep_once(&app, ttl);
         }
     });
 }
 
-/// Resolve the configured idle TTL, or `None` when retirement is disabled
-/// (`idle_retire_minutes = 0`). Read fresh each tick so Settings edits apply
-/// live.
-fn configured_ttl(app: &AppHandle) -> Option<Duration> {
+fn config_path(app: &AppHandle) -> Option<PathBuf> {
     let home = app.path().home_dir().ok()?;
     let user_dir = helpers::aethon_dir(Some(home.clone())).unwrap_or_else(|| home.join(".aethon"));
-    let raw = std::fs::read_to_string(user_dir.join("config.toml")).unwrap_or_default();
+    Some(user_dir.join("config.toml"))
+}
+
+/// Resolve the configured idle TTL (`None` = retirement disabled). Re-reads +
+/// re-parses `config.toml` only when its mtime differs from the cached one;
+/// otherwise returns the cached value. A missing file (no mtime) falls back to
+/// reading (cheap — yields the default) without caching.
+fn resolve_ttl_cached(
+    app: &AppHandle,
+    cache: &mut Option<(SystemTime, Option<Duration>)>,
+) -> Option<Duration> {
+    let path = config_path(app)?;
+    let mtime = std::fs::metadata(&path).and_then(|m| m.modified()).ok();
+    if let (Some(mtime), Some((cached_mtime, cached_ttl))) = (mtime, cache.as_ref())
+        && mtime == *cached_mtime
+    {
+        return *cached_ttl;
+    }
+    let raw = std::fs::read_to_string(&path).unwrap_or_default();
     let minutes = parse_config_toml(&raw)["agent"]["idleRetireMinutes"]
         .as_u64()
         .unwrap_or(15);
-    (minutes > 0).then(|| Duration::from_secs(minutes * 60))
+    let ttl = (minutes > 0).then(|| Duration::from_secs(minutes * 60));
+    if let Some(mtime) = mtime {
+        *cache = Some((mtime, ttl));
+    }
+    ttl
 }
 
-fn sweep_once(app: &AppHandle) {
-    let Some(ttl) = configured_ttl(app) else {
-        return;
-    };
+fn sweep_once(app: &AppHandle, ttl: Duration) {
     let state = app.state::<AgentProcesses>();
     let keys = idle_keys_to_retire(&state.meta, Instant::now(), ttl);
     for key in keys {

--- a/src-tauri/src/helpers/config.rs
+++ b/src-tauri/src/helpers/config.rs
@@ -31,6 +31,11 @@ pub struct UiConfig {
 #[derive(Default, Deserialize)]
 pub struct AgentConfig {
     pub model: Option<String>,
+    /// Minutes a per-tab agent worker may sit idle (no prompt in flight, no
+    /// traffic) before the background sweep retires it; it respawns lazily from
+    /// the persisted session on the next message. `0` disables retirement.
+    /// Clamped to 24h. Default 15.
+    pub idle_retire_minutes: Option<u32>,
 }
 
 #[derive(Default, Deserialize)]
@@ -286,6 +291,7 @@ pub fn parse_config_toml(input: &str) -> serde_json::Value {
         },
         "agent": {
             "model": cfg.agent.model,
+            "idleRetireMinutes": cfg.agent.idle_retire_minutes.map(|n| n.min(1440)).unwrap_or(15),
         },
         "shell": {
             "defaultShareMode": default_share_mode,
@@ -387,6 +393,19 @@ mod tests {
         let v = parse_config_toml("[agent]\nmodel = \"anthropic/claude-sonnet-4-6\"\n");
         assert_eq!(v["agent"]["model"], "anthropic/claude-sonnet-4-6");
         assert_eq!(v["ui"]["theme"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn idle_retire_minutes_defaults_clamps_and_disables() {
+        assert_eq!(parse_config_toml("")["agent"]["idleRetireMinutes"], 15);
+        assert_eq!(
+            parse_config_toml("[agent]\nidle_retire_minutes = 0\n")["agent"]["idleRetireMinutes"],
+            0
+        );
+        assert_eq!(
+            parse_config_toml("[agent]\nidle_retire_minutes = 99999\n")["agent"]["idleRetireMinutes"],
+            1440
+        );
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -159,6 +159,7 @@ pub fn run() {
             agent_commands::force_restart_agent,
             agent_commands::reload_agent,
             agent_commands::agent_diagnostics,
+            agent_commands::reconcile_agent_workers,
             agent_commands::dispatch_a2ui_event,
             paste::save_paste_image,
             commands::config::read_state,
@@ -329,6 +330,11 @@ pub fn run() {
             let server_state = app.state::<Arc<server::ServerState>>().inner().clone();
             server::boot(app.handle().clone(), server_state);
 
+            // Idle per-tab agent worker retirement (#159): a background sweep
+            // retires `tab:<id>` workers that have sat idle past the configured
+            // TTL; they respawn lazily from their session on next use.
+            agent_process::spawn_idle_sweep(app.handle().clone());
+
             // Release app launches can start with a skeletal PATH. Warm
             // the launch-safe tool path off the setup thread so the
             // first devshell status/probe IPC does not pay for the
@@ -386,6 +392,7 @@ mod tests {
             "agent_commands::force_restart_agent",
             "agent_commands::reload_agent",
             "agent_commands::agent_diagnostics",
+            "agent_commands::reconcile_agent_workers",
             "agent_commands::dispatch_a2ui_event",
             "paste::save_paste_image",
         ] {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -115,10 +115,6 @@ export default function App() {
 
   useSessionPersistence({ appStore, hasSyncSessionSnapshot });
 
-  // Orphan agent-worker cleanup (#159): retire per-tab workers whose tab is
-  // gone from the live set, as a faster complement to the Rust idle sweep.
-  useAgentWorkerReconcile(stateRef);
-
   const recordProjectModel = useProjectModelRecorder(setState);
 
   // ---------------------------------------------------------------------
@@ -372,6 +368,7 @@ export default function App() {
   const {
     projectsLoadedRef,
     allDiscoveredSessionsRef,
+    tabBucketsRef,
     buildSidebarHistory,
     knownTabIds,
     scopedDiscoveredSessions,
@@ -419,6 +416,12 @@ export default function App() {
     activateWorktree,
     setProjectIconUrl,
   });
+
+  // Orphan agent-worker cleanup (#159): retire per-tab workers whose tab is
+  // gone from the live set, a faster complement to the Rust idle sweep. Needs
+  // tabBucketsRef so the live set spans every project bucket, not just the
+  // active one (tabs are project-scoped).
+  useAgentWorkerReconcile(stateRef, tabBucketsRef);
 
   // ---------------------------------------------------------------------
   // Toast stack + OS completion notification. Owned by useNotifications.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { useHostInfo } from "./hooks/useHostInfo";
 import { useDevshell, type DevshellEntry } from "./hooks/useDevshell";
 import { activeCwd as projectsActiveCwd, type ProjectsState } from "./projects";
 import { useProjects } from "./hooks/useProjects";
+import { useAgentWorkerReconcile } from "./hooks/useAgentWorkerReconcile";
 import { useVcsStatus } from "./hooks/useVcsStatus";
 import { useGitWatch } from "./hooks/useGitWatch";
 import { useTabNavigation } from "./hooks/useTabNavigation";
@@ -113,6 +114,10 @@ export default function App() {
   } = useAppStateRefs(appStore);
 
   useSessionPersistence({ appStore, hasSyncSessionSnapshot });
+
+  // Orphan agent-worker cleanup (#159): retire per-tab workers whose tab is
+  // gone from the live set, as a faster complement to the Rust idle sweep.
+  useAgentWorkerReconcile(stateRef);
 
   const recordProjectModel = useProjectModelRecorder(setState);
 

--- a/src/hooks/useAgentWorkerReconcile.test.ts
+++ b/src/hooks/useAgentWorkerReconcile.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { liveAgentTabIds } from "./useAgentWorkerReconcile";
+import type { Tab } from "../types/tab";
+
+function tab(id: string, kind: Tab["kind"]): Tab {
+  return { id, kind, label: id, messages: [] } as Tab;
+}
+
+describe("liveAgentTabIds", () => {
+  it("keeps only agent tabs", () => {
+    const tabs = [
+      tab("a1", "agent"),
+      tab("s1", "shell"),
+      tab("e1", "editor"),
+      tab("a2", "agent"),
+    ];
+    expect(liveAgentTabIds(tabs)).toEqual(["a1", "a2"]);
+  });
+
+  it("returns an empty list when there are no agent tabs", () => {
+    expect(liveAgentTabIds([tab("s1", "shell")])).toEqual([]);
+    expect(liveAgentTabIds([])).toEqual([]);
+  });
+});

--- a/src/hooks/useAgentWorkerReconcile.test.ts
+++ b/src/hooks/useAgentWorkerReconcile.test.ts
@@ -4,7 +4,20 @@ import type { Tab } from "../types/tab";
 import type { TabBucket } from "./projectOps/types";
 
 function tab(id: string, kind: Tab["kind"]): Tab {
-  return { id, kind, label: id, messages: [] } as Tab;
+  return {
+    id,
+    kind,
+    label: id,
+    messages: [],
+    draft: "",
+    waiting: false,
+    queueCount: 0,
+    queuedMessages: [],
+    canvas: null,
+    model: "",
+    terminalBuffer: "",
+    projectId: null,
+  };
 }
 
 function bucket(tabs: Tab[]): TabBucket {

--- a/src/hooks/useAgentWorkerReconcile.test.ts
+++ b/src/hooks/useAgentWorkerReconcile.test.ts
@@ -1,24 +1,44 @@
 import { describe, expect, it } from "vitest";
 import { liveAgentTabIds } from "./useAgentWorkerReconcile";
 import type { Tab } from "../types/tab";
+import type { TabBucket } from "./projectOps/types";
 
 function tab(id: string, kind: Tab["kind"]): Tab {
   return { id, kind, label: id, messages: [] } as Tab;
 }
 
+function bucket(tabs: Tab[]): TabBucket {
+  return { tabs, activeTabId: tabs[0]?.id };
+}
+
 describe("liveAgentTabIds", () => {
-  it("keeps only agent tabs", () => {
+  it("keeps only agent tabs from the active bucket", () => {
     const tabs = [
       tab("a1", "agent"),
       tab("s1", "shell"),
       tab("e1", "editor"),
       tab("a2", "agent"),
     ];
-    expect(liveAgentTabIds(tabs)).toEqual(["a1", "a2"]);
+    expect(liveAgentTabIds(tabs, [])).toEqual(["a1", "a2"]);
+  });
+
+  it("unions agent tabs across inactive project buckets", () => {
+    const active = [tab("a1", "agent")];
+    const buckets = [
+      bucket([tab("b1", "agent"), tab("bshell", "shell")]),
+      bucket([tab("b2", "agent")]),
+    ];
+    expect(liveAgentTabIds(active, buckets).sort()).toEqual(["a1", "b1", "b2"]);
+  });
+
+  it("dedupes a tab present in both the active list and a stale bucket", () => {
+    const active = [tab("a1", "agent")];
+    const buckets = [bucket([tab("a1", "agent"), tab("b1", "agent")])];
+    expect(liveAgentTabIds(active, buckets).sort()).toEqual(["a1", "b1"]);
   });
 
   it("returns an empty list when there are no agent tabs", () => {
-    expect(liveAgentTabIds([tab("s1", "shell")])).toEqual([]);
-    expect(liveAgentTabIds([])).toEqual([]);
+    expect(liveAgentTabIds([tab("s1", "shell")], [])).toEqual([]);
+    expect(liveAgentTabIds([], [])).toEqual([]);
   });
 });

--- a/src/hooks/useAgentWorkerReconcile.ts
+++ b/src/hooks/useAgentWorkerReconcile.ts
@@ -1,34 +1,50 @@
 import { invoke } from "@tauri-apps/api/core";
 import { useEffect, type MutableRefObject } from "react";
 import type { Tab } from "../types/tab";
+import type { TabBucket } from "./projectOps/types";
 
 // Low cadence — this is orphan cleanup, not a latency-sensitive path. The idle
 // sweep (Rust) already retires inactive workers; this just retires faster when
-// a tab is gone. The startup delay lets session/tab restore settle so we don't
-// reconcile against a not-yet-populated tab set.
+// a tab is truly gone. The startup delay lets session/tab restore settle so we
+// don't reconcile against a not-yet-populated tab set.
 const RECONCILE_INTERVAL_MS = 60_000;
 const RECONCILE_START_DELAY_MS = 8_000;
 
-/** Agent-tab ids the frontend currently considers live. The Rust
- *  `reconcile_agent_workers` command retires any per-tab worker NOT in this set
- *  — a safety net for a dropped `tab_close` or a worker left over from a crash.
- *  Shell/editor tabs never have agent workers, so they're excluded. */
-export function liveAgentTabIds(tabs: Tab[]): string[] {
-  return tabs.filter((tab) => tab.kind === "agent").map((tab) => tab.id);
+/** Agent-tab ids the frontend considers live, ACROSS ALL PROJECT BUCKETS.
+ *  Tabs are project-scoped: only the active project's tabs live in
+ *  `state.tabs`; the other buckets are stashed in `tabBucketsRef`. The
+ *  reconcile set MUST union both — otherwise switching projects would make the
+ *  Rust side treat a hidden bucket's tabs as orphaned and retire their
+ *  (possibly mid-prompt) workers. Shell/editor tabs never have agent workers,
+ *  so they're excluded. Deduped because the active bucket can also linger as a
+ *  stale entry in the map. */
+export function liveAgentTabIds(
+  activeTabs: Tab[],
+  buckets: Iterable<TabBucket>,
+): string[] {
+  const ids = new Set<string>();
+  const addAgentTabs = (tabs: Tab[]) => {
+    for (const tab of tabs) if (tab.kind === "agent") ids.add(tab.id);
+  };
+  addAgentTabs(activeTabs);
+  for (const bucket of buckets) addAgentTabs(bucket.tabs);
+  return [...ids];
 }
 
 /** Periodically reconcile the Rust agent-worker set against the live agent
- *  tabs. Best-effort: IPC errors (e.g. an older shell without the command) are
- *  swallowed. The Rust side age-guards just-spawned workers, so a momentarily
- *  empty set can't kill a freshly-opened tab's worker. */
+ *  tabs across every project bucket. Best-effort: IPC errors (e.g. an older
+ *  shell without the command) are swallowed. The Rust side both age-guards
+ *  just-spawned workers and skips mid-prompt ones, so a momentarily empty set
+ *  can't kill a live worker. */
 export function useAgentWorkerReconcile(
   stateRef: MutableRefObject<Record<string, unknown>>,
+  tabBucketsRef: MutableRefObject<Map<string, TabBucket>>,
 ): void {
   useEffect(() => {
     const reconcile = () => {
-      const tabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
+      const activeTabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
       invoke("reconcile_agent_workers", {
-        liveTabIds: liveAgentTabIds(tabs),
+        liveTabIds: liveAgentTabIds(activeTabs, tabBucketsRef.current.values()),
       }).catch(() => {
         /* best-effort cleanup; ignore IPC errors */
       });
@@ -39,5 +55,5 @@ export function useAgentWorkerReconcile(
       window.clearTimeout(startId);
       window.clearInterval(intervalId);
     };
-  }, [stateRef]);
+  }, [stateRef, tabBucketsRef]);
 }

--- a/src/hooks/useAgentWorkerReconcile.ts
+++ b/src/hooks/useAgentWorkerReconcile.ts
@@ -1,0 +1,43 @@
+import { invoke } from "@tauri-apps/api/core";
+import { useEffect, type MutableRefObject } from "react";
+import type { Tab } from "../types/tab";
+
+// Low cadence — this is orphan cleanup, not a latency-sensitive path. The idle
+// sweep (Rust) already retires inactive workers; this just retires faster when
+// a tab is gone. The startup delay lets session/tab restore settle so we don't
+// reconcile against a not-yet-populated tab set.
+const RECONCILE_INTERVAL_MS = 60_000;
+const RECONCILE_START_DELAY_MS = 8_000;
+
+/** Agent-tab ids the frontend currently considers live. The Rust
+ *  `reconcile_agent_workers` command retires any per-tab worker NOT in this set
+ *  — a safety net for a dropped `tab_close` or a worker left over from a crash.
+ *  Shell/editor tabs never have agent workers, so they're excluded. */
+export function liveAgentTabIds(tabs: Tab[]): string[] {
+  return tabs.filter((tab) => tab.kind === "agent").map((tab) => tab.id);
+}
+
+/** Periodically reconcile the Rust agent-worker set against the live agent
+ *  tabs. Best-effort: IPC errors (e.g. an older shell without the command) are
+ *  swallowed. The Rust side age-guards just-spawned workers, so a momentarily
+ *  empty set can't kill a freshly-opened tab's worker. */
+export function useAgentWorkerReconcile(
+  stateRef: MutableRefObject<Record<string, unknown>>,
+): void {
+  useEffect(() => {
+    const reconcile = () => {
+      const tabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
+      invoke("reconcile_agent_workers", {
+        liveTabIds: liveAgentTabIds(tabs),
+      }).catch(() => {
+        /* best-effort cleanup; ignore IPC errors */
+      });
+    };
+    const startId = window.setTimeout(reconcile, RECONCILE_START_DELAY_MS);
+    const intervalId = window.setInterval(reconcile, RECONCILE_INTERVAL_MS);
+    return () => {
+      window.clearTimeout(startId);
+      window.clearInterval(intervalId);
+    };
+  }, [stateRef]);
+}


### PR DESCRIPTION
## Summary

Stacked on #164 (telemetry). Uses the per-worker metadata from that PR to stop
finished/abandoned per-tab `aethon-agent` workers from lingering — the #159
acceptance criterion that inactive workers are demonstrably idle or retired.

## Phase 5 — idle sweep

A background thread retires `tab:<id>` workers idle past `[agent]
idle_retire_minutes` (default 15, `0` disables, clamped 24h). Guards:
- never the global agent;
- never a worker that's `prompt_in_flight` (no killing a turn mid-flight);
- only after no inbound/outbound traffic for the TTL.

Retired workers respawn lazily from their persisted pi session on the next
message (`ensure_agent_spawned` is idempotent), so it's transparent. TTL is read
fresh each tick, so a Settings change applies without a restart.

## Phase 6 — orphan reconcile

`reconcile_agent_workers(live_tab_ids)` retires per-tab workers whose tab is
gone from the frontend's live set — a safety net for a dropped `tab_close` or a
post-crash straggler. `useAgentWorkerReconcile` calls it ~8s after restore
settles and every 60s.

## Review fix (codex P1)

Tabs are **project-scoped**: only the active project's tabs are in `state.tabs`,
the rest are stashed in `tabBucketsRef`. The first cut built the live set from
`state.tabs` alone, so switching projects would orphan-kill valid workers in
other buckets. Fixed: `liveAgentTabIds` now unions the active tabs with **every
bucket** (deduped), and `keys_to_reconcile` additionally skips `prompt_in_flight`
workers so an in-flight turn is never killed even if its tab momentarily looks
orphaned.

## Tests

Pure policy helpers (`should_retire_idle`, `idle_keys_to_retire`,
`keys_to_reconcile`, `liveAgentTabIds`) with idle/busy/global/fresh/orphan/
mid-prompt/bucket-union/dedupe cases, plus the config-clamp test. Full `cargo
test` (332) + `vitest` (1504) + tsc + clippy green.

Refs #159