### PR TITLE
perf(noise): gate mDNS advertiser + throttle updater 403s + visibility-gate polls (#159)

### DIFF
--- a/agent/projectLifecycle.ts
+++ b/agent/projectLifecycle.ts
@@ -245,7 +245,7 @@ export async function handleSetProject(
     unloadProjectExtensions(state, deps);
     logger
       .scope("project-switch")
-      .info(`set_project unload took ${Date.now() - t0}ms (cwd=${cwd})`);
+      .debug(`set_project unload took ${Date.now() - t0}ms (cwd=${cwd})`);
   }
   const projectName = projectDisplayName(cwd);
   const loadingNoticeId = `aethon:loading-project-ext:${cwd}`;
@@ -277,7 +277,7 @@ export async function handleSetProject(
   if (projectChanged) {
     logger
       .scope("project-switch")
-      .info(
+      .debug(
         `set_project load took ${Date.now() - tLoad}ms (loaded=${result.loaded} failed=${result.failed} prunedDisabled=${result.prunedDisabled})`,
       );
   }
@@ -293,16 +293,21 @@ export async function handleSetProject(
     if (projectChanged) {
       logger
         .scope("project-switch")
-        .info(
+        .debug(
           `set_project resourceLoader.reload took ${Date.now() - tReload}ms`,
         );
     }
     deps.scheduleStateFileWrite();
     emitGlobalReady(state, deps);
     if (projectChanged) {
+      // Single info summary per real project switch (the per-phase timings
+      // above are debug) — keeps the signal without ~4 info lines per switch,
+      // which dominated logs during worktree-heavy sessions (#159).
       logger
         .scope("project-switch")
-        .info(`set_project total ${Date.now() - t0}ms (cwd=${cwd})`);
+        .info(
+          `set_project total ${Date.now() - t0}ms (cwd=${cwd}, loaded=${result.loaded} failed=${result.failed})`,
+        );
     }
   }
 }

--- a/src-tauri/src/commands/server.rs
+++ b/src-tauri/src/commands/server.rs
@@ -28,7 +28,9 @@ pub async fn server_start(
     app: AppHandle,
     state: State<'_, Arc<ServerState>>,
 ) -> Result<u16, String> {
-    crate::server::start(&app, state.inner()).await
+    // Explicit user action always advertises, regardless of the
+    // `[server] enabled` boot gate.
+    crate::server::start(&app, state.inner(), true).await
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -8,6 +8,7 @@
 //! release URLs, tracing target, and managed-state hand-off rebased on
 //! Aethon's conventions.
 
+use std::sync::Mutex;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
@@ -106,10 +107,60 @@ fn nightly_candidate_urls_from_json(body: &str, limit: usize) -> Vec<Url> {
     urls
 }
 
+/// The nightly-discovery failure modes, distinguished so a *transition* between
+/// them warns once but a steady-state repeat (e.g. a 403 every 30 min) stays
+/// quiet after the first occurrence per boot.
+#[derive(Clone, PartialEq, Eq)]
+enum DiscoveryWarn {
+    Request,
+    Status(u16),
+    Body,
+}
+
+/// Should we warn for `current`? True only when it differs from the last
+/// warned state; `None` (a successful discovery) resets so a later failure
+/// warns again. Pure so the gate logic is unit-testable.
+fn should_warn_discovery(last: &mut Option<DiscoveryWarn>, current: Option<DiscoveryWarn>) -> bool {
+    match current {
+        None => {
+            *last = None;
+            false
+        }
+        Some(w) => {
+            let warn = last.as_ref() != Some(&w);
+            *last = Some(w);
+            warn
+        }
+    }
+}
+
+fn discovery_warn_gate() -> &'static Mutex<Option<DiscoveryWarn>> {
+    static GATE: std::sync::OnceLock<Mutex<Option<DiscoveryWarn>>> = std::sync::OnceLock::new();
+    GATE.get_or_init(|| Mutex::new(None))
+}
+
+/// Process-lifetime gate: returns true the first time `w` recurs, false on
+/// steady-state repeats. Poisoned lock falls back to warning (fail loud).
+fn warn_once(w: DiscoveryWarn) -> bool {
+    discovery_warn_gate()
+        .lock()
+        .map(|mut g| should_warn_discovery(&mut g, Some(w)))
+        .unwrap_or(true)
+}
+
+/// Reset the gate after a successful discovery so the next failure warns.
+fn reset_discovery_warn() {
+    if let Ok(mut g) = discovery_warn_gate().lock() {
+        should_warn_discovery(&mut g, None);
+    }
+}
+
 /// Discover nightly `latest.json` candidate URLs by querying the GitHub
 /// Releases API. Always returns a (possibly empty) vec; transport, HTTP,
 /// or parse failures are logged and downgrade to "no candidates," letting
-/// the caller fall back to the static [`NIGHTLY_URL`].
+/// the caller fall back to the static [`NIGHTLY_URL`]. Repeated identical
+/// failures (the every-30-min poll hitting a steady 403) log once at warn,
+/// then drop to debug — see [`should_warn_discovery`].
 async fn discover_nightly_endpoints() -> Vec<Url> {
     let resp = match http_client()
         .get(GITHUB_RELEASES_API)
@@ -121,37 +172,39 @@ async fn discover_nightly_endpoints() -> Vec<Url> {
     {
         Ok(r) => r,
         Err(e) => {
-            tracing::warn!(
-                target: "aethon::updater",
-                error = %e,
-                "nightly discovery request failed — falling back to static URL"
-            );
+            if warn_once(DiscoveryWarn::Request) {
+                tracing::warn!(target: "aethon::updater", error = %e, "nightly discovery request failed — falling back to static URL");
+            } else {
+                tracing::debug!(target: "aethon::updater", error = %e, "nightly discovery request failed (repeat)");
+            }
             return Vec::new();
         }
     };
 
     let status = resp.status();
     if !status.is_success() {
-        tracing::warn!(
-            target: "aethon::updater",
-            status = %status,
-            "nightly discovery returned non-success HTTP status — falling back to static URL"
-        );
+        if warn_once(DiscoveryWarn::Status(status.as_u16())) {
+            tracing::warn!(target: "aethon::updater", status = %status, "nightly discovery returned non-success HTTP status — falling back to static URL");
+        } else {
+            tracing::debug!(target: "aethon::updater", status = %status, "nightly discovery non-success status (repeat)");
+        }
         return Vec::new();
     }
 
     let body = match resp.text().await {
         Ok(b) => b,
         Err(e) => {
-            tracing::warn!(
-                target: "aethon::updater",
-                error = %e,
-                "nightly discovery body read failed — falling back to static URL"
-            );
+            if warn_once(DiscoveryWarn::Body) {
+                tracing::warn!(target: "aethon::updater", error = %e, "nightly discovery body read failed — falling back to static URL");
+            } else {
+                tracing::debug!(target: "aethon::updater", error = %e, "nightly discovery body read failed (repeat)");
+            }
             return Vec::new();
         }
     };
 
+    // A clean fetch resets the gate so a later failure warns once again.
+    reset_discovery_warn();
     nightly_candidate_urls_from_json(&body, NIGHTLY_CANDIDATE_LIMIT)
 }
 
@@ -347,6 +400,41 @@ fn aethon_data_dir(app: &AppHandle) -> Result<std::path::PathBuf, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn discovery_warn_suppresses_steady_state_repeats() {
+        let mut last = None;
+        // First 403 warns.
+        assert!(should_warn_discovery(
+            &mut last,
+            Some(DiscoveryWarn::Status(403))
+        ));
+        // Same 403 again stays quiet.
+        assert!(!should_warn_discovery(
+            &mut last,
+            Some(DiscoveryWarn::Status(403))
+        ));
+        // A different failure mode warns once.
+        assert!(should_warn_discovery(
+            &mut last,
+            Some(DiscoveryWarn::Request)
+        ));
+        assert!(!should_warn_discovery(
+            &mut last,
+            Some(DiscoveryWarn::Request)
+        ));
+        // A different status code warns.
+        assert!(should_warn_discovery(
+            &mut last,
+            Some(DiscoveryWarn::Status(500))
+        ));
+        // Success resets, so the next 403 warns again.
+        assert!(!should_warn_discovery(&mut last, None));
+        assert!(should_warn_discovery(
+            &mut last,
+            Some(DiscoveryWarn::Status(403))
+        ));
+    }
 
     #[test]
     fn release_not_found_is_treated_as_no_update() {

--- a/src-tauri/src/helpers/config.rs
+++ b/src-tauri/src/helpers/config.rs
@@ -98,6 +98,17 @@ pub struct UpdatesConfig {
 }
 
 #[derive(Default, Deserialize)]
+pub struct ServerConfig {
+    /// Whether to advertise this host over mDNS (`_aethon._tcp.local.`) on
+    /// boot. Default `true`. Set `false` to stop the LAN announcement — and
+    /// the "No route to host" send-failure log churn it can produce on
+    /// networks without multicast — while keeping peer *discovery* (the
+    /// browser) running, since that's read-only. The `server_start` IPC
+    /// (explicit user action) always advertises regardless of this flag.
+    pub enabled: Option<bool>,
+}
+
+#[derive(Default, Deserialize)]
 pub struct DevshellConfig {
     /// Whether to detect + apply a Nix devshell on shell + agent
     /// spawn. Accepted values: `"auto"` (default — detect via marker
@@ -155,6 +166,8 @@ pub struct AethonConfig {
     pub updates: UpdatesConfig,
     #[serde(default)]
     pub devshell: DevshellConfig,
+    #[serde(default)]
+    pub server: ServerConfig,
 }
 
 /// Validate-and-normalize `[devshell] enabled`. Unknown values fall
@@ -322,6 +335,9 @@ pub fn parse_config_toml(input: &str) -> serde_json::Value {
             "cacheTtlHours": devshell_cache_ttl_hours,
             "refreshOnLockfileChange": devshell_refresh_on_lockfile_change,
         },
+        "server": {
+            "enabled": cfg.server.enabled.unwrap_or(true),
+        },
     })
 }
 
@@ -393,6 +409,15 @@ mod tests {
         let v = parse_config_toml("[agent]\nmodel = \"anthropic/claude-sonnet-4-6\"\n");
         assert_eq!(v["agent"]["model"], "anthropic/claude-sonnet-4-6");
         assert_eq!(v["ui"]["theme"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn server_enabled_defaults_true_and_honors_override() {
+        assert_eq!(parse_config_toml("")["server"]["enabled"], true);
+        assert_eq!(
+            parse_config_toml("[server]\nenabled = false\n")["server"]["enabled"],
+            false
+        );
     }
 
     #[test]

--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -62,9 +62,13 @@ pub(crate) fn init_tracing() {
     } else {
         "warn"
     };
+    // Quiet the mdns_sd crate's below-warn chatter (routine multicast send
+    // retries on interfaces without a route) in the DEFAULT filter only — an
+    // explicit AETHON_LOG / RUST_LOG override wins and can re-enable it. The
+    // `[server] enabled = false` gate is the full off-switch.
     let filter = EnvFilter::try_from_env("AETHON_LOG")
         .or_else(|_| EnvFilter::try_from_default_env())
-        .unwrap_or_else(|_| EnvFilter::new(default_level));
+        .unwrap_or_else(|_| EnvFilter::new(format!("{default_level},mdns_sd=warn")));
 
     let stderr_layer = fmt::layer().with_target(true).with_writer(std::io::stderr);
 

--- a/src-tauri/src/server/mod.rs
+++ b/src-tauri/src/server/mod.rs
@@ -29,9 +29,11 @@ pub struct ServerHandle {
     pub port: u16,
     pub http_task: JoinHandle<()>,
     // Held for the lifetime of the announcement — dropping the daemon
-    // stops the mDNS advertisement. Never read directly.
+    // stops the mDNS advertisement. `None` when advertising is gated off
+    // via `[server] enabled = false` (HTTP + browser still run). Never
+    // read directly.
     #[allow(dead_code)]
-    pub advertise_daemon: mdns_sd::ServiceDaemon,
+    pub advertise_daemon: Option<mdns_sd::ServiceDaemon>,
 }
 
 /// Managed by Tauri (`.manage(ServerState::new())`). Wraps an
@@ -73,11 +75,16 @@ impl ServerState {
 }
 
 /// Start the server on app boot. Failures log + carry on — a network
-/// hiccup must never block the UI.
+/// hiccup must never block the UI. The mDNS advertiser is gated on
+/// `[server] enabled` (default true); the browser always runs.
 pub fn boot(app: AppHandle, state: Arc<ServerState>) {
     tauri::async_runtime::spawn(async move {
-        if let Err(e) = start(&app, &state).await {
+        let advertise = server_advertise_enabled(&app);
+        if let Err(e) = start(&app, &state, advertise).await {
             tracing::warn!(target: "aethon::server", "boot failed: {e}");
+        }
+        if !advertise {
+            tracing::info!(target: "aethon::server", "mDNS advertiser disabled via [server] enabled = false");
         }
         if let Err(e) = mdns::start_browser(app.clone()) {
             tracing::warn!(target: "aethon::server::mdns", "browser failed: {e}");
@@ -85,13 +92,35 @@ pub fn boot(app: AppHandle, state: Arc<ServerState>) {
     });
 }
 
-/// Bind HTTP + register mDNS. Pulled out so `server_start` IPC can
-/// reuse it after a user-triggered stop.
-pub async fn start(_app: &AppHandle, state: &ServerState) -> Result<u16, String> {
+/// Read `[server] enabled` from `~/.aethon/config.toml` (default true).
+fn server_advertise_enabled(app: &AppHandle) -> bool {
+    use tauri::Manager;
+    let Ok(home) = app.path().home_dir() else {
+        return true;
+    };
+    let user_dir =
+        crate::helpers::aethon_dir(Some(home.clone())).unwrap_or_else(|| home.join(".aethon"));
+    let raw = std::fs::read_to_string(user_dir.join("config.toml")).unwrap_or_default();
+    crate::helpers::parse_config_toml(&raw)["server"]["enabled"]
+        .as_bool()
+        .unwrap_or(true)
+}
+
+/// Bind HTTP + (optionally) register the mDNS advertiser. Pulled out so the
+/// `server_start` IPC can reuse it after a user-triggered stop — that path
+/// passes `advertise = true` so an explicit start always announces,
+/// regardless of the config gate.
+pub async fn start(_app: &AppHandle, state: &ServerState, advertise: bool) -> Result<u16, String> {
     let info = crate::commands::host::local_host_info();
     let (port, http_task) = http::serve(info.clone()).await?;
-    let advertise_daemon = mdns::advertise(&info.display_name, port, &info.fingerprint)
-        .map_err(|e| format!("mdns advertise failed: {e}"))?;
+    let advertise_daemon = if advertise {
+        Some(
+            mdns::advertise(&info.display_name, port, &info.fingerprint)
+                .map_err(|e| format!("mdns advertise failed: {e}"))?,
+        )
+    } else {
+        None
+    };
     let handle = ServerHandle {
         port,
         http_task,

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -112,7 +112,10 @@ export function useProjects(ctx: UseProjectsContext): UseProjectsActions {
   useEffect(() => {
     let cancelled = false;
     const tick = async () => {
-      if (cancelled || gitPollingRef.current) return;
+      // Skip background git polling while the window is hidden — no chips are
+      // visible to update, so it's pure wasted subprocess churn. The
+      // visibilitychange listener below refreshes on the way back.
+      if (cancelled || gitPollingRef.current || document.hidden) return;
       gitPollingRef.current = true;
       try {
         await refreshAllGitStatus();
@@ -138,12 +141,20 @@ export function useProjects(ctx: UseProjectsContext): UseProjectsActions {
     };
     void bootstrap();
     const onFocus = () => void tick();
+    // Refresh when the window becomes visible again (covers restore-from-
+    // minimized, which doesn't always fire `focus`), catching up on anything
+    // that drifted while polling was paused.
+    const onVisibility = () => {
+      if (!document.hidden) void tick();
+    };
     window.addEventListener("focus", onFocus);
+    document.addEventListener("visibilitychange", onVisibility);
     const interval = window.setInterval(tick, 30_000);
     return () => {
       cancelled = true;
       window.clearInterval(interval);
       window.removeEventListener("focus", onFocus);
+      document.removeEventListener("visibilitychange", onVisibility);
     };
     // ctx.getProjectPaths is read inside `tick`, so we deliberately
     // capture the closure-time reference; the hook is mounted once with

--- a/src/hooks/useVcsStatus.ts
+++ b/src/hooks/useVcsStatus.ts
@@ -240,7 +240,10 @@ export function useVcsStatus({ activeRoot, setState }: UseVcsStatusContext): voi
     });
 
     const tick = async () => {
-      if (cancelled) return;
+      // Pause VCS polling while the window is hidden — the status cluster +
+      // source-control panel aren't visible, so the git/gh calls are wasted.
+      // The visibilitychange listener refreshes on return.
+      if (cancelled || document.hidden) return;
       if (polling) {
         rerun = true;
         return;
@@ -320,7 +323,11 @@ export function useVcsStatus({ activeRoot, setState }: UseVcsStatusContext): voi
 
     void tick();
     const onFocus = () => void tick();
+    const onVisibility = () => {
+      if (!document.hidden) void tick();
+    };
     window.addEventListener("focus", onFocus);
+    document.addEventListener("visibilitychange", onVisibility);
     const interval = window.setInterval(() => void tick(), POLL_INTERVAL_MS);
 
     // Event-driven refresh: the Rust git watcher fires `git-state-changed`
@@ -339,6 +346,7 @@ export function useVcsStatus({ activeRoot, setState }: UseVcsStatusContext): voi
     return () => {
       cancelled = true;
       window.removeEventListener("focus", onFocus);
+      document.removeEventListener("visibilitychange", onVisibility);
       window.clearInterval(interval);
       unlisten?.();
     };


### PR DESCRIPTION
## Summary

Addresses the recurring background-noise findings in #159 — the secondary
"recurring failures dominate the logs / background wakeups" items, now that the
hot-agent (telemetry + idle retirement) and chat-lag (reconcile + virtualize)
root causes have landed.

## Changes

- **Updater 403 suppression.** Nightly-discovery failures now warn once per
  failure-state per boot — a steady 403 every 30 min drops to `debug` after the
  first; a successful discovery resets the gate so a later failure warns again.
  Pure, tested `should_warn_discovery` helper.
- **mDNS advertiser gate.** New `[server] enabled` config (default `true`) gates
  the mDNS advertiser. The browser (read-only peer discovery) always runs, and
  the `server_start` IPC always advertises. Setting it `false` stops the
  "No route to host" send-failure churn at the source. The default log filter
  also quiets `mdns_sd` below-warn chatter (overridable via `AETHON_LOG`).
- **Poll visibility-gating.** `useProjects` (30s) and `useVcsStatus` (20s)
  early-return when `document.hidden` and refresh on `visibilitychange` — no
  wasted git/gh subprocesses while the window is hidden/minimized.
- **set_project log volume.** One `info` summary per real project switch instead
  of ~4 lines; per-phase timings drop to `debug`. (This dominated logs during
  worktree-heavy sessions — 1380 lines/day in the report.)

## Acceptance criterion

> mDNS/updater recurring failures are throttled or gated and no longer dominate logs.

mDNS: gated (`[server] enabled`) + throttled (log filter). Updater: throttled
(once-per-state-per-boot).

## Tests

`should_warn_discovery` + `server.enabled` config-default unit tests; full
`cargo test` (334) + `vitest` (1509) + `tsc -b` + clippy + eslint green.

Refs #159