### PR TITLE
perf(projects): externalize project icons out of projects.json (#159)

### DIFF
--- a/src/projects.icons.test.ts
+++ b/src/projects.icons.test.ts
@@ -1,0 +1,93 @@
+// @vitest-environment node
+//
+// Icon externalization (#159): project icons (base64 data: URLs) persist in a
+// `project-icons.json` sidecar, NOT inline in projects.json, to keep the hot
+// project-list file small. These tests pin the save/load round-trip and the
+// automatic migration of a pre-externalization inline icon.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// In-memory persist backend keyed by filename.
+const store = new Map<string, string>();
+vi.mock("./persist", () => ({
+  readState: vi.fn((file: string) => Promise.resolve(store.get(file) ?? null)),
+  writeState: vi.fn((file: string, content: string) => {
+    store.set(file, content);
+    return Promise.resolve();
+  }),
+}));
+
+import {
+  emptyProjectsState,
+  loadProjects,
+  saveProjects,
+  upsertProject,
+} from "./projects";
+
+const HOST = "local:test";
+
+beforeEach(() => store.clear());
+afterEach(() => vi.clearAllMocks());
+
+function projectsWithIcon(iconUrl: string) {
+  const { state } = upsertProject(emptyProjectsState(HOST), "/Users/x/aethon");
+  state.projects[0].iconUrl = iconUrl;
+  return state;
+}
+
+describe("project icon externalization", () => {
+  it("keeps icons out of projects.json and in the sidecar on save", async () => {
+    await saveProjects(projectsWithIcon("data:image/png;base64,AAAA"));
+
+    const main = JSON.parse(store.get("projects.json")!);
+    expect(main.projects[0].iconUrl).toBeUndefined();
+
+    const icons = JSON.parse(store.get("project-icons.json")!);
+    const id = main.projects[0].id;
+    expect(icons[id]).toBe("data:image/png;base64,AAAA");
+  });
+
+  it("re-attaches icons from the sidecar on load", async () => {
+    await saveProjects(projectsWithIcon("data:image/png;base64,BBBB"));
+    const loaded = await loadProjects(HOST);
+    expect(loaded.projects[0].iconUrl).toBe("data:image/png;base64,BBBB");
+  });
+
+  it("migrates a pre-externalization inline icon, then strips it on next save", async () => {
+    // Old-format projects.json: icon embedded inline, no sidecar yet.
+    const id = "p1";
+    store.set(
+      "projects.json",
+      JSON.stringify({
+        schemaVersion: 3,
+        projects: [
+          {
+            id,
+            label: "aethon",
+            path: "/Users/x/aethon",
+            lastUsed: 1,
+            hostId: HOST,
+            iconUrl: "data:image/png;base64,OLD",
+          },
+        ],
+        activeId: null,
+      }),
+    );
+
+    // Load keeps the inline icon (sidecar absent).
+    const loaded = await loadProjects(HOST);
+    expect(loaded.projects[0].iconUrl).toBe("data:image/png;base64,OLD");
+
+    // Saving externalizes it: stripped from main, written to the sidecar.
+    await saveProjects(loaded);
+    expect(JSON.parse(store.get("projects.json")!).projects[0].iconUrl).toBeUndefined();
+    expect(JSON.parse(store.get("project-icons.json")!)[id]).toBe(
+      "data:image/png;base64,OLD",
+    );
+  });
+
+  it("omits projects without an icon from the sidecar", async () => {
+    const { state } = upsertProject(emptyProjectsState(HOST), "/Users/x/noicon");
+    await saveProjects(state);
+    expect(JSON.parse(store.get("project-icons.json")!)).toEqual({});
+  });
+});

--- a/src/projects.ts
+++ b/src/projects.ts
@@ -48,6 +48,11 @@ export interface ProjectsState {
 }
 
 const FILE = "projects.json";
+/** Project icons (base64 `data:` URLs) live in a sidecar keyed by project id,
+ *  NOT inline in projects.json — embedding them bloated the hot project-list
+ *  file to hundreds of KB, slowing every load/save/parse on the sidebar path
+ *  (#159). The sidecar is read once on load and rewritten on save. */
+const ICONS_FILE = "project-icons.json";
 const MAX_PROJECTS = 16;
 const SCHEMA_VERSION = 3;
 export const DEFAULT_WORKTREE_BASE_BRANCH = "origin/main";
@@ -88,6 +93,34 @@ interface PersistedV3 extends PersistedV2 {
   activeHostId?: string | null;
 }
 
+/** Read the project-icon sidecar: a `{ projectId: iconUrl }` map. Returns an
+ *  empty map when absent or malformed (icons are a cosmetic cache). */
+async function loadProjectIcons(): Promise<Record<string, string>> {
+  const raw = await readState(ICONS_FILE);
+  if (!raw) return {};
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return {};
+    const out: Record<string, string> = {};
+    for (const [id, url] of Object.entries(parsed as Record<string, unknown>)) {
+      if (typeof url === "string" && url.length > 0) out[id] = url;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+/** Persist the icon sidecar from the live project list. Only projects that
+ *  actually have an icon are written, so the file stays minimal. */
+async function saveProjectIcons(projects: Project[]): Promise<void> {
+  const map: Record<string, string> = {};
+  for (const p of projects) {
+    if (p.iconUrl) map[p.id] = p.iconUrl;
+  }
+  await writeState(ICONS_FILE, JSON.stringify(map));
+}
+
 export async function loadProjects(localHostId?: string): Promise<ProjectsState> {
   // Resolve the local host id from the bridge BEFORE migrating so v1/v2
   // entries get stamped with the real id, not the FALLBACK placeholder
@@ -99,7 +132,16 @@ export async function loadProjects(localHostId?: string): Promise<ProjectsState>
   if (!raw) return emptyProjectsState(hostId);
   try {
     const parsed = JSON.parse(raw) as PersistedV3 | PersistedV2 | PersistedV1;
-    return migrateProjects(parsed, hostId);
+    const state = migrateProjects(parsed, hostId);
+    // Re-attach icons from the sidecar. The sidecar wins; an inline `iconUrl`
+    // from a pre-externalization projects.json is kept as a fallback (it gets
+    // moved into the sidecar + stripped from the main file on the next save).
+    const icons = await loadProjectIcons();
+    for (const p of state.projects) {
+      const fromSidecar = icons[p.id];
+      if (fromSidecar) p.iconUrl = fromSidecar;
+    }
+    return state;
   } catch {
     return emptyProjectsState(hostId);
   }
@@ -183,15 +225,21 @@ export async function saveProjects(state: ProjectsState): Promise<void> {
   for (const [pid, list] of Object.entries(state.worktreesByProject)) {
     worktreesByProject[pid] = worktreesForPersist(list);
   }
+  // Externalize icons: keep the (potentially hundreds-of-KB base64) `iconUrl`
+  // out of the hot projects.json and in the sidecar instead.
+  const projectsForPersist = state.projects.map(({ iconUrl: _icon, ...rest }) =>
+    rest,
+  );
   const payload: PersistedV3 = {
     schemaVersion: SCHEMA_VERSION,
-    projects: state.projects,
+    projects: projectsForPersist,
     activeId: state.activeId,
     activeWorktreeId: state.activeWorktreeId,
     worktreesByProject,
     activeHostId: state.activeHostId,
   };
   await writeState(FILE, JSON.stringify(payload));
+  await saveProjectIcons(state.projects);
 }
 
 export function setActiveWorktree(


### PR DESCRIPTION
## Summary

Final #159 cleanup. Project icons were stored as base64 `data:` URLs **inline**
in `projects.json`, bloating that hot file to hundreds of KB (~446KB in the
report) and slowing every load / save / parse on the sidebar + project-switch
path. Move them to a `project-icons.json` sidecar keyed by project id.

## Behavior

- `saveProjects` strips `iconUrl` from the main file and writes the sidecar
  (only projects that actually have an icon).
- `loadProjects` re-attaches icons from the sidecar. An inline `iconUrl` from a
  pre-externalization `projects.json` is kept as a fallback and gets moved into
  the sidecar (and stripped from the main file) on the next save — automatic
  migration, no explicit step, no data loss.
- In-memory `Project.iconUrl` is unchanged, so the icon-render hot path
  (`iconForProject`/`discoverIcon`) and the `stampProjectIcon` writer are
  untouched.

## Tests

New `projects.icons.test.ts`: save keeps icons out of `projects.json` + in the
sidecar; load re-attaches; a pre-externalization inline icon migrates on next
save; icon-less projects are omitted. vitest (1513) + tsc -b + eslint green.

Refs #159