### PR TITLE
fix(chat): keep streamed thinking blocks ordered

### DIFF
--- a/agent/dispatcher.test.ts
+++ b/agent/dispatcher.test.ts
@@ -66,6 +66,7 @@ function fakeTabRecord(overrides: Partial<TabRecord> = {}): TabRecord {
     agentEndFired: false,
     queuedCount: 0,
     toolCardSeq: 0,
+    responseMessageSeq: 0,
     ...overrides,
   };
 }

--- a/agent/session-history.test.ts
+++ b/agent/session-history.test.ts
@@ -340,6 +340,70 @@ describe("readSessionTranscript", () => {
     ]);
   });
 
+  it("drops local streamed thinking slices already covered by pi history", async () => {
+    const dir = await tempRoot();
+    await writeFile(
+      join(dir, "session.jsonl"),
+      `${JSON.stringify({
+        type: "message",
+        id: "pi-agent",
+        timestamp: 1779979121365,
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "thinking",
+              thinking:
+                "**Earlier reasoning**\n\nstep one\n\n**Later reasoning**\n\nstep two",
+            },
+          ],
+        },
+      })}\n`,
+    );
+    await appendLocalChatMessage(dir, {
+      id: "text-1779979103491",
+      role: "agent",
+      thinking: "**Later reasoning**\n\nstep two",
+      createdAt: 1779979120970,
+    });
+
+    await expect(readSessionTranscript(dir)).resolves.toEqual([
+      {
+        id: "pi-agent",
+        role: "agent",
+        thinking: "**Earlier reasoning**\n\nstep one\n\n**Later reasoning**\n\nstep two",
+        createdAt: 1779979121365,
+      },
+    ]);
+  });
+
+  it("keeps later local streamed snapshots even when their text appears in earlier pi history", async () => {
+    const dir = await tempRoot();
+    await writeFile(
+      join(dir, "session.jsonl"),
+      `${JSON.stringify({
+        type: "message",
+        id: "pi-agent",
+        timestamp: 1_000,
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "all done" }],
+        },
+      })}\n`,
+    );
+    await appendLocalChatMessage(dir, {
+      id: "text-2",
+      role: "agent",
+      text: "done",
+      createdAt: 2_000,
+    });
+
+    await expect(readSessionTranscript(dir)).resolves.toEqual([
+      { id: "pi-agent", role: "agent", text: "all done", createdAt: 1_000 },
+      { id: "text-2", role: "agent", text: "done", createdAt: 2_000 },
+    ]);
+  });
+
   it("keeps the latest local assistant snapshot for stopped turns", async () => {
     const dir = await tempRoot();
     await appendLocalChatMessage(dir, {

--- a/agent/session-history/parse-pi.ts
+++ b/agent/session-history/parse-pi.ts
@@ -156,11 +156,13 @@ export function parseSessionHistoryLines(
         : `restored-${messages.length}`;
     if ((text || thinking) && !seen.has(id)) {
       seen.add(id);
+      const createdAt = parseMessageTime(record, msg);
       messages.push({
         id,
         role,
         ...(text ? { text: trimText(text) } : {}),
         ...(thinking ? { thinking: trimText(thinking) } : {}),
+        ...(createdAt !== undefined ? { createdAt } : {}),
       });
     }
 

--- a/agent/session-history/restore.ts
+++ b/agent/session-history/restore.ts
@@ -9,7 +9,9 @@
  *  - Dedup of local-chat entries already covered by pi messages
  *
  * The dedupe runs only on local-chat entries to avoid pi-on-pi
- * collisions (pi never replays the same id twice within a file).
+ * collisions (pi never replays the same id twice within a file). Assistant
+ * local content is also considered covered when it is a slice of canonical
+ * pi text/thinking, which filters streaming snapshots from completed turns.
  */
 
 import { readFile } from "node:fs/promises";
@@ -19,13 +21,75 @@ import { readLocalChatTranscript } from "./parse-local";
 import { parseSessionHistoryLines } from "./parse-pi";
 import { MAX_RESTORED_MESSAGES, type RestoredChatMessage } from "./shared";
 
-function comparableMessageText(
-  message: RestoredChatMessage,
-): string | undefined {
-  const value = message.text ?? message.thinking;
+type ContentChannel = "text" | "thinking";
+
+function normalizedMessageText(value: string | undefined): string | undefined {
   if (typeof value !== "string") return undefined;
   const normalized = value.replace(/\s+/g, " ").trim();
   return normalized.length > 0 ? normalized : undefined;
+}
+
+function messageContentParts(
+  message: RestoredChatMessage,
+): Array<[ContentChannel, string]> {
+  const parts: Array<[ContentChannel, string]> = [];
+  const text = normalizedMessageText(message.text);
+  if (text) parts.push(["text", text]);
+  const thinking = normalizedMessageText(message.thinking);
+  if (thinking) parts.push(["thinking", thinking]);
+  return parts;
+}
+
+interface IndexedPiContent {
+  text: string;
+  createdAt?: number;
+}
+
+function piContentIndex(
+  piMessages: RestoredChatMessage[],
+): Map<string, IndexedPiContent[]> {
+  const index = new Map<string, IndexedPiContent[]>();
+  for (const message of piMessages) {
+    for (const [channel, text] of messageContentParts(message)) {
+      const key = `${message.role}\0${channel}`;
+      const existing = index.get(key);
+      const entry = {
+        text,
+        ...(typeof message.createdAt === "number"
+          ? { createdAt: message.createdAt }
+          : {}),
+      };
+      if (existing) existing.push(entry);
+      else index.set(key, [entry]);
+    }
+  }
+  return index;
+}
+
+function isCoveredByPiContent(
+  message: RestoredChatMessage,
+  index: ReadonlyMap<string, IndexedPiContent[]>,
+): boolean {
+  const parts = messageContentParts(message);
+  if (parts.length === 0) return false;
+  return parts.every(([channel, text]) => {
+    const candidates = index.get(`${message.role}\0${channel}`) ?? [];
+    return candidates.some((candidate) => {
+      if (candidate.text === text) return true;
+      // Partial local agent snapshots are only safe to drop when they are
+      // timestamped streaming snapshots that were later finalized into a pi
+      // assistant message. A global substring match against older pi content
+      // can otherwise erase unrelated stopped/crashed-turn snapshots.
+      return (
+        message.role === "agent" &&
+        message.id.startsWith("text-") &&
+        typeof message.createdAt === "number" &&
+        typeof candidate.createdAt === "number" &&
+        message.createdAt <= candidate.createdAt &&
+        candidate.text.includes(text)
+      );
+    });
+  });
 }
 
 function dedupeLocalMessages(
@@ -33,19 +97,10 @@ function dedupeLocalMessages(
   localMessages: RestoredChatMessage[],
 ): RestoredChatMessage[] {
   const seenIds = new Set(piMessages.map((message) => message.id));
-  const seenContent = new Set(
-    piMessages
-      .map((message) => {
-        const text = comparableMessageText(message);
-        return text ? `${message.role}\0${text}` : undefined;
-      })
-      .filter((value): value is string => Boolean(value)),
-  );
+  const contentIndex = piContentIndex(piMessages);
   return localMessages.filter((message) => {
     if (seenIds.has(message.id)) return false;
-    const text = comparableMessageText(message);
-    if (!text) return true;
-    return !seenContent.has(`${message.role}\0${text}`);
+    return !isCoveredByPiContent(message, contentIndex);
   });
 }
 

--- a/agent/state.test.ts
+++ b/agent/state.test.ts
@@ -82,6 +82,7 @@ describe("AethonAgentState", () => {
       agentEndFired: false,
       queuedCount: 0,
       toolCardSeq: 0,
+      responseMessageSeq: 0,
     });
     expect(s.extensionComponents.get("foo")).toEqual({ type: "card" });
     expect(s.tabs.get("default")?.id).toBe("default");

--- a/agent/state.ts
+++ b/agent/state.ts
@@ -237,6 +237,16 @@ export interface TabRecord {
   agentEndFired: boolean;
   queuedCount: number;
   toolCardSeq: number;
+  /** Synthetic assistant message id currently receiving streamed text /
+   *  thinking deltas. Cleared at tool boundaries so post-tool deltas land
+   *  after the tool card instead of amending an earlier bubble. */
+  activeResponseMessageId?: string;
+  /** Canonical pi id (when present) for the active streamed segment. */
+  activeResponseCanonicalId?: string;
+  /** Monotonic per-tab counter used to make synthetic response ids unique
+   *  without trusting pi message_update timestamps (which can refer to an
+   *  earlier transcript record during streaming). */
+  responseMessageSeq: number;
 }
 
 export interface ProjectBaselineSnapshot {

--- a/agent/tab-lifecycle.test.ts
+++ b/agent/tab-lifecycle.test.ts
@@ -60,6 +60,7 @@ function fakeRec(model = "anthropic/claude-x"): TabRecord {
     agentEndFired: false,
     queuedCount: 0,
     toolCardSeq: 0,
+    responseMessageSeq: 0,
   };
 }
 
@@ -452,7 +453,7 @@ describe("handleSessionEvent", () => {
       type: "response_delta",
       tabId: "tab-1",
       content: "hello",
-      messageId: "text-1234",
+      messageId: expect.stringMatching(/^text-\d+-1$/),
       channel: "text",
     });
   });
@@ -469,9 +470,90 @@ describe("handleSessionEvent", () => {
       type: "response_delta",
       tabId: "tab-1",
       content: "plan",
-      messageId: "text-1234",
+      messageId: expect.stringMatching(/^text-\d+-1$/),
       channel: "thinking",
     });
+  });
+
+  it("rolls streamed assistant message ids at tool boundaries", () => {
+    const f = makeFixture();
+    const rec = fakeRec();
+    handleSessionEvent(f.state, f.deps, rec, "tab-1", {
+      type: "message_update",
+      assistantMessageEvent: { type: "thinking_delta", delta: "before" },
+      message: { timestamp: 1111 },
+    });
+    handleSessionEvent(f.state, f.deps, rec, "tab-1", {
+      type: "tool_execution_start",
+      toolCallId: "c1",
+      toolName: "read",
+      args: { path: "a.ts" },
+    });
+    handleSessionEvent(f.state, f.deps, rec, "tab-1", {
+      type: "message_update",
+      assistantMessageEvent: { type: "thinking_delta", delta: "after" },
+      // Regression: pi can report the previous tool/result timestamp here.
+      // The second delta must still allocate a new id so it renders after
+      // the tool card rather than amending the earlier bubble in place.
+      message: { timestamp: 1111 },
+    });
+
+    const deltas = f.sent.filter((m) => m.type === "response_delta");
+    expect(deltas).toHaveLength(2);
+    expect(deltas[0].messageId).toEqual(expect.stringMatching(/^text-\d+-1$/));
+    expect(deltas[1].messageId).toEqual(expect.stringMatching(/^text-\d+-2$/));
+    expect(deltas[1].messageId).not.toBe(deltas[0].messageId);
+  });
+
+  it("uses canonical assistant message ids as segment id source when available", () => {
+    const f = makeFixture();
+    const rec = fakeRec();
+    handleSessionEvent(f.state, f.deps, rec, "tab-1", {
+      type: "message_update",
+      assistantMessageEvent: {
+        type: "text_delta",
+        delta: "hello",
+        messageId: "a0468d98",
+      },
+      message: { timestamp: 1234 },
+    });
+    expect(f.sent[0]).toMatchObject({
+      type: "response_delta",
+      messageId: "text-a0468d98-1",
+    });
+  });
+
+  it("does not reuse canonical assistant ids across tool boundaries", () => {
+    const f = makeFixture();
+    const rec = fakeRec();
+    handleSessionEvent(f.state, f.deps, rec, "tab-1", {
+      type: "message_update",
+      assistantMessageEvent: {
+        type: "thinking_delta",
+        delta: "before",
+        messageId: "assistant-1",
+      },
+    });
+    handleSessionEvent(f.state, f.deps, rec, "tab-1", {
+      type: "tool_execution_start",
+      toolCallId: "c1",
+      toolName: "read",
+      args: { path: "a.ts" },
+    });
+    handleSessionEvent(f.state, f.deps, rec, "tab-1", {
+      type: "message_update",
+      assistantMessageEvent: {
+        type: "thinking_delta",
+        delta: "after",
+        messageId: "assistant-1",
+      },
+    });
+
+    const deltas = f.sent.filter((m) => m.type === "response_delta");
+    expect(deltas.map((m) => m.messageId)).toEqual([
+      "text-assistant-1-1",
+      "text-assistant-1-2",
+    ]);
   });
 
   it("tool_execution_start emits a2ui card and (for bash) a terminal echo", () => {

--- a/agent/tab-lifecycle/events.ts
+++ b/agent/tab-lifecycle/events.ts
@@ -14,6 +14,9 @@
  *    prompt (cf. cancelRunningToolCards in `./tools.ts`).
  *  - `agent_end` always emits `response_end` so the frontend can release
  *    the turn UI, even on error.
+ *  - Streaming assistant text/thinking ids are synthetic per assistant
+ *    segment and roll at tool boundaries; never key them from pi event
+ *    timestamps, which can point at earlier transcript records.
  */
 
 import {
@@ -34,6 +37,59 @@ import { modelKey } from "./utils";
 
 const turnLog = logger.scope("turn");
 
+function assistantEventMessageId(
+  ame: { id?: unknown; messageId?: unknown },
+): string | undefined {
+  if (typeof ame.messageId === "string" && ame.messageId.length > 0) {
+    return ame.messageId;
+  }
+  if (typeof ame.id === "string" && ame.id.length > 0) return ame.id;
+  return undefined;
+}
+
+function safeIdPart(value: string): string {
+  return value.replace(/[^A-Za-z0-9_-]+/g, "-").slice(0, 96) || "assistant";
+}
+
+function startResponseSegment(
+  rec: TabRecord,
+  canonical: string | undefined,
+): string {
+  rec.responseMessageSeq = (rec.responseMessageSeq ?? 0) + 1;
+  rec.activeResponseCanonicalId = canonical;
+  rec.activeResponseMessageId = canonical
+    ? `text-${safeIdPart(canonical)}-${rec.responseMessageSeq}`
+    : `text-${Date.now()}-${rec.responseMessageSeq}`;
+  return rec.activeResponseMessageId;
+}
+
+function responseMessageId(
+  rec: TabRecord,
+  ame: { id?: unknown; messageId?: unknown },
+): string {
+  // Do not derive identity from the outer message_update.message timestamp
+  // (or its surrounding record). In practice that metadata can refer to an
+  // earlier transcript record during streaming, causing later thinking deltas
+  // to amend an older bubble and render above intervening tool cards.
+  const canonical = assistantEventMessageId(ame);
+  if (
+    rec.activeResponseMessageId &&
+    rec.activeResponseCanonicalId === canonical
+  ) {
+    return rec.activeResponseMessageId;
+  }
+  // Even when pi supplies a canonical assistant id, use a segment-scoped UI
+  // id. Some providers use one canonical id for an assistant message that
+  // spans tool calls; reusing it after a tool boundary would amend the
+  // pre-tool bubble above the tool card.
+  return startResponseSegment(rec, canonical);
+}
+
+function rollResponseMessage(rec: TabRecord): void {
+  rec.activeResponseMessageId = undefined;
+  rec.activeResponseCanonicalId = undefined;
+}
+
 /** Per-tab pi session event subscriber. Extracted so tests can drive it
  *  directly with synthetic event payloads. */
 export function handleSessionEvent(
@@ -48,6 +104,7 @@ export function handleSessionEvent(
 ): void {
   switch (event.type) {
     case "agent_start": {
+      rollResponseMessage(rec);
       state.currentAgentTabId = tabId;
       state.turnStartTimes.set(tabId, Date.now());
       const model = rec.session.model ? modelKey(rec.session.model) : "unknown";
@@ -84,14 +141,10 @@ export function handleSessionEvent(
       ) {
         const delta = ame.delta ?? "";
         if (delta) {
-          const ts =
-            (event as { message?: { timestamp?: number } }).message
-              ?.timestamp ?? 0;
-          const messageId = `text-${ts}`;
           deps.send({
             type: "response_delta",
             tabId,
-            messageId,
+            messageId: responseMessageId(rec, ame),
             content: delta,
             channel,
           });
@@ -121,6 +174,7 @@ export function handleSessionEvent(
         startedAt,
       });
       deps.send({ type: "a2ui", tabId, id: uiId, payload });
+      rollResponseMessage(rec);
       if (ev.toolName === "bash") {
         const cmd = String(
           (ev.args as { command?: unknown } | undefined)?.command ?? "",
@@ -195,6 +249,7 @@ export function handleSessionEvent(
         deps.send({ type: "terminal_output", tabId, content: "\r\n" });
       }
       rec.toolArgsCache.delete(ev.toolCallId);
+      rollResponseMessage(rec);
       break;
     }
     case "agent_end": {
@@ -235,6 +290,7 @@ export function handleSessionEvent(
         if (state.currentAgentTabId === tabId) {
           state.currentAgentTabId = undefined;
         }
+        rollResponseMessage(rec);
         deps.send({ type: "response_end", tabId });
       }
       break;
@@ -274,6 +330,7 @@ export function handleSessionEvent(
         if (state.currentAgentTabId === tabId) {
           state.currentAgentTabId = undefined;
         }
+        rollResponseMessage(rec);
         deps.send({ type: "response_end", tabId });
       }
       break;

--- a/agent/tab-lifecycle/lifecycle.ts
+++ b/agent/tab-lifecycle/lifecycle.ts
@@ -135,6 +135,7 @@ export async function ensureTab(
     agentEndFired: false,
     queuedCount: 0,
     toolCardSeq: 0,
+    responseMessageSeq: 0,
   };
   state.tabs.set(tabId, rec);
   refreshPiSlashCommands(state, session);

--- a/src/hooks/bridgeMessageHandlers/a2ui.test.ts
+++ b/src/hooks/bridgeMessageHandlers/a2ui.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { handleA2ui } from "./a2ui";
+import { handleResponseDelta } from "./responseDelta";
 import { buildHandlerFixture } from "./testFixtures";
 import { makeEmptyTab } from "../../types/tab";
 import type { ChatMessage } from "../../types/a2ui";
@@ -27,6 +28,39 @@ describe("handleA2ui", () => {
     const [, updater] = mocks.updateTab.mock.calls[0];
     expect(updater(makeEmptyTab("default", "Tab 1")).waiting).toBe(false);
     expect(mocks.setStatusFlags).toHaveBeenCalledWith({ status: "ready" });
+  });
+
+  it("flushes pending streamed deltas before appending an a2ui bubble", () => {
+    const { ctx, mocks } = buildHandlerFixture({
+      state: { activeTabId: "tab-1" },
+    });
+    handleResponseDelta(
+      {
+        type: "response_delta",
+        content: "before tool",
+        messageId: "msg-1",
+        tabId: "tab-1",
+        channel: "thinking",
+      },
+      ctx,
+    );
+
+    const payload = { components: [{ id: "tool-1", type: "tool-card" }] };
+    handleA2ui({ type: "a2ui", payload, id: "tool-1", tabId: "tab-1" }, ctx);
+
+    expect(mocks.appendOrAmendAgentText).toHaveBeenCalledWith(
+      "before tool",
+      "msg-1",
+      "tab-1",
+      "thinking",
+    );
+    expect(mocks.appendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "tool-1", role: "agent", a2ui: payload }),
+      "tab-1",
+    );
+    expect(
+      mocks.appendOrAmendAgentText.mock.invocationCallOrder[0],
+    ).toBeLessThan(mocks.appendMessage.mock.invocationCallOrder[0]);
   });
 
   it("replaces a stale running terminal tool card when the final event has a sibling id", () => {

--- a/src/hooks/bridgeMessageHandlers/a2ui.ts
+++ b/src/hooks/bridgeMessageHandlers/a2ui.ts
@@ -2,6 +2,7 @@ import type { A2UIPayload } from "../../types/a2ui";
 import type { Tab } from "../../types/tab";
 import { toolCardIdentityFromId } from "../../utils/toolCardIdentity";
 import type { BridgeMessageHandler } from "./types";
+import { flushResponseDeltas } from "./responseDelta";
 
 function completedToolCardIdentity(payload: A2UIPayload): string | undefined {
   const toolCards = (payload.components ?? []).filter(
@@ -38,6 +39,10 @@ export const handleA2ui: BridgeMessageHandler = (data, ctx) => {
   const payload = data.payload as A2UIPayload | undefined;
   const id = (data.id as string) || crypto.randomUUID();
   const tabId = (data.tabId as string | undefined) ?? "default";
+  // Tool cards / A2UI payloads are appended synchronously, while streamed
+  // response deltas are frame-batched. Drain this tab's pending deltas first
+  // so any pre-tool assistant text/thinking renders before the tool card.
+  flushResponseDeltas(tabId);
   if (payload) {
     const tabs = (ctx.stateRef.current.tabs as Tab[] | undefined) ?? [];
     const tab = tabs.find((t) => t.id === tabId);

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -124,9 +124,10 @@ export function useChat(ctx: UseChatContext): UseChatActions {
   } = ctx;
 
   // Fallback id for text bubbles when the bridge doesn't supply one. The
-  // bridge now sends a stable `messageId` per pi assistant message so text
-  // deltas after a tool card still land in the original bubble; this ref
-  // only matters for old-bridge / legacy `response_delta` payloads.
+  // bridge sends a stable `messageId` for the active streamed assistant
+  // segment and rolls it at tool boundaries so later deltas do not amend an
+  // earlier bubble above intervening tool cards. This ref only matters for
+  // old-bridge / legacy `response_delta` payloads.
   const activeResponseIdRef = useRef<string | null>(null);
   // P4: per-tab turn start timestamps. Set on `prompt_started`, cleared
   // on `response_end`. Used to compute turn duration for the OS
@@ -156,10 +157,10 @@ export function useChat(ctx: UseChatContext): UseChatActions {
   }
 
   // Append a streaming text delta to its bubble. When the bridge supplies a
-  // stable `messageId` (one per pi assistant message), look up the bubble by
-  // id anywhere in the array — this keeps text from a single agent message in
-  // one bubble even after tool cards land between deltas. Without a messageId
-  // (legacy bridges), fall back to the previous "is it the last message?"
+  // stable `messageId`, look up the bubble by id anywhere in the array —
+  // this keeps deltas for one streamed assistant segment in one bubble while
+  // allowing the bridge to start a fresh bubble after tool cards. Without a
+  // messageId (legacy bridges), fall back to the previous "is it the last message?"
   // behavior tracked via activeResponseIdRef.
   function appendOrAmendAgentText(
     delta: string,


### PR DESCRIPTION
## Summary

Fixes #148.

This PR fixes streamed thinking/text blocks rendering out of order around tool cards and prevents restored sessions from appending duplicate local-only thinking snapshots at the end.

## What changed

- Stop using `message_update.message.timestamp` as the streaming assistant UI identity.
  - That timestamp can refer to an earlier transcript record and cause later thinking deltas to amend an older bubble in-place.
- Track a per-tab active streamed assistant segment id in the bridge.
  - Segment ids roll at agent start, tool boundaries, and response end.
  - Canonical assistant ids from pi are used only as a stable segment source, not as a reusable UI id across tool boundaries.
- Flush pending frame-batched response deltas before synchronous A2UI/tool-card inserts.
  - This preserves the live ordering of pre-tool thinking/text before the tool card.
- Improve restore dedupe for Aethon-local streamed assistant snapshots.
  - Drops timestamped local streamed snapshots only when their text/thinking is later covered by canonical pi history.
  - Preserves unrelated stopped/crashed-turn local snapshots even if their text appears in older pi content.
- Preserve pi assistant message timestamps as `createdAt` during parse, enabling safer restore dedupe.
- Added regression coverage for:
  - Tool-boundary response id rolling.
  - Canonical id segmentation across tool boundaries.
  - A2UI boundary flushing of pending deltas.
  - Restore filtering of local thinking slices.
  - Keeping later unrelated local snapshots.

## Validation

- `bun run typecheck`
- `bunx vitest run agent/tab-lifecycle.test.ts agent/session-history.test.ts src/hooks/bridgeMessageHandlers/a2ui.test.ts src/hooks/bridgeMessageHandlers/responseDelta.test.ts src/hooks/bridgeMessageHandlers/sessionHistory.test.ts --environment jsdom`
- `bun run lint` — no errors; existing unrelated React hook warnings remain.
- Codex peer review run after fixes; final review reported no findings.
