### PR TITLE
fix(chat): contain horizontal overflow in chat window

### DIFF
--- a/e2e/aethon.spec.ts
+++ b/e2e/aethon.spec.ts
@@ -166,10 +166,15 @@ test("chat canvas contains wide content without horizontal scrolling", async ({
     .evaluate((el) => ({ overflowX: getComputedStyle(el).overflowX }));
   expect(scrollerMetrics.overflowX).toBe("hidden");
 
-  const codeMetrics = await page.locator(".a2ui-code").last().evaluate((el) => ({
-    clientWidth: el.clientWidth,
-    scrollWidth: el.scrollWidth,
-  }));
+  await page.locator(".ae-tool-card-summary").click();
+  await expect(page.locator(".ae-tool-card[open] .a2ui-code")).toBeVisible();
+
+  const codeMetrics = await page
+    .locator(".ae-tool-card[open] .a2ui-code")
+    .evaluate((el) => ({
+      clientWidth: el.clientWidth,
+      scrollWidth: el.scrollWidth,
+    }));
   expect(codeMetrics.scrollWidth).toBeGreaterThan(codeMetrics.clientWidth);
 });
 

--- a/e2e/aethon.spec.ts
+++ b/e2e/aethon.spec.ts
@@ -92,6 +92,87 @@ test("boots the real app shell through mocked Tauri IPC", async ({ page }) => {
   );
 });
 
+test("chat canvas contains wide content without horizontal scrolling", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 900, height: 700 });
+  await waitForAethonReady(page);
+
+  await page.getByRole("button", { name: "New Tab" }).click();
+  await expect(page.locator(".a2ui-chat-input-field")).toBeVisible();
+
+  const tabId = await page.evaluate(
+    () => window.__AETHON_STATE__?.().activeTabId ?? "default",
+  );
+  const longToken = "0123456789abcdef".repeat(220);
+  const wideMarkdown = [
+    `Long URL: https://example.com/${longToken}`,
+    "",
+    "| path | value |",
+    "| --- | --- |",
+    `| ${longToken} | ${longToken} |`,
+    "",
+    "```typescript",
+    `const value = "${longToken}";`,
+    "```",
+  ].join("\n");
+
+  await page.evaluate(
+    ({ tabId: activeTabId, longToken: token, wideMarkdown: markdown }) => {
+      window.__AETHON_E2E__?.emitAgent({
+        type: "response",
+        tabId: activeTabId,
+        content: markdown,
+        done: true,
+      });
+      window.__AETHON_E2E__?.emitAgent({
+        type: "a2ui",
+        tabId: activeTabId,
+        id: "wide-tool",
+        done: true,
+        payload: {
+          components: [
+            {
+              id: "tool-wide",
+              type: "tool-card",
+              props: {
+                title: "bash",
+                description: token,
+                startedAt: 1,
+                endedAt: 2,
+              },
+              children: [
+                {
+                  id: "tool-code-wide",
+                  type: "code",
+                  props: {
+                    content: `const value = "${token}";`,
+                    language: "typescript",
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      });
+    },
+    { tabId, longToken, wideMarkdown },
+  );
+
+  await expect(page.locator(".a2ui-canvas-message")).toHaveCount(2);
+
+  const scrollerMetrics = await page
+    .locator(".a2ui-canvas-scroller")
+    .evaluate((el) => ({ overflowX: getComputedStyle(el).overflowX }));
+  expect(scrollerMetrics.overflowX).toBe("hidden");
+
+  const codeMetrics = await page.locator(".a2ui-code").last().evaluate((el) => ({
+    clientWidth: el.clientWidth,
+    scrollWidth: el.scrollWidth,
+  }));
+  expect(codeMetrics.scrollWidth).toBeGreaterThan(codeMetrics.clientWidth);
+});
+
 test("queues normal Enter messages behind an in-flight turn and drains cleanly", async ({
   page,
 }) => {

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -1902,6 +1902,9 @@ body.ae-resizing-sidebar .a2ui-layout {
 }
 
 .a2ui-canvas-scroller {
+  min-width: 0;
+  max-width: 100%;
+  overflow-x: hidden;
   overscroll-behavior: none;
   padding: 16px 20px 12px;
   background: var(--bg);
@@ -2423,8 +2426,12 @@ body.ae-resizing-sidebar .a2ui-layout {
   opacity: 0.55;
 }
 
+.a2ui-chat-text,
 .a2ui-canvas-text {
+  min-width: 0;
+  max-width: 100%;
   white-space: pre-wrap;
+  overflow-wrap: anywhere;
   word-break: break-word;
 }
 
@@ -2435,6 +2442,7 @@ body.ae-resizing-sidebar .a2ui-layout {
   line-height: 1.55;
   min-width: 0;
   max-width: 100%;
+  overflow-wrap: anywhere;
 }
 .a2ui-markdown > :first-child {
   margin-top: 0;
@@ -2475,6 +2483,11 @@ body.ae-resizing-sidebar .a2ui-layout {
   margin: 0.15em 0;
 }
 
+.a2ui-markdown img {
+  max-width: 100%;
+  height: auto;
+}
+
 .a2ui-markdown code {
   /* Inline code sits over running prose, so the tint is intentionally
      warm-leaning — it nudges the eye toward the syntax-highlighted
@@ -2495,8 +2508,9 @@ body.ae-resizing-sidebar .a2ui-layout {
   background: var(--bg-input);
   border: 1px solid var(--border);
   border-radius: 6px;
-  overflow-x: auto;
+  min-width: 0;
   max-width: 100%;
+  overflow-x: auto;
 }
 .a2ui-markdown pre code {
   background: transparent;
@@ -2516,13 +2530,14 @@ body.ae-resizing-sidebar .a2ui-layout {
   background: var(--bg-input);
   border: 1px solid var(--border);
   border-radius: 6px;
+  min-width: 0;
+  max-width: 100%;
   overflow-x: auto;
   font-family: var(--font-mono);
   font-size: var(--text-sm);
   line-height: 1.5;
   color: var(--syntax-text, var(--text));
   white-space: pre;
-  max-width: 100%;
 }
 .a2ui-code code {
   background: transparent;
@@ -2674,6 +2689,9 @@ body.ae-resizing-sidebar .a2ui-layout {
 }
 
 .a2ui-markdown table {
+  display: block;
+  max-width: 100%;
+  overflow-x: auto;
   border-collapse: collapse;
   margin: 0.5em 0;
 }
@@ -2681,6 +2699,7 @@ body.ae-resizing-sidebar .a2ui-layout {
 .a2ui-markdown td {
   border: 1px solid var(--border);
   padding: 4px 8px;
+  overflow-wrap: anywhere;
 }
 .a2ui-markdown th {
   background: var(--bg-input);
@@ -2740,13 +2759,18 @@ body.ae-resizing-sidebar .a2ui-layout {
   flex-direction: column;
   flex: 1;
   min-width: 0;
+  max-width: 100%;
   min-height: 0;
+  overflow-x: hidden;
 }
 
 /* Standalone chat-history (used when sidebars or panels need a feed). With
    virtualization this class lands on Virtuoso's scroller; Virtuoso supplies
    the overflow + height, so we only add chrome (padding, no-bounce). */
 .a2ui-chat-history {
+  min-width: 0;
+  max-width: 100%;
+  overflow-x: hidden;
   overscroll-behavior: none;
   padding: 12px 12px 8px;
   contain: layout style;
@@ -2758,7 +2782,9 @@ body.ae-resizing-sidebar .a2ui-layout {
   flex-direction: column;
   flex: 1;
   min-width: 0;
+  max-width: 100%;
   min-height: 0;
+  overflow-x: hidden;
   overflow-y: auto;
 }
 
@@ -2772,6 +2798,9 @@ body.ae-resizing-sidebar .a2ui-layout {
 .a2ui-msg-row {
   display: flex;
   flex-direction: column;
+  min-width: 0;
+  max-width: 100%;
+  overflow-x: hidden;
 }
 
 .a2ui-chat-load-older {

--- a/src/styles/scrollbar.test.ts
+++ b/src/styles/scrollbar.test.ts
@@ -55,3 +55,41 @@ describe("terminal overflow containment CSS", () => {
     );
   });
 });
+
+describe("chat overflow containment CSS", () => {
+  it("prevents the chat scroller from owning horizontal overflow", () => {
+    const canvasScroller = cssRuleBody(chromeCss, ".a2ui-canvas-scroller");
+    expect(canvasScroller).toMatch(/min-width:\s*0;/);
+    expect(canvasScroller).toMatch(/max-width:\s*100%;/);
+    expect(canvasScroller).toMatch(/overflow-x:\s*hidden;/);
+
+    const chatHistory = cssRuleBody(chromeCss, ".a2ui-chat-history");
+    expect(chatHistory).toMatch(/min-width:\s*0;/);
+    expect(chatHistory).toMatch(/max-width:\s*100%;/);
+    expect(chatHistory).toMatch(/overflow-x:\s*hidden;/);
+
+    const row = cssRuleBody(chromeCss, ".a2ui-msg-row");
+    expect(row).toMatch(/min-width:\s*0;/);
+    expect(row).toMatch(/max-width:\s*100%;/);
+  });
+
+  it("wraps prose while keeping code and tables constrained locally", () => {
+    expect(chromeCss).toMatch(
+      /\.a2ui-chat-text,\s*\.a2ui-canvas-text\s*\{[\s\S]*?overflow-wrap:\s*anywhere;/,
+    );
+
+    const markdownTable = cssRuleBody(chromeCss, ".a2ui-markdown table");
+    expect(markdownTable).toMatch(/display:\s*block;/);
+    expect(markdownTable).toMatch(/max-width:\s*100%;/);
+    expect(markdownTable).toMatch(/overflow-x:\s*auto;/);
+
+    const markdownImage = cssRuleBody(chromeCss, ".a2ui-markdown img");
+    expect(markdownImage).toMatch(/max-width:\s*100%;/);
+    expect(markdownImage).toMatch(/height:\s*auto;/);
+
+    const codeBlock = cssRuleBody(chromeCss, ".a2ui-code");
+    expect(codeBlock).toMatch(/min-width:\s*0;/);
+    expect(codeBlock).toMatch(/max-width:\s*100%;/);
+    expect(codeBlock).toMatch(/overflow-x:\s*auto;/);
+  });
+});


### PR DESCRIPTION
## Summary
- Prevent chat/canvas scrollers and virtualized message rows from owning horizontal overflow
- Wrap long chat prose and constrain markdown images/tables/code blocks so wide embedded content scrolls locally
- Add regression coverage for wide URLs, markdown tables, code blocks, and tool-card content

Closes #169.

## Validation
- bunx vitest run src/styles/scrollbar.test.ts
- bunx playwright test e2e/aethon.spec.ts -g "chat canvas contains wide content"
- bun run typecheck
- bun run lint (0 errors; existing unrelated react-hooks warnings remain)