### PR TITLE
Fix chat image persistence, sticky scroll, and worktree launch polish

### DIFF
--- a/agent/chat.ts
+++ b/agent/chat.ts
@@ -1,4 +1,4 @@
-import type { Api, Model } from "@mariozechner/pi-ai";
+import type { Api, ImageContent, Model } from "@mariozechner/pi-ai";
 import type { AethonAgentState } from "./state";
 import type { DispatcherDeps, InboundMessage } from "./dispatcherTypes";
 import { maybeExitForReload } from "./dispatcherTypes";
@@ -37,11 +37,14 @@ export async function handleChat(
     cwdOverride || initialModel ? { cwdOverride, initialModel } : {},
   );
   const wantsSteer = msg.mode === "steer";
+  const images = normalizeImages(msg.images);
   if (wantsSteer && tab.promptInFlight) {
     state.currentAgentTabId = tabId;
     const content = msg.content;
     state.tabContext
-      .run(tabId, () => tab.session.steer(content))
+      .run(tabId, () =>
+        images.length > 0 ? tab.session.steer(content, images) : tab.session.steer(content),
+      )
       .catch((err: unknown) => {
         const message = err instanceof Error ? err.message : String(err);
         deps.send({ type: "error", tabId, message: `steer: ${message}` });
@@ -53,7 +56,11 @@ export async function handleChat(
     tab.queuedCount += 1;
     const content = msg.content;
     state.tabContext
-      .run(tabId, () => tab.session.followUp(content))
+      .run(tabId, () =>
+        images.length > 0
+          ? tab.session.followUp(content, images)
+          : tab.session.followUp(content),
+      )
       .catch((err: unknown) => {
         tab.queuedCount = Math.max(0, tab.queuedCount - 1);
         const message = err instanceof Error ? err.message : String(err);
@@ -73,7 +80,11 @@ export async function handleChat(
   state.currentAgentTabId = tabId;
   const content = msg.content;
   state.tabContext
-    .run(tabId, () => tab.session.prompt(content))
+    .run(tabId, () =>
+      images.length > 0
+        ? tab.session.prompt(content, { images })
+        : tab.session.prompt(content),
+    )
     .catch((err: unknown) => {
       const message = err instanceof Error ? err.message : String(err);
       deps.send({ type: "error", tabId, message: `prompt: ${message}` });
@@ -88,6 +99,23 @@ export async function handleChat(
       }
       maybeExitForReload(state, deps);
     });
+}
+
+function normalizeImages(images: InboundMessage["images"]): ImageContent[] {
+  if (!Array.isArray(images)) return [];
+  return images
+    .filter(
+      (image): image is { mimeType: string; data: string } =>
+        typeof image?.mimeType === "string" &&
+        image.mimeType.startsWith("image/") &&
+        typeof image.data === "string" &&
+        image.data.length > 0,
+    )
+    .map((image) => ({
+      type: "image" as const,
+      mimeType: image.mimeType,
+      data: image.data,
+    }));
 }
 
 export async function handleSetModel(

--- a/agent/dispatcher.test.ts
+++ b/agent/dispatcher.test.ts
@@ -351,6 +351,67 @@ describe("handleChat", () => {
     expect(f.sent).not.toContainEqual({ type: "queued", tabId: "tab-1" });
   });
 
+  it("passes image attachments to prompt, steer, and followUp", async () => {
+    const image = { mimeType: "image/png", data: "abc123" };
+    const f = makeFixture();
+    const calls: Record<string, unknown[][]> = {
+      prompt: [],
+      steer: [],
+      followUp: [],
+    };
+    const tab = fakeTabRecord({
+      session: {
+        prompt: (...args: unknown[]) => {
+          calls.prompt.push(args);
+          return new Promise<void>(() => {});
+        },
+        followUp: (...args: unknown[]) => {
+          calls.followUp.push(args);
+          return Promise.resolve();
+        },
+        steer: (...args: unknown[]) => {
+          calls.steer.push(args);
+          return Promise.resolve();
+        },
+      } as unknown as TabRecord["session"],
+    });
+    f.state.tabs.set("tab-1", tab);
+
+    await handleChat(f.state, f.deps, {
+      type: "chat",
+      content: "look",
+      tabId: "tab-1",
+      mode: "normal",
+      images: [image],
+    });
+
+    expect(calls.prompt).toEqual([
+      ["look", { images: [{ type: "image", mimeType: "image/png", data: "abc123" }] }],
+    ]);
+
+    await handleChat(f.state, f.deps, {
+      type: "chat",
+      content: "zoom",
+      tabId: "tab-1",
+      mode: "steer",
+      images: [image],
+    });
+    await handleChat(f.state, f.deps, {
+      type: "chat",
+      content: "next",
+      tabId: "tab-1",
+      mode: "normal",
+      images: [image],
+    });
+
+    expect(calls.steer).toEqual([
+      ["zoom", [{ type: "image", mimeType: "image/png", data: "abc123" }]],
+    ]);
+    expect(calls.followUp).toEqual([
+      ["next", [{ type: "image", mimeType: "image/png", data: "abc123" }]],
+    ]);
+  });
+
   it("treats steer as a normal prompt when the tab is idle", async () => {
     const f = makeFixture();
     const promptCalls: unknown[][] = [];

--- a/agent/dispatcherTypes.ts
+++ b/agent/dispatcherTypes.ts
@@ -26,6 +26,12 @@ export interface DispatcherDeps {
 export interface InboundMessage {
   type: string;
   content?: string;
+  images?: {
+    id?: string;
+    name?: string;
+    mimeType: string;
+    data: string;
+  }[];
   mode?: "normal" | "steer";
   cwd?: string;
   model?: string;

--- a/agent/session-history.test.ts
+++ b/agent/session-history.test.ts
@@ -380,6 +380,57 @@ describe("readSessionTranscript", () => {
     ]);
   });
 
+  it("merges local attachment metadata into matching pi user messages", async () => {
+    const dir = await tempRoot();
+    await writeFile(
+      join(dir, "session.jsonl"),
+      `${JSON.stringify({
+        type: "message",
+        id: "pi-user",
+        timestamp: 1_500,
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "what is this?" }],
+        },
+      })}\n`,
+    );
+    await appendLocalChatMessage(dir, {
+      id: "local-user",
+      role: "user",
+      text: "what is this?",
+      attachments: [
+        {
+          id: "img-1",
+          kind: "image",
+          path: "/tmp/aethon-pastes/one.png",
+          name: "one.png",
+          mimeType: "image/png",
+          sizeBytes: 12,
+        },
+      ],
+      createdAt: 1_000,
+    });
+
+    await expect(readSessionTranscript(dir)).resolves.toEqual([
+      {
+        id: "pi-user",
+        role: "user",
+        text: "what is this?",
+        createdAt: 1_500,
+        attachments: [
+          {
+            id: "img-1",
+            kind: "image",
+            path: "/tmp/aethon-pastes/one.png",
+            name: "one.png",
+            mimeType: "image/png",
+            sizeBytes: 12,
+          },
+        ],
+      },
+    ]);
+  });
+
   it("does not duplicate local prompt snapshots already present in pi history", async () => {
     const dir = await tempRoot();
     const path = join(dir, "session.jsonl");

--- a/agent/session-history.test.ts
+++ b/agent/session-history.test.ts
@@ -22,7 +22,9 @@ async function tempRoot(): Promise<string> {
 }
 
 afterEach(async () => {
-  await Promise.all(roots.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  await Promise.all(
+    roots.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+  );
 });
 
 describe("parseSessionHistoryLines", () => {
@@ -259,7 +261,10 @@ describe("readSessionTranscript", () => {
       `${JSON.stringify({
         type: "message",
         id: "new",
-        message: { role: "assistant", content: [{ type: "text", text: "new" }] },
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "new" }],
+        },
       })}\n`,
     );
     await utimes(oldPath, new Date(1_000), new Date(1_000));
@@ -302,6 +307,75 @@ describe("readSessionTranscript", () => {
         role: "system",
         text: "## Context",
         createdAt: 2,
+      },
+    ]);
+  });
+
+  it("restores local image attachments from the durable chat log", async () => {
+    const dir = await tempRoot();
+    await appendLocalChatMessage(dir, {
+      id: "image-only",
+      role: "user",
+      attachments: [
+        {
+          id: "img-1",
+          kind: "image",
+          path: "/tmp/aethon-pastes/one.png",
+          name: "one.png",
+          mimeType: "image/png",
+          sizeBytes: 12,
+        },
+      ],
+      createdAt: 1,
+    });
+
+    await expect(readSessionTranscript(dir)).resolves.toEqual([
+      {
+        id: "image-only",
+        role: "user",
+        attachments: [
+          {
+            id: "img-1",
+            kind: "image",
+            path: "/tmp/aethon-pastes/one.png",
+            name: "one.png",
+            mimeType: "image/png",
+            sizeBytes: 12,
+          },
+        ],
+        createdAt: 1,
+      },
+    ]);
+  });
+
+  it("drops non-durable preview URLs from local attachment history", async () => {
+    const dir = await tempRoot();
+    const attachmentWithPreview = {
+      id: "img-1",
+      kind: "image" as const,
+      path: "/tmp/aethon-pastes/one.png",
+      name: "one.png",
+      mimeType: "image/png",
+      sizeBytes: 12,
+      previewUrl: "blob:temp",
+    };
+    await appendLocalChatMessage(dir, {
+      id: "image-with-preview",
+      role: "user",
+      text: "see this",
+      attachments: [attachmentWithPreview],
+      createdAt: 1,
+    });
+
+    const transcript = await readSessionTranscript(dir);
+    expect(transcript[0].attachments).toEqual([
+      {
+        id: "img-1",
+        kind: "image",
+        path: "/tmp/aethon-pastes/one.png",
+        name: "one.png",
+        mimeType: "image/png",
+        sizeBytes: 12,
       },
     ]);
   });
@@ -371,7 +445,8 @@ describe("readSessionTranscript", () => {
       {
         id: "pi-agent",
         role: "agent",
-        thinking: "**Earlier reasoning**\n\nstep one\n\n**Later reasoning**\n\nstep two",
+        thinking:
+          "**Earlier reasoning**\n\nstep one\n\n**Later reasoning**\n\nstep two",
         createdAt: 1779979121365,
       },
     ]);
@@ -536,31 +611,53 @@ describe("readSessionTranscript with expectedCwd", () => {
 
   it("returns the matching project's session, not the latest by mtime", async () => {
     const dir = await tempRoot();
-    await writeMiniSession(dir, "old.jsonl", "/tmp/target", "from target", 1_000);
-    await writeMiniSession(dir, "leak.jsonl", "/tmp/other", "from other", 9_000);
+    await writeMiniSession(
+      dir,
+      "old.jsonl",
+      "/tmp/target",
+      "from target",
+      1_000,
+    );
+    await writeMiniSession(
+      dir,
+      "leak.jsonl",
+      "/tmp/other",
+      "from other",
+      9_000,
+    );
     // Without the cwd filter the latest mtime ("leak.jsonl") wins.
     await expect(readSessionTranscript(dir)).resolves.toEqual([
       { id: "leak.jsonl-u", role: "user", text: "from other" },
     ]);
     // With the cwd filter, the older matching session is returned.
-    await expect(
-      readSessionTranscript(dir, "/tmp/target"),
-    ).resolves.toEqual([
+    await expect(readSessionTranscript(dir, "/tmp/target")).resolves.toEqual([
       { id: "old.jsonl-u", role: "user", text: "from target" },
     ]);
   });
 
   it("returns no messages when no session matches the requested cwd", async () => {
     const dir = await tempRoot();
-    await writeMiniSession(dir, "other.jsonl", "/tmp/other", "from other", 1_000);
-    await expect(
-      readSessionTranscript(dir, "/tmp/target"),
-    ).resolves.toEqual([]);
+    await writeMiniSession(
+      dir,
+      "other.jsonl",
+      "/tmp/other",
+      "from other",
+      1_000,
+    );
+    await expect(readSessionTranscript(dir, "/tmp/target")).resolves.toEqual(
+      [],
+    );
   });
 
   it("filters Aethon-local slash overlay by cwd when restoring a scoped session", async () => {
     const dir = await tempRoot();
-    await writeMiniSession(dir, "target.jsonl", "/tmp/target", "from target", 1_000);
+    await writeMiniSession(
+      dir,
+      "target.jsonl",
+      "/tmp/target",
+      "from target",
+      1_000,
+    );
     await appendLocalChatMessage(dir, {
       id: "target-local",
       role: "system",
@@ -576,9 +673,7 @@ describe("readSessionTranscript with expectedCwd", () => {
       createdAt: 2,
     });
 
-    await expect(
-      readSessionTranscript(dir, "/tmp/target"),
-    ).resolves.toEqual([
+    await expect(readSessionTranscript(dir, "/tmp/target")).resolves.toEqual([
       { id: "target.jsonl-u", role: "user", text: "from target" },
       {
         id: "target-local",
@@ -607,9 +702,7 @@ describe("readSessionTranscript with expectedCwd", () => {
       createdAt: 2,
     });
 
-    await expect(
-      readSessionTranscript(dir, "/tmp/target"),
-    ).resolves.toEqual([
+    await expect(readSessionTranscript(dir, "/tmp/target")).resolves.toEqual([
       {
         id: "target-local",
         role: "system",
@@ -630,11 +723,17 @@ describe("readSessionTranscript with expectedCwd", () => {
     // next prompt loses the displayed context. Caller in main.ts now
     // passes `process.cwd()` (not `undefined`) when no project is set.
     const dir = await tempRoot();
-    await writeMiniSession(dir, "other.jsonl", "/tmp/other", "from other", 9_000);
+    await writeMiniSession(
+      dir,
+      "other.jsonl",
+      "/tmp/other",
+      "from other",
+      9_000,
+    );
     // Caller's no-project fallback (== `activeProjectCwd ?? process.cwd()`).
-    await expect(
-      readSessionTranscript(dir, process.cwd()),
-    ).resolves.toEqual([]);
+    await expect(readSessionTranscript(dir, process.cwd())).resolves.toEqual(
+      [],
+    );
   });
 });
 
@@ -679,17 +778,17 @@ describe("findSessionFileMatchingCwd", () => {
     const newer = await writeSession(dir, "new.jsonl", "/tmp/target", 3_000);
     // A more recent session for a *different* cwd must not be picked.
     await writeSession(dir, "leak.jsonl", "/tmp/other-project", 9_000);
-    await expect(
-      findSessionFileMatchingCwd(dir, "/tmp/target"),
-    ).resolves.toBe(newer);
+    await expect(findSessionFileMatchingCwd(dir, "/tmp/target")).resolves.toBe(
+      newer,
+    );
   });
 
   it("ignores trailing slashes when comparing cwds", async () => {
     const dir = await tempRoot();
     const path = await writeSession(dir, "a.jsonl", "/tmp/project/", 1_000);
-    await expect(
-      findSessionFileMatchingCwd(dir, "/tmp/project"),
-    ).resolves.toBe(path);
+    await expect(findSessionFileMatchingCwd(dir, "/tmp/project")).resolves.toBe(
+      path,
+    );
   });
 
   it("skips legacy session files that have no cwd in the header", async () => {
@@ -698,9 +797,9 @@ describe("findSessionFileMatchingCwd", () => {
     await writeSession(dir, "legacy.jsonl", undefined, 5_000);
     await expect(findSessionFileMatchingCwd(dir, "")).resolves.toBeUndefined();
     const fresh = await writeSession(dir, "fresh.jsonl", "/tmp/target", 1_000);
-    await expect(
-      findSessionFileMatchingCwd(dir, "/tmp/target"),
-    ).resolves.toBe(fresh);
+    await expect(findSessionFileMatchingCwd(dir, "/tmp/target")).resolves.toBe(
+      fresh,
+    );
   });
 
   it("does not leak the most-recent session from another project (regression)", async () => {

--- a/agent/session-history/index.ts
+++ b/agent/session-history/index.ts
@@ -22,7 +22,12 @@
  * barrel resolves their imports to the directory's index.
  */
 
-export type { RestoredChatMessage, SessionLogMetadata } from "./shared";
+export type {
+  RestoredChatAttachment,
+  RestoredChatMessage,
+  SessionLogMetadata,
+} from "./shared";
+export { parseChatAttachments } from "./shared";
 export { parseSessionHistoryLines } from "./parse-pi";
 export {
   appendLocalChatMessage,

--- a/agent/session-history/io.ts
+++ b/agent/session-history/io.ts
@@ -27,6 +27,7 @@ import {
   type RestoredChatMessage,
   hasA2ui,
   isChatRole,
+  parseChatAttachments,
   trimText,
 } from "./shared";
 
@@ -83,8 +84,9 @@ export async function appendLocalChatMessage(
   const text = typeof message.text === "string" ? trimText(message.text) : "";
   const thinking =
     typeof message.thinking === "string" ? trimText(message.thinking) : "";
+  const attachments = parseChatAttachments(message.attachments);
   const a2ui = hasA2ui(message.a2ui) ? message.a2ui : undefined;
-  if (!text && !thinking && !a2ui) return;
+  if (!text && !thinking && !a2ui && attachments.length === 0) return;
   await mkdir(sessionDir, { recursive: true });
   const entry = {
     type: "aethon_chat",
@@ -92,9 +94,11 @@ export async function appendLocalChatMessage(
     role: message.role,
     ...(text ? { text } : {}),
     ...(thinking ? { thinking } : {}),
+    ...(attachments.length > 0 ? { attachments } : {}),
     ...(a2ui ? { a2ui } : {}),
     createdAt:
-      typeof message.createdAt === "number" && Number.isFinite(message.createdAt)
+      typeof message.createdAt === "number" &&
+      Number.isFinite(message.createdAt)
         ? message.createdAt
         : Date.now(),
     ...(typeof message.cwd === "string" && message.cwd.length > 0
@@ -120,8 +124,13 @@ async function pruneLocalChatFile(path: string): Promise<void> {
           role: m.role,
           ...(m.text ? { text: m.text } : {}),
           ...(m.thinking ? { thinking: m.thinking } : {}),
+          ...(m.attachments && m.attachments.length > 0
+            ? { attachments: m.attachments }
+            : {}),
           ...(m.a2ui ? { a2ui: m.a2ui } : {}),
-          ...(typeof m.createdAt === "number" ? { createdAt: m.createdAt } : {}),
+          ...(typeof m.createdAt === "number"
+            ? { createdAt: m.createdAt }
+            : {}),
           ...(m.cwd ? { cwd: m.cwd } : {}),
         }),
       )

--- a/agent/session-history/parse-local.ts
+++ b/agent/session-history/parse-local.ts
@@ -17,6 +17,7 @@ import {
   hasA2ui,
   isChatRole,
   normalizeCwd,
+  parseChatAttachments,
   trimText,
 } from "./shared";
 
@@ -50,8 +51,9 @@ export function parseLocalChatLines(
     const text = typeof record.text === "string" ? trimText(record.text) : "";
     const thinking =
       typeof record.thinking === "string" ? trimText(record.thinking) : "";
+    const attachments = parseChatAttachments(record.attachments);
     const a2ui = hasA2ui(record.a2ui) ? record.a2ui : undefined;
-    if (!text && !thinking && !a2ui) continue;
+    if (!text && !thinking && !a2ui && attachments.length === 0) continue;
     const id =
       typeof record.id === "string" && record.id.length > 0
         ? record.id
@@ -61,6 +63,7 @@ export function parseLocalChatLines(
       role: record.role,
       ...(text ? { text } : {}),
       ...(thinking ? { thinking } : {}),
+      ...(attachments.length > 0 ? { attachments } : {}),
       ...(a2ui ? { a2ui } : {}),
       ...(typeof record.createdAt === "number"
         ? { createdAt: record.createdAt }

--- a/agent/session-history/restore.ts
+++ b/agent/session-history/restore.ts
@@ -19,7 +19,11 @@ import { latestSessionLog } from "./metadata";
 import { findSessionFileMatchingCwd } from "./lookup";
 import { readLocalChatTranscript } from "./parse-local";
 import { parseSessionHistoryLines } from "./parse-pi";
-import { MAX_RESTORED_MESSAGES, type RestoredChatMessage } from "./shared";
+import {
+  MAX_RESTORED_MESSAGES,
+  type RestoredChatAttachment,
+  type RestoredChatMessage,
+} from "./shared";
 
 type ContentChannel = "text" | "thinking";
 
@@ -104,6 +108,91 @@ function dedupeLocalMessages(
   });
 }
 
+function attachmentKey(attachment: RestoredChatAttachment): string {
+  return [
+    attachment.kind,
+    attachment.id,
+    attachment.path,
+    attachment.name,
+    attachment.mimeType,
+    attachment.sizeBytes,
+  ].join("\0");
+}
+
+function mergeAttachments(
+  base: RestoredChatMessage,
+  additions: RestoredChatAttachment[],
+): RestoredChatMessage {
+  if (additions.length === 0) return base;
+  const merged = [...(base.attachments ?? [])];
+  const seen = new Set(merged.map(attachmentKey));
+  for (const attachment of additions) {
+    const key = attachmentKey(attachment);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push(attachment);
+  }
+  return { ...base, attachments: merged };
+}
+
+function sameRestoredContent(
+  piMessage: RestoredChatMessage,
+  localMessage: RestoredChatMessage,
+): boolean {
+  if (piMessage.role !== localMessage.role) return false;
+  const localParts = messageContentParts(localMessage);
+  if (localParts.length === 0) return false;
+  const piParts = new Map(messageContentParts(piMessage));
+  return localParts.every(([channel, text]) => piParts.get(channel) === text);
+}
+
+function messageTimeDistance(
+  piMessage: RestoredChatMessage,
+  localMessage: RestoredChatMessage,
+): number {
+  if (
+    typeof piMessage.createdAt !== "number" ||
+    typeof localMessage.createdAt !== "number"
+  ) {
+    return Number.POSITIVE_INFINITY;
+  }
+  return Math.abs(piMessage.createdAt - localMessage.createdAt);
+}
+
+function findPiMessageForLocalAttachments(
+  piMessages: RestoredChatMessage[],
+  localMessage: RestoredChatMessage,
+): number {
+  let bestIndex = -1;
+  let bestDistance = Number.POSITIVE_INFINITY;
+  for (let index = 0; index < piMessages.length; index += 1) {
+    const candidate = piMessages[index];
+    if (!sameRestoredContent(candidate, localMessage)) continue;
+    const distance = messageTimeDistance(candidate, localMessage);
+    if (bestIndex < 0 || distance < bestDistance) {
+      bestIndex = index;
+      bestDistance = distance;
+    }
+  }
+  return bestIndex;
+}
+
+function mergeLocalAttachmentsIntoPiMessages(
+  piMessages: RestoredChatMessage[],
+  localMessages: RestoredChatMessage[],
+): RestoredChatMessage[] {
+  let merged = piMessages;
+  for (const localMessage of localMessages) {
+    const attachments = localMessage.attachments ?? [];
+    if (attachments.length === 0) continue;
+    const index = findPiMessageForLocalAttachments(merged, localMessage);
+    if (index < 0) continue;
+    if (merged === piMessages) merged = [...piMessages];
+    merged[index] = mergeAttachments(merged[index], attachments);
+  }
+  return merged;
+}
+
 export async function readSessionTranscript(
   sessionDir: string,
   expectedCwd?: string,
@@ -126,6 +215,10 @@ export async function readSessionTranscript(
 
   const raw = await readFile(path, "utf8");
   const piMessages = parseSessionHistoryLines(raw.split(/\r?\n/));
-  const localOnly = dedupeLocalMessages(piMessages, localMessages);
-  return [...piMessages, ...localOnly].slice(-MAX_RESTORED_MESSAGES);
+  const mergedPiMessages = mergeLocalAttachmentsIntoPiMessages(
+    piMessages,
+    localMessages,
+  );
+  const localOnly = dedupeLocalMessages(mergedPiMessages, localMessages);
+  return [...mergedPiMessages, ...localOnly].slice(-MAX_RESTORED_MESSAGES);
 }

--- a/agent/session-history/shared.ts
+++ b/agent/session-history/shared.ts
@@ -18,9 +18,19 @@ export interface RestoredChatMessage {
   role: "user" | "agent" | "system";
   text?: string;
   thinking?: string;
+  attachments?: RestoredChatAttachment[];
   a2ui?: { components: unknown[] };
   createdAt?: number;
   cwd?: string;
+}
+
+export interface RestoredChatAttachment {
+  id: string;
+  kind: "image";
+  path: string;
+  name: string;
+  mimeType: string;
+  sizeBytes: number;
 }
 
 export interface LatestSessionLog {
@@ -50,6 +60,36 @@ export function hasA2ui(value: unknown): value is { components: unknown[] } {
     typeof value === "object" &&
     Array.isArray((value as { components?: unknown }).components)
   );
+}
+
+export function parseChatAttachments(value: unknown): RestoredChatAttachment[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((item) => {
+    if (!item || typeof item !== "object") return [];
+    const record = item as Record<string, unknown>;
+    if (
+      typeof record.id !== "string" ||
+      record.kind !== "image" ||
+      typeof record.path !== "string" ||
+      typeof record.name !== "string" ||
+      typeof record.mimeType !== "string" ||
+      !record.mimeType.startsWith("image/") ||
+      typeof record.sizeBytes !== "number" ||
+      !Number.isFinite(record.sizeBytes)
+    ) {
+      return [];
+    }
+    return [
+      {
+        id: record.id,
+        kind: "image",
+        path: record.path,
+        name: record.name,
+        mimeType: record.mimeType,
+        sizeBytes: record.sizeBytes,
+      },
+    ];
+  });
 }
 
 export function trimText(text: string): string {

--- a/agent/tabs.ts
+++ b/agent/tabs.ts
@@ -6,6 +6,7 @@ import { emitGlobalReady } from "./dispatcherTypes";
 import { loadProjectAethonExtensions } from "./extension-loader";
 import {
   appendLocalChatMessage,
+  parseChatAttachments,
   readSessionMetadata,
   readSessionTranscript,
   writeSessionLabel,
@@ -180,6 +181,7 @@ export async function handleLocalChatMessage(
   const role = record.role;
   const text = record.text;
   const thinking = record.thinking;
+  const attachments = parseChatAttachments(record.attachments);
   if (role !== "user" && role !== "agent" && role !== "system") {
     deps.send({
       type: "notice",
@@ -190,7 +192,7 @@ export async function handleLocalChatMessage(
   }
   const hasText = typeof text === "string" && text.length > 0;
   const hasThinking = typeof thinking === "string" && thinking.length > 0;
-  if (!hasText && !hasThinking) {
+  if (!hasText && !hasThinking && attachments.length === 0) {
     deps.send({
       type: "notice",
       tabId,
@@ -212,6 +214,7 @@ export async function handleLocalChatMessage(
       role,
       ...(hasText ? { text } : {}),
       ...(hasThinking ? { thinking } : {}),
+      ...(attachments.length > 0 ? { attachments } : {}),
       ...(localCwd ? { cwd: localCwd } : {}),
       ...(typeof record.createdAt === "number"
         ? { createdAt: record.createdAt }

--- a/e2e/aethon.spec.ts
+++ b/e2e/aethon.spec.ts
@@ -21,6 +21,11 @@ type ActiveTurnState = {
   status?: string;
 };
 
+type InvokeCall = {
+  cmd: string;
+  args: Record<string, unknown>;
+};
+
 function isTransientNavigationError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
   return (
@@ -67,6 +72,16 @@ async function completeActiveTurn(page: Page): Promise<void> {
   });
 }
 
+function sendMessageRequests(calls: InvokeCall[]): Record<string, unknown>[] {
+  return calls
+    .filter((c) => c.cmd === "send_message")
+    .map((c) =>
+      c.args.request && typeof c.args.request === "object"
+        ? (c.args.request as Record<string, unknown>)
+        : c.args,
+    );
+}
+
 test.beforeEach(async ({ page }) => {
   await installAethonHarness(page);
 });
@@ -74,8 +89,12 @@ test.beforeEach(async ({ page }) => {
 test("boots the real app shell through mocked Tauri IPC", async ({ page }) => {
   await waitForAethonReady(page);
 
-  await expect(page.getByRole("tab", { name: "Back to overview" })).toBeVisible();
-  await expect(page.locator(".a2ui-tab:not(.a2ui-tab-overview)")).toHaveCount(0);
+  await expect(
+    page.getByRole("tab", { name: "Back to overview" }),
+  ).toBeVisible();
+  await expect(page.locator(".a2ui-tab:not(.a2ui-tab-overview)")).toHaveCount(
+    0,
+  );
   await expect(page.getByRole("heading", { name: "aethon" })).toBeVisible();
   await expect(page.locator(".ae-file-tree")).toContainText("package.json");
 
@@ -205,8 +224,12 @@ test("queues normal Enter messages behind an in-flight turn and drains cleanly",
   await expect(page.locator(".a2ui-tab-active")).toContainText("+1");
   await expect(page.locator(".a2ui-queued-popover")).toBeVisible();
   await expect(page.locator(".a2ui-queued-message")).toHaveCount(1);
-  await expect(page.locator(".a2ui-queued-content")).toHaveText("queued prompt");
-  await expect(page.getByRole("button", { name: "Stop + clear" })).toBeVisible();
+  await expect(page.locator(".a2ui-queued-content")).toHaveText(
+    "queued prompt",
+  );
+  await expect(
+    page.getByRole("button", { name: "Stop + clear" }),
+  ).toBeVisible();
   await expect
     .poll(() => getActiveTurnState(page))
     .toEqual({ waiting: true, queueCount: 1, status: "thinking…" });
@@ -256,8 +279,7 @@ test("queues normal Enter messages behind an in-flight turn and drains cleanly",
   await expect(page.getByText("Enter queues")).toHaveCount(0);
 
   const calls = await getInvokeCalls(page);
-  const sends = calls.filter((c) => c.cmd === "send_message");
-  expect(sends.map((c) => c.args)).toEqual(
+  expect(sendMessageRequests(calls)).toEqual(
     expect.arrayContaining([
       expect.objectContaining({ message: "first prompt", mode: "normal" }),
       expect.objectContaining({ message: "queued prompt", mode: "normal" }),
@@ -288,7 +310,9 @@ test("steers Command-Enter into the running turn without queuing it", async ({
 
   await expect(page.locator(".a2ui-chat-input-queue")).toHaveCount(0);
   await expect(page.locator(".a2ui-tab-active")).not.toContainText("+1");
-  await expect(page.locator(".a2ui-chat-delivery-steered")).toHaveText("steered");
+  await expect(page.locator(".a2ui-chat-delivery-steered")).toHaveText(
+    "steered",
+  );
   await expect
     .poll(() => getActiveTurnState(page))
     .toEqual({ waiting: true, queueCount: 0, status: "thinking…" });
@@ -309,8 +333,7 @@ test("steers Command-Enter into the running turn without queuing it", async ({
     model: DEFAULT_MODEL,
   });
 
-  const sends = calls.filter((c) => c.cmd === "send_message");
-  expect(sends.map((c) => c.args)).toEqual(
+  expect(sendMessageRequests(calls)).toEqual(
     expect.arrayContaining([
       expect.objectContaining({ message: "first prompt", mode: "normal" }),
       expect.objectContaining({ message: "steer now", mode: "steer" }),
@@ -341,8 +364,7 @@ test("retries failed user sends from the transcript", async ({ page }) => {
     .poll(() => getActiveTurnState(page))
     .toEqual({ waiting: false, queueCount: 0, status: "ready" });
 
-  const sends = (await getInvokeCalls(page)).filter((c) => c.cmd === "send_message");
-  expect(sends.map((c) => c.args)).toEqual([
+  expect(sendMessageRequests(await getInvokeCalls(page))).toEqual([
     expect.objectContaining({ message: "retry me", mode: "normal" }),
     expect.objectContaining({ message: "retry me", mode: "normal" }),
   ]);
@@ -371,8 +393,12 @@ test("steering during an existing follow-up queue preserves the queued turn", as
   // queued message in the popover untouched.
   await expect(page.locator(".a2ui-chat-input-queue")).toHaveText("+1");
   await expect(page.locator(".a2ui-queued-message")).toHaveCount(1);
-  await expect(page.locator(".a2ui-queued-content")).toHaveText("queued prompt");
-  await expect(page.locator(".a2ui-chat-delivery-steered")).toHaveText("steered");
+  await expect(page.locator(".a2ui-queued-content")).toHaveText(
+    "queued prompt",
+  );
+  await expect(page.locator(".a2ui-chat-delivery-steered")).toHaveText(
+    "steered",
+  );
   await expect
     .poll(() => getActiveTurnState(page))
     .toEqual({ waiting: true, queueCount: 1, status: "thinking…" });
@@ -381,7 +407,9 @@ test("steering during an existing follow-up queue preserves the queued turn", as
   // as historical record of the mid-turn interjection.
   await completeActiveTurn(page);
   await expect(page.locator(".a2ui-queued-popover")).toHaveCount(0);
-  await expect(page.locator(".a2ui-chat-delivery-steered")).toHaveText("steered");
+  await expect(page.locator(".a2ui-chat-delivery-steered")).toHaveText(
+    "steered",
+  );
   await expect
     .poll(() => getActiveTurnState(page))
     .toEqual({ waiting: true, queueCount: 0, status: "thinking…" });
@@ -391,8 +419,7 @@ test("steering during an existing follow-up queue preserves the queued turn", as
     .poll(() => getActiveTurnState(page))
     .toEqual({ waiting: false, queueCount: 0, status: "ready" });
 
-  const sends = (await getInvokeCalls(page)).filter((c) => c.cmd === "send_message");
-  expect(sends.map((c) => c.args)).toEqual([
+  expect(sendMessageRequests(await getInvokeCalls(page))).toEqual([
     expect.objectContaining({ message: "first prompt", mode: "normal" }),
     expect.objectContaining({ message: "steer current turn", mode: "steer" }),
     expect.objectContaining({ message: "queued prompt", mode: "normal" }),
@@ -425,8 +452,13 @@ test("switches models through the real picker path and keeps active state aligne
   await waitForAethonReady(page);
 
   await page.getByRole("button", { name: "New Tab" }).click();
-  await page.locator(".a2ui-dropdown-trigger").filter({ hasText: "GPT-5.5" }).click();
-  await page.getByRole("option", { name: /qwen3\.6:35b-a3b-coding-nvfp4/ }).click();
+  await page
+    .locator(".a2ui-dropdown-trigger")
+    .filter({ hasText: "GPT-5.5" })
+    .click();
+  await page
+    .getByRole("option", { name: /qwen3\.6:35b-a3b-coding-nvfp4/ })
+    .click();
 
   await expect
     .poll(() =>
@@ -434,8 +466,9 @@ test("switches models through the real picker path and keeps active state aligne
         const state = window.__AETHON_STATE__?.();
         return {
           model: state?.model,
-          active: state?.sidebar?.models?.find((m: { id: string }) => m.id === state?.model)
-            ?.active,
+          active: state?.sidebar?.models?.find(
+            (m: { id: string }) => m.id === state?.model,
+          )?.active,
         };
       }),
     )
@@ -447,21 +480,38 @@ test("refreshes visible file-tree folders after fs-tree-changed events", async (
 }) => {
   await waitForAethonReady(page);
 
-  await page.evaluate(({ root }) => {
-    window.__AETHON_E2E__?.setDir(root, root, [
-      { name: "agent", path: `${root}/agent`, kind: "dir", size: 0, modified: 1 },
-      { name: "src", path: `${root}/src`, kind: "dir", size: 0, modified: 1 },
-      { name: "package.json", path: `${root}/package.json`, kind: "file", size: 42, modified: 1 },
-      {
-        name: "z-e2e-created.txt",
-        path: `${root}/z-e2e-created.txt`,
-        kind: "file",
-        size: 42,
-        modified: 1,
-      },
-    ]);
-    window.__AETHON_E2E__?.emit("fs-tree-changed", { root, dirs: [root] });
-  }, { root: PROJECT_ROOT });
+  await page.evaluate(
+    ({ root }) => {
+      window.__AETHON_E2E__?.setDir(root, root, [
+        {
+          name: "agent",
+          path: `${root}/agent`,
+          kind: "dir",
+          size: 0,
+          modified: 1,
+        },
+        { name: "src", path: `${root}/src`, kind: "dir", size: 0, modified: 1 },
+        {
+          name: "package.json",
+          path: `${root}/package.json`,
+          kind: "file",
+          size: 42,
+          modified: 1,
+        },
+        {
+          name: "z-e2e-created.txt",
+          path: `${root}/z-e2e-created.txt`,
+          kind: "file",
+          size: 42,
+          modified: 1,
+        },
+      ]);
+      window.__AETHON_E2E__?.emit("fs-tree-changed", { root, dirs: [root] });
+    },
+    { root: PROJECT_ROOT },
+  );
 
-  await expect(page.locator(".ae-file-tree")).toContainText("z-e2e-created.txt");
+  await expect(page.locator(".ae-file-tree")).toContainText(
+    "z-e2e-created.txt",
+  );
 });

--- a/e2e/support/aethon-harness.ts
+++ b/e2e/support/aethon-harness.ts
@@ -86,7 +86,10 @@ export async function installAethonHarness(page: Page): Promise<void> {
       let nextCallbackId = 1;
       let nextListenerId = 1;
       let model = defaultModel;
-      const promptStateByTab = new Map<string, { inFlight: boolean; queued: number }>();
+      const promptStateByTab = new Map<
+        string,
+        { inFlight: boolean; queued: number }
+      >();
       let failNextSend = false;
 
       const key = (root: string, path: string) => `${root}\u0000${path}`;
@@ -96,7 +99,13 @@ export async function installAethonHarness(page: Page): Promise<void> {
         name: string,
         path: string,
         kind: "file" | "dir",
-      ): Entry => ({ name, path, kind, size: kind === "file" ? 42 : 0, modified: 1 });
+      ): Entry => ({
+        name,
+        path,
+        kind,
+        size: kind === "file" ? 42 : 0,
+        modified: 1,
+      });
 
       files.set(key(projectRoot, projectRoot), [
         entry("agent", `${projectRoot}/agent`, "dir"),
@@ -369,8 +378,12 @@ export async function installAethonHarness(page: Page): Promise<void> {
               failNextSend = false;
               throw new Error("e2e send failure");
             }
-            const tabId = stringArg(args.tabId, "default");
-            const mode = stringArg(args.mode, "normal");
+            const request =
+              args.request && typeof args.request === "object"
+                ? (args.request as Record<string, unknown>)
+                : args;
+            const tabId = stringArg(request.tabId, "default");
+            const mode = stringArg(request.mode, "normal");
             const turn = promptState(tabId);
             if (mode === "steer" && turn.inFlight) {
               return undefined;
@@ -435,7 +448,12 @@ export async function installAethonHarness(page: Page): Promise<void> {
         },
       };
     },
-    { projectRoot: PROJECT_ROOT, aethonRoot: AETHON_ROOT, defaultModel: DEFAULT_MODEL, altModel: ALT_MODEL },
+    {
+      projectRoot: PROJECT_ROOT,
+      aethonRoot: AETHON_ROOT,
+      defaultModel: DEFAULT_MODEL,
+      altModel: ALT_MODEL,
+    },
   );
 }
 

--- a/src-tauri/src/agent_commands.rs
+++ b/src-tauri/src/agent_commands.rs
@@ -29,6 +29,17 @@ pub(crate) struct ChatAttachmentInput {
     size_bytes: u64,
 }
 
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SendMessageRequest {
+    message: String,
+    tab_id: Option<String>,
+    mode: Option<String>,
+    cwd: Option<String>,
+    model: Option<String>,
+    attachments: Option<Vec<ChatAttachmentInput>>,
+}
+
 #[tauri::command]
 pub(crate) fn start_agent(state: State<'_, AgentProcesses>, app: AppHandle) -> Result<(), String> {
     ensure_global_agent(&state, &app)
@@ -36,33 +47,28 @@ pub(crate) fn start_agent(state: State<'_, AgentProcesses>, app: AppHandle) -> R
 
 #[tauri::command]
 pub(crate) fn send_message(
-    message: String,
-    tab_id: Option<String>,
-    mode: Option<String>,
-    cwd: Option<String>,
-    model: Option<String>,
-    attachments: Option<Vec<ChatAttachmentInput>>,
+    request: SendMessageRequest,
     state: State<'_, AgentProcesses>,
     app: AppHandle,
 ) -> Result<(), String> {
-    let tab_id = tab_id.unwrap_or_else(|| "default".to_string());
+    let tab_id = request.tab_id.unwrap_or_else(|| "default".to_string());
     let mut payload = serde_json::json!({
         "type": "chat",
-        "content": message,
-        "mode": mode.unwrap_or_else(|| "normal".to_string()),
+        "content": request.message,
+        "mode": request.mode.unwrap_or_else(|| "normal".to_string()),
         "tabId": tab_id,
     });
-    if let Some(cwd) = cwd
+    if let Some(cwd) = request.cwd
         && !cwd.is_empty()
     {
         payload["cwd"] = serde_json::Value::String(cwd);
     }
-    if let Some(model) = model
+    if let Some(model) = request.model
         && !model.is_empty()
     {
         payload["model"] = serde_json::Value::String(model);
     }
-    let images = attachments_to_agent_images(&app, attachments.unwrap_or_default())?;
+    let images = attachments_to_agent_images(&app, request.attachments.unwrap_or_default())?;
     if !images.is_empty() {
         payload["images"] = serde_json::Value::Array(images);
     }

--- a/src-tauri/src/agent_commands.rs
+++ b/src-tauri/src/agent_commands.rs
@@ -1,9 +1,11 @@
 use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
 use std::process::Child;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use tauri::{AppHandle, Emitter, State};
+use base64::Engine;
+use tauri::{AppHandle, Emitter, Manager, State};
 
 use crate::agent_process::{
     AgentProcesses, AgentWorker, GLOBAL_AGENT_KEY, WorkerMeta, ensure_global_agent,
@@ -14,6 +16,18 @@ use crate::agent_process::{
 /// tab the frontend just opened (but hasn't yet included in its reported live
 /// set) isn't killed mid-handshake.
 const RECONCILE_MIN_AGE: Duration = Duration::from_secs(10);
+const MAX_ATTACHMENT_BYTES: u64 = 32 * 1024 * 1024;
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ChatAttachmentInput {
+    id: String,
+    kind: String,
+    path: String,
+    name: String,
+    mime_type: String,
+    size_bytes: u64,
+}
 
 #[tauri::command]
 pub(crate) fn start_agent(state: State<'_, AgentProcesses>, app: AppHandle) -> Result<(), String> {
@@ -27,6 +41,7 @@ pub(crate) fn send_message(
     mode: Option<String>,
     cwd: Option<String>,
     model: Option<String>,
+    attachments: Option<Vec<ChatAttachmentInput>>,
     state: State<'_, AgentProcesses>,
     app: AppHandle,
 ) -> Result<(), String> {
@@ -47,10 +62,82 @@ pub(crate) fn send_message(
     {
         payload["model"] = serde_json::Value::String(model);
     }
+    let images = attachments_to_agent_images(&app, attachments.unwrap_or_default())?;
+    if !images.is_empty() {
+        payload["images"] = serde_json::Value::Array(images);
+    }
 
     let key = route_payload_key(&state, &payload);
     let worker = worker_for_payload(&key, &payload, true);
     write_agent_payload(&state, &app, key, payload, worker)
+}
+
+fn attachments_to_agent_images(
+    app: &AppHandle,
+    attachments: Vec<ChatAttachmentInput>,
+) -> Result<Vec<serde_json::Value>, String> {
+    let paste_dir = paste_dir(app)?;
+    let mut images = Vec::new();
+    for attachment in attachments {
+        if attachment.kind != "image" {
+            continue;
+        }
+        if !attachment.mime_type.starts_with("image/") {
+            return Err(format!("attachment '{}' is not an image", attachment.name));
+        }
+        if attachment.size_bytes > MAX_ATTACHMENT_BYTES {
+            return Err(format!("attachment '{}' exceeds 32 MiB", attachment.name));
+        }
+        let path = PathBuf::from(&attachment.path);
+        let canonical = path
+            .canonicalize()
+            .map_err(|e| format!("attachment '{}': {e}", attachment.name))?;
+        if !canonical.starts_with(&paste_dir) {
+            return Err(format!(
+                "attachment '{}' is outside the paste directory",
+                attachment.name
+            ));
+        }
+        let metadata = std::fs::metadata(&canonical)
+            .map_err(|e| format!("attachment '{}': {e}", attachment.name))?;
+        if metadata.len() > MAX_ATTACHMENT_BYTES {
+            return Err(format!("attachment '{}' exceeds 32 MiB", attachment.name));
+        }
+        let bytes = std::fs::read(&canonical)
+            .map_err(|e| format!("attachment '{}': {e}", attachment.name))?;
+        images.push(serde_json::json!({
+            "id": attachment.id,
+            "name": attachment.name,
+            "mimeType": attachment.mime_type,
+            "data": base64::engine::general_purpose::STANDARD.encode(bytes),
+        }));
+    }
+    Ok(images)
+}
+
+fn paste_dir(app: &AppHandle) -> Result<PathBuf, String> {
+    let home = app
+        .path()
+        .home_dir()
+        .map_err(|e| format!("home_dir: {e}"))?;
+    let dir = crate::helpers::aethon_dir(Some(home))
+        .ok_or_else(|| "aethon dir unresolved".to_string())?
+        .join("pastes");
+    canonicalize_existing_or_parent(&dir)
+}
+
+fn canonicalize_existing_or_parent(path: &Path) -> Result<PathBuf, String> {
+    if path.exists() {
+        return path.canonicalize().map_err(|e| e.to_string());
+    }
+    let parent = path
+        .parent()
+        .ok_or_else(|| "paste directory has no parent".to_string())?;
+    let parent = parent.canonicalize().map_err(|e| e.to_string())?;
+    let name = path
+        .file_name()
+        .ok_or_else(|| "paste directory has no name".to_string())?;
+    Ok(parent.join(name))
 }
 
 /// Hard-kill the running agent child. Called by the frontend's hang-warn

--- a/src-tauri/src/commands/git/worktrees.rs
+++ b/src-tauri/src/commands/git/worktrees.rs
@@ -134,9 +134,8 @@ pub async fn git_worktree_add(
     if let Some(parent) = target.parent()
         && !parent.as_os_str().is_empty()
     {
-        std::fs::create_dir_all(parent).map_err(|e| {
-            format!("create worktree parent {}: {e}", parent.display())
-        })?;
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("create worktree parent {}: {e}", parent.display()))?;
     }
     // Detect whether the branch exists so we know whether to pass `-b`.
     let exists = env::command("git")
@@ -485,13 +484,9 @@ mod tests {
 
         assert_eq!(wt.branch.as_deref(), Some("feature-y"));
         assert!(target.exists());
-        git_worktree_remove(
-            project_path,
-            target.to_string_lossy().to_string(),
-            false,
-        )
-        .await
-        .expect("worktree remove");
+        git_worktree_remove(project_path, target.to_string_lossy().to_string(), false)
+            .await
+            .expect("worktree remove");
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/git/worktrees.rs
+++ b/src-tauri/src/commands/git/worktrees.rs
@@ -130,6 +130,14 @@ pub async fn git_worktree_add(
     if !dir.is_dir() {
         return Err(format!("not a directory: {project_path}"));
     }
+    let target = PathBuf::from(&target_path);
+    if let Some(parent) = target.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent).map_err(|e| {
+            format!("create worktree parent {}: {e}", parent.display())
+        })?;
+    }
     // Detect whether the branch exists so we know whether to pass `-b`.
     let exists = env::command("git")
         .arg("-C")
@@ -455,6 +463,35 @@ mod tests {
             .expect("worktree remove");
         let after = git_worktrees(project_path).await.expect("list after");
         assert_eq!(after.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn add_worktree_creates_missing_parent_directory() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let parent = tempfile::tempdir().expect("tempdir");
+        init_repo(dir.path());
+        let project_path = dir.path().to_string_lossy().to_string();
+        let target = parent.path().join("aethon").join("feature-y");
+        assert!(!target.parent().expect("target parent").exists());
+
+        let wt = git_worktree_add(
+            project_path.clone(),
+            target.to_string_lossy().to_string(),
+            "feature-y".to_string(),
+            None,
+        )
+        .await
+        .expect("worktree add");
+
+        assert_eq!(wt.branch.as_deref(), Some("feature-y"));
+        assert!(target.exists());
+        git_worktree_remove(
+            project_path,
+            target.to_string_lossy().to_string(),
+            false,
+        )
+        .await
+        .expect("worktree remove");
     }
 
     #[tokio::test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -162,6 +162,7 @@ pub fn run() {
             agent_commands::reconcile_agent_workers,
             agent_commands::dispatch_a2ui_event,
             paste::save_paste_image,
+            paste::read_paste_image_base64,
             commands::config::read_state,
             commands::config::write_state,
             commands::config::read_config,
@@ -395,6 +396,7 @@ mod tests {
             "agent_commands::reconcile_agent_workers",
             "agent_commands::dispatch_a2ui_event",
             "paste::save_paste_image",
+            "paste::read_paste_image_base64",
         ] {
             assert!(
                 src.contains(command),

--- a/src-tauri/src/paste.rs
+++ b/src-tauri/src/paste.rs
@@ -2,6 +2,8 @@ use tauri::{AppHandle, Manager};
 
 use crate::helpers::{self, sanitize_filename_segment};
 
+const MAX_PASTE_IMAGE_BYTES: u64 = 32 * 1024 * 1024;
+
 /// Persist an image paste from the clipboard to `~/.aethon/pastes/`.
 /// Returns the absolute path so the frontend can insert it into the
 /// draft as an `@<path>` token and let the agent read it like any other file.
@@ -14,22 +16,59 @@ pub(crate) fn save_paste_image(
     if bytes.is_empty() {
         return Err("save_paste_image: empty payload".to_string());
     }
-    if bytes.len() > 32 * 1024 * 1024 {
+    if bytes.len() as u64 > MAX_PASTE_IMAGE_BYTES {
         return Err("save_paste_image: payload exceeds 32 MiB".to_string());
     }
-    let home = app
-        .path()
-        .home_dir()
-        .map_err(|e| format!("home_dir: {e}"))?;
-    let dir = helpers::aethon_dir(Some(home))
-        .ok_or_else(|| "aethon dir unresolved".to_string())?
-        .join("pastes");
+    let dir = paste_dir(&app)?;
     std::fs::create_dir_all(&dir).map_err(|e| format!("create_dir_all: {e}"))?;
     let ext = sanitize_extension(extension.as_deref());
     let id = uuid::Uuid::new_v4().simple().to_string();
     let path = dir.join(format!("{id}.{ext}"));
     std::fs::write(&path, bytes).map_err(|e| format!("write: {e}"))?;
     Ok(path.to_string_lossy().to_string())
+}
+
+/// Read a previously-saved paste image back as base64 for durable chat previews.
+/// The requested path must resolve inside `~/.aethon/pastes/`.
+#[tauri::command]
+pub(crate) fn read_paste_image_base64(path: String, app: AppHandle) -> Result<String, String> {
+    use base64::Engine as _;
+
+    let dir = paste_dir(&app)?;
+    let dir_canon = dir
+        .canonicalize()
+        .map_err(|e| format!("paste dir canonicalize: {e}"))?;
+    let target = std::path::PathBuf::from(&path);
+    let target_canon = target
+        .canonicalize()
+        .map_err(|e| format!("paste image canonicalize: {e}"))?;
+    if !target_canon.starts_with(&dir_canon) {
+        return Err("paste image is outside the paste directory".to_string());
+    }
+    let metadata = std::fs::metadata(&target_canon)
+        .map_err(|e| format!("stat {}: {e}", target_canon.display()))?;
+    if metadata.is_dir() {
+        return Err(format!("not a file: {}", target_canon.display()));
+    }
+    if metadata.len() > MAX_PASTE_IMAGE_BYTES {
+        return Err(format!(
+            "paste image too large: {} bytes (cap {MAX_PASTE_IMAGE_BYTES})",
+            metadata.len()
+        ));
+    }
+    let bytes = std::fs::read(&target_canon)
+        .map_err(|e| format!("read {}: {e}", target_canon.display()))?;
+    Ok(base64::engine::general_purpose::STANDARD.encode(bytes))
+}
+
+fn paste_dir(app: &AppHandle) -> Result<std::path::PathBuf, String> {
+    let home = app
+        .path()
+        .home_dir()
+        .map_err(|e| format!("home_dir: {e}"))?;
+    Ok(helpers::aethon_dir(Some(home))
+        .ok_or_else(|| "aethon dir unresolved".to_string())?
+        .join("pastes"))
 }
 
 fn sanitize_extension(extension: Option<&str>) -> String {

--- a/src/eventRoutes/chatInput.ts
+++ b/src/eventRoutes/chatInput.ts
@@ -1,4 +1,5 @@
 import type { QueuedMessage, Tab } from "../types/tab";
+import type { ChatAttachment } from "../types/a2ui";
 import type { EventRouteHandler } from "./types";
 
 function newestQueuedMessage(
@@ -24,7 +25,14 @@ export const handleChatInput: EventRouteHandler = async (
   ctx,
 ) => {
   if (eventType === "submit") {
-    const value = (data as { value?: string } | undefined)?.value ?? "";
+    const payload =
+      (data as
+        | { value?: string; attachments?: unknown }
+        | undefined) ?? {};
+    const value = payload.value ?? "";
+    const attachments = Array.isArray(payload.attachments)
+      ? (payload.attachments as ChatAttachment[])
+      : [];
     const mode =
       (data as { mode?: unknown } | undefined)?.mode === "steer"
         ? "steer"
@@ -36,7 +44,34 @@ export const handleChatInput: EventRouteHandler = async (
       }
       return true;
     }
-    await ctx.sendChat(value, { mode });
+    await ctx.sendChat(value, {
+      mode,
+      ...(attachments.length > 0 ? { attachments } : {}),
+    });
+    return true;
+  }
+  if (eventType === "attachments:add") {
+    const attachments: ChatAttachment[] = Array.isArray(
+      (data as { attachments?: unknown } | undefined)?.attachments,
+    )
+      ? ((data as { attachments: ChatAttachment[] }).attachments)
+      : [];
+    if (attachments.length > 0) {
+      ctx.updateActiveTab((tab) => ({
+        ...tab,
+        draftAttachments: [...(tab.draftAttachments ?? []), ...attachments],
+      }));
+    }
+    return true;
+  }
+  if (eventType === "attachment:remove") {
+    const id = (data as { id?: string } | undefined)?.id;
+    if (id) {
+      ctx.updateActiveTab((tab) => ({
+        ...tab,
+        draftAttachments: (tab.draftAttachments ?? []).filter((a) => a.id !== id),
+      }));
+    }
     return true;
   }
   if (eventType === "change") {

--- a/src/eventRoutes/dashboard.test.ts
+++ b/src/eventRoutes/dashboard.test.ts
@@ -212,6 +212,26 @@ describe("handleProjectDashboard", () => {
       }),
     );
   });
+
+  it("forwards task-launcher paste failures emitted through the project dashboard", async () => {
+    const { ctx } = buildRouteFixture();
+    const handled = await handleProjectDashboard(
+      {
+        component: { id: "project-dashboard", type: "project-dashboard" },
+        eventType: "paste-image-failed",
+        data: { message: "payload exceeds 32 MiB" },
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(ctx.pushNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Image paste failed",
+        message: "payload exceeds 32 MiB",
+        kind: "error",
+      }),
+    );
+  });
 });
 
 describe("handleTaskLauncher", () => {
@@ -292,6 +312,26 @@ describe("handleTaskLauncher", () => {
     );
     expect(ctx.activateWorktree).toHaveBeenCalledWith(null);
     expect(mocks.setActiveProjectById).toHaveBeenCalledWith("p2");
+  });
+
+  it("paste-image-failed notifies the user", async () => {
+    const { ctx } = buildRouteFixture();
+    const handled = await handleTaskLauncher(
+      {
+        component: { id: "x", type: "task-launcher" },
+        eventType: "paste-image-failed",
+        data: { message: "payload exceeds 32 MiB" },
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(ctx.pushNotification).toHaveBeenCalledWith({
+      id: "ae-task-paste-image-failed",
+      title: "Image paste failed",
+      message: "payload exceeds 32 MiB",
+      kind: "error",
+      durationMs: 3000,
+    });
   });
 });
 

--- a/src/eventRoutes/dashboard.ts
+++ b/src/eventRoutes/dashboard.ts
@@ -139,6 +139,7 @@ export const handleTaskLauncher: EventRouteHandler = (
       | {
           projectId?: string;
           prompt?: string;
+          attachments?: unknown;
           newWorktree?: boolean;
           branch?: string;
           baseBranch?: string;
@@ -150,6 +151,7 @@ export const handleTaskLauncher: EventRouteHandler = (
       projectId: sel.projectId,
       prompt: sel.prompt,
       newWorktree: sel.newWorktree === true,
+      attachments: Array.isArray(sel.attachments) ? sel.attachments : undefined,
       branch: sel.branch,
       baseBranch: sel.baseBranch,
       worktreeId: sel.worktreeId,

--- a/src/eventRoutes/dashboard.ts
+++ b/src/eventRoutes/dashboard.ts
@@ -87,7 +87,7 @@ export const handleProjectDashboard: EventRouteHandler = (
       ctx,
     );
   }
-  if (eventType === "start-task") {
+  if (eventType === "start-task" || eventType === "paste-image-failed") {
     return handleTaskLauncher(
       { component: { id: "", type: "task-launcher" }, eventType, data },
       ctx,
@@ -134,6 +134,20 @@ export const handleTaskLauncher: EventRouteHandler = (
   { eventType, data },
   ctx,
 ) => {
+  if (eventType === "paste-image-failed") {
+    const sel = data as { message?: unknown } | undefined;
+    ctx.pushNotification({
+      id: "ae-task-paste-image-failed",
+      title: "Image paste failed",
+      message:
+        typeof sel?.message === "string"
+          ? sel.message
+          : "Could not paste image.",
+      kind: "error",
+      durationMs: 3000,
+    });
+    return true;
+  }
   if (eventType === "start-task") {
     const sel = data as
       | {

--- a/src/eventRoutes/types.ts
+++ b/src/eventRoutes/types.ts
@@ -1,5 +1,6 @@
 import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 import type { EditorMeta, Tab } from "../types/tab";
+import type { ChatAttachment } from "../types/a2ui";
 import type { ShareMode } from "../utils/shareMode";
 import type {
   NotificationEntry,
@@ -65,7 +66,7 @@ export interface EventRouteContext {
   // ─── Chat / prompt ──────────────────────────────────────────────────
   sendChat: (
     text: string,
-    options?: { mode?: "normal" | "steer" },
+    options?: { mode?: "normal" | "steer"; attachments?: ChatAttachment[] },
   ) => Promise<void>;
   stopPrompt: (explicitTabId?: string) => Promise<void>;
   updateActiveTab: (updater: (tab: Tab) => Tab) => void;
@@ -158,6 +159,7 @@ export interface EventRouteContext {
   startTaskInProject: (opts: {
     projectId: string;
     prompt: string;
+    attachments?: ChatAttachment[];
     newWorktree?: boolean;
     branch?: string;
     baseBranch?: string;

--- a/src/extensions/default-layout/chat-input.tsx
+++ b/src/extensions/default-layout/chat-input.tsx
@@ -40,6 +40,7 @@ import {
   type SlashCommandSource,
   useSlashMatching,
 } from "./use-slash-matching";
+import { ImageLightbox } from "./image-lightbox";
 import { imageAttachmentSrc } from "../../utils/imageAttachments";
 
 export function ChatInput({
@@ -474,23 +475,36 @@ function AttachmentTray({
   attachments: ChatAttachment[];
   onRemove: (id: string) => void;
 }) {
+  const [open, setOpen] = useState<ChatAttachment | null>(null);
   return (
-    <div className="a2ui-chat-attachments" aria-label="Attached images">
-      {attachments.map((attachment) => (
-        <figure className="a2ui-chat-attachment" key={attachment.id}>
-          <img src={imageAttachmentSrc(attachment)} alt={attachment.name} />
-          <figcaption title={attachment.name}>{attachment.name}</figcaption>
-          <button
-            type="button"
-            className="a2ui-chat-attachment-remove"
-            aria-label={`Remove ${attachment.name}`}
-            onClick={() => onRemove(attachment.id)}
-          >
-            ×
-          </button>
-        </figure>
-      ))}
-    </div>
+    <>
+      <div className="a2ui-chat-attachments" aria-label="Attached images">
+        {attachments.map((attachment) => (
+          <figure className="a2ui-chat-attachment" key={attachment.id}>
+            <button
+              type="button"
+              className="a2ui-chat-attachment-thumb"
+              aria-label={`Open ${attachment.name}`}
+              onClick={() => setOpen(attachment)}
+            >
+              <img src={imageAttachmentSrc(attachment)} alt="" />
+            </button>
+            <figcaption title={attachment.name}>{attachment.name}</figcaption>
+            <button
+              type="button"
+              className="a2ui-chat-attachment-remove"
+              aria-label={`Remove ${attachment.name}`}
+              onClick={() => onRemove(attachment.id)}
+            >
+              ×
+            </button>
+          </figure>
+        ))}
+      </div>
+      {open && (
+        <ImageLightbox attachment={open} onClose={() => setOpen(null)} />
+      )}
+    </>
   );
 }
 

--- a/src/extensions/default-layout/chat-input.tsx
+++ b/src/extensions/default-layout/chat-input.tsx
@@ -40,8 +40,8 @@ import {
   type SlashCommandSource,
   useSlashMatching,
 } from "./use-slash-matching";
+import { ImageAttachmentImage } from "./image-attachment-image";
 import { ImageLightbox } from "./image-lightbox";
-import { imageAttachmentSrc } from "../../utils/imageAttachments";
 
 export function ChatInput({
   component,
@@ -65,12 +65,10 @@ export function ChatInput({
   };
 
   const externalValue = props.value ? resolveString(props.value, state) : "";
-  const {
-    value,
-    setValue,
-    commitDraft,
-    scheduleDraftCommit,
-  } = useDraftCommit(externalValue, onEvent);
+  const { value, setValue, commitDraft, scheduleDraftCommit } = useDraftCommit(
+    externalValue,
+    onEvent,
+  );
   const placeholder = props.placeholder
     ? resolveString(props.placeholder, state)
     : "";
@@ -103,16 +101,12 @@ export function ChatInput({
     ? resolveString(props.queueBadgeFormat, state)
     : "+{n}";
 
-  const {
-    slashMatch,
-    highlightIdx,
-    setHighlightIdx,
-    dismissPicker,
-  } = useSlashMatching({
-    value,
-    commandsRaw: props.commands,
-    state,
-  });
+  const { slashMatch, highlightIdx, setHighlightIdx, dismissPicker } =
+    useSlashMatching({
+      value,
+      commandsRaw: props.commands,
+      state,
+    });
   const inputContainerRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const { composerHeight, startComposerResize } = useComposerResize();
@@ -389,7 +383,10 @@ export function ChatInput({
           }`}
           onClick={() => {
             if (voice.state === "recording") voice.stop();
-            else if (voice.state === "starting" || voice.state === "transcribing") {
+            else if (
+              voice.state === "starting" ||
+              voice.state === "transcribing"
+            ) {
               voice.cancel();
             } else {
               void voice.start();
@@ -487,7 +484,7 @@ function AttachmentTray({
               aria-label={`Open ${attachment.name}`}
               onClick={() => setOpen(attachment)}
             >
-              <img src={imageAttachmentSrc(attachment)} alt="" />
+              <ImageAttachmentImage attachment={attachment} alt="" />
             </button>
             <figcaption title={attachment.name}>{attachment.name}</figcaption>
             <button

--- a/src/extensions/default-layout/chat-input.tsx
+++ b/src/extensions/default-layout/chat-input.tsx
@@ -10,6 +10,7 @@ import {
   type KeyboardEvent,
 } from "react";
 import type {
+  ChatAttachment,
   BooleanValue,
   NumberValue,
   StringValue,
@@ -39,6 +40,7 @@ import {
   type SlashCommandSource,
   useSlashMatching,
 } from "./use-slash-matching";
+import { imageAttachmentSrc } from "../../utils/imageAttachments";
 
 export function ChatInput({
   component,
@@ -77,6 +79,8 @@ export function ChatInput({
     : 0;
   const queuedMessages =
     (state.queuedMessages as QueuedMessage[] | undefined) ?? [];
+  const attachments =
+    (state.draftAttachments as ChatAttachment[] | undefined) ?? [];
   const canSteerQueuedMessage = queuedMessages.length > 0 || queueCount > 0;
   const sendLabel = props.sendLabel
     ? resolveString(props.sendLabel, state)
@@ -198,11 +202,17 @@ export function ChatInput({
     commitDraft(text);
   };
 
+  const submitPayload = (value: string, mode: "normal" | "steer") => ({
+    value,
+    mode,
+    ...(attachments.length > 0 ? { attachments } : {}),
+  });
+
   const submitArgMatch = (match: ArgMatch) => {
     const submitText = `/${match.cmd.name} ${match.choice.value}`;
     setValue(submitText);
     commitDraft(submitText);
-    onEvent("submit", { value: submitText, mode: "normal" });
+    onEvent("submit", submitPayload(submitText, "normal"));
   };
 
   const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
@@ -217,14 +227,14 @@ export function ChatInput({
         voice.cancel();
       }
       const v = (e.target as HTMLTextAreaElement).value;
-      if (v.trim().length === 0) {
+      if (v.trim().length === 0 && attachments.length === 0) {
         if (mode === "steer" && canSteerQueuedMessage) {
-          onEvent("submit", { value: "", mode });
+          onEvent("submit", submitPayload("", mode));
         }
         return;
       }
       commitDraft(v);
-      onEvent("submit", { value: v, mode });
+      onEvent("submit", submitPayload(v, mode));
     };
 
     if (e.key === "Enter" && !e.shiftKey && (e.metaKey || e.ctrlKey)) {
@@ -268,7 +278,7 @@ export function ChatInput({
           (c) => v === `/${c.cmd.name}` || v.startsWith(`/${c.cmd.name} `),
         );
         if (exact && v.trim().length > 0) {
-          onEvent("submit", { value: v, mode: "normal" });
+          onEvent("submit", submitPayload(v, "normal"));
           return;
         }
         const match = list[highlightIdx] ?? list[0];
@@ -283,12 +293,12 @@ export function ChatInput({
   };
 
   const handleClick = () => {
-    if (value.trim().length > 0) {
+    if (value.trim().length > 0 || attachments.length > 0) {
       if (voice.state === "recording" || voice.state === "starting") {
         voice.cancel();
       }
       commitDraft(value);
-      onEvent("submit", { value, mode: "normal" });
+      onEvent("submit", submitPayload(value, "normal"));
     }
   };
 
@@ -337,6 +347,12 @@ export function ChatInput({
               : "Cmd/Ctrl+Enter steers"}
           </span>
         </div>
+      )}
+      {attachments.length > 0 && (
+        <AttachmentTray
+          attachments={attachments}
+          onRemove={(id) => onEvent("attachment:remove", { id })}
+        />
       )}
       <div className="a2ui-chat-input-field-wrap">
         <textarea
@@ -423,7 +439,7 @@ export function ChatInput({
             type="button"
             className="a2ui-chat-input-send"
             onClick={handleClick}
-            disabled={value.trim().length === 0}
+            disabled={value.trim().length === 0 && attachments.length === 0}
             aria-label={sendLabel}
             title={`${sendLabel} (Enter)`}
           >
@@ -450,6 +466,33 @@ export function ChatInput({
 }
 
 type VoiceView = ReturnType<typeof useVoiceInput>;
+
+function AttachmentTray({
+  attachments,
+  onRemove,
+}: {
+  attachments: ChatAttachment[];
+  onRemove: (id: string) => void;
+}) {
+  return (
+    <div className="a2ui-chat-attachments" aria-label="Attached images">
+      {attachments.map((attachment) => (
+        <figure className="a2ui-chat-attachment" key={attachment.id}>
+          <img src={imageAttachmentSrc(attachment)} alt={attachment.name} />
+          <figcaption title={attachment.name}>{attachment.name}</figcaption>
+          <button
+            type="button"
+            className="a2ui-chat-attachment-remove"
+            aria-label={`Remove ${attachment.name}`}
+            onClick={() => onRemove(attachment.id)}
+          >
+            ×
+          </button>
+        </figure>
+      ))}
+    </div>
+  );
+}
 
 function VoiceStatus({
   voice,

--- a/src/extensions/default-layout/chat.test.tsx
+++ b/src/extensions/default-layout/chat.test.tsx
@@ -13,11 +13,9 @@ const { openUrl } = vi.hoisted(() => ({
   openUrl: vi.fn(),
 }));
 
-const virtuosoMockState = vi.hoisted(
-  (): { followOutput?: unknown } => ({
-    followOutput: undefined,
-  }),
-);
+const virtuosoMockState = vi.hoisted((): { followOutput?: unknown } => ({
+  followOutput: undefined,
+}));
 
 vi.mock("@tauri-apps/plugin-opener", () => ({
   openUrl: (...args: unknown[]) => openUrl(...args),
@@ -466,7 +464,9 @@ describe("ChatInput", () => {
     });
 
     fireEvent.click(screen.getByRole("button", { name: "Open one.png" }));
-    expect(screen.getByRole("dialog")).toBeTruthy();
+    expect(
+      screen.getByRole("dialog", { name: "Image preview: one.png" }),
+    ).toBeTruthy();
     expect(screen.getAllByText("one.png").length).toBeGreaterThanOrEqual(2);
   });
 

--- a/src/extensions/default-layout/chat.test.tsx
+++ b/src/extensions/default-layout/chat.test.tsx
@@ -13,6 +13,12 @@ const { openUrl } = vi.hoisted(() => ({
   openUrl: vi.fn(),
 }));
 
+const virtuosoMockState = vi.hoisted(
+  (): { followOutput?: unknown } => ({
+    followOutput: undefined,
+  }),
+);
+
 vi.mock("@tauri-apps/plugin-opener", () => ({
   openUrl: (...args: unknown[]) => openUrl(...args),
 }));
@@ -39,6 +45,7 @@ vi.mock("react-virtuoso", () => ({
     atBottomStateChange,
     scrollerRef,
     totalListHeightChanged,
+    followOutput,
   }: {
     data?: Array<{ id?: string }>;
     itemContent: (index: number, item: unknown) => React.ReactNode;
@@ -48,12 +55,25 @@ vi.mock("react-virtuoso", () => ({
     atBottomStateChange?: (atBottom: boolean) => void;
     scrollerRef?: (ref: HTMLElement | null) => void;
     totalListHeightChanged?: (height: number) => void;
+    followOutput?: unknown;
   }) => {
     const Footer = components?.Footer;
+    virtuosoMockState.followOutput = followOutput;
     useEffect(() => {
       const el = document.querySelector<HTMLElement>(
         "[data-testid='virtuoso-mock']",
       );
+      if (el) {
+        Object.defineProperties(el, {
+          scrollHeight: { value: 1000, configurable: true },
+          clientHeight: { value: 500, configurable: true },
+          scrollTop: {
+            value: 470,
+            writable: true,
+            configurable: true,
+          },
+        });
+      }
       scrollerRef?.(el);
       totalListHeightChanged?.(0);
       atBottomStateChange?.(false);
@@ -407,6 +427,21 @@ describe("ChatInput", () => {
     expect(
       screen.queryByRole("button", { name: "Scroll to latest message" }),
     ).toBeNull();
+  });
+
+  it("keeps following latest when Virtuoso reports false before a user scrolls away", () => {
+    renderHistory({
+      messages: [
+        { id: "1", role: "user", text: "start" },
+        { id: "2", role: "agent", text: "streaming update" },
+      ],
+    });
+
+    expect(
+      screen.queryByRole("button", { name: "Scroll to latest message" }),
+    ).toBeNull();
+    expect(virtuosoMockState.followOutput).toEqual(expect.any(Function));
+    expect((virtuosoMockState.followOutput as () => unknown)()).toBe("smooth");
   });
 
   it("renders user image attachments and opens them in a lightbox", () => {

--- a/src/extensions/default-layout/chat.test.tsx
+++ b/src/extensions/default-layout/chat.test.tsx
@@ -11,6 +11,11 @@ vi.mock("@tauri-apps/plugin-opener", () => ({
   openUrl: (...args: unknown[]) => openUrl(...args),
 }));
 
+vi.mock("@tauri-apps/api/core", () => ({
+  convertFileSrc: (path: string) => `asset://${path}`,
+  invoke: vi.fn(),
+}));
+
 vi.mock("../../components/HighlightedCode", () => ({
   HighlightedCode: ({ code }: { code: string }) => code,
 }));
@@ -293,6 +298,31 @@ describe("ChatInput", () => {
     expect(screen.getByText("Cmd/Ctrl+Enter steers latest queued")).toBeTruthy();
   });
 
+  it("renders draft image attachments and submits them with the message", () => {
+    const attachment = {
+      id: "img-1",
+      kind: "image" as const,
+      path: "/tmp/one.png",
+      name: "one.png",
+      mimeType: "image/png",
+      sizeBytes: 10,
+    };
+    const { input, onEvent } = renderInput(
+      vi.fn(),
+      {},
+      { draftAttachments: [attachment] },
+    );
+
+    expect(screen.getByText("one.png")).toBeTruthy();
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(onEvent).toHaveBeenLastCalledWith("submit", {
+      value: "",
+      mode: "normal",
+      attachments: [attachment],
+    });
+  });
+
   it("renders queued and steered delivery badges on user messages", () => {
     renderHistory({
       messages: [
@@ -331,6 +361,32 @@ describe("ChatInput", () => {
       messageId: "1",
       value: "again please",
     });
+  });
+
+  it("renders user image attachments and opens them in a lightbox", () => {
+    renderHistory({
+      messages: [
+        {
+          id: "1",
+          role: "user",
+          text: "see this",
+          attachments: [
+            {
+              id: "img-1",
+              kind: "image",
+              path: "/tmp/one.png",
+              name: "one.png",
+              mimeType: "image/png",
+              sizeBytes: 10,
+            },
+          ],
+        },
+      ],
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Open one.png" }));
+    expect(screen.getByRole("dialog")).toBeTruthy();
+    expect(screen.getAllByText("one.png").length).toBeGreaterThanOrEqual(2);
   });
 
   it("renders bare HTTP URLs as links in user, agent, and system bubbles", () => {

--- a/src/extensions/default-layout/chat.test.tsx
+++ b/src/extensions/default-layout/chat.test.tsx
@@ -1,7 +1,13 @@
 // @vitest-environment jsdom
+import { useEffect } from "react";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { ChatHistory, ChatInput, QueuedMessagesPopover, ToolCard } from "./chat";
+import {
+  ChatHistory,
+  ChatInput,
+  QueuedMessagesPopover,
+  ToolCard,
+} from "./chat";
 
 const { openUrl } = vi.hoisted(() => ({
   openUrl: vi.fn(),
@@ -30,14 +36,29 @@ vi.mock("react-virtuoso", () => ({
     components,
     context,
     className,
+    atBottomStateChange,
+    scrollerRef,
+    totalListHeightChanged,
   }: {
     data?: Array<{ id?: string }>;
     itemContent: (index: number, item: unknown) => React.ReactNode;
     components?: { Footer?: (props: { context?: unknown }) => React.ReactNode };
     context?: unknown;
     className?: string;
+    atBottomStateChange?: (atBottom: boolean) => void;
+    scrollerRef?: (ref: HTMLElement | null) => void;
+    totalListHeightChanged?: (height: number) => void;
   }) => {
     const Footer = components?.Footer;
+    useEffect(() => {
+      const el = document.querySelector<HTMLElement>(
+        "[data-testid='virtuoso-mock']",
+      );
+      scrollerRef?.(el);
+      totalListHeightChanged?.(0);
+      atBottomStateChange?.(false);
+      return () => scrollerRef?.(null);
+    }, [atBottomStateChange, scrollerRef, totalListHeightChanged]);
     return (
       <div className={className} data-testid="virtuoso-mock">
         {data.map((item, index) => (
@@ -268,7 +289,9 @@ describe("ChatInput", () => {
 
     unmount();
 
-    expect(document.body.classList.contains("ae-resizing-composer")).toBe(false);
+    expect(document.body.classList.contains("ae-resizing-composer")).toBe(
+      false,
+    );
   });
 
   it("shows the running-turn shortcut hint only when busy", () => {
@@ -278,7 +301,11 @@ describe("ChatInput", () => {
     expect(screen.getByText("Cmd/Ctrl+Enter steers")).toBeTruthy();
 
     cleanup();
-    renderInput(vi.fn(), { disabled: { $ref: "/waiting" } }, { waiting: false });
+    renderInput(
+      vi.fn(),
+      { disabled: { $ref: "/waiting" } },
+      { waiting: false },
+    );
     expect(screen.queryByText("Enter queues")).toBeNull();
   });
 
@@ -290,12 +317,16 @@ describe("ChatInput", () => {
     );
 
     expect(
-      screen.getByRole("button", { name: "Stop + clear" }).getAttribute("title"),
+      screen
+        .getByRole("button", { name: "Stop + clear" })
+        .getAttribute("title"),
     ).toBe("Stop the current prompt and clear 2 messages queued");
     expect(screen.getByText("+2").getAttribute("title")).toBe(
       "2 messages queued behind the current prompt",
     );
-    expect(screen.getByText("Cmd/Ctrl+Enter steers latest queued")).toBeTruthy();
+    expect(
+      screen.getByText("Cmd/Ctrl+Enter steers latest queued"),
+    ).toBeTruthy();
   });
 
   it("renders draft image attachments and submits them with the message", () => {
@@ -366,6 +397,16 @@ describe("ChatInput", () => {
       messageId: "1",
       value: "again please",
     });
+  });
+
+  it("keeps the latest pill hidden when the feed is not scrollable", () => {
+    renderHistory({
+      messages: [{ id: "1", role: "agent", text: "short answer" }],
+    });
+
+    expect(
+      screen.queryByRole("button", { name: "Scroll to latest message" }),
+    ).toBeNull();
   });
 
   it("renders user image attachments and opens them in a lightbox", () => {
@@ -450,9 +491,7 @@ describe("ChatInput", () => {
       throw new Error("opener failed");
     });
     renderHistory({
-      messages: [
-        { id: "1", role: "agent", text: "https://example.com/fail" },
-      ],
+      messages: [{ id: "1", role: "agent", text: "https://example.com/fail" }],
     });
 
     expect(() =>

--- a/src/extensions/default-layout/chat.test.tsx
+++ b/src/extensions/default-layout/chat.test.tsx
@@ -19,7 +19,7 @@ vi.mock("@tauri-apps/plugin-opener", () => ({
 
 vi.mock("@tauri-apps/api/core", () => ({
   convertFileSrc: (path: string) => `asset://${path}`,
-  invoke: vi.fn(),
+  invoke: vi.fn(() => Promise.reject(new Error("invoke not mocked"))),
 }));
 
 vi.mock("../../components/HighlightedCode", () => ({

--- a/src/extensions/default-layout/chat.test.tsx
+++ b/src/extensions/default-layout/chat.test.tsx
@@ -314,6 +314,11 @@ describe("ChatInput", () => {
     );
 
     expect(screen.getByText("one.png")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Open one.png" }));
+    expect(screen.getByRole("dialog")).toBeTruthy();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByRole("dialog")).toBeNull();
+
     fireEvent.keyDown(input, { key: "Enter" });
 
     expect(onEvent).toHaveBeenLastCalledWith("submit", {

--- a/src/extensions/default-layout/dashboard/issues-section.test.ts
+++ b/src/extensions/default-layout/dashboard/issues-section.test.ts
@@ -12,16 +12,15 @@ import { IssuesSection } from "./issues-section";
 import { buildIssueBranch, buildIssuePrompt } from "./issue-task";
 import type { GhIssue } from "../../../ghIssuesCache";
 
-const { getIssues, getIssueDetail, openUrl } = vi.hoisted(() => ({
-  getIssues: vi.fn(),
+const { getIssueDetail, refreshIssues, openUrl } = vi.hoisted(() => ({
   getIssueDetail: vi.fn(),
+  refreshIssues: vi.fn(),
   openUrl: vi.fn(),
 }));
 
 vi.mock("../../../ghIssuesCache", () => ({
-  getIssues: (...args: unknown[]) => getIssues(...args),
   getIssueDetail: (...args: unknown[]) => getIssueDetail(...args),
-  refreshIssues: vi.fn(),
+  refreshIssues: (...args: unknown[]) => refreshIssues(...args),
 }));
 
 vi.mock("@tauri-apps/plugin-opener", () => ({
@@ -45,7 +44,7 @@ const issue: GhIssue = {
 };
 
 function renderIssues(onEvent = vi.fn()) {
-  getIssues.mockResolvedValue([issue]);
+  refreshIssues.mockResolvedValue([issue]);
   getIssueDetail.mockResolvedValue({
     ...issue,
     body: "Rename should stay available.",
@@ -206,6 +205,13 @@ describe("issues-section task helpers", () => {
 });
 
 describe("IssuesSection", () => {
+  it("force-refreshes issues on first visible load", async () => {
+    renderIssues();
+
+    await screen.findByText(issue.title);
+    expect(refreshIssues).toHaveBeenCalledWith("/repo/aethon", 30);
+  });
+
   it("sends the hover action to a fresh worktree by default", async () => {
     const { onEvent } = renderIssues();
 

--- a/src/extensions/default-layout/dashboard/issues-section.tsx
+++ b/src/extensions/default-layout/dashboard/issues-section.tsx
@@ -33,7 +33,6 @@ import { resolvePointer } from "../../../utils/jsonPointer";
 import {
   type GhIssue,
   getIssueDetail,
-  getIssues,
   refreshIssues,
 } from "../../../ghIssuesCache";
 import { formatRelativeTime } from "../../../utils/time";
@@ -171,7 +170,7 @@ export function IssuesSection({
     if (loadedFor === project.path) return;
     let cancelled = false;
     void (async () => {
-      const fetched = await getIssues(project.path, limit);
+      const fetched = await refreshIssues(project.path, limit);
       if (cancelled) return;
       setIssues(fetched);
       setLoadedFor(project.path);
@@ -310,6 +309,7 @@ export function IssuesSection({
               try {
                 const fresh = await refreshIssues(project.path, limit);
                 setIssues(fresh);
+                setLoadedFor(project.path);
               } finally {
                 setRefreshing(false);
               }

--- a/src/extensions/default-layout/dashboard/project-dashboard.test.tsx
+++ b/src/extensions/default-layout/dashboard/project-dashboard.test.tsx
@@ -7,16 +7,23 @@ import type { A2UIComponent } from "../../../types/a2ui";
 import { ExtensionRegistry } from "../../ExtensionRegistry";
 import { ExtensionRegistryProvider } from "../../ExtensionRegistryProvider";
 
-vi.mock("../../../ghRepoOverviewCache", () => ({
-  getRepoOverview: vi.fn(
-    () =>
+const { refreshRepoOverview } = vi.hoisted(() => ({
+  refreshRepoOverview: vi.fn(
+    (_projectPath: string) =>
       new Promise(() => {
         /* keep dashboard overview pending */
       }),
   ),
 }));
 
-afterEach(() => cleanup());
+vi.mock("../../../ghRepoOverviewCache", () => ({
+  refreshRepoOverview: (projectPath: string) => refreshRepoOverview(projectPath),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
 
 function dashboard(props: Record<string, unknown>): A2UIComponent {
   return {
@@ -69,6 +76,12 @@ function renderDashboard(
 }
 
 describe("ProjectDashboard project icon", () => {
+  it("force-refreshes repo overview when the project dashboard loads", () => {
+    renderDashboard();
+
+    expect(refreshRepoOverview).toHaveBeenCalledWith("/repo");
+  });
+
   it("uses the discovered project icon in the hero when one is available", () => {
     const { container } = renderDashboard(vi.fn(), {
       id: "p1",

--- a/src/extensions/default-layout/dashboard/project-dashboard.tsx
+++ b/src/extensions/default-layout/dashboard/project-dashboard.tsx
@@ -21,7 +21,7 @@ import { AeMarkInline } from "../layout";
 import { RegistryComponent } from "../../../components/A2UIRenderer";
 import { DashboardSessionRow } from "./session-row";
 import {
-  getRepoOverview,
+  refreshRepoOverview,
   type GhRepoOverview,
 } from "../../../ghRepoOverviewCache";
 
@@ -152,26 +152,21 @@ export function ProjectDashboard({
       : null,
   );
 
-  // Eager fetch on project activation. The cache handles dedupe. Drops
+  // Eager refresh on project activation. Drops
   // the stale entry whenever `project.path` changes so the visible card
   // doesn't lag a project switch.
   useEffect(() => {
-    if (!project) return;
-    if (overview?.path === project.path && overview.data?.repo) return;
+    const projectPath = project?.path;
+    if (!projectPath) return;
     let cancelled = false;
-    // Optimistic clear so the previous project's strip / description
-    // doesn't briefly render under the new project's title.
-    if (overview && overview.path !== project.path) {
-      setOverview(null);
-    }
     void (async () => {
-      const o = await getRepoOverview(project.path);
-      if (!cancelled) setOverview({ path: project.path, data: o });
+      const o = await refreshRepoOverview(projectPath);
+      if (!cancelled) setOverview({ path: projectPath, data: o });
     })();
     return () => {
       cancelled = true;
     };
-  }, [project, overview]);
+  }, [project?.path]);
   const overviewData = overview?.path === project?.path ? overview?.data : null;
 
   if (!project) return null;

--- a/src/extensions/default-layout/dashboard/task-launcher.test.tsx
+++ b/src/extensions/default-layout/dashboard/task-launcher.test.tsx
@@ -93,6 +93,41 @@ describe("TaskLauncher", () => {
     }
   });
 
+  it("allows a new worktree session with an automatic branch", async () => {
+    const onEvent = vi.fn();
+    render(
+      <TaskLauncher
+        component={launcher({
+          project: { id: "p1", label: "aethon", path: "/repo/aethon" },
+        })}
+        state={{}}
+        onEvent={onEvent}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Task prompt"), {
+      target: { value: "start this" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Worktree" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "+ New worktree" }));
+
+    const start = screen.getByRole("button", { name: "Start" });
+    expect(start.hasAttribute("disabled")).toBe(false);
+    fireEvent.click(start);
+
+    await waitFor(() =>
+      expect(onEvent).toHaveBeenCalledWith(
+        "start-task",
+        expect.objectContaining({
+          projectId: "p1",
+          prompt: "start this",
+          newWorktree: true,
+          branch: "",
+        }),
+      ),
+    );
+  });
+
   it("resolves project via $ref", () => {
     const html = renderToStaticMarkup(
       <TaskLauncher

--- a/src/extensions/default-layout/dashboard/task-launcher.test.tsx
+++ b/src/extensions/default-layout/dashboard/task-launcher.test.tsx
@@ -69,6 +69,30 @@ describe("TaskLauncher", () => {
     expect(html).toContain("Start");
   });
 
+  it("disables OS autocorrection on branch inputs", () => {
+    render(
+      <TaskLauncher
+        component={launcher({
+          project: { id: "p1", label: "aethon", path: "/a" },
+        })}
+        state={{}}
+        onEvent={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Worktree" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "+ New worktree" }));
+
+    for (const input of [
+      screen.getByLabelText("New branch name"),
+      screen.getByLabelText("Base branch (empty = project default)"),
+    ]) {
+      expect(input.getAttribute("autocapitalize")).toBe("none");
+      expect(input.getAttribute("autocorrect")).toBe("off");
+      expect(input.getAttribute("spellcheck")).toBe("false");
+    }
+  });
+
   it("resolves project via $ref", () => {
     const html = renderToStaticMarkup(
       <TaskLauncher

--- a/src/extensions/default-layout/dashboard/task-launcher.test.tsx
+++ b/src/extensions/default-layout/dashboard/task-launcher.test.tsx
@@ -133,6 +133,11 @@ describe("TaskLauncher", () => {
     });
 
     await screen.findByText("shot.png");
+    fireEvent.click(screen.getByRole("button", { name: "Open shot.png" }));
+    expect(screen.getByRole("dialog")).toBeTruthy();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByRole("dialog")).toBeNull();
+
     fireEvent.click(screen.getByRole("button", { name: "Start" }));
 
     await waitFor(() =>

--- a/src/extensions/default-layout/dashboard/task-launcher.test.tsx
+++ b/src/extensions/default-layout/dashboard/task-launcher.test.tsx
@@ -1,10 +1,19 @@
 // @vitest-environment jsdom
 
 import { renderToStaticMarkup } from "react-dom/server";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { TaskLauncher } from "./task-launcher";
 import type { A2UIComponent } from "../../../types/a2ui";
+
+const { invoke } = vi.hoisted(() => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  convertFileSrc: (path: string) => `asset://${path}`,
+  invoke: (...args: unknown[]) => invoke(...args),
+}));
 
 function launcher(props: Record<string, unknown>): A2UIComponent {
   return {
@@ -14,7 +23,10 @@ function launcher(props: Record<string, unknown>): A2UIComponent {
   };
 }
 
-afterEach(() => cleanup());
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
 
 describe("TaskLauncher", () => {
   it("renders prompt placeholder with the project name", () => {
@@ -92,5 +104,52 @@ describe("TaskLauncher", () => {
     expect(screen.getByRole("menu")).toBeTruthy();
     fireEvent.focusIn(screen.getByRole("button", { name: "outside" }));
     expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("pastes image attachments into the task launcher and submits them", async () => {
+    invoke.mockResolvedValue("/Users/james/.aethon/pastes/pasted.png");
+    const onEvent = vi.fn();
+    render(
+      <TaskLauncher
+        component={launcher({
+          project: { id: "p1", label: "aethon", path: "/a" },
+        })}
+        state={{}}
+        onEvent={onEvent}
+      />,
+    );
+    const input = screen.getByLabelText("Task prompt");
+    const file = new File(["abc"], "shot.png", { type: "image/png" });
+    fireEvent.paste(input, {
+      clipboardData: {
+        items: [
+          {
+            kind: "file",
+            type: "image/png",
+            getAsFile: () => file,
+          },
+        ],
+      },
+    });
+
+    await screen.findByText("shot.png");
+    fireEvent.click(screen.getByRole("button", { name: "Start" }));
+
+    await waitFor(() =>
+      expect(onEvent).toHaveBeenCalledWith(
+        "start-task",
+        expect.objectContaining({
+          projectId: "p1",
+          prompt: "",
+          attachments: [
+            expect.objectContaining({
+              name: "shot.png",
+              path: "/Users/james/.aethon/pastes/pasted.png",
+              mimeType: "image/png",
+            }),
+          ],
+        }),
+      ),
+    );
   });
 });

--- a/src/extensions/default-layout/dashboard/task-launcher.test.tsx
+++ b/src/extensions/default-layout/dashboard/task-launcher.test.tsx
@@ -1,7 +1,13 @@
 // @vitest-environment jsdom
 
 import { renderToStaticMarkup } from "react-dom/server";
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { TaskLauncher } from "./task-launcher";
 import type { A2UIComponent } from "../../../types/a2ui";
@@ -44,11 +50,7 @@ describe("TaskLauncher", () => {
 
   it("renders nothing when no project is set", () => {
     const html = renderToStaticMarkup(
-      <TaskLauncher
-        component={launcher({})}
-        state={{}}
-        onEvent={() => {}}
-      />,
+      <TaskLauncher component={launcher({})} state={{}} onEvent={() => {}} />,
     );
     expect(html).toBe("");
   });
@@ -107,7 +109,7 @@ describe("TaskLauncher", () => {
   });
 
   it("pastes image attachments into the task launcher and submits them", async () => {
-    invoke.mockResolvedValue("/Users/james/.aethon/pastes/pasted.png");
+    invoke.mockResolvedValue("/tmp/aethon-pastes/pasted.png");
     const onEvent = vi.fn();
     render(
       <TaskLauncher
@@ -149,7 +151,7 @@ describe("TaskLauncher", () => {
           attachments: [
             expect.objectContaining({
               name: "shot.png",
-              path: "/Users/james/.aethon/pastes/pasted.png",
+              path: "/tmp/aethon-pastes/pasted.png",
               mimeType: "image/png",
             }),
           ],

--- a/src/extensions/default-layout/dashboard/task-launcher.test.tsx
+++ b/src/extensions/default-layout/dashboard/task-launcher.test.tsx
@@ -218,4 +218,38 @@ describe("TaskLauncher", () => {
       ),
     );
   });
+
+  it("emits an event when pasted image persistence fails", async () => {
+    invoke.mockRejectedValue(new Error("payload exceeds 32 MiB"));
+    const onEvent = vi.fn();
+    render(
+      <TaskLauncher
+        component={launcher({
+          project: { id: "p1", label: "aethon", path: "/a" },
+        })}
+        state={{}}
+        onEvent={onEvent}
+      />,
+    );
+    const input = screen.getByLabelText("Task prompt");
+    const file = new File(["abc"], "huge.png", { type: "image/png" });
+    fireEvent.paste(input, {
+      clipboardData: {
+        items: [
+          {
+            kind: "file",
+            type: "image/png",
+            getAsFile: () => file,
+          },
+        ],
+      },
+    });
+
+    await waitFor(() =>
+      expect(onEvent).toHaveBeenCalledWith("paste-image-failed", {
+        message: "payload exceeds 32 MiB",
+      }),
+    );
+    expect(screen.queryByText("huge.png")).toBeNull();
+  });
 });

--- a/src/extensions/default-layout/dashboard/task-launcher.tsx
+++ b/src/extensions/default-layout/dashboard/task-launcher.tsx
@@ -169,7 +169,6 @@ export function TaskLauncher({
     const text = promptText.trim();
     if (!text && attachments.length === 0) return;
     if (!data.project) return;
-    if (worktreeChoice.kind === "new" && !newBranch.trim()) return;
     setSubmitting(true);
     const baseTrimmed = baseBranch.trim();
     onEvent("start-task", {
@@ -387,8 +386,7 @@ export function TaskLauncher({
           onClick={submit}
           disabled={
             submitting ||
-            (!promptText.trim() && attachments.length === 0) ||
-            (worktreeChoice.kind === "new" && !newBranch.trim())
+            (!promptText.trim() && attachments.length === 0)
           }
         >
           {submitting ? "…" : "Start"}

--- a/src/extensions/default-layout/dashboard/task-launcher.tsx
+++ b/src/extensions/default-layout/dashboard/task-launcher.tsx
@@ -25,6 +25,7 @@ import {
   imageAttachmentSrc,
   saveClipboardImageAttachment,
 } from "../../../utils/imageAttachments";
+import { ImageLightbox } from "../image-lightbox";
 
 interface ProjectLite {
   id: string;
@@ -111,6 +112,9 @@ export function TaskLauncher({
 
   const [promptText, setPromptText] = useState(initialPrompt);
   const [attachments, setAttachments] = useState<ChatAttachment[]>([]);
+  const [openAttachment, setOpenAttachment] = useState<ChatAttachment | null>(
+    null,
+  );
   // Seed worktree selection from the project's currently-active
   // worktree so the chip shows what the user has switched to in the
   // sidebar, not just "project root". Falls back to "current" (project
@@ -258,10 +262,18 @@ export function TaskLauncher({
         <div className="a2ui-task-launcher-attachments">
           {attachments.map((attachment) => (
             <figure className="a2ui-task-launcher-attachment" key={attachment.id}>
-              <img src={imageAttachmentSrc(attachment)} alt={attachment.name} />
+              <button
+                type="button"
+                className="a2ui-task-launcher-attachment-thumb"
+                aria-label={`Open ${attachment.name}`}
+                onClick={() => setOpenAttachment(attachment)}
+              >
+                <img src={imageAttachmentSrc(attachment)} alt="" />
+              </button>
               <figcaption title={attachment.name}>{attachment.name}</figcaption>
               <button
                 type="button"
+                className="a2ui-task-launcher-attachment-remove"
                 aria-label={`Remove ${attachment.name}`}
                 onClick={() =>
                   setAttachments((current) =>
@@ -274,6 +286,12 @@ export function TaskLauncher({
             </figure>
           ))}
         </div>
+      )}
+      {openAttachment && (
+        <ImageLightbox
+          attachment={openAttachment}
+          onClose={() => setOpenAttachment(null)}
+        />
       )}
       <div className="a2ui-task-launcher-row">
         <ChipMenu

--- a/src/extensions/default-layout/dashboard/task-launcher.tsx
+++ b/src/extensions/default-layout/dashboard/task-launcher.tsx
@@ -231,6 +231,10 @@ export function TaskLauncher({
       .then((saved) => setAttachments((current) => [...current, ...saved]))
       .catch((err) => {
         console.warn("task-launcher paste image failed:", err);
+        onEvent("paste-image-failed", {
+          message:
+            err instanceof Error ? err.message : "Could not paste image.",
+        });
       });
   };
 
@@ -385,8 +389,7 @@ export function TaskLauncher({
           className="a2ui-task-launcher-submit"
           onClick={submit}
           disabled={
-            submitting ||
-            (!promptText.trim() && attachments.length === 0)
+            submitting || (!promptText.trim() && attachments.length === 0)
           }
         >
           {submitting ? "…" : "Start"}

--- a/src/extensions/default-layout/dashboard/task-launcher.tsx
+++ b/src/extensions/default-layout/dashboard/task-launcher.tsx
@@ -71,6 +71,12 @@ type WorktreeChoice =
   | { kind: "existing"; id: string; path: string; label: string }
   | { kind: "new" };
 
+const codeInputProps = {
+  autoCapitalize: "none",
+  autoCorrect: "off",
+  spellCheck: false,
+} as const;
+
 export function TaskLauncher({
   component,
   state,
@@ -361,6 +367,7 @@ export function TaskLauncher({
               value={newBranch}
               onChange={(e) => setNewBranch(e.target.value)}
               aria-label="New branch name"
+              {...codeInputProps}
             />
             <input
               type="text"
@@ -370,6 +377,7 @@ export function TaskLauncher({
               onChange={(e) => setBaseBranch(e.target.value)}
               aria-label="Base branch (empty = project default)"
               title="Base branch to fork from. Leave empty to use the project default."
+              {...codeInputProps}
             />
           </>
         )}

--- a/src/extensions/default-layout/dashboard/task-launcher.tsx
+++ b/src/extensions/default-layout/dashboard/task-launcher.tsx
@@ -21,10 +21,8 @@ import type { BuiltinComponentProps } from "../../../components/A2UIRenderer";
 import type { ChatAttachment } from "../../../types/a2ui";
 import { resolvePointer } from "../../../utils/jsonPointer";
 import { DEFAULT_WORKTREE_BASE_BRANCH } from "../../../projects";
-import {
-  imageAttachmentSrc,
-  saveClipboardImageAttachment,
-} from "../../../utils/imageAttachments";
+import { saveClipboardImageAttachment } from "../../../utils/imageAttachments";
+import { ImageAttachmentImage } from "../image-attachment-image";
 import { ImageLightbox } from "../image-lightbox";
 
 interface ProjectLite {
@@ -53,10 +51,13 @@ interface LauncherData {
 }
 
 function isRef(v: unknown): v is { $ref: string } {
-  return typeof v === "object" && v !== null && "$ref" in (v);
+  return typeof v === "object" && v !== null && "$ref" in v;
 }
 
-function resolveOrInline<T>(v: unknown, state: Record<string, unknown>): T | null {
+function resolveOrInline<T>(
+  v: unknown,
+  state: Record<string, unknown>,
+): T | null {
   if (!v) return null;
   if (isRef(v)) {
     const r = resolvePointer(state, v.$ref);
@@ -91,8 +92,7 @@ export function TaskLauncher({
       project: resolveOrInline<ProjectLite>(props?.project, state),
       otherProjects:
         resolveOrInline<ProjectLite[]>(props?.otherProjects, state) ?? [],
-      worktrees:
-        resolveOrInline<WorktreeLite[]>(props?.worktrees, state) ?? [],
+      worktrees: resolveOrInline<WorktreeLite[]>(props?.worktrees, state) ?? [],
       activeWorktreeId:
         resolveOrInline<string>(props?.activeWorktreeId, state) ?? null,
     }),
@@ -171,8 +171,7 @@ export function TaskLauncher({
       prompt: text,
       attachments,
       newWorktree: worktreeChoice.kind === "new",
-      branch:
-        worktreeChoice.kind === "new" ? newBranch.trim() : undefined,
+      branch: worktreeChoice.kind === "new" ? newBranch.trim() : undefined,
       baseBranch:
         worktreeChoice.kind === "new" && baseTrimmed.length > 0
           ? baseTrimmed
@@ -236,8 +235,8 @@ export function TaskLauncher({
     worktreeChoice.kind === "current"
       ? "project root"
       : worktreeChoice.kind === "existing"
-      ? worktreeChoice.label
-      : "+ New worktree";
+        ? worktreeChoice.label
+        : "+ New worktree";
 
   return (
     <div className="a2ui-task-launcher">
@@ -261,14 +260,17 @@ export function TaskLauncher({
       {attachments.length > 0 && (
         <div className="a2ui-task-launcher-attachments">
           {attachments.map((attachment) => (
-            <figure className="a2ui-task-launcher-attachment" key={attachment.id}>
+            <figure
+              className="a2ui-task-launcher-attachment"
+              key={attachment.id}
+            >
               <button
                 type="button"
                 className="a2ui-task-launcher-attachment-thumb"
                 aria-label={`Open ${attachment.name}`}
                 onClick={() => setOpenAttachment(attachment)}
               >
-                <img src={imageAttachmentSrc(attachment)} alt="" />
+                <ImageAttachmentImage attachment={attachment} alt="" />
               </button>
               <figcaption title={attachment.name}>{attachment.name}</figcaption>
               <button

--- a/src/extensions/default-layout/dashboard/task-launcher.tsx
+++ b/src/extensions/default-layout/dashboard/task-launcher.tsx
@@ -18,8 +18,13 @@
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { BuiltinComponentProps } from "../../../components/A2UIRenderer";
+import type { ChatAttachment } from "../../../types/a2ui";
 import { resolvePointer } from "../../../utils/jsonPointer";
 import { DEFAULT_WORKTREE_BASE_BRANCH } from "../../../projects";
+import {
+  imageAttachmentSrc,
+  saveClipboardImageAttachment,
+} from "../../../utils/imageAttachments";
 
 interface ProjectLite {
   id: string;
@@ -105,6 +110,7 @@ export function TaskLauncher({
   );
 
   const [promptText, setPromptText] = useState(initialPrompt);
+  const [attachments, setAttachments] = useState<ChatAttachment[]>([]);
   // Seed worktree selection from the project's currently-active
   // worktree so the chip shows what the user has switched to in the
   // sidebar, not just "project root". Falls back to "current" (project
@@ -128,7 +134,8 @@ export function TaskLauncher({
   // implies intent, so don't yank their selection out from under them.
   const [touched, setTouched] = useState(false);
   useEffect(() => {
-    if (!touched) setWorktreeChoice(initialChoice);
+    if (touched) return;
+    queueMicrotask(() => setWorktreeChoice(initialChoice));
   }, [initialChoice, touched]);
   const [newBranch, setNewBranch] = useState("");
   const defaultBaseBranch =
@@ -150,7 +157,7 @@ export function TaskLauncher({
   const submit = useCallback(() => {
     if (submitting) return;
     const text = promptText.trim();
-    if (!text) return;
+    if (!text && attachments.length === 0) return;
     if (!data.project) return;
     if (worktreeChoice.kind === "new" && !newBranch.trim()) return;
     setSubmitting(true);
@@ -158,6 +165,7 @@ export function TaskLauncher({
     onEvent("start-task", {
       projectId: data.project.id,
       prompt: text,
+      attachments,
       newWorktree: worktreeChoice.kind === "new",
       branch:
         worktreeChoice.kind === "new" ? newBranch.trim() : undefined,
@@ -174,11 +182,13 @@ export function TaskLauncher({
     // will surface the error via the notification stack. Reset `touched`
     // so a fresh dashboard visit re-syncs to the active worktree.
     setPromptText("");
+    setAttachments([]);
     setTouched(false);
     setSubmitting(false);
   }, [
     submitting,
     promptText,
+    attachments,
     data.project,
     worktreeChoice,
     newBranch,
@@ -194,6 +204,26 @@ export function TaskLauncher({
       e.preventDefault();
       submit();
     }
+  };
+
+  const onPaste = (event: React.ClipboardEvent<HTMLTextAreaElement>) => {
+    const items = event.clipboardData?.items;
+    if (!items || items.length === 0) return;
+    const files: File[] = [];
+    for (let i = 0; i < items.length; i += 1) {
+      const item = items[i];
+      if (item.kind === "file" && item.type.startsWith("image/")) {
+        const file = item.getAsFile();
+        if (file) files.push(file);
+      }
+    }
+    if (files.length === 0) return;
+    event.preventDefault();
+    void Promise.all(files.map((file) => saveClipboardImageAttachment(file)))
+      .then((saved) => setAttachments((current) => [...current, ...saved]))
+      .catch((err) => {
+        console.warn("task-launcher paste image failed:", err);
+      });
   };
 
   if (!data.project) return null;
@@ -219,10 +249,32 @@ export function TaskLauncher({
           setPromptText(e.target.value);
           setTouched(true);
         }}
+        onPaste={onPaste}
         onKeyDown={onKey}
         disabled={submitting}
         aria-label="Task prompt"
       />
+      {attachments.length > 0 && (
+        <div className="a2ui-task-launcher-attachments">
+          {attachments.map((attachment) => (
+            <figure className="a2ui-task-launcher-attachment" key={attachment.id}>
+              <img src={imageAttachmentSrc(attachment)} alt={attachment.name} />
+              <figcaption title={attachment.name}>{attachment.name}</figcaption>
+              <button
+                type="button"
+                aria-label={`Remove ${attachment.name}`}
+                onClick={() =>
+                  setAttachments((current) =>
+                    current.filter((item) => item.id !== attachment.id),
+                  )
+                }
+              >
+                ×
+              </button>
+            </figure>
+          ))}
+        </div>
+      )}
       <div className="a2ui-task-launcher-row">
         <ChipMenu
           label={data.project.label}
@@ -307,7 +359,7 @@ export function TaskLauncher({
           onClick={submit}
           disabled={
             submitting ||
-            !promptText.trim() ||
+            (!promptText.trim() && attachments.length === 0) ||
             (worktreeChoice.kind === "new" && !newBranch.trim())
           }
         >

--- a/src/extensions/default-layout/image-attachment-image.test.tsx
+++ b/src/extensions/default-layout/image-attachment-image.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ImageAttachmentImage } from "./image-attachment-image";
+import type { ChatAttachment } from "../../types/a2ui";
+
+const { invoke } = vi.hoisted(() => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  convertFileSrc: (path: string) => `asset://${path}`,
+  invoke: (...args: unknown[]) => invoke(...args),
+}));
+
+const attachment: ChatAttachment = {
+  id: "img-1",
+  kind: "image",
+  path: "/tmp/one.png",
+  name: "one.png",
+  mimeType: "image/png",
+  sizeBytes: 10,
+};
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("ImageAttachmentImage", () => {
+  it("uses the asset URL without eagerly reading pasted image bytes", () => {
+    render(<ImageAttachmentImage attachment={attachment} alt="one" />);
+
+    const img = screen.getByAltText("one");
+    expect(img.getAttribute("src")).toBe("asset:///tmp/one.png");
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it("reads pasted image bytes only when the asset URL fails", async () => {
+    invoke.mockResolvedValue("abc123");
+    render(<ImageAttachmentImage attachment={attachment} alt="one" />);
+
+    const img = screen.getByAltText("one");
+    fireEvent.error(img);
+
+    await waitFor(() =>
+      expect(invoke).toHaveBeenCalledWith("read_paste_image_base64", {
+        path: "/tmp/one.png",
+      }),
+    );
+    await waitFor(() =>
+      expect(img.getAttribute("src")).toBe("data:image/png;base64,abc123"),
+    );
+  });
+});

--- a/src/extensions/default-layout/image-attachment-image.tsx
+++ b/src/extensions/default-layout/image-attachment-image.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useMemo, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import type { ChatAttachment } from "../../types/a2ui";
+import { imageAttachmentSrc } from "../../utils/imageAttachments";
+
+export function ImageAttachmentImage({
+  attachment,
+  alt,
+}: {
+  attachment: ChatAttachment;
+  alt: string;
+}) {
+  const cacheKey = `${attachment.path}\0${attachment.mimeType}`;
+  const fallbackSrc = useMemo(
+    () => imageAttachmentSrc(attachment),
+    [attachment],
+  );
+  const [pasteResult, setPasteResult] = useState<{
+    key: string;
+    src: string | null;
+  } | null>(null);
+  const src =
+    pasteResult?.key === cacheKey && pasteResult.src
+      ? pasteResult.src
+      : fallbackSrc;
+  const attemptedPasteRead = pasteResult?.key === cacheKey;
+
+  useEffect(() => {
+    if (attachment.previewUrl) return;
+    let cancelled = false;
+    void invoke<string>("read_paste_image_base64", { path: attachment.path })
+      .then((base64) => {
+        if (cancelled) return;
+        setPasteResult({
+          key: cacheKey,
+          src: `data:${attachment.mimeType};base64,${base64}`,
+        });
+      })
+      .catch(() => {
+        if (!cancelled) setPasteResult({ key: cacheKey, src: null });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [attachment.mimeType, attachment.path, attachment.previewUrl, cacheKey]);
+
+  const loadPasteFallback = () => {
+    if (attemptedPasteRead) return;
+    void invoke<string>("read_paste_image_base64", { path: attachment.path })
+      .then((base64) =>
+        setPasteResult({
+          key: cacheKey,
+          src: `data:${attachment.mimeType};base64,${base64}`,
+        }),
+      )
+      .catch(() => {
+        setPasteResult({ key: cacheKey, src: null });
+      });
+  };
+
+  return <img src={src} alt={alt} onError={loadPasteFallback} />;
+}

--- a/src/extensions/default-layout/image-attachment-image.tsx
+++ b/src/extensions/default-layout/image-attachment-image.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import type { ChatAttachment } from "../../types/a2ui";
 import { imageAttachmentSrc } from "../../utils/imageAttachments";
@@ -24,25 +24,6 @@ export function ImageAttachmentImage({
       ? pasteResult.src
       : fallbackSrc;
   const attemptedPasteRead = pasteResult?.key === cacheKey;
-
-  useEffect(() => {
-    if (attachment.previewUrl) return;
-    let cancelled = false;
-    void invoke<string>("read_paste_image_base64", { path: attachment.path })
-      .then((base64) => {
-        if (cancelled) return;
-        setPasteResult({
-          key: cacheKey,
-          src: `data:${attachment.mimeType};base64,${base64}`,
-        });
-      })
-      .catch(() => {
-        if (!cancelled) setPasteResult({ key: cacheKey, src: null });
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [attachment.mimeType, attachment.path, attachment.previewUrl, cacheKey]);
 
   const loadPasteFallback = () => {
     if (attemptedPasteRead) return;

--- a/src/extensions/default-layout/image-lightbox.tsx
+++ b/src/extensions/default-layout/image-lightbox.tsx
@@ -20,7 +20,12 @@ export function ImageLightbox({
   }, [onClose]);
 
   return (
-    <div className="a2ui-image-lightbox" role="dialog" aria-modal="true">
+    <div
+      className="a2ui-image-lightbox"
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Image preview: ${attachment.name}`}
+    >
       <button
         type="button"
         className="a2ui-image-lightbox-backdrop"

--- a/src/extensions/default-layout/image-lightbox.tsx
+++ b/src/extensions/default-layout/image-lightbox.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import type { ChatAttachment } from "../../types/a2ui";
-import { imageAttachmentSrc } from "../../utils/imageAttachments";
+import { ImageAttachmentImage } from "./image-attachment-image";
 
 export function ImageLightbox({
   attachment,
@@ -28,7 +28,7 @@ export function ImageLightbox({
         onClick={onClose}
       />
       <figure className="a2ui-image-lightbox-figure">
-        <img src={imageAttachmentSrc(attachment)} alt={attachment.name} />
+        <ImageAttachmentImage attachment={attachment} alt={attachment.name} />
         <figcaption>{attachment.name}</figcaption>
         <button
           type="button"

--- a/src/extensions/default-layout/image-lightbox.tsx
+++ b/src/extensions/default-layout/image-lightbox.tsx
@@ -1,0 +1,45 @@
+import { useEffect } from "react";
+import type { ChatAttachment } from "../../types/a2ui";
+import { imageAttachmentSrc } from "../../utils/imageAttachments";
+
+export function ImageLightbox({
+  attachment,
+  onClose,
+}: {
+  attachment: ChatAttachment;
+  onClose: () => void;
+}) {
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  return (
+    <div className="a2ui-image-lightbox" role="dialog" aria-modal="true">
+      <button
+        type="button"
+        className="a2ui-image-lightbox-backdrop"
+        aria-label="Close image preview"
+        onClick={onClose}
+      />
+      <figure className="a2ui-image-lightbox-figure">
+        <img src={imageAttachmentSrc(attachment)} alt={attachment.name} />
+        <figcaption>{attachment.name}</figcaption>
+        <button
+          type="button"
+          className="a2ui-image-lightbox-close"
+          aria-label="Close image preview"
+          onClick={onClose}
+          autoFocus
+        >
+          ×
+        </button>
+      </figure>
+    </div>
+  );
+}

--- a/src/extensions/default-layout/message-list.tsx
+++ b/src/extensions/default-layout/message-list.tsx
@@ -399,7 +399,11 @@ function VirtualMessageList({
       // through it. Virtuoso measures the wrapper, so the margins are counted —
       // bare margins on the row would escape measurement and drift the
       // follow-to-bottom / scrollToIndex offsets in long transcripts.
-      <div className="a2ui-msg-row">
+      <div
+        className={`a2ui-msg-row${index === 0 ? " a2ui-msg-row-first" : ""}${
+          index === messages.length - 1 ? " a2ui-msg-row-last" : ""
+        }`}
+      >
         <ChatMessageRow
           message={m}
           state={state}

--- a/src/extensions/default-layout/message-list.tsx
+++ b/src/extensions/default-layout/message-list.tsx
@@ -1,11 +1,4 @@
-import {
-  memo,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
 import type {
@@ -346,9 +339,41 @@ function VirtualMessageList({
 }: VirtualMessageListProps) {
   const virtuosoRef = useRef<VirtuosoHandle>(null);
   const [isAtBottom, setIsAtBottom] = useState(true);
+  const [canScroll, setCanScroll] = useState(false);
+  const scrollerElRef = useRef<HTMLElement | null>(null);
   const [flashIndex, setFlashIndex] = useState<number | null>(null);
   const prevScrollToMatch = useRef<string | undefined>(undefined);
-  const queuedLabels = useMemo(() => queuedDeliveryLabels(messages), [messages]);
+  const queuedLabels = useMemo(
+    () => queuedDeliveryLabels(messages),
+    [messages],
+  );
+  const updateCanScroll = useCallback(() => {
+    const el = scrollerElRef.current;
+    setCanScroll(
+      Boolean(
+        el && el.scrollHeight - el.clientHeight > DEFAULT_AT_BOTTOM_THRESHOLD,
+      ),
+    );
+  }, []);
+
+  const handleScrollerRef = useCallback(
+    (ref: HTMLElement | Window | null) => {
+      scrollerElRef.current =
+        typeof HTMLElement !== "undefined" && ref instanceof HTMLElement
+          ? ref
+          : null;
+      updateCanScroll();
+    },
+    [updateCanScroll],
+  );
+
+  const handleAtBottomStateChange = useCallback(
+    (atBottom: boolean) => {
+      updateCanScroll();
+      setIsAtBottom(atBottom);
+    },
+    [updateCanScroll],
+  );
 
   // Jump to the newest message matching the search needle and flash it. Virtuoso
   // mounts the target row even when it's far offscreen, so no DOM walk is needed.
@@ -430,11 +455,13 @@ function VirtualMessageList({
         }}
         followOutput="auto"
         atBottomThreshold={DEFAULT_AT_BOTTOM_THRESHOLD}
-        atBottomStateChange={setIsAtBottom}
+        atBottomStateChange={handleAtBottomStateChange}
+        scrollerRef={handleScrollerRef}
+        totalListHeightChanged={updateCanScroll}
         {...footerProps}
       />
       <ScrollToBottomPill
-        visible={!isAtBottom && hasContent}
+        visible={!isAtBottom && canScroll && hasContent}
         onClick={() =>
           // Scroll to the true bottom of the scroller, which includes the
           // Footer (live subtree / typing indicator) — scrollToIndex(last)

--- a/src/extensions/default-layout/message-list.tsx
+++ b/src/extensions/default-layout/message-list.tsx
@@ -16,6 +16,7 @@ import {
   CHAT_MARKDOWN_COMPONENTS,
   MARKDOWN_REMARK_PLUGINS,
 } from "./markdown-adapter";
+import { isAtBottom as metricsAreAtBottom } from "../../utils/stickyScrollController";
 import { ImageAttachmentImage } from "./image-attachment-image";
 import { ImageLightbox } from "./image-lightbox";
 
@@ -341,6 +342,7 @@ function VirtualMessageList({
   const [isAtBottom, setIsAtBottom] = useState(true);
   const [canScroll, setCanScroll] = useState(false);
   const scrollerElRef = useRef<HTMLElement | null>(null);
+  const followLatestRef = useRef(true);
   const [flashIndex, setFlashIndex] = useState<number | null>(null);
   const prevScrollToMatch = useRef<string | undefined>(undefined);
   const queuedLabels = useMemo(
@@ -356,23 +358,68 @@ function VirtualMessageList({
     );
   }, []);
 
+  const updateFollowFromScroller = useCallback(() => {
+    const el = scrollerElRef.current;
+    if (!el) return;
+    const atBottom = metricsAreAtBottom(
+      {
+        scrollTop: el.scrollTop,
+        clientHeight: el.clientHeight,
+        scrollHeight: el.scrollHeight,
+      },
+      DEFAULT_AT_BOTTOM_THRESHOLD,
+    );
+    followLatestRef.current = atBottom;
+    setIsAtBottom(atBottom);
+    updateCanScroll();
+  }, [updateCanScroll]);
+
   const handleScrollerRef = useCallback(
     (ref: HTMLElement | Window | null) => {
-      scrollerElRef.current =
+      if (scrollerElRef.current) {
+        scrollerElRef.current.removeEventListener(
+          "scroll",
+          updateFollowFromScroller,
+        );
+      }
+      const el =
         typeof HTMLElement !== "undefined" && ref instanceof HTMLElement
           ? ref
           : null;
+      scrollerElRef.current = el;
+      if (el) {
+        el.addEventListener("scroll", updateFollowFromScroller, {
+          passive: true,
+        });
+      }
       updateCanScroll();
     },
-    [updateCanScroll],
+    [updateCanScroll, updateFollowFromScroller],
   );
 
   const handleAtBottomStateChange = useCallback(
     (atBottom: boolean) => {
       updateCanScroll();
-      setIsAtBottom(atBottom);
+      if (atBottom) {
+        followLatestRef.current = true;
+        setIsAtBottom(true);
+      } else if (!followLatestRef.current) {
+        setIsAtBottom(false);
+      }
     },
     [updateCanScroll],
+  );
+
+  useEffect(
+    () => () => {
+      if (scrollerElRef.current) {
+        scrollerElRef.current.removeEventListener(
+          "scroll",
+          updateFollowFromScroller,
+        );
+      }
+    },
+    [updateFollowFromScroller],
   );
 
   // Jump to the newest message matching the search needle and flash it. Virtuoso
@@ -457,7 +504,7 @@ function VirtualMessageList({
           index: Math.max(0, messages.length - 1),
           align: "end",
         }}
-        followOutput="auto"
+        followOutput={() => (followLatestRef.current ? "smooth" : false)}
         atBottomThreshold={DEFAULT_AT_BOTTOM_THRESHOLD}
         atBottomStateChange={handleAtBottomStateChange}
         scrollerRef={handleScrollerRef}
@@ -466,12 +513,14 @@ function VirtualMessageList({
       />
       <ScrollToBottomPill
         visible={!isAtBottom && canScroll && hasContent}
-        onClick={() =>
+        onClick={() => {
+          followLatestRef.current = true;
+          setIsAtBottom(true);
           // Scroll to the true bottom of the scroller, which includes the
           // Footer (live subtree / typing indicator) — scrollToIndex(last)
           // would stop at the last message, above a footer-only response.
-          virtuosoRef.current?.scrollTo({ top: Number.MAX_SAFE_INTEGER })
-        }
+          virtuosoRef.current?.scrollTo({ top: Number.MAX_SAFE_INTEGER });
+        }}
       />
     </div>
   );

--- a/src/extensions/default-layout/message-list.tsx
+++ b/src/extensions/default-layout/message-list.tsx
@@ -23,6 +23,7 @@ import {
   CHAT_MARKDOWN_COMPONENTS,
   MARKDOWN_REMARK_PLUGINS,
 } from "./markdown-adapter";
+import { ImageLightbox } from "./image-lightbox";
 import { imageAttachmentSrc } from "../../utils/imageAttachments";
 
 // Distance (px) from the bottom still treated as "at the bottom" for follow +
@@ -174,48 +175,6 @@ function MarkdownWithThinking({ text }: { text: string }) {
 }
 
 const MemoMarkdownWithThinking = memo(MarkdownWithThinking);
-
-function ImageLightbox({
-  attachment,
-  onClose,
-}: {
-  attachment: ChatAttachment;
-  onClose: () => void;
-}) {
-  useEffect(() => {
-    const onKey = (event: KeyboardEvent) => {
-      if (event.key !== "Escape") return;
-      event.preventDefault();
-      onClose();
-    };
-    document.addEventListener("keydown", onKey);
-    return () => document.removeEventListener("keydown", onKey);
-  }, [onClose]);
-
-  return (
-    <div className="a2ui-image-lightbox" role="dialog" aria-modal="true">
-      <button
-        type="button"
-        className="a2ui-image-lightbox-backdrop"
-        aria-label="Close image preview"
-        onClick={onClose}
-      />
-      <figure className="a2ui-image-lightbox-figure">
-        <img src={imageAttachmentSrc(attachment)} alt={attachment.name} />
-        <figcaption>{attachment.name}</figcaption>
-        <button
-          type="button"
-          className="a2ui-image-lightbox-close"
-          aria-label="Close image preview"
-          onClick={onClose}
-          autoFocus
-        >
-          ×
-        </button>
-      </figure>
-    </div>
-  );
-}
 
 function AttachmentGallery({ attachments }: { attachments: ChatAttachment[] }) {
   const [open, setOpen] = useState<ChatAttachment | null>(null);

--- a/src/extensions/default-layout/message-list.tsx
+++ b/src/extensions/default-layout/message-list.tsx
@@ -10,6 +10,7 @@ import ReactMarkdown from "react-markdown";
 import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
 import type {
   A2UIComponent,
+  ChatAttachment,
   ChatMessage,
   StringValue,
 } from "../../types/a2ui";
@@ -22,6 +23,7 @@ import {
   CHAT_MARKDOWN_COMPONENTS,
   MARKDOWN_REMARK_PLUGINS,
 } from "./markdown-adapter";
+import { imageAttachmentSrc } from "../../utils/imageAttachments";
 
 // Distance (px) from the bottom still treated as "at the bottom" for follow +
 // the scroll-to-bottom pill. Matches the old StickyScrollController default.
@@ -173,6 +175,74 @@ function MarkdownWithThinking({ text }: { text: string }) {
 
 const MemoMarkdownWithThinking = memo(MarkdownWithThinking);
 
+function ImageLightbox({
+  attachment,
+  onClose,
+}: {
+  attachment: ChatAttachment;
+  onClose: () => void;
+}) {
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  return (
+    <div className="a2ui-image-lightbox" role="dialog" aria-modal="true">
+      <button
+        type="button"
+        className="a2ui-image-lightbox-backdrop"
+        aria-label="Close image preview"
+        onClick={onClose}
+      />
+      <figure className="a2ui-image-lightbox-figure">
+        <img src={imageAttachmentSrc(attachment)} alt={attachment.name} />
+        <figcaption>{attachment.name}</figcaption>
+        <button
+          type="button"
+          className="a2ui-image-lightbox-close"
+          aria-label="Close image preview"
+          onClick={onClose}
+          autoFocus
+        >
+          ×
+        </button>
+      </figure>
+    </div>
+  );
+}
+
+function AttachmentGallery({ attachments }: { attachments: ChatAttachment[] }) {
+  const [open, setOpen] = useState<ChatAttachment | null>(null);
+  if (attachments.length === 0) return null;
+  return (
+    <>
+      <div className="a2ui-message-attachments">
+        {attachments.map((attachment) => (
+          <button
+            key={attachment.id}
+            type="button"
+            className="a2ui-message-attachment"
+            onClick={() => setOpen(attachment)}
+            aria-label={`Open ${attachment.name}`}
+          >
+            <img src={imageAttachmentSrc(attachment)} alt="" />
+            <span>{attachment.name}</span>
+          </button>
+        ))}
+      </div>
+      {open && (
+        <ImageLightbox attachment={open} onClose={() => setOpen(null)} />
+      )}
+    </>
+  );
+}
+
 const ChatMessageRow = memo(
   function ChatMessageRow({
     message,
@@ -242,6 +312,9 @@ const ChatMessageRow = memo(
           <div className={textClass}>
             <MemoMarkdownWithThinking text={message.text} />
           </div>
+        )}
+        {message.attachments && message.attachments.length > 0 && (
+          <AttachmentGallery attachments={message.attachments} />
         )}
         {message.a2ui && (
           <A2UIRenderer payload={message.a2ui} state={state} tabId={tabId} />

--- a/src/extensions/default-layout/message-list.tsx
+++ b/src/extensions/default-layout/message-list.tsx
@@ -16,8 +16,8 @@ import {
   CHAT_MARKDOWN_COMPONENTS,
   MARKDOWN_REMARK_PLUGINS,
 } from "./markdown-adapter";
+import { ImageAttachmentImage } from "./image-attachment-image";
 import { ImageLightbox } from "./image-lightbox";
-import { imageAttachmentSrc } from "../../utils/imageAttachments";
 
 // Distance (px) from the bottom still treated as "at the bottom" for follow +
 // the scroll-to-bottom pill. Matches the old StickyScrollController default.
@@ -183,7 +183,7 @@ function AttachmentGallery({ attachments }: { attachments: ChatAttachment[] }) {
             onClick={() => setOpen(attachment)}
             aria-label={`Open ${attachment.name}`}
           >
-            <img src={imageAttachmentSrc(attachment)} alt="" />
+            <ImageAttachmentImage attachment={attachment} alt="" />
             <span>{attachment.name}</span>
           </button>
         ))}

--- a/src/hooks/bridgeMessageHandlers/ready.test.ts
+++ b/src/hooks/bridgeMessageHandlers/ready.test.ts
@@ -539,7 +539,7 @@ describe("handleReady", () => {
     ]);
   });
 
-  it("does not replay tab_open for non-default tabs already present in bridge ready data", () => {
+  it("requests transcript replay for non-default tabs already present in bridge ready data", () => {
     const harness = installTauriMocks();
     const { ctx } = buildHandlerFixture({
       state: {
@@ -575,7 +575,14 @@ describe("handleReady", () => {
       .filter((call) => call[0] === "agent_command")
       .map((call) => JSON.parse(call[1].payload as string))
       .filter((payload) => payload.type === "tab_open");
-    expect(tabOpenPayloads).toEqual([]);
+    expect(tabOpenPayloads).toEqual([
+      expect.objectContaining({
+        type: "tab_open",
+        tabId: "tab-2",
+        restoreHistory: true,
+        cwd: "/repo/a",
+      }),
+    ]);
   });
 
   it("does not replay shell tabs as bridge agent sessions after frontend reload", () => {

--- a/src/hooks/bridgeMessageHandlers/ready.ts
+++ b/src/hooks/bridgeMessageHandlers/ready.ts
@@ -421,20 +421,16 @@ export const handleReady: BridgeMessageHandler = (data, ctx) => {
     }
     return next;
   });
-  // Re-establish bridge sessions for any non-default local tabs the
-  // user created before the agent reloaded. The bridge starts fresh
-  // each spawn — without this, prompts on those tabs would hit a tab
-  // the bridge has never seen and fail. After the session is open,
-  // also restore the tab's previously-selected model so the user
-  // doesn't silently send the next prompt to pi's default.
+  // Re-establish or replay bridge sessions for any non-default local
+  // tabs the webview restored. A right-click / Vite reload keeps the
+  // bridge process alive, so ready may already list the tab; still send
+  // tab_open with restoreHistory so the durable transcript can repair a
+  // stale UI snapshot (for example image attachment metadata) after the
+  // webview reconstructs React state.
   const localTabs = (ctx.stateRef.current.tabs as Tab[] | undefined) ?? [];
-  const bridgeTabIds = new Set(
-    ((data.tabs as { id: string }[] | undefined) ?? []).map((t) => t.id),
-  );
   for (const t of localTabs) {
     if ((t.kind ?? "agent") !== "agent") continue;
     if (t.id === "default") continue;
-    if (bridgeTabIds.has(t.id)) continue;
     // Pass `model` so the new bridge session boots with the same model
     // the user previously selected — no race window. Track in
     // pendingTabOpens so a fast first chat on the restored tab waits

--- a/src/hooks/bridgeMessageHandlers/sessionHistory.test.ts
+++ b/src/hooks/bridgeMessageHandlers/sessionHistory.test.ts
@@ -26,6 +26,91 @@ describe("handleSessionHistory", () => {
     expect(mocks.syncRecentSessionsToState).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps restored image attachments on user messages", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleSessionHistory(
+      {
+        type: "session_history",
+        tabId: "tab-1",
+        messages: [
+          {
+            id: "image-user",
+            role: "user",
+            text: "what is this?",
+            attachments: [
+              {
+                id: "img-1",
+                kind: "image",
+                path: "/tmp/aethon-pastes/one.png",
+                name: "one.png",
+                mimeType: "image/png",
+                sizeBytes: 12,
+              },
+            ],
+          },
+        ],
+      },
+      ctx,
+    );
+    const [, updater] = mocks.updateTab.mock.calls[0];
+    const out = updater(makeEmptyTab("tab-1", "Tab 1"));
+    expect(out.messages).toEqual([
+      {
+        id: "image-user",
+        role: "user",
+        text: "what is this?",
+        attachments: [
+          {
+            id: "img-1",
+            kind: "image",
+            path: "/tmp/aethon-pastes/one.png",
+            name: "one.png",
+            mimeType: "image/png",
+            sizeBytes: 12,
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("restores image-only messages", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleSessionHistory(
+      {
+        type: "session_history",
+        tabId: "tab-1",
+        messages: [
+          {
+            id: "image-only",
+            role: "user",
+            attachments: [
+              {
+                id: "img-1",
+                kind: "image",
+                path: "/tmp/aethon-pastes/one.png",
+                name: "one.png",
+                mimeType: "image/png",
+                sizeBytes: 12,
+              },
+            ],
+          },
+        ],
+      },
+      ctx,
+    );
+    const [, updater] = mocks.updateTab.mock.calls[0];
+    const out = updater(makeEmptyTab("tab-1", "Tab 1"));
+    expect(out.messages[0]).toMatchObject({
+      id: "image-only",
+      role: "user",
+      attachments: [
+        expect.objectContaining({
+          path: "/tmp/aethon-pastes/one.png",
+        }),
+      ],
+    });
+  });
+
   it("uses discovered custom session labels for restored chat tabs", () => {
     const { ctx, mocks } = buildHandlerFixture();
     ctx.allDiscoveredSessionsRef.current = [

--- a/src/hooks/osEdges/clipboardPaste.ts
+++ b/src/hooks/osEdges/clipboardPaste.ts
@@ -1,7 +1,7 @@
 import type { MutableRefObject } from "react";
-import { invoke } from "@tauri-apps/api/core";
 import type { Tab } from "../../types/tab";
 import type { NotificationInput } from "../useNotifications";
+import { saveClipboardImageAttachment } from "../../utils/imageAttachments";
 
 export interface ClipboardPasteDeps {
   stateRef: MutableRefObject<Record<string, unknown>>;
@@ -12,9 +12,8 @@ export interface ClipboardPasteDeps {
 /** Image paste into the chat composer. Tauri webview surfaces
  *  clipboard images via `event.clipboardData.items`; for each
  *  `image/*` item we persist the bytes to `~/.aethon/pastes/<uuid>.<ext>`
- *  via the `save_paste_image` Tauri command and insert `@<path>` into
- *  the active agent tab's draft. The agent's existing read tool can
- *  then pick up the image via the path. Files larger than the Rust
+ *  via the `save_paste_image` Tauri command and attach it to the
+ *  active agent tab's draft. Files larger than the Rust
  *  32 MiB cap surface as a notification rather than silently dropping.
  *
  *  Target tab is captured at paste time, NOT after the async save
@@ -52,15 +51,8 @@ export function subscribeClipboardPaste(deps: ClipboardPasteDeps): () => void {
       imageItems.map(async (item) => {
         const file = item.getAsFile();
         if (!file) return null;
-        const buffer = await file.arrayBuffer();
-        const bytes = Array.from(new Uint8Array(buffer));
-        const ext = file.type.split("/")[1] ?? "png";
         try {
-          const path = await invoke<string>("save_paste_image", {
-            bytes,
-            extension: ext,
-          });
-          return path;
+          return await saveClipboardImageAttachment(file);
         } catch (err) {
           pushNotification({
             id: "ae-paste-image-failed",
@@ -73,18 +65,15 @@ export function subscribeClipboardPaste(deps: ClipboardPasteDeps): () => void {
         }
       }),
     ).then((paths) => {
-      const tokens = paths
-        .filter((p): p is string => typeof p === "string")
-        .map((p) => `@${p}`)
-        .join(" ");
-      if (tokens.length === 0) return;
+      const attachments = paths.filter((p): p is NonNullable<typeof p> => !!p);
+      if (attachments.length === 0) return;
       const stillExists = (stateRef.current.tabs as Tab[] | undefined)?.some(
         (t) => t.id === targetId,
       );
       if (!stillExists) return;
       updateTab(targetId, (t) => ({
         ...t,
-        draft: t.draft.length > 0 ? `${t.draft} ${tokens}` : tokens,
+        draftAttachments: [...(t.draftAttachments ?? []), ...attachments],
       }));
     });
   };

--- a/src/hooks/projectOps/types.ts
+++ b/src/hooks/projectOps/types.ts
@@ -123,7 +123,7 @@ export interface UseProjectOpsActions {
    *  surfaces the error in the sidebar). */
   createWorktreeWithParams: (opts: {
     projectId: string;
-    branch: string;
+    branch?: string;
     targetPath?: string;
     baseBranch?: string;
   }) => Promise<string | null>;

--- a/src/hooks/projectOps/worktreeOperations.ts
+++ b/src/hooks/projectOps/worktreeOperations.ts
@@ -52,6 +52,7 @@ export function useWorktreeOperations(
 
   const gitDeps = {
     projectsRef: deps.projectsRef,
+    stateRef: deps.stateRef,
     lookups,
     syncProjectsToState: deps.syncProjectsToState,
     persistProjects: deps.persistProjects,

--- a/src/hooks/projectOps/worktreeOps/git.ts
+++ b/src/hooks/projectOps/worktreeOps/git.ts
@@ -19,6 +19,7 @@ import type { ProjectLookups } from "./types";
 
 interface GitDeps {
   projectsRef: MutableRefObject<ProjectsState>;
+  stateRef?: MutableRefObject<Record<string, unknown>>;
   lookups: ProjectLookups;
   syncProjectsToState: () => void;
   persistProjects: () => Promise<void>;
@@ -38,9 +39,48 @@ export function resolveWorktreeBaseBranch(
 export function defaultWorktreePath(
   projectPath: string,
   branch: string,
+  aethonRoot?: string,
 ): string {
-  const safe = branch.replace(/[^a-z0-9._-]/gi, "-");
-  return `${projectPath.replace(/\/$/, "")}-${safe}`;
+  const worktreeName = safePathSegment(branch, "worktree");
+  const root = aethonRoot?.trim();
+  if (root) {
+    const sep = root.includes("\\") && !root.includes("/") ? "\\" : "/";
+    const repoName = safePathSegment(pathBasename(projectPath), "repo");
+    return `${trimTrailingSeparators(root)}${sep}${repoName}${sep}${worktreeName}`;
+  }
+  return `${projectPath.replace(/[\\/]+$/, "")}-${worktreeName}`;
+}
+
+function trimTrailingSeparators(path: string): string {
+  return path.replace(/[\\/]+$/, "");
+}
+
+function pathBasename(path: string): string {
+  const parts = trimTrailingSeparators(path).split(/[\\/]+/).filter(Boolean);
+  return parts[parts.length - 1] ?? "repo";
+}
+
+function safePathSegment(value: string, fallback: string): string {
+  return value.replace(/[^a-z0-9._-]/gi, "-").replace(/^-+|-+$/g, "") || fallback;
+}
+
+async function pickGeneratedWorktreeBranch(
+  deps: Pick<GitDeps, "projectsRef"> & { lookups: ProjectLookups },
+  project: Project,
+): Promise<string> {
+  const taken = new Set<string>();
+  for (const w of deps.projectsRef.current.worktreesByProject[project.id] ??
+    []) {
+    if (w.branch) taken.add(w.branch);
+    if (w.label) taken.add(w.label);
+  }
+  try {
+    const branches = await gitBranchList(project.path);
+    for (const b of branches) taken.add(b.name);
+  } catch {
+    // Branch list failed; random naming remains good enough.
+  }
+  return pickWorktreeName(taken);
 }
 
 export function navigateToWorktree(
@@ -112,37 +152,29 @@ export async function createWorktreeForProject(
 ): Promise<void> {
   const project = deps.lookups.findProject(projectId);
   if (!project) return;
-  const taken = new Set<string>();
-  for (const w of deps.projectsRef.current.worktreesByProject[projectId] ??
-    []) {
-    if (w.branch) taken.add(w.branch);
-    if (w.label) taken.add(w.label);
-  }
-  try {
-    const branches = await gitBranchList(project.path);
-    for (const b of branches) taken.add(b.name);
-  } catch {
-    // Branch list failed; random naming remains good enough.
-  }
-  const branch = pickWorktreeName(taken);
-  await createWorktreeWithParams(deps, { projectId, branch });
+  await createWorktreeWithParams(deps, { projectId });
 }
 
 export async function createWorktreeWithParams(
   deps: GitDeps,
   opts: {
     projectId: string;
-    branch: string;
+    branch?: string;
     targetPath?: string;
     baseBranch?: string;
   },
 ): Promise<string | null> {
   const project = deps.lookups.findProject(opts.projectId);
   if (!project) return null;
-  const branch = opts.branch.trim();
-  if (!branch) return null;
+  const branch =
+    opts.branch?.trim() || (await pickGeneratedWorktreeBranch(deps, project));
+  const aethonRoot =
+    typeof deps.stateRef?.current.aethonRoot === "string"
+      ? deps.stateRef.current.aethonRoot
+      : undefined;
   const targetPath =
-    opts.targetPath?.trim() || defaultWorktreePath(project.path, branch);
+    opts.targetPath?.trim() ||
+    defaultWorktreePath(project.path, branch, aethonRoot);
   const pending = newPendingWorktree(opts.projectId, branch, targetPath);
   const baseBranch = resolveWorktreeBaseBranch(project, opts.baseBranch);
   const before =

--- a/src/hooks/projectOps/worktreeOps/types.ts
+++ b/src/hooks/projectOps/worktreeOps/types.ts
@@ -31,7 +31,7 @@ export interface WorktreeOperations {
   createWorktreeForProject: (projectId: string) => Promise<void>;
   createWorktreeWithParams: (opts: {
     projectId: string;
-    branch: string;
+    branch?: string;
     targetPath?: string;
     baseBranch?: string;
   }) => Promise<string | null>;

--- a/src/hooks/tabOps/constants.ts
+++ b/src/hooks/tabOps/constants.ts
@@ -12,6 +12,7 @@ export const TERMINAL_REPLAY_MAX = 256 * 1024;
 export const TAB_MIRROR_KEYS: (keyof Tab)[] = [
   "messages",
   "draft",
+  "draftAttachments",
   "waiting",
   "queueCount",
   "queuedMessages",

--- a/src/hooks/useAppSlashCommandContext.test.ts
+++ b/src/hooks/useAppSlashCommandContext.test.ts
@@ -131,4 +131,66 @@ describe("useAppSlashCommandContext", () => {
 
     expect(invokeMock).not.toHaveBeenCalled();
   });
+
+  it("persists image attachment metadata without blob preview URLs", () => {
+    const { result } = renderHook(() =>
+      useAppSlashCommandContext({
+        bootLayout: { components: [] },
+        setState: vi.fn(),
+        setLayout: vi.fn(),
+        stateRef: ref({}),
+        projectsRef: ref(makeProjects()),
+        layoutCatalogueRef: ref([]),
+        registry: new ExtensionRegistry(),
+        appendMessage: vi.fn(),
+        pushNotification: vi.fn(() => "toast-1"),
+        clearChat: vi.fn(),
+        setTheme: vi.fn(),
+        listThemes: vi.fn(() => []),
+        setModel: vi.fn(() => Promise.resolve()),
+        toggleTerminal: vi.fn(),
+        toggleSidebar: vi.fn(),
+        toggleFilesSidebar: vi.fn(),
+        activateLayoutById: vi.fn(() => true),
+        openProjectFromPicker: vi.fn(() => Promise.resolve(null)),
+        openProjectByPath: vi.fn((path: string) => path),
+        setActiveProjectById: vi.fn(() => true),
+        clearActiveProject: vi.fn(),
+        removeProjectById: vi.fn(() => true),
+      }),
+    );
+
+    act(() => {
+      result.current.persistLocalChatMessage(
+        {
+          id: "m1",
+          role: "user",
+          attachments: [
+            {
+              id: "img-1",
+              kind: "image",
+              path: "/tmp/aethon-pastes/one.png",
+              name: "one.png",
+              mimeType: "image/png",
+              sizeBytes: 12,
+              previewUrl: "blob:temp",
+            },
+          ],
+        },
+        "tab-1",
+      );
+    });
+
+    const payload = JSON.parse(invokeMock.mock.calls[0]?.[1]?.payload);
+    expect(payload.payload.attachments).toEqual([
+      {
+        id: "img-1",
+        kind: "image",
+        path: "/tmp/aethon-pastes/one.png",
+        name: "one.png",
+        mimeType: "image/png",
+        sizeBytes: 12,
+      },
+    ]);
+  });
 });

--- a/src/hooks/useAppSlashCommandContext.ts
+++ b/src/hooks/useAppSlashCommandContext.ts
@@ -8,6 +8,7 @@ import { invoke } from "@tauri-apps/api/core";
 import type { A2UIPayload, ChatMessage } from "../types/a2ui";
 import type { Tab } from "../types/tab";
 import { activeProject, type ProjectsState } from "../projects";
+import { durableImageAttachments } from "../utils/imageAttachments";
 import type { SlashCommandContext } from "../slashCommands";
 import type { ExtensionRegistry } from "../extensions/ExtensionRegistry";
 import type { LayoutCatalogueEntry } from "../extensions/default-layout";
@@ -70,7 +71,8 @@ export function useAppSlashCommandContext({
 }: UseAppSlashCommandContextOptions): AppSlashCommandContextResult {
   const persistLocalChatMessage = useCallback(
     (msg: ChatMessage, tabId: string) => {
-      if (!msg.text && !msg.thinking) return;
+      const attachments = durableImageAttachments(msg.attachments);
+      if (!msg.text && !msg.thinking && attachments.length === 0) return;
       invoke("agent_command", {
         payload: JSON.stringify({
           type: "local_chat_message",
@@ -81,6 +83,7 @@ export function useAppSlashCommandContext({
             ...(msg.text ? { text: msg.text } : {}),
             ...(msg.thinking ? { thinking: msg.thinking } : {}),
             ...(msg.delivery ? { delivery: msg.delivery } : {}),
+            ...(attachments.length > 0 ? { attachments } : {}),
             createdAt: Date.now(),
           },
         }),

--- a/src/hooks/useChat.test.ts
+++ b/src/hooks/useChat.test.ts
@@ -107,6 +107,40 @@ describe("useChat setModel", () => {
     });
   });
 
+  it("sends image attachments with the user message and clears draft attachments", async () => {
+    const attachment = {
+      id: "img-1",
+      kind: "image" as const,
+      path: "/Users/james/.aethon/pastes/one.png",
+      name: "one.png",
+      mimeType: "image/png",
+      sizeBytes: 12,
+    };
+    const { ctx, stateRef } = buildContext();
+    const { result } = renderHook(() => useChat(ctx));
+
+    await act(async () => {
+      await result.current.sendChat("what is this?", {
+        attachments: [attachment],
+      });
+    });
+
+    expect(invoke).toHaveBeenCalledWith("send_message", {
+      message: "what is this?",
+      tabId: "tab-1",
+      mode: "normal",
+      attachments: [attachment],
+      model: "anthropic/claude-opus-4-7",
+    });
+    const tab = (stateRef.current.tabs as Tab[])[0];
+    expect(tab.messages.at(-1)).toMatchObject({
+      role: "user",
+      text: "what is this?",
+      attachments: [attachment],
+    });
+    expect(tab.draftAttachments).toEqual([]);
+  });
+
   it("can send a programmatic prompt to an explicit non-active tab", async () => {
     const mainTab = { ...makeEmptyTab("main-tab", "Main"), projectId: "p1" };
     const issueTab = {
@@ -291,6 +325,34 @@ describe("useChat setModel", () => {
     // No user bubble lands in history while queued — the popover owns
     // the visual representation until drain.
     expect(tab.messages.some((m) => m.text === "after this")).toBe(false);
+  });
+
+  it("holds attachments with queued normal messages while the prompt is busy", async () => {
+    const attachment = {
+      id: "img-queued",
+      kind: "image" as const,
+      path: "/Users/james/.aethon/pastes/queued.png",
+      name: "queued.png",
+      mimeType: "image/png",
+      sizeBytes: 10,
+    };
+    const { ctx, stateRef } = buildContext({ waiting: true });
+    const { result } = renderHook(() => useChat(ctx));
+
+    await act(async () => {
+      await result.current.sendChat("after this", {
+        attachments: [attachment],
+      });
+    });
+
+    const tab = (stateRef.current.tabs as Tab[])[0];
+    expect(tab.queuedMessages).toEqual([
+      expect.objectContaining({
+        content: "after this",
+        attachments: [attachment],
+      }),
+    ]);
+    expect(tab.draftAttachments).toEqual([]);
   });
 
   it("stopPrompt empties the client-held queue (regression: P2 from peer review)", async () => {

--- a/src/hooks/useChat.test.ts
+++ b/src/hooks/useChat.test.ts
@@ -111,7 +111,7 @@ describe("useChat setModel", () => {
     const attachment = {
       id: "img-1",
       kind: "image" as const,
-      path: "/Users/james/.aethon/pastes/one.png",
+      path: "/tmp/aethon-pastes/one.png",
       name: "one.png",
       mimeType: "image/png",
       sizeBytes: 12,
@@ -331,7 +331,7 @@ describe("useChat setModel", () => {
     const attachment = {
       id: "img-queued",
       kind: "image" as const,
-      path: "/Users/james/.aethon/pastes/queued.png",
+      path: "/tmp/aethon-pastes/queued.png",
       name: "queued.png",
       mimeType: "image/png",
       sizeBytes: 10,

--- a/src/hooks/useChat.test.ts
+++ b/src/hooks/useChat.test.ts
@@ -95,10 +95,12 @@ describe("useChat setModel", () => {
     });
 
     expect(invoke).toHaveBeenCalledWith("send_message", {
-      message: "hello",
-      tabId: "tab-1",
-      mode: "normal",
-      model: "anthropic/claude-opus-4-7",
+      request: {
+        message: "hello",
+        tabId: "tab-1",
+        mode: "normal",
+        model: "anthropic/claude-opus-4-7",
+      },
     });
     expect((stateRef.current.tabs as Tab[])[0].messages.at(-1)).toMatchObject({
       role: "user",
@@ -126,11 +128,13 @@ describe("useChat setModel", () => {
     });
 
     expect(invoke).toHaveBeenCalledWith("send_message", {
-      message: "what is this?",
-      tabId: "tab-1",
-      mode: "normal",
-      attachments: [attachment],
-      model: "anthropic/claude-opus-4-7",
+      request: {
+        message: "what is this?",
+        tabId: "tab-1",
+        mode: "normal",
+        attachments: [attachment],
+        model: "anthropic/claude-opus-4-7",
+      },
     });
     const tab = (stateRef.current.tabs as Tab[])[0];
     expect(tab.messages.at(-1)).toMatchObject({
@@ -160,11 +164,13 @@ describe("useChat setModel", () => {
     });
 
     expect(invoke).toHaveBeenCalledWith("send_message", {
-      message: "work on issue",
-      tabId: "issue-tab",
-      mode: "normal",
-      cwd: "/projects/aethon-fix-86",
-      model: "anthropic/claude-opus-4-7",
+      request: {
+        message: "work on issue",
+        tabId: "issue-tab",
+        mode: "normal",
+        cwd: "/projects/aethon-fix-86",
+        model: "anthropic/claude-opus-4-7",
+      },
     });
     const tabs = stateRef.current.tabs as Tab[];
     expect(tabs.find((t) => t.id === "main-tab")?.messages).toEqual([]);
@@ -206,10 +212,12 @@ describe("useChat setModel", () => {
 
     expect(run).not.toHaveBeenCalled();
     expect(invoke).toHaveBeenCalledWith("send_message", {
-      message: "/clear",
-      tabId: "issue-tab",
-      mode: "normal",
-      model: "anthropic/claude-opus-4-7",
+      request: {
+        message: "/clear",
+        tabId: "issue-tab",
+        mode: "normal",
+        model: "anthropic/claude-opus-4-7",
+      },
     });
     const tabs = stateRef.current.tabs as Tab[];
     expect(tabs.find((t) => t.id === "main-tab")?.messages).toEqual([]);
@@ -243,10 +251,12 @@ describe("useChat setModel", () => {
     // queuedSteeringId clears after the dispatch settles.
     expect(finalTab.queuedSteeringId).toBeUndefined();
     expect(invoke).toHaveBeenCalledWith("send_message", {
-      message: "first",
-      tabId: "tab-1",
-      mode: "steer",
-      model: "anthropic/claude-opus-4-7",
+      request: {
+        message: "first",
+        tabId: "tab-1",
+        mode: "steer",
+        model: "anthropic/claude-opus-4-7",
+      },
     });
   });
 
@@ -317,7 +327,9 @@ describe("useChat setModel", () => {
 
     expect(invoke).not.toHaveBeenCalledWith(
       "send_message",
-      expect.objectContaining({ message: "after this" }),
+      expect.objectContaining({
+        request: expect.objectContaining({ message: "after this" }),
+      }),
     );
     const tab = (stateRef.current.tabs as Tab[])[0];
     expect(tab.queuedMessages.map((m) => m.content)).toEqual(["after this"]);
@@ -408,10 +420,12 @@ describe("useChat setModel", () => {
     });
 
     expect(invoke).toHaveBeenCalledWith("send_message", {
-      message: "drained",
-      tabId: "tab-1",
-      mode: "normal",
-      model: "anthropic/claude-opus-4-7",
+      request: {
+        message: "drained",
+        tabId: "tab-1",
+        mode: "normal",
+        model: "anthropic/claude-opus-4-7",
+      },
     });
     const tab = (stateRef.current.tabs as Tab[])[0];
     expect(tab.queuedMessages).toEqual([]);
@@ -454,10 +468,12 @@ describe("useChat setModel", () => {
     });
 
     expect(invoke).toHaveBeenCalledWith("send_message", {
-      message: "look now",
-      tabId: "tab-1",
-      mode: "steer",
-      model: "anthropic/claude-opus-4-7",
+      request: {
+        message: "look now",
+        tabId: "tab-1",
+        mode: "steer",
+        model: "anthropic/claude-opus-4-7",
+      },
     });
     expect((stateRef.current.tabs as Tab[])[0].messages.at(-1)).toMatchObject({
       role: "user",

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -5,7 +5,7 @@ import {
   type SetStateAction,
 } from "react";
 import { invoke } from "@tauri-apps/api/core";
-import type { ChatMessage } from "../types/a2ui";
+import type { ChatAttachment, ChatMessage } from "../types/a2ui";
 import type { QueuedMessage, Tab } from "../types/tab";
 import {
   parseSlashCommand,
@@ -72,7 +72,11 @@ export interface UseChatActions {
   clearChat: () => void;
   sendChat: (
     text: string,
-    options?: { mode?: "normal" | "steer"; tabId?: string },
+    options?: {
+      mode?: "normal" | "steer";
+      tabId?: string;
+      attachments?: ChatAttachment[];
+    },
   ) => Promise<void>;
   setModel: (id: string) => Promise<void>;
   stopPrompt: (explicitTabId?: string) => Promise<void>;
@@ -266,10 +270,15 @@ export function useChat(ctx: UseChatContext): UseChatActions {
 
   async function sendChat(
     text: string,
-    options?: { mode?: "normal" | "steer"; tabId?: string },
+    options?: {
+      mode?: "normal" | "steer";
+      tabId?: string;
+      attachments?: ChatAttachment[];
+    },
   ) {
     const trimmed = text.trim();
-    if (!trimmed) return;
+    const attachments = options?.attachments ?? [];
+    if (!trimmed && attachments.length === 0) return;
 
     const activeTabId = stateRef.current.activeTabId as string | undefined;
     const explicitTabId = options?.tabId;
@@ -299,7 +308,11 @@ export function useChat(ctx: UseChatContext): UseChatActions {
         // draft still holds the slash text and any subsequent mirror
         // (clearChat, theme switch, …) writes it back into root.draft,
         // making the input "stick".
-        updateActiveTab((tab) => ({ ...tab, draft: "" }));
+        updateActiveTab((tab) => ({
+          ...tab,
+          draft: "",
+          draftAttachments: [],
+        }));
         try {
           await cmd.run(parsed.args, slashContext());
         } catch (err) {
@@ -313,6 +326,12 @@ export function useChat(ctx: UseChatContext): UseChatActions {
     }
 
     const sendText = trimmed.startsWith("//") ? trimmed.slice(1) : trimmed;
+    const bridgeText =
+      sendText.length > 0
+        ? sendText
+        : attachments.length === 1
+          ? "Please inspect the attached image."
+          : "Please inspect the attached images.";
     const mode = options?.mode === "steer" ? "steer" : "normal";
     const tabId = explicitTabId ?? activeTabId ?? "default";
     const targetTab = ((stateRef.current.tabs as Tab[] | undefined) ?? []).find(
@@ -338,13 +357,18 @@ export function useChat(ctx: UseChatContext): UseChatActions {
     ) {
       const entry: QueuedMessage = {
         id: crypto.randomUUID(),
-        content: sendText,
+        content: bridgeText,
+        attachments,
       };
       updateTab(tabId, (tab) => withQueue(tab, [...queueOf(tab), entry]));
       // Clear the draft on the originating tab so the textarea empties
       // even though we didn't ship the message. Mirrors the normal-send
       // behavior below.
-      updateTab(tabId, (tab) => ({ ...tab, draft: "" }));
+      updateTab(tabId, (tab) => ({
+        ...tab,
+        draft: "",
+        draftAttachments: [],
+      }));
       return;
     }
 
@@ -354,11 +378,17 @@ export function useChat(ctx: UseChatContext): UseChatActions {
     const userMessage = {
       id: userMessageId,
       role: "user" as const,
-      text: sendText,
+      text: bridgeText,
+      ...(attachments.length > 0 ? { attachments } : {}),
       delivery,
     };
     appendMessage(userMessage, tabId);
-    updateTab(tabId, (tab) => ({ ...tab, draft: "", waiting: true }));
+    updateTab(tabId, (tab) => ({
+      ...tab,
+      draft: "",
+      draftAttachments: [],
+      waiting: true,
+    }));
     setState((prev) =>
       prev.activeTabId === tabId
         ? {
@@ -395,9 +425,10 @@ export function useChat(ctx: UseChatContext): UseChatActions {
           : undefined;
     try {
       await invoke("send_message", {
-        message: sendText,
+        message: bridgeText,
         tabId,
         mode,
+        ...(attachments.length > 0 ? { attachments } : {}),
         ...(targetCwd ? { cwd: targetCwd } : {}),
         ...(targetModel ? { model: targetModel } : {}),
       });
@@ -585,7 +616,11 @@ export function useChat(ctx: UseChatContext): UseChatActions {
       queuedSteeringId: messageId,
     }));
     try {
-      await sendChat(entry.content, { mode: "steer", tabId });
+      await sendChat(entry.content, {
+        mode: "steer",
+        tabId,
+        attachments: entry.attachments,
+      });
     } finally {
       updateTab(tabId, (t) =>
         t.queuedSteeringId === messageId

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -425,12 +425,14 @@ export function useChat(ctx: UseChatContext): UseChatActions {
           : undefined;
     try {
       await invoke("send_message", {
-        message: bridgeText,
-        tabId,
-        mode,
-        ...(attachments.length > 0 ? { attachments } : {}),
-        ...(targetCwd ? { cwd: targetCwd } : {}),
-        ...(targetModel ? { model: targetModel } : {}),
+        request: {
+          message: bridgeText,
+          tabId,
+          mode,
+          ...(attachments.length > 0 ? { attachments } : {}),
+          ...(targetCwd ? { cwd: targetCwd } : {}),
+          ...(targetModel ? { model: targetModel } : {}),
+        },
       });
     } catch (err) {
       updateTab(tabId, (tab) => ({

--- a/src/hooks/useProjectOps.test.ts
+++ b/src/hooks/useProjectOps.test.ts
@@ -846,7 +846,7 @@ describe("useProjectOps worktree creation", () => {
     harness.invoke.mockImplementation((cmd: string) => {
       if (cmd === "git_worktree_add") {
         return Promise.resolve({
-          path: "/projects/aethon-fix-thing",
+          path: "/tmp/aethon/aethon/fix-thing",
           branch: "fix/thing",
           head: "def456",
           isMain: false,
@@ -863,7 +863,7 @@ describe("useProjectOps worktree creation", () => {
             locked: false,
           },
           {
-            path: "/projects/aethon-fix-thing",
+            path: "/tmp/aethon/aethon/fix-thing",
             branch: "fix/thing",
             head: "def456",
             isMain: false,
@@ -874,7 +874,8 @@ describe("useProjectOps worktree creation", () => {
       return Promise.resolve(undefined);
     });
     const initial = makeProjectsState({ activeId: "project-1" });
-    const { result, projectsRef } = renderProjectOps(initial);
+    const { result, projectsRef, stateRef } = renderProjectOps(initial);
+    stateRef.current.aethonRoot = "/tmp/aethon";
     await act(async () => {
       await Promise.resolve();
       await Promise.resolve();
@@ -886,12 +887,12 @@ describe("useProjectOps worktree creation", () => {
         projectId: "project-1",
         branch: "fix/thing",
       });
-      expect(created).toBe("/projects/aethon-fix-thing");
+      expect(created).toBe("/tmp/aethon/aethon/fix-thing");
     });
 
     expect(harness.invoke).toHaveBeenCalledWith("git_worktree_add", {
       projectPath: "/projects/aethon",
-      targetPath: "/projects/aethon-fix-thing",
+      targetPath: "/tmp/aethon/aethon/fix-thing",
       branch: "fix/thing",
       base: "origin/main",
     });
@@ -899,8 +900,71 @@ describe("useProjectOps worktree creation", () => {
     const active = projectsRef.current.worktreesByProject["project-1"]?.find(
       (w) => w.id === projectsRef.current.activeWorktreeId,
     );
-    expect(active?.path).toBe("/projects/aethon-fix-thing");
+    expect(active?.path).toBe("/tmp/aethon/aethon/fix-thing");
     expect(projectsRef.current.projects[0].uiExpanded).toBe(true);
+  });
+
+  it("auto-generates blank worktree branches under the Aethon user dir", async () => {
+    const harness = installTauriMocks();
+    harness.invoke.mockImplementation((cmd: string, args) => {
+      if (cmd === "git_branch_list") {
+        return Promise.resolve([{ name: "main", current: true }]);
+      }
+      if (cmd === "git_worktree_add") {
+        return Promise.resolve({
+          path: args.targetPath,
+          branch: args.branch,
+          head: "def456",
+          isMain: false,
+          locked: false,
+        });
+      }
+      if (cmd === "git_worktrees") {
+        const addCall = harness.invoke.mock.calls.find(
+          ([name]) => name === "git_worktree_add",
+        );
+        return Promise.resolve([
+          {
+            path: "/projects/aethon",
+            branch: "main",
+            head: "abc123",
+            isMain: true,
+            locked: false,
+          },
+          {
+            path: addCall?.[1]?.targetPath,
+            branch: addCall?.[1]?.branch,
+            head: "def456",
+            isMain: false,
+            locked: false,
+          },
+        ]);
+      }
+      return Promise.resolve(undefined);
+    });
+    const initial = makeProjectsState({ activeId: "project-1" });
+    const { result, stateRef } = renderProjectOps(initial);
+    stateRef.current.aethonRoot = "/tmp/aethon";
+
+    let created: string | null = null;
+    await act(async () => {
+      created = await result.current.createWorktreeWithParams({
+        projectId: "project-1",
+      });
+    });
+
+    const addCall = harness.invoke.mock.calls.find(
+      ([cmd]) => cmd === "git_worktree_add",
+    );
+    expect(addCall?.[1]).toMatchObject({
+      projectPath: "/projects/aethon",
+      base: "origin/main",
+    });
+    expect(addCall?.[1]?.branch).toMatch(/^feat\//);
+    expect(addCall?.[1]?.targetPath).toMatch(
+      /^\/tmp\/aethon\/aethon\/feat-/,
+    );
+    expect(created).toBe(addCall?.[1]?.targetPath);
   });
 
   it("uses project and explicit base branch overrides in priority order", async () => {

--- a/src/hooks/useQueuedDispatch.ts
+++ b/src/hooks/useQueuedDispatch.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from "react";
+import type { ChatAttachment } from "../types/a2ui";
 import type { Tab } from "../types/tab";
 
 /**
@@ -30,7 +31,11 @@ export interface UseQueuedDispatchParams {
   tabs: Tab[];
   sendChat: (
     text: string,
-    options?: { mode?: "normal" | "steer"; tabId?: string },
+    options?: {
+      mode?: "normal" | "steer";
+      tabId?: string;
+      attachments?: ChatAttachment[];
+    },
   ) => Promise<void>;
   updateTab: (tabId: string, mutator: (tab: Tab) => Tab) => void;
 }
@@ -78,7 +83,11 @@ export function useQueuedDispatch({
         };
       });
 
-      sendChat(head.content, { mode: "normal", tabId: tab.id }).finally(() => {
+      sendChat(head.content, {
+        mode: "normal",
+        tabId: tab.id,
+        attachments: head.attachments,
+      }).finally(() => {
         dispatchingRef.current.delete(tab.id);
       });
     }

--- a/src/hooks/useTaskLauncher.test.ts
+++ b/src/hooks/useTaskLauncher.test.ts
@@ -108,4 +108,51 @@ describe("useTaskLauncher", () => {
     });
     expect(sendChat).toHaveBeenCalledWith("implement this", { tabId });
   });
+
+  it("uses automatic worktree naming when the launcher branch is blank", async () => {
+    const projects = makeProjects();
+    projects.worktreesByProject.p1 = [
+      {
+        id: "wt-auto",
+        projectId: "p1",
+        path: "/tmp/aethon/aethon/feat-aurora",
+        branch: "feat/aurora",
+        isMain: false,
+      },
+    ];
+    const projectsRef = ref(projects);
+    const createWorktreeWithParams = vi.fn(() =>
+      Promise.resolve("/tmp/aethon/aethon/feat-aurora"),
+    );
+    const activateWorktree = vi.fn();
+    const newTab = vi.fn();
+    const sendChat = vi.fn(() => Promise.resolve());
+    const { result } = renderHook(() =>
+      useTaskLauncher({
+        projectsRef,
+        pushNotificationRef: ref((_: NotificationInput) => {}),
+        setActiveProjectById: vi.fn(() => true),
+        createWorktreeWithParams,
+        activateWorktree,
+        newTab,
+        pendingTabOpens: ref(new Map()),
+        sendChat,
+      }),
+    );
+
+    await act(async () => {
+      await result.current({
+        projectId: "p1",
+        prompt: "  implement this  ",
+        newWorktree: true,
+        branch: "   ",
+      });
+    });
+
+    expect(createWorktreeWithParams).toHaveBeenCalledWith({
+      projectId: "p1",
+      baseBranch: undefined,
+    });
+    expect(activateWorktree).toHaveBeenCalledWith("wt-auto");
+  });
 });

--- a/src/hooks/useTaskLauncher.ts
+++ b/src/hooks/useTaskLauncher.ts
@@ -19,7 +19,7 @@ export interface UseTaskLauncherOptions {
   setActiveProjectById: (id: string) => boolean;
   createWorktreeWithParams: (opts: {
     projectId: string;
-    branch: string;
+    branch?: string;
     targetPath?: string;
     baseBranch?: string;
   }) => Promise<string | null>;
@@ -69,23 +69,17 @@ export function useTaskLauncher({
       let cwd = project.path;
       if (opts.newWorktree) {
         const branch = (opts.branch ?? "").trim();
-        if (!branch) {
-          pushNotificationRef.current({
-            title: "New worktree needs a branch name",
-            message: "Enter a branch name in the launcher before starting.",
-            kind: "warning",
-          });
-          return;
-        }
         const created = await createWorktreeWithParams({
           projectId: opts.projectId,
-          branch,
+          ...(branch ? { branch } : {}),
           baseBranch: opts.baseBranch,
         });
         if (!created) {
           pushNotificationRef.current({
             title: "Worktree create failed",
-            message: `Could not create '${branch}'. See the sidebar's pending row for details.`,
+            message: branch
+              ? `Could not create '${branch}'. See the sidebar's pending row for details.`
+              : "Could not create an automatic worktree. See the sidebar's pending row for details.",
             kind: "warning",
           });
           return;

--- a/src/hooks/useTaskLauncher.ts
+++ b/src/hooks/useTaskLauncher.ts
@@ -1,10 +1,12 @@
 import { useCallback, type MutableRefObject } from "react";
+import type { ChatAttachment } from "../types/a2ui";
 import type { ProjectsState } from "../projects";
 import type { NotificationInput } from "./useNotifications";
 
 export interface StartTaskOptions {
   projectId: string;
   prompt: string;
+  attachments?: ChatAttachment[];
   newWorktree?: boolean;
   branch?: string;
   baseBranch?: string;
@@ -32,7 +34,10 @@ export interface UseTaskLauncherOptions {
     },
   ) => void;
   pendingTabOpens: MutableRefObject<Map<string, Promise<unknown>>>;
-  sendChat: (text: string, options?: { tabId?: string }) => Promise<void>;
+  sendChat: (
+    text: string,
+    options?: { tabId?: string; attachments?: ChatAttachment[] },
+  ) => Promise<void>;
 }
 
 export function useTaskLauncher({
@@ -111,7 +116,9 @@ export function useTaskLauncher({
         }
       }
       const trimmed = opts.prompt.trim();
-      if (trimmed) await sendChat(trimmed, { tabId });
+      if (trimmed || (opts.attachments?.length ?? 0) > 0) {
+        await sendChat(trimmed, { tabId, attachments: opts.attachments });
+      }
     },
     [
       activateWorktree,

--- a/src/state/sessionUiSnapshot.test.ts
+++ b/src/state/sessionUiSnapshot.test.ts
@@ -70,6 +70,63 @@ describe("sessionUiSnapshot", () => {
     expect(loadSessionUiSnapshot()?.activeTabId).toBe("tab-a");
   });
 
+  it("strips transient image preview URLs from persisted snapshots", () => {
+    const tab = {
+      ...makeEmptyTab("tab-a", "A"),
+      messages: [
+        {
+          id: "m1",
+          role: "user" as const,
+          attachments: [
+            {
+              id: "img-1",
+              kind: "image" as const,
+              path: "/tmp/aethon-pastes/one.png",
+              name: "one.png",
+              mimeType: "image/png",
+              sizeBytes: 12,
+              previewUrl: "blob:temp",
+            },
+          ],
+        },
+      ],
+      draftAttachments: [
+        {
+          id: "img-2",
+          kind: "image" as const,
+          path: "/tmp/aethon-pastes/two.png",
+          name: "two.png",
+          mimeType: "image/png",
+          sizeBytes: 13,
+          previewUrl: "blob:draft",
+        },
+      ],
+    };
+
+    saveSessionUiSnapshot({
+      tabs: [tab],
+      activeTabId: "tab-a",
+    });
+
+    const restored = loadSessionUiSnapshot();
+    expect(restored?.tabs[0].messages[0].attachments?.[0]).toEqual({
+      id: "img-1",
+      kind: "image",
+      path: "/tmp/aethon-pastes/one.png",
+      name: "one.png",
+      mimeType: "image/png",
+      sizeBytes: 12,
+    });
+    expect(restored?.tabs[0].draftAttachments?.[0]).toEqual({
+      id: "img-2",
+      kind: "image",
+      path: "/tmp/aethon-pastes/two.png",
+      name: "two.png",
+      mimeType: "image/png",
+      sizeBytes: 13,
+    });
+  });
+
   it("does not restore persistent localStorage snapshots synchronously", () => {
     const localStorage =
       window.localStorage ??

--- a/src/state/sessionUiSnapshot.ts
+++ b/src/state/sessionUiSnapshot.ts
@@ -1,4 +1,6 @@
 import { OVERVIEW_TAB_ID, type Tab } from "../types/tab";
+import type { ChatMessage } from "../types/a2ui";
+import { durableImageAttachments } from "../utils/imageAttachments";
 import { dedupeToolResultTextMessages } from "../utils/messages";
 
 export const SESSION_UI_SNAPSHOT_FILE = "session_ui_snapshot";
@@ -35,11 +37,21 @@ function canUseSessionStorage(): boolean {
 }
 
 function trimTab(tab: Tab): Tab {
+  const messages = dedupeToolResultTextMessages(tab.messages)
+    .slice(-MAX_MESSAGES_PER_TAB)
+    .map((message): ChatMessage => {
+      if (!message.attachments || message.attachments.length === 0) {
+        return message;
+      }
+      return {
+        ...message,
+        attachments: durableImageAttachments(message.attachments),
+      };
+    });
   return {
     ...tab,
-    messages: dedupeToolResultTextMessages(tab.messages).slice(
-      -MAX_MESSAGES_PER_TAB,
-    ),
+    messages,
+    draftAttachments: durableImageAttachments(tab.draftAttachments),
     terminalBuffer: tab.terminalBuffer.slice(-MAX_TERMINAL_BUFFER),
   };
 }
@@ -197,52 +209,60 @@ export function parseSessionUiSnapshot(
         const base = {
           ...t,
           kind: t.kind ?? "agent",
-          messages: dedupeToolResultTextMessages(t.messages),
+          messages: dedupeToolResultTextMessages(t.messages).map(
+            (message): ChatMessage =>
+              message.attachments && message.attachments.length > 0
+                ? {
+                    ...message,
+                    attachments: durableImageAttachments(message.attachments),
+                  }
+                : message,
+          ),
           draft: t.draft ?? "",
           draftAttachments: Array.isArray(t.draftAttachments)
-            ? t.draftAttachments
+            ? durableImageAttachments(t.draftAttachments)
             : [],
-        // Waiting is process-local state. After an app restart there is no
-        // still-attached prompt runner behind this tab, so restoring it as
-        // busy leaves the UI stuck in "thinking..." with a dead stop button.
-        waiting: false,
-        // Client-held queue is intentionally NOT restored: queued
-        // messages are ephemeral, and a user who closed the app while
-        // queue items were pending probably abandoned them. The next
-        // run starts with a clean queue. `queueCount` is derived from
-        // `queuedMessages.length`, so zero it in lockstep — otherwise
-        // the composer badge / "Stop + clear" label would read as
-        // non-empty against an empty popover.
-        queueCount: 0,
-        queuedMessages: [],
-        canvas: t.canvas ?? null,
-        model: t.model ?? "",
-        terminalBuffer: t.terminalBuffer ?? "",
+          // Waiting is process-local state. After an app restart there is no
+          // still-attached prompt runner behind this tab, so restoring it as
+          // busy leaves the UI stuck in "thinking..." with a dead stop button.
+          waiting: false,
+          // Client-held queue is intentionally NOT restored: queued
+          // messages are ephemeral, and a user who closed the app while
+          // queue items were pending probably abandoned them. The next
+          // run starts with a clean queue. `queueCount` is derived from
+          // `queuedMessages.length`, so zero it in lockstep — otherwise
+          // the composer badge / "Stop + clear" label would read as
+          // non-empty against an empty popover.
+          queueCount: 0,
+          queuedMessages: [],
+          canvas: t.canvas ?? null,
+          model: t.model ?? "",
+          terminalBuffer: t.terminalBuffer ?? "",
           projectId: t.projectId ?? null,
-        // Preserve editor metadata so a persisted editor tab reopens
-        // pointing at the same file. Validate the shape minimally —
-        // `filePath` is the field EditorCanvas actually requires; the
-        // rest fall back to safe defaults on the next render.
-        ...(t.kind === "editor" &&
-        t.editor &&
-        typeof t.editor.filePath === "string"
-          ? {
-              editor: {
-                filePath: t.editor.filePath,
-                ...(typeof t.editor.rootPath === "string" && t.editor.rootPath
-                  ? { rootPath: t.editor.rootPath }
-                  : {}),
-                language:
-                  typeof t.editor.language === "string"
-                    ? t.editor.language
-                    : "plaintext",
-                isDirty: false,
-                ...(typeof t.editor.cursorLine === "number"
-                  ? { cursorLine: t.editor.cursorLine }
-                  : {}),
-                ...(typeof t.editor.cursorColumn === "number"
-                  ? { cursorColumn: t.editor.cursorColumn }
-                  : {}),
+          // Preserve editor metadata so a persisted editor tab reopens
+          // pointing at the same file. Validate the shape minimally —
+          // `filePath` is the field EditorCanvas actually requires; the
+          // rest fall back to safe defaults on the next render.
+          ...(t.kind === "editor" &&
+          t.editor &&
+          typeof t.editor.filePath === "string"
+            ? {
+                editor: {
+                  filePath: t.editor.filePath,
+                  ...(typeof t.editor.rootPath === "string" && t.editor.rootPath
+                    ? { rootPath: t.editor.rootPath }
+                    : {}),
+                  language:
+                    typeof t.editor.language === "string"
+                      ? t.editor.language
+                      : "plaintext",
+                  isDirty: false,
+                  ...(typeof t.editor.cursorLine === "number"
+                    ? { cursorLine: t.editor.cursorLine }
+                    : {}),
+                  ...(typeof t.editor.cursorColumn === "number"
+                    ? { cursorColumn: t.editor.cursorColumn }
+                    : {}),
                 },
               }
             : {}),
@@ -287,8 +307,7 @@ export function serializeSessionUiSnapshot(
     const activeTab = tabs.find((t) => t.id === state.activeTabId);
     const activeTabId =
       typeof state.activeTabId === "string" &&
-      (state.activeTabId === OVERVIEW_TAB_ID ||
-        tabCanOwnMainSurface(activeTab))
+      (state.activeTabId === OVERVIEW_TAB_ID || tabCanOwnMainSurface(activeTab))
         ? state.activeTabId
         : (tabs.find(tabCanOwnMainSurface)?.id ?? OVERVIEW_TAB_ID);
     const snapshot: SessionUiSnapshot = {

--- a/src/state/sessionUiSnapshot.ts
+++ b/src/state/sessionUiSnapshot.ts
@@ -199,6 +199,9 @@ export function parseSessionUiSnapshot(
           kind: t.kind ?? "agent",
           messages: dedupeToolResultTextMessages(t.messages),
           draft: t.draft ?? "",
+          draftAttachments: Array.isArray(t.draftAttachments)
+            ? t.draftAttachments
+            : [],
         // Waiting is process-local state. After an app restart there is no
         // still-attached prompt runner behind this tab, so restoring it as
         // busy leaves the UI stuck in "thinking..." with a dead stop button.

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -1906,7 +1906,7 @@ body.ae-resizing-sidebar .a2ui-layout {
   max-width: 100%;
   overflow-x: hidden;
   overscroll-behavior: none;
-  padding: 16px 20px 12px;
+  padding: 0;
   background: var(--bg);
 }
 
@@ -2775,7 +2775,7 @@ body.ae-resizing-sidebar .a2ui-layout {
   max-width: 100%;
   overflow-x: hidden;
   overscroll-behavior: none;
-  padding: 12px 12px 8px;
+  padding: 0;
   contain: layout style;
 }
 
@@ -2803,7 +2803,32 @@ body.ae-resizing-sidebar .a2ui-layout {
   flex-direction: column;
   min-width: 0;
   max-width: 100%;
+  box-sizing: border-box;
   overflow-x: hidden;
+}
+
+.a2ui-canvas-scroller .a2ui-msg-row {
+  padding-inline: 20px;
+}
+
+.a2ui-chat-history .a2ui-msg-row {
+  padding-inline: 12px;
+}
+
+.a2ui-canvas-scroller .a2ui-msg-row-first {
+  padding-top: 16px;
+}
+
+.a2ui-chat-history .a2ui-msg-row-first {
+  padding-top: 12px;
+}
+
+.a2ui-canvas-scroller .a2ui-msg-row-last {
+  padding-bottom: 12px;
+}
+
+.a2ui-chat-history .a2ui-msg-row-last {
+  padding-bottom: 8px;
 }
 
 .a2ui-chat-load-older {

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -3181,10 +3181,20 @@ body.ae-resizing-composer * {
   background: var(--bg-elev);
 }
 
-.a2ui-chat-attachment img,
-.a2ui-task-launcher-attachment img {
+.a2ui-chat-attachment-thumb,
+.a2ui-task-launcher-attachment-thumb {
   width: 46px;
   height: 34px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: zoom-in;
+}
+
+.a2ui-chat-attachment-thumb img,
+.a2ui-task-launcher-attachment-thumb img {
+  width: 100%;
+  height: 100%;
   object-fit: cover;
   border-radius: 4px;
   border: 1px solid var(--border);
@@ -3201,7 +3211,7 @@ body.ae-resizing-composer * {
 }
 
 .a2ui-chat-attachment-remove,
-.a2ui-task-launcher-attachment button {
+.a2ui-task-launcher-attachment-remove {
   position: absolute;
   top: 5px;
   right: 5px;
@@ -3218,7 +3228,7 @@ body.ae-resizing-composer * {
 }
 
 .a2ui-chat-attachment-remove:hover,
-.a2ui-task-launcher-attachment button:hover {
+.a2ui-task-launcher-attachment-remove:hover {
   color: var(--text);
   border-color: var(--accent);
 }

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -3153,6 +3153,76 @@ body.ae-resizing-composer * {
   border-left: 1px solid var(--border);
 }
 
+.a2ui-chat-attachments,
+.a2ui-task-launcher-attachments,
+.a2ui-message-attachments {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  min-width: 0;
+}
+
+.a2ui-chat-attachments {
+  margin: 0 0 8px;
+}
+
+.a2ui-chat-attachment,
+.a2ui-task-launcher-attachment {
+  position: relative;
+  display: grid;
+  grid-template-columns: 46px minmax(0, 1fr);
+  align-items: center;
+  gap: 8px;
+  width: min(240px, 100%);
+  margin: 0;
+  padding: 5px 28px 5px 5px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-elev);
+}
+
+.a2ui-chat-attachment img,
+.a2ui-task-launcher-attachment img {
+  width: 46px;
+  height: 34px;
+  object-fit: cover;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+}
+
+.a2ui-chat-attachment figcaption,
+.a2ui-task-launcher-attachment figcaption {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-dim);
+  font-size: var(--chrome-text-compact);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.a2ui-chat-attachment-remove,
+.a2ui-task-launcher-attachment button {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  display: inline-grid;
+  place-items: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  background: var(--bg);
+  color: var(--text-dim);
+  cursor: pointer;
+}
+
+.a2ui-chat-attachment-remove:hover,
+.a2ui-task-launcher-attachment button:hover {
+  color: var(--text);
+  border-color: var(--accent);
+}
+
 /* Slash command autocomplete — portal-rendered to document.body and
    anchored via inline `position: fixed` (see ChatInput). The default
    layout grid cell uses overflow: hidden, so the menu must escape the
@@ -3392,6 +3462,97 @@ body.ae-resizing-composer * {
 }
 .a2ui-chat-input-stop:hover {
   background: var(--accent-soft);
+}
+
+.a2ui-message-attachments {
+  margin-top: 8px;
+}
+
+.a2ui-message-attachment {
+  display: grid;
+  gap: 5px;
+  width: min(220px, 100%);
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-elev);
+  color: var(--text);
+  cursor: zoom-in;
+  overflow: hidden;
+  text-align: left;
+}
+
+.a2ui-message-attachment img {
+  width: 100%;
+  aspect-ratio: 16 / 10;
+  object-fit: cover;
+  background: var(--bg);
+}
+
+.a2ui-message-attachment span {
+  min-width: 0;
+  padding: 0 8px 7px;
+  overflow: hidden;
+  color: var(--text-dim);
+  font-size: var(--chrome-text-compact);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.a2ui-image-lightbox {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: grid;
+  place-items: center;
+  padding: 32px;
+}
+
+.a2ui-image-lightbox-backdrop {
+  position: absolute;
+  inset: 0;
+  border: 0;
+  background: rgba(15, 23, 42, 0.72);
+  cursor: zoom-out;
+}
+
+.a2ui-image-lightbox-figure {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 8px;
+  max-width: min(1100px, 94vw);
+  max-height: 90vh;
+  margin: 0;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-elev);
+  box-shadow: var(--shadow-2);
+}
+
+.a2ui-image-lightbox-figure img {
+  max-width: 100%;
+  max-height: calc(90vh - 70px);
+  object-fit: contain;
+}
+
+.a2ui-image-lightbox-figure figcaption {
+  color: var(--text-dim);
+  font-size: var(--chrome-text-compact);
+}
+
+.a2ui-image-lightbox-close {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  background: var(--bg);
+  color: var(--text);
+  cursor: pointer;
 }
 
 .ae-voice-provider-list {

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -2364,10 +2364,11 @@ body.ae-resizing-sidebar .a2ui-layout {
 }
 
 .a2ui-canvas-message {
-  max-width: min(88%, 100%);
+  max-width: min(88%, calc(100% - 24px));
   min-width: 0;
   padding: 8px 12px;
   line-height: 1.5;
+  overflow-wrap: anywhere;
 }
 
 .a2ui-canvas-message.user {
@@ -2376,6 +2377,7 @@ body.ae-resizing-sidebar .a2ui-layout {
   border: 1px solid var(--border);
   border-radius: 14px 14px 4px 14px;
   margin-left: 14%;
+  margin-right: 0;
   margin-top: 10px;
 }
 .a2ui-canvas-message.user.ae-msg-cont {
@@ -2501,6 +2503,7 @@ body.ae-resizing-sidebar .a2ui-layout {
   font-size: 0.88em;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   color: var(--syntax-keyword, var(--text));
+  overflow-wrap: anywhere;
 }
 .a2ui-markdown pre {
   margin: 0.35em 0;
@@ -2825,9 +2828,10 @@ body.ae-resizing-sidebar .a2ui-layout {
   padding: 8px 12px;
   font-size: var(--text-sm);
   min-width: 0;
-  max-width: 88%;
+  max-width: min(88%, calc(100% - 24px));
   line-height: 1.5;
   position: relative;
+  overflow-wrap: anywhere;
 }
 
 /* Continuation message — same sender, no top margin needed */
@@ -2842,6 +2846,7 @@ body.ae-resizing-sidebar .a2ui-layout {
   border-radius: 14px 14px 4px 14px;
   align-self: flex-end;
   margin-left: 14%;
+  margin-right: 0;
   margin-top: 10px;
 }
 .a2ui-chat-message.user.ae-msg-cont {

--- a/src/styles/scrollbar.test.ts
+++ b/src/styles/scrollbar.test.ts
@@ -62,15 +62,27 @@ describe("chat overflow containment CSS", () => {
     expect(canvasScroller).toMatch(/min-width:\s*0;/);
     expect(canvasScroller).toMatch(/max-width:\s*100%;/);
     expect(canvasScroller).toMatch(/overflow-x:\s*hidden;/);
+    expect(canvasScroller).toMatch(/padding:\s*0;/);
 
     const chatHistory = cssRuleBody(chromeCss, ".a2ui-chat-history");
     expect(chatHistory).toMatch(/min-width:\s*0;/);
     expect(chatHistory).toMatch(/max-width:\s*100%;/);
     expect(chatHistory).toMatch(/overflow-x:\s*hidden;/);
+    expect(chatHistory).toMatch(/padding:\s*0;/);
 
     const row = cssRuleBody(chromeCss, ".a2ui-msg-row");
     expect(row).toMatch(/min-width:\s*0;/);
     expect(row).toMatch(/max-width:\s*100%;/);
+    expect(row).toMatch(/box-sizing:\s*border-box;/);
+
+    const canvasRows = cssRuleBody(
+      chromeCss,
+      ".a2ui-canvas-scroller .a2ui-msg-row",
+    );
+    expect(canvasRows).toMatch(/padding-inline:\s*20px;/);
+
+    const chatRows = cssRuleBody(chromeCss, ".a2ui-chat-history .a2ui-msg-row");
+    expect(chatRows).toMatch(/padding-inline:\s*12px;/);
   });
 
   it("wraps prose while keeping code and tables constrained locally", () => {

--- a/src/types/a2ui.ts
+++ b/src/types/a2ui.ts
@@ -299,6 +299,7 @@ export interface ChatAttachment {
   name: string;
   mimeType: string;
   sizeBytes: number;
+  previewUrl?: string;
 }
 
 // Message shape used by ChatHistory and MainCanvas — text or embedded A2UI subtree.

--- a/src/types/a2ui.ts
+++ b/src/types/a2ui.ts
@@ -292,11 +292,21 @@ export type TerminalProps = TerminalComponent["props"];
 export type ChatInputProps = ChatInputComponent["props"];
 export type MainCanvasProps = MainCanvasComponent["props"];
 
+export interface ChatAttachment {
+  id: string;
+  kind: "image";
+  path: string;
+  name: string;
+  mimeType: string;
+  sizeBytes: number;
+}
+
 // Message shape used by ChatHistory and MainCanvas — text or embedded A2UI subtree.
 export interface ChatMessage {
   id: string;
   role: "user" | "agent" | "system";
   text?: string;
+  attachments?: ChatAttachment[];
   thinking?: string;
   a2ui?: A2UIPayload;
   delivery?: "sent" | "queued" | "steered" | "failed";

--- a/src/types/tab.ts
+++ b/src/types/tab.ts
@@ -1,4 +1,4 @@
-import type { ChatMessage } from "./a2ui";
+import type { ChatAttachment, ChatMessage } from "./a2ui";
 import type { ShareMode } from "../utils/shareMode";
 
 // M6 P1: shell-tab metadata. Present iff Tab.kind === "shell".
@@ -65,6 +65,7 @@ export type TabKind = "agent" | "shell" | "editor";
 export interface QueuedMessage {
   id: string;
   content: string;
+  attachments?: ChatAttachment[];
 }
 
 export interface Tab {
@@ -75,6 +76,7 @@ export interface Tab {
   label: string;
   messages: ChatMessage[];
   draft: string;
+  draftAttachments?: ChatAttachment[];
   waiting: boolean;
   /** Derived: equals `queuedMessages.length`. Kept as a separate field so
    *  the existing `/queueCount` binding (badge in the composer) doesn't
@@ -195,6 +197,7 @@ export function makeEmptyTab(
     label,
     messages: [],
     draft: "",
+    draftAttachments: [],
     waiting: false,
     queueCount: 0,
     queuedMessages: [],

--- a/src/utils/imageAttachments.ts
+++ b/src/utils/imageAttachments.ts
@@ -36,3 +36,16 @@ export function imageAttachmentSrc(attachment: ChatAttachment): string {
   if (attachment.previewUrl) return attachment.previewUrl;
   return convertFileSrc(attachment.path);
 }
+
+export function durableImageAttachment(
+  attachment: ChatAttachment,
+): ChatAttachment {
+  const { previewUrl: _previewUrl, ...durable } = attachment;
+  return durable;
+}
+
+export function durableImageAttachments(
+  attachments: ChatAttachment[] | undefined,
+): ChatAttachment[] {
+  return (attachments ?? []).map(durableImageAttachment);
+}

--- a/src/utils/imageAttachments.ts
+++ b/src/utils/imageAttachments.ts
@@ -9,6 +9,10 @@ export function imageNameFromPath(path: string): string {
 export async function saveClipboardImageAttachment(
   file: File,
 ): Promise<ChatAttachment> {
+  const previewUrl =
+    typeof URL !== "undefined" && typeof URL.createObjectURL === "function"
+      ? URL.createObjectURL(file)
+      : undefined;
   const buffer = await file.arrayBuffer();
   const bytes = Array.from(new Uint8Array(buffer));
   const mimeType = file.type || "image/png";
@@ -24,9 +28,11 @@ export async function saveClipboardImageAttachment(
     name: file.name || imageNameFromPath(path),
     mimeType,
     sizeBytes: file.size,
+    ...(previewUrl ? { previewUrl } : {}),
   };
 }
 
 export function imageAttachmentSrc(attachment: ChatAttachment): string {
+  if (attachment.previewUrl) return attachment.previewUrl;
   return convertFileSrc(attachment.path);
 }

--- a/src/utils/imageAttachments.ts
+++ b/src/utils/imageAttachments.ts
@@ -1,0 +1,32 @@
+import { convertFileSrc, invoke } from "@tauri-apps/api/core";
+import type { ChatAttachment } from "../types/a2ui";
+
+export function imageNameFromPath(path: string): string {
+  const normalized = path.replace(/\\/g, "/");
+  return normalized.split("/").pop() || "image";
+}
+
+export async function saveClipboardImageAttachment(
+  file: File,
+): Promise<ChatAttachment> {
+  const buffer = await file.arrayBuffer();
+  const bytes = Array.from(new Uint8Array(buffer));
+  const mimeType = file.type || "image/png";
+  const ext = mimeType.split("/")[1] || "png";
+  const path = await invoke<string>("save_paste_image", {
+    bytes,
+    extension: ext,
+  });
+  return {
+    id: crypto.randomUUID(),
+    kind: "image",
+    path,
+    name: file.name || imageNameFromPath(path),
+    mimeType,
+    sizeBytes: file.size,
+  };
+}
+
+export function imageAttachmentSrc(attachment: ChatAttachment): string {
+  return convertFileSrc(attachment.path);
+}

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -1,4 +1,4 @@
-import type { A2UIPayload, ChatMessage } from "../types/a2ui";
+import type { A2UIPayload, ChatAttachment, ChatMessage } from "../types/a2ui";
 
 // Persisted-history budget per message text. The in-memory message keeps
 // the full string; only the persisted snapshot is trimmed so localStorage
@@ -85,6 +85,36 @@ export function dedupeToolResultTextMessages(
   return out;
 }
 
+function coerceChatAttachments(value: unknown): ChatAttachment[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((item) => {
+    if (!item || typeof item !== "object") return [];
+    const record = item as Record<string, unknown>;
+    if (
+      typeof record.id !== "string" ||
+      record.kind !== "image" ||
+      typeof record.path !== "string" ||
+      typeof record.name !== "string" ||
+      typeof record.mimeType !== "string" ||
+      !record.mimeType.startsWith("image/") ||
+      typeof record.sizeBytes !== "number" ||
+      !Number.isFinite(record.sizeBytes)
+    ) {
+      return [];
+    }
+    return [
+      {
+        id: record.id,
+        kind: "image",
+        path: record.path,
+        name: record.name,
+        mimeType: record.mimeType,
+        sizeBytes: record.sizeBytes,
+      },
+    ];
+  });
+}
+
 export function coerceChatMessages(value: unknown): ChatMessage[] {
   if (!Array.isArray(value)) return [];
   const messages: ChatMessage[] = [];
@@ -114,7 +144,8 @@ export function coerceChatMessages(value: unknown): ChatMessage[] {
       record.delivery === "failed"
         ? record.delivery
         : undefined;
-    if (!text && !thinking && !a2ui) continue;
+    const attachments = coerceChatAttachments(record.attachments);
+    if (!text && !thinking && !a2ui && attachments.length === 0) continue;
     messages.push(
       trimMessage({
         id:
@@ -124,6 +155,7 @@ export function coerceChatMessages(value: unknown): ChatMessage[] {
         role,
         ...(text ? { text } : {}),
         ...(thinking ? { thinking } : {}),
+        ...(attachments.length > 0 ? { attachments } : {}),
         ...(a2ui ? { a2ui } : {}),
         ...(delivery ? { delivery } : {}),
       }),


### PR DESCRIPTION
## Summary

- Add image paste/attachment support across the task launcher and chat composer, including thumbnails, lightbox viewing, and multimodal agent payload forwarding.
- Preserve image attachment metadata across session restore, right-click reloads, and bridge-ready replays so chat thumbnails survive app/webview reloads.
- Fix chat layout and sticky-scroll behavior so user bubbles stay inside the chat surface and the latest pill only appears when the user is actually away from the bottom.
- Let blank + New worktree launches auto-generate a branch, place worktrees under the Aethon user dir layout, and ensure nested worktree parent directories are created before invoking git.
- Disable OS autocorrect/autocapitalization/spellcheck on worktree branch inputs.

## Validation

- `bunx vitest run src/extensions/default-layout/dashboard/task-launcher.test.tsx`
- `bunx vitest run src/extensions/default-layout/chat.test.tsx src/extensions/default-layout/dashboard/task-launcher.test.tsx src/hooks/useTaskLauncher.test.ts src/hooks/useProjectOps.test.ts`
- `bunx vitest run src/hooks/bridgeMessageHandlers/sessionHistory.test.ts src/hooks/bridgeMessageHandlers/ready.test.ts src/hooks/useSessionPersistence.test.tsx src/state/sessionUiSnapshot.test.ts agent/session-history.test.ts`
- `bunx vitest run`
- `bun run typecheck`
- `bun run lint` (passes with existing React hook warnings in editor/image-viewer, editor/markdown-preview, layout/worktree-landing, usePersistEditorTabs, and useRestoreShellTabs)
- `cargo test --lib commands::git::worktrees::tests::add_worktree_creates_missing_parent_directory` from `src-tauri`
- `cargo test --lib commands::git::worktrees::tests` from `src-tauri`

## Review / UAT

- UAT confirmed image thumbnails, reload survival, responsive chat padding, and blank-branch new worktree launch behavior.
- Codex peer review found the missing parent-directory case for nested worktree paths; fixed in `4bff691` with a Rust regression.

Closes #171
Closes #172