### PR TITLE
fix(ci): serialize release-please runs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,6 +14,12 @@ permissions:
   contents: write
   pull-requests: write
 
+# release-please mutates one long-lived PR branch for main; queue runs so
+# bursty merges cannot race while updating that shared ref.
+concurrency:
+  group: release-please-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
## Summary
- Add workflow-level concurrency to the Release Please workflow.
- Queue runs for the same ref instead of cancelling them, so release builds are not interrupted.

## Root Cause
A burst of pushes to `main` can start multiple Release Please runs at once. Each run mutates the same long-lived `release-please--branches--main--components--aethon` branch, which caused one run to fail while updating that shared ref.

## Verification
- `bun run version:check`
- `git diff --check`
- Ruby YAML parse/assertion for the new concurrency block

## Notes
`actionlint` was not installed in the local shell, so I used the platform Ruby YAML parser for syntax/structure validation.