### PR TITLE
ci(release): author release PR via GitHub App so CI runs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,8 +34,23 @@ jobs:
       prs_created: ${{ steps.release.outputs.prs_created }}
       pr: ${{ steps.release.outputs.pr }}
     steps:
+      # release-please opens/updates the release PR. If we let it use the
+      # default GITHUB_TOKEN, GitHub's recursion guard suppresses the
+      # `pull_request` event, so ci.yml never runs and the required checks
+      # sit in "Expected — waiting for status" forever (unmergeable PR).
+      # Mint a short-lived GitHub App token instead so the PR is authored
+      # by a real identity and CI fires normally.
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+
       - id: release
         uses: googleapis/release-please-action@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       # Immediately mark the release as draft so it's not visible until
       # all build artifacts have been uploaded successfully.
@@ -75,13 +90,26 @@ jobs:
           fi
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
 
+      # Same App token as the release job. This is load-bearing: the
+      # commit pushed below becomes the PR's HEAD, and required checks
+      # attach to the HEAD SHA. Pushing with the default GITHUB_TOKEN
+      # would not fire `pull_request: synchronize`, so CI would run on
+      # release-please's commit but never on this final HEAD — leaving
+      # the PR blocked. Pushing as the App fires synchronize → CI runs.
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v5
         with:
           ref: ${{ steps.pr.outputs.branch }}
-          # release-please-action runs as github-actions[bot]; we push
-          # back to the PR branch as the same identity so the commit
-          # shows up as a sibling of release-please's own commits.
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Push back to the PR branch as the App identity so the push
+          # triggers CI (the default GITHUB_TOKEN would be suppressed by
+          # GitHub's recursion guard).
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## Problem

The release-please "chore: release" PR sits forever with its required checks in **Expected — waiting for status to be reported** (see the 4 `rust`/`ts` checks). It's unmergeable.

Root cause is GitHub's recursion guard, not our logic: release-please opened the PR using the default `GITHUB_TOKEN`, and

> events triggered by the `GITHUB_TOKEN`, with the exception of `workflow_dispatch` and `repository_dispatch`, will not create a new workflow run.

So `ci.yml`'s `pull_request` trigger never fires → required checks never run → branch protection blocks merge.

## Fix

Mint a short-lived GitHub App token via `actions/create-github-app-token@v3` and pass it to **both** jobs that touch the release PR:

- **`release-please` job** → `token:` on `googleapis/release-please-action@v4`, so the PR is *opened* by a real identity (`pull_request: opened` fires).
- **`sync-version-files` job** → `actions/checkout` token + the `chore: sync version files` push. That commit becomes the PR **HEAD**, and required checks bind to the HEAD SHA, so the push itself must fire `pull_request: synchronize`. Using the default token here would leave CI running on release-please's commit but not the final HEAD → still blocked.

Build/publish/crate jobs keep `secrets.GITHUB_TOKEN` (they run on tag push, not the PR — unaffected).

## Setup (done)

- GitHub App `aethon-release-bot` created, **public** (so it can install on the `utensils` org), permissions **Contents: write** + **Pull requests: write**.
- Installed on `utensils/aethon` (org-scoped, selected repos).
- Repo secrets `RELEASE_PLEASE_APP_ID` + `RELEASE_PLEASE_APP_PRIVATE_KEY` set.

Verified end-to-end before opening this PR: JWT → installation lookup → `POST .../access_tokens` returns `HTTP 201` with `{contents: write, pull_requests: write}`.

## After merge

The merge is itself a push to `main`, which re-runs release-please with the App token and re-drives the stuck release PR — CI should finally fire on it.