### PR TITLE
ci: gate nightly/release on CI + patch-aware nightly versioning

### DIFF
--- a/.github/workflows/_ci.yml
+++ b/.github/workflows/_ci.yml
@@ -1,0 +1,104 @@
+name: _ci
+
+# Reusable CI: lint + typecheck + tests. Called by ci.yml (push / PR) and
+# embedded into release-please.yml as a gate before the macOS build, so
+# the same checks are defined exactly once. The jobs use no secrets, so
+# callers do not need `secrets: inherit`.
+
+on:
+  workflow_call: {}
+
+jobs:
+  ts:
+    name: ts (typecheck + eslint + vitest)
+    env:
+      NODE_OPTIONS: --max-old-space-size=4096
+    # macOS for parity with the dev environment + Bun's native target
+    # is well-supported here. Linux mirrors the Tauri release target.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, macos-15]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v5
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.x
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Version files are synced
+        run: bun run version:check
+      - name: TypeScript typecheck
+        run: bunx tsc -b --noEmit
+      - name: ESLint
+        run: bunx eslint .
+      - name: Vitest
+        run: bunx vitest run
+
+  e2e:
+    name: e2e (playwright)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.x
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Version files are synced
+        run: bun run version:check
+      - name: Install Playwright Chromium
+        run: bunx playwright install --with-deps chromium
+      - name: Playwright
+        run: bun run test:e2e
+
+  rust:
+    name: rust (clippy + cargo test)
+    strategy:
+      fail-fast: false
+      matrix:
+        # macOS first because the dev workflow targets Apple Silicon.
+        # Ubuntu validates the cross-platform build invariants.
+        os: [ubuntu-24.04, macos-15]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install Rust toolchain
+        # Pinned to match rust-toolchain.toml — bumping that file
+        # automatically flows here too.
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.92.0"
+          components: clippy, rustfmt
+      - name: Cache cargo registry + target
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri -> target
+      - name: Install Linux build deps (webkit2gtk, gtk, ALSA closure)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y \
+            libasound2-dev \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libsoup-3.0-dev \
+            pkg-config \
+            patchelf
+      - name: Setup Bun (build.rs runs `bun build --compile`)
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.x
+      - name: Install JS deps so the agent sidecar build can find them
+        run: bun install --frozen-lockfile
+      - name: Version files are synced
+        run: bun run version:check
+      - name: Cargo clippy
+        run: cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings
+      - name: Cargo test (lib only — no Tauri runtime needed)
+        run: cargo test --manifest-path src-tauri/Cargo.toml --lib

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,8 @@
 name: CI
 
-# Lint + typecheck + tests on every push / PR. Mirrors the `check`
-# devshell command but split into individual steps so a failing job
-# surfaces the right log section in the Actions UI without scrolling
-# through everything else.
+# Lint + typecheck + tests on every push / PR. The actual jobs live in the
+# reusable _ci.yml so release-please.yml can embed the same gate before its
+# macOS build, and the checks are defined exactly once.
 
 on:
   push:
@@ -17,96 +16,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  ts:
-    name: ts (typecheck + eslint + vitest)
-    env:
-      NODE_OPTIONS: --max-old-space-size=4096
-    # macOS for parity with the dev environment + Bun's native target
-    # is well-supported here. Linux mirrors the Tauri release target.
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-24.04, macos-15]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v5
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.x
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-      - name: Version files are synced
-        run: bun run version:check
-      - name: TypeScript typecheck
-        run: bunx tsc -b --noEmit
-      - name: ESLint
-        run: bunx eslint .
-      - name: Vitest
-        run: bunx vitest run
-
-  e2e:
-    name: e2e (playwright)
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v5
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.x
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-      - name: Version files are synced
-        run: bun run version:check
-      - name: Install Playwright Chromium
-        run: bunx playwright install --with-deps chromium
-      - name: Playwright
-        run: bun run test:e2e
-
-  rust:
-    name: rust (clippy + cargo test)
-    strategy:
-      fail-fast: false
-      matrix:
-        # macOS first because the dev workflow targets Apple Silicon.
-        # Ubuntu validates the cross-platform build invariants.
-        os: [ubuntu-24.04, macos-15]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v5
-      - name: Install Rust toolchain
-        # Pinned to match rust-toolchain.toml — bumping that file
-        # automatically flows here too.
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: "1.92.0"
-          components: clippy, rustfmt
-      - name: Cache cargo registry + target
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: src-tauri -> target
-      - name: Install Linux build deps (webkit2gtk, gtk, ALSA closure)
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install --no-install-recommends -y \
-            libasound2-dev \
-            libwebkit2gtk-4.1-dev \
-            libgtk-3-dev \
-            libayatana-appindicator3-dev \
-            librsvg2-dev \
-            libsoup-3.0-dev \
-            pkg-config \
-            patchelf
-      - name: Setup Bun (build.rs runs `bun build --compile`)
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.x
-      - name: Install JS deps so the agent sidecar build can find them
-        run: bun install --frozen-lockfile
-      - name: Version files are synced
-        run: bun run version:check
-      - name: Cargo clippy
-        run: cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings
-      - name: Cargo test (lib only — no Tauri runtime needed)
-        run: cargo test --manifest-path src-tauri/Cargo.toml --lib
+  call-ci:
+    uses: ./.github/workflows/_ci.yml
+    # CI uses no secrets; `secrets: inherit` is intentionally omitted.

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,11 +26,13 @@ env:
 jobs:
   compute-version:
     name: Compute Version
-    # Only build when CI passed (workflow_run already filters branches:[main]),
-    # or when manually dispatched.
+    # Build only when CI passed on main (workflow_run already filters
+    # branches:[main]), or when manually dispatched from main. The explicit
+    # ref check keeps a `workflow_dispatch` from a feature branch from
+    # publishing a "nightly" built off a non-main ref.
     if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.v.outputs.version }}
@@ -59,6 +61,7 @@ jobs:
       - id: v
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RESOLVED_SHA: ${{ steps.sha.outputs.sha }}
         run: |
           set -euo pipefail
 
@@ -89,7 +92,9 @@ jobs:
             COMMITS=$(git rev-list --count HEAD)
           fi
 
-          SHORT=$(git rev-parse --short=7 HEAD)
+          # Short SHA from the resolved tested commit directly, so the
+          # version label doesn't depend on the checkout landing on it.
+          SHORT="${RESOLVED_SHA:0:7}"
           VERSION="${NEXT}-dev.${COMMITS}.g${SHORT}"
 
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,15 +1,16 @@
 name: Nightly Build
 
+# Chains off CI: a nightly only builds after the `CI` workflow reports
+# success on `main` (workflow_run), so a red tree never publishes a
+# nightly and CI is never duplicated. `workflow_run` carries no path
+# filter, so the old `paths-ignore` is dropped — nightly now runs after
+# every green main CI (doc-only / release-please merges are rare and
+# cheap relative to a broken nightly).
 on:
-  push:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
     branches: [main]
-    paths-ignore:
-      - "**/*.md"
-      - ".github/workflows/docs.yml"
-      - ".github/workflows/release-please.yml"
-      - ".github/workflows/copilot-review.yml"
-      - ".release-please-manifest.json"
-      - "CHANGELOG.md"
   workflow_dispatch: {}
 
 concurrency:
@@ -25,23 +26,61 @@ env:
 jobs:
   compute-version:
     name: Compute Version
-    if: github.ref == 'refs/heads/main'
+    # Only build when CI passed (workflow_run already filters branches:[main]),
+    # or when manually dispatched.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.v.outputs.version }}
       short_sha: ${{ steps.v.outputs.short_sha }}
       last_tag: ${{ steps.v.outputs.last_tag }}
+      sha: ${{ steps.sha.outputs.sha }}
     steps:
+      # Under workflow_run, github.sha / the default checkout point at the
+      # workflow file's ref, NOT the commit CI validated. Resolve the tested
+      # commit explicitly (head_sha), falling back to github.sha for dispatch
+      # (where the workflow_run context is empty). Every downstream job
+      # consumes this single resolved SHA.
+      - id: sha
+        run: |
+          set -euo pipefail
+          SHA="${{ github.event.workflow_run.head_sha }}"
+          [ -z "$SHA" ] && SHA="${{ github.sha }}"
+          echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
+          echo "Resolved head SHA: ${SHA}"
+
       - uses: actions/checkout@v5
         with:
+          ref: ${{ steps.sha.outputs.sha }}
           fetch-depth: 0
 
       - id: v
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          CURRENT=$(jq -r '.version' package.json)
-          IFS='.' read -r MAJ MIN _ <<< "$CURRENT"
-          NEXT_MINOR="${MAJ}.$((MIN + 1)).0"
+
+          # The next version is whatever release-please will actually cut
+          # (patch / minor / major), read from its open release PR. The PR
+          # title is `chore(main): release X.Y.Z` and carries the
+          # `autorelease: pending` label. `|| true` so a no-match grep under
+          # `pipefail` doesn't kill the step.
+          NEXT=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open \
+            --label "autorelease: pending" --json title \
+            --jq '.[0].title // ""' \
+            | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1 || true)
+
+          # Fallback (no release PR open → no releasable commits pending):
+          # patch-bump the last *released* version. The manifest is the
+          # authoritative pointer — package.json can be transiently bumped on
+          # a release-merge HEAD, and the newest git tag can lag the manifest.
+          if [ -z "$NEXT" ]; then
+            CURRENT=$(jq -r '."."' .release-please-manifest.json)
+            IFS='.' read -r MAJ MIN PAT <<< "$CURRENT"
+            NEXT="${MAJ}.${MIN}.$((PAT + 1))"
+          fi
 
           LAST_TAG=$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || echo "")
           if [ -n "$LAST_TAG" ]; then
@@ -51,7 +90,7 @@ jobs:
           fi
 
           SHORT=$(git rev-parse --short=7 HEAD)
-          VERSION="${NEXT_MINOR}-dev.${COMMITS}.g${SHORT}"
+          VERSION="${NEXT}-dev.${COMMITS}.g${SHORT}"
 
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "short_sha=${SHORT}" >> "$GITHUB_OUTPUT"
@@ -64,6 +103,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.compute-version.outputs.sha }}
 
       # Build into a separate `nightly-staging` release so the live
       # `nightly` release (with the previous build's assets) stays
@@ -76,16 +117,17 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ needs.compute-version.outputs.version }}
           LAST_TAG: ${{ needs.compute-version.outputs.last_tag }}
+          RESOLVED_SHA: ${{ needs.compute-version.outputs.sha }}
         run: |
           gh release delete nightly-staging --yes --cleanup-tag --repo "$GITHUB_REPOSITORY" 2>/dev/null || true
 
-          NOTES="Automated nightly build of \`${GITHUB_SHA}\`.
+          NOTES="Automated nightly build of \`${RESOLVED_SHA}\`.
 
           **Version:** \`${VERSION}\`
           **Built:** $(date -u +%FT%TZ)"
 
           if [ -n "$LAST_TAG" ]; then
-            DIFF_URL="https://github.com/${GITHUB_REPOSITORY}/compare/${LAST_TAG}...${GITHUB_SHA}"
+            DIFF_URL="https://github.com/${GITHUB_REPOSITORY}/compare/${LAST_TAG}...${RESOLVED_SHA}"
             NOTES="${NOTES}
           [Changes since ${LAST_TAG}](${DIFF_URL})"
           fi
@@ -96,7 +138,7 @@ jobs:
 
           gh release create nightly-staging \
             --repo "$GITHUB_REPOSITORY" \
-            --target "$GITHUB_SHA" \
+            --target "$RESOLVED_SHA" \
             --title "Nightly ${VERSION}" \
             --notes "$NOTES" \
             --prerelease \
@@ -109,6 +151,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.compute-version.outputs.sha }}
 
       # Stamp the nightly version into package.json, then let the
       # project's existing sync-version script propagate it to

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -156,10 +156,24 @@ jobs:
             echo "tag=${{ needs.release-please.outputs.tag_name }}" >> "$GITHUB_OUTPUT"
           fi
 
-  build:
-    name: Build (macos-aarch64)
+  # Re-run the full reusable CI before the signed macOS build, so a broken
+  # tree never produces a release artifact. Only fires when a release will
+  # actually build (resolve-tag succeeded), so ordinary non-release pushes
+  # do NOT trigger a second CI run — identical to the previous behavior.
+  ci:
+    name: CI gate
     needs: resolve-tag
     if: always() && needs.resolve-tag.result == 'success'
+    uses: ./.github/workflows/_ci.yml
+    # No secrets needed.
+
+  build:
+    name: Build (macos-aarch64)
+    needs: [resolve-tag, ci]
+    if: >-
+      always() &&
+      needs.resolve-tag.result == 'success' &&
+      needs.ci.result == 'success'
     runs-on: macos-15
     steps:
       - name: Checkout

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,8 +6,8 @@ Aethon ships two channels:
   [release-please](https://github.com/googleapis/release-please) from
   Conventional Commits on `main`. The bot opens a release PR; merging
   it tags + builds + publishes the GitHub Release.
-- **Nightly** — rebuilt on every push to `main`. Always at the
-  `nightly` tag; previous nightly assets remain reachable for the
+- **Nightly** — rebuilt after every green CI run on `main`. Always at
+  the `nightly` tag; previous nightly assets remain reachable for the
   in-app updater until the new build promotes atomically.
 
 Both build on **macOS Apple Silicon only** today (the only platform
@@ -29,20 +29,32 @@ release X.Y.Z`. It bumps `package.json`, `package-lock.json`, and
    `bun run version:check` passes on the PR's CI.
 4. Merge the release PR. release-please creates the `vX.Y.Z` tag +
    GitHub Release (immediately marked draft).
-5. The build matrix builds + notarizes + signs the macOS bundle and
-   uploads to the draft release. The publish job synthesizes
-   `latest.json` and un-drafts.
+5. The embedded reusable CI (`_ci.yml`) runs against the release ref
+   first; only on green does the build matrix build + notarize + sign the
+   macOS bundle and upload to the draft release. The publish job
+   synthesizes `latest.json` and un-drafts. A broken tree never produces
+   a signed release artifact.
 
 To build/publish an existing tag manually, use **Actions → Release
 Please → Run workflow** with the tag input.
 
 ### Nightly
 
-Push to `main` → the `Nightly Build` workflow:
+Push to `main` → `CI` runs → on green, the `Nightly Build` workflow
+chains off it via `workflow_run` (so nightly never builds on a red tree,
+and CI is never duplicated):
 
-1. Computes a `dev`-suffixed version like `0.4.0-dev.46.g9153d99`
-   (next minor + commit-count + short SHA).
-2. Creates a fresh `nightly-staging` release.
+1. Derives the next version from release-please's open release PR — the
+   `X.Y.Z` in its `chore(main): release X.Y.Z` title, located via the
+   `autorelease: pending` label — so the nightly mirrors whatever
+   release-please will actually cut (patch / minor / major). If no release
+   PR is open, it falls back to a patch bump of the last released version
+   recorded in `.release-please-manifest.json` (e.g. `0.4.0` → `0.4.1`).
+   It then appends `-dev.<commits-since-last-tag>.g<short-sha>`, e.g.
+   `0.5.0-dev.46.g9153d99` (open feat PR) or `0.4.1-dev.46.g9153d99`
+   (fix PR or fallback).
+2. Creates a fresh `nightly-staging` release targeting the exact commit
+   CI validated (`workflow_run.head_sha`).
 3. Builds + notarizes + signs the macOS bundle into staging.
 4. Synthesizes `latest.json` using the future `nightly/` asset URLs.
 5. Atomically retags `nightly-staging` → `nightly` and un-drafts.
@@ -50,6 +62,10 @@ Push to `main` → the `Nightly Build` workflow:
 The previous nightly's `latest.json` stays live for the ~entire build
 duration; the actual swap window is ~1–2 s. The updater treats
 "manifest not found" as "no update," which covers that window.
+
+Nightly can also be run manually via **Actions → Nightly Build → Run
+workflow** (workflow_dispatch); it then resolves the SHA from the current
+`main` tip.
 
 ## One-time setup
 


### PR DESCRIPTION
## What

Makes the `CI` workflow a true prerequisite for the nightly and release builds (they previously ran **concurrently** with CI), and fixes the nightly version so it reflects the **actual** next release (patch/minor/major) instead of a hardcoded minor bump.

Closes the two issues raised: nightly jumping to `0.5.0-dev.N` when the next release should be a patch, and CI not gating the publish paths.

## Changes

- **Reusable CI** — `ts`/`e2e`/`rust` extracted into `.github/workflows/_ci.yml` (`workflow_call`). `ci.yml` is now a thin push/PR entrypoint that calls it. Defined once, reused everywhere.
- **Nightly gated on CI** — `nightly.yml` now triggers on `workflow_run` after `CI` succeeds on `main` (plus `workflow_dispatch`). No broken nightlies, and CI is **not** duplicated. The tested commit is resolved via `workflow_run.head_sha` and threaded through `compute-version` / `prepare-release` (`--target` + notes) / `build` checkout.
- **Patch-aware nightly version** — derives the next version from release-please's open PR (`autorelease: pending` → `chore(main): release X.Y.Z`); falls back to a patch bump of the last released version in `.release-please-manifest.json`. With the current tree this yields `0.4.1-dev.83.g1c101d2` instead of `0.5.0-dev.83.g1c101d2`.
- **Release build gated** — `release-please.yml` adds a `ci` job (`uses: ./.github/workflows/_ci.yml`, `needs: resolve-tag`) and `build` now `needs: [resolve-tag, ci]`. Only runs when a release will actually build, so ordinary non-release pushes don't trigger a second CI.
- **Docs** — `RELEASING.md` updated.

## ⚠️ Branch-protection migration required

Reusable-workflow jobs report status-check contexts as `call-ci / <job>`. The required checks must be repointed **after this PR's first CI run**:

| Old | New |
| --- | --- |
| `ts (ubuntu-24.04)` / `ts (macos-15)` | `call-ci / ts (ubuntu-24.04)` / `call-ci / ts (macos-15)` |
| `e2e (playwright)` | `call-ci / e2e (playwright)` |
| `rust (ubuntu-24.04)` / `rust (macos-15)` | `call-ci / rust (ubuntu-24.04)` / `call-ci / rust (macos-15)` |

Until repointed, the old required contexts won't report and the PR stays blocked. Read exact names with `gh pr checks` once CI runs.

## Verification

- `actionlint` clean on all four workflow files.
- Version derivation validated locally: fallback → `0.4.1-dev.83.g1c101d2`; feat PR title → `0.5.0`; `version:check` regex accepts the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)