### PR TITLE
feat(model): restore pi-default + custom-id options in the header picker

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -516,6 +516,7 @@ export default function App() {
     slashContext: () => slashContext(),
     persistLocalChatMessage,
     recordProjectModel,
+    piDefaultModelRef,
   });
 
   // All forward-ref slots — used by earlier hooks to call through to

--- a/src/extensions/default-layout/variation-components.tsx
+++ b/src/extensions/default-layout/variation-components.tsx
@@ -366,10 +366,13 @@ export function ModelPicker({ component, state, onEvent }: BuiltinComponentProps
     : "filter models — sonnet, gpt, qwen…";
 
   if (customMode) {
-    const commit = () => {
-      const next = customValue.trim();
+    const cancel = () => {
       setCustomMode(false);
       setCustomValue("");
+    };
+    const commit = () => {
+      const next = customValue.trim();
+      cancel();
       if (next) onEvent("select", { sectionId: "models", itemId: next }, next);
     };
     return (
@@ -391,11 +394,13 @@ export function ModelPicker({ component, state, onEvent }: BuiltinComponentProps
               commit();
             } else if (e.key === "Escape") {
               e.preventDefault();
-              setCustomMode(false);
-              setCustomValue("");
+              cancel();
             }
           }}
-          onBlur={commit}
+          // Blur cancels — only Enter commits. This also makes Escape's
+          // unmount-triggered blur a no-op instead of committing the
+          // typed value, and avoids accidental commits on click-away.
+          onBlur={cancel}
         />
       </span>
     );
@@ -403,15 +408,21 @@ export function ModelPicker({ component, state, onEvent }: BuiltinComponentProps
 
   // Prepend "(pi default)" and append "Custom id…" so the header picker
   // is a full superset of the model controls (no separate Settings field).
+  // "(pi default)" is active when no explicit default is set and the
+  // visible model is just pi's fallback; in that state no concrete model
+  // is marked active too, so the listbox never shows two selected items.
+  const piDefaultActive =
+    !defaultModel && (!activeTabModel || activeTabModel === piDefaultModel);
   const sectionItems: DropdownItem[] = [
     {
       id: PI_DEFAULT_MODEL_SENTINEL,
       label: "(pi default — picks from env vars)",
-      // Highlight when no explicit default is set: the chosen default is
-      // empty AND the visible model is just pi's fallback.
-      active: !defaultModel && (!activeTabModel || activeTabModel === piDefaultModel),
+      active: piDefaultActive,
     },
-    ...items.map((it) => ({ ...it, active: it.id === activeId })),
+    ...items.map((it) => ({
+      ...it,
+      active: !piDefaultActive && it.id === activeId,
+    })),
     { id: CUSTOM_MODEL_SENTINEL, label: "Custom id…" },
   ];
   const activeItem = sectionItems.find((it) => it.active);

--- a/src/extensions/default-layout/variation-components.tsx
+++ b/src/extensions/default-layout/variation-components.tsx
@@ -20,6 +20,7 @@ import {
   resolveString,
 } from "../../utils/dataBinding";
 import { resolvePointer } from "../../utils/jsonPointer";
+import { PI_DEFAULT_MODEL_SENTINEL } from "../../utils/modelPicker";
 import type { BuiltinComponentProps } from "../../components/A2UIRenderer";
 import type { VcsSlice } from "../../hooks/useVcsStatus";
 import { ciMeta, prMeta } from "./sidebar/vcs-presentation";
@@ -315,6 +316,13 @@ function asDropdownItems(raw: unknown): DropdownItem[] {
 // event matching the sidebar shape so App routes to setModel.
 // ---------------------------------------------------------------------------
 
+// Sentinel that flips the picker into a free-text input for a model id
+// not on the loaded list. Local to the picker — custom ids resolve to a
+// real id before the `select` event fires, so nothing downstream needs
+// to know about it. `(pi default)` uses the shared
+// `PI_DEFAULT_MODEL_SENTINEL` instead, which `setModel` interprets.
+const CUSTOM_MODEL_SENTINEL = "__custom__";
+
 export function ModelPicker({ component, state, onEvent }: BuiltinComponentProps) {
   const props = component.props as {
     source?: { $ref: string } | DropdownItem[];
@@ -324,6 +332,10 @@ export function ModelPicker({ component, state, onEvent }: BuiltinComponentProps
     visible?: BooleanValue;
   };
   const visible = props.visible === undefined ? true : resolveBoolean(props.visible, state);
+  // Custom-id mode: replaces the dropdown with a free-text input so a
+  // model not in the loaded registry can still be set as the default.
+  const [customMode, setCustomMode] = useState(false);
+  const [customValue, setCustomValue] = useState("");
   if (!visible) return null;
 
   const sourceRaw = Array.isArray(props.source)
@@ -348,19 +360,65 @@ export function ModelPicker({ component, state, onEvent }: BuiltinComponentProps
   const activeId = props.active
     ? resolveString(props.active, state)
     : (activeTabModel || defaultModel || piDefaultModel || "");
-  const itemsWithActive = items.map((it) => ({
-    ...it,
-    active: it.id === activeId,
-  }));
-  const activeItem = itemsWithActive.find((it) => it.id === activeId);
-
-  const buttonLabel = props.buttonLabel
-    ? resolveString(props.buttonLabel, state)
-    : activeItem?.label || activeId || "model";
 
   const placeholder = props.placeholder
     ? resolveString(props.placeholder, state)
     : "filter models — sonnet, gpt, qwen…";
+
+  if (customMode) {
+    const commit = () => {
+      const next = customValue.trim();
+      setCustomMode(false);
+      setCustomValue("");
+      if (next) onEvent("select", { sectionId: "models", itemId: next }, next);
+    };
+    return (
+      <span className="a2ui-model-picker-custom">
+        <input
+          type="text"
+          className="a2ui-model-picker-custom-input"
+          placeholder="provider/model-id"
+          value={customValue}
+          autoFocus
+          autoCapitalize="none"
+          autoCorrect="off"
+          spellCheck={false}
+          aria-label="Custom model id"
+          onChange={(e) => setCustomValue(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              commit();
+            } else if (e.key === "Escape") {
+              e.preventDefault();
+              setCustomMode(false);
+              setCustomValue("");
+            }
+          }}
+          onBlur={commit}
+        />
+      </span>
+    );
+  }
+
+  // Prepend "(pi default)" and append "Custom id…" so the header picker
+  // is a full superset of the model controls (no separate Settings field).
+  const sectionItems: DropdownItem[] = [
+    {
+      id: PI_DEFAULT_MODEL_SENTINEL,
+      label: "(pi default — picks from env vars)",
+      // Highlight when no explicit default is set: the chosen default is
+      // empty AND the visible model is just pi's fallback.
+      active: !defaultModel && (!activeTabModel || activeTabModel === piDefaultModel),
+    },
+    ...items.map((it) => ({ ...it, active: it.id === activeId })),
+    { id: CUSTOM_MODEL_SENTINEL, label: "Custom id…" },
+  ];
+  const activeItem = sectionItems.find((it) => it.active);
+
+  const buttonLabel = props.buttonLabel
+    ? resolveString(props.buttonLabel, state)
+    : activeItem?.label || activeId || "model";
 
   return (
     <DropdownPickerCore
@@ -371,15 +429,22 @@ export function ModelPicker({ component, state, onEvent }: BuiltinComponentProps
         {
           id: "models",
           title: "models",
-          items: itemsWithActive,
+          items: sectionItems,
           searchable: true,
           searchPlaceholder: placeholder,
           emptyLabel: "no models match",
         },
       ]}
-      onSelect={(sectionId, itemId) =>
-        onEvent("select", { sectionId, itemId }, itemId)
-      }
+      onSelect={(sectionId, itemId) => {
+        if (itemId === CUSTOM_MODEL_SENTINEL) {
+          setCustomValue("");
+          setCustomMode(true);
+          return;
+        }
+        // PI_DEFAULT_MODEL_SENTINEL flows through unchanged — setModel
+        // interprets it as "reset to pi's env-driven default".
+        onEvent("select", { sectionId, itemId }, itemId);
+      }}
     />
   );
 }

--- a/src/hooks/useChat.test.ts
+++ b/src/hooks/useChat.test.ts
@@ -5,6 +5,7 @@ import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 
 import { makeEmptyTab, type Tab } from "../types/tab";
 import { useChat, type UseChatContext } from "./useChat";
+import { PI_DEFAULT_MODEL_SENTINEL } from "../utils/modelPicker";
 
 const invoke = vi.fn((..._args: unknown[]) => Promise.resolve(undefined));
 
@@ -24,6 +25,7 @@ function buildContext(overrides: Record<string, unknown> = {}): {
   ctx: UseChatContext;
   stateRef: MutableRefObject<Record<string, unknown>>;
   recordProjectModel: ReturnType<typeof vi.fn>;
+  piDefaultModelRef: MutableRefObject<string>;
 } {
   const tab = {
     ...makeEmptyTab("tab-1", "Tab 1"),
@@ -63,9 +65,13 @@ function buildContext(overrides: Record<string, unknown> = {}): {
     });
   };
   const recordProjectModel = vi.fn();
+  const piDefaultModelRef: MutableRefObject<string> = {
+    current: (overrides.piDefaultModel as string | undefined) ?? "",
+  };
   return {
     stateRef,
     recordProjectModel,
+    piDefaultModelRef,
     ctx: {
       setState,
       stateRef,
@@ -85,6 +91,7 @@ function buildContext(overrides: Record<string, unknown> = {}): {
         }) as unknown as ReturnType<UseChatContext["slashContext"]>,
       persistLocalChatMessage: vi.fn(),
       recordProjectModel,
+      piDefaultModelRef,
     },
   };
 }
@@ -621,6 +628,45 @@ describe("useChat setModel", () => {
     );
     // …but the user's chosen default is intent and must survive.
     expect(stateRef.current.defaultModel).toBe("openai/gpt-5.5");
+  });
+
+  it("'(pi default)' clears every runtime fallback and persists null without retargeting", async () => {
+    vi.useFakeTimers();
+    try {
+      const { ctx, stateRef, piDefaultModelRef } = buildContext({
+        activeTabId: undefined,
+        tabs: [],
+        defaultModel: "ollama/qwen",
+        piDefaultModel: "ollama/qwen",
+        projectModels: { p1: "ollama/qwen" },
+      });
+      const { result } = renderHook(() => useChat(ctx));
+
+      await act(async () => {
+        await result.current.setModel(PI_DEFAULT_MODEL_SENTINEL);
+      });
+
+      // Every fallback is cleared so the next new tab sends no model and
+      // the agent picks its env default; no live session retarget.
+      expect(stateRef.current.defaultModel).toBe("");
+      expect(stateRef.current.piDefaultModel).toBe("");
+      expect(stateRef.current.model).toBe("");
+      expect(stateRef.current.projectModels).toEqual({});
+      expect(piDefaultModelRef.current).toBe("");
+      expect(invoke).not.toHaveBeenCalledWith(
+        "agent_command",
+        expect.anything(),
+      );
+
+      await vi.advanceTimersByTimeAsync(450);
+      const write = invoke.mock.calls.find((c) => c[0] === "write_config");
+      expect(
+        (write?.[1] as { config: { agent: { model: string | null } } }).config
+          .agent.model,
+      ).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("persists the chosen default to [agent] model (debounced)", async () => {

--- a/src/hooks/useChat.test.ts
+++ b/src/hooks/useChat.test.ts
@@ -660,6 +660,7 @@ describe("useChat setModel", () => {
 
       await vi.advanceTimersByTimeAsync(450);
       const write = invoke.mock.calls.find((c) => c[0] === "write_config");
+      expect(write).toBeTruthy();
       expect(
         (write?.[1] as { config: { agent: { model: string | null } } }).config
           .agent.model,

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -13,7 +13,10 @@ import {
   type SlashCommandContext,
 } from "../slashCommands";
 import type { NotificationInput } from "./useNotifications";
-import { recomputeModelPicker } from "../utils/modelPicker";
+import {
+  recomputeModelPicker,
+  PI_DEFAULT_MODEL_SENTINEL,
+} from "../utils/modelPicker";
 import { getConfig, clearConfigCache, type AethonConfig } from "../config";
 
 /** Patch `queuedMessages` and the derived `queueCount` together so the
@@ -48,6 +51,10 @@ export interface UseChatContext {
   slashContext: () => SlashCommandContext;
   persistLocalChatMessage: (msg: ChatMessage, tabId: string) => void;
   recordProjectModel: (model: string, tabId?: string) => void;
+  /** pi's boot/default model, used as the new-tab fallback. Cleared when
+   *  the user resets to "(pi default)" so the next new session sends no
+   *  explicit model and the agent picks its env-driven default. */
+  piDefaultModelRef: MutableRefObject<string>;
 }
 
 export interface UseChatActions {
@@ -126,6 +133,7 @@ export function useChat(ctx: UseChatContext): UseChatActions {
     slashContext,
     persistLocalChatMessage,
     recordProjectModel,
+    piDefaultModelRef,
   } = ctx;
 
   // Fallback id for text bubbles when the bridge doesn't supply one. The
@@ -524,6 +532,38 @@ export function useChat(ctx: UseChatContext): UseChatActions {
    *  would spin up a phantom "default" session — but the default pick above
    *  is enough for the next new session to inherit. */
   async function setModel(id: string) {
+    // "(pi default)" — fully reset to pi's env-driven default for new
+    // sessions. Clear every runtime fallback so the next new tab sends
+    // NO explicit model and the agent picks from env: the chosen default
+    // (/defaultModel), per-project memory (/projectModels), and pi's
+    // cached boot model (/piDefaultModel + piDefaultModelRef — which may
+    // itself be a stale configured value seeded at boot). Persist
+    // [agent] model = null. Does not retarget a running session — the
+    // reset governs new sessions only, matching the old Settings field.
+    if (id === PI_DEFAULT_MODEL_SENTINEL) {
+      const activeId = stateRef.current.activeTabId as string | undefined;
+      const tabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
+      const activeTab = activeId
+        ? tabs.find((t) => t.id === activeId)
+        : undefined;
+      const hasActiveAgentTab = activeTab?.kind === "agent";
+      piDefaultModelRef.current = "";
+      setState((prev) => ({
+        ...prev,
+        defaultModel: "",
+        piDefaultModel: "",
+        projectModels: {},
+        // Blank the header display when no agent tab owns it so the picker
+        // shows "(pi default)"; a focused session keeps its own model.
+        ...(hasActiveAgentTab ? {} : { model: "" }),
+        sidebar: recomputeModelPicker(
+          prev.sidebar as Record<string, unknown> | undefined,
+          hasActiveAgentTab ? (activeTab?.model ?? "") : "",
+        ),
+      }));
+      persistDefaultModel(""); // writes [agent] model = null
+      return;
+    }
     const trimmed = id.trim();
     if (!trimmed) return;
     const activeId = stateRef.current.activeTabId as string | undefined;

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -1743,6 +1743,28 @@ body.ae-resizing-sidebar .a2ui-layout {
   max-width: min(44ch, calc(var(--app-viewport-width) - 32px));
 }
 
+/* Custom-id input mode: styled to match the dropdown trigger pill so the
+   header doesn't jump when "Custom id…" swaps the button for an input. */
+.a2ui-model-picker-custom {
+  display: inline-flex;
+}
+.a2ui-model-picker-custom-input {
+  height: 26px;
+  padding: 0 10px;
+  font-size: var(--chrome-text-compact);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  letter-spacing: 0.02em;
+  color: var(--text);
+  background: var(--pill-bg, var(--bg-elev, rgba(255, 255, 255, 0.03)));
+  border: 1px solid var(--accent, #ff6a18);
+  border-radius: 6px;
+  outline: none;
+  width: min(34ch, calc(var(--app-viewport-width) - 32px));
+}
+.a2ui-model-picker-custom-input::placeholder {
+  color: var(--text-dim);
+}
+
 .a2ui-appearance-menu .a2ui-dropdown-trigger {
   max-width: min(46ch, calc(var(--app-viewport-width) - 32px));
 }

--- a/src/utils/modelPicker.ts
+++ b/src/utils/modelPicker.ts
@@ -1,3 +1,10 @@
+/** Sentinel item id for the header picker's "(pi default)" entry.
+ *  Selecting it clears the chosen default (`/defaultModel`) and writes
+ *  `[agent] model = null`, so new sessions fall back to pi's env-driven
+ *  default. `setModel` interprets this id specially rather than treating
+ *  it as a concrete model. */
+export const PI_DEFAULT_MODEL_SENTINEL = "__pi_default__";
+
 /** Recompute the global model picker's `active` flag against `model`.
  *  Called whenever the active tab changes (switch / new / close) so the
  *  sidebar highlight tracks the active session's chosen model. Returns


### PR DESCRIPTION
## Context

Follow-up to the header-default model work already on `main` (`b921987`,
which made the header model picker the persisted default for *new*
sessions). During Codex peer review of that change, the reviewer flagged
that removing the Settings → **"Default model for new tabs"** field
dropped the only UI paths to:

1. **Reset to pi's env-driven default** — write `[agent] model = null` so
   the agent picks based on `ANTHROPIC_API_KEY` etc.
2. **Enter a model id not in the loaded registry** (the old picker's
   free-text "Custom id…" mode).

Per the earlier decision that the **header picker is the single canonical
control** (no duplicate Settings field), this PR folds both capabilities
into the header picker so it's a strict superset of what was removed —
rather than re-introducing a second surface for the same value.

## What changed

- **Header `ModelPicker`** (`variation-components.tsx`) gains two entries:
  - `(pi default — picks from env vars)` at the top.
  - `Custom id…` at the bottom, which swaps the trigger pill for a
    free-text input (Enter commits, Escape / blur cancels), styled to
    match the dropdown so the header doesn't jump.
- **`(pi default)` is a full reset for new sessions.** It flows through a
  shared `PI_DEFAULT_MODEL_SENTINEL` that `setModel` interprets to clear
  **every** runtime fallback — `/defaultModel`, `/projectModels`,
  `/piDefaultModel`, and `piDefaultModelRef` — and persist
  `[agent] model = null`. The next new tab then sends *no* explicit model,
  so the agent picks its env default.
  - Clearing all of them is **required for correctness**: `useBootConfig`
    seeds `piDefaultModel`/`piDefaultModelRef` with the *configured* model
    when `[agent] model` is set, so a partial reset would leave new tabs
    (and the header label) on the stale configured model until restart.
  - The **running session is not retargeted** — the reset governs new
    sessions only, matching the old Settings field's semantics.
- **`piDefaultModelRef` threaded into `useChat`** so the reset can clear it.

## Why two Codex rounds shaped this

This addresses three Codex findings across review rounds:
- R1: removing the Settings field dropped pi-default + custom-id → this PR.
- R2 (P2 ×2): the first cut of the reset only cleared `/defaultModel`,
  leaving the stale configured fallback and per-project memory able to
  override it → fixed by clearing every fallback.
- R3 (P2): a now-unnecessary type assertion in the e2e spec → removed.
- Final round: **clean, no findings.**

## Testing

- `bunx tsc -b --noEmit` clean; `bun run lint` exits 0 (5 pre-existing
  warnings, none in changed files).
- Full vitest: **1558 passing.** New/updated unit coverage:
  `setModel('(pi default)')` clears every fallback + persists `null`
  without retargeting.
- e2e (`aethon.spec.ts`): both model tests pass, including the
  "pick a model with no active session → new tab inherits it" regression.

## Verification suggestions for reviewers

- Open the header picker with a configured `[agent] model`, choose
  `(pi default)`, then open a new tab — it should boot on the agent's
  env-driven default, and the header should read `(pi default …)`.
- Choose `Custom id…`, type `provider/some-model`, press Enter — it
  becomes the default and (if a session is focused) retargets it.