### PR TITLE
test(e2e): fix AethonE2eState type so model-picker tests typecheck (unblocks main CI)

### DIFF
--- a/e2e/aethon.spec.ts
+++ b/e2e/aethon.spec.ts
@@ -504,9 +504,9 @@ test("a model picked with no active session is the default for the next new tab"
     .poll(() =>
       page.evaluate(() => {
         const state = window.__AETHON_STATE__?.();
-        const active = (
-          (state?.tabs as { id: string; model?: string }[] | undefined) ?? []
-        ).find((t) => t.id === state?.activeTabId);
+        const active = (state?.tabs ?? []).find(
+          (t) => t.id === state?.activeTabId,
+        );
         return active?.model;
       }),
     )

--- a/e2e/support/aethon-harness.ts
+++ b/e2e/support/aethon-harness.ts
@@ -25,9 +25,11 @@ type AethonE2eState = {
   waiting?: boolean;
   queueCount?: number;
   model?: string;
+  defaultModel?: string;
   sidebar?: {
     models?: { id: string; active?: boolean }[];
   };
+  tabs?: { id: string; model?: string }[];
 };
 
 type TauriCallback = (event: unknown) => void;


### PR DESCRIPTION
## Problem

`main` CI is **red**. `tsc -b` fails:

```
e2e/aethon.spec.ts(470,32): error TS2339: Property 'defaultModel' does not exist on type 'AethonE2eState'.
e2e/aethon.spec.ts(496,66): error TS2339: Property 'defaultModel' does not exist on type 'AethonE2eState'.
e2e/aethon.spec.ts(508,19): error TS2339: Property 'tabs' does not exist on type 'AethonE2eState'.
```

## Root cause

Commit b921987 (`feat(model): make the header picker the default model`) added e2e test references to `state.defaultModel` and `state.tabs` but did not extend the `AethonE2eState` harness type in `e2e/support/aethon-harness.ts`.

## Fix

Add the two optional fields (`defaultModel?: string`, `tabs?: { id: string; model?: string }[]`) to `AethonE2eState`.

## Verification

- `bunx tsc -b --noEmit` → clean (0 errors) locally.

Unblocks CI on `main` and on PR #177 (whose CI inherits this failure via the merge commit).