### PR TITLE
fix: restore stderr messages inline and retry transient failures

### DIFF
--- a/agent/chat.ts
+++ b/agent/chat.ts
@@ -3,6 +3,7 @@ import type { AethonAgentState } from "./state";
 import type { DispatcherDeps, InboundMessage } from "./dispatcherTypes";
 import { maybeExitForReload } from "./dispatcherTypes";
 import {
+  cancelAethonRetry,
   cancelRunningToolCards,
   ensurePickerHasModel,
   ensureTab,
@@ -43,7 +44,9 @@ export async function handleChat(
     const content = msg.content;
     state.tabContext
       .run(tabId, () =>
-        images.length > 0 ? tab.session.steer(content, images) : tab.session.steer(content),
+        images.length > 0
+          ? tab.session.steer(content, images)
+          : tab.session.steer(content),
       )
       .catch((err: unknown) => {
         const message = err instanceof Error ? err.message : String(err);
@@ -90,11 +93,11 @@ export async function handleChat(
       deps.send({ type: "error", tabId, message: `prompt: ${message}` });
     })
     .finally(() => {
-      if (!tab.agentEndFired) {
+      if (!tab.agentEndFired && !tab.aethonRetryInFlight) {
         tab.promptInFlight = false;
         deps.send({ type: "response_end", tabId });
       }
-      if (state.currentAgentTabId === tabId) {
+      if (state.currentAgentTabId === tabId && !tab.aethonRetryInFlight) {
         state.currentAgentTabId = undefined;
       }
       maybeExitForReload(state, deps);
@@ -139,10 +142,7 @@ export async function handleSetModel(
   }
   const [provider, ...rest] = msg.id.split("/");
   const id = rest.join("/");
-  const next = modelRegistryForModelId(state, tabId, msg.id).find(
-    provider,
-    id,
-  );
+  const next = modelRegistryForModelId(state, tabId, msg.id).find(provider, id);
   if (!next) {
     deps.send({
       type: "error",
@@ -187,6 +187,7 @@ export function handleStop(
     }
   }
   tab.queuedCount = 0;
+  cancelAethonRetry(tab);
   deps.send({ type: "queue_reset", tabId });
   cancelRunningToolCards(deps, tab, tabId);
   if (

--- a/agent/session-history.test.ts
+++ b/agent/session-history.test.ts
@@ -311,6 +311,48 @@ describe("readSessionTranscript", () => {
     ]);
   });
 
+  it("restores Aethon-local system messages inline by creation time", async () => {
+    const dir = await tempRoot();
+    const path = join(dir, "session.jsonl");
+    await writeFile(
+      path,
+      [
+        JSON.stringify({
+          type: "message",
+          id: "pi-user",
+          timestamp: 1_000,
+          message: { role: "user", content: [{ type: "text", text: "hi" }] },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "pi-agent",
+          timestamp: 3_000,
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "done" }],
+          },
+        }),
+      ].join("\n") + "\n",
+    );
+    await appendLocalChatMessage(dir, {
+      id: "stderr-warning",
+      role: "system",
+      text: "[agent stderr] transient provider error",
+      createdAt: 2_000,
+    });
+
+    await expect(readSessionTranscript(dir)).resolves.toEqual([
+      { id: "pi-user", role: "user", text: "hi", createdAt: 1_000 },
+      {
+        id: "stderr-warning",
+        role: "system",
+        text: "[agent stderr] transient provider error",
+        createdAt: 2_000,
+      },
+      { id: "pi-agent", role: "agent", text: "done", createdAt: 3_000 },
+    ]);
+  });
+
   it("restores local image attachments from the durable chat log", async () => {
     const dir = await tempRoot();
     await appendLocalChatMessage(dir, {

--- a/agent/session-history/restore.ts
+++ b/agent/session-history/restore.ts
@@ -193,6 +193,32 @@ function mergeLocalAttachmentsIntoPiMessages(
   return merged;
 }
 
+function mergeRestoredMessagesChronologically(
+  piMessages: RestoredChatMessage[],
+  localMessages: RestoredChatMessage[],
+): RestoredChatMessage[] {
+  return [
+    ...piMessages.map((message, order) => ({ message, order })),
+    ...localMessages.map((message, offset) => ({
+      message,
+      order: piMessages.length + offset,
+    })),
+  ]
+    .sort((a, b) => {
+      const aTime = a.message.createdAt;
+      const bTime = b.message.createdAt;
+      if (
+        typeof aTime === "number" &&
+        typeof bTime === "number" &&
+        aTime !== bTime
+      ) {
+        return aTime - bTime;
+      }
+      return a.order - b.order;
+    })
+    .map((entry) => entry.message);
+}
+
 export async function readSessionTranscript(
   sessionDir: string,
   expectedCwd?: string,
@@ -220,5 +246,8 @@ export async function readSessionTranscript(
     localMessages,
   );
   const localOnly = dedupeLocalMessages(mergedPiMessages, localMessages);
-  return [...mergedPiMessages, ...localOnly].slice(-MAX_RESTORED_MESSAGES);
+  return mergeRestoredMessagesChronologically(
+    mergedPiMessages,
+    localOnly,
+  ).slice(-MAX_RESTORED_MESSAGES);
 }

--- a/agent/state.ts
+++ b/agent/state.ts
@@ -20,10 +20,7 @@ import type {
 } from "@mariozechner/pi-coding-agent";
 import { AsyncLocalStorage } from "node:async_hooks";
 import type { BashTerminalStreamState } from "./terminal-stream";
-import type {
-  AuthProfileServices,
-  AuthProfilesState,
-} from "./auth-profiles";
+import type { AuthProfileServices, AuthProfilesState } from "./auth-profiles";
 
 // ---------------------------------------------------------------------------
 // Shared types — extracted from the original main.ts
@@ -247,6 +244,11 @@ export interface TabRecord {
    *  without trusting pi message_update timestamps (which can refer to an
    *  earlier transcript record during streaming). */
   responseMessageSeq: number;
+  /** Aethon-side retry fallback for retryable agent_end errors that the SDK
+   *  reports without driving its own auto-retry event sequence. */
+  aethonRetryAttempt?: number;
+  aethonRetryInFlight?: boolean;
+  aethonRetryTimer?: ReturnType<typeof setTimeout>;
 }
 
 export interface ProjectBaselineSnapshot {

--- a/agent/tab-lifecycle.test.ts
+++ b/agent/tab-lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   AethonAgentState,
   type AethonAgentStateOptions,
@@ -718,6 +718,62 @@ describe("handleSessionEvent", () => {
     expect(f.sent.some((m) => m.type === "response_end")).toBe(false);
   });
 
+  it("agent_end starts an Aethon retry when the SDK reports a retryable failure without auto-retry", async () => {
+    vi.useFakeTimers();
+    try {
+      const f = makeFixture();
+      const rec = fakeRec();
+      const continueRun = vi.fn(() => Promise.resolve());
+      const failure = {
+        role: "assistant",
+        stopReason: "error",
+        errorMessage: "WebSocket closed 1006 Connection ended",
+      };
+      rec.promptInFlight = true;
+      rec.session = {
+        ...rec.session,
+        agent: {
+          state: { messages: [{ role: "user" }, failure] },
+          continue: continueRun,
+        },
+        settingsManager: {
+          getRetrySettings: () => ({
+            enabled: true,
+            maxRetries: 3,
+            baseDelayMs: 2_000,
+          }),
+        },
+      } as TabRecord["session"];
+      f.state.currentAgentTabId = "tab-1";
+
+      handleSessionEvent(f.state, f.deps, rec, "tab-1", {
+        type: "agent_end",
+        messages: [failure],
+      });
+
+      expect(rec.promptInFlight).toBe(true);
+      expect(rec.agentEndFired).toBe(false);
+      expect(rec.aethonRetryInFlight).toBe(true);
+      expect(
+        (rec.session as never as { agent: { state: { messages: unknown[] } } })
+          .agent.state.messages,
+      ).toEqual([{ role: "user" }]);
+      expect(f.state.currentAgentTabId).toBe("tab-1");
+      expect(f.sent).toContainEqual({
+        type: "notice",
+        tabId: "tab-1",
+        message: "Transient provider error; retrying 1/3 in 2s.",
+      });
+      expect(f.sent.some((m) => m.type === "error")).toBe(false);
+      expect(f.sent.some((m) => m.type === "response_end")).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(continueRun).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("agent_end during auto-retry surfaces non-retryable failures and ends the turn", () => {
     const f = makeFixture();
     const rec = fakeRec();
@@ -743,7 +799,8 @@ describe("handleSessionEvent", () => {
     expect(f.sent[0]).toMatchObject({
       type: "error",
       tabId: "tab-1",
-      message: "Authentication failed for openai-codex. Run /login openai-codex.",
+      message:
+        "Authentication failed for openai-codex. Run /login openai-codex.",
     });
     expect(f.sent[1]).toMatchObject({ type: "response_end", tabId: "tab-1" });
     expect(rec.promptInFlight).toBe(false);

--- a/agent/tab-lifecycle/events.ts
+++ b/agent/tab-lifecycle/events.ts
@@ -32,14 +32,16 @@ import {
   toolCardPayload,
 } from "../tool-card";
 import { emitBashResult } from "./terminal";
+import { cancelAethonRetry, scheduleAethonRetry } from "./retry";
 import type { TabLifecycleDeps } from "./utils";
 import { modelKey } from "./utils";
 
 const turnLog = logger.scope("turn");
 
-function assistantEventMessageId(
-  ame: { id?: unknown; messageId?: unknown },
-): string | undefined {
+function assistantEventMessageId(ame: {
+  id?: unknown;
+  messageId?: unknown;
+}): string | undefined {
   if (typeof ame.messageId === "string" && ame.messageId.length > 0) {
     return ame.messageId;
   }
@@ -256,10 +258,13 @@ export function handleSessionEvent(
       const messages = (event as { messages?: unknown[] }).messages;
       const failedMessage = extractAgentEndError(messages);
       const retrying =
-        (rec.session as { isRetrying?: boolean } | undefined)?.isRetrying === true;
+        (rec.session as { isRetrying?: boolean } | undefined)?.isRetrying ===
+        true;
       const retryableFailure =
         failedMessage !== undefined && isRetryableAgentEndError(failedMessage);
-      const keepTurnOpenForRetry = retrying && retryableFailure;
+      const keepTurnOpenForRetry =
+        retryableFailure &&
+        (retrying || scheduleAethonRetry(state, deps, rec, tabId));
       if (failedMessage && !keepTurnOpenForRetry) {
         deps.send({ type: "error", tabId, message: failedMessage });
       }
@@ -285,6 +290,7 @@ export function handleSessionEvent(
         if (cached.endedAt !== undefined) rec.toolArgsCache.delete(toolCallId);
       }
       if (!keepTurnOpenForRetry) {
+        cancelAethonRetry(rec);
         rec.agentEndFired = true;
         rec.promptInFlight = false;
         if (state.currentAgentTabId === tabId) {
@@ -302,6 +308,7 @@ export function handleSessionEvent(
         delayMs?: number;
         errorMessage?: string;
       };
+      cancelAethonRetry(rec);
       rec.promptInFlight = true;
       rec.agentEndFired = false;
       state.currentAgentTabId = tabId;
@@ -319,6 +326,7 @@ export function handleSessionEvent(
     }
     case "auto_retry_end": {
       const ev = event as { success?: boolean; finalError?: string };
+      cancelAethonRetry(rec);
       if (!ev.success && ev.finalError) {
         deps.send({
           type: "error",

--- a/agent/tab-lifecycle/index.ts
+++ b/agent/tab-lifecycle/index.ts
@@ -46,6 +46,6 @@ export {
 } from "./slash-commands";
 export { emitReady } from "./ready-handshake";
 export { handleSessionEvent } from "./events";
-export { installAethonRetryClassifier } from "./retry";
+export { cancelAethonRetry, installAethonRetryClassifier } from "./retry";
 export type { EnsureTabOptions } from "./lifecycle";
 export { ensureTab } from "./lifecycle";

--- a/agent/tab-lifecycle/retry.ts
+++ b/agent/tab-lifecycle/retry.ts
@@ -1,4 +1,6 @@
 import { isRetryableAgentEndError } from "../agent-errors";
+import type { AethonAgentState, TabRecord } from "../state";
+import type { TabLifecycleDeps } from "./utils";
 
 interface RetryClassifierSession {
   _isRetryableError?: (message: {
@@ -17,4 +19,112 @@ export function installAethonRetryClassifier(session: unknown): void {
     (message.stopReason === "error" &&
       typeof message.errorMessage === "string" &&
       isRetryableAgentEndError(message.errorMessage));
+}
+
+interface RetrySettings {
+  enabled?: boolean;
+  maxRetries?: number;
+  baseDelayMs?: number;
+}
+
+interface AethonRetrySession {
+  agent?: {
+    state?: { messages?: unknown[] };
+    continue?: () => Promise<void>;
+  };
+  settingsManager?: { getRetrySettings?: () => RetrySettings };
+}
+
+const DEFAULT_RETRY_SETTINGS = {
+  enabled: true,
+  maxRetries: 3,
+  baseDelayMs: 2_000,
+};
+
+function retrySettings(session: unknown): Required<RetrySettings> {
+  const raw = (
+    session as AethonRetrySession
+  ).settingsManager?.getRetrySettings?.();
+  return {
+    enabled: raw?.enabled ?? DEFAULT_RETRY_SETTINGS.enabled,
+    maxRetries: raw?.maxRetries ?? DEFAULT_RETRY_SETTINGS.maxRetries,
+    baseDelayMs: raw?.baseDelayMs ?? DEFAULT_RETRY_SETTINGS.baseDelayMs,
+  };
+}
+
+function removeTrailingFailureMessage(session: unknown): void {
+  const agent = (session as AethonRetrySession).agent;
+  const messages = agent?.state?.messages;
+  if (!Array.isArray(messages) || messages.length === 0) return;
+  const last = messages[messages.length - 1] as
+    | { role?: unknown; stopReason?: unknown }
+    | undefined;
+  if (last?.role === "assistant" && last.stopReason === "error") {
+    agent.state.messages = messages.slice(0, -1);
+  }
+}
+
+export function cancelAethonRetry(rec: TabRecord): void {
+  if (rec.aethonRetryTimer) {
+    clearTimeout(rec.aethonRetryTimer);
+    rec.aethonRetryTimer = undefined;
+  }
+  rec.aethonRetryInFlight = false;
+  rec.aethonRetryAttempt = 0;
+}
+
+export function scheduleAethonRetry(
+  state: AethonAgentState,
+  deps: TabLifecycleDeps,
+  rec: TabRecord,
+  tabId: string,
+): boolean {
+  const settings = retrySettings(rec.session);
+  const agent = (rec.session as AethonRetrySession).agent;
+  const continueAgent = agent?.continue;
+  if (!settings.enabled || typeof continueAgent !== "function") {
+    cancelAethonRetry(rec);
+    return false;
+  }
+
+  const attempt = (rec.aethonRetryAttempt ?? 0) + 1;
+  if (attempt > settings.maxRetries) {
+    cancelAethonRetry(rec);
+    return false;
+  }
+
+  rec.aethonRetryAttempt = attempt;
+  rec.aethonRetryInFlight = true;
+  rec.promptInFlight = true;
+  rec.agentEndFired = false;
+  state.currentAgentTabId = tabId;
+  removeTrailingFailureMessage(rec.session);
+
+  const delayMs = settings.baseDelayMs * 2 ** (attempt - 1);
+  deps.send({
+    type: "notice",
+    tabId,
+    message: `Transient provider error; retrying ${attempt}/${settings.maxRetries} in ${Math.max(
+      0,
+      Math.round(delayMs / 1000),
+    )}s.`,
+  });
+
+  if (rec.aethonRetryTimer) clearTimeout(rec.aethonRetryTimer);
+  rec.aethonRetryTimer = setTimeout(() => {
+    rec.aethonRetryTimer = undefined;
+    continueAgent().catch((err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err);
+      cancelAethonRetry(rec);
+      rec.promptInFlight = false;
+      rec.agentEndFired = true;
+      if (state.currentAgentTabId === tabId) {
+        state.currentAgentTabId = undefined;
+      }
+      deps.send({ type: "error", tabId, message: `retry: ${message}` });
+      deps.send({ type: "response_end", tabId });
+    });
+  }, delayMs);
+
+  return true;
 }

--- a/src/hooks/osEdges/agentStderr.test.ts
+++ b/src/hooks/osEdges/agentStderr.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { createdAtFromAgentStderr, tabIdFromAgentStderr } from "./agentStderr";
+
+describe("agent stderr helpers", () => {
+  it("extracts tab ids from bridge turn logs", () => {
+    expect(
+      tabIdFromAgentStderr(
+        "2026-06-01T15:57:41.305Z WARN turn: end model=openai-codex/gpt-5.5 tabId=d42627d5-5bd1-485d-848c-ea996250506a durationMs=51994 stopReason=error",
+      ),
+    ).toBe("d42627d5-5bd1-485d-848c-ea996250506a");
+  });
+
+  it("extracts timestamps from bridge log lines", () => {
+    expect(
+      createdAtFromAgentStderr(
+        "2026-06-01T15:57:41.305Z WARN turn: end model=openai-codex/gpt-5.5 tabId=tab-1",
+      ),
+    ).toBe(Date.parse("2026-06-01T15:57:41.305Z"));
+  });
+});

--- a/src/hooks/osEdges/agentStderr.ts
+++ b/src/hooks/osEdges/agentStderr.ts
@@ -5,6 +5,17 @@ export interface AgentStderrDeps {
   appendMessage: (msg: ChatMessage, tabId?: string) => void;
 }
 
+export function tabIdFromAgentStderr(text: string): string | undefined {
+  return /\btabId=([A-Za-z0-9_-]+)/.exec(text)?.[1];
+}
+
+export function createdAtFromAgentStderr(text: string): number | undefined {
+  const raw = /^(\d{4}-\d{2}-\d{2}T[^\s]+)/.exec(text)?.[1];
+  if (!raw) return undefined;
+  const timestamp = Date.parse(raw);
+  return Number.isFinite(timestamp) ? timestamp : undefined;
+}
+
 /** Mirror agent stderr into chat as a system message. When the bridge
  *  dies on startup this is the only signal we have.
  *
@@ -36,11 +47,15 @@ export function subscribeAgentStderr(deps: AgentStderrDeps): () => void {
       );
     const isExtensionNoise = /\b(WARN|INFO)\s+ext-state:/.test(text);
     if ((isLeveledFailure || isRawCrash) && !isExtensionNoise) {
-      appendMessage({
-        id: crypto.randomUUID(),
-        role: "system",
-        text: `[agent stderr] ${text}`,
-      });
+      appendMessage(
+        {
+          id: crypto.randomUUID(),
+          role: "system",
+          text: `[agent stderr] ${text}`,
+          createdAt: createdAtFromAgentStderr(text),
+        },
+        tabIdFromAgentStderr(text),
+      );
     }
     // Always log to webview console for debug skill access.
     console.warn("[agent stderr]", text);

--- a/src/hooks/useChat.test.ts
+++ b/src/hooks/useChat.test.ts
@@ -97,6 +97,31 @@ function buildContext(overrides: Record<string, unknown> = {}): {
 }
 
 describe("useChat setModel", () => {
+  it("inserts timestamped system messages inline for restored transcripts", () => {
+    const tab = {
+      ...makeEmptyTab("tab-1", "Tab 1"),
+      messages: [
+        { id: "u1", role: "user" as const, text: "hi", createdAt: 1_000 },
+        { id: "a1", role: "agent" as const, text: "done", createdAt: 3_000 },
+      ],
+    };
+    const { ctx, stateRef } = buildContext({ tabs: [tab] });
+    const { result } = renderHook(() => useChat(ctx));
+
+    act(() => {
+      result.current.appendMessage({
+        id: "stderr",
+        role: "system",
+        text: "[agent stderr] warning",
+        createdAt: 2_000,
+      });
+    });
+
+    expect(
+      (stateRef.current.tabs as Tab[])[0].messages.map((m) => m.id),
+    ).toEqual(["u1", "stderr", "a1"]);
+  });
+
   it("sends normal chat messages with normal mode", async () => {
     const { ctx, stateRef } = buildContext();
     const { result } = renderHook(() => useChat(ctx));
@@ -592,10 +617,7 @@ describe("useChat setModel", () => {
     });
 
     // No live session → never invoke set_model (would spin up a phantom).
-    expect(invoke).not.toHaveBeenCalledWith(
-      "agent_command",
-      expect.anything(),
-    );
+    expect(invoke).not.toHaveBeenCalledWith("agent_command", expect.anything());
     // …but the default is recorded + mirrored for the header display.
     expect(stateRef.current.defaultModel).toBe("openai/gpt-5.5");
     expect(stateRef.current.model).toBe("openai/gpt-5.5");

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -215,6 +215,16 @@ export function useChat(ctx: UseChatContext): UseChatActions {
       const idx = messages.findIndex((m) => m.id === msg.id);
       if (idx >= 0) {
         messages[idx] = msg;
+      } else if (typeof msg.createdAt === "number") {
+        const insertAt = messages.findIndex(
+          (m) =>
+            typeof m.createdAt === "number" && m.createdAt > msg.createdAt!,
+        );
+        if (insertAt >= 0) {
+          messages.splice(insertAt, 0, msg);
+        } else {
+          messages.push(msg);
+        }
       } else {
         messages.push(msg);
       }

--- a/src/types/a2ui.ts
+++ b/src/types/a2ui.ts
@@ -310,5 +310,6 @@ export interface ChatMessage {
   attachments?: ChatAttachment[];
   thinking?: string;
   a2ui?: A2UIPayload;
+  createdAt?: number;
   delivery?: "sent" | "queued" | "steered" | "failed";
 }


### PR DESCRIPTION
## Summary

- route mirrored agent stderr to the tab named in bridge turn logs instead of the active tab
- preserve stderr/system messages inline across session restore by timestamp
- add an Aethon retry fallback when retryable provider failures arrive as terminal `agent_end` events without SDK auto-retry

## Root Cause

The bridge stderr mirror appended WARN/ERROR log lines to whichever tab was active in the UI, even though turn logs already include `tabId=...`. Aethon-local chat messages were also restored after the pi transcript, so timestamped system messages moved to the bottom after reopening a workspace. For transient provider failures, pi can report `WebSocket closed 1006 Connection ended` as a synthetic terminal `agent_end` without a preceding assistant message that triggers the SDK retry path, so Aethon treated it as final.

## Validation

- `bun run typecheck`
- `bun run lint`
- `bunx vitest run src/hooks/useChat.test.ts src/hooks/osEdges/agentStderr.test.ts agent/tab-lifecycle.test.ts agent/session-history.test.ts --testTimeout 15000`
- `git diff --check`
