### PR TITLE
fix(agent): guard retry-active tabs from bare prompts

### DIFF
--- a/agent/chat.ts
+++ b/agent/chat.ts
@@ -1,5 +1,5 @@
 import type { Api, ImageContent, Model } from "@mariozechner/pi-ai";
-import type { AethonAgentState } from "./state";
+import type { AethonAgentState, TabRecord } from "./state";
 import type { DispatcherDeps, InboundMessage } from "./dispatcherTypes";
 import { maybeExitForReload } from "./dispatcherTypes";
 import {
@@ -39,7 +39,13 @@ export async function handleChat(
   );
   const wantsSteer = msg.mode === "steer";
   const images = normalizeImages(msg.images);
-  if (wantsSteer && tab.promptInFlight) {
+  const busyForTurn = tab.promptInFlight || isUnderlyingSessionBusy(tab);
+  if (busyForTurn && !tab.promptInFlight) {
+    tab.promptInFlight = true;
+    tab.agentEndFired = false;
+    state.currentAgentTabId = tabId;
+  }
+  if (wantsSteer && busyForTurn) {
     state.currentAgentTabId = tabId;
     const content = msg.content;
     state.tabContext
@@ -54,7 +60,7 @@ export async function handleChat(
       });
     return;
   }
-  const queued = tab.promptInFlight;
+  const queued = busyForTurn;
   if (queued) {
     tab.queuedCount += 1;
     const content = msg.content;
@@ -93,15 +99,28 @@ export async function handleChat(
       deps.send({ type: "error", tabId, message: `prompt: ${message}` });
     })
     .finally(() => {
-      if (!tab.agentEndFired && !tab.aethonRetryInFlight) {
+      const stillStreamingOrRetrying = isUnderlyingSessionBusy(tab);
+      if (!tab.agentEndFired && !stillStreamingOrRetrying) {
         tab.promptInFlight = false;
         deps.send({ type: "response_end", tabId });
       }
-      if (state.currentAgentTabId === tabId && !tab.aethonRetryInFlight) {
+      if (state.currentAgentTabId === tabId && !stillStreamingOrRetrying) {
         state.currentAgentTabId = undefined;
       }
       maybeExitForReload(state, deps);
     });
+}
+
+function isUnderlyingSessionBusy(tab: TabRecord): boolean {
+  const sessionFlags = tab.session as {
+    isStreaming?: unknown;
+    isRetrying?: unknown;
+  };
+  return (
+    tab.aethonRetryInFlight === true ||
+    sessionFlags.isStreaming === true ||
+    sessionFlags.isRetrying === true
+  );
 }
 
 function normalizeImages(images: InboundMessage["images"]): ImageContent[] {

--- a/agent/dispatcher.test.ts
+++ b/agent/dispatcher.test.ts
@@ -351,6 +351,75 @@ describe("handleChat", () => {
     expect(f.sent).not.toContainEqual({ type: "queued", tabId: "tab-1" });
   });
 
+  it("steers retry-active sessions even when Aethon's in-flight flag is stale", async () => {
+    const f = makeFixture();
+    const promptCalls: unknown[][] = [];
+    const steerCalls: unknown[][] = [];
+    const tab = fakeTabRecord({
+      promptInFlight: false,
+      session: {
+        isStreaming: true,
+        prompt: (...args: unknown[]) => {
+          promptCalls.push(args);
+          return Promise.resolve();
+        },
+        followUp: () => Promise.resolve(),
+        steer: (...args: unknown[]) => {
+          steerCalls.push(args);
+          return Promise.resolve();
+        },
+      } as unknown as TabRecord["session"],
+    });
+    f.state.tabs.set("tab-1", tab);
+
+    await handleChat(f.state, f.deps, {
+      type: "chat",
+      content: "status update?",
+      tabId: "tab-1",
+      mode: "steer",
+    });
+
+    expect(tab.promptInFlight).toBe(true);
+    expect(promptCalls).toEqual([]);
+    expect(steerCalls).toEqual([["status update?"]]);
+    expect(f.sent).not.toContainEqual({ type: "queued", tabId: "tab-1" });
+  });
+
+  it("queues normal sends for retry-active sessions when Aethon's in-flight flag is stale", async () => {
+    const f = makeFixture();
+    const promptCalls: unknown[][] = [];
+    const followUpCalls: unknown[][] = [];
+    const tab = fakeTabRecord({
+      promptInFlight: false,
+      session: {
+        isStreaming: true,
+        prompt: (...args: unknown[]) => {
+          promptCalls.push(args);
+          return Promise.resolve();
+        },
+        followUp: (...args: unknown[]) => {
+          followUpCalls.push(args);
+          return Promise.resolve();
+        },
+        steer: () => Promise.resolve(),
+      } as unknown as TabRecord["session"],
+    });
+    f.state.tabs.set("tab-1", tab);
+
+    await handleChat(f.state, f.deps, {
+      type: "chat",
+      content: "update?",
+      tabId: "tab-1",
+      mode: "normal",
+    });
+
+    expect(tab.promptInFlight).toBe(true);
+    expect(tab.queuedCount).toBe(1);
+    expect(promptCalls).toEqual([]);
+    expect(followUpCalls).toEqual([["update?"]]);
+    expect(f.sent).toContainEqual({ type: "queued", tabId: "tab-1" });
+  });
+
   it("passes image attachments to prompt, steer, and followUp", async () => {
     const image = { mimeType: "image/png", data: "abc123" };
     const f = makeFixture();
@@ -410,6 +479,38 @@ describe("handleChat", () => {
     expect(calls.followUp).toEqual([
       ["next", [{ type: "image", mimeType: "image/png", data: "abc123" }]],
     ]);
+  });
+
+  it("keeps the turn busy if the SDK is still streaming when prompt() settles", async () => {
+    const f = makeFixture();
+    let resolvePrompt: (() => void) | undefined;
+    const session = {
+      isStreaming: false,
+      prompt: () =>
+        new Promise<void>((resolve) => {
+          resolvePrompt = resolve;
+        }),
+      followUp: () => Promise.resolve(),
+      steer: () => Promise.resolve(),
+    };
+    const tab = fakeTabRecord({
+      session: session as unknown as TabRecord["session"],
+    });
+    f.state.tabs.set("tab-1", tab);
+
+    await handleChat(f.state, f.deps, {
+      type: "chat",
+      content: "start",
+      tabId: "tab-1",
+      mode: "normal",
+    });
+    session.isStreaming = true;
+    resolvePrompt?.();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(tab.promptInFlight).toBe(true);
+    expect(f.sent).not.toContainEqual({ type: "response_end", tabId: "tab-1" });
   });
 
   it("treats steer as a normal prompt when the tab is idle", async () => {

--- a/agent/tab-lifecycle.test.ts
+++ b/agent/tab-lifecycle.test.ts
@@ -762,6 +762,7 @@ describe("handleSessionEvent", () => {
       expect(f.sent).toContainEqual({
         type: "notice",
         tabId: "tab-1",
+        busy: true,
         message: "Transient provider error; retrying 1/3 in 2s.",
       });
       expect(f.sent.some((m) => m.type === "error")).toBe(false);
@@ -826,6 +827,7 @@ describe("handleSessionEvent", () => {
     expect(f.sent[0]).toMatchObject({
       type: "notice",
       tabId: "tab-1",
+      busy: true,
       message: "Transient provider error; retrying 1/3 in 2s.",
     });
   });

--- a/agent/tab-lifecycle/events.ts
+++ b/agent/tab-lifecycle/events.ts
@@ -315,6 +315,7 @@ export function handleSessionEvent(
       deps.send({
         type: "notice",
         tabId,
+        busy: true,
         message: `Transient provider error; retrying ${
           ev.attempt ?? "?"
         }/${ev.maxAttempts ?? "?"} in ${Math.max(

--- a/agent/tab-lifecycle/retry.ts
+++ b/agent/tab-lifecycle/retry.ts
@@ -104,6 +104,7 @@ export function scheduleAethonRetry(
   deps.send({
     type: "notice",
     tabId,
+    busy: true,
     message: `Transient provider error; retrying ${attempt}/${settings.maxRetries} in ${Math.max(
       0,
       Math.round(delayMs / 1000),

--- a/src/hooks/bridgeMessageHandlers/notice.test.ts
+++ b/src/hooks/bridgeMessageHandlers/notice.test.ts
@@ -19,6 +19,39 @@ describe("handleNotice", () => {
     });
   });
 
+  it("marks retry notices busy so normal sends stay client-queued", () => {
+    const { ctx, mocks } = buildHandlerFixture({
+      state: { activeTabId: "default" },
+    });
+
+    handleNotice(
+      {
+        type: "notice",
+        message: "Transient provider error; retrying 1/3 in 2s.",
+        tabId: "default",
+        busy: true,
+      },
+      ctx,
+    );
+
+    expect(mocks.updateTab).toHaveBeenCalledWith(
+      "default",
+      expect.any(Function),
+    );
+    const update = mocks.updateTab.mock.calls[0][1] as (tab: {
+      waiting: boolean;
+      queueCount: number;
+      queuedMessages: unknown[];
+    }) => unknown;
+    expect(
+      update({ waiting: false, queueCount: 0, queuedMessages: [] }),
+    ).toMatchObject({ waiting: true, queueCount: 0 });
+    expect(mocks.setStatusFlags).toHaveBeenCalledWith({
+      status: "thinking…",
+      waiting: true,
+    });
+  });
+
   it("ignores empty messages", () => {
     const { ctx, mocks } = buildHandlerFixture();
     handleNotice({ type: "notice", message: "" }, ctx);

--- a/src/hooks/bridgeMessageHandlers/notice.ts
+++ b/src/hooks/bridgeMessageHandlers/notice.ts
@@ -1,10 +1,12 @@
 import type { BridgeMessageHandler } from "./types";
 
-/** Non-terminal — surface as a system message but DO NOT touch
- *  waiting/status. Used e.g. when a second chat IPC arrives while a
- *  prompt is in-flight: the user sees the rejection but the Stop button
- *  and waiting state for the original prompt persist. Also surface as a
- *  warning toast so a notice that arrives while the user isn't looking
+/** Non-terminal — surface as a system message without ending the turn.
+ *  Most notices deliberately leave waiting/status untouched: a second
+ *  chat IPC while a prompt is in-flight should not hide Stop or clear
+ *  the original prompt's waiting state. Notices with `busy: true` are
+ *  the explicit exception used by retry flows to reassert that the tab
+ *  is still working while the SDK owns a pending retry. Also surface as
+ *  a warning toast so a notice that arrives while the user isn't looking
  *  at chat doesn't get missed. */
 export const handleNotice: BridgeMessageHandler = (data, ctx) => {
   const message = (data.message as string) ?? "";

--- a/src/hooks/bridgeMessageHandlers/notice.ts
+++ b/src/hooks/bridgeMessageHandlers/notice.ts
@@ -9,6 +9,16 @@ import type { BridgeMessageHandler } from "./types";
 export const handleNotice: BridgeMessageHandler = (data, ctx) => {
   const message = (data.message as string) ?? "";
   const tabId = (data.tabId as string | undefined) ?? "default";
+  if (data.busy === true) {
+    ctx.updateTab(tabId, (tab) => ({
+      ...tab,
+      waiting: true,
+      queueCount: (tab.queuedMessages ?? []).length,
+    }));
+    if (ctx.stateRef.current.activeTabId === tabId) {
+      ctx.setStatusFlags({ waiting: true, status: "thinking…" });
+    }
+  }
   if (message) {
     ctx.appendMessage(
       { id: crypto.randomUUID(), role: "system", text: message },


### PR DESCRIPTION
## Summary
- Treat SDK streaming/retrying state as authoritative busy state before routing chat input
- Route retry-active Cmd/Ctrl+Enter through steer and normal sends through follow-up instead of bare prompt
- Keep frontend waiting state true from retry notices through actual retry completion/exhaustion

## Tests
- bunx vitest run
- bunx tsc -b --noEmit
- bunx eslint agent/chat.ts agent/dispatcher.test.ts agent/tab-lifecycle.test.ts agent/tab-lifecycle/events.ts agent/tab-lifecycle/retry.ts src/hooks/bridgeMessageHandlers/notice.ts src/hooks/bridgeMessageHandlers/notice.test.ts

Closes #186