### PR TITLE
feat(ui): agent-activity indicators + completion alerts + per-workspace tab restore

### DIFF
--- a/.claude/skills/aethon-debug/SKILL.md
+++ b/.claude/skills/aethon-debug/SKILL.md
@@ -17,8 +17,14 @@ The server listens on **19433** by default (Claudette uses 19432; Aethon picks t
 ```bash
 ${CLAUDE_SKILL_DIR}/scripts/debug-eval.sh 'return 1 + 1'
 ${CLAUDE_SKILL_DIR}/scripts/debug-eval.sh 'return window.__AETHON_STATE__().model'
+${CLAUDE_SKILL_DIR}/scripts/debug-eval.sh --file snippet.js   # multi-line JS
 ${CLAUDE_SKILL_DIR}/scripts/debug-screenshot.sh
 ```
+
+Inline JS is read from the args verbatim. For a multi-line snippet, pass it
+with `--file <path>` (or pipe it on stdin) — **do not** pass a bare file path
+as the JS string; it would be eval'd literally and hang until timeout. (A lone
+arg that happens to be an existing file is auto-read as a safety net.)
 
 Or via the slash-command form, which reads from `${CLAUDE_SKILL_DIR}/scripts/`:
 

--- a/.claude/skills/aethon-debug/scripts/debug-eval.sh
+++ b/.claude/skills/aethon-debug/scripts/debug-eval.sh
@@ -183,7 +183,11 @@ ARGS=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
     -f|--file)
-      JS_FILE="${2:-}"
+      if [[ $# -lt 2 ]]; then
+        echo "ERROR: --file requires a path argument" >&2
+        exit 1
+      fi
+      JS_FILE="$2"
       shift 2
       ;;
     *)

--- a/.claude/skills/aethon-debug/scripts/debug-eval.sh
+++ b/.claude/skills/aethon-debug/scripts/debug-eval.sh
@@ -3,7 +3,13 @@
 # Auto-starts the dev build if it is not running.
 #
 # Usage: debug-eval.sh 'return 1 + 1'
+#        debug-eval.sh --file snippet.js      # multi-line JS from a file
 #        echo 'return document.title' | debug-eval.sh
+#
+# NOTE: inline JS is read from the args verbatim. If you have a multi-line
+# snippet, pass it with --file (or pipe it on stdin) — do NOT pass a bare
+# file path as the JS, it would be eval'd as a string. As a safety net, a
+# single arg that is an existing file is auto-read (with a stderr note).
 #
 # Port discovery (in priority order):
 #   1. $AETHON_DEBUG_PORT — explicit override
@@ -170,16 +176,46 @@ sys.exit(1)
 }
 
 # ---------------------------------------------------------------------------
-# Read JS from args or stdin
+# Read JS from --file, args, or stdin
 # ---------------------------------------------------------------------------
-if [[ $# -gt 0 ]]; then
-  JS="$*"
+JS_FILE=""
+ARGS=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -f|--file)
+      JS_FILE="${2:-}"
+      shift 2
+      ;;
+    *)
+      ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ -n "${JS_FILE}" ]]; then
+  if [[ ! -f "${JS_FILE}" ]]; then
+    echo "ERROR: --file path not found: ${JS_FILE}" >&2
+    exit 1
+  fi
+  JS="$(cat "${JS_FILE}")"
+elif [[ "${#ARGS[@]}" -gt 0 ]]; then
+  # Safety net: a lone arg that is an existing file is almost certainly a
+  # path the caller meant to read, not literal JS. Read it (with a note)
+  # instead of eval'ing the path string — which just hangs until timeout.
+  if [[ "${#ARGS[@]}" -eq 1 && -f "${ARGS[0]}" ]]; then
+    echo "INFO: '${ARGS[0]}' is a file — reading JS from it (use --file to silence)." >&2
+    JS="$(cat "${ARGS[0]}")"
+  else
+    JS="${ARGS[*]}"
+  fi
 else
   JS="$(cat)"
 fi
 
 if [[ -z "${JS}" ]]; then
   echo "Usage: debug-eval.sh <javascript>" >&2
+  echo "       debug-eval.sh --file snippet.js" >&2
   echo "       echo 'return ...' | debug-eval.sh" >&2
   exit 1
 fi

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,13 +34,18 @@ import { useUiOverlays } from "./hooks/useUiOverlays";
 import { useUpdater } from "./hooks/useUpdater";
 import { UpdateBanner } from "./components/UpdateBanner";
 import type { AethonConfig } from "./config";
-import { useProjectOps } from "./hooks/useProjectOps";
+import {
+  useProjectOps,
+  projectIdFromBucketKey,
+  worktreeIdFromBucketKey,
+} from "./hooks/useProjectOps";
 import { useOsEdges } from "./hooks/useOsEdges";
 import {
   buildInitialAppStore,
   useSessionPersistence,
 } from "./hooks/useSessionPersistence";
 import { useDerivedRenderState } from "./hooks/useDerivedRenderState";
+import { useTabBucketHydration } from "./hooks/useTabBucketHydration";
 import { useTaskLauncher } from "./hooks/useTaskLauncher";
 import { useAppEventRouting } from "./hooks/useAppEventRouting";
 import { useAppStateRefs } from "./hooks/useAppStateRefs";
@@ -428,6 +433,11 @@ export default function App() {
   // tabBucketsRef so the live set spans every project bucket, not just the
   // active one (tabs are project-scoped).
   useAgentWorkerReconcile(stateRef, tabBucketsRef);
+
+  // Hydrate per-workspace tab buckets restored from disk into tabBucketsRef so
+  // switching to a backgrounded workspace after a restart lands on its
+  // last-active tab rather than the empty landing card.
+  useTabBucketHydration(state.persistedTabBuckets, tabBucketsRef);
 
   // ---------------------------------------------------------------------
   // Toast stack + OS completion notification. Owned by useNotifications.
@@ -843,6 +853,32 @@ export default function App() {
     closeEditorTabsForPath,
     closeTab,
     setActiveTab,
+    activateTabAnywhere: (tabId: string) => {
+      const tabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
+      if (tabs.some((t) => t.id === tabId)) {
+        setActiveTab(tabId);
+        return;
+      }
+      // Not in the active workspace — find the bucket that owns it, switch
+      // into that project/worktree, then select. setState is synchronous so
+      // the bucket load lands before setActiveTab reads state.tabs.
+      for (const [key, bucket] of tabBucketsRef.current.entries()) {
+        if (!bucket.tabs.some((t) => t.id === tabId)) continue;
+        const projectId = projectIdFromBucketKey(key);
+        const currentProjectId =
+          (stateRef.current.activeProjectId as string | null | undefined) ??
+          null;
+        if (projectId !== currentProjectId) {
+          if (projectId) setActiveProjectById(projectId);
+          else clearActiveProject();
+        }
+        activateWorktree(worktreeIdFromBucketKey(key));
+        setActiveTab(tabId);
+        return;
+      }
+      // Unknown tab — best effort (no-op if it's truly gone).
+      setActiveTab(tabId);
+    },
     setActiveSubTab,
     applyShareModeToTab,
     closeSettings,

--- a/src/eventRoutes/notifications.test.ts
+++ b/src/eventRoutes/notifications.test.ts
@@ -104,6 +104,31 @@ describe("handleNotifications", () => {
     expect(mocks.invoke).toHaveBeenCalledWith("force_restart_agent");
   });
 
+  it("activate-tab:<tabId> jumps to the finished session and dismisses", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    const handled = await handleNotifications(
+      {
+        component: { id: "notification-stack" },
+        eventType: "action",
+        data: {
+          id: "agent-complete:tab-done",
+          action: "activate-tab:tab-done",
+        },
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.activateTabAnywhere).toHaveBeenCalledWith("tab-done");
+    expect(mocks.dismissNotification).toHaveBeenCalledWith(
+      "agent-complete:tab-done",
+    );
+    // It must NOT fall through to the generic bridge-forward path.
+    expect(mocks.invoke).not.toHaveBeenCalledWith(
+      "dispatch_a2ui_event",
+      expect.anything(),
+    );
+  });
+
   it("forwards an unknown action through dispatch_a2ui_event", async () => {
     const { ctx, mocks } = buildRouteFixture({
       state: { activeTabId: "tab-active" },

--- a/src/eventRoutes/notifications.ts
+++ b/src/eventRoutes/notifications.ts
@@ -92,6 +92,13 @@ export const handleNotifications: EventRouteHandler = (
       }
       ctx.dismissNotification(id);
       return true;
+    } else if (action && action.startsWith("activate-tab:")) {
+      // Completion toast → jump to the finished session, switching
+      // workspaces first if it lives in a backgrounded bucket.
+      const targetTabId = action.slice("activate-tab:".length);
+      if (targetTabId) ctx.activateTabAnywhere(targetTabId);
+      ctx.dismissNotification(id);
+      return true;
     } else if (action) {
       const tabId = ctx.stateRef.current.activeTabId as string | undefined;
       ctx

--- a/src/eventRoutes/testFixtures.ts
+++ b/src/eventRoutes/testFixtures.ts
@@ -47,6 +47,7 @@ export interface RouteFixture {
     closeEditorTabsForPath: Mock;
     closeTab: Mock;
     setActiveTab: Mock;
+    activateTabAnywhere: Mock;
     setActiveSubTab: Mock;
     applyShareModeToTab: Mock;
     closeSettings: Mock;
@@ -130,6 +131,7 @@ export function buildRouteFixture(
   const closeEditorTabsForPath = vi.fn();
   const closeTab = vi.fn();
   const setActiveTab = vi.fn();
+  const activateTabAnywhere = vi.fn();
   const setActiveSubTab = vi.fn();
   const applyShareModeToTab = vi.fn();
   const closeSettings = vi.fn();
@@ -191,6 +193,7 @@ export function buildRouteFixture(
     closeEditorTabsForPath,
     closeTab,
     setActiveTab,
+    activateTabAnywhere,
     setActiveSubTab,
     applyShareModeToTab,
     closeSettings,
@@ -270,6 +273,7 @@ export function buildRouteFixture(
       closeEditorTabsForPath,
       closeTab,
       setActiveTab,
+      activateTabAnywhere,
       setActiveSubTab,
       applyShareModeToTab,
       closeSettings,

--- a/src/eventRoutes/types.ts
+++ b/src/eventRoutes/types.ts
@@ -115,6 +115,11 @@ export interface EventRouteContext {
   closeEditorTabsForPath: (path: string, kind: string) => void;
   closeTab: (tabId: string) => void;
   setActiveTab: (tabId: string) => void;
+  /** Activate a tab by id no matter which workspace owns it. If the tab is
+   *  in the active workspace it selects it directly; otherwise it switches
+   *  to the owning project/worktree bucket first, then selects it. Backs
+   *  the completion toast's click-to-jump. */
+  activateTabAnywhere: (tabId: string) => void;
   setActiveSubTab: (subId: string) => void;
   applyShareModeToTab: (tabId: string, mode: ShareMode) => void;
 

--- a/src/extensions/default-layout/sidebar/item-row.tsx
+++ b/src/extensions/default-layout/sidebar/item-row.tsx
@@ -101,6 +101,38 @@ export function ItemRow({
   const ahead = git?.ahead ?? 0;
   const behind = git?.behind ?? 0;
 
+  // Agent-activity dot — leading status indicator distinct from the trailing
+  // git dirty dot. When the project row is collapsed, fall back to the
+  // rollup so a hidden active worktree still surfaces a dot; when expanded,
+  // show only this row's own (main-scope) activity since the worktree rows
+  // carry their own dots.
+  const agentRaw = item as {
+    agent?: { status?: string; runningCount?: number };
+    agentRollup?: { status?: string; runningCount?: number };
+  };
+  const agent =
+    disclosure === "collapsed"
+      ? (agentRaw.agentRollup ?? agentRaw.agent)
+      : agentRaw.agent;
+  const agentDotEl =
+    agent && agent.status && agent.status !== "none" ? (
+      <span
+        className={`ae-sb-agent-dot ae-sb-agent-dot--${
+          agent.status === "running" ? "running" : "idle"
+        }`}
+        aria-label={
+          agent.status === "running" ? "Agent running" : "Agent session idle"
+        }
+        title={
+          agent.status === "running"
+            ? `${agent.runningCount ?? 1} agent turn${
+                (agent.runningCount ?? 1) === 1 ? "" : "s"
+              } running`
+            : "Idle agent session — awaiting your input"
+        }
+      />
+    ) : null;
+
   // Disclosure caret (or a reserved spacer when alignSlots is set so
   // worktree-less rows align with their siblings). Shared by both the
   // flat and stacked layouts; lives in the row's left gutter.
@@ -200,7 +232,10 @@ export function ItemRow({
         {chevronEl}
         {iconEl}
         <span className="a2ui-sidebar-item-stack">
-          <span className="a2ui-sidebar-item-label">{item.label}</span>
+          <span className="a2ui-sidebar-item-name-row">
+            {agentDotEl}
+            <span className="a2ui-sidebar-item-label">{item.label}</span>
+          </span>
           {hasMeta && (
             <span className="a2ui-sidebar-item-meta">
               {git?.branch && (

--- a/src/extensions/default-layout/sidebar/worktree-row.tsx
+++ b/src/extensions/default-layout/sidebar/worktree-row.tsx
@@ -15,6 +15,7 @@
 
 import { useState } from "react";
 import type { BuiltinComponentProps } from "../../../components/A2UIRenderer";
+import type { AgentActivitySummary } from "../../../hooks/projectOps/agentActivity";
 
 export interface WorktreeSidebarItem {
   id: string;
@@ -28,6 +29,10 @@ export interface WorktreeSidebarItem {
   pendingState?: "queued" | "starting" | "succeeded" | "failed";
   pendingError?: string;
   locked?: boolean;
+  /** Live agent-activity for this worktree's session scope. Only attached
+   *  to non-main rows (the main worktree shares the project path, so its
+   *  activity surfaces on the project line instead). */
+  agent?: AgentActivitySummary;
 }
 
 export interface WorktreeRowProps {
@@ -92,6 +97,25 @@ export function WorktreeRow({
             <circle cx="5" cy="5" r="3.5" fill="currentColor" />
           </svg>
         </span>
+      ) : null}
+      {item.agent && item.agent.status !== "none" ? (
+        <span
+          className={`ae-sb-agent-dot ae-sb-agent-dot--${
+            item.agent.status === "running" ? "running" : "idle"
+          }`}
+          aria-label={
+            item.agent.status === "running"
+              ? "Agent running"
+              : "Agent session idle"
+          }
+          title={
+            item.agent.status === "running"
+              ? `${item.agent.runningCount} agent turn${
+                  item.agent.runningCount === 1 ? "" : "s"
+                } running`
+              : "Idle agent session — awaiting your input"
+          }
+        />
       ) : null}
       <span className="a2ui-sidebar-item-label">{displayLabel}</span>
       {item.branch && item.branch !== displayLabel ? (

--- a/src/hooks/bridgeMessageHandlers/promptStarted.test.ts
+++ b/src/hooks/bridgeMessageHandlers/promptStarted.test.ts
@@ -36,7 +36,15 @@ describe("handlePromptStarted", () => {
     const out = updater(seedTab);
     expect(out.waiting).toBe(true);
     expect(out.queueCount).toBe(2);
-    expect(mocks.setState).toHaveBeenCalledTimes(1);
+    // Two setState calls: the bucket-independent running set, then the
+    // active-tab status flip.
+    expect(mocks.setState).toHaveBeenCalledTimes(2);
+    const runningUpdater = mocks.setState.mock.calls[0][0] as (
+      prev: Record<string, unknown>,
+    ) => Record<string, unknown>;
+    expect(runningUpdater({ agentRunningTabs: {} })).toMatchObject({
+      agentRunningTabs: { default: true },
+    });
   });
 
   it("derives queueCount from the client queue rather than the bridge's stale value", () => {

--- a/src/hooks/bridgeMessageHandlers/promptStarted.ts
+++ b/src/hooks/bridgeMessageHandlers/promptStarted.ts
@@ -43,6 +43,16 @@ export const handlePromptStarted: BridgeMessageHandler = (data, ctx) => {
       }),
     };
   });
+  // Track the in-flight turn in a bucket-independent running set. Unlike
+  // `tab.waiting` (only mirrored into `state.tabs`, i.e. the active
+  // workspace), this set spans every workspace so the sidebar's
+  // agent-activity dots stay accurate for backgrounded projects/worktrees.
+  ctx.setState((prev) => {
+    const running =
+      (prev.agentRunningTabs as Record<string, true> | undefined) ?? {};
+    if (running[tabId]) return prev;
+    return { ...prev, agentRunningTabs: { ...running, [tabId]: true } };
+  });
   if (ctx.stateRef.current.activeTabId === tabId) {
     ctx.setState((prev) => ({ ...prev, status: "thinking…" }));
   }

--- a/src/hooks/bridgeMessageHandlers/responseEnd.ts
+++ b/src/hooks/bridgeMessageHandlers/responseEnd.ts
@@ -11,6 +11,14 @@ export const handleResponseEnd: BridgeMessageHandler = (data, ctx) => {
   // next message — same render commit, so the Send button doesn't
   // flash. When the queue is empty, waiting stays false.
   ctx.updateTab(tabId, (tab) => ({ ...tab, waiting: false }));
+  // Drop the tab from the bucket-independent running set (see promptStarted).
+  ctx.setState((prev) => {
+    const running = prev.agentRunningTabs as Record<string, true> | undefined;
+    if (!running || !running[tabId]) return prev;
+    const next = { ...running };
+    delete next[tabId];
+    return { ...prev, agentRunningTabs: next };
+  });
   if (ctx.stateRef.current.activeTabId === tabId) {
     ctx.setState((prev) => ({ ...prev, status: "ready" }));
   }

--- a/src/hooks/osEdges/agentCrash.ts
+++ b/src/hooks/osEdges/agentCrash.ts
@@ -94,9 +94,23 @@ export function subscribeAgentCrash(deps: AgentCrashDeps): () => void {
             }
           : t,
       );
+      // Drop the crashed tab(s) from the bucket-independent running set so the
+      // sidebar activity dot can't stay stuck — a crash doesn't emit
+      // response_end. A whole-process crash (no crashedTabId) aborts every
+      // in-flight turn, including backgrounded ones.
+      const prevRunning =
+        (prev.agentRunningTabs as Record<string, true> | undefined) ?? {};
+      let agentRunningTabs: Record<string, true>;
+      if (crashedTabId) {
+        agentRunningTabs = { ...prevRunning };
+        delete agentRunningTabs[crashedTabId];
+      } else {
+        agentRunningTabs = {};
+      }
       return {
         ...prev,
         tabs,
+        agentRunningTabs,
         ...(!crashedTabId || prev.activeTabId === crashedTabId
           ? { waiting: false, queueCount: 0 }
           : {}),

--- a/src/hooks/projectOps/agentActivity.test.ts
+++ b/src/hooks/projectOps/agentActivity.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "vitest";
+import { makeEmptyTab, type Tab } from "../../types/tab";
+import {
+  attachAgentActivity,
+  summarizeAgentTabs,
+} from "./agentActivity";
+
+function agentTab(id: string, projectId: string | null, cwd?: string): Tab {
+  return { ...makeEmptyTab(id, id, projectId, "agent"), cwd };
+}
+
+describe("summarizeAgentTabs", () => {
+  it("returns none for an empty scope", () => {
+    expect(summarizeAgentTabs([], new Set())).toEqual({
+      status: "none",
+      activeCount: 0,
+      runningCount: 0,
+    });
+  });
+
+  it("returns idle-with-session when a session exists but nothing runs", () => {
+    const tabs = [agentTab("a", "p", "/p")];
+    expect(summarizeAgentTabs(tabs, new Set())).toEqual({
+      status: "idle-with-session",
+      activeCount: 1,
+      runningCount: 0,
+    });
+  });
+
+  it("returns running when at least one tab is in the running set", () => {
+    const tabs = [agentTab("a", "p", "/p"), agentTab("b", "p", "/p")];
+    expect(summarizeAgentTabs(tabs, new Set(["b"]))).toEqual({
+      status: "running",
+      activeCount: 2,
+      runningCount: 1,
+    });
+  });
+
+  it("ignores non-agent tabs", () => {
+    const shell = { ...makeEmptyTab("s", "s", "p", "shell"), cwd: "/p" };
+    expect(summarizeAgentTabs([shell], new Set(["s"]))).toEqual({
+      status: "none",
+      activeCount: 0,
+      runningCount: 0,
+    });
+  });
+
+  it("treats the running set as authoritative over a stale waiting flag", () => {
+    // Background tab snapshot still carries waiting:true but is no longer in
+    // the live running set — it must read as idle, not running.
+    const stale: Tab = { ...agentTab("a", "p", "/p"), waiting: true };
+    expect(summarizeAgentTabs([stale], new Set()).status).toBe(
+      "idle-with-session",
+    );
+  });
+});
+
+describe("attachAgentActivity", () => {
+  const project = (worktrees: { id: string; path: string; isMain?: boolean }[]) => ({
+    id: "proj",
+    label: "proj",
+    worktrees: worktrees.map((w) => ({
+      id: w.id,
+      label: w.id,
+      branch: w.id,
+      path: w.path,
+      isMain: w.isMain ?? false,
+    })),
+  });
+
+  it("scopes main-path tabs to the project line, leaving the main worktree dot-free", () => {
+    const projects = [
+      project([{ id: "wt-main", path: "/p", isMain: true }]),
+    ];
+    const tabs = [agentTab("a", "proj", "/p")];
+    const [out] = attachAgentActivity(projects, tabs, new Set(["a"]));
+    expect(out.agent.status).toBe("running");
+    expect(out.agentRollup.status).toBe("running");
+    // Main worktree row carries no agent summary (no double dot).
+    expect("agent" in out.worktrees[0]).toBe(false);
+  });
+
+  it("scopes worktree-path tabs to that worktree row", () => {
+    const projects = [
+      project([
+        { id: "wt-main", path: "/p", isMain: true },
+        { id: "wt-feat", path: "/p/.wt/feat" },
+      ]),
+    ];
+    const tabs = [agentTab("w", "proj", "/p/.wt/feat")];
+    const [out] = attachAgentActivity(projects, tabs, new Set());
+    // Not main scope — the project line stays empty.
+    expect(out.agent.status).toBe("none");
+    const feat = out.worktrees.find((w) => w.id === "wt-feat");
+    expect(feat?.agent?.status).toBe("idle-with-session");
+    // Rollup sees the worktree session even though main is empty.
+    expect(out.agentRollup.status).toBe("idle-with-session");
+  });
+
+  it("rolls up running worktree activity for a collapsed project", () => {
+    const projects = [
+      project([
+        { id: "wt-main", path: "/p", isMain: true },
+        { id: "wt-feat", path: "/p/.wt/feat" },
+      ]),
+    ];
+    const tabs = [
+      agentTab("m", "proj", "/p"),
+      agentTab("w", "proj", "/p/.wt/feat"),
+    ];
+    const [out] = attachAgentActivity(projects, tabs, new Set(["w"]));
+    expect(out.agent.status).toBe("idle-with-session"); // only main, not running
+    expect(out.agentRollup.status).toBe("running"); // worktree turn in flight
+    expect(out.agentRollup.activeCount).toBe(2);
+    expect(out.agentRollup.runningCount).toBe(1);
+  });
+
+  it("does not leak tabs across sibling projects", () => {
+    const projects = [
+      { id: "p1", label: "p1", worktrees: [{ id: "m1", path: "/p1", isMain: true }] },
+      { id: "p2", label: "p2", worktrees: [{ id: "m2", path: "/p2", isMain: true }] },
+    ];
+    const tabs = [agentTab("a", "p1", "/p1")];
+    const out = attachAgentActivity(projects, tabs, new Set(["a"]));
+    expect(out[0].agent.status).toBe("running");
+    expect(out[1].agent.status).toBe("none");
+  });
+});

--- a/src/hooks/projectOps/agentActivity.ts
+++ b/src/hooks/projectOps/agentActivity.ts
@@ -1,0 +1,132 @@
+import type { Tab } from "../../types/tab";
+import { normalizeSessionPath } from "./tabBuckets";
+
+/** Aggregate agent state for one sidebar scope (a project's main worktree,
+ *  a specific worktree, or a project rollup):
+ *   - `running`            — at least one agent turn is in flight.
+ *   - `idle-with-session`  — an agent session exists but no turn is running
+ *                            (i.e. it's waiting on the user's next input).
+ *   - `none`               — no agent session for this scope. */
+export type AgentActivity = "running" | "idle-with-session" | "none";
+
+export interface AgentActivitySummary {
+  status: AgentActivity;
+  /** Agent tabs scoped here. */
+  activeCount: number;
+  /** Subset of `activeCount` with a turn currently in flight. */
+  runningCount: number;
+}
+
+const NONE: AgentActivitySummary = {
+  status: "none",
+  activeCount: 0,
+  runningCount: 0,
+};
+
+/** Whether `runningIds` is authoritative for liveness rather than each tab's
+ *  own `waiting` flag. Background-workspace tabs live in a stashed bucket and
+ *  never receive `updateTab` writes, so their `waiting` is stale; the live
+ *  running set (maintained from prompt_started/response_end regardless of
+ *  bucket) is the only trustworthy signal across every workspace. */
+export function summarizeAgentTabs(
+  tabs: readonly Tab[],
+  runningIds: ReadonlySet<string>,
+): AgentActivitySummary {
+  let activeCount = 0;
+  let runningCount = 0;
+  for (const tab of tabs) {
+    if (tab.kind !== "agent") continue;
+    activeCount += 1;
+    if (runningIds.has(tab.id)) runningCount += 1;
+  }
+  if (activeCount === 0) return NONE;
+  return {
+    status: runningCount > 0 ? "running" : "idle-with-session",
+    activeCount,
+    runningCount,
+  };
+}
+
+interface WorktreeLike {
+  path?: string;
+  isMain?: boolean;
+}
+
+interface ProjectLike {
+  id: string;
+  worktrees?: WorktreeLike[];
+}
+
+/** A sidebar project item with agent-activity overlaid. The worktree shape is
+ *  preserved apart from an optional `agent` summary added on non-main rows. */
+export type WithAgentActivity<P extends ProjectLike> = Omit<P, "worktrees"> & {
+  agent: AgentActivitySummary;
+  agentRollup: AgentActivitySummary;
+  worktrees: Array<
+    NonNullable<P["worktrees"]>[number] & { agent?: AgentActivitySummary }
+  >;
+};
+
+/** Overlay agent-activity summaries onto sidebar project items.
+ *
+ *  Scoping rules:
+ *   - A non-main worktree row gets the agent tabs whose cwd matches its path.
+ *   - The project line gets its "main scope" tabs: agent tabs with this
+ *     `projectId` whose cwd is NOT one of the project's non-main worktrees
+ *     (so a main-worktree session surfaces on the project line and the main
+ *     worktree row stays dot-free — they share a path and would otherwise
+ *     double up).
+ *   - `agentRollup` summarises main ∪ every worktree, used when the project
+ *     row is collapsed so a hidden active worktree still shows a dot.
+ *
+ *  `agentTabs` must already span every workspace (active `state.tabs` ∪ all
+ *  stashed buckets); `runningIds` is the live in-flight set. */
+export function attachAgentActivity<P extends ProjectLike>(
+  projects: readonly P[],
+  agentTabs: readonly Tab[],
+  runningIds: ReadonlySet<string>,
+): WithAgentActivity<P>[] {
+  const tabsByCwd = new Map<string, Tab[]>();
+  for (const tab of agentTabs) {
+    if (tab.kind !== "agent") continue;
+    const key = normalizeSessionPath(tab.cwd);
+    const bucket = tabsByCwd.get(key);
+    if (bucket) bucket.push(tab);
+    else tabsByCwd.set(key, [tab]);
+  }
+
+  return projects.map((project) => {
+    const worktrees = project.worktrees ?? [];
+    const nonMainPaths = new Set(
+      worktrees
+        .filter((w) => !w.isMain)
+        .map((w) => normalizeSessionPath(w.path)),
+    );
+
+    const mainTabs: Tab[] = [];
+    const rollupTabs: Tab[] = [];
+    for (const tab of agentTabs) {
+      if (tab.kind !== "agent") continue;
+      const cwdKey = normalizeSessionPath(tab.cwd);
+      const belongsByProject = tab.projectId === project.id;
+      const belongsByWorktree = nonMainPaths.has(cwdKey);
+      if (belongsByProject && !belongsByWorktree) mainTabs.push(tab);
+      if (belongsByProject || belongsByWorktree) rollupTabs.push(tab);
+    }
+
+    const nextWorktrees = worktrees.map((w) => {
+      // Main worktree shares the project path — its activity is already
+      // surfaced on the project line, so leave its row dot-free.
+      if (w.isMain) return w;
+      const wtTabs = tabsByCwd.get(normalizeSessionPath(w.path)) ?? [];
+      return { ...w, agent: summarizeAgentTabs(wtTabs, runningIds) };
+    });
+
+    return {
+      ...project,
+      agent: summarizeAgentTabs(mainTabs, runningIds),
+      agentRollup: summarizeAgentTabs(rollupTabs, runningIds),
+      worktrees: nextWorktrees,
+    };
+  });
+}

--- a/src/hooks/projectOps/tabBuckets.test.ts
+++ b/src/hooks/projectOps/tabBuckets.test.ts
@@ -1,0 +1,95 @@
+import type { Dispatch, SetStateAction } from "react";
+import { describe, it, expect } from "vitest";
+import { makeEmptyTab, type Tab } from "../../types/tab";
+import { switchProjectBucket } from "./tabBuckets";
+import type { TabBucket } from "./types";
+
+function agentTab(id: string, projectId: string, cwd: string): Tab {
+  return {
+    ...makeEmptyTab(id, id, projectId, "agent"),
+    cwd,
+    messages: [{ id: `${id}-m`, role: "user", text: id }],
+  };
+}
+
+function makeHarness(initial: Record<string, unknown>) {
+  let state = initial;
+  const stateRef = { current: state };
+  const setState: Dispatch<SetStateAction<Record<string, unknown>>> = (
+    update,
+  ) => {
+    state = typeof update === "function" ? update(state) : update;
+    stateRef.current = state;
+  };
+  const tabBucketsRef = { current: new Map<string, TabBucket>() };
+  const deps = {
+    setState,
+    stateRef,
+    tabBucketsRef,
+    buildProjectsMirror: () => ({}),
+    dispatchTerminalReplay: () => {},
+  };
+  return { deps, tabBucketsRef, setState, get: () => state };
+}
+
+describe("switchProjectBucket", () => {
+  it("keeps each workspace's tabs separate and restores the last-active tab", () => {
+    const tabP = agentTab("p-main", "P", "/P");
+    const h = makeHarness({ tabs: [tabP], activeTabId: "p-main" });
+
+    // P-main -> worktree A (empty bucket -> overview).
+    switchProjectBucket(h.deps, "P", "P::worktree::A");
+    expect(h.tabBucketsRef.current.get("P")?.tabs.map((t) => t.id)).toEqual([
+      "p-main",
+    ]);
+    expect((h.get().tabs as Tab[]).length).toBe(0);
+
+    // Open a session in worktree A.
+    const tabA = agentTab("a1", "P", "/P/A");
+    h.deps.setState((prev) => ({ ...prev, tabs: [tabA], activeTabId: "a1" }));
+
+    // A -> B.
+    switchProjectBucket(h.deps, "P::worktree::A", "P::worktree::B");
+    expect(
+      h.tabBucketsRef.current.get("P::worktree::A")?.tabs.map((t) => t.id),
+    ).toEqual(["a1"]);
+
+    // Open a session in worktree B.
+    const tabB = agentTab("b1", "P", "/P/B");
+    h.deps.setState((prev) => ({ ...prev, tabs: [tabB], activeTabId: "b1" }));
+
+    // B -> back to P-main: should restore p-main, not the landing.
+    const restored = switchProjectBucket(h.deps, "P::worktree::B", "P");
+    expect(restored).toBe("p-main");
+    expect((h.get().tabs as Tab[]).map((t) => t.id)).toEqual(["p-main"]);
+    expect(h.get().activeTabId).toBe("p-main");
+
+    // No cross-contamination: each worktree bucket kept only its own tab.
+    expect(
+      h.tabBucketsRef.current.get("P::worktree::A")?.tabs.map((t) => t.id),
+    ).toEqual(["a1"]);
+    expect(
+      h.tabBucketsRef.current.get("P::worktree::B")?.tabs.map((t) => t.id),
+    ).toEqual(["b1"]);
+  });
+
+  it("mirrors non-active buckets into state.persistedTabBuckets for persistence", () => {
+    const tabP = agentTab("p-main", "P", "/P");
+    const h = makeHarness({ tabs: [tabP], activeTabId: "p-main" });
+
+    switchProjectBucket(h.deps, "P", "P::worktree::A");
+    const tabA = agentTab("a1", "P", "/P/A");
+    h.deps.setState((prev) => ({ ...prev, tabs: [tabA], activeTabId: "a1" }));
+    switchProjectBucket(h.deps, "P::worktree::A", "P");
+
+    // Active workspace ("P") lives in state.tabs, so it's excluded from the
+    // mirror; the backgrounded worktree A is included with its active tab.
+    const mirror = h.get().persistedTabBuckets as Record<
+      string,
+      { tabs: Tab[]; activeTabId?: string }
+    >;
+    expect(Object.keys(mirror)).toEqual(["P::worktree::A"]);
+    expect(mirror["P::worktree::A"].activeTabId).toBe("a1");
+    expect(mirror["P::worktree::A"].tabs.map((t) => t.id)).toEqual(["a1"]);
+  });
+});

--- a/src/hooks/projectOps/tabBuckets.ts
+++ b/src/hooks/projectOps/tabBuckets.ts
@@ -16,6 +16,15 @@ export function projectIdFromBucketKey(key: string): string | null {
   return key.split(WORKTREE_BUCKET_SEPARATOR, 1)[0] || null;
 }
 
+/** Worktree id encoded in a bucket key, or null for a project-main /
+ *  no-project bucket. Inverse of `projectScopeBucketKey`. */
+export function worktreeIdFromBucketKey(key: string): string | null {
+  if (key === NO_PROJECT_KEY) return null;
+  const idx = key.indexOf(WORKTREE_BUCKET_SEPARATOR);
+  if (idx < 0) return null;
+  return key.slice(idx + WORKTREE_BUCKET_SEPARATOR.length) || null;
+}
+
 export function projectScopeBucketKey(
   projectId: string | null | undefined,
   worktreeId: string | null | undefined,
@@ -129,11 +138,12 @@ export function switchProjectBucket(
       ),
     );
     const currentActive = prev.activeTabId as string | undefined;
+    const fromActiveTabId = currentTabs.some((t) => t.id === currentActive)
+      ? currentActive
+      : currentTabs[0]?.id;
     tabBucketsRef.current.set(fromKey, {
       tabs: currentTabs,
-      activeTabId: currentTabs.some((t) => t.id === currentActive)
-        ? currentActive
-        : currentTabs[0]?.id,
+      activeTabId: fromActiveTabId,
     });
 
     const savedNextRaw = tabBucketsRef.current.get(toKey);
@@ -155,10 +165,24 @@ export function switchProjectBucket(
     const activeTabId = hasOrphan ? next.tabs[0].id : next.activeTabId;
     nextActiveTabId = activeTabId;
 
+    // Mirror the non-active workspace buckets into state so a restart can
+    // restore each workspace's tabs (not just the active one's). The active
+    // workspace's tabs live in `state.tabs`, so exclude `toKey` (now active);
+    // `fromKey` was just snapshotted into tabBucketsRef above.
+    const persistedTabBuckets: Record<string, TabBucket> = {};
+    for (const [bucketKey, bucket] of tabBucketsRef.current.entries()) {
+      if (bucketKey === toKey) continue;
+      persistedTabBuckets[bucketKey] = {
+        tabs: bucket.tabs,
+        activeTabId: bucket.activeTabId,
+      };
+    }
+
     const result: Record<string, unknown> = {
       ...prev,
       tabs: next.tabs,
       activeTabId,
+      persistedTabBuckets,
     };
     const activeTab = next.tabs.find((t) => t.id === activeTabId);
     if (activeTab) {

--- a/src/hooks/tabOps/closeTab.ts
+++ b/src/hooks/tabOps/closeTab.ts
@@ -238,6 +238,16 @@ export function useCloseTabActions(deps: CloseTabDeps): CloseTabActions {
             }
           : {}),
       };
+      // Drop a closed tab from the bucket-independent agent-running set so a
+      // closed-mid-turn tab can't leave a stale entry behind.
+      const running = prev.agentRunningTabs as
+        | Record<string, true>
+        | undefined;
+      if (running && running[tabId]) {
+        const nextRunning = { ...running };
+        delete nextRunning[tabId];
+        result.agentRunningTabs = nextRunning;
+      }
       if (closing) {
         const closedSession = recentSessionItemFromClosedTab(
           closing,

--- a/src/hooks/useDerivedRenderState.test.ts
+++ b/src/hooks/useDerivedRenderState.test.ts
@@ -213,4 +213,64 @@ describe("useDerivedRenderState", () => {
       widgets: [],
     });
   });
+
+  it("overlays agent-activity across the active tabs and stashed buckets", () => {
+    const mainTab = {
+      ...makeEmptyTab("m", "m", "p1", "agent"),
+      cwd: "/repo/app",
+    };
+    // Background worktree session lives in a stashed bucket (mirrored into
+    // state.persistedTabBuckets), not state.tabs.
+    const bgTab = {
+      ...makeEmptyTab("w", "w", "p1", "agent"),
+      cwd: "/repo/app-fix",
+    };
+    const { result } = renderHook(() =>
+      useDerivedRenderState({
+        state: {
+          tabs: [mainTab],
+          activeTabId: "m",
+          // bucket-independent running set: the backgrounded worktree turn.
+          agentRunningTabs: { w: true },
+          persistedTabBuckets: {
+            "p1::worktree::wt-1": { tabs: [bgTab], activeTabId: "w" },
+          },
+          sidebar: {
+            projects: [
+              {
+                id: "p1",
+                worktrees: [
+                  { id: "wt-main", path: "/repo/app", isMain: true },
+                  { id: "wt-1", path: "/repo/app-fix" },
+                ],
+              },
+            ],
+          },
+        },
+        buildSidebarHistory: vi.fn(() => []),
+        hostInfo,
+      }),
+    );
+
+    const projects = (
+      result.current.renderState.sidebar as {
+        projects: {
+          agent: { status: string };
+          agentRollup: { status: string };
+          worktrees: { id: string; agent?: { status: string } }[];
+        }[];
+      }
+    ).projects;
+    // Main scope has an idle session (mainTab is not running).
+    expect(projects[0].agent.status).toBe("idle-with-session");
+    // The worktree row reports "running" even though its tab is stashed —
+    // liveness comes from the running set, not the bucket's stale waiting.
+    const wt1 = projects[0].worktrees.find((w) => w.id === "wt-1");
+    expect(wt1?.agent?.status).toBe("running");
+    // Rollup is running (a worktree turn is in flight).
+    expect(projects[0].agentRollup.status).toBe("running");
+    // The main worktree row stays dot-free (activity shown on project line).
+    const wtMain = projects[0].worktrees.find((w) => w.id === "wt-main");
+    expect(wtMain && "agent" in wtMain).toBe(false);
+  });
 });

--- a/src/hooks/useDerivedRenderState.test.ts
+++ b/src/hooks/useDerivedRenderState.test.ts
@@ -273,4 +273,40 @@ describe("useDerivedRenderState", () => {
     const wtMain = projects[0].worktrees.find((w) => w.id === "wt-main");
     expect(wtMain && "agent" in wtMain).toBe(false);
   });
+
+  it("reconciles the running set against active tabs' waiting flag", () => {
+    // Stale running entry for an ACTIVE tab whose turn already ended (crash /
+    // error cleared `waiting` but not the running set) must read as idle, not
+    // running — the active tab's `waiting` is authoritative.
+    const idleActive = {
+      ...makeEmptyTab("m", "m", "p1", "agent"),
+      cwd: "/repo/app",
+      waiting: false,
+    };
+    const { result } = renderHook(() =>
+      useDerivedRenderState({
+        state: {
+          tabs: [idleActive],
+          activeTabId: "m",
+          agentRunningTabs: { m: true }, // stale — turn already ended
+          sidebar: {
+            projects: [
+              {
+                id: "p1",
+                worktrees: [{ id: "wt-main", path: "/repo/app", isMain: true }],
+              },
+            ],
+          },
+        },
+        buildSidebarHistory: vi.fn(() => []),
+        hostInfo,
+      }),
+    );
+    const projects = (
+      result.current.renderState.sidebar as {
+        projects: { agent: { status: string } }[];
+      }
+    ).projects;
+    expect(projects[0].agent.status).toBe("idle-with-session");
+  });
 });

--- a/src/hooks/useDerivedRenderState.ts
+++ b/src/hooks/useDerivedRenderState.ts
@@ -164,6 +164,18 @@ export function useDerivedRenderState({
         (state.agentRunningTabs as Record<string, unknown> | undefined) ?? {},
       ),
     );
+    // The active workspace's tabs carry an authoritative `waiting` flag —
+    // EVERY turn-end path clears it (response_end, error, legacy response,
+    // native slash, agent crash, agent reload), whereas the bucket-independent
+    // running set is only cleared on response_end + crash/reload. Reconcile
+    // against `waiting` here so a crashed/errored ACTIVE tab can't leave its
+    // dot stuck "running". Backgrounded tabs (frozen `waiting`) keep relying
+    // on the running set.
+    for (const t of tabs) {
+      if (t.kind !== "agent") continue;
+      if (t.waiting) runningIds.add(t.id);
+      else runningIds.delete(t.id);
+    }
     const sidebarProjectsWithAgent = Array.isArray(sidebar.projects)
       ? attachAgentActivity(
           sidebar.projects as Array<{

--- a/src/hooks/useDerivedRenderState.ts
+++ b/src/hooks/useDerivedRenderState.ts
@@ -5,6 +5,7 @@ import {
   type Tab,
 } from "../types/tab";
 import type { UseHostInfo } from "./useHostInfo";
+import { attachAgentActivity } from "./projectOps/agentActivity";
 
 interface RecentSessionItem {
   id: string;
@@ -133,6 +134,47 @@ export function useDerivedRenderState({
     const activeHost =
       hostInfo.hosts.find((h) => h.id === activeHostId) ?? null;
 
+    // Overlay live agent-activity onto the sidebar project rows. The tab set
+    // must span every workspace: the active one in `state.tabs` plus the
+    // backgrounded ones mirrored into `state.persistedTabBuckets` (kept in
+    // state — not a ref — so this stays a pure render derivation). Liveness
+    // comes from the bucket-independent running set, since a backgrounded
+    // tab's own `waiting` flag is frozen at switch-away time.
+    const agentTabs: Tab[] = [];
+    const seenAgentIds = new Set<string>();
+    const collectAgents = (list: Tab[] | undefined) => {
+      for (const t of list ?? []) {
+        if (t.kind === "agent" && !seenAgentIds.has(t.id)) {
+          seenAgentIds.add(t.id);
+          agentTabs.push(t);
+        }
+      }
+    };
+    collectAgents(tabs);
+    const persistedBuckets = state.persistedTabBuckets as
+      | Record<string, { tabs?: Tab[] }>
+      | undefined;
+    if (persistedBuckets) {
+      for (const bucket of Object.values(persistedBuckets)) {
+        collectAgents(bucket?.tabs);
+      }
+    }
+    const runningIds = new Set(
+      Object.keys(
+        (state.agentRunningTabs as Record<string, unknown> | undefined) ?? {},
+      ),
+    );
+    const sidebarProjectsWithAgent = Array.isArray(sidebar.projects)
+      ? attachAgentActivity(
+          sidebar.projects as Array<{
+            id: string;
+            worktrees?: { path?: string; isMain?: boolean }[];
+          }>,
+          agentTabs,
+          runningIds,
+        )
+      : sidebar.projects;
+
     return {
       ...state,
       hasTabs,
@@ -148,6 +190,7 @@ export function useDerivedRenderState({
       landingVisible,
       sidebar: {
         ...sidebar,
+        projects: sidebarProjectsWithAgent,
         history,
         hosts: sidebarHosts,
       },

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -124,30 +124,54 @@ export function useNotifications(
     });
   }
 
-  /** P4: native OS notification on agent turn completion. Fires when:
-   *    1. `[ui] notify_on_completion` is true (default), AND
-   *    2. The turn ran at least `notify_min_duration_seconds` seconds, AND
-   *    3. The window is unfocused OR the originating tab isn't the
-   *       active one (i.e. the user is not looking at the result).
+  /** Agent turn-completion alert. Gated on `[ui] notify_on_completion` and
+   *  a minimum turn duration, then split by where the user's attention is:
    *
-   *  Click → focus the window + switch to that tab. Permission is
-   *  requested lazily on first call so the OS prompt only appears
-   *  when there's actually something to notify about (Tauri's
-   *  notification plugin handles the macOS / Linux / Windows backend).
-   */
+   *    • focused + originating tab active  → nothing (they see the result).
+   *    • focused + a different tab/workspace → in-app toast that deep-links
+   *      back to the finished session (less disruptive than an OS banner
+   *      while the window is up).
+   *    • window unfocused → native OS notification (shows even when the
+   *      app is hidden; permission requested lazily on first fire).
+   *
+   *  Both surfaces read "ready for your reply" so a completed-and-idle
+   *  agent is legible as "your turn", not just "done". The originating tab
+   *  may live in a stashed bucket (a background workspace), so its label
+   *  falls back to a generic when it isn't in `state.tabs`. */
   async function maybeFireCompletionNotification(input: {
     tabId: string;
     turnDurationMs: number;
   }) {
     if (!notifyOnCompletionRef.current) return;
     if (input.turnDurationMs < notifyMinDurationMsRef.current) return;
-    // Only fire when the user can't already see the result. Active-tab
-    // check: a focused window with the originating tab active means the
-    // user is looking at it; no notification needed.
     const windowFocused = typeof document !== "undefined" && document.hasFocus();
-    const isActiveTab =
-      stateRef.current.activeTabId === input.tabId;
+    const isActiveTab = stateRef.current.activeTabId === input.tabId;
     if (windowFocused && isActiveTab) return;
+
+    const tabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
+    const tab = tabs.find((t) => t.id === input.tabId);
+    const lastMsg = tab?.messages?.at(-1);
+    const snippet =
+      typeof lastMsg?.text === "string" && lastMsg.text.length > 0
+        ? lastMsg.text.slice(0, 120)
+        : "Turn complete.";
+
+    if (windowFocused) {
+      // The window is up but the user is elsewhere — an in-app toast that
+      // jumps to the finished session beats an OS banner here.
+      pushNotification({
+        id: `agent-complete:${input.tabId}`,
+        title: tab?.label
+          ? `${tab.label} — ready for your reply`
+          : "Agent ready for your reply",
+        message: snippet,
+        kind: "success",
+        durationMs: 6000,
+        actions: [{ label: "View", action: `activate-tab:${input.tabId}` }],
+      });
+      return;
+    }
+
     try {
       const notif = await import("@tauri-apps/plugin-notification");
       let granted = await notif.isPermissionGranted();
@@ -156,16 +180,9 @@ export function useNotifications(
         granted = perm === "granted";
       }
       if (!granted) return;
-      const tabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
-      const tab = tabs.find((t) => t.id === input.tabId);
-      const lastMsg = tab?.messages?.at(-1);
-      const body =
-        typeof lastMsg?.text === "string" && lastMsg.text.length > 0
-          ? lastMsg.text.slice(0, 120)
-          : "Turn complete.";
       notif.sendNotification({
-        title: tab?.label ? `${tab.label} ✓` : "Aethon ✓",
-        body,
+        title: tab?.label ? `${tab.label} — ready` : "Aethon — ready",
+        body: snippet,
       });
     } catch (err) {
       console.warn("notification fire failed:", err);

--- a/src/hooks/useProjectOps.ts
+++ b/src/hooks/useProjectOps.ts
@@ -50,6 +50,7 @@ export {
   projectScopeBucketKey,
   tabsForProjectBucket,
   worktreeIdForCwd,
+  worktreeIdFromBucketKey,
 } from "./projectOps/tabBuckets";
 
 /**

--- a/src/hooks/useSessionPersistence.ts
+++ b/src/hooks/useSessionPersistence.ts
@@ -134,11 +134,22 @@ export function useSessionPersistence({
     (snapshot: SessionUiSnapshot) => {
       appStore.setState((prev) => {
         const tabs = snapshot.tabs.length ? snapshot.tabs : [];
-        if (tabs.length === 0) return prev;
-        const activeTabId =
-          restoredActiveTabId(tabs, snapshot.activeTabId) ?? tabs[0].id;
-        const activeTab = tabs.find((t) => t.id === activeTabId) ?? tabs[0];
-        const activeRecord = activeTab as unknown as Record<string, unknown>;
+        const buckets = snapshot.buckets ?? {};
+        const hasBuckets = Object.keys(buckets).length > 0;
+        // Nothing to restore only if BOTH the active workspace and every
+        // backgrounded workspace are empty. A buckets-only snapshot (the user
+        // closed on an overview while agents ran in worktrees) must still
+        // restore its buckets — otherwise the next persist wipes them.
+        if (tabs.length === 0 && !hasBuckets) return prev;
+        const hasActiveTabs = tabs.length > 0;
+        const activeTabId = hasActiveTabs
+          ? (restoredActiveTabId(tabs, snapshot.activeTabId) ?? tabs[0].id)
+          : OVERVIEW_TAB_ID;
+        const activeTab = hasActiveTabs
+          ? (tabs.find((t) => t.id === activeTabId) ?? tabs[0])
+          : undefined;
+        const activeRecord =
+          (activeTab as unknown as Record<string, unknown>) ?? {};
         const rootMirror = Object.fromEntries(
           TAB_MIRROR_KEYS.map((key) => [key, activeRecord[key]]),
         );
@@ -173,9 +184,9 @@ export function useSessionPersistence({
           activeTabId,
           // Restored non-active workspace buckets — the seeding effect
           // hydrates tabBucketsRef from this.
-          persistedTabBuckets: snapshot.buckets ?? {},
-          empty: false,
-          hasTabs: true,
+          persistedTabBuckets: buckets,
+          empty: !hasActiveTabs,
+          hasTabs: hasActiveTabs,
           ...rootMirror,
         };
       });

--- a/src/hooks/useSessionPersistence.ts
+++ b/src/hooks/useSessionPersistence.ts
@@ -94,6 +94,10 @@ export function buildInitialAppStore({
       appVersion,
       tabs,
       activeTabId,
+      // Non-active workspace buckets restored from disk. Set synchronously
+      // here so a first persist (which reads state) can't wipe them before
+      // the seeding effect copies them into tabBucketsRef.
+      persistedTabBuckets: restored?.buckets ?? {},
       ...rootMirror,
       palette: { open: false, mode: "switcher", query: "", selectedIndex: 0 },
       notifications: [],
@@ -167,6 +171,9 @@ export function useSessionPersistence({
             : {}),
           tabs,
           activeTabId,
+          // Restored non-active workspace buckets — the seeding effect
+          // hydrates tabBucketsRef from this.
+          persistedTabBuckets: snapshot.buckets ?? {},
           empty: false,
           hasTabs: true,
           ...rootMirror,

--- a/src/hooks/useTabBucketHydration.test.ts
+++ b/src/hooks/useTabBucketHydration.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { makeEmptyTab, type Tab } from "../types/tab";
+import { useTabBucketHydration } from "./useTabBucketHydration";
+import type { TabBucket } from "./projectOps/types";
+
+function bucketTab(id: string): Tab {
+  return { ...makeEmptyTab(id, id, "P", "agent"), cwd: `/P/${id}` };
+}
+
+describe("useTabBucketHydration", () => {
+  it("seeds restored buckets into an empty ref", () => {
+    const ref = { current: new Map<string, TabBucket>() };
+    renderHook(() =>
+      useTabBucketHydration(
+        {
+          "P::worktree::A": { tabs: [bucketTab("a1")], activeTabId: "a1" },
+        },
+        ref,
+      ),
+    );
+    expect(ref.current.get("P::worktree::A")?.activeTabId).toBe("a1");
+    expect(ref.current.get("P::worktree::A")?.tabs.map((t) => t.id)).toEqual([
+      "a1",
+    ]);
+  });
+
+  it("never clobbers a bucket the session already populated", () => {
+    const live: TabBucket = { tabs: [bucketTab("live")], activeTabId: "live" };
+    const ref = { current: new Map<string, TabBucket>([["P::worktree::A", live]]) };
+    renderHook(() =>
+      useTabBucketHydration(
+        {
+          "P::worktree::A": { tabs: [bucketTab("stale")], activeTabId: "stale" },
+        },
+        ref,
+      ),
+    );
+    // Live bucket wins over the disk snapshot.
+    expect(ref.current.get("P::worktree::A")?.activeTabId).toBe("live");
+  });
+
+  it("ignores empty / missing snapshots", () => {
+    const ref = { current: new Map<string, TabBucket>() };
+    renderHook(() => useTabBucketHydration(undefined, ref));
+    renderHook(() => useTabBucketHydration({}, ref));
+    renderHook(() =>
+      useTabBucketHydration({ "P::worktree::A": { tabs: [] } }, ref),
+    );
+    expect(ref.current.size).toBe(0);
+  });
+});

--- a/src/hooks/useTabBucketHydration.ts
+++ b/src/hooks/useTabBucketHydration.ts
@@ -1,0 +1,45 @@
+import { useEffect, type MutableRefObject } from "react";
+import type { Tab } from "../types/tab";
+import type { TabBucket } from "./projectOps/types";
+
+/**
+ * Hydrate per-workspace tab buckets restored from disk
+ * (`state.persistedTabBuckets`) into the live `tabBucketsRef`.
+ *
+ * Only the ACTIVE workspace's tabs live in `state.tabs`; every other open
+ * workspace is stashed in `tabBucketsRef`, which is not itself persisted. On
+ * boot the persistence layer puts the restored non-active buckets into
+ * `state.persistedTabBuckets`; this effect copies them into the live ref so
+ * switching to a backgrounded workspace after a restart lands on the tab the
+ * user last had open there instead of the empty landing card.
+ *
+ * Never clobbers a bucket the session has already populated (so a live switch
+ * always wins over a stale disk snapshot), and is safe to re-run when an async
+ * disk restore lands after first paint.
+ */
+export function useTabBucketHydration(
+  persistedTabBuckets: unknown,
+  tabBucketsRef: MutableRefObject<Map<string, TabBucket>>,
+): void {
+  useEffect(() => {
+    if (
+      !persistedTabBuckets ||
+      typeof persistedTabBuckets !== "object" ||
+      Array.isArray(persistedTabBuckets)
+    ) {
+      return;
+    }
+    const restored = persistedTabBuckets as Record<
+      string,
+      { tabs?: Tab[]; activeTabId?: string }
+    >;
+    for (const [key, bucket] of Object.entries(restored)) {
+      if (tabBucketsRef.current.has(key)) continue;
+      if (!Array.isArray(bucket?.tabs) || bucket.tabs.length === 0) continue;
+      tabBucketsRef.current.set(key, {
+        tabs: bucket.tabs,
+        activeTabId: bucket.activeTabId,
+      });
+    }
+  }, [persistedTabBuckets, tabBucketsRef]);
+}

--- a/src/state/sessionUiSnapshot.test.ts
+++ b/src/state/sessionUiSnapshot.test.ts
@@ -35,6 +35,19 @@ describe("sessionUiSnapshot", () => {
       terminal: { open: true },
       terminalPanel: { activeSubId: "agent-bash", height: 240 },
       projectModels: { "project-1": "anthropic/claude-opus-4-7" },
+      // A backgrounded workspace's tabs ride along in persistedTabBuckets so
+      // a restart can restore them when the user switches to that workspace.
+      persistedTabBuckets: {
+        "project-2": {
+          tabs: [
+            {
+              ...makeEmptyTab("bt-1", "Bucket Tab", "project-2"),
+              messages: [{ id: "bm", role: "user" as const, text: "bg" }],
+            },
+          ],
+          activeTabId: "bt-1",
+        },
+      },
     });
 
     expect(loadSessionUiSnapshot()).toMatchObject({
@@ -54,7 +67,46 @@ describe("sessionUiSnapshot", () => {
       terminal: { open: true },
       terminalPanel: { activeSubId: "agent-bash", height: 240 },
       projectModels: { "project-1": "anthropic/claude-opus-4-7" },
+      buckets: {
+        "project-2": {
+          tabs: [{ id: "bt-1", label: "Bucket Tab", projectId: "project-2" }],
+          activeTabId: "bt-1",
+        },
+      },
     });
+  });
+
+  it("persists buckets-only when the active workspace has no sessions", () => {
+    // User sitting on a project overview while agents run in its worktrees:
+    // state.tabs is empty but a backgrounded bucket has a session.
+    saveSessionUiSnapshot({
+      tabs: [],
+      activeTabId: "__overview__",
+      persistedTabBuckets: {
+        "project-1::worktree::wt-1": {
+          tabs: [
+            {
+              ...makeEmptyTab("wt-tab", "WT Tab", "project-1"),
+              messages: [{ id: "m", role: "user" as const, text: "hi" }],
+            },
+          ],
+          activeTabId: "wt-tab",
+        },
+      },
+    });
+
+    const loaded = loadSessionUiSnapshot();
+    expect(loaded).not.toBeNull();
+    expect(loaded?.activeTabId).toBe("__overview__");
+    expect(loaded?.tabs).toEqual([]);
+    expect(loaded?.buckets?.["project-1::worktree::wt-1"]?.activeTabId).toBe(
+      "wt-tab",
+    );
+  });
+
+  it("returns null when neither active tabs nor buckets have sessions", () => {
+    saveSessionUiSnapshot({ tabs: [], activeTabId: "__overview__" });
+    expect(loadSessionUiSnapshot()).toBeNull();
   });
 
   it("falls back to the first tab when the active id is stale", () => {

--- a/src/state/sessionUiSnapshot.ts
+++ b/src/state/sessionUiSnapshot.ts
@@ -10,6 +10,13 @@ const MAX_MESSAGES_PER_TAB = 200;
 const MAX_TERMINAL_BUFFER = 256 * 1024;
 const MAX_TERMINAL_BUFFER_ENTRIES = 8;
 
+/** A stashed (non-active) workspace's tabs + its last-active tab, keyed in
+ *  `SessionUiSnapshot.buckets` by `projectScopeBucketKey`. */
+export interface PersistedTabBucket {
+  tabs: Tab[];
+  activeTabId?: string;
+}
+
 export interface SessionUiSnapshot {
   activeTabId?: string;
   tabs: Tab[];
@@ -18,6 +25,12 @@ export interface SessionUiSnapshot {
   terminalPanel?: unknown;
   scrollToMatchByTab?: unknown;
   projectModels?: Record<string, string>;
+  /** Non-active workspace tab buckets, keyed by `projectScopeBucketKey`.
+   *  The ACTIVE workspace's tabs live in `tabs`; every other workspace the
+   *  user had open is stashed here so a restart can restore the tab they
+   *  last had open in EACH workspace, not just the global `activeTabId`.
+   *  Seeded back into `tabBucketsRef` on boot. */
+  buckets?: Record<string, PersistedTabBucket>;
   savedAt: number;
 }
 
@@ -167,6 +180,141 @@ function durableTerminalSnapshot(
   return Object.keys(next).length > 0 ? next : undefined;
 }
 
+/** Trim the live `state.persistedTabBuckets` mirror for serialization:
+ *  filter + trim each bucket's tabs like the active list, drop empties. */
+function serializePersistedBuckets(
+  value: unknown,
+): Record<string, PersistedTabBucket> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const out: Record<string, PersistedTabBucket> = {};
+  for (const [key, raw] of Object.entries(value as Record<string, unknown>)) {
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) continue;
+    const bucket = raw as { tabs?: unknown; activeTabId?: unknown };
+    const tabs = (Array.isArray(bucket.tabs) ? (bucket.tabs as Tab[]) : [])
+      .filter(shouldPersistTab)
+      .map(trimTab);
+    if (tabs.length === 0) continue;
+    out[key] = {
+      tabs,
+      ...(typeof bucket.activeTabId === "string"
+        ? { activeTabId: bucket.activeTabId }
+        : {}),
+    };
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/** Minimal structural validation for a persisted tab record. */
+function validTabsFrom(value: unknown): Tab[] {
+  return Array.isArray(value)
+    ? value.filter((t): t is Tab => {
+        const candidate = t as Partial<Tab>;
+        return (
+          typeof candidate.id === "string" &&
+          typeof candidate.label === "string" &&
+          Array.isArray(candidate.messages)
+        );
+      })
+    : [];
+}
+
+/** Normalise a persisted tab back into a live Tab: dedupe + durable-ify
+ *  attachments, reset process-local fields (waiting / queue), preserve
+ *  editor metadata, and re-arm or quiesce shell tabs. Shared by the main
+ *  tab list and the stashed per-workspace buckets so both restore the same
+ *  way. */
+function restoreTabRecord(t: Tab, restartShellTabs: boolean): Tab {
+  const base = {
+    ...t,
+    kind: t.kind ?? "agent",
+    messages: dedupeToolResultTextMessages(t.messages).map(
+      (message): ChatMessage =>
+        message.attachments && message.attachments.length > 0
+          ? {
+              ...message,
+              attachments: durableImageAttachments(message.attachments),
+            }
+          : message,
+    ),
+    draft: t.draft ?? "",
+    draftAttachments: Array.isArray(t.draftAttachments)
+      ? durableImageAttachments(t.draftAttachments)
+      : [],
+    // Waiting is process-local state. After an app restart there is no
+    // still-attached prompt runner behind this tab, so restoring it as
+    // busy leaves the UI stuck in "thinking..." with a dead stop button.
+    waiting: false,
+    // Client-held queue is intentionally NOT restored: queued messages are
+    // ephemeral, and a user who closed the app while queue items were
+    // pending probably abandoned them. queueCount derives from
+    // queuedMessages.length, so zero it in lockstep.
+    queueCount: 0,
+    queuedMessages: [],
+    canvas: t.canvas ?? null,
+    model: t.model ?? "",
+    terminalBuffer: t.terminalBuffer ?? "",
+    projectId: t.projectId ?? null,
+    // Preserve editor metadata so a persisted editor tab reopens pointing at
+    // the same file. Validate minimally — `filePath` is what EditorCanvas
+    // requires; the rest fall back to safe defaults on the next render.
+    ...(t.kind === "editor" &&
+    t.editor &&
+    typeof t.editor.filePath === "string"
+      ? {
+          editor: {
+            filePath: t.editor.filePath,
+            ...(typeof t.editor.rootPath === "string" && t.editor.rootPath
+              ? { rootPath: t.editor.rootPath }
+              : {}),
+            language:
+              typeof t.editor.language === "string"
+                ? t.editor.language
+                : "plaintext",
+            isDirty: false,
+            ...(typeof t.editor.cursorLine === "number"
+              ? { cursorLine: t.editor.cursorLine }
+              : {}),
+            ...(typeof t.editor.cursorColumn === "number"
+              ? { cursorColumn: t.editor.cursorColumn }
+              : {}),
+          },
+        }
+      : {}),
+  };
+  return base.kind === "shell"
+    ? restoreShellTab(base, restartShellTabs)
+    : base;
+}
+
+/** Validate + restore the non-active workspace buckets. Each bucket's tabs
+ *  go through `restoreTabRecord`; an empty bucket is dropped. */
+function parsePersistedBuckets(
+  value: unknown,
+  restartShellTabs: boolean,
+): Record<string, PersistedTabBucket> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const out: Record<string, PersistedTabBucket> = {};
+  for (const [key, raw] of Object.entries(value as Record<string, unknown>)) {
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) continue;
+    const bucket = raw as { tabs?: unknown; activeTabId?: unknown };
+    const tabs = validTabsFrom(bucket.tabs).map((t) =>
+      restoreTabRecord(t, restartShellTabs),
+    );
+    if (tabs.length === 0) continue;
+    const activeTabId =
+      typeof bucket.activeTabId === "string" &&
+      tabs.some((t) => t.id === bucket.activeTabId)
+        ? bucket.activeTabId
+        : tabs[0]?.id;
+    out[key] = { tabs, ...(activeTabId ? { activeTabId } : {}) };
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
 export function loadSessionUiSnapshot(): SessionUiSnapshot | null {
   if (canUseSessionStorage()) {
     const raw = window.sessionStorage.getItem(KEY);
@@ -182,95 +330,27 @@ export function parseSessionUiSnapshot(
   try {
     if (!raw) return null;
     const parsed = JSON.parse(raw) as Partial<SessionUiSnapshot>;
-    const tabs = Array.isArray(parsed.tabs)
-      ? parsed.tabs.filter((t): t is Tab => {
-          const candidate = t as Partial<Tab>;
-          return (
-            typeof candidate.id === "string" &&
-            typeof candidate.label === "string" &&
-            Array.isArray(candidate.messages)
-          );
-        })
-      : [];
-    if (tabs.length === 0) return null;
+    const tabs = validTabsFrom(parsed.tabs);
+    const restartShellTabs = options.restartShellTabs === true;
+    const buckets = parsePersistedBuckets(parsed.buckets, restartShellTabs);
+    // Nothing to restore if neither the active workspace nor any backgrounded
+    // workspace had sessions.
+    if (tabs.length === 0 && !buckets) return null;
     // OVERVIEW_TAB_ID is a valid persisted value (the user closed the
     // app while the overview pseudo-tab owned the canvas with sessions
-    // open) — keep it as-is. Other ids must still match a real tab.
+    // open) — keep it as-is. Other ids must still match a real tab. With no
+    // active tabs (buckets-only restore), the overview owns the canvas.
     const parsedActiveTab = tabs.find((t) => t.id === parsed.activeTabId);
     const activeTabId =
-      typeof parsed.activeTabId === "string" &&
-      (parsed.activeTabId === OVERVIEW_TAB_ID ||
-        tabCanOwnMainSurface(parsedActiveTab))
-        ? parsed.activeTabId
-        : (tabs.find(tabCanOwnMainSurface)?.id ?? OVERVIEW_TAB_ID);
-    const restartShellTabs = options.restartShellTabs === true;
+      tabs.length === 0
+        ? OVERVIEW_TAB_ID
+        : typeof parsed.activeTabId === "string" &&
+            (parsed.activeTabId === OVERVIEW_TAB_ID ||
+              tabCanOwnMainSurface(parsedActiveTab))
+          ? parsed.activeTabId
+          : (tabs.find(tabCanOwnMainSurface)?.id ?? OVERVIEW_TAB_ID);
     return {
-      tabs: tabs.map((t) => {
-        const base = {
-          ...t,
-          kind: t.kind ?? "agent",
-          messages: dedupeToolResultTextMessages(t.messages).map(
-            (message): ChatMessage =>
-              message.attachments && message.attachments.length > 0
-                ? {
-                    ...message,
-                    attachments: durableImageAttachments(message.attachments),
-                  }
-                : message,
-          ),
-          draft: t.draft ?? "",
-          draftAttachments: Array.isArray(t.draftAttachments)
-            ? durableImageAttachments(t.draftAttachments)
-            : [],
-          // Waiting is process-local state. After an app restart there is no
-          // still-attached prompt runner behind this tab, so restoring it as
-          // busy leaves the UI stuck in "thinking..." with a dead stop button.
-          waiting: false,
-          // Client-held queue is intentionally NOT restored: queued
-          // messages are ephemeral, and a user who closed the app while
-          // queue items were pending probably abandoned them. The next
-          // run starts with a clean queue. `queueCount` is derived from
-          // `queuedMessages.length`, so zero it in lockstep — otherwise
-          // the composer badge / "Stop + clear" label would read as
-          // non-empty against an empty popover.
-          queueCount: 0,
-          queuedMessages: [],
-          canvas: t.canvas ?? null,
-          model: t.model ?? "",
-          terminalBuffer: t.terminalBuffer ?? "",
-          projectId: t.projectId ?? null,
-          // Preserve editor metadata so a persisted editor tab reopens
-          // pointing at the same file. Validate the shape minimally —
-          // `filePath` is the field EditorCanvas actually requires; the
-          // rest fall back to safe defaults on the next render.
-          ...(t.kind === "editor" &&
-          t.editor &&
-          typeof t.editor.filePath === "string"
-            ? {
-                editor: {
-                  filePath: t.editor.filePath,
-                  ...(typeof t.editor.rootPath === "string" && t.editor.rootPath
-                    ? { rootPath: t.editor.rootPath }
-                    : {}),
-                  language:
-                    typeof t.editor.language === "string"
-                      ? t.editor.language
-                      : "plaintext",
-                  isDirty: false,
-                  ...(typeof t.editor.cursorLine === "number"
-                    ? { cursorLine: t.editor.cursorLine }
-                    : {}),
-                  ...(typeof t.editor.cursorColumn === "number"
-                    ? { cursorColumn: t.editor.cursorColumn }
-                    : {}),
-                },
-              }
-            : {}),
-        };
-        return base.kind === "shell"
-          ? restoreShellTab(base, restartShellTabs)
-          : base;
-      }),
+      tabs: tabs.map((t) => restoreTabRecord(t, restartShellTabs)),
       activeTabId,
       layout: durableLayoutSnapshot(parsed.layout),
       terminal: durableTerminalSnapshot(parsed.terminal),
@@ -287,6 +367,7 @@ export function parseSessionUiSnapshot(
               ),
             )
           : undefined,
+      buckets,
       savedAt: typeof parsed.savedAt === "number" ? parsed.savedAt : 0,
     };
   } catch {
@@ -301,7 +382,11 @@ export function serializeSessionUiSnapshot(
     const tabs = Array.isArray(state.tabs)
       ? (state.tabs as Tab[]).filter(shouldPersistTab).map(trimTab)
       : [];
-    if (tabs.length === 0) {
+    const buckets = serializePersistedBuckets(state.persistedTabBuckets);
+    // Persist when the active workspace OR any backgrounded workspace has
+    // sessions worth keeping. A user sitting on a project's overview while
+    // agents run in its worktrees still has state to restore.
+    if (tabs.length === 0 && !buckets) {
       return null;
     }
     const activeTab = tabs.find((t) => t.id === state.activeTabId);
@@ -323,6 +408,10 @@ export function serializeSessionUiSnapshot(
         !Array.isArray(state.projectModels)
           ? (state.projectModels as Record<string, string>)
           : undefined,
+      // Non-active workspace buckets mirrored into state by
+      // switchProjectBucket (and seeded at boot). Already trimmed above; the
+      // active workspace is excluded by the mirror.
+      buckets,
       savedAt: Date.now(),
     };
     return JSON.stringify(snapshot);

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -1068,6 +1068,44 @@ body.ae-resizing-sidebar .a2ui-layout {
   height: 6px;
 }
 
+/* Name row inside a stacked project card — holds the leading agent-activity
+   dot (optional) and the label on one line so the dot tracks the label's
+   vertical center and the label still ellipsizes. With no dot the gap
+   collapses (single child), so dot-less rows don't shift. */
+.a2ui-sidebar-item-name-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+/* Agent-activity dot — leading status indicator on project / worktree rows.
+   Deliberately the theme SUCCESS tone, not --accent: the trailing git dirty
+   dot already owns --accent, so "an agent is here" must never read as
+   "uncommitted changes". A filled, softly-haloed dot pulses while a turn is
+   in flight; a hollow ring marks an idle session waiting on the user. */
+.ae-sb-agent-dot {
+  flex-shrink: 0;
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+}
+.ae-sb-agent-dot--running {
+  background: var(--state-success-fg, var(--success));
+  box-shadow: 0 0 0 2px var(--state-success-border, transparent);
+  animation: ae-tab-busy-pulse 1.6s ease-in-out infinite;
+}
+.ae-sb-agent-dot--idle {
+  background: transparent;
+  box-shadow: inset 0 0 0 1.5px
+    var(--state-success-border, var(--text-dim));
+}
+@media (prefers-reduced-motion: reduce) {
+  .ae-sb-agent-dot--running {
+    animation: none;
+  }
+}
+
 /* Branch label — quiet mono text on the right of a project row.
    No border / no chip — the row's own type weight differentiates. */
 .a2ui-sidebar-item-git-branch {


### PR DESCRIPTION
## What & why

Two user-requested capabilities, plus a debug-skill ergonomics fix.

### 1. Agent-activity indicators + completion/awaiting-input alerts
You couldn't tell which repos/worktrees had an agent **running** vs **idle awaiting your input** — the only cue was the top tab strip's busy dot, invisible once you switch workspaces.

- **Leading status dot** on sidebar project & worktree rows: pulsing (theme `--state-success-fg`) while a turn is in flight, hollow ring when an idle session awaits input. Deliberately the success tone, not `--accent`, so it never reads as the trailing git **dirty** dot. Collapsed projects roll up worktree activity.
- **Bucket-independent running set** (`state.agentRunningTabs`) maintained in `promptStarted`/`responseEnd`/`closeTab` + cleared on crash, so **backgrounded** workspaces report activity accurately even though their tabs are stashed in `tabBucketsRef` and never receive `updateTab`. The overlay (`useDerivedRenderState`) reconciles this set against the active workspace's authoritative `waiting`.
- **Completion**: in-app **click-to-jump toast** when you're focused on another tab/workspace (`activate-tab:` route switches workspace first via `activateTabAnywhere`), native **OS notification** when the window is unfocused; both read "ready for your reply".

### 2. Per-workspace last-active tab, persisted across restarts
Switching to a workspace dumped you on the worktree **landing card** instead of the tab you last had open there — and that loss was permanent across a restart (non-active workspace tabs were never persisted).

- Non-active workspace buckets are mirrored into `state.persistedTabBuckets` by `switchProjectBucket` and persisted in the session snapshot (including the **buckets-only** case: overview active while agents run in worktrees).
- On boot, `useTabBucketHydration` seeds `tabBucketsRef` from the restored buckets, so switching to a backgrounded workspace lands on its last tab instead of the empty landing card.

### 3. Debug skill
`debug-eval.sh` gains `--file` + a bare-path safety net so multi-line snippets work instead of silently eval'ing a path string (mirrored to both skill copies).

## Verification
- `tsc -b` clean, ESLint **0/0**, **1586 vitest tests** pass (new: `agentActivity`, `tabBuckets` switch/no-cross-contamination, `useTabBucketHydration` seeding, snapshot buckets round-trip + buckets-only, notification `activate-tab` routing, running-set reconciliation).
- **Live UAT** in the running dev app via the debug skill: confirmed the running/idle dots render on the correct worktree rows with distinct theme-success styling vs the git dirty dot, and that a backgrounded worktree bucket (with its own active tab) is written to the on-disk session snapshot.
- **Codex peer review** run pre-push; both P2 findings addressed (stale running dot on crash → running-set reconciliation + crash clear; buckets-only disk-restore drop → fixed `restoreSessionUiSnapshot`).