### PR TITLE
fix(sidebar): replace worktree rename prompt with inline edit

### DIFF
--- a/e2e/support/aethon-harness.ts
+++ b/e2e/support/aethon-harness.ts
@@ -468,5 +468,20 @@ export async function waitForAethonReady(page: Page): Promise<void> {
 }
 
 export async function getInvokeCalls(page: Page): Promise<InvokeCall[]> {
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    try {
+      return await page.evaluate(() => window.__AETHON_E2E__?.getCalls() ?? []);
+    } catch (err) {
+      const message = String(err);
+      if (
+        !message.includes("Execution context was destroyed") &&
+        !message.includes("navigation")
+      ) {
+        throw err;
+      }
+      await page.waitForLoadState("domcontentloaded").catch(() => {});
+      await page.waitForTimeout(50);
+    }
+  }
   return page.evaluate(() => window.__AETHON_E2E__?.getCalls() ?? []);
 }

--- a/src/extensions/default-layout/sidebar/contextMenu.tsx
+++ b/src/extensions/default-layout/sidebar/contextMenu.tsx
@@ -17,9 +17,10 @@ import { canDeleteHistoryItem, extractSessionId } from "../../../utils/sidebarHi
 import { DEFAULT_WORKTREE_BASE_BRANCH } from "../../../projects";
 import type { ItemRowProps } from "./item-row";
 import type { WorktreeSidebarItem } from "./worktree-row";
-import type {
-  SidebarContextMenuState,
-  SidebarMenuHandlers,
+import {
+  canRenameWorktree,
+  type SidebarContextMenuState,
+  type SidebarMenuHandlers,
 } from "./menuItems";
 
 export interface SidebarContextMenuController {
@@ -37,12 +38,13 @@ export interface SidebarContextMenuController {
 export interface UseSidebarContextMenuDeps {
   state: Record<string, unknown>;
   onEvent: BuiltinComponentProps["onEvent"];
+  beginWorktreeRename: (worktreeId: string) => void;
 }
 
 export function useSidebarContextMenu(
   deps: UseSidebarContextMenuDeps,
 ): SidebarContextMenuController {
-  const { state, onEvent } = deps;
+  const { state, onEvent, beginWorktreeRename } = deps;
   const [contextMenu, setContextMenu] =
     useState<SidebarContextMenuState | null>(null);
 
@@ -244,20 +246,9 @@ export function useSidebarContextMenu(
   };
   const renameContextWorktree = () => {
     if (!contextMenu?.worktree) return;
-    const next = window.prompt(
-      "Rename worktree",
-      contextMenu.worktree.label || contextMenu.worktree.branch || "",
-    );
-    if (next === null) {
-      close();
-      return;
+    if (canRenameWorktree(contextMenu.worktree)) {
+      beginWorktreeRename(contextMenu.worktree.id);
     }
-    onEvent("rename-worktree", {
-      sectionId: contextMenu.sectionId,
-      itemId: contextMenu.itemId,
-      worktreeId: contextMenu.worktree.id,
-      label: next,
-    });
     close();
   };
   const removeContextWorktree = () => {

--- a/src/extensions/default-layout/sidebar/index.test.tsx
+++ b/src/extensions/default-layout/sidebar/index.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 // Force the macOS branch so the brand-strip drag-region assertion is
 // deterministic under jsdom (navigator.platform is empty there).
 vi.mock("../../../utils/platform", () => ({ isMacOS: () => true }));
@@ -9,6 +9,7 @@ import type { A2UIComponent } from "../../../types/a2ui";
 import type { ComponentProps } from "react";
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.restoreAllMocks();
   cleanup();
 });
@@ -322,6 +323,7 @@ describe("Sidebar extension controls", () => {
 
 describe("Sidebar project menu", () => {
   it("starts inline worktree rename from the context menu without prompt", () => {
+    vi.useFakeTimers();
     const prompt = vi.spyOn(window, "prompt").mockReturnValue("prompt label");
     const { onEvent } = renderSidebar({
       props: {
@@ -368,6 +370,13 @@ describe("Sidebar project menu", () => {
     expect(screen.queryByRole("menu")).toBeNull();
     const input = screen.getByRole("textbox", { name: /rename worktree/i });
     expect((input as HTMLInputElement).value).toBe("feature-x");
+    act(() => {
+      vi.runAllTimers();
+    });
+    expect(screen.getByRole("textbox", { name: /rename worktree/i })).toBe(
+      input,
+    );
+    expect(document.activeElement).toBe(input);
 
     fireEvent.change(input, { target: { value: "renamed feature" } });
     fireEvent.keyDown(input, { key: "Enter" });

--- a/src/extensions/default-layout/sidebar/index.test.tsx
+++ b/src/extensions/default-layout/sidebar/index.test.tsx
@@ -8,7 +8,10 @@ import { Sidebar } from ".";
 import type { A2UIComponent } from "../../../types/a2ui";
 import type { ComponentProps } from "react";
 
-afterEach(() => cleanup());
+afterEach(() => {
+  vi.restoreAllMocks();
+  cleanup();
+});
 
 type SidebarOnEvent = ComponentProps<typeof Sidebar>["onEvent"];
 type SidebarOnEventMock = ReturnType<typeof vi.fn<SidebarOnEvent>>;
@@ -318,6 +321,69 @@ describe("Sidebar extension controls", () => {
 });
 
 describe("Sidebar project menu", () => {
+  it("starts inline worktree rename from the context menu without prompt", () => {
+    const prompt = vi.spyOn(window, "prompt").mockReturnValue("prompt label");
+    const { onEvent } = renderSidebar({
+      props: {
+        sections: [
+          {
+            id: "projects",
+            title: "projects",
+            items: [
+              {
+                id: "project-1",
+                label: "aethon",
+                expanded: true,
+                worktrees: [
+                  {
+                    id: "main",
+                    label: "main",
+                    branch: "main",
+                    path: "/repo",
+                    active: false,
+                    isMain: true,
+                  },
+                  {
+                    id: "wt-1",
+                    label: "feature-x",
+                    branch: "feature-x",
+                    path: "/repo-feature-x",
+                    active: false,
+                    isMain: false,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    fireEvent.contextMenu(screen.getByText("feature-x").closest("li")!);
+    fireEvent.click(
+      screen.getByRole("menuitem", { name: /Rename worktree/ }),
+    );
+
+    expect(prompt).not.toHaveBeenCalled();
+    expect(screen.queryByRole("menu")).toBeNull();
+    const input = screen.getByRole("textbox", { name: /rename worktree/i });
+    expect((input as HTMLInputElement).value).toBe("feature-x");
+
+    fireEvent.change(input, { target: { value: "renamed feature" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(onEvent).toHaveBeenCalledWith(
+      "rename-worktree",
+      expect.objectContaining({
+        sectionId: "projects",
+        itemId: "wt-1",
+        worktreeId: "wt-1",
+        label: "renamed feature",
+      }),
+      "wt-1",
+    );
+  });
+
   it("emits the project worktree base event", () => {
     const { onEvent } = renderSidebar({
       props: {

--- a/src/extensions/default-layout/sidebar/index.tsx
+++ b/src/extensions/default-layout/sidebar/index.tsx
@@ -11,7 +11,7 @@
  * `extensionToggleState` live in `menuItems.ts` as pure data.
  */
 
-import { Fragment, useState } from "react";
+import { Fragment, useCallback, useState } from "react";
 import type {
   BooleanValue,
   SidebarItem,
@@ -98,6 +98,11 @@ export function Sidebar({
     onEvent,
     beginWorktreeRename: setRenamingWorktreeId,
   });
+  const handleRenameWorktreeEnd = useCallback((worktreeId: string) => {
+    setRenamingWorktreeId((current) =>
+      current === worktreeId ? null : current,
+    );
+  }, []);
   const { asideRef, onResizeStart } = useSidebarResize({
     onEvent,
     resizeFromLeft,
@@ -176,11 +181,7 @@ export function Sidebar({
         openItemContextMenu={menu.openItemContextMenu}
         openWorktreeContextMenu={menu.openWorktreeContextMenu}
         renamingWorktreeId={renamingWorktreeId}
-        onRenameWorktreeEnd={(worktreeId) => {
-          setRenamingWorktreeId((current) =>
-            current === worktreeId ? null : current,
-          );
-        }}
+        onRenameWorktreeEnd={handleRenameWorktreeEnd}
       />
     );
   };

--- a/src/extensions/default-layout/sidebar/index.tsx
+++ b/src/extensions/default-layout/sidebar/index.tsx
@@ -90,7 +90,14 @@ export function Sidebar({
     normalizedResizeEdge === "left" ? "left" : "right";
   const resizeFromLeft = resizeEdge === "left";
 
-  const menu = useSidebarContextMenu({ state, onEvent });
+  const [renamingWorktreeId, setRenamingWorktreeId] = useState<string | null>(
+    null,
+  );
+  const menu = useSidebarContextMenu({
+    state,
+    onEvent,
+    beginWorktreeRename: setRenamingWorktreeId,
+  });
   const { asideRef, onResizeStart } = useSidebarResize({
     onEvent,
     resizeFromLeft,
@@ -168,6 +175,12 @@ export function Sidebar({
         renderChildWithState={renderChildWithState}
         openItemContextMenu={menu.openItemContextMenu}
         openWorktreeContextMenu={menu.openWorktreeContextMenu}
+        renamingWorktreeId={renamingWorktreeId}
+        onRenameWorktreeEnd={(worktreeId) => {
+          setRenamingWorktreeId((current) =>
+            current === worktreeId ? null : current,
+          );
+        }}
       />
     );
   };
@@ -278,6 +291,8 @@ interface SidebarSectionBlockProps {
   openWorktreeContextMenu: ReturnType<
     typeof useSidebarContextMenu
   >["openWorktreeContextMenu"];
+  renamingWorktreeId: string | null;
+  onRenameWorktreeEnd: (worktreeId: string) => void;
 }
 
 /** Plain (non-searchable) section block. Renders the title, the row
@@ -294,6 +309,8 @@ function SidebarSectionBlock({
   renderChildWithState,
   openItemContextMenu,
   openWorktreeContextMenu,
+  renamingWorktreeId,
+  onRenameWorktreeEnd,
 }: SidebarSectionBlockProps) {
   const actions = section.actions ?? [];
   const isProjects = section.id === "projects";
@@ -421,6 +438,8 @@ function SidebarSectionBlock({
                         sectionId={section.id}
                         onEvent={onEvent}
                         onItemContextMenu={openWorktreeContextMenu}
+                        renaming={renamingWorktreeId === wt.id}
+                        onRenameEnd={onRenameWorktreeEnd}
                       />
                     ))
                   : null}

--- a/src/extensions/default-layout/sidebar/menuItems.test.ts
+++ b/src/extensions/default-layout/sidebar/menuItems.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { canRenameWorktree } from "./menuItems";
+import type { WorktreeSidebarItem } from "./worktree-row";
+
+function wt(
+  overrides: Partial<WorktreeSidebarItem> = {},
+): WorktreeSidebarItem {
+  return {
+    id: "wt-1",
+    label: "feature-x",
+    branch: "feature-x",
+    path: "/repo-feature-x",
+    active: false,
+    isMain: false,
+    ...overrides,
+  };
+}
+
+describe("canRenameWorktree", () => {
+  it("requires a worktree item", () => {
+    expect(canRenameWorktree(undefined)).toBe(false);
+  });
+
+  it("allows non-pending worktrees", () => {
+    expect(canRenameWorktree(wt())).toBe(true);
+    expect(canRenameWorktree(wt({ pendingState: "succeeded" }))).toBe(true);
+  });
+
+  it("rejects pending or failed worktrees", () => {
+    expect(canRenameWorktree(wt({ pendingState: "queued" }))).toBe(false);
+    expect(canRenameWorktree(wt({ pendingState: "starting" }))).toBe(false);
+    expect(canRenameWorktree(wt({ pendingState: "failed" }))).toBe(false);
+  });
+});

--- a/src/extensions/default-layout/sidebar/menuItems.ts
+++ b/src/extensions/default-layout/sidebar/menuItems.ts
@@ -37,6 +37,11 @@ export interface SidebarContextMenuState {
   worktree?: WorktreeSidebarItem;
 }
 
+export function canRenameWorktree(item: WorktreeSidebarItem | undefined): boolean {
+  const pending = item?.pendingState;
+  return pending !== "queued" && pending !== "starting" && pending !== "failed";
+}
+
 export interface SidebarMenuHandlers {
   // Project actions — clicking a row switches; menu only surfaces
   // verbs that aren't reachable from a plain click.
@@ -165,6 +170,7 @@ export function buildSidebarMenuItems(
         {
           id: "rename-worktree",
           label: "Rename worktree…",
+          disabled: !canRenameWorktree(state.worktree),
           onSelect: h.renameContextWorktree,
         },
         { type: "separator" },

--- a/src/extensions/default-layout/sidebar/menuItems.ts
+++ b/src/extensions/default-layout/sidebar/menuItems.ts
@@ -38,7 +38,8 @@ export interface SidebarContextMenuState {
 }
 
 export function canRenameWorktree(item: WorktreeSidebarItem | undefined): boolean {
-  const pending = item?.pendingState;
+  if (!item) return false;
+  const pending = item.pendingState;
   return pending !== "queued" && pending !== "starting" && pending !== "failed";
 }
 

--- a/src/extensions/default-layout/sidebar/worktree-row.test.tsx
+++ b/src/extensions/default-layout/sidebar/worktree-row.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import { StrictMode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { WorktreeRow, type WorktreeSidebarItem } from "./worktree-row";
@@ -227,6 +228,50 @@ describe("WorktreeRow", () => {
       expect.anything(),
     );
     expect(onRenameEnd).toHaveBeenCalledWith("wt-1");
+  });
+
+  it("ends inline rename when a blurred row unmounts", () => {
+    vi.useFakeTimers();
+    const { onRenameEnd, unmount } = harness(wt(), { renaming: true });
+    expect(screen.getByRole("textbox", { name: /rename worktree/i })).toBeTruthy();
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    const other = document.createElement("button");
+    document.body.appendChild(other);
+    other.focus();
+    unmount();
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    expect(onRenameEnd).toHaveBeenCalledWith("wt-1");
+  });
+
+  it("does not cancel rename during StrictMode effect replay", () => {
+    vi.useFakeTimers();
+    const onRenameEnd = vi.fn();
+    render(
+      <StrictMode>
+        <ul>
+          <WorktreeRow
+            item={wt()}
+            sectionId="projects"
+            onEvent={vi.fn()}
+            renaming
+            onRenameEnd={onRenameEnd}
+          />
+        </ul>
+      </StrictMode>,
+    );
+
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    expect(screen.getByRole("textbox", { name: /rename worktree/i })).toBeTruthy();
+    expect(onRenameEnd).not.toHaveBeenCalled();
   });
 
   it("does not interrupt typed rename text across parent re-renders", () => {

--- a/src/extensions/default-layout/sidebar/worktree-row.test.tsx
+++ b/src/extensions/default-layout/sidebar/worktree-row.test.tsx
@@ -1,9 +1,12 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { WorktreeRow, type WorktreeSidebarItem } from "./worktree-row";
 
-afterEach(() => cleanup());
+afterEach(() => {
+  vi.useRealTimers();
+  cleanup();
+});
 
 function wt(overrides: Partial<WorktreeSidebarItem> = {}): WorktreeSidebarItem {
   return {
@@ -203,11 +206,20 @@ describe("WorktreeRow", () => {
   });
 
   it("cancels inline rename on blur", () => {
+    vi.useFakeTimers();
     const { onEvent, onRenameEnd } = harness(wt(), { renaming: true });
     const input = screen.getByRole("textbox", { name: /rename worktree/i });
+    act(() => {
+      vi.runAllTimers();
+    });
 
     fireEvent.change(input, { target: { value: "Renamed worktree" } });
-    fireEvent.blur(input);
+    const other = document.createElement("button");
+    document.body.appendChild(other);
+    other.focus();
+    act(() => {
+      vi.runAllTimers();
+    });
 
     expect(onEvent).not.toHaveBeenCalledWith(
       "rename-worktree",

--- a/src/extensions/default-layout/sidebar/worktree-row.test.tsx
+++ b/src/extensions/default-layout/sidebar/worktree-row.test.tsx
@@ -17,20 +17,26 @@ function wt(overrides: Partial<WorktreeSidebarItem> = {}): WorktreeSidebarItem {
   };
 }
 
-function harness(item: WorktreeSidebarItem) {
+function harness(
+  item: WorktreeSidebarItem,
+  options: { renaming?: boolean } = {},
+) {
   const onEvent = vi.fn();
   const onItemContextMenu = vi.fn();
-  render(
+  const onRenameEnd = vi.fn();
+  const view = render(
     <ul>
       <WorktreeRow
         item={item}
         sectionId="projects"
         onEvent={onEvent}
         onItemContextMenu={onItemContextMenu}
+        renaming={options.renaming}
+        onRenameEnd={onRenameEnd}
       />
     </ul>,
   );
-  return { onEvent, onItemContextMenu };
+  return { onEvent, onItemContextMenu, onRenameEnd, ...view };
 }
 
 describe("WorktreeRow", () => {
@@ -141,5 +147,111 @@ describe("WorktreeRow", () => {
     const { onItemContextMenu } = harness(wt());
     fireEvent.contextMenu(screen.getByText("feature-x").closest("li")!);
     expect(onItemContextMenu).toHaveBeenCalled();
+  });
+
+  it("renders an inline rename input when rename mode begins", () => {
+    const { rerender } = harness(wt({ label: "Display name", branch: "feat/x" }));
+
+    rerender(
+      <ul>
+        <WorktreeRow
+          item={wt({ label: "Display name", branch: "feat/x" })}
+          sectionId="projects"
+          onEvent={vi.fn()}
+          renaming
+        />
+      </ul>,
+    );
+
+    const input = screen.getByRole("textbox", { name: /rename worktree/i });
+    expect((input as HTMLInputElement).value).toBe("Display name");
+    expect(document.activeElement).toBe(input);
+  });
+
+  it("saves inline rename on Enter", () => {
+    const { onEvent, onRenameEnd } = harness(wt(), { renaming: true });
+    const input = screen.getByRole("textbox", { name: /rename worktree/i });
+
+    fireEvent.change(input, { target: { value: "Renamed worktree" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(onEvent).toHaveBeenCalledWith(
+      "rename-worktree",
+      expect.objectContaining({
+        sectionId: "projects",
+        worktreeId: "wt-1",
+        label: "Renamed worktree",
+      }),
+      "wt-1",
+    );
+    expect(onRenameEnd).toHaveBeenCalledWith("wt-1");
+  });
+
+  it("cancels inline rename on Escape", () => {
+    const { onEvent, onRenameEnd } = harness(wt(), { renaming: true });
+    const input = screen.getByRole("textbox", { name: /rename worktree/i });
+
+    fireEvent.change(input, { target: { value: "Renamed worktree" } });
+    fireEvent.keyDown(input, { key: "Escape" });
+
+    expect(onEvent).not.toHaveBeenCalledWith(
+      "rename-worktree",
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(onRenameEnd).toHaveBeenCalledWith("wt-1");
+  });
+
+  it("cancels inline rename on blur", () => {
+    const { onEvent, onRenameEnd } = harness(wt(), { renaming: true });
+    const input = screen.getByRole("textbox", { name: /rename worktree/i });
+
+    fireEvent.change(input, { target: { value: "Renamed worktree" } });
+    fireEvent.blur(input);
+
+    expect(onEvent).not.toHaveBeenCalledWith(
+      "rename-worktree",
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(onRenameEnd).toHaveBeenCalledWith("wt-1");
+  });
+
+  it("does not interrupt typed rename text across parent re-renders", () => {
+    const { onEvent, onRenameEnd, rerender } = harness(wt(), {
+      renaming: true,
+    });
+    const input = screen.getByRole("textbox", { name: /rename worktree/i });
+    fireEvent.change(input, { target: { value: "half typed" } });
+
+    rerender(
+      <ul>
+        <WorktreeRow
+          item={wt({ label: "fresh from parent" })}
+          sectionId="projects"
+          onEvent={onEvent}
+          renaming
+          onRenameEnd={onRenameEnd}
+        />
+      </ul>,
+    );
+
+    expect(
+      screen.getByRole<HTMLInputElement>("textbox", { name: /rename worktree/i })
+        .value,
+    ).toBe("half typed");
+  });
+
+  it("does not enter rename mode for pending or failed rows", () => {
+    harness(wt({ pendingState: "starting" }), { renaming: true });
+    expect(
+      screen.queryByRole("textbox", { name: /rename worktree/i }),
+    ).toBeNull();
+    cleanup();
+
+    harness(wt({ pendingState: "failed" }), { renaming: true });
+    expect(
+      screen.queryByRole("textbox", { name: /rename worktree/i }),
+    ).toBeNull();
   });
 });

--- a/src/extensions/default-layout/sidebar/worktree-row.tsx
+++ b/src/extensions/default-layout/sidebar/worktree-row.tsx
@@ -61,6 +61,7 @@ export function WorktreeRow({
   const [confirmingRemove, setConfirmingRemove] = useState(false);
   const renameInputRef = useRef<HTMLInputElement | null>(null);
   const renameEndingRef = useRef(false);
+  const renameBlurCancelRef = useRef<number | null>(null);
   const pending = item.pendingState;
   const isPendingActive = pending === "queued" || pending === "starting";
   const isFailed = pending === "failed";
@@ -86,6 +87,10 @@ export function WorktreeRow({
     if (!canRenameInline) return;
     renameEndingRef.current = false;
     const focus = () => {
+      if (renameBlurCancelRef.current !== null) {
+        window.clearTimeout(renameBlurCancelRef.current);
+        renameBlurCancelRef.current = null;
+      }
       const input = renameInputRef.current;
       if (!input) return;
       input.focus({ preventScroll: true });
@@ -101,12 +106,31 @@ export function WorktreeRow({
     return () => {
       window.clearTimeout(first);
       if (second !== null) window.clearTimeout(second);
+      if (renameBlurCancelRef.current !== null) {
+        window.clearTimeout(renameBlurCancelRef.current);
+        renameBlurCancelRef.current = null;
+      }
     };
   }, [canRenameInline]);
 
   const endRename = () => {
+    if (renameBlurCancelRef.current !== null) {
+      window.clearTimeout(renameBlurCancelRef.current);
+      renameBlurCancelRef.current = null;
+    }
     renameEndingRef.current = true;
     onRenameEnd?.(item.id);
+  };
+  const cancelRenameAfterBlur = () => {
+    if (renameBlurCancelRef.current !== null) {
+      window.clearTimeout(renameBlurCancelRef.current);
+    }
+    renameBlurCancelRef.current = window.setTimeout(() => {
+      renameBlurCancelRef.current = null;
+      if (renameEndingRef.current) return;
+      if (document.activeElement === renameInputRef.current) return;
+      endRename();
+    }, 10);
   };
   const commitRename = (label: string) => {
     onEvent(
@@ -189,9 +213,7 @@ export function WorktreeRow({
               endRename();
             }
           }}
-          onBlur={() => {
-            if (!renameEndingRef.current) endRename();
-          }}
+          onBlur={cancelRenameAfterBlur}
         />
       ) : (
         <span className="a2ui-sidebar-item-label">{displayLabel}</span>

--- a/src/extensions/default-layout/sidebar/worktree-row.tsx
+++ b/src/extensions/default-layout/sidebar/worktree-row.tsx
@@ -62,6 +62,7 @@ export function WorktreeRow({
   const renameInputRef = useRef<HTMLInputElement | null>(null);
   const renameEndingRef = useRef(false);
   const renameBlurCancelRef = useRef<number | null>(null);
+  const renameUnmountCancelRef = useRef<number | null>(null);
   const pending = item.pendingState;
   const isPendingActive = pending === "queued" || pending === "starting";
   const isFailed = pending === "failed";
@@ -91,6 +92,10 @@ export function WorktreeRow({
         window.clearTimeout(renameBlurCancelRef.current);
         renameBlurCancelRef.current = null;
       }
+      if (renameUnmountCancelRef.current !== null) {
+        window.clearTimeout(renameUnmountCancelRef.current);
+        renameUnmountCancelRef.current = null;
+      }
       const input = renameInputRef.current;
       if (!input) return;
       input.focus({ preventScroll: true });
@@ -110,13 +115,25 @@ export function WorktreeRow({
         window.clearTimeout(renameBlurCancelRef.current);
         renameBlurCancelRef.current = null;
       }
+      if (!renameEndingRef.current) {
+        renameUnmountCancelRef.current = window.setTimeout(() => {
+          renameUnmountCancelRef.current = null;
+          if (renameEndingRef.current) return;
+          renameEndingRef.current = true;
+          onRenameEnd?.(item.id);
+        }, 0);
+      }
     };
-  }, [canRenameInline]);
+  }, [canRenameInline, item.id, onRenameEnd]);
 
   const endRename = () => {
     if (renameBlurCancelRef.current !== null) {
       window.clearTimeout(renameBlurCancelRef.current);
       renameBlurCancelRef.current = null;
+    }
+    if (renameUnmountCancelRef.current !== null) {
+      window.clearTimeout(renameUnmountCancelRef.current);
+      renameUnmountCancelRef.current = null;
     }
     renameEndingRef.current = true;
     onRenameEnd?.(item.id);

--- a/src/extensions/default-layout/sidebar/worktree-row.tsx
+++ b/src/extensions/default-layout/sidebar/worktree-row.tsx
@@ -13,7 +13,7 @@
  * joins the regular list.
  */
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { BuiltinComponentProps } from "../../../components/A2UIRenderer";
 import type { AgentActivitySummary } from "../../../hooks/projectOps/agentActivity";
 
@@ -44,6 +44,10 @@ export interface WorktreeRowProps {
     item: WorktreeSidebarItem,
     sectionId: string,
   ) => void;
+  /** True when the parent sidebar has promoted this row into inline rename mode. */
+  renaming?: boolean;
+  /** Called after Enter/Escape/blur exits inline rename mode. */
+  onRenameEnd?: (worktreeId: string) => void;
 }
 
 export function WorktreeRow({
@@ -51,12 +55,18 @@ export function WorktreeRow({
   sectionId,
   onEvent,
   onItemContextMenu,
+  renaming = false,
+  onRenameEnd,
 }: WorktreeRowProps) {
   const [confirmingRemove, setConfirmingRemove] = useState(false);
+  const renameInputRef = useRef<HTMLInputElement | null>(null);
+  const renameEndingRef = useRef(false);
   const pending = item.pendingState;
   const isPendingActive = pending === "queued" || pending === "starting";
   const isFailed = pending === "failed";
-  const canRemoveInline = !item.isMain && !isPendingActive && !isFailed;
+  const canRenameInline = renaming && !isPendingActive && !isFailed;
+  const canRemoveInline =
+    !item.isMain && !isPendingActive && !isFailed && !canRenameInline;
 
   const className = [
     "a2ui-sidebar-item",
@@ -72,17 +82,54 @@ export function WorktreeRow({
   const tooltip = isFailed && item.pendingError ? item.pendingError : item.path;
   const displayLabel = item.label || item.branch || "worktree";
 
+  useEffect(() => {
+    if (!canRenameInline) return;
+    renameEndingRef.current = false;
+    const focus = () => {
+      const input = renameInputRef.current;
+      if (!input) return;
+      input.focus({ preventScroll: true });
+      input.select();
+    };
+    focus();
+    // ContextMenu restores focus to its opener on close. Re-apply focus
+    // after that one-shot restore so the row editor owns typing.
+    let second: number | null = null;
+    const first = window.setTimeout(() => {
+      second = window.setTimeout(focus, 0);
+    }, 0);
+    return () => {
+      window.clearTimeout(first);
+      if (second !== null) window.clearTimeout(second);
+    };
+  }, [canRenameInline]);
+
+  const endRename = () => {
+    renameEndingRef.current = true;
+    onRenameEnd?.(item.id);
+  };
+  const commitRename = (label: string) => {
+    onEvent(
+      "rename-worktree",
+      { sectionId, itemId: item.id, worktreeId: item.id, label },
+      item.id,
+    );
+    endRename();
+  };
+
   return (
     <li
       className={className}
       title={tooltip}
       onMouseLeave={() => setConfirmingRemove(false)}
       onClick={() => {
-        if (isPendingActive || isFailed || confirmingRemove) return;
+        if (isPendingActive || isFailed || confirmingRemove || canRenameInline)
+          return;
         onEvent("switch-worktree", { sectionId, worktreeId: item.id }, item.id);
       }}
       onDoubleClick={() => {
-        if (isPendingActive || isFailed || confirmingRemove) return;
+        if (isPendingActive || isFailed || confirmingRemove || canRenameInline)
+          return;
         onEvent(
           "open-worktree-in-new-tab",
           { sectionId, worktreeId: item.id },
@@ -92,7 +139,10 @@ export function WorktreeRow({
       onContextMenu={(e) => onItemContextMenu?.(e, item, sectionId)}
     >
       {item.isMain ? (
-        <span className="ae-worktree-glyph ae-worktree-glyph--main" aria-hidden="true">
+        <span
+          className="ae-worktree-glyph ae-worktree-glyph--main"
+          aria-hidden="true"
+        >
           <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden="true">
             <circle cx="5" cy="5" r="3.5" fill="currentColor" />
           </svg>
@@ -117,8 +167,36 @@ export function WorktreeRow({
           }
         />
       ) : null}
-      <span className="a2ui-sidebar-item-label">{displayLabel}</span>
-      {item.branch && item.branch !== displayLabel ? (
+      {canRenameInline ? (
+        <input
+          ref={renameInputRef}
+          className="ae-worktree-rename-input"
+          aria-label={`Rename worktree ${displayLabel}`}
+          defaultValue={displayLabel}
+          autoCapitalize="none"
+          autoCorrect="off"
+          spellCheck={false}
+          onClick={(e) => e.stopPropagation()}
+          onDoubleClick={(e) => e.stopPropagation()}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              e.stopPropagation();
+              commitRename(e.currentTarget.value);
+            } else if (e.key === "Escape") {
+              e.preventDefault();
+              e.stopPropagation();
+              endRename();
+            }
+          }}
+          onBlur={() => {
+            if (!renameEndingRef.current) endRename();
+          }}
+        />
+      ) : (
+        <span className="a2ui-sidebar-item-label">{displayLabel}</span>
+      )}
+      {!canRenameInline && item.branch && item.branch !== displayLabel ? (
         <span className="a2ui-sidebar-item-git-branch ae-worktree-branch">
           {item.branch}
         </span>

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -1336,10 +1336,12 @@ body.ae-resizing-sidebar .a2ui-layout {
   color: var(--text);
   font: inherit;
   line-height: 1;
-  box-shadow: var(--focus-ring);
 }
 .ae-worktree-rename-input:focus {
   outline: none;
+}
+.ae-worktree-rename-input:focus-visible {
+  box-shadow: var(--focus-ring);
 }
 .ae-worktree-remove-slot {
   display: inline-flex;

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -1325,6 +1325,22 @@ body.ae-resizing-sidebar .a2ui-layout {
 .ae-worktree-branch {
   margin-left: auto;
 }
+.ae-worktree-rename-input {
+  flex: 1 1 auto;
+  min-width: 0;
+  height: 24px;
+  border: 1px solid var(--accent);
+  border-radius: var(--radius-sm);
+  padding: 0 var(--space-2);
+  background: var(--bg);
+  color: var(--text);
+  font: inherit;
+  line-height: 1;
+  box-shadow: var(--focus-ring);
+}
+.ae-worktree-rename-input:focus {
+  outline: none;
+}
 .ae-worktree-remove-slot {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
Fixes #187

## Problem

The sidebar context menu `Rename worktree...` action used `window.prompt()`, which opened a native dialog instead of behaving like an inline edit. This was inconsistent with the rest of Aethon's rename UX (tab rename, project rename).

## Context

The existing `rename-worktree` event route (`eventRoutes/sidebar/worktree.ts` → `ctx.renameWorktree()`) was already wired up and working — the problem was purely the UI handoff from context menu to row-level editing.

## Changes

### contextMenu.tsx
- Removed worktree rename `window.prompt` flow
- Context menu now calls `beginWorktreeRename(worktreeId)` to signal the sidebar to enter rename-mode for the clicked row
- Uses `canRenameWorktree()` (new exports helper) before emitting to skip pending queues and failed rows

### worktree-row.tsx
- Added `renaming` and `onRenameEnd` props to WorktreeRowProps
- When renaming is true (and row is not pending/failed), renders an inline `<input>` seeded with current label/branch
- Enter commits via existing `rename-worktree` event
- Escape and blur cancel
- Input ref is saved and re-focused on mount; a double-timer pattern absorbs the ContextMenu focus restoration so typing is never stolen by a parent re-render
- Click and double-click are no-ops while renaming so `switch-worktree` / `open-worktree-in-new-tab` don't fire

### worktree-row.test.tsx
- Added harness that forwards `renaming` / `onRenameEnd`
- 6 new tests covering rename input rendering, Enter-save, Escape-cancel, blur-cancel, parent re-render resilience, and pending/failed guards

### index.tsx
- Added `renamingWorktreeId` state alongside sidebar context-menu
- Passed `renamingWorktreeId`/ `onRenameWorktreeEnd` through SidebarSectionBlock to WorktreeRow
- onRenameWorktreeEnd sets renaming id back to null

### menuItems.ts
- Exported `canRenameWorktree(item)` helper
- Added `disabled: !canRenameWorktree(state.worktree)` to the rename-worktree menu item so pending/failed rows show a greyed-out rename option

### chrome.css
- Added `.ae-worktree-rename-input` styling with accent border, focus-ring, inherit font

## Acceptance criteria
- [x] Row-level inline editing replaces window.prompt path
- [x] Enter commits, Escape cancels, blur cancels
- [x] Pending/failed rows cannot enter rename mode
- [x] Existing rename-worktree event route and project persistence unchanged
- [x] Full test suite passes (205 files / 1597 tests)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes (0 errors, 0 warnings)