### PR TITLE
fix(vcs): merge PR badges should use purple, not neutral gray

### DIFF
--- a/src/extensions/default-layout/sidebar/source-control-panel.test.tsx
+++ b/src/extensions/default-layout/sidebar/source-control-panel.test.tsx
@@ -5,7 +5,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { SourceControlPanel } from "./source-control-panel";
 import type { BuiltinComponentProps } from "../../../components/A2UIRenderer";
 import type { GhCheckRun } from "../../../ghChecksCache";
-import type { VcsCi, VcsSlice } from "../../../hooks/useVcsStatus";
+import type { VcsCi, VcsPr, VcsSlice } from "../../../hooks/useVcsStatus";
 
 afterEach(() => cleanup());
 
@@ -30,6 +30,19 @@ function ci(over: Partial<VcsCi> = {}): VcsCi {
     pending: 0,
     skipped: 0,
     checks: [],
+    ...over,
+  };
+}
+
+function pr(over: Partial<VcsPr> = {}): VcsPr {
+  return {
+    number: 185,
+    state: "OPEN",
+    title: "Add aurora",
+    url: "https://gh/pr/185",
+    isDraft: false,
+    merged: false,
+    baseRefName: "main",
     ...over,
   };
 }
@@ -77,6 +90,31 @@ function renderPanel(slice: VcsSlice, onEvent: OnEvent = vi.fn()) {
   );
   return { onEvent };
 }
+
+describe("SourceControlPanel — PR badge", () => {
+  it("renders merged PRs with the merged badge class, not neutral", () => {
+    renderPanel(vcs({ pr: pr({ merged: true }) }));
+
+    const badge = screen.getByText("merged");
+    expect(badge.classList.contains("is-merged")).toBe(true);
+    expect(badge.classList.contains("is-neutral")).toBe(false);
+  });
+
+  it("keeps open, closed, and draft badge tones unchanged", () => {
+    const cases: Array<[string, VcsPr, string]> = [
+      ["open", pr(), "is-success"],
+      ["closed", pr({ state: "CLOSED" }), "is-failure"],
+      ["draft", pr({ isDraft: true }), "is-muted"],
+    ];
+
+    for (const [label, value, className] of cases) {
+      cleanup();
+      renderPanel(vcs({ pr: value }));
+      const badge = screen.getByText(label);
+      expect(badge.classList.contains(className)).toBe(true);
+    }
+  });
+});
 
 describe("SourceControlPanel — CI jobs", () => {
   it("auto-expands the job list when CI is failing, failures first", () => {
@@ -183,15 +221,7 @@ describe("SourceControlPanel — CI jobs", () => {
     const onEvent = vi.fn();
     renderPanel(
       vcs({
-        pr: {
-          number: 7,
-          state: "OPEN",
-          title: "x",
-          url: "https://gh/pr/7",
-          isDraft: false,
-          merged: false,
-          baseRefName: "main",
-        },
+        pr: pr({ number: 7, title: "x", url: "https://gh/pr/7" }),
         ci: ci({ checks: [] }),
       }),
       onEvent,

--- a/src/extensions/default-layout/sidebar/vcs-presentation.test.ts
+++ b/src/extensions/default-layout/sidebar/vcs-presentation.test.ts
@@ -180,9 +180,15 @@ describe("prMeta", () => {
     expect(prMeta(null)).toBeNull();
   });
 
-  it("prefers merged state over everything", () => {
-    expect(prMeta(pr({ merged: true }))!.label).toBe("merged");
-    expect(prMeta(pr({ state: "MERGED" }))!.label).toBe("merged");
+  it("prefers merged state over everything and uses the merged tone", () => {
+    expect(prMeta(pr({ merged: true }))!).toMatchObject({
+      label: "merged",
+      tone: "merged",
+    });
+    expect(prMeta(pr({ state: "MERGED" }))!).toMatchObject({
+      label: "merged",
+      tone: "merged",
+    });
   });
 
   it("maps closed, draft, and open", () => {

--- a/src/extensions/default-layout/sidebar/vcs-presentation.ts
+++ b/src/extensions/default-layout/sidebar/vcs-presentation.ts
@@ -8,6 +8,7 @@ import type { GhCheckRun } from "../../../ghChecksCache";
 import type { VcsCi, VcsChanges, VcsPr } from "../../../hooks/useVcsStatus";
 
 export type Tone = "success" | "failure" | "pending" | "neutral" | "muted";
+export type PrTone = Tone | "merged";
 
 export interface CiMeta {
   icon: string;
@@ -106,7 +107,7 @@ export function sortChecks(runs: GhCheckRun[]): GhCheckRun[] {
 
 export interface PrMeta {
   label: string;
-  tone: Tone;
+  tone: PrTone;
   title: string;
 }
 
@@ -117,7 +118,7 @@ export function prMeta(pr: VcsPr | null): PrMeta | null {
   if (pr.merged || state === "MERGED") {
     return {
       label: "merged",
-      tone: "neutral",
+      tone: "merged",
       title: `PR #${pr.number} merged`,
     };
   }

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -7389,6 +7389,11 @@ button.ae-vcs-chip:focus-visible {
 .ae-vcs-chip.is-neutral {
   color: var(--text-secondary);
 }
+.ae-vcs-chip.is-merged {
+  background: rgba(140, 82, 255, 0.15);
+  color: #b58aff;
+  border-color: rgba(140, 82, 255, 0.35);
+}
 .ae-vcs-chip.is-muted {
   color: var(--text-dim);
 }
@@ -7547,6 +7552,11 @@ button.ae-vcs-chip:focus-visible {
 }
 .ae-scm-badge.is-neutral {
   color: var(--text-secondary);
+}
+.ae-scm-badge.is-merged {
+  background: rgba(140, 82, 255, 0.15);
+  color: #b58aff;
+  border-color: rgba(140, 82, 255, 0.35);
 }
 .ae-scm-badge.is-muted {
   color: var(--text-dim);

--- a/src/styles/vcs-badges.test.ts
+++ b/src/styles/vcs-badges.test.ts
@@ -12,12 +12,14 @@ const chromeCss = readFileSync(join(here, "chrome.css"), "utf8");
 function cssRuleBody(selector: string): string {
   const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const match = chromeCss.match(new RegExp(`${escaped}\\s*\\{([\\s\\S]*?)\\}`));
+  expect(match, `${selector} rule should exist`).not.toBeNull();
   return match?.[1] ?? "";
 }
 
-function cssProperty(body: string, name: string): string | undefined {
+function cssProperty(body: string, name: string): string {
   const match = body.match(new RegExp(`${name}:\\s*([^;]+);`));
-  return match?.[1]?.trim();
+  expect(match, `${name} property should exist`).not.toBeNull();
+  return match?.[1]?.trim() ?? "";
 }
 
 describe("VCS merged PR badge CSS", () => {

--- a/src/styles/vcs-badges.test.ts
+++ b/src/styles/vcs-badges.test.ts
@@ -1,0 +1,55 @@
+// @ts-expect-error - app tsconfig omits Node types; Vitest runs this file in Node.
+import { readFileSync } from "node:fs";
+// @ts-expect-error - app tsconfig omits Node types; Vitest runs this file in Node.
+import { fileURLToPath } from "node:url";
+// @ts-expect-error - app tsconfig omits Node types; Vitest runs this file in Node.
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const chromeCss = readFileSync(join(here, "chrome.css"), "utf8");
+
+function cssRuleBody(selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = chromeCss.match(new RegExp(`${escaped}\\s*\\{([\\s\\S]*?)\\}`));
+  return match?.[1] ?? "";
+}
+
+function cssProperty(body: string, name: string): string | undefined {
+  const match = body.match(new RegExp(`${name}:\\s*([^;]+);`));
+  return match?.[1]?.trim();
+}
+
+describe("VCS merged PR badge CSS", () => {
+  it("matches the source-control merged badge to the worktree purple treatment", () => {
+    const worktreeMerged = cssRuleBody(".ae-pr-merged");
+    const sourceControlMerged = cssRuleBody(".ae-scm-badge.is-merged");
+
+    expect(cssProperty(sourceControlMerged, "background")).toBe(
+      cssProperty(worktreeMerged, "background"),
+    );
+    expect(cssProperty(sourceControlMerged, "color")).toBe(
+      cssProperty(worktreeMerged, "color"),
+    );
+  });
+
+  it("keeps merged PR badges separate from neutral styling", () => {
+    const sourceControlMerged = cssRuleBody(".ae-scm-badge.is-merged");
+    const sourceControlNeutral = cssRuleBody(".ae-scm-badge.is-neutral");
+
+    expect(sourceControlMerged).toContain("#b58aff");
+    expect(sourceControlNeutral).not.toContain("#b58aff");
+    expect(sourceControlNeutral).not.toMatch(/background:\s*rgba\(140, 82, 255, 0\.15\);/);
+  });
+
+  it("gives header PR chips the same explicit merged tone", () => {
+    const headerMerged = cssRuleBody(".ae-vcs-chip.is-merged");
+
+    expect(cssProperty(headerMerged, "background")).toBe(
+      cssProperty(cssRuleBody(".ae-pr-merged"), "background"),
+    );
+    expect(cssProperty(headerMerged, "color")).toBe(
+      cssProperty(cssRuleBody(".ae-pr-merged"), "color"),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Merged PR state badges should use the same purple treatment everywhere. In the nightly UI, the worktree/header/landing PR state reads as purple, but the source-control panel badge in the upper-right rendered the same `merged` state as a gray/neutral pill.

## Observed

- Worktree: `aethon feat/aurora`
- PR: `#185`, merged
- Header chip / landing merged state visually reads purple.
- Source-control panel row shows `merged` as a gray/neutral badge.

## Root Cause

The shared PR presenter (`prMeta` in `vcs-presentation.ts`) mapped merged PRs to `tone: "neutral"`. The source-control panel then rendered that tone as `is-neutral`, which had gray/neutral styling in `chrome.css`.

## Fix

1. Introduced an explicit `PrTone = Tone | "merged"` type and changed the merged PR tone from `"neutral"` to `"merged"`.
2. Added `.ae-scm-badge.is-merged` and `.ae-vcs-chip.is-merged` CSS rules matching the existing `.ae-pr-merged` purple treatment (`rgba(140, 82, 255, 0.15)` bg, `#b58aff` text).
3. Updated `prMeta` tests to assert `tone: "merged"`.
4. Added new tests for the source-control panel PR badge class rendering.
5. Added new CSS regression test (`vcs-badges.test.ts`) ensuring the source-control merged badge matches the worktree `.ae-pr-merged` treatment and differs from neutral.

## Testing

- `bun run typecheck` — passes
- `bunx eslint ...` — no warnings
- `bun run test` — 206 files, 1595 tests passed