### PR TITLE
fix(session): restored live turns stay visible when chat falls behind pi transcript

### DIFF
--- a/agent/session-history.test.ts
+++ b/agent/session-history.test.ts
@@ -111,6 +111,7 @@ describe("parseSessionHistoryLines", () => {
       {
         id: "restored-tool-call-read-1",
         role: "agent",
+        createdAt: 1_000,
         a2ui: {
           components: [
             {
@@ -206,6 +207,7 @@ describe("parseSessionHistoryLines", () => {
       {
         id: "restored-tool-call-grep-1",
         role: "agent",
+        createdAt: 7_000,
         a2ui: {
           components: [
             {
@@ -569,6 +571,90 @@ describe("readSessionTranscript", () => {
     await expect(readSessionTranscript(dir)).resolves.toEqual([
       { id: "pi-agent", role: "agent", text: "all done", createdAt: 1_000 },
       { id: "text-2", role: "agent", text: "done", createdAt: 2_000 },
+    ]);
+  });
+
+  it("orders pi tool activity after stale local streaming snapshots on restore", async () => {
+    const dir = await tempRoot();
+    await writeFile(
+      join(dir, "session.jsonl"),
+      `${JSON.stringify({
+        type: "message",
+        id: "assistant-tool",
+        timestamp: 3_000,
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "call-bash-after-restart",
+              name: "bash",
+              arguments: { command: "git push" },
+            },
+          ],
+        },
+      })}\n`,
+    );
+    await appendLocalChatMessage(dir, {
+      id: "text-stale-thinking",
+      role: "agent",
+      thinking: "Inspecting code status",
+      createdAt: 2_000,
+    });
+
+    const restored = await readSessionTranscript(dir);
+    expect(restored.map((message) => message.id)).toEqual([
+      "text-stale-thinking",
+      "restored-tool-call-bash-after-restart",
+    ]);
+    expect(restored.at(-1)?.a2ui?.components[0]).toMatchObject({
+      type: "tool-card",
+      props: { toolName: "bash", startedAt: 3_000 },
+    });
+  });
+
+  it("dedupes locally mirrored live tool cards once pi history has the same tool", async () => {
+    const dir = await tempRoot();
+    await writeFile(
+      join(dir, "session.jsonl"),
+      `${JSON.stringify({
+        type: "message",
+        id: "assistant-tool",
+        timestamp: 3_000,
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "call_live_1|fc_abc",
+              name: "bash",
+              arguments: { command: "nix flake check" },
+            },
+          ],
+        },
+      })}\n`,
+    );
+    await appendLocalChatMessage(dir, {
+      id: "tool-7-call_live_1-fc_abc",
+      role: "agent",
+      a2ui: {
+        components: [
+          {
+            id: "tool-7-call_live_1-fc_abc",
+            type: "tool-card",
+            props: {
+              toolName: "bash",
+              startedAt: 3_000,
+            },
+          },
+        ],
+      },
+      createdAt: 3_000,
+    });
+
+    const restored = await readSessionTranscript(dir);
+    expect(restored.map((message) => message.id)).toEqual([
+      "restored-tool-call_live_1-fc_abc",
     ]);
   });
 

--- a/agent/session-history/index.ts
+++ b/agent/session-history/index.ts
@@ -27,7 +27,7 @@ export type {
   RestoredChatMessage,
   SessionLogMetadata,
 } from "./shared";
-export { parseChatAttachments } from "./shared";
+export { hasA2ui, parseChatAttachments } from "./shared";
 export { parseSessionHistoryLines } from "./parse-pi";
 export {
   appendLocalChatMessage,

--- a/agent/session-history/parse-pi.ts
+++ b/agent/session-history/parse-pi.ts
@@ -54,6 +54,7 @@ function toolCardMessage(opts: {
   startedAt?: number;
   endedAt?: number;
 }): RestoredChatMessage {
+  const createdAt = opts.startedAt ?? opts.endedAt;
   return {
     id: opts.uiId,
     role: "agent",
@@ -66,6 +67,7 @@ function toolCardMessage(opts: {
       ...(opts.startedAt !== undefined ? { startedAt: opts.startedAt } : {}),
       ...(opts.endedAt !== undefined ? { endedAt: opts.endedAt } : {}),
     }),
+    ...(createdAt !== undefined ? { createdAt } : {}),
   };
 }
 
@@ -180,8 +182,7 @@ export function parseSessionHistoryLines(
         typeof toolCall.name === "string" && toolCall.name.length > 0
           ? toolCall.name
           : "tool";
-      const args =
-        "arguments" in toolCall ? toolCall.arguments : undefined;
+      const args = "arguments" in toolCall ? toolCall.arguments : undefined;
       const argsSummary = summarizeToolArgs(toolName, args);
       const startedAt = parseMessageTime(record, msg);
       const uiId = restoredToolUiId(toolCallId);

--- a/agent/session-history/restore.ts
+++ b/agent/session-history/restore.ts
@@ -96,14 +96,64 @@ function isCoveredByPiContent(
   });
 }
 
+function normalizeToolCallId(value: string): string {
+  return value.replace(/[^A-Za-z0-9_-]+/g, "-").slice(0, 96);
+}
+
+function toolCardIdentityFromId(id: string): string | undefined {
+  if (id.startsWith("restored-tool-")) {
+    return id.slice("restored-tool-".length);
+  }
+  const liveMatch = /^tool-\d+-(.+)$/.exec(id);
+  if (liveMatch) return normalizeToolCallId(liveMatch[1]);
+  return undefined;
+}
+
+function toolCardIdentities(message: RestoredChatMessage): string[] {
+  const components = message.a2ui?.components ?? [];
+  const identities: string[] = [];
+  for (const component of components) {
+    if (!component || typeof component !== "object") continue;
+    const record = component as Record<string, unknown>;
+    if (record.type !== "tool-card" || typeof record.id !== "string") {
+      continue;
+    }
+    const identity = toolCardIdentityFromId(record.id);
+    if (identity) identities.push(identity);
+  }
+  return identities;
+}
+
+function piToolCardIdentitySet(piMessages: RestoredChatMessage[]): Set<string> {
+  const identities = new Set<string>();
+  for (const message of piMessages) {
+    for (const identity of toolCardIdentities(message))
+      identities.add(identity);
+  }
+  return identities;
+}
+
+function isCoveredByPiToolCard(
+  message: RestoredChatMessage,
+  piToolCards: ReadonlySet<string>,
+): boolean {
+  const identities = toolCardIdentities(message);
+  return (
+    identities.length > 0 &&
+    identities.every((identity) => piToolCards.has(identity))
+  );
+}
+
 function dedupeLocalMessages(
   piMessages: RestoredChatMessage[],
   localMessages: RestoredChatMessage[],
 ): RestoredChatMessage[] {
   const seenIds = new Set(piMessages.map((message) => message.id));
   const contentIndex = piContentIndex(piMessages);
+  const piToolCards = piToolCardIdentitySet(piMessages);
   return localMessages.filter((message) => {
     if (seenIds.has(message.id)) return false;
+    if (isCoveredByPiToolCard(message, piToolCards)) return false;
     return !isCoveredByPiContent(message, contentIndex);
   });
 }

--- a/agent/tab-lifecycle.test.ts
+++ b/agent/tab-lifecycle.test.ts
@@ -441,6 +441,22 @@ describe("handleSessionEvent", () => {
     });
   });
 
+  it("surfaces auto-compaction progress as an inline busy notice", () => {
+    const f = makeFixture();
+    const rec = fakeRec();
+
+    handleSessionEvent(f.state, f.deps, rec, "tab-1", {
+      type: "auto_compaction_start",
+    });
+
+    expect(f.sent[0]).toEqual({
+      type: "notice",
+      tabId: "tab-1",
+      busy: true,
+      message: "Compacting context…",
+    });
+  });
+
   it("message_update with text_delta emits response_delta", () => {
     const f = makeFixture();
     const rec = fakeRec();

--- a/agent/tab-lifecycle/events.ts
+++ b/agent/tab-lifecycle/events.ts
@@ -92,6 +92,34 @@ function rollResponseMessage(rec: TabRecord): void {
   rec.activeResponseCanonicalId = undefined;
 }
 
+function compactionNotice(
+  event: { type: string } & Record<string, unknown>,
+): { message: string; busy?: true } | undefined {
+  const type = event.type.toLowerCase();
+  if (!type.includes("compact")) return undefined;
+  if (type.includes("start") || type.includes("begin")) {
+    return { message: "Compacting context…", busy: true };
+  }
+  if (type.includes("fail") || type.includes("error")) {
+    const reason =
+      typeof event.error === "string"
+        ? event.error
+        : typeof event.message === "string"
+          ? event.message
+          : "unknown error";
+    return { message: `Context compaction failed: ${reason}` };
+  }
+  if (
+    type.includes("end") ||
+    type.includes("finish") ||
+    type.includes("complete") ||
+    type.includes("success")
+  ) {
+    return { message: "Context compaction complete." };
+  }
+  return undefined;
+}
+
 /** Per-tab pi session event subscriber. Extracted so tests can drive it
  *  directly with synthetic event payloads. */
 export function handleSessionEvent(
@@ -104,6 +132,16 @@ export function handleSessionEvent(
   // exhaustive shape.
   event: { type: string } & Record<string, unknown>,
 ): void {
+  const compacting = compactionNotice(event);
+  if (compacting) {
+    deps.send({
+      type: "notice",
+      tabId,
+      ...(compacting.busy ? { busy: true } : {}),
+      message: compacting.message,
+    });
+  }
+
   switch (event.type) {
     case "agent_start": {
       rollResponseMessage(rec);

--- a/agent/tabs.ts
+++ b/agent/tabs.ts
@@ -6,6 +6,7 @@ import { emitGlobalReady } from "./dispatcherTypes";
 import { loadProjectAethonExtensions } from "./extension-loader";
 import {
   appendLocalChatMessage,
+  hasA2ui,
   parseChatAttachments,
   readSessionMetadata,
   readSessionTranscript,
@@ -182,6 +183,7 @@ export async function handleLocalChatMessage(
   const text = record.text;
   const thinking = record.thinking;
   const attachments = parseChatAttachments(record.attachments);
+  const a2ui = hasA2ui(record.a2ui) ? record.a2ui : undefined;
   if (role !== "user" && role !== "agent" && role !== "system") {
     deps.send({
       type: "notice",
@@ -192,7 +194,7 @@ export async function handleLocalChatMessage(
   }
   const hasText = typeof text === "string" && text.length > 0;
   const hasThinking = typeof thinking === "string" && thinking.length > 0;
-  if (!hasText && !hasThinking && attachments.length === 0) {
+  if (!hasText && !hasThinking && !a2ui && attachments.length === 0) {
     deps.send({
       type: "notice",
       tabId,
@@ -215,6 +217,7 @@ export async function handleLocalChatMessage(
       ...(hasText ? { text } : {}),
       ...(hasThinking ? { thinking } : {}),
       ...(attachments.length > 0 ? { attachments } : {}),
+      ...(a2ui ? { a2ui } : {}),
       ...(localCwd ? { cwd: localCwd } : {}),
       ...(typeof record.createdAt === "number"
         ? { createdAt: record.createdAt }

--- a/src/hooks/bridgeMessageHandlers/a2ui.test.ts
+++ b/src/hooks/bridgeMessageHandlers/a2ui.test.ts
@@ -63,6 +63,36 @@ describe("handleA2ui", () => {
     ).toBeLessThan(mocks.appendMessage.mock.invocationCallOrder[0]);
   });
 
+  it("mirrors a2ui tool cards to the durable local chat log", () => {
+    const { ctx, mocks } = buildHandlerFixture({
+      state: { activeTabId: "tab-1" },
+    });
+    const payload = {
+      components: [
+        {
+          id: "tool-1-call-1",
+          type: "tool-card",
+          props: { toolName: "bash", startedAt: 1_000 },
+        },
+      ],
+    };
+
+    handleA2ui(
+      { type: "a2ui", payload, id: "tool-1-call-1", tabId: "tab-1" },
+      ctx,
+    );
+
+    expect(mocks.persistLocalChatMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "tool-1-call-1",
+        role: "agent",
+        a2ui: payload,
+        createdAt: 1_000,
+      }),
+      "tab-1",
+    );
+  });
+
   it("replaces a stale running terminal tool card when the final event has a sibling id", () => {
     const runningId =
       "tool-1-call_run-fc_01a0cf101a3d1343016a14d6465b9c819b8b75c60642c6bd59";

--- a/src/hooks/bridgeMessageHandlers/a2ui.ts
+++ b/src/hooks/bridgeMessageHandlers/a2ui.ts
@@ -1,4 +1,4 @@
-import type { A2UIPayload } from "../../types/a2ui";
+import type { A2UIComponent, A2UIPayload, ChatMessage } from "../../types/a2ui";
 import type { Tab } from "../../types/tab";
 import { toolCardIdentityFromId } from "../../utils/toolCardIdentity";
 import type { BridgeMessageHandler } from "./types";
@@ -14,6 +14,26 @@ function completedToolCardIdentity(payload: A2UIPayload): string | undefined {
   if (component.props?.startedAt === undefined) return undefined;
   if (component.props.endedAt === undefined) return undefined;
   return toolCardIdentityFromId(component.id);
+}
+
+function numericProp(
+  component: A2UIComponent,
+  key: string,
+): number | undefined {
+  const value = component.props?.[key];
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function createdAtFromPayload(payload: A2UIPayload): number | undefined {
+  for (const component of payload.components ?? []) {
+    if (component?.type !== "tool-card") continue;
+    return (
+      numericProp(component, "startedAt") ?? numericProp(component, "endedAt")
+    );
+  }
+  return undefined;
 }
 
 function replacesRunningToolCard(
@@ -44,14 +64,21 @@ export const handleA2ui: BridgeMessageHandler = (data, ctx) => {
   // so any pre-tool assistant text/thinking renders before the tool card.
   flushResponseDeltas(tabId);
   if (payload) {
+    const createdAt = createdAtFromPayload(payload);
+    const message: ChatMessage = {
+      id,
+      role: "agent",
+      a2ui: payload,
+      ...(createdAt !== undefined ? { createdAt } : {}),
+    };
     const tabs = (ctx.stateRef.current.tabs as Tab[] | undefined) ?? [];
     const tab = tabs.find((t) => t.id === tabId);
     const identity = completedToolCardIdentity(payload);
     if (replacesRunningToolCard(tab, id, identity)) {
       ctx.updateTab(tabId, (current) => ({
         ...current,
-        messages: current.messages.map((message) => {
-          const matches = (message.a2ui?.components ?? []).some(
+        messages: current.messages.map((currentMessage) => {
+          const matches = (currentMessage.a2ui?.components ?? []).some(
             (component) =>
               component?.type === "tool-card" &&
               typeof component.id === "string" &&
@@ -59,12 +86,13 @@ export const handleA2ui: BridgeMessageHandler = (data, ctx) => {
               component.props.endedAt === undefined &&
               toolCardIdentityFromId(component.id) === identity,
           );
-          return matches ? { id, role: "agent", a2ui: payload } : message;
+          return matches ? message : currentMessage;
         }),
       }));
     } else {
-      ctx.appendMessage({ id, role: "agent", a2ui: payload }, tabId);
+      ctx.appendMessage(message, tabId);
     }
+    ctx.persistLocalChatMessage(message, tabId);
   }
   if (data.done) {
     ctx.updateTab(tabId, (tab) => ({ ...tab, waiting: false }));

--- a/src/hooks/bridgeMessageHandlers/notice.test.ts
+++ b/src/hooks/bridgeMessageHandlers/notice.test.ts
@@ -13,6 +13,10 @@ describe("handleNotice", () => {
       expect.objectContaining({ role: "system", text: "queued for follow-up" }),
       "default",
     );
+    expect(mocks.persistLocalChatMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ role: "system", text: "queued for follow-up" }),
+      "default",
+    );
     expect(mocks.pushNotification).toHaveBeenCalledWith({
       title: "queued for follow-up",
       kind: "warning",

--- a/src/hooks/bridgeMessageHandlers/notice.ts
+++ b/src/hooks/bridgeMessageHandlers/notice.ts
@@ -22,10 +22,13 @@ export const handleNotice: BridgeMessageHandler = (data, ctx) => {
     }
   }
   if (message) {
-    ctx.appendMessage(
-      { id: crypto.randomUUID(), role: "system", text: message },
-      tabId,
-    );
+    const chatMessage = {
+      id: crypto.randomUUID(),
+      role: "system" as const,
+      text: message,
+    };
+    ctx.appendMessage(chatMessage, tabId);
+    ctx.persistLocalChatMessage(chatMessage, tabId);
     ctx.pushNotification({ title: message, kind: "warning" });
   }
 };

--- a/src/hooks/useAppSlashCommandContext.test.ts
+++ b/src/hooks/useAppSlashCommandContext.test.ts
@@ -132,6 +132,59 @@ describe("useAppSlashCommandContext", () => {
     expect(invokeMock).not.toHaveBeenCalled();
   });
 
+  it("persists a2ui payloads and honors their creation timestamp", () => {
+    const { result } = renderHook(() =>
+      useAppSlashCommandContext({
+        bootLayout: { components: [] },
+        setState: vi.fn(),
+        setLayout: vi.fn(),
+        stateRef: ref({}),
+        projectsRef: ref(makeProjects()),
+        layoutCatalogueRef: ref([]),
+        registry: new ExtensionRegistry(),
+        appendMessage: vi.fn(),
+        pushNotification: vi.fn(() => "toast-1"),
+        clearChat: vi.fn(),
+        setTheme: vi.fn(),
+        listThemes: vi.fn(() => []),
+        setModel: vi.fn(() => Promise.resolve()),
+        toggleTerminal: vi.fn(),
+        toggleSidebar: vi.fn(),
+        toggleFilesSidebar: vi.fn(),
+        activateLayoutById: vi.fn(() => true),
+        openProjectFromPicker: vi.fn(() => Promise.resolve(null)),
+        openProjectByPath: vi.fn((path: string) => path),
+        setActiveProjectById: vi.fn(() => true),
+        clearActiveProject: vi.fn(),
+        removeProjectById: vi.fn(() => true),
+      }),
+    );
+
+    const a2ui = {
+      components: [
+        {
+          id: "tool-1",
+          type: "tool-card",
+          props: { toolName: "bash", startedAt: 1_000 },
+        },
+      ],
+    };
+    act(() => {
+      result.current.persistLocalChatMessage(
+        { id: "tool-1", role: "agent", a2ui, createdAt: 1_000 },
+        "tab-1",
+      );
+    });
+
+    const payload = JSON.parse(invokeMock.mock.calls[0]?.[1]?.payload);
+    expect(payload.payload).toMatchObject({
+      id: "tool-1",
+      role: "agent",
+      a2ui,
+      createdAt: 1_000,
+    });
+  });
+
   it("persists image attachment metadata without blob preview URLs", () => {
     const { result } = renderHook(() =>
       useAppSlashCommandContext({

--- a/src/hooks/useAppSlashCommandContext.ts
+++ b/src/hooks/useAppSlashCommandContext.ts
@@ -9,6 +9,7 @@ import type { A2UIPayload, ChatMessage } from "../types/a2ui";
 import type { Tab } from "../types/tab";
 import { activeProject, type ProjectsState } from "../projects";
 import { durableImageAttachments } from "../utils/imageAttachments";
+import { trimMessage } from "../utils/messages";
 import type { SlashCommandContext } from "../slashCommands";
 import type { ExtensionRegistry } from "../extensions/ExtensionRegistry";
 import type { LayoutCatalogueEntry } from "../extensions/default-layout";
@@ -71,9 +72,17 @@ export function useAppSlashCommandContext({
 }: UseAppSlashCommandContextOptions): AppSlashCommandContextResult {
   const persistLocalChatMessage = useCallback(
     (msg: ChatMessage, tabId: string) => {
-      const attachments = durableImageAttachments(msg.attachments);
-      const a2ui = Array.isArray(msg.a2ui?.components) ? msg.a2ui : undefined;
-      if (!msg.text && !msg.thinking && !a2ui && attachments.length === 0) {
+      const durableMessage = trimMessage(msg);
+      const attachments = durableImageAttachments(durableMessage.attachments);
+      const a2ui = Array.isArray(durableMessage.a2ui?.components)
+        ? durableMessage.a2ui
+        : undefined;
+      if (
+        !durableMessage.text &&
+        !durableMessage.thinking &&
+        !a2ui &&
+        attachments.length === 0
+      ) {
         return;
       }
       invoke("agent_command", {
@@ -81,17 +90,21 @@ export function useAppSlashCommandContext({
           type: "local_chat_message",
           tabId,
           payload: {
-            id: msg.id,
-            role: msg.role,
-            ...(msg.text ? { text: msg.text } : {}),
-            ...(msg.thinking ? { thinking: msg.thinking } : {}),
-            ...(msg.delivery ? { delivery: msg.delivery } : {}),
+            id: durableMessage.id,
+            role: durableMessage.role,
+            ...(durableMessage.text ? { text: durableMessage.text } : {}),
+            ...(durableMessage.thinking
+              ? { thinking: durableMessage.thinking }
+              : {}),
+            ...(durableMessage.delivery
+              ? { delivery: durableMessage.delivery }
+              : {}),
             ...(attachments.length > 0 ? { attachments } : {}),
             ...(a2ui ? { a2ui } : {}),
             createdAt:
-              typeof msg.createdAt === "number" &&
-              Number.isFinite(msg.createdAt)
-                ? msg.createdAt
+              typeof durableMessage.createdAt === "number" &&
+              Number.isFinite(durableMessage.createdAt)
+                ? durableMessage.createdAt
                 : Date.now(),
           },
         }),

--- a/src/hooks/useAppSlashCommandContext.ts
+++ b/src/hooks/useAppSlashCommandContext.ts
@@ -72,7 +72,10 @@ export function useAppSlashCommandContext({
   const persistLocalChatMessage = useCallback(
     (msg: ChatMessage, tabId: string) => {
       const attachments = durableImageAttachments(msg.attachments);
-      if (!msg.text && !msg.thinking && attachments.length === 0) return;
+      const a2ui = Array.isArray(msg.a2ui?.components) ? msg.a2ui : undefined;
+      if (!msg.text && !msg.thinking && !a2ui && attachments.length === 0) {
+        return;
+      }
       invoke("agent_command", {
         payload: JSON.stringify({
           type: "local_chat_message",
@@ -84,7 +87,12 @@ export function useAppSlashCommandContext({
             ...(msg.thinking ? { thinking: msg.thinking } : {}),
             ...(msg.delivery ? { delivery: msg.delivery } : {}),
             ...(attachments.length > 0 ? { attachments } : {}),
-            createdAt: Date.now(),
+            ...(a2ui ? { a2ui } : {}),
+            createdAt:
+              typeof msg.createdAt === "number" &&
+              Number.isFinite(msg.createdAt)
+                ? msg.createdAt
+                : Date.now(),
           },
         }),
       }).catch(() => {

--- a/src/utils/messages.test.ts
+++ b/src/utils/messages.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  MAX_A2UI_BYTES,
   MAX_TEXT_BYTES,
   coerceChatMessages,
   stripImageDataUrls,
@@ -65,7 +66,9 @@ describe("trimMessage", () => {
       id: "1",
       role: "agent",
       a2ui: {
-        components: [{ type: "image", props: { src: "data:image/png;base64,AAA" } }],
+        components: [
+          { type: "image", props: { src: "data:image/png;base64,AAA" } },
+        ],
         rootId: "image",
       } as never,
     });
@@ -73,6 +76,45 @@ describe("trimMessage", () => {
       props: { src: string };
     }>;
     expect(comps[0].props.src).toBe("");
+  });
+
+  it("falls back to lightweight a2ui summaries when payloads exceed the durable budget", () => {
+    const out = trimMessage({
+      id: "1",
+      role: "agent",
+      a2ui: {
+        components: [
+          {
+            id: "tool-1-call-1",
+            type: "tool-card",
+            props: {
+              title: "bash",
+              toolName: "bash",
+              description: "nix flake check",
+              startedAt: 1,
+            },
+            children: Array.from({ length: 16 }, (_, index) => ({
+              id: `tool-1-call-1-result-${index}`,
+              type: "code",
+              props: { content: "x".repeat(MAX_A2UI_BYTES * 2) },
+            })),
+          },
+        ],
+      },
+    });
+
+    expect(JSON.stringify(out.a2ui).length).toBeLessThan(MAX_A2UI_BYTES);
+    expect(out.a2ui?.components[0]).toMatchObject({
+      id: "tool-1-call-1",
+      type: "tool-card",
+      props: {
+        title: "bash",
+        toolName: "bash",
+        description: "nix flake check",
+        startedAt: 1,
+      },
+      children: [],
+    });
   });
 });
 

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -4,10 +4,42 @@ import type { A2UIPayload, ChatAttachment, ChatMessage } from "../types/a2ui";
 // the full string; only the persisted snapshot is trimmed so localStorage
 // doesn't blow past quota.
 export const MAX_TEXT_BYTES = 8 * 1024;
+export const MAX_A2UI_STRING_BYTES = 8 * 1024;
+export const MAX_A2UI_BYTES = 64 * 1024;
 
-// Replace `image` component data URLs with a placeholder so persisted history
-// doesn't blow past the localStorage quota. The in-memory message keeps the
-// full data URL — only the persisted copy is slimmed.
+function utf8Bytes(value: string): number {
+  return new TextEncoder().encode(value).length;
+}
+
+function serializedBytes(value: unknown): number {
+  try {
+    return utf8Bytes(JSON.stringify(value));
+  } catch {
+    return Number.POSITIVE_INFINITY;
+  }
+}
+
+function truncateString(value: string): string {
+  if (utf8Bytes(value) <= MAX_A2UI_STRING_BYTES) return value;
+  return `${value.slice(0, MAX_A2UI_STRING_BYTES - 1)}…`;
+}
+
+function slimA2uiValue(value: unknown): unknown {
+  if (typeof value === "string") {
+    if (value.startsWith("data:"))
+      return "[embedded data dropped from history]";
+    return truncateString(value);
+  }
+  if (Array.isArray(value)) return value.map(slimA2uiValue);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.entries(value).map(([key, child]) => [key, slimA2uiValue(child)]),
+  );
+}
+
+// Replace `image` component data URLs with a placeholder and truncate large
+// string props so persisted history doesn't blow past disk/quota budgets. The
+// in-memory message keeps the full payload — only the persisted copy is slimmed.
 export function stripImageDataUrls(component: unknown): unknown {
   if (!component || typeof component !== "object") return component;
   const c = component as {
@@ -15,18 +47,71 @@ export function stripImageDataUrls(component: unknown): unknown {
     props?: Record<string, unknown>;
     children?: unknown[];
   };
-  let next = c;
+  let next = {
+    ...c,
+    ...(c.props
+      ? { props: slimA2uiValue(c.props) as Record<string, unknown> }
+      : {}),
+  };
   if (
     c.type === "image" &&
     typeof c.props?.src === "string" &&
     c.props.src.startsWith("data:")
   ) {
-    next = { ...c, props: { ...c.props, src: "", caption: "[image dropped from history]" } };
+    next = {
+      ...next,
+      props: {
+        ...(next.props ?? {}),
+        src: "",
+        caption: "[image dropped from history]",
+      },
+    };
   }
   if (Array.isArray(c.children) && c.children.length > 0) {
     next = { ...next, children: c.children.map(stripImageDataUrls) };
   }
   return next;
+}
+
+function summarizedA2uiComponent(component: unknown): unknown {
+  if (!component || typeof component !== "object") return component;
+  const c = component as {
+    id?: unknown;
+    type?: unknown;
+    props?: Record<string, unknown>;
+  };
+  const props = c.props ?? {};
+  const keptProps = Object.fromEntries(
+    [
+      "title",
+      "toolName",
+      "description",
+      "status",
+      "isError",
+      "startedAt",
+      "endedAt",
+    ].flatMap((key) => (key in props ? [[key, props[key]]] : [])),
+  );
+  return {
+    ...(typeof c.id === "string" ? { id: c.id } : {}),
+    ...(typeof c.type === "string" ? { type: c.type } : {}),
+    ...(Object.keys(keptProps).length > 0
+      ? { props: slimA2uiValue(keptProps) }
+      : {}),
+    children: [],
+  };
+}
+
+function durableA2uiPayload(payload: A2UIPayload): A2UIPayload {
+  const slimmed = {
+    ...payload,
+    components: payload.components.map(stripImageDataUrls) as never,
+  };
+  if (serializedBytes(slimmed) <= MAX_A2UI_BYTES) return slimmed;
+  return {
+    ...payload,
+    components: payload.components.map(summarizedA2uiComponent) as never,
+  };
 }
 
 export function trimMessage(m: ChatMessage): ChatMessage {
@@ -37,7 +122,7 @@ export function trimMessage(m: ChatMessage): ChatMessage {
   if (m.a2ui && Array.isArray(m.a2ui.components)) {
     out = {
       ...out,
-      a2ui: { ...m.a2ui, components: m.a2ui.components.map(stripImageDataUrls) as never },
+      a2ui: durableA2uiPayload(m.a2ui),
     };
   }
   return out;


### PR DESCRIPTION
Fixes #190

## Problem

After restart, the UI restored the tab stuck at an older thinking block even though the underlying pi transcript had continued past that state. Local `aethon-chat.jsonl` could lag behind pi history, leaving the user staring at an apparently stale bottom-of-chat state.

## Root Cause

Three gaps in the restore path:

1. **Tool cards never had `createdAt`** -- pi session history parsing returned tool-cards without timestamps, so restore ordering placed stale local thinking/text before newer pi tool activity.

2. **No deduplication of locally mirrored live tool cards** -- when the bridge captured a tool card via `handleA2ui`, the local `aethon-chat.jsonl` entry had a live ID while pi history would later have the same tool with a different ID.

3. **Auto-compaction events were invisible** -- `auto_compaction_start` etc. were handled by pi internally but never surfaced as an inline chat message.

## Solution

### 1. Bridge A2UI persistence with `createdAt`

- `createdAtFromPayload` derives `createdAt` from a2ui tool-card `startedAt`/`endedAt`
- All A2UI messages now call `persistLocalChatMessage`

### 2. Tool-card deduplication during restore

- `dedupeLocalMessages` builds a `piToolCardIdentitySet` from pi messages
- Local tool cards whose identity matches any pi tool card are dropped

### 3. System notices persist

- Notices from `handleNotice` now call `persistLocalChatMessage`

### 4. Compaction lifecycle events

- `compactionNotice` emits inline busy/complete/fail notices for `auto_compaction_start` etc.

### 5. A2UI payload support in local chat storage

- `handleLocalChatMessage` accepts and stores A2UI payloads
- `persistLocalChatMessage` sends A2UI payloads and honors explicit `createdAt`

## Acceptance criteria

- [x] Restarting during an active turn restores inline current representation of the in-flight turn
- [x] Long-running tool calls that started after restart remain visible after leaving/re-entering
- [x] Auto-compaction has a visible inline marker, not a silent stuck state
- [x] All 205 test files pass (1595 tests), typecheck clean, lint clean
