### PR TITLE
feat(git): periodically fetch project remotes

### DIFF
--- a/src-tauri/src/commands/git/mod.rs
+++ b/src-tauri/src/commands/git/mod.rs
@@ -16,4 +16,5 @@ pub(crate) mod test_support;
 pub mod watch;
 pub mod worktrees;
 
+pub use status::GitFetchState;
 pub use watch::GitWatchState;

--- a/src-tauri/src/commands/git/status.rs
+++ b/src-tauri/src/commands/git/status.rs
@@ -1,16 +1,18 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::{Mutex, OnceLock};
+use std::sync::Mutex;
 use std::time::{Duration, Instant};
+
+use tauri::State;
 
 use crate::env;
 
 const FETCH_TIMEOUT: Duration = Duration::from_secs(120);
 const FETCH_DEDUP_WINDOW: Duration = Duration::from_secs(30);
 
-fn git_fetch_attempts() -> &'static Mutex<HashMap<PathBuf, Instant>> {
-    static ATTEMPTS: OnceLock<Mutex<HashMap<PathBuf, Instant>>> = OnceLock::new();
-    ATTEMPTS.get_or_init(|| Mutex::new(HashMap::new()))
+#[derive(Default)]
+pub struct GitFetchState {
+    attempts: Mutex<HashMap<PathBuf, Instant>>,
 }
 
 /// Read minimal git status for a project directory. Used by the
@@ -42,7 +44,14 @@ pub struct GitStatus {
 /// frontend treats this as a background maintenance task and must never blank
 /// existing status chips because it failed.
 #[tauri::command]
-pub async fn git_fetch_all(project_path: String) -> Result<bool, String> {
+pub async fn git_fetch_all(
+    project_path: String,
+    state: State<'_, GitFetchState>,
+) -> Result<bool, String> {
+    git_fetch_all_inner(project_path, state.inner()).await
+}
+
+async fn git_fetch_all_inner(project_path: String, state: &GitFetchState) -> Result<bool, String> {
     let dir = PathBuf::from(&project_path);
     if !dir.is_dir() {
         return Ok(false);
@@ -52,7 +61,7 @@ pub async fn git_fetch_all(project_path: String) -> Result<bool, String> {
     }
 
     let key = git_common_dir(&dir).unwrap_or_else(|| dir.canonicalize().unwrap_or(dir.clone()));
-    if !reserve_git_fetch_attempt(key) {
+    if !state.reserve_attempt(key) {
         return Ok(false);
     }
 
@@ -63,6 +72,8 @@ pub async fn git_fetch_all(project_path: String) -> Result<bool, String> {
     cmd.arg("-C")
         .arg(&dir)
         .args(["fetch", "--all", "--prune", "--quiet"])
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GCM_INTERACTIVE", "never")
         .kill_on_drop(true);
     let out = tokio::time::timeout(FETCH_TIMEOUT, cmd.output()).await;
     Ok(matches!(out, Ok(Ok(_))))
@@ -96,20 +107,20 @@ fn git_common_dir(dir: &Path) -> Option<PathBuf> {
     Some(path.canonicalize().unwrap_or(path))
 }
 
-fn reserve_git_fetch_attempt(key: PathBuf) -> bool {
-    let now = Instant::now();
-    let mut attempts = git_fetch_attempts()
-        .lock()
-        .unwrap_or_else(|e| e.into_inner());
-    attempts.retain(|_, last| now.duration_since(*last) < FETCH_DEDUP_WINDOW);
-    if attempts
-        .get(&key)
-        .is_some_and(|last| now.duration_since(*last) < FETCH_DEDUP_WINDOW)
-    {
-        return false;
+impl GitFetchState {
+    fn reserve_attempt(&self, key: PathBuf) -> bool {
+        let now = Instant::now();
+        let mut attempts = self.attempts.lock().unwrap_or_else(|e| e.into_inner());
+        attempts.retain(|_, last| now.duration_since(*last) < FETCH_DEDUP_WINDOW);
+        if attempts
+            .get(&key)
+            .is_some_and(|last| now.duration_since(*last) < FETCH_DEDUP_WINDOW)
+        {
+            return false;
+        }
+        attempts.insert(key, now);
+        true
     }
-    attempts.insert(key, now);
-    true
 }
 
 /// One per-file worktree change as reported by `git status --porcelain`.
@@ -438,8 +449,9 @@ mod tests {
     #[tokio::test]
     async fn git_fetch_all_returns_false_for_missing_directory() {
         let missing = tempfile::tempdir().unwrap().path().join("missing");
+        let state = GitFetchState::default();
         assert!(
-            !git_fetch_all(missing.to_string_lossy().to_string())
+            !git_fetch_all_inner(missing.to_string_lossy().to_string(), &state)
                 .await
                 .unwrap()
         );
@@ -448,8 +460,9 @@ mod tests {
     #[tokio::test]
     async fn git_fetch_all_returns_false_for_non_repo() {
         let tmp = tempfile::tempdir().unwrap();
+        let state = GitFetchState::default();
         assert!(
-            !git_fetch_all(tmp.path().to_string_lossy().to_string())
+            !git_fetch_all_inner(tmp.path().to_string_lossy().to_string(), &state)
                 .await
                 .unwrap()
         );
@@ -468,8 +481,9 @@ mod tests {
             .unwrap();
         assert!(init.status.success());
 
+        let state = GitFetchState::default();
         assert!(
-            git_fetch_all(tmp.path().to_string_lossy().to_string())
+            git_fetch_all_inner(tmp.path().to_string_lossy().to_string(), &state)
                 .await
                 .unwrap()
         );
@@ -478,8 +492,9 @@ mod tests {
     #[test]
     fn fetch_attempt_reservation_dedupes_recent_repo_keys() {
         let key = tempfile::tempdir().unwrap().path().join("repo.git");
-        assert!(reserve_git_fetch_attempt(key.clone()));
-        assert!(!reserve_git_fetch_attempt(key));
+        let state = GitFetchState::default();
+        assert!(state.reserve_attempt(key.clone()));
+        assert!(!state.reserve_attempt(key));
     }
 
     #[test]

--- a/src-tauri/src/commands/git/status.rs
+++ b/src-tauri/src/commands/git/status.rs
@@ -1,6 +1,17 @@
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
 
 use crate::env;
+
+const FETCH_TIMEOUT: Duration = Duration::from_secs(120);
+const FETCH_DEDUP_WINDOW: Duration = Duration::from_secs(30);
+
+fn git_fetch_attempts() -> &'static Mutex<HashMap<PathBuf, Instant>> {
+    static ATTEMPTS: OnceLock<Mutex<HashMap<PathBuf, Instant>>> = OnceLock::new();
+    ATTEMPTS.get_or_init(|| Mutex::new(HashMap::new()))
+}
 
 /// Read minimal git status for a project directory. Used by the
 /// sidebar to surface a branch chip + dirty dot per project. Returns
@@ -22,6 +33,83 @@ pub struct GitStatus {
     dirty: bool,
     ahead: u32,
     behind: u32,
+}
+
+/// Best-effort refresh of remote-tracking refs for a project. Returns `true`
+/// when a fetch command actually ran to completion (even if git exited nonzero
+/// after partially updating refs), `false` for non-repositories, missing `git`,
+/// duplicate worktree fetches that were recently attempted, or timeouts. The
+/// frontend treats this as a background maintenance task and must never blank
+/// existing status chips because it failed.
+#[tauri::command]
+pub async fn git_fetch_all(project_path: String) -> Result<bool, String> {
+    let dir = PathBuf::from(&project_path);
+    if !dir.is_dir() {
+        return Ok(false);
+    }
+    if !is_inside_work_tree(&dir) {
+        return Ok(false);
+    }
+
+    let key = git_common_dir(&dir).unwrap_or_else(|| dir.canonicalize().unwrap_or(dir.clone()));
+    if !reserve_git_fetch_attempt(key) {
+        return Ok(false);
+    }
+
+    // `--prune` only removes stale remote-tracking refs; it does not delete
+    // local branches. Keeping those refs accurate makes ahead/behind chips
+    // reflect deleted/renamed upstream branches instead of preserving ghosts.
+    let mut cmd = env::tokio_command("git");
+    cmd.arg("-C")
+        .arg(&dir)
+        .args(["fetch", "--all", "--prune", "--quiet"])
+        .kill_on_drop(true);
+    let out = tokio::time::timeout(FETCH_TIMEOUT, cmd.output()).await;
+    Ok(matches!(out, Ok(Ok(_))))
+}
+
+fn is_inside_work_tree(dir: &Path) -> bool {
+    let inside = env::command("git")
+        .arg("-C")
+        .arg(dir)
+        .args(["rev-parse", "--is-inside-work-tree"])
+        .output();
+    match inside {
+        Ok(o) => o.status.success() && String::from_utf8_lossy(&o.stdout).trim() == "true",
+        Err(_) => false,
+    }
+}
+
+fn git_common_dir(dir: &Path) -> Option<PathBuf> {
+    let out = env::command("git")
+        .arg("-C")
+        .arg(dir)
+        .args(["rev-parse", "--path-format=absolute", "--git-common-dir"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())?;
+    let raw = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if raw.is_empty() {
+        return None;
+    }
+    let path = PathBuf::from(raw);
+    Some(path.canonicalize().unwrap_or(path))
+}
+
+fn reserve_git_fetch_attempt(key: PathBuf) -> bool {
+    let now = Instant::now();
+    let mut attempts = git_fetch_attempts()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    attempts.retain(|_, last| now.duration_since(*last) < FETCH_DEDUP_WINDOW);
+    if attempts
+        .get(&key)
+        .is_some_and(|last| now.duration_since(*last) < FETCH_DEDUP_WINDOW)
+    {
+        return false;
+    }
+    attempts.insert(key, now);
+    true
 }
 
 /// One per-file worktree change as reported by `git status --porcelain`.
@@ -346,6 +434,53 @@ pub(crate) fn parse_git_file_status_porcelain_z(bytes: &[u8]) -> Vec<GitFileStat
 mod tests {
     use super::*;
     use std::path::PathBuf;
+
+    #[tokio::test]
+    async fn git_fetch_all_returns_false_for_missing_directory() {
+        let missing = tempfile::tempdir().unwrap().path().join("missing");
+        assert!(
+            !git_fetch_all(missing.to_string_lossy().to_string())
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn git_fetch_all_returns_false_for_non_repo() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(
+            !git_fetch_all(tmp.path().to_string_lossy().to_string())
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn git_fetch_all_runs_for_repo_without_remotes() {
+        if env::resolve_program("git").is_none() {
+            return;
+        }
+        let tmp = tempfile::tempdir().unwrap();
+        let init = env::command("git")
+            .arg("init")
+            .arg(tmp.path())
+            .output()
+            .unwrap();
+        assert!(init.status.success());
+
+        assert!(
+            git_fetch_all(tmp.path().to_string_lossy().to_string())
+                .await
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn fetch_attempt_reservation_dedupes_recent_repo_keys() {
+        let key = tempfile::tempdir().unwrap().path().join("repo.git");
+        assert!(reserve_git_fetch_attempt(key.clone()));
+        assert!(!reserve_git_fetch_attempt(key));
+    }
 
     #[test]
     fn parses_git_file_status_porcelain_entries() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -193,6 +193,7 @@ pub fn run() {
             commands::fs::fs_open_in_file_manager,
             commands::fs::fs_open_in_default_app,
             commands::git::status::git_status,
+            commands::git::status::git_fetch_all,
             commands::git::status::git_file_status,
             commands::git::status::git_ignored_paths,
             commands::git::watch::git_watch_root,
@@ -380,6 +381,15 @@ mod tests {
         assert!(
             src.contains("commands::extensions::set_extension_menu_items"),
             "set_extension_menu_items must be registered in the invoke_handler list",
+        );
+    }
+
+    #[test]
+    fn git_fetch_all_is_wired_to_handler() {
+        let src = include_str!("lib.rs");
+        assert!(
+            src.contains("commands::git::status::git_fetch_all"),
+            "git_fetch_all must be registered in the invoke_handler list",
         );
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -128,6 +128,7 @@ pub fn run() {
         .manage(agent_process::AgentProcesses::new())
         .manage(shell::ShellRegistry::new())
         .manage(commands::fs::FsWatchState::default())
+        .manage(commands::git::GitFetchState::default())
         .manage(commands::git::GitWatchState::default())
         .manage(window_state::WindowStateStore::new())
         .manage(updater_state::UpdaterState::new())

--- a/src/gitFetchCache.ts
+++ b/src/gitFetchCache.ts
@@ -1,0 +1,91 @@
+/**
+ * Disk-backed throttle cache for background git fetch attempts. This is
+ * intentionally separate from `git-status.json`: status entries are user-facing
+ * data, while this file only prevents fetch storms after reload/focus when a
+ * repo is offline, auth prompts fail, or the app restarts repeatedly.
+ */
+import { readState, writeState } from "./persist";
+
+const CACHE_FILE = "git-fetch-attempts.json";
+const SCHEMA_VERSION = 1;
+const STALE_AFTER_MS = 30 * 24 * 60 * 60 * 1000;
+const WRITE_DEBOUNCE_MS = 400;
+
+interface CacheFile {
+  schemaVersion: number;
+  entries: Record<string, { lastAttemptedAt: string }>;
+}
+
+function emptyCache(): CacheFile {
+  return { schemaVersion: SCHEMA_VERSION, entries: {} };
+}
+
+function parseCache(raw: string): CacheFile {
+  if (!raw) return emptyCache();
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object") return emptyCache();
+    const obj = parsed as { schemaVersion?: number; entries?: unknown };
+    if (obj.schemaVersion !== SCHEMA_VERSION) return emptyCache();
+    if (!obj.entries || typeof obj.entries !== "object") return emptyCache();
+    const entries: CacheFile["entries"] = {};
+    for (const [path, value] of Object.entries(obj.entries)) {
+      if (!value || typeof value !== "object") continue;
+      const entry = value as { lastAttemptedAt?: unknown };
+      if (typeof entry.lastAttemptedAt !== "string") continue;
+      entries[path] = { lastAttemptedAt: entry.lastAttemptedAt };
+    }
+    return { schemaVersion: SCHEMA_VERSION, entries };
+  } catch {
+    return emptyCache();
+  }
+}
+
+export async function loadGitFetchAttempts(): Promise<Map<string, number>> {
+  const raw = await readState(CACHE_FILE);
+  const cache = parseCache(raw);
+  const cutoff = Date.now() - STALE_AFTER_MS;
+  const out = new Map<string, number>();
+  for (const [path, entry] of Object.entries(cache.entries)) {
+    const ts = Date.parse(entry.lastAttemptedAt);
+    if (Number.isFinite(ts) && ts >= cutoff) out.set(path, ts);
+  }
+  return out;
+}
+
+let pendingWriteTimer: ReturnType<typeof setTimeout> | null = null;
+let pendingWriteSnapshot: Map<string, number> | null = null;
+
+export function persistGitFetchAttemptsDebounced(
+  attempts: Map<string, number>,
+): void {
+  pendingWriteSnapshot = new Map(attempts);
+  if (pendingWriteTimer) clearTimeout(pendingWriteTimer);
+  pendingWriteTimer = setTimeout(() => {
+    pendingWriteTimer = null;
+    const snap = pendingWriteSnapshot;
+    pendingWriteSnapshot = null;
+    if (!snap) return;
+    void writeAttemptsNow(snap);
+  }, WRITE_DEBOUNCE_MS);
+}
+
+async function writeAttemptsNow(attempts: Map<string, number>): Promise<void> {
+  const cache: CacheFile = { schemaVersion: SCHEMA_VERSION, entries: {} };
+  for (const [path, ts] of attempts) {
+    cache.entries[path] = { lastAttemptedAt: new Date(ts).toISOString() };
+  }
+  await writeState(CACHE_FILE, JSON.stringify(cache));
+}
+
+export async function flushPendingGitFetchAttemptsForTesting(): Promise<void> {
+  if (pendingWriteTimer) {
+    clearTimeout(pendingWriteTimer);
+    pendingWriteTimer = null;
+  }
+  const snap = pendingWriteSnapshot;
+  pendingWriteSnapshot = null;
+  if (snap) await writeAttemptsNow(snap);
+}
+
+export const __TEST__ = { CACHE_FILE, SCHEMA_VERSION, STALE_AFTER_MS };

--- a/src/hooks/gitFetchScheduler.test.ts
+++ b/src/hooks/gitFetchScheduler.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  dueGitFetchPaths,
+  GIT_FETCH_INTERVAL_MS,
+  uniqueProjectPaths,
+  type GitFetchCadenceState,
+} from "./gitFetchScheduler";
+
+function state(
+  lastAttemptedAt: Array<[string, number]> = [],
+  inFlight: string[] = [],
+): GitFetchCadenceState {
+  return {
+    lastAttemptedAt: new Map(lastAttemptedAt),
+    inFlight: new Set(inFlight),
+  };
+}
+
+describe("git fetch scheduler", () => {
+  it("deduplicates project paths while preserving order", () => {
+    expect(uniqueProjectPaths(["/repo", "/repo", "/other", "", "/other"])).toEqual([
+      "/repo",
+      "/other",
+    ]);
+  });
+
+  it("fetches projects with no prior attempt", () => {
+    expect(dueGitFetchPaths(["/repo"], state(), 1_000)).toEqual(["/repo"]);
+  });
+
+  it("skips projects fetched recently or already in flight", () => {
+    const now = 20_000;
+    expect(
+      dueGitFetchPaths(
+        ["/fresh", "/stale", "/busy"],
+        state(
+          [
+            ["/fresh", now - GIT_FETCH_INTERVAL_MS + 1],
+            ["/stale", now - GIT_FETCH_INTERVAL_MS],
+          ],
+          ["/busy"],
+        ),
+        now,
+      ),
+    ).toEqual(["/stale"]);
+  });
+
+  it("uses the configured cadence for focus/interval checks", () => {
+    const now = 1_000_000;
+    const cadence = 15_000;
+    expect(
+      dueGitFetchPaths(["/repo"], state([["/repo", now - cadence + 1]]), now, cadence),
+    ).toEqual([]);
+    expect(
+      dueGitFetchPaths(["/repo"], state([["/repo", now - cadence]]), now, cadence),
+    ).toEqual(["/repo"]);
+  });
+});

--- a/src/hooks/gitFetchScheduler.ts
+++ b/src/hooks/gitFetchScheduler.ts
@@ -1,0 +1,43 @@
+/**
+ * Cadence helpers for best-effort `git fetch --all` across known projects.
+ * Kept as pure functions so the hook's timer/focus behavior has cheap unit
+ * coverage without mounting React timers for every edge case.
+ */
+
+/** Remote-tracking refs are refreshed much less often than local status polls.
+ *  Ten minutes keeps ahead/behind reasonably fresh without hammering remotes
+ *  on focus toggles or short-lived app reloads. */
+export const GIT_FETCH_INTERVAL_MS = 10 * 60 * 1000;
+
+export interface GitFetchCadenceState {
+  /** Last attempted fetch time keyed by project path. Attempts (not only
+   *  successes) are recorded so offline/auth failures don't retry on every
+   *  focus event. */
+  lastAttemptedAt: Map<string, number>;
+  /** Project paths currently being fetched. */
+  inFlight: Set<string>;
+}
+
+export function uniqueProjectPaths(paths: string[]): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const path of paths) {
+    if (!path || seen.has(path)) continue;
+    seen.add(path);
+    out.push(path);
+  }
+  return out;
+}
+
+export function dueGitFetchPaths(
+  paths: string[],
+  state: GitFetchCadenceState,
+  now = Date.now(),
+  minAgeMs = GIT_FETCH_INTERVAL_MS,
+): string[] {
+  return uniqueProjectPaths(paths).filter((path) => {
+    if (state.inFlight.has(path)) return false;
+    const lastAttemptedAt = state.lastAttemptedAt.get(path);
+    return lastAttemptedAt === undefined || now - lastAttemptedAt >= minAgeMs;
+  });
+}

--- a/src/hooks/useProjects.test.ts
+++ b/src/hooks/useProjects.test.ts
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+
+const {
+  invokeMock,
+  loadCachedStatusesMock,
+  persistStatusesDebouncedMock,
+  loadGitFetchAttemptsMock,
+  persistGitFetchAttemptsDebouncedMock,
+} = vi.hoisted(() => ({
+  invokeMock: vi.fn(),
+  loadCachedStatusesMock: vi.fn(),
+  persistStatusesDebouncedMock: vi.fn(),
+  loadGitFetchAttemptsMock: vi.fn(),
+  persistGitFetchAttemptsDebouncedMock: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: invokeMock }));
+vi.mock("../gitStatusCache", () => ({
+  loadCachedStatuses: loadCachedStatusesMock,
+  persistStatusesDebounced: persistStatusesDebouncedMock,
+}));
+vi.mock("../gitFetchCache", () => ({
+  loadGitFetchAttempts: loadGitFetchAttemptsMock,
+  persistGitFetchAttemptsDebounced: persistGitFetchAttemptsDebouncedMock,
+}));
+
+import { useProjects } from "./useProjects";
+
+beforeEach(() => {
+  invokeMock.mockReset();
+  loadCachedStatusesMock.mockReset().mockResolvedValue(new Map());
+  persistStatusesDebouncedMock.mockReset();
+  loadGitFetchAttemptsMock.mockReset().mockResolvedValue(new Map());
+  persistGitFetchAttemptsDebouncedMock.mockReset();
+});
+
+describe("useProjects", () => {
+  it("fetches known project remotes once on startup and refreshes status after success", async () => {
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === "git_fetch_all") return Promise.resolve(true);
+      if (cmd === "git_status") {
+        return Promise.resolve({ branch: "main", dirty: false, ahead: 0, behind: 1 });
+      }
+      return Promise.resolve(null);
+    });
+    const onGitStatusChanged = vi.fn();
+
+    const { unmount } = renderHook(() =>
+      useProjects({
+        getProjectPaths: () => ["/repo", "/repo"],
+        onGitStatusChanged,
+      }),
+    );
+
+    await waitFor(() => expect(invokeMock).toHaveBeenCalledWith("git_fetch_all", { projectPath: "/repo" }));
+    expect(invokeMock.mock.calls.filter((c) => c[0] === "git_fetch_all")).toHaveLength(1);
+
+    await waitFor(() =>
+      expect(invokeMock.mock.calls.filter((c) => c[0] === "git_status").length).toBeGreaterThan(0),
+    );
+    await waitFor(() => expect(onGitStatusChanged).toHaveBeenCalled());
+    expect(persistGitFetchAttemptsDebouncedMock).toHaveBeenCalled();
+
+    unmount();
+  });
+
+  it("does not refetch on focus before the persisted cadence expires", async () => {
+    invokeMock.mockImplementation((cmd: string) =>
+      Promise.resolve(
+        cmd === "git_fetch_all"
+          ? true
+          : { branch: "main", dirty: false, ahead: 0, behind: 0 },
+      ),
+    );
+
+    const { unmount } = renderHook(() =>
+      useProjects({
+        getProjectPaths: () => ["/repo"],
+        onGitStatusChanged: vi.fn(),
+      }),
+    );
+
+    await waitFor(() => expect(invokeMock.mock.calls.filter((c) => c[0] === "git_fetch_all")).toHaveLength(1));
+    window.dispatchEvent(new FocusEvent("focus"));
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    expect(invokeMock.mock.calls.filter((c) => c[0] === "git_fetch_all")).toHaveLength(1);
+    unmount();
+  });
+});

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -96,7 +96,9 @@ export function useProjects(ctx: UseProjectsContext): UseProjectsActions {
     await Promise.all(paths.map((p) => refreshGitStatusFor(p)));
   }
 
-  async function fetchGitRemotesIfDue(): Promise<void> {
+  async function fetchGitRemotesIfDue(
+    refreshStatusAfterFetch = refreshAllGitStatus,
+  ): Promise<void> {
     if (document.hidden) return;
     const due = dueGitFetchPaths(ctx.getProjectPaths(), {
       lastAttemptedAt: gitFetchAttemptsRef.current,
@@ -128,7 +130,7 @@ export function useProjects(ctx: UseProjectsContext): UseProjectsActions {
     // surface that reads cached git status (including duplicate worktree rows)
     // gets refreshed from local metadata.
     if (results.some(Boolean)) {
-      await refreshAllGitStatus();
+      await refreshStatusAfterFetch();
     }
   }
 
@@ -158,16 +160,25 @@ export function useProjects(ctx: UseProjectsContext): UseProjectsActions {
 
   useEffect(() => {
     let cancelled = false;
+    let rerun = false;
     const tick = async () => {
       // Skip background git polling while the window is hidden — no chips are
       // visible to update, so it's pure wasted subprocess churn. The
       // visibilitychange listener below refreshes on the way back.
-      if (cancelled || gitPollingRef.current || document.hidden) return;
+      if (cancelled || document.hidden) return;
+      if (gitPollingRef.current) {
+        rerun = true;
+        return;
+      }
       gitPollingRef.current = true;
       try {
         await refreshAllGitStatus();
       } finally {
         gitPollingRef.current = false;
+        if (rerun && !cancelled) {
+          rerun = false;
+          void tick();
+        }
       }
     };
     // 1. Hydrate from the disk-backed cache so chips paint with the
@@ -187,12 +198,12 @@ export function useProjects(ctx: UseProjectsContext): UseProjectsActions {
       gitFetchAttemptsRef.current = await loadGitFetchAttempts();
       if (cancelled) return;
       void tick();
-      void fetchGitRemotesIfDue();
+      void fetchGitRemotesIfDue(tick);
     };
     void bootstrap();
     const onFocus = () => {
       void tick();
-      void fetchGitRemotesIfDue();
+      void fetchGitRemotesIfDue(tick);
     };
     // Refresh when the window becomes visible again (covers restore-from-
     // minimized, which doesn't always fire `focus`), catching up on anything
@@ -200,14 +211,14 @@ export function useProjects(ctx: UseProjectsContext): UseProjectsActions {
     const onVisibility = () => {
       if (!document.hidden) {
         void tick();
-        void fetchGitRemotesIfDue();
+        void fetchGitRemotesIfDue(tick);
       }
     };
     window.addEventListener("focus", onFocus);
     document.addEventListener("visibilitychange", onVisibility);
     const interval = window.setInterval(tick, 30_000);
     const fetchInterval = window.setInterval(
-      () => void fetchGitRemotesIfDue(),
+      () => void fetchGitRemotesIfDue(tick),
       GIT_FETCH_INTERVAL_MS,
     );
     return () => {

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -4,6 +4,14 @@ import {
   loadCachedStatuses,
   persistStatusesDebounced,
 } from "../gitStatusCache";
+import {
+  loadGitFetchAttempts,
+  persistGitFetchAttemptsDebounced,
+} from "../gitFetchCache";
+import {
+  dueGitFetchPaths,
+  GIT_FETCH_INTERVAL_MS,
+} from "./gitFetchScheduler";
 
 export interface GitStatus {
   branch?: string;
@@ -50,14 +58,17 @@ export interface UseProjectsActions {
  * now — those are entangled with tab management and will move when
  * useTabs is extracted in a follow-up.
  *
- * The git poller ticks immediately on mount, every 30s, and on window
- * focus. A guard ref prevents two overlapping refreshes from running
- * (a long projects list could otherwise fork dozens of git processes
- * on rapid focus toggles).
+ * The git status poller ticks immediately on mount, every 30s, and on window
+ * focus. Remote-tracking refs are refreshed on a separate 10-minute cadence
+ * with persisted attempt timestamps so ahead/behind can catch up without
+ * hammering remotes after reloads or repeated focus toggles. Guard refs prevent
+ * overlapping refresh/fetch batches from forking redundant git processes.
  */
 export function useProjects(ctx: UseProjectsContext): UseProjectsActions {
   const gitStatusRef = useRef<Map<string, GitStatus>>(new Map());
   const gitPollingRef = useRef(false);
+  const gitFetchAttemptsRef = useRef<Map<string, number>>(new Map());
+  const gitFetchInFlightRef = useRef<Set<string>>(new Set());
 
   async function refreshGitStatusFor(path: string): Promise<void> {
     try {
@@ -83,6 +94,42 @@ export function useProjects(ctx: UseProjectsContext): UseProjectsActions {
     // and the project list is capped at 16, so concurrency is bounded.
     // Sequential previously meant the slowest repo gated all the rest.
     await Promise.all(paths.map((p) => refreshGitStatusFor(p)));
+  }
+
+  async function fetchGitRemotesIfDue(): Promise<void> {
+    if (document.hidden) return;
+    const due = dueGitFetchPaths(ctx.getProjectPaths(), {
+      lastAttemptedAt: gitFetchAttemptsRef.current,
+      inFlight: gitFetchInFlightRef.current,
+    });
+    if (due.length === 0) return;
+
+    const startedAt = Date.now();
+    for (const path of due) {
+      gitFetchInFlightRef.current.add(path);
+      gitFetchAttemptsRef.current.set(path, startedAt);
+    }
+    persistGitFetchAttemptsDebounced(gitFetchAttemptsRef.current);
+
+    const results = await Promise.all(
+      due.map(async (path) => {
+        try {
+          return await invoke<boolean>("git_fetch_all", { projectPath: path });
+        } catch {
+          return false;
+        } finally {
+          gitFetchInFlightRef.current.delete(path);
+        }
+      }),
+    );
+
+    // Fetches may mutate remote-tracking refs even when one remote exits
+    // nonzero. Once any fetch ran, run the existing status fan-out so every
+    // surface that reads cached git status (including duplicate worktree rows)
+    // gets refreshed from local metadata.
+    if (results.some(Boolean)) {
+      await refreshAllGitStatus();
+    }
   }
 
   function announceProjectToBridge(tabId: string, cwd: string | null) {
@@ -137,27 +184,41 @@ export function useProjects(ctx: UseProjectsContext): UseProjectsActions {
         }
         ctx.onGitStatusChanged();
       }
+      gitFetchAttemptsRef.current = await loadGitFetchAttempts();
+      if (cancelled) return;
       void tick();
+      void fetchGitRemotesIfDue();
     };
     void bootstrap();
-    const onFocus = () => void tick();
+    const onFocus = () => {
+      void tick();
+      void fetchGitRemotesIfDue();
+    };
     // Refresh when the window becomes visible again (covers restore-from-
     // minimized, which doesn't always fire `focus`), catching up on anything
     // that drifted while polling was paused.
     const onVisibility = () => {
-      if (!document.hidden) void tick();
+      if (!document.hidden) {
+        void tick();
+        void fetchGitRemotesIfDue();
+      }
     };
     window.addEventListener("focus", onFocus);
     document.addEventListener("visibilitychange", onVisibility);
     const interval = window.setInterval(tick, 30_000);
+    const fetchInterval = window.setInterval(
+      () => void fetchGitRemotesIfDue(),
+      GIT_FETCH_INTERVAL_MS,
+    );
     return () => {
       cancelled = true;
       window.clearInterval(interval);
+      window.clearInterval(fetchInterval);
       window.removeEventListener("focus", onFocus);
       document.removeEventListener("visibilitychange", onVisibility);
     };
-    // ctx.getProjectPaths is read inside `tick`, so we deliberately
-    // capture the closure-time reference; the hook is mounted once with
+    // ctx.getProjectPaths is read inside `tick` / `fetchGitRemotesIfDue`,
+    // so we deliberately capture the closure-time reference; the hook is mounted once with
     // a stable ctx for App's lifetime.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);


### PR DESCRIPTION
## Summary
- add a best-effort `git_fetch_all` Tauri command using `git fetch --all --prune --quiet`
- schedule remote fetch attempts from `useProjects` on startup, focus/visibility return, and a 10-minute interval
- persist fetch-attempt timestamps and dedupe project/worktree fetches
- refresh existing git status after fetches so ahead/behind indicators update

Closes #196

## Tests
- `bun run test src/hooks/gitFetchScheduler.test.ts src/hooks/useProjects.test.ts`
- `bun run typecheck`
- `bun run lint`
- `cd src-tauri && cargo fmt --check`
- `cd src-tauri && cargo test commands::git::status::tests --lib`
- `cd src-tauri && cargo test git_fetch_all_is_wired_to_handler --lib`