### PR TITLE
fix(markdown): polish code blocks and editor links

### DIFF
--- a/src/components/HighlightedCode.test.tsx
+++ b/src/components/HighlightedCode.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { HighlightedCode } from "./HighlightedCode";
+
+vi.mock("../utils/highlight", () => ({
+  getCachedHighlight: vi.fn(() => null),
+  highlightCode: vi.fn(() => Promise.resolve(null)),
+}));
+
+describe("HighlightedCode", () => {
+  const writeText = vi.fn();
+
+  beforeEach(() => {
+    writeText.mockReset();
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+  });
+
+  afterEach(() => cleanup());
+
+  it("renders syntax blocks as framed, copyable code", () => {
+    const { container } = render(
+      <HighlightedCode code={"koban --help\n"} language="bash" />,
+    );
+
+    const frame = container.querySelector(".a2ui-code-frame");
+    expect(frame?.getAttribute("data-language")).toBe("bash");
+    expect(screen.getByText("bash").classList.contains("a2ui-code-title")).toBe(
+      true,
+    );
+    expect(container.querySelector("pre.a2ui-code")?.textContent).toBe(
+      "koban --help",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy code" }));
+
+    expect(writeText).toHaveBeenCalledWith("koban --help");
+    expect(screen.getByRole("button", { name: "Copied code" })).not.toBeNull();
+  });
+
+  it("labels unlabeled fenced blocks as text without using the compact text chip", () => {
+    const { container } = render(<HighlightedCode code="plain command" />);
+
+    expect(container.querySelector(".a2ui-code-frame")).not.toBeNull();
+    expect(
+      container
+        .querySelector(".a2ui-code-frame")
+        ?.getAttribute("data-language"),
+    ).toBe("plain");
+    expect(screen.getByText("text").classList.contains("a2ui-code-title")).toBe(
+      true,
+    );
+  });
+
+  it("preserves compact rendering for explicit text primitives", () => {
+    const { container } = render(
+      <HighlightedCode code="/Users/jamesbrink/project" language="text" />,
+    );
+
+    expect(container.querySelector(".a2ui-code-frame")).toBeNull();
+    expect(
+      container.querySelector("pre.a2ui-code")?.getAttribute("data-language"),
+    ).toBe("text");
+  });
+});

--- a/src/components/HighlightedCode.test.tsx
+++ b/src/components/HighlightedCode.test.tsx
@@ -1,6 +1,12 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { HighlightedCode } from "./HighlightedCode";
 
@@ -22,7 +28,7 @@ describe("HighlightedCode", () => {
 
   afterEach(() => cleanup());
 
-  it("renders syntax blocks as framed, copyable code", () => {
+  it("renders syntax blocks as framed, copyable code", async () => {
     const { container } = render(
       <HighlightedCode code={"koban --help\n"} language="bash" />,
     );
@@ -38,8 +44,23 @@ describe("HighlightedCode", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Copy code" }));
 
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Copied code" }),
+      ).not.toBeNull(),
+    );
     expect(writeText).toHaveBeenCalledWith("koban --help");
-    expect(screen.getByRole("button", { name: "Copied code" })).not.toBeNull();
+  });
+
+  it("does not claim copied when the clipboard write rejects", async () => {
+    writeText.mockRejectedValueOnce(new Error("denied"));
+    render(<HighlightedCode code={"koban --help\n"} language="bash" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy code" }));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith("koban --help"));
+    expect(screen.queryByRole("button", { name: "Copied code" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Copy code" })).not.toBeNull();
   });
 
   it("labels unlabeled fenced blocks as text without using the compact text chip", () => {

--- a/src/components/HighlightedCode.tsx
+++ b/src/components/HighlightedCode.tsx
@@ -16,11 +16,14 @@ function trimSingleTrailingNewline(s: string): string {
   return s.endsWith("\n") ? s.slice(0, -1) : s;
 }
 
-function copyText(text: string): void {
+async function copyText(text: string): Promise<boolean> {
+  if (!navigator.clipboard?.writeText) return false;
   try {
-    void navigator.clipboard?.writeText(text);
+    await navigator.clipboard.writeText(text);
+    return true;
   } catch {
     // Clipboard availability is host/browser dependent; the block remains selectable.
+    return false;
   }
 }
 
@@ -111,15 +114,17 @@ export function HighlightedCode({
           aria-label={copied ? "Copied code" : "Copy code"}
           title={copied ? "Copied" : "Copy code"}
           onClick={() => {
-            copyText(text);
-            setCopied(true);
-            if (copyResetTimer.current != null) {
-              window.clearTimeout(copyResetTimer.current);
-            }
-            copyResetTimer.current = window.setTimeout(() => {
-              setCopied(false);
-              copyResetTimer.current = null;
-            }, 1200);
+            void copyText(text).then((ok) => {
+              if (!ok) return;
+              setCopied(true);
+              if (copyResetTimer.current != null) {
+                window.clearTimeout(copyResetTimer.current);
+              }
+              copyResetTimer.current = window.setTimeout(() => {
+                setCopied(false);
+                copyResetTimer.current = null;
+              }, 1200);
+            });
           }}
         />
       </div>

--- a/src/components/HighlightedCode.tsx
+++ b/src/components/HighlightedCode.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useReducer } from "react";
+import { useEffect, useReducer, useRef, useState } from "react";
 import { getCachedHighlight, highlightCode } from "../utils/highlight";
 
 interface HighlightedCodeProps {
@@ -14,6 +14,14 @@ interface HighlightedCodeProps {
 // bottom of every block.
 function trimSingleTrailingNewline(s: string): string {
   return s.endsWith("\n") ? s.slice(0, -1) : s;
+}
+
+function copyText(text: string): void {
+  try {
+    void navigator.clipboard?.writeText(text);
+  } catch {
+    // Clipboard availability is host/browser dependent; the block remains selectable.
+  }
 }
 
 // Worker-backed Shiki highlighter (same pattern as Claudette's chat).
@@ -32,7 +40,10 @@ export function HighlightedCode({
 }: HighlightedCodeProps) {
   const text = trimSingleTrailingNewline(code);
   const lang = (language ?? "").toLowerCase();
+  const displayLang = lang || "text";
   const cached = lang ? getCachedHighlight(text, lang) : null;
+  const copyResetTimer = useRef<number | null>(null);
+  const [copied, setCopied] = useState(false);
   const [, forceUpdate] = useReducer((n: number) => n + 1, 0);
 
   useEffect(() => {
@@ -49,6 +60,14 @@ export function HighlightedCode({
     // cache is reset between renders.
   }, [text, lang, cached]);
 
+  useEffect(() => {
+    return () => {
+      if (copyResetTimer.current != null) {
+        window.clearTimeout(copyResetTimer.current);
+      }
+    };
+  }, []);
+
   if (inline) {
     if (cached != null) {
       return (
@@ -63,18 +82,54 @@ export function HighlightedCode({
     );
   }
 
+  const codeEl =
+    cached != null ? (
+      <code dangerouslySetInnerHTML={{ __html: cached }} />
+    ) : (
+      <code>{text}</code>
+    );
+
+  if (lang === "text" && !showLineNumbers) {
+    return (
+      <pre className={`a2ui-code ${className ?? ""}`} data-language="text">
+        {codeEl}
+      </pre>
+    );
+  }
+
   return (
-    <pre
-      className={`a2ui-code ${className ?? ""}`}
-      data-language={language ?? lang}
-      data-show-lineno={showLineNumbers ? "true" : undefined}
+    <div
+      className={`a2ui-code-frame ${className ?? ""}`}
+      data-language={lang || "plain"}
     >
-      {language && <span className="a2ui-code-lang">{language}</span>}
-      {cached != null ? (
-        <code dangerouslySetInnerHTML={{ __html: cached }} />
-      ) : (
-        <code>{text}</code>
-      )}
-    </pre>
+      <div className="a2ui-code-header">
+        <span className="a2ui-code-title">{displayLang}</span>
+        <button
+          type="button"
+          className="a2ui-code-copy"
+          data-copied={copied ? "true" : undefined}
+          aria-label={copied ? "Copied code" : "Copy code"}
+          title={copied ? "Copied" : "Copy code"}
+          onClick={() => {
+            copyText(text);
+            setCopied(true);
+            if (copyResetTimer.current != null) {
+              window.clearTimeout(copyResetTimer.current);
+            }
+            copyResetTimer.current = window.setTimeout(() => {
+              setCopied(false);
+              copyResetTimer.current = null;
+            }, 1200);
+          }}
+        />
+      </div>
+      <pre
+        className="a2ui-code"
+        data-language={lang || "plain"}
+        data-show-lineno={showLineNumbers ? "true" : undefined}
+      >
+        {codeEl}
+      </pre>
+    </div>
   );
 }

--- a/src/eventRoutes/editor.test.ts
+++ b/src/eventRoutes/editor.test.ts
@@ -76,6 +76,36 @@ describe("handleEditorCanvas", () => {
     });
   });
 
+  it("opens markdown preview file links in an editor tab", async () => {
+    const fx = buildRouteFixture();
+    const claimed = await handleEditorCanvas(
+      editorEvent("markdown-link-open", {
+        tabId: "tab-1",
+        filePath: "/projects/aethon/docs/api.md",
+        rootPath: "/projects/aethon",
+      }),
+      fx.ctx,
+    );
+    expect(claimed).toBe(true);
+    expect(fx.mocks.newEditorTab).toHaveBeenCalledWith(
+      "/projects/aethon/docs/api.md",
+      { rootPath: "/projects/aethon" },
+    );
+  });
+
+  it("claims empty markdown link events without opening a tab", async () => {
+    const fx = buildRouteFixture();
+    const claimed = await handleEditorCanvas(
+      editorEvent("markdown-link-open", {
+        tabId: "tab-1",
+        rootPath: "/projects/aethon",
+      }),
+      fx.ctx,
+    );
+    expect(claimed).toBe(true);
+    expect(fx.mocks.newEditorTab).not.toHaveBeenCalled();
+  });
+
   it("invokes fs_write_file on editor-save and clears dirty", async () => {
     const fx = buildRouteFixture({
       state: { project: { path: "/projects/aethon" } },
@@ -210,8 +240,9 @@ describe("handleFileTree", () => {
     const next = fx.applySetState({
       layout: { columns: "220px minmax(0,1fr) 360px" },
     });
-    expect((next.layout as { columns: string; lastRightWidth: string }).columns)
-      .toBe("220px minmax(0,1fr) 640px");
+    expect(
+      (next.layout as { columns: string; lastRightWidth: string }).columns,
+    ).toBe("220px minmax(0,1fr) 640px");
     expect((next.layout as { lastRightWidth: string }).lastRightWidth).toBe(
       "640px",
     );

--- a/src/eventRoutes/editor.ts
+++ b/src/eventRoutes/editor.ts
@@ -8,6 +8,8 @@
  *   - `editor-loaded`  — file fully populated from disk; clears dirty.
  *   - `editor-save`    — Cmd+S; writes content via fs_write_file and
  *                        clears dirty on success.
+ *   - `markdown-link-open` — preview/Monaco markdown link resolved to a
+ *                            project file; opens it in an editor tab.
  *
  * The file-tree sidebar section (`type:file-tree`) emits a single
  * `file-tree-open` event to open / focus an editor tab.
@@ -76,6 +78,16 @@ export const handleEditorCanvas: EventRouteHandler = async (
       // "Edit file" affordance in the diff view: drop the diff flag so
       // this tab becomes the editable Monaco editor for the same path.
       ctx.updateEditorMeta(tabId, { diff: false });
+      return true;
+    }
+    case "markdown-link-open": {
+      const filePath =
+        typeof payload.filePath === "string" ? payload.filePath : "";
+      if (!filePath) return true;
+      const rootPath =
+        typeof payload.rootPath === "string" ? payload.rootPath : "";
+      if (rootPath) ctx.newEditorTab(filePath, { rootPath });
+      else ctx.newEditorTab(filePath);
       return true;
     }
     case "editor-close": {

--- a/src/extensions/default-layout/editor/canvas.tsx
+++ b/src/extensions/default-layout/editor/canvas.tsx
@@ -30,6 +30,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { openUrl } from "@tauri-apps/plugin-opener";
 import * as monaco from "monaco-editor";
 
 import type { StringValue } from "../../../types/a2ui";
@@ -52,6 +53,7 @@ import { createEditorActions, type EditorActions } from "./editorActions";
 import { useEditorViewSettings } from "./useEditorViewSettings";
 import { useEditorExternalChange } from "./useEditorExternalChange";
 import { monacoOptionsFor } from "./viewSettings";
+import { handleEditorLinkOpen } from "./link-openers";
 
 /** Read the shared `--scrollbar-size` token (px) so Monaco's scrollbar
  *  matches the terminal + WebKit scrollbars. Falls back to 4px. */
@@ -86,7 +88,11 @@ interface EditorTabLike {
   };
 }
 
-export function EditorCanvas({ component, state, onEvent }: BuiltinComponentProps) {
+export function EditorCanvas({
+  component,
+  state,
+  onEvent,
+}: BuiltinComponentProps) {
   const props = component.props as {
     tabId?: StringValue;
   };
@@ -134,7 +140,10 @@ export function EditorCanvas({ component, state, onEvent }: BuiltinComponentProp
     isDiffRef.current = editorMeta?.diff === true;
   }, [editorMeta?.diff]);
   const [loadError, setLoadError] = useState<string>("");
-  const [cursorDisplay, setCursorDisplay] = useState<{ line: number; column: number }>({
+  const [cursorDisplay, setCursorDisplay] = useState<{
+    line: number;
+    column: number;
+  }>({
     line: 1,
     column: 1,
   });
@@ -234,6 +243,22 @@ export function EditorCanvas({ component, state, onEvent }: BuiltinComponentProp
     });
     editorRef.current = ed;
 
+    const linkOpenerDisposable = monaco.editor.registerLinkOpener({
+      open: (resource) =>
+        handleEditorLinkOpen(resource, {
+          currentTabId: currentTabIdRef.current,
+          projectPath: projectPathRef.current,
+          openExternalUrl: openUrl,
+          openMarkdownFile: ({ tabId, filePath, rootPath }) => {
+            onEventRef.current("markdown-link-open", {
+              tabId,
+              filePath,
+              rootPath,
+            });
+          },
+        }),
+    });
+
     // Build the menubar actions now that the editor exists. The closures
     // bind the stable refs, so this object stays valid across tab swaps.
     setActions(
@@ -249,7 +274,10 @@ export function EditorCanvas({ component, state, onEvent }: BuiltinComponentProp
     );
 
     const positionDisposable = ed.onDidChangeCursorPosition((e) => {
-      setCursorDisplay({ line: e.position.lineNumber, column: e.position.column });
+      setCursorDisplay({
+        line: e.position.lineNumber,
+        column: e.position.column,
+      });
       const tid = currentTabIdRef.current;
       if (!tid) return;
       onEventRef.current("editor-cursor", {
@@ -314,6 +342,7 @@ export function EditorCanvas({ component, state, onEvent }: BuiltinComponentProp
         const buf = getEditorBuffer(tid);
         if (buf) buf.viewState = ed.saveViewState();
       }
+      linkOpenerDisposable.dispose();
       positionDisposable.dispose();
       contentDisposable.dispose();
       ed.dispose();
@@ -445,7 +474,10 @@ export function EditorCanvas({ component, state, onEvent }: BuiltinComponentProp
     const apply = () => applyMonacoTheme(root.dataset.theme);
     apply();
     const observer = new MutationObserver(apply);
-    observer.observe(root, { attributes: true, attributeFilter: ["data-theme"] });
+    observer.observe(root, {
+      attributes: true,
+      attributeFilter: ["data-theme"],
+    });
     return () => observer.disconnect();
   }, []);
 
@@ -487,7 +519,8 @@ export function EditorCanvas({ component, state, onEvent }: BuiltinComponentProp
     const ed = editorRef.current;
     if (!ed) return;
     const collection =
-      gutterRef.current ?? (gutterRef.current = ed.createDecorationsCollection());
+      gutterRef.current ??
+      (gutterRef.current = ed.createDecorationsCollection());
     if (!showMonaco || !tabId || !editorMeta?.filePath || !projectPath) {
       collection.clear();
       return;
@@ -600,7 +633,9 @@ export function EditorCanvas({ component, state, onEvent }: BuiltinComponentProp
         />
       )}
       {showMonaco && loadError && (
-        <div className="ae-editor-canvas-error">Failed to load file: {loadError}</div>
+        <div className="ae-editor-canvas-error">
+          Failed to load file: {loadError}
+        </div>
       )}
       {showMonaco && (
         <EditorStatusBar
@@ -637,7 +672,11 @@ function EditorStatusBar({
         {shortPath}
       </span>
       {isDirty && (
-        <span className="ae-editor-status-dirty" title="Unsaved changes" aria-label="Unsaved changes">
+        <span
+          className="ae-editor-status-dirty"
+          title="Unsaved changes"
+          aria-label="Unsaved changes"
+        >
           •
         </span>
       )}
@@ -645,7 +684,9 @@ function EditorStatusBar({
       <span className="ae-editor-status-pos">
         Ln {line}, Col {column}
       </span>
-      <span className="ae-editor-status-sep" aria-hidden="true">·</span>
+      <span className="ae-editor-status-sep" aria-hidden="true">
+        ·
+      </span>
       <span className="ae-editor-status-lang">{language}</span>
     </div>
   );

--- a/src/extensions/default-layout/editor/link-openers.test.ts
+++ b/src/extensions/default-layout/editor/link-openers.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from "vitest";
+import { handleEditorLinkOpen, type EditorLinkResource } from "./link-openers";
+
+const resource = (
+  scheme: string,
+  value: Partial<EditorLinkResource> = {},
+): EditorLinkResource => {
+  const ownToString = Object.prototype.hasOwnProperty.call(value, "toString")
+    ? value.toString
+    : undefined;
+  return {
+    scheme,
+    path: value.path ?? "",
+    fsPath: value.fsPath,
+    toString: ownToString ?? (() => `${scheme}://example.test/path`),
+  };
+};
+
+describe("handleEditorLinkOpen", () => {
+  it("opens http and https links through the system opener", async () => {
+    const openExternalUrl = vi.fn(() => Promise.resolve());
+    const openMarkdownFile = vi.fn();
+
+    await expect(
+      handleEditorLinkOpen(resource("https"), {
+        currentTabId: "tab-1",
+        projectPath: "/repo",
+        openExternalUrl,
+        openMarkdownFile,
+      }),
+    ).resolves.toBe(true);
+
+    expect(openExternalUrl).toHaveBeenCalledWith("https://example.test/path");
+    expect(openMarkdownFile).not.toHaveBeenCalled();
+  });
+
+  it("still claims external links when the system opener fails", async () => {
+    const openExternalUrl = vi.fn(() => Promise.reject(new Error("no opener")));
+    const openMarkdownFile = vi.fn();
+
+    await expect(
+      handleEditorLinkOpen(resource("http"), {
+        currentTabId: "tab-1",
+        projectPath: "/repo",
+        openExternalUrl,
+        openMarkdownFile,
+      }),
+    ).resolves.toBe(true);
+
+    expect(openMarkdownFile).not.toHaveBeenCalled();
+  });
+
+  it("routes file links back through the editor tab opener", async () => {
+    const openExternalUrl = vi.fn(() => Promise.resolve());
+    const openMarkdownFile = vi.fn();
+
+    await expect(
+      handleEditorLinkOpen(resource("file", { path: "/repo/docs/api.md" }), {
+        currentTabId: "tab-1",
+        projectPath: "/repo",
+        openExternalUrl,
+        openMarkdownFile,
+      }),
+    ).resolves.toBe(true);
+
+    expect(openMarkdownFile).toHaveBeenCalledWith({
+      tabId: "tab-1",
+      filePath: "/repo/docs/api.md",
+      rootPath: "/repo",
+    });
+    expect(openExternalUrl).not.toHaveBeenCalled();
+  });
+
+  it("prefers fsPath for platform-normalized file links", async () => {
+    const openMarkdownFile = vi.fn();
+
+    await handleEditorLinkOpen(
+      resource("file", {
+        path: "/repo/docs/api.md",
+        fsPath: "C:\\repo\\docs\\api.md",
+      }),
+      {
+        currentTabId: "tab-1",
+        projectPath: "C:\\repo",
+        openExternalUrl: vi.fn(() => Promise.resolve()),
+        openMarkdownFile,
+      },
+    );
+
+    expect(openMarkdownFile).toHaveBeenCalledWith({
+      tabId: "tab-1",
+      filePath: "C:\\repo\\docs\\api.md",
+      rootPath: "C:\\repo",
+    });
+  });
+
+  it("declines file links when there is no active editor tab", async () => {
+    const openMarkdownFile = vi.fn();
+
+    await expect(
+      handleEditorLinkOpen(resource("file", { path: "/repo/docs/api.md" }), {
+        currentTabId: "",
+        projectPath: "/repo",
+        openExternalUrl: vi.fn(() => Promise.resolve()),
+        openMarkdownFile,
+      }),
+    ).resolves.toBe(false);
+
+    expect(openMarkdownFile).not.toHaveBeenCalled();
+  });
+
+  it("declines schemes Monaco can handle elsewhere", async () => {
+    await expect(
+      handleEditorLinkOpen(resource("mailto"), {
+        currentTabId: "tab-1",
+        projectPath: "/repo",
+        openExternalUrl: vi.fn(() => Promise.resolve()),
+        openMarkdownFile: vi.fn(),
+      }),
+    ).resolves.toBe(false);
+  });
+});

--- a/src/extensions/default-layout/editor/link-openers.ts
+++ b/src/extensions/default-layout/editor/link-openers.ts
@@ -1,0 +1,45 @@
+export interface EditorLinkResource {
+  scheme: string;
+  path: string;
+  fsPath?: string;
+  toString(): string;
+}
+
+export interface EditorLinkOpenDeps {
+  currentTabId: string;
+  projectPath: string;
+  openExternalUrl: (url: string) => Promise<void>;
+  openMarkdownFile: (data: {
+    tabId: string;
+    filePath: string;
+    rootPath: string;
+  }) => void;
+}
+
+export async function handleEditorLinkOpen(
+  resource: EditorLinkResource,
+  deps: EditorLinkOpenDeps,
+): Promise<boolean> {
+  const scheme = resource.scheme.toLowerCase();
+  if (scheme === "http" || scheme === "https") {
+    try {
+      await deps.openExternalUrl(resource.toString());
+    } catch {
+      /* opener failures are not actionable from Monaco's link UI */
+    }
+    return true;
+  }
+
+  if (scheme === "file") {
+    const filePath = resource.fsPath || resource.path;
+    if (!deps.currentTabId || !filePath) return false;
+    deps.openMarkdownFile({
+      tabId: deps.currentTabId,
+      filePath,
+      rootPath: deps.projectPath,
+    });
+    return true;
+  }
+
+  return false;
+}

--- a/src/extensions/default-layout/editor/markdown-links.ts
+++ b/src/extensions/default-layout/editor/markdown-links.ts
@@ -73,3 +73,14 @@ export function resolveMarkdownLinkPath(
   if (!baseDir) return normalizePath(decoded);
   return normalizePath(`${baseDir.replace(/\/+$/, "")}/${decoded}`);
 }
+
+export function safeExternalHttpUrl(value: string | undefined): string | null {
+  if (!value) return null;
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    return url.href;
+  } catch {
+    return null;
+  }
+}

--- a/src/extensions/default-layout/editor/markdown-links.ts
+++ b/src/extensions/default-layout/editor/markdown-links.ts
@@ -5,9 +5,12 @@ function dirname(path: string): string {
 }
 
 function normalizePath(path: string): string {
-  const absolute = path.startsWith("/");
+  const slashed = path.replace(/\\/g, "/");
+  const drive = /^[A-Za-z]:/.exec(slashed)?.[0] ?? "";
+  const body = drive ? slashed.slice(drive.length) : slashed;
+  const absolute = Boolean(drive) || body.startsWith("/");
   const parts: string[] = [];
-  for (const part of path.replace(/\\/g, "/").split("/")) {
+  for (const part of body.split("/")) {
     if (!part || part === ".") continue;
     if (part === "..") {
       parts.pop();
@@ -15,7 +18,8 @@ function normalizePath(path: string): string {
     }
     parts.push(part);
   }
-  return `${absolute ? "/" : ""}${parts.join("/")}`;
+  const prefix = drive ? `${drive}/` : absolute ? "/" : "";
+  return `${prefix}${parts.join("/")}`;
 }
 
 function stripHashAndQuery(href: string): string {
@@ -38,6 +42,20 @@ function decodeHrefPath(href: string): string | null {
   }
 }
 
+function isInsideRoot(path: string, root: string): boolean {
+  const normalizedPath = normalizePath(path).replace(/\/+$/, "");
+  const normalizedRoot = normalizePath(root).replace(/\/+$/, "");
+  if (!normalizedRoot) return true;
+  const caseInsensitive = /^[A-Za-z]:/.test(normalizedRoot);
+  const candidate = caseInsensitive
+    ? normalizedPath.toLowerCase()
+    : normalizedPath;
+  const boundary = caseInsensitive
+    ? normalizedRoot.toLowerCase()
+    : normalizedRoot;
+  return candidate === boundary || candidate.startsWith(`${boundary}/`);
+}
+
 export function resolveMarkdownLinkPath(
   href: string | undefined,
   currentFilePath: string,
@@ -50,7 +68,8 @@ export function resolveMarkdownLinkPath(
   if (!withoutFragment) return null;
 
   let linkPath = withoutFragment;
-  if (linkPath.startsWith("file://")) {
+  const fileUrl = linkPath.startsWith("file://");
+  if (fileUrl) {
     try {
       linkPath = new URL(linkPath).pathname;
     } catch {
@@ -61,17 +80,25 @@ export function resolveMarkdownLinkPath(
   const decoded = decodeHrefPath(linkPath);
   if (!decoded) return null;
 
-  const projectRoot = projectPath.replace(/\/+$/, "");
+  const projectRoot = normalizePath(projectPath).replace(/\/+$/, "");
+  let resolved: string;
   if (decoded.startsWith("/")) {
-    if (projectRoot && !decoded.startsWith(`${projectRoot}/`)) {
-      return normalizePath(`${projectRoot}${decoded}`);
+    const normalizedDecoded = normalizePath(decoded);
+    if (projectRoot && !isInsideRoot(normalizedDecoded, projectRoot)) {
+      if (fileUrl) return null;
+      resolved = normalizePath(`${projectRoot}${normalizedDecoded}`);
+    } else {
+      resolved = normalizedDecoded;
     }
-    return normalizePath(decoded);
+  } else {
+    const baseDir = dirname(currentFilePath) || projectRoot;
+    resolved = baseDir
+      ? normalizePath(`${baseDir.replace(/\/+$/, "")}/${decoded}`)
+      : normalizePath(decoded);
   }
 
-  const baseDir = dirname(currentFilePath) || projectPath;
-  if (!baseDir) return normalizePath(decoded);
-  return normalizePath(`${baseDir.replace(/\/+$/, "")}/${decoded}`);
+  if (projectRoot && !isInsideRoot(resolved, projectRoot)) return null;
+  return resolved;
 }
 
 export function safeExternalHttpUrl(value: string | undefined): string | null {

--- a/src/extensions/default-layout/editor/markdown-links.ts
+++ b/src/extensions/default-layout/editor/markdown-links.ts
@@ -1,0 +1,75 @@
+function dirname(path: string): string {
+  const normalized = path.replace(/\\/g, "/");
+  const idx = normalized.lastIndexOf("/");
+  return idx <= 0 ? "" : normalized.slice(0, idx);
+}
+
+function normalizePath(path: string): string {
+  const absolute = path.startsWith("/");
+  const parts: string[] = [];
+  for (const part of path.replace(/\\/g, "/").split("/")) {
+    if (!part || part === ".") continue;
+    if (part === "..") {
+      parts.pop();
+      continue;
+    }
+    parts.push(part);
+  }
+  return `${absolute ? "/" : ""}${parts.join("/")}`;
+}
+
+function stripHashAndQuery(href: string): string {
+  const hashIdx = href.indexOf("#");
+  const queryIdx = href.indexOf("?");
+  const indexes = [hashIdx, queryIdx].filter((idx) => idx >= 0);
+  if (indexes.length === 0) return href;
+  return href.slice(0, Math.min(...indexes));
+}
+
+function hasExternalScheme(href: string): boolean {
+  return /^[a-z][a-z0-9+.-]*:/i.test(href) && !href.startsWith("file:");
+}
+
+function decodeHrefPath(href: string): string | null {
+  try {
+    return decodeURIComponent(href);
+  } catch {
+    return null;
+  }
+}
+
+export function resolveMarkdownLinkPath(
+  href: string | undefined,
+  currentFilePath: string,
+  projectPath: string,
+): string | null {
+  const raw = (href ?? "").trim();
+  if (!raw || raw.startsWith("#") || hasExternalScheme(raw)) return null;
+
+  const withoutFragment = stripHashAndQuery(raw);
+  if (!withoutFragment) return null;
+
+  let linkPath = withoutFragment;
+  if (linkPath.startsWith("file://")) {
+    try {
+      linkPath = new URL(linkPath).pathname;
+    } catch {
+      return null;
+    }
+  }
+
+  const decoded = decodeHrefPath(linkPath);
+  if (!decoded) return null;
+
+  const projectRoot = projectPath.replace(/\/+$/, "");
+  if (decoded.startsWith("/")) {
+    if (projectRoot && !decoded.startsWith(`${projectRoot}/`)) {
+      return normalizePath(`${projectRoot}${decoded}`);
+    }
+    return normalizePath(decoded);
+  }
+
+  const baseDir = dirname(currentFilePath) || projectPath;
+  if (!baseDir) return normalizePath(decoded);
+  return normalizePath(`${baseDir.replace(/\/+$/, "")}/${decoded}`);
+}

--- a/src/extensions/default-layout/editor/markdown-preview.test.tsx
+++ b/src/extensions/default-layout/editor/markdown-preview.test.tsx
@@ -112,6 +112,46 @@ describe("resolveMarkdownLinkPath", () => {
     ).toBe("/repo/docs/My API.md");
   });
 
+  it("rejects relative links that escape the project root", () => {
+    expect(
+      resolveMarkdownLinkPath(
+        "../../../../etc/passwd",
+        "/repo/docs/guides/api.md",
+        "/repo",
+      ),
+    ).toBeNull();
+  });
+
+  it("rejects file urls outside the project root", () => {
+    expect(
+      resolveMarkdownLinkPath("file:///etc/passwd", "/repo/README.md", "/repo"),
+    ).toBeNull();
+  });
+
+  it("handles Windows-style project roots", () => {
+    expect(
+      resolveMarkdownLinkPath(
+        "docs\\api.md",
+        "C:\\repo\\README.md",
+        "C:\\repo\\",
+      ),
+    ).toBe("C:/repo/docs/api.md");
+    expect(
+      resolveMarkdownLinkPath(
+        "..\\secrets.md",
+        "C:\\repo\\docs\\api.md",
+        "C:\\repo\\",
+      ),
+    ).toBe("C:/repo/secrets.md");
+    expect(
+      resolveMarkdownLinkPath(
+        "..\\..\\Windows\\win.ini",
+        "C:\\repo\\docs\\api.md",
+        "C:\\repo\\",
+      ),
+    ).toBeNull();
+  });
+
   it("declines hash-only and external links", () => {
     expect(
       resolveMarkdownLinkPath("#releases", "/repo/README.md", "/repo"),
@@ -232,6 +272,24 @@ describe("MarkdownPreview", () => {
       filePath: "/repo/docs/invoice-ninja-api.md",
       rootPath: "/repo",
     });
+  });
+
+  it("keeps local markdown links from navigating when no tab id is bound", async () => {
+    const { onEvent } = renderMarkdownPreview(
+      "See [API notes](docs/invoice-ninja-api.md).",
+      {
+        filePath: "/repo/README.md",
+        projectPath: "/repo",
+        tabId: "",
+      },
+    );
+
+    const link = await screen.findByRole("link", { name: "API notes" });
+    const allowed = fireEvent.click(link);
+
+    expect(allowed).toBe(false);
+    expect(onEvent).not.toHaveBeenCalled();
+    expect(openUrl).not.toHaveBeenCalled();
   });
 
   it("opens external markdown links through the system opener", async () => {

--- a/src/extensions/default-layout/editor/markdown-preview.test.tsx
+++ b/src/extensions/default-layout/editor/markdown-preview.test.tsx
@@ -8,6 +8,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { invoke } from "@tauri-apps/api/core";
+import { openUrl } from "@tauri-apps/plugin-opener";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveMarkdownLinkPath } from "./markdown-links";
 import { MarkdownPreview } from "./markdown-preview";
@@ -128,6 +129,8 @@ describe("resolveMarkdownLinkPath", () => {
 describe("MarkdownPreview", () => {
   beforeEach(() => {
     vi.mocked(invoke).mockReset();
+    vi.mocked(openUrl).mockReset();
+    vi.mocked(openUrl).mockResolvedValue(undefined);
   });
 
   afterEach(() => cleanup());
@@ -231,7 +234,7 @@ describe("MarkdownPreview", () => {
     });
   });
 
-  it("leaves external markdown links as normal links", async () => {
+  it("opens external markdown links through the system opener", async () => {
     const { onEvent } = renderMarkdownPreview(
       "See [release-plz](https://release-plz.dev).",
       {
@@ -242,11 +245,9 @@ describe("MarkdownPreview", () => {
     );
 
     const link = await screen.findByRole("link", { name: "release-plz" });
-    link.addEventListener("click", (event) => event.preventDefault(), {
-      once: true,
-    });
     fireEvent.click(link);
 
+    expect(openUrl).toHaveBeenCalledWith("https://release-plz.dev/");
     expect(onEvent).not.toHaveBeenCalled();
   });
 });

--- a/src/extensions/default-layout/editor/markdown-preview.test.tsx
+++ b/src/extensions/default-layout/editor/markdown-preview.test.tsx
@@ -1,8 +1,15 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { invoke } from "@tauri-apps/api/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveMarkdownLinkPath } from "./markdown-links";
 import { MarkdownPreview } from "./markdown-preview";
 import type { A2UIComponent } from "../../../types/a2ui";
 
@@ -25,28 +32,98 @@ const readmeMarkdown = `<p align="center"><img src="assets/logo.png" alt="Claude
 - [ ] Escape unsafe HTML
 `;
 
-function markdownPreviewComponent(props?: Record<string, unknown>): A2UIComponent {
+function markdownPreviewComponent(
+  props?: Record<string, unknown>,
+): A2UIComponent {
   return {
     id: "markdown-preview",
     type: "markdown-preview",
     props: {
-      filePath: "README.md",
+      filePath: "/repo/README.md",
       projectPath: "/repo",
       ...props,
     },
   };
 }
 
-function renderMarkdownPreview(markdown: string) {
+function renderMarkdownPreview(
+  markdown: string,
+  props?: Record<string, unknown>,
+) {
   vi.mocked(invoke).mockResolvedValueOnce(markdown);
-  return render(
-    <MarkdownPreview
-      component={markdownPreviewComponent()}
-      state={{}}
-      onEvent={vi.fn()}
-    />,
-  );
+  const onEvent = vi.fn();
+  return {
+    ...render(
+      <MarkdownPreview
+        component={markdownPreviewComponent(props)}
+        state={{}}
+        onEvent={onEvent}
+      />,
+    ),
+    onEvent,
+  };
 }
+
+describe("resolveMarkdownLinkPath", () => {
+  it("resolves relative links from the current markdown file", () => {
+    expect(
+      resolveMarkdownLinkPath(
+        "docs/invoice-ninja-api.md",
+        "/repo/README.md",
+        "/repo",
+      ),
+    ).toBe("/repo/docs/invoice-ninja-api.md");
+  });
+
+  it("normalizes parent directory links and strips fragments", () => {
+    expect(
+      resolveMarkdownLinkPath(
+        "../README.md#releases",
+        "/repo/docs/api.md",
+        "/repo",
+      ),
+    ).toBe("/repo/README.md");
+  });
+
+  it("treats root-relative links as project-relative when needed", () => {
+    expect(
+      resolveMarkdownLinkPath("/docs/api.md", "/repo/README.md", "/repo"),
+    ).toBe("/repo/docs/api.md");
+  });
+
+  it("keeps absolute file links that are already under the project root", () => {
+    expect(
+      resolveMarkdownLinkPath(
+        "/repo/docs/api.md?plain=1",
+        "/repo/README.md",
+        "/repo",
+      ),
+    ).toBe("/repo/docs/api.md");
+  });
+
+  it("decodes file urls and escaped paths", () => {
+    expect(
+      resolveMarkdownLinkPath(
+        "file:///repo/docs/My%20API.md",
+        "/repo/README.md",
+        "/repo",
+      ),
+    ).toBe("/repo/docs/My API.md");
+  });
+
+  it("declines hash-only and external links", () => {
+    expect(
+      resolveMarkdownLinkPath("#releases", "/repo/README.md", "/repo"),
+    ).toBeNull();
+    expect(
+      resolveMarkdownLinkPath(
+        "https://release-plz.dev",
+        "/repo/README.md",
+        "/repo",
+      ),
+    ).toBeNull();
+  });
+});
 
 describe("MarkdownPreview", () => {
   beforeEach(() => {
@@ -54,6 +131,17 @@ describe("MarkdownPreview", () => {
   });
 
   afterEach(() => cleanup());
+
+  it("loads markdown through fs_read_file", async () => {
+    renderMarkdownPreview("# Hello");
+
+    await screen.findByRole("heading", { name: "Hello" });
+
+    expect(invoke).toHaveBeenCalledWith("fs_read_file", {
+      root: "/repo",
+      path: "/repo/README.md",
+    });
+  });
 
   it("renders GitHub README raw HTML through the shared markdown styling", async () => {
     const { container } = renderMarkdownPreview(readmeMarkdown);
@@ -77,17 +165,36 @@ describe("MarkdownPreview", () => {
   it("uses GFM plugins for tables and task lists", async () => {
     const { container } = renderMarkdownPreview(readmeMarkdown);
 
-    await waitFor(() => expect(container.querySelector("table")).not.toBeNull());
+    await waitFor(() =>
+      expect(container.querySelector("table")).not.toBeNull(),
+    );
 
     expect(container.querySelector("thead th")?.textContent).toBe("Feature");
     expect(container.querySelector("tbody td")?.textContent).toBe("Preview");
-
     const checkboxes = container.querySelectorAll<HTMLInputElement>(
       'input[type="checkbox"]',
     );
     expect(checkboxes).toHaveLength(2);
     expect(checkboxes.item(0).checked).toBe(true);
     expect(checkboxes.item(1).checked).toBe(false);
+  });
+
+  it("renders unlabeled fenced code through the shared code frame", async () => {
+    const { container } = renderMarkdownPreview(
+      "Current CLI\n\n```\nkoban --help\nkoban completions zsh\n```\n",
+    );
+
+    await waitFor(() =>
+      expect(container.querySelector(".a2ui-code-frame")).not.toBeNull(),
+    );
+
+    const frame = container.querySelector(".a2ui-code-frame");
+    expect(frame?.getAttribute("data-language")).toBe("plain");
+    expect(frame?.querySelector(".a2ui-code-title")?.textContent).toBe("text");
+    expect(frame?.querySelector("pre.a2ui-code")?.textContent).toContain(
+      "koban completions zsh",
+    );
+    expect(frame?.querySelector("button.a2ui-code-copy")).not.toBeNull();
   });
 
   it("sanitizes unsafe raw HTML while preserving README-safe tags", async () => {
@@ -98,7 +205,48 @@ describe("MarkdownPreview", () => {
     await screen.findByRole("heading", { name: "Claudette", level: 1 });
 
     expect(container.querySelector("script")).toBeNull();
-    expect(container.textContent).not.toContain("alert(\"x\")");
-    expect(container.querySelector('img[alt="bad"]')?.getAttribute("src")).toBeNull();
+    expect(container.textContent).not.toContain('alert("x")');
+    expect(
+      container.querySelector('img[alt="bad"]')?.getAttribute("src"),
+    ).toBeNull();
+  });
+
+  it("opens relative markdown links in Monaco via the editor route", async () => {
+    const { onEvent } = renderMarkdownPreview(
+      "See [API notes](docs/invoice-ninja-api.md).",
+      {
+        filePath: "/repo/README.md",
+        projectPath: "/repo",
+        tabId: "editor-1",
+      },
+    );
+
+    const link = await screen.findByRole("link", { name: "API notes" });
+    fireEvent.click(link);
+
+    expect(onEvent).toHaveBeenCalledWith("markdown-link-open", {
+      tabId: "editor-1",
+      filePath: "/repo/docs/invoice-ninja-api.md",
+      rootPath: "/repo",
+    });
+  });
+
+  it("leaves external markdown links as normal links", async () => {
+    const { onEvent } = renderMarkdownPreview(
+      "See [release-plz](https://release-plz.dev).",
+      {
+        filePath: "/repo/README.md",
+        projectPath: "/repo",
+        tabId: "editor-1",
+      },
+    );
+
+    const link = await screen.findByRole("link", { name: "release-plz" });
+    link.addEventListener("click", (event) => event.preventDefault(), {
+      once: true,
+    });
+    fireEvent.click(link);
+
+    expect(onEvent).not.toHaveBeenCalled();
   });
 });

--- a/src/extensions/default-layout/editor/markdown-preview.tsx
+++ b/src/extensions/default-layout/editor/markdown-preview.tsx
@@ -24,12 +24,13 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { openUrl } from "@tauri-apps/plugin-opener";
 import ReactMarkdown from "react-markdown";
 import type { Options as ReactMarkdownOptions } from "react-markdown";
 
 import type { BuiltinComponentProps } from "../../../components/A2UIRenderer";
 import { MARKDOWN_PREVIEW_PROPS } from "../markdown-adapter";
-import { resolveMarkdownLinkPath } from "./markdown-links";
+import { resolveMarkdownLinkPath, safeExternalHttpUrl } from "./markdown-links";
 
 interface MarkdownPreviewProps {
   filePath: string;
@@ -40,6 +41,14 @@ interface MarkdownPreviewProps {
   /** Bumps whenever the user saves the file — forces the preview to
    *  re-read fresh content. */
   refreshKey?: number;
+}
+
+function openExternalUrl(url: string): void {
+  try {
+    void openUrl(url).catch(() => undefined);
+  } catch {
+    // Opener failures are not actionable from preview rendering.
+  }
 }
 
 export function MarkdownPreview(props: BuiltinComponentProps) {
@@ -73,7 +82,15 @@ export function MarkdownPreview(props: BuiltinComponentProps) {
                 filePath,
                 projectPath,
               );
-              if (!targetPath || !tabId) return;
+              const externalUrl = safeExternalHttpUrl(href);
+              if (!targetPath) {
+                if (!externalUrl) return;
+                event.preventDefault();
+                event.stopPropagation();
+                openExternalUrl(externalUrl);
+                return;
+              }
+              if (!tabId) return;
               event.preventDefault();
               event.stopPropagation();
               onEvent("markdown-link-open", {

--- a/src/extensions/default-layout/editor/markdown-preview.tsx
+++ b/src/extensions/default-layout/editor/markdown-preview.tsx
@@ -90,9 +90,9 @@ export function MarkdownPreview(props: BuiltinComponentProps) {
                 openExternalUrl(externalUrl);
                 return;
               }
-              if (!tabId) return;
               event.preventDefault();
               event.stopPropagation();
+              if (!tabId) return;
               onEvent("markdown-link-open", {
                 tabId,
                 filePath: targetPath,

--- a/src/extensions/default-layout/editor/markdown-preview.tsx
+++ b/src/extensions/default-layout/editor/markdown-preview.tsx
@@ -22,12 +22,14 @@
  *     tab's editor metadata says clean).
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import ReactMarkdown from "react-markdown";
+import type { Options as ReactMarkdownOptions } from "react-markdown";
 
 import type { BuiltinComponentProps } from "../../../components/A2UIRenderer";
 import { MARKDOWN_PREVIEW_PROPS } from "../markdown-adapter";
+import { resolveMarkdownLinkPath } from "./markdown-links";
 
 interface MarkdownPreviewProps {
   filePath: string;
@@ -41,14 +43,53 @@ interface MarkdownPreviewProps {
 }
 
 export function MarkdownPreview(props: BuiltinComponentProps) {
-  const componentProps = (props.component.props as Partial<MarkdownPreviewProps>) ?? {};
+  const componentProps =
+    (props.component.props as Partial<MarkdownPreviewProps>) ?? {};
   const filePath = componentProps.filePath ?? "";
   const projectPath = componentProps.projectPath ?? "";
   const tabId = componentProps.tabId ?? "";
   const refreshKey = componentProps.refreshKey ?? 0;
+  const onEvent = props.onEvent;
   const [text, setText] = useState<string>("");
   const [error, setError] = useState<string>("");
   const [loading, setLoading] = useState<boolean>(true);
+  const markdownProps = useMemo<ReactMarkdownOptions>(() => {
+    const components = {
+      ...MARKDOWN_PREVIEW_PROPS.components,
+      a({
+        children,
+        href,
+        node,
+        ...rest
+      }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { node?: unknown }) {
+        void node;
+        return (
+          <a
+            {...rest}
+            href={href}
+            onClick={(event) => {
+              const targetPath = resolveMarkdownLinkPath(
+                href,
+                filePath,
+                projectPath,
+              );
+              if (!targetPath || !tabId) return;
+              event.preventDefault();
+              event.stopPropagation();
+              onEvent("markdown-link-open", {
+                tabId,
+                filePath: targetPath,
+                rootPath: projectPath,
+              });
+            }}
+          >
+            {children}
+          </a>
+        );
+      },
+    };
+    return { ...MARKDOWN_PREVIEW_PROPS, components };
+  }, [filePath, onEvent, projectPath, tabId]);
 
   useEffect(() => {
     if (!filePath || !projectPath) {
@@ -87,7 +128,7 @@ export function MarkdownPreview(props: BuiltinComponentProps) {
           <div className="ae-md-preview-empty">empty file</div>
         ) : (
           <div className="ae-md-preview-doc a2ui-markdown">
-            <ReactMarkdown {...MARKDOWN_PREVIEW_PROPS}>{text}</ReactMarkdown>
+            <ReactMarkdown {...markdownProps}>{text}</ReactMarkdown>
           </div>
         )}
       </div>

--- a/src/extensions/default-layout/markdown-adapter.tsx
+++ b/src/extensions/default-layout/markdown-adapter.tsx
@@ -13,6 +13,7 @@
  */
 
 import { openUrl } from "@tauri-apps/plugin-opener";
+import { Children, isValidElement } from "react";
 import rehypeRaw from "rehype-raw";
 import rehypeSanitize, {
   defaultSchema,
@@ -22,12 +23,8 @@ import remarkGfm from "remark-gfm";
 import type { Options as ReactMarkdownOptions } from "react-markdown";
 import { HighlightedCode } from "../../components/HighlightedCode";
 
-type MarkdownRemarkPlugins = NonNullable<
-  ReactMarkdownOptions["remarkPlugins"]
->;
-type MarkdownRehypePlugins = NonNullable<
-  ReactMarkdownOptions["rehypePlugins"]
->;
+type MarkdownRemarkPlugins = NonNullable<ReactMarkdownOptions["remarkPlugins"]>;
+type MarkdownRehypePlugins = NonNullable<ReactMarkdownOptions["rehypePlugins"]>;
 
 interface MarkdownNode {
   type?: string;
@@ -35,6 +32,20 @@ interface MarkdownNode {
   url?: string;
   children?: MarkdownNode[];
 }
+
+type CodeElementProps = {
+  className?: string;
+  children?: React.ReactNode;
+};
+
+type HastElementNode = {
+  tagName?: string;
+  properties?: {
+    className?: string | string[];
+  };
+  children?: HastElementNode[];
+  value?: string;
+};
 
 const BARE_HTTP_URL_RE = /\bhttps?:\/\/[^\s<>"'`]+/gi;
 const TRAILING_PUNCTUATION = new Set([".", ",", "!", "?", ":", ";"]);
@@ -186,16 +197,73 @@ export const MARKDOWN_PREVIEW_REHYPE_PLUGINS: MarkdownRehypePlugins = [
 
 // eslint-disable-next-line react-refresh/only-export-components -- helper consumed by the markdown-adapter map below
 export function isHighlightedFenceChild(node: React.ReactNode): boolean {
-  if (!node || typeof node !== "object") return false;
-  const el = node as React.ReactElement<{ "data-highlighted-fence"?: boolean }>;
-  return el.props?.["data-highlighted-fence"] === true;
+  const child = Children.toArray(node)[0];
+  if (!isValidElement<{ "data-highlighted-fence"?: boolean }>(child)) {
+    return false;
+  }
+  return child.props?.["data-highlighted-fence"] === true;
+}
+
+function codeChildFromPre(
+  node: React.ReactNode,
+): React.ReactElement<CodeElementProps> | null {
+  const children = Children.toArray(node);
+  if (children.length !== 1) return null;
+  const child = children[0];
+  if (!isValidElement<CodeElementProps>(child)) return null;
+  return child.type === "code" ? child : null;
+}
+
+function languageFromClassName(
+  className: string | undefined,
+): string | undefined {
+  return /language-([\w+-]+)/.exec(className ?? "")?.[1];
+}
+
+function classNameFromHast(
+  node: HastElementNode | undefined,
+): string | undefined {
+  const className = node?.properties?.className;
+  return Array.isArray(className) ? className.join(" ") : className;
+}
+
+function textFromHast(node: HastElementNode | undefined): string {
+  if (!node) return "";
+  if (typeof node.value === "string") return node.value;
+  return (node.children ?? []).map((child) => textFromHast(child)).join("");
 }
 
 // eslint-disable-next-line react-refresh/only-export-components -- adapter map for react-markdown; not a component module
 export const MARKDOWN_COMPONENTS = {
-  pre({ children, ...rest }: React.HTMLAttributes<HTMLPreElement>) {
+  pre({
+    children,
+    node,
+    ...rest
+  }: React.HTMLAttributes<HTMLPreElement> & { node?: HastElementNode }) {
     if (isHighlightedFenceChild(children)) {
       return <>{children}</>;
+    }
+    const hastCodeChild =
+      node?.children?.length === 1 && node.children[0]?.tagName === "code"
+        ? node.children[0]
+        : undefined;
+    if (hastCodeChild) {
+      return (
+        <HighlightedFence
+          code={textFromHast(hastCodeChild).replace(/\n$/, "")}
+          language={languageFromClassName(classNameFromHast(hastCodeChild))}
+        />
+      );
+    }
+    const codeChild = codeChildFromPre(children);
+    if (codeChild) {
+      const text = String(codeChild.props.children ?? "").replace(/\n$/, "");
+      return (
+        <HighlightedFence
+          code={text}
+          language={languageFromClassName(codeChild.props.className)}
+        />
+      );
     }
     return <pre {...rest}>{children}</pre>;
   },
@@ -213,13 +281,16 @@ export const MARKDOWN_COMPONENTS = {
   } & React.HTMLAttributes<HTMLElement>) {
     void node;
     const text = String(children ?? "").replace(/\n$/, "");
-    const langMatch = /language-([\w+-]+)/.exec(className ?? "");
-    if (inline || !langMatch) {
-      return <code className={className} {...rest}>{children}</code>;
+    const language = languageFromClassName(className);
+    const isFence = inline === false || Boolean(language);
+    if (!isFence) {
+      return (
+        <code className={className} {...rest}>
+          {children}
+        </code>
+      );
     }
-    return (
-      <HighlightedFence code={text} language={langMatch[1]} />
-    );
+    return <HighlightedFence code={text} language={language} />;
   },
 };
 
@@ -278,7 +349,7 @@ export function HighlightedFence({
   language,
 }: {
   code: string;
-  language: string;
+  language?: string;
 }) {
   return (
     <span data-highlighted-fence style={{ display: "block" }}>

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -1097,8 +1097,7 @@ body.ae-resizing-sidebar .a2ui-layout {
 }
 .ae-sb-agent-dot--idle {
   background: transparent;
-  box-shadow: inset 0 0 0 1.5px
-    var(--state-success-border, var(--text-dim));
+  box-shadow: inset 0 0 0 1.5px var(--state-success-border, var(--text-dim));
 }
 @media (prefers-reduced-motion: reduce) {
   .ae-sb-agent-dot--running {
@@ -2584,44 +2583,162 @@ body.ae-resizing-sidebar .a2ui-layout {
   overflow-wrap: anywhere;
 }
 .a2ui-markdown pre {
-  margin: 0.35em 0;
-  padding: 8px 12px;
-  background: var(--bg-input);
-  border: 1px solid var(--border);
-  border-radius: 6px;
+  margin: 0.55em 0;
+  padding: 12px 14px;
+  background: color-mix(in oklab, var(--bg-input) 88%, var(--bg-elev) 12%);
+  border: 1px solid color-mix(in oklab, var(--border) 82%, var(--accent) 18%);
+  border-radius: 8px;
   min-width: 0;
   max-width: 100%;
   overflow-x: auto;
+  box-shadow: inset 0 1px 0 color-mix(in oklab, white 7%, transparent);
 }
 .a2ui-markdown pre code {
   background: transparent;
+  border: 0;
   padding: 0;
   font-size: var(--text-sm);
 }
 
-/* ---- Syntax-highlighted code blocks (Prism via HighlightedCode) -------- */
+/* ---- Syntax-highlighted code blocks (Shiki via HighlightedCode) -------- */
 
 /* The primitive block — used by both `code` payloads and react-markdown
-   fenced blocks. Spacing matches the .a2ui-markdown pre so the two
-   visually agree when mixed in the same message. */
+   fenced blocks. Markdown fences use the framed wrapper below; compact
+   `language="text"` primitives keep the bare `.a2ui-code` chip style. */
+.a2ui-code-frame {
+  margin: 0.65em 0;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+  border: 1px solid color-mix(in oklab, var(--border) 76%, var(--accent) 24%);
+  border-radius: 8px;
+  background: color-mix(in oklab, var(--bg-input) 90%, var(--bg-elev) 10%);
+  box-shadow:
+    inset 0 1px 0 color-mix(in oklab, white 8%, transparent),
+    0 1px 10px color-mix(in oklab, black 10%, transparent);
+}
+
+.a2ui-code-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  min-height: 32px;
+  padding: 0 8px 0 12px;
+  border-bottom: 1px solid color-mix(in oklab, var(--border) 74%, transparent);
+  background: color-mix(in oklab, var(--bg-elev) 78%, var(--accent) 5%);
+}
+
+.a2ui-code-title {
+  min-width: 0;
+  overflow: hidden;
+  color: color-mix(in oklab, var(--text-dim) 88%, var(--accent) 12%);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1;
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.a2ui-code-copy {
+  appearance: none;
+  position: relative;
+  flex: 0 0 auto;
+  width: 26px;
+  height: 24px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-dim);
+  cursor: pointer;
+  transition:
+    background 0.12s ease,
+    border-color 0.12s ease,
+    color 0.12s ease,
+    transform 0.12s ease;
+}
+
+.a2ui-code-copy::before,
+.a2ui-code-copy::after {
+  content: "";
+  position: absolute;
+  width: 10px;
+  height: 12px;
+  border: 1.5px solid currentColor;
+  border-radius: 2px;
+}
+
+.a2ui-code-copy::before {
+  top: 5px;
+  left: 8px;
+  opacity: 0.55;
+}
+
+.a2ui-code-copy::after {
+  top: 7px;
+  left: 11px;
+  background: color-mix(in oklab, var(--bg-elev) 78%, var(--accent) 5%);
+}
+
+.a2ui-code-copy:hover {
+  border-color: color-mix(in oklab, var(--border) 70%, var(--accent) 30%);
+  background: color-mix(in oklab, var(--accent) 12%, transparent);
+  color: var(--text);
+}
+
+.a2ui-code-copy:active {
+  transform: translateY(1px);
+}
+
+.a2ui-code-copy[data-copied="true"] {
+  color: var(--accent);
+}
+
+.a2ui-code-copy[data-copied="true"]::before {
+  display: none;
+}
+
+.a2ui-code-copy[data-copied="true"]::after {
+  top: 5px;
+  left: 9px;
+  width: 8px;
+  height: 13px;
+  border-width: 0 2px 2px 0;
+  border-radius: 0;
+  background: transparent;
+  transform: rotate(45deg);
+}
+
 .a2ui-code {
   position: relative;
-  margin: 0.35em 0;
-  padding: 8px 12px;
-  background: var(--bg-input);
+  margin: 0.55em 0;
+  padding: 12px 14px;
+  background: color-mix(in oklab, var(--bg-input) 88%, var(--bg-elev) 12%);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: 8px;
   min-width: 0;
   max-width: 100%;
   overflow-x: auto;
   font-family: var(--font-mono);
   font-size: var(--text-sm);
-  line-height: 1.5;
+  line-height: 1.55;
   color: var(--syntax-text, var(--text));
   white-space: pre;
 }
+
+.a2ui-code-frame .a2ui-code {
+  margin: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
 .a2ui-code code {
   background: transparent;
+  border: 0;
   padding: 0;
   font: inherit;
   color: inherit;
@@ -2651,9 +2768,6 @@ body.ae-resizing-sidebar .a2ui-layout {
   width: auto;
   min-width: 0;
 }
-.a2ui-code[data-language="text"] .a2ui-code-lang {
-  display: none;
-}
 .a2ui-code-line {
   display: block;
 }
@@ -2666,20 +2780,9 @@ body.ae-resizing-sidebar .a2ui-layout {
   user-select: none;
   opacity: 0.6;
 }
-.a2ui-code-lang {
-  position: absolute;
-  top: 5px;
-  right: 8px;
-  font-family: var(--font-mono);
-  font-size: 10px;
-  letter-spacing: 0.04em;
-  text-transform: lowercase;
-  color: var(--text-dim);
-  opacity: 0.55;
-  pointer-events: none;
-}
 .a2ui-code-inline {
   background: var(--bg-input);
+  border: 1px solid color-mix(in oklab, var(--border) 70%, var(--accent) 30%);
   padding: 1px 5px;
   border-radius: 4px;
   font-size: 0.88em;

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -2688,6 +2688,12 @@ body.ae-resizing-sidebar .a2ui-layout {
   color: var(--text);
 }
 
+.a2ui-code-copy:focus-visible {
+  border-color: var(--accent);
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
 .a2ui-code-copy:active {
   transform: translateY(1px);
 }


### PR DESCRIPTION
## Summary

- Render Markdown fenced code blocks through the shared highlighted code frame, including unlabeled fences, with copy affordances and matching chrome styling.
- Route Markdown preview file links into Monaco editor tabs and register a Monaco link opener for local file links and external web links.
- Keep external Markdown preview links inside Aethon by opening them through the Tauri system opener instead of allowing webview navigation.
- Only show the code-block copy success state after the clipboard write resolves successfully.

## Rationale

This tightens the Markdown/editor experience around the issues seen in preview mode: code fences should have the polished framed treatment, local docs links should open in the editor, Monaco's follow-link affordance should work, and external links should not replace the app webview.

## Validation

- `bunx vitest run src/components/HighlightedCode.test.tsx src/extensions/default-layout/editor/markdown-preview.test.tsx src/extensions/default-layout/editor/link-openers.test.ts src/eventRoutes/editor.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bunx vitest run` — 212 files, 1,644 tests passed
- Claude ultrareview against `main`; addressed both verified findings in follow-up commit `1f16f49`.
