### PR TITLE
fix: preserve agent stop after frontend reload

### DIFF
--- a/agent/session-history/io.ts
+++ b/agent/session-history/io.ts
@@ -113,9 +113,13 @@ export async function appendLocalChatMessage(
 async function pruneLocalChatFile(path: string): Promise<void> {
   try {
     const raw = await readFile(path, "utf8");
-    const kept = parseLocalChatLines(raw.split(/\r?\n/)).slice(
-      -MAX_LOCAL_CHAT_MESSAGES,
-    );
+    const lines = raw.split(/\r?\n/);
+    const lineCount =
+      lines.length > 0 && lines[lines.length - 1] === ""
+        ? lines.length - 1
+        : lines.length;
+    if (lineCount <= MAX_LOCAL_CHAT_MESSAGES) return;
+    const kept = parseLocalChatLines(lines).slice(-MAX_LOCAL_CHAT_MESSAGES);
     const next = kept
       .map((m) =>
         JSON.stringify({

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import { useDevshell, type DevshellEntry } from "./hooks/useDevshell";
 import { activeCwd as projectsActiveCwd, type ProjectsState } from "./projects";
 import { useProjects } from "./hooks/useProjects";
 import { useAgentWorkerReconcile } from "./hooks/useAgentWorkerReconcile";
+import { useAgentActivityHydration } from "./hooks/useAgentActivityHydration";
 import { useVcsStatus } from "./hooks/useVcsStatus";
 import { useGitWatch } from "./hooks/useGitWatch";
 import { useTabNavigation } from "./hooks/useTabNavigation";
@@ -120,6 +121,7 @@ export default function App() {
   } = useAppStateRefs(appStore);
 
   useSessionPersistence({ appStore, hasSyncSessionSnapshot });
+  useAgentActivityHydration(setState);
 
   const recordProjectModel = useProjectModelRecorder(setState);
 

--- a/src/hooks/useAgentActivityHydration.test.ts
+++ b/src/hooks/useAgentActivityHydration.test.ts
@@ -144,6 +144,63 @@ describe("hydrateAgentActivityState", () => {
     expect(next.status).toBe("ready");
   });
 
+  it("marks stale running tool cards stopped when diagnostics show no live prompt", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(123_456);
+    const waitingTab = {
+      ...makeEmptyTab("tab-a", "A"),
+      messages: [
+        {
+          id: "tool-message",
+          role: "agent" as const,
+          a2ui: {
+            components: [
+              {
+                id: "restored-tool-call_1",
+                type: "tool-card",
+                props: {
+                  title: "bash",
+                  description: "curl https://example.test",
+                  startedAt: 100_000,
+                },
+                children: [],
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    const next = hydrateAgentActivityState(
+      {
+        activeTabId: "tab-a",
+        waiting: false,
+        status: "stopping…",
+        tabs: [waitingTab],
+      },
+      [
+        {
+          key: "tab:tab-a",
+          tab_id: "tab-a",
+          alive: true,
+          prompt_in_flight: false,
+        },
+      ],
+    );
+
+    expect(next.status).toBe("ready");
+    const toolCard = (
+      (next.tabs as typeof waitingTab[])[0].messages[0].a2ui?.components ?? []
+    )[0];
+    expect(toolCard.props).toMatchObject({
+      status: "cancelled",
+      endedAt: 123_456,
+    });
+    expect(toolCard.children?.[0].props?.content).toContain(
+      "No live prompt is running",
+    );
+  });
+
   it("clears stale restored waiting state when there are no live diagnostics", () => {
     const waitingTab = { ...makeEmptyTab("tab-a", "A"), waiting: true };
     const next = hydrateAgentActivityState(

--- a/src/hooks/useAgentActivityHydration.test.ts
+++ b/src/hooks/useAgentActivityHydration.test.ts
@@ -3,6 +3,7 @@
 import { act, renderHook } from "@testing-library/react";
 import type { Dispatch, SetStateAction } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { A2UIComponent } from "../types/a2ui";
 import { makeEmptyTab } from "../types/tab";
 import {
   AGENT_ACTIVITY_HYDRATION_RETRY_DELAYS_MS,
@@ -189,10 +190,14 @@ describe("hydrateAgentActivityState", () => {
     );
 
     expect(next.status).toBe("ready");
-    const toolCard = (
-      (next.tabs as typeof waitingTab[])[0].messages[0].a2ui?.components ?? []
-    )[0];
-    expect(toolCard.props).toMatchObject({
+    const components = (next.tabs as typeof waitingTab[])[0].messages[0].a2ui
+      ?.components as A2UIComponent[] | undefined;
+    const toolCard = components?.[0];
+    expect(toolCard).toBeDefined();
+    if (!toolCard) {
+      throw new Error("expected restored tool card to be preserved");
+    }
+    expect(toolCard?.props).toMatchObject({
       status: "cancelled",
       endedAt: 123_456,
     });

--- a/src/hooks/useAgentActivityHydration.test.ts
+++ b/src/hooks/useAgentActivityHydration.test.ts
@@ -1,0 +1,217 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import type { Dispatch, SetStateAction } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { makeEmptyTab } from "../types/tab";
+import {
+  AGENT_ACTIVITY_HYDRATION_RETRY_DELAYS_MS,
+  hydrateAgentActivityState,
+  useAgentActivityHydration,
+} from "./useAgentActivityHydration";
+
+const invoke = vi.fn();
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (cmd: string, args?: unknown) => invoke(cmd, args),
+}));
+
+afterEach(() => {
+  vi.useRealTimers();
+  invoke.mockReset();
+});
+
+describe("hydrateAgentActivityState", () => {
+  it("marks a restored active tab busy from live agent diagnostics", () => {
+    const next = hydrateAgentActivityState(
+      {
+        activeTabId: "tab-a",
+        waiting: false,
+        status: "ready",
+        tabs: [makeEmptyTab("tab-a", "A")],
+      },
+      [
+        {
+          key: "tab:tab-a",
+          tab_id: "tab-a",
+          alive: true,
+          prompt_in_flight: true,
+        },
+      ],
+    );
+
+    expect((next.tabs as ReturnType<typeof makeEmptyTab>[])[0].waiting).toBe(
+      true,
+    );
+    expect(next.waiting).toBe(true);
+    expect(next.status).toBe("thinking…");
+  });
+
+  it("repairs the active root mirror when the tab was already marked busy", () => {
+    const busyTab = { ...makeEmptyTab("tab-a", "A"), waiting: true };
+    const tabs = [busyTab];
+    const next = hydrateAgentActivityState(
+      {
+        activeTabId: "tab-a",
+        waiting: false,
+        status: "ready",
+        tabs,
+      },
+      [
+        {
+          key: "tab:tab-a",
+          tab_id: "tab-a",
+          alive: true,
+          prompt_in_flight: true,
+        },
+      ],
+    );
+
+    expect(next.waiting).toBe(true);
+    expect(next.status).toBe("thinking…");
+    expect(next.tabs).toBe(tabs);
+  });
+
+  it("maps the global worker to the default tab", () => {
+    const next = hydrateAgentActivityState(
+      {
+        activeTabId: "default",
+        waiting: false,
+        status: "ready",
+        tabs: [makeEmptyTab("default", "Default")],
+      },
+      [
+        {
+          key: "__global__",
+          tab_id: null,
+          alive: true,
+          prompt_in_flight: true,
+        },
+      ],
+    );
+
+    expect((next.tabs as ReturnType<typeof makeEmptyTab>[])[0].waiting).toBe(
+      true,
+    );
+    expect(next.waiting).toBe(true);
+  });
+
+  it("does not create tabs from orphan diagnostics", () => {
+    const next = hydrateAgentActivityState(
+      {
+        activeTabId: "tab-a",
+        waiting: false,
+        tabs: [makeEmptyTab("tab-a", "A")],
+      },
+      [
+        {
+          key: "tab:missing",
+          tab_id: "missing",
+          alive: true,
+          prompt_in_flight: true,
+        },
+      ],
+    );
+
+    expect((next.tabs as ReturnType<typeof makeEmptyTab>[]).map((t) => t.id))
+      .toEqual(["tab-a"]);
+    expect(next.waiting).toBe(false);
+  });
+
+  it("clears stale restored waiting state when diagnostics show no live prompt", () => {
+    const waitingTab = { ...makeEmptyTab("tab-a", "A"), waiting: true };
+    const next = hydrateAgentActivityState(
+      {
+        activeTabId: "tab-a",
+        waiting: true,
+        status: "thinking…",
+        tabs: [waitingTab],
+      },
+      [
+        {
+          key: "tab:tab-a",
+          tab_id: "tab-a",
+          alive: true,
+          prompt_in_flight: false,
+        },
+      ],
+    );
+
+    expect((next.tabs as ReturnType<typeof makeEmptyTab>[])[0].waiting).toBe(
+      false,
+    );
+    expect(next.waiting).toBe(false);
+    expect(next.status).toBe("ready");
+  });
+
+  it("clears stale restored waiting state when there are no live diagnostics", () => {
+    const waitingTab = { ...makeEmptyTab("tab-a", "A"), waiting: true };
+    const next = hydrateAgentActivityState(
+      {
+        activeTabId: "tab-a",
+        waiting: true,
+        status: "thinking…",
+        tabs: [waitingTab],
+      },
+      [],
+    );
+
+    expect((next.tabs as ReturnType<typeof makeEmptyTab>[])[0].waiting).toBe(
+      false,
+    );
+    expect(next.waiting).toBe(false);
+    expect(next.status).toBe("ready");
+  });
+
+  it("retries diagnostics hydration so hot reload races recover stop affordance", async () => {
+    vi.useFakeTimers();
+    const tab = makeEmptyTab("tab-a", "A");
+    let state: Record<string, unknown> = {
+      activeTabId: "tab-a",
+      waiting: false,
+      status: "ready",
+      tabs: [tab],
+    };
+    const setState: Dispatch<SetStateAction<Record<string, unknown>>> = (
+      arg,
+    ) => {
+      state = typeof arg === "function" ? arg(state) : arg;
+    };
+    invoke
+      .mockResolvedValueOnce([
+        {
+          key: "tab:tab-a",
+          tab_id: "tab-a",
+          alive: true,
+          prompt_in_flight: false,
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          key: "tab:tab-a",
+          tab_id: "tab-a",
+          alive: true,
+          prompt_in_flight: true,
+        },
+      ]);
+
+    renderHook(() => useAgentActivityHydration(setState));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(state).toMatchObject({ waiting: false, status: "ready" });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(
+        AGENT_ACTIVITY_HYDRATION_RETRY_DELAYS_MS[1],
+      );
+    });
+
+    expect(invoke).toHaveBeenCalledTimes(2);
+    expect(state).toMatchObject({ waiting: true, status: "thinking…" });
+    expect(
+      ((state.tabs as ReturnType<typeof makeEmptyTab>[])[0]).waiting,
+    ).toBe(true);
+  });
+});

--- a/src/hooks/useAgentActivityHydration.ts
+++ b/src/hooks/useAgentActivityHydration.ts
@@ -1,5 +1,6 @@
 import { useEffect, type Dispatch, type SetStateAction } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import type { A2UIComponent, ChatMessage } from "../types/a2ui";
 import type { Tab } from "../types/tab";
 import { TAB_MIRROR_KEYS } from "./useTabs";
 
@@ -32,6 +33,60 @@ function diagnosticPromptInFlight(row: AgentDiagnosticRow): boolean {
   return row.prompt_in_flight === true || row.promptInFlight === true;
 }
 
+function stoppedToolCardNotice(componentId: string): A2UIComponent {
+  return {
+    id: `${componentId}-stopped-notice`,
+    type: "code",
+    props: {
+      content:
+        "No live prompt is running. This tool was marked stopped after reload.",
+      language: "text",
+    },
+  };
+}
+
+function closeStoppedToolCards(
+  messages: ChatMessage[],
+  endedAt: number,
+): { messages: ChatMessage[]; changed: boolean } {
+  let changed = false;
+  const nextMessages = messages.map((message): ChatMessage => {
+    const components = message.a2ui?.components;
+    if (!components) return message;
+    let messageChanged = false;
+    const nextComponents = components.map((component): A2UIComponent => {
+      if (
+        component?.type !== "tool-card" ||
+        component.props?.startedAt === undefined ||
+        component.props.endedAt !== undefined
+      ) {
+        return component;
+      }
+      messageChanged = true;
+      const children = component.children ?? [];
+      return {
+        ...component,
+        props: {
+          ...(component.props ?? {}),
+          status: "cancelled",
+          endedAt,
+        },
+        children: [...children, stoppedToolCardNotice(component.id)],
+      };
+    });
+    if (!messageChanged) return message;
+    changed = true;
+    return {
+      ...message,
+      a2ui: {
+        ...message.a2ui,
+        components: nextComponents,
+      },
+    };
+  });
+  return { messages: nextMessages, changed };
+}
+
 export function hydrateAgentActivityState(
   state: Record<string, unknown>,
   diagnostics: AgentDiagnosticRow[],
@@ -51,15 +106,19 @@ export function hydrateAgentActivityState(
     );
   }
   let tabChanged = false;
+  const endedAt = Date.now();
   const nextTabs = tabs.map((tab) => {
     if ((tab.kind ?? "agent") !== "agent") return tab;
     const hasDiagnostic = livePromptByTabId.has(tab.id);
     const nextWaiting = hasDiagnostic
       ? livePromptByTabId.get(tab.id) === true
       : false;
-    if (tab.waiting === nextWaiting) return tab;
+    const stoppedTools = nextWaiting
+      ? { messages: tab.messages, changed: false }
+      : closeStoppedToolCards(tab.messages, endedAt);
+    if (tab.waiting === nextWaiting && !stoppedTools.changed) return tab;
     tabChanged = true;
-    return { ...tab, waiting: nextWaiting };
+    return { ...tab, waiting: nextWaiting, messages: stoppedTools.messages };
   });
 
   const activeTabId = state.activeTabId as string | undefined;

--- a/src/hooks/useAgentActivityHydration.ts
+++ b/src/hooks/useAgentActivityHydration.ts
@@ -1,0 +1,118 @@
+import { useEffect, type Dispatch, type SetStateAction } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import type { Tab } from "../types/tab";
+import { TAB_MIRROR_KEYS } from "./useTabs";
+
+export const AGENT_ACTIVITY_HYDRATION_RETRY_DELAYS_MS = [
+  0, 250, 1000, 2500, 5000, 10000,
+] as const;
+
+export interface AgentDiagnosticRow {
+  key: string;
+  tab_id?: string | null;
+  tabId?: string | null;
+  alive?: boolean;
+  prompt_in_flight?: boolean;
+  promptInFlight?: boolean;
+}
+
+function diagnosticTabId(row: AgentDiagnosticRow): string | null {
+  if (typeof row.tab_id === "string" && row.tab_id.length > 0) {
+    return row.tab_id;
+  }
+  if (typeof row.tabId === "string" && row.tabId.length > 0) {
+    return row.tabId;
+  }
+  if (row.key === "__global__") return "default";
+  if (row.key.startsWith("tab:")) return row.key.slice("tab:".length);
+  return null;
+}
+
+function diagnosticPromptInFlight(row: AgentDiagnosticRow): boolean {
+  return row.prompt_in_flight === true || row.promptInFlight === true;
+}
+
+export function hydrateAgentActivityState(
+  state: Record<string, unknown>,
+  diagnostics: AgentDiagnosticRow[],
+): Record<string, unknown> {
+  const tabs = (state.tabs as Tab[] | undefined) ?? [];
+  if (tabs.length === 0) return state;
+
+  const livePromptByTabId = new Map<string, boolean>();
+  for (const row of diagnostics) {
+    if (row.alive === false) continue;
+    const tabId = diagnosticTabId(row);
+    if (!tabId) continue;
+    livePromptByTabId.set(
+      tabId,
+      (livePromptByTabId.get(tabId) ?? false) ||
+        diagnosticPromptInFlight(row),
+    );
+  }
+  let tabChanged = false;
+  const nextTabs = tabs.map((tab) => {
+    if ((tab.kind ?? "agent") !== "agent") return tab;
+    const hasDiagnostic = livePromptByTabId.has(tab.id);
+    const nextWaiting = hasDiagnostic
+      ? livePromptByTabId.get(tab.id) === true
+      : false;
+    if (tab.waiting === nextWaiting) return tab;
+    tabChanged = true;
+    return { ...tab, waiting: nextWaiting };
+  });
+
+  const activeTabId = state.activeTabId as string | undefined;
+  const activeTab = nextTabs.find((tab) => tab.id === activeTabId);
+  const activeRecord =
+    (activeTab as unknown as Record<string, unknown> | undefined) ?? {};
+  const activeTurnBusy =
+    activeTab?.waiting === true || (activeTab?.queueCount ?? 0) > 0;
+  const nextStatus = activeTurnBusy ? "thinking…" : "ready";
+  const statusChanged = !!activeTab && state.status !== nextStatus;
+  const mirrorChanged =
+    !!activeTab &&
+    TAB_MIRROR_KEYS.some(
+      (key) => state[key as string] !== activeRecord[key as string],
+    );
+  if (!tabChanged && !statusChanged && !mirrorChanged) return state;
+
+  const next: Record<string, unknown> = {
+    ...state,
+    ...(tabChanged ? { tabs: nextTabs } : {}),
+    ...(activeTab ? { status: nextStatus } : {}),
+  };
+  if (activeTab) {
+    for (const key of TAB_MIRROR_KEYS) {
+      next[key as string] = activeRecord[key as string];
+    }
+  }
+  return next;
+}
+
+export function useAgentActivityHydration(
+  setState: Dispatch<SetStateAction<Record<string, unknown>>>,
+): void {
+  useEffect(() => {
+    let cancelled = false;
+    const timers: ReturnType<typeof setTimeout>[] = [];
+    const hydrate = () => {
+      invoke<AgentDiagnosticRow[]>("agent_diagnostics")
+        .then((diagnostics) => {
+          if (cancelled || !Array.isArray(diagnostics)) return;
+          setState((prev) => hydrateAgentActivityState(prev, diagnostics));
+        })
+        .catch(() => {
+          /* Older/dev-mismatched shells may not expose diagnostics. */
+        });
+    };
+
+    for (const delay of AGENT_ACTIVITY_HYDRATION_RETRY_DELAYS_MS) {
+      timers.push(setTimeout(hydrate, delay));
+    }
+    return () => {
+      cancelled = true;
+      for (const timer of timers) clearTimeout(timer);
+    };
+  }, [setState]);
+}

--- a/src/hooks/useChat.test.ts
+++ b/src/hooks/useChat.test.ts
@@ -430,6 +430,76 @@ describe("useChat setModel", () => {
     });
   });
 
+  it("stopPrompt reconciles confirmed stops so stale tool cards do not keep spinning", async () => {
+    invoke.mockImplementation((cmd: string) => {
+      if (cmd === "agent_diagnostics") {
+        return Promise.resolve([
+          {
+            key: "tab:tab-1",
+            tab_id: "tab-1",
+            alive: true,
+            prompt_in_flight: false,
+          },
+        ]);
+      }
+      return Promise.resolve(undefined);
+    });
+    const runningTool = {
+      id: "tool-message",
+      role: "agent" as const,
+      a2ui: {
+        components: [
+          {
+            id: "restored-tool-call_1",
+            type: "tool-card",
+            props: {
+              title: "bash",
+              description: "curl https://example.test",
+              startedAt: 1_000,
+            },
+            children: [],
+          },
+        ],
+      },
+    };
+    const { ctx, stateRef } = buildContext({
+      status: "thinking…",
+      waiting: true,
+      tabs: [
+        {
+          ...makeEmptyTab("tab-1", "Tab 1"),
+          waiting: true,
+          messages: [runningTool],
+        },
+      ],
+    });
+    const { result } = renderHook(() => useChat(ctx));
+
+    await act(async () => {
+      await result.current.stopPrompt("tab-1");
+    });
+
+    expect(stateRef.current.status).toBe("stopped");
+    expect(stateRef.current.waiting).toBe(false);
+    const tab = (stateRef.current.tabs as Tab[])[0];
+    const toolCard = (tab.messages[0].a2ui?.components ?? [])[0];
+    expect(toolCard.props).toMatchObject({
+      status: "cancelled",
+      endedAt: expect.any(Number),
+    });
+    expect(toolCard.children?.[0].props?.content).toContain(
+      "No live prompt is running",
+    );
+    expect(tab.messages.at(-1)).toMatchObject({
+      role: "system",
+      text: "Agent stopped.",
+    });
+    expect(ctx.persistLocalChatMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ role: "system", text: "Agent stopped." }),
+      "tab-1",
+    );
+  });
+
   it("drained queued messages actually reach invoke('send_message') (regression: P1 from peer review)", async () => {
     // Reproduces the bug Codex flagged: useQueuedDispatch previously
     // flipped waiting=true *before* calling sendChat. Because the

--- a/src/hooks/useChat.test.ts
+++ b/src/hooks/useChat.test.ts
@@ -7,7 +7,9 @@ import { makeEmptyTab, type Tab } from "../types/tab";
 import { useChat, type UseChatContext } from "./useChat";
 import { PI_DEFAULT_MODEL_SENTINEL } from "../utils/modelPicker";
 
-const invoke = vi.fn((..._args: unknown[]) => Promise.resolve(undefined));
+const invoke = vi.fn<(...args: unknown[]) => Promise<unknown>>(() =>
+  Promise.resolve(undefined),
+);
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: (cmd: string, args?: unknown) => invoke(cmd, args),
@@ -431,7 +433,7 @@ describe("useChat setModel", () => {
   });
 
   it("stopPrompt reconciles confirmed stops so stale tool cards do not keep spinning", async () => {
-    invoke.mockImplementation((cmd: string) => {
+    invoke.mockImplementation((cmd: unknown) => {
       if (cmd === "agent_diagnostics") {
         return Promise.resolve([
           {

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -18,6 +18,12 @@ import {
   PI_DEFAULT_MODEL_SENTINEL,
 } from "../utils/modelPicker";
 import { getConfig, clearConfigCache, type AethonConfig } from "../config";
+import {
+  hydrateAgentActivityState,
+  type AgentDiagnosticRow,
+} from "./useAgentActivityHydration";
+
+const STOP_CONFIRM_DELAYS_MS = [0, 150, 500, 1000, 2000] as const;
 
 /** Patch `queuedMessages` and the derived `queueCount` together so the
  *  composer badge can't drift out of sync with the popover list. */
@@ -311,6 +317,63 @@ export function useChat(ctx: UseChatContext): UseChatActions {
     updateActiveTab((tab) => ({ ...tab, messages: [] }));
   }
 
+  function diagnosticMatchesTab(row: AgentDiagnosticRow, tabId: string) {
+    return (
+      row.tab_id === tabId ||
+      row.tabId === tabId ||
+      row.key === `tab:${tabId}` ||
+      (tabId === "default" && row.key === "__global__")
+    );
+  }
+
+  async function confirmPromptStopped(tabId: string) {
+    for (const delay of STOP_CONFIRM_DELAYS_MS) {
+      if (delay > 0) {
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
+      let diagnostics: AgentDiagnosticRow[];
+      try {
+        const result = await invoke<AgentDiagnosticRow[]>("agent_diagnostics");
+        if (!Array.isArray(result)) return;
+        diagnostics = result;
+      } catch {
+        return;
+      }
+      const row = diagnostics.find((entry) => diagnosticMatchesTab(entry, tabId));
+      if (!row) continue;
+      const promptInFlight =
+        row.prompt_in_flight === true || row.promptInFlight === true;
+      if (row.alive !== false && promptInFlight) continue;
+      const stoppedMessage: ChatMessage = {
+        id: crypto.randomUUID(),
+        role: "system",
+        text: "Agent stopped.",
+      };
+      setState((prev) => {
+        const hydrated = hydrateAgentActivityState(prev, diagnostics);
+        const tabs = (hydrated.tabs as Tab[] | undefined) ?? [];
+        const nextTabs = tabs.map((tab) =>
+          tab.id === tabId
+            ? { ...tab, messages: [...tab.messages, stoppedMessage] }
+            : tab,
+        );
+        return hydrated.activeTabId === tabId
+          ? {
+              ...hydrated,
+              status: "stopped",
+              messages: [
+                ...((hydrated.messages as ChatMessage[]) ?? []),
+                stoppedMessage,
+              ],
+              tabs: nextTabs,
+            }
+          : { ...hydrated, tabs: nextTabs };
+      });
+      persistLocalChatMessage(stoppedMessage, tabId);
+      return;
+    }
+  }
+
   async function stopPrompt(explicitTabId?: string) {
     const tabId =
       explicitTabId ??
@@ -328,6 +391,7 @@ export function useChat(ctx: UseChatContext): UseChatActions {
         payload: JSON.stringify({ type: "stop", tabId }),
       });
       setStatusFlags({ status: "stopping…" });
+      await confirmPromptStopped(tabId);
     } catch (err) {
       appendMessage(
         {

--- a/src/hooks/useKeyboardShortcuts.test.tsx
+++ b/src/hooks/useKeyboardShortcuts.test.tsx
@@ -82,6 +82,38 @@ describe("useKeyboardShortcuts Escape handling", () => {
     expect(ctx.closePalette).toHaveBeenCalledTimes(1);
     expect(ctx.closeSettings).not.toHaveBeenCalled();
   });
+
+  it("stops a busy active agent tab when no overlay is open", () => {
+    const ctx = buildContext({
+      activeTabId: "agent-1",
+      waiting: false,
+      palette: { open: false },
+      settings: { open: false },
+      tabs: [{ id: "agent-1", kind: "agent", label: "Tab 1", waiting: true }],
+    });
+    render(<Harness ctx={ctx} />);
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(ctx.stopPrompt).toHaveBeenCalledTimes(1);
+    expect(ctx.closePalette).not.toHaveBeenCalled();
+    expect(ctx.closeSettings).not.toHaveBeenCalled();
+  });
+
+  it("does not stop an idle active agent tab on Escape", () => {
+    const ctx = buildContext({
+      activeTabId: "agent-1",
+      waiting: false,
+      palette: { open: false },
+      settings: { open: false },
+      tabs: [{ id: "agent-1", kind: "agent", label: "Tab 1", waiting: false }],
+    });
+    render(<Harness ctx={ctx} />);
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(ctx.stopPrompt).not.toHaveBeenCalled();
+  });
 });
 
 describe("Cmd+W is focus-aware", () => {

--- a/src/hooks/useKeyboardShortcuts.test.tsx
+++ b/src/hooks/useKeyboardShortcuts.test.tsx
@@ -100,6 +100,44 @@ describe("useKeyboardShortcuts Escape handling", () => {
     expect(ctx.closeSettings).not.toHaveBeenCalled();
   });
 
+  it("stops when a running tool card is visible even if waiting drifted false", () => {
+    const ctx = buildContext({
+      activeTabId: "agent-1",
+      waiting: false,
+      palette: { open: false },
+      settings: { open: false },
+      tabs: [
+        {
+          id: "agent-1",
+          kind: "agent",
+          label: "Tab 1",
+          waiting: false,
+          queueCount: 0,
+          messages: [
+            {
+              id: "tool-message",
+              role: "agent",
+              a2ui: {
+                components: [
+                  {
+                    id: "restored-tool-call_1",
+                    type: "tool-card",
+                    props: { startedAt: 1_000 },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    });
+    render(<Harness ctx={ctx} />);
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(ctx.stopPrompt).toHaveBeenCalledTimes(1);
+  });
+
   it("does not stop an idle active agent tab on Escape", () => {
     const ctx = buildContext({
       activeTabId: "agent-1",

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -16,6 +16,20 @@ interface NotificationInput {
   durationMs?: number | null;
 }
 
+function activeAgentTabIsBusy(state: Record<string, unknown>): boolean {
+  const activeTabId = state.activeTabId as string | undefined;
+  const tabs = (state.tabs as Tab[] | undefined) ?? [];
+  const activeTab = tabs.find((tab) => tab.id === activeTabId);
+  if (!activeTab) return false;
+  if ((activeTab.kind ?? "agent") !== "agent") return false;
+  return (
+    activeTab?.waiting === true ||
+    (activeTab?.queueCount ?? 0) > 0 ||
+    state.waiting === true ||
+    ((state.queueCount as number | undefined) ?? 0) > 0
+  );
+}
+
 export interface UseKeyboardShortcutsContext {
   stateRef: MutableRefObject<Record<string, unknown>>;
   /** Map of canonical combo string ("meta+shift+p") to the registered
@@ -312,7 +326,8 @@ export function useKeyboardShortcuts(ctx: UseKeyboardShortcutsContext): void {
       // Esc closes the active overlay, with palette taking precedence
       // because it can sit on top of Settings.
       if (e.key === "Escape") {
-        const palette = ctx.stateRef.current.palette as
+        const state = ctx.stateRef.current;
+        const palette = state.palette as
           | { open?: boolean }
           | undefined;
         if (palette?.open) {
@@ -321,13 +336,19 @@ export function useKeyboardShortcuts(ctx: UseKeyboardShortcutsContext): void {
           ctx.closePalette();
           return;
         }
-        const settings = ctx.stateRef.current.settings as
+        const settings = state.settings as
           | { open?: boolean }
           | undefined;
         if (settings?.open) {
           e.preventDefault();
           e.stopPropagation();
           ctx.closeSettings();
+          return;
+        }
+        if (activeAgentTabIsBusy(state)) {
+          e.preventDefault();
+          e.stopPropagation();
+          void ctx.stopPrompt();
           return;
         }
       }

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -25,6 +25,14 @@ function activeAgentTabIsBusy(state: Record<string, unknown>): boolean {
   return (
     activeTab?.waiting === true ||
     (activeTab?.queueCount ?? 0) > 0 ||
+    (activeTab.messages ?? []).some((message) =>
+      (message.a2ui?.components ?? []).some(
+        (component) =>
+          component.type === "tool-card" &&
+          component.props?.startedAt !== undefined &&
+          component.props.endedAt === undefined,
+      ),
+    ) ||
     state.waiting === true ||
     ((state.queueCount as number | undefined) ?? 0) > 0
   );

--- a/src/hooks/useSessionPersistence.test.tsx
+++ b/src/hooks/useSessionPersistence.test.tsx
@@ -89,6 +89,43 @@ describe("useSessionPersistence", () => {
     expect(appStore.getState().activeTabId).toBe("__overview__");
   });
 
+  it("mirrors restored hot-reload busy state onto the active root tab", () => {
+    window.sessionStorage.setItem(
+      "aethon:session-ui-snapshot:v1",
+      JSON.stringify({
+        tabs: [
+          {
+            id: "restored-tab",
+            kind: "agent",
+            label: "Restored",
+            messages: [{ id: "m1", role: "user", text: "running" }],
+            draft: "",
+            waiting: true,
+            queueCount: 0,
+            queuedMessages: [],
+            canvas: null,
+            model: "claude",
+            terminalBuffer: "",
+            projectId: null,
+          },
+        ],
+        activeTabId: "restored-tab",
+        savedAt: 1,
+      }),
+    );
+
+    const { appStore } = buildInitialAppStore({
+      bootLayout: { components: [], state: { terminalPanel: {} } },
+      logoUrl: "/logo.svg",
+      appVersion: "v0.0.0",
+    });
+
+    expect(appStore.getState()).toMatchObject({
+      activeTabId: "restored-tab",
+      waiting: true,
+    });
+  });
+
   it("does not restore durable session snapshots when restore_tabs is disabled", async () => {
     vi.mocked(getConfig).mockResolvedValue(defaultConfig);
     vi.mocked(readState).mockResolvedValue(

--- a/src/state/sessionUiSnapshot.test.ts
+++ b/src/state/sessionUiSnapshot.test.ts
@@ -291,6 +291,62 @@ describe("sessionUiSnapshot", () => {
     });
   });
 
+  it("preserves running agent activity for hot frontend reload snapshots", () => {
+    const tab = {
+      ...makeEmptyTab("tab-a", "A"),
+      waiting: true,
+      queueCount: 1,
+      queuedMessages: [
+        {
+          id: "queued",
+          content: "follow up",
+          attachments: [
+            {
+              id: "img-queued",
+              kind: "image" as const,
+              path: "/tmp/aethon-pastes/queued.png",
+              name: "queued.png",
+              mimeType: "image/png",
+              sizeBytes: 14,
+              previewUrl: "blob:queued",
+            },
+          ],
+        },
+      ],
+      messages: [
+        { id: "m1", role: "user" as const, text: "fix it" },
+        { id: "m2", role: "agent" as const, thinking: "Working" },
+      ],
+    };
+
+    saveSessionUiSnapshot({
+      tabs: [tab],
+      activeTabId: "tab-a",
+    });
+
+    expect(loadSessionUiSnapshot()?.tabs[0]).toMatchObject({
+      id: "tab-a",
+      waiting: true,
+      queueCount: 1,
+      queuedMessages: [
+        {
+          id: "queued",
+          content: "follow up",
+          attachments: [
+            {
+              id: "img-queued",
+              kind: "image",
+              path: "/tmp/aethon-pastes/queued.png",
+              name: "queued.png",
+              mimeType: "image/png",
+              sizeBytes: 14,
+            },
+          ],
+        },
+      ],
+    });
+  });
+
   it("persists shell tabs for frontend reload and restores their PTY on mount", () => {
     saveSessionUiSnapshot({
       tabs: [

--- a/src/state/sessionUiSnapshot.ts
+++ b/src/state/sessionUiSnapshot.ts
@@ -1,4 +1,4 @@
-import { OVERVIEW_TAB_ID, type Tab } from "../types/tab";
+import { OVERVIEW_TAB_ID, type QueuedMessage, type Tab } from "../types/tab";
 import type { ChatMessage } from "../types/a2ui";
 import { durableImageAttachments } from "../utils/imageAttachments";
 import { dedupeToolResultTextMessages } from "../utils/messages";
@@ -38,6 +38,11 @@ export interface ParseSessionUiSnapshotOptions {
   /** Hot webview reloads can reattach/reopen PTYs. Durable disk restore
    *  after an app restart must not silently run saved shell commands. */
   restartShellTabs?: boolean;
+  /** A webview reload keeps the Rust/Bun agent workers alive. Preserve
+   *  local busy/queue state so the user can still press Stop after the
+   *  React tree remounts. Durable disk restore leaves this false because
+   *  there is no attached prompt runner after a full app restart. */
+  preserveAgentActivity?: boolean;
 }
 
 function canUseSessionStorage(): boolean {
@@ -67,6 +72,15 @@ function trimTab(tab: Tab): Tab {
     draftAttachments: durableImageAttachments(tab.draftAttachments),
     terminalBuffer: tab.terminalBuffer.slice(-MAX_TERMINAL_BUFFER),
   };
+}
+
+function durableQueuedMessages(
+  queuedMessages: QueuedMessage[] | undefined,
+): QueuedMessage[] {
+  return (queuedMessages ?? []).map((message) => ({
+    ...message,
+    attachments: durableImageAttachments(message.attachments),
+  }));
 }
 
 function shouldPersistTab(tab: Tab): boolean {
@@ -225,10 +239,20 @@ function validTabsFrom(value: unknown): Tab[] {
  *  editor metadata, and re-arm or quiesce shell tabs. Shared by the main
  *  tab list and the stashed per-workspace buckets so both restore the same
  *  way. */
-function restoreTabRecord(t: Tab, restartShellTabs: boolean): Tab {
+function restoreTabRecord(
+  t: Tab,
+  restartShellTabs: boolean,
+  preserveAgentActivity: boolean,
+): Tab {
+  const kind = t.kind ?? "agent";
+  const preserveActivity = preserveAgentActivity && kind === "agent";
+  const queuedMessages =
+    preserveActivity && Array.isArray(t.queuedMessages)
+      ? durableQueuedMessages(t.queuedMessages)
+      : [];
   const base = {
     ...t,
-    kind: t.kind ?? "agent",
+    kind,
     messages: dedupeToolResultTextMessages(t.messages).map(
       (message): ChatMessage =>
         message.attachments && message.attachments.length > 0
@@ -242,16 +266,16 @@ function restoreTabRecord(t: Tab, restartShellTabs: boolean): Tab {
     draftAttachments: Array.isArray(t.draftAttachments)
       ? durableImageAttachments(t.draftAttachments)
       : [],
-    // Waiting is process-local state. After an app restart there is no
-    // still-attached prompt runner behind this tab, so restoring it as
-    // busy leaves the UI stuck in "thinking..." with a dead stop button.
-    waiting: false,
-    // Client-held queue is intentionally NOT restored: queued messages are
-    // ephemeral, and a user who closed the app while queue items were
-    // pending probably abandoned them. queueCount derives from
-    // queuedMessages.length, so zero it in lockstep.
-    queueCount: 0,
-    queuedMessages: [],
+    // Waiting is process-local state. Preserve it only for same-process
+    // webview reloads; after an app restart there is no still-attached
+    // prompt runner behind this tab, so restoring it as busy leaves the UI
+    // stuck in "thinking..." with a dead stop button.
+    waiting: preserveActivity ? t.waiting === true : false,
+    // Client-held queue is restored only for hot reload. Durable app-start
+    // restore treats queued messages as abandoned and zeroes the derived
+    // count in lockstep.
+    queueCount: preserveActivity ? queuedMessages.length : 0,
+    queuedMessages,
     canvas: t.canvas ?? null,
     model: t.model ?? "",
     terminalBuffer: t.terminalBuffer ?? "",
@@ -293,6 +317,7 @@ function restoreTabRecord(t: Tab, restartShellTabs: boolean): Tab {
 function parsePersistedBuckets(
   value: unknown,
   restartShellTabs: boolean,
+  preserveAgentActivity: boolean,
 ): Record<string, PersistedTabBucket> | undefined {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return undefined;
@@ -302,7 +327,7 @@ function parsePersistedBuckets(
     if (!raw || typeof raw !== "object" || Array.isArray(raw)) continue;
     const bucket = raw as { tabs?: unknown; activeTabId?: unknown };
     const tabs = validTabsFrom(bucket.tabs).map((t) =>
-      restoreTabRecord(t, restartShellTabs),
+      restoreTabRecord(t, restartShellTabs, preserveAgentActivity),
     );
     if (tabs.length === 0) continue;
     const activeTabId =
@@ -318,7 +343,11 @@ function parsePersistedBuckets(
 export function loadSessionUiSnapshot(): SessionUiSnapshot | null {
   if (canUseSessionStorage()) {
     const raw = window.sessionStorage.getItem(KEY);
-    if (raw) return parseSessionUiSnapshot(raw, { restartShellTabs: true });
+    if (raw)
+      return parseSessionUiSnapshot(raw, {
+        restartShellTabs: true,
+        preserveAgentActivity: true,
+      });
   }
   return null;
 }
@@ -332,7 +361,12 @@ export function parseSessionUiSnapshot(
     const parsed = JSON.parse(raw) as Partial<SessionUiSnapshot>;
     const tabs = validTabsFrom(parsed.tabs);
     const restartShellTabs = options.restartShellTabs === true;
-    const buckets = parsePersistedBuckets(parsed.buckets, restartShellTabs);
+    const preserveAgentActivity = options.preserveAgentActivity === true;
+    const buckets = parsePersistedBuckets(
+      parsed.buckets,
+      restartShellTabs,
+      preserveAgentActivity,
+    );
     // Nothing to restore if neither the active workspace nor any backgrounded
     // workspace had sessions.
     if (tabs.length === 0 && !buckets) return null;
@@ -350,7 +384,9 @@ export function parseSessionUiSnapshot(
           ? parsed.activeTabId
           : (tabs.find(tabCanOwnMainSurface)?.id ?? OVERVIEW_TAB_ID);
     return {
-      tabs: tabs.map((t) => restoreTabRecord(t, restartShellTabs)),
+      tabs: tabs.map((t) =>
+        restoreTabRecord(t, restartShellTabs, preserveAgentActivity),
+      ),
       activeTabId,
       layout: durableLayoutSnapshot(parsed.layout),
       terminal: durableTerminalSnapshot(parsed.terminal),


### PR DESCRIPTION
## Summary

- Preserve agent-tab busy and queued-message state only for same-process frontend reloads, so Stop remains available while the Rust/Bun worker is still running.
- Retry post-reload `agent_diagnostics` hydration across the remount window, so late worker diagnostics can recover the busy state instead of leaving the composer idle.
- Keep durable app-restart restores safe by continuing to clear process-local prompt and queue state.
- Make `Escape` stop the active busy agent tab when no overlay is consuming Escape; palette/settings dismissal still takes precedence.
- Add regression coverage across snapshot parsing, session persistence/root mirrors, diagnostics hydration, and keyboard stop routing.

## Root Cause

The frontend hot-reload path restores UI tabs from `sessionStorage`, but `restoreTabRecord()` treated every restore like a full app restart and always scrubbed `waiting`, `queueCount`, and `queuedMessages`. The backend worker can survive a webview reload, so the UI lost the active-tab busy state and no longer exposed the Stop control even though a prompt was still running.

A live dev repro also showed a second race: the backend diagnostic could report `prompt_in_flight: true` after the one-shot hydration had already run, leaving root/tab `waiting` false. The diagnostics hydration now retries briefly after mount to bridge that reload race.

## Validation

- `bunx vitest run src/hooks/useAgentActivityHydration.test.ts src/hooks/useKeyboardShortcuts.test.tsx src/state/sessionUiSnapshot.test.ts src/hooks/useSessionPersistence.test.tsx src/hooks/useChat.test.ts src/eventRoutes/chatInput.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bunx vitest run`
- `bun run build`
- `git diff --check`
- Live dev debug check: started a controlled long-running prompt, reloaded `http://localhost:1420/`, confirmed restored root/tab `waiting: true` with backend `prompt_in_flight: true`, then dispatched `Escape` and confirmed backend `prompt_in_flight: false`.

Notes: the full Vitest run emitted the existing extension/devshell/canvas mock warnings, and the production build emitted the existing large-chunk Vite warning.
