### PR TITLE
fix(markdown): prevent preview badge flicker

### DIFF
--- a/src/extensions/default-layout/editor/markdown-preview.test.tsx
+++ b/src/extensions/default-layout/editor/markdown-preview.test.tsx
@@ -314,6 +314,79 @@ describe("MarkdownPreview", () => {
     );
   });
 
+  it("keeps safe remote badge images mounted across preview rerenders", async () => {
+    const markdown =
+      "![Nix Flake](https://img.shields.io/badge/nix-flake-blue?logo=nixos)";
+    const { container, rerender } = renderMarkdownPreview(markdown, {
+      tabId: "editor-1",
+    });
+
+    await screen.findByRole("img", { name: "Nix Flake" });
+    expect(container.querySelectorAll("img")).toHaveLength(1);
+    const imageMutations: Array<{ added: number; removed: number }> = [];
+    const doc = container.querySelector(".ae-md-preview-doc");
+    expect(doc).not.toBeNull();
+    if (!doc) throw new Error("expected markdown preview document");
+    const observer = new MutationObserver((records) => {
+      for (const record of records) {
+        imageMutations.push({
+          added: Array.from(record.addedNodes).filter(
+            (node) =>
+              node instanceof HTMLImageElement ||
+              (node instanceof Element && node.querySelector("img")),
+          ).length,
+          removed: Array.from(record.removedNodes).filter(
+            (node) =>
+              node instanceof HTMLImageElement ||
+              (node instanceof Element && node.querySelector("img")),
+          ).length,
+        });
+      }
+    });
+    observer.observe(doc, { childList: true, subtree: true });
+
+    rerender(
+      <MarkdownPreview
+        component={markdownPreviewComponent({ tabId: "editor-2" })}
+        state={{}}
+        onEvent={vi.fn()}
+      />,
+    );
+    await Promise.resolve();
+    observer.disconnect();
+
+    const image = container.querySelector("img");
+    expect(image?.getAttribute("src")).toBe(
+      "https://img.shields.io/badge/nix-flake-blue?logo=nixos",
+    );
+    expect(container.querySelectorAll("img")).toHaveLength(1);
+    expect(imageMutations.filter((mutation) => mutation.removed > 0)).toEqual(
+      [],
+    );
+
+    imageMutations.length = 0;
+    rerender(
+      <MarkdownPreview
+        component={markdownPreviewComponent({
+          refreshKey: 2,
+          tabId: "editor-2",
+        })}
+        state={{}}
+        onEvent={vi.fn()}
+      />,
+    );
+    await Promise.resolve();
+
+    expect(container.querySelectorAll("img")).toHaveLength(1);
+    expect(imageMutations.filter((mutation) => mutation.removed > 0)).toEqual(
+      [],
+    );
+    expect(invoke).not.toHaveBeenCalledWith(
+      "fs_read_file_base64",
+      expect.anything(),
+    );
+  });
+
   it("strips unsafe image sources", async () => {
     const { container } = renderMarkdownPreview(
       '![Bad](javascript:alert(1))\n\n<img src="javascript:alert(1)" alt="raw bad" />',

--- a/src/extensions/default-layout/editor/markdown-preview.tsx
+++ b/src/extensions/default-layout/editor/markdown-preview.tsx
@@ -22,7 +22,7 @@
  *     tab's editor metadata says clean).
  */
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import ReactMarkdown from "react-markdown";
@@ -97,42 +97,45 @@ function PreviewMarkdownImage({
   node?: unknown;
 }) {
   void node;
-  const [resolvedSrc, setResolvedSrc] = useState<string | null>(null);
+  const [resolvedLocalSrc, setResolvedLocalSrc] = useState<{
+    key: string;
+    src: string;
+  } | null>(null);
+  const safeDirectSrc = safeMarkdownImageSrc(src);
+  const imagePath = safeDirectSrc
+    ? null
+    : resolveMarkdownLinkPath(src, currentFilePath, projectPath);
+  const localImageKey =
+    imagePath && projectPath ? `${projectPath}\0${imagePath}` : "";
 
   useEffect(() => {
-    const safeDirectSrc = safeMarkdownImageSrc(src);
-    if (safeDirectSrc) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- Keep remote/data images synchronous from the markdown source.
-      setResolvedSrc(safeDirectSrc);
-      return;
-    }
-
-    const imagePath = resolveMarkdownLinkPath(src, currentFilePath, projectPath);
-    if (!imagePath || !projectPath) {
-      setResolvedSrc(null);
-      return;
-    }
+    if (!imagePath || !projectPath || !localImageKey) return;
 
     let cancelled = false;
-    setResolvedSrc(null);
     void invoke<string>("fs_read_file_base64", {
       root: projectPath,
       path: imagePath,
     })
       .then((b64) => {
         if (cancelled) return;
-        setResolvedSrc(`data:${imageMimeFromPath(imagePath)};base64,${b64}`);
+        setResolvedLocalSrc({
+          key: localImageKey,
+          src: `data:${imageMimeFromPath(imagePath)};base64,${b64}`,
+        });
       })
       .catch(() => {
-        if (!cancelled) setResolvedSrc(null);
+        if (!cancelled) setResolvedLocalSrc({ key: localImageKey, src: "" });
       });
     return () => {
       cancelled = true;
     };
-  }, [currentFilePath, projectPath, src]);
+  }, [imagePath, localImageKey, projectPath]);
 
-  if (!resolvedSrc) return null;
-  return <img {...rest} src={resolvedSrc} alt={alt ?? ""} />;
+  const imageSrc =
+    safeDirectSrc ??
+    (resolvedLocalSrc?.key === localImageKey ? resolvedLocalSrc.src : null);
+  if (!imageSrc) return null;
+  return <img {...rest} src={imageSrc} alt={alt ?? ""} />;
 }
 
 export function MarkdownPreview(props: BuiltinComponentProps) {
@@ -143,81 +146,100 @@ export function MarkdownPreview(props: BuiltinComponentProps) {
   const tabId = componentProps.tabId ?? "";
   const refreshKey = componentProps.refreshKey ?? 0;
   const onEvent = props.onEvent;
+  const linkEventContextRef = useRef({ tabId, onEvent });
+  const loadedPreviewTargetRef = useRef<string>("");
   const [text, setText] = useState<string>("");
   const [error, setError] = useState<string>("");
   const [loading, setLoading] = useState<boolean>(true);
+  useEffect(() => {
+    linkEventContextRef.current = { tabId, onEvent };
+  }, [onEvent, tabId]);
+  const markdownLinkComponent = useMemo(() => {
+    function MarkdownPreviewLink({
+      children,
+      href,
+      node,
+      ...rest
+    }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { node?: unknown }) {
+      void node;
+      return (
+        <a
+          {...rest}
+          href={href}
+          onClick={(event) => {
+            const targetPath = resolveMarkdownLinkPath(
+              href,
+              filePath,
+              projectPath,
+            );
+            const externalUrl = safeExternalHttpUrl(href);
+            if (!targetPath) {
+              if (!externalUrl) return;
+              event.preventDefault();
+              event.stopPropagation();
+              openExternalUrl(externalUrl);
+              return;
+            }
+            event.preventDefault();
+            event.stopPropagation();
+            const context = linkEventContextRef.current;
+            if (!context.tabId) return;
+            context.onEvent("markdown-link-open", {
+              tabId: context.tabId,
+              filePath: targetPath,
+              rootPath: projectPath,
+            });
+          }}
+        >
+          {children}
+        </a>
+      );
+    }
+    return MarkdownPreviewLink;
+  }, [filePath, projectPath]);
+  const markdownImageComponent = useMemo(() => {
+    function MarkdownPreviewImage({
+      node,
+      ...rest
+    }: React.ImgHTMLAttributes<HTMLImageElement> & { node?: unknown }) {
+      return (
+        <PreviewMarkdownImage
+          {...rest}
+          node={node}
+          currentFilePath={filePath}
+          projectPath={projectPath}
+        />
+      );
+    }
+    return MarkdownPreviewImage;
+  }, [filePath, projectPath]);
   const markdownProps = useMemo<ReactMarkdownOptions>(() => {
     const components = {
       ...MARKDOWN_PREVIEW_PROPS.components,
-      a({
-        children,
-        href,
-        node,
-        ...rest
-      }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { node?: unknown }) {
-        void node;
-        return (
-          <a
-            {...rest}
-            href={href}
-            onClick={(event) => {
-              const targetPath = resolveMarkdownLinkPath(
-                href,
-                filePath,
-                projectPath,
-              );
-              const externalUrl = safeExternalHttpUrl(href);
-              if (!targetPath) {
-                if (!externalUrl) return;
-                event.preventDefault();
-                event.stopPropagation();
-                openExternalUrl(externalUrl);
-                return;
-              }
-              event.preventDefault();
-              event.stopPropagation();
-              if (!tabId) return;
-              onEvent("markdown-link-open", {
-                tabId,
-                filePath: targetPath,
-                rootPath: projectPath,
-              });
-            }}
-          >
-            {children}
-          </a>
-        );
-      },
-      img({
-        node,
-        ...rest
-      }: React.ImgHTMLAttributes<HTMLImageElement> & { node?: unknown }) {
-        return (
-          <PreviewMarkdownImage
-            {...rest}
-            node={node}
-            currentFilePath={filePath}
-            projectPath={projectPath}
-          />
-        );
-      },
+      a: markdownLinkComponent,
+      img: markdownImageComponent,
     };
     return { ...MARKDOWN_PREVIEW_PROPS, components };
-  }, [filePath, onEvent, projectPath, tabId]);
+  }, [markdownImageComponent, markdownLinkComponent]);
 
   useEffect(() => {
     if (!filePath || !projectPath) {
+      loadedPreviewTargetRef.current = "";
       // eslint-disable-next-line react-hooks/set-state-in-effect -- Reflect the missing-file state before any async preview load can run.
       setError("no file");
       setLoading(false);
       return;
     }
     let cancelled = false;
-    setLoading(true);
+    const previewTarget = `${projectPath}\0${filePath}`;
+    if (loadedPreviewTargetRef.current !== previewTarget) {
+      setLoading(true);
+    }
     setError("");
     void invoke<string>("fs_read_file", { root: projectPath, path: filePath })
       .then((value) => {
         if (cancelled) return;
+        loadedPreviewTargetRef.current = previewTarget;
         setText(value);
         setLoading(false);
       })


### PR DESCRIPTION
## Summary
- Keep markdown preview badge images mounted across same-file rerenders and refreshes.
- Render safe remote/data image sources synchronously instead of routing them through an effect.
- Preserve the current rendered markdown while refreshing an already loaded file.
- Add a MutationObserver regression test that fails if remote badge images are removed during preview rerenders.

## Root Cause
`MarkdownPreview` rebuilt its custom ReactMarkdown `img` component during preview rerenders and refreshes. Safe remote badge images also passed through an effect-backed `resolvedSrc` state path, so the rendered `<img>` nodes could be removed and re-added even when the source URL never changed. In the dev app this showed up as shields.io README badges flickering around the badge row.

## Validation
- `bunx vitest run src/extensions/default-layout/editor/markdown-preview.test.tsx`
- `bun run typecheck`
- `bun run lint`
- Live dev-webview probe via `aethon-debug`: README preview badge count stayed at 4 with zero removed/added image mutations during an explicit preview refresh.
