### PR TITLE
Improve session restore, tabs, streaming, and context meter

### DIFF
--- a/agent/auth-profiles/manager.ts
+++ b/agent/auth-profiles/manager.ts
@@ -9,6 +9,7 @@ import type { Api, Model } from "@mariozechner/pi-ai";
 import type { AethonAgentState } from "../state";
 import type { DispatcherDeps, InboundMessage } from "../dispatcherTypes";
 import { emitGlobalReady } from "../dispatcherTypes";
+import { clearPendingContextUsageEmit } from "../context-usage";
 import { ensureTab } from "../tab-lifecycle";
 import {
   authProfileAuthPath,
@@ -398,6 +399,7 @@ async function handleUseForTab(
   }
   const previousModel = existing?.session.model;
   const cwd = state.tabProjectCwds.get(tabId);
+  if (existing) clearPendingContextUsageEmit(existing);
   state.tabs.delete(tabId);
   state.tabAuthProfileIds.set(tabId, profile.id);
   const services = servicesForProfile(state, profile.id);

--- a/agent/chat.ts
+++ b/agent/chat.ts
@@ -9,6 +9,7 @@ import {
   ensureTab,
 } from "./tab-lifecycle";
 import { modelRegistryForModelId } from "./auth-profiles";
+import { emitContextUsage } from "./context-usage";
 
 export async function handleChat(
   state: AethonAgentState,
@@ -185,6 +186,7 @@ export async function handleSetModel(
   deps.scheduleStateFileWrite();
   ensurePickerHasModel(state, deps, next);
   deps.send({ type: "model_changed", tabId, model: msg.id });
+  emitContextUsage(state, deps, tabId, tab);
 }
 
 export function handleStop(

--- a/agent/context-usage.test.ts
+++ b/agent/context-usage.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import type { AethonAgentState, TabRecord } from "./state";
+import {
+  contextUsageSnapshot,
+  emitContextUsage,
+} from "./context-usage";
+import { handleSessionEvent } from "./tab-lifecycle";
+
+function stateWithCompaction(overrides: Record<string, unknown> = {}) {
+  return {
+    currentAgentTabId: undefined,
+    turnStartTimes: new Map(),
+    settingsManager: {
+      getCompactionSettings: () => ({
+        enabled: true,
+        reserveTokens: 200,
+        keepRecentTokens: 100,
+      }),
+    },
+    ...overrides,
+  } as unknown as AethonAgentState;
+}
+
+function recWithUsage(
+  usage: { tokens: number | null; contextWindow: number; percent: number | null },
+): TabRecord {
+  return {
+    id: "tab-1",
+    session: {
+      model: {
+        id: "claude",
+        provider: "anthropic",
+        name: "Claude",
+        contextWindow: usage.contextWindow,
+      },
+      getContextUsage: () => usage,
+    } as unknown as TabRecord["session"],
+    toolArgsCache: new Map(),
+    promptInFlight: false,
+    agentEndFired: false,
+    queuedCount: 0,
+    toolCardSeq: 0,
+    responseMessageSeq: 0,
+  };
+}
+
+describe("contextUsageSnapshot", () => {
+  it("reports compaction threshold and remaining tokens from pi settings", () => {
+    const snapshot = contextUsageSnapshot(
+      stateWithCompaction(),
+      "tab-1",
+      recWithUsage({ tokens: 1_000, contextWindow: 2_000, percent: 50 }),
+    );
+
+    expect(snapshot).toMatchObject({
+      tabId: "tab-1",
+      model: "anthropic/claude",
+      status: "known",
+      tokens: 1_000,
+      contextWindow: 2_000,
+      autoCompactEnabled: true,
+      reserveTokens: 200,
+      compactAtTokens: 1_800,
+      tokensUntilCompact: 800,
+    });
+  });
+
+  it("keeps post-compaction usage unknown until pi reports fresh tokens", () => {
+    const snapshot = contextUsageSnapshot(
+      stateWithCompaction(),
+      "tab-1",
+      recWithUsage({ tokens: null, contextWindow: 2_000, percent: null }),
+    );
+
+    expect(snapshot).toMatchObject({
+      status: "unknown",
+      tokens: null,
+      percent: null,
+      compactAtTokens: 1_800,
+      tokensUntilCompact: null,
+    });
+  });
+});
+
+describe("live context updates", () => {
+  it("emits a realtime estimated context snapshot while text is streaming", () => {
+    const state = stateWithCompaction();
+    const rec = recWithUsage({
+      tokens: 1_000,
+      contextWindow: 2_000,
+      percent: 50,
+    });
+    const sent: Record<string, unknown>[] = [];
+
+    handleSessionEvent(
+      state,
+      { send: (msg) => sent.push(msg) },
+      rec,
+      "tab-1",
+      {
+        type: "message_update",
+        assistantMessageEvent: {
+          type: "text_delta",
+          delta: "streaming response grows the visible context meter",
+        },
+      },
+    );
+
+    const context = sent.find((msg) => msg.type === "context_usage");
+    expect(context).toMatchObject({
+      type: "context_usage",
+      tabId: "tab-1",
+      tokens: expect.any(Number),
+    });
+    expect(context?.tokens).toBeGreaterThan(1_000);
+    expect(context?.tokensUntilCompact).toBeLessThan(800);
+  });
+
+  it("clears transient estimates for authoritative turn-end usage", () => {
+    const state = stateWithCompaction({ currentAgentTabId: "tab-1" });
+    const rec = recWithUsage({
+      tokens: 1_000,
+      contextWindow: 2_000,
+      percent: 50,
+    });
+    rec.contextUsageTransientTokens = 50;
+    const sent: Record<string, unknown>[] = [];
+
+    emitContextUsage(state, { send: (msg) => sent.push(msg) }, "tab-1", rec);
+    handleSessionEvent(
+      state,
+      { send: (msg) => sent.push(msg) },
+      rec,
+      "tab-1",
+      { type: "agent_end", messages: [{ role: "assistant" }] },
+    );
+
+    const contexts = sent.filter((msg) => msg.type === "context_usage");
+    expect(contexts.at(-1)).toMatchObject({ tokens: 1_000 });
+    expect(rec.contextUsageTransientTokens).toBe(0);
+  });
+});

--- a/agent/context-usage.test.ts
+++ b/agent/context-usage.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { AethonAgentState, TabRecord } from "./state";
 import {
+  clearPendingContextUsageEmit,
   contextUsageSnapshot,
   emitContextUsage,
 } from "./context-usage";
@@ -83,6 +84,27 @@ describe("contextUsageSnapshot", () => {
 });
 
 describe("live context updates", () => {
+  it("cancels pending throttled context emits when a tab record is discarded", () => {
+    vi.useFakeTimers();
+    try {
+      const rec = recWithUsage({
+        tokens: 1_000,
+        contextWindow: 2_000,
+        percent: 50,
+      });
+      const fired = vi.fn();
+      rec.contextUsageEmitTimer = setTimeout(fired, 100);
+
+      clearPendingContextUsageEmit(rec);
+      vi.advanceTimersByTime(100);
+
+      expect(fired).not.toHaveBeenCalled();
+      expect(rec.contextUsageEmitTimer).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("emits a realtime estimated context snapshot while text is streaming", () => {
     const state = stateWithCompaction();
     const rec = recWithUsage({

--- a/agent/context-usage.ts
+++ b/agent/context-usage.ts
@@ -1,0 +1,135 @@
+import type { AethonAgentState, TabRecord } from "./state";
+import { modelKey } from "./tab-lifecycle/utils";
+
+const LIVE_CONTEXT_EMIT_INTERVAL_MS = 250;
+
+export interface ContextUsageSnapshot {
+  tabId: string;
+  model: string;
+  status: "known" | "unknown";
+  tokens: number | null;
+  contextWindow: number;
+  percent: number | null;
+  autoCompactEnabled: boolean;
+  reserveTokens: number;
+  compactAtTokens: number;
+  tokensUntilCompact: number | null;
+  compacting?: boolean;
+}
+
+interface PiContextUsage {
+  tokens: number | null;
+  contextWindow: number;
+  percent: number | null;
+}
+
+function finiteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function estimateTokens(text: string): number {
+  if (!text) return 0;
+  return Math.max(1, Math.ceil(text.length / 4));
+}
+
+function clearPendingEmit(rec: TabRecord): void {
+  if (rec.contextUsageEmitTimer !== undefined) {
+    clearTimeout(rec.contextUsageEmitTimer);
+    rec.contextUsageEmitTimer = undefined;
+  }
+}
+
+export function clearLiveContextUsageEstimate(rec: TabRecord): void {
+  rec.contextUsageTransientTokens = 0;
+}
+
+export function addLiveContextUsageEstimate(
+  rec: TabRecord,
+  text: string,
+): void {
+  const estimated = estimateTokens(text);
+  if (estimated <= 0) return;
+  rec.contextUsageTransientTokens =
+    (rec.contextUsageTransientTokens ?? 0) + estimated;
+}
+
+export function contextUsageSnapshot(
+  state: AethonAgentState,
+  tabId: string,
+  rec: TabRecord,
+  options: { compacting?: boolean } = {},
+): ContextUsageSnapshot | undefined {
+  const usage = (
+    rec.session as { getContextUsage?: () => PiContextUsage | undefined }
+  ).getContextUsage?.();
+  const modelContextWindow = finiteNumber(rec.session.model?.contextWindow);
+  const contextWindow =
+    finiteNumber(usage?.contextWindow) ?? modelContextWindow ?? 0;
+  if (contextWindow <= 0) return undefined;
+
+  const settings = state.settingsManager.getCompactionSettings();
+  const reserveTokens = Math.max(0, settings.reserveTokens);
+  const compactAtTokens = Math.max(contextWindow - reserveTokens, 0);
+  const baseTokens = finiteNumber(usage?.tokens) ?? null;
+  const transientTokens = Math.max(0, rec.contextUsageTransientTokens ?? 0);
+  const tokens =
+    baseTokens === null ? null : Math.min(baseTokens + transientTokens, contextWindow);
+  const percent =
+    (tokens !== baseTokens && tokens !== null
+      ? (tokens / contextWindow) * 100
+      : finiteNumber(usage?.percent)) ??
+    (tokens !== null && contextWindow > 0
+      ? (tokens / contextWindow) * 100
+      : null);
+
+  return {
+    tabId,
+    model: rec.session.model ? modelKey(rec.session.model) : "",
+    status: tokens === null || percent === null ? "unknown" : "known",
+    tokens,
+    contextWindow,
+    percent,
+    autoCompactEnabled: settings.enabled,
+    reserveTokens,
+    compactAtTokens,
+    tokensUntilCompact:
+      tokens === null ? null : Math.max(compactAtTokens - tokens, 0),
+    ...(options.compacting ? { compacting: true } : {}),
+  };
+}
+
+export function emitContextUsage(
+  state: AethonAgentState,
+  deps: { send: (obj: Record<string, unknown>) => void },
+  tabId: string,
+  rec: TabRecord,
+  options: { compacting?: boolean } = {},
+): void {
+  clearPendingEmit(rec);
+  rec.contextUsageLastEmitMs = Date.now();
+  const snapshot = contextUsageSnapshot(state, tabId, rec, options);
+  if (!snapshot) return;
+  deps.send({ type: "context_usage", ...snapshot });
+}
+
+export function emitContextUsageThrottled(
+  state: AethonAgentState,
+  deps: { send: (obj: Record<string, unknown>) => void },
+  tabId: string,
+  rec: TabRecord,
+): void {
+  const now = Date.now();
+  const last = rec.contextUsageLastEmitMs ?? 0;
+  const remaining = LIVE_CONTEXT_EMIT_INTERVAL_MS - (now - last);
+  if (remaining <= 0) {
+    emitContextUsage(state, deps, tabId, rec);
+    return;
+  }
+  if (rec.contextUsageEmitTimer !== undefined) return;
+  rec.contextUsageEmitTimer = setTimeout(() => {
+    rec.contextUsageEmitTimer = undefined;
+    emitContextUsage(state, deps, tabId, rec);
+  }, remaining);
+}

--- a/agent/context-usage.ts
+++ b/agent/context-usage.ts
@@ -34,7 +34,7 @@ function estimateTokens(text: string): number {
   return Math.max(1, Math.ceil(text.length / 4));
 }
 
-function clearPendingEmit(rec: TabRecord): void {
+export function clearPendingContextUsageEmit(rec: TabRecord): void {
   if (rec.contextUsageEmitTimer !== undefined) {
     clearTimeout(rec.contextUsageEmitTimer);
     rec.contextUsageEmitTimer = undefined;
@@ -107,7 +107,7 @@ export function emitContextUsage(
   rec: TabRecord,
   options: { compacting?: boolean } = {},
 ): void {
-  clearPendingEmit(rec);
+  clearPendingContextUsageEmit(rec);
   rec.contextUsageLastEmitMs = Date.now();
   const snapshot = contextUsageSnapshot(state, tabId, rec, options);
   if (!snapshot) return;

--- a/agent/dispatcher.test.ts
+++ b/agent/dispatcher.test.ts
@@ -120,6 +120,31 @@ describe("dispatchInboundMessage", () => {
     expect(f.writes()).toBe(1);
   });
 
+  it("formats native compact results as timeline markers", async () => {
+    const f = makeFixture();
+    f.state.tabs.set(
+      "tab-1",
+      fakeTabRecord({
+        session: {
+          compact: vi.fn(() => Promise.resolve({ tokensBefore: 159_747 })),
+        } as unknown as TabRecord["session"],
+      }),
+    );
+
+    await dispatchInboundMessage(f.state, f.deps, fakeAethonApi(), fakeExtensionApi, {
+      type: "native_slash_command",
+      name: "compact",
+      tabId: "tab-1",
+    });
+
+    expect(f.sent).toContainEqual({
+      type: "native_slash_result",
+      tabId: "tab-1",
+      command: "compact",
+      message: "Context compacted · 159,747 tokens summarized",
+    });
+  });
+
   it("contains handler failures and reports them as bridge errors", async () => {
     const f = makeFixture();
     const api = fakeAethonApi({

--- a/agent/dispatcher.test.ts
+++ b/agent/dispatcher.test.ts
@@ -120,6 +120,38 @@ describe("dispatchInboundMessage", () => {
     expect(f.writes()).toBe(1);
   });
 
+  it("cancels pending context usage emits when closing a tab", async () => {
+    vi.useFakeTimers();
+    try {
+      const f = makeFixture();
+      const delayedSend = vi.fn(() => {
+        f.sent.push({ type: "context_usage", tabId: "tab-1" });
+      });
+      const tab = fakeTabRecord({
+        contextUsageEmitTimer: setTimeout(delayedSend, 100),
+      });
+      f.state.tabs.set("tab-1", tab);
+
+      await dispatchInboundMessage(
+        f.state,
+        f.deps,
+        fakeAethonApi(),
+        fakeExtensionApi,
+        {
+          type: "tab_close",
+          tabId: "tab-1",
+        },
+      );
+      vi.advanceTimersByTime(100);
+
+      expect(delayedSend).not.toHaveBeenCalled();
+      expect(tab.contextUsageEmitTimer).toBeUndefined();
+      expect(f.state.tabs.has("tab-1")).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("formats native compact results as timeline markers", async () => {
     const f = makeFixture();
     f.state.tabs.set(

--- a/agent/nativeSlash.ts
+++ b/agent/nativeSlash.ts
@@ -207,13 +207,13 @@ export async function handleNativeSlashCommand(
         const result = await tab.session.compact(customInstructions);
         const tokensBefore =
           typeof result?.tokensBefore === "number"
-            ? ` ${formatInt(result.tokensBefore)} tokens were summarized.`
+            ? ` · ${formatInt(result.tokensBefore)} tokens summarized`
             : "";
         deps.send({
           type: "native_slash_result",
           tabId,
           command,
-          message: `Context compacted.${tokensBefore}`,
+          message: `Context compacted${tokensBefore}`,
         });
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);

--- a/agent/session-history.test.ts
+++ b/agent/session-history.test.ts
@@ -227,6 +227,43 @@ describe("parseSessionHistoryLines", () => {
     ]);
   });
 
+  it("restores pi compaction entries as durable timeline markers", () => {
+    const parsed = parseSessionHistoryLines([
+      JSON.stringify({
+        type: "message",
+        id: "before",
+        timestamp: "2026-06-02T13:23:02.101Z",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "before compaction" }],
+        },
+      }),
+      JSON.stringify({
+        type: "compaction",
+        id: "cmp-1",
+        parentId: "before",
+        timestamp: "2026-06-02T13:28:04.875Z",
+        summary: "Older work was summarized.",
+        tokensBefore: 13_005,
+      }),
+    ]);
+
+    expect(parsed).toEqual([
+      {
+        id: "before",
+        role: "agent",
+        text: "before compaction",
+        createdAt: Date.parse("2026-06-02T13:23:02.101Z"),
+      },
+      {
+        id: "compaction:cmp-1",
+        role: "system",
+        text: "Context compacted · 13,005 tokens summarized",
+        createdAt: Date.parse("2026-06-02T13:28:04.875Z"),
+      },
+    ]);
+  });
+
   it("keeps the most recent bounded set of restored messages", () => {
     const lines = Array.from({ length: 205 }, (_, index) =>
       JSON.stringify({
@@ -349,6 +386,61 @@ describe("readSessionTranscript", () => {
         id: "stderr-warning",
         role: "system",
         text: "[agent stderr] transient provider error",
+        createdAt: 2_000,
+      },
+      { id: "pi-agent", role: "agent", text: "done", createdAt: 3_000 },
+    ]);
+  });
+
+  it("dedupes live compaction notices when pi restored the compaction entry", async () => {
+    const dir = await tempRoot();
+    const path = join(dir, "session.jsonl");
+    await writeFile(
+      path,
+      [
+        JSON.stringify({
+          type: "message",
+          id: "pi-user",
+          timestamp: 1_000,
+          message: { role: "user", content: [{ type: "text", text: "hi" }] },
+        }),
+        JSON.stringify({
+          type: "compaction",
+          id: "cmp-1",
+          timestamp: 2_000,
+          summary: "Older work was summarized.",
+          tokensBefore: 13_005,
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "pi-agent",
+          timestamp: 3_000,
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "done" }],
+          },
+        }),
+      ].join("\n") + "\n",
+    );
+    await appendLocalChatMessage(dir, {
+      id: "compact-start",
+      role: "system",
+      text: "Compacting context...",
+      createdAt: 1_990,
+    });
+    await appendLocalChatMessage(dir, {
+      id: "compact-done",
+      role: "system",
+      text: "Context compacted · 13,005 tokens summarized",
+      createdAt: 2_010,
+    });
+
+    await expect(readSessionTranscript(dir)).resolves.toEqual([
+      { id: "pi-user", role: "user", text: "hi", createdAt: 1_000 },
+      {
+        id: "compaction:cmp-1",
+        role: "system",
+        text: "Context compacted · 13,005 tokens summarized",
         createdAt: 2_000,
       },
       { id: "pi-agent", role: "agent", text: "done", createdAt: 3_000 },

--- a/agent/session-history/parse-pi.ts
+++ b/agent/session-history/parse-pi.ts
@@ -63,6 +63,7 @@ function compactionMessage(record: Record<string, unknown>): RestoredChatMessage
     typeof record.tokensBefore === "number" && Number.isFinite(record.tokensBefore)
       ? record.tokensBefore
       : undefined;
+  const createdAt = parseRecordTime(record);
   return {
     id: `compaction:${id}`,
     role: "system",
@@ -70,9 +71,7 @@ function compactionMessage(record: Record<string, unknown>): RestoredChatMessage
       tokensBefore !== undefined
         ? `Context compacted · ${formatInt(tokensBefore)} tokens summarized`
         : "Context compacted",
-    ...(parseRecordTime(record) !== undefined
-      ? { createdAt: parseRecordTime(record) }
-      : {}),
+    ...(createdAt !== undefined ? { createdAt } : {}),
   };
 }
 

--- a/agent/session-history/parse-pi.ts
+++ b/agent/session-history/parse-pi.ts
@@ -37,6 +37,45 @@ function restoredToolUiId(toolCallId: string): string {
   return `restored-tool-${safe || "unknown"}`;
 }
 
+function formatInt(value: number): string {
+  return new Intl.NumberFormat("en-US").format(Math.round(value));
+}
+
+function parseRecordTime(record: Record<string, unknown>): number | undefined {
+  const timestamp = record.timestamp;
+  if (typeof timestamp === "number" && Number.isFinite(timestamp)) {
+    return timestamp;
+  }
+  if (typeof timestamp === "string") {
+    const parsed = Date.parse(timestamp);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+}
+
+function compactionMessage(record: Record<string, unknown>): RestoredChatMessage | undefined {
+  const id =
+    typeof record.id === "string" && record.id.length > 0
+      ? record.id
+      : undefined;
+  if (!id) return undefined;
+  const tokensBefore =
+    typeof record.tokensBefore === "number" && Number.isFinite(record.tokensBefore)
+      ? record.tokensBefore
+      : undefined;
+  return {
+    id: `compaction:${id}`,
+    role: "system",
+    text:
+      tokensBefore !== undefined
+        ? `Context compacted · ${formatInt(tokensBefore)} tokens summarized`
+        : "Context compacted",
+    ...(parseRecordTime(record) !== undefined
+      ? { createdAt: parseRecordTime(record) }
+      : {}),
+  };
+}
+
 interface RestoredToolCall {
   messageIndex: number;
   uiId: string;
@@ -90,6 +129,14 @@ export function parseSessionHistoryLines(
     }
     if (!entry || typeof entry !== "object") continue;
     const record = entry as Record<string, unknown>;
+    if (record.type === "compaction") {
+      const message = compactionMessage(record);
+      if (message && !seen.has(message.id)) {
+        seen.add(message.id);
+        messages.push(message);
+      }
+      continue;
+    }
     if (record.type !== "message") continue;
 
     const message = record.message;

--- a/agent/session-history/restore.ts
+++ b/agent/session-history/restore.ts
@@ -144,6 +144,43 @@ function isCoveredByPiToolCard(
   );
 }
 
+function isCompactionMarker(message: RestoredChatMessage): boolean {
+  if (message.role !== "system" || typeof message.text !== "string") {
+    return false;
+  }
+  const text = message.text.replace(/\s+/g, " ").trim().toLowerCase();
+  return (
+    text === "compacting context..." ||
+    text === "compacting context…" ||
+    text.startsWith("context compacted") ||
+    text.startsWith("context compaction complete") ||
+    text.startsWith("context compaction failed:")
+  );
+}
+
+function piCompactionMarkers(
+  piMessages: RestoredChatMessage[],
+): RestoredChatMessage[] {
+  return piMessages.filter(
+    (message) => message.id.startsWith("compaction:") && isCompactionMarker(message),
+  );
+}
+
+function isCoveredByPiCompaction(
+  message: RestoredChatMessage,
+  piCompactions: readonly RestoredChatMessage[],
+): boolean {
+  if (!isCompactionMarker(message) || piCompactions.length === 0) return false;
+  if (typeof message.createdAt !== "number") {
+    return piCompactions.some((candidate) => candidate.text === message.text);
+  }
+  return piCompactions.some(
+    (candidate) =>
+      typeof candidate.createdAt === "number" &&
+      Math.abs(candidate.createdAt - message.createdAt) <= 5 * 60 * 1000,
+  );
+}
+
 function dedupeLocalMessages(
   piMessages: RestoredChatMessage[],
   localMessages: RestoredChatMessage[],
@@ -151,8 +188,10 @@ function dedupeLocalMessages(
   const seenIds = new Set(piMessages.map((message) => message.id));
   const contentIndex = piContentIndex(piMessages);
   const piToolCards = piToolCardIdentitySet(piMessages);
+  const piCompactions = piCompactionMarkers(piMessages);
   return localMessages.filter((message) => {
     if (seenIds.has(message.id)) return false;
+    if (isCoveredByPiCompaction(message, piCompactions)) return false;
     if (isCoveredByPiToolCard(message, piToolCards)) return false;
     return !isCoveredByPiContent(message, contentIndex);
   });

--- a/agent/state.ts
+++ b/agent/state.ts
@@ -249,6 +249,11 @@ export interface TabRecord {
   aethonRetryAttempt?: number;
   aethonRetryInFlight?: boolean;
   aethonRetryTimer?: ReturnType<typeof setTimeout>;
+  /** Live context-meter estimate for text/tool output that has streamed
+   *  in this turn but has not yet landed in pi's authoritative usage. */
+  contextUsageTransientTokens?: number;
+  contextUsageLastEmitMs?: number;
+  contextUsageEmitTimer?: ReturnType<typeof setTimeout>;
 }
 
 export interface ProjectBaselineSnapshot {

--- a/agent/tab-lifecycle.test.ts
+++ b/agent/tab-lifecycle.test.ts
@@ -453,7 +453,23 @@ describe("handleSessionEvent", () => {
       type: "notice",
       tabId: "tab-1",
       busy: true,
-      message: "Compacting context…",
+      message: "Compacting context...",
+    });
+  });
+
+  it("surfaces completed compaction as a timeline notice with token count", () => {
+    const f = makeFixture();
+    const rec = fakeRec();
+
+    handleSessionEvent(f.state, f.deps, rec, "tab-1", {
+      type: "auto_compaction_end",
+      tokensBefore: 13_005,
+    });
+
+    expect(f.sent[0]).toEqual({
+      type: "notice",
+      tabId: "tab-1",
+      message: "Context compacted · 13,005 tokens summarized",
     });
   });
 

--- a/agent/tab-lifecycle/events.ts
+++ b/agent/tab-lifecycle/events.ts
@@ -35,6 +35,12 @@ import { emitBashResult } from "./terminal";
 import { cancelAethonRetry, scheduleAethonRetry } from "./retry";
 import type { TabLifecycleDeps } from "./utils";
 import { modelKey } from "./utils";
+import {
+  addLiveContextUsageEstimate,
+  clearLiveContextUsageEstimate,
+  emitContextUsage,
+  emitContextUsageThrottled,
+} from "../context-usage";
 
 const turnLog = logger.scope("turn");
 
@@ -134,19 +140,27 @@ export function handleSessionEvent(
 ): void {
   const compacting = compactionNotice(event);
   if (compacting) {
+    if (!compacting.busy) {
+      clearLiveContextUsageEstimate(rec);
+    }
     deps.send({
       type: "notice",
       tabId,
       ...(compacting.busy ? { busy: true } : {}),
       message: compacting.message,
     });
+    emitContextUsage(state, deps, tabId, rec, {
+      compacting: compacting.busy === true,
+    });
   }
 
   switch (event.type) {
     case "agent_start": {
       rollResponseMessage(rec);
+      clearLiveContextUsageEstimate(rec);
       state.currentAgentTabId = tabId;
       state.turnStartTimes.set(tabId, Date.now());
+      emitContextUsage(state, deps, tabId, rec);
       const model = rec.session.model ? modelKey(rec.session.model) : "unknown";
       turnLog.info(`start model=${model} tabId=${tabId}`);
       if (rec.queuedCount > 0) {
@@ -188,6 +202,8 @@ export function handleSessionEvent(
             content: delta,
             channel,
           });
+          addLiveContextUsageEstimate(rec, delta);
+          emitContextUsageThrottled(state, deps, tabId, rec);
         }
       }
       break;
@@ -214,6 +230,8 @@ export function handleSessionEvent(
         startedAt,
       });
       deps.send({ type: "a2ui", tabId, id: uiId, payload });
+      addLiveContextUsageEstimate(rec, `${ev.toolName} ${summary}`);
+      emitContextUsageThrottled(state, deps, tabId, rec);
       rollResponseMessage(rec);
       if (ev.toolName === "bash") {
         const cmd = String(
@@ -252,6 +270,8 @@ export function handleSessionEvent(
         );
         cached.bashStream = streamed.state;
         emitBashResult(deps, streamed.delta, tabId);
+        addLiveContextUsageEstimate(rec, streamed.delta);
+        emitContextUsageThrottled(state, deps, tabId, rec);
       }
       break;
     }
@@ -286,10 +306,14 @@ export function handleSessionEvent(
           cached?.bashStream,
         );
         emitBashResult(deps, streamed.delta, tabId);
+        addLiveContextUsageEstimate(rec, streamed.delta);
         deps.send({ type: "terminal_output", tabId, content: "\r\n" });
+      } else {
+        addLiveContextUsageEstimate(rec, summarizeToolResult(ev.result));
       }
       rec.toolArgsCache.delete(ev.toolCallId);
       rollResponseMessage(rec);
+      emitContextUsageThrottled(state, deps, tabId, rec);
       break;
     }
     case "agent_end": {
@@ -335,6 +359,8 @@ export function handleSessionEvent(
           state.currentAgentTabId = undefined;
         }
         rollResponseMessage(rec);
+        clearLiveContextUsageEstimate(rec);
+        emitContextUsage(state, deps, tabId, rec);
         deps.send({ type: "response_end", tabId });
       }
       break;
@@ -382,5 +408,14 @@ export function handleSessionEvent(
       }
       break;
     }
+  }
+}
+
+function summarizeToolResult(result: unknown): string {
+  if (typeof result === "string") return result.slice(0, 16_384);
+  try {
+    return JSON.stringify(result).slice(0, 16_384);
+  } catch {
+    return String(result).slice(0, 16_384);
   }
 }

--- a/agent/tab-lifecycle/events.ts
+++ b/agent/tab-lifecycle/events.ts
@@ -104,7 +104,7 @@ function compactionNotice(
   const type = event.type.toLowerCase();
   if (!type.includes("compact")) return undefined;
   if (type.includes("start") || type.includes("begin")) {
-    return { message: "Compacting context…", busy: true };
+    return { message: "Compacting context...", busy: true };
   }
   if (type.includes("fail") || type.includes("error")) {
     const reason =
@@ -121,7 +121,11 @@ function compactionNotice(
     type.includes("complete") ||
     type.includes("success")
   ) {
-    return { message: "Context compaction complete." };
+    const tokensBefore =
+      typeof event.tokensBefore === "number" && Number.isFinite(event.tokensBefore)
+        ? ` · ${event.tokensBefore.toLocaleString("en-US")} tokens summarized`
+        : "";
+    return { message: `Context compacted${tokensBefore}` };
   }
   return undefined;
 }

--- a/agent/tab-lifecycle/index.ts
+++ b/agent/tab-lifecycle/index.ts
@@ -49,3 +49,8 @@ export { handleSessionEvent } from "./events";
 export { cancelAethonRetry, installAethonRetryClassifier } from "./retry";
 export type { EnsureTabOptions } from "./lifecycle";
 export { ensureTab } from "./lifecycle";
+export {
+  contextUsageSnapshot,
+  emitContextUsage,
+  type ContextUsageSnapshot,
+} from "../context-usage";

--- a/agent/tab-lifecycle/lifecycle.ts
+++ b/agent/tab-lifecycle/lifecycle.ts
@@ -25,6 +25,7 @@ import { logger } from "../logger";
 import { authProfileServicesForTab } from "../auth-profiles";
 import { findSessionFileMatchingCwd } from "../session-history";
 import type { AethonAgentState, TabRecord } from "../state";
+import { contextUsageSnapshot, emitContextUsage } from "../context-usage";
 import { handleSessionEvent } from "./events";
 import { installAethonRetryClassifier } from "./retry";
 import {
@@ -159,7 +160,9 @@ export async function ensureTab(
     type: "tab_ready",
     tabId,
     model: session.model ? modelKey(session.model) : "",
+    contextUsage: contextUsageSnapshot(state, tabId, rec),
   });
+  emitContextUsage(state, deps, tabId, rec);
 
   return rec;
 }

--- a/agent/tab-lifecycle/ready-handshake.ts
+++ b/agent/tab-lifecycle/ready-handshake.ts
@@ -12,6 +12,7 @@
 
 import type { AethonAgentState } from "../state";
 import { authProfilesSnapshot } from "../auth-profiles";
+import { contextUsageSnapshot } from "../context-usage";
 import { defaultModelKey } from "./models";
 import { refreshPiSlashCommands } from "./slash-commands";
 import type { TabLifecycleDeps } from "./utils";
@@ -39,6 +40,7 @@ export function emitReady(
       model: t.session.model ? modelKey(t.session.model) : "",
       cwd: state.tabProjectCwds.get(t.id),
       authProfileId: state.tabAuthProfileIds.get(t.id),
+      contextUsage: contextUsageSnapshot(state, t.id, t),
     })),
     extensionComponents: Object.fromEntries(state.extensionComponents),
     extensionState: state.extensionStateTree,

--- a/agent/tabs.ts
+++ b/agent/tabs.ts
@@ -15,6 +15,7 @@ import {
 import { ensureTab, tabSessionDir } from "./tab-lifecycle";
 import { unloadProjectExtensions } from "./projectLifecycle";
 import { modelRegistryForModelId } from "./auth-profiles";
+import { clearPendingContextUsageEmit } from "./context-usage";
 
 export async function handleTabOpen(
   state: AethonAgentState,
@@ -117,6 +118,7 @@ export function handleTabClose(
       /* fire-and-forget - we're tearing down anyway */
     });
   }
+  clearPendingContextUsageEmit(tab);
   state.tabs.delete(tabId);
   state.tabProjectCwds.delete(tabId);
   state.tabAuthProfileIds.delete(tabId);

--- a/src-tauri/src/helpers/config.rs
+++ b/src-tauri/src/helpers/config.rs
@@ -219,8 +219,8 @@ pub fn normalize_default_share_mode(input: Option<&str>) -> &'static str {
     }
 }
 
-/// Validate-and-normalize the `[shortcuts] new_tab_kind` key. Unknown or
-/// missing values fall through to `"agent"` (the focus-aware default).
+/// Validate-and-normalize the deprecated `[shortcuts] new_tab_kind` key so
+/// older config files still parse and round-trip predictably.
 pub fn normalize_new_tab_kind(input: Option<&str>) -> &'static str {
     match input {
         Some("shell") => "shell",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -139,7 +139,6 @@ export default function App() {
     shellDefaultArgsRef,
     shellInheritEnvRef,
     shellPromptBeforeCloseRef,
-    shortcutsNewTabKindRef,
     reapplyConfig,
   } = useBootConfig({ setState, piDefaultModelRef });
 
@@ -717,7 +716,6 @@ export default function App() {
   useKeyboardShortcuts({
     stateRef,
     extensionKeybindingsRef,
-    shortcutsNewTabKindRef,
     toggleTerminalAndFocus,
     toggleSidebar,
     toggleFilesSidebar,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -801,6 +801,7 @@ export default function App() {
     closeTab,
     nextTab,
     appendMessage,
+    persistLocalChatMessage,
     appendSystem,
     setStatusFlags,
     clearChat,

--- a/src/components/HighlightedCode.tsx
+++ b/src/components/HighlightedCode.tsx
@@ -92,7 +92,7 @@ export function HighlightedCode({
       <code>{text}</code>
     );
 
-  if (lang === "text" && !showLineNumbers) {
+  if (lang === "text" && !showLineNumbers && !text.includes("\n")) {
     return (
       <pre className={`a2ui-code ${className ?? ""}`} data-language="text">
         {codeEl}

--- a/src/config.ts
+++ b/src/config.ts
@@ -46,10 +46,9 @@ export interface AethonConfig {
     promptBeforeClose: boolean;
   };
   shortcuts: {
-    /** What `Cmd+T` opens when focus is *outside* the bottom terminal
-     *  panel: `"agent"` (default — focus-aware behaviour) or `"shell"`
-     *  (Cmd+T always opens a shell sub-tab). Anything else falls
-     *  through to `"agent"`. */
+    /** Deprecated compatibility field. Older configs may contain
+     *  `[shortcuts] new_tab_kind`, so parse and round-trip it, but Cmd+T
+     *  is now strictly focus-aware in the keyboard handler. */
     newTabKind: "agent" | "shell";
   };
   voice: {

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,8 +13,8 @@ export interface AethonConfig {
      *  `aethon.registerTheme`. */
     theme: string | null;
     fontSize: number | null;
-    /** When true, discovered per-tab sessions are reopened automatically
-     *  on app launch instead of only appearing in the empty-state list. */
+    /** Deprecated compatibility field. Session tabs are restored
+     *  unconditionally; keep this so older configs round-trip. */
     restoreTabs: boolean;
     /** Fire a native OS notification when an agent turn finishes while
      *  the originating tab/window is unfocused. Default true. */

--- a/src/extensions/default-layout/chat.test.tsx
+++ b/src/extensions/default-layout/chat.test.tsx
@@ -147,7 +147,7 @@ function renderInput(
 
 function renderHistory(state: Record<string, unknown>) {
   const onEvent = vi.fn();
-  render(
+  const result = render(
     <ChatHistory
       component={{
         id: "chat-history",
@@ -158,7 +158,7 @@ function renderHistory(state: Record<string, unknown>) {
       onEvent={onEvent}
     />,
   );
-  return { onEvent };
+  return { onEvent, ...result };
 }
 
 function renderToolCard(props: Record<string, unknown>) {
@@ -459,6 +459,37 @@ describe("ChatInput", () => {
     expect(screen.queryByText("```text")).toBeNull();
     expect(virtuosoMockState.followOutput).toEqual(expect.any(Function));
     expect((virtuosoMockState.followOutput as () => unknown)()).toBe("auto");
+  });
+
+  it("rerenders the latest fenced message when streaming finishes", () => {
+    const messages = [
+      { id: "1", role: "user", text: "show code" },
+      {
+        id: "2",
+        role: "agent",
+        text: ["```text", "hello", "```"].join("\n"),
+      },
+    ];
+    const { onEvent, rerender } = renderHistory({
+      waiting: true,
+      messages,
+    });
+
+    expect(document.querySelector(".a2ui-code-frame")).toBeTruthy();
+
+    rerender(
+      <ChatHistory
+        component={{
+          id: "chat-history",
+          type: "chat-history",
+          props: { messages: { $ref: "/messages" } },
+        }}
+        state={{ waiting: false, messages }}
+        onEvent={onEvent}
+      />,
+    );
+
+    expect(document.querySelector(".a2ui-code-frame")).toBeNull();
   });
 
   it("keeps smooth follow for normal streaming prose", () => {

--- a/src/extensions/default-layout/chat.test.tsx
+++ b/src/extensions/default-layout/chat.test.tsx
@@ -442,6 +442,39 @@ describe("ChatInput", () => {
     expect((virtuosoMockState.followOutput as () => unknown)()).toBe("smooth");
   });
 
+  it("uses stable non-animated follow only while the latest agent text streams a fenced block", () => {
+    renderHistory({
+      waiting: true,
+      messages: [
+        { id: "1", role: "user", text: "show code" },
+        {
+          id: "2",
+          role: "agent",
+          text: ["```text", "hello", "```"].join("\n"),
+        },
+      ],
+    });
+
+    expect(document.querySelector(".a2ui-code-frame")).toBeTruthy();
+    expect(screen.queryByText("```text")).toBeNull();
+    expect(virtuosoMockState.followOutput).toEqual(expect.any(Function));
+    expect((virtuosoMockState.followOutput as () => unknown)()).toBe("auto");
+  });
+
+  it("keeps smooth follow for normal streaming prose", () => {
+    renderHistory({
+      waiting: true,
+      messages: [
+        { id: "1", role: "user", text: "go" },
+        { id: "2", role: "agent", text: "ordinary streaming answer" },
+      ],
+    });
+
+    expect(document.querySelector(".a2ui-code-frame")).toBeNull();
+    expect(virtuosoMockState.followOutput).toEqual(expect.any(Function));
+    expect((virtuosoMockState.followOutput as () => unknown)()).toBe("smooth");
+  });
+
   it("renders user image attachments and opens them in a lightbox", () => {
     renderHistory({
       messages: [

--- a/src/extensions/default-layout/layout/status-bar.test.tsx
+++ b/src/extensions/default-layout/layout/status-bar.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { A2UIComponent } from "../../../types/a2ui";
+import { StatusBar } from "./status-bar";
+
+afterEach(() => cleanup());
+
+function statusBarComponent(): A2UIComponent {
+  return {
+    id: "status-bar",
+    type: "status-bar",
+    props: {
+      left: { $ref: "/status" },
+      center: { $ref: "/connection" },
+      right: { $ref: "/model" },
+      context: { $ref: "/contextUsage" },
+    },
+  };
+}
+
+function renderStatusBar(state: Record<string, unknown>) {
+  render(
+    <StatusBar
+      component={statusBarComponent()}
+      state={state}
+      onEvent={vi.fn()}
+    />,
+  );
+}
+
+describe("StatusBar context meter", () => {
+  it("renders current context and next auto-compaction threshold", () => {
+    renderStatusBar({
+      status: "ready",
+      connection: "connected",
+      model: "anthropic/claude",
+      contextUsage: {
+        model: "anthropic/claude",
+        status: "known",
+        tokens: 13_073,
+        contextWindow: 262_144,
+        percent: 4.98,
+        autoCompactEnabled: true,
+        reserveTokens: 16_384,
+        compactAtTokens: 245_760,
+        tokensUntilCompact: 232_687,
+      },
+    });
+
+    expect(screen.getByLabelText("Context 5%")).toBeTruthy();
+    expect(screen.getByText("ctx 5%")).toBeTruthy();
+    expect(screen.getByText("13k/262k")).toBeTruthy();
+    expect(screen.getByText("auto @246k")).toBeTruthy();
+  });
+
+  it("shows unknown usage after compaction without losing the threshold", () => {
+    renderStatusBar({
+      status: "ready",
+      connection: "connected",
+      model: "anthropic/claude",
+      contextUsage: {
+        model: "anthropic/claude",
+        status: "unknown",
+        tokens: null,
+        contextWindow: 200_000,
+        percent: null,
+        autoCompactEnabled: true,
+        reserveTokens: 16_384,
+        compactAtTokens: 183_616,
+        tokensUntilCompact: null,
+      },
+    });
+
+    expect(screen.getByLabelText("Context ?")).toBeTruthy();
+    expect(screen.getByText("?/200k")).toBeTruthy();
+    expect(screen.getByText("auto @184k")).toBeTruthy();
+  });
+});

--- a/src/extensions/default-layout/layout/status-bar.tsx
+++ b/src/extensions/default-layout/layout/status-bar.tsx
@@ -11,12 +11,14 @@ import { resolveString } from "../../../utils/dataBinding";
 import type { BuiltinComponentProps } from "../../../components/A2UIRenderer";
 import type { StringValue } from "../../../types/a2ui";
 import type { DevshellEntry } from "../../../hooks/useDevshell";
+import type { ContextUsageState } from "../../../types/tab";
 
 export function StatusBar({ component, state }: BuiltinComponentProps) {
   const props = component.props as {
     left?: StringValue;
     center?: StringValue;
     right?: StringValue;
+    context?: { $ref: string };
     /** Optional segments rendered between `left` and `center`. Each is
      *  a small chip carrying project / worktree / branch context.
      *  Resolved by reading the active project + active worktree from
@@ -27,6 +29,9 @@ export function StatusBar({ component, state }: BuiltinComponentProps) {
   const left = props.left ? resolveString(props.left, state) : "";
   const center = props.center ? resolveString(props.center, state) : "";
   const right = props.right ? resolveString(props.right, state) : "";
+  const contextUsage = props.context
+    ? contextUsageFromValue(resolveValue(state, props.context.$ref))
+    : null;
 
   // Project / worktree / branch chip — derived from the live sidebar
   // projects list so a single source of truth drives both the sidebar
@@ -128,6 +133,7 @@ export function StatusBar({ component, state }: BuiltinComponentProps) {
           <span className="a2ui-status-devshell-label">{devshellLabel}</span>
         </span>
       ) : null}
+      {contextUsage ? <ContextMeter usage={contextUsage} /> : null}
       <span className="a2ui-status-center">{center}</span>
       <span className="a2ui-status-right">{right}</span>
     </footer>
@@ -194,4 +200,104 @@ function devshellChipTooltip(entry: DevshellEntry): string | null {
       break;
   }
   return lines.join("\n");
+}
+
+function contextUsageFromValue(value: unknown): ContextUsageState | null {
+  if (!value || typeof value !== "object") return null;
+  const usage = value as Partial<ContextUsageState>;
+  if (
+    typeof usage.contextWindow !== "number" ||
+    !Number.isFinite(usage.contextWindow) ||
+    usage.contextWindow <= 0
+  ) {
+    return null;
+  }
+  return {
+    model: typeof usage.model === "string" ? usage.model : "",
+    status: usage.status === "known" ? "known" : "unknown",
+    tokens: finiteNumberOrNull(usage.tokens),
+    contextWindow: usage.contextWindow,
+    percent: finiteNumberOrNull(usage.percent),
+    autoCompactEnabled: usage.autoCompactEnabled === true,
+    reserveTokens: finiteNumberOrNull(usage.reserveTokens) ?? 0,
+    compactAtTokens:
+      finiteNumberOrNull(usage.compactAtTokens) ?? usage.contextWindow,
+    tokensUntilCompact: finiteNumberOrNull(usage.tokensUntilCompact),
+    ...(usage.compacting === true ? { compacting: true } : {}),
+  };
+}
+
+function finiteNumberOrNull(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function formatTokens(value: number | null | undefined): string {
+  if (typeof value !== "number" || !Number.isFinite(value)) return "?";
+  if (value < 1000) return value.toLocaleString("en-US");
+  if (value < 10_000) return `${(value / 1000).toFixed(1)}k`;
+  if (value < 1_000_000) return `${Math.round(value / 1000)}k`;
+  if (value < 10_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  return `${Math.round(value / 1_000_000)}M`;
+}
+
+function formatExactTokens(value: number | null | undefined): string {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value.toLocaleString("en-US")
+    : "unknown";
+}
+
+function ContextMeter({ usage }: { usage: ContextUsageState }) {
+  const percentValue =
+    usage.percent ??
+    (usage.tokens !== null ? (usage.tokens / usage.contextWindow) * 100 : null);
+  const usageClass =
+    percentValue !== null && percentValue >= 90
+      ? " is-danger"
+      : percentValue !== null && percentValue >= 70
+        ? " is-warning"
+        : "";
+  const compactingClass = usage.compacting ? " is-compacting" : "";
+  const percentLabel =
+    percentValue === null ? "?" : `${Math.round(percentValue)}%`;
+  const usedLabel =
+    usage.tokens === null
+      ? `?/${formatTokens(usage.contextWindow)}`
+      : `${formatTokens(usage.tokens)}/${formatTokens(usage.contextWindow)}`;
+  const autoLabel = usage.autoCompactEnabled
+    ? `auto @${formatTokens(usage.compactAtTokens)}`
+    : "auto off";
+  const title = [
+    usage.model ? `Model: ${usage.model}` : null,
+    `Context used: ${formatExactTokens(usage.tokens)} of ${formatExactTokens(
+      usage.contextWindow,
+    )} tokens`,
+    usage.percent === null
+      ? "Usage is unknown until the next assistant response."
+      : `Usage: ${usage.percent.toFixed(1)}%`,
+    usage.autoCompactEnabled
+      ? `Next auto compaction: ${formatExactTokens(
+          usage.compactAtTokens,
+        )} tokens (${formatExactTokens(usage.tokensUntilCompact)} remaining)`
+      : "Auto compaction: off",
+    `Reserve: ${formatExactTokens(usage.reserveTokens)} tokens`,
+  ]
+    .filter(Boolean)
+    .join("\n");
+  return (
+    <span
+      className={`a2ui-status-context-chip${usageClass}${compactingClass}`}
+      title={title}
+      aria-label={`Context ${percentLabel}`}
+    >
+      <span className="a2ui-status-context-track" aria-hidden="true">
+        <span
+          className="a2ui-status-context-fill"
+          style={{ width: `${Math.max(0, Math.min(percentValue ?? 0, 100))}%` }}
+        />
+      </span>
+      <span className="a2ui-status-context-label">ctx {percentLabel}</span>
+      <span className="a2ui-status-context-detail">{usedLabel}</span>
+      <span className="a2ui-status-context-auto">{autoLabel}</span>
+    </span>
+  );
 }

--- a/src/extensions/default-layout/markdown-adapter.tsx
+++ b/src/extensions/default-layout/markdown-adapter.tsx
@@ -270,80 +270,81 @@ function textFromHast(node: HastElementNode | undefined): string {
 }
 
 function createMarkdownComponents({
+  highlightFences = true,
   renderMermaid,
 }: {
+  highlightFences?: boolean;
   renderMermaid: boolean;
 }) {
+  const renderFence = (code: string, language?: string) =>
+    highlightFences ? (
+      <HighlightedFence code={code} language={language} />
+    ) : (
+      <PlainFence code={code} language={language} />
+    );
+
   return {
-  pre({
-    children,
-    node,
-    ...rest
-  }: React.HTMLAttributes<HTMLPreElement> & { node?: HastElementNode }) {
-    if (isHighlightedFenceChild(children)) {
-      return <>{children}</>;
-    }
-    const hastCodeChild =
-      node?.children?.length === 1 && node.children[0]?.tagName === "code"
-        ? node.children[0]
-        : undefined;
-    if (hastCodeChild) {
-      const code = textFromHast(hastCodeChild).replace(/\n$/, "");
-      const language = languageFromClassName(classNameFromHast(hastCodeChild));
-      if (renderMermaid && language?.toLowerCase() === "mermaid") {
-        return <MermaidDiagram code={code} />;
+    pre({
+      children,
+      node,
+      ...rest
+    }: React.HTMLAttributes<HTMLPreElement> & { node?: HastElementNode }) {
+      if (isHighlightedFenceChild(children)) {
+        return <>{children}</>;
       }
-      return (
-        <HighlightedFence
-          code={code}
-          language={language}
-        />
-      );
-    }
-    const codeChild = codeChildFromPre(children);
-    if (codeChild) {
-      const text = String(codeChild.props.children ?? "").replace(/\n$/, "");
-      const language = languageFromClassName(codeChild.props.className);
+      const hastCodeChild =
+        node?.children?.length === 1 && node.children[0]?.tagName === "code"
+          ? node.children[0]
+          : undefined;
+      if (hastCodeChild) {
+        const code = textFromHast(hastCodeChild).replace(/\n$/, "");
+        const language = languageFromClassName(
+          classNameFromHast(hastCodeChild),
+        );
+        if (renderMermaid && language?.toLowerCase() === "mermaid") {
+          return <MermaidDiagram code={code} />;
+        }
+        return renderFence(code, language);
+      }
+      const codeChild = codeChildFromPre(children);
+      if (codeChild) {
+        const text = String(codeChild.props.children ?? "").replace(/\n$/, "");
+        const language = languageFromClassName(codeChild.props.className);
+        if (renderMermaid && language?.toLowerCase() === "mermaid") {
+          return <MermaidDiagram code={text} />;
+        }
+        return renderFence(text, language);
+      }
+      return <pre {...rest}>{children}</pre>;
+    },
+    code({
+      inline,
+      className,
+      children,
+      node,
+      ...rest
+    }: {
+      inline?: boolean;
+      className?: string;
+      children?: React.ReactNode;
+      node?: { tagName?: string };
+    } & React.HTMLAttributes<HTMLElement>) {
+      void node;
+      const text = String(children ?? "").replace(/\n$/, "");
+      const language = languageFromClassName(className);
+      const isFence = inline === false || Boolean(language);
+      if (!isFence) {
+        return (
+          <code className={className} {...rest}>
+            {children}
+          </code>
+        );
+      }
       if (renderMermaid && language?.toLowerCase() === "mermaid") {
         return <MermaidDiagram code={text} />;
       }
-      return (
-        <HighlightedFence
-          code={text}
-          language={language}
-        />
-      );
-    }
-    return <pre {...rest}>{children}</pre>;
-  },
-  code({
-    inline,
-    className,
-    children,
-    node,
-    ...rest
-  }: {
-    inline?: boolean;
-    className?: string;
-    children?: React.ReactNode;
-    node?: { tagName?: string };
-  } & React.HTMLAttributes<HTMLElement>) {
-    void node;
-    const text = String(children ?? "").replace(/\n$/, "");
-    const language = languageFromClassName(className);
-    const isFence = inline === false || Boolean(language);
-    if (!isFence) {
-      return (
-        <code className={className} {...rest}>
-          {children}
-        </code>
-      );
-    }
-    if (renderMermaid && language?.toLowerCase() === "mermaid") {
-      return <MermaidDiagram code={text} />;
-    }
-    return <HighlightedFence code={text} language={language} />;
-  },
+      return renderFence(text, language);
+    },
   };
 }
 
@@ -356,40 +357,56 @@ const MARKDOWN_PREVIEW_COMPONENTS = createMarkdownComponents({
   renderMermaid: true,
 });
 
+function ChatAnchor({
+  children,
+  href,
+  node,
+  ...rest
+}: React.AnchorHTMLAttributes<HTMLAnchorElement> & { node?: unknown }) {
+  void node;
+  const safeHref = safeHttpUrl(href);
+  if (!safeHref) return <span>{children}</span>;
+
+  return (
+    <a
+      {...rest}
+      href={safeHref}
+      rel="noopener noreferrer"
+      target="_blank"
+      onClick={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        openExternalUrl(safeHref);
+      }}
+    >
+      {children}
+    </a>
+  );
+}
+
 // eslint-disable-next-line react-refresh/only-export-components -- chat-specific adapter map for react-markdown; not a component module
 export const CHAT_MARKDOWN_COMPONENTS = {
   ...MARKDOWN_COMPONENTS,
-  a({
-    children,
-    href,
-    node,
-    ...rest
-  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { node?: unknown }) {
-    void node;
-    const safeHref = safeHttpUrl(href);
-    if (!safeHref) return <span>{children}</span>;
-
-    return (
-      <a
-        {...rest}
-        href={safeHref}
-        rel="noopener noreferrer"
-        target="_blank"
-        onClick={(event) => {
-          event.preventDefault();
-          event.stopPropagation();
-          openExternalUrl(safeHref);
-        }}
-      >
-        {children}
-      </a>
-    );
-  },
+  a: ChatAnchor,
 };
 
 // eslint-disable-next-line react-refresh/only-export-components -- shared ReactMarkdown props for chat rendering
 export const CHAT_MARKDOWN_PROPS = {
   components: CHAT_MARKDOWN_COMPONENTS,
+  remarkPlugins: MARKDOWN_REMARK_PLUGINS,
+} satisfies Pick<ReactMarkdownOptions, "components" | "remarkPlugins">;
+
+const CHAT_STREAMING_MARKDOWN_COMPONENTS = {
+  ...createMarkdownComponents({
+    highlightFences: false,
+    renderMermaid: false,
+  }),
+  a: ChatAnchor,
+};
+
+// eslint-disable-next-line react-refresh/only-export-components -- shared ReactMarkdown props for active streaming code blocks
+export const CHAT_STREAMING_MARKDOWN_PROPS = {
+  components: CHAT_STREAMING_MARKDOWN_COMPONENTS,
   remarkPlugins: MARKDOWN_REMARK_PLUGINS,
 } satisfies Pick<ReactMarkdownOptions, "components" | "remarkPlugins">;
 
@@ -415,14 +432,41 @@ export function HighlightedFence({
   language?: string;
 }) {
   return (
-    <span data-highlighted-fence style={{ display: "block" }}>
+    <div data-highlighted-fence>
       <HighlightedCode code={code} language={language} />
-    </span>
+    </div>
+  );
+}
+
+export function PlainFence({
+  code,
+  language,
+}: {
+  code: string;
+  language?: string;
+}) {
+  const text = code.endsWith("\n") ? code.slice(0, -1) : code;
+  const lang = (language ?? "").toLowerCase();
+  const displayLang = lang || "text";
+  return (
+    <div data-highlighted-fence>
+      <div className="a2ui-code-frame" data-language={lang || "plain"}>
+        <div className="a2ui-code-header">
+          <span className="a2ui-code-title">{displayLang}</span>
+        </div>
+        <pre className="a2ui-code" data-language={lang || "plain"}>
+          <code>{text}</code>
+        </pre>
+      </div>
+    </div>
   );
 }
 
 function sanitizeMermaidSvg(svg: string): string {
-  if (typeof DOMParser === "undefined" || typeof XMLSerializer === "undefined") {
+  if (
+    typeof DOMParser === "undefined" ||
+    typeof XMLSerializer === "undefined"
+  ) {
     return svg;
   }
   const doc = new DOMParser().parseFromString(svg, "image/svg+xml");
@@ -433,7 +477,9 @@ function sanitizeMermaidSvg(svg: string): string {
   if (root.tagName.toLowerCase() !== "svg") {
     throw new Error("mermaid returned non-SVG content");
   }
-  for (const unsafe of Array.from(doc.querySelectorAll("script, foreignObject"))) {
+  for (const unsafe of Array.from(
+    doc.querySelectorAll("script, foreignObject"),
+  )) {
     unsafe.remove();
   }
   for (const element of Array.from(doc.querySelectorAll("*"))) {
@@ -488,7 +534,7 @@ export function MermaidDiagram({ code }: { code: string }) {
   const failed = renderResult.code === code ? renderResult.failed : false;
 
   return (
-    <span data-highlighted-fence style={{ display: "block" }}>
+    <div data-highlighted-fence>
       {svg && !failed ? (
         <div className="a2ui-mermaid-frame">
           <div className="a2ui-mermaid-header">mermaid</div>
@@ -500,6 +546,6 @@ export function MermaidDiagram({ code }: { code: string }) {
       ) : (
         <HighlightedCode code={code} language="mermaid" />
       )}
-    </span>
+    </div>
   );
 }

--- a/src/extensions/default-layout/message-list.tsx
+++ b/src/extensions/default-layout/message-list.tsx
@@ -12,7 +12,10 @@ import type { BuiltinComponentProps } from "../../components/A2UIRenderer";
 import { resolveString } from "../../utils/dataBinding";
 import { resolvePointer } from "../../utils/jsonPointer";
 import { splitThinkingBlocks } from "../../utils/thinkingBlocks";
-import { CHAT_MARKDOWN_PROPS } from "./markdown-adapter";
+import {
+  CHAT_MARKDOWN_PROPS,
+  CHAT_STREAMING_MARKDOWN_PROPS,
+} from "./markdown-adapter";
 import { isAtBottom as metricsAreAtBottom } from "../../utils/stickyScrollController";
 import { ImageAttachmentImage } from "./image-attachment-image";
 import { ImageLightbox } from "./image-lightbox";
@@ -20,6 +23,7 @@ import { ImageLightbox } from "./image-lightbox";
 // Distance (px) from the bottom still treated as "at the bottom" for follow +
 // the scroll-to-bottom pill. Matches the old StickyScrollController default.
 const DEFAULT_AT_BOTTOM_THRESHOLD = 60;
+const FENCED_CODE_MARKER_RE = /(^|\n)(```|~~~)/;
 
 // Top-level state keys that change identity on every streamed token — the
 // active tab's `messages` array and the `tabs` array that nests it (both
@@ -134,7 +138,20 @@ function ThinkingBlock({
   );
 }
 
-function MarkdownWithThinking({ text }: { text: string }) {
+function hasFencedCodeMarker(text: string | undefined): boolean {
+  return FENCED_CODE_MARKER_RE.test(text ?? "");
+}
+
+function MarkdownWithThinking({
+  text,
+  streamingFences = false,
+}: {
+  text: string;
+  streamingFences?: boolean;
+}) {
+  const markdownProps = streamingFences
+    ? CHAT_STREAMING_MARKDOWN_PROPS
+    : CHAT_MARKDOWN_PROPS;
   return (
     <>
       {splitThinkingBlocks(text).map((segment, index) => {
@@ -147,7 +164,7 @@ function MarkdownWithThinking({ text }: { text: string }) {
           );
         }
         return (
-          <ReactMarkdown key={index} {...CHAT_MARKDOWN_PROPS}>
+          <ReactMarkdown key={index} {...markdownProps}>
             {segment.content}
           </ReactMarkdown>
         );
@@ -193,6 +210,7 @@ const ChatMessageRow = memo(
     prevRole,
     onEvent,
     deliveryText,
+    isLatest,
   }: {
     message: ChatMessage;
     state: Record<string, unknown>;
@@ -201,6 +219,7 @@ const ChatMessageRow = memo(
     prevRole?: string;
     onEvent?: BuiltinComponentProps["onEvent"];
     deliveryText?: string;
+    isLatest?: boolean;
   }) {
     const isCanvas = className === "a2ui-canvas-message";
     const roleClass = isCanvas ? "a2ui-canvas-role" : "a2ui-chat-role";
@@ -212,6 +231,11 @@ const ChatMessageRow = memo(
       message.role === "user"
         ? (deliveryText ?? deliveryLabel(message.delivery))
         : null;
+    const streamingFences =
+      isLatest &&
+      message.role === "agent" &&
+      state.waiting === true &&
+      hasFencedCodeMarker(message.text);
     return (
       <div
         className={`${className} ${message.role}${showRole ? "" : " ae-msg-cont"}`}
@@ -251,7 +275,10 @@ const ChatMessageRow = memo(
         )}
         {message.text && (
           <div className={textClass}>
-            <MemoMarkdownWithThinking text={message.text} />
+            <MemoMarkdownWithThinking
+              text={message.text}
+              streamingFences={streamingFences}
+            />
           </div>
         )}
         {message.attachments && message.attachments.length > 0 && (
@@ -270,6 +297,7 @@ const ChatMessageRow = memo(
     prev.prevRole === next.prevRole &&
     prev.onEvent === next.onEvent &&
     prev.deliveryText === next.deliveryText &&
+    (!next.message.text || prev.isLatest === next.isLatest) &&
     (!next.message.a2ui ||
       shallowEqualExcept(prev.state, next.state, VOLATILE_ROW_STATE_KEYS)),
 );
@@ -451,6 +479,7 @@ function VirtualMessageList({
           prevRole={index > 0 ? messages[index - 1].role : undefined}
           onEvent={onEvent}
           deliveryText={queuedLabels.get(m.id)}
+          isLatest={index === messages.length - 1}
         />
       </div>
     ),
@@ -470,6 +499,11 @@ function VirtualMessageList({
     footerContext && (footerContext.liveSubtree || footerContext.showTyping),
   );
   const hasContent = messages.length > 0 || hasFooterContent;
+  const latestMessage = messages.at(-1);
+  const latestStreamingFences =
+    latestMessage?.role === "agent" &&
+    state.waiting === true &&
+    hasFencedCodeMarker(latestMessage.text);
 
   return (
     <div className="a2ui-msg-list-shell">
@@ -492,7 +526,13 @@ function VirtualMessageList({
           index: Math.max(0, messages.length - 1),
           align: "end",
         }}
-        followOutput={() => (followLatestRef.current ? "smooth" : false)}
+        followOutput={() =>
+          followLatestRef.current
+            ? latestStreamingFences
+              ? "auto"
+              : "smooth"
+            : false
+        }
         atBottomThreshold={DEFAULT_AT_BOTTOM_THRESHOLD}
         atBottomStateChange={handleAtBottomStateChange}
         scrollerRef={handleScrollerRef}

--- a/src/extensions/default-layout/message-list.tsx
+++ b/src/extensions/default-layout/message-list.tsx
@@ -297,6 +297,9 @@ const ChatMessageRow = memo(
     prev.prevRole === next.prevRole &&
     prev.onEvent === next.onEvent &&
     prev.deliveryText === next.deliveryText &&
+    (!next.message.text ||
+      !next.isLatest ||
+      prev.state.waiting === next.state.waiting) &&
     (!next.message.text || prev.isLatest === next.isLatest) &&
     (!next.message.a2ui ||
       shallowEqualExcept(prev.state, next.state, VOLATILE_ROW_STATE_KEYS)),

--- a/src/extensions/default-layout/settings-panel/panel.tsx
+++ b/src/extensions/default-layout/settings-panel/panel.tsx
@@ -272,26 +272,6 @@ export function SettingsPanel({ state, onEvent }: BuiltinComponentProps) {
                   }
                 />
               </Field>
-              <Field label="Cmd+T opens">
-                <select
-                  className="ae-settings-input"
-                  value={eff.shortcuts.newTabKind}
-                  onChange={(e) =>
-                    update({
-                      shortcuts: {
-                        ...eff.shortcuts,
-                        newTabKind:
-                          e.target.value === "shell" ? "shell" : "agent",
-                      },
-                    })
-                  }
-                >
-                  <option value="agent">
-                    Agent tab (focus-aware default)
-                  </option>
-                  <option value="shell">Always a shell tab</option>
-                </select>
-              </Field>
               <div className="ae-settings-ansi-preview">
                 <span className="ae-settings-field-label">
                   ANSI palette preview

--- a/src/extensions/default-layout/settings-panel/panel.tsx
+++ b/src/extensions/default-layout/settings-panel/panel.tsx
@@ -129,15 +129,6 @@ export function SettingsPanel({ state, onEvent }: BuiltinComponentProps) {
                   }
                 />
               </Field>
-              <Field label="Restore tabs on launch">
-                <input
-                  type="checkbox"
-                  checked={eff.ui.restoreTabs}
-                  onChange={(e) =>
-                    update({ ui: { ...eff.ui, restoreTabs: e.target.checked } })
-                  }
-                />
-              </Field>
             </Section>
 
             <Section id="notifications" title="Notifications">

--- a/src/extensions/default-layout/shell/tab-strip.test.tsx
+++ b/src/extensions/default-layout/shell/tab-strip.test.tsx
@@ -39,14 +39,25 @@ function renderTabStrip(onEvent = vi.fn<TabStripOnEvent>()) {
 }
 
 describe("TabStrip", () => {
-  it("opens tab actions on right-click and emits a rename event", () => {
+  it("starts inline session rename from the tab context menu", () => {
     const { onEvent } = renderTabStrip();
     fireEvent.contextMenu(screen.getByText("Tab 1").closest('[role="tab"]')!);
 
-    fireEvent.change(screen.getByLabelText("Session name"), {
+    expect(screen.queryByLabelText("Session name")).toBeNull();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Rename Session" }));
+
+    const input = screen.getByRole("textbox", {
+      name: "Rename session Tab 1",
+    });
+    fireEvent.change(input, {
       target: { value: "Planning" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Rename" }));
+    expect(input).toHaveProperty("value", "Planning");
+    expect(
+      screen.queryByRole("menuitem", { name: "Rename Session" }),
+    ).toBeNull();
+
+    fireEvent.keyDown(input, { key: "Enter" });
 
     expect(onEvent).toHaveBeenCalledWith("rename", {
       tabId: "tab-1",
@@ -67,7 +78,10 @@ describe("TabStrip", () => {
       />,
     );
     fireEvent.contextMenu(screen.getByText("Tab 1").closest('[role="tab"]')!);
-    const input = screen.getByLabelText("Session name");
+    fireEvent.click(screen.getByRole("menuitem", { name: "Rename Session" }));
+    const input = screen.getByRole("textbox", {
+      name: "Rename session Tab 1",
+    });
     input.focus();
     fireEvent.change(input, { target: { value: "Planning" } });
 
@@ -134,9 +148,7 @@ describe("TabStrip", () => {
     const tabs = screen.getAllByRole("tab");
     expect(tabs[0].textContent).toContain("overview");
     // No close button on the overview pill.
-    expect(
-      tabs[0].querySelector(".a2ui-tab-close"),
-    ).toBeNull();
+    expect(tabs[0].querySelector(".a2ui-tab-close")).toBeNull();
     // Real tabs do have one.
     expect(
       screen

--- a/src/extensions/default-layout/shell/tab-strip.tsx
+++ b/src/extensions/default-layout/shell/tab-strip.tsx
@@ -18,7 +18,14 @@
  *   ("new")                 click on the "+" button
  */
 
-import { useMemo, useState, type MouseEvent } from "react";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type MouseEvent,
+} from "react";
 import type { StringValue } from "../../../types/a2ui";
 import { OVERVIEW_TAB_ID } from "../../../types/tab";
 import { resolveString } from "../../../utils/dataBinding";
@@ -79,10 +86,62 @@ export function TabStrip({ component, state, onEvent }: BuiltinComponentProps) {
     y: number;
     tab: TabStripItem;
   } | null>(null);
+  const [renamingTab, setRenamingTab] = useState<{
+    id: string;
+    value: string;
+  } | null>(null);
+  const renameInputRef = useRef<HTMLInputElement | null>(null);
+  const renameEndingRef = useRef(false);
+  const renamingTabId = renamingTab?.id;
   const openTabMenu = (event: MouseEvent, tab: TabStripItem) => {
     event.preventDefault();
     event.stopPropagation();
     setContextMenu({ x: event.clientX, y: event.clientY, tab });
+  };
+
+  useEffect(() => {
+    if (!renamingTabId) return;
+    renameEndingRef.current = false;
+    const focus = () => {
+      const input = renameInputRef.current;
+      if (!input) return;
+      input.focus({ preventScroll: true });
+      input.select();
+    };
+    focus();
+    const first = window.setTimeout(focus, 0);
+    return () => window.clearTimeout(first);
+  }, [renamingTabId]);
+
+  const beginRename = (tab: TabStripItem) => {
+    setContextMenu(null);
+    setRenamingTab({ id: tab.id, value: tab.label });
+  };
+
+  const finishRename = (tab: TabStripItem, mode: "save" | "cancel") => {
+    if (!renamingTab || renamingTab.id !== tab.id) return;
+    if (renameEndingRef.current) return;
+    renameEndingRef.current = true;
+    const label = renamingTab.value.trim();
+    setRenamingTab(null);
+    if (mode === "save" && label && label !== tab.label) {
+      onEvent("rename", { tabId: tab.id, label });
+    }
+  };
+
+  const onRenameKeyDown = (
+    event: KeyboardEvent<HTMLInputElement>,
+    tab: TabStripItem,
+  ) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      finishRename(tab, "save");
+      return;
+    }
+    if (event.key === "Escape") {
+      event.preventDefault();
+      finishRename(tab, "cancel");
+    }
   };
 
   const projectPath =
@@ -149,12 +208,9 @@ export function TabStrip({ component, state, onEvent }: BuiltinComponentProps) {
     // Agent (and any other) tabs keep the rename + close menu.
     return [
       {
-        type: "input",
         id: "rename-session",
-        label: "Session name",
-        defaultValue: tab.label,
-        submitLabel: "Rename",
-        onSubmit: (label) => onEvent("rename", { tabId: tab.id, label }),
+        label: "Rename Session",
+        onSelect: () => beginRename(tab),
       },
       { type: "separator" },
       ...closeFamily,
@@ -202,15 +258,15 @@ export function TabStrip({ component, state, onEvent }: BuiltinComponentProps) {
             key={t.id}
             role="tab"
             aria-selected={isActive}
-            className={
-              isActive ? "a2ui-tab a2ui-tab-active" : "a2ui-tab"
-            }
+            className={isActive ? "a2ui-tab a2ui-tab-active" : "a2ui-tab"}
             onMouseDown={(e) => {
               // mousedown not click so focus doesn't shift away from the
               // chat input first (avoids a stray blur that could submit
               // a draft). The select handler swaps the active tab.
               if (e.button !== 0) return;
               if ((e.target as HTMLElement).closest(".a2ui-tab-close")) return;
+              if ((e.target as HTMLElement).closest(".ae-tab-rename-input"))
+                return;
               e.preventDefault();
               onEvent("select", { tabId: t.id });
             }}
@@ -230,12 +286,28 @@ export function TabStrip({ component, state, onEvent }: BuiltinComponentProps) {
                 className="a2ui-tab-icon"
               />
             ) : null}
-            <span className="a2ui-tab-label">{t.label}</span>
+            {renamingTab?.id === t.id ? (
+              <input
+                ref={renameInputRef}
+                className="ae-tab-rename-input"
+                aria-label={`Rename session ${t.label}`}
+                value={renamingTab.value}
+                onMouseDown={(event) => event.stopPropagation()}
+                onClick={(event) => event.stopPropagation()}
+                onChange={(event) => {
+                  const value = event.currentTarget.value;
+                  setRenamingTab((current) =>
+                    current?.id === t.id ? { ...current, value } : current,
+                  );
+                }}
+                onKeyDown={(event) => onRenameKeyDown(event, t)}
+                onBlur={() => finishRename(t, "save")}
+              />
+            ) : (
+              <span className="a2ui-tab-label">{t.label}</span>
+            )}
             {typeof t.queueCount === "number" && t.queueCount > 0 ? (
-              <span
-                className="a2ui-tab-queue"
-                title={`${t.queueCount} queued`}
-              >
+              <span className="a2ui-tab-queue" title={`${t.queueCount} queued`}>
                 +{t.queueCount}
               </span>
             ) : null}
@@ -272,8 +344,8 @@ export function TabStrip({ component, state, onEvent }: BuiltinComponentProps) {
         items={menuItems}
         onClose={() => setContextMenu(null)}
         ariaLabel="Tab actions"
-        estimatedWidth={320}
-        estimatedHeight={176}
+        estimatedWidth={220}
+        estimatedHeight={156}
       />
     </div>
   );

--- a/src/extensions/default-layout/workstation.a2ui.json
+++ b/src/extensions/default-layout/workstation.a2ui.json
@@ -211,7 +211,8 @@
             "area": "status",
             "left": { "$ref": "/status" },
             "center": { "$ref": "/connection" },
-            "right": { "$ref": "/model" }
+            "right": { "$ref": "/model" },
+            "context": { "$ref": "/contextUsage" }
           }
         }
       ]
@@ -221,6 +222,7 @@
     "status": "starting…",
     "connection": "disconnected",
     "model": "—",
+    "contextUsage": null,
     "draft": "",
     "waiting": false,
     "queueCount": 0,

--- a/src/hooks/bridgeMessageHandlers/contextUsage.test.ts
+++ b/src/hooks/bridgeMessageHandlers/contextUsage.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { makeEmptyTab } from "../../types/tab";
+import { handleContextUsage } from "./contextUsage";
+import { buildHandlerFixture } from "./testFixtures";
+
+describe("handleContextUsage", () => {
+  it("stores context usage on the target tab", () => {
+    const { ctx, mocks } = buildHandlerFixture({
+      state: { activeTabId: "default" },
+    });
+
+    handleContextUsage(
+      {
+        type: "context_usage",
+        tabId: "default",
+        model: "anthropic/claude",
+        status: "known",
+        tokens: 12_000,
+        contextWindow: 200_000,
+        percent: 6,
+        autoCompactEnabled: true,
+        reserveTokens: 16_384,
+        compactAtTokens: 183_616,
+        tokensUntilCompact: 171_616,
+      },
+      ctx,
+    );
+
+    expect(mocks.updateTab).toHaveBeenCalledTimes(1);
+    const [tabId, updater] = mocks.updateTab.mock.calls[0];
+    expect(tabId).toBe("default");
+    expect(updater(makeEmptyTab("default", "Tab 1")).contextUsage).toEqual({
+      tabId: "default",
+      model: "anthropic/claude",
+      status: "known",
+      tokens: 12_000,
+      contextWindow: 200_000,
+      percent: 6,
+      autoCompactEnabled: true,
+      reserveTokens: 16_384,
+      compactAtTokens: 183_616,
+      tokensUntilCompact: 171_616,
+    });
+  });
+
+  it("ignores malformed usage payloads", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+
+    handleContextUsage(
+      {
+        type: "context_usage",
+        tabId: "default",
+        tokens: 12_000,
+      },
+      ctx,
+    );
+
+    expect(mocks.updateTab).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/bridgeMessageHandlers/contextUsage.ts
+++ b/src/hooks/bridgeMessageHandlers/contextUsage.ts
@@ -1,0 +1,35 @@
+import type { ContextUsageState } from "../../types/tab";
+import type { BridgeMessage, BridgeMessageHandler } from "./types";
+
+function finiteNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+export function contextUsageFromMessage(
+  data: BridgeMessage,
+): ContextUsageState | null {
+  const contextWindow = finiteNumber(data.contextWindow);
+  if (contextWindow === null || contextWindow <= 0) return null;
+  const compactAtTokens = finiteNumber(data.compactAtTokens);
+  const reserveTokens = finiteNumber(data.reserveTokens);
+  return {
+    tabId: typeof data.tabId === "string" ? data.tabId : undefined,
+    model: typeof data.model === "string" ? data.model : "",
+    status: data.status === "known" ? "known" : "unknown",
+    tokens: finiteNumber(data.tokens),
+    contextWindow,
+    percent: finiteNumber(data.percent),
+    autoCompactEnabled: data.autoCompactEnabled === true,
+    reserveTokens: reserveTokens ?? 0,
+    compactAtTokens: compactAtTokens ?? contextWindow,
+    tokensUntilCompact: finiteNumber(data.tokensUntilCompact),
+    ...(data.compacting === true ? { compacting: true } : {}),
+  };
+}
+
+export const handleContextUsage: BridgeMessageHandler = (data, ctx) => {
+  const tabId = (data.tabId as string | undefined) ?? "default";
+  const contextUsage = contextUsageFromMessage(data);
+  if (!contextUsage) return;
+  ctx.updateTab(tabId, (tab) => ({ ...tab, contextUsage }));
+};

--- a/src/hooks/bridgeMessageHandlers/index.ts
+++ b/src/hooks/bridgeMessageHandlers/index.ts
@@ -15,6 +15,7 @@ import {
   handleAuthProfiles,
 } from "./authProfiles";
 import { handleA2ui } from "./a2ui";
+import { handleContextUsage } from "./contextUsage";
 import { handleError } from "./error";
 import { handleExtensionComponents } from "./extensionComponents";
 import { handleExtensionEventRoutes } from "./extensionEventRoutes";
@@ -58,6 +59,7 @@ export const bridgeMessageHandlers: Readonly<
   auth_profile_changed: handleAuthProfileChanged,
   auth_profile_login_event: handleAuthProfileLoginEvent,
   auth_profiles: handleAuthProfiles,
+  context_usage: handleContextUsage,
   error: handleError,
   extension_components: handleExtensionComponents,
   extension_event_routes: handleExtensionEventRoutes,

--- a/src/hooks/bridgeMessageHandlers/nativeSlashResult.test.ts
+++ b/src/hooks/bridgeMessageHandlers/nativeSlashResult.test.ts
@@ -41,7 +41,7 @@ describe("handleNativeSlashResult", () => {
         type: "native_slash_result",
         command: "compact",
         tabId: "default",
-        message: "Context compacted. 159,747 tokens were summarized.",
+        message: "Context compacted · 159,747 tokens summarized",
       },
       ctx,
     );

--- a/src/hooks/bridgeMessageHandlers/ready.ts
+++ b/src/hooks/bridgeMessageHandlers/ready.ts
@@ -21,6 +21,7 @@ import type {
   DiscoveredSession,
   ModelDescriptor,
 } from "./types";
+import { contextUsageFromMessage } from "./contextUsage";
 
 function isWorkstationBootLayout(layout: A2UIPayload): boolean {
   const state = layout.state as
@@ -318,7 +319,13 @@ export const handleReady: BridgeMessageHandler = (data, ctx) => {
       const localTabs = ((next.tabs as Tab[] | undefined) ?? []).slice();
       const bridgeTabs =
         (data.tabs as
-          | { id: string; model: string; cwd?: string; authProfileId?: string }[]
+          | {
+              id: string;
+              model: string;
+              cwd?: string;
+              authProfileId?: string;
+              contextUsage?: Record<string, unknown>;
+            }[]
           | undefined) ?? [];
       const tabReplay =
         (data.extensionTabState as
@@ -347,6 +354,12 @@ export const handleReady: BridgeMessageHandler = (data, ctx) => {
         }
         if (bt?.authProfileId) {
           localTabs[i] = { ...localTabs[i], authProfileId: bt.authProfileId };
+        }
+        const contextUsage = bt?.contextUsage
+          ? contextUsageFromMessage(bt.contextUsage)
+          : null;
+        if (contextUsage) {
+          localTabs[i] = { ...localTabs[i], contextUsage };
         }
       }
       // Apply the bridge's per-tab replay over each tab record. prev

--- a/src/hooks/bridgeMessageHandlers/sessionHistory.test.ts
+++ b/src/hooks/bridgeMessageHandlers/sessionHistory.test.ts
@@ -316,6 +316,190 @@ describe("handleSessionHistory", () => {
     expect(out.waiting).toBe(true);
   });
 
+  it("orders timestamped local stderr by its original time during hydrate", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleSessionHistory(
+      {
+        type: "session_history",
+        tabId: "tab-1",
+        messages: [
+          {
+            id: "old-user",
+            role: "user",
+            text: "previous prompt",
+            createdAt: 1_000,
+          },
+          {
+            id: "old-agent",
+            role: "agent",
+            text: "previous answer",
+            createdAt: 3_000,
+          },
+        ],
+      },
+      ctx,
+    );
+    const [, updater] = mocks.updateTab.mock.calls[0];
+    const tab = makeEmptyTab("tab-1", "Tab 1");
+    const out = updater({
+      ...tab,
+      messages: [
+        {
+          id: "local-stderr",
+          role: "system",
+          text: "[agent stderr] 2026-06-02T13:36:55.343Z WARN devshell: failed",
+          createdAt: 2_000,
+        },
+        {
+          id: "streaming-agent",
+          role: "agent",
+          text: "new answer is streaming",
+        },
+      ],
+    });
+
+    expect(out.messages.map((m: ChatMessage) => m.id)).toEqual([
+      "old-user",
+      "local-stderr",
+      "old-agent",
+      "streaming-agent",
+    ]);
+  });
+
+  it("orders stale local assistant snapshots by timestamp when the tab is idle", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleSessionHistory(
+      {
+        type: "session_history",
+        tabId: "tab-1",
+        messages: [
+          {
+            id: "old-user",
+            role: "user",
+            text: "previous prompt",
+            createdAt: 1_000,
+          },
+          {
+            id: "newer-agent",
+            role: "agent",
+            text: "newer restored answer",
+            createdAt: 3_000,
+          },
+        ],
+      },
+      ctx,
+    );
+    const [, updater] = mocks.updateTab.mock.calls[0];
+    const tab = makeEmptyTab("tab-1", "Tab 1");
+    const out = updater({
+      ...tab,
+      waiting: false,
+      messages: [
+        {
+          id: "stale-stream",
+          role: "agent",
+          text: "old streamed answer",
+          createdAt: 2_000,
+        },
+      ],
+    });
+
+    expect(out.messages.map((m: ChatMessage) => m.id)).toEqual([
+      "old-user",
+      "stale-stream",
+      "newer-agent",
+    ]);
+    expect(out.waiting).toBe(false);
+  });
+
+  it("clears active thinking status when hydration proves the tab is idle", () => {
+    const { ctx, mocks } = buildHandlerFixture({
+      state: {
+        activeTabId: "tab-1",
+        waiting: true,
+        status: "thinking…",
+        tabs: [
+          {
+            ...makeEmptyTab("tab-1", "Tab 1"),
+            waiting: true,
+            messages: [
+              {
+                id: "stale-stream",
+                role: "agent",
+                text: "old streamed answer",
+                createdAt: 2_000,
+              },
+            ],
+          },
+        ],
+      },
+    });
+    handleSessionHistory(
+      {
+        type: "session_history",
+        tabId: "tab-1",
+        messages: [
+          {
+            id: "old-user",
+            role: "user",
+            text: "previous prompt",
+            createdAt: 1_000,
+          },
+          {
+            id: "newer-agent",
+            role: "agent",
+            text: "newer restored answer",
+            createdAt: 3_000,
+          },
+        ],
+      },
+      ctx,
+    );
+
+    expect(mocks.setStatusFlags).toHaveBeenCalledWith({
+      waiting: false,
+      status: "ready",
+    });
+  });
+
+  it("does not restore durable stop notices as the latest chat message", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleSessionHistory(
+      {
+        type: "session_history",
+        tabId: "tab-1",
+        messages: [
+          {
+            id: "old-user",
+            role: "user",
+            text: "previous prompt",
+            createdAt: 1_000,
+          },
+          {
+            id: "stopped",
+            role: "system",
+            text: "Agent stopped.",
+            createdAt: 2_000,
+          },
+          {
+            id: "old-agent",
+            role: "agent",
+            text: "previous answer",
+            createdAt: 3_000,
+          },
+        ],
+      },
+      ctx,
+    );
+    const [, updater] = mocks.updateTab.mock.calls[0];
+    const out = updater(makeEmptyTab("tab-1", "Tab 1"));
+
+    expect(out.messages.map((m: ChatMessage) => m.id)).toEqual([
+      "old-user",
+      "old-agent",
+    ]);
+  });
+
   it("does not append live compaction notices below restored compaction markers", () => {
     const { ctx, mocks } = buildHandlerFixture();
     handleSessionHistory(

--- a/src/hooks/bridgeMessageHandlers/sessionHistory.test.ts
+++ b/src/hooks/bridgeMessageHandlers/sessionHistory.test.ts
@@ -256,6 +256,130 @@ describe("handleSessionHistory", () => {
     expect(out.waiting).toBe(true);
   });
 
+  it("does not append a persisted stderr mirror below restored history", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    const stderrText =
+      "[agent stderr] 2026-06-02T13:36:55.343Z WARN devshell: env_for_path(/repo) failed: timeout tabId=tab-1";
+    handleSessionHistory(
+      {
+        type: "session_history",
+        tabId: "tab-1",
+        messages: [
+          {
+            id: "old-user",
+            role: "user",
+            text: "previous prompt",
+            createdAt: 1_000,
+          },
+          {
+            id: "restored-stderr",
+            role: "system",
+            text: stderrText,
+            createdAt: 2_000,
+          },
+          {
+            id: "old-agent",
+            role: "agent",
+            text: "previous answer",
+            createdAt: 3_000,
+          },
+        ],
+      },
+      ctx,
+    );
+    const [, updater] = mocks.updateTab.mock.calls[0];
+    const tab = makeEmptyTab("tab-1", "Tab 1");
+    const out = updater({
+      ...tab,
+      waiting: true,
+      messages: [
+        {
+          id: "local-stderr",
+          role: "system",
+          text: stderrText,
+          createdAt: 2_000,
+        },
+        {
+          id: "streaming-agent",
+          role: "agent",
+          text: "new answer is streaming",
+        },
+      ],
+    });
+
+    expect(out.messages.map((m: ChatMessage) => m.id)).toEqual([
+      "old-user",
+      "restored-stderr",
+      "old-agent",
+      "streaming-agent",
+    ]);
+    expect(out.waiting).toBe(true);
+  });
+
+  it("does not append live compaction notices below restored compaction markers", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleSessionHistory(
+      {
+        type: "session_history",
+        tabId: "tab-1",
+        messages: [
+          {
+            id: "old-user",
+            role: "user",
+            text: "previous prompt",
+            createdAt: 1_000,
+          },
+          {
+            id: "compaction:cmp-1",
+            role: "system",
+            text: "Context compacted · 13,005 tokens summarized",
+            createdAt: 2_000,
+          },
+          {
+            id: "old-agent",
+            role: "agent",
+            text: "previous answer",
+            createdAt: 3_000,
+          },
+        ],
+      },
+      ctx,
+    );
+    const [, updater] = mocks.updateTab.mock.calls[0];
+    const tab = makeEmptyTab("tab-1", "Tab 1");
+    const out = updater({
+      ...tab,
+      waiting: true,
+      messages: [
+        {
+          id: "local-compact-start",
+          role: "system",
+          text: "Compacting context...",
+          createdAt: 1_990,
+        },
+        {
+          id: "local-compact-end",
+          role: "system",
+          text: "Context compacted · 13,005 tokens summarized",
+          createdAt: 2_010,
+        },
+        {
+          id: "streaming-agent",
+          role: "agent",
+          text: "new answer is streaming",
+        },
+      ],
+    });
+
+    expect(out.messages.map((m: ChatMessage) => m.id)).toEqual([
+      "old-user",
+      "compaction:cmp-1",
+      "old-agent",
+      "streaming-agent",
+    ]);
+    expect(out.waiting).toBe(true);
+  });
+
   it("drops stale running tool cards when restored history has the completed tool result", () => {
     const { ctx, mocks } = buildHandlerFixture();
     const toolCallId =

--- a/src/hooks/bridgeMessageHandlers/sessionHistory.ts
+++ b/src/hooks/bridgeMessageHandlers/sessionHistory.ts
@@ -4,6 +4,7 @@ import {
 } from "../../utils/messages";
 import { toolCardIdentityFromId } from "../../utils/toolCardIdentity";
 import type { A2UIComponent, ChatMessage } from "../../types/a2ui";
+import type { Tab } from "../../types/tab";
 import type { BridgeMessageHandler } from "./types";
 
 function firstUserMessageLabel(messages: ChatMessage[]): string | undefined {
@@ -62,11 +63,24 @@ function isDuplicateCompletedToolCard(
   });
 }
 
-function isLivePendingMessage(message: ChatMessage): boolean {
+function isLivePendingMessage(
+  message: ChatMessage,
+  currentlyWaiting: boolean,
+  latestRestoredTime: number | undefined,
+): boolean {
   if (message.role === "user") {
     return message.delivery === "sent" || message.delivery === "steered";
   }
+  if (!currentlyWaiting) return false;
   if (message.role !== "agent") return false;
+  const createdAt = messageCreatedAt(message);
+  if (
+    typeof createdAt === "number" &&
+    typeof latestRestoredTime === "number" &&
+    createdAt < latestRestoredTime
+  ) {
+    return false;
+  }
   if (message.text || message.thinking) return true;
   return toolCardComponents(message).some(
     (component) =>
@@ -131,6 +145,14 @@ function isCompactionMarker(message: ChatMessage): boolean {
   );
 }
 
+function isStopNotice(message: ChatMessage): boolean {
+  return (
+    message.role === "system" &&
+    message.text?.replace(/\s+/g, " ").trim().toLowerCase() ===
+      "agent stopped."
+  );
+}
+
 function restoredCompactionMarkers(restored: ChatMessage[]): ChatMessage[] {
   return restored.filter(
     (message) => message.id.startsWith("compaction:") && isCompactionMarker(message),
@@ -166,9 +188,81 @@ function isDuplicateRestoredAgentContent(
   );
 }
 
+function messageCreatedAt(message: ChatMessage): number | undefined {
+  if (
+    typeof message.createdAt === "number" &&
+    Number.isFinite(message.createdAt)
+  ) {
+    return message.createdAt;
+  }
+  if (message.role !== "system" || typeof message.text !== "string") {
+    return undefined;
+  }
+  const raw = /^\[agent stderr\]\s+(\d{4}-\d{2}-\d{2}T[^\s]+)/.exec(
+    message.text,
+  )?.[1];
+  if (!raw) return undefined;
+  const parsed = Date.parse(raw);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function isStaleUntimestampedSystemNotice(message: ChatMessage): boolean {
+  if (isStopNotice(message)) return true;
+  if (message.role !== "system" || messageCreatedAt(message) !== undefined) {
+    return false;
+  }
+  const text = message.text?.replace(/\s+/g, " ").trim().toLowerCase() ?? "";
+  return (
+    text === "agent stopped." ||
+    text === "compacting context..." ||
+    text === "compacting context…" ||
+    text.startsWith("context compacted") ||
+    text.startsWith("context compaction complete") ||
+    text.startsWith("context compaction failed:")
+  );
+}
+
+function mergeTimestampedLocalMessages(
+  restored: ChatMessage[],
+  local: ChatMessage[],
+): ChatMessage[] {
+  if (local.length === 0) return restored;
+  return [
+    ...restored.map((message, order) => ({ message, order })),
+    ...local.map((message, offset) => ({
+      message,
+      order: restored.length + offset,
+    })),
+  ]
+    .sort((a, b) => {
+      const aTime = messageCreatedAt(a.message);
+      const bTime = messageCreatedAt(b.message);
+      if (
+        typeof aTime === "number" &&
+        typeof bTime === "number" &&
+        aTime !== bTime
+      ) {
+        return aTime - bTime;
+      }
+      return a.order - b.order;
+    })
+    .map((entry) => entry.message);
+}
+
+function latestMessageTime(messages: ChatMessage[]): number | undefined {
+  let latest: number | undefined;
+  for (const message of messages) {
+    const createdAt = messageCreatedAt(message);
+    if (createdAt === undefined) continue;
+    latest = latest === undefined ? createdAt : Math.max(latest, createdAt);
+  }
+  return latest;
+}
+
 function mergePendingLocalPrompts(
   restored: ChatMessage[],
   current: ChatMessage[],
+  currentlyWaiting: boolean,
 ): { messages: ChatMessage[]; hasLivePending: boolean } {
   // Carry pending local messages — both the optimistic user prompts
   // the user sent before the restored history arrived AND any
@@ -181,6 +275,7 @@ function mergePendingLocalPrompts(
   const restoredAgentContent = restoredAgentContentSignatures(restored);
   const restoredStderr = restoredStderrMirrorSignatures(restored);
   const restoredCompactions = restoredCompactionMarkers(restored);
+  const latestRestoredTime = latestMessageTime(restored);
   const restoredUserTexts = new Set(
     restored
       .filter((m) => m.role === "user" && typeof m.text === "string")
@@ -204,6 +299,13 @@ function mergePendingLocalPrompts(
       // recorded it canonically); otherwise keep it.
       return text.length > 0 && !restoredUserTexts.has(text);
     }
+    if (
+      restored.length > 0 &&
+      m.role === "system" &&
+      isStaleUntimestampedSystemNotice(m)
+    ) {
+      return false;
+    }
     // Keep system + agent messages that don't share an id with
     // anything in the restored set — those are typically streaming
     // assistant deltas, system notices about the in-flight turn, or
@@ -212,17 +314,30 @@ function mergePendingLocalPrompts(
     // user just watched land.
     return true;
   });
+  const timestampedLocal = pendingLocal.filter(
+    (message) =>
+      !isLivePendingMessage(message, currentlyWaiting, latestRestoredTime) &&
+      messageCreatedAt(message) !== undefined,
+  );
+  const appendLocal = pendingLocal.filter(
+    (message) =>
+      isLivePendingMessage(message, currentlyWaiting, latestRestoredTime) ||
+      messageCreatedAt(message) === undefined,
+  );
+  const mergedHistory = mergeTimestampedLocalMessages(restored, timestampedLocal);
   return {
     messages:
-      pendingLocal.length > 0 ? [...restored, ...pendingLocal] : restored,
-    hasLivePending: pendingLocal.some(isLivePendingMessage),
+      appendLocal.length > 0 ? [...mergedHistory, ...appendLocal] : mergedHistory,
+    hasLivePending: pendingLocal.some((message) =>
+      isLivePendingMessage(message, currentlyWaiting, latestRestoredTime),
+    ),
   };
 }
 
 export const handleSessionHistory: BridgeMessageHandler = (data, ctx) => {
   const tabId = (data.tabId as string | undefined) ?? "default";
   const messages = dedupeToolResultTextMessages(
-    coerceChatMessages(data.messages),
+    coerceChatMessages(data.messages).filter((message) => !isStopNotice(message)),
   );
   const session = ctx.allDiscoveredSessionsRef.current.find(
     (s) => s.tabId === tabId,
@@ -232,21 +347,39 @@ export const handleSessionHistory: BridgeMessageHandler = (data, ctx) => {
     (session?.firstUserMessage
       ? session.firstUserMessage.replace(/\s+/g, " ").trim()
       : undefined);
+  const activeTab =
+    ctx.stateRef.current.activeTabId === tabId
+      ? ((ctx.stateRef.current.tabs as Tab[] | undefined) ?? []).find(
+          (tab) => tab.id === tabId,
+        )
+      : undefined;
+  const activeHydration = activeTab
+    ? mergePendingLocalPrompts(
+        messages,
+        dedupeToolResultTextMessages(activeTab.messages),
+        activeTab.waiting === true,
+      )
+    : undefined;
   ctx.updateTab(tabId, (tab) => {
     const merged = mergePendingLocalPrompts(
       messages,
       dedupeToolResultTextMessages(tab.messages),
+      tab.waiting === true,
     );
+    const nextWaiting = merged.hasLivePending ? tab.waiting : false;
     return {
       ...tab,
       messages: dedupeToolResultTextMessages(merged.messages),
-      waiting: merged.hasLivePending ? tab.waiting : false,
+      waiting: nextWaiting,
       ...(label
         ? { label }
         : shouldReplaceGenericLabel(tab.label)
           ? { label: firstUserMessageLabel(messages) ?? tab.label }
-          : {}),
+      : {}),
     };
   });
+  if (activeHydration && !activeHydration.hasLivePending) {
+    ctx.setStatusFlags({ waiting: false, status: "ready" });
+  }
   ctx.syncRecentSessionsToState();
 };

--- a/src/hooks/bridgeMessageHandlers/sessionHistory.ts
+++ b/src/hooks/bridgeMessageHandlers/sessionHistory.ts
@@ -95,6 +95,66 @@ function restoredAgentContentSignatures(restored: ChatMessage[]): Set<string> {
   return signatures;
 }
 
+function stderrMirrorSignature(message: ChatMessage): string | undefined {
+  if (message.role !== "system" || typeof message.text !== "string") {
+    return undefined;
+  }
+  const text = message.text.replace(/\s+/g, " ").trim();
+  if (!text.startsWith("[agent stderr] ")) return undefined;
+  const timestamp =
+    typeof message.createdAt === "number" && Number.isFinite(message.createdAt)
+      ? String(message.createdAt)
+      : "";
+  return `stderr:${timestamp}:${text}`;
+}
+
+function restoredStderrMirrorSignatures(restored: ChatMessage[]): Set<string> {
+  const signatures = new Set<string>();
+  for (const message of restored) {
+    const signature = stderrMirrorSignature(message);
+    if (signature) signatures.add(signature);
+  }
+  return signatures;
+}
+
+function isCompactionMarker(message: ChatMessage): boolean {
+  if (message.role !== "system" || typeof message.text !== "string") {
+    return false;
+  }
+  const text = message.text.replace(/\s+/g, " ").trim().toLowerCase();
+  return (
+    text === "compacting context..." ||
+    text === "compacting context…" ||
+    text.startsWith("context compacted") ||
+    text.startsWith("context compaction complete") ||
+    text.startsWith("context compaction failed:")
+  );
+}
+
+function restoredCompactionMarkers(restored: ChatMessage[]): ChatMessage[] {
+  return restored.filter(
+    (message) => message.id.startsWith("compaction:") && isCompactionMarker(message),
+  );
+}
+
+function isDuplicateCompactionMarker(
+  message: ChatMessage,
+  restoredCompactions: readonly ChatMessage[],
+): boolean {
+  if (!isCompactionMarker(message) || restoredCompactions.length === 0) {
+    return false;
+  }
+  if (typeof message.createdAt !== "number") {
+    return restoredCompactions.some((candidate) => candidate.text === message.text);
+  }
+  const createdAt = message.createdAt;
+  return restoredCompactions.some(
+    (candidate) =>
+      typeof candidate.createdAt === "number" &&
+      Math.abs(candidate.createdAt - createdAt) <= 5 * 60 * 1000,
+  );
+}
+
 function isDuplicateRestoredAgentContent(
   message: ChatMessage,
   restoredAgentContent: ReadonlySet<string>,
@@ -119,6 +179,8 @@ function mergePendingLocalPrompts(
   const restoredIds = new Set(restored.map((m) => m.id));
   const completedTools = completedRestoredToolIdentities(restored);
   const restoredAgentContent = restoredAgentContentSignatures(restored);
+  const restoredStderr = restoredStderrMirrorSignatures(restored);
+  const restoredCompactions = restoredCompactionMarkers(restored);
   const restoredUserTexts = new Set(
     restored
       .filter((m) => m.role === "user" && typeof m.text === "string")
@@ -129,6 +191,9 @@ function mergePendingLocalPrompts(
     if (restoredIds.has(m.id)) return false;
     if (isDuplicateCompletedToolCard(m, completedTools)) return false;
     if (isDuplicateRestoredAgentContent(m, restoredAgentContent)) return false;
+    const stderrSignature = stderrMirrorSignature(m);
+    if (stderrSignature && restoredStderr.has(stderrSignature)) return false;
+    if (isDuplicateCompactionMarker(m, restoredCompactions)) return false;
     if (m.role === "user") {
       // A failed local user message is informational once history
       // catches up — the bridge will resend or the user will retry.

--- a/src/hooks/bridgeMessageHandlers/tabReady.ts
+++ b/src/hooks/bridgeMessageHandlers/tabReady.ts
@@ -1,5 +1,6 @@
 import type { BridgeMessageHandler } from "./types";
 import { recomputeModelPicker } from "../../utils/modelPicker";
+import { contextUsageFromMessage } from "./contextUsage";
 
 /** Bridge confirms a per-tab pi session is up and tells us its chosen
  *  model. Update the tab record so the sidebar can reflect it on next
@@ -9,7 +10,14 @@ import { recomputeModelPicker } from "../../utils/modelPicker";
 export const handleTabReady: BridgeMessageHandler = (data, ctx) => {
   const tabId = (data.tabId as string | undefined) ?? "default";
   const model = (data.model as string) ?? "";
-  ctx.updateTab(tabId, (tab) => ({ ...tab, model }));
+  const contextUsage = contextUsageFromMessage(
+    (data.contextUsage as Record<string, unknown> | undefined) ?? {},
+  );
+  ctx.updateTab(tabId, (tab) => ({
+    ...tab,
+    model,
+    ...(contextUsage ? { contextUsage } : {}),
+  }));
   if (ctx.stateRef.current.activeTabId === tabId) {
     ctx.setState((prev) => ({
       ...prev,

--- a/src/hooks/osEdges/agentStderr.test.ts
+++ b/src/hooks/osEdges/agentStderr.test.ts
@@ -1,7 +1,23 @@
-import { describe, expect, it } from "vitest";
-import { createdAtFromAgentStderr, tabIdFromAgentStderr } from "./agentStderr";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createdAtFromAgentStderr,
+  subscribeAgentStderr,
+  tabIdFromAgentStderr,
+} from "./agentStderr";
+import { clearTauriMocks, installTauriMocks } from "../../test/tauriMocks";
 
 describe("agent stderr helpers", () => {
+  let harness: ReturnType<typeof installTauriMocks>;
+
+  beforeEach(() => {
+    harness = installTauriMocks();
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    clearTauriMocks();
+  });
+
   it("extracts tab ids from bridge turn logs", () => {
     expect(
       tabIdFromAgentStderr(
@@ -16,5 +32,26 @@ describe("agent stderr helpers", () => {
         "2026-06-01T15:57:41.305Z WARN turn: end model=openai-codex/gpt-5.5 tabId=tab-1",
       ),
     ).toBe(Date.parse("2026-06-01T15:57:41.305Z"));
+  });
+
+  it("mirrors and persists warning lines with their tab and timestamp", () => {
+    const appendMessage = vi.fn();
+    const persistLocalChatMessage = vi.fn();
+    subscribeAgentStderr({ appendMessage, persistLocalChatMessage });
+
+    const line =
+      "2026-06-02T13:36:55.343Z WARN devshell: env_for_path(/repo) failed: timeout tabId=tab-1";
+    expect(harness.fireEvent("agent-stderr", line)).toBe(1);
+
+    expect(appendMessage).toHaveBeenCalledTimes(1);
+    expect(persistLocalChatMessage).toHaveBeenCalledTimes(1);
+    const [message, tabId] = appendMessage.mock.calls[0];
+    expect(tabId).toBe("tab-1");
+    expect(message).toMatchObject({
+      role: "system",
+      text: `[agent stderr] ${line}`,
+      createdAt: Date.parse("2026-06-02T13:36:55.343Z"),
+    });
+    expect(persistLocalChatMessage).toHaveBeenCalledWith(message, "tab-1");
   });
 });

--- a/src/hooks/osEdges/agentStderr.ts
+++ b/src/hooks/osEdges/agentStderr.ts
@@ -3,6 +3,7 @@ import type { ChatMessage } from "../../types/a2ui";
 
 export interface AgentStderrDeps {
   appendMessage: (msg: ChatMessage, tabId?: string) => void;
+  persistLocalChatMessage: (msg: ChatMessage, tabId: string) => void;
 }
 
 export function tabIdFromAgentStderr(text: string): string | undefined {
@@ -32,7 +33,7 @@ export function createdAtFromAgentStderr(text: string): number | undefined {
  *  etc.) and stay in bridge logs only; surfacing them to chat would
  *  spam when an extension misbehaves on a setInterval. */
 export function subscribeAgentStderr(deps: AgentStderrDeps): () => void {
-  const { appendMessage } = deps;
+  const { appendMessage, persistLocalChatMessage } = deps;
 
   const unlistenStderr = listen<string>("agent-stderr", (event) => {
     const text = event.payload?.toString().trim();
@@ -47,15 +48,15 @@ export function subscribeAgentStderr(deps: AgentStderrDeps): () => void {
       );
     const isExtensionNoise = /\b(WARN|INFO)\s+ext-state:/.test(text);
     if ((isLeveledFailure || isRawCrash) && !isExtensionNoise) {
-      appendMessage(
-        {
-          id: crypto.randomUUID(),
-          role: "system",
-          text: `[agent stderr] ${text}`,
-          createdAt: createdAtFromAgentStderr(text),
-        },
-        tabIdFromAgentStderr(text),
-      );
+      const tabId = tabIdFromAgentStderr(text) ?? "default";
+      const chatMessage = {
+        id: crypto.randomUUID(),
+        role: "system" as const,
+        text: `[agent stderr] ${text}`,
+        createdAt: createdAtFromAgentStderr(text),
+      };
+      appendMessage(chatMessage, tabId);
+      persistLocalChatMessage(chatMessage, tabId);
     }
     // Always log to webview console for debug skill access.
     console.warn("[agent stderr]", text);

--- a/src/hooks/osEdges/types.ts
+++ b/src/hooks/osEdges/types.ts
@@ -36,6 +36,7 @@ export interface UseOsEdgesContext {
 
   // Chat helpers (from useChat).
   appendMessage: (msg: ChatMessage, tabId?: string) => void;
+  persistLocalChatMessage: (msg: ChatMessage, tabId: string) => void;
   appendSystem: (text: string) => void;
   setStatusFlags: (
     flags: Partial<{ waiting: boolean; status: string; connection: string }>,

--- a/src/hooks/tabOps/agentTab.test.ts
+++ b/src/hooks/tabOps/agentTab.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+import type { MutableRefObject } from "react";
+import { useNewTab } from "./agentTab";
+import type { ProjectsState } from "../../projects";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(() => Promise.resolve(null)),
+}));
+
+const ref = <T>(value: T): MutableRefObject<T> => ({ current: value });
+
+describe("newTab restore handling", () => {
+  it("clears the closed-session suppression when a session is manually restored", () => {
+    let state: Record<string, unknown> = {
+      tabs: [],
+      closedSessionIds: ["restore-me", "other-closed"],
+    };
+    const stateRef = ref(state);
+    const setState = vi.fn((updater: unknown) => {
+      if (typeof updater !== "function") return;
+      state = (
+        updater as (prev: Record<string, unknown>) => Record<string, unknown>
+      )(state);
+      stateRef.current = state;
+    });
+    const newTab = useNewTab({
+      setState,
+      stateRef,
+      projectsRef: ref<ProjectsState>({
+        activeId: null,
+        activeWorktreeId: null,
+        activeHostId: null,
+        projects: [],
+        worktreesByProject: {},
+      }),
+      piDefaultModelRef: ref(""),
+      pendingTabOpens: ref(new Map()),
+      appendSystem: vi.fn(),
+      dispatchTerminalReplay: vi.fn(),
+    });
+
+    newTab("restore-me", "Restored", { restoredSession: true });
+
+    expect(state.closedSessionIds).toEqual(["other-closed"]);
+    expect((state.tabs as Array<{ id: string }>).map((t) => t.id)).toEqual([
+      "restore-me",
+    ]);
+  });
+});

--- a/src/hooks/tabOps/agentTab.ts
+++ b/src/hooks/tabOps/agentTab.ts
@@ -117,6 +117,16 @@ export function useNewTab(deps: NewTabDeps) {
         empty: false,
         hasTabs: true,
       };
+      if (restoreId) {
+        const closedIds = Array.isArray(prev.closedSessionIds)
+          ? (prev.closedSessionIds as string[])
+          : [];
+        if (closedIds.includes(restoreId)) {
+          result.closedSessionIds = closedIds.filter(
+            (item) => item !== restoreId,
+          );
+        }
+      }
       const tabRec = tab as unknown as Record<string, unknown>;
       for (const key of TAB_MIRROR_KEYS) {
         result[key as string] = tabRec[key as string];

--- a/src/hooks/tabOps/autoRestore.test.ts
+++ b/src/hooks/tabOps/autoRestore.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import type { MutableRefObject } from "react";
+import { useAutoRestoreDiscoveredSessions } from "./autoRestore";
+import { makeEmptyTab } from "../../types/tab";
+
+const ref = <T>(value: T): MutableRefObject<T> => ({ current: value });
+
+describe("autoRestoreDiscoveredSessions", () => {
+  it("does not reopen discovered sessions the user explicitly closed", () => {
+    const newTab = vi.fn();
+    const pushNotification = vi.fn();
+    const autoRestore = useAutoRestoreDiscoveredSessions({
+      stateRef: ref({
+        tabs: [],
+        closedSessionIds: ["closed-session"],
+      }),
+      autoRestoredSessionIdsRef: ref(new Set<string>()),
+      pushNotification,
+      newTab,
+    });
+
+    autoRestore(
+      [
+        {
+          tabId: "closed-session",
+          lastModified: 2,
+          firstUserMessage: "Closed should stay closed",
+        },
+        {
+          tabId: "open-session",
+          lastModified: 1,
+          firstUserMessage: "Restore me",
+          cwd: "/repo/app",
+        },
+      ],
+      new Set(),
+    );
+
+    expect(newTab).toHaveBeenCalledTimes(1);
+    expect(newTab).toHaveBeenCalledWith("open-session", "Restore me", {
+      restoredSession: true,
+      cwd: "/repo/app",
+    });
+    expect(pushNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Restored 1 session" }),
+    );
+  });
+
+  it("does not restore already-open local tabs", () => {
+    const newTab = vi.fn();
+    const autoRestore = useAutoRestoreDiscoveredSessions({
+      stateRef: ref({
+        tabs: [makeEmptyTab("local-session", "Local")],
+        closedSessionIds: [],
+      }),
+      autoRestoredSessionIdsRef: ref(new Set<string>()),
+      pushNotification: vi.fn(),
+      newTab,
+    });
+
+    autoRestore(
+      [
+        {
+          tabId: "local-session",
+          lastModified: 1,
+          firstUserMessage: "already open",
+        },
+      ],
+      new Set(),
+    );
+
+    expect(newTab).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/tabOps/autoRestore.ts
+++ b/src/hooks/tabOps/autoRestore.ts
@@ -1,6 +1,5 @@
 import type { MutableRefObject } from "react";
 import type { Tab } from "../../types/tab";
-import { getConfig } from "../../config";
 import { sessionLabel } from "./helpers";
 import type { DiscoveredSession, NotificationInput } from "./types";
 
@@ -17,10 +16,7 @@ export interface AutoRestoreDeps {
   ) => void;
 }
 
-/** Build the boot-time auto-restore action. Reads `ui.restoreTabs`
- *  from `aethon.toml`; bails silently when the user disabled it. The
- *  config read is intentionally lazy (per call) so a settings-panel
- *  toggle takes effect on the next discovery wave without rebuild. */
+/** Build the boot-time auto-restore action for bridge-discovered sessions. */
 export function useAutoRestoreDiscoveredSessions(deps: AutoRestoreDeps) {
   const { stateRef, autoRestoredSessionIdsRef, pushNotification, newTab } =
     deps;
@@ -30,37 +26,28 @@ export function useAutoRestoreDiscoveredSessions(deps: AutoRestoreDeps) {
     knownIds: Set<string>,
   ): void {
     if (discovered.length === 0) return;
-    getConfig()
-      .then((config) => {
-        if (!config.ui.restoreTabs) return;
-        const liveIds = new Set([
-          ...knownIds,
-          ...((stateRef.current.tabs as Tab[] | undefined) ?? []).map(
-            (t) => t.id,
-          ),
-        ]);
-        const toRestore = discovered
-          .filter((d) => !liveIds.has(d.tabId))
-          .filter((d) => !autoRestoredSessionIdsRef.current.has(d.tabId))
-          .slice(0, 8);
-        if (toRestore.length === 0) return;
-        // Open oldest first so the most recent session ends up active.
-        for (const session of [...toRestore].reverse()) {
-          autoRestoredSessionIdsRef.current.add(session.tabId);
-          newTab(session.tabId, sessionLabel(session), {
-            restoredSession: true,
-            ...(session.cwd ? { cwd: session.cwd } : {}),
-          });
-        }
-        pushNotification({
-          id: "ae-auto-restore-tabs",
-          title: `Restored ${toRestore.length} session${toRestore.length === 1 ? "" : "s"}`,
-          kind: "success",
-          durationMs: 3000,
-        });
-      })
-      .catch(() => {
-        /* config read already logs; manual restore remains available */
+    const liveIds = new Set([
+      ...knownIds,
+      ...((stateRef.current.tabs as Tab[] | undefined) ?? []).map((t) => t.id),
+    ]);
+    const toRestore = discovered
+      .filter((d) => !liveIds.has(d.tabId))
+      .filter((d) => !autoRestoredSessionIdsRef.current.has(d.tabId))
+      .slice(0, 8);
+    if (toRestore.length === 0) return;
+    // Open oldest first so the most recent session ends up active.
+    for (const session of [...toRestore].reverse()) {
+      autoRestoredSessionIdsRef.current.add(session.tabId);
+      newTab(session.tabId, sessionLabel(session), {
+        restoredSession: true,
+        ...(session.cwd ? { cwd: session.cwd } : {}),
       });
+    }
+    pushNotification({
+      id: "ae-auto-restore-tabs",
+      title: `Restored ${toRestore.length} session${toRestore.length === 1 ? "" : "s"}`,
+      kind: "success",
+      durationMs: 3000,
+    });
   };
 }

--- a/src/hooks/tabOps/autoRestore.ts
+++ b/src/hooks/tabOps/autoRestore.ts
@@ -30,8 +30,14 @@ export function useAutoRestoreDiscoveredSessions(deps: AutoRestoreDeps) {
       ...knownIds,
       ...((stateRef.current.tabs as Tab[] | undefined) ?? []).map((t) => t.id),
     ]);
+    const closedSessionIds = new Set(
+      Array.isArray(stateRef.current.closedSessionIds)
+        ? (stateRef.current.closedSessionIds as string[])
+        : [],
+    );
     const toRestore = discovered
       .filter((d) => !liveIds.has(d.tabId))
+      .filter((d) => !closedSessionIds.has(d.tabId))
       .filter((d) => !autoRestoredSessionIdsRef.current.has(d.tabId))
       .slice(0, 8);
     if (toRestore.length === 0) return;

--- a/src/hooks/tabOps/closeTab.test.ts
+++ b/src/hooks/tabOps/closeTab.test.ts
@@ -167,6 +167,27 @@ describe("closeTabNow → overview fallback", () => {
     window.removeEventListener(SESSION_UI_SNAPSHOT_FLUSH_EVENT, flushSpy);
   });
 
+  it("bounds closed agent session suppression to the most recent entries", () => {
+    const closedSessionIds = Array.from(
+      { length: 200 },
+      (_, index) => `closed-${index}`,
+    );
+    const agent = makeTab("agent-1", "agent");
+    const { deps, apply } = buildDeps({
+      tabs: [agent],
+      activeTabId: "agent-1",
+      closedSessionIds,
+    });
+    const { closeTabNow } = useCloseTabActions(deps);
+
+    closeTabNow("agent-1");
+
+    const next = apply();
+    expect(next.closedSessionIds).toHaveLength(200);
+    expect((next.closedSessionIds as string[])[0]).toBe("closed-1");
+    expect((next.closedSessionIds as string[]).at(-1)).toBe("agent-1");
+  });
+
   it("does not suppress shell sessions when closing shell sub-tabs", () => {
     const agent = makeTab("agent-1", "agent");
     const shell = makeTab("shell-1", "shell");

--- a/src/hooks/tabOps/closeTab.test.ts
+++ b/src/hooks/tabOps/closeTab.test.ts
@@ -5,6 +5,7 @@ import { useCloseTabActions, type CloseTabDeps } from "./closeTab";
 import { OVERVIEW_TAB_ID, makeEmptyTab, type Tab } from "../../types/tab";
 import type { ProjectsState } from "../../projects";
 import { focusTerminalPanelSoon } from "../../utils/focus";
+import { SESSION_UI_SNAPSHOT_FLUSH_EVENT } from "../../state/sessionUiSnapshot";
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn(() => Promise.resolve(null)),
@@ -22,7 +23,7 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-const ref = <T,>(value: T): MutableRefObject<T> => ({ current: value });
+const ref = <T>(value: T): MutableRefObject<T> => ({ current: value });
 
 function buildDeps(
   initial: Record<string, unknown>,
@@ -143,6 +144,43 @@ describe("closeTabNow → overview fallback", () => {
     closeTabNow("agent-2");
     const next = apply();
     expect(next.activeTabId).toBe("agent-1");
+  });
+
+  it("marks closed agent sessions so reload auto-restore keeps them closed", () => {
+    const t1 = makeTab("agent-1", "agent");
+    const t2 = makeTab("agent-2", "agent");
+    const flushSpy = vi.fn();
+    window.addEventListener(SESSION_UI_SNAPSHOT_FLUSH_EVENT, flushSpy);
+    const { deps, apply } = buildDeps({
+      tabs: [t1, t2],
+      activeTabId: "agent-1",
+      closedSessionIds: ["already-closed"],
+    });
+    const { closeTabNow } = useCloseTabActions(deps);
+
+    closeTabNow("agent-2");
+
+    const next = apply();
+    expect((next.tabs as Tab[]).map((t) => t.id)).toEqual(["agent-1"]);
+    expect(next.closedSessionIds).toEqual(["already-closed", "agent-2"]);
+    expect(flushSpy).toHaveBeenCalledTimes(1);
+    window.removeEventListener(SESSION_UI_SNAPSHOT_FLUSH_EVENT, flushSpy);
+  });
+
+  it("does not suppress shell sessions when closing shell sub-tabs", () => {
+    const agent = makeTab("agent-1", "agent");
+    const shell = makeTab("shell-1", "shell");
+    const { deps, apply } = buildDeps({
+      tabs: [agent, shell],
+      activeTabId: "agent-1",
+      terminalPanel: { activeSubId: "shell-1" },
+      closedSessionIds: ["agent-old"],
+    });
+    const { closeTabNow } = useCloseTabActions(deps);
+
+    closeTabNow("shell-1");
+
+    expect(apply().closedSessionIds).toEqual(["agent-old"]);
   });
 
   it("activates an editor tab if it's the only remaining session kind", () => {
@@ -273,9 +311,7 @@ describe("closeTab — idle-shell guard", () => {
   it("falls back to prompting when isShellBusy throws (assume busy)", async () => {
     const shell = makeTab("sh-1", "shell");
     const promptFn = vi.fn(() => Promise.resolve(true));
-    const isShellBusy = vi.fn(() =>
-      Promise.reject(new Error("ipc lost")),
-    );
+    const isShellBusy = vi.fn(() => Promise.reject(new Error("ipc lost")));
     const { deps } = buildDeps(
       { tabs: [shell], activeTabId: "sh-1" },
       {

--- a/src/hooks/tabOps/closeTab.ts
+++ b/src/hooks/tabOps/closeTab.ts
@@ -247,7 +247,9 @@ export function useCloseTabActions(deps: CloseTabDeps): CloseTabActions {
         const closedIds = Array.isArray(prev.closedSessionIds)
           ? (prev.closedSessionIds as string[])
           : [];
-        result.closedSessionIds = Array.from(new Set([...closedIds, tabId]));
+        result.closedSessionIds = Array.from(new Set([...closedIds, tabId])).slice(
+          -200,
+        );
       }
       // Drop a closed tab from the bucket-independent agent-running set so a
       // closed-mid-turn tab can't leave a stale entry behind.

--- a/src/hooks/tabOps/closeTab.ts
+++ b/src/hooks/tabOps/closeTab.ts
@@ -1,12 +1,17 @@
 import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 import { invoke } from "@tauri-apps/api/core";
-import { OVERVIEW_TAB_ID, type ClosedTabEntry, type Tab } from "../../types/tab";
+import {
+  OVERVIEW_TAB_ID,
+  type ClosedTabEntry,
+  type Tab,
+} from "../../types/tab";
 import type { ProjectsState } from "../../projects";
 import { disposeEditorBuffer } from "../../monaco/editor-buffers";
 import { recomputeModelPicker } from "../../utils/modelPicker";
 import { focusTerminalPanelSoon } from "../../utils/focus";
 import { CLOSED_TAB_STACK_MAX, TAB_MIRROR_KEYS } from "./constants";
 import { recentSessionItemFromClosedTab } from "./helpers";
+import { SESSION_UI_SNAPSHOT_FLUSH_EVENT } from "../../state/sessionUiSnapshot";
 
 export interface CloseTabDeps {
   setState: Dispatch<SetStateAction<Record<string, unknown>>>;
@@ -238,11 +243,15 @@ export function useCloseTabActions(deps: CloseTabDeps): CloseTabActions {
             }
           : {}),
       };
+      if (closedKind === "agent") {
+        const closedIds = Array.isArray(prev.closedSessionIds)
+          ? (prev.closedSessionIds as string[])
+          : [];
+        result.closedSessionIds = Array.from(new Set([...closedIds, tabId]));
+      }
       // Drop a closed tab from the bucket-independent agent-running set so a
       // closed-mid-turn tab can't leave a stale entry behind.
-      const running = prev.agentRunningTabs as
-        | Record<string, true>
-        | undefined;
+      const running = prev.agentRunningTabs as Record<string, true> | undefined;
       if (running && running[tabId]) {
         const nextRunning = { ...running };
         delete nextRunning[tabId];
@@ -316,6 +325,7 @@ export function useCloseTabActions(deps: CloseTabDeps): CloseTabActions {
     if (closedKind === "editor") {
       disposeEditorBuffer(tabId);
     }
+    window.dispatchEvent(new Event(SESSION_UI_SNAPSHOT_FLUSH_EVENT));
   }
 
   /** Close every editor tab whose filePath matches `path` (or is a

--- a/src/hooks/tabOps/constants.ts
+++ b/src/hooks/tabOps/constants.ts
@@ -19,6 +19,7 @@ export const TAB_MIRROR_KEYS: (keyof Tab)[] = [
   "queuedSteeringId",
   "canvas",
   "model",
+  "contextUsage",
   "cwd",
   // M6 P1: shell-tab fields. The "kind" + "shell" mirror lets layouts
   // bind `visible: { $ref: "/kind" }`-style toggles without running a

--- a/src/hooks/uiOverlays/settings.ts
+++ b/src/hooks/uiOverlays/settings.ts
@@ -179,8 +179,9 @@ export function useSettingsOverlay(ctx: SettingsOverlayContext) {
         ...(live?.shell ?? {}),
         ...((pendingSnapshot as { shell?: object }).shell ?? {}),
       },
-      // Always include `shortcuts` so `[shortcuts] new_tab_kind` survives
-      // any other Settings save. write_config drops sections it doesn't see.
+      // Keep deprecated `[shortcuts] new_tab_kind` round-tripping when
+      // users save unrelated settings. write_config drops sections it
+      // doesn't see.
       shortcuts: {
         ...(live?.shortcuts ?? {}),
         ...((pendingSnapshot as { shortcuts?: object }).shortcuts ?? {}),

--- a/src/hooks/useBootConfig.ts
+++ b/src/hooks/useBootConfig.ts
@@ -37,9 +37,6 @@ export interface UseBootConfigActions {
   shellDefaultArgsRef: MutableRefObject<string[]>;
   shellInheritEnvRef: MutableRefObject<boolean>;
   shellPromptBeforeCloseRef: MutableRefObject<boolean>;
-  /** [shortcuts] new_tab_kind — controls Cmd+T routing when focus is
-   *  outside the bottom terminal panel. */
-  shortcutsNewTabKindRef: MutableRefObject<"agent" | "shell">;
   /** [updates] channel — initial value passed to `useUpdater` so the
    *  first background poll hits the right endpoint without a wasted
    *  round-trip against the default ("stable"). Settings save calls
@@ -64,7 +61,7 @@ export interface UseBootConfigActions {
  *
  * The refs are exposed so other hooks can mutate them (currently only
  * the settings save path) and read them (notify-on-completion gate,
- * shell tab defaults, agent-crashed auto-restart, Cmd+T routing).
+ * shell tab defaults, and agent-crashed auto-restart).
  *
  * Held in refs (not React state) so handlers that fire from the bridge
  * see the latest values without re-binding listeners on every config
@@ -81,7 +78,6 @@ export function useBootConfig(ctx: UseBootConfigContext): UseBootConfigActions {
   const shellDefaultArgsRef = useRef<string[]>([]);
   const shellInheritEnvRef = useRef<boolean>(true);
   const shellPromptBeforeCloseRef = useRef<boolean>(true);
-  const shortcutsNewTabKindRef = useRef<"agent" | "shell">("agent");
   const updateChannelRef = useRef<"stable" | "nightly">("stable");
   const disableAutoCheckRef = useRef<boolean>(false);
 
@@ -106,7 +102,6 @@ export function useBootConfig(ctx: UseBootConfigContext): UseBootConfigActions {
     shellDefaultArgsRef.current = fresh.shell.defaultArgs;
     shellInheritEnvRef.current = fresh.shell.inheritEnv;
     shellPromptBeforeCloseRef.current = fresh.shell.promptBeforeClose;
-    shortcutsNewTabKindRef.current = fresh.shortcuts.newTabKind;
     updateChannelRef.current = fresh.updates.channel;
     disableAutoCheckRef.current = fresh.updates.disableAutoCheck;
     setState((prev) => ({
@@ -193,8 +188,6 @@ export function useBootConfig(ctx: UseBootConfigContext): UseBootConfigActions {
       shellDefaultArgsRef.current = config.shell.defaultArgs;
       shellInheritEnvRef.current = config.shell.inheritEnv;
       shellPromptBeforeCloseRef.current = config.shell.promptBeforeClose;
-      // [shortcuts] new_tab_kind.
-      shortcutsNewTabKindRef.current = config.shortcuts.newTabKind;
       // [updates] — seed the hook ref so the first poll fires against
       // the configured channel.
       updateChannelRef.current = config.updates.channel;
@@ -254,7 +247,6 @@ export function useBootConfig(ctx: UseBootConfigContext): UseBootConfigActions {
     shellDefaultArgsRef,
     shellInheritEnvRef,
     shellPromptBeforeCloseRef,
-    shortcutsNewTabKindRef,
     updateChannelRef,
     disableAutoCheckRef,
     reapplyConfig,

--- a/src/hooks/useChat.test.ts
+++ b/src/hooks/useChat.test.ts
@@ -496,9 +496,9 @@ describe("useChat setModel", () => {
       role: "system",
       text: "Agent stopped.",
     });
-    expect(ctx.persistLocalChatMessage).toHaveBeenCalledWith(
+    expect(ctx.persistLocalChatMessage).not.toHaveBeenCalledWith(
       expect.objectContaining({ role: "system", text: "Agent stopped." }),
-      "tab-1",
+      expect.any(String),
     );
   });
 
@@ -612,6 +612,7 @@ describe("useChat setModel", () => {
     expect((stateRef.current.tabs as Tab[])[0].messages.at(-1)).toMatchObject({
       id: "agent-1",
       role: "agent",
+      createdAt: expect.any(Number),
       thinking: "Inspecting",
       text: "\nDone",
     });
@@ -619,6 +620,7 @@ describe("useChat setModel", () => {
       expect.objectContaining({
         id: "agent-1",
         role: "agent",
+        createdAt: expect.any(Number),
         thinking: "Inspecting",
         text: "\nDone",
       }),

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -262,11 +262,17 @@ export function useChat(ctx: UseChatContext): UseChatActions {
         if (idx >= 0) {
           nextMessage = {
             ...messages[idx],
+            createdAt: messages[idx].createdAt ?? Date.now(),
             [channel]: (messages[idx][channel] ?? "") + delta,
           };
           messages[idx] = nextMessage;
         } else {
-          nextMessage = { id: messageId, role: "agent", [channel]: delta };
+          nextMessage = {
+            id: messageId,
+            role: "agent",
+            createdAt: Date.now(),
+            [channel]: delta,
+          };
           messages.push(nextMessage);
         }
         activeResponseIdRef.current = messageId;
@@ -278,6 +284,7 @@ export function useChat(ctx: UseChatContext): UseChatActions {
       if (activeId && last && last.id === activeId && last.role === "agent") {
         const nextMessage = {
           ...last,
+          createdAt: last.createdAt ?? Date.now(),
           [channel]: (last[channel] ?? "") + delta,
         };
         messages[messages.length - 1] = nextMessage;
@@ -288,6 +295,7 @@ export function useChat(ctx: UseChatContext): UseChatActions {
         const nextMessage = {
           id: newId,
           role: "agent" as const,
+          createdAt: Date.now(),
           [channel]: delta,
         };
         messages.push(nextMessage);
@@ -304,7 +312,12 @@ export function useChat(ctx: UseChatContext): UseChatActions {
   }
 
   function appendSystem(text: string) {
-    appendMessage({ id: crypto.randomUUID(), role: "system", text });
+    appendMessage({
+      id: crypto.randomUUID(),
+      role: "system",
+      text,
+      createdAt: Date.now(),
+    });
   }
 
   function clearChat() {
@@ -348,6 +361,7 @@ export function useChat(ctx: UseChatContext): UseChatActions {
         id: crypto.randomUUID(),
         role: "system",
         text: "Agent stopped.",
+        createdAt: Date.now(),
       };
       setState((prev) => {
         const hydrated = hydrateAgentActivityState(prev, diagnostics);
@@ -369,7 +383,6 @@ export function useChat(ctx: UseChatContext): UseChatActions {
             }
           : { ...hydrated, tabs: nextTabs };
       });
-      persistLocalChatMessage(stoppedMessage, tabId);
       return;
     }
   }

--- a/src/hooks/useKeyboardShortcuts.test.tsx
+++ b/src/hooks/useKeyboardShortcuts.test.tsx
@@ -25,7 +25,6 @@ function buildContext(
   return {
     stateRef: ref(state),
     extensionKeybindingsRef: ref(new Map()),
-    shortcutsNewTabKindRef: ref("agent"),
     toggleTerminalAndFocus: vi.fn(),
     toggleSidebar: vi.fn(),
     toggleFilesSidebar: vi.fn(),
@@ -275,6 +274,26 @@ describe("Cmd+T terminal focus retention", () => {
     expect(ctx.newShellTab).toHaveBeenCalledTimes(1);
     expect(ctx.newTab).not.toHaveBeenCalled();
     expect(document.activeElement).toBe(panelInput);
+  });
+
+  it("opens an agent tab when the terminal is open but focus is outside it", () => {
+    const { elsewhere } = mountTerminalFocusDom();
+    elsewhere?.focus();
+    const ctx = buildContext({
+      activeTabId: "__overview__",
+      tabs: [
+        { id: "shell-1", kind: "shell", label: "Shell 1" },
+        { id: "shell-2", kind: "shell", label: "Shell 2" },
+      ],
+      terminal: { open: true },
+      terminalPanel: { activeSubId: "shell-2" },
+    });
+    render(<Harness ctx={ctx} />);
+
+    fireEvent.keyDown(document, { key: "t", metaKey: true });
+
+    expect(ctx.newTab).toHaveBeenCalledTimes(1);
+    expect(ctx.newShellTab).not.toHaveBeenCalled();
   });
 
   it("returns focus to the terminal after Cmd+Shift+T creates a shell sub-tab", () => {

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -47,10 +47,6 @@ export interface UseKeyboardShortcutsContext {
   extensionKeybindingsRef: MutableRefObject<
     Map<string, { combo: string; action: string; description?: string }>
   >;
-  /** "shell" forces Cmd+T to always open a shell sub-tab; "agent"
-   *  (default) preserves focus-aware routing. From `[shortcuts]
-   *  new_tab_kind`. */
-  shortcutsNewTabKindRef: MutableRefObject<"agent" | "shell">;
 
   // Built-in actions, all hoisted from App or hook destructures.
   toggleTerminalAndFocus: () => void;
@@ -180,15 +176,12 @@ export function useKeyboardShortcuts(ctx: UseKeyboardShortcutsContext): void {
         focusTerminalPanelSoon();
         return;
       }
-      // Cmd+T: focus-aware new tab (shell when focus is in panel, else
-      // agent — or always shell when [shortcuts] new_tab_kind = "shell").
+      // Cmd+T: focus-aware new tab. Shell sub-tabs only own this when
+      // keyboard focus is actually inside the bottom terminal panel.
       if (e.key.toLowerCase() === "t" && mod && !e.shiftKey && !e.altKey) {
         e.preventDefault();
         e.stopPropagation();
-        if (
-          isFocusInTerminalPanel() ||
-          ctx.shortcutsNewTabKindRef.current === "shell"
-        ) {
+        if (isFocusInTerminalPanel()) {
           ctx.newShellTab();
           focusTerminalPanelSoon();
         } else {

--- a/src/hooks/useOsEdges.ts
+++ b/src/hooks/useOsEdges.ts
@@ -67,7 +67,10 @@ export function useOsEdges(ctx: UseOsEdgesContext): void {
         autoRestartAgentRef: ctx.autoRestartAgentRef,
         pushNotification: ctx.pushNotification,
       }),
-      subscribeAgentStderr({ appendMessage: ctx.appendMessage }),
+      subscribeAgentStderr({
+        appendMessage: ctx.appendMessage,
+        persistLocalChatMessage: ctx.persistLocalChatMessage,
+      }),
       subscribeMenu({
         stateRef: ctx.stateRef,
         newTab: ctx.newTab,

--- a/src/hooks/useSessionPersistence.test.tsx
+++ b/src/hooks/useSessionPersistence.test.tsx
@@ -2,17 +2,12 @@
 
 import { renderHook, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { getConfig, type AethonConfig } from "../config";
 import { readState, writeState } from "../persist";
 import { createAppStore } from "../state/appStore";
 import {
   buildInitialAppStore,
   useSessionPersistence,
 } from "./useSessionPersistence";
-
-vi.mock("../config", () => ({
-  getConfig: vi.fn(),
-}));
 
 vi.mock("../persist", () => ({
   readState: vi.fn(),
@@ -25,37 +20,6 @@ vi.mock("../layoutPrefs", () => ({
   mergeLayoutPrefsIntoState: vi.fn((state) => state),
   saveLayoutPrefs: vi.fn(() => Promise.resolve()),
 }));
-
-const defaultConfig: AethonConfig = {
-  ui: {
-    theme: null,
-    fontSize: null,
-    restoreTabs: false,
-    notifyOnCompletion: true,
-    notifyMinDurationSeconds: 8,
-  },
-  agent: { model: null },
-  shell: {
-    defaultShareMode: "private",
-    autoRestartAgent: true,
-    defaultCommand: null,
-    defaultArgs: [],
-    inheritEnv: true,
-    promptBeforeClose: true,
-  },
-  shortcuts: { newTabKind: "agent" },
-  voice: {
-    toggleHotkey: "mod+shift+m",
-    holdHotkey: null,
-  },
-  updates: { channel: "stable", disableAutoCheck: false },
-  devshell: {
-    enabled: "auto",
-    mode: "auto",
-    cacheTtlHours: 720,
-    refreshOnLockfileChange: true,
-  },
-};
 
 afterEach(() => {
   vi.clearAllMocks();
@@ -126,8 +90,7 @@ describe("useSessionPersistence", () => {
     });
   });
 
-  it("does not restore durable session snapshots when restore_tabs is disabled", async () => {
-    vi.mocked(getConfig).mockResolvedValue(defaultConfig);
+  it("restores durable session snapshots without a restore_tabs opt-in", async () => {
     vi.mocked(readState).mockResolvedValue(
       JSON.stringify({
         tabs: [
@@ -155,55 +118,14 @@ describe("useSessionPersistence", () => {
       }),
     );
 
-    await waitFor(() => expect(getConfig).toHaveBeenCalled());
-    expect(readState).not.toHaveBeenCalled();
-    expect(appStore.getState().tabs).toEqual([]);
-  });
-
-  it("restores durable session snapshots when restore_tabs is enabled", async () => {
-    vi.mocked(getConfig).mockResolvedValue({
-      ...defaultConfig,
-      ui: { ...defaultConfig.ui, restoreTabs: true },
-    });
-    vi.mocked(readState).mockResolvedValue(
-      JSON.stringify({
-        tabs: [
-          {
-            id: "restored-tab",
-            label: "Restored",
-            messages: [{ id: "m1", role: "user", text: "old context" }],
-          },
-        ],
-        activeTabId: "restored-tab",
-        savedAt: 1,
-      }),
-    );
-    const appStore = createAppStore({
-      tabs: [],
-      activeTabId: null,
-      layout: {},
-      terminalPanel: {},
-    });
-
-    renderHook(() =>
-      useSessionPersistence({
-        appStore,
-        hasSyncSessionSnapshot: false,
-      }),
-    );
-
     await waitFor(() => {
-      expect(appStore.getState().activeTabId).toBe("restored-tab");
+      expect(appStore.getState().activeTabId).toBe("stale-tab");
     });
     expect(readState).toHaveBeenCalledWith("session_ui_snapshot");
     expect(writeState).toHaveBeenCalled();
   });
 
   it("preserves overview as the active surface during durable restore", async () => {
-    vi.mocked(getConfig).mockResolvedValue({
-      ...defaultConfig,
-      ui: { ...defaultConfig.ui, restoreTabs: true },
-    });
     vi.mocked(readState).mockResolvedValue(
       JSON.stringify({
         tabs: [
@@ -239,10 +161,6 @@ describe("useSessionPersistence", () => {
   });
 
   it("restores cold shell snapshots as exited instead of restarting commands", async () => {
-    vi.mocked(getConfig).mockResolvedValue({
-      ...defaultConfig,
-      ui: { ...defaultConfig.ui, restoreTabs: true },
-    });
     vi.mocked(readState).mockResolvedValue(
       JSON.stringify({
         tabs: [

--- a/src/hooks/useSessionPersistence.ts
+++ b/src/hooks/useSessionPersistence.ts
@@ -11,7 +11,6 @@ import {
 } from "../state/sessionUiSnapshot";
 import { createAppStore, type AppStore } from "../state/appStore";
 import { readState, writeState } from "../persist";
-import { getConfig } from "../config";
 import {
   loadLayoutPrefsFromDisk,
   loadLayoutPrefsSync,
@@ -244,21 +243,15 @@ export function useSessionPersistence({
     if (hasSyncSessionSnapshot) {
       startPersistence();
     } else {
-      getConfig()
-        .then((config) => {
-          if (cancelled) return;
-          if (!config.ui.restoreTabs) {
-            startPersistence();
-            return;
-          }
-          return readState(SESSION_UI_SNAPSHOT_FILE);
-        })
+      readState(SESSION_UI_SNAPSHOT_FILE)
         .then((raw) => {
-          if (cancelled || raw === undefined) return;
-          const snapshot = parseSessionUiSnapshot(raw, {
-            restartShellTabs: false,
-          });
-          if (snapshot) restoreSessionUiSnapshot(snapshot);
+          if (cancelled) return;
+          if (raw !== undefined) {
+            const snapshot = parseSessionUiSnapshot(raw, {
+              restartShellTabs: false,
+            });
+            if (snapshot) restoreSessionUiSnapshot(snapshot);
+          }
           startPersistence();
         })
         .catch(() => {

--- a/src/hooks/useSessionPersistence.ts
+++ b/src/hooks/useSessionPersistence.ts
@@ -4,6 +4,7 @@ import { TAB_MIRROR_KEYS } from "./useTabs";
 import { WORKSTATION_AREAS, workstationRows } from "./useFocus";
 import {
   SESSION_UI_SNAPSHOT_FILE,
+  SESSION_UI_SNAPSHOT_FLUSH_EVENT,
   loadSessionUiSnapshot,
   parseSessionUiSnapshot,
   saveSessionUiSnapshot,
@@ -89,6 +90,7 @@ export function buildInitialAppStore({
       ...(restored?.projectModels
         ? { projectModels: restored.projectModels }
         : {}),
+      closedSessionIds: restored?.closedSessionIds ?? [],
       logoUrl,
       appVersion,
       tabs,
@@ -135,11 +137,16 @@ export function useSessionPersistence({
         const tabs = snapshot.tabs.length ? snapshot.tabs : [];
         const buckets = snapshot.buckets ?? {};
         const hasBuckets = Object.keys(buckets).length > 0;
+        const closedSessionIds = snapshot.closedSessionIds ?? [];
         // Nothing to restore only if BOTH the active workspace and every
         // backgrounded workspace are empty. A buckets-only snapshot (the user
         // closed on an overview while agents ran in worktrees) must still
-        // restore its buckets — otherwise the next persist wipes them.
-        if (tabs.length === 0 && !hasBuckets) return prev;
+        // restore its buckets — otherwise the next persist wipes them. A
+        // closed-ids-only snapshot still matters too: it suppresses
+        // auto-restore for sessions the user explicitly closed.
+        if (tabs.length === 0 && !hasBuckets && closedSessionIds.length === 0) {
+          return prev;
+        }
         const hasActiveTabs = tabs.length > 0;
         const activeTabId = hasActiveTabs
           ? (restoredActiveTabId(tabs, snapshot.activeTabId) ?? tabs[0].id)
@@ -170,6 +177,7 @@ export function useSessionPersistence({
           ...(snapshot.projectModels
             ? { projectModels: snapshot.projectModels }
             : {}),
+          closedSessionIds,
           ...(Object.keys(restoredLayout).length > 0
             ? {
                 layout: {
@@ -226,6 +234,7 @@ export function useSessionPersistence({
       persistNow();
       unsubscribe = appStore.subscribe(schedulePersist);
       window.addEventListener("beforeunload", persistNow);
+      window.addEventListener(SESSION_UI_SNAPSHOT_FLUSH_EVENT, persistNow);
     };
     const hot = import.meta.hot;
     let hmrReloadQueued = false;
@@ -267,6 +276,7 @@ export function useSessionPersistence({
         sessionSnapshotPersistTimerRef.current = null;
       }
       window.removeEventListener("beforeunload", persistNow);
+      window.removeEventListener(SESSION_UI_SNAPSHOT_FLUSH_EVENT, persistNow);
       hot?.off("vite:beforeUpdate", reloadOnJsUpdate);
       hot?.off("vite:beforeFullReload", persistNow);
     };

--- a/src/state/sessionUiSnapshot.test.ts
+++ b/src/state/sessionUiSnapshot.test.ts
@@ -104,6 +104,32 @@ describe("sessionUiSnapshot", () => {
     );
   });
 
+  it("persists empty agent tabs in the active workspace and background buckets", () => {
+    saveSessionUiSnapshot({
+      tabs: [makeEmptyTab("empty-active", "Empty Active", "project-1")],
+      activeTabId: "empty-active",
+      persistedTabBuckets: {
+        "project-1::worktree::wt-1": {
+          tabs: [
+            makeEmptyTab("empty-bucket", "Empty Bucket", "project-1"),
+          ],
+          activeTabId: "empty-bucket",
+        },
+      },
+    });
+
+    const loaded = loadSessionUiSnapshot();
+    expect(loaded?.activeTabId).toBe("empty-active");
+    expect(loaded?.tabs).toMatchObject([
+      { id: "empty-active", label: "Empty Active", messages: [] },
+    ]);
+    expect(
+      loaded?.buckets?.["project-1::worktree::wt-1"]?.tabs,
+    ).toMatchObject([
+      { id: "empty-bucket", label: "Empty Bucket", messages: [] },
+    ]);
+  });
+
   it("returns null when neither active tabs nor buckets have sessions", () => {
     saveSessionUiSnapshot({ tabs: [], activeTabId: "__overview__" });
     expect(loadSessionUiSnapshot()).toBeNull();
@@ -468,7 +494,7 @@ describe("sessionUiSnapshot", () => {
     });
   });
 
-  it("does not persist blank empty new tabs", () => {
+  it("persists blank empty new tabs and keeps them active", () => {
     saveSessionUiSnapshot({
       tabs: [
         makeEmptyTab("blank", "Tab 1"),
@@ -483,8 +509,11 @@ describe("sessionUiSnapshot", () => {
     });
 
     const restored = loadSessionUiSnapshot();
-    expect(restored?.tabs.map((t) => t.id)).toEqual(["active-chat"]);
-    expect(restored?.activeTabId).toBe("active-chat");
+    expect(restored?.tabs.map((t) => t.id)).toEqual([
+      "blank",
+      "active-chat",
+    ]);
+    expect(restored?.activeTabId).toBe("blank");
   });
 
   it("does not persist extension-added layout columns or areas", () => {

--- a/src/state/sessionUiSnapshot.test.ts
+++ b/src/state/sessionUiSnapshot.test.ts
@@ -126,6 +126,84 @@ describe("sessionUiSnapshot", () => {
     ]);
   });
 
+  it("repairs timestamped message order and drops stale stop notices on restore", () => {
+    const parsed = parseSessionUiSnapshot(
+      JSON.stringify({
+        tabs: [
+          {
+            ...makeEmptyTab("tab", "Tab"),
+            messages: [
+              {
+                id: "later-agent",
+                role: "agent",
+                text: "later",
+                createdAt: 3_000,
+              },
+              {
+                id: "stderr",
+                role: "system",
+                text: "[agent stderr] 2026-06-02T13:36:55.343Z WARN devshell: failed",
+                createdAt: 2_000,
+              },
+              {
+                id: "stopped",
+                role: "system",
+                text: "Agent stopped.",
+                createdAt: 2_500,
+              },
+              {
+                id: "earlier-user",
+                role: "user",
+                text: "earlier",
+                createdAt: 1_000,
+              },
+            ],
+          },
+        ],
+        activeTabId: "tab",
+        savedAt: 1,
+      }),
+    );
+
+    expect(parsed?.tabs[0].messages.map((message) => message.id)).toEqual([
+      "earlier-user",
+      "stderr",
+      "later-agent",
+    ]);
+  });
+
+  it("restores agent-owned terminal panel to agent bash instead of a shell sub-tab", () => {
+    const parsed = parseSessionUiSnapshot(
+      JSON.stringify({
+        tabs: [
+          {
+            ...makeEmptyTab("agent", "Agent"),
+            messages: [{ id: "m", role: "user", text: "hi" }],
+          },
+          {
+            ...makeEmptyTab("shell", "Shell", null, "shell"),
+            shell: {
+              cwd: "/repo/app",
+              command: "",
+              args: [],
+              shareMode: "private",
+              shellState: "running",
+            },
+          },
+        ],
+        activeTabId: "agent",
+        terminalPanel: { activeSubId: "shell", height: 300 },
+        savedAt: 1,
+      }),
+      { restartShellTabs: true },
+    );
+
+    expect(parsed?.terminalPanel).toEqual({
+      activeSubId: "agent-bash",
+      height: 300,
+    });
+  });
+
   it("returns null when neither active tabs nor buckets have sessions", () => {
     saveSessionUiSnapshot({ tabs: [], activeTabId: "__overview__" });
     expect(loadSessionUiSnapshot()).toBeNull();

--- a/src/state/sessionUiSnapshot.test.ts
+++ b/src/state/sessionUiSnapshot.test.ts
@@ -110,9 +110,7 @@ describe("sessionUiSnapshot", () => {
       activeTabId: "empty-active",
       persistedTabBuckets: {
         "project-1::worktree::wt-1": {
-          tabs: [
-            makeEmptyTab("empty-bucket", "Empty Bucket", "project-1"),
-          ],
+          tabs: [makeEmptyTab("empty-bucket", "Empty Bucket", "project-1")],
           activeTabId: "empty-bucket",
         },
       },
@@ -123,9 +121,7 @@ describe("sessionUiSnapshot", () => {
     expect(loaded?.tabs).toMatchObject([
       { id: "empty-active", label: "Empty Active", messages: [] },
     ]);
-    expect(
-      loaded?.buckets?.["project-1::worktree::wt-1"]?.tabs,
-    ).toMatchObject([
+    expect(loaded?.buckets?.["project-1::worktree::wt-1"]?.tabs).toMatchObject([
       { id: "empty-bucket", label: "Empty Bucket", messages: [] },
     ]);
   });
@@ -133,6 +129,20 @@ describe("sessionUiSnapshot", () => {
   it("returns null when neither active tabs nor buckets have sessions", () => {
     saveSessionUiSnapshot({ tabs: [], activeTabId: "__overview__" });
     expect(loadSessionUiSnapshot()).toBeNull();
+  });
+
+  it("persists closed session ids even when no tabs are open", () => {
+    saveSessionUiSnapshot({
+      tabs: [],
+      activeTabId: "__overview__",
+      closedSessionIds: ["closed-a", "closed-b", "closed-a"],
+    });
+
+    const loaded = loadSessionUiSnapshot();
+    expect(loaded).not.toBeNull();
+    expect(loaded?.tabs).toEqual([]);
+    expect(loaded?.activeTabId).toBe("__overview__");
+    expect(loaded?.closedSessionIds).toEqual(["closed-a", "closed-b"]);
   });
 
   it("falls back to the first tab when the active id is stale", () => {
@@ -509,10 +519,7 @@ describe("sessionUiSnapshot", () => {
     });
 
     const restored = loadSessionUiSnapshot();
-    expect(restored?.tabs.map((t) => t.id)).toEqual([
-      "blank",
-      "active-chat",
-    ]);
+    expect(restored?.tabs.map((t) => t.id)).toEqual(["blank", "active-chat"]);
     expect(restored?.activeTabId).toBe("blank");
   });
 

--- a/src/state/sessionUiSnapshot.ts
+++ b/src/state/sessionUiSnapshot.ts
@@ -4,6 +4,8 @@ import { durableImageAttachments } from "../utils/imageAttachments";
 import { dedupeToolResultTextMessages } from "../utils/messages";
 
 export const SESSION_UI_SNAPSHOT_FILE = "session_ui_snapshot";
+export const SESSION_UI_SNAPSHOT_FLUSH_EVENT =
+  "aethon:flush-session-ui-snapshot";
 
 const KEY = "aethon:session-ui-snapshot:v1";
 const MAX_MESSAGES_PER_TAB = 200;
@@ -25,6 +27,7 @@ export interface SessionUiSnapshot {
   terminalPanel?: unknown;
   scrollToMatchByTab?: unknown;
   projectModels?: Record<string, string>;
+  closedSessionIds?: string[];
   /** Non-active workspace tab buckets, keyed by `projectScopeBucketKey`.
    *  The ACTIVE workspace's tabs live in `tabs`; every other workspace the
    *  user had open is stashed here so a restart can restore the tab they
@@ -227,6 +230,18 @@ function validTabsFrom(value: unknown): Tab[] {
     : [];
 }
 
+function validSessionIdsFrom(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return Array.from(
+    new Set(
+      value.filter(
+        (candidate): candidate is string =>
+          typeof candidate === "string" && candidate.length > 0,
+      ),
+    ),
+  ).slice(-200);
+}
+
 /** Normalise a persisted tab back into a live Tab: dedupe + durable-ify
  *  attachments, reset process-local fields (waiting / queue), preserve
  *  editor metadata, and re-arm or quiesce shell tabs. Shared by the main
@@ -276,9 +291,7 @@ function restoreTabRecord(
     // Preserve editor metadata so a persisted editor tab reopens pointing at
     // the same file. Validate minimally — `filePath` is what EditorCanvas
     // requires; the rest fall back to safe defaults on the next render.
-    ...(t.kind === "editor" &&
-    t.editor &&
-    typeof t.editor.filePath === "string"
+    ...(t.kind === "editor" && t.editor && typeof t.editor.filePath === "string"
       ? {
           editor: {
             filePath: t.editor.filePath,
@@ -300,9 +313,7 @@ function restoreTabRecord(
         }
       : {}),
   };
-  return base.kind === "shell"
-    ? restoreShellTab(base, restartShellTabs)
-    : base;
+  return base.kind === "shell" ? restoreShellTab(base, restartShellTabs) : base;
 }
 
 /** Validate + restore the non-active workspace buckets. Each bucket's tabs
@@ -353,6 +364,7 @@ export function parseSessionUiSnapshot(
     if (!raw) return null;
     const parsed = JSON.parse(raw) as Partial<SessionUiSnapshot>;
     const tabs = validTabsFrom(parsed.tabs);
+    const closedSessionIds = validSessionIdsFrom(parsed.closedSessionIds);
     const restartShellTabs = options.restartShellTabs === true;
     const preserveAgentActivity = options.preserveAgentActivity === true;
     const buckets = parsePersistedBuckets(
@@ -361,8 +373,11 @@ export function parseSessionUiSnapshot(
       preserveAgentActivity,
     );
     // Nothing to restore if neither the active workspace nor any backgrounded
-    // workspace had sessions.
-    if (tabs.length === 0 && !buckets) return null;
+    // workspace had sessions, and no closed-session suppressions need to
+    // survive to keep discovered sessions from auto-opening on reload.
+    if (tabs.length === 0 && !buckets && closedSessionIds.length === 0) {
+      return null;
+    }
     // OVERVIEW_TAB_ID is a valid persisted value (the user closed the
     // app while the overview pseudo-tab owned the canvas with sessions
     // open) — keep it as-is. Other ids must still match a real tab. With no
@@ -385,6 +400,8 @@ export function parseSessionUiSnapshot(
       terminal: durableTerminalSnapshot(parsed.terminal),
       terminalPanel: parsed.terminalPanel,
       scrollToMatchByTab: parsed.scrollToMatchByTab,
+      closedSessionIds:
+        closedSessionIds.length > 0 ? closedSessionIds : undefined,
       projectModels:
         parsed.projectModels &&
         typeof parsed.projectModels === "object" &&
@@ -412,10 +429,11 @@ export function serializeSessionUiSnapshot(
       ? (state.tabs as Tab[]).filter(shouldPersistTab).map(trimTab)
       : [];
     const buckets = serializePersistedBuckets(state.persistedTabBuckets);
+    const closedSessionIds = validSessionIdsFrom(state.closedSessionIds);
     // Persist when the active workspace OR any backgrounded workspace has
     // sessions worth keeping. A user sitting on a project's overview while
     // agents run in its worktrees still has state to restore.
-    if (tabs.length === 0 && !buckets) {
+    if (tabs.length === 0 && !buckets && closedSessionIds.length === 0) {
       return null;
     }
     const activeTab = tabs.find((t) => t.id === state.activeTabId);
@@ -431,6 +449,7 @@ export function serializeSessionUiSnapshot(
       terminal: durableTerminalSnapshot(state.terminal),
       terminalPanel: state.terminalPanel,
       scrollToMatchByTab: state.scrollToMatchByTab,
+      ...(closedSessionIds.length > 0 ? { closedSessionIds } : {}),
       projectModels:
         state.projectModels &&
         typeof state.projectModels === "object" &&

--- a/src/state/sessionUiSnapshot.ts
+++ b/src/state/sessionUiSnapshot.ts
@@ -90,14 +90,7 @@ function shouldPersistTab(tab: Tab): boolean {
   // are intentionally not serialised (saving arbitrary in-memory edits
   // could surprise the user on next launch).
   if (tab.kind === "editor") return tab.editor?.filePath != null;
-  return (
-    tab.messages.length > 0 ||
-    tab.draft.trim().length > 0 ||
-    tab.waiting ||
-    tab.queueCount > 0 ||
-    tab.canvas !== null ||
-    tab.terminalBuffer.length > 0
-  );
+  return true;
 }
 
 function restoreShellTab(tab: Tab, restartShellTabs: boolean): Tab {

--- a/src/state/sessionUiSnapshot.ts
+++ b/src/state/sessionUiSnapshot.ts
@@ -11,6 +11,7 @@ const KEY = "aethon:session-ui-snapshot:v1";
 const MAX_MESSAGES_PER_TAB = 200;
 const MAX_TERMINAL_BUFFER = 256 * 1024;
 const MAX_TERMINAL_BUFFER_ENTRIES = 8;
+const AGENT_BASH_SUB_ID = "agent-bash";
 
 /** A stashed (non-active) workspace's tabs + its last-active tab, keyed in
  *  `SessionUiSnapshot.buckets` by `projectScopeBucketKey`. */
@@ -126,6 +127,93 @@ function restoreShellTab(tab: Tab, restartShellTabs: boolean): Tab {
 
 function tabCanOwnMainSurface(tab: Tab | undefined): boolean {
   return !!tab && tab.kind !== "shell";
+}
+
+function messageCreatedAt(message: ChatMessage): number | undefined {
+  if (
+    typeof message.createdAt === "number" &&
+    Number.isFinite(message.createdAt)
+  ) {
+    return message.createdAt;
+  }
+  if (message.role !== "system" || typeof message.text !== "string") {
+    return undefined;
+  }
+  const raw = /^\[agent stderr\]\s+(\d{4}-\d{2}-\d{2}T[^\s]+)/.exec(
+    message.text,
+  )?.[1];
+  if (!raw) return undefined;
+  const parsed = Date.parse(raw);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function isStaleUntimestampedSystemNotice(message: ChatMessage): boolean {
+  const text = message.text?.replace(/\s+/g, " ").trim().toLowerCase() ?? "";
+  if (message.role === "system" && text === "agent stopped.") {
+    return true;
+  }
+  if (message.role !== "system" || messageCreatedAt(message) !== undefined) {
+    return false;
+  }
+  return (
+    text === "compacting context..." ||
+    text === "compacting context…" ||
+    text.startsWith("context compacted") ||
+    text.startsWith("context compaction complete") ||
+    text.startsWith("context compaction failed:")
+  );
+}
+
+function normalizeRestoredMessages(messages: ChatMessage[]): ChatMessage[] {
+  return messages
+    .filter((message) => !isStaleUntimestampedSystemNotice(message))
+    .map((message) => {
+      const createdAt = messageCreatedAt(message);
+      return createdAt !== undefined && message.createdAt !== createdAt
+        ? { ...message, createdAt }
+        : message;
+    })
+    .map((message, order) => ({ message, order }))
+    .sort((a, b) => {
+      const aTime = messageCreatedAt(a.message);
+      const bTime = messageCreatedAt(b.message);
+      if (
+        typeof aTime === "number" &&
+        typeof bTime === "number" &&
+        aTime !== bTime
+      ) {
+        return aTime - bTime;
+      }
+      return a.order - b.order;
+    })
+    .map((entry) => entry.message);
+}
+
+function durableTerminalPanelSnapshot(
+  terminalPanel: unknown,
+  tabs: readonly Tab[],
+  activeTabId: string | undefined,
+): Record<string, unknown> | undefined {
+  if (!terminalPanel || typeof terminalPanel !== "object") return undefined;
+  const input = terminalPanel as Record<string, unknown>;
+  const next: Record<string, unknown> = {};
+  if (typeof input.height === "number" && Number.isFinite(input.height)) {
+    next.height = input.height;
+  }
+
+  const activeTab = tabs.find((tab) => tab.id === activeTabId);
+  if (activeTab?.kind === "agent") {
+    next.activeSubId = AGENT_BASH_SUB_ID;
+  } else if (typeof input.activeSubId === "string") {
+    const activeShell = tabs.find(
+      (tab) => tab.id === input.activeSubId && tab.kind === "shell",
+    );
+    if (activeShell?.shell?.shellState !== "exited") {
+      next.activeSubId = input.activeSubId;
+    }
+  }
+
+  return Object.keys(next).length > 0 ? next : undefined;
 }
 
 function durableLayoutSnapshot(
@@ -261,14 +349,15 @@ function restoreTabRecord(
   const base = {
     ...t,
     kind,
-    messages: dedupeToolResultTextMessages(t.messages).map(
-      (message): ChatMessage =>
+    messages: normalizeRestoredMessages(
+      dedupeToolResultTextMessages(t.messages).map((message): ChatMessage =>
         message.attachments && message.attachments.length > 0
           ? {
               ...message,
               attachments: durableImageAttachments(message.attachments),
             }
           : message,
+      ),
     ),
     draft: t.draft ?? "",
     draftAttachments: Array.isArray(t.draftAttachments)
@@ -391,14 +480,19 @@ export function parseSessionUiSnapshot(
               tabCanOwnMainSurface(parsedActiveTab))
           ? parsed.activeTabId
           : (tabs.find(tabCanOwnMainSurface)?.id ?? OVERVIEW_TAB_ID);
+    const restoredTabs = tabs.map((t) =>
+      restoreTabRecord(t, restartShellTabs, preserveAgentActivity),
+    );
     return {
-      tabs: tabs.map((t) =>
-        restoreTabRecord(t, restartShellTabs, preserveAgentActivity),
-      ),
+      tabs: restoredTabs,
       activeTabId,
       layout: durableLayoutSnapshot(parsed.layout),
       terminal: durableTerminalSnapshot(parsed.terminal),
-      terminalPanel: parsed.terminalPanel,
+      terminalPanel: durableTerminalPanelSnapshot(
+        parsed.terminalPanel,
+        restoredTabs,
+        activeTabId,
+      ),
       scrollToMatchByTab: parsed.scrollToMatchByTab,
       closedSessionIds:
         closedSessionIds.length > 0 ? closedSessionIds : undefined,
@@ -447,7 +541,11 @@ export function serializeSessionUiSnapshot(
       activeTabId,
       layout: durableLayoutSnapshot(state.layout),
       terminal: durableTerminalSnapshot(state.terminal),
-      terminalPanel: state.terminalPanel,
+      terminalPanel: durableTerminalPanelSnapshot(
+        state.terminalPanel,
+        tabs,
+        activeTabId,
+      ),
       scrollToMatchByTab: state.scrollToMatchByTab,
       ...(closedSessionIds.length > 0 ? { closedSessionIds } : {}),
       projectModels:

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -4492,6 +4492,26 @@ body.ae-resizing-composer * {
   white-space: nowrap;
 }
 
+.ae-tab-rename-input {
+  flex: 1 1 auto;
+  min-width: 2.5rem;
+  max-width: 100%;
+  height: 22px;
+  border: 1px solid var(--accent);
+  border-radius: 4px;
+  padding: 0 5px;
+  background: var(--bg);
+  color: var(--text);
+  font: inherit;
+  font-size: var(--chrome-text);
+  outline: none;
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 28%, transparent);
+}
+
+.ae-tab-rename-input::selection {
+  background: var(--accent-soft);
+}
+
 .a2ui-tab-close {
   background: transparent;
   border: none;

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -4153,10 +4153,7 @@ body.ae-resizing-composer * {
 /* ---- Status bar --------------------------------------------------------- */
 
 .a2ui-status-bar {
-  display: grid;
-  grid-template-columns:
-    minmax(0, auto) minmax(0, auto) minmax(10rem, 1fr)
-    minmax(0, auto);
+  display: flex;
   align-items: center;
   gap: var(--space-3);
   height: 22px;
@@ -4165,7 +4162,7 @@ body.ae-resizing-composer * {
   border-top: 1px solid var(--border);
   font-size: var(--chrome-text-compact);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  letter-spacing: 0.02em;
+  letter-spacing: 0;
   color: var(--text-dim);
   width: 100%;
   min-width: 0;
@@ -4263,6 +4260,82 @@ body.ae-resizing-composer * {
   color: var(--text);
   font-family: var(--font-ui);
 }
+
+.a2ui-status-context-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
+  max-width: 300px;
+  height: 18px;
+  padding: 0 var(--space-2);
+  border-right: 1px solid var(--border);
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  font-size: var(--chrome-text-muted);
+  overflow: hidden;
+  white-space: nowrap;
+}
+.a2ui-status-context-track {
+  position: relative;
+  width: 28px;
+  height: 4px;
+  border-radius: var(--radius-pill);
+  overflow: hidden;
+  background: color-mix(in srgb, var(--text-dim) 18%, transparent);
+  flex: 0 0 auto;
+}
+.a2ui-status-context-fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  min-width: 2px;
+  border-radius: inherit;
+  background: var(--accent);
+}
+.a2ui-status-context-chip.is-warning .a2ui-status-context-fill,
+.a2ui-status-context-chip.is-warning .a2ui-status-context-track {
+  background: var(--warn);
+}
+.a2ui-status-context-chip.is-warning .a2ui-status-context-label {
+  color: var(--warn);
+}
+.a2ui-status-context-chip.is-danger .a2ui-status-context-fill,
+.a2ui-status-context-chip.is-danger .a2ui-status-context-track {
+  background: var(--err, #c0392b);
+}
+.a2ui-status-context-chip.is-danger .a2ui-status-context-label {
+  color: var(--err, #c0392b);
+}
+.a2ui-status-context-chip.is-compacting .a2ui-status-context-track {
+  animation: ae-context-compact-pulse 1.1s ease-in-out infinite;
+}
+.a2ui-status-context-label {
+  color: var(--text);
+  font-family: var(--font-ui);
+  flex: 0 0 auto;
+}
+.a2ui-status-context-detail,
+.a2ui-status-context-auto {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.a2ui-status-context-detail {
+  color: var(--text-dim);
+  max-width: 90px;
+}
+.a2ui-status-context-auto {
+  color: var(--accent);
+  max-width: 110px;
+}
+@keyframes ae-context-compact-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.45;
+  }
+}
 @keyframes ae-devshell-pulse {
   0%,
   100% {
@@ -4289,6 +4362,7 @@ body.ae-resizing-composer * {
   display: inline-flex;
   align-items: center;
   gap: 6px;
+  flex: 0 1 auto;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -4307,6 +4381,7 @@ body.ae-resizing-composer * {
 .a2ui-status-center {
   text-align: center;
   color: var(--text);
+  flex: 1 1 auto;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -4315,6 +4390,7 @@ body.ae-resizing-composer * {
 
 .a2ui-status-right {
   text-align: right;
+  flex: 0 1 auto;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/types/a2ui.ts
+++ b/src/types/a2ui.ts
@@ -215,6 +215,7 @@ export interface StatusBarComponent extends A2UIComponent {
     left?: StringValue;
     center?: StringValue;
     right?: StringValue;
+    context?: { $ref: string };
   };
 }
 

--- a/src/types/tab.ts
+++ b/src/types/tab.ts
@@ -53,6 +53,20 @@ export interface EditorMeta {
   diff?: boolean;
 }
 
+export interface ContextUsageState {
+  tabId?: string;
+  model: string;
+  status: "known" | "unknown";
+  tokens: number | null;
+  contextWindow: number;
+  percent: number | null;
+  autoCompactEnabled: boolean;
+  reserveTokens: number;
+  compactAtTokens: number;
+  tokensUntilCompact: number | null;
+  compacting?: boolean;
+}
+
 export type TabKind = "agent" | "shell" | "editor";
 
 /**
@@ -98,6 +112,7 @@ export interface Tab {
   queuedSteeringId?: string;
   canvas: unknown;
   model: string;
+  contextUsage?: ContextUsageState;
   // Rolling buffer of bash output for this tab. The Terminal component
   // writes to xterm directly for the active tab; this buffer survives
   // tab switches so the panel can replay it when the user comes back.

--- a/src/utils/focus.ts
+++ b/src/utils/focus.ts
@@ -8,7 +8,10 @@ export function isFocusInTerminalPanel(): boolean {
   const focused = document.activeElement;
   if (!focused) return false;
   const panel = document.querySelector(".ae-terminal-panel");
-  return !!panel?.contains(focused);
+  if (!panel) return false;
+  if (panel.classList.contains("is-closed")) return false;
+  if (panel.getAttribute("aria-hidden") === "true") return false;
+  return panel.contains(focused);
 }
 
 export function focusTerminalPanel(): void {

--- a/src/utils/messages.test.ts
+++ b/src/utils/messages.test.ts
@@ -138,6 +138,18 @@ describe("coerceChatMessages", () => {
     expect(out[0].id).toBe("abc");
   });
 
+  it("preserves finite creation timestamps", () => {
+    const out = coerceChatMessages([
+      { id: "abc", role: "system", text: "warning", createdAt: 1_234 },
+    ]);
+    expect(out[0]).toEqual({
+      id: "abc",
+      role: "system",
+      text: "warning",
+      createdAt: 1_234,
+    });
+  });
+
   it("generates a uuid when id missing", () => {
     const out = coerceChatMessages([{ role: "user", text: "hi" }]);
     expect(out[0].id).toMatch(/^[0-9a-f-]{36}$/i);

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -230,6 +230,10 @@ export function coerceChatMessages(value: unknown): ChatMessage[] {
         ? record.delivery
         : undefined;
     const attachments = coerceChatAttachments(record.attachments);
+    const createdAt =
+      typeof record.createdAt === "number" && Number.isFinite(record.createdAt)
+        ? record.createdAt
+        : undefined;
     if (!text && !thinking && !a2ui && attachments.length === 0) continue;
     messages.push(
       trimMessage({
@@ -243,6 +247,7 @@ export function coerceChatMessages(value: unknown): ChatMessage[] {
         ...(attachments.length > 0 ? { attachments } : {}),
         ...(a2ui ? { a2ui } : {}),
         ...(delivery ? { delivery } : {}),
+        ...(createdAt !== undefined ? { createdAt } : {}),
       }),
     );
   }


### PR DESCRIPTION
## Summary

This branch collects the misc fixes and UX improvements we have been iterating on across Aethon sessions. It tightens tab/session persistence, fixes terminal focus behavior, improves streaming markdown rendering, adds a live context meter, and makes compaction/session timeline events durable and visible in the right place.

## What changed

### Session and tab persistence

- Restores session tabs across hot reloads and app restarts, including active tab state and per-project buckets.
- Persists closed session ids so `Close`, `Close Others`, and `Close All` do not resurrect closed tabs on reload.
- Adds inline tab rename from the tab context menu instead of the previous modal-like rename UI.
- Fixes rename editing so typing in the tab label does not blank the app.
- Normalizes restored chat timelines so stale local stderr, streamed assistant fragments, stop notices, and compaction markers do not reappear at the bottom out of order.
- Makes `Agent stopped.` a live-only UI acknowledgement instead of durable transcript content.

### Terminal and shortcut behavior

- Restores `Cmd+T` as focus-aware: agent tab outside the bottom terminal panel, shell sub-tab only when terminal focus owns the shortcut.
- Keeps shell tabs in the bottom terminal panel and prevents stale shell sub-tab selection from hijacking an agent session after reload.
- Preserves terminal panel sizing while sanitizing durable active-sub-tab state.

### Streaming markdown and message rendering

- Stabilizes streaming markdown/code rendering to avoid jitter while text is arriving.
- Avoids showing raw backticks longer than necessary for markdown that can render cleanly.
- Preserves better rendering for messages that were already streaming well before this branch.
- Keeps agent stderr and tool/system messages in their chronological transcript location instead of appending them after reload.

### Context meter and compaction visibility

- Adds a compact context meter to the bottom status bar with current context percentage, token counts, and auto-compaction threshold.
- Wires live context usage updates from the agent to the frontend so the status bar updates as the model streams/tool-calls.
- Persists compaction markers consistently in the chat transcript so manual and automatic compactions are visible after leaving and re-entering a session.
- Adds backend/frontend parsing for pi/Ollama context usage so the UI can work across model providers.

## Root causes addressed

- Some local UI-only chat rows were persisted without enough timestamp information, so restored history could place them at the end of the conversation.
- Stop notices were durable even though they represented transient UI state, so they returned after reload as if they were the latest chat event.
- Terminal panel active-sub-tab state was being persisted too literally, causing old shell selections to come back in agent sessions.
- The context meter had data plumbing but did not reliably receive live updates or durable compaction events.
- Streaming markdown rendering was reacting too aggressively to partial fenced-code input, causing visible jitter.

## Validation

- `bun run typecheck`
- `bun run lint`
- `bun run test` — 218 files, 1701 tests passed
- `bun run build` — passed with the existing Vite large-chunk warning
- `cargo test --lib -p aethon` — 344 passed, 2 ignored
- Live dev-app reload inspection with Aethon debug tooling:
  - restored session selected `agent-bash` for the terminal panel
  - stale `Agent stopped.` rows no longer appeared at the restored bottom
  - older stderr/compaction rows remained in chronological transcript positions

## Peer review

A read-only Codex peer review flagged three risks before this PR was opened. Two were addressed in the final commit:

- streamed assistant snapshots now receive `createdAt` values so stale fragments can be ordered/dropped correctly on restore
- session-history hydration now clears the global `thinking…` status when it proves the active tab is idle

The third item, resetting a persisted shell sub-tab back to `agent-bash` for agent-session restore, is intentional for this branch: shell sub-tabs still exist, but reload/re-enter should not reopen an agent session onto an old shell selection.
