### PR TITLE
feat: working-context injection, tri-state transcript controls, project-root guardrail

### DIFF
--- a/agent/chat.ts
+++ b/agent/chat.ts
@@ -21,6 +21,11 @@ export async function handleChat(
     return;
   }
   const tabId = msg.tabId ?? "default";
+  // Per-tab hard-guardrail override rides each chat so the source guard sees
+  // the current value before this turn's tool calls (and survives a respawn).
+  if (typeof msg.hardEnforce === "boolean") {
+    state.tabHardEnforce.set(tabId, msg.hardEnforce);
+  }
   const cwdOverride =
     typeof msg.cwd === "string" && msg.cwd.length > 0 ? msg.cwd : undefined;
   let initialModel: Model<Api> | undefined;

--- a/agent/dispatcherTypes.ts
+++ b/agent/dispatcherTypes.ts
@@ -35,6 +35,8 @@ export interface InboundMessage {
   mode?: "normal" | "steer";
   cwd?: string;
   model?: string;
+  /** Per-tab hard project-root guardrail override, carried on `chat`. */
+  hardEnforce?: boolean;
   name?: string;
   args?: string;
   id?: string;

--- a/agent/git-context.test.ts
+++ b/agent/git-context.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  AethonAgentState,
+  type AethonAgentStateOptions,
+} from "./state";
+import {
+  getWorkingContext,
+  _resetGitContextCacheForTests,
+  type GitContextDeps,
+} from "./git-context";
+
+function makeState(): AethonAgentState {
+  const userDir = "/tmp/aethon-gc";
+  const opts: AethonAgentStateOptions = {
+    userDir,
+    stateFile: `${userDir}/state.json`,
+    sessionsDir: `${userDir}/sessions`,
+    docsDir: undefined,
+    projectRoot: undefined,
+    releaseMode: false,
+    bootLayoutFile: undefined,
+    layoutSlotsFile: undefined,
+    statePayloadWarnBytes: 64 * 1024,
+    statePayloadHardBytes: 512 * 1024,
+    statePayloadWarnKb: 64,
+    statePayloadHardKb: 512,
+  };
+  const state = new AethonAgentState(opts);
+  state.frontendReady = true;
+  return state;
+}
+
+/** Build a deps.send that synchronously resolves the matching pending
+ *  mutation with `reply` — modelling the frontend's `git_query` ack. */
+function replyWith(
+  state: AethonAgentState,
+  sent: Record<string, unknown>[],
+  reply: { ok: boolean; error?: string; data?: unknown },
+): GitContextDeps {
+  return {
+    send: (msg) => {
+      sent.push(msg);
+      const id = msg.mutationId as string;
+      const pending = state.pendingMutations.get(id);
+      if (pending) {
+        clearTimeout(pending.timer);
+        state.pendingMutations.delete(id);
+        pending.resolve(reply);
+      }
+    },
+  };
+}
+
+describe("getWorkingContext", () => {
+  beforeEach(() => _resetGitContextCacheForTests());
+
+  it("queries the bridge and normalizes the git working context", async () => {
+    const state = makeState();
+    const sent: Record<string, unknown>[] = [];
+    const deps = replyWith(state, sent, {
+      ok: true,
+      data: {
+        repoRoot: "/r",
+        branch: "main",
+        isWorktree: false,
+        changedFiles: 2,
+        ahead: 1,
+        behind: 0,
+      },
+    });
+    const ctx = await getWorkingContext(state, deps, "/r", 1000);
+    expect(sent[0]).toMatchObject({
+      type: "git_query",
+      op: "working_context",
+      args: { cwd: "/r" },
+    });
+    expect(ctx).toEqual({
+      repoRoot: "/r",
+      branch: "main",
+      isWorktree: false,
+      changedFiles: 2,
+      ahead: 1,
+      behind: 0,
+    });
+  });
+
+  it("serves a cached result within the TTL without re-querying", async () => {
+    const state = makeState();
+    const sent: Record<string, unknown>[] = [];
+    const deps = replyWith(state, sent, {
+      ok: true,
+      data: { repoRoot: "/r", branch: "main", isWorktree: false, changedFiles: 0, ahead: 0, behind: 0 },
+    });
+    await getWorkingContext(state, deps, "/r", 1000);
+    await getWorkingContext(state, deps, "/r", 2000); // within 2.5s TTL
+    expect(sent).toHaveLength(1);
+    // Past the TTL → a fresh query.
+    await getWorkingContext(state, deps, "/r", 9000);
+    expect(sent).toHaveLength(2);
+  });
+
+  it("returns null when the cwd is not a git repository", async () => {
+    const state = makeState();
+    const sent: Record<string, unknown>[] = [];
+    const deps = replyWith(state, sent, { ok: true, data: null });
+    const ctx = await getWorkingContext(state, deps, "/tmp/plain", 1000);
+    expect(ctx).toBeNull();
+  });
+
+  it("degrades to null on a failed query without throwing", async () => {
+    const state = makeState();
+    const sent: Record<string, unknown>[] = [];
+    const deps = replyWith(state, sent, { ok: false, error: "timeout" });
+    const ctx = await getWorkingContext(state, deps, "/r", 1000);
+    expect(ctx).toBeNull();
+  });
+
+  it("normalizes partial/garbage payloads to safe defaults", async () => {
+    const state = makeState();
+    const sent: Record<string, unknown>[] = [];
+    const deps = replyWith(state, sent, {
+      ok: true,
+      data: { branch: 42, changedFiles: "lots" },
+    });
+    const ctx = await getWorkingContext(state, deps, "/r", 1000);
+    expect(ctx).toEqual({
+      repoRoot: null,
+      branch: null,
+      isWorktree: false,
+      changedFiles: 0,
+      ahead: 0,
+      behind: 0,
+    });
+  });
+});

--- a/agent/git-context.ts
+++ b/agent/git-context.ts
@@ -1,0 +1,131 @@
+/**
+ * Agent-side working-directory git context.
+ *
+ * The `before_agent_start` hook (wired in `main.ts`) injects a fresh
+ * "Working context" block into the model's system prompt every turn so a
+ * local model never loses track of the active tab's cwd. Git facts for that
+ * block come from the Rust `git_working_context` command, reached through the
+ * `git_query` mutation-ack bridge (Rust resolves `git` via the PATH-augmenting
+ * `env` helper, so this is correct in Finder-launched release builds too —
+ * unlike a bare `child_process` spawn from the bun process).
+ *
+ * Results are cached per-cwd with a short TTL so a multi-step turn (or rapid
+ * re-prompts) doesn't re-query, while still refreshing between turns that are
+ * seconds apart — branch/dirty state stays live. Failures degrade silently to
+ * the last known value (or null); a missing git context never blocks a turn.
+ */
+
+import { trackMutation } from "./mutation-ack";
+import type { AethonAgentState, MutationResult } from "./state";
+import { logger } from "./logger";
+
+export interface GitWorkingContext {
+  repoRoot: string | null;
+  branch: string | null;
+  isWorktree: boolean;
+  changedFiles: number;
+  ahead: number;
+  behind: number;
+}
+
+interface CacheEntry {
+  ctx: GitWorkingContext | null;
+  ts: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+const inflight = new Map<string, Promise<GitWorkingContext | null>>();
+
+const TTL_MS = 2_500;
+const QUERY_TIMEOUT_MS = 4_000;
+
+export interface GitContextDeps {
+  send: (obj: Record<string, unknown>) => void;
+}
+
+/** Test-only: drop the module-local cache so cases don't bleed into each
+ *  other. Not part of the runtime surface. */
+export function _resetGitContextCacheForTests(): void {
+  cache.clear();
+  inflight.clear();
+}
+
+/** Resolve the working-directory git context for `cwd`. Returns `null` when
+ *  the directory isn't a git work tree (or on a degraded/timed-out query).
+ *  `now` is injectable for tests. */
+export async function getWorkingContext(
+  state: AethonAgentState,
+  deps: GitContextDeps,
+  cwd: string,
+  now: number = Date.now(),
+): Promise<GitWorkingContext | null> {
+  const cached = cache.get(cwd);
+  if (cached && now - cached.ts < TTL_MS) {
+    return cached.ctx;
+  }
+  const pending = inflight.get(cwd);
+  if (pending) return pending;
+
+  const fetchPromise = (async () => {
+    try {
+      const result = await sendQuery(state, deps, cwd);
+      if (!result.ok) {
+        // Transient failure — keep the previous value (if any) rather than
+        // poisoning the cache with a null the next turn would have to undo.
+        return cached?.ctx ?? null;
+      }
+      const ctx = normalizeContext(result.data);
+      cache.set(cwd, { ctx, ts: now });
+      return ctx;
+    } catch (err) {
+      logger
+        .scope("git-context")
+        .warn(`working_context(${cwd}) threw: ${(err as Error).message}`);
+      return cached?.ctx ?? null;
+    } finally {
+      inflight.delete(cwd);
+    }
+  })();
+  inflight.set(cwd, fetchPromise);
+  return fetchPromise;
+}
+
+async function sendQuery(
+  state: AethonAgentState,
+  deps: GitContextDeps,
+  cwd: string,
+): Promise<MutationResult> {
+  if (!state.frontendReady) {
+    const ready = await Promise.race<boolean>([
+      state.frontendReadyPromise.then(() => true),
+      new Promise<boolean>((resolve) =>
+        setTimeout(() => resolve(false), QUERY_TIMEOUT_MS),
+      ),
+    ]);
+    if (!ready) return { ok: false, error: "frontend_not_ready" };
+  }
+  const { id, promise } = trackMutation(state, QUERY_TIMEOUT_MS);
+  deps.send({
+    type: "git_query",
+    mutationId: id,
+    op: "working_context",
+    args: { cwd },
+  });
+  return promise;
+}
+
+/** Coerce the Rust `Option<GitWorkingContext>` JSON into our shape. `null`
+ *  (not a repo) passes through; partial/garbage payloads clamp to safe
+ *  defaults so the prompt builder never sees `undefined`. */
+function normalizeContext(data: unknown): GitWorkingContext | null {
+  if (data == null || typeof data !== "object") return null;
+  const d = data as Record<string, unknown>;
+  return {
+    repoRoot: typeof d.repoRoot === "string" ? d.repoRoot : null,
+    branch: typeof d.branch === "string" ? d.branch : null,
+    isWorktree: d.isWorktree === true,
+    changedFiles: typeof d.changedFiles === "number" ? d.changedFiles : 0,
+    ahead: typeof d.ahead === "number" ? d.ahead : 0,
+    behind: typeof d.behind === "number" ? d.behind : 0,
+  };
+}

--- a/agent/main.ts
+++ b/agent/main.ts
@@ -47,6 +47,7 @@ import { homedir } from "node:os";
 import {
   AuthStorage,
   DefaultResourceLoader,
+  type ExtensionFactory,
   ModelRegistry,
   SessionManager,
   SettingsManager,
@@ -56,6 +57,8 @@ import {
 import { logger } from "./logger";
 import { resolveStateLimits } from "./state-limits";
 import { resolveAethonSystemPrompt } from "./system-prompt";
+import { buildWorkingContextSection } from "./system-prompt/working-context";
+import { getWorkingContext } from "./git-context";
 import { readSessionTranscript } from "./session-history";
 import { readActiveProjectCwd, resolveStartupCwd } from "./active-project-cwd";
 import {
@@ -183,11 +186,45 @@ async function main(): Promise<void> {
   (globalThis as { aethon?: typeof aethonApi }).aethon = aethonApi;
   const extensionApi = aethonApi;
 
+  // -- Per-turn working-context injection --------------------------------
+  // The appended system prompt is cached at resourceLoader.reload() (pi's
+  // ResourceLoader.getAppendSystemPrompt returns a memoized string), so it
+  // can't carry per-tab or per-turn-fresh data. The `before_agent_start`
+  // hook, by contrast, fires synchronously inside every session.prompt()
+  // — which chat.ts wraps in `state.tabContext.run(tabId, …)` — so reading
+  // `tabContext.getStore()` here yields the active tab, and its result
+  // `systemPrompt` overrides the prompt for that turn only (never
+  // persisted). This is how a local model keeps a correct picture of which
+  // directory it's working in. See agent/git-context.ts for the git source.
+  const softGuardrailPrompt = process.env.AETHON_SOFT_GUARDRAIL_PROMPT;
+  const workingContextExtension: ExtensionFactory = (pi) => {
+    pi.on("before_agent_start", async (event) => {
+      const tabId = state.tabContext.getStore() ?? state.currentAgentTabId;
+      const resolvedCwd =
+        (tabId ? state.tabProjectCwds.get(tabId) : undefined) ??
+        state.currentProjectCwd ??
+        process.cwd();
+      // getWorkingContext degrades to null internally; .catch is a
+      // belt-and-braces guard so a never-expected rejection can't abort
+      // the user's turn.
+      const git = await getWorkingContext(state, { send }, resolvedCwd).catch(
+        () => null,
+      );
+      const section = buildWorkingContextSection({
+        cwd: resolvedCwd,
+        git,
+        softAnchor: softGuardrailPrompt,
+      });
+      return { systemPrompt: `${event.systemPrompt}\n\n${section}` };
+    });
+  };
+
   // -- pi resource loader (system prompt, tools, memory) ------------------
   state.resourceLoader = new DefaultResourceLoader({
     cwd: process.cwd(),
     agentDir: getAgentDir(),
     settingsManager: state.settingsManager,
+    extensionFactories: [workingContextExtension],
     appendSystemPromptOverride: (base) => [
       ...base,
       ...resolveAethonSystemPrompt(getRuntimeSnapshot(state)),

--- a/agent/main.ts
+++ b/agent/main.ts
@@ -197,6 +197,8 @@ async function main(): Promise<void> {
   // persisted). This is how a local model keeps a correct picture of which
   // directory it's working in. See agent/git-context.ts for the git source.
   const softGuardrailPrompt = process.env.AETHON_SOFT_GUARDRAIL_PROMPT;
+  state.hardEnforceProjectRootDefault =
+    process.env.AETHON_HARD_ENFORCE_PROJECT_ROOT === "1";
   const workingContextExtension: ExtensionFactory = (pi) => {
     pi.on("before_agent_start", async (event) => {
       const tabId = state.tabContext.getStore() ?? state.currentAgentTabId;

--- a/agent/runtime-snapshot.test.ts
+++ b/agent/runtime-snapshot.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import {
   AethonAgentState,
   type AethonAgentStateOptions,
+  type TabRecord,
 } from "./state";
 import {
   getRuntimeSnapshot,
@@ -56,6 +57,25 @@ describe("getRuntimeSnapshot", () => {
     expect(snap.extensions).toEqual([{ name: "hello", source: "directory" }]);
     expect(snap.themes).toEqual([{ id: "twilight", label: "Twilight" }]);
     expect(snap.components).toEqual(["card-x"]);
+  });
+
+  it("annotates each tab with its per-tab working directory", () => {
+    const state = new AethonAgentState(makeOpts("/tmp/aethon-rs"));
+    state.tabProjectCwds.set("t1", "/work/repo");
+    state.tabs.set("t1", {
+      id: "t1",
+      session: { model: null, messages: [] },
+    } as unknown as TabRecord);
+    // A tab with no recorded cwd omits the field entirely (no `cwd: undefined`).
+    state.tabs.set("t2", {
+      id: "t2",
+      session: { model: null, messages: [] },
+    } as unknown as TabRecord);
+    const snap = getRuntimeSnapshot(state);
+    expect(snap.tabs).toEqual([
+      { id: "t1", model: "", messageCount: 0, cwd: "/work/repo" },
+      { id: "t2", model: "", messageCount: 0 },
+    ]);
   });
 
   it("includes layout structure when boot layout is loaded", () => {

--- a/agent/runtime-snapshot.ts
+++ b/agent/runtime-snapshot.ts
@@ -66,6 +66,9 @@ export function getRuntimeSnapshot(state: AethonAgentState): RuntimeSnapshot {
       id: t.id,
       model: t.session.model ? modelKey(t.session.model) : "",
       messageCount: t.session.messages?.length ?? 0,
+      ...(state.tabProjectCwds.has(t.id)
+        ? { cwd: state.tabProjectCwds.get(t.id) }
+        : {}),
     })),
     eventHandlers: state.a2uiEventHandlers.map(({ match }) => ({
       ...(match.templateRootType

--- a/agent/source-guard.test.ts
+++ b/agent/source-guard.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { Agent } from "@mariozechner/pi-agent-core";
-import { wrapWithSourceGuard } from "./source-guard";
+import {
+  wrapWithSourceGuard,
+  bashEscapesRoot,
+  isInsideRoot,
+} from "./source-guard";
 
 function makeAgent(existing?: Agent["beforeToolCall"]): Agent {
   return { beforeToolCall: existing } as unknown as Agent;
@@ -10,6 +14,15 @@ function ctx(tool: string, path?: string) {
   return {
     toolCall: { name: tool },
     args: path !== undefined ? { path } : {},
+    assistantMessage: {},
+    context: {},
+  } as Parameters<NonNullable<Agent["beforeToolCall"]>>[0];
+}
+
+function bashCtx(command: string) {
+  return {
+    toolCall: { name: "bash" },
+    args: { command },
     assistantMessage: {},
     context: {},
   } as Parameters<NonNullable<Agent["beforeToolCall"]>>[0];
@@ -124,5 +137,135 @@ describe("wrapWithSourceGuard", () => {
     wrapWithSourceGuard(agent, ROOT);
     const r = await agent.beforeToolCall(ctx("write"), undefined);
     expect(r?.block).toBeFalsy();
+  });
+});
+
+describe("wrapWithSourceGuard hard project-root enforcement", () => {
+  const TAB = "/Users/dev/Projects/myapp";
+  const hard = (on = true) => ({ tabRoot: TAB, hardEnforce: () => on });
+
+  it("is a no-op when neither source root nor a hard guard is supplied", () => {
+    const agent = makeAgent();
+    wrapWithSourceGuard(agent, undefined, { hardEnforce: () => true });
+    expect(agent.beforeToolCall).toBeUndefined();
+  });
+
+  it("does not enforce while hardEnforce() is false", async () => {
+    const agent = makeAgent();
+    wrapWithSourceGuard(agent, undefined, hard(false));
+    const r = await agent.beforeToolCall(ctx("write", "/etc/passwd"), undefined);
+    expect(r?.block).toBeFalsy();
+  });
+
+  it("reads hardEnforce() live so a runtime toggle takes effect", async () => {
+    let on = false;
+    const agent = makeAgent();
+    wrapWithSourceGuard(agent, undefined, {
+      tabRoot: TAB,
+      hardEnforce: () => on,
+    });
+    expect(
+      (await agent.beforeToolCall(ctx("write", "/etc/x"), undefined))?.block,
+    ).toBeFalsy();
+    on = true;
+    expect(
+      (await agent.beforeToolCall(ctx("write", "/etc/x"), undefined))?.block,
+    ).toBe(true);
+  });
+
+  it("blocks write/edit outside the tab root", async () => {
+    const agent = makeAgent();
+    wrapWithSourceGuard(agent, undefined, hard());
+    const r = await agent.beforeToolCall(ctx("write", "/etc/passwd"), undefined);
+    expect(r?.block).toBe(true);
+    expect(r?.reason).toContain("outside the active project root");
+  });
+
+  it("allows write/edit inside the tab root (absolute + relative)", async () => {
+    const agent = makeAgent();
+    wrapWithSourceGuard(agent, undefined, hard());
+    expect(
+      (await agent.beforeToolCall(ctx("edit", `${TAB}/src/x.ts`), undefined))
+        ?.block,
+    ).toBeFalsy();
+    expect(
+      (await agent.beforeToolCall(ctx("write", "notes/todo.md"), undefined))
+        ?.block,
+    ).toBeFalsy();
+  });
+
+  it("blocks a relative write that climbs out via ..", async () => {
+    const agent = makeAgent();
+    wrapWithSourceGuard(agent, undefined, hard());
+    const r = await agent.beforeToolCall(
+      ctx("write", "../sibling/x.ts"),
+      undefined,
+    );
+    expect(r?.block).toBe(true);
+  });
+
+  it("blocks bash redirecting / cd-ing outside the root", async () => {
+    const agent = makeAgent();
+    wrapWithSourceGuard(agent, undefined, hard());
+    expect(
+      (
+        await agent.beforeToolCall(
+          bashCtx("echo pwned > /etc/cron.d/x"),
+          undefined,
+        )
+      )?.block,
+    ).toBe(true);
+    expect(
+      (await agent.beforeToolCall(bashCtx("cd /tmp && rm -rf foo"), undefined))
+        ?.block,
+    ).toBe(true);
+  });
+
+  it("allows bash writing inside the root or not writing at all", async () => {
+    const agent = makeAgent();
+    wrapWithSourceGuard(agent, undefined, hard());
+    expect(
+      (await agent.beforeToolCall(bashCtx("echo hi > out.txt"), undefined))
+        ?.block,
+    ).toBeFalsy();
+    expect(
+      (await agent.beforeToolCall(bashCtx("npm test"), undefined))?.block,
+    ).toBeFalsy();
+    expect(
+      (await agent.beforeToolCall(bashCtx("cat ../README.md"), undefined))
+        ?.block,
+    ).toBeFalsy(); // reads aren't write targets
+  });
+
+  it("still enforces the Aethon source guard alongside hard enforcement", async () => {
+    const agent = makeAgent();
+    wrapWithSourceGuard(agent, ROOT, hard());
+    // Inside the tab root but inside Aethon's source — source guard wins.
+    const r = await agent.beforeToolCall(
+      ctx("write", `${ROOT}/src/App.tsx`),
+      undefined,
+    );
+    expect(r?.block).toBe(true);
+    expect(r?.reason).toContain("source tree");
+  });
+});
+
+describe("bashEscapesRoot / isInsideRoot", () => {
+  const ROOT2 = "/work/repo";
+
+  it("isInsideRoot handles root, descendants, and siblings", () => {
+    expect(isInsideRoot("/work/repo", ROOT2)).toBe(true);
+    expect(isInsideRoot("/work/repo/src/a.ts", ROOT2)).toBe(true);
+    expect(isInsideRoot("/work/repo-evil/x", ROOT2)).toBe(false);
+    expect(isInsideRoot("/etc/passwd", ROOT2)).toBe(false);
+  });
+
+  it("flags redirections, tee, and cd that escape; passes in-root writes", () => {
+    expect(bashEscapesRoot("echo x > /etc/y", ROOT2)).toBe("/etc/y");
+    expect(bashEscapesRoot("echo x >> ../out", ROOT2)).toBe("/work/out");
+    expect(bashEscapesRoot("foo | tee /tmp/z", ROOT2)).toBe("/tmp/z");
+    expect(bashEscapesRoot("cd /usr/local", ROOT2)).toBe("/usr/local");
+    expect(bashEscapesRoot("echo x > build/out.txt", ROOT2)).toBeUndefined();
+    expect(bashEscapesRoot("grep -r foo .", ROOT2)).toBeUndefined();
   });
 });

--- a/agent/source-guard.ts
+++ b/agent/source-guard.ts
@@ -1,44 +1,170 @@
-import { isAbsolute, join, resolve } from "node:path";
+import { isAbsolute, join, resolve, sep } from "node:path";
 import type { Agent } from "@mariozechner/pi-agent-core";
 
 const GUARDED_TOOLS = new Set(["write", "edit"]);
 
 const PROTECTED_DIRS = ["src", "src-tauri", "agent"] as const;
 
+/** Optional hard project-root guardrail layered on top of the always-on
+ *  Aethon source guard. When `hardEnforce()` returns true, write/edit/bash
+ *  tool calls touching paths outside `tabRoot` are blocked. */
+export interface HardGuardOptions {
+  /** The tab's working directory (the bash/edit/write tools resolve relative
+   *  paths against this). Paths outside it are blocked when enforcement is on. */
+  tabRoot?: string;
+  /** Live per-tab toggle, read on every tool call so a runtime flip (the
+   *  composer guardrail switch) takes effect without re-wrapping the agent. */
+  hardEnforce?: () => boolean;
+}
+
+/**
+ * Wrap `agent.beforeToolCall` with two guards:
+ *
+ *  1. **Source guard** (always on when `sourceRoot` is set — dev only): blocks
+ *     write/edit into Aethon's own `{src,src-tauri,agent}` tree. Extensions go
+ *     to `~/.aethon/extensions/` instead.
+ *  2. **Hard project-root guard** (opt-in, per tab): when `hardGuard.hardEnforce()`
+ *     is true, blocks write/edit (exact, from the structured `path` arg) and
+ *     bash (best-effort, from parsed write/cd targets) that escape `tabRoot`.
+ *
+ * No-op when neither guard applies, preserving the previous release-mode
+ * behaviour (no `beforeToolCall` wrapper at all).
+ */
 export function wrapWithSourceGuard(
   agent: Agent,
-  projectRoot: string | undefined,
+  sourceRoot: string | undefined,
+  hardGuard?: HardGuardOptions,
 ): void {
-  if (!projectRoot) return;
+  if (!sourceRoot && !hardGuard?.tabRoot) return;
 
-  const prefixes = PROTECTED_DIRS.map((d) => join(projectRoot, d) + "/");
+  const sourcePrefixes = sourceRoot
+    ? PROTECTED_DIRS.map((d) => join(sourceRoot, d) + sep)
+    : [];
 
   const original = agent.beforeToolCall;
-  // Plain (non-async) function — the body never awaits, so wrapping
-  // would only add a microtask hop. Returns a Promise either by
-  // delegating to `original` or by wrapping the guard verdict in
-  // Promise.resolve so the call site sees a consistent Promise.
+  // Plain (non-async) wrapper — the body never awaits; it returns a Promise
+  // either from the guard verdict or by delegating to `original`.
   agent.beforeToolCall = (ctx, signal) => {
-    if (GUARDED_TOOLS.has(ctx.toolCall.name)) {
-      const args = ctx.args as { path?: string } | undefined;
-      if (args?.path) {
-        const abs = isAbsolute(args.path)
-          ? resolve(args.path)
-          : resolve(process.cwd(), args.path);
-        for (const prefix of prefixes) {
-          if (abs.startsWith(prefix) || abs === prefix.slice(0, -1)) {
-            return Promise.resolve({
-              block: true,
-              reason:
-                `Blocked: "${abs}" is inside Aethon's source tree. ` +
-                "Aethon source is not user-editable from inside the agent. " +
-                "Write extensions to ~/.aethon/extensions/ instead — " +
-                "see $AETHON_DOCS_DIR/extensions.md for authoring guidance.",
-            });
-          }
-        }
-      }
-    }
+    const verdict = evaluateGuard(ctx, sourcePrefixes, hardGuard);
+    if (verdict) return Promise.resolve(verdict);
     return original?.call(agent, ctx, signal) ?? Promise.resolve(undefined);
   };
+}
+
+interface GuardCtx {
+  toolCall: { name: string };
+  args?: unknown;
+}
+
+function evaluateGuard(
+  ctx: GuardCtx,
+  sourcePrefixes: string[],
+  hardGuard: HardGuardOptions | undefined,
+): { block: true; reason: string } | undefined {
+  const name = ctx.toolCall.name;
+  const args = ctx.args as { path?: string; command?: string } | undefined;
+
+  // 1. Aethon source guard. Resolve relative paths against process.cwd()
+  //    (the agent launch dir == the source root in dev), matching the
+  //    original behaviour.
+  if (sourcePrefixes.length > 0 && GUARDED_TOOLS.has(name) && args?.path) {
+    const abs = isAbsolute(args.path)
+      ? resolve(args.path)
+      : resolve(process.cwd(), args.path);
+    for (const prefix of sourcePrefixes) {
+      if (abs.startsWith(prefix) || abs === prefix.slice(0, -1)) {
+        return {
+          block: true,
+          reason:
+            `Blocked: "${abs}" is inside Aethon's source tree. ` +
+            "Aethon source is not user-editable from inside the agent. " +
+            "Write extensions to ~/.aethon/extensions/ instead — " +
+            "see $AETHON_DOCS_DIR/extensions.md for authoring guidance.",
+        };
+      }
+    }
+  }
+
+  // 2. Hard project-root guard (opt-in). Resolve relative paths against the
+  //    tab's working dir, which is where the tools actually run.
+  const tabRoot = hardGuard?.tabRoot;
+  if (tabRoot && hardGuard?.hardEnforce?.()) {
+    if (GUARDED_TOOLS.has(name) && args?.path) {
+      const abs = isAbsolute(args.path)
+        ? resolve(args.path)
+        : resolve(tabRoot, args.path);
+      if (!isInsideRoot(abs, tabRoot)) {
+        return { block: true, reason: outsideRootReason(name, abs, tabRoot) };
+      }
+    }
+    if (name === "bash" && typeof args?.command === "string") {
+      const escapee = bashEscapesRoot(args.command, tabRoot);
+      if (escapee) {
+        return {
+          block: true,
+          reason: outsideRootReason("bash", escapee, tabRoot),
+        };
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function outsideRootReason(tool: string, abs: string, root: string): string {
+  return (
+    `Guardrail: "${abs}" is outside the active project root "${root}". ` +
+    `Hard enforcement is on for this session, so ${tool} operations outside ` +
+    "the project are blocked. Work within the project root, or ask the user " +
+    "to turn the guardrail off (composer ⋯ menu) if this is intentional."
+  );
+}
+
+/** True when `abs` is `root` itself or a descendant of it. */
+export function isInsideRoot(abs: string, root: string): boolean {
+  const r = root.endsWith(sep) ? root.slice(0, -1) : root;
+  return abs === r || abs.startsWith(r + sep);
+}
+
+/**
+ * Best-effort detection of a bash command writing to / cd-ing to a path
+ * outside `root`. Returns the first escaping absolute path, or undefined.
+ *
+ * Catches the common escape patterns — output redirections (`>`, `>>`),
+ * `tee`, and `cd` / `pushd` — resolving relative targets against `root`
+ * (where the bash tool runs). It deliberately does NOT try to fully parse
+ * the shell: `eval`, command substitution, variable expansion, and
+ * `cp`/`mv` destinations can slip through. This is a speed-bump against a
+ * wandering model, not a sandbox; the write/edit guard above is exact.
+ */
+export function bashEscapesRoot(
+  command: string,
+  root: string,
+): string | undefined {
+  for (const candidate of extractBashTargets(command)) {
+    const abs = isAbsolute(candidate)
+      ? resolve(candidate)
+      : resolve(root, candidate);
+    if (!isInsideRoot(abs, root)) return abs;
+  }
+  return undefined;
+}
+
+function extractBashTargets(command: string): string[] {
+  const targets: string[] = [];
+  const push = (re: RegExp, group: number) => {
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(command)) !== null) {
+      const v = m[group];
+      if (v) targets.push(v);
+    }
+  };
+  // Output redirection: `> path`, `>> path` (skip fd-dup `>&` and stderr
+  // `2>` — the char before `>` must not be a digit or `>`).
+  push(/(?:^|[^0-9>])>>?\s*(['"]?)([^\s'"|&;<>]+)\1/g, 2);
+  // `tee [-a] path` (write side of a pipe).
+  push(/\btee\s+(?:-a\s+)?(['"]?)([^\s'"|&;<>]+)\1/g, 2);
+  // `cd` / `pushd` — a working-dir escape, even without a write.
+  push(/\b(?:cd|pushd)\s+(['"]?)([^\s'"|&;<>]+)\1/g, 2);
+  return targets;
 }

--- a/agent/state.ts
+++ b/agent/state.ts
@@ -363,6 +363,16 @@ export class AethonAgentState {
   readonly tabs = new Map<string, TabRecord>();
   readonly tabProjectCwds = new Map<string, string>();
   readonly tabAuthProfileIds = new Map<string, string>();
+  /** Per-tab hard project-root guardrail override. When unset for a tab, the
+   *  source guard falls back to {@link hardEnforceProjectRootDefault}. Set from
+   *  the `hardEnforce` field that rides each `chat` message (the frontend's
+   *  per-tab toggle), so it's always current before a turn's tool calls and
+   *  survives an agent respawn. Read live by the wrapWithSourceGuard closure. */
+  readonly tabHardEnforce = new Map<string, boolean>();
+  /** Global default for the hard project-root guardrail, from
+   *  `[guardrails] hard_enforce_project_root` via the
+   *  AETHON_HARD_ENFORCE_PROJECT_ROOT env at spawn. */
+  hardEnforceProjectRootDefault = false;
   /** Tab whose pi turn is currently running. Set when a chat / handler
    *  prompt is dispatched; cleared on agent_end. Used by setState so
    *  direct globalThis.aethon.setState calls from the agent or extensions

--- a/agent/system-prompt.test.ts
+++ b/agent/system-prompt.test.ts
@@ -85,4 +85,26 @@ describe("buildRuntimeSection failedExtensions", () => {
     delete stale.failedExtensions;
     expect(() => buildRuntimeSection(stale as RuntimeSnapshot)).not.toThrow();
   });
+
+  it("labels the host dir and defers to the per-turn Working context section", () => {
+    const out = buildRuntimeSection(snapshot({ cwd: "/launch/dir" }));
+    expect(out).toContain("Agent host dir: `/launch/dir`");
+    expect(out).toContain("Working context");
+    // The old bare `cwd=...` phrasing is gone — it misled the model into
+    // treating the launch dir as the working dir.
+    expect(out).not.toContain("cwd=`/launch/dir`");
+  });
+
+  it("annotates open tabs with their cwd when present", () => {
+    const out = buildRuntimeSection(
+      snapshot({
+        tabs: [
+          { id: "default", model: "anthropic/x", messageCount: 2, cwd: "/repo/a" },
+          { id: "t2", model: "", messageCount: 0 },
+        ],
+      }),
+    );
+    expect(out).toContain("cwd `/repo/a`");
+    expect(out).toContain("`t2` — model `(none)`, 0 messages");
+  });
 });

--- a/agent/system-prompt.ts
+++ b/agent/system-prompt.ts
@@ -33,7 +33,10 @@ export type { RuntimeSnapshot };
 export function buildRuntimeSection(snapshot: RuntimeSnapshot): string {
   const lines: string[] = ["# Current runtime snapshot"];
   lines.push(
-    `Build: ${snapshot.release ? "release" : "dev"}; cwd=\`${snapshot.cwd}\`.`,
+    `Build: ${snapshot.release ? "release" : "dev"}. Agent host dir: \`${snapshot.cwd}\` — ` +
+      "this is where the bridge process launched, NOT necessarily where any tab " +
+      'operates. Each turn\'s authoritative working directory + git state arrives in the ' +
+      '"Working context" section appended below; trust that over this line.',
   );
   if (snapshot.projectRoot) {
     lines.push(
@@ -218,8 +221,9 @@ export function buildRuntimeSection(snapshot: RuntimeSnapshot): string {
     lines.push("");
     lines.push("Open tabs:");
     for (const t of snapshot.tabs) {
+      const cwdNote = t.cwd ? `, cwd \`${t.cwd}\`` : "";
       lines.push(
-        `- \`${t.id}\` — model \`${t.model || "(none)"}\`, ${t.messageCount} messages`,
+        `- \`${t.id}\` — model \`${t.model || "(none)"}\`, ${t.messageCount} messages${cwdNote}`,
       );
     }
   }

--- a/agent/system-prompt/types.ts
+++ b/agent/system-prompt/types.ts
@@ -40,7 +40,12 @@ export interface RuntimeSnapshot {
   themes: { id: string; label: string }[];
   components: string[];
   layoutSummary: string;
-  tabs: { id: string; model: string; messageCount: number }[];
+  // `cwd` is the per-tab working directory (from `state.tabProjectCwds`).
+  // Distinct from the top-level `cwd` (the agent process launch dir), which
+  // is shared across tabs and does NOT reflect where any given tab works.
+  // The authoritative per-turn working dir is injected separately by the
+  // `before_agent_start` hook; this list is the at-a-glance map.
+  tabs: { id: string; model: string; messageCount: number; cwd?: string }[];
   // Active aethon.onEvent registrations (match shape only — handler bodies
   // are intentionally omitted so the snapshot stays small + serializable).
   // Lets the agent answer "what handlers are wired?" without invoking JS.

--- a/agent/system-prompt/working-context.test.ts
+++ b/agent/system-prompt/working-context.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { buildWorkingContextSection } from "./working-context";
+
+describe("buildWorkingContextSection", () => {
+  it("renders cwd, branch, worktree, dirty count and ahead/behind", () => {
+    const out = buildWorkingContextSection({
+      cwd: "/work/repo",
+      git: {
+        repoRoot: "/work/main",
+        branch: "feat/x",
+        isWorktree: true,
+        changedFiles: 5,
+        ahead: 5,
+        behind: 0,
+      },
+    });
+    expect(out).toContain("Working directory: `/work/repo`");
+    expect(out).toContain("Repository root: `/work/main`");
+    expect(out).toContain("branch `feat/x` (worktree)");
+    expect(out).toContain("5 changed files");
+    expect(out).toContain("ahead 5 / behind 0");
+    expect(out).toContain("Operate within this directory");
+  });
+
+  it("omits repo root when equal to cwd and reports a clean tree", () => {
+    const out = buildWorkingContextSection({
+      cwd: "/work/repo",
+      git: {
+        repoRoot: "/work/repo",
+        branch: "main",
+        isWorktree: false,
+        changedFiles: 0,
+        ahead: 0,
+        behind: 0,
+      },
+    });
+    expect(out).not.toContain("Repository root:");
+    expect(out).toContain("working tree clean");
+    expect(out).not.toContain("ahead");
+    expect(out).not.toContain("(worktree)");
+  });
+
+  it("singularizes a single changed file", () => {
+    const out = buildWorkingContextSection({
+      cwd: "/x",
+      git: {
+        repoRoot: null,
+        branch: "m",
+        isWorktree: false,
+        changedFiles: 1,
+        ahead: 0,
+        behind: 0,
+      },
+    });
+    expect(out).toContain("1 changed file");
+    expect(out).not.toContain("1 changed files");
+  });
+
+  it("says not a git repository when git is null", () => {
+    const out = buildWorkingContextSection({ cwd: "/tmp/x", git: null });
+    expect(out).toContain("Git: not a git repository.");
+  });
+
+  it("appends a trimmed soft anchor when provided", () => {
+    const out = buildWorkingContextSection({
+      cwd: "/x",
+      git: null,
+      softAnchor: "  Only touch files under src/.  ",
+    });
+    expect(out.endsWith("Only touch files under src/.")).toBe(true);
+  });
+
+  it("ignores a blank soft anchor", () => {
+    const out = buildWorkingContextSection({
+      cwd: "/x",
+      git: null,
+      softAnchor: "   ",
+    });
+    expect(out.endsWith("unless the user explicitly asks.")).toBe(true);
+  });
+});

--- a/agent/system-prompt/working-context.ts
+++ b/agent/system-prompt/working-context.ts
@@ -1,0 +1,65 @@
+/**
+ * Per-turn "Working context" section.
+ *
+ * Appended to the system prompt by the `before_agent_start` hook (see
+ * `agent/main.ts`) on every turn, so the model always knows the *active
+ * tab's* working directory and live git state — the shared runtime snapshot
+ * can't, because it's resolved once at `resourceLoader.reload()` (outside any
+ * tab context) and reports the agent process's launch dir for every tab.
+ *
+ * Kept compact and imperative: a confused local model benefits from a short,
+ * unambiguous "you are here, stay here" anchor far more than prose.
+ */
+
+import type { GitWorkingContext } from "../git-context";
+
+export interface WorkingContextInput {
+  /** The active tab's resolved working directory. */
+  cwd: string;
+  /** Git facts for `cwd`, or null when it isn't a git work tree / lookup
+   *  failed. */
+  git: GitWorkingContext | null;
+  /** Optional user-configured advisory text (`[guardrails] soft_prompt_anchor`). */
+  softAnchor?: string;
+}
+
+export function buildWorkingContextSection(input: WorkingContextInput): string {
+  const { cwd, git, softAnchor } = input;
+  const lines: string[] = ["# Working context (this turn)"];
+  lines.push(`Working directory: \`${cwd}\``);
+
+  if (git) {
+    if (git.repoRoot && git.repoRoot !== cwd) {
+      lines.push(`Repository root: \`${git.repoRoot}\``);
+    }
+    const parts: string[] = [];
+    if (git.branch) {
+      parts.push(`branch \`${git.branch}\`${git.isWorktree ? " (worktree)" : ""}`);
+    }
+    parts.push(
+      git.changedFiles === 0
+        ? "working tree clean"
+        : `${git.changedFiles} changed file${git.changedFiles === 1 ? "" : "s"}`,
+    );
+    if (git.ahead > 0 || git.behind > 0) {
+      parts.push(`ahead ${git.ahead} / behind ${git.behind}`);
+    }
+    lines.push(`Git: ${parts.join(", ")}.`);
+  } else {
+    lines.push("Git: not a git repository.");
+  }
+
+  lines.push(
+    "Operate within this directory. Your tools (bash, read, edit, write) run " +
+      "here by default — use paths relative to it, and do not `cd` to or modify " +
+      "files outside it unless the user explicitly asks.",
+  );
+
+  const anchor = softAnchor?.trim();
+  if (anchor) {
+    lines.push("");
+    lines.push(anchor);
+  }
+
+  return lines.join("\n");
+}

--- a/agent/tab-lifecycle/lifecycle.ts
+++ b/agent/tab-lifecycle/lifecycle.ts
@@ -126,7 +126,11 @@ export async function ensureTab(
     ...(options.initialModel ? { model: options.initialModel } : {}),
   });
   installAethonRetryClassifier(session);
-  wrapWithSourceGuard(session.agent, state.projectRoot);
+  wrapWithSourceGuard(session.agent, state.projectRoot, {
+    tabRoot: resolvedCwd,
+    hardEnforce: () =>
+      state.tabHardEnforce.get(tabId) ?? state.hardEnforceProjectRootDefault,
+  });
 
   const rec: TabRecord = {
     id: tabId,

--- a/src-tauri/src/agent_commands.rs
+++ b/src-tauri/src/agent_commands.rs
@@ -38,6 +38,11 @@ pub(crate) struct SendMessageRequest {
     cwd: Option<String>,
     model: Option<String>,
     attachments: Option<Vec<ChatAttachmentInput>>,
+    /// Per-tab hard project-root guardrail override. Forwarded to the agent's
+    /// `chat` message so the source guard sees the current value before the
+    /// turn's tool calls. `None` leaves the per-tab value untouched (the
+    /// agent falls back to the global default).
+    hard_enforce: Option<bool>,
 }
 
 #[tauri::command]
@@ -67,6 +72,9 @@ pub(crate) fn send_message(
         && !model.is_empty()
     {
         payload["model"] = serde_json::Value::String(model);
+    }
+    if let Some(hard_enforce) = request.hard_enforce {
+        payload["hardEnforce"] = serde_json::Value::Bool(hard_enforce);
     }
     let images = attachments_to_agent_images(&app, request.attachments.unwrap_or_default())?;
     if !images.is_empty() {

--- a/src-tauri/src/agent_process/spawn.rs
+++ b/src-tauri/src/agent_process/spawn.rs
@@ -206,6 +206,23 @@ fn apply_user_env(app: &AppHandle, command: &mut Command) {
         .unwrap_or(512);
     command.env("AETHON_STATE_WARN_KB", warn_kb.to_string());
     command.env("AETHON_STATE_HARD_KB", hard_kb.to_string());
+
+    // Guardrails: the soft anchor is appended to the per-turn working-context
+    // the agent injects; the hard-enforce default is consumed by the agent's
+    // source-guard wrapper (per-tab overridable at runtime). Only emit the
+    // anchor when present so the agent can distinguish "unset" from "empty".
+    if let Some(anchor) = cfg_json["guardrails"]["softPromptAnchor"].as_str()
+        && !anchor.trim().is_empty()
+    {
+        command.env("AETHON_SOFT_GUARDRAIL_PROMPT", anchor);
+    }
+    let hard_enforce = cfg_json["guardrails"]["hardEnforceProjectRoot"]
+        .as_bool()
+        .unwrap_or(false);
+    command.env(
+        "AETHON_HARD_ENFORCE_PROJECT_ROOT",
+        if hard_enforce { "1" } else { "0" },
+    );
 }
 
 fn apply_worker_env(command: &mut Command, worker: Option<&AgentWorker>) {

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -150,6 +150,7 @@ pub fn write_config(config: serde_json::Value, app: AppHandle) -> Result<(), Str
     let voice = config.get("voice").and_then(|v| v.as_object());
     let updates = config.get("updates").and_then(|v| v.as_object());
     let devshell = config.get("devshell").and_then(|v| v.as_object());
+    let guardrails = config.get("guardrails").and_then(|v| v.as_object());
 
     let theme = ui
         .and_then(|m| m.get("theme"))
@@ -234,6 +235,14 @@ pub fn write_config(config: serde_json::Value, app: AppHandle) -> Result<(), Str
         .map(|n| n.min(u32::MAX as u64));
     let devshell_refresh_on_lockfile = devshell
         .and_then(|m| m.get("refreshOnLockfileChange"))
+        .and_then(|v| v.as_bool());
+    let soft_prompt_anchor = guardrails
+        .and_then(|m| m.get("softPromptAnchor"))
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    let hard_enforce_project_root = guardrails
+        .and_then(|m| m.get("hardEnforceProjectRoot"))
         .and_then(|v| v.as_bool());
 
     // Load the existing file (or seed a fresh document with our header
@@ -373,6 +382,17 @@ pub fn write_config(config: serde_json::Value, app: AppHandle) -> Result<(), Str
             devshell_table,
             "refresh_on_lockfile_change",
             devshell_refresh_on_lockfile,
+        );
+    }
+
+    // ── [guardrails] ──
+    {
+        let guardrails_table = ensure_table(&mut doc, "guardrails");
+        set_or_clear_str(guardrails_table, "soft_prompt_anchor", soft_prompt_anchor);
+        set_or_clear_bool(
+            guardrails_table,
+            "hard_enforce_project_root",
+            hard_enforce_project_root,
         );
     }
 

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -170,6 +170,14 @@ pub fn write_config(config: serde_json::Value, app: AppHandle) -> Result<(), Str
         .and_then(|m| m.get("notifyMinDurationSeconds"))
         .and_then(|v| v.as_u64())
         .map(|n| n.min(3600));
+    let thinking_visibility = ui
+        .and_then(|m| m.get("thinkingVisibility"))
+        .and_then(|v| v.as_str())
+        .map(|s| helpers::normalize_visibility(Some(s)));
+    let tool_calls_visibility = ui
+        .and_then(|m| m.get("toolCallsVisibility"))
+        .and_then(|v| v.as_str())
+        .map(|s| helpers::normalize_visibility(Some(s)));
 
     let model = agent
         .and_then(|m| m.get("model"))
@@ -281,6 +289,22 @@ pub fn write_config(config: serde_json::Value, app: AppHandle) -> Result<(), Str
             }
             None => {
                 ui_table.remove("notify_min_duration_seconds");
+            }
+        }
+        match thinking_visibility {
+            Some(v) => {
+                ui_table.insert("thinking_visibility", toml_edit::value(v));
+            }
+            None => {
+                ui_table.remove("thinking_visibility");
+            }
+        }
+        match tool_calls_visibility {
+            Some(v) => {
+                ui_table.insert("tool_calls_visibility", toml_edit::value(v));
+            }
+            None => {
+                ui_table.remove("tool_calls_visibility");
             }
         }
     }

--- a/src-tauri/src/commands/git/status.rs
+++ b/src-tauri/src/commands/git/status.rs
@@ -226,6 +226,152 @@ pub async fn git_status(path: String) -> Result<Option<GitStatus>, String> {
     }))
 }
 
+/// Richer working-directory context for a single cwd, used by the agent
+/// bridge to inject "where am I working" into the model's per-turn system
+/// prompt (a local Ollama model otherwise loses track of the active tab's
+/// directory). Reuses the same `git` shell-outs as [`git_status`] plus a
+/// worktree check and a changed-file count. Returns `None` when `cwd` isn't
+/// inside a git work tree so the caller still reports the bare directory.
+#[derive(serde::Serialize, Default, Debug, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct GitWorkingContext {
+    pub repo_root: Option<String>,
+    pub branch: Option<String>,
+    pub is_worktree: bool,
+    pub changed_files: u32,
+    pub ahead: u32,
+    pub behind: u32,
+}
+
+#[tauri::command]
+pub async fn git_working_context(cwd: String) -> Result<Option<GitWorkingContext>, String> {
+    let dir = PathBuf::from(&cwd);
+    if !dir.is_dir() {
+        return Ok(None);
+    }
+    if !is_inside_work_tree(&dir) {
+        return Ok(None);
+    }
+    let repo_root = env::command("git")
+        .arg("-C")
+        .arg(&dir)
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .filter(|s| !s.is_empty());
+
+    // A linked worktree has a per-checkout git-dir (`.git/worktrees/<name>`)
+    // distinct from the shared common dir (the main repo's `.git`); they're
+    // equal in the primary worktree. Surfacing this lets the model know it's
+    // on a worktree branch, not the canonical checkout.
+    let is_worktree = match (
+        git_rev_parse_abs_path(&dir, "--git-dir"),
+        git_rev_parse_abs_path(&dir, "--git-common-dir"),
+    ) {
+        (Some(git_dir), Some(common_dir)) => git_dir != common_dir,
+        _ => false,
+    };
+
+    let branch = read_head_branch(&dir);
+    let (changed_files, ahead, behind) = read_branch_porcelain_counts(&dir);
+
+    Ok(Some(GitWorkingContext {
+        repo_root,
+        branch,
+        is_worktree,
+        changed_files,
+        ahead,
+        behind,
+    }))
+}
+
+/// Resolve an absolute git path for `flag` (e.g. `--git-dir`,
+/// `--git-common-dir`), canonicalized so the worktree comparison is stable.
+fn git_rev_parse_abs_path(dir: &Path, flag: &str) -> Option<PathBuf> {
+    let out = env::command("git")
+        .arg("-C")
+        .arg(dir)
+        .args(["rev-parse", "--path-format=absolute", flag])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())?;
+    let raw = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if raw.is_empty() {
+        return None;
+    }
+    let path = PathBuf::from(raw);
+    Some(path.canonicalize().unwrap_or(path))
+}
+
+/// Symbolic branch name, falling back to a short SHA on detached HEAD so the
+/// prompt still says something useful. Mirrors [`git_status`]'s branch read.
+fn read_head_branch(dir: &Path) -> Option<String> {
+    let symbolic = env::command("git")
+        .arg("-C")
+        .arg(dir)
+        .args(["symbolic-ref", "--short", "HEAD"])
+        .output()
+        .ok();
+    match symbolic {
+        Some(o) if o.status.success() => Some(String::from_utf8_lossy(&o.stdout).trim().to_string()),
+        _ => env::command("git")
+            .arg("-C")
+            .arg(dir)
+            .args(["rev-parse", "--short", "HEAD"])
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string()),
+    }
+}
+
+/// Parse `git status --porcelain=v1 --branch` into `(changed, ahead, behind)`.
+/// The `## ` header carries the optional `[ahead N, behind M]` tail; every
+/// other non-empty line is a tracked/untracked change.
+fn read_branch_porcelain_counts(dir: &Path) -> (u32, u32, u32) {
+    let porcelain = env::command("git")
+        .arg("-C")
+        .arg(dir)
+        .args(["status", "--porcelain=v1", "--branch"])
+        .output();
+    let Ok(out) = porcelain else {
+        return (0, 0, 0);
+    };
+    if !out.status.success() {
+        return (0, 0, 0);
+    }
+    parse_branch_porcelain_counts(&String::from_utf8_lossy(&out.stdout))
+}
+
+/// Pure parse half of [`read_branch_porcelain_counts`], split out for tests.
+pub(crate) fn parse_branch_porcelain_counts(text: &str) -> (u32, u32, u32) {
+    let mut changed = 0u32;
+    let mut ahead = 0u32;
+    let mut behind = 0u32;
+    for line in text.lines() {
+        if let Some(rest) = line.strip_prefix("## ") {
+            if let Some(start) = rest.find('[')
+                && let Some(end) = rest[start..].find(']')
+            {
+                let inner = &rest[start + 1..start + end];
+                for part in inner.split(',') {
+                    let part = part.trim();
+                    if let Some(n) = part.strip_prefix("ahead ") {
+                        ahead = n.trim().parse().unwrap_or(0);
+                    } else if let Some(n) = part.strip_prefix("behind ") {
+                        behind = n.trim().parse().unwrap_or(0);
+                    }
+                }
+            }
+        } else if !line.is_empty() {
+            changed += 1;
+        }
+    }
+    (changed, ahead, behind)
+}
+
 /// Return per-file Git decorations for the active file tree root. `None`
 /// means the directory is not inside a Git worktree; callers should render
 /// the plain filesystem tree in that case.
@@ -528,6 +674,80 @@ mod tests {
         let out = parse_nul_paths(text);
         assert_eq!(out, vec!["node_modules/", ".env", "build/cache file.txt"]);
         assert!(parse_nul_paths(b"").is_empty());
+    }
+
+    #[test]
+    fn parse_branch_porcelain_counts_reads_ahead_behind_and_changes() {
+        let text = "## main...origin/main [ahead 2, behind 1]\n M src/a.ts\n?? src/b.ts\n";
+        assert_eq!(parse_branch_porcelain_counts(text), (2, 2, 1));
+    }
+
+    #[test]
+    fn parse_branch_porcelain_counts_clean_repo_is_zeroes() {
+        assert_eq!(parse_branch_porcelain_counts("## main...origin/main\n"), (0, 0, 0));
+        // No upstream configured — header has no bracket tail.
+        assert_eq!(parse_branch_porcelain_counts("## main\n"), (0, 0, 0));
+    }
+
+    #[test]
+    fn parse_branch_porcelain_counts_handles_ahead_only() {
+        let text = "## feat...origin/feat [ahead 5]\n";
+        assert_eq!(parse_branch_porcelain_counts(text), (0, 5, 0));
+    }
+
+    #[tokio::test]
+    async fn git_working_context_returns_none_for_missing_dir() {
+        let missing = tempfile::tempdir().unwrap().path().join("missing");
+        assert_eq!(
+            git_working_context(missing.to_string_lossy().to_string())
+                .await
+                .unwrap(),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn git_working_context_returns_none_for_non_repo() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert_eq!(
+            git_working_context(tmp.path().to_string_lossy().to_string())
+                .await
+                .unwrap(),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn git_working_context_reports_branch_and_changes_for_repo() {
+        if env::resolve_program("git").is_none() {
+            return;
+        }
+        let tmp = tempfile::tempdir().unwrap();
+        let run = |args: &[&str]| {
+            env::command("git")
+                .arg("-C")
+                .arg(tmp.path())
+                .args(args)
+                .output()
+                .unwrap()
+        };
+        assert!(run(&["init", "--initial-branch=trunk"]).status.success());
+        run(&["config", "user.email", "t@t.io"]);
+        run(&["config", "user.name", "Test"]);
+        std::fs::write(tmp.path().join("a.txt"), "hi").unwrap();
+        run(&["add", "."]);
+        run(&["commit", "-m", "init"]);
+        // Dirty the tree with an untracked file.
+        std::fs::write(tmp.path().join("b.txt"), "new").unwrap();
+
+        let ctx = git_working_context(tmp.path().to_string_lossy().to_string())
+            .await
+            .unwrap()
+            .expect("inside a work tree");
+        assert_eq!(ctx.branch.as_deref(), Some("trunk"));
+        assert!(!ctx.is_worktree);
+        assert_eq!(ctx.changed_files, 1);
+        assert!(ctx.repo_root.is_some());
     }
 
     #[test]

--- a/src-tauri/src/helpers/config.rs
+++ b/src-tauri/src/helpers/config.rs
@@ -26,6 +26,15 @@ pub struct UiConfig {
     /// Minimum turn duration (seconds) for the completion notification to
     /// fire. Sub-second turns rarely need a notification. Default 8.
     pub notify_min_duration_seconds: Option<u32>,
+    /// Global default visibility for the model's thinking blocks in the chat
+    /// transcript. Allowed: `"show"` (default), `"collapse"`, `"hide"`.
+    /// Unknown values fall back to `"show"`. Per-tab overridable at runtime
+    /// via the composer pills; this is the default new tabs inherit.
+    pub thinking_visibility: Option<String>,
+    /// Global default visibility for tool-call cards in the transcript.
+    /// Allowed: `"show"` (default), `"collapse"` (group consecutive cards),
+    /// `"hide"`. Unknown values fall back to `"show"`.
+    pub tool_calls_visibility: Option<String>,
 }
 
 #[derive(Default, Deserialize)]
@@ -187,6 +196,19 @@ pub struct AethonConfig {
     pub guardrails: GuardrailsConfig,
 }
 
+/// Validate-and-normalize a tri-state transcript visibility value
+/// (`[ui] thinking_visibility` / `tool_calls_visibility`). Unknown strings,
+/// missing values, and parse failures all fall through to `"show"` so a typo
+/// can't silently hide the transcript.
+pub fn normalize_visibility(input: Option<&str>) -> &'static str {
+    match input {
+        Some("collapse") => "collapse",
+        Some("hide") => "hide",
+        // Includes Some("show"), Some(<unknown>), and None.
+        _ => "show",
+    }
+}
+
 /// Validate-and-normalize `[devshell] enabled`. Unknown values fall
 /// through to `"auto"` so a typo can't silently disable the feature.
 pub fn normalize_devshell_enabled(input: Option<&str>) -> &'static str {
@@ -296,6 +318,8 @@ pub fn parse_config_toml(input: &str) -> serde_json::Value {
         .map(|n| n.min(3600))
         .unwrap_or(8);
     let new_tab_kind = normalize_new_tab_kind(cfg.shortcuts.new_tab_kind.as_deref());
+    let thinking_visibility = normalize_visibility(cfg.ui.thinking_visibility.as_deref());
+    let tool_calls_visibility = normalize_visibility(cfg.ui.tool_calls_visibility.as_deref());
     let default_command = cfg
         .shell
         .default_command
@@ -325,6 +349,8 @@ pub fn parse_config_toml(input: &str) -> serde_json::Value {
             "restoreTabs": cfg.ui.restore_tabs,
             "notifyOnCompletion": notify_on_completion,
             "notifyMinDurationSeconds": notify_min_duration_seconds,
+            "thinkingVisibility": thinking_visibility,
+            "toolCallsVisibility": tool_calls_visibility,
         },
         "agent": {
             "model": cfg.agent.model,
@@ -795,6 +821,41 @@ enabled = "never"
         // Malformed TOML must never block a shell open — we just ignore it.
         let v = parse_project_devshell_override("=== broken ===");
         assert!(v.devshell.enabled.is_none());
+    }
+
+    // ── visibility (tri-state) ─────────────────────────────────────────────
+    #[test]
+    fn normalize_visibility_accepts_known_values() {
+        assert_eq!(normalize_visibility(Some("show")), "show");
+        assert_eq!(normalize_visibility(Some("collapse")), "collapse");
+        assert_eq!(normalize_visibility(Some("hide")), "hide");
+    }
+
+    #[test]
+    fn normalize_visibility_falls_back_to_show() {
+        assert_eq!(normalize_visibility(None), "show");
+        assert_eq!(normalize_visibility(Some("")), "show");
+        assert_eq!(normalize_visibility(Some("Hide")), "show");
+        assert_eq!(normalize_visibility(Some("gone")), "show");
+    }
+
+    #[test]
+    fn parse_config_toml_visibility_defaults_to_show() {
+        let v = parse_config_toml("");
+        assert_eq!(v["ui"]["thinkingVisibility"], "show");
+        assert_eq!(v["ui"]["toolCallsVisibility"], "show");
+    }
+
+    #[test]
+    fn parse_config_toml_extracts_visibility() {
+        let v = parse_config_toml(
+            "[ui]\nthinking_visibility = \"collapse\"\ntool_calls_visibility = \"hide\"\n",
+        );
+        assert_eq!(v["ui"]["thinkingVisibility"], "collapse");
+        assert_eq!(v["ui"]["toolCallsVisibility"], "hide");
+        // Unknown clamps to show.
+        let v = parse_config_toml("[ui]\nthinking_visibility = \"yolo\"\n");
+        assert_eq!(v["ui"]["thinkingVisibility"], "show");
     }
 
     // ── guardrails ─────────────────────────────────────────────────────────

--- a/src-tauri/src/helpers/config.rs
+++ b/src-tauri/src/helpers/config.rs
@@ -149,6 +149,21 @@ pub struct ExtensionsConfig {
 }
 
 #[derive(Default, Deserialize)]
+pub struct GuardrailsConfig {
+    /// Optional free-text "soft anchor" appended to the per-turn working
+    /// context the agent injects into the model's system prompt. Use it to
+    /// remind the model of project rules ("only touch files under src/",
+    /// "never run destructive git commands", etc.). Empty/omitted → no
+    /// anchor. This never *enforces* anything — it's advisory prompt text.
+    pub soft_prompt_anchor: Option<String>,
+    /// Hard enforcement: when `true`, the agent blocks write/edit/bash tool
+    /// calls that touch paths outside the active tab's project root. Default
+    /// `false` (permissive). Deterministic backstop for a wandering model;
+    /// the per-tab composer toggle can override this default per session.
+    pub hard_enforce_project_root: Option<bool>,
+}
+
+#[derive(Default, Deserialize)]
 pub struct AethonConfig {
     #[serde(default)]
     pub ui: UiConfig,
@@ -168,6 +183,8 @@ pub struct AethonConfig {
     pub devshell: DevshellConfig,
     #[serde(default)]
     pub server: ServerConfig,
+    #[serde(default)]
+    pub guardrails: GuardrailsConfig,
 }
 
 /// Validate-and-normalize `[devshell] enabled`. Unknown values fall
@@ -294,6 +311,13 @@ pub fn parse_config_toml(input: &str) -> serde_json::Value {
     let devshell_cache_ttl_hours = cfg.devshell.cache_ttl_hours.unwrap_or(720);
     let devshell_refresh_on_lockfile_change =
         cfg.devshell.refresh_on_lockfile_change.unwrap_or(true);
+    let soft_prompt_anchor = cfg
+        .guardrails
+        .soft_prompt_anchor
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    let hard_enforce_project_root = cfg.guardrails.hard_enforce_project_root.unwrap_or(false);
     serde_json::json!({
         "ui": {
             "theme": cfg.ui.theme,
@@ -337,6 +361,10 @@ pub fn parse_config_toml(input: &str) -> serde_json::Value {
         },
         "server": {
             "enabled": cfg.server.enabled.unwrap_or(true),
+        },
+        "guardrails": {
+            "softPromptAnchor": soft_prompt_anchor,
+            "hardEnforceProjectRoot": hard_enforce_project_root,
         },
     })
 }
@@ -767,6 +795,36 @@ enabled = "never"
         // Malformed TOML must never block a shell open — we just ignore it.
         let v = parse_project_devshell_override("=== broken ===");
         assert!(v.devshell.enabled.is_none());
+    }
+
+    // ── guardrails ─────────────────────────────────────────────────────────
+    #[test]
+    fn parse_config_toml_guardrails_defaults() {
+        let v = parse_config_toml("");
+        assert_eq!(v["guardrails"]["softPromptAnchor"], serde_json::Value::Null);
+        assert_eq!(v["guardrails"]["hardEnforceProjectRoot"], false);
+    }
+
+    #[test]
+    fn parse_config_toml_extracts_guardrails_section() {
+        let v = parse_config_toml(
+            r#"[guardrails]
+soft_prompt_anchor = "Only edit files under src/."
+hard_enforce_project_root = true
+"#,
+        );
+        assert_eq!(
+            v["guardrails"]["softPromptAnchor"],
+            "Only edit files under src/."
+        );
+        assert_eq!(v["guardrails"]["hardEnforceProjectRoot"], true);
+    }
+
+    #[test]
+    fn parse_config_toml_guardrails_blank_anchor_is_null() {
+        // Whitespace-only anchor is treated as "no anchor".
+        let v = parse_config_toml("[guardrails]\nsoft_prompt_anchor = \"   \"\n");
+        assert_eq!(v["guardrails"]["softPromptAnchor"], serde_json::Value::Null);
     }
 
     // ── clamp_font_size ────────────────────────────────────────────────────

--- a/src-tauri/src/helpers/mod.rs
+++ b/src-tauri/src/helpers/mod.rs
@@ -24,7 +24,7 @@ pub mod paths;
 pub use config::{
     FONT_SIZE_MAX, FONT_SIZE_MIN, clamp_font_size, normalize_default_share_mode,
     normalize_devshell_enabled, normalize_devshell_mode, normalize_new_tab_kind,
-    normalize_update_channel, parse_config_toml,
+    normalize_update_channel, normalize_visibility, parse_config_toml,
 };
 pub use names::{sanitize_filename_segment, validate_state_name};
 pub use paths::{aethon_dir, resolve_inside_root};

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -194,6 +194,7 @@ pub fn run() {
             commands::fs::fs_open_in_file_manager,
             commands::fs::fs_open_in_default_app,
             commands::git::status::git_status,
+            commands::git::status::git_working_context,
             commands::git::status::git_fetch_all,
             commands::git::status::git_file_status,
             commands::git::status::git_ignored_paths,

--- a/src/config.ts
+++ b/src/config.ts
@@ -78,6 +78,15 @@ export interface AethonConfig {
     /** Re-resolve when watched lockfile / marker file mtime changes. */
     refreshOnLockfileChange: boolean;
   };
+  guardrails: {
+    /** Optional advisory text appended to the per-turn working-context the
+     *  agent injects. Reminds the model of project rules; never enforces.
+     *  Null/empty → no anchor. From `[guardrails] soft_prompt_anchor`. */
+    softPromptAnchor: string | null;
+    /** When true, the agent hard-blocks write/edit/bash tool calls outside
+     *  the active tab's project root. Default false. Per-tab overridable. */
+    hardEnforceProjectRoot: boolean;
+  };
 }
 
 const DEFAULTS: AethonConfig = {
@@ -112,6 +121,10 @@ const DEFAULTS: AethonConfig = {
     mode: "auto",
     cacheTtlHours: 720,
     refreshOnLockfileChange: true,
+  },
+  guardrails: {
+    softPromptAnchor: null,
+    hardEnforceProjectRoot: false,
   },
 };
 
@@ -219,6 +232,14 @@ export function getConfig(): Promise<AethonConfig> {
             typeof obj?.devshell?.refreshOnLockfileChange === "boolean"
               ? obj.devshell.refreshOnLockfileChange
               : true,
+        },
+        guardrails: {
+          softPromptAnchor:
+            typeof obj?.guardrails?.softPromptAnchor === "string" &&
+            obj.guardrails.softPromptAnchor.trim().length > 0
+              ? obj.guardrails.softPromptAnchor
+              : null,
+          hardEnforceProjectRoot: obj?.guardrails?.hardEnforceProjectRoot === true,
         },
       };
     } catch (err) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,10 @@ import { invoke } from "@tauri-apps/api/core";
 import type { ShareMode } from "./utils/shareMode";
 import { SHARE_MODES } from "./utils/shareMode";
 
+/** Tri-state visibility for transcript sections (thinking / tool calls):
+ *  `show` (full), `collapse` (grouped/labelled), `hide` (removed). */
+export type VisibilityMode = "show" | "collapse" | "hide";
+
 export interface AethonConfig {
   ui: {
     /** Theme id from `[ui] theme = "..."`. Built-ins are
@@ -22,6 +26,12 @@ export interface AethonConfig {
     /** Don't fire the completion notification for turns shorter than
      *  this many seconds. Default 8 — sub-second turns rarely need it. */
     notifyMinDurationSeconds: number;
+    /** Global default visibility for the model's thinking blocks. Per-tab
+     *  overridable via the composer pills; `show` by default. */
+    thinkingVisibility: VisibilityMode;
+    /** Global default visibility for tool-call cards. `collapse` groups
+     *  consecutive cards into one cluster; `show` by default. */
+    toolCallsVisibility: VisibilityMode;
   };
   agent: {
     model: string | null;
@@ -96,6 +106,8 @@ const DEFAULTS: AethonConfig = {
     restoreTabs: false,
     notifyOnCompletion: true,
     notifyMinDurationSeconds: 8,
+    thinkingVisibility: "show",
+    toolCallsVisibility: "show",
   },
   agent: { model: null },
   shell: {
@@ -170,6 +182,8 @@ export function getConfig(): Promise<AethonConfig> {
             obj.ui.notifyMinDurationSeconds >= 0
               ? obj.ui.notifyMinDurationSeconds
               : 8,
+          thinkingVisibility: normalizeVisibility(obj?.ui?.thinkingVisibility),
+          toolCallsVisibility: normalizeVisibility(obj?.ui?.toolCallsVisibility),
         },
         agent: {
           model: typeof obj?.agent?.model === "string" ? obj.agent.model : null,
@@ -252,6 +266,11 @@ export function getConfig(): Promise<AethonConfig> {
 
 function normalizeTheme(t: unknown): string | null {
   return typeof t === "string" && t.length > 0 ? t : null;
+}
+
+/** Mirrors `normalize_visibility` in helpers.rs — unknown/missing → "show". */
+export function normalizeVisibility(value: unknown): VisibilityMode {
+  return value === "collapse" || value === "hide" ? value : "show";
 }
 
 /** Mirrors `normalize_default_share_mode` in helpers.rs. Belt-and-braces:

--- a/src/eventRoutes/composerPills.test.ts
+++ b/src/eventRoutes/composerPills.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { handleComposerPills } from "./composerPills";
+import { buildRouteFixture } from "./testFixtures";
+import { makeEmptyTab } from "../types/tab";
+
+const pillEvent = (eventType: string, data?: unknown) => ({
+  component: { id: "composer-visibility-pills", type: "composer-visibility-pills" },
+  eventType,
+  data,
+});
+
+describe("handleComposerPills", () => {
+  it("ignores events from other components", () => {
+    const { ctx } = buildRouteFixture();
+    expect(
+      handleComposerPills(
+        { component: { id: "x", type: "chat-input" }, eventType: "cycle" },
+        ctx,
+      ),
+    ).toBe(false);
+  });
+
+  it("cycles the active tab thinking override show → collapse off the global default", () => {
+    const { ctx, mocks } = buildRouteFixture({
+      state: {
+        activeTabId: "t1",
+        transcriptVisibility: { thinking: "show", toolCalls: "show" },
+        tabs: [makeEmptyTab("t1", "T1")],
+      },
+    });
+    const handled = handleComposerPills(
+      pillEvent("cycle", { category: "thinking" }),
+      ctx,
+    );
+    expect(handled).toBe(true);
+    const updater = mocks.updateActiveTab.mock.calls[0][0];
+    expect(updater(makeEmptyTab("t1", "T1")).visibilityOverrides).toEqual({
+      thinking: "collapse",
+    });
+  });
+
+  it("cycles off the per-tab override when present (collapse → hide)", () => {
+    const tab = {
+      ...makeEmptyTab("t1", "T1"),
+      visibilityOverrides: { toolCalls: "collapse" as const },
+    };
+    const { ctx, mocks } = buildRouteFixture({
+      state: { activeTabId: "t1", tabs: [tab] },
+    });
+    handleComposerPills(pillEvent("cycle", { category: "toolCalls" }), ctx);
+    const updater = mocks.updateActiveTab.mock.calls[0][0];
+    expect(updater(tab).visibilityOverrides.toolCalls).toBe("hide");
+  });
+
+  it("wraps hide back to show", () => {
+    const tab = {
+      ...makeEmptyTab("t1", "T1"),
+      visibilityOverrides: { thinking: "hide" as const },
+    };
+    const { ctx, mocks } = buildRouteFixture({
+      state: { activeTabId: "t1", tabs: [tab] },
+    });
+    handleComposerPills(pillEvent("cycle", { category: "thinking" }), ctx);
+    const updater = mocks.updateActiveTab.mock.calls[0][0];
+    expect(updater(tab).visibilityOverrides.thinking).toBe("show");
+  });
+
+  it("promotes effective visibility to the global config on set-default", () => {
+    const tab = {
+      ...makeEmptyTab("t1", "T1"),
+      visibilityOverrides: { thinking: "hide" as const },
+    };
+    const { ctx, mocks } = buildRouteFixture({
+      state: {
+        activeTabId: "t1",
+        transcriptVisibility: { thinking: "show", toolCalls: "collapse" },
+        tabs: [tab],
+      },
+    });
+    const handled = handleComposerPills(pillEvent("set-default"), ctx);
+    expect(handled).toBe(true);
+    expect(mocks.applySettingsPatch).toHaveBeenCalledWith({
+      ui: { thinkingVisibility: "hide", toolCallsVisibility: "collapse" },
+    });
+  });
+
+  it("ignores a cycle with an unknown category but marks it handled", () => {
+    const { ctx, mocks } = buildRouteFixture({
+      state: { activeTabId: "t1", tabs: [makeEmptyTab("t1", "T1")] },
+    });
+    const handled = handleComposerPills(
+      pillEvent("cycle", { category: "nope" }),
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.updateActiveTab).not.toHaveBeenCalled();
+  });
+});

--- a/src/eventRoutes/composerPills.test.ts
+++ b/src/eventRoutes/composerPills.test.ts
@@ -84,6 +84,19 @@ describe("handleComposerPills", () => {
     });
   });
 
+  it("toggles the per-session hard guardrail override", () => {
+    const { ctx, mocks } = buildRouteFixture({
+      state: { activeTabId: "t1", tabs: [makeEmptyTab("t1", "T1")] },
+    });
+    const handled = handleComposerPills(
+      pillEvent("toggle-guardrail", { next: true }),
+      ctx,
+    );
+    expect(handled).toBe(true);
+    const updater = mocks.updateActiveTab.mock.calls[0][0];
+    expect(updater(makeEmptyTab("t1", "T1")).hardEnforceProjectRoot).toBe(true);
+  });
+
   it("ignores a cycle with an unknown category but marks it handled", () => {
     const { ctx, mocks } = buildRouteFixture({
       state: { activeTabId: "t1", tabs: [makeEmptyTab("t1", "T1")] },

--- a/src/eventRoutes/composerPills.ts
+++ b/src/eventRoutes/composerPills.ts
@@ -37,6 +37,12 @@ export const handleComposerPills: EventRouteHandler = (event, ctx) => {
     return true;
   }
 
+  if (event.eventType === "toggle-guardrail") {
+    const next = (event.data as { next?: unknown } | undefined)?.next === true;
+    ctx.updateActiveTab((tab) => ({ ...tab, hardEnforceProjectRoot: next }));
+    return true;
+  }
+
   if (event.eventType === "set-default") {
     const eff = resolveVisibility(state, activeId);
     ctx.applySettingsPatch({

--- a/src/eventRoutes/composerPills.ts
+++ b/src/eventRoutes/composerPills.ts
@@ -1,0 +1,52 @@
+import type { EventRouteHandler } from "./types";
+import { resolveVisibility } from "../utils/visibilityResolver";
+import type { VisibilityMode } from "../config";
+
+const CYCLE: readonly VisibilityMode[] = ["show", "collapse", "hide"];
+
+function nextMode(current: VisibilityMode): VisibilityMode {
+  const i = CYCLE.indexOf(current);
+  return CYCLE[(i + 1) % CYCLE.length];
+}
+
+/**
+ * Composer visibility pills (`type:composer-visibility-pills`):
+ *   - `cycle`       — advance the active session's override for one category
+ *                     (thinking / toolCalls) show → collapse → hide → show.
+ *   - `set-default` — promote the active session's *effective* visibility to
+ *                     the global config default (all future sessions).
+ *
+ * Cycling reads the effective value (per-tab override ?? global) so the first
+ * click moves off whatever the user currently sees, not off a stale null.
+ */
+export const handleComposerPills: EventRouteHandler = (event, ctx) => {
+  if (event.component.type !== "composer-visibility-pills") return false;
+  const state = ctx.stateRef.current;
+  const activeId =
+    typeof state.activeTabId === "string" ? state.activeTabId : undefined;
+
+  if (event.eventType === "cycle") {
+    const category = (event.data as { category?: unknown } | undefined)
+      ?.category;
+    if (category !== "thinking" && category !== "toolCalls") return true;
+    const next = nextMode(resolveVisibility(state, activeId)[category]);
+    ctx.updateActiveTab((tab) => ({
+      ...tab,
+      visibilityOverrides: { ...tab.visibilityOverrides, [category]: next },
+    }));
+    return true;
+  }
+
+  if (event.eventType === "set-default") {
+    const eff = resolveVisibility(state, activeId);
+    ctx.applySettingsPatch({
+      ui: {
+        thinkingVisibility: eff.thinking,
+        toolCallsVisibility: eff.toolCalls,
+      },
+    });
+    return true;
+  }
+
+  return false;
+};

--- a/src/eventRoutes/index.ts
+++ b/src/eventRoutes/index.ts
@@ -30,6 +30,7 @@ import { handleShellConsent } from "./shellConsent";
 import { matchesExtensionRoute } from "./extensions";
 import { handleChatInput } from "./chatInput";
 import { handleChatMessages } from "./chatMessages";
+import { handleComposerPills } from "./composerPills";
 import { handleQueuedMessages } from "./queue";
 import { handleSettings } from "./settings";
 import { handleAuthProfiles } from "./authProfiles";
@@ -94,6 +95,7 @@ export const BUILTIN_ROUTE_TABLE: ReadonlyMap<string, readonly EventRouteHandler
     // input events (submit / change / cancel) still flow to
     // handleChatInput unchanged.
     ["type:chat-input", [handleQueuedMessages, handleChatInput]],
+    ["type:composer-visibility-pills", [handleComposerPills]],
     ["type:chat-history", [handleChatMessages]],
     ["type:main-canvas", [handleChatMessages]],
     ["type:queued-messages-popover", [handleQueuedMessages]],

--- a/src/extensions/default-layout/composer-visibility-pills.tsx
+++ b/src/extensions/default-layout/composer-visibility-pills.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import type { BuiltinComponentProps } from "../../components/A2UIRenderer";
 import { resolveVisibility } from "../../utils/visibilityResolver";
 import type { VisibilityMode } from "../../config";
+import type { Tab } from "../../types/tab";
 
 /**
  * Composer-bar tri-state visibility pills (chrome composite). Two pills —
@@ -27,6 +28,26 @@ const MODE_TITLE: Record<VisibilityMode, string> = {
   hide: "hidden",
 };
 
+/** Effective hard-guardrail state: per-tab override wins; else the global
+ *  default mirrored at `/guardrails/hardEnforceProjectRoot`; else false. */
+function resolveHardEnforce(
+  state: Record<string, unknown>,
+  tabId: string | undefined,
+): boolean {
+  const tabs = state.tabs;
+  const tab =
+    tabId && Array.isArray(tabs)
+      ? (tabs as Tab[]).find((t) => t?.id === tabId)
+      : undefined;
+  if (typeof tab?.hardEnforceProjectRoot === "boolean") {
+    return tab.hardEnforceProjectRoot;
+  }
+  const global = state.guardrails as
+    | { hardEnforceProjectRoot?: unknown }
+    | undefined;
+  return global?.hardEnforceProjectRoot === true;
+}
+
 export function ComposerVisibilityPills({
   state,
   tabId,
@@ -34,6 +55,7 @@ export function ComposerVisibilityPills({
 }: BuiltinComponentProps) {
   const [menuOpen, setMenuOpen] = useState(false);
   const visibility = resolveVisibility(state, tabId);
+  const hardEnforce = resolveHardEnforce(state, tabId);
 
   const pill = (category: "thinking" | "toolCalls", label: string) => {
     const mode = visibility[category];
@@ -79,6 +101,23 @@ export function ComposerVisibilityPills({
             <div className="ae-vis-menu" role="menu">
               <button
                 type="button"
+                role="menuitemcheckbox"
+                aria-checked={hardEnforce}
+                className="ae-vis-menu-item ae-vis-menu-toggle"
+                data-checked={hardEnforce ? "true" : "false"}
+                onClick={() => {
+                  onEvent("toggle-guardrail", { next: !hardEnforce });
+                  setMenuOpen(false);
+                }}
+              >
+                <span className="ae-vis-menu-check" aria-hidden="true">
+                  {hardEnforce ? "✓" : ""}
+                </span>
+                Restrict tools to project root (this session)
+              </button>
+              <div className="ae-vis-menu-sep" role="separator" />
+              <button
+                type="button"
                 role="menuitem"
                 className="ae-vis-menu-item"
                 onClick={() => {
@@ -86,7 +125,7 @@ export function ComposerVisibilityPills({
                   setMenuOpen(false);
                 }}
               >
-                Use current as default for all sessions
+                Use current visibility as default for all sessions
               </button>
             </div>
           </>

--- a/src/extensions/default-layout/composer-visibility-pills.tsx
+++ b/src/extensions/default-layout/composer-visibility-pills.tsx
@@ -1,0 +1,97 @@
+import { useState } from "react";
+import type { BuiltinComponentProps } from "../../components/A2UIRenderer";
+import { resolveVisibility } from "../../utils/visibilityResolver";
+import type { VisibilityMode } from "../../config";
+
+/**
+ * Composer-bar tri-state visibility pills (chrome composite). Two pills —
+ * Thinking and Tool calls — each cycle show → collapse → hide on click,
+ * driving the active session's transcript. A "…" caret promotes the current
+ * choices to the global default for all sessions.
+ *
+ * Routing: events are keyed by `type:composer-visibility-pills` in
+ * BUILTIN_ROUTE_TABLE (see `eventRoutes/composerPills.ts`). The pill reads
+ * effective visibility via the shared resolver so it shows the same value the
+ * transcript renders.
+ */
+
+const MODE_LABEL: Record<VisibilityMode, string> = {
+  show: "shown",
+  collapse: "collapsed",
+  hide: "hidden",
+};
+
+const MODE_TITLE: Record<VisibilityMode, string> = {
+  show: "shown in full",
+  collapse: "collapsed / grouped",
+  hide: "hidden",
+};
+
+export function ComposerVisibilityPills({
+  state,
+  tabId,
+  onEvent,
+}: BuiltinComponentProps) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const visibility = resolveVisibility(state, tabId);
+
+  const pill = (category: "thinking" | "toolCalls", label: string) => {
+    const mode = visibility[category];
+    return (
+      <button
+        type="button"
+        className="ae-vis-pill"
+        data-category={category}
+        data-mode={mode}
+        title={`${label}: ${MODE_TITLE[mode]} — click to cycle (show → collapse → hide)`}
+        aria-label={`${label} visibility: ${MODE_LABEL[mode]}. Click to cycle.`}
+        onClick={() => onEvent("cycle", { category })}
+      >
+        <span className="ae-vis-pill-dot" aria-hidden="true" />
+        <span className="ae-vis-pill-label">{label}</span>
+        <span className="ae-vis-pill-state">{MODE_LABEL[mode]}</span>
+      </button>
+    );
+  };
+
+  return (
+    <div className="ae-composer-pills">
+      {pill("thinking", "Thinking")}
+      {pill("toolCalls", "Tool calls")}
+      <div className="ae-vis-more">
+        <button
+          type="button"
+          className="ae-vis-more-btn"
+          aria-haspopup="menu"
+          aria-expanded={menuOpen}
+          title="Visibility scope"
+          aria-label="Visibility scope menu"
+          onClick={() => setMenuOpen((v) => !v)}
+        >
+          …
+        </button>
+        {menuOpen && (
+          <>
+            <div
+              className="ae-vis-menu-backdrop"
+              onClick={() => setMenuOpen(false)}
+            />
+            <div className="ae-vis-menu" role="menu">
+              <button
+                type="button"
+                role="menuitem"
+                className="ae-vis-menu-item"
+                onClick={() => {
+                  onEvent("set-default");
+                  setMenuOpen(false);
+                }}
+              >
+                Use current as default for all sessions
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/extensions/default-layout/index.ts
+++ b/src/extensions/default-layout/index.ts
@@ -36,6 +36,7 @@ import {
   VcsStatus,
 } from "./variation-components";
 import { SourceControlPanel } from "./sidebar/source-control-panel";
+import { ComposerVisibilityPills } from "./composer-visibility-pills";
 import { CommandPalette } from "./command-palette";
 import { NotificationStack } from "./notifications";
 import { SettingsPanel } from "./settings-panel";
@@ -69,6 +70,9 @@ export const defaultLayoutExtension: A2UIExtension = {
     sidebar: Sidebar,
     "chat-history": ChatHistory,
     "chat-input": ChatInput,
+    // Composer-bar tri-state visibility pills (Thinking / Tool calls) with a
+    // "…" popover to promote the per-session choice to the global default.
+    "composer-visibility-pills": ComposerVisibilityPills,
     // Popover above the composer listing client-held queued messages
     // with per-row edit / steer / delete. Drained by `useQueuedDispatch`
     // on the next idle. Replaceable via

--- a/src/extensions/default-layout/message-list.tsx
+++ b/src/extensions/default-layout/message-list.tsx
@@ -13,6 +13,16 @@ import { resolveString } from "../../utils/dataBinding";
 import { resolvePointer } from "../../utils/jsonPointer";
 import { splitThinkingBlocks } from "../../utils/thinkingBlocks";
 import {
+  resolveVisibility,
+  type ResolvedVisibility,
+} from "../../utils/visibilityResolver";
+import {
+  groupMessages,
+  groupKey,
+  type MessageGroup,
+} from "../../utils/toolCardGrouping";
+import type { VisibilityMode } from "../../config";
+import {
   CHAT_MARKDOWN_PROPS,
   CHAT_STREAMING_MARKDOWN_PROPS,
 } from "./markdown-adapter";
@@ -123,13 +133,17 @@ function queuedDeliveryLabels(messages: ChatMessage[]): Map<string, string> {
 function ThinkingBlock({
   children,
   complete = true,
+  collapsed = false,
 }: {
   children: string;
   complete?: boolean;
+  /** When true (visibility = "collapse") the block never auto-expands, even
+   *  while streaming — it stays a quiet "Thinking" label the user can open. */
+  collapsed?: boolean;
 }) {
   const label = complete ? "Thinking" : "Thinking...";
   return (
-    <details className="a2ui-thinking-block" open={!complete}>
+    <details className="a2ui-thinking-block" open={collapsed ? false : !complete}>
       <summary>{label}</summary>
       <div className="a2ui-thinking-content a2ui-markdown">
         <ReactMarkdown {...CHAT_MARKDOWN_PROPS}>{children}</ReactMarkdown>
@@ -145,9 +159,11 @@ function hasFencedCodeMarker(text: string | undefined): boolean {
 function MarkdownWithThinking({
   text,
   streamingFences = false,
+  thinkingVisibility = "show",
 }: {
   text: string;
   streamingFences?: boolean;
+  thinkingVisibility?: VisibilityMode;
 }) {
   const markdownProps = streamingFences
     ? CHAT_STREAMING_MARKDOWN_PROPS
@@ -157,8 +173,13 @@ function MarkdownWithThinking({
       {splitThinkingBlocks(text).map((segment, index) => {
         if (!segment.content) return null;
         if (segment.type === "thinking") {
+          if (thinkingVisibility === "hide") return null;
           return (
-            <ThinkingBlock key={index} complete={segment.closed !== false}>
+            <ThinkingBlock
+              key={index}
+              complete={segment.closed !== false}
+              collapsed={thinkingVisibility === "collapse"}
+            >
               {segment.content}
             </ThinkingBlock>
           );
@@ -211,6 +232,7 @@ const ChatMessageRow = memo(
     onEvent,
     deliveryText,
     isLatest,
+    thinkingVisibility = "show",
   }: {
     message: ChatMessage;
     state: Record<string, unknown>;
@@ -220,6 +242,7 @@ const ChatMessageRow = memo(
     onEvent?: BuiltinComponentProps["onEvent"];
     deliveryText?: string;
     isLatest?: boolean;
+    thinkingVisibility?: VisibilityMode;
   }) {
     const isCanvas = className === "a2ui-canvas-message";
     const roleClass = isCanvas ? "a2ui-canvas-role" : "a2ui-chat-role";
@@ -268,8 +291,11 @@ const ChatMessageRow = memo(
             )}
           </span>
         )}
-        {message.thinking && (
-          <ThinkingBlock complete={Boolean(message.text)}>
+        {message.thinking && thinkingVisibility !== "hide" && (
+          <ThinkingBlock
+            complete={Boolean(message.text)}
+            collapsed={thinkingVisibility === "collapse"}
+          >
             {message.thinking}
           </ThinkingBlock>
         )}
@@ -278,6 +304,7 @@ const ChatMessageRow = memo(
             <MemoMarkdownWithThinking
               text={message.text}
               streamingFences={streamingFences}
+              thinkingVisibility={thinkingVisibility}
             />
           </div>
         )}
@@ -297,6 +324,7 @@ const ChatMessageRow = memo(
     prev.prevRole === next.prevRole &&
     prev.onEvent === next.onEvent &&
     prev.deliveryText === next.deliveryText &&
+    prev.thinkingVisibility === next.thinkingVisibility &&
     (!next.message.text ||
       !next.isLatest ||
       prev.state.waiting === next.state.waiting) &&
@@ -331,6 +359,54 @@ function CanvasFooter({ context }: { context?: CanvasFooterContext }) {
   );
 }
 
+/** Collapsed cluster of consecutive completed tool-call cards (visibility =
+ *  "collapse"). One disclosure row labelled "N tool calls" that expands to
+ *  the individual cards. Expansion is local UI state in VirtualMessageList. */
+function ToolGroupRow({
+  group,
+  state,
+  tabId,
+  expanded,
+  onToggle,
+}: {
+  group: Extract<MessageGroup, { type: "tool-group" }>;
+  state: Record<string, unknown>;
+  tabId?: string;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  const count = group.messages.length;
+  return (
+    <div className="ae-tool-group" data-expanded={expanded ? "true" : "false"}>
+      <button
+        type="button"
+        className="ae-tool-group-summary"
+        aria-expanded={expanded}
+        onClick={onToggle}
+      >
+        <span className="ae-tool-group-caret" aria-hidden="true">
+          {expanded ? "▾" : "▸"}
+        </span>
+        <span className="ae-tool-group-label">{count} tool calls</span>
+      </button>
+      {expanded && (
+        <div className="ae-tool-group-body">
+          {group.messages.map((m) =>
+            m.a2ui ? (
+              <A2UIRenderer
+                key={m.id}
+                payload={m.a2ui}
+                state={state}
+                tabId={tabId}
+              />
+            ) : null,
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
 interface VirtualMessageListProps {
   messages: ChatMessage[];
   state: Record<string, unknown>;
@@ -341,6 +417,8 @@ interface VirtualMessageListProps {
   className: string;
   scrollToMatch?: string;
   footerContext?: CanvasFooterContext;
+  /** Resolved per-tab transcript visibility (thinking + tool calls). */
+  visibility: ResolvedVisibility;
 }
 
 /** Virtualized chat feed. Replaces the old hand-rolled window + useStickyScroll:
@@ -356,6 +434,7 @@ function VirtualMessageList({
   className,
   scrollToMatch,
   footerContext,
+  visibility,
 }: VirtualMessageListProps) {
   const virtuosoRef = useRef<VirtuosoHandle>(null);
   const [isAtBottom, setIsAtBottom] = useState(true);
@@ -368,6 +447,25 @@ function VirtualMessageList({
     () => queuedDeliveryLabels(messages),
     [messages],
   );
+  // Tool-call visibility transforms the flat list into render groups: `show`
+  // → one single per message, `hide` → tool cards dropped, `collapse` → runs
+  // of completed tool cards folded into expandable clusters. Virtuoso renders
+  // groups, so its data length / keys track groups, not raw messages.
+  const groups = useMemo(
+    () => groupMessages(messages, visibility.toolCalls),
+    [messages, visibility.toolCalls],
+  );
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const toggleGroup = useCallback((id: string) => {
+    setExpandedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
   const updateCanScroll = useCallback(() => {
     const el = scrollerElRef.current;
     setCanScroll(
@@ -447,8 +545,12 @@ function VirtualMessageList({
     if (!scrollToMatch || scrollToMatch === prevScrollToMatch.current) return;
     prevScrollToMatch.current = scrollToMatch;
     const needle = scrollToMatch.toLowerCase();
-    const idx = messages.findIndex((m) =>
-      (m.text ?? "").toLowerCase().includes(needle),
+    // Search runs over groups so the scroll index matches Virtuoso's data.
+    // Only text-bearing single rows can match (tool clusters carry no text).
+    const idx = groups.findIndex(
+      (g) =>
+        g.type === "single" &&
+        (g.message.text ?? "").toLowerCase().includes(needle),
     );
     if (idx < 0) return;
     virtuosoRef.current?.scrollToIndex({ index: idx, align: "center" });
@@ -456,37 +558,73 @@ function VirtualMessageList({
     setFlashIndex(idx);
     const timer = window.setTimeout(() => setFlashIndex(null), 1200);
     return () => window.clearTimeout(timer);
-  }, [messages, scrollToMatch]);
+  }, [groups, scrollToMatch]);
 
   const itemContent = useCallback(
-    (index: number, m: ChatMessage) => (
+    (index: number, group: MessageGroup) => {
       // flow-root establishes a BFC so the row's vertical margins (role-change
       // spacing, etc.) are CONTAINED in this wrapper rather than collapsing
       // through it. Virtuoso measures the wrapper, so the margins are counted —
       // bare margins on the row would escape measurement and drift the
       // follow-to-bottom / scrollToIndex offsets in long transcripts.
-      <div
-        className={`a2ui-msg-row${index === 0 ? " a2ui-msg-row-first" : ""}${
-          index === messages.length - 1 ? " a2ui-msg-row-last" : ""
-        }`}
-      >
-        <ChatMessageRow
-          message={m}
-          state={state}
-          tabId={tabId}
-          className={
-            index === flashIndex
-              ? `${rowClassName} a2ui-chat-message-flash`
-              : rowClassName
-          }
-          prevRole={index > 0 ? messages[index - 1].role : undefined}
-          onEvent={onEvent}
-          deliveryText={queuedLabels.get(m.id)}
-          isLatest={index === messages.length - 1}
-        />
-      </div>
-    ),
-    [state, tabId, rowClassName, flashIndex, messages, onEvent, queuedLabels],
+      const rowClass = `a2ui-msg-row${index === 0 ? " a2ui-msg-row-first" : ""}${
+        index === groups.length - 1 ? " a2ui-msg-row-last" : ""
+      }`;
+      if (group.type === "tool-group") {
+        return (
+          <div className={rowClass}>
+            <ToolGroupRow
+              group={group}
+              state={state}
+              tabId={tabId}
+              expanded={expandedGroups.has(group.id)}
+              onToggle={() => toggleGroup(group.id)}
+            />
+          </div>
+        );
+      }
+      const m = group.message;
+      // prevRole drives role-badge suppression on consecutive same-role rows.
+      // A preceding tool cluster reads as an agent turn, so it counts as
+      // "agent" for that purpose.
+      const prev = groups[index - 1];
+      const prevRole = prev
+        ? prev.type === "single"
+          ? prev.message.role
+          : "agent"
+        : undefined;
+      return (
+        <div className={rowClass}>
+          <ChatMessageRow
+            message={m}
+            state={state}
+            tabId={tabId}
+            className={
+              index === flashIndex
+                ? `${rowClassName} a2ui-chat-message-flash`
+                : rowClassName
+            }
+            prevRole={prevRole}
+            onEvent={onEvent}
+            deliveryText={queuedLabels.get(m.id)}
+            isLatest={index === groups.length - 1}
+            thinkingVisibility={visibility.thinking}
+          />
+        </div>
+      );
+    },
+    [
+      groups,
+      state,
+      tabId,
+      rowClassName,
+      flashIndex,
+      onEvent,
+      queuedLabels,
+      visibility.thinking,
+      expandedGroups,
+      toggleGroup,
+    ],
   );
 
   // Only wire `context`/`components` when there's a footer. Passing
@@ -514,8 +652,8 @@ function VirtualMessageList({
         ref={virtuosoRef}
         className={className}
         style={{ flex: 1, minHeight: 0 }}
-        data={messages}
-        computeItemKey={(_index, m) => m.id}
+        data={groups}
+        computeItemKey={(index, g) => (g ? groupKey(g) : String(index))}
         itemContent={itemContent}
         // Open scrolled to the BOTTOM of the newest message. `align: "end"`
         // pins the last item's bottom to the viewport bottom — a bare index
@@ -526,7 +664,7 @@ function VirtualMessageList({
         // `undefined` into computeItemKey, crashing on m.id for any restored 2+
         // message chat (see message-list.virtuoso.test.tsx).
         initialTopMostItemIndex={{
-          index: Math.max(0, messages.length - 1),
+          index: Math.max(0, groups.length - 1),
           align: "end",
         }}
         followOutput={() =>
@@ -572,6 +710,10 @@ export function ChatHistory({
     () => (resolvePointer(state, props.messages.$ref) as ChatMessage[]) || [],
     [props.messages.$ref, state],
   );
+  const visibility = useMemo(
+    () => resolveVisibility(state, tabId),
+    [state, tabId],
+  );
   const emptyHint = props.emptyHint
     ? resolveString(props.emptyHint, state)
     : "Start a conversation.";
@@ -596,6 +738,7 @@ export function ChatHistory({
       tabId={tabId}
       onEvent={onEvent}
       scrollToMatch={scrollToMatch}
+      visibility={visibility}
     />
   );
 }
@@ -619,6 +762,11 @@ export function MainCanvas({
         ? (resolvePointer(state, props.messages!.$ref) as ChatMessage[]) || []
         : [],
     [chatMode, props.messages, state],
+  );
+
+  const visibility = useMemo(
+    () => resolveVisibility(state, tabId),
+    [state, tabId],
   );
 
   const live = props.slot ? resolvePointer(state, props.slot) : null;
@@ -670,6 +818,7 @@ export function MainCanvas({
         tabId={tabId}
         onEvent={onEvent}
         footerContext={footerContext}
+        visibility={visibility}
       />
     </main>
   );

--- a/src/extensions/default-layout/settings-panel/hooks.ts
+++ b/src/extensions/default-layout/settings-panel/hooks.ts
@@ -45,6 +45,7 @@ export function useEffectiveConfig(
       voice: { ...snapshot.voice, ...(p.voice ?? {}) },
       updates: { ...snapshot.updates, ...(p.updates ?? {}) },
       devshell: { ...snapshot.devshell, ...(p.devshell ?? {}) },
+      guardrails: { ...snapshot.guardrails, ...(p.guardrails ?? {}) },
     };
   }, [snapshot, pending]);
 }

--- a/src/extensions/default-layout/settings-panel/panel.tsx
+++ b/src/extensions/default-layout/settings-panel/panel.tsx
@@ -131,6 +131,51 @@ export function SettingsPanel({ state, onEvent }: BuiltinComponentProps) {
               </Field>
             </Section>
 
+            <Section id="view" title="View">
+              <Field label="Thinking blocks (global default)">
+                <select
+                  className="ae-settings-input"
+                  value={eff.ui.thinkingVisibility}
+                  onChange={(e) =>
+                    update({
+                      ui: {
+                        ...eff.ui,
+                        thinkingVisibility: e.target.value as
+                          | "show"
+                          | "collapse"
+                          | "hide",
+                      },
+                    })
+                  }
+                >
+                  <option value="show">Show</option>
+                  <option value="collapse">Collapse to a label</option>
+                  <option value="hide">Hide</option>
+                </select>
+              </Field>
+              <Field label="Tool calls (global default)">
+                <select
+                  className="ae-settings-input"
+                  value={eff.ui.toolCallsVisibility}
+                  onChange={(e) =>
+                    update({
+                      ui: {
+                        ...eff.ui,
+                        toolCallsVisibility: e.target.value as
+                          | "show"
+                          | "collapse"
+                          | "hide",
+                      },
+                    })
+                  }
+                >
+                  <option value="show">Show</option>
+                  <option value="collapse">Collapse &amp; group</option>
+                  <option value="hide">Hide</option>
+                </select>
+              </Field>
+            </Section>
+
             <Section id="notifications" title="Notifications">
               <Field label="Notify on agent completion (when unfocused)">
                 <input

--- a/src/extensions/default-layout/settings-panel/panel.tsx
+++ b/src/extensions/default-layout/settings-panel/panel.tsx
@@ -176,6 +176,42 @@ export function SettingsPanel({ state, onEvent }: BuiltinComponentProps) {
               </Field>
             </Section>
 
+            <Section id="guardrails" title="Guardrails">
+              <Field label="Restrict agent tools to the project root (default for new sessions)">
+                <input
+                  type="checkbox"
+                  checked={eff.guardrails.hardEnforceProjectRoot}
+                  onChange={(e) =>
+                    update({
+                      guardrails: {
+                        ...eff.guardrails,
+                        hardEnforceProjectRoot: e.target.checked,
+                      },
+                    })
+                  }
+                />
+              </Field>
+              <Field label="Soft prompt anchor (advisory text injected every turn)">
+                <textarea
+                  className="ae-settings-input"
+                  rows={3}
+                  placeholder="e.g. Only modify files under src/. Never run destructive git commands."
+                  value={eff.guardrails.softPromptAnchor ?? ""}
+                  onChange={(e) =>
+                    update({
+                      guardrails: {
+                        ...eff.guardrails,
+                        softPromptAnchor:
+                          e.target.value.trim().length > 0
+                            ? e.target.value
+                            : null,
+                      },
+                    })
+                  }
+                />
+              </Field>
+            </Section>
+
             <Section id="notifications" title="Notifications">
               <Field label="Notify on agent completion (when unfocused)">
                 <input

--- a/src/extensions/default-layout/workstation.a2ui.json
+++ b/src/extensions/default-layout/workstation.a2ui.json
@@ -191,18 +191,34 @@
           }
         },
         {
-          "id": "chat-input",
-          "type": "chat-input",
+          "id": "composer-area",
+          "type": "container",
           "props": {
             "area": "composer",
             "visible": { "$ref": "/agentTabActive" },
-            "value": { "$ref": "/draft" },
-            "placeholder": "Message Aethon… (Enter to send, Shift+Enter for newline, / for commands)",
-            "disabled": { "$ref": "/waiting" },
-            "queueCount": { "$ref": "/queueCount" },
-            "commands": { "$ref": "/slashCommands" },
-            "onSubmit": "chat:send"
-          }
+            "direction": "column",
+            "gap": 0,
+            "className": "ae-composer-area"
+          },
+          "children": [
+            {
+              "id": "composer-visibility-pills",
+              "type": "composer-visibility-pills",
+              "props": {}
+            },
+            {
+              "id": "chat-input",
+              "type": "chat-input",
+              "props": {
+                "value": { "$ref": "/draft" },
+                "placeholder": "Message Aethon… (Enter to send, Shift+Enter for newline, / for commands)",
+                "disabled": { "$ref": "/waiting" },
+                "queueCount": { "$ref": "/queueCount" },
+                "commands": { "$ref": "/slashCommands" },
+                "onSubmit": "chat:send"
+              }
+            }
+          ]
         },
         {
           "id": "status-bar",

--- a/src/hooks/bridgeMessageHandlers/gitQuery.test.ts
+++ b/src/hooks/bridgeMessageHandlers/gitQuery.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { handleGitQuery } from "./gitQuery";
+import { buildHandlerFixture } from "./testFixtures";
+import { clearTauriMocks, installTauriMocks } from "../../test/tauriMocks";
+
+describe("handleGitQuery", () => {
+  let harness: ReturnType<typeof installTauriMocks>;
+  beforeEach(() => {
+    harness = installTauriMocks();
+  });
+  afterEach(() => {
+    clearTauriMocks();
+  });
+
+  it("routes working_context op to git_working_context and acks the result", async () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    const fakeCtx = {
+      repoRoot: "/proj",
+      branch: "main",
+      isWorktree: false,
+      changedFiles: 3,
+      ahead: 2,
+      behind: 0,
+    };
+    harness.invoke.mockResolvedValueOnce(fakeCtx);
+    handleGitQuery(
+      {
+        type: "git_query",
+        op: "working_context",
+        mutationId: "g1",
+        args: { cwd: "/proj" },
+      },
+      ctx,
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(harness.invoke).toHaveBeenCalledWith("git_working_context", {
+      cwd: "/proj",
+    });
+    expect(mocks.ackMutation).toHaveBeenCalledWith("g1", true, undefined, fakeCtx);
+  });
+
+  it("acks null through unchanged when the cwd is not a git repo", async () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    harness.invoke.mockResolvedValueOnce(null);
+    handleGitQuery(
+      { type: "git_query", op: "working_context", mutationId: "g2", args: { cwd: "/tmp" } },
+      ctx,
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mocks.ackMutation).toHaveBeenCalledWith("g2", true, undefined, null);
+  });
+
+  it("rejects a missing cwd", async () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleGitQuery(
+      { type: "git_query", op: "working_context", mutationId: "g3", args: {} },
+      ctx,
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mocks.ackMutation).toHaveBeenCalledWith(
+      "g3",
+      false,
+      "git_query.working_context requires cwd",
+    );
+  });
+
+  it("rejects an unknown op", async () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleGitQuery({ type: "git_query", op: "explode", mutationId: "g4" }, ctx);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mocks.ackMutation).toHaveBeenCalledWith(
+      "g4",
+      false,
+      "unknown git_query op: explode",
+    );
+  });
+});

--- a/src/hooks/bridgeMessageHandlers/gitQuery.ts
+++ b/src/hooks/bridgeMessageHandlers/gitQuery.ts
@@ -1,0 +1,37 @@
+import { invoke } from "@tauri-apps/api/core";
+import type { BridgeMessageHandler } from "./types";
+
+/** Bridge proxy for the agent's working-directory git lookups.
+ *
+ *  The agent injects a per-turn "Working context" block into the model's
+ *  system prompt (so a local model doesn't lose track of the active tab's
+ *  cwd). It can't call Tauri directly, so it rounds a `git_query` message
+ *  through here; we invoke the Rust `git_working_context` command (which
+ *  resolves `git` via the PATH-augmenting `env` helper, so it works in
+ *  Finder-launched release builds) and ack the result.
+ *
+ *  Currently one op:
+ *    - `working_context` — `{ repoRoot, branch, isWorktree, changedFiles,
+ *      ahead, behind } | null` for a cwd (null when not a git work tree).
+ */
+export const handleGitQuery: BridgeMessageHandler = (data, ctx) => {
+  const op = data.op as string | undefined;
+  const args = (data.args as Record<string, unknown> | undefined) ?? {};
+  const mid = data.mutationId;
+
+  const route = async (): Promise<unknown> => {
+    if (op === "working_context") {
+      const cwd = args.cwd as string | undefined;
+      if (!cwd) throw new Error("git_query.working_context requires cwd");
+      return await invoke("git_working_context", { cwd });
+    }
+    throw new Error(`unknown git_query op: ${op}`);
+  };
+
+  route()
+    .then((result) => ctx.ackMutation(mid, true, undefined, result))
+    .catch((err: unknown) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      ctx.ackMutation(mid, false, msg);
+    });
+};

--- a/src/hooks/bridgeMessageHandlers/index.ts
+++ b/src/hooks/bridgeMessageHandlers/index.ts
@@ -47,6 +47,7 @@ import { handleSessionHistory } from "./sessionHistory";
 import { handleShellQuery } from "./shellQuery";
 import { handleDashboardQuery } from "./dashboardQuery";
 import { handleDevshellQuery } from "./devshellQuery";
+import { handleGitQuery } from "./gitQuery";
 import { handleStatePatch } from "./statePatch";
 import { handleTabClosed } from "./tabClosed";
 import { handleTabReady } from "./tabReady";
@@ -91,6 +92,7 @@ export const bridgeMessageHandlers: Readonly<
   shell_query: handleShellQuery,
   dashboard_query: handleDashboardQuery,
   devshell_query: handleDevshellQuery,
+  git_query: handleGitQuery,
   state_patch: handleStatePatch,
   tab_closed: handleTabClosed,
   tab_ready: handleTabReady,

--- a/src/hooks/uiOverlays/settings.test.ts
+++ b/src/hooks/uiOverlays/settings.test.ts
@@ -43,6 +43,7 @@ const baseConfig: AethonConfig = {
     cacheTtlHours: 720,
     refreshOnLockfileChange: true,
   },
+  guardrails: { softPromptAnchor: null, hardEnforceProjectRoot: false },
 };
 
 function buildContext(initialState: Record<string, unknown>): {

--- a/src/hooks/uiOverlays/settings.test.ts
+++ b/src/hooks/uiOverlays/settings.test.ts
@@ -24,6 +24,8 @@ const baseConfig: AethonConfig = {
     restoreTabs: false,
     notifyOnCompletion: true,
     notifyMinDurationSeconds: 8,
+    thinkingVisibility: "show",
+    toolCallsVisibility: "show",
   },
   agent: { model: "openai/gpt-5.5" },
   shell: {

--- a/src/hooks/uiOverlays/settings.ts
+++ b/src/hooks/uiOverlays/settings.ts
@@ -92,6 +92,7 @@ export function useSettingsOverlay(ctx: SettingsOverlayContext) {
       voice: unknown;
       updates: unknown;
       devshell: unknown;
+      guardrails: unknown;
     }>,
   ) {
     setState((prev) => {
@@ -199,6 +200,13 @@ export function useSettingsOverlay(ctx: SettingsOverlayContext) {
       devshell: {
         ...(live?.devshell ?? {}),
         ...((pendingSnapshot as { devshell?: object }).devshell ?? {}),
+      },
+      // Preserve `[guardrails]` (soft anchor + hard-enforce default) across
+      // saves of unrelated sections — write_config drops any section it
+      // isn't handed, so omitting this would wipe the user's guardrails.
+      guardrails: {
+        ...(live?.guardrails ?? {}),
+        ...((pendingSnapshot as { guardrails?: object }).guardrails ?? {}),
       },
     };
     try {

--- a/src/hooks/useBootConfig.ts
+++ b/src/hooks/useBootConfig.ts
@@ -111,6 +111,12 @@ export function useBootConfig(ctx: UseBootConfigContext): UseBootConfigActions {
         toggleHotkey: fresh.voice.toggleHotkey,
         holdHotkey: fresh.voice.holdHotkey,
       },
+      // Global transcript-visibility defaults, mirrored into state so the
+      // renderer's resolver can read them via $ref. Per-tab overrides win.
+      transcriptVisibility: {
+        thinking: fresh.ui.thinkingVisibility,
+        toolCalls: fresh.ui.toolCallsVisibility,
+      },
     }));
     if (fresh.agent.model) {
       piDefaultModelRef.current = fresh.agent.model;
@@ -198,6 +204,10 @@ export function useBootConfig(ctx: UseBootConfigContext): UseBootConfigActions {
           ...(prev.voice as object | undefined),
           toggleHotkey: config.voice.toggleHotkey,
           holdHotkey: config.voice.holdHotkey,
+        },
+        transcriptVisibility: {
+          thinking: config.ui.thinkingVisibility,
+          toolCalls: config.ui.toolCallsVisibility,
         },
       }));
 

--- a/src/hooks/useBootConfig.ts
+++ b/src/hooks/useBootConfig.ts
@@ -117,6 +117,9 @@ export function useBootConfig(ctx: UseBootConfigContext): UseBootConfigActions {
         thinking: fresh.ui.thinkingVisibility,
         toolCalls: fresh.ui.toolCallsVisibility,
       },
+      guardrails: {
+        hardEnforceProjectRoot: fresh.guardrails.hardEnforceProjectRoot,
+      },
     }));
     if (fresh.agent.model) {
       piDefaultModelRef.current = fresh.agent.model;
@@ -208,6 +211,9 @@ export function useBootConfig(ctx: UseBootConfigContext): UseBootConfigActions {
         transcriptVisibility: {
           thinking: config.ui.thinkingVisibility,
           toolCalls: config.ui.toolCallsVisibility,
+        },
+        guardrails: {
+          hardEnforceProjectRoot: config.guardrails.hardEnforceProjectRoot,
         },
       }));
 

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -581,6 +581,9 @@ export function useChat(ctx: UseChatContext): UseChatActions {
           ...(attachments.length > 0 ? { attachments } : {}),
           ...(targetCwd ? { cwd: targetCwd } : {}),
           ...(targetModel ? { model: targetModel } : {}),
+          ...(typeof targetTab?.hardEnforceProjectRoot === "boolean"
+            ? { hardEnforce: targetTab.hardEnforceProjectRoot }
+            : {}),
         },
       });
     } catch (err) {

--- a/src/state/sessionUiSnapshot.test.ts
+++ b/src/state/sessionUiSnapshot.test.ts
@@ -87,6 +87,7 @@ describe("sessionUiSnapshot", () => {
         thinking: "hide" as const,
         toolCalls: "collapse" as const,
       },
+      hardEnforceProjectRoot: true,
     };
     saveSessionUiSnapshot({ tabs: [tab], activeTabId: "tab-vis" });
     expect(loadSessionUiSnapshot()).toMatchObject({
@@ -94,6 +95,7 @@ describe("sessionUiSnapshot", () => {
         {
           id: "tab-vis",
           visibilityOverrides: { thinking: "hide", toolCalls: "collapse" },
+          hardEnforceProjectRoot: true,
         },
       ],
     });

--- a/src/state/sessionUiSnapshot.test.ts
+++ b/src/state/sessionUiSnapshot.test.ts
@@ -76,6 +76,29 @@ describe("sessionUiSnapshot", () => {
     });
   });
 
+  it("round-trips per-tab visibilityOverrides across save + restore", () => {
+    // Per-session thinking/tool-call visibility must survive reload AND a
+    // full relaunch (both go through this snapshot). restoreTabRecord spreads
+    // `...t`, so the field carries through — this test is the tripwire if
+    // that ever regresses to a strict allowlist.
+    const tab = {
+      ...makeEmptyTab("tab-vis", "Vis"),
+      visibilityOverrides: {
+        thinking: "hide" as const,
+        toolCalls: "collapse" as const,
+      },
+    };
+    saveSessionUiSnapshot({ tabs: [tab], activeTabId: "tab-vis" });
+    expect(loadSessionUiSnapshot()).toMatchObject({
+      tabs: [
+        {
+          id: "tab-vis",
+          visibilityOverrides: { thinking: "hide", toolCalls: "collapse" },
+        },
+      ],
+    });
+  });
+
   it("persists buckets-only when the active workspace has no sessions", () => {
     // User sitting on a project overview while agents run in its worktrees:
     // state.tabs is empty but a backgrounded bucket has a session.

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -8141,3 +8141,152 @@ button.ae-vcs-chip:focus-visible {
     transition: none;
   }
 }
+
+/* ── Composer visibility pills (tri-state Thinking / Tool calls) ──────── */
+.ae-composer-area {
+  min-width: 0;
+}
+.ae-composer-pills {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px 2px;
+  justify-content: flex-end;
+}
+.ae-vis-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-dim);
+  font: inherit;
+  font-size: 11px;
+  line-height: 1;
+  padding: 3px 9px;
+  cursor: pointer;
+  transition:
+    border-color 120ms ease,
+    background 120ms ease,
+    color 120ms ease;
+}
+.ae-vis-pill:hover {
+  border-color: var(--border-strong);
+  background: var(--bg-hover);
+  color: var(--text);
+}
+.ae-vis-pill-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  flex: none;
+}
+.ae-vis-pill[data-mode="collapse"] .ae-vis-pill-dot {
+  background: color-mix(in oklab, var(--accent) 45%, transparent);
+}
+.ae-vis-pill[data-mode="hide"] {
+  color: color-mix(in oklab, var(--text-dim) 70%, transparent);
+}
+.ae-vis-pill[data-mode="hide"] .ae-vis-pill-dot {
+  background: transparent;
+  border: 1px solid var(--border-strong);
+}
+.ae-vis-pill-state {
+  opacity: 0.75;
+  font-variant-numeric: tabular-nums;
+}
+.ae-vis-more {
+  position: relative;
+  display: inline-flex;
+}
+.ae-vis-more-btn {
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-size: 13px;
+  line-height: 1;
+  padding: 2px 8px;
+}
+.ae-vis-more-btn:hover {
+  border-color: var(--border-strong);
+  background: var(--bg-hover);
+  color: var(--text);
+}
+.ae-vis-menu-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+}
+.ae-vis-menu {
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 6px);
+  z-index: 41;
+  min-width: 220px;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.28);
+  padding: 4px;
+}
+.ae-vis-menu-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  color: var(--text);
+  font: inherit;
+  font-size: 12px;
+  padding: 7px 10px;
+  cursor: pointer;
+}
+.ae-vis-menu-item:hover {
+  background: var(--bg-hover);
+}
+
+/* ── Collapsed tool-call cluster (tool-call visibility = "collapse") ──── */
+.ae-tool-group {
+  border: 1px dashed var(--border);
+  border-radius: 10px;
+  width: fit-content;
+  max-width: 100%;
+}
+.ae-tool-group[data-expanded="true"] {
+  width: 100%;
+  border-style: solid;
+  background: var(--bg-elev);
+}
+.ae-tool-group-summary {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  background: transparent;
+  border: none;
+  color: var(--text-dim);
+  font: inherit;
+  font-size: 12px;
+  padding: 5px 10px;
+  cursor: pointer;
+  text-align: left;
+}
+.ae-tool-group-summary:hover {
+  color: var(--text);
+}
+.ae-tool-group-caret {
+  font-size: 10px;
+  opacity: 0.8;
+}
+.ae-tool-group-body {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 0 8px 8px;
+}

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -8250,6 +8250,23 @@ button.ae-vcs-chip:focus-visible {
 .ae-vis-menu-item:hover {
   background: var(--bg-hover);
 }
+.ae-vis-menu-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.ae-vis-menu-check {
+  display: inline-flex;
+  justify-content: center;
+  width: 12px;
+  color: var(--accent);
+  flex: none;
+}
+.ae-vis-menu-sep {
+  height: 1px;
+  margin: 4px 6px;
+  background: var(--border);
+}
 
 /* ── Collapsed tool-call cluster (tool-call visibility = "collapse") ──── */
 .ae-tool-group {

--- a/src/types/tab.ts
+++ b/src/types/tab.ts
@@ -145,6 +145,11 @@ export interface Tab {
   /** Per-session transcript visibility overrides (thinking / tool calls).
    *  Absent → follow the global `[ui]` defaults. Agent tabs only. */
   visibilityOverrides?: TabVisibilityOverrides;
+  /** Per-session hard project-root guardrail override. `true`/`false`
+   *  overrides the global `[guardrails] hard_enforce_project_root` default;
+   *  absent → follow the global default. Rides each chat message to the
+   *  agent's source guard. Persisted with the tab. */
+  hardEnforceProjectRoot?: boolean;
   /** Present iff kind === "shell". */
   shell?: ShellMeta;
   /** Present iff kind === "editor". */

--- a/src/types/tab.ts
+++ b/src/types/tab.ts
@@ -1,5 +1,18 @@
 import type { ChatAttachment, ChatMessage } from "./a2ui";
 import type { ShareMode } from "../utils/shareMode";
+import type { VisibilityMode } from "../config";
+
+/**
+ * Per-tab transcript visibility overrides. When a field is absent (or null)
+ * the tab follows the global default (`[ui] thinking_visibility` /
+ * `tool_calls_visibility`); a concrete value overrides it for this session.
+ * Persisted with the tab (see `restoreTabRecord` in `state/sessionUiSnapshot`)
+ * so a per-session choice survives reloads and restarts.
+ */
+export interface TabVisibilityOverrides {
+  thinking?: VisibilityMode | null;
+  toolCalls?: VisibilityMode | null;
+}
 
 // M6 P1: shell-tab metadata. Present iff Tab.kind === "shell".
 // Carried as an optional sibling field (rather than refactoring Tab to a
@@ -129,6 +142,9 @@ export interface Tab {
   cwd?: string;
   /** Auth profile id selected for this agent session, if any. */
   authProfileId?: string;
+  /** Per-session transcript visibility overrides (thinking / tool calls).
+   *  Absent → follow the global `[ui]` defaults. Agent tabs only. */
+  visibilityOverrides?: TabVisibilityOverrides;
   /** Present iff kind === "shell". */
   shell?: ShellMeta;
   /** Present iff kind === "editor". */

--- a/src/utils/toolCardGrouping.test.ts
+++ b/src/utils/toolCardGrouping.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import {
+  groupMessages,
+  isToolCardMessage,
+  isRunningToolCard,
+  type MessageGroup,
+} from "./toolCardGrouping";
+import type { ChatMessage } from "../types/a2ui";
+
+function text(id: string): ChatMessage {
+  return { id, role: "agent", text: `msg ${id}` };
+}
+
+function tool(id: string, opts: { running?: boolean } = {}): ChatMessage {
+  const props: Record<string, unknown> = { title: "bash", startedAt: 1 };
+  if (!opts.running) props.endedAt = 2;
+  return {
+    id,
+    role: "agent",
+    a2ui: { components: [{ id: `c-${id}`, type: "tool-card", props }] },
+  };
+}
+
+const kinds = (groups: MessageGroup[]) => groups.map((g) => g.type);
+
+describe("isToolCardMessage / isRunningToolCard", () => {
+  it("detects tool cards and running state", () => {
+    expect(isToolCardMessage(tool("a"))).toBe(true);
+    expect(isToolCardMessage(text("a"))).toBe(false);
+    expect(isRunningToolCard(tool("a", { running: true }))).toBe(true);
+    expect(isRunningToolCard(tool("a"))).toBe(false);
+    expect(isRunningToolCard(text("a"))).toBe(false);
+  });
+});
+
+describe("groupMessages", () => {
+  const messages = [
+    text("u1"),
+    tool("t1"),
+    tool("t2"),
+    tool("t3"),
+    text("a1"),
+    tool("t4"),
+  ];
+
+  it("show → one single per message", () => {
+    const groups = groupMessages(messages, "show");
+    expect(groups).toHaveLength(messages.length);
+    expect(groups.every((g) => g.type === "single")).toBe(true);
+  });
+
+  it("hide → drops tool-card messages entirely", () => {
+    const groups = groupMessages(messages, "hide");
+    expect(groups.map((g) => (g.type === "single" ? g.message.id : g.id))).toEqual([
+      "u1",
+      "a1",
+    ]);
+  });
+
+  it("collapse → folds consecutive completed tool cards into one cluster", () => {
+    const groups = groupMessages(messages, "collapse");
+    // u1(single) | [t1,t2,t3](group) | a1(single) | t4(single, lone)
+    expect(kinds(groups)).toEqual(["single", "tool-group", "single", "single"]);
+    const cluster = groups[1];
+    expect(cluster.type === "tool-group" && cluster.messages.map((m) => m.id)).toEqual([
+      "t1",
+      "t2",
+      "t3",
+    ]);
+    expect(cluster.type === "tool-group" && cluster.id).toBe("toolgroup-t1");
+  });
+
+  it("collapse → a lone tool card stays a single (no cluster wrapper)", () => {
+    const groups = groupMessages([text("u1"), tool("t1"), text("a1")], "collapse");
+    expect(kinds(groups)).toEqual(["single", "single", "single"]);
+  });
+
+  it("collapse → keeps a running tool card ungrouped so live progress shows", () => {
+    const groups = groupMessages(
+      [tool("t1"), tool("t2"), tool("t3", { running: true })],
+      "collapse",
+    );
+    // t1+t2 group; the running t3 stays a single after the cluster.
+    expect(kinds(groups)).toEqual(["tool-group", "single"]);
+  });
+});

--- a/src/utils/toolCardGrouping.ts
+++ b/src/utils/toolCardGrouping.ts
@@ -1,0 +1,87 @@
+import type { ChatMessage } from "../types/a2ui";
+import type { VisibilityMode } from "../config";
+
+/**
+ * A render unit for the transcript: either a normal message rendered on its
+ * own row, or a collapsible cluster of consecutive completed tool-call cards
+ * (produced only in `collapse` mode).
+ */
+export type MessageGroup =
+  | { type: "single"; message: ChatMessage }
+  | { type: "tool-group"; id: string; messages: ChatMessage[] };
+
+/** True when a message's A2UI payload is a tool-call card. */
+export function isToolCardMessage(m: ChatMessage): boolean {
+  const components = m.a2ui?.components;
+  return (
+    Array.isArray(components) && components.some((c) => c?.type === "tool-card")
+  );
+}
+
+function toolCardProps(m: ChatMessage): Record<string, unknown> | undefined {
+  const comp = m.a2ui?.components?.find((c) => c?.type === "tool-card");
+  return comp?.props;
+}
+
+/** A tool card that started but hasn't ended is still streaming — keep it
+ *  visible (ungrouped) so the user can watch live progress even in collapse
+ *  mode. Mirrors ToolCard's own `running` derivation. */
+export function isRunningToolCard(m: ChatMessage): boolean {
+  const props = toolCardProps(m);
+  return (
+    !!props && props.startedAt !== undefined && props.endedAt === undefined
+  );
+}
+
+/**
+ * Transform the flat message list into render groups according to the
+ * tool-call visibility mode:
+ *   - `show`     → one single per message (current behaviour).
+ *   - `hide`     → tool-card messages dropped entirely.
+ *   - `collapse` → runs of ≥2 consecutive *completed* tool-card messages fold
+ *                  into one collapsible cluster; a lone card or a running card
+ *                  stays a single so live progress and one-offs read normally.
+ *
+ * Pure + order-preserving so it's safe to memoize and easy to test.
+ */
+export function groupMessages(
+  messages: ChatMessage[],
+  mode: VisibilityMode,
+): MessageGroup[] {
+  if (mode === "show") {
+    return messages.map((message) => ({ type: "single", message }));
+  }
+  if (mode === "hide") {
+    return messages
+      .filter((m) => !isToolCardMessage(m))
+      .map((message) => ({ type: "single", message }));
+  }
+
+  // collapse
+  const out: MessageGroup[] = [];
+  let batch: ChatMessage[] = [];
+  const flush = () => {
+    if (batch.length === 0) return;
+    if (batch.length === 1) {
+      out.push({ type: "single", message: batch[0] });
+    } else {
+      out.push({ type: "tool-group", id: `toolgroup-${batch[0].id}`, messages: batch });
+    }
+    batch = [];
+  };
+  for (const message of messages) {
+    if (isToolCardMessage(message) && !isRunningToolCard(message)) {
+      batch.push(message);
+    } else {
+      flush();
+      out.push({ type: "single", message });
+    }
+  }
+  flush();
+  return out;
+}
+
+/** Stable React key for a group. */
+export function groupKey(group: MessageGroup): string {
+  return group.type === "single" ? group.message.id : group.id;
+}

--- a/src/utils/visibilityResolver.test.ts
+++ b/src/utils/visibilityResolver.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { resolveVisibility } from "./visibilityResolver";
+
+describe("resolveVisibility", () => {
+  it("defaults to show when nothing is set", () => {
+    expect(resolveVisibility({}, undefined)).toEqual({
+      thinking: "show",
+      toolCalls: "show",
+    });
+  });
+
+  it("reads the global default from /transcriptVisibility", () => {
+    const state = {
+      transcriptVisibility: { thinking: "collapse", toolCalls: "hide" },
+    };
+    expect(resolveVisibility(state, "t1")).toEqual({
+      thinking: "collapse",
+      toolCalls: "hide",
+    });
+  });
+
+  it("lets a per-tab override win over the global default", () => {
+    const state = {
+      transcriptVisibility: { thinking: "show", toolCalls: "show" },
+      tabs: [
+        { id: "t1", visibilityOverrides: { thinking: "hide" } },
+        { id: "t2", visibilityOverrides: { toolCalls: "collapse" } },
+      ],
+    };
+    expect(resolveVisibility(state, "t1")).toEqual({
+      thinking: "hide", // overridden
+      toolCalls: "show", // falls back to global
+    });
+    expect(resolveVisibility(state, "t2")).toEqual({
+      thinking: "show",
+      toolCalls: "collapse",
+    });
+  });
+
+  it("treats a null override as 'follow global'", () => {
+    const state = {
+      transcriptVisibility: { thinking: "collapse", toolCalls: "collapse" },
+      tabs: [{ id: "t1", visibilityOverrides: { thinking: null } }],
+    };
+    expect(resolveVisibility(state, "t1")).toEqual({
+      thinking: "collapse",
+      toolCalls: "collapse",
+    });
+  });
+
+  it("clamps unknown global values to show", () => {
+    const state = { transcriptVisibility: { thinking: "yolo" } };
+    expect(resolveVisibility(state, undefined).thinking).toBe("show");
+  });
+});

--- a/src/utils/visibilityResolver.ts
+++ b/src/utils/visibilityResolver.ts
@@ -1,0 +1,57 @@
+import { normalizeVisibility, type VisibilityMode } from "../config";
+import type { Tab } from "../types/tab";
+
+export interface ResolvedVisibility {
+  thinking: VisibilityMode;
+  toolCalls: VisibilityMode;
+}
+
+/**
+ * Resolve effective transcript visibility for a tab: a concrete per-tab
+ * override wins; otherwise fall back to the global default mirrored at
+ * `/transcriptVisibility` (seeded from `[ui]` config); otherwise `show`.
+ *
+ * Kept pure (state + tabId in, modes out) so it's trivially testable and the
+ * renderer can memoize on `[state, tabId]`.
+ */
+export function resolveVisibility(
+  state: Record<string, unknown>,
+  tabId: string | undefined,
+): ResolvedVisibility {
+  const global = (state.transcriptVisibility ?? {}) as {
+    thinking?: unknown;
+    toolCalls?: unknown;
+  };
+  const globalThinking = normalizeVisibility(global.thinking);
+  const globalTool = normalizeVisibility(global.toolCalls);
+
+  const overrides = findTabOverrides(state, tabId);
+  return {
+    thinking: pick(overrides?.thinking, globalThinking),
+    toolCalls: pick(overrides?.toolCalls, globalTool),
+  };
+}
+
+function findTabOverrides(
+  state: Record<string, unknown>,
+  tabId: string | undefined,
+): Tab["visibilityOverrides"] | undefined {
+  if (!tabId) return undefined;
+  const tabs = state.tabs;
+  if (!Array.isArray(tabs)) return undefined;
+  const tab = (tabs as Tab[]).find((t) => t?.id === tabId);
+  return tab?.visibilityOverrides;
+}
+
+/** A per-tab override only wins when it's an explicit mode; null/undefined
+ *  (the "follow global" sentinel) defers to the global default. */
+function pick(
+  override: VisibilityMode | null | undefined,
+  fallback: VisibilityMode,
+): VisibilityMode {
+  return override === "show" ||
+    override === "collapse" ||
+    override === "hide"
+    ? override
+    : fallback;
+}


### PR DESCRIPTION
## Summary

Three related features that keep the agent oriented and give the user real-time control over the transcript — motivated by a local Ollama `qwen` model that kept losing track of which directory it was working in.

Delivered in three reviewable commits (one branch):

1. **`feat(agent)`: per-turn working-directory + git context** — the root fix for the confusion.
2. **`feat(ui)`: tri-state Thinking / Tool-call visibility controls** — composer-bar pills.
3. **`feat(agent)`: hard project-root guardrail** — opt-in write/edit/bash enforcement.

## 1 · Working-context injection

**Problem (confirmed in code, not a model quirk):** the shared runtime snapshot advertised `cwd: process.cwd()` — the agent process's *launch* dir — for every tab, and the appended system prompt is **cached at `resourceLoader.reload()`**, never per-turn. So the model's mental map of "where am I" was wrong even though each tab's tools were correctly cwd-scoped.

**Fix:** pi's `before_agent_start` hook fires synchronously inside every `session.prompt()` (which `chat.ts` already wraps in `tabContext.run(tabId, …)`), so a single `ExtensionFactory` on the shared resource loader reads the active tab and returns a per-turn `systemPrompt` override (non-persisted) carrying the tab's real cwd + fresh git facts (repo root, branch, worktree, changed-file count, ahead/behind) + an optional user soft anchor.

- Git source: new `git_working_context` Rust command (reuses `commands/git` shell-outs, resolves `git` via the PATH-augmenting `env` helper so release builds work), reached through a `git_query` mutation-ack bridge, cached agent-side with a short TTL.
- Also de-misleads the static snapshot: per-tab cwd on each open-tab line; the global `cwd=` line is relabeled the *agent host dir*.

## 2 · Tri-state transcript controls

Composer-bar pills toggle **Thinking** and **Tool calls** between **show / collapse / hide** in real time:
- `collapse` keeps thinking as a quiet label and folds runs of consecutive *completed* tool cards into one expandable "N tool calls" cluster (the running card stays visible);
- `hide` removes them entirely for a fast, clean transcript.

Scope uses the same control: clicking a pill overrides the **active session**; the `…` popover promotes the current choices to the **global default**. Effective value = per-tab override ?? global default.

**Persistence (both scopes, reload + restart):** global default in `[ui] thinking_visibility` / `tool_calls_visibility` (config.toml round-trip + TS mirror, clamped); per-tab override on the `Tab` record, carried through `sessionUiSnapshot` (spread-preserved, locked in with a round-trip test).

Rendering: pure `groupMessages()` feeds Virtuoso render groups; `resolveVisibility()` resolves modes; `message-list` gates thinking inline and via `message.thinking`. New `composer-visibility-pills` composite + `composerPills` event route (type-keyed) + Settings → View.

## 3 · Hard project-root guardrail

Opt-in deterministic backstop. `wrapWithSourceGuard` now layers a per-tab working-root guard over the existing Aethon source guard. When on, it blocks:
- write/edit whose resolved path escapes the tab root (exact), and
- bash whose parsed write/cd targets (`>`, `>>`, `tee`, `cd`/`pushd`) escape it — best-effort, documented as a speed-bump (won't catch `eval`/subshells/var-expansion), not a sandbox.

Global default via `[guardrails] hard_enforce_project_root` → spawn env; per-session override via the composer `…` menu, riding each chat message (`SendMessageRequest.hard_enforce` → `state.tabHardEnforce`) so it's current before the turn's tool calls, survives a respawn, and persists with the tab. Settings → Guardrails exposes the global default + the always-injected soft anchor.

Also fixes a latent bug: the settings autosave merge omitted new sections, so a save would have wiped `[guardrails]`; the merge now carries it.

## Verification

- **Automated:** full `check` gate green — clippy + `tsc -b` + ESLint (0 warnings) + cargo test (**357**) + vitest (**1753**, 224 files). New coverage at every layer: `git_working_context` (Rust), `buildWorkingContextSection`, `getWorkingContext` cache/degrade, `git_query` handler, snapshot per-tab cwd + prompt signposting, config parse/round-trip (visibility + guardrails), `resolveVisibility`, `groupMessages` (incl. running-/lone-card), `composerPills` (cycle/wrap/set-default/toggle-guardrail), per-tab persistence round-trip, and hard-enforce write/edit/bash (block + allow + live toggle) + `bashEscapesRoot`/`isInsideRoot`.
- **Live UAT (suggested):** with the dev build running, open two agent tabs on different repos and ask each (no tools) what directory + branch it's in → each answers its own; switch a branch and re-ask → updates (per-turn freshness); cycle the pills through show/collapse/hide and confirm real-time grouping/hiding + per-tab isolation + persistence across reload and relaunch; flip the guardrail on and confirm an out-of-root `write`/`bash` is blocked while in-root succeeds. Driveable via the `aethon-debug` skill.

## Notes
- Doesn't touch the disabled `@brink/current-context-widget` user extension.
- Global guardrail default + soft anchor are read at agent spawn, so they apply to new sessions / after an agent restart; the per-session composer guardrail toggle is live.
