### PR TITLE
feat(transcript): cycle tool-call grouping (turn/run/block) + fix visibility-scope popover

### DIFF
--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -177,7 +177,7 @@ pub fn write_config(config: serde_json::Value, app: AppHandle) -> Result<(), Str
     let tool_calls_visibility = ui
         .and_then(|m| m.get("toolCallsVisibility"))
         .and_then(|v| v.as_str())
-        .map(|s| helpers::normalize_visibility(Some(s)));
+        .map(|s| helpers::normalize_tool_visibility(Some(s)));
 
     let model = agent
         .and_then(|m| m.get("model"))

--- a/src-tauri/src/helpers/config.rs
+++ b/src-tauri/src/helpers/config.rs
@@ -209,6 +209,26 @@ pub fn normalize_visibility(input: Option<&str>) -> &'static str {
     }
 }
 
+/// Validate-and-normalize the tool-call visibility value
+/// (`[ui] tool_calls_visibility`). Tool calls support three *grouping* styles
+/// in place of thinking's single `collapse`: `group-turn` (one cluster per
+/// agent turn), `group-run` (one cluster per consecutive run), and
+/// `group-block` (the whole agent turn folded into one block). The legacy
+/// `"collapse"` value (written by PR #204) maps to `group-turn` so existing
+/// configs adopt the natural per-turn grouping. Unknown/missing → `"show"`.
+pub fn normalize_tool_visibility(input: Option<&str>) -> &'static str {
+    match input {
+        Some("group-turn") => "group-turn",
+        Some("group-run") => "group-run",
+        Some("group-block") => "group-block",
+        Some("hide") => "hide",
+        // Back-compat: the old tri-state "collapse" becomes per-turn grouping.
+        Some("collapse") => "group-turn",
+        // Includes Some("show"), Some(<unknown>), and None.
+        _ => "show",
+    }
+}
+
 /// Validate-and-normalize `[devshell] enabled`. Unknown values fall
 /// through to `"auto"` so a typo can't silently disable the feature.
 pub fn normalize_devshell_enabled(input: Option<&str>) -> &'static str {
@@ -319,7 +339,7 @@ pub fn parse_config_toml(input: &str) -> serde_json::Value {
         .unwrap_or(8);
     let new_tab_kind = normalize_new_tab_kind(cfg.shortcuts.new_tab_kind.as_deref());
     let thinking_visibility = normalize_visibility(cfg.ui.thinking_visibility.as_deref());
-    let tool_calls_visibility = normalize_visibility(cfg.ui.tool_calls_visibility.as_deref());
+    let tool_calls_visibility = normalize_tool_visibility(cfg.ui.tool_calls_visibility.as_deref());
     let default_command = cfg
         .shell
         .default_command
@@ -856,6 +876,40 @@ enabled = "never"
         // Unknown clamps to show.
         let v = parse_config_toml("[ui]\nthinking_visibility = \"yolo\"\n");
         assert_eq!(v["ui"]["thinkingVisibility"], "show");
+    }
+
+    #[test]
+    fn normalize_tool_visibility_accepts_grouping_values() {
+        assert_eq!(normalize_tool_visibility(Some("show")), "show");
+        assert_eq!(normalize_tool_visibility(Some("group-turn")), "group-turn");
+        assert_eq!(normalize_tool_visibility(Some("group-run")), "group-run");
+        assert_eq!(
+            normalize_tool_visibility(Some("group-block")),
+            "group-block"
+        );
+        assert_eq!(normalize_tool_visibility(Some("hide")), "hide");
+    }
+
+    #[test]
+    fn normalize_tool_visibility_migrates_legacy_collapse() {
+        // PR #204 wrote "collapse"; it now means per-turn grouping.
+        assert_eq!(normalize_tool_visibility(Some("collapse")), "group-turn");
+    }
+
+    #[test]
+    fn normalize_tool_visibility_falls_back_to_show() {
+        assert_eq!(normalize_tool_visibility(None), "show");
+        assert_eq!(normalize_tool_visibility(Some("")), "show");
+        assert_eq!(normalize_tool_visibility(Some("group-yolo")), "show");
+    }
+
+    #[test]
+    fn parse_config_toml_extracts_tool_grouping() {
+        let v = parse_config_toml("[ui]\ntool_calls_visibility = \"group-block\"\n");
+        assert_eq!(v["ui"]["toolCallsVisibility"], "group-block");
+        // Legacy collapse migrates to per-turn grouping on read.
+        let v = parse_config_toml("[ui]\ntool_calls_visibility = \"collapse\"\n");
+        assert_eq!(v["ui"]["toolCallsVisibility"], "group-turn");
     }
 
     // ── guardrails ─────────────────────────────────────────────────────────

--- a/src-tauri/src/helpers/mod.rs
+++ b/src-tauri/src/helpers/mod.rs
@@ -24,7 +24,8 @@ pub mod paths;
 pub use config::{
     FONT_SIZE_MAX, FONT_SIZE_MIN, clamp_font_size, normalize_default_share_mode,
     normalize_devshell_enabled, normalize_devshell_mode, normalize_new_tab_kind,
-    normalize_update_channel, normalize_visibility, parse_config_toml,
+    normalize_update_channel, normalize_tool_visibility, normalize_visibility,
+    parse_config_toml,
 };
 pub use names::{sanitize_filename_segment, validate_state_name};
 pub use paths::{aethon_dir, resolve_inside_root};

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,9 +5,25 @@ import { invoke } from "@tauri-apps/api/core";
 import type { ShareMode } from "./utils/shareMode";
 import { SHARE_MODES } from "./utils/shareMode";
 
-/** Tri-state visibility for transcript sections (thinking / tool calls):
- *  `show` (full), `collapse` (grouped/labelled), `hide` (removed). */
+/** Tri-state visibility for the model's thinking blocks:
+ *  `show` (full), `collapse` (closed "Thinking" label), `hide` (removed). */
 export type VisibilityMode = "show" | "collapse" | "hide";
+
+/** Tool-call visibility. Like thinking it can be `show`n or `hide`den, but the
+ *  middle is split into three chronological *grouping* styles the composer pill
+ *  cycles through:
+ *    - `group-turn`  — one collapsed cluster per agent turn (all of a turn's
+ *                      tool calls gathered into one group);
+ *    - `group-run`   — one collapsed cluster per consecutive run of tool calls;
+ *    - `group-block` — the whole agent turn (narration + tools) folded into one
+ *                      collapsed block.
+ *  The legacy `"collapse"` value (PR #204) migrates to `group-turn`. */
+export type ToolCallsMode =
+  | "show"
+  | "group-turn"
+  | "group-run"
+  | "group-block"
+  | "hide";
 
 export interface AethonConfig {
   ui: {
@@ -29,9 +45,10 @@ export interface AethonConfig {
     /** Global default visibility for the model's thinking blocks. Per-tab
      *  overridable via the composer pills; `show` by default. */
     thinkingVisibility: VisibilityMode;
-    /** Global default visibility for tool-call cards. `collapse` groups
-     *  consecutive cards into one cluster; `show` by default. */
-    toolCallsVisibility: VisibilityMode;
+    /** Global default visibility for tool-call cards. The grouped values
+     *  (`group-turn` / `group-run` / `group-block`) fold cards into collapsed
+     *  clusters; `show` by default. Per-tab overridable via the composer pills. */
+    toolCallsVisibility: ToolCallsMode;
   };
   agent: {
     model: string | null;
@@ -183,7 +200,9 @@ export function getConfig(): Promise<AethonConfig> {
               ? obj.ui.notifyMinDurationSeconds
               : 8,
           thinkingVisibility: normalizeVisibility(obj?.ui?.thinkingVisibility),
-          toolCallsVisibility: normalizeVisibility(obj?.ui?.toolCallsVisibility),
+          toolCallsVisibility: normalizeToolCallsVisibility(
+            obj?.ui?.toolCallsVisibility,
+          ),
         },
         agent: {
           model: typeof obj?.agent?.model === "string" ? obj.agent.model : null,
@@ -271,6 +290,23 @@ function normalizeTheme(t: unknown): string | null {
 /** Mirrors `normalize_visibility` in helpers.rs — unknown/missing → "show". */
 export function normalizeVisibility(value: unknown): VisibilityMode {
   return value === "collapse" || value === "hide" ? value : "show";
+}
+
+/** Mirrors `normalize_tool_visibility` in helpers.rs. Accepts the three
+ *  grouping styles plus show/hide; legacy `"collapse"` → `"group-turn"`;
+ *  unknown/missing → `"show"`. */
+export function normalizeToolCallsVisibility(value: unknown): ToolCallsMode {
+  switch (value) {
+    case "group-turn":
+    case "group-run":
+    case "group-block":
+    case "hide":
+      return value;
+    case "collapse":
+      return "group-turn";
+    default:
+      return "show";
+  }
 }
 
 /** Mirrors `normalize_default_share_mode` in helpers.rs. Belt-and-braces:

--- a/src/eventRoutes/composerPills.test.ts
+++ b/src/eventRoutes/composerPills.test.ts
@@ -39,17 +39,88 @@ describe("handleComposerPills", () => {
     });
   });
 
-  it("cycles off the per-tab override when present (collapse → hide)", () => {
+  it("cycles tool calls through the grouping styles from the global default", () => {
+    const { ctx, mocks } = buildRouteFixture({
+      state: {
+        activeTabId: "t1",
+        transcriptVisibility: { toolCalls: "show" },
+        tabs: [makeEmptyTab("t1", "T1")],
+      },
+    });
+    // show → group-turn (first grouped style).
+    handleComposerPills(pillEvent("cycle", { category: "toolCalls" }), ctx);
+    const updater = mocks.updateActiveTab.mock.calls[0][0];
+    expect(updater(makeEmptyTab("t1", "T1")).visibilityOverrides.toolCalls).toBe(
+      "group-turn",
+    );
+  });
+
+  it("cycles group-block → hide and a legacy 'collapse' override resolves into the cycle", () => {
+    const blockTab = {
+      ...makeEmptyTab("t1", "T1"),
+      visibilityOverrides: { toolCalls: "group-block" as const },
+    };
+    const fx = buildRouteFixture({
+      state: { activeTabId: "t1", tabs: [blockTab] },
+    });
+    handleComposerPills(pillEvent("cycle", { category: "toolCalls" }), fx.ctx);
+    expect(
+      fx.mocks.updateActiveTab.mock.calls[0][0](blockTab).visibilityOverrides
+        .toolCalls,
+    ).toBe("hide");
+
+    // A legacy "collapse" override resolves to group-turn, so cycling advances
+    // to group-run (not the removed tri-state "hide").
+    const legacyTab = {
+      ...makeEmptyTab("t2", "T2"),
+      visibilityOverrides: { toolCalls: "collapse" },
+    } as unknown as ReturnType<typeof makeEmptyTab>;
+    const fx2 = buildRouteFixture({
+      state: { activeTabId: "t2", tabs: [legacyTab] },
+    });
+    handleComposerPills(pillEvent("cycle", { category: "toolCalls" }), fx2.ctx);
+    expect(
+      fx2.mocks.updateActiveTab.mock.calls[0][0](legacyTab).visibilityOverrides
+        .toolCalls,
+    ).toBe("group-run");
+  });
+
+  it("jumps straight to a grouping style on set-tool-grouping", () => {
+    const { ctx, mocks } = buildRouteFixture({
+      state: { activeTabId: "t1", tabs: [makeEmptyTab("t1", "T1")] },
+    });
+    const handled = handleComposerPills(
+      pillEvent("set-tool-grouping", { mode: "group-block" }),
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(
+      mocks.updateActiveTab.mock.calls[0][0](makeEmptyTab("t1", "T1"))
+        .visibilityOverrides.toolCalls,
+    ).toBe("group-block");
+  });
+
+  it("ignores set-tool-grouping with a non-grouping mode", () => {
+    const { ctx, mocks } = buildRouteFixture({
+      state: { activeTabId: "t1", tabs: [makeEmptyTab("t1", "T1")] },
+    });
+    handleComposerPills(pillEvent("set-tool-grouping", { mode: "hide" }), ctx);
+    expect(mocks.updateActiveTab).not.toHaveBeenCalled();
+  });
+
+  it("clears per-tab overrides on reset-to-global", () => {
     const tab = {
       ...makeEmptyTab("t1", "T1"),
-      visibilityOverrides: { toolCalls: "collapse" as const },
+      visibilityOverrides: { thinking: "hide" as const, toolCalls: "group-run" as const },
     };
     const { ctx, mocks } = buildRouteFixture({
       state: { activeTabId: "t1", tabs: [tab] },
     });
-    handleComposerPills(pillEvent("cycle", { category: "toolCalls" }), ctx);
-    const updater = mocks.updateActiveTab.mock.calls[0][0];
-    expect(updater(tab).visibilityOverrides.toolCalls).toBe("hide");
+    const handled = handleComposerPills(pillEvent("reset-to-global"), ctx);
+    expect(handled).toBe(true);
+    expect(mocks.updateActiveTab.mock.calls[0][0](tab).visibilityOverrides).toBe(
+      undefined,
+    );
   });
 
   it("wraps hide back to show", () => {
@@ -73,14 +144,14 @@ describe("handleComposerPills", () => {
     const { ctx, mocks } = buildRouteFixture({
       state: {
         activeTabId: "t1",
-        transcriptVisibility: { thinking: "show", toolCalls: "collapse" },
+        transcriptVisibility: { thinking: "show", toolCalls: "group-run" },
         tabs: [tab],
       },
     });
     const handled = handleComposerPills(pillEvent("set-default"), ctx);
     expect(handled).toBe(true);
     expect(mocks.applySettingsPatch).toHaveBeenCalledWith({
-      ui: { thinkingVisibility: "hide", toolCallsVisibility: "collapse" },
+      ui: { thinkingVisibility: "hide", toolCallsVisibility: "group-run" },
     });
   });
 

--- a/src/eventRoutes/composerPills.ts
+++ b/src/eventRoutes/composerPills.ts
@@ -1,20 +1,42 @@
 import type { EventRouteHandler } from "./types";
 import { resolveVisibility } from "../utils/visibilityResolver";
-import type { VisibilityMode } from "../config";
+import type { ToolCallsMode, VisibilityMode } from "../config";
 
-const CYCLE: readonly VisibilityMode[] = ["show", "collapse", "hide"];
+// Thinking cycles show → collapse → hide. Tool calls cycle through the three
+// grouping styles between show and hide so one pill reaches every mode.
+const THINKING_CYCLE: readonly VisibilityMode[] = ["show", "collapse", "hide"];
+const TOOLCALLS_CYCLE: readonly ToolCallsMode[] = [
+  "show",
+  "group-turn",
+  "group-run",
+  "group-block",
+  "hide",
+];
 
-function nextMode(current: VisibilityMode): VisibilityMode {
-  const i = CYCLE.indexOf(current);
-  return CYCLE[(i + 1) % CYCLE.length];
+function nextIn<T>(cycle: readonly T[], current: T): T {
+  const i = cycle.indexOf(current);
+  return cycle[(i + 1) % cycle.length];
 }
+
+const GROUPING_MODES: readonly ToolCallsMode[] = [
+  "group-turn",
+  "group-run",
+  "group-block",
+];
 
 /**
  * Composer visibility pills (`type:composer-visibility-pills`):
- *   - `cycle`       — advance the active session's override for one category
- *                     (thinking / toolCalls) show → collapse → hide → show.
- *   - `set-default` — promote the active session's *effective* visibility to
- *                     the global config default (all future sessions).
+ *   - `cycle`            — advance the active session's override for one
+ *                          category. Thinking: show → collapse → hide. Tool
+ *                          calls: show → group-turn → group-run → group-block →
+ *                          hide.
+ *   - `set-tool-grouping`— jump the active session's tool-call mode straight to
+ *                          a specific grouping style (popover radios).
+ *   - `reset-to-global`  — drop the session's per-tab overrides so it follows
+ *                          the global defaults again.
+ *   - `toggle-guardrail` — flip the per-session hard project-root guardrail.
+ *   - `set-default`      — promote the active session's *effective* visibility
+ *                          to the global config default (all future sessions).
  *
  * Cycling reads the effective value (per-tab override ?? global) so the first
  * click moves off whatever the user currently sees, not off a stale null.
@@ -28,12 +50,41 @@ export const handleComposerPills: EventRouteHandler = (event, ctx) => {
   if (event.eventType === "cycle") {
     const category = (event.data as { category?: unknown } | undefined)
       ?.category;
-    if (category !== "thinking" && category !== "toolCalls") return true;
-    const next = nextMode(resolveVisibility(state, activeId)[category]);
+    const eff = resolveVisibility(state, activeId);
+    if (category === "thinking") {
+      const next = nextIn(THINKING_CYCLE, eff.thinking);
+      ctx.updateActiveTab((tab) => ({
+        ...tab,
+        visibilityOverrides: { ...tab.visibilityOverrides, thinking: next },
+      }));
+      return true;
+    }
+    if (category === "toolCalls") {
+      const next = nextIn(TOOLCALLS_CYCLE, eff.toolCalls);
+      ctx.updateActiveTab((tab) => ({
+        ...tab,
+        visibilityOverrides: { ...tab.visibilityOverrides, toolCalls: next },
+      }));
+      return true;
+    }
+    return true;
+  }
+
+  if (event.eventType === "set-tool-grouping") {
+    const mode = (event.data as { mode?: unknown } | undefined)?.mode;
+    if (!GROUPING_MODES.includes(mode as ToolCallsMode)) return true;
     ctx.updateActiveTab((tab) => ({
       ...tab,
-      visibilityOverrides: { ...tab.visibilityOverrides, [category]: next },
+      visibilityOverrides: {
+        ...tab.visibilityOverrides,
+        toolCalls: mode as ToolCallsMode,
+      },
     }));
+    return true;
+  }
+
+  if (event.eventType === "reset-to-global") {
+    ctx.updateActiveTab((tab) => ({ ...tab, visibilityOverrides: undefined }));
     return true;
   }
 

--- a/src/extensions/default-layout/chat.test.tsx
+++ b/src/extensions/default-layout/chat.test.tsx
@@ -739,3 +739,111 @@ describe("ChatHistory render isolation", () => {
     expect(spyRenders).toBe(baseline);
   });
 });
+
+describe("ChatHistory tool-call grouping (mocked Virtuoso renders rows)", () => {
+  // Two completed tool-using turns plus a final live-ish turn; the bridge
+  // emits each tool call as its own role:"agent" message carrying a tool-card.
+  const toolMessages = [
+    { id: "u1", role: "user", text: "do the thing" },
+    { id: "a1", role: "agent", text: "reading files" },
+    {
+      id: "t1",
+      role: "agent",
+      a2ui: {
+        components: [
+          { id: "c1", type: "tool-card", props: { title: "read", startedAt: 1, endedAt: 2 } },
+        ],
+      },
+    },
+    {
+      id: "t2",
+      role: "agent",
+      a2ui: {
+        components: [
+          { id: "c2", type: "tool-card", props: { title: "bash", startedAt: 1, endedAt: 2 } },
+        ],
+      },
+    },
+    { id: "a2", role: "agent", text: "done" },
+    { id: "u2", role: "user", text: "now this" },
+    {
+      id: "t3",
+      role: "agent",
+      a2ui: {
+        components: [
+          { id: "c3", type: "tool-card", props: { title: "edit", startedAt: 1, endedAt: 2 } },
+        ],
+      },
+    },
+  ];
+
+  // Single tool cards render through A2UIRenderer, which resolves the
+  // `tool-card` component from the registry — so wrap in a provider that has it.
+  function renderGroupedHistory(state: Record<string, unknown>) {
+    const registry = new ExtensionRegistry();
+    registry.register({
+      name: "test-tool-card",
+      components: { "tool-card": ToolCard },
+    });
+    return render(
+      <ExtensionRegistryProvider registry={registry}>
+        <ChatHistory
+          component={{
+            id: "chat-history",
+            type: "chat-history",
+            props: { messages: { $ref: "/messages" } },
+          }}
+          state={state}
+          onEvent={vi.fn()}
+        />
+      </ExtensionRegistryProvider>,
+    );
+  }
+
+  it("group-run folds the consecutive run into a '2 tool calls' cluster", () => {
+    renderGroupedHistory({
+      messages: toolMessages,
+      transcriptVisibility: { toolCalls: "group-run" },
+    });
+    expect(screen.getByText("2 tool calls")).toBeTruthy();
+  });
+
+  it("group-turn folds a turn's tools into one cluster with a name peek", () => {
+    renderGroupedHistory({
+      messages: toolMessages,
+      transcriptVisibility: { toolCalls: "group-turn" },
+    });
+    expect(screen.getByText("2 tool calls")).toBeTruthy();
+    expect(screen.getByText("read · bash")).toBeTruthy();
+  });
+
+  it("group-block folds the first completed turn into an 'Agent turn' block", () => {
+    renderGroupedHistory({
+      messages: toolMessages,
+      transcriptVisibility: { toolCalls: "group-block" },
+    });
+    expect(screen.getByText("Agent turn")).toBeTruthy();
+    // The last turn stays expanded, so no group label wraps its single tool.
+    expect(screen.queryByText("1 tool call")).toBeNull();
+  });
+
+  it("hide drops tool cards and never renders a group label", () => {
+    renderGroupedHistory({
+      messages: toolMessages,
+      transcriptVisibility: { toolCalls: "hide" },
+    });
+    expect(screen.queryByText("2 tool calls")).toBeNull();
+    expect(screen.queryByText("Agent turn")).toBeNull();
+    // Narration stays.
+    expect(screen.getByText("reading files")).toBeTruthy();
+  });
+
+  it("show renders tool cards individually with no grouping chrome", () => {
+    renderGroupedHistory({
+      messages: toolMessages,
+      transcriptVisibility: { toolCalls: "show" },
+    });
+    expect(screen.queryByText("2 tool calls")).toBeNull();
+    expect(screen.queryByText("Agent turn")).toBeNull();
+  });
+});

--- a/src/extensions/default-layout/composer-visibility-pills.tsx
+++ b/src/extensions/default-layout/composer-visibility-pills.tsx
@@ -1,14 +1,18 @@
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { BuiltinComponentProps } from "../../components/A2UIRenderer";
 import { resolveVisibility } from "../../utils/visibilityResolver";
-import type { VisibilityMode } from "../../config";
+import type { ToolCallsMode, VisibilityMode } from "../../config";
 import type { Tab } from "../../types/tab";
+import { readUiScale } from "./layout";
 
 /**
- * Composer-bar tri-state visibility pills (chrome composite). Two pills —
- * Thinking and Tool calls — each cycle show → collapse → hide on click,
- * driving the active session's transcript. A "…" caret promotes the current
- * choices to the global default for all sessions.
+ * Composer-bar visibility pills (chrome composite). Two pills — Thinking and
+ * Tool calls — cycle the active session's transcript visibility on click.
+ * Thinking cycles show → collapse → hide; Tool calls cycle through the three
+ * chronological grouping styles (by turn / by run / as block) between show and
+ * hide. A "More options" caret opens a popover that explains scope (this
+ * session vs. all sessions), offers direct grouping selection, a reset, and the
+ * per-session project-root guardrail.
  *
  * Routing: events are keyed by `type:composer-visibility-pills` in
  * BUILTIN_ROUTE_TABLE (see `eventRoutes/composerPills.ts`). The pill reads
@@ -16,17 +20,39 @@ import type { Tab } from "../../types/tab";
  * transcript renders.
  */
 
-const MODE_LABEL: Record<VisibilityMode, string> = {
+const THINKING_LABEL: Record<VisibilityMode, string> = {
   show: "shown",
   collapse: "collapsed",
   hide: "hidden",
 };
 
-const MODE_TITLE: Record<VisibilityMode, string> = {
+const THINKING_TITLE: Record<VisibilityMode, string> = {
   show: "shown in full",
-  collapse: "collapsed / grouped",
+  collapse: "collapsed to a label",
   hide: "hidden",
 };
+
+const TOOL_LABEL: Record<ToolCallsMode, string> = {
+  show: "shown",
+  "group-turn": "by turn",
+  "group-run": "by run",
+  "group-block": "as block",
+  hide: "hidden",
+};
+
+const TOOL_TITLE: Record<ToolCallsMode, string> = {
+  show: "shown in full",
+  "group-turn": "grouped — one cluster per agent turn",
+  "group-run": "grouped — one cluster per consecutive run",
+  "group-block": "grouped — the whole turn folded into one block",
+  hide: "hidden",
+};
+
+const GROUPING_OPTIONS: { mode: ToolCallsMode; label: string }[] = [
+  { mode: "group-turn", label: "Per turn" },
+  { mode: "group-run", label: "Per run" },
+  { mode: "group-block", label: "Whole turn" },
+];
 
 /** Effective hard-guardrail state: per-tab override wins; else the global
  *  default mirrored at `/guardrails/hardEnforceProjectRoot`; else false. */
@@ -34,11 +60,7 @@ function resolveHardEnforce(
   state: Record<string, unknown>,
   tabId: string | undefined,
 ): boolean {
-  const tabs = state.tabs;
-  const tab =
-    tabId && Array.isArray(tabs)
-      ? (tabs as Tab[]).find((t) => t?.id === tabId)
-      : undefined;
+  const tab = findTab(state, tabId);
   if (typeof tab?.hardEnforceProjectRoot === "boolean") {
     return tab.hardEnforceProjectRoot;
   }
@@ -48,30 +70,113 @@ function resolveHardEnforce(
   return global?.hardEnforceProjectRoot === true;
 }
 
+function findTab(
+  state: Record<string, unknown>,
+  tabId: string | undefined,
+): Tab | undefined {
+  const tabs = state.tabs;
+  return tabId && Array.isArray(tabs)
+    ? (tabs as Tab[]).find((t) => t?.id === tabId)
+    : undefined;
+}
+
+/** Whether a category currently carries an explicit per-session override
+ *  (distinct from following the global default). Drives the "session" marker. */
+function hasOverride(
+  state: Record<string, unknown>,
+  tabId: string | undefined,
+  category: "thinking" | "toolCalls",
+): boolean {
+  const ov = findTab(state, tabId)?.visibilityOverrides;
+  const v = ov?.[category];
+  return v !== undefined && v !== null;
+}
+
 export function ComposerVisibilityPills({
   state,
   tabId,
   onEvent,
 }: BuiltinComponentProps) {
   const [menuOpen, setMenuOpen] = useState(false);
+  const [coords, setCoords] = useState<{ bottom: number; right: number } | null>(
+    null,
+  );
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
   const visibility = resolveVisibility(state, tabId);
   const hardEnforce = resolveHardEnforce(state, tabId);
+  const sessionOverridden =
+    hasOverride(state, tabId, "thinking") ||
+    hasOverride(state, tabId, "toolCalls");
+
+  const close = useCallback(() => {
+    setMenuOpen(false);
+    setCoords(null);
+  }, []);
+
+  // The pills live inside `.a2ui-layout-cell`, which clips overflow. Render the
+  // popover with position:fixed and coordinates from the trigger's bounding
+  // rect (converted out of the UI-scale transform) so it floats *above* the
+  // composer uncut — the same trick DropdownPickerCore uses.
+  const openMenu = useCallback(() => {
+    const r = triggerRef.current?.getBoundingClientRect();
+    if (r) {
+      const scale = readUiScale();
+      setCoords({
+        bottom: (window.innerHeight - r.top) / scale + 6,
+        right: (window.innerWidth - r.right) / scale,
+      });
+    }
+    setMenuOpen(true);
+  }, []);
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") close();
+    };
+    const onResize = () => close();
+    document.addEventListener("keydown", onKey);
+    window.addEventListener("resize", onResize);
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      window.removeEventListener("resize", onResize);
+    };
+  }, [menuOpen, close]);
 
   const pill = (category: "thinking" | "toolCalls", label: string) => {
     const mode = visibility[category];
+    const stateLabel =
+      category === "thinking"
+        ? THINKING_LABEL[visibility.thinking]
+        : TOOL_LABEL[visibility.toolCalls];
+    const titleText =
+      category === "thinking"
+        ? THINKING_TITLE[visibility.thinking]
+        : TOOL_TITLE[visibility.toolCalls];
+    const scoped = hasOverride(state, tabId, category);
     return (
       <button
         type="button"
         className="ae-vis-pill"
         data-category={category}
         data-mode={mode}
-        title={`${label}: ${MODE_TITLE[mode]} — click to cycle (show → collapse → hide)`}
-        aria-label={`${label} visibility: ${MODE_LABEL[mode]}. Click to cycle.`}
+        data-scope={scoped ? "session" : "global"}
+        title={`${label}: ${titleText}${
+          scoped ? " — this session only (overrides the global default)" : ""
+        }. Click to cycle.`}
+        aria-label={`${label} visibility: ${stateLabel}${
+          scoped ? ", this session" : ""
+        }. Click to cycle.`}
         onClick={() => onEvent("cycle", { category })}
       >
         <span className="ae-vis-pill-dot" aria-hidden="true" />
         <span className="ae-vis-pill-label">{label}</span>
-        <span className="ae-vis-pill-state">{MODE_LABEL[mode]}</span>
+        <span className="ae-vis-pill-state">{stateLabel}</span>
+        {scoped && (
+          <span className="ae-vis-pill-scope" aria-hidden="true">
+            session
+          </span>
+        )}
       </button>
     );
   };
@@ -82,23 +187,79 @@ export function ComposerVisibilityPills({
       {pill("toolCalls", "Tool calls")}
       <div className="ae-vis-more">
         <button
+          ref={triggerRef}
           type="button"
           className="ae-vis-more-btn"
           aria-haspopup="menu"
           aria-expanded={menuOpen}
-          title="Visibility scope"
-          aria-label="Visibility scope menu"
-          onClick={() => setMenuOpen((v) => !v)}
+          title="More options"
+          aria-label="More visibility options"
+          onClick={() => (menuOpen ? close() : openMenu())}
         >
           …
         </button>
-        {menuOpen && (
+        {menuOpen && coords && (
           <>
+            <div className="ae-vis-menu-backdrop" onClick={close} />
             <div
-              className="ae-vis-menu-backdrop"
-              onClick={() => setMenuOpen(false)}
-            />
-            <div className="ae-vis-menu" role="menu">
+              className="ae-vis-menu"
+              role="menu"
+              style={{ bottom: coords.bottom, right: coords.right }}
+            >
+              <div className="ae-vis-menu-head">This session</div>
+              <div
+                className="ae-vis-menu-radios"
+                role="group"
+                aria-label="Tool-call grouping"
+              >
+                <span className="ae-vis-menu-radios-label">Tool-call grouping</span>
+                <div className="ae-vis-menu-radio-row">
+                  {GROUPING_OPTIONS.map((opt) => (
+                    <button
+                      key={opt.mode}
+                      type="button"
+                      role="menuitemradio"
+                      aria-checked={visibility.toolCalls === opt.mode}
+                      data-checked={
+                        visibility.toolCalls === opt.mode ? "true" : "false"
+                      }
+                      className="ae-vis-menu-radio"
+                      onClick={() => {
+                        onEvent("set-tool-grouping", { mode: opt.mode });
+                        close();
+                      }}
+                    >
+                      {opt.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+              <button
+                type="button"
+                role="menuitem"
+                className="ae-vis-menu-item"
+                onClick={() => {
+                  onEvent("set-default");
+                  close();
+                }}
+              >
+                Save current visibility as default for all sessions
+              </button>
+              {sessionOverridden && (
+                <button
+                  type="button"
+                  role="menuitem"
+                  className="ae-vis-menu-item"
+                  onClick={() => {
+                    onEvent("reset-to-global");
+                    close();
+                  }}
+                >
+                  Reset this session to the global default
+                </button>
+              )}
+              <div className="ae-vis-menu-sep" role="separator" />
+              <div className="ae-vis-menu-head">Tools</div>
               <button
                 type="button"
                 role="menuitemcheckbox"
@@ -107,25 +268,13 @@ export function ComposerVisibilityPills({
                 data-checked={hardEnforce ? "true" : "false"}
                 onClick={() => {
                   onEvent("toggle-guardrail", { next: !hardEnforce });
-                  setMenuOpen(false);
+                  close();
                 }}
               >
                 <span className="ae-vis-menu-check" aria-hidden="true">
                   {hardEnforce ? "✓" : ""}
                 </span>
                 Restrict tools to project root (this session)
-              </button>
-              <div className="ae-vis-menu-sep" role="separator" />
-              <button
-                type="button"
-                role="menuitem"
-                className="ae-vis-menu-item"
-                onClick={() => {
-                  onEvent("set-default");
-                  setMenuOpen(false);
-                }}
-              >
-                Use current visibility as default for all sessions
               </button>
             </div>
           </>

--- a/src/extensions/default-layout/message-list.tsx
+++ b/src/extensions/default-layout/message-list.tsx
@@ -19,6 +19,7 @@ import {
 import {
   groupMessages,
   groupKey,
+  isToolCardMessage,
   type MessageGroup,
 } from "../../utils/toolCardGrouping";
 import type { VisibilityMode } from "../../config";
@@ -359,9 +360,29 @@ function CanvasFooter({ context }: { context?: CanvasFooterContext }) {
   );
 }
 
-/** Collapsed cluster of consecutive completed tool-call cards (visibility =
- *  "collapse"). One disclosure row labelled "N tool calls" that expands to
- *  the individual cards. Expansion is local UI state in VirtualMessageList. */
+/** Title shown on a tool-call card (e.g. "bash", "read"), used for the
+ *  collapsed-group peek. */
+function toolCardTitle(m: ChatMessage): string | undefined {
+  const comp = m.a2ui?.components?.find((c) => c?.type === "tool-card");
+  const title = comp?.props?.title;
+  return typeof title === "string" && title.length > 0 ? title : undefined;
+}
+
+/** A short "name · name · …" peek of the tools inside a collapsed group, so the
+ *  user can tell what's hidden without expanding. Caps at 4 names. */
+function toolPeek(messages: ChatMessage[]): string {
+  const names = messages
+    .map(toolCardTitle)
+    .filter((n): n is string => Boolean(n));
+  if (names.length === 0) return "";
+  const shown = names.slice(0, 4).join(" · ");
+  return names.length > 4 ? `${shown} · …` : shown;
+}
+
+/** Collapsed cluster of completed tool-call cards (tool visibility =
+ *  "group-run" / "group-turn"). One disclosure row labelled "N tool calls"
+ *  with a name peek, expanding to the individual cards. Expansion is local UI
+ *  state in VirtualMessageList. */
 function ToolGroupRow({
   group,
   state,
@@ -376,6 +397,7 @@ function ToolGroupRow({
   onToggle: () => void;
 }) {
   const count = group.messages.length;
+  const peek = toolPeek(group.messages);
   return (
     <div className="ae-tool-group" data-expanded={expanded ? "true" : "false"}>
       <button
@@ -388,6 +410,9 @@ function ToolGroupRow({
           {expanded ? "▾" : "▸"}
         </span>
         <span className="ae-tool-group-label">{count} tool calls</span>
+        {!expanded && peek && (
+          <span className="ae-tool-group-peek">{peek}</span>
+        )}
       </button>
       {expanded && (
         <div className="ae-tool-group-body">
@@ -401,6 +426,80 @@ function ToolGroupRow({
               />
             ) : null,
           )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Header label for a folded agent turn: "N replies · M tool calls". */
+function turnBlockLabel(messages: ChatMessage[]): string {
+  const tools = messages.filter(isToolCardMessage).length;
+  const replies = messages.filter(
+    (m) => !isToolCardMessage(m) && Boolean(m.text || m.thinking),
+  ).length;
+  const parts: string[] = [];
+  if (replies > 0) {
+    parts.push(`${replies} ${replies === 1 ? "reply" : "replies"}`);
+  }
+  parts.push(`${tools} ${tools === 1 ? "tool call" : "tool calls"}`);
+  return parts.join(" · ");
+}
+
+/** A whole completed agent turn folded into one collapsible block (tool
+ *  visibility = "group-block"). Expands to the turn's messages — narration and
+ *  tool cards — rendered in order via ChatMessageRow. */
+function TurnBlockRow({
+  group,
+  state,
+  tabId,
+  onEvent,
+  rowClassName,
+  thinkingVisibility,
+  expanded,
+  onToggle,
+}: {
+  group: Extract<MessageGroup, { type: "turn-block" }>;
+  state: Record<string, unknown>;
+  tabId?: string;
+  onEvent?: BuiltinComponentProps["onEvent"];
+  rowClassName: string;
+  thinkingVisibility: VisibilityMode;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  const peek = toolPeek(group.messages);
+  return (
+    <div className="ae-turn-block" data-expanded={expanded ? "true" : "false"}>
+      <button
+        type="button"
+        className="ae-turn-block-summary"
+        aria-expanded={expanded}
+        onClick={onToggle}
+      >
+        <span className="ae-turn-block-caret" aria-hidden="true">
+          {expanded ? "▾" : "▸"}
+        </span>
+        <span className="ae-turn-block-label">Agent turn</span>
+        <span className="ae-turn-block-meta">{turnBlockLabel(group.messages)}</span>
+        {!expanded && peek && (
+          <span className="ae-turn-block-peek">{peek}</span>
+        )}
+      </button>
+      {expanded && (
+        <div className="ae-turn-block-body">
+          {group.messages.map((m, i) => (
+            <ChatMessageRow
+              key={m.id}
+              message={m}
+              state={state}
+              tabId={tabId}
+              className={rowClassName}
+              prevRole={i > 0 ? group.messages[i - 1].role : undefined}
+              onEvent={onEvent}
+              thinkingVisibility={thinkingVisibility}
+            />
+          ))}
         </div>
       )}
     </div>
@@ -448,9 +547,11 @@ function VirtualMessageList({
     [messages],
   );
   // Tool-call visibility transforms the flat list into render groups: `show`
-  // → one single per message, `hide` → tool cards dropped, `collapse` → runs
-  // of completed tool cards folded into expandable clusters. Virtuoso renders
-  // groups, so its data length / keys track groups, not raw messages.
+  // → one single per message, `hide` → tool cards dropped, and the grouped
+  // modes fold tool cards into expandable clusters (`group-run` / `group-turn`
+  // → tool-group rows) or whole turns into one block (`group-block` →
+  // turn-block rows). Virtuoso renders groups, so its data length / keys track
+  // groups, not raw messages.
   const groups = useMemo(
     () => groupMessages(messages, visibility.toolCalls),
     [messages, visibility.toolCalls],
@@ -577,6 +678,22 @@ function VirtualMessageList({
               group={group}
               state={state}
               tabId={tabId}
+              expanded={expandedGroups.has(group.id)}
+              onToggle={() => toggleGroup(group.id)}
+            />
+          </div>
+        );
+      }
+      if (group.type === "turn-block") {
+        return (
+          <div className={rowClass}>
+            <TurnBlockRow
+              group={group}
+              state={state}
+              tabId={tabId}
+              onEvent={onEvent}
+              rowClassName={rowClassName}
+              thinkingVisibility={visibility.thinking}
               expanded={expandedGroups.has(group.id)}
               onToggle={() => toggleGroup(group.id)}
             />

--- a/src/extensions/default-layout/message-list.virtuoso.test.tsx
+++ b/src/extensions/default-layout/message-list.virtuoso.test.tsx
@@ -79,6 +79,71 @@ describe("ChatHistory + real Virtuoso", () => {
     ).not.toThrow();
   });
 
+  // A transcript with two completed turns, each using multiple tools, plus a
+  // final live-ish turn. Exercises every grouped rendering path.
+  function toolTranscript() {
+    return [
+      { id: "u1", role: "user", text: "do the thing" },
+      { id: "a1", role: "agent", text: "reading files" },
+      {
+        id: "t1",
+        role: "agent",
+        a2ui: {
+          components: [
+            { id: "c1", type: "tool-card", props: { title: "read", startedAt: 1, endedAt: 2 } },
+          ],
+        },
+      },
+      {
+        id: "t2",
+        role: "agent",
+        a2ui: {
+          components: [
+            { id: "c2", type: "tool-card", props: { title: "bash", startedAt: 1, endedAt: 2 } },
+          ],
+        },
+      },
+      { id: "a2", role: "agent", text: "done" },
+      { id: "u2", role: "user", text: "now this" },
+      {
+        id: "t3",
+        role: "agent",
+        a2ui: {
+          components: [
+            { id: "c3", type: "tool-card", props: { title: "edit", startedAt: 1, endedAt: 2 } },
+          ],
+        },
+      },
+    ];
+  }
+
+  function renderToolChat(mode: string) {
+    return render(
+      <ChatHistory
+        component={{
+          id: "chat-history",
+          type: "chat-history",
+          props: { messages: { $ref: "/messages" } },
+        }}
+        state={{
+          messages: toolTranscript(),
+          transcriptVisibility: { toolCalls: mode },
+        }}
+        onEvent={vi.fn()}
+      />,
+    );
+  }
+
+  // Real Virtuoso virtualizes (no row mounts in jsdom), so this only guards
+  // that every grouped mode wires through Virtuoso without crashing
+  // computeItemKey. Rendered-content assertions live in chat.test.tsx, which
+  // mocks Virtuoso and actually mounts the rows.
+  it("mounts every tool-call visibility mode without crashing", () => {
+    for (const mode of ["show", "group-run", "group-turn", "group-block", "hide"]) {
+      expect(() => renderToolChat(mode)).not.toThrow();
+    }
+  });
+
   it("renders the empty-state hint without Virtuoso", () => {
     const { getByText } = render(
       <ChatHistory

--- a/src/extensions/default-layout/settings-panel/panel.tsx
+++ b/src/extensions/default-layout/settings-panel/panel.tsx
@@ -163,14 +163,18 @@ export function SettingsPanel({ state, onEvent }: BuiltinComponentProps) {
                         ...eff.ui,
                         toolCallsVisibility: e.target.value as
                           | "show"
-                          | "collapse"
+                          | "group-turn"
+                          | "group-run"
+                          | "group-block"
                           | "hide",
                       },
                     })
                   }
                 >
                   <option value="show">Show</option>
-                  <option value="collapse">Collapse &amp; group</option>
+                  <option value="group-turn">Group by turn</option>
+                  <option value="group-run">Group by run</option>
+                  <option value="group-block">Group whole turn</option>
                   <option value="hide">Hide</option>
                 </select>
               </Field>

--- a/src/state/sessionUiSnapshot.test.ts
+++ b/src/state/sessionUiSnapshot.test.ts
@@ -85,7 +85,7 @@ describe("sessionUiSnapshot", () => {
       ...makeEmptyTab("tab-vis", "Vis"),
       visibilityOverrides: {
         thinking: "hide" as const,
-        toolCalls: "collapse" as const,
+        toolCalls: "group-block" as const,
       },
       hardEnforceProjectRoot: true,
     };
@@ -94,7 +94,8 @@ describe("sessionUiSnapshot", () => {
       tabs: [
         {
           id: "tab-vis",
-          visibilityOverrides: { thinking: "hide", toolCalls: "collapse" },
+          // A grouping mode (not just the legacy tri-state) must survive intact.
+          visibilityOverrides: { thinking: "hide", toolCalls: "group-block" },
           hardEnforceProjectRoot: true,
         },
       ],

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -8184,8 +8184,24 @@ button.ae-vcs-chip:focus-visible {
   background: var(--accent);
   flex: none;
 }
-.ae-vis-pill[data-mode="collapse"] .ae-vis-pill-dot {
+.ae-vis-pill[data-mode="collapse"] .ae-vis-pill-dot,
+.ae-vis-pill[data-mode="group-turn"] .ae-vis-pill-dot,
+.ae-vis-pill[data-mode="group-run"] .ae-vis-pill-dot,
+.ae-vis-pill[data-mode="group-block"] .ae-vis-pill-dot {
   background: color-mix(in oklab, var(--accent) 45%, transparent);
+}
+/* Per-session override marker — a small accent tag after the state text. */
+.ae-vis-pill[data-scope="session"] {
+  border-color: color-mix(in oklab, var(--accent) 55%, var(--border));
+}
+.ae-vis-pill-scope {
+  font-size: 9px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 1px 4px;
+  border-radius: 999px;
+  background: color-mix(in oklab, var(--accent) 20%, transparent);
+  color: var(--accent);
 }
 .ae-vis-pill[data-mode="hide"] {
   color: color-mix(in oklab, var(--text-dim) 70%, transparent);
@@ -8223,15 +8239,18 @@ button.ae-vcs-chip:focus-visible {
   z-index: 40;
 }
 .ae-vis-menu {
-  position: absolute;
-  right: 0;
-  bottom: calc(100% + 6px);
+  /* Fixed positioning so the popover escapes `.a2ui-layout-cell`'s
+     overflow:hidden clip (same trick as `.a2ui-dropdown-panel`). `bottom` /
+     `right` are set inline from the trigger's bounding rect so the menu floats
+     above the composer. */
+  position: fixed;
   z-index: 41;
-  min-width: 220px;
+  min-width: 248px;
+  max-width: calc(var(--app-viewport-width, 100vw) - 16px);
   background: var(--bg-elev);
   border: 1px solid var(--border);
   border-radius: 8px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.28);
+  box-shadow: 0 14px 40px rgba(0, 0, 0, 0.4);
   padding: 4px;
 }
 .ae-vis-menu-item {
@@ -8267,6 +8286,51 @@ button.ae-vcs-chip:focus-visible {
   margin: 4px 6px;
   background: var(--border);
 }
+.ae-vis-menu-head {
+  padding: 6px 10px 2px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+.ae-vis-menu-radios {
+  padding: 4px 10px 6px;
+}
+.ae-vis-menu-radios-label {
+  display: block;
+  font-size: 11px;
+  color: var(--text-dim);
+  margin-bottom: 4px;
+}
+.ae-vis-menu-radio-row {
+  display: flex;
+  gap: 4px;
+}
+.ae-vis-menu-radio {
+  flex: 1;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-dim);
+  font: inherit;
+  font-size: 11px;
+  padding: 4px 6px;
+  cursor: pointer;
+  transition:
+    border-color 120ms ease,
+    background 120ms ease,
+    color 120ms ease;
+}
+.ae-vis-menu-radio:hover {
+  border-color: var(--border-strong);
+  color: var(--text);
+}
+.ae-vis-menu-radio[data-checked="true"] {
+  border-color: var(--accent);
+  background: color-mix(in oklab, var(--accent) 16%, transparent);
+  color: var(--text);
+}
 
 /* ── Collapsed tool-call cluster (tool-call visibility = "collapse") ──── */
 .ae-tool-group {
@@ -8301,9 +8365,76 @@ button.ae-vcs-chip:focus-visible {
   font-size: 10px;
   opacity: 0.8;
 }
+.ae-tool-group-label {
+  font-weight: 500;
+}
+.ae-tool-group-peek {
+  min-width: 0;
+  color: var(--text-dim);
+  opacity: 0.7;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .ae-tool-group-body {
   display: flex;
   flex-direction: column;
   gap: 6px;
   padding: 0 8px 8px;
+}
+
+/* ── Folded agent turn (tool-call visibility = "group-block") ─────────── */
+.ae-turn-block {
+  border: 1px dashed var(--border);
+  border-radius: 10px;
+  width: fit-content;
+  max-width: 100%;
+}
+.ae-turn-block[data-expanded="true"] {
+  width: 100%;
+  border-style: solid;
+  background: var(--bg-elev);
+}
+.ae-turn-block-summary {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  background: transparent;
+  border: none;
+  color: var(--text-dim);
+  font: inherit;
+  font-size: 12px;
+  padding: 5px 10px;
+  cursor: pointer;
+  text-align: left;
+}
+.ae-turn-block-summary:hover {
+  color: var(--text);
+}
+.ae-turn-block-caret {
+  font-size: 10px;
+  opacity: 0.8;
+}
+.ae-turn-block-label {
+  font-weight: 500;
+  color: var(--text);
+}
+.ae-turn-block-meta {
+  color: var(--text-dim);
+  opacity: 0.85;
+}
+.ae-turn-block-peek {
+  min-width: 0;
+  color: var(--text-dim);
+  opacity: 0.7;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ae-turn-block-body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 4px 8px 10px;
 }

--- a/src/types/tab.ts
+++ b/src/types/tab.ts
@@ -1,6 +1,6 @@
 import type { ChatAttachment, ChatMessage } from "./a2ui";
 import type { ShareMode } from "../utils/shareMode";
-import type { VisibilityMode } from "../config";
+import type { ToolCallsMode, VisibilityMode } from "../config";
 
 /**
  * Per-tab transcript visibility overrides. When a field is absent (or null)
@@ -11,7 +11,7 @@ import type { VisibilityMode } from "../config";
  */
 export interface TabVisibilityOverrides {
   thinking?: VisibilityMode | null;
-  toolCalls?: VisibilityMode | null;
+  toolCalls?: ToolCallsMode | null;
 }
 
 // M6 P1: shell-tab metadata. Present iff Tab.kind === "shell".

--- a/src/utils/toolCardGrouping.test.ts
+++ b/src/utils/toolCardGrouping.test.ts
@@ -1,14 +1,15 @@
 import { describe, expect, it } from "vitest";
 import {
   groupMessages,
+  groupKey,
   isToolCardMessage,
   isRunningToolCard,
   type MessageGroup,
 } from "./toolCardGrouping";
 import type { ChatMessage } from "../types/a2ui";
 
-function text(id: string): ChatMessage {
-  return { id, role: "agent", text: `msg ${id}` };
+function text(id: string, role: ChatMessage["role"] = "agent"): ChatMessage {
+  return { id, role, text: `msg ${id}` };
 }
 
 function tool(id: string, opts: { running?: boolean } = {}): ChatMessage {
@@ -22,6 +23,8 @@ function tool(id: string, opts: { running?: boolean } = {}): ChatMessage {
 }
 
 const kinds = (groups: MessageGroup[]) => groups.map((g) => g.type);
+const ids = (g: MessageGroup): string[] =>
+  g.type === "single" ? [g.message.id] : g.messages.map((m) => m.id);
 
 describe("isToolCardMessage / isRunningToolCard", () => {
   it("detects tool cards and running state", () => {
@@ -33,14 +36,13 @@ describe("isToolCardMessage / isRunningToolCard", () => {
   });
 });
 
-describe("groupMessages", () => {
+describe("groupMessages — show / hide", () => {
   const messages = [
-    text("u1"),
+    text("u1", "user"),
     tool("t1"),
     tool("t2"),
-    tool("t3"),
     text("a1"),
-    tool("t4"),
+    tool("t3"),
   ];
 
   it("show → one single per message", () => {
@@ -51,36 +53,140 @@ describe("groupMessages", () => {
 
   it("hide → drops tool-card messages entirely", () => {
     const groups = groupMessages(messages, "hide");
-    expect(groups.map((g) => (g.type === "single" ? g.message.id : g.id))).toEqual([
-      "u1",
-      "a1",
-    ]);
+    expect(groups.flatMap(ids)).toEqual(["u1", "a1"]);
   });
+});
 
-  it("collapse → folds consecutive completed tool cards into one cluster", () => {
-    const groups = groupMessages(messages, "collapse");
-    // u1(single) | [t1,t2,t3](group) | a1(single) | t4(single, lone)
+describe("groupMessages — group-run (consecutive runs)", () => {
+  it("folds runs of ≥2 consecutive completed cards; lone card stays single", () => {
+    const groups = groupMessages(
+      [text("u1", "user"), tool("t1"), tool("t2"), tool("t3"), text("a1"), tool("t4")],
+      "group-run",
+    );
+    // u1 | [t1,t2,t3] | a1 | t4(lone)
     expect(kinds(groups)).toEqual(["single", "tool-group", "single", "single"]);
-    const cluster = groups[1];
-    expect(cluster.type === "tool-group" && cluster.messages.map((m) => m.id)).toEqual([
-      "t1",
-      "t2",
-      "t3",
-    ]);
-    expect(cluster.type === "tool-group" && cluster.id).toBe("toolgroup-t1");
+    expect(ids(groups[1])).toEqual(["t1", "t2", "t3"]);
+    expect(groups[1].type === "tool-group" && groups[1].id).toBe("toolgroup-t1");
   });
 
-  it("collapse → a lone tool card stays a single (no cluster wrapper)", () => {
-    const groups = groupMessages([text("u1"), tool("t1"), text("a1")], "collapse");
+  it("keeps a running card ungrouped after a completed run", () => {
+    const groups = groupMessages(
+      [tool("t1"), tool("t2"), tool("t3", { running: true })],
+      "group-run",
+    );
+    expect(kinds(groups)).toEqual(["tool-group", "single"]);
+  });
+});
+
+describe("groupMessages — group-turn (one cluster per turn)", () => {
+  it("gathers all of a turn's completed cards into one cluster at the first slot", () => {
+    const groups = groupMessages(
+      [
+        text("u1", "user"),
+        text("a1"),
+        tool("t1"),
+        text("a2"),
+        tool("t2"),
+        text("a3"),
+      ],
+      "group-turn",
+    );
+    // u1 | a1 | [t1,t2] (at t1's slot) | a2 | a3
+    expect(kinds(groups)).toEqual([
+      "single",
+      "single",
+      "tool-group",
+      "single",
+      "single",
+    ]);
+    expect(ids(groups[2])).toEqual(["t1", "t2"]);
+    expect(groups[2].type === "tool-group" && groups[2].id).toBe("toolgroup-t1");
+    expect(groups.map(ids).flat()).toEqual(["u1", "a1", "t1", "t2", "a2", "a3"]);
+  });
+
+  it("makes a separate cluster per turn", () => {
+    const groups = groupMessages(
+      [text("u1", "user"), tool("t1"), tool("t2"), text("u2", "user"), tool("t3"), tool("t4")],
+      "group-turn",
+    );
+    expect(kinds(groups)).toEqual(["single", "tool-group", "single", "tool-group"]);
+    expect(ids(groups[1])).toEqual(["t1", "t2"]);
+    expect(ids(groups[3])).toEqual(["t3", "t4"]);
+  });
+
+  it("leaves a turn with ≤1 completed card ungrouped", () => {
+    const groups = groupMessages(
+      [text("u1", "user"), text("a1"), tool("t1")],
+      "group-turn",
+    );
     expect(kinds(groups)).toEqual(["single", "single", "single"]);
   });
 
-  it("collapse → keeps a running tool card ungrouped so live progress shows", () => {
+  it("keeps a running card visible alongside the cluster", () => {
     const groups = groupMessages(
-      [tool("t1"), tool("t2"), tool("t3", { running: true })],
-      "collapse",
+      [text("u1", "user"), tool("t1"), tool("t2"), tool("t3", { running: true })],
+      "group-turn",
     );
-    // t1+t2 group; the running t3 stays a single after the cluster.
-    expect(kinds(groups)).toEqual(["tool-group", "single"]);
+    // u1 | [t1,t2] | t3(running)
+    expect(kinds(groups)).toEqual(["single", "tool-group", "single"]);
+    expect(ids(groups[1])).toEqual(["t1", "t2"]);
+  });
+});
+
+describe("groupMessages — group-block (whole turn folded)", () => {
+  it("folds a completed tool-using turn into one block; the last turn stays expanded", () => {
+    const groups = groupMessages(
+      [
+        text("u1", "user"),
+        text("a1"),
+        tool("t1"),
+        tool("t2"),
+        text("a2"),
+        text("u2", "user"),
+        text("a3"),
+        tool("t3"),
+      ],
+      "group-block",
+    );
+    // u1 | block([a1,t1,t2,a2]) | u2 | a3 | t3 (last turn = singles)
+    expect(kinds(groups)).toEqual([
+      "single",
+      "turn-block",
+      "single",
+      "single",
+      "single",
+    ]);
+    expect(ids(groups[1])).toEqual(["a1", "t1", "t2", "a2"]);
+    expect(groups[1].type === "turn-block" && groups[1].id).toBe("turnblock-a1");
+  });
+
+  it("does not block a turn that used no tools", () => {
+    const groups = groupMessages(
+      [text("u1", "user"), text("a1"), text("u2", "user"), text("a2"), tool("t1")],
+      "group-block",
+    );
+    expect(kinds(groups)).toEqual(["single", "single", "single", "single", "single"]);
+  });
+
+  it("blocks a leading segment that has no user message", () => {
+    const groups = groupMessages(
+      [text("a0"), tool("t0"), text("u1", "user"), text("a1"), tool("t1")],
+      "group-block",
+    );
+    // block([a0,t0]) | u1 | a1 | t1 (last turn singles)
+    expect(kinds(groups)).toEqual(["turn-block", "single", "single", "single"]);
+    expect(ids(groups[0])).toEqual(["a0", "t0"]);
+  });
+});
+
+describe("groupKey", () => {
+  it("keys singles by message id and clusters/blocks by group id", () => {
+    expect(groupKey({ type: "single", message: text("m1") })).toBe("m1");
+    expect(
+      groupKey({ type: "tool-group", id: "toolgroup-x", messages: [tool("x")] }),
+    ).toBe("toolgroup-x");
+    expect(
+      groupKey({ type: "turn-block", id: "turnblock-y", messages: [text("y")] }),
+    ).toBe("turnblock-y");
   });
 });

--- a/src/utils/toolCardGrouping.ts
+++ b/src/utils/toolCardGrouping.ts
@@ -1,14 +1,18 @@
 import type { ChatMessage } from "../types/a2ui";
-import type { VisibilityMode } from "../config";
+import type { ToolCallsMode } from "../config";
 
 /**
- * A render unit for the transcript: either a normal message rendered on its
- * own row, or a collapsible cluster of consecutive completed tool-call cards
- * (produced only in `collapse` mode).
+ * A render unit for the transcript. One of:
+ *   - `single`     — a normal message rendered on its own row;
+ *   - `tool-group` — a collapsible cluster of completed tool-call cards
+ *                    (produced by `group-run` and `group-turn`);
+ *   - `turn-block` — a whole agent turn (narration + tools) folded into one
+ *                    collapsible block (produced by `group-block`).
  */
 export type MessageGroup =
   | { type: "single"; message: ChatMessage }
-  | { type: "tool-group"; id: string; messages: ChatMessage[] };
+  | { type: "tool-group"; id: string; messages: ChatMessage[] }
+  | { type: "turn-block"; id: string; messages: ChatMessage[] };
 
 /** True when a message's A2UI payload is a tool-call card. */
 export function isToolCardMessage(m: ChatMessage): boolean {
@@ -24,7 +28,7 @@ function toolCardProps(m: ChatMessage): Record<string, unknown> | undefined {
 }
 
 /** A tool card that started but hasn't ended is still streaming — keep it
- *  visible (ungrouped) so the user can watch live progress even in collapse
+ *  visible (ungrouped) so the user can watch live progress even in a grouped
  *  mode. Mirrors ToolCard's own `running` derivation. */
 export function isRunningToolCard(m: ChatMessage): boolean {
   const props = toolCardProps(m);
@@ -33,52 +37,153 @@ export function isRunningToolCard(m: ChatMessage): boolean {
   );
 }
 
-/**
- * Transform the flat message list into render groups according to the
- * tool-call visibility mode:
- *   - `show`     → one single per message (current behaviour).
- *   - `hide`     → tool-card messages dropped entirely.
- *   - `collapse` → runs of ≥2 consecutive *completed* tool-card messages fold
- *                  into one collapsible cluster; a lone card or a running card
- *                  stays a single so live progress and one-offs read normally.
- *
- * Pure + order-preserving so it's safe to memoize and easy to test.
- */
-export function groupMessages(
-  messages: ChatMessage[],
-  mode: VisibilityMode,
-): MessageGroup[] {
-  if (mode === "show") {
-    return messages.map((message) => ({ type: "single", message }));
-  }
-  if (mode === "hide") {
-    return messages
-      .filter((m) => !isToolCardMessage(m))
-      .map((message) => ({ type: "single", message }));
-  }
+/** A completed tool card — the unit that grouping consolidates. */
+function isCompletedToolCard(m: ChatMessage): boolean {
+  return isToolCardMessage(m) && !isRunningToolCard(m);
+}
 
-  // collapse
+const single = (message: ChatMessage): MessageGroup => ({
+  type: "single",
+  message,
+});
+
+/**
+ * Split the flat list into turns. A turn boundary is a `role === "user"`
+ * message; everything from one user message up to (but not including) the next
+ * starts a new segment. Messages before the first user message form an initial
+ * segment. Each returned segment is a contiguous slice in original order.
+ */
+function segmentByTurn(messages: ChatMessage[]): ChatMessage[][] {
+  const segments: ChatMessage[][] = [];
+  let current: ChatMessage[] = [];
+  for (const m of messages) {
+    if (m.role === "user" && current.length > 0) {
+      segments.push(current);
+      current = [];
+    }
+    current.push(m);
+  }
+  if (current.length > 0) segments.push(current);
+  return segments;
+}
+
+/** `group-run`: runs of ≥2 consecutive *completed* tool cards fold into one
+ *  cluster; a lone card or a running card stays a single. This is the exact
+ *  behaviour shipped as the original tri-state `collapse`. */
+function groupRun(messages: ChatMessage[]): MessageGroup[] {
   const out: MessageGroup[] = [];
   let batch: ChatMessage[] = [];
   const flush = () => {
     if (batch.length === 0) return;
     if (batch.length === 1) {
-      out.push({ type: "single", message: batch[0] });
+      out.push(single(batch[0]));
     } else {
-      out.push({ type: "tool-group", id: `toolgroup-${batch[0].id}`, messages: batch });
+      out.push({
+        type: "tool-group",
+        id: `toolgroup-${batch[0].id}`,
+        messages: batch,
+      });
     }
     batch = [];
   };
   for (const message of messages) {
-    if (isToolCardMessage(message) && !isRunningToolCard(message)) {
+    if (isCompletedToolCard(message)) {
       batch.push(message);
     } else {
       flush();
-      out.push({ type: "single", message });
+      out.push(single(message));
     }
   }
   flush();
   return out;
+}
+
+/** `group-turn`: within each turn, all completed tool cards collapse into ONE
+ *  cluster anchored at the first card's slot; narration and any running card
+ *  stay singles in place. A turn with ≤1 completed card is left ungrouped. */
+function groupTurn(messages: ChatMessage[]): MessageGroup[] {
+  const out: MessageGroup[] = [];
+  for (const segment of segmentByTurn(messages)) {
+    const completed = segment.filter(isCompletedToolCard);
+    if (completed.length < 2) {
+      for (const m of segment) out.push(single(m));
+      continue;
+    }
+    let clusterEmitted = false;
+    for (const m of segment) {
+      if (isCompletedToolCard(m)) {
+        if (!clusterEmitted) {
+          out.push({
+            type: "tool-group",
+            id: `toolgroup-${completed[0].id}`,
+            messages: completed,
+          });
+          clusterEmitted = true;
+        }
+        // subsequent completed cards are already inside the cluster
+      } else {
+        out.push(single(m));
+      }
+    }
+  }
+  return out;
+}
+
+/** `group-block`: every *completed* turn that used at least one tool folds
+ *  into a single collapsible block (the boundary user message stays a single).
+ *  The last turn is always left expanded so an in-progress turn — streaming
+ *  text or tools — is never hidden behind a collapsed block. */
+function groupBlock(messages: ChatMessage[]): MessageGroup[] {
+  const segments = segmentByTurn(messages);
+  const lastIndex = segments.length - 1;
+  const out: MessageGroup[] = [];
+  segments.forEach((segment, i) => {
+    const hasTool = segment.some(isToolCardMessage);
+    if (i === lastIndex || !hasTool) {
+      for (const m of segment) out.push(single(m));
+      return;
+    }
+    const leadsWithUser = segment[0]?.role === "user";
+    const blockMessages = leadsWithUser ? segment.slice(1) : segment;
+    if (leadsWithUser) out.push(single(segment[0]));
+    if (blockMessages.length === 0) return;
+    out.push({
+      type: "turn-block",
+      id: `turnblock-${blockMessages[0].id}`,
+      messages: blockMessages,
+    });
+  });
+  return out;
+}
+
+/**
+ * Transform the flat message list into render groups according to the
+ * tool-call visibility mode:
+ *   - `show`        → one single per message;
+ *   - `hide`        → tool-card messages dropped entirely;
+ *   - `group-run`   → consecutive completed tool cards fold into clusters;
+ *   - `group-turn`  → all of a turn's completed tool cards fold into one
+ *                     chronological cluster;
+ *   - `group-block` → each completed tool-using turn folds into one block.
+ *
+ * Pure + order-preserving so it's safe to memoize and easy to test.
+ */
+export function groupMessages(
+  messages: ChatMessage[],
+  mode: ToolCallsMode,
+): MessageGroup[] {
+  switch (mode) {
+    case "show":
+      return messages.map(single);
+    case "hide":
+      return messages.filter((m) => !isToolCardMessage(m)).map(single);
+    case "group-run":
+      return groupRun(messages);
+    case "group-turn":
+      return groupTurn(messages);
+    case "group-block":
+      return groupBlock(messages);
+  }
 }
 
 /** Stable React key for a group. */

--- a/src/utils/visibilityResolver.test.ts
+++ b/src/utils/visibilityResolver.test.ts
@@ -11,11 +11,11 @@ describe("resolveVisibility", () => {
 
   it("reads the global default from /transcriptVisibility", () => {
     const state = {
-      transcriptVisibility: { thinking: "collapse", toolCalls: "hide" },
+      transcriptVisibility: { thinking: "collapse", toolCalls: "group-run" },
     };
     expect(resolveVisibility(state, "t1")).toEqual({
       thinking: "collapse",
-      toolCalls: "hide",
+      toolCalls: "group-run",
     });
   });
 
@@ -24,7 +24,7 @@ describe("resolveVisibility", () => {
       transcriptVisibility: { thinking: "show", toolCalls: "show" },
       tabs: [
         { id: "t1", visibilityOverrides: { thinking: "hide" } },
-        { id: "t2", visibilityOverrides: { toolCalls: "collapse" } },
+        { id: "t2", visibilityOverrides: { toolCalls: "group-block" } },
       ],
     };
     expect(resolveVisibility(state, "t1")).toEqual({
@@ -33,23 +33,51 @@ describe("resolveVisibility", () => {
     });
     expect(resolveVisibility(state, "t2")).toEqual({
       thinking: "show",
-      toolCalls: "collapse",
+      toolCalls: "group-block",
     });
   });
 
   it("treats a null override as 'follow global'", () => {
     const state = {
-      transcriptVisibility: { thinking: "collapse", toolCalls: "collapse" },
+      transcriptVisibility: { thinking: "collapse", toolCalls: "group-turn" },
       tabs: [{ id: "t1", visibilityOverrides: { thinking: null } }],
     };
     expect(resolveVisibility(state, "t1")).toEqual({
       thinking: "collapse",
-      toolCalls: "collapse",
+      toolCalls: "group-turn",
     });
   });
 
   it("clamps unknown global values to show", () => {
-    const state = { transcriptVisibility: { thinking: "yolo" } };
-    expect(resolveVisibility(state, undefined).thinking).toBe("show");
+    const state = {
+      transcriptVisibility: { thinking: "yolo", toolCalls: "group-yolo" },
+    };
+    expect(resolveVisibility(state, undefined)).toEqual({
+      thinking: "show",
+      toolCalls: "show",
+    });
+  });
+
+  it("accepts every tool grouping mode", () => {
+    for (const mode of ["group-turn", "group-run", "group-block"] as const) {
+      const state = { transcriptVisibility: { toolCalls: mode } };
+      expect(resolveVisibility(state, undefined).toolCalls).toBe(mode);
+    }
+  });
+
+  it("migrates a legacy 'collapse' tool value to group-turn (global + override)", () => {
+    // PR #204 persisted "collapse"; it now means per-turn grouping.
+    expect(
+      resolveVisibility(
+        { transcriptVisibility: { toolCalls: "collapse" } },
+        undefined,
+      ).toolCalls,
+    ).toBe("group-turn");
+    expect(
+      resolveVisibility(
+        { tabs: [{ id: "t1", visibilityOverrides: { toolCalls: "collapse" } }] },
+        "t1",
+      ).toolCalls,
+    ).toBe("group-turn");
   });
 });

--- a/src/utils/visibilityResolver.ts
+++ b/src/utils/visibilityResolver.ts
@@ -1,9 +1,14 @@
-import { normalizeVisibility, type VisibilityMode } from "../config";
+import {
+  normalizeToolCallsVisibility,
+  normalizeVisibility,
+  type ToolCallsMode,
+  type VisibilityMode,
+} from "../config";
 import type { Tab } from "../types/tab";
 
 export interface ResolvedVisibility {
   thinking: VisibilityMode;
-  toolCalls: VisibilityMode;
+  toolCalls: ToolCallsMode;
 }
 
 /**
@@ -23,12 +28,12 @@ export function resolveVisibility(
     toolCalls?: unknown;
   };
   const globalThinking = normalizeVisibility(global.thinking);
-  const globalTool = normalizeVisibility(global.toolCalls);
+  const globalTool = normalizeToolCallsVisibility(global.toolCalls);
 
   const overrides = findTabOverrides(state, tabId);
   return {
     thinking: pick(overrides?.thinking, globalThinking),
-    toolCalls: pick(overrides?.toolCalls, globalTool),
+    toolCalls: pickTool(overrides?.toolCalls, globalTool),
   };
 }
 
@@ -54,4 +59,23 @@ function pick(
     override === "hide"
     ? override
     : fallback;
+}
+
+/** Tool-call flavor of `pick`. Accepts the five tool modes; a legacy
+ *  `"collapse"` override (persisted by PR #204) migrates to `group-turn`;
+ *  null/undefined/unknown defer to the global default. Typed `unknown` because
+ *  the value can come from on-disk session snapshots that predate the enum. */
+function pickTool(override: unknown, fallback: ToolCallsMode): ToolCallsMode {
+  switch (override) {
+    case "show":
+    case "group-turn":
+    case "group-run":
+    case "group-block":
+    case "hide":
+      return override;
+    case "collapse":
+      return "group-turn";
+    default:
+      return fallback;
+  }
 }


### PR DESCRIPTION
## Summary

Follow-up to #204. Two pieces of feedback on the transcript visibility controls:

1. **Tool calls should be _grouped_, not just collapsed — and the toggle should cycle through all the grouping styles.** The old middle mode (`collapse`) only folded *consecutive runs of ≥2* tool cards, so interleaved agent narration fragmented a turn and lone cards never grouped. The Tool calls pill now cycles through **three chronological grouping styles** between `show` and `hide`:
   - **Group by turn** — all of an agent turn's completed tool calls fold into one cluster (anchored at the first call); narration stays visible.
   - **Group by run** — one cluster per consecutive run (the original `collapse` behaviour, preserved).
   - **Group whole turn** — the entire completed tool-using turn (narration + tools) folds into one block. The *last* turn always stays expanded so an in-progress turn is never hidden.

   Cycle order: `show → by turn → by run → as block → hidden`. Legacy `collapse` (config + persisted per-tab overrides) auto-migrates to `group-turn`.

2. **The "…" visibility-scope popover was confusing / not rendered right.** It was `position:absolute` opening upward out of the composer cell, which sets `overflow:hidden` — so it was clipped. It now renders `position:fixed` with trigger-rect coordinates (the same trick `DropdownPickerCore` uses) and floats above the composer uncut. Clarity: each pill shows a **per-session marker** when it overrides the global default; the menu is restructured under **This session** / **Tools** headings with direct grouping radios (Per turn / Per run / Whole turn), a **Reset this session to the global default** action, and the project-root guardrail toggle.

Frontend + config only — no agent/runtime changes.

## Changes

- **Config** — `ToolCallsMode` (`show | group-turn | group-run | group-block | hide`); `normalize_tool_visibility` (Rust) + `normalizeToolCallsVisibility` (TS) migrate legacy `collapse → group-turn`. Thinking keeps its tri-state.
- **Grouping** — `toolCardGrouping` reworked into the three strategies + a new `turn-block` render unit; `TurnBlockRow` renders a folded turn; tool-group clusters gain a tool-name peek.
- **UI** — pill cycle (category-aware), `set-tool-grouping` + `reset-to-global` routes, fixed-position popover, scope markers, 5-option View setting.
- Per-session + global persistence reuses the existing snapshot/config plumbing (overrides spread through `restoreTabRecord`, so a grouping value survives reload + restart).

## Testing

- `check` green: clippy `-D warnings`, `tsc -b`, ESLint (0 warnings), cargo test **361**, vitest **1772 / 224 files**.
- New/updated unit + integration tests: grouping across all five modes (interleaved narration, lone card, running card, multi-turn, leading no-user segment), legacy-`collapse` migration in both normalizers, category-aware cycle + `set-tool-grouping` + `reset-to-global`, mocked-Virtuoso render assertions (`2 tool calls`, `Agent turn`, name peek, hide/show), config round-trip, and a `group-block` per-tab snapshot round-trip.
- **Live UAT** on the dev build (real 118-message / 73-tool-card session):
  - Pill cycles `hide → show → by turn → by run → as block → hidden` ✓
  - Popover renders `position:fixed`, above the composer, fully on-screen, escaping the cell clip ✓
  - Grouping renders on real data: `group-run` → fragmented runs (2/2/4), `group-turn` → consolidated clusters (incl. a 7-call turn), `group-block` → 4 "Agent turn" blocks, `show`/`hide` correct ✓
  - Grouping radio reflects the active mode; **Reset** clears the override and the scope marker flips back to global ✓
  - A `group-block` per-session override **survived a full webview reload** ✓

Closes the follow-up feedback on #204.
