### PR TITLE
fix(transcript): address Copilot review on tool-call grouping

### DIFF
--- a/src/extensions/default-layout/chat.test.tsx
+++ b/src/extensions/default-layout/chat.test.tsx
@@ -823,6 +823,8 @@ describe("ChatHistory tool-call grouping (mocked Virtuoso renders rows)", () => 
       transcriptVisibility: { toolCalls: "group-block" },
     });
     expect(screen.getByText("Agent turn")).toBeTruthy();
+    // Meta counts only text-bearing replies (a1 "reading files" + a2 "done").
+    expect(screen.getByText("2 replies · 2 tool calls")).toBeTruthy();
     // The last turn stays expanded, so no group label wraps its single tool.
     expect(screen.queryByText("1 tool call")).toBeNull();
   });

--- a/src/extensions/default-layout/message-list.tsx
+++ b/src/extensions/default-layout/message-list.tsx
@@ -432,11 +432,14 @@ function ToolGroupRow({
   );
 }
 
-/** Header label for a folded agent turn: "N replies · M tool calls". */
+/** Header label for a folded agent turn: "N replies · M tool calls". Counts
+ *  only text-bearing non-tool messages as replies — a thinking-only message
+ *  may render nothing when thinking is hidden, so it shouldn't inflate the
+ *  count. */
 function turnBlockLabel(messages: ChatMessage[]): string {
   const tools = messages.filter(isToolCardMessage).length;
   const replies = messages.filter(
-    (m) => !isToolCardMessage(m) && Boolean(m.text || m.thinking),
+    (m) => !isToolCardMessage(m) && Boolean(m.text),
   ).length;
   const parts: string[] = [];
   if (replies > 0) {

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -8332,7 +8332,7 @@ button.ae-vcs-chip:focus-visible {
   color: var(--text);
 }
 
-/* ── Collapsed tool-call cluster (tool-call visibility = "collapse") ──── */
+/* ── Grouped tool-call cluster (tool visibility = "group-run" / "group-turn") ── */
 .ae-tool-group {
   border: 1px dashed var(--border);
   border-radius: 10px;

--- a/src/utils/toolCardGrouping.test.ts
+++ b/src/utils/toolCardGrouping.test.ts
@@ -168,6 +168,25 @@ describe("groupMessages — group-block (whole turn folded)", () => {
     expect(kinds(groups)).toEqual(["single", "single", "single", "single", "single"]);
   });
 
+  it("never folds a segment that still has a running tool card", () => {
+    const groups = groupMessages(
+      [
+        text("u1", "user"),
+        text("a1"),
+        tool("t1"),
+        tool("t2", { running: true }),
+        text("u2", "user"),
+        text("a2"),
+        tool("t3"),
+      ],
+      "group-block",
+    );
+    // Live progress (t2 running) must stay visible — the first turn is NOT
+    // folded despite having a tool card; only completed turns fold.
+    expect(kinds(groups).filter((k) => k === "turn-block")).toHaveLength(0);
+    expect(kinds(groups).every((k) => k === "single")).toBe(true);
+  });
+
   it("blocks a leading segment that has no user message", () => {
     const groups = groupMessages(
       [text("a0"), tool("t0"), text("u1", "user"), text("a1"), tool("t1")],

--- a/src/utils/toolCardGrouping.ts
+++ b/src/utils/toolCardGrouping.ts
@@ -139,7 +139,11 @@ function groupBlock(messages: ChatMessage[]): MessageGroup[] {
   const out: MessageGroup[] = [];
   segments.forEach((segment, i) => {
     const hasTool = segment.some(isToolCardMessage);
-    if (i === lastIndex || !hasTool) {
+    // A still-running tool card means live progress — never fold it away, even
+    // in an earlier segment (e.g. a turn that errored mid-tool and was left
+    // without an `endedAt`). Matches this mode's "completed turns" contract.
+    const hasRunning = segment.some(isRunningToolCard);
+    if (i === lastIndex || !hasTool || hasRunning) {
       for (const m of segment) out.push(single(m));
       return;
     }


### PR DESCRIPTION
## Summary

Addresses the three [Copilot review findings](https://github.com/utensils/aethon/pull/205) on #205 (which had already auto-merged on green CI before the review posted).

1. **`group-block` could hide live progress** (`toolCardGrouping.ts`). The fold condition checked `some(isToolCardMessage)`, so a non-last segment containing a *running* tool card (e.g. a turn left mid-tool without an `endedAt`) would collapse into a block and hide it. Now also skip folding when `some(isRunningToolCard)` — matching the documented "completed turns" contract. The last turn already stays expanded, so genuinely live turns were never affected; this covers the abandoned/stale-card edge.
2. **Turn-block reply count** (`message-list.tsx`). `turnBlockLabel` counted `m.text || m.thinking` as replies, but a thinking-only message renders nothing when thinking is hidden — inflating the count. Now counts only text-bearing non-tool messages.
3. **Stale CSS comment** (`chrome.css`). The `.ae-tool-group` section header still said `visibility = "collapse"`; updated to the renamed grouped modes.

## Testing

- `check` green: clippy `-D warnings`, `tsc -b`, ESLint (0 warnings), cargo test, vitest **1773 / 224 files**.
- New unit test: a `group-block` segment with a running tool card stays fully expanded (no `turn-block`).
- Tightened the mocked-Virtuoso `group-block` render test to assert the meta label (`2 replies · 2 tool calls`), locking the reply-count fix.
