### PR TITLE
feat: configurable subagents + session rollback & fork

### DIFF
--- a/agent/auth-profiles/index.ts
+++ b/agent/auth-profiles/index.ts
@@ -23,4 +23,5 @@ export {
   loadAuthProfiles,
   modelRegistryForModelId,
   saveAuthProfiles,
+  servicesForProvider,
 } from "./manager";

--- a/agent/auth-profiles/manager.ts
+++ b/agent/auth-profiles/manager.ts
@@ -1,10 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { mkdirSync } from "node:fs";
 import { dirname } from "node:path";
-import {
-  AuthStorage,
-  ModelRegistry,
-} from "@mariozechner/pi-coding-agent";
+import { AuthStorage, ModelRegistry } from "@mariozechner/pi-coding-agent";
 import type { Api, Model } from "@mariozechner/pi-ai";
 import type { AethonAgentState } from "../state";
 import type { DispatcherDeps, InboundMessage } from "../dispatcherTypes";
@@ -59,7 +56,9 @@ export function saveAuthProfiles(state: AethonAgentState): void {
   saveAuthProfilesState(state.userDir, state.authProfiles);
 }
 
-export function authProfilesSnapshot(state: AethonAgentState): AuthProfilesSnapshot {
+export function authProfilesSnapshot(
+  state: AethonAgentState,
+): AuthProfilesSnapshot {
   return {
     profiles: state.authProfiles.profiles,
     defaultByProvider: state.authProfiles.defaultByProvider,
@@ -133,6 +132,25 @@ export function modelRegistryForModelId(
     : state.modelRegistry;
 }
 
+/**
+ * Resolve the auth + model services for a *provider's* default profile,
+ * independent of any tab. Unlike {@link modelRegistryForModelId} this ignores
+ * the calling tab's profile, so a subagent on a different provider (e.g. an
+ * Ollama subagent delegated to by an OpenAI main agent) gets the matching
+ * authStorage AND modelRegistry as a pair — the model's base URL / key live on
+ * that profile's authStorage, so they must be resolved together. Falls back to
+ * the global services when the provider has no configured profile.
+ */
+export function servicesForProvider(
+  state: AethonAgentState,
+  provider: string,
+): AuthProfileServices {
+  const profileId = state.authProfiles.defaultByProvider[provider];
+  return profileId && findProfile(state, profileId)
+    ? servicesForProfile(state, profileId)
+    : { authStorage: state.authStorage, modelRegistry: state.modelRegistry };
+}
+
 export async function handleAuthProfileMessage(
   state: AethonAgentState,
   deps: DispatcherDeps,
@@ -175,7 +193,10 @@ export function emitAuthProfiles(
   state: AethonAgentState,
   deps: Pick<DispatcherDeps, "send">,
 ): void {
-  deps.send({ type: "auth_profiles", authProfiles: authProfilesSnapshot(state) });
+  deps.send({
+    type: "auth_profiles",
+    authProfiles: authProfilesSnapshot(state),
+  });
 }
 
 function servicesForProfile(
@@ -209,7 +230,10 @@ function authProfileProviders(state: AethonAgentState): AuthProfileProvider[] {
   return [...ids]
     .map((id) => ({
       id,
-      label: state.modelRegistry.getProviderDisplayName(id) || oauthIds.get(id) || id,
+      label:
+        state.modelRegistry.getProviderDisplayName(id) ||
+        oauthIds.get(id) ||
+        id,
       kind: oauthIds.has(id) ? ("oauth" as const) : ("api_key" as const),
       configured: state.modelRegistry.getProviderAuthStatus(id).configured,
       modelCount: modelCounts.get(id) ?? 0,
@@ -224,7 +248,8 @@ function handleApiKeySave(
 ): void {
   const providerId = stringField(msg.providerId);
   const key = stringField(msg.key);
-  if (!providerId || !key) throw new Error("auth_profile_api_key_save: providerId and key required");
+  if (!providerId || !key)
+    throw new Error("auth_profile_api_key_save: providerId and key required");
   const meta = createProfileMeta(state.authProfiles, {
     providerId,
     label: stringField(msg.label) || providerId,
@@ -250,7 +275,8 @@ function handleOAuthStart(
   msg: InboundMessage,
 ): void {
   const providerId = stringField(msg.providerId);
-  if (!providerId) throw new Error("auth_profile_login_start: providerId required");
+  if (!providerId)
+    throw new Error("auth_profile_login_start: providerId required");
   const meta = createProfileMeta(state.authProfiles, {
     providerId,
     label: stringField(msg.label) || providerId,
@@ -279,13 +305,26 @@ function handleOAuthStart(
       onAuth: ({ url, instructions }) => {
         deps.send({
           type: "auth_profile_login_event",
-          event: { type: "auth", challengeId, profileId: meta.id, providerId, url, instructions },
+          event: {
+            type: "auth",
+            challengeId,
+            profileId: meta.id,
+            providerId,
+            url,
+            instructions,
+          },
         });
       },
       onProgress: (message) => {
         deps.send({
           type: "auth_profile_login_event",
-          event: { type: "progress", challengeId, profileId: meta.id, providerId, message },
+          event: {
+            type: "progress",
+            challengeId,
+            profileId: meta.id,
+            providerId,
+            message,
+          },
         });
       },
       onPrompt: ({ message, placeholder, allowEmpty }) =>
@@ -336,7 +375,13 @@ function handleOAuthStart(
       state.authProfileServices.delete(meta.id);
       deps.send({
         type: "auth_profile_login_event",
-        event: { type: "complete", challengeId, profileId: meta.id, providerId, ok: true },
+        event: {
+          type: "complete",
+          challengeId,
+          profileId: meta.id,
+          providerId,
+          ok: true,
+        },
       });
       emitAuthProfiles(state, deps);
     })
@@ -347,7 +392,14 @@ function handleOAuthStart(
       const message = err instanceof Error ? err.message : String(err);
       deps.send({
         type: "auth_profile_login_event",
-        event: { type: "complete", challengeId, profileId: meta.id, providerId, ok: false, error: message },
+        event: {
+          type: "complete",
+          challengeId,
+          profileId: meta.id,
+          providerId,
+          ok: false,
+          error: message,
+        },
       });
       emitAuthProfiles(state, deps);
     });
@@ -404,7 +456,8 @@ async function handleUseForTab(
   state.tabAuthProfileIds.set(tabId, profile.id);
   const services = servicesForProfile(state, profile.id);
   const nextModel =
-    previousModel && services.modelRegistry.find(previousModel.provider, previousModel.id);
+    previousModel &&
+    services.modelRegistry.find(previousModel.provider, previousModel.id);
   const rec = await ensureTab(state, deps, tabId, {
     cwdOverride: cwd,
     initialModel: nextModel || previousModel,
@@ -466,7 +519,9 @@ function handleDelete(
     if (activeProfileId !== profileId) continue;
     const tab = state.tabs.get(tabId);
     if (tab?.promptInFlight) {
-      throw new Error("Cannot delete an account while one of its sessions is running.");
+      throw new Error(
+        "Cannot delete an account while one of its sessions is running.",
+      );
     }
   }
   removeProfile(state, profileId);

--- a/agent/chat.ts
+++ b/agent/chat.ts
@@ -9,6 +9,7 @@ import {
   ensureTab,
 } from "./tab-lifecycle";
 import { modelRegistryForModelId } from "./auth-profiles";
+import { detectSubagentMention } from "./subagents/steer";
 import { emitContextUsage } from "./context-usage";
 
 export async function handleChat(
@@ -25,6 +26,12 @@ export async function handleChat(
   // the current value before this turn's tool calls (and survives a respawn).
   if (typeof msg.hardEnforce === "boolean") {
     state.tabHardEnforce.set(tabId, msg.hardEnforce);
+  }
+  // Explicit `@name` subagent invocation: record a one-shot steer consumed by
+  // the before_agent_start hook so this turn delegates to that subagent.
+  const mention = detectSubagentMention(msg.content);
+  if (mention && state.subagents.has(mention)) {
+    state.pendingExplicitSubagent.set(tabId, mention);
   }
   const cwdOverride =
     typeof msg.cwd === "string" && msg.cwd.length > 0 ? msg.cwd : undefined;

--- a/agent/chat.ts
+++ b/agent/chat.ts
@@ -10,6 +10,7 @@ import {
 } from "./tab-lifecycle";
 import { modelRegistryForModelId } from "./auth-profiles";
 import { detectSubagentMention } from "./subagents/steer";
+import { getSubagentsForCwd } from "./subagents";
 import { emitContextUsage } from "./context-usage";
 
 export async function handleChat(
@@ -29,9 +30,13 @@ export async function handleChat(
   }
   // Explicit `@name` subagent invocation: record a one-shot steer consumed by
   // the before_agent_start hook so this turn delegates to that subagent.
+  // Resolve against this tab's cwd so the mention matches the tab's project.
   const mention = detectSubagentMention(msg.content);
-  if (mention && state.subagents.has(mention)) {
-    state.pendingExplicitSubagent.set(tabId, mention);
+  if (mention) {
+    const tabCwd = state.tabProjectCwds.get(tabId) ?? state.currentProjectCwd;
+    if (getSubagentsForCwd(state, tabCwd).byName.has(mention)) {
+      state.pendingExplicitSubagent.set(tabId, mention);
+    }
   }
   const cwdOverride =
     typeof msg.cwd === "string" && msg.cwd.length > 0 ? msg.cwd : undefined;

--- a/agent/dispatcher.ts
+++ b/agent/dispatcher.ts
@@ -14,6 +14,7 @@ import { handleSetExtensionDisabled } from "./extensionControl";
 import { ackMutation, markFrontendReady } from "./mutation-ack";
 import { onDevshellEvent } from "./devshell";
 import { handleSubagentsChanged } from "./subagents/changed";
+import { handleForkSession, handleRollbackSession } from "./session-branch";
 import { handleNativeSlashCommand } from "./nativeSlash";
 import { handleSetProject } from "./projectLifecycle";
 import { handleAuthProfileMessage } from "./auth-profiles";
@@ -195,6 +196,12 @@ export async function dispatchInboundMessage(
         break;
       case "subagents_changed":
         await handleSubagentsChanged(state, deps);
+        break;
+      case "rollback_session":
+        await handleRollbackSession(state, deps, msg);
+        break;
+      case "fork_session":
+        await handleForkSession(state, deps, msg);
         break;
       case "devshell_event": {
         const status = msg.devshellStatus;

--- a/agent/dispatcher.ts
+++ b/agent/dispatcher.ts
@@ -13,6 +13,7 @@ import { emitGlobalReady, maybeExitForReload } from "./dispatcherTypes";
 import { handleSetExtensionDisabled } from "./extensionControl";
 import { ackMutation, markFrontendReady } from "./mutation-ack";
 import { onDevshellEvent } from "./devshell";
+import { handleSubagentsChanged } from "./subagents/changed";
 import { handleNativeSlashCommand } from "./nativeSlash";
 import { handleSetProject } from "./projectLifecycle";
 import { handleAuthProfileMessage } from "./auth-profiles";
@@ -191,6 +192,9 @@ export async function dispatchInboundMessage(
         break;
       case "local_chat_message":
         await handleLocalChatMessage(state, deps, msg);
+        break;
+      case "subagents_changed":
+        await handleSubagentsChanged(state, deps);
         break;
       case "devshell_event": {
         const status = msg.devshellStatus;

--- a/agent/dispatcherTypes.ts
+++ b/agent/dispatcherTypes.ts
@@ -41,6 +41,8 @@ export interface InboundMessage {
   args?: string;
   id?: string;
   tabId?: string;
+  /** pi session entry id — carried on `rollback_session` / `fork_session`. */
+  entryId?: string;
   componentType?: string;
   template?: unknown;
   path?: string;

--- a/agent/main.ts
+++ b/agent/main.ts
@@ -82,6 +82,8 @@ import {
   discoverPiAethonExtensions,
 } from "./extension-loader";
 import { ensureTab, emitReady, tabSessionDir } from "./tab-lifecycle";
+import { refreshSubagents } from "./subagents";
+import { buildExplicitSubagentSteer } from "./subagents/steer";
 import { loadDisabledExtensionsSnapshot } from "./disabled-extensions";
 import { captureProjectExtensionBaseline, runDispatcher } from "./dispatcher";
 
@@ -217,7 +219,19 @@ async function main(): Promise<void> {
         git,
         softAnchor: softGuardrailPrompt,
       });
-      return { systemPrompt: `${event.systemPrompt}\n\n${section}` };
+      let systemPrompt = `${event.systemPrompt}\n\n${section}`;
+      // Explicit @name invocation: consume the one-shot steer for this tab
+      // (clearing it prevents the subagent's own turn from re-triggering it).
+      if (tabId) {
+        const explicit = state.pendingExplicitSubagent.get(tabId);
+        if (explicit && state.subagents.has(explicit)) {
+          state.pendingExplicitSubagent.delete(tabId);
+          systemPrompt += `\n\n${buildExplicitSubagentSteer(explicit)}`;
+        } else if (explicit) {
+          state.pendingExplicitSubagent.delete(tabId);
+        }
+      }
+      return { systemPrompt };
     });
   };
 
@@ -307,6 +321,9 @@ async function main(): Promise<void> {
     loadHooks,
   );
   state.currentProjectCwd = startupCwd;
+  // Merge user + project subagents before the reload so the very first turn's
+  // system prompt already advertises them.
+  refreshSubagents(state);
 
   // Reload so the appendSystemPromptOverride sees the populated extensions.
   await state.resourceLoader.reload();

--- a/agent/main.ts
+++ b/agent/main.ts
@@ -56,7 +56,10 @@ import {
 
 import { logger } from "./logger";
 import { resolveStateLimits } from "./state-limits";
-import { resolveAethonSystemPrompt } from "./system-prompt";
+import {
+  buildSubagentsSection,
+  resolveAethonSystemPrompt,
+} from "./system-prompt";
 import { buildWorkingContextSection } from "./system-prompt/working-context";
 import { getWorkingContext } from "./git-context";
 import { readSessionTranscript } from "./session-history";
@@ -82,7 +85,7 @@ import {
   discoverPiAethonExtensions,
 } from "./extension-loader";
 import { ensureTab, emitReady, tabSessionDir } from "./tab-lifecycle";
-import { refreshSubagents } from "./subagents";
+import { getSubagentsForCwd } from "./subagents";
 import { buildExplicitSubagentSteer } from "./subagents/steer";
 import { loadDisabledExtensionsSnapshot } from "./disabled-extensions";
 import { captureProjectExtensionBaseline, runDispatcher } from "./dispatcher";
@@ -220,11 +223,17 @@ async function main(): Promise<void> {
         softAnchor: softGuardrailPrompt,
       });
       let systemPrompt = `${event.systemPrompt}\n\n${section}`;
+      // Advertise the subagents available for THIS tab's cwd, per turn — so a
+      // tab on project A never sees project B's subagents even after B opens
+      // (the static system-prompt snapshot can't be per-tab).
+      const subagents = getSubagentsForCwd(state, resolvedCwd).byName;
+      const advert = buildSubagentsSection([...subagents.values()]);
+      if (advert) systemPrompt += `\n\n${advert}`;
       // Explicit @name invocation: consume the one-shot steer for this tab
       // (clearing it prevents the subagent's own turn from re-triggering it).
       if (tabId) {
         const explicit = state.pendingExplicitSubagent.get(tabId);
-        if (explicit && state.subagents.has(explicit)) {
+        if (explicit && subagents.has(explicit)) {
           state.pendingExplicitSubagent.delete(tabId);
           systemPrompt += `\n\n${buildExplicitSubagentSteer(explicit)}`;
         } else if (explicit) {
@@ -321,9 +330,6 @@ async function main(): Promise<void> {
     loadHooks,
   );
   state.currentProjectCwd = startupCwd;
-  // Merge user + project subagents before the reload so the very first turn's
-  // system prompt already advertises them.
-  refreshSubagents(state);
 
   // Reload so the appendSystemPromptOverride sees the populated extensions.
   await state.resourceLoader.reload();

--- a/agent/projectLifecycle.ts
+++ b/agent/projectLifecycle.ts
@@ -9,7 +9,6 @@ import { loadProjectAethonExtensions } from "./extension-loader";
 import { patchLayoutTree } from "./layout-manager";
 import { logger } from "./logger";
 import { dismissNotification, notify } from "./notifications";
-import { refreshSubagents } from "./subagents";
 
 export function projectDisplayName(cwd: string): string {
   const trimmed = cwd.replace(/[\\/]+$/, "");
@@ -226,7 +225,6 @@ export async function handleSetProject(
     if (state.currentProjectCwd !== null) {
       unloadProjectExtensions(state, deps);
       state.currentProjectCwd = null;
-      refreshSubagents(state);
       await state.resourceLoader.reload();
       deps.scheduleStateFileWrite();
       emitGlobalReady(state, deps);
@@ -284,8 +282,6 @@ export async function handleSetProject(
       );
   }
   state.currentProjectCwd = cwd;
-  // Re-merge subagents so project-scoped definitions follow the active cwd.
-  if (projectChanged) refreshSubagents(state);
   if (
     result.loaded > 0 ||
     result.failed > 0 ||

--- a/agent/projectLifecycle.ts
+++ b/agent/projectLifecycle.ts
@@ -9,6 +9,7 @@ import { loadProjectAethonExtensions } from "./extension-loader";
 import { patchLayoutTree } from "./layout-manager";
 import { logger } from "./logger";
 import { dismissNotification, notify } from "./notifications";
+import { refreshSubagents } from "./subagents";
 
 export function projectDisplayName(cwd: string): string {
   const trimmed = cwd.replace(/[\\/]+$/, "");
@@ -225,6 +226,7 @@ export async function handleSetProject(
     if (state.currentProjectCwd !== null) {
       unloadProjectExtensions(state, deps);
       state.currentProjectCwd = null;
+      refreshSubagents(state);
       await state.resourceLoader.reload();
       deps.scheduleStateFileWrite();
       emitGlobalReady(state, deps);
@@ -282,6 +284,8 @@ export async function handleSetProject(
       );
   }
   state.currentProjectCwd = cwd;
+  // Re-merge subagents so project-scoped definitions follow the active cwd.
+  if (projectChanged) refreshSubagents(state);
   if (
     result.loaded > 0 ||
     result.failed > 0 ||

--- a/agent/runtime-snapshot.test.ts
+++ b/agent/runtime-snapshot.test.ts
@@ -59,22 +59,35 @@ describe("getRuntimeSnapshot", () => {
 
   it("includes configured subagents", () => {
     const state = new AethonAgentState(makeOpts("/tmp/aethon-sa"));
-    state.subagents.set("reviewer", {
-      name: "reviewer",
-      description: "Reviews diffs",
-      model: "ollama/llama3.3",
-      surface: "inline",
-      systemPrompt: "You review.",
-      scope: "user",
-      filePath: "/agents/reviewer.md",
-    });
-    state.subagents.set("builder", {
-      name: "builder",
-      description: "Builds features",
-      surface: "tab",
-      systemPrompt: "You build.",
-      scope: "project",
-      filePath: "/proj/.aethon/agents/builder.md",
+    // The snapshot reads the active project's cwd cache (currentProjectCwd is
+    // null here, so the resolver keys on ""). Seed it directly.
+    state.subagentsByCwd.set("", {
+      byName: new Map([
+        [
+          "reviewer",
+          {
+            name: "reviewer",
+            description: "Reviews diffs",
+            model: "ollama/llama3.3",
+            surface: "inline",
+            systemPrompt: "You review.",
+            scope: "user",
+            filePath: "/agents/reviewer.md",
+          },
+        ],
+        [
+          "builder",
+          {
+            name: "builder",
+            description: "Builds features",
+            surface: "tab",
+            systemPrompt: "You build.",
+            scope: "project",
+            filePath: "/proj/.aethon/agents/builder.md",
+          },
+        ],
+      ]),
+      issues: [],
     });
     const snap = getRuntimeSnapshot(state);
     expect(snap.subagents).toEqual([

--- a/agent/runtime-snapshot.test.ts
+++ b/agent/runtime-snapshot.test.ts
@@ -7,10 +7,7 @@ import {
   type AethonAgentStateOptions,
   type TabRecord,
 } from "./state";
-import {
-  getRuntimeSnapshot,
-  scheduleStateFileWrite,
-} from "./runtime-snapshot";
+import { getRuntimeSnapshot, scheduleStateFileWrite } from "./runtime-snapshot";
 
 function makeOpts(userDir: string): AethonAgentStateOptions {
   return {
@@ -38,6 +35,7 @@ describe("getRuntimeSnapshot", () => {
     expect(snap.extensions).toEqual([]);
     expect(snap.themes).toEqual([]);
     expect(snap.components).toEqual([]);
+    expect(snap.subagents).toEqual([]);
     expect(snap.tabs).toEqual([]);
     expect(snap.eventRoutingMode).toBe("builtin");
     expect(snap.layoutStructure).toBeNull();
@@ -57,6 +55,37 @@ describe("getRuntimeSnapshot", () => {
     expect(snap.extensions).toEqual([{ name: "hello", source: "directory" }]);
     expect(snap.themes).toEqual([{ id: "twilight", label: "Twilight" }]);
     expect(snap.components).toEqual(["card-x"]);
+  });
+
+  it("includes configured subagents", () => {
+    const state = new AethonAgentState(makeOpts("/tmp/aethon-sa"));
+    state.subagents.set("reviewer", {
+      name: "reviewer",
+      description: "Reviews diffs",
+      model: "ollama/llama3.3",
+      surface: "inline",
+      systemPrompt: "You review.",
+      scope: "user",
+      filePath: "/agents/reviewer.md",
+    });
+    state.subagents.set("builder", {
+      name: "builder",
+      description: "Builds features",
+      surface: "tab",
+      systemPrompt: "You build.",
+      scope: "project",
+      filePath: "/proj/.aethon/agents/builder.md",
+    });
+    const snap = getRuntimeSnapshot(state);
+    expect(snap.subagents).toEqual([
+      {
+        name: "reviewer",
+        description: "Reviews diffs",
+        model: "ollama/llama3.3",
+        surface: "inline",
+      },
+      { name: "builder", description: "Builds features", surface: "tab" },
+    ]);
   });
 
   it("annotates each tab with its per-tab working directory", () => {

--- a/agent/runtime-snapshot.ts
+++ b/agent/runtime-snapshot.ts
@@ -23,6 +23,7 @@ import type { AethonAgentState } from "./state";
 import type { RuntimeSnapshot } from "./system-prompt";
 import { logger } from "./logger";
 import { summarizeLayout, summarizeLayoutStructure } from "./layout-manager";
+import { getSubagentsForCwd } from "./subagents";
 
 const STATE_FILE_DEBOUNCE_MS = 200;
 
@@ -60,7 +61,11 @@ export function getRuntimeSnapshot(state: AethonAgentState): RuntimeSnapshot {
       id: t.id,
       label: t.label,
     })),
-    subagents: [...state.subagents.values()].map((s) => ({
+    // Introspection / state-file view of the active project's subagents (the
+    // prompt advertisement is injected per-turn per-tab-cwd, see system-prompt).
+    subagents: [
+      ...getSubagentsForCwd(state, state.currentProjectCwd).byName.values(),
+    ].map((s) => ({
       name: s.name,
       description: s.description,
       ...(s.model ? { model: s.model } : {}),

--- a/agent/runtime-snapshot.ts
+++ b/agent/runtime-snapshot.ts
@@ -60,6 +60,12 @@ export function getRuntimeSnapshot(state: AethonAgentState): RuntimeSnapshot {
       id: t.id,
       label: t.label,
     })),
+    subagents: [...state.subagents.values()].map((s) => ({
+      name: s.name,
+      description: s.description,
+      ...(s.model ? { model: s.model } : {}),
+      surface: s.surface,
+    })),
     components: [...state.extensionComponents.keys()],
     layoutSummary: summarizeLayout(state),
     tabs: [...state.tabs.values()].map((t) => ({

--- a/agent/session-branch.test.ts
+++ b/agent/session-branch.test.ts
@@ -1,0 +1,176 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { handleForkSession, handleRollbackSession } from "./session-branch";
+import type { AethonAgentState } from "./state";
+import type { DispatcherDeps, InboundMessage } from "./dispatcherTypes";
+
+let sessionsDir: string;
+
+function makeDeps() {
+  const sent: Record<string, unknown>[] = [];
+  const deps = {
+    send: (m: Record<string, unknown>) => sent.push(m),
+    scheduleStateFileWrite: () => {},
+    loadHooks: {},
+  } as unknown as DispatcherDeps;
+  return { deps, sent };
+}
+
+interface FakeSm {
+  getEntry: ReturnType<typeof vi.fn>;
+  branch: ReturnType<typeof vi.fn>;
+  createBranchedSession: ReturnType<typeof vi.fn>;
+}
+
+function makeState(opts?: {
+  streaming?: boolean;
+  promptInFlight?: boolean;
+  branchedPath?: string | undefined;
+  hasTab?: boolean;
+}): { state: AethonAgentState; sm: FakeSm; abort: ReturnType<typeof vi.fn> } {
+  const sm: FakeSm = {
+    getEntry: vi.fn((id: string) =>
+      id === "e2"
+        ? { id: "e2", timestamp: "2026-06-02T13:00:00.000Z" }
+        : undefined,
+    ),
+    branch: vi.fn(),
+    createBranchedSession: vi.fn(() =>
+      opts && "branchedPath" in opts
+        ? opts.branchedPath
+        : join(sessionsDir, "t1", "branch.jsonl"),
+    ),
+  };
+  const abort = vi.fn(() => Promise.resolve());
+  const session = {
+    sessionManager: sm,
+    abort,
+    isStreaming: opts?.streaming ?? false,
+  };
+  const tab = {
+    id: "t1",
+    session,
+    promptInFlight: opts?.promptInFlight ?? false,
+    agentEndFired: false,
+    queuedCount: 0,
+  };
+  const tabs = new Map<string, unknown>();
+  if (opts?.hasTab !== false) tabs.set("t1", tab);
+  const state = {
+    sessionsDir,
+    tabs,
+    tabProjectCwds: new Map([["t1", "/proj"]]),
+    currentAgentTabId: undefined,
+  } as unknown as AethonAgentState;
+  return { state, sm, abort };
+}
+
+function msg(extra: Partial<InboundMessage>): InboundMessage {
+  return { type: "x", ...extra };
+}
+
+beforeEach(() => {
+  sessionsDir = mkdtempSync(join(tmpdir(), "aethon-branch-"));
+});
+
+afterEach(() => {
+  rmSync(sessionsDir, { recursive: true, force: true });
+});
+
+describe("handleRollbackSession", () => {
+  it("branches at the entry and emits session_rolled_back", async () => {
+    const { state, sm } = makeState();
+    const { deps, sent } = makeDeps();
+    await handleRollbackSession(
+      state,
+      deps,
+      msg({ tabId: "t1", entryId: "e2" }),
+    );
+    expect(sm.branch).toHaveBeenCalledWith("e2");
+    expect(sent).toContainEqual({
+      type: "session_rolled_back",
+      tabId: "t1",
+      entryId: "e2",
+    });
+  });
+
+  it("aborts an in-flight turn before branching", async () => {
+    const { state, sm, abort } = makeState({ promptInFlight: true });
+    const { deps } = makeDeps();
+    await handleRollbackSession(
+      state,
+      deps,
+      msg({ tabId: "t1", entryId: "e2" }),
+    );
+    expect(abort).toHaveBeenCalled();
+    expect(sm.branch).toHaveBeenCalledWith("e2");
+  });
+
+  it("errors on an unknown entry without branching", async () => {
+    const { state, sm } = makeState();
+    const { deps, sent } = makeDeps();
+    await handleRollbackSession(
+      state,
+      deps,
+      msg({ tabId: "t1", entryId: "ghost" }),
+    );
+    expect(sm.branch).not.toHaveBeenCalled();
+    expect(sent.some((m) => m.type === "error")).toBe(true);
+  });
+
+  it("errors on an unknown tab", async () => {
+    const { state } = makeState({ hasTab: false });
+    const { deps, sent } = makeDeps();
+    await handleRollbackSession(
+      state,
+      deps,
+      msg({ tabId: "t1", entryId: "e2" }),
+    );
+    expect(sent.some((m) => m.type === "error")).toBe(true);
+  });
+
+  it("requires tabId and entryId", async () => {
+    const { state } = makeState();
+    const { deps, sent } = makeDeps();
+    await handleRollbackSession(state, deps, msg({ tabId: "t1" }));
+    expect(sent.some((m) => m.type === "error")).toBe(true);
+  });
+});
+
+describe("handleForkSession", () => {
+  it("creates a branched session and emits session_forked", async () => {
+    const { state, sm } = makeState();
+    const { deps, sent } = makeDeps();
+    await handleForkSession(state, deps, msg({ tabId: "t1", entryId: "e2" }));
+    expect(sm.createBranchedSession).toHaveBeenCalledWith("e2");
+    const forked = sent.find((m) => m.type === "session_forked");
+    expect(forked).toBeTruthy();
+    expect(typeof forked?.newTabId).toBe("string");
+    expect((forked?.newTabId as string).length).toBeGreaterThan(0);
+    expect(forked?.sourcePath).toBe(join(sessionsDir, "t1", "branch.jsonl"));
+    expect(forked?.label).toMatch(/^Fork of /);
+    expect(forked?.cwd).toBe("/proj");
+  });
+
+  it("errors when the session is in-memory (no branched path)", async () => {
+    const { state } = makeState({ branchedPath: undefined });
+    const { deps, sent } = makeDeps();
+    await handleForkSession(state, deps, msg({ tabId: "t1", entryId: "e2" }));
+    expect(sent.some((m) => m.type === "error")).toBe(true);
+    expect(sent.some((m) => m.type === "session_forked")).toBe(false);
+  });
+
+  it("errors on an unknown entry", async () => {
+    const { state, sm } = makeState();
+    const { deps, sent } = makeDeps();
+    await handleForkSession(
+      state,
+      deps,
+      msg({ tabId: "t1", entryId: "ghost" }),
+    );
+    expect(sm.createBranchedSession).not.toHaveBeenCalled();
+    expect(sent.some((m) => m.type === "error")).toBe(true);
+  });
+});

--- a/agent/session-branch.ts
+++ b/agent/session-branch.ts
@@ -1,0 +1,194 @@
+/**
+ * Session branching — rollback and fork.
+ *
+ * Both are thin wrappers over pi's `SessionManager`:
+ *  - rollback: `branch(entryId)` rewinds the active session's leaf to an
+ *    earlier message. Non-destructive — the abandoned path stays in the file,
+ *    so a later restore still sees it; we just realign the Aethon-local chat
+ *    so it doesn't resurrect post-rollback rows.
+ *  - fork: `createBranchedSession(entryId)` extracts the path root→entry into a
+ *    fresh jsonl (in the source tab's dir) *without* disturbing the source
+ *    session. The frontend then moves that file into a new tab's dir (via the
+ *    `copy_session_file` Rust command) and opens the tab.
+ */
+
+import { randomUUID } from "node:crypto";
+import { mkdirSync } from "node:fs";
+import type { AethonAgentState, TabRecord } from "./state";
+import type { DispatcherDeps, InboundMessage } from "./dispatcherTypes";
+import { tabSessionDir } from "./tab-lifecycle";
+import {
+  readSessionLabel,
+  truncateLocalChatAfterEntry,
+  writeSessionLabel,
+} from "./session-history";
+
+function stringField(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function isSessionBusy(tab: TabRecord): boolean {
+  const flags = tab.session as { isStreaming?: unknown; isRetrying?: unknown };
+  return (
+    tab.promptInFlight ||
+    tab.aethonRetryInFlight === true ||
+    flags.isStreaming === true ||
+    flags.isRetrying === true
+  );
+}
+
+function parseEntryTimestamp(entry: {
+  timestamp?: unknown;
+}): number | undefined {
+  const ts = entry.timestamp;
+  if (typeof ts === "number" && Number.isFinite(ts)) return ts;
+  if (typeof ts === "string") {
+    const parsed = Date.parse(ts);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+}
+
+export async function handleRollbackSession(
+  state: AethonAgentState,
+  deps: DispatcherDeps,
+  msg: InboundMessage,
+): Promise<void> {
+  const tabId = stringField(msg.tabId);
+  const entryId = stringField(msg.entryId);
+  if (!tabId || !entryId) {
+    deps.send({
+      type: "error",
+      message: "rollback_session: tabId and entryId required",
+    });
+    return;
+  }
+  const tab = state.tabs.get(tabId);
+  if (!tab) {
+    deps.send({
+      type: "error",
+      tabId,
+      message: "rollback_session: unknown tab",
+    });
+    return;
+  }
+  const sm = tab.session.sessionManager;
+  const entry = sm.getEntry(entryId);
+  if (!entry) {
+    deps.send({
+      type: "error",
+      tabId,
+      message: `rollback_session: unknown entry ${entryId}`,
+    });
+    return;
+  }
+  // Abort any in-flight turn before mutating the branch.
+  if (isSessionBusy(tab)) {
+    try {
+      await tab.session.abort();
+    } catch {
+      /* best effort — we're rewinding anyway */
+    }
+    tab.promptInFlight = false;
+    tab.agentEndFired = true;
+    tab.queuedCount = 0;
+    if (state.currentAgentTabId === tabId) state.currentAgentTabId = undefined;
+  }
+  try {
+    sm.branch(entryId);
+  } catch (err) {
+    deps.send({
+      type: "error",
+      tabId,
+      message: `rollback_session: ${(err as Error).message}`,
+    });
+    return;
+  }
+  const cutoff = parseEntryTimestamp(entry);
+  if (cutoff !== undefined) {
+    await truncateLocalChatAfterEntry(
+      tabSessionDir(state, tabId),
+      cutoff,
+    ).catch(() => {
+      /* best effort */
+    });
+  }
+  deps.send({ type: "session_rolled_back", tabId, entryId });
+}
+
+function forkLabel(srcLabel: string | undefined): string {
+  const base = srcLabel?.trim() ? srcLabel.trim() : "session";
+  return `Fork of ${base}`.slice(0, 120);
+}
+
+export async function handleForkSession(
+  state: AethonAgentState,
+  deps: DispatcherDeps,
+  msg: InboundMessage,
+): Promise<void> {
+  const tabId = stringField(msg.tabId);
+  const entryId = stringField(msg.entryId);
+  if (!tabId || !entryId) {
+    deps.send({
+      type: "error",
+      message: "fork_session: tabId and entryId required",
+    });
+    return;
+  }
+  const tab = state.tabs.get(tabId);
+  if (!tab) {
+    deps.send({ type: "error", tabId, message: "fork_session: unknown tab" });
+    return;
+  }
+  const sm = tab.session.sessionManager;
+  if (!sm.getEntry(entryId)) {
+    deps.send({
+      type: "error",
+      tabId,
+      message: `fork_session: unknown entry ${entryId}`,
+    });
+    return;
+  }
+  let sourcePath: string | undefined;
+  try {
+    sourcePath = sm.createBranchedSession(entryId);
+  } catch (err) {
+    deps.send({
+      type: "error",
+      tabId,
+      message: `fork_session: ${(err as Error).message}`,
+    });
+    return;
+  }
+  if (!sourcePath) {
+    deps.send({
+      type: "error",
+      tabId,
+      message: "fork_session: cannot fork an in-memory session",
+    });
+    return;
+  }
+  const newTabId = randomUUID();
+  const newDir = tabSessionDir(state, newTabId);
+  try {
+    mkdirSync(newDir, { recursive: true });
+  } catch {
+    /* the Rust copy command also creates it */
+  }
+  const srcLabel = await readSessionLabel(tabSessionDir(state, tabId)).catch(
+    () => undefined,
+  );
+  const label = forkLabel(srcLabel);
+  await writeSessionLabel(newDir, label).catch(() => {
+    /* best effort */
+  });
+  const cwd = state.tabProjectCwds.get(tabId);
+  deps.send({
+    type: "session_forked",
+    tabId,
+    newTabId,
+    sourcePath,
+    label,
+    ...(cwd ? { cwd } : {}),
+  });
+}

--- a/agent/session-history.test.ts
+++ b/agent/session-history.test.ts
@@ -65,9 +65,10 @@ describe("parseSessionHistoryLines", () => {
     ];
 
     expect(parseSessionHistoryLines(lines)).toEqual([
-      { id: "u1", role: "user", text: "hello" },
+      { id: "u1", entryId: "u1", role: "user", text: "hello" },
       {
         id: "a1",
+        entryId: "a1",
         role: "agent",
         text: "Hi there.",
         thinking: "hidden reasoning",
@@ -251,6 +252,7 @@ describe("parseSessionHistoryLines", () => {
     expect(parsed).toEqual([
       {
         id: "before",
+        entryId: "before",
         role: "agent",
         text: "before compaction",
         createdAt: Date.parse("2026-06-02T13:23:02.101Z"),
@@ -278,7 +280,12 @@ describe("parseSessionHistoryLines", () => {
 
     const parsed = parseSessionHistoryLines(lines);
     expect(parsed).toHaveLength(200);
-    expect(parsed[0]).toEqual({ id: "m5", role: "user", text: "message 5" });
+    expect(parsed[0]).toEqual({
+      id: "m5",
+      entryId: "m5",
+      role: "user",
+      text: "message 5",
+    });
   });
 });
 
@@ -310,7 +317,7 @@ describe("readSessionTranscript", () => {
     await utimes(newPath, new Date(2_000), new Date(2_000));
 
     await expect(readSessionTranscript(dir)).resolves.toEqual([
-      { id: "new", role: "agent", text: "new" },
+      { id: "new", entryId: "new", role: "agent", text: "new" },
     ]);
   });
 
@@ -339,7 +346,7 @@ describe("readSessionTranscript", () => {
     });
 
     await expect(readSessionTranscript(dir)).resolves.toEqual([
-      { id: "pi-user", role: "user", text: "hi" },
+      { id: "pi-user", entryId: "pi-user", role: "user", text: "hi" },
       { id: "slash-user", role: "user", text: "/context", createdAt: 1 },
       {
         id: "slash-output",
@@ -381,14 +388,14 @@ describe("readSessionTranscript", () => {
     });
 
     await expect(readSessionTranscript(dir)).resolves.toEqual([
-      { id: "pi-user", role: "user", text: "hi", createdAt: 1_000 },
+      { id: "pi-user", entryId: "pi-user", role: "user", text: "hi", createdAt: 1_000 },
       {
         id: "stderr-warning",
         role: "system",
         text: "[agent stderr] transient provider error",
         createdAt: 2_000,
       },
-      { id: "pi-agent", role: "agent", text: "done", createdAt: 3_000 },
+      { id: "pi-agent", entryId: "pi-agent", role: "agent", text: "done", createdAt: 3_000 },
     ]);
   });
 
@@ -436,14 +443,14 @@ describe("readSessionTranscript", () => {
     });
 
     await expect(readSessionTranscript(dir)).resolves.toEqual([
-      { id: "pi-user", role: "user", text: "hi", createdAt: 1_000 },
+      { id: "pi-user", entryId: "pi-user", role: "user", text: "hi", createdAt: 1_000 },
       {
         id: "compaction:cmp-1",
         role: "system",
         text: "Context compacted · 13,005 tokens summarized",
         createdAt: 2_000,
       },
-      { id: "pi-agent", role: "agent", text: "done", createdAt: 3_000 },
+      { id: "pi-agent", entryId: "pi-agent", role: "agent", text: "done", createdAt: 3_000 },
     ]);
   });
 
@@ -550,6 +557,7 @@ describe("readSessionTranscript", () => {
     await expect(readSessionTranscript(dir)).resolves.toEqual([
       {
         id: "pi-user",
+        entryId: "pi-user",
         role: "user",
         text: "what is this?",
         createdAt: 1_500,
@@ -596,8 +604,13 @@ describe("readSessionTranscript", () => {
     });
 
     await expect(readSessionTranscript(dir)).resolves.toEqual([
-      { id: "pi-user", role: "user", text: "Please work on issue 85" },
-      { id: "pi-agent", role: "agent", text: "Working on it" },
+      {
+        id: "pi-user",
+        entryId: "pi-user",
+        role: "user",
+        text: "Please work on issue 85",
+      },
+      { id: "pi-agent", entryId: "pi-agent", role: "agent", text: "Working on it" },
     ]);
   });
 
@@ -631,6 +644,7 @@ describe("readSessionTranscript", () => {
     await expect(readSessionTranscript(dir)).resolves.toEqual([
       {
         id: "pi-agent",
+        entryId: "pi-agent",
         role: "agent",
         thinking:
           "**Earlier reasoning**\n\nstep one\n\n**Later reasoning**\n\nstep two",
@@ -661,7 +675,13 @@ describe("readSessionTranscript", () => {
     });
 
     await expect(readSessionTranscript(dir)).resolves.toEqual([
-      { id: "pi-agent", role: "agent", text: "all done", createdAt: 1_000 },
+      {
+        id: "pi-agent",
+        entryId: "pi-agent",
+        role: "agent",
+        text: "all done",
+        createdAt: 1_000,
+      },
       { id: "text-2", role: "agent", text: "done", createdAt: 2_000 },
     ]);
   });
@@ -898,11 +918,21 @@ describe("readSessionTranscript with expectedCwd", () => {
     );
     // Without the cwd filter the latest mtime ("leak.jsonl") wins.
     await expect(readSessionTranscript(dir)).resolves.toEqual([
-      { id: "leak.jsonl-u", role: "user", text: "from other" },
+      {
+        id: "leak.jsonl-u",
+        entryId: "leak.jsonl-u",
+        role: "user",
+        text: "from other",
+      },
     ]);
     // With the cwd filter, the older matching session is returned.
     await expect(readSessionTranscript(dir, "/tmp/target")).resolves.toEqual([
-      { id: "old.jsonl-u", role: "user", text: "from target" },
+      {
+        id: "old.jsonl-u",
+        entryId: "old.jsonl-u",
+        role: "user",
+        text: "from target",
+      },
     ]);
   });
 
@@ -945,7 +975,12 @@ describe("readSessionTranscript with expectedCwd", () => {
     });
 
     await expect(readSessionTranscript(dir, "/tmp/target")).resolves.toEqual([
-      { id: "target.jsonl-u", role: "user", text: "from target" },
+      {
+        id: "target.jsonl-u",
+        entryId: "target.jsonl-u",
+        role: "user",
+        text: "from target",
+      },
       {
         id: "target-local",
         role: "system",

--- a/agent/session-history/index.ts
+++ b/agent/session-history/index.ts
@@ -33,6 +33,7 @@ export {
   appendLocalChatMessage,
   normalizeSessionLabel,
   readSessionLabel,
+  truncateLocalChatAfterEntry,
   writeSessionLabel,
 } from "./io";
 export { readSessionMetadata } from "./metadata";

--- a/agent/session-history/io.test.ts
+++ b/agent/session-history/io.test.ts
@@ -1,0 +1,79 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { appendLocalChatMessage, truncateLocalChatAfterEntry } from "./io";
+import { LOCAL_CHAT_FILE } from "./shared";
+
+let dir: string;
+
+function localIds(): string[] {
+  const raw = readFileSync(join(dir, LOCAL_CHAT_FILE), "utf8").trim();
+  if (!raw) return [];
+  return raw.split("\n").map((line) => JSON.parse(line).id as string);
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "aethon-io-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("truncateLocalChatAfterEntry", () => {
+  it("drops rows created strictly after the cutoff", async () => {
+    await appendLocalChatMessage(dir, {
+      id: "a",
+      role: "user",
+      text: "first",
+      createdAt: 100,
+    });
+    await appendLocalChatMessage(dir, {
+      id: "b",
+      role: "user",
+      text: "second",
+      createdAt: 200,
+    });
+    await appendLocalChatMessage(dir, {
+      id: "c",
+      role: "user",
+      text: "third",
+      createdAt: 300,
+    });
+
+    await truncateLocalChatAfterEntry(dir, 200);
+    expect(localIds()).toEqual(["a", "b"]);
+  });
+
+  it("keeps rows without a timestamp", () => {
+    const path = join(dir, LOCAL_CHAT_FILE);
+    writeFileSync(
+      path,
+      [
+        JSON.stringify({
+          type: "aethon_chat",
+          id: "no-ts",
+          role: "user",
+          text: "x",
+        }),
+        JSON.stringify({
+          type: "aethon_chat",
+          id: "newer",
+          role: "user",
+          text: "y",
+          createdAt: 500,
+        }),
+      ].join("\n") + "\n",
+    );
+    return truncateLocalChatAfterEntry(dir, 200).then(() => {
+      expect(localIds()).toEqual(["no-ts"]);
+    });
+  });
+
+  it("is a no-op when the local chat file is missing", async () => {
+    await expect(
+      truncateLocalChatAfterEntry(dir, 100),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/agent/session-history/io.ts
+++ b/agent/session-history/io.ts
@@ -110,6 +110,34 @@ export async function appendLocalChatMessage(
   await pruneLocalChatFile(path);
 }
 
+function serializeLocalChatEntry(m: RestoredChatMessage): string {
+  return JSON.stringify({
+    type: "aethon_chat",
+    id: m.id,
+    role: m.role,
+    ...(m.text ? { text: m.text } : {}),
+    ...(m.thinking ? { thinking: m.thinking } : {}),
+    ...(m.attachments && m.attachments.length > 0
+      ? { attachments: m.attachments }
+      : {}),
+    ...(m.a2ui ? { a2ui: m.a2ui } : {}),
+    ...(typeof m.createdAt === "number" ? { createdAt: m.createdAt } : {}),
+    ...(m.cwd ? { cwd: m.cwd } : {}),
+  });
+}
+
+/** Atomically rewrite the local-chat file from a kept set of messages
+ *  (temp-write + rename, same contract as the append path). */
+async function rewriteLocalChatFile(
+  path: string,
+  kept: RestoredChatMessage[],
+): Promise<void> {
+  const next = kept.map(serializeLocalChatEntry).join("\n");
+  const tempPath = `${path}.${process.pid}.${randomUUID()}.tmp`;
+  await writeFile(tempPath, next ? `${next}\n` : "", "utf8");
+  await rename(tempPath, path);
+}
+
 async function pruneLocalChatFile(path: string): Promise<void> {
   try {
     const raw = await readFile(path, "utf8");
@@ -120,29 +148,32 @@ async function pruneLocalChatFile(path: string): Promise<void> {
         : lines.length;
     if (lineCount <= MAX_LOCAL_CHAT_MESSAGES) return;
     const kept = parseLocalChatLines(lines).slice(-MAX_LOCAL_CHAT_MESSAGES);
-    const next = kept
-      .map((m) =>
-        JSON.stringify({
-          type: "aethon_chat",
-          id: m.id,
-          role: m.role,
-          ...(m.text ? { text: m.text } : {}),
-          ...(m.thinking ? { thinking: m.thinking } : {}),
-          ...(m.attachments && m.attachments.length > 0
-            ? { attachments: m.attachments }
-            : {}),
-          ...(m.a2ui ? { a2ui: m.a2ui } : {}),
-          ...(typeof m.createdAt === "number"
-            ? { createdAt: m.createdAt }
-            : {}),
-          ...(m.cwd ? { cwd: m.cwd } : {}),
-        }),
-      )
-      .join("\n");
-    const tempPath = `${path}.${process.pid}.${randomUUID()}.tmp`;
-    await writeFile(tempPath, next ? `${next}\n` : "", "utf8");
-    await rename(tempPath, path);
+    await rewriteLocalChatFile(path, kept);
   } catch {
     /* best effort */
+  }
+}
+
+/**
+ * Drop local-chat rows created strictly after `cutoffMs`. Called after a
+ * rollback so a subsequent restore (which merges pi history with the local
+ * chat) doesn't resurrect content the user discarded. Rows without a
+ * timestamp are kept — they predate timestamping and are rare. Best-effort:
+ * a missing file is success.
+ */
+export async function truncateLocalChatAfterEntry(
+  sessionDir: string,
+  cutoffMs: number,
+): Promise<void> {
+  const path = join(sessionDir, LOCAL_CHAT_FILE);
+  try {
+    const raw = await readFile(path, "utf8");
+    const lines = raw.split(/\r?\n/);
+    const kept = parseLocalChatLines(lines).filter(
+      (m) => typeof m.createdAt !== "number" || m.createdAt <= cutoffMs,
+    );
+    await rewriteLocalChatFile(path, kept);
+  } catch {
+    /* best effort — missing file is fine */
   }
 }

--- a/agent/session-history/parse-pi.ts
+++ b/agent/session-history/parse-pi.ts
@@ -198,15 +198,18 @@ export function parseSessionHistoryLines(
     const text = textFromContent(msg.content);
     const thinking = role === "agent" ? thinkingFromContent(msg.content) : "";
 
-    const id =
-      typeof record.id === "string" && record.id.length > 0
-        ? record.id
-        : `restored-${messages.length}`;
+    const hasRealId = typeof record.id === "string" && record.id.length > 0;
+    const id = hasRealId
+      ? (record.id as string)
+      : `restored-${messages.length}`;
     if ((text || thinking) && !seen.has(id)) {
       seen.add(id);
       const createdAt = parseMessageTime(record, msg);
       messages.push({
         id,
+        // The pi entry id is the rollback/fork handle. Only carry it when it's
+        // a real session id (not the positional `restored-N` fallback).
+        ...(hasRealId ? { entryId: id } : {}),
         role,
         ...(text ? { text: trimText(text) } : {}),
         ...(thinking ? { thinking: trimText(thinking) } : {}),

--- a/agent/session-history/shared.ts
+++ b/agent/session-history/shared.ts
@@ -15,6 +15,10 @@ export const MAX_LABEL_CHARS = 60;
 
 export interface RestoredChatMessage {
   id: string;
+  /** pi session entry id (8-char hex) for user/assistant turns — the handle
+   *  `SessionManager.branch()` / `createBranchedSession()` need for rollback /
+   *  fork. Absent on tool-card and system rows (you don't branch to those). */
+  entryId?: string;
   role: "user" | "agent" | "system";
   text?: string;
   thinking?: string;

--- a/agent/state.ts
+++ b/agent/state.ts
@@ -398,6 +398,12 @@ export class AethonAgentState {
   readonly subagents = new Map<string, Subagent>();
   /** Definitions that failed to load/parse, surfaced to the UI. */
   subagentIssues: SubagentLoadIssue[] = [];
+  /** One-shot per-tab steer: when the user opens a message with `@<name>`
+   *  matching a known subagent, the tabId → name is recorded here and the
+   *  `before_agent_start` hook consumes (and clears) it to strongly steer the
+   *  model to delegate. One-shot + clear prevents the subagent's own turn from
+   *  re-triggering delegation. */
+  readonly pendingExplicitSubagent = new Map<string, string>();
   /** Persisted per-tab session directories discovered at boot. Shipped
    *  in `ready` so the frontend can offer "Recent sessions". */
   discoveredTabs: DiscoveredTab[] = [];

--- a/agent/state.ts
+++ b/agent/state.ts
@@ -79,7 +79,7 @@ export interface MutationResult {
 import type { AethonApi } from "./aethon-api";
 export type AethonExtensionApi = AethonApi;
 
-import type { Subagent, SubagentLoadIssue } from "./subagents/types";
+import type { LoadSubagentsResult } from "./subagents/types";
 
 export interface AethonExtensionModule {
   register?: (api: AethonExtensionApi) => void | Promise<void>;
@@ -391,13 +391,12 @@ export class AethonAgentState {
   cachedModels: ModelDescriptor[] = [];
 
   // -- Subagents -----------------------------------------------------------
-  /** Merged effective subagent registry (user scope + active project scope,
-   *  project-wins-by-name). Re-merged at boot, on project change, and when the
-   *  UI edits a definition. Read live by the `task` tool and the runtime
-   *  snapshot, so it only needs to be current — not pushed into open sessions. */
-  readonly subagents = new Map<string, Subagent>();
-  /** Definitions that failed to load/parse, surfaced to the UI. */
-  subagentIssues: SubagentLoadIssue[] = [];
+  /** Per-cwd subagent registry cache (user scope + that project's scope,
+   *  merged project-wins-by-name), keyed by project cwd ("" = user-only).
+   *  Lazily populated by `getSubagentsForCwd` and cleared by `refreshSubagents`
+   *  when the UI edits a definition. Keying by cwd keeps subagents correct when
+   *  tabs on different projects are open simultaneously. */
+  readonly subagentsByCwd = new Map<string, LoadSubagentsResult>();
   /** One-shot per-tab steer: when the user opens a message with `@<name>`
    *  matching a known subagent, the tabId → name is recorded here and the
    *  `before_agent_start` hook consumes (and clears) it to strongly steer the

--- a/agent/state.ts
+++ b/agent/state.ts
@@ -79,6 +79,8 @@ export interface MutationResult {
 import type { AethonApi } from "./aethon-api";
 export type AethonExtensionApi = AethonApi;
 
+import type { Subagent, SubagentLoadIssue } from "./subagents/types";
+
 export interface AethonExtensionModule {
   register?: (api: AethonExtensionApi) => void | Promise<void>;
   default?: { register?: (api: AethonExtensionApi) => void | Promise<void> };
@@ -387,6 +389,15 @@ export class AethonAgentState {
   readonly turnStartTimes = new Map<string, number>();
   /** Cached model picker. First populated when the default tab is created. */
   cachedModels: ModelDescriptor[] = [];
+
+  // -- Subagents -----------------------------------------------------------
+  /** Merged effective subagent registry (user scope + active project scope,
+   *  project-wins-by-name). Re-merged at boot, on project change, and when the
+   *  UI edits a definition. Read live by the `task` tool and the runtime
+   *  snapshot, so it only needs to be current — not pushed into open sessions. */
+  readonly subagents = new Map<string, Subagent>();
+  /** Definitions that failed to load/parse, surfaced to the UI. */
+  subagentIssues: SubagentLoadIssue[] = [];
   /** Persisted per-tab session directories discovered at boot. Shipped
    *  in `ready` so the frontend can offer "Recent sessions". */
   discoveredTabs: DiscoveredTab[] = [];

--- a/agent/subagents/changed.ts
+++ b/agent/subagents/changed.ts
@@ -1,0 +1,24 @@
+/**
+ * Handle the `subagents_changed` signal.
+ *
+ * The Rust side writes `{"type":"subagents_changed"}` to the bridge's stdin
+ * after the UI creates / edits / deletes a subagent definition. We re-merge the
+ * registry and reload the resource loader so the next turn's system prompt
+ * re-advertises — without killing in-flight prompts (this is intentionally a
+ * lighter signal than `reload_request`, which respawns the whole bridge).
+ */
+
+import type { AethonAgentState } from "../state";
+import type { DispatcherDeps } from "../dispatcherTypes";
+import { emitGlobalReady } from "../dispatcherTypes";
+import { refreshSubagents } from "./loader";
+
+export async function handleSubagentsChanged(
+  state: AethonAgentState,
+  deps: DispatcherDeps,
+): Promise<void> {
+  refreshSubagents(state);
+  await state.resourceLoader.reload();
+  deps.scheduleStateFileWrite();
+  emitGlobalReady(state, deps);
+}

--- a/agent/subagents/index.ts
+++ b/agent/subagents/index.ts
@@ -1,4 +1,5 @@
 export type {
+  LoadSubagentsResult,
   Subagent,
   SubagentLoadIssue,
   SubagentScope,
@@ -12,12 +13,12 @@ export {
 } from "./parse";
 export type { ParseSubagentResult } from "./parse";
 export {
+  getSubagentsForCwd,
   loadSubagents,
   projectAgentsDir,
   refreshSubagents,
   userAgentsDir,
 } from "./loader";
-export type { LoadSubagentsResult } from "./loader";
 export { buildSubagentTaskTool } from "./task-tool";
 export type { SubagentTaskDeps } from "./task-tool";
 export { buildExplicitSubagentSteer, detectSubagentMention } from "./steer";

--- a/agent/subagents/index.ts
+++ b/agent/subagents/index.ts
@@ -1,0 +1,20 @@
+export type {
+  Subagent,
+  SubagentLoadIssue,
+  SubagentScope,
+  SubagentSurface,
+} from "./types";
+export {
+  isSafeSubagentName,
+  parseSubagentMarkdown,
+  resolveSubagentTools,
+  sanitizeSubagentName,
+} from "./parse";
+export type { ParseSubagentResult } from "./parse";
+export {
+  loadSubagents,
+  projectAgentsDir,
+  refreshSubagents,
+  userAgentsDir,
+} from "./loader";
+export type { LoadSubagentsResult } from "./loader";

--- a/agent/subagents/index.ts
+++ b/agent/subagents/index.ts
@@ -18,3 +18,7 @@ export {
   userAgentsDir,
 } from "./loader";
 export type { LoadSubagentsResult } from "./loader";
+export { buildSubagentTaskTool } from "./task-tool";
+export type { SubagentTaskDeps } from "./task-tool";
+export { buildExplicitSubagentSteer, detectSubagentMention } from "./steer";
+export { handleSubagentsChanged } from "./changed";

--- a/agent/subagents/loader.test.ts
+++ b/agent/subagents/loader.test.ts
@@ -1,0 +1,154 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  loadSubagents,
+  projectAgentsDir,
+  refreshSubagents,
+  userAgentsDir,
+} from "./loader";
+import type { AethonAgentState } from "../state";
+import type { Subagent, SubagentLoadIssue } from "./types";
+
+let root: string;
+let userDir: string;
+let projectCwd: string;
+
+function writeAgent(dir: string, name: string, body: string): void {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, name), body);
+}
+
+const def = (description: string, model?: string) =>
+  `---\ndescription: ${description}\n${model ? `model: ${model}\n` : ""}---\nsystem prompt for ${description}`;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "aethon-subagents-"));
+  userDir = join(root, "user");
+  projectCwd = join(root, "project");
+  mkdirSync(userDir, { recursive: true });
+  mkdirSync(projectCwd, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("loadSubagents", () => {
+  it("returns an empty registry when no dirs exist", () => {
+    const { byName, issues } = loadSubagents({ userDir, projectCwd });
+    expect(byName.size).toBe(0);
+    expect(issues).toEqual([]);
+  });
+
+  it("loads user-scope subagents", () => {
+    writeAgent(
+      userAgentsDir(userDir),
+      "reviewer.md",
+      def("Reviews diffs", "ollama/llama3.3"),
+    );
+    const { byName } = loadSubagents({ userDir, projectCwd });
+    expect(byName.size).toBe(1);
+    const sub = byName.get("reviewer");
+    expect(sub?.scope).toBe("user");
+    expect(sub?.model).toBe("ollama/llama3.3");
+    expect(sub?.description).toBe("Reviews diffs");
+  });
+
+  it("project scope overrides user scope by name", () => {
+    writeAgent(
+      userAgentsDir(userDir),
+      "reviewer.md",
+      def("User reviewer", "openai/gpt-5.5"),
+    );
+    writeAgent(
+      projectAgentsDir(projectCwd),
+      "reviewer.md",
+      def("Project reviewer", "ollama/llama3.3"),
+    );
+    const { byName } = loadSubagents({ userDir, projectCwd });
+    expect(byName.size).toBe(1);
+    const sub = byName.get("reviewer");
+    expect(sub?.scope).toBe("project");
+    expect(sub?.description).toBe("Project reviewer");
+    expect(sub?.model).toBe("ollama/llama3.3");
+  });
+
+  it("merges distinct names across scopes", () => {
+    writeAgent(userAgentsDir(userDir), "reviewer.md", def("Reviews"));
+    writeAgent(projectAgentsDir(projectCwd), "planner.md", def("Plans"));
+    const { byName } = loadSubagents({ userDir, projectCwd });
+    expect([...byName.keys()].sort()).toEqual(["planner", "reviewer"]);
+  });
+
+  it("ignores project scope when projectCwd is null", () => {
+    writeAgent(userAgentsDir(userDir), "reviewer.md", def("Reviews"));
+    writeAgent(projectAgentsDir(projectCwd), "planner.md", def("Plans"));
+    const { byName } = loadSubagents({ userDir, projectCwd: null });
+    expect([...byName.keys()]).toEqual(["reviewer"]);
+  });
+
+  it("records an issue for an unsafe filename and keeps going", () => {
+    writeAgent(userAgentsDir(userDir), "Bad Name.md", def("nope"));
+    writeAgent(userAgentsDir(userDir), "good.md", def("ok"));
+    const { byName, issues } = loadSubagents({ userDir, projectCwd });
+    expect(byName.has("good")).toBe(true);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].error).toMatch(/invalid subagent filename/);
+  });
+
+  it("records an issue for a malformed definition", () => {
+    writeAgent(userAgentsDir(userDir), "broken.md", "no frontmatter here");
+    const { byName, issues } = loadSubagents({ userDir, projectCwd });
+    expect(byName.size).toBe(0);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].scope).toBe("user");
+    expect(issues[0].error).toMatch(/frontmatter/);
+  });
+
+  it("records an issue for an oversized file", () => {
+    const big = `---\ndescription: big\n---\n${"x".repeat(70 * 1024)}`;
+    writeAgent(userAgentsDir(userDir), "big.md", big);
+    const { byName, issues } = loadSubagents({ userDir, projectCwd });
+    expect(byName.size).toBe(0);
+    expect(issues[0].error).toMatch(/too large/);
+  });
+
+  it("skips dotfiles and non-markdown files", () => {
+    const dir = userAgentsDir(userDir);
+    writeAgent(dir, ".hidden.md", def("hidden"));
+    writeAgent(dir, "notes.txt", def("text"));
+    writeAgent(dir, "real.md", def("real"));
+    const { byName } = loadSubagents({ userDir, projectCwd });
+    expect([...byName.keys()]).toEqual(["real"]);
+  });
+});
+
+describe("refreshSubagents", () => {
+  /** Minimal state stub — refreshSubagents only reads userDir +
+   *  currentProjectCwd and writes the subagents map + issues. */
+  function stubState(): AethonAgentState {
+    return {
+      userDir,
+      currentProjectCwd: projectCwd,
+      subagents: new Map<string, Subagent>(),
+      subagentIssues: [] as SubagentLoadIssue[],
+    } as unknown as AethonAgentState;
+  }
+
+  it("populates state and replaces stale entries on re-run", () => {
+    writeAgent(userAgentsDir(userDir), "reviewer.md", def("Reviews"));
+    const state = stubState();
+    refreshSubagents(state);
+    expect(state.subagents.get("reviewer")?.description).toBe("Reviews");
+
+    // Stale entry must be dropped after the source file is removed.
+    rmSync(join(userAgentsDir(userDir), "reviewer.md"));
+    writeAgent(userAgentsDir(userDir), "planner.md", def("Plans"));
+    refreshSubagents(state);
+    expect(state.subagents.has("reviewer")).toBe(false);
+    expect(state.subagents.get("planner")?.description).toBe("Plans");
+    expect(state.subagentIssues).toEqual([]);
+  });
+});

--- a/agent/subagents/loader.test.ts
+++ b/agent/subagents/loader.test.ts
@@ -3,13 +3,14 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  getSubagentsForCwd,
   loadSubagents,
   projectAgentsDir,
   refreshSubagents,
   userAgentsDir,
 } from "./loader";
 import type { AethonAgentState } from "../state";
-import type { Subagent, SubagentLoadIssue } from "./types";
+import type { LoadSubagentsResult } from "./types";
 
 let root: string;
 let userDir: string;
@@ -125,30 +126,50 @@ describe("loadSubagents", () => {
   });
 });
 
-describe("refreshSubagents", () => {
-  /** Minimal state stub — refreshSubagents only reads userDir +
-   *  currentProjectCwd and writes the subagents map + issues. */
+describe("getSubagentsForCwd / refreshSubagents", () => {
+  /** Minimal state stub — the cwd resolver only reads userDir + the cwd cache. */
   function stubState(): AethonAgentState {
     return {
       userDir,
-      currentProjectCwd: projectCwd,
-      subagents: new Map<string, Subagent>(),
-      subagentIssues: [] as SubagentLoadIssue[],
+      subagentsByCwd: new Map<string, LoadSubagentsResult>(),
     } as unknown as AethonAgentState;
   }
 
-  it("populates state and replaces stale entries on re-run", () => {
+  it("caches per cwd and project wins by name", () => {
+    writeAgent(userAgentsDir(userDir), "reviewer.md", def("User reviewer"));
+    writeAgent(
+      projectAgentsDir(projectCwd),
+      "reviewer.md",
+      def("Project reviewer"),
+    );
+    const state = stubState();
+
+    const forProject = getSubagentsForCwd(state, projectCwd);
+    expect(forProject.byName.get("reviewer")?.description).toBe(
+      "Project reviewer",
+    );
+    // User-only scope (no project cwd) sees the user definition.
+    expect(
+      getSubagentsForCwd(state, null).byName.get("reviewer")?.description,
+    ).toBe("User reviewer");
+
+    // Second resolve returns the cached object (no re-read).
+    expect(getSubagentsForCwd(state, projectCwd)).toBe(forProject);
+  });
+
+  it("refreshSubagents invalidates the cache so the next resolve re-reads", () => {
     writeAgent(userAgentsDir(userDir), "reviewer.md", def("Reviews"));
     const state = stubState();
-    refreshSubagents(state);
-    expect(state.subagents.get("reviewer")?.description).toBe("Reviews");
+    expect(getSubagentsForCwd(state, null).byName.has("reviewer")).toBe(true);
 
-    // Stale entry must be dropped after the source file is removed.
     rmSync(join(userAgentsDir(userDir), "reviewer.md"));
     writeAgent(userAgentsDir(userDir), "planner.md", def("Plans"));
+    // Still cached until invalidated.
+    expect(getSubagentsForCwd(state, null).byName.has("reviewer")).toBe(true);
+
     refreshSubagents(state);
-    expect(state.subagents.has("reviewer")).toBe(false);
-    expect(state.subagents.get("planner")?.description).toBe("Plans");
-    expect(state.subagentIssues).toEqual([]);
+    const fresh = getSubagentsForCwd(state, null);
+    expect(fresh.byName.has("reviewer")).toBe(false);
+    expect(fresh.byName.get("planner")?.description).toBe("Plans");
   });
 });

--- a/agent/subagents/loader.ts
+++ b/agent/subagents/loader.ts
@@ -1,0 +1,123 @@
+/**
+ * Two-scope subagent loader.
+ *
+ * Reads `~/.aethon/agents/*.md` (user scope) then
+ * `<projectCwd>/.aethon/agents/*.md` (project scope) and merges them by
+ * canonical name (the file stem). Project scope is loaded second, so a
+ * project `reviewer.md` overrides a user `reviewer.md`.
+ *
+ * Everything is best-effort: a missing directory, an oversized file, or a
+ * malformed definition is recorded as a {@link SubagentLoadIssue} and skipped
+ * — one bad file never breaks the registry.
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import type { AethonAgentState } from "../state";
+import { isSafeSubagentName, parseSubagentMarkdown } from "./parse";
+import type { Subagent, SubagentLoadIssue, SubagentScope } from "./types";
+
+/** Hard cap on a single definition file, matching the config.toml convention. */
+const MAX_SUBAGENT_BYTES = 64 * 1024;
+
+export interface LoadSubagentsResult {
+  /** Merged effective registry, project-wins-by-name. */
+  byName: Map<string, Subagent>;
+  issues: SubagentLoadIssue[];
+}
+
+export function userAgentsDir(userDir: string): string {
+  return join(userDir, "agents");
+}
+
+export function projectAgentsDir(projectCwd: string): string {
+  return join(projectCwd, ".aethon", "agents");
+}
+
+export function loadSubagents(opts: {
+  userDir: string;
+  projectCwd?: string | null;
+}): LoadSubagentsResult {
+  const byName = new Map<string, Subagent>();
+  const issues: SubagentLoadIssue[] = [];
+  loadScopeInto(byName, issues, userAgentsDir(opts.userDir), "user");
+  if (opts.projectCwd) {
+    loadScopeInto(byName, issues, projectAgentsDir(opts.projectCwd), "project");
+  }
+  return { byName, issues };
+}
+
+function loadScopeInto(
+  byName: Map<string, Subagent>,
+  issues: SubagentLoadIssue[],
+  dir: string,
+  scope: SubagentScope,
+): void {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    // ENOENT / unreadable — simply no subagents at this scope.
+    return;
+  }
+  for (const entry of entries.sort()) {
+    if (entry.startsWith(".") || !entry.toLowerCase().endsWith(".md")) continue;
+    const filePath = join(dir, entry);
+    const name = entry.slice(0, -3).toLowerCase();
+    if (!isSafeSubagentName(name)) {
+      issues.push({
+        filePath,
+        scope,
+        error: `invalid subagent filename "${entry}" (name must be [a-z0-9_-], starting alphanumeric)`,
+      });
+      continue;
+    }
+    let raw: string;
+    try {
+      const stat = statSync(filePath);
+      if (!stat.isFile()) continue;
+      if (stat.size > MAX_SUBAGENT_BYTES) {
+        issues.push({
+          filePath,
+          scope,
+          error: `subagent file too large (${stat.size} bytes; max ${MAX_SUBAGENT_BYTES})`,
+        });
+        continue;
+      }
+      raw = readFileSync(filePath, "utf8");
+    } catch (err) {
+      issues.push({
+        filePath,
+        scope,
+        error: `read failed: ${(err as Error).message}`,
+      });
+      continue;
+    }
+    const { subagent, error } = parseSubagentMarkdown(raw, {
+      filePath,
+      scope,
+      name,
+    });
+    if (!subagent) {
+      issues.push({ filePath, scope, error: error ?? "unknown parse error" });
+      continue;
+    }
+    // Project scope loads after user scope, so this overrides by name.
+    byName.set(name, subagent);
+  }
+}
+
+/**
+ * Re-merge the subagent registry into shared state from the current user dir
+ * and active project cwd. Called at boot, on project change, and when the UI
+ * edits a definition. Cheap and synchronous (a handful of small file reads).
+ */
+export function refreshSubagents(state: AethonAgentState): void {
+  const { byName, issues } = loadSubagents({
+    userDir: state.userDir,
+    projectCwd: state.currentProjectCwd,
+  });
+  state.subagents.clear();
+  for (const [name, sub] of byName) state.subagents.set(name, sub);
+  state.subagentIssues = issues;
+}

--- a/agent/subagents/loader.ts
+++ b/agent/subagents/loader.ts
@@ -15,16 +15,17 @@ import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import type { AethonAgentState } from "../state";
 import { isSafeSubagentName, parseSubagentMarkdown } from "./parse";
-import type { Subagent, SubagentLoadIssue, SubagentScope } from "./types";
+import type {
+  LoadSubagentsResult,
+  Subagent,
+  SubagentLoadIssue,
+  SubagentScope,
+} from "./types";
+
+export type { LoadSubagentsResult } from "./types";
 
 /** Hard cap on a single definition file, matching the config.toml convention. */
 const MAX_SUBAGENT_BYTES = 64 * 1024;
-
-export interface LoadSubagentsResult {
-  /** Merged effective registry, project-wins-by-name. */
-  byName: Map<string, Subagent>;
-  issues: SubagentLoadIssue[];
-}
 
 export function userAgentsDir(userDir: string): string {
   return join(userDir, "agents");
@@ -108,16 +109,31 @@ function loadScopeInto(
 }
 
 /**
- * Re-merge the subagent registry into shared state from the current user dir
- * and active project cwd. Called at boot, on project change, and when the UI
- * edits a definition. Cheap and synchronous (a handful of small file reads).
+ * Resolve the merged subagent registry for a specific cwd, memoized on
+ * `state.subagentsByCwd`. Keying by cwd (rather than a single global registry)
+ * keeps subagents correct when tabs on different projects are open at once: a
+ * tab on project A always sees project A's subagents even after project B is
+ * opened. The `task` tool, `@name` detection, and the per-turn advertisement
+ * all resolve through here using the relevant tab's cwd.
+ */
+export function getSubagentsForCwd(
+  state: AethonAgentState,
+  cwd: string | null | undefined,
+): LoadSubagentsResult {
+  const key = cwd ?? "";
+  const cached = state.subagentsByCwd.get(key);
+  if (cached) return cached;
+  const result = loadSubagents({ userDir: state.userDir, projectCwd: cwd });
+  state.subagentsByCwd.set(key, result);
+  return result;
+}
+
+/**
+ * Invalidate the per-cwd registry cache so the next resolve re-reads from disk.
+ * Called when the UI creates / edits / deletes a definition (the affected cwd
+ * isn't known, so clear all). Project switches need no invalidation — the cache
+ * is already cwd-keyed.
  */
 export function refreshSubagents(state: AethonAgentState): void {
-  const { byName, issues } = loadSubagents({
-    userDir: state.userDir,
-    projectCwd: state.currentProjectCwd,
-  });
-  state.subagents.clear();
-  for (const [name, sub] of byName) state.subagents.set(name, sub);
-  state.subagentIssues = issues;
+  state.subagentsByCwd.clear();
 }

--- a/agent/subagents/parse.test.ts
+++ b/agent/subagents/parse.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+import {
+  isSafeSubagentName,
+  parseSubagentMarkdown,
+  resolveSubagentTools,
+  sanitizeSubagentName,
+} from "./parse";
+
+const ctx = {
+  filePath: "/agents/reviewer.md",
+  scope: "user" as const,
+  name: "reviewer",
+};
+
+describe("isSafeSubagentName", () => {
+  it("accepts lowercase slugs", () => {
+    expect(isSafeSubagentName("reviewer")).toBe(true);
+    expect(isSafeSubagentName("code-reviewer_2")).toBe(true);
+    expect(isSafeSubagentName("a")).toBe(true);
+  });
+  it("rejects unsafe names", () => {
+    expect(isSafeSubagentName("")).toBe(false);
+    expect(isSafeSubagentName("-leading")).toBe(false);
+    expect(isSafeSubagentName("UPPER")).toBe(false);
+    expect(isSafeSubagentName("has space")).toBe(false);
+    expect(isSafeSubagentName("../escape")).toBe(false);
+    expect(isSafeSubagentName("x".repeat(65))).toBe(false);
+  });
+});
+
+describe("sanitizeSubagentName", () => {
+  it("slugifies arbitrary input", () => {
+    expect(sanitizeSubagentName("Code Reviewer")).toBe("code-reviewer");
+    expect(sanitizeSubagentName("  My Agent!!  ")).toBe("my-agent");
+    expect(sanitizeSubagentName("__trim__")).toBe("trim");
+  });
+  it("returns empty when nothing usable remains", () => {
+    expect(sanitizeSubagentName("!!!")).toBe("");
+    expect(sanitizeSubagentName("   ")).toBe("");
+  });
+  it("clamps to 64 chars", () => {
+    expect(sanitizeSubagentName("a".repeat(100)).length).toBe(64);
+  });
+});
+
+describe("parseSubagentMarkdown", () => {
+  it("parses a full definition", () => {
+    const raw = [
+      "---",
+      "description: Reviews diffs for correctness",
+      "model: ollama/llama3.3",
+      "tools: [read, grep, bash]",
+      "surface: inline",
+      "---",
+      "You are a meticulous code reviewer.",
+      "Focus on edge cases.",
+    ].join("\n");
+    const { subagent, error } = parseSubagentMarkdown(raw, ctx);
+    expect(error).toBeUndefined();
+    expect(subagent).toEqual({
+      name: "reviewer",
+      description: "Reviews diffs for correctness",
+      model: "ollama/llama3.3",
+      tools: ["read", "grep", "bash"],
+      surface: "inline",
+      systemPrompt: "You are a meticulous code reviewer.\nFocus on edge cases.",
+      scope: "user",
+      filePath: "/agents/reviewer.md",
+    });
+  });
+
+  it("requires a description", () => {
+    const raw = "---\nmodel: gpt-5.5\n---\nbody";
+    const { subagent, error } = parseSubagentMarkdown(raw, ctx);
+    expect(subagent).toBeUndefined();
+    expect(error).toMatch(/description/);
+  });
+
+  it("requires frontmatter", () => {
+    const { error } = parseSubagentMarkdown("just a body, no frontmatter", ctx);
+    expect(error).toMatch(/frontmatter/);
+  });
+
+  it("reports invalid YAML", () => {
+    const raw = "---\ndescription: ok\ntools: [unterminated\n---\nbody";
+    const { subagent, error } = parseSubagentMarkdown(raw, ctx);
+    expect(subagent).toBeUndefined();
+    expect(error).toMatch(/invalid YAML/);
+  });
+
+  it("rejects a non-mapping frontmatter", () => {
+    const raw = "---\n- just\n- a\n- list\n---\nbody";
+    const { error } = parseSubagentMarkdown(raw, ctx);
+    expect(error).toMatch(/mapping/);
+  });
+
+  it("defaults surface to inline and tools to inherit", () => {
+    const raw = "---\ndescription: d\n---\nbody";
+    const { subagent } = parseSubagentMarkdown(raw, ctx);
+    expect(subagent?.surface).toBe("inline");
+    expect(subagent?.tools).toBeUndefined();
+    expect(subagent?.model).toBeUndefined();
+  });
+
+  it("honors surface: tab", () => {
+    const raw = "---\ndescription: d\nsurface: tab\n---\nbody";
+    expect(parseSubagentMarkdown(raw, ctx).subagent?.surface).toBe("tab");
+  });
+
+  it("treats an unknown surface as inline", () => {
+    const raw = "---\ndescription: d\nsurface: floating\n---\nbody";
+    expect(parseSubagentMarkdown(raw, ctx).subagent?.surface).toBe("inline");
+  });
+
+  it("parses tools as a comma-separated string", () => {
+    const raw = "---\ndescription: d\ntools: read, grep , bash\n---\nbody";
+    expect(parseSubagentMarkdown(raw, ctx).subagent?.tools).toEqual([
+      "read",
+      "grep",
+      "bash",
+    ]);
+  });
+
+  it("treats an empty tools list as 'no tools'", () => {
+    const raw = "---\ndescription: d\ntools: []\n---\nbody";
+    expect(parseSubagentMarkdown(raw, ctx).subagent?.tools).toEqual([]);
+  });
+
+  it("treats an empty tools string as 'no tools'", () => {
+    const raw = '---\ndescription: d\ntools: ""\n---\nbody';
+    expect(parseSubagentMarkdown(raw, ctx).subagent?.tools).toEqual([]);
+  });
+
+  it("dedupes tools and preserves order", () => {
+    const raw = "---\ndescription: d\ntools: [read, grep, read]\n---\nbody";
+    expect(parseSubagentMarkdown(raw, ctx).subagent?.tools).toEqual([
+      "read",
+      "grep",
+    ]);
+  });
+
+  it("tolerates CRLF line endings and a BOM", () => {
+    const raw = "﻿---\r\ndescription: d\r\n---\r\nbody line\r\n";
+    const { subagent, error } = parseSubagentMarkdown(raw, ctx);
+    expect(error).toBeUndefined();
+    expect(subagent?.systemPrompt).toBe("body line");
+  });
+
+  it("trims the system prompt body", () => {
+    const raw = "---\ndescription: d\n---\n\n\n  hello  \n\n";
+    expect(parseSubagentMarkdown(raw, ctx).subagent?.systemPrompt).toBe(
+      "hello",
+    );
+  });
+
+  it("supports an empty body", () => {
+    const raw = "---\ndescription: d\n---\n";
+    const { subagent, error } = parseSubagentMarkdown(raw, ctx);
+    expect(error).toBeUndefined();
+    expect(subagent?.systemPrompt).toBe("");
+  });
+});
+
+describe("resolveSubagentTools", () => {
+  it("inherits when tools is undefined", () => {
+    expect(resolveSubagentTools({ tools: undefined })).toEqual({});
+  });
+  it("locks down to no tools when empty", () => {
+    expect(resolveSubagentTools({ tools: [] })).toEqual({ noTools: "all" });
+  });
+  it("passes through an allowlist", () => {
+    expect(resolveSubagentTools({ tools: ["read", "bash"] })).toEqual({
+      tools: ["read", "bash"],
+    });
+  });
+});

--- a/agent/subagents/parse.ts
+++ b/agent/subagents/parse.ts
@@ -1,0 +1,139 @@
+/**
+ * Pure parsing + validation for subagent markdown definitions.
+ *
+ * No IO — given a raw file body and its context (path, scope, name), produce
+ * either a {@link Subagent} or a human-readable error. The loader ({@link
+ * ./loader}) supplies the canonical name (the file stem) and records errors as
+ * {@link SubagentLoadIssue}s.
+ */
+
+import { parse as parseYaml } from "yaml";
+import type { Subagent, SubagentScope, SubagentSurface } from "./types";
+
+/** Canonical name shape: lower-case, `[a-z0-9_-]`, must start alphanumeric,
+ *  ≤64 chars. Mirrors the auth-profile id guard so file/registry/disk stay in
+ *  lockstep. */
+const SAFE_NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/;
+
+export function isSafeSubagentName(input: string): boolean {
+  return SAFE_NAME_RE.test(input);
+}
+
+/** Best-effort slug for a user-supplied name (used by the editor before a
+ *  write). Returns "" when nothing usable remains, which callers reject. */
+export function sanitizeSubagentName(input: string): string {
+  return input
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^[-_]+|[-_]+$/g, "")
+    .slice(0, 64);
+}
+
+export interface ParseSubagentResult {
+  subagent?: Subagent;
+  error?: string;
+}
+
+/** Unicode BOM code point — stripped before frontmatter detection. */
+const BOM = 0xfeff;
+
+/** Frontmatter block: a leading `---` line, the YAML body, a closing `---`
+ *  line, then the markdown body. Tolerant of CRLF line endings. */
+const FRONTMATTER_RE =
+  /^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*\r?\n?([\s\S]*)$/;
+
+export function parseSubagentMarkdown(
+  raw: string,
+  ctx: { filePath: string; scope: SubagentScope; name: string },
+): ParseSubagentResult {
+  const text = raw.charCodeAt(0) === BOM ? raw.slice(1) : raw;
+  const match = FRONTMATTER_RE.exec(text);
+  if (!match) {
+    return { error: "missing YAML frontmatter (expected a leading --- block)" };
+  }
+  const [, frontmatterText, body] = match;
+
+  let frontmatter: unknown;
+  try {
+    frontmatter = parseYaml(frontmatterText);
+  } catch (err) {
+    return { error: `invalid YAML frontmatter: ${(err as Error).message}` };
+  }
+  if (
+    !frontmatter ||
+    typeof frontmatter !== "object" ||
+    Array.isArray(frontmatter)
+  ) {
+    return { error: "frontmatter must be a YAML mapping" };
+  }
+  const fields = frontmatter as Record<string, unknown>;
+
+  const description =
+    typeof fields.description === "string" ? fields.description.trim() : "";
+  if (!description) {
+    return {
+      error:
+        "frontmatter `description` is required (it drives auto-delegation)",
+    };
+  }
+
+  const model =
+    typeof fields.model === "string" && fields.model.trim()
+      ? fields.model.trim()
+      : undefined;
+
+  return {
+    subagent: {
+      name: ctx.name,
+      description,
+      model,
+      tools: parseToolsField(fields.tools),
+      surface: parseSurfaceField(fields.surface),
+      systemPrompt: body.trim(),
+      scope: ctx.scope,
+      filePath: ctx.filePath,
+    },
+  };
+}
+
+/**
+ * Normalize the `tools` frontmatter into the three meaningful states:
+ *  - absent / wrong-type  → `undefined`  (inherit the full toolset)
+ *  - empty list or string → `[]`         (reasoning only, no tools)
+ *  - non-empty            → allowlist (deduped, order-preserved)
+ *
+ * Accepts both YAML list form (`[a, b]` / block list) and a comma/space
+ * separated string (`a, b`), matching common subagent conventions.
+ */
+function parseToolsField(value: unknown): string[] | undefined {
+  let tokens: string[];
+  if (Array.isArray(value)) {
+    tokens = value.map((v) => (typeof v === "string" ? v : String(v)));
+  } else if (typeof value === "string") {
+    tokens = value.split(/[,\s]+/);
+  } else {
+    return undefined;
+  }
+  const tools = tokens.map((t) => t.trim()).filter((t) => t.length > 0);
+  return [...new Set(tools)];
+}
+
+function parseSurfaceField(value: unknown): SubagentSurface {
+  return value === "tab" ? "tab" : "inline";
+}
+
+/**
+ * Map a subagent's tool allowlist onto pi's `createAgentSession` options.
+ *  - inherit (undefined) → `{}` (pi enables its default toolset)
+ *  - none (`[]`)         → `{ noTools: "all" }`
+ *  - allowlist           → `{ tools: [...] }`
+ */
+export function resolveSubagentTools(sub: Pick<Subagent, "tools">): {
+  tools?: string[];
+  noTools?: "all" | "builtin";
+} {
+  if (sub.tools === undefined) return {};
+  if (sub.tools.length === 0) return { noTools: "all" };
+  return { tools: sub.tools };
+}

--- a/agent/subagents/steer.test.ts
+++ b/agent/subagents/steer.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { buildExplicitSubagentSteer, detectSubagentMention } from "./steer";
+
+describe("detectSubagentMention", () => {
+  it("detects a leading @name", () => {
+    expect(detectSubagentMention("@reviewer check this")).toBe("reviewer");
+    expect(detectSubagentMention("@code-reviewer_2 go")).toBe(
+      "code-reviewer_2",
+    );
+  });
+  it("lowercases the name", () => {
+    expect(detectSubagentMention("@Reviewer hi")).toBe("reviewer");
+  });
+  it("tolerates leading whitespace", () => {
+    expect(detectSubagentMention("   @planner do x")).toBe("planner");
+  });
+  it("returns null without a leading mention", () => {
+    expect(detectSubagentMention("hello @reviewer")).toBeNull();
+    expect(detectSubagentMention("no mention")).toBeNull();
+    expect(detectSubagentMention("@ bad")).toBeNull();
+    expect(detectSubagentMention("")).toBeNull();
+  });
+  it("stops at a word boundary", () => {
+    expect(detectSubagentMention("@reviewer, please")).toBe("reviewer");
+    expect(detectSubagentMention("@reviewer.")).toBe("reviewer");
+  });
+});
+
+describe("buildExplicitSubagentSteer", () => {
+  it("names the subagent and instructs delegation via the task tool", () => {
+    const steer = buildExplicitSubagentSteer("reviewer");
+    expect(steer).toContain('"reviewer"');
+    expect(steer).toContain("task");
+    expect(steer).toContain('subagent_type="reviewer"');
+  });
+});

--- a/agent/subagents/steer.ts
+++ b/agent/subagents/steer.ts
@@ -1,0 +1,36 @@
+/**
+ * Explicit `@name` subagent invocation.
+ *
+ * When a user opens a chat message with `@<name>`, that's an explicit request
+ * to delegate to the named subagent. Detection lives here (shared by the chat
+ * handler) and the one-shot system steer that nudges the model to call the
+ * `task` tool lives here too (consumed by the `before_agent_start` hook). Kept
+ * separate from the parser so it has no IO and is trivially unit-tested.
+ */
+
+/** A leading `@name` mention. Case-insensitive on input; the captured name is
+ *  lower-cased by the caller to match the canonical registry key. */
+const MENTION_RE = /^@([A-Za-z0-9][A-Za-z0-9_-]{0,63})\b/;
+
+/**
+ * Detect a leading `@name` mention in a chat message. Returns the lowercased
+ * name (caller checks it against the registry) or null when absent.
+ */
+export function detectSubagentMention(content: string): string | null {
+  const match = MENTION_RE.exec(content.trimStart());
+  return match ? match[1].toLowerCase() : null;
+}
+
+/**
+ * Build the per-turn system steer appended when the user explicitly invoked a
+ * subagent. A same-turn system instruction is far more reliable than relying on
+ * the model to notice the `@name` convention, while keeping the user's message
+ * intact in the transcript.
+ */
+export function buildExplicitSubagentSteer(name: string): string {
+  return (
+    `The user explicitly invoked the "${name}" subagent. Delegate this request ` +
+    `to it by calling the \`task\` tool with subagent_type="${name}" and a ` +
+    `complete, self-contained prompt. Do not perform the task yourself.`
+  );
+}

--- a/agent/subagents/task-tool.test.ts
+++ b/agent/subagents/task-tool.test.ts
@@ -1,0 +1,307 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ToolDefinition } from "@mariozechner/pi-coding-agent";
+import type { AethonAgentState } from "../state";
+import type { Subagent } from "./types";
+import { buildSubagentTaskTool } from "./task-tool";
+
+const fakeModel = { provider: "ollama", id: "llama3.3", name: "Llama 3.3" };
+
+// Hoisted handle so the vi.mock factory and the tests share the same scripting
+// surface for the fake pi session.
+interface MockHandle {
+  subscribers: Array<(e: Record<string, unknown>) => void>;
+  scriptedEvents: Array<Record<string, unknown>>;
+  promptImpl: null | (() => Promise<void>);
+  lastConfig: Record<string, unknown> | undefined;
+  createAgentSession: ReturnType<typeof vi.fn>;
+  disposeSpy: ReturnType<typeof vi.fn>;
+  abortSpy: ReturnType<typeof vi.fn>;
+}
+
+const h = vi.hoisted<MockHandle>(() => ({
+  subscribers: [],
+  scriptedEvents: [],
+  promptImpl: null,
+  lastConfig: undefined,
+  createAgentSession: vi.fn(),
+  disposeSpy: vi.fn(),
+  abortSpy: vi.fn(),
+}));
+
+vi.mock("@mariozechner/pi-coding-agent", () => {
+  const createAgentSession = vi.fn((config: Record<string, unknown>) => {
+    h.lastConfig = config;
+    h.disposeSpy = vi.fn();
+    h.abortSpy = vi.fn(() => Promise.resolve());
+    const session = {
+      model: config.model,
+      subscribe(fn: (e: Record<string, unknown>) => void) {
+        h.subscribers.push(fn);
+        return () => {
+          const i = h.subscribers.indexOf(fn);
+          if (i >= 0) h.subscribers.splice(i, 1);
+        };
+      },
+      prompt(): Promise<void> {
+        if (h.promptImpl) return h.promptImpl();
+        for (const ev of h.scriptedEvents) {
+          for (const s of [...h.subscribers]) s(ev);
+        }
+        return Promise.resolve();
+      },
+      abort: h.abortSpy,
+      dispose: h.disposeSpy,
+    };
+    return Promise.resolve({ session });
+  });
+  h.createAgentSession = createAgentSession;
+  return {
+    defineTool: (spec: unknown) => spec,
+    SessionManager: { inMemory: () => ({ __inMemory: true }) },
+    createBashToolDefinition: () => ({ name: "bash" }),
+    createAgentSession,
+  };
+});
+
+type ExecResult = {
+  content: { type: string; text: string }[];
+  details: { subagent: string; model: string; surface: string };
+};
+type Exec = (
+  callId: string,
+  params: { subagent_type: string; prompt: string; context?: string },
+  signal?: AbortSignal,
+  onUpdate?: (p: { content: { type: string; text: string }[] }) => void,
+) => Promise<ExecResult>;
+
+function execOf(tool: ToolDefinition): Exec {
+  return (tool as unknown as { execute: Exec }).execute;
+}
+
+function makeState(sub: Partial<Subagent> & { name: string }): {
+  state: AethonAgentState;
+  findSpy: ReturnType<typeof vi.fn>;
+} {
+  const full: Subagent = {
+    name: sub.name,
+    description: sub.description ?? "does things",
+    model: sub.model,
+    tools: sub.tools,
+    surface: sub.surface ?? "inline",
+    systemPrompt: sub.systemPrompt ?? "You are a helper.",
+    scope: "user",
+    filePath: `/agents/${sub.name}.md`,
+  };
+  const findSpy = vi.fn((_provider: string, _id: string) => fakeModel);
+  const state = {
+    subagents: new Map([[full.name, full]]),
+    tabProjectCwds: new Map<string, string>(),
+    tabAuthProfileIds: new Map<string, string>(),
+    currentProjectCwd: "/proj",
+    tabs: new Map([["default", { session: { model: fakeModel } }]]),
+    authProfiles: { version: 1, profiles: [], defaultByProvider: {} },
+    authStorage: {},
+    modelRegistry: { find: findSpy },
+    settingsManager: {
+      getDefaultProvider: () => undefined,
+      getDefaultModel: () => undefined,
+    },
+    resourceLoader: {},
+  } as unknown as AethonAgentState;
+  return { state, findSpy };
+}
+
+const successEvents = [
+  {
+    type: "message_update",
+    assistantMessageEvent: { type: "text_delta", delta: "Found " },
+  },
+  {
+    type: "message_update",
+    assistantMessageEvent: { type: "text_delta", delta: "2 bugs." },
+  },
+  {
+    type: "agent_end",
+    messages: [{ role: "assistant", content: [], stopReason: "stop" }],
+  },
+];
+
+beforeEach(() => {
+  h.subscribers = [];
+  h.scriptedEvents = [...successEvents];
+  h.promptImpl = null;
+  h.lastConfig = undefined;
+  h.createAgentSession.mockClear();
+});
+
+afterEach(() => {
+  delete (globalThis as { aethon?: unknown }).aethon;
+});
+
+describe("buildSubagentTaskTool", () => {
+  it("runs an inline subagent on its configured model and returns its text", async () => {
+    const { state } = makeState({ name: "reviewer", model: "ollama/llama3.3" });
+    const send = vi.fn();
+    const onUpdate = vi.fn();
+    const tool = buildSubagentTaskTool(state, { send }, "default");
+
+    const result = await execOf(tool)(
+      "call-1",
+      { subagent_type: "reviewer", prompt: "check src/foo.ts" },
+      undefined,
+      onUpdate,
+    );
+
+    expect(result.content[0].text).toBe("Found 2 bugs.");
+    expect(result.details).toEqual({
+      subagent: "reviewer",
+      model: "ollama/llama3.3",
+      surface: "inline",
+    });
+    // Model + in-memory session + bash shadow passed to pi.
+    expect(h.lastConfig?.model).toBe(fakeModel);
+    expect(h.lastConfig?.sessionManager).toEqual({ __inMemory: true });
+    expect(h.lastConfig?.customTools).toEqual([{ name: "bash" }]);
+    // Live streaming surfaced.
+    expect(onUpdate).toHaveBeenCalled();
+    const phases = send.mock.calls
+      .map((c) => c[0] as { type?: string; phase?: string })
+      .filter((m) => m.type === "subagent_progress")
+      .map((m) => m.phase);
+    expect(phases).toContain("start");
+    expect(phases).toContain("text");
+    expect(phases).toContain("done");
+    expect(h.disposeSpy).toHaveBeenCalled();
+  });
+
+  it("passes a tools allowlist through to the session", async () => {
+    const { state } = makeState({
+      name: "reviewer",
+      model: "ollama/llama3.3",
+      tools: ["read", "grep"],
+    });
+    const tool = buildSubagentTaskTool(state, { send: vi.fn() }, "default");
+    await execOf(tool)("c", { subagent_type: "reviewer", prompt: "x" });
+    expect(h.lastConfig?.tools).toEqual(["read", "grep"]);
+    expect(h.lastConfig?.noTools).toBeUndefined();
+  });
+
+  it("locks the subagent to no tools when tools is empty", async () => {
+    const { state } = makeState({
+      name: "reviewer",
+      model: "ollama/llama3.3",
+      tools: [],
+    });
+    const tool = buildSubagentTaskTool(state, { send: vi.fn() }, "default");
+    await execOf(tool)("c", { subagent_type: "reviewer", prompt: "x" });
+    expect(h.lastConfig?.noTools).toBe("all");
+    expect(h.lastConfig?.tools).toBeUndefined();
+  });
+
+  it("inherits the parent tab's model when none is configured", async () => {
+    const { state } = makeState({ name: "helper" });
+    const tool = buildSubagentTaskTool(state, { send: vi.fn() }, "default");
+    const result = await execOf(tool)("c", {
+      subagent_type: "helper",
+      prompt: "x",
+    });
+    expect(h.lastConfig?.model).toBe(fakeModel);
+    expect(result.details.model).toBe("ollama/llama3.3");
+  });
+
+  it("throws on an unknown subagent", async () => {
+    const { state } = makeState({ name: "reviewer" });
+    const tool = buildSubagentTaskTool(state, { send: vi.fn() }, "default");
+    await expect(
+      execOf(tool)("c", { subagent_type: "ghost", prompt: "x" }),
+    ).rejects.toThrow(/unknown subagent/);
+  });
+
+  it("throws when the configured model is unavailable", async () => {
+    const { state, findSpy } = makeState({
+      name: "reviewer",
+      model: "ollama/missing",
+    });
+    findSpy.mockReturnValueOnce(undefined);
+    const tool = buildSubagentTaskTool(state, { send: vi.fn() }, "default");
+    await expect(
+      execOf(tool)("c", { subagent_type: "reviewer", prompt: "x" }),
+    ).rejects.toThrow(/not available/);
+  });
+
+  it("surfaces an agent_end error as a thrown error", async () => {
+    h.scriptedEvents = [
+      {
+        type: "agent_end",
+        messages: [
+          {
+            role: "assistant",
+            stopReason: "error",
+            errorMessage: "model overloaded",
+          },
+        ],
+      },
+    ];
+    const { state } = makeState({ name: "reviewer", model: "ollama/llama3.3" });
+    const tool = buildSubagentTaskTool(state, { send: vi.fn() }, "default");
+    await expect(
+      execOf(tool)("c", { subagent_type: "reviewer", prompt: "x" }),
+    ).rejects.toThrow(/model overloaded/);
+    expect(h.disposeSpy).toHaveBeenCalled();
+  });
+
+  it("wraps a prompt rejection and still disposes", async () => {
+    h.promptImpl = () => Promise.reject(new Error("boom"));
+    const { state } = makeState({ name: "reviewer", model: "ollama/llama3.3" });
+    const tool = buildSubagentTaskTool(state, { send: vi.fn() }, "default");
+    await expect(
+      execOf(tool)("c", { subagent_type: "reviewer", prompt: "x" }),
+    ).rejects.toThrow(/failed: boom/);
+    expect(h.disposeSpy).toHaveBeenCalled();
+  });
+
+  it("aborts the subagent session when the parent signal aborts", async () => {
+    let release!: () => void;
+    h.promptImpl = () => new Promise<void>((res) => (release = res));
+    const { state } = makeState({ name: "reviewer", model: "ollama/llama3.3" });
+    const tool = buildSubagentTaskTool(state, { send: vi.fn() }, "default");
+    const ctrl = new AbortController();
+    const pending = execOf(tool)(
+      "c",
+      { subagent_type: "reviewer", prompt: "x" },
+      ctrl.signal,
+    );
+    // Let the microtasks settle so subscribe + prompt start.
+    await Promise.resolve();
+    ctrl.abort();
+    expect(h.abortSpy).toHaveBeenCalled();
+    release();
+    await pending;
+  });
+
+  it("launches a tab for surface: tab subagents", async () => {
+    const start = vi.fn(() =>
+      Promise.resolve({ ok: true, data: { tabId: "t2" } }),
+    );
+    (globalThis as { aethon?: unknown }).aethon = { tasks: { start } };
+    const { state } = makeState({
+      name: "builder",
+      model: "ollama/llama3.3",
+      surface: "tab",
+    });
+    const tool = buildSubagentTaskTool(state, { send: vi.fn() }, "default");
+    const result = await execOf(tool)("c", {
+      subagent_type: "builder",
+      prompt: "do it",
+    });
+    expect(start).toHaveBeenCalledWith({
+      projectPath: "/proj",
+      prompt: expect.stringContaining("do it"),
+      model: "ollama/llama3.3",
+    });
+    expect(result.details.surface).toBe("tab");
+    expect(result.content[0].text).toMatch(/Launched subagent/);
+    // No isolated session created for the tab surface.
+    expect(h.createAgentSession).not.toHaveBeenCalled();
+  });
+});

--- a/agent/subagents/task-tool.test.ts
+++ b/agent/subagents/task-tool.test.ts
@@ -94,7 +94,9 @@ function makeState(sub: Partial<Subagent> & { name: string }): {
   };
   const findSpy = vi.fn((_provider: string, _id: string) => fakeModel);
   const state = {
-    subagents: new Map([[full.name, full]]),
+    subagentsByCwd: new Map([
+      ["/proj", { byName: new Map([[full.name, full]]), issues: [] }],
+    ]),
     tabProjectCwds: new Map<string, string>(),
     tabAuthProfileIds: new Map<string, string>(),
     currentProjectCwd: "/proj",

--- a/agent/subagents/task-tool.ts
+++ b/agent/subagents/task-tool.ts
@@ -1,0 +1,516 @@
+/**
+ * The `task` delegation tool.
+ *
+ * Registered per agent tab (alongside the devshell bash shadow and the
+ * dashboard/shell tools) so the main model can hand a focused task to a
+ * configured subagent — chosen by `description` (auto-delegation) or named
+ * explicitly via `@name`. Each delegation runs an **isolated** pi session
+ * (`SessionManager.inMemory()`) with the subagent's own model + tool allowlist
+ * and returns its final text to the caller as the tool result.
+ *
+ * Two surfaces:
+ *  - `inline` (default): the subagent runs here, streaming live progress into
+ *    the outer tool card (via `onUpdate`) and a richer `subagent_progress`
+ *    sidecar stream. Its summary becomes the tool result.
+ *  - `tab`: the subagent is launched as its own agent tab via
+ *    `aethon.tasks.start`; the tool result just confirms the launch.
+ *
+ * The subagent never receives the `task` tool itself, so it can't recurse.
+ */
+
+import {
+  SessionManager,
+  createAgentSession,
+  createBashToolDefinition,
+  defineTool,
+  type ToolDefinition,
+} from "@mariozechner/pi-coding-agent";
+import type { Api, Model } from "@mariozechner/pi-ai";
+import { Type, type Static } from "typebox";
+import type { AethonAgentState } from "../state";
+import {
+  authProfileServicesForTab,
+  servicesForProvider,
+} from "../auth-profiles";
+import { buildDevshellSpawnHook } from "../devshell";
+import { extractAgentEndError } from "../agent-errors";
+import { summarizeToolArgs } from "../tool-card";
+import { logger } from "../logger";
+import { resolveSubagentTools } from "./parse";
+import type { Subagent, SubagentSurface } from "./types";
+
+/** Hard ceiling on a single delegation so a wedged subagent can't hang the
+ *  parent turn indefinitely. */
+const DEFAULT_TIMEOUT_MS = 300_000;
+/** Cap on the text returned to the parent (and streamed partials). */
+const MAX_RESULT_CHARS = 100_000;
+
+export interface SubagentTaskDeps {
+  send: (obj: Record<string, unknown>) => void;
+}
+
+interface SubagentRunDetails {
+  subagent: string;
+  model: string;
+  surface: SubagentSurface;
+}
+
+type TextBlock = { type: "text"; text: string };
+type SubagentToolResult = { content: TextBlock[]; details: SubagentRunDetails };
+type SubagentPartial = { content: TextBlock[]; details?: SubagentRunDetails };
+type UpdateFn = (partial: SubagentPartial) => void;
+
+const TaskParams = Type.Object({
+  subagent_type: Type.String({
+    description:
+      "Name of the subagent to delegate to. Must match one of the available subagents listed in the system prompt.",
+  }),
+  prompt: Type.String({
+    description:
+      "The full, self-contained task for the subagent. It runs in a fresh isolated session and only sees this text — include all context it needs.",
+  }),
+  context: Type.Optional(
+    Type.String({
+      description:
+        "Optional extra context (file paths, constraints) prepended to the task.",
+    }),
+  ),
+});
+type TaskParamsT = Static<typeof TaskParams>;
+
+/** Build the `task` tool bound to a specific parent tab. The captured
+ *  `parentTabId` routes nested progress events and resolves the inherited
+ *  model + cwd. */
+export function buildSubagentTaskTool(
+  state: AethonAgentState,
+  deps: SubagentTaskDeps,
+  parentTabId: string,
+): ToolDefinition {
+  return defineTool({
+    name: "task",
+    label: "Delegate to a subagent",
+    description:
+      "Delegate a focused task to a configured subagent. Pick the subagent whose description best matches the work; pass a complete, self-contained prompt. The subagent runs in an isolated session (its own model + tools) and returns a summary. Use this to offload narrow, well-scoped work (review, research, codegen) — especially to a cheaper/local model.",
+    promptSnippet:
+      "task: delegate a focused task to a configured subagent (see the subagents list)",
+    parameters: TaskParams,
+    async execute(
+      callId: string,
+      params: TaskParamsT,
+      signal: AbortSignal | undefined,
+      onUpdate: UpdateFn | undefined,
+    ): Promise<SubagentToolResult> {
+      return runSubagentTask(
+        state,
+        deps,
+        parentTabId,
+        callId,
+        params,
+        signal,
+        onUpdate,
+      );
+    },
+  }) as ToolDefinition;
+}
+
+async function runSubagentTask(
+  state: AethonAgentState,
+  deps: SubagentTaskDeps,
+  parentTabId: string,
+  callId: string,
+  params: TaskParamsT,
+  signal: AbortSignal | undefined,
+  onUpdate: UpdateFn | undefined,
+): Promise<SubagentToolResult> {
+  const name = params.subagent_type.trim().toLowerCase();
+  const sub = state.subagents.get(name);
+  if (!sub) {
+    const available =
+      [...state.subagents.keys()].join(", ") || "(none configured)";
+    throw new Error(
+      `unknown subagent "${params.subagent_type}". Available subagents: ${available}.`,
+    );
+  }
+  const cwd =
+    state.tabProjectCwds.get(parentTabId) ??
+    state.currentProjectCwd ??
+    process.cwd();
+  const composedPrompt = composePrompt(sub, params);
+
+  if (sub.surface === "tab") {
+    return launchSubagentTab(sub, cwd, composedPrompt);
+  }
+  return runInlineSubagent(
+    state,
+    deps,
+    parentTabId,
+    callId,
+    sub,
+    cwd,
+    composedPrompt,
+    signal,
+    onUpdate,
+  );
+}
+
+/** Compose the subagent's instructions (its markdown body) with the delegated
+ *  task into a single self-contained prompt. */
+function composePrompt(sub: Subagent, params: TaskParamsT): string {
+  const extra = params.context?.trim() ? `${params.context.trim()}\n\n` : "";
+  const preamble = sub.systemPrompt.trim()
+    ? `${sub.systemPrompt.trim()}\n\n---\n`
+    : "";
+  return `${preamble}Task:\n${extra}${params.prompt}`;
+}
+
+interface ResolvedModelServices {
+  model: Model<Api> | undefined;
+  authStorage: ReturnType<typeof servicesForProvider>["authStorage"];
+  modelRegistry: ReturnType<typeof servicesForProvider>["modelRegistry"];
+}
+
+/** Resolve the model AND its matching auth/model services together (see
+ *  {@link servicesForProvider}). Returns null when an explicit model can't be
+ *  found in its provider's registry. */
+function resolveModelServices(
+  state: AethonAgentState,
+  parentTabId: string,
+  modelId: string | undefined,
+): ResolvedModelServices | null {
+  if (modelId && modelId.trim()) {
+    const [provider, ...rest] = modelId.split("/");
+    const services = servicesForProvider(state, provider);
+    const model = services.modelRegistry.find(provider, rest.join("/"));
+    if (!model) return null;
+    return {
+      model,
+      authStorage: services.authStorage,
+      modelRegistry: services.modelRegistry,
+    };
+  }
+  // No explicit model — inherit the parent tab's model + services.
+  const parent = state.tabs.get(parentTabId);
+  const services = authProfileServicesForTab(state, parentTabId);
+  return {
+    model: parent?.session.model ?? undefined,
+    authStorage: services.authStorage,
+    modelRegistry: services.modelRegistry,
+  };
+}
+
+async function runInlineSubagent(
+  state: AethonAgentState,
+  deps: SubagentTaskDeps,
+  parentTabId: string,
+  callId: string,
+  sub: Subagent,
+  cwd: string,
+  composedPrompt: string,
+  signal: AbortSignal | undefined,
+  onUpdate: UpdateFn | undefined,
+): Promise<SubagentToolResult> {
+  const resolved = resolveModelServices(state, parentTabId, sub.model);
+  if (!resolved) {
+    throw new Error(
+      `subagent "${sub.name}": model "${sub.model}" is not available — check that its provider is signed in.`,
+    );
+  }
+  const { model, authStorage, modelRegistry } = resolved;
+  const modelLabel = model
+    ? `${model.provider}/${model.id}`
+    : (sub.model ?? "inherited");
+  const details: SubagentRunDetails = {
+    subagent: sub.name,
+    model: modelLabel,
+    surface: "inline",
+  };
+
+  // Devshell-aware bash shadow so the subagent's bash (if allowlisted) inherits
+  // the project's Nix env, exactly like the main agent's.
+  const devshellBashTool = createBashToolDefinition(cwd, {
+    spawnHook: buildDevshellSpawnHook(state, deps),
+  });
+
+  const { session } = await createAgentSession({
+    ...(model ? { model } : {}),
+    authStorage,
+    modelRegistry,
+    settingsManager: state.settingsManager,
+    sessionManager: SessionManager.inMemory(),
+    resourceLoader: state.resourceLoader,
+    cwd,
+    customTools: [devshellBashTool],
+    ...resolveSubagentTools(sub),
+  });
+
+  let finalText = "";
+  let errorMessage: string | undefined;
+
+  const unsubscribe = session.subscribe(
+    (event: { type: string } & Record<string, unknown>) => {
+      handleSubagentEvent(event, {
+        onText: (delta) => {
+          finalText += delta;
+          onUpdate?.({
+            content: [
+              { type: "text", text: finalText.slice(-MAX_RESULT_CHARS) },
+            ],
+            details,
+          });
+          emitProgress(deps, parentTabId, callId, details, {
+            phase: "text",
+            delta,
+          });
+        },
+        onThinking: (delta) =>
+          emitProgress(deps, parentTabId, callId, details, {
+            phase: "thinking",
+            delta,
+          }),
+        onToolStart: (toolName, toolSummary) =>
+          emitProgress(deps, parentTabId, callId, details, {
+            phase: "tool_start",
+            toolName,
+            toolSummary,
+          }),
+        onToolEnd: (toolName, isError) =>
+          emitProgress(deps, parentTabId, callId, details, {
+            phase: "tool_end",
+            toolName,
+            isError,
+          }),
+        onEnd: (messages) => {
+          errorMessage = extractAgentEndError(messages);
+          if (!finalText.trim()) finalText = extractLastAssistantText(messages);
+        },
+      });
+    },
+  );
+
+  const onAbort = (): void => {
+    void session.abort();
+  };
+  signal?.addEventListener("abort", onAbort);
+
+  emitProgress(deps, parentTabId, callId, details, { phase: "start" });
+  try {
+    await withTimeout(
+      session.prompt(composedPrompt),
+      DEFAULT_TIMEOUT_MS,
+      () => {
+        void session.abort();
+      },
+    );
+  } catch (err) {
+    emitProgress(deps, parentTabId, callId, details, {
+      phase: "error",
+      error: (err as Error).message,
+    });
+    throw new Error(
+      `subagent "${sub.name}" failed: ${(err as Error).message}`,
+      {
+        cause: err,
+      },
+    );
+  } finally {
+    signal?.removeEventListener("abort", onAbort);
+    unsubscribe();
+    try {
+      session.dispose();
+    } catch (err) {
+      logger
+        .scope("subagent")
+        .warn(`dispose failed for "${sub.name}": ${(err as Error).message}`);
+    }
+  }
+
+  if (errorMessage) {
+    emitProgress(deps, parentTabId, callId, details, {
+      phase: "error",
+      error: errorMessage,
+    });
+    throw new Error(`subagent "${sub.name}" error: ${errorMessage}`);
+  }
+
+  emitProgress(deps, parentTabId, callId, details, { phase: "done" });
+  const text = finalText.trim() || "(subagent produced no text output)";
+  return {
+    content: [{ type: "text", text: text.slice(0, MAX_RESULT_CHARS) }],
+    details,
+  };
+}
+
+interface TasksApi {
+  start(args: {
+    projectPath: string;
+    prompt: string;
+    model?: string;
+  }): Promise<{ ok: boolean; error?: string; data?: unknown }>;
+}
+
+function getTasksApi(): TasksApi | null {
+  const g = globalThis as { aethon?: { tasks?: TasksApi } };
+  return g.aethon?.tasks ?? null;
+}
+
+async function launchSubagentTab(
+  sub: Subagent,
+  cwd: string,
+  composedPrompt: string,
+): Promise<SubagentToolResult> {
+  const api = getTasksApi();
+  if (!api)
+    throw new Error(
+      "subagent tab launch unavailable (aethon.tasks API missing)",
+    );
+  const result = await api.start({
+    projectPath: cwd,
+    prompt: composedPrompt,
+    ...(sub.model ? { model: sub.model } : {}),
+  });
+  if (!result.ok) {
+    throw new Error(
+      `subagent "${sub.name}" tab launch failed: ${result.error ?? "unknown"}`,
+    );
+  }
+  const details: SubagentRunDetails = {
+    subagent: sub.name,
+    model: sub.model ?? "inherited",
+    surface: "tab",
+  };
+  return {
+    content: [
+      { type: "text", text: `Launched subagent \`${sub.name}\` in a new tab.` },
+    ],
+    details,
+  };
+}
+
+interface SubagentEventCallbacks {
+  onText: (delta: string) => void;
+  onThinking: (delta: string) => void;
+  onToolStart: (toolName: string, toolSummary: string) => void;
+  onToolEnd: (toolName: string, isError: boolean) => void;
+  onEnd: (messages: unknown[]) => void;
+}
+
+/** Translate the subagent session's pi events into the streaming callbacks. */
+function handleSubagentEvent(
+  event: { type: string } & Record<string, unknown>,
+  cb: SubagentEventCallbacks,
+): void {
+  switch (event.type) {
+    case "message_update": {
+      const ame = (
+        event as { assistantMessageEvent?: { type?: string; delta?: string } }
+      ).assistantMessageEvent;
+      const delta = ame?.delta ?? "";
+      if (!delta) break;
+      if (ame?.type === "text_delta") cb.onText(delta);
+      else if (
+        ame?.type === "thinking_delta" ||
+        ame?.type === "reasoning_delta"
+      ) {
+        cb.onThinking(delta);
+      }
+      break;
+    }
+    case "tool_execution_start": {
+      const ev = event as { toolName?: string; args?: unknown };
+      const toolName = ev.toolName ?? "tool";
+      cb.onToolStart(toolName, summarizeToolArgs(toolName, ev.args));
+      break;
+    }
+    case "tool_execution_end": {
+      const ev = event as { toolName?: string; isError?: boolean };
+      cb.onToolEnd(ev.toolName ?? "tool", ev.isError === true);
+      break;
+    }
+    case "agent_end": {
+      const ev = event as { messages?: unknown[] };
+      cb.onEnd(ev.messages ?? []);
+      break;
+    }
+  }
+}
+
+/** Pull the last assistant message's text out of an agent_end `messages` array
+ *  (fallback when no text deltas were captured). */
+function extractLastAssistantText(messages: unknown[]): string {
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const message = messages[i] as { role?: string; content?: unknown };
+    if (message?.role !== "assistant") continue;
+    const content = message.content;
+    if (typeof content === "string") return content;
+    if (Array.isArray(content)) {
+      const text = content
+        .map((block) =>
+          block &&
+          typeof block === "object" &&
+          (block as { type?: string }).type === "text" &&
+          typeof (block as { text?: string }).text === "string"
+            ? (block as { text: string }).text
+            : "",
+        )
+        .join("");
+      if (text) return text;
+    }
+  }
+  return "";
+}
+
+interface ProgressInfo {
+  phase:
+    | "start"
+    | "text"
+    | "thinking"
+    | "tool_start"
+    | "tool_end"
+    | "done"
+    | "error";
+  delta?: string;
+  toolName?: string;
+  toolSummary?: string;
+  isError?: boolean;
+  error?: string;
+}
+
+function emitProgress(
+  deps: SubagentTaskDeps,
+  parentTabId: string,
+  callId: string,
+  details: SubagentRunDetails,
+  info: ProgressInfo,
+): void {
+  deps.send({
+    type: "subagent_progress",
+    tabId: parentTabId,
+    parentCallId: callId,
+    subagent: details.subagent,
+    model: details.model,
+    ...info,
+  });
+}
+
+function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  onTimeout: () => void,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      onTimeout();
+      reject(new Error(`timed out after ${Math.round(ms / 1000)}s`));
+    }, ms);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err: unknown) => {
+        clearTimeout(timer);
+        reject(err instanceof Error ? err : new Error(String(err)));
+      },
+    );
+  });
+}

--- a/agent/subagents/task-tool.ts
+++ b/agent/subagents/task-tool.ts
@@ -36,6 +36,7 @@ import { buildDevshellSpawnHook } from "../devshell";
 import { extractAgentEndError } from "../agent-errors";
 import { summarizeToolArgs } from "../tool-card";
 import { logger } from "../logger";
+import { getSubagentsForCwd } from "./loader";
 import { resolveSubagentTools } from "./parse";
 import type { Subagent, SubagentSurface } from "./types";
 
@@ -122,19 +123,22 @@ async function runSubagentTask(
   signal: AbortSignal | undefined,
   onUpdate: UpdateFn | undefined,
 ): Promise<SubagentToolResult> {
-  const name = params.subagent_type.trim().toLowerCase();
-  const sub = state.subagents.get(name);
-  if (!sub) {
-    const available =
-      [...state.subagents.keys()].join(", ") || "(none configured)";
-    throw new Error(
-      `unknown subagent "${params.subagent_type}". Available subagents: ${available}.`,
-    );
-  }
   const cwd =
     state.tabProjectCwds.get(parentTabId) ??
     state.currentProjectCwd ??
     process.cwd();
+  const name = params.subagent_type.trim().toLowerCase();
+  // Resolve against the *parent tab's* cwd, not a global registry, so a tab on
+  // project A always delegates to project A's subagents.
+  const registry = getSubagentsForCwd(state, cwd);
+  const sub = registry.byName.get(name);
+  if (!sub) {
+    const available =
+      [...registry.byName.keys()].join(", ") || "(none configured)";
+    throw new Error(
+      `unknown subagent "${params.subagent_type}". Available subagents: ${available}.`,
+    );
+  }
   const composedPrompt = composePrompt(sub, params);
 
   if (sub.surface === "tab") {

--- a/agent/subagents/task-tool.ts
+++ b/agent/subagents/task-tool.ts
@@ -254,11 +254,11 @@ async function runInlineSubagent(
     (event: { type: string } & Record<string, unknown>) => {
       handleSubagentEvent(event, {
         onText: (delta) => {
-          finalText += delta;
+          // Keep only the trailing MAX_RESULT_CHARS so a verbose subagent can't
+          // grow this buffer without bound (the result we return is the tail).
+          finalText = (finalText + delta).slice(-MAX_RESULT_CHARS);
           onUpdate?.({
-            content: [
-              { type: "text", text: finalText.slice(-MAX_RESULT_CHARS) },
-            ],
+            content: [{ type: "text", text: finalText }],
             details,
           });
           emitProgress(deps, parentTabId, callId, details, {
@@ -285,7 +285,10 @@ async function runInlineSubagent(
           }),
         onEnd: (messages) => {
           errorMessage = extractAgentEndError(messages);
-          if (!finalText.trim()) finalText = extractLastAssistantText(messages);
+          if (!finalText.trim()) {
+            finalText =
+              extractLastAssistantText(messages).slice(-MAX_RESULT_CHARS);
+          }
         },
       });
     },

--- a/agent/subagents/types.ts
+++ b/agent/subagents/types.ts
@@ -1,0 +1,61 @@
+/**
+ * Subagent definitions.
+ *
+ * A subagent is a named, scoped delegate the main agent can hand a focused
+ * task to via the `task` tool (auto-delegation by `description`, or explicit
+ * `@name`). Each runs in an isolated pi session with its own model + tool
+ * allowlist, so a main agent on (say) `openai/gpt-5.5` can delegate to a
+ * subagent on a local Ollama model.
+ *
+ * Definitions live as one markdown file per subagent with YAML frontmatter:
+ *
+ *   ~/.aethon/agents/<name>.md            (user scope, global)
+ *   <project>/.aethon/agents/<name>.md    (project scope, overrides user)
+ *
+ *   ---
+ *   description: Reviews diffs for correctness and edge cases.
+ *   model: ollama/llama3.3
+ *   tools: [read, grep, bash]
+ *   surface: inline
+ *   ---
+ *   You are a meticulous code reviewer...   <- markdown body == system prompt
+ *
+ * The file *stem* is the canonical name and the override key (a project
+ * `reviewer.md` shadows a user `reviewer.md`). This module is pure data +
+ * parsing; IO lives in {@link ./loader}.
+ */
+
+export type SubagentScope = "user" | "project";
+
+/** Where a subagent's run is surfaced in the UI. `inline` streams a nested
+ *  tool card inside the delegating turn (default); `tab` opens its own agent
+ *  tab via the task launcher. */
+export type SubagentSurface = "inline" | "tab";
+
+export interface Subagent {
+  /** Canonical name == sanitized file stem; also the override key. */
+  name: string;
+  /** Drives auto-delegation — the main model picks a subagent by this. */
+  description: string;
+  /** `provider/model-id` (e.g. `ollama/llama3.3`). Undefined inherits the
+   *  delegating tab's model. */
+  model?: string;
+  /** Tool allowlist. `undefined` inherits the full toolset; `[]` locks the
+   *  subagent down to reasoning only (no tools). */
+  tools?: string[];
+  /** Default `inline`. */
+  surface: SubagentSurface;
+  /** Markdown body — used as the subagent's system prompt. */
+  systemPrompt: string;
+  scope: SubagentScope;
+  /** Absolute path the definition was loaded from. */
+  filePath: string;
+}
+
+/** A definition that failed to load/parse. Surfaced to the user (settings /
+ *  overview) rather than thrown, so one bad file never breaks the registry. */
+export interface SubagentLoadIssue {
+  filePath: string;
+  scope: SubagentScope;
+  error: string;
+}

--- a/agent/subagents/types.ts
+++ b/agent/subagents/types.ts
@@ -59,3 +59,10 @@ export interface SubagentLoadIssue {
   scope: SubagentScope;
   error: string;
 }
+
+/** Merged effective registry for one cwd (user scope + that project scope,
+ *  project-wins-by-name) plus any load issues. */
+export interface LoadSubagentsResult {
+  byName: Map<string, Subagent>;
+  issues: SubagentLoadIssue[];
+}

--- a/agent/system-prompt.test.ts
+++ b/agent/system-prompt.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildRuntimeSection, type RuntimeSnapshot } from "./system-prompt";
+import {
+  buildRuntimeSection,
+  buildSubagentsSection,
+  type RuntimeSnapshot,
+} from "./system-prompt";
 
 function snapshot(overrides: Partial<RuntimeSnapshot> = {}): RuntimeSnapshot {
   return {
@@ -118,27 +122,21 @@ describe("buildRuntimeSection failedExtensions", () => {
   });
 });
 
-describe("buildRuntimeSection subagents", () => {
-  it("renders nothing when there are no subagents", () => {
-    expect(buildRuntimeSection(snapshot())).not.toContain(
-      "Available subagents",
-    );
+describe("buildSubagentsSection", () => {
+  it("returns empty when there are no subagents", () => {
+    expect(buildSubagentsSection([])).toBe("");
   });
 
   it("lists subagents with model, surface, and delegation guidance", () => {
-    const out = buildRuntimeSection(
-      snapshot({
-        subagents: [
-          {
-            name: "reviewer",
-            description: "Reviews diffs",
-            model: "ollama/llama3.3",
-            surface: "inline",
-          },
-          { name: "builder", description: "Builds features", surface: "tab" },
-        ],
-      }),
-    );
+    const out = buildSubagentsSection([
+      {
+        name: "reviewer",
+        description: "Reviews diffs",
+        model: "ollama/llama3.3",
+        surface: "inline",
+      },
+      { name: "builder", description: "Builds features", surface: "tab" },
+    ]);
     expect(out).toContain("Available subagents");
     expect(out).toContain("`task`");
     expect(out).toContain("@<name>");
@@ -146,5 +144,11 @@ describe("buildRuntimeSection subagents", () => {
     expect(out).toContain("ollama/llama3.3");
     expect(out).toContain("Reviews diffs");
     expect(out).toContain("opens its own tab");
+  });
+
+  it("is not rendered by buildRuntimeSection (advertisement is per-turn)", () => {
+    expect(buildRuntimeSection(snapshot())).not.toContain(
+      "Available subagents",
+    );
   });
 });

--- a/agent/system-prompt.test.ts
+++ b/agent/system-prompt.test.ts
@@ -13,6 +13,7 @@ function snapshot(overrides: Partial<RuntimeSnapshot> = {}): RuntimeSnapshot {
     failedExtensions: [],
     disabledExtensions: [],
     themes: [],
+    subagents: [],
     components: [],
     layoutSummary: "(none)",
     tabs: [],
@@ -46,7 +47,8 @@ describe("buildRuntimeSection failedExtensions", () => {
             name: "git-worktree-manager",
             source: "directory",
             status: "failed",
-            error: "This assignment will throw because \"entries\" is a constant.",
+            error:
+              'This assignment will throw because "entries" is a constant.',
             path: "/Users/me/.aethon/extensions/git-worktree-manager.ts",
           },
           {
@@ -60,7 +62,9 @@ describe("buildRuntimeSection failedExtensions", () => {
     );
     expect(out).toContain("Extensions that did NOT load");
     expect(out).toContain("`git-worktree-manager` (directory, failed)");
-    expect(out).toContain("/Users/me/.aethon/extensions/git-worktree-manager.ts");
+    expect(out).toContain(
+      "/Users/me/.aethon/extensions/git-worktree-manager.ts",
+    );
     expect(out).toContain("entries");
     expect(out).toContain("`no-register` (extension-package, skipped)");
     expect(out).toContain("no register() export");
@@ -99,12 +103,48 @@ describe("buildRuntimeSection failedExtensions", () => {
     const out = buildRuntimeSection(
       snapshot({
         tabs: [
-          { id: "default", model: "anthropic/x", messageCount: 2, cwd: "/repo/a" },
+          {
+            id: "default",
+            model: "anthropic/x",
+            messageCount: 2,
+            cwd: "/repo/a",
+          },
           { id: "t2", model: "", messageCount: 0 },
         ],
       }),
     );
     expect(out).toContain("cwd `/repo/a`");
     expect(out).toContain("`t2` — model `(none)`, 0 messages");
+  });
+});
+
+describe("buildRuntimeSection subagents", () => {
+  it("renders nothing when there are no subagents", () => {
+    expect(buildRuntimeSection(snapshot())).not.toContain(
+      "Available subagents",
+    );
+  });
+
+  it("lists subagents with model, surface, and delegation guidance", () => {
+    const out = buildRuntimeSection(
+      snapshot({
+        subagents: [
+          {
+            name: "reviewer",
+            description: "Reviews diffs",
+            model: "ollama/llama3.3",
+            surface: "inline",
+          },
+          { name: "builder", description: "Builds features", surface: "tab" },
+        ],
+      }),
+    );
+    expect(out).toContain("Available subagents");
+    expect(out).toContain("`task`");
+    expect(out).toContain("@<name>");
+    expect(out).toContain("`reviewer`");
+    expect(out).toContain("ollama/llama3.3");
+    expect(out).toContain("Reviews diffs");
+    expect(out).toContain("opens its own tab");
   });
 });

--- a/agent/system-prompt.ts
+++ b/agent/system-prompt.ts
@@ -30,6 +30,38 @@ export type { RuntimeSnapshot };
 // prompt. Compact by design — the agent can read $AETHON_STATE_FILE for
 // the full data; this is just enough to answer "what's loaded?" without
 // a tool call.
+/**
+ * Build the "Available subagents" advertisement appended to the system prompt.
+ * Injected per-turn by the `before_agent_start` hook (not via the static
+ * snapshot) so it reflects the *active tab's* cwd — tabs on different projects
+ * see different subagents. Returns "" when none are configured.
+ */
+export function buildSubagentsSection(
+  subagents: {
+    name: string;
+    description: string;
+    model?: string;
+    surface: "inline" | "tab";
+  }[],
+): string {
+  if (subagents.length === 0) return "";
+  const lines: string[] = [
+    "# Available subagents",
+    "Delegate focused work to one with the `task` tool " +
+      '(`task({ subagent_type: "<name>", prompt: "<self-contained task>" })`). ' +
+      "Choose the subagent whose description best fits; pass everything it needs " +
+      "in `prompt` (it runs in an isolated session and sees only that). When the " +
+      "user prefixes a message with `@<name>`, delegate to that subagent. Do NOT " +
+      "delegate trivial work you can do directly.",
+  ];
+  for (const s of subagents) {
+    const model = s.model ? `, model \`${s.model}\`` : "";
+    const tab = s.surface === "tab" ? ", opens its own tab" : "";
+    lines.push(`- \`${s.name}\`${model}${tab} — ${s.description}`);
+  }
+  return lines.join("\n");
+}
+
 export function buildRuntimeSection(snapshot: RuntimeSnapshot): string {
   const lines: string[] = ["# Current runtime snapshot"];
   lines.push(
@@ -88,23 +120,6 @@ export function buildRuntimeSection(snapshot: RuntimeSnapshot): string {
         .map((c) => `\`${c}\``)
         .join(", ")}.`,
     );
-  }
-
-  if (snapshot.subagents.length > 0) {
-    lines.push("");
-    lines.push(
-      "Available subagents — delegate focused work to one with the `task` tool " +
-        '(`task({ subagent_type: "<name>", prompt: "<self-contained task>" })`). ' +
-        "Choose the subagent whose description best fits; pass everything it needs " +
-        "in `prompt` (it runs in an isolated session and sees only that). When the " +
-        "user prefixes a message with `@<name>`, delegate to that subagent. Do NOT " +
-        "delegate trivial work you can do directly.",
-    );
-    for (const s of snapshot.subagents) {
-      const model = s.model ? `, model \`${s.model}\`` : "";
-      const tab = s.surface === "tab" ? ", opens its own tab" : "";
-      lines.push(`- \`${s.name}\`${model}${tab} — ${s.description}`);
-    }
   }
 
   if (snapshot.slashCommands.length > 0) {

--- a/agent/system-prompt.ts
+++ b/agent/system-prompt.ts
@@ -35,7 +35,7 @@ export function buildRuntimeSection(snapshot: RuntimeSnapshot): string {
   lines.push(
     `Build: ${snapshot.release ? "release" : "dev"}. Agent host dir: \`${snapshot.cwd}\` — ` +
       "this is where the bridge process launched, NOT necessarily where any tab " +
-      'operates. Each turn\'s authoritative working directory + git state arrives in the ' +
+      "operates. Each turn's authoritative working directory + git state arrives in the " +
       '"Working context" section appended below; trust that over this line.',
   );
   if (snapshot.projectRoot) {
@@ -88,6 +88,23 @@ export function buildRuntimeSection(snapshot: RuntimeSnapshot): string {
         .map((c) => `\`${c}\``)
         .join(", ")}.`,
     );
+  }
+
+  if (snapshot.subagents.length > 0) {
+    lines.push("");
+    lines.push(
+      "Available subagents — delegate focused work to one with the `task` tool " +
+        '(`task({ subagent_type: "<name>", prompt: "<self-contained task>" })`). ' +
+        "Choose the subagent whose description best fits; pass everything it needs " +
+        "in `prompt` (it runs in an isolated session and sees only that). When the " +
+        "user prefixes a message with `@<name>`, delegate to that subagent. Do NOT " +
+        "delegate trivial work you can do directly.",
+    );
+    for (const s of snapshot.subagents) {
+      const model = s.model ? `, model \`${s.model}\`` : "";
+      const tab = s.surface === "tab" ? ", opens its own tab" : "";
+      lines.push(`- \`${s.name}\`${model}${tab} — ${s.description}`);
+    }
   }
 
   if (snapshot.slashCommands.length > 0) {

--- a/agent/system-prompt/types.ts
+++ b/agent/system-prompt/types.ts
@@ -39,6 +39,16 @@ export interface RuntimeSnapshot {
   disabledExtensions: string[];
   themes: { id: string; label: string }[];
   components: string[];
+  // Configured subagents the main model can delegate to via the `task` tool.
+  // Merged user-scope + active-project-scope (project wins by name). The model
+  // chooses one by `description`; the user can also invoke explicitly with
+  // `@name`. `surface` is where the run shows up (inline card vs its own tab).
+  subagents: {
+    name: string;
+    description: string;
+    model?: string;
+    surface: "inline" | "tab";
+  }[];
   layoutSummary: string;
   // `cwd` is the per-tab working directory (from `state.tabProjectCwds`).
   // Distinct from the top-level `cwd` (the agent process launch dir), which

--- a/agent/tab-lifecycle/events.ts
+++ b/agent/tab-lifecycle/events.ts
@@ -365,6 +365,9 @@ export function handleSessionEvent(
         rollResponseMessage(rec);
         clearLiveContextUsageEstimate(rec);
         emitContextUsage(state, deps, tabId, rec);
+        // Back-fill pi entry ids onto the just-streamed messages so the
+        // rollback / fork affordances work without a reload.
+        emitEntryIds(deps, rec, tabId);
         deps.send({ type: "response_end", tabId });
       }
       break;
@@ -421,5 +424,39 @@ function summarizeToolResult(result: unknown): string {
     return JSON.stringify(result).slice(0, 16_384);
   } catch {
     return String(result).slice(0, 16_384);
+  }
+}
+
+/** Emit the current branch's user/assistant message entry ids, in order, so
+ *  the frontend can back-fill `entryId` onto its live transcript and offer
+ *  rollback / fork before a reload. Best-effort: branching is the user's escape
+ *  hatch, never a turn-critical path, so any failure is swallowed. */
+function emitEntryIds(
+  deps: TabLifecycleDeps,
+  rec: TabRecord,
+  tabId: string,
+): void {
+  let branch: ReadonlyArray<unknown>;
+  try {
+    branch = rec.session.sessionManager.getBranch();
+  } catch {
+    return;
+  }
+  const entries: { entryId: string; role: "user" | "agent" }[] = [];
+  for (const raw of branch) {
+    const entry = raw as {
+      type?: string;
+      id?: unknown;
+      message?: { role?: unknown };
+    };
+    if (entry.type !== "message" || typeof entry.id !== "string") continue;
+    const role = entry.message?.role;
+    if (role === "user") entries.push({ entryId: entry.id, role: "user" });
+    else if (role === "assistant") {
+      entries.push({ entryId: entry.id, role: "agent" });
+    }
+  }
+  if (entries.length > 0) {
+    deps.send({ type: "entry_ids", tabId, entries });
   }
 }

--- a/agent/tab-lifecycle/lifecycle.ts
+++ b/agent/tab-lifecycle/lifecycle.ts
@@ -19,7 +19,11 @@ import {
 import type { Api, Model } from "@mariozechner/pi-ai";
 import { buildShellTools } from "../shell-tools";
 import { buildDashboardTools } from "../dashboard-tools";
-import { buildDevshellSpawnHook, ensureFetched as ensureDevshellFetched } from "../devshell";
+import { buildSubagentTaskTool } from "../subagents/task-tool";
+import {
+  buildDevshellSpawnHook,
+  ensureFetched as ensureDevshellFetched,
+} from "../devshell";
 import { wrapWithSourceGuard } from "../source-guard";
 import { logger } from "../logger";
 import { authProfileServicesForTab } from "../auth-profiles";
@@ -28,10 +32,7 @@ import type { AethonAgentState, TabRecord } from "../state";
 import { contextUsageSnapshot, emitContextUsage } from "../context-usage";
 import { handleSessionEvent } from "./events";
 import { installAethonRetryClassifier } from "./retry";
-import {
-  buildPickerModels,
-  ensurePickerHasModel,
-} from "./models";
+import { buildPickerModels, ensurePickerHasModel } from "./models";
 import { refreshPiSlashCommands } from "./slash-commands";
 import { modelDescriptor, modelKey, tabSessionDir } from "./utils";
 import type { TabLifecycleDeps } from "./utils";
@@ -122,6 +123,7 @@ export async function ensureTab(
       devshellBashTool,
       ...buildShellTools(),
       ...buildDashboardTools(),
+      buildSubagentTaskTool(state, deps, tabId),
     ],
     ...(options.initialModel ? { model: options.initialModel } : {}),
   });

--- a/agent/tabs.ts
+++ b/agent/tabs.ts
@@ -13,6 +13,7 @@ import {
   writeSessionLabel,
 } from "./session-history";
 import { ensureTab, tabSessionDir } from "./tab-lifecycle";
+import { refreshSubagents } from "./subagents";
 import { unloadProjectExtensions } from "./projectLifecycle";
 import { modelRegistryForModelId } from "./auth-profiles";
 import { clearPendingContextUsageEmit } from "./context-usage";
@@ -61,6 +62,8 @@ export async function handleTabOpen(
       deps.loadHooks,
     );
     state.currentProjectCwd = cwdOverride;
+    // Re-merge subagents so project-scoped definitions follow the active cwd.
+    if (projectChanged) refreshSubagents(state);
     if (
       result.loaded > 0 ||
       result.failed > 0 ||

--- a/agent/tabs.ts
+++ b/agent/tabs.ts
@@ -13,7 +13,6 @@ import {
   writeSessionLabel,
 } from "./session-history";
 import { ensureTab, tabSessionDir } from "./tab-lifecycle";
-import { refreshSubagents } from "./subagents";
 import { unloadProjectExtensions } from "./projectLifecycle";
 import { modelRegistryForModelId } from "./auth-profiles";
 import { clearPendingContextUsageEmit } from "./context-usage";
@@ -62,8 +61,6 @@ export async function handleTabOpen(
       deps.loadHooks,
     );
     state.currentProjectCwd = cwdOverride;
-    // Re-merge subagents so project-scoped definitions follow the active cwd.
-    if (projectChanged) refreshSubagents(state);
     if (
       result.loaded > 0 ||
       result.failed > 0 ||

--- a/bun.lock
+++ b/bun.lock
@@ -30,6 +30,7 @@
         "remark-gfm": "^4.0.1",
         "shiki": "^4",
         "typebox": "^1.1.34",
+        "yaml": "2.8.3",
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "shiki": "^4",
-    "typebox": "^1.1.34"
+    "typebox": "^1.1.34",
+    "yaml": "2.8.3"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/src-tauri/src/commands/fs/mod.rs
+++ b/src-tauri/src/commands/fs/mod.rs
@@ -27,6 +27,9 @@
 
 mod security;
 
+/// Symlink-escape guard reused by the subagent + session-branch commands.
+pub(crate) use security::ensure_symlink_safe;
+
 pub mod icons;
 pub mod io;
 pub mod listing;

--- a/src-tauri/src/commands/fs/security.rs
+++ b/src-tauri/src/commands/fs/security.rs
@@ -9,8 +9,9 @@
 //!   path inside `root` resolves through a symlink to somewhere outside
 //!   (e.g. a malicious `node_modules/foo/bar` -> `/etc/passwd`).
 //!
-//! Helpers stay `pub(super)` so sibling submodules can use them; nothing
-//! here is part of the crate-wide API.
+//! Most helpers stay `pub(super)` so sibling submodules can use them.
+//! `ensure_symlink_safe` is `pub(crate)` because the subagent + session-branch
+//! commands reuse the same symlink-escape guard (re-exported via `fs::`).
 
 use std::path::{Path, PathBuf};
 
@@ -58,7 +59,7 @@ fn canonicalize_existing_prefix(path: &Path) -> Result<PathBuf, String> {
 /// Verify the canonicalised existing prefix of `path` stays under
 /// `root_canon`. Catches the symlink-escape case where a path inside
 /// `root` resolves to a target outside of it.
-pub(super) fn ensure_symlink_safe(path: &Path, root_canon: &Path) -> Result<(), String> {
+pub(crate) fn ensure_symlink_safe(path: &Path, root_canon: &Path) -> Result<(), String> {
     let prefix = canonicalize_existing_prefix(path)?;
     if prefix == root_canon || prefix.starts_with(root_canon) {
         Ok(())

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -28,6 +28,7 @@ pub mod git;
 pub mod host;
 pub mod server;
 pub mod session;
+pub mod subagents;
 pub mod updater;
 pub mod voice;
 pub mod window;

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -216,6 +216,9 @@ fn copy_session_into_tab(
     let dest_dir = canonical_root.join(dest_tab_id);
     std::fs::create_dir_all(&dest_dir)
         .map_err(|e| format!("create_dir_all {}: {e}", dest_dir.display()))?;
+    // Symlink-aware: if `<sessions>/<dest_tab_id>` is (or resolves through) a
+    // symlink out of the sessions tree, reject before writing into it.
+    crate::commands::fs::ensure_symlink_safe(&dest_dir, &canonical_root)?;
     let dest_path = dest_dir.join(file_name);
     if resolve_inside_root(&dest_dir, &dest_path).is_none() {
         return Err("refusing to copy: dest escapes the tab dir".to_string());
@@ -485,6 +488,26 @@ mod tests {
 
         let err = copy_session_into_tab(&outside, &sessions, "tab-b").unwrap_err();
         assert!(err.contains("escapes the sessions root"), "got: {err}");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn copy_session_into_tab_rejects_symlinked_dest_dir() {
+        use std::os::unix::fs::symlink;
+        let root = copy_test_root();
+        let sessions = root.join("sessions");
+        let src_dir = sessions.join("tab-a");
+        std::fs::create_dir_all(&src_dir).expect("create src tab dir");
+        let src = src_dir.join("x.jsonl");
+        std::fs::write(&src, "{}\n").expect("write source");
+        // A pre-existing dest tab dir that's a symlink pointing outside sessions.
+        let evil = root.join("evil");
+        std::fs::create_dir_all(&evil).expect("create evil dir");
+        symlink(&evil, sessions.join("tabb")).expect("symlink dest");
+
+        let err = copy_session_into_tab(&src, &sessions, "tabb").unwrap_err();
+        assert!(err.contains("symlink escapes"), "got: {err}");
         let _ = std::fs::remove_dir_all(&root);
     }
 

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -6,11 +6,11 @@
 //! a rendered chat to `~/Downloads/`. Snippet building lives here too
 //! so UTF-16 / multibyte indexing pitfalls stay Rust-side.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use tauri::{AppHandle, Manager};
 
-use crate::helpers::sanitize_filename_segment;
+use crate::helpers::{resolve_inside_root, sanitize_filename_segment};
 
 /// Cross-session search (M6 P6). Walks `~/.aethon/sessions/<tabId>/*.jsonl`
 /// and returns user / assistant messages whose text content contains
@@ -162,6 +162,71 @@ pub fn delete_session(tab_id: String, app: AppHandle) -> Result<(), String> {
         .join("sessions");
     let target = sessions_root.join(&tab_id);
     delete_session_dir(target, sessions_root)
+}
+
+/// Move a freshly-branched session file (produced by `createBranchedSession`
+/// into the *source* tab's dir) into a new tab's session directory, so the
+/// per-tab layout the bridge expects holds for the fork. Used by `fork_session`.
+///
+/// `source_path` is supplied by the bridge; we trust nothing about it — it must
+/// canonicalize to a real file that already lives under `~/.aethon/sessions`
+/// (blocking a spoofed path at `/etc/...`), and the destination is pinned to
+/// `<sessions>/<dest_tab_id>/` with a validated tab id + lexical inside-root
+/// check. Returns the absolute destination path.
+#[tauri::command]
+pub fn copy_session_file(
+    source_path: String,
+    dest_tab_id: String,
+    app: AppHandle,
+) -> Result<String, String> {
+    let home = app
+        .path()
+        .home_dir()
+        .map_err(|e| format!("home_dir: {e}"))?;
+    let sessions_root = crate::helpers::aethon_dir(Some(home))
+        .ok_or_else(|| "aethon dir unresolved".to_string())?
+        .join("sessions");
+    let dest = copy_session_into_tab(Path::new(&source_path), &sessions_root, &dest_tab_id)?;
+    Ok(dest.to_string_lossy().into_owned())
+}
+
+fn copy_session_into_tab(
+    source_path: &Path,
+    sessions_root: &Path,
+    dest_tab_id: &str,
+) -> Result<PathBuf, String> {
+    validate_session_tab_id(dest_tab_id)?;
+    // The source must exist and live under the sessions root (it was produced by
+    // createBranchedSession into a tab dir). Canonicalize both so a symlink or
+    // `..` can't smuggle a path outside the tree past the prefix check.
+    let canonical_root = std::fs::canonicalize(sessions_root)
+        .map_err(|e| format!("canonicalize sessions root: {e}"))?;
+    let canonical_source =
+        std::fs::canonicalize(source_path).map_err(|e| format!("canonicalize source: {e}"))?;
+    if !canonical_source.starts_with(&canonical_root) {
+        return Err("refusing to copy: source escapes the sessions root".to_string());
+    }
+    if !canonical_source.is_file() {
+        return Err("source is not a file".to_string());
+    }
+    let file_name = canonical_source
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| "source has no file name".to_string())?;
+    let dest_dir = canonical_root.join(dest_tab_id);
+    std::fs::create_dir_all(&dest_dir)
+        .map_err(|e| format!("create_dir_all {}: {e}", dest_dir.display()))?;
+    let dest_path = dest_dir.join(file_name);
+    if resolve_inside_root(&dest_dir, &dest_path).is_none() {
+        return Err("refusing to copy: dest escapes the tab dir".to_string());
+    }
+    // Rename when same-filesystem (atomic); copy + remove for cross-device.
+    if std::fs::rename(&canonical_source, &dest_path).is_err() {
+        std::fs::copy(&canonical_source, &dest_path)
+            .map_err(|e| format!("copy {}: {e}", dest_path.display()))?;
+        let _ = std::fs::remove_file(&canonical_source);
+    }
+    Ok(dest_path)
 }
 
 fn validate_session_tab_id(tab_id: &str) -> Result<(), String> {
@@ -356,7 +421,8 @@ pub fn export_chat_markdown(
 
 #[cfg(test)]
 mod tests {
-    use super::{delete_session_dir, validate_session_tab_id};
+    use super::{copy_session_into_tab, delete_session_dir, validate_session_tab_id};
+    use std::path::PathBuf;
 
     #[test]
     fn validate_session_tab_id_allows_default() {
@@ -382,5 +448,57 @@ mod tests {
         delete_session_dir(default_dir.clone(), sessions).expect("delete default session");
         assert!(!default_dir.exists());
         let _ = std::fs::remove_dir_all(root);
+    }
+
+    fn copy_test_root() -> PathBuf {
+        std::env::temp_dir().join(format!("aethon-session-copy-{}", uuid::Uuid::new_v4()))
+    }
+
+    #[test]
+    fn copy_session_into_tab_moves_file_and_preserves_header() {
+        let root = copy_test_root();
+        let sessions = root.join("sessions");
+        let src_dir = sessions.join("tab-a");
+        std::fs::create_dir_all(&src_dir).expect("create src tab dir");
+        let header = "{\"type\":\"session\",\"id\":\"s1\",\"cwd\":\"/proj\"}\n{\"type\":\"message\",\"id\":\"m1\"}\n";
+        let src = src_dir.join("123_branch.jsonl");
+        std::fs::write(&src, header).expect("write source session");
+
+        let dest = copy_session_into_tab(&src, &sessions, "tab-b").expect("copy into tab-b");
+
+        assert!(dest.ends_with("123_branch.jsonl"));
+        assert!(dest.starts_with(std::fs::canonicalize(&sessions).unwrap().join("tab-b")));
+        assert_eq!(std::fs::read_to_string(&dest).unwrap(), header);
+        // Move semantics: the branched source is gone.
+        assert!(!src.exists());
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn copy_session_into_tab_rejects_source_outside_sessions_root() {
+        let root = copy_test_root();
+        let sessions = root.join("sessions");
+        std::fs::create_dir_all(&sessions).expect("create sessions root");
+        // A real file, but outside the sessions tree.
+        let outside = root.join("outside.jsonl");
+        std::fs::write(&outside, "{}\n").expect("write outside file");
+
+        let err = copy_session_into_tab(&outside, &sessions, "tab-b").unwrap_err();
+        assert!(err.contains("escapes the sessions root"), "got: {err}");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn copy_session_into_tab_rejects_invalid_dest_tab_id() {
+        let root = copy_test_root();
+        let sessions = root.join("sessions");
+        let src_dir = sessions.join("tab-a");
+        std::fs::create_dir_all(&src_dir).expect("create src tab dir");
+        let src = src_dir.join("x.jsonl");
+        std::fs::write(&src, "{}\n").expect("write source");
+
+        assert!(copy_session_into_tab(&src, &sessions, "../escape").is_err());
+        assert!(copy_session_into_tab(&src, &sessions, "nested/id").is_err());
+        let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/src-tauri/src/commands/subagents.rs
+++ b/src-tauri/src/commands/subagents.rs
@@ -51,6 +51,11 @@ fn is_safe_subagent_name(name: &str) -> bool {
 
 fn read_capped(path: &Path) -> Option<String> {
     let file = std::fs::File::open(path).ok()?;
+    // Skip (not truncate) oversized files — a partial read would feed broken
+    // YAML/frontmatter to the parser. Matches the bridge loader's size cap.
+    if file.metadata().ok()?.len() > MAX_SUBAGENT_BYTES {
+        return None;
+    }
     let mut buf = String::new();
     file.take(MAX_SUBAGENT_BYTES)
         .read_to_string(&mut buf)
@@ -183,30 +188,11 @@ fn assert_inside_project(
     if resolve_inside_root(&root, target).is_none() {
         return Err("refusing to touch a path outside the project root".to_string());
     }
+    // Symlink-aware second pass: canonicalize the deepest existing ancestor and
+    // verify it stays under the canonical project root (shared fs helper).
     let canonical_root =
         std::fs::canonicalize(&root).map_err(|e| format!("canonicalize project root: {e}"))?;
-    // Walk up to the deepest component that already exists on disk (the target
-    // file usually doesn't yet), then canonicalize it to resolve any symlinks.
-    let mut probe: &Path = target;
-    let existing = loop {
-        if probe.exists() {
-            break Some(probe);
-        }
-        match probe.parent() {
-            Some(parent) => probe = parent,
-            None => break None,
-        }
-    };
-    if let Some(existing) = existing {
-        let canonical = std::fs::canonicalize(existing)
-            .map_err(|e| format!("canonicalize {}: {e}", existing.display()))?;
-        if !canonical.starts_with(&canonical_root) {
-            return Err(
-                "refusing to touch a path that escapes the project root via a symlink".to_string(),
-            );
-        }
-    }
-    Ok(())
+    crate::commands::fs::ensure_symlink_safe(target, &canonical_root)
 }
 
 /// Nudge every running bridge to re-merge its subagent registry. Best-effort —
@@ -355,6 +341,19 @@ mod tests {
         fs::write(dir.join("notes.txt"), "x").unwrap();
         fs::write(dir.join(".hidden.md"), "x").unwrap();
         let listed = list_in_dir(&dir, "user");
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].name, "good");
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn list_skips_oversized_file_without_truncating() {
+        let dir = tmpdir();
+        fs::write(dir.join("good.md"), "---\ndescription: d\n---\nbody").unwrap();
+        let big = format!("---\ndescription: big\n---\n{}", "x".repeat(70 * 1024));
+        fs::write(dir.join("big.md"), big).unwrap();
+        let listed = list_in_dir(&dir, "user");
+        // The oversized file is omitted entirely (not truncated into the list).
         assert_eq!(listed.len(), 1);
         assert_eq!(listed[0].name, "good");
         fs::remove_dir_all(&dir).ok();

--- a/src-tauri/src/commands/subagents.rs
+++ b/src-tauri/src/commands/subagents.rs
@@ -1,0 +1,354 @@
+//! Subagent definition CRUD for the overview UI.
+//!
+//! Subagents live as one markdown-with-frontmatter file per definition:
+//!
+//!   ~/.aethon/agents/<name>.md            (user scope, global)
+//!   <project>/.aethon/agents/<name>.md    (project scope, overrides user)
+//!
+//! Rust owns only the **file IO** (list / write / delete) with the usual
+//! path-safety guards; *parsing* the frontmatter is the agent bridge's and the
+//! frontend's job (a single TS parser, mirrored), so the markdown contract
+//! never diverges across two languages. After a mutation we nudge the running
+//! bridge(s) with a `subagents_changed` line so the registry re-merges and the
+//! system prompt re-advertises without a restart.
+
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use serde::Serialize;
+use tauri::{AppHandle, Manager, State};
+
+use crate::agent_process::AgentProcesses;
+use crate::helpers::{self, resolve_inside_root};
+
+/// Hard cap on a single definition file, matching the config.toml convention.
+const MAX_SUBAGENT_BYTES: u64 = 64 * 1024;
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SubagentFile {
+    pub scope: String,
+    pub name: String,
+    pub file_path: String,
+    pub content: String,
+}
+
+/// Canonical name shape, mirroring the TS `isSafeSubagentName`:
+/// lower-case, `[a-z0-9_-]`, starting alphanumeric, ≤64 chars.
+fn is_safe_subagent_name(name: &str) -> bool {
+    if name.is_empty() || name.len() > 64 {
+        return false;
+    }
+    let mut chars = name.chars();
+    let first = chars.next().expect("non-empty checked above");
+    if !(first.is_ascii_lowercase() || first.is_ascii_digit()) {
+        return false;
+    }
+    name.chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-' || c == '_')
+}
+
+fn read_capped(path: &Path) -> Option<String> {
+    let file = std::fs::File::open(path).ok()?;
+    let mut buf = String::new();
+    file.take(MAX_SUBAGENT_BYTES)
+        .read_to_string(&mut buf)
+        .ok()?;
+    Some(buf)
+}
+
+/// List every `<safe-name>.md` definition in `dir`, sorted by name. Missing or
+/// unreadable directory → empty (no subagents at this scope). Unsafe filenames
+/// and oversized files are skipped silently — the bridge surfaces load issues.
+fn list_in_dir(dir: &Path, scope: &str) -> Vec<SubagentFile> {
+    let mut names: Vec<(String, PathBuf)> = Vec::new();
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let Some(file_name) = path.file_name().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        if file_name.starts_with('.') || !file_name.to_ascii_lowercase().ends_with(".md") {
+            continue;
+        }
+        let stem = &file_name[..file_name.len() - 3];
+        let name = stem.to_ascii_lowercase();
+        if !is_safe_subagent_name(&name) {
+            continue;
+        }
+        names.push((name, path));
+    }
+    names.sort_by(|a, b| a.0.cmp(&b.0));
+    names
+        .into_iter()
+        .filter_map(|(name, path)| {
+            read_capped(&path).map(|content| SubagentFile {
+                scope: scope.to_string(),
+                name,
+                file_path: path.to_string_lossy().into_owned(),
+                content,
+            })
+        })
+        .collect()
+}
+
+/// Atomically write `<name>.md` into `dir` (tmp + rename). Validates the name
+/// and size; creates the directory on demand. Returns the written path.
+fn write_in_dir(dir: &Path, name: &str, content: &str) -> Result<PathBuf, String> {
+    if !is_safe_subagent_name(name) {
+        return Err(format!("invalid subagent name: {name}"));
+    }
+    if content.len() as u64 > MAX_SUBAGENT_BYTES {
+        return Err(format!(
+            "subagent definition too large ({} bytes; max {MAX_SUBAGENT_BYTES})",
+            content.len()
+        ));
+    }
+    std::fs::create_dir_all(dir).map_err(|e| format!("create_dir_all {}: {e}", dir.display()))?;
+    let target = dir.join(format!("{name}.md"));
+    let tmp = dir.join(format!("{name}.md.tmp"));
+    std::fs::write(&tmp, content).map_err(|e| format!("write {}: {e}", tmp.display()))?;
+    std::fs::rename(&tmp, &target).map_err(|e| {
+        // Best-effort cleanup so a failed rename doesn't strand a .tmp file.
+        let _ = std::fs::remove_file(&tmp);
+        format!("rename {}: {e}", target.display())
+    })?;
+    Ok(target)
+}
+
+/// Delete `<name>.md` from `dir`. Idempotent — a missing file is success.
+fn delete_in_dir(dir: &Path, name: &str) -> Result<(), String> {
+    if !is_safe_subagent_name(name) {
+        return Err(format!("invalid subagent name: {name}"));
+    }
+    let target = dir.join(format!("{name}.md"));
+    match std::fs::remove_file(&target) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(format!("delete {}: {e}", target.display())),
+    }
+}
+
+/// Resolve the agents directory for a scope. `user` → `~/.aethon/agents`;
+/// `project` → `<project_root>/.aethon/agents` (root must be absolute).
+fn scope_agents_dir(
+    scope: &str,
+    project_root: Option<&str>,
+    app: &AppHandle,
+) -> Result<PathBuf, String> {
+    match scope {
+        "user" => {
+            let home = app
+                .path()
+                .home_dir()
+                .map_err(|e| format!("home_dir: {e}"))?;
+            let dir = helpers::aethon_dir(Some(home))
+                .ok_or_else(|| "aethon dir unresolved".to_string())?;
+            Ok(dir.join("agents"))
+        }
+        "project" => {
+            let root =
+                project_root.ok_or_else(|| "project scope requires project_root".to_string())?;
+            let root_path = PathBuf::from(root);
+            if !root_path.is_absolute() {
+                return Err("project_root must be absolute".to_string());
+            }
+            Ok(root_path.join(".aethon").join("agents"))
+        }
+        other => Err(format!("invalid scope: {other}")),
+    }
+}
+
+/// Belt-and-suspenders: for project scope, refuse a target that lexically
+/// escapes the project root (the safe-name check already blocks separators).
+fn assert_inside_project(
+    scope: &str,
+    project_root: Option<&str>,
+    target: &Path,
+) -> Result<(), String> {
+    if scope != "project" {
+        return Ok(());
+    }
+    let root = PathBuf::from(project_root.ok_or_else(|| "project_root required".to_string())?);
+    if resolve_inside_root(&root, target).is_none() {
+        return Err("refusing to touch a path outside the project root".to_string());
+    }
+    Ok(())
+}
+
+/// Nudge every running bridge to re-merge its subagent registry. Best-effort —
+/// a wedged child is simply skipped (the next project change / boot re-reads).
+fn notify_bridge_subagents_changed(app: &AppHandle) {
+    let state: State<'_, AgentProcesses> = app.state();
+    let children: Vec<Arc<_>> = match state.children.lock() {
+        Ok(guard) => guard.values().map(Arc::clone).collect(),
+        Err(_) => return,
+    };
+    for child in children {
+        if let Ok(mut child) = child.lock()
+            && let Some(stdin) = child.stdin.as_mut()
+        {
+            use std::io::Write;
+            let _ =
+                writeln!(stdin, "{{\"type\":\"subagents_changed\"}}").and_then(|_| stdin.flush());
+        }
+    }
+}
+
+/// List the merged-by-the-caller subagent files across user scope and (when a
+/// project is active) project scope. Returns raw content per file; the frontend
+/// parses + merges (project wins by name).
+#[tauri::command]
+pub fn subagents_list(
+    project_root: Option<String>,
+    app: AppHandle,
+) -> Result<Vec<SubagentFile>, String> {
+    let mut out = Vec::new();
+    let user_dir = scope_agents_dir("user", None, &app)?;
+    out.extend(list_in_dir(&user_dir, "user"));
+    if let Some(root) = project_root.as_deref() {
+        let project_dir = scope_agents_dir("project", Some(root), &app)?;
+        out.extend(list_in_dir(&project_dir, "project"));
+    }
+    Ok(out)
+}
+
+/// Create or replace a subagent definition at the given scope.
+#[tauri::command]
+pub fn subagents_write(
+    scope: String,
+    name: String,
+    content: String,
+    project_root: Option<String>,
+    app: AppHandle,
+) -> Result<(), String> {
+    let name = name.trim().to_ascii_lowercase();
+    let dir = scope_agents_dir(&scope, project_root.as_deref(), &app)?;
+    let target = dir.join(format!("{name}.md"));
+    assert_inside_project(&scope, project_root.as_deref(), &target)?;
+    write_in_dir(&dir, &name, &content)?;
+    notify_bridge_subagents_changed(&app);
+    Ok(())
+}
+
+/// Delete a subagent definition at the given scope.
+#[tauri::command]
+pub fn subagents_delete(
+    scope: String,
+    name: String,
+    project_root: Option<String>,
+    app: AppHandle,
+) -> Result<(), String> {
+    let name = name.trim().to_ascii_lowercase();
+    let dir = scope_agents_dir(&scope, project_root.as_deref(), &app)?;
+    let target = dir.join(format!("{name}.md"));
+    assert_inside_project(&scope, project_root.as_deref(), &target)?;
+    delete_in_dir(&dir, &name)?;
+    notify_bridge_subagents_changed(&app);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn tmpdir() -> PathBuf {
+        let base = std::env::temp_dir().join(format!(
+            "aethon-subagents-test-{}-{}",
+            std::process::id(),
+            // A monotonic-ish suffix without Date::now (unavailable here):
+            // use a static atomic counter.
+            next_id(),
+        ));
+        fs::create_dir_all(&base).unwrap();
+        base
+    }
+
+    fn next_id() -> u64 {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static N: AtomicU64 = AtomicU64::new(0);
+        N.fetch_add(1, Ordering::Relaxed)
+    }
+
+    #[test]
+    fn safe_name_accepts_and_rejects() {
+        assert!(is_safe_subagent_name("reviewer"));
+        assert!(is_safe_subagent_name("code-reviewer_2"));
+        assert!(is_safe_subagent_name("a"));
+        assert!(!is_safe_subagent_name(""));
+        assert!(!is_safe_subagent_name("-lead"));
+        assert!(!is_safe_subagent_name("UPPER"));
+        assert!(!is_safe_subagent_name("has space"));
+        assert!(!is_safe_subagent_name("../escape"));
+        assert!(!is_safe_subagent_name(&"x".repeat(65)));
+    }
+
+    #[test]
+    fn write_list_delete_round_trip() {
+        let dir = tmpdir();
+        let body = "---\ndescription: Reviews\nmodel: ollama/llama3.3\n---\nYou review.";
+        let written = write_in_dir(&dir, "reviewer", body).expect("write");
+        assert!(written.ends_with("reviewer.md"));
+
+        let listed = list_in_dir(&dir, "user");
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].name, "reviewer");
+        assert_eq!(listed[0].scope, "user");
+        assert_eq!(listed[0].content, body);
+
+        delete_in_dir(&dir, "reviewer").expect("delete");
+        assert!(list_in_dir(&dir, "user").is_empty());
+        // Delete is idempotent.
+        delete_in_dir(&dir, "reviewer").expect("idempotent delete");
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn write_rejects_unsafe_name_and_oversize() {
+        let dir = tmpdir();
+        assert!(write_in_dir(&dir, "Bad Name", "x").is_err());
+        let big = "x".repeat((MAX_SUBAGENT_BYTES + 1) as usize);
+        assert!(write_in_dir(&dir, "ok", &big).is_err());
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn list_skips_unsafe_and_non_markdown() {
+        let dir = tmpdir();
+        fs::write(dir.join("good.md"), "---\ndescription: d\n---\nbody").unwrap();
+        fs::write(dir.join("Bad Name.md"), "x").unwrap();
+        fs::write(dir.join("notes.txt"), "x").unwrap();
+        fs::write(dir.join(".hidden.md"), "x").unwrap();
+        let listed = list_in_dir(&dir, "user");
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].name, "good");
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn list_missing_dir_is_empty() {
+        let dir = std::env::temp_dir().join("aethon-subagents-does-not-exist-xyz");
+        assert!(list_in_dir(&dir, "user").is_empty());
+    }
+
+    #[test]
+    fn assert_inside_project_rejects_escape() {
+        // A safe name can never escape, but the guard must reject a crafted
+        // target that lexically leaves the root.
+        let root = "/projects/aethon";
+        let inside = PathBuf::from("/projects/aethon/.aethon/agents/reviewer.md");
+        assert!(assert_inside_project("project", Some(root), &inside).is_ok());
+        let outside = PathBuf::from("/projects/other/.aethon/agents/x.md");
+        assert!(assert_inside_project("project", Some(root), &outside).is_err());
+        // User scope is never project-guarded.
+        assert!(assert_inside_project("user", None, &outside).is_ok());
+    }
+}

--- a/src-tauri/src/commands/subagents.rs
+++ b/src-tauri/src/commands/subagents.rs
@@ -165,8 +165,12 @@ fn scope_agents_dir(
     }
 }
 
-/// Belt-and-suspenders: for project scope, refuse a target that lexically
-/// escapes the project root (the safe-name check already blocks separators).
+/// For project scope, refuse a target that escapes the project root — both
+/// lexically (the safe-name check already blocks separators) AND via symlinks:
+/// if `.aethon` / `.aethon/agents` is a symlink to a directory outside the
+/// project, the lexical check passes but the file op would follow it. So we
+/// also canonicalize the deepest existing ancestor and verify it still lives
+/// under the canonical project root (same defence as the fs commands).
 fn assert_inside_project(
     scope: &str,
     project_root: Option<&str>,
@@ -178,6 +182,29 @@ fn assert_inside_project(
     let root = PathBuf::from(project_root.ok_or_else(|| "project_root required".to_string())?);
     if resolve_inside_root(&root, target).is_none() {
         return Err("refusing to touch a path outside the project root".to_string());
+    }
+    let canonical_root =
+        std::fs::canonicalize(&root).map_err(|e| format!("canonicalize project root: {e}"))?;
+    // Walk up to the deepest component that already exists on disk (the target
+    // file usually doesn't yet), then canonicalize it to resolve any symlinks.
+    let mut probe: &Path = target;
+    let existing = loop {
+        if probe.exists() {
+            break Some(probe);
+        }
+        match probe.parent() {
+            Some(parent) => probe = parent,
+            None => break None,
+        }
+    };
+    if let Some(existing) = existing {
+        let canonical = std::fs::canonicalize(existing)
+            .map_err(|e| format!("canonicalize {}: {e}", existing.display()))?;
+        if !canonical.starts_with(&canonical_root) {
+            return Err(
+                "refusing to touch a path that escapes the project root via a symlink".to_string(),
+            );
+        }
     }
     Ok(())
 }
@@ -340,15 +367,39 @@ mod tests {
     }
 
     #[test]
-    fn assert_inside_project_rejects_escape() {
-        // A safe name can never escape, but the guard must reject a crafted
-        // target that lexically leaves the root.
-        let root = "/projects/aethon";
-        let inside = PathBuf::from("/projects/aethon/.aethon/agents/reviewer.md");
-        assert!(assert_inside_project("project", Some(root), &inside).is_ok());
-        let outside = PathBuf::from("/projects/other/.aethon/agents/x.md");
-        assert!(assert_inside_project("project", Some(root), &outside).is_err());
+    fn assert_inside_project_accepts_inside_and_rejects_lexical_escape() {
+        let base = tmpdir();
+        let root = base.join("project");
+        fs::create_dir_all(&root).unwrap();
+        let root_str = root.to_str().unwrap();
+
+        let inside = root.join(".aethon").join("agents").join("reviewer.md");
+        assert!(assert_inside_project("project", Some(root_str), &inside).is_ok());
+
+        let outside = base.join("other").join("x.md");
+        assert!(assert_inside_project("project", Some(root_str), &outside).is_err());
+
         // User scope is never project-guarded.
         assert!(assert_inside_project("user", None, &outside).is_ok());
+        fs::remove_dir_all(&base).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn assert_inside_project_rejects_symlinked_aethon_dir() {
+        use std::os::unix::fs::symlink;
+        let base = tmpdir();
+        let root = base.join("project");
+        fs::create_dir_all(&root).unwrap();
+        // An attacker-controlled `.aethon` symlink pointing outside the project.
+        let evil = base.join("evil");
+        fs::create_dir_all(&evil).unwrap();
+        symlink(&evil, root.join(".aethon")).unwrap();
+
+        // The lexical check passes, but canonicalizing the existing `.aethon`
+        // symlink resolves outside the root, so the guard must reject it.
+        let target = root.join(".aethon").join("agents").join("x.md");
+        assert!(assert_inside_project("project", Some(root.to_str().unwrap()), &target).is_err());
+        fs::remove_dir_all(&base).ok();
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -172,6 +172,7 @@ pub fn run() {
             commands::session::search_sessions,
             commands::session::delete_session,
             commands::session::export_chat_markdown,
+            commands::session::copy_session_file,
             commands::subagents::subagents_list,
             commands::subagents::subagents_write,
             commands::subagents::subagents_delete,
@@ -399,12 +400,13 @@ mod tests {
     }
 
     #[test]
-    fn subagents_commands_are_wired_to_handler() {
+    fn subagents_and_session_branch_commands_are_wired_to_handler() {
         let src = include_str!("lib.rs");
         for command in [
             "commands::subagents::subagents_list",
             "commands::subagents::subagents_write",
             "commands::subagents::subagents_delete",
+            "commands::session::copy_session_file",
         ] {
             assert!(
                 src.contains(command),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -172,6 +172,9 @@ pub fn run() {
             commands::session::search_sessions,
             commands::session::delete_session,
             commands::session::export_chat_markdown,
+            commands::subagents::subagents_list,
+            commands::subagents::subagents_write,
+            commands::subagents::subagents_delete,
             commands::extensions::set_extension_menu_items,
             commands::extensions::install_aethon_extension,
             commands::extensions::watch_project_extensions,
@@ -393,6 +396,21 @@ mod tests {
             src.contains("commands::git::status::git_fetch_all"),
             "git_fetch_all must be registered in the invoke_handler list",
         );
+    }
+
+    #[test]
+    fn subagents_commands_are_wired_to_handler() {
+        let src = include_str!("lib.rs");
+        for command in [
+            "commands::subagents::subagents_list",
+            "commands::subagents::subagents_write",
+            "commands::subagents::subagents_delete",
+        ] {
+            assert!(
+                src.contains(command),
+                "{command} must stay registered in the invoke_handler list",
+            );
+        }
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -684,6 +684,7 @@ export default function App() {
     pendingTabOpens,
     updateTab,
     updateActiveTab,
+    newTab,
     dispatchTerminalReplay,
     autoRestoreDiscoveredSessions,
     hydrateThemes,

--- a/src/eventRoutes/index.ts
+++ b/src/eventRoutes/index.ts
@@ -30,6 +30,7 @@ import { handleShellConsent } from "./shellConsent";
 import { matchesExtensionRoute } from "./extensions";
 import { handleChatInput } from "./chatInput";
 import { handleChatMessages } from "./chatMessages";
+import { handleSessionBranch } from "./session";
 import { handleComposerPills } from "./composerPills";
 import { handleQueuedMessages } from "./queue";
 import { handleSettings } from "./settings";
@@ -96,8 +97,8 @@ export const BUILTIN_ROUTE_TABLE: ReadonlyMap<string, readonly EventRouteHandler
     // handleChatInput unchanged.
     ["type:chat-input", [handleQueuedMessages, handleChatInput]],
     ["type:composer-visibility-pills", [handleComposerPills]],
-    ["type:chat-history", [handleChatMessages]],
-    ["type:main-canvas", [handleChatMessages]],
+    ["type:chat-history", [handleChatMessages, handleSessionBranch]],
+    ["type:main-canvas", [handleChatMessages, handleSessionBranch]],
     ["type:queued-messages-popover", [handleQueuedMessages]],
     ["type:empty-state", [handleEmptyState]],
     // Worktree landing — session rows share dashboard restore/delete

--- a/src/eventRoutes/session.test.ts
+++ b/src/eventRoutes/session.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { handleSessionBranch } from "./session";
+import { buildRouteFixture } from "./testFixtures";
+import type { Tab } from "../types/tab";
+import type { ChatMessage } from "../types/a2ui";
+
+const event = (eventType: string, data: Record<string, unknown>) => ({
+  component: { id: "chat", type: "chat-history" },
+  eventType,
+  data,
+});
+
+describe("handleSessionBranch", () => {
+  it("rollback-to-here truncates optimistically and asks the bridge to branch", async () => {
+    const { ctx, mocks } = buildRouteFixture({ state: { activeTabId: "t1" } });
+    const handled = await handleSessionBranch(
+      event("rollback-to-here", { entryId: "e2" }),
+      ctx,
+    );
+    expect(handled).toBe(true);
+
+    // Optimistic truncate: apply the captured updater to a sample tab.
+    const updater = mocks.updateActiveTab.mock.calls[0][0] as (t: Tab) => Tab;
+    const messages: ChatMessage[] = [
+      { id: "1", entryId: "e1", role: "user", text: "a" },
+      { id: "2", entryId: "e2", role: "agent", text: "b" },
+      { id: "3", entryId: "e3", role: "user", text: "c" },
+    ];
+    const next = updater({ id: "t1", messages, waiting: true } as Tab);
+    expect(next.messages.map((m) => m.id)).toEqual(["1", "2"]);
+    expect(next.waiting).toBe(false);
+
+    expect(mocks.invoke).toHaveBeenCalledWith("agent_command", {
+      payload: JSON.stringify({
+        type: "rollback_session",
+        tabId: "t1",
+        entryId: "e2",
+      }),
+    });
+  });
+
+  it("fork-to-tab asks the bridge to fork", async () => {
+    const { ctx, mocks } = buildRouteFixture({ state: { activeTabId: "t1" } });
+    const handled = await handleSessionBranch(
+      event("fork-to-tab", { entryId: "e2" }),
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.invoke).toHaveBeenCalledWith("agent_command", {
+      payload: JSON.stringify({
+        type: "fork_session",
+        tabId: "t1",
+        entryId: "e2",
+      }),
+    });
+  });
+
+  it("ignores unrelated events and missing entryId", async () => {
+    const { ctx } = buildRouteFixture({ state: { activeTabId: "t1" } });
+    expect(await handleSessionBranch(event("retry", {}), ctx)).toBe(false);
+    expect(await handleSessionBranch(event("rollback-to-here", {}), ctx)).toBe(
+      false,
+    );
+  });
+});

--- a/src/eventRoutes/session.ts
+++ b/src/eventRoutes/session.ts
@@ -1,0 +1,53 @@
+import type { EventRouteHandler } from "./types";
+import { truncateToEntry } from "../utils/messages";
+
+function str(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+/**
+ * Rollback / fork affordances fired from a transcript row (the per-message
+ * hover toolbar in the chat-history / main-canvas surfaces).
+ *
+ *  - `rollback-to-here`: optimistically truncate the rendered transcript to the
+ *    chosen message, then ask the bridge to branch the session there. The
+ *    bridge's `session_rolled_back` reply reconciles authoritatively.
+ *  - `fork-to-tab`: ask the bridge to extract the branch into a new session;
+ *    the bridge's `session_forked` reply copies the file + opens the new tab.
+ *
+ * Both are keyed off `entryId` (the pi session entry id carried on the row).
+ */
+export const handleSessionBranch: EventRouteHandler = (
+  { eventType, data },
+  ctx,
+) => {
+  const record =
+    data && typeof data === "object" ? (data as Record<string, unknown>) : {};
+  const entryId = str(record.entryId);
+
+  if (eventType === "rollback-to-here") {
+    if (!entryId) return false;
+    const tabId = str(ctx.stateRef.current.activeTabId);
+    ctx.updateActiveTab((tab) => {
+      const messages = truncateToEntry(tab.messages, entryId);
+      return messages === tab.messages
+        ? tab
+        : { ...tab, messages, waiting: false };
+    });
+    void ctx.invoke("agent_command", {
+      payload: JSON.stringify({ type: "rollback_session", tabId, entryId }),
+    });
+    return true;
+  }
+
+  if (eventType === "fork-to-tab") {
+    if (!entryId) return false;
+    const tabId = str(ctx.stateRef.current.activeTabId);
+    void ctx.invoke("agent_command", {
+      payload: JSON.stringify({ type: "fork_session", tabId, entryId }),
+    });
+    return true;
+  }
+
+  return false;
+};

--- a/src/extensions/default-layout/dashboard/project-dashboard.tsx
+++ b/src/extensions/default-layout/dashboard/project-dashboard.tsx
@@ -56,10 +56,13 @@ interface DashboardWidget {
 }
 
 function isRef(v: unknown): v is { $ref: string } {
-  return typeof v === "object" && v !== null && "$ref" in (v);
+  return typeof v === "object" && v !== null && "$ref" in v;
 }
 
-function resolveOrInline<T>(v: unknown, state: Record<string, unknown>): T | null {
+function resolveOrInline<T>(
+  v: unknown,
+  state: Record<string, unknown>,
+): T | null {
   if (!v) return null;
   if (isRef(v)) {
     const r = resolvePointer(state, v.$ref);
@@ -170,7 +173,8 @@ export function ProjectDashboard({
   const overviewData = overview?.path === project?.path ? overview?.data : null;
 
   if (!project) return null;
-  const iconUrl = projectIconUrlFromSidebar(state, project.id) ?? project.iconUrl;
+  const iconUrl =
+    projectIconUrlFromSidebar(state, project.id) ?? project.iconUrl;
 
   return (
     <div className="a2ui-project-dashboard">
@@ -237,6 +241,17 @@ export function ProjectDashboard({
               project,
               activeWorktreeIdRef: { $ref: "/activeWorktreeId" },
             }}
+          />
+        </section>
+
+        <section className="a2ui-project-dashboard-section">
+          <RegistryComponent
+            type="subagents-config"
+            state={state}
+            onEvent={(_component, eventType, data) =>
+              onEvent(eventType, data, "subagents-config")
+            }
+            componentProps={{ scope: "project", projectPath: project.path }}
           />
         </section>
 

--- a/src/extensions/default-layout/dashboard/projects-dashboard.tsx
+++ b/src/extensions/default-layout/dashboard/projects-dashboard.tsx
@@ -29,7 +29,12 @@ interface ProjectListItem {
   path: string;
   active?: boolean;
   iconUrl?: string;
-  gitStatus?: { branch?: string; dirty?: boolean; ahead?: number; behind?: number };
+  gitStatus?: {
+    branch?: string;
+    dirty?: boolean;
+    ahead?: number;
+    behind?: number;
+  };
 }
 
 interface HostBannerInfo {
@@ -39,7 +44,10 @@ interface HostBannerInfo {
   isLocal: boolean;
 }
 
-function resolveOptional<T>(v: unknown, state: Record<string, unknown>): T | null {
+function resolveOptional<T>(
+  v: unknown,
+  state: Record<string, unknown>,
+): T | null {
   if (!v) return null;
   if (isRef(v)) {
     const r = resolvePointer(state, v.$ref);
@@ -62,7 +70,7 @@ interface ExtraCard {
 }
 
 function isRef(v: unknown): v is { $ref: string } {
-  return typeof v === "object" && v !== null && "$ref" in (v);
+  return typeof v === "object" && v !== null && "$ref" in v;
 }
 
 function resolveArray<T>(v: unknown, state: Record<string, unknown>): T[] {
@@ -214,6 +222,16 @@ export function ProjectsDashboard({
             </ul>
           </section>
         )}
+        <section className="a2ui-projects-dashboard-section">
+          <RegistryComponent
+            type="subagents-config"
+            state={state}
+            onEvent={(_component, eventType, data) =>
+              onEvent(eventType, data, "subagents-config")
+            }
+            componentProps={{ scope: "user" }}
+          />
+        </section>
       </div>
     </div>
   );

--- a/src/extensions/default-layout/dashboard/subagents-config.test.tsx
+++ b/src/extensions/default-layout/dashboard/subagents-config.test.tsx
@@ -162,7 +162,7 @@ describe("SubagentsConfig", () => {
     );
   });
 
-  it("renames by deleting the old file then writing the new", async () => {
+  it("renames by writing the new file before deleting the old", async () => {
     render(
       <SubagentsConfig
         component={comp({ scope: "user" })}
@@ -186,5 +186,15 @@ describe("SubagentsConfig", () => {
       "subagents_write",
       expect.objectContaining({ name: "auditor" }),
     );
+    // Write must land before the delete so a failed write can't lose the
+    // original definition.
+    const writeIdx = invoke.mock.calls.findIndex(
+      (c) => c[0] === "subagents_write",
+    );
+    const deleteIdx = invoke.mock.calls.findIndex(
+      (c) => c[0] === "subagents_delete",
+    );
+    expect(writeIdx).toBeGreaterThanOrEqual(0);
+    expect(writeIdx).toBeLessThan(deleteIdx);
   });
 });

--- a/src/extensions/default-layout/dashboard/subagents-config.test.tsx
+++ b/src/extensions/default-layout/dashboard/subagents-config.test.tsx
@@ -1,0 +1,190 @@
+// @vitest-environment jsdom
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SubagentsConfig } from "./subagents-config";
+import type { A2UIComponent } from "../../../types/a2ui";
+import type { SubagentFile } from "../../../subagents";
+
+const { invoke } = vi.hoisted(() => ({ invoke: vi.fn() }));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invoke(...args),
+}));
+
+const userReviewer: SubagentFile = {
+  scope: "user",
+  name: "reviewer",
+  filePath: "/u/agents/reviewer.md",
+  content:
+    "---\ndescription: Reviews diffs\nmodel: ollama/llama3.3\n---\nYou review.",
+};
+const projectPlanner: SubagentFile = {
+  scope: "project",
+  name: "planner",
+  filePath: "/p/.aethon/agents/planner.md",
+  content: "---\ndescription: Plans work\nsurface: tab\n---\nYou plan.",
+};
+
+function comp(props: Record<string, unknown>): A2UIComponent {
+  return { id: "subagents-config", type: "subagents-config", props };
+}
+
+const state = {
+  sidebar: { models: [{ id: "ollama/llama3.3", label: "Llama 3.3" }] },
+};
+
+function mockList(files: SubagentFile[]): void {
+  invoke.mockImplementation((cmd: string) => {
+    if (cmd === "subagents_list") return Promise.resolve(files);
+    return Promise.resolve(undefined);
+  });
+}
+
+beforeEach(() => {
+  mockList([userReviewer, projectPlanner]);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("SubagentsConfig", () => {
+  it("lists subagents for the user scope only", async () => {
+    render(
+      <SubagentsConfig
+        component={comp({ scope: "user" })}
+        state={state}
+        onEvent={() => {}}
+      />,
+    );
+    await waitFor(() => expect(screen.getByText("reviewer")).toBeTruthy());
+    expect(screen.queryByText("planner")).toBeNull();
+    expect(invoke).toHaveBeenCalledWith("subagents_list", {
+      projectRoot: null,
+    });
+  });
+
+  it("lists project-scope subagents with the project root", async () => {
+    render(
+      <SubagentsConfig
+        component={comp({ scope: "project", projectPath: "/p" })}
+        state={state}
+        onEvent={() => {}}
+      />,
+    );
+    await waitFor(() => expect(screen.getByText("planner")).toBeTruthy());
+    expect(screen.queryByText("reviewer")).toBeNull();
+    expect(invoke).toHaveBeenCalledWith("subagents_list", {
+      projectRoot: "/p",
+    });
+  });
+
+  it("creates a new subagent and writes a serialized file", async () => {
+    render(
+      <SubagentsConfig
+        component={comp({ scope: "user" })}
+        state={state}
+        onEvent={() => {}}
+      />,
+    );
+    await waitFor(() => expect(screen.getByText("reviewer")).toBeTruthy());
+
+    fireEvent.click(screen.getByText("+ New subagent"));
+    fireEvent.change(screen.getByPlaceholderText("reviewer"), {
+      target: { value: "builder" },
+    });
+    fireEvent.change(
+      screen.getByPlaceholderText(/Reviews diffs for correctness/),
+      { target: { value: "Builds features" } },
+    );
+    fireEvent.click(screen.getByText("Save"));
+
+    await waitFor(() =>
+      expect(invoke).toHaveBeenCalledWith(
+        "subagents_write",
+        expect.objectContaining({
+          scope: "user",
+          name: "builder",
+          projectRoot: null,
+        }),
+      ),
+    );
+    const writeCall = invoke.mock.calls.find((c) => c[0] === "subagents_write");
+    expect(writeCall?.[1].content).toContain("description: Builds features");
+  });
+
+  it("blocks save when the description is empty", async () => {
+    render(
+      <SubagentsConfig
+        component={comp({ scope: "user" })}
+        state={state}
+        onEvent={() => {}}
+      />,
+    );
+    await waitFor(() => expect(screen.getByText("reviewer")).toBeTruthy());
+    fireEvent.click(screen.getByText("+ New subagent"));
+    fireEvent.change(screen.getByPlaceholderText("reviewer"), {
+      target: { value: "builder" },
+    });
+    fireEvent.click(screen.getByText("Save"));
+    await waitFor(() =>
+      expect(screen.getByText(/description is required/i)).toBeTruthy(),
+    );
+    expect(invoke.mock.calls.some((c) => c[0] === "subagents_write")).toBe(
+      false,
+    );
+  });
+
+  it("deletes a subagent", async () => {
+    render(
+      <SubagentsConfig
+        component={comp({ scope: "user" })}
+        state={state}
+        onEvent={() => {}}
+      />,
+    );
+    await waitFor(() => expect(screen.getByText("reviewer")).toBeTruthy());
+    fireEvent.click(screen.getByText("Delete"));
+    await waitFor(() =>
+      expect(invoke).toHaveBeenCalledWith("subagents_delete", {
+        scope: "user",
+        name: "reviewer",
+        projectRoot: null,
+      }),
+    );
+  });
+
+  it("renames by deleting the old file then writing the new", async () => {
+    render(
+      <SubagentsConfig
+        component={comp({ scope: "user" })}
+        state={state}
+        onEvent={() => {}}
+      />,
+    );
+    await waitFor(() => expect(screen.getByText("reviewer")).toBeTruthy());
+    fireEvent.click(screen.getByText("Edit"));
+    const nameInput = screen.getByDisplayValue("reviewer");
+    fireEvent.change(nameInput, { target: { value: "auditor" } });
+    fireEvent.click(screen.getByText("Save"));
+    await waitFor(() =>
+      expect(invoke).toHaveBeenCalledWith("subagents_delete", {
+        scope: "user",
+        name: "reviewer",
+        projectRoot: null,
+      }),
+    );
+    expect(invoke).toHaveBeenCalledWith(
+      "subagents_write",
+      expect.objectContaining({ name: "auditor" }),
+    );
+  });
+});

--- a/src/extensions/default-layout/dashboard/subagents-config.tsx
+++ b/src/extensions/default-layout/dashboard/subagents-config.tsx
@@ -177,6 +177,15 @@ export function SubagentsConfig({ component, state }: BuiltinComponentProps) {
     setBusy(true);
     try {
       const content = serializeSubagent(editorToFields({ ...editor, name }));
+      // Write the new definition first; only remove the old name once the new
+      // file is safely on disk. A failed write then can't lose the original
+      // (worst case leaves a recoverable duplicate, never a gap).
+      await invoke("subagents_write", {
+        scope,
+        name,
+        content,
+        projectRoot: projectPath ?? null,
+      });
       if (editor.original && editor.original !== name) {
         await invoke("subagents_delete", {
           scope,
@@ -184,12 +193,6 @@ export function SubagentsConfig({ component, state }: BuiltinComponentProps) {
           projectRoot: projectPath ?? null,
         });
       }
-      await invoke("subagents_write", {
-        scope,
-        name,
-        content,
-        projectRoot: projectPath ?? null,
-      });
       setEditor(null);
       setError(null);
       await reload();

--- a/src/extensions/default-layout/dashboard/subagents-config.tsx
+++ b/src/extensions/default-layout/dashboard/subagents-config.tsx
@@ -1,0 +1,473 @@
+/**
+ * subagents-config — the overview editor for configurable subagents.
+ *
+ * Scope-parameterized via `componentProps`: the project overview mounts it with
+ * `{ scope: "project", projectPath }`, the host overview with `{ scope: "user" }`.
+ * It owns its Tauri IPC directly (like the gh caches) — `subagents_list` to
+ * load, `subagents_write` / `subagents_delete` to mutate. Rust signals the
+ * running bridge after each mutation, so a save re-advertises subagents to the
+ * agent without a restart.
+ *
+ * The markdown contract is parsed/serialized by `src/subagents` (mirror of the
+ * agent-side parser), so this component never hand-rolls frontmatter.
+ */
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import type { BuiltinComponentProps } from "../../../components/A2UIRenderer";
+import { resolvePointer } from "../../../utils/jsonPointer";
+import {
+  isSafeSubagentName,
+  parseSubagentContent,
+  sanitizeSubagentName,
+  serializeSubagent,
+  type SubagentFields,
+  type SubagentFile,
+  type SubagentScope,
+  type SubagentSurface,
+} from "../../../subagents";
+
+/** Built-in pi tools offered as checkboxes when restricting a subagent. */
+const BUILTIN_TOOLS = ["read", "write", "edit", "bash", "grep", "find", "ls"];
+
+type ToolsMode = "inherit" | "restrict" | "none";
+
+interface Row {
+  name: string;
+  filePath: string;
+  fields: SubagentFields | null;
+  error?: string;
+}
+
+interface EditorState {
+  /** Original name when editing an existing definition; null for a new one. */
+  original: string | null;
+  name: string;
+  description: string;
+  model: string;
+  toolsMode: ToolsMode;
+  tools: string[];
+  surface: SubagentSurface;
+  systemPrompt: string;
+}
+
+function blankEditor(): EditorState {
+  return {
+    original: null,
+    name: "",
+    description: "",
+    model: "",
+    toolsMode: "inherit",
+    tools: [],
+    surface: "inline",
+    systemPrompt: "",
+  };
+}
+
+function editorFromRow(row: Row): EditorState {
+  const f = row.fields;
+  const toolsMode: ToolsMode =
+    f?.tools === undefined
+      ? "inherit"
+      : f.tools.length === 0
+        ? "none"
+        : "restrict";
+  return {
+    original: row.name,
+    name: row.name,
+    description: f?.description ?? "",
+    model: f?.model ?? "",
+    toolsMode,
+    tools: f?.tools ?? [],
+    surface: f?.surface ?? "inline",
+    systemPrompt: f?.systemPrompt ?? "",
+  };
+}
+
+function editorToFields(editor: EditorState): SubagentFields {
+  const tools =
+    editor.toolsMode === "inherit"
+      ? undefined
+      : editor.toolsMode === "none"
+        ? []
+        : editor.tools;
+  return {
+    description: editor.description,
+    model: editor.model.trim() || undefined,
+    tools,
+    surface: editor.surface,
+    systemPrompt: editor.systemPrompt,
+  };
+}
+
+function errMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+export function SubagentsConfig({ component, state }: BuiltinComponentProps) {
+  const props = component.props as
+    | { scope?: unknown; projectPath?: unknown }
+    | undefined;
+  const scope: SubagentScope = props?.scope === "project" ? "project" : "user";
+  const projectPath =
+    typeof props?.projectPath === "string" ? props.projectPath : undefined;
+
+  const models = useMemo<{ id: string; label: string }[]>(() => {
+    const raw = resolvePointer(state, "/sidebar/models");
+    if (!Array.isArray(raw)) return [];
+    return raw
+      .filter(
+        (m): m is { id: unknown; label?: unknown } =>
+          typeof m === "object" && m !== null,
+      )
+      .map((m) => ({
+        id: String(m.id ?? ""),
+        label: String(m.label ?? m.id ?? ""),
+      }))
+      .filter((m) => m.id.length > 0);
+  }, [state]);
+
+  const [rows, setRows] = useState<Row[]>([]);
+  const [editor, setEditor] = useState<EditorState | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const reload = useCallback(async () => {
+    try {
+      const files = await invoke<SubagentFile[]>("subagents_list", {
+        projectRoot: projectPath ?? null,
+      });
+      const scoped = files.filter((f) => f.scope === scope);
+      setRows(
+        scoped.map((f) => {
+          const parsed = parseSubagentContent(f.content);
+          return {
+            name: f.name,
+            filePath: f.filePath,
+            fields: parsed.fields ?? null,
+            error: parsed.error,
+          };
+        }),
+      );
+      setError(null);
+    } catch (err) {
+      setError(`Failed to load subagents: ${errMessage(err)}`);
+    }
+  }, [scope, projectPath]);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- initial load + reload when scope/project changes; reload() fetches over IPC then setState
+    void reload();
+  }, [reload]);
+
+  const save = useCallback(async () => {
+    if (!editor) return;
+    const name = sanitizeSubagentName(editor.name);
+    if (!isSafeSubagentName(name)) {
+      setError(
+        "Name must be lowercase letters, digits, - or _ (start alphanumeric).",
+      );
+      return;
+    }
+    if (!editor.description.trim()) {
+      setError(
+        "A description is required — it's how the main agent decides when to delegate.",
+      );
+      return;
+    }
+    setBusy(true);
+    try {
+      const content = serializeSubagent(editorToFields({ ...editor, name }));
+      if (editor.original && editor.original !== name) {
+        await invoke("subagents_delete", {
+          scope,
+          name: editor.original,
+          projectRoot: projectPath ?? null,
+        });
+      }
+      await invoke("subagents_write", {
+        scope,
+        name,
+        content,
+        projectRoot: projectPath ?? null,
+      });
+      setEditor(null);
+      setError(null);
+      await reload();
+    } catch (err) {
+      setError(`Save failed: ${errMessage(err)}`);
+    } finally {
+      setBusy(false);
+    }
+  }, [editor, scope, projectPath, reload]);
+
+  const remove = useCallback(
+    async (name: string) => {
+      setBusy(true);
+      try {
+        await invoke("subagents_delete", {
+          scope,
+          name,
+          projectRoot: projectPath ?? null,
+        });
+        await reload();
+      } catch (err) {
+        setError(`Delete failed: ${errMessage(err)}`);
+      } finally {
+        setBusy(false);
+      }
+    },
+    [scope, projectPath, reload],
+  );
+
+  const scopeNote =
+    scope === "project"
+      ? "Project subagents (override your user subagents by name)."
+      : "User subagents — available in every project.";
+
+  return (
+    <div className="ae-subagents" data-scope={scope}>
+      <header className="ae-subagents-head">
+        <div className="ae-subagents-head-text">
+          <h2 className="ae-subagents-title">Subagents</h2>
+          <p className="ae-subagents-note">{scopeNote}</p>
+        </div>
+        {!editor && (
+          <button
+            type="button"
+            className="ae-subagents-new"
+            onClick={() => {
+              setError(null);
+              setEditor(blankEditor());
+            }}
+          >
+            + New subagent
+          </button>
+        )}
+      </header>
+
+      {error && <div className="ae-subagents-error">{error}</div>}
+
+      {editor ? (
+        <SubagentEditor
+          editor={editor}
+          models={models}
+          busy={busy}
+          onChange={setEditor}
+          onSave={() => void save()}
+          onCancel={() => {
+            setEditor(null);
+            setError(null);
+          }}
+        />
+      ) : rows.length === 0 ? (
+        <p className="ae-subagents-empty">
+          No subagents yet. Create one to let the main agent delegate focused
+          work to a different (e.g. local) model.
+        </p>
+      ) : (
+        <ul className="ae-subagents-list">
+          {rows.map((row) => (
+            <li
+              key={row.name}
+              className="ae-subagents-row"
+              data-name={row.name}
+            >
+              <div className="ae-subagents-row-main">
+                <span className="ae-subagents-row-name">{row.name}</span>
+                <span className="ae-subagents-row-desc">
+                  {row.error
+                    ? `⚠ ${row.error}`
+                    : (row.fields?.description ?? "")}
+                </span>
+              </div>
+              <div className="ae-subagents-row-badges">
+                {row.fields?.model && (
+                  <span className="ae-subagents-badge">{row.fields.model}</span>
+                )}
+                {row.fields?.surface === "tab" && (
+                  <span className="ae-subagents-badge ae-subagents-badge-tab">
+                    tab
+                  </span>
+                )}
+              </div>
+              <div className="ae-subagents-row-actions">
+                <button
+                  type="button"
+                  className="ae-subagents-action"
+                  disabled={busy}
+                  onClick={() => {
+                    setError(null);
+                    setEditor(editorFromRow(row));
+                  }}
+                >
+                  Edit
+                </button>
+                <button
+                  type="button"
+                  className="ae-subagents-action ae-subagents-action-danger"
+                  disabled={busy}
+                  onClick={() => void remove(row.name)}
+                >
+                  Delete
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function SubagentEditor({
+  editor,
+  models,
+  busy,
+  onChange,
+  onSave,
+  onCancel,
+}: {
+  editor: EditorState;
+  models: { id: string; label: string }[];
+  busy: boolean;
+  onChange: (next: EditorState) => void;
+  onSave: () => void;
+  onCancel: () => void;
+}) {
+  const set = <K extends keyof EditorState>(key: K, value: EditorState[K]) =>
+    onChange({ ...editor, [key]: value });
+
+  const toggleTool = (tool: string) => {
+    const has = editor.tools.includes(tool);
+    onChange({
+      ...editor,
+      tools: has
+        ? editor.tools.filter((t) => t !== tool)
+        : [...editor.tools, tool],
+    });
+  };
+
+  return (
+    <div className="ae-subagents-editor">
+      <label className="ae-subagents-field">
+        <span className="ae-subagents-label">Name</span>
+        <input
+          type="text"
+          className="ae-subagents-input"
+          value={editor.name}
+          placeholder="reviewer"
+          autoCapitalize="none"
+          autoCorrect="off"
+          spellCheck={false}
+          onChange={(e) => set("name", e.target.value)}
+        />
+      </label>
+
+      <label className="ae-subagents-field">
+        <span className="ae-subagents-label">Description</span>
+        <textarea
+          className="ae-subagents-textarea"
+          rows={2}
+          value={editor.description}
+          placeholder="Reviews diffs for correctness and edge cases."
+          onChange={(e) => set("description", e.target.value)}
+        />
+        <span className="ae-subagents-hint">
+          Action-oriented — the main agent reads this to decide when to
+          delegate.
+        </span>
+      </label>
+
+      <label className="ae-subagents-field">
+        <span className="ae-subagents-label">Model</span>
+        <input
+          type="text"
+          className="ae-subagents-input"
+          list="ae-subagents-model-list"
+          value={editor.model}
+          placeholder="inherit the tab's model (e.g. ollama/llama3.3)"
+          autoCapitalize="none"
+          autoCorrect="off"
+          spellCheck={false}
+          onChange={(e) => set("model", e.target.value)}
+        />
+        <datalist id="ae-subagents-model-list">
+          {models.map((m) => (
+            <option key={m.id} value={m.id}>
+              {m.label}
+            </option>
+          ))}
+        </datalist>
+      </label>
+
+      <div className="ae-subagents-field">
+        <span className="ae-subagents-label">Tools</span>
+        <select
+          className="ae-subagents-select"
+          value={editor.toolsMode}
+          onChange={(e) => set("toolsMode", e.target.value as ToolsMode)}
+        >
+          <option value="inherit">Inherit all tools</option>
+          <option value="restrict">Restrict to selected</option>
+          <option value="none">None (reasoning only)</option>
+        </select>
+        {editor.toolsMode === "restrict" && (
+          <div className="ae-subagents-tools">
+            {BUILTIN_TOOLS.map((tool) => (
+              <label key={tool} className="ae-subagents-tool">
+                <input
+                  type="checkbox"
+                  checked={editor.tools.includes(tool)}
+                  onChange={() => toggleTool(tool)}
+                />
+                {tool}
+              </label>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <label className="ae-subagents-field">
+        <span className="ae-subagents-label">Run surface</span>
+        <select
+          className="ae-subagents-select"
+          value={editor.surface}
+          onChange={(e) => set("surface", e.target.value as SubagentSurface)}
+        >
+          <option value="inline">Inline (nested card in the turn)</option>
+          <option value="tab">Tab (its own agent tab)</option>
+        </select>
+      </label>
+
+      <label className="ae-subagents-field">
+        <span className="ae-subagents-label">System prompt</span>
+        <textarea
+          className="ae-subagents-textarea ae-subagents-prompt"
+          rows={6}
+          value={editor.systemPrompt}
+          placeholder="You are a meticulous code reviewer. Focus on correctness…"
+          onChange={(e) => set("systemPrompt", e.target.value)}
+        />
+      </label>
+
+      <div className="ae-subagents-editor-actions">
+        <button
+          type="button"
+          className="ae-subagents-save"
+          disabled={busy}
+          onClick={onSave}
+        >
+          {busy ? "Saving…" : "Save"}
+        </button>
+        <button
+          type="button"
+          className="ae-subagents-cancel"
+          disabled={busy}
+          onClick={onCancel}
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/extensions/default-layout/index.ts
+++ b/src/extensions/default-layout/index.ts
@@ -48,6 +48,7 @@ import { TaskLauncher } from "./dashboard/task-launcher";
 import { ProjectsDashboard } from "./dashboard/projects-dashboard";
 import { ProjectDashboard } from "./dashboard/project-dashboard";
 import { IssuesSection } from "./dashboard/issues-section";
+import { SubagentsConfig } from "./dashboard/subagents-config";
 import workstationPayload from "./workstation.a2ui.json";
 
 export {
@@ -150,6 +151,7 @@ export const defaultLayoutExtension: A2UIExtension = {
     "projects-dashboard": ProjectsDashboard,
     "project-dashboard": ProjectDashboard,
     "issues-section": IssuesSection,
+    "subagents-config": SubagentsConfig,
   },
   layout: workstationPayload,
 };

--- a/src/extensions/default-layout/message-list.branch.test.tsx
+++ b/src/extensions/default-layout/message-list.branch.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ChatMessageRow } from "./message-list";
+import type { ChatMessage } from "../../types/a2ui";
+
+afterEach(cleanup);
+
+function row(message: ChatMessage, onEvent = vi.fn()) {
+  render(<ChatMessageRow message={message} state={{}} onEvent={onEvent} />);
+  return onEvent;
+}
+
+describe("ChatMessageRow rollback/fork affordance", () => {
+  it("shows Rollback + Fork on a user/agent row that has an entry id", () => {
+    row({ id: "1", entryId: "e1", role: "agent", text: "hello" });
+    expect(screen.getByText("↶ Rollback")).toBeTruthy();
+    expect(screen.getByText("⑂ Fork")).toBeTruthy();
+  });
+
+  it("hides the affordance when there is no entry id", () => {
+    row({ id: "1", role: "agent", text: "hello" });
+    expect(screen.queryByText("↶ Rollback")).toBeNull();
+    expect(screen.queryByText("⑂ Fork")).toBeNull();
+  });
+
+  it("hides the affordance on text-less rows (e.g. tool cards)", () => {
+    // Tool-card rows carry an a2ui payload but no text; the gate keys off
+    // text, so the affordance never appears on them.
+    row({ id: "tc", entryId: "e1", role: "agent" });
+    expect(screen.queryByText("↶ Rollback")).toBeNull();
+  });
+
+  it("hides the affordance on system rows", () => {
+    row({ id: "s", entryId: "e1", role: "system", text: "Context compacted" });
+    expect(screen.queryByText("↶ Rollback")).toBeNull();
+  });
+
+  it("fork fires fork-to-tab immediately", () => {
+    const onEvent = row({ id: "1", entryId: "e1", role: "user", text: "hi" });
+    fireEvent.click(screen.getByText("⑂ Fork"));
+    expect(onEvent).toHaveBeenCalledWith("fork-to-tab", { entryId: "e1" });
+  });
+
+  it("rollback requires a second confirm click", () => {
+    const onEvent = row({ id: "1", entryId: "e1", role: "user", text: "hi" });
+    fireEvent.click(screen.getByText("↶ Rollback"));
+    // First click only arms the confirm — no event yet.
+    expect(onEvent).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByText("Confirm rollback"));
+    expect(onEvent).toHaveBeenCalledWith("rollback-to-here", { entryId: "e1" });
+  });
+});

--- a/src/extensions/default-layout/message-list.branch.test.tsx
+++ b/src/extensions/default-layout/message-list.branch.test.tsx
@@ -37,6 +37,12 @@ describe("ChatMessageRow rollback/fork affordance", () => {
     expect(screen.queryByText("↶ Rollback")).toBeNull();
   });
 
+  it("shows the affordance on a thinking-only turn", () => {
+    row({ id: "1", entryId: "e1", role: "agent", thinking: "let me reason" });
+    expect(screen.getByText("↶ Rollback")).toBeTruthy();
+    expect(screen.getByText("⑂ Fork")).toBeTruthy();
+  });
+
   it("fork fires fork-to-tab immediately", () => {
     const onEvent = row({ id: "1", entryId: "e1", role: "user", text: "hi" });
     fireEvent.click(screen.getByText("⑂ Fork"));

--- a/src/extensions/default-layout/message-list.tsx
+++ b/src/extensions/default-layout/message-list.tsx
@@ -223,7 +223,7 @@ function AttachmentGallery({ attachments }: { attachments: ChatAttachment[] }) {
   );
 }
 
-const ChatMessageRow = memo(
+export const ChatMessageRow = memo(
   function ChatMessageRow({
     message,
     state,
@@ -245,6 +245,14 @@ const ChatMessageRow = memo(
     isLatest?: boolean;
     thinkingVisibility?: VisibilityMode;
   }) {
+    const [confirmingRollback, setConfirmingRollback] = useState(false);
+    // Rollback / fork are offered on real user/assistant turns that carry a pi
+    // entry id (tool-card and system rows are not branch targets).
+    const canBranch =
+      Boolean(message.entryId) &&
+      (message.role === "user" || message.role === "agent") &&
+      Boolean(message.text) &&
+      Boolean(onEvent);
     const isCanvas = className === "a2ui-canvas-message";
     const roleClass = isCanvas ? "a2ui-canvas-role" : "a2ui-chat-role";
     const textClass = isCanvas
@@ -314,6 +322,55 @@ const ChatMessageRow = memo(
         )}
         {message.a2ui && (
           <A2UIRenderer payload={message.a2ui} state={state} tabId={tabId} />
+        )}
+        {canBranch && (
+          <div
+            className="ae-msg-branch-actions"
+            onMouseLeave={() => setConfirmingRollback(false)}
+          >
+            {confirmingRollback ? (
+              <>
+                <button
+                  type="button"
+                  className="ae-msg-branch-btn ae-msg-branch-confirm"
+                  onClick={() => {
+                    setConfirmingRollback(false);
+                    onEvent?.("rollback-to-here", { entryId: message.entryId });
+                  }}
+                >
+                  Confirm rollback
+                </button>
+                <button
+                  type="button"
+                  className="ae-msg-branch-btn"
+                  onClick={() => setConfirmingRollback(false)}
+                >
+                  Cancel
+                </button>
+              </>
+            ) : (
+              <>
+                <button
+                  type="button"
+                  className="ae-msg-branch-btn"
+                  title="Rewind the conversation to this message"
+                  onClick={() => setConfirmingRollback(true)}
+                >
+                  ↶ Rollback
+                </button>
+                <button
+                  type="button"
+                  className="ae-msg-branch-btn"
+                  title="Fork the conversation into a new tab from here"
+                  onClick={() =>
+                    onEvent?.("fork-to-tab", { entryId: message.entryId })
+                  }
+                >
+                  ⑂ Fork
+                </button>
+              </>
+            )}
+          </div>
         )}
       </div>
     );

--- a/src/extensions/default-layout/message-list.tsx
+++ b/src/extensions/default-layout/message-list.tsx
@@ -144,7 +144,10 @@ function ThinkingBlock({
 }) {
   const label = complete ? "Thinking" : "Thinking...";
   return (
-    <details className="a2ui-thinking-block" open={collapsed ? false : !complete}>
+    <details
+      className="a2ui-thinking-block"
+      open={collapsed ? false : !complete}
+    >
       <summary>{label}</summary>
       <div className="a2ui-thinking-content a2ui-markdown">
         <ReactMarkdown {...CHAT_MARKDOWN_PROPS}>{children}</ReactMarkdown>
@@ -247,11 +250,12 @@ export const ChatMessageRow = memo(
   }) {
     const [confirmingRollback, setConfirmingRollback] = useState(false);
     // Rollback / fork are offered on real user/assistant turns that carry a pi
-    // entry id (tool-card and system rows are not branch targets).
+    // entry id (tool-card and system rows are not branch targets). Thinking-only
+    // turns count too — they're valid branch points.
     const canBranch =
       Boolean(message.entryId) &&
       (message.role === "user" || message.role === "agent") &&
-      Boolean(message.text) &&
+      (Boolean(message.text) || Boolean(message.thinking)) &&
       Boolean(onEvent);
     const isCanvas = className === "a2ui-canvas-message";
     const roleClass = isCanvas ? "a2ui-canvas-role" : "a2ui-chat-role";
@@ -541,7 +545,9 @@ function TurnBlockRow({
           {expanded ? "▾" : "▸"}
         </span>
         <span className="ae-turn-block-label">Agent turn</span>
-        <span className="ae-turn-block-meta">{turnBlockLabel(group.messages)}</span>
+        <span className="ae-turn-block-meta">
+          {turnBlockLabel(group.messages)}
+        </span>
         {!expanded && peek && (
           <span className="ae-turn-block-peek">{peek}</span>
         )}

--- a/src/extensions/default-layout/tool-card.subagent.test.tsx
+++ b/src/extensions/default-layout/tool-card.subagent.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { ToolCard } from "./tool-card";
+import type { A2UIComponent } from "../../types/a2ui";
+
+afterEach(cleanup);
+
+function taskCard(state: Record<string, unknown>) {
+  const component: A2UIComponent = {
+    id: "tool-3-call-abc",
+    type: "tool-card",
+    props: { title: "task", toolName: "task", startedAt: 1 },
+  };
+  render(<ToolCard component={component} state={state} onEvent={() => {}} />);
+}
+
+describe("ToolCard subagent activity", () => {
+  it("renders the subagent timeline for a running task card", () => {
+    taskCard({
+      subagentProgress: {
+        "call-abc": {
+          subagent: "reviewer",
+          model: "ollama/llama3.3",
+          steps: [
+            { kind: "tool", label: "read src/foo.ts" },
+            { kind: "error", label: "boom" },
+          ],
+          text: "working on it",
+          done: false,
+        },
+      },
+    });
+    expect(screen.getByText(/reviewer/)).toBeTruthy();
+    expect(screen.getByText("read src/foo.ts")).toBeTruthy();
+    expect(screen.getByText("boom")).toBeTruthy();
+    expect(screen.getByText("working on it")).toBeTruthy();
+  });
+
+  it("shows no activity block when there's no progress for the card", () => {
+    taskCard({ subagentProgress: {} });
+    expect(screen.queryByText("read src/foo.ts")).toBeNull();
+  });
+});

--- a/src/extensions/default-layout/tool-card.tsx
+++ b/src/extensions/default-layout/tool-card.tsx
@@ -10,8 +10,51 @@ import {
   resolveNumber,
   resolveString,
 } from "../../utils/dataBinding";
+import type { SubagentProgress } from "../../hooks/bridgeMessageHandlers/subagentProgress";
 
 const TOOL_LONG_RUN_THRESHOLD_MS = 30 * 1000;
+
+/** The tool-card's component id is `tool-<seq>-<callId>`; the subagent progress
+ *  slice is keyed by the raw callId, so strip the prefix to look it up. */
+function readSubagentProgress(
+  state: Record<string, unknown>,
+  componentId: string | undefined,
+): SubagentProgress | null {
+  if (!componentId) return null;
+  const callId = componentId.replace(/^tool-\d+-/, "");
+  const map = state.subagentProgress as
+    | Record<string, SubagentProgress>
+    | undefined;
+  return map?.[callId] ?? null;
+}
+
+function SubagentActivity({ progress }: { progress: SubagentProgress }) {
+  return (
+    <div className="ae-subagent-activity">
+      <div className="ae-subagent-activity-head">
+        <span aria-hidden="true">⬡</span> {progress.subagent}
+        {progress.model ? ` · ${progress.model}` : ""}
+      </div>
+      {progress.steps.length > 0 && (
+        <ul className="ae-subagent-steps">
+          {progress.steps.map((step, i) => (
+            <li
+              key={i}
+              className={
+                step.kind === "error" ? "ae-subagent-step-error" : undefined
+              }
+            >
+              {step.label}
+            </li>
+          ))}
+        </ul>
+      )}
+      {!progress.done && progress.text && (
+        <div className="ae-subagent-text">{progress.text}</div>
+      )}
+    </div>
+  );
+}
 
 // eslint-disable-next-line react-refresh/only-export-components -- exported for vitest unit tests; doesn't affect HMR semantics in practice
 export function formatToolDuration(ms: number): string {
@@ -96,6 +139,9 @@ export function ToolCard({
     ? resolveNumber(props.endedAt, state)
     : undefined;
   const isError = props.isError ? resolveBoolean(props.isError, state) : false;
+  const toolName = props.toolName ? resolveString(props.toolName, state) : "";
+  const subagentProgress =
+    toolName === "task" ? readSubagentProgress(state, component.id) : null;
   const status = props.status ? resolveString(props.status, state) : undefined;
   const isCancelled = status === "cancelled";
   const running = startedAt !== undefined && endedAt === undefined;
@@ -154,9 +200,10 @@ export function ToolCard({
         )}
       </summary>
       <div className="ae-tool-card-body">
+        {subagentProgress && <SubagentActivity progress={subagentProgress} />}
         {hasChildren ? (
           renderChildren?.()
-        ) : (
+        ) : subagentProgress ? null : (
           <div className="ae-tool-card-empty">No output</div>
         )}
       </div>

--- a/src/hooks/bridgeMessageHandlers/entryIds.test.ts
+++ b/src/hooks/bridgeMessageHandlers/entryIds.test.ts
@@ -71,6 +71,21 @@ describe("handleEntryIds", () => {
     ]);
   });
 
+  it("back-fills thinking-only turns", () => {
+    const messages: ChatMessage[] = [
+      { id: "u", role: "user", text: "hi" },
+      { id: "a", role: "agent", thinking: "reasoning, no text" },
+    ];
+    const { result } = applyUpdater(
+      [
+        { entryId: "E_u", role: "user" },
+        { entryId: "E_a", role: "agent" },
+      ],
+      messages,
+    );
+    expect(result.messages.map((m) => m.entryId)).toEqual(["E_u", "E_a"]);
+  });
+
   it("does nothing when there are no entries", () => {
     const { called } = applyUpdater(
       [],

--- a/src/hooks/bridgeMessageHandlers/entryIds.test.ts
+++ b/src/hooks/bridgeMessageHandlers/entryIds.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { handleEntryIds } from "./entryIds";
+import { buildHandlerFixture } from "./testFixtures";
+import type { Tab } from "../../types/tab";
+import type { ChatMessage } from "../../types/a2ui";
+
+function tab(messages: ChatMessage[]): Tab {
+  return { id: "t1", messages } as Tab;
+}
+
+function applyUpdater(
+  entries: { entryId: string; role: "user" | "agent" }[],
+  messages: ChatMessage[],
+): { result: Tab; called: boolean } {
+  const { ctx, mocks } = buildHandlerFixture();
+  handleEntryIds({ type: "entry_ids", tabId: "t1", entries }, ctx);
+  if (mocks.updateTab.mock.calls.length === 0) {
+    return { result: tab(messages), called: false };
+  }
+  const updater = mocks.updateTab.mock.calls[0][1] as (t: Tab) => Tab;
+  return { result: updater(tab(messages)), called: true };
+}
+
+const a2uiRow: ChatMessage = {
+  id: "tc",
+  role: "agent",
+  a2ui: { components: [{ id: "tool-1", type: "tool-card" }] },
+};
+
+describe("handleEntryIds", () => {
+  it("assigns entry ids positionally to user/agent text rows", () => {
+    const messages: ChatMessage[] = [
+      { id: "u", role: "user", text: "hi" },
+      { id: "a", role: "agent", text: "hello" },
+    ];
+    const { result } = applyUpdater(
+      [
+        { entryId: "E_u", role: "user" },
+        { entryId: "E_a", role: "agent" },
+      ],
+      messages,
+    );
+    expect(result.messages.map((m) => m.entryId)).toEqual(["E_u", "E_a"]);
+  });
+
+  it("skips tool-card rows and a multi-segment assistant turn aligns", () => {
+    const messages: ChatMessage[] = [
+      { id: "u1", role: "user", text: "do it" },
+      { id: "a1", role: "agent", text: "let me check" },
+      a2uiRow, // tool card — no text, skipped
+      { id: "a2", role: "agent", text: "found a bug" },
+      { id: "u2", role: "user", text: "fix it" },
+      { id: "a3", role: "agent", text: "fixed" },
+    ];
+    const { result } = applyUpdater(
+      [
+        { entryId: "E_u1", role: "user" },
+        { entryId: "E_a1", role: "agent" },
+        { entryId: "E_u2", role: "user" },
+        { entryId: "E_a2", role: "agent" },
+      ],
+      messages,
+    );
+    expect(result.messages.map((m) => m.entryId)).toEqual([
+      "E_u1",
+      "E_a1",
+      undefined, // tool card
+      undefined, // second agent segment of the first turn
+      "E_u2",
+      "E_a2",
+    ]);
+  });
+
+  it("does nothing when there are no entries", () => {
+    const { called } = applyUpdater(
+      [],
+      [{ id: "u", role: "user", text: "hi" }],
+    );
+    expect(called).toBe(false);
+  });
+
+  it("returns the same tab when nothing changes", () => {
+    const messages: ChatMessage[] = [
+      { id: "u", role: "user", text: "hi", entryId: "E_u" },
+    ];
+    const { ctx, mocks } = buildHandlerFixture();
+    handleEntryIds(
+      {
+        type: "entry_ids",
+        tabId: "t1",
+        entries: [{ entryId: "E_u", role: "user" }],
+      },
+      ctx,
+    );
+    const updater = mocks.updateTab.mock.calls[0][1] as (t: Tab) => Tab;
+    const input = tab(messages);
+    expect(updater(input)).toBe(input);
+  });
+});

--- a/src/hooks/bridgeMessageHandlers/entryIds.ts
+++ b/src/hooks/bridgeMessageHandlers/entryIds.ts
@@ -1,0 +1,65 @@
+import type { BridgeMessageHandler } from "./types";
+
+interface OrderedEntry {
+  entryId: string;
+  role: "user" | "agent";
+}
+
+function coerceEntries(value: unknown): OrderedEntry[] {
+  if (!Array.isArray(value)) return [];
+  const out: OrderedEntry[] = [];
+  for (const item of value) {
+    if (!item || typeof item !== "object") continue;
+    const record = item as { entryId?: unknown; role?: unknown };
+    if (typeof record.entryId !== "string" || record.entryId.length === 0) {
+      continue;
+    }
+    if (record.role === "user" || record.role === "agent") {
+      out.push({ entryId: record.entryId, role: record.role });
+    }
+  }
+  return out;
+}
+
+/**
+ * Back-fill pi session entry ids onto a tab's *live* transcript so the
+ * rollback / fork affordances have a valid handle before a reload (restored
+ * transcripts already carry entry ids via the session-history path).
+ *
+ * The bridge emits the branch's user/assistant message entries in order. We
+ * walk the transcript and the entry list together, assigning each entry to the
+ * next text row of the matching role. Tool-card and system rows are skipped;
+ * a multi-segment assistant turn (text → tool → text) renders as several agent
+ * rows but is one assistant entry, so only the first agent text row of the turn
+ * gets the id (rolling back there branches at the right entry). Rows whose role
+ * doesn't match the current expected entry are skipped, keeping alignment
+ * robust across the interleaving.
+ */
+export const handleEntryIds: BridgeMessageHandler = (data, ctx) => {
+  const tabId = (data.tabId as string | undefined) ?? "default";
+  const ordered = coerceEntries(data.entries);
+  if (ordered.length === 0) return;
+
+  ctx.updateTab(tabId, (tab) => {
+    let entryIdx = 0;
+    let changed = false;
+    const messages = tab.messages.map((message) => {
+      if (entryIdx >= ordered.length) return message;
+      const isTextRow =
+        (message.role === "user" || message.role === "agent") &&
+        typeof message.text === "string" &&
+        message.text.length > 0;
+      if (!isTextRow) return message;
+      const next = ordered[entryIdx];
+      // Role mismatch: this row belongs to a later/earlier turn segment than
+      // the current entry expects (e.g. a second agent text segment). Skip it
+      // and keep the entry for the next matching-role row.
+      if (next.role !== message.role) return message;
+      entryIdx += 1;
+      if (message.entryId === next.entryId) return message;
+      changed = true;
+      return { ...message, entryId: next.entryId };
+    });
+    return changed ? { ...tab, messages } : tab;
+  });
+};

--- a/src/hooks/bridgeMessageHandlers/entryIds.ts
+++ b/src/hooks/bridgeMessageHandlers/entryIds.ts
@@ -45,11 +45,14 @@ export const handleEntryIds: BridgeMessageHandler = (data, ctx) => {
     let changed = false;
     const messages = tab.messages.map((message) => {
       if (entryIdx >= ordered.length) return message;
-      const isTextRow =
+      // A branch target is a user/assistant turn with visible content — text
+      // OR thinking (thinking-only turns are valid branch points too).
+      const isTurnRow =
         (message.role === "user" || message.role === "agent") &&
-        typeof message.text === "string" &&
-        message.text.length > 0;
-      if (!isTextRow) return message;
+        ((typeof message.text === "string" && message.text.length > 0) ||
+          (typeof message.thinking === "string" &&
+            message.thinking.length > 0));
+      if (!isTurnRow) return message;
       const next = ordered[entryIdx];
       // Role mismatch: this row belongs to a later/earlier turn segment than
       // the current entry expects (e.g. a second agent text segment). Skip it

--- a/src/hooks/bridgeMessageHandlers/index.ts
+++ b/src/hooks/bridgeMessageHandlers/index.ts
@@ -52,6 +52,7 @@ import { handleDashboardQuery } from "./dashboardQuery";
 import { handleDevshellQuery } from "./devshellQuery";
 import { handleGitQuery } from "./gitQuery";
 import { handleStatePatch } from "./statePatch";
+import { handleSubagentProgress } from "./subagentProgress";
 import { handleTabClosed } from "./tabClosed";
 import { handleTabReady } from "./tabReady";
 import { handleTerminalOutput } from "./terminalOutput";
@@ -100,6 +101,7 @@ export const bridgeMessageHandlers: Readonly<
   devshell_query: handleDevshellQuery,
   git_query: handleGitQuery,
   state_patch: handleStatePatch,
+  subagent_progress: handleSubagentProgress,
   tab_closed: handleTabClosed,
   tab_ready: handleTabReady,
   terminal_output: handleTerminalOutput,

--- a/src/hooks/bridgeMessageHandlers/index.ts
+++ b/src/hooks/bridgeMessageHandlers/index.ts
@@ -44,7 +44,9 @@ import { handleRegisterHighlightGrammar } from "./registerHighlightGrammar";
 import { handleResponse } from "./response";
 import { handleResponseDelta } from "./responseDelta";
 import { handleResponseEnd } from "./responseEnd";
+import { handleSessionForked } from "./sessionForked";
 import { handleSessionHistory } from "./sessionHistory";
+import { handleSessionRolledBack } from "./sessionRolledBack";
 import { handleShellQuery } from "./shellQuery";
 import { handleDashboardQuery } from "./dashboardQuery";
 import { handleDevshellQuery } from "./devshellQuery";
@@ -90,7 +92,9 @@ export const bridgeMessageHandlers: Readonly<
   response: handleResponse,
   response_delta: handleResponseDelta,
   response_end: handleResponseEnd,
+  session_forked: handleSessionForked,
   session_history: handleSessionHistory,
+  session_rolled_back: handleSessionRolledBack,
   shell_query: handleShellQuery,
   dashboard_query: handleDashboardQuery,
   devshell_query: handleDevshellQuery,

--- a/src/hooks/bridgeMessageHandlers/index.ts
+++ b/src/hooks/bridgeMessageHandlers/index.ts
@@ -16,6 +16,7 @@ import {
 } from "./authProfiles";
 import { handleA2ui } from "./a2ui";
 import { handleContextUsage } from "./contextUsage";
+import { handleEntryIds } from "./entryIds";
 import { handleError } from "./error";
 import { handleExtensionComponents } from "./extensionComponents";
 import { handleExtensionEventRoutes } from "./extensionEventRoutes";
@@ -61,6 +62,7 @@ export const bridgeMessageHandlers: Readonly<
   auth_profile_login_event: handleAuthProfileLoginEvent,
   auth_profiles: handleAuthProfiles,
   context_usage: handleContextUsage,
+  entry_ids: handleEntryIds,
   error: handleError,
   extension_components: handleExtensionComponents,
   extension_event_routes: handleExtensionEventRoutes,

--- a/src/hooks/bridgeMessageHandlers/sessionForked.test.ts
+++ b/src/hooks/bridgeMessageHandlers/sessionForked.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { invoke } = vi.hoisted(() => ({
+  invoke: vi.fn((..._args: unknown[]) => Promise.resolve(undefined)),
+}));
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invoke(...args),
+}));
+
+import { handleSessionForked } from "./sessionForked";
+import { buildHandlerFixture } from "./testFixtures";
+
+afterEach(() => vi.clearAllMocks());
+
+describe("handleSessionForked", () => {
+  it("copies the forked session file then opens the new tab", async () => {
+    invoke.mockResolvedValue(undefined);
+    const { ctx, mocks } = buildHandlerFixture();
+    handleSessionForked(
+      {
+        type: "session_forked",
+        tabId: "t1",
+        newTabId: "t2",
+        sourcePath: "/s/x.jsonl",
+        label: "Fork of foo",
+        cwd: "/proj",
+      },
+      ctx,
+    );
+    await vi.waitFor(() =>
+      expect(invoke).toHaveBeenCalledWith("copy_session_file", {
+        sourcePath: "/s/x.jsonl",
+        destTabId: "t2",
+      }),
+    );
+    await vi.waitFor(() =>
+      expect(mocks.newTab).toHaveBeenCalledWith("t2", "Fork of foo", {
+        restoredSession: true,
+        cwd: "/proj",
+      }),
+    );
+  });
+
+  it("does not open a tab when the copy fails", async () => {
+    invoke.mockRejectedValueOnce(new Error("boom"));
+    const { ctx, mocks } = buildHandlerFixture();
+    handleSessionForked(
+      {
+        type: "session_forked",
+        tabId: "t1",
+        newTabId: "t2",
+        sourcePath: "/s/x.jsonl",
+        label: "Fork",
+      },
+      ctx,
+    );
+    await vi.waitFor(() => expect(mocks.pushNotification).toHaveBeenCalled());
+    expect(mocks.newTab).not.toHaveBeenCalled();
+  });
+
+  it("ignores a message missing newTabId or sourcePath", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleSessionForked({ type: "session_forked", tabId: "t1" }, ctx);
+    expect(invoke).not.toHaveBeenCalled();
+    expect(mocks.newTab).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/bridgeMessageHandlers/sessionForked.ts
+++ b/src/hooks/bridgeMessageHandlers/sessionForked.ts
@@ -1,0 +1,38 @@
+import { invoke } from "@tauri-apps/api/core";
+import type { BridgeMessageHandler } from "./types";
+
+function errMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * The bridge extracted a branch into a new session file (`sourcePath`) and
+ * allocated `newTabId`. We move that file into the new tab's session dir via
+ * the FS-safe `copy_session_file` command, then open the tab with its restored
+ * history. The bridge can't invoke Tauri or open tabs, so this lands here.
+ */
+export const handleSessionForked: BridgeMessageHandler = (data, ctx) => {
+  const newTabId = typeof data.newTabId === "string" ? data.newTabId : "";
+  const sourcePath = typeof data.sourcePath === "string" ? data.sourcePath : "";
+  const label = typeof data.label === "string" ? data.label : "Fork";
+  const cwd = typeof data.cwd === "string" ? data.cwd : undefined;
+  if (!newTabId || !sourcePath) return;
+
+  void (async () => {
+    try {
+      await invoke("copy_session_file", { sourcePath, destTabId: newTabId });
+    } catch (err) {
+      // Don't open a tab pointing at a session file that never landed.
+      ctx.pushNotification({
+        title: "Fork failed",
+        message: `Couldn't copy the forked session: ${errMessage(err)}`,
+        kind: "error",
+      });
+      return;
+    }
+    ctx.newTab(newTabId, label, {
+      restoredSession: true,
+      ...(cwd ? { cwd } : {}),
+    });
+  })();
+};

--- a/src/hooks/bridgeMessageHandlers/sessionRolledBack.test.ts
+++ b/src/hooks/bridgeMessageHandlers/sessionRolledBack.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { handleSessionRolledBack } from "./sessionRolledBack";
+import { buildHandlerFixture } from "./testFixtures";
+import type { Tab } from "../../types/tab";
+import type { ChatMessage } from "../../types/a2ui";
+
+const messages: ChatMessage[] = [
+  { id: "1", entryId: "e1", role: "user", text: "a" },
+  { id: "2", entryId: "e2", role: "agent", text: "b" },
+  { id: "3", entryId: "e3", role: "user", text: "c" },
+];
+
+describe("handleSessionRolledBack", () => {
+  it("truncates the tab transcript to the confirmed entry", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleSessionRolledBack(
+      { type: "session_rolled_back", tabId: "t1", entryId: "e2" },
+      ctx,
+    );
+    expect(mocks.updateTab).toHaveBeenCalledWith("t1", expect.any(Function));
+    const updater = mocks.updateTab.mock.calls[0][1] as (t: Tab) => Tab;
+    const next = updater({ id: "t1", messages, waiting: true } as Tab);
+    expect(next.messages.map((m) => m.id)).toEqual(["1", "2"]);
+    expect(next.waiting).toBe(false);
+  });
+
+  it("ignores a message with no entryId", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleSessionRolledBack({ type: "session_rolled_back", tabId: "t1" }, ctx);
+    expect(mocks.updateTab).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/bridgeMessageHandlers/sessionRolledBack.ts
+++ b/src/hooks/bridgeMessageHandlers/sessionRolledBack.ts
@@ -1,0 +1,19 @@
+import type { BridgeMessageHandler } from "./types";
+import { truncateToEntry } from "../../utils/messages";
+
+/**
+ * Authoritative reconcile after the bridge branched the session. The event
+ * route already truncated optimistically; this lands the same truncation
+ * keyed off the bridge's confirmed entry id (idempotent — truncating an
+ * already-truncated transcript is a no-op) and clears the turn UI.
+ */
+export const handleSessionRolledBack: BridgeMessageHandler = (data, ctx) => {
+  const tabId = typeof data.tabId === "string" ? data.tabId : "default";
+  const entryId = typeof data.entryId === "string" ? data.entryId : "";
+  if (!entryId) return;
+  ctx.updateTab(tabId, (tab) => {
+    const messages = truncateToEntry(tab.messages, entryId);
+    if (messages === tab.messages && !tab.waiting) return tab;
+    return { ...tab, messages, waiting: false, queueCount: 0 };
+  });
+};

--- a/src/hooks/bridgeMessageHandlers/subagentProgress.test.ts
+++ b/src/hooks/bridgeMessageHandlers/subagentProgress.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+  handleSubagentProgress,
+  type SubagentProgress,
+} from "./subagentProgress";
+import { buildHandlerFixture } from "./testFixtures";
+import type { BridgeMessageContext } from "./types";
+
+function fire(ctx: BridgeMessageContext, info: Record<string, unknown>) {
+  handleSubagentProgress(
+    { type: "subagent_progress", tabId: "t1", parentCallId: "c1", ...info },
+    ctx,
+  );
+}
+
+function progress(ctx: BridgeMessageContext): SubagentProgress | undefined {
+  const map = ctx.stateRef.current.subagentProgress as
+    | Record<string, SubagentProgress>
+    | undefined;
+  return map?.c1;
+}
+
+describe("handleSubagentProgress", () => {
+  it("accumulates tool steps, streamed text, and the done flag", () => {
+    const { ctx } = buildHandlerFixture();
+    fire(ctx, {
+      phase: "start",
+      subagent: "reviewer",
+      model: "ollama/llama3.3",
+    });
+    fire(ctx, {
+      phase: "tool_start",
+      toolName: "read",
+      toolSummary: "src/foo.ts",
+    });
+    fire(ctx, { phase: "text", delta: "Found " });
+    fire(ctx, { phase: "text", delta: "a bug." });
+    fire(ctx, { phase: "done" });
+
+    const p = progress(ctx);
+    expect(p?.subagent).toBe("reviewer");
+    expect(p?.model).toBe("ollama/llama3.3");
+    expect(p?.steps).toEqual([{ kind: "tool", label: "read src/foo.ts" }]);
+    expect(p?.text).toBe("Found a bug.");
+    expect(p?.done).toBe(true);
+  });
+
+  it("records errors as error steps", () => {
+    const { ctx } = buildHandlerFixture();
+    fire(ctx, { phase: "error", error: "model overloaded" });
+    expect(progress(ctx)?.steps).toEqual([
+      { kind: "error", label: "model overloaded" },
+    ]);
+  });
+
+  it("ignores events without a parentCallId", () => {
+    const { ctx } = buildHandlerFixture();
+    handleSubagentProgress(
+      { type: "subagent_progress", phase: "text", delta: "x" },
+      ctx,
+    );
+    expect(ctx.stateRef.current.subagentProgress).toBeUndefined();
+  });
+});

--- a/src/hooks/bridgeMessageHandlers/subagentProgress.ts
+++ b/src/hooks/bridgeMessageHandlers/subagentProgress.ts
@@ -1,0 +1,79 @@
+import type { BridgeMessageHandler } from "./types";
+
+/** Accumulated live progress for one `task` delegation, keyed by the parent
+ *  tool-call id. Read by the tool-card to render a nested activity timeline. */
+export interface SubagentProgress {
+  subagent: string;
+  model: string;
+  steps: { kind: "tool" | "error"; label: string }[];
+  text: string;
+  done: boolean;
+}
+
+const MAX_TEXT = 4000;
+const MAX_STEPS = 60;
+
+function str(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function toolLabel(data: Record<string, unknown>): string {
+  const name = str(data.toolName) || "tool";
+  const summary = str(data.toolSummary);
+  return summary ? `${name} ${summary}` : name;
+}
+
+/**
+ * Translate a subagent_progress event (emitted by the `task` tool while a
+ * subagent runs inline) into the `/subagentProgress/<parentCallId>` state slice.
+ * The outer tool card already streams the subagent's text via pi's partial
+ * results; this drives the richer nested timeline (per-tool steps).
+ */
+export const handleSubagentProgress: BridgeMessageHandler = (data, ctx) => {
+  const parentCallId = str(data.parentCallId);
+  if (!parentCallId) return;
+  const phase = str(data.phase);
+  const subagent = str(data.subagent);
+  const model = str(data.model);
+
+  ctx.setState((prev) => {
+    const map =
+      (prev.subagentProgress as Record<string, SubagentProgress> | undefined) ??
+      {};
+    const cur: SubagentProgress = map[parentCallId] ?? {
+      subagent,
+      model,
+      steps: [],
+      text: "",
+      done: false,
+    };
+    const next: SubagentProgress = {
+      ...cur,
+      subagent: subagent || cur.subagent,
+      model: model || cur.model,
+    };
+    switch (phase) {
+      case "text":
+        next.text = (cur.text + str(data.delta)).slice(-MAX_TEXT);
+        break;
+      case "tool_start":
+        next.steps = [
+          ...cur.steps,
+          { kind: "tool" as const, label: toolLabel(data) },
+        ].slice(-MAX_STEPS);
+        break;
+      case "error":
+        next.steps = [
+          ...cur.steps,
+          { kind: "error" as const, label: str(data.error) || "error" },
+        ].slice(-MAX_STEPS);
+        break;
+      case "done":
+        next.done = true;
+        break;
+      default:
+        break;
+    }
+    return { ...prev, subagentProgress: { ...map, [parentCallId]: next } };
+  });
+};

--- a/src/hooks/bridgeMessageHandlers/testFixtures.ts
+++ b/src/hooks/bridgeMessageHandlers/testFixtures.ts
@@ -28,6 +28,7 @@ export interface HandlerFixture {
     setLayout: Mock;
     updateTab: Mock;
     updateActiveTab: Mock;
+    newTab: Mock;
     appendMessage: Mock;
     persistLocalChatMessage: Mock;
     recordProjectModel: Mock;
@@ -82,6 +83,7 @@ export function buildHandlerFixture(
   const setLayout = vi.fn();
   const updateTab = vi.fn();
   const updateActiveTab = vi.fn();
+  const newTab = vi.fn();
   const appendMessage = vi.fn();
   const persistLocalChatMessage = vi.fn();
   const recordProjectModel = vi.fn();
@@ -128,6 +130,7 @@ export function buildHandlerFixture(
 
     updateTab,
     updateActiveTab,
+    newTab,
     dispatchTerminalReplay,
     autoRestoreDiscoveredSessions,
 
@@ -191,6 +194,7 @@ export function buildHandlerFixture(
       setLayout,
       updateTab,
       updateActiveTab,
+      newTab,
       appendMessage,
       persistLocalChatMessage,
       recordProjectModel,

--- a/src/hooks/bridgeMessageHandlers/types.ts
+++ b/src/hooks/bridgeMessageHandlers/types.ts
@@ -74,6 +74,13 @@ export interface BridgeMessageContext {
   // ─── Tab actions (from useTabs) ─────────────────────────────────────
   updateTab: (tabId: string, updater: (tab: Tab) => Tab) => void;
   updateActiveTab: (updater: (tab: Tab) => Tab) => void;
+  /** Open (or focus) a tab. Used by `session_forked` to open the forked tab
+   *  with its restored history. */
+  newTab: (
+    tabId?: string,
+    label?: string,
+    options?: { restoredSession?: boolean; cwd?: string; scrollToMatch?: string },
+  ) => void;
   dispatchTerminalReplay: (buffer: string) => void;
   autoRestoreDiscoveredSessions: (
     discovered: DiscoveredSession[],

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -8637,3 +8637,45 @@ button.ae-vcs-chip:focus-visible {
   display: flex;
   gap: 8px;
 }
+
+/* --------------------------------------------------------------------------
+ * Per-message rollback / fork hover toolbar (chat + canvas transcripts).
+ * ------------------------------------------------------------------------ */
+.a2ui-canvas-message {
+  position: relative;
+}
+.ae-msg-branch-actions {
+  position: absolute;
+  top: 4px;
+  right: 8px;
+  display: flex;
+  gap: 4px;
+  opacity: 0;
+  transition: opacity var(--motion-fast) ease;
+  pointer-events: none;
+}
+.a2ui-chat-message:hover .ae-msg-branch-actions,
+.a2ui-canvas-message:hover .ae-msg-branch-actions,
+.ae-msg-branch-actions:focus-within {
+  opacity: 1;
+  pointer-events: auto;
+}
+.ae-msg-branch-btn {
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  font-size: var(--text-xs);
+  padding: 1px 7px;
+  border-radius: var(--radius-pill);
+  cursor: pointer;
+  line-height: 1.4;
+}
+.ae-msg-branch-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+  border-color: var(--border-strong);
+}
+.ae-msg-branch-confirm {
+  color: var(--danger);
+  border-color: var(--danger);
+}

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -8679,3 +8679,53 @@ button.ae-vcs-chip:focus-visible {
   color: var(--danger);
   border-color: var(--danger);
 }
+
+/* --------------------------------------------------------------------------
+ * Subagent activity timeline (nested inside a `task` tool card).
+ * ------------------------------------------------------------------------ */
+.ae-subagent-activity {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 6px 8px;
+  margin-bottom: 6px;
+  border-left: 2px solid var(--accent-soft);
+  background: color-mix(in srgb, var(--accent) 5%, transparent);
+  border-radius: var(--radius-sm, 6px);
+}
+.ae-subagent-activity-head {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  color: var(--accent);
+}
+.ae-subagent-steps {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.ae-subagent-steps li {
+  font-size: var(--text-xs);
+  font-family: var(--font-mono, monospace);
+  color: var(--text-dim);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ae-subagent-steps li::before {
+  content: "▸ ";
+  color: var(--text-dim);
+}
+.ae-subagent-step-error {
+  color: var(--danger) !important;
+}
+.ae-subagent-text {
+  font-size: var(--text-xs);
+  color: var(--text-md, var(--text));
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  max-height: 8em;
+  overflow-y: auto;
+}

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -8445,3 +8445,195 @@ button.ae-vcs-chip:focus-visible {
   gap: 10px;
   padding: 4px 8px 10px;
 }
+
+/* --------------------------------------------------------------------------
+ * Subagents config (overview editor) — project + host overview surfaces.
+ * ------------------------------------------------------------------------ */
+.ae-subagents {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.ae-subagents-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+.ae-subagents-title {
+  margin: 0;
+  font-size: var(--text-md);
+  font-weight: 600;
+  color: var(--text);
+}
+.ae-subagents-note {
+  margin: 2px 0 0;
+  font-size: var(--text-xs);
+  color: var(--text-dim);
+}
+.ae-subagents-new,
+.ae-subagents-save,
+.ae-subagents-cancel,
+.ae-subagents-action {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text);
+  font-size: var(--chrome-text-compact);
+  padding: 4px var(--space-2);
+  border-radius: var(--radius-pill);
+  cursor: pointer;
+  transition:
+    background var(--motion-fast) ease,
+    border-color var(--motion-fast) ease;
+}
+.ae-subagents-new:hover,
+.ae-subagents-action:hover,
+.ae-subagents-save:hover,
+.ae-subagents-cancel:hover {
+  background: var(--bg-hover);
+  border-color: var(--border-strong);
+}
+.ae-subagents-save {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--accent-contrast, #fff);
+}
+.ae-subagents-save:hover {
+  background: var(--accent-hover-tint, var(--accent));
+}
+.ae-subagents-action-danger:hover {
+  border-color: var(--danger);
+  color: var(--danger);
+}
+.ae-subagents-error {
+  font-size: var(--text-xs);
+  color: var(--danger);
+  border: 1px solid var(--danger);
+  border-radius: var(--radius-sm, 6px);
+  padding: 6px 8px;
+  background: color-mix(in srgb, var(--danger) 8%, transparent);
+}
+.ae-subagents-empty {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--text-dim);
+}
+.ae-subagents-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.ae-subagents-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 7px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm, 8px);
+  background: var(--bg-elev);
+}
+.ae-subagents-row-main {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+  flex: 1;
+}
+.ae-subagents-row-name {
+  font-weight: 600;
+  font-size: var(--text-sm);
+  color: var(--text);
+}
+.ae-subagents-row-desc {
+  font-size: var(--text-xs);
+  color: var(--text-dim);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ae-subagents-row-badges {
+  display: flex;
+  gap: 4px;
+  flex-shrink: 0;
+}
+.ae-subagents-badge {
+  font-size: var(--text-xs);
+  font-family: var(--font-mono, monospace);
+  color: var(--text-dim);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  padding: 1px 7px;
+}
+.ae-subagents-badge-tab {
+  color: var(--accent);
+  border-color: var(--accent-soft);
+}
+.ae-subagents-row-actions {
+  display: flex;
+  gap: 4px;
+  flex-shrink: 0;
+}
+.ae-subagents-editor {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm, 8px);
+  padding: var(--space-3, 12px);
+  background: var(--bg-elev);
+}
+.ae-subagents-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.ae-subagents-label {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  color: var(--text-md, var(--text));
+}
+.ae-subagents-hint {
+  font-size: var(--text-xs);
+  color: var(--text-dim);
+}
+.ae-subagents-input,
+.ae-subagents-textarea,
+.ae-subagents-select {
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm, 6px);
+  color: var(--text);
+  font-size: var(--text-sm);
+  padding: 6px 8px;
+  font-family: inherit;
+}
+.ae-subagents-input:focus,
+.ae-subagents-textarea:focus,
+.ae-subagents-select:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+.ae-subagents-prompt {
+  font-family: var(--font-mono, monospace);
+  resize: vertical;
+}
+.ae-subagents-tools {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 4px;
+}
+.ae-subagents-tool {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: var(--text-xs);
+  color: var(--text);
+}
+.ae-subagents-editor-actions {
+  display: flex;
+  gap: 8px;
+}

--- a/src/subagents/index.ts
+++ b/src/subagents/index.ts
@@ -1,0 +1,13 @@
+export type {
+  ParseSubagentResult,
+  SubagentFields,
+  SubagentFile,
+  SubagentScope,
+  SubagentSurface,
+} from "./parse";
+export {
+  isSafeSubagentName,
+  parseSubagentContent,
+  sanitizeSubagentName,
+  serializeSubagent,
+} from "./parse";

--- a/src/subagents/parse.test.ts
+++ b/src/subagents/parse.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import {
+  isSafeSubagentName,
+  parseSubagentContent,
+  sanitizeSubagentName,
+  serializeSubagent,
+  type SubagentFields,
+} from "./parse";
+
+describe("isSafeSubagentName / sanitizeSubagentName", () => {
+  it("validates names", () => {
+    expect(isSafeSubagentName("reviewer")).toBe(true);
+    expect(isSafeSubagentName("code-reviewer_2")).toBe(true);
+    expect(isSafeSubagentName("UPPER")).toBe(false);
+    expect(isSafeSubagentName("-x")).toBe(false);
+    expect(isSafeSubagentName("")).toBe(false);
+  });
+  it("sanitizes user input", () => {
+    expect(sanitizeSubagentName("Code Reviewer")).toBe("code-reviewer");
+    expect(sanitizeSubagentName("!!!")).toBe("");
+  });
+});
+
+describe("parseSubagentContent", () => {
+  it("parses a full definition", () => {
+    const raw = [
+      "---",
+      "description: Reviews diffs",
+      "model: ollama/llama3.3",
+      "tools: [read, grep]",
+      "surface: tab",
+      "---",
+      "You review code.",
+    ].join("\n");
+    const { fields, error } = parseSubagentContent(raw);
+    expect(error).toBeUndefined();
+    expect(fields).toEqual({
+      description: "Reviews diffs",
+      model: "ollama/llama3.3",
+      tools: ["read", "grep"],
+      surface: "tab",
+      systemPrompt: "You review code.",
+    });
+  });
+
+  it("requires a description", () => {
+    const { error } = parseSubagentContent("---\nmodel: x\n---\nbody");
+    expect(error).toMatch(/description/);
+  });
+
+  it("requires frontmatter", () => {
+    expect(parseSubagentContent("no frontmatter").error).toMatch(/frontmatter/);
+  });
+
+  it("defaults surface to inline and tools to inherit", () => {
+    const { fields } = parseSubagentContent("---\ndescription: d\n---\nbody");
+    expect(fields?.surface).toBe("inline");
+    expect(fields?.tools).toBeUndefined();
+    expect(fields?.model).toBeUndefined();
+  });
+
+  it("treats an empty tools list as none", () => {
+    const { fields } = parseSubagentContent(
+      "---\ndescription: d\ntools: []\n---\nb",
+    );
+    expect(fields?.tools).toEqual([]);
+  });
+});
+
+describe("serializeSubagent", () => {
+  const base: SubagentFields = {
+    description: "Reviews diffs",
+    model: "ollama/llama3.3",
+    tools: ["read", "grep"],
+    surface: "tab",
+    systemPrompt: "You review.",
+  };
+
+  it("round-trips through parse", () => {
+    const text = serializeSubagent(base);
+    const { fields, error } = parseSubagentContent(text);
+    expect(error).toBeUndefined();
+    expect(fields).toEqual(base);
+  });
+
+  it("omits default surface and inherited tools", () => {
+    const text = serializeSubagent({
+      description: "d",
+      surface: "inline",
+      systemPrompt: "body",
+    });
+    expect(text).not.toContain("surface:");
+    expect(text).not.toContain("tools:");
+    expect(text).toContain("description: d");
+    const { fields } = parseSubagentContent(text);
+    expect(fields?.surface).toBe("inline");
+    expect(fields?.tools).toBeUndefined();
+  });
+
+  it("serializes an empty tools list (none) round-trip", () => {
+    const text = serializeSubagent({
+      description: "d",
+      tools: [],
+      surface: "inline",
+      systemPrompt: "",
+    });
+    const { fields } = parseSubagentContent(text);
+    expect(fields?.tools).toEqual([]);
+  });
+});

--- a/src/subagents/parse.ts
+++ b/src/subagents/parse.ts
@@ -1,0 +1,129 @@
+/**
+ * Frontend mirror of the agent-side subagent parser, plus a serializer for the
+ * editor. The agent bridge ({@link ../../agent/subagents/parse.ts}) and this
+ * module must agree on the markdown+frontmatter contract — kept in lockstep by
+ * convention (same as `src/auth-profiles` mirrors `agent/auth-profiles`).
+ *
+ * The UI works at the file level: it reads raw content from `subagents_list`,
+ * parses it for display, and serializes the editor form back to a file written
+ * via `subagents_write`. Rust never parses the markdown, so the contract lives
+ * in one language.
+ */
+
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
+
+export type SubagentScope = "user" | "project";
+export type SubagentSurface = "inline" | "tab";
+
+/** Parsed definition fields (name comes from the filename, not the body). */
+export interface SubagentFields {
+  description: string;
+  /** `provider/model-id`; empty/undefined inherits the tab's model. */
+  model?: string;
+  /** undefined = inherit all tools; [] = none; [...] = allowlist. */
+  tools?: string[];
+  surface: SubagentSurface;
+  systemPrompt: string;
+}
+
+/** A raw file as returned by the `subagents_list` Tauri command. */
+export interface SubagentFile {
+  scope: SubagentScope;
+  name: string;
+  filePath: string;
+  content: string;
+}
+
+const SAFE_NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/;
+
+export function isSafeSubagentName(input: string): boolean {
+  return SAFE_NAME_RE.test(input);
+}
+
+export function sanitizeSubagentName(input: string): string {
+  return input
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^[-_]+|[-_]+$/g, "")
+    .slice(0, 64);
+}
+
+const BOM = 0xfeff;
+const FRONTMATTER_RE =
+  /^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*\r?\n?([\s\S]*)$/;
+
+export interface ParseSubagentResult {
+  fields?: SubagentFields;
+  error?: string;
+}
+
+export function parseSubagentContent(raw: string): ParseSubagentResult {
+  const text = raw.charCodeAt(0) === BOM ? raw.slice(1) : raw;
+  const match = FRONTMATTER_RE.exec(text);
+  if (!match) {
+    return { error: "missing YAML frontmatter (expected a leading --- block)" };
+  }
+  const [, frontmatterText, body] = match;
+
+  let frontmatter: unknown;
+  try {
+    frontmatter = parseYaml(frontmatterText);
+  } catch (err) {
+    return { error: `invalid YAML frontmatter: ${(err as Error).message}` };
+  }
+  if (
+    !frontmatter ||
+    typeof frontmatter !== "object" ||
+    Array.isArray(frontmatter)
+  ) {
+    return { error: "frontmatter must be a YAML mapping" };
+  }
+  const fields = frontmatter as Record<string, unknown>;
+  const description =
+    typeof fields.description === "string" ? fields.description.trim() : "";
+  if (!description) {
+    return { error: "frontmatter `description` is required" };
+  }
+  const model =
+    typeof fields.model === "string" && fields.model.trim()
+      ? fields.model.trim()
+      : undefined;
+
+  return {
+    fields: {
+      description,
+      model,
+      tools: parseToolsField(fields.tools),
+      surface: fields.surface === "tab" ? "tab" : "inline",
+      systemPrompt: body.trim(),
+    },
+  };
+}
+
+function parseToolsField(value: unknown): string[] | undefined {
+  let tokens: string[];
+  if (Array.isArray(value)) {
+    tokens = value.map((v) => (typeof v === "string" ? v : String(v)));
+  } else if (typeof value === "string") {
+    tokens = value.split(/[,\s]+/);
+  } else {
+    return undefined;
+  }
+  const tools = tokens.map((t) => t.trim()).filter((t) => t.length > 0);
+  return [...new Set(tools)];
+}
+
+/** Serialize editor fields back to a markdown+frontmatter file body. Default
+ *  fields (inline surface, inherited tools) are omitted to keep files clean. */
+export function serializeSubagent(fields: SubagentFields): string {
+  const frontmatter: Record<string, unknown> = {
+    description: fields.description.trim(),
+  };
+  if (fields.model?.trim()) frontmatter.model = fields.model.trim();
+  if (fields.tools !== undefined) frontmatter.tools = fields.tools;
+  if (fields.surface === "tab") frontmatter.surface = "tab";
+  const yaml = stringifyYaml(frontmatter).trimEnd();
+  const body = fields.systemPrompt.trim();
+  return `---\n${yaml}\n---\n${body ? `${body}\n` : ""}`;
+}

--- a/src/types/a2ui.ts
+++ b/src/types/a2ui.ts
@@ -306,6 +306,11 @@ export interface ChatAttachment {
 // Message shape used by ChatHistory and MainCanvas — text or embedded A2UI subtree.
 export interface ChatMessage {
   id: string;
+  /** pi session entry id (8-char hex) for user/assistant turns. Present on
+   *  restored messages and back-filled on live ones after a turn settles; it's
+   *  the handle the rollback/fork affordances pass to the bridge. Absent on
+   *  tool-card / system rows. */
+  entryId?: string;
   role: "user" | "agent" | "system";
   text?: string;
   attachments?: ChatAttachment[];

--- a/src/utils/messages.test.ts
+++ b/src/utils/messages.test.ts
@@ -5,7 +5,29 @@ import {
   coerceChatMessages,
   stripImageDataUrls,
   trimMessage,
+  truncateToEntry,
 } from "./messages";
+import type { ChatMessage } from "../types/a2ui";
+
+describe("truncateToEntry", () => {
+  const messages: ChatMessage[] = [
+    { id: "1", entryId: "e1", role: "user", text: "a" },
+    { id: "2", entryId: "e2", role: "agent", text: "b" },
+    { id: "3", entryId: "e3", role: "user", text: "c" },
+  ];
+
+  it("keeps the prefix up to and including the matched entry", () => {
+    expect(truncateToEntry(messages, "e2").map((m) => m.id)).toEqual(["1", "2"]);
+  });
+
+  it("returns the same array reference when no entry matches", () => {
+    expect(truncateToEntry(messages, "missing")).toBe(messages);
+  });
+
+  it("keeps everything when the last entry matches", () => {
+    expect(truncateToEntry(messages, "e3")).toHaveLength(3);
+  });
+});
 
 describe("stripImageDataUrls", () => {
   it("returns non-objects unchanged", () => {

--- a/src/utils/messages.test.ts
+++ b/src/utils/messages.test.ts
@@ -138,6 +138,18 @@ describe("coerceChatMessages", () => {
     expect(out[0].id).toBe("abc");
   });
 
+  it("threads the pi entry id when present", () => {
+    const out = coerceChatMessages([
+      { id: "abc", entryId: "e1f2", role: "user", text: "hi" },
+    ]);
+    expect(out[0].entryId).toBe("e1f2");
+  });
+
+  it("omits entryId when absent", () => {
+    const out = coerceChatMessages([{ id: "abc", role: "user", text: "hi" }]);
+    expect(out[0].entryId).toBeUndefined();
+  });
+
   it("preserves finite creation timestamps", () => {
     const out = coerceChatMessages([
       { id: "abc", role: "system", text: "warning", createdAt: 1_234 },

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -200,6 +200,22 @@ function coerceChatAttachments(value: unknown): ChatAttachment[] {
   });
 }
 
+/**
+ * Keep the transcript prefix up to and INCLUDING the row whose `entryId`
+ * matches; drop everything after. Used by rollback to rewind the rendered
+ * transcript to a chosen message. Returns the input array unchanged (same
+ * reference) when no row matches — the rollback target isn't on the live
+ * transcript, so the authoritative truncate will land on the next reload.
+ */
+export function truncateToEntry(
+  messages: ChatMessage[],
+  entryId: string,
+): ChatMessage[] {
+  const idx = messages.findIndex((m) => m.entryId === entryId);
+  if (idx === -1) return messages;
+  return messages.slice(0, idx + 1);
+}
+
 export function coerceChatMessages(value: unknown): ChatMessage[] {
   if (!Array.isArray(value)) return [];
   const messages: ChatMessage[] = [];

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -234,6 +234,10 @@ export function coerceChatMessages(value: unknown): ChatMessage[] {
       typeof record.createdAt === "number" && Number.isFinite(record.createdAt)
         ? record.createdAt
         : undefined;
+    const entryId =
+      typeof record.entryId === "string" && record.entryId.length > 0
+        ? record.entryId
+        : undefined;
     if (!text && !thinking && !a2ui && attachments.length === 0) continue;
     messages.push(
       trimMessage({
@@ -241,6 +245,7 @@ export function coerceChatMessages(value: unknown): ChatMessage[] {
           typeof record.id === "string" && record.id.length > 0
             ? record.id
             : crypto.randomUUID(),
+        ...(entryId ? { entryId } : {}),
         role,
         ...(text ? { text } : {}),
         ...(thinking ? { thinking } : {}),


### PR DESCRIPTION
## Summary

Three capabilities, built in 9 verified phases (each its own commit, green on the `check` gate):

### 1. Configurable subagents (multi-model delegation)
A main agent (e.g. `openai/gpt-5.5`) can delegate focused work to named **subagents** running *different* models (e.g. a local Ollama model).

- **Storage:** one markdown-with-YAML-frontmatter file per subagent — `~/.aethon/agents/<name>.md` (user) and `<project>/.aethon/agents/<name>.md` (project, overrides user by name). Frontmatter: `description`, `model`, `tools` (allowlist), `surface` (`inline`|`tab`); body = system prompt.
- **Runtime:** a `task` tool runs each delegation in an isolated pi session (`SessionManager.inMemory()`) on the subagent's own model + tool allowlist. Model + auth + registry are resolved **together** (`servicesForProvider`) so an Ollama subagent gets its provider's base-URL/key. The subagent never receives the `task` tool (no recursion). `surface: tab` routes to the existing tab launcher instead.
- **Invocation:** auto-delegation (the model picks a subagent by `description`, advertised in the system prompt) **and** explicit `@name` (a one-shot `before_agent_start` steer; no transcript pollution).
- **UI:** a `subagents-config` editor in the **project overview** (project scope) and **host overview** (user scope) — list/New/Edit/Delete with a model picker (reuses `/sidebar/models`), tools mode, surface toggle, and system-prompt editor. Rust owns file CRUD (`subagents_list/write/delete`, path-safe); TS owns parsing (bridge + a `src/` mirror) so the contract never diverges. Edits re-advertise to the running bridge without a restart.
- **Live nested card:** a `task` card streams its subagent's text (pi partials) plus a per-tool activity timeline.

### 2. Rollback a conversation to a message
Non-destructive `SessionManager.branch()` rewind. Per-message hover **↶ Rollback** (two-click confirm) → optimistic truncate + bridge `rollback_session` (aborts any in-flight turn, realigns the local chat).

### 3. Fork a conversation into a new tab
`createBranchedSession()` extracts the branch → FS-safe `copy_session_file` moves it into a new tab dir → the tab opens with restored history and a "Fork of …" label. Per-message **⑂ Fork** button.

The rollback/fork affordances rely on new **entry-id plumbing**: the pi session entry id is carried onto restored rows (deterministic) and back-filled onto live rows at `agent_end` (role-aware positional matching that handles multi-segment assistant turns).

## Design notes
- pi-coding-agent has **no native subagent primitive** — a subagent is just a second `AgentSession` driven inside a custom tool. `branch()` / `createBranchedSession()` are pi's existing (non-destructive) branching primitives.
- **FS safety lives Rust-side**; **markdown parsing lives in one language (TS)**, mirrored between `agent/` and `src/`.

## Tests
Comprehensive colocated coverage at every layer — parser/loader, the `task` tool (mocked sessions), advertisement + `@name`, Rust CRUD + `copy_session_file` (incl. traversal rejection), entry-id round-trip + live back-fill matching, rollback/fork bridge handlers, local-chat truncation, event routes, both frontend bridge handlers, the per-message affordance (render + two-click confirm), and the nested activity timeline.

**Full `check` gate green locally:** `tsc -b`, ESLint (0 warnings), **1889 vitest**, `clippy -D warnings`, **371 cargo tests**.

## Not included / manual verification
No automated **e2e** for the subagent run path — the Playwright harness mocks Tauri (no real bridge/Ollama), so an end-to-end subagent delegation needs the dev build + a real local model. Recommend a manual pass: define an Ollama `@reviewer` in the project overview, delegate to it, then exercise rollback + fork.