### PR TITLE
fix(tabs): show Aethon menu for overview tab

### DIFF
--- a/src/eventRoutes/tabStrip.test.ts
+++ b/src/eventRoutes/tabStrip.test.ts
@@ -96,6 +96,29 @@ describe("handleTabStrip", () => {
     expect(mocks.closeTab).not.toHaveBeenCalledWith("sh-1");
   });
 
+  it("close-others from overview closes every non-shell tab", async () => {
+    const { ctx, mocks } = buildRouteFixture({
+      state: {
+        tabs: [
+          { id: "ed-1", kind: "editor" },
+          { id: "ag-1", kind: "agent" },
+          { id: "sh-1", kind: "shell" },
+        ],
+      },
+    });
+    await handleTabStrip(
+      {
+        component: { id: "header-tabs", type: "tab-strip" },
+        eventType: "close-others",
+        data: { tabId: OVERVIEW_TAB_ID },
+      },
+      ctx,
+    );
+    expect(mocks.closeTab).toHaveBeenCalledWith("ed-1");
+    expect(mocks.closeTab).toHaveBeenCalledWith("ag-1");
+    expect(mocks.closeTab).not.toHaveBeenCalledWith("sh-1");
+  });
+
   it("close-all closes every non-shell tab", async () => {
     const { ctx, mocks } = buildRouteFixture({
       state: {

--- a/src/extensions/default-layout/shell/tab-strip.test.tsx
+++ b/src/extensions/default-layout/shell/tab-strip.test.tsx
@@ -167,6 +167,34 @@ describe("TabStrip", () => {
     expect(onEvent).toHaveBeenCalledWith("select", { tabId: OVERVIEW_TAB_ID });
   });
 
+  it("opens the Aethon context menu for the overview pill and suppresses the native menu", () => {
+    const { onEvent } = renderTabStrip();
+    const overviewPill = screen
+      .getAllByRole("tab")
+      .find((el) => el.textContent?.includes("overview"))!;
+    const event = new MouseEvent("contextmenu", {
+      bubbles: true,
+      cancelable: true,
+      clientX: 12,
+      clientY: 16,
+    });
+
+    fireEvent(overviewPill, event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(screen.getByRole("menu", { name: "Tab actions" })).toBeTruthy();
+    expect(screen.getByRole("menuitem", { name: "New Tab" })).toBeTruthy();
+    expect(screen.getByRole("menuitem", { name: "Close Others" })).toBeTruthy();
+    expect(
+      screen.getByRole("menuitem", { name: "Close All Sessions" }),
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "Close Others" }));
+    expect(onEvent).toHaveBeenCalledWith("close-others", {
+      tabId: OVERVIEW_TAB_ID,
+    });
+  });
+
   it("marks the overview pill active when no tab id is set", () => {
     render(
       <TabStrip

--- a/src/extensions/default-layout/shell/tab-strip.tsx
+++ b/src/extensions/default-layout/shell/tab-strip.tsx
@@ -99,6 +99,10 @@ export function TabStrip({ component, state, onEvent }: BuiltinComponentProps) {
     setContextMenu({ x: event.clientX, y: event.clientY, tab });
   };
 
+  const openOverviewMenu = (event: MouseEvent) => {
+    openTabMenu(event, { id: OVERVIEW_TAB_ID, label: "overview" });
+  };
+
   useEffect(() => {
     if (!renamingTabId) return;
     renameEndingRef.current = false;
@@ -150,6 +154,31 @@ export function TabStrip({ component, state, onEvent }: BuiltinComponentProps) {
   const buildMenuItems = (): ContextMenuItem[] => {
     if (!contextMenu) return [];
     const tab = contextMenu.tab;
+
+    if (tab.id === OVERVIEW_TAB_ID) {
+      const hasTopStripTabs = tabs.length > 0;
+      return [
+        {
+          id: "new-tab",
+          label: "New Tab",
+          onSelect: () => onEvent("new"),
+        },
+        { type: "separator" },
+        {
+          id: "close-others",
+          label: "Close Others",
+          disabled: !hasTopStripTabs,
+          onSelect: () => onEvent("close-others", { tabId: OVERVIEW_TAB_ID }),
+        },
+        {
+          id: "close-all",
+          label: "Close All Sessions",
+          disabled: !hasTopStripTabs,
+          onSelect: () => onEvent("close-all", { tabId: OVERVIEW_TAB_ID }),
+        },
+      ];
+    }
+
     const closeFamily: ContextMenuItem[] = [
       {
         id: "close-tab",
@@ -241,6 +270,7 @@ export function TabStrip({ component, state, onEvent }: BuiltinComponentProps) {
           e.preventDefault();
           onEvent("select", { tabId: OVERVIEW_TAB_ID });
         }}
+        onContextMenu={openOverviewMenu}
       >
         <span className="a2ui-tab-overview-glyph" aria-hidden="true">
           Æ


### PR DESCRIPTION
## Summary

Fixes #212.

Right-clicking the pinned `Æ overview` tab now opens the same Aethon-styled context menu surface used by real tabs instead of falling through to the native browser/webview context menu.

## Changes

- Added an `onContextMenu` handler to the pinned overview pill.
- Reused the existing tab-strip context menu plumbing so right-clicks call `preventDefault()` and `stopPropagation()`.
- Added overview-specific menu actions:
  - `New Tab`
  - `Close Others`
  - `Close All Sessions`
- Kept overview close actions safe for the top strip by targeting non-shell tabs and leaving bottom-panel shell tabs alone.
- Preserved existing real-tab context menu behavior for agent and editor tabs.

## Tests

- Added component coverage for right-clicking the overview pill:
  - verifies the native context menu is prevented
  - verifies the Aethon tab actions menu appears
  - verifies `Close Others` emits the overview sentinel action
- Added route coverage for `close-others` invoked from overview, confirming it closes all non-shell top-strip tabs and preserves shell tabs.

## Verification

- `nix develop -c npm test -- src/extensions/default-layout/shell/tab-strip.test.tsx src/eventRoutes/tabStrip.test.ts`
- `nix develop -c npm run typecheck`
- `codex review --uncommitted` reported no correctness issues.
