### PR TITLE
fix(auth): refresh Codex auth profile state without restart

### DIFF
--- a/agent/auth-profiles/index.ts
+++ b/agent/auth-profiles/index.ts
@@ -22,6 +22,9 @@ export {
   handleAuthProfileMessage,
   loadAuthProfiles,
   modelRegistryForModelId,
+  refreshAuthServicesForTab,
+  refreshGlobalAuthServicesIfChanged,
+  refreshTabSessionModelFromAuthServices,
   saveAuthProfiles,
   servicesForProvider,
 } from "./manager";

--- a/agent/auth-profiles/manager.test.ts
+++ b/agent/auth-profiles/manager.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -15,8 +15,10 @@ import {
   defaultProfileIdForTab,
   handleAuthProfileMessage,
   modelRegistryForModelId,
+  refreshAuthServicesForTab,
 } from "./manager";
 import {
+  authProfileAuthPath,
   createProfileMeta,
   loadAuthProfilesState,
   upsertProfileMeta,
@@ -134,6 +136,71 @@ describe("auth profile manager", () => {
     expect(modelRegistryForModelId(state, "tab-1", "anthropic/claude")).toBe(
       state.modelRegistry,
     );
+  });
+
+  it("reloads cached profile auth services when the profile auth file changes", () => {
+    const userDir = tempUserDir();
+    const state = makeState(userDir);
+    const profileId = addProfile(state, "openai-codex", "Codex Work");
+
+    const services = authProfileServicesForTab(state, "default");
+    const reload = vi.spyOn(services.authStorage, "reload");
+    const refresh = vi.spyOn(services.modelRegistry, "refresh");
+    const authPath = authProfileAuthPath(userDir, profileId);
+    writeFileSync(
+      authPath,
+      JSON.stringify({ "openai-codex": { type: "api_key", key: "new" } }),
+    );
+    const future = new Date(Date.now() + 10_000);
+    utimesSync(authPath, future, future);
+
+    const refreshed = refreshAuthServicesForTab(state, "default");
+
+    expect(refreshed).toBe(true);
+    expect(reload).toHaveBeenCalledOnce();
+    expect(refresh).toHaveBeenCalledOnce();
+    expect(authProfileServicesForTab(state, "default")).toBe(services);
+  });
+
+  it("force-refreshes profile services even when the auth file mtime is unchanged", () => {
+    const state = makeState();
+    addProfile(state, "openai-codex", "Codex Work");
+    const services = authProfileServicesForTab(state, "default");
+    const reload = vi.spyOn(services.authStorage, "reload");
+    const refresh = vi.spyOn(services.modelRegistry, "refresh");
+
+    const refreshed = refreshAuthServicesForTab(state, "default", {
+      forceRefresh: true,
+    });
+
+    expect(refreshed).toBe(true);
+    expect(reload).toHaveBeenCalledOnce();
+    expect(refresh).toHaveBeenCalledOnce();
+  });
+
+  it("refreshes cached default profile services before a new tab uses that provider", () => {
+    const userDir = tempUserDir();
+    const state = makeState(userDir);
+    const profileId = addProfile(state, "openai-codex", "Codex Work");
+    const services = authProfileServicesForTab(state, "existing-tab");
+    const reload = vi.spyOn(services.authStorage, "reload");
+    const refresh = vi.spyOn(services.modelRegistry, "refresh");
+    const authPath = authProfileAuthPath(userDir, profileId);
+    writeFileSync(
+      authPath,
+      JSON.stringify({ "openai-codex": { type: "api_key", key: "new" } }),
+    );
+    const future = new Date(Date.now() + 10_000);
+    utimesSync(authPath, future, future);
+
+    const refreshed = refreshAuthServicesForTab(state, "new-tab", {
+      modelId: "openai-codex/gpt-5.1-codex",
+    });
+
+    expect(state.tabAuthProfileIds.has("new-tab")).toBe(false);
+    expect(refreshed).toBe(true);
+    expect(reload).toHaveBeenCalledOnce();
+    expect(refresh).toHaveBeenCalledOnce();
   });
 
   it("rejects deleting unknown or unsafe profile ids before removing files", async () => {

--- a/agent/auth-profiles/manager.ts
+++ b/agent/auth-profiles/manager.ts
@@ -1,7 +1,11 @@
 import { randomUUID } from "node:crypto";
-import { mkdirSync } from "node:fs";
-import { dirname } from "node:path";
-import { AuthStorage, ModelRegistry } from "@mariozechner/pi-coding-agent";
+import { mkdirSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
+import {
+  AuthStorage,
+  getAgentDir,
+  ModelRegistry,
+} from "@mariozechner/pi-coding-agent";
 import type { Api, Model } from "@mariozechner/pi-ai";
 import type { AethonAgentState } from "../state";
 import type { DispatcherDeps, InboundMessage } from "../dispatcherTypes";
@@ -22,6 +26,8 @@ import {
 export interface AuthProfileServices {
   authStorage: AuthStorage;
   modelRegistry: ModelRegistry;
+  authPath?: string;
+  authMtimeMs?: number;
 }
 
 export interface AuthProfileProvider {
@@ -43,10 +49,12 @@ interface PendingOAuth {
   profileId: string;
   providerId: string;
   controller: AbortController;
+  isReauth: boolean;
   resolvePrompt?: (value: string) => void;
 }
 
 const pendingOAuth = new Map<string, PendingOAuth>();
+const globalAuthMtimes = new WeakMap<AethonAgentState, number | undefined>();
 
 export function loadAuthProfiles(userDir: string): AuthProfilesState {
   return loadAuthProfilesState(userDir);
@@ -132,6 +140,73 @@ export function modelRegistryForModelId(
     : state.modelRegistry;
 }
 
+export function refreshAuthServicesForTab(
+  state: AethonAgentState,
+  tabId: string,
+  options: {
+    forceRefresh?: boolean;
+    initialModel?: Model<Api>;
+    modelId?: string;
+  } = {},
+): boolean {
+  const profileId =
+    state.tabAuthProfileIds.get(tabId) ??
+    defaultProfileIdForTab(
+      state,
+      options.initialModel ?? modelStubFromId(options.modelId),
+    );
+  if (profileId && findProfile(state, profileId)) {
+    return servicesForProfileWithStatus(state, profileId, {
+      forceRefresh: options.forceRefresh,
+    }).refreshed;
+  }
+  return refreshGlobalAuthServicesIfChanged(state, options);
+}
+
+function modelStubFromId(modelId: string | undefined): Model<Api> | undefined {
+  if (!modelId) return undefined;
+  const [provider] = modelId.split("/");
+  if (!provider) return undefined;
+  return { provider, id: "" } as Model<Api>;
+}
+
+export function refreshGlobalAuthServicesIfChanged(
+  state: AethonAgentState,
+  options: { forceRefresh?: boolean } = {},
+): boolean {
+  if (!state.authStorage || !state.modelRegistry) return false;
+
+  const authPath = join(getAgentDir(), "auth.json");
+  const authMtimeMs = fileMtimeMs(authPath);
+  const previous = globalAuthMtimes.get(state);
+  const refreshed = options.forceRefresh === true || previous !== authMtimeMs;
+  if (refreshed) {
+    state.authStorage.reload();
+    state.modelRegistry.refresh();
+    globalAuthMtimes.set(state, authMtimeMs);
+  }
+  return refreshed;
+}
+
+export function refreshTabSessionModelFromAuthServices(
+  state: AethonAgentState,
+  tabId: string,
+): void {
+  const tab = state.tabs.get(tabId);
+  const current = tab?.session.model;
+  if (!tab || !current) return;
+  const refreshed = modelRegistryForModelId(
+    state,
+    tabId,
+    `${current.provider}/${current.id}`,
+  ).find(current.provider, current.id);
+  if (!refreshed) return;
+  const mutableSession = tab.session as {
+    state?: { model?: Model<Api> };
+  };
+  if (mutableSession.state) mutableSession.state.model = refreshed;
+}
+
 /**
  * Resolve the auth + model services for a *provider's* default profile,
  * independent of any tab. Unlike {@link modelRegistryForModelId} this ignores
@@ -202,19 +277,56 @@ export function emitAuthProfiles(
 function servicesForProfile(
   state: AethonAgentState,
   profileId: string,
+  options: { forceRefresh?: boolean } = {},
 ): AuthProfileServices {
+  return servicesForProfileWithStatus(state, profileId, options).services;
+}
+
+function servicesForProfileWithStatus(
+  state: AethonAgentState,
+  profileId: string,
+  options: { forceRefresh?: boolean } = {},
+): { services: AuthProfileServices; refreshed: boolean } {
   if (!isSafeProfileId(profileId)) {
     throw new Error(`Invalid auth profile id: ${profileId}`);
   }
-  const cached = state.authProfileServices.get(profileId);
-  if (cached) return cached;
   const authPath = authProfileAuthPath(state.userDir, profileId);
+  const cached = state.authProfileServices.get(profileId);
+  if (cached) {
+    const authMtimeMs = fileMtimeMs(authPath);
+    const changed = cached.authMtimeMs !== authMtimeMs;
+    const refreshed = options.forceRefresh === true || changed;
+    if (refreshed) {
+      refreshServicePair(cached);
+      cached.authPath = authPath;
+      cached.authMtimeMs = authMtimeMs;
+    }
+    return { services: cached, refreshed };
+  }
   mkdirSync(dirname(authPath), { recursive: true });
   const authStorage = AuthStorage.create(authPath);
   const modelRegistry = ModelRegistry.create(authStorage);
-  const services = { authStorage, modelRegistry };
+  const services = {
+    authStorage,
+    modelRegistry,
+    authPath,
+    authMtimeMs: fileMtimeMs(authPath),
+  };
   state.authProfileServices.set(profileId, services);
-  return services;
+  return { services, refreshed: false };
+}
+
+function refreshServicePair(services: AuthProfileServices): void {
+  services.authStorage.reload();
+  services.modelRegistry.refresh();
+}
+
+function fileMtimeMs(path: string): number | undefined {
+  try {
+    return statSync(path).mtimeMs;
+  } catch {
+    return undefined;
+  }
 }
 
 function authProfileProviders(state: AethonAgentState): AuthProfileProvider[] {
@@ -250,22 +362,54 @@ function handleApiKeySave(
   const key = stringField(msg.key);
   if (!providerId || !key)
     throw new Error("auth_profile_api_key_save: providerId and key required");
-  const meta = createProfileMeta(state.authProfiles, {
-    providerId,
-    label: stringField(msg.label) || providerId,
-    kind: "api_key",
-  });
-  const services = servicesForProfile(state, meta.id);
+  const requestedProfileId = stringField(msg.profileId);
+  const existing = requestedProfileId
+    ? findProfile(state, requestedProfileId)
+    : undefined;
+  if (requestedProfileId && !existing) {
+    throw new Error("auth_profile_api_key_save: unknown profileId");
+  }
+  if (existing && existing.providerId !== providerId) {
+    throw new Error("auth_profile_api_key_save: providerId mismatch");
+  }
+  if (existing && existing.kind !== "api_key") {
+    throw new Error("auth_profile_api_key_save: profile is not api_key");
+  }
+  const meta =
+    existing ??
+    createProfileMeta(state.authProfiles, {
+      providerId,
+      label: stringField(msg.label) || providerId,
+      kind: "api_key",
+    });
+  const services = servicesForProfile(state, meta.id, { forceRefresh: true });
   services.authStorage.set(providerId, { type: "api_key", key });
-  state.authProfiles = {
-    ...state.authProfiles,
-    profiles: [...state.authProfiles.profiles, meta],
-  };
+  const now = Date.now();
+  state.authProfiles = existing
+    ? {
+        ...state.authProfiles,
+        profiles: state.authProfiles.profiles.map((p) =>
+          p.id === meta.id ? { ...p, updatedAt: now, lastUsedAt: now } : p,
+        ),
+      }
+    : {
+        ...state.authProfiles,
+        profiles: [...state.authProfiles.profiles, meta],
+      };
   if (!state.authProfiles.defaultByProvider[providerId]) {
     state.authProfiles.defaultByProvider[providerId] = meta.id;
   }
   saveAuthProfiles(state);
-  state.authProfileServices.delete(meta.id);
+  servicesForProfile(state, meta.id, { forceRefresh: true });
+  void recreateIdleTabsUsingProfile(state, deps, meta.id).catch(
+    (err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err);
+      deps.send({
+        type: "error",
+        message: `auth_profile_api_key_save: ${message}`,
+      });
+    },
+  );
   emitAuthProfiles(state, deps);
 }
 
@@ -277,22 +421,41 @@ function handleOAuthStart(
   const providerId = stringField(msg.providerId);
   if (!providerId)
     throw new Error("auth_profile_login_start: providerId required");
-  const meta = createProfileMeta(state.authProfiles, {
-    providerId,
-    label: stringField(msg.label) || providerId,
-    kind: "oauth",
-  });
-  state.authProfiles = {
-    ...state.authProfiles,
-    profiles: [...state.authProfiles.profiles, meta],
-  };
-  saveAuthProfiles(state);
-  const services = servicesForProfile(state, meta.id);
+  const requestedProfileId = stringField(msg.profileId);
+  const existing = requestedProfileId
+    ? findProfile(state, requestedProfileId)
+    : undefined;
+  if (requestedProfileId && !existing) {
+    throw new Error("auth_profile_login_start: unknown profileId");
+  }
+  if (existing && existing.providerId !== providerId) {
+    throw new Error("auth_profile_login_start: providerId mismatch");
+  }
+  if (existing && existing.kind !== "oauth") {
+    throw new Error("auth_profile_login_start: profile is not oauth");
+  }
+  const isReauth = Boolean(existing);
+  const meta =
+    existing ??
+    createProfileMeta(state.authProfiles, {
+      providerId,
+      label: stringField(msg.label) || providerId,
+      kind: "oauth",
+    });
+  if (!existing) {
+    state.authProfiles = {
+      ...state.authProfiles,
+      profiles: [...state.authProfiles.profiles, meta],
+    };
+    saveAuthProfiles(state);
+  }
+  const services = servicesForProfile(state, meta.id, { forceRefresh: true });
   const challengeId = randomUUID();
   const pending: PendingOAuth = {
     profileId: meta.id,
     providerId,
     controller: new AbortController(),
+    isReauth,
   };
   pendingOAuth.set(challengeId, pending);
   deps.send({
@@ -359,7 +522,7 @@ function handleOAuthStart(
           });
         }),
     })
-    .then(() => {
+    .then(async () => {
       pendingOAuth.delete(challengeId);
       const now = Date.now();
       state.authProfiles = {
@@ -372,7 +535,8 @@ function handleOAuthStart(
         state.authProfiles.defaultByProvider[providerId] = meta.id;
       }
       saveAuthProfiles(state);
-      state.authProfileServices.delete(meta.id);
+      servicesForProfile(state, meta.id, { forceRefresh: true });
+      await recreateIdleTabsUsingProfile(state, deps, meta.id);
       deps.send({
         type: "auth_profile_login_event",
         event: {
@@ -387,7 +551,7 @@ function handleOAuthStart(
     })
     .catch((err: unknown) => {
       pendingOAuth.delete(challengeId);
-      removeProfile(state, meta.id);
+      if (!isReauth) removeProfile(state, meta.id);
       saveAuthProfiles(state);
       const message = err instanceof Error ? err.message : String(err);
       deps.send({
@@ -424,9 +588,44 @@ function handleOAuthCancel(
   if (!pending) return;
   pending.controller.abort();
   pendingOAuth.delete(challengeId);
-  removeProfile(state, pending.profileId);
+  if (!pending.isReauth) removeProfile(state, pending.profileId);
   saveAuthProfiles(state);
   emitAuthProfiles(state, deps);
+}
+
+async function recreateIdleTabsUsingProfile(
+  state: AethonAgentState,
+  deps: DispatcherDeps,
+  profileId: string,
+): Promise<void> {
+  for (const [tabId, activeProfileId] of state.tabAuthProfileIds) {
+    if (activeProfileId !== profileId) continue;
+    const existing = state.tabs.get(tabId);
+    if (!existing || existing.promptInFlight) continue;
+    await recreateTabSession(state, deps, tabId, profileId);
+  }
+}
+
+async function recreateTabSession(
+  state: AethonAgentState,
+  deps: DispatcherDeps,
+  tabId: string,
+  profileId: string,
+): Promise<void> {
+  const existing = state.tabs.get(tabId);
+  const previousModel = existing?.session.model;
+  const cwd = state.tabProjectCwds.get(tabId);
+  if (existing) clearPendingContextUsageEmit(existing);
+  state.tabs.delete(tabId);
+  state.tabAuthProfileIds.set(tabId, profileId);
+  const services = servicesForProfile(state, profileId, { forceRefresh: true });
+  const nextModel =
+    previousModel &&
+    services.modelRegistry.find(previousModel.provider, previousModel.id);
+  await ensureTab(state, deps, tabId, {
+    cwdOverride: cwd,
+    initialModel: nextModel || previousModel,
+  });
 }
 
 async function handleUseForTab(
@@ -454,7 +653,7 @@ async function handleUseForTab(
   if (existing) clearPendingContextUsageEmit(existing);
   state.tabs.delete(tabId);
   state.tabAuthProfileIds.set(tabId, profile.id);
-  const services = servicesForProfile(state, profile.id);
+  const services = servicesForProfile(state, profile.id, { forceRefresh: true });
   const nextModel =
     previousModel &&
     services.modelRegistry.find(previousModel.provider, previousModel.id);

--- a/agent/chat.ts
+++ b/agent/chat.ts
@@ -8,7 +8,11 @@ import {
   ensurePickerHasModel,
   ensureTab,
 } from "./tab-lifecycle";
-import { modelRegistryForModelId } from "./auth-profiles";
+import {
+  modelRegistryForModelId,
+  refreshAuthServicesForTab,
+  refreshTabSessionModelFromAuthServices,
+} from "./auth-profiles";
 import { detectSubagentMention } from "./subagents/steer";
 import { getSubagentsForCwd } from "./subagents";
 import { emitContextUsage } from "./context-usage";
@@ -38,13 +42,20 @@ export async function handleChat(
       state.pendingExplicitSubagent.set(tabId, mention);
     }
   }
+  const modelId =
+    typeof msg.model === "string" && msg.model.length > 0
+      ? msg.model
+      : undefined;
+  const authServicesRefreshed = refreshAuthServicesForTab(state, tabId, {
+    modelId,
+  });
   const cwdOverride =
     typeof msg.cwd === "string" && msg.cwd.length > 0 ? msg.cwd : undefined;
   let initialModel: Model<Api> | undefined;
-  if (typeof msg.model === "string" && msg.model.length > 0) {
-    const [provider, ...rest] = msg.model.split("/");
+  if (modelId) {
+    const [provider, ...rest] = modelId.split("/");
     initialModel =
-      modelRegistryForModelId(state, tabId, msg.model).find(
+      modelRegistryForModelId(state, tabId, modelId).find(
         provider,
         rest.join("/"),
       ) ?? undefined;
@@ -55,6 +66,9 @@ export async function handleChat(
     tabId,
     cwdOverride || initialModel ? { cwdOverride, initialModel } : {},
   );
+  if (authServicesRefreshed) {
+    refreshTabSessionModelFromAuthServices(state, tabId);
+  }
   const wantsSteer = msg.mode === "steer";
   const images = normalizeImages(msg.images);
   const busyForTurn = tab.promptInFlight || isUnderlyingSessionBusy(tab);
@@ -168,7 +182,13 @@ export async function handleSetModel(
     deps.send({ type: "error", tabId, message: "set_model: missing id" });
     return;
   }
+  const authServicesRefreshed = refreshAuthServicesForTab(state, tabId, {
+    modelId: msg.id,
+  });
   const tab = await ensureTab(state, deps, tabId);
+  if (authServicesRefreshed) {
+    refreshTabSessionModelFromAuthServices(state, tabId);
+  }
   if (tab.promptInFlight) {
     deps.send({
       type: "notice",

--- a/src/extensions/default-layout/auth-profile-panel.tsx
+++ b/src/extensions/default-layout/auth-profile-panel.tsx
@@ -78,6 +78,18 @@ export function AuthProfilePanel({
   const setDefault = (profileId: string) =>
     sendAuthProfileCommand({ type: "auth_profile_set_default", profileId });
 
+  const reauthProfile = (profile: {
+    id: string;
+    providerId: string;
+    label: string;
+  }) =>
+    sendAuthProfileCommand({
+      type: "auth_profile_login_start",
+      providerId: profile.providerId,
+      profileId: profile.id,
+      label: profile.label,
+    });
+
   const deleteProfile = (profileId: string) =>
     sendAuthProfileCommand({ type: "auth_profile_delete", profileId });
 
@@ -204,6 +216,15 @@ export function AuthProfilePanel({
                         >
                           Default
                         </button>
+                        {profile.kind === "oauth" && (
+                          <button
+                            type="button"
+                            className="ae-settings-secondary"
+                            onClick={() => void reauthProfile(profile)}
+                          >
+                            Re-auth
+                          </button>
+                        )}
                         <button
                           type="button"
                           className="ae-settings-secondary"


### PR DESCRIPTION
## Summary

Closes #211.

This PR makes Codex/OpenAI auth profile changes take effect without requiring a full Aethon restart. The fix focuses on the stale in-process service path described in the issue: cached `AuthStorage`, `ModelRegistry`, and tab session model objects could continue using stale credentials after account switching, re-authentication, or an external auth file update.

## What changed

- Refresh cached profile auth services when a profile `auth.json` changes
  - Tracks per-profile auth file mtimes on cached `AuthProfileServices`.
  - Calls `AuthStorage.reload()` and `ModelRegistry.refresh()` on stale or forced refresh.
  - Refreshes default profile services for new tabs before resolving the initial model, not only already-active tab profiles.

- Force-refresh and recreate idle tab sessions on account switch/re-auth
  - `/login use <account>` / Accounts → Use now force-refreshes the selected profile service before recreating the tab session.
  - OAuth and API-key re-auth flows can update an existing stored profile via `profileId`.
  - Idle tabs using a re-authenticated profile are recreated so the next request uses a fresh session/model service pair.
  - Busy tabs are left alone until idle, preserving the existing “don’t switch while prompt in flight” behavior.

- Keep active session model objects aligned with refreshed registries
  - Before chat and model switching, auth services are refreshed if needed.
  - If a tab’s current model can be found in the refreshed registry, the session’s current model object is updated so provider/base URL/auth-derived model mutations do not remain stale.

- Add UI affordance for deterministic re-auth
  - Stored OAuth accounts in the Accounts panel now expose a `Re-auth` button.
  - Re-auth updates the existing profile instead of creating a throwaway duplicate profile.

- Regression coverage
  - Adds tests for stale profile auth file reload.
  - Adds tests for force-refresh behavior when mtimes are unchanged.
  - Adds coverage for refreshing cached default profile services before a new tab uses the provider.

## Codex peer review

Requested and addressed Codex peer review findings:

1. **P1: Guard global auth refresh when services are uninitialized**
   - Fixed by making the global refresh path a no-op until `authStorage` and `modelRegistry` are installed.
   - Confirmed the full agent test slice passes afterward.

2. **P2: Refresh default profile services before new-tab prompts**
   - Fixed by allowing `refreshAuthServicesForTab()` to resolve default profiles from an initial model/model id.
   - Added regression coverage for a cached default profile used by a new tab.

Final Codex review reported no introduced bug worth flagging.

## Validation

- `npx vitest run agent`
- `npm run typecheck`
- `npm run lint`
- `codex review --uncommitted --title "Issue 211 Codex auth account switching final"`

## Notes

This preserves the existing profile isolation model: tabs with an auth profile continue to use per-profile `AuthStorage`/`ModelRegistry` pairs, while tabs without profile selection still fall back to the global auth/model services. External auth file changes are supported by mtime-based reloads on the next relevant chat/model resolution path.
