### PR TITLE
test(file-tree): poll scrollIntoView spy to fix macOS flake

### DIFF
--- a/src/extensions/default-layout/sidebar/file-tree.test.tsx
+++ b/src/extensions/default-layout/sidebar/file-tree.test.tsx
@@ -901,7 +901,10 @@ describe("FileTreePanel", () => {
 
     const appRow = await waitFor(() => screen.getByText("App.tsx"));
     expect(appRow.closest("li")?.className).toContain("is-revealed");
-    expect(scrollSpy).toHaveBeenCalled();
+    // scrollIntoView fires in a `revealed`-keyed effect that flushes a tick
+    // after the row commits, so poll rather than assert synchronously — the
+    // synchronous check raced under CI load and flaked on macOS.
+    await waitFor(() => expect(scrollSpy).toHaveBeenCalled());
     proto.scrollIntoView = prevScroll;
   });
 });


### PR DESCRIPTION
## What

The `FileTreePanel > reveals a nested file on aethon:reveal-in-tree` test asserted `scrollSpy` synchronously immediately after the revealed row committed. But `scrollIntoView` fires in a `revealed`-keyed `useEffect` (`file-tree.tsx:542`) that flushes a tick *after* the `is-revealed` class is applied. The test's `waitFor` resolves when the row text appears (same commit that sets `revealed`), so the spy check ran before the effect flushed.

## Why now

Under load on macOS CI this raced and flaked. It failed the **post-merge CI gate** on the 0.6.0 release run (#210), which **skipped Build / Publish Release** — the v0.6.0 release stalled as a draft until a re-run. Passed on ubuntu and every PR run on the same tree, confirming it's timing, not a real regression.

## Fix

Poll the spy with `await waitFor(() => expect(scrollSpy).toHaveBeenCalled())` so the assertion is deterministic regardless of effect-flush timing. Test-only change.