### PR TITLE
feat(tabs): support drag reorder for sessions and shells

### DIFF
--- a/src/eventRoutes/tabStrip.test.ts
+++ b/src/eventRoutes/tabStrip.test.ts
@@ -177,6 +177,65 @@ describe("handleTabStrip", () => {
     );
   });
 
+  it("reorder rearranges only visible top-strip tabs and keeps active id", async () => {
+    const { ctx, applySetState } = buildRouteFixture({
+      state: {
+        activeTabId: "ed-1",
+        tabs: [
+          { id: "ag-1", kind: "agent" },
+          { id: "sh-1", kind: "shell" },
+          { id: "ed-1", kind: "editor" },
+          { id: "sh-2", kind: "shell" },
+          { id: "ag-2", kind: "agent" },
+        ],
+      },
+    });
+    const handled = await handleTabStrip(
+      {
+        component: { id: "header-tabs", type: "tab-strip" },
+        eventType: "reorder",
+        data: { tabId: "ag-2", toIndex: 0 },
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    const next = applySetState();
+    expect((next.tabs as Array<{ id: string }>).map((tab) => tab.id)).toEqual([
+      "ag-2",
+      "sh-1",
+      "ag-1",
+      "sh-2",
+      "ed-1",
+    ]);
+    expect(next.activeTabId).toBe("ed-1");
+  });
+
+  it("reorder ignores shell ids in the top strip route", async () => {
+    const { ctx, applySetState } = buildRouteFixture({
+      state: {
+        tabs: [
+          { id: "ag-1", kind: "agent" },
+          { id: "sh-1", kind: "shell" },
+          { id: "ag-2", kind: "agent" },
+        ],
+      },
+    });
+    await handleTabStrip(
+      {
+        component: { id: "header-tabs", type: "tab-strip" },
+        eventType: "reorder",
+        data: { tabId: "sh-1", toIndex: 0 },
+      },
+      ctx,
+    );
+    const next = applySetState();
+    expect((next.tabs as Array<{ id: string }>).map((tab) => tab.id)).toEqual([
+      "ag-1",
+      "sh-1",
+      "ag-2",
+    ]);
+  });
+
   it("new spawns a fresh tab", async () => {
     const { ctx, mocks } = buildRouteFixture();
     await handleTabStrip(

--- a/src/eventRoutes/tabStrip.ts
+++ b/src/eventRoutes/tabStrip.ts
@@ -1,7 +1,8 @@
 import type { EventRouteHandler, EventRouteContext } from "./types";
-import { OVERVIEW_TAB_ID } from "../types/tab";
+import { OVERVIEW_TAB_ID, type Tab } from "../types/tab";
 import { restoreSessionFromSelection } from "./sessionRestore";
 import { renameSessionLabel } from "./sessionRename";
+import { reorderTabToIndex } from "../utils/tabReorder";
 
 /** Switch the active tab to the overview sentinel. Used both by the
  *  permanent overview pill in the tab strip and by the sidebar
@@ -24,7 +25,13 @@ export const handleTabStrip: EventRouteHandler = (
 ) => {
   if (component.type !== "tab-strip") return false;
   const sel = data as
-    | { tabId?: string; action?: string; id?: string; label?: string }
+    | {
+        tabId?: string;
+        action?: string;
+        id?: string;
+        label?: string;
+        toIndex?: number;
+      }
     | undefined;
   if (eventType === "select" && sel?.tabId) {
     if (sel.tabId === OVERVIEW_TAB_ID) {
@@ -62,6 +69,16 @@ export const handleTabStrip: EventRouteHandler = (
   if (eventType === "rename" && sel?.tabId) {
     const label = typeof sel.label === "string" ? sel.label : "";
     renameSessionLabel(ctx, sel.tabId, label);
+    return true;
+  }
+  if (eventType === "reorder" && sel?.tabId) {
+    const tabId = sel.tabId;
+    const toIndex = typeof sel.toIndex === "number" ? sel.toIndex : NaN;
+    ctx.setState((prev) => {
+      const tabs = (prev.tabs as Tab[] | undefined) ?? [];
+      const reordered = reorderTabToIndex(tabs, "top", tabId, toIndex);
+      return reordered ? { ...prev, tabs: reordered } : prev;
+    });
     return true;
   }
   if (eventType === "new") {

--- a/src/eventRoutes/terminal.test.ts
+++ b/src/eventRoutes/terminal.test.ts
@@ -57,6 +57,65 @@ describe("handleTerminalPanel", () => {
     expect(mocks.newShellTab).toHaveBeenCalledTimes(1);
   });
 
+  it("reorder-sub-tab rearranges only shell tabs and keeps active sub-tab", async () => {
+    const { ctx, applySetState } = buildRouteFixture({
+      state: {
+        terminalPanel: { activeSubId: "sh-2" },
+        tabs: [
+          { id: "ag-1", kind: "agent" },
+          { id: "sh-1", kind: "shell" },
+          { id: "ed-1", kind: "editor" },
+          { id: "sh-2", kind: "shell" },
+          { id: "sh-3", kind: "shell" },
+        ],
+      },
+    });
+    const handled = await handleTerminalPanel(
+      {
+        component: { id: "tp", type: "terminal-panel" },
+        eventType: "reorder-sub-tab",
+        data: { subTabId: "sh-3", toIndex: 0 },
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    const next = applySetState();
+    expect((next.tabs as Array<{ id: string }>).map((tab) => tab.id)).toEqual([
+      "ag-1",
+      "sh-3",
+      "ed-1",
+      "sh-1",
+      "sh-2",
+    ]);
+    expect((next.terminalPanel as { activeSubId?: string }).activeSubId).toBe(
+      "sh-2",
+    );
+  });
+
+  it("reorder-sub-tab ignores the pinned agent-bash tab", async () => {
+    const { ctx, applySetState } = buildRouteFixture({
+      state: {
+        tabs: [
+          { id: "sh-1", kind: "shell" },
+          { id: "sh-2", kind: "shell" },
+        ],
+      },
+    });
+    await handleTerminalPanel(
+      {
+        component: { id: "tp", type: "terminal-panel" },
+        eventType: "reorder-sub-tab",
+        data: { subTabId: "agent-bash", toIndex: 0 },
+      },
+      ctx,
+    );
+    const next = applySetState();
+    expect((next.tabs as Array<{ id: string }>).map((tab) => tab.id)).toEqual([
+      "sh-1",
+      "sh-2",
+    ]);
+  });
+
   it("resize stores the terminal panel height and updates the open row track", async () => {
     const { ctx, applySetState } = buildRouteFixture({
       state: {

--- a/src/eventRoutes/terminal.ts
+++ b/src/eventRoutes/terminal.ts
@@ -2,6 +2,7 @@ import type { EventRouteHandler } from "./types";
 import { cycleShareMode } from "../utils/shareMode";
 import type { Tab } from "../types/tab";
 import { WORKSTATION_AREAS, workstationRows } from "../hooks/useFocus";
+import { reorderTabToIndex } from "../utils/tabReorder";
 
 const TERMINAL_PANEL_MIN_HEIGHT = 120;
 const TERMINAL_PANEL_MAX_HEIGHT = 720;
@@ -23,7 +24,7 @@ export const handleTerminalPanel: EventRouteHandler = (
   ctx,
 ) => {
   if (component.type !== "terminal-panel") return false;
-  const sel = data as { subTabId?: string } | undefined;
+  const sel = data as { subTabId?: string; toIndex?: number } | undefined;
   if (eventType === "select-sub-tab" && sel?.subTabId) {
     ctx.setActiveSubTab(sel.subTabId);
     return true;
@@ -36,6 +37,16 @@ export const handleTerminalPanel: EventRouteHandler = (
   }
   if (eventType === "new-shell-sub-tab") {
     ctx.newShellTab();
+    return true;
+  }
+  if (eventType === "reorder-sub-tab" && sel?.subTabId) {
+    const subTabId = sel.subTabId;
+    const toIndex = typeof sel.toIndex === "number" ? sel.toIndex : NaN;
+    ctx.setState((prev) => {
+      const tabs = (prev.tabs as Tab[] | undefined) ?? [];
+      const reordered = reorderTabToIndex(tabs, "shell", subTabId, toIndex);
+      return reordered ? { ...prev, tabs: reordered } : prev;
+    });
     return true;
   }
   if (eventType === "resize") {

--- a/src/extensions/default-layout/shell/panel.test.tsx
+++ b/src/extensions/default-layout/shell/panel.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { OVERVIEW_TAB_ID } from "../../../types/tab";
 import type { A2UIComponent } from "../../../types/a2ui";
@@ -21,7 +21,10 @@ vi.mock("./canvas", () => ({
 import { TerminalPanel } from "./panel";
 import { resolveActiveSubId, resolveActiveSubIdFromState } from "./panel-helpers";
 
-afterEach(() => cleanup());
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
 
 describe("resolveActiveSubId", () => {
   it("returns the requested shell when it still exists", () => {
@@ -113,6 +116,30 @@ describe("resolveActiveSubIdFromState", () => {
     expect(resolveActiveSubIdFromState(state)).toBe("agent-bash");
   });
 });
+
+function createDataTransfer() {
+  const values = new Map<string, string>();
+  return {
+    effectAllowed: "",
+    dropEffect: "",
+    setData: vi.fn((type: string, value: string) => values.set(type, value)),
+    getData: vi.fn((type: string) => values.get(type) ?? ""),
+  };
+}
+
+function setRect(element: Element, rect: Partial<DOMRect>) {
+  vi.spyOn(element, "getBoundingClientRect").mockReturnValue({
+    left: rect.left ?? 0,
+    top: rect.top ?? 0,
+    right: rect.right ?? 100,
+    bottom: rect.bottom ?? 20,
+    width: rect.width ?? 100,
+    height: rect.height ?? 20,
+    x: rect.left ?? 0,
+    y: rect.top ?? 0,
+    toJSON: () => ({}),
+  });
+}
 
 function panelComponent(): A2UIComponent {
   return {
@@ -228,6 +255,59 @@ describe("TerminalPanel", () => {
     );
     const shell = screen.getByTestId("stub-shell");
     expect(shell.getAttribute("data-tab-id")).toBe("sh-2");
+  });
+
+  it("emits reorder-sub-tab when an interactive shell tab is dragged", () => {
+    const onEvent = vi.fn();
+    render(
+      <TerminalPanel
+        component={panelComponent()}
+        state={{
+          activeTabId: OVERVIEW_TAB_ID,
+          tabs: [
+            { id: "sh-1", kind: "shell", label: "Shell 1" },
+            { id: "sh-2", kind: "shell", label: "Shell 2" },
+          ],
+          terminalPanel: { activeSubId: "sh-1" },
+        }}
+        onEvent={onEvent}
+      />,
+    );
+    const shell1 = screen.getByText("Shell 1").closest('[role="tab"]')!;
+    const shell2 = screen.getByText("Shell 2").closest('[role="tab"]')!;
+    setRect(shell1, { left: 0, width: 100 });
+    const dataTransfer = createDataTransfer();
+
+    fireEvent.dragStart(shell2, { dataTransfer });
+    fireEvent.dragOver(shell1, { clientX: 10, dataTransfer });
+    fireEvent.drop(shell1, { clientX: 10, dataTransfer });
+
+    expect(onEvent).toHaveBeenCalledWith("reorder-sub-tab", {
+      subTabId: "sh-2",
+      toIndex: 0,
+    });
+  });
+
+  it("keeps Agent bash pinned and only shell tabs draggable", () => {
+    render(
+      <TerminalPanel
+        component={panelComponent()}
+        state={{
+          activeTabId: "tab-1",
+          tabs: [
+            { id: "tab-1", kind: "agent", label: "Tab 1" },
+            { id: "sh-1", kind: "shell", label: "Shell 1" },
+          ],
+          terminalPanel: { activeSubId: "agent-bash" },
+        }}
+        onEvent={vi.fn()}
+      />,
+    );
+    const agentBash = screen.getByText("Agent bash").closest('[role="tab"]')!;
+    const shell = screen.getByText("Shell 1").closest('[role="tab"]')!;
+
+    expect(agentBash.getAttribute("draggable")).toBe("false");
+    expect(shell.getAttribute("draggable")).toBe("true");
   });
 
   it("always renders the + new-shell button", () => {

--- a/src/extensions/default-layout/shell/panel.tsx
+++ b/src/extensions/default-layout/shell/panel.tsx
@@ -15,9 +15,12 @@
  * "agent-bash" when an agent session is live, otherwise the first shell.
  * Switching sub-tabs unmounts/remounts the inner xterm so per-sub-tab
  * scrollback isolation is automatic.
+ *
+ * Events:
+ *   ("reorder-sub-tab", { subTabId, toIndex }) drag an interactive shell tab
  */
 
-import { useMemo, useRef } from "react";
+import { useMemo, useRef, useState, type DragEvent } from "react";
 import type {
   BooleanValue,
   NumberValue,
@@ -77,6 +80,8 @@ export function TerminalPanel({
     "agent";
   const requestedActiveId = panelState.activeSubId ?? AGENT_BASH_SUB_ID;
   const panelRef = useRef<HTMLDivElement>(null);
+  const [draggingSubTabId, setDraggingSubTabId] = useState<string | null>(null);
+  const draggedSubTabIdRef = useRef<string | null>(null);
   // Resolve via the shared helper so the focus-aware Cmd+W path in
   // useKeyboardShortcuts sees the same active sub-tab the user does.
   const activeSubId = useMemo<string | null>(
@@ -88,6 +93,49 @@ export function TerminalPanel({
       }),
     [requestedActiveId, shellTabs, showAgentBash],
   );
+
+  const dragPayloadType = "application/x-aethon-shell-sub-tab-id";
+  const startSubTabDrag = (
+    event: DragEvent<HTMLElement>,
+    subTab: ShellSubTabItem,
+  ) => {
+    if ((event.target as HTMLElement).closest(".ae-sub-tab-close")) {
+      event.preventDefault();
+      return;
+    }
+    draggedSubTabIdRef.current = subTab.id;
+    setDraggingSubTabId(subTab.id);
+    event.dataTransfer.effectAllowed = "move";
+    event.dataTransfer.setData(dragPayloadType, subTab.id);
+  };
+
+  const finishSubTabDrag = () => {
+    draggedSubTabIdRef.current = null;
+    setDraggingSubTabId(null);
+  };
+
+  const getDraggedSubTabId = (event: DragEvent<HTMLElement>) =>
+    event.dataTransfer.getData(dragPayloadType) || draggedSubTabIdRef.current;
+
+  const dropSubTabOnTarget = (
+    event: DragEvent<HTMLElement>,
+    target: ShellSubTabItem,
+  ) => {
+    const subTabId = getDraggedSubTabId(event);
+    if (!subTabId || subTabId === target.id) return;
+    event.preventDefault();
+    event.stopPropagation();
+    const remaining = shellTabs.filter((tab) => tab.id !== subTabId);
+    const targetIndex = remaining.findIndex((tab) => tab.id === target.id);
+    if (targetIndex < 0) return;
+    const rect = event.currentTarget.getBoundingClientRect();
+    const after = event.clientX > rect.left + rect.width / 2;
+    onEvent("reorder-sub-tab", {
+      subTabId,
+      toIndex: targetIndex + (after ? 1 : 0),
+    });
+    finishSubTabDrag();
+  };
 
   const onResizeStart = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -150,8 +198,18 @@ export function TerminalPanel({
             hint={s.shellState === "exited" ? "exited" : undefined}
             active={activeSubId === s.id}
             closable
+            dragging={draggingSubTabId === s.id}
             onSelect={() => onEvent("select-sub-tab", { subTabId: s.id })}
             onClose={() => onEvent("close-sub-tab", { subTabId: s.id })}
+            onDragStart={(e) => startSubTabDrag(e, s)}
+            onDragOver={(e) => {
+              const subTabId = draggedSubTabIdRef.current;
+              if (!subTabId || subTabId === s.id) return;
+              e.preventDefault();
+              e.dataTransfer.dropEffect = "move";
+            }}
+            onDrop={(e) => dropSubTabOnTarget(e, s)}
+            onDragEnd={finishSubTabDrag}
           />
         ))}
         <button
@@ -208,20 +266,45 @@ function SubTabPill(props: {
   hint?: string;
   active: boolean;
   closable?: boolean;
+  dragging?: boolean;
   onSelect: () => void;
   onClose?: () => void;
+  onDragStart?: (event: DragEvent<HTMLElement>) => void;
+  onDragOver?: (event: DragEvent<HTMLElement>) => void;
+  onDrop?: (event: DragEvent<HTMLElement>) => void;
+  onDragEnd?: () => void;
 }) {
-  const { label, hint, active, closable, onSelect, onClose } = props;
+  const {
+    label,
+    hint,
+    active,
+    closable,
+    dragging,
+    onSelect,
+    onClose,
+    onDragStart,
+    onDragOver,
+    onDrop,
+    onDragEnd,
+  } = props;
   return (
     <div
       role="tab"
       aria-selected={active}
-      className={
-        active ? "ae-sub-tab ae-sub-tab-active" : "ae-sub-tab"
-      }
+      className={[
+        "ae-sub-tab",
+        active ? "ae-sub-tab-active" : "",
+        dragging ? "ae-sub-tab-dragging" : "",
+      ]
+        .filter(Boolean)
+        .join(" ")}
+      draggable={!!onDragStart}
+      onDragStart={onDragStart}
+      onDragOver={onDragOver}
+      onDrop={onDrop}
+      onDragEnd={onDragEnd}
       onMouseDown={(e) => {
         if ((e.target as HTMLElement).closest(".ae-sub-tab-close")) return;
-        e.preventDefault();
         onSelect();
       }}
     >

--- a/src/extensions/default-layout/shell/panel.tsx
+++ b/src/extensions/default-layout/shell/panel.tsx
@@ -304,7 +304,10 @@ function SubTabPill(props: {
       onDrop={onDrop}
       onDragEnd={onDragEnd}
       onMouseDown={(e) => {
-        if ((e.target as HTMLElement).closest(".ae-sub-tab-close")) return;
+        if ((e.target as HTMLElement).closest(".ae-sub-tab-close")) {
+          e.preventDefault();
+          return;
+        }
         onSelect();
       }}
     >

--- a/src/extensions/default-layout/shell/tab-strip.test.tsx
+++ b/src/extensions/default-layout/shell/tab-strip.test.tsx
@@ -6,7 +6,10 @@ import { TabStrip } from "./tab-strip";
 import type { A2UIComponent } from "../../../types/a2ui";
 import { OVERVIEW_TAB_ID } from "../../../types/tab";
 
-afterEach(() => cleanup());
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
 
 type TabStripOnEvent = ComponentProps<typeof TabStrip>["onEvent"];
 
@@ -19,6 +22,30 @@ function tabStripComponent(): A2UIComponent {
       activeId: { $ref: "/activeTabId" },
     },
   };
+}
+
+function createDataTransfer() {
+  const values = new Map<string, string>();
+  return {
+    effectAllowed: "",
+    dropEffect: "",
+    setData: vi.fn((type: string, value: string) => values.set(type, value)),
+    getData: vi.fn((type: string) => values.get(type) ?? ""),
+  };
+}
+
+function setRect(element: Element, rect: Partial<DOMRect>) {
+  vi.spyOn(element, "getBoundingClientRect").mockReturnValue({
+    left: rect.left ?? 0,
+    top: rect.top ?? 0,
+    right: rect.right ?? 100,
+    bottom: rect.bottom ?? 20,
+    width: rect.width ?? 100,
+    height: rect.height ?? 20,
+    x: rect.left ?? 0,
+    y: rect.top ?? 0,
+    toJSON: () => ({}),
+  });
 }
 
 function renderTabStrip(onEvent = vi.fn<TabStripOnEvent>()) {
@@ -270,6 +297,55 @@ describe("TabStrip", () => {
     ).toBeTruthy();
     fireEvent.click(screen.getByRole("menuitem", { name: "Close Others" }));
     expect(onEvent).toHaveBeenCalledWith("close-others", { tabId: "ed-1" });
+  });
+
+  it("emits a reorder event when a top tab is dragged before another tab", () => {
+    const onEvent = vi.fn<TabStripOnEvent>();
+    render(
+      <TabStrip
+        component={tabStripComponent()}
+        state={{
+          activeTabId: "ag-1",
+          tabs: [
+            { id: "ag-1", label: "Chat", kind: "agent" },
+            { id: "sh-1", label: "Shell", kind: "shell" },
+            {
+              id: "ed-1",
+              label: "App.tsx",
+              kind: "editor",
+              editor: { filePath: "/repo/App.tsx" },
+            },
+          ],
+        }}
+        onEvent={onEvent}
+      />,
+    );
+    const chat = screen.getByText("Chat").closest('[role="tab"]')!;
+    const editor = screen.getByText("App.tsx").closest('[role="tab"]')!;
+    setRect(chat, { left: 0, width: 100 });
+    const dataTransfer = createDataTransfer();
+
+    fireEvent.dragStart(editor, { dataTransfer });
+    fireEvent.dragOver(chat, { clientX: 10, dataTransfer });
+    fireEvent.drop(chat, { clientX: 10, dataTransfer });
+
+    expect(onEvent).toHaveBeenCalledWith("reorder", {
+      tabId: "ed-1",
+      toIndex: 0,
+    });
+  });
+
+  it("keeps the overview and new-tab controls out of drag reordering", () => {
+    renderTabStrip();
+    const overviewPill = screen
+      .getAllByRole("tab")
+      .find((el) => el.textContent?.includes("overview"))!;
+    const realTab = screen.getByText("Tab 1").closest('[role="tab"]')!;
+    const newButton = screen.getByRole("button", { name: "New Tab" });
+
+    expect(realTab.getAttribute("draggable")).toBe("true");
+    expect(overviewPill.getAttribute("draggable")).not.toBe("true");
+    expect(newButton.getAttribute("draggable")).not.toBe("true");
   });
 
   it("renders a file-type icon for editor tabs but not agent tabs", () => {

--- a/src/extensions/default-layout/shell/tab-strip.tsx
+++ b/src/extensions/default-layout/shell/tab-strip.tsx
@@ -16,6 +16,7 @@
  *   ("select",  { tabId })  click on a tab pill (overview emits its sentinel id)
  *   ("close",   { tabId })  click on a tab's close button
  *   ("new")                 click on the "+" button
+ *   ("reorder", { tabId, toIndex }) drag a visible top-strip tab
  */
 
 import {
@@ -23,6 +24,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type DragEvent,
   type KeyboardEvent,
   type MouseEvent,
 } from "react";
@@ -90,6 +92,8 @@ export function TabStrip({ component, state, onEvent }: BuiltinComponentProps) {
     id: string;
     value: string;
   } | null>(null);
+  const [draggingTabId, setDraggingTabId] = useState<string | null>(null);
+  const draggedTabIdRef = useRef<string | null>(null);
   const renameInputRef = useRef<HTMLInputElement | null>(null);
   const renameEndingRef = useRef(false);
   const renamingTabId = renamingTab?.id;
@@ -150,6 +154,51 @@ export function TabStrip({ component, state, onEvent }: BuiltinComponentProps) {
 
   const projectPath =
     (state["project"] as { path?: string } | undefined)?.path ?? "";
+
+  const dragPayloadType = "application/x-aethon-tab-id";
+  const startTabDrag = (event: DragEvent<HTMLElement>, tab: TabStripItem) => {
+    const target = event.target as HTMLElement;
+    if (
+      renamingTab?.id === tab.id ||
+      target.closest(".a2ui-tab-close") ||
+      target.closest(".ae-tab-rename-input")
+    ) {
+      event.preventDefault();
+      return;
+    }
+    draggedTabIdRef.current = tab.id;
+    setDraggingTabId(tab.id);
+    event.dataTransfer.effectAllowed = "move";
+    event.dataTransfer.setData(dragPayloadType, tab.id);
+  };
+
+  const finishTabDrag = () => {
+    draggedTabIdRef.current = null;
+    setDraggingTabId(null);
+  };
+
+  const getDraggedTabId = (event: DragEvent<HTMLElement>) =>
+    event.dataTransfer.getData(dragPayloadType) || draggedTabIdRef.current;
+
+  const dropTabOnTarget = (
+    event: DragEvent<HTMLElement>,
+    target: TabStripItem,
+  ) => {
+    const tabId = getDraggedTabId(event);
+    if (!tabId || tabId === target.id) return;
+    event.preventDefault();
+    event.stopPropagation();
+    const remaining = tabs.filter((tab) => tab.id !== tabId);
+    const targetIndex = remaining.findIndex((tab) => tab.id === target.id);
+    if (targetIndex < 0) return;
+    const rect = event.currentTarget.getBoundingClientRect();
+    const after = event.clientX > rect.left + rect.width / 2;
+    onEvent("reorder", {
+      tabId,
+      toIndex: targetIndex + (after ? 1 : 0),
+    });
+    finishTabDrag();
+  };
 
   const buildMenuItems = (): ContextMenuItem[] => {
     if (!contextMenu) return [];
@@ -288,16 +337,31 @@ export function TabStrip({ component, state, onEvent }: BuiltinComponentProps) {
             key={t.id}
             role="tab"
             aria-selected={isActive}
-            className={isActive ? "a2ui-tab a2ui-tab-active" : "a2ui-tab"}
+            className={[
+              "a2ui-tab",
+              isActive ? "a2ui-tab-active" : "",
+              draggingTabId === t.id ? "a2ui-tab-dragging" : "",
+            ]
+              .filter(Boolean)
+              .join(" ")}
+            draggable={renamingTab?.id !== t.id}
+            onDragStart={(e) => startTabDrag(e, t)}
+            onDragOver={(e) => {
+              const tabId = draggedTabIdRef.current;
+              if (!tabId || tabId === t.id) return;
+              e.preventDefault();
+              e.dataTransfer.dropEffect = "move";
+            }}
+            onDrop={(e) => dropTabOnTarget(e, t)}
+            onDragEnd={finishTabDrag}
             onMouseDown={(e) => {
-              // mousedown not click so focus doesn't shift away from the
-              // chat input first (avoids a stray blur that could submit
-              // a draft). The select handler swaps the active tab.
+              // mousedown not click so selecting feels immediate, but do
+              // not preventDefault here: native draggable tabs need the
+              // browser's default mouse gesture to fire dragstart.
               if (e.button !== 0) return;
               if ((e.target as HTMLElement).closest(".a2ui-tab-close")) return;
               if ((e.target as HTMLElement).closest(".ae-tab-rename-input"))
                 return;
-              e.preventDefault();
               onEvent("select", { tabId: t.id });
             }}
             onContextMenu={(e) => openTabMenu(e, t)}

--- a/src/extensions/default-layout/shell/tab-strip.tsx
+++ b/src/extensions/default-layout/shell/tab-strip.tsx
@@ -359,9 +359,13 @@ export function TabStrip({ component, state, onEvent }: BuiltinComponentProps) {
               // not preventDefault here: native draggable tabs need the
               // browser's default mouse gesture to fire dragstart.
               if (e.button !== 0) return;
-              if ((e.target as HTMLElement).closest(".a2ui-tab-close")) return;
-              if ((e.target as HTMLElement).closest(".ae-tab-rename-input"))
+              if (
+                (e.target as HTMLElement).closest(".a2ui-tab-close") ||
+                (e.target as HTMLElement).closest(".ae-tab-rename-input")
+              ) {
+                e.preventDefault();
                 return;
+              }
               onEvent("select", { tabId: t.id });
             }}
             onContextMenu={(e) => openTabMenu(e, t)}

--- a/src/hooks/useTabNavigation.test.ts
+++ b/src/hooks/useTabNavigation.test.ts
@@ -20,7 +20,7 @@ function setup(fx: Fixture) {
   const { result } = renderHook(() =>
     useTabNavigation({ stateRef, setState, setActiveTab, setActiveSubTab }),
   );
-  return { stateRef, setActiveTab, actions: result.current };
+  return { stateRef, setState, setActiveTab, actions: result.current };
 }
 
 describe("nextTab includes editor tabs", () => {
@@ -102,6 +102,32 @@ describe("nextTab includes editor tabs", () => {
     });
     actions.nextTab(-1);
     expect(setActiveTab).toHaveBeenLastCalledWith("editor-1");
+  });
+});
+
+describe("moveActiveTab", () => {
+  it("reorders top-strip tabs without moving shell slots", () => {
+    const agentA = makeEmptyTab("agent-a", "Agent A", null, "agent");
+    const shell = makeEmptyTab("shell-1", "Shell", null, "shell");
+    const editor = makeEmptyTab("editor-1", "App.tsx", null, "editor");
+    const agentB = makeEmptyTab("agent-b", "Agent B", null, "agent");
+    const { actions, setState } = setup({
+      tabs: [agentA, shell, editor, agentB],
+      activeTabId: "agent-b",
+    });
+
+    actions.moveActiveTab(-1);
+
+    const reducer = setState.mock.calls[0][0] as (state: {
+      tabs: Tab[];
+    }) => { tabs: Tab[] };
+    const next = reducer({ tabs: [agentA, shell, editor, agentB] });
+    expect(next.tabs.map((t) => t.id)).toEqual([
+      "agent-a",
+      "shell-1",
+      "agent-b",
+      "editor-1",
+    ]);
   });
 });
 

--- a/src/hooks/useTabNavigation.test.ts
+++ b/src/hooks/useTabNavigation.test.ts
@@ -8,10 +8,17 @@ import { makeEmptyTab, OVERVIEW_TAB_ID, type Tab } from "../types/tab";
 interface Fixture {
   tabs: Tab[];
   activeTabId: string;
+  activeSubId?: string;
 }
 
 function setup(fx: Fixture) {
-  const stateRef = { current: { tabs: fx.tabs, activeTabId: fx.activeTabId } };
+  const stateRef = {
+    current: {
+      tabs: fx.tabs,
+      activeTabId: fx.activeTabId,
+      terminalPanel: fx.activeSubId ? { activeSubId: fx.activeSubId } : {},
+    },
+  };
   const setState = vi.fn();
   const setActiveTab = vi.fn((id: string) => {
     stateRef.current.activeTabId = id;
@@ -128,6 +135,40 @@ describe("moveActiveTab", () => {
       "agent-b",
       "editor-1",
     ]);
+  });
+});
+
+describe("moveActiveShellSubTab", () => {
+  it("reorders shell sub-tabs without moving agent/editor slots", () => {
+    const agent = makeEmptyTab("agent-1", "Agent", null, "agent");
+    const shellA = makeEmptyTab("shell-a", "Shell A", null, "shell");
+    const editor = makeEmptyTab("editor-1", "App.tsx", null, "editor");
+    const shellB = makeEmptyTab("shell-b", "Shell B", null, "shell");
+    const shellC = makeEmptyTab("shell-c", "Shell C", null, "shell");
+    const { actions, setState } = setup({
+      tabs: [agent, shellA, editor, shellB, shellC],
+      activeTabId: "agent-1",
+      activeSubId: "shell-c",
+    });
+
+    actions.moveActiveShellSubTab(-1);
+
+    const reducer = setState.mock.calls[0][0] as (state: {
+      tabs: Tab[];
+      terminalPanel: { activeSubId?: string };
+    }) => { tabs: Tab[]; terminalPanel: { activeSubId?: string } };
+    const next = reducer({
+      tabs: [agent, shellA, editor, shellB, shellC],
+      terminalPanel: { activeSubId: "shell-c" },
+    });
+    expect(next.tabs.map((t) => t.id)).toEqual([
+      "agent-1",
+      "shell-a",
+      "editor-1",
+      "shell-c",
+      "shell-b",
+    ]);
+    expect(next.terminalPanel.activeSubId).toBe("shell-c");
   });
 });
 

--- a/src/hooks/useTabNavigation.ts
+++ b/src/hooks/useTabNavigation.ts
@@ -1,5 +1,6 @@
 import { useCallback, type Dispatch, type MutableRefObject, type SetStateAction } from "react";
 import { OVERVIEW_TAB_ID, type Tab } from "../types/tab";
+import { reorderTabByDirection } from "../utils/tabReorder";
 
 export interface UseTabNavigationContext {
   stateRef: MutableRefObject<Record<string, unknown>>;
@@ -24,7 +25,7 @@ export interface UseTabNavigationActions {
    *  agent and editor tabs in left-to-right order. Out-of-range is
    *  silent (Cmd+5 with only 3 top-strip tabs is a no-op). */
   jumpToTab: (idx: number) => void;
-  /** Reorder the active tab one slot left (-1) or right (+1). Wraps. */
+  /** Reorder the active top-strip tab one slot left (-1) or right (+1). Wraps. */
   moveActiveTab: (direction: 1 | -1) => void;
   /** Cycle the active sub-tab in the bottom panel. Order is
    *  agent-bash first, then shells in /tabs order. Wraps. */
@@ -32,7 +33,7 @@ export interface UseTabNavigationActions {
   /** Idx 0 selects agent-bash; idx 1+ selects the corresponding shell
    *  sub-tab. Out-of-range is silent. */
   jumpToShellSubTab: (idx: number) => void;
-  /** Reorder the active shell sub-tab within /tabs (agent-bash is
+  /** Reorder the active shell sub-tab within the shell surface (agent-bash is
    *  pinned first; trying to move it is a no-op). */
   moveActiveShellSubTab: (direction: 1 | -1) => void;
 }
@@ -123,22 +124,14 @@ export function useTabNavigation(
         | undefined)?.activeSubId;
       if (!activeSub || activeSub === "agent-bash") return;
       setState((prev) => {
-        const tabs = ((prev.tabs as Tab[] | undefined) ?? []).slice();
-        const shellPositions = tabs
-          .map((t, i) => (t.kind === "shell" ? i : -1))
-          .filter((i) => i >= 0);
-        if (shellPositions.length <= 1) return prev;
-        const idx = tabs.findIndex((t) => t.id === activeSub);
-        if (idx < 0) return prev;
-        const subPos = shellPositions.indexOf(idx);
-        if (subPos < 0) return prev;
-        const swapSubPos =
-          (subPos + direction + shellPositions.length) % shellPositions.length;
-        const swapIdx = shellPositions[swapSubPos];
-        const tmp = tabs[idx];
-        tabs[idx] = tabs[swapIdx];
-        tabs[swapIdx] = tmp;
-        return { ...prev, tabs };
+        const tabs = (prev.tabs as Tab[] | undefined) ?? [];
+        const reordered = reorderTabByDirection(
+          tabs,
+          "shell",
+          activeSub,
+          direction,
+        );
+        return reordered ? { ...prev, tabs: reordered } : prev;
       });
     },
     [stateRef, setState],
@@ -149,14 +142,14 @@ export function useTabNavigation(
       const activeId = stateRef.current.activeTabId as string | undefined;
       if (!activeId) return;
       setState((prev) => {
-        const tabs = ((prev.tabs as Tab[] | undefined) ?? []).slice();
-        if (tabs.length <= 1) return prev;
-        const idx = tabs.findIndex((t) => t.id === activeId);
-        if (idx < 0) return prev;
-        const nextIdx = (idx + direction + tabs.length) % tabs.length;
-        const [moved] = tabs.splice(idx, 1);
-        tabs.splice(nextIdx, 0, moved);
-        return { ...prev, tabs };
+        const tabs = (prev.tabs as Tab[] | undefined) ?? [];
+        const reordered = reorderTabByDirection(
+          tabs,
+          "top",
+          activeId,
+          direction,
+        );
+        return reordered ? { ...prev, tabs: reordered } : prev;
       });
     },
     [stateRef, setState],

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -4454,7 +4454,7 @@ body.ae-resizing-composer * {
   border-radius: 0;
   color: var(--text-dim);
   font-size: var(--chrome-text);
-  cursor: pointer;
+  cursor: grab;
   user-select: none;
   white-space: nowrap;
   position: relative;
@@ -4491,6 +4491,14 @@ body.ae-resizing-composer * {
 .a2ui-tab:hover {
   color: var(--text);
   background: var(--bg-hover, var(--accent-hover-tint));
+}
+
+.a2ui-tab:active {
+  cursor: grabbing;
+}
+
+.a2ui-tab-dragging {
+  opacity: 0.62;
 }
 
 .a2ui-tab-active {
@@ -4662,6 +4670,7 @@ body.ae-resizing-composer * {
    navigation, not a session, and carries the Æ brand glyph instead of a
    close button (it can't be closed). */
 .a2ui-tab-overview {
+  cursor: pointer;
   min-inline-size: 6.5rem;
   max-inline-size: 8rem;
   flex: 0 0 7rem;
@@ -5230,13 +5239,22 @@ body.ae-resizing-terminal * {
   border: 1px solid transparent;
   border-bottom: none;
   border-radius: 6px 6px 0 0;
-  cursor: pointer;
+  cursor: grab;
   white-space: nowrap;
   user-select: none;
   margin-top: 2px;
 }
 .ae-sub-tab:hover {
   background: color-mix(in oklab, var(--accent) 8%, transparent);
+}
+.ae-sub-tab:active {
+  cursor: grabbing;
+}
+.ae-sub-tab[draggable="false"] {
+  cursor: pointer;
+}
+.ae-sub-tab-dragging {
+  opacity: 0.62;
 }
 .ae-sub-tab-active {
   background: var(--bg-elev);

--- a/src/utils/tabReorder.ts
+++ b/src/utils/tabReorder.ts
@@ -1,0 +1,82 @@
+import type { TabKind } from "../types/tab";
+
+export type TabReorderItem = { id: string; kind?: TabKind };
+
+export type TabReorderGroup = "top" | "shell";
+
+function isInGroup(tab: TabReorderItem, group: TabReorderGroup): boolean {
+  const kind = tab.kind ?? "agent";
+  return group === "shell" ? kind === "shell" : kind !== "shell";
+}
+
+function reorderWithinGroup<T extends TabReorderItem>(
+  tabs: readonly T[],
+  group: TabReorderGroup,
+  reorderMatching: (items: T[]) => T[] | null,
+): T[] | null {
+  const groupItems = tabs.filter((tab) => isInGroup(tab, group));
+  if (groupItems.length <= 1) return null;
+
+  const reordered = reorderMatching(groupItems.slice());
+  if (!reordered) return null;
+
+  const changed = reordered.some(
+    (tab, index) => tab.id !== groupItems[index]?.id,
+  );
+  if (!changed) return null;
+
+  let groupIndex = 0;
+  return tabs.map((tab) =>
+    isInGroup(tab, group) ? reordered[groupIndex++] : tab,
+  );
+}
+
+/**
+ * Reorder a tab within one logical tab surface while preserving every
+ * other surface's slots. Top-strip reorders only non-shell tabs; terminal
+ * reorders only shell tabs. `toIndex` is the destination index in the
+ * matching group after the dragged tab has been removed.
+ */
+export function reorderTabToIndex<T extends TabReorderItem>(
+  tabs: readonly T[],
+  group: TabReorderGroup,
+  tabId: string,
+  toIndex: number,
+): T[] | null {
+  if (!tabId || !Number.isFinite(toIndex)) return null;
+  return reorderWithinGroup(tabs, group, (items) => {
+    const fromIndex = items.findIndex((tab) => tab.id === tabId);
+    if (fromIndex < 0) return null;
+    const [moved] = items.splice(fromIndex, 1);
+    const targetIndex = Math.max(
+      0,
+      Math.min(items.length, Math.trunc(toIndex)),
+    );
+    items.splice(targetIndex, 0, moved);
+    return items;
+  });
+}
+
+/** Move a tab one slot within a logical surface, wrapping at the ends. */
+export function reorderTabByDirection<T extends TabReorderItem>(
+  tabs: readonly T[],
+  group: TabReorderGroup,
+  tabId: string,
+  direction: 1 | -1,
+): T[] | null {
+  if (!tabId) return null;
+  return reorderWithinGroup(tabs, group, (items) => {
+    const fromIndex = items.findIndex((tab) => tab.id === tabId);
+    if (fromIndex < 0) return null;
+    const destination = (fromIndex + direction + items.length) % items.length;
+    const [moved] = items.splice(fromIndex, 1);
+    const toIndex =
+      direction === 1 && destination === 0
+        ? 0
+        : direction === -1 && destination === items.length
+          ? items.length
+          : destination;
+    items.splice(toIndex, 0, moved);
+    return items;
+  });
+}


### PR DESCRIPTION
## Summary
- add drag/drop reorder events for top session/editor tabs and terminal shell sub-tabs
- route reorder events through shared tab-order helpers that preserve shell vs non-shell ordering boundaries
- keep overview, Agent bash, and new-tab buttons pinned/non-draggable
- update keyboard reorder paths to use the same helper logic

Fixes #207

## Validation
- bun run lint
- bun run typecheck
- bun run test
- codex review --uncommitted (initial review finding addressed; final review found no discrete correctness issues)