### PR TITLE
fix(agent): keep sidebar activity running for live tool cards

### DIFF
--- a/src/hooks/useChat.test.ts
+++ b/src/hooks/useChat.test.ts
@@ -377,6 +377,47 @@ describe("useChat setModel", () => {
     expect(tab.messages.some((m) => m.text === "after this")).toBe(false);
   });
 
+  it("holds normal messages in the client queue while a tool-card is still running", async () => {
+    const runningTool = {
+      id: "tool-message",
+      role: "agent" as const,
+      a2ui: {
+        components: [
+          {
+            id: "tool-1",
+            type: "tool-card",
+            props: { title: "bash", startedAt: 1_000 },
+          },
+        ],
+      },
+    };
+    const { ctx, stateRef } = buildContext({
+      waiting: false,
+      tabs: [
+        {
+          ...makeEmptyTab("tab-1", "Tab 1"),
+          waiting: false,
+          messages: [runningTool],
+        },
+      ],
+    });
+    const { result } = renderHook(() => useChat(ctx));
+
+    await act(async () => {
+      await result.current.sendChat("after this");
+    });
+
+    expect(invoke).not.toHaveBeenCalledWith(
+      "send_message",
+      expect.objectContaining({
+        request: expect.objectContaining({ message: "after this" }),
+      }),
+    );
+    const tab = (stateRef.current.tabs as Tab[])[0];
+    expect(tab.queuedMessages.map((m) => m.content)).toEqual(["after this"]);
+    expect(tab.messages.some((m) => m.text === "after this")).toBe(false);
+  });
+
   it("holds attachments with queued normal messages while the prompt is busy", async () => {
     const attachment = {
       id: "img-queued",

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -22,6 +22,7 @@ import {
   hydrateAgentActivityState,
   type AgentDiagnosticRow,
 } from "./useAgentActivityHydration";
+import { isAgentTabInFlight } from "../utils/agentBusy";
 
 const STOP_CONFIRM_DELAYS_MS = [0, 150, 500, 1000, 2000] as const;
 
@@ -492,7 +493,7 @@ export function useChat(ctx: UseChatContext): UseChatActions {
       (tab) => tab.id === tabId,
     );
     const wasBusy =
-      targetTab?.waiting === true ||
+      isAgentTabInFlight(targetTab) ||
       ((targetTab === undefined || tabId === activeTabId) &&
         stateRef.current.waiting === true);
 
@@ -674,7 +675,10 @@ export function useChat(ctx: UseChatContext): UseChatActions {
     const previousTabModel = activeTab?.model ?? "";
     // Only mirror onto a live session when an agent tab is focused and not
     // mid-turn (the bridge rejects a switch while a prompt is in flight).
-    const canMirror = hasActiveAgentTab && stateRef.current.waiting !== true;
+    const canMirror =
+      hasActiveAgentTab &&
+      stateRef.current.waiting !== true &&
+      !isAgentTabInFlight(activeTab);
 
     recordProjectModel(trimmed, activeId);
     setState((prev) => ({

--- a/src/hooks/useDerivedRenderState.test.ts
+++ b/src/hooks/useDerivedRenderState.test.ts
@@ -274,10 +274,10 @@ describe("useDerivedRenderState", () => {
     expect(wtMain && "agent" in wtMain).toBe(false);
   });
 
-  it("reconciles the running set against active tabs' waiting flag", () => {
+  it("reconciles the running set against active tabs' in-flight state", () => {
     // Stale running entry for an ACTIVE tab whose turn already ended (crash /
     // error cleared `waiting` but not the running set) must read as idle, not
-    // running — the active tab's `waiting` is authoritative.
+    // running — the active tab's in-flight state is authoritative.
     const idleActive = {
       ...makeEmptyTab("m", "m", "p1", "agent"),
       cwd: "/repo/app",
@@ -308,5 +308,54 @@ describe("useDerivedRenderState", () => {
       }
     ).projects;
     expect(projects[0].agent.status).toBe("idle-with-session");
+  });
+
+  it("keeps sidebar activity running while a visible tool-card is still live", () => {
+    const activeWithRunningTool = {
+      ...makeEmptyTab("m", "m", "p1", "agent"),
+      cwd: "/repo/app",
+      waiting: false,
+      messages: [
+        {
+          id: "tool-message",
+          role: "agent" as const,
+          a2ui: {
+            components: [
+              {
+                id: "tool-1",
+                type: "tool-card",
+                props: { title: "bash", startedAt: 1_000 },
+              },
+            ],
+          },
+        },
+      ],
+    };
+    const { result } = renderHook(() =>
+      useDerivedRenderState({
+        state: {
+          tabs: [activeWithRunningTool],
+          activeTabId: "m",
+          agentRunningTabs: { m: true },
+          sidebar: {
+            projects: [
+              {
+                id: "p1",
+                worktrees: [{ id: "wt-main", path: "/repo/app", isMain: true }],
+              },
+            ],
+          },
+        },
+        buildSidebarHistory: vi.fn(() => []),
+        hostInfo,
+      }),
+    );
+    const projects = (
+      result.current.renderState.sidebar as {
+        projects: { agent: { status: string }; agentRollup: { status: string } }[];
+      }
+    ).projects;
+    expect(projects[0].agent.status).toBe("running");
+    expect(projects[0].agentRollup.status).toBe("running");
   });
 });

--- a/src/hooks/useDerivedRenderState.ts
+++ b/src/hooks/useDerivedRenderState.ts
@@ -6,6 +6,7 @@ import {
 } from "../types/tab";
 import type { UseHostInfo } from "./useHostInfo";
 import { attachAgentActivity } from "./projectOps/agentActivity";
+import { isAgentTabInFlight } from "../utils/agentBusy";
 
 interface RecentSessionItem {
   id: string;
@@ -164,16 +165,15 @@ export function useDerivedRenderState({
         (state.agentRunningTabs as Record<string, unknown> | undefined) ?? {},
       ),
     );
-    // The active workspace's tabs carry an authoritative `waiting` flag —
-    // EVERY turn-end path clears it (response_end, error, legacy response,
-    // native slash, agent crash, agent reload), whereas the bucket-independent
-    // running set is only cleared on response_end + crash/reload. Reconcile
-    // against `waiting` here so a crashed/errored ACTIVE tab can't leave its
-    // dot stuck "running". Backgrounded tabs (frozen `waiting`) keep relying
-    // on the running set.
+    // The active workspace's tabs carry the freshest liveness signals:
+    // `waiting` plus any visible running tool-card. Reconcile active tabs
+    // here so stale running-set entries do not keep ended/crashed turns orange,
+    // while a waiting drift cannot hide a command that is still visibly live.
+    // Backgrounded tabs (frozen `waiting` and messages) keep relying on the
+    // bucket-independent running set.
     for (const t of tabs) {
       if (t.kind !== "agent") continue;
-      if (t.waiting) runningIds.add(t.id);
+      if (isAgentTabInFlight(t)) runningIds.add(t.id);
       else runningIds.delete(t.id);
     }
     const sidebarProjectsWithAgent = Array.isArray(sidebar.projects)

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -7,6 +7,7 @@ import {
   resolveActiveSubIdFromState,
 } from "../extensions/default-layout/shell/panel-helpers";
 import type { Tab } from "../types/tab";
+import { isAgentTabBusy } from "../utils/agentBusy";
 
 interface NotificationInput {
   id: string;
@@ -23,16 +24,7 @@ function activeAgentTabIsBusy(state: Record<string, unknown>): boolean {
   if (!activeTab) return false;
   if ((activeTab.kind ?? "agent") !== "agent") return false;
   return (
-    activeTab?.waiting === true ||
-    (activeTab?.queueCount ?? 0) > 0 ||
-    (activeTab.messages ?? []).some((message) =>
-      (message.a2ui?.components ?? []).some(
-        (component) =>
-          component.type === "tool-card" &&
-          component.props?.startedAt !== undefined &&
-          component.props.endedAt === undefined,
-      ),
-    ) ||
+    isAgentTabBusy(activeTab, { includeQueue: true }) ||
     state.waiting === true ||
     ((state.queueCount as number | undefined) ?? 0) > 0
   );

--- a/src/hooks/useQueuedDispatch.test.ts
+++ b/src/hooks/useQueuedDispatch.test.ts
@@ -80,6 +80,35 @@ describe("useQueuedDispatch", () => {
     expect(updateTab).not.toHaveBeenCalled();
   });
 
+  it("does nothing while a tool-card is still running after waiting drifted false", () => {
+    const sendChat = vi.fn(() => Promise.resolve());
+    const updateTab = vi.fn();
+    const busy = tabWithQueue(
+      {
+        waiting: false,
+        messages: [
+          {
+            id: "tool-message",
+            role: "agent",
+            a2ui: {
+              components: [
+                {
+                  id: "tool-1",
+                  type: "tool-card",
+                  props: { title: "bash", startedAt: 1_000 },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      { id: "q1", content: "wait" },
+    );
+    renderHook(() => useQueuedDispatch({ tabs: [busy], sendChat, updateTab }));
+    expect(sendChat).not.toHaveBeenCalled();
+    expect(updateTab).not.toHaveBeenCalled();
+  });
+
   it("does nothing while a queued steer is in flight", () => {
     const sendChat = vi.fn(() => Promise.resolve());
     const updateTab = vi.fn();

--- a/src/hooks/useQueuedDispatch.ts
+++ b/src/hooks/useQueuedDispatch.ts
@@ -1,11 +1,12 @@
 import { useEffect, useRef } from "react";
 import type { ChatAttachment } from "../types/a2ui";
 import type { Tab } from "../types/tab";
+import { isAgentTabInFlight } from "../utils/agentBusy";
 
 /**
- * Drains client-held queues. Watches every agent tab's `waiting` flag;
- * when it transitions to false and the tab still has queued messages,
- * the head pops and ships through `sendChat(..., { mode: "normal" })`.
+ * Drains client-held queues. Watches every agent tab's in-flight state;
+ * when it transitions to idle and the tab still has queued messages, the
+ * head pops and ships through `sendChat(..., { mode: "normal" })`.
  *
  * Coupling notes:
  *
@@ -51,7 +52,7 @@ export function useQueuedDispatch({
   useEffect(() => {
     for (const tab of tabs) {
       if (tab.kind !== "agent") continue;
-      if (tab.waiting) continue;
+      if (isAgentTabInFlight(tab)) continue;
       // Defensive: persisted tabs created before this feature don't have
       // queuedMessages on disk. The sessionUiSnapshot loader now seeds
       // [], but a tab created by the bridge / a hand-crafted state

--- a/src/utils/agentBusy.ts
+++ b/src/utils/agentBusy.ts
@@ -1,0 +1,57 @@
+import type { A2UIComponent, ChatMessage } from "../types/a2ui";
+import type { Tab } from "../types/tab";
+
+function componentHasRunningToolCard(
+  component: A2UIComponent | undefined,
+): boolean {
+  if (!component) return false;
+  if (
+    component.type === "tool-card" &&
+    component.props?.startedAt !== undefined &&
+    component.props.endedAt === undefined
+  ) {
+    return true;
+  }
+  return (component.children ?? []).some(componentHasRunningToolCard);
+}
+
+/** True when the transcript still contains a visible tool card that has
+ *  started but has not received its terminal update. This catches the edge
+ *  case where `waiting` drifted false while the UI still shows a live tool. */
+export function hasRunningToolCard(
+  messages: readonly ChatMessage[] | undefined,
+): boolean {
+  return (messages ?? []).some((message) =>
+    (message.a2ui?.components ?? []).some(componentHasRunningToolCard),
+  );
+}
+
+/** A turn is actively in flight for an agent tab. Queue state is intentionally
+ *  excluded: queued messages are pending client work, not an active command. */
+export function isAgentTabInFlight(
+  tab:
+    | Pick<Tab, "kind" | "waiting" | "messages">
+    | undefined,
+): boolean {
+  if (!tab) return false;
+  if ((tab.kind ?? "agent") !== "agent") return false;
+  return tab.waiting === true || hasRunningToolCard(tab.messages);
+}
+
+/** UI-level busy predicate. Used by controls that should also react to queued
+ *  messages (for example Escape/Stop), while in-flight-only callers can use
+ *  `isAgentTabInFlight` directly. */
+export function isAgentTabBusy(
+  tab:
+    | Pick<
+        Tab,
+        "kind" | "waiting" | "messages" | "queueCount" | "queuedMessages"
+      >
+    | undefined,
+  options: { includeQueue?: boolean } = {},
+): boolean {
+  if (!tab) return false;
+  if (isAgentTabInFlight(tab)) return true;
+  if (options.includeQueue !== true) return false;
+  return (tab.queueCount ?? tab.queuedMessages?.length ?? 0) > 0;
+}


### PR DESCRIPTION
## Summary

Fixes #223.

Sidebar project/worktree activity could show an idle green dot while the active chat still displayed a running tool card, such as a long-running `bash` command. The active-tab reconciliation in `useDerivedRenderState` treated `tab.waiting === false` as authoritative and deleted the tab from `agentRunningTabs`, even when the transcript still contained a live `tool-card`.

This PR centralizes the frontend busy/in-flight predicate and applies it to the surfaces that need to agree about agent liveness.

## What changed

- Added `src/utils/agentBusy.ts` with shared helpers:
  - `hasRunningToolCard(messages)`
  - `isAgentTabInFlight(tab)` for active-turn liveness (`waiting` or live tool-card)
  - `isAgentTabBusy(tab, { includeQueue })` for UI controls that also care about queued client work
- Updated sidebar activity derivation in `useDerivedRenderState` so active tabs remain `running` when a visible tool-card has `startedAt` and no `endedAt`, even if `waiting` drifted false.
- Reused the shared helper in `useKeyboardShortcuts` for the stop shortcut busy check.
- Updated `useChat.sendChat()` so normal sends queue instead of bypassing while a visible tool-card is still running.
- Updated `useQueuedDispatch` so queued messages do not drain until the live tool-card has ended.
- Kept stale-running cleanup behavior: if an active tab has no `waiting` state and no live tool-card, stale `agentRunningTabs` entries are still reconciled back to idle.

## Regression coverage

Added/updated tests for:

- `useDerivedRenderState`: active tab with `waiting: false`, `agentRunningTabs`, and a live `tool-card` reports sidebar project/rollup `running`.
- `useChat`: normal sends are held in the client queue while a tool-card is still running after `waiting` drifted false.
- `useQueuedDispatch`: queued prompts do not drain while a tool-card remains live despite `waiting: false`.

## Validation

- `bunx vitest run src/hooks/useDerivedRenderState.test.ts src/hooks/useChat.test.ts src/hooks/useQueuedDispatch.test.ts src/hooks/useKeyboardShortcuts.test.tsx`
- `bunx tsc -b --noEmit`
- targeted `bunx eslint ...`
- `bunx vitest run`
- Codex peer review: no actionable correctness issues found.
