### PR TITLE
fix(chat): keep normal submits queued during running tool calls

### DIFF
--- a/src/hooks/bridgeMessageHandlers/a2ui.test.ts
+++ b/src/hooks/bridgeMessageHandlers/a2ui.test.ts
@@ -93,6 +93,68 @@ describe("handleA2ui", () => {
     );
   });
 
+  it("replaces a stale cancelled terminal tool card when the final event has a sibling id", () => {
+    const runningId =
+      "restored-tool-call_run-fc_01a0cf101a3d1343016a14d6465b9c819b8b75c60642c6bd59";
+    const finalId =
+      "tool-2-call_run-fc_01a0cf101a3d1343016a14d6465b9c819b8b75c60642c6bd59";
+    const tab = {
+      ...makeEmptyTab("tab-1", "Tab 1"),
+      messages: [
+        {
+          id: runningId,
+          role: "agent",
+          a2ui: {
+            components: [
+              {
+                id: runningId,
+                type: "tool-card",
+                props: {
+                  title: "bash",
+                  toolName: "bash",
+                  description: "sleep 60",
+                  startedAt: 1_000,
+                  endedAt: 1_500,
+                  status: "cancelled",
+                },
+              },
+            ],
+          },
+        } satisfies ChatMessage,
+      ],
+    };
+    const { ctx, mocks } = buildHandlerFixture({
+      state: { activeTabId: "tab-1", tabs: [tab] },
+    });
+    const payload = {
+      components: [
+        {
+          id: finalId,
+          type: "tool-card",
+          props: {
+            title: "bash",
+            toolName: "bash",
+            description: "sleep 60",
+            startedAt: 1_000,
+            endedAt: 2_000,
+          },
+        },
+      ],
+    };
+
+    handleA2ui({ type: "a2ui", payload, id: finalId, tabId: "tab-1" }, ctx);
+
+    expect(mocks.appendMessage).not.toHaveBeenCalled();
+    const [, updater] = mocks.updateTab.mock.calls[0];
+    const out = updater(tab);
+    expect(out.messages).toHaveLength(1);
+    expect(out.messages[0]).toMatchObject({
+      id: finalId,
+      role: "agent",
+      a2ui: payload,
+    });
+  });
+
   it("replaces a stale running terminal tool card when the final event has a sibling id", () => {
     const runningId =
       "tool-1-call_run-fc_01a0cf101a3d1343016a14d6465b9c819b8b75c60642c6bd59";

--- a/src/hooks/bridgeMessageHandlers/a2ui.ts
+++ b/src/hooks/bridgeMessageHandlers/a2ui.ts
@@ -1,5 +1,6 @@
 import type { A2UIComponent, A2UIPayload, ChatMessage } from "../../types/a2ui";
 import type { Tab } from "../../types/tab";
+import { closeRunningToolCards } from "../../utils/agentBusy";
 import { toolCardIdentityFromId } from "../../utils/toolCardIdentity";
 import type { BridgeMessageHandler } from "./types";
 import { flushResponseDeltas } from "./responseDelta";
@@ -36,7 +37,7 @@ function createdAtFromPayload(payload: A2UIPayload): number | undefined {
   return undefined;
 }
 
-function replacesRunningToolCard(
+function replacesPriorToolCard(
   tab: Tab | undefined,
   incomingMessageId: string,
   identity: string | undefined,
@@ -49,7 +50,6 @@ function replacesRunningToolCard(
       if (component?.type !== "tool-card") return false;
       if (typeof component.id !== "string") return false;
       if (component.props?.startedAt === undefined) return false;
-      if (component.props.endedAt !== undefined) return false;
       return toolCardIdentityFromId(component.id) === identity;
     });
   });
@@ -74,7 +74,7 @@ export const handleA2ui: BridgeMessageHandler = (data, ctx) => {
     const tabs = (ctx.stateRef.current.tabs as Tab[] | undefined) ?? [];
     const tab = tabs.find((t) => t.id === tabId);
     const identity = completedToolCardIdentity(payload);
-    if (replacesRunningToolCard(tab, id, identity)) {
+    if (replacesPriorToolCard(tab, id, identity)) {
       ctx.updateTab(tabId, (current) => ({
         ...current,
         messages: current.messages.map((currentMessage) => {
@@ -83,7 +83,6 @@ export const handleA2ui: BridgeMessageHandler = (data, ctx) => {
               component?.type === "tool-card" &&
               typeof component.id === "string" &&
               component.props?.startedAt !== undefined &&
-              component.props.endedAt === undefined &&
               toolCardIdentityFromId(component.id) === identity,
           );
           return matches ? message : currentMessage;
@@ -95,7 +94,14 @@ export const handleA2ui: BridgeMessageHandler = (data, ctx) => {
     ctx.persistLocalChatMessage(message, tabId);
   }
   if (data.done) {
-    ctx.updateTab(tabId, (tab) => ({ ...tab, waiting: false }));
+    ctx.updateTab(tabId, (tab) => {
+      const closedTools = closeRunningToolCards(tab.messages);
+      return {
+        ...tab,
+        waiting: false,
+        ...(closedTools.changed ? { messages: closedTools.messages } : {}),
+      };
+    });
     if (ctx.stateRef.current.activeTabId === tabId) {
       ctx.setStatusFlags({ status: "ready" });
     }

--- a/src/hooks/bridgeMessageHandlers/error.ts
+++ b/src/hooks/bridgeMessageHandlers/error.ts
@@ -1,3 +1,4 @@
+import { closeRunningToolCards } from "../../utils/agentBusy";
 import type { BridgeMessageHandler } from "./types";
 
 export const handleError: BridgeMessageHandler = (data, ctx) => {
@@ -8,7 +9,16 @@ export const handleError: BridgeMessageHandler = (data, ctx) => {
     { id: crypto.randomUUID(), role: "agent", text: `Error: ${message}` },
     tabId,
   );
-  ctx.updateTab(tabId, (tab) => ({ ...tab, waiting: false }));
+  ctx.updateTab(tabId, (tab) => {
+    const closedTools = closeRunningToolCards(tab.messages, {
+      notice: "Tool call did not finish before the turn errored.",
+    });
+    return {
+      ...tab,
+      waiting: false,
+      ...(closedTools.changed ? { messages: closedTools.messages } : {}),
+    };
+  });
   if (ctx.stateRef.current.activeTabId === tabId) {
     ctx.setStatusFlags({ status: "error" });
   }

--- a/src/hooks/bridgeMessageHandlers/response.ts
+++ b/src/hooks/bridgeMessageHandlers/response.ts
@@ -1,3 +1,4 @@
+import { closeRunningToolCards } from "../../utils/agentBusy";
 import type { BridgeMessageHandler } from "./types";
 
 /** Legacy single-shot response (kept so old bridge builds still render). */
@@ -11,7 +12,14 @@ export const handleResponse: BridgeMessageHandler = (data, ctx) => {
     );
   }
   if (data.done) {
-    ctx.updateTab(tabId, (tab) => ({ ...tab, waiting: false }));
+    ctx.updateTab(tabId, (tab) => {
+      const closedTools = closeRunningToolCards(tab.messages);
+      return {
+        ...tab,
+        waiting: false,
+        ...(closedTools.changed ? { messages: closedTools.messages } : {}),
+      };
+    });
     if (ctx.stateRef.current.activeTabId === tabId) {
       ctx.setStatusFlags({ status: "ready" });
     }

--- a/src/hooks/bridgeMessageHandlers/responseEnd.test.ts
+++ b/src/hooks/bridgeMessageHandlers/responseEnd.test.ts
@@ -24,6 +24,44 @@ describe("handleResponseEnd", () => {
     expect(mocks.maybeFireCompletionNotification).toHaveBeenCalled();
   });
 
+  it("freezes running tool cards when the turn ends", () => {
+    const { ctx, mocks } = buildHandlerFixture({
+      state: { activeTabId: "default" },
+    });
+    handleResponseEnd({ type: "response_end", tabId: "default" }, ctx);
+    const [, updater] = mocks.updateTab.mock.calls[0];
+    const seed = {
+      ...makeEmptyTab("default", "Tab 1"),
+      waiting: true,
+      messages: [
+        {
+          id: "tool-message",
+          role: "agent" as const,
+          a2ui: {
+            components: [
+              {
+                id: "running-tool",
+                type: "tool-card",
+                props: { startedAt: 1_000 },
+                children: [],
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    const out = updater(seed);
+    const toolCard = out.messages[0].a2ui?.components[0];
+    expect(toolCard?.props).toMatchObject({
+      status: "cancelled",
+      endedAt: expect.any(Number),
+    });
+    expect(toolCard?.children?.[0].props?.content).toContain(
+      "did not finish",
+    );
+  });
+
   it("clears waiting even when a client-side queue is non-empty", () => {
     // The client-side queue is drained by useQueuedDispatch on the
     // waiting=true→false transition, so we MUST clear waiting here —

--- a/src/hooks/bridgeMessageHandlers/responseEnd.ts
+++ b/src/hooks/bridgeMessageHandlers/responseEnd.ts
@@ -1,3 +1,4 @@
+import { closeRunningToolCards } from "../../utils/agentBusy";
 import type { BridgeMessageHandler } from "./types";
 import { flushResponseDeltas } from "./responseDelta";
 
@@ -10,7 +11,14 @@ export const handleResponseEnd: BridgeMessageHandler = (data, ctx) => {
   // re-flips it to true while popping the head and dispatching the
   // next message — same render commit, so the Send button doesn't
   // flash. When the queue is empty, waiting stays false.
-  ctx.updateTab(tabId, (tab) => ({ ...tab, waiting: false }));
+  ctx.updateTab(tabId, (tab) => {
+    const closedTools = closeRunningToolCards(tab.messages);
+    return {
+      ...tab,
+      waiting: false,
+      ...(closedTools.changed ? { messages: closedTools.messages } : {}),
+    };
+  });
   // Drop the tab from the bucket-independent running set (see promptStarted).
   ctx.setState((prev) => {
     const running = prev.agentRunningTabs as Record<string, true> | undefined;

--- a/src/hooks/bridgeMessageHandlers/sessionHistory.test.ts
+++ b/src/hooks/bridgeMessageHandlers/sessionHistory.test.ts
@@ -637,6 +637,52 @@ describe("handleSessionHistory", () => {
     expect(out.waiting).toBe(false);
   });
 
+  it("freezes restored unfinished tool cards when no live turn remains", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleSessionHistory(
+      {
+        type: "session_history",
+        tabId: "tab-1",
+        messages: [
+          {
+            id: "restored-tool-call_stale",
+            role: "agent",
+            a2ui: {
+              components: [
+                {
+                  id: "restored-tool-call_stale",
+                  type: "tool-card",
+                  props: {
+                    title: "bash",
+                    toolName: "bash",
+                    startedAt: 1_000,
+                  },
+                  children: [],
+                },
+              ],
+            },
+          },
+        ],
+      },
+      ctx,
+    );
+    const [, updater] = mocks.updateTab.mock.calls[0];
+    const out = updater({
+      ...makeEmptyTab("tab-1", "Tab 1"),
+      waiting: false,
+    });
+
+    const toolCard = out.messages[0].a2ui?.components[0];
+    expect(out.waiting).toBe(false);
+    expect(toolCard?.props).toMatchObject({
+      status: "cancelled",
+      endedAt: expect.any(Number),
+    });
+    expect(toolCard?.children?.[0].props?.content).toContain(
+      "stopped after restore",
+    );
+  });
+
   it("drops restored duplicate assistant text and completed tool cards so reloads do not look busy", () => {
     const { ctx, mocks } = buildHandlerFixture();
     handleSessionHistory(

--- a/src/hooks/bridgeMessageHandlers/sessionHistory.ts
+++ b/src/hooks/bridgeMessageHandlers/sessionHistory.ts
@@ -1,3 +1,4 @@
+import { closeRunningToolCards } from "../../utils/agentBusy";
 import {
   coerceChatMessages,
   dedupeToolResultTextMessages,
@@ -367,9 +368,16 @@ export const handleSessionHistory: BridgeMessageHandler = (data, ctx) => {
       tab.waiting === true,
     );
     const nextWaiting = merged.hasLivePending ? tab.waiting : false;
+    const dedupedMessages = dedupeToolResultTextMessages(merged.messages);
+    const closedTools = nextWaiting
+      ? { messages: dedupedMessages, changed: false }
+      : closeRunningToolCards(dedupedMessages, {
+          notice:
+            "No live prompt is running. This tool was marked stopped after restore.",
+        });
     return {
       ...tab,
-      messages: dedupeToolResultTextMessages(merged.messages),
+      messages: closedTools.messages,
       waiting: nextWaiting,
       ...(label
         ? { label }

--- a/src/hooks/osEdges/agentCrash.ts
+++ b/src/hooks/osEdges/agentCrash.ts
@@ -2,6 +2,7 @@ import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import type { Tab } from "../../types/tab";
+import { closeRunningToolCards } from "../../utils/agentBusy";
 import type { NotificationInput } from "../useNotifications";
 
 export interface AgentCrashDeps {
@@ -85,15 +86,18 @@ export function subscribeAgentCrash(deps: AgentCrashDeps): () => void {
       hangWarnActiveRef.current.clear();
     }
     setState((prev) => {
-      const tabs = ((prev.tabs as Tab[] | undefined) ?? []).map((t) =>
-        !crashedTabId || t.id === crashedTabId
-          ? {
-              ...t,
-              waiting: false,
-              queueCount: 0,
-            }
-          : t,
-      );
+      const tabs = ((prev.tabs as Tab[] | undefined) ?? []).map((t) => {
+        if (crashedTabId && t.id !== crashedTabId) return t;
+        const closedTools = closeRunningToolCards(t.messages, {
+          notice: "Tool call did not finish before the agent crashed.",
+        });
+        return {
+          ...t,
+          waiting: false,
+          queueCount: 0,
+          ...(closedTools.changed ? { messages: closedTools.messages } : {}),
+        };
+      });
       // Drop the crashed tab(s) from the bucket-independent running set so the
       // sidebar activity dot can't stay stuck — a crash doesn't emit
       // response_end. A whole-process crash (no crashedTabId) aborts every

--- a/src/hooks/useAgentActivityHydration.ts
+++ b/src/hooks/useAgentActivityHydration.ts
@@ -1,7 +1,7 @@
 import { useEffect, type Dispatch, type SetStateAction } from "react";
 import { invoke } from "@tauri-apps/api/core";
-import type { A2UIComponent, ChatMessage } from "../types/a2ui";
 import type { Tab } from "../types/tab";
+import { closeRunningToolCards } from "../utils/agentBusy";
 import { TAB_MIRROR_KEYS } from "./useTabs";
 
 export const AGENT_ACTIVITY_HYDRATION_RETRY_DELAYS_MS = [
@@ -33,60 +33,6 @@ function diagnosticPromptInFlight(row: AgentDiagnosticRow): boolean {
   return row.prompt_in_flight === true || row.promptInFlight === true;
 }
 
-function stoppedToolCardNotice(componentId: string): A2UIComponent {
-  return {
-    id: `${componentId}-stopped-notice`,
-    type: "code",
-    props: {
-      content:
-        "No live prompt is running. This tool was marked stopped after reload.",
-      language: "text",
-    },
-  };
-}
-
-function closeStoppedToolCards(
-  messages: ChatMessage[],
-  endedAt: number,
-): { messages: ChatMessage[]; changed: boolean } {
-  let changed = false;
-  const nextMessages = messages.map((message): ChatMessage => {
-    const components = message.a2ui?.components;
-    if (!components) return message;
-    let messageChanged = false;
-    const nextComponents = components.map((component): A2UIComponent => {
-      if (
-        component?.type !== "tool-card" ||
-        component.props?.startedAt === undefined ||
-        component.props.endedAt !== undefined
-      ) {
-        return component;
-      }
-      messageChanged = true;
-      const children = component.children ?? [];
-      return {
-        ...component,
-        props: {
-          ...(component.props ?? {}),
-          status: "cancelled",
-          endedAt,
-        },
-        children: [...children, stoppedToolCardNotice(component.id)],
-      };
-    });
-    if (!messageChanged) return message;
-    changed = true;
-    return {
-      ...message,
-      a2ui: {
-        ...message.a2ui,
-        components: nextComponents,
-      },
-    };
-  });
-  return { messages: nextMessages, changed };
-}
-
 export function hydrateAgentActivityState(
   state: Record<string, unknown>,
   diagnostics: AgentDiagnosticRow[],
@@ -115,7 +61,11 @@ export function hydrateAgentActivityState(
       : false;
     const stoppedTools = nextWaiting
       ? { messages: tab.messages, changed: false }
-      : closeStoppedToolCards(tab.messages, endedAt);
+      : closeRunningToolCards(tab.messages, {
+          endedAt,
+          notice:
+            "No live prompt is running. This tool was marked stopped after reload.",
+        });
     if (tab.waiting === nextWaiting && !stoppedTools.changed) return tab;
     tabChanged = true;
     return { ...tab, waiting: nextWaiting, messages: stoppedTools.messages };

--- a/src/hooks/useChat.test.ts
+++ b/src/hooks/useChat.test.ts
@@ -418,6 +418,7 @@ describe("useChat setModel", () => {
     expect(tab.messages.some((m) => m.text === "after this")).toBe(false);
   });
 
+
   it("holds attachments with queued normal messages while the prompt is busy", async () => {
     const attachment = {
       id: "img-queued",

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -19,6 +19,7 @@ interface NotificationInput {
 
 function activeAgentTabIsBusy(state: Record<string, unknown>): boolean {
   const activeTabId = state.activeTabId as string | undefined;
+  if (!activeTabId) return false;
   const tabs = (state.tabs as Tab[] | undefined) ?? [];
   const activeTab = tabs.find((tab) => tab.id === activeTabId);
   if (!activeTab) return false;

--- a/src/hooks/useQueuedDispatch.test.ts
+++ b/src/hooks/useQueuedDispatch.test.ts
@@ -109,6 +109,7 @@ describe("useQueuedDispatch", () => {
     expect(updateTab).not.toHaveBeenCalled();
   });
 
+
   it("does nothing while a queued steer is in flight", () => {
     const sendChat = vi.fn(() => Promise.resolve());
     const updateTab = vi.fn();

--- a/src/utils/agentBusy.test.ts
+++ b/src/utils/agentBusy.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { makeEmptyTab } from "../types/tab";
+import { isAgentTabBusy } from "./agentBusy";
+
+describe("isAgentTabBusy", () => {
+  it("treats queuedMessages as authoritative when including client queue", () => {
+    const tab = {
+      ...makeEmptyTab("tab-1", "Tab 1"),
+      queueCount: 0,
+      queuedMessages: [{ id: "q1", content: "queued" }],
+    };
+
+    expect(isAgentTabBusy(tab, { includeQueue: true })).toBe(true);
+  });
+});

--- a/src/utils/agentBusy.ts
+++ b/src/utils/agentBusy.ts
@@ -29,9 +29,7 @@ export function hasRunningToolCard(
 /** A turn is actively in flight for an agent tab. Queue state is intentionally
  *  excluded: queued messages are pending client work, not an active command. */
 export function isAgentTabInFlight(
-  tab:
-    | Pick<Tab, "kind" | "waiting" | "messages">
-    | undefined,
+  tab: Pick<Tab, "kind" | "waiting" | "messages"> | undefined,
 ): boolean {
   if (!tab) return false;
   if ((tab.kind ?? "agent") !== "agent") return false;
@@ -54,4 +52,99 @@ export function isAgentTabBusy(
   if (isAgentTabInFlight(tab)) return true;
   if (options.includeQueue !== true) return false;
   return (tab.queueCount ?? tab.queuedMessages?.length ?? 0) > 0;
+}
+
+export interface CloseRunningToolCardsOptions {
+  endedAt?: number;
+  status?: string;
+  notice?: string;
+}
+
+function toolCardClosedNotice(
+  componentId: string,
+  content: string,
+): A2UIComponent {
+  return {
+    id: `${componentId}-closed-notice`,
+    type: "code",
+    props: { content, language: "text" },
+  };
+}
+
+function closeRunningToolCardComponent(
+  component: A2UIComponent,
+  endedAt: number,
+  status: string,
+  notice: string,
+): { component: A2UIComponent; changed: boolean } {
+  let childrenChanged = false;
+  const nextChildren = (component.children ?? []).map((child) => {
+    const next = closeRunningToolCardComponent(child, endedAt, status, notice);
+    childrenChanged = childrenChanged || next.changed;
+    return next.component;
+  });
+
+  if (
+    component.type === "tool-card" &&
+    component.props?.startedAt !== undefined &&
+    component.props.endedAt === undefined
+  ) {
+    return {
+      changed: true,
+      component: {
+        ...component,
+        props: {
+          ...(component.props ?? {}),
+          status,
+          endedAt,
+        },
+        children: [
+          ...nextChildren,
+          toolCardClosedNotice(component.id, notice),
+        ],
+      },
+    };
+  }
+
+  if (!childrenChanged) return { component, changed: false };
+  return { component: { ...component, children: nextChildren }, changed: true };
+}
+
+/** Freeze any still-running tool-card timers once the surrounding turn has
+ *  definitely ended. This prevents a stale visual card from keeping the
+ *  frontend busy predicate true forever. */
+export function closeRunningToolCards(
+  messages: readonly ChatMessage[],
+  options: CloseRunningToolCardsOptions = {},
+): { messages: ChatMessage[]; changed: boolean } {
+  let changed = false;
+  const endedAt = options.endedAt ?? Date.now();
+  const status = options.status ?? "cancelled";
+  const notice =
+    options.notice ?? "Tool call did not finish before the turn ended.";
+  const nextMessages = messages.map((message): ChatMessage => {
+    const components = message.a2ui?.components;
+    if (!components) return message;
+    let messageChanged = false;
+    const nextComponents = components.map((component): A2UIComponent => {
+      const next = closeRunningToolCardComponent(
+        component,
+        endedAt,
+        status,
+        notice,
+      );
+      messageChanged = messageChanged || next.changed;
+      return next.component;
+    });
+    if (!messageChanged) return message;
+    changed = true;
+    return {
+      ...message,
+      a2ui: {
+        ...message.a2ui,
+        components: nextComponents,
+      },
+    };
+  });
+  return { messages: nextMessages, changed };
 }

--- a/src/utils/agentBusy.ts
+++ b/src/utils/agentBusy.ts
@@ -51,7 +51,7 @@ export function isAgentTabBusy(
   if (!tab) return false;
   if (isAgentTabInFlight(tab)) return true;
   if (options.includeQueue !== true) return false;
-  return (tab.queueCount ?? tab.queuedMessages?.length ?? 0) > 0;
+  return (tab.queuedMessages?.length ?? tab.queueCount ?? 0) > 0;
 }
 
 export interface CloseRunningToolCardsOptions {


### PR DESCRIPTION
## Summary

Fixes #222.

Normal-mode submits now use a shared frontend agent-busy predicate instead of checking only `waiting`. The predicate includes visible in-flight tool cards (`startedAt` without `endedAt`), so a normal submit made while a tool call is still running is held in `tab.queuedMessages` and managed by the client queue UI instead of falling through to the bridge/backend follow-up queue.

## What changed

- Added `src/utils/agentBusy.ts` with shared helpers for:
  - detecting running tool cards
  - determining whether an agent tab is busy
  - freezing stale running tool cards once a turn is known to be over
- Updated `useChat.sendChat()` to use the shared busy predicate before deciding whether to queue a normal submit.
- Updated keyboard Escape handling to use the same predicate, preserving the existing queue-aware Stop behavior.
- Updated `useQueuedDispatch` so client-held queue drain waits for both `waiting === false` and no running tool cards.
- Closed/froze stale running tool cards on terminal turn-end paths so a missing tool end event cannot keep the frontend permanently busy:
  - `response_end`
  - legacy `response.done`
  - `a2ui.done`
  - error handling
  - agent crash recovery
  - session history restore when no live prompt remains
- Allowed final completed tool-card events to replace prior matching tool cards even if the prior card was already frozen/cancelled, preventing duplicate cards if a final tool result arrives after stale-card cleanup.

## Regression coverage

Added tests for:

- normal sends with `waiting: false` but a visible running tool-card queue client-side and do not invoke `send_message`
- queued dispatch does not drain while a tool-card is still running
- response end freezes stale running tool cards
- restored unfinished tool cards are frozen when no live turn remains
- final sibling tool-card events replace previously frozen/cancelled matching tool cards

## Verification

- Peer reviewed with Codex CLI: no remaining discrete correctness issues reported.
- `bun run test` — 245 files / 1952 tests passed
- `bun run typecheck`
- `bun run lint`


## Review follow-up

- Rebased on latest `origin/main`.
- Addressed Copilot review finding by making `queuedMessages.length` authoritative for queue-aware busy checks, with regression coverage in `src/utils/agentBusy.test.ts`.
