### PR TITLE
fix(context): distinguish live estimates in context meter

### DIFF
--- a/agent/context-usage.test.ts
+++ b/agent/context-usage.test.ts
@@ -153,10 +153,60 @@ describe("live context updates", () => {
     expect(context).toMatchObject({
       type: "context_usage",
       tabId: "tab-1",
-      tokens: expect.any(Number),
+      tokens: 1_000,
+      estimatedTokens: expect.any(Number),
+      transientTokens: expect.any(Number),
+      tokensUntilCompact: 800,
     });
-    expect(context?.tokens).toBeGreaterThan(1_000);
-    expect(context?.tokensUntilCompact).toBeLessThan(800);
+    expect(context?.estimatedTokens).toBeGreaterThan(1_000);
+    expect(context?.estimatedTokensUntilCompact).toBeLessThan(800);
+  });
+
+  it("marks live bash-output saturation without changing provider usage", () => {
+    const state = stateWithCompaction({
+      settingsManager: {
+        getCompactionSettings: () => ({
+          enabled: true,
+          reserveTokens: 16_384,
+          keepRecentTokens: 100,
+        }),
+      },
+    });
+    const rec = recWithUsage({
+      tokens: 199_999,
+      contextWindow: 272_000,
+      percent: 73.5,
+    });
+    const sent: Record<string, unknown>[] = [];
+
+    handleSessionEvent(
+      state,
+      { send: (msg) => sent.push(msg) },
+      rec,
+      "tab-1",
+      {
+        type: "tool_execution_update",
+        toolCallId: "bash-1",
+        toolName: "bash",
+        args: { command: "yes" },
+        partialResult: {
+          content: [{ type: "text", text: "x".repeat(320_000) }],
+        },
+      },
+    );
+
+    const context = sent.find((msg) => msg.type === "context_usage");
+    expect(context).toMatchObject({
+      tokens: 199_999,
+      percent: 73.5,
+      compactAtTokens: 255_616,
+      tokensUntilCompact: 55_617,
+      saturatedByEstimate: true,
+    });
+    expect(context?.estimatedTokens).toBeGreaterThan(272_000);
+    expect(context?.estimatedTokensUntilCompact).toBe(0);
+    expect(context?.saturatedByProvider).toBeUndefined();
+    expect(context?.saturated).toBeUndefined();
   });
 
   it("clears transient estimates for authoritative turn-end usage", () => {

--- a/agent/context-usage.ts
+++ b/agent/context-usage.ts
@@ -11,18 +11,34 @@ export interface ContextUsageSnapshot {
   tabId: string;
   model: string;
   status: "known" | "unknown";
+  /** Provider/persisted usage from pi, without Aethon's current-turn
+   *  transient estimate. This is the value pi uses for threshold compaction. */
   tokens: number | null;
   contextWindow: number;
+  /** Percent for provider/persisted usage only. */
   percent: number | null;
+  /** Provider/persisted usage plus Aethon's current-turn streaming/tool-output
+   *  estimate. This may exceed the context window; the UI must render it as an
+   *  estimate, not as the authoritative compaction state. */
+  estimatedTokens: number | null;
+  estimatedPercent: number | null;
+  transientTokens: number;
   autoCompactEnabled: boolean;
   reserveTokens: number;
   compactAtTokens: number;
   tokensUntilCompact: number | null;
+  estimatedTokensUntilCompact: number | null;
   compacting?: boolean;
-  /** The model's own authoritative usage has reached/exceeded the context
-   *  window. For Ollama this means the server is silently truncating the
-   *  oldest turns and re-reporting the cap — a frozen "100%" that hides
-   *  data loss, distinct from a healthy near-full window. */
+  /** The provider/persisted usage has reached/exceeded the context window. For
+   *  Ollama this means the server is silently truncating the oldest turns and
+   *  re-reporting the cap — a frozen "100%" that hides data loss, distinct
+   *  from a healthy near-full window. */
+  saturatedByProvider?: boolean;
+  /** Only Aethon's current-turn streaming/tool-output estimate reached the
+   *  context window; pi has not yet had a response boundary or overflow event
+   *  at which it can compact/recover. */
+  saturatedByEstimate?: boolean;
+  /** Back-compat alias for saturatedByProvider. */
   saturated?: boolean;
 }
 
@@ -85,21 +101,27 @@ export function contextUsageSnapshot(
   const settings = state.settingsManager.getCompactionSettings();
   const reserveTokens = Math.max(0, settings.reserveTokens);
   const compactAtTokens = Math.max(contextWindow - reserveTokens, 0);
-  const baseTokens = finiteNumber(usage?.tokens) ?? null;
+  const tokens = finiteNumber(usage?.tokens) ?? null;
   const transientTokens = Math.max(0, rec.contextUsageTransientTokens ?? 0);
-  const tokens =
-    baseTokens === null ? null : Math.min(baseTokens + transientTokens, contextWindow);
+  const estimatedTokens =
+    tokens === null ? null : Math.max(tokens + transientTokens, tokens);
   // The model's own authoritative count reached the window (Ollama pegs
-  // prompt_tokens at num_ctx and truncates). Key off baseTokens, not the
-  // transient-augmented/clamped tokens, so we only flag a real model report.
-  const saturated = baseTokens !== null && baseTokens >= contextWindow;
+  // prompt_tokens at num_ctx and truncates). Key off provider tokens, not the
+  // transient estimate, so we only flag a real model report.
+  const saturatedByProvider = tokens !== null && tokens >= contextWindow;
+  const saturatedByEstimate =
+    !saturatedByProvider &&
+    estimatedTokens !== null &&
+    estimatedTokens >= contextWindow;
   const percent =
-    (tokens !== baseTokens && tokens !== null
-      ? (tokens / contextWindow) * 100
-      : finiteNumber(usage?.percent)) ??
+    finiteNumber(usage?.percent) ??
     (tokens !== null && contextWindow > 0
       ? (tokens / contextWindow) * 100
       : null);
+  const estimatedPercent =
+    estimatedTokens !== null && contextWindow > 0
+      ? (estimatedTokens / contextWindow) * 100
+      : null;
 
   return {
     tabId,
@@ -108,13 +130,21 @@ export function contextUsageSnapshot(
     tokens,
     contextWindow,
     percent,
+    estimatedTokens,
+    estimatedPercent,
+    transientTokens,
     autoCompactEnabled: settings.enabled,
     reserveTokens,
     compactAtTokens,
     tokensUntilCompact:
       tokens === null ? null : Math.max(compactAtTokens - tokens, 0),
+    estimatedTokensUntilCompact:
+      estimatedTokens === null
+        ? null
+        : Math.max(compactAtTokens - estimatedTokens, 0),
     ...(options.compacting ? { compacting: true } : {}),
-    ...(saturated ? { saturated: true } : {}),
+    ...(saturatedByProvider ? { saturatedByProvider: true, saturated: true } : {}),
+    ...(saturatedByEstimate ? { saturatedByEstimate: true } : {}),
   };
 }
 

--- a/src/extensions/default-layout/layout/status-bar.test.tsx
+++ b/src/extensions/default-layout/layout/status-bar.test.tsx
@@ -77,6 +77,44 @@ describe("StatusBar context meter", () => {
     expect(screen.getByText("auto @184k")).toBeTruthy();
   });
 
+  it("renders live tool-output saturation as an estimate, not authoritative 100%", () => {
+    renderStatusBar({
+      status: "ready",
+      connection: "connected",
+      model: "anthropic/claude",
+      contextUsage: {
+        model: "anthropic/claude",
+        status: "known",
+        tokens: 199_999,
+        contextWindow: 272_000,
+        percent: 73.5,
+        estimatedTokens: 280_000,
+        estimatedPercent: 102.9,
+        transientTokens: 80_001,
+        autoCompactEnabled: true,
+        reserveTokens: 16_384,
+        compactAtTokens: 255_616,
+        tokensUntilCompact: 55_617,
+        estimatedTokensUntilCompact: 0,
+        saturatedByEstimate: true,
+      },
+    });
+
+    expect(screen.getByText("ctx 74%")).toBeTruthy();
+    expect(screen.getByText("200k/272k")).toBeTruthy();
+    expect(screen.getByText("est 272k+")).toBeTruthy();
+    expect(screen.getByText("pending turn")).toBeTruthy();
+    const chip = screen.getByLabelText(
+      "Context 74%, tool-output estimate pending compaction",
+    );
+    expect(chip.getAttribute("title")).toContain(
+      "Live estimate including current turn/tool output",
+    );
+    expect(chip.getAttribute("title")).toContain(
+      "compaction is pending the current turn",
+    );
+  });
+
   it("surfaces a distinct FULL state when the window is saturated (Ollama truncating)", () => {
     renderStatusBar({
       status: "ready",

--- a/src/extensions/default-layout/layout/status-bar.tsx
+++ b/src/extensions/default-layout/layout/status-bar.tsx
@@ -212,19 +212,31 @@ function contextUsageFromValue(value: unknown): ContextUsageState | null {
   ) {
     return null;
   }
+  const tokens = finiteNumberOrNull(usage.tokens);
+  const estimatedTokens = finiteNumberOrNull(usage.estimatedTokens) ?? tokens;
+  const transientTokens = finiteNumberOrNull(usage.transientTokens) ?? 0;
+  const saturatedByProvider =
+    usage.saturatedByProvider === true || usage.saturated === true;
   return {
     model: typeof usage.model === "string" ? usage.model : "",
     status: usage.status === "known" ? "known" : "unknown",
-    tokens: finiteNumberOrNull(usage.tokens),
+    tokens,
     contextWindow: usage.contextWindow,
     percent: finiteNumberOrNull(usage.percent),
+    estimatedTokens,
+    estimatedPercent: finiteNumberOrNull(usage.estimatedPercent),
+    transientTokens,
     autoCompactEnabled: usage.autoCompactEnabled === true,
     reserveTokens: finiteNumberOrNull(usage.reserveTokens) ?? 0,
     compactAtTokens:
       finiteNumberOrNull(usage.compactAtTokens) ?? usage.contextWindow,
     tokensUntilCompact: finiteNumberOrNull(usage.tokensUntilCompact),
+    estimatedTokensUntilCompact: finiteNumberOrNull(
+      usage.estimatedTokensUntilCompact,
+    ),
     ...(usage.compacting === true ? { compacting: true } : {}),
-    ...(usage.saturated === true ? { saturated: true } : {}),
+    ...(saturatedByProvider ? { saturatedByProvider: true, saturated: true } : {}),
+    ...(usage.saturatedByEstimate === true ? { saturatedByEstimate: true } : {}),
   };
 }
 
@@ -247,27 +259,67 @@ function formatExactTokens(value: number | null | undefined): string {
     : "unknown";
 }
 
+function formatEstimatedTokens(
+  value: number | null | undefined,
+  contextWindow: number,
+): string {
+  if (typeof value !== "number" || !Number.isFinite(value)) return "?";
+  return value >= contextWindow
+    ? `${formatTokens(contextWindow)}+`
+    : formatTokens(value);
+}
+
 function ContextMeter({ usage }: { usage: ContextUsageState }) {
-  const percentValue =
+  const providerPercent =
     usage.percent ??
     (usage.tokens !== null ? (usage.tokens / usage.contextWindow) * 100 : null);
-  const usageClass =
-    usage.saturated || (percentValue !== null && percentValue >= 90)
+  const estimatedPercent =
+    usage.estimatedPercent ??
+    (usage.estimatedTokens !== null
+      ? (usage.estimatedTokens / usage.contextWindow) * 100
+      : null);
+  const saturatedByProvider = usage.saturatedByProvider || usage.saturated;
+  const estimateActive =
+    usage.transientTokens > 0 &&
+    usage.tokens !== null &&
+    usage.estimatedTokens !== null &&
+    usage.estimatedTokens > usage.tokens;
+  const estimateOverCompact =
+    estimateActive &&
+    usage.autoCompactEnabled &&
+    usage.estimatedTokens !== null &&
+    usage.estimatedTokens >= usage.compactAtTokens &&
+    (usage.tokens === null || usage.tokens < usage.compactAtTokens);
+  const saturatedByEstimate =
+    usage.saturatedByEstimate ||
+    (estimateActive &&
+      !saturatedByProvider &&
+      usage.estimatedTokens !== null &&
+      usage.estimatedTokens >= usage.contextWindow);
+  const usageClass = saturatedByProvider
+    ? " is-danger"
+    : providerPercent !== null && providerPercent >= 90
       ? " is-danger"
-      : percentValue !== null && percentValue >= 70
+      : estimateOverCompact ||
+          (providerPercent !== null && providerPercent >= 70)
         ? " is-warning"
         : "";
-  const saturatedClass = usage.saturated ? " is-saturated" : "";
+  const saturatedClass = saturatedByProvider ? " is-saturated" : "";
+  const estimatedClass = estimateOverCompact ? " is-estimated-over" : "";
   const compactingClass = usage.compacting ? " is-compacting" : "";
-  const percentLabel = usage.saturated
+  const percentLabel = saturatedByProvider
     ? "FULL"
-    : percentValue === null
+    : providerPercent === null
       ? "?"
-      : `${Math.round(percentValue)}%`;
+      : `${Math.round(providerPercent)}%`;
   const usedLabel =
     usage.tokens === null
       ? `?/${formatTokens(usage.contextWindow)}`
       : `${formatTokens(usage.tokens)}/${formatTokens(usage.contextWindow)}`;
+  const estimateLabel = estimateActive
+    ? `est ${formatEstimatedTokens(usage.estimatedTokens, usage.contextWindow)}`
+    : null;
+  const pendingLabel = estimateOverCompact ? "pending turn" : null;
   const autoLabel = usage.autoCompactEnabled
     ? `auto @${formatTokens(usage.compactAtTokens)}`
     : "auto off";
@@ -276,37 +328,64 @@ function ContextMeter({ usage }: { usage: ContextUsageState }) {
     `Context used: ${formatExactTokens(usage.tokens)} of ${formatExactTokens(
       usage.contextWindow,
     )} tokens`,
-    usage.percent === null
-      ? "Usage is unknown until the next assistant response."
-      : `Usage: ${usage.percent.toFixed(1)}%`,
+    providerPercent === null
+      ? "Provider usage is unknown until the next assistant response."
+      : `Provider usage: ${providerPercent.toFixed(1)}%`,
+    estimateActive
+      ? `Live estimate including current turn/tool output: ${formatExactTokens(
+          usage.estimatedTokens,
+        )} of ${formatExactTokens(usage.contextWindow)} tokens${
+          estimatedPercent === null ? "" : ` (${estimatedPercent.toFixed(1)}%)`
+        }`
+      : null,
+    estimateOverCompact
+      ? "Tool output estimate exceeds the auto-compact threshold; compaction is pending the current turn/model response or overflow recovery."
+      : null,
     usage.autoCompactEnabled
       ? `Next auto compaction: ${formatExactTokens(
           usage.compactAtTokens,
-        )} tokens (${formatExactTokens(usage.tokensUntilCompact)} remaining)`
+        )} provider tokens (${formatExactTokens(
+          usage.tokensUntilCompact,
+        )} provider tokens remaining)`
       : "Auto compaction: off",
     `Reserve: ${formatExactTokens(usage.reserveTokens)} tokens`,
-    usage.saturated
+    saturatedByProvider
       ? "Context full — older turns are being truncated (silent, lossy). Run /compact or /clear."
+      : null,
+    saturatedByEstimate
+      ? "The live estimate has reached the context window, but provider usage has not; this is not an auto-compaction failure."
       : null,
   ]
     .filter(Boolean)
     .join("\n");
   return (
     <span
-      className={`a2ui-status-context-chip${usageClass}${saturatedClass}${compactingClass}`}
+      className={`a2ui-status-context-chip${usageClass}${saturatedClass}${estimatedClass}${compactingClass}`}
       title={title}
       aria-label={
-        usage.saturated ? "Context full, truncating" : `Context ${percentLabel}`
+        saturatedByProvider
+          ? "Context full, truncating"
+          : estimateOverCompact
+            ? `Context ${percentLabel}, tool-output estimate pending compaction`
+            : `Context ${percentLabel}`
       }
     >
       <span className="a2ui-status-context-track" aria-hidden="true">
         <span
           className="a2ui-status-context-fill"
-          style={{ width: `${Math.max(0, Math.min(percentValue ?? 0, 100))}%` }}
+          style={{
+            width: `${Math.max(0, Math.min(providerPercent ?? 0, 100))}%`,
+          }}
         />
       </span>
       <span className="a2ui-status-context-label">ctx {percentLabel}</span>
       <span className="a2ui-status-context-detail">{usedLabel}</span>
+      {estimateLabel ? (
+        <span className="a2ui-status-context-estimate">{estimateLabel}</span>
+      ) : null}
+      {pendingLabel ? (
+        <span className="a2ui-status-context-pending">{pendingLabel}</span>
+      ) : null}
       <span className="a2ui-status-context-auto">{autoLabel}</span>
     </span>
   );

--- a/src/hooks/bridgeMessageHandlers/contextUsage.test.ts
+++ b/src/hooks/bridgeMessageHandlers/contextUsage.test.ts
@@ -36,10 +36,14 @@ describe("handleContextUsage", () => {
       tokens: 12_000,
       contextWindow: 200_000,
       percent: 6,
+      estimatedTokens: 12_000,
+      estimatedPercent: null,
+      transientTokens: 0,
       autoCompactEnabled: true,
       reserveTokens: 16_384,
       compactAtTokens: 183_616,
       tokensUntilCompact: 171_616,
+      estimatedTokensUntilCompact: null,
     });
   });
 

--- a/src/hooks/bridgeMessageHandlers/contextUsage.ts
+++ b/src/hooks/bridgeMessageHandlers/contextUsage.ts
@@ -12,19 +12,29 @@ export function contextUsageFromMessage(
   if (contextWindow === null || contextWindow <= 0) return null;
   const compactAtTokens = finiteNumber(data.compactAtTokens);
   const reserveTokens = finiteNumber(data.reserveTokens);
+  const tokens = finiteNumber(data.tokens);
+  const estimatedTokens = finiteNumber(data.estimatedTokens) ?? tokens;
+  const transientTokens = finiteNumber(data.transientTokens) ?? 0;
+  const saturatedByProvider =
+    data.saturatedByProvider === true || data.saturated === true;
   return {
     tabId: typeof data.tabId === "string" ? data.tabId : undefined,
     model: typeof data.model === "string" ? data.model : "",
     status: data.status === "known" ? "known" : "unknown",
-    tokens: finiteNumber(data.tokens),
+    tokens,
     contextWindow,
     percent: finiteNumber(data.percent),
+    estimatedTokens,
+    estimatedPercent: finiteNumber(data.estimatedPercent),
+    transientTokens,
     autoCompactEnabled: data.autoCompactEnabled === true,
     reserveTokens: reserveTokens ?? 0,
     compactAtTokens: compactAtTokens ?? contextWindow,
     tokensUntilCompact: finiteNumber(data.tokensUntilCompact),
+    estimatedTokensUntilCompact: finiteNumber(data.estimatedTokensUntilCompact),
     ...(data.compacting === true ? { compacting: true } : {}),
-    ...(data.saturated === true ? { saturated: true } : {}),
+    ...(saturatedByProvider ? { saturatedByProvider: true, saturated: true } : {}),
+    ...(data.saturatedByEstimate === true ? { saturatedByEstimate: true } : {}),
   };
 }
 

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -4266,7 +4266,7 @@ body.ae-resizing-composer * {
   align-items: center;
   gap: 5px;
   min-width: 0;
-  max-width: 300px;
+  max-width: 390px;
   height: 18px;
   padding: 0 var(--space-2);
   border-right: 1px solid var(--border);
@@ -4309,6 +4309,9 @@ body.ae-resizing-composer * {
 .a2ui-status-context-chip.is-compacting .a2ui-status-context-track {
   animation: ae-context-compact-pulse 1.1s ease-in-out infinite;
 }
+.a2ui-status-context-chip.is-estimated-over .a2ui-status-context-pending {
+  color: var(--warn);
+}
 /* Saturated = window full and the model is silently truncating. Pulse the
  * "FULL" label so it reads as an active, lossy state rather than a calm 100%. */
 .a2ui-status-context-chip.is-saturated .a2ui-status-context-label {
@@ -4322,11 +4325,21 @@ body.ae-resizing-composer * {
   flex: 0 0 auto;
 }
 .a2ui-status-context-detail,
+.a2ui-status-context-estimate,
+.a2ui-status-context-pending,
 .a2ui-status-context-auto {
   overflow: hidden;
   text-overflow: ellipsis;
 }
 .a2ui-status-context-detail {
+  color: var(--text-dim);
+  max-width: 90px;
+}
+.a2ui-status-context-estimate {
+  color: var(--warn);
+  max-width: 72px;
+}
+.a2ui-status-context-pending {
   color: var(--text-dim);
   max-width: 90px;
 }

--- a/src/types/tab.ts
+++ b/src/types/tab.ts
@@ -85,9 +85,9 @@ export interface ContextUsageState {
   tokensUntilCompact: number | null;
   estimatedTokensUntilCompact: number | null;
   compacting?: boolean;
-  /** The model's authoritative usage has reached/exceeded the window. For
-   *  Ollama this means the server is silently truncating the oldest turns —
-   *  surfaced as a distinct "full" state rather than a calm 100%. */
+  /** Provider/persisted usage has reached/exceeded the window. For Ollama,
+   *  this means the server is silently truncating the oldest turns — surfaced
+   *  as a distinct "full" state rather than a calm 100%. */
   saturatedByProvider?: boolean;
   /** Only the live current-turn/tool-output estimate reached the window. */
   saturatedByEstimate?: boolean;

--- a/src/types/tab.ts
+++ b/src/types/tab.ts
@@ -70,17 +70,28 @@ export interface ContextUsageState {
   tabId?: string;
   model: string;
   status: "known" | "unknown";
+  /** Provider/persisted usage, without live current-turn estimates. */
   tokens: number | null;
   contextWindow: number;
+  /** Percent for provider/persisted usage only. */
   percent: number | null;
+  /** Provider/persisted usage plus live current-turn/tool-output estimate. */
+  estimatedTokens: number | null;
+  estimatedPercent: number | null;
+  transientTokens: number;
   autoCompactEnabled: boolean;
   reserveTokens: number;
   compactAtTokens: number;
   tokensUntilCompact: number | null;
+  estimatedTokensUntilCompact: number | null;
   compacting?: boolean;
   /** The model's authoritative usage has reached/exceeded the window. For
    *  Ollama this means the server is silently truncating the oldest turns —
    *  surfaced as a distinct "full" state rather than a calm 100%. */
+  saturatedByProvider?: boolean;
+  /** Only the live current-turn/tool-output estimate reached the window. */
+  saturatedByEstimate?: boolean;
+  /** Back-compat alias for saturatedByProvider. */
   saturated?: boolean;
 }
 


### PR DESCRIPTION
## Summary
- split provider/persisted context usage from live current-turn/tool-output estimates
- render live estimate saturation as an estimated pending-turn state instead of authoritative ctx 100%
- add regression coverage for persisted usage below threshold plus large streamed bash output

Fixes #228.

## Validation
- bun run vitest run agent/context-usage.test.ts src/hooks/bridgeMessageHandlers/contextUsage.test.ts src/extensions/default-layout/layout/status-bar.test.tsx
- bun run typecheck
- bun run lint
- codex review --base origin/main --title "Peer review issue 228 context meter live estimate fix"