### PR TITLE
fix(worktrees): remove worktrees optimistically

### DIFF
--- a/src/extensions/default-layout/sidebar/menuItems.test.ts
+++ b/src/extensions/default-layout/sidebar/menuItems.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { canRenameWorktree } from "./menuItems";
+import { canRemoveWorktree, canRenameWorktree } from "./menuItems";
 import type { WorktreeSidebarItem } from "./worktree-row";
 
 function wt(
@@ -29,6 +29,23 @@ describe("canRenameWorktree", () => {
   it("rejects pending or failed worktrees", () => {
     expect(canRenameWorktree(wt({ pendingState: "queued" }))).toBe(false);
     expect(canRenameWorktree(wt({ pendingState: "starting" }))).toBe(false);
+    expect(canRenameWorktree(wt({ pendingState: "removing" }))).toBe(false);
     expect(canRenameWorktree(wt({ pendingState: "failed" }))).toBe(false);
+  });
+});
+
+describe("canRemoveWorktree", () => {
+  it("rejects missing, main, and pending worktrees", () => {
+    expect(canRemoveWorktree(undefined)).toBe(false);
+    expect(canRemoveWorktree(wt({ isMain: true }))).toBe(false);
+    expect(canRemoveWorktree(wt({ pendingState: "queued" }))).toBe(false);
+    expect(canRemoveWorktree(wt({ pendingState: "starting" }))).toBe(false);
+    expect(canRemoveWorktree(wt({ pendingState: "removing" }))).toBe(false);
+    expect(canRemoveWorktree(wt({ pendingState: "failed" }))).toBe(false);
+  });
+
+  it("allows removable live worktrees", () => {
+    expect(canRemoveWorktree(wt())).toBe(true);
+    expect(canRemoveWorktree(wt({ pendingState: "succeeded" }))).toBe(true);
   });
 });

--- a/src/extensions/default-layout/sidebar/menuItems.ts
+++ b/src/extensions/default-layout/sidebar/menuItems.ts
@@ -37,10 +37,20 @@ export interface SidebarContextMenuState {
   worktree?: WorktreeSidebarItem;
 }
 
-export function canRenameWorktree(item: WorktreeSidebarItem | undefined): boolean {
+export function canRenameWorktree(
+  item: WorktreeSidebarItem | undefined,
+): boolean {
   if (!item) return false;
   const pending = item.pendingState;
-  return pending !== "queued" && pending !== "starting" && pending !== "failed";
+  return !pending || pending === "succeeded";
+}
+
+export function canRemoveWorktree(
+  item: WorktreeSidebarItem | undefined,
+): boolean {
+  if (!item || item.isMain) return false;
+  const pending = item.pendingState;
+  return !pending || pending === "succeeded";
 }
 
 export interface SidebarMenuHandlers {
@@ -157,6 +167,7 @@ export function buildSidebarMenuItems(
       ];
     case "worktree": {
       const isMain = state.worktree?.isMain === true;
+      const canRemove = canRemoveWorktree(state.worktree);
       return [
         {
           id: "open-finder",
@@ -179,7 +190,7 @@ export function buildSidebarMenuItems(
           id: "remove-worktree",
           label: "Remove worktree",
           danger: true,
-          disabled: isMain,
+          disabled: !canRemove,
           onSelect: h.removeContextWorktree,
         },
         isMain

--- a/src/extensions/default-layout/sidebar/worktree-row.test.tsx
+++ b/src/extensions/default-layout/sidebar/worktree-row.test.tsx
@@ -81,6 +81,16 @@ describe("WorktreeRow", () => {
     expect(onEvent).not.toHaveBeenCalled();
   });
 
+  it("renders removing status without actions", () => {
+    const { onEvent } = harness(
+      wt({ pendingState: "removing", label: "wip" }),
+    );
+    expect(screen.getByText(/removing/i)).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /cancel/i })).toBeNull();
+    fireEvent.click(screen.getByText("wip").closest("li")!);
+    expect(onEvent).not.toHaveBeenCalled();
+  });
+
   it("renders retry + dismiss for failed pending entries", () => {
     const { onEvent } = harness(
       wt({ pendingState: "failed", pendingError: "boom", label: "wip" }),
@@ -301,6 +311,12 @@ describe("WorktreeRow", () => {
 
   it("does not enter rename mode for pending or failed rows", () => {
     harness(wt({ pendingState: "starting" }), { renaming: true });
+    expect(
+      screen.queryByRole("textbox", { name: /rename worktree/i }),
+    ).toBeNull();
+    cleanup();
+
+    harness(wt({ pendingState: "removing" }), { renaming: true });
     expect(
       screen.queryByRole("textbox", { name: /rename worktree/i }),
     ).toBeNull();

--- a/src/extensions/default-layout/sidebar/worktree-row.tsx
+++ b/src/extensions/default-layout/sidebar/worktree-row.tsx
@@ -7,10 +7,10 @@
  * The non-main rows therefore render *no* per-row glyph — the guide
  * does the work.
  *
- * Pending worktrees (during `git worktree add`) get a distinct visual
- * treatment + a small Cancel / Retry / Dismiss button cluster. Once
- * `git worktree add` resolves, the pending state clears and the row
- * joins the regular list.
+ * Pending worktrees (during `git worktree add` or remove) get a distinct
+ * visual treatment + a small Cancel / Retry / Dismiss button cluster. Once
+ * `git worktree add` resolves, the pending state clears and the row joins
+ * the regular list.
  */
 
 import { useEffect, useRef, useState } from "react";
@@ -26,7 +26,7 @@ export interface WorktreeSidebarItem {
   path: string;
   active: boolean;
   isMain: boolean;
-  pendingState?: "queued" | "starting" | "succeeded" | "failed";
+  pendingState?: "queued" | "starting" | "removing" | "succeeded" | "failed";
   pendingError?: string;
   locked?: boolean;
   /** Live agent-activity for this worktree's session scope. Only attached
@@ -64,7 +64,8 @@ export function WorktreeRow({
   const renameBlurCancelRef = useRef<number | null>(null);
   const renameUnmountCancelRef = useRef<number | null>(null);
   const pending = item.pendingState;
-  const isPendingActive = pending === "queued" || pending === "starting";
+  const isPendingActive =
+    pending === "queued" || pending === "starting" || pending === "removing";
   const isFailed = pending === "failed";
   const canRenameInline = renaming && !isPendingActive && !isFailed;
   const canRemoveInline =
@@ -242,22 +243,28 @@ export function WorktreeRow({
       ) : null}
       {isPendingActive ? (
         <span className="ae-worktree-pending-status">
-          {pending === "queued" ? "queued…" : "creating…"}
-          <button
-            type="button"
-            className="ae-worktree-action"
-            onClick={(e) => {
-              e.stopPropagation();
-              onEvent(
-                "cancel-pending-worktree",
-                { sectionId, worktreeId: item.id },
-                item.id,
-              );
-            }}
-            aria-label="Cancel"
-          >
-            ×
-          </button>
+          {pending === "queued"
+            ? "queued…"
+            : pending === "removing"
+              ? "removing…"
+              : "creating…"}
+          {pending !== "removing" ? (
+            <button
+              type="button"
+              className="ae-worktree-action"
+              onClick={(e) => {
+                e.stopPropagation();
+                onEvent(
+                  "cancel-pending-worktree",
+                  { sectionId, worktreeId: item.id },
+                  item.id,
+                );
+              }}
+              aria-label="Cancel"
+            >
+              ×
+            </button>
+          ) : null}
         </span>
       ) : null}
       {isFailed ? (

--- a/src/hooks/projectOps/worktreeOps/remove.ts
+++ b/src/hooks/projectOps/worktreeOps/remove.ts
@@ -1,10 +1,11 @@
 import type { MutableRefObject } from "react";
-import type { ProjectsState } from "../../../projects";
+import { setProjectWorktrees, type ProjectsState } from "../../../projects";
 import {
   gitWorktreeRemove,
   gitWorktreeRemoveOrphan,
+  removeWorktreeFromList,
+  type Worktree,
 } from "../../../worktrees";
-import { applyWorktreeRemoval } from "./state";
 import { closeTabsForRemovedWorktree } from "./tabCleanup";
 import type {
   ProjectLookups,
@@ -35,6 +36,7 @@ export async function removeWorktreeById(
   const hit = deps.lookups.findProjectOfWorktree(worktreeId);
   if (!hit) return;
   const { project, worktree } = hit;
+  if (worktree.pendingState === "removing") return;
   if (worktree.isMain) {
     deps.worktreePrompts.notifyCannotRemoveMain();
     return;
@@ -44,7 +46,32 @@ export async function removeWorktreeById(
     if (!(await deps.worktreePrompts.promptRemoveWorktree(label))) return;
   }
 
-  const applyRemoval = (): void => {
+  const originalList = [
+    ...(deps.projectsRef.current.worktreesByProject[project.id] ?? []),
+  ];
+  const originalWorktree: Worktree = { ...worktree };
+
+  const applyOptimisticRemoval = (): void => {
+    const next = (
+      deps.projectsRef.current.worktreesByProject[project.id] ?? []
+    ).map((w) =>
+      w.id === worktreeId
+        ? { ...w, pendingState: "removing" as const, pendingError: undefined }
+        : w,
+    );
+    deps.projectsRef.current = setProjectWorktrees(
+      deps.projectsRef.current,
+      project.id,
+      next,
+    );
+    deps.syncProjectsToState();
+  };
+
+  const finalizeRemoval = (): void => {
+    const projectStillExists = deps.projectsRef.current.projects.some(
+      (p) => p.id === project.id,
+    );
+    if (!projectStillExists) return;
     closeTabsForRemovedWorktree(
       deps.tabCleanupDeps,
       project.id,
@@ -52,55 +79,99 @@ export async function removeWorktreeById(
       worktree.path,
       deps.projectsRef.current.activeWorktreeId === worktreeId,
     );
-    applyWorktreeRemoval(
-      {
-        projectsRef: deps.projectsRef,
-        syncProjectsToState: deps.syncProjectsToState,
-        persistProjects: deps.persistProjects,
-      },
-      project.id,
+    const next = removeWorktreeFromList(
+      deps.projectsRef.current.worktreesByProject[project.id] ?? [],
       worktreeId,
     );
+    deps.projectsRef.current = setProjectWorktrees(
+      deps.projectsRef.current,
+      project.id,
+      next,
+    );
+    deps.syncProjectsToState();
+    void deps.persistProjects();
   };
 
-  try {
-    await gitWorktreeRemove({
-      projectPath: project.path,
-      worktreePath: worktree.path,
-      force: false,
-    });
-    applyRemoval();
-  } catch (err) {
-    const msg = String(err);
-    if (msg.includes("dirty") || msg.includes("modified")) {
-      if (!(await deps.worktreePrompts.promptForceRemove(msg))) return;
-      try {
-        await gitWorktreeRemove({
-          projectPath: project.path,
-          worktreePath: worktree.path,
-          force: true,
-        });
-        applyRemoval();
-        return;
-      } catch (e2) {
-        deps.worktreePrompts.notifyFailure(String(e2));
-        return;
+  const restoreRemoval = (): void => {
+    const projectStillExists = deps.projectsRef.current.projects.some(
+      (p) => p.id === project.id,
+    );
+    if (!projectStillExists) return;
+    const currentList =
+      deps.projectsRef.current.worktreesByProject[project.id] ?? [];
+    const existingIndex = currentList.findIndex((w) => w.id === worktreeId);
+    const next = [...currentList];
+    if (existingIndex >= 0) {
+      next[existingIndex] = originalWorktree;
+    } else {
+      const originalIndex = originalList.findIndex((w) => w.id === worktreeId);
+      if (originalIndex < 0 || originalIndex >= next.length) {
+        next.push(originalWorktree);
+      } else {
+        next.splice(originalIndex, 0, originalWorktree);
       }
     }
-    if (msg.includes("worktree not tracked")) {
-      if (!(await deps.worktreePrompts.promptOrphanCleanup())) return;
-      try {
-        await gitWorktreeRemoveOrphan({
-          projectPath: project.path,
-          worktreePath: worktree.path,
-        });
-        applyRemoval();
-        return;
-      } catch (e2) {
-        deps.worktreePrompts.notifyFailure(String(e2));
-        return;
+    deps.projectsRef.current = setProjectWorktrees(
+      deps.projectsRef.current,
+      project.id,
+      next,
+    );
+    deps.syncProjectsToState();
+    void deps.persistProjects();
+  };
+
+  const removeInBackground = async (): Promise<void> => {
+    try {
+      await gitWorktreeRemove({
+        projectPath: project.path,
+        worktreePath: worktree.path,
+        force: false,
+      });
+      finalizeRemoval();
+    } catch (err) {
+      const msg = String(err);
+      if (msg.includes("dirty") || msg.includes("modified")) {
+        if (!(await deps.worktreePrompts.promptForceRemove(msg))) {
+          restoreRemoval();
+          return;
+        }
+        try {
+          await gitWorktreeRemove({
+            projectPath: project.path,
+            worktreePath: worktree.path,
+            force: true,
+          });
+          finalizeRemoval();
+          return;
+        } catch (e2) {
+          deps.worktreePrompts.notifyFailure(String(e2));
+          restoreRemoval();
+          return;
+        }
       }
+      if (msg.includes("worktree not tracked")) {
+        if (!(await deps.worktreePrompts.promptOrphanCleanup())) {
+          restoreRemoval();
+          return;
+        }
+        try {
+          await gitWorktreeRemoveOrphan({
+            projectPath: project.path,
+            worktreePath: worktree.path,
+          });
+          finalizeRemoval();
+          return;
+        } catch (e2) {
+          deps.worktreePrompts.notifyFailure(String(e2));
+          restoreRemoval();
+          return;
+        }
+      }
+      deps.worktreePrompts.notifyFailure(msg);
+      restoreRemoval();
     }
-    deps.worktreePrompts.notifyFailure(msg);
-  }
+  };
+
+  applyOptimisticRemoval();
+  void removeInBackground();
 }

--- a/src/hooks/useProjectOps.test.ts
+++ b/src/hooks/useProjectOps.test.ts
@@ -57,6 +57,16 @@ function nonEmptyAgentTab(
   };
 }
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 function renderProjectOps(
   initialProjects: ProjectsState,
   overrides: Partial<UseProjectOpsContext> = {},
@@ -1131,18 +1141,203 @@ describe("useProjectOps worktree removal", () => {
       worktreePath: "/projects/aethon-fix-issue",
       force: false,
     });
-    expect(closeTabNow).toHaveBeenCalledWith("issue-tab");
+    await waitFor(() =>
+      expect(closeTabNow).toHaveBeenCalledWith("issue-tab"),
+    );
     expect(
       result.current.tabBucketsRef.current.has(
         projectScopeBucketKey("project-1", "wt-issue"),
       ),
     ).toBe(false);
     expect(projectsRef.current.activeWorktreeId).toBeNull();
+    await waitFor(() =>
+      expect(
+        projectsRef.current.worktreesByProject["project-1"]?.some(
+          (wt) => wt.id === "wt-issue",
+        ),
+      ).toBe(false),
+    );
+  });
+
+  it("marks the row as removing before a delayed git removal resolves", async () => {
+    const harness = installTauriMocks();
+    const removal = deferred<void>();
+    harness.invoke.mockImplementation((cmd: string) => {
+      if (cmd === "git_worktree_remove") return removal.promise;
+      return Promise.resolve(undefined);
+    });
+    const initial = makeProjectsState({
+      activeId: "project-1",
+      activeWorktreeId: "wt-issue",
+      worktreesByProject: {
+        "project-1": [
+          {
+            id: "wt-main",
+            projectId: "project-1",
+            path: "/projects/aethon",
+            branch: "main",
+            isMain: true,
+          },
+          {
+            id: "wt-issue",
+            projectId: "project-1",
+            path: "/projects/aethon-fix-issue",
+            branch: "fix/issue",
+            isMain: false,
+          },
+          {
+            id: "wt-other",
+            projectId: "project-1",
+            path: "/projects/aethon-other",
+            branch: "other",
+            isMain: false,
+          },
+        ],
+      },
+    });
+    const { result, projectsRef } = renderProjectOps(initial);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    projectsRef.current = initial;
+
+    await act(async () => {
+      await result.current.removeWorktreeById("wt-issue", { confirmed: true });
+    });
+
+    expect(harness.invoke).toHaveBeenCalledWith("git_worktree_remove", {
+      projectPath: "/projects/aethon",
+      worktreePath: "/projects/aethon-fix-issue",
+      force: false,
+    });
     expect(
-      projectsRef.current.worktreesByProject["project-1"]?.some(
+      projectsRef.current.worktreesByProject["project-1"]?.find(
         (wt) => wt.id === "wt-issue",
+      )?.pendingState,
+    ).toBe("removing");
+
+    await act(async () => {
+      await result.current.removeWorktreeById("wt-issue", { confirmed: true });
+    });
+    expect(
+      harness.invoke.mock.calls.filter(
+        ([cmd]) => cmd === "git_worktree_remove",
       ),
-    ).toBe(false);
+    ).toHaveLength(1);
+
+    projectsRef.current = {
+      ...projectsRef.current,
+      activeWorktreeId: "wt-other",
+    };
+
+    await act(async () => {
+      removal.resolve();
+      await removal.promise;
+    });
+    await waitFor(() =>
+      expect(
+        projectsRef.current.worktreesByProject["project-1"]?.some(
+          (wt) => wt.id === "wt-issue",
+        ),
+      ).toBe(false),
+    );
+    expect(projectsRef.current.activeWorktreeId).toBe("wt-other");
+  });
+
+  it("restores the row if dirty removal is not forced", async () => {
+    const harness = installTauriMocks();
+    harness.invoke.mockImplementation(
+      (cmd: string, args?: { force?: boolean }) => {
+        if (cmd === "git_worktree_remove" && args?.force === true) {
+          return Promise.resolve(undefined);
+        }
+        if (cmd === "git_worktree_remove") {
+          return Promise.reject(new Error("worktree contains modified files"));
+        }
+        return Promise.resolve(undefined);
+      },
+    );
+    const forcePrompt = deferred<boolean>();
+    const promptForceRemove = vi.fn(() => forcePrompt.promise);
+    const initial = makeProjectsState({
+      activeId: "project-1",
+      activeWorktreeId: "wt-issue",
+      worktreesByProject: {
+        "project-1": [
+          {
+            id: "wt-main",
+            projectId: "project-1",
+            path: "/projects/aethon",
+            branch: "main",
+            isMain: true,
+          },
+          {
+            id: "wt-issue",
+            projectId: "project-1",
+            path: "/projects/aethon-fix-issue",
+            branch: "fix/issue",
+            isMain: false,
+          },
+        ],
+      },
+    });
+    const { result, projectsRef, stateRef, closeTabNow } = renderProjectOps(
+      initial,
+      {
+        worktreePrompts: {
+          promptRemoveWorktree: vi.fn(() => Promise.resolve(true)),
+          promptForceRemove,
+          promptOrphanCleanup: vi.fn(() => Promise.resolve(true)),
+          notifyCannotRemoveMain: vi.fn(),
+          notifyFailure: vi.fn(),
+        },
+      },
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+    projectsRef.current = initial;
+    stateRef.current = {
+      activeTabId: "issue-tab",
+      tabs: [
+        {
+          ...makeEmptyTab("issue-tab", "Issue"),
+          messages: [],
+          projectId: "project-1",
+          cwd: "/projects/aethon-fix-issue",
+        },
+      ],
+    };
+
+    await act(async () => {
+      await result.current.removeWorktreeById("wt-issue", { confirmed: true });
+    });
+    await waitFor(() => expect(promptForceRemove).toHaveBeenCalledTimes(1));
+    expect(
+      projectsRef.current.worktreesByProject["project-1"]?.find(
+        (wt) => wt.id === "wt-issue",
+      )?.pendingState,
+    ).toBe("removing");
+    expect(projectsRef.current.activeWorktreeId).toBe("wt-issue");
+    expect(closeTabNow).not.toHaveBeenCalled();
+
+    await act(async () => {
+      forcePrompt.resolve(false);
+      await forcePrompt.promise;
+    });
+    expect(harness.invoke).not.toHaveBeenCalledWith(
+      "git_worktree_remove",
+      expect.objectContaining({ force: true }),
+    );
+    await waitFor(() =>
+      expect(
+        projectsRef.current.worktreesByProject["project-1"]?.some(
+          (wt) => wt.id === "wt-issue",
+        ),
+      ).toBe(true),
+    );
+    expect(projectsRef.current.activeWorktreeId).toBe("wt-issue");
+    expect(closeTabNow).not.toHaveBeenCalled();
   });
 
   it("falls through to the orphan command when git reports 'worktree not tracked'", async () => {
@@ -1185,17 +1380,21 @@ describe("useProjectOps worktree removal", () => {
     await act(async () => {
       await result.current.removeWorktreeById("wt-issue", { confirmed: true });
     });
-    expect(worktreePrompts.promptOrphanCleanup).toHaveBeenCalledTimes(1);
+    await waitFor(() =>
+      expect(worktreePrompts.promptOrphanCleanup).toHaveBeenCalledTimes(1),
+    );
     expect(harness.invoke).toHaveBeenCalledWith("git_worktree_remove_orphan", {
       projectPath: "/projects/aethon",
       worktreePath: "/projects/aethon-fix-issue",
     });
     expect(worktreePrompts.notifyFailure).not.toHaveBeenCalled();
-    expect(
-      projectsRef.current.worktreesByProject["project-1"]?.some(
-        (wt) => wt.id === "wt-issue",
-      ),
-    ).toBe(false);
+    await waitFor(() =>
+      expect(
+        projectsRef.current.worktreesByProject["project-1"]?.some(
+          (wt) => wt.id === "wt-issue",
+        ),
+      ).toBe(false),
+    );
   });
 
   it("aborts cleanly if the user declines the orphan confirmation", async () => {
@@ -1245,18 +1444,22 @@ describe("useProjectOps worktree removal", () => {
     await act(async () => {
       await result.current.removeWorktreeById("wt-issue", { confirmed: true });
     });
-    expect(worktreePrompts.promptOrphanCleanup).toHaveBeenCalledTimes(1);
+    await waitFor(() =>
+      expect(worktreePrompts.promptOrphanCleanup).toHaveBeenCalledTimes(1),
+    );
     expect(harness.invoke).not.toHaveBeenCalledWith(
       "git_worktree_remove_orphan",
       expect.anything(),
     );
     expect(worktreePrompts.notifyFailure).not.toHaveBeenCalled();
-    // Row remains visible so the user can try again later.
-    expect(
-      projectsRef.current.worktreesByProject["project-1"]?.some(
-        (wt) => wt.id === "wt-issue",
-      ),
-    ).toBe(true);
+    // Row is restored so the user can try again later.
+    await waitFor(() =>
+      expect(
+        projectsRef.current.worktreesByProject["project-1"]?.some(
+          (wt) => wt.id === "wt-issue",
+        ),
+      ).toBe(true),
+    );
   });
 
   it("alerts when the orphan command itself fails", async () => {
@@ -1297,10 +1500,12 @@ describe("useProjectOps worktree removal", () => {
     await act(async () => {
       await result.current.removeWorktreeById("wt-issue", { confirmed: true });
     });
-    expect(worktreePrompts.notifyFailure).toHaveBeenCalledWith(
-      "Error: trash: permission denied",
+    await waitFor(() =>
+      expect(worktreePrompts.notifyFailure).toHaveBeenCalledWith(
+        "Error: trash: permission denied",
+      ),
     );
-    // Row stays so a follow-up attempt is possible.
+    // Row is restored so a follow-up attempt is possible.
     expect(
       projectsRef.current.worktreesByProject["project-1"]?.some(
         (wt) => wt.id === "wt-issue",

--- a/src/worktrees.test.ts
+++ b/src/worktrees.test.ts
@@ -39,7 +39,7 @@ describe("reconcileWorktrees", () => {
     expect(next[0].head).toBe("abc");
   });
 
-  it("clears pendingState when the worktree appears in listing", () => {
+  it("clears creation pendingState when the worktree appears in listing", () => {
     const prior: Worktree[] = [
       wt({ id: "p", path: "/repo-feat", pendingState: "starting" }),
     ];
@@ -54,6 +54,25 @@ describe("reconcileWorktrees", () => {
     ]);
     expect(next).toHaveLength(1);
     expect(next[0].pendingState).toBeUndefined();
+  });
+
+  it("preserves removing state while git still lists the worktree", () => {
+    const prior: Worktree[] = [
+      wt({ id: "p", path: "/repo-feat", pendingState: "removing" }),
+    ];
+    const next = reconcileWorktrees("p1", prior, [
+      {
+        path: "/repo-feat",
+        branch: "feat",
+        head: "def",
+        isMain: false,
+        locked: false,
+      },
+    ]);
+    expect(next).toHaveLength(1);
+    expect(next[0].id).toBe("p");
+    expect(next[0].pendingState).toBe("removing");
+    expect(next[0].head).toBe("def");
   });
 
   it("drops in-flight pending rows that disappeared from listing", () => {
@@ -117,12 +136,13 @@ describe("updateWorktreePendingState", () => {
 });
 
 describe("worktreesForPersist", () => {
-  it("drops queued + starting pending rows", () => {
+  it("drops in-flight pending rows", () => {
     const list: Worktree[] = [
       wt({ id: "a" }),
       wt({ id: "b", pendingState: "queued" }),
       wt({ id: "c", pendingState: "starting" }),
       wt({ id: "d", pendingState: "failed" }),
+      wt({ id: "e", pendingState: "removing" }),
     ];
     const out = worktreesForPersist(list);
     expect(out.map((w) => w.id)).toEqual(["a", "d"]);

--- a/src/worktrees.ts
+++ b/src/worktrees.ts
@@ -18,16 +18,18 @@
 //     }
 //   }
 //
-// Pending worktrees (`pendingState in {queued, starting}`) are filtered
-// out at save time — they only live in memory while git is doing the
-// async `worktree add`. Failed worktrees stay until the user dismisses
-// them (the row carries Retry / Dismiss actions in the sidebar UI).
+// Pending worktrees (`pendingState in {queued, starting, removing}`) are
+// filtered out at save time — they only live in memory while git is doing
+// the async `worktree add` or `worktree remove`. Failed worktrees stay
+// until the user dismisses them (the row carries Retry / Dismiss actions
+// in the sidebar UI).
 
 import { invoke } from "@tauri-apps/api/core";
 
 export type WorktreePendingState =
   | "queued"
   | "starting"
+  | "removing"
   | "succeeded"
   | "failed";
 
@@ -71,8 +73,9 @@ export interface GitBranchInfo {
  * Reconcile a fresh `git_worktrees` listing against the in-memory store
  * for a single project. The on-disk listing wins for path / branch /
  * head / isMain; existing in-memory entries keep their id, label, and
- * pending state when paths match. Pending entries whose target path now
- * appears in the listing collapse into the matching live row.
+ * pending state when paths match. Creation-pending entries whose target
+ * path now appears in the listing collapse into the matching live row;
+ * removing entries stay pending until the background remove finalizes.
  */
 export function reconcileWorktrees(
   projectId: string,
@@ -86,23 +89,35 @@ export function reconcileWorktrees(
   const out: Worktree[] = [];
   for (const rec of listing) {
     const existing = byPath.get(rec.path);
-    out.push({
-      id: existing?.id ?? crypto.randomUUID(),
-      projectId,
-      path: rec.path,
-      branch: rec.branch,
-      isMain: rec.isMain,
-      head: rec.head ?? undefined,
-      locked: rec.locked || undefined,
-      label: existing?.label,
-      // Live row — pendingState always clears on reconcile.
-    });
+    if (existing?.pendingState === "removing") {
+      out.push({
+        ...existing,
+        projectId,
+        path: rec.path,
+        branch: rec.branch,
+        isMain: rec.isMain,
+        head: rec.head ?? undefined,
+        locked: rec.locked || undefined,
+      });
+    } else {
+      out.push({
+        id: existing?.id ?? crypto.randomUUID(),
+        projectId,
+        path: rec.path,
+        branch: rec.branch,
+        isMain: rec.isMain,
+        head: rec.head ?? undefined,
+        locked: rec.locked || undefined,
+        label: existing?.label,
+        // Live row — creation pendingState clears on reconcile.
+      });
+    }
     byPath.delete(rec.path);
   }
   // Preserve unresolved pending rows + any prior worktrees that didn't
   // surface this poll (rare: stale fs cache, external delete). We keep
   // failed pending entries so the user can Dismiss them; queued/starting
-  // entries are still in-flight on the bridge.
+  // and removing entries are still in-flight on the bridge.
   for (const w of byPath.values()) {
     if (w.pendingState && w.pendingState !== "succeeded") {
       out.push(w);


### PR DESCRIPTION
## Summary
- mark confirmed worktree removals as a disabled `removing…` state immediately
- run git removal, force removal, and orphan cleanup in the background
- finalize persisted/sidebar state on success and restore recoverable rows on failure or declined prompts
- prevent duplicate removal attempts while cleanup is pending

## Validation
- `bun run test`
- `bun run typecheck`
- targeted lint for touched files
- Codex peer review: no remaining findings

Closes #226
