### PR TITLE
Fix pointer-driven tab reordering

### DIFF
--- a/src/extensions/default-layout/shell/panel.test.tsx
+++ b/src/extensions/default-layout/shell/panel.test.tsx
@@ -11,15 +11,16 @@ vi.mock("../terminal", () => ({
   Terminal: () => <div data-testid="stub-terminal" />,
 }));
 vi.mock("./canvas", () => ({
-  ShellCanvas: ({
-    component,
-  }: {
-    component: { props: { tabId: string } };
-  }) => <div data-testid="stub-shell" data-tab-id={component.props.tabId} />,
+  ShellCanvas: ({ component }: { component: { props: { tabId: string } } }) => (
+    <div data-testid="stub-shell" data-tab-id={component.props.tabId} />
+  ),
 }));
 
 import { TerminalPanel } from "./panel";
-import { resolveActiveSubId, resolveActiveSubIdFromState } from "./panel-helpers";
+import {
+  resolveActiveSubId,
+  resolveActiveSubIdFromState,
+} from "./panel-helpers";
 
 afterEach(() => {
   cleanup();
@@ -88,9 +89,7 @@ describe("resolveActiveSubIdFromState", () => {
     // resolve the same shell the panel paints.
     const state = {
       activeTabId: "__overview__",
-      tabs: [
-        { id: "sh-1", kind: "shell", label: "Shell 1" },
-      ],
+      tabs: [{ id: "sh-1", kind: "shell", label: "Shell 1" }],
       terminalPanel: { activeSubId: "agent-bash" },
     } as Record<string, unknown>;
     expect(resolveActiveSubIdFromState(state)).toBe("sh-1");
@@ -99,9 +98,7 @@ describe("resolveActiveSubIdFromState", () => {
   it("treats a shell active id like overview instead of showing agent-bash", () => {
     const state = {
       activeTabId: "sh-1",
-      tabs: [
-        { id: "sh-1", kind: "shell", label: "Shell 1" },
-      ],
+      tabs: [{ id: "sh-1", kind: "shell", label: "Shell 1" }],
       terminalPanel: { activeSubId: "agent-bash" },
     } as Record<string, unknown>;
     expect(resolveActiveSubIdFromState(state)).toBe("sh-1");
@@ -116,16 +113,6 @@ describe("resolveActiveSubIdFromState", () => {
     expect(resolveActiveSubIdFromState(state)).toBe("agent-bash");
   });
 });
-
-function createDataTransfer() {
-  const values = new Map<string, string>();
-  return {
-    effectAllowed: "",
-    dropEffect: "",
-    setData: vi.fn((type: string, value: string) => values.set(type, value)),
-    getData: vi.fn((type: string) => values.get(type) ?? ""),
-  };
-}
 
 function setRect(element: Element, rect: Partial<DOMRect>) {
   vi.spyOn(element, "getBoundingClientRect").mockReturnValue({
@@ -276,11 +263,15 @@ describe("TerminalPanel", () => {
     const shell1 = screen.getByText("Shell 1").closest('[role="tab"]')!;
     const shell2 = screen.getByText("Shell 2").closest('[role="tab"]')!;
     setRect(shell1, { left: 0, width: 100 });
-    const dataTransfer = createDataTransfer();
 
-    fireEvent.dragStart(shell2, { dataTransfer });
-    fireEvent.dragOver(shell1, { clientX: 10, dataTransfer });
-    fireEvent.drop(shell1, { clientX: 10, dataTransfer });
+    fireEvent.pointerDown(shell2, { button: 0, clientX: 120, clientY: 8 });
+    fireEvent.pointerMove(document, { clientX: 10, clientY: 8 });
+
+    expect(shell2.className).toContain("ae-sub-tab-dragging");
+    expect(shell2.getAttribute("style")).toContain("--ae-tab-drag-x");
+    expect(shell1.className).toContain("ae-sub-tab-drop-before");
+
+    fireEvent.pointerUp(document, { clientX: 10, clientY: 8 });
 
     expect(onEvent).toHaveBeenCalledWith("reorder-sub-tab", {
       subTabId: "sh-2",
@@ -307,7 +298,9 @@ describe("TerminalPanel", () => {
     const shell = screen.getByText("Shell 1").closest('[role="tab"]')!;
 
     expect(agentBash.getAttribute("draggable")).toBe("false");
-    expect(shell.getAttribute("draggable")).toBe("true");
+    expect(agentBash.getAttribute("data-sub-tab-id")).toBeNull();
+    expect(shell.getAttribute("draggable")).toBe("false");
+    expect(shell.getAttribute("data-sub-tab-id")).toBe("sh-1");
   });
 
   it("always renders the + new-shell button", () => {

--- a/src/extensions/default-layout/shell/panel.test.tsx
+++ b/src/extensions/default-layout/shell/panel.test.tsx
@@ -279,6 +279,48 @@ describe("TerminalPanel", () => {
     });
   });
 
+  it("does not let drag click suppression leak into the next real sub-tab click", () => {
+    vi.useFakeTimers();
+    try {
+      const onEvent = vi.fn();
+      render(
+        <TerminalPanel
+          component={panelComponent()}
+          state={{
+            activeTabId: OVERVIEW_TAB_ID,
+            tabs: [
+              { id: "sh-1", kind: "shell", label: "Shell 1" },
+              { id: "sh-2", kind: "shell", label: "Shell 2" },
+            ],
+            terminalPanel: { activeSubId: "sh-1" },
+          }}
+          onEvent={onEvent}
+        />,
+      );
+      const shell1 = screen.getByText("Shell 1").closest('[role="tab"]')!;
+      const shell2 = screen.getByText("Shell 2").closest('[role="tab"]')!;
+      setRect(shell1, { left: 0, width: 100 });
+
+      fireEvent.pointerDown(shell2, { button: 0, clientX: 120, clientY: 8 });
+      fireEvent.pointerMove(document, { clientX: 10, clientY: 8 });
+      fireEvent.pointerUp(document, { clientX: 10, clientY: 8 });
+      expect(onEvent).toHaveBeenCalledWith("reorder-sub-tab", {
+        subTabId: "sh-2",
+        toIndex: 0,
+      });
+
+      onEvent.mockClear();
+      vi.runOnlyPendingTimers();
+      fireEvent.click(shell1);
+
+      expect(onEvent).toHaveBeenCalledWith("select-sub-tab", {
+        subTabId: "sh-1",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("keeps Agent bash pinned and only shell tabs draggable", () => {
     render(
       <TerminalPanel

--- a/src/extensions/default-layout/shell/panel.tsx
+++ b/src/extensions/default-layout/shell/panel.tsx
@@ -100,6 +100,7 @@ export function TerminalPanel({
     dragging: boolean;
   } | null>(null);
   const pointerCleanupRef = useRef<(() => void) | null>(null);
+  const suppressionClearTimerRef = useRef<number | null>(null);
   const suppressNextClickRef = useRef(false);
   // Resolve via the shared helper so the focus-aware Cmd+W path in
   // useKeyboardShortcuts sees the same active sub-tab the user does.
@@ -166,10 +167,24 @@ export function TerminalPanel({
     finishSubTabDrag();
   };
 
+  const clearSuppressionSoon = () => {
+    if (suppressionClearTimerRef.current !== null) {
+      window.clearTimeout(suppressionClearTimerRef.current);
+    }
+    suppressionClearTimerRef.current = window.setTimeout(() => {
+      suppressNextClickRef.current = false;
+      suppressionClearTimerRef.current = null;
+    }, 0);
+  };
+
   useEffect(
     () => () => {
       pointerCleanupRef.current?.();
       pointerCleanupRef.current = null;
+      if (suppressionClearTimerRef.current !== null) {
+        window.clearTimeout(suppressionClearTimerRef.current);
+        suppressionClearTimerRef.current = null;
+      }
     },
     [],
   );
@@ -223,6 +238,7 @@ export function TerminalPanel({
       pointerCleanupRef.current?.();
       pointerCleanupRef.current = null;
       pendingPointerDragRef.current = null;
+      if (wasDragging) clearSuppressionSoon();
       if (!wasDragging) finishSubTabDrag();
     };
 

--- a/src/extensions/default-layout/shell/panel.tsx
+++ b/src/extensions/default-layout/shell/panel.tsx
@@ -20,11 +20,15 @@
  *   ("reorder-sub-tab", { subTabId, toIndex }) drag an interactive shell tab
  */
 
-import { useMemo, useRef, useState, type DragEvent } from "react";
-import type {
-  BooleanValue,
-  NumberValue,
-} from "../../../types/a2ui";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
+import type { BooleanValue, NumberValue } from "../../../types/a2ui";
 import { resolveBoolean } from "../../../utils/dataBinding";
 import { activeTabKind, type Tab } from "../../../types/tab";
 import type { BuiltinComponentProps } from "../../../components/A2UIRenderer";
@@ -74,14 +78,29 @@ export function TerminalPanel({
   // pseudo-tab hides the agent-bash sub-tab (no agent session is
   // running) — fall through to the first interactive shell instead.
   const panelState =
-    (state["terminalPanel"] as { activeSubId?: string; height?: number } | undefined) ?? {};
+    (state["terminalPanel"] as
+      | { activeSubId?: string; height?: number }
+      | undefined) ?? {};
   const showAgentBash =
-    activeTabKind(tabs, state["activeTabId"] as string | undefined) ===
-    "agent";
+    activeTabKind(tabs, state["activeTabId"] as string | undefined) === "agent";
   const requestedActiveId = panelState.activeSubId ?? AGENT_BASH_SUB_ID;
   const panelRef = useRef<HTMLDivElement>(null);
+  const tabsRef = useRef<HTMLDivElement>(null);
   const [draggingSubTabId, setDraggingSubTabId] = useState<string | null>(null);
+  const [dropIndicator, setDropIndicator] = useState<{
+    subTabId: string;
+    side: "before" | "after";
+  } | null>(null);
+  const [dragOffsetX, setDragOffsetX] = useState(0);
   const draggedSubTabIdRef = useRef<string | null>(null);
+  const pendingPointerDragRef = useRef<{
+    subTabId: string;
+    startX: number;
+    startY: number;
+    dragging: boolean;
+  } | null>(null);
+  const pointerCleanupRef = useRef<(() => void) | null>(null);
+  const suppressNextClickRef = useRef(false);
   // Resolve via the shared helper so the focus-aware Cmd+W path in
   // useKeyboardShortcuts sees the same active sub-tab the user does.
   const activeSubId = useMemo<string | null>(
@@ -94,47 +113,125 @@ export function TerminalPanel({
     [requestedActiveId, shellTabs, showAgentBash],
   );
 
-  const dragPayloadType = "application/x-aethon-shell-sub-tab-id";
-  const startSubTabDrag = (
-    event: DragEvent<HTMLElement>,
-    subTab: ShellSubTabItem,
-  ) => {
-    if ((event.target as HTMLElement).closest(".ae-sub-tab-close")) {
-      event.preventDefault();
-      return;
-    }
-    draggedSubTabIdRef.current = subTab.id;
-    setDraggingSubTabId(subTab.id);
-    event.dataTransfer.effectAllowed = "move";
-    event.dataTransfer.setData(dragPayloadType, subTab.id);
-  };
-
   const finishSubTabDrag = () => {
     draggedSubTabIdRef.current = null;
     setDraggingSubTabId(null);
+    setDropIndicator(null);
+    setDragOffsetX(0);
   };
 
-  const getDraggedSubTabId = (event: DragEvent<HTMLElement>) =>
-    event.dataTransfer.getData(dragPayloadType) || draggedSubTabIdRef.current;
+  const subTabElementsForDrop = (root: HTMLElement, draggedSubTabId: string) =>
+    Array.from(
+      root.querySelectorAll<HTMLElement>(".ae-sub-tab[data-sub-tab-id]"),
+    ).filter((el) => el.dataset.subTabId !== draggedSubTabId);
 
-  const dropSubTabOnTarget = (
-    event: DragEvent<HTMLElement>,
-    target: ShellSubTabItem,
+  const insertionIndexForDrop = (
+    root: HTMLElement,
+    draggedSubTabId: string,
+    clientX: number,
   ) => {
-    const subTabId = getDraggedSubTabId(event);
-    if (!subTabId || subTabId === target.id) return;
-    event.preventDefault();
-    event.stopPropagation();
-    const remaining = shellTabs.filter((tab) => tab.id !== subTabId);
-    const targetIndex = remaining.findIndex((tab) => tab.id === target.id);
-    if (targetIndex < 0) return;
-    const rect = event.currentTarget.getBoundingClientRect();
-    const after = event.clientX > rect.left + rect.width / 2;
-    onEvent("reorder-sub-tab", {
-      subTabId,
-      toIndex: targetIndex + (after ? 1 : 0),
-    });
+    const subTabElements = subTabElementsForDrop(root, draggedSubTabId);
+    for (let index = 0; index < subTabElements.length; index += 1) {
+      const rect = subTabElements[index].getBoundingClientRect();
+      if (clientX < rect.left + rect.width / 2) return index;
+    }
+    return subTabElements.length;
+  };
+
+  const showDropIndicator = (
+    root: HTMLElement,
+    draggedSubTabId: string,
+    clientX: number,
+  ) => {
+    const subTabElements = subTabElementsForDrop(root, draggedSubTabId);
+    if (subTabElements.length === 0) {
+      setDropIndicator(null);
+      return;
+    }
+    for (let index = 0; index < subTabElements.length; index += 1) {
+      const el = subTabElements[index];
+      const rect = el.getBoundingClientRect();
+      if (clientX < rect.left + rect.width / 2) {
+        const subTabId = el.dataset.subTabId;
+        if (subTabId) setDropIndicator({ subTabId, side: "before" });
+        return;
+      }
+    }
+    const subTabId = subTabElements[subTabElements.length - 1].dataset.subTabId;
+    if (subTabId) setDropIndicator({ subTabId, side: "after" });
+  };
+
+  const emitSubTabReorder = (subTabId: string, toIndex: number) => {
+    onEvent("reorder-sub-tab", { subTabId, toIndex });
     finishSubTabDrag();
+  };
+
+  useEffect(
+    () => () => {
+      pointerCleanupRef.current?.();
+      pointerCleanupRef.current = null;
+    },
+    [],
+  );
+
+  const startPointerDrag = (
+    event: ReactPointerEvent<HTMLElement>,
+    subTab: ShellSubTabItem,
+  ) => {
+    if (event.button !== 0) return;
+    if ((event.target as HTMLElement).closest(".ae-sub-tab-close")) return;
+
+    pointerCleanupRef.current?.();
+    pendingPointerDragRef.current = {
+      subTabId: subTab.id,
+      startX: event.clientX,
+      startY: event.clientY,
+      dragging: false,
+    };
+
+    const onMove = (moveEvent: PointerEvent) => {
+      const pending = pendingPointerDragRef.current;
+      const root = tabsRef.current;
+      if (!pending || !root) return;
+      const dx = moveEvent.clientX - pending.startX;
+      const dy = moveEvent.clientY - pending.startY;
+      if (!pending.dragging && Math.hypot(dx, dy) < 4) return;
+      if (!pending.dragging) {
+        pending.dragging = true;
+        suppressNextClickRef.current = true;
+        draggedSubTabIdRef.current = pending.subTabId;
+        setDraggingSubTabId(pending.subTabId);
+      }
+      moveEvent.preventDefault();
+      setDragOffsetX(dx);
+      showDropIndicator(root, pending.subTabId, moveEvent.clientX);
+    };
+
+    const onUp = (upEvent: PointerEvent) => {
+      const pending = pendingPointerDragRef.current;
+      const root = tabsRef.current;
+      const wasDragging = pending?.dragging;
+      if (pending && root && wasDragging) {
+        upEvent.preventDefault();
+        const toIndex = insertionIndexForDrop(
+          root,
+          pending.subTabId,
+          upEvent.clientX,
+        );
+        emitSubTabReorder(pending.subTabId, toIndex);
+      }
+      pointerCleanupRef.current?.();
+      pointerCleanupRef.current = null;
+      pendingPointerDragRef.current = null;
+      if (!wasDragging) finishSubTabDrag();
+    };
+
+    document.addEventListener("pointermove", onMove);
+    document.addEventListener("pointerup", onUp, { once: true });
+    pointerCleanupRef.current = () => {
+      document.removeEventListener("pointermove", onMove);
+      document.removeEventListener("pointerup", onUp);
+    };
   };
 
   const onResizeStart = (e: React.MouseEvent) => {
@@ -165,9 +262,7 @@ export function TerminalPanel({
   return (
     <div
       ref={panelRef}
-      className={
-        visible ? "ae-terminal-panel" : "ae-terminal-panel is-closed"
-      }
+      className={visible ? "ae-terminal-panel" : "ae-terminal-panel is-closed"}
       aria-hidden={!visible}
       style={{ gridArea: "terminal", height: "100%" }}
     >
@@ -178,7 +273,16 @@ export function TerminalPanel({
         aria-label="Resize terminal panel"
         onMouseDown={onResizeStart}
       />
-      <div className="ae-terminal-panel-tabs" role="tablist">
+      <div
+        ref={tabsRef}
+        className={[
+          "ae-terminal-panel-tabs",
+          draggingSubTabId ? "ae-terminal-panel-tabs-dragging" : "",
+        ]
+          .filter(Boolean)
+          .join(" ")}
+        role="tablist"
+      >
         {showAgentBash && (
           <SubTabPill
             id={AGENT_BASH_SUB_ID}
@@ -199,17 +303,18 @@ export function TerminalPanel({
             active={activeSubId === s.id}
             closable
             dragging={draggingSubTabId === s.id}
+            dragOffsetX={draggingSubTabId === s.id ? dragOffsetX : undefined}
+            dropSide={
+              dropIndicator?.subTabId === s.id ? dropIndicator.side : undefined
+            }
             onSelect={() => onEvent("select-sub-tab", { subTabId: s.id })}
             onClose={() => onEvent("close-sub-tab", { subTabId: s.id })}
-            onDragStart={(e) => startSubTabDrag(e, s)}
-            onDragOver={(e) => {
-              const subTabId = draggedSubTabIdRef.current;
-              if (!subTabId || subTabId === s.id) return;
-              e.preventDefault();
-              e.dataTransfer.dropEffect = "move";
+            shouldSuppressClick={() => {
+              if (!suppressNextClickRef.current) return false;
+              suppressNextClickRef.current = false;
+              return true;
             }}
-            onDrop={(e) => dropSubTabOnTarget(e, s)}
-            onDragEnd={finishSubTabDrag}
+            onPointerDown={(e) => startPointerDrag(e, s)}
           />
         ))}
         <button
@@ -267,25 +372,26 @@ function SubTabPill(props: {
   active: boolean;
   closable?: boolean;
   dragging?: boolean;
+  dragOffsetX?: number;
+  dropSide?: "before" | "after";
   onSelect: () => void;
   onClose?: () => void;
-  onDragStart?: (event: DragEvent<HTMLElement>) => void;
-  onDragOver?: (event: DragEvent<HTMLElement>) => void;
-  onDrop?: (event: DragEvent<HTMLElement>) => void;
-  onDragEnd?: () => void;
+  shouldSuppressClick?: () => boolean;
+  onPointerDown?: (event: ReactPointerEvent<HTMLElement>) => void;
 }) {
   const {
+    id,
     label,
     hint,
     active,
     closable,
     dragging,
+    dragOffsetX,
+    dropSide,
     onSelect,
     onClose,
-    onDragStart,
-    onDragOver,
-    onDrop,
-    onDragEnd,
+    shouldSuppressClick,
+    onPointerDown,
   } = props;
   return (
     <div
@@ -295,17 +401,31 @@ function SubTabPill(props: {
         "ae-sub-tab",
         active ? "ae-sub-tab-active" : "",
         dragging ? "ae-sub-tab-dragging" : "",
+        dropSide ? `ae-sub-tab-drop-${dropSide}` : "",
       ]
         .filter(Boolean)
         .join(" ")}
-      draggable={!!onDragStart}
-      onDragStart={onDragStart}
-      onDragOver={onDragOver}
-      onDrop={onDrop}
-      onDragEnd={onDragEnd}
+      data-sub-tab-id={onPointerDown ? id : undefined}
+      draggable={false}
+      style={
+        dragging && typeof dragOffsetX === "number"
+          ? ({ "--ae-tab-drag-x": `${dragOffsetX}px` } as CSSProperties)
+          : undefined
+      }
+      onPointerDown={onPointerDown}
       onMouseDown={(e) => {
         if ((e.target as HTMLElement).closest(".ae-sub-tab-close")) {
           e.preventDefault();
+          return;
+        }
+      }}
+      onClick={(e) => {
+        if (shouldSuppressClick?.()) {
+          e.preventDefault();
+          e.stopPropagation();
+          return;
+        }
+        if ((e.target as HTMLElement).closest(".ae-sub-tab-close")) {
           return;
         }
         onSelect();

--- a/src/extensions/default-layout/shell/tab-strip.test.tsx
+++ b/src/extensions/default-layout/shell/tab-strip.test.tsx
@@ -24,16 +24,6 @@ function tabStripComponent(): A2UIComponent {
   };
 }
 
-function createDataTransfer() {
-  const values = new Map<string, string>();
-  return {
-    effectAllowed: "",
-    dropEffect: "",
-    setData: vi.fn((type: string, value: string) => values.set(type, value)),
-    getData: vi.fn((type: string) => values.get(type) ?? ""),
-  };
-}
-
 function setRect(element: Element, rect: Partial<DOMRect>) {
   vi.spyOn(element, "getBoundingClientRect").mockReturnValue({
     left: rect.left ?? 0,
@@ -323,11 +313,15 @@ describe("TabStrip", () => {
     const chat = screen.getByText("Chat").closest('[role="tab"]')!;
     const editor = screen.getByText("App.tsx").closest('[role="tab"]')!;
     setRect(chat, { left: 0, width: 100 });
-    const dataTransfer = createDataTransfer();
 
-    fireEvent.dragStart(editor, { dataTransfer });
-    fireEvent.dragOver(chat, { clientX: 10, dataTransfer });
-    fireEvent.drop(chat, { clientX: 10, dataTransfer });
+    fireEvent.pointerDown(editor, { button: 0, clientX: 120, clientY: 8 });
+    fireEvent.pointerMove(document, { clientX: 10, clientY: 8 });
+
+    expect(editor.className).toContain("a2ui-tab-dragging");
+    expect(editor.getAttribute("style")).toContain("--ae-tab-drag-x");
+    expect(chat.className).toContain("a2ui-tab-drop-before");
+
+    fireEvent.pointerUp(document, { clientX: 10, clientY: 8 });
 
     expect(onEvent).toHaveBeenCalledWith("reorder", {
       tabId: "ed-1",
@@ -343,9 +337,12 @@ describe("TabStrip", () => {
     const realTab = screen.getByText("Tab 1").closest('[role="tab"]')!;
     const newButton = screen.getByRole("button", { name: "New Tab" });
 
-    expect(realTab.getAttribute("draggable")).toBe("true");
+    expect(realTab.getAttribute("draggable")).toBe("false");
+    expect(realTab.getAttribute("data-tab-id")).toBe("tab-1");
     expect(overviewPill.getAttribute("draggable")).not.toBe("true");
+    expect(overviewPill.getAttribute("data-tab-id")).toBeNull();
     expect(newButton.getAttribute("draggable")).not.toBe("true");
+    expect(newButton.getAttribute("data-tab-id")).toBeNull();
   });
 
   it("renders a file-type icon for editor tabs but not agent tabs", () => {

--- a/src/extensions/default-layout/shell/tab-strip.test.tsx
+++ b/src/extensions/default-layout/shell/tab-strip.test.tsx
@@ -329,6 +329,50 @@ describe("TabStrip", () => {
     });
   });
 
+  it("does not let drag click suppression leak into the next real tab click", () => {
+    vi.useFakeTimers();
+    try {
+      const onEvent = vi.fn<TabStripOnEvent>();
+      render(
+        <TabStrip
+          component={tabStripComponent()}
+          state={{
+            activeTabId: "ag-1",
+            tabs: [
+              { id: "ag-1", label: "Chat", kind: "agent" },
+              {
+                id: "ed-1",
+                label: "App.tsx",
+                kind: "editor",
+                editor: { filePath: "/repo/App.tsx" },
+              },
+            ],
+          }}
+          onEvent={onEvent}
+        />,
+      );
+      const chat = screen.getByText("Chat").closest('[role="tab"]')!;
+      const editor = screen.getByText("App.tsx").closest('[role="tab"]')!;
+      setRect(chat, { left: 0, width: 100 });
+
+      fireEvent.pointerDown(editor, { button: 0, clientX: 120, clientY: 8 });
+      fireEvent.pointerMove(document, { clientX: 10, clientY: 8 });
+      fireEvent.pointerUp(document, { clientX: 10, clientY: 8 });
+      expect(onEvent).toHaveBeenCalledWith("reorder", {
+        tabId: "ed-1",
+        toIndex: 0,
+      });
+
+      onEvent.mockClear();
+      vi.runOnlyPendingTimers();
+      fireEvent.click(chat);
+
+      expect(onEvent).toHaveBeenCalledWith("select", { tabId: "ag-1" });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("keeps the overview and new-tab controls out of drag reordering", () => {
     renderTabStrip();
     const overviewPill = screen

--- a/src/extensions/default-layout/shell/tab-strip.tsx
+++ b/src/extensions/default-layout/shell/tab-strip.tsx
@@ -24,9 +24,10 @@ import {
   useMemo,
   useRef,
   useState,
-  type DragEvent,
+  type CSSProperties,
   type KeyboardEvent,
   type MouseEvent,
+  type PointerEvent as ReactPointerEvent,
 } from "react";
 import type { StringValue } from "../../../types/a2ui";
 import { OVERVIEW_TAB_ID } from "../../../types/tab";
@@ -93,7 +94,21 @@ export function TabStrip({ component, state, onEvent }: BuiltinComponentProps) {
     value: string;
   } | null>(null);
   const [draggingTabId, setDraggingTabId] = useState<string | null>(null);
+  const [dropIndicator, setDropIndicator] = useState<{
+    tabId: string;
+    side: "before" | "after";
+  } | null>(null);
+  const [dragOffsetX, setDragOffsetX] = useState(0);
+  const stripRef = useRef<HTMLDivElement | null>(null);
   const draggedTabIdRef = useRef<string | null>(null);
+  const pendingPointerDragRef = useRef<{
+    tabId: string;
+    startX: number;
+    startY: number;
+    dragging: boolean;
+  } | null>(null);
+  const pointerCleanupRef = useRef<(() => void) | null>(null);
+  const suppressNextClickRef = useRef(false);
   const renameInputRef = useRef<HTMLInputElement | null>(null);
   const renameEndingRef = useRef(false);
   const renamingTabId = renamingTab?.id;
@@ -155,49 +170,131 @@ export function TabStrip({ component, state, onEvent }: BuiltinComponentProps) {
   const projectPath =
     (state["project"] as { path?: string } | undefined)?.path ?? "";
 
-  const dragPayloadType = "application/x-aethon-tab-id";
-  const startTabDrag = (event: DragEvent<HTMLElement>, tab: TabStripItem) => {
+  const finishTabDrag = () => {
+    draggedTabIdRef.current = null;
+    setDraggingTabId(null);
+    setDropIndicator(null);
+    setDragOffsetX(0);
+  };
+
+  const tabElementsForDrop = (root: HTMLElement, draggedTabId: string) =>
+    Array.from(
+      root.querySelectorAll<HTMLElement>(".a2ui-tab[data-tab-id]"),
+    ).filter((el) => el.dataset.tabId !== draggedTabId);
+
+  const insertionIndexForDrop = (
+    root: HTMLElement,
+    draggedTabId: string,
+    clientX: number,
+  ) => {
+    const tabElements = tabElementsForDrop(root, draggedTabId);
+    for (let index = 0; index < tabElements.length; index += 1) {
+      const rect = tabElements[index].getBoundingClientRect();
+      if (clientX < rect.left + rect.width / 2) return index;
+    }
+    return tabElements.length;
+  };
+
+  const showDropIndicator = (
+    root: HTMLElement,
+    draggedTabId: string,
+    clientX: number,
+  ) => {
+    const tabElements = tabElementsForDrop(root, draggedTabId);
+    if (tabElements.length === 0) {
+      setDropIndicator(null);
+      return;
+    }
+    for (let index = 0; index < tabElements.length; index += 1) {
+      const el = tabElements[index];
+      const rect = el.getBoundingClientRect();
+      if (clientX < rect.left + rect.width / 2) {
+        const tabId = el.dataset.tabId;
+        if (tabId) setDropIndicator({ tabId, side: "before" });
+        return;
+      }
+    }
+    const tabId = tabElements[tabElements.length - 1].dataset.tabId;
+    if (tabId) setDropIndicator({ tabId, side: "after" });
+  };
+
+  const emitReorder = (tabId: string, toIndex: number) => {
+    onEvent("reorder", { tabId, toIndex });
+    finishTabDrag();
+  };
+
+  useEffect(
+    () => () => {
+      pointerCleanupRef.current?.();
+      pointerCleanupRef.current = null;
+    },
+    [],
+  );
+
+  const startPointerDrag = (
+    event: ReactPointerEvent<HTMLElement>,
+    tab: TabStripItem,
+  ) => {
+    if (event.button !== 0) return;
     const target = event.target as HTMLElement;
     if (
       renamingTab?.id === tab.id ||
       target.closest(".a2ui-tab-close") ||
       target.closest(".ae-tab-rename-input")
     ) {
-      event.preventDefault();
       return;
     }
-    draggedTabIdRef.current = tab.id;
-    setDraggingTabId(tab.id);
-    event.dataTransfer.effectAllowed = "move";
-    event.dataTransfer.setData(dragPayloadType, tab.id);
-  };
+    pointerCleanupRef.current?.();
+    pendingPointerDragRef.current = {
+      tabId: tab.id,
+      startX: event.clientX,
+      startY: event.clientY,
+      dragging: false,
+    };
 
-  const finishTabDrag = () => {
-    draggedTabIdRef.current = null;
-    setDraggingTabId(null);
-  };
+    const onMove = (moveEvent: PointerEvent) => {
+      const pending = pendingPointerDragRef.current;
+      const root = stripRef.current;
+      if (!pending || !root) return;
+      const dx = moveEvent.clientX - pending.startX;
+      const dy = moveEvent.clientY - pending.startY;
+      if (!pending.dragging && Math.hypot(dx, dy) < 4) return;
+      if (!pending.dragging) {
+        pending.dragging = true;
+        suppressNextClickRef.current = true;
+        draggedTabIdRef.current = pending.tabId;
+        setDraggingTabId(pending.tabId);
+      }
+      moveEvent.preventDefault();
+      setDragOffsetX(dx);
+      showDropIndicator(root, pending.tabId, moveEvent.clientX);
+    };
 
-  const getDraggedTabId = (event: DragEvent<HTMLElement>) =>
-    event.dataTransfer.getData(dragPayloadType) || draggedTabIdRef.current;
+    const onUp = (upEvent: PointerEvent) => {
+      const pending = pendingPointerDragRef.current;
+      const root = stripRef.current;
+      const wasDragging = pending?.dragging;
+      if (pending && root && wasDragging) {
+        upEvent.preventDefault();
+        const toIndex = insertionIndexForDrop(
+          root,
+          pending.tabId,
+          upEvent.clientX,
+        );
+        emitReorder(pending.tabId, toIndex);
+      }
+      pointerCleanupRef.current?.();
+      pointerCleanupRef.current = null;
+      pendingPointerDragRef.current = null;
+      if (!wasDragging) finishTabDrag();
+    };
 
-  const dropTabOnTarget = (
-    event: DragEvent<HTMLElement>,
-    target: TabStripItem,
-  ) => {
-    const tabId = getDraggedTabId(event);
-    if (!tabId || tabId === target.id) return;
-    event.preventDefault();
-    event.stopPropagation();
-    const remaining = tabs.filter((tab) => tab.id !== tabId);
-    const targetIndex = remaining.findIndex((tab) => tab.id === target.id);
-    if (targetIndex < 0) return;
-    const rect = event.currentTarget.getBoundingClientRect();
-    const after = event.clientX > rect.left + rect.width / 2;
-    onEvent("reorder", {
-      tabId,
-      toIndex: targetIndex + (after ? 1 : 0),
-    });
-    finishTabDrag();
+    document.addEventListener("pointermove", onMove);
+    document.addEventListener("pointerup", onUp, { once: true });
+    pointerCleanupRef.current = () => {
+      document.removeEventListener("pointermove", onMove);
+      document.removeEventListener("pointerup", onUp);
+    };
   };
 
   const buildMenuItems = (): ContextMenuItem[] => {
@@ -302,7 +399,16 @@ export function TabStrip({ component, state, onEvent }: BuiltinComponentProps) {
     activeId === OVERVIEW_TAB_ID ||
     !tabs.some((t) => t.id === activeId);
   return (
-    <div className="a2ui-tab-strip" role="tablist">
+    <div
+      ref={stripRef}
+      className={[
+        "a2ui-tab-strip",
+        draggingTabId ? "a2ui-tab-strip-dragging" : "",
+      ]
+        .filter(Boolean)
+        .join(" ")}
+      role="tablist"
+    >
       <button
         type="button"
         role="tab"
@@ -341,29 +447,41 @@ export function TabStrip({ component, state, onEvent }: BuiltinComponentProps) {
               "a2ui-tab",
               isActive ? "a2ui-tab-active" : "",
               draggingTabId === t.id ? "a2ui-tab-dragging" : "",
+              dropIndicator?.tabId === t.id
+                ? `a2ui-tab-drop-${dropIndicator.side}`
+                : "",
             ]
               .filter(Boolean)
               .join(" ")}
-            draggable={renamingTab?.id !== t.id}
-            onDragStart={(e) => startTabDrag(e, t)}
-            onDragOver={(e) => {
-              const tabId = draggedTabIdRef.current;
-              if (!tabId || tabId === t.id) return;
-              e.preventDefault();
-              e.dataTransfer.dropEffect = "move";
-            }}
-            onDrop={(e) => dropTabOnTarget(e, t)}
-            onDragEnd={finishTabDrag}
+            data-tab-id={t.id}
+            draggable={false}
+            style={
+              draggingTabId === t.id
+                ? ({ "--ae-tab-drag-x": `${dragOffsetX}px` } as CSSProperties)
+                : undefined
+            }
+            onPointerDown={(e) => startPointerDrag(e, t)}
             onMouseDown={(e) => {
-              // mousedown not click so selecting feels immediate, but do
-              // not preventDefault here: native draggable tabs need the
-              // browser's default mouse gesture to fire dragstart.
               if (e.button !== 0) return;
               if (
                 (e.target as HTMLElement).closest(".a2ui-tab-close") ||
                 (e.target as HTMLElement).closest(".ae-tab-rename-input")
               ) {
                 e.preventDefault();
+                return;
+              }
+            }}
+            onClick={(e) => {
+              if (suppressNextClickRef.current) {
+                suppressNextClickRef.current = false;
+                e.preventDefault();
+                e.stopPropagation();
+                return;
+              }
+              if (
+                (e.target as HTMLElement).closest(".a2ui-tab-close") ||
+                (e.target as HTMLElement).closest(".ae-tab-rename-input")
+              ) {
                 return;
               }
               onEvent("select", { tabId: t.id });

--- a/src/extensions/default-layout/shell/tab-strip.tsx
+++ b/src/extensions/default-layout/shell/tab-strip.tsx
@@ -108,6 +108,7 @@ export function TabStrip({ component, state, onEvent }: BuiltinComponentProps) {
     dragging: boolean;
   } | null>(null);
   const pointerCleanupRef = useRef<(() => void) | null>(null);
+  const suppressionClearTimerRef = useRef<number | null>(null);
   const suppressNextClickRef = useRef(false);
   const renameInputRef = useRef<HTMLInputElement | null>(null);
   const renameEndingRef = useRef(false);
@@ -223,10 +224,24 @@ export function TabStrip({ component, state, onEvent }: BuiltinComponentProps) {
     finishTabDrag();
   };
 
+  const clearSuppressionSoon = () => {
+    if (suppressionClearTimerRef.current !== null) {
+      window.clearTimeout(suppressionClearTimerRef.current);
+    }
+    suppressionClearTimerRef.current = window.setTimeout(() => {
+      suppressNextClickRef.current = false;
+      suppressionClearTimerRef.current = null;
+    }, 0);
+  };
+
   useEffect(
     () => () => {
       pointerCleanupRef.current?.();
       pointerCleanupRef.current = null;
+      if (suppressionClearTimerRef.current !== null) {
+        window.clearTimeout(suppressionClearTimerRef.current);
+        suppressionClearTimerRef.current = null;
+      }
     },
     [],
   );
@@ -286,6 +301,7 @@ export function TabStrip({ component, state, onEvent }: BuiltinComponentProps) {
       pointerCleanupRef.current?.();
       pointerCleanupRef.current = null;
       pendingPointerDragRef.current = null;
+      if (wasDragging) clearSuppressionSoon();
       if (!wasDragging) finishTabDrag();
     };
 

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -4448,6 +4448,12 @@ body.ae-resizing-composer * {
   min-width: 0;
   flex: 1 1 auto;
 }
+
+.a2ui-tab-strip-dragging,
+.a2ui-tab-strip-dragging .a2ui-tab {
+  cursor: grabbing;
+}
+
 .a2ui-tab-strip::-webkit-scrollbar {
   /* WebKit (the only browser engine the Tauri webview uses on macOS,
      and one of the engines on Linux) needs an explicit zero-size rule
@@ -4481,7 +4487,10 @@ body.ae-resizing-composer * {
   flex: 0 1 13rem;
   transition:
     color 120ms var(--ease-out, ease),
-    background-color 120ms var(--ease-out, ease);
+    background-color 120ms var(--ease-out, ease),
+    opacity 120ms var(--ease-out, ease),
+    box-shadow 120ms var(--ease-out, ease),
+    transform 120ms var(--ease-out, ease);
 }
 
 /* Underline marker — sits flush with the strip's bottom border so a
@@ -4511,7 +4520,20 @@ body.ae-resizing-composer * {
 }
 
 .a2ui-tab-dragging {
-  opacity: 0.62;
+  z-index: var(--z-elevated);
+  color: var(--text);
+  background: var(--bg-active);
+  opacity: 0.94;
+  transform: translate3d(var(--ae-tab-drag-x, 0px), -2px, 0);
+  box-shadow:
+    0 0 0 1px var(--border-hover),
+    var(--shadow-2);
+  transition:
+    color 120ms var(--ease-out, ease),
+    background-color 120ms var(--ease-out, ease),
+    opacity 120ms var(--ease-out, ease),
+    box-shadow 120ms var(--ease-out, ease),
+    transform 0ms linear;
 }
 
 .a2ui-tab-active {
@@ -4534,6 +4556,33 @@ body.ae-resizing-composer * {
   background: var(--accent);
   margin-right: 4px;
   flex-shrink: 0;
+}
+
+.a2ui-tab-drop-before,
+.a2ui-tab-drop-after {
+  background: var(--accent-hover-tint);
+}
+
+.a2ui-tab-drop-before::before,
+.a2ui-tab-drop-after::before {
+  content: "";
+  position: absolute;
+  top: 7px;
+  bottom: 7px;
+  width: 3px;
+  border-radius: var(--radius-pill);
+  background: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+  pointer-events: none;
+  z-index: 1;
+}
+
+.a2ui-tab-drop-before::before {
+  left: -2px;
+}
+
+.a2ui-tab-drop-after::before {
+  right: -2px;
 }
 
 /* Live busy dot — a subtly pulsing accent dot when a tab is mid-prompt.
@@ -5241,6 +5290,12 @@ body.ae-resizing-terminal * {
   overflow-x: auto;
   scrollbar-width: thin;
 }
+
+.ae-terminal-panel-tabs-dragging,
+.ae-terminal-panel-tabs-dragging .ae-sub-tab {
+  cursor: grabbing;
+}
+
 .ae-sub-tab {
   display: inline-flex;
   align-items: center;
@@ -5256,6 +5311,14 @@ body.ae-resizing-terminal * {
   white-space: nowrap;
   user-select: none;
   margin-top: 2px;
+  position: relative;
+  transition:
+    color var(--motion-fast) var(--ease-out),
+    background var(--motion-fast) var(--ease-out),
+    border-color var(--motion-fast) var(--ease-out),
+    opacity var(--motion-fast) var(--ease-out),
+    box-shadow var(--motion-fast) var(--ease-out),
+    transform var(--motion-fast) var(--ease-out);
 }
 .ae-sub-tab:hover {
   background: color-mix(in oklab, var(--accent) 8%, transparent);
@@ -5263,11 +5326,49 @@ body.ae-resizing-terminal * {
 .ae-sub-tab:active {
   cursor: grabbing;
 }
-.ae-sub-tab[draggable="false"] {
+.ae-sub-tab:not([data-sub-tab-id]) {
   cursor: pointer;
 }
 .ae-sub-tab-dragging {
-  opacity: 0.62;
+  z-index: var(--z-elevated);
+  color: var(--text);
+  background: var(--bg-active);
+  border-color: var(--border-hover);
+  opacity: 0.95;
+  transform: translate3d(var(--ae-tab-drag-x, 0px), -2px, 0);
+  box-shadow:
+    0 0 0 1px var(--border-hover),
+    var(--shadow-2);
+  transition:
+    color var(--motion-fast) var(--ease-out),
+    background var(--motion-fast) var(--ease-out),
+    border-color var(--motion-fast) var(--ease-out),
+    opacity var(--motion-fast) var(--ease-out),
+    box-shadow var(--motion-fast) var(--ease-out),
+    transform 0ms linear;
+}
+.ae-sub-tab-drop-before,
+.ae-sub-tab-drop-after {
+  background: var(--accent-hover-tint);
+}
+.ae-sub-tab-drop-before::before,
+.ae-sub-tab-drop-after::before {
+  content: "";
+  position: absolute;
+  top: 5px;
+  bottom: 5px;
+  width: 3px;
+  border-radius: var(--radius-pill);
+  background: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+  pointer-events: none;
+  z-index: 1;
+}
+.ae-sub-tab-drop-before::before {
+  left: -2px;
+}
+.ae-sub-tab-drop-after::before {
+  right: -2px;
 }
 .ae-sub-tab-active {
   background: var(--bg-elev);


### PR DESCRIPTION
## Summary

- replace native HTML5 drag/drop for session tabs and terminal sub-tabs with pointer-driven reordering
- add familiar drag feedback: lifted dragged tab, grab/grabbing strip state, and a slot marker for the landing position
- cover both tab surfaces with regression tests for pointer drag, visual drag state, drop indication, and emitted reorder events

## Root Cause

The Tauri/WebKit webview allowed `dragstart` to fire but ended the native drag immediately before any useful `dragover` or `drop` event reached the tab strip. That meant the UI could appear draggable while no reorder event was dispatched.

## Validation

- `bunx vitest run src/extensions/default-layout/shell/tab-strip.test.tsx src/extensions/default-layout/shell/panel.test.tsx`
- `bun run typecheck`
- `bun run lint`
- `bunx vitest run`
- live dev-webview sanity check via Aethon debug eval confirmed pointer-only tabs, grab cursors, and transform transitions on session and terminal tabs
