### PR TITLE
fix(settings): open config.toml in host editor tab

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -901,6 +901,7 @@ export default function App() {
     activateLayoutById,
     openProjectFromPicker,
     setActiveProjectById,
+    clearActiveProject,
     removeProjectById,
     setActiveHost: (id) => {
       hostInfo.setActiveHost(id);

--- a/src/eventRoutes/settings.test.ts
+++ b/src/eventRoutes/settings.test.ts
@@ -58,6 +58,62 @@ describe("handleSettings", () => {
     });
   });
 
+  it("opens config.toml in a host-level editor tab rooted at the Aethon dir", async () => {
+    const { ctx, mocks } = buildRouteFixture({
+      state: { activeProjectId: "project-1" },
+    });
+    mocks.invoke
+      .mockResolvedValueOnce("/Users/test/.aethon")
+      .mockResolvedValueOnce("");
+    const handled = await handleSettings(
+      {
+        component: { id: "settings-panel" },
+        eventType: "open-config-file",
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(mocks.invoke).toHaveBeenNthCalledWith(1, "aethon_home_dir");
+    expect(mocks.invoke).toHaveBeenNthCalledWith(2, "read_state", {
+      name: "config.toml",
+    });
+    expect(mocks.invoke).toHaveBeenNthCalledWith(3, "write_state", {
+      name: "config.toml",
+      content: "",
+    });
+    expect(mocks.clearActiveProject).toHaveBeenCalledTimes(1);
+    expect(mocks.newEditorTab).toHaveBeenCalledWith(
+      "/Users/test/.aethon/config.toml",
+      { rootPath: "/Users/test/.aethon" },
+    );
+    expect(
+      mocks.clearActiveProject.mock.invocationCallOrder[0],
+    ).toBeLessThan(mocks.newEditorTab.mock.invocationCallOrder[0]);
+    expect(mocks.closeSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces a notification when config.toml cannot be opened", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    mocks.invoke.mockRejectedValueOnce(new Error("boom"));
+    const handled = await handleSettings(
+      {
+        component: { id: "settings-panel" },
+        eventType: "open-config-file",
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(mocks.newEditorTab).not.toHaveBeenCalled();
+    expect(mocks.pushNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Open config.toml failed",
+        kind: "error",
+      }),
+    );
+  });
+
   it("opens system-prompt.md in an editor tab rooted at the Aethon dir", async () => {
     const { ctx, mocks } = buildRouteFixture();
     mocks.invoke

--- a/src/eventRoutes/settings.ts
+++ b/src/eventRoutes/settings.ts
@@ -51,6 +51,32 @@ export const handleSettings: EventRouteHandler = (
       });
     return true;
   }
+  if (eventType === "open-config-file") {
+    void ctx
+      .invoke("aethon_home_dir")
+      .then(async (dir) => {
+        if (typeof dir !== "string" || dir.length === 0) {
+          throw new Error("Aethon directory unavailable");
+        }
+        const fileName = "config.toml";
+        const existing = await ctx.invoke("read_state", { name: fileName });
+        if (typeof existing !== "string" || existing.length === 0) {
+          await ctx.invoke("write_state", { name: fileName, content: "" });
+        }
+        ctx.clearActiveProject();
+        ctx.newEditorTab(`${dir}/${fileName}`, { rootPath: dir });
+        ctx.closeSettings();
+      })
+      .catch((err: unknown) => {
+        ctx.pushNotification({
+          title: "Open config.toml failed",
+          message: String(err),
+          kind: "error",
+          durationMs: 6000,
+        });
+      });
+    return true;
+  }
   if (eventType === "open-system-prompt") {
     void ctx
       .invoke("aethon_home_dir")

--- a/src/eventRoutes/testFixtures.ts
+++ b/src/eventRoutes/testFixtures.ts
@@ -66,6 +66,7 @@ export interface RouteFixture {
     activateLayoutById: Mock;
     openProjectFromPicker: Mock;
     setActiveProjectById: Mock;
+    clearActiveProject: Mock;
     removeProjectById: Mock;
     syncRecentSessionsToState: Mock;
     activateWorktree: Mock;
@@ -154,6 +155,7 @@ export function buildRouteFixture(
     Promise.resolve<string | null>(null),
   );
   const setActiveProjectById = vi.fn();
+  const clearActiveProject = vi.fn();
   const removeProjectById = vi.fn(() => true);
   const syncRecentSessionsToState = vi.fn();
   const activateWorktree = vi.fn();
@@ -216,6 +218,7 @@ export function buildRouteFixture(
     activateLayoutById,
     openProjectFromPicker,
     setActiveProjectById,
+    clearActiveProject,
     removeProjectById,
     setActiveHost: vi.fn(),
     syncRecentSessionsToState,
@@ -298,6 +301,7 @@ export function buildRouteFixture(
       activateLayoutById,
       openProjectFromPicker,
       setActiveProjectById,
+      clearActiveProject,
       removeProjectById,
       syncRecentSessionsToState,
       activateWorktree,

--- a/src/eventRoutes/types.ts
+++ b/src/eventRoutes/types.ts
@@ -148,9 +148,9 @@ export interface EventRouteContext {
   setActiveProjectById: (id: string) => void;
   clearActiveProject: () => void;
   removeProjectById: (id: string) => boolean;
-  /** Switch the active host (HOSTS sidebar section). Clearing the active
-   *  project is the responsibility of the caller chain; this just
-   *  flips the host pointer. */
+  /** Switch the active host (HOSTS sidebar section). App's implementation
+   *  also clears the active project so host selection lands in the
+   *  no-project workspace. */
   setActiveHost: (id: string | null) => void;
   syncRecentSessionsToState: () => void;
   // ─── Worktrees ─────────────────────────────────────────────────────

--- a/src/eventRoutes/types.ts
+++ b/src/eventRoutes/types.ts
@@ -146,6 +146,7 @@ export interface EventRouteContext {
   activateLayoutById: (id: string) => void;
   openProjectFromPicker: () => Promise<string | null>;
   setActiveProjectById: (id: string) => void;
+  clearActiveProject: () => void;
   removeProjectById: (id: string) => boolean;
   /** Switch the active host (HOSTS sidebar section). Clearing the active
    *  project is the responsibility of the caller chain; this just

--- a/src/extensions/default-layout/settings-panel/panel.test.tsx
+++ b/src/extensions/default-layout/settings-panel/panel.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SettingsPanel } from "./panel";
@@ -10,10 +10,6 @@ vi.mock("@tauri-apps/api/core", () => ({
 
 vi.mock("@tauri-apps/api/event", () => ({
   listen: vi.fn(() => Promise.resolve(() => {})),
-}));
-
-vi.mock("@tauri-apps/plugin-opener", () => ({
-  openUrl: vi.fn(),
 }));
 
 vi.mock("../../../config", () => ({
@@ -68,6 +64,27 @@ describe("SettingsPanel", () => {
   });
 
   afterEach(() => cleanup());
+
+  it("routes Open config.toml through the settings event route", async () => {
+    const onEvent = vi.fn();
+    render(
+      <SettingsPanel
+        component={{ id: "settings-panel", type: "settings-panel" }}
+        state={{
+          settings: { open: true, pending: null, saveStatus: "idle" },
+          sidebar: { models: [] },
+        }}
+        onEvent={onEvent}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Open config.toml" })).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Open config.toml" }));
+    expect(onEvent).toHaveBeenCalledWith("open-config-file");
+  });
 
   it("renders as a live settings dialog without a save footer or stale save copy", async () => {
     render(

--- a/src/extensions/default-layout/settings-panel/panel.tsx
+++ b/src/extensions/default-layout/settings-panel/panel.tsx
@@ -11,9 +11,7 @@
 // so the form reflects what's actually on disk, not stale in-memory
 // tab state.
 
-import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
-import { openUrl } from "@tauri-apps/plugin-opener";
 import { useCallback, useEffect, useState } from "react";
 import type { BuiltinComponentProps } from "../../../components/A2UIRenderer";
 import {
@@ -54,18 +52,6 @@ export function SettingsPanel({ state, onEvent }: BuiltinComponentProps) {
     onEvent("update", { patch });
   };
   const close = () => onEvent("close");
-  // `aethon_home_dir` returns the *Aethon* dir (`~/.aethon`), not the
-  // user's home — joining another `/.aethon/` produces a wrong nested
-  // path that the agent never reads. Append the bare filename only.
-  const openConfigFile = async () => {
-    try {
-      const aethonDir = (await invoke<string>("aethon_home_dir")) ?? "";
-      const path = `${aethonDir}/config.toml`;
-      await openUrl(`file://${path}`);
-    } catch (err) {
-      console.warn("open config.toml failed:", err);
-    }
-  };
   const openSystemPromptFile = () => {
     onEvent("open-system-prompt");
   };
@@ -628,7 +614,7 @@ export function SettingsPanel({ state, onEvent }: BuiltinComponentProps) {
               <button
                 type="button"
                 className="ae-settings-secondary"
-                onClick={openConfigFile}
+                onClick={() => onEvent("open-config-file")}
               >
                 Open config.toml
               </button>

--- a/website/guide/settings-and-search.md
+++ b/website/guide/settings-and-search.md
@@ -25,9 +25,8 @@ Two convenience buttons live at the bottom:
 
 - **Open `config.toml`** — opens `~/.aethon/config.toml` in Aethon's
   in-app Monaco editor for power-user edits.
-- **Reset to defaults** — clears every key Aethon manages. Doesn't
-  delete the file (it stays for any keys you've added by hand) — only
-  the Aethon-managed sections are reset.
+- **Reset layout** — restores the sidebar, file sidebar, and terminal
+  panel sizes to their defaults without changing `config.toml`.
 
 ::: tip Direct edits override
 The Settings panel reads the file every time it opens, so manual edits

--- a/website/guide/settings-and-search.md
+++ b/website/guide/settings-and-search.md
@@ -19,12 +19,12 @@ Sections:
 - **Voice** — toggle and hold-to-record hotkeys.
 - **Updater** — stable/nightly channel and background-check toggle.
 - **Nix devshell** — detection mode, cache lifetime, lockfile refresh, and manual refresh.
-- **Advanced** — extension state payload limits.
+- **Advanced** — extension state payload limits and layout reset.
 
 Two convenience buttons live at the bottom:
 
-- **Open `config.toml`** — reveals the file in your default editor for
-  power-user edits.
+- **Open `config.toml`** — opens `~/.aethon/config.toml` in Aethon's
+  in-app Monaco editor for power-user edits.
 - **Reset to defaults** — clears every key Aethon manages. Doesn't
   delete the file (it stays for any keys you've added by hand) — only
   the Aethon-managed sections are reset.


### PR DESCRIPTION
## Summary
- route Settings → Advanced → Open config.toml through the settings event route
- open ~/.aethon/config.toml in an in-app Monaco editor tab after switching to host/no-project scope
- add failure notifications, tests, and docs update

Fixes #236.

## Verification
- npm test -- --run src/eventRoutes/settings.test.ts src/extensions/default-layout/settings-panel/panel.test.tsx
- npm run typecheck
- npm run lint -- src/eventRoutes/settings.ts src/eventRoutes/settings.test.ts src/eventRoutes/types.ts src/eventRoutes/testFixtures.ts src/extensions/default-layout/settings-panel/panel.tsx src/extensions/default-layout/settings-panel/panel.test.tsx
- codex review --uncommitted
- bunx vitest run