### PR TITLE
fix(ui): refresh worktree PR badges

### DIFF
--- a/src/extensions/default-layout/sidebar/worktree-pr-status.test.ts
+++ b/src/extensions/default-layout/sidebar/worktree-pr-status.test.ts
@@ -48,7 +48,10 @@ describe("summarizeWorktreePrStatus", () => {
   });
 
   it("summarizes open and draft PRs", () => {
-    expect(summarizeWorktreePrStatus(status(), checks())?.label).toBe("#12");
+    const openChip = summarizeWorktreePrStatus(status(), checks());
+    expect(openChip?.label).toBe("open #12");
+    expect(openChip?.kind).toBe("open");
+    expect(openChip?.title).toContain("CI success");
     expect(
       summarizeWorktreePrStatus(
         status({
@@ -66,6 +69,23 @@ describe("summarizeWorktreePrStatus", () => {
         }),
       )?.label,
     ).toBe("draft #13");
+    expect(
+      summarizeWorktreePrStatus(
+        status({
+          prs: [
+            {
+              number: 13,
+              state: "OPEN",
+              title: "Draft work",
+              url: "u",
+              isDraft: true,
+              merged: false,
+              baseRefName: "main",
+            },
+          ],
+        }),
+      )?.kind,
+    ).toBe("draft");
   });
 
   it("summarizes merged and closed PRs", () => {
@@ -106,10 +126,20 @@ describe("summarizeWorktreePrStatus", () => {
   });
 
   it("carries CI rollup into the chip", () => {
+    const chip = summarizeWorktreePrStatus(
+      status(),
+      checks({ conclusion: "failure" }),
+    );
+    expect(chip?.ci).toBe("failure");
+    expect(chip?.title).toContain("CI failure");
     expect(
-      summarizeWorktreePrStatus(status(), checks({ conclusion: "failure" }))
+      summarizeWorktreePrStatus(status(), checks({ conclusion: "pending" }))
         ?.ci,
-    ).toBe("failure");
+    ).toBe("pending");
+    expect(
+      summarizeWorktreePrStatus(status(), checks({ conclusion: "neutral" }))
+        ?.ci,
+    ).toBe("neutral");
   });
 
   it("marks broken worktrees as stale", () => {

--- a/src/extensions/default-layout/sidebar/worktree-pr-status.ts
+++ b/src/extensions/default-layout/sidebar/worktree-pr-status.ts
@@ -63,7 +63,7 @@ export function summarizeWorktreePrStatus(
         ? `merged #${pr.number}`
         : kind === "closed"
           ? `closed #${pr.number}`
-          : `#${pr.number}`;
+          : `open #${pr.number}`;
   const stateLabel =
     kind === "open"
       ? "Open"

--- a/src/extensions/default-layout/sidebar/worktree-row.test.tsx
+++ b/src/extensions/default-layout/sidebar/worktree-row.test.tsx
@@ -10,25 +10,21 @@ import {
   waitFor,
 } from "@testing-library/react";
 
-const { branchStatusMock, branchRefreshMock, checksMock, checksRefreshMock } =
-  vi.hoisted(() => ({
+const { branchStatusMock, checksMock } = vi.hoisted(() => ({
     branchStatusMock: vi.fn(),
-    branchRefreshMock: vi.fn(),
     checksMock: vi.fn(),
-    checksRefreshMock: vi.fn(),
-  }));
+}));
 
 vi.mock("../../../ghBranchStatusCache", () => ({
   getGhBranchStatus: branchStatusMock,
-  refreshGhBranchStatus: branchRefreshMock,
 }));
 vi.mock("../../../ghChecksCache", () => ({
   getGhChecks: checksMock,
-  refreshGhChecks: checksRefreshMock,
 }));
 
 import {
   WORKTREE_PENDING_CI_REFRESH_MS,
+  WORKTREE_PR_REFRESH_MS,
   WorktreeRow,
   type WorktreeSidebarItem,
 } from "./worktree-row";
@@ -36,9 +32,7 @@ import {
 afterEach(() => {
   vi.useRealTimers();
   branchStatusMock.mockReset();
-  branchRefreshMock.mockReset();
   checksMock.mockReset();
-  checksRefreshMock.mockReset();
   cleanup();
 });
 
@@ -97,8 +91,6 @@ describe("WorktreeRow", () => {
       skipped: 0,
       checks: [],
     });
-    branchRefreshMock.mockImplementation(branchStatusMock);
-    checksRefreshMock.mockImplementation(checksMock);
   });
 
   it("emits switch-worktree on row click", () => {
@@ -198,64 +190,66 @@ describe("WorktreeRow", () => {
     ).toBeTruthy();
   });
 
-  it("periodically refreshes PR and CI badges without remounting", async () => {
+  it("periodically polls PR and CI badges through the cache getters", async () => {
     vi.useFakeTimers();
-    branchStatusMock.mockResolvedValueOnce({
-      ghAvailable: true,
-      repo: "owner/repo",
-      pushed: true,
-      worktreeBroken: false,
-      prs: [
-        {
-          number: 42,
-          state: "OPEN",
-          title: "Feature X",
-          url: "https://github.test/pr/42",
-          isDraft: false,
-          merged: false,
-          baseRefName: "main",
-        },
-      ],
-    });
-    checksMock.mockResolvedValueOnce({
-      ghAvailable: true,
-      repo: "owner/repo",
-      conclusion: "pending",
-      total: 1,
-      passed: 0,
-      failed: 0,
-      pending: 1,
-      skipped: 0,
-      checks: [],
-    });
-    branchRefreshMock.mockResolvedValueOnce({
-      ghAvailable: true,
-      repo: "owner/repo",
-      pushed: true,
-      worktreeBroken: false,
-      prs: [
-        {
-          number: 42,
-          state: "CLOSED",
-          title: "Feature X",
-          url: "https://github.test/pr/42",
-          isDraft: false,
-          merged: true,
-          baseRefName: "main",
-        },
-      ],
-    });
-    checksRefreshMock.mockResolvedValueOnce({
-      ghAvailable: true,
-      repo: "owner/repo",
-      conclusion: "success",
-      total: 1,
-      passed: 1,
-      failed: 0,
-      pending: 0,
-      skipped: 0,
-      checks: [],
-    });
+    branchStatusMock
+      .mockResolvedValueOnce({
+        ghAvailable: true,
+        repo: "owner/repo",
+        pushed: true,
+        worktreeBroken: false,
+        prs: [
+          {
+            number: 42,
+            state: "OPEN",
+            title: "Feature X",
+            url: "https://github.test/pr/42",
+            isDraft: false,
+            merged: false,
+            baseRefName: "main",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        ghAvailable: true,
+        repo: "owner/repo",
+        pushed: true,
+        worktreeBroken: false,
+        prs: [
+          {
+            number: 42,
+            state: "CLOSED",
+            title: "Feature X",
+            url: "https://github.test/pr/42",
+            isDraft: false,
+            merged: true,
+            baseRefName: "main",
+          },
+        ],
+      });
+    checksMock
+      .mockResolvedValueOnce({
+        ghAvailable: true,
+        repo: "owner/repo",
+        conclusion: "pending",
+        total: 1,
+        passed: 0,
+        failed: 0,
+        pending: 1,
+        skipped: 0,
+        checks: [],
+      })
+      .mockResolvedValueOnce({
+        ghAvailable: true,
+        repo: "owner/repo",
+        conclusion: "success",
+        total: 1,
+        passed: 1,
+        failed: 0,
+        pending: 0,
+        skipped: 0,
+        checks: [],
+      });
 
     harness(wt());
     await act(async () => {
@@ -268,11 +262,13 @@ describe("WorktreeRow", () => {
       await vi.advanceTimersByTimeAsync(WORKTREE_PENDING_CI_REFRESH_MS);
     });
 
-    expect(branchRefreshMock).toHaveBeenCalledWith(
+    expect(branchStatusMock).toHaveBeenCalledTimes(2);
+    expect(branchStatusMock).toHaveBeenLastCalledWith(
       "/repo-feature-x",
       "feature-x",
     );
-    expect(checksRefreshMock).toHaveBeenCalledWith(
+    expect(checksMock).toHaveBeenCalledTimes(2);
+    expect(checksMock).toHaveBeenLastCalledWith(
       "/repo-feature-x",
       "feature-x",
     );
@@ -280,6 +276,32 @@ describe("WorktreeRow", () => {
     expect(
       document.querySelector(".ae-worktree-pr-ci--success"),
     ).toBeTruthy();
+  });
+
+  it("does not show an empty PR slot during background refreshes without a PR", async () => {
+    vi.useFakeTimers();
+    branchStatusMock.mockResolvedValue({
+      ghAvailable: true,
+      repo: "owner/repo",
+      pushed: true,
+      worktreeBroken: false,
+      prs: [],
+    });
+
+    harness(wt());
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(document.querySelector(".ae-worktree-pr-slot")).toBeNull();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(WORKTREE_PR_REFRESH_MS);
+    });
+
+    expect(branchStatusMock).toHaveBeenCalledTimes(2);
+    expect(checksMock).not.toHaveBeenCalled();
+    expect(document.querySelector(".ae-worktree-pr-slot")).toBeNull();
   });
 
   it("does not fetch CI checks when there is no PR to summarize", async () => {

--- a/src/extensions/default-layout/sidebar/worktree-row.test.tsx
+++ b/src/extensions/default-layout/sidebar/worktree-row.test.tsx
@@ -10,24 +10,35 @@ import {
   waitFor,
 } from "@testing-library/react";
 
-const { branchStatusMock, checksMock } = vi.hoisted(() => ({
-  branchStatusMock: vi.fn(),
-  checksMock: vi.fn(),
-}));
+const { branchStatusMock, branchRefreshMock, checksMock, checksRefreshMock } =
+  vi.hoisted(() => ({
+    branchStatusMock: vi.fn(),
+    branchRefreshMock: vi.fn(),
+    checksMock: vi.fn(),
+    checksRefreshMock: vi.fn(),
+  }));
 
 vi.mock("../../../ghBranchStatusCache", () => ({
   getGhBranchStatus: branchStatusMock,
+  refreshGhBranchStatus: branchRefreshMock,
 }));
 vi.mock("../../../ghChecksCache", () => ({
   getGhChecks: checksMock,
+  refreshGhChecks: checksRefreshMock,
 }));
 
-import { WorktreeRow, type WorktreeSidebarItem } from "./worktree-row";
+import {
+  WORKTREE_PENDING_CI_REFRESH_MS,
+  WorktreeRow,
+  type WorktreeSidebarItem,
+} from "./worktree-row";
 
 afterEach(() => {
   vi.useRealTimers();
   branchStatusMock.mockReset();
+  branchRefreshMock.mockReset();
   checksMock.mockReset();
+  checksRefreshMock.mockReset();
   cleanup();
 });
 
@@ -86,6 +97,8 @@ describe("WorktreeRow", () => {
       skipped: 0,
       checks: [],
     });
+    branchRefreshMock.mockImplementation(branchStatusMock);
+    checksRefreshMock.mockImplementation(checksMock);
   });
 
   it("emits switch-worktree on row click", () => {
@@ -178,8 +191,95 @@ describe("WorktreeRow", () => {
       checks: [],
     });
     harness(wt());
-    await waitFor(() => expect(screen.getByText("#42")).toBeTruthy());
+    await waitFor(() => expect(screen.getByText("open #42")).toBeTruthy());
     expect(screen.getByLabelText(/Open PR #42/)).toBeTruthy();
+    expect(
+      document.querySelector(".ae-worktree-pr-ci--pending"),
+    ).toBeTruthy();
+  });
+
+  it("periodically refreshes PR and CI badges without remounting", async () => {
+    vi.useFakeTimers();
+    branchStatusMock.mockResolvedValueOnce({
+      ghAvailable: true,
+      repo: "owner/repo",
+      pushed: true,
+      worktreeBroken: false,
+      prs: [
+        {
+          number: 42,
+          state: "OPEN",
+          title: "Feature X",
+          url: "https://github.test/pr/42",
+          isDraft: false,
+          merged: false,
+          baseRefName: "main",
+        },
+      ],
+    });
+    checksMock.mockResolvedValueOnce({
+      ghAvailable: true,
+      repo: "owner/repo",
+      conclusion: "pending",
+      total: 1,
+      passed: 0,
+      failed: 0,
+      pending: 1,
+      skipped: 0,
+      checks: [],
+    });
+    branchRefreshMock.mockResolvedValueOnce({
+      ghAvailable: true,
+      repo: "owner/repo",
+      pushed: true,
+      worktreeBroken: false,
+      prs: [
+        {
+          number: 42,
+          state: "CLOSED",
+          title: "Feature X",
+          url: "https://github.test/pr/42",
+          isDraft: false,
+          merged: true,
+          baseRefName: "main",
+        },
+      ],
+    });
+    checksRefreshMock.mockResolvedValueOnce({
+      ghAvailable: true,
+      repo: "owner/repo",
+      conclusion: "success",
+      total: 1,
+      passed: 1,
+      failed: 0,
+      pending: 0,
+      skipped: 0,
+      checks: [],
+    });
+
+    harness(wt());
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByText("open #42")).toBeTruthy();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(WORKTREE_PENDING_CI_REFRESH_MS);
+    });
+
+    expect(branchRefreshMock).toHaveBeenCalledWith(
+      "/repo-feature-x",
+      "feature-x",
+    );
+    expect(checksRefreshMock).toHaveBeenCalledWith(
+      "/repo-feature-x",
+      "feature-x",
+    );
+    expect(screen.getByText("merged #42")).toBeTruthy();
+    expect(
+      document.querySelector(".ae-worktree-pr-ci--success"),
+    ).toBeTruthy();
   });
 
   it("does not fetch CI checks when there is no PR to summarize", async () => {

--- a/src/extensions/default-layout/sidebar/worktree-row.tsx
+++ b/src/extensions/default-layout/sidebar/worktree-row.tsx
@@ -16,11 +16,8 @@
 import { useEffect, useRef, useState, type CSSProperties } from "react";
 import type { BuiltinComponentProps } from "../../../components/A2UIRenderer";
 import type { AgentActivitySummary } from "../../../hooks/projectOps/agentActivity";
-import {
-  getGhBranchStatus,
-  refreshGhBranchStatus,
-} from "../../../ghBranchStatusCache";
-import { getGhChecks, refreshGhChecks } from "../../../ghChecksCache";
+import { getGhBranchStatus } from "../../../ghBranchStatusCache";
+import { getGhChecks } from "../../../ghChecksCache";
 import {
   summarizeWorktreePrStatus,
   type WorktreePrChip,
@@ -126,29 +123,26 @@ export function WorktreeRow({
           ? WORKTREE_PENDING_CI_REFRESH_MS
           : WORKTREE_PR_REFRESH_MS;
       refreshTimer = window.setTimeout(() => {
-        void load("refresh");
+        void load();
       }, delay);
     };
 
-    const load = async (mode: "cache" | "refresh") => {
+    const load = async () => {
       if (cancelled || polling || document.hidden) return;
+      const showLoading = !loadedOnce;
       polling = true;
-      setPrLoading(true);
-      if (!loadedOnce) setPrChip(null);
+      if (showLoading) {
+        setPrLoading(true);
+        setPrChip(null);
+      }
       try {
-        const status =
-          mode === "refresh"
-            ? await refreshGhBranchStatus(item.path, branch)
-            : await getGhBranchStatus(item.path, branch);
+        const status = await getGhBranchStatus(item.path, branch);
         const checks =
           status.ghAvailable &&
           status.repo &&
           !status.worktreeBroken &&
           status.prs.length > 0
-            ? await (mode === "refresh"
-                ? refreshGhChecks(item.path, branch)
-                : getGhChecks(item.path, branch)
-              ).catch(() => null)
+            ? await getGhChecks(item.path, branch).catch(() => null)
             : null;
         if (!cancelled) {
           const chip = summarizeWorktreePrStatus(status, checks);
@@ -164,18 +158,18 @@ export function WorktreeRow({
         }
       } finally {
         polling = false;
-        if (!cancelled) setPrLoading(false);
+        if (!cancelled && showLoading) setPrLoading(false);
       }
     };
 
     const onFocus = () => {
-      if (!document.hidden) void load("cache");
+      if (!document.hidden) void load();
     };
     const onVisibility = () => {
-      if (!document.hidden) void load("cache");
+      if (!document.hidden) void load();
     };
 
-    void load("cache");
+    void load();
     window.addEventListener("focus", onFocus);
     document.addEventListener("visibilitychange", onVisibility);
 

--- a/src/extensions/default-layout/sidebar/worktree-row.tsx
+++ b/src/extensions/default-layout/sidebar/worktree-row.tsx
@@ -16,12 +16,18 @@
 import { useEffect, useRef, useState, type CSSProperties } from "react";
 import type { BuiltinComponentProps } from "../../../components/A2UIRenderer";
 import type { AgentActivitySummary } from "../../../hooks/projectOps/agentActivity";
-import { getGhBranchStatus } from "../../../ghBranchStatusCache";
-import { getGhChecks } from "../../../ghChecksCache";
+import {
+  getGhBranchStatus,
+  refreshGhBranchStatus,
+} from "../../../ghBranchStatusCache";
+import { getGhChecks, refreshGhChecks } from "../../../ghChecksCache";
 import {
   summarizeWorktreePrStatus,
   type WorktreePrChip,
 } from "./worktree-pr-status";
+
+export const WORKTREE_PR_REFRESH_MS = 60_000;
+export const WORKTREE_PENDING_CI_REFRESH_MS = 45_000;
 
 export interface WorktreeSidebarItem {
   id: string;
@@ -98,33 +104,86 @@ export function WorktreeRow({
 
   useEffect(() => {
     let cancelled = false;
+    let polling = false;
+    let loadedOnce = false;
+    let refreshTimer: number | null = null;
     const branch = item.branch;
     if (!prEligible || !branch) {
       return;
     }
-    void (async () => {
+
+    const clearRefreshTimer = () => {
+      if (refreshTimer !== null) {
+        window.clearTimeout(refreshTimer);
+        refreshTimer = null;
+      }
+    };
+
+    const scheduleRefresh = (chip: WorktreePrChip | null) => {
+      clearRefreshTimer();
+      const delay =
+        chip?.ci === "pending"
+          ? WORKTREE_PENDING_CI_REFRESH_MS
+          : WORKTREE_PR_REFRESH_MS;
+      refreshTimer = window.setTimeout(() => {
+        void load("refresh");
+      }, delay);
+    };
+
+    const load = async (mode: "cache" | "refresh") => {
+      if (cancelled || polling || document.hidden) return;
+      polling = true;
       setPrLoading(true);
-      setPrChip(null);
+      if (!loadedOnce) setPrChip(null);
       try {
-        const status = await getGhBranchStatus(item.path, branch);
+        const status =
+          mode === "refresh"
+            ? await refreshGhBranchStatus(item.path, branch)
+            : await getGhBranchStatus(item.path, branch);
         const checks =
           status.ghAvailable &&
           status.repo &&
           !status.worktreeBroken &&
           status.prs.length > 0
-            ? await getGhChecks(item.path, branch).catch(() => null)
+            ? await (mode === "refresh"
+                ? refreshGhChecks(item.path, branch)
+                : getGhChecks(item.path, branch)
+              ).catch(() => null)
             : null;
         if (!cancelled) {
-          setPrChip(summarizeWorktreePrStatus(status, checks));
+          const chip = summarizeWorktreePrStatus(status, checks);
+          loadedOnce = true;
+          setPrChip(chip);
+          scheduleRefresh(chip);
         }
       } catch {
-        if (!cancelled) setPrChip(null);
+        if (!cancelled) {
+          loadedOnce = true;
+          setPrChip(null);
+          scheduleRefresh(null);
+        }
       } finally {
+        polling = false;
         if (!cancelled) setPrLoading(false);
       }
-    })();
+    };
+
+    const onFocus = () => {
+      if (!document.hidden) void load("cache");
+    };
+    const onVisibility = () => {
+      if (!document.hidden) void load("cache");
+    };
+
+    void load("cache");
+    window.addEventListener("focus", onFocus);
+    document.addEventListener("visibilitychange", onVisibility);
+
     return () => {
       cancelled = true;
+      clearRefreshTimer();
+      window.removeEventListener("focus", onFocus);
+      document.removeEventListener("visibilitychange", onVisibility);
     };
   }, [item.branch, item.path, prEligible]);
 

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -1367,8 +1367,8 @@ body.ae-resizing-sidebar .a2ui-layout {
   display: inline-flex;
   align-items: center;
   justify-content: flex-end;
-  flex: 0 0 58px;
-  min-width: 58px;
+  flex: 0 0 86px;
+  min-width: 86px;
   margin-left: var(--space-1);
 }
 .ae-worktree-pr-chip {
@@ -1376,7 +1376,7 @@ body.ae-resizing-sidebar .a2ui-layout {
   align-items: center;
   justify-content: center;
   gap: 4px;
-  max-width: 58px;
+  max-width: 86px;
   min-width: 0;
   height: 18px;
   padding: 0 6px;


### PR DESCRIPTION
## Summary

- Make sidebar worktree PR chips show explicit PR state labels, including `open #123`, instead of hiding open state behind the tooltip.
- Add a worktree-row refresh loop for PR/CI badges: cached reads on mount/focus, forced cache refresh on timer, 45s while CI is pending and 60s otherwise.
- Keep cache behavior centralized in the existing `ghBranchStatusCache` / `ghChecksCache` modules and use their refresh functions for periodic updates.
- Widen the compact chip slot so explicit state labels fit without colliding with the remove control.

## Root Cause

The worktree sidebar badge fetched PR/CI state once when the row mounted or changed branch/path. The caches had sane TTLs, but the row never asked again, so merged/closed/open/check-state transitions could remain stale until a remount or unrelated re-render.

## Validation

- `bunx vitest run src/extensions/default-layout/sidebar/worktree-pr-status.test.ts src/extensions/default-layout/sidebar/worktree-row.test.tsx`
- `bun run typecheck`
- `bun run lint`
- `bunx vitest run` (248 files, 2001 tests)
- `git diff --check`
- Playwright CSS measurement for `open #123` chip: label fits, no overlap with remove control
