### PR TITLE
fix: keep host sessions scoped and closed

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,6 +54,7 @@ import { useProjectModelRecorder } from "./hooks/useProjectModelRecorder";
 import { useProjectSyncEffects } from "./hooks/useProjectSyncEffects";
 import { useAppSlashCommandContext } from "./hooks/useAppSlashCommandContext";
 import { useAppBridgeMessages } from "./hooks/useAppBridgeMessages";
+import { closeAllWorkspaceSessions } from "./hooks/tabOps/closeWorkspaceSessions";
 import { writeState } from "./persist";
 import { useAppState } from "./state/appStore";
 import pkg from "../package.json" with { type: "json" };
@@ -856,6 +857,14 @@ export default function App() {
     renameEditorTabsForPath,
     closeEditorTabsForPath,
     closeTab,
+    closeAllWorkspaceSessions: () =>
+      closeAllWorkspaceSessions({
+        setState,
+        stateRef,
+        projectsRef,
+        tabBucketsRef,
+        closeTab,
+      }),
     setActiveTab,
     activateTabAnywhere: (tabId: string) => {
       const tabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];

--- a/src/eventRoutes/tabStrip.test.ts
+++ b/src/eventRoutes/tabStrip.test.ts
@@ -119,7 +119,7 @@ describe("handleTabStrip", () => {
     expect(mocks.closeTab).not.toHaveBeenCalledWith("sh-1");
   });
 
-  it("close-all closes every non-shell tab", async () => {
+  it("close-all delegates to the active workspace close operation", async () => {
     const { ctx, mocks } = buildRouteFixture({
       state: {
         tabs: [
@@ -136,9 +136,8 @@ describe("handleTabStrip", () => {
       },
       ctx,
     );
-    expect(mocks.closeTab).toHaveBeenCalledWith("ed-1");
-    expect(mocks.closeTab).toHaveBeenCalledWith("ag-1");
-    expect(mocks.closeTab).not.toHaveBeenCalledWith("sh-1");
+    expect(mocks.closeAllWorkspaceSessions).toHaveBeenCalledTimes(1);
+    expect(mocks.closeTab).not.toHaveBeenCalled();
   });
 
   it("rename updates the label and persists it through the bridge", async () => {

--- a/src/eventRoutes/tabStrip.ts
+++ b/src/eventRoutes/tabStrip.ts
@@ -57,13 +57,7 @@ export const handleTabStrip: EventRouteHandler = (
     return true;
   }
   if (eventType === "close-all") {
-    const tabs =
-      (ctx.stateRef.current.tabs as
-        | Array<{ id: string; kind?: string }>
-        | undefined) ?? [];
-    for (const t of tabs) {
-      if (t.kind !== "shell") ctx.closeTab(t.id);
-    }
+    ctx.closeAllWorkspaceSessions();
     return true;
   }
   if (eventType === "rename" && sel?.tabId) {

--- a/src/eventRoutes/testFixtures.ts
+++ b/src/eventRoutes/testFixtures.ts
@@ -46,6 +46,7 @@ export interface RouteFixture {
     renameEditorTabsForPath: Mock;
     closeEditorTabsForPath: Mock;
     closeTab: Mock;
+    closeAllWorkspaceSessions: Mock;
     setActiveTab: Mock;
     activateTabAnywhere: Mock;
     setActiveSubTab: Mock;
@@ -133,6 +134,7 @@ export function buildRouteFixture(
   const renameEditorTabsForPath = vi.fn();
   const closeEditorTabsForPath = vi.fn();
   const closeTab = vi.fn();
+  const closeAllWorkspaceSessions = vi.fn();
   const setActiveTab = vi.fn();
   const activateTabAnywhere = vi.fn();
   const setActiveSubTab = vi.fn();
@@ -198,6 +200,7 @@ export function buildRouteFixture(
     renameEditorTabsForPath,
     closeEditorTabsForPath,
     closeTab,
+    closeAllWorkspaceSessions,
     setActiveTab,
     activateTabAnywhere,
     setActiveSubTab,
@@ -281,6 +284,7 @@ export function buildRouteFixture(
       renameEditorTabsForPath,
       closeEditorTabsForPath,
       closeTab,
+      closeAllWorkspaceSessions,
       setActiveTab,
       activateTabAnywhere,
       setActiveSubTab,

--- a/src/eventRoutes/types.ts
+++ b/src/eventRoutes/types.ts
@@ -114,6 +114,7 @@ export interface EventRouteContext {
    *  trashed file on the next Cmd+S. */
   closeEditorTabsForPath: (path: string, kind: string) => void;
   closeTab: (tabId: string) => void;
+  closeAllWorkspaceSessions: () => void;
   setActiveTab: (tabId: string) => void;
   /** Activate a tab by id no matter which workspace owns it. If the tab is
    *  in the active workspace it selects it directly; otherwise it switches

--- a/src/hooks/projectOps/projectStore.ts
+++ b/src/hooks/projectOps/projectStore.ts
@@ -142,7 +142,23 @@ export function useProjectStore(deps: ProjectStoreDeps): ProjectStore {
     const activePath = normalizeSessionPath(
       activeCwd(projectsRef.current) ?? undefined,
     );
-    if (!activePath) return discovered;
+    if (!activePath) {
+      const projectPaths = new Set<string>();
+      for (const project of projectsRef.current.projects) {
+        const projectPath = normalizeSessionPath(project.path);
+        if (projectPath) projectPaths.add(projectPath);
+        for (const worktree of projectsRef.current.worktreesByProject[
+          project.id
+        ] ?? []) {
+          const worktreePath = normalizeSessionPath(worktree.path);
+          if (worktreePath) projectPaths.add(worktreePath);
+        }
+      }
+      return discovered.filter((session) => {
+        const cwd = normalizeSessionPath(session.cwd);
+        return !cwd || !projectPaths.has(cwd);
+      });
+    }
     return discovered.filter(
       (session) => normalizeSessionPath(session.cwd) === activePath,
     );

--- a/src/hooks/tabOps/closeWorkspaceSessions.test.ts
+++ b/src/hooks/tabOps/closeWorkspaceSessions.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Dispatch, MutableRefObject, SetStateAction } from "react";
+import { closeAllWorkspaceSessions } from "./closeWorkspaceSessions";
+import { makeEmptyTab, NO_PROJECT_KEY, type Tab } from "../../types/tab";
+import type { ProjectsState } from "../../projects";
+import type { TabBucket } from "../projectOps/types";
+
+const ref = <T>(value: T): MutableRefObject<T> => ({ current: value });
+
+function shellTab(id: string, projectId: string | null): Tab {
+  return {
+    ...makeEmptyTab(id, id, projectId, "shell"),
+    shell: {
+      cwd: "/tmp",
+      command: "",
+      args: [],
+      shareMode: "private",
+      shellState: "running",
+    },
+  };
+}
+
+function buildHarness(initial: Record<string, unknown>) {
+  let state = initial;
+  const stateRef = ref<Record<string, unknown>>(state);
+  const setState: Dispatch<SetStateAction<Record<string, unknown>>> = (
+    update,
+  ) => {
+    state = typeof update === "function" ? update(state) : update;
+    stateRef.current = state;
+  };
+  const tabBucketsRef = ref(new Map<string, TabBucket>());
+  const closeTab = vi.fn((tabId: string) => {
+    setState((prev) => ({
+      ...prev,
+      tabs: ((prev.tabs as Tab[] | undefined) ?? []).filter(
+        (tab) => tab.id !== tabId,
+      ),
+    }));
+  });
+  const projectsRef = ref<ProjectsState>({
+    activeId: null,
+    activeWorktreeId: null,
+    activeHostId: "local:test",
+    projects: [],
+    worktreesByProject: {},
+  });
+  return {
+    stateRef,
+    setState,
+    tabBucketsRef,
+    closeTab,
+    projectsRef,
+    getState: () => state,
+  };
+}
+
+describe("closeAllWorkspaceSessions", () => {
+  it("keeps host shell tabs but clears stale host agent sessions from buckets", () => {
+    const hostAgent = makeEmptyTab("host-agent", "Host Agent", null, "agent");
+    const hostShell = shellTab("host-shell", null);
+    const visibleAgent = makeEmptyTab(
+      "visible-agent",
+      "Visible Agent",
+      null,
+      "agent",
+    );
+    const visibleShell = shellTab("visible-shell", null);
+    const h = buildHarness({
+      tabs: [visibleAgent, visibleShell],
+      closedSessionIds: ["already-closed"],
+      persistedTabBuckets: {
+        [NO_PROJECT_KEY]: {
+          tabs: [hostAgent, hostShell],
+          activeTabId: "host-agent",
+        },
+        "project-1": {
+          tabs: [makeEmptyTab("project-agent", "Project Agent", "project-1")],
+          activeTabId: "project-agent",
+        },
+      },
+    });
+    h.tabBucketsRef.current.set(NO_PROJECT_KEY, {
+      tabs: [hostAgent, hostShell],
+      activeTabId: "host-agent",
+    });
+
+    closeAllWorkspaceSessions(h);
+
+    expect(h.closeTab).toHaveBeenCalledWith("visible-agent");
+    expect((h.getState().tabs as Tab[]).map((tab) => tab.id)).toEqual([
+      "visible-shell",
+    ]);
+    expect(h.tabBucketsRef.current.get(NO_PROJECT_KEY)).toEqual({
+      tabs: [hostShell],
+      activeTabId: undefined,
+    });
+    expect(
+      (
+        h.getState().persistedTabBuckets as Record<string, TabBucket>
+      )[NO_PROJECT_KEY],
+    ).toEqual({
+      tabs: [hostShell],
+      activeTabId: undefined,
+    });
+    expect(
+      (
+        h.getState().persistedTabBuckets as Record<string, TabBucket>
+      )["project-1"]?.tabs.map((tab) => tab.id),
+    ).toEqual(["project-agent"]);
+    expect(h.getState().closedSessionIds).toEqual([
+      "already-closed",
+      "visible-agent",
+      "host-agent",
+    ]);
+  });
+});

--- a/src/hooks/tabOps/closeWorkspaceSessions.ts
+++ b/src/hooks/tabOps/closeWorkspaceSessions.ts
@@ -1,0 +1,103 @@
+import type { Dispatch, MutableRefObject, SetStateAction } from "react";
+import { projectScopeBucketKey } from "../projectOps/tabBuckets";
+import type { TabBucket } from "../projectOps/types";
+import type { ProjectsState } from "../../projects";
+import type { Tab } from "../../types/tab";
+
+export interface CloseAllWorkspaceSessionsDeps {
+  setState: Dispatch<SetStateAction<Record<string, unknown>>>;
+  stateRef: MutableRefObject<Record<string, unknown>>;
+  projectsRef: MutableRefObject<ProjectsState>;
+  tabBucketsRef: MutableRefObject<Map<string, TabBucket>>;
+  closeTab: (tabId: string) => void;
+}
+
+function onlyShellTabs(tabs: readonly Tab[]): Tab[] {
+  return tabs.filter((tab) => tab.kind === "shell");
+}
+
+function addAgentIds(ids: Set<string>, tabs: readonly Tab[]): void {
+  for (const tab of tabs) {
+    if (tab.kind === "agent") ids.add(tab.id);
+  }
+}
+
+function shellOnlyBucket(bucket: TabBucket): TabBucket | null {
+  const tabs = onlyShellTabs(bucket.tabs);
+  if (tabs.length === 0) return null;
+  return {
+    tabs,
+    activeTabId: tabs.some((tab) => tab.id === bucket.activeTabId)
+      ? bucket.activeTabId
+      : undefined,
+  };
+}
+
+/**
+ * Close every non-shell tab in the active workspace and make the close
+ * authoritative across both visible state and the restored bucket mirror.
+ *
+ * Host overview uses the no-project bucket, so stale host bucket entries can
+ * otherwise rehydrate sessions after the visible tabs have been closed.
+ */
+export function closeAllWorkspaceSessions(
+  deps: CloseAllWorkspaceSessionsDeps,
+): void {
+  const { setState, stateRef, projectsRef, tabBucketsRef, closeTab } = deps;
+  const bucketKey = projectScopeBucketKey(
+    projectsRef.current.activeId,
+    projectsRef.current.activeWorktreeId,
+  );
+  const visibleTabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
+  const visibleSessionTabs = visibleTabs.filter((tab) => tab.kind !== "shell");
+  const agentIdsToSuppress = new Set<string>();
+  addAgentIds(agentIdsToSuppress, visibleSessionTabs);
+
+  const inMemoryBucket = tabBucketsRef.current.get(bucketKey);
+  if (inMemoryBucket) {
+    addAgentIds(agentIdsToSuppress, inMemoryBucket.tabs);
+    const shellBucket = shellOnlyBucket(inMemoryBucket);
+    if (shellBucket) {
+      tabBucketsRef.current.set(bucketKey, shellBucket);
+    } else {
+      tabBucketsRef.current.delete(bucketKey);
+    }
+  }
+
+  for (const tab of visibleSessionTabs) {
+    closeTab(tab.id);
+  }
+
+  setState((prev) => {
+    const result: Record<string, unknown> = { ...prev };
+    const persisted =
+      prev.persistedTabBuckets &&
+      typeof prev.persistedTabBuckets === "object" &&
+      !Array.isArray(prev.persistedTabBuckets)
+        ? (prev.persistedTabBuckets as Record<string, TabBucket>)
+        : {};
+    const persistedBucket = persisted[bucketKey];
+    if (persistedBucket) {
+      addAgentIds(agentIdsToSuppress, persistedBucket.tabs);
+      const nextPersisted = { ...persisted };
+      const shellBucket = shellOnlyBucket(persistedBucket);
+      if (shellBucket) {
+        nextPersisted[bucketKey] = shellBucket;
+      } else {
+        delete nextPersisted[bucketKey];
+      }
+      result.persistedTabBuckets = nextPersisted;
+    }
+
+    if (agentIdsToSuppress.size > 0) {
+      const closedIds = Array.isArray(prev.closedSessionIds)
+        ? (prev.closedSessionIds as string[])
+        : [];
+      result.closedSessionIds = Array.from(
+        new Set([...closedIds, ...agentIdsToSuppress]),
+      ).slice(-200);
+    }
+
+    return result;
+  });
+}

--- a/src/hooks/useProjectOps.test.ts
+++ b/src/hooks/useProjectOps.test.ts
@@ -467,6 +467,50 @@ describe("useProjectOps session scoping", () => {
       },
     ]);
   });
+
+  it("excludes project and worktree sessions from the host scope", () => {
+    const { result } = renderProjectOps(
+      makeProjectsState({
+        activeId: null,
+        activeWorktreeId: null,
+        projects: [
+          {
+            id: "project-1",
+            label: "aethon",
+            path: "/projects/aethon",
+            lastUsed: 1,
+          },
+        ],
+        worktreesByProject: {
+          "project-1": [
+            {
+              id: "wt-1",
+              projectId: "project-1",
+              path: "/projects/aethon-fix-session-restore",
+              branch: "fix/session-restore",
+              isMain: false,
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(
+      result.current.scopedDiscoveredSessions([
+        { tabId: "host", lastModified: 1 },
+        { tabId: "project", lastModified: 2, cwd: "/projects/aethon/" },
+        {
+          tabId: "worktree",
+          lastModified: 3,
+          cwd: "/projects/aethon-fix-session-restore",
+        },
+        { tabId: "other-host-cwd", lastModified: 4, cwd: "/tmp/scratch" },
+      ]),
+    ).toEqual([
+      { tabId: "host", lastModified: 1 },
+      { tabId: "other-host-cwd", lastModified: 4, cwd: "/tmp/scratch" },
+    ]);
+  });
 });
 
 describe("useProjectOps overview terminal project switches", () => {


### PR DESCRIPTION
## Summary

- Treat the host/no-project workspace as its own permanent session scope instead of a global catch-all.
- Exclude known project and worktree session cwd values from host-level recent-session discovery and auto-restore inputs.
- Route Close All Sessions through a workspace-aware close operation that clears stale active-bucket session entries while preserving shell tabs.

## Root Cause

Host overview is represented as the no-project workspace. The session discovery path interpreted “no active project” as “all discovered sessions,” so project and worktree transcripts leaked into the host-level recent sessions list and could be auto-restored into the host bucket. Separately, Close All Sessions only closed visible tabs; stale restored bucket entries for the active workspace could survive in the in-memory/persisted bucket mirrors and rehydrate sessions later.

## User Impact

Host-level sessions now behave like a permanent project-like workspace with no worktrees: host recent sessions stay host-scoped, project sessions remain under their projects/worktrees, and closing all host sessions keeps them closed.

## Validation

- `bunx vitest run src/hooks/useProjectOps.test.ts src/eventRoutes/tabStrip.test.ts src/hooks/tabOps/closeWorkspaceSessions.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bunx vitest run`
