### PR TITLE
fix(sidebar): open worktree PR badges externally

### DIFF
--- a/src/extensions/default-layout/sidebar/worktree-row.test.tsx
+++ b/src/extensions/default-layout/sidebar/worktree-row.test.tsx
@@ -9,10 +9,11 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
+import { openUrl } from "@tauri-apps/plugin-opener";
 
 const { branchStatusMock, checksMock } = vi.hoisted(() => ({
-    branchStatusMock: vi.fn(),
-    checksMock: vi.fn(),
+  branchStatusMock: vi.fn(),
+  checksMock: vi.fn(),
 }));
 
 vi.mock("../../../ghBranchStatusCache", () => ({
@@ -20,6 +21,9 @@ vi.mock("../../../ghBranchStatusCache", () => ({
 }));
 vi.mock("../../../ghChecksCache", () => ({
   getGhChecks: checksMock,
+}));
+vi.mock("@tauri-apps/plugin-opener", () => ({
+  openUrl: vi.fn(),
 }));
 
 import {
@@ -33,6 +37,7 @@ afterEach(() => {
   vi.useRealTimers();
   branchStatusMock.mockReset();
   checksMock.mockReset();
+  vi.mocked(openUrl).mockReset();
   cleanup();
 });
 
@@ -73,6 +78,7 @@ function harness(
 
 describe("WorktreeRow", () => {
   beforeEach(() => {
+    vi.mocked(openUrl).mockResolvedValue(undefined);
     branchStatusMock.mockResolvedValue({
       ghAvailable: true,
       repo: "owner/repo",
@@ -188,6 +194,55 @@ describe("WorktreeRow", () => {
     expect(
       document.querySelector(".ae-worktree-pr-ci--pending"),
     ).toBeTruthy();
+  });
+
+  it("opens PR badge links in the user's browser without switching worktrees", async () => {
+    branchStatusMock.mockResolvedValueOnce({
+      ghAvailable: true,
+      repo: "owner/repo",
+      pushed: true,
+      worktreeBroken: false,
+      prs: [
+        {
+          number: 42,
+          state: "OPEN",
+          title: "Feature X",
+          url: "https://github.test/pr/42",
+          isDraft: false,
+          merged: false,
+          baseRefName: "main",
+        },
+      ],
+    });
+    checksMock.mockResolvedValueOnce({
+      ghAvailable: true,
+      repo: "owner/repo",
+      conclusion: "success",
+      total: 1,
+      passed: 1,
+      failed: 0,
+      pending: 0,
+      skipped: 0,
+      checks: [],
+    });
+    const { onEvent } = harness(wt());
+    const badge = await screen.findByLabelText(/Open PR #42/);
+
+    fireEvent.click(badge);
+
+    expect(openUrl).toHaveBeenCalledWith("https://github.test/pr/42");
+    expect(onEvent).not.toHaveBeenCalledWith(
+      "switch-worktree",
+      expect.anything(),
+      expect.anything(),
+    );
+
+    fireEvent.doubleClick(badge);
+    expect(onEvent).not.toHaveBeenCalledWith(
+      "open-worktree-in-new-tab",
+      expect.anything(),
+      expect.anything(),
+    );
   });
 
   it("periodically polls PR and CI badges through the cache getters", async () => {

--- a/src/extensions/default-layout/sidebar/worktree-row.test.tsx
+++ b/src/extensions/default-layout/sidebar/worktree-row.test.tsx
@@ -30,6 +30,7 @@ import {
   WORKTREE_PENDING_CI_REFRESH_MS,
   WORKTREE_PR_REFRESH_MS,
   WorktreeRow,
+  type WorktreeRowProps,
   type WorktreeSidebarItem,
 } from "./worktree-row";
 
@@ -56,7 +57,10 @@ function wt(overrides: Partial<WorktreeSidebarItem> = {}): WorktreeSidebarItem {
 
 function harness(
   item: WorktreeSidebarItem,
-  options: { renaming?: boolean } = {},
+  options: {
+    renaming?: boolean;
+    onPointerDragStart?: WorktreeRowProps["onPointerDragStart"];
+  } = {},
 ) {
   const onEvent = vi.fn();
   const onItemContextMenu = vi.fn();
@@ -70,6 +74,7 @@ function harness(
         onItemContextMenu={onItemContextMenu}
         renaming={options.renaming}
         onRenameEnd={onRenameEnd}
+        onPointerDragStart={options.onPointerDragStart}
       />
     </ul>,
   );
@@ -225,11 +230,14 @@ describe("WorktreeRow", () => {
       skipped: 0,
       checks: [],
     });
-    const { onEvent } = harness(wt());
+    const onPointerDragStart = vi.fn();
+    const { onEvent } = harness(wt(), { onPointerDragStart });
     const badge = await screen.findByLabelText(/Open PR #42/);
 
+    fireEvent.pointerDown(badge);
     fireEvent.click(badge);
 
+    expect(onPointerDragStart).not.toHaveBeenCalled();
     expect(openUrl).toHaveBeenCalledWith("https://github.test/pr/42");
     expect(onEvent).not.toHaveBeenCalledWith(
       "switch-worktree",
@@ -237,7 +245,9 @@ describe("WorktreeRow", () => {
       expect.anything(),
     );
 
+    fireEvent.click(badge, { detail: 2 });
     fireEvent.doubleClick(badge);
+    expect(openUrl).toHaveBeenCalledTimes(1);
     expect(onEvent).not.toHaveBeenCalledWith(
       "open-worktree-in-new-tab",
       expect.anything(),

--- a/src/extensions/default-layout/sidebar/worktree-row.tsx
+++ b/src/extensions/default-layout/sidebar/worktree-row.tsx
@@ -513,9 +513,11 @@ function WorktreePrBadge({ chip }: { chip: WorktreePrChip }) {
         href={url}
         title={chip.title}
         aria-label={chip.title}
+        onPointerDown={(e) => e.stopPropagation()}
         onClick={(e) => {
           e.preventDefault();
           e.stopPropagation();
+          if (e.detail > 1) return;
           void openUrl(url).catch(() => undefined);
         }}
         onDoubleClick={(e) => e.stopPropagation()}

--- a/src/extensions/default-layout/sidebar/worktree-row.tsx
+++ b/src/extensions/default-layout/sidebar/worktree-row.tsx
@@ -14,6 +14,7 @@
  */
 
 import { useEffect, useRef, useState, type CSSProperties } from "react";
+import { openUrl } from "@tauri-apps/plugin-opener";
 import type { BuiltinComponentProps } from "../../../components/A2UIRenderer";
 import type { AgentActivitySummary } from "../../../hooks/projectOps/agentActivity";
 import { getGhBranchStatus } from "../../../ghBranchStatusCache";
@@ -505,15 +506,18 @@ function WorktreePrBadge({ chip }: { chip: WorktreePrChip }) {
   );
   const className = `ae-worktree-pr-chip ae-worktree-pr-chip--${chip.kind}`;
   if (chip.url) {
+    const url = chip.url;
     return (
       <a
         className={className}
-        href={chip.url}
-        target="_blank"
-        rel="noreferrer"
+        href={url}
         title={chip.title}
         aria-label={chip.title}
-        onClick={(e) => e.stopPropagation()}
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          void openUrl(url).catch(() => undefined);
+        }}
         onDoubleClick={(e) => e.stopPropagation()}
       >
         {content}


### PR DESCRIPTION
## Summary
- open worktree PR badge URLs via Tauri opener instead of raw target=_blank webview links
- keep click/double-click propagation isolated from parent worktree rows
- add regression coverage for PR badge opening behavior

Fixes #242

## Test plan
- bun run test src/extensions/default-layout/sidebar/worktree-row.test.tsx
- bun run typecheck