### PR TITLE
fix(chat): stabilize virtual sticky follow

### DIFF
--- a/src/extensions/default-layout/chat.test.tsx
+++ b/src/extensions/default-layout/chat.test.tsx
@@ -494,6 +494,51 @@ describe("ChatInput", () => {
     expect((virtuosoMockState.followOutput as () => unknown)()).toBe("smooth");
   });
 
+  it("does not treat non-scrolling keydown events as user scroll-away", () => {
+    renderHistory({
+      messages: [
+        { id: "1", role: "user", text: "start" },
+        { id: "2", role: "agent", text: "streaming update" },
+      ],
+    });
+
+    expect(virtuosoMockState.followOutput).toEqual(expect.any(Function));
+    expect((virtuosoMockState.followOutput as () => unknown)()).toBe("smooth");
+
+    const scroller = screen.getByTestId("virtuoso-mock");
+    fireEvent.keyDown(scroller, { key: "Enter" });
+    scroller.scrollTop = 100;
+    fireEvent.scroll(scroller);
+
+    expect(
+      screen.queryByRole("button", { name: "Scroll to latest message" }),
+    ).toBeNull();
+    expect(virtuosoMockState.followOutput).toEqual(expect.any(Function));
+    expect((virtuosoMockState.followOutput as () => unknown)()).toBe("smooth");
+  });
+
+  it("treats scrolling keydown events as user scroll-away", () => {
+    renderHistory({
+      messages: [
+        { id: "1", role: "user", text: "start" },
+        { id: "2", role: "agent", text: "streaming update" },
+      ],
+    });
+
+    expect(virtuosoMockState.followOutput).toEqual(expect.any(Function));
+    expect((virtuosoMockState.followOutput as () => unknown)()).toBe("smooth");
+
+    const scroller = screen.getByTestId("virtuoso-mock");
+    fireEvent.keyDown(scroller, { key: "PageUp" });
+    scroller.scrollTop = 100;
+    fireEvent.scroll(scroller);
+
+    expect(
+      screen.getByRole("button", { name: "Scroll to latest message" }),
+    ).toBeTruthy();
+    expect(virtuosoMockState.followOutput).toBe(false);
+  });
+
   it("disables Virtuoso followOutput when the user scrolls away", () => {
     const messages = [
       { id: "1", role: "user", text: "start" },

--- a/src/extensions/default-layout/chat.test.tsx
+++ b/src/extensions/default-layout/chat.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { useEffect } from "react";
+import { forwardRef, useEffect, useImperativeHandle } from "react";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -13,9 +13,17 @@ const { openUrl } = vi.hoisted(() => ({
   openUrl: vi.fn(),
 }));
 
-const virtuosoMockState = vi.hoisted((): { followOutput?: unknown } => ({
-  followOutput: undefined,
-}));
+const virtuosoMockState = vi.hoisted(
+  (): {
+    followOutput?: unknown;
+    scrollToCalls: unknown[];
+    scrollToIndexCalls: unknown[];
+  } => ({
+    followOutput: undefined,
+    scrollToCalls: [],
+    scrollToIndexCalls: [],
+  }),
+);
 
 vi.mock("@tauri-apps/plugin-opener", () => ({
   openUrl: (...args: unknown[]) => openUrl(...args),
@@ -34,58 +42,77 @@ vi.mock("../../components/HighlightedCode", () => ({
 // nothing. Render all rows synchronously here — scroll/measurement behavior is
 // verified live in the app, while these tests assert row content + memoization.
 vi.mock("react-virtuoso", () => ({
-  Virtuoso: ({
-    data = [],
-    itemContent,
-    components,
-    context,
-    className,
-    atBottomStateChange,
-    scrollerRef,
-    totalListHeightChanged,
-    followOutput,
-  }: {
-    data?: Array<{ id?: string }>;
-    itemContent: (index: number, item: unknown) => React.ReactNode;
-    components?: { Footer?: (props: { context?: unknown }) => React.ReactNode };
-    context?: unknown;
-    className?: string;
-    atBottomStateChange?: (atBottom: boolean) => void;
-    scrollerRef?: (ref: HTMLElement | null) => void;
-    totalListHeightChanged?: (height: number) => void;
-    followOutput?: unknown;
-  }) => {
-    const Footer = components?.Footer;
-    virtuosoMockState.followOutput = followOutput;
-    useEffect(() => {
-      const el = document.querySelector<HTMLElement>(
-        "[data-testid='virtuoso-mock']",
-      );
-      if (el) {
-        Object.defineProperties(el, {
-          scrollHeight: { value: 1000, configurable: true },
-          clientHeight: { value: 500, configurable: true },
-          scrollTop: {
-            value: 470,
-            writable: true,
-            configurable: true,
+  Virtuoso: forwardRef(
+    (
+      {
+        data = [],
+        itemContent,
+        components,
+        context,
+        className,
+        atBottomStateChange,
+        scrollerRef,
+        totalListHeightChanged,
+        followOutput,
+      }: {
+        data?: Array<{ id?: string }>;
+        itemContent: (index: number, item: unknown) => React.ReactNode;
+        components?: {
+          Footer?: (props: { context?: unknown }) => React.ReactNode;
+        };
+        context?: unknown;
+        className?: string;
+        atBottomStateChange?: (atBottom: boolean) => void;
+        scrollerRef?: (ref: HTMLElement | null) => void;
+        totalListHeightChanged?: (height: number) => void;
+        followOutput?: unknown;
+      },
+      ref,
+    ) => {
+      const Footer = components?.Footer;
+      virtuosoMockState.followOutput = followOutput;
+      useImperativeHandle(
+        ref,
+        () => ({
+          scrollTo: (options: unknown) => {
+            virtuosoMockState.scrollToCalls.push(options);
           },
-        });
-      }
-      scrollerRef?.(el);
-      totalListHeightChanged?.(0);
-      atBottomStateChange?.(false);
-      return () => scrollerRef?.(null);
-    }, [atBottomStateChange, scrollerRef, totalListHeightChanged]);
-    return (
-      <div className={className} data-testid="virtuoso-mock">
-        {data.map((item, index) => (
-          <div key={item.id ?? index}>{itemContent(index, item)}</div>
-        ))}
-        {Footer ? <Footer context={context} /> : null}
-      </div>
-    );
-  },
+          scrollToIndex: (options: unknown) => {
+            virtuosoMockState.scrollToIndexCalls.push(options);
+          },
+        }),
+        [],
+      );
+      useEffect(() => {
+        const el = document.querySelector<HTMLElement>(
+          "[data-testid='virtuoso-mock']",
+        );
+        if (el) {
+          Object.defineProperties(el, {
+            scrollHeight: { value: 1000, configurable: true },
+            clientHeight: { value: 500, configurable: true },
+            scrollTop: {
+              value: 470,
+              writable: true,
+              configurable: true,
+            },
+          });
+        }
+        scrollerRef?.(el);
+        totalListHeightChanged?.(0);
+        atBottomStateChange?.(false);
+        return () => scrollerRef?.(null);
+      }, [atBottomStateChange, scrollerRef, totalListHeightChanged]);
+      return (
+        <div className={className} data-testid="virtuoso-mock">
+          {data.map((item, index) => (
+            <div key={item.id ?? index}>{itemContent(index, item)}</div>
+          ))}
+          {Footer ? <Footer context={context} /> : null}
+        </div>
+      );
+    },
+  ),
 }));
 import { ExtensionRegistry } from "../ExtensionRegistry";
 import { ExtensionRegistryProvider } from "../ExtensionRegistryProvider";
@@ -100,6 +127,9 @@ class ResizeObserverMock {
 beforeEach(() => {
   vi.stubGlobal("ResizeObserver", ResizeObserverMock);
   openUrl.mockResolvedValue(undefined);
+  virtuosoMockState.followOutput = undefined;
+  virtuosoMockState.scrollToCalls = [];
+  virtuosoMockState.scrollToIndexCalls = [];
 });
 
 afterEach(() => {
@@ -440,6 +470,69 @@ describe("ChatInput", () => {
     ).toBeNull();
     expect(virtuosoMockState.followOutput).toEqual(expect.any(Function));
     expect((virtuosoMockState.followOutput as () => unknown)()).toBe("smooth");
+  });
+
+  it("ignores intermediate non-bottom scroll events from programmatic follow", () => {
+    renderHistory({
+      messages: [
+        { id: "1", role: "user", text: "start" },
+        { id: "2", role: "agent", text: "streaming update" },
+      ],
+    });
+
+    expect(virtuosoMockState.followOutput).toEqual(expect.any(Function));
+    expect((virtuosoMockState.followOutput as () => unknown)()).toBe("smooth");
+
+    const scroller = screen.getByTestId("virtuoso-mock");
+    scroller.scrollTop = 100;
+    fireEvent.scroll(scroller);
+
+    expect(
+      screen.queryByRole("button", { name: "Scroll to latest message" }),
+    ).toBeNull();
+    expect(virtuosoMockState.followOutput).toEqual(expect.any(Function));
+    expect((virtuosoMockState.followOutput as () => unknown)()).toBe("smooth");
+  });
+
+  it("disables Virtuoso followOutput when the user scrolls away", () => {
+    const messages = [
+      { id: "1", role: "user", text: "start" },
+      { id: "2", role: "agent", text: "streaming update", thinking: "plan" },
+    ];
+    const { onEvent, rerender } = renderHistory({
+      waiting: true,
+      messages,
+    });
+
+    const scroller = screen.getByTestId("virtuoso-mock");
+    fireEvent.wheel(scroller);
+    scroller.scrollTop = 100;
+    fireEvent.scroll(scroller);
+
+    expect(
+      screen.getByRole("button", { name: "Scroll to latest message" }),
+    ).toBeTruthy();
+    expect(virtuosoMockState.followOutput).toBe(false);
+
+    rerender(
+      <ChatHistory
+        component={{
+          id: "chat-history",
+          type: "chat-history",
+          props: { messages: { $ref: "/messages" } },
+        }}
+        state={{
+          waiting: true,
+          messages: [
+            messages[0],
+            { ...messages[1], thinking: "plan\nmore streamed thinking" },
+          ],
+        }}
+        onEvent={onEvent}
+      />,
+    );
+
+    expect(virtuosoMockState.followOutput).toBe(false);
   });
 
   it("uses stable non-animated follow only while the latest agent text streams a fenced block", () => {
@@ -806,6 +899,77 @@ describe("ChatHistory tool-call grouping (mocked Virtuoso renders rows)", () => 
       transcriptVisibility: { toolCalls: "group-run" },
     });
     expect(screen.getByText("2 tool calls")).toBeTruthy();
+  });
+
+  it("keeps followOutput disabled when completed tool cards collapse into a group after user scroll-away", () => {
+    const registry = new ExtensionRegistry();
+    registry.register({
+      name: "test-tool-card",
+      components: { "tool-card": ToolCard },
+    });
+    const onEvent = vi.fn();
+    const withHistory = (messages: unknown[]) => (
+      <ExtensionRegistryProvider registry={registry}>
+        <ChatHistory
+          component={{
+            id: "chat-history",
+            type: "chat-history",
+            props: { messages: { $ref: "/messages" } },
+          }}
+          state={{
+            messages,
+            transcriptVisibility: { toolCalls: "group-run" },
+          }}
+          onEvent={onEvent}
+        />
+      </ExtensionRegistryProvider>
+    );
+    const running = [
+      { id: "u1", role: "user", text: "do tools" },
+      {
+        id: "t1",
+        role: "agent",
+        a2ui: {
+          components: [
+            { id: "c1", type: "tool-card", props: { title: "read", startedAt: 1, endedAt: 2 } },
+          ],
+        },
+      },
+      {
+        id: "t2",
+        role: "agent",
+        a2ui: {
+          components: [
+            { id: "c2", type: "tool-card", props: { title: "bash", startedAt: 3 } },
+          ],
+        },
+      },
+    ];
+    const { rerender } = render(withHistory(running));
+
+    const scroller = screen.getByTestId("virtuoso-mock");
+    fireEvent.wheel(scroller);
+    scroller.scrollTop = 100;
+    fireEvent.scroll(scroller);
+    expect(virtuosoMockState.followOutput).toBe(false);
+
+    rerender(
+      withHistory([
+        running[0],
+        running[1],
+        {
+          ...running[2],
+          a2ui: {
+            components: [
+              { id: "c2", type: "tool-card", props: { title: "bash", startedAt: 3, endedAt: 4 } },
+            ],
+          },
+        },
+      ]),
+    );
+
+    expect(screen.getByText("2 tool calls")).toBeTruthy();
+    expect(virtuosoMockState.followOutput).toBe(false);
   });
 
   it("group-turn folds a turn's tools into one cluster with a name peek", () => {

--- a/src/extensions/default-layout/message-list.tsx
+++ b/src/extensions/default-layout/message-list.tsx
@@ -1,4 +1,12 @@
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import ReactMarkdown from "react-markdown";
 import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
 import type {
@@ -34,7 +42,33 @@ import { ImageLightbox } from "./image-lightbox";
 // Distance (px) from the bottom still treated as "at the bottom" for follow +
 // the scroll-to-bottom pill. Matches the old StickyScrollController default.
 const DEFAULT_AT_BOTTOM_THRESHOLD = 60;
+const PROGRAMMATIC_SCROLL_GUARD_MS = 1200;
 const FENCED_CODE_MARKER_RE = /(^|\n)(```|~~~)/;
+const USER_SCROLL_INTENT_EVENTS = [
+  "wheel",
+  "touchstart",
+  "touchmove",
+  "pointerdown",
+  "keydown",
+] as const;
+
+function addUserScrollIntentListeners(
+  el: HTMLElement,
+  listener: EventListener,
+): void {
+  for (const eventName of USER_SCROLL_INTENT_EVENTS) {
+    el.addEventListener(eventName, listener, { passive: true });
+  }
+}
+
+function removeUserScrollIntentListeners(
+  el: HTMLElement,
+  listener: EventListener,
+): void {
+  for (const eventName of USER_SCROLL_INTENT_EVENTS) {
+    el.removeEventListener(eventName, listener);
+  }
+}
 
 // Top-level state keys that change identity on every streamed token — the
 // active tab's `messages` array and the `tabs` array that nests it (both
@@ -606,6 +640,9 @@ function VirtualMessageList({
   const [canScroll, setCanScroll] = useState(false);
   const scrollerElRef = useRef<HTMLElement | null>(null);
   const followLatestRef = useRef(true);
+  const [followLatest, setFollowLatestState] = useState(true);
+  const programmaticScrollUntilRef = useRef(0);
+  const userScrollIntentRef = useRef(false);
   const [flashIndex, setFlashIndex] = useState<number | null>(null);
   const prevScrollToMatch = useRef<string | undefined>(undefined);
   const queuedLabels = useMemo(
@@ -633,6 +670,23 @@ function VirtualMessageList({
       return next;
     });
   }, []);
+  const setFollowLatest = useCallback((next: boolean) => {
+    followLatestRef.current = next;
+    setFollowLatestState(next);
+  }, []);
+
+  const markProgrammaticScroll = useCallback(() => {
+    programmaticScrollUntilRef.current = Math.max(
+      programmaticScrollUntilRef.current,
+      Date.now() + PROGRAMMATIC_SCROLL_GUARD_MS,
+    );
+  }, []);
+
+  const markUserScrollIntent = useCallback(() => {
+    userScrollIntentRef.current = true;
+    programmaticScrollUntilRef.current = 0;
+  }, []);
+
   const updateCanScroll = useCallback(() => {
     const el = scrollerElRef.current;
     setCanScroll(
@@ -641,6 +695,11 @@ function VirtualMessageList({
       ),
     );
   }, []);
+
+  const scrollToBottom = useCallback(() => {
+    markProgrammaticScroll();
+    virtuosoRef.current?.scrollTo({ top: Number.MAX_SAFE_INTEGER });
+  }, [markProgrammaticScroll]);
 
   const updateFollowFromScroller = useCallback(() => {
     const el = scrollerElRef.current;
@@ -653,10 +712,25 @@ function VirtualMessageList({
       },
       DEFAULT_AT_BOTTOM_THRESHOLD,
     );
-    followLatestRef.current = atBottom;
-    setIsAtBottom(atBottom);
+    const isProgrammaticFollowScroll =
+      Date.now() < programmaticScrollUntilRef.current &&
+      !userScrollIntentRef.current;
+
     updateCanScroll();
-  }, [updateCanScroll]);
+
+    if (isProgrammaticFollowScroll) {
+      if (atBottom) {
+        programmaticScrollUntilRef.current = 0;
+        setFollowLatest(true);
+        setIsAtBottom(true);
+      }
+      return;
+    }
+
+    userScrollIntentRef.current = false;
+    setFollowLatest(atBottom);
+    setIsAtBottom(atBottom);
+  }, [setFollowLatest, updateCanScroll]);
 
   const handleScrollerRef = useCallback(
     (ref: HTMLElement | Window | null) => {
@@ -664,6 +738,10 @@ function VirtualMessageList({
         scrollerElRef.current.removeEventListener(
           "scroll",
           updateFollowFromScroller,
+        );
+        removeUserScrollIntentListeners(
+          scrollerElRef.current,
+          markUserScrollIntent,
         );
       }
       const el =
@@ -675,23 +753,25 @@ function VirtualMessageList({
         el.addEventListener("scroll", updateFollowFromScroller, {
           passive: true,
         });
+        addUserScrollIntentListeners(el, markUserScrollIntent);
       }
       updateCanScroll();
     },
-    [updateCanScroll, updateFollowFromScroller],
+    [markUserScrollIntent, updateCanScroll, updateFollowFromScroller],
   );
 
   const handleAtBottomStateChange = useCallback(
     (atBottom: boolean) => {
       updateCanScroll();
       if (atBottom) {
-        followLatestRef.current = true;
+        programmaticScrollUntilRef.current = 0;
+        setFollowLatest(true);
         setIsAtBottom(true);
       } else if (!followLatestRef.current) {
         setIsAtBottom(false);
       }
     },
-    [updateCanScroll],
+    [setFollowLatest, updateCanScroll],
   );
 
   useEffect(
@@ -701,9 +781,13 @@ function VirtualMessageList({
           "scroll",
           updateFollowFromScroller,
         );
+        removeUserScrollIntentListeners(
+          scrollerElRef.current,
+          markUserScrollIntent,
+        );
       }
     },
-    [updateFollowFromScroller],
+    [markUserScrollIntent, updateFollowFromScroller],
   );
 
   // Jump to the newest message matching the search needle and flash it. Virtuoso
@@ -829,6 +913,38 @@ function VirtualMessageList({
     state.waiting === true &&
     hasFencedCodeMarker(latestMessage.text);
 
+  const handleFollowOutput = useCallback(() => {
+    if (!followLatestRef.current) return false;
+    markProgrammaticScroll();
+    return latestStreamingFences ? "auto" : "smooth";
+  }, [latestStreamingFences, markProgrammaticScroll]);
+
+  const handleTotalListHeightChanged = useCallback(() => {
+    updateCanScroll();
+    if (followLatestRef.current) scrollToBottom();
+  }, [scrollToBottom, updateCanScroll]);
+
+  // Tool grouping and streamed thinking frequently change row keys/counts or
+  // measured heights without a simple "new last item appended" signal. When
+  // follow intent is still enabled, explicitly pin the scroller after React has
+  // committed the new rows; when the user has scrolled away, `followLatest`
+  // stays false and this path is inert.
+  useLayoutEffect(() => {
+    updateCanScroll();
+    if (!followLatest) return;
+    const frame = window.requestAnimationFrame(scrollToBottom);
+    return () => window.cancelAnimationFrame(frame);
+  }, [
+    expandedGroups,
+    followLatest,
+    footerContext,
+    groups,
+    messages,
+    scrollToBottom,
+    updateCanScroll,
+    visibility.thinking,
+  ]);
+
   return (
     <div className="a2ui-msg-list-shell">
       <Virtuoso
@@ -850,28 +966,22 @@ function VirtualMessageList({
           index: Math.max(0, groups.length - 1),
           align: "end",
         }}
-        followOutput={() =>
-          followLatestRef.current
-            ? latestStreamingFences
-              ? "auto"
-              : "smooth"
-            : false
-        }
+        followOutput={followLatest ? handleFollowOutput : false}
         atBottomThreshold={DEFAULT_AT_BOTTOM_THRESHOLD}
         atBottomStateChange={handleAtBottomStateChange}
         scrollerRef={handleScrollerRef}
-        totalListHeightChanged={updateCanScroll}
+        totalListHeightChanged={handleTotalListHeightChanged}
         {...footerProps}
       />
       <ScrollToBottomPill
         visible={!isAtBottom && canScroll && hasContent}
         onClick={() => {
-          followLatestRef.current = true;
+          setFollowLatest(true);
           setIsAtBottom(true);
           // Scroll to the true bottom of the scroller, which includes the
           // Footer (live subtree / typing indicator) — scrollToIndex(last)
           // would stop at the last message, above a footer-only response.
-          virtuosoRef.current?.scrollTo({ top: Number.MAX_SAFE_INTEGER });
+          scrollToBottom();
         }}
       />
     </div>

--- a/src/extensions/default-layout/message-list.tsx
+++ b/src/extensions/default-layout/message-list.tsx
@@ -51,6 +51,33 @@ const USER_SCROLL_INTENT_EVENTS = [
   "pointerdown",
   "keydown",
 ] as const;
+const SCROLL_INTENT_KEYS = new Set([
+  "ArrowUp",
+  "ArrowDown",
+  "PageUp",
+  "PageDown",
+  "Home",
+  "End",
+  " ",
+  "Spacebar",
+]);
+
+function isInteractiveKeyboardTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target.isContentEditable) return true;
+  return Boolean(
+    target.closest(
+      "button,a,input,textarea,select,[role='button'],[role='link'],[role='textbox'],[tabindex]:not([tabindex='-1'])",
+    ),
+  );
+}
+
+function isUserScrollIntentEvent(event: Event): boolean {
+  if (!(event instanceof KeyboardEvent)) return true;
+  if (!SCROLL_INTENT_KEYS.has(event.key)) return false;
+  if (isInteractiveKeyboardTarget(event.target)) return false;
+  return true;
+}
 
 function addUserScrollIntentListeners(
   el: HTMLElement,
@@ -682,7 +709,8 @@ function VirtualMessageList({
     );
   }, []);
 
-  const markUserScrollIntent = useCallback(() => {
+  const markUserScrollIntent = useCallback((event: Event) => {
+    if (!isUserScrollIntentEvent(event)) return;
     userScrollIntentRef.current = true;
     programmaticScrollUntilRef.current = 0;
   }, []);


### PR DESCRIPTION
## Summary
- track explicit follow intent in the virtualized chat feed
- ignore programmatic follow-scroll events unless a user scroll intent is seen
- disable Virtuoso followOutput when the user scrolls away and explicitly repin dynamic grouped/thinking changes only while following
- add regressions for thinking updates and tool-card grouping scroll behavior

Fixes #241

## Validation
- bunx vitest run src/extensions/default-layout/chat.test.tsx src/extensions/default-layout/message-list.virtuoso.test.tsx src/utils/stickyScrollController.test.ts src/utils/toolCardGrouping.test.ts --environment jsdom
- bun run typecheck
- bun run lint
- bunx vitest run
- codex review --uncommitted