### PR TITLE
fix(agent): isolate tab activity hydration

### DIFF
--- a/agent/session-history.test.ts
+++ b/agent/session-history.test.ts
@@ -388,14 +388,26 @@ describe("readSessionTranscript", () => {
     });
 
     await expect(readSessionTranscript(dir)).resolves.toEqual([
-      { id: "pi-user", entryId: "pi-user", role: "user", text: "hi", createdAt: 1_000 },
+      {
+        id: "pi-user",
+        entryId: "pi-user",
+        role: "user",
+        text: "hi",
+        createdAt: 1_000,
+      },
       {
         id: "stderr-warning",
         role: "system",
         text: "[agent stderr] transient provider error",
         createdAt: 2_000,
       },
-      { id: "pi-agent", entryId: "pi-agent", role: "agent", text: "done", createdAt: 3_000 },
+      {
+        id: "pi-agent",
+        entryId: "pi-agent",
+        role: "agent",
+        text: "done",
+        createdAt: 3_000,
+      },
     ]);
   });
 
@@ -443,14 +455,26 @@ describe("readSessionTranscript", () => {
     });
 
     await expect(readSessionTranscript(dir)).resolves.toEqual([
-      { id: "pi-user", entryId: "pi-user", role: "user", text: "hi", createdAt: 1_000 },
+      {
+        id: "pi-user",
+        entryId: "pi-user",
+        role: "user",
+        text: "hi",
+        createdAt: 1_000,
+      },
       {
         id: "compaction:cmp-1",
         role: "system",
         text: "Context compacted · 13,005 tokens summarized",
         createdAt: 2_000,
       },
-      { id: "pi-agent", entryId: "pi-agent", role: "agent", text: "done", createdAt: 3_000 },
+      {
+        id: "pi-agent",
+        entryId: "pi-agent",
+        role: "agent",
+        text: "done",
+        createdAt: 3_000,
+      },
     ]);
   });
 
@@ -610,7 +634,12 @@ describe("readSessionTranscript", () => {
         role: "user",
         text: "Please work on issue 85",
       },
-      { id: "pi-agent", entryId: "pi-agent", role: "agent", text: "Working on it" },
+      {
+        id: "pi-agent",
+        entryId: "pi-agent",
+        role: "agent",
+        text: "Working on it",
+      },
     ]);
   });
 
@@ -722,6 +751,67 @@ describe("readSessionTranscript", () => {
     expect(restored.at(-1)?.a2ui?.components[0]).toMatchObject({
       type: "tool-card",
       props: { toolName: "bash", startedAt: 3_000 },
+    });
+  });
+
+  it("keeps locally cancelled tool cards ahead of late pi completions on restore", async () => {
+    const dir = await tempRoot();
+    await writeFile(
+      join(dir, "session.jsonl"),
+      `${JSON.stringify({
+        type: "message",
+        id: "assistant-tool",
+        timestamp: 3_000,
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "call_late_1|fc_abc",
+              name: "bash",
+              arguments: { command: "sleep 60" },
+            },
+          ],
+        },
+      })}\n${JSON.stringify({
+        type: "message",
+        id: "tool-result",
+        timestamp: 5_000,
+        message: {
+          role: "toolResult",
+          toolCallId: "call_late_1|fc_abc",
+          toolName: "bash",
+          content: [{ type: "text", text: "done" }],
+        },
+      })}\n`,
+    );
+    await appendLocalChatMessage(dir, {
+      id: "tool-7-call_late_1-fc_abc",
+      role: "agent",
+      a2ui: {
+        components: [
+          {
+            id: "tool-7-call_late_1-fc_abc",
+            type: "tool-card",
+            props: {
+              toolName: "bash",
+              startedAt: 3_000,
+              endedAt: 4_000,
+              status: "cancelled",
+            },
+          },
+        ],
+      },
+      createdAt: 4_000,
+    });
+
+    const restored = await readSessionTranscript(dir);
+    expect(restored.map((message) => message.id)).toEqual([
+      "tool-7-call_late_1-fc_abc",
+    ]);
+    expect(restored[0].a2ui?.components[0].props).toMatchObject({
+      status: "cancelled",
+      endedAt: 4_000,
     });
   });
 

--- a/agent/session-history/restore.ts
+++ b/agent/session-history/restore.ts
@@ -109,9 +109,11 @@ function toolCardIdentityFromId(id: string): string | undefined {
   return undefined;
 }
 
-function toolCardIdentities(message: RestoredChatMessage): string[] {
+function toolCardRecords(
+  message: RestoredChatMessage,
+): Array<{ identity: string; status?: unknown }> {
   const components = message.a2ui?.components ?? [];
-  const identities: string[] = [];
+  const records: Array<{ identity: string; status?: unknown }> = [];
   for (const component of components) {
     if (!component || typeof component !== "object") continue;
     const record = component as Record<string, unknown>;
@@ -119,9 +121,18 @@ function toolCardIdentities(message: RestoredChatMessage): string[] {
       continue;
     }
     const identity = toolCardIdentityFromId(record.id);
-    if (identity) identities.push(identity);
+    if (!identity) continue;
+    const props =
+      record.props && typeof record.props === "object"
+        ? (record.props as Record<string, unknown>)
+        : undefined;
+    records.push({ identity, status: props?.status });
   }
-  return identities;
+  return records;
+}
+
+function toolCardIdentities(message: RestoredChatMessage): string[] {
+  return toolCardRecords(message).map((record) => record.identity);
 }
 
 function piToolCardIdentitySet(piMessages: RestoredChatMessage[]): Set<string> {
@@ -133,15 +144,51 @@ function piToolCardIdentitySet(piMessages: RestoredChatMessage[]): Set<string> {
   return identities;
 }
 
+function isCancelledToolCardMessage(message: RestoredChatMessage): boolean {
+  const records = toolCardRecords(message);
+  return (
+    records.length > 0 &&
+    records.some((record) => record.status === "cancelled")
+  );
+}
+
+function cancelledToolCardIdentitySet(
+  messages: RestoredChatMessage[],
+): Set<string> {
+  const identities = new Set<string>();
+  for (const message of messages) {
+    for (const record of toolCardRecords(message)) {
+      if (record.status === "cancelled") identities.add(record.identity);
+    }
+  }
+  return identities;
+}
+
 function isCoveredByPiToolCard(
   message: RestoredChatMessage,
   piToolCards: ReadonlySet<string>,
 ): boolean {
+  if (isCancelledToolCardMessage(message)) return false;
   const identities = toolCardIdentities(message);
   return (
     identities.length > 0 &&
     identities.every((identity) => piToolCards.has(identity))
   );
+}
+
+function removePiToolCardsCoveredByLocalCancellation(
+  piMessages: RestoredChatMessage[],
+  localMessages: RestoredChatMessage[],
+): RestoredChatMessage[] {
+  const cancelledIdentities = cancelledToolCardIdentitySet(localMessages);
+  if (cancelledIdentities.size === 0) return piMessages;
+  return piMessages.filter((message) => {
+    const identities = toolCardIdentities(message);
+    return (
+      identities.length === 0 ||
+      !identities.every((identity) => cancelledIdentities.has(identity))
+    );
+  });
 }
 
 function isCompactionMarker(message: RestoredChatMessage): boolean {
@@ -162,7 +209,8 @@ function piCompactionMarkers(
   piMessages: RestoredChatMessage[],
 ): RestoredChatMessage[] {
   return piMessages.filter(
-    (message) => message.id.startsWith("compaction:") && isCompactionMarker(message),
+    (message) =>
+      message.id.startsWith("compaction:") && isCompactionMarker(message),
   );
 }
 
@@ -329,7 +377,10 @@ export async function readSessionTranscript(
   if (!path) return localMessages.slice(-MAX_RESTORED_MESSAGES);
 
   const raw = await readFile(path, "utf8");
-  const piMessages = parseSessionHistoryLines(raw.split(/\r?\n/));
+  const piMessages = removePiToolCardsCoveredByLocalCancellation(
+    parseSessionHistoryLines(raw.split(/\r?\n/)),
+    localMessages,
+  );
   const mergedPiMessages = mergeLocalAttachmentsIntoPiMessages(
     piMessages,
     localMessages,

--- a/src-tauri/src/agent_process/process.rs
+++ b/src-tauri/src/agent_process/process.rs
@@ -232,17 +232,7 @@ pub(crate) fn retire_agent_key(state: &State<'_, AgentProcesses>, key: &str) -> 
     Ok(())
 }
 
-pub(crate) fn route_payload_key(
-    state: &State<'_, AgentProcesses>,
-    payload: &serde_json::Value,
-) -> String {
-    if payload.get("type").and_then(|v| v.as_str()) == Some("mutation_ack")
-        && let Some(mutation_id) = payload.get("mutationId").and_then(|v| v.as_str())
-        && let Ok(mut routes) = state.mutation_routes.lock()
-        && let Some(key) = routes.remove(mutation_id)
-    {
-        return key;
-    }
+fn route_payload_key_without_mutation(payload: &serde_json::Value) -> String {
     let tab_scoped = matches!(
         payload.get("type").and_then(|v| v.as_str()),
         Some(
@@ -266,12 +256,26 @@ pub(crate) fn route_payload_key(
     GLOBAL_AGENT_KEY.to_string()
 }
 
+pub(crate) fn route_payload_key(
+    state: &State<'_, AgentProcesses>,
+    payload: &serde_json::Value,
+) -> String {
+    if payload.get("type").and_then(|v| v.as_str()) == Some("mutation_ack")
+        && let Some(mutation_id) = payload.get("mutationId").and_then(|v| v.as_str())
+        && let Ok(mut routes) = state.mutation_routes.lock()
+        && let Some(key) = routes.remove(mutation_id)
+    {
+        return key;
+    }
+    route_payload_key_without_mutation(payload)
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
         Arc, GLOBAL_AGENT_KEY, HashMap, HashSet, Instant, Mutex, WorkerMeta, idle_keys_to_retire,
-        keys_to_reconcile, payload_starts_prompt, should_retire_idle, tab_agent_key,
-        touch_worker_activity,
+        keys_to_reconcile, payload_starts_prompt, route_payload_key_without_mutation,
+        should_retire_idle, tab_agent_key, touch_worker_activity,
     };
     use std::time::Duration;
 
@@ -407,6 +411,37 @@ mod tests {
     #[test]
     fn tab_agent_key_keeps_tab_prefix() {
         assert_eq!(tab_agent_key("abc"), "tab:abc");
+    }
+
+    #[test]
+    fn tab_scoped_chats_route_to_distinct_workers() {
+        let first = route_payload_key_without_mutation(&serde_json::json!({
+            "type": "chat",
+            "tabId": "tab-a",
+        }));
+        let second = route_payload_key_without_mutation(&serde_json::json!({
+            "type": "chat",
+            "tabId": "tab-b",
+        }));
+
+        assert_eq!(first, tab_agent_key("tab-a"));
+        assert_eq!(second, tab_agent_key("tab-b"));
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn default_and_unscoped_payloads_route_to_global_worker() {
+        assert_eq!(
+            route_payload_key_without_mutation(&serde_json::json!({
+                "type": "chat",
+                "tabId": "default",
+            })),
+            GLOBAL_AGENT_KEY
+        );
+        assert_eq!(
+            route_payload_key_without_mutation(&serde_json::json!({ "type": "report" })),
+            GLOBAL_AGENT_KEY
+        );
     }
 
     #[test]

--- a/src/hooks/bridgeMessageHandlers/a2ui.test.ts
+++ b/src/hooks/bridgeMessageHandlers/a2ui.test.ts
@@ -93,7 +93,7 @@ describe("handleA2ui", () => {
     );
   });
 
-  it("replaces a stale cancelled terminal tool card when the final event has a sibling id", () => {
+  it("preserves cancellation state when a late final event has a sibling id", () => {
     const runningId =
       "restored-tool-call_run-fc_01a0cf101a3d1343016a14d6465b9c819b8b75c60642c6bd59";
     const finalId =
@@ -151,8 +151,149 @@ describe("handleA2ui", () => {
     expect(out.messages[0]).toMatchObject({
       id: finalId,
       role: "agent",
-      a2ui: payload,
+      a2ui: {
+        components: [
+          {
+            id: finalId,
+            props: {
+              status: "cancelled",
+              startedAt: 1_000,
+              endedAt: 2_000,
+            },
+            children: [
+              {
+                id: `${finalId}-late-completion-notice`,
+                props: {
+                  content: expect.stringContaining(
+                    "reported a final result after it had already been marked stopped",
+                  ),
+                },
+              },
+            ],
+          },
+        ],
+      },
     });
+  });
+
+  it("preserves cancellation state when a late final event reuses the same id", () => {
+    const id = "tool-1-call_1";
+    const tab = {
+      ...makeEmptyTab("tab-1", "Tab 1"),
+      messages: [
+        {
+          id,
+          role: "agent",
+          a2ui: {
+            components: [
+              {
+                id,
+                type: "tool-card",
+                props: {
+                  title: "bash",
+                  toolName: "bash",
+                  startedAt: 1_000,
+                  endedAt: 1_500,
+                  status: "cancelled",
+                },
+              },
+            ],
+          },
+        } satisfies ChatMessage,
+      ],
+    };
+    const { ctx, mocks } = buildHandlerFixture({
+      state: { activeTabId: "tab-1", tabs: [tab] },
+    });
+    const payload = {
+      components: [
+        {
+          id,
+          type: "tool-card",
+          props: {
+            title: "bash",
+            toolName: "bash",
+            startedAt: 1_000,
+            endedAt: 2_000,
+          },
+        },
+      ],
+    };
+
+    handleA2ui({ type: "a2ui", payload, id, tabId: "tab-1" }, ctx);
+
+    expect(mocks.appendMessage).not.toHaveBeenCalled();
+    const [, updater] = mocks.updateTab.mock.calls[0];
+    const out = updater(tab);
+    expect(out.messages[0].a2ui?.components[0].props).toMatchObject({
+      status: "cancelled",
+      endedAt: 2_000,
+    });
+  });
+
+  it("updates same-id repeated tool calls without replacing older siblings", () => {
+    const oldId = "tool-1-call_1";
+    const currentId = "tool-2-call_1";
+    const oldMessage = {
+      id: oldId,
+      role: "agent" as const,
+      a2ui: {
+        components: [
+          {
+            id: oldId,
+            type: "tool-card",
+            props: {
+              title: "bash",
+              toolName: "bash",
+              startedAt: 1_000,
+              endedAt: 1_500,
+            },
+          },
+        ],
+      },
+    } satisfies ChatMessage;
+    const currentMessage = {
+      id: currentId,
+      role: "agent" as const,
+      a2ui: {
+        components: [
+          {
+            id: currentId,
+            type: "tool-card",
+            props: { title: "bash", toolName: "bash", startedAt: 2_000 },
+          },
+        ],
+      },
+    } satisfies ChatMessage;
+    const tab = {
+      ...makeEmptyTab("tab-1", "Tab 1"),
+      messages: [oldMessage, currentMessage],
+    };
+    const { ctx, mocks } = buildHandlerFixture({
+      state: { activeTabId: "tab-1", tabs: [tab] },
+    });
+    const payload = {
+      components: [
+        {
+          id: currentId,
+          type: "tool-card",
+          props: {
+            title: "bash",
+            toolName: "bash",
+            startedAt: 2_000,
+            endedAt: 2_500,
+          },
+        },
+      ],
+    };
+
+    handleA2ui({ type: "a2ui", payload, id: currentId, tabId: "tab-1" }, ctx);
+
+    const [, updater] = mocks.updateTab.mock.calls[0];
+    const out = updater(tab);
+    expect(out.messages).toHaveLength(2);
+    expect(out.messages[0]).toBe(oldMessage);
+    expect(out.messages[1]).toMatchObject({ id: currentId, a2ui: payload });
   });
 
   it("replaces a stale running terminal tool card when the final event has a sibling id", () => {

--- a/src/hooks/bridgeMessageHandlers/a2ui.ts
+++ b/src/hooks/bridgeMessageHandlers/a2ui.ts
@@ -5,7 +5,7 @@ import { toolCardIdentityFromId } from "../../utils/toolCardIdentity";
 import type { BridgeMessageHandler } from "./types";
 import { flushResponseDeltas } from "./responseDelta";
 
-function completedToolCardIdentity(payload: A2UIPayload): string | undefined {
+function completedToolCard(payload: A2UIPayload): A2UIComponent | undefined {
   const toolCards = (payload.components ?? []).filter(
     (component) =>
       component?.type === "tool-card" && typeof component.id === "string",
@@ -14,7 +14,7 @@ function completedToolCardIdentity(payload: A2UIPayload): string | undefined {
   const component = toolCards[0];
   if (component.props?.startedAt === undefined) return undefined;
   if (component.props.endedAt === undefined) return undefined;
-  return toolCardIdentityFromId(component.id);
+  return component;
 }
 
 function numericProp(
@@ -37,22 +37,78 @@ function createdAtFromPayload(payload: A2UIPayload): number | undefined {
   return undefined;
 }
 
-function replacesPriorToolCard(
+interface PriorToolCardMatch {
+  component: A2UIComponent;
+  id: string;
+}
+
+function priorToolCardMatch(
   tab: Tab | undefined,
-  incomingMessageId: string,
+  incomingId: string | undefined,
   identity: string | undefined,
-): boolean {
-  if (!tab || !identity) return false;
-  return tab.messages.some((message) => {
-    if (message.id === incomingMessageId) return false;
-    const toolCards = message.a2ui?.components ?? [];
-    return toolCards.some((component) => {
-      if (component?.type !== "tool-card") return false;
-      if (typeof component.id !== "string") return false;
-      if (component.props?.startedAt === undefined) return false;
-      return toolCardIdentityFromId(component.id) === identity;
-    });
-  });
+): PriorToolCardMatch | undefined {
+  if (!tab) return undefined;
+  if (incomingId) {
+    for (const message of tab.messages) {
+      for (const component of message.a2ui?.components ?? []) {
+        if (component?.type !== "tool-card") continue;
+        if (component.props?.startedAt === undefined) continue;
+        if (component.id === incomingId) {
+          return { component, id: incomingId };
+        }
+      }
+    }
+  }
+  if (!identity) return undefined;
+  for (const message of tab.messages) {
+    for (const component of message.a2ui?.components ?? []) {
+      if (component?.type !== "tool-card") continue;
+      if (typeof component.id !== "string") continue;
+      if (component.props?.startedAt === undefined) continue;
+      if (toolCardIdentityFromId(component.id) === identity) {
+        return { component, id: component.id };
+      }
+    }
+  }
+  return undefined;
+}
+
+function isCancelledToolCard(component: A2UIComponent | undefined): boolean {
+  return (
+    component?.type === "tool-card" && component.props?.status === "cancelled"
+  );
+}
+
+function cancellationHistoryNotice(componentId: string): A2UIComponent {
+  return {
+    id: `${componentId}-late-completion-notice`,
+    type: "code",
+    props: {
+      language: "text",
+      content:
+        "This tool reported a final result after it had already been marked stopped. Keeping the cancellation state; final output is shown below.",
+    },
+  };
+}
+
+function preserveCancelledToolState(payload: A2UIPayload): A2UIPayload {
+  return {
+    ...payload,
+    components: (payload.components ?? []).map((component) => {
+      if (component?.type !== "tool-card") return component;
+      return {
+        ...component,
+        props: {
+          ...(component.props ?? {}),
+          status: "cancelled",
+        },
+        children: [
+          cancellationHistoryNotice(component.id),
+          ...(component.children ?? []),
+        ],
+      };
+    }),
+  };
 }
 
 export const handleA2ui: BridgeMessageHandler = (data, ctx) => {
@@ -65,25 +121,34 @@ export const handleA2ui: BridgeMessageHandler = (data, ctx) => {
   flushResponseDeltas(tabId);
   if (payload) {
     const createdAt = createdAtFromPayload(payload);
+    const tabs = (ctx.stateRef.current.tabs as Tab[] | undefined) ?? [];
+    const tab = tabs.find((t) => t.id === tabId);
+    const completedCard = completedToolCard(payload);
+    const identity = completedCard
+      ? toolCardIdentityFromId(completedCard.id)
+      : undefined;
+    const priorMatch = priorToolCardMatch(tab, completedCard?.id, identity);
+    const finalPayload =
+      isCancelledToolCard(priorMatch?.component) &&
+      payload.components?.some(isCancelledToolCard) !== true
+        ? preserveCancelledToolState(payload)
+        : payload;
     const message: ChatMessage = {
       id,
       role: "agent",
-      a2ui: payload,
+      a2ui: finalPayload,
       ...(createdAt !== undefined ? { createdAt } : {}),
     };
-    const tabs = (ctx.stateRef.current.tabs as Tab[] | undefined) ?? [];
-    const tab = tabs.find((t) => t.id === tabId);
-    const identity = completedToolCardIdentity(payload);
-    if (replacesPriorToolCard(tab, id, identity)) {
+    if (priorMatch) {
       ctx.updateTab(tabId, (current) => ({
         ...current,
         messages: current.messages.map((currentMessage) => {
           const matches = (currentMessage.a2ui?.components ?? []).some(
-            (component) =>
-              component?.type === "tool-card" &&
-              typeof component.id === "string" &&
-              component.props?.startedAt !== undefined &&
-              toolCardIdentityFromId(component.id) === identity,
+            (component) => {
+              if (component?.type !== "tool-card") return false;
+              if (component.props?.startedAt === undefined) return false;
+              return component.id === priorMatch.id;
+            },
           );
           return matches ? message : currentMessage;
         }),

--- a/src/hooks/useAgentActivityHydration.test.ts
+++ b/src/hooks/useAgentActivityHydration.test.ts
@@ -114,8 +114,9 @@ describe("hydrateAgentActivityState", () => {
       ],
     );
 
-    expect((next.tabs as ReturnType<typeof makeEmptyTab>[]).map((t) => t.id))
-      .toEqual(["tab-a"]);
+    expect(
+      (next.tabs as ReturnType<typeof makeEmptyTab>[]).map((t) => t.id),
+    ).toEqual(["tab-a"]);
     expect(next.waiting).toBe(false);
   });
 
@@ -143,6 +144,118 @@ describe("hydrateAgentActivityState", () => {
     );
     expect(next.waiting).toBe(false);
     expect(next.status).toBe("ready");
+  });
+
+  it("keeps another tab's running tool card when diagnostics only mention a different worker", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(123_456);
+    const tabA = {
+      ...makeEmptyTab("tab-a", "A"),
+      waiting: true,
+      messages: [
+        {
+          id: "tool-message",
+          role: "agent" as const,
+          a2ui: {
+            components: [
+              {
+                id: "tool-1-call_1",
+                type: "tool-card",
+                props: {
+                  title: "bash",
+                  description: "sleep 60",
+                  startedAt: 100_000,
+                },
+                children: [],
+              },
+            ],
+          },
+        },
+      ],
+    };
+    const tabB = makeEmptyTab("tab-b", "B");
+
+    const next = hydrateAgentActivityState(
+      {
+        activeTabId: "tab-a",
+        waiting: true,
+        status: "thinking…",
+        agentRunningTabs: { "tab-a": true },
+        tabs: [tabA, tabB],
+      },
+      [
+        {
+          key: "tab:tab-b",
+          tab_id: "tab-b",
+          alive: true,
+          prompt_in_flight: true,
+        },
+      ],
+    );
+
+    expect(next.status).toBe("thinking…");
+    const outTabA = (next.tabs as (typeof tabA)[])[0];
+    expect(outTabA.waiting).toBe(true);
+    const toolCard = outTabA.messages[0].a2ui?.components?.[0] as
+      | A2UIComponent
+      | undefined;
+    expect(toolCard?.props?.endedAt).toBeUndefined();
+    expect(toolCard?.props?.status).toBeUndefined();
+  });
+
+  it("marks stale running tool cards stopped when diagnostics only show unrelated idle workers", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(123_456);
+    const waitingTab = {
+      ...makeEmptyTab("tab-a", "A"),
+      waiting: true,
+      messages: [
+        {
+          id: "tool-message",
+          role: "agent" as const,
+          a2ui: {
+            components: [
+              {
+                id: "tool-1-call_1",
+                type: "tool-card",
+                props: {
+                  title: "bash",
+                  description: "sleep 60",
+                  startedAt: 100_000,
+                },
+                children: [],
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    const next = hydrateAgentActivityState(
+      {
+        activeTabId: "tab-a",
+        waiting: true,
+        status: "thinking…",
+        agentRunningTabs: { "tab-a": true },
+        tabs: [waitingTab],
+      },
+      [
+        {
+          key: "__global__",
+          tab_id: null,
+          alive: true,
+          prompt_in_flight: false,
+        },
+      ],
+    );
+
+    expect(next.status).toBe("ready");
+    const toolCard = ((next.tabs as (typeof waitingTab)[])[0].messages[0].a2ui
+      ?.components?.[0] ?? {}) as A2UIComponent;
+    expect(toolCard.props).toMatchObject({
+      status: "cancelled",
+      endedAt: 123_456,
+    });
   });
 
   it("marks stale running tool cards stopped when diagnostics show no live prompt", () => {
@@ -190,7 +303,7 @@ describe("hydrateAgentActivityState", () => {
     );
 
     expect(next.status).toBe("ready");
-    const components = (next.tabs as typeof waitingTab[])[0].messages[0].a2ui
+    const components = (next.tabs as (typeof waitingTab)[])[0].messages[0].a2ui
       ?.components as A2UIComponent[] | undefined;
     const toolCard = components?.[0];
     expect(toolCard).toBeDefined();
@@ -272,8 +385,8 @@ describe("hydrateAgentActivityState", () => {
 
     expect(invoke).toHaveBeenCalledTimes(2);
     expect(state).toMatchObject({ waiting: true, status: "thinking…" });
-    expect(
-      ((state.tabs as ReturnType<typeof makeEmptyTab>[])[0]).waiting,
-    ).toBe(true);
+    expect((state.tabs as ReturnType<typeof makeEmptyTab>[])[0].waiting).toBe(
+      true,
+    );
   });
 });

--- a/src/hooks/useAgentActivityHydration.ts
+++ b/src/hooks/useAgentActivityHydration.ts
@@ -1,7 +1,7 @@
 import { useEffect, type Dispatch, type SetStateAction } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import type { Tab } from "../types/tab";
-import { closeRunningToolCards } from "../utils/agentBusy";
+import { closeRunningToolCards, hasRunningToolCard } from "../utils/agentBusy";
 import { TAB_MIRROR_KEYS } from "./useTabs";
 
 export const AGENT_ACTIVITY_HYDRATION_RETRY_DELAYS_MS = [
@@ -40,32 +40,45 @@ export function hydrateAgentActivityState(
   const tabs = (state.tabs as Tab[] | undefined) ?? [];
   if (tabs.length === 0) return state;
 
-  const livePromptByTabId = new Map<string, boolean>();
+  const promptByTabId = new Map<string, boolean>();
   for (const row of diagnostics) {
-    if (row.alive === false) continue;
     const tabId = diagnosticTabId(row);
     if (!tabId) continue;
-    livePromptByTabId.set(
+    const promptInFlight = row.alive !== false && diagnosticPromptInFlight(row);
+    promptByTabId.set(
       tabId,
-      (livePromptByTabId.get(tabId) ?? false) ||
-        diagnosticPromptInFlight(row),
+      (promptByTabId.get(tabId) ?? false) || promptInFlight,
     );
   }
+  const runningTabs =
+    (state.agentRunningTabs as Record<string, true> | undefined) ?? {};
+  const anyPromptInFlight = [...promptByTabId.values()].some(Boolean);
   let tabChanged = false;
   const endedAt = Date.now();
   const nextTabs = tabs.map((tab) => {
     if ((tab.kind ?? "agent") !== "agent") return tab;
-    const hasDiagnostic = livePromptByTabId.has(tab.id);
-    const nextWaiting = hasDiagnostic
-      ? livePromptByTabId.get(tab.id) === true
-      : false;
-    const stoppedTools = nextWaiting
-      ? { messages: tab.messages, changed: false }
-      : closeRunningToolCards(tab.messages, {
+    const hasDiagnostic = promptByTabId.has(tab.id);
+    const runningTool = hasRunningToolCard(tab.messages);
+    const diagnosticsAbsent = diagnostics.length === 0;
+    const preserveUnknownBusyState =
+      !hasDiagnostic &&
+      !diagnosticsAbsent &&
+      anyPromptInFlight &&
+      runningTabs[tab.id] === true &&
+      (tab.waiting || runningTool);
+    const nextWaiting = preserveUnknownBusyState
+      ? true
+      : hasDiagnostic
+        ? promptByTabId.get(tab.id) === true
+        : false;
+    const shouldStopTools = !nextWaiting;
+    const stoppedTools = shouldStopTools
+      ? closeRunningToolCards(tab.messages, {
           endedAt,
           notice:
             "No live prompt is running. This tool was marked stopped after reload.",
-        });
+        })
+      : { messages: tab.messages, changed: false };
     if (tab.waiting === nextWaiting && !stoppedTools.changed) return tab;
     tabChanged = true;
     return { ...tab, waiting: nextWaiting, messages: stoppedTools.messages };


### PR DESCRIPTION
Closes #243.

## Summary
- keep diagnostics hydration from closing running tool cards on unrelated tabs
- preserve cancelled tool-card state when late completions arrive, including session restore
- add regression coverage for tab worker routing and cancelled-to-completed sequences

## Validation
- Codex peer review: no findings after fixes
- npm run typecheck
- npm test
- npm run build
- cd src-tauri && cargo test route_to
