### PR TITLE
fix(workspaces): clear stale landing on tab restore

### DIFF
--- a/src/hooks/projectOps/tabBuckets.test.ts
+++ b/src/hooks/projectOps/tabBuckets.test.ts
@@ -73,6 +73,47 @@ describe("switchProjectBucket", () => {
     ).toEqual(["b1"]);
   });
 
+  it("clears a stale landing override when restoring an active tab", () => {
+    const tabA = agentTab("a1", "P", "/P/A");
+    const h = makeHarness({
+      tabs: [],
+      activeTabId: undefined,
+      landing: { kind: "worktree", worktreeId: "B" },
+      messages: [{ id: "stale", role: "user", text: "stale landing" }],
+      draft: "stale draft",
+    });
+    h.tabBucketsRef.current.set("P::worktree::A", {
+      tabs: [tabA],
+      activeTabId: "a1",
+    });
+
+    const restored = switchProjectBucket(
+      h.deps,
+      "P::worktree::B",
+      "P::worktree::A",
+    );
+
+    expect(restored).toBe("a1");
+    expect(h.get().activeTabId).toBe("a1");
+    expect(h.get().landing).toBeNull();
+    expect(h.get().messages).toEqual(tabA.messages);
+    expect(h.get().draft).toBe(tabA.draft);
+  });
+
+  it("preserves landing when switching to an empty workspace", () => {
+    const h = makeHarness({
+      tabs: [],
+      activeTabId: undefined,
+      landing: { kind: "worktree", worktreeId: "B" },
+    });
+
+    switchProjectBucket(h.deps, "P::worktree::B", "P::worktree::A");
+
+    expect(h.get().activeTabId).toBeUndefined();
+    expect(h.get().tabs).toEqual([]);
+    expect(h.get().landing).toEqual({ kind: "worktree", worktreeId: "B" });
+  });
+
   it("mirrors non-active buckets into state.persistedTabBuckets for persistence", () => {
     const tabP = agentTab("p-main", "P", "/P");
     const h = makeHarness({ tabs: [tabP], activeTabId: "p-main" });

--- a/src/hooks/projectOps/tabBuckets.ts
+++ b/src/hooks/projectOps/tabBuckets.ts
@@ -192,6 +192,10 @@ export function switchProjectBucket(
       }
       result.empty = false;
       result.hasTabs = true;
+      // Restoring a real tab must clear any worktree-landing override,
+      // matching setActiveTab's invariant so the active tab's canvas owns
+      // the main surface after a workspace switch.
+      result.landing = null;
       result.sidebar = recomputeModelPicker(
         prev.sidebar as Record<string, unknown> | undefined,
         activeTab.model,

--- a/src/hooks/useProjectOps.test.ts
+++ b/src/hooks/useProjectOps.test.ts
@@ -344,6 +344,67 @@ describe("useProjectOps session scoping", () => {
     expect(stateRef.current.activeTabId).toBe("root-tab");
   });
 
+  it("clears stale landing when activateWorktree restores a saved tab", () => {
+    const worktreeTab = {
+      ...nonEmptyAgentTab("worktree-tab", "Worktree chat", "project-1"),
+      cwd: "/projects/aethon-fix-issue",
+    };
+    const { result, stateRef, projectsRef } = renderProjectOps(
+      makeProjectsState({
+        activeId: "project-1",
+        activeWorktreeId: "wt-issue",
+        worktreesByProject: {
+          "project-1": [
+            {
+              id: "wt-issue",
+              projectId: "project-1",
+              path: "/projects/aethon-fix-issue",
+              branch: "fix/issue",
+              isMain: false,
+            },
+            {
+              id: "wt-empty",
+              projectId: "project-1",
+              path: "/projects/aethon-empty",
+              branch: "empty",
+              isMain: false,
+            },
+          ],
+        },
+      }),
+    );
+    stateRef.current = {
+      ...stateRef.current,
+      tabs: [worktreeTab],
+      activeTabId: "worktree-tab",
+    };
+
+    act(() => {
+      result.current.activateWorktree("wt-empty");
+    });
+    expect((stateRef.current.tabs as Tab[]).map((t) => t.id)).toEqual([]);
+
+    stateRef.current = {
+      ...stateRef.current,
+      landing: { kind: "worktree", worktreeId: "wt-empty" },
+      messages: [{ id: "stale", role: "user", text: "stale" }],
+      draft: "stale draft",
+    };
+
+    act(() => {
+      result.current.activateWorktree("wt-issue");
+    });
+
+    expect(projectsRef.current.activeWorktreeId).toBe("wt-issue");
+    expect((stateRef.current.tabs as Tab[]).map((t) => t.id)).toEqual([
+      "worktree-tab",
+    ]);
+    expect(stateRef.current.activeTabId).toBe("worktree-tab");
+    expect(stateRef.current.landing).toBeNull();
+    expect(stateRef.current.messages).toEqual(worktreeTab.messages);
+    expect(stateRef.current.draft).toBe(worktreeTab.draft);
+  });
+
   it("swaps the project extensions watcher when a worktree from another project is activated", () => {
     // Regression: activateWorktree changed activeId directly when the
     // worktree belonged to a different project than the current one,

--- a/src/hooks/useProjectOps.ts
+++ b/src/hooks/useProjectOps.ts
@@ -110,9 +110,10 @@ export function useProjectOps(ctx: UseProjectOpsContext): UseProjectOpsActions {
     toKey: string,
     opts: { mirrorProjects?: boolean } = {},
   ): string | undefined {
-    const wasOverview = isOverviewActive(
-      stateRef.current.activeTabId as string | undefined,
-    );
+    // Preserve only an explicitly selected overview. An unset activeTabId
+    // usually means the source bucket was empty; it must not suppress a
+    // real active tab restored from the destination bucket.
+    const wasOverview = stateRef.current.activeTabId === OVERVIEW_TAB_ID;
     const nextTabId = switchTabBucket(
       {
         setState,


### PR DESCRIPTION
## Summary
- clear stale worktree landing state when a workspace bucket restores a real active tab
- preserve only the explicit overview sentinel during workspace switches, so empty source buckets do not suppress restored destination sessions
- add regression coverage for switchProjectBucket and activateWorktree consistency

## Tests
- bunx vitest run src/hooks/projectOps/tabBuckets.test.ts src/hooks/useProjectOps.test.ts src/eventRoutes/sidebar.test.ts src/hooks/tabOps/mutations.test.ts
- bun run typecheck
- git diff --check

Closes #248