### PR TITLE
fix: harden subagent output lifecycle

### DIFF
--- a/agent/context-usage.test.ts
+++ b/agent/context-usage.test.ts
@@ -209,6 +209,44 @@ describe("live context updates", () => {
     expect(context?.saturated).toBeUndefined();
   });
 
+  it("counts only task partial deltas in live context estimates", () => {
+    const state = stateWithCompaction();
+    const rec = recWithUsage({
+      tokens: 1_000,
+      contextWindow: 2_000,
+      percent: 50,
+    });
+    const sent: Record<string, unknown>[] = [];
+    const deps = { send: (msg: Record<string, unknown>) => sent.push(msg) };
+
+    handleSessionEvent(state, deps, rec, "tab-1", {
+      type: "tool_execution_start",
+      toolCallId: "task-1",
+      toolName: "task",
+      args: { subagent_type: "coder", prompt: "fix it" },
+    });
+    const beforePartials = rec.contextUsageTransientTokens ?? 0;
+    handleSessionEvent(state, deps, rec, "tab-1", {
+      type: "tool_execution_update",
+      toolCallId: "task-1",
+      toolName: "task",
+      args: { subagent_type: "coder", prompt: "fix it" },
+      partialResult: { content: [{ type: "text", text: "abcd" }] },
+    });
+    handleSessionEvent(state, deps, rec, "tab-1", {
+      type: "tool_execution_update",
+      toolCallId: "task-1",
+      toolName: "task",
+      args: { subagent_type: "coder", prompt: "fix it" },
+      partialResult: { content: [{ type: "text", text: "abcdef" }] },
+    });
+
+    // estimateTokens is ceil(chars / 4), so "abcd" contributes 1 and the
+    // cumulative update's delta "ef" contributes 1. Counting full snapshots
+    // would yield 3 instead.
+    expect((rec.contextUsageTransientTokens ?? 0) - beforePartials).toBe(2);
+  });
+
   it("clears transient estimates for authoritative turn-end usage", () => {
     const state = stateWithCompaction({ currentAgentTabId: "tab-1" });
     const rec = recWithUsage({

--- a/agent/state.ts
+++ b/agent/state.ts
@@ -229,6 +229,7 @@ export interface TabRecord {
       summary: string;
       uiId: string;
       bashStream?: BashTerminalStreamState;
+      taskPartialStream?: BashTerminalStreamState;
       /** Epoch ms — when tool_execution_start fired. Used by the M6 P4
        *  `tool-card` component to render a live elapsed-time clock. */
       startedAt?: number;

--- a/agent/subagents/task-tool.test.ts
+++ b/agent/subagents/task-tool.test.ts
@@ -347,6 +347,30 @@ describe("buildSubagentTaskTool", () => {
     await pending;
   });
 
+  it("catches rejected aborts before disposing the subagent session", async () => {
+    let release!: () => void;
+    h.promptImpl = () => new Promise<void>((res) => (release = res));
+    const { state } = makeState({ name: "reviewer", model: "ollama/llama3.3" });
+    const tool = buildSubagentTaskTool(state, { send: vi.fn() }, "default");
+    const ctrl = new AbortController();
+    const pending = execOf(tool)(
+      "c",
+      { subagent_type: "reviewer", prompt: "x" },
+      ctrl.signal,
+    );
+    await Promise.resolve();
+    h.abortSpy.mockRejectedValueOnce(new Error("abort failed"));
+
+    ctrl.abort();
+    release();
+
+    await expect(pending).resolves.toMatchObject({
+      details: { subagent: "reviewer" },
+    });
+    expect(h.abortSpy).toHaveBeenCalledTimes(1);
+    expect(h.disposeSpy).toHaveBeenCalled();
+  });
+
   it("uses the subagent timeout override for inline runs", async () => {
     vi.useFakeTimers();
     h.promptImpl = () => new Promise<void>(() => {});

--- a/agent/subagents/task-tool.ts
+++ b/agent/subagents/task-tool.ts
@@ -319,8 +319,21 @@ async function runInlineSubagent(
     },
   );
 
+  let abortPromise: Promise<void> | undefined;
+  const requestAbort = (): Promise<void> => {
+    abortPromise ??= session.abort().catch((err: unknown) => {
+      logger
+        .scope("subagent")
+        .warn(
+          `abort failed for "${sub.name}": ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+    });
+    return abortPromise;
+  };
   const onAbort = (): void => {
-    void session.abort();
+    void requestAbort();
   };
   signal?.addEventListener("abort", onAbort);
 
@@ -330,7 +343,7 @@ async function runInlineSubagent(
       session.prompt(composedPrompt),
       timeoutMsFromSeconds(sub.timeoutSeconds ?? state.subagentTimeoutSeconds),
       () => {
-        void session.abort();
+        void requestAbort();
       },
     );
   } catch (err) {
@@ -346,6 +359,9 @@ async function runInlineSubagent(
     );
   } finally {
     signal?.removeEventListener("abort", onAbort);
+    if (abortPromise) {
+      await abortPromise;
+    }
     unsubscribe();
     try {
       session.dispose();

--- a/agent/tab-lifecycle.test.ts
+++ b/agent/tab-lifecycle.test.ts
@@ -114,6 +114,21 @@ describe("summarizeToolArgs", () => {
     expect(summarizeToolArgs("read", null)).toBe("");
     expect(summarizeToolArgs("read", "x")).toBe("");
   });
+
+  it("summarizes Aethon and pi subagent tools without raw JSON", () => {
+    expect(
+      summarizeToolArgs("task", {
+        subagent_type: "coder",
+        prompt: "Fix the UI\nwith details",
+      }),
+    ).toBe("coder · Fix the UI");
+    expect(
+      summarizeToolArgs("subagent", {
+        agent: "reviewer",
+        task: "Review the patch",
+      }),
+    ).toBe("reviewer · Review the patch");
+  });
 });
 
 describe("extractToolContent", () => {
@@ -195,6 +210,22 @@ describe("toolCardPayload", () => {
     expect(code.type).toBe("code");
     expect(code.props.content.length).toBe(1500);
     expect(code.props.content.endsWith("…")).toBe(true);
+  });
+
+  it("renders task text results as subagent prose output", () => {
+    const payload = toolCardPayload({
+      id: "tool-c1",
+      toolName: "task",
+      argsSummary: "coder · fix it",
+      result: "Done.",
+    });
+    const root = payload.components[0] as { children: unknown[] };
+    const child = root.children[0] as {
+      type: string;
+      props: { content: string };
+    };
+    expect(child.type).toBe("subagent-result");
+    expect(child.props.content).toBe("Done.");
   });
 
   it("infers the code language for file-backed tool results", () => {
@@ -602,6 +633,47 @@ describe("handleSessionEvent", () => {
     expect(a2uiMsg).toMatchObject({ id: "tool-1-c1" });
     expect(f.sent.find((m) => m.type === "terminal_output")).toMatchObject({
       content: "\r\n$ ls\r\n",
+    });
+  });
+
+  it("tool_execution_update streams task partials into the existing card", () => {
+    const f = makeFixture();
+    const rec = fakeRec();
+    handleSessionEvent(f.state, f.deps, rec, "tab-1", {
+      type: "tool_execution_start",
+      toolCallId: "c1",
+      toolName: "task",
+      args: { subagent_type: "coder", prompt: "fix the bug" },
+    });
+    handleSessionEvent(f.state, f.deps, rec, "tab-1", {
+      type: "tool_execution_update",
+      toolCallId: "c1",
+      toolName: "task",
+      args: { subagent_type: "coder", prompt: "fix the bug" },
+      partialResult: { content: [{ type: "text", text: "working" }] },
+    });
+
+    const a2uiMessages = f.sent.filter((m) => m.type === "a2ui");
+    expect(a2uiMessages.map((m) => m.id)).toEqual(["tool-1-c1", "tool-1-c1"]);
+    expect(a2uiMessages.at(-1)).toMatchObject({
+      payload: {
+        components: [
+          {
+            id: "tool-1-c1",
+            props: {
+              toolName: "task",
+              description: "coder · fix the bug",
+              startedAt: expect.any(Number),
+            },
+            children: [
+              {
+                type: "subagent-result",
+                props: { content: "working" },
+              },
+            ],
+          },
+        ],
+      },
     });
   });
 

--- a/agent/tab-lifecycle/events.ts
+++ b/agent/tab-lifecycle/events.ts
@@ -276,6 +276,33 @@ export function handleSessionEvent(
         emitBashResult(deps, streamed.delta, tabId);
         addLiveContextUsageEstimate(rec, streamed.delta);
         emitContextUsageThrottled(state, deps, tabId, rec);
+      } else if (ev.toolName === "task") {
+        let cached = rec.toolArgsCache.get(ev.toolCallId);
+        if (!cached) {
+          cached = {
+            name: ev.toolName,
+            summary: summarizeToolArgs(ev.toolName, ev.args),
+            uiId: `tool-${++rec.toolCardSeq}-${ev.toolCallId}`,
+            startedAt: Date.now(),
+          };
+          rec.toolArgsCache.set(ev.toolCallId, cached);
+        }
+        const payload = toolCardPayload({
+          id: cached.uiId,
+          toolName: ev.toolName,
+          argsSummary: cached.summary,
+          result: ev.partialResult,
+          startedAt: cached.startedAt,
+        });
+        deps.send({ type: "a2ui", tabId, id: cached.uiId, payload });
+        const extracted = extractToolContent(ev.partialResult);
+        const streamed = consumeBashTerminalSnapshot(
+          extracted.text,
+          cached.taskPartialStream,
+        );
+        cached.taskPartialStream = streamed.state;
+        addLiveContextUsageEstimate(rec, streamed.delta);
+        emitContextUsageThrottled(state, deps, tabId, rec);
       }
       break;
     }

--- a/agent/tool-card.ts
+++ b/agent/tool-card.ts
@@ -2,7 +2,9 @@ const MAX_IMAGES_PER_RESULT = 4;
 
 function firstLine(value: unknown, max = 180): string {
   if (typeof value !== "string") return "";
-  const line = value.trim().split(/\r?\n/)[0] ?? "";
+  const trimmed = value.trim();
+  const newline = trimmed.search(/\r?\n/);
+  const line = newline >= 0 ? trimmed.slice(0, newline) : trimmed;
   return line.length > max ? line.slice(0, max - 1) + "…" : line;
 }
 

--- a/agent/tool-card.ts
+++ b/agent/tool-card.ts
@@ -1,5 +1,20 @@
 const MAX_IMAGES_PER_RESULT = 4;
 
+function firstLine(value: unknown, max = 180): string {
+  if (typeof value !== "string") return "";
+  const line = value.trim().split(/\r?\n/)[0] ?? "";
+  return line.length > max ? line.slice(0, max - 1) + "…" : line;
+}
+
+function baseName(value: unknown): string {
+  if (typeof value !== "string" || !value.trim()) return "";
+  return value.replace(/[/\\]+$/, "").split(/[/\\]/).pop() ?? value;
+}
+
+function compactSummary(parts: Array<string | false | undefined>): string {
+  return parts.filter(Boolean).join(" · ");
+}
+
 /** Render a one-line summary of tool args so the card description shows
  *  what the tool was actually invoked with, not just `{...}`. */
 export function summarizeToolArgs(toolName: string, args: unknown): string {
@@ -28,6 +43,15 @@ export function summarizeToolArgs(toolName: string, args: unknown): string {
       return String(a.pattern ?? a.path ?? "");
     case "ls":
       return String(a.path ?? ".");
+    case "task":
+      return compactSummary([
+        String(a.subagent_type ?? "subagent"),
+        firstLine(a.prompt),
+      ]);
+    case "subagent":
+      return compactSummary([String(a.agent ?? "agent"), firstLine(a.task)]);
+    case "startTask":
+      return compactSummary([baseName(a.projectPath), firstLine(a.prompt)]);
     default: {
       const json = JSON.stringify(args);
       return json.length > 200 ? json.slice(0, 197) + "…" : json;
@@ -192,18 +216,29 @@ export function toolCardPayload(opts: {
   if (result !== undefined) {
     const extracted = extractToolContent(result);
     if (extracted.text) {
-      children.push({
-        id: `${id}-result`,
-        type: "code",
-        props: {
-          content: truncate(extracted.text, 1500),
-          language: inferToolResultLanguage(
-            toolName,
-            argsSummary,
-            extracted.text,
-          ),
-        },
-      });
+      if (toolName === "task") {
+        children.push({
+          id: `${id}-result`,
+          type: "subagent-result",
+          props: {
+            content: truncate(extracted.text, 3000),
+            ...(isError ? { isError: true } : {}),
+          },
+        });
+      } else {
+        children.push({
+          id: `${id}-result`,
+          type: "code",
+          props: {
+            content: truncate(extracted.text, 1500),
+            language: inferToolResultLanguage(
+              toolName,
+              argsSummary,
+              extracted.text,
+            ),
+          },
+        });
+      }
     }
     extracted.images.forEach((img, i) => {
       children.push({

--- a/src/extensions/default-layout/chat.tsx
+++ b/src/extensions/default-layout/chat.tsx
@@ -3,4 +3,4 @@
 export { ChatInput } from "./chat-input";
 export { ChatHistory, MainCanvas } from "./message-list";
 export { QueuedMessagesPopover } from "./queued-popover";
-export { ToolCard, formatToolDuration } from "./tool-card";
+export { ToolCard, SubagentResult, formatToolDuration } from "./tool-card";

--- a/src/extensions/default-layout/components.tsx
+++ b/src/extensions/default-layout/components.tsx
@@ -37,6 +37,7 @@ export {
   ChatInput,
   MainCanvas,
   QueuedMessagesPopover,
+  SubagentResult,
   ToolCard,
   formatToolDuration,
 } from "./chat";

--- a/src/extensions/default-layout/index.ts
+++ b/src/extensions/default-layout/index.ts
@@ -27,6 +27,7 @@ import {
   Terminal,
   TerminalPanel,
   ToolCard,
+  SubagentResult,
   AuthProfilePanel,
 } from "./components";
 import {
@@ -114,6 +115,7 @@ export const defaultLayoutExtension: A2UIExtension = {
     // amber warning at 30s. Bridge emits this for tool execution events
     // (replacing the plain `card` primitive in toolCardPayload).
     "tool-card": ToolCard,
+    "subagent-result": SubagentResult,
     "empty-state": EmptyState,
     // Worktree landing page — shown when the user clicks a worktree in
     // the sidebar but hasn't yet started a session. Mirrors EmptyState

--- a/src/extensions/default-layout/tool-card.subagent.test.tsx
+++ b/src/extensions/default-layout/tool-card.subagent.test.tsx
@@ -2,7 +2,7 @@
 
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
-import { ToolCard } from "./tool-card";
+import { SubagentResult, ToolCard } from "./tool-card";
 import type { A2UIComponent } from "../../types/a2ui";
 
 afterEach(cleanup);
@@ -41,5 +41,35 @@ describe("ToolCard subagent activity", () => {
   it("shows no activity block when there's no progress for the card", () => {
     taskCard({ subagentProgress: {} });
     expect(screen.queryByText("read src/foo.ts")).toBeNull();
+  });
+
+  it("keeps streamed subagent text visible after completion", () => {
+    taskCard({
+      subagentProgress: {
+        "call-abc": {
+          subagent: "reviewer",
+          model: "ollama/llama3.3",
+          steps: [],
+          text: "final summary",
+          done: true,
+        },
+      },
+    });
+    expect(screen.getByText("final summary")).toBeTruthy();
+  });
+
+  it("renders task result output as prose", () => {
+    render(
+      <SubagentResult
+        component={{
+          id: "r1",
+          type: "subagent-result",
+          props: { content: "Line one\nLine two" },
+        }}
+        state={{}}
+        onEvent={() => {}}
+      />,
+    );
+    expect(screen.getByText(/Line one/)).toBeTruthy();
   });
 });

--- a/src/extensions/default-layout/tool-card.tsx
+++ b/src/extensions/default-layout/tool-card.tsx
@@ -49,9 +49,25 @@ function SubagentActivity({ progress }: { progress: SubagentProgress }) {
           ))}
         </ul>
       )}
-      {!progress.done && progress.text && (
-        <div className="ae-subagent-text">{progress.text}</div>
+      {progress.text && (
+        <div className="ae-subagent-text" data-done={progress.done}>
+          {progress.text}
+        </div>
       )}
+    </div>
+  );
+}
+
+export function SubagentResult({ component, state }: BuiltinComponentProps) {
+  const props = component.props as {
+    content?: StringValue;
+    isError?: BooleanValue;
+  };
+  const content = props.content ? resolveString(props.content, state) : "";
+  const isError = props.isError ? resolveBoolean(props.isError, state) : false;
+  return (
+    <div className="ae-subagent-result" data-error={isError ? "true" : "false"}>
+      {content}
     </div>
   );
 }

--- a/src/state/sessionUiSnapshot.ts
+++ b/src/state/sessionUiSnapshot.ts
@@ -1,7 +1,10 @@
 import { OVERVIEW_TAB_ID, type QueuedMessage, type Tab } from "../types/tab";
 import type { ChatMessage } from "../types/a2ui";
 import { durableImageAttachments } from "../utils/imageAttachments";
-import { dedupeToolResultTextMessages } from "../utils/messages";
+import {
+  collapseAmendedAgentMessages,
+  dedupeToolResultTextMessages,
+} from "../utils/messages";
 
 export const SESSION_UI_SNAPSHOT_FILE = "session_ui_snapshot";
 export const SESSION_UI_SNAPSHOT_FLUSH_EVENT =
@@ -59,7 +62,9 @@ function canUseSessionStorage(): boolean {
 }
 
 function trimTab(tab: Tab): Tab {
-  const messages = dedupeToolResultTextMessages(tab.messages)
+  const messages = collapseAmendedAgentMessages(
+    dedupeToolResultTextMessages(tab.messages),
+  )
     .slice(-MAX_MESSAGES_PER_TAB)
     .map((message): ChatMessage => {
       if (!message.attachments || message.attachments.length === 0) {
@@ -350,7 +355,9 @@ function restoreTabRecord(
     ...t,
     kind,
     messages: normalizeRestoredMessages(
-      dedupeToolResultTextMessages(t.messages).map((message): ChatMessage =>
+      collapseAmendedAgentMessages(
+        dedupeToolResultTextMessages(t.messages),
+      ).map((message): ChatMessage =>
         message.attachments && message.attachments.length > 0
           ? {
               ...message,

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -6260,6 +6260,25 @@ body.ae-resizing-terminal * {
   font-style: italic;
 }
 
+.ae-subagent-result {
+  width: 100%;
+  min-width: 0;
+  padding: 8px 10px;
+  border: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
+  border-radius: var(--radius-sm, 6px);
+  background: color-mix(in srgb, var(--bg) 72%, transparent);
+  color: var(--text);
+  font-size: var(--type-body-size, 0.92rem);
+  line-height: var(--type-body-line, 1.5);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.ae-subagent-result[data-error="true"] {
+  border-color: color-mix(in srgb, var(--danger, #c5494a) 42%, var(--border));
+  color: var(--state-error-fg, var(--danger, #c5494a));
+}
+
 /* =============================================================================
    Shell canvas — interactive PTY tab. The container is a flex column so
    the xterm fills the canvas cell and a thin status bar sits underneath

--- a/src/utils/messages.test.ts
+++ b/src/utils/messages.test.ts
@@ -206,6 +206,26 @@ describe("coerceChatMessages", () => {
     ]);
   });
 
+  it("collapses repeated amended agent snapshots by id", () => {
+    const out = coerceChatMessages([
+      { id: "t1", role: "agent", thinking: "first", createdAt: 10 },
+      { id: "t1", role: "agent", thinking: "first second", createdAt: 20 },
+      { id: "u1", role: "user", text: "next" },
+      { id: "t1", role: "agent", text: "final", createdAt: 30 },
+    ]);
+
+    expect(out).toEqual([
+      {
+        id: "t1",
+        role: "agent",
+        thinking: "first second",
+        text: "final",
+        createdAt: 10,
+      },
+      { id: "u1", role: "user", text: "next" },
+    ]);
+  });
+
   it("preserves known user delivery states", () => {
     const out = coerceChatMessages([
       { id: "q1", role: "user", text: "after this", delivery: "queued" },

--- a/src/utils/messages.test.ts
+++ b/src/utils/messages.test.ts
@@ -226,6 +226,17 @@ describe("coerceChatMessages", () => {
     ]);
   });
 
+  it("does not let empty amended snapshots erase prior streamed content", () => {
+    const out = coerceChatMessages([
+      { id: "t1", role: "agent", text: "visible", thinking: "plan" },
+      { id: "t1", role: "agent", text: "", thinking: "" },
+    ]);
+
+    expect(out).toEqual([
+      { id: "t1", role: "agent", text: "visible", thinking: "plan" },
+    ]);
+  });
+
   it("preserves known user delivery states", () => {
     const out = coerceChatMessages([
       { id: "q1", role: "user", text: "after this", delivery: "queued" },

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -183,7 +183,7 @@ function latestNonEmpty(
   previous: string | undefined,
   next: string | undefined,
 ): string | undefined {
-  if (next !== undefined) return next;
+  if (next && next.length > 0) return next;
   return previous;
 }
 

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -138,7 +138,7 @@ function toolResultTexts(message: ChatMessage): string[] {
   for (const component of components) {
     if (component.type !== "tool-card") continue;
     for (const child of component.children ?? []) {
-      if (child.type !== "code") continue;
+      if (child.type !== "code" && child.type !== "subagent-result") continue;
       const content = child.props?.content;
       if (typeof content === "string" && content.trim().length > 0) {
         texts.push(normalizedText(content));
@@ -166,6 +166,60 @@ export function dedupeToolResultTextMessages(
         : "";
     if (text && toolOutputs.has(text)) continue;
     out.push(message);
+  }
+  return out;
+}
+
+function canCollapseAmendedAgentMessage(message: ChatMessage): boolean {
+  return (
+    message.role === "agent" &&
+    !message.a2ui &&
+    typeof message.id === "string" &&
+    message.id.length > 0
+  );
+}
+
+function latestNonEmpty(
+  previous: string | undefined,
+  next: string | undefined,
+): string | undefined {
+  if (next !== undefined) return next;
+  return previous;
+}
+
+/** Persisted local chat is append-only, while streamed agent text/thinking is
+ * amended in memory under one stable message id. If the app reloads before a
+ * compacting rewrite, the JSONL history can contain many cumulative snapshots
+ * of the same message. Collapse those rows back to the latest amended state so
+ * restore matches the live transcript. */
+export function collapseAmendedAgentMessages(
+  messages: ChatMessage[],
+): ChatMessage[] {
+  const out: ChatMessage[] = [];
+  const byId = new Map<string, number>();
+  for (const message of messages) {
+    if (!canCollapseAmendedAgentMessage(message)) {
+      out.push(message);
+      continue;
+    }
+    const existingIndex = byId.get(message.id);
+    if (existingIndex === undefined) {
+      byId.set(message.id, out.length);
+      out.push(message);
+      continue;
+    }
+    const previous = out[existingIndex];
+    out[existingIndex] = {
+      ...previous,
+      ...message,
+      createdAt: previous.createdAt ?? message.createdAt,
+      text: latestNonEmpty(previous.text, message.text),
+      thinking: latestNonEmpty(previous.thinking, message.thinking),
+      attachments:
+        message.attachments && message.attachments.length > 0
+          ? message.attachments
+          : previous.attachments,
+    };
   }
   return out;
 }
@@ -272,5 +326,5 @@ export function coerceChatMessages(value: unknown): ChatMessage[] {
       }),
     );
   }
-  return messages;
+  return collapseAmendedAgentMessages(messages);
 }


### PR DESCRIPTION
## Summary

- Collapse append-only streamed agent text/thinking snapshots on restore so repeated partial rows do not render as duplicate transcript messages.
- Improve Aethon `task` and external `subagent` tool-card summaries, and render inline task output as readable prose instead of a cramped code block.
- Stream inline task partial results into the existing tool card and keep completed subagent activity text visible.
- Harden inline subagent abort/timeout handling by catching rejected aborts and awaiting abort completion before session disposal.
- Count only task partial deltas in the live context meter after Claude peer review found cumulative partials could overestimate usage.

## Root Cause

- Streamed agent text was amended in memory but every cumulative snapshot could be appended to local JSONL history, so restore replayed multiple partial snapshots as separate rows.
- Inline Aethon `task` calls were rendered through generic tool-card result handling, producing raw JSON-ish summaries and code-block output.
- `tool_execution_update` only special-cased `bash`, so task progress updates were not reflected in the card until final completion.
- Subagent timeout/abort paths called `session.abort()` without catching or awaiting the promise, then immediately unsubscribed/disposed the session.

## Validation

- `bunx vitest run src/utils/messages.test.ts src/extensions/default-layout/tool-card.subagent.test.tsx agent/tab-lifecycle.test.ts agent/subagents/task-tool.test.ts`
- `bunx vitest run src/state/sessionUiSnapshot.test.ts src/hooks/bridgeMessageHandlers/sessionHistory.test.ts`
- `bunx vitest run agent/context-usage.test.ts agent/tab-lifecycle.test.ts`
- `bun run typecheck`
- `bunx vitest run` (249 files / 2046 tests)
- `bun run lint`

## Peer Review

- Claude Code was requested with `claude-opus-4.6[1m]`; the local CLI rejected that spelling, so the accepted Opus 4.6 CLI model id `claude-opus-4-6` was used.
- Claude found one valid low-severity issue: task partial context usage was counted cumulatively. This PR includes the follow-up delta-accounting fix and regression test.
- Final Claude review on commit `270b7cf` reported no blocking issues and called the branch ship-ready.
