### PR TITLE
fix: preserve live agent activity until turn end

### DIFF
--- a/src/hooks/bridgeMessageHandlers/a2ui.ts
+++ b/src/hooks/bridgeMessageHandlers/a2ui.ts
@@ -170,5 +170,12 @@ export const handleA2ui: BridgeMessageHandler = (data, ctx) => {
     if (ctx.stateRef.current.activeTabId === tabId) {
       ctx.setStatusFlags({ status: "ready" });
     }
+    ctx.setState((prev) => {
+      const running = prev.agentRunningTabs as Record<string, true> | undefined;
+      if (!running || !running[tabId]) return prev;
+      const next = { ...running };
+      delete next[tabId];
+      return { ...prev, agentRunningTabs: next };
+    });
   }
 };

--- a/src/hooks/bridgeMessageHandlers/error.ts
+++ b/src/hooks/bridgeMessageHandlers/error.ts
@@ -19,6 +19,13 @@ export const handleError: BridgeMessageHandler = (data, ctx) => {
       ...(closedTools.changed ? { messages: closedTools.messages } : {}),
     };
   });
+  ctx.setState((prev) => {
+    const running = prev.agentRunningTabs as Record<string, true> | undefined;
+    if (!running || !running[tabId]) return prev;
+    const next = { ...running };
+    delete next[tabId];
+    return { ...prev, agentRunningTabs: next };
+  });
   if (ctx.stateRef.current.activeTabId === tabId) {
     ctx.setStatusFlags({ status: "error" });
   }

--- a/src/hooks/bridgeMessageHandlers/response.ts
+++ b/src/hooks/bridgeMessageHandlers/response.ts
@@ -23,5 +23,12 @@ export const handleResponse: BridgeMessageHandler = (data, ctx) => {
     if (ctx.stateRef.current.activeTabId === tabId) {
       ctx.setStatusFlags({ status: "ready" });
     }
+    ctx.setState((prev) => {
+      const running = prev.agentRunningTabs as Record<string, true> | undefined;
+      if (!running || !running[tabId]) return prev;
+      const next = { ...running };
+      delete next[tabId];
+      return { ...prev, agentRunningTabs: next };
+    });
   }
 };

--- a/src/hooks/bridgeMessageHandlers/responseEnd.test.ts
+++ b/src/hooks/bridgeMessageHandlers/responseEnd.test.ts
@@ -7,7 +7,11 @@ describe("handleResponseEnd", () => {
   it("clears waiting + status, dismisses hang notification, fires completion", () => {
     const tabId = "default";
     const { ctx, mocks, applySetState } = buildHandlerFixture({
-      state: { activeTabId: tabId, queueCount: 0 },
+      state: {
+        activeTabId: tabId,
+        queueCount: 0,
+        agentRunningTabs: { [tabId]: true },
+      },
     });
     ctx.activeResponseIdRef.current = "msg-1";
     ctx.turnStartedAtRef.current.set(tabId, Date.now() - 5000);
@@ -19,7 +23,10 @@ describe("handleResponseEnd", () => {
     expect(out.waiting).toBe(false);
     const next = applySetState();
     expect(next.status).toBe("ready");
-    expect(mocks.dismissNotification).toHaveBeenCalledWith(`ae-hang-warn:${tabId}`);
+    expect(next.agentRunningTabs).toEqual({});
+    expect(mocks.dismissNotification).toHaveBeenCalledWith(
+      `ae-hang-warn:${tabId}`,
+    );
     // maybeFireCompletionNotification called via void.
     expect(mocks.maybeFireCompletionNotification).toHaveBeenCalled();
   });
@@ -57,9 +64,7 @@ describe("handleResponseEnd", () => {
       status: "cancelled",
       endedAt: expect.any(Number),
     });
-    expect(toolCard?.children?.[0].props?.content).toContain(
-      "did not finish",
-    );
+    expect(toolCard?.children?.[0].props?.content).toContain("did not finish");
   });
 
   it("clears waiting even when a client-side queue is non-empty", () => {

--- a/src/hooks/bridgeMessageHandlers/sessionHistory.test.ts
+++ b/src/hooks/bridgeMessageHandlers/sessionHistory.test.ts
@@ -683,6 +683,60 @@ describe("handleSessionHistory", () => {
     );
   });
 
+  it("keeps restored unfinished tool cards live while the tab is still running", () => {
+    const { ctx, mocks } = buildHandlerFixture({
+      state: {
+        activeTabId: "tab-1",
+        waiting: true,
+        status: "thinking…",
+        agentRunningTabs: { "tab-1": true },
+        tabs: [{ ...makeEmptyTab("tab-1", "Tab 1"), waiting: true }],
+      },
+    });
+    handleSessionHistory(
+      {
+        type: "session_history",
+        tabId: "tab-1",
+        messages: [
+          {
+            id: "restored-tool-call_live",
+            role: "agent",
+            a2ui: {
+              components: [
+                {
+                  id: "restored-tool-call_live",
+                  type: "tool-card",
+                  props: {
+                    title: "bash",
+                    toolName: "bash",
+                    startedAt: 1_000,
+                  },
+                  children: [],
+                },
+              ],
+            },
+          },
+        ],
+      },
+      ctx,
+    );
+    const [, updater] = mocks.updateTab.mock.calls[0];
+    const out = updater({
+      ...makeEmptyTab("tab-1", "Tab 1"),
+      waiting: false,
+    });
+
+    const toolCard = out.messages[0].a2ui?.components[0];
+    expect(out.waiting).toBe(true);
+    expect(toolCard?.props?.status).toBeUndefined();
+    expect(toolCard?.props?.endedAt).toBeUndefined();
+    expect(toolCard?.children?.[0]).toBeUndefined();
+    expect(mocks.setStatusFlags).not.toHaveBeenCalledWith({
+      waiting: false,
+      status: "ready",
+    });
+  });
+
   it("drops restored duplicate assistant text and completed tool cards so reloads do not look busy", () => {
     const { ctx, mocks } = buildHandlerFixture();
     handleSessionHistory(

--- a/src/hooks/bridgeMessageHandlers/sessionHistory.ts
+++ b/src/hooks/bridgeMessageHandlers/sessionHistory.ts
@@ -1,4 +1,7 @@
-import { closeRunningToolCards } from "../../utils/agentBusy";
+import {
+  closeRunningToolCards,
+  hasRunningToolCard,
+} from "../../utils/agentBusy";
 import {
   coerceChatMessages,
   dedupeToolResultTextMessages,
@@ -149,14 +152,14 @@ function isCompactionMarker(message: ChatMessage): boolean {
 function isStopNotice(message: ChatMessage): boolean {
   return (
     message.role === "system" &&
-    message.text?.replace(/\s+/g, " ").trim().toLowerCase() ===
-      "agent stopped."
+    message.text?.replace(/\s+/g, " ").trim().toLowerCase() === "agent stopped."
   );
 }
 
 function restoredCompactionMarkers(restored: ChatMessage[]): ChatMessage[] {
   return restored.filter(
-    (message) => message.id.startsWith("compaction:") && isCompactionMarker(message),
+    (message) =>
+      message.id.startsWith("compaction:") && isCompactionMarker(message),
   );
 }
 
@@ -168,7 +171,9 @@ function isDuplicateCompactionMarker(
     return false;
   }
   if (typeof message.createdAt !== "number") {
-    return restoredCompactions.some((candidate) => candidate.text === message.text);
+    return restoredCompactions.some(
+      (candidate) => candidate.text === message.text,
+    );
   }
   const createdAt = message.createdAt;
   return restoredCompactions.some(
@@ -325,10 +330,15 @@ function mergePendingLocalPrompts(
       isLivePendingMessage(message, currentlyWaiting, latestRestoredTime) ||
       messageCreatedAt(message) === undefined,
   );
-  const mergedHistory = mergeTimestampedLocalMessages(restored, timestampedLocal);
+  const mergedHistory = mergeTimestampedLocalMessages(
+    restored,
+    timestampedLocal,
+  );
   return {
     messages:
-      appendLocal.length > 0 ? [...mergedHistory, ...appendLocal] : mergedHistory,
+      appendLocal.length > 0
+        ? [...mergedHistory, ...appendLocal]
+        : mergedHistory,
     hasLivePending: pendingLocal.some((message) =>
       isLivePendingMessage(message, currentlyWaiting, latestRestoredTime),
     ),
@@ -338,7 +348,9 @@ function mergePendingLocalPrompts(
 export const handleSessionHistory: BridgeMessageHandler = (data, ctx) => {
   const tabId = (data.tabId as string | undefined) ?? "default";
   const messages = dedupeToolResultTextMessages(
-    coerceChatMessages(data.messages).filter((message) => !isStopNotice(message)),
+    coerceChatMessages(data.messages).filter(
+      (message) => !isStopNotice(message),
+    ),
   );
   const session = ctx.allDiscoveredSessionsRef.current.find(
     (s) => s.tabId === tabId,
@@ -354,21 +366,32 @@ export const handleSessionHistory: BridgeMessageHandler = (data, ctx) => {
           (tab) => tab.id === tabId,
         )
       : undefined;
+  const runningTabs =
+    (ctx.stateRef.current.agentRunningTabs as
+      | Record<string, true>
+      | undefined) ?? {};
+  const hasLiveTurnEvidence = (tab: Tab): boolean =>
+    tab.waiting === true ||
+    runningTabs[tab.id] === true ||
+    hasRunningToolCard(tab.messages);
   const activeHydration = activeTab
     ? mergePendingLocalPrompts(
         messages,
         dedupeToolResultTextMessages(activeTab.messages),
-        activeTab.waiting === true,
+        hasLiveTurnEvidence(activeTab),
       )
     : undefined;
   ctx.updateTab(tabId, (tab) => {
+    const liveTurnEvidence = hasLiveTurnEvidence(tab);
     const merged = mergePendingLocalPrompts(
       messages,
       dedupeToolResultTextMessages(tab.messages),
-      tab.waiting === true,
+      liveTurnEvidence,
     );
-    const nextWaiting = merged.hasLivePending ? tab.waiting : false;
     const dedupedMessages = dedupeToolResultTextMessages(merged.messages);
+    const nextWaiting =
+      liveTurnEvidence &&
+      (merged.hasLivePending || hasRunningToolCard(dedupedMessages));
     const closedTools = nextWaiting
       ? { messages: dedupedMessages, changed: false }
       : closeRunningToolCards(dedupedMessages, {
@@ -383,10 +406,18 @@ export const handleSessionHistory: BridgeMessageHandler = (data, ctx) => {
         ? { label }
         : shouldReplaceGenericLabel(tab.label)
           ? { label: firstUserMessageLabel(messages) ?? tab.label }
-      : {}),
+          : {}),
     };
   });
-  if (activeHydration && !activeHydration.hasLivePending) {
+  if (
+    activeHydration &&
+    !activeHydration.hasLivePending &&
+    !(
+      activeTab &&
+      hasLiveTurnEvidence(activeTab) &&
+      hasRunningToolCard(activeHydration.messages)
+    )
+  ) {
     ctx.setStatusFlags({ waiting: false, status: "ready" });
   }
   ctx.syncRecentSessionsToState();

--- a/src/hooks/useAgentActivityHydration.test.ts
+++ b/src/hooks/useAgentActivityHydration.test.ts
@@ -203,7 +203,7 @@ describe("hydrateAgentActivityState", () => {
     expect(toolCard?.props?.status).toBeUndefined();
   });
 
-  it("marks stale running tool cards stopped when diagnostics only show unrelated idle workers", () => {
+  it("keeps a running tab alive when diagnostics only show unrelated idle workers", () => {
     vi.useFakeTimers();
     vi.setSystemTime(123_456);
     const waitingTab = {
@@ -249,16 +249,15 @@ describe("hydrateAgentActivityState", () => {
       ],
     );
 
-    expect(next.status).toBe("ready");
+    expect(next.status).toBe("thinking…");
+    expect(next.agentRunningTabs).toMatchObject({ "tab-a": true });
     const toolCard = ((next.tabs as (typeof waitingTab)[])[0].messages[0].a2ui
       ?.components?.[0] ?? {}) as A2UIComponent;
-    expect(toolCard.props).toMatchObject({
-      status: "cancelled",
-      endedAt: 123_456,
-    });
+    expect(toolCard.props?.status).toBeUndefined();
+    expect(toolCard.props?.endedAt).toBeUndefined();
   });
 
-  it("marks stale running tool cards stopped when diagnostics show no live prompt", () => {
+  it("does not stop a visible running tool card from a negative live diagnostic", () => {
     vi.useFakeTimers();
     vi.setSystemTime(123_456);
     const waitingTab = {
@@ -302,7 +301,8 @@ describe("hydrateAgentActivityState", () => {
       ],
     );
 
-    expect(next.status).toBe("ready");
+    expect(next.status).toBe("thinking…");
+    expect((next.tabs as (typeof waitingTab)[])[0].waiting).toBe(true);
     const components = (next.tabs as (typeof waitingTab)[])[0].messages[0].a2ui
       ?.components as A2UIComponent[] | undefined;
     const toolCard = components?.[0];
@@ -310,13 +310,69 @@ describe("hydrateAgentActivityState", () => {
     if (!toolCard) {
       throw new Error("expected restored tool card to be preserved");
     }
-    expect(toolCard?.props).toMatchObject({
+    expect(toolCard?.props?.status).toBeUndefined();
+    expect(toolCard?.props?.endedAt).toBeUndefined();
+    expect(toolCard.children?.[0]).toBeUndefined();
+  });
+
+  it("can stop running tool cards when an explicit stop flow trusts diagnostics", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(123_456);
+    const waitingTab = {
+      ...makeEmptyTab("tab-a", "A"),
+      waiting: true,
+      messages: [
+        {
+          id: "tool-message",
+          role: "agent" as const,
+          a2ui: {
+            components: [
+              {
+                id: "tool-1-call_1",
+                type: "tool-card",
+                props: {
+                  title: "bash",
+                  description: "sleep 60",
+                  startedAt: 100_000,
+                },
+                children: [],
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    const next = hydrateAgentActivityState(
+      {
+        activeTabId: "tab-a",
+        waiting: true,
+        status: "stopping…",
+        agentRunningTabs: { "tab-a": true },
+        tabs: [waitingTab],
+      },
+      [
+        {
+          key: "tab:tab-a",
+          tab_id: "tab-a",
+          alive: true,
+          prompt_in_flight: false,
+        },
+      ],
+      {
+        trustNegativeDiagnosticsForRunningTabs: true,
+        closeStaleToolCards: true,
+      },
+    );
+
+    expect(next.status).toBe("ready");
+    expect(next.agentRunningTabs).toEqual({});
+    const toolCard = ((next.tabs as (typeof waitingTab)[])[0].messages[0].a2ui
+      ?.components?.[0] ?? {}) as A2UIComponent;
+    expect(toolCard.props).toMatchObject({
       status: "cancelled",
       endedAt: 123_456,
     });
-    expect(toolCard.children?.[0].props?.content).toContain(
-      "No live prompt is running",
-    );
   });
 
   it("clears stale restored waiting state when there are no live diagnostics", () => {

--- a/src/hooks/useAgentActivityHydration.test.ts
+++ b/src/hooks/useAgentActivityHydration.test.ts
@@ -375,6 +375,105 @@ describe("hydrateAgentActivityState", () => {
     });
   });
 
+  it("scopes explicit stop diagnostics to one tab without cancelling concurrent turns", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(123_456);
+    const stoppedTab = {
+      ...makeEmptyTab("tab-a", "A"),
+      waiting: true,
+      messages: [
+        {
+          id: "tool-message-a",
+          role: "agent" as const,
+          a2ui: {
+            components: [
+              {
+                id: "tool-a-call_1",
+                type: "tool-card",
+                props: {
+                  title: "bash",
+                  description: "sleep 60",
+                  startedAt: 100_000,
+                },
+                children: [],
+              },
+            ],
+          },
+        },
+      ],
+    };
+    const concurrentTab = {
+      ...makeEmptyTab("tab-b", "B"),
+      waiting: true,
+      messages: [
+        {
+          id: "tool-message-b",
+          role: "agent" as const,
+          a2ui: {
+            components: [
+              {
+                id: "tool-b-call_1",
+                type: "tool-card",
+                props: {
+                  title: "bash",
+                  description: "pnpm test",
+                  startedAt: 100_000,
+                },
+                children: [],
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    const next = hydrateAgentActivityState(
+      {
+        activeTabId: "tab-a",
+        waiting: true,
+        status: "stopping…",
+        agentRunningTabs: { "tab-a": true, "tab-b": true },
+        tabs: [stoppedTab, concurrentTab],
+      },
+      [
+        {
+          key: "tab:tab-a",
+          tab_id: "tab-a",
+          alive: true,
+          prompt_in_flight: false,
+        },
+        {
+          key: "tab:tab-b",
+          tab_id: "tab-b",
+          alive: true,
+          prompt_in_flight: false,
+        },
+      ],
+      {
+        trustNegativeDiagnosticsForTabIds: new Set(["tab-a"]),
+        closeStaleToolCardsForTabIds: new Set(["tab-a"]),
+      },
+    );
+
+    expect(next.agentRunningTabs).toEqual({ "tab-b": true });
+    const [nextStoppedTab, nextConcurrentTab] = next.tabs as [
+      typeof stoppedTab,
+      typeof concurrentTab,
+    ];
+    const stoppedToolCard = nextStoppedTab.messages[0].a2ui
+      ?.components?.[0] as A2UIComponent | undefined;
+    const concurrentToolCard = nextConcurrentTab.messages[0].a2ui
+      ?.components?.[0] as A2UIComponent | undefined;
+    expect(nextStoppedTab.waiting).toBe(false);
+    expect(stoppedToolCard?.props).toMatchObject({
+      status: "cancelled",
+      endedAt: 123_456,
+    });
+    expect(nextConcurrentTab.waiting).toBe(true);
+    expect(concurrentToolCard?.props?.status).toBeUndefined();
+    expect(concurrentToolCard?.props?.endedAt).toBeUndefined();
+  });
+
   it("clears stale restored waiting state when there are no live diagnostics", () => {
     const waitingTab = { ...makeEmptyTab("tab-a", "A"), waiting: true };
     const next = hydrateAgentActivityState(

--- a/src/hooks/useAgentActivityHydration.ts
+++ b/src/hooks/useAgentActivityHydration.ts
@@ -22,7 +22,9 @@ export interface HydrateAgentActivityOptions {
    *  is running, but a transient negative row must not cancel work that may
    *  resume. Explicit stop/crash flows opt into trusting negatives. */
   trustNegativeDiagnosticsForRunningTabs?: boolean;
+  trustNegativeDiagnosticsForTabIds?: ReadonlySet<string>;
   closeStaleToolCards?: boolean;
+  closeStaleToolCardsForTabIds?: ReadonlySet<string>;
 }
 
 function diagnosticTabId(row: AgentDiagnosticRow): string | null {
@@ -65,7 +67,8 @@ export function hydrateAgentActivityState(
   for (const [tabId, promptInFlight] of promptByTabId) {
     if (!promptInFlight) {
       if (
-        options.trustNegativeDiagnosticsForRunningTabs === true &&
+        (options.trustNegativeDiagnosticsForRunningTabs === true ||
+          options.trustNegativeDiagnosticsForTabIds?.has(tabId) === true) &&
         nextRunningTabs[tabId] === true
       ) {
         nextRunningTabs =
@@ -92,13 +95,14 @@ export function hydrateAgentActivityState(
       : false;
     const runningSetBusy =
       nextRunningTabs[tab.id] === true &&
-      options.trustNegativeDiagnosticsForRunningTabs !== true;
+      options.trustNegativeDiagnosticsForRunningTabs !== true &&
+      options.trustNegativeDiagnosticsForTabIds?.has(tab.id) !== true;
+    const closeToolsForTab =
+      options.closeStaleToolCards === true ||
+      options.closeStaleToolCardsForTabIds?.has(tab.id) === true;
     const nextWaiting =
-      diagnosticRunning ||
-      runningSetBusy ||
-      (runningTool && options.closeStaleToolCards !== true);
-    const shouldStopTools =
-      options.closeStaleToolCards === true && !nextWaiting && runningTool;
+      diagnosticRunning || runningSetBusy || (runningTool && !closeToolsForTab);
+    const shouldStopTools = closeToolsForTab && !nextWaiting && runningTool;
     const stoppedTools = shouldStopTools
       ? closeRunningToolCards(tab.messages, {
           endedAt,

--- a/src/hooks/useAgentActivityHydration.ts
+++ b/src/hooks/useAgentActivityHydration.ts
@@ -17,6 +17,14 @@ export interface AgentDiagnosticRow {
   promptInFlight?: boolean;
 }
 
+export interface HydrateAgentActivityOptions {
+  /** Live boot/retry hydration is conservative: diagnostics can prove a turn
+   *  is running, but a transient negative row must not cancel work that may
+   *  resume. Explicit stop/crash flows opt into trusting negatives. */
+  trustNegativeDiagnosticsForRunningTabs?: boolean;
+  closeStaleToolCards?: boolean;
+}
+
 function diagnosticTabId(row: AgentDiagnosticRow): string | null {
   if (typeof row.tab_id === "string" && row.tab_id.length > 0) {
     return row.tab_id;
@@ -36,6 +44,7 @@ function diagnosticPromptInFlight(row: AgentDiagnosticRow): boolean {
 export function hydrateAgentActivityState(
   state: Record<string, unknown>,
   diagnostics: AgentDiagnosticRow[],
+  options: HydrateAgentActivityOptions = {},
 ): Record<string, unknown> {
   const tabs = (state.tabs as Tab[] | undefined) ?? [];
   if (tabs.length === 0) return state;
@@ -52,26 +61,44 @@ export function hydrateAgentActivityState(
   }
   const runningTabs =
     (state.agentRunningTabs as Record<string, true> | undefined) ?? {};
-  const anyPromptInFlight = [...promptByTabId.values()].some(Boolean);
+  let nextRunningTabs = runningTabs;
+  for (const [tabId, promptInFlight] of promptByTabId) {
+    if (!promptInFlight) {
+      if (
+        options.trustNegativeDiagnosticsForRunningTabs === true &&
+        nextRunningTabs[tabId] === true
+      ) {
+        nextRunningTabs =
+          nextRunningTabs === runningTabs
+            ? { ...runningTabs }
+            : nextRunningTabs;
+        delete nextRunningTabs[tabId];
+      }
+      continue;
+    }
+    if (nextRunningTabs[tabId]) continue;
+    nextRunningTabs =
+      nextRunningTabs === runningTabs ? { ...runningTabs } : nextRunningTabs;
+    nextRunningTabs[tabId] = true;
+  }
   let tabChanged = false;
   const endedAt = Date.now();
   const nextTabs = tabs.map((tab) => {
     if ((tab.kind ?? "agent") !== "agent") return tab;
     const hasDiagnostic = promptByTabId.has(tab.id);
     const runningTool = hasRunningToolCard(tab.messages);
-    const diagnosticsAbsent = diagnostics.length === 0;
-    const preserveUnknownBusyState =
-      !hasDiagnostic &&
-      !diagnosticsAbsent &&
-      anyPromptInFlight &&
-      runningTabs[tab.id] === true &&
-      (tab.waiting || runningTool);
-    const nextWaiting = preserveUnknownBusyState
-      ? true
-      : hasDiagnostic
-        ? promptByTabId.get(tab.id) === true
-        : false;
-    const shouldStopTools = !nextWaiting;
+    const diagnosticRunning = hasDiagnostic
+      ? promptByTabId.get(tab.id) === true
+      : false;
+    const runningSetBusy =
+      nextRunningTabs[tab.id] === true &&
+      options.trustNegativeDiagnosticsForRunningTabs !== true;
+    const nextWaiting =
+      diagnosticRunning ||
+      runningSetBusy ||
+      (runningTool && options.closeStaleToolCards !== true);
+    const shouldStopTools =
+      options.closeStaleToolCards === true && !nextWaiting && runningTool;
     const stoppedTools = shouldStopTools
       ? closeRunningToolCards(tab.messages, {
           endedAt,
@@ -89,20 +116,27 @@ export function hydrateAgentActivityState(
   const activeRecord =
     (activeTab as unknown as Record<string, unknown> | undefined) ?? {};
   const activeTurnBusy =
-    activeTab?.waiting === true || (activeTab?.queueCount ?? 0) > 0;
+    activeTab?.waiting === true ||
+    (activeTab ? nextRunningTabs[activeTab.id] === true : false) ||
+    hasRunningToolCard(activeTab?.messages) ||
+    (activeTab?.queueCount ?? 0) > 0;
   const nextStatus = activeTurnBusy ? "thinking…" : "ready";
   const statusChanged = !!activeTab && state.status !== nextStatus;
+  const runningChanged = nextRunningTabs !== runningTabs;
   const mirrorChanged =
     !!activeTab &&
     TAB_MIRROR_KEYS.some(
       (key) => state[key as string] !== activeRecord[key as string],
     );
-  if (!tabChanged && !statusChanged && !mirrorChanged) return state;
+  if (!tabChanged && !statusChanged && !runningChanged && !mirrorChanged) {
+    return state;
+  }
 
   const next: Record<string, unknown> = {
     ...state,
     ...(tabChanged ? { tabs: nextTabs } : {}),
     ...(activeTab ? { status: nextStatus } : {}),
+    ...(runningChanged ? { agentRunningTabs: nextRunningTabs } : {}),
   };
   if (activeTab) {
     for (const key of TAB_MIRROR_KEYS) {

--- a/src/hooks/useChat.test.ts
+++ b/src/hooks/useChat.test.ts
@@ -418,7 +418,6 @@ describe("useChat setModel", () => {
     expect(tab.messages.some((m) => m.text === "after this")).toBe(false);
   });
 
-
   it("holds attachments with queued normal messages while the prompt is busy", async () => {
     const attachment = {
       id: "img-queued",
@@ -484,6 +483,12 @@ describe("useChat setModel", () => {
             alive: true,
             prompt_in_flight: false,
           },
+          {
+            key: "tab:tab-2",
+            tab_id: "tab-2",
+            alive: true,
+            prompt_in_flight: false,
+          },
         ]);
       }
       return Promise.resolve(undefined);
@@ -509,11 +514,36 @@ describe("useChat setModel", () => {
     const { ctx, stateRef } = buildContext({
       status: "thinking…",
       waiting: true,
+      agentRunningTabs: { "tab-1": true, "tab-2": true },
       tabs: [
         {
           ...makeEmptyTab("tab-1", "Tab 1"),
           waiting: true,
           messages: [runningTool],
+        },
+        {
+          ...makeEmptyTab("tab-2", "Tab 2"),
+          waiting: true,
+          messages: [
+            {
+              ...runningTool,
+              id: "tool-message-2",
+              a2ui: {
+                components: [
+                  {
+                    id: "restored-tool-call_2",
+                    type: "tool-card",
+                    props: {
+                      title: "bash",
+                      description: "pnpm test",
+                      startedAt: 1_000,
+                    },
+                    children: [],
+                  },
+                ],
+              },
+            },
+          ],
         },
       ],
     });
@@ -538,6 +568,12 @@ describe("useChat setModel", () => {
       role: "system",
       text: "Agent stopped.",
     });
+    expect(stateRef.current.agentRunningTabs).toEqual({ "tab-2": true });
+    const concurrentTab = (stateRef.current.tabs as Tab[])[1];
+    const concurrentToolCard = concurrentTab.messages[0].a2ui?.components?.[0];
+    expect(concurrentTab.waiting).toBe(true);
+    expect(concurrentToolCard?.props?.status).toBeUndefined();
+    expect(concurrentToolCard?.props?.endedAt).toBeUndefined();
     expect(ctx.persistLocalChatMessage).not.toHaveBeenCalledWith(
       expect.objectContaining({ role: "system", text: "Agent stopped." }),
       expect.any(String),

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -368,7 +368,10 @@ export function useChat(ctx: UseChatContext): UseChatActions {
         createdAt: Date.now(),
       };
       setState((prev) => {
-        const hydrated = hydrateAgentActivityState(prev, diagnostics);
+        const hydrated = hydrateAgentActivityState(prev, diagnostics, {
+          trustNegativeDiagnosticsForRunningTabs: true,
+          closeStaleToolCards: true,
+        });
         const tabs = (hydrated.tabs as Tab[] | undefined) ?? [];
         const nextTabs = tabs.map((tab) =>
           tab.id === tabId

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -369,8 +369,8 @@ export function useChat(ctx: UseChatContext): UseChatActions {
       };
       setState((prev) => {
         const hydrated = hydrateAgentActivityState(prev, diagnostics, {
-          trustNegativeDiagnosticsForRunningTabs: true,
-          closeStaleToolCards: true,
+          trustNegativeDiagnosticsForTabIds: new Set([tabId]),
+          closeStaleToolCardsForTabIds: new Set([tabId]),
         });
         const tabs = (hydrated.tabs as Tab[] | undefined) ?? [];
         const nextTabs = tabs.map((tab) =>

--- a/src/hooks/useDerivedRenderState.test.ts
+++ b/src/hooks/useDerivedRenderState.test.ts
@@ -55,11 +55,7 @@ describe("useDerivedRenderState", () => {
         },
       ],
     });
-    expect(buildSidebarHistory).toHaveBeenCalledWith(
-      [active],
-      "tab-1",
-      [],
-    );
+    expect(buildSidebarHistory).toHaveBeenCalledWith([active], "tab-1", []);
   });
 
   it("keeps the overview visible when only shell tabs exist", () => {
@@ -274,10 +270,10 @@ describe("useDerivedRenderState", () => {
     expect(wtMain && "agent" in wtMain).toBe(false);
   });
 
-  it("reconciles the running set against active tabs' in-flight state", () => {
-    // Stale running entry for an ACTIVE tab whose turn already ended (crash /
-    // error cleared `waiting` but not the running set) must read as idle, not
-    // running — the active tab's in-flight state is authoritative.
+  it("keeps sidebar activity running until a terminal turn event clears it", () => {
+    // `waiting` can briefly drift false while the agent is still streaming
+    // tool output. The running set owns lifecycle until response_end,
+    // explicit stop, or crash removes the tab id.
     const idleActive = {
       ...makeEmptyTab("m", "m", "p1", "agent"),
       cwd: "/repo/app",
@@ -288,7 +284,7 @@ describe("useDerivedRenderState", () => {
         state: {
           tabs: [idleActive],
           activeTabId: "m",
-          agentRunningTabs: { m: true }, // stale — turn already ended
+          agentRunningTabs: { m: true },
           sidebar: {
             projects: [
               {
@@ -307,7 +303,7 @@ describe("useDerivedRenderState", () => {
         projects: { agent: { status: string } }[];
       }
     ).projects;
-    expect(projects[0].agent.status).toBe("idle-with-session");
+    expect(projects[0].agent.status).toBe("running");
   });
 
   it("keeps sidebar activity running while a visible tool-card is still live", () => {
@@ -352,7 +348,10 @@ describe("useDerivedRenderState", () => {
     );
     const projects = (
       result.current.renderState.sidebar as {
-        projects: { agent: { status: string }; agentRollup: { status: string } }[];
+        projects: {
+          agent: { status: string };
+          agentRollup: { status: string };
+        }[];
       }
     ).projects;
     expect(projects[0].agent.status).toBe("running");

--- a/src/hooks/useDerivedRenderState.ts
+++ b/src/hooks/useDerivedRenderState.ts
@@ -1,9 +1,5 @@
 import { useMemo } from "react";
-import {
-  activeTabKind,
-  OVERVIEW_TAB_ID,
-  type Tab,
-} from "../types/tab";
+import { activeTabKind, OVERVIEW_TAB_ID, type Tab } from "../types/tab";
 import type { UseHostInfo } from "./useHostInfo";
 import { attachAgentActivity } from "./projectOps/agentActivity";
 import { isAgentTabInFlight } from "../utils/agentBusy";
@@ -67,8 +63,7 @@ export function useDerivedRenderState({
       (t) => t.kind === "agent" || t.kind === "editor",
     );
     const activeKind = activeTabKind(tabs, activeTabId);
-    const overviewActive =
-      activeKind === null || activeKind === "shell";
+    const overviewActive = activeKind === null || activeKind === "shell";
     const landing = state.landing as { kind?: string } | null | undefined;
     const landingVisible = !!landing && landing.kind === "worktree";
     // The overview owns the canvas when there are no session tabs *or*
@@ -165,16 +160,14 @@ export function useDerivedRenderState({
         (state.agentRunningTabs as Record<string, unknown> | undefined) ?? {},
       ),
     );
-    // The active workspace's tabs carry the freshest liveness signals:
-    // `waiting` plus any visible running tool-card. Reconcile active tabs
-    // here so stale running-set entries do not keep ended/crashed turns orange,
-    // while a waiting drift cannot hide a command that is still visibly live.
-    // Backgrounded tabs (frozen `waiting` and messages) keep relying on the
-    // bucket-independent running set.
+    // The running set is the authoritative cross-workspace turn lifecycle:
+    // prompt_started adds, response_end / explicit stop / crash removes. The
+    // active tab can still promote itself when a visible tool card is live, but
+    // render derivation must not demote a running id just because `waiting`
+    // briefly drifted false before response_end.
     for (const t of tabs) {
       if (t.kind !== "agent") continue;
       if (isAgentTabInFlight(t)) runningIds.add(t.id);
-      else runningIds.delete(t.id);
     }
     const sidebarProjectsWithAgent = Array.isArray(sidebar.projects)
       ? attachAgentActivity(


### PR DESCRIPTION
## Summary
- make live diagnostics conservative so they can promote running agent state without cancelling in-flight turns
- preserve restored unfinished tool cards while a tab still has live turn evidence
- keep sidebar/worktree activity indicators running until response_end, explicit stop, crash, or close clears the tab

## Root Cause
The UI trusted transient negative diagnostics and session-history restore data as proof that a turn was done. That could close live tool cards with the "No live prompt is running" notice, clear waiting/status, and remove the green activity affordance even though the agent/tool stream could later resume. With multiple concurrent sessions this made active work appear randomly cancelled and contributed to the laggy, confusing UI state.

## Impact
Concurrent agent sessions now remain independent and visible. Diagnostics no longer demote active work by default, while explicit stop/crash/turn-end paths still settle the UI and clear stale running markers.

Fixes #253.

## Validation
- bunx vitest run src/hooks/useAgentActivityHydration.test.ts src/hooks/useDerivedRenderState.test.ts src/hooks/bridgeMessageHandlers/sessionHistory.test.ts src/hooks/bridgeMessageHandlers/error.test.ts src/hooks/bridgeMessageHandlers/response.test.ts src/hooks/bridgeMessageHandlers/a2ui.test.ts src/hooks/bridgeMessageHandlers/responseEnd.test.ts src/hooks/bridgeMessageHandlers/promptStarted.test.ts
- bun run --silent typecheck
- bun run --silent lint
- git diff --check
