### PR TITLE
fix: run project agents and shells inside devshells

### DIFF
--- a/agent/chat.ts
+++ b/agent/chat.ts
@@ -20,6 +20,9 @@ import {
   FileReferenceError,
   expandFileReferencesInPrompt,
 } from "./file-references";
+import { logger } from "./logger";
+
+const chatLog = logger.scope("chat");
 
 export async function handleChat(
   state: AethonAgentState,
@@ -31,6 +34,7 @@ export async function handleChat(
     return;
   }
   const tabId = msg.tabId ?? "default";
+  chatLog.info(`received tabId=${tabId} chars=${msg.content.length}`);
   // Per-tab hard-guardrail override rides each chat so the source guard sees
   // the current value before this turn's tool calls (and survives a respawn).
   if (typeof msg.hardEnforce === "boolean") {
@@ -73,6 +77,7 @@ export async function handleChat(
     tabId,
     cwdOverride || initialModel ? { cwdOverride, initialModel } : {},
   );
+  chatLog.info(`tab ready tabId=${tabId}`);
   if (authServicesRefreshed) {
     refreshTabSessionModelFromAuthServices(state, tabId);
   }
@@ -171,6 +176,7 @@ export async function handleChat(
       }
       maybeExitForReload(state, deps);
     });
+  chatLog.info(`prompt dispatched tabId=${tabId}`);
 }
 
 function isUnderlyingSessionBusy(tab: TabRecord): boolean {

--- a/agent/devshell/client.test.ts
+++ b/agent/devshell/client.test.ts
@@ -8,6 +8,7 @@ import {
   maybeWarnColdRun,
   onDevshellEvent,
   refresh,
+  seedPreparedEnv,
 } from "./client";
 import { ackMutation, markFrontendReady } from "../mutation-ack";
 
@@ -50,7 +51,12 @@ function makeHarness(): Harness {
   return { state, deps: { send }, sent };
 }
 
-function ackLastWith(harness: Harness, success: boolean, data?: unknown, error?: string): void {
+function ackLastWith(
+  harness: Harness,
+  success: boolean,
+  data?: unknown,
+  error?: string,
+): void {
   const last = harness.sent[harness.sent.length - 1];
   if (!last?.mutationId) throw new Error("no pending mutation to ack");
   ackMutation(harness.state, last.mutationId, success, error, data);
@@ -90,7 +96,10 @@ describe("getCachedEnv", () => {
     const { env, kind, hot } = getCachedEnv(h.state, h.deps, "/proj");
     expect(hot).toBe(true);
     expect(kind).toBe("flake");
-    expect(env).toEqual({ PATH: "/nix/store/abc/bin", RUSTC: "/nix/store/xyz/bin/rustc" });
+    expect(env).toEqual({
+      PATH: "/nix/store/abc/bin",
+      RUSTC: "/nix/store/xyz/bin/rustc",
+    });
   });
 
   it("flushes env when enabled is 'never'", async () => {
@@ -108,7 +117,11 @@ describe("getCachedEnv", () => {
     const h = makeHarness();
     // 1st fetch — success
     let p = ensureFetched(h.state, h.deps, "/proj");
-    ackLastWith(h, true, { enabled: "auto", kind: "flake", env: { PATH: "/x" } });
+    ackLastWith(h, true, {
+      enabled: "auto",
+      kind: "flake",
+      env: { PATH: "/x" },
+    });
     await p;
     // 2nd fetch — failure should NOT clear the cached env.
     p = ensureFetched(h.state, h.deps, "/proj");
@@ -117,6 +130,55 @@ describe("getCachedEnv", () => {
     const { env, hot } = getCachedEnv(h.state, h.deps, "/proj");
     expect(env).toEqual({ PATH: "/x" });
     expect(hot).toBe(true);
+  });
+});
+
+describe("seedPreparedEnv", () => {
+  it("seeds only the supervisor-marked devshell env keys", () => {
+    const h = makeHarness();
+    seedPreparedEnv(
+      "/proj",
+      {
+        AETHON_WORKER_DEVSHELL_ENV_KEYS: JSON.stringify([
+          "PATH",
+          "IN_NIX_SHELL",
+        ]),
+        PATH: "/nix/store/bin",
+        IN_NIX_SHELL: "impure",
+        PWD: "/wrong",
+        SHLVL: "7",
+        "BASH_FUNC_menu%%": "() { echo leaked; }",
+      },
+      "flake",
+    );
+
+    const { env, kind, hot } = getCachedEnv(h.state, h.deps, "/proj");
+    expect(hot).toBe(true);
+    expect(kind).toBe("flake");
+    expect(env).toEqual({
+      PATH: "/nix/store/bin",
+      IN_NIX_SHELL: "impure",
+    });
+    expect(h.sent.length).toBe(0);
+  });
+
+  it("keeps the cache cold when prepared env keys are missing", () => {
+    const h = makeHarness();
+    seedPreparedEnv(
+      "/proj",
+      { PATH: "/nix/store/bin", PWD: "/wrong" },
+      "flake",
+    );
+
+    const { env, kind, hot } = getCachedEnv(h.state, h.deps, "/proj");
+    expect(hot).toBe(false);
+    expect(kind).toBeNull();
+    expect(env).toEqual({});
+    expect(h.sent[0]).toMatchObject({
+      type: "devshell_query",
+      op: "env_for_path",
+      args: { cwd: "/proj" },
+    });
   });
 });
 
@@ -155,13 +217,25 @@ describe("onDevshellEvent", () => {
   it("invalidates cache entries under a root on ready", async () => {
     const h = makeHarness();
     const p1 = ensureFetched(h.state, h.deps, "/proj");
-    ackLastWith(h, true, { enabled: "auto", kind: "flake", env: { PATH: "/old" } });
+    ackLastWith(h, true, {
+      enabled: "auto",
+      kind: "flake",
+      env: { PATH: "/old" },
+    });
     await p1;
     const p2 = ensureFetched(h.state, h.deps, "/proj/sub");
-    ackLastWith(h, true, { enabled: "auto", kind: "flake", env: { PATH: "/old-sub" } });
+    ackLastWith(h, true, {
+      enabled: "auto",
+      kind: "flake",
+      env: { PATH: "/old-sub" },
+    });
     await p2;
 
-    onDevshellEvent(h.state, h.deps, { kind: "flake", root: "/proj", status: "ready" });
+    onDevshellEvent(h.state, h.deps, {
+      kind: "flake",
+      root: "/proj",
+      status: "ready",
+    });
     const { hot: hotRoot } = getCachedEnv(h.state, h.deps, "/proj");
     const { hot: hotSub } = getCachedEnv(h.state, h.deps, "/proj/sub");
     // Both went cold → fetches kicked off.
@@ -172,9 +246,17 @@ describe("onDevshellEvent", () => {
   it("does not invalidate cache entries under unrelated roots", async () => {
     const h = makeHarness();
     const p = ensureFetched(h.state, h.deps, "/proj-a");
-    ackLastWith(h, true, { enabled: "auto", kind: "flake", env: { PATH: "/a" } });
+    ackLastWith(h, true, {
+      enabled: "auto",
+      kind: "flake",
+      env: { PATH: "/a" },
+    });
     await p;
-    onDevshellEvent(h.state, h.deps, { kind: "flake", root: "/proj-b", status: "ready" });
+    onDevshellEvent(h.state, h.deps, {
+      kind: "flake",
+      root: "/proj-b",
+      status: "ready",
+    });
     const { env, hot } = getCachedEnv(h.state, h.deps, "/proj-a");
     expect(hot).toBe(true);
     expect(env).toEqual({ PATH: "/a" });
@@ -185,7 +267,11 @@ describe("refresh", () => {
   it("clears cache for the root and sends a refresh query", async () => {
     const h = makeHarness();
     const p = ensureFetched(h.state, h.deps, "/proj");
-    ackLastWith(h, true, { enabled: "auto", kind: "flake", env: { PATH: "/old" } });
+    ackLastWith(h, true, {
+      enabled: "auto",
+      kind: "flake",
+      env: { PATH: "/old" },
+    });
     await p;
 
     const refreshP = refresh(h.state, h.deps, "/proj");

--- a/agent/devshell/client.test.ts
+++ b/agent/devshell/client.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AethonAgentState, type AethonAgentStateOptions } from "../state";
 import {
   _resetForTests,
+  ensurePrepared,
   ensureFetched,
   getCachedEnv,
   maybeWarnColdRun,
@@ -116,6 +117,37 @@ describe("getCachedEnv", () => {
     const { env, hot } = getCachedEnv(h.state, h.deps, "/proj");
     expect(env).toEqual({ PATH: "/x" });
     expect(hot).toBe(true);
+  });
+});
+
+describe("ensurePrepared", () => {
+  it("sends blocking prepare query and seeds the cache", async () => {
+    const h = makeHarness();
+    const p = ensurePrepared(h.state, h.deps, "/proj");
+    expect(h.sent[0]).toMatchObject({
+      type: "devshell_query",
+      op: "prepare_for_path",
+      args: { cwd: "/proj", includeEnv: true },
+    });
+    ackLastWith(h, true, {
+      enabled: "auto",
+      state: "ready",
+      kind: "direnv",
+      env: { PATH: "/nix/store/bin", IN_NIX_SHELL: "impure" },
+      stale: false,
+    });
+    await p;
+    const { env, kind, hot } = getCachedEnv(h.state, h.deps, "/proj");
+    expect(hot).toBe(true);
+    expect(kind).toBe("direnv");
+    expect(env).toEqual({ PATH: "/nix/store/bin", IN_NIX_SHELL: "impure" });
+  });
+
+  it("throws when blocking prepare is rejected", async () => {
+    const h = makeHarness();
+    const p = ensurePrepared(h.state, h.deps, "/proj");
+    ackLastWith(h, false, undefined, "devshell required");
+    await expect(p).rejects.toThrow("devshell required");
   });
 });
 

--- a/agent/devshell/client.ts
+++ b/agent/devshell/client.ts
@@ -42,6 +42,7 @@ export interface DevshellClientDeps {
 }
 
 const FETCH_TIMEOUT_MS = 5_000;
+const PREPARE_TIMEOUT_MS = 130_000;
 
 /** Hit point for the bash spawnHook. Synchronous. Returns the cached
  *  env (possibly empty) and, if necessary, kicks off a background
@@ -60,6 +61,29 @@ export function getCachedEnv(
     void ensureFetched(state, deps, cwd);
   }
   return { env: entry?.env ?? {}, kind: entry?.kind ?? null, hot: false };
+}
+
+/** Seed the synchronous bash-hook cache from a tab worker process that Rust
+ *  already spawned under a prepared devshell env. This avoids a duplicate
+ *  bridge -> frontend -> Rust prepare query before the first prompt can reach
+ *  pi, while still keeping Force/None modes honest: callers only invoke this
+ *  when the supervisor explicitly marked the worker env prepared. */
+export function seedPreparedEnv(
+  cwd: string,
+  env: NodeJS.ProcessEnv,
+  kind: string | null,
+): void {
+  const prepared: Record<string, string> = {};
+  for (const [key, value] of Object.entries(env)) {
+    if (typeof value === "string") prepared[key] = value;
+  }
+  cache.set(cwd, {
+    kind,
+    env: prepared,
+    resolvedAt: Date.now(),
+    stale: false,
+    fetching: false,
+  });
 }
 
 /** Explicit fetch — used by tab-lifecycle on session creation so the
@@ -133,6 +157,90 @@ export async function ensureFetched(
     logger
       .scope("devshell")
       .warn(`env_for_path(${cwd}) threw: ${(err as Error).message}`);
+  }
+}
+
+/** Blocking preparation used before creating a tab-scoped session. This asks
+ *  the frontend/Rust cache to wait for Nix/direnv readiness, then seeds the
+ *  synchronous spawn-hook cache with the prepared env. */
+export async function ensurePrepared(
+  state: AethonAgentState,
+  deps: DevshellClientDeps,
+  cwd: string,
+): Promise<void> {
+  const existing = cache.get(cwd);
+  cache.set(cwd, {
+    kind: existing?.kind ?? null,
+    env: existing?.env ?? {},
+    resolvedAt: existing?.resolvedAt ?? 0,
+    stale: existing?.stale ?? false,
+    fetching: true,
+  });
+  try {
+    const result = await sendQuery(
+      state,
+      deps,
+      "prepare_for_path",
+      { cwd, includeEnv: true },
+      PREPARE_TIMEOUT_MS,
+    );
+    if (!result.ok) {
+      cache.set(cwd, {
+        kind: existing?.kind ?? null,
+        env: existing?.env ?? {},
+        resolvedAt: existing?.resolvedAt ?? 0,
+        stale: true,
+        fetching: false,
+      });
+      throw new Error(result.error ?? "devshell prepare failed");
+    }
+    const payload = (result.data ?? {}) as {
+      enabled?: string;
+      state?: string;
+      kind?: string | null;
+      env?: Record<string, string>;
+      stale?: boolean;
+      reason?: string | null;
+    };
+    if (payload.enabled === "never" || payload.state === "none") {
+      cache.set(cwd, {
+        kind: null,
+        env: {},
+        resolvedAt: Date.now(),
+        stale: false,
+        fetching: false,
+      });
+      return;
+    }
+    if (payload.state === "failed") {
+      cache.set(cwd, {
+        kind: payload.kind ?? existing?.kind ?? null,
+        env: existing?.env ?? {},
+        resolvedAt: existing?.resolvedAt ?? 0,
+        stale: true,
+        fetching: false,
+      });
+      logger
+        .scope("devshell")
+        .warn(`prepare_for_path(${cwd}) failed: ${payload.reason ?? "unknown"}`);
+      return;
+    }
+    cache.set(cwd, {
+      kind: payload.kind ?? null,
+      env: payload.env ?? {},
+      resolvedAt: Date.now(),
+      stale: payload.stale === true,
+      fetching: false,
+    });
+  } catch (err) {
+    cache.set(cwd, {
+      kind: existing?.kind ?? null,
+      env: existing?.env ?? {},
+      resolvedAt: existing?.resolvedAt ?? 0,
+      stale: true,
+      fetching: false,
+    });
+    throw err;
   }
 }
 

--- a/agent/devshell/client.ts
+++ b/agent/devshell/client.ts
@@ -43,6 +43,7 @@ export interface DevshellClientDeps {
 
 const FETCH_TIMEOUT_MS = 5_000;
 const PREPARE_TIMEOUT_MS = 130_000;
+const PREPARED_ENV_KEYS_VAR = "AETHON_WORKER_DEVSHELL_ENV_KEYS";
 
 /** Hit point for the bash spawnHook. Synchronous. Returns the cached
  *  env (possibly empty) and, if necessary, kicks off a background
@@ -73,8 +74,11 @@ export function seedPreparedEnv(
   env: NodeJS.ProcessEnv,
   kind: string | null,
 ): void {
+  const keys = preparedEnvKeys(env);
+  if (keys.length === 0) return;
   const prepared: Record<string, string> = {};
-  for (const [key, value] of Object.entries(env)) {
+  for (const key of keys) {
+    const value = env[key];
     if (typeof value === "string") prepared[key] = value;
   }
   cache.set(cwd, {
@@ -84,6 +88,20 @@ export function seedPreparedEnv(
     stale: false,
     fetching: false,
   });
+}
+
+function preparedEnvKeys(env: NodeJS.ProcessEnv): string[] {
+  const raw = env[PREPARED_ENV_KEYS_VAR];
+  if (typeof raw !== "string" || raw.length === 0) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (key): key is string => typeof key === "string" && key.length > 0,
+    );
+  } catch {
+    return [];
+  }
 }
 
 /** Explicit fetch — used by tab-lifecycle on session creation so the
@@ -104,7 +122,13 @@ export async function ensureFetched(
     fetching: true,
   });
   try {
-    const result = await sendQuery(state, deps, "env_for_path", { cwd }, FETCH_TIMEOUT_MS);
+    const result = await sendQuery(
+      state,
+      deps,
+      "env_for_path",
+      { cwd },
+      FETCH_TIMEOUT_MS,
+    );
     if (!result.ok) {
       // Don't drop the existing cache on a transient failure — the
       // previous env (if any) is still our best bet. Just clear the
@@ -222,7 +246,9 @@ export async function ensurePrepared(
       });
       logger
         .scope("devshell")
-        .warn(`prepare_for_path(${cwd}) failed: ${payload.reason ?? "unknown"}`);
+        .warn(
+          `prepare_for_path(${cwd}) failed: ${payload.reason ?? "unknown"}`,
+        );
       return;
     }
     cache.set(cwd, {
@@ -277,7 +303,11 @@ export async function refresh(
 export function onDevshellEvent(
   state: AethonAgentState,
   deps: DevshellClientDeps,
-  event: { kind: string; root: string; status: "ready" | "failed" | "resolving" },
+  event: {
+    kind: string;
+    root: string;
+    status: "ready" | "failed" | "resolving";
+  },
 ): void {
   if (event.status === "ready") {
     // Just invalidate; the next spawnHook call will re-fetch under
@@ -319,10 +349,12 @@ function isUnderRoot(cwd: string, root: string): boolean {
 export function maybeWarnColdRun(cwd: string, kind: string | null): boolean {
   if (warned.has(cwd)) return false;
   warned.add(cwd);
-  logger.scope("devshell").warn(
-    `cold devshell run for cwd ${cwd}${kind ? ` (kind=${kind})` : ""}: ` +
-      `host env in use until resolver completes. Subsequent calls will inherit the devshell env.`,
-  );
+  logger
+    .scope("devshell")
+    .warn(
+      `cold devshell run for cwd ${cwd}${kind ? ` (kind=${kind})` : ""}: ` +
+        `host env in use until resolver completes. Subsequent calls will inherit the devshell env.`,
+    );
   return true;
 }
 
@@ -348,7 +380,9 @@ async function sendQuery(
   if (!state.frontendReady) {
     const ready = await Promise.race<boolean>([
       state.frontendReadyPromise.then(() => true),
-      new Promise<boolean>((resolve) => setTimeout(() => resolve(false), timeoutMs)),
+      new Promise<boolean>((resolve) =>
+        setTimeout(() => resolve(false), timeoutMs),
+      ),
     ]);
     if (!ready) return { ok: false, error: "frontend_not_ready" };
   }

--- a/agent/devshell/index.ts
+++ b/agent/devshell/index.ts
@@ -5,11 +5,13 @@
 
 export { buildDevshellSpawnHook } from "./spawnHook";
 export {
+  ensurePrepared,
   ensureFetched,
   getCachedEnv,
   maybeWarnColdRun,
   onDevshellEvent,
   refresh,
+  seedPreparedEnv,
   _resetForTests,
 } from "./client";
 export type { DevshellClientDeps } from "./client";

--- a/agent/main.ts
+++ b/agent/main.ts
@@ -80,6 +80,7 @@ import {
   getRuntimeSnapshot,
   scheduleStateFileWrite as scheduleStateFileWriteImpl,
 } from "./runtime-snapshot";
+import { markFrontendReady } from "./mutation-ack";
 import {
   loadAethonExtensions,
   loadAethonExtensionPackages,
@@ -89,6 +90,7 @@ import {
   discoverPiAethonExtensions,
 } from "./extension-loader";
 import { ensureTab, emitReady, tabSessionDir } from "./tab-lifecycle";
+import { seedPreparedEnv } from "./devshell";
 import { getSubagentsForCwd } from "./subagents";
 import { buildExplicitSubagentSteer } from "./subagents/steer";
 import { loadDisabledExtensionsSnapshot } from "./disabled-extensions";
@@ -112,6 +114,8 @@ async function main(): Promise<void> {
   const layoutSlotsFile = process.env.AETHON_LAYOUT_SLOTS_FILE;
   const workerTabId = process.env.AETHON_WORKER_TAB_ID;
   const workerCwd = process.env.AETHON_WORKER_CWD;
+  const workerDevshellReady = process.env.AETHON_WORKER_DEVSHELL_READY === "1";
+  const workerDevshellKind = process.env.AETHON_WORKER_DEVSHELL_KIND ?? null;
   const workerMode = typeof workerTabId === "string" && workerTabId.length > 0;
   const { warnKb, hardKb } = resolveStateLimits(
     process.env.AETHON_STATE_WARN_KB,
@@ -379,7 +383,12 @@ async function main(): Promise<void> {
       });
   } else {
     state.tabProjectCwds.set(workerTabId, startupCwd);
+    if (workerDevshellReady) {
+      seedPreparedEnv(startupCwd, process.env, workerDevshellKind);
+    }
+    markFrontendReady(state);
     scheduleStateFileWrite();
+    send({ type: "worker_ready", tabId: workerTabId, cwd: startupCwd });
   }
 
   // -- Run the dispatcher ------------------------------------------------

--- a/agent/tab-lifecycle/lifecycle.ts
+++ b/agent/tab-lifecycle/lifecycle.ts
@@ -23,7 +23,7 @@ import { buildDashboardTools } from "../dashboard-tools";
 import { buildSubagentTaskTool } from "../subagents/task-tool";
 import {
   buildDevshellSpawnHook,
-  ensureFetched as ensureDevshellFetched,
+  ensurePrepared as ensureDevshellPrepared,
 } from "../devshell";
 import { wrapWithSourceGuard } from "../source-guard";
 import { logger } from "../logger";
@@ -42,6 +42,11 @@ export interface EnsureTabOptions {
   initialModel?: Model<Api>;
   cwdOverride?: string;
 }
+
+const lifecycleLog = logger.scope("tab-lifecycle");
+const WORKER_MODE =
+  typeof process.env.AETHON_WORKER_TAB_ID === "string" &&
+  process.env.AETHON_WORKER_TAB_ID.length > 0;
 
 /** Create (or fetch) the session record for a tabId. Subscribes to its
  *  pi session and tags every per-turn event with tabId so the frontend
@@ -91,12 +96,19 @@ export async function ensureTab(
     sessionManager = SessionManager.inMemory();
   }
 
-  // Warm the devshell cache for this tab's cwd in the background.
-  // The fetch races with the first bash tool call; if the resolver
-  // hasn't completed in time, the spawnHook emits a one-shot
-  // advisory warning and the command runs against the host env.
-  // Subsequent commands pick up the devshell env automatically.
-  void ensureDevshellFetched(state, deps, resolvedCwd);
+  // Frontend tab creation normally prepares the devshell before `tab_open`.
+  // Tab workers are spawned by Rust only after that prepare step has run and
+  // after any ready env has been injected into process.env, so do not issue a
+  // second blocking devshell_query here. That duplicate query can wedge the
+  // first prompt before pi emits agent_start if the frontend ack path is not
+  // available yet.
+  if (WORKER_MODE) {
+    lifecycleLog.info(
+      `worker session using pre-spawn devshell cwd=${resolvedCwd} tabId=${tabId}`,
+    );
+  } else {
+    await ensureDevshellPrepared(state, deps, resolvedCwd);
+  }
 
   // Shadow pi's built-in `bash` tool with our own that mounts the
   // devshell spawnHook. The customTools registry merges later-wins
@@ -129,6 +141,7 @@ export async function ensureTab(
     ],
     ...(options.initialModel ? { model: options.initialModel } : {}),
   });
+  lifecycleLog.info(`session ready tabId=${tabId} cwd=${resolvedCwd}`);
   installAethonRetryClassifier(session);
   wrapWithSourceGuard(session.agent, state.projectRoot, {
     tabRoot: resolvedCwd,

--- a/src-tauri/src/agent_commands.rs
+++ b/src-tauri/src/agent_commands.rs
@@ -265,17 +265,45 @@ async fn prepare_worker_devshell(
         return Err(format!("devshell prepare: {reason}"));
     }
     let Some(kind) = crate::devshell::detect_mode(&cwd, configured_mode) else {
+        let reason = format!("no devshell detected at {}", cwd.display());
+        if let Some(error) =
+            crate::commands::devshell::required_devshell_missing_error(&enabled, reason)
+        {
+            return Err(format!("devshell prepare: {error}"));
+        }
         return Ok(());
     };
-    if kind.as_str() == "direnv" {
-        crate::commands::devshell::direnv_allow(&cwd).await?;
+    if kind.as_str() == "direnv"
+        && let Err(reason) = crate::commands::devshell::direnv_allow(&cwd).await
+    {
+        if crate::commands::devshell::devshell_prepare_is_required(&enabled) {
+            return Err(reason);
+        }
+        tracing::warn!(
+            target: "aethon::devshell",
+            "agent worker devshell direnv allow failed for {}: {reason}; opening host worker",
+            cwd.display()
+        );
+        return Ok(());
     }
     let emitter = crate::commands::devshell::emitter_for(app);
-    cache
+    match cache
         .prepare_for(Some(&emitter), &cwd, configured_mode)
         .await
-        .map(|_| ())
-        .map_err(|e| format!("devshell prepare: {e}"))
+    {
+        Ok(_) => Ok(()),
+        Err(reason) => {
+            if crate::commands::devshell::devshell_prepare_is_required(&enabled) {
+                return Err(format!("devshell prepare: {reason}"));
+            }
+            tracing::warn!(
+                target: "aethon::devshell",
+                "agent worker devshell prepare failed for {}: {reason}; opening host worker",
+                cwd.display()
+            );
+            Ok(())
+        }
+    }
 }
 
 /// Forward a JSON payload to every currently running agent worker without

--- a/src-tauri/src/agent_commands.rs
+++ b/src-tauri/src/agent_commands.rs
@@ -87,7 +87,7 @@ pub(crate) async fn send_message(
     let key = route_payload_key(&state, &payload);
     let worker = worker_for_payload(&key, &payload, true);
     prepare_worker_devshell(&app, &devshell, worker.as_ref()).await?;
-    write_agent_payload(&state, &app, key, payload, worker)
+    write_agent_payload(&state, &app, key, payload, worker).await
 }
 
 fn attachments_to_agent_images(
@@ -236,7 +236,7 @@ pub(crate) async fn agent_command(
     let should_retire = payload_value.get("type").and_then(|v| v.as_str()) == Some("tab_close")
         && key != GLOBAL_AGENT_KEY;
     prepare_worker_devshell(&app, &devshell, worker.as_ref()).await?;
-    write_agent_payload(&state, &app, key.clone(), payload_value, worker)?;
+    write_agent_payload(&state, &app, key.clone(), payload_value, worker).await?;
     if should_retire {
         retire_agent_key(&state, &key)?;
     }
@@ -354,7 +354,7 @@ pub(crate) fn agent_broadcast_command(
 }
 
 #[tauri::command]
-pub(crate) fn dispatch_a2ui_event(
+pub(crate) async fn dispatch_a2ui_event(
     event: String,
     tab_id: Option<String>,
     state: State<'_, AgentProcesses>,
@@ -369,7 +369,7 @@ pub(crate) fn dispatch_a2ui_event(
     });
     let key = route_payload_key(&state, &payload);
     let worker = worker_for_payload(&key, &payload, false);
-    write_agent_payload(&state, &app, key, payload, worker)
+    write_agent_payload(&state, &app, key, payload, worker).await
 }
 
 /// Read-only per-worker diagnostic row. Maps a live `aethon-agent` PID back to

--- a/src-tauri/src/agent_commands.rs
+++ b/src-tauri/src/agent_commands.rs
@@ -12,6 +12,7 @@ use crate::agent_process::{
     AgentProcesses, AgentWorker, GLOBAL_AGENT_KEY, WorkerMeta, ensure_global_agent,
     keys_to_reconcile, retire_agent_key, route_payload_key, write_agent_payload,
 };
+use crate::devshell::DevshellCache;
 
 /// Grace period before a worker is eligible for orphan reconciliation, so a
 /// tab the frontend just opened (but hasn't yet included in its reported live
@@ -52,9 +53,10 @@ pub(crate) fn start_agent(state: State<'_, AgentProcesses>, app: AppHandle) -> R
 }
 
 #[tauri::command]
-pub(crate) fn send_message(
+pub(crate) async fn send_message(
     request: SendMessageRequest,
     state: State<'_, AgentProcesses>,
+    devshell: State<'_, Arc<DevshellCache>>,
     app: AppHandle,
 ) -> Result<(), String> {
     let tab_id = request.tab_id.unwrap_or_else(|| "default".to_string());
@@ -84,6 +86,7 @@ pub(crate) fn send_message(
 
     let key = route_payload_key(&state, &payload);
     let worker = worker_for_payload(&key, &payload, true);
+    prepare_worker_devshell(&app, &devshell, worker.as_ref()).await?;
     write_agent_payload(&state, &app, key, payload, worker)
 }
 
@@ -220,9 +223,10 @@ pub(crate) fn reload_agent(state: State<'_, AgentProcesses>, app: AppHandle) -> 
 /// Forward an arbitrary JSON payload to the agent's stdin. Used by the model
 /// picker and runtime controls that are not wrapped in `dispatch_a2ui_event`.
 #[tauri::command]
-pub(crate) fn agent_command(
+pub(crate) async fn agent_command(
     payload: String,
     state: State<'_, AgentProcesses>,
+    devshell: State<'_, Arc<DevshellCache>>,
     app: AppHandle,
 ) -> Result<(), String> {
     let payload_value: serde_json::Value =
@@ -231,11 +235,47 @@ pub(crate) fn agent_command(
     let worker = worker_for_payload(&key, &payload_value, true);
     let should_retire = payload_value.get("type").and_then(|v| v.as_str()) == Some("tab_close")
         && key != GLOBAL_AGENT_KEY;
+    prepare_worker_devshell(&app, &devshell, worker.as_ref()).await?;
     write_agent_payload(&state, &app, key.clone(), payload_value, worker)?;
     if should_retire {
         retire_agent_key(&state, &key)?;
     }
     Ok(())
+}
+
+async fn prepare_worker_devshell(
+    app: &AppHandle,
+    cache: &Arc<DevshellCache>,
+    worker: Option<&AgentWorker>,
+) -> Result<(), String> {
+    let Some(cwd) = worker
+        .and_then(|w| w.cwd.as_deref())
+        .filter(|cwd| !cwd.is_empty())
+    else {
+        return Ok(());
+    };
+    let cwd = PathBuf::from(cwd);
+    let (enabled, configured_mode) = crate::commands::devshell::effective_config(app, &cwd);
+    if enabled == "never" {
+        return Ok(());
+    }
+    if let Some(reason) =
+        crate::commands::devshell::forced_mode_mismatch_reason(&cwd, configured_mode)
+    {
+        return Err(format!("devshell prepare: {reason}"));
+    }
+    let Some(kind) = crate::devshell::detect_mode(&cwd, configured_mode) else {
+        return Ok(());
+    };
+    if kind.as_str() == "direnv" {
+        crate::commands::devshell::direnv_allow(&cwd).await?;
+    }
+    let emitter = crate::commands::devshell::emitter_for(app);
+    cache
+        .prepare_for(Some(&emitter), &cwd, configured_mode)
+        .await
+        .map(|_| ())
+        .map_err(|e| format!("devshell prepare: {e}"))
 }
 
 /// Forward a JSON payload to every currently running agent worker without
@@ -318,7 +358,20 @@ pub(crate) struct AgentDiagnostic {
     pub(crate) spawned_ms_ago: u128,
     pub(crate) last_activity_ms_ago: u128,
     pub(crate) prompt_in_flight: bool,
+    pub(crate) bridge_ready: bool,
     pub(crate) session_label: String,
+    pub(crate) process: Option<ProcessDiagnostic>,
+    pub(crate) children: Vec<ProcessDiagnostic>,
+}
+
+#[derive(Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ProcessDiagnostic {
+    pub(crate) pid: u32,
+    pub(crate) ppid: Option<u32>,
+    pub(crate) cpu_percent: Option<f64>,
+    pub(crate) rss_bytes: Option<u64>,
+    pub(crate) command: Option<String>,
 }
 
 /// Human-friendly label for a worker: "global" for the shared agent, otherwise
@@ -364,6 +417,7 @@ pub(crate) fn agent_diagnostics(
         .collect();
 
     let now = Instant::now();
+    let metrics = process_metrics_snapshot();
     let map = state.meta.lock().map_err(|e| e.to_string())?;
     let mut rows: Vec<AgentDiagnostic> = map
         .iter()
@@ -376,11 +430,53 @@ pub(crate) fn agent_diagnostics(
             spawned_ms_ago: now.duration_since(m.spawned_at).as_millis(),
             last_activity_ms_ago: now.duration_since(m.last_activity).as_millis(),
             prompt_in_flight: m.prompt_in_flight,
+            bridge_ready: m.bridge_ready,
             session_label: session_label_for(key, m),
+            process: metrics.get(&m.pid).cloned(),
+            children: metrics
+                .values()
+                .filter(|p| p.ppid == Some(m.pid))
+                .cloned()
+                .collect(),
         })
         .collect();
     rows.sort_by(|a, b| a.key.cmp(&b.key));
     Ok(rows)
+}
+
+fn process_metrics_snapshot() -> HashMap<u32, ProcessDiagnostic> {
+    let mut command = crate::env::command("ps");
+    command.args(["-axo", "pid=,ppid=,%cpu=,rss=,command="]);
+    let Ok(output) = command.output() else {
+        return HashMap::new();
+    };
+    if !output.status.success() {
+        return HashMap::new();
+    }
+    let text = String::from_utf8_lossy(&output.stdout);
+    text.lines()
+        .filter_map(parse_ps_metrics_line)
+        .map(|row| (row.pid, row))
+        .collect()
+}
+
+fn parse_ps_metrics_line(line: &str) -> Option<ProcessDiagnostic> {
+    let mut parts = line.split_whitespace();
+    let pid = parts.next()?.parse::<u32>().ok()?;
+    let ppid = parts.next().and_then(|value| value.parse::<u32>().ok());
+    let cpu_percent = parts.next().and_then(|value| value.parse::<f64>().ok());
+    let rss_bytes = parts
+        .next()
+        .and_then(|value| value.parse::<u64>().ok())
+        .map(|kib| kib.saturating_mul(1024));
+    let command = parts.collect::<Vec<_>>().join(" ");
+    Some(ProcessDiagnostic {
+        pid,
+        ppid,
+        cpu_percent,
+        rss_bytes,
+        command: (!command.is_empty()).then_some(command),
+    })
 }
 
 /// Retire per-tab workers whose tab no longer exists in the frontend's live
@@ -427,7 +523,9 @@ fn worker_for_payload(
 
 #[cfg(test)]
 mod tests {
-    use super::{GLOBAL_AGENT_KEY, WorkerMeta, session_label_for, worker_for_payload};
+    use super::{
+        GLOBAL_AGENT_KEY, WorkerMeta, parse_ps_metrics_line, session_label_for, worker_for_payload,
+    };
     use std::time::Instant;
 
     fn meta(tab_id: Option<&str>, cwd: Option<&str>) -> WorkerMeta {
@@ -439,6 +537,7 @@ mod tests {
             spawned_at: now,
             last_activity: now,
             prompt_in_flight: false,
+            bridge_ready: true,
         }
     }
 
@@ -492,5 +591,16 @@ mod tests {
 
         assert_eq!(worker.tab_id, "tab-1");
         assert_eq!(worker.cwd, None);
+    }
+
+    #[test]
+    fn parses_ps_metrics_line() {
+        let row =
+            parse_ps_metrics_line("  123   45  12.5  2048 /bin/bash -lc menu").expect("parsed");
+        assert_eq!(row.pid, 123);
+        assert_eq!(row.ppid, Some(45));
+        assert_eq!(row.cpu_percent, Some(12.5));
+        assert_eq!(row.rss_bytes, Some(2048 * 1024));
+        assert_eq!(row.command.as_deref(), Some("/bin/bash -lc menu"));
     }
 }

--- a/src-tauri/src/agent_process/mod.rs
+++ b/src-tauri/src/agent_process/mod.rs
@@ -29,8 +29,9 @@ mod spawn;
 mod sweep;
 
 pub(crate) use process::{
-    AgentProcesses, AgentWorker, GLOBAL_AGENT_KEY, WorkerMeta, ensure_global_agent,
-    keys_to_reconcile, retire_agent_key, route_payload_key, write_agent_payload,
+    AgentProcesses, AgentWorker, GLOBAL_AGENT_KEY, WorkerMeta, cleanup_orphaned_dev_agents,
+    ensure_global_agent, keys_to_reconcile, retire_agent_key, route_payload_key,
+    shutdown_all_agents, write_agent_payload,
 };
 pub(crate) use sidecar::project_root;
 pub(crate) use sweep::spawn_idle_sweep;

--- a/src-tauri/src/agent_process/process.rs
+++ b/src-tauri/src/agent_process/process.rs
@@ -15,10 +15,10 @@
 use std::collections::{HashMap, HashSet};
 use std::process::Child;
 use std::sync::{Arc, Mutex};
-use std::thread;
 use std::time::{Duration, Instant};
 
 use tauri::{AppHandle, State};
+use tokio::time::sleep;
 
 use super::sidecar::project_root;
 use super::spawn::ensure_agent_spawned;
@@ -116,7 +116,7 @@ fn worker_ready(meta: &Arc<Mutex<HashMap<String, WorkerMeta>>>, key: &str) -> bo
         .unwrap_or(false)
 }
 
-fn wait_for_worker_ready(
+async fn wait_for_worker_ready(
     child: &Arc<Mutex<Child>>,
     meta: &Arc<Mutex<HashMap<String, WorkerMeta>>>,
     key: &str,
@@ -137,7 +137,7 @@ fn wait_for_worker_ready(
         {
             return Err(format!("agent worker exited before ready: {status:?}"));
         }
-        thread::sleep(Duration::from_millis(25));
+        sleep(Duration::from_millis(25)).await;
     }
     Err(format!(
         "agent worker did not become ready within {timeout:?}"
@@ -218,7 +218,7 @@ pub(crate) fn tab_agent_key(tab_id: &str) -> String {
     format!("tab:{tab_id}")
 }
 
-pub(crate) fn write_agent_payload(
+pub(crate) async fn write_agent_payload(
     state: &State<'_, AgentProcesses>,
     app: &AppHandle,
     key: String,
@@ -241,7 +241,7 @@ pub(crate) fn write_agent_payload(
 
     let prompt_starts = payload_starts_prompt(&payload);
     if prompt_starts {
-        wait_for_worker_ready(&child, &state.meta, &key, Duration::from_secs(20))?;
+        wait_for_worker_ready(&child, &state.meta, &key, Duration::from_secs(20)).await?;
     }
     let prompt_flag = prompt_starts.then_some(true);
 

--- a/src-tauri/src/agent_process/process.rs
+++ b/src-tauri/src/agent_process/process.rs
@@ -15,11 +15,14 @@
 use std::collections::{HashMap, HashSet};
 use std::process::Child;
 use std::sync::{Arc, Mutex};
+use std::thread;
 use std::time::{Duration, Instant};
 
 use tauri::{AppHandle, State};
 
+use super::sidecar::project_root;
 use super::spawn::ensure_agent_spawned;
+use crate::env;
 
 pub(crate) const GLOBAL_AGENT_KEY: &str = "__global__";
 
@@ -34,6 +37,7 @@ pub(crate) struct WorkerMeta {
     pub(crate) spawned_at: Instant,
     pub(crate) last_activity: Instant,
     pub(crate) prompt_in_flight: bool,
+    pub(crate) bridge_ready: bool,
 }
 
 pub(crate) struct AgentProcesses {
@@ -81,6 +85,63 @@ pub(crate) fn touch_worker_activity(
             entry.prompt_in_flight = flag;
         }
     }
+}
+
+pub(crate) fn mark_worker_ready(meta: &Arc<Mutex<HashMap<String, WorkerMeta>>>, key: &str) {
+    if let Ok(mut map) = meta.lock()
+        && let Some(entry) = map.get_mut(key)
+    {
+        entry.last_activity = Instant::now();
+        entry.bridge_ready = true;
+    }
+}
+
+pub(crate) fn clear_worker_meta_for_pid(
+    meta: &Arc<Mutex<HashMap<String, WorkerMeta>>>,
+    key: &str,
+    pid: u32,
+) {
+    if let Ok(mut map) = meta.lock() {
+        let should_remove = map.get(key).is_some_and(|entry| entry.pid == pid);
+        if should_remove {
+            map.remove(key);
+        }
+    }
+}
+
+fn worker_ready(meta: &Arc<Mutex<HashMap<String, WorkerMeta>>>, key: &str) -> bool {
+    meta.lock()
+        .ok()
+        .and_then(|map| map.get(key).map(|entry| entry.bridge_ready))
+        .unwrap_or(false)
+}
+
+fn wait_for_worker_ready(
+    child: &Arc<Mutex<Child>>,
+    meta: &Arc<Mutex<HashMap<String, WorkerMeta>>>,
+    key: &str,
+    timeout: Duration,
+) -> Result<(), String> {
+    if key == GLOBAL_AGENT_KEY || worker_ready(meta, key) {
+        return Ok(());
+    }
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if worker_ready(meta, key) {
+            return Ok(());
+        }
+        if let Some(status) = child
+            .lock()
+            .ok()
+            .and_then(|mut child| child.try_wait().ok().flatten())
+        {
+            return Err(format!("agent worker exited before ready: {status:?}"));
+        }
+        thread::sleep(Duration::from_millis(25));
+    }
+    Err(format!(
+        "agent worker did not become ready within {timeout:?}"
+    ))
 }
 
 /// Should this worker be retired by the idle sweep? Pure so the policy is
@@ -178,7 +239,11 @@ pub(crate) fn write_agent_payload(
         guard.get(&key).cloned().ok_or("agent not running")?
     };
 
-    let prompt_flag = payload_starts_prompt(&payload).then_some(true);
+    let prompt_starts = payload_starts_prompt(&payload);
+    if prompt_starts {
+        wait_for_worker_ready(&child, &state.meta, &key, Duration::from_secs(20))?;
+    }
+    let prompt_flag = prompt_starts.then_some(true);
 
     {
         let mut child = child.lock().map_err(|e| e.to_string())?;
@@ -230,6 +295,99 @@ pub(crate) fn retire_agent_key(state: &State<'_, AgentProcesses>, key: &str) -> 
     let _ = child.kill();
     let _ = child.wait();
     Ok(())
+}
+
+pub(crate) fn shutdown_all_agents(state: &AgentProcesses, reason: &str) {
+    let children: Vec<_> = match state.children.lock() {
+        Ok(mut guard) => guard.drain().collect(),
+        Err(e) => {
+            tracing::warn!(target: "aethon::agent", "shutdown: children lock: {e}");
+            Vec::new()
+        }
+    };
+    if children.is_empty() {
+        return;
+    }
+    if let Ok(mut exits) = state.intentional_exits.lock() {
+        for (key, _) in &children {
+            exits.insert(key.clone());
+        }
+    }
+    for (key, child) in children {
+        let Ok(mut child) = child.lock() else {
+            continue;
+        };
+        let pid = child.id();
+        tracing::info!(target: "aethon::agent", key = key, "shutdown: killing pid={pid}; reason={reason}");
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+    if let Ok(mut routes) = state.mutation_routes.lock() {
+        routes.clear();
+    }
+    if let Ok(mut meta) = state.meta.lock() {
+        meta.clear();
+    }
+}
+
+pub(crate) fn cleanup_orphaned_dev_agents() {
+    if !cfg!(debug_assertions) {
+        return;
+    }
+    let marker = project_root()
+        .join("agent")
+        .join("main.ts")
+        .to_string_lossy()
+        .to_string();
+    let output = match env::command("ps")
+        .args(["-axo", "pid=,ppid=,command="])
+        .output()
+    {
+        Ok(output) if output.status.success() => output,
+        Ok(output) => {
+            tracing::warn!(
+                target: "aethon::agent",
+                "orphan cleanup ps exited with status {}",
+                output.status
+            );
+            return;
+        }
+        Err(e) => {
+            tracing::warn!(target: "aethon::agent", "orphan cleanup ps failed: {e}");
+            return;
+        }
+    };
+    let text = String::from_utf8_lossy(&output.stdout);
+    for line in text.lines() {
+        let Some((pid, ppid, command)) = parse_ps_process_line(line) else {
+            continue;
+        };
+        if ppid != 1 || !command.contains(&marker) {
+            continue;
+        }
+        tracing::warn!(
+            target: "aethon::agent",
+            "terminating orphaned dev agent pid={pid}"
+        );
+        if let Err(e) = env::command("kill")
+            .args(["-TERM", &pid.to_string()])
+            .status()
+        {
+            tracing::warn!(target: "aethon::agent", "orphan cleanup kill pid={pid}: {e}");
+        }
+    }
+}
+
+fn parse_ps_process_line(line: &str) -> Option<(u32, u32, &str)> {
+    let trimmed = line.trim_start();
+    let (pid_s, rest) = trimmed.split_once(char::is_whitespace)?;
+    let rest = rest.trim_start();
+    let (ppid_s, command) = rest.split_once(char::is_whitespace)?;
+    Some((
+        pid_s.parse().ok()?,
+        ppid_s.parse().ok()?,
+        command.trim_start(),
+    ))
 }
 
 fn route_payload_key_without_mutation(payload: &serde_json::Value) -> String {
@@ -288,6 +446,7 @@ mod tests {
             spawned_at: spawned,
             last_activity: spawned,
             prompt_in_flight: false,
+            bridge_ready: true,
         }
     }
 
@@ -300,6 +459,7 @@ mod tests {
             spawned_at: last,
             last_activity: last,
             prompt_in_flight,
+            bridge_ready: true,
         }
     }
 
@@ -477,6 +637,7 @@ mod tests {
                 spawned_at: stale,
                 last_activity: stale,
                 prompt_in_flight: true,
+                bridge_ready: true,
             },
         );
         Arc::new(Mutex::new(map))

--- a/src-tauri/src/agent_process/readers.rs
+++ b/src-tauri/src/agent_process/readers.rs
@@ -22,7 +22,9 @@ use std::sync::{Arc, Mutex};
 
 use tauri::{AppHandle, Emitter};
 
-use super::process::{WorkerMeta, touch_worker_activity};
+use super::process::{
+    WorkerMeta, clear_worker_meta_for_pid, mark_worker_ready, touch_worker_activity,
+};
 
 pub(super) const STDERR_TAIL_CAP: usize = 32;
 
@@ -76,10 +78,26 @@ pub(super) fn spawn_stdout_reader(ctx: StdoutReaderCtx) {
                             routes.insert(mutation_id.to_string(), key.clone());
                         }
                         prompt_flag = match value.get("type").and_then(|v| v.as_str()) {
+                            Some("worker_ready") => {
+                                mark_worker_ready(&meta, &key);
+                                None
+                            }
+                            Some("ready") | Some("tab_ready") => {
+                                mark_worker_ready(&meta, &key);
+                                None
+                            }
                             Some("prompt_started") => Some(true),
                             Some("response_end") => Some(false),
                             _ => None,
                         };
+                    } else if let Ok(mut g) = stderr_tail.lock() {
+                        if g.len() >= STDERR_TAIL_CAP {
+                            g.pop_front();
+                        }
+                        g.push_back(format!(
+                            "stdout: {}",
+                            text.chars().take(500).collect::<String>()
+                        ));
                     }
                     touch_worker_activity(&meta, &key, prompt_flag);
                     let _ = app.emit("agent-response", text);
@@ -93,20 +111,28 @@ pub(super) fn spawn_stdout_reader(ctx: StdoutReaderCtx) {
             .map(|mut exits| exits.remove(&key))
             .unwrap_or(false);
         if intentional_exit || saw_reload_done {
+            clear_worker_meta_for_pid(&meta, &key, pid);
             return;
         }
-        let tail: Vec<String> = match stderr_tail.lock() {
+        let mut tail: Vec<String> = match stderr_tail.lock() {
             Ok(g) => g.iter().cloned().collect(),
             Err(_) => Vec::new(),
         };
+        if tail.is_empty() {
+            tail.push(format!(
+                "agent stdout closed unexpectedly (key={key}, pid={pid})"
+            ));
+        }
         let _ = app.emit(
             "agent-crashed",
             serde_json::json!({
                 "pid": pid,
+                "key": key,
                 "tabId": tab_id,
                 "stderrTail": tail,
             }),
         );
+        clear_worker_meta_for_pid(&meta, &key, pid);
     });
 }
 
@@ -116,6 +142,7 @@ pub(super) struct StderrReaderCtx {
     pub(super) pid: u32,
     pub(super) key: String,
     pub(super) stderr_tail: Arc<Mutex<VecDeque<String>>>,
+    pub(super) meta: Arc<Mutex<HashMap<String, WorkerMeta>>>,
 }
 
 pub(super) fn spawn_stderr_reader(ctx: StderrReaderCtx) {
@@ -125,6 +152,7 @@ pub(super) fn spawn_stderr_reader(ctx: StderrReaderCtx) {
         pid,
         key,
         stderr_tail,
+        meta,
     } = ctx;
     std::thread::spawn(move || {
         let reader = BufReader::new(stderr);
@@ -132,6 +160,14 @@ pub(super) fn spawn_stderr_reader(ctx: StderrReaderCtx) {
             match line {
                 Ok(text) => {
                     tracing::info!(target: "aethon::agent::stderr", pid = pid, key = key, "{text}");
+                    let prompt_flag = if text.contains("turn: start") {
+                        Some(true)
+                    } else if text.contains("turn: end") {
+                        Some(false)
+                    } else {
+                        None
+                    };
+                    touch_worker_activity(&meta, &key, prompt_flag);
                     if let Ok(mut g) = stderr_tail.lock() {
                         if g.len() >= STDERR_TAIL_CAP {
                             g.pop_front();

--- a/src-tauri/src/agent_process/readers.rs
+++ b/src-tauri/src/agent_process/readers.rs
@@ -23,7 +23,8 @@ use std::sync::{Arc, Mutex};
 use tauri::{AppHandle, Emitter};
 
 use super::process::{
-    WorkerMeta, clear_worker_meta_for_pid, mark_worker_ready, touch_worker_activity,
+    GLOBAL_AGENT_KEY, WorkerMeta, clear_worker_meta_for_pid, mark_worker_ready,
+    touch_worker_activity,
 };
 
 pub(super) const STDERR_TAIL_CAP: usize = 32;
@@ -118,11 +119,16 @@ pub(super) fn spawn_stdout_reader(ctx: StdoutReaderCtx) {
             Ok(g) => g.iter().cloned().collect(),
             Err(_) => Vec::new(),
         };
-        if tail.is_empty() {
-            tail.push(format!(
-                "agent stdout closed unexpectedly (key={key}, pid={pid})"
-            ));
+        if quiet_global_stdout_eof(&key, &tail) {
+            tracing::info!(
+                target: "aethon::agent",
+                key = key,
+                "global agent stdout closed without stderr; waiting for the next global request"
+            );
+            clear_worker_meta_for_pid(&meta, &key, pid);
+            return;
         }
+        fill_empty_stdout_tail(&mut tail, &key, pid);
         let _ = app.emit(
             "agent-crashed",
             serde_json::json!({
@@ -136,6 +142,18 @@ pub(super) fn spawn_stdout_reader(ctx: StdoutReaderCtx) {
     });
 }
 
+fn quiet_global_stdout_eof(key: &str, tail: &[String]) -> bool {
+    key == GLOBAL_AGENT_KEY && tail.is_empty()
+}
+
+fn fill_empty_stdout_tail(tail: &mut Vec<String>, key: &str, pid: u32) {
+    if tail.is_empty() {
+        tail.push(format!(
+            "agent stdout closed unexpectedly (key={key}, pid={pid})"
+        ));
+    }
+}
+
 pub(super) struct StderrReaderCtx {
     pub(super) stderr: ChildStderr,
     pub(super) app: AppHandle,
@@ -143,6 +161,32 @@ pub(super) struct StderrReaderCtx {
     pub(super) key: String,
     pub(super) stderr_tail: Arc<Mutex<VecDeque<String>>>,
     pub(super) meta: Arc<Mutex<HashMap<String, WorkerMeta>>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{fill_empty_stdout_tail, quiet_global_stdout_eof};
+    use crate::agent_process::GLOBAL_AGENT_KEY;
+
+    #[test]
+    fn quiet_global_stdout_eof_does_not_count_as_a_crash() {
+        assert!(quiet_global_stdout_eof(GLOBAL_AGENT_KEY, &[]));
+        assert!(!quiet_global_stdout_eof(
+            GLOBAL_AGENT_KEY,
+            &["panic".to_string()]
+        ));
+        assert!(!quiet_global_stdout_eof("tab:abc", &[]));
+    }
+
+    #[test]
+    fn non_global_empty_stdout_tail_gets_a_diagnostic_line() {
+        let mut tail = Vec::new();
+        fill_empty_stdout_tail(&mut tail, "tab:abc", 42);
+        assert_eq!(
+            tail,
+            ["agent stdout closed unexpectedly (key=tab:abc, pid=42)"]
+        );
+    }
 }
 
 pub(super) fn spawn_stderr_reader(ctx: StderrReaderCtx) {

--- a/src-tauri/src/agent_process/spawn.rs
+++ b/src-tauri/src/agent_process/spawn.rs
@@ -331,6 +331,9 @@ fn apply_worker_devshell_env(app: &AppHandle, command: &mut Command, worker: Opt
     command.env("AETHON_WORKER_DEVSHELL_READY", "1");
     if let Some(kind) = prepared.kind.as_deref() {
         command.env("AETHON_WORKER_DEVSHELL_KIND", kind);
+        if kind != "direnv" {
+            command.env("DIRENV_DISABLE", "1");
+        }
     }
     for (k, v) in prepared.env {
         command.env(k, v);

--- a/src-tauri/src/agent_process/spawn.rs
+++ b/src-tauri/src/agent_process/spawn.rs
@@ -50,6 +50,26 @@ pub(super) fn ensure_agent_spawned(
         guard.remove(key);
     }
 
+    if should_respawn_for_worker_cwd(key, &meta, worker.as_ref())
+        && let Some(child) = guard.remove(key)
+    {
+        tracing::info!(
+            target: "aethon::agent",
+            key = key,
+            "worker cwd changed; respawning agent"
+        );
+        if let Ok(mut exits) = intentional_exits.lock() {
+            exits.insert(key.to_string());
+        }
+        if let Ok(mut child) = child.lock() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+        if let Ok(mut map) = meta.lock() {
+            map.remove(key);
+        }
+    }
+
     if guard.contains_key(key) {
         return Ok(());
     }
@@ -57,6 +77,9 @@ pub(super) fn ensure_agent_spawned(
     let mut command = build_command(app)?;
     apply_user_env(app, &mut command);
     apply_worker_env(&mut command, worker.as_ref());
+    clear_inherited_devshell_identity(&mut command, worker.as_ref());
+    apply_worker_devshell_env(app, &mut command, worker.as_ref());
+    apply_worker_current_dir(&mut command, worker.as_ref());
 
     let mut child = command
         .stdin(Stdio::piped())
@@ -91,24 +114,8 @@ pub(super) fn ensure_agent_spawned(
         pid,
         key: key.to_string(),
         stderr_tail,
+        meta: Arc::clone(&meta),
     });
-
-    // Bridge processes start with `frontendReady = false` and only
-    // flip it when the dispatcher receives `{"type":"report"}`. The
-    // React tree sends one such message on mount, but `route_payload_key`
-    // pins it to `__global__` — workers would otherwise stay un-ready
-    // forever and `sendQuery` (e.g. devshell `env_for_path`) would race
-    // against a 5s timeout. Synthesise the handshake here so every
-    // bridge — global and per-tab — comes up ready.
-    if let Some(stdin) = child.stdin.as_mut()
-        && let Err(e) = inject_initial_handshake(stdin)
-    {
-        tracing::warn!(
-            target: "aethon::agent",
-            key = key,
-            "failed to inject initial handshake: {e}"
-        );
-    }
 
     {
         let now = Instant::now();
@@ -126,9 +133,28 @@ pub(super) fn ensure_agent_spawned(
                     spawned_at: now,
                     last_activity: now,
                     prompt_in_flight: false,
+                    bridge_ready: key == super::process::GLOBAL_AGENT_KEY,
                 },
             );
         }
+    }
+
+    // Bridge processes start with `frontendReady = false` and only
+    // flip it when the dispatcher receives `{"type":"report"}`. The
+    // React tree sends one such message on mount, but `route_payload_key`
+    // pins it to `__global__` — workers would otherwise stay un-ready
+    // forever and `sendQuery` (e.g. devshell `env_for_path`) would race
+    // against a 5s timeout. Synthesise the handshake here so every
+    // bridge — global and per-tab — comes up ready. Metadata is registered
+    // first so any immediate stdout readiness marker can be recorded.
+    if let Some(stdin) = child.stdin.as_mut()
+        && let Err(e) = inject_initial_handshake(stdin)
+    {
+        tracing::warn!(
+            target: "aethon::agent",
+            key = key,
+            "failed to inject initial handshake: {e}"
+        );
     }
 
     guard.insert(key.to_string(), Arc::new(Mutex::new(child)));
@@ -150,7 +176,9 @@ fn build_command(app: &AppHandle) -> Result<Command, String> {
             .join("default-layout")
             .join("slots.json");
         let mut c = env::command("bun");
-        c.current_dir(&root).arg("run").arg("agent/main.ts");
+        c.current_dir(&root)
+            .arg("run")
+            .arg(root.join("agent").join("main.ts"));
         c.env("AETHON_RELEASE_MODE", "0");
         c.env("AETHON_PROJECT_ROOT", &root);
         c.env("AETHON_DOCS_DIR", &docs_dir);
@@ -255,6 +283,88 @@ fn apply_worker_env(command: &mut Command, worker: Option<&AgentWorker>) {
     {
         command.env("AETHON_WORKER_CWD", cwd);
     }
+}
+
+fn clear_inherited_devshell_identity(command: &mut Command, worker: Option<&AgentWorker>) {
+    if worker.is_none() {
+        return;
+    }
+    for key in [
+        "IN_NIX_SHELL",
+        "DEVSHELL_DIR",
+        "NIX_BUILD_TOP",
+        "NIX_ENFORCE_PURITY",
+        "name",
+    ] {
+        command.env_remove(key);
+    }
+    command.env("PATH", env::resolved_project_path());
+}
+
+fn apply_worker_devshell_env(app: &AppHandle, command: &mut Command, worker: Option<&AgentWorker>) {
+    let Some(cwd) = worker
+        .and_then(|w| w.cwd.as_deref())
+        .filter(|cwd| !cwd.is_empty())
+    else {
+        return;
+    };
+    let cwd = std::path::PathBuf::from(cwd);
+    let (enabled, configured_mode) = crate::commands::devshell::effective_config(app, &cwd);
+    if enabled == "never" {
+        return;
+    }
+    let cache = app.state::<Arc<crate::devshell::DevshellCache>>();
+    let Some(prepared) = cache.ready_env_now(&cwd, configured_mode) else {
+        tracing::warn!(
+            target: "aethon::devshell",
+            "agent worker spawn for {} did not find a ready devshell env",
+            cwd.display()
+        );
+        return;
+    };
+    tracing::debug!(
+        target: "aethon::devshell",
+        "applying {} devshell vars to agent worker {}",
+        prepared.env.len(),
+        cwd.display()
+    );
+    command.env("AETHON_WORKER_DEVSHELL_READY", "1");
+    if let Some(kind) = prepared.kind.as_deref() {
+        command.env("AETHON_WORKER_DEVSHELL_KIND", kind);
+    }
+    for (k, v) in prepared.env {
+        command.env(k, v);
+    }
+}
+
+fn apply_worker_current_dir(command: &mut Command, worker: Option<&AgentWorker>) {
+    let Some(worker) = worker else {
+        return;
+    };
+    let Some(cwd) = worker.cwd.as_deref().filter(|cwd| !cwd.is_empty()) else {
+        return;
+    };
+    command.current_dir(cwd);
+}
+
+fn should_respawn_for_worker_cwd(
+    key: &str,
+    meta: &Arc<Mutex<HashMap<String, WorkerMeta>>>,
+    worker: Option<&AgentWorker>,
+) -> bool {
+    let Some(worker_cwd) = worker
+        .and_then(|w| w.cwd.as_deref())
+        .filter(|cwd| !cwd.is_empty())
+    else {
+        return false;
+    };
+    let Ok(map) = meta.lock() else {
+        return false;
+    };
+    let Some(existing) = map.get(key) else {
+        return false;
+    };
+    existing.cwd.as_deref() != Some(worker_cwd)
 }
 
 /// Synthesise the `{"type":"report"}` handshake that the React tree

--- a/src-tauri/src/agent_process/spawn.rs
+++ b/src-tauri/src/agent_process/spawn.rs
@@ -329,6 +329,10 @@ fn apply_worker_devshell_env(app: &AppHandle, command: &mut Command, worker: Opt
         cwd.display()
     );
     command.env("AETHON_WORKER_DEVSHELL_READY", "1");
+    let prepared_keys: Vec<String> = prepared.env.keys().cloned().collect();
+    if let Ok(keys_json) = serde_json::to_string(&prepared_keys) {
+        command.env("AETHON_WORKER_DEVSHELL_ENV_KEYS", keys_json);
+    }
     if let Some(kind) = prepared.kind.as_deref() {
         command.env("AETHON_WORKER_DEVSHELL_KIND", kind);
         if kind != "direnv" {

--- a/src-tauri/src/commands/devshell.rs
+++ b/src-tauri/src/commands/devshell.rs
@@ -157,9 +157,9 @@ pub struct StatusResponse {
 /// a devshell becomes a hard error (returned via `StatusSnapshot::
 /// Failed`), so the user sees a loud signal on the badge instead of
 /// the silent no-op the original `"auto"` policy would produce. The
-/// caller (PTY intercept, agent spawnHook) still falls through to
-/// the host env so shells continue to work — `"always"` only changes
-/// what the UI shows, not whether the shell opens.
+/// caller (PTY intercept, agent provisioning) treats the same
+/// condition as a hard prepare failure, so `"always"` means "do not
+/// silently open outside the devshell".
 #[tauri::command]
 pub async fn devshell_status<R: Runtime>(
     app: AppHandle<R>,
@@ -217,8 +217,17 @@ fn expected_marker(mode: DetectMode) -> &'static str {
         DetectMode::Auto => "devshell",
         DetectMode::Direnv => ".envrc with use flake/use nix",
         DetectMode::Nix => "flake.nix",
-        DetectMode::NixShell => "shell.nix",
+        DetectMode::NixShell => "flake.nix or shell.nix",
     }
+}
+
+pub(crate) fn devshell_prepare_is_required(enabled: &str) -> bool {
+    enabled == "always"
+}
+
+pub(crate) fn required_devshell_missing_error(enabled: &str, reason: String) -> Option<String> {
+    devshell_prepare_is_required(enabled)
+        .then(|| format!("{reason} and [devshell] enabled = \"always\""))
 }
 
 #[derive(Deserialize)]
@@ -296,8 +305,8 @@ pub async fn devshell_prepare_for_path<R: Runtime>(
     let Some(kind) = detected_kind else {
         let reason = forced_mode_mismatch_reason(&cwd, configured_mode)
             .unwrap_or_else(|| format!("no devshell detected at {}", cwd.display()));
-        if enabled == "always" {
-            return Err(format!("{reason} and [devshell] enabled = \"always\""));
+        if let Some(error) = required_devshell_missing_error(&enabled, reason.clone()) {
+            return Err(error);
         }
         let is_mismatch = crate::devshell::forced_mode_mismatch(&cwd, configured_mode).is_some();
         return Ok(PrepareForPathResponse {
@@ -412,7 +421,7 @@ pub(crate) async fn direnv_allow(root: &Path) -> Result<(), String> {
 
 /// Non-blocking env lookup. Returns immediately even if a resolver is
 /// in-flight; the agent spawnHook + PTY intercept both use this and
-/// must never block the user's tool call on `nix print-dev-env`.
+/// must never block the user's tool call on Nix evaluation.
 #[tauri::command]
 pub async fn devshell_env_for_path<R: Runtime>(
     app: AppHandle<R>,
@@ -474,7 +483,11 @@ pub async fn devshell_refresh<R: Runtime>(
             // "auto" silently no-ops when there's no devshell to
             // refresh (a project without a flake is fine to refresh);
             // "always" treats the same condition as a hard error.
-            if enabled == "always" { Err(e) } else { Ok(()) }
+            if devshell_prepare_is_required(&enabled) {
+                Err(e)
+            } else {
+                Ok(())
+            }
         }
     }
 }
@@ -502,5 +515,27 @@ pub async fn boot_init_cache<R: Runtime>(app: &AppHandle<R>, cache: &DevshellCac
             disk_root.display(),
             e
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{devshell_prepare_is_required, required_devshell_missing_error};
+
+    #[test]
+    fn only_always_requires_devshell_preparation() {
+        assert!(devshell_prepare_is_required("always"));
+        assert!(!devshell_prepare_is_required("auto"));
+        assert!(!devshell_prepare_is_required("never"));
+    }
+
+    #[test]
+    fn required_devshell_missing_error_preserves_the_detected_reason() {
+        assert_eq!(
+            required_devshell_missing_error("always", "configured mode mismatch".to_string())
+                .as_deref(),
+            Some("configured mode mismatch and [devshell] enabled = \"always\""),
+        );
+        assert!(required_devshell_missing_error("auto", "missing".to_string()).is_none());
     }
 }

--- a/src-tauri/src/commands/devshell.rs
+++ b/src-tauri/src/commands/devshell.rs
@@ -18,7 +18,9 @@
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
+use std::process::Stdio;
 use std::sync::Arc;
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, Manager, Runtime, State};
@@ -56,14 +58,17 @@ impl<R: Runtime> DevshellEmitter for TauriEmitter<R> {
     }
 }
 
-fn emitter_for<R: Runtime>(app: &AppHandle<R>) -> AppEmitter {
+pub(crate) fn emitter_for<R: Runtime>(app: &AppHandle<R>) -> AppEmitter {
     AppEmitter::new(Arc::new(TauriEmitter::new(app.clone())) as Arc<dyn DevshellEmitter>)
 }
 
 /// Resolve `[devshell]` config — global toml merged with the
 /// optional `<root>/.aethon/devshell.toml` override. Returns the
 /// effective `(enabled, mode)` strings already normalised.
-fn effective_config<R: Runtime>(app: &AppHandle<R>, root: &Path) -> (String, DetectMode) {
+pub(crate) fn effective_config<R: Runtime>(
+    app: &AppHandle<R>,
+    root: &Path,
+) -> (String, DetectMode) {
     use std::io::Read;
 
     // 1) Global config. Replicate aethon_state_path's home-dir
@@ -110,6 +115,20 @@ fn effective_config<R: Runtime>(app: &AppHandle<R>, root: &Path) -> (String, Det
     (enabled, DetectMode::from_str(&mode_str))
 }
 
+pub(crate) fn forced_mode_mismatch_reason(
+    root: &Path,
+    configured_mode: DetectMode,
+) -> Option<String> {
+    let natural = crate::devshell::forced_mode_mismatch(root, configured_mode)?;
+    Some(format!(
+        "configured [devshell].mode = \"{}\", but {} is detected as a {} devshell. Aethon will not fall back to a different resolver; change Resolver mode or add the expected {} marker.",
+        mode_str(configured_mode),
+        root.display(),
+        natural.as_str(),
+        expected_marker(configured_mode)
+    ))
+}
+
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StatusArgs {
@@ -148,16 +167,26 @@ pub async fn devshell_status<R: Runtime>(
     args: StatusArgs,
 ) -> Result<StatusResponse, String> {
     let root = PathBuf::from(&args.root);
-    let (enabled, mode) = effective_config(&app, &root);
+    let (enabled, configured_mode) = effective_config(&app, &root);
     let detected_kind = if enabled == "never" {
         None
     } else {
-        crate::devshell::detect_mode(&root, mode).map(|k| k.as_str().to_string())
+        crate::devshell::detect_mode(&root, configured_mode).map(|k| k.as_str().to_string())
+    };
+    let mismatch = if enabled == "never" {
+        None
+    } else {
+        forced_mode_mismatch_reason(&root, configured_mode)
     };
     let snapshot = match enabled.as_str() {
         "never" => StatusSnapshot::None,
+        _ if mismatch.is_some() => StatusSnapshot::Failed {
+            kind: mode_str(configured_mode).to_string(),
+            reason: mismatch.unwrap(),
+            failed_at_ms: 0,
+        },
         "always" if detected_kind.is_none() => StatusSnapshot::Failed {
-            kind: mode_str(mode).to_string(),
+            kind: mode_str(configured_mode).to_string(),
             reason: format!(
                 "no devshell detected at {} and [devshell] enabled = \"always\"",
                 root.display()
@@ -168,7 +197,7 @@ pub async fn devshell_status<R: Runtime>(
     };
     Ok(StatusResponse {
         enabled,
-        mode: mode_str(mode).to_string(),
+        mode: mode_str(configured_mode).to_string(),
         snapshot,
         detected_kind,
     })
@@ -180,6 +209,15 @@ fn mode_str(mode: DetectMode) -> &'static str {
         DetectMode::Direnv => "direnv",
         DetectMode::Nix => "nix",
         DetectMode::NixShell => "nix-shell",
+    }
+}
+
+fn expected_marker(mode: DetectMode) -> &'static str {
+    match mode {
+        DetectMode::Auto => "devshell",
+        DetectMode::Direnv => ".envrc with use flake/use nix",
+        DetectMode::Nix => "flake.nix",
+        DetectMode::NixShell => "shell.nix",
     }
 }
 
@@ -201,6 +239,177 @@ pub struct EnvForPathResponse {
     pub env: BTreeMap<String, String>,
 }
 
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PrepareForPathArgs {
+    /// The project/worktree cwd that is about to be provisioned.
+    pub cwd: String,
+    /// Agent-side callers set this so the prepared env can seed their
+    /// synchronous spawn-hook cache. Frontend tab-open callers leave it false.
+    pub include_env: Option<bool>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PrepareForPathResponse {
+    pub enabled: String,
+    pub mode: String,
+    pub state: String,
+    pub kind: Option<String>,
+    pub stale: bool,
+    pub duration_ms: Option<u64>,
+    pub var_count: usize,
+    pub direnv_allowed: bool,
+    pub reason: Option<String>,
+    pub env: Option<BTreeMap<String, String>>,
+}
+
+/// Blocking prepare for explicit project/worktree roots. This is intentionally
+/// separate from `devshell_env_for_path`: agent/session provisioning should
+/// wait for the env so the first tool call is correct, while PTY opens still
+/// use the non-blocking path.
+#[tauri::command]
+pub async fn devshell_prepare_for_path<R: Runtime>(
+    app: AppHandle<R>,
+    cache: State<'_, Arc<DevshellCache>>,
+    args: PrepareForPathArgs,
+) -> Result<PrepareForPathResponse, String> {
+    let cwd = PathBuf::from(&args.cwd);
+    let include_env = args.include_env.unwrap_or(false);
+    let (enabled, configured_mode) = effective_config(&app, &cwd);
+    if enabled == "never" {
+        return Ok(PrepareForPathResponse {
+            enabled,
+            mode: mode_str(configured_mode).to_string(),
+            state: "disabled".to_string(),
+            kind: None,
+            stale: false,
+            duration_ms: None,
+            var_count: 0,
+            direnv_allowed: false,
+            reason: None,
+            env: include_env.then(BTreeMap::new),
+        });
+    }
+
+    let detected_kind = crate::devshell::detect_mode(&cwd, configured_mode);
+    let Some(kind) = detected_kind else {
+        let reason = forced_mode_mismatch_reason(&cwd, configured_mode)
+            .unwrap_or_else(|| format!("no devshell detected at {}", cwd.display()));
+        if enabled == "always" {
+            return Err(format!("{reason} and [devshell] enabled = \"always\""));
+        }
+        let is_mismatch = crate::devshell::forced_mode_mismatch(&cwd, configured_mode).is_some();
+        return Ok(PrepareForPathResponse {
+            enabled,
+            mode: mode_str(configured_mode).to_string(),
+            state: if is_mismatch { "failed" } else { "none" }.to_string(),
+            kind: None,
+            stale: false,
+            duration_ms: None,
+            var_count: 0,
+            direnv_allowed: false,
+            reason: Some(reason),
+            env: include_env.then(BTreeMap::new),
+        });
+    };
+
+    let mut direnv_allowed = false;
+    if kind.as_str() == "direnv" {
+        if let Err(reason) = direnv_allow(&cwd).await {
+            if enabled == "always" {
+                return Err(reason);
+            }
+            return Ok(PrepareForPathResponse {
+                enabled,
+                mode: mode_str(configured_mode).to_string(),
+                state: "failed".to_string(),
+                kind: Some(kind.as_str().to_string()),
+                stale: false,
+                duration_ms: None,
+                var_count: 0,
+                direnv_allowed: false,
+                reason: Some(reason),
+                env: include_env.then(BTreeMap::new),
+            });
+        }
+        direnv_allowed = true;
+    }
+
+    let emitter = emitter_for(&app);
+    match cache
+        .prepare_for(Some(&emitter), &cwd, configured_mode)
+        .await
+    {
+        Ok(prepared) => {
+            let var_count = prepared.env.len();
+            Ok(PrepareForPathResponse {
+                enabled,
+                mode: mode_str(configured_mode).to_string(),
+                state: "ready".to_string(),
+                kind: prepared.kind,
+                stale: prepared.stale,
+                duration_ms: prepared.duration_ms,
+                var_count,
+                direnv_allowed,
+                reason: None,
+                env: include_env.then_some(prepared.env),
+            })
+        }
+        Err(reason) => {
+            if enabled == "always" {
+                return Err(reason);
+            }
+            Ok(PrepareForPathResponse {
+                enabled,
+                mode: mode_str(configured_mode).to_string(),
+                state: "failed".to_string(),
+                kind: Some(kind.as_str().to_string()),
+                stale: false,
+                duration_ms: None,
+                var_count: 0,
+                direnv_allowed,
+                reason: Some(reason),
+                env: include_env.then(BTreeMap::new),
+            })
+        }
+    }
+}
+
+pub(crate) async fn direnv_allow(root: &Path) -> Result<(), String> {
+    let Some(bin) = crate::env::resolve_program("direnv") else {
+        return Err("direnv binary not found on Aethon tool PATH".to_string());
+    };
+    let mut command = tokio::process::Command::new(bin);
+    command
+        .arg("allow")
+        .arg(root)
+        .current_dir(root)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let output = tokio::time::timeout(Duration::from_secs(30), command.output())
+        .await
+        .map_err(|_| format!("direnv allow {} timed out after 30s", root.display()))?
+        .map_err(|e| format!("direnv allow {} failed to start: {e}", root.display()))?;
+    if output.status.success() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let detail = if !stderr.is_empty() { stderr } else { stdout };
+    Err(format!(
+        "direnv allow {} exited with {}{}",
+        root.display(),
+        output.status,
+        if detail.is_empty() {
+            String::new()
+        } else {
+            format!(": {detail}")
+        }
+    ))
+}
+
 /// Non-blocking env lookup. Returns immediately even if a resolver is
 /// in-flight; the agent spawnHook + PTY intercept both use this and
 /// must never block the user's tool call on `nix print-dev-env`.
@@ -211,7 +420,7 @@ pub async fn devshell_env_for_path<R: Runtime>(
     args: EnvForPathArgs,
 ) -> Result<EnvForPathResponse, String> {
     let cwd = PathBuf::from(&args.cwd);
-    let (enabled, mode) = effective_config(&app, &cwd);
+    let (enabled, configured_mode) = effective_config(&app, &cwd);
     if enabled == "never" {
         return Ok(EnvForPathResponse {
             enabled,
@@ -221,7 +430,8 @@ pub async fn devshell_env_for_path<R: Runtime>(
         });
     }
     let emitter = emitter_for(&app);
-    let EnvForPath { kind, stale, env } = cache.env_for(Some(&emitter), &cwd, mode).await;
+    let EnvForPath { kind, stale, env } =
+        cache.env_for(Some(&emitter), &cwd, configured_mode).await;
     Ok(EnvForPathResponse {
         enabled,
         kind,
@@ -250,12 +460,15 @@ pub async fn devshell_refresh<R: Runtime>(
     args: RefreshArgs,
 ) -> Result<(), String> {
     let root = PathBuf::from(&args.root);
-    let (enabled, mode) = effective_config(&app, &root);
+    let (enabled, configured_mode) = effective_config(&app, &root);
     if enabled == "never" {
         return Ok(());
     }
+    if let Some(reason) = forced_mode_mismatch_reason(&root, configured_mode) {
+        return Err(reason);
+    }
     let emitter = emitter_for(&app);
-    match cache.refresh(Some(&emitter), &root, mode).await {
+    match cache.refresh(Some(&emitter), &root, configured_mode).await {
         Ok(()) => Ok(()),
         Err(e) => {
             // "auto" silently no-ops when there's no devshell to

--- a/src-tauri/src/devshell/cache.rs
+++ b/src-tauri/src/devshell/cache.rs
@@ -15,7 +15,7 @@
 //! The resolver task is launched once per (root, fingerprint) — the
 //! second-pass write lock checks whether a matching `Resolving` /
 //! `Ready` already exists so concurrent shell opens collapse onto the
-//! same in-flight `nix print-dev-env` evaluation instead of fanning
+//! same in-flight `nix develop --command env` evaluation instead of fanning
 //! out into N parallel resolves.
 
 use std::collections::BTreeMap;
@@ -230,7 +230,7 @@ impl DevshellCache {
         // Cold-start disk pre-warm: no in-memory slot for this root
         // AND a snapshot on disk matches the current fingerprint?
         // Hydrate the slot before deciding whether to spawn a
-        // resolver. Saves a full `nix print-dev-env` re-eval on app
+        // resolver. Saves a full `nix develop --command env` re-eval on app
         // boot when nothing has changed since the previous session.
         {
             let already_warm = self.slots.read().await.contains_key(&root);
@@ -453,9 +453,7 @@ impl DevshellCache {
         fingerprint: &str,
     ) -> Option<PreparedEnv> {
         let guard = self.slots.read().await;
-        let Some(slot) = guard.get(root) else {
-            return None;
-        };
+        let slot = guard.get(root)?;
         let ResolverState::Ready {
             env,
             duration_ms,
@@ -702,6 +700,7 @@ impl AppEmitter {
 /// bytes once.
 pub fn fingerprint_inputs(root: &Path) -> String {
     let mut hasher = Sha1::new();
+    hasher.update(b"resolver:v2:nix-develop-env");
     if let Ok(bytes) = std::fs::read(root.join("flake.lock")) {
         hasher.update(b"lock:");
         hasher.update(&bytes);
@@ -780,7 +779,7 @@ fn write_disk_snapshot(
 /// `env_for` call for a project after app boot pulls the previous
 /// session's resolver output from disk (if its fingerprint still
 /// matches the current `flake.lock` + marker mtimes), skipping the
-/// full `nix print-dev-env` re-eval. Fingerprint mismatch falls
+/// full `nix develop --command env` re-eval. Fingerprint mismatch falls
 /// through to a fresh resolve.
 pub fn load_disk_snapshot(disk_root: &Path, fingerprint: &str) -> Option<ResolvedEnv> {
     let dir = disk_root.join(&fingerprint[..fingerprint.len().min(16)]);

--- a/src-tauri/src/devshell/cache.rs
+++ b/src-tauri/src/devshell/cache.rs
@@ -26,14 +26,16 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use serde::{Deserialize, Serialize};
 use sha1::{Digest, Sha1};
 use tokio::sync::{Notify, RwLock};
+use tokio::time::timeout;
 
 use super::detect::{DetectMode, DevshellKind, RealProbe, detect_with};
-use super::resolve::{ResolvedEnv, resolve};
+use super::resolve::{ResolveProgress, ResolveProgressSender, ResolvedEnv, resolve};
 
 /// How long we wait before retrying a `Failed` resolve. Without this
 /// floor, a hard error (missing `nix` binary, broken flake) would be
 /// re-attempted on every shell open and storm the user with errors.
 const FAILED_RETRY_AFTER: Duration = Duration::from_secs(30);
+const PREPARE_WAIT_TIMEOUT: Duration = Duration::from_secs(125);
 
 /// State of a single resolver slot.
 #[derive(Debug, Clone)]
@@ -102,6 +104,15 @@ pub struct EnvForPath {
     pub stale: bool,
     /// Empty when state is anything other than `Ready`.
     pub env: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PreparedEnv {
+    pub kind: Option<String>,
+    pub stale: bool,
+    pub env: BTreeMap<String, String>,
+    pub duration_ms: Option<u64>,
 }
 
 struct Slot {
@@ -284,6 +295,109 @@ impl DevshellCache {
         }
     }
 
+    /// Blocking preparation for project/worktree provisioning. Unlike
+    /// [`env_for`], this waits until the resolver is either `Ready` or
+    /// `Failed` so the first agent/tool run does not race a cold Nix/direnv
+    /// evaluation.
+    pub async fn prepare_for(
+        &self,
+        emitter: Option<&AppEmitter>,
+        root: &Path,
+        mode: DetectMode,
+    ) -> Result<PreparedEnv, String> {
+        let root = canonicalize_key(root);
+        let Some(kind) = detect_with(&root, mode, &RealProbe) else {
+            return Ok(PreparedEnv {
+                kind: None,
+                stale: false,
+                env: BTreeMap::new(),
+                duration_ms: None,
+            });
+        };
+        let fingerprint = fingerprint_inputs(&root);
+        self.hydrate_from_disk_if_available(&root, kind, &fingerprint)
+            .await;
+
+        if let Some(ready) = self
+            .ready_env_for_fingerprint(&root, kind, &fingerprint)
+            .await
+        {
+            return Ok(ready);
+        }
+
+        self.kick_resolve(emitter, root.clone(), kind, fingerprint.clone(), false)
+            .await;
+
+        let wait = async {
+            loop {
+                let notify = {
+                    let guard = self.slots.read().await;
+                    match guard.get(&root) {
+                        Some(slot) => match &slot.state {
+                            ResolverState::Ready {
+                                env,
+                                duration_ms,
+                                fingerprint: fp,
+                                ..
+                            } if *fp == fingerprint => {
+                                return Ok(PreparedEnv {
+                                    kind: Some(kind.as_str().into()),
+                                    stale: false,
+                                    env: env.clone(),
+                                    duration_ms: Some(*duration_ms),
+                                });
+                            }
+                            ResolverState::Failed {
+                                reason,
+                                fingerprint: fp,
+                                ..
+                            } if *fp == fingerprint => {
+                                return Err(reason.clone());
+                            }
+                            _ => Arc::clone(&slot.notify),
+                        },
+                        None => {
+                            return Err(format!(
+                                "devshell resolver slot disappeared for {}",
+                                root.display()
+                            ));
+                        }
+                    }
+                };
+                let notified = notify.notified();
+                if let Some(ready) = self
+                    .ready_env_for_fingerprint(&root, kind, &fingerprint)
+                    .await
+                {
+                    return Ok(ready);
+                }
+                {
+                    let guard = self.slots.read().await;
+                    if let Some(slot) = guard.get(&root)
+                        && let ResolverState::Failed {
+                            reason,
+                            fingerprint: fp,
+                            ..
+                        } = &slot.state
+                        && *fp == fingerprint
+                    {
+                        return Err(reason.clone());
+                    }
+                }
+                notified.await;
+            }
+        };
+
+        match timeout(PREPARE_WAIT_TIMEOUT, wait).await {
+            Ok(result) => result,
+            Err(_) => Err(format!(
+                "timed out waiting for devshell at {} after {}s",
+                root.display(),
+                PREPARE_WAIT_TIMEOUT.as_secs()
+            )),
+        }
+    }
+
     /// Invalidate the cached state for `root` and kick off a fresh
     /// resolve. Frontend "Refresh now" button reaches here.
     pub async fn refresh(
@@ -300,6 +414,95 @@ impl DevshellCache {
         self.kick_resolve(emitter, root, kind, fingerprint, true)
             .await;
         Ok(())
+    }
+
+    async fn hydrate_from_disk_if_available(
+        &self,
+        root: &Path,
+        kind: DevshellKind,
+        fingerprint: &str,
+    ) {
+        let already_warm = self.slots.read().await.contains_key(root);
+        if already_warm {
+            return;
+        }
+        let disk_root = self.disk_root.read().await.clone();
+        let Some(disk) = disk_root else {
+            return;
+        };
+        let Some(snap) = load_disk_snapshot(&disk, fingerprint) else {
+            return;
+        };
+        let mut guard = self.slots.write().await;
+        guard.entry(root.to_path_buf()).or_insert_with(|| Slot {
+            state: ResolverState::Ready {
+                kind,
+                env: snap.env,
+                resolved_at: SystemTime::now(),
+                duration_ms: snap.duration_ms,
+                fingerprint: fingerprint.to_string(),
+            },
+            notify: Arc::new(Notify::new()),
+        });
+    }
+
+    async fn ready_env_for_fingerprint(
+        &self,
+        root: &Path,
+        kind: DevshellKind,
+        fingerprint: &str,
+    ) -> Option<PreparedEnv> {
+        let guard = self.slots.read().await;
+        let Some(slot) = guard.get(root) else {
+            return None;
+        };
+        let ResolverState::Ready {
+            env,
+            duration_ms,
+            fingerprint: fp,
+            ..
+        } = &slot.state
+        else {
+            return None;
+        };
+        if fp != fingerprint {
+            return None;
+        }
+        Some(PreparedEnv {
+            kind: Some(kind.as_str().into()),
+            stale: false,
+            env: env.clone(),
+            duration_ms: Some(*duration_ms),
+        })
+    }
+
+    /// Immediate, non-blocking read of a hot env. Used by synchronous
+    /// process-spawn paths after the frontend already performed the
+    /// blocking prepare step.
+    pub fn ready_env_now(&self, root: &Path, mode: DetectMode) -> Option<PreparedEnv> {
+        let root = canonicalize_key(root);
+        let kind = detect_with(&root, mode, &RealProbe)?;
+        let fingerprint = fingerprint_inputs(&root);
+        let guard = self.slots.try_read().ok()?;
+        let slot = guard.get(&root)?;
+        let ResolverState::Ready {
+            env,
+            duration_ms,
+            fingerprint: fp,
+            ..
+        } = &slot.state
+        else {
+            return None;
+        };
+        if *fp != fingerprint {
+            return None;
+        }
+        Some(PreparedEnv {
+            kind: Some(kind.as_str().into()),
+            stale: false,
+            env: env.clone(),
+            duration_ms: Some(*duration_ms),
+        })
     }
 
     async fn kick_resolve(
@@ -372,7 +575,8 @@ impl DevshellCache {
         let emitter_clone = emitter.cloned();
         let fingerprint_owned = fingerprint.clone();
         tokio::spawn(async move {
-            let outcome = resolve(&root, kind).await;
+            let progress = progress_sender(emitter_clone.clone(), root.display().to_string(), kind);
+            let outcome = resolve(&root, kind, progress).await;
             let now = SystemTime::now();
             let new_state = match outcome {
                 Ok(resolved) => {
@@ -451,6 +655,26 @@ impl DevshellCache {
             }
         });
     }
+}
+
+fn progress_sender(
+    emitter: Option<AppEmitter>,
+    root: String,
+    kind: DevshellKind,
+) -> Option<ResolveProgressSender> {
+    emitter.map(|emitter| {
+        Arc::new(move |progress: ResolveProgress| {
+            emitter.emit(
+                "devshell-output",
+                serde_json::json!({
+                    "root": root.as_str(),
+                    "kind": kind.as_str(),
+                    "stream": progress.stream,
+                    "content": progress.content,
+                }),
+            );
+        }) as ResolveProgressSender
+    })
 }
 
 /// Lightweight emitter trait so the cache doesn't have to depend on

--- a/src-tauri/src/devshell/detect.rs
+++ b/src-tauri/src/devshell/detect.rs
@@ -7,7 +7,7 @@
 //! warm in-process cache pi can't see. Flake comes next so a
 //! repo with `flake.nix` + `nix` on PATH transparently lights up
 //! without any direnv setup. `shell.nix` is the legacy non-flake
-//! fallback.
+//! fallback when no flake is present.
 //!
 //! Detection is intentionally *capability-aware*: a `flake.nix`
 //! without `nix` on PATH yields `None` rather than `Flake`, because
@@ -24,10 +24,11 @@ pub enum DevshellKind {
     /// `direnv exec <root> env -0`.
     Direnv,
     /// `flake.nix` + `nix` binary present. Resolve via
-    /// `nix print-dev-env --json` from the root.
+    /// `nix develop --command env -0` from the root.
     Flake,
     /// `shell.nix` + `nix` binary present. Resolve via
-    /// `nix-shell --run 'env -0'` from the root.
+    /// `nix-shell --run 'env -0'` from the root. Used only for
+    /// non-flake legacy projects.
     Shell,
 }
 
@@ -44,9 +45,12 @@ impl DevshellKind {
 }
 
 /// Override for `mode` from `[devshell] mode` in `config.toml`. `Auto`
-/// keeps the natural precedence; the named variants pin a kind and
-/// still gracefully fall back to `None` if the marker file or the
-/// required binary is missing.
+/// keeps the natural precedence; the named variants pin a resolver family and
+/// still gracefully fall back to `None` if the marker file or the required
+/// binary is missing. `NixShell` is kept as a compatibility spelling for the
+/// user-facing "Nix devshell" mode: flake projects use the flake resolver
+/// (`nix develop --command env -0`), and only
+/// non-flake projects fall back to legacy `shell.nix`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum DetectMode {
     #[default]
@@ -130,7 +134,13 @@ pub(super) fn detect_with(
         }
         DetectMode::Direnv => direnv_ok.then_some(DevshellKind::Direnv),
         DetectMode::Nix => flake_ok.then_some(DevshellKind::Flake),
-        DetectMode::NixShell => shell_ok.then_some(DevshellKind::Shell),
+        DetectMode::NixShell => {
+            if flake_ok {
+                Some(DevshellKind::Flake)
+            } else {
+                shell_ok.then_some(DevshellKind::Shell)
+            }
+        }
     }
 }
 
@@ -392,7 +402,7 @@ mod tests {
         );
         assert_eq!(
             detect_with(td.path(), DetectMode::NixShell, &probe),
-            Some(DevshellKind::Shell)
+            Some(DevshellKind::Flake)
         );
     }
 
@@ -409,7 +419,7 @@ mod tests {
     }
 
     #[test]
-    fn forced_mode_mismatch_reports_natural_kind() {
+    fn nix_shell_mode_uses_flake_devshell_when_present() {
         let td = TempDir::new().unwrap();
         write(&td, "flake.nix", "{}");
         write(&td, ".envrc", "use flake\n");
@@ -419,8 +429,27 @@ mod tests {
         };
 
         assert_eq!(
+            detect_with(td.path(), DetectMode::NixShell, &probe),
+            Some(DevshellKind::Flake)
+        );
+        assert_eq!(
             forced_mode_mismatch_with(td.path(), DetectMode::NixShell, &probe),
-            Some(DevshellKind::Direnv)
+            None
+        );
+    }
+
+    #[test]
+    fn forced_mode_mismatch_reports_natural_kind_for_unmatched_mode() {
+        let td = TempDir::new().unwrap();
+        write(&td, "flake.nix", "{}");
+        let probe = FakeProbe {
+            direnv: true,
+            nix: true,
+        };
+
+        assert_eq!(
+            forced_mode_mismatch_with(td.path(), DetectMode::Direnv, &probe),
+            Some(DevshellKind::Flake)
         );
     }
 

--- a/src-tauri/src/devshell/detect.rs
+++ b/src-tauri/src/devshell/detect.rs
@@ -75,6 +75,14 @@ pub fn detect_mode(root: &Path, mode: DetectMode) -> Option<DevshellKind> {
     detect_with(root, mode, &RealProbe)
 }
 
+/// If a named resolver is forced but this root only matches another
+/// Nix-backed devshell entry path, return the naturally detected kind.
+/// Callers use this to surface a configuration mismatch instead of
+/// silently falling back to direnv/flake/shell.
+pub fn forced_mode_mismatch(root: &Path, configured: DetectMode) -> Option<DevshellKind> {
+    forced_mode_mismatch_with(root, configured, &RealProbe)
+}
+
 /// Trait so unit tests can fake binary availability without poking
 /// the real PATH. Production callers use `RealProbe`.
 pub trait BinProbe {
@@ -124,6 +132,20 @@ pub(super) fn detect_with(
         DetectMode::Nix => flake_ok.then_some(DevshellKind::Flake),
         DetectMode::NixShell => shell_ok.then_some(DevshellKind::Shell),
     }
+}
+
+pub(super) fn forced_mode_mismatch_with(
+    root: &Path,
+    configured: DetectMode,
+    probe: &dyn BinProbe,
+) -> Option<DevshellKind> {
+    if matches!(configured, DetectMode::Auto) {
+        return None;
+    }
+    if detect_with(root, configured, probe).is_some() {
+        return None;
+    }
+    detect_with(root, DetectMode::Auto, probe)
 }
 
 /// Cheaply check whether a `.envrc` actually wires up Nix. A `.envrc`
@@ -384,6 +406,54 @@ mod tests {
         };
         // Forced Nix mode but no nix binary on PATH — refuse rather than lie.
         assert_eq!(detect_with(td.path(), DetectMode::Nix, &probe), None);
+    }
+
+    #[test]
+    fn forced_mode_mismatch_reports_natural_kind() {
+        let td = TempDir::new().unwrap();
+        write(&td, "flake.nix", "{}");
+        write(&td, ".envrc", "use flake\n");
+        let probe = FakeProbe {
+            direnv: true,
+            nix: true,
+        };
+
+        assert_eq!(
+            forced_mode_mismatch_with(td.path(), DetectMode::NixShell, &probe),
+            Some(DevshellKind::Direnv)
+        );
+    }
+
+    #[test]
+    fn forced_mode_mismatch_is_none_for_auto_mode() {
+        let td = TempDir::new().unwrap();
+        write(&td, "flake.nix", "{}");
+        write(&td, ".envrc", "use flake\n");
+        let probe = FakeProbe {
+            direnv: true,
+            nix: true,
+        };
+
+        assert_eq!(
+            forced_mode_mismatch_with(td.path(), DetectMode::Auto, &probe),
+            None
+        );
+    }
+
+    #[test]
+    fn forced_mode_mismatch_is_none_when_preferred_marker_exists() {
+        let td = TempDir::new().unwrap();
+        write(&td, "flake.nix", "{}");
+        write(&td, "shell.nix", "{}");
+        let probe = FakeProbe {
+            direnv: true,
+            nix: true,
+        };
+
+        assert_eq!(
+            forced_mode_mismatch_with(td.path(), DetectMode::NixShell, &probe),
+            None
+        );
     }
 
     #[test]

--- a/src-tauri/src/devshell/mod.rs
+++ b/src-tauri/src/devshell/mod.rs
@@ -27,4 +27,4 @@ pub mod resolve;
 pub use cache::{
     AppEmitter, DevshellCache, DevshellEmitter, EnvForPath, StatusSnapshot, evict_stale_snapshots,
 };
-pub use detect::{DetectMode, detect_mode};
+pub use detect::{DetectMode, detect_mode, forced_mode_mismatch};

--- a/src-tauri/src/devshell/mod.rs
+++ b/src-tauri/src/devshell/mod.rs
@@ -10,7 +10,7 @@
 //! - [`detect`] — pure: which kind of devshell does this root have?
 //!   No subprocesses; no I/O beyond reading the marker files.
 //! - [`resolve`] — runs the kind-specific resolver command
-//!   (`nix print-dev-env --json`, `direnv exec env -0`, etc.) and
+//!   (`nix develop --command env -0`, `direnv exec env -0`, etc.) and
 //!   parses the env output into a `BTreeMap`.
 //! - [`cache`] — wraps both behind a non-blocking state machine and
 //!   the on-disk snapshot store. Callers always see `Idle | Resolving

--- a/src-tauri/src/devshell/resolve.rs
+++ b/src-tauri/src/devshell/resolve.rs
@@ -3,7 +3,7 @@
 //! Three resolvers, all reduce to a `BTreeMap<String, String>`:
 //!
 //! - `Direnv` → `direnv exec <root> env -0`
-//! - `Flake`  → `nix print-dev-env --json` from the root
+//! - `Flake`  → `nix develop --command env -0` from the root
 //! - `Shell`  → `nix-shell --run 'env -0'` from the root
 //!
 //! Every spawn captures stdout+stderr and uses a wall-clock timeout so
@@ -28,18 +28,19 @@ use crate::env;
 
 use super::detect::DevshellKind;
 
-/// Per-resolver wall-clock timeout. A cold `nix print-dev-env --json`
+/// Per-resolver wall-clock timeout. A cold `nix develop --command env`
 /// on a complex flake can easily take 30-60 s; we cap at 120 s so a
 /// genuinely wedged Nix evaluation can't keep the resolver task alive
 /// forever. The state machine surfaces the timeout as a `Failed`.
 const RESOLVE_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// Maximum bytes we'll read from a resolver's stdout. A normal flake
-/// `print-dev-env` output is a few hundred KB; the cap keeps a runaway
+/// `nix develop --command env -0` output is a few hundred KB; the cap keeps a runaway
 /// shell from OOM'ing us. 32 MiB is well above the worst realistic
 /// shell env.
 const STDOUT_MAX_BYTES: usize = 32 * 1024 * 1024;
 const STDERR_MAX_BYTES: usize = 256 * 1024;
+const NIX_DEVELOP_ENV_SENTINEL: &[u8] = b"__AETHON_ENV_START__\0";
 
 #[derive(Debug, Clone)]
 pub struct ResolveProgress {
@@ -48,6 +49,12 @@ pub struct ResolveProgress {
 }
 
 pub type ResolveProgressSender = Arc<dyn Fn(ResolveProgress) + Send + Sync>;
+
+#[derive(Clone, Copy)]
+enum StdoutProgressMode {
+    None,
+    UntilSentinel(&'static [u8]),
+}
 
 /// The resolved devshell environment in a stable serializable form.
 /// Returning a `BTreeMap` (not `HashMap`) makes snapshot-style tests
@@ -97,7 +104,14 @@ async fn resolve_direnv(
         .env("DIRENV_LOG_FORMAT", "")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
-    let raw = run_with_timeout("direnv exec", cmd, RESOLVE_TIMEOUT, progress).await?;
+    let raw = run_with_timeout(
+        "direnv exec",
+        cmd,
+        RESOLVE_TIMEOUT,
+        progress,
+        StdoutProgressMode::None,
+    )
+    .await?;
     parse_null_separated_env(&raw)
 }
 
@@ -106,17 +120,27 @@ async fn resolve_flake(
     progress: Option<&ResolveProgressSender>,
 ) -> Result<BTreeMap<String, String>, String> {
     let mut cmd = env::tokio_command("nix");
-    cmd.arg("print-dev-env")
-        .arg("--json")
+    cmd.arg("develop")
         // The `--accept-flake-config` flag matches what users routinely
         // pass at the CLI to avoid the interactive "trust this flake?"
         // prompt that would otherwise wedge the resolver on first use.
         .arg("--accept-flake-config")
+        .arg("--command")
+        .arg("sh")
+        .arg("-lc")
+        .arg("printf '%s\\0' __AETHON_ENV_START__; env -0")
         .current_dir(root)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
-    let raw = run_with_timeout("nix print-dev-env", cmd, RESOLVE_TIMEOUT, progress).await?;
-    parse_print_dev_env_json(&raw)
+    let raw = run_with_timeout(
+        "nix develop",
+        cmd,
+        RESOLVE_TIMEOUT,
+        progress,
+        StdoutProgressMode::UntilSentinel(NIX_DEVELOP_ENV_SENTINEL),
+    )
+    .await?;
+    parse_nix_develop_env(&raw)
 }
 
 async fn resolve_shell_nix(
@@ -129,7 +153,14 @@ async fn resolve_shell_nix(
         .current_dir(root)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
-    let raw = run_with_timeout("nix-shell", cmd, RESOLVE_TIMEOUT, progress).await?;
+    let raw = run_with_timeout(
+        "nix-shell",
+        cmd,
+        RESOLVE_TIMEOUT,
+        progress,
+        StdoutProgressMode::None,
+    )
+    .await?;
     parse_null_separated_env(&raw)
 }
 
@@ -138,6 +169,7 @@ async fn run_with_timeout(
     mut cmd: Command,
     t: Duration,
     progress: Option<&ResolveProgressSender>,
+    stdout_progress: StdoutProgressMode,
 ) -> Result<Vec<u8>, String> {
     emit_progress(
         progress,
@@ -156,9 +188,12 @@ async fn run_with_timeout(
         .take()
         .ok_or_else(|| format!("{label}: stderr pipe missing"))?;
 
+    let progress_for_stdout = progress.cloned();
     let collect = async move {
         let mut stdout = stdout;
         let mut buf = Vec::with_capacity(64 * 1024);
+        let mut emitted_prelude = 0usize;
+        let mut prelude_done = false;
         loop {
             let mut chunk = [0u8; 16 * 1024];
             let n = stdout
@@ -172,6 +207,28 @@ async fn run_with_timeout(
                 return Err(format!("{label}: stdout exceeded {STDOUT_MAX_BYTES} bytes"));
             }
             buf.extend_from_slice(&chunk[..n]);
+            if let (Some(progress), StdoutProgressMode::UntilSentinel(sentinel)) =
+                (progress_for_stdout.as_ref(), stdout_progress)
+            {
+                emit_stdout_prelude(
+                    Some(progress),
+                    &buf,
+                    &mut emitted_prelude,
+                    &mut prelude_done,
+                    sentinel,
+                );
+            }
+        }
+        if let (Some(progress), StdoutProgressMode::UntilSentinel(sentinel)) =
+            (progress_for_stdout.as_ref(), stdout_progress)
+        {
+            finish_stdout_prelude(
+                Some(progress),
+                &buf,
+                &mut emitted_prelude,
+                prelude_done,
+                sentinel,
+            );
         }
         Ok::<Vec<u8>, String>(buf)
     };
@@ -243,6 +300,67 @@ fn emit_progress(progress: Option<&ResolveProgressSender>, stream: &'static str,
     }
 }
 
+fn emit_stdout_prelude(
+    progress: Option<&ResolveProgressSender>,
+    buf: &[u8],
+    emitted: &mut usize,
+    done: &mut bool,
+    sentinel: &[u8],
+) {
+    if *done || sentinel.is_empty() {
+        return;
+    }
+    let end = if let Some(idx) = find_bytes(buf, sentinel) {
+        *done = true;
+        idx
+    } else {
+        buf.len()
+            .saturating_sub(sentinel_prefix_suffix_len(buf, sentinel))
+    };
+    emit_stdout_range(progress, buf, emitted, end);
+}
+
+fn finish_stdout_prelude(
+    progress: Option<&ResolveProgressSender>,
+    buf: &[u8],
+    emitted: &mut usize,
+    done: bool,
+    sentinel: &[u8],
+) {
+    if done {
+        return;
+    }
+    let end = find_bytes(buf, sentinel).unwrap_or(buf.len());
+    emit_stdout_range(progress, buf, emitted, end);
+}
+
+fn emit_stdout_range(
+    progress: Option<&ResolveProgressSender>,
+    buf: &[u8],
+    emitted: &mut usize,
+    end: usize,
+) {
+    if end <= *emitted {
+        return;
+    }
+    emit_progress(
+        progress,
+        "stdout",
+        String::from_utf8_lossy(&buf[*emitted..end]).into_owned(),
+    );
+    *emitted = end;
+}
+
+fn sentinel_prefix_suffix_len(buf: &[u8], sentinel: &[u8]) -> usize {
+    let max = buf.len().min(sentinel.len().saturating_sub(1));
+    for len in (1..=max).rev() {
+        if buf[buf.len() - len..] == sentinel[..len] {
+            return len;
+        }
+    }
+    0
+}
+
 /// Parse `env -0` output: each var is `KEY=VAL\0`. We tolerate a
 /// trailing NUL.
 pub fn parse_null_separated_env(buf: &[u8]) -> Result<BTreeMap<String, String>, String> {
@@ -255,61 +373,39 @@ pub fn parse_null_separated_env(buf: &[u8]) -> Result<BTreeMap<String, String>, 
             .map_err(|e| format!("env -0 output: invalid utf-8 — {e}"))?;
         if let Some(idx) = s.find('=') {
             let (k, v) = s.split_at(idx);
-            out.insert(k.to_string(), v[1..].to_string());
+            if is_valid_env_key(k) {
+                out.insert(k.to_string(), v[1..].to_string());
+            }
         }
     }
     Ok(out)
 }
 
-/// Parse the JSON shape `nix print-dev-env --json` emits. Schema:
-/// `{ "variables": { NAME: { "type": "exported" | "var" | "array", "value": ... } } }`
-/// We keep `exported` (and `var` for parity with how bash sources the
-/// output) but drop `array`-typed (bash-array) and function entries
-/// since they don't translate to a `KEY=VAL` flat env. `nix print-dev-env`
-/// also emits a `bashFunctions` block that we deliberately drop —
-/// reinstating bash functions in a non-bash shell would silently
-/// produce broken environments.
-pub fn parse_print_dev_env_json(buf: &[u8]) -> Result<BTreeMap<String, String>, String> {
-    #[derive(Deserialize)]
-    struct Doc {
-        variables: BTreeMap<String, Variable>,
-    }
-    #[derive(Deserialize)]
-    #[serde(untagged)]
-    enum Variable {
-        Scalar {
-            #[serde(rename = "type")]
-            kind: String,
-            value: String,
-        },
-        // Array form `{ "type": "array", "value": [...] }`. We must
-        // accept this shape during deserialization so the whole
-        // document doesn't get rejected, but bash-array semantics
-        // don't survive a round-trip to a flat `KEY=VAL` env, so the
-        // payload itself is discarded below.
-        #[allow(dead_code)]
-        Array(serde_json::Value),
-        // Untyped or unknown shape — ignore.
-        #[allow(dead_code)]
-        Other(serde_json::Value),
-    }
+fn parse_nix_develop_env(buf: &[u8]) -> Result<BTreeMap<String, String>, String> {
+    let Some(idx) = find_bytes(buf, NIX_DEVELOP_ENV_SENTINEL) else {
+        return Err("nix develop: env sentinel missing from resolver output".to_string());
+    };
+    parse_null_separated_env(&buf[idx + NIX_DEVELOP_ENV_SENTINEL.len()..])
+}
 
-    let doc: Doc = serde_json::from_slice(buf)
-        .map_err(|e| format!("nix print-dev-env: invalid JSON — {e}"))?;
-    let mut out = BTreeMap::new();
-    for (name, var) in doc.variables {
-        match var {
-            Variable::Scalar { kind, value } => {
-                if matches!(kind.as_str(), "exported" | "var") {
-                    out.insert(name, value);
-                }
-            }
-            // Skip arrays — they're meaningful in bash only.
-            Variable::Array(_) => {}
-            Variable::Other(_) => {}
-        }
+fn find_bytes(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() {
+        return Some(0);
     }
-    Ok(out)
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
+}
+
+fn is_valid_env_key(key: &str) -> bool {
+    let mut chars = key.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !(first == '_' || first.is_ascii_alphabetic()) {
+        return false;
+    }
+    chars.all(|c| c == '_' || c.is_ascii_alphanumeric())
 }
 
 /// Strip env vars the resolver subshell pollutes. Without this filter
@@ -379,50 +475,96 @@ mod tests {
     }
 
     #[test]
+    fn parse_null_separated_drops_invalid_env_keys() {
+        let buf: &[u8] = b"[devshell] FORCE=true\0OK=1\0";
+        let m = parse_null_separated_env(buf).unwrap();
+        assert!(!m.contains_key("[devshell] FORCE"));
+        assert_eq!(m.get("OK").map(String::as_str), Some("1"));
+    }
+
+    #[test]
     fn parse_null_separated_rejects_invalid_utf8() {
         let buf: &[u8] = b"\xff\xfe=oops\0";
         assert!(parse_null_separated_env(buf).is_err());
     }
 
     #[test]
-    fn parse_print_dev_env_extracts_exported_scalars() {
-        let json = br#"{
-            "variables": {
-                "PATH": {"type": "exported", "value": "/nix/store/abc/bin"},
-                "RUSTC": {"type": "var",      "value": "/nix/store/xyz/bin/rustc"},
-                "arr":   {"type": "array",    "value": ["a", "b"]}
-            }
-        }"#;
-        let m = parse_print_dev_env_json(json).unwrap();
-        assert_eq!(
-            m.get("PATH").map(String::as_str),
-            Some("/nix/store/abc/bin")
-        );
-        assert_eq!(
-            m.get("RUSTC").map(String::as_str),
-            Some("/nix/store/xyz/bin/rustc")
-        );
-        assert!(!m.contains_key("arr"));
+    fn parse_nix_develop_env_skips_shell_hook_prelude() {
+        let mut raw = b"\x1b[33m[devshell]\x1b[0m menu output\n".to_vec();
+        raw.extend_from_slice(NIX_DEVELOP_ENV_SENTINEL);
+        raw.extend_from_slice(b"PATH=/nix/store/bin\0IN_NIX_SHELL=impure\0");
+        let m = parse_nix_develop_env(&raw).unwrap();
+        assert_eq!(m.get("PATH").map(String::as_str), Some("/nix/store/bin"));
+        assert_eq!(m.get("IN_NIX_SHELL").map(String::as_str), Some("impure"));
     }
 
     #[test]
-    fn parse_print_dev_env_tolerates_unknown_variable_shapes() {
-        // Future schema additions shouldn't fail the parser; unknown
-        // shapes are silently skipped rather than crashing.
-        let json = br#"{
-            "variables": {
-                "FOO": {"type": "exported", "value": "1"},
-                "FUNC": {"type": "function", "value": {"signature": "x()"}}
-            }
-        }"#;
-        let m = parse_print_dev_env_json(json).unwrap();
-        assert_eq!(m.get("FOO").map(String::as_str), Some("1"));
-        assert!(!m.contains_key("FUNC"));
+    fn parse_nix_develop_env_requires_sentinel() {
+        assert!(parse_nix_develop_env(b"PATH=/x\0").is_err());
     }
 
     #[test]
-    fn parse_print_dev_env_errors_on_bad_json() {
-        assert!(parse_print_dev_env_json(b"not json").is_err());
+    fn stdout_prelude_streaming_waits_for_possible_split_sentinel() {
+        let captured = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sink = {
+            let captured = Arc::clone(&captured);
+            Arc::new(move |progress: ResolveProgress| {
+                captured.lock().unwrap().push(progress.content);
+            }) as ResolveProgressSender
+        };
+        let mut emitted = 0usize;
+        let mut done = false;
+        let sentinel = b"__SENTINEL__";
+        let mut buf = b"hello __SENT".to_vec();
+
+        emit_stdout_prelude(Some(&sink), &buf, &mut emitted, &mut done, sentinel);
+        assert_eq!(captured.lock().unwrap().join(""), "hello ");
+
+        buf.extend_from_slice(b"INEL__PATH=/nix\0");
+        emit_stdout_prelude(Some(&sink), &buf, &mut emitted, &mut done, sentinel);
+        assert_eq!(captured.lock().unwrap().join(""), "hello ");
+        assert!(done);
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn run_with_timeout_streams_nix_prelude_before_process_exit() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+        let sink = Arc::new(move |progress: ResolveProgress| {
+            if progress.stream == "stdout" {
+                let _ = tx.send(progress.content);
+            }
+        }) as ResolveProgressSender;
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c")
+            .arg("printf 'building drv\\n'; sleep 1; printf '__AETHON_ENV_START__\\0PATH=/nix/bin\\0'")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        let run = tokio::spawn(async move {
+            run_with_timeout(
+                "nix develop",
+                cmd,
+                Duration::from_secs(5),
+                Some(&sink),
+                StdoutProgressMode::UntilSentinel(NIX_DEVELOP_ENV_SENTINEL),
+            )
+            .await
+        });
+
+        let streamed = timeout(Duration::from_millis(500), rx.recv())
+            .await
+            .expect("stdout prelude should arrive before the process exits")
+            .expect("progress channel should stay open");
+        assert_eq!(streamed, "building drv\n");
+        let raw = run.await.unwrap().unwrap();
+        assert_eq!(
+            parse_nix_develop_env(&raw)
+                .unwrap()
+                .get("PATH")
+                .map(String::as_str),
+            Some("/nix/bin")
+        );
     }
 
     #[test]

--- a/src-tauri/src/devshell/resolve.rs
+++ b/src-tauri/src/devshell/resolve.rs
@@ -16,6 +16,7 @@
 use std::collections::BTreeMap;
 use std::path::Path;
 use std::process::Stdio;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
@@ -38,6 +39,15 @@ const RESOLVE_TIMEOUT: Duration = Duration::from_secs(120);
 /// shell from OOM'ing us. 32 MiB is well above the worst realistic
 /// shell env.
 const STDOUT_MAX_BYTES: usize = 32 * 1024 * 1024;
+const STDERR_MAX_BYTES: usize = 256 * 1024;
+
+#[derive(Debug, Clone)]
+pub struct ResolveProgress {
+    pub stream: &'static str,
+    pub content: String,
+}
+
+pub type ResolveProgressSender = Arc<dyn Fn(ResolveProgress) + Send + Sync>;
 
 /// The resolved devshell environment in a stable serializable form.
 /// Returning a `BTreeMap` (not `HashMap`) makes snapshot-style tests
@@ -53,12 +63,16 @@ pub struct ResolvedEnv {
 /// Resolve the devshell env for `root` given the chosen kind. Returns
 /// an error string suitable for surfacing in the status badge — never
 /// panics on bad resolver output (always falls through to a `Failed`).
-pub async fn resolve(root: &Path, kind: DevshellKind) -> Result<ResolvedEnv, String> {
+pub async fn resolve(
+    root: &Path,
+    kind: DevshellKind,
+    progress: Option<ResolveProgressSender>,
+) -> Result<ResolvedEnv, String> {
     let started = Instant::now();
     let raw_env = match kind {
-        DevshellKind::Direnv => resolve_direnv(root).await?,
-        DevshellKind::Flake => resolve_flake(root).await?,
-        DevshellKind::Shell => resolve_shell_nix(root).await?,
+        DevshellKind::Direnv => resolve_direnv(root, progress.as_ref()).await?,
+        DevshellKind::Flake => resolve_flake(root, progress.as_ref()).await?,
+        DevshellKind::Shell => resolve_shell_nix(root, progress.as_ref()).await?,
     };
     let filtered = filter_resolver_junk(raw_env);
     Ok(ResolvedEnv {
@@ -67,7 +81,10 @@ pub async fn resolve(root: &Path, kind: DevshellKind) -> Result<ResolvedEnv, Str
     })
 }
 
-async fn resolve_direnv(root: &Path) -> Result<BTreeMap<String, String>, String> {
+async fn resolve_direnv(
+    root: &Path,
+    progress: Option<&ResolveProgressSender>,
+) -> Result<BTreeMap<String, String>, String> {
     let mut cmd = env::tokio_command("direnv");
     cmd.arg("exec")
         .arg(root)
@@ -80,11 +97,14 @@ async fn resolve_direnv(root: &Path) -> Result<BTreeMap<String, String>, String>
         .env("DIRENV_LOG_FORMAT", "")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
-    let raw = run_with_timeout("direnv exec", cmd, RESOLVE_TIMEOUT).await?;
+    let raw = run_with_timeout("direnv exec", cmd, RESOLVE_TIMEOUT, progress).await?;
     parse_null_separated_env(&raw)
 }
 
-async fn resolve_flake(root: &Path) -> Result<BTreeMap<String, String>, String> {
+async fn resolve_flake(
+    root: &Path,
+    progress: Option<&ResolveProgressSender>,
+) -> Result<BTreeMap<String, String>, String> {
     let mut cmd = env::tokio_command("nix");
     cmd.arg("print-dev-env")
         .arg("--json")
@@ -95,18 +115,21 @@ async fn resolve_flake(root: &Path) -> Result<BTreeMap<String, String>, String> 
         .current_dir(root)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
-    let raw = run_with_timeout("nix print-dev-env", cmd, RESOLVE_TIMEOUT).await?;
+    let raw = run_with_timeout("nix print-dev-env", cmd, RESOLVE_TIMEOUT, progress).await?;
     parse_print_dev_env_json(&raw)
 }
 
-async fn resolve_shell_nix(root: &Path) -> Result<BTreeMap<String, String>, String> {
+async fn resolve_shell_nix(
+    root: &Path,
+    progress: Option<&ResolveProgressSender>,
+) -> Result<BTreeMap<String, String>, String> {
     let mut cmd = env::tokio_command("nix-shell");
     cmd.arg("--run")
         .arg("env -0")
         .current_dir(root)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
-    let raw = run_with_timeout("nix-shell", cmd, RESOLVE_TIMEOUT).await?;
+    let raw = run_with_timeout("nix-shell", cmd, RESOLVE_TIMEOUT, progress).await?;
     parse_null_separated_env(&raw)
 }
 
@@ -114,7 +137,13 @@ async fn run_with_timeout(
     label: &'static str,
     mut cmd: Command,
     t: Duration,
+    progress: Option<&ResolveProgressSender>,
 ) -> Result<Vec<u8>, String> {
+    emit_progress(
+        progress,
+        "status",
+        format!("\r\n[devshell] resolving with {label}\r\n"),
+    );
     let mut child = cmd
         .spawn()
         .map_err(|e| format!("{label}: failed to spawn — {e} (is the binary on PATH?)"))?;
@@ -147,10 +176,32 @@ async fn run_with_timeout(
         Ok::<Vec<u8>, String>(buf)
     };
 
+    let progress_for_stderr = progress.cloned();
     let stderr_drain = async move {
         let mut stderr = stderr;
         let mut buf = Vec::with_capacity(4 * 1024);
-        let _ = stderr.read_to_end(&mut buf).await;
+        loop {
+            let mut chunk = [0u8; 8 * 1024];
+            let n = match stderr.read(&mut chunk).await {
+                Ok(n) => n,
+                Err(_) => break,
+            };
+            if n == 0 {
+                break;
+            }
+            let bytes = &chunk[..n];
+            if let Some(progress) = progress_for_stderr.as_ref() {
+                emit_progress(
+                    Some(progress),
+                    "stderr",
+                    String::from_utf8_lossy(bytes).into_owned(),
+                );
+            }
+            if buf.len() < STDERR_MAX_BYTES {
+                let available = STDERR_MAX_BYTES - buf.len();
+                buf.extend_from_slice(&bytes[..bytes.len().min(available)]);
+            }
+        }
         buf
     };
 
@@ -169,12 +220,26 @@ async fn run_with_timeout(
                     .unwrap_or_else(|| "signal".to_string())
             ));
         }
+        emit_progress(
+            progress,
+            "status",
+            format!("[devshell] {label} completed\r\n"),
+        );
         Ok::<Vec<u8>, String>(out)
     })
     .await;
     match result {
         Ok(inner) => inner,
         Err(_elapsed) => Err(format!("{label}: timed out after {}s", t.as_secs())),
+    }
+}
+
+fn emit_progress(progress: Option<&ResolveProgressSender>, stream: &'static str, content: String) {
+    if content.is_empty() {
+        return;
+    }
+    if let Some(progress) = progress {
+        progress(ResolveProgress { stream, content });
     }
 }
 

--- a/src-tauri/src/env.rs
+++ b/src-tauri/src/env.rs
@@ -6,7 +6,7 @@
 //! Rust IPC command resolves dependencies the same way.
 
 use std::collections::HashSet;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::OnceLock;
 
@@ -119,6 +119,25 @@ pub(crate) fn resolved_login_path() -> Option<String> {
     if path.is_empty() { None } else { Some(path) }
 }
 
+pub(crate) fn resolved_project_path() -> String {
+    strip_devshell_path_entries(
+        &resolved_tool_path(),
+        std::env::var_os("DEVSHELL_DIR")
+            .map(PathBuf::from)
+            .as_deref(),
+    )
+}
+
+fn strip_devshell_path_entries(path: &str, devshell_dir: Option<&Path>) -> String {
+    let Some(devshell_dir) = devshell_dir.filter(|p| !p.as_os_str().is_empty()) else {
+        return path.to_string();
+    };
+    let paths = std::env::split_paths(path).filter(|entry| !entry.starts_with(devshell_dir));
+    std::env::join_paths(paths)
+        .map(|v| v.to_string_lossy().to_string())
+        .unwrap_or_else(|_| path.to_string())
+}
+
 fn has_separator(program: &str) -> bool {
     program.contains('/') || program.contains('\\')
 }
@@ -174,5 +193,16 @@ mod tests {
     #[test]
     fn resolve_program_does_not_require_login_shell_for_system_tools() {
         assert!(resolve_program("sh").is_some() || resolve_program("cmd").is_some());
+    }
+
+    #[test]
+    fn strips_active_devshell_entries_from_project_path() {
+        let devshell = Path::new("/nix/store/example-aethon-dir");
+        let path = "/nix/store/example-aethon-dir/bin:/opt/homebrew/bin:/nix/store/other/bin";
+        let clean = strip_devshell_path_entries(path, Some(devshell));
+        let paths: Vec<_> = std::env::split_paths(&clean).collect();
+        assert!(!paths.contains(&PathBuf::from("/nix/store/example-aethon-dir/bin")));
+        assert!(paths.contains(&PathBuf::from("/opt/homebrew/bin")));
+        assert!(paths.contains(&PathBuf::from("/nix/store/other/bin")));
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -241,6 +241,7 @@ pub fn run() {
             commands::boot::boot_stage,
             commands::boot::boot_ok,
             commands::devshell::devshell_status,
+            commands::devshell::devshell_prepare_for_path,
             commands::devshell::devshell_env_for_path,
             commands::devshell::devshell_refresh,
             shell::shell_open,
@@ -262,8 +263,9 @@ pub fn run() {
             debug::debug_shell_write_raw,
         ]);
 
-    builder
+    let app = builder
         .setup(|app| {
+            agent_process::cleanup_orphaned_dev_agents();
             if let Some(watcher) = commands::extensions::start_agent_watcher(app.handle().clone()) {
                 app.manage(watcher);
             }
@@ -362,8 +364,14 @@ pub fn run() {
             });
             Ok(())
         })
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application");
+    app.run(|app_handle, event| {
+        if matches!(event, tauri::RunEvent::Exit) {
+            let state = app_handle.state::<agent_process::AgentProcesses>();
+            agent_process::shutdown_all_agents(&state, "app exit");
+        }
+    });
 }
 
 #[cfg(test)]

--- a/src-tauri/src/shell/lifecycle/open.rs
+++ b/src-tauri/src/shell/lifecycle/open.rs
@@ -15,6 +15,7 @@ use super::registry::{
     ChildHandle, SCROLLBACK_BYTES, ScrollbackHandle, ShareHandle, ShellRegistry, ShellSlot,
 };
 use crate::commands::devshell::TauriEmitter;
+use crate::devshell::detect::DevshellKind;
 use crate::devshell::{AppEmitter, DetectMode, DevshellCache, DevshellEmitter};
 use crate::shell::scrollback::Scrollback;
 use crate::shell::sharemode::{ShareMode, ShareState};
@@ -87,18 +88,122 @@ pub async fn shell_open<R: Runtime>(
     // derivations in sync.
     let effective_command: Option<&str> = args.command.as_deref().filter(|c| !c.is_empty());
 
-    let mut cmd = match effective_command {
-        Some(c) => CommandBuilder::new(c),
-        None => default_shell_command(),
+    let command_args = match effective_command {
+        Some(_) => args.args.unwrap_or_default(),
+        None => default_shell_args(),
     };
-    if let Some(extra_args) = args.args {
-        for a in extra_args {
-            cmd.arg(a);
+    let command_program = effective_command
+        .map(str::to_string)
+        .unwrap_or_else(default_shell_label);
+    let mut launch_kind: Option<DevshellKind> = None;
+    let mut prepared_env: Option<(Option<String>, std::collections::BTreeMap<String, String>)> =
+        None;
+    let mut detected_launch_kind: Option<DevshellKind> = None;
+
+    if let Some(cwd) = args.cwd.as_ref() {
+        let cwd_path = std::path::PathBuf::from(cwd);
+        let (enabled, configured_mode) = devshell_effective_config(&app, &cwd_path);
+        if enabled != "never" {
+            if let Some(reason) =
+                crate::commands::devshell::forced_mode_mismatch_reason(&cwd_path, configured_mode)
+            {
+                return Err(format!("devshell prepare: {reason}"));
+            }
+            let detected_kind = crate::devshell::detect_mode(&cwd_path, configured_mode);
+            match detected_kind {
+                Some(kind) => {
+                    detected_launch_kind = Some(kind);
+                    let mut can_prepare = true;
+                    if kind.as_str() == "direnv"
+                        && let Err(reason) =
+                            crate::commands::devshell::direnv_allow(&cwd_path).await
+                    {
+                        if crate::commands::devshell::devshell_prepare_is_required(&enabled) {
+                            return Err(reason);
+                        }
+                        tracing::warn!(
+                            target: "aethon::devshell",
+                            "shell_open: direnv allow failed for {}: {reason}; opening host shell",
+                            cwd_path.display()
+                        );
+                        can_prepare = false;
+                    }
+                    if can_prepare {
+                        let emitter: AppEmitter =
+                            AppEmitter::new(Arc::new(TauriEmitter::new(app.clone()))
+                                as Arc<dyn DevshellEmitter>);
+                        let prepared = match devshell
+                            .prepare_for(Some(&emitter), &cwd_path, configured_mode)
+                            .await
+                        {
+                            Ok(prepared) => Some(prepared),
+                            Err(reason) => {
+                                if crate::commands::devshell::devshell_prepare_is_required(&enabled)
+                                {
+                                    return Err(format!("devshell prepare: {reason}"));
+                                }
+                                tracing::warn!(
+                                    target: "aethon::devshell",
+                                    "shell_open: devshell prepare failed for {}: {reason}; opening host shell",
+                                    cwd_path.display()
+                                );
+                                None
+                            }
+                        };
+                        if let Some(prepared) = prepared {
+                            tracing::debug!(
+                                target: "aethon::devshell",
+                                "shell_open: prepared {} devshell vars for tab {}",
+                                prepared.env.len(),
+                                args.tab_id
+                            );
+                            match kind {
+                                DevshellKind::Flake | DevshellKind::Direnv => {
+                                    launch_kind = Some(kind);
+                                }
+                                DevshellKind::Shell => {
+                                    prepared_env = Some((prepared.kind, prepared.env));
+                                }
+                            }
+                        }
+                    }
+                }
+                None if enabled == "always" => {
+                    let reason = format!("no devshell detected at {}", cwd_path.display());
+                    if let Some(error) =
+                        crate::commands::devshell::required_devshell_missing_error(&enabled, reason)
+                    {
+                        return Err(format!("devshell prepare: {error}"));
+                    }
+                }
+                None => {}
+            }
         }
     }
-    if let Some(cwd) = args.cwd.as_ref() {
-        cmd.cwd(cwd);
-    }
+
+    let disable_direnv_hooks = matches!(launch_kind, Some(DevshellKind::Flake))
+        || matches!(
+            detected_launch_kind,
+            Some(DevshellKind::Flake | DevshellKind::Shell)
+        )
+        || prepared_env
+            .as_ref()
+            .is_some_and(|(kind, _)| kind.as_deref() != Some("direnv"));
+    let launch_kind_for_log = launch_kind;
+    tracing::info!(
+        target: "aethon::devshell",
+        "shell_open: launching tab {} via {:?}: {} {:?}",
+        args.tab_id,
+        launch_kind_for_log,
+        command_program,
+        command_args
+    );
+    let mut cmd = devshell_launch_command(
+        launch_kind,
+        args.cwd.as_deref(),
+        &command_program,
+        &command_args,
+    )?;
     // Hermetic mode: drop the host env before stamping our own
     // baseline. `TERM`/`COLORTERM`/`AETHON` and the explicit per-tab
     // `env` table still get applied below so the shell remains usable.
@@ -110,42 +215,19 @@ pub async fn shell_open<R: Runtime>(
     cmd.env("AETHON", "1");
     clear_inherited_devshell_identity(&mut cmd);
     cmd.env("PATH", crate::env::resolved_project_path());
+    if disable_direnv_hooks {
+        cmd.env("DIRENV_DISABLE", "1");
+    }
 
-    // Devshell wrap: shells must enter the project environment on the
-    // first prompt. If a devshell is detected, block until it is ready
-    // and fail the open on resolver errors instead of spawning a plain
-    // host shell that can trip direnv's "blocked" prompt.
-    if let Some(cwd) = args.cwd.as_ref() {
-        let cwd_path = std::path::PathBuf::from(cwd);
-        let (enabled, configured_mode) = devshell_effective_config(&app, &cwd_path);
-        if enabled != "never" {
-            if let Some(reason) =
-                crate::commands::devshell::forced_mode_mismatch_reason(&cwd_path, configured_mode)
-            {
-                return Err(format!("devshell prepare: {reason}"));
-            }
-            let detected_kind = crate::devshell::detect_mode(&cwd_path, configured_mode);
-            if let Some(kind) = detected_kind {
-                if kind.as_str() == "direnv" {
-                    crate::commands::devshell::direnv_allow(&cwd_path).await?;
-                }
-                let emitter: AppEmitter = AppEmitter::new(
-                    Arc::new(TauriEmitter::new(app.clone())) as Arc<dyn DevshellEmitter>
-                );
-                let prepared = devshell
-                    .prepare_for(Some(&emitter), &cwd_path, configured_mode)
-                    .await
-                    .map_err(|e| format!("devshell prepare: {e}"))?;
-                tracing::debug!(
-                    target: "aethon::devshell",
-                    "shell_open: applying {} devshell vars to tab {}",
-                    prepared.env.len(),
-                    args.tab_id
-                );
-                for (k, v) in prepared.env {
-                    cmd.env(k, v);
-                }
-            }
+    if let Some((_kind, env)) = prepared_env {
+        tracing::debug!(
+            target: "aethon::devshell",
+            "shell_open: applying {} legacy devshell vars to tab {}",
+            env.len(),
+            args.tab_id
+        );
+        for (k, v) in env {
+            cmd.env(k, v);
         }
     }
 
@@ -196,9 +278,7 @@ pub async fn shell_open<R: Runtime>(
     );
 
     let display_cwd = args.cwd.clone().unwrap_or_default();
-    let display_command = effective_command
-        .map(str::to_string)
-        .unwrap_or_else(default_shell_label);
+    let display_command = command_program.clone();
     // No `effective_command` means we used the system shell — that child
     // *is* an interactive shell and manages a foreground process group.
     // A configured command means the child is the foreground job itself
@@ -249,6 +329,70 @@ pub async fn shell_open<R: Runtime>(
         let _ = handle.join();
     }
     Err(format!("shell already open for tab {}", args.tab_id))
+}
+
+fn devshell_launch_command(
+    launch_kind: Option<DevshellKind>,
+    cwd: Option<&str>,
+    command: &str,
+    args: &[String],
+) -> Result<CommandBuilder, String> {
+    devshell_launch_command_with_resolver(launch_kind, cwd, command, args, |program| {
+        crate::env::resolve_program(program).map(|path| path.to_string_lossy().to_string())
+    })
+}
+
+fn devshell_launch_command_with_resolver<F>(
+    launch_kind: Option<DevshellKind>,
+    cwd: Option<&str>,
+    command: &str,
+    args: &[String],
+    resolve_program: F,
+) -> Result<CommandBuilder, String>
+where
+    F: Fn(&str) -> Option<String>,
+{
+    let mut cmd = match launch_kind {
+        Some(DevshellKind::Flake) => {
+            let nix = resolve_program("nix")
+                .ok_or_else(|| "devshell prepare: nix is not on PATH".to_string())?;
+            let mut cmd = CommandBuilder::new(nix);
+            cmd.arg("develop");
+            cmd.arg("--accept-flake-config");
+            cmd.arg("--command");
+            cmd.arg(command);
+            for arg in args {
+                cmd.arg(arg);
+            }
+            cmd
+        }
+        Some(DevshellKind::Direnv) => {
+            let direnv = resolve_program("direnv")
+                .ok_or_else(|| "devshell prepare: direnv is not on PATH".to_string())?;
+            let Some(root) = cwd else {
+                return Err("devshell prepare: cwd is required for direnv".to_string());
+            };
+            let mut cmd = CommandBuilder::new(direnv);
+            cmd.arg("exec");
+            cmd.arg(root);
+            cmd.arg(command);
+            for arg in args {
+                cmd.arg(arg);
+            }
+            cmd
+        }
+        Some(DevshellKind::Shell) | None => {
+            let mut cmd = CommandBuilder::new(command);
+            for arg in args {
+                cmd.arg(arg);
+            }
+            cmd
+        }
+    };
+    if let Some(cwd) = cwd {
+        cmd.cwd(cwd);
+    }
+    Ok(cmd)
 }
 
 fn clear_inherited_devshell_identity(cmd: &mut CommandBuilder) {
@@ -349,18 +493,14 @@ pub(super) fn is_known_interactive_shell(command: &str) -> bool {
     SHELLS.iter().any(|s| s.eq_ignore_ascii_case(basename))
 }
 
-fn default_shell_command() -> CommandBuilder {
+fn default_shell_args() -> Vec<String> {
     #[cfg(unix)]
     {
-        let mut cmd = CommandBuilder::new(default_shell_label());
-        cmd.arg("-il");
-        cmd
+        vec!["-il".to_string()]
     }
     #[cfg(windows)]
     {
-        let mut cmd = CommandBuilder::new(default_shell_label());
-        cmd.arg("-NoLogo");
-        cmd
+        vec!["-NoLogo".to_string()]
     }
 }
 
@@ -377,7 +517,25 @@ fn default_shell_label() -> String {
 
 #[cfg(test)]
 mod shell_classification_tests {
-    use super::is_known_interactive_shell;
+    use std::ffi::OsString;
+
+    use super::{devshell_launch_command_with_resolver, is_known_interactive_shell};
+    use crate::devshell::detect::DevshellKind;
+
+    fn argv(cmd: &portable_pty::CommandBuilder) -> Vec<String> {
+        cmd.get_argv()
+            .iter()
+            .map(|item| item.to_string_lossy().to_string())
+            .collect()
+    }
+
+    fn fake_resolver(program: &str) -> Option<String> {
+        match program {
+            "nix" => Some("/bin/nix".to_string()),
+            "direnv" => Some("/bin/direnv".to_string()),
+            _ => None,
+        }
+    }
 
     #[test]
     fn classifies_common_unix_shells() {
@@ -416,5 +574,62 @@ mod shell_classification_tests {
                 "expected {cmd} to NOT be classified as an interactive shell",
             );
         }
+    }
+
+    #[test]
+    fn flake_devshell_wraps_shell_in_nix_develop_command() {
+        let cmd = devshell_launch_command_with_resolver(
+            Some(DevshellKind::Flake),
+            Some("/repo/worktree"),
+            "/bin/zsh",
+            &["-il".to_string()],
+            fake_resolver,
+        )
+        .unwrap();
+
+        assert_eq!(
+            argv(&cmd),
+            [
+                "/bin/nix",
+                "develop",
+                "--accept-flake-config",
+                "--command",
+                "/bin/zsh",
+                "-il"
+            ]
+        );
+        assert_eq!(cmd.get_cwd(), Some(&OsString::from("/repo/worktree")));
+    }
+
+    #[test]
+    fn direnv_devshell_wraps_command_in_direnv_exec_root() {
+        let cmd = devshell_launch_command_with_resolver(
+            Some(DevshellKind::Direnv),
+            Some("/repo/worktree"),
+            "menu",
+            &[],
+            fake_resolver,
+        )
+        .unwrap();
+
+        assert_eq!(
+            argv(&cmd),
+            ["/bin/direnv", "exec", "/repo/worktree", "menu"]
+        );
+        assert_eq!(cmd.get_cwd(), Some(&OsString::from("/repo/worktree")));
+    }
+
+    #[test]
+    fn direnv_devshell_requires_a_cwd_for_exec_root() {
+        let err = devshell_launch_command_with_resolver(
+            Some(DevshellKind::Direnv),
+            None,
+            "menu",
+            &[],
+            fake_resolver,
+        )
+        .unwrap_err();
+
+        assert_eq!(err, "devshell prepare: cwd is required for direnv");
     }
 }

--- a/src-tauri/src/shell/lifecycle/open.rs
+++ b/src-tauri/src/shell/lifecycle/open.rs
@@ -108,35 +108,41 @@ pub async fn shell_open<R: Runtime>(
     cmd.env("TERM", "xterm-256color");
     cmd.env("COLORTERM", "truecolor");
     cmd.env("AETHON", "1");
+    clear_inherited_devshell_identity(&mut cmd);
+    cmd.env("PATH", crate::env::resolved_project_path());
 
-    // Devshell wrap: if the cwd has a flake / direnv / shell.nix and
-    // the global config doesn't disable the feature, layer the
-    // resolved devshell env over the inherited host env. We apply
-    // *before* the user's per-tab `env` table so explicit overrides
-    // still win.
-    //
-    // The lookup is intentionally non-blocking: a `Resolving` slot
-    // returns immediately with an empty env, the shell spawns
-    // unwrapped, and the next shell open in this tab will be
-    // wrapped once the background resolver completes. The frontend
-    // listens for `devshell-ready` / `devshell-failed` to update
-    // the status badge.
+    // Devshell wrap: shells must enter the project environment on the
+    // first prompt. If a devshell is detected, block until it is ready
+    // and fail the open on resolver errors instead of spawning a plain
+    // host shell that can trip direnv's "blocked" prompt.
     if let Some(cwd) = args.cwd.as_ref() {
         let cwd_path = std::path::PathBuf::from(cwd);
-        let (enabled, mode) = devshell_effective_config(&app, &cwd_path);
+        let (enabled, configured_mode) = devshell_effective_config(&app, &cwd_path);
         if enabled != "never" {
-            let emitter: AppEmitter = AppEmitter::new(
-                Arc::new(TauriEmitter::new(app.clone())) as Arc<dyn DevshellEmitter>
-            );
-            let env_response = devshell.env_for(Some(&emitter), &cwd_path, mode).await;
-            if !env_response.env.is_empty() {
+            if let Some(reason) =
+                crate::commands::devshell::forced_mode_mismatch_reason(&cwd_path, configured_mode)
+            {
+                return Err(format!("devshell prepare: {reason}"));
+            }
+            let detected_kind = crate::devshell::detect_mode(&cwd_path, configured_mode);
+            if let Some(kind) = detected_kind {
+                if kind.as_str() == "direnv" {
+                    crate::commands::devshell::direnv_allow(&cwd_path).await?;
+                }
+                let emitter: AppEmitter = AppEmitter::new(
+                    Arc::new(TauriEmitter::new(app.clone())) as Arc<dyn DevshellEmitter>
+                );
+                let prepared = devshell
+                    .prepare_for(Some(&emitter), &cwd_path, configured_mode)
+                    .await
+                    .map_err(|e| format!("devshell prepare: {e}"))?;
                 tracing::debug!(
                     target: "aethon::devshell",
                     "shell_open: applying {} devshell vars to tab {}",
-                    env_response.env.len(),
+                    prepared.env.len(),
                     args.tab_id
                 );
-                for (k, v) in env_response.env {
+                for (k, v) in prepared.env {
                     cmd.env(k, v);
                 }
             }
@@ -243,6 +249,18 @@ pub async fn shell_open<R: Runtime>(
         let _ = handle.join();
     }
     Err(format!("shell already open for tab {}", args.tab_id))
+}
+
+fn clear_inherited_devshell_identity(cmd: &mut CommandBuilder) {
+    for key in [
+        "IN_NIX_SHELL",
+        "DEVSHELL_DIR",
+        "NIX_BUILD_TOP",
+        "NIX_ENFORCE_PURITY",
+        "name",
+    ] {
+        cmd.env(key, "");
+    }
 }
 
 /// Read `[devshell] enabled` + `mode` from the global config (and any

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,6 @@ import { useZoomAndTheme } from "./hooks/useZoomAndTheme";
 import { useShellConsent } from "./hooks/useShellConsent";
 import { useHostInfo } from "./hooks/useHostInfo";
 import { useDevshell, type DevshellEntry } from "./hooks/useDevshell";
-import { activeCwd as projectsActiveCwd, type ProjectsState } from "./projects";
 import { useProjects } from "./hooks/useProjects";
 import { useAgentWorkerReconcile } from "./hooks/useAgentWorkerReconcile";
 import { useAgentActivityHydration } from "./hooks/useAgentActivityHydration";
@@ -57,6 +56,7 @@ import { useAppBridgeMessages } from "./hooks/useAppBridgeMessages";
 import { closeAllWorkspaceSessions } from "./hooks/tabOps/closeWorkspaceSessions";
 import { writeState } from "./persist";
 import { useAppState } from "./state/appStore";
+import { activeWorkspaceCwd } from "./utils/activeWorkspaceRoot";
 import pkg from "../package.json" with { type: "json" };
 // Vite resolves `?url` imports to a hashed asset URL at build time. Injecting
 // the URL into layout state lets the header bind via `{"$ref": "/logoUrl"}`
@@ -198,15 +198,19 @@ export default function App() {
   // from Tauri events; the active host is a user-driven selection.
   const hostInfo = useHostInfo();
 
+  // Active workspace root. Root derivation mirrors the file tree
+  // (file-tree.tsx): the active worktree path when one is selected, else the
+  // active project's path, else the active editor tab's root — so devshell,
+  // VCS, and tree decoration all point at the same cwd.
+  const activeWorkspaceRoot = activeWorkspaceCwd(state);
+
   // Devshell badge wiring. Track the current project root; the hook
   // hydrates the chip from the Rust cache on switch and stays in
   // sync via the Tauri `devshell-*` events. Events are also
   // forwarded into the agent so the bash-tool spawnHook's cache
   // stays warm without polling.
-  const projectsSlice = state.projects as ProjectsState | undefined;
-  const devshellActiveRoot = projectsSlice ? projectsActiveCwd(projectsSlice) : null;
   useDevshell({
-    activeRoot: devshellActiveRoot,
+    activeRoot: activeWorkspaceRoot,
     setDevshellEntry: (root, patch) => {
       setState((s) => {
         const prev = (s.devshell as { entries?: Record<string, DevshellEntry> }) ?? {};
@@ -237,42 +241,11 @@ export default function App() {
   // VCS surface wiring. Polls working-tree changes + PR + CI status for the
   // active project/worktree root into the `/vcs` slice, consumed by the
   // header `vcs-status` cluster and the `source-control-panel` above the
-  // file tree. Root derivation mirrors the file tree (file-tree.tsx): the
-  // active worktree path when one is selected, else the active project's
-  // path, else the active editor tab's root — so when an editor is open on
-  // a git repo with no project selected, the VCS surface tracks the same
-  // root the tree is decorating. The file tree's final `~/.aethon` fallback
-  // is intentionally omitted: it is never a git repo, so `/vcs` would
-  // collapse anyway, and replicating the async home-dir fetch here is noise.
-  // (devshellActiveRoot reads a different state shape and can lag.)
-  const vcsActiveRoot = (() => {
-    const wtId = (state.activeWorktreeId as string | null) ?? null;
-    if (wtId) {
-      const projs =
-        ((state.sidebar as { projects?: Array<{ worktrees?: Array<{ id: string; path?: string }> }> } | undefined)
-          ?.projects) ?? [];
-      for (const p of projs) {
-        const wt = p.worktrees?.find((w) => w.id === wtId);
-        if (wt?.path) return wt.path;
-      }
-    }
-    const projectPath = (state.project as { path?: string } | null)?.path;
-    if (projectPath) return projectPath;
-    const tabs =
-      (state.tabs as
-        | Array<{ id: string; kind?: string; editor?: { rootPath?: string } }>
-        | undefined) ?? [];
-    const activeTabId = state.activeTabId as string | undefined;
-    const activeTab = activeTabId
-      ? tabs.find((t) => t.id === activeTabId)
-      : undefined;
-    if (activeTab?.kind === "editor" && activeTab.editor?.rootPath) {
-      return activeTab.editor.rootPath;
-    }
-    return null;
-  })();
-  useVcsStatus({ activeRoot: vcsActiveRoot, setState });
-  useGitWatch(vcsActiveRoot);
+  // file tree. The file tree's final `~/.aethon` fallback is intentionally
+  // omitted: it is never a git repo, so `/vcs` would collapse anyway, and
+  // replicating the async home-dir fetch here is noise.
+  useVcsStatus({ activeRoot: activeWorkspaceRoot, setState });
+  useGitWatch(activeWorkspaceRoot);
 
   // ---------------------------------------------------------------------
   // Tab lifecycle (create / switch / update / close / undo-close), the

--- a/src/extensions/default-layout/layout/status-bar.tsx
+++ b/src/extensions/default-layout/layout/status-bar.tsx
@@ -188,7 +188,7 @@ function devshellChipTooltip(entry: DevshellEntry): string | null {
       }
       break;
     case "resolving":
-      lines.push("Resolver running — first shell may use host env");
+      lines.push("Resolver running — new shells wait for the dev env");
       break;
     case "failed":
       if (entry.reason) lines.push(`Error: ${entry.reason}`);

--- a/src/extensions/default-layout/settings-panel/panel.tsx
+++ b/src/extensions/default-layout/settings-panel/panel.tsx
@@ -545,8 +545,10 @@ export function SettingsPanel({ state, onEvent }: BuiltinComponentProps) {
                     Auto (direnv when present, else flake, else shell.nix)
                   </option>
                   <option value="direnv">Force direnv exec</option>
-                  <option value="nix">Force nix print-dev-env (flake)</option>
-                  <option value="nix-shell">Force nix-shell (legacy)</option>
+                  <option value="nix">Force nix develop (flake)</option>
+                  <option value="nix-shell">
+                    Force Nix devshell (flake, legacy alias)
+                  </option>
                 </select>
               </Field>
               <Field label="Cache TTL (hours)">

--- a/src/extensions/default-layout/shell/panel.tsx
+++ b/src/extensions/default-layout/shell/panel.tsx
@@ -315,7 +315,13 @@ export function TerminalPanel({
             key={s.id}
             id={s.id}
             label={s.label || `Shell ${i + 1}`}
-            hint={s.shellState === "exited" ? "exited" : undefined}
+            hint={
+              s.shellState === "starting"
+                ? "starting"
+                : s.shellState === "exited"
+                  ? "exited"
+                  : undefined
+            }
             active={activeSubId === s.id}
             closable
             dragging={draggingSubTabId === s.id}

--- a/src/hooks/bridgeMessageHandlers/devshellQuery.test.ts
+++ b/src/hooks/bridgeMessageHandlers/devshellQuery.test.ts
@@ -59,6 +59,40 @@ describe("handleDevshellQuery", () => {
     expect(mocks.ackMutation).toHaveBeenCalledWith("m2", true, undefined, fakeResp);
   });
 
+  it("routes prepare_for_path op with includeEnv", async () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    const fakeResp = {
+      enabled: "auto",
+      mode: "auto",
+      state: "ready",
+      kind: "direnv",
+      stale: false,
+      varCount: 3,
+      env: { PATH: "/nix/store/bin" },
+    };
+    harness.invoke.mockResolvedValueOnce(fakeResp);
+    handleDevshellQuery(
+      {
+        type: "devshell_query",
+        op: "prepare_for_path",
+        mutationId: "m-prepare",
+        args: { cwd: "/proj", includeEnv: true },
+      },
+      ctx,
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(harness.invoke).toHaveBeenCalledWith("devshell_prepare_for_path", {
+      args: { cwd: "/proj", includeEnv: true },
+    });
+    expect(mocks.ackMutation).toHaveBeenCalledWith(
+      "m-prepare",
+      true,
+      undefined,
+      fakeResp,
+    );
+  });
+
   it("routes refresh op", async () => {
     const { ctx, mocks } = buildHandlerFixture();
     harness.invoke.mockResolvedValueOnce(undefined);

--- a/src/hooks/bridgeMessageHandlers/devshellQuery.ts
+++ b/src/hooks/bridgeMessageHandlers/devshellQuery.ts
@@ -4,9 +4,11 @@ import type { BridgeMessageHandler } from "./types";
 /** Bridge proxy for the agent's `aethon.devshell.*` queries
  *  (currently consumed by the bash spawnHook).
  *
- *  Three ops, mirroring the Rust IPC surface:
+ *  Four ops, mirroring the Rust IPC surface:
  *    - `status` — non-blocking snapshot for the status badge / agent
  *      hot-cache primer.
+ *    - `prepare_for_path` — blocking project/worktree preparation used before
+ *      provisioning an agent session.
  *    - `env_for_path` — non-blocking env lookup. The spawnHook
  *      consumes this; when state is still `Resolving` the response
  *      carries an empty `env` and the agent re-fetches after the
@@ -33,6 +35,14 @@ export const handleDevshellQuery: BridgeMessageHandler = (data, ctx) => {
       const cwd = args.cwd as string | undefined;
       if (!cwd) throw new Error("devshell_query.env_for_path requires cwd");
       return await invoke("devshell_env_for_path", { args: { cwd } });
+    }
+    if (op === "prepare_for_path") {
+      const cwd = args.cwd as string | undefined;
+      if (!cwd) throw new Error("devshell_query.prepare_for_path requires cwd");
+      const includeEnv = args.includeEnv === true;
+      return await invoke("devshell_prepare_for_path", {
+        args: { cwd, includeEnv },
+      });
     }
     if (op === "refresh") {
       const root = args.root as string | undefined;

--- a/src/hooks/osEdges/agentCrash.ts
+++ b/src/hooks/osEdges/agentCrash.ts
@@ -60,16 +60,24 @@ export function subscribeAgentCrash(deps: AgentCrashDeps): () => void {
 
   const unlistenCrashed = listen<{
     pid?: number;
+    key?: string;
     tabId?: string | null;
     stderrTail?: string[];
   }>("agent-crashed", (event) => {
     const tail = event.payload?.stderrTail ?? [];
+    const crashedKey = event.payload?.key;
     const crashedTabId =
       typeof event.payload?.tabId === "string" &&
       event.payload.tabId.length > 0
         ? event.payload.tabId
         : undefined;
-    const lastLine = tail.length > 0 ? tail[tail.length - 1] : "no stderr";
+    const globalOnlyCrash = !crashedTabId && crashedKey === "__global__";
+    const lastLine =
+      tail.length > 0
+        ? tail[tail.length - 1]
+        : crashedKey
+          ? `agent stdout closed unexpectedly (${crashedKey})`
+          : "agent stdout closed unexpectedly";
     activeResponseIdRef.current = null;
     if (crashedTabId) {
       const h = hangWarnTimersRef.current.get(crashedTabId);
@@ -87,6 +95,7 @@ export function subscribeAgentCrash(deps: AgentCrashDeps): () => void {
     }
     setState((prev) => {
       const tabs = ((prev.tabs as Tab[] | undefined) ?? []).map((t) => {
+        if (globalOnlyCrash) return t;
         if (crashedTabId && t.id !== crashedTabId) return t;
         const closedTools = closeRunningToolCards(t.messages, {
           notice: "Tool call did not finish before the agent crashed.",
@@ -105,7 +114,9 @@ export function subscribeAgentCrash(deps: AgentCrashDeps): () => void {
       const prevRunning =
         (prev.agentRunningTabs as Record<string, true> | undefined) ?? {};
       let agentRunningTabs: Record<string, true>;
-      if (crashedTabId) {
+      if (globalOnlyCrash) {
+        agentRunningTabs = prevRunning;
+      } else if (crashedTabId) {
         agentRunningTabs = { ...prevRunning };
         delete agentRunningTabs[crashedTabId];
       } else {
@@ -115,10 +126,10 @@ export function subscribeAgentCrash(deps: AgentCrashDeps): () => void {
         ...prev,
         tabs,
         agentRunningTabs,
-        ...(!crashedTabId || prev.activeTabId === crashedTabId
+        ...(!globalOnlyCrash && (!crashedTabId || prev.activeTabId === crashedTabId)
           ? { waiting: false, queueCount: 0 }
           : {}),
-        status: "agent crashed",
+        status: globalOnlyCrash ? "agent reloading" : "agent crashed",
       };
     });
     const willAutoRestart = autoRestartAgentRef.current;

--- a/src/hooks/osEdges/devshellOutput.test.ts
+++ b/src/hooks/osEdges/devshellOutput.test.ts
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { makeEmptyTab, type Tab } from "../../types/tab";
+import { clearTauriMocks, installTauriMocks } from "../../test/tauriMocks";
+import { subscribeDevshellOutput } from "./devshellOutput";
+
+const agentTab = (id: string, cwd: string): Tab => ({
+  ...makeEmptyTab(id, id, null),
+  cwd,
+});
+
+const shellTab = (id: string, cwd: string): Tab => ({
+  ...makeEmptyTab(id, id, null, "shell"),
+  shell: {
+    cwd,
+    command: "zsh",
+    args: [],
+    shareMode: "read",
+    shellState: "running",
+  },
+});
+
+describe("subscribeDevshellOutput", () => {
+  let harness: ReturnType<typeof installTauriMocks>;
+
+  beforeEach(() => {
+    harness = installTauriMocks();
+  });
+
+  afterEach(() => {
+    clearTauriMocks();
+  });
+
+  it("retains devshell output and appends it to matching agent and shell tabs", async () => {
+    let state: Record<string, unknown> = {
+      activeTabId: "agent-1",
+      terminalPanel: { activeSubId: "shell-1" },
+      tabs: [
+        agentTab("agent-1", "/repo/worktree"),
+        shellTab("shell-1", "/repo/worktree"),
+        agentTab("other", "/other"),
+      ],
+    };
+    const stateRef = { current: state };
+    const setState = vi.fn((updater: unknown) => {
+      state = (updater as (prev: Record<string, unknown>) => Record<string, unknown>)(
+        state,
+      );
+      stateRef.current = state;
+    });
+    const updateTab = vi.fn();
+    const events: Array<{ type: string; detail: unknown }> = [];
+    vi.spyOn(window, "dispatchEvent").mockImplementation((event: Event) => {
+      events.push({
+        type: event.type,
+        detail: event instanceof CustomEvent ? event.detail : undefined,
+      });
+      return true;
+    });
+
+    subscribeDevshellOutput({ stateRef, setState, updateTab });
+    await Promise.resolve();
+    expect(harness.fireEvent("devshell-output", {
+      root: "/repo",
+      content: "building drv\n",
+    })).toBe(1);
+
+    const tabs = state.tabs as Tab[];
+    expect(tabs.find((tab) => tab.id === "agent-1")?.terminalBuffer).toBe(
+      "building drv\r\n",
+    );
+    expect(tabs.find((tab) => tab.id === "shell-1")?.terminalBuffer).toBe(
+      "building drv\r\n",
+    );
+    expect(tabs.find((tab) => tab.id === "other")?.terminalBuffer).toBe("");
+    expect(
+      (state.devshell as { outputByRoot: Record<string, string> }).outputByRoot[
+        "/repo"
+      ],
+    ).toBe("building drv\r\n");
+    expect(
+      (state.terminal as { buffer: Record<string, string> }).buffer["shell-1"],
+    ).toBe("building drv\r\n");
+    expect(events).toContainEqual({
+      type: "aethon:terminal",
+      detail: "building drv\r\n",
+    });
+    expect(events).toContainEqual({
+      type: "aethon:shell-output:shell-1",
+      detail: "building drv\r\n",
+    });
+  });
+
+  it("writes resolving and ready status lines into retained output", async () => {
+    let state: Record<string, unknown> = {
+      tabs: [agentTab("agent-1", "/repo")],
+    };
+    const stateRef = { current: state };
+    const setState = vi.fn((updater: unknown) => {
+      state = (updater as (prev: Record<string, unknown>) => Record<string, unknown>)(
+        state,
+      );
+      stateRef.current = state;
+    });
+
+    subscribeDevshellOutput({ stateRef, setState, updateTab: vi.fn() });
+    await Promise.resolve();
+    harness.fireEvent("devshell-resolving", { root: "/repo", kind: "flake" });
+    harness.fireEvent("devshell-ready", {
+      root: "/repo",
+      kind: "flake",
+      durationMs: 1250,
+      varCount: 7,
+    });
+
+    const output =
+      (state.devshell as { outputByRoot: Record<string, string> }).outputByRoot[
+        "/repo"
+      ];
+    expect(output).toContain("Preparing Nix devshell");
+    expect(output).toContain("Nix devshell ready in 1.3s (7 vars)");
+  });
+});

--- a/src/hooks/osEdges/devshellOutput.ts
+++ b/src/hooks/osEdges/devshellOutput.ts
@@ -1,0 +1,90 @@
+import { listen } from "@tauri-apps/api/event";
+import type {
+  Dispatch,
+  MutableRefObject,
+  SetStateAction,
+} from "react";
+import type { Tab } from "../../types/tab";
+import { TERMINAL_REPLAY_MAX } from "../useTabs";
+
+export interface DevshellOutputDeps {
+  setState: Dispatch<SetStateAction<Record<string, unknown>>>;
+  stateRef: MutableRefObject<Record<string, unknown>>;
+  updateTab: (tabId: string, mutator: (tab: Tab) => Tab) => void;
+}
+
+interface DevshellOutputPayload {
+  root?: string;
+  kind?: string;
+  stream?: "status" | "stderr" | string;
+  content?: string;
+}
+
+export function subscribeDevshellOutput(deps: DevshellOutputDeps): () => void {
+  const unlisten = listen<DevshellOutputPayload>("devshell-output", (event) => {
+    const root = event.payload?.root;
+    const raw = event.payload?.content;
+    if (!root || typeof raw !== "string" || raw.length === 0) return;
+    const content = raw.replace(/\r?\n/g, "\r\n");
+    const state = deps.stateRef.current;
+    const tabs = ((state.tabs as Tab[] | undefined) ?? []).filter(
+      (tab) => tab.kind === "agent" && tab.cwd && isUnderRoot(tab.cwd, root),
+    );
+    if (tabs.length === 0) return;
+
+    for (const tab of tabs) {
+      deps.updateTab(tab.id, (current) => appendTerminal(current, content));
+    }
+
+    deps.setState((prev) => {
+      const term = (prev.terminal as Record<string, unknown> | undefined) ?? {};
+      const buffers = (term.buffer as Record<string, string> | undefined) ?? {};
+      const nextBuffers = { ...buffers };
+      for (const tab of tabs) {
+        nextBuffers[tab.id] = trimTerminal((nextBuffers[tab.id] ?? "") + content);
+      }
+      return {
+        ...prev,
+        terminal: {
+          ...term,
+          buffer: nextBuffers,
+        },
+      };
+    });
+
+    const activeTabId = state.activeTabId as string | undefined;
+    if (activeTabId && tabs.some((tab) => tab.id === activeTabId)) {
+      window.dispatchEvent(
+        new CustomEvent("aethon:terminal", { detail: content }),
+      );
+      window.dispatchEvent(
+        new CustomEvent("aethon:terminal-tap", {
+          detail: { tabId: activeTabId, content },
+        }),
+      );
+    }
+  });
+
+  return () => {
+    unlisten.then((fn) => fn());
+  };
+}
+
+function appendTerminal(tab: Tab, content: string): Tab {
+  return {
+    ...tab,
+    terminalBuffer: trimTerminal((tab.terminalBuffer ?? "") + content),
+  };
+}
+
+function trimTerminal(value: string): string {
+  return value.length > TERMINAL_REPLAY_MAX
+    ? value.slice(value.length - TERMINAL_REPLAY_MAX)
+    : value;
+}
+
+function isUnderRoot(cwd: string, root: string): boolean {
+  if (cwd === root) return true;
+  const prefix = root.endsWith("/") ? root : `${root}/`;
+  return cwd.startsWith(prefix);
+}

--- a/src/hooks/osEdges/devshellOutput.ts
+++ b/src/hooks/osEdges/devshellOutput.ts
@@ -20,54 +20,157 @@ interface DevshellOutputPayload {
   content?: string;
 }
 
+interface DevshellResolvingPayload {
+  root?: string;
+  kind?: string;
+}
+
+interface DevshellReadyPayload {
+  root?: string;
+  kind?: string;
+  durationMs?: number;
+  varCount?: number;
+}
+
+interface DevshellFailedPayload {
+  root?: string;
+  kind?: string;
+  reason?: string;
+}
+
 export function subscribeDevshellOutput(deps: DevshellOutputDeps): () => void {
-  const unlisten = listen<DevshellOutputPayload>("devshell-output", (event) => {
+  const unlistenOutput = listen<DevshellOutputPayload>("devshell-output", (event) => {
     const root = event.payload?.root;
     const raw = event.payload?.content;
     if (!root || typeof raw !== "string" || raw.length === 0) return;
-    const content = raw.replace(/\r?\n/g, "\r\n");
-    const state = deps.stateRef.current;
-    const tabs = ((state.tabs as Tab[] | undefined) ?? []).filter(
-      (tab) => tab.kind === "agent" && tab.cwd && isUnderRoot(tab.cwd, root),
-    );
-    if (tabs.length === 0) return;
-
-    for (const tab of tabs) {
-      deps.updateTab(tab.id, (current) => appendTerminal(current, content));
-    }
-
-    deps.setState((prev) => {
-      const term = (prev.terminal as Record<string, unknown> | undefined) ?? {};
-      const buffers = (term.buffer as Record<string, string> | undefined) ?? {};
-      const nextBuffers = { ...buffers };
-      for (const tab of tabs) {
-        nextBuffers[tab.id] = trimTerminal((nextBuffers[tab.id] ?? "") + content);
-      }
-      return {
-        ...prev,
-        terminal: {
-          ...term,
-          buffer: nextBuffers,
-        },
-      };
-    });
-
-    const activeTabId = state.activeTabId as string | undefined;
-    if (activeTabId && tabs.some((tab) => tab.id === activeTabId)) {
-      window.dispatchEvent(
-        new CustomEvent("aethon:terminal", { detail: content }),
-      );
-      window.dispatchEvent(
-        new CustomEvent("aethon:terminal-tap", {
-          detail: { tabId: activeTabId, content },
-        }),
-      );
-    }
+    appendForRoot(deps, root, raw);
   });
 
+  const unlistenResolving = listen<DevshellResolvingPayload>(
+    "devshell-resolving",
+    (event) => {
+      const { root, kind } = event.payload ?? {};
+      if (!root) return;
+      appendForRoot(
+        deps,
+        root,
+        `\r\n[devshell] Preparing ${kindLabel(kind)} devshell for this workspace...\r\n`,
+      );
+    },
+  );
+
+  const unlistenReady = listen<DevshellReadyPayload>("devshell-ready", (event) => {
+    const { root, kind, durationMs, varCount } = event.payload ?? {};
+    if (!root) return;
+    const duration =
+      typeof durationMs === "number" ? ` in ${(durationMs / 1000).toFixed(1)}s` : "";
+    const vars = typeof varCount === "number" ? ` (${varCount} vars)` : "";
+    appendForRoot(
+      deps,
+      root,
+      `[devshell] ${kindLabel(kind)} devshell ready${duration}${vars}\r\n`,
+    );
+  });
+
+  const unlistenFailed = listen<DevshellFailedPayload>(
+    "devshell-failed",
+    (event) => {
+      const { root, kind, reason } = event.payload ?? {};
+      if (!root) return;
+      appendForRoot(
+        deps,
+        root,
+        `[devshell] ${kindLabel(kind)} devshell failed${
+          reason ? `: ${reason}` : ""
+        }\r\n`,
+      );
+    },
+  );
+
   return () => {
-    unlisten.then((fn) => fn());
+    unlistenOutput.then(safeUnlisten).catch(() => {});
+    unlistenResolving.then(safeUnlisten).catch(() => {});
+    unlistenReady.then(safeUnlisten).catch(() => {});
+    unlistenFailed.then(safeUnlisten).catch(() => {});
   };
+}
+
+function safeUnlisten(fn: () => void): void {
+  try {
+    fn();
+  } catch {
+    // Reload/shutdown can invalidate Tauri listener ids before React cleanup.
+  }
+}
+
+function appendForRoot(
+  deps: DevshellOutputDeps,
+  root: string,
+  rawContent: string,
+): void {
+  const content = normalizeTerminal(rawContent);
+  if (!content) return;
+  const state = deps.stateRef.current;
+  const tabs = matchingTabs(state, root);
+
+  deps.setState((prev) => {
+    const term = (prev.terminal as Record<string, unknown> | undefined) ?? {};
+    const buffers = (term.buffer as Record<string, string> | undefined) ?? {};
+    const devshell =
+      (prev.devshell as Record<string, unknown> | undefined) ?? {};
+    const outputByRoot =
+      (devshell.outputByRoot as Record<string, string> | undefined) ?? {};
+    const tabs = (prev.tabs as Tab[] | undefined) ?? [];
+    const nextBuffers = { ...buffers };
+    const nextTabs = tabs.map((tab) => {
+      const cwd = cwdForTab(tab);
+      if (!cwd || !isUnderRoot(cwd, root)) {
+        return tab;
+      }
+      const next = appendTerminal(tab, content);
+      nextBuffers[tab.id] = next.terminalBuffer;
+      return next;
+    });
+
+    return {
+      ...prev,
+      tabs: nextTabs,
+      devshell: {
+        ...devshell,
+        outputByRoot: {
+          ...outputByRoot,
+          [root]: trimTerminal((outputByRoot[root] ?? "") + content),
+        },
+      },
+      terminal: {
+        ...term,
+        buffer: nextBuffers,
+      },
+    };
+  });
+
+  const activeTabId = state.activeTabId as string | undefined;
+  const terminalPanel =
+    state.terminalPanel as { activeSubId?: string } | undefined;
+  const activeSubId = terminalPanel?.activeSubId;
+  for (const tab of tabs) {
+    if (tab.kind === "shell") {
+      if (activeSubId === tab.id) {
+        window.dispatchEvent(
+          new CustomEvent(`aethon:shell-output:${tab.id}`, { detail: content }),
+        );
+      }
+    } else {
+      window.dispatchEvent(
+        new CustomEvent("aethon:terminal-tap", {
+          detail: { tabId: tab.id, content },
+        }),
+      );
+      if (activeTabId === tab.id) {
+        window.dispatchEvent(new CustomEvent("aethon:terminal", { detail: content }));
+      }
+    }
+  }
 }
 
 function appendTerminal(tab: Tab, content: string): Tab {
@@ -83,8 +186,33 @@ function trimTerminal(value: string): string {
     : value;
 }
 
+function normalizeTerminal(value: string): string {
+  return value.replace(/\r?\n/g, "\r\n");
+}
+
+function matchingTabs(state: Record<string, unknown>, root: string): Tab[] {
+  return ((state.tabs as Tab[] | undefined) ?? []).filter(
+    (tab) => {
+      const cwd = cwdForTab(tab);
+      return !!cwd && isUnderRoot(cwd, root);
+    },
+  );
+}
+
+function cwdForTab(tab: Tab): string | undefined {
+  if (tab.kind === "shell") return tab.shell?.cwd;
+  return tab.cwd;
+}
+
 function isUnderRoot(cwd: string, root: string): boolean {
   if (cwd === root) return true;
   const prefix = root.endsWith("/") ? root : `${root}/`;
   return cwd.startsWith(prefix);
+}
+
+function kindLabel(kind: string | undefined): string {
+  if (kind === "flake") return "Nix";
+  if (kind === "direnv") return "direnv";
+  if (kind === "shell") return "nix-shell";
+  return "Nix";
 }

--- a/src/hooks/tabOps/agentTab.test.ts
+++ b/src/hooks/tabOps/agentTab.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { MutableRefObject } from "react";
+import { invoke } from "@tauri-apps/api/core";
 import { useNewTab } from "./agentTab";
 import type { ProjectsState } from "../../projects";
 
@@ -10,6 +11,10 @@ vi.mock("@tauri-apps/api/core", () => ({
 const ref = <T>(value: T): MutableRefObject<T> => ({ current: value });
 
 describe("newTab restore handling", () => {
+  beforeEach(() => {
+    vi.mocked(invoke).mockClear();
+  });
+
   it("clears the closed-session suppression when a session is manually restored", () => {
     let state: Record<string, unknown> = {
       tabs: [],
@@ -45,5 +50,51 @@ describe("newTab restore handling", () => {
     expect((state.tabs as Array<{ id: string }>).map((t) => t.id)).toEqual([
       "restore-me",
     ]);
+  });
+
+  it("prepares the devshell before opening a cwd-backed agent tab", async () => {
+    const invokeMock = vi.mocked(invoke);
+    invokeMock.mockResolvedValue(null);
+    let state: Record<string, unknown> = { tabs: [] };
+    const stateRef = ref(state);
+    const setState = vi.fn((updater: unknown) => {
+      if (typeof updater !== "function") return;
+      state = (
+        updater as (prev: Record<string, unknown>) => Record<string, unknown>
+      )(state);
+      stateRef.current = state;
+    });
+    const pending = ref(new Map<string, Promise<unknown>>());
+    const newTab = useNewTab({
+      setState,
+      stateRef,
+      projectsRef: ref<ProjectsState>({
+        activeId: "p1",
+        activeWorktreeId: null,
+        activeHostId: null,
+        projects: [
+          {
+            id: "p1",
+            label: "Project",
+            path: "/proj",
+            lastUsed: 1,
+          },
+        ],
+        worktreesByProject: {},
+      }),
+      piDefaultModelRef: ref(""),
+      pendingTabOpens: pending,
+      appendSystem: vi.fn(),
+      dispatchTerminalReplay: vi.fn(),
+    });
+
+    newTab("tab-1", "Project");
+    await pending.current.get("tab-1");
+
+    expect(invokeMock.mock.calls[0]).toEqual([
+      "devshell_prepare_for_path",
+      { args: { cwd: "/proj", includeEnv: false } },
+    ]);
+    expect(invokeMock.mock.calls[1]?.[0]).toBe("agent_command");
   });
 });

--- a/src/hooks/tabOps/agentTab.test.ts
+++ b/src/hooks/tabOps/agentTab.test.ts
@@ -98,6 +98,58 @@ describe("newTab restore handling", () => {
     expect(invokeMock.mock.calls[1]?.[0]).toBe("agent_command");
   });
 
+  it("still opens the agent tab when frontend devshell prepare rejects", async () => {
+    const invokeMock = vi.mocked(invoke);
+    invokeMock.mockImplementation((command) =>
+      command === "devshell_prepare_for_path"
+        ? Promise.reject(new Error("ipc unavailable"))
+        : Promise.resolve(null),
+    );
+    let state: Record<string, unknown> = { tabs: [] };
+    const stateRef = ref(state);
+    const setState = vi.fn((updater: unknown) => {
+      if (typeof updater !== "function") return;
+      state = (
+        updater as (prev: Record<string, unknown>) => Record<string, unknown>
+      )(state);
+      stateRef.current = state;
+    });
+    const appendSystem = vi.fn();
+    const pending = ref(new Map<string, Promise<unknown>>());
+    const newTab = useNewTab({
+      setState,
+      stateRef,
+      projectsRef: ref<ProjectsState>({
+        activeId: "p1",
+        activeWorktreeId: null,
+        activeHostId: null,
+        projects: [
+          {
+            id: "p1",
+            label: "Project",
+            path: "/proj",
+            lastUsed: 1,
+          },
+        ],
+        worktreesByProject: {},
+      }),
+      piDefaultModelRef: ref(""),
+      pendingTabOpens: pending,
+      appendSystem,
+      dispatchTerminalReplay: vi.fn(),
+    });
+
+    newTab("tab-1", "Project");
+    await pending.current.get("tab-1");
+
+    expect(invokeMock.mock.calls[0]?.[0]).toBe("devshell_prepare_for_path");
+    expect(invokeMock.mock.calls[1]?.[0]).toBe("agent_command");
+    expect(appendSystem).toHaveBeenCalledWith(
+      "Devshell prepare failed for /proj: ipc unavailable. Opening tab with the host environment.",
+    );
+    expect((state.tabs as Array<{ waiting: boolean }>)[0].waiting).toBe(false);
+  });
+
   it("shows retained devshell output immediately when opening a cwd-backed agent tab", () => {
     let state: Record<string, unknown> = {
       tabs: [],
@@ -144,7 +196,9 @@ describe("newTab restore handling", () => {
 
     newTab("tab-1", "Project");
 
-    const tab = (state.tabs as Array<{ terminalBuffer: string; waiting: boolean }>)[0];
+    const tab = (
+      state.tabs as Array<{ terminalBuffer: string; waiting: boolean }>
+    )[0];
     expect(tab.terminalBuffer).toBe("building deps\r\n");
     expect(tab.waiting).toBe(true);
     expect(dispatchTerminalReplay).toHaveBeenCalledWith("building deps\r\n");

--- a/src/hooks/tabOps/agentTab.test.ts
+++ b/src/hooks/tabOps/agentTab.test.ts
@@ -97,4 +97,56 @@ describe("newTab restore handling", () => {
     ]);
     expect(invokeMock.mock.calls[1]?.[0]).toBe("agent_command");
   });
+
+  it("shows retained devshell output immediately when opening a cwd-backed agent tab", () => {
+    let state: Record<string, unknown> = {
+      tabs: [],
+      devshell: {
+        outputByRoot: {
+          "/proj": "building deps\r\n",
+        },
+        entries: {
+          "/proj": { state: "resolving" },
+        },
+      },
+    };
+    const stateRef = ref(state);
+    const setState = vi.fn((updater: unknown) => {
+      if (typeof updater !== "function") return;
+      state = (
+        updater as (prev: Record<string, unknown>) => Record<string, unknown>
+      )(state);
+      stateRef.current = state;
+    });
+    const dispatchTerminalReplay = vi.fn();
+    const newTab = useNewTab({
+      setState,
+      stateRef,
+      projectsRef: ref<ProjectsState>({
+        activeId: "p1",
+        activeWorktreeId: null,
+        activeHostId: null,
+        projects: [
+          {
+            id: "p1",
+            label: "Project",
+            path: "/proj",
+            lastUsed: 1,
+          },
+        ],
+        worktreesByProject: {},
+      }),
+      piDefaultModelRef: ref(""),
+      pendingTabOpens: ref(new Map()),
+      appendSystem: vi.fn(),
+      dispatchTerminalReplay,
+    });
+
+    newTab("tab-1", "Project");
+
+    const tab = (state.tabs as Array<{ terminalBuffer: string; waiting: boolean }>)[0];
+    expect(tab.terminalBuffer).toBe("building deps\r\n");
+    expect(tab.waiting).toBe(true);
+    expect(dispatchTerminalReplay).toHaveBeenCalledWith("building deps\r\n");
+  });
 });

--- a/src/hooks/tabOps/agentTab.ts
+++ b/src/hooks/tabOps/agentTab.ts
@@ -154,33 +154,43 @@ export function useNewTab(deps: NewTabDeps) {
     dispatchTerminalReplay(initialTerminalBuffer);
     const opening = (async () => {
       if (inheritedCwd) {
-        const prepared = await invoke<{
-          state?: string;
-          kind?: string | null;
-          reason?: string | null;
-        }>("devshell_prepare_for_path", {
-          args: { cwd: inheritedCwd, includeEnv: false },
-        });
-        if (prepared?.state === "failed") {
+        try {
+          const prepared = await invoke<{
+            state?: string;
+            kind?: string | null;
+            reason?: string | null;
+          }>("devshell_prepare_for_path", {
+            args: { cwd: inheritedCwd, includeEnv: false },
+          });
+          if (prepared?.state === "failed") {
+            appendSystem(
+              `Devshell prepare failed for ${inheritedCwd}${
+                prepared.reason ? `: ${prepared.reason}` : ""
+              }. Opening tab with the host environment.`,
+            );
+          }
+        } catch (err) {
+          const reason = err instanceof Error ? err.message : String(err);
           appendSystem(
             `Devshell prepare failed for ${inheritedCwd}${
-              prepared.reason ? `: ${prepared.reason}` : ""
+              reason ? `: ${reason}` : ""
             }. Opening tab with the host environment.`,
           );
+        } finally {
+          setState((prev) => {
+            const tabs = ((prev.tabs as Tab[] | undefined) ?? []).map((tab) =>
+              tab.id === id && tab.waiting === true
+                ? { ...tab, waiting: false }
+                : tab,
+            );
+            const activeTabId = prev.activeTabId;
+            return {
+              ...prev,
+              tabs,
+              ...(activeTabId === id ? { waiting: false } : {}),
+            };
+          });
         }
-        setState((prev) => {
-          const tabs = ((prev.tabs as Tab[] | undefined) ?? []).map((tab) =>
-            tab.id === id && tab.waiting === true
-              ? { ...tab, waiting: false }
-              : tab,
-          );
-          const activeTabId = prev.activeTabId;
-          return {
-            ...prev,
-            tabs,
-            ...(activeTabId === id ? { waiting: false } : {}),
-          };
-        });
       }
       return await invoke("agent_command", {
         payload: JSON.stringify({

--- a/src/hooks/tabOps/agentTab.ts
+++ b/src/hooks/tabOps/agentTab.ts
@@ -5,6 +5,10 @@ import type { ProjectsState } from "../../projects";
 import { recomputeModelPicker } from "../../utils/modelPicker";
 import { TAB_MIRROR_KEYS } from "./constants";
 import {
+  devshellNeedsPreparation,
+  initialDevshellTerminalBuffer,
+} from "./devshellTerminal";
+import {
   cwdForNewTab,
   modelForNewProjectTab,
   sessionLabelFromMessages,
@@ -93,6 +97,12 @@ export function useNewTab(deps: NewTabDeps) {
       piDefaultModelRef.current,
       options?.model,
     );
+    const initialTerminalBuffer = inheritedCwd
+      ? initialDevshellTerminalBuffer(stateRef.current, inheritedCwd)
+      : "";
+    const preparingDevshell = inheritedCwd
+      ? devshellNeedsPreparation(stateRef.current, inheritedCwd)
+      : false;
     const existingSessionLabel = restoreId
       ? sessionLabelFromMessages(
           ((stateRef.current.tabs as Tab[] | undefined) ?? []).find(
@@ -107,6 +117,8 @@ export function useNewTab(deps: NewTabDeps) {
       const tab: Tab = {
         ...makeEmptyTab(id, label, projectId),
         model: inheritedModel,
+        terminalBuffer: initialTerminalBuffer,
+        waiting: preparingDevshell,
         ...(inheritedCwd ? { cwd: inheritedCwd } : {}),
       };
       tabs.push(tab);
@@ -139,7 +151,7 @@ export function useNewTab(deps: NewTabDeps) {
     });
     // Clear the shared xterm so it doesn't keep showing the previous
     // tab's scrollback until the next switch / output event.
-    dispatchTerminalReplay("");
+    dispatchTerminalReplay(initialTerminalBuffer);
     const opening = (async () => {
       if (inheritedCwd) {
         const prepared = await invoke<{
@@ -156,6 +168,19 @@ export function useNewTab(deps: NewTabDeps) {
             }. Opening tab with the host environment.`,
           );
         }
+        setState((prev) => {
+          const tabs = ((prev.tabs as Tab[] | undefined) ?? []).map((tab) =>
+            tab.id === id && tab.waiting === true
+              ? { ...tab, waiting: false }
+              : tab,
+          );
+          const activeTabId = prev.activeTabId;
+          return {
+            ...prev,
+            tabs,
+            ...(activeTabId === id ? { waiting: false } : {}),
+          };
+        });
       }
       return await invoke("agent_command", {
         payload: JSON.stringify({

--- a/src/hooks/tabOps/agentTab.ts
+++ b/src/hooks/tabOps/agentTab.ts
@@ -140,15 +140,33 @@ export function useNewTab(deps: NewTabDeps) {
     // Clear the shared xterm so it doesn't keep showing the previous
     // tab's scrollback until the next switch / output event.
     dispatchTerminalReplay("");
-    const opening = invoke("agent_command", {
-      payload: JSON.stringify({
-        type: "tab_open",
-        tabId: id,
-        ...(inheritedModel ? { model: inheritedModel } : {}),
-        ...(inheritedCwd ? { cwd: inheritedCwd } : {}),
-        ...(options?.restoredSession ? { restoreHistory: true } : {}),
-      }),
-    });
+    const opening = (async () => {
+      if (inheritedCwd) {
+        const prepared = await invoke<{
+          state?: string;
+          kind?: string | null;
+          reason?: string | null;
+        }>("devshell_prepare_for_path", {
+          args: { cwd: inheritedCwd, includeEnv: false },
+        });
+        if (prepared?.state === "failed") {
+          appendSystem(
+            `Devshell prepare failed for ${inheritedCwd}${
+              prepared.reason ? `: ${prepared.reason}` : ""
+            }. Opening tab with the host environment.`,
+          );
+        }
+      }
+      return await invoke("agent_command", {
+        payload: JSON.stringify({
+          type: "tab_open",
+          tabId: id,
+          ...(inheritedModel ? { model: inheritedModel } : {}),
+          ...(inheritedCwd ? { cwd: inheritedCwd } : {}),
+          ...(options?.restoredSession ? { restoreHistory: true } : {}),
+        }),
+      });
+    })();
     pendingTabOpens.current.set(id, opening);
     opening
       .catch((err) => {

--- a/src/hooks/tabOps/devshellTerminal.test.ts
+++ b/src/hooks/tabOps/devshellTerminal.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  devshellNeedsPreparation,
+  initialDevshellTerminalBuffer,
+} from "./devshellTerminal";
+import { TERMINAL_REPLAY_MAX } from "./constants";
+
+describe("devshell terminal seed helpers", () => {
+  it("seeds a loading line when the matching workspace devshell is resolving", () => {
+    const state = {
+      devshell: {
+        entries: {
+          "/worktrees/nyc": { state: "resolving" },
+        },
+      },
+    };
+
+    expect(devshellNeedsPreparation(state, "/worktrees/nyc/feature")).toBe(true);
+    expect(initialDevshellTerminalBuffer(state, "/worktrees/nyc/feature")).toBe(
+      "[devshell] Preparing Nix devshell for this workspace...\r\n",
+    );
+  });
+
+  it("replays retained output from the most specific matching workspace root", () => {
+    const state = {
+      devshell: {
+        entries: {
+          "/worktrees/nyc": { state: "resolving" },
+          "/worktrees/nyc/feature": { state: "ready" },
+        },
+        outputByRoot: {
+          "/worktrees/nyc": "parent output\r\n",
+          "/worktrees/nyc/feature": "feature output\r\n",
+        },
+      },
+    };
+
+    expect(initialDevshellTerminalBuffer(state, "/worktrees/nyc/feature")).toBe(
+      "feature output\r\n",
+    );
+  });
+
+  it("trims retained output to the terminal replay cap", () => {
+    const output = "x".repeat(TERMINAL_REPLAY_MAX + 10);
+    const state = {
+      devshell: {
+        outputByRoot: {
+          "/repo": output,
+        },
+      },
+    };
+
+    const seeded = initialDevshellTerminalBuffer(state, "/repo");
+    expect(seeded).toHaveLength(TERMINAL_REPLAY_MAX);
+    expect(seeded).toBe(output.slice(10));
+  });
+});

--- a/src/hooks/tabOps/devshellTerminal.ts
+++ b/src/hooks/tabOps/devshellTerminal.ts
@@ -1,0 +1,67 @@
+import { TERMINAL_REPLAY_MAX } from "./constants";
+
+const PREPARING_MESSAGE =
+  "[devshell] Preparing Nix devshell for this workspace...\r\n";
+
+export function initialDevshellTerminalBuffer(
+  state: Record<string, unknown>,
+  cwd: string,
+): string {
+  const existing = devshellOutputForCwd(state, cwd);
+  if (existing) return existing;
+  return devshellNeedsPreparation(state, cwd) ? PREPARING_MESSAGE : "";
+}
+
+export function devshellNeedsPreparation(
+  state: Record<string, unknown>,
+  cwd: string,
+): boolean {
+  const entry = devshellEntryForCwd(state, cwd);
+  if (!entry) return false;
+  return entry.state === "idle" || entry.state === "resolving";
+}
+
+function devshellOutputForCwd(
+  state: Record<string, unknown>,
+  cwd: string,
+): string {
+  const devshell = state.devshell as Record<string, unknown> | undefined;
+  const outputByRoot =
+    (devshell?.outputByRoot as Record<string, string> | undefined) ?? {};
+  let bestRoot = "";
+  let bestBuffer = "";
+  for (const [root, buffer] of Object.entries(outputByRoot)) {
+    if (typeof buffer !== "string") continue;
+    if (isUnderRoot(cwd, root) && root.length > bestRoot.length) {
+      bestRoot = root;
+      bestBuffer = buffer;
+    }
+  }
+  return bestBuffer.length > TERMINAL_REPLAY_MAX
+    ? bestBuffer.slice(bestBuffer.length - TERMINAL_REPLAY_MAX)
+    : bestBuffer;
+}
+
+function devshellEntryForCwd(
+  state: Record<string, unknown>,
+  cwd: string,
+): { state?: string } | null {
+  const devshell = state.devshell as Record<string, unknown> | undefined;
+  const entries =
+    (devshell?.entries as Record<string, { state?: string }> | undefined) ?? {};
+  let bestRoot = "";
+  let bestEntry: { state?: string } | null = null;
+  for (const [root, entry] of Object.entries(entries)) {
+    if (isUnderRoot(cwd, root) && root.length > bestRoot.length) {
+      bestRoot = root;
+      bestEntry = entry;
+    }
+  }
+  return bestEntry;
+}
+
+function isUnderRoot(cwd: string, root: string): boolean {
+  if (cwd === root) return true;
+  const prefix = root.endsWith("/") ? root : `${root}/`;
+  return cwd.startsWith(prefix);
+}

--- a/src/hooks/tabOps/shellTab.test.ts
+++ b/src/hooks/tabOps/shellTab.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MutableRefObject } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { useNewShellTab } from "./shellTab";
+import type { ProjectsState } from "../../projects";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(() => Promise.resolve(null)),
+}));
+
+const ref = <T>(value: T): MutableRefObject<T> => ({ current: value });
+
+describe("newShellTab", () => {
+  beforeEach(() => {
+    vi.mocked(invoke).mockClear();
+  });
+
+  it("opens a project shell tab with retained devshell output visible immediately", () => {
+    let state: Record<string, unknown> = {
+      tabs: [],
+      devshell: {
+        outputByRoot: {
+          "/proj": "[devshell] Preparing Nix devshell for this workspace...\r\n",
+        },
+        entries: {
+          "/proj": { state: "resolving" },
+        },
+      },
+    };
+    const stateRef = ref(state);
+    const setState = vi.fn((updater: unknown) => {
+      if (typeof updater !== "function") return;
+      state = (
+        updater as (prev: Record<string, unknown>) => Record<string, unknown>
+      )(state);
+      stateRef.current = state;
+    });
+
+    const newShellTab = useNewShellTab({
+      setState,
+      stateRef,
+      projectsRef: ref<ProjectsState>({
+        activeId: "p1",
+        activeWorktreeId: null,
+        activeHostId: null,
+        projects: [
+          {
+            id: "p1",
+            label: "Project",
+            path: "/proj",
+            lastUsed: 1,
+          },
+        ],
+        worktreesByProject: {},
+      }),
+      appendSystem: vi.fn(),
+      defaultShareModeRef: ref("read"),
+      shellDefaultCommandRef: ref(null),
+      shellDefaultArgsRef: ref([]),
+      shellInheritEnvRef: ref(true),
+      updateTab: vi.fn(),
+    });
+
+    newShellTab();
+
+    const tab = (
+      state.tabs as Array<{
+        id: string;
+        terminalBuffer: string;
+        shell: { cwd: string; shellState: string };
+      }>
+    )[0];
+    expect(tab.terminalBuffer).toBe(
+      "[devshell] Preparing Nix devshell for this workspace...\r\n",
+    );
+    expect(tab.shell).toMatchObject({ cwd: "/proj", shellState: "starting" });
+    expect(state.terminalPanel).toMatchObject({ activeSubId: tab.id });
+    expect(invoke).toHaveBeenCalledWith("shell_open", {
+      args: {
+        tabId: tab.id,
+        cwd: "/proj",
+        shareMode: "read",
+      },
+    });
+  });
+});

--- a/src/hooks/tabOps/shellTab.ts
+++ b/src/hooks/tabOps/shellTab.ts
@@ -2,6 +2,7 @@ import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { makeEmptyTab, type ShellMeta, type Tab } from "../../types/tab";
 import type { ProjectsState } from "../../projects";
+import { initialDevshellTerminalBuffer } from "./devshellTerminal";
 import { cwdForNewTab } from "./helpers";
 
 export interface NewShellTabDeps {
@@ -58,12 +59,16 @@ export function useNewShellTab(deps: NewShellTabDeps) {
         ? shellDefaultArgsRef.current
         : undefined);
     const inheritEnv = shellInheritEnvRef.current;
+    const initialTerminalBuffer = inheritedCwd
+      ? initialDevshellTerminalBuffer(stateRef.current, inheritedCwd)
+      : "";
     setState((prev) => {
       const tabs = ((prev.tabs as Tab[] | undefined) ?? []).slice();
       const label = `Shell ${tabs.filter((t) => t.kind === "shell").length + 1}`;
       const projectId = projectsRef.current.activeId;
       const tab: Tab = {
         ...makeEmptyTab(id, label, projectId, "shell"),
+        terminalBuffer: initialTerminalBuffer,
         shell: {
           cwd: inheritedCwd ?? "",
           command: resolvedCommand ?? "",

--- a/src/hooks/useAgentActivityHydration.ts
+++ b/src/hooks/useAgentActivityHydration.ts
@@ -15,6 +15,20 @@ export interface AgentDiagnosticRow {
   alive?: boolean;
   prompt_in_flight?: boolean;
   promptInFlight?: boolean;
+  process?: {
+    pid: number;
+    ppid?: number | null;
+    cpuPercent?: number | null;
+    rssBytes?: number | null;
+    command?: string | null;
+  } | null;
+  children?: Array<{
+    pid: number;
+    ppid?: number | null;
+    cpuPercent?: number | null;
+    rssBytes?: number | null;
+    command?: string | null;
+  }>;
 }
 
 export interface HydrateAgentActivityOptions {

--- a/src/hooks/useDevshell.ts
+++ b/src/hooks/useDevshell.ts
@@ -131,6 +131,20 @@ export function useDevshell(opts: UseDevshellOptions): void {
   useEffect(() => {
     let unlisteners: UnlistenFn[] = [];
     let cancelled = false;
+    const hydrateRootStatus = async (root: string) => {
+      try {
+        const result = await invoke<StatusResponse>("devshell_status", {
+          args: { root },
+        });
+        const entry = entryFromStatus(result);
+        if (entry) {
+          optsRef.current.setDevshellEntry(root, entry);
+        }
+      } catch {
+        // Lifecycle events already updated state; config metadata
+        // hydration is best-effort.
+      }
+    };
     void (async () => {
       try {
         // Push events carry only what the resolver knows (kind +
@@ -149,6 +163,7 @@ export function useDevshell(opts: UseDevshellOptions): void {
               detectedKind: kind,
               state: "resolving",
             });
+            void hydrateRootStatus(root);
             forwardToAgent(root, kind, "resolving");
           },
         );
@@ -162,6 +177,7 @@ export function useDevshell(opts: UseDevshellOptions): void {
             durationMs,
             varCount,
           });
+          void hydrateRootStatus(root);
           forwardToAgent(root, kind, "ready");
         });
         const offFailed = await listen<FailedPayload>("devshell-failed", (event) => {
@@ -172,12 +188,13 @@ export function useDevshell(opts: UseDevshellOptions): void {
             state: "failed",
             reason,
           });
+          void hydrateRootStatus(root);
           forwardToAgent(root, kind, "failed");
         });
         if (cancelled) {
-          offResolving();
-          offReady();
-          offFailed();
+          safeUnlisten(offResolving);
+          safeUnlisten(offReady);
+          safeUnlisten(offFailed);
           return;
         }
         unlisteners = [offResolving, offReady, offFailed];
@@ -187,9 +204,18 @@ export function useDevshell(opts: UseDevshellOptions): void {
     })();
     return () => {
       cancelled = true;
-      for (const fn of unlisteners) fn();
+      for (const fn of unlisteners) safeUnlisten(fn);
     };
   }, []);
+}
+
+function safeUnlisten(fn: UnlistenFn): void {
+  try {
+    fn();
+  } catch {
+    // Tauri can already have dropped listener ids during webview reload or
+    // app shutdown. Cleanup is best-effort; avoid surfacing teardown noise.
+  }
 }
 
 function entryFromStatus(s: StatusResponse): DevshellEntry | null {

--- a/src/hooks/useOsEdges.ts
+++ b/src/hooks/useOsEdges.ts
@@ -3,6 +3,7 @@ import { subscribeShellStreams } from "./osEdges/shellStreams";
 import { subscribeAgentReload } from "./osEdges/agentReload";
 import { subscribeAgentCrash } from "./osEdges/agentCrash";
 import { subscribeAgentStderr } from "./osEdges/agentStderr";
+import { subscribeDevshellOutput } from "./osEdges/devshellOutput";
 import { subscribeMenu } from "./osEdges/menu";
 import { subscribeDragDrop } from "./osEdges/dragDrop";
 import { subscribeClipboardPaste } from "./osEdges/clipboardPaste";
@@ -70,6 +71,11 @@ export function useOsEdges(ctx: UseOsEdgesContext): void {
       subscribeAgentStderr({
         appendMessage: ctx.appendMessage,
         persistLocalChatMessage: ctx.persistLocalChatMessage,
+      }),
+      subscribeDevshellOutput({
+        setState: ctx.setState,
+        stateRef: ctx.stateRef,
+        updateTab: ctx.updateTab,
       }),
       subscribeMenu({
         stateRef: ctx.stateRef,

--- a/src/utils/activeWorkspaceRoot.test.ts
+++ b/src/utils/activeWorkspaceRoot.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { activeWorkspaceCwd } from "./activeWorkspaceRoot";
+
+describe("activeWorkspaceCwd", () => {
+  it("prefers the selected worktree path over the parent project path", () => {
+    expect(
+      activeWorkspaceCwd({
+        activeWorktreeId: "wt-2",
+        project: { path: "/projects/nyc-real-estate" },
+        sidebar: {
+          projects: [
+            {
+              worktrees: [
+                { id: "wt-1", path: "/worktrees/other" },
+                { id: "wt-2", path: "/worktrees/nyc-real-estate/feature" },
+              ],
+            },
+          ],
+        },
+      }),
+    ).toBe("/worktrees/nyc-real-estate/feature");
+  });
+
+  it("falls back to the active project path", () => {
+    expect(activeWorkspaceCwd({ project: { path: "/projects/aethon" } })).toBe(
+      "/projects/aethon",
+    );
+  });
+
+  it("uses the active editor root only when no project/worktree is active", () => {
+    expect(
+      activeWorkspaceCwd({
+        activeTabId: "editor-1",
+        tabs: [
+          {
+            id: "editor-1",
+            kind: "editor",
+            editor: { rootPath: "/tmp/editor-repo" },
+          },
+        ],
+      }),
+    ).toBe("/tmp/editor-repo");
+  });
+});

--- a/src/utils/activeWorkspaceRoot.ts
+++ b/src/utils/activeWorkspaceRoot.ts
@@ -1,0 +1,36 @@
+export function activeWorkspaceCwd(
+  state: Record<string, unknown>,
+): string | null {
+  const wtId =
+    typeof state.activeWorktreeId === "string" && state.activeWorktreeId.length > 0
+      ? state.activeWorktreeId
+      : null;
+  if (wtId) {
+    const projects =
+      ((state.sidebar as
+        | { projects?: Array<{ worktrees?: Array<{ id?: string; path?: string }> }> }
+        | undefined)?.projects) ?? [];
+    for (const project of projects) {
+      const worktree = project.worktrees?.find((w) => w.id === wtId);
+      if (worktree?.path) return worktree.path;
+    }
+  }
+
+  const projectPath =
+    (state.project as { path?: string } | null | undefined)?.path ?? null;
+  if (projectPath) return projectPath;
+
+  const tabs =
+    (state.tabs as
+      | Array<{ id: string; kind?: string; editor?: { rootPath?: string } }>
+      | undefined) ?? [];
+  const activeTabId =
+    typeof state.activeTabId === "string" ? state.activeTabId : undefined;
+  const activeTab = activeTabId
+    ? tabs.find((t) => t.id === activeTabId)
+    : undefined;
+  if (activeTab?.kind === "editor" && activeTab.editor?.rootPath) {
+    return activeTab.editor.rootPath;
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary

This PR fixes the devshell/session regressions that made Aethon feel unstable with multiple active worktrees and agent sessions:

- runs agent workers and user shell tabs inside the selected project/worktree devshell instead of inheriting the Aethon launch shell
- treats the settings resolver mode as authoritative: forced Nix devshell uses `nix develop` for flake workspaces and does not silently fall back to direnv
- streams `nix develop`/devshell preparation output into the Agent bash/session terminal while the environment is being prepared
- seeds new agent and shell tabs with an intuitive devshell loading/retained-output state instead of a blank terminal
- prevents quiet `__global__` agent EOF from surfacing as a no-stderr crash loop
- keeps `enabled = "always"` strict while preserving best-effort host fallback for `enabled = "auto"` resolver failures

## Root Cause

Aethon had three overlapping problems:

1. Frontend active-root derivation used a stale project slice, so devshell/VCS state could point at the app launch repo instead of the selected worktree.
2. Shell and worker process launch paths applied cached env maps but did not actually launch interactive shells through the chosen flake devshell, allowing login-shell direnv hooks or inherited launch env to win.
3. Resolver output was buffered too late and `__global__` helper exits were treated like worker crashes, creating confusing UI states and noisy no-stderr crash reports.

A Codex peer review also caught follow-up correctness gaps before publication: strict `always` semantics were missing from shell/agent launch paths, auto-mode resolver failures were too hard, and flake stdout was not truly streamed before process exit. Those are addressed in the final commit.

## What Changed

- Added a shared active-workspace-root helper so devshell and VCS use the selected worktree path first, then project path, then editor root.
- Changed flake devshell resolution from static `nix print-dev-env` parsing to real `nix develop --accept-flake-config --command sh -lc ...` env capture.
- Added live stdout/stderr resolver progress events, with stdout streamed up to the env sentinel so build/shell-hook output appears in the Agent bash terminal immediately.
- Wrapped flake user shells as `nix develop --accept-flake-config --command <shell> ...`; direnv shells still use `direnv exec`; legacy `shell.nix` applies prepared env directly.
- Prepared agent workers before spawn, applied the selected worktree cwd/env, and disabled direnv hooks for non-direnv prepared envs.
- Added retained devshell terminal buffers and loading messages for new agent/shell tabs while the devshell is resolving.
- Suppressed quiet global-agent EOF crash events while preserving per-tab worker crash diagnostics.
- Added tests for detection semantics, resolver streaming, shell argv wrapping, devshell output routing, tab loading state, active workspace root selection, and global EOF behavior.

## Validation

- Codex peer review: completed; all actionable findings addressed.
- `bunx tsc --noEmit --pretty false`
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- `bunx vitest run src/utils/activeWorkspaceRoot.test.ts src/hooks/tabOps/devshellTerminal.test.ts src/hooks/osEdges/devshellOutput.test.ts src/hooks/tabOps/agentTab.test.ts src/hooks/tabOps/shellTab.test.ts`
- `cargo test --manifest-path src-tauri/Cargo.toml -p aethon --no-default-features devshell -- --nocapture`
- `cargo test --manifest-path src-tauri/Cargo.toml -p aethon --no-default-features quiet_global_stdout_eof -- --nocapture`
- `bunx vitest run` — 253 files / 2064 tests passed
- `cargo test --manifest-path src-tauri/Cargo.toml -p aethon --no-default-features --lib` — 355 tests passed
- `check` — clippy, TypeScript build, ESLint, cargo test --lib, and Vitest passed; final run reported 395 Rust tests passed, 2 ignored, and 2064 Vitest tests passed
