### PR TITLE
fix: stabilize agent sessions and worktree routing

### DIFF
--- a/agent/auth-profiles/manager.ts
+++ b/agent/auth-profiles/manager.ts
@@ -671,7 +671,7 @@ async function handleUseForTab(
       : "",
   });
   emitAuthProfiles(state, deps);
-  emitGlobalReady(state, deps);
+  await emitGlobalReady(state, deps);
 }
 
 function handleSetDefault(

--- a/agent/devshell/client.test.ts
+++ b/agent/devshell/client.test.ts
@@ -266,6 +266,42 @@ describe("onDevshellEvent", () => {
     expect(h.sent.filter((c) => c.op === "env_for_path")).toHaveLength(4);
   });
 
+  it("does not start a duplicate ready refresh while a fetch is already in flight", async () => {
+    const h = makeHarness();
+    const p1 = ensureFetched(h.state, h.deps, "/proj");
+    ackLastWith(h, true, {
+      enabled: "auto",
+      kind: "flake",
+      env: { PATH: "/old" },
+    });
+    await p1;
+
+    const refreshP = ensureFetched(h.state, h.deps, "/proj");
+    expect(h.sent.filter((c) => c.op === "env_for_path")).toHaveLength(2);
+
+    onDevshellEvent(h.state, h.deps, {
+      kind: "flake",
+      root: "/proj",
+      status: "ready",
+    });
+
+    expect(h.sent.filter((c) => c.op === "env_for_path")).toHaveLength(2);
+    const duringRefresh = getCachedEnv(h.state, h.deps, "/proj");
+    expect(duringRefresh.hot).toBe(true);
+    expect(duringRefresh.env).toEqual({ PATH: "/old" });
+
+    ackLastWith(h, true, {
+      enabled: "auto",
+      kind: "flake",
+      env: { PATH: "/new" },
+    });
+    await refreshP;
+
+    expect(getCachedEnv(h.state, h.deps, "/proj").env).toEqual({
+      PATH: "/new",
+    });
+  });
+
   it("does not invalidate cache entries under unrelated roots", async () => {
     const h = makeHarness();
     const p = ensureFetched(h.state, h.deps, "/proj-a");

--- a/agent/devshell/client.test.ts
+++ b/agent/devshell/client.test.ts
@@ -113,6 +113,22 @@ describe("getCachedEnv", () => {
     expect(env).toEqual({});
   });
 
+  it("keeps a known-empty env hot while a refresh fetch is in flight", async () => {
+    const h = makeHarness();
+    let fetchP = ensureFetched(h.state, h.deps, "/proj");
+    ackLastWith(h, true, { enabled: "never", kind: null, env: {} });
+    await fetchP;
+
+    fetchP = ensureFetched(h.state, h.deps, "/proj");
+    const { env, kind, hot } = getCachedEnv(h.state, h.deps, "/proj");
+    expect(hot).toBe(true);
+    expect(kind).toBeNull();
+    expect(env).toEqual({});
+
+    ackLastWith(h, true, { enabled: "never", kind: null, env: {} });
+    await fetchP;
+  });
+
   it("preserves previous env on a failed re-fetch (marks stale)", async () => {
     const h = makeHarness();
     // 1st fetch — success

--- a/agent/devshell/client.test.ts
+++ b/agent/devshell/client.test.ts
@@ -131,6 +131,27 @@ describe("getCachedEnv", () => {
     expect(env).toEqual({ PATH: "/x" });
     expect(hot).toBe(true);
   });
+
+  it("keeps using a prepared env while a refresh fetch is in flight", async () => {
+    const h = makeHarness();
+    const p = ensureFetched(h.state, h.deps, "/proj");
+    ackLastWith(h, true, {
+      enabled: "auto",
+      kind: "flake",
+      env: { PATH: "/nix/store/old/bin", IN_NIX_SHELL: "impure" },
+    });
+    await p;
+
+    void ensureFetched(h.state, h.deps, "/proj");
+
+    const { env, kind, hot } = getCachedEnv(h.state, h.deps, "/proj");
+    expect(hot).toBe(true);
+    expect(kind).toBe("flake");
+    expect(env).toEqual({
+      PATH: "/nix/store/old/bin",
+      IN_NIX_SHELL: "impure",
+    });
+  });
 });
 
 describe("seedPreparedEnv", () => {
@@ -214,7 +235,7 @@ describe("ensurePrepared", () => {
 });
 
 describe("onDevshellEvent", () => {
-  it("invalidates cache entries under a root on ready", async () => {
+  it("keeps existing env hot under a root on ready while refreshing it", async () => {
     const h = makeHarness();
     const p1 = ensureFetched(h.state, h.deps, "/proj");
     ackLastWith(h, true, {
@@ -236,11 +257,13 @@ describe("onDevshellEvent", () => {
       root: "/proj",
       status: "ready",
     });
-    const { hot: hotRoot } = getCachedEnv(h.state, h.deps, "/proj");
-    const { hot: hotSub } = getCachedEnv(h.state, h.deps, "/proj/sub");
-    // Both went cold → fetches kicked off.
-    expect(hotRoot).toBe(false);
-    expect(hotSub).toBe(false);
+    const root = getCachedEnv(h.state, h.deps, "/proj");
+    const sub = getCachedEnv(h.state, h.deps, "/proj/sub");
+    expect(root.hot).toBe(true);
+    expect(sub.hot).toBe(true);
+    expect(root.env).toEqual({ PATH: "/old" });
+    expect(sub.env).toEqual({ PATH: "/old-sub" });
+    expect(h.sent.filter((c) => c.op === "env_for_path")).toHaveLength(4);
   });
 
   it("does not invalidate cache entries under unrelated roots", async () => {
@@ -264,7 +287,7 @@ describe("onDevshellEvent", () => {
 });
 
 describe("refresh", () => {
-  it("clears cache for the root and sends a refresh query", async () => {
+  it("keeps cached env hot for the root while sending a refresh query", async () => {
     const h = makeHarness();
     const p = ensureFetched(h.state, h.deps, "/proj");
     ackLastWith(h, true, {
@@ -275,11 +298,12 @@ describe("refresh", () => {
     await p;
 
     const refreshP = refresh(h.state, h.deps, "/proj");
-    // Cache should be gone immediately, before the refresh ack lands.
+    // The old devshell env should remain usable until the refresh result lands.
     const beforeAck = getCachedEnv(h.state, h.deps, "/proj");
-    expect(beforeAck.hot).toBe(false);
+    expect(beforeAck.hot).toBe(true);
+    expect(beforeAck.env).toEqual({ PATH: "/old" });
 
-    // Now ack the refresh + the cache-miss fetch fired by getCachedEnv above.
+    // Now ack the refresh query.
     // Two acks may be pending — drain them in order.
     while (h.sent.length > 0) {
       const last = h.sent[h.sent.length - 1];

--- a/agent/devshell/client.ts
+++ b/agent/devshell/client.ts
@@ -54,7 +54,7 @@ export function getCachedEnv(
   cwd: string,
 ): { env: Record<string, string>; kind: string | null; hot: boolean } {
   const entry = cache.get(cwd);
-  if (entry && !entry.fetching) {
+  if (entry && (!entry.fetching || Object.keys(entry.env).length > 0)) {
     return { env: entry.env, kind: entry.kind, hot: true };
   }
   if (!entry) {
@@ -278,15 +278,11 @@ export async function refresh(
   deps: DevshellClientDeps,
   root: string,
 ): Promise<void> {
-  // Clear all cache entries whose cwd lies under root — a worktree
-  // shares the root flake but lives in a different cwd. Mirror the
-  // same loop into `warned` so a subpath cwd that previously emitted
-  // a cold-run warning will warn again after the refresh (otherwise
-  // the user gets a silent first command on stale env).
-  for (const key of [...cache.keys()]) {
-    if (isUnderRoot(key, root)) {
-      cache.delete(key);
-    }
+  // Keep any previous env hot while Rust refreshes the resolver. The bash
+  // spawnHook is synchronous, so deleting here would make the next command
+  // fall back to the host env for one turn.
+  for (const [key, entry] of [...cache.entries()]) {
+    if (isUnderRoot(key, root)) cache.set(key, { ...entry, stale: true });
   }
   for (const key of [...warned]) {
     if (isUnderRoot(key, root)) {
@@ -310,15 +306,13 @@ export function onDevshellEvent(
   },
 ): void {
   if (event.status === "ready") {
-    // Just invalidate; the next spawnHook call will re-fetch under
-    // its own cwd (which may be a worktree subpath of `root`).
-    // Mirror the loop into `warned` so a subpath cwd that previously
-    // emitted a cold-run warning will warn again after the resolver
-    // completes a fresh resolve (otherwise the user gets a silent
-    // first command on stale env).
-    for (const key of [...cache.keys()]) {
+    // Refresh any matching agent-side entries without making the synchronous
+    // bash spawnHook go cold. Existing env remains usable until env_for_path
+    // returns the freshly prepared resolver output.
+    for (const [key, entry] of [...cache.entries()]) {
       if (isUnderRoot(key, event.root)) {
-        cache.delete(key);
+        cache.set(key, { ...entry, stale: true, fetching: false });
+        void ensureFetched(state, deps, key);
       }
     }
     for (const key of [...warned]) {

--- a/agent/devshell/client.ts
+++ b/agent/devshell/client.ts
@@ -54,7 +54,12 @@ export function getCachedEnv(
   cwd: string,
 ): { env: Record<string, string>; kind: string | null; hot: boolean } {
   const entry = cache.get(cwd);
-  if (entry && (!entry.fetching || Object.keys(entry.env).length > 0)) {
+  if (
+    entry &&
+    (!entry.fetching ||
+      Object.keys(entry.env).length > 0 ||
+      entry.resolvedAt > 0)
+  ) {
     return { env: entry.env, kind: entry.kind, hot: true };
   }
   if (!entry) {

--- a/agent/devshell/client.ts
+++ b/agent/devshell/client.ts
@@ -311,8 +311,8 @@ export function onDevshellEvent(
     // returns the freshly prepared resolver output.
     for (const [key, entry] of [...cache.entries()]) {
       if (isUnderRoot(key, event.root)) {
-        cache.set(key, { ...entry, stale: true, fetching: false });
-        void ensureFetched(state, deps, key);
+        cache.set(key, { ...entry, stale: true });
+        if (!entry.fetching) void ensureFetched(state, deps, key);
       }
     }
     for (const key of [...warned]) {

--- a/agent/dispatcher.test.ts
+++ b/agent/dispatcher.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   AethonAgentState,
   type AethonAgentStateOptions,
@@ -35,8 +38,8 @@ const baseOpts: AethonAgentStateOptions = {
   statePayloadHardKb: 512,
 };
 
-function makeFixture() {
-  const state = new AethonAgentState(baseOpts);
+function makeFixture(opts: Partial<AethonAgentStateOptions> = {}) {
+  const state = new AethonAgentState({ ...baseOpts, ...opts });
   const sent: Record<string, unknown>[] = [];
   let writes = 0;
   return {
@@ -86,6 +89,53 @@ function fakeAethonApi(overrides: Record<string, unknown> = {}) {
 const fakeExtensionApi = {} as Parameters<typeof dispatchInboundMessage>[3];
 
 describe("dispatchInboundMessage", () => {
+  it("refreshes persisted session discovery before report ready payloads", async () => {
+    const root = mkdtempSync(join(tmpdir(), "aethon-report-"));
+    try {
+      const sessionsDir = join(root, "sessions");
+      const tabDir = join(sessionsDir, "tab-new");
+      mkdirSync(tabDir, { recursive: true });
+      writeFileSync(
+        join(tabDir, "1.jsonl"),
+        `${JSON.stringify({ type: "session", id: "s", cwd: "/repo/worktree" })}\n${JSON.stringify(
+          {
+            type: "message",
+            message: {
+              role: "user",
+              content: [{ type: "text", text: "restore this worktree" }],
+            },
+          },
+        )}\n`,
+      );
+      const f = makeFixture({
+        userDir: root,
+        stateFile: join(root, "state.json"),
+        sessionsDir,
+      });
+      f.state.discoveredTabs = [];
+
+      await dispatchInboundMessage(
+        f.state,
+        f.deps,
+        fakeAethonApi(),
+        fakeExtensionApi,
+        { type: "report" },
+      );
+
+      expect(f.sent.find((m) => m.type === "ready")).toMatchObject({
+        discoveredTabs: [
+          {
+            tabId: "tab-new",
+            cwd: "/repo/worktree",
+            firstUserMessage: "restore this worktree",
+          },
+        ],
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("keeps bridge API commands in the router shell", async () => {
     const f = makeFixture();
     const api = fakeAethonApi();

--- a/agent/dispatcher.ts
+++ b/agent/dispatcher.ts
@@ -102,7 +102,7 @@ export async function dispatchInboundMessage(
         break;
       case "report":
         markFrontendReady(state);
-        emitGlobalReady(state, deps);
+        await emitGlobalReady(state, deps);
         break;
       case "reload_request":
         // Rust file-watcher asked us to reload because an extension file

--- a/agent/dispatcherTypes.ts
+++ b/agent/dispatcherTypes.ts
@@ -4,6 +4,7 @@ import type {
   ExtensionFailureSource,
 } from "./state";
 import { emitReady } from "./tab-lifecycle";
+import { refreshPersistedTabs } from "./extension-loader";
 
 const WORKER_MODE =
   typeof process.env.AETHON_WORKER_TAB_ID === "string" &&
@@ -74,11 +75,13 @@ export interface InboundMessage {
   devshellKind?: string;
 }
 
-export function emitGlobalReady(
+export async function emitGlobalReady(
   state: AethonAgentState,
   deps: { send: (obj: Record<string, unknown>) => void },
-): void {
-  if (!WORKER_MODE) emitReady(state, deps);
+): Promise<void> {
+  if (WORKER_MODE) return;
+  state.discoveredTabs = await refreshPersistedTabs(state);
+  emitReady(state, deps);
 }
 
 /** If a reload was requested AND no tab has a prompt in flight, write

--- a/agent/extension-loader.test.ts
+++ b/agent/extension-loader.test.ts
@@ -23,6 +23,7 @@ import {
   loadProjectAethonExtensions,
   normalizeTheme,
   projectExtensionDisplayName,
+  refreshPersistedTabs,
 } from "./extension-loader";
 
 function makeOpts(userDir: string): AethonAgentStateOptions {
@@ -137,6 +138,35 @@ describe("discoverPersistedTabs", () => {
       const ids = tabs.map((t) => t.tabId);
       expect(ids).toContain("default");
       expect(ids).not.toContain("weird name?!");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("refreshPersistedTabs", () => {
+  it("returns [] when sessionsDir does not exist", async () => {
+    const f = makeFixture("/tmp/aethon-nope-" + Date.now());
+    f.state.discoveredTabs = [
+      { tabId: "existing", lastModified: 123, cwd: "/proj" },
+    ];
+
+    expect(await refreshPersistedTabs(f.state)).toEqual([]);
+  });
+
+  it("preserves existing tabs on non-ENOENT readdir failures", async () => {
+    const root = mkdtempSync(join(tmpdir(), "aethon-ext-"));
+    try {
+      const stateOpts = makeOpts(root);
+      stateOpts.sessionsDir = join(root, "sessions-as-file");
+      writeFileSync(stateOpts.sessionsDir, "not a directory");
+      const state = new AethonAgentState(stateOpts);
+      const existing = [
+        { tabId: "existing", lastModified: 123, cwd: "/proj" },
+      ];
+      state.discoveredTabs = existing;
+
+      expect(await refreshPersistedTabs(state)).toBe(existing);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/agent/extension-loader/discovery.ts
+++ b/agent/extension-loader/discovery.ts
@@ -69,12 +69,11 @@ export async function discoverPersistedTabs(
   try {
     entries = await readdir(state.sessionsDir);
   } catch (err) {
-    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-      logger
-        .scope("tabs")
-        .warn(`readdir ${state.sessionsDir}: ${(err as Error).message}`);
-    }
-    return [];
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+    logger
+      .scope("tabs")
+      .warn(`readdir ${state.sessionsDir}: ${(err as Error).message}`);
+    return state.discoveredTabs;
   }
   const results: DiscoveredTab[] = [];
   for (const name of entries) {
@@ -101,12 +100,11 @@ export async function refreshPersistedTabs(
   try {
     entries = await readdir(state.sessionsDir);
   } catch (err) {
-    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-      logger
-        .scope("tabs")
-        .warn(`readdir ${state.sessionsDir}: ${(err as Error).message}`);
-    }
-    return [];
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+    logger
+      .scope("tabs")
+      .warn(`readdir ${state.sessionsDir}: ${(err as Error).message}`);
+    return state.discoveredTabs;
   }
   const existing = new Map(
     state.discoveredTabs.map((tab) => [tab.tabId, tab] as const),

--- a/agent/extension-loader/discovery.ts
+++ b/agent/extension-loader/discovery.ts
@@ -11,7 +11,7 @@ import { readdir } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { logger } from "../logger";
-import { readSessionMetadata } from "../session-history";
+import { latestSessionLog, readSessionMetadata } from "../session-history";
 import type {
   AethonAgentState,
   DiscoveredTab,
@@ -81,6 +81,48 @@ export async function discoverPersistedTabs(
     if (!/^[A-Za-z0-9_-]{1,128}$/.test(name)) continue;
     const dir = join(state.sessionsDir, name);
     try {
+      const meta = await readSessionMetadata(dir);
+      if (meta) results.push({ tabId: name, ...meta });
+    } catch {
+      /* skip — best effort */
+    }
+  }
+  results.sort((a, b) => b.lastModified - a.lastModified);
+  return results;
+}
+
+/** Incrementally refresh `state.discoveredTabs` from disk. This keeps
+ * report/ready payloads current without rereading every large transcript on
+ * every webview reload or project switch. */
+export async function refreshPersistedTabs(
+  state: AethonAgentState,
+): Promise<DiscoveredTab[]> {
+  let entries: string[];
+  try {
+    entries = await readdir(state.sessionsDir);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      logger
+        .scope("tabs")
+        .warn(`readdir ${state.sessionsDir}: ${(err as Error).message}`);
+    }
+    return [];
+  }
+  const existing = new Map(
+    state.discoveredTabs.map((tab) => [tab.tabId, tab] as const),
+  );
+  const results: DiscoveredTab[] = [];
+  for (const name of entries) {
+    if (!/^[A-Za-z0-9_-]{1,128}$/.test(name)) continue;
+    const dir = join(state.sessionsDir, name);
+    try {
+      const latest = await latestSessionLog(dir);
+      if (!latest) continue;
+      const cached = existing.get(name);
+      if (cached?.lastModified === latest.mtimeMs) {
+        results.push(cached);
+        continue;
+      }
       const meta = await readSessionMetadata(dir);
       if (meta) results.push({ tabId: name, ...meta });
     } catch {

--- a/agent/extension-loader/index.ts
+++ b/agent/extension-loader/index.ts
@@ -28,4 +28,8 @@ export {
   projectExtensionDisplayName,
 } from "./directory";
 export { loadAethonExtensionPackages } from "./packages";
-export { discoverPersistedTabs, discoverPiAethonExtensions } from "./discovery";
+export {
+  discoverPersistedTabs,
+  discoverPiAethonExtensions,
+  refreshPersistedTabs,
+} from "./discovery";

--- a/agent/nativeSlash.ts
+++ b/agent/nativeSlash.ts
@@ -3,7 +3,11 @@ import { basename, extname, join } from "node:path";
 import type { AethonAgentState } from "./state";
 import type { DispatcherDeps, InboundMessage } from "./dispatcherTypes";
 import { emitGlobalReady } from "./dispatcherTypes";
-import { normalizeSessionLabel, writeSessionLabel } from "./session-history";
+import {
+  normalizeSessionLabel,
+  readSessionMetadata,
+  writeSessionLabel,
+} from "./session-history";
 import { ensureTab, modelKey, tabSessionDir } from "./tab-lifecycle";
 
 interface NativeContextUsage {
@@ -249,6 +253,13 @@ export async function handleNativeSlashCommand(
       tab.session.setSessionName(nextName);
       try {
         await writeSessionLabel(tabSessionDir(state, tabId), nextName);
+        const refreshed = await readSessionMetadata(tabSessionDir(state, tabId));
+        if (refreshed) {
+          const idx = state.discoveredTabs.findIndex((t) => t.tabId === tabId);
+          const entry = { tabId, ...refreshed };
+          if (idx >= 0) state.discoveredTabs[idx] = entry;
+          else state.discoveredTabs.push(entry);
+        }
       } catch {
         /* pi session name still succeeded; label replay is best effort */
       }
@@ -258,7 +269,7 @@ export async function handleNativeSlashCommand(
         command,
         message: `Session name set: ${nextName}`,
       });
-      emitGlobalReady(state, deps);
+      await emitGlobalReady(state, deps);
       return;
     }
     case "export": {

--- a/agent/projectLifecycle.ts
+++ b/agent/projectLifecycle.ts
@@ -236,7 +236,7 @@ export async function handleSetProject(
       state.currentProjectCwd = null;
       await state.resourceLoader.reload();
       deps.scheduleStateFileWrite();
-      emitGlobalReady(state, deps);
+      await emitGlobalReady(state, deps);
     }
     return;
   }
@@ -307,7 +307,7 @@ export async function handleSetProject(
         );
     }
     deps.scheduleStateFileWrite();
-    emitGlobalReady(state, deps);
+    await emitGlobalReady(state, deps);
     if (projectChanged) {
       // Single info summary per real project switch (the per-phase timings
       // above are debug) — keeps the signal without ~4 info lines per switch,

--- a/agent/session-history/index.ts
+++ b/agent/session-history/index.ts
@@ -36,6 +36,6 @@ export {
   truncateLocalChatAfterEntry,
   writeSessionLabel,
 } from "./io";
-export { readSessionMetadata } from "./metadata";
+export { latestSessionLog, readSessionMetadata } from "./metadata";
 export { findSessionFileMatchingCwd } from "./lookup";
 export { readSessionTranscript } from "./restore";

--- a/agent/state.ts
+++ b/agent/state.ts
@@ -249,6 +249,11 @@ export interface TabRecord {
   activeResponseMessageId?: string;
   /** Canonical pi id (when present) for the active streamed segment. */
   activeResponseCanonicalId?: string;
+  /** Text streamed into the active response segment. Used to reconcile
+   *  missing final content from agent_end without duplicating deltas. */
+  activeResponseText?: string;
+  /** Thinking/reasoning streamed into the active response segment. */
+  activeResponseThinking?: string;
   /** Monotonic per-tab counter used to make synthetic response ids unique
    *  without trusting pi message_update timestamps (which can refer to an
    *  earlier transcript record during streaming). */

--- a/agent/subagents/changed.ts
+++ b/agent/subagents/changed.ts
@@ -20,5 +20,5 @@ export async function handleSubagentsChanged(
   refreshSubagents(state);
   await state.resourceLoader.reload();
   deps.scheduleStateFileWrite();
-  emitGlobalReady(state, deps);
+  await emitGlobalReady(state, deps);
 }

--- a/agent/tab-lifecycle.test.ts
+++ b/agent/tab-lifecycle.test.ts
@@ -538,6 +538,81 @@ describe("handleSessionEvent", () => {
     });
   });
 
+  it("agent_end emits missing final text when streaming only delivered thinking", () => {
+    const f = makeFixture();
+    const rec = fakeRec();
+    rec.promptInFlight = true;
+
+    handleSessionEvent(f.state, f.deps, rec, "tab-1", {
+      type: "message_update",
+      assistantMessageEvent: {
+        type: "thinking_delta",
+        delta: "checking",
+        messageId: "assistant-final",
+      },
+    });
+    handleSessionEvent(f.state, f.deps, rec, "tab-1", {
+      type: "agent_end",
+      messages: [
+        {
+          role: "assistant",
+          stopReason: "stop",
+          content: [
+            { type: "thinking", thinking: "checking" },
+            { type: "text", text: "No. The PR did not add a rake task." },
+          ],
+        },
+      ],
+    });
+
+    expect(f.sent).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "response_delta",
+          tabId: "tab-1",
+          messageId: "text-assistant-final-1",
+          channel: "text",
+          content: "No. The PR did not add a rake task.",
+        }),
+      ]),
+    );
+    const responseEndIndex = f.sent.findIndex((m) => m.type === "response_end");
+    const finalTextIndex = f.sent.findIndex(
+      (m) => m.type === "response_delta" && m.channel === "text",
+    );
+    expect(finalTextIndex).toBeGreaterThan(-1);
+    expect(finalTextIndex).toBeLessThan(responseEndIndex);
+  });
+
+  it("agent_end only emits the unstreamed suffix of final text", () => {
+    const f = makeFixture();
+    const rec = fakeRec();
+
+    handleSessionEvent(f.state, f.deps, rec, "tab-1", {
+      type: "message_update",
+      assistantMessageEvent: {
+        type: "text_delta",
+        delta: "Done",
+        messageId: "assistant-final",
+      },
+    });
+    handleSessionEvent(f.state, f.deps, rec, "tab-1", {
+      type: "agent_end",
+      messages: [
+        {
+          role: "assistant",
+          stopReason: "stop",
+          content: [{ type: "text", text: "Done." }],
+        },
+      ],
+    });
+
+    const textDeltas = f.sent.filter(
+      (m) => m.type === "response_delta" && m.channel === "text",
+    );
+    expect(textDeltas.map((m) => m.content)).toEqual(["Done", "."]);
+  });
+
   it("rolls streamed assistant message ids at tool boundaries", () => {
     const f = makeFixture();
     const rec = fakeRec();

--- a/agent/tab-lifecycle/events.ts
+++ b/agent/tab-lifecycle/events.ts
@@ -25,6 +25,10 @@ import {
 } from "../agent-errors";
 import { logger } from "../logger";
 import type { AethonAgentState, TabRecord } from "../state";
+import {
+  textFromContent,
+  thinkingFromContent,
+} from "../session-history/shared";
 import { consumeBashTerminalSnapshot } from "../terminal-stream";
 import {
   extractToolContent,
@@ -68,6 +72,8 @@ function startResponseSegment(
   rec.activeResponseMessageId = canonical
     ? `text-${safeIdPart(canonical)}-${rec.responseMessageSeq}`
     : `text-${Date.now()}-${rec.responseMessageSeq}`;
+  rec.activeResponseText = "";
+  rec.activeResponseThinking = "";
   return rec.activeResponseMessageId;
 }
 
@@ -96,6 +102,87 @@ function responseMessageId(
 function rollResponseMessage(rec: TabRecord): void {
   rec.activeResponseMessageId = undefined;
   rec.activeResponseCanonicalId = undefined;
+  rec.activeResponseText = undefined;
+  rec.activeResponseThinking = undefined;
+}
+
+function rememberResponseDelta(
+  rec: TabRecord,
+  channel: "text" | "thinking",
+  delta: string,
+): void {
+  if (channel === "thinking") {
+    rec.activeResponseThinking = (rec.activeResponseThinking ?? "") + delta;
+  } else {
+    rec.activeResponseText = (rec.activeResponseText ?? "") + delta;
+  }
+}
+
+function assistantMessageCanonicalId(message: {
+  id?: unknown;
+  messageId?: unknown;
+}): string | undefined {
+  return assistantEventMessageId(message);
+}
+
+function missingSuffix(
+  finalContent: string,
+  streamedContent: string | undefined,
+): string {
+  if (!finalContent) return "";
+  const streamed = streamedContent ?? "";
+  if (!streamed) return finalContent;
+  if (finalContent === streamed) return "";
+  if (finalContent.startsWith(streamed))
+    return finalContent.slice(streamed.length);
+  if (streamed.includes(finalContent)) return "";
+  return finalContent;
+}
+
+function emitFinalAssistantContent(
+  deps: TabLifecycleDeps,
+  rec: TabRecord,
+  tabId: string,
+  assistant:
+    | ({ role?: unknown; content?: unknown } & {
+        id?: unknown;
+        messageId?: unknown;
+      })
+    | undefined,
+): void {
+  if (!assistant || assistant.role !== "assistant") return;
+  const finalThinking = thinkingFromContent(assistant.content);
+  const finalText = textFromContent(assistant.content);
+  if (!finalThinking && !finalText) return;
+
+  const messageId =
+    rec.activeResponseMessageId ??
+    startResponseSegment(rec, assistantMessageCanonicalId(assistant));
+  const thinkingDelta = missingSuffix(
+    finalThinking,
+    rec.activeResponseThinking,
+  );
+  if (thinkingDelta) {
+    deps.send({
+      type: "response_delta",
+      tabId,
+      messageId,
+      content: thinkingDelta,
+      channel: "thinking",
+    });
+    rememberResponseDelta(rec, "thinking", thinkingDelta);
+  }
+  const textDelta = missingSuffix(finalText, rec.activeResponseText);
+  if (textDelta) {
+    deps.send({
+      type: "response_delta",
+      tabId,
+      messageId,
+      content: textDelta,
+      channel: "text",
+    });
+    rememberResponseDelta(rec, "text", textDelta);
+  }
 }
 
 function compactionNotice(
@@ -122,7 +209,8 @@ function compactionNotice(
     type.includes("success")
   ) {
     const tokensBefore =
-      typeof event.tokensBefore === "number" && Number.isFinite(event.tokensBefore)
+      typeof event.tokensBefore === "number" &&
+      Number.isFinite(event.tokensBefore)
         ? ` · ${event.tokensBefore.toLocaleString("en-US")} tokens summarized`
         : "";
     return { message: `Context compacted${tokensBefore}` };
@@ -206,6 +294,7 @@ export function handleSessionEvent(
             content: delta,
             channel,
           });
+          rememberResponseDelta(rec, channel, delta);
           addLiveContextUsageEstimate(rec, delta);
           emitContextUsageThrottled(state, deps, tabId, rec);
         }
@@ -368,7 +457,13 @@ export function handleSessionEvent(
         ? modelKey(rec.session.model)
         : "unknown";
       const lastAssistant = [
-        ...((messages ?? []) as { role?: string; stopReason?: string }[]),
+        ...((messages ?? []) as Array<{
+          role?: string;
+          stopReason?: string;
+          content?: unknown;
+          id?: unknown;
+          messageId?: unknown;
+        }>),
       ]
         .reverse()
         .find((m) => m.role === "assistant");
@@ -389,6 +484,7 @@ export function handleSessionEvent(
         if (state.currentAgentTabId === tabId) {
           state.currentAgentTabId = undefined;
         }
+        emitFinalAssistantContent(deps, rec, tabId, lastAssistant);
         rollResponseMessage(rec);
         clearLiveContextUsageEstimate(rec);
         emitContextUsage(state, deps, tabId, rec);

--- a/agent/tabs.ts
+++ b/agent/tabs.ts
@@ -69,7 +69,7 @@ export async function handleTabOpen(
     ) {
       await state.resourceLoader.reload();
       deps.scheduleStateFileWrite();
-      emitGlobalReady(state, deps);
+      await emitGlobalReady(state, deps);
     }
   }
   const restoreHistory =
@@ -162,7 +162,7 @@ export async function handleSetSessionLabel(
     if (idx >= 0) state.discoveredTabs[idx] = entry;
     else state.discoveredTabs.push(entry);
   }
-  emitGlobalReady(state, deps);
+  await emitGlobalReady(state, deps);
 }
 
 export async function handleLocalChatMessage(

--- a/src/eventRoutes/dashboard.test.ts
+++ b/src/eventRoutes/dashboard.test.ts
@@ -156,8 +156,28 @@ describe("handleProjectDashboard", () => {
     expect(ctx.createWorktreeForProject).toHaveBeenCalledWith("p1");
   });
 
-  it("switch-worktree activates the worktree", async () => {
-    const { ctx } = buildRouteFixture();
+  it("switch-worktree builds the worktree landing", async () => {
+    const { ctx, applySetState } = buildRouteFixture({
+      state: {
+        sidebar: {
+          projects: [
+            {
+              id: "p1",
+              label: "aethon",
+              worktrees: [
+                {
+                  id: "w-1",
+                  label: "fix/session",
+                  branch: "fix/session",
+                  path: "/repo/aethon-fix-session",
+                  isMain: false,
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
     const handled = await handleProjectDashboard(
       {
         component: { id: "x", type: "project-dashboard" },
@@ -168,6 +188,78 @@ describe("handleProjectDashboard", () => {
     );
     expect(handled).toBe(true);
     expect(ctx.activateWorktree).toHaveBeenCalledWith("w-1");
+    expect(applySetState().landing).toMatchObject({
+      kind: "worktree",
+      projectId: "p1",
+      worktreeId: "w-1",
+      path: "/repo/aethon-fix-session",
+    });
+  });
+
+  it("switch-worktree shows landing when the destination scope is empty", async () => {
+    const { ctx, mocks, applySetState } = buildRouteFixture({
+      state: {
+        activeWorktreeId: "w-current",
+        activeTabId: "tab-current",
+        tabs: [
+          {
+            id: "tab-current",
+            kind: "agent",
+            projectId: "p1",
+            cwd: "/repo/aethon-current",
+            messages: [{ id: "m1", role: "user", text: "current" }],
+            draft: "",
+            waiting: false,
+            queueCount: 0,
+            canvas: null,
+            terminalBuffer: "",
+          },
+        ],
+        sidebar: {
+          projects: [
+            {
+              id: "p1",
+              label: "aethon",
+              worktrees: [
+                {
+                  id: "w-next",
+                  label: "fix/session",
+                  branch: "fix/session",
+                  path: "/repo/aethon-fix-session",
+                  isMain: false,
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+    mocks.activateWorktree.mockImplementation(() => {
+      ctx.stateRef.current = {
+        ...ctx.stateRef.current,
+        activeWorktreeId: "w-next",
+        activeTabId: undefined,
+        tabs: [],
+      };
+    });
+
+    const handled = await handleProjectDashboard(
+      {
+        component: { id: "x", type: "project-dashboard" },
+        eventType: "switch-worktree",
+        data: { worktreeId: "w-next" },
+      },
+      ctx,
+    );
+
+    expect(handled).toBe(true);
+    expect(ctx.activateWorktree).toHaveBeenCalledWith("w-next");
+    expect(applySetState().landing).toMatchObject({
+      kind: "worktree",
+      projectId: "p1",
+      worktreeId: "w-next",
+      path: "/repo/aethon-fix-session",
+    });
   });
 
   it("forwards dashboard worktree removal to the shared remove route", async () => {

--- a/src/eventRoutes/dashboard.ts
+++ b/src/eventRoutes/dashboard.ts
@@ -18,6 +18,7 @@ import type { EventRouteHandler } from "./types";
 import {
   handleSidebarDeleteSession,
   handleSidebarRemoveWorktree,
+  handleSidebarSwitchWorktree,
 } from "./sidebar";
 import { restoreSessionFromSelection } from "./sessionRestore";
 
@@ -99,9 +100,10 @@ export const handleProjectDashboard: EventRouteHandler = (
     return true;
   }
   if (eventType === "switch-worktree") {
-    const sel = data as { worktreeId?: string } | undefined;
-    if (sel?.worktreeId) ctx.activateWorktree(sel.worktreeId);
-    return true;
+    return handleSidebarSwitchWorktree(
+      { component: { id: "", type: "sidebar" }, eventType, data },
+      ctx,
+    );
   }
   if (eventType === "remove-worktree") {
     return handleSidebarRemoveWorktree(

--- a/src/hooks/bridgeMessageHandlers/a2ui.test.ts
+++ b/src/hooks/bridgeMessageHandlers/a2ui.test.ts
@@ -231,6 +231,144 @@ describe("handleA2ui", () => {
     });
   });
 
+  it("upserts a completed tool card against the current tab even when the snapshot missed it", () => {
+    const id = "tool-1-call_1";
+    const snapshotTab = makeEmptyTab("tab-1", "Tab 1");
+    const currentTab = {
+      ...snapshotTab,
+      messages: [
+        {
+          id,
+          role: "agent",
+          a2ui: {
+            components: [
+              {
+                id,
+                type: "tool-card",
+                props: {
+                  title: "bash",
+                  toolName: "bash",
+                  description: "codex review",
+                  startedAt: 1_000,
+                },
+              },
+            ],
+          },
+        } satisfies ChatMessage,
+      ],
+    };
+    const { ctx, mocks } = buildHandlerFixture({
+      state: { activeTabId: "tab-1", tabs: [snapshotTab] },
+    });
+    const payload = {
+      components: [
+        {
+          id,
+          type: "tool-card",
+          props: {
+            title: "bash",
+            toolName: "bash",
+            description: "codex review",
+            startedAt: 1_000,
+            endedAt: 2_000,
+          },
+        },
+      ],
+    };
+
+    handleA2ui({ type: "a2ui", payload, id, tabId: "tab-1" }, ctx);
+
+    expect(mocks.appendMessage).not.toHaveBeenCalled();
+    const [, updater] = mocks.updateTab.mock.calls[0];
+    const out = updater(currentTab);
+    expect(out.messages).toHaveLength(1);
+    expect(out.messages[0]).toMatchObject({
+      id,
+      role: "agent",
+      a2ui: payload,
+    });
+  });
+
+  it("prefers the current tab's exact running id over a stale snapshot identity match", () => {
+    const oldId = "tool-1-call_1";
+    const currentId = "tool-2-call_1";
+    const snapshotTab = {
+      ...makeEmptyTab("tab-1", "Tab 1"),
+      messages: [
+        {
+          id: oldId,
+          role: "agent",
+          a2ui: {
+            components: [
+              {
+                id: oldId,
+                type: "tool-card",
+                props: {
+                  title: "bash",
+                  toolName: "bash",
+                  description: "older codex review",
+                  startedAt: 1_000,
+                  endedAt: 1_500,
+                },
+              },
+            ],
+          },
+        } satisfies ChatMessage,
+      ],
+    };
+    const currentTab = {
+      ...snapshotTab,
+      messages: [
+        {
+          id: currentId,
+          role: "agent",
+          a2ui: {
+            components: [
+              {
+                id: currentId,
+                type: "tool-card",
+                props: {
+                  title: "bash",
+                  toolName: "bash",
+                  description: "current codex review",
+                  startedAt: 2_000,
+                },
+              },
+            ],
+          },
+        } satisfies ChatMessage,
+      ],
+    };
+    const { ctx, mocks } = buildHandlerFixture({
+      state: { activeTabId: "tab-1", tabs: [snapshotTab] },
+    });
+    const payload = {
+      components: [
+        {
+          id: currentId,
+          type: "tool-card",
+          props: {
+            title: "bash",
+            toolName: "bash",
+            description: "current codex review",
+            startedAt: 2_000,
+            endedAt: 2_500,
+          },
+        },
+      ],
+    };
+
+    handleA2ui({ type: "a2ui", payload, id: currentId, tabId: "tab-1" }, ctx);
+
+    const [, updater] = mocks.updateTab.mock.calls[0];
+    const out = updater(currentTab);
+    expect(out.messages).toHaveLength(1);
+    expect(out.messages[0]).toMatchObject({
+      id: currentId,
+      a2ui: payload,
+    });
+  });
+
   it("updates same-id repeated tool calls without replacing older siblings", () => {
     const oldId = "tool-1-call_1";
     const currentId = "tool-2-call_1";

--- a/src/hooks/bridgeMessageHandlers/a2ui.test.ts
+++ b/src/hooks/bridgeMessageHandlers/a2ui.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { handleA2ui } from "./a2ui";
 import { handleResponseDelta } from "./responseDelta";
 import { buildHandlerFixture } from "./testFixtures";
@@ -229,6 +229,77 @@ describe("handleA2ui", () => {
       status: "cancelled",
       endedAt: 2_000,
     });
+  });
+
+  it("persists the preserved cancellation state for late final tool cards", () => {
+    const id = "tool-1-call_1";
+    const tab = {
+      ...makeEmptyTab("tab-1", "Tab 1"),
+      messages: [
+        {
+          id,
+          role: "agent",
+          a2ui: {
+            components: [
+              {
+                id,
+                type: "tool-card",
+                props: {
+                  title: "bash",
+                  toolName: "bash",
+                  startedAt: 1_000,
+                  endedAt: 1_500,
+                  status: "cancelled",
+                },
+              },
+            ],
+          },
+        } satisfies ChatMessage,
+      ],
+    };
+    const { ctx, mocks } = buildHandlerFixture({
+      state: { activeTabId: "tab-1", tabs: [tab] },
+    });
+    ctx.updateTab = vi.fn((_tabId, updater) => {
+      updater(tab);
+    });
+    const payload = {
+      components: [
+        {
+          id,
+          type: "tool-card",
+          props: {
+            title: "bash",
+            toolName: "bash",
+            startedAt: 1_000,
+            endedAt: 2_000,
+          },
+        },
+      ],
+    };
+
+    handleA2ui({ type: "a2ui", payload, id, tabId: "tab-1" }, ctx);
+
+    expect(mocks.persistLocalChatMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        a2ui: {
+          components: [
+            expect.objectContaining({
+              props: expect.objectContaining({
+                status: "cancelled",
+                endedAt: 2_000,
+              }),
+              children: [
+                expect.objectContaining({
+                  id: `${id}-late-completion-notice`,
+                }),
+              ],
+            }),
+          ],
+        },
+      }),
+      "tab-1",
+    );
   });
 
   it("upserts a completed tool card against the current tab even when the snapshot missed it", () => {

--- a/src/hooks/bridgeMessageHandlers/a2ui.ts
+++ b/src/hooks/bridgeMessageHandlers/a2ui.ts
@@ -37,46 +37,81 @@ function createdAtFromPayload(payload: A2UIPayload): number | undefined {
   return undefined;
 }
 
-interface PriorToolCardMatch {
-  component: A2UIComponent;
-  id: string;
-}
-
-function priorToolCardMatch(
-  tab: Tab | undefined,
-  incomingId: string | undefined,
-  identity: string | undefined,
-): PriorToolCardMatch | undefined {
-  if (!tab) return undefined;
-  if (incomingId) {
-    for (const message of tab.messages) {
-      for (const component of message.a2ui?.components ?? []) {
-        if (component?.type !== "tool-card") continue;
-        if (component.props?.startedAt === undefined) continue;
-        if (component.id === incomingId) {
-          return { component, id: incomingId };
-        }
-      }
-    }
-  }
-  if (!identity) return undefined;
-  for (const message of tab.messages) {
-    for (const component of message.a2ui?.components ?? []) {
-      if (component?.type !== "tool-card") continue;
-      if (typeof component.id !== "string") continue;
-      if (component.props?.startedAt === undefined) continue;
-      if (toolCardIdentityFromId(component.id) === identity) {
-        return { component, id: component.id };
-      }
-    }
-  }
-  return undefined;
-}
-
 function isCancelledToolCard(component: A2UIComponent | undefined): boolean {
   return (
     component?.type === "tool-card" && component.props?.status === "cancelled"
   );
+}
+
+function messageMatchesToolCardId(
+  message: ChatMessage,
+  toolCardId: string,
+): boolean {
+  return (message.a2ui?.components ?? []).some((component) => {
+    if (component?.type !== "tool-card") return false;
+    if (component.props?.startedAt === undefined) return false;
+    return component.id === toolCardId;
+  });
+}
+
+function componentMatchesIncomingToolId(
+  component: A2UIComponent | undefined,
+  incomingId: string,
+): boolean {
+  if (component?.type !== "tool-card") return false;
+  if (component.props?.startedAt === undefined) return false;
+  return component.id === incomingId;
+}
+
+function componentMatchesToolIdentity(
+  component: A2UIComponent | undefined,
+  identity: string,
+): boolean {
+  if (component?.type !== "tool-card") return false;
+  if (component.props?.startedAt === undefined) return false;
+  return (
+    typeof component.id === "string" &&
+    toolCardIdentityFromId(component.id) === identity
+  );
+}
+
+function findCurrentToolCardMatch(
+  messages: ChatMessage[],
+  incomingId: string | undefined,
+  identity: string | undefined,
+): { index: number; component: A2UIComponent } | undefined {
+  if (incomingId) {
+    for (let index = 0; index < messages.length; index += 1) {
+      const component = (messages[index].a2ui?.components ?? []).find((item) =>
+        componentMatchesIncomingToolId(item, incomingId),
+      );
+      if (component) return { index, component };
+    }
+  }
+  if (!identity) return undefined;
+  for (let index = 0; index < messages.length; index += 1) {
+    const component = (messages[index].a2ui?.components ?? []).find((item) =>
+      componentMatchesToolIdentity(item, identity),
+    );
+    if (component) return { index, component };
+  }
+  return undefined;
+}
+
+function insertChronologically(
+  messages: ChatMessage[],
+  message: ChatMessage,
+): ChatMessage[] {
+  if (typeof message.createdAt !== "number") return [...messages, message];
+  const insertAt = messages.findIndex(
+    (current) =>
+      typeof current.createdAt === "number" &&
+      current.createdAt > message.createdAt!,
+  );
+  if (insertAt < 0) return [...messages, message];
+  const next = [...messages];
+  next.splice(insertAt, 0, message);
+  return next;
 }
 
 function cancellationHistoryNotice(componentId: string): A2UIComponent {
@@ -111,6 +146,47 @@ function preserveCancelledToolState(payload: A2UIPayload): A2UIPayload {
   };
 }
 
+function upsertCompletedToolCardMessage(
+  current: Tab,
+  message: ChatMessage,
+  payload: A2UIPayload,
+  completedCard: A2UIComponent,
+  identity: string | undefined,
+): Tab {
+  const incomingId = completedCard.id;
+  const matched = findCurrentToolCardMatch(
+    current.messages,
+    incomingId,
+    identity,
+  );
+  if (matched) {
+    const finalPayload =
+      isCancelledToolCard(matched.component) &&
+      payload.components?.some(isCancelledToolCard) !== true
+        ? preserveCancelledToolState(payload)
+        : payload;
+    const nextMessages = [...current.messages];
+    nextMessages[matched.index] = { ...message, a2ui: finalPayload };
+    return { ...current, messages: nextMessages };
+  }
+
+  const sameMessageIndex = current.messages.findIndex(
+    (currentMessage) =>
+      currentMessage.id === message.id ||
+      messageMatchesToolCardId(currentMessage, incomingId),
+  );
+  if (sameMessageIndex >= 0) {
+    const replacedMessages = [...current.messages];
+    replacedMessages[sameMessageIndex] = message;
+    return { ...current, messages: replacedMessages };
+  }
+
+  return {
+    ...current,
+    messages: insertChronologically(current.messages, message),
+  };
+}
+
 export const handleA2ui: BridgeMessageHandler = (data, ctx) => {
   const payload = data.payload as A2UIPayload | undefined;
   const id = (data.id as string) || crypto.randomUUID();
@@ -121,38 +197,26 @@ export const handleA2ui: BridgeMessageHandler = (data, ctx) => {
   flushResponseDeltas(tabId);
   if (payload) {
     const createdAt = createdAtFromPayload(payload);
-    const tabs = (ctx.stateRef.current.tabs as Tab[] | undefined) ?? [];
-    const tab = tabs.find((t) => t.id === tabId);
     const completedCard = completedToolCard(payload);
     const identity = completedCard
       ? toolCardIdentityFromId(completedCard.id)
       : undefined;
-    const priorMatch = priorToolCardMatch(tab, completedCard?.id, identity);
-    const finalPayload =
-      isCancelledToolCard(priorMatch?.component) &&
-      payload.components?.some(isCancelledToolCard) !== true
-        ? preserveCancelledToolState(payload)
-        : payload;
     const message: ChatMessage = {
       id,
       role: "agent",
-      a2ui: finalPayload,
+      a2ui: payload,
       ...(createdAt !== undefined ? { createdAt } : {}),
     };
-    if (priorMatch) {
-      ctx.updateTab(tabId, (current) => ({
-        ...current,
-        messages: current.messages.map((currentMessage) => {
-          const matches = (currentMessage.a2ui?.components ?? []).some(
-            (component) => {
-              if (component?.type !== "tool-card") return false;
-              if (component.props?.startedAt === undefined) return false;
-              return component.id === priorMatch.id;
-            },
-          );
-          return matches ? message : currentMessage;
-        }),
-      }));
+    if (completedCard) {
+      ctx.updateTab(tabId, (current) =>
+        upsertCompletedToolCardMessage(
+          current,
+          message,
+          payload,
+          completedCard,
+          identity,
+        ),
+      );
     } else {
       ctx.appendMessage(message, tabId);
     }

--- a/src/hooks/bridgeMessageHandlers/a2ui.ts
+++ b/src/hooks/bridgeMessageHandlers/a2ui.ts
@@ -102,11 +102,12 @@ function insertChronologically(
   messages: ChatMessage[],
   message: ChatMessage,
 ): ChatMessage[] {
-  if (typeof message.createdAt !== "number") return [...messages, message];
+  const createdAt = message.createdAt;
+  if (typeof createdAt !== "number") return [...messages, message];
   const insertAt = messages.findIndex(
     (current) =>
       typeof current.createdAt === "number" &&
-      current.createdAt > message.createdAt!,
+      current.createdAt > createdAt,
   );
   if (insertAt < 0) return [...messages, message];
   const next = [...messages];
@@ -152,7 +153,7 @@ function upsertCompletedToolCardMessage(
   payload: A2UIPayload,
   completedCard: A2UIComponent,
   identity: string | undefined,
-): Tab {
+): { tab: Tab; message: ChatMessage } {
   const incomingId = completedCard.id;
   const matched = findCurrentToolCardMatch(
     current.messages,
@@ -166,8 +167,9 @@ function upsertCompletedToolCardMessage(
         ? preserveCancelledToolState(payload)
         : payload;
     const nextMessages = [...current.messages];
-    nextMessages[matched.index] = { ...message, a2ui: finalPayload };
-    return { ...current, messages: nextMessages };
+    const finalMessage = { ...message, a2ui: finalPayload };
+    nextMessages[matched.index] = finalMessage;
+    return { tab: { ...current, messages: nextMessages }, message: finalMessage };
   }
 
   const sameMessageIndex = current.messages.findIndex(
@@ -178,12 +180,15 @@ function upsertCompletedToolCardMessage(
   if (sameMessageIndex >= 0) {
     const replacedMessages = [...current.messages];
     replacedMessages[sameMessageIndex] = message;
-    return { ...current, messages: replacedMessages };
+    return { tab: { ...current, messages: replacedMessages }, message };
   }
 
   return {
-    ...current,
-    messages: insertChronologically(current.messages, message),
+    tab: {
+      ...current,
+      messages: insertChronologically(current.messages, message),
+    },
+    message,
   };
 }
 
@@ -208,19 +213,23 @@ export const handleA2ui: BridgeMessageHandler = (data, ctx) => {
       ...(createdAt !== undefined ? { createdAt } : {}),
     };
     if (completedCard) {
-      ctx.updateTab(tabId, (current) =>
-        upsertCompletedToolCardMessage(
+      let durableMessage = message;
+      ctx.updateTab(tabId, (current) => {
+        const result = upsertCompletedToolCardMessage(
           current,
           message,
           payload,
           completedCard,
           identity,
-        ),
-      );
+        );
+        durableMessage = result.message;
+        return result.tab;
+      });
+      ctx.persistLocalChatMessage(durableMessage, tabId);
     } else {
       ctx.appendMessage(message, tabId);
+      ctx.persistLocalChatMessage(message, tabId);
     }
-    ctx.persistLocalChatMessage(message, tabId);
   }
   if (data.done) {
     ctx.updateTab(tabId, (tab) => {

--- a/src/hooks/projectOps/tabBuckets.test.ts
+++ b/src/hooks/projectOps/tabBuckets.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from "vitest";
 import { makeEmptyTab, type Tab } from "../../types/tab";
 import { switchProjectBucket } from "./tabBuckets";
 import type { TabBucket } from "./types";
+import type { ProjectsState } from "../../projects";
 
 function agentTab(id: string, projectId: string, cwd: string): Tab {
   return {
@@ -11,6 +12,33 @@ function agentTab(id: string, projectId: string, cwd: string): Tab {
     messages: [{ id: `${id}-m`, role: "user", text: id }],
   };
 }
+
+function shellTab(id: string, projectId: string, cwd: string): Tab {
+  return {
+    ...makeEmptyTab(id, id, projectId, "shell"),
+    shell: {
+      cwd,
+      command: "",
+      args: [],
+      shareMode: "private",
+      shellState: "running",
+    },
+  };
+}
+
+const projects: ProjectsState = {
+  projects: [{ id: "P", label: "Project", path: "/P", lastUsed: 1 }],
+  activeId: "P",
+  activeWorktreeId: null,
+  activeHostId: null,
+  worktreesByProject: {
+    P: [
+      { id: "main", projectId: "P", path: "/P", branch: "main", isMain: true },
+      { id: "A", projectId: "P", path: "/P/A", branch: "A", isMain: false },
+      { id: "B", projectId: "P", path: "/P/B", branch: "B", isMain: false },
+    ],
+  },
+};
 
 function makeHarness(initial: Record<string, unknown>) {
   let state = initial;
@@ -25,6 +53,7 @@ function makeHarness(initial: Record<string, unknown>) {
   const deps = {
     setState,
     stateRef,
+    projects,
     tabBucketsRef,
     buildProjectsMirror: () => ({}),
     dispatchTerminalReplay: () => {},
@@ -132,5 +161,52 @@ describe("switchProjectBucket", () => {
     expect(Object.keys(mirror)).toEqual(["P::worktree::A"]);
     expect(mirror["P::worktree::A"].activeTabId).toBe("a1");
     expect(mirror["P::worktree::A"].tabs.map((t) => t.id)).toEqual(["a1"]);
+  });
+
+  it("redistributes visible sibling-worktree tabs before switching buckets", () => {
+    const tabA = agentTab("a1", "P", "/P/A");
+    const tabB = agentTab("b1", "P", "/P/B");
+    const h = makeHarness({
+      tabs: [tabA, tabB],
+      activeTabId: "a1",
+    });
+
+    const restored = switchProjectBucket(
+      h.deps,
+      "P::worktree::B",
+      "P::worktree::A",
+    );
+
+    expect(restored).toBe("a1");
+    expect((h.get().tabs as Tab[]).map((t) => t.id)).toEqual(["a1"]);
+    expect(h.get().activeTabId).toBe("a1");
+    expect(
+      h.tabBucketsRef.current
+        .get("P::worktree::B")
+        ?.tabs.map((t) => t.id),
+    ).toEqual(["b1"]);
+    expect(
+      h.tabBucketsRef.current
+        .get("P::worktree::A")
+        ?.tabs.map((t) => t.id),
+    ).toEqual(["a1"]);
+  });
+
+  it("prefers an agent tab over a shell when choosing a bucket fallback active tab", () => {
+    const tabA = agentTab("a1", "P", "/P/A");
+    const shellB = shellTab("shell-b", "P", "/P/B");
+    const tabB = agentTab("b1", "P", "/P/B");
+    const h = makeHarness({
+      tabs: [tabA, shellB, tabB],
+      activeTabId: "a1",
+    });
+
+    switchProjectBucket(h.deps, "P::worktree::A", "P::worktree::B");
+
+    expect(h.get().activeTabId).toBe("b1");
+    expect((h.get().tabs as Tab[]).map((t) => t.id)).toEqual([
+      "shell-b",
+      "b1",
+    ]);
   });
 });

--- a/src/hooks/projectOps/tabBuckets.ts
+++ b/src/hooks/projectOps/tabBuckets.ts
@@ -8,7 +8,7 @@ import type { TabBucket } from "./types";
 const WORKTREE_BUCKET_SEPARATOR = "::worktree::";
 
 export function normalizeSessionPath(path: string | undefined): string {
-  return (path ?? "").replace(/[/\\]+$/, "");
+  return (path ?? "").replace(/\\/g, "/").replace(/\/+$/, "");
 }
 
 export function projectIdFromBucketKey(key: string): string | null {
@@ -35,11 +35,38 @@ export function projectScopeBucketKey(
     : projectId;
 }
 
-export function tabsForProjectBucket(tabs: Tab[], bucketKey: string): Tab[] {
+function isSameOrChildPath(path: string, root: string): boolean {
+  if (!path || !root) return false;
+  return path === root || path.startsWith(`${root}/`);
+}
+
+function pathForTab(tab: Tab): string | undefined {
+  if (tab.kind === "shell") return tab.shell?.cwd ?? tab.cwd;
+  if (tab.kind === "editor") return tab.editor?.rootPath ?? tab.editor?.filePath;
+  return tab.cwd;
+}
+
+export function tabBucketKeyForTab(
+  projects: ProjectsState,
+  tab: Tab,
+): string {
+  if (!tab.projectId) return NO_PROJECT_KEY;
+  const resolved = worktreeIdForCwd(projects, pathForTab(tab), tab.projectId);
+  return projectScopeBucketKey(tab.projectId, resolved ?? null);
+}
+
+export function tabsForProjectBucket(
+  tabs: Tab[],
+  bucketKey: string,
+  projects?: ProjectsState,
+): Tab[] {
   const projectId = projectIdFromBucketKey(bucketKey);
-  return tabs.filter((tab) =>
-    projectId === null ? tab.projectId == null : tab.projectId === projectId,
-  );
+  return tabs.filter((tab) => {
+    if (projectId === null) return tab.projectId == null;
+    if (tab.projectId !== projectId) return false;
+    if (!projects) return true;
+    return tabBucketKeyForTab(projects, tab) === bucketKey;
+  });
 }
 
 export function nonEmptyProjectTabs(tabs: Tab[]): Tab[] {
@@ -58,6 +85,19 @@ export function nonEmptyProjectTabs(tabs: Tab[]): Tab[] {
       tab.terminalBuffer.length > 0
     );
   });
+}
+
+function preferredActiveTabId(
+  tabs: Tab[],
+  currentActive: string | undefined,
+  existingActive: string | undefined,
+): string | undefined {
+  if (tabs.some((t) => t.id === currentActive)) return currentActive;
+  if (tabs.some((t) => t.id === existingActive)) return existingActive;
+  return (
+    tabs.find((t) => t.kind === "agent" || t.kind === "editor")?.id ??
+    tabs[0]?.id
+  );
 }
 
 export function worktreeIdForCwd(
@@ -79,11 +119,19 @@ export function worktreeIdForCwd(
   for (const id of orderedProjectIds) {
     const project = projects.projects.find((p) => p.id === id);
     if (!project) continue;
-    if (normalizeSessionPath(project.path) === target) return null;
-    const worktree = (projects.worktreesByProject[id] ?? []).find(
-      (w) => normalizeSessionPath(w.path) === target,
-    );
-    if (worktree) return worktree.isMain ? null : worktree.id;
+    const candidates = [
+      { id: null as string | null, path: project.path, isMain: true },
+      ...(projects.worktreesByProject[id] ?? []).map((w) => ({
+        id: w.id,
+        path: w.path,
+        isMain: w.isMain,
+      })),
+    ]
+      .map((item) => ({ ...item, path: normalizeSessionPath(item.path) }))
+      .filter((item) => isSameOrChildPath(target, item.path))
+      .sort((a, b) => b.path.length - a.path.length);
+    const hit = candidates[0];
+    if (hit) return hit.isMain ? null : hit.id;
   }
   return undefined;
 }
@@ -95,6 +143,7 @@ export interface SwitchProjectBucketOptions {
 interface SwitchProjectBucketDeps {
   setState: Dispatch<SetStateAction<Record<string, unknown>>>;
   stateRef: MutableRefObject<Record<string, unknown>>;
+  projects: ProjectsState;
   tabBucketsRef: MutableRefObject<Map<string, TabBucket>>;
   buildProjectsMirror: (
     prev: Record<string, unknown>,
@@ -118,6 +167,7 @@ export function switchProjectBucket(
   const {
     setState,
     stateRef,
+    projects,
     tabBucketsRef,
     buildProjectsMirror,
     dispatchTerminalReplay,
@@ -131,26 +181,37 @@ export function switchProjectBucket(
   let nextTerminalBuffer = "";
   let nextActiveTabId: string | undefined;
   setState((prev) => {
-    const currentTabs = nonEmptyProjectTabs(
-      tabsForProjectBucket(
-        ((prev.tabs as Tab[] | undefined) ?? []).slice(),
-        fromKey,
-      ),
+    const visibleTabs = nonEmptyProjectTabs(
+      ((prev.tabs as Tab[] | undefined) ?? []).slice(),
     );
     const currentActive = prev.activeTabId as string | undefined;
-    const fromActiveTabId = currentTabs.some((t) => t.id === currentActive)
-      ? currentActive
-      : currentTabs[0]?.id;
-    tabBucketsRef.current.set(fromKey, {
-      tabs: currentTabs,
-      activeTabId: fromActiveTabId,
-    });
+    const visibleBuckets = new Map<string, Tab[]>();
+    for (const tab of visibleTabs) {
+      const bucketKey = tabBucketKeyForTab(projects, tab);
+      visibleBuckets.set(bucketKey, [
+        ...(visibleBuckets.get(bucketKey) ?? []),
+        tab,
+      ]);
+    }
+    if (!visibleBuckets.has(fromKey)) visibleBuckets.set(fromKey, []);
+    for (const [bucketKey, bucketTabs] of visibleBuckets.entries()) {
+      const existing = tabBucketsRef.current.get(bucketKey);
+      const activeTabId = preferredActiveTabId(
+        bucketTabs,
+        currentActive,
+        existing?.activeTabId,
+      );
+      tabBucketsRef.current.set(bucketKey, {
+        tabs: bucketTabs,
+        activeTabId,
+      });
+    }
 
     const savedNextRaw = tabBucketsRef.current.get(toKey);
     const savedNext = savedNextRaw
       ? {
           tabs: nonEmptyProjectTabs(
-            tabsForProjectBucket(savedNextRaw.tabs, toKey),
+            tabsForProjectBucket(savedNextRaw.tabs, toKey, projects),
           ),
           activeTabId: savedNextRaw.activeTabId,
         }

--- a/src/hooks/useDerivedRenderState.test.ts
+++ b/src/hooks/useDerivedRenderState.test.ts
@@ -210,6 +210,41 @@ describe("useDerivedRenderState", () => {
     });
   });
 
+  it("keeps worktree sessions visible on the project dashboard", () => {
+    const { result } = renderHook(() =>
+      useDerivedRenderState({
+        state: {
+          tabs: [],
+          activeTabId: OVERVIEW_TAB_ID,
+          project: { id: "p1", path: "/repo/app" },
+          projects: [{ id: "p1" }],
+          sidebar: {
+            projects: [
+              {
+                id: "p1",
+                worktrees: [{ id: "wt-1", path: "/repo/app-fix" }],
+              },
+            ],
+          },
+          recentSessions: [
+            { id: "main", cwd: "/repo/app" },
+            { id: "worktree", cwd: "/repo/app-fix/" },
+            { id: "other", cwd: "/repo/other" },
+          ],
+        },
+        buildSidebarHistory: vi.fn(() => []),
+        hostInfo,
+      }),
+    );
+
+    expect(result.current.renderState.projectDashboard).toMatchObject({
+      recentSessions: [
+        { id: "main", cwd: "/repo/app" },
+        { id: "worktree", cwd: "/repo/app-fix/" },
+      ],
+    });
+  });
+
   it("overlays agent-activity across the active tabs and stashed buckets", () => {
     const mainTab = {
       ...makeEmptyTab("m", "m", "p1", "agent"),

--- a/src/hooks/useDerivedRenderState.ts
+++ b/src/hooks/useDerivedRenderState.ts
@@ -86,18 +86,6 @@ export function useDerivedRenderState({
     );
     const projectDashboardWorktrees =
       (activeProjectSidebarEntry?.worktrees as unknown[] | undefined) ?? [];
-    const recentSessionsArr = Array.isArray(state.recentSessions)
-      ? (state.recentSessions as { cwd?: string }[])
-      : [];
-    const projectPath =
-      (state.project as { path?: string } | null | undefined)?.path ?? null;
-    const projectDashboardSessions = projectPath
-      ? recentSessionsArr.filter((s) => {
-          const sCwd = (s.cwd ?? "").replace(/[/\\]+$/, "");
-          const pCwd = projectPath.replace(/[/\\]+$/, "");
-          return sCwd === pCwd;
-        })
-      : [];
     const projectsArr = Array.isArray(state.projects)
       ? (state.projects as { id: string }[])
       : [];
@@ -110,7 +98,28 @@ export function useDerivedRenderState({
       ...existingProjectDashboard,
       otherProjects,
       worktrees: projectDashboardWorktrees,
-      recentSessions: projectDashboardSessions,
+      recentSessions: (() => {
+        const recentSessionsArr = Array.isArray(state.recentSessions)
+          ? (state.recentSessions as { cwd?: string }[])
+          : [];
+        const projectPath =
+          (state.project as { path?: string } | null | undefined)?.path ?? null;
+        const scopePaths = new Set<string>();
+        const addScopePath = (path?: string) => {
+          const normalized = (path ?? "").replace(/[/\\]+$/, "");
+          if (normalized) scopePaths.add(normalized);
+        };
+        addScopePath(projectPath ?? undefined);
+        for (const worktree of projectDashboardWorktrees as Array<{
+          path?: string;
+        }>) {
+          addScopePath(worktree.path);
+        }
+        if (scopePaths.size === 0) return [];
+        return recentSessionsArr.filter((s) =>
+          scopePaths.has((s.cwd ?? "").replace(/[/\\]+$/, "")),
+        );
+      })(),
       widgets: existingProjectDashboard.widgets ?? [],
     };
     const existingProjectsDashboard =

--- a/src/hooks/useProjectOps.test.ts
+++ b/src/hooks/useProjectOps.test.ts
@@ -50,9 +50,11 @@ function nonEmptyAgentTab(
   id: string,
   label: string,
   projectId: string | null,
+  cwd?: string,
 ): Tab {
   return {
     ...makeEmptyTab(id, label, projectId),
+    ...(cwd ? { cwd } : {}),
     messages: [{ id: `${id}-msg`, role: "user", text: label }],
   };
 }
@@ -221,7 +223,13 @@ describe("useProjectOps session scoping", () => {
     expect(worktreeIdForCwd(projects, "/projects/aethon-fix-issue/")).toBe(
       "wt-issue",
     );
+    expect(worktreeIdForCwd(projects, "/projects/aethon-fix-issue/app")).toBe(
+      "wt-issue",
+    );
     expect(worktreeIdForCwd(projects, "/projects/aethon")).toBeNull();
+    expect(
+      worktreeIdForCwd(projects, "/projects/aethon-fix-issue-sibling"),
+    ).toBeUndefined();
     expect(worktreeIdForCwd(projects, "/projects/other")).toBeUndefined();
   });
 
@@ -816,6 +824,7 @@ describe("useProjectOps overview terminal project switches", () => {
       "worktree-agent",
       "Worktree",
       "project-1",
+      "/projects/alpha-feature",
     );
     result.current.tabBucketsRef.current.set(
       projectScopeBucketKey("project-1", "wt-alpha-feature"),

--- a/src/hooks/useProjectOps.ts
+++ b/src/hooks/useProjectOps.ts
@@ -118,6 +118,7 @@ export function useProjectOps(ctx: UseProjectOpsContext): UseProjectOpsActions {
       {
         setState,
         stateRef,
+        projects: projectsRef.current,
         tabBucketsRef,
         buildProjectsMirror,
         dispatchTerminalReplay,


### PR DESCRIPTION
## Summary

- emit missing final assistant text/thinking before `response_end` so completed turns do not appear cut off
- keep devshell env cache hot during resolver refreshes, avoid duplicate ready-triggered env fetches, and preserve prepared envs over time
- upsert completed A2UI tool cards against current tab state and persist preserved cancellation state
- refresh persisted session discovery before ready/report payloads so sessions created after bridge startup appear without a full bridge restart
- route project-dashboard worktree clicks through the shared worktree landing path and include worktree sessions in project dashboard recent sessions
- fix project/worktree tab bucket assignment so tabs are grouped by actual cwd-derived workspace, preventing session selection from jumping to another worktree or overview

## Validation

- `bun run typecheck`
- `bun run lint`
- `git diff --check`
- `bunx vitest run` (253 files, 2079 tests)
- live dev-app verification through the Aethon debug bridge: selecting the `fix/issue-539` session keeps its matching worktree active; switching back to `feat/issue-537` restores `Tab 3` as the active agent tab instead of shell/overview
- Copilot inline threads replied to and resolved
