### PR TITLE
fix(frontend): address Copilot review findings from #259

### DIFF
--- a/docs/aethon-agent/api.md
+++ b/docs/aethon-agent/api.md
@@ -645,7 +645,7 @@ Agent-side counterparts to the per-project dashboard's task launcher
 aethon.tasks.start({
   projectPath,                // absolute fs path of the target project
   prompt,                     // the first chat message to send
-  newWorkspace?: boolean,      // create a fresh git worktree first
+  newWorkspace?: boolean,      // create a fresh workspace (git worktree) first
   branch?: string,            // required when newWorkspace is true
   baseBranch?: string,        // base to fork from (project default, then origin/main)
   model?: string,             // optional model id for the launched tab

--- a/src/hooks/useBridgeMessages.test.ts
+++ b/src/hooks/useBridgeMessages.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "vitest";
 import { bridgeDispatchDecision } from "./useBridgeMessages";
 
-const activeTabs = new Set(["tab-active", "tab-two"]);
+const activeTabs = () => new Set(["tab-active", "tab-two"]);
 
 describe("bridgeDispatchDecision", () => {
   test("unstamped messages from the global bridge are handled", () => {

--- a/src/hooks/useBridgeMessages.ts
+++ b/src/hooks/useBridgeMessages.ts
@@ -66,11 +66,13 @@ export type BridgeDispatchDecision =
 export function bridgeDispatchDecision(
   message: BridgeMessage,
   hasHandler: boolean,
-  activeTabIds: ReadonlySet<string>,
+  // Lazy: most inbound traffic (streaming deltas, tool cards) carries no
+  // originTabId, so the active-tab Set is only built when gating applies.
+  activeTabIds: () => ReadonlySet<string>,
 ): BridgeDispatchDecision {
   const origin = message.originTabId;
   if (typeof origin === "string" && origin.length > 0) {
-    if (!activeTabIds.has(origin)) {
+    if (!activeTabIds().has(origin)) {
       return {
         kind: "ack-reject",
         error: `origin tab "${origin}" is not in the active workspace`,
@@ -162,7 +164,7 @@ export function useBridgeMessages(
         const decision = bridgeDispatchDecision(
           data,
           handler !== undefined,
-          activeTabIdsFromState(opts.ctx.stateRef.current),
+          () => activeTabIdsFromState(opts.ctx.stateRef.current),
         );
         if (decision.kind === "ack-reject") {
           ackMutation(data.mutationId, false, decision.error);

--- a/src/vcsSliceCache.test.ts
+++ b/src/vcsSliceCache.test.ts
@@ -127,6 +127,27 @@ describe("vcsSliceCache", () => {
     expect(getCachedVcsSlice("/live")?.branch).toBe("fresh-live");
   });
 
+  it("enforces the entry cap when hydrating an oversized disk cache", async () => {
+    const entries: Record<string, unknown> = {};
+    for (let i = 0; i < __TEST__.MAX_ENTRIES + 8; i++) {
+      entries[`/p${i}`] = {
+        updatedAt: new Date().toISOString(),
+        slice: slice(`/p${i}`),
+      };
+    }
+    readStateMock.mockResolvedValue(
+      JSON.stringify({ schemaVersion: 1, entries }),
+    );
+
+    await hydrateVcsSliceCache();
+
+    let inMemory = 0;
+    for (let i = 0; i < __TEST__.MAX_ENTRIES + 8; i++) {
+      if (getCachedVcsSlice(`/p${i}`)) inMemory += 1;
+    }
+    expect(inMemory).toBeLessThanOrEqual(__TEST__.MAX_ENTRIES);
+  });
+
   it("drops stale and malformed disk entries", async () => {
     readStateMock.mockResolvedValue(
       JSON.stringify({

--- a/src/vcsSliceCache.ts
+++ b/src/vcsSliceCache.ts
@@ -124,6 +124,13 @@ export function hydrateVcsSliceCache(): Promise<void> {
       if (!slice || typeof slice !== "object" || slice.root !== root) continue;
       memory.set(root, slice);
     }
+    // A hand-edited / corrupted / pre-cap cache file must not blow past
+    // the in-memory cap — apply the same eviction as putCachedVcsSlice.
+    while (memory.size > MAX_ENTRIES) {
+      const oldest = memory.keys().next().value;
+      if (oldest === undefined) break;
+      memory.delete(oldest);
+    }
   })();
   return hydrated;
 }

--- a/website/guide/projects.md
+++ b/website/guide/projects.md
@@ -77,9 +77,10 @@ The MRU order is updated whenever you activate a project.
 
 ## Workspaces
 
-Projects can expand into their git worktrees in the sidebar. Selecting a
-workspace makes it the active working directory for new tabs; existing tabs keep
-their original `cwd`.
+A project has one or more workspaces: the main checkout, plus any number of
+additional working copies (each backed by a git worktree). Projects expand into
+their workspaces in the sidebar. Selecting a workspace makes it the active
+working directory for new tabs; existing tabs keep their original `cwd`.
 
 New workspaces fork from `origin/main` by default. To change that for a project,
 right-click the project and choose **Set workspace base...**. Leaving it blank


### PR DESCRIPTION
Follow-ups to #259 (merged before the Copilot review was addressed):

- **Lazy origin-gate Set** — `bridgeDispatchDecision` now takes a supplier, so the active-tab-id Set is only built for messages that actually carry `originTabId` (registry hydrates), not on every streaming delta.
- **vcsSliceCache hydrate cap** — disk hydration enforces `MAX_ENTRIES` with the same eviction as live puts, so a corrupted/hand-edited cache file can't exceed the in-memory cap.
- **Docs wording** — clarify workspaces are backed by git worktrees in `website/guide/projects.md` and `docs/aethon-agent/api.md`.

All four Copilot findings on #259 addressed.