### PR TITLE
fix(agent): read pre-v5 worktree keys in the bridge startup cwd parser

### DIFF
--- a/agent/active-project-cwd.test.ts
+++ b/agent/active-project-cwd.test.ts
@@ -31,6 +31,26 @@ describe("activeProjectCwdFromJson", () => {
     ).toBe("/repo/aethon-fix");
   });
 
+  it("reads pre-v5 worktree spellings on an upgrade boot (regression)", () => {
+    // The bridge can start against a projects.json the frontend hasn't
+    // re-saved in the v5 schema yet. The old keys must still resolve the
+    // active workspace cwd, or the agent boots in the project root and
+    // loads the wrong extensions / session scope.
+    expect(
+      activeProjectCwdFromJson(
+        JSON.stringify({
+          schemaVersion: 4,
+          activeId: "p1",
+          activeWorktreeId: "wt1",
+          projects: [{ id: "p1", path: "/repo/aethon" }],
+          worktreesByProject: {
+            p1: [{ id: "wt1", projectId: "p1", path: "/repo/aethon-fix" }],
+          },
+        }),
+      ),
+    ).toBe("/repo/aethon-fix");
+  });
+
   it("falls back to the project path when the active workspace is stale", () => {
     expect(
       activeProjectCwdFromJson(

--- a/agent/active-project-cwd.ts
+++ b/agent/active-project-cwd.ts
@@ -17,6 +17,14 @@ interface PersistedProjects {
   activeWorkspaceId?: unknown;
   projects?: PersistedProject[];
   workspacesByProject?: Record<string, PersistedWorkspace[]>;
+  /** Pre-v5 spellings. The frontend migrates these on load, but this
+   *  parser runs at bridge startup — possibly BEFORE the frontend has
+   *  re-saved the file in the v5 schema. Without the fallback, an
+   *  upgrade boot with an active workspace selected would resolve the
+   *  project root instead of the workspace cwd and load the wrong
+   *  extensions / session scope. */
+  activeWorktreeId?: unknown;
+  worktreesByProject?: Record<string, PersistedWorkspace[]>;
 }
 
 export function activeProjectCwdFromJson(text: string): string | undefined {
@@ -37,12 +45,19 @@ export function activeProjectCwdFromJson(text: string): string | undefined {
       : undefined;
   if (!projectPath) return undefined;
 
-  if (typeof parsed.activeWorkspaceId === "string" && parsed.activeWorkspaceId) {
-    const workspaces = parsed.workspacesByProject?.[parsed.activeId] ?? [];
+  const activeWorkspaceId =
+    typeof parsed.activeWorkspaceId === "string" && parsed.activeWorkspaceId
+      ? parsed.activeWorkspaceId
+      : typeof parsed.activeWorktreeId === "string" && parsed.activeWorktreeId
+        ? parsed.activeWorktreeId
+        : undefined;
+  if (activeWorkspaceId) {
+    const byProject = parsed.workspacesByProject ?? parsed.worktreesByProject;
+    const workspaces = byProject?.[parsed.activeId] ?? [];
     const activeWorkspace = workspaces.find(
       (w) =>
         w &&
-        w.id === parsed.activeWorkspaceId &&
+        w.id === activeWorkspaceId &&
         w.projectId === parsed.activeId &&
         typeof w.path === "string" &&
         w.path.length > 0,


### PR DESCRIPTION
Codex peer-review P2 on the #259 workspace rename: `activeProjectCwdFromJson` parses `projects.json` directly at bridge startup — possibly before the frontend has re-saved the file in the v5 schema. An upgrade boot with an active workspace selected would resolve the project root instead of the workspace cwd and load the wrong extensions / session scope. Falls back to `activeWorktreeId` / `worktreesByProject`, mirroring the frontend migration; regression test included.

The other Codex P2 (keep a `newWorktree` alias on `aethon.tasks.start`) is intentionally not taken — the rename shipped as an explicit clean break with no API aliases.