### PR TITLE
fix(agent): skip startup devshell prepare before the frontend handshake

### DIFF
--- a/agent/devshell/client.test.ts
+++ b/agent/devshell/client.test.ts
@@ -248,6 +248,24 @@ describe("ensurePrepared", () => {
     ackLastWith(h, false, undefined, "devshell required");
     await expect(p).rejects.toThrow("devshell required");
   });
+
+  it("skips the query entirely before the frontend handshake", async () => {
+    // Regression: the global bridge creates its default tab during startup,
+    // before the dispatcher loop that processes `frontend_ready`. A blocking
+    // prepare there can never be answered — it must return immediately
+    // instead of stalling until PREPARE_TIMEOUT_MS and throwing a fatal
+    // `frontend_not_ready` out of main().
+    const state = new AethonAgentState(baseOpts); // no markFrontendReady
+    const sent: SendCall[] = [];
+    const deps = { send: vi.fn((obj: Record<string, unknown>) => {
+      sent.push(obj as SendCall);
+    }) };
+    await expect(ensurePrepared(state, deps, "/proj")).resolves.toBeUndefined();
+    expect(sent).toEqual([]);
+    // Cache stays cold; the spawn hook degrades to the host env.
+    const { hot } = getCachedEnv(state, deps, "/proj");
+    expect(hot).toBe(false);
+  });
 });
 
 describe("onDevshellEvent", () => {

--- a/agent/devshell/client.ts
+++ b/agent/devshell/client.ts
@@ -197,6 +197,19 @@ export async function ensurePrepared(
   deps: DevshellClientDeps,
   cwd: string,
 ): Promise<void> {
+  // The prepare query is answered by the frontend, so before the handshake
+  // completes it CANNOT succeed. The global bridge creates its default tab
+  // during startup — before the dispatcher loop that would process
+  // `frontend_ready` — so awaiting here deadlocks for the full
+  // PREPARE_TIMEOUT_MS and the resulting throw is fatal to the bridge.
+  // Degrade to the documented cold-cache behavior instead: the spawn hook
+  // runs against the host env until devshell events warm the cache.
+  if (!state.frontendReady) {
+    logger
+      .scope("devshell")
+      .info(`prepare_for_path(${cwd}) skipped: frontend not ready yet`);
+    return;
+  }
   const existing = cache.get(cwd);
   cache.set(cwd, {
     kind: existing?.kind ?? null,

--- a/agent/tab-lifecycle/lifecycle.ts
+++ b/agent/tab-lifecycle/lifecycle.ts
@@ -130,7 +130,17 @@ export async function ensureTab(
       `worker session using pre-spawn devshell cwd=${resolvedCwd} tabId=${tabId}`,
     );
   } else {
-    await ensureDevshellPrepared(state, deps, resolvedCwd);
+    // Never let devshell preparation abort tab creation — a session on the
+    // host env beats no session. ensurePrepared also self-skips before the
+    // frontend handshake (startup default tab), where the query can't be
+    // answered and would otherwise wedge the bridge until a fatal timeout.
+    await ensureDevshellPrepared(state, deps, resolvedCwd).catch(
+      (err: unknown) => {
+        lifecycleLog.warn(
+          `devshell prepare failed for ${resolvedCwd}: ${(err as Error).message}; continuing with host env`,
+        );
+      },
+    );
   }
 
   // Shadow pi's built-in `bash` tool with our own that mounts the


### PR DESCRIPTION
## Problem

Since #256, every global-bridge boot crash-loops with a uniform ~2m11s lifetime, exit code 1, and no stderr. Symptoms in the app: the model picker is empty and `/login` (codex re-auth) does nothing.

Root cause is a startup-order deadlock:

1. `main()` creates the default tab via `ensureTab()` **before** `runDispatcher()` starts.
2. The non-worker branch added in #256 awaits `ensurePrepared()` — a blocking `devshell_query` answered by the frontend.
3. The frontend's `report` handshake is only processed by the dispatcher loop, which hasn't started — so `state.frontendReady` can never flip.
4. The gate times out after `PREPARE_TIMEOUT_MS` (130 s), `ensurePrepared` throws `frontend_not_ready`, and `main()`'s fatal handler exits 1 (`stdout closed without stderr` in the supervisor log).
5. The supervisor lazily respawns on the next IPC call → infinite crash loop. The `ready` payload (model list) is never sent and `/login` lands on a dead bridge.

Workers were unaffected (`AETHON_WORKER_DEVSHELL_READY` pre-spawn path skips the prepare), which is why agent task tabs kept working while the picker stayed blank.

## Fix

- `ensurePrepared` self-skips before the frontend handshake, degrading to the documented cold-cache behavior: the bash spawn hook runs against the host env until `devshell_event` pushes warm the cache (same semantics as the Rust PTY cold-cache path).
- The `ensureTab` call site is now non-fatal: a post-ready prepare failure downgrades the session to the host env instead of aborting tab creation.

## Verification

- Regression test: `ensurePrepared` with `frontendReady=false` resolves immediately and sends no query (`agent/devshell/client.test.ts`).
- Manual E2E: ran `bun run agent/main.ts` standalone — pre-fix it wedges silently and dies at exactly 130 s with `{"type":"error","message":"fatal: frontend_not_ready"}`; post-fix it boots in seconds and the `report` handshake returns `ready` with 28 models (incl. `openai-codex/gpt-5.5`).
- `bunx vitest run agent/` — 567 passed; `bunx tsc -b --noEmit` and ESLint clean.