### PR TITLE
fix(workspaces): retire tabs and sessions when a workspace is removed or externally pruned

### DIFF
--- a/src/hooks/projectOps/orphanTabSweep.test.ts
+++ b/src/hooks/projectOps/orphanTabSweep.test.ts
@@ -1,0 +1,249 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { makeEmptyTab, NO_PROJECT_KEY, type Tab } from "../../types/tab";
+import type { ProjectsState } from "../../projects";
+import { installTauriMocks, clearTauriMocks } from "../../test/tauriMocks";
+import {
+  isOrphanWorkspaceTab,
+  sweepOrphanWorkspaceTabs,
+  type OrphanTabSweepDeps,
+} from "./orphanTabSweep";
+import { projectScopeBucketKey } from "./tabBuckets";
+import type { TabBucket } from "./types";
+
+afterEach(() => {
+  clearTauriMocks();
+});
+
+const ref = <T>(value: T) => ({ current: value });
+
+function makeProjects(overrides: Partial<ProjectsState> = {}): ProjectsState {
+  return {
+    projects: [
+      {
+        id: "project-1",
+        label: "aethon",
+        path: "/projects/aethon",
+        lastUsed: 1,
+      },
+    ],
+    activeId: "project-1",
+    activeWorkspaceId: null,
+    workspacesByProject: {
+      "project-1": [
+        {
+          id: "ws-main",
+          projectId: "project-1",
+          path: "/projects/aethon",
+          branch: "main",
+          isMain: true,
+        },
+        {
+          id: "ws-live",
+          projectId: "project-1",
+          path: "/projects/aethon-live",
+          branch: "live",
+          isMain: false,
+        },
+      ],
+    },
+    activeHostId: null,
+    ...overrides,
+  };
+}
+
+function agentTab(id: string, projectId: string | null, cwd?: string): Tab {
+  return {
+    ...makeEmptyTab(id, id, projectId),
+    ...(cwd ? { cwd } : {}),
+  };
+}
+
+function makeDeps(
+  projects: ProjectsState,
+  tabs: Tab[],
+  buckets: Record<string, TabBucket> = {},
+  persisted?: Record<string, TabBucket>,
+) {
+  const stateRef = ref<Record<string, unknown>>({
+    tabs,
+    activeTabId: tabs[0]?.id,
+    closedSessionIds: [],
+    ...(persisted ? { persistedTabBuckets: persisted } : {}),
+  });
+  const setState = vi.fn(
+    (
+      next:
+        | Record<string, unknown>
+        | ((prev: Record<string, unknown>) => Record<string, unknown>),
+    ) => {
+      stateRef.current =
+        typeof next === "function" ? next(stateRef.current) : next;
+    },
+  );
+  const closeTabNow = vi.fn((tabId: string) => {
+    stateRef.current = {
+      ...stateRef.current,
+      tabs: ((stateRef.current.tabs as Tab[]) ?? []).filter(
+        (tab) => tab.id !== tabId,
+      ),
+    };
+  });
+  const deps: OrphanTabSweepDeps = {
+    setState,
+    stateRef,
+    projectsRef: ref(projects),
+    tabBucketsRef: ref(new Map(Object.entries(buckets))),
+    closeTabNow,
+    syncRecentSessionsToState: vi.fn(),
+  };
+  return { deps, stateRef, setState, closeTabNow };
+}
+
+describe("isOrphanWorkspaceTab", () => {
+  it("flags a tab whose cwd resolves to no live project or workspace", () => {
+    const projects = makeProjects();
+    expect(
+      isOrphanWorkspaceTab(
+        projects,
+        agentTab("t", "project-1", "/projects/aethon-deleted"),
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps tabs on live workspace, main, unknown-list, and no-project paths", () => {
+    const projects = makeProjects();
+    expect(
+      isOrphanWorkspaceTab(
+        projects,
+        agentTab("a", "project-1", "/projects/aethon-live"),
+      ),
+    ).toBe(false);
+    expect(
+      isOrphanWorkspaceTab(
+        projects,
+        agentTab("b", "project-1", "/projects/aethon/src"),
+      ),
+    ).toBe(false);
+    // No projectId — not ours to judge.
+    expect(
+      isOrphanWorkspaceTab(projects, agentTab("c", null, "/somewhere")),
+    ).toBe(false);
+    // Workspace list not loaded — "deleted" is indistinguishable from
+    // "not yet fetched".
+    const unloaded = makeProjects({ workspacesByProject: {} });
+    expect(
+      isOrphanWorkspaceTab(
+        unloaded,
+        agentTab("d", "project-1", "/projects/aethon-deleted"),
+      ),
+    ).toBe(false);
+    // Cwd-less tabs are spared.
+    expect(isOrphanWorkspaceTab(projects, agentTab("e", "project-1"))).toBe(
+      false,
+    );
+  });
+});
+
+describe("sweepOrphanWorkspaceTabs", () => {
+  it("closes visible orphan tabs and spares resolvable ones", () => {
+    const harness = installTauriMocks();
+    const projects = makeProjects();
+    const orphan = agentTab("orphan", "project-1", "/projects/aethon-deleted");
+    const live = agentTab("live", "project-1", "/projects/aethon-live");
+    const { deps, closeTabNow } = makeDeps(projects, [orphan, live]);
+
+    sweepOrphanWorkspaceTabs(deps);
+
+    expect(closeTabNow).toHaveBeenCalledWith("orphan");
+    expect(closeTabNow).not.toHaveBeenCalledWith("live");
+    // Visible closes go through closeTabNow (which owns suppression);
+    // no direct tab_close should be sent for them here.
+    expect(
+      harness.invoke.mock.calls.filter(([cmd]) => cmd === "agent_command"),
+    ).toHaveLength(0);
+  });
+
+  it("prunes buckets whose workspace id is gone and suppresses their sessions", () => {
+    const harness = installTauriMocks();
+    const projects = makeProjects();
+    const deadKey = projectScopeBucketKey("project-1", "ws-deleted");
+    const liveKey = projectScopeBucketKey("project-1", "ws-live");
+    const deadBucket: TabBucket = {
+      tabs: [agentTab("dead-tab", "project-1", "/projects/aethon-deleted")],
+      activeTabId: "dead-tab",
+    };
+    const liveBucket: TabBucket = {
+      tabs: [agentTab("live-tab", "project-1", "/projects/aethon-live")],
+      activeTabId: "live-tab",
+    };
+    const { deps, stateRef } = makeDeps(
+      projects,
+      [],
+      { [deadKey]: deadBucket, [liveKey]: liveBucket },
+      { [deadKey]: deadBucket, [liveKey]: liveBucket },
+    );
+
+    sweepOrphanWorkspaceTabs(deps);
+
+    expect(deps.tabBucketsRef.current.has(deadKey)).toBe(false);
+    expect(deps.tabBucketsRef.current.has(liveKey)).toBe(true);
+    const persisted = stateRef.current.persistedTabBuckets as Record<
+      string,
+      TabBucket
+    >;
+    expect(persisted[deadKey]).toBeUndefined();
+    expect(persisted[liveKey]).toBeDefined();
+    expect(stateRef.current.closedSessionIds).toContain("dead-tab");
+    expect(harness.invoke).toHaveBeenCalledWith("agent_command", {
+      payload: JSON.stringify({ type: "tab_close", tabId: "dead-tab" }),
+    });
+  });
+
+  it("filters orphan tabs out of live buckets and keeps the rest", () => {
+    installTauriMocks();
+    const projects = makeProjects();
+    const liveKey = projectScopeBucketKey("project-1", "ws-live");
+    const { deps, stateRef } = makeDeps(projects, [], {
+      [liveKey]: {
+        tabs: [
+          agentTab("stale", "project-1", "/projects/aethon-deleted"),
+          agentTab("fresh", "project-1", "/projects/aethon-live"),
+        ],
+        activeTabId: "stale",
+      },
+    });
+
+    sweepOrphanWorkspaceTabs(deps);
+
+    const bucket = deps.tabBucketsRef.current.get(liveKey);
+    expect(bucket?.tabs.map((tab) => tab.id)).toEqual(["fresh"]);
+    expect(bucket?.activeTabId).toBe("fresh");
+    expect(stateRef.current.closedSessionIds).toContain("stale");
+  });
+
+  it("leaves the no-project bucket and unknown projects alone", () => {
+    installTauriMocks();
+    const projects = makeProjects();
+    const homeless: TabBucket = {
+      tabs: [agentTab("homeless", null, "/Users/me/.aethon")],
+      activeTabId: "homeless",
+    };
+    const foreignKey = projectScopeBucketKey("project-unknown", "ws-x");
+    const foreign: TabBucket = {
+      tabs: [agentTab("foreign", "project-unknown", "/elsewhere")],
+      activeTabId: "foreign",
+    };
+    const { deps, setState } = makeDeps(projects, [], {
+      [NO_PROJECT_KEY]: homeless,
+      [foreignKey]: foreign,
+    });
+
+    sweepOrphanWorkspaceTabs(deps);
+
+    expect(deps.tabBucketsRef.current.get(NO_PROJECT_KEY)).toBe(homeless);
+    expect(deps.tabBucketsRef.current.get(foreignKey)).toBe(foreign);
+    expect(setState).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/projectOps/orphanTabSweep.ts
+++ b/src/hooks/projectOps/orphanTabSweep.ts
@@ -1,0 +1,172 @@
+import { invoke } from "@tauri-apps/api/core";
+import type { Dispatch, MutableRefObject, SetStateAction } from "react";
+import type { ProjectsState } from "../../projects";
+import type { Tab } from "../../types/tab";
+import {
+  pathForTab,
+  projectIdFromBucketKey,
+  workspaceIdForCwd,
+  workspaceIdFromBucketKey,
+} from "./tabBuckets";
+import { mergeClosedSessionIds } from "./workspaceOps/tabCleanup";
+import type { TabBucket } from "./types";
+
+export interface OrphanTabSweepDeps {
+  setState: Dispatch<SetStateAction<Record<string, unknown>>>;
+  stateRef: MutableRefObject<Record<string, unknown>>;
+  projectsRef: MutableRefObject<ProjectsState>;
+  tabBucketsRef: MutableRefObject<Map<string, TabBucket>>;
+  closeTabNow: (tabId: string) => void;
+  syncRecentSessionsToState: () => void;
+}
+
+/**
+ * A tab is an orphan when it claims a known project, that project's
+ * workspace list is actually loaded, and its cwd resolves to no live
+ * project or workspace path anywhere — the signature of a tab whose
+ * backing workspace was deleted while the app couldn't clean it up
+ * (removed in another instance, or before the reconcile-prune cleanup
+ * existed). An absent workspace list means "not yet fetched", which is
+ * indistinguishable from "deleted", so those tabs are left alone.
+ */
+export function isOrphanWorkspaceTab(
+  projects: ProjectsState,
+  tab: Tab,
+): boolean {
+  if (!tab.projectId) return false;
+  if (tab.kind !== "agent" && tab.kind !== "shell") return false;
+  if (!projects.projects.some((p) => p.id === tab.projectId)) return false;
+  if (!Array.isArray(projects.workspacesByProject[tab.projectId])) {
+    return false;
+  }
+  const cwd = pathForTab(tab);
+  if (!cwd) return false;
+  return workspaceIdForCwd(projects, cwd, tab.projectId) === undefined;
+}
+
+/** Whole-bucket verdict: a workspace-scoped bucket whose workspace id no
+ *  longer exists on a known project is dead in its entirety. */
+function bucketWorkspaceIsGone(
+  projects: ProjectsState,
+  bucketKey: string,
+): boolean {
+  const projectId = projectIdFromBucketKey(bucketKey);
+  const workspaceId = workspaceIdFromBucketKey(bucketKey);
+  if (!projectId || !workspaceId) return false;
+  if (!projects.projects.some((p) => p.id === projectId)) return false;
+  const list = projects.workspacesByProject[projectId];
+  if (!Array.isArray(list)) return false;
+  return !list.some((w) => w.id === workspaceId);
+}
+
+/** Returns the cleaned bucket, `null` to drop it, or the input bucket
+ *  unchanged (identity) when nothing matched. */
+function cleanBucket(
+  projects: ProjectsState,
+  bucketKey: string,
+  bucket: TabBucket,
+  suppressed: Set<string>,
+): TabBucket | null {
+  const tabs = bucket.tabs ?? [];
+  if (bucketWorkspaceIsGone(projects, bucketKey)) {
+    for (const tab of tabs) {
+      if (tab.kind === "agent") suppressed.add(tab.id);
+    }
+    return null;
+  }
+  const keep = tabs.filter((tab) => !isOrphanWorkspaceTab(projects, tab));
+  if (keep.length === tabs.length) return bucket;
+  for (const tab of tabs) {
+    if (tab.kind === "agent" && !keep.includes(tab)) suppressed.add(tab.id);
+  }
+  if (keep.length === 0) return null;
+  return {
+    tabs: keep,
+    activeTabId: keep.some((tab) => tab.id === bucket.activeTabId)
+      ? bucket.activeTabId
+      : keep[0]?.id,
+  };
+}
+
+/**
+ * One-shot boot hygiene: retire tabs and buckets that survived a
+ * workspace deletion the app never saw (deleted while it wasn't
+ * running, or by an older build without removal cleanup). Restored
+ * snapshots are taken verbatim at boot, so without this sweep a dead
+ * workspace's session can squat in whatever workspace is active.
+ *
+ * Conservative on purpose: only tabs/buckets that name a known project
+ * with a loaded workspace list are judged; anything ambiguous is kept.
+ */
+export function sweepOrphanWorkspaceTabs(deps: OrphanTabSweepDeps): void {
+  const projects = deps.projectsRef.current;
+  const suppressed = new Set<string>();
+
+  // Visible strip: closeTabNow handles closedSessionIds, bridge
+  // tab_close / shell_close, and active-tab mirror fixup.
+  const visible = (deps.stateRef.current.tabs as Tab[] | undefined) ?? [];
+  const visibleOrphans = visible.filter((tab) =>
+    isOrphanWorkspaceTab(projects, tab),
+  );
+  for (const tab of visibleOrphans) deps.closeTabNow(tab.id);
+
+  // Live bucket store.
+  for (const [key, bucket] of [...deps.tabBucketsRef.current.entries()]) {
+    const next = cleanBucket(projects, key, bucket, suppressed);
+    if (next === bucket) continue;
+    if (next === null) deps.tabBucketsRef.current.delete(key);
+    else deps.tabBucketsRef.current.set(key, next);
+  }
+
+  // Persisted bucket mirror + session suppression.
+  const persistedRaw = deps.stateRef.current.persistedTabBuckets;
+  const persisted =
+    persistedRaw &&
+    typeof persistedRaw === "object" &&
+    !Array.isArray(persistedRaw)
+      ? (persistedRaw as Record<string, TabBucket>)
+      : null;
+  let nextPersisted: Record<string, TabBucket> | null = null;
+  if (persisted) {
+    let changed = false;
+    const result: Record<string, TabBucket> = {};
+    for (const [key, bucket] of Object.entries(persisted)) {
+      const next = cleanBucket(projects, key, bucket, suppressed);
+      if (next === bucket) {
+        result[key] = bucket;
+        continue;
+      }
+      changed = true;
+      if (next === null) continue;
+      result[key] = next;
+    }
+    if (changed) nextPersisted = result;
+  }
+
+  if (nextPersisted !== null || suppressed.size > 0) {
+    deps.setState((prev) => {
+      const result: Record<string, unknown> = { ...prev };
+      if (nextPersisted !== null) result.persistedTabBuckets = nextPersisted;
+      if (suppressed.size > 0) {
+        result.closedSessionIds = mergeClosedSessionIds(
+          prev.closedSessionIds,
+          suppressed,
+        );
+      }
+      return result;
+    });
+  }
+
+  // Retire any background workers still running for swept hidden tabs.
+  for (const tabId of suppressed) {
+    invoke("agent_command", {
+      payload: JSON.stringify({ type: "tab_close", tabId }),
+    }).catch(() => {
+      /* best-effort teardown */
+    });
+  }
+
+  if (visibleOrphans.length > 0 || suppressed.size > 0) {
+    deps.syncRecentSessionsToState();
+  }
+}

--- a/src/hooks/projectOps/tabBuckets.ts
+++ b/src/hooks/projectOps/tabBuckets.ts
@@ -40,16 +40,14 @@ function isSameOrChildPath(path: string, root: string): boolean {
   return path === root || path.startsWith(`${root}/`);
 }
 
-function pathForTab(tab: Tab): string | undefined {
+export function pathForTab(tab: Tab): string | undefined {
   if (tab.kind === "shell") return tab.shell?.cwd ?? tab.cwd;
-  if (tab.kind === "editor") return tab.editor?.rootPath ?? tab.editor?.filePath;
+  if (tab.kind === "editor")
+    return tab.editor?.rootPath ?? tab.editor?.filePath;
   return tab.cwd;
 }
 
-export function tabBucketKeyForTab(
-  projects: ProjectsState,
-  tab: Tab,
-): string {
+export function tabBucketKeyForTab(projects: ProjectsState, tab: Tab): string {
   if (!tab.projectId) return NO_PROJECT_KEY;
   const resolved = workspaceIdForCwd(projects, pathForTab(tab), tab.projectId);
   return projectScopeBucketKey(tab.projectId, resolved ?? null);

--- a/src/hooks/projectOps/workspaceOperations.ts
+++ b/src/hooks/projectOps/workspaceOperations.ts
@@ -46,10 +46,20 @@ export function useWorkspaceOperations(
       workspaceId,
     );
 
+  const tabCleanupDeps = {
+    setState: deps.setState,
+    stateRef: deps.stateRef,
+    tabBucketsRef: deps.tabBucketsRef,
+    syncRecentSessionsToState: deps.syncRecentSessionsToState,
+    closeTabNow: deps.closeTabNow,
+    activateWorkspace: activateWorkspaceBound,
+  };
+
   const refreshDeps = {
     projectsRef: deps.projectsRef,
     lookups,
     persistProjects: deps.persistProjects,
+    tabCleanup: tabCleanupDeps,
   };
 
   const gitDeps = {
@@ -60,6 +70,7 @@ export function useWorkspaceOperations(
     persistProjects: deps.persistProjects,
     setActiveProjectById: deps.setActiveProjectById,
     activateWorkspace: activateWorkspaceBound,
+    tabCleanup: tabCleanupDeps,
   };
 
   const dismissPendingWorkspaceBound = (workspaceId: string): void =>
@@ -110,13 +121,7 @@ export function useWorkspaceOperations(
           lookups,
           syncProjectsToState: deps.syncProjectsToState,
           persistProjects: deps.persistProjects,
-          tabCleanupDeps: {
-            stateRef: deps.stateRef,
-            tabBucketsRef: deps.tabBucketsRef,
-            syncRecentSessionsToState: deps.syncRecentSessionsToState,
-            closeTabNow: deps.closeTabNow,
-            activateWorkspace: activateWorkspaceBound,
-          },
+          tabCleanupDeps,
           workspacePrompts: deps.workspacePrompts,
         },
         workspaceId,

--- a/src/hooks/projectOps/workspaceOps/git.ts
+++ b/src/hooks/projectOps/workspaceOps/git.ts
@@ -15,6 +15,10 @@ import {
   reconcileWorkspaces,
   updateWorkspacePendingState,
 } from "../../../workspaces";
+import {
+  closeTabsForRemovedWorkspace,
+  type TabCleanupDeps,
+} from "./tabCleanup";
 import type { ProjectLookups } from "./types";
 
 interface GitDeps {
@@ -25,6 +29,10 @@ interface GitDeps {
   persistProjects: () => Promise<void>;
   setActiveProjectById: (id: string) => boolean;
   activateWorkspace: (workspaceId: string | null) => void;
+  /** When present, reconcile-pruned workspaces (worktree removed outside
+   *  the app) get the same tab/bucket/session retirement as an in-app
+   *  removal. Optional so pure listing callers stay side-effect free. */
+  tabCleanup?: TabCleanupDeps;
 }
 
 export function resolveWorkspaceBaseBranch(
@@ -56,12 +64,16 @@ function trimTrailingSeparators(path: string): string {
 }
 
 function pathBasename(path: string): string {
-  const parts = trimTrailingSeparators(path).split(/[\\/]+/).filter(Boolean);
+  const parts = trimTrailingSeparators(path)
+    .split(/[\\/]+/)
+    .filter(Boolean);
   return parts[parts.length - 1] ?? "repo";
 }
 
 function safePathSegment(value: string, fallback: string): string {
-  return value.replace(/[^a-z0-9._-]/gi, "-").replace(/^-+|-+$/g, "") || fallback;
+  return (
+    value.replace(/[^a-z0-9._-]/gi, "-").replace(/^-+|-+$/g, "") || fallback
+  );
 }
 
 async function pickGeneratedWorkspaceBranch(
@@ -103,7 +115,10 @@ export function navigateToWorkspace(
 }
 
 export async function refreshProjectWorkspaces(
-  deps: Pick<GitDeps, "projectsRef" | "lookups" | "persistProjects">,
+  deps: Pick<
+    GitDeps,
+    "projectsRef" | "lookups" | "persistProjects" | "tabCleanup"
+  >,
   projectId: string,
 ): Promise<void> {
   const project = deps.lookups.findProject(projectId);
@@ -112,6 +127,30 @@ export async function refreshProjectWorkspaces(
     const listing = await gitWorktrees(project.path);
     const prior = deps.projectsRef.current.workspacesByProject[projectId] ?? [];
     const next = reconcileWorkspaces(projectId, prior, listing);
+    // A successful listing that no longer shows a previously-live
+    // workspace means its worktree was removed outside the app (a task
+    // runner archiving its branch, a manual `git worktree remove`, …).
+    // Retire its tabs, buckets, and session discoverability exactly like
+    // an in-app removal — otherwise the dropped workspace's sessions
+    // squat in whatever workspace is active and auto-restore can
+    // resurrect them later. Pending rows are skipped: they're still
+    // in-flight on the create/remove state machines.
+    if (deps.tabCleanup) {
+      const nextIds = new Set(next.map((w) => w.id));
+      const pruned = prior.filter(
+        (w) => !nextIds.has(w.id) && !w.isMain && !w.pendingState,
+      );
+      for (const workspace of pruned) {
+        const ps = deps.projectsRef.current;
+        closeTabsForRemovedWorkspace(
+          deps.tabCleanup,
+          projectId,
+          workspace.id,
+          workspace.path,
+          ps.activeId === projectId && ps.activeWorkspaceId === workspace.id,
+        );
+      }
+    }
     let nextState = setProjectWorkspaces(
       deps.projectsRef.current,
       projectId,
@@ -216,9 +255,7 @@ export async function createWorkspaceWithParams(
       deps.projectsRef.current.workspacesByProject[opts.projectId] ?? [];
     const live = list.find(
       (w) =>
-        w.id === pending.id ||
-        w.path === created.path ||
-        w.path === targetPath,
+        w.id === pending.id || w.path === created.path || w.path === targetPath,
     );
     navigateToWorkspace(deps, opts.projectId, live?.id ?? pending.id);
     return live?.path ?? created.path ?? targetPath;

--- a/src/hooks/projectOps/workspaceOps/remove.ts
+++ b/src/hooks/projectOps/workspaceOps/remove.ts
@@ -6,25 +6,18 @@ import {
   removeWorkspaceFromList,
   type Workspace,
 } from "../../../workspaces";
-import { closeTabsForRemovedWorkspace } from "./tabCleanup";
-import type {
-  ProjectLookups,
-  WorkspaceOperationDeps,
-  WorkspaceRemovalPrompts,
-} from "./types";
+import {
+  closeTabsForRemovedWorkspace,
+  type TabCleanupDeps,
+} from "./tabCleanup";
+import type { ProjectLookups, WorkspaceRemovalPrompts } from "./types";
 
 interface RemoveDeps {
   projectsRef: MutableRefObject<ProjectsState>;
   lookups: ProjectLookups;
   syncProjectsToState: () => void;
   persistProjects: () => Promise<void>;
-  tabCleanupDeps: {
-    stateRef: WorkspaceOperationDeps["stateRef"];
-    tabBucketsRef: WorkspaceOperationDeps["tabBucketsRef"];
-    syncRecentSessionsToState: WorkspaceOperationDeps["syncRecentSessionsToState"];
-    closeTabNow: WorkspaceOperationDeps["closeTabNow"];
-    activateWorkspace: (workspaceId: string | null) => void;
-  };
+  tabCleanupDeps: TabCleanupDeps;
   workspacePrompts: WorkspaceRemovalPrompts;
 }
 

--- a/src/hooks/projectOps/workspaceOps/tabCleanup.ts
+++ b/src/hooks/projectOps/workspaceOps/tabCleanup.ts
@@ -1,9 +1,11 @@
-import type { MutableRefObject } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 import type { Tab } from "../../../types/tab";
 import { normalizeSessionPath, projectScopeBucketKey } from "../tabBuckets";
 import type { TabBucket } from "../types";
 
-interface TabCleanupDeps {
+export interface TabCleanupDeps {
+  setState: Dispatch<SetStateAction<Record<string, unknown>>>;
   stateRef: MutableRefObject<Record<string, unknown>>;
   tabBucketsRef: MutableRefObject<Map<string, TabBucket>>;
   syncRecentSessionsToState: () => void;
@@ -11,9 +13,71 @@ interface TabCleanupDeps {
   activateWorkspace: (workspaceId: string | null) => void;
 }
 
+const CLOSED_SESSION_IDS_CAP = 200;
+
 function tabCwdMatches(tab: Tab, path: string): boolean {
-  if (tab.kind !== "agent") return false;
-  return normalizeSessionPath(tab.cwd) === normalizeSessionPath(path);
+  const target = normalizeSessionPath(path);
+  if (!target) return false;
+  if (tab.kind === "agent") return normalizeSessionPath(tab.cwd) === target;
+  // Shell tabs anchor their PTY at shell.cwd; a removed worktree leaves
+  // them pointing at a deleted directory, so they go too.
+  if (tab.kind === "shell") {
+    return normalizeSessionPath(tab.shell?.cwd ?? tab.cwd) === target;
+  }
+  return false;
+}
+
+function readPersistedBuckets(
+  value: unknown,
+): Record<string, TabBucket> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, TabBucket>;
+}
+
+/** Agent-tab ids belonging to the removed workspace, gathered from every
+ *  store: its own bucket (matching cwd or not — the bucket IS the
+ *  workspace's tab set), plus matching-cwd tabs in any other bucket and
+ *  the persisted mirror. Must run BEFORE any mutation: the wasActive
+ *  bucket switch rewrites the removed workspace's bucket and would lose
+ *  these ids. */
+function collectRemovedSessionIds(
+  deps: Pick<TabCleanupDeps, "stateRef" | "tabBucketsRef">,
+  path: string,
+  removedBucketKey: string,
+): Set<string> {
+  const suppressed = new Set<string>();
+  const collect = (key: string, tabs: readonly Tab[] | undefined) => {
+    for (const tab of tabs ?? []) {
+      if (tab.kind !== "agent") continue;
+      if (key === removedBucketKey || tabCwdMatches(tab, path)) {
+        suppressed.add(tab.id);
+      }
+    }
+  };
+  for (const [key, bucket] of deps.tabBucketsRef.current.entries()) {
+    collect(key, bucket.tabs);
+  }
+  const persisted = readPersistedBuckets(
+    deps.stateRef.current.persistedTabBuckets,
+  );
+  if (persisted) {
+    for (const [key, bucket] of Object.entries(persisted)) {
+      collect(key, bucket.tabs);
+    }
+  }
+  return suppressed;
+}
+
+function filterBucket(bucket: TabBucket, path: string): TabBucket | null {
+  const keep = bucket.tabs.filter((tab) => !tabCwdMatches(tab, path));
+  if (keep.length === bucket.tabs.length) return bucket;
+  if (keep.length === 0) return null;
+  return {
+    tabs: keep,
+    activeTabId: keep.some((tab) => tab.id === bucket.activeTabId)
+      ? bucket.activeTabId
+      : keep[0]?.id,
+  };
 }
 
 function removeStoredTabsForWorkspacePath(
@@ -23,16 +87,13 @@ function removeStoredTabsForWorkspacePath(
 ): void {
   tabBucketsRef.current.delete(removedBucketKey);
   for (const [key, bucket] of tabBucketsRef.current.entries()) {
-    const tabs = bucket.tabs.filter((tab) => !tabCwdMatches(tab, path));
-    if (tabs.length === bucket.tabs.length) continue;
-    if (tabs.length === 0) {
+    const next = filterBucket(bucket, path);
+    if (next === bucket) continue;
+    if (next === null) {
       tabBucketsRef.current.delete(key);
       continue;
     }
-    const activeTabId = tabs.some((tab) => tab.id === bucket.activeTabId)
-      ? bucket.activeTabId
-      : tabs[0]?.id;
-    tabBucketsRef.current.set(key, { tabs, activeTabId });
+    tabBucketsRef.current.set(key, next);
   }
 }
 
@@ -40,12 +101,23 @@ function closeVisibleTabsForWorkspacePath(
   stateRef: MutableRefObject<Record<string, unknown>>,
   closeTabNow: (tabId: string) => void,
   path: string,
-): void {
+): Set<string> {
   const tabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
-  const closing = tabs
-    .filter((tab) => tabCwdMatches(tab, path))
-    .map((tab) => tab.id);
-  for (const tabId of closing) closeTabNow(tabId);
+  const closing = tabs.filter((tab) => tabCwdMatches(tab, path));
+  for (const tab of closing) closeTabNow(tab.id);
+  return new Set(
+    closing.filter((tab) => tab.kind === "agent").map((tab) => tab.id),
+  );
+}
+
+export function mergeClosedSessionIds(
+  prev: unknown,
+  ids: Iterable<string>,
+): string[] {
+  const closedIds = Array.isArray(prev) ? (prev as string[]) : [];
+  return Array.from(new Set([...closedIds, ...ids])).slice(
+    -CLOSED_SESSION_IDS_CAP,
+  );
 }
 
 export function closeTabsForRemovedWorkspace(
@@ -55,12 +127,76 @@ export function closeTabsForRemovedWorkspace(
   path: string,
   wasActive: boolean,
 ): void {
-  closeVisibleTabsForWorkspacePath(deps.stateRef, deps.closeTabNow, path);
-  if (wasActive) deps.activateWorkspace(null);
-  removeStoredTabsForWorkspacePath(
-    deps.tabBucketsRef,
+  const removedBucketKey = projectScopeBucketKey(projectId, workspaceId);
+  const suppressed = collectRemovedSessionIds(deps, path, removedBucketKey);
+  const visibleAgentClosed = closeVisibleTabsForWorkspacePath(
+    deps.stateRef,
+    deps.closeTabNow,
     path,
-    projectScopeBucketKey(projectId, workspaceId),
   );
+  if (wasActive) deps.activateWorkspace(null);
+  removeStoredTabsForWorkspacePath(deps.tabBucketsRef, path, removedBucketKey);
+
+  // Purge the persisted-bucket mirror too — otherwise a webview reload
+  // rehydrates the removed workspace's tabs straight back into the ref.
+  // Read it AFTER the activate/close mutations so we purge the freshest
+  // mirror, but suppress with the ids collected up front.
+  const persisted = readPersistedBuckets(
+    deps.stateRef.current.persistedTabBuckets,
+  );
+  let nextPersisted: Record<string, TabBucket> | null = null;
+  if (persisted) {
+    let changed = false;
+    const result: Record<string, TabBucket> = {};
+    for (const [key, bucket] of Object.entries(persisted)) {
+      if (key === removedBucketKey) {
+        changed = true;
+        continue;
+      }
+      const original: TabBucket = {
+        tabs: bucket.tabs ?? [],
+        activeTabId: bucket.activeTabId,
+      };
+      const next = filterBucket(original, path);
+      if (next === original) {
+        result[key] = bucket;
+        continue;
+      }
+      changed = true;
+      if (next === null) continue;
+      result[key] = next;
+    }
+    if (changed) nextPersisted = result;
+  }
+
+  if (nextPersisted !== null || suppressed.size > 0) {
+    deps.setState((prev) => {
+      const result: Record<string, unknown> = { ...prev };
+      if (nextPersisted !== null) result.persistedTabBuckets = nextPersisted;
+      if (suppressed.size > 0) {
+        // Suppress the retired sessions from discovery-driven auto-restore.
+        // A deleted workspace's session must not resurrect into whatever
+        // workspace happens to be active later.
+        result.closedSessionIds = mergeClosedSessionIds(
+          prev.closedSessionIds,
+          suppressed,
+        );
+      }
+      return result;
+    });
+  }
+
+  // Retire background workers for tabs that were never visible —
+  // closeTabNow already sent tab_close for the visible ones. The bridge
+  // no-ops on unknown tab ids.
+  for (const tabId of suppressed) {
+    if (visibleAgentClosed.has(tabId)) continue;
+    invoke("agent_command", {
+      payload: JSON.stringify({ type: "tab_close", tabId }),
+    }).catch(() => {
+      /* best-effort teardown */
+    });
+  }
+
   deps.syncRecentSessionsToState();
 }

--- a/src/hooks/projectOps/workspaceOps/types.ts
+++ b/src/hooks/projectOps/workspaceOps/types.ts
@@ -1,10 +1,11 @@
-import type { MutableRefObject } from "react";
+import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 import type { Project, ProjectsState } from "../../../projects";
 import type { Workspace } from "../../../workspaces";
 import type { TabBucket } from "../types";
 
 export interface WorkspaceOperationDeps {
   projectsRef: MutableRefObject<ProjectsState>;
+  setState: Dispatch<SetStateAction<Record<string, unknown>>>;
   stateRef: MutableRefObject<Record<string, unknown>>;
   tabBucketsRef: MutableRefObject<Map<string, TabBucket>>;
   syncProjectsToState: () => void;

--- a/src/hooks/useProjectOps.test.ts
+++ b/src/hooks/useProjectOps.test.ts
@@ -975,7 +975,9 @@ describe("useProjectOps workspace refresh", () => {
     });
 
     expect(projectsRef.current.activeWorkspaceId).toBeNull();
-    expect(projectsRef.current.workspacesByProject["project-1"]).toHaveLength(1);
+    expect(projectsRef.current.workspacesByProject["project-1"]).toHaveLength(
+      1,
+    );
     expect(
       projectsRef.current.workspacesByProject["project-1"]?.[0],
     ).toMatchObject({
@@ -983,6 +985,86 @@ describe("useProjectOps workspace refresh", () => {
       branch: "main",
       isMain: true,
     });
+  });
+
+  it("retires tabs and sessions for a workspace pruned by an external worktree removal", async () => {
+    const harness = installTauriMocks();
+    harness.invoke.mockImplementation((cmd: string) => {
+      if (cmd === "git_worktrees") {
+        return Promise.resolve([
+          {
+            path: "/projects/aethon",
+            branch: "main",
+            head: "abc123",
+            isMain: true,
+            locked: false,
+          },
+        ]);
+      }
+      return Promise.resolve(undefined);
+    });
+    const externallyRemoved = {
+      id: "wt-archived",
+      projectId: "project-1",
+      path: "/projects/aethon-archived",
+      branch: "archived",
+      isMain: false,
+    };
+    const makeInitial = () =>
+      makeProjectsState({
+        activeId: "project-1",
+        activeWorkspaceId: "wt-archived",
+        workspacesByProject: { "project-1": [externallyRemoved] },
+      });
+    const { result, projectsRef, stateRef, closeTabNow } =
+      renderProjectOps(makeInitial());
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    projectsRef.current = makeInitial();
+    const removedKey = projectScopeBucketKey("project-1", "wt-archived");
+    stateRef.current = {
+      activeTabId: "visible-archived-tab",
+      closedSessionIds: [],
+      tabs: [
+        nonEmptyAgentTab(
+          "visible-archived-tab",
+          "Archived task",
+          "project-1",
+          "/projects/aethon-archived",
+        ),
+      ],
+    };
+    result.current.tabBucketsRef.current.set(removedKey, {
+      activeTabId: "hidden-archived-tab",
+      tabs: [
+        nonEmptyAgentTab(
+          "hidden-archived-tab",
+          "Hidden archived task",
+          "project-1",
+          "/projects/aethon-archived",
+        ),
+      ],
+    });
+
+    await act(async () => {
+      await result.current.refreshProjectWorkspaces("project-1");
+    });
+
+    // The reconcile prune retires the workspace's tabs exactly like an
+    // in-app removal: visible tab closed, stored bucket dropped, hidden
+    // session suppressed from auto-restore, worker told to retire.
+    expect(closeTabNow).toHaveBeenCalledWith("visible-archived-tab");
+    expect(result.current.tabBucketsRef.current.has(removedKey)).toBe(false);
+    expect(stateRef.current.closedSessionIds).toContain("hidden-archived-tab");
+    expect(harness.invoke).toHaveBeenCalledWith("agent_command", {
+      payload: JSON.stringify({
+        type: "tab_close",
+        tabId: "hidden-archived-tab",
+      }),
+    });
+    expect(projectsRef.current.activeWorkspaceId).toBeNull();
   });
 });
 
@@ -1107,9 +1189,7 @@ describe("useProjectOps workspace creation", () => {
       base: "origin/main",
     });
     expect(addCall?.[1]?.branch).toMatch(/^feat\//);
-    expect(addCall?.[1]?.targetPath).toMatch(
-      /^\/tmp\/aethon\/aethon\/feat-/,
-    );
+    expect(addCall?.[1]?.targetPath).toMatch(/^\/tmp\/aethon\/aethon\/feat-/);
     expect(created).toBe(addCall?.[1]?.targetPath);
   });
 
@@ -1255,9 +1335,7 @@ describe("useProjectOps workspace removal", () => {
       worktreePath: "/projects/aethon-fix-issue",
       force: false,
     });
-    await waitFor(() =>
-      expect(closeTabNow).toHaveBeenCalledWith("issue-tab"),
-    );
+    await waitFor(() => expect(closeTabNow).toHaveBeenCalledWith("issue-tab"));
     expect(
       result.current.tabBucketsRef.current.has(
         projectScopeBucketKey("project-1", "wt-issue"),
@@ -1271,6 +1349,95 @@ describe("useProjectOps workspace removal", () => {
         ),
       ).toBe(false),
     );
+  });
+
+  it("suppresses removed-workspace sessions and closes matching shell tabs", async () => {
+    const harness = installTauriMocks();
+    harness.invoke.mockImplementation(() => Promise.resolve(undefined));
+    const workspace = {
+      id: "wt-issue",
+      projectId: "project-1",
+      path: "/projects/aethon-fix-issue",
+      branch: "fix/issue",
+      isMain: false,
+    };
+    const initial = makeProjectsState({
+      activeId: "project-1",
+      activeWorkspaceId: null,
+      workspacesByProject: {
+        "project-1": [
+          {
+            id: "wt-main",
+            projectId: "project-1",
+            path: "/projects/aethon",
+            branch: "main",
+            isMain: true,
+          },
+          workspace,
+        ],
+      },
+    });
+    const { result, projectsRef, stateRef, closeTabNow } =
+      renderProjectOps(initial);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    projectsRef.current = initial;
+    const removedKey = projectScopeBucketKey("project-1", "wt-issue");
+    stateRef.current = {
+      activeTabId: "shell-tab",
+      closedSessionIds: [],
+      tabs: [
+        {
+          ...makeEmptyTab("shell-tab", "Shell", "project-1", "shell"),
+          cwd: "/projects/aethon-fix-issue",
+        },
+      ],
+      persistedTabBuckets: {
+        [removedKey]: {
+          activeTabId: "persisted-issue-tab",
+          tabs: [
+            {
+              ...makeEmptyTab("persisted-issue-tab", "Persisted"),
+              projectId: "project-1",
+              cwd: "/projects/aethon-fix-issue",
+            },
+          ],
+        },
+      },
+    };
+    result.current.tabBucketsRef.current.set(removedKey, {
+      activeTabId: "hidden-issue-tab",
+      tabs: [
+        {
+          ...makeEmptyTab("hidden-issue-tab", "Hidden issue"),
+          projectId: "project-1",
+          cwd: "/projects/aethon-fix-issue",
+        },
+      ],
+    });
+
+    await act(async () => {
+      await result.current.removeWorkspaceById("wt-issue", { confirmed: true });
+    });
+
+    // The shell tab anchored in the removed worktree closes with it.
+    await waitFor(() => expect(closeTabNow).toHaveBeenCalledWith("shell-tab"));
+    // Hidden bucket sessions are suppressed from discovery auto-restore
+    // and their background workers are told to retire.
+    await waitFor(() =>
+      expect(stateRef.current.closedSessionIds).toContain("hidden-issue-tab"),
+    );
+    expect(stateRef.current.closedSessionIds).toContain("persisted-issue-tab");
+    expect(
+      (stateRef.current.persistedTabBuckets as Record<string, unknown>)[
+        removedKey
+      ],
+    ).toBeUndefined();
+    expect(harness.invoke).toHaveBeenCalledWith("agent_command", {
+      payload: JSON.stringify({ type: "tab_close", tabId: "hidden-issue-tab" }),
+    });
   });
 
   it("marks the row as removing before a delayed git removal resolves", async () => {
@@ -1461,7 +1628,8 @@ describe("useProjectOps workspace removal", () => {
         return Promise.reject(
           new Error("workspace not tracked: /projects/aethon-fix-issue"),
         );
-      if (cmd === "git_worktree_remove_orphan") return Promise.resolve(undefined);
+      if (cmd === "git_worktree_remove_orphan")
+        return Promise.resolve(undefined);
       return Promise.resolve(undefined);
     });
     const initial = makeProjectsState({
@@ -1542,15 +1710,18 @@ describe("useProjectOps workspace removal", () => {
       },
     });
     const promptOrphanCleanup = vi.fn(() => Promise.resolve(false));
-    const { result, projectsRef, workspacePrompts } = renderProjectOps(initial, {
-      workspacePrompts: {
-        promptRemoveWorkspace: vi.fn(() => Promise.resolve(true)),
-        promptForceRemove: vi.fn(() => Promise.resolve(true)),
-        promptOrphanCleanup,
-        notifyCannotRemoveMain: vi.fn(),
-        notifyFailure: vi.fn(),
+    const { result, projectsRef, workspacePrompts } = renderProjectOps(
+      initial,
+      {
+        workspacePrompts: {
+          promptRemoveWorkspace: vi.fn(() => Promise.resolve(true)),
+          promptForceRemove: vi.fn(() => Promise.resolve(true)),
+          promptOrphanCleanup,
+          notifyCannotRemoveMain: vi.fn(),
+          notifyFailure: vi.fn(),
+        },
       },
-    });
+    );
     await act(async () => {
       await Promise.resolve();
     });

--- a/src/hooks/useProjectOps.ts
+++ b/src/hooks/useProjectOps.ts
@@ -24,6 +24,7 @@ import { editorLabelForPath } from "./tabOps/helpers";
 import { TAB_MIRROR_KEYS } from "./tabOps/constants";
 import { disposeEditorBuffer } from "../monaco/editor-buffers";
 import { useProjectStore } from "./projectOps/projectStore";
+import { sweepOrphanWorkspaceTabs } from "./projectOps/orphanTabSweep";
 import { recordWorkspaceActivation } from "./statusPollScheduler";
 import {
   projectScopeBucketKey,
@@ -278,6 +279,7 @@ export function useProjectOps(ctx: UseProjectOpsContext): UseProjectOpsActions {
 
   const workspaceOps = useWorkspaceOperations({
     projectsRef,
+    setState,
     stateRef,
     tabBucketsRef,
     syncProjectsToState,
@@ -315,6 +317,17 @@ export function useProjectOps(ctx: UseProjectOpsContext): UseProjectOpsActions {
           return { ...prev, tabs };
         });
       }
+      // Retire tabs whose backing workspace no longer exists BEFORE
+      // auto-restore runs, so their session ids are suppressed by the
+      // time discovery could resurrect them.
+      sweepOrphanWorkspaceTabs({
+        setState,
+        stateRef,
+        projectsRef,
+        tabBucketsRef,
+        closeTabNow,
+        syncRecentSessionsToState,
+      });
       const scoped = scopedDiscoveredSessions(allDiscoveredSessionsRef.current);
       autoRestoreDiscoveredSessions(scoped, knownTabIds());
       syncRecentSessionsToState();
@@ -381,7 +394,8 @@ export function useProjectOps(ctx: UseProjectOpsContext): UseProjectOpsActions {
       `${t.editor?.filePath}::${t.editor?.diff ? "d" : "e"}`;
     const activeRestored = persisted.activeFilePath
       ? restored.find(
-          (t) => t.editor?.filePath === persisted.activeFilePath && !t.editor?.diff,
+          (t) =>
+            t.editor?.filePath === persisted.activeFilePath && !t.editor?.diff,
         )
       : undefined;
     setState((prev) => {


### PR DESCRIPTION
## Problem

A session from an old archived/deleted task workflow appeared inside a *different, newly created* workspace's tab strip (observed live: a deleted `feat/issue-542` workspace's session — 76 messages, still streaming — sitting in the `fix/issue-536` workspace, alongside that dead workspace's shell tab).

## Root cause

Three gaps lined up:

1. **External worktree removal is cleanup-free.** `refreshProjectWorkspaces` (which runs on every project activation and after workspace creation) reconciles against `git worktree list` and silently drops records whose worktree was removed outside the app — a task runner archiving its branch, a manual `git worktree remove`. No tab close, no bucket purge, no session suppression. If the pruned workspace was active, `activeWorkspaceId` was nulled **without a bucket switch**, stranding the dead workspace's tabs in the visible strip to be re-attributed to whatever workspace is shown next.
2. **In-app removal misses several stores.** `closeTabsForRemovedWorkspace` dropped stored-bucket agent tabs without adding their ids to `closedSessionIds` — so bridge session discovery could auto-restore them later (`scopedDiscoveredSessions`' no-active-project branch actively *selects* sessions whose cwd matches no known workspace, which is exactly what a deleted workspace's session looks like). It also never matched shell tabs (`tabCwdMatches` only handled `kind === "agent"`), never purged the `persistedTabBuckets` mirror (a webview reload rehydrated the removed workspace's tabs straight back), and never told background workers to retire.
3. **Boot restores verbatim.** The strip and buckets restore with no validation against the live workspace set — stale buckets keyed to long-deleted workspace ids (observed for two older task workspaces) leak forever.

## Fix

- **Reconcile prune = real removal.** Workspaces dropped by a successful `git worktree list` reconcile now get the same retirement as an in-app removal: visible tabs closed, stored + persisted buckets purged, session ids suppressed, background workers sent `tab_close`. Pending rows are exempt (still in-flight on the create/remove state machines).
- **Removal cleanup is now authoritative across all stores.** Suppression ids are collected from every store *before* the `wasActive` bucket switch can rewrite the removed workspace's bucket (a real ordering bug the new test caught); shell tabs anchored in the removed worktree close too; the `persistedTabBuckets` mirror is purged; suppressed ids merge into `closedSessionIds` (cap 200).
- **Boot orphan sweep.** `sweepOrphanWorkspaceTabs` runs once after projects load, before session auto-restore: tabs that name a known project whose workspace list is loaded but whose cwd resolves to no live project/workspace path are retired, and buckets keyed to workspace ids that no longer exist are dropped. Deliberately conservative — tabs with no `projectId`, an unloaded workspace list, or no cwd are left alone. This also heals already-corrupted installs on next launch.

## Tests

- `orphanTabSweep.test.ts` — orphan predicate edges (live workspace, main checkout, unloaded list, no-project) plus sweep behavior across strip, live buckets, and persisted mirror.
- `useProjectOps.test.ts` — in-app removal now suppresses hidden-bucket sessions, closes matching shell tabs, purges the persisted mirror, and retires workers; external reconcile-prune retires tabs exactly like an in-app removal.

`tsc -b`, ESLint (0/0), and the full vitest suite (2128 tests) pass.