### PR TITLE
fix(workspaces): close hidden shell PTYs when their workspace is retired

### DIFF
--- a/src/hooks/projectOps/orphanTabSweep.test.ts
+++ b/src/hooks/projectOps/orphanTabSweep.test.ts
@@ -171,7 +171,13 @@ describe("sweepOrphanWorkspaceTabs", () => {
     const deadKey = projectScopeBucketKey("project-1", "ws-deleted");
     const liveKey = projectScopeBucketKey("project-1", "ws-live");
     const deadBucket: TabBucket = {
-      tabs: [agentTab("dead-tab", "project-1", "/projects/aethon-deleted")],
+      tabs: [
+        agentTab("dead-tab", "project-1", "/projects/aethon-deleted"),
+        {
+          ...makeEmptyTab("dead-shell", "Shell", "project-1", "shell"),
+          cwd: "/projects/aethon-deleted",
+        },
+      ],
       activeTabId: "dead-tab",
     };
     const liveBucket: TabBucket = {
@@ -196,8 +202,16 @@ describe("sweepOrphanWorkspaceTabs", () => {
     expect(persisted[deadKey]).toBeUndefined();
     expect(persisted[liveKey]).toBeDefined();
     expect(stateRef.current.closedSessionIds).toContain("dead-tab");
+    // Shell ids never enter closedSessionIds — that list is for agent
+    // session suppression only.
+    expect(stateRef.current.closedSessionIds).not.toContain("dead-shell");
     expect(harness.invoke).toHaveBeenCalledWith("agent_command", {
       payload: JSON.stringify({ type: "tab_close", tabId: "dead-tab" }),
+    });
+    // The hidden shell's PTY is still alive in the Rust registry —
+    // sweeping its tab must close it explicitly.
+    expect(harness.invoke).toHaveBeenCalledWith("shell_close", {
+      tabId: "dead-shell",
     });
   });
 

--- a/src/hooks/projectOps/orphanTabSweep.ts
+++ b/src/hooks/projectOps/orphanTabSweep.ts
@@ -60,24 +60,30 @@ function bucketWorkspaceIsGone(
 }
 
 /** Returns the cleaned bucket, `null` to drop it, or the input bucket
- *  unchanged (identity) when nothing matched. */
+ *  unchanged (identity) when nothing matched. Swept agent ids land in
+ *  `suppressed` (session suppression + worker teardown); swept shell ids
+ *  in `sweptShells` (their PTYs keep running in the Rust ShellRegistry
+ *  while hidden and need an explicit shell_close). */
 function cleanBucket(
   projects: ProjectsState,
   bucketKey: string,
   bucket: TabBucket,
   suppressed: Set<string>,
+  sweptShells: Set<string>,
 ): TabBucket | null {
   const tabs = bucket.tabs ?? [];
+  const sweep = (tab: Tab) => {
+    if (tab.kind === "agent") suppressed.add(tab.id);
+    if (tab.kind === "shell") sweptShells.add(tab.id);
+  };
   if (bucketWorkspaceIsGone(projects, bucketKey)) {
-    for (const tab of tabs) {
-      if (tab.kind === "agent") suppressed.add(tab.id);
-    }
+    for (const tab of tabs) sweep(tab);
     return null;
   }
   const keep = tabs.filter((tab) => !isOrphanWorkspaceTab(projects, tab));
   if (keep.length === tabs.length) return bucket;
   for (const tab of tabs) {
-    if (tab.kind === "agent" && !keep.includes(tab)) suppressed.add(tab.id);
+    if (!keep.includes(tab)) sweep(tab);
   }
   if (keep.length === 0) return null;
   return {
@@ -101,6 +107,7 @@ function cleanBucket(
 export function sweepOrphanWorkspaceTabs(deps: OrphanTabSweepDeps): void {
   const projects = deps.projectsRef.current;
   const suppressed = new Set<string>();
+  const sweptShells = new Set<string>();
 
   // Visible strip: closeTabNow handles closedSessionIds, bridge
   // tab_close / shell_close, and active-tab mirror fixup.
@@ -112,7 +119,7 @@ export function sweepOrphanWorkspaceTabs(deps: OrphanTabSweepDeps): void {
 
   // Live bucket store.
   for (const [key, bucket] of [...deps.tabBucketsRef.current.entries()]) {
-    const next = cleanBucket(projects, key, bucket, suppressed);
+    const next = cleanBucket(projects, key, bucket, suppressed, sweptShells);
     if (next === bucket) continue;
     if (next === null) deps.tabBucketsRef.current.delete(key);
     else deps.tabBucketsRef.current.set(key, next);
@@ -131,7 +138,7 @@ export function sweepOrphanWorkspaceTabs(deps: OrphanTabSweepDeps): void {
     let changed = false;
     const result: Record<string, TabBucket> = {};
     for (const [key, bucket] of Object.entries(persisted)) {
-      const next = cleanBucket(projects, key, bucket, suppressed);
+      const next = cleanBucket(projects, key, bucket, suppressed, sweptShells);
       if (next === bucket) {
         result[key] = bucket;
         continue;
@@ -157,7 +164,8 @@ export function sweepOrphanWorkspaceTabs(deps: OrphanTabSweepDeps): void {
     });
   }
 
-  // Retire any background workers still running for swept hidden tabs.
+  // Retire any background workers and hidden-shell PTYs still running
+  // for swept hidden tabs. Both sides no-op on unknown tab ids.
   for (const tabId of suppressed) {
     invoke("agent_command", {
       payload: JSON.stringify({ type: "tab_close", tabId }),
@@ -165,8 +173,17 @@ export function sweepOrphanWorkspaceTabs(deps: OrphanTabSweepDeps): void {
       /* best-effort teardown */
     });
   }
+  for (const tabId of sweptShells) {
+    invoke("shell_close", { tabId }).catch(() => {
+      /* idempotent — already torn down by natural exit */
+    });
+  }
 
-  if (visibleOrphans.length > 0 || suppressed.size > 0) {
+  if (
+    visibleOrphans.length > 0 ||
+    suppressed.size > 0 ||
+    sweptShells.size > 0
+  ) {
     deps.syncRecentSessionsToState();
   }
 }

--- a/src/hooks/projectOps/workspaceOps/tabCleanup.ts
+++ b/src/hooks/projectOps/workspaceOps/tabCleanup.ts
@@ -34,23 +34,26 @@ function readPersistedBuckets(
   return value as Record<string, TabBucket>;
 }
 
-/** Agent-tab ids belonging to the removed workspace, gathered from every
+/** Tab ids belonging to the removed workspace, gathered from every
  *  store: its own bucket (matching cwd or not — the bucket IS the
  *  workspace's tab set), plus matching-cwd tabs in any other bucket and
- *  the persisted mirror. Must run BEFORE any mutation: the wasActive
- *  bucket switch rewrites the removed workspace's bucket and would lose
- *  these ids. */
-function collectRemovedSessionIds(
+ *  the persisted mirror. Agent ids feed closedSessionIds suppression +
+ *  worker teardown; shell ids feed PTY teardown (their processes keep
+ *  running in the Rust ShellRegistry while hidden). Must run BEFORE any
+ *  mutation: the wasActive bucket switch rewrites the removed
+ *  workspace's bucket and would lose these ids. */
+function collectRemovedTabIds(
   deps: Pick<TabCleanupDeps, "stateRef" | "tabBucketsRef">,
   path: string,
   removedBucketKey: string,
-): Set<string> {
-  const suppressed = new Set<string>();
+): { agentIds: Set<string>; shellIds: Set<string> } {
+  const agentIds = new Set<string>();
+  const shellIds = new Set<string>();
   const collect = (key: string, tabs: readonly Tab[] | undefined) => {
     for (const tab of tabs ?? []) {
-      if (tab.kind !== "agent") continue;
+      if (tab.kind !== "agent" && tab.kind !== "shell") continue;
       if (key === removedBucketKey || tabCwdMatches(tab, path)) {
-        suppressed.add(tab.id);
+        (tab.kind === "agent" ? agentIds : shellIds).add(tab.id);
       }
     }
   };
@@ -65,7 +68,7 @@ function collectRemovedSessionIds(
       collect(key, bucket.tabs);
     }
   }
-  return suppressed;
+  return { agentIds, shellIds };
 }
 
 function filterBucket(bucket: TabBucket, path: string): TabBucket | null {
@@ -105,9 +108,9 @@ function closeVisibleTabsForWorkspacePath(
   const tabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
   const closing = tabs.filter((tab) => tabCwdMatches(tab, path));
   for (const tab of closing) closeTabNow(tab.id);
-  return new Set(
-    closing.filter((tab) => tab.kind === "agent").map((tab) => tab.id),
-  );
+  // closeTabNow owns the full teardown for these (bridge tab_close for
+  // agents, shell_close for shells) — the caller skips them.
+  return new Set(closing.map((tab) => tab.id));
 }
 
 export function mergeClosedSessionIds(
@@ -128,8 +131,12 @@ export function closeTabsForRemovedWorkspace(
   wasActive: boolean,
 ): void {
   const removedBucketKey = projectScopeBucketKey(projectId, workspaceId);
-  const suppressed = collectRemovedSessionIds(deps, path, removedBucketKey);
-  const visibleAgentClosed = closeVisibleTabsForWorkspacePath(
+  const { agentIds: suppressed, shellIds } = collectRemovedTabIds(
+    deps,
+    path,
+    removedBucketKey,
+  );
+  const visibleClosed = closeVisibleTabsForWorkspacePath(
     deps.stateRef,
     deps.closeTabNow,
     path,
@@ -186,15 +193,21 @@ export function closeTabsForRemovedWorkspace(
     });
   }
 
-  // Retire background workers for tabs that were never visible —
-  // closeTabNow already sent tab_close for the visible ones. The bridge
-  // no-ops on unknown tab ids.
+  // Retire background workers and hidden-shell PTYs for tabs that were
+  // never visible — closeTabNow already tore down the visible ones. The
+  // bridge and the shell registry both no-op on unknown tab ids.
   for (const tabId of suppressed) {
-    if (visibleAgentClosed.has(tabId)) continue;
+    if (visibleClosed.has(tabId)) continue;
     invoke("agent_command", {
       payload: JSON.stringify({ type: "tab_close", tabId }),
     }).catch(() => {
       /* best-effort teardown */
+    });
+  }
+  for (const tabId of shellIds) {
+    if (visibleClosed.has(tabId)) continue;
+    invoke("shell_close", { tabId }).catch(() => {
+      /* idempotent — already torn down by natural exit */
     });
   }
 

--- a/src/hooks/useProjectOps.test.ts
+++ b/src/hooks/useProjectOps.test.ts
@@ -1415,6 +1415,10 @@ describe("useProjectOps workspace removal", () => {
           projectId: "project-1",
           cwd: "/projects/aethon-fix-issue",
         },
+        {
+          ...makeEmptyTab("hidden-shell-tab", "Shell", "project-1", "shell"),
+          cwd: "/projects/aethon-fix-issue",
+        },
       ],
     });
 
@@ -1438,6 +1442,12 @@ describe("useProjectOps workspace removal", () => {
     expect(harness.invoke).toHaveBeenCalledWith("agent_command", {
       payload: JSON.stringify({ type: "tab_close", tabId: "hidden-issue-tab" }),
     });
+    // The hidden shell's PTY still runs in the Rust registry — removal
+    // must close it explicitly (visible shells get this via closeTabNow).
+    expect(harness.invoke).toHaveBeenCalledWith("shell_close", {
+      tabId: "hidden-shell-tab",
+    });
+    expect(stateRef.current.closedSessionIds).not.toContain("hidden-shell-tab");
   });
 
   it("marks the row as removing before a delayed git removal resolves", async () => {


### PR DESCRIPTION
Follow-up to #263 addressing both Copilot review findings there (same root issue in two places): shell tabs dropped from **stored buckets** — by in-app workspace removal, the reconcile prune, or the boot orphan sweep — were removed from frontend state without `shell_close`, leaving their PTY processes alive in the Rust `ShellRegistry` with no remaining UI handle to close them. Visible shells were already covered because they go through `closeTabNow`.

- `closeTabsForRemovedWorkspace` now collects swept shell-tab ids from every store (alongside the agent ids) and invokes `shell_close` for any that weren't visible. Idempotent on the Rust side.
- `sweepOrphanWorkspaceTabs` does the same for buckets it prunes/filters.
- Shell ids deliberately stay out of `closedSessionIds` — that list is agent-session suppression only — with a test asserting it.

Tests extended in `orphanTabSweep.test.ts` and `useProjectOps.test.ts` (hidden shell in a removed workspace's bucket → `shell_close` invoked, not in `closedSessionIds`). `tsc -b`, ESLint 0/0, and the project-ops suites pass.