### PR TITLE
fix(workspaces): dispose Monaco buffers for editor tabs in dropped buckets

### DIFF
--- a/src/hooks/projectOps/orphanTabSweep.test.ts
+++ b/src/hooks/projectOps/orphanTabSweep.test.ts
@@ -4,6 +4,11 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { makeEmptyTab, NO_PROJECT_KEY, type Tab } from "../../types/tab";
 import type { ProjectsState } from "../../projects";
 import { installTauriMocks, clearTauriMocks } from "../../test/tauriMocks";
+import { disposeEditorBuffer } from "../../monaco/editor-buffers";
+
+vi.mock("../../monaco/editor-buffers", () => ({
+  disposeEditorBuffer: vi.fn(),
+}));
 import {
   isOrphanWorkspaceTab,
   sweepOrphanWorkspaceTabs,
@@ -177,6 +182,7 @@ describe("sweepOrphanWorkspaceTabs", () => {
           ...makeEmptyTab("dead-shell", "Shell", "project-1", "shell"),
           cwd: "/projects/aethon-deleted",
         },
+        makeEmptyTab("dead-editor", "file.ts", "project-1", "editor"),
       ],
       activeTabId: "dead-tab",
     };
@@ -213,6 +219,10 @@ describe("sweepOrphanWorkspaceTabs", () => {
     expect(harness.invoke).toHaveBeenCalledWith("shell_close", {
       tabId: "dead-shell",
     });
+    // A dropped bucket's editor tabs lose their last UI handle — their
+    // cached Monaco models must be disposed.
+    expect(disposeEditorBuffer).toHaveBeenCalledWith("dead-editor");
+    expect(stateRef.current.closedSessionIds).not.toContain("dead-editor");
   });
 
   it("filters orphan tabs out of live buckets and keeps the rest", () => {

--- a/src/hooks/projectOps/orphanTabSweep.ts
+++ b/src/hooks/projectOps/orphanTabSweep.ts
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import type { Dispatch, MutableRefObject, SetStateAction } from "react";
+import { disposeEditorBuffer } from "../../monaco/editor-buffers";
 import type { ProjectsState } from "../../projects";
 import type { Tab } from "../../types/tab";
 import {
@@ -63,18 +64,22 @@ function bucketWorkspaceIsGone(
  *  unchanged (identity) when nothing matched. Swept agent ids land in
  *  `suppressed` (session suppression + worker teardown); swept shell ids
  *  in `sweptShells` (their PTYs keep running in the Rust ShellRegistry
- *  while hidden and need an explicit shell_close). */
+ *  while hidden and need an explicit shell_close); swept editor ids in
+ *  `sweptEditors` (their cached Monaco models become unreachable once
+ *  the bucket is gone and must be disposed). */
 function cleanBucket(
   projects: ProjectsState,
   bucketKey: string,
   bucket: TabBucket,
   suppressed: Set<string>,
   sweptShells: Set<string>,
+  sweptEditors: Set<string>,
 ): TabBucket | null {
   const tabs = bucket.tabs ?? [];
   const sweep = (tab: Tab) => {
     if (tab.kind === "agent") suppressed.add(tab.id);
     if (tab.kind === "shell") sweptShells.add(tab.id);
+    if (tab.kind === "editor") sweptEditors.add(tab.id);
   };
   if (bucketWorkspaceIsGone(projects, bucketKey)) {
     for (const tab of tabs) sweep(tab);
@@ -108,6 +113,7 @@ export function sweepOrphanWorkspaceTabs(deps: OrphanTabSweepDeps): void {
   const projects = deps.projectsRef.current;
   const suppressed = new Set<string>();
   const sweptShells = new Set<string>();
+  const sweptEditors = new Set<string>();
 
   // Visible strip: closeTabNow handles closedSessionIds, bridge
   // tab_close / shell_close, and active-tab mirror fixup.
@@ -119,7 +125,14 @@ export function sweepOrphanWorkspaceTabs(deps: OrphanTabSweepDeps): void {
 
   // Live bucket store.
   for (const [key, bucket] of [...deps.tabBucketsRef.current.entries()]) {
-    const next = cleanBucket(projects, key, bucket, suppressed, sweptShells);
+    const next = cleanBucket(
+      projects,
+      key,
+      bucket,
+      suppressed,
+      sweptShells,
+      sweptEditors,
+    );
     if (next === bucket) continue;
     if (next === null) deps.tabBucketsRef.current.delete(key);
     else deps.tabBucketsRef.current.set(key, next);
@@ -138,7 +151,14 @@ export function sweepOrphanWorkspaceTabs(deps: OrphanTabSweepDeps): void {
     let changed = false;
     const result: Record<string, TabBucket> = {};
     for (const [key, bucket] of Object.entries(persisted)) {
-      const next = cleanBucket(projects, key, bucket, suppressed, sweptShells);
+      const next = cleanBucket(
+        projects,
+        key,
+        bucket,
+        suppressed,
+        sweptShells,
+        sweptEditors,
+      );
       if (next === bucket) {
         result[key] = bucket;
         continue;
@@ -178,11 +198,17 @@ export function sweepOrphanWorkspaceTabs(deps: OrphanTabSweepDeps): void {
       /* idempotent — already torn down by natural exit */
     });
   }
+  // Swept editor tabs: release their cached Monaco models — nothing can
+  // reach them once the bucket is gone. No-op for ids without a buffer.
+  for (const tabId of sweptEditors) {
+    disposeEditorBuffer(tabId);
+  }
 
   if (
     visibleOrphans.length > 0 ||
     suppressed.size > 0 ||
-    sweptShells.size > 0
+    sweptShells.size > 0 ||
+    sweptEditors.size > 0
   ) {
     deps.syncRecentSessionsToState();
   }

--- a/src/hooks/projectOps/workspaceOps/tabCleanup.ts
+++ b/src/hooks/projectOps/workspaceOps/tabCleanup.ts
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import type { Dispatch, MutableRefObject, SetStateAction } from "react";
+import { disposeEditorBuffer } from "../../../monaco/editor-buffers";
 import type { Tab } from "../../../types/tab";
 import { normalizeSessionPath, projectScopeBucketKey } from "../tabBuckets";
 import type { TabBucket } from "../types";
@@ -34,23 +35,33 @@ function readPersistedBuckets(
   return value as Record<string, TabBucket>;
 }
 
-/** Tab ids belonging to the removed workspace, gathered from every
- *  store: its own bucket (matching cwd or not — the bucket IS the
- *  workspace's tab set), plus matching-cwd tabs in any other bucket and
- *  the persisted mirror. Agent ids feed closedSessionIds suppression +
- *  worker teardown; shell ids feed PTY teardown (their processes keep
- *  running in the Rust ShellRegistry while hidden). Must run BEFORE any
- *  mutation: the wasActive bucket switch rewrites the removed
- *  workspace's bucket and would lose these ids. */
+/** Agent-, shell-, and editor-tab ids retired with the removed
+ *  workspace, gathered from every store: its own bucket (matching cwd
+ *  or not — the bucket IS the workspace's tab set), plus matching-cwd
+ *  agent/shell tabs in any other bucket and the persisted mirror.
+ *  Agent ids feed closedSessionIds suppression + worker teardown;
+ *  shell ids feed PTY teardown (their processes keep running in the
+ *  Rust ShellRegistry while hidden); editor ids feed Monaco buffer
+ *  disposal (the buffer cache is intentionally long-lived for hidden
+ *  buckets, but a dropped bucket leaves no UI handle to ever reach the
+ *  model again). Editor tabs only retire with their own bucket — they
+ *  have no cwd to match elsewhere. Must run BEFORE any mutation: the
+ *  wasActive bucket switch rewrites the removed workspace's bucket and
+ *  would lose these ids. */
 function collectRemovedTabIds(
   deps: Pick<TabCleanupDeps, "stateRef" | "tabBucketsRef">,
   path: string,
   removedBucketKey: string,
-): { agentIds: Set<string>; shellIds: Set<string> } {
+): { agentIds: Set<string>; shellIds: Set<string>; editorIds: Set<string> } {
   const agentIds = new Set<string>();
   const shellIds = new Set<string>();
+  const editorIds = new Set<string>();
   const collect = (key: string, tabs: readonly Tab[] | undefined) => {
     for (const tab of tabs ?? []) {
+      if (tab.kind === "editor") {
+        if (key === removedBucketKey) editorIds.add(tab.id);
+        continue;
+      }
       if (tab.kind !== "agent" && tab.kind !== "shell") continue;
       if (key === removedBucketKey || tabCwdMatches(tab, path)) {
         (tab.kind === "agent" ? agentIds : shellIds).add(tab.id);
@@ -68,7 +79,7 @@ function collectRemovedTabIds(
       collect(key, bucket.tabs);
     }
   }
-  return { agentIds, shellIds };
+  return { agentIds, shellIds, editorIds };
 }
 
 function filterBucket(bucket: TabBucket, path: string): TabBucket | null {
@@ -131,11 +142,11 @@ export function closeTabsForRemovedWorkspace(
   wasActive: boolean,
 ): void {
   const removedBucketKey = projectScopeBucketKey(projectId, workspaceId);
-  const { agentIds: suppressed, shellIds } = collectRemovedTabIds(
-    deps,
-    path,
-    removedBucketKey,
-  );
+  const {
+    agentIds: suppressed,
+    shellIds,
+    editorIds,
+  } = collectRemovedTabIds(deps, path, removedBucketKey);
   const visibleClosed = closeVisibleTabsForWorkspacePath(
     deps.stateRef,
     deps.closeTabNow,
@@ -209,6 +220,13 @@ export function closeTabsForRemovedWorkspace(
     invoke("shell_close", { tabId }).catch(() => {
       /* idempotent — already torn down by natural exit */
     });
+  }
+  // Hidden editor tabs dropped with the bucket: release their cached
+  // Monaco models — nothing can reach them again. No-op for ids that
+  // never materialised a buffer.
+  for (const tabId of editorIds) {
+    if (visibleClosed.has(tabId)) continue;
+    disposeEditorBuffer(tabId);
   }
 
   deps.syncRecentSessionsToState();

--- a/src/hooks/useProjectOps.test.ts
+++ b/src/hooks/useProjectOps.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../types/tab";
 import type { ProjectsState } from "../projects";
 import { installTauriMocks, clearTauriMocks } from "../test/tauriMocks";
+import { disposeEditorBuffer } from "../monaco/editor-buffers";
 import {
   nonEmptyProjectTabs,
   projectIdFromBucketKey,
@@ -19,6 +20,10 @@ import {
   workspaceIdForCwd,
   type UseProjectOpsContext,
 } from "./useProjectOps";
+
+vi.mock("../monaco/editor-buffers", () => ({
+  disposeEditorBuffer: vi.fn(),
+}));
 
 afterEach(() => {
   clearTauriMocks();
@@ -1419,6 +1424,7 @@ describe("useProjectOps workspace removal", () => {
           ...makeEmptyTab("hidden-shell-tab", "Shell", "project-1", "shell"),
           cwd: "/projects/aethon-fix-issue",
         },
+        makeEmptyTab("hidden-editor-tab", "file.ts", "project-1", "editor"),
       ],
     });
 
@@ -1448,6 +1454,12 @@ describe("useProjectOps workspace removal", () => {
       tabId: "hidden-shell-tab",
     });
     expect(stateRef.current.closedSessionIds).not.toContain("hidden-shell-tab");
+    // The removed bucket's editor tab loses its last UI handle — its
+    // cached Monaco model must be disposed.
+    expect(disposeEditorBuffer).toHaveBeenCalledWith("hidden-editor-tab");
+    expect(stateRef.current.closedSessionIds).not.toContain(
+      "hidden-editor-tab",
+    );
   });
 
   it("marks the row as removing before a delayed git removal resolves", async () => {


### PR DESCRIPTION
Follow-up to #264 addressing both Copilot review findings there:

- **Monaco model leak**: editor tabs inside a wholly-dropped bucket (in-app workspace removal, reconcile prune, or the boot orphan sweep) vanished from state without `disposeEditorBuffer`, leaking their cached Monaco models. The buffer cache is intentionally long-lived for *hidden* buckets, but a *dropped* bucket leaves no UI handle to ever reach the model again. Both cleanup paths now collect swept editor-tab ids and dispose their buffers (no-op for ids that never materialised a buffer). Editor ids stay out of `closedSessionIds` — that list is agent-session suppression only.
- **Doc wording**: `collectRemovedTabIds`' comment said it gathered "Tab ids", implying editor tabs were included when they weren't; now it spells out the three kinds and what each set feeds.

Tests extended in `orphanTabSweep.test.ts` and `useProjectOps.test.ts` (editor tab in a dropped bucket → `disposeEditorBuffer` called, id not in `closedSessionIds`). `tsc -b`, ESLint 0/0, full vitest (2128) pass.