### PR TITLE
feat(composer): add @file completion picker to chat input and task launcher

### DIFF
--- a/src/extensions/default-layout/at-mention.test.ts
+++ b/src/extensions/default-layout/at-mention.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import {
+  AT_MATCH_LIMIT,
+  atMentionRoot,
+  findActiveAtToken,
+  formatAtInsertion,
+  matchAtFiles,
+  type AtFileMatch,
+} from "./at-mention";
+
+function files(...rels: string[]): AtFileMatch[] {
+  return rels.map((rel) => ({ rel, path: `/proj/${rel}` }));
+}
+
+describe("findActiveAtToken", () => {
+  it("matches a bare @ at the start of the draft", () => {
+    expect(findActiveAtToken("@", 1)).toEqual({ query: "", start: 0, end: 1 });
+  });
+
+  it("captures the query between @ and the cursor", () => {
+    expect(findActiveAtToken("@src/app", 8)).toEqual({
+      query: "src/app",
+      start: 0,
+      end: 8,
+    });
+  });
+
+  it("matches a token mid-draft after whitespace", () => {
+    expect(findActiveAtToken("look at @chat", 13)).toEqual({
+      query: "chat",
+      start: 8,
+      end: 13,
+    });
+  });
+
+  it("allows opening brackets and quotes before the @", () => {
+    expect(findActiveAtToken("(@src", 5)).toMatchObject({ query: "src" });
+  });
+
+  it("never triggers inside an email address", () => {
+    const value = "mail me@example.com";
+    expect(findActiveAtToken(value, value.length)).toBeNull();
+  });
+
+  it("does not match once whitespace follows the token", () => {
+    expect(findActiveAtToken("@src foo", 8)).toBeNull();
+  });
+
+  it("extends end to the rest of the token when the cursor sits inside", () => {
+    expect(findActiveAtToken("@src", 2)).toEqual({
+      query: "s",
+      start: 0,
+      end: 4,
+    });
+  });
+
+  it("stops the token at trailing whitespace", () => {
+    expect(findActiveAtToken("@src more", 4)).toEqual({
+      query: "src",
+      start: 0,
+      end: 4,
+    });
+  });
+
+  it("strips a hand-typed leading quote from the query", () => {
+    expect(findActiveAtToken('@"src', 5)).toMatchObject({ query: "src" });
+  });
+
+  it("returns null without an @ before the cursor", () => {
+    expect(findActiveAtToken("hello", 5)).toBeNull();
+    expect(findActiveAtToken("", 0)).toBeNull();
+  });
+});
+
+describe("matchAtFiles", () => {
+  it("ranks basename prefix matches above scattered path hits", () => {
+    const result = matchAtFiles(
+      "app",
+      files("docs/notes/snappy.md", "src/App.tsx"),
+    );
+    expect(result[0]?.rel).toBe("src/App.tsx");
+  });
+
+  it("matches across the full relative path", () => {
+    const result = matchAtFiles("src/app", files("src/App.tsx", "README.md"));
+    expect(result.map((f) => f.rel)).toEqual(["src/App.tsx"]);
+  });
+
+  it("returns the walk ordering for an empty query, capped", () => {
+    const many = files(
+      ...Array.from({ length: 30 }, (_, i) => `file-${String(i).padStart(2, "0")}.ts`),
+    );
+    const result = matchAtFiles("", many);
+    expect(result).toHaveLength(AT_MATCH_LIMIT);
+    expect(result[0]?.rel).toBe("file-00.ts");
+  });
+
+  it("caps scored results at the limit", () => {
+    const many = files(
+      ...Array.from({ length: 30 }, (_, i) => `src/app-${i}.ts`),
+    );
+    expect(matchAtFiles("app", many)).toHaveLength(AT_MATCH_LIMIT);
+  });
+
+  it("returns empty when nothing matches", () => {
+    expect(matchAtFiles("zzz", files("src/App.tsx"))).toEqual([]);
+  });
+});
+
+describe("formatAtInsertion", () => {
+  it("inserts plain paths with a trailing space", () => {
+    expect(formatAtInsertion("src/App.tsx")).toBe("@src/App.tsx ");
+  });
+
+  it("quotes paths containing whitespace", () => {
+    expect(formatAtInsertion("docs/my file.md")).toBe('@"docs/my file.md" ');
+  });
+
+  it("escapes quotes and backslashes inside quoted paths", () => {
+    expect(formatAtInsertion('we"ird file.md')).toBe('@"we\\"ird file.md" ');
+  });
+});
+
+describe("atMentionRoot", () => {
+  it("prefers the active tab's recorded cwd", () => {
+    expect(
+      atMentionRoot({
+        activeTabId: "t1",
+        tabs: [{ id: "t1", cwd: "/tab/cwd" }],
+        project: { path: "/proj" },
+      }),
+    ).toBe("/tab/cwd");
+  });
+
+  it("falls back to the active project path", () => {
+    expect(
+      atMentionRoot({
+        activeTabId: "t1",
+        tabs: [{ id: "t1" }],
+        project: { path: "/proj" },
+      }),
+    ).toBe("/proj");
+  });
+
+  it("returns null with no root at all", () => {
+    expect(atMentionRoot({})).toBeNull();
+  });
+});

--- a/src/extensions/default-layout/at-mention.ts
+++ b/src/extensions/default-layout/at-mention.ts
@@ -1,0 +1,136 @@
+/**
+ * Pure helpers for the composer's `@file` completion.
+ *
+ * The agent bridge already parses `@path` / `@"path with spaces"` tokens
+ * out of the prompt and inlines the referenced files as deterministic
+ * context (agent/file-references.ts). These helpers exist so the picker
+ * only ever inserts text that round-trips through that parser: the same
+ * `@`-boundary rule (an email's `@` never starts a reference) and the
+ * same quoting/escaping rules for paths containing whitespace.
+ *
+ * IO-free by design — the file list comes from the `useAtMention` hook.
+ */
+
+import { fuzzyScore } from "./palette-items";
+import { activeWorkspaceCwd } from "../../utils/activeWorkspaceRoot";
+
+export interface AtFileMatch {
+  /** Project-relative path — what gets inserted after the `@`. */
+  rel: string;
+  /** Absolute path on disk (kept for icon resolution / open actions). */
+  path: string;
+}
+
+export interface AtToken {
+  /** Text between the `@` and the cursor, leading quote stripped. */
+  query: string;
+  /** Index of the `@` in the draft. */
+  start: number;
+  /** End of the token — first whitespace at/after the cursor, or EOL. */
+  end: number;
+}
+
+export interface AtMention extends AtToken {
+  matches: AtFileMatch[];
+}
+
+/** Upper bound on rendered suggestions; matches quick-open's feel. */
+export const AT_MATCH_LIMIT = 12;
+
+/**
+ * Find the `@token` the cursor is inside, if any. Mirrors the agent
+ * parser's boundary rule: the `@` must sit at the start of the draft or
+ * after whitespace / an opening bracket / a quote, so `me@example.com`
+ * never opens the picker. The token may not contain whitespace — typing
+ * a space closes the picker (paths with spaces are still completable by
+ * fuzzy-matching the typed part, and insertion quotes them).
+ */
+export function findActiveAtToken(
+  value: string,
+  cursor: number,
+): AtToken | null {
+  if (cursor < 1 || cursor > value.length) return null;
+  let at = -1;
+  for (let i = cursor - 1; i >= 0; i -= 1) {
+    const ch = value[i];
+    if (/\s/.test(ch)) return null;
+    if (ch === "@") {
+      at = i;
+      break;
+    }
+  }
+  if (at < 0) return null;
+  const prev = at > 0 ? value[at - 1] : undefined;
+  const boundary =
+    prev === undefined || /\s/.test(prev) || "([{<'\"`".includes(prev);
+  if (!boundary) return null;
+  let query = value.slice(at + 1, cursor);
+  // A quote right after the `@` is the user hand-typing the quoted form;
+  // strip it so matching still works against bare relative paths.
+  if (query.startsWith('"') || query.startsWith("'")) query = query.slice(1);
+  let end = cursor;
+  while (end < value.length && !/\s/.test(value[end])) end += 1;
+  return { query, start: at, end };
+}
+
+/**
+ * Rank project files against the typed query. Scores both the full
+ * relative path and the basename (slightly boosted) so `app` surfaces
+ * `src/App.tsx` ahead of paths that merely contain the letters. Empty
+ * query shows the walk's stable ordering — same as opening Cmd+P.
+ */
+export function matchAtFiles(
+  query: string,
+  files: AtFileMatch[],
+  limit: number = AT_MATCH_LIMIT,
+): AtFileMatch[] {
+  if (!query) return files.slice(0, limit);
+  const scored: { file: AtFileMatch; score: number }[] = [];
+  for (const file of files) {
+    const base = file.rel.slice(file.rel.lastIndexOf("/") + 1);
+    const score = Math.max(
+      fuzzyScore(query, file.rel),
+      fuzzyScore(query, base) * 1.1,
+    );
+    if (score <= 0) continue;
+    scored.push({ file, score });
+  }
+  scored.sort(
+    (a, b) =>
+      b.score - a.score ||
+      a.file.rel.length - b.file.rel.length ||
+      (a.file.rel < b.file.rel ? -1 : 1),
+  );
+  return scored.slice(0, limit).map((s) => s.file);
+}
+
+/**
+ * Format the text that replaces the `@token`. Plain paths insert as
+ * `@rel `; anything the agent's unquoted reader would mis-tokenize
+ * (whitespace, quotes, backslashes) gets the quoted form with the same
+ * escapes `readQuoted` in agent/file-references.ts understands. The
+ * trailing space ends the token so the picker closes after insertion.
+ */
+export function formatAtInsertion(rel: string): string {
+  if (!/[\s"'\\]/.test(rel)) return `@${rel} `;
+  const escaped = rel.replace(/[\\"]/g, (ch) => `\\${ch}`);
+  return `@"${escaped}" `;
+}
+
+/**
+ * Root the completion list should come from. The agent resolves `@refs`
+ * against the tab's recorded cwd first (agent/chat.ts), then the active
+ * project — mirror that precedence so suggestions match what will
+ * actually resolve.
+ */
+export function atMentionRoot(state: Record<string, unknown>): string | null {
+  const tabs =
+    (state.tabs as Array<{ id: string; cwd?: string }> | undefined) ?? [];
+  const activeTabId =
+    typeof state.activeTabId === "string" ? state.activeTabId : undefined;
+  const activeTab = activeTabId
+    ? tabs.find((t) => t.id === activeTabId)
+    : undefined;
+  if (activeTab?.cwd) return activeTab.cwd;
+  return activeWorkspaceCwd(state);
+}

--- a/src/extensions/default-layout/at-picker.tsx
+++ b/src/extensions/default-layout/at-picker.tsx
@@ -1,0 +1,73 @@
+import type { Dispatch, RefObject, SetStateAction } from "react";
+import { createPortal } from "react-dom";
+import { FileIcon } from "../../components/file-icon";
+import type { AtFileMatch, AtMention } from "./at-mention";
+import { usePickerAnchor } from "./use-picker-anchor";
+
+interface AtPickerProps {
+  anchorRef: RefObject<HTMLDivElement | null>;
+  atMatch: AtMention | null;
+  highlightIdx: number;
+  setHighlightIdx: Dispatch<SetStateAction<number>>;
+  onInsert: (match: AtFileMatch) => void;
+}
+
+/**
+ * `@file` completion menu. Shares the slash picker's chrome (portal +
+ * fixed anchor + `.a2ui-slash-menu` styling) so the two composer
+ * popovers look and behave identically; rows render basename-first with
+ * the directory dimmed, like quick-open.
+ */
+export function AtPicker({
+  anchorRef,
+  atMatch,
+  highlightIdx,
+  setHighlightIdx,
+  onInsert,
+}: AtPickerProps) {
+  const menuAnchor = usePickerAnchor(anchorRef, atMatch);
+
+  if (!atMatch || !menuAnchor) return null;
+
+  return createPortal(
+    <div
+      className="a2ui-slash-menu"
+      role="listbox"
+      aria-label="File suggestions"
+      style={{
+        position: "fixed",
+        left: `${menuAnchor.left}px`,
+        bottom: `${menuAnchor.bottom}px`,
+        width: `${menuAnchor.width}px`,
+      }}
+    >
+      {atMatch.matches.map((m, i) => {
+        const slash = m.rel.lastIndexOf("/");
+        const base = slash >= 0 ? m.rel.slice(slash + 1) : m.rel;
+        const dir = slash >= 0 ? m.rel.slice(0, slash) : "";
+        return (
+          <div
+            key={m.rel}
+            role="option"
+            aria-selected={i === highlightIdx}
+            className={
+              i === highlightIdx
+                ? "a2ui-slash-item a2ui-at-item a2ui-slash-item-active"
+                : "a2ui-slash-item a2ui-at-item"
+            }
+            onMouseDown={(e) => {
+              e.preventDefault();
+              onInsert(m);
+            }}
+            onMouseEnter={() => setHighlightIdx(i)}
+          >
+            <FileIcon path={m.rel} isDir={false} size={14} />
+            <span className="a2ui-at-item-name">{base}</span>
+            {dir && <span className="a2ui-at-item-dir">{dir}</span>}
+          </div>
+        );
+      })}
+    </div>,
+    document.body,
+  );
+}

--- a/src/extensions/default-layout/chat-input.tsx
+++ b/src/extensions/default-layout/chat-input.tsx
@@ -24,6 +24,13 @@ import {
 import { useExtensionRegistry } from "../ExtensionRegistry";
 import type { QueuedMessage } from "../../types/tab";
 import { SlashPicker } from "./slash-picker";
+import { AtPicker } from "./at-picker";
+import {
+  atMentionRoot,
+  formatAtInsertion,
+  type AtFileMatch,
+} from "./at-mention";
+import { useAtMention } from "./use-at-mention";
 import { useComposerResize } from "./use-composer-resize";
 import { useDraftCommit } from "./use-draft-commit";
 import { useVoiceHotkey } from "../../hooks/useVoiceHotkey";
@@ -107,6 +114,23 @@ export function ChatInput({
       commandsRaw: props.commands,
       state,
     });
+  // Caret offset in the draft, tracked so the @file picker knows which
+  // token the user is editing. Updated on change + select (clicks,
+  // arrow keys) and after programmatic insertions.
+  const [cursor, setCursor] = useState(0);
+  const {
+    atMatch,
+    highlightIdx: atHighlightIdx,
+    setHighlightIdx: setAtHighlightIdx,
+    dismissPicker: dismissAtPicker,
+  } = useAtMention({
+    value,
+    cursor,
+    root: atMentionRoot(state),
+    // The slash picker owns the keyboard while it's open; `/command @arg`
+    // drafts stay slash-flavored.
+    enabled: !slashMatch,
+  });
   const inputContainerRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const { composerHeight, startComposerResize } = useComposerResize();
@@ -123,6 +147,7 @@ export function ChatInput({
       );
       setValue(next.text);
       commitDraft(next.text);
+      setCursor(next.cursor);
       requestAnimationFrame(() => {
         const current = textareaRef.current;
         if (!current) return;
@@ -197,6 +222,25 @@ export function ChatInput({
     commitDraft(text);
   };
 
+  // Replace the active `@token` with the chosen file reference and park
+  // the caret after the trailing space so typing continues naturally.
+  const insertAtFile = (m: AtFileMatch) => {
+    if (!atMatch) return;
+    const insertion = formatAtInsertion(m.rel);
+    const next =
+      value.slice(0, atMatch.start) + insertion + value.slice(atMatch.end);
+    const nextCursor = atMatch.start + insertion.length;
+    setValue(next);
+    commitDraft(next);
+    setCursor(nextCursor);
+    requestAnimationFrame(() => {
+      const current = textareaRef.current;
+      if (!current) return;
+      current.focus();
+      current.selectionStart = current.selectionEnd = nextCursor;
+    });
+  };
+
   const submitPayload = (value: string, mode: "normal" | "steer") => ({
     value,
     mode,
@@ -213,6 +257,7 @@ export function ChatInput({
   const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
     const next = e.target.value;
     setValue(next);
+    setCursor(e.target.selectionStart ?? next.length);
     scheduleDraftCommit();
   };
 
@@ -281,6 +326,42 @@ export function ChatInput({
         return;
       }
     }
+    if (!slashMatch && atMatch) {
+      const list = atMatch.matches;
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setAtHighlightIdx((i) => (i + 1) % list.length);
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setAtHighlightIdx((i) => (i - 1 + list.length) % list.length);
+        return;
+      }
+      if (e.key === "Tab") {
+        e.preventDefault();
+        const match = list[atHighlightIdx] ?? list[0];
+        if (match) insertAtFile(match);
+        return;
+      }
+      if (e.key === "Enter" && !e.shiftKey) {
+        // A hand-typed exact reference sends the message — same bypass
+        // the slash picker gives an exactly-typed command. Partial
+        // tokens complete instead of submitting.
+        const exact = list.some((m) => m.rel === atMatch.query);
+        if (!exact) {
+          e.preventDefault();
+          const match = list[atHighlightIdx] ?? list[0];
+          if (match) insertAtFile(match);
+          return;
+        }
+      }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        dismissAtPicker();
+        return;
+      }
+    }
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       submit("normal");
@@ -333,6 +414,13 @@ export function ChatInput({
         onInsert={insertMatch}
         onSubmitArg={submitArgMatch}
       />
+      <AtPicker
+        anchorRef={inputContainerRef}
+        atMatch={atMatch}
+        highlightIdx={atHighlightIdx}
+        setHighlightIdx={setAtHighlightIdx}
+        onInsert={insertAtFile}
+      />
       {busy && (
         <div className="a2ui-chat-input-hint">
           <span>Enter queues</span>
@@ -357,6 +445,7 @@ export function ChatInput({
           value={value}
           onChange={handleChange}
           onKeyDown={handleKeyDown}
+          onSelect={(e) => setCursor(e.currentTarget.selectionStart ?? 0)}
         />
         {queueCount > 0 && (
           <span

--- a/src/extensions/default-layout/chat.test.tsx
+++ b/src/extensions/default-layout/chat.test.tsx
@@ -145,6 +145,9 @@ vi.mock("react-virtuoso", () => ({
 import { ExtensionRegistry } from "../ExtensionRegistry";
 import { ExtensionRegistryProvider } from "../ExtensionRegistryProvider";
 import type { BuiltinComponentProps } from "../../components/A2UIRenderer";
+import { invoke } from "@tauri-apps/api/core";
+
+const invokeMock = invoke as unknown as ReturnType<typeof vi.fn>;
 
 class ResizeObserverMock {
   observe = vi.fn();
@@ -951,6 +954,99 @@ describe("ChatInput", () => {
     expect(
       screen.getByRole("link", { name: "https://example.com/after" }),
     ).toBeTruthy();
+  });
+});
+
+describe("ChatInput @file completion", () => {
+  const WALK = ["/proj/src/App.tsx", "/proj/src/main.tsx", "/proj/README.md"];
+
+  beforeEach(() => {
+    invokeMock.mockImplementation((cmd: string) =>
+      cmd === "fs_walk_project"
+        ? Promise.resolve(WALK)
+        : Promise.reject(new Error(`invoke not mocked: ${cmd}`)),
+    );
+  });
+
+  afterEach(() => {
+    // Restore the module-level default so unrelated tests keep seeing
+    // the "invoke not mocked" rejection.
+    invokeMock.mockImplementation(() =>
+      Promise.reject(new Error("invoke not mocked")),
+    );
+  });
+
+  function renderWithProject(onEvent = vi.fn()) {
+    return renderInput(onEvent, {}, { project: { path: "/proj" } });
+  }
+
+  it("offers file suggestions while typing an @token", async () => {
+    const { input } = renderWithProject();
+
+    fireEvent.change(input, { target: { value: "@app" } });
+
+    expect(await screen.findByText("App.tsx")).toBeTruthy();
+    expect(invokeMock).toHaveBeenCalledWith("fs_walk_project", {
+      root: "/proj",
+    });
+  });
+
+  it("inserts the highlighted file on Tab", async () => {
+    const { input } = renderWithProject();
+
+    fireEvent.change(input, { target: { value: "@app" } });
+    await screen.findByText("App.tsx");
+    fireEvent.keyDown(input, { key: "Tab" });
+
+    expect((input as HTMLTextAreaElement).value).toBe("@src/App.tsx ");
+  });
+
+  it("completes on Enter instead of submitting while the picker is open", async () => {
+    const { input, onEvent } = renderWithProject();
+
+    fireEvent.change(input, { target: { value: "@app" } });
+    await screen.findByText("App.tsx");
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect((input as HTMLTextAreaElement).value).toBe("@src/App.tsx ");
+    expect(onEvent).not.toHaveBeenCalledWith("submit", expect.any(Object));
+  });
+
+  it("dismisses on Escape and lets Enter submit the raw draft", async () => {
+    const { input, onEvent } = renderWithProject();
+
+    fireEvent.change(input, { target: { value: "@app" } });
+    await screen.findByText("App.tsx");
+    fireEvent.keyDown(input, { key: "Escape" });
+
+    expect(screen.queryByText("App.tsx")).toBeNull();
+
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onEvent).toHaveBeenLastCalledWith("submit", {
+      value: "@app",
+      mode: "normal",
+    });
+  });
+
+  it("submits on Enter when the typed token is already an exact path", async () => {
+    const { input, onEvent } = renderWithProject();
+
+    fireEvent.change(input, { target: { value: "@src/App.tsx" } });
+    await screen.findByText("App.tsx");
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(onEvent).toHaveBeenLastCalledWith("submit", {
+      value: "@src/App.tsx",
+      mode: "normal",
+    });
+  });
+
+  it("never triggers inside an email address", () => {
+    const { input } = renderWithProject();
+
+    fireEvent.change(input, { target: { value: "mail me@example" } });
+
+    expect(screen.queryByRole("listbox")).toBeNull();
   });
 });
 

--- a/src/extensions/default-layout/dashboard/task-launcher.test.tsx
+++ b/src/extensions/default-layout/dashboard/task-launcher.test.tsx
@@ -93,6 +93,30 @@ describe("TaskLauncher", () => {
     }
   });
 
+  it("offers @file completions rooted at the project and inserts on Tab", async () => {
+    invoke.mockResolvedValue(["/repo/aethon/src/App.tsx"]);
+    render(
+      <TaskLauncher
+        component={launcher({
+          project: { id: "p1", label: "aethon", path: "/repo/aethon" },
+        })}
+        state={{}}
+        onEvent={vi.fn()}
+      />,
+    );
+
+    const prompt = screen.getByLabelText("Task prompt");
+    fireEvent.change(prompt, { target: { value: "@app" } });
+
+    await screen.findByText("App.tsx");
+    expect(invoke).toHaveBeenCalledWith("fs_walk_project", {
+      root: "/repo/aethon",
+    });
+
+    fireEvent.keyDown(prompt, { key: "Tab" });
+    expect((prompt as HTMLTextAreaElement).value).toBe("@src/App.tsx ");
+  });
+
   it("allows a new workspace session with an automatic branch", async () => {
     const onEvent = vi.fn();
     render(

--- a/src/extensions/default-layout/dashboard/task-launcher.tsx
+++ b/src/extensions/default-layout/dashboard/task-launcher.tsx
@@ -24,6 +24,9 @@ import { DEFAULT_WORKSPACE_BASE_BRANCH } from "../../../projects";
 import { saveClipboardImageAttachment } from "../../../utils/imageAttachments";
 import { ImageAttachmentImage } from "../image-attachment-image";
 import { ImageLightbox } from "../image-lightbox";
+import { AtPicker } from "../at-picker";
+import { formatAtInsertion, type AtFileMatch } from "../at-mention";
+import { useAtMention } from "../use-at-mention";
 
 interface ProjectLite {
   id: string;
@@ -195,6 +198,50 @@ export function TaskLauncher({
     el.style.height = `${next}px`;
   }, [promptText]);
 
+  // `@file` completion — same picker as the chat composer, rooted at
+  // whatever the task will actually run against: the selected existing
+  // workspace, else the project root (a "+ New workspace" forks from the
+  // project, so its files are the right suggestions too).
+  const launcherRef = useRef<HTMLDivElement | null>(null);
+  const [cursor, setCursor] = useState(0);
+  const atRoot =
+    workspaceChoice.kind === "existing"
+      ? workspaceChoice.path
+      : (data.project?.path ?? null);
+  const {
+    atMatch,
+    highlightIdx: atHighlightIdx,
+    setHighlightIdx: setAtHighlightIdx,
+    dismissPicker: dismissAtPicker,
+  } = useAtMention({
+    value: promptText,
+    cursor,
+    root: atRoot,
+    enabled: !submitting,
+  });
+
+  const insertAtFile = useCallback(
+    (m: AtFileMatch) => {
+      if (!atMatch) return;
+      const insertion = formatAtInsertion(m.rel);
+      const next =
+        promptText.slice(0, atMatch.start) +
+        insertion +
+        promptText.slice(atMatch.end);
+      const nextCursor = atMatch.start + insertion.length;
+      setPromptText(next);
+      setTouched(true);
+      setCursor(nextCursor);
+      requestAnimationFrame(() => {
+        const el = textareaRef.current;
+        if (!el) return;
+        el.focus();
+        el.selectionStart = el.selectionEnd = nextCursor;
+      });
+    },
+    [atMatch, promptText],
+  );
+
   const submit = useCallback(() => {
     if (submitting) return;
     const text = promptText.trim();
@@ -243,6 +290,40 @@ export function TaskLauncher({
   ]);
 
   const onKey = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (atMatch) {
+      const list = atMatch.matches;
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setAtHighlightIdx((i) => (i + 1) % list.length);
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setAtHighlightIdx((i) => (i - 1 + list.length) % list.length);
+        return;
+      }
+      if (e.key === "Tab") {
+        e.preventDefault();
+        const match = list[atHighlightIdx] ?? list[0];
+        if (match) insertAtFile(match);
+        return;
+      }
+      if (e.key === "Enter" && !e.shiftKey) {
+        // A hand-typed exact reference submits; partial tokens complete.
+        const exact = list.some((m) => m.rel === atMatch.query);
+        if (!exact) {
+          e.preventDefault();
+          const match = list[atHighlightIdx] ?? list[0];
+          if (match) insertAtFile(match);
+          return;
+        }
+      }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        dismissAtPicker();
+        return;
+      }
+    }
     // Plain Enter submits; Shift+Enter adds a newline. Matches the main
     // chat composer. Cmd/Ctrl+Enter also submits for users who hold
     // modifiers out of habit.
@@ -290,7 +371,7 @@ export function TaskLauncher({
     "model";
 
   return (
-    <div className="a2ui-task-launcher">
+    <div className="a2ui-task-launcher" ref={launcherRef}>
       <textarea
         ref={textareaRef}
         className="a2ui-task-launcher-input"
@@ -302,12 +383,21 @@ export function TaskLauncher({
         rows={3}
         onChange={(e) => {
           setPromptText(e.target.value);
+          setCursor(e.target.selectionStart ?? e.target.value.length);
           setTouched(true);
         }}
+        onSelect={(e) => setCursor(e.currentTarget.selectionStart ?? 0)}
         onPaste={onPaste}
         onKeyDown={onKey}
         disabled={submitting}
         aria-label="Task prompt"
+      />
+      <AtPicker
+        anchorRef={launcherRef}
+        atMatch={atMatch}
+        highlightIdx={atHighlightIdx}
+        setHighlightIdx={setAtHighlightIdx}
+        onInsert={insertAtFile}
       />
       {attachments.length > 0 && (
         <div className="a2ui-task-launcher-attachments">

--- a/src/extensions/default-layout/slash-picker.tsx
+++ b/src/extensions/default-layout/slash-picker.tsx
@@ -1,17 +1,11 @@
-import {
-  useEffect,
-  useState,
-  type Dispatch,
-  type RefObject,
-  type SetStateAction,
-} from "react";
+import type { Dispatch, RefObject, SetStateAction } from "react";
 import { createPortal } from "react-dom";
 import type {
   ArgMatch,
   PickerMatch,
   SlashMatch,
 } from "./use-slash-matching";
-import { readUiScale } from "./layout";
+import { usePickerAnchor } from "./use-picker-anchor";
 
 interface SlashPickerProps {
   anchorRef: RefObject<HTMLDivElement | null>;
@@ -30,47 +24,7 @@ export function SlashPicker({
   onInsert,
   onSubmitArg,
 }: SlashPickerProps) {
-  const [menuAnchor, setMenuAnchor] = useState<{
-    left: number;
-    bottom: number;
-    width: number;
-  } | null>(null);
-
-  useEffect(() => {
-    if (!slashMatch || !anchorRef.current) {
-      setMenuAnchor(null);
-      return;
-    }
-    const update = () => {
-      const anchor = anchorRef.current;
-      if (!anchor) {
-        setMenuAnchor(null);
-        return;
-      }
-      const r = anchor.getBoundingClientRect();
-      const scale = readUiScale();
-      const viewportWidth = window.innerWidth / scale;
-      const viewportHeight = window.innerHeight / scale;
-      const left = Math.max(
-        8,
-        Math.min(r.left / scale + 16, viewportWidth - 128),
-      );
-      const availableWidth = Math.max(0, viewportWidth - left - 8);
-      const preferredWidth = Math.max(160, r.width / scale - 32);
-      setMenuAnchor({
-        left,
-        bottom: Math.max(8, viewportHeight - r.top / scale + 4),
-        width: Math.min(preferredWidth, availableWidth || preferredWidth),
-      });
-    };
-    update();
-    window.addEventListener("resize", update);
-    window.addEventListener("scroll", update, true);
-    return () => {
-      window.removeEventListener("resize", update);
-      window.removeEventListener("scroll", update, true);
-    };
-  }, [anchorRef, slashMatch]);
+  const menuAnchor = usePickerAnchor(anchorRef, slashMatch);
 
   if (!slashMatch || !menuAnchor) return null;
 

--- a/src/extensions/default-layout/use-at-mention.ts
+++ b/src/extensions/default-layout/use-at-mention.ts
@@ -1,0 +1,93 @@
+import { useEffect, useMemo, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import {
+  findActiveAtToken,
+  matchAtFiles,
+  type AtFileMatch,
+  type AtMention,
+} from "./at-mention";
+
+/**
+ * Live `@file` completion state for a composer. Modeled on
+ * `useSlashMatching`: the caller feeds the draft + cursor + the root the
+ * prompt will resolve against (`atMentionRoot(state)` for the chat
+ * composer, the targeted project/workspace path for the task launcher),
+ * and gets back the current match (or null) plus highlight/dismiss
+ * controls.
+ *
+ * The file list comes from `fs_walk_project` — the same backend as the
+ * Cmd+P quick-open. A walk fires each time an `@token` becomes active
+ * (cheap: capped + excluded-dirs pruned Rust walk), while the previous
+ * list keeps serving matches so suggestions never flicker out mid-typing.
+ */
+export function useAtMention({
+  value,
+  cursor,
+  root,
+  enabled,
+}: {
+  value: string;
+  cursor: number;
+  root: string | null;
+  enabled: boolean;
+}) {
+  const token = useMemo(
+    () => (enabled ? findActiveAtToken(value, cursor) : null),
+    [enabled, value, cursor],
+  );
+  const [files, setFiles] = useState<AtFileMatch[]>([]);
+  const [dismissedDraft, setDismissedDraft] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (dismissedDraft !== null && value !== dismissedDraft) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- one-shot picker re-enable when the draft changes after Escape
+      setDismissedDraft(null);
+    }
+  }, [value, dismissedDraft]);
+
+  const tokenActive = token !== null;
+  useEffect(() => {
+    if (!tokenActive || !root) return;
+    let cancelled = false;
+    invoke<string[]>("fs_walk_project", { root })
+      .then((paths) => {
+        if (cancelled) return;
+        const normalized = root.replace(/\/+$/, "");
+        setFiles(
+          paths.map((path) => ({
+            path,
+            rel: path.startsWith(normalized + "/")
+              ? path.slice(normalized.length + 1)
+              : path,
+          })),
+        );
+      })
+      .catch(() => {
+        // Walk failed (project gone, permission) — degrade to no picker.
+        if (!cancelled) setFiles([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [tokenActive, root]);
+
+  const atMatch: AtMention | null = useMemo(() => {
+    if (!token) return null;
+    if (dismissedDraft !== null && value === dismissedDraft) return null;
+    const matches = matchAtFiles(token.query, files);
+    return matches.length > 0 ? { ...token, matches } : null;
+  }, [token, files, value, dismissedDraft]);
+
+  const [highlightIdx, setHighlightIdx] = useState(0);
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- keep keyboard highlight inside the newly visible suggestion list
+    setHighlightIdx(0);
+  }, [atMatch?.matches.length, atMatch?.query, atMatch?.start]);
+
+  return {
+    atMatch,
+    highlightIdx,
+    setHighlightIdx,
+    dismissPicker: () => setDismissedDraft(value),
+  };
+}

--- a/src/extensions/default-layout/use-picker-anchor.ts
+++ b/src/extensions/default-layout/use-picker-anchor.ts
@@ -1,0 +1,64 @@
+import { useEffect, useState, type RefObject } from "react";
+import { readUiScale } from "./layout";
+
+export interface PickerAnchor {
+  left: number;
+  bottom: number;
+  width: number;
+}
+
+/**
+ * Fixed-position anchor for composer popovers (slash picker, @file
+ * picker). Portal-rendered menus must escape the layout cell's
+ * `overflow: hidden`, so they position against the composer's viewport
+ * rect instead of the DOM tree.
+ *
+ * `activeKey` doubles as the open flag and the reposition trigger: pass
+ * the live match object so the anchor re-measures on every keystroke
+ * (the composer can grow/shrink while typing), or null/undefined to
+ * close.
+ */
+export function usePickerAnchor(
+  anchorRef: RefObject<HTMLDivElement | null>,
+  activeKey: unknown,
+): PickerAnchor | null {
+  const [menuAnchor, setMenuAnchor] = useState<PickerAnchor | null>(null);
+
+  useEffect(() => {
+    if (!activeKey || !anchorRef.current) {
+      setMenuAnchor(null);
+      return;
+    }
+    const update = () => {
+      const anchor = anchorRef.current;
+      if (!anchor) {
+        setMenuAnchor(null);
+        return;
+      }
+      const r = anchor.getBoundingClientRect();
+      const scale = readUiScale();
+      const viewportWidth = window.innerWidth / scale;
+      const viewportHeight = window.innerHeight / scale;
+      const left = Math.max(
+        8,
+        Math.min(r.left / scale + 16, viewportWidth - 128),
+      );
+      const availableWidth = Math.max(0, viewportWidth - left - 8);
+      const preferredWidth = Math.max(160, r.width / scale - 32);
+      setMenuAnchor({
+        left,
+        bottom: Math.max(8, viewportHeight - r.top / scale + 4),
+        width: Math.min(preferredWidth, availableWidth || preferredWidth),
+      });
+    };
+    update();
+    window.addEventListener("resize", update);
+    window.addEventListener("scroll", update, true);
+    return () => {
+      window.removeEventListener("resize", update);
+      window.removeEventListener("scroll", update, true);
+    };
+  }, [anchorRef, activeKey]);
+
+  return menuAnchor;
+}

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -3676,6 +3676,36 @@ body.ae-resizing-composer * {
   color: var(--text-dim);
 }
 
+/* @file completion rows — same menu chrome as the slash picker, but
+   single-line file rows: icon, basename, dimmed directory. */
+.a2ui-at-item {
+  flex-wrap: nowrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.a2ui-at-item .ae-file-icon {
+  flex: none;
+}
+
+.a2ui-at-item-name {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  color: var(--text);
+  white-space: nowrap;
+}
+
+.a2ui-at-item-dir {
+  color: var(--text-dim);
+  font-size: var(--chrome-text-compact);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+  flex: 1;
+  direction: rtl;
+  text-align: left;
+}
+
 .a2ui-chat-input-field {
   flex: 1 1 auto;
   width: 100%;


### PR DESCRIPTION
## Summary

Typing `@` in the chat composer or the dashboard task launcher now opens a fuzzy file-completion picker, matching the Codex / Claude Code mention UX. Previously the task launcher even advertised `use @path for file context` in its placeholder with no completion behind it.

- **Suggestions** come from `fs_walk_project` (the same backend as Cmd+P quick-open), rooted at whatever the prompt will actually resolve against: the active tab's cwd (falling back to the active workspace) for the chat composer, and the targeted project/workspace for the task launcher.
- **Insertion round-trips the agent's existing `@file` parser** (`agent/file-references.ts`): same `@`-boundary rule (emails never trigger), and paths with spaces insert as `@"quoted paths"` with `readQuoted`-compatible escapes.
- **Keyboard**: arrows navigate, Tab/Enter complete, Escape dismisses, and a hand-typed exact path submits on Enter (same bypass as the slash picker's exact-command rule).
- The slash picker's portal anchor positioning is extracted into a shared `usePickerAnchor` hook so both composer popovers position identically.

## Testing

- 21 new unit tests for the pure helpers (token detection, ranking, quoting, root precedence)
- 6 new ChatInput integration tests + 1 TaskLauncher integration test (picker open, Tab/Enter insertion, Escape dismissal, exact-path submit, email non-trigger)
- Full suite: 2156 tests green; `tsc -b` and ESLint clean
- Verified live in the dev app via the debug skill: picker opens on `@src` in both composers, ArrowDown+Tab inserts `@src/tray.rs ` with correct caret placement