### PR TITLE
fix(agent): keep bad at-file refs non-fatal

### DIFF
--- a/agent/chat.ts
+++ b/agent/chat.ts
@@ -93,6 +93,13 @@ export async function handleChat(
       cwd: tabCwdForMention ?? process.cwd(),
       leadingSubagentName: explicitSubagent,
     });
+    if (expanded.issues?.length) {
+      deps.send({
+        type: "notice",
+        tabId,
+        message: `file references: ${expanded.issues.join("\n")}`,
+      });
+    }
     content = expanded.prompt;
   } catch (err) {
     if (explicitSubagent) state.pendingExplicitSubagent.delete(tabId);

--- a/agent/dispatcher.test.ts
+++ b/agent/dispatcher.test.ts
@@ -620,6 +620,43 @@ describe("handleChat", () => {
     expect(f.sent).not.toContainEqual({ type: "response_end", tabId: "tab-1" });
   });
 
+  it("dispatches prompts containing unresolved dotted @mentions instead of failing file-reference expansion", async () => {
+    const f = makeFixture();
+    const promptCalls: unknown[][] = [];
+    const tab = fakeTabRecord({
+      session: {
+        prompt: (...args: unknown[]) => {
+          promptCalls.push(args);
+          return new Promise<void>(() => {});
+        },
+        followUp: () => Promise.resolve(),
+        steer: () => Promise.resolve(),
+      } as unknown as TabRecord["session"],
+    });
+    f.state.tabs.set("tab-1", tab);
+
+    await handleChat(f.state, f.deps, {
+      type: "chat",
+      content: "Allow the @search_result.resolved_bbl.blank? guard to continue",
+      tabId: "tab-1",
+      mode: "normal",
+    });
+
+    expect(promptCalls).toEqual([
+      ["Allow the @search_result.resolved_bbl.blank? guard to continue"],
+    ]);
+    expect(f.sent).toContainEqual({
+      type: "notice",
+      tabId: "tab-1",
+      message:
+        "file references: @search_result.resolved_bbl.blank? was not found under " +
+        process.cwd(),
+    });
+    expect(f.sent).not.toContainEqual(
+      expect.objectContaining({ type: "error", tabId: "tab-1" }),
+    );
+  });
+
   it("treats steer as a normal prompt when the tab is idle", async () => {
     const f = makeFixture();
     const promptCalls: unknown[][] = [];

--- a/agent/file-references.test.ts
+++ b/agent/file-references.test.ts
@@ -100,10 +100,41 @@ describe("expandFileReferencesInPrompt", () => {
     expect(out.references[0]?.content).toContain("space path");
   });
 
-  it("throws a clear error for missing likely paths", async () => {
-    await expect(
-      expandFileReferencesInPrompt("Read @src/Missing.ts", { cwd: root }),
-    ).rejects.toMatchObject({ name: "FileReferenceError" });
+  it("reports missing explicit paths without failing the prompt", async () => {
+    const out = await expandFileReferencesInPrompt("Read @src/Missing.ts", {
+      cwd: root,
+    });
+    expect(out.references).toEqual([]);
+    expect(out.prompt).toBe("Read @src/Missing.ts");
+    expect(out.issues).toEqual([expect.stringContaining("@src/Missing.ts")]);
+
+    const bareOut = await expandFileReferencesInPrompt("Read @tsconfig.json", {
+      cwd: root,
+    });
+    expect(bareOut.references).toEqual([]);
+    expect(bareOut.issues).toEqual([expect.stringContaining("@tsconfig.json")]);
+  });
+
+  it("reports dotted expression-style @mentions without failing the prompt", async () => {
+    const prompt = "Allow the @search_result.resolved_bbl.blank? guard to continue";
+    const out = await expandFileReferencesInPrompt(prompt, { cwd: root });
+    expect(out.references).toEqual([]);
+    expect(out.prompt).toBe(prompt);
+    expect(out.issues).toEqual([
+      expect.stringContaining("@search_result.resolved_bbl.blank?"),
+    ]);
+  });
+
+  it("keeps valid file context when another @mention is unresolved", async () => {
+    const out = await expandFileReferencesInPrompt(
+      "Review @README.md and @search_result.resolved_bbl.blank?",
+      { cwd: root },
+    );
+    expect(out.references.map((ref) => ref.displayPath)).toEqual(["README.md"]);
+    expect(out.issues).toEqual([
+      expect.stringContaining("@search_result.resolved_bbl.blank?"),
+    ]);
+    expect(out.prompt).toContain("<aethon_file_references");
   });
 
   it("ignores missing package-style and punctuated @mentions", async () => {
@@ -118,16 +149,18 @@ describe("expandFileReferencesInPrompt", () => {
     }
   });
 
-  it("rejects directories and outside-root absolute paths", async () => {
-    await expect(
-      expandFileReferencesInPrompt("Read @src", { cwd: root }),
-    ).rejects.toThrow(/directory/);
+  it("reports directories and outside-root absolute paths without failing", async () => {
+    const dirOut = await expandFileReferencesInPrompt("Read @src", { cwd: root });
+    expect(dirOut.references).toEqual([]);
+    expect(dirOut.issues).toEqual([expect.stringContaining("directory")]);
 
     const outsideFile = join(outside, "secret.txt");
     await writeFile(outsideFile, "secret\n");
-    await expect(
-      expandFileReferencesInPrompt(`Read @${outsideFile}`, { cwd: root }),
-    ).rejects.toThrow(/outside/);
+    const outsideOut = await expandFileReferencesInPrompt(`Read @${outsideFile}`, {
+      cwd: root,
+    });
+    expect(outsideOut.references).toEqual([]);
+    expect(outsideOut.issues).toEqual([expect.stringContaining("outside")]);
   });
 
   it("does not treat a leading accepted @subagent as a file reference", async () => {

--- a/agent/file-references.ts
+++ b/agent/file-references.ts
@@ -28,6 +28,8 @@ export interface ResolvedFileReference {
 export interface FileReferenceExpansion {
   prompt: string;
   references: ResolvedFileReference[];
+  /** Non-fatal reference issues surfaced to the user while the turn continues. */
+  issues?: string[];
 }
 
 export interface FileReferenceExpansionOptions {
@@ -139,8 +141,7 @@ export async function expandFileReferencesInPrompt(
     }
   }
 
-  if (issues.length > 0) throw new FileReferenceError(issues);
-  if (resolved.length === 0) return { prompt: content, references: [] };
+  if (resolved.length === 0) return { prompt: content, references: [], issues };
 
   const references: ResolvedFileReference[] = [];
   let remainingTotal = maxTotalBytes;
@@ -169,6 +170,7 @@ export async function expandFileReferencesInPrompt(
   return {
     prompt: `${content}${formatFileReferenceContext(root, references)}`,
     references,
+    issues,
   };
 }
 


### PR DESCRIPTION
## Summary
- Treat unresolved/bad @file references as non-fatal expansion issues
- Surface file-reference issues as notices while still dispatching the prompt
- Add regression coverage for dotted @mentions, missing paths, invalid refs, and chat dispatch

## Tests
- env -u AETHON_WORKER_TAB_ID bunx vitest run agent/file-references.test.ts agent/dispatcher.test.ts
- env -u AETHON_WORKER_TAB_ID bun run typecheck
- env -u AETHON_WORKER_TAB_ID bun run lint
- env -u AETHON_WORKER_TAB_ID bunx vitest run

## Peer review
- codex review --uncommitted: no actionable correctness issues found