### PR TITLE
fix(sidebar): show project activity for running workspaces

### DIFF
--- a/src/extensions/default-layout/sidebar/item-row.test.tsx
+++ b/src/extensions/default-layout/sidebar/item-row.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { SidebarItem } from "../../../types/a2ui";
+import { ItemRow } from "./item-row";
+
+function renderItemRow(
+  item: SidebarItem,
+  disclosure?: "expanded" | "collapsed",
+) {
+  return render(
+    <ul>
+      <ItemRow
+        item={item}
+        monoItems={false}
+        sectionId="projects"
+        componentId="sidebar"
+        onEvent={vi.fn()}
+        renderChildWithState={vi.fn()}
+        state={{}}
+        index={0}
+        disclosure={disclosure}
+        stacked
+      />
+    </ul>,
+  );
+}
+
+afterEach(() => cleanup());
+
+describe("ItemRow agent activity", () => {
+  it("shows project rollup activity while expanded when a workspace agent is running", () => {
+    renderItemRow(
+      {
+        id: "p1",
+        label: "aethon",
+        agent: { status: "none", runningCount: 0 },
+        agentRollup: { status: "running", runningCount: 1 },
+      },
+      "expanded",
+    );
+
+    expect(screen.getByLabelText("Agent running")).toBeTruthy();
+  });
+
+  it("keeps expanded project rows dot-free for idle workspace-only sessions", () => {
+    renderItemRow(
+      {
+        id: "p1",
+        label: "aethon",
+        agent: { status: "none", runningCount: 0 },
+        agentRollup: { status: "idle-with-session", runningCount: 0 },
+      },
+      "expanded",
+    );
+
+    expect(screen.queryByLabelText("Agent session idle")).toBeNull();
+  });
+});

--- a/src/extensions/default-layout/sidebar/item-row.tsx
+++ b/src/extensions/default-layout/sidebar/item-row.tsx
@@ -102,18 +102,23 @@ export function ItemRow({
   const behind = git?.behind ?? 0;
 
   // Agent-activity dot — leading status indicator distinct from the trailing
-  // git dirty dot. When the project row is collapsed, fall back to the
-  // rollup so a hidden active workspace still surfaces a dot; when expanded,
-  // show only this row's own (main-scope) activity since the workspace rows
-  // carry their own dots.
+  // git dirty dot. A running workspace turn should keep the project line
+  // visibly active even while the project is expanded and another workspace
+  // is selected. Idle workspace-only sessions stay on their own rows while
+  // expanded to avoid duplicate idle rings; collapsed projects fall back to
+  // the rollup because their workspace rows are hidden.
   const agentRaw = item as {
     agent?: { status?: string; runningCount?: number };
     agentRollup?: { status?: string; runningCount?: number };
   };
+  const ownAgent = agentRaw.agent;
+  const rollupAgent = agentRaw.agentRollup;
   const agent =
-    disclosure === "collapsed"
-      ? (agentRaw.agentRollup ?? agentRaw.agent)
-      : agentRaw.agent;
+    rollupAgent?.status === "running"
+      ? rollupAgent
+      : disclosure === "collapsed"
+        ? (rollupAgent ?? ownAgent)
+        : ownAgent;
   const agentDotEl =
     agent && agent.status && agent.status !== "none" ? (
       <span


### PR DESCRIPTION
## Summary
- keep expanded project rows marked active when any workspace agent is running
- avoid duplicate idle workspace indicators on expanded project rows
- add focused ItemRow coverage for running rollup behavior

## Tests
- bunx vitest run src/extensions/default-layout/sidebar/item-row.test.tsx
- bunx vitest run src/extensions/default-layout/sidebar/item-row.test.tsx src/extensions/default-layout/sidebar/workspace-row.test.tsx src/hooks/projectOps/agentActivity.test.ts src/hooks/useDerivedRenderState.test.ts
- bunx tsc -b --noEmit
- bunx eslint src/extensions/default-layout/sidebar/item-row.tsx src/extensions/default-layout/sidebar/item-row.test.tsx