### PR TITLE
feat(memory): add Aethon user and project memory

### DIFF
--- a/agent/aethon-api.test.ts
+++ b/agent/aethon-api.test.ts
@@ -103,7 +103,7 @@ describe("buildAethonApi", () => {
 
   it("registerSlashCommand collides with built-ins", async () => {
     const { api } = makeFixture();
-    for (const name of ["clear", "login", "files"]) {
+    for (const name of ["clear", "login", "files", "memory"]) {
       const r = await api.registerSlashCommand({ name });
       expect(r.ok).toBe(false);
       expect(r.error).toContain("collides with a built-in");

--- a/agent/aethon-api.ts
+++ b/agent/aethon-api.ts
@@ -71,6 +71,7 @@ const BUILTIN_SLASH_NAMES = new Set([
   "reset",
   "reload",
   "rename",
+  "memory",
   "context",
   "session",
   "compact",

--- a/agent/main.ts
+++ b/agent/main.ts
@@ -94,6 +94,8 @@ import { seedPreparedEnv } from "./devshell";
 import { getSubagentsForCwd } from "./subagents";
 import { buildExplicitSubagentSteer } from "./subagents/steer";
 import { loadDisabledExtensionsSnapshot } from "./disabled-extensions";
+import { resolveMemoryContext, readMemoryPath } from "./memory/resolver";
+import { renderMemoryPromptSection } from "./memory/renderer";
 import { captureProjectExtensionBaseline, runDispatcher } from "./dispatcher";
 import { withWorkerOrigin } from "./origin-gate";
 
@@ -238,7 +240,20 @@ async function main(): Promise<void> {
         git,
         softAnchor: softGuardrailPrompt,
       });
-      let systemPrompt = `${event.systemPrompt}\n\n${section}`;
+      const memoryContext = await resolveMemoryContext({
+        userDir: state.userDir,
+        cwd: resolvedCwd,
+      }).catch(() => null);
+      const memorySection = memoryContext
+        ? renderMemoryPromptSection({
+            ...memoryContext,
+            userMemory: readMemoryPath(memoryContext.user.memoryPath),
+            projectMemory: readMemoryPath(memoryContext.project.memoryPath),
+          })
+        : "";
+      let systemPrompt = memorySection
+        ? `${event.systemPrompt}\n\n${memorySection}\n\n${section}`
+        : `${event.systemPrompt}\n\n${section}`;
       // Advertise the subagents available for THIS tab's cwd, per turn — so a
       // tab on project A never sees project B's subagents even after B opens
       // (the static system-prompt snapshot can't be per-tab).

--- a/agent/memory/renderer.test.ts
+++ b/agent/memory/renderer.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { renderMemoryPromptSection } from "./renderer";
+import type { ResolvedMemoryContext } from "./types";
+
+function ctx(overrides: Partial<ResolvedMemoryContext> = {}): ResolvedMemoryContext {
+  return {
+    user: {
+      scope: "user",
+      dir: "/home/me/.aethon/memory/user",
+      memoryPath: "/home/me/.aethon/memory/user/MEMORY.md",
+      topicsDir: "/home/me/.aethon/memory/user/topics",
+    },
+    project: {
+      scope: "project",
+      dir: "/home/me/.aethon/memory/projects/aethon-abc",
+      memoryPath: "/home/me/.aethon/memory/projects/aethon-abc/MEMORY.md",
+      topicsDir: "/home/me/.aethon/memory/projects/aethon-abc/topics",
+      project: {
+        id: "aethon-abc",
+        key: "aethon-project:p1:/repo/aethon",
+        root: "/repo/aethon",
+        label: "aethon",
+        source: "aethon-workspace",
+        resolvedFromCwd: "/repo/aethon/.aethon/workspaces/feat-x",
+      },
+    },
+    userMemory: "- Prefer concise replies\n",
+    projectMemory: "- Use bun for frontend commands\n",
+    ...overrides,
+  };
+}
+
+describe("renderMemoryPromptSection", () => {
+  it("renders user memory before project memory and includes resolved project metadata", () => {
+    const out = renderMemoryPromptSection(ctx());
+
+    expect(out).toContain("# Aethon memory");
+    expect(out.indexOf("## User memory")).toBeLessThan(out.indexOf("## Project memory"));
+    expect(out).toContain("- Prefer concise replies");
+    expect(out).toContain("- Use bun for frontend commands");
+    expect(out).toContain("Resolved project: `aethon` at `/repo/aethon`");
+    expect(out).toContain("scope source: `aethon-workspace`");
+  });
+
+  it("omits the section when both memory files are empty", () => {
+    expect(renderMemoryPromptSection(ctx({ userMemory: "", projectMemory: "" }))).toBe("");
+  });
+
+  it("caps loaded memory by line count and bytes", () => {
+    const manyLines = Array.from({ length: 205 }, (_, i) => `- line ${i + 1}`).join("\n");
+    const out = renderMemoryPromptSection(ctx({ userMemory: manyLines, projectMemory: "", maxLines: 200 }));
+
+    expect(out).toContain("- line 200");
+    expect(out).not.toContain("- line 201");
+    expect(out).toContain("truncated");
+
+    const bytesOut = renderMemoryPromptSection(
+      ctx({ userMemory: "abcdef", projectMemory: "", maxLines: 200, maxBytes: 3 }),
+    );
+    expect(bytesOut).toContain("abc");
+    expect(bytesOut).not.toContain("abcdef");
+    expect(bytesOut).toContain("truncated");
+  });
+});

--- a/agent/memory/renderer.ts
+++ b/agent/memory/renderer.ts
@@ -1,0 +1,56 @@
+import type { ResolvedMemoryContext } from "./types";
+
+const DEFAULT_MAX_LINES = 200;
+const DEFAULT_MAX_BYTES = 25 * 1024;
+
+function capText(
+  text: string,
+  maxLines: number,
+  maxBytes: number,
+): { text: string; truncated: boolean } {
+  let truncated = false;
+  const lines = text.replace(/\r\n/g, "\n").split("\n");
+  let next = lines.slice(0, maxLines).join("\n");
+  if (lines.length > maxLines) truncated = true;
+
+  const bytes = Buffer.byteLength(next, "utf8");
+  if (bytes > maxBytes) {
+    truncated = true;
+    next = Buffer.from(next, "utf8").subarray(0, maxBytes).toString("utf8");
+  }
+  return { text: next.trim(), truncated };
+}
+
+export function renderMemoryPromptSection(ctx: ResolvedMemoryContext): string {
+  const maxLines = ctx.maxLines ?? DEFAULT_MAX_LINES;
+  const maxBytes = ctx.maxBytes ?? DEFAULT_MAX_BYTES;
+  const user = capText(ctx.userMemory, maxLines, maxBytes);
+  const project = capText(ctx.projectMemory, maxLines, maxBytes);
+  if (!user.text && !project.text) return "";
+
+  const lines: string[] = ["# Aethon memory"];
+  lines.push(
+    "These are persistent user/project memories stored under `~/.aethon`. Treat them as durable guidance, but do not store secrets. If the user explicitly asks you to remember, always do, never do, or from now on do something, use the memory tools to update the appropriate scope.",
+  );
+
+  if (user.text) {
+    lines.push("", `## User memory (${ctx.user.memoryPath})`, user.text);
+    if (user.truncated) lines.push("(User memory truncated for prompt budget.)");
+  }
+
+  if (project.text) {
+    lines.push("", `## Project memory (${ctx.project.memoryPath})`);
+    const p = ctx.project.project;
+    if (p) {
+      lines.push(
+        `Resolved project: \`${p.label}\` at \`${p.root}\` (scope source: \`${p.source}\`, current cwd: \`${p.resolvedFromCwd}\`).`,
+      );
+    }
+    lines.push(project.text);
+    if (project.truncated) {
+      lines.push("(Project memory truncated for prompt budget.)");
+    }
+  }
+
+  return lines.join("\n");
+}

--- a/agent/memory/resolver.test.ts
+++ b/agent/memory/resolver.test.ts
@@ -1,0 +1,90 @@
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { projectIdentityFromProjectsJson, resolveMemoryContext } from "./resolver";
+
+function projectsJson(root: string, workspace: string): string {
+  return JSON.stringify({
+    activeId: "p1",
+    projects: [{ id: "p1", label: "Aethon", path: root }],
+    activeWorkspaceId: "w1",
+    workspacesByProject: {
+      p1: [{ id: "w1", projectId: "p1", path: workspace }],
+    },
+  });
+}
+
+describe("memory resolver", () => {
+  it("resolves a workspace cwd to its parent Aethon project", () => {
+    const id = projectIdentityFromProjectsJson(
+      projectsJson("/repo/aethon", "/repo/aethon/.aethon/workspaces/feat-x"),
+      "/repo/aethon/.aethon/workspaces/feat-x/src",
+    );
+
+    expect(id).toMatchObject({
+      root: "/repo/aethon",
+      label: "Aethon",
+      source: "aethon-workspace",
+      resolvedFromCwd: "/repo/aethon/.aethon/workspaces/feat-x/src",
+    });
+    expect(id?.key).toContain("p1");
+  });
+
+  it("falls back to the git common dir so linked worktrees share one memory scope", async () => {
+    const userDir = mkdtempSync(join(tmpdir(), "aethon-memory-"));
+    const ctx = await resolveMemoryContext({
+      userDir,
+      cwd: "/work/repo-linked",
+      readProjectsJson: () => Promise.resolve(undefined),
+      git: (_cwd, args) => {
+        if (args.includes("--git-common-dir")) return Promise.resolve("/work/repo/.git");
+        if (args.includes("--show-toplevel")) return Promise.resolve("/work/repo-linked");
+        return Promise.resolve(undefined);
+      },
+    });
+
+    expect(ctx.project.project?.root).toBe("/work/repo");
+    expect(ctx.project.project?.source).toBe("git-common-dir");
+    expect(ctx.project.project?.key).toBe("git:/work/repo");
+  });
+
+  it("keeps the same project memory directory when only the display label changes", async () => {
+    const first = projectIdentityFromProjectsJson(
+      projectsJson("/repo/aethon", "/repo/aethon/.aethon/workspaces/feat-x"),
+      "/repo/aethon/src",
+    );
+    const second = projectIdentityFromProjectsJson(
+      projectsJson("/repo/aethon", "/repo/aethon/.aethon/workspaces/feat-x").replace("Aethon", "Renamed"),
+      "/repo/aethon/src",
+    );
+    const userDir = mkdtempSync(join(tmpdir(), "aethon-memory-"));
+    const firstCtx = await resolveMemoryContext({
+      userDir,
+      cwd: "/repo/aethon/src",
+      readProjectsJson: () => Promise.resolve(JSON.stringify({ projects: [{ id: "p1", label: first?.label, path: first?.root }] })),
+    });
+    const secondCtx = await resolveMemoryContext({
+      userDir,
+      cwd: "/repo/aethon/src",
+      readProjectsJson: () => Promise.resolve(JSON.stringify({ projects: [{ id: "p1", label: second?.label, path: second?.root }] })),
+    });
+
+    expect(firstCtx.project.dir).toBe(secondCtx.project.dir);
+  });
+
+  it("creates memory files under ~/.aethon without writing to the project", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "aethon-memory-"));
+    mkdirSync(join(dir, "repo"));
+    writeFileSync(join(dir, "projects.json"), projectsJson(join(dir, "repo"), join(dir, "repo", "wt")));
+
+    const ctx = await resolveMemoryContext({
+      userDir: dir,
+      cwd: join(dir, "repo", "src"),
+    });
+
+    expect(ctx.user.memoryPath).toBe(join(dir, "memory", "user", "MEMORY.md"));
+    expect(ctx.project.memoryPath).toContain(join(dir, "memory", "projects"));
+    expect(ctx.project.memoryPath).not.toContain(join(dir, "repo"));
+  });
+});

--- a/agent/memory/resolver.test.ts
+++ b/agent/memory/resolver.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -71,6 +71,30 @@ describe("memory resolver", () => {
     });
 
     expect(firstCtx.project.dir).toBe(secondCtx.project.dir);
+  });
+
+  it("does not rewrite project metadata when stable identity is unchanged", async () => {
+    const userDir = mkdtempSync(join(tmpdir(), "aethon-memory-"));
+    const options = {
+      userDir,
+      cwd: "/repo/aethon/src",
+      readProjectsJson: () =>
+        Promise.resolve(
+          JSON.stringify({ projects: [{ id: "p1", label: "Aethon", path: "/repo/aethon" }] }),
+        ),
+    };
+
+    const first = await resolveMemoryContext(options);
+    const metaPath = join(first.project.dir, "meta.json");
+    const firstMeta = readFileSync(metaPath, "utf8");
+    const firstMtime = statSync(metaPath).mtimeMs;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    await resolveMemoryContext(options);
+
+    expect(readFileSync(metaPath, "utf8")).toBe(firstMeta);
+    expect(statSync(metaPath).mtimeMs).toBe(firstMtime);
+    expect(firstMeta).not.toContain("resolvedFromCwd");
+    expect(firstMeta).not.toContain("updatedAt");
   });
 
   it("creates memory files under ~/.aethon without writing to the project", async () => {

--- a/agent/memory/resolver.ts
+++ b/agent/memory/resolver.ts
@@ -1,0 +1,258 @@
+import { existsSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { basename, dirname, join, resolve, sep } from "node:path";
+import { spawnSync } from "node:child_process";
+import type { ProjectMemoryIdentity, ResolvedMemoryContext, ResolvedMemoryScope } from "./types";
+
+interface PersistedProject {
+  id?: unknown;
+  label?: unknown;
+  path?: unknown;
+}
+
+interface PersistedWorkspace {
+  id?: unknown;
+  projectId?: unknown;
+  path?: unknown;
+}
+
+interface PersistedProjects {
+  projects?: PersistedProject[];
+  workspacesByProject?: Record<string, PersistedWorkspace[]>;
+  worktreesByProject?: Record<string, PersistedWorkspace[]>;
+}
+
+export interface ResolveMemoryOptions {
+  userDir: string;
+  cwd: string;
+  readProjectsJson?: () => Promise<string | undefined>;
+  git?: (cwd: string, args: string[]) => Promise<string | undefined>;
+}
+
+function normalizePath(p: string): string {
+  let out = resolve(p).replace(/[/\\]+$/, "");
+  if (out === "") out = sep;
+  return process.platform === "win32" ? out.toLowerCase() : out;
+}
+
+function canonicalPath(p: string): string {
+  try {
+    return normalizePath(realpathSync(p));
+  } catch {
+    return normalizePath(p);
+  }
+}
+
+function isInsidePath(child: string, parent: string): boolean {
+  const c = canonicalPath(child);
+  const p = canonicalPath(parent);
+  if (c === p) return true;
+  const prefix = p.endsWith(sep) ? p : `${p}${sep}`;
+  return c.startsWith(prefix);
+}
+
+function slug(input: string): string {
+  const s = input
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return s || "project";
+}
+
+function shortHash(input: string): string {
+  return createHash("sha256").update(input).digest("hex").slice(0, 16);
+}
+
+function projectDirName(identity: ProjectMemoryIdentity): string {
+  return `project-${shortHash(identity.key)}`;
+}
+
+function userScope(userDir: string): ResolvedMemoryScope {
+  const dir = join(userDir, "memory", "user");
+  return {
+    scope: "user",
+    dir,
+    memoryPath: join(dir, "MEMORY.md"),
+    topicsDir: join(dir, "topics"),
+  };
+}
+
+function projectScope(userDir: string, identity: ProjectMemoryIdentity): ResolvedMemoryScope {
+  const dir = join(userDir, "memory", "projects", projectDirName(identity));
+  return {
+    scope: "project",
+    dir,
+    memoryPath: join(dir, "MEMORY.md"),
+    topicsDir: join(dir, "topics"),
+    project: { ...identity, id: projectDirName(identity) },
+  };
+}
+
+function cwdIdentity(cwd: string): ProjectMemoryIdentity {
+  const root = canonicalPath(cwd);
+  return {
+    id: `${slug(basename(root))}-${shortHash(`cwd:${root}`)}`,
+    key: `cwd:${root}`,
+    root,
+    label: basename(root) || "project",
+    source: "cwd",
+    resolvedFromCwd: cwd,
+  };
+}
+
+export function projectIdentityFromProjectsJson(
+  text: string | undefined,
+  cwd: string,
+): ProjectMemoryIdentity | undefined {
+  if (!text) return undefined;
+  let parsed: PersistedProjects;
+  try {
+    parsed = JSON.parse(text) as PersistedProjects;
+  } catch {
+    return undefined;
+  }
+  if (!Array.isArray(parsed.projects)) return undefined;
+
+  const candidates: {
+    root: string;
+    matched: string;
+    label: string;
+    projectId: string;
+    source: "aethon-project" | "aethon-workspace";
+  }[] = [];
+  const workspacesByProject = parsed.workspacesByProject ?? parsed.worktreesByProject ?? {};
+
+  for (const p of parsed.projects) {
+    if (typeof p?.id !== "string" || typeof p.path !== "string" || p.path.length === 0) {
+      continue;
+    }
+    const label = typeof p.label === "string" && p.label.length > 0 ? p.label : basename(p.path);
+    if (isInsidePath(cwd, p.path)) {
+      candidates.push({ root: canonicalPath(p.path), matched: p.path, label, projectId: p.id, source: "aethon-project" });
+    }
+    const workspaces = workspacesByProject[p.id] ?? [];
+    for (const w of workspaces) {
+      if (w?.projectId !== p.id || typeof w.path !== "string" || w.path.length === 0) continue;
+      if (isInsidePath(cwd, w.path)) {
+        candidates.push({ root: canonicalPath(p.path), matched: w.path, label, projectId: p.id, source: "aethon-workspace" });
+      }
+    }
+  }
+
+  candidates.sort((a, b) => canonicalPath(b.matched).length - canonicalPath(a.matched).length);
+  const best = candidates[0];
+  if (!best) return undefined;
+  return {
+    id: best.projectId,
+    key: `aethon-project:${best.projectId}:${best.root}`,
+    root: best.root,
+    label: best.label,
+    source: best.source,
+    resolvedFromCwd: cwd,
+  };
+}
+
+async function defaultReadProjectsJson(userDir: string): Promise<string | undefined> {
+  try {
+    return await readFile(join(userDir, "projects.json"), "utf8");
+  } catch {
+    return undefined;
+  }
+}
+
+function defaultGit(cwd: string, args: string[]): Promise<string | undefined> {
+  const out = spawnSync("git", ["-C", cwd, ...args], { encoding: "utf8" });
+  if (out.status !== 0) return Promise.resolve(undefined);
+  const text = out.stdout.trim();
+  return Promise.resolve(text.length > 0 ? text : undefined);
+}
+
+async function projectIdentityFromGit(
+  cwd: string,
+  git: (cwd: string, args: string[]) => Promise<string | undefined>,
+): Promise<ProjectMemoryIdentity | undefined> {
+  const common = await git(cwd, ["rev-parse", "--path-format=absolute", "--git-common-dir"]);
+  const top = await git(cwd, ["rev-parse", "--show-toplevel"]);
+  if (!common && !top) return undefined;
+
+  let root: string | undefined;
+  let source: ProjectMemoryIdentity["source"] = "git-toplevel";
+  if (common) {
+    const commonPath = canonicalPath(common);
+    if (basename(commonPath) === ".git") {
+      root = canonicalPath(dirname(commonPath));
+      source = "git-common-dir";
+    }
+  }
+  root ??= top ? canonicalPath(top) : undefined;
+  if (!root) return undefined;
+  return {
+    id: `${slug(basename(root))}-${shortHash(`git:${root}`)}`,
+    key: `git:${root}`,
+    root,
+    label: basename(root) || "project",
+    source,
+    resolvedFromCwd: cwd,
+  };
+}
+
+function ensureScope(scope: ResolvedMemoryScope): void {
+  mkdirSync(scope.topicsDir, { recursive: true });
+  if (!existsSync(scope.memoryPath)) {
+    writeFileSync(scope.memoryPath, "", "utf8");
+  }
+  if (scope.scope === "project" && scope.project) {
+    const metaPath = join(scope.dir, "meta.json");
+    writeFileSync(
+      metaPath,
+      `${JSON.stringify(
+        {
+          id: scope.project.id,
+          key: scope.project.key,
+          root: scope.project.root,
+          label: scope.project.label,
+          source: scope.project.source,
+          resolvedFromCwd: scope.project.resolvedFromCwd,
+          updatedAt: new Date().toISOString(),
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+  }
+}
+
+export async function resolveMemoryContext(
+  options: ResolveMemoryOptions,
+): Promise<Omit<ResolvedMemoryContext, "userMemory" | "projectMemory">> {
+  const user = userScope(options.userDir);
+  const projectsJson = options.readProjectsJson
+    ? await options.readProjectsJson()
+    : await defaultReadProjectsJson(options.userDir);
+  const identity =
+    projectIdentityFromProjectsJson(projectsJson, options.cwd) ??
+    (await projectIdentityFromGit(options.cwd, options.git ?? defaultGit)) ??
+    cwdIdentity(options.cwd);
+  const project = projectScope(options.userDir, identity);
+  ensureScope(user);
+  ensureScope(project);
+  return { user, project };
+}
+
+export async function resolveMemoryScope(
+  options: ResolveMemoryOptions & { scope: "user" | "project" },
+): Promise<ResolvedMemoryScope> {
+  const ctx = await resolveMemoryContext(options);
+  return options.scope === "user" ? ctx.user : ctx.project;
+}
+
+export function readMemoryPath(path: string): string {
+  try {
+    return readFileSync(path, "utf8");
+  } catch {
+    return "";
+  }
+}

--- a/agent/memory/resolver.ts
+++ b/agent/memory/resolver.ts
@@ -2,7 +2,8 @@ import { existsSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from
 import { readFile } from "node:fs/promises";
 import { createHash } from "node:crypto";
 import { basename, dirname, join, resolve, sep } from "node:path";
-import { spawnSync } from "node:child_process";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import type { ProjectMemoryIdentity, ResolvedMemoryContext, ResolvedMemoryScope } from "./types";
 
 interface PersistedProject {
@@ -22,6 +23,9 @@ interface PersistedProjects {
   workspacesByProject?: Record<string, PersistedWorkspace[]>;
   worktreesByProject?: Record<string, PersistedWorkspace[]>;
 }
+
+const execFileAsync = promisify(execFile);
+const GIT_TIMEOUT_MS = 2_000;
 
 export interface ResolveMemoryOptions {
   userDir: string;
@@ -162,11 +166,17 @@ async function defaultReadProjectsJson(userDir: string): Promise<string | undefi
   }
 }
 
-function defaultGit(cwd: string, args: string[]): Promise<string | undefined> {
-  const out = spawnSync("git", ["-C", cwd, ...args], { encoding: "utf8" });
-  if (out.status !== 0) return Promise.resolve(undefined);
-  const text = out.stdout.trim();
-  return Promise.resolve(text.length > 0 ? text : undefined);
+async function defaultGit(cwd: string, args: string[]): Promise<string | undefined> {
+  try {
+    const out = await execFileAsync("git", ["-C", cwd, ...args], {
+      encoding: "utf8",
+      timeout: GIT_TIMEOUT_MS,
+    });
+    const text = out.stdout.trim();
+    return text.length > 0 ? text : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 async function projectIdentityFromGit(
@@ -198,6 +208,15 @@ async function projectIdentityFromGit(
   };
 }
 
+function writeIfChanged(path: string, text: string): void {
+  try {
+    if (readFileSync(path, "utf8") === text) return;
+  } catch {
+    // Missing or unreadable files are replaced below.
+  }
+  writeFileSync(path, text, "utf8");
+}
+
 function ensureScope(scope: ResolvedMemoryScope): void {
   mkdirSync(scope.topicsDir, { recursive: true });
   if (!existsSync(scope.memoryPath)) {
@@ -205,7 +224,7 @@ function ensureScope(scope: ResolvedMemoryScope): void {
   }
   if (scope.scope === "project" && scope.project) {
     const metaPath = join(scope.dir, "meta.json");
-    writeFileSync(
+    writeIfChanged(
       metaPath,
       `${JSON.stringify(
         {
@@ -214,13 +233,10 @@ function ensureScope(scope: ResolvedMemoryScope): void {
           root: scope.project.root,
           label: scope.project.label,
           source: scope.project.source,
-          resolvedFromCwd: scope.project.resolvedFromCwd,
-          updatedAt: new Date().toISOString(),
         },
         null,
         2,
       )}\n`,
-      "utf8",
     );
   }
 }

--- a/agent/memory/store.test.ts
+++ b/agent/memory/store.test.ts
@@ -1,0 +1,83 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { forgetMemoryEntry, readMemoryFile, rememberEntry } from "./store";
+import type { ResolvedMemoryScope } from "./types";
+
+function scope(dir: string): ResolvedMemoryScope {
+  return {
+    scope: "project",
+    dir,
+    memoryPath: join(dir, "MEMORY.md"),
+    topicsDir: join(dir, "topics"),
+    project: {
+      id: "proj-123",
+      key: "project:/repo",
+      root: "/repo",
+      label: "repo",
+      source: "cwd",
+      resolvedFromCwd: "/repo",
+    },
+  };
+}
+
+describe("memory store", () => {
+  it("appends durable entries with ids and avoids duplicate text", async () => {
+    const s = scope(mkdtempSync(join(tmpdir(), "aethon-memory-store-")));
+
+    const first = await rememberEntry(s, {
+      kind: "instruction",
+      text: "Always run focused tests before broad gates.",
+      tags: ["testing"],
+    });
+    const second = await rememberEntry(s, {
+      kind: "instruction",
+      text: "Always run focused tests before broad gates.",
+      tags: ["testing"],
+    });
+
+    expect(first.created).toBe(true);
+    expect(second.created).toBe(false);
+    const text = await readFile(s.memoryPath, "utf8");
+    expect(text.match(/Always run focused tests/g)).toHaveLength(1);
+    expect(text).toContain(`<!-- id: ${first.id}`);
+  });
+
+  it("serializes concurrent remembers so entries are not lost", async () => {
+    const s = scope(mkdtempSync(join(tmpdir(), "aethon-memory-store-")));
+
+    await Promise.all([
+      rememberEntry(s, { kind: "fact", text: "The API test suite needs Redis." }),
+      rememberEntry(s, { kind: "fact", text: "The UI test suite needs Playwright." }),
+    ]);
+
+    const text = await readMemoryFile(s);
+    expect(text).toContain("The API test suite needs Redis.");
+    expect(text).toContain("The UI test suite needs Playwright.");
+  });
+
+  it("waits for an inter-process lock before writing", async () => {
+    const s = scope(mkdtempSync(join(tmpdir(), "aethon-memory-store-")));
+    mkdirSync(`${s.memoryPath}.lock`, { recursive: true });
+
+    const pending = rememberEntry(s, { kind: "fact", text: "Locked writes eventually persist." });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(await readMemoryFile(s)).not.toContain("Locked writes eventually persist.");
+
+    rmSync(`${s.memoryPath}.lock`, { recursive: true, force: true });
+    await pending;
+    expect(await readMemoryFile(s)).toContain("Locked writes eventually persist.");
+  });
+
+  it("removes entries by id", async () => {
+    const s = scope(mkdtempSync(join(tmpdir(), "aethon-memory-store-")));
+    const entry = await rememberEntry(s, { kind: "preference", text: "Prefer Nix over Homebrew." });
+
+    const removed = await forgetMemoryEntry(s, { id: entry.id });
+
+    expect(removed.removed).toBe(1);
+    expect(await readMemoryFile(s)).not.toContain("Prefer Nix");
+  });
+});

--- a/agent/memory/store.ts
+++ b/agent/memory/store.ts
@@ -1,0 +1,154 @@
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { createHash, randomUUID } from "node:crypto";
+import { dirname } from "node:path";
+import type { ForgetInput, ForgetResult, RememberInput, RememberResult, ResolvedMemoryScope } from "./types";
+
+function normalizeEntryText(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+function entryHash(scope: ResolvedMemoryScope, text: string): string {
+  return createHash("sha256")
+    .update(`${scope.scope}:${scope.project?.key ?? "user"}:${normalizeEntryText(text).toLowerCase()}`)
+    .digest("hex")
+    .slice(0, 12);
+}
+
+function entryId(scope: ResolvedMemoryScope, text: string): string {
+  return `mem_${entryHash(scope, text)}_${randomUUID().slice(0, 8)}`;
+}
+
+function safeTags(tags: string[] | undefined): string[] {
+  return (tags ?? [])
+    .map((tag) => tag.trim().toLowerCase().replace(/[^a-z0-9_-]+/g, "-"))
+    .filter(Boolean)
+    .slice(0, 8);
+}
+
+const writeQueues = new Map<string, Promise<unknown>>();
+const LOCK_RETRY_MS = 25;
+const LOCK_TIMEOUT_MS = 10_000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function acquireFileLock(path: string): Promise<() => Promise<void>> {
+  const lockDir = `${path}.lock`;
+  await mkdir(dirname(path), { recursive: true });
+  const deadline = Date.now() + LOCK_TIMEOUT_MS;
+  while (true) {
+    try {
+      await mkdir(lockDir);
+      return async () => {
+        await rm(lockDir, { recursive: true, force: true });
+      };
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== "EEXIST" || Date.now() >= deadline) {
+        throw err;
+      }
+      await sleep(LOCK_RETRY_MS);
+    }
+  }
+}
+
+async function withMemoryWriteLock<T>(path: string, fn: () => Promise<T>): Promise<T> {
+  const previous = writeQueues.get(path) ?? Promise.resolve();
+  const run = (async () => {
+    await previous.catch(() => undefined);
+    const release = await acquireFileLock(path);
+    try {
+      return await fn();
+    } finally {
+      await release();
+    }
+  })();
+  writeQueues.set(path, run);
+  try {
+    return await run;
+  } finally {
+    if (writeQueues.get(path) === run) {
+      writeQueues.delete(path);
+    }
+  }
+}
+
+function renderEntry(scope: ResolvedMemoryScope, input: RememberInput, id: string): string {
+  const tags = safeTags(input.tags);
+  const meta = [
+    `id: ${id}`,
+    `kind: ${input.kind}`,
+    `created: ${new Date().toISOString()}`,
+    ...(tags.length > 0 ? [`tags: ${tags.join(",")}`] : []),
+    `scope: ${scope.scope}`,
+  ].join("; ");
+  return `- [${input.kind}] ${normalizeEntryText(input.text)} <!-- ${meta} -->`;
+}
+
+function lineHasId(line: string, id: string): boolean {
+  return line.includes(`id: ${id}`) || line.includes(`id:${id}`);
+}
+
+function lineText(line: string): string {
+  return line.replace(/<!--.*?-->/g, "").replace(/^\s*-\s*(\[[^\]]+\]\s*)?/, "").trim();
+}
+
+export async function readMemoryFile(scope: ResolvedMemoryScope): Promise<string> {
+  try {
+    return await readFile(scope.memoryPath, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+async function writeMemoryFile(scope: ResolvedMemoryScope, content: string): Promise<void> {
+  await mkdir(scope.topicsDir, { recursive: true });
+  await writeFile(scope.memoryPath, content, "utf8");
+}
+
+export async function rememberEntry(
+  scope: ResolvedMemoryScope,
+  input: RememberInput,
+): Promise<RememberResult> {
+  return withMemoryWriteLock(scope.memoryPath, async () => {
+    const text = normalizeEntryText(input.text);
+    if (!text) throw new Error("memory text is required");
+    const current = await readMemoryFile(scope);
+    const duplicate = current
+      .split(/\r?\n/)
+      .find((line) => lineText(line).toLowerCase() === text.toLowerCase());
+    if (duplicate) {
+      const existingId = duplicate.match(/id:\s*([^;\s]+)/)?.[1] ?? entryHash(scope, text);
+      return { id: existingId, created: false, path: scope.memoryPath };
+    }
+
+    const id = entryId(scope, text);
+    const header = current.trim().length === 0 ? "# Aethon memory\n\n" : "";
+    const prefix = current.trim().length === 0 ? header : current.replace(/\s*$/, "\n");
+    await writeMemoryFile(scope, `${prefix}${renderEntry(scope, { ...input, text }, id)}\n`);
+    return { id, created: true, path: scope.memoryPath };
+  });
+}
+
+export async function forgetMemoryEntry(
+  scope: ResolvedMemoryScope,
+  input: ForgetInput,
+): Promise<ForgetResult> {
+  return withMemoryWriteLock(scope.memoryPath, async () => {
+    const current = await readMemoryFile(scope);
+    const targetText = input.text ? normalizeEntryText(input.text).toLowerCase() : undefined;
+    let removed = 0;
+    const kept = current.split(/\r?\n/).filter((line) => {
+      const match =
+        (input.id ? lineHasId(line, input.id) : false) ||
+        (targetText ? lineText(line).toLowerCase() === targetText : false);
+      if (match) removed += 1;
+      return !match;
+    });
+    if (removed > 0) {
+      await writeMemoryFile(scope, kept.join("\n").replace(/\n{3,}/g, "\n\n"));
+    }
+    return { removed, path: scope.memoryPath };
+  });
+}

--- a/agent/memory/tools.test.ts
+++ b/agent/memory/tools.test.ts
@@ -1,0 +1,43 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { AethonAgentState } from "../state";
+import { buildMemoryTools } from "./tools";
+
+function tool(name: string) {
+  const userDir = mkdtempSync(join(tmpdir(), "aethon-memory-tools-"));
+  const state = new AethonAgentState({
+    userDir,
+    stateFile: join(userDir, "state.json"),
+    sessionsDir: join(userDir, "sessions"),
+    releaseMode: false,
+  });
+  state.tabProjectCwds.set("tab-1", join(userDir, "repo"));
+  const found = buildMemoryTools(state, "tab-1").find((t) => t.name === name);
+  if (!found) throw new Error(`missing tool ${name}`);
+  return { found, state, userDir };
+}
+
+describe("buildMemoryTools", () => {
+  it("advertises remember/always behavior in the prompt snippet", () => {
+    const { found } = tool("remember");
+    expect(found.promptSnippet).toContain("remember");
+    expect(found.promptSnippet).toContain("Always");
+  });
+
+  it("stores and reads project memory", async () => {
+    const { found: remember, state } = tool("remember");
+    const read = buildMemoryTools(state, "tab-1").find((t) => t.name === "readMemory");
+    if (!read) throw new Error("missing readMemory");
+
+    await remember.execute("call-1", {
+      scope: "project",
+      kind: "instruction",
+      text: "Always use bun for frontend package commands.",
+    });
+    const result = await read.execute("call-2", { scope: "project" });
+
+    expect(result.content[0]?.text).toContain("Always use bun");
+  });
+});

--- a/agent/memory/tools.ts
+++ b/agent/memory/tools.ts
@@ -1,0 +1,142 @@
+import type { ToolDefinition } from "@mariozechner/pi-coding-agent";
+import { defineTool } from "@mariozechner/pi-coding-agent";
+import { Type, type Static } from "typebox";
+import type { AethonAgentState } from "../state";
+import { readMemoryPath, resolveMemoryContext, resolveMemoryScope } from "./resolver";
+import { forgetMemoryEntry, readMemoryFile, rememberEntry } from "./store";
+import type { MemoryScopeName, RememberInput } from "./types";
+
+const Scope = Type.Union([Type.Literal("user"), Type.Literal("project")]);
+
+const EmptyParams = Type.Object({});
+type EmptyParamsT = Static<typeof EmptyParams>;
+
+const ReadParams = Type.Object({
+  scope: Scope,
+});
+type ReadParamsT = { scope: MemoryScopeName };
+
+const RememberParams = Type.Object({
+  scope: Scope,
+  kind: Type.Union([
+    Type.Literal("instruction"),
+    Type.Literal("preference"),
+    Type.Literal("fact"),
+    Type.Literal("workflow"),
+    Type.Literal("pitfall"),
+  ]),
+  text: Type.String({
+    description: "Durable memory text to store. Do not include secrets, credentials, tokens, or temporary one-off context.",
+  }),
+  tags: Type.Optional(Type.Array(Type.String())),
+});
+type RememberParamsT = RememberInput & { scope: MemoryScopeName };
+
+const ForgetParams = Type.Object({
+  scope: Scope,
+  id: Type.Optional(Type.String()),
+  text: Type.Optional(Type.String()),
+});
+type ForgetParamsT = { scope: MemoryScopeName; id?: string; text?: string };
+
+function cwdForTab(state: AethonAgentState, tabId: string): string {
+  return state.tabProjectCwds.get(tabId) ?? state.currentProjectCwd ?? state.userDir ?? process.cwd();
+}
+
+function asJson(value: unknown): { content: { type: "text"; text: string }[]; details: unknown } {
+  return {
+    content: [{ type: "text", text: JSON.stringify(value, null, 2) }],
+    details: value,
+  };
+}
+
+function hasSecretShape(text: string): boolean {
+  return /(api[_-]?key|secret|token|password|passwd|private[_-]?key)\s*[:=]/i.test(text) ||
+    /(?:sk-|ghp_|gho_|github_pat_|AKIA)[A-Za-z0-9_-]{12,}/.test(text);
+}
+
+async function scopeFor(state: AethonAgentState, tabId: string, scope: MemoryScopeName) {
+  return resolveMemoryScope({ userDir: state.userDir, cwd: cwdForTab(state, tabId), scope });
+}
+
+export function buildMemoryTools(state: AethonAgentState, tabId: string): ToolDefinition[] {
+  const listTool = defineTool({
+    name: "listMemoryScopes",
+    label: "List Aethon memory scopes",
+    description:
+      "List the Aethon user and resolved-project memory scopes for the active tab, including file paths and project/worktree resolution metadata.",
+    promptSnippet:
+      "listMemoryScopes: inspect Aethon's user/project memory files and current project/worktree resolution",
+    parameters: EmptyParams,
+    async execute(_callId: string, _params: EmptyParamsT) {
+      const ctx = await resolveMemoryContext({ userDir: state.userDir, cwd: cwdForTab(state, tabId) });
+      return asJson({ user: ctx.user, project: ctx.project });
+    },
+  }) as ToolDefinition;
+
+  const readTool = defineTool({
+    name: "readMemory",
+    label: "Read Aethon memory",
+    description:
+      "Read the Aethon MEMORY.md file for the selected scope. Use this before editing memory when you need to inspect existing entries.",
+    promptSnippet: "readMemory: read Aethon's user or resolved-project MEMORY.md",
+    parameters: ReadParams,
+    async execute(_callId: string, params: ReadParamsT) {
+      const scope = await scopeFor(state, tabId, params.scope);
+      const text = await readMemoryFile(scope);
+      return { content: [{ type: "text" as const, text }], details: { scope, text } };
+    },
+  }) as ToolDefinition;
+
+  const rememberTool = defineTool({
+    name: "remember",
+    label: "Remember in Aethon memory",
+    description:
+      "Persist a durable user or project memory under ~/.aethon. Call this when the user explicitly says things like 'remember ...', 'Always ...', 'Never ...', or 'from now on ...'. Use scope='user' for global personal preferences and scope='project' for codebase/workflow facts. Do not store secrets, credentials, sensitive personal data, or temporary one-off context; ask first if scope or durability is ambiguous.",
+    promptSnippet:
+      "remember: persist explicit durable memory. Use when the user says 'remember', 'Always ...', 'Never ...', or 'from now on ...'; never store secrets.",
+    parameters: RememberParams,
+    async execute(_callId: string, params: RememberParamsT) {
+      if (hasSecretShape(params.text)) {
+        throw new Error("Refusing to store likely secret or credential-shaped memory.");
+      }
+      const scope = await scopeFor(state, tabId, params.scope);
+      return asJson(await rememberEntry(scope, params));
+    },
+  }) as ToolDefinition;
+
+  const forgetTool = defineTool({
+    name: "forgetMemory",
+    label: "Forget Aethon memory",
+    description:
+      "Remove a memory entry from the selected Aethon scope by id or exact text. Use when the user asks you to forget or delete a stored memory.",
+    promptSnippet:
+      "forgetMemory: delete an Aethon memory entry by id or exact text when the user asks to forget it",
+    parameters: ForgetParams,
+    async execute(_callId: string, params: ForgetParamsT) {
+      if (!params.id && !params.text) {
+        throw new Error("forgetMemory requires id or text");
+      }
+      const scope = await scopeFor(state, tabId, params.scope);
+      return asJson(await forgetMemoryEntry(scope, { id: params.id, text: params.text }));
+    },
+  }) as ToolDefinition;
+
+  return [listTool, readTool, rememberTool, forgetTool];
+}
+
+export async function formatMemorySummary(state: AethonAgentState, tabId: string): Promise<string> {
+  const ctx = await resolveMemoryContext({ userDir: state.userDir, cwd: cwdForTab(state, tabId) });
+  const userMemory = readMemoryPath(ctx.user.memoryPath).trim() || "(empty)";
+  const projectMemory = readMemoryPath(ctx.project.memoryPath).trim() || "(empty)";
+  const lines = ["## Aethon memory"];
+  lines.push("Aethon memory is stored locally under `~/.aethon/memory` and is separate from repository `AGENTS.md` files.");
+  lines.push("", "### User scope", `- File: ${ctx.user.memoryPath}`, "", userMemory);
+  lines.push("", "### Project scope", `- File: ${ctx.project.memoryPath}`);
+  if (ctx.project.project) {
+    lines.push(`- Resolved project: ${ctx.project.project.label} (${ctx.project.project.root})`);
+    lines.push(`- Source: ${ctx.project.project.source}`);
+  }
+  lines.push("", projectMemory);
+  return lines.join("\n");
+}

--- a/agent/memory/types.ts
+++ b/agent/memory/types.ts
@@ -1,0 +1,56 @@
+export type MemoryScopeName = "user" | "project";
+
+export type ProjectMemorySource =
+  | "aethon-project"
+  | "aethon-workspace"
+  | "git-common-dir"
+  | "git-toplevel"
+  | "cwd";
+
+export interface ProjectMemoryIdentity {
+  id: string;
+  key: string;
+  root: string;
+  label: string;
+  source: ProjectMemorySource;
+  resolvedFromCwd: string;
+}
+
+export interface ResolvedMemoryScope {
+  scope: MemoryScopeName;
+  dir: string;
+  memoryPath: string;
+  topicsDir: string;
+  project?: ProjectMemoryIdentity;
+}
+
+export interface ResolvedMemoryContext {
+  user: ResolvedMemoryScope;
+  project: ResolvedMemoryScope;
+  userMemory: string;
+  projectMemory: string;
+  maxLines?: number;
+  maxBytes?: number;
+}
+
+export interface RememberInput {
+  kind: "instruction" | "preference" | "fact" | "workflow" | "pitfall";
+  text: string;
+  tags?: string[];
+}
+
+export interface RememberResult {
+  id: string;
+  created: boolean;
+  path: string;
+}
+
+export interface ForgetInput {
+  id?: string;
+  text?: string;
+}
+
+export interface ForgetResult {
+  removed: number;
+  path: string;
+}

--- a/agent/nativeSlash.ts
+++ b/agent/nativeSlash.ts
@@ -9,6 +9,7 @@ import {
   writeSessionLabel,
 } from "./session-history";
 import { ensureTab, modelKey, tabSessionDir } from "./tab-lifecycle";
+import { formatMemorySummary } from "./memory/tools";
 
 interface NativeContextUsage {
   tokens: number | null;
@@ -147,6 +148,15 @@ export async function handleNativeSlashCommand(
   const tab = await ensureTab(state, deps, tabId);
   const command = name.toLowerCase();
   switch (command) {
+    case "memory": {
+      deps.send({
+        type: "native_slash_result",
+        tabId,
+        command,
+        message: await formatMemorySummary(state, tabId),
+      });
+      return;
+    }
     case "context": {
       const usage = (
         tab.session as {

--- a/agent/system-prompt/prompt-template.ts
+++ b/agent/system-prompt/prompt-template.ts
@@ -62,6 +62,23 @@ A snapshot of the current state is included below this prompt for quick
 reference, but **trust \`$AETHON_STATE_FILE\` over the snapshot** — by the
 time you read this it may have changed.
 
+## Aethon memory
+
+Aethon has a separate local memory system under \`$AETHON_USER_DIR/memory\`
+(default \`~/.aethon/memory\`). It is distinct from Pi \`AGENTS.md\` and
+repository files. Each turn may include compact user memory and memory for the
+active tab's resolved project. Project memory resolves workspaces/git worktrees
+back to their parent project when possible.
+
+Use the memory tools in your tool catalog instead of editing memory files by
+hand: \`listMemoryScopes\`, \`readMemory\`, \`remember\`, and
+\`forgetMemory\`. When the user explicitly says phrases like "remember ...",
+"Always ...", "Never ...", or "from now on ...", call \`remember\` with the
+appropriate scope: \`user\` for global personal preferences and \`project\` for
+codebase-specific facts, workflows, and pitfalls. Do not store secrets,
+credentials, sensitive personal data, or temporary one-off context. If scope or
+durability is ambiguous, ask before saving.
+
 ## What you can mutate at runtime
 
 The host exposes a runtime API at \`globalThis.aethon\`. When the user asks

--- a/agent/tab-lifecycle/lifecycle.ts
+++ b/agent/tab-lifecycle/lifecycle.ts
@@ -21,6 +21,7 @@ import { buildA2uiTools } from "../a2ui-tools";
 import { createAethonBashToolDefinition } from "../bash-tool";
 import { buildDashboardTools } from "../dashboard-tools";
 import { buildSubagentTaskTool } from "../subagents/task-tool";
+import { buildMemoryTools } from "../memory/tools";
 import {
   buildDevshellSpawnHook,
   ensurePrepared as ensureDevshellPrepared,
@@ -170,6 +171,7 @@ export async function ensureTab(
       ...buildA2uiTools(),
       ...buildShellTools(),
       ...buildDashboardTools(),
+      ...buildMemoryTools(state, tabId),
       buildSubagentTaskTool(state, deps, tabId),
     ],
     ...(options.initialModel ? { model: options.initialModel } : {}),

--- a/src/slashCommands.ts
+++ b/src/slashCommands.ts
@@ -297,6 +297,11 @@ export function buildBuiltinSlashCommands(): SlashCommand[] {
       },
     },
     {
+      name: "memory",
+      description: "Show Aethon's user and resolved-project memory",
+      run: (args, ctx) => ctx.runNativeCommand("memory", args),
+    },
+    {
       name: "context",
       description: "Show current pi context window usage",
       run: (args, ctx) => ctx.runNativeCommand("context", args),


### PR DESCRIPTION
## Summary
- add local Aethon memory under ~/.aethon for user and resolved project scopes
- resolve project memory across Aethon workspaces/worktrees, git worktrees, git top-levels, and cwd fallback
- inject capped memory context per turn and add memory CRUD tools plus /memory inspection
- document model behavior for explicit remember/always/never requests while avoiding secrets

Closes #270.

## Verification
- Codex peer review: no discrete correctness issues found
- bun run lint
- bun run typecheck
- env -u AETHON_WORKER_TAB_ID bunx vitest run agent/memory/*.test.ts agent/aethon-api.test.ts src/slashCommands.test.ts
- env -u AETHON_WORKER_TAB_ID bunx vitest run