### PR TITLE
fix(terminal): sync xterm metrics with app zoom

### DIFF
--- a/src/extensions/default-layout/shell/canvas.tsx
+++ b/src/extensions/default-layout/shell/canvas.tsx
@@ -27,9 +27,15 @@ import type {
   BuiltinComponentProps,
 } from "../../../components/A2UIRenderer";
 import {
+  applyTerminalHostUiScale,
+  applyTerminalUiScale,
   observeTerminalTheme,
+  observeTerminalUiScale,
+  readAppUiScale,
   readTerminalTheme,
   terminalFitDelay,
+  terminalFontSizeForUiScale,
+  TERMINAL_UI_SCALE_SETTLE_MS,
 } from "../terminal-helpers";
 import {
   decideShellResize,
@@ -73,19 +79,35 @@ export function ShellCanvas({ component, state, onEvent }: BuiltinComponentProps
   const termRef = useRef<XTerm | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
   const tabIdRef = useRef<string>(tabId);
+  const fontSizeRef = useRef(fontSize);
   // Live cols×rows for the status line. Updated in the same ResizeObserver
   // callback that resizes the PTY so the displayed value never drifts.
   const [dims, setDims] = useState<{ cols: number; rows: number } | null>(null);
   useEffect(() => {
     tabIdRef.current = tabId;
   }, [tabId]);
+  useEffect(() => {
+    fontSizeRef.current = fontSize;
+    const term = termRef.current;
+    const fit = fitRef.current;
+    const host = containerRef.current;
+    if (!term || !fit || !host) return;
+    applyTerminalUiScale(host, term, fontSize);
+    try {
+      fit.fit();
+    } catch {
+      /* ignore transient xterm resize errors */
+    }
+  }, [fontSize]);
 
   useEffect(() => {
     if (!containerRef.current) return;
     if (!tabId) return; // no tab bound yet — wait for the layout to populate
 
+    const uiScale = readAppUiScale();
+    applyTerminalHostUiScale(containerRef.current, uiScale);
     const term = new XTerm({
-      fontSize,
+      fontSize: terminalFontSizeForUiScale(fontSize, uiScale),
       fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
       cursorBlink: true,
       allowProposedApi: true,
@@ -107,7 +129,6 @@ export function ShellCanvas({ component, state, onEvent }: BuiltinComponentProps
     } catch (err) {
       console.warn("WebGL renderer unavailable, using canvas fallback:", err);
     }
-    fit.fit();
     if (bootGreeting) term.write(bootGreeting);
 
     // Keystrokes → shell_input. Send the raw bytes the shell wants to
@@ -128,6 +149,7 @@ export function ShellCanvas({ component, state, onEvent }: BuiltinComponentProps
     // guards that keep panel-toggle from raising spurious SIGWINCHes.
     const lastSentDimsRef = { current: null as ShellDims | null };
     let resizeTimer: ReturnType<typeof setTimeout> | null = null;
+    let scaleSettleTimer: ReturnType<typeof setTimeout> | null = null;
     let ptyResizeTimer: ReturnType<typeof setTimeout> | null = null;
     let pendingPtyResize: ShellDims | null = null;
     const sendPtyResize = (dims: ShellDims) => {
@@ -187,6 +209,22 @@ export function ShellCanvas({ component, state, onEvent }: BuiltinComponentProps
         /* fit transient errors during teardown */
       }
     };
+    const syncUiScaleAndResize = (scale = readAppUiScale()) => {
+      if (!containerRef.current) return;
+      applyTerminalUiScale(
+        containerRef.current,
+        term,
+        fontSizeRef.current,
+        scale,
+      );
+      resizeToContainer();
+      if (scaleSettleTimer) clearTimeout(scaleSettleTimer);
+      scaleSettleTimer = window.setTimeout(() => {
+        scaleSettleTimer = null;
+        resizeToContainer();
+      }, TERMINAL_UI_SCALE_SETTLE_MS);
+    };
+    syncUiScaleAndResize(uiScale);
     const ro = new ResizeObserver((entries) => {
       if (shouldSkipResize(entries[0], containerRef.current)) return;
       if (resizeTimer) clearTimeout(resizeTimer);
@@ -199,6 +237,7 @@ export function ShellCanvas({ component, state, onEvent }: BuiltinComponentProps
     });
     ro.observe(containerRef.current);
     const stopThemeObserver = observeTerminalTheme(term);
+    const stopScaleObserver = observeTerminalUiScale(syncUiScaleAndResize);
 
     // PTY chunks land via per-tab CustomEvent (`aethon:shell-output:<tabId>`).
     // App.tsx dispatches them; we route to xterm.write here.
@@ -222,8 +261,10 @@ export function ShellCanvas({ component, state, onEvent }: BuiltinComponentProps
       window.removeEventListener(eventName, onShellOutput);
       ro.disconnect();
       if (resizeTimer) clearTimeout(resizeTimer);
+      if (scaleSettleTimer) clearTimeout(scaleSettleTimer);
       if (ptyResizeTimer) clearTimeout(ptyResizeTimer);
       stopThemeObserver();
+      stopScaleObserver();
       onDataDisposable.dispose();
       term.dispose();
       termRef.current = null;

--- a/src/extensions/default-layout/shell/canvas.zoom.test.tsx
+++ b/src/extensions/default-layout/shell/canvas.zoom.test.tsx
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+
+import { render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { invoke } from "@tauri-apps/api/core";
+import { ShellCanvas } from "./canvas";
+import { applyUiScale } from "../../../utils/viewport";
+
+interface MockTerminal {
+  options: { fontSize?: number };
+  cols: number;
+  rows: number;
+  open: ReturnType<typeof vi.fn>;
+  loadAddon: ReturnType<typeof vi.fn>;
+  write: ReturnType<typeof vi.fn>;
+  onData: ReturnType<typeof vi.fn>;
+  refresh: ReturnType<typeof vi.fn>;
+  dispose: ReturnType<typeof vi.fn>;
+}
+
+interface MockFitAddon {
+  term?: MockTerminal;
+  fit: ReturnType<typeof vi.fn>;
+  __attach: (term: MockTerminal) => void;
+}
+
+const xtermMocks = vi.hoisted(() => ({
+  terminals: [] as MockTerminal[],
+  fits: [] as MockFitAddon[],
+}));
+
+vi.mock("@xterm/xterm", () => ({
+  Terminal: vi.fn(function (options: { fontSize?: number }) {
+    const term: MockTerminal = {
+      options: { ...options },
+      cols: 80,
+      rows: 24,
+      open: vi.fn(),
+      loadAddon: vi.fn((addon: { __attach?: (term: MockTerminal) => void }) => {
+        addon.__attach?.(term);
+      }),
+      write: vi.fn(),
+      onData: vi.fn(() => ({ dispose: vi.fn() })),
+      refresh: vi.fn(),
+      dispose: vi.fn(),
+    };
+    xtermMocks.terminals.push(term);
+    return term;
+  }),
+}));
+
+vi.mock("@xterm/addon-fit", () => ({
+  FitAddon: vi.fn(function () {
+    const fit: MockFitAddon = {
+      fit: vi.fn(() => {
+        const fontSize = fit.term?.options.fontSize ?? 13;
+        if (fit.term) {
+          fit.term.cols = Math.floor(960 / fontSize);
+          fit.term.rows = Math.floor(260 / fontSize);
+        }
+      }),
+      __attach: (term: MockTerminal) => {
+        fit.term = term;
+      },
+    };
+    xtermMocks.fits.push(fit);
+    return fit;
+  }),
+}));
+
+vi.mock("@xterm/addon-webgl", () => ({
+  WebglAddon: vi.fn(function () {
+    return {
+      onContextLoss: vi.fn(),
+      dispose: vi.fn(),
+    };
+  }),
+}));
+
+vi.mock("../../../components/A2UIRenderer", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...(actual as object),
+    RegistryComponent: () => <span data-testid="share-mode-badge" />,
+  };
+});
+
+class MockResizeObserver {
+  observe = vi.fn();
+  disconnect = vi.fn();
+}
+
+beforeEach(() => {
+  xtermMocks.terminals.length = 0;
+  xtermMocks.fits.length = 0;
+  vi.mocked(invoke).mockClear();
+  document.documentElement.style.removeProperty("--app-ui-scale");
+  document.documentElement.style.zoom = "";
+  vi.stubGlobal("ResizeObserver", MockResizeObserver);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("ShellCanvas zoom synchronization", () => {
+  it("refits xterm and resizes the PTY when app zoom changes", async () => {
+    const state = {
+      tabs: [
+        {
+          id: "shell-1",
+          kind: "shell",
+          shell: { cwd: "/repo", command: "zsh", shareMode: "private" },
+        },
+      ],
+    };
+
+    const { container } = render(
+      <ShellCanvas
+        component={{
+          id: "shell-canvas",
+          type: "shell-canvas",
+          props: { tabId: "shell-1", fontSize: 13 },
+        }}
+        state={state}
+        onEvent={vi.fn()}
+      />,
+    );
+
+    const term = xtermMocks.terminals[0];
+    const fit = xtermMocks.fits[0];
+    const mount = container.querySelector<HTMLElement>(".ae-shell-canvas-term");
+
+    applyUiScale(1.5);
+
+    await waitFor(() => expect(term.options.fontSize).toBeCloseTo(19.5));
+    expect(Number(mount?.style.zoom)).toBeCloseTo(1 / 1.5);
+    expect(fit.fit.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(term.refresh).toHaveBeenCalledWith(0, expect.any(Number));
+    await waitFor(() =>
+      expect(invoke).toHaveBeenCalledWith("shell_resize", {
+        tabId: "shell-1",
+        cols: Math.floor(960 / 19.5),
+        rows: Math.floor(260 / 19.5),
+      }),
+    );
+  });
+});

--- a/src/extensions/default-layout/terminal-helpers.ts
+++ b/src/extensions/default-layout/terminal-helpers.ts
@@ -112,17 +112,17 @@ export function applyTerminalUiScale(
 export function observeTerminalUiScale(onScale: (scale: number) => void): () => void {
   if (typeof window === "undefined") return () => {};
   let lastScale = readAppUiScale();
-  const notifyIfChanged = () => {
-    const nextScale = readAppUiScale();
+  const emitIfChanged = (nextScale: number) => {
+    if (!Number.isFinite(nextScale) || nextScale <= 0) return;
     if (Math.abs(nextScale - lastScale) < 0.0001) return;
     lastScale = nextScale;
     onScale(nextScale);
   };
+  const notifyIfChanged = () => emitIfChanged(readAppUiScale());
   const onEvent = (event: Event) => {
     const detailScale = (event as CustomEvent<{ scale?: number }>).detail?.scale;
-    if (typeof detailScale === "number" && Number.isFinite(detailScale)) {
-      lastScale = detailScale;
-      onScale(detailScale);
+    if (typeof detailScale === "number") {
+      emitIfChanged(detailScale);
       return;
     }
     notifyIfChanged();

--- a/src/extensions/default-layout/terminal-helpers.ts
+++ b/src/extensions/default-layout/terminal-helpers.ts
@@ -48,11 +48,95 @@ const ANSI_FALLBACK: XTermThemeShape = {
 
 export const TERMINAL_FIT_DEBOUNCE_MS = 80;
 export const TERMINAL_FIT_DRAG_THROTTLE_MS = 48;
+export const TERMINAL_UI_SCALE_SETTLE_MS = 32;
+
+const UI_SCALE_EVENT = "aethon:ui-scale-change";
 
 export function terminalFitDelay(isUserResizing: boolean): number {
   return isUserResizing
     ? TERMINAL_FIT_DRAG_THROTTLE_MS
     : TERMINAL_FIT_DEBOUNCE_MS;
+}
+
+export function readAppUiScale(): number {
+  if (typeof window === "undefined") return 1;
+  const root = document.documentElement;
+  const raw =
+    root.style.getPropertyValue("--app-ui-scale") ||
+    getComputedStyle(root).getPropertyValue("--app-ui-scale") ||
+    root.style.zoom ||
+    "1";
+  const scale = Number.parseFloat(raw);
+  return Number.isFinite(scale) && scale > 0 ? scale : 1;
+}
+
+export function terminalFontSizeForUiScale(
+  baseFontSize: number,
+  scale = readAppUiScale(),
+): number {
+  return baseFontSize * scale;
+}
+
+// The app still uses root-level CSS zoom for chrome. Counter-zoom xterm's
+// host and scale xterm's own font metrics instead so mouse coordinates,
+// cached cell dimensions, and the rendered glyph grid stay in one coordinate
+// system after Cmd+/-. Keep the host at the panel size; app viewport
+// compensation already keeps the visible layout bounds correct.
+export function applyTerminalHostUiScale(
+  host: HTMLElement,
+  scale = readAppUiScale(),
+): void {
+  host.style.transformOrigin = "top left";
+  host.style.zoom = String(1 / scale);
+  host.style.width = "100%";
+  host.style.height = "100%";
+}
+
+export function applyTerminalUiScale(
+  host: HTMLElement,
+  term: XTerm,
+  baseFontSize: number,
+  scale = readAppUiScale(),
+): number {
+  applyTerminalHostUiScale(host, scale);
+  const scaledFontSize = terminalFontSizeForUiScale(baseFontSize, scale);
+  term.options.fontSize = scaledFontSize;
+  try {
+    term.refresh(0, Math.max(0, term.rows - 1));
+  } catch {
+    /* terminal may be mid-open/dispose; refit path will retry */
+  }
+  return scaledFontSize;
+}
+
+export function observeTerminalUiScale(onScale: (scale: number) => void): () => void {
+  if (typeof window === "undefined") return () => {};
+  let lastScale = readAppUiScale();
+  const notifyIfChanged = () => {
+    const nextScale = readAppUiScale();
+    if (Math.abs(nextScale - lastScale) < 0.0001) return;
+    lastScale = nextScale;
+    onScale(nextScale);
+  };
+  const onEvent = (event: Event) => {
+    const detailScale = (event as CustomEvent<{ scale?: number }>).detail?.scale;
+    if (typeof detailScale === "number" && Number.isFinite(detailScale)) {
+      lastScale = detailScale;
+      onScale(detailScale);
+      return;
+    }
+    notifyIfChanged();
+  };
+  window.addEventListener(UI_SCALE_EVENT, onEvent);
+  const obs = new MutationObserver(notifyIfChanged);
+  obs.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ["style"],
+  });
+  return () => {
+    window.removeEventListener(UI_SCALE_EVENT, onEvent);
+    obs.disconnect();
+  };
 }
 
 export function readTerminalTheme(): XTermThemeShape {

--- a/src/extensions/default-layout/terminal-helpers.zoom.test.ts
+++ b/src/extensions/default-layout/terminal-helpers.zoom.test.ts
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { observeTerminalUiScale } from "./terminal-helpers";
+
+afterEach(() => {
+  document.documentElement.style.removeProperty("--app-ui-scale");
+  document.documentElement.style.zoom = "";
+});
+
+describe("observeTerminalUiScale", () => {
+  it("ignores unchanged and invalid explicit scale events", () => {
+    document.documentElement.style.setProperty("--app-ui-scale", "1.2");
+    const onScale = vi.fn();
+    const stop = observeTerminalUiScale(onScale);
+
+    window.dispatchEvent(
+      new CustomEvent("aethon:ui-scale-change", { detail: { scale: 1.2 } }),
+    );
+    window.dispatchEvent(
+      new CustomEvent("aethon:ui-scale-change", { detail: { scale: 0 } }),
+    );
+    window.dispatchEvent(
+      new CustomEvent("aethon:ui-scale-change", { detail: { scale: -1 } }),
+    );
+
+    expect(onScale).not.toHaveBeenCalled();
+    stop();
+  });
+
+  it("emits changed positive explicit scale events", () => {
+    document.documentElement.style.setProperty("--app-ui-scale", "1");
+    const onScale = vi.fn();
+    const stop = observeTerminalUiScale(onScale);
+
+    window.dispatchEvent(
+      new CustomEvent("aethon:ui-scale-change", { detail: { scale: 1.5 } }),
+    );
+
+    expect(onScale).toHaveBeenCalledWith(1.5);
+    stop();
+  });
+});

--- a/src/extensions/default-layout/terminal.tsx
+++ b/src/extensions/default-layout/terminal.tsx
@@ -21,7 +21,17 @@ import {
   resolveString,
 } from "../../utils/dataBinding";
 import type { BuiltinComponentProps } from "../../components/A2UIRenderer";
-import { observeTerminalTheme, readTerminalTheme, terminalFitDelay } from "./terminal-helpers";
+import {
+  applyTerminalHostUiScale,
+  applyTerminalUiScale,
+  observeTerminalTheme,
+  observeTerminalUiScale,
+  readAppUiScale,
+  readTerminalTheme,
+  terminalFitDelay,
+  terminalFontSizeForUiScale,
+  TERMINAL_UI_SCALE_SETTLE_MS,
+} from "./terminal-helpers";
 
 // ---------------------------------------------------------------------------
 // Terminal — xterm.js with WebGL renderer. Falls back to canvas if WebGL
@@ -93,18 +103,35 @@ export function Terminal({ component, state, onEvent }: BuiltinComponentProps) {
   const termRef = useRef<XTerm | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
   const lastOutputRef = useRef<string>("");
+  const fontSizeRef = useRef(fontSize);
+
+  useEffect(() => {
+    fontSizeRef.current = fontSize;
+    const term = termRef.current;
+    const fit = fitRef.current;
+    const host = containerRef.current;
+    if (!term || !fit || !host) return;
+    applyTerminalUiScale(host, term, fontSize);
+    try {
+      fit.fit();
+    } catch {
+      /* ignore transient xterm resize errors */
+    }
+  }, [fontSize]);
 
   useEffect(() => {
     if (!containerRef.current) return;
     if (termRef.current) return;
 
     const baseTheme = readTerminalTheme();
+    const uiScale = readAppUiScale();
+    applyTerminalHostUiScale(containerRef.current, uiScale);
     // xterm.js validates `cols`/`rows` as soon as they appear in the
     // options object — passing `cols: undefined` triggers
     // "cols must be numeric, value: undefined". Build the option bag
     // dynamically so only defined dimensions reach the constructor.
     const term = new XTerm({
-      fontSize,
+      fontSize: terminalFontSizeForUiScale(fontSize, uiScale),
       ...(typeof cols === "number" ? { cols } : {}),
       ...(typeof rows === "number" ? { rows } : {}),
       fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
@@ -139,7 +166,33 @@ export function Terminal({ component, state, onEvent }: BuiltinComponentProps) {
       console.warn("WebGL renderer unavailable, using canvas fallback:", err);
     }
 
-    fit.fit();
+    let resizeTimer: ReturnType<typeof setTimeout> | null = null;
+    let scaleSettleTimer: ReturnType<typeof setTimeout> | null = null;
+    const fitToContainer = () => {
+      resizeTimer = null;
+      try {
+        fit.fit();
+      } catch {
+        /* noop */
+      }
+    };
+    const syncUiScale = (scale = readAppUiScale()) => {
+      if (!containerRef.current) return;
+      applyTerminalUiScale(
+        containerRef.current,
+        term,
+        fontSizeRef.current,
+        scale,
+      );
+      fitToContainer();
+      if (scaleSettleTimer) clearTimeout(scaleSettleTimer);
+      scaleSettleTimer = window.setTimeout(() => {
+        scaleSettleTimer = null;
+        fitToContainer();
+      }, TERMINAL_UI_SCALE_SETTLE_MS);
+    };
+
+    syncUiScale(uiScale);
     term.write(bootGreetingRef.current);
 
     // onInput wires xterm's keystroke stream to an A2UI event so a future
@@ -182,15 +235,6 @@ export function Terminal({ component, state, onEvent }: BuiltinComponentProps) {
       window.addEventListener("aethon:terminal-replay", onReplayEvent);
     }
 
-    let resizeTimer: ReturnType<typeof setTimeout> | null = null;
-    const fitToContainer = () => {
-      resizeTimer = null;
-      try {
-        fit.fit();
-      } catch {
-        /* noop */
-      }
-    };
     const ro = new ResizeObserver(() => {
       if (resizeTimer) clearTimeout(resizeTimer);
       resizeTimer = setTimeout(
@@ -202,11 +246,14 @@ export function Terminal({ component, state, onEvent }: BuiltinComponentProps) {
     });
     ro.observe(containerRef.current);
     const stopThemeObserver = observeTerminalTheme(term);
+    const stopScaleObserver = observeTerminalUiScale(syncUiScale);
 
     return () => {
       ro.disconnect();
       if (resizeTimer) clearTimeout(resizeTimer);
+      if (scaleSettleTimer) clearTimeout(scaleSettleTimer);
       stopThemeObserver();
+      stopScaleObserver();
       if (onTerminalEvent) {
         window.removeEventListener("aethon:terminal", onTerminalEvent);
       }

--- a/src/extensions/default-layout/terminal.zoom.test.tsx
+++ b/src/extensions/default-layout/terminal.zoom.test.tsx
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+
+import { render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Terminal } from "./terminal";
+import { applyUiScale } from "../../utils/viewport";
+
+interface MockTerminal {
+  options: { fontSize?: number };
+  cols: number;
+  rows: number;
+  open: ReturnType<typeof vi.fn>;
+  loadAddon: ReturnType<typeof vi.fn>;
+  write: ReturnType<typeof vi.fn>;
+  onData: ReturnType<typeof vi.fn>;
+  reset: ReturnType<typeof vi.fn>;
+  refresh: ReturnType<typeof vi.fn>;
+  dispose: ReturnType<typeof vi.fn>;
+}
+
+interface MockFitAddon {
+  term?: MockTerminal;
+  fit: ReturnType<typeof vi.fn>;
+  __attach: (term: MockTerminal) => void;
+}
+
+const xtermMocks = vi.hoisted(() => ({
+  terminals: [] as MockTerminal[],
+  fits: [] as MockFitAddon[],
+}));
+
+vi.mock("@xterm/xterm", () => ({
+  Terminal: vi.fn(function (options: { fontSize?: number }) {
+    const term: MockTerminal = {
+      options: { ...options },
+      cols: 80,
+      rows: 24,
+      open: vi.fn(),
+      loadAddon: vi.fn((addon: { __attach?: (term: MockTerminal) => void }) => {
+        addon.__attach?.(term);
+      }),
+      write: vi.fn(),
+      onData: vi.fn(() => ({ dispose: vi.fn() })),
+      reset: vi.fn(),
+      refresh: vi.fn(),
+      dispose: vi.fn(),
+    };
+    xtermMocks.terminals.push(term);
+    return term;
+  }),
+}));
+
+vi.mock("@xterm/addon-fit", () => ({
+  FitAddon: vi.fn(function () {
+    const fit: MockFitAddon = {
+      fit: vi.fn(() => {
+        const fontSize = fit.term?.options.fontSize ?? 13;
+        if (fit.term) {
+          fit.term.cols = Math.floor(960 / fontSize);
+          fit.term.rows = Math.floor(260 / fontSize);
+        }
+      }),
+      __attach: (term: MockTerminal) => {
+        fit.term = term;
+      },
+    };
+    xtermMocks.fits.push(fit);
+    return fit;
+  }),
+}));
+
+vi.mock("@xterm/addon-webgl", () => ({
+  WebglAddon: vi.fn(function () {
+    return {
+      onContextLoss: vi.fn(),
+      dispose: vi.fn(),
+    };
+  }),
+}));
+
+class MockResizeObserver {
+  observe = vi.fn();
+  disconnect = vi.fn();
+}
+
+beforeEach(() => {
+  xtermMocks.terminals.length = 0;
+  xtermMocks.fits.length = 0;
+  document.documentElement.style.removeProperty("--app-ui-scale");
+  document.documentElement.style.zoom = "";
+  vi.stubGlobal("ResizeObserver", MockResizeObserver);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("Terminal zoom synchronization", () => {
+  it("counter-scales the xterm host and recomputes font metrics when app zoom changes", async () => {
+    const { container } = render(
+      <Terminal
+        component={{ id: "terminal", type: "terminal", props: { fontSize: 13 } }}
+        state={{}}
+        onEvent={vi.fn()}
+      />,
+    );
+
+    const term = xtermMocks.terminals[0];
+    const fit = xtermMocks.fits[0];
+    const mount = container.querySelector<HTMLElement>(".a2ui-terminal-mount");
+    expect(term.options.fontSize).toBe(13);
+    expect(mount?.style.zoom).toBe("1");
+
+    applyUiScale(1.5);
+
+    await waitFor(() => expect(term.options.fontSize).toBeCloseTo(19.5));
+    expect(Number(mount?.style.zoom)).toBeCloseTo(1 / 1.5);
+    expect(mount?.style.width).toBe("100%");
+    expect(mount?.style.height).toBe("100%");
+    expect(fit.fit.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(term.refresh).toHaveBeenCalledWith(0, expect.any(Number));
+  });
+});

--- a/src/utils/viewport.test.ts
+++ b/src/utils/viewport.test.ts
@@ -1,0 +1,26 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { applyUiScale } from "./viewport";
+
+afterEach(() => {
+  document.documentElement.style.removeProperty("--app-ui-scale");
+  document.documentElement.style.zoom = "";
+});
+
+describe("applyUiScale", () => {
+  it("dispatches ui-scale changes only when the scale changes", () => {
+    const listener = vi.fn();
+    window.addEventListener("aethon:ui-scale-change", listener);
+
+    applyUiScale(1.2);
+    applyUiScale(1.2);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener.mock.calls[0][0]).toMatchObject({
+      detail: { scale: 1.2 },
+    });
+
+    window.removeEventListener("aethon:ui-scale-change", listener);
+  });
+});

--- a/src/utils/viewport.ts
+++ b/src/utils/viewport.ts
@@ -11,13 +11,16 @@ export function writeUiViewportVars(scale: number) {
 }
 
 export function applyUiScale(scale: number) {
+  const previous = readZoom();
   const root = document.documentElement;
   root.style.setProperty("--app-ui-scale", String(scale));
   writeUiViewportVars(scale);
   root.style.zoom = String(scale);
-  window.dispatchEvent(
-    new CustomEvent("aethon:ui-scale-change", { detail: { scale } }),
-  );
+  if (Math.abs(scale - previous) >= 0.0001) {
+    window.dispatchEvent(
+      new CustomEvent("aethon:ui-scale-change", { detail: { scale } }),
+    );
+  }
 }
 
 export function readZoom(): number {

--- a/src/utils/viewport.ts
+++ b/src/utils/viewport.ts
@@ -15,6 +15,9 @@ export function applyUiScale(scale: number) {
   root.style.setProperty("--app-ui-scale", String(scale));
   writeUiViewportVars(scale);
   root.style.zoom = String(scale);
+  window.dispatchEvent(
+    new CustomEvent("aethon:ui-scale-change", { detail: { scale } }),
+  );
 }
 
 export function readZoom(): number {


### PR DESCRIPTION
## Summary

- counter-scale xterm host surfaces when app CSS zoom changes while scaling xterm's own font size
- refit and refresh agent-bash and shell terminals after zoom changes
- resize interactive shell PTYs after zoom-driven xterm dimensions settle
- add regression coverage for agent-bash and shell terminal zoom synchronization

Closes #275.

## Validation

- `bunx vitest run src/extensions/default-layout/terminal.zoom.test.tsx src/extensions/default-layout/shell/canvas.zoom.test.tsx src/extensions/default-layout/shell/canvas.test.ts`
- `bunx tsc -b --noEmit`
- `bunx eslint .`
- Codex peer review: no discrete correctness issues found after addressing the initial double-scaling comment

Note: `bunx vitest run` still has one unrelated existing failure in `agent/dispatcher.test.ts` (`refreshes persisted session discovery before report ready payloads`).
