### PR TITLE
fix(git): avoid optional locks during background status

### DIFF
--- a/src-tauri/src/commands/git/checks.rs
+++ b/src-tauri/src/commands/git/checks.rs
@@ -12,8 +12,8 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
+use super::common::read_only_tokio_gh_command;
 use crate::commands::git::github::{url_encode_path_segment, worktree_is_dangling};
-use crate::env;
 
 /// One CI check-run, narrowed to what the UI shows.
 #[derive(serde::Serialize, Debug, Clone, PartialEq)]
@@ -73,7 +73,7 @@ async fn gh_checks_inner(project_path: &str, branch: &str) -> GhChecks {
         return checks;
     }
 
-    let auth = env::tokio_command("gh")
+    let auth = read_only_tokio_gh_command()
         .args(["auth", "status"])
         .output()
         .await;
@@ -84,7 +84,7 @@ async fn gh_checks_inner(project_path: &str, branch: &str) -> GhChecks {
     checks.gh_available = true;
 
     // Resolve <owner>/<repo>; empty / non-zero means no GitHub remote.
-    let repo_out = env::tokio_command("gh")
+    let repo_out = read_only_tokio_gh_command()
         .args([
             "repo",
             "view",
@@ -110,7 +110,7 @@ async fn gh_checks_inner(project_path: &str, branch: &str) -> GhChecks {
     // body doesn't merge cleanly under `gh api --paginate`). Branch names
     // with slashes must be percent-encoded.
     let branch_encoded = url_encode_path_segment(branch);
-    let runs_fut = env::tokio_command("gh")
+    let runs_fut = read_only_tokio_gh_command()
         .args([
             "api",
             "-X",

--- a/src-tauri/src/commands/git/common.rs
+++ b/src-tauri/src/commands/git/common.rs
@@ -1,0 +1,130 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{Duration, SystemTime};
+
+use crate::env;
+
+pub(crate) const GIT_OPTIONAL_LOCKS_ENV: &str = "GIT_OPTIONAL_LOCKS";
+pub(crate) const GIT_OPTIONAL_LOCKS_DISABLED: &str = "0";
+pub(crate) const GIT_INDEX_LOCKED_MESSAGE: &str = "git index locked; skipping read-only refresh";
+const INDEX_LOCK_TRANSIENT_WINDOW: Duration = Duration::from_secs(300);
+
+/// Build a read-only `git` command that cannot take Git's optional index lock.
+///
+/// Background UI refreshes must observe repository state without refreshing the
+/// index stat cache; otherwise they can race user-owned operations and create or
+/// contend on `.git/index.lock`.
+pub(crate) fn read_only_git_command() -> Command {
+    let mut command = env::command("git");
+    disable_optional_locks(&mut command);
+    command
+}
+
+/// Build a read-only `gh` command. The GitHub CLI may inspect local repository
+/// metadata under the hood, so pass the same optional-lock guard through its
+/// environment for dashboard/status queries.
+pub(crate) fn read_only_gh_command() -> Command {
+    let mut command = env::command("gh");
+    disable_optional_locks(&mut command);
+    command
+}
+
+/// Tokio variant of [`read_only_gh_command`].
+pub(crate) fn read_only_tokio_gh_command() -> tokio::process::Command {
+    let mut command = env::tokio_command("gh");
+    command.env(GIT_OPTIONAL_LOCKS_ENV, GIT_OPTIONAL_LOCKS_DISABLED);
+    command
+}
+
+pub(crate) fn fail_if_index_locked(dir: &Path) -> Result<(), String> {
+    if git_index_lock_exists(dir) {
+        Err(GIT_INDEX_LOCKED_MESSAGE.to_string())
+    } else {
+        Ok(())
+    }
+}
+
+fn disable_optional_locks(command: &mut Command) {
+    command.env(GIT_OPTIONAL_LOCKS_ENV, GIT_OPTIONAL_LOCKS_DISABLED);
+}
+
+fn git_index_lock_exists(dir: &Path) -> bool {
+    read_only_git_dir(dir).is_some_and(|git_dir| {
+        let lock = git_dir.join("index.lock");
+        lock.exists() && index_lock_is_recent(&lock, SystemTime::now())
+    })
+}
+
+fn index_lock_is_recent(lock: &Path, now: SystemTime) -> bool {
+    let Ok(modified) = lock.metadata().and_then(|m| m.modified()) else {
+        return true;
+    };
+    now.duration_since(modified)
+        .map(|age| age <= INDEX_LOCK_TRANSIENT_WINDOW)
+        .unwrap_or(true)
+}
+
+fn read_only_git_dir(dir: &Path) -> Option<PathBuf> {
+    let out = read_only_git_command()
+        .arg("-C")
+        .arg(dir)
+        .args(["rev-parse", "--path-format=absolute", "--git-dir"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())?;
+    let raw = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if raw.is_empty() {
+        return None;
+    }
+    let path = PathBuf::from(raw);
+    Some(path.canonicalize().unwrap_or(path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsStr;
+
+    fn command_env(command: &Command, key: &str) -> Option<String> {
+        command
+            .get_envs()
+            .find(|(k, _)| *k == OsStr::new(key))
+            .and_then(|(_, v)| v.map(|v| v.to_string_lossy().to_string()))
+    }
+
+    #[test]
+    fn read_only_git_command_disables_optional_locks() {
+        let command = read_only_git_command();
+
+        assert_eq!(
+            command_env(&command, GIT_OPTIONAL_LOCKS_ENV).as_deref(),
+            Some(GIT_OPTIONAL_LOCKS_DISABLED)
+        );
+    }
+
+    #[test]
+    fn read_only_gh_command_propagates_optional_lock_guard_to_child_git() {
+        let command = read_only_gh_command();
+
+        assert_eq!(
+            command_env(&command, GIT_OPTIONAL_LOCKS_ENV).as_deref(),
+            Some(GIT_OPTIONAL_LOCKS_DISABLED)
+        );
+    }
+
+    #[test]
+    fn stale_index_lock_is_not_treated_as_active() {
+        let lock = tempfile::NamedTempFile::new().unwrap();
+        let later = SystemTime::now() + INDEX_LOCK_TRANSIENT_WINDOW + Duration::from_secs(1);
+
+        assert!(!index_lock_is_recent(lock.path(), later));
+    }
+
+    #[test]
+    fn recent_index_lock_is_treated_as_active() {
+        let lock = tempfile::NamedTempFile::new().unwrap();
+        let now = SystemTime::now();
+
+        assert!(index_lock_is_recent(lock.path(), now));
+    }
+}

--- a/src-tauri/src/commands/git/diff.rs
+++ b/src-tauri/src/commands/git/diff.rs
@@ -15,8 +15,7 @@
 
 use std::path::{Path, PathBuf};
 
-use crate::env;
-
+use super::common::{fail_if_index_locked, read_only_git_command};
 use super::status::resolve_repo_and_active_root;
 
 /// One contiguous change in a file relative to HEAD, in **new-file** line
@@ -64,6 +63,7 @@ pub async fn git_file_diff_hunks(
     let Some((_repo_root, active_root)) = resolve_repo_and_active_root(&dir)? else {
         return Ok(None);
     };
+    fail_if_index_locked(&active_root)?;
     let Some(rel) = rel_to_active(&active_root, &path) else {
         return Ok(Some(Vec::new()));
     };
@@ -72,7 +72,7 @@ pub async fn git_file_diff_hunks(
     // header alone tells us the kind + line range. `HEAD` compares the
     // working tree (staged + unstaged) against the last commit, matching
     // VS Code's default dirty-diff baseline.
-    let output = env::command("git")
+    let output = read_only_git_command()
         .arg("-C")
         .arg(&active_root)
         .args(["diff", "--no-color", "-U0", "HEAD", "--", &rel])
@@ -105,10 +105,11 @@ pub async fn git_diff_stat(root: String) -> Result<Option<DiffStat>, String> {
     let Some((_repo_root, active_root)) = resolve_repo_and_active_root(&dir)? else {
         return Ok(None);
     };
+    fail_if_index_locked(&active_root)?;
     // `--numstat` prints `adds<TAB>dels<TAB>path` per file (binary files
     // report `-`); summing the columns gives the working-tree-vs-HEAD
     // totals. `-- .` scopes to the active root for subdirectory-opened repos.
-    let output = env::command("git")
+    let output = read_only_git_command()
         .arg("-C")
         .arg(&active_root)
         .args(["diff", "--no-color", "--numstat", "HEAD", "--", "."])
@@ -158,7 +159,7 @@ pub async fn git_show_head(root: String, path: String) -> Result<Option<String>,
     // `HEAD:./<rel>` resolves the blob relative to the cwd (`-C` target),
     // so we don't have to translate into repo-root coordinates.
     let spec = format!("HEAD:./{rel}");
-    let output = env::command("git")
+    let output = read_only_git_command()
         .arg("-C")
         .arg(&active_root)
         .args(["show", &spec])

--- a/src-tauri/src/commands/git/github.rs
+++ b/src-tauri/src/commands/git/github.rs
@@ -1,6 +1,6 @@
 use std::path::{Component, Path, PathBuf};
 
-use crate::env;
+use super::common::{read_only_gh_command, read_only_tokio_gh_command};
 
 /// GitHub branch status as understood by `gh` CLI. Returned shape is
 /// intentionally narrow so the worktree-landing UI can render without
@@ -126,7 +126,7 @@ pub(crate) fn gh_branch_status_inner(project_path: &str, branch: &str) -> GhBran
         return status;
     }
     // 1. gh available + authed?
-    let auth = env::command("gh").args(["auth", "status"]).output();
+    let auth = read_only_gh_command().args(["auth", "status"]).output();
     let Ok(out) = auth else { return status };
     if !out.status.success() {
         return status;
@@ -139,7 +139,7 @@ pub(crate) fn gh_branch_status_inner(project_path: &str, branch: &str) -> GhBran
     //    convention), so we rely on `current_dir(&dir)` and a bare
     //    invocation. Output empty / non-zero on non-GitHub remotes,
     //    which doubles as our "is this on GitHub?" check.
-    let repo_out = env::command("gh")
+    let repo_out = read_only_gh_command()
         .args([
             "repo",
             "view",
@@ -166,7 +166,7 @@ pub(crate) fn gh_branch_status_inner(project_path: &str, branch: &str) -> GhBran
     //    as a separate path element and returns 404 even when the
     //    branch exists.
     let branch_encoded = url_encode_path_segment(branch);
-    let pushed_out = env::command("gh")
+    let pushed_out = read_only_gh_command()
         .args([
             "api",
             "-X",
@@ -184,7 +184,7 @@ pub(crate) fn gh_branch_status_inner(project_path: &str, branch: &str) -> GhBran
     //    open + closed (incl. merged). Limit 5 keeps the call cheap and
     //    the UI tidy. `--json` makes parsing robust against future CLI
     //    output tweaks.
-    let pr_out = env::command("gh")
+    let pr_out = read_only_gh_command()
         .args([
             "pr",
             "list",
@@ -344,7 +344,7 @@ async fn gh_repo_overview_inner(project_path: &str) -> GhRepoOverview {
     }
 
     // gh available + authed?
-    let auth = env::tokio_command("gh")
+    let auth = read_only_tokio_gh_command()
         .args(["auth", "status"])
         .output()
         .await;
@@ -356,7 +356,7 @@ async fn gh_repo_overview_inner(project_path: &str) -> GhRepoOverview {
 
     let dir_a = dir.clone();
     let repo_view_fut = async move {
-        env::tokio_command("gh")
+        read_only_tokio_gh_command()
             .args([
                 "repo",
                 "view",
@@ -370,7 +370,7 @@ async fn gh_repo_overview_inner(project_path: &str) -> GhRepoOverview {
 
     let dir_b = dir.clone();
     let pr_count_fut = async move {
-        env::tokio_command("gh")
+        read_only_tokio_gh_command()
             .args([
                 "pr", "list", "--state", "open", "--json", "number", "-q", "length",
             ])
@@ -388,7 +388,7 @@ async fn gh_repo_overview_inner(project_path: &str) -> GhRepoOverview {
     // which counts issues + PRs together and inflates the dashboard
     // figure when the repo has open PRs.
     let issue_count_fut = async move {
-        let count_out = env::tokio_command("gh")
+        let count_out = read_only_tokio_gh_command()
             .args([
                 "issue", "list", "--state", "open", "--limit", "1000", "--json", "number", "-q",
                 "length",
@@ -450,7 +450,7 @@ pub async fn gh_repo_avatar_url(project_path: String) -> Option<String> {
     if !dir.is_dir() {
         return None;
     }
-    let out = env::tokio_command("gh")
+    let out = read_only_tokio_gh_command()
         .args([
             "repo",
             "view",

--- a/src-tauri/src/commands/git/issues.rs
+++ b/src-tauri/src/commands/git/issues.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use crate::env;
+use super::common::read_only_tokio_gh_command;
 
 /// Compact view of a single GitHub issue, surfaced on the dashboard.
 /// camelCase serde so the TS side reads it as-is.
@@ -109,7 +109,7 @@ pub async fn gh_issue_list(project_path: String, limit: Option<u32>) -> Vec<GhIs
     let limit = limit.unwrap_or(30).clamp(1, 100);
     let limit_str = limit.to_string();
     tokio::time::timeout(Duration::from_secs(5), async {
-        let out = env::tokio_command("gh")
+        let out = read_only_tokio_gh_command()
             .args([
                 "issue",
                 "list",
@@ -148,7 +148,7 @@ pub async fn gh_issue_view(project_path: String, number: i64) -> Result<GhIssueD
         return Err("issue number must be positive".into());
     }
     let out = tokio::time::timeout(Duration::from_secs(5), async {
-        env::tokio_command("gh")
+        read_only_tokio_gh_command()
             .args([
                 "issue",
                 "view",

--- a/src-tauri/src/commands/git/mod.rs
+++ b/src-tauri/src/commands/git/mod.rs
@@ -6,6 +6,7 @@
 //! picking each live in their own file.
 
 pub mod checks;
+pub(crate) mod common;
 pub mod diff;
 pub mod github;
 pub mod issues;

--- a/src-tauri/src/commands/git/status.rs
+++ b/src-tauri/src/commands/git/status.rs
@@ -7,6 +7,8 @@ use tauri::State;
 
 use crate::env;
 
+use super::common::{fail_if_index_locked, read_only_git_command};
+
 const FETCH_TIMEOUT: Duration = Duration::from_secs(120);
 const FETCH_DEDUP_WINDOW: Duration = Duration::from_secs(30);
 
@@ -80,7 +82,7 @@ async fn git_fetch_all_inner(project_path: String, state: &GitFetchState) -> Res
 }
 
 fn is_inside_work_tree(dir: &Path) -> bool {
-    let inside = env::command("git")
+    let inside = read_only_git_command()
         .arg("-C")
         .arg(dir)
         .args(["rev-parse", "--is-inside-work-tree"])
@@ -92,7 +94,7 @@ fn is_inside_work_tree(dir: &Path) -> bool {
 }
 
 fn git_common_dir(dir: &Path) -> Option<PathBuf> {
-    let out = env::command("git")
+    let out = read_only_git_command()
         .arg("-C")
         .arg(dir)
         .args(["rev-parse", "--path-format=absolute", "--git-common-dir"])
@@ -142,7 +144,7 @@ pub async fn git_status(path: String) -> Result<Option<GitStatus>, String> {
     }
     // Quick presence check — `git rev-parse --is-inside-work-tree`.
     // Saves spawning the porcelain pass on a non-git directory.
-    let inside = env::command("git")
+    let inside = read_only_git_command()
         .arg("-C")
         .arg(&dir)
         .args(["rev-parse", "--is-inside-work-tree"])
@@ -154,9 +156,10 @@ pub async fn git_status(path: String) -> Result<Option<GitStatus>, String> {
     if !inside_ok {
         return Ok(None);
     }
+    fail_if_index_locked(&dir)?;
     // Branch: prefer the symbolic name. Falls back to a short SHA on
     // detached HEAD so the chip still says something useful.
-    let branch_out = env::command("git")
+    let branch_out = read_only_git_command()
         .arg("-C")
         .arg(&dir)
         .args(["symbolic-ref", "--short", "HEAD"])
@@ -166,7 +169,7 @@ pub async fn git_status(path: String) -> Result<Option<GitStatus>, String> {
         Some(o) if o.status.success() => {
             Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
         }
-        _ => env::command("git")
+        _ => read_only_git_command()
             .arg("-C")
             .arg(&dir)
             .args(["rev-parse", "--short", "HEAD"])
@@ -181,7 +184,7 @@ pub async fn git_status(path: String) -> Result<Option<GitStatus>, String> {
     //   …
     // The header line is parsed for ahead/behind (when an upstream is
     // configured). Any subsequent line means the worktree is dirty.
-    let porcelain = env::command("git")
+    let porcelain = read_only_git_command()
         .arg("-C")
         .arg(&dir)
         .args(["status", "--porcelain=v1", "--branch"])
@@ -252,7 +255,8 @@ pub async fn git_working_context(cwd: String) -> Result<Option<GitWorkingContext
     if !is_inside_work_tree(&dir) {
         return Ok(None);
     }
-    let repo_root = env::command("git")
+    fail_if_index_locked(&dir)?;
+    let repo_root = read_only_git_command()
         .arg("-C")
         .arg(&dir)
         .args(["rev-parse", "--show-toplevel"])
@@ -290,7 +294,7 @@ pub async fn git_working_context(cwd: String) -> Result<Option<GitWorkingContext
 /// Resolve an absolute git path for `flag` (e.g. `--git-dir`,
 /// `--git-common-dir`), canonicalized so the worktree comparison is stable.
 fn git_rev_parse_abs_path(dir: &Path, flag: &str) -> Option<PathBuf> {
-    let out = env::command("git")
+    let out = read_only_git_command()
         .arg("-C")
         .arg(dir)
         .args(["rev-parse", "--path-format=absolute", flag])
@@ -308,7 +312,7 @@ fn git_rev_parse_abs_path(dir: &Path, flag: &str) -> Option<PathBuf> {
 /// Symbolic branch name, falling back to a short SHA on detached HEAD so the
 /// prompt still says something useful. Mirrors [`git_status`]'s branch read.
 fn read_head_branch(dir: &Path) -> Option<String> {
-    let symbolic = env::command("git")
+    let symbolic = read_only_git_command()
         .arg("-C")
         .arg(dir)
         .args(["symbolic-ref", "--short", "HEAD"])
@@ -318,7 +322,7 @@ fn read_head_branch(dir: &Path) -> Option<String> {
         Some(o) if o.status.success() => {
             Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
         }
-        _ => env::command("git")
+        _ => read_only_git_command()
             .arg("-C")
             .arg(dir)
             .args(["rev-parse", "--short", "HEAD"])
@@ -333,7 +337,7 @@ fn read_head_branch(dir: &Path) -> Option<String> {
 /// The `## ` header carries the optional `[ahead N, behind M]` tail; every
 /// other non-empty line is a tracked/untracked change.
 fn read_branch_porcelain_counts(dir: &Path) -> (u32, u32, u32) {
-    let porcelain = env::command("git")
+    let porcelain = read_only_git_command()
         .arg("-C")
         .arg(dir)
         .args(["status", "--porcelain=v1", "--branch"])
@@ -387,12 +391,13 @@ pub async fn git_file_status(root: String) -> Result<Option<Vec<GitFileStatusEnt
     let Some((repo_root, active_root)) = resolve_repo_and_active_root(&dir)? else {
         return Ok(None);
     };
+    fail_if_index_locked(&active_root)?;
 
     // `--porcelain=v1 -z` gives a stable, NUL-delimited format whose paths
     // are not quoted, so spaces and unusual characters do not need a fragile
     // line parser. `-- .` scopes the result to the active root when the user
     // opened a repository subdirectory as the project.
-    let porcelain = env::command("git")
+    let porcelain = read_only_git_command()
         .arg("-C")
         .arg(&active_root)
         .args([
@@ -430,7 +435,7 @@ pub async fn git_file_status(root: String) -> Result<Option<Vec<GitFileStatusEnt
 pub(crate) fn resolve_repo_and_active_root(
     dir: &Path,
 ) -> Result<Option<(PathBuf, PathBuf)>, String> {
-    let inside = env::command("git")
+    let inside = read_only_git_command()
         .arg("-C")
         .arg(dir)
         .args(["rev-parse", "--is-inside-work-tree"])
@@ -443,7 +448,7 @@ pub(crate) fn resolve_repo_and_active_root(
         return Ok(None);
     }
 
-    let top_level = env::command("git")
+    let top_level = read_only_git_command()
         .arg("-C")
         .arg(dir)
         .args(["rev-parse", "--show-toplevel"])
@@ -480,12 +485,13 @@ pub async fn git_ignored_paths(root: String) -> Result<Option<Vec<String>>, Stri
     let Some((_repo_root, active_root)) = resolve_repo_and_active_root(&dir)? else {
         return Ok(None);
     };
+    fail_if_index_locked(&active_root)?;
 
     // `--others --ignored --exclude-standard` lists only ignored entries; `-z`
     // keeps paths unquoted + NUL-delimited; `-- .` scopes to the active root
     // so a subdirectory-opened repo reports its own ignores, output relative
     // to that root.
-    let output = env::command("git")
+    let output = read_only_git_command()
         .arg("-C")
         .arg(&active_root)
         .args([
@@ -643,6 +649,27 @@ mod tests {
         let state = GitFetchState::default();
         assert!(state.reserve_attempt(key.clone()));
         assert!(!state.reserve_attempt(key));
+    }
+
+    #[tokio::test]
+    async fn git_status_skips_refresh_when_index_lock_exists() {
+        if env::resolve_program("git").is_none() {
+            return;
+        }
+        let tmp = tempfile::tempdir().unwrap();
+        let init = env::command("git")
+            .arg("init")
+            .arg(tmp.path())
+            .output()
+            .unwrap();
+        assert!(init.status.success());
+        std::fs::File::create(tmp.path().join(".git").join("index.lock")).unwrap();
+
+        let result = git_status(tmp.path().to_string_lossy().to_string()).await;
+        assert_eq!(
+            result.err().as_deref(),
+            Some(super::super::common::GIT_INDEX_LOCKED_MESSAGE)
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/git/watch.rs
+++ b/src-tauri/src/commands/git/watch.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 
 use tauri::Emitter;
 
-use crate::env;
+use super::common::read_only_git_command;
 
 /// Git writes several files per operation (HEAD, index, a ref, sometimes
 /// packed-refs); coalesce a touch longer than the fs watcher's 120ms so a
@@ -70,7 +70,7 @@ fn absolutize(root: &Path, raw: &str) -> PathBuf {
 /// dir — which is the case that actually breaks today. Non-existent paths are
 /// dropped so `notify::watch` never errors on them.
 fn resolve_git_watch_targets(root: &Path) -> Vec<PathBuf> {
-    let out = env::command("git")
+    let out = read_only_git_command()
         .arg("-C")
         .arg(root)
         .args(["rev-parse", "--git-dir", "--git-common-dir"])

--- a/src-tauri/src/commands/git/worktrees.rs
+++ b/src-tauri/src/commands/git/worktrees.rs
@@ -3,6 +3,8 @@ use std::time::UNIX_EPOCH;
 
 use crate::env;
 
+use super::common::read_only_git_command;
+
 /// One worktree row as reported by `git worktree list --porcelain`.
 /// `serde(rename_all = "camelCase")` matches the TS `GitWorktreeRecord`
 /// shape — without it, `is_main` would serialize as `is_main` and the
@@ -45,7 +47,7 @@ pub async fn git_worktrees(project_path: String) -> Result<Vec<Worktree>, String
     if !dir.is_dir() {
         return Ok(Vec::new());
     }
-    let output = env::command("git")
+    let output = read_only_git_command()
         .arg("-C")
         .arg(&dir)
         .args(["worktree", "list", "--porcelain"])
@@ -151,7 +153,7 @@ pub async fn git_worktree_add(
             .map_err(|e| format!("create worktree parent {}: {e}", parent.display()))?;
     }
     // Detect whether the branch exists so we know whether to pass `-b`.
-    let exists = env::command("git")
+    let exists = read_only_git_command()
         .arg("-C")
         .arg(&dir)
         .args(["rev-parse", "--verify", "--quiet"])
@@ -366,7 +368,7 @@ pub async fn git_branch_list(project_path: String) -> Result<Vec<BranchInfo>, St
     if !dir.is_dir() {
         return Ok(Vec::new());
     }
-    let output = env::command("git")
+    let output = read_only_git_command()
         .arg("-C")
         .arg(&dir)
         .args([

--- a/src/extensions/default-layout/editor/canvas.tsx
+++ b/src/extensions/default-layout/editor/canvas.tsx
@@ -54,6 +54,7 @@ import { useEditorViewSettings } from "./useEditorViewSettings";
 import { useEditorExternalChange } from "./useEditorExternalChange";
 import { monacoOptionsFor } from "./viewSettings";
 import { handleEditorLinkOpen } from "./link-openers";
+import { isGitIndexLockedError } from "../../../utils/gitErrors";
 
 /** Read the shared `--scrollbar-size` token (px) so Monaco's scrollbar
  *  matches the terminal + WebKit scrollbars. Falls back to 4px. */
@@ -120,6 +121,7 @@ export function EditorCanvas({
   const gutterRef = useRef<monaco.editor.IEditorDecorationsCollection | null>(
     null,
   );
+  const gutterKeyRef = useRef<string>("");
   const currentTabIdRef = useRef<string>("");
   const projectPathRef = useRef<string>(projectPath);
   // Stable reference to the live onEvent callback. The renderer
@@ -522,12 +524,18 @@ export function EditorCanvas({
       gutterRef.current ??
       (gutterRef.current = ed.createDecorationsCollection());
     if (!showMonaco || !tabId || !editorMeta?.filePath || !projectPath) {
+      gutterKeyRef.current = "";
       collection.clear();
       return;
     }
     const path = editorMeta.filePath;
     const root = projectPath;
     const forTabId = tabId;
+    const gutterKey = `${root}\0${path}\0${forTabId}`;
+    if (gutterKeyRef.current !== gutterKey) {
+      gutterKeyRef.current = gutterKey;
+      collection.clear();
+    }
     let cancelled = false;
     void invoke<DiffHunk[] | null>("git_file_diff_hunks", { root, path })
       .then((hunks) => {
@@ -545,8 +553,8 @@ export function EditorCanvas({
         );
         collection.set(decorations);
       })
-      .catch(() => {
-        if (!cancelled) collection.clear();
+      .catch((err) => {
+        if (!cancelled && !isGitIndexLockedError(err)) collection.clear();
       });
     return () => {
       cancelled = true;

--- a/src/extensions/default-layout/sidebar/useFileTreeData.ts
+++ b/src/extensions/default-layout/sidebar/useFileTreeData.ts
@@ -3,6 +3,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 
 import { readState, writeState } from "../../../persist";
+import { isGitIndexLockedError } from "../../../utils/gitErrors";
 import {
   EXPANDED_CAP_PER_PROJECT,
   EXPAND_STATE_FILE,
@@ -152,7 +153,10 @@ function useFileTreeData({
       if (projectPathRef.current !== rootPath) return;
       setGitStatuses(gitStatusesFromEntries(entries));
       setIgnoredPaths(Array.isArray(ignored) ? ignored : []);
-    } catch {
+    } catch (err) {
+      // If a user-owned git operation is holding `.git/index.lock`, keep the
+      // last decorations until the watcher/next poll refreshes successfully.
+      if (isGitIndexLockedError(err)) return;
       // Non-git directories, missing git binary, or transient status errors
       // should never block the file tree; just render without decorations.
       if (projectPathRef.current === rootPath) {

--- a/src/hooks/useVcsStatus.test.ts
+++ b/src/hooks/useVcsStatus.test.ts
@@ -249,6 +249,32 @@ describe("useVcsStatus", () => {
     expect(warm.loading).toBe(true); // reconcile in flight
   });
 
+  it("preserves the current slice when a read-only git refresh sees index.lock", async () => {
+    invokeMock.mockImplementation((cmd: string) =>
+      cmd === "git_status"
+        ? Promise.resolve({ branch: "main", ahead: 0, behind: 0, dirty: false })
+        : Promise.resolve(cmd === "git_file_status" ? [] : null),
+    );
+    branchMock.mockResolvedValue(null);
+    checksMock.mockResolvedValue(null);
+    const h = makeSetState();
+    renderHook(() =>
+      useVcsStatus({ activeRoot: "/repo", setState: h.setState }),
+    );
+    await waitFor(() => expect(h.vcs()?.loading).toBe(false));
+    expect(h.vcs()?.branch).toBe("main");
+
+    invokeMock.mockRejectedValue(
+      "git index locked; skipping read-only refresh",
+    );
+    emitGitStateChanged("/repo");
+    await new Promise((r) => setTimeout(r, 30));
+
+    expect(h.vcs()?.branch).toBe("main");
+    expect(h.vcs()?.loading).toBe(false);
+    expect(branchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("treats a 'none' CI conclusion as no CI signal", async () => {
     invokeMock.mockImplementation((cmd: string) =>
       cmd === "git_status"

--- a/src/hooks/useVcsStatus.ts
+++ b/src/hooks/useVcsStatus.ts
@@ -29,6 +29,7 @@ import {
   hydrateVcsSliceCache,
   putCachedVcsSlice,
 } from "../vcsSliceCache";
+import { isGitIndexLockedError } from "../utils/gitErrors";
 
 type GitFileStatusKind =
   | "modified"
@@ -109,6 +110,7 @@ export interface UseVcsStatusContext {
 }
 
 const POLL_INTERVAL_MS = 20_000;
+const GIT_REFRESH_LOCKED = Symbol("git-refresh-locked");
 /** Keep the panel tidy + the IPC payload small; the count is exact even
  *  when the file list is truncated. */
 const MAX_FILES = 200;
@@ -130,6 +132,13 @@ const EMPTY_CHANGES: VcsChanges = {
 interface DiffStat {
   insertions: number;
   deletions: number;
+}
+
+type GitPollResult<T> = T | null | typeof GIT_REFRESH_LOCKED;
+
+function catchGitPollError<T>(err: unknown): GitPollResult<T> {
+  if (isGitIndexLockedError(err)) return GIT_REFRESH_LOCKED;
+  return null;
 }
 
 function emptySlice(root: string | null, loading: boolean): VcsSlice {
@@ -285,13 +294,27 @@ export function useVcsStatus({ activeRoot, setState }: UseVcsStatusContext): voi
         // run together; PR/CI gate on having a branch.
         const [statusRes, filesRes, statRes] = await Promise.all([
           invoke<GitStatus | null>("git_status", { path: root }).catch(
-            () => null,
+            catchGitPollError<GitStatus>,
           ),
           invoke<GitFileStatusEntry[] | null>("git_file_status", {
             root,
-          }).catch(() => null),
-          invoke<DiffStat | null>("git_diff_stat", { root }).catch(() => null),
+          }).catch(catchGitPollError<GitFileStatusEntry[]>),
+          invoke<DiffStat | null>("git_diff_stat", { root }).catch(
+            catchGitPollError<DiffStat>,
+          ),
         ]);
+        if (
+          statusRes === GIT_REFRESH_LOCKED ||
+          filesRes === GIT_REFRESH_LOCKED ||
+          statRes === GIT_REFRESH_LOCKED
+        ) {
+          setState((s) => {
+            const prev = (s.vcs as VcsSlice | undefined) ?? null;
+            if (!prev || prev.root !== root || !prev.loading) return s;
+            return { ...s, vcs: { ...prev, loading: false } };
+          });
+          return;
+        }
 
         const branch = statusRes?.branch ?? null;
         // Spread so we never mutate the shared EMPTY_CHANGES constant.

--- a/src/utils/gitErrors.ts
+++ b/src/utils/gitErrors.ts
@@ -1,0 +1,4 @@
+export function isGitIndexLockedError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return message.includes("git index locked") || message.includes("index.lock");
+}


### PR DESCRIPTION
## Summary
- route read-only git/gh metadata refreshes through helpers that disable optional index locks
- skip transient recent `.git/index.lock` refreshes while preserving existing VCS/file-tree UI state
- keep stale lock files from permanently freezing status and add regression coverage

Closes #274

## Validation
- Codex peer review: no regressions found after fixes
- `cargo test --manifest-path src-tauri/Cargo.toml --lib -p aethon commands::git -- --nocapture`
- `cargo clippy --manifest-path src-tauri/Cargo.toml -p aethon --lib -- -D warnings`
- `bunx tsc -b --noEmit`
- `bunx vitest run src/hooks/useVcsStatus.test.ts src/extensions/default-layout/sidebar/file-tree.test.tsx`
- targeted ESLint on touched TS/TSX files
- `git diff --check`