### PR TITLE
fix(chat): keep initial prompts ordered after restore

### DIFF
--- a/src/hooks/bridgeMessageHandlers/sessionHistory.test.ts
+++ b/src/hooks/bridgeMessageHandlers/sessionHistory.test.ts
@@ -917,4 +917,43 @@ describe("handleSessionHistory", () => {
     expect(out.messages).toHaveLength(1);
     expect(out.messages[0]).toMatchObject({ id: "restored-user" });
   });
+
+  it("orders an older initial prompt before newer restored transcript rows", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleSessionHistory(
+      {
+        type: "session_history",
+        tabId: "tab-1",
+        messages: [
+          {
+            id: "restored-final",
+            role: "agent",
+            text: "Done. PR #281 was merged.",
+            createdAt: 3_000,
+          },
+        ],
+      },
+      ctx,
+    );
+    const [, updater] = mocks.updateTab.mock.calls[0];
+    const tab = makeEmptyTab("tab-1", "Tab 1");
+    const out = updater({
+      ...tab,
+      waiting: true,
+      messages: [
+        {
+          id: "initial-prompt",
+          role: "user",
+          text: "Please work on GitHub issue #279",
+          delivery: "sent",
+          createdAt: 1_000,
+        },
+      ],
+    });
+
+    expect(out.messages.map((m: ChatMessage) => m.id)).toEqual([
+      "initial-prompt",
+      "restored-final",
+    ]);
+  });
 });

--- a/src/hooks/bridgeMessageHandlers/sessionHistory.ts
+++ b/src/hooks/bridgeMessageHandlers/sessionHistory.ts
@@ -73,7 +73,18 @@ function isLivePendingMessage(
   latestRestoredTime: number | undefined,
 ): boolean {
   if (message.role === "user") {
-    return message.delivery === "sent" || message.delivery === "steered";
+    if (message.delivery !== "sent" && message.delivery !== "steered") {
+      return false;
+    }
+    const createdAt = messageCreatedAt(message);
+    if (
+      typeof createdAt === "number" &&
+      typeof latestRestoredTime === "number" &&
+      createdAt < latestRestoredTime
+    ) {
+      return false;
+    }
+    return true;
   }
   if (!currentlyWaiting) return false;
   if (message.role !== "agent") return false;

--- a/src/hooks/useChat.test.ts
+++ b/src/hooks/useChat.test.ts
@@ -147,6 +147,31 @@ describe("useChat setModel", () => {
     });
   });
 
+  it("timestamps optimistic user prompts so restore hydration can order them", async () => {
+    const { ctx, stateRef } = buildContext();
+    const { result } = renderHook(() => useChat(ctx));
+
+    await act(async () => {
+      await result.current.sendChat("Please work on GitHub issue #279");
+    });
+
+    expect((stateRef.current.tabs as Tab[])[0].messages.at(-1)).toMatchObject({
+      role: "user",
+      text: "Please work on GitHub issue #279",
+      delivery: "sent",
+      createdAt: expect.any(Number),
+    });
+    expect(ctx.persistLocalChatMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        role: "user",
+        text: "Please work on GitHub issue #279",
+        delivery: "sent",
+        createdAt: expect.any(Number),
+      }),
+      "tab-1",
+    );
+  });
+
   it("forwards a restored tab's reasoning level on the first chat", async () => {
     const tab = {
       ...makeEmptyTab("tab-1", "Tab 1"),

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -484,6 +484,7 @@ export function useChat(ctx: UseChatContext): UseChatActions {
           id: crypto.randomUUID(),
           role: "user" as const,
           text: trimmed,
+          createdAt: Date.now(),
         };
         appendMessage(slashUserMessage, slashTabId);
         persistLocalChatMessage(slashUserMessage, slashTabId);
@@ -569,6 +570,7 @@ export function useChat(ctx: UseChatContext): UseChatActions {
       text: displayText,
       ...(attachments.length > 0 ? { attachments } : {}),
       delivery,
+      createdAt: Date.now(),
     };
     appendMessage(userMessage, tabId);
     updateTab(tabId, (tab) => ({


### PR DESCRIPTION
## Summary

Fixes restored chat ordering when an initial programmatic prompt races with session-history hydration.

Root cause: the affected #279 session restored from `~/.aethon/sessions/f8fee8b6-40b0-4588-bbfb-abb7ad937032`. The canonical pi transcript had the GitHub issue prompt at line 4, but the restored transcript was capped to the newest 200 rows, so that first user turn could fall out of the restored payload. The remaining optimistic local prompt had no `createdAt`, and `handleSessionHistory` treated all `delivery: "sent"` user messages as live-pending, forcing them to append after restored rows like the merged-PR final answer.

## Changes

- Stamp optimistic user messages, including slash-command echoes, with `createdAt`.
- Let older timestamped sent/steered user messages merge chronologically with restored history instead of always appending.
- Add red-green coverage for the prompt ordering regression and prompt timestamping.

## Validation

- `bunx vitest run src/hooks/bridgeMessageHandlers/sessionHistory.test.ts -t "orders an older initial prompt"` (red before fix, green after)
- `bunx vitest run src/hooks/useChat.test.ts -t "timestamps optimistic user prompts"` (red before fix, green after)
- `bunx vitest run src/hooks/bridgeMessageHandlers/sessionHistory.test.ts src/hooks/useChat.test.ts agent/session-history.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bunx vitest run` (270 files, 2200 tests; existing test warning noise only)
