### PR TITLE
[codex] Respawn exited shell tabs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -774,6 +774,7 @@ export default function App() {
     hangWarnActiveRef,
     hangWarnNotifId,
     autoRestartAgentRef,
+    shellInheritEnvRef,
     updateTab,
     newTab,
     newShellTab,

--- a/src/hooks/osEdges/shellStreams.test.ts
+++ b/src/hooks/osEdges/shellStreams.test.ts
@@ -172,6 +172,7 @@ describe("subscribeShellStreams", () => {
         args: [],
         shareMode: "private",
         shellState: "running",
+        restartOnMount: true,
       },
     };
     let state: Record<string, unknown> = { tabs: [tab] };
@@ -209,5 +210,6 @@ describe("subscribeShellStreams", () => {
       shellState: "exited",
       exitCode: -1,
     });
+    expect(tab.shell?.restartOnMount).toBeUndefined();
   });
 });

--- a/src/hooks/osEdges/shellStreams.test.ts
+++ b/src/hooks/osEdges/shellStreams.test.ts
@@ -1,7 +1,12 @@
+// @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { createShellOutputCoalescer } from "./shellStreams";
+import {
+  createShellOutputCoalescer,
+  subscribeShellStreams,
+} from "./shellStreams";
 import { TERMINAL_REPLAY_MAX } from "../useTabs";
 import type { Tab } from "../../types/tab";
+import { clearTauriMocks, installTauriMocks } from "../../test/tauriMocks";
 
 function makeTab(buffer = ""): Tab {
   return {
@@ -89,5 +94,120 @@ describe("createShellOutputCoalescer", () => {
 });
 
 function makeTabWithBuffer(buffer: string): Tab {
-  return { id: "x", label: "x", kind: "shell", terminalBuffer: buffer } as unknown as Tab;
+  return {
+    id: "x",
+    label: "x",
+    kind: "shell",
+    terminalBuffer: buffer,
+  } as unknown as Tab;
 }
+
+describe("subscribeShellStreams", () => {
+  let harness: ReturnType<typeof installTauriMocks>;
+
+  beforeEach(() => {
+    harness = installTauriMocks();
+  });
+
+  afterEach(() => {
+    clearTauriMocks();
+  });
+
+  test("respawns a live shell tab when its PTY exits", async () => {
+    let tab: Tab = {
+      ...makeTab(),
+      shell: {
+        cwd: "/repo/app",
+        command: "",
+        args: [],
+        shareMode: "read",
+        shellState: "running",
+      },
+    };
+    let state: Record<string, unknown> = { tabs: [tab] };
+    const stateRef = { current: state };
+    const updateTab = vi.fn((tabId: string, mutator: (t: Tab) => Tab) => {
+      expect(tabId).toBe("shell-1");
+      tab = mutator(tab);
+      state = { tabs: [tab] };
+      stateRef.current = state;
+    });
+    const appendSystem = vi.fn();
+
+    subscribeShellStreams({
+      updateTab,
+      stateRef,
+      appendSystem,
+      shellInheritEnvRef: { current: false },
+    });
+    await Promise.resolve();
+
+    expect(harness.fireEvent("shell-exit", { tabId: "shell-1", code: 0 })).toBe(
+      1,
+    );
+    expect(tab.shell?.shellState).toBe("starting");
+
+    await vi.waitFor(() => {
+      expect(harness.invoke).toHaveBeenCalledWith("shell_open", {
+        args: {
+          tabId: "shell-1",
+          cwd: "/repo/app",
+          shareMode: "read",
+          inheritEnv: false,
+        },
+      });
+    });
+
+    expect(tab.shell?.shellState).toBe("running");
+    expect(tab.shell?.exitCode).toBeUndefined();
+    expect(appendSystem).not.toHaveBeenCalled();
+  });
+
+  test("marks the shell as failed when respawn cannot reopen it", async () => {
+    let tab: Tab = {
+      ...makeTab(),
+      shell: {
+        cwd: "/repo/app",
+        command: "",
+        args: [],
+        shareMode: "private",
+        shellState: "running",
+      },
+    };
+    let state: Record<string, unknown> = { tabs: [tab] };
+    const stateRef = { current: state };
+    const updateTab = vi.fn((tabId: string, mutator: (t: Tab) => Tab) => {
+      expect(tabId).toBe("shell-1");
+      tab = mutator(tab);
+      state = { tabs: [tab] };
+      stateRef.current = state;
+    });
+    const appendSystem = vi.fn();
+    harness.invoke.mockImplementation((command: string) =>
+      command === "shell_open"
+        ? Promise.reject(new Error("spawn failed"))
+        : Promise.resolve(undefined),
+    );
+
+    subscribeShellStreams({
+      updateTab,
+      stateRef,
+      appendSystem,
+      shellInheritEnvRef: { current: true },
+    });
+    await Promise.resolve();
+
+    harness.fireEvent("shell-exit", { tabId: "shell-1", code: 0 });
+
+    await vi.waitFor(() => {
+      expect(appendSystem).toHaveBeenCalledWith(
+        "Shell tab exited and could not be restarted: Error: spawn failed",
+      );
+    });
+
+    expect(tab.shell).toMatchObject({
+      shellState: "exited",
+      exitCode: -1,
+    });
+  });
+});

--- a/src/hooks/osEdges/shellStreams.ts
+++ b/src/hooks/osEdges/shellStreams.ts
@@ -210,13 +210,15 @@ function updateShellState(
 ): void {
   deps.updateTab(tabId, (t) => {
     if (t.kind !== "shell" || !t.shell) return t;
+    const shell = {
+      ...t.shell,
+      shellState,
+      ...(typeof code === "number" ? { exitCode: code } : {}),
+    };
+    if (shellState === "exited" && code === -1) delete shell.restartOnMount;
     return {
       ...t,
-      shell: {
-        ...t.shell,
-        shellState,
-        ...(typeof code === "number" ? { exitCode: code } : {}),
-      },
+      shell,
     };
   });
 }

--- a/src/hooks/osEdges/shellStreams.ts
+++ b/src/hooks/osEdges/shellStreams.ts
@@ -1,9 +1,14 @@
 import { listen } from "@tauri-apps/api/event";
-import type { Tab } from "../../types/tab";
+import { invoke } from "@tauri-apps/api/core";
+import type { MutableRefObject } from "react";
+import type { ShellMeta, Tab } from "../../types/tab";
 import { TERMINAL_REPLAY_MAX } from "../useTabs";
 
 export interface ShellStreamsDeps {
   updateTab: (tabId: string, mutator: (tab: Tab) => Tab) => void;
+  stateRef: MutableRefObject<Record<string, unknown>>;
+  appendSystem: (text: string) => void;
+  shellInheritEnvRef: MutableRefObject<boolean>;
 }
 
 /** How long PTY chunks accumulate before one state flush. The xterm gets
@@ -77,8 +82,9 @@ export function createShellOutputCoalescer(
  *  terminalBuffer (trimmed to TERMINAL_REPLAY_MAX, coalesced to one state
  *  write per SHELL_BUFFER_FLUSH_MS) and dispatches a per-tab DOM event so
  *  the shell-canvas composite writes the chunk to its xterm immediately.
- *  `shell-exit` flips the tab's shellState to "exited" with the exit
- *  code. `shell-title` mirrors OSC 0/1/2 title-set sequences into the tab
+ *  `shell-exit` restarts the same shell tab id when the tab still exists,
+ *  falling back to "exited" only if the respawn fails. `shell-title` mirrors
+ *  OSC 0/1/2 title-set sequences into the tab
  *  label (truncated to 64 chars).
  *
  *  Inactive shell-tab output stays buffered until the user switches
@@ -87,6 +93,7 @@ export function createShellOutputCoalescer(
 export function subscribeShellStreams(deps: ShellStreamsDeps): () => void {
   const { updateTab } = deps;
   const coalescer = createShellOutputCoalescer(updateTab);
+  const restartingTabs = new Set<string>();
 
   const unlistenShellOutput = listen<{ tabId: string; content: string }>(
     "shell-output",
@@ -108,17 +115,7 @@ export function subscribeShellStreams(deps: ShellStreamsDeps): () => void {
       // The final output chunks must land in the replay buffer before the
       // exited state renders (replay/persist read the buffer).
       coalescer.flushTab(tabId);
-      updateTab(tabId, (t) => {
-        if (t.kind !== "shell" || !t.shell) return t;
-        return {
-          ...t,
-          shell: {
-            ...t.shell,
-            shellState: "exited",
-            ...(typeof code === "number" ? { exitCode: code } : {}),
-          },
-        };
-      });
+      void respawnShellTab(deps, restartingTabs, tabId, code);
     },
   );
 
@@ -141,4 +138,85 @@ export function subscribeShellStreams(deps: ShellStreamsDeps): () => void {
     unlistenShellExit.then((fn) => fn());
     unlistenShellTitle.then((fn) => fn());
   };
+}
+
+function liveShellTab(
+  stateRef: MutableRefObject<Record<string, unknown>>,
+  tabId: string,
+): Tab | undefined {
+  const tabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
+  return tabs.find(
+    (tab) => tab.id === tabId && tab.kind === "shell" && tab.shell,
+  );
+}
+
+function shellOpenArgs(
+  tabId: string,
+  shell: ShellMeta,
+  inheritEnv: boolean,
+): Record<string, unknown> {
+  return {
+    tabId,
+    ...(shell.command ? { command: shell.command } : {}),
+    ...(shell.args.length > 0 ? { args: shell.args } : {}),
+    ...(shell.cwd ? { cwd: shell.cwd } : {}),
+    ...(shell.shareMode !== "private" ? { shareMode: shell.shareMode } : {}),
+    ...(inheritEnv === false ? { inheritEnv: false } : {}),
+  };
+}
+
+async function respawnShellTab(
+  deps: ShellStreamsDeps,
+  restartingTabs: Set<string>,
+  tabId: string,
+  code: number | null,
+): Promise<void> {
+  if (restartingTabs.has(tabId)) return;
+  const tab = liveShellTab(deps.stateRef, tabId);
+  if (!tab?.shell) return;
+
+  restartingTabs.add(tabId);
+  updateShellState(deps, tabId, "starting", code);
+
+  try {
+    await invoke("shell_close", { tabId });
+    const latest = liveShellTab(deps.stateRef, tabId);
+    if (!latest?.shell) return;
+    await invoke("shell_open", {
+      args: shellOpenArgs(tabId, latest.shell, deps.shellInheritEnvRef.current),
+    });
+    deps.updateTab(tabId, (t) => {
+      if (t.kind !== "shell" || !t.shell) return t;
+      const shell = { ...t.shell, shellState: "running" as const };
+      delete shell.exitCode;
+      delete shell.restartOnMount;
+      return { ...t, shell };
+    });
+  } catch (err) {
+    deps.appendSystem(
+      `Shell tab exited and could not be restarted: ${String(err)}`,
+    );
+    updateShellState(deps, tabId, "exited", -1);
+  } finally {
+    restartingTabs.delete(tabId);
+  }
+}
+
+function updateShellState(
+  deps: ShellStreamsDeps,
+  tabId: string,
+  shellState: ShellMeta["shellState"],
+  code: number | null,
+): void {
+  deps.updateTab(tabId, (t) => {
+    if (t.kind !== "shell" || !t.shell) return t;
+    return {
+      ...t,
+      shell: {
+        ...t.shell,
+        shellState,
+        ...(typeof code === "number" ? { exitCode: code } : {}),
+      },
+    };
+  });
 }

--- a/src/hooks/osEdges/types.ts
+++ b/src/hooks/osEdges/types.ts
@@ -26,6 +26,7 @@ export interface UseOsEdgesContext {
 
   // Live config refs (from useBootConfig).
   autoRestartAgentRef: MutableRefObject<boolean>;
+  shellInheritEnvRef: MutableRefObject<boolean>;
 
   // Tab actions (from useTabs).
   updateTab: (tabId: string, mutator: (tab: Tab) => Tab) => void;

--- a/src/hooks/useOsEdges.ts
+++ b/src/hooks/useOsEdges.ts
@@ -47,7 +47,12 @@ export type { UseOsEdgesContext } from "./osEdges/types";
 export function useOsEdges(ctx: UseOsEdgesContext): void {
   useEffect(() => {
     const cleanups = [
-      subscribeShellStreams({ updateTab: ctx.updateTab }),
+      subscribeShellStreams({
+        updateTab: ctx.updateTab,
+        stateRef: ctx.stateRef,
+        appendSystem: ctx.appendSystem,
+        shellInheritEnvRef: ctx.shellInheritEnvRef,
+      }),
       subscribeAgentReload({
         bootLayout: ctx.bootLayout,
         activeResponseIdRef: ctx.activeResponseIdRef,

--- a/src/state/sessionUiSnapshot.test.ts
+++ b/src/state/sessionUiSnapshot.test.ts
@@ -173,9 +173,9 @@ describe("sessionUiSnapshot", () => {
     expect(loaded?.tabs).toMatchObject([
       { id: "empty-active", label: "Empty Active", messages: [] },
     ]);
-    expect(loaded?.buckets?.["project-1::workspace::wt-1"]?.tabs).toMatchObject([
-      { id: "empty-bucket", label: "Empty Bucket", messages: [] },
-    ]);
+    expect(loaded?.buckets?.["project-1::workspace::wt-1"]?.tabs).toMatchObject(
+      [{ id: "empty-bucket", label: "Empty Bucket", messages: [] }],
+    );
   });
 
   it("repairs timestamped message order and drops stale stop notices on restore", () => {
@@ -590,6 +590,7 @@ describe("sessionUiSnapshot", () => {
               shareMode: "private",
               shellState: "exited",
               exitCode: -1,
+              restartOnMount: true,
             },
           },
         ],

--- a/src/state/sessionUiSnapshot.test.ts
+++ b/src/state/sessionUiSnapshot.test.ts
@@ -547,7 +547,7 @@ describe("sessionUiSnapshot", () => {
     });
   });
 
-  it("does not mark exited shell tabs for PTY restore", () => {
+  it("marks cleanly exited shell tabs for PTY restore", () => {
     const parsed = parseSessionUiSnapshot(
       JSON.stringify({
         tabs: [
@@ -566,12 +566,42 @@ describe("sessionUiSnapshot", () => {
         activeTabId: "shell",
         savedAt: 1,
       }),
+      { restartShellTabs: true },
+    );
+
+    expect(parsed?.activeTabId).toBe("__overview__");
+    expect(parsed?.tabs[0].shell).toMatchObject({
+      shellState: "starting",
+      exitCode: 0,
+      restartOnMount: true,
+    });
+  });
+
+  it("does not mark failed shell tabs for PTY restore", () => {
+    const parsed = parseSessionUiSnapshot(
+      JSON.stringify({
+        tabs: [
+          {
+            ...makeEmptyTab("shell", "Shell", null, "shell"),
+            shell: {
+              cwd: "/repo/app",
+              command: "",
+              args: [],
+              shareMode: "private",
+              shellState: "exited",
+              exitCode: -1,
+            },
+          },
+        ],
+        activeTabId: "shell",
+        savedAt: 1,
+      }),
     );
 
     expect(parsed?.activeTabId).toBe("__overview__");
     expect(parsed?.tabs[0].shell).toMatchObject({
       shellState: "exited",
-      exitCode: 0,
+      exitCode: -1,
     });
     expect(parsed?.tabs[0].shell?.restartOnMount).toBeUndefined();
   });

--- a/src/state/sessionUiSnapshot.ts
+++ b/src/state/sessionUiSnapshot.ts
@@ -118,7 +118,9 @@ function restoreShellTab(tab: Tab, restartShellTabs: boolean): Tab {
     };
   }
   if (tab.shell?.shellState === "exited" && tab.shell.exitCode === -1) {
-    return tab;
+    const shell = { ...tab.shell };
+    delete shell.restartOnMount;
+    return { ...tab, shell };
   }
   return {
     ...tab,
@@ -359,13 +361,14 @@ function restoreTabRecord(
     messages: normalizeRestoredMessages(
       collapseAmendedAgentMessages(
         dedupeToolResultTextMessages(t.messages),
-      ).map((message): ChatMessage =>
-        message.attachments && message.attachments.length > 0
-          ? {
-              ...message,
-              attachments: durableImageAttachments(message.attachments),
-            }
-          : message,
+      ).map(
+        (message): ChatMessage =>
+          message.attachments && message.attachments.length > 0
+            ? {
+                ...message,
+                attachments: durableImageAttachments(message.attachments),
+              }
+            : message,
       ),
     ),
     draft: t.draft ?? "",
@@ -425,7 +428,9 @@ function parsePersistedBuckets(
     return undefined;
   }
   const out: Record<string, PersistedTabBucket> = {};
-  for (const [rawKey, raw] of Object.entries(value as Record<string, unknown>)) {
+  for (const [rawKey, raw] of Object.entries(
+    value as Record<string, unknown>,
+  )) {
     if (!raw || typeof raw !== "object" || Array.isArray(raw)) continue;
     // Pre-workspace-rename snapshots used "::worktree::" in bucket keys;
     // migrate on read so existing tabs restore into the renamed buckets.

--- a/src/state/sessionUiSnapshot.ts
+++ b/src/state/sessionUiSnapshot.ts
@@ -103,7 +103,6 @@ function shouldPersistTab(tab: Tab): boolean {
 }
 
 function restoreShellTab(tab: Tab, restartShellTabs: boolean): Tab {
-  if (tab.shell?.shellState === "exited") return tab;
   if (!restartShellTabs) {
     const shell = tab.shell ? { ...tab.shell } : undefined;
     if (shell) delete shell.restartOnMount;
@@ -117,6 +116,9 @@ function restoreShellTab(tab: Tab, restartShellTabs: boolean): Tab {
           }
         : shell,
     };
+  }
+  if (tab.shell?.shellState === "exited" && tab.shell.exitCode === -1) {
+    return tab;
   }
   return {
     ...tab,


### PR DESCRIPTION
## Summary

- Respawn shell tabs on `shell-exit` when the tab still exists, preserving the same tab id/cwd/command/share-mode settings.
- Treat respawn/open failures as the durable failed state (`exitCode: -1`) instead of letting a clean `exit` become permanent.
- Restore cleanly exited shell tabs as `restartOnMount` during synchronous session restore, while leaving failed shell tabs visible as failures.

## Root Cause

The frontend handled every `shell-exit` event by setting `shellState: "exited"` and never attempted to reopen the PTY. Clean exits could also be persisted and restored as permanent exited shell tabs.

## Validation

- `bunx vitest run src/hooks/osEdges/shellStreams.test.ts` (red before implementation, green after)
- `bunx vitest run src/hooks/useRestoreShellTabs.test.tsx src/hooks/tabOps/shellTab.test.ts src/hooks/tabOps/closeTab.test.ts src/extensions/default-layout/shell/panel.test.tsx`
- `bunx vitest run src/state/sessionUiSnapshot.test.ts`
- `bunx vitest run`
- `bun run typecheck`
- `bun run lint`
- Live dev-session verification via Aethon debug bridge at `http://localhost:1420/`: created a temporary `/tmp` shell tab, recorded `beforePid=83981`, sent `exit`, then sent another command and observed `afterPid=84040` with final shell state `running`. The temporary probe tab was removed afterward.