### PR TITLE
[codex] Remove nested chat row scrollbars

### DIFF
--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -3180,7 +3180,10 @@ body.ae-resizing-sidebar .a2ui-layout {
   min-width: 0;
   max-width: 100%;
   box-sizing: border-box;
-  overflow-x: hidden;
+  /* `overflow-x: hidden` computes overflow-y to auto in WebKit, which makes
+     tall measured rows paint their own scrollbar inside the chat scroller. */
+  overflow-x: clip;
+  overflow-y: visible;
 }
 
 .a2ui-canvas-scroller .a2ui-msg-row {

--- a/src/styles/scrollbar.test.ts
+++ b/src/styles/scrollbar.test.ts
@@ -74,6 +74,9 @@ describe("chat overflow containment CSS", () => {
     expect(row).toMatch(/min-width:\s*0;/);
     expect(row).toMatch(/max-width:\s*100%;/);
     expect(row).toMatch(/box-sizing:\s*border-box;/);
+    expect(row).toMatch(/overflow-x:\s*clip;/);
+    expect(row).toMatch(/overflow-y:\s*visible;/);
+    expect(row).not.toMatch(/overflow-x:\s*hidden;/);
 
     const canvasRows = cssRuleBody(
       chromeCss,


### PR DESCRIPTION
## Summary

Fixes the duplicate scrollbar that appeared inside chat rows in the Aethon dev app. The root cause was `.a2ui-msg-row` using `overflow-x: hidden`; in WebKit that computes the vertical axis to `auto`, so a tall measured row can become its own vertical scroll container inside the real Virtuoso chat scroller.

This changes the row to use horizontal `clip` with visible vertical overflow, preserving horizontal containment without creating nested vertical scrollbars. The existing scrollbar CSS regression test now pins that contract.

## Validation

- Confirmed the bug in the running dev app via the Aethon debug webview: `.a2ui-msg-row` had `overflowY: auto` and one row was vertically scrollable.
- Ran the focused regression red first: `bunx vitest run src/styles/scrollbar.test.ts` failed on the old `overflow-x: hidden` rule.
- After the fix:
  - `bunx vitest run src/styles/scrollbar.test.ts`
  - `bunx vitest run src/styles/scrollbar.test.ts src/extensions/default-layout/message-list.virtuoso.test.tsx src/extensions/default-layout/chat.test.tsx`
  - `bun run typecheck`
  - `bun run lint`
- Rechecked the running dev app via the webview: zero `.a2ui-msg-row` elements are vertical scroll containers; only `.a2ui-canvas-scroller` owns chat scrolling.
- Captured a fresh focused dev-app screenshot and visually confirmed the duplicate chat row rail is gone.
