### PR TITLE
fix: prevent startup reload flicker

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -108,6 +108,7 @@ export default function App() {
   // by calling window.aethon.setLayout(payload), or register a new extension via
   // window.aethon.registerExtension(extension) and switch to its layout.
   const [layout, setLayout] = useState<A2UIPayload>(BOOT_LAYOUT);
+  const [startupChromeReady, setStartupChromeReady] = useState(false);
 
   const {
     stateRef,
@@ -132,6 +133,7 @@ export default function App() {
   // settings save path's re-prime helper.
   // ---------------------------------------------------------------------
   const {
+    bootConfigReady,
     defaultShareModeRef,
     notifyOnCompletionRef,
     notifyMinDurationMsRef,
@@ -639,6 +641,7 @@ export default function App() {
   useAppBridgeMessages({
     bootLayout: BOOT_LAYOUT,
     onBootError: (err) => {
+      setStartupChromeReady(true);
       appendMessage({
         id: crypto.randomUUID(),
         role: "agent",
@@ -687,6 +690,7 @@ export default function App() {
     syncRecentSessionsToState,
     routeShellWrite,
     startTaskInProject,
+    markStartupChromeReady: () => setStartupChromeReady(true),
   });
 
   // Global keyboard shortcuts. Lives in useKeyboardShortcuts which
@@ -920,6 +924,7 @@ export default function App() {
     searchOpen,
     authProfilesOpen,
   } = useDerivedRenderState({ state, buildSidebarHistory, hostInfo });
+  const chromeReady = bootConfigReady && startupChromeReady;
 
   return (
     <AppRoot
@@ -934,6 +939,8 @@ export default function App() {
       settingsOpen={settingsOpen}
       searchOpen={searchOpen}
       authProfilesOpen={authProfilesOpen}
+      chromeReady={chromeReady}
+      startupLogoUrl={logoUrl}
       topBanner={
         <UpdateBanner
           state={updaterState}

--- a/src/app/AppRoot.tsx
+++ b/src/app/AppRoot.tsx
@@ -20,6 +20,8 @@ export interface AppRootProps {
   settingsOpen: boolean;
   searchOpen: boolean;
   authProfilesOpen: boolean;
+  chromeReady: boolean;
+  startupLogoUrl: string;
   /** Optional banner row rendered above the layout. Sits in flow as the
    *  first flex child of `.app` so it pushes the rest of the chrome
    *  down instead of floating over it. */
@@ -45,6 +47,8 @@ export function AppRoot({
   settingsOpen,
   searchOpen,
   authProfilesOpen,
+  chromeReady,
+  startupLogoUrl,
   topBanner,
 }: AppRootProps) {
   return (
@@ -52,15 +56,21 @@ export function AppRoot({
       {/* `data-platform="mac"` gates the overlay-titlebar chrome (traffic-
           light clearance + drag regions) so non-mac builds render unchanged. */}
       <div className="app" {...(isMacOS() ? { "data-platform": "mac" } : {})}>
-        {topBanner}
-        <A2UIRenderer
-          payload={layout}
-          state={renderState}
-          onStateChange={setState}
-          onEvent={onEvent}
-          tabId={activeTabId}
-        />
-        {notificationsOpen && (
+        {chromeReady ? topBanner : null}
+        {chromeReady ? (
+          <A2UIRenderer
+            payload={layout}
+            state={renderState}
+            onStateChange={setState}
+            onEvent={onEvent}
+            tabId={activeTabId}
+          />
+        ) : (
+          <div className="ae-boot-curtain" aria-hidden="true">
+            <img src={startupLogoUrl} alt="" />
+          </div>
+        )}
+        {chromeReady && notificationsOpen && (
           <RegistryComponent
             type="notification-stack"
             state={renderState}
@@ -68,7 +78,7 @@ export function AppRoot({
             tabId={activeTabId}
           />
         )}
-        {paletteOpen && (
+        {chromeReady && paletteOpen && (
           <RegistryComponent
             type="command-palette"
             state={renderState}
@@ -76,7 +86,7 @@ export function AppRoot({
             tabId={activeTabId}
           />
         )}
-        {settingsOpen && (
+        {chromeReady && settingsOpen && (
           <RegistryComponent
             type="settings-panel"
             state={renderState}
@@ -84,7 +94,7 @@ export function AppRoot({
             tabId={activeTabId}
           />
         )}
-        {searchOpen && (
+        {chromeReady && searchOpen && (
           <RegistryComponent
             type="search-panel"
             state={renderState}
@@ -92,7 +102,7 @@ export function AppRoot({
             tabId={activeTabId}
           />
         )}
-        {authProfilesOpen && (
+        {chromeReady && authProfilesOpen && (
           <RegistryComponent
             type="auth-profile-panel"
             state={renderState}

--- a/src/hooks/bridgeMessageHandlers/ready.test.ts
+++ b/src/hooks/bridgeMessageHandlers/ready.test.ts
@@ -398,6 +398,7 @@ describe("handleReady", () => {
       "default",
       "/tmp/p1",
     );
+    expect(mocks.markStartupChromeReady).not.toHaveBeenCalled();
   });
 
   it("does not re-announce the active project when ready already reports that cwd", () => {
@@ -423,6 +424,18 @@ describe("handleReady", () => {
     );
 
     expect(mocks.announceProjectToBridge).not.toHaveBeenCalled();
+    expect(mocks.markStartupChromeReady).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks startup chrome ready when no project reannounce is needed", () => {
+    const { ctx, mocks } = buildHandlerFixture({
+      state: { activeTabId: "default", tabs: [] },
+    });
+
+    handleReady({ type: "ready", model: "claude", tabs: [] }, ctx);
+
+    expect(mocks.announceProjectToBridge).not.toHaveBeenCalled();
+    expect(mocks.markStartupChromeReady).toHaveBeenCalledTimes(1);
   });
 
   it("re-announces the active workspace cwd, not the project root", () => {

--- a/src/hooks/bridgeMessageHandlers/ready.ts
+++ b/src/hooks/bridgeMessageHandlers/ready.ts
@@ -522,5 +522,7 @@ export const handleReady: BridgeMessageHandler = (data, ctx) => {
     : (priorActiveTabCwd ?? projectActivePath);
   if (activePath && currentProjectCwd !== activePath) {
     ctx.announceProjectToBridge(priorActiveTabId, activePath);
+    return;
   }
+  ctx.markStartupChromeReady();
 };

--- a/src/hooks/bridgeMessageHandlers/testFixtures.ts
+++ b/src/hooks/bridgeMessageHandlers/testFixtures.ts
@@ -53,6 +53,7 @@ export interface HandlerFixture {
     knownTabIds: Mock;
     scopedDiscoveredSessions: Mock;
     recentSessionItems: Mock;
+    markStartupChromeReady: Mock;
   };
   /** Apply every queued setState reducer in order against the supplied
    *  seed. Returns the resulting state for assertion. */
@@ -111,6 +112,7 @@ export function buildHandlerFixture(
     (d: DiscoveredSession[]) => d,
   );
   const recentSessionItems = vi.fn(() => []);
+  const markStartupChromeReady = vi.fn();
 
   const ctx: BridgeMessageContext = {
     setState,
@@ -161,6 +163,7 @@ export function buildHandlerFixture(
 
     routeShellWrite,
     startTaskInProject,
+    markStartupChromeReady,
 
     ackMutation,
     hangWarnNotifId: (tabId: string) => `ae-hang-warn:${tabId}`,
@@ -219,6 +222,7 @@ export function buildHandlerFixture(
       knownTabIds,
       scopedDiscoveredSessions,
       recentSessionItems,
+      markStartupChromeReady,
     },
     applySetState,
   };

--- a/src/hooks/bridgeMessageHandlers/types.ts
+++ b/src/hooks/bridgeMessageHandlers/types.ts
@@ -180,6 +180,10 @@ export interface BridgeMessageContext {
   }) => Promise<void>;
 
   // ─── Hook-owned ────────────────────────────────────────────────────
+  /** Startup/reload paint gate. The first bridge ready can still represent
+   *  a stale project cwd; callers mark chrome paintable only after ready has
+   *  the active project's extension/layout surface. */
+  markStartupChromeReady: () => void;
   /** Ack a mutation back to the bridge. Provided by useBridgeMessages so
    *  handlers don't have to know about the IPC channel. */
   ackMutation: (

--- a/src/hooks/useBootConfig.ts
+++ b/src/hooks/useBootConfig.ts
@@ -1,6 +1,7 @@
 import {
   useEffect,
   useRef,
+  useState,
   type Dispatch,
   type MutableRefObject,
   type SetStateAction,
@@ -9,6 +10,11 @@ import { readStateWithLocalStorageFallback } from "../persist";
 import { applyUiScale } from "../utils/viewport";
 import { getConfig, type AethonConfig } from "../config";
 import type { ShellMeta } from "../types/tab";
+import {
+  mirrorBootTheme,
+  normalizeThemeId,
+  readBootThemeSeed,
+} from "../themeBootstrap";
 
 export interface UseBootConfigContext {
   setState: Dispatch<SetStateAction<Record<string, unknown>>>;
@@ -52,6 +58,10 @@ export interface UseBootConfigActions {
    *  + `getConfig()` so the running app picks up the new values without
    *  a page reload. */
   reapplyConfig: (fresh: AethonConfig) => void;
+  /** True after the boot config effect has applied the authoritative
+   *  theme/font/settings pass. App paint is held behind this so startup
+   *  never flashes a stale theme. */
+  bootConfigReady: boolean;
 }
 
 /**
@@ -80,10 +90,13 @@ export function useBootConfig(ctx: UseBootConfigContext): UseBootConfigActions {
   const shellPromptBeforeCloseRef = useRef<boolean>(true);
   const updateChannelRef = useRef<"stable" | "nightly">("stable");
   const disableAutoCheckRef = useRef<boolean>(false);
+  const [bootConfigReady, setBootConfigReady] = useState(false);
 
   function reapplyConfig(fresh: AethonConfig) {
     if (fresh.ui.theme) {
-      document.documentElement.dataset.theme = fresh.ui.theme;
+      const theme = normalizeThemeId(fresh.ui.theme);
+      document.documentElement.dataset.theme = theme;
+      mirrorBootTheme(theme);
     }
     const size = fresh.ui.fontSize;
     if (typeof size === "number" && Number.isFinite(size)) {
@@ -137,126 +150,129 @@ export function useBootConfig(ctx: UseBootConfigContext): UseBootConfigActions {
   }
 
   useEffect(() => {
+    let cancelled = false;
     (async () => {
-      const [saved, config] = await Promise.all([
-        readStateWithLocalStorageFallback("theme", "aethon-theme"),
-        getConfig(),
-      ]);
-      const trimmed = saved.trim();
-      // Migrate legacy theme ids:
-      //   - `signature` (one-theme era) → `aether`
-      //   - `dark` (pre-palette-rename) → `ember`
-      //   - `light` (pre-palette-rename) → `paper`
-      // Without this, a saved id from an older build resolves to a
-      // `data-theme="dark"` selector that no stylesheet defines, so the
-      // app falls back to base ember tokens regardless of the user's
-      // actual choice.
-      const LEGACY_THEME_MAP: Record<string, string> = {
-        signature: "aether",
-        dark: "ember",
-        light: "paper",
-      };
-      const normalize = (id: string) => LEGACY_THEME_MAP[id] ?? id;
-      const prefersLight =
-        typeof window !== "undefined" &&
-        typeof window.matchMedia === "function" &&
-        window.matchMedia("(prefers-color-scheme: light)").matches;
-      const initial =
-        trimmed.length > 0
-          ? normalize(trimmed)
-          : config.ui.theme
-            ? normalize(config.ui.theme)
-            : prefersLight
-              ? "paper"
-              : "ember";
-      document.documentElement.dataset.theme = initial;
-      // Apply [ui] font_size as a CSS custom property — components that
-      // care can read it via var(--app-font-size, 14px). Clamped to a
-      // sensible range so a malformed config can't make the UI
-      // unreadable. Skipped when null so the stylesheet's default wins.
-      const size = config.ui.fontSize;
-      if (typeof size === "number" && Number.isFinite(size)) {
-        const clamped = Math.max(10, Math.min(24, Math.round(size)));
-        document.documentElement.style.setProperty(
-          "--app-font-size",
-          `${clamped}px`,
-        );
-      }
-      // [shell] default_share_mode: seed the ref so subsequent
-      // newShellTab calls open with the configured default. Already
-      // clamped to the four valid modes by getConfig() / parse_config_toml.
-      defaultShareModeRef.current = config.shell.defaultShareMode;
+      try {
+        const [saved, config] = await Promise.all([
+          readStateWithLocalStorageFallback("theme", "aethon-theme"),
+          getConfig(),
+        ]);
+        if (cancelled) return;
+        const trimmed = saved.trim();
+        // Migrate legacy theme ids:
+        //   - `signature` (one-theme era) → `aether`
+        //   - `dark` (pre-palette-rename) → `ember`
+        //   - `light` (pre-palette-rename) → `paper`
+        // Without this, a saved id from an older build resolves to a
+        // `data-theme="dark"` selector that no stylesheet defines, so the
+        // app falls back to base ember tokens regardless of the user's
+        // actual choice.
+        const hasSavedTheme = trimmed.length > 0;
+        const hasConfigTheme = !!config.ui.theme;
+        const initial = hasSavedTheme
+          ? normalizeThemeId(trimmed)
+          : hasConfigTheme
+            ? normalizeThemeId(config.ui.theme!)
+            : readBootThemeSeed();
+        document.documentElement.dataset.theme = initial;
+        if (hasSavedTheme || hasConfigTheme) {
+          mirrorBootTheme(initial);
+        }
+        // Apply [ui] font_size as a CSS custom property — components that
+        // care can read it via var(--app-font-size, 14px). Clamped to a
+        // sensible range so a malformed config can't make the UI
+        // unreadable. Skipped when null so the stylesheet's default wins.
+        const size = config.ui.fontSize;
+        if (typeof size === "number" && Number.isFinite(size)) {
+          const clamped = Math.max(10, Math.min(24, Math.round(size)));
+          document.documentElement.style.setProperty(
+            "--app-font-size",
+            `${clamped}px`,
+          );
+        }
+        // [shell] default_share_mode: seed the ref so subsequent
+        // newShellTab calls open with the configured default. Already
+        // clamped to the four valid modes by getConfig() / parse_config_toml.
+        defaultShareModeRef.current = config.shell.defaultShareMode;
 
-      // P4: notify_on_completion + notify_min_duration_seconds.
-      notifyOnCompletionRef.current = config.ui.notifyOnCompletion;
-      notifyMinDurationMsRef.current =
-        Math.max(0, config.ui.notifyMinDurationSeconds) * 1000;
-      // P5: [shell] auto_restart_agent.
-      autoRestartAgentRef.current = config.shell.autoRestartAgent;
-      // Extended [shell] keys.
-      shellDefaultCommandRef.current = config.shell.defaultCommand;
-      shellDefaultArgsRef.current = config.shell.defaultArgs;
-      shellInheritEnvRef.current = config.shell.inheritEnv;
-      shellPromptBeforeCloseRef.current = config.shell.promptBeforeClose;
-      // [updates] — seed the hook ref so the first poll fires against
-      // the configured channel.
-      updateChannelRef.current = config.updates.channel;
-      disableAutoCheckRef.current = config.updates.disableAutoCheck;
-      setState((prev) => ({
-        ...prev,
-        voice: {
-          ...(prev.voice as object | undefined),
-          toggleHotkey: config.voice.toggleHotkey,
-          holdHotkey: config.voice.holdHotkey,
-        },
-        transcriptVisibility: {
-          thinking: config.ui.thinkingVisibility,
-          toolCalls: config.ui.toolCallsVisibility,
-        },
-        guardrails: {
-          hardEnforceProjectRoot: config.guardrails.hardEnforceProjectRoot,
-        },
-        codexFastMode: config.agent.codexFastMode,
-      }));
-
-      // [agent] model: when set, seed the picker default for this
-      // session. Only applied if no per-session model has been saved
-      // and the bridge hasn't already locked one in. The bridge's
-      // ensureTab() reads the global picker default at session-create
-      // time, so writing /model here makes the next set_model dispatch
-      // pick it up.
-      if (config.agent.model) {
-        piDefaultModelRef.current = config.agent.model;
+        // P4: notify_on_completion + notify_min_duration_seconds.
+        notifyOnCompletionRef.current = config.ui.notifyOnCompletion;
+        notifyMinDurationMsRef.current =
+          Math.max(0, config.ui.notifyMinDurationSeconds) * 1000;
+        // P5: [shell] auto_restart_agent.
+        autoRestartAgentRef.current = config.shell.autoRestartAgent;
+        // Extended [shell] keys.
+        shellDefaultCommandRef.current = config.shell.defaultCommand;
+        shellDefaultArgsRef.current = config.shell.defaultArgs;
+        shellInheritEnvRef.current = config.shell.inheritEnv;
+        shellPromptBeforeCloseRef.current = config.shell.promptBeforeClose;
+        // [updates] — seed the hook ref so the first poll fires against
+        // the configured channel.
+        updateChannelRef.current = config.updates.channel;
+        disableAutoCheckRef.current = config.updates.disableAutoCheck;
         setState((prev) => ({
           ...prev,
-          // Use as the initial display value and the new-tab fallback.
-          // Per-tab model_changed events remain authoritative after a
-          // session is actually running.
-          model: config.agent.model!,
-          piDefaultModel: config.agent.model!,
-          // The chosen default for new sessions (`/defaultModel`), seeded
-          // from the durable [agent] model. The header picker writes both
-          // this and the config; `modelForNewProjectTab` reads it first.
-          defaultModel: config.agent.model!,
+          voice: {
+            ...(prev.voice as object | undefined),
+            toggleHotkey: config.voice.toggleHotkey,
+            holdHotkey: config.voice.holdHotkey,
+          },
+          transcriptVisibility: {
+            thinking: config.ui.thinkingVisibility,
+            toolCalls: config.ui.toolCallsVisibility,
+          },
+          guardrails: {
+            hardEnforceProjectRoot: config.guardrails.hardEnforceProjectRoot,
+          },
+          codexFastMode: config.agent.codexFastMode,
         }));
-      }
-      // Restore saved UI zoom (Cmd+/-). Stored as a string number on
-      // disk; clamp to a sensible range so a stale value can't make
-      // the UI unusable. applyUiScale writes both CSS zoom and the
-      // --app-ui-scale token that viewport-sized containers use to
-      // compensate, so zooming does not push chrome outside the window.
-      const savedZoom = (
-        await readStateWithLocalStorageFallback("ui_zoom", "")
-      ).trim();
-      const z = parseFloat(savedZoom);
-      if (Number.isFinite(z) && z >= 0.7 && z <= 1.6) {
-        applyUiScale(z);
+
+        // [agent] model: when set, seed the picker default for this
+        // session. Only applied if no per-session model has been saved
+        // and the bridge hasn't already locked one in. The bridge's
+        // ensureTab() reads the global picker default at session-create
+        // time, so writing /model here makes the next set_model dispatch
+        // pick it up.
+        if (config.agent.model) {
+          piDefaultModelRef.current = config.agent.model;
+          setState((prev) => ({
+            ...prev,
+            // Use as the initial display value and the new-tab fallback.
+            // Per-tab model_changed events remain authoritative after a
+            // session is actually running.
+            model: config.agent.model!,
+            piDefaultModel: config.agent.model!,
+            // The chosen default for new sessions (`/defaultModel`), seeded
+            // from the durable [agent] model. The header picker writes both
+            // this and the config; `modelForNewProjectTab` reads it first.
+            defaultModel: config.agent.model!,
+          }));
+        }
+        // Restore saved UI zoom (Cmd+/-). Stored as a string number on
+        // disk; clamp to a sensible range so a stale value can't make
+        // the UI unusable. applyUiScale writes both CSS zoom and the
+        // --app-ui-scale token that viewport-sized containers use to
+        // compensate, so zooming does not push chrome outside the window.
+        const savedZoom = (
+          await readStateWithLocalStorageFallback("ui_zoom", "")
+        ).trim();
+        if (cancelled) return;
+        const z = parseFloat(savedZoom);
+        if (Number.isFinite(z) && z >= 0.7 && z <= 1.6) {
+          applyUiScale(z);
+        }
+      } finally {
+        if (!cancelled) setBootConfigReady(true);
       }
     })();
+    return () => {
+      cancelled = true;
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return {
+    bootConfigReady,
     defaultShareModeRef,
     notifyOnCompletionRef,
     notifyMinDurationMsRef,

--- a/src/hooks/useZoomAndTheme.ts
+++ b/src/hooks/useZoomAndTheme.ts
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { writeState } from "../persist";
 import { applyUiScale, readZoom, writeUiViewportVars } from "../utils/viewport";
+import { mirrorBootTheme } from "../themeBootstrap";
 
 export const ZOOM_MIN = 0.7;
 export const ZOOM_MAX = 1.6;
@@ -80,6 +81,7 @@ export function useZoomAndTheme(
     root.classList.add("ae-theme-switching");
     window.setTimeout(() => root.classList.remove("ae-theme-switching"), 320);
     root.dataset.theme = id;
+    mirrorBootTheme(id);
     writeState("theme", id).catch(() => {
       /* ignore */
     });

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,37 +1,4 @@
-import { StrictMode } from "react";
-import { createRoot } from "react-dom/client";
-import { invoke } from "@tauri-apps/api/core";
-import App from "./App.tsx";
-import { prewarmHighlighter } from "./utils/highlight";
-// Side-effect import: registers Monaco's web-worker factories and binds
-// the @monaco-editor/react loader to the bundled monaco package so the
-// editor mounts work offline / under Tauri's CSP. Must run before any
-// component imports a Monaco-backed surface.
-import "./monaco/setup";
-// Style entry. Order matters: shape tokens first (theme-agnostic), then
-// theme color tokens, then chrome rules (consumes everything). Import
-// each file directly here instead of chaining through `@import` in a
-// single index.css — Vite's HMR dep graph tracks JS module imports
-// reliably, but `@import` chains in CSS files have produced silently
-// stale stylesheets in the webview after edits to chrome.css.
-import "./styles/tokens.css";
-import "./styles/themes.css";
-import "./styles/chrome.css";
+import { applyBootTheme } from "./themeBootstrap";
 
-// Expose Tauri's invoke globally in dev so the aethon-debug skill's TCP eval
-// server can wrap user JS to call back via __AETHON_INVOKE__('debug_eval_result', ...).
-// Compiled out of release builds.
-if (import.meta.env.DEV) {
-  (window as unknown as { __AETHON_INVOKE__: typeof invoke }).__AETHON_INVOKE__ = invoke;
-}
-
-// Spawn the Shiki highlight worker eagerly so the first user-visible code
-// block doesn't pay the cold-start cost (Oniguruma WASM + theme parse).
-// Idempotent; safe to call here.
-prewarmHighlighter();
-
-createRoot(document.getElementById("root")!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-);
+applyBootTheme();
+void import("./mainApp");

--- a/src/mainApp.tsx
+++ b/src/mainApp.tsx
@@ -1,0 +1,37 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { invoke } from "@tauri-apps/api/core";
+import App from "./App.tsx";
+import { prewarmHighlighter } from "./utils/highlight";
+// Side-effect import: registers Monaco's web-worker factories and binds
+// the @monaco-editor/react loader to the bundled monaco package so the
+// editor mounts work offline / under Tauri's CSP. Must run before any
+// component imports a Monaco-backed surface.
+import "./monaco/setup";
+// Style entry. Order matters: shape tokens first (theme-agnostic), then
+// theme color tokens, then chrome rules (consumes everything). Import
+// each file directly here instead of chaining through `@import` in a
+// single index.css — Vite's HMR dep graph tracks JS module imports
+// reliably, but `@import` chains in CSS files have produced silently
+// stale stylesheets in the webview after edits to chrome.css.
+import "./styles/tokens.css";
+import "./styles/themes.css";
+import "./styles/chrome.css";
+
+// Expose Tauri's invoke globally in dev so the aethon-debug skill's TCP eval
+// server can wrap user JS to call back via __AETHON_INVOKE__('debug_eval_result', ...).
+// Compiled out of release builds.
+if (import.meta.env.DEV) {
+  (window as unknown as { __AETHON_INVOKE__: typeof invoke }).__AETHON_INVOKE__ = invoke;
+}
+
+// Spawn the Shiki highlight worker eagerly so the first user-visible code
+// block doesn't pay the cold-start cost (Oniguruma WASM + theme parse).
+// Idempotent; safe to call here.
+prewarmHighlighter();
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -147,6 +147,22 @@ body {
   overflow: hidden;
 }
 
+.ae-boot-curtain {
+  display: grid;
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  place-items: center;
+  background: var(--gradient-app-backdrop, var(--bg));
+}
+
+.ae-boot-curtain img {
+  width: 56px;
+  max-width: 18vw;
+  height: auto;
+  opacity: 0.9;
+}
+
 .a2ui-renderer {
   display: flex;
   flex-direction: column;

--- a/src/themeBootstrap.test.ts
+++ b/src/themeBootstrap.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  LEGACY_THEME_MAP,
+  applyBootTheme,
+  mirrorBootTheme,
+  readBootThemeSeed,
+  THEME_STORAGE_KEY,
+} from "./themeBootstrap";
+
+describe("themeBootstrap", () => {
+  let storage: Map<string, string>;
+
+  beforeEach(() => {
+    storage = new Map();
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: {
+        getItem: vi.fn((key: string) => storage.get(key) ?? null),
+        setItem: vi.fn((key: string, value: string) => {
+          storage.set(key, value);
+        }),
+        removeItem: vi.fn((key: string) => {
+          storage.delete(key);
+        }),
+        clear: vi.fn(() => {
+          storage.clear();
+        }),
+      },
+    });
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+    document.documentElement.removeAttribute("data-theme");
+    vi.restoreAllMocks();
+  });
+
+  it("reads the persisted theme synchronously before React paints", () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, "paper");
+
+    expect(readBootThemeSeed()).toBe("paper");
+    applyBootTheme();
+    expect(document.documentElement.dataset.theme).toBe("paper");
+  });
+
+  it("normalizes legacy ids and falls back to the OS color scheme", () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, "dark");
+    expect(readBootThemeSeed()).toBe(LEGACY_THEME_MAP.dark);
+
+    window.localStorage.removeItem(THEME_STORAGE_KEY);
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: vi.fn(() => ({
+        matches: true,
+        media: "(prefers-color-scheme: light)",
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+    expect(readBootThemeSeed()).toBe("paper");
+  });
+
+  it("mirrors the applied theme for the next reload", () => {
+    mirrorBootTheme("aether");
+
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("aether");
+  });
+});

--- a/src/themeBootstrap.ts
+++ b/src/themeBootstrap.ts
@@ -1,0 +1,43 @@
+export const THEME_STORAGE_KEY = "aethon-theme";
+
+export const LEGACY_THEME_MAP: Record<string, string> = {
+  signature: "aether",
+  dark: "ember",
+  light: "paper",
+};
+
+export function normalizeThemeId(id: string): string {
+  return LEGACY_THEME_MAP[id] ?? id;
+}
+
+function prefersLightTheme(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-color-scheme: light)").matches
+  );
+}
+
+export function readBootThemeSeed(): string {
+  try {
+    const saved = window.localStorage.getItem(THEME_STORAGE_KEY)?.trim();
+    if (saved) return normalizeThemeId(saved);
+  } catch {
+    /* storage may be unavailable during early webview startup */
+  }
+  return prefersLightTheme() ? "paper" : "ember";
+}
+
+export function mirrorBootTheme(id: string): void {
+  try {
+    window.localStorage.setItem(THEME_STORAGE_KEY, normalizeThemeId(id));
+  } catch {
+    /* best effort; disk/config remains authoritative */
+  }
+}
+
+export function applyBootTheme(id = readBootThemeSeed()): string {
+  const theme = normalizeThemeId(id);
+  document.documentElement.dataset.theme = theme;
+  return theme;
+}


### PR DESCRIPTION
## Summary

Stops startup and webview reload from briefly painting the wrong A2UI template or theme before the real extension/theme state is ready.

## Root Cause

React mounted the default workstation layout immediately, then the async boot config and bridge `ready` payload swapped in the saved theme, extension templates, and active-project layout. On reload, the first `ready` could also represent a stale bridge cwd before the frontend re-announced the active project/workspace, producing a visible wrong-template/theme flash.

## Changes

- Seed the last known theme synchronously before importing CSS or mounting React.
- Keep the app behind a minimal token-driven Aethon boot curtain until boot config has applied and bridge `ready` has the active cwd's chrome surface.
- Delay startup chrome readiness when `ready` needs to re-announce the active project/workspace cwd.
- Mirror runtime theme changes into the synchronous boot seed for the next reload.
- Add regression coverage for theme bootstrapping and the `ready` reannounce gate.

## Validation

- `bunx vitest run src/hooks/bridgeMessageHandlers/ready.test.ts src/themeBootstrap.test.ts`
- `bunx vitest run src/hooks/useSessionPersistence.test.tsx src/hooks/useBridgeMessages.test.ts src/hooks/uiOverlays/settings.test.ts src/hooks/bridgeMessageHandlers/ready.test.ts src/themeBootstrap.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bunx vitest run`
- `bun run build`
- Playwright visual checks for paper desktop and ember mobile startup curtain: full viewport, no stray text, and no `.a2ui-layout` mounted before ready.
