### PR TITLE
fix(editor): restore inline file tree rename

### DIFF
--- a/src/extensions/default-layout/sidebar/file-tree.test.tsx
+++ b/src/extensions/default-layout/sidebar/file-tree.test.tsx
@@ -49,6 +49,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.restoreAllMocks();
   // Portal-mounted context menus survive React Testing Library's default
   // autocleanup until the component unmounts; call cleanup explicitly so
   // each test starts with an empty document.body.

--- a/src/extensions/default-layout/sidebar/file-tree.test.tsx
+++ b/src/extensions/default-layout/sidebar/file-tree.test.tsx
@@ -622,6 +622,64 @@ describe("FileTreePanel", () => {
     ).toBeTruthy();
   });
 
+  it("renames files inline from the context menu", async () => {
+    invokeMock.mockImplementation((cmd: string, args?: { path?: string }) => {
+      if (cmd === "fs_list_dir" && args?.path === "/projects/aethon") {
+        return Promise.resolve([
+          {
+            name: "README.md",
+            path: "/projects/aethon/README.md",
+            kind: "file",
+          },
+        ]);
+      }
+      if (cmd === "git_file_status" || cmd === "git_ignored_paths") {
+        return Promise.resolve([]);
+      }
+      return Promise.resolve(undefined);
+    });
+    const promptSpy = vi.spyOn(window, "prompt").mockReturnValue("ignored");
+    const onEvent = vi.fn();
+    render(<FileTreePanel {...panelProps({ onEvent })} />);
+
+    const row = await waitFor(() => screen.getByText("README.md"));
+    const rootListCallCount = () =>
+      invokeMock.mock.calls.filter(
+        ([cmd, args]) =>
+          cmd === "fs_list_dir" &&
+          (args as { path?: string } | undefined)?.path === "/projects/aethon",
+      ).length;
+    const listCallsBeforeRename = rootListCallCount();
+    fireEvent.contextMenu(row.closest("li") as Element);
+    fireEvent.click(screen.getByRole("menuitem", { name: /Rename…/ }));
+
+    expect(promptSpy).not.toHaveBeenCalled();
+    const input = await screen.findByRole<HTMLInputElement>("textbox", {
+      name: /Rename README\.md/,
+    });
+    expect(input.value).toBe("README.md");
+    expect(document.activeElement).toBe(input);
+
+    fireEvent.change(input, { target: { value: "CHANGELOG.md" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith("fs_rename", {
+        root: "/projects/aethon",
+        from: "/projects/aethon/README.md",
+        to: "/projects/aethon/CHANGELOG.md",
+      });
+    });
+    expect(onEvent).toHaveBeenCalledWith("file-tree-rename", {
+      from: "/projects/aethon/README.md",
+      to: "/projects/aethon/CHANGELOG.md",
+      kind: "file",
+    });
+    await waitFor(() => {
+      expect(rootListCallCount()).toBeGreaterThan(listCallsBeforeRename);
+    });
+  });
+
   it("closes an open context menu when the project changes", async () => {
     invokeMock.mockImplementation((cmd: string, args?: { path?: string }) => {
       if (cmd === "fs_list_dir" && args?.path === "/projects/aethon") {

--- a/src/extensions/default-layout/sidebar/file-tree.tsx
+++ b/src/extensions/default-layout/sidebar/file-tree.tsx
@@ -13,6 +13,7 @@ import {
   useRef,
   useState,
   type CSSProperties,
+  type KeyboardEvent as ReactKeyboardEvent,
   type MouseEvent as ReactMouseEvent,
 } from "react";
 import { invoke } from "@tauri-apps/api/core";
@@ -131,10 +132,13 @@ export function FileTreePanel({
   });
 
   const {
+    cancelRename,
+    commitRename,
     contextMenu,
     createEntry,
     fileTreeMenuItems,
     openContextMenu,
+    renamingPath,
     setContextMenu,
   } = useFileTreeActions({
     onEvent,
@@ -492,8 +496,13 @@ export function FileTreePanel({
                   node.entry.path === activeFilePath
                 }
                 revealed={node.entry.path === revealTarget}
-                onClick={() => onItemClick(node)}
+                renaming={node.entry.path === renamingPath}
+                onClick={() => {
+                  if (node.entry.path !== renamingPath) onItemClick(node);
+                }}
                 onContextMenu={(e) => openContextMenu(e, node)}
+                onCommitRename={(name) => void commitRename(node, name)}
+                onCancelRename={cancelRename}
               />
             );
           })}
@@ -523,8 +532,11 @@ interface FileTreeRowProps {
   /** Transiently set after "Reveal in Files Panel" — scrolls into view
    *  and flashes a highlight. */
   revealed?: boolean;
+  renaming?: boolean;
   onClick: () => void;
   onContextMenu: (e: ReactMouseEvent) => void;
+  onCommitRename: (name: string) => void;
+  onCancelRename: () => void;
 }
 
 function FileTreeRow({
@@ -534,13 +546,46 @@ function FileTreeRow({
   ignored,
   active,
   revealed,
+  renaming,
   onClick,
   onContextMenu,
+  onCommitRename,
+  onCancelRename,
 }: FileTreeRowProps) {
   const rowRef = useRef<HTMLLIElement>(null);
+  const renameInputRef = useRef<HTMLInputElement>(null);
+  const renameFinishedRef = useRef(false);
   useEffect(() => {
     if (revealed) rowRef.current?.scrollIntoView({ block: "center" });
   }, [revealed]);
+
+  useEffect(() => {
+    if (!renaming) return;
+    renameFinishedRef.current = false;
+    const input = renameInputRef.current;
+    if (!input) return;
+    input.focus();
+    input.select();
+  }, [renaming]);
+
+  const finishRename = (mode: "save" | "cancel", value?: string) => {
+    if (renameFinishedRef.current) return;
+    renameFinishedRef.current = true;
+    if (mode === "save") onCommitRename(value ?? node.entry.name);
+    else onCancelRename();
+  };
+
+  const onRenameKeyDown = (event: ReactKeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      finishRename("save", event.currentTarget.value);
+      return;
+    }
+    if (event.key === "Escape") {
+      event.preventDefault();
+      finishRename("cancel");
+    }
+  };
   const isDir = node.entry.kind === "dir";
   const statusMeta = decoration ? GIT_STATUS_META[decoration.status] : null;
   const statusTitle = statusMeta
@@ -561,7 +606,9 @@ function FileTreeRow({
       aria-current={active ? "true" : undefined}
       className={`ae-file-tree-row ${isDir ? "is-dir" : "is-file"}${
         active ? " is-active" : ""
-      }${revealed ? " is-revealed" : ""}${ignored ? " is-ignored" : ""}${
+      }${revealed ? " is-revealed" : ""}${renaming ? " is-renaming" : ""}${
+        ignored ? " is-ignored" : ""
+      }${
         decoration
           ? ` has-git-status git-status-${decoration.status} git-status-${decoration.source}`
           : ""
@@ -586,8 +633,22 @@ function FileTreeRow({
         open={isDir && expanded}
         className="ae-file-tree-icon"
       />
-      <span className="ae-file-tree-label">{node.entry.name}</span>
-      {statusMeta && (
+      {renaming ? (
+        <input
+          ref={renameInputRef}
+          className="ae-file-tree-rename-input"
+          aria-label={`Rename ${node.entry.name}`}
+          defaultValue={node.entry.name}
+          spellCheck={false}
+          onClick={(event) => event.stopPropagation()}
+          onContextMenu={(event) => event.stopPropagation()}
+          onKeyDown={onRenameKeyDown}
+          onBlur={(event) => finishRename("save", event.currentTarget.value)}
+        />
+      ) : (
+        <span className="ae-file-tree-label">{node.entry.name}</span>
+      )}
+      {statusMeta && !renaming && (
         <span
           className="ae-file-tree-git-decoration"
           aria-label={statusTitle}

--- a/src/extensions/default-layout/sidebar/fileTreeActions.ts
+++ b/src/extensions/default-layout/sidebar/fileTreeActions.ts
@@ -32,8 +32,14 @@ function useFileTreeActions({
   collapseUnder,
 }: UseFileTreeActionsArgs) {
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
+  const [renamingTarget, setRenamingTarget] = useState<{
+    rootPath: string;
+    node: TreeNode;
+  } | null>(null);
   const activeContextMenu =
     contextMenu?.rootPath === projectPath ? contextMenu : null;
+  const activeRenamingNode =
+    renamingTarget?.rootPath === projectPath ? renamingTarget.node : null;
   const closeContextMenu = useCallback(() => setContextMenu(null), []);
 
   const openContextMenu = useCallback(
@@ -94,41 +100,52 @@ function useFileTreeActions({
     await createEntry(parentPath, "dir");
   }, [activeContextMenu, closeContextMenu, createEntry]);
 
-  const onContextRename = useCallback(async () => {
+  const onContextRename = useCallback(() => {
     if (!activeContextMenu) return;
-    const node = activeContextMenu.node;
+    setRenamingTarget({
+      rootPath: activeContextMenu.rootPath,
+      node: activeContextMenu.node,
+    });
     closeContextMenu();
-    const name = window.prompt("Rename to", node.entry.name);
-    if (!name || name === node.entry.name) return;
-    const dirIdx = Math.max(
-      node.entry.path.lastIndexOf("/"),
-      node.entry.path.lastIndexOf("\\"),
-    );
-    const parentPath =
-      dirIdx >= 0 ? node.entry.path.slice(0, dirIdx) : node.entry.path;
-    const target = `${parentPath}/${name}`;
-    try {
-      await invoke("fs_rename", {
-        root: projectPathRef.current,
-        from: node.entry.path,
-        to: target,
-      });
-      onEvent("file-tree-rename", {
-        from: node.entry.path,
-        to: target,
-        kind: node.entry.kind,
-      });
-      await refreshFolder(parentPath);
-    } catch (err) {
-      window.alert(`Rename failed: ${String(err)}`);
-    }
-  }, [
-    activeContextMenu,
-    closeContextMenu,
-    onEvent,
-    projectPathRef,
-    refreshFolder,
-  ]);
+  }, [activeContextMenu, closeContextMenu]);
+
+  const cancelRename = useCallback(() => {
+    setRenamingTarget(null);
+  }, []);
+
+  const commitRename = useCallback(
+    async (node: TreeNode, name: string) => {
+      setRenamingTarget(null);
+      if (!name.trim() || name === node.entry.name) return;
+      const dirIdx = Math.max(
+        node.entry.path.lastIndexOf("/"),
+        node.entry.path.lastIndexOf("\\"),
+      );
+      const parentPath =
+        dirIdx >= 0 ? node.entry.path.slice(0, dirIdx) : node.entry.path;
+      const separator =
+        node.entry.path.lastIndexOf("\\") > node.entry.path.lastIndexOf("/")
+          ? "\\"
+          : "/";
+      const target = parentPath ? `${parentPath}${separator}${name}` : name;
+      try {
+        await invoke("fs_rename", {
+          root: projectPathRef.current,
+          from: node.entry.path,
+          to: target,
+        });
+        onEvent("file-tree-rename", {
+          from: node.entry.path,
+          to: target,
+          kind: node.entry.kind,
+        });
+        await refreshFolder(parentPath);
+      } catch (err) {
+        window.alert(`Rename failed: ${String(err)}`);
+      }
+    },
+    [onEvent, projectPathRef, refreshFolder],
+  );
 
   const onContextDelete = useCallback(async () => {
     if (!activeContextMenu) return;
@@ -306,10 +323,13 @@ function useFileTreeActions({
   );
 
   return {
+    cancelRename,
+    commitRename,
     contextMenu: activeContextMenu,
     createEntry,
     fileTreeMenuItems,
     openContextMenu,
+    renamingPath: activeRenamingNode?.entry.path ?? null,
     setContextMenu,
   };
 }

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -580,10 +580,30 @@ body.ae-resizing-sidebar .ae-file-tree-sidebar-resize-handle {
 .ae-file-tree-row.is-dir .ae-file-tree-label {
   color: var(--text);
 }
+.ae-file-tree-row.is-renaming {
+  cursor: text;
+}
 .ae-file-tree-label {
   flex: 1 1 auto;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+.ae-file-tree-rename-input {
+  flex: 1 1 auto;
+  min-width: 0;
+  height: 22px;
+  padding: 1px 5px;
+  border: 1px solid var(--accent);
+  border-radius: var(--radius-sm);
+  outline: none;
+  background: var(--bg-elevated);
+  color: var(--text);
+  font: inherit;
+  line-height: 1.2;
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 18%, transparent);
+}
+.ae-file-tree-rename-input::selection {
+  background: color-mix(in srgb, var(--accent) 35%, transparent);
 }
 /* Color the whole name by git status (VS Code style). Keyed on the row's
    git-status class regardless of source, so folders carrying a propagated


### PR DESCRIPTION
## Summary
- replace the file tree Rename prompt with a VS Code-style inline rename input
- commit rename on Enter/blur and cancel on Escape while preserving editor tab rename reconciliation
- add regression coverage for context-menu inline rename

## Validation
- bun run test -- src/extensions/default-layout/sidebar/file-tree.test.tsx
- bun run typecheck
- bun run lint