### PR TITLE
[codex] feat: add subagent mention autocomplete

### DIFF
--- a/agent/subagents/task-tool.test.ts
+++ b/agent/subagents/task-tool.test.ts
@@ -11,12 +11,26 @@ const fakeModel = { provider: "ollama", id: "llama3.3", name: "Llama 3.3" };
 
 // Hoisted handle so the vi.mock factory and the tests share the same scripting
 // surface for the fake pi session.
+interface MockSessionHandle {
+  subscribers: Array<(e: Record<string, unknown>) => void>;
+  scriptedEvents: Array<Record<string, unknown>>;
+  promptImpl: null | ((session: MockSessionHandle) => Promise<void>);
+  lastConfig: Record<string, unknown> | undefined;
+  lastPrompt: string | undefined;
+  disposeSpy: ReturnType<typeof vi.fn>;
+  abortSpy: ReturnType<typeof vi.fn>;
+}
+
 interface MockHandle {
   subscribers: Array<(e: Record<string, unknown>) => void>;
   scriptedEvents: Array<Record<string, unknown>>;
-  promptImpl: null | (() => Promise<void>);
+  promptImpl: null | ((session: MockSessionHandle) => Promise<void>);
   lastConfig: Record<string, unknown> | undefined;
   lastPrompt: string | undefined;
+  sessions: MockSessionHandle[];
+  nextSessions: Array<
+    Partial<Pick<MockSessionHandle, "scriptedEvents" | "promptImpl">>
+  >;
   createAgentSession: ReturnType<typeof vi.fn>;
   disposeSpy: ReturnType<typeof vi.fn>;
   abortSpy: ReturnType<typeof vi.fn>;
@@ -28,6 +42,8 @@ const h = vi.hoisted<MockHandle>(() => ({
   promptImpl: null,
   lastConfig: undefined,
   lastPrompt: undefined,
+  sessions: [],
+  nextSessions: [],
   createAgentSession: vi.fn(),
   disposeSpy: vi.fn(),
   abortSpy: vi.fn(),
@@ -35,28 +51,41 @@ const h = vi.hoisted<MockHandle>(() => ({
 
 vi.mock("@mariozechner/pi-coding-agent", () => {
   const createAgentSession = vi.fn((config: Record<string, unknown>) => {
+    const next = h.nextSessions.shift() ?? {};
+    const handle: MockSessionHandle = {
+      subscribers: [],
+      scriptedEvents: next.scriptedEvents ?? [...h.scriptedEvents],
+      promptImpl: next.promptImpl ?? h.promptImpl,
+      lastConfig: config,
+      lastPrompt: undefined,
+      disposeSpy: vi.fn(),
+      abortSpy: vi.fn(() => Promise.resolve()),
+    };
+    h.sessions.push(handle);
+    h.subscribers = handle.subscribers;
     h.lastConfig = config;
-    h.disposeSpy = vi.fn();
-    h.abortSpy = vi.fn(() => Promise.resolve());
+    h.disposeSpy = handle.disposeSpy;
+    h.abortSpy = handle.abortSpy;
     const session = {
       model: config.model,
       subscribe(fn: (e: Record<string, unknown>) => void) {
-        h.subscribers.push(fn);
+        handle.subscribers.push(fn);
         return () => {
-          const i = h.subscribers.indexOf(fn);
-          if (i >= 0) h.subscribers.splice(i, 1);
+          const i = handle.subscribers.indexOf(fn);
+          if (i >= 0) handle.subscribers.splice(i, 1);
         };
       },
       prompt(prompt: string): Promise<void> {
+        handle.lastPrompt = prompt;
         h.lastPrompt = prompt;
-        if (h.promptImpl) return h.promptImpl();
-        for (const ev of h.scriptedEvents) {
-          for (const s of [...h.subscribers]) s(ev);
+        if (handle.promptImpl) return handle.promptImpl(handle);
+        for (const ev of handle.scriptedEvents) {
+          for (const s of [...handle.subscribers]) s(ev);
         }
         return Promise.resolve();
       },
-      abort: h.abortSpy,
-      dispose: h.disposeSpy,
+      abort: handle.abortSpy,
+      dispose: handle.disposeSpy,
     };
     return Promise.resolve({ session });
   });
@@ -137,12 +166,23 @@ const successEvents = [
   },
 ];
 
+function emitSessionEvents(
+  session: MockSessionHandle,
+  events: Array<Record<string, unknown>>,
+) {
+  for (const event of events) {
+    for (const subscriber of [...session.subscribers]) subscriber(event);
+  }
+}
+
 beforeEach(() => {
   h.subscribers = [];
   h.scriptedEvents = [...successEvents];
   h.promptImpl = null;
   h.lastConfig = undefined;
   h.lastPrompt = undefined;
+  h.sessions = [];
+  h.nextSessions = [];
   h.createAgentSession.mockClear();
 });
 
@@ -185,6 +225,104 @@ describe("buildSubagentTaskTool", () => {
     expect(phases).toContain("text");
     expect(phases).toContain("done");
     expect(h.disposeSpy).toHaveBeenCalled();
+  });
+
+  it("keeps concurrent inline subagent runs isolated by call id", async () => {
+    let releaseA!: () => void;
+    let releaseB!: () => void;
+    h.nextSessions = [
+      {
+        promptImpl: (session) =>
+          new Promise<void>((resolve) => {
+            releaseA = () => {
+              emitSessionEvents(session, [
+                {
+                  type: "message_update",
+                  assistantMessageEvent: {
+                    type: "text_delta",
+                    delta: "A done",
+                  },
+                },
+                {
+                  type: "agent_end",
+                  messages: [
+                    { role: "assistant", content: [], stopReason: "stop" },
+                  ],
+                },
+              ]);
+              resolve();
+            };
+          }),
+      },
+      {
+        promptImpl: (session) =>
+          new Promise<void>((resolve) => {
+            releaseB = () => {
+              emitSessionEvents(session, [
+                {
+                  type: "message_update",
+                  assistantMessageEvent: {
+                    type: "text_delta",
+                    delta: "B done",
+                  },
+                },
+                {
+                  type: "agent_end",
+                  messages: [
+                    { role: "assistant", content: [], stopReason: "stop" },
+                  ],
+                },
+              ]);
+              resolve();
+            };
+          }),
+      },
+    ];
+    const { state } = makeState({ name: "reviewer", model: "ollama/llama3.3" });
+    const send = vi.fn();
+    const tool = buildSubagentTaskTool(state, { send }, "default");
+
+    const first = execOf(tool)("call-a", {
+      subagent_type: "reviewer",
+      prompt: "first task",
+    });
+    const second = execOf(tool)("call-b", {
+      subagent_type: "reviewer",
+      prompt: "second task",
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(h.sessions).toHaveLength(2);
+    expect(h.sessions[0]?.lastPrompt).toContain("first task");
+    expect(h.sessions[1]?.lastPrompt).toContain("second task");
+
+    releaseB();
+    await expect(second).resolves.toMatchObject({
+      content: [{ type: "text", text: "B done" }],
+      details: { subagent: "reviewer" },
+    });
+    expect(h.sessions[1]?.disposeSpy).toHaveBeenCalledTimes(1);
+    expect(h.sessions[0]?.disposeSpy).not.toHaveBeenCalled();
+
+    releaseA();
+    await expect(first).resolves.toMatchObject({
+      content: [{ type: "text", text: "A done" }],
+      details: { subagent: "reviewer" },
+    });
+    expect(h.sessions[0]?.disposeSpy).toHaveBeenCalledTimes(1);
+
+    const progress = send.mock.calls
+      .map(
+        (c) => c[0] as { type?: string; parentCallId?: string; phase?: string },
+      )
+      .filter((m) => m.type === "subagent_progress");
+    expect(
+      progress.filter((m) => m.parentCallId === "call-a").map((m) => m.phase),
+    ).toEqual(["start", "text", "done"]);
+    expect(
+      progress.filter((m) => m.parentCallId === "call-b").map((m) => m.phase),
+    ).toEqual(["start", "text", "done"]);
   });
 
   it("expands @file references before sending the task to an inline subagent", async () => {

--- a/src/extensions/default-layout/at-mention.test.ts
+++ b/src/extensions/default-layout/at-mention.test.ts
@@ -4,12 +4,46 @@ import {
   atMentionRoot,
   findActiveAtToken,
   formatAtInsertion,
+  formatAtMentionInsertion,
+  isLeadingAtToken,
+  matchAtMentions,
+  matchAtSubagents,
   matchAtFiles,
+  subagentSuggestionsFromFiles,
   type AtFileMatch,
+  type AtSubagentMatch,
 } from "./at-mention";
+import type { SubagentFile } from "../../subagents";
 
 function files(...rels: string[]): AtFileMatch[] {
   return rels.map((rel) => ({ rel, path: `/proj/${rel}` }));
+}
+
+function agent(
+  name: string,
+  description = `${name} helper`,
+  extra: Partial<AtSubagentMatch> = {},
+): AtSubagentMatch {
+  return {
+    kind: "agent",
+    name,
+    description,
+    surface: "inline",
+    ...extra,
+  };
+}
+
+function subagentFile(
+  scope: SubagentFile["scope"],
+  name: string,
+  description: string,
+): SubagentFile {
+  return {
+    scope,
+    name,
+    filePath: `/agents/${name}.md`,
+    content: `---\ndescription: ${description}\n---\nYou help.\n`,
+  };
 }
 
 describe("findActiveAtToken", () => {
@@ -88,7 +122,10 @@ describe("matchAtFiles", () => {
 
   it("returns the walk ordering for an empty query, capped", () => {
     const many = files(
-      ...Array.from({ length: 30 }, (_, i) => `file-${String(i).padStart(2, "0")}.ts`),
+      ...Array.from(
+        { length: 30 },
+        (_, i) => `file-${String(i).padStart(2, "0")}.ts`,
+      ),
     );
     const result = matchAtFiles("", many);
     expect(result).toHaveLength(AT_MATCH_LIMIT);
@@ -107,6 +144,61 @@ describe("matchAtFiles", () => {
   });
 });
 
+describe("subagent mention matching", () => {
+  it("detects when the active token is the leading message token", () => {
+    const leading = findActiveAtToken("   @kimi review", 8);
+    expect(leading).not.toBeNull();
+    expect(isLeadingAtToken("   @kimi review", leading!)).toBe(true);
+
+    const later = findActiveAtToken("hello @kimi", 11);
+    expect(later).not.toBeNull();
+    expect(isLeadingAtToken("hello @kimi", later!)).toBe(false);
+  });
+
+  it("ranks matching subagents by name and description", () => {
+    const result = matchAtSubagents("ki", [
+      agent("reviewer", "checks diffs"),
+      agent("kimi", "moonshot code model"),
+    ]);
+    expect(result.map((m) => m.name)).toEqual(["kimi"]);
+  });
+
+  it("does not suggest agents for file-shaped tokens", () => {
+    expect(matchAtSubagents("reviewer.md", [agent("reviewer")])).toEqual([]);
+    expect(matchAtSubagents("reviewer/check", [agent("reviewer")])).toEqual([]);
+  });
+
+  it("shows agents first only for leading tokens and keeps files elsewhere", () => {
+    const leading = matchAtMentions({
+      query: "ki",
+      files: files("src/kitchen.ts"),
+      subagents: [agent("kimi", "review code")],
+      includeAgents: true,
+    });
+    expect(leading.map((m) => m.kind)).toEqual(["agent", "file"]);
+
+    const midDraft = matchAtMentions({
+      query: "ki",
+      files: files("src/kitchen.ts"),
+      subagents: [agent("kimi", "review code")],
+      includeAgents: false,
+    });
+    expect(midDraft.map((m) => m.kind)).toEqual(["file"]);
+  });
+
+  it("merges user and project subagents with project winning by name", () => {
+    const result = subagentSuggestionsFromFiles([
+      subagentFile("user", "reviewer", "user reviewer"),
+      subagentFile("project", "reviewer", "project reviewer"),
+      subagentFile("user", "kimi", "moonshot model"),
+    ]);
+    expect(result.map((m) => [m.name, m.description])).toEqual([
+      ["kimi", "moonshot model"],
+      ["reviewer", "project reviewer"],
+    ]);
+  });
+});
+
 describe("formatAtInsertion", () => {
   it("inserts plain paths with a trailing space", () => {
     expect(formatAtInsertion("src/App.tsx")).toBe("@src/App.tsx ");
@@ -118,6 +210,22 @@ describe("formatAtInsertion", () => {
 
   it("escapes quotes and backslashes inside quoted paths", () => {
     expect(formatAtInsertion('we"ird file.md')).toBe('@"we\\"ird file.md" ');
+  });
+});
+
+describe("formatAtMentionInsertion", () => {
+  it("formats agent mentions with a trailing space", () => {
+    expect(formatAtMentionInsertion(agent("kimi"))).toBe("@kimi ");
+  });
+
+  it("delegates file suggestions to the file reference formatter", () => {
+    expect(
+      formatAtMentionInsertion({
+        kind: "file",
+        rel: "docs/my file.md",
+        path: "/proj/docs/my file.md",
+      }),
+    ).toBe('@"docs/my file.md" ');
   });
 });
 

--- a/src/extensions/default-layout/at-mention.ts
+++ b/src/extensions/default-layout/at-mention.ts
@@ -1,5 +1,5 @@
 /**
- * Pure helpers for the composer's `@file` completion.
+ * Pure helpers for the composer's `@` completion.
  *
  * The agent bridge already parses `@path` / `@"path with spaces"` tokens
  * out of the prompt and inlines the referenced files as deterministic
@@ -8,11 +8,17 @@
  * `@`-boundary rule (an email's `@` never starts a reference) and the
  * same quoting/escaping rules for paths containing whitespace.
  *
- * IO-free by design — the file list comes from the `useAtMention` hook.
+ * IO-free by design — files and subagents come from the `useAtMention` hook.
  */
 
 import { fuzzyScore } from "./palette-items";
 import { activeWorkspaceCwd } from "../../utils/activeWorkspaceRoot";
+import {
+  isSafeSubagentName,
+  parseSubagentContent,
+  type SubagentFile,
+  type SubagentSurface,
+} from "../../subagents";
 
 export interface AtFileMatch {
   /** Project-relative path — what gets inserted after the `@`. */
@@ -20,6 +26,20 @@ export interface AtFileMatch {
   /** Absolute path on disk (kept for icon resolution / open actions). */
   path: string;
 }
+
+export interface AtSubagentMatch {
+  kind: "agent";
+  name: string;
+  description: string;
+  model?: string;
+  surface: SubagentSurface;
+}
+
+export interface AtFileSuggestion extends AtFileMatch {
+  kind: "file";
+}
+
+export type AtMentionMatch = AtSubagentMatch | AtFileSuggestion;
 
 export interface AtToken {
   /** Text between the `@` and the cursor, leading quote stripped. */
@@ -31,11 +51,13 @@ export interface AtToken {
 }
 
 export interface AtMention extends AtToken {
-  matches: AtFileMatch[];
+  matches: AtMentionMatch[];
 }
 
 /** Upper bound on rendered suggestions; matches quick-open's feel. */
 export const AT_MATCH_LIMIT = 12;
+
+const AGENT_QUERY_RE = /^[A-Za-z0-9_-]*$/;
 
 /**
  * Find the `@token` the cursor is inside, if any. Mirrors the agent
@@ -105,6 +127,87 @@ export function matchAtFiles(
 }
 
 /**
+ * Merge raw subagent files into effective suggestions. User scope loads first,
+ * project scope second, so project definitions override by name exactly like
+ * the bridge loader.
+ */
+export function subagentSuggestionsFromFiles(
+  files: SubagentFile[],
+): AtSubagentMatch[] {
+  const merged = new Map<string, AtSubagentMatch>();
+  for (const file of files) {
+    const name = file.name.trim().toLowerCase();
+    if (!isSafeSubagentName(name)) continue;
+    const parsed = parseSubagentContent(file.content);
+    if (!parsed.fields) continue;
+    merged.set(name, {
+      kind: "agent",
+      name,
+      description: parsed.fields.description,
+      model: parsed.fields.model,
+      surface: parsed.fields.surface,
+    });
+  }
+  return [...merged.values()].sort((a, b) =>
+    a.name === b.name ? 0 : a.name < b.name ? -1 : 1,
+  );
+}
+
+export function isLeadingAtToken(value: string, token: AtToken): boolean {
+  const firstNonSpace = value.search(/\S/);
+  return firstNonSpace >= 0 && token.start === firstNonSpace;
+}
+
+export function matchAtSubagents(
+  query: string,
+  subagents: AtSubagentMatch[],
+  limit: number = AT_MATCH_LIMIT,
+): AtSubagentMatch[] {
+  if (!AGENT_QUERY_RE.test(query)) return [];
+  if (!query) return subagents.slice(0, limit);
+  const normalized = query.toLowerCase();
+  const scored: { agent: AtSubagentMatch; score: number }[] = [];
+  for (const agent of subagents) {
+    const score = Math.max(
+      fuzzyScore(normalized, agent.name) * 1.2,
+      fuzzyScore(normalized, agent.description),
+    );
+    if (score <= 0) continue;
+    scored.push({ agent, score });
+  }
+  scored.sort(
+    (a, b) =>
+      b.score - a.score ||
+      a.agent.name.length - b.agent.name.length ||
+      (a.agent.name < b.agent.name ? -1 : 1),
+  );
+  return scored.slice(0, limit).map((s) => s.agent);
+}
+
+export function matchAtMentions({
+  query,
+  files,
+  subagents,
+  includeAgents,
+  limit = AT_MATCH_LIMIT,
+}: {
+  query: string;
+  files: AtFileMatch[];
+  subagents: AtSubagentMatch[];
+  includeAgents: boolean;
+  limit?: number;
+}): AtMentionMatch[] {
+  const agentMatches = includeAgents
+    ? matchAtSubagents(query, subagents, limit)
+    : [];
+  const remaining = Math.max(0, limit - agentMatches.length);
+  const fileMatches = matchAtFiles(query, files, remaining).map(
+    (file): AtFileSuggestion => ({ kind: "file", ...file }),
+  );
+  return [...agentMatches, ...fileMatches];
+}
+
+/**
  * Format the text that replaces the `@token`. Plain paths insert as
  * `@rel `; anything the agent's unquoted reader would mis-tokenize
  * (whitespace, quotes, backslashes) gets the quoted form with the same
@@ -115,6 +218,12 @@ export function formatAtInsertion(rel: string): string {
   if (!/[\s"'\\]/.test(rel)) return `@${rel} `;
   const escaped = rel.replace(/[\\"]/g, (ch) => `\\${ch}`);
   return `@"${escaped}" `;
+}
+
+export function formatAtMentionInsertion(match: AtMentionMatch): string {
+  return match.kind === "agent"
+    ? `@${match.name} `
+    : formatAtInsertion(match.rel);
 }
 
 /**

--- a/src/extensions/default-layout/at-picker.tsx
+++ b/src/extensions/default-layout/at-picker.tsx
@@ -1,7 +1,7 @@
 import type { Dispatch, RefObject, SetStateAction } from "react";
 import { createPortal } from "react-dom";
 import { FileIcon } from "../../components/file-icon";
-import type { AtFileMatch, AtMention } from "./at-mention";
+import type { AtMention, AtMentionMatch } from "./at-mention";
 import { usePickerAnchor } from "./use-picker-anchor";
 
 interface AtPickerProps {
@@ -9,14 +9,14 @@ interface AtPickerProps {
   atMatch: AtMention | null;
   highlightIdx: number;
   setHighlightIdx: Dispatch<SetStateAction<number>>;
-  onInsert: (match: AtFileMatch) => void;
+  onInsert: (match: AtMentionMatch) => void;
 }
 
 /**
- * `@file` completion menu. Shares the slash picker's chrome (portal +
+ * `@` completion menu. Shares the slash picker's chrome (portal +
  * fixed anchor + `.a2ui-slash-menu` styling) so the two composer
- * popovers look and behave identically; rows render basename-first with
- * the directory dimmed, like quick-open.
+ * popovers look and behave identically. File rows render basename-first
+ * like quick-open; agent rows render as lightweight delegates.
  */
 export function AtPicker({
   anchorRef,
@@ -33,7 +33,7 @@ export function AtPicker({
     <div
       className="a2ui-slash-menu"
       role="listbox"
-      aria-label="File suggestions"
+      aria-label="Mention suggestions"
       style={{
         position: "fixed",
         left: `${menuAnchor.left}px`,
@@ -42,12 +42,10 @@ export function AtPicker({
       }}
     >
       {atMatch.matches.map((m, i) => {
-        const slash = m.rel.lastIndexOf("/");
-        const base = slash >= 0 ? m.rel.slice(slash + 1) : m.rel;
-        const dir = slash >= 0 ? m.rel.slice(0, slash) : "";
+        const key = m.kind === "agent" ? `agent:${m.name}` : `file:${m.rel}`;
         return (
           <div
-            key={m.rel}
+            key={key}
             role="option"
             aria-selected={i === highlightIdx}
             className={
@@ -61,13 +59,53 @@ export function AtPicker({
             }}
             onMouseEnter={() => setHighlightIdx(i)}
           >
-            <FileIcon path={m.rel} isDir={false} size={14} />
-            <span className="a2ui-at-item-name">{base}</span>
-            {dir && <span className="a2ui-at-item-dir">{dir}</span>}
+            {m.kind === "agent" ? (
+              <AgentRow match={m} />
+            ) : (
+              <FileRow match={m} />
+            )}
           </div>
         );
       })}
     </div>,
     document.body,
+  );
+}
+
+function AgentRow({
+  match,
+}: {
+  match: Extract<AtMentionMatch, { kind: "agent" }>;
+}) {
+  const meta =
+    match.surface === "tab" ? "tab" : match.model ? match.model : "agent";
+  return (
+    <>
+      <span className="a2ui-at-agent-mark" aria-hidden="true">
+        @
+      </span>
+      <span className="a2ui-at-item-main">
+        <span className="a2ui-at-item-name">@{match.name}</span>
+        <span className="a2ui-at-item-desc">{match.description}</span>
+      </span>
+      <span className="a2ui-at-item-meta">{meta}</span>
+    </>
+  );
+}
+
+function FileRow({
+  match,
+}: {
+  match: Extract<AtMentionMatch, { kind: "file" }>;
+}) {
+  const slash = match.rel.lastIndexOf("/");
+  const base = slash >= 0 ? match.rel.slice(slash + 1) : match.rel;
+  const dir = slash >= 0 ? match.rel.slice(0, slash) : "";
+  return (
+    <>
+      <FileIcon path={match.rel} isDir={false} size={14} />
+      <span className="a2ui-at-item-name">{base}</span>
+      {dir && <span className="a2ui-at-item-dir">{dir}</span>}
+    </>
   );
 }

--- a/src/extensions/default-layout/chat-input.tsx
+++ b/src/extensions/default-layout/chat-input.tsx
@@ -27,8 +27,8 @@ import { SlashPicker } from "./slash-picker";
 import { AtPicker } from "./at-picker";
 import {
   atMentionRoot,
-  formatAtInsertion,
-  type AtFileMatch,
+  formatAtMentionInsertion,
+  type AtMentionMatch,
 } from "./at-mention";
 import { useAtMention } from "./use-at-mention";
 import { useComposerResize } from "./use-composer-resize";
@@ -222,11 +222,11 @@ export function ChatInput({
     commitDraft(text);
   };
 
-  // Replace the active `@token` with the chosen file reference and park
+  // Replace the active `@token` with the chosen mention and park
   // the caret after the trailing space so typing continues naturally.
-  const insertAtFile = (m: AtFileMatch) => {
+  const insertAtMention = (m: AtMentionMatch) => {
     if (!atMatch) return;
-    const insertion = formatAtInsertion(m.rel);
+    const insertion = formatAtMentionInsertion(m);
     const next =
       value.slice(0, atMatch.start) + insertion + value.slice(atMatch.end);
     const nextCursor = atMatch.start + insertion.length;
@@ -341,18 +341,19 @@ export function ChatInput({
       if (e.key === "Tab") {
         e.preventDefault();
         const match = list[atHighlightIdx] ?? list[0];
-        if (match) insertAtFile(match);
+        if (match) insertAtMention(match);
         return;
       }
       if (e.key === "Enter" && !e.shiftKey) {
-        // A hand-typed exact reference sends the message — same bypass
-        // the slash picker gives an exactly-typed command. Partial
-        // tokens complete instead of submitting.
-        const exact = list.some((m) => m.rel === atMatch.query);
-        if (!exact) {
+        const match = list[atHighlightIdx] ?? list[0];
+        // Exact file references submit like before. Agent mentions complete
+        // first so `@kimi` becomes `@kimi ` before a later Enter sends.
+        const exactFile = list.some(
+          (m) => m.kind === "file" && m.rel === atMatch.query,
+        );
+        if (match?.kind === "agent" || !exactFile) {
           e.preventDefault();
-          const match = list[atHighlightIdx] ?? list[0];
-          if (match) insertAtFile(match);
+          if (match) insertAtMention(match);
           return;
         }
       }
@@ -419,7 +420,7 @@ export function ChatInput({
         atMatch={atMatch}
         highlightIdx={atHighlightIdx}
         setHighlightIdx={setAtHighlightIdx}
-        onInsert={insertAtFile}
+        onInsert={insertAtMention}
       />
       {busy && (
         <div className="a2ui-chat-input-hint">

--- a/src/extensions/default-layout/chat.test.tsx
+++ b/src/extensions/default-layout/chat.test.tsx
@@ -6,6 +6,7 @@ import {
   fireEvent,
   render,
   screen,
+  waitFor,
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -957,14 +958,23 @@ describe("ChatInput", () => {
   });
 });
 
-describe("ChatInput @file completion", () => {
+describe("ChatInput @ completion", () => {
   const WALK = ["/proj/src/App.tsx", "/proj/src/main.tsx", "/proj/README.md"];
+  const KIMI = {
+    scope: "user",
+    name: "kimi",
+    filePath: "/agents/kimi.md",
+    content:
+      "---\ndescription: Reviews code with Moonshot Kimi.\nmodel: openrouter/moonshotai/kimi-k2.7-code\n---\nYou review code.\n",
+  };
 
   beforeEach(() => {
     invokeMock.mockImplementation((cmd: string) =>
       cmd === "fs_walk_project"
         ? Promise.resolve(WALK)
-        : Promise.reject(new Error(`invoke not mocked: ${cmd}`)),
+        : cmd === "subagents_list"
+          ? Promise.resolve([])
+          : Promise.reject(new Error(`invoke not mocked: ${cmd}`)),
     );
   });
 
@@ -989,6 +999,66 @@ describe("ChatInput @file completion", () => {
     expect(invokeMock).toHaveBeenCalledWith("fs_walk_project", {
       root: "/proj",
     });
+  });
+
+  it("offers leading subagent suggestions and inserts one on Tab", async () => {
+    invokeMock.mockImplementation((cmd: string) =>
+      cmd === "fs_walk_project"
+        ? Promise.resolve(WALK)
+        : cmd === "subagents_list"
+          ? Promise.resolve([KIMI])
+          : Promise.reject(new Error(`invoke not mocked: ${cmd}`)),
+    );
+    const { input } = renderWithProject();
+
+    fireEvent.change(input, { target: { value: "@ki" } });
+
+    expect(await screen.findByText("@kimi")).toBeTruthy();
+    expect(screen.getByText("Reviews code with Moonshot Kimi.")).toBeTruthy();
+    expect(invokeMock).toHaveBeenCalledWith("subagents_list", {
+      projectRoot: "/proj",
+    });
+
+    fireEvent.keyDown(input, { key: "Tab" });
+    expect((input as HTMLTextAreaElement).value).toBe("@kimi ");
+  });
+
+  it("does not offer subagents for mid-draft @tokens", async () => {
+    invokeMock.mockImplementation((cmd: string) =>
+      cmd === "fs_walk_project"
+        ? Promise.resolve(WALK)
+        : cmd === "subagents_list"
+          ? Promise.resolve([KIMI])
+          : Promise.reject(new Error(`invoke not mocked: ${cmd}`)),
+    );
+    const { input } = renderWithProject();
+
+    fireEvent.change(input, { target: { value: "hello @ki" } });
+
+    await waitFor(() =>
+      expect(invokeMock).toHaveBeenCalledWith("subagents_list", {
+        projectRoot: "/proj",
+      }),
+    );
+    expect(screen.queryByText("@kimi")).toBeNull();
+  });
+
+  it("completes an exact leading subagent on Enter before submitting", async () => {
+    invokeMock.mockImplementation((cmd: string) =>
+      cmd === "fs_walk_project"
+        ? Promise.resolve(WALK)
+        : cmd === "subagents_list"
+          ? Promise.resolve([KIMI])
+          : Promise.reject(new Error(`invoke not mocked: ${cmd}`)),
+    );
+    const { input, onEvent } = renderWithProject();
+
+    fireEvent.change(input, { target: { value: "@kimi" } });
+    await screen.findByText("@kimi");
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect((input as HTMLTextAreaElement).value).toBe("@kimi ");
+    expect(onEvent).not.toHaveBeenCalledWith("submit", expect.any(Object));
   });
 
   it("inserts the highlighted file on Tab", async () => {

--- a/src/extensions/default-layout/dashboard/task-launcher.test.tsx
+++ b/src/extensions/default-layout/dashboard/task-launcher.test.tsx
@@ -94,7 +94,13 @@ describe("TaskLauncher", () => {
   });
 
   it("offers @file completions rooted at the project and inserts on Tab", async () => {
-    invoke.mockResolvedValue(["/repo/aethon/src/App.tsx"]);
+    invoke.mockImplementation((cmd: string) =>
+      cmd === "fs_walk_project"
+        ? Promise.resolve(["/repo/aethon/src/App.tsx"])
+        : cmd === "subagents_list"
+          ? Promise.resolve([])
+          : Promise.reject(new Error(`invoke not mocked: ${cmd}`)),
+    );
     render(
       <TaskLauncher
         component={launcher({
@@ -115,6 +121,44 @@ describe("TaskLauncher", () => {
 
     fireEvent.keyDown(prompt, { key: "Tab" });
     expect((prompt as HTMLTextAreaElement).value).toBe("@src/App.tsx ");
+  });
+
+  it("offers leading @agent completions rooted at the project", async () => {
+    invoke.mockImplementation((cmd: string) =>
+      cmd === "fs_walk_project"
+        ? Promise.resolve([])
+        : cmd === "subagents_list"
+          ? Promise.resolve([
+              {
+                scope: "project",
+                name: "kimi",
+                filePath: "/repo/aethon/.aethon/agents/kimi.md",
+                content:
+                  "---\ndescription: Reviews code with Kimi.\nsurface: tab\n---\nYou review code.\n",
+              },
+            ])
+          : Promise.reject(new Error(`invoke not mocked: ${cmd}`)),
+    );
+    render(
+      <TaskLauncher
+        component={launcher({
+          project: { id: "p1", label: "aethon", path: "/repo/aethon" },
+        })}
+        state={{}}
+        onEvent={vi.fn()}
+      />,
+    );
+
+    const prompt = screen.getByLabelText("Task prompt");
+    fireEvent.change(prompt, { target: { value: "@ki" } });
+
+    await screen.findByText("@kimi");
+    expect(invoke).toHaveBeenCalledWith("subagents_list", {
+      projectRoot: "/repo/aethon",
+    });
+
+    fireEvent.keyDown(prompt, { key: "Tab" });
+    expect((prompt as HTMLTextAreaElement).value).toBe("@kimi ");
   });
 
   it("allows a new workspace session with an automatic branch", async () => {

--- a/src/extensions/default-layout/dashboard/task-launcher.tsx
+++ b/src/extensions/default-layout/dashboard/task-launcher.tsx
@@ -25,7 +25,7 @@ import { saveClipboardImageAttachment } from "../../../utils/imageAttachments";
 import { ImageAttachmentImage } from "../image-attachment-image";
 import { ImageLightbox } from "../image-lightbox";
 import { AtPicker } from "../at-picker";
-import { formatAtInsertion, type AtFileMatch } from "../at-mention";
+import { formatAtMentionInsertion, type AtMentionMatch } from "../at-mention";
 import { useAtMention } from "../use-at-mention";
 
 interface ProjectLite {
@@ -101,7 +101,8 @@ export function TaskLauncher({
       project: resolveOrInline<ProjectLite>(props?.project, state),
       otherProjects:
         resolveOrInline<ProjectLite[]>(props?.otherProjects, state) ?? [],
-      workspaces: resolveOrInline<WorkspaceLite[]>(props?.workspaces, state) ?? [],
+      workspaces:
+        resolveOrInline<WorkspaceLite[]>(props?.workspaces, state) ?? [],
       activeWorkspaceId:
         resolveOrInline<string>(props?.activeWorkspaceId, state) ?? null,
     }),
@@ -131,7 +132,10 @@ export function TaskLauncher({
         (m): m is { id: unknown; label?: unknown } =>
           typeof m === "object" && m !== null,
       )
-      .map((m) => ({ id: String(m.id ?? ""), label: String(m.label ?? m.id ?? "") }))
+      .map((m) => ({
+        id: String(m.id ?? ""),
+        label: String(m.label ?? m.id ?? ""),
+      }))
       .filter((m) => m.id.length > 0);
   }, [state]);
   const defaultModelId = useMemo(() => {
@@ -198,7 +202,7 @@ export function TaskLauncher({
     el.style.height = `${next}px`;
   }, [promptText]);
 
-  // `@file` completion — same picker as the chat composer, rooted at
+  // `@` completion — same picker as the chat composer, rooted at
   // whatever the task will actually run against: the selected existing
   // workspace, else the project root (a "+ New workspace" forks from the
   // project, so its files are the right suggestions too).
@@ -220,10 +224,10 @@ export function TaskLauncher({
     enabled: !submitting,
   });
 
-  const insertAtFile = useCallback(
-    (m: AtFileMatch) => {
+  const insertAtMention = useCallback(
+    (m: AtMentionMatch) => {
       if (!atMatch) return;
-      const insertion = formatAtInsertion(m.rel);
+      const insertion = formatAtMentionInsertion(m);
       const next =
         promptText.slice(0, atMatch.start) +
         insertion +
@@ -305,16 +309,19 @@ export function TaskLauncher({
       if (e.key === "Tab") {
         e.preventDefault();
         const match = list[atHighlightIdx] ?? list[0];
-        if (match) insertAtFile(match);
+        if (match) insertAtMention(match);
         return;
       }
       if (e.key === "Enter" && !e.shiftKey) {
-        // A hand-typed exact reference submits; partial tokens complete.
-        const exact = list.some((m) => m.rel === atMatch.query);
-        if (!exact) {
+        const match = list[atHighlightIdx] ?? list[0];
+        // A hand-typed exact file reference submits; partial tokens and agent
+        // mentions complete first.
+        const exactFile = list.some(
+          (m) => m.kind === "file" && m.rel === atMatch.query,
+        );
+        if (match?.kind === "agent" || !exactFile) {
           e.preventDefault();
-          const match = list[atHighlightIdx] ?? list[0];
-          if (match) insertAtFile(match);
+          if (match) insertAtMention(match);
           return;
         }
       }
@@ -377,7 +384,7 @@ export function TaskLauncher({
         className="a2ui-task-launcher-input"
         placeholder={
           props?.placeholder ??
-          `Start a task in ${data.project.label}… use @path for file context`
+          `Start a task in ${data.project.label}… use @agent or @path`
         }
         value={promptText}
         rows={3}
@@ -397,7 +404,7 @@ export function TaskLauncher({
         atMatch={atMatch}
         highlightIdx={atHighlightIdx}
         setHighlightIdx={setAtHighlightIdx}
-        onInsert={insertAtFile}
+        onInsert={insertAtMention}
       />
       {attachments.length > 0 && (
         <div className="a2ui-task-launcher-attachments">
@@ -649,9 +656,7 @@ function ChipMenu({
             />
           )}
           {filtered.length === 0 ? (
-            <div className="a2ui-task-launcher-chip-menu-empty">
-              no matches
-            </div>
+            <div className="a2ui-task-launcher-chip-menu-empty">no matches</div>
           ) : (
             filtered.map((item) => (
               <button

--- a/src/extensions/default-layout/use-at-mention.ts
+++ b/src/extensions/default-layout/use-at-mention.ts
@@ -2,23 +2,27 @@ import { useEffect, useMemo, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import {
   findActiveAtToken,
-  matchAtFiles,
+  isLeadingAtToken,
+  matchAtMentions,
   type AtFileMatch,
   type AtMention,
+  type AtSubagentMatch,
+  subagentSuggestionsFromFiles,
 } from "./at-mention";
+import type { SubagentFile } from "../../subagents";
 
 /**
- * Live `@file` completion state for a composer. Modeled on
+ * Live `@` completion state for a composer. Modeled on
  * `useSlashMatching`: the caller feeds the draft + cursor + the root the
  * prompt will resolve against (`atMentionRoot(state)` for the chat
  * composer, the targeted project/workspace path for the task launcher),
  * and gets back the current match (or null) plus highlight/dismiss
  * controls.
  *
- * The file list comes from `fs_walk_project` — the same backend as the
- * Cmd+P quick-open. A walk fires each time an `@token` becomes active
- * (cheap: capped + excluded-dirs pruned Rust walk), while the previous
- * list keeps serving matches so suggestions never flicker out mid-typing.
+ * File matches come from `fs_walk_project` and agent matches come from
+ * `subagents_list`. A walk fires each time an `@token` becomes active, while
+ * the previous lists keep serving matches so suggestions never flicker out
+ * mid-typing.
  */
 export function useAtMention({
   value,
@@ -36,6 +40,7 @@ export function useAtMention({
     [enabled, value, cursor],
   );
   const [files, setFiles] = useState<AtFileMatch[]>([]);
+  const [subagents, setSubagents] = useState<AtSubagentMatch[]>([]);
   const [dismissedDraft, setDismissedDraft] = useState<string | null>(null);
 
   useEffect(() => {
@@ -47,24 +52,33 @@ export function useAtMention({
 
   const tokenActive = token !== null;
   useEffect(() => {
-    if (!tokenActive || !root) return;
+    if (!tokenActive) return;
     let cancelled = false;
-    invoke<string[]>("fs_walk_project", { root })
-      .then((paths) => {
-        if (cancelled) return;
-        const normalized = root.replace(/\/+$/, "");
-        setFiles(
-          paths.map((path) => ({
-            path,
-            rel: path.startsWith(normalized + "/")
-              ? path.slice(normalized.length + 1)
-              : path,
-          })),
-        );
+    if (root) {
+      invoke<string[]>("fs_walk_project", { root })
+        .then((paths) => {
+          if (cancelled) return;
+          const normalized = root.replace(/\/+$/, "");
+          setFiles(
+            paths.map((path) => ({
+              path,
+              rel: path.startsWith(normalized + "/")
+                ? path.slice(normalized.length + 1)
+                : path,
+            })),
+          );
+        })
+        .catch(() => {
+          // Walk failed (project gone, permission) — degrade to no file rows.
+          if (!cancelled) setFiles([]);
+        });
+    }
+    invoke<SubagentFile[]>("subagents_list", { projectRoot: root ?? null })
+      .then((raw) => {
+        if (!cancelled) setSubagents(subagentSuggestionsFromFiles(raw));
       })
       .catch(() => {
-        // Walk failed (project gone, permission) — degrade to no picker.
-        if (!cancelled) setFiles([]);
+        if (!cancelled) setSubagents([]);
       });
     return () => {
       cancelled = true;
@@ -74,9 +88,14 @@ export function useAtMention({
   const atMatch: AtMention | null = useMemo(() => {
     if (!token) return null;
     if (dismissedDraft !== null && value === dismissedDraft) return null;
-    const matches = matchAtFiles(token.query, files);
+    const matches = matchAtMentions({
+      query: token.query,
+      files: root ? files : [],
+      subagents,
+      includeAgents: isLeadingAtToken(value, token),
+    });
     return matches.length > 0 ? { ...token, matches } : null;
-  }, [token, files, value, dismissedDraft]);
+  }, [token, root, files, subagents, value, dismissedDraft]);
 
   const [highlightIdx, setHighlightIdx] = useState(0);
   useEffect(() => {

--- a/src/extensions/default-layout/workstation.a2ui.json
+++ b/src/extensions/default-layout/workstation.a2ui.json
@@ -211,7 +211,7 @@
               "type": "chat-input",
               "props": {
                 "value": { "$ref": "/draft" },
-                "placeholder": "Message Aethon… (@file for file context, / for commands)",
+                "placeholder": "Message Aethon… (@agent to delegate, @file for context, / for commands)",
                 "disabled": { "$ref": "/waiting" },
                 "queueCount": { "$ref": "/queueCount" },
                 "commands": { "$ref": "/slashCommands" },

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -3725,8 +3725,7 @@ body.ae-resizing-composer * {
   color: var(--text-dim);
 }
 
-/* @file completion rows — same menu chrome as the slash picker, but
-   single-line file rows: icon, basename, dimmed directory. */
+/* @ mention rows — same menu chrome as the slash picker. */
 .a2ui-at-item {
   flex-wrap: nowrap;
   align-items: center;
@@ -3740,6 +3739,48 @@ body.ae-resizing-composer * {
 .a2ui-at-item-name {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   color: var(--text);
+  white-space: nowrap;
+}
+
+.a2ui-at-agent-mark {
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 6px;
+  background: var(--accent-hover-tint);
+  color: var(--accent);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: var(--chrome-text-compact);
+  font-weight: 700;
+}
+
+.a2ui-at-item-main {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.a2ui-at-item-desc {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-dim);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.a2ui-at-item-meta {
+  flex: none;
+  max-width: 38%;
+  overflow: hidden;
+  color: var(--text-dim);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: var(--chrome-text-muted);
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 


### PR DESCRIPTION
## Summary

Adds first-class `@agent` mention autocomplete alongside the existing `@file` picker.

- Shows subagent suggestions for leading `@` tokens, ranked before file matches.
- Keeps mid-draft `@` behavior file-only so autocomplete matches the existing delegation parser.
- Shares the new union mention model between the main composer and dashboard task launcher.
- Preserves exact `@file` submit behavior while making exact `@agent` complete to `@name ` first.
- Adds regression coverage for two concurrent inline subagent task runs with independent sessions and progress call IDs.

## Why

The app could already delegate with `@kimi hello`, but the composer only autocompleted files. This makes configured subagents discoverable in the same first-class picker without changing the runtime `task` tool contract.

## Review

Codex peer review (`codex review --base main`) found no blocking or actionable regressions. The reviewer also reran focused tests, typecheck, lint, and full Vitest during review.

Claude peer review was attempted first, but the local CLI review path stalled and `ultrareview` was unavailable, so this PR uses Codex peer review as requested.

## Validation

- `bunx vitest run src/extensions/default-layout/at-mention.test.ts src/extensions/default-layout/chat.test.tsx src/extensions/default-layout/dashboard/task-launcher.test.tsx agent/subagents/task-tool.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bunx vitest run`
- Live Aethon dev webview check: typed `@ki`, verified `@kimi` appears first with file rows below, no clipping, then cleared the draft.
