### PR TITLE
feat(voice): LFM2-Audio third voice mode (ASR + TTS + hands-free conversation)

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -293,22 +293,33 @@ version:sync` propagates the version to `tauri.conf.json`,
 - **LFM2-Audio voice runner.** The LFM2-Audio voice provider shells out
   to the prebuilt `llama-lfm2-audio` runner (a binary plus its
   `@loader_path` dylibs). It is **not** committed — `src-tauri/binaries/`
-  is gitignored and the runner is fetched at build time by
-  `scripts/stage-lfm2-runner.sh` (per-platform zip from Liquid AI's GGUF
-  repo). `build-app` stages it, then copies the directory into
-  `Aethon.app/Contents/MacOS/lfm2-audio/`, where `resolve_lfm2_binary`
-  (`src-tauri/src/voice/lfm2.rs`) finds it. `verify-bundle.sh` scans the
-  runner for `/nix/store` install_names alongside the main binary — the
-  upstream runner is system-linked, so a leak means a Nix build was
-  staged by mistake. In dev, `scripts/macos-dev-app-runner.sh` mirrors the
-  same directory into the dev `.app`; or point `AETHON_LFM2_AUDIO_BIN` at
-  a runner binary directly. **Signed/notarized caveat:** the nested runner
-  must be signed and present before notarization. `build-app` re-signs the
-  runner + app when `APPLE_SIGNING_IDENTITY` is set, but because it adds
-  the runner after `cargo tauri build` runs, a fully notarized release
-  must be validated on a signed build (the unsigned local path is verified
-  by `verify-bundle.sh`). The model GGUFs themselves are downloaded
-  on-demand into `~/.aethon/models/voice/` and are never bundled.
+  is gitignored and the runner is fetched at build time. Staging and
+  bundling go through Tauri's own build inputs so every build path ships
+  it (including the GitHub workflows that build via `tauri-action` →
+  `bun tauri build`, not the devshell `build-app`):
+  - `tauri.conf.json` `build.beforeBuildCommand` runs
+    `scripts/stage-lfm2-runner.sh` before the frontend build. The script
+    downloads the per-platform runner zip from Liquid AI's GGUF repo
+    **pinned to a commit + verified against a checked-in SHA-256**, then
+    unpacks it to `src-tauri/binaries/lfm2-audio/`. Unsupported platforms
+    (e.g. Windows) skip gracefully. Only `macos-aarch64` is built for
+    release/nightly today.
+  - `tauri.conf.json` `bundle.resources` includes `binaries/lfm2-audio`,
+    so Tauri copies it into `Aethon.app/Contents/Resources/lfm2-audio/`
+    and **signs + notarizes it as part of the bundle** before producing
+    the DMG/updater artifacts. `resolve_lfm2_binary`
+    (`src-tauri/src/voice/lfm2.rs`) finds it there at runtime.
+  - `verify-bundle.sh` scans the runner (binary + dylibs) for
+    `/nix/store` install_names alongside the main binary — the upstream
+    runner is system-linked, so a leak means a Nix build was staged by
+    mistake.
+  - In dev, `scripts/macos-dev-app-runner.sh` mirrors the directory into
+    the dev `.app`'s `Resources/`; or point `AETHON_LFM2_AUDIO_BIN` at a
+    runner binary directly.
+  - Bumping the runner: update `hf_rev` and the per-platform SHA-256s in
+    `scripts/stage-lfm2-runner.sh` together.
+  The model GGUFs themselves are downloaded on-demand into
+  `~/.aethon/models/voice/` and are never bundled.
 - **Boot-probation rollback.** Each in-app update first copies the
   installed `.app` bundle to `~/.aethon/updates/previous/<version>/`
   and writes a sentinel to `~/.aethon/boot-probation.json`. If the

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -290,6 +290,25 @@ version:sync` propagates the version to `tauri.conf.json`,
   resolves endpoints per channel at runtime, so the bundled
   `tauri.conf.json` endpoint only sets the default for the very
   first launch.
+- **LFM2-Audio voice runner.** The LFM2-Audio voice provider shells out
+  to the prebuilt `llama-lfm2-audio` runner (a binary plus its
+  `@loader_path` dylibs). It is **not** committed — `src-tauri/binaries/`
+  is gitignored and the runner is fetched at build time by
+  `scripts/stage-lfm2-runner.sh` (per-platform zip from Liquid AI's GGUF
+  repo). `build-app` stages it, then copies the directory into
+  `Aethon.app/Contents/MacOS/lfm2-audio/`, where `resolve_lfm2_binary`
+  (`src-tauri/src/voice/lfm2.rs`) finds it. `verify-bundle.sh` scans the
+  runner for `/nix/store` install_names alongside the main binary — the
+  upstream runner is system-linked, so a leak means a Nix build was
+  staged by mistake. In dev, `scripts/macos-dev-app-runner.sh` mirrors the
+  same directory into the dev `.app`; or point `AETHON_LFM2_AUDIO_BIN` at
+  a runner binary directly. **Signed/notarized caveat:** the nested runner
+  must be signed and present before notarization. `build-app` re-signs the
+  runner + app when `APPLE_SIGNING_IDENTITY` is set, but because it adds
+  the runner after `cargo tauri build` runs, a fully notarized release
+  must be validated on a signed build (the unsigned local path is verified
+  by `verify-bundle.sh`). The model GGUFs themselves are downloaded
+  on-demand into `~/.aethon/models/voice/` and are never bundled.
 - **Boot-probation rollback.** Each in-app update first copies the
   installed `.app` bundle to `~/.aethon/updates/previous/<version>/`
   and writes a sentinel to `~/.aethon/boot-probation.json`. If the

--- a/flake.nix
+++ b/flake.nix
@@ -311,6 +311,11 @@
                   else
                     echo "==> .secrets/signing.env not present; building unsigned"
                   fi
+                  # Stage the prebuilt LFM2-Audio runner so the bundler can
+                  # ship it. Best-effort: voice is optional, and a missing
+                  # runner only disables that one provider.
+                  ./scripts/stage-lfm2-runner.sh || \
+                    echo "build-app: LFM2-Audio runner not staged (voice provider will be unavailable)"
                   # Tauri's bundler exits non-zero on a missing
                   # TAURI_SIGNING_PRIVATE_KEY even though the .app has
                   # already been written. For local unsigned builds we
@@ -321,6 +326,25 @@
                   bundle=src-tauri/target/release/bundle/macos/Aethon.app
                   if [ $status -ne 0 ] && [ ! -d "$bundle" ]; then
                     exit $status
+                  fi
+                  # Place the runner (binary + @loader_path dylibs) beside the
+                  # executable, where resolve_lfm2_binary finds it. NOTE: for a
+                  # SIGNED + notarized release the nested runner must be signed
+                  # too — re-sign it and the app here. A notarized build that
+                  # adds the runner after `cargo tauri build` notarizes would
+                  # invalidate the ticket, so signed pipelines should validate
+                  # this on a real signed build (see RELEASING.md).
+                  if [ -d src-tauri/binaries/lfm2-audio ] && [ -d "$bundle" ]; then
+                    rm -rf "$bundle/Contents/MacOS/lfm2-audio"
+                    cp -R src-tauri/binaries/lfm2-audio "$bundle/Contents/MacOS/lfm2-audio"
+                    if [ -n "''${APPLE_SIGNING_IDENTITY:-}" ] && [ "$(uname -s)" = "Darwin" ]; then
+                      find "$bundle/Contents/MacOS/lfm2-audio" -type f \
+                        \( -name '*.dylib' -o -name '*.so' -o -name 'llama-lfm2-audio' \) \
+                        -exec codesign --force --options runtime --timestamp \
+                        --sign "$APPLE_SIGNING_IDENTITY" {} + || true
+                      codesign --force --options runtime --timestamp \
+                        --sign "$APPLE_SIGNING_IDENTITY" "$bundle" || true
+                    fi
                   fi
                   # Belt-and-braces: scan the bundle's load commands for any
                   # /nix/store path. dyld rejects those on non-builder Macs

--- a/flake.nix
+++ b/flake.nix
@@ -311,11 +311,11 @@
                   else
                     echo "==> .secrets/signing.env not present; building unsigned"
                   fi
-                  # Stage the prebuilt LFM2-Audio runner so the bundler can
-                  # ship it. Best-effort: voice is optional, and a missing
-                  # runner only disables that one provider.
-                  ./scripts/stage-lfm2-runner.sh || \
-                    echo "build-app: LFM2-Audio runner not staged (voice provider will be unavailable)"
+                  # The LFM2-Audio runner is staged by tauri.conf's
+                  # `beforeBuildCommand` (scripts/stage-lfm2-runner.sh) and
+                  # bundled via `resources`, so Tauri packages + signs it into
+                  # the .app / DMG / updater itself — no post-build copy.
+                  #
                   # Tauri's bundler exits non-zero on a missing
                   # TAURI_SIGNING_PRIVATE_KEY even though the .app has
                   # already been written. For local unsigned builds we
@@ -326,25 +326,6 @@
                   bundle=src-tauri/target/release/bundle/macos/Aethon.app
                   if [ $status -ne 0 ] && [ ! -d "$bundle" ]; then
                     exit $status
-                  fi
-                  # Place the runner (binary + @loader_path dylibs) beside the
-                  # executable, where resolve_lfm2_binary finds it. NOTE: for a
-                  # SIGNED + notarized release the nested runner must be signed
-                  # too — re-sign it and the app here. A notarized build that
-                  # adds the runner after `cargo tauri build` notarizes would
-                  # invalidate the ticket, so signed pipelines should validate
-                  # this on a real signed build (see RELEASING.md).
-                  if [ -d src-tauri/binaries/lfm2-audio ] && [ -d "$bundle" ]; then
-                    rm -rf "$bundle/Contents/MacOS/lfm2-audio"
-                    cp -R src-tauri/binaries/lfm2-audio "$bundle/Contents/MacOS/lfm2-audio"
-                    if [ -n "''${APPLE_SIGNING_IDENTITY:-}" ] && [ "$(uname -s)" = "Darwin" ]; then
-                      find "$bundle/Contents/MacOS/lfm2-audio" -type f \
-                        \( -name '*.dylib' -o -name '*.so' -o -name 'llama-lfm2-audio' \) \
-                        -exec codesign --force --options runtime --timestamp \
-                        --sign "$APPLE_SIGNING_IDENTITY" {} + || true
-                      codesign --force --options runtime --timestamp \
-                        --sign "$APPLE_SIGNING_IDENTITY" "$bundle" || true
-                    fi
                   fi
                   # Belt-and-braces: scan the bundle's load commands for any
                   # /nix/store path. dyld rejects those on non-builder Macs

--- a/scripts/macos-dev-app-runner.sh
+++ b/scripts/macos-dev-app-runner.sh
@@ -197,12 +197,13 @@ if [ -n "$host_triple" ] && [ -d "$staged_dir" ]; then
     echo "▸ Mirrored pi/package.json → Resources/pi/"
   fi
 
-  # The LFM2-Audio runner is a directory (binary + @loader_path dylibs), so it
-  # is mirrored whole next to the executable where resolve_lfm2_binary finds it.
+  # The LFM2-Audio runner is a directory (binary + @loader_path dylibs),
+  # bundled via Tauri `resources` → Contents/Resources/lfm2-audio/. Mirror it
+  # to the same place so the dev .app resolves it like a release bundle.
   if [ -d "$staged_dir/lfm2-audio" ]; then
-    rm -rf "$macos_dir/lfm2-audio"
-    cp -R "$staged_dir/lfm2-audio" "$macos_dir/lfm2-audio"
-    echo "▸ Mirrored lfm2-audio runner → MacOS/lfm2-audio/"
+    rm -rf "$resources_dir/lfm2-audio"
+    cp -R "$staged_dir/lfm2-audio" "$resources_dir/lfm2-audio"
+    echo "▸ Mirrored lfm2-audio runner → Resources/lfm2-audio/"
   fi
 fi
 

--- a/scripts/macos-dev-app-runner.sh
+++ b/scripts/macos-dev-app-runner.sh
@@ -196,6 +196,14 @@ if [ -n "$host_triple" ] && [ -d "$staged_dir" ]; then
     cp "$staged_dir/pi/package.json" "$resource_pi_dir/package.json"
     echo "▸ Mirrored pi/package.json → Resources/pi/"
   fi
+
+  # The LFM2-Audio runner is a directory (binary + @loader_path dylibs), so it
+  # is mirrored whole next to the executable where resolve_lfm2_binary finds it.
+  if [ -d "$staged_dir/lfm2-audio" ]; then
+    rm -rf "$macos_dir/lfm2-audio"
+    cp -R "$staged_dir/lfm2-audio" "$macos_dir/lfm2-audio"
+    echo "▸ Mirrored lfm2-audio runner → MacOS/lfm2-audio/"
+  fi
 fi
 
 cat >"$contents_dir/Info.plist" <<'PLIST'

--- a/scripts/stage-lfm2-runner.sh
+++ b/scripts/stage-lfm2-runner.sh
@@ -2,11 +2,16 @@
 # Stage the prebuilt `llama-lfm2-audio` runner (binary + its @loader_path
 # dylibs) into src-tauri/binaries/lfm2-audio/ for the LFM2-Audio voice provider.
 #
-# The runner ships inside Liquid AI's GGUF repo as a per-platform zip. We treat
-# it like the other staged binaries (src-tauri/binaries/ is gitignored, fetched
-# at build time, never committed). The release bundle and the dev-app mirror
-# copy this directory next to the executable, where `resolve_lfm2_binary`
-# (src-tauri/src/voice/lfm2.rs) finds it.
+# The runner ships inside Liquid AI's GGUF repo as a per-platform zip, pinned
+# here to a known commit + SHA-256 so a release machine can't silently ship a
+# different binary. It is treated like the other staged binaries
+# (src-tauri/binaries/ is gitignored, fetched at build time, never committed).
+# `beforeBuildCommand` stages it; Tauri bundles it via `resources` (so it is
+# packaged + signed/notarized); `resolve_lfm2_binary` (src-tauri/src/voice/
+# lfm2.rs) finds it at runtime.
+#
+# Unsupported platforms (e.g. Windows, where there is no prebuilt runner) skip
+# gracefully so the build proceeds without the voice provider.
 #
 # Usage: scripts/stage-lfm2-runner.sh [--force]
 set -euo pipefail
@@ -14,6 +19,8 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 dest="$repo_root/src-tauri/binaries/lfm2-audio"
 hf_repo="LiquidAI/LFM2-Audio-1.5B-GGUF"
+# Pinned revision of the GGUF repo. Bump together with the SHA-256s below.
+hf_rev="5a54beabc49a8abcd158a9ea86516fa4ae82dfc9"
 
 os="$(uname -s)"
 arch="$(uname -m)"
@@ -21,18 +28,21 @@ case "$os/$arch" in
   Darwin/arm64)
     runner="runners/macos-arm64/lfm2-audio-macos-arm64.zip"
     inner="lfm2-audio-macos-arm64"
+    sha256="f225cacaa98c0e2a32cb3bb9ab2d31f5c00868360a8d4ce0a711c822a3c9a744"
     ;;
   Linux/x86_64)
     runner="runners/ubuntu-x64/lfm2-audio-ubuntu-x64.zip"
     inner="lfm2-audio-ubuntu-x64"
+    sha256="60172bb90804b76bf249cf0ba71da40b12b5c8dd531f40d37f4f24b49e712ddf"
     ;;
   Linux/aarch64)
     runner="runners/ubuntu-arm64/lfm2-audio-ubuntu-arm64.zip"
     inner="lfm2-audio-ubuntu-arm64"
+    sha256="2f2ff9c757dee96a9e191aec10eb5616dd9691d858125f8fb7b43847fab17ac4"
     ;;
   *)
-    echo "stage-lfm2-runner: unsupported platform $os/$arch" >&2
-    exit 1
+    echo "stage-lfm2-runner: no prebuilt runner for $os/$arch; skipping (voice provider unavailable)"
+    exit 0
     ;;
 esac
 
@@ -45,13 +55,21 @@ fi
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
-url="https://huggingface.co/$hf_repo/resolve/main/$runner"
-echo "stage-lfm2-runner: downloading $runner ..."
+url="https://huggingface.co/$hf_repo/resolve/$hf_rev/$runner"
+echo "stage-lfm2-runner: downloading $runner @ ${hf_rev:0:12} ..."
 curl -fL --retry 3 -o "$tmp/runner.zip" "$url"
-unzip -q -o "$tmp/runner.zip" -d "$tmp/unzipped"
 
+actual="$(shasum -a 256 "$tmp/runner.zip" | awk '{print $1}')"
+if [ "$actual" != "$sha256" ]; then
+  echo "stage-lfm2-runner: checksum mismatch for $runner" >&2
+  echo "  expected $sha256" >&2
+  echo "  actual   $actual" >&2
+  exit 1
+fi
+
+unzip -q -o "$tmp/runner.zip" -d "$tmp/unzipped"
 rm -rf "$dest"
 mkdir -p "$dest"
 cp -R "$tmp/unzipped/$inner/." "$dest/"
 chmod +x "$bin"
-echo "stage-lfm2-runner: staged runner → $dest"
+echo "stage-lfm2-runner: staged + verified runner → $dest"

--- a/scripts/stage-lfm2-runner.sh
+++ b/scripts/stage-lfm2-runner.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Stage the prebuilt `llama-lfm2-audio` runner (binary + its @loader_path
+# dylibs) into src-tauri/binaries/lfm2-audio/ for the LFM2-Audio voice provider.
+#
+# The runner ships inside Liquid AI's GGUF repo as a per-platform zip. We treat
+# it like the other staged binaries (src-tauri/binaries/ is gitignored, fetched
+# at build time, never committed). The release bundle and the dev-app mirror
+# copy this directory next to the executable, where `resolve_lfm2_binary`
+# (src-tauri/src/voice/lfm2.rs) finds it.
+#
+# Usage: scripts/stage-lfm2-runner.sh [--force]
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+dest="$repo_root/src-tauri/binaries/lfm2-audio"
+hf_repo="LiquidAI/LFM2-Audio-1.5B-GGUF"
+
+os="$(uname -s)"
+arch="$(uname -m)"
+case "$os/$arch" in
+  Darwin/arm64)
+    runner="runners/macos-arm64/lfm2-audio-macos-arm64.zip"
+    inner="lfm2-audio-macos-arm64"
+    ;;
+  Linux/x86_64)
+    runner="runners/ubuntu-x64/lfm2-audio-ubuntu-x64.zip"
+    inner="lfm2-audio-ubuntu-x64"
+    ;;
+  Linux/aarch64)
+    runner="runners/ubuntu-arm64/lfm2-audio-ubuntu-arm64.zip"
+    inner="lfm2-audio-ubuntu-arm64"
+    ;;
+  *)
+    echo "stage-lfm2-runner: unsupported platform $os/$arch" >&2
+    exit 1
+    ;;
+esac
+
+bin="$dest/llama-lfm2-audio"
+if [ -x "$bin" ] && [ "${1:-}" != "--force" ]; then
+  echo "stage-lfm2-runner: already staged at $dest (use --force to refresh)"
+  exit 0
+fi
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+url="https://huggingface.co/$hf_repo/resolve/main/$runner"
+echo "stage-lfm2-runner: downloading $runner ..."
+curl -fL --retry 3 -o "$tmp/runner.zip" "$url"
+unzip -q -o "$tmp/runner.zip" -d "$tmp/unzipped"
+
+rm -rf "$dest"
+mkdir -p "$dest"
+cp -R "$tmp/unzipped/$inner/." "$dest/"
+chmod +x "$bin"
+echo "stage-lfm2-runner: staged runner → $dest"

--- a/scripts/verify-bundle.sh
+++ b/scripts/verify-bundle.sh
@@ -41,3 +41,27 @@ if [[ -n "$leaks" ]]; then
 fi
 
 echo "verify-bundle.sh: OK — no /nix/store paths in $bin"
+
+# Scan the bundled LFM2-Audio runner (binary + @loader_path dylibs), if staged.
+# The prebuilt runner is system-linked, so a /nix/store hit here means a
+# Nix-built binary was staged by mistake instead of the upstream release.
+runner_dir="$bundle/Contents/MacOS/lfm2-audio"
+if [[ -d "$runner_dir" ]]; then
+  runner_leaks=""
+  while IFS= read -r -d '' macho; do
+    hits="$(otool -L "$macho" 2>/dev/null | awk 'NR>1 {print $1}' | grep -E '^/nix/store/' || true)"
+    if [[ -n "$hits" ]]; then
+      runner_leaks+="$macho"$'\n'"$hits"$'\n'
+    fi
+  done < <(find "$runner_dir" -type f \
+    \( -name '*.dylib' -o -name '*.so' -o -name 'llama-lfm2-audio' \) -print0)
+  if [[ -n "$runner_leaks" ]]; then
+    echo "verify-bundle.sh: FAIL — Nix store paths in the LFM2-Audio runner" >&2
+    echo "$runner_leaks" | sed 's/^/  /' >&2
+    echo "" >&2
+    echo "  Stage the upstream prebuilt runner via scripts/stage-lfm2-runner.sh;" >&2
+    echo "  do not bundle a Nix-built llama-lfm2-audio." >&2
+    exit 2
+  fi
+  echo "verify-bundle.sh: OK — no /nix/store paths in the LFM2-Audio runner"
+fi

--- a/scripts/verify-bundle.sh
+++ b/scripts/verify-bundle.sh
@@ -43,9 +43,10 @@ fi
 echo "verify-bundle.sh: OK — no /nix/store paths in $bin"
 
 # Scan the bundled LFM2-Audio runner (binary + @loader_path dylibs), if staged.
-# The prebuilt runner is system-linked, so a /nix/store hit here means a
-# Nix-built binary was staged by mistake instead of the upstream release.
-runner_dir="$bundle/Contents/MacOS/lfm2-audio"
+# Bundled via Tauri `resources` → Contents/Resources/lfm2-audio/. The prebuilt
+# runner is system-linked, so a /nix/store hit here means a Nix-built binary
+# was staged by mistake instead of the upstream release.
+runner_dir="$bundle/Contents/Resources/lfm2-audio"
 if [[ -d "$runner_dir" ]]; then
   runner_leaks=""
   while IFS= read -r -d '' macho; do

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -73,6 +73,7 @@ tokenizers = { version = "0.22", default-features = false, features = [
 ], optional = true }
 rubato = { version = "2", default-features = false, optional = true }
 hound = { version = "3", optional = true }
+tempfile = { version = "3", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
@@ -104,6 +105,7 @@ voice = [
   "dep:tokenizers",
   "dep:rubato",
   "dep:hound",
+  "dep:tempfile",
 ]
 
 [dev-dependencies]

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -75,12 +75,32 @@ fn main() {
             // panicking here aborts the build script before it can.
             panic!("aethon-agent sidecar build failed: {msg}");
         }
+        // The LFM2-Audio voice runner is staged into binaries/lfm2-audio by
+        // tauri.conf's `beforeBuildCommand` for actual bundling, but
+        // `bundle.resources` validation inside tauri_build::build() requires
+        // the path to exist for *any* cargo build (clippy/test included).
+        // Ensure at least an empty directory so those commands don't fail; a
+        // real `tauri build` repopulates it before the bundler copies it.
+        ensure_lfm2_resource_dir(&project_root);
         tauri_build::build();
     } else {
         println!(
             "cargo:warning=skipping aethon-agent sidecar build; repository-level agent inputs are absent"
         );
         println!("cargo:warning=skipping tauri bundle metadata generation for crate packaging");
+    }
+}
+
+/// Ensure `src-tauri/binaries/lfm2-audio/` exists so the `bundle.resources`
+/// entry validates during plain cargo builds. No network; the real runner is
+/// staged by `scripts/stage-lfm2-runner.sh` (run from `beforeBuildCommand`).
+fn ensure_lfm2_resource_dir(project_root: &Path) {
+    let dir = project_root
+        .join("src-tauri")
+        .join("binaries")
+        .join("lfm2-audio");
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        println!("cargo:warning=could not create {}: {e}", dir.display());
     }
 }
 

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -393,6 +393,9 @@ pub fn write_config(config: serde_json::Value, app: AppHandle) -> Result<(), Str
         .and_then(|m| m.get("speakMaxChars"))
         .and_then(|v| v.as_u64())
         .map(|n| n.clamp(50, 5000) as u32);
+    let voice_conversation_continuous = voice
+        .and_then(|m| m.get("conversationContinuous"))
+        .and_then(|v| v.as_bool());
     let update_channel = updates
         .and_then(|m| m.get("channel"))
         .and_then(|v| v.as_str())
@@ -552,6 +555,11 @@ pub fn write_config(config: serde_json::Value, app: AppHandle) -> Result<(), Str
             voice_speak_agent_replies,
         );
         set_or_clear_int(voice_table, "speak_max_chars", voice_speak_max_chars);
+        set_or_clear_bool(
+            voice_table,
+            "conversation_continuous",
+            voice_conversation_continuous,
+        );
     }
 
     // ── [updates] ──

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -386,6 +386,13 @@ pub fn write_config(config: serde_json::Value, app: AppHandle) -> Result<(), Str
         .and_then(|m| m.get("holdHotkey"))
         .and_then(|v| v.as_str())
         .filter(|s| !s.is_empty());
+    let voice_speak_agent_replies = voice
+        .and_then(|m| m.get("speakAgentReplies"))
+        .and_then(|v| v.as_bool());
+    let voice_speak_max_chars = voice
+        .and_then(|m| m.get("speakMaxChars"))
+        .and_then(|v| v.as_u64())
+        .map(|n| n.clamp(50, 5000) as u32);
     let update_channel = updates
         .and_then(|m| m.get("channel"))
         .and_then(|v| v.as_str())
@@ -539,6 +546,12 @@ pub fn write_config(config: serde_json::Value, app: AppHandle) -> Result<(), Str
         let voice_table = ensure_table(&mut doc, "voice");
         set_or_clear_str(voice_table, "toggle_hotkey", voice_toggle_hotkey);
         set_or_clear_str(voice_table, "hold_hotkey", voice_hold_hotkey);
+        set_or_clear_bool(
+            voice_table,
+            "speak_agent_replies",
+            voice_speak_agent_replies,
+        );
+        set_or_clear_int(voice_table, "speak_max_chars", voice_speak_max_chars);
     }
 
     // ── [updates] ──

--- a/src-tauri/src/commands/voice.rs
+++ b/src-tauri/src/commands/voice.rs
@@ -8,7 +8,7 @@ use tauri::{AppHandle, State};
 use {serde::Serialize, tauri::Emitter};
 
 #[cfg(feature = "voice")]
-use crate::voice::{VoiceProviderInfo, VoiceProviderRegistry, VoiceSettings};
+use crate::voice::{AudioPlayer, VoiceProviderInfo, VoiceProviderRegistry, VoiceSettings};
 
 #[cfg(feature = "voice")]
 fn open_voice_settings(app: &AppHandle) -> Result<VoiceSettings, String> {
@@ -165,6 +165,29 @@ pub async fn voice_cancel_recording(
     voice.cancel_recording(&provider_id).await
 }
 
+#[cfg(feature = "voice")]
+#[tauri::command]
+pub async fn voice_speak(
+    text: String,
+    app: AppHandle,
+    voice: State<'_, VoiceProviderRegistry>,
+    player: State<'_, AudioPlayer>,
+) -> Result<(), String> {
+    let audio = voice.synthesize_speech(text).await?;
+    player.play_samples(audio.samples, audio.sample_rate, Some(app))
+}
+
+#[cfg(feature = "voice")]
+#[tauri::command]
+pub async fn voice_stop_playback(
+    voice: State<'_, VoiceProviderRegistry>,
+    player: State<'_, AudioPlayer>,
+) -> Result<(), String> {
+    voice.cancel_speech();
+    player.stop();
+    Ok(())
+}
+
 // Shim implementations (compiled when the `voice` feature is disabled).
 // These preserve the JS binding surface — including parameter names — so the
 // frontend's existing invoke args still deserialize cleanly and callers get
@@ -232,5 +255,17 @@ pub async fn voice_stop_and_transcribe(
 pub async fn voice_cancel_recording(
     #[allow(unused_variables)] provider_id: Option<String>,
 ) -> Result<(), String> {
+    Err(VOICE_NOT_BUILT.into())
+}
+
+#[cfg(not(feature = "voice"))]
+#[tauri::command]
+pub async fn voice_speak(#[allow(unused_variables)] text: String) -> Result<(), String> {
+    Err(VOICE_NOT_BUILT.into())
+}
+
+#[cfg(not(feature = "voice"))]
+#[tauri::command]
+pub async fn voice_stop_playback() -> Result<(), String> {
     Err(VOICE_NOT_BUILT.into())
 }

--- a/src-tauri/src/helpers/config.rs
+++ b/src-tauri/src/helpers/config.rs
@@ -434,7 +434,7 @@ pub fn parse_config_toml(input: &str) -> serde_json::Value {
             "holdHotkey": cfg.voice.hold_hotkey.or_else(|| default_voice_hold_hotkey().map(str::to_string)),
             "speakAgentReplies": cfg.voice.speak_agent_replies.unwrap_or(false),
             "speakMaxChars": cfg.voice.speak_max_chars.unwrap_or(600),
-            "conversationContinuous": cfg.voice.conversation_continuous.unwrap_or(false),
+            "conversationContinuous": cfg.voice.conversation_continuous.unwrap_or(true),
         },
         "extensions": {
             "stateWarnKb": state_warn_kb,
@@ -696,7 +696,7 @@ mod tests {
         assert_eq!(v["voice"]["holdHotkey"], serde_json::Value::Null);
         assert_eq!(v["voice"]["speakAgentReplies"], false);
         assert_eq!(v["voice"]["speakMaxChars"], 600);
-        assert_eq!(v["voice"]["conversationContinuous"], false);
+        assert_eq!(v["voice"]["conversationContinuous"], true);
     }
 
     #[test]
@@ -707,12 +707,15 @@ toggle_hotkey = "mod+alt+v"
 hold_hotkey = "AltRight"
 speak_agent_replies = true
 speak_max_chars = 250
+conversation_continuous = false
 "#,
         );
         assert_eq!(v["voice"]["toggleHotkey"], "mod+alt+v");
         assert_eq!(v["voice"]["holdHotkey"], "AltRight");
         assert_eq!(v["voice"]["speakAgentReplies"], true);
         assert_eq!(v["voice"]["speakMaxChars"], 250);
+        // Explicit opt-out of hands-free auto-loop.
+        assert_eq!(v["voice"]["conversationContinuous"], false);
     }
 
     #[test]

--- a/src-tauri/src/helpers/config.rs
+++ b/src-tauri/src/helpers/config.rs
@@ -106,6 +106,7 @@ pub struct VoiceConfig {
     pub hold_hotkey: Option<String>,
     pub speak_agent_replies: Option<bool>,
     pub speak_max_chars: Option<u32>,
+    pub conversation_continuous: Option<bool>,
 }
 
 #[derive(Default, Deserialize)]
@@ -433,6 +434,7 @@ pub fn parse_config_toml(input: &str) -> serde_json::Value {
             "holdHotkey": cfg.voice.hold_hotkey.or_else(|| default_voice_hold_hotkey().map(str::to_string)),
             "speakAgentReplies": cfg.voice.speak_agent_replies.unwrap_or(false),
             "speakMaxChars": cfg.voice.speak_max_chars.unwrap_or(600),
+            "conversationContinuous": cfg.voice.conversation_continuous.unwrap_or(false),
         },
         "extensions": {
             "stateWarnKb": state_warn_kb,
@@ -694,6 +696,7 @@ mod tests {
         assert_eq!(v["voice"]["holdHotkey"], serde_json::Value::Null);
         assert_eq!(v["voice"]["speakAgentReplies"], false);
         assert_eq!(v["voice"]["speakMaxChars"], 600);
+        assert_eq!(v["voice"]["conversationContinuous"], false);
     }
 
     #[test]

--- a/src-tauri/src/helpers/config.rs
+++ b/src-tauri/src/helpers/config.rs
@@ -104,6 +104,8 @@ pub struct ShortcutsConfig {
 pub struct VoiceConfig {
     pub toggle_hotkey: Option<String>,
     pub hold_hotkey: Option<String>,
+    pub speak_agent_replies: Option<bool>,
+    pub speak_max_chars: Option<u32>,
 }
 
 #[derive(Default, Deserialize)]
@@ -429,6 +431,8 @@ pub fn parse_config_toml(input: &str) -> serde_json::Value {
         "voice": {
             "toggleHotkey": cfg.voice.toggle_hotkey.unwrap_or_else(|| "mod+shift+m".to_string()),
             "holdHotkey": cfg.voice.hold_hotkey.or_else(|| default_voice_hold_hotkey().map(str::to_string)),
+            "speakAgentReplies": cfg.voice.speak_agent_replies.unwrap_or(false),
+            "speakMaxChars": cfg.voice.speak_max_chars.unwrap_or(600),
         },
         "extensions": {
             "stateWarnKb": state_warn_kb,
@@ -688,6 +692,8 @@ mod tests {
         assert_eq!(v["voice"]["holdHotkey"], "AltRight");
         #[cfg(not(target_os = "macos"))]
         assert_eq!(v["voice"]["holdHotkey"], serde_json::Value::Null);
+        assert_eq!(v["voice"]["speakAgentReplies"], false);
+        assert_eq!(v["voice"]["speakMaxChars"], 600);
     }
 
     #[test]
@@ -696,10 +702,14 @@ mod tests {
             r#"[voice]
 toggle_hotkey = "mod+alt+v"
 hold_hotkey = "AltRight"
+speak_agent_replies = true
+speak_max_chars = 250
 "#,
         );
         assert_eq!(v["voice"]["toggleHotkey"], "mod+alt+v");
         assert_eq!(v["voice"]["holdHotkey"], "AltRight");
+        assert_eq!(v["voice"]["speakAgentReplies"], true);
+        assert_eq!(v["voice"]["speakMaxChars"], 250);
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -135,9 +135,11 @@ pub fn run() {
         .manage(Arc::new(server::ServerState::new()))
         .manage(devshell::DevshellCache::shared());
     #[cfg(feature = "voice")]
-    let builder = builder.manage(voice::VoiceProviderRegistry::new(
-        voice::VoiceProviderRegistry::default_model_root(),
-    ));
+    let builder = builder
+        .manage(voice::VoiceProviderRegistry::new(
+            voice::VoiceProviderRegistry::default_model_root(),
+        ))
+        .manage(voice::AudioPlayer::new());
     let builder = builder
         .on_window_event(|window, event| match event {
             tauri::WindowEvent::Resized(_) | tauri::WindowEvent::Moved(_) => {
@@ -238,6 +240,8 @@ pub fn run() {
             commands::voice::voice_start_recording,
             commands::voice::voice_stop_and_transcribe,
             commands::voice::voice_cancel_recording,
+            commands::voice::voice_speak,
+            commands::voice::voice_stop_playback,
             commands::boot::boot_stage,
             commands::boot::boot_ok,
             commands::devshell::devshell_status,

--- a/src-tauri/src/voice/audio.rs
+++ b/src-tauri/src/voice/audio.rs
@@ -78,7 +78,7 @@ pub(crate) trait AudioRecorder: Send + Sync {
 
 pub(crate) struct CpalAudioRecorder;
 
-fn compute_rms(samples: &[f32]) -> f32 {
+pub(super) fn compute_rms(samples: &[f32]) -> f32 {
     if samples.is_empty() {
         return 0.0;
     }
@@ -202,14 +202,16 @@ where
         .collect()
 }
 
-pub(super) fn resample_to_target_rate(samples: &[f32], sample_rate: u32) -> Vec<f32> {
-    if samples.is_empty() || sample_rate == TARGET_SAMPLE_RATE {
+/// Linear-resample mono `samples` from `from_rate` to `to_rate`. Used both for
+/// microphone capture (→ 16 kHz for ASR) and TTS playback (24 kHz → the output
+/// device rate).
+pub(super) fn resample(samples: &[f32], from_rate: u32, to_rate: u32) -> Vec<f32> {
+    if samples.is_empty() || from_rate == to_rate {
         return samples.to_vec();
     }
 
-    let output_len =
-        (samples.len() as u64 * u64::from(TARGET_SAMPLE_RATE) / u64::from(sample_rate)).max(1);
-    let ratio = sample_rate as f64 / TARGET_SAMPLE_RATE as f64;
+    let output_len = (samples.len() as u64 * u64::from(to_rate) / u64::from(from_rate)).max(1);
+    let ratio = from_rate as f64 / to_rate as f64;
     (0..output_len)
         .map(|out_index| {
             let source = out_index as f64 * ratio;
@@ -219,6 +221,10 @@ pub(super) fn resample_to_target_rate(samples: &[f32], sample_rate: u32) -> Vec<
             samples[left] * (1.0 - frac) + samples[right] * frac
         })
         .collect()
+}
+
+pub(super) fn resample_to_target_rate(samples: &[f32], sample_rate: u32) -> Vec<f32> {
+    resample(samples, sample_rate, TARGET_SAMPLE_RATE)
 }
 
 impl AudioRecorder for CpalAudioRecorder {

--- a/src-tauri/src/voice/download.rs
+++ b/src-tauri/src/voice/download.rs
@@ -5,23 +5,53 @@ pub(super) async fn download_distil_model(
     provider_id: &str,
     cache_path: &Path,
 ) -> Result<(), String> {
-    let known_total = DISTIL_MODEL_FILES
-        .iter()
-        .filter_map(|(_, size)| *size)
-        .sum::<u64>();
+    download_hf_model(
+        app,
+        provider_id,
+        cache_path,
+        "distil-whisper/distil-large-v3",
+        &DISTIL_MODEL_FILES,
+    )
+    .await
+}
+
+pub(super) async fn download_lfm2_model(
+    app: &AppHandle,
+    provider_id: &str,
+    cache_path: &Path,
+) -> Result<(), String> {
+    download_hf_model(
+        app,
+        provider_id,
+        cache_path,
+        LFM2_HF_REPO,
+        &LFM2_MODEL_FILES,
+    )
+    .await
+}
+
+/// Stream a set of files from a Hugging Face repo into `cache_path`, emitting
+/// `voice-download-progress` events and writing each file via a `.part`
+/// tempfile that is renamed into place only once fully downloaded.
+async fn download_hf_model(
+    app: &AppHandle,
+    provider_id: &str,
+    cache_path: &Path,
+    repo: &str,
+    files: &[(&str, Option<u64>)],
+) -> Result<(), String> {
+    let known_total = files.iter().filter_map(|(_, size)| *size).sum::<u64>();
     let mut overall_downloaded = 0_u64;
     let client = reqwest::Client::new();
 
-    for (filename, known_size) in DISTIL_MODEL_FILES {
+    for (filename, known_size) in files.iter().copied() {
         let destination = cache_path.join(filename);
         if destination.is_file() {
             overall_downloaded += destination.metadata().map(|m| m.len()).unwrap_or(0);
             continue;
         }
 
-        let url = format!(
-            "https://huggingface.co/distil-whisper/distil-large-v3/resolve/main/{filename}"
-        );
+        let url = format!("https://huggingface.co/{repo}/resolve/main/{filename}");
         let response = client
             .get(&url)
             .send()

--- a/src-tauri/src/voice/lfm2.rs
+++ b/src-tauri/src/voice/lfm2.rs
@@ -21,6 +21,10 @@ use tokio::io::AsyncReadExt;
 
 const LFM2_BIN_NAME: &str = "llama-lfm2-audio";
 const LFM2_BIN_ENV: &str = "AETHON_LFM2_AUDIO_BIN";
+/// The runner ships as a directory (binary + `@loader_path` dylibs), staged
+/// beside the app executable under this subdirectory by the release bundle and
+/// the dev-app mirror.
+const LFM2_BUNDLE_SUBDIR: &str = "lfm2-audio";
 pub(super) const LFM2_BINARY_MISSING: &str = "LFM2-Audio runtime not found. The llama-lfm2-audio binary ships with Aethon; \
      reinstall, or set AETHON_LFM2_AUDIO_BIN to its path.";
 const ASR_SYSTEM_PROMPT: &str = "Perform ASR.";
@@ -68,12 +72,23 @@ pub(super) fn resolve_lfm2_binary() -> Option<PathBuf> {
         }
     }
     if let Ok(exe) = std::env::current_exe()
-        && let Some(candidate) = exe.parent().map(|dir| dir.join(LFM2_BIN_NAME))
-        && candidate.is_file()
+        && let Some(dir) = exe.parent()
+        && let Some(found) = bundled_lfm2_binary(dir)
     {
-        return Some(candidate);
+        return Some(found);
     }
     crate::env::resolve_program(LFM2_BIN_NAME)
+}
+
+/// Find the staged runner beside the executable: either directly (`<dir>/
+/// llama-lfm2-audio`) or in the bundled `lfm2-audio/` subdir.
+pub(super) fn bundled_lfm2_binary(exe_dir: &Path) -> Option<PathBuf> {
+    [
+        exe_dir.join(LFM2_BIN_NAME),
+        exe_dir.join(LFM2_BUNDLE_SUBDIR).join(LFM2_BIN_NAME),
+    ]
+    .into_iter()
+    .find(|candidate| candidate.is_file())
 }
 
 /// Audio capabilities are injected through this trait so the registry can

--- a/src-tauri/src/voice/lfm2.rs
+++ b/src-tauri/src/voice/lfm2.rs
@@ -24,8 +24,23 @@ const LFM2_BIN_ENV: &str = "AETHON_LFM2_AUDIO_BIN";
 pub(super) const LFM2_BINARY_MISSING: &str = "LFM2-Audio runtime not found. The llama-lfm2-audio binary ships with Aethon; \
      reinstall, or set AETHON_LFM2_AUDIO_BIN to its path.";
 const ASR_SYSTEM_PROMPT: &str = "Perform ASR.";
+// The 1.5B llama.cpp runner only accepts the bare task prompt; appending a
+// voice name (e.g. "Use the UK male voice.") makes it abort with
+// "Failed to init generation params", so voice selection is intentionally
+// not exposed here (see the Phase 0 spike notes).
+const TTS_SYSTEM_PROMPT: &str = "Perform TTS.";
+// The runner defaults to `--predict -1` (unbounded) and the 1.5B model
+// sometimes fails to emit an end token, rambling into a minutes-long clip for
+// a short prompt. Cap generation to a ~60 s ceiling (~13 audio tokens/sec) so
+// a wedged synthesis can't produce a runaway file. Callers further cap the
+// *input* length (see speak-agent-replies).
+const TTS_MAX_TOKENS: u32 = 768;
 const CANCELLED_MESSAGE: &str = "Transcription cancelled.";
+const SYNTHESIS_CANCELLED_MESSAGE: &str = "Speech synthesis cancelled.";
 const LFM2_CANCEL_POLL: Duration = Duration::from_millis(100);
+/// Mimi codec output sample rate, used as a fallback if the WAV header is
+/// somehow missing the rate.
+pub(super) const LFM2_TTS_SAMPLE_RATE: u32 = 24_000;
 
 /// Resolved on-disk locations of the three GGUF files the runner needs.
 pub(super) struct Lfm2ModelPaths {
@@ -72,6 +87,10 @@ pub(super) trait Lfm2Backend: Send + Sync {
     /// Transcribe captured audio. `cancel` is polled cooperatively and kills
     /// the child process if it flips mid-run.
     async fn asr(&self, audio: CapturedAudio, cancel: Arc<AtomicBool>) -> Result<String, String>;
+
+    /// Synthesize speech for `text`, returning 24 kHz mono PCM. `cancel` is
+    /// polled cooperatively and kills the child process if it flips mid-run.
+    async fn tts(&self, text: String, cancel: Arc<AtomicBool>) -> Result<CapturedAudio, String>;
 }
 
 pub(super) struct Lfm2CliBackend {
@@ -114,7 +133,7 @@ impl Lfm2Backend for Lfm2CliBackend {
             .arg("--audio")
             .arg(input_wav.path());
 
-        let output = run_cli_capture(command, &cancel).await?;
+        let output = run_cli_capture(command, &cancel, CANCELLED_MESSAGE).await?;
         if !output.status.success() {
             return Err(format!(
                 "LFM2-Audio transcription failed: {}",
@@ -123,6 +142,95 @@ impl Lfm2Backend for Lfm2CliBackend {
         }
         Ok(parse_asr_stdout(&output.stdout))
     }
+
+    async fn tts(&self, text: String, cancel: Arc<AtomicBool>) -> Result<CapturedAudio, String> {
+        let binary = resolve_lfm2_binary().ok_or_else(|| LFM2_BINARY_MISSING.to_string())?;
+        let paths = lfm2_model_paths(&self.cache_path());
+        // The runner writes the synthesized WAV to this path; held alive (and
+        // cleaned up) for the duration of the call.
+        let output_wav = tempfile::Builder::new()
+            .prefix("aethon-lfm2-tts-")
+            .suffix(".wav")
+            .tempfile()
+            .map_err(|e| format!("Failed to allocate temporary audio file: {e}"))?;
+
+        let mut command = crate::env::tokio_command(binary.to_string_lossy().as_ref());
+        command
+            .arg("-m")
+            .arg(&paths.lm)
+            .arg("--mmproj")
+            .arg(&paths.encoder)
+            .arg("-mv")
+            .arg(&paths.decoder)
+            .arg("-sys")
+            .arg(TTS_SYSTEM_PROMPT)
+            .arg("-p")
+            .arg(&text)
+            .arg("-n")
+            .arg(TTS_MAX_TOKENS.to_string())
+            .arg("--output")
+            .arg(output_wav.path());
+
+        let output = run_cli_capture(command, &cancel, SYNTHESIS_CANCELLED_MESSAGE).await?;
+        if !output.status.success() {
+            return Err(format!(
+                "LFM2-Audio speech synthesis failed: {}",
+                last_error_line(&output.stderr)
+            ));
+        }
+        read_output_wav(output_wav.path())
+    }
+}
+
+/// Read the runner's synthesized WAV back into mono f32 PCM. TTS output is
+/// 16-bit mono at 24 kHz, but stay tolerant of float samples / extra channels.
+fn read_output_wav(path: &Path) -> Result<CapturedAudio, String> {
+    let mut reader =
+        hound::WavReader::open(path).map_err(|e| format!("Failed to open synthesized WAV: {e}"))?;
+    let spec = reader.spec();
+    let channels = usize::from(spec.channels.max(1));
+    let interleaved: Vec<f32> = match (spec.sample_format, spec.bits_per_sample) {
+        (hound::SampleFormat::Float, 32) => reader
+            .samples::<f32>()
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| format!("Failed to read synthesized samples: {e}"))?,
+        (hound::SampleFormat::Int, 16) => reader
+            .samples::<i16>()
+            .map(|sample| sample.map(|value| f32::from(value) / f32::from(i16::MAX)))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| format!("Failed to read synthesized samples: {e}"))?,
+        (hound::SampleFormat::Int, bits @ (24 | 32)) => {
+            let scale = (1_i64 << (bits - 1)) as f32;
+            reader
+                .samples::<i32>()
+                .map(|sample| sample.map(|value| value as f32 / scale))
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| format!("Failed to read synthesized samples: {e}"))?
+        }
+        (format, bits) => {
+            return Err(format!(
+                "Unsupported synthesized WAV format: {format:?} {bits}-bit"
+            ));
+        }
+    };
+
+    let samples = if channels <= 1 {
+        interleaved
+    } else {
+        interleaved
+            .chunks(channels)
+            .map(|frame| frame.iter().sum::<f32>() / frame.len() as f32)
+            .collect()
+    };
+    let sample_rate = if spec.sample_rate == 0 {
+        LFM2_TTS_SAMPLE_RATE
+    } else {
+        spec.sample_rate
+    };
+    Ok(CapturedAudio {
+        samples,
+        sample_rate,
+    })
 }
 
 struct CliOutput {
@@ -136,6 +244,7 @@ struct CliOutput {
 async fn run_cli_capture(
     mut command: tokio::process::Command,
     cancel: &Arc<AtomicBool>,
+    cancelled_message: &str,
 ) -> Result<CliOutput, String> {
     command
         .stdin(Stdio::null())
@@ -169,7 +278,7 @@ async fn run_cli_capture(
         if cancel.load(Ordering::Relaxed) {
             let _ = child.start_kill();
             let _ = child.wait().await;
-            return Err(CANCELLED_MESSAGE.to_string());
+            return Err(cancelled_message.to_string());
         }
         // Re-create the wait future each tick so neither branch holds a
         // long-lived mutable borrow of `child` (the tokio::select! footgun).

--- a/src-tauri/src/voice/lfm2.rs
+++ b/src-tauri/src/voice/lfm2.rs
@@ -1,0 +1,273 @@
+//! LFM2-Audio runtime — a thin wrapper over Liquid AI's prebuilt llama.cpp
+//! `llama-lfm2-audio` one-shot CLI.
+//!
+//! Runtime contract (validated by the Phase 0 spike on Apple Silicon):
+//! - ASR: `llama-lfm2-audio -m <lm> --mmproj <encoder> -mv <decoder>
+//!   -sys "Perform ASR." --audio <in.wav>`. The transcript is printed on
+//!   **stdout**, interleaved with stable diagnostic lines (`load_gguf:`,
+//!   `main:`, `encoding audio slice`, `audio decoded`, …) — filter those out.
+//! - The binary is genuinely one-shot (a fresh process per call), which is why
+//!   it sidesteps the upstream "crash after the first ASR+TTS cycle" entirely.
+//! - **Never** pass `--log-disable`: it suppresses the transcript (a log line)
+//!   and breaks audio output writing.
+//! - The runner is system-linked (`@rpath` dylibs + `/usr/lib`), so it is
+//!   resolved next to the app executable (release sidecar), via the
+//!   `AETHON_LFM2_AUDIO_BIN` override (dev), or on `PATH`. Model weights are
+//!   downloaded on demand; the binary is never auto-downloaded-and-executed.
+
+use super::*;
+use std::process::Stdio;
+use tokio::io::AsyncReadExt;
+
+const LFM2_BIN_NAME: &str = "llama-lfm2-audio";
+const LFM2_BIN_ENV: &str = "AETHON_LFM2_AUDIO_BIN";
+pub(super) const LFM2_BINARY_MISSING: &str = "LFM2-Audio runtime not found. The llama-lfm2-audio binary ships with Aethon; \
+     reinstall, or set AETHON_LFM2_AUDIO_BIN to its path.";
+const ASR_SYSTEM_PROMPT: &str = "Perform ASR.";
+const CANCELLED_MESSAGE: &str = "Transcription cancelled.";
+const LFM2_CANCEL_POLL: Duration = Duration::from_millis(100);
+
+/// Resolved on-disk locations of the three GGUF files the runner needs.
+pub(super) struct Lfm2ModelPaths {
+    pub(super) lm: PathBuf,
+    pub(super) encoder: PathBuf,
+    pub(super) decoder: PathBuf,
+}
+
+pub(super) fn lfm2_model_paths(cache_path: &Path) -> Lfm2ModelPaths {
+    Lfm2ModelPaths {
+        lm: cache_path.join(LFM2_LM_FILE),
+        encoder: cache_path.join(LFM2_ENCODER_FILE),
+        decoder: cache_path.join(LFM2_DECODER_FILE),
+    }
+}
+
+/// Locate the `llama-lfm2-audio` binary. Order: explicit dev override, a
+/// sidecar staged next to the running executable (release bundle), then `PATH`
+/// through the shared resolver in `env.rs`.
+pub(super) fn resolve_lfm2_binary() -> Option<PathBuf> {
+    if let Some(raw) = std::env::var_os(LFM2_BIN_ENV) {
+        let path = PathBuf::from(raw);
+        if path.is_file() {
+            return Some(path);
+        }
+    }
+    if let Ok(exe) = std::env::current_exe()
+        && let Some(candidate) = exe.parent().map(|dir| dir.join(LFM2_BIN_NAME))
+        && candidate.is_file()
+    {
+        return Some(candidate);
+    }
+    crate::env::resolve_program(LFM2_BIN_NAME)
+}
+
+/// Audio capabilities are injected through this trait so the registry can
+/// substitute a fake in tests instead of spawning the real binary.
+#[async_trait]
+pub(super) trait Lfm2Backend: Send + Sync {
+    /// Whether the runner binary can be located on this machine. Feeds the
+    /// provider's readiness status without spawning anything.
+    fn binary_available(&self) -> bool;
+
+    /// Transcribe captured audio. `cancel` is polled cooperatively and kills
+    /// the child process if it flips mid-run.
+    async fn asr(&self, audio: CapturedAudio, cancel: Arc<AtomicBool>) -> Result<String, String>;
+}
+
+pub(super) struct Lfm2CliBackend {
+    model_root: PathBuf,
+}
+
+impl Lfm2CliBackend {
+    pub(super) fn new(model_root: PathBuf) -> Self {
+        Self { model_root }
+    }
+
+    fn cache_path(&self) -> PathBuf {
+        self.model_root.join(LFM2_CACHE_DIR)
+    }
+}
+
+#[async_trait]
+impl Lfm2Backend for Lfm2CliBackend {
+    fn binary_available(&self) -> bool {
+        resolve_lfm2_binary().is_some()
+    }
+
+    async fn asr(&self, audio: CapturedAudio, cancel: Arc<AtomicBool>) -> Result<String, String> {
+        let binary = resolve_lfm2_binary().ok_or_else(|| LFM2_BINARY_MISSING.to_string())?;
+        let paths = lfm2_model_paths(&self.cache_path());
+        // Held alive for the duration of the run; the CLI reads it from disk.
+        // Dropped (and deleted) when this scope ends.
+        let input_wav = write_input_wav(&audio)?;
+
+        let mut command = crate::env::tokio_command(binary.to_string_lossy().as_ref());
+        command
+            .arg("-m")
+            .arg(&paths.lm)
+            .arg("--mmproj")
+            .arg(&paths.encoder)
+            .arg("-mv")
+            .arg(&paths.decoder)
+            .arg("-sys")
+            .arg(ASR_SYSTEM_PROMPT)
+            .arg("--audio")
+            .arg(input_wav.path());
+
+        let output = run_cli_capture(command, &cancel).await?;
+        if !output.status.success() {
+            return Err(format!(
+                "LFM2-Audio transcription failed: {}",
+                last_error_line(&output.stderr)
+            ));
+        }
+        Ok(parse_asr_stdout(&output.stdout))
+    }
+}
+
+struct CliOutput {
+    status: std::process::ExitStatus,
+    stdout: String,
+    stderr: String,
+}
+
+/// Spawn a runner command, draining stdout/stderr concurrently (so a full pipe
+/// can't deadlock the child), while polling `cancel` to kill the process early.
+async fn run_cli_capture(
+    mut command: tokio::process::Command,
+    cancel: &Arc<AtomicBool>,
+) -> Result<CliOutput, String> {
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    let mut child = command
+        .spawn()
+        .map_err(|e| format!("Failed to launch LFM2-Audio runner: {e}"))?;
+
+    let mut stdout_pipe = child
+        .stdout
+        .take()
+        .ok_or_else(|| "LFM2-Audio runner stdout unavailable".to_string())?;
+    let mut stderr_pipe = child
+        .stderr
+        .take()
+        .ok_or_else(|| "LFM2-Audio runner stderr unavailable".to_string())?;
+    let stdout_task = tokio::spawn(async move {
+        let mut buf = String::new();
+        let _ = stdout_pipe.read_to_string(&mut buf).await;
+        buf
+    });
+    let stderr_task = tokio::spawn(async move {
+        let mut buf = String::new();
+        let _ = stderr_pipe.read_to_string(&mut buf).await;
+        buf
+    });
+
+    let status = loop {
+        if cancel.load(Ordering::Relaxed) {
+            let _ = child.start_kill();
+            let _ = child.wait().await;
+            return Err(CANCELLED_MESSAGE.to_string());
+        }
+        // Re-create the wait future each tick so neither branch holds a
+        // long-lived mutable borrow of `child` (the tokio::select! footgun).
+        match tokio::time::timeout(LFM2_CANCEL_POLL, child.wait()).await {
+            Ok(status) => break status.map_err(|e| format!("LFM2-Audio runner failed: {e}"))?,
+            Err(_) => continue,
+        }
+    };
+
+    let stdout = stdout_task.await.unwrap_or_default();
+    let stderr = stderr_task.await.unwrap_or_default();
+    Ok(CliOutput {
+        status,
+        stdout,
+        stderr,
+    })
+}
+
+/// Write captured 16 kHz mono audio to a temporary 16-bit PCM WAV for the CLI.
+fn write_input_wav(audio: &CapturedAudio) -> Result<tempfile::NamedTempFile, String> {
+    let temp = tempfile::Builder::new()
+        .prefix("aethon-lfm2-asr-")
+        .suffix(".wav")
+        .tempfile()
+        .map_err(|e| format!("Failed to allocate temporary audio file: {e}"))?;
+    let spec = hound::WavSpec {
+        channels: 1,
+        sample_rate: audio.sample_rate,
+        bits_per_sample: 16,
+        sample_format: hound::SampleFormat::Int,
+    };
+    let mut writer = hound::WavWriter::create(temp.path(), spec)
+        .map_err(|e| format!("Failed to open WAV writer: {e}"))?;
+    for &sample in &audio.samples {
+        let scaled = (sample.clamp(-1.0, 1.0) * f32::from(i16::MAX)).round() as i16;
+        writer
+            .write_sample(scaled)
+            .map_err(|e| format!("Failed to write WAV sample: {e}"))?;
+    }
+    writer
+        .finalize()
+        .map_err(|e| format!("Failed to finalize WAV: {e}"))?;
+    Ok(temp)
+}
+
+/// Extract the transcript from runner stdout, dropping the interleaved
+/// llama.cpp/mtmd diagnostic lines. The remaining non-empty lines are the
+/// model's generated text.
+pub(super) fn parse_asr_stdout(stdout: &str) -> String {
+    stdout
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !is_lfm2_diagnostic_line(line))
+        .collect::<Vec<_>>()
+        .join(" ")
+        .trim()
+        .to_string()
+}
+
+fn is_lfm2_diagnostic_line(line: &str) -> bool {
+    const DIAGNOSTIC_PREFIXES: &[&str] = &[
+        "load_gguf:",
+        "main:",
+        "encoding audio slice",
+        "audio slice encoded",
+        "decoding audio batch",
+        "audio decoded",
+        "load_backend",
+        "register_backend",
+        "build:",
+        "llama_",
+        "ggml_",
+        "clip_",
+        "mtmd_",
+        "init_audio:",
+        "init:",
+        "warming up",
+        "<|audio_start|>",
+        "decode_frame:",
+        "decode:",
+    ];
+    DIAGNOSTIC_PREFIXES
+        .iter()
+        .any(|prefix| line.starts_with(prefix))
+}
+
+/// Pick the most informative line out of runner stderr for an error message.
+fn last_error_line(stderr: &str) -> String {
+    let lines: Vec<&str> = stderr
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect();
+    lines
+        .iter()
+        .rev()
+        .find(|line| line.starts_with("ERR") || line.contains("error") || line.contains("Error"))
+        .or_else(|| lines.last())
+        .map(|line| line.to_string())
+        .unwrap_or_else(|| "unknown error".to_string())
+}

--- a/src-tauri/src/voice/lfm2.rs
+++ b/src-tauri/src/voice/lfm2.rs
@@ -80,15 +80,26 @@ pub(super) fn resolve_lfm2_binary() -> Option<PathBuf> {
     crate::env::resolve_program(LFM2_BIN_NAME)
 }
 
-/// Find the staged runner beside the executable: either directly (`<dir>/
-/// llama-lfm2-audio`) or in the bundled `lfm2-audio/` subdir.
+/// Find the staged runner relative to the executable. Candidates, in order:
+/// - `<dir>/llama-lfm2-audio` (direct sibling),
+/// - `<dir>/lfm2-audio/llama-lfm2-audio` (subdir beside the exe — dev mirror),
+/// - `<dir>/../Resources/lfm2-audio/llama-lfm2-audio` (macOS .app bundle: the
+///   exe lives in `Contents/MacOS/`, Tauri `resources` land in
+///   `Contents/Resources/`).
 pub(super) fn bundled_lfm2_binary(exe_dir: &Path) -> Option<PathBuf> {
-    [
+    let mut candidates = vec![
         exe_dir.join(LFM2_BIN_NAME),
         exe_dir.join(LFM2_BUNDLE_SUBDIR).join(LFM2_BIN_NAME),
-    ]
-    .into_iter()
-    .find(|candidate| candidate.is_file())
+    ];
+    if let Some(contents) = exe_dir.parent() {
+        candidates.push(
+            contents
+                .join("Resources")
+                .join(LFM2_BUNDLE_SUBDIR)
+                .join(LFM2_BIN_NAME),
+        );
+    }
+    candidates.into_iter().find(|candidate| candidate.is_file())
 }
 
 /// Audio capabilities are injected through this trait so the registry can

--- a/src-tauri/src/voice/mod.rs
+++ b/src-tauri/src/voice/mod.rs
@@ -1631,6 +1631,25 @@ mod tests {
         );
     }
 
+    #[test]
+    fn bundled_lfm2_binary_finds_sibling_runner() {
+        let dir = tempdir().expect("dir");
+        assert!(bundled_lfm2_binary(dir.path()).is_none());
+        let binary = dir.path().join("llama-lfm2-audio");
+        std::fs::write(&binary, b"runner").expect("write binary");
+        assert_eq!(bundled_lfm2_binary(dir.path()), Some(binary));
+    }
+
+    #[test]
+    fn bundled_lfm2_binary_finds_runner_subdir() {
+        let dir = tempdir().expect("dir");
+        let subdir = dir.path().join("lfm2-audio");
+        std::fs::create_dir_all(&subdir).expect("create subdir");
+        let binary = subdir.join("llama-lfm2-audio");
+        std::fs::write(&binary, b"runner").expect("write binary");
+        assert_eq!(bundled_lfm2_binary(dir.path()), Some(binary));
+    }
+
     #[tokio::test]
     async fn remove_lfm2_model_clears_cache_and_status() {
         let (_db_dir, db_path) = test_db_path();

--- a/src-tauri/src/voice/mod.rs
+++ b/src-tauri/src/voice/mod.rs
@@ -1969,6 +1969,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn overlapping_synthesis_cancels_previous() {
+        let model_dir = tempdir().expect("model dir");
+        write_complete_lfm2_model(&model_dir.path().join(LFM2_CACHE_DIR));
+        let registry = Arc::new(lfm2_registry(
+            model_dir.path().to_path_buf(),
+            FakeLfm2Backend::slow("x", Duration::from_secs(5)),
+        ));
+
+        let first_registry = Arc::clone(&registry);
+        let first =
+            tokio::spawn(
+                async move { first_registry.synthesize_speech("first".to_string()).await },
+            );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // A second request must cancel the first so the older runner can't
+        // proceed to playback after the user moved on.
+        let second_registry = Arc::clone(&registry);
+        let second = tokio::spawn(async move {
+            second_registry
+                .synthesize_speech("second".to_string())
+                .await
+        });
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let first_err = first
+            .await
+            .expect("first task joined")
+            .expect_err("first synthesis should be superseded");
+        assert!(
+            first_err.contains("cancelled"),
+            "expected cancellation: {first_err}"
+        );
+
+        registry.cancel_speech();
+        let _ = second.await;
+    }
+
+    #[tokio::test]
     async fn synthesize_speech_times_out() {
         let model_dir = tempdir().expect("model dir");
         write_complete_lfm2_model(&model_dir.path().join(LFM2_CACHE_DIR));
@@ -2006,8 +2045,17 @@ mod tests {
         player
             .play_samples(samples, sample_rate, None)
             .expect("playback should start");
-        // Hold the player (and thus the stream) alive while the tone plays.
-        tokio::time::sleep(Duration::from_millis(1300)).await;
+        assert!(
+            player.is_playing(),
+            "stream should be active during playback"
+        );
+        // Hold the player (and thus the stream) alive while the tone plays, then
+        // confirm the watcher freed the stream on natural completion.
+        tokio::time::sleep(Duration::from_millis(1600)).await;
+        assert!(
+            !player.is_playing(),
+            "stream should be released once the clip drains",
+        );
         player.stop();
     }
 

--- a/src-tauri/src/voice/mod.rs
+++ b/src-tauri/src/voice/mod.rs
@@ -38,6 +38,7 @@ use self::audio::{
 
 mod download;
 mod inference;
+mod lfm2;
 mod mel;
 mod providers;
 mod registry;
@@ -46,6 +47,7 @@ mod types;
 
 use download::*;
 use inference::*;
+use lfm2::*;
 use mel::*;
 use providers::*;
 pub(crate) use registry::*;
@@ -81,6 +83,27 @@ pub(super) const DISTIL_MODEL_FILES: [(&str, Option<u64>); 5] = [
     ("preprocessor_config.json", None),
     ("tokenizer.json", None),
     ("model.safetensors", Some(100_000_000)),
+];
+
+// --- LFM2-Audio (Liquid AI) provider, run via the prebuilt llama.cpp
+// `llama-lfm2-audio` one-shot CLI. End-to-end audio model: ASR (speech-in)
+// today, TTS (speech-out) in a later phase. The Q8_0 GGUF trio lives beside
+// the binary's documented `-m` / `--mmproj` / `-mv` flags. See `lfm2.rs` for
+// the runtime contract distilled from the Phase 0 spike.
+pub(super) const LFM2_ID: &str = "voice-lfm2-audio-llamacpp";
+pub(super) const LFM2_CACHE_DIR: &str = "lfm2-audio-1.5b";
+pub(super) const LFM2_HF_REPO: &str = "LiquidAI/LFM2-Audio-1.5B-GGUF";
+pub(super) const LFM2_READY_MESSAGE: &str = "Ready for offline speech";
+pub(super) const LFM2_LM_FILE: &str = "LFM2-Audio-1.5B-Q8_0.gguf";
+pub(super) const LFM2_ENCODER_FILE: &str = "mmproj-audioencoder-LFM2-Audio-1.5B-Q8_0.gguf";
+pub(super) const LFM2_DECODER_FILE: &str = "audiodecoder-LFM2-Audio-1.5B-Q8_0.gguf";
+// Conservative size floors guard against truncated/partial downloads while
+// tolerating minor upstream re-quantization. Actual Q8_0 sizes (bytes) are
+// LM 1_246_253_280 / encoder 332_716_640 / decoder 375_009_888.
+pub(super) const LFM2_MODEL_FILES: [(&str, Option<u64>); 3] = [
+    (LFM2_LM_FILE, Some(1_000_000_000)),
+    (LFM2_ENCODER_FILE, Some(250_000_000)),
+    (LFM2_DECODER_FILE, Some(250_000_000)),
 ];
 pub(super) const WHISPER_LANGUAGE_CODES: [&str; 99] = [
     "en", "zh", "de", "es", "ru", "ko", "fr", "ja", "pt", "tr", "pl", "ca", "nl", "ar", "sv", "it",
@@ -1367,5 +1390,422 @@ mod tests {
         assert_eq!(provider.status, VoiceProviderStatus::Downloading);
         assert_eq!(provider.status_label, "Downloading model");
         assert!(provider.setup_required);
+    }
+
+    // --- LFM2-Audio provider ---------------------------------------------
+
+    struct FakeLfm2Backend {
+        binary_available: bool,
+        result: Mutex<Result<String, String>>,
+        sleep_for: Duration,
+        calls: AtomicUsize,
+    }
+
+    impl FakeLfm2Backend {
+        fn ready(text: &str) -> Self {
+            Self {
+                binary_available: true,
+                result: Mutex::new(Ok(text.to_string())),
+                sleep_for: Duration::ZERO,
+                calls: AtomicUsize::new(0),
+            }
+        }
+
+        fn binary_missing() -> Self {
+            Self {
+                binary_available: false,
+                result: Mutex::new(Ok("ignored".to_string())),
+                sleep_for: Duration::ZERO,
+                calls: AtomicUsize::new(0),
+            }
+        }
+
+        fn slow(text: &str, sleep_for: Duration) -> Self {
+            Self {
+                binary_available: true,
+                result: Mutex::new(Ok(text.to_string())),
+                sleep_for,
+                calls: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Lfm2Backend for FakeLfm2Backend {
+        fn binary_available(&self) -> bool {
+            self.binary_available
+        }
+
+        async fn asr(
+            &self,
+            _audio: CapturedAudio,
+            cancel: Arc<AtomicBool>,
+        ) -> Result<String, String> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            // Poll the cancel flag while "working" so tests can exercise the
+            // cooperative cancel path the real subprocess wrapper uses.
+            let step = Duration::from_millis(10);
+            let mut remaining = self.sleep_for;
+            while remaining > Duration::ZERO {
+                if cancel.load(Ordering::Relaxed) {
+                    return Err("Transcription cancelled.".to_string());
+                }
+                let nap = step.min(remaining);
+                tokio::time::sleep(nap).await;
+                remaining = remaining.saturating_sub(nap);
+            }
+            self.result.lock().clone()
+        }
+    }
+
+    fn write_complete_lfm2_model(cache_path: &Path) {
+        std::fs::create_dir_all(cache_path).expect("create lfm2 cache");
+        for (filename, min_size) in LFM2_MODEL_FILES {
+            let file = std::fs::File::create(cache_path.join(filename)).expect("create lfm2 file");
+            if let Some(min_size) = min_size {
+                file.set_len(min_size).expect("size lfm2 file");
+            }
+        }
+    }
+
+    fn lfm2_registry(model_root: PathBuf, lfm2: FakeLfm2Backend) -> VoiceProviderRegistry {
+        VoiceProviderRegistry::with_runtime(
+            model_root,
+            Arc::new(FakeRecorder::new(vec![0.1, 0.2, 0.3])),
+            Arc::new(FakeTranscriber::ok("ignored")),
+        )
+        .with_lfm2_backend(Arc::new(lfm2))
+    }
+
+    fn find_lfm2(registry: &VoiceProviderRegistry, db: &VoiceSettings) -> VoiceProviderInfo {
+        registry
+            .list_providers(db)
+            .into_iter()
+            .find(|provider| provider.metadata.id == LFM2_ID)
+            .expect("lfm2 provider present")
+    }
+
+    #[test]
+    fn lfm2_provider_appears_in_default_list() {
+        let (_dir, db_path) = test_db_path();
+        let db = open_test_db(&db_path);
+        let registry = VoiceProviderRegistry::new(PathBuf::from("/tmp/models"));
+
+        assert!(
+            registry
+                .list_providers(&db)
+                .iter()
+                .any(|provider| provider.metadata.id == LFM2_ID)
+        );
+    }
+
+    #[test]
+    fn lfm2_cache_path_uses_provider_specific_directory() {
+        let root = PathBuf::from("/tmp/aethon-test-models");
+        let registry = VoiceProviderRegistry::new(root.clone());
+        assert_eq!(registry.lfm2_cache_path(), root.join(LFM2_CACHE_DIR));
+    }
+
+    #[test]
+    fn lfm2_ready_when_model_and_binary_present() {
+        let (_db_dir, db_path) = test_db_path();
+        let model_dir = tempdir().expect("model dir");
+        write_complete_lfm2_model(&model_dir.path().join(LFM2_CACHE_DIR));
+        let db = open_test_db(&db_path);
+        let registry = lfm2_registry(model_dir.path().to_path_buf(), FakeLfm2Backend::ready("x"));
+
+        let provider = find_lfm2(&registry, &db);
+        assert_eq!(provider.status, VoiceProviderStatus::Ready);
+        assert!(!provider.setup_required);
+        assert!(provider.can_remove_model);
+        assert_eq!(provider.error, None);
+    }
+
+    #[test]
+    fn lfm2_needs_setup_when_model_missing() {
+        let (_db_dir, db_path) = test_db_path();
+        let model_dir = tempdir().expect("model dir");
+        let db = open_test_db(&db_path);
+        let registry = lfm2_registry(model_dir.path().to_path_buf(), FakeLfm2Backend::ready("x"));
+
+        let provider = find_lfm2(&registry, &db);
+        assert_eq!(provider.status, VoiceProviderStatus::NeedsSetup);
+        assert!(provider.setup_required);
+        assert!(!provider.can_remove_model);
+    }
+
+    #[test]
+    fn lfm2_engine_unavailable_when_binary_missing() {
+        let (_db_dir, db_path) = test_db_path();
+        let model_dir = tempdir().expect("model dir");
+        write_complete_lfm2_model(&model_dir.path().join(LFM2_CACHE_DIR));
+        let db = open_test_db(&db_path);
+        let registry = lfm2_registry(
+            model_dir.path().to_path_buf(),
+            FakeLfm2Backend::binary_missing(),
+        );
+
+        let provider = find_lfm2(&registry, &db);
+        assert_eq!(provider.status, VoiceProviderStatus::EngineUnavailable);
+        assert!(!provider.setup_required);
+        assert!(
+            provider
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("llama-lfm2-audio"))
+        );
+    }
+
+    #[test]
+    fn lfm2_disabled_reports_unavailable() {
+        let (_db_dir, db_path) = test_db_path();
+        let model_dir = tempdir().expect("model dir");
+        write_complete_lfm2_model(&model_dir.path().join(LFM2_CACHE_DIR));
+        let db = open_test_db(&db_path);
+        db.set_app_setting(&enabled_key(LFM2_ID), "false")
+            .expect("disable lfm2");
+        let registry = lfm2_registry(model_dir.path().to_path_buf(), FakeLfm2Backend::ready("x"));
+
+        let provider = find_lfm2(&registry, &db);
+        assert_eq!(provider.status, VoiceProviderStatus::Unavailable);
+        assert!(!provider.enabled);
+        assert!(!provider.setup_required);
+    }
+
+    #[test]
+    fn lfm2_model_ready_requires_all_files() {
+        let model_dir = tempdir().expect("model dir");
+        let cache_path = model_dir.path().join(LFM2_CACHE_DIR);
+        std::fs::create_dir_all(&cache_path).expect("create cache");
+        // Only the LM file present — encoder + decoder still missing.
+        let lm = std::fs::File::create(cache_path.join(LFM2_LM_FILE)).expect("create lm");
+        lm.set_len(1_000_000_000).expect("size lm");
+
+        assert!(!lfm2_model_ready(&cache_path));
+    }
+
+    #[test]
+    fn resolve_provider_id_accepts_lfm2() {
+        let (_dir, db_path) = test_db_path();
+        let db = open_test_db(&db_path);
+        let registry = VoiceProviderRegistry::new(PathBuf::from("/tmp/models"));
+
+        assert_eq!(
+            registry
+                .resolve_provider_id(&db, Some(LFM2_ID))
+                .expect("lfm2 is a known provider"),
+            LFM2_ID
+        );
+    }
+
+    #[tokio::test]
+    async fn remove_lfm2_model_clears_cache_and_status() {
+        let (_db_dir, db_path) = test_db_path();
+        let model_dir = tempdir().expect("model dir");
+        let cache_path = model_dir.path().join(LFM2_CACHE_DIR);
+        write_complete_lfm2_model(&cache_path);
+        let db = open_test_db(&db_path);
+        db.set_app_setting(&model_status_key(LFM2_ID), "installed")
+            .expect("set model status");
+        drop(db);
+
+        let registry = lfm2_registry(model_dir.path().to_path_buf(), FakeLfm2Backend::ready("x"));
+        let provider = registry
+            .remove_provider_model(&db_path, LFM2_ID)
+            .await
+            .expect("remove lfm2 model");
+
+        assert!(!cache_path.exists());
+        assert_eq!(provider.status, VoiceProviderStatus::NeedsSetup);
+        let db = open_test_db(&db_path);
+        assert_eq!(
+            db.get_app_setting(&model_status_key(LFM2_ID))
+                .expect("get model status"),
+            Some("not-installed".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn start_lfm2_recording_rejects_missing_model() {
+        let (_db_dir, db_path) = test_db_path();
+        let model_dir = tempdir().expect("model dir");
+        let registry = lfm2_registry(model_dir.path().to_path_buf(), FakeLfm2Backend::ready("x"));
+
+        let err = registry
+            .start_recording(&db_path, LFM2_ID, None)
+            .await
+            .expect_err("missing model should not record");
+        assert!(err.contains("Download"));
+    }
+
+    #[tokio::test]
+    async fn start_lfm2_recording_rejects_disabled_provider() {
+        let (_db_dir, db_path) = test_db_path();
+        let model_dir = tempdir().expect("model dir");
+        write_complete_lfm2_model(&model_dir.path().join(LFM2_CACHE_DIR));
+        let db = open_test_db(&db_path);
+        db.set_app_setting(&enabled_key(LFM2_ID), "false")
+            .expect("disable provider");
+        drop(db);
+        let registry = lfm2_registry(model_dir.path().to_path_buf(), FakeLfm2Backend::ready("x"));
+
+        let err = registry
+            .start_recording(&db_path, LFM2_ID, None)
+            .await
+            .expect_err("disabled provider should not record");
+        assert!(err.contains("disabled"));
+    }
+
+    #[tokio::test]
+    async fn start_lfm2_recording_rejects_missing_binary() {
+        let (_db_dir, db_path) = test_db_path();
+        let model_dir = tempdir().expect("model dir");
+        write_complete_lfm2_model(&model_dir.path().join(LFM2_CACHE_DIR));
+        let registry = lfm2_registry(
+            model_dir.path().to_path_buf(),
+            FakeLfm2Backend::binary_missing(),
+        );
+
+        let err = registry
+            .start_recording(&db_path, LFM2_ID, None)
+            .await
+            .expect_err("missing binary should not record");
+        assert!(err.contains("llama-lfm2-audio"));
+    }
+
+    #[tokio::test]
+    async fn start_then_stop_lfm2_returns_transcript() {
+        let (_db_dir, db_path) = test_db_path();
+        let model_dir = tempdir().expect("model dir");
+        write_complete_lfm2_model(&model_dir.path().join(LFM2_CACHE_DIR));
+        let registry = lfm2_registry(
+            model_dir.path().to_path_buf(),
+            FakeLfm2Backend::ready("hello from lfm2"),
+        );
+
+        registry
+            .start_recording(&db_path, LFM2_ID, None)
+            .await
+            .expect("recording starts");
+        let transcript = registry
+            .stop_and_transcribe(LFM2_ID)
+            .await
+            .expect("transcribes");
+
+        assert_eq!(transcript, "hello from lfm2");
+    }
+
+    #[tokio::test]
+    async fn cancel_during_lfm2_transcription_returns_early() {
+        let (_db_dir, db_path) = test_db_path();
+        let model_dir = tempdir().expect("model dir");
+        write_complete_lfm2_model(&model_dir.path().join(LFM2_CACHE_DIR));
+        let registry = Arc::new(lfm2_registry(
+            model_dir.path().to_path_buf(),
+            FakeLfm2Backend::slow("would have transcribed", Duration::from_secs(5)),
+        ));
+
+        registry
+            .start_recording(&db_path, LFM2_ID, None)
+            .await
+            .expect("recording starts");
+
+        let stop_registry = Arc::clone(&registry);
+        let stop_handle =
+            tokio::spawn(async move { stop_registry.stop_and_transcribe(LFM2_ID).await });
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let cancel_started = std::time::Instant::now();
+        registry
+            .cancel_recording(LFM2_ID)
+            .await
+            .expect("cancel succeeds");
+
+        let result = stop_handle.await.expect("stop task joined");
+        let elapsed = cancel_started.elapsed();
+        let err = result.expect_err("transcription should be cancelled");
+        assert!(err.contains("cancelled"), "expected cancellation: {err}");
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "expected fast return: {elapsed:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn lfm2_transcription_timeout_returns_clear_error() {
+        let (_db_dir, db_path) = test_db_path();
+        let model_dir = tempdir().expect("model dir");
+        write_complete_lfm2_model(&model_dir.path().join(LFM2_CACHE_DIR));
+        let registry = VoiceProviderRegistry::with_runtime_and_timeout(
+            model_dir.path().to_path_buf(),
+            Arc::new(FakeRecorder::new(vec![0.1, 0.2, 0.3])),
+            Arc::new(FakeTranscriber::ok("ignored")),
+            Duration::from_millis(5),
+        )
+        .with_lfm2_backend(Arc::new(FakeLfm2Backend::slow(
+            "late transcript",
+            Duration::from_millis(80),
+        )));
+
+        registry
+            .start_recording(&db_path, LFM2_ID, None)
+            .await
+            .expect("recording starts");
+        let err = registry
+            .stop_and_transcribe(LFM2_ID)
+            .await
+            .expect_err("slow transcription should time out");
+        assert!(err.contains("timed out"));
+    }
+
+    #[tokio::test]
+    #[ignore = "requires AETHON_LFM2_AUDIO_BIN, the LFM2 model cache, and AETHON_VOICE_SAMPLE_WAV"]
+    async fn ignored_real_lfm2_asr_transcribes_fixture_wav() {
+        let model_root = std::env::var_os("AETHON_LFM2_MODEL_ROOT")
+            .map(PathBuf::from)
+            .unwrap_or_else(VoiceProviderRegistry::default_model_root);
+        let sample_path = std::env::var_os("AETHON_VOICE_SAMPLE_WAV")
+            .map(PathBuf::from)
+            .expect("set AETHON_VOICE_SAMPLE_WAV to a short speech WAV");
+        let audio = read_wav_fixture(&sample_path).expect("read speech wav");
+
+        let backend = Lfm2CliBackend::new(model_root);
+        assert!(
+            backend.binary_available(),
+            "set AETHON_LFM2_AUDIO_BIN to the llama-lfm2-audio binary",
+        );
+        let cancel = Arc::new(AtomicBool::new(false));
+        let transcript = backend
+            .asr(audio, cancel)
+            .await
+            .expect("transcribe fixture");
+        assert!(!transcript.trim().is_empty(), "got empty transcript");
+        println!("LFM2 ASR transcript: {transcript}");
+    }
+
+    #[test]
+    fn parse_asr_stdout_keeps_only_transcript() {
+        let stdout = "load_gguf: Loaded 369 tensors from audiodecoder.gguf\n\
+             main: loading model: lm.gguf\n\
+             encoding audio slice...\n\
+             audio slice encoded in 35 ms\n\
+             decoding audio batch 1/1, n_tokens_batch = 35\n\
+             audio decoded (batch 1/1) in 16 ms\n\
+             \n\
+             The quick brown fox jumps over the lazy dog.\n\
+             \n";
+        assert_eq!(
+            parse_asr_stdout(stdout),
+            "The quick brown fox jumps over the lazy dog."
+        );
+    }
+
+    #[test]
+    fn parse_asr_stdout_joins_multiline_transcript_and_trims_noise() {
+        let stdout = "main: loading model: lm.gguf\n\
+             First sentence.\n\
+             Second sentence.\n\
+             ggml_metal_free: deallocating\n";
+        assert_eq!(parse_asr_stdout(stdout), "First sentence. Second sentence.");
     }
 }

--- a/src-tauri/src/voice/mod.rs
+++ b/src-tauri/src/voice/mod.rs
@@ -1650,6 +1650,23 @@ mod tests {
         assert_eq!(bundled_lfm2_binary(dir.path()), Some(binary));
     }
 
+    #[test]
+    fn bundled_lfm2_binary_finds_macos_resources_runner() {
+        // Mirror the .app layout: Contents/MacOS/<exe>, Contents/Resources/.
+        let app = tempdir().expect("dir");
+        let macos = app.path().join("Contents").join("MacOS");
+        let resources = app
+            .path()
+            .join("Contents")
+            .join("Resources")
+            .join("lfm2-audio");
+        std::fs::create_dir_all(&macos).expect("create MacOS");
+        std::fs::create_dir_all(&resources).expect("create Resources");
+        let binary = resources.join("llama-lfm2-audio");
+        std::fs::write(&binary, b"runner").expect("write binary");
+        assert_eq!(bundled_lfm2_binary(&macos), Some(binary));
+    }
+
     #[tokio::test]
     async fn remove_lfm2_model_clears_cache_and_status() {
         let (_db_dir, db_path) = test_db_path();

--- a/src-tauri/src/voice/mod.rs
+++ b/src-tauri/src/voice/mod.rs
@@ -29,6 +29,8 @@ pub(crate) use self::audio::{
     AudioRecorder, CpalAudioRecorder, LevelTask, RecordingSession, spawn_level_emitter,
     validate_captured_audio,
 };
+// Shared DSP helpers consumed by the playback module.
+use self::audio::{compute_rms, resample};
 #[cfg(test)]
 use self::audio::{
     normalize_interleaved_f32, normalize_interleaved_f64, normalize_interleaved_i16,
@@ -40,6 +42,7 @@ mod download;
 mod inference;
 mod lfm2;
 mod mel;
+mod playback;
 mod providers;
 mod registry;
 mod settings;
@@ -49,6 +52,7 @@ use download::*;
 use inference::*;
 use lfm2::*;
 use mel::*;
+pub(crate) use playback::*;
 use providers::*;
 pub(crate) use registry::*;
 pub(crate) use settings::*;
@@ -1444,17 +1448,46 @@ mod tests {
             self.calls.fetch_add(1, Ordering::Relaxed);
             // Poll the cancel flag while "working" so tests can exercise the
             // cooperative cancel path the real subprocess wrapper uses.
+            self.wait_for_cancel(&cancel, "Transcription cancelled.")
+                .await?;
+            self.result.lock().clone()
+        }
+
+        async fn tts(
+            &self,
+            _text: String,
+            cancel: Arc<AtomicBool>,
+        ) -> Result<CapturedAudio, String> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            self.wait_for_cancel(&cancel, "Speech synthesis cancelled.")
+                .await?;
+            // Surface a configured error, otherwise return a short canned clip.
+            self.result.lock().clone().map(|_| CapturedAudio {
+                samples: vec![0.1, -0.1, 0.2, -0.2],
+                sample_rate: 24_000,
+            })
+        }
+    }
+
+    impl FakeLfm2Backend {
+        /// Poll `cancel` over `sleep_for`, returning an `Err` with `message` if
+        /// it flips — mirrors the real subprocess wrapper's cooperative cancel.
+        async fn wait_for_cancel(
+            &self,
+            cancel: &Arc<AtomicBool>,
+            message: &str,
+        ) -> Result<(), String> {
             let step = Duration::from_millis(10);
             let mut remaining = self.sleep_for;
             while remaining > Duration::ZERO {
                 if cancel.load(Ordering::Relaxed) {
-                    return Err("Transcription cancelled.".to_string());
+                    return Err(message.to_string());
                 }
                 let nap = step.min(remaining);
                 tokio::time::sleep(nap).await;
                 remaining = remaining.saturating_sub(nap);
             }
-            self.result.lock().clone()
+            Ok(())
         }
     }
 
@@ -1783,6 +1816,51 @@ mod tests {
         println!("LFM2 ASR transcript: {transcript}");
     }
 
+    #[tokio::test]
+    #[ignore = "requires AETHON_LFM2_AUDIO_BIN and the LFM2 model cache"]
+    async fn ignored_real_lfm2_tts_synthesizes_audio() {
+        let model_root = std::env::var_os("AETHON_LFM2_MODEL_ROOT")
+            .map(PathBuf::from)
+            .unwrap_or_else(VoiceProviderRegistry::default_model_root);
+        let backend = Lfm2CliBackend::new(model_root);
+        assert!(
+            backend.binary_available(),
+            "set AETHON_LFM2_AUDIO_BIN to the llama-lfm2-audio binary",
+        );
+        let cancel = Arc::new(AtomicBool::new(false));
+        let audio = backend
+            .tts(
+                "Hello from Aethon. Phase two is online.".to_string(),
+                cancel,
+            )
+            .await
+            .expect("synthesize speech");
+        assert!(!audio.samples.is_empty(), "got empty audio");
+        assert_eq!(audio.sample_rate, LFM2_TTS_SAMPLE_RATE);
+
+        // Optionally dump the clip for manual listening (AETHON_TTS_OUT=/path.wav).
+        if let Some(out) = std::env::var_os("AETHON_TTS_OUT") {
+            let spec = hound::WavSpec {
+                channels: 1,
+                sample_rate: audio.sample_rate,
+                bits_per_sample: 16,
+                sample_format: hound::SampleFormat::Int,
+            };
+            let mut writer =
+                hound::WavWriter::create(PathBuf::from(out), spec).expect("wav writer");
+            for &sample in &audio.samples {
+                let scaled = (sample.clamp(-1.0, 1.0) * f32::from(i16::MAX)).round() as i16;
+                writer.write_sample(scaled).expect("write sample");
+            }
+            writer.finalize().expect("finalize wav");
+        }
+        println!(
+            "LFM2 TTS produced {} samples @ {} Hz",
+            audio.samples.len(),
+            audio.sample_rate
+        );
+    }
+
     #[test]
     fn parse_asr_stdout_keeps_only_transcript() {
         let stdout = "load_gguf: Loaded 369 tensors from audiodecoder.gguf\n\
@@ -1807,5 +1885,158 @@ mod tests {
              Second sentence.\n\
              ggml_metal_free: deallocating\n";
         assert_eq!(parse_asr_stdout(stdout), "First sentence. Second sentence.");
+    }
+
+    // --- Phase 2: TTS synthesis + playback ------------------------------
+
+    #[tokio::test]
+    async fn synthesize_speech_returns_audio() {
+        let model_dir = tempdir().expect("model dir");
+        write_complete_lfm2_model(&model_dir.path().join(LFM2_CACHE_DIR));
+        let registry = lfm2_registry(model_dir.path().to_path_buf(), FakeLfm2Backend::ready("x"));
+
+        let audio = registry
+            .synthesize_speech("hello".to_string())
+            .await
+            .expect("synthesize");
+        assert!(!audio.samples.is_empty());
+        assert_eq!(audio.sample_rate, 24_000);
+    }
+
+    #[tokio::test]
+    async fn synthesize_speech_rejects_empty_text() {
+        let model_dir = tempdir().expect("model dir");
+        write_complete_lfm2_model(&model_dir.path().join(LFM2_CACHE_DIR));
+        let registry = lfm2_registry(model_dir.path().to_path_buf(), FakeLfm2Backend::ready("x"));
+
+        let err = registry
+            .synthesize_speech("   ".to_string())
+            .await
+            .expect_err("empty text should be rejected");
+        assert!(err.contains("Nothing to speak"));
+    }
+
+    #[tokio::test]
+    async fn synthesize_speech_rejects_missing_model() {
+        let model_dir = tempdir().expect("model dir");
+        let registry = lfm2_registry(model_dir.path().to_path_buf(), FakeLfm2Backend::ready("x"));
+
+        let err = registry
+            .synthesize_speech("hello".to_string())
+            .await
+            .expect_err("missing model should be rejected");
+        assert!(err.contains("Download"));
+    }
+
+    #[tokio::test]
+    async fn synthesize_speech_rejects_missing_binary() {
+        let model_dir = tempdir().expect("model dir");
+        write_complete_lfm2_model(&model_dir.path().join(LFM2_CACHE_DIR));
+        let registry = lfm2_registry(
+            model_dir.path().to_path_buf(),
+            FakeLfm2Backend::binary_missing(),
+        );
+
+        let err = registry
+            .synthesize_speech("hello".to_string())
+            .await
+            .expect_err("missing binary should be rejected");
+        assert!(err.contains("llama-lfm2-audio"));
+    }
+
+    #[tokio::test]
+    async fn cancel_speech_aborts_synthesis() {
+        let model_dir = tempdir().expect("model dir");
+        write_complete_lfm2_model(&model_dir.path().join(LFM2_CACHE_DIR));
+        let registry = Arc::new(lfm2_registry(
+            model_dir.path().to_path_buf(),
+            FakeLfm2Backend::slow("x", Duration::from_secs(5)),
+        ));
+
+        let synth_registry = Arc::clone(&registry);
+        let handle =
+            tokio::spawn(
+                async move { synth_registry.synthesize_speech("hello".to_string()).await },
+            );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        registry.cancel_speech();
+
+        let err = handle
+            .await
+            .expect("synthesis task joined")
+            .expect_err("synthesis should be cancelled");
+        assert!(err.contains("cancelled"), "expected cancellation: {err}");
+    }
+
+    #[tokio::test]
+    async fn synthesize_speech_times_out() {
+        let model_dir = tempdir().expect("model dir");
+        write_complete_lfm2_model(&model_dir.path().join(LFM2_CACHE_DIR));
+        let registry = VoiceProviderRegistry::with_runtime_and_timeout(
+            model_dir.path().to_path_buf(),
+            Arc::new(FakeRecorder::new(vec![0.1])),
+            Arc::new(FakeTranscriber::ok("ignored")),
+            Duration::from_millis(5),
+        )
+        .with_lfm2_backend(Arc::new(FakeLfm2Backend::slow(
+            "late",
+            Duration::from_millis(80),
+        )));
+
+        let err = registry
+            .synthesize_speech("hello".to_string())
+            .await
+            .expect_err("slow synthesis should time out");
+        assert!(err.contains("timed out"));
+    }
+
+    #[tokio::test]
+    #[ignore = "plays a tone through the default output device"]
+    async fn ignored_real_playback_plays_tone() {
+        let sample_rate = 24_000_u32;
+        let freq = 440.0_f32;
+        let count = sample_rate as usize; // ~1 second
+        let samples: Vec<f32> = (0..count)
+            .map(|i| {
+                0.2 * (2.0 * std::f32::consts::PI * freq * i as f32 / sample_rate as f32).sin()
+            })
+            .collect();
+
+        let player = AudioPlayer::new();
+        player
+            .play_samples(samples, sample_rate, None)
+            .expect("playback should start");
+        // Hold the player (and thus the stream) alive while the tone plays.
+        tokio::time::sleep(Duration::from_millis(1300)).await;
+        player.stop();
+    }
+
+    #[test]
+    fn playback_buffer_drains_then_finishes() {
+        let mut buffer = PlaybackBuffer::new(vec![0.1, 0.2, 0.3]);
+        assert!(!buffer.finished());
+        assert_eq!(buffer.next_sample(), Some(0.1));
+        assert_eq!(buffer.next_sample(), Some(0.2));
+        assert!(!buffer.finished());
+        assert_eq!(buffer.next_sample(), Some(0.3));
+        assert!(buffer.finished());
+        assert_eq!(buffer.next_sample(), None);
+        assert!(buffer.finished());
+    }
+
+    #[test]
+    fn empty_playback_buffer_is_immediately_finished() {
+        let mut buffer = PlaybackBuffer::new(Vec::new());
+        assert!(buffer.finished());
+        assert_eq!(buffer.next_sample(), None);
+    }
+
+    #[test]
+    fn resample_scales_length_with_rate() {
+        let mono = vec![0.0, 0.5, 1.0, 0.5];
+        assert_eq!(resample(&mono, 16_000, 16_000), mono);
+        assert_eq!(resample(&mono, 24_000, 48_000).len(), 8);
+        assert_eq!(resample(&mono, 48_000, 24_000).len(), 2);
+        assert!(resample(&[], 24_000, 48_000).is_empty());
     }
 }

--- a/src-tauri/src/voice/playback.rs
+++ b/src-tauri/src/voice/playback.rs
@@ -13,6 +13,7 @@
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use parking_lot::Mutex;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use tauri::{AppHandle, Emitter};
 use tokio::task::AbortHandle;
 
@@ -46,14 +47,18 @@ impl PlaybackBuffer {
 }
 
 pub(crate) struct AudioPlayer {
-    active: Mutex<Option<PlaybackHandle>>,
+    active: Arc<Mutex<Option<PlaybackHandle>>>,
+    generation: AtomicU64,
 }
 
 /// Holds a playing stream and its level/finished watcher. Dropping it stops
 /// playback (drops the `cpal::Stream`) and aborts the watcher (`LevelTask`).
+/// `generation` tags which `play_samples` call owns the slot so the watcher
+/// only clears its own clip on completion.
 struct PlaybackHandle {
     _stream: cpal::Stream,
     _watcher: LevelTask,
+    generation: u64,
 }
 
 impl Default for AudioPlayer {
@@ -65,8 +70,14 @@ impl Default for AudioPlayer {
 impl AudioPlayer {
     pub(crate) fn new() -> Self {
         Self {
-            active: Mutex::new(None),
+            active: Arc::new(Mutex::new(None)),
+            generation: AtomicU64::new(0),
         }
+    }
+
+    #[cfg(test)]
+    pub(super) fn is_playing(&self) -> bool {
+        self.active.lock().is_some()
     }
 
     /// Resample `samples` (recorded at `sample_rate`) to the default output
@@ -112,10 +123,12 @@ impl AudioPlayer {
             .play()
             .map_err(|e| format!("Failed to start audio output stream: {e}"))?;
 
-        let watcher = spawn_playback_watcher(app, buffer);
+        let generation = self.generation.fetch_add(1, Ordering::Relaxed) + 1;
+        let watcher = spawn_playback_watcher(app, buffer, Arc::clone(&self.active), generation);
         *self.active.lock() = Some(PlaybackHandle {
             _stream: stream,
             _watcher: LevelTask(watcher),
+            generation,
         });
         Ok(())
     }
@@ -191,10 +204,15 @@ where
 }
 
 /// Poll the playback buffer at ~20 Hz, emitting `voice://playback-level` for a
-/// speaking meter and a final `voice://playback-finished` once drained.
+/// speaking meter and a final `voice://playback-finished` once drained. On
+/// natural completion it also frees the stream by clearing the active slot —
+/// but only if that slot is still *this* clip (`generation`), so a newer clip
+/// that replaced it is left untouched.
 fn spawn_playback_watcher(
     app: Option<AppHandle>,
     buffer: Arc<Mutex<PlaybackBuffer>>,
+    active: Arc<Mutex<Option<PlaybackHandle>>>,
+    generation: u64,
 ) -> AbortHandle {
     tokio::spawn(async move {
         let mut interval = tokio::time::interval(std::time::Duration::from_millis(50));
@@ -216,6 +234,20 @@ fn spawn_playback_watcher(
                 let _ = app.emit("voice://playback-level", VoiceLevelPayload { level });
             }
             if done {
+                // Free the device by dropping our handle (drops the stream).
+                // Taken under the lock, dropped after release. Aborting our own
+                // watcher this way is harmless — we break immediately after.
+                let _stale = {
+                    let mut slot = active.lock();
+                    if slot
+                        .as_ref()
+                        .is_some_and(|handle| handle.generation == generation)
+                    {
+                        slot.take()
+                    } else {
+                        None
+                    }
+                };
                 if let Some(app) = &app {
                     let _ = app.emit("voice://playback-finished", ());
                 }

--- a/src-tauri/src/voice/playback.rs
+++ b/src-tauri/src/voice/playback.rs
@@ -1,0 +1,227 @@
+//! Audio output for synthesized speech.
+//!
+//! Aethon's voice stack was capture-only until LFM2-Audio added text-to-speech.
+//! This module plays a block of mono PCM (the TTS result) through the default
+//! output device, resampling to the device rate and fanning the mono signal
+//! out to every channel. It deliberately reuses the existing `cpal` dependency
+//! rather than pulling in a playback crate.
+//!
+//! The recorder uses the default *input* device and the player the default
+//! *output* device, so the two never contend; the conversation state machine
+//! is what enforces "listen XOR speak" so the agent never hears itself.
+
+use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+use parking_lot::Mutex;
+use std::sync::Arc;
+use tauri::{AppHandle, Emitter};
+use tokio::task::AbortHandle;
+
+use super::{LevelTask, VoiceLevelPayload, compute_rms, resample};
+
+/// Cursor over mono PCM samples, advanced one frame at a time by the audio
+/// callback. Factored out so the draining logic is unit-testable without a
+/// real output device.
+pub(super) struct PlaybackBuffer {
+    samples: Vec<f32>,
+    pos: usize,
+}
+
+impl PlaybackBuffer {
+    pub(super) fn new(samples: Vec<f32>) -> Self {
+        Self { samples, pos: 0 }
+    }
+
+    /// The next mono sample, or `None` once the buffer is drained.
+    pub(super) fn next_sample(&mut self) -> Option<f32> {
+        let sample = self.samples.get(self.pos).copied();
+        if sample.is_some() {
+            self.pos += 1;
+        }
+        sample
+    }
+
+    pub(super) fn finished(&self) -> bool {
+        self.pos >= self.samples.len()
+    }
+}
+
+pub(crate) struct AudioPlayer {
+    active: Mutex<Option<PlaybackHandle>>,
+}
+
+/// Holds a playing stream and its level/finished watcher. Dropping it stops
+/// playback (drops the `cpal::Stream`) and aborts the watcher (`LevelTask`).
+struct PlaybackHandle {
+    _stream: cpal::Stream,
+    _watcher: LevelTask,
+}
+
+impl Default for AudioPlayer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AudioPlayer {
+    pub(crate) fn new() -> Self {
+        Self {
+            active: Mutex::new(None),
+        }
+    }
+
+    /// Resample `samples` (recorded at `sample_rate`) to the default output
+    /// device and start playing. Any in-flight playback is stopped first.
+    pub(crate) fn play_samples(
+        &self,
+        samples: Vec<f32>,
+        sample_rate: u32,
+        app: Option<AppHandle>,
+    ) -> Result<(), String> {
+        // Stop any current playback (drops its stream + aborts its watcher).
+        *self.active.lock() = None;
+        if samples.is_empty() {
+            // Nothing to play; still signal completion so callers advance.
+            if let Some(app) = &app {
+                let _ = app.emit("voice://playback-finished", ());
+            }
+            return Ok(());
+        }
+
+        let host = cpal::default_host();
+        let device = host
+            .default_output_device()
+            .ok_or_else(|| "No default audio output device is available".to_string())?;
+        let supported = device
+            .default_output_config()
+            .map_err(|e| format!("Failed to read audio output config: {e}"))?;
+        let device_rate = supported.sample_rate();
+        let channels = usize::from(supported.channels().max(1));
+        let config: cpal::StreamConfig = supported.clone().into();
+
+        let resampled = resample(&samples, sample_rate, device_rate);
+        let buffer = Arc::new(Mutex::new(PlaybackBuffer::new(resampled)));
+
+        let stream = build_output_stream(
+            &device,
+            &config,
+            supported.sample_format(),
+            channels,
+            Arc::clone(&buffer),
+        )?;
+        stream
+            .play()
+            .map_err(|e| format!("Failed to start audio output stream: {e}"))?;
+
+        let watcher = spawn_playback_watcher(app, buffer);
+        *self.active.lock() = Some(PlaybackHandle {
+            _stream: stream,
+            _watcher: LevelTask(watcher),
+        });
+        Ok(())
+    }
+
+    /// Stop any in-flight playback immediately (drops the stream + watcher).
+    pub(crate) fn stop(&self) {
+        *self.active.lock() = None;
+    }
+}
+
+fn build_output_stream(
+    device: &cpal::Device,
+    config: &cpal::StreamConfig,
+    sample_format: cpal::SampleFormat,
+    channels: usize,
+    buffer: Arc<Mutex<PlaybackBuffer>>,
+) -> Result<cpal::Stream, String> {
+    // Each match arm is mutually exclusive, so moving `buffer` into the
+    // per-type helper in every arm is fine.
+    let stream = match sample_format {
+        cpal::SampleFormat::I8 => typed_output_stream::<i8>(device, config, channels, buffer),
+        cpal::SampleFormat::I16 => typed_output_stream::<i16>(device, config, channels, buffer),
+        cpal::SampleFormat::I24 => {
+            typed_output_stream::<cpal::I24>(device, config, channels, buffer)
+        }
+        cpal::SampleFormat::I32 => typed_output_stream::<i32>(device, config, channels, buffer),
+        cpal::SampleFormat::I64 => typed_output_stream::<i64>(device, config, channels, buffer),
+        cpal::SampleFormat::U8 => typed_output_stream::<u8>(device, config, channels, buffer),
+        cpal::SampleFormat::U16 => typed_output_stream::<u16>(device, config, channels, buffer),
+        cpal::SampleFormat::U24 => {
+            typed_output_stream::<cpal::U24>(device, config, channels, buffer)
+        }
+        cpal::SampleFormat::U32 => typed_output_stream::<u32>(device, config, channels, buffer),
+        cpal::SampleFormat::U64 => typed_output_stream::<u64>(device, config, channels, buffer),
+        cpal::SampleFormat::F32 => typed_output_stream::<f32>(device, config, channels, buffer),
+        cpal::SampleFormat::F64 => typed_output_stream::<f64>(device, config, channels, buffer),
+        other => return Err(format!("Unsupported audio output sample format: {other:?}")),
+    };
+    stream.map_err(|e| format!("Failed to open audio output stream: {e}"))
+}
+
+/// Build an output stream for a concrete sample type, fanning the mono buffer
+/// out to every channel. Completion is observed by the watcher polling the
+/// shared buffer cursor, so the callback needs no extra signaling.
+fn typed_output_stream<T>(
+    device: &cpal::Device,
+    config: &cpal::StreamConfig,
+    channels: usize,
+    buffer: Arc<Mutex<PlaybackBuffer>>,
+) -> Result<cpal::Stream, cpal::BuildStreamError>
+where
+    T: cpal::SizedSample + cpal::FromSample<f32>,
+{
+    device.build_output_stream(
+        config,
+        move |data: &mut [T], _| {
+            let mut buf = buffer.lock();
+            for frame in data.chunks_mut(channels) {
+                let converted = match buf.next_sample() {
+                    Some(value) => <T as cpal::Sample>::from_sample(value),
+                    None => <T as cpal::Sample>::EQUILIBRIUM,
+                };
+                for slot in frame.iter_mut() {
+                    *slot = converted;
+                }
+            }
+        },
+        |err| {
+            tracing::warn!(target: "aethon::voice", error = %err, "output stream error");
+        },
+        None,
+    )
+}
+
+/// Poll the playback buffer at ~20 Hz, emitting `voice://playback-level` for a
+/// speaking meter and a final `voice://playback-finished` once drained.
+fn spawn_playback_watcher(
+    app: Option<AppHandle>,
+    buffer: Arc<Mutex<PlaybackBuffer>>,
+) -> AbortHandle {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(std::time::Duration::from_millis(50));
+        let mut last_pos = 0usize;
+        loop {
+            interval.tick().await;
+            let (level, done, pos) = {
+                let buf = buffer.lock();
+                let end = buf.pos.min(buf.samples.len());
+                let start = last_pos.min(end);
+                (
+                    compute_rms(&buf.samples[start..end]),
+                    buf.finished(),
+                    buf.pos,
+                )
+            };
+            last_pos = pos;
+            if let Some(app) = &app {
+                let _ = app.emit("voice://playback-level", VoiceLevelPayload { level });
+            }
+            if done {
+                if let Some(app) = &app {
+                    let _ = app.emit("voice://playback-finished", ());
+                }
+                break;
+            }
+        }
+    })
+    .abort_handle()
+}

--- a/src-tauri/src/voice/providers.rs
+++ b/src-tauri/src/voice/providers.rs
@@ -351,6 +351,177 @@ impl VoiceProvider for DistilWhisperCandleProvider {
     }
 }
 
+#[cfg(target_os = "macos")]
+fn lfm2_accelerator_label() -> &'static str {
+    "Metal via llama.cpp"
+}
+
+#[cfg(not(target_os = "macos"))]
+fn lfm2_accelerator_label() -> &'static str {
+    "CPU via llama.cpp"
+}
+
+pub(super) struct Lfm2AudioProvider;
+
+#[async_trait]
+impl VoiceProvider for Lfm2AudioProvider {
+    fn id(&self) -> &'static str {
+        LFM2_ID
+    }
+
+    fn metadata(&self, registry: &VoiceProviderRegistry) -> VoiceProviderMetadata {
+        let cache_path = registry.lfm2_cache_path();
+        VoiceProviderMetadata {
+            id: self.id().to_string(),
+            name: "LFM2-Audio (Liquid AI)".to_string(),
+            description: "On-device speech recognition powered by Liquid AI's LFM2-Audio 1.5B \
+                          through llama.cpp. Audio stays local after the one-time model download."
+                .to_string(),
+            kind: VoiceProviderKind::LocalModel,
+            recording_mode: VoiceRecordingMode::Native,
+            privacy_label: "Private after download; audio stays local".to_string(),
+            offline: true,
+            download_required: true,
+            model_size_label: Some("About 1.7 GB (Q8_0)".to_string()),
+            cache_path: Some(cache_path.display().to_string()),
+            accelerator_label: Some(lfm2_accelerator_label().to_string()),
+        }
+    }
+
+    fn status(&self, registry: &VoiceProviderRegistry, db: &VoiceSettings) -> VoiceProviderInfo {
+        let enabled = registry.enabled(db, self.id());
+        let metadata = self.metadata(registry);
+        if !enabled {
+            return VoiceProviderInfo {
+                metadata,
+                status: VoiceProviderStatus::Unavailable,
+                status_label: "Disabled".to_string(),
+                enabled: false,
+                selected: false,
+                setup_required: false,
+                can_remove_model: false,
+                error: None,
+            };
+        }
+
+        let cache_path = registry.lfm2_cache_path();
+        let installed = lfm2_model_ready(&cache_path);
+        let downloading = registry.active_downloads.lock().contains(self.id());
+        let binary_available = registry.lfm2.binary_available();
+        let model_status = db
+            .get_app_setting(&model_status_key(self.id()))
+            .ok()
+            .flatten();
+
+        // Precedence: an in-flight download wins; then a missing runtime binary
+        // (an install problem the download can't fix); then installed/ready;
+        // then a recorded download error; otherwise setup is still required.
+        let (status, status_label, setup_required, error) = if downloading {
+            (
+                VoiceProviderStatus::Downloading,
+                "Downloading model".to_string(),
+                true,
+                None,
+            )
+        } else if !binary_available {
+            (
+                VoiceProviderStatus::EngineUnavailable,
+                "Runtime unavailable".to_string(),
+                false,
+                Some(LFM2_BINARY_MISSING.to_string()),
+            )
+        } else if installed {
+            (
+                VoiceProviderStatus::Ready,
+                LFM2_READY_MESSAGE.to_string(),
+                false,
+                None,
+            )
+        } else if model_status
+            .as_deref()
+            .is_some_and(|status| status.starts_with("error:"))
+        {
+            (
+                VoiceProviderStatus::Error,
+                "Download failed".to_string(),
+                true,
+                model_status.map(|s| s.trim_start_matches("error:").to_string()),
+            )
+        } else {
+            (
+                VoiceProviderStatus::NeedsSetup,
+                "Download required".to_string(),
+                true,
+                None,
+            )
+        };
+
+        VoiceProviderInfo {
+            metadata,
+            status,
+            status_label,
+            enabled,
+            selected: registry.selected_provider(db).as_deref() == Some(self.id()),
+            setup_required,
+            can_remove_model: installed,
+            error,
+        }
+    }
+
+    async fn prepare(
+        &self,
+        registry: &VoiceProviderRegistry,
+        app: &AppHandle,
+        db_path: &Path,
+    ) -> Result<VoiceProviderInfo, String> {
+        let cache_path = registry.lfm2_cache_path();
+        tokio::fs::create_dir_all(&cache_path)
+            .await
+            .map_err(|e| format!("Failed to create model cache: {e}"))?;
+        {
+            let mut active_downloads = registry.active_downloads.lock();
+            if !active_downloads.insert(self.id().to_string()) {
+                let db = VoiceSettings::open(db_path).map_err(|e| e.to_string())?;
+                return Ok(self.status(registry, &db));
+            }
+        }
+        let active_download = ActiveDownloadGuard {
+            registry,
+            provider_id: self.id(),
+        };
+        {
+            let db = VoiceSettings::open(db_path).map_err(|e| e.to_string())?;
+            let info = self.status(registry, &db);
+            let _ = app.emit("voice-provider-status", &info);
+        }
+
+        let result = download_lfm2_model(app, self.id(), &cache_path).await;
+        drop(active_download);
+        match result {
+            Ok(()) => {
+                let db = VoiceSettings::open(db_path).map_err(|e| e.to_string())?;
+                db.set_app_setting(&model_status_key(self.id()), "installed")
+                    .map_err(|e| e.to_string())?;
+                let info = self.status(registry, &db);
+                let _ = app.emit("voice-provider-status", &info);
+                Ok(info)
+            }
+            Err(err) => {
+                let db = VoiceSettings::open(db_path).map_err(|e| e.to_string())?;
+                let _ = db.set_app_setting(&model_status_key(self.id()), &format!("error:{err}"));
+                let _ = app.emit(
+                    "voice-error",
+                    VoiceErrorEvent {
+                        provider_id: Some(self.id().to_string()),
+                        message: err.clone(),
+                    },
+                );
+                Err(err)
+            }
+        }
+    }
+}
+
 pub(super) struct ActiveDownloadGuard<'a> {
     registry: &'a VoiceProviderRegistry,
     provider_id: &'static str,
@@ -373,8 +544,10 @@ pub(super) fn model_status_key(provider_id: &str) -> String {
     format!("voice:{provider_id}:model_status")
 }
 
-pub(super) fn distil_model_ready(cache_path: &Path) -> bool {
-    DISTIL_MODEL_FILES.iter().all(|(filename, min_size)| {
+/// A model is "ready" when every required file exists and, where a minimum
+/// size is known, is at least that large (guards against truncated downloads).
+pub(super) fn model_files_ready(cache_path: &Path, files: &[(&str, Option<u64>)]) -> bool {
+    files.iter().all(|(filename, min_size)| {
         let path = cache_path.join(filename);
         if let Some(min_size) = min_size {
             path.metadata().is_ok_and(|m| m.len() >= *min_size)
@@ -382,4 +555,12 @@ pub(super) fn distil_model_ready(cache_path: &Path) -> bool {
             path.is_file()
         }
     })
+}
+
+pub(super) fn distil_model_ready(cache_path: &Path) -> bool {
+    model_files_ready(cache_path, &DISTIL_MODEL_FILES)
+}
+
+pub(super) fn lfm2_model_ready(cache_path: &Path) -> bool {
+    model_files_ready(cache_path, &LFM2_MODEL_FILES)
 }

--- a/src-tauri/src/voice/registry.rs
+++ b/src-tauri/src/voice/registry.rs
@@ -533,7 +533,15 @@ impl VoiceProviderRegistry {
         }
 
         let cancel = Arc::new(AtomicBool::new(false));
-        *self.active_tts_cancel.lock() = Some(Arc::clone(&cancel));
+        {
+            // A newer request supersedes any in-flight synthesis: cancel the
+            // previous one so its runner process can't finish and start
+            // playback after the user moved on (or hit stop).
+            let mut slot = self.active_tts_cancel.lock();
+            if let Some(previous) = slot.replace(Arc::clone(&cancel)) {
+                previous.store(true, Ordering::Relaxed);
+            }
+        }
 
         let timeout = self.transcription_timeout;
         let lfm2 = Arc::clone(&self.lfm2);

--- a/src-tauri/src/voice/registry.rs
+++ b/src-tauri/src/voice/registry.rs
@@ -11,6 +11,7 @@ pub struct VoiceProviderRegistry {
     transcription_timeout: Duration,
     active_distil_cancel: Mutex<Option<Arc<AtomicBool>>>,
     active_lfm2_cancel: Mutex<Option<Arc<AtomicBool>>>,
+    active_tts_cancel: Mutex<Option<Arc<AtomicBool>>>,
     pub(super) active_downloads: Mutex<std::collections::HashSet<String>>,
 }
 
@@ -109,6 +110,7 @@ impl VoiceProviderRegistry {
             transcription_timeout,
             active_distil_cancel: Mutex::new(None),
             active_lfm2_cancel: Mutex::new(None),
+            active_tts_cancel: Mutex::new(None),
             active_downloads: Mutex::new(std::collections::HashSet::new()),
         }
     }
@@ -514,6 +516,48 @@ impl VoiceProviderRegistry {
         }
         let _ = self.active_recording.lock().take();
         Ok(())
+    }
+
+    /// Synthesize speech for `text` via the LFM2-Audio runner, returning 24 kHz
+    /// mono PCM. Requires the LFM2 model + binary; cancellable via
+    /// `cancel_speech` and bounded by the shared transcription timeout.
+    pub async fn synthesize_speech(&self, text: String) -> Result<CapturedAudio, String> {
+        if text.trim().is_empty() {
+            return Err("Nothing to speak".to_string());
+        }
+        if !lfm2_model_ready(&self.lfm2_cache_path()) {
+            return Err("Download the LFM2-Audio model before using text-to-speech".to_string());
+        }
+        if !self.lfm2.binary_available() {
+            return Err(LFM2_BINARY_MISSING.to_string());
+        }
+
+        let cancel = Arc::new(AtomicBool::new(false));
+        *self.active_tts_cancel.lock() = Some(Arc::clone(&cancel));
+
+        let timeout = self.transcription_timeout;
+        let lfm2 = Arc::clone(&self.lfm2);
+        let cancel_for_task = Arc::clone(&cancel);
+        let result = tokio::time::timeout(timeout, lfm2.tts(text, cancel_for_task)).await;
+        if result.is_err() {
+            cancel.store(true, Ordering::Relaxed);
+        }
+
+        {
+            let mut active = self.active_tts_cancel.lock();
+            if active.as_ref().is_some_and(|a| Arc::ptr_eq(a, &cancel)) {
+                *active = None;
+            }
+        }
+
+        result.map_err(|_| timeout_error_message(timeout))?
+    }
+
+    /// Signal any in-flight speech synthesis to abort.
+    pub fn cancel_speech(&self) {
+        if let Some(cancel) = self.active_tts_cancel.lock().clone() {
+            cancel.store(true, Ordering::Relaxed);
+        }
     }
 
     fn ensure_known(&self, provider_id: &str) -> Result<(), String> {

--- a/src-tauri/src/voice/registry.rs
+++ b/src-tauri/src/voice/registry.rs
@@ -6,9 +6,11 @@ pub struct VoiceProviderRegistry {
     recorder: Arc<dyn AudioRecorder>,
     transcriber: Arc<dyn VoiceTranscriber>,
     pub(super) platform_speech: Arc<dyn PlatformSpeechEngine>,
+    pub(super) lfm2: Arc<dyn Lfm2Backend>,
     backend_checker: Arc<dyn CandleBackendChecker>,
     transcription_timeout: Duration,
     active_distil_cancel: Mutex<Option<Arc<AtomicBool>>>,
+    active_lfm2_cancel: Mutex<Option<Arc<AtomicBool>>>,
     pub(super) active_downloads: Mutex<std::collections::HashSet<String>>,
 }
 
@@ -95,17 +97,28 @@ impl VoiceProviderRegistry {
         backend_checker: Arc<dyn CandleBackendChecker>,
         transcription_timeout: Duration,
     ) -> Self {
+        let lfm2: Arc<dyn Lfm2Backend> = Arc::new(Lfm2CliBackend::new(model_root.clone()));
         Self {
             model_root,
             active_recording: Mutex::new(None),
             recorder,
             transcriber,
             platform_speech,
+            lfm2,
             backend_checker,
             transcription_timeout,
             active_distil_cancel: Mutex::new(None),
+            active_lfm2_cancel: Mutex::new(None),
             active_downloads: Mutex::new(std::collections::HashSet::new()),
         }
+    }
+
+    /// Swap in a fake LFM2 backend for tests, leaving the rest of the runtime
+    /// intact. Mirrors the recorder/transcriber substitution helpers above.
+    #[cfg(test)]
+    pub(super) fn with_lfm2_backend(mut self, lfm2: Arc<dyn Lfm2Backend>) -> Self {
+        self.lfm2 = lfm2;
+        self
     }
 
     pub fn default_model_root() -> PathBuf {
@@ -122,10 +135,15 @@ impl VoiceProviderRegistry {
         self.model_root.join(DISTIL_CACHE_DIR)
     }
 
+    pub fn lfm2_cache_path(&self) -> PathBuf {
+        self.model_root.join(LFM2_CACHE_DIR)
+    }
+
     pub fn list_providers(&self, db: &VoiceSettings) -> Vec<VoiceProviderInfo> {
         vec![
             PlatformVoiceProvider.status(self, db),
             DistilWhisperCandleProvider.status(self, db),
+            Lfm2AudioProvider.status(self, db),
         ]
     }
 
@@ -172,6 +190,7 @@ impl VoiceProviderRegistry {
                     .prepare(self, app, db_path)
                     .await
             }
+            LFM2_ID => Lfm2AudioProvider.prepare(self, app, db_path).await,
             _ => Err(format!("Unknown voice provider: {provider_id}")),
         }
     }
@@ -182,23 +201,28 @@ impl VoiceProviderRegistry {
         provider_id: &str,
     ) -> Result<VoiceProviderInfo, String> {
         self.ensure_known(provider_id)?;
-        if provider_id != DISTIL_ID {
-            return Err("This provider does not use a removable local model".to_string());
-        }
+        let cache_path = match provider_id {
+            DISTIL_ID => self.distil_cache_path(),
+            LFM2_ID => self.lfm2_cache_path(),
+            _ => return Err("This provider does not use a removable local model".to_string()),
+        };
 
-        let path = self.distil_cache_path();
-        if tokio::fs::try_exists(&path)
+        if tokio::fs::try_exists(&cache_path)
             .await
             .map_err(|e| e.to_string())?
         {
-            tokio::fs::remove_dir_all(&path)
+            tokio::fs::remove_dir_all(&cache_path)
                 .await
                 .map_err(|e| format!("Failed to remove model cache: {e}"))?;
         }
         let db = VoiceSettings::open(db_path).map_err(|e| e.to_string())?;
         db.set_app_setting(&model_status_key(provider_id), "not-installed")
             .map_err(|e| e.to_string())?;
-        Ok(DistilWhisperCandleProvider.status(self, &db))
+        let info = match provider_id {
+            LFM2_ID => Lfm2AudioProvider.status(self, &db),
+            _ => DistilWhisperCandleProvider.status(self, &db),
+        };
+        Ok(info)
     }
 
     pub async fn start_recording(
@@ -211,6 +235,7 @@ impl VoiceProviderRegistry {
         let stream_open_ms = match provider_id {
             PLATFORM_ID => self.start_platform_recording(db_path, app).await,
             DISTIL_ID => self.start_distil_recording(db_path, app).await,
+            LFM2_ID => self.start_lfm2_recording(db_path, app).await,
             _ => Err(format!("Unknown voice provider: {provider_id}")),
         }?;
         Ok(VoiceStartLatency { stream_open_ms })
@@ -221,6 +246,7 @@ impl VoiceProviderRegistry {
         match provider_id {
             PLATFORM_ID => self.stop_platform_recording().await,
             DISTIL_ID => self.stop_distil_recording().await,
+            LFM2_ID => self.stop_lfm2_recording().await,
             _ => Err(format!("Unknown voice provider: {provider_id}")),
         }
     }
@@ -230,6 +256,7 @@ impl VoiceProviderRegistry {
         match provider_id {
             PLATFORM_ID => self.cancel_platform_recording().await,
             DISTIL_ID => self.cancel_distil_recording().await,
+            LFM2_ID => self.cancel_lfm2_recording().await,
             _ => Err(format!("Unknown voice provider: {provider_id}")),
         }
     }
@@ -405,9 +432,93 @@ impl VoiceProviderRegistry {
         Ok(())
     }
 
+    async fn start_lfm2_recording(
+        &self,
+        db_path: &Path,
+        app: Option<AppHandle>,
+    ) -> Result<u128, String> {
+        {
+            let db = VoiceSettings::open(db_path).map_err(|e| e.to_string())?;
+            if !self.enabled(&db, LFM2_ID) {
+                return Err("LFM2-Audio voice input is disabled".to_string());
+            }
+            if !lfm2_model_ready(&self.lfm2_cache_path()) {
+                return Err("Download the LFM2-Audio model before recording".to_string());
+            }
+            if !self.lfm2.binary_available() {
+                return Err(LFM2_BINARY_MISSING.to_string());
+            }
+        }
+
+        let mut active = self.active_recording.lock();
+        if active.is_some() {
+            return Err("Voice recording is already active".to_string());
+        }
+        let t_stream = Instant::now();
+        let mut session = self.recorder.start()?;
+        let stream_open_ms = t_stream.elapsed().as_millis();
+        if let Some(app) = app {
+            let abort = spawn_level_emitter(app, Arc::clone(&session.samples));
+            session._level_task = Some(LevelTask(abort));
+        }
+        *active = Some(session);
+        Ok(stream_open_ms)
+    }
+
+    async fn stop_lfm2_recording(&self) -> Result<String, String> {
+        let session = self
+            .active_recording
+            .lock()
+            .take()
+            .ok_or_else(|| "No voice recording is active".to_string())?;
+        let audio = session.finish()?;
+        if audio.samples.is_empty() {
+            return Err("No audio was captured".to_string());
+        }
+        validate_captured_audio(&audio)?;
+
+        let cancel = Arc::new(AtomicBool::new(false));
+        *self.active_lfm2_cancel.lock() = Some(Arc::clone(&cancel));
+
+        let timeout = self.transcription_timeout;
+        let lfm2 = Arc::clone(&self.lfm2);
+        let cancel_for_task = Arc::clone(&cancel);
+        // The runner is a subprocess, so the work is naturally async (no
+        // blocking pool needed). On timeout we both drop the future
+        // (`kill_on_drop` reaps the child) and flip the cancel flag.
+        let result = tokio::time::timeout(timeout, lfm2.asr(audio, cancel_for_task)).await;
+        if result.is_err() {
+            cancel.store(true, Ordering::Relaxed);
+        }
+
+        {
+            let mut active = self.active_lfm2_cancel.lock();
+            if active.as_ref().is_some_and(|a| Arc::ptr_eq(a, &cancel)) {
+                *active = None;
+            }
+        }
+
+        let transcript = result.map_err(|_| timeout_error_message(timeout))??;
+        let transcript = transcript.trim().to_string();
+        if transcript.is_empty() {
+            return Err(
+                "No speech was recognized. Try again closer to the microphone.".to_string(),
+            );
+        }
+        Ok(transcript)
+    }
+
+    async fn cancel_lfm2_recording(&self) -> Result<(), String> {
+        if let Some(cancel) = self.active_lfm2_cancel.lock().clone() {
+            cancel.store(true, Ordering::Relaxed);
+        }
+        let _ = self.active_recording.lock().take();
+        Ok(())
+    }
+
     fn ensure_known(&self, provider_id: &str) -> Result<(), String> {
         match provider_id {
-            PLATFORM_ID | DISTIL_ID => Ok(()),
+            PLATFORM_ID | DISTIL_ID | LFM2_ID => Ok(()),
             _ => Err(format!("Unknown voice provider: {provider_id}")),
         }
     }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -5,7 +5,7 @@
   "identifier": "com.utensils.aethon",
   "build": {
     "beforeDevCommand": "bun run dev",
-    "beforeBuildCommand": "bun run build",
+    "beforeBuildCommand": "bash scripts/stage-lfm2-runner.sh && bun run build",
     "devUrl": "http://localhost:1420",
     "frontendDist": "../dist"
   },
@@ -37,6 +37,7 @@
     "longDescription": "Aethon wraps the pi-coding-agent in a Tauri 2 desktop workspace where the agent renders its UI as A2UI components. The agent can mutate the layout in real time — registering sidebar sections, themes, and interactive panels via globalThis.aethon — making the entire window an extension surface, not just the chat.",
     "externalBin": ["binaries/aethon-agent"],
     "resources": {
+      "binaries/lfm2-audio": "lfm2-audio",
       "binaries/pi/package.json": "pi/package.json",
       "../docs/aethon-agent/README.md": "docs/aethon-agent/README.md",
       "../docs/aethon-agent/api.md": "docs/aethon-agent/api.md",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { useAppForwardRefs } from "./app/useAppForwardRefs";
 import type { A2UIPayload } from "./types/a2ui";
 import type { Tab } from "./types/tab";
 import { useZoomAndTheme } from "./hooks/useZoomAndTheme";
+import { useSpeakReplies } from "./hooks/useSpeakReplies";
 import { useShellConsent } from "./hooks/useShellConsent";
 import { useHostInfo } from "./hooks/useHostInfo";
 import { useDevshell, type DevshellEntry } from "./hooks/useDevshell";
@@ -412,6 +413,11 @@ export default function App() {
   // tabBucketsRef so the live set spans every project bucket, not just the
   // active one (tabs are project-scoped).
   useAgentWorkerReconcile(stateRef, tabBucketsRef);
+
+  // Speak the agent's reply aloud on turn completion when enabled (LFM2-Audio
+  // text-to-speech). Listens for the `aethon://agent-turn-complete` signal
+  // emitted by the response_end handler.
+  useSpeakReplies(stateRef);
 
   // Hydrate per-workspace tab buckets restored from disk into tabBucketsRef so
   // switching to a backgrounded workspace after a restart lands on its

--- a/src/config.ts
+++ b/src/config.ts
@@ -89,6 +89,12 @@ export interface AethonConfig {
   voice: {
     toggleHotkey: string | null;
     holdHotkey: string | null;
+    /** When true, the agent's reply is spoken aloud (via the LFM2-Audio
+     *  provider's text-to-speech) once a turn completes on the active tab. */
+    speakAgentReplies: boolean;
+    /** Upper bound on how many characters of a reply are spoken, so a long
+     *  diff or log dump isn't read out in full. */
+    speakMaxChars: number;
   };
   updates: {
     /** Release channel the auto-updater follows. `"stable"` (default)
@@ -160,6 +166,8 @@ const DEFAULTS: AethonConfig = {
       (/Mac/.test(navigator.platform) || /Mac OS X/.test(navigator.userAgent))
         ? "AltRight"
         : null,
+    speakAgentReplies: false,
+    speakMaxChars: 600,
   },
   updates: { channel: "stable", disableAutoCheck: false },
   devshell: {
@@ -274,6 +282,12 @@ export function getConfig(): Promise<AethonConfig> {
               : obj?.voice?.holdHotkey === null
                 ? null
                 : DEFAULTS.voice.holdHotkey,
+          speakAgentReplies: obj?.voice?.speakAgentReplies === true,
+          speakMaxChars:
+            typeof obj?.voice?.speakMaxChars === "number" &&
+            Number.isFinite(obj.voice.speakMaxChars)
+              ? Math.min(5000, Math.max(50, Math.round(obj.voice.speakMaxChars)))
+              : DEFAULTS.voice.speakMaxChars,
         },
         updates: {
           channel: obj?.updates?.channel === "nightly" ? "nightly" : "stable",

--- a/src/config.ts
+++ b/src/config.ts
@@ -95,6 +95,9 @@ export interface AethonConfig {
     /** Upper bound on how many characters of a reply are spoken, so a long
      *  diff or log dump isn't read out in full. */
     speakMaxChars: number;
+    /** In conversation voice mode, auto-reopen the mic after the agent
+     *  finishes speaking (hands-free) instead of waiting for a tap. */
+    conversationContinuous: boolean;
   };
   updates: {
     /** Release channel the auto-updater follows. `"stable"` (default)
@@ -168,6 +171,7 @@ const DEFAULTS: AethonConfig = {
         : null,
     speakAgentReplies: false,
     speakMaxChars: 600,
+    conversationContinuous: false,
   },
   updates: { channel: "stable", disableAutoCheck: false },
   devshell: {
@@ -288,6 +292,7 @@ export function getConfig(): Promise<AethonConfig> {
             Number.isFinite(obj.voice.speakMaxChars)
               ? Math.min(5000, Math.max(50, Math.round(obj.voice.speakMaxChars)))
               : DEFAULTS.voice.speakMaxChars,
+          conversationContinuous: obj?.voice?.conversationContinuous === true,
         },
         updates: {
           channel: obj?.updates?.channel === "nightly" ? "nightly" : "stable",

--- a/src/config.ts
+++ b/src/config.ts
@@ -171,7 +171,7 @@ const DEFAULTS: AethonConfig = {
         : null,
     speakAgentReplies: false,
     speakMaxChars: 600,
-    conversationContinuous: false,
+    conversationContinuous: true,
   },
   updates: { channel: "stable", disableAutoCheck: false },
   devshell: {
@@ -292,7 +292,8 @@ export function getConfig(): Promise<AethonConfig> {
             Number.isFinite(obj.voice.speakMaxChars)
               ? Math.min(5000, Math.max(50, Math.round(obj.voice.speakMaxChars)))
               : DEFAULTS.voice.speakMaxChars,
-          conversationContinuous: obj?.voice?.conversationContinuous === true,
+          conversationContinuous:
+            obj?.voice?.conversationContinuous !== false,
         },
         updates: {
           channel: obj?.updates?.channel === "nightly" ? "nightly" : "stable",

--- a/src/extensions/default-layout/chat-input.tsx
+++ b/src/extensions/default-layout/chat-input.tsx
@@ -175,7 +175,7 @@ export function ChatInput({
   const conversation = useVoiceConversation({
     submitText: (text) => onEvent("submit", { value: text, mode: "normal" }),
     getActiveTabId: () => state.activeTabId as string | undefined,
-    continuous: voiceConfig.conversationContinuous ?? false,
+    continuous: voiceConfig.conversationContinuous ?? true,
     maxSpokenChars: voiceConfig.speakMaxChars ?? 600,
     onNeedsSetup: (providerId) => onEvent("voice:setup", { providerId }),
   });

--- a/src/extensions/default-layout/chat-input.tsx
+++ b/src/extensions/default-layout/chat-input.tsx
@@ -35,11 +35,13 @@ import { useComposerResize } from "./use-composer-resize";
 import { useDraftCommit } from "./use-draft-commit";
 import { useVoiceHotkey } from "../../hooks/useVoiceHotkey";
 import { useVoiceInput } from "../../hooks/useVoiceInput";
+import { useVoiceConversation } from "../../hooks/useVoiceConversation";
 import {
   insertTranscriptAtSelection,
   shouldOpenVoiceSettingsForError,
 } from "../../utils/voice";
 import { VoiceMeter } from "./voice-meter";
+import { ConversationHud } from "./conversation-hud";
 import {
   type ArgMatch,
   type CommandMatch,
@@ -163,8 +165,20 @@ export function ChatInput({
   const voiceState = voice.state;
   const cancelVoice = voice.cancel;
   const voiceConfig = (state.voice as
-    | { toggleHotkey?: string | null; holdHotkey?: string | null }
+    | {
+        toggleHotkey?: string | null;
+        holdHotkey?: string | null;
+        speakMaxChars?: number;
+        conversationContinuous?: boolean;
+      }
     | undefined) ?? { toggleHotkey: "mod+shift+m", holdHotkey: null };
+  const conversation = useVoiceConversation({
+    submitText: (text) => onEvent("submit", { value: text, mode: "normal" }),
+    getActiveTabId: () => state.activeTabId as string | undefined,
+    continuous: voiceConfig.conversationContinuous ?? false,
+    maxSpokenChars: voiceConfig.speakMaxChars ?? 600,
+    onNeedsSetup: (providerId) => onEvent("voice:setup", { providerId }),
+  });
   const settings = state.settings as { open?: boolean } | undefined;
   const palette = state.commandPalette as { open?: boolean } | undefined;
   const search = state.search as { open?: boolean } | undefined;
@@ -438,6 +452,14 @@ export function ChatInput({
           onRemove={(id) => onEvent("attachment:remove", { id })}
         />
       )}
+      {conversation.active && (
+        <ConversationHud
+          phase={conversation.phase}
+          error={conversation.error}
+          onPrimary={conversation.primaryAction}
+          onExit={conversation.exit}
+        />
+      )}
       <div className="a2ui-chat-input-field-wrap">
         <textarea
           ref={textareaRef}
@@ -493,6 +515,28 @@ export function ChatInput({
           ) : (
             <MicIcon />
           )}
+        </button>
+        <button
+          type="button"
+          className={`a2ui-chat-input-voice a2ui-chat-input-conversation ${
+            conversation.active ? "a2ui-chat-input-conversation-active" : ""
+          }`}
+          onClick={() =>
+            conversation.active ? conversation.exit() : conversation.enter()
+          }
+          disabled={busy && !conversation.active}
+          aria-label={
+            conversation.active
+              ? "Exit voice conversation"
+              : "Start voice conversation"
+          }
+          title={
+            conversation.active
+              ? "Exit voice conversation"
+              : "Start voice conversation"
+          }
+        >
+          <ConversationIcon />
         </button>
         {busy ? (
           <button
@@ -657,6 +701,33 @@ function VoiceStatus({
     );
   }
   return null;
+}
+
+function ConversationIcon() {
+  // A speech / conversation glyph (two overlapping bubbles).
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      aria-hidden="true"
+    >
+      <path
+        d="M2 4.5A1.5 1.5 0 0 1 3.5 3h6A1.5 1.5 0 0 1 11 4.5v3A1.5 1.5 0 0 1 9.5 9H6L3.5 11V9A1.5 1.5 0 0 1 2 7.5v-3Z"
+        stroke="currentColor"
+        strokeWidth="1.3"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M6.5 11.5A1.5 1.5 0 0 0 8 13h3l1.5 1.5V13A1.5 1.5 0 0 0 14 11.5V9"
+        stroke="currentColor"
+        strokeWidth="1.3"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
 }
 
 function voiceButtonLabel(state: VoiceView["state"]): string {

--- a/src/extensions/default-layout/conversation-hud.tsx
+++ b/src/extensions/default-layout/conversation-hud.tsx
@@ -1,0 +1,66 @@
+import type { ConversationPhase } from "../../hooks/useVoiceConversation";
+
+const STATUS_LABEL: Record<ConversationPhase, string> = {
+  idle: "Tap speak, then talk",
+  listening: "Listening…",
+  transcribing: "Transcribing…",
+  thinking: "Thinking…",
+  speaking: "Speaking…",
+};
+
+const PRIMARY_LABEL: Record<ConversationPhase, string> = {
+  idle: "Speak",
+  listening: "Done",
+  transcribing: "…",
+  thinking: "Stop",
+  speaking: "Stop",
+};
+
+export interface ConversationHudProps {
+  phase: ConversationPhase;
+  error: string | null;
+  onPrimary: () => void;
+  onExit: () => void;
+}
+
+/** Compact in-composer panel for the LFM2-Audio conversation voice mode:
+ *  shows the current phase plus a context-aware primary action and an exit. */
+export function ConversationHud({
+  phase,
+  error,
+  onPrimary,
+  onExit,
+}: ConversationHudProps) {
+  return (
+    <div
+      className="a2ui-conversation-hud"
+      role="group"
+      aria-label="Voice conversation"
+    >
+      <span
+        className={`a2ui-conversation-hud-dot a2ui-conversation-hud-${phase}`}
+        aria-hidden="true"
+      />
+      <span className="a2ui-conversation-hud-status" aria-live="polite">
+        {error ?? STATUS_LABEL[phase]}
+      </span>
+      <button
+        type="button"
+        className="a2ui-conversation-hud-primary"
+        disabled={phase === "transcribing"}
+        onClick={onPrimary}
+      >
+        {PRIMARY_LABEL[phase]}
+      </button>
+      <button
+        type="button"
+        className="a2ui-conversation-hud-exit"
+        onClick={onExit}
+        aria-label="Exit voice conversation"
+        title="Exit voice conversation"
+      >
+        Exit
+      </button>
+    </div>
+  );
+}

--- a/src/extensions/default-layout/conversation-hud.tsx
+++ b/src/extensions/default-layout/conversation-hud.tsx
@@ -1,8 +1,8 @@
 import type { ConversationPhase } from "../../hooks/useVoiceConversation";
 
 const STATUS_LABEL: Record<ConversationPhase, string> = {
-  idle: "Tap speak, then talk",
-  listening: "Listening…",
+  idle: "Paused — tap to talk",
+  listening: "Listening… (pause when done)",
   transcribing: "Transcribing…",
   thinking: "Thinking…",
   speaking: "Speaking…",

--- a/src/extensions/default-layout/settings-panel/panel.test.tsx
+++ b/src/extensions/default-layout/settings-panel/panel.test.tsx
@@ -39,6 +39,7 @@ vi.mock("../../../config", () => ({
         holdHotkey: "AltRight",
         speakAgentReplies: false,
         speakMaxChars: 600,
+        conversationContinuous: false,
       },
       updates: { channel: "stable", disableAutoCheck: false },
       devshell: {

--- a/src/extensions/default-layout/settings-panel/panel.test.tsx
+++ b/src/extensions/default-layout/settings-panel/panel.test.tsx
@@ -34,7 +34,12 @@ vi.mock("../../../config", () => ({
         promptBeforeClose: true,
       },
       shortcuts: { newTabKind: "agent" },
-      voice: { toggleHotkey: "mod+shift+m", holdHotkey: "AltRight" },
+      voice: {
+        toggleHotkey: "mod+shift+m",
+        holdHotkey: "AltRight",
+        speakAgentReplies: false,
+        speakMaxChars: 600,
+      },
       updates: { channel: "stable", disableAutoCheck: false },
       devshell: {
         enabled: "auto",

--- a/src/extensions/default-layout/settings-panel/panel.tsx
+++ b/src/extensions/default-layout/settings-panel/panel.tsx
@@ -507,6 +507,20 @@ export function SettingsPanel({ state, onEvent }: BuiltinComponentProps) {
                   }
                 />
               </Field>
+              <Field label="Hands-free conversation (auto-reopen mic)">
+                <input
+                  type="checkbox"
+                  checked={eff.voice.conversationContinuous}
+                  onChange={(e) =>
+                    update({
+                      voice: {
+                        ...eff.voice,
+                        conversationContinuous: e.target.checked,
+                      },
+                    })
+                  }
+                />
+              </Field>
               <VoiceProviders />
             </Section>
 

--- a/src/extensions/default-layout/settings-panel/panel.tsx
+++ b/src/extensions/default-layout/settings-panel/panel.tsx
@@ -476,6 +476,37 @@ export function SettingsPanel({ state, onEvent }: BuiltinComponentProps) {
                   }
                 />
               </Field>
+              <Field label="Speak agent replies aloud (LFM2-Audio)">
+                <input
+                  type="checkbox"
+                  checked={eff.voice.speakAgentReplies}
+                  onChange={(e) =>
+                    update({
+                      voice: {
+                        ...eff.voice,
+                        speakAgentReplies: e.target.checked,
+                      },
+                    })
+                  }
+                />
+              </Field>
+              <Field label="Spoken reply length (characters)">
+                <input
+                  type="number"
+                  className="ae-settings-input"
+                  min={50}
+                  max={5000}
+                  value={eff.voice.speakMaxChars}
+                  onChange={(e) =>
+                    update({
+                      voice: {
+                        ...eff.voice,
+                        speakMaxChars: Number(e.target.value) || 600,
+                      },
+                    })
+                  }
+                />
+              </Field>
               <VoiceProviders />
             </Section>
 

--- a/src/hooks/bridgeMessageHandlers/responseEnd.test.ts
+++ b/src/hooks/bridgeMessageHandlers/responseEnd.test.ts
@@ -1,7 +1,12 @@
+// @vitest-environment jsdom
 import { describe, expect, it } from "vitest";
 import { handleResponseEnd } from "./responseEnd";
 import { buildHandlerFixture } from "./testFixtures";
 import { makeEmptyTab } from "../../types/tab";
+import {
+  onAgentTurnComplete,
+  type AgentTurnCompleteDetail,
+} from "../../utils/agentTurnEvents";
 
 describe("handleResponseEnd", () => {
   it("clears waiting + status, dismisses hang notification, fires completion", () => {
@@ -84,5 +89,54 @@ describe("handleResponseEnd", () => {
       waiting: true,
     };
     expect(updater(seed).waiting).toBe(false);
+  });
+
+  it("emits agent-turn-complete with the final agent text", () => {
+    const tabId = "default";
+    const { ctx } = buildHandlerFixture({ state: { activeTabId: tabId } });
+    const seed = {
+      ...makeEmptyTab(tabId, "Tab 1"),
+      messages: [
+        { id: "u1", role: "user" as const, text: "hi" },
+        { id: "a1", role: "agent" as const, text: "Hello there." },
+      ],
+    };
+    // The real updateTab runs its mutator synchronously; make the mock do the
+    // same so the handler captures the reply text it just flushed.
+    ctx.updateTab = (_id, mutator) => {
+      mutator(seed);
+    };
+    const events: AgentTurnCompleteDetail[] = [];
+    const off = onAgentTurnComplete((detail) => events.push(detail));
+
+    handleResponseEnd({ type: "response_end", tabId }, ctx);
+    off();
+
+    expect(events).toEqual([{ tabId, text: "Hello there." }]);
+  });
+
+  it("emits empty text for a tool-only turn", () => {
+    const tabId = "default";
+    const { ctx } = buildHandlerFixture({ state: { activeTabId: tabId } });
+    const seed = {
+      ...makeEmptyTab(tabId, "Tab 1"),
+      messages: [
+        {
+          id: "a1",
+          role: "agent" as const,
+          a2ui: { components: [{ id: "t", type: "tool-card", children: [] }] },
+        },
+      ],
+    };
+    ctx.updateTab = (_id, mutator) => {
+      mutator(seed);
+    };
+    const events: AgentTurnCompleteDetail[] = [];
+    const off = onAgentTurnComplete((detail) => events.push(detail));
+
+    handleResponseEnd({ type: "response_end", tabId }, ctx);
+    off();
+
+    expect(events).toEqual([{ tabId, text: "" }]);
   });
 });

--- a/src/hooks/bridgeMessageHandlers/responseEnd.ts
+++ b/src/hooks/bridgeMessageHandlers/responseEnd.ts
@@ -1,4 +1,6 @@
 import { closeRunningToolCards } from "../../utils/agentBusy";
+import { emitAgentTurnComplete } from "../../utils/agentTurnEvents";
+import { lastAgentText } from "../../utils/messages";
 import type { BridgeMessageHandler } from "./types";
 import { flushResponseDeltas } from "./responseDelta";
 
@@ -11,7 +13,12 @@ export const handleResponseEnd: BridgeMessageHandler = (data, ctx) => {
   // re-flips it to true while popping the head and dispatching the
   // next message — same render commit, so the Send button doesn't
   // flash. When the queue is empty, waiting stays false.
+  // `updateTab` runs its mutator synchronously against the store, so the
+  // final reply text is captured here (deltas were just flushed) and
+  // broadcast below for speak-agent-replies / conversation mode.
+  let finalAgentText = "";
   ctx.updateTab(tabId, (tab) => {
+    finalAgentText = lastAgentText(tab.messages);
     const closedTools = closeRunningToolCards(tab.messages);
     return {
       ...tab,
@@ -19,6 +26,7 @@ export const handleResponseEnd: BridgeMessageHandler = (data, ctx) => {
       ...(closedTools.changed ? { messages: closedTools.messages } : {}),
     };
   });
+  emitAgentTurnComplete({ tabId, text: finalAgentText });
   // Drop the tab from the bucket-independent running set (see promptStarted).
   ctx.setState((prev) => {
     const running = prev.agentRunningTabs as Record<string, true> | undefined;

--- a/src/hooks/uiOverlays/settings.test.ts
+++ b/src/hooks/uiOverlays/settings.test.ts
@@ -48,6 +48,7 @@ const baseConfig: AethonConfig = {
     holdHotkey: "AltRight",
     speakAgentReplies: false,
     speakMaxChars: 600,
+    conversationContinuous: false,
   },
   updates: { channel: "nightly", disableAutoCheck: false },
   devshell: {

--- a/src/hooks/uiOverlays/settings.test.ts
+++ b/src/hooks/uiOverlays/settings.test.ts
@@ -43,7 +43,12 @@ const baseConfig: AethonConfig = {
     promptBeforeClose: true,
   },
   shortcuts: { newTabKind: "agent" },
-  voice: { toggleHotkey: "mod+shift+m", holdHotkey: "AltRight" },
+  voice: {
+    toggleHotkey: "mod+shift+m",
+    holdHotkey: "AltRight",
+    speakAgentReplies: false,
+    speakMaxChars: 600,
+  },
   updates: { channel: "nightly", disableAutoCheck: false },
   devshell: {
     enabled: "auto",

--- a/src/hooks/useBootConfig.ts
+++ b/src/hooks/useBootConfig.ts
@@ -125,6 +125,7 @@ export function useBootConfig(ctx: UseBootConfigContext): UseBootConfigActions {
         holdHotkey: fresh.voice.holdHotkey,
         speakAgentReplies: fresh.voice.speakAgentReplies,
         speakMaxChars: fresh.voice.speakMaxChars,
+        conversationContinuous: fresh.voice.conversationContinuous,
       },
       // Global transcript-visibility defaults, mirrored into state so the
       // renderer's resolver can read them via $ref. Per-tab overrides win.
@@ -220,6 +221,7 @@ export function useBootConfig(ctx: UseBootConfigContext): UseBootConfigActions {
             holdHotkey: config.voice.holdHotkey,
             speakAgentReplies: config.voice.speakAgentReplies,
             speakMaxChars: config.voice.speakMaxChars,
+            conversationContinuous: config.voice.conversationContinuous,
           },
           transcriptVisibility: {
             thinking: config.ui.thinkingVisibility,

--- a/src/hooks/useBootConfig.ts
+++ b/src/hooks/useBootConfig.ts
@@ -123,6 +123,8 @@ export function useBootConfig(ctx: UseBootConfigContext): UseBootConfigActions {
         ...(prev.voice as object | undefined),
         toggleHotkey: fresh.voice.toggleHotkey,
         holdHotkey: fresh.voice.holdHotkey,
+        speakAgentReplies: fresh.voice.speakAgentReplies,
+        speakMaxChars: fresh.voice.speakMaxChars,
       },
       // Global transcript-visibility defaults, mirrored into state so the
       // renderer's resolver can read them via $ref. Per-tab overrides win.
@@ -216,6 +218,8 @@ export function useBootConfig(ctx: UseBootConfigContext): UseBootConfigActions {
             ...(prev.voice as object | undefined),
             toggleHotkey: config.voice.toggleHotkey,
             holdHotkey: config.voice.holdHotkey,
+            speakAgentReplies: config.voice.speakAgentReplies,
+            speakMaxChars: config.voice.speakMaxChars,
           },
           transcriptVisibility: {
             thinking: config.ui.thinkingVisibility,

--- a/src/hooks/useSpeakReplies.test.ts
+++ b/src/hooks/useSpeakReplies.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, renderHook } from "@testing-library/react";
+import type { MutableRefObject } from "react";
+import { useSpeakReplies } from "./useSpeakReplies";
+import { emitAgentTurnComplete } from "../utils/agentTurnEvents";
+
+const { invokeMock } = vi.hoisted(() => ({
+  invokeMock: vi.fn((..._args: unknown[]) => Promise.resolve()),
+}));
+vi.mock("@tauri-apps/api/core", () => ({ invoke: invokeMock }));
+
+function stateRef(
+  value: Record<string, unknown>,
+): MutableRefObject<Record<string, unknown>> {
+  return { current: value };
+}
+
+describe("useSpeakReplies", () => {
+  beforeEach(() => invokeMock.mockClear());
+  // Unmount the hook between tests so its window listener doesn't leak and fire
+  // on a later test's emit.
+  afterEach(() => cleanup());
+
+  it("speaks the reply on the active tab when enabled", () => {
+    const ref = stateRef({
+      activeTabId: "t1",
+      voice: { speakAgentReplies: true, speakMaxChars: 600 },
+    });
+    renderHook(() => useSpeakReplies(ref));
+
+    emitAgentTurnComplete({ tabId: "t1", text: "All done." });
+
+    expect(invokeMock).toHaveBeenCalledWith("voice_speak", { text: "All done." });
+  });
+
+  it("does nothing when speak-agent-replies is off", () => {
+    const ref = stateRef({
+      activeTabId: "t1",
+      voice: { speakAgentReplies: false, speakMaxChars: 600 },
+    });
+    renderHook(() => useSpeakReplies(ref));
+
+    emitAgentTurnComplete({ tabId: "t1", text: "All done." });
+
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it("ignores turns finishing on a background tab", () => {
+    const ref = stateRef({
+      activeTabId: "t1",
+      voice: { speakAgentReplies: true, speakMaxChars: 600 },
+    });
+    renderHook(() => useSpeakReplies(ref));
+
+    emitAgentTurnComplete({ tabId: "t2", text: "Background reply." });
+
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it("skips empty / tool-only turns", () => {
+    const ref = stateRef({
+      activeTabId: "t1",
+      voice: { speakAgentReplies: true, speakMaxChars: 600 },
+    });
+    renderHook(() => useSpeakReplies(ref));
+
+    emitAgentTurnComplete({ tabId: "t1", text: "   " });
+
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it("caps long replies to speakMaxChars", () => {
+    const ref = stateRef({
+      activeTabId: "t1",
+      voice: { speakAgentReplies: true, speakMaxChars: 12 },
+    });
+    renderHook(() => useSpeakReplies(ref));
+
+    emitAgentTurnComplete({
+      tabId: "t1",
+      text: "one two three four five six seven",
+    });
+
+    const spoken = invokeMock.mock.calls[0]?.[1] as { text: string };
+    expect(spoken.text.length).toBeLessThanOrEqual(12);
+  });
+});

--- a/src/hooks/useSpeakReplies.ts
+++ b/src/hooks/useSpeakReplies.ts
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import type { MutableRefObject } from "react";
 import { onAgentTurnComplete } from "../utils/agentTurnEvents";
+import { isConversationActive } from "../utils/conversationMode";
 import { speakVoice } from "../services/voice";
 import { capSpokenText } from "../utils/voice";
 
@@ -22,6 +23,8 @@ export function useSpeakReplies(
 ): void {
   useEffect(() => {
     return onAgentTurnComplete(({ tabId, text }) => {
+      // The conversation voice mode owns synthesis while it runs.
+      if (isConversationActive()) return;
       const state = stateRef.current;
       const voice = (state.voice as VoiceSettingsSlice | undefined) ?? {};
       if (!voice.speakAgentReplies) return;

--- a/src/hooks/useSpeakReplies.ts
+++ b/src/hooks/useSpeakReplies.ts
@@ -1,0 +1,42 @@
+import { useEffect } from "react";
+import type { MutableRefObject } from "react";
+import { onAgentTurnComplete } from "../utils/agentTurnEvents";
+import { speakVoice } from "../services/voice";
+import { capSpokenText } from "../utils/voice";
+
+interface VoiceSettingsSlice {
+  speakAgentReplies?: boolean;
+  speakMaxChars?: number;
+}
+
+const DEFAULT_MAX_CHARS = 600;
+
+/** Speak the agent's reply aloud when a turn completes, if the user enabled
+ *  "speak agent replies" and the turn finished on the *active* tab. Reads
+ *  config + active tab from the live state ref so it never goes stale and the
+ *  listener is registered only once. Best-effort: synthesis/playback errors
+ *  (e.g. model not downloaded) are swallowed — the Settings panel surfaces
+ *  provider state. */
+export function useSpeakReplies(
+  stateRef: MutableRefObject<Record<string, unknown>>,
+): void {
+  useEffect(() => {
+    return onAgentTurnComplete(({ tabId, text }) => {
+      const state = stateRef.current;
+      const voice = (state.voice as VoiceSettingsSlice | undefined) ?? {};
+      if (!voice.speakAgentReplies) return;
+      if (tabId !== (state.activeTabId as string | undefined)) return;
+
+      const maxChars =
+        typeof voice.speakMaxChars === "number" && voice.speakMaxChars > 0
+          ? voice.speakMaxChars
+          : DEFAULT_MAX_CHARS;
+      const spoken = capSpokenText(text, maxChars);
+      if (!spoken) return;
+
+      void speakVoice(spoken).catch(() => {
+        // Swallow — a missing model / disabled provider shouldn't raise here.
+      });
+    });
+  }, [stateRef]);
+}

--- a/src/hooks/useVoiceConversation.test.ts
+++ b/src/hooks/useVoiceConversation.test.ts
@@ -5,8 +5,11 @@ import { useVoiceConversation } from "./useVoiceConversation";
 import { emitAgentTurnComplete } from "../utils/agentTurnEvents";
 import { isConversationActive } from "../utils/conversationMode";
 
-const { mocks, playback } = vi.hoisted(() => ({
-  playback: { fn: undefined as undefined | (() => void) },
+const { mocks, ev } = vi.hoisted(() => ({
+  ev: {
+    fn: undefined as undefined | (() => void),
+    level: undefined as undefined | ((e: { payload: { level: number } }) => void),
+  },
   mocks: {
     startVoiceRecording: vi.fn(() => Promise.resolve()),
     stopAndTranscribeVoice: vi.fn(() => Promise.resolve("hello agent")),
@@ -25,8 +28,10 @@ vi.mock("../services/voice", () => ({
 }));
 
 vi.mock("@tauri-apps/api/event", () => ({
-  listen: (name: string, cb: () => void) => {
-    if (name === "voice://playback-finished") playback.fn = cb;
+  listen: (name: string, cb: (e?: unknown) => void) => {
+    if (name === "voice://playback-finished") ev.fn = cb as () => void;
+    if (name === "voice://level")
+      ev.level = cb as (e: { payload: { level: number } }) => void;
     return Promise.resolve(() => {});
   },
 }));
@@ -57,7 +62,8 @@ describe("useVoiceConversation", () => {
     Object.values(mocks).forEach((m) => m.mockClear());
     mocks.startVoiceRecording.mockResolvedValue(undefined);
     mocks.stopAndTranscribeVoice.mockResolvedValue("hello agent");
-    playback.fn = undefined;
+    ev.fn = undefined;
+    ev.level = undefined;
   });
   afterEach(() => cleanup());
 
@@ -83,7 +89,7 @@ describe("useVoiceConversation", () => {
     expect(mocks.speakVoice).toHaveBeenCalledWith("The reply.");
     expect(result.current.phase).toBe("speaking");
 
-    act(() => playback.fn?.());
+    act(() => ev.fn?.());
     await flush();
     expect(result.current.phase).toBe("idle");
   });
@@ -98,10 +104,54 @@ describe("useVoiceConversation", () => {
     await flush();
     mocks.startVoiceRecording.mockClear();
 
-    act(() => playback.fn?.());
+    act(() => ev.fn?.());
     await flush();
     expect(mocks.startVoiceRecording).toHaveBeenCalledTimes(1);
     expect(result.current.phase).toBe("listening");
+  });
+
+  it("auto-ends the utterance on silence (hands-free, no tap)", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      vi.setSystemTime(1000);
+      const { result, submitText } = makeController(true);
+      act(() => result.current.enter());
+      await flush();
+      expect(result.current.phase).toBe("listening");
+
+      // The user speaks...
+      act(() => ev.level?.({ payload: { level: 0.12 } }));
+      // ...then goes quiet for longer than the silence-hang window.
+      vi.setSystemTime(1000 + 1500);
+      act(() => ev.level?.({ payload: { level: 0.0 } }));
+      await flush();
+
+      // VAD finished the turn without any manual "done" action.
+      expect(mocks.stopAndTranscribeVoice).toHaveBeenCalled();
+      expect(submitText).toHaveBeenCalledWith("hello agent");
+      expect(result.current.phase).toBe("thinking");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not auto-end before the user has spoken", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      vi.setSystemTime(1000);
+      const { result } = makeController(true);
+      act(() => result.current.enter());
+      await flush();
+
+      // Pure silence (no speech yet) must not end the turn, no matter how long.
+      vi.setSystemTime(1000 + 5000);
+      act(() => ev.level?.({ payload: { level: 0.0 } }));
+      await flush();
+      expect(mocks.stopAndTranscribeVoice).not.toHaveBeenCalled();
+      expect(result.current.phase).toBe("listening");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("ignores a turn-complete for a different tab", async () => {

--- a/src/hooks/useVoiceConversation.test.ts
+++ b/src/hooks/useVoiceConversation.test.ts
@@ -55,6 +55,7 @@ function makeController(continuous = false) {
 describe("useVoiceConversation", () => {
   beforeEach(() => {
     Object.values(mocks).forEach((m) => m.mockClear());
+    mocks.startVoiceRecording.mockResolvedValue(undefined);
     mocks.stopAndTranscribeVoice.mockResolvedValue("hello agent");
     playback.fn = undefined;
   });
@@ -125,6 +126,27 @@ describe("useVoiceConversation", () => {
     await flush();
     expect(submitText).not.toHaveBeenCalled();
     expect(result.current.phase).toBe("idle");
+  });
+
+  it("ignores a second start while the first is still opening the mic", async () => {
+    let resolveStart: () => void = () => {};
+    mocks.startVoiceRecording.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveStart = resolve;
+        }),
+    );
+    const { result } = makeController(false);
+
+    act(() => result.current.enter()); // first start — hangs in the open window
+    act(() => result.current.primaryAction()); // second tap during the window
+    expect(mocks.startVoiceRecording).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveStart();
+      await Promise.resolve();
+    });
+    expect(result.current.phase).toBe("listening");
   });
 
   it("exit cancels recording/playback and clears the active flag", async () => {

--- a/src/hooks/useVoiceConversation.test.ts
+++ b/src/hooks/useVoiceConversation.test.ts
@@ -28,10 +28,9 @@ vi.mock("../services/voice", () => ({
 }));
 
 vi.mock("@tauri-apps/api/event", () => ({
-  listen: (name: string, cb: (e?: unknown) => void) => {
-    if (name === "voice://playback-finished") ev.fn = cb as () => void;
-    if (name === "voice://level")
-      ev.level = cb as (e: { payload: { level: number } }) => void;
+  listen: (name: string, cb: (e: { payload: { level: number } }) => void) => {
+    if (name === "voice://playback-finished") ev.fn = () => cb({ payload: { level: 0 } });
+    if (name === "voice://level") ev.level = cb;
     return Promise.resolve(() => {});
   },
 }));

--- a/src/hooks/useVoiceConversation.test.ts
+++ b/src/hooks/useVoiceConversation.test.ts
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { useVoiceConversation } from "./useVoiceConversation";
+import { emitAgentTurnComplete } from "../utils/agentTurnEvents";
+import { isConversationActive } from "../utils/conversationMode";
+
+const { mocks, playback } = vi.hoisted(() => ({
+  playback: { fn: undefined as undefined | (() => void) },
+  mocks: {
+    startVoiceRecording: vi.fn(() => Promise.resolve()),
+    stopAndTranscribeVoice: vi.fn(() => Promise.resolve("hello agent")),
+    speakVoice: vi.fn(() => Promise.resolve()),
+    cancelVoiceRecording: vi.fn(() => Promise.resolve()),
+    stopVoicePlayback: vi.fn(() => Promise.resolve()),
+  },
+}));
+
+vi.mock("../services/voice", () => ({
+  startVoiceRecording: mocks.startVoiceRecording,
+  stopAndTranscribeVoice: mocks.stopAndTranscribeVoice,
+  speakVoice: mocks.speakVoice,
+  cancelVoiceRecording: mocks.cancelVoiceRecording,
+  stopVoicePlayback: mocks.stopVoicePlayback,
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: (name: string, cb: () => void) => {
+    if (name === "voice://playback-finished") playback.fn = cb;
+    return Promise.resolve(() => {});
+  },
+}));
+
+/** Flush pending microtasks created by the hook's async transitions. */
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function makeController(continuous = false) {
+  const submitText = vi.fn();
+  const { result, unmount } = renderHook(() =>
+    useVoiceConversation({
+      submitText,
+      getActiveTabId: () => "t1",
+      continuous,
+      maxSpokenChars: 600,
+    }),
+  );
+  return { result, submitText, unmount };
+}
+
+describe("useVoiceConversation", () => {
+  beforeEach(() => {
+    Object.values(mocks).forEach((m) => m.mockClear());
+    mocks.stopAndTranscribeVoice.mockResolvedValue("hello agent");
+    playback.fn = undefined;
+  });
+  afterEach(() => cleanup());
+
+  it("runs a full turn: listen → transcribe → submit → speak → idle", async () => {
+    const { result, submitText } = makeController(false);
+
+    act(() => result.current.enter());
+    await flush();
+    expect(mocks.startVoiceRecording).toHaveBeenCalledWith(
+      "voice-lfm2-audio-llamacpp",
+    );
+    expect(result.current.phase).toBe("listening");
+    expect(isConversationActive()).toBe(true);
+
+    act(() => result.current.primaryAction());
+    await flush();
+    expect(mocks.stopAndTranscribeVoice).toHaveBeenCalled();
+    expect(submitText).toHaveBeenCalledWith("hello agent");
+    expect(result.current.phase).toBe("thinking");
+
+    act(() => emitAgentTurnComplete({ tabId: "t1", text: "The reply." }));
+    await flush();
+    expect(mocks.speakVoice).toHaveBeenCalledWith("The reply.");
+    expect(result.current.phase).toBe("speaking");
+
+    act(() => playback.fn?.());
+    await flush();
+    expect(result.current.phase).toBe("idle");
+  });
+
+  it("re-opens the mic after speaking in continuous mode", async () => {
+    const { result } = makeController(true);
+    act(() => result.current.enter());
+    await flush();
+    act(() => result.current.primaryAction());
+    await flush();
+    act(() => emitAgentTurnComplete({ tabId: "t1", text: "Reply." }));
+    await flush();
+    mocks.startVoiceRecording.mockClear();
+
+    act(() => playback.fn?.());
+    await flush();
+    expect(mocks.startVoiceRecording).toHaveBeenCalledTimes(1);
+    expect(result.current.phase).toBe("listening");
+  });
+
+  it("ignores a turn-complete for a different tab", async () => {
+    const { result } = makeController(false);
+    act(() => result.current.enter());
+    await flush();
+    act(() => result.current.primaryAction());
+    await flush();
+
+    act(() => emitAgentTurnComplete({ tabId: "other", text: "Not mine." }));
+    await flush();
+    expect(mocks.speakVoice).not.toHaveBeenCalled();
+    expect(result.current.phase).toBe("thinking");
+  });
+
+  it("does not submit an empty transcript", async () => {
+    const { result, submitText } = makeController(false);
+    mocks.stopAndTranscribeVoice.mockResolvedValueOnce("   ");
+    act(() => result.current.enter());
+    await flush();
+    act(() => result.current.primaryAction());
+    await flush();
+    expect(submitText).not.toHaveBeenCalled();
+    expect(result.current.phase).toBe("idle");
+  });
+
+  it("exit cancels recording/playback and clears the active flag", async () => {
+    const { result } = makeController(false);
+    act(() => result.current.enter());
+    await flush();
+
+    act(() => result.current.exit());
+    await flush();
+    expect(mocks.cancelVoiceRecording).toHaveBeenCalled();
+    expect(mocks.stopVoicePlayback).toHaveBeenCalled();
+    expect(result.current.active).toBe(false);
+    expect(isConversationActive()).toBe(false);
+  });
+});

--- a/src/hooks/useVoiceConversation.ts
+++ b/src/hooks/useVoiceConversation.ts
@@ -25,7 +25,8 @@ export interface UseVoiceConversationOptions {
   submitText: (text: string) => void;
   /** The tab the conversation is bound to, captured at submit time. */
   getActiveTabId: () => string | undefined;
-  /** Auto-reopen the mic after the agent finishes speaking. */
+  /** Hands-free: auto-reopen the mic after the agent finishes speaking so the
+   *  user never taps to start the next turn. */
   continuous: boolean;
   /** Cap on spoken reply length (shared with speak-agent-replies). */
   maxSpokenChars: number;
@@ -47,6 +48,21 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+// Voice-activity detection thresholds (over the recorder's ~30 Hz
+// `voice://level` RMS, where typical speech is ~0.05–0.15). Speech must first
+// be detected, then a sustained silence ends the utterance — so the user never
+// taps "done". Hysteresis (speech > silence) avoids flapping on word gaps.
+const VAD_SPEECH_LEVEL = 0.05;
+const VAD_SILENCE_LEVEL = 0.03;
+const VAD_SILENCE_HANG_MS = 1100;
+// Hard ceiling so a noisy room (level never dipping below silence) still ends
+// the turn rather than recording forever.
+const VAD_MAX_UTTERANCE_MS = 30_000;
+
+interface VoiceLevel {
+  level: number;
+}
+
 export function useVoiceConversation(
   options: UseVoiceConversationOptions,
 ): VoiceConversationController {
@@ -60,6 +76,11 @@ export function useVoiceConversation(
   const activeRef = useRef(false);
   const startingRef = useRef(false);
   const tabIdRef = useRef<string | undefined>(undefined);
+  // VAD bookkeeping for the current listening window.
+  const vadSpokeRef = useRef(false);
+  const lastSpeechAtRef = useRef(0);
+  const listenStartAtRef = useRef(0);
+  const finishRef = useRef<() => void>(() => {});
   const optionsRef = useRef(options);
   // Keep the latest callbacks/config available to async transitions without a
   // render-phase ref write (mirrors the voiceInputBlockedRef pattern).
@@ -85,6 +106,11 @@ export function useVoiceConversation(
         await cancelVoiceRecording(LFM2_VOICE_PROVIDER_ID).catch(() => {});
         return;
       }
+      // Arm VAD for this listening window (the level listener drives end-of-
+      // utterance, so no manual "done" tap is needed).
+      vadSpokeRef.current = false;
+      lastSpeechAtRef.current = 0;
+      listenStartAtRef.current = Date.now();
       setPhase("listening");
     } catch (caught) {
       setError(errorMessage(caught));
@@ -201,6 +227,46 @@ export function useVoiceConversation(
       unlisten?.();
     };
   }, [goIdleOrContinue]);
+
+  // Keep the latest finishListening reachable from the VAD listener without
+  // re-subscribing the event on every render.
+  useEffect(() => {
+    finishRef.current = () => void finishListening();
+  });
+
+  // Voice-activity detection: end the utterance automatically once the user
+  // stops talking. Drives a fluid, hands-free conversation — the mic closes on
+  // silence instead of a manual tap. Subscribed once; gated on the listening
+  // phase so dictation levels are ignored.
+  useEffect(() => {
+    let unlisten: (() => void) | undefined;
+    let cancelled = false;
+    void listen<VoiceLevel>("voice://level", ({ payload }) => {
+      if (!activeRef.current || phaseRef.current !== "listening") return;
+      const now = Date.now();
+      const level = payload?.level ?? 0;
+      if (level >= VAD_SPEECH_LEVEL) {
+        vadSpokeRef.current = true;
+        lastSpeechAtRef.current = now;
+        return;
+      }
+      if (!vadSpokeRef.current) return; // wait for speech before arming silence
+      const silentLongEnough =
+        level < VAD_SILENCE_LEVEL &&
+        now - lastSpeechAtRef.current >= VAD_SILENCE_HANG_MS;
+      const tooLong = now - listenStartAtRef.current >= VAD_MAX_UTTERANCE_MS;
+      if (silentLongEnough || tooLong) {
+        finishRef.current();
+      }
+    }).then((fn) => {
+      if (cancelled) fn();
+      else unlisten = fn;
+    });
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, []);
 
   // Tear down recording/playback if we unmount mid-conversation.
   useEffect(() => {

--- a/src/hooks/useVoiceConversation.ts
+++ b/src/hooks/useVoiceConversation.ts
@@ -1,0 +1,210 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { listen } from "@tauri-apps/api/event";
+import {
+  cancelVoiceRecording,
+  speakVoice,
+  startVoiceRecording,
+  stopAndTranscribeVoice,
+  stopVoicePlayback,
+} from "../services/voice";
+import { onAgentTurnComplete } from "../utils/agentTurnEvents";
+import { setConversationActive } from "../utils/conversationMode";
+import { LFM2_VOICE_PROVIDER_ID, capSpokenText } from "../utils/voice";
+
+/** A full turn of the LFM2-Audio conversation loop:
+ *  idle → listening → transcribing → thinking → speaking → (continue|idle). */
+export type ConversationPhase =
+  | "idle"
+  | "listening"
+  | "transcribing"
+  | "thinking"
+  | "speaking";
+
+export interface UseVoiceConversationOptions {
+  /** Send the transcript to the agent (reuses the composer submit path). */
+  submitText: (text: string) => void;
+  /** The tab the conversation is bound to, captured at submit time. */
+  getActiveTabId: () => string | undefined;
+  /** Auto-reopen the mic after the agent finishes speaking. */
+  continuous: boolean;
+  /** Cap on spoken reply length (shared with speak-agent-replies). */
+  maxSpokenChars: number;
+  /** Routed to Settings when the LFM2 model/binary isn't ready. */
+  onNeedsSetup?: (providerId: string) => void;
+}
+
+export interface VoiceConversationController {
+  active: boolean;
+  phase: ConversationPhase;
+  error: string | null;
+  enter: () => void;
+  exit: () => void;
+  /** Context-aware tap: start speaking / finish speaking / interrupt. */
+  primaryAction: () => void;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function useVoiceConversation(
+  options: UseVoiceConversationOptions,
+): VoiceConversationController {
+  const [active, setActive] = useState(false);
+  const [phase, setPhaseState] = useState<ConversationPhase>("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  // Mirror the latest values for use inside async callbacks / event listeners,
+  // which would otherwise close over stale state.
+  const phaseRef = useRef<ConversationPhase>("idle");
+  const activeRef = useRef(false);
+  const tabIdRef = useRef<string | undefined>(undefined);
+  const optionsRef = useRef(options);
+  // Keep the latest callbacks/config available to async transitions without a
+  // render-phase ref write (mirrors the voiceInputBlockedRef pattern).
+  useEffect(() => {
+    optionsRef.current = options;
+  });
+
+  const setPhase = useCallback((next: ConversationPhase) => {
+    phaseRef.current = next;
+    setPhaseState(next);
+  }, []);
+
+  const startListening = useCallback(async () => {
+    setError(null);
+    try {
+      await startVoiceRecording(LFM2_VOICE_PROVIDER_ID);
+      if (!activeRef.current) {
+        // Conversation was exited while the start call was in flight.
+        await cancelVoiceRecording(LFM2_VOICE_PROVIDER_ID).catch(() => {});
+        return;
+      }
+      setPhase("listening");
+    } catch (caught) {
+      setError(errorMessage(caught));
+      setPhase("idle");
+      optionsRef.current.onNeedsSetup?.(LFM2_VOICE_PROVIDER_ID);
+    }
+  }, [setPhase]);
+
+  const goIdleOrContinue = useCallback(() => {
+    if (activeRef.current && optionsRef.current.continuous) {
+      void startListening();
+    } else {
+      setPhase("idle");
+    }
+  }, [setPhase, startListening]);
+
+  const finishListening = useCallback(async () => {
+    if (phaseRef.current !== "listening") return;
+    setPhase("transcribing");
+    try {
+      const transcript = await stopAndTranscribeVoice(LFM2_VOICE_PROVIDER_ID);
+      if (!activeRef.current) return;
+      const text = transcript.trim();
+      if (!text) {
+        goIdleOrContinue();
+        return;
+      }
+      // Bind the reply we await to the tab we sent on.
+      tabIdRef.current = optionsRef.current.getActiveTabId();
+      optionsRef.current.submitText(text);
+      setPhase("thinking");
+    } catch (caught) {
+      setError(errorMessage(caught));
+      setPhase("idle");
+    }
+  }, [goIdleOrContinue, setPhase]);
+
+  const interrupt = useCallback(() => {
+    void stopVoicePlayback().catch(() => {});
+    void cancelVoiceRecording(LFM2_VOICE_PROVIDER_ID).catch(() => {});
+    setPhase("idle");
+  }, [setPhase]);
+
+  const enter = useCallback(() => {
+    if (activeRef.current) return;
+    activeRef.current = true;
+    setActive(true);
+    setConversationActive(true);
+    void startListening();
+  }, [startListening]);
+
+  const exit = useCallback(() => {
+    activeRef.current = false;
+    setActive(false);
+    setConversationActive(false);
+    void cancelVoiceRecording(LFM2_VOICE_PROVIDER_ID).catch(() => {});
+    void stopVoicePlayback().catch(() => {});
+    setPhase("idle");
+    setError(null);
+  }, [setPhase]);
+
+  const primaryAction = useCallback(() => {
+    switch (phaseRef.current) {
+      case "idle":
+        void startListening();
+        break;
+      case "listening":
+        void finishListening();
+        break;
+      case "thinking":
+      case "speaking":
+        interrupt();
+        break;
+      case "transcribing":
+        break; // mid-flight; ignore taps
+    }
+  }, [finishListening, interrupt, startListening]);
+
+  // Speak the agent's reply once the turn completes, then continue/idle.
+  useEffect(() => {
+    return onAgentTurnComplete(({ tabId, text }) => {
+      if (!activeRef.current || phaseRef.current !== "thinking") return;
+      if (tabIdRef.current && tabId !== tabIdRef.current) return;
+      const spoken = capSpokenText(text, optionsRef.current.maxSpokenChars);
+      if (!spoken) {
+        goIdleOrContinue();
+        return;
+      }
+      setPhase("speaking");
+      void speakVoice(spoken).catch(() => {
+        if (activeRef.current && phaseRef.current === "speaking") {
+          goIdleOrContinue();
+        }
+      });
+    });
+  }, [goIdleOrContinue, setPhase]);
+
+  // Advance the loop when the spoken reply finishes playing.
+  useEffect(() => {
+    let unlisten: (() => void) | undefined;
+    let cancelled = false;
+    void listen("voice://playback-finished", () => {
+      if (activeRef.current && phaseRef.current === "speaking") {
+        goIdleOrContinue();
+      }
+    }).then((fn) => {
+      if (cancelled) fn();
+      else unlisten = fn;
+    });
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, [goIdleOrContinue]);
+
+  // Tear down recording/playback if we unmount mid-conversation.
+  useEffect(() => {
+    return () => {
+      if (activeRef.current) {
+        setConversationActive(false);
+        void cancelVoiceRecording(LFM2_VOICE_PROVIDER_ID).catch(() => {});
+        void stopVoicePlayback().catch(() => {});
+      }
+    };
+  }, []);
+
+  return { active, phase, error, enter, exit, primaryAction };
+}

--- a/src/hooks/useVoiceConversation.ts
+++ b/src/hooks/useVoiceConversation.ts
@@ -58,6 +58,7 @@ export function useVoiceConversation(
   // which would otherwise close over stale state.
   const phaseRef = useRef<ConversationPhase>("idle");
   const activeRef = useRef(false);
+  const startingRef = useRef(false);
   const tabIdRef = useRef<string | undefined>(undefined);
   const optionsRef = useRef(options);
   // Keep the latest callbacks/config available to async transitions without a
@@ -72,6 +73,10 @@ export function useVoiceConversation(
   }, []);
 
   const startListening = useCallback(async () => {
+    // Guard the start window: phase is still "idle" until the recorder opens,
+    // so without this a second tap would fire another (rejected) start.
+    if (startingRef.current) return;
+    startingRef.current = true;
     setError(null);
     try {
       await startVoiceRecording(LFM2_VOICE_PROVIDER_ID);
@@ -85,6 +90,8 @@ export function useVoiceConversation(
       setError(errorMessage(caught));
       setPhase("idle");
       optionsRef.current.onNeedsSetup?.(LFM2_VOICE_PROVIDER_ID);
+    } finally {
+      startingRef.current = false;
     }
   }, [setPhase]);
 

--- a/src/services/voice.test.ts
+++ b/src/services/voice.test.ts
@@ -7,8 +7,10 @@ import {
   removeVoiceProviderModel,
   setSelectedVoiceProvider,
   setVoiceProviderEnabled,
+  speakVoice,
   startVoiceRecording,
   stopAndTranscribeVoice,
+  stopVoicePlayback,
 } from "./voice";
 
 describe("voice service", () => {
@@ -28,6 +30,16 @@ describe("voice service", () => {
     await expect(listVoiceProviders()).resolves.toEqual([]);
 
     expect(harness.invoke).toHaveBeenCalledWith("voice_list_providers");
+  });
+
+  it("speaks text and stops playback", async () => {
+    await speakVoice("hello world");
+    await stopVoicePlayback();
+
+    expect(harness.invoke).toHaveBeenNthCalledWith(1, "voice_speak", {
+      text: "hello world",
+    });
+    expect(harness.invoke).toHaveBeenNthCalledWith(2, "voice_stop_playback");
   });
 
   it("serializes selected and enabled provider mutations", async () => {

--- a/src/services/voice.ts
+++ b/src/services/voice.ts
@@ -45,3 +45,13 @@ export function stopAndTranscribeVoice(
 export function cancelVoiceRecording(providerId?: string): Promise<void> {
   return invoke("voice_cancel_recording", { providerId: providerId ?? null });
 }
+
+/** Synthesize `text` via the LFM2-Audio provider and play it back. */
+export function speakVoice(text: string): Promise<void> {
+  return invoke("voice_speak", { text });
+}
+
+/** Stop any in-flight speech synthesis + playback. */
+export function stopVoicePlayback(): Promise<void> {
+  return invoke("voice_stop_playback");
+}

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -3854,8 +3854,9 @@ body.ae-resizing-composer * {
   border-radius: var(--radius-md);
   /* Right padding clears the absolute-positioned Send button so text
      doesn't run under it. Bottom padding clears the Send button when
-     the user types multiple lines. */
-  padding: 10px 86px 10px 14px;
+     the user types multiple lines. Right padding reserves room for the
+     full three-button cluster (send + mic + conversation, out to ~108px). */
+  padding: 10px 116px 10px 14px;
   font: inherit;
   outline: none;
   line-height: 1.5;

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -3925,6 +3925,66 @@ body.ae-resizing-composer * {
   color: var(--danger, #ef4444);
   border-color: color-mix(in srgb, currentColor 60%, transparent);
 }
+/* Conversation-mode toggle sits just left of the dictation mic. */
+.a2ui-chat-input-conversation {
+  right: 78px;
+}
+.a2ui-chat-input-conversation-active {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+/* In-composer conversation HUD (banner above the field). */
+.a2ui-conversation-hud {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  margin-bottom: 6px;
+  border: 1px solid var(--accent);
+  border-radius: var(--radius-sm);
+  background: var(--accent-soft);
+  font-size: var(--chrome-text-compact);
+}
+.a2ui-conversation-hud-status {
+  flex: 1 1 auto;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.a2ui-conversation-hud-dot {
+  flex: 0 0 auto;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--text-dim);
+}
+.a2ui-conversation-hud-listening,
+.a2ui-conversation-hud-speaking {
+  background: var(--accent);
+}
+.a2ui-conversation-hud-thinking {
+  background: var(--warning, #f59e0b);
+}
+.a2ui-conversation-hud-primary,
+.a2ui-conversation-hud-exit {
+  flex: 0 0 auto;
+  padding: 3px 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: var(--bg-active);
+  color: var(--text);
+  cursor: pointer;
+  font-size: inherit;
+}
+.a2ui-conversation-hud-primary {
+  border-color: var(--accent);
+}
+.a2ui-conversation-hud-primary:disabled {
+  opacity: var(--opacity-disabled);
+  cursor: default;
+}
 .a2ui-chat-input-voice-spinner {
   animation: a2ui-voice-spin 0.9s linear infinite;
 }

--- a/src/utils/agentTurnEvents.ts
+++ b/src/utils/agentTurnEvents.ts
@@ -1,0 +1,32 @@
+/** A window-level signal fired once per completed agent turn. Decouples the
+ *  bridge `response_end` handler (which knows the final reply) from features
+ *  that react to a turn finishing — speak-agent-replies today, the
+ *  conversation voice mode next — without threading them through the handler
+ *  context. */
+export const AGENT_TURN_COMPLETE_EVENT = "aethon://agent-turn-complete";
+
+export interface AgentTurnCompleteDetail {
+  tabId: string;
+  /** The final assistant text for the turn ("" for tool-only/empty turns). */
+  text: string;
+}
+
+export function emitAgentTurnComplete(detail: AgentTurnCompleteDetail): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(
+    new CustomEvent<AgentTurnCompleteDetail>(AGENT_TURN_COMPLETE_EVENT, {
+      detail,
+    }),
+  );
+}
+
+export function onAgentTurnComplete(
+  listener: (detail: AgentTurnCompleteDetail) => void,
+): () => void {
+  if (typeof window === "undefined") return () => {};
+  const handler = (event: Event) => {
+    listener((event as CustomEvent<AgentTurnCompleteDetail>).detail);
+  };
+  window.addEventListener(AGENT_TURN_COMPLETE_EVENT, handler);
+  return () => window.removeEventListener(AGENT_TURN_COMPLETE_EVENT, handler);
+}

--- a/src/utils/conversationMode.ts
+++ b/src/utils/conversationMode.ts
@@ -1,0 +1,13 @@
+/** Process-wide flag for whether the LFM2-Audio conversation voice mode is
+ *  driving the speak loop. While active, the conversation hook owns synthesis
+ *  + playback of agent replies, so `useSpeakReplies` stands down to avoid
+ *  double-speaking the same turn. */
+let active = false;
+
+export function setConversationActive(value: boolean): void {
+  active = value;
+}
+
+export function isConversationActive(): boolean {
+  return active;
+}

--- a/src/utils/messages.test.ts
+++ b/src/utils/messages.test.ts
@@ -3,11 +3,46 @@ import {
   MAX_A2UI_BYTES,
   MAX_TEXT_BYTES,
   coerceChatMessages,
+  lastAgentText,
   stripImageDataUrls,
   trimMessage,
   truncateToEntry,
 } from "./messages";
 import type { ChatMessage } from "../types/a2ui";
+
+describe("lastAgentText", () => {
+  it("returns the final agent text of the current turn", () => {
+    const messages: ChatMessage[] = [
+      { id: "u1", role: "user", text: "question" },
+      { id: "a1", role: "agent", text: "the answer" },
+    ];
+    expect(lastAgentText(messages)).toBe("the answer");
+  });
+
+  it("returns empty for a tool-only turn even after an earlier reply", () => {
+    const messages: ChatMessage[] = [
+      { id: "u1", role: "user", text: "first" },
+      { id: "a1", role: "agent", text: "old reply" },
+      { id: "u2", role: "user", text: "second" },
+      {
+        id: "a2",
+        role: "agent",
+        a2ui: { components: [{ id: "t", type: "tool-card", children: [] }] },
+      },
+    ];
+    // Must not replay "old reply" — the current turn produced no spoken text.
+    expect(lastAgentText(messages)).toBe("");
+  });
+
+  it("ignores thinking-only and empty agent messages", () => {
+    const messages: ChatMessage[] = [
+      { id: "u1", role: "user", text: "q" },
+      { id: "a1", role: "agent", thinking: "hmm" },
+      { id: "a2", role: "agent", text: "   " },
+    ];
+    expect(lastAgentText(messages)).toBe("");
+  });
+});
 
 describe("truncateToEntry", () => {
   const messages: ChatMessage[] = [

--- a/src/utils/messages.test.ts
+++ b/src/utils/messages.test.ts
@@ -34,6 +34,16 @@ describe("lastAgentText", () => {
     expect(lastAgentText(messages)).toBe("");
   });
 
+  it("still speaks the reply when a steer message lands after it", () => {
+    const messages: ChatMessage[] = [
+      { id: "u1", role: "user", text: "do the thing" },
+      { id: "a1", role: "agent", text: "Here is the result." },
+      { id: "u2", role: "user", text: "also check X", delivery: "steered" },
+    ];
+    // The steered user bubble is a mid-turn interjection, not a new turn.
+    expect(lastAgentText(messages)).toBe("Here is the result.");
+  });
+
   it("ignores thinking-only and empty agent messages", () => {
     const messages: ChatMessage[] = [
       { id: "u1", role: "user", text: "q" },

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -1,12 +1,14 @@
 import type { A2UIPayload, ChatAttachment, ChatMessage } from "../types/a2ui";
 
-/** The spoken text of the *current* turn's reply. Walks back only to the last
- *  user message so a tool-only / thinking-only / empty turn returns "" instead
- *  of replaying an earlier turn's reply (callers treat "" as "nothing to say"). */
+/** The spoken text of the *current* turn's reply. Walks back to the user
+ *  message that started the turn so a tool-only / thinking-only / empty turn
+ *  returns "" instead of replaying an earlier reply. A *steered* user message
+ *  is a mid-turn interjection (it lands after the agent's text), so it is not
+ *  treated as a turn boundary — the reply before it is still spoken. */
 export function lastAgentText(messages: ChatMessage[]): string {
   for (let i = messages.length - 1; i >= 0; i--) {
     const message = messages[i];
-    if (message.role === "user") break;
+    if (message.role === "user" && message.delivery !== "steered") break;
     if (
       message.role === "agent" &&
       typeof message.text === "string" &&

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -1,5 +1,22 @@
 import type { A2UIPayload, ChatAttachment, ChatMessage } from "../types/a2ui";
 
+/** The text of the last agent message that actually has spoken content.
+ *  Returns "" for a tool-only / thinking-only / empty turn, which callers
+ *  (e.g. speak-agent-replies) treat as "nothing to say". */
+export function lastAgentText(messages: ChatMessage[]): string {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (
+      message.role === "agent" &&
+      typeof message.text === "string" &&
+      message.text.trim().length > 0
+    ) {
+      return message.text;
+    }
+  }
+  return "";
+}
+
 // Persisted-history budget per message text. The in-memory message keeps
 // the full string; only the persisted snapshot is trimmed so localStorage
 // doesn't blow past quota.

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -1,11 +1,12 @@
 import type { A2UIPayload, ChatAttachment, ChatMessage } from "../types/a2ui";
 
-/** The text of the last agent message that actually has spoken content.
- *  Returns "" for a tool-only / thinking-only / empty turn, which callers
- *  (e.g. speak-agent-replies) treat as "nothing to say". */
+/** The spoken text of the *current* turn's reply. Walks back only to the last
+ *  user message so a tool-only / thinking-only / empty turn returns "" instead
+ *  of replaying an earlier turn's reply (callers treat "" as "nothing to say"). */
 export function lastAgentText(messages: ChatMessage[]): string {
   for (let i = messages.length - 1; i >= 0; i--) {
     const message = messages[i];
+    if (message.role === "user") break;
     if (
       message.role === "agent" &&
       typeof message.text === "string" &&

--- a/src/utils/voice.test.ts
+++ b/src/utils/voice.test.ts
@@ -2,12 +2,36 @@ import { describe, expect, it } from "vitest";
 import type { VoiceProviderInfo } from "../types/voice";
 import {
   PLATFORM_VOICE_PROVIDER_ID,
+  capSpokenText,
   chooseVoiceProvider,
   describeSpeechRecognitionError,
   formatVoiceDownloadProgress,
   insertTranscriptAtSelection,
   shouldOpenVoiceSettingsForError,
 } from "./voice";
+
+describe("capSpokenText", () => {
+  it("returns short text untouched (trimmed)", () => {
+    expect(capSpokenText("  hello world  ", 600)).toBe("hello world");
+  });
+
+  it("cuts at a sentence boundary when one is available", () => {
+    const text = "First sentence is here. Second sentence keeps going on and on.";
+    const out = capSpokenText(text, 30);
+    expect(out).toBe("First sentence is here.");
+  });
+
+  it("falls back to a word boundary, never mid-word", () => {
+    // No sentence boundary in the first 24 chars, so it cuts at the last space.
+    const out = capSpokenText("supercalifragilistic expialidocious extra", 24);
+    expect(out).toBe("supercalifragilistic");
+    expect(out.length).toBeLessThanOrEqual(24);
+  });
+
+  it("treats a non-positive cap as no cap", () => {
+    expect(capSpokenText("hello", 0)).toBe("hello");
+  });
+});
 
 function provider(
   overrides: Partial<VoiceProviderInfo> & Pick<VoiceProviderInfo, "id">,

--- a/src/utils/voice.ts
+++ b/src/utils/voice.ts
@@ -2,6 +2,28 @@ import type { VoiceDownloadProgress, VoiceProviderInfo } from "../types/voice";
 
 export const PLATFORM_VOICE_PROVIDER_ID = "voice-platform-system";
 
+/** Trim spoken text to at most `maxChars`, preferring a clean break: the last
+ *  sentence boundary inside the cap (if past the halfway point), otherwise the
+ *  last word boundary — so a long reply isn't read out in full and never gets
+ *  cut mid-word. */
+export function capSpokenText(text: string, maxChars: number): string {
+  const trimmed = text.trim();
+  if (maxChars <= 0 || trimmed.length <= maxChars) return trimmed;
+
+  const slice = trimmed.slice(0, maxChars);
+  const sentenceEnd = Math.max(
+    slice.lastIndexOf(". "),
+    slice.lastIndexOf("! "),
+    slice.lastIndexOf("? "),
+    slice.lastIndexOf("\n"),
+  );
+  if (sentenceEnd >= maxChars * 0.5) {
+    return slice.slice(0, sentenceEnd + 1).trim();
+  }
+  const wordEnd = slice.lastIndexOf(" ");
+  return (wordEnd > 0 ? slice.slice(0, wordEnd) : slice).trim();
+}
+
 export interface SpeechRecognitionErrorLike {
   error?: string;
   message?: string;

--- a/src/utils/voice.ts
+++ b/src/utils/voice.ts
@@ -1,6 +1,9 @@
 import type { VoiceDownloadProgress, VoiceProviderInfo } from "../types/voice";
 
 export const PLATFORM_VOICE_PROVIDER_ID = "voice-platform-system";
+/** Must match the Rust `LFM2_ID` constant. The conversation voice mode and
+ *  text-to-speech both require this provider (it owns ASR + TTS). */
+export const LFM2_VOICE_PROVIDER_ID = "voice-lfm2-audio-llamacpp";
 
 /** Trim spoken text to at most `maxChars`, preferring a clean break: the last
  *  sentence boundary inside the cap (if past the halfway point), otherwise the


### PR DESCRIPTION
## LFM2-Audio — a third voice mode (ASR + TTS + hands-free conversation)

Adds Liquid AI's **LFM2-Audio 1.5B** as a third on-device voice provider beside the existing native-speech and Distil-Whisper providers, run via the prebuilt llama.cpp `llama-lfm2-audio` one-shot CLI (no Python/PyTorch). LFM2-Audio is the speech-in / speech-out bookend around the pi/Claude agent — the agent stays the brain.

Built in reviewable phases, each peer-reviewed by codex and fixed before the next.

### What's new
- **ASR provider** (`voice/lfm2.rs`, `Lfm2Backend` trait + `Lfm2CliBackend`): temp WAV in → spawn runner → transcript parsed off stdout; cancel via child-kill + timeout. Binary resolved via `AETHON_LFM2_AUDIO_BIN` → bundled Resources → PATH; never auto-fetched. Picked up by the existing 8 voice IPC commands + provider-card UI with no new wiring.
- **TTS + audio playback** (`voice/playback.rs`, `AudioPlayer` over a **cpal output stream** — reuses the existing dep, no `rodio`). Generation-guarded stream release; overlapping-synthesis cancellation. New `voice_speak` / `voice_stop_playback` IPC. This is the app's first audio-output path.
- **Speak agent replies** (opt-in): on turn completion on the active tab, the reply is synthesized + spoken. Capped at a sentence/word boundary. Skips tool-only/empty/steered-stale turns.
- **Hands-free conversation mode**: enter once, then talk. **Voice-activity detection** over the recorder's `voice://level` stream auto-ends each utterance on silence (no "done" tap); the mic auto-reopens after the agent speaks (continuous by default). In-composer HUD + toggle button.
- **Release packaging**: the runner (binary + `@loader_path` dylibs) is staged from Liquid AI's GGUF repo — pinned to a commit + SHA-256 — by `beforeBuildCommand`, and bundled via Tauri `resources` so it's packaged + signed/notarized into the DMG/updater. `verify-bundle.sh` scans it for `/nix/store` leaks.

### Config (`[voice]`)
`speak_agent_replies`, `speak_max_chars`, `conversation_continuous` — round-tripped TS ↔ Rust TOML ↔ Settings panel. Model GGUFs download on demand into `~/.aethon/models/voice/`.

### Verification
- **Full CI `check` green**: clippy + tsc + ESLint + **438 Rust** + **2277 frontend** tests.
- **Real-binary integration** (ignored tests): ASR, TTS, and cpal playback against the actual runner.
- **Live in the running app**: provider reports *ready* (Metal via llama.cpp); `voice_speak` synthesizes + plays audibly; conversation UI + config plumbing confirmed via debug-eval.
- **Release bundle**: a Tauri-produced `.app` was confirmed to contain `Contents/Resources/lfm2-audio/`, the bundled runner is system-linked (0 `/nix/store` refs) and transcribes correctly; `verify-bundle.sh` passes on the real bundle.

### Notes
- Standalone LFM2 speech-to-speech (its own 1.5B brain) is intentionally **out of scope** — for a coding agent, the ASR+TTS bookend around the real agent is the useful design.
- llama.cpp TTS is upstream-experimental, but each call is a fresh process so the documented "crash after first ASR+TTS cycle" doesn't apply here.

Follow-up polish to come per discussion.
