### PR TITLE
fix(voice): address Copilot review of #289

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -318,8 +318,8 @@ version:sync` propagates the version to `tauri.conf.json`,
     runner binary directly.
   - Bumping the runner: update `hf_rev` and the per-platform SHA-256s in
     `scripts/stage-lfm2-runner.sh` together.
-  The model GGUFs themselves are downloaded on-demand into
-  `~/.aethon/models/voice/` and are never bundled.
+    The model GGUFs themselves are downloaded on-demand into
+    `~/.aethon/models/voice/` and are never bundled.
 - **Boot-probation rollback.** Each in-app update first copies the
   installed `.app` bundle to `~/.aethon/updates/previous/<version>/`
   and writes a sentinel to `~/.aethon/boot-probation.json`. If the

--- a/scripts/stage-lfm2-runner.sh
+++ b/scripts/stage-lfm2-runner.sh
@@ -59,7 +59,16 @@ url="https://huggingface.co/$hf_repo/resolve/$hf_rev/$runner"
 echo "stage-lfm2-runner: downloading $runner @ ${hf_rev:0:12} ..."
 curl -fL --retry 3 -o "$tmp/runner.zip" "$url"
 
-actual="$(shasum -a 256 "$tmp/runner.zip" | awk '{print $1}')"
+# Prefer coreutils sha256sum (ubiquitous on Linux CI); fall back to shasum
+# (default on macOS). One of the two is present on every target platform.
+if command -v sha256sum >/dev/null 2>&1; then
+  actual="$(sha256sum "$tmp/runner.zip" | awk '{print $1}')"
+elif command -v shasum >/dev/null 2>&1; then
+  actual="$(shasum -a 256 "$tmp/runner.zip" | awk '{print $1}')"
+else
+  echo "stage-lfm2-runner: neither sha256sum nor shasum found; cannot verify download" >&2
+  exit 1
+fi
 if [ "$actual" != "$sha256" ]; then
   echo "stage-lfm2-runner: checksum mismatch for $runner" >&2
   echo "  expected $sha256" >&2

--- a/src-tauri/src/commands/voice.rs
+++ b/src-tauri/src/commands/voice.rs
@@ -173,7 +173,8 @@ pub async fn voice_speak(
     voice: State<'_, VoiceProviderRegistry>,
     player: State<'_, AudioPlayer>,
 ) -> Result<(), String> {
-    let audio = voice.synthesize_speech(text).await?;
+    let state_path = crate::commands::config::aethon_state_path(&app, "voice.json")?;
+    let audio = voice.synthesize_speech(&state_path, text).await?;
     player.play_samples(audio.samples, audio.sample_rate, Some(app))
 }
 

--- a/src-tauri/src/voice/mod.rs
+++ b/src-tauri/src/voice/mod.rs
@@ -91,9 +91,10 @@ pub(super) const DISTIL_MODEL_FILES: [(&str, Option<u64>); 5] = [
 
 // --- LFM2-Audio (Liquid AI) provider, run via the prebuilt llama.cpp
 // `llama-lfm2-audio` one-shot CLI. End-to-end audio model: ASR (speech-in)
-// today, TTS (speech-out) in a later phase. The Q8_0 GGUF trio lives beside
-// the binary's documented `-m` / `--mmproj` / `-mv` flags. See `lfm2.rs` for
-// the runtime contract distilled from the Phase 0 spike.
+// and TTS (speech-out, see `playback.rs` + `voice_speak`) are both wired up.
+// The Q8_0 GGUF trio lives beside the binary's documented `-m` / `--mmproj`
+// / `-mv` flags. See `lfm2.rs` for the runtime contract distilled from the
+// Phase 0 spike.
 pub(super) const LFM2_ID: &str = "voice-lfm2-audio-llamacpp";
 pub(super) const LFM2_CACHE_DIR: &str = "lfm2-audio-1.5b";
 pub(super) const LFM2_HF_REPO: &str = "LiquidAI/LFM2-Audio-1.5B-GGUF";
@@ -1929,10 +1930,11 @@ mod tests {
     async fn synthesize_speech_returns_audio() {
         let model_dir = tempdir().expect("model dir");
         write_complete_lfm2_model(&model_dir.path().join(LFM2_CACHE_DIR));
+        let (_db_dir, db_path) = test_db_path();
         let registry = lfm2_registry(model_dir.path().to_path_buf(), FakeLfm2Backend::ready("x"));
 
         let audio = registry
-            .synthesize_speech("hello".to_string())
+            .synthesize_speech(&db_path, "hello".to_string())
             .await
             .expect("synthesize");
         assert!(!audio.samples.is_empty());
@@ -1943,10 +1945,11 @@ mod tests {
     async fn synthesize_speech_rejects_empty_text() {
         let model_dir = tempdir().expect("model dir");
         write_complete_lfm2_model(&model_dir.path().join(LFM2_CACHE_DIR));
+        let (_db_dir, db_path) = test_db_path();
         let registry = lfm2_registry(model_dir.path().to_path_buf(), FakeLfm2Backend::ready("x"));
 
         let err = registry
-            .synthesize_speech("   ".to_string())
+            .synthesize_speech(&db_path, "   ".to_string())
             .await
             .expect_err("empty text should be rejected");
         assert!(err.contains("Nothing to speak"));
@@ -1955,10 +1958,11 @@ mod tests {
     #[tokio::test]
     async fn synthesize_speech_rejects_missing_model() {
         let model_dir = tempdir().expect("model dir");
+        let (_db_dir, db_path) = test_db_path();
         let registry = lfm2_registry(model_dir.path().to_path_buf(), FakeLfm2Backend::ready("x"));
 
         let err = registry
-            .synthesize_speech("hello".to_string())
+            .synthesize_speech(&db_path, "hello".to_string())
             .await
             .expect_err("missing model should be rejected");
         assert!(err.contains("Download"));
@@ -1972,28 +1976,50 @@ mod tests {
             model_dir.path().to_path_buf(),
             FakeLfm2Backend::binary_missing(),
         );
+        let (_db_dir, db_path) = test_db_path();
 
         let err = registry
-            .synthesize_speech("hello".to_string())
+            .synthesize_speech(&db_path, "hello".to_string())
             .await
             .expect_err("missing binary should be rejected");
         assert!(err.contains("llama-lfm2-audio"));
     }
 
     #[tokio::test]
+    async fn synthesize_speech_rejects_when_disabled() {
+        let model_dir = tempdir().expect("model dir");
+        write_complete_lfm2_model(&model_dir.path().join(LFM2_CACHE_DIR));
+        let (_db_dir, db_path) = test_db_path();
+        let db = open_test_db(&db_path);
+        db.set_app_setting(&enabled_key(LFM2_ID), "false")
+            .expect("disable provider");
+        drop(db);
+        let registry = lfm2_registry(model_dir.path().to_path_buf(), FakeLfm2Backend::ready("x"));
+
+        let err = registry
+            .synthesize_speech(&db_path, "hello".to_string())
+            .await
+            .expect_err("disabled provider should not speak");
+        assert!(err.contains("disabled"));
+    }
+
+    #[tokio::test]
     async fn cancel_speech_aborts_synthesis() {
         let model_dir = tempdir().expect("model dir");
         write_complete_lfm2_model(&model_dir.path().join(LFM2_CACHE_DIR));
+        let (_db_dir, db_path) = test_db_path();
         let registry = Arc::new(lfm2_registry(
             model_dir.path().to_path_buf(),
             FakeLfm2Backend::slow("x", Duration::from_secs(5)),
         ));
 
         let synth_registry = Arc::clone(&registry);
-        let handle =
-            tokio::spawn(
-                async move { synth_registry.synthesize_speech("hello".to_string()).await },
-            );
+        let synth_db = db_path.clone();
+        let handle = tokio::spawn(async move {
+            synth_registry
+                .synthesize_speech(&synth_db, "hello".to_string())
+                .await
+        });
         tokio::time::sleep(Duration::from_millis(50)).await;
         registry.cancel_speech();
 
@@ -2008,24 +2034,28 @@ mod tests {
     async fn overlapping_synthesis_cancels_previous() {
         let model_dir = tempdir().expect("model dir");
         write_complete_lfm2_model(&model_dir.path().join(LFM2_CACHE_DIR));
+        let (_db_dir, db_path) = test_db_path();
         let registry = Arc::new(lfm2_registry(
             model_dir.path().to_path_buf(),
             FakeLfm2Backend::slow("x", Duration::from_secs(5)),
         ));
 
         let first_registry = Arc::clone(&registry);
-        let first =
-            tokio::spawn(
-                async move { first_registry.synthesize_speech("first".to_string()).await },
-            );
+        let first_db = db_path.clone();
+        let first = tokio::spawn(async move {
+            first_registry
+                .synthesize_speech(&first_db, "first".to_string())
+                .await
+        });
         tokio::time::sleep(Duration::from_millis(50)).await;
 
         // A second request must cancel the first so the older runner can't
         // proceed to playback after the user moved on.
         let second_registry = Arc::clone(&registry);
+        let second_db = db_path.clone();
         let second = tokio::spawn(async move {
             second_registry
-                .synthesize_speech("second".to_string())
+                .synthesize_speech(&second_db, "second".to_string())
                 .await
         });
         tokio::time::sleep(Duration::from_millis(50)).await;
@@ -2057,9 +2087,10 @@ mod tests {
             "late",
             Duration::from_millis(80),
         )));
+        let (_db_dir, db_path) = test_db_path();
 
         let err = registry
-            .synthesize_speech("hello".to_string())
+            .synthesize_speech(&db_path, "hello".to_string())
             .await
             .expect_err("slow synthesis should time out");
         assert!(err.contains("timed out"));

--- a/src-tauri/src/voice/registry.rs
+++ b/src-tauri/src/voice/registry.rs
@@ -519,11 +519,24 @@ impl VoiceProviderRegistry {
     }
 
     /// Synthesize speech for `text` via the LFM2-Audio runner, returning 24 kHz
-    /// mono PCM. Requires the LFM2 model + binary; cancellable via
-    /// `cancel_speech` and bounded by the shared transcription timeout.
-    pub async fn synthesize_speech(&self, text: String) -> Result<CapturedAudio, String> {
+    /// mono PCM. Requires the LFM2 provider to be enabled with its model +
+    /// binary present; cancellable via `cancel_speech` and bounded by the
+    /// shared transcription timeout.
+    pub async fn synthesize_speech(
+        &self,
+        db_path: &Path,
+        text: String,
+    ) -> Result<CapturedAudio, String> {
         if text.trim().is_empty() {
             return Err("Nothing to speak".to_string());
+        }
+        {
+            // Honor the same enable toggle the recording path enforces, so a
+            // disabled provider never speaks (TTS used to bypass this).
+            let db = VoiceSettings::open(db_path).map_err(|e| e.to_string())?;
+            if !self.enabled(&db, LFM2_ID) {
+                return Err("LFM2-Audio voice output is disabled".to_string());
+            }
         }
         if !lfm2_model_ready(&self.lfm2_cache_path()) {
             return Err("Download the LFM2-Audio model before using text-to-speech".to_string());

--- a/src/utils/messages.test.ts
+++ b/src/utils/messages.test.ts
@@ -44,6 +44,17 @@ describe("lastAgentText", () => {
     expect(lastAgentText(messages)).toBe("Here is the result.");
   });
 
+  it("still speaks the reply when a queued follow-up is already appended", () => {
+    const messages: ChatMessage[] = [
+      { id: "u1", role: "user", text: "do the thing" },
+      { id: "a1", role: "agent", text: "Done." },
+      { id: "u2", role: "user", text: "next thing", delivery: "queued" },
+    ];
+    // A queued follow-up can land before this turn's response_end fires; it
+    // must not suppress speaking the reply that just completed.
+    expect(lastAgentText(messages)).toBe("Done.");
+  });
+
   it("ignores thinking-only and empty agent messages", () => {
     const messages: ChatMessage[] = [
       { id: "u1", role: "user", text: "q" },

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -2,13 +2,21 @@ import type { A2UIPayload, ChatAttachment, ChatMessage } from "../types/a2ui";
 
 /** The spoken text of the *current* turn's reply. Walks back to the user
  *  message that started the turn so a tool-only / thinking-only / empty turn
- *  returns "" instead of replaying an earlier reply. A *steered* user message
- *  is a mid-turn interjection (it lands after the agent's text), so it is not
- *  treated as a turn boundary — the reply before it is still spoken. */
+ *  returns "" instead of replaying an earlier reply. `steered` (mid-turn
+ *  interjection) and `queued` (a follow-up already appended while the agent
+ *  finishes this turn) user messages are NOT turn boundaries — they can sit
+ *  after the agent's text, so skipping them keeps the just-finished reply
+ *  speakable. */
 export function lastAgentText(messages: ChatMessage[]): string {
   for (let i = messages.length - 1; i >= 0; i--) {
     const message = messages[i];
-    if (message.role === "user" && message.delivery !== "steered") break;
+    if (
+      message.role === "user" &&
+      message.delivery !== "steered" &&
+      message.delivery !== "queued"
+    ) {
+      break;
+    }
     if (
       message.role === "agent" &&
       typeof message.text === "string" &&


### PR DESCRIPTION
Follow-up to #289 (merged), addressing the Copilot review findings.

| # | Finding | Resolution |
|---|---------|------------|
| 1 | `lastAgentText` treats `queued` follow-ups as a turn boundary → suppresses the reply | Skip `queued` user messages too (like `steered`) + test |
| 2 | No test for the queued case | Added |
| 3 | `conversationMode` process-global state | **Kept** — the A2UI component model gives `chat-input` no direct store setter; moving it to app state needs an event-route round-trip for marginal benefit in a single-window app. Module flag stays documented/minimal. |
| 4 | `voice_speak` ignores the provider enable toggle | `synthesize_speech` now checks `enabled` (threads `db_path` like the recording path) + test |
| 5 | `shasum` may be absent on minimal Linux CI | Prefer `sha256sum`, fall back to `shasum` |
| 6 | Stale "TTS in a later phase" comment | Corrected |

Full CI `check` green locally: **439 Rust + 2278 frontend** tests, clippy/tsc/eslint clean.
