### PR TITLE
fix(voice): code-sign the bundled LFM2 runner for notarization

### DIFF
--- a/scripts/stage-lfm2-runner.sh
+++ b/scripts/stage-lfm2-runner.sh
@@ -82,3 +82,24 @@ mkdir -p "$dest"
 cp -R "$tmp/unzipped/$inner/." "$dest/"
 chmod +x "$bin"
 echo "stage-lfm2-runner: staged + verified runner → $dest"
+
+# Code-sign every nested Mach-O (the runner binary + its @loader_path dylibs)
+# with the Developer ID + hardened runtime + secure timestamp. Tauri signs the
+# app and its externalBin sidecars, but NOT executables dropped into
+# `resources`, and Apple notarization rejects any unsigned nested Mach-O. We
+# sign here (in beforeBuildCommand, after tauri-action has imported the cert)
+# so the files are already signed when Tauri copies them into Resources and
+# seals the outer bundle. Only runs on macOS when a signing identity is set;
+# local/unsigned builds skip.
+if [ "$os" = "Darwin" ] && [ -n "${APPLE_SIGNING_IDENTITY:-}" ]; then
+  echo "stage-lfm2-runner: code-signing nested runner binaries"
+  signed=0
+  while IFS= read -r macho; do
+    if file -b "$macho" | grep -q "Mach-O"; then
+      codesign --force --options runtime --timestamp \
+        --sign "$APPLE_SIGNING_IDENTITY" "$macho"
+      signed=$((signed + 1))
+    fi
+  done < <(find "$dest" -type f)
+  echo "stage-lfm2-runner: signed $signed nested Mach-O file(s)"
+fi


### PR DESCRIPTION
## Fix: code-sign the bundled LFM2 runner so notarization passes

The nightly macOS build (the first to exercise the LFM2 release packaging from #289) failed notarization:

```
The binary is not signed with a valid Developer ID certificate.
The signature does not include a secure timestamp.
... Aethon.app/Contents/Resources/lfm2-audio/llama-lfm2-audio (+ all lib*.dylib / lib*.so / llama-mtmd-cli)
```

**Cause:** Tauri signs the app and its `externalBin` sidecars, but **not** executables/dylibs dropped into `bundle.resources`. Apple notarization rejects any nested Mach-O that isn't signed with a Developer ID cert + hardened runtime + secure timestamp, and the upstream runner ships only ad-hoc-signed.

**Fix:** `stage-lfm2-runner.sh` now codesigns every nested Mach-O (`--options runtime --timestamp`, Developer ID) when `APPLE_SIGNING_IDENTITY` is set. It runs inside `beforeBuildCommand` — *after* `tauri-action` imports the cert into the keychain, *before* Tauri copies the files into `Resources` and seals the bundle — so the nested signatures are present at notarization time (correct inside-out signing order). Local/unsigned builds skip the block.

**Verified locally** (no real cert): Mach-O detection signs the 11 runner Mach-O files and skips `LICENSE*`/`.h`/`.metal`; ad-hoc `codesign --options runtime` applies the hardened-runtime flag; a pristine restage stays unsigned (block correctly skipped). The signed path can only be fully validated by the next nightly, which I'll watch.
