### PR TITLE
feat(voice): push-to-talk hotkey — hold to dictate, release to send

### DIFF
--- a/src/extensions/default-layout/chat-input.tsx
+++ b/src/extensions/default-layout/chat-input.tsx
@@ -3,6 +3,7 @@ import {
   useCallback,
   useEffect,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState,
   type ChangeEvent,
@@ -87,8 +88,10 @@ export function ChatInput({
     : 0;
   const queuedMessages =
     (state.queuedMessages as QueuedMessage[] | undefined) ?? [];
-  const attachments =
-    (state.draftAttachments as ChatAttachment[] | undefined) ?? [];
+  const attachments = useMemo(
+    () => (state.draftAttachments as ChatAttachment[] | undefined) ?? [],
+    [state.draftAttachments],
+  );
   const canSteerQueuedMessage = queuedMessages.length > 0 || queueCount > 0;
   const sendLabel = props.sendLabel
     ? resolveString(props.sendLabel, state)
@@ -136,8 +139,8 @@ export function ChatInput({
   const inputContainerRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const { composerHeight, startComposerResize } = useComposerResize();
-  const insertTranscript = useCallback(
-    (transcript: string) => {
+  const handleTranscript = useCallback(
+    (transcript: string, options?: { autoSend?: boolean }) => {
       const textarea = textareaRef.current;
       const start = textarea?.selectionStart ?? value.length;
       const end = textarea?.selectionEnd ?? value.length;
@@ -150,6 +153,16 @@ export function ChatInput({
       setValue(next.text);
       commitDraft(next.text);
       setCursor(next.cursor);
+      // Push-to-talk (hold-hotkey release) sends straight away rather than
+      // parking the dictation in the composer for a manual Enter.
+      if (options?.autoSend && next.text.trim().length > 0) {
+        onEvent("submit", {
+          value: next.text,
+          mode: "normal",
+          ...(attachments.length > 0 ? { attachments } : {}),
+        });
+        return;
+      }
       requestAnimationFrame(() => {
         const current = textareaRef.current;
         if (!current) return;
@@ -157,9 +170,9 @@ export function ChatInput({
         current.selectionStart = current.selectionEnd = next.cursor;
       });
     },
-    [commitDraft, setValue, value],
+    [attachments, commitDraft, onEvent, setValue, value],
   );
-  const voice = useVoiceInput(insertTranscript, (providerId) => {
+  const voice = useVoiceInput(handleTranscript, (providerId) => {
     onEvent("voice:setup", { providerId });
   });
   const voiceState = voice.state;
@@ -197,6 +210,7 @@ export function ChatInput({
     voiceConfig.toggleHotkey ?? "mod+shift+m",
     voiceConfig.holdHotkey ?? null,
     isVoiceInputBlocked,
+    conversation,
   );
   const [reducedMotion, setReducedMotion] = useState(() => {
     if (typeof window === "undefined" || !window.matchMedia) return false;

--- a/src/hooks/useVoiceConversation.test.ts
+++ b/src/hooks/useVoiceConversation.test.ts
@@ -210,4 +210,75 @@ describe("useVoiceConversation", () => {
     expect(result.current.active).toBe(false);
     expect(isConversationActive()).toBe(false);
   });
+
+  it("push-to-talk hold keeps the mic open through silence until release", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      vi.setSystemTime(1000);
+      const { result, submitText } = makeController(true);
+      act(() => result.current.enter());
+      await flush();
+      expect(result.current.phase).toBe("listening");
+
+      // The user presses and holds the push-to-talk key.
+      act(() => result.current.beginHold());
+
+      // They speak, then pause well past the silence-hang window — VAD must NOT
+      // end the utterance because the key is held.
+      act(() => ev.level?.({ payload: { level: 0.12 } }));
+      vi.setSystemTime(1000 + 5000);
+      act(() => ev.level?.({ payload: { level: 0.0 } }));
+      await flush();
+      expect(mocks.stopAndTranscribeVoice).not.toHaveBeenCalled();
+      expect(result.current.phase).toBe("listening");
+
+      // Releasing ends the utterance and sends it.
+      act(() => result.current.endHold());
+      await flush();
+      expect(mocks.stopAndTranscribeVoice).toHaveBeenCalled();
+      expect(submitText).toHaveBeenCalledWith("hello agent");
+      expect(result.current.phase).toBe("thinking");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("push-to-talk from an idle turn re-opens the mic", async () => {
+    const { result } = makeController(false);
+    act(() => result.current.enter());
+    await flush();
+    act(() => result.current.primaryAction()); // finish → submit → thinking
+    await flush();
+    // An empty reply drops a non-continuous conversation back to idle.
+    act(() => emitAgentTurnComplete({ tabId: "t1", text: "" }));
+    await flush();
+    expect(result.current.phase).toBe("idle");
+
+    mocks.startVoiceRecording.mockClear();
+    act(() => result.current.beginHold());
+    await flush();
+    expect(mocks.startVoiceRecording).toHaveBeenCalledTimes(1);
+    expect(result.current.phase).toBe("listening");
+  });
+
+  it("a release without a held press never sends", async () => {
+    const { result, submitText } = makeController(true);
+    act(() => result.current.enter());
+    await flush();
+    expect(result.current.phase).toBe("listening");
+
+    act(() => result.current.endHold());
+    await flush();
+    expect(mocks.stopAndTranscribeVoice).not.toHaveBeenCalled();
+    expect(submitText).not.toHaveBeenCalled();
+    expect(result.current.phase).toBe("listening");
+  });
+
+  it("push-to-talk is inert when no conversation is active", async () => {
+    const { result } = makeController(false);
+    act(() => result.current.beginHold());
+    await flush();
+    expect(mocks.startVoiceRecording).not.toHaveBeenCalled();
+    expect(result.current.phase).toBe("idle");
+  });
 });

--- a/src/hooks/useVoiceConversation.test.ts
+++ b/src/hooks/useVoiceConversation.test.ts
@@ -298,6 +298,23 @@ describe("useVoiceConversation", () => {
     expect(result.current.phase).not.toBe("listening");
   });
 
+  it("ends a held utterance when focus is lost (no stuck mic)", async () => {
+    const { result } = makeController(true);
+    act(() => result.current.enter());
+    await flush();
+    expect(result.current.phase).toBe("listening");
+
+    // Holding push-to-talk (VAD suppressed), but the user never spoke.
+    act(() => result.current.beginHold());
+
+    // Focus leaves before any speech — the lost keyup must not wedge the mic.
+    act(() => window.dispatchEvent(new Event("blur")));
+    await flush();
+
+    expect(mocks.stopAndTranscribeVoice).toHaveBeenCalled();
+    expect(result.current.phase).not.toBe("listening");
+  });
+
   it("a release without a held press never sends", async () => {
     const { result, submitText } = makeController(true);
     act(() => result.current.enter());

--- a/src/hooks/useVoiceConversation.test.ts
+++ b/src/hooks/useVoiceConversation.test.ts
@@ -261,6 +261,43 @@ describe("useVoiceConversation", () => {
     expect(result.current.phase).toBe("listening");
   });
 
+  it("a release before the mic opens does not strand it recording", async () => {
+    const { result } = makeController(false);
+    // Drive one turn so the conversation settles back to idle.
+    act(() => result.current.enter());
+    await flush();
+    act(() => result.current.primaryAction());
+    await flush();
+    act(() => emitAgentTurnComplete({ tabId: "t1", text: "" }));
+    await flush();
+    expect(result.current.phase).toBe("idle");
+
+    // The next open hangs so we can release while it is still in flight.
+    let resolveStart: () => void = () => {};
+    mocks.startVoiceRecording.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveStart = resolve;
+        }),
+    );
+    mocks.stopAndTranscribeVoice.mockClear();
+    mocks.stopAndTranscribeVoice.mockResolvedValueOnce("");
+
+    act(() => result.current.beginHold()); // idle → start (hanging)
+    act(() => result.current.endHold()); // released before the recorder is ready
+
+    await act(async () => {
+      resolveStart();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // The deferred open immediately finishes — the mic never stays "listening"
+    // with no keyup left to close it.
+    expect(mocks.stopAndTranscribeVoice).toHaveBeenCalled();
+    expect(result.current.phase).not.toBe("listening");
+  });
+
   it("a release without a held press never sends", async () => {
     const { result, submitText } = makeController(true);
     act(() => result.current.enter());

--- a/src/hooks/useVoiceConversation.ts
+++ b/src/hooks/useVoiceConversation.ts
@@ -323,11 +323,17 @@ export function useVoiceConversation(
   }, []);
 
   // If focus leaves while the push-to-talk key is held, the keyup never
-  // arrives — drop the suppression so VAD resumes and the mic can't stay
-  // wedged open. The conversation itself deliberately keeps running across blur.
+  // arrives. Release the hold and END the capture — just dropping the
+  // suppression isn't enough: VAD refuses to finish until it has seen speech,
+  // so a blur before the user spoke would otherwise wedge the mic open in the
+  // background. If the mic is open, finish now; if it's still opening, clearing
+  // manualHold lets the deferred open-check (holdStartRef) finish it on open.
+  // The conversation itself deliberately keeps running across blur.
   useEffect(() => {
     const onBlur = () => {
+      if (!manualHoldRef.current) return;
       manualHoldRef.current = false;
+      if (phaseRef.current === "listening") finishRef.current();
     };
     window.addEventListener("blur", onBlur);
     return () => window.removeEventListener("blur", onBlur);

--- a/src/hooks/useVoiceConversation.ts
+++ b/src/hooks/useVoiceConversation.ts
@@ -88,6 +88,10 @@ export function useVoiceConversation(
   // True while the user holds the push-to-talk key: VAD never auto-ends the
   // utterance, so the release is the sole end-of-message signal.
   const manualHoldRef = useRef(false);
+  // True while a push-to-talk press is opening the mic from idle. Lets a
+  // release that lands before the recorder is ready finish the moment it opens,
+  // instead of stranding the mic in "listening" with no keyup to close it.
+  const holdStartRef = useRef(false);
   const finishRef = useRef<() => void>(() => {});
   const optionsRef = useRef(options);
   // Keep the latest callbacks/config available to async transitions without a
@@ -120,9 +124,19 @@ export function useVoiceConversation(
       lastSpeechAtRef.current = 0;
       listenStartAtRef.current = Date.now();
       setPhase("listening");
+      // If a push-to-talk press opened this window but the key was already
+      // released before the recorder became ready, honor that release now —
+      // otherwise the mic would stay hot with no keyup left to finish it.
+      // Route through finishRef to dodge the startListening↔finishListening
+      // useCallback cycle (same indirection the VAD listener uses).
+      if (holdStartRef.current) {
+        holdStartRef.current = false;
+        if (!manualHoldRef.current) finishRef.current();
+      }
     } catch (caught) {
       // A failed open must not leave VAD suppressed for the next window.
       manualHoldRef.current = false;
+      holdStartRef.current = false;
       setError(errorMessage(caught));
       setPhase("idle");
       optionsRef.current.onNeedsSetup?.(LFM2_VOICE_PROVIDER_ID);
@@ -177,6 +191,7 @@ export function useVoiceConversation(
   const exit = useCallback(() => {
     activeRef.current = false;
     manualHoldRef.current = false;
+    holdStartRef.current = false;
     setActive(false);
     setConversationActive(false);
     void cancelVoiceRecording(LFM2_VOICE_PROVIDER_ID).catch(() => {});
@@ -210,6 +225,7 @@ export function useVoiceConversation(
     if (!activeRef.current) return;
     if (phaseRef.current === "idle") {
       manualHoldRef.current = true;
+      holdStartRef.current = true;
       void startListening();
     } else if (phaseRef.current === "listening") {
       manualHoldRef.current = true;

--- a/src/hooks/useVoiceConversation.ts
+++ b/src/hooks/useVoiceConversation.ts
@@ -42,6 +42,11 @@ export interface VoiceConversationController {
   exit: () => void;
   /** Context-aware tap: start speaking / finish speaking / interrupt. */
   primaryAction: () => void;
+  /** Push-to-talk press: open/keep the mic and suppress VAD auto-end so the
+   *  user controls when the utterance ends (held key). No-op unless active. */
+  beginHold: () => void;
+  /** Push-to-talk release: end the held utterance and send it to the agent. */
+  endHold: () => void;
 }
 
 function errorMessage(error: unknown): string {
@@ -80,6 +85,9 @@ export function useVoiceConversation(
   const vadSpokeRef = useRef(false);
   const lastSpeechAtRef = useRef(0);
   const listenStartAtRef = useRef(0);
+  // True while the user holds the push-to-talk key: VAD never auto-ends the
+  // utterance, so the release is the sole end-of-message signal.
+  const manualHoldRef = useRef(false);
   const finishRef = useRef<() => void>(() => {});
   const optionsRef = useRef(options);
   // Keep the latest callbacks/config available to async transitions without a
@@ -113,6 +121,8 @@ export function useVoiceConversation(
       listenStartAtRef.current = Date.now();
       setPhase("listening");
     } catch (caught) {
+      // A failed open must not leave VAD suppressed for the next window.
+      manualHoldRef.current = false;
       setError(errorMessage(caught));
       setPhase("idle");
       optionsRef.current.onNeedsSetup?.(LFM2_VOICE_PROVIDER_ID);
@@ -166,6 +176,7 @@ export function useVoiceConversation(
 
   const exit = useCallback(() => {
     activeRef.current = false;
+    manualHoldRef.current = false;
     setActive(false);
     setConversationActive(false);
     void cancelVoiceRecording(LFM2_VOICE_PROVIDER_ID).catch(() => {});
@@ -190,6 +201,30 @@ export function useVoiceConversation(
         break; // mid-flight; ignore taps
     }
   }, [finishListening, interrupt, startListening]);
+
+  // Push-to-talk press. Opens the mic if idle and suppresses VAD so the held
+  // key — not silence — decides when the utterance ends. While the agent is
+  // thinking/speaking, or mid-transcription, the press is ignored (tap the HUD
+  // to interrupt); we only arm the hold when we actually reach listening.
+  const beginHold = useCallback(() => {
+    if (!activeRef.current) return;
+    if (phaseRef.current === "idle") {
+      manualHoldRef.current = true;
+      void startListening();
+    } else if (phaseRef.current === "listening") {
+      manualHoldRef.current = true;
+    }
+  }, [startListening]);
+
+  // Push-to-talk release. Drops the VAD suppression and ends the utterance,
+  // sending whatever was captured (finishListening is a no-op off "listening").
+  const endHold = useCallback(() => {
+    if (!manualHoldRef.current) return;
+    manualHoldRef.current = false;
+    if (phaseRef.current === "listening") {
+      void finishListening();
+    }
+  }, [finishListening]);
 
   // Speak the agent's reply once the turn completes, then continue/idle.
   useEffect(() => {
@@ -250,6 +285,9 @@ export function useVoiceConversation(
         lastSpeechAtRef.current = now;
         return;
       }
+      // While the user holds the push-to-talk key, they own the end-of-message
+      // signal — never auto-close on silence or the ceiling.
+      if (manualHoldRef.current) return;
       if (!vadSpokeRef.current) return; // wait for speech before arming silence
       const silentLongEnough =
         level < VAD_SILENCE_LEVEL &&
@@ -268,6 +306,17 @@ export function useVoiceConversation(
     };
   }, []);
 
+  // If focus leaves while the push-to-talk key is held, the keyup never
+  // arrives — drop the suppression so VAD resumes and the mic can't stay
+  // wedged open. The conversation itself deliberately keeps running across blur.
+  useEffect(() => {
+    const onBlur = () => {
+      manualHoldRef.current = false;
+    };
+    window.addEventListener("blur", onBlur);
+    return () => window.removeEventListener("blur", onBlur);
+  }, []);
+
   // Tear down recording/playback if we unmount mid-conversation.
   useEffect(() => {
     return () => {
@@ -279,5 +328,5 @@ export function useVoiceConversation(
     };
   }, []);
 
-  return { active, phase, error, enter, exit, primaryAction };
+  return { active, phase, error, enter, exit, primaryAction, beginHold, endHold };
 }

--- a/src/hooks/useVoiceHotkey.test.ts
+++ b/src/hooks/useVoiceHotkey.test.ts
@@ -8,6 +8,21 @@ import {
 } from "./useVoiceHotkey";
 import type { VoiceInputController } from "./useVoiceInput";
 
+// A Mock is structurally assignable to the handle's `() => void` methods, so
+// inference gives us both a valid ConversationHotkeyHandle and spies to assert.
+function conversation(active: boolean) {
+  return { active, beginHold: vi.fn(), endHold: vi.fn() };
+}
+
+const altRightDown = {
+  key: "Alt",
+  code: "AltRight",
+  metaKey: false,
+  shiftKey: false,
+  altKey: true,
+} as const;
+const altRightUp = { ...altRightDown, altKey: false } as const;
+
 function keyEvent(init: KeyboardEventInit): KeyboardEvent {
   return new KeyboardEvent("keydown", {
     key: "m",
@@ -80,7 +95,7 @@ describe("voice hotkeys", () => {
     expect(starting.cancel).toHaveBeenCalledTimes(1);
   });
 
-  it("hold-to-talk starts on keydown and stops on keyup", () => {
+  it("hold-to-talk starts (auto-send) on keydown and stops on keyup", () => {
     const current = voice("idle");
     const handlers = createVoiceHotkeyHandlers(
       () => current,
@@ -88,28 +103,72 @@ describe("voice hotkeys", () => {
       "code:AltRight",
     );
 
-    handlers.onKeyDown(
-      keyEvent({
-        key: "Alt",
-        code: "AltRight",
-        metaKey: false,
-        shiftKey: false,
-        altKey: true,
-      }),
-    );
+    handlers.onKeyDown(keyEvent(altRightDown));
     expect(current.start).toHaveBeenCalledTimes(1);
+    // Release after a hold must submit, not just insert into the composer.
+    expect(current.start).toHaveBeenCalledWith({ autoSend: true });
 
     current.state = "recording";
-    handlers.onKeyUp(
-      keyEvent({
-        key: "Alt",
-        code: "AltRight",
-        metaKey: false,
-        shiftKey: false,
-        altKey: false,
-      }),
-    );
+    handlers.onKeyUp(keyEvent(altRightUp));
     expect(current.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("routes the hold key to conversation push-to-talk when a conversation is active", () => {
+    const current = voice("idle");
+    const convo = conversation(true);
+    const handlers = createVoiceHotkeyHandlers(
+      () => current,
+      "mod+shift+m",
+      "code:AltRight",
+      () => false,
+      () => convo,
+    );
+
+    handlers.onKeyDown(keyEvent(altRightDown));
+    expect(convo.beginHold).toHaveBeenCalledTimes(1);
+    expect(current.start).not.toHaveBeenCalled();
+
+    handlers.onKeyUp(keyEvent(altRightUp));
+    expect(convo.endHold).toHaveBeenCalledTimes(1);
+    expect(current.stop).not.toHaveBeenCalled();
+  });
+
+  it("ends the same subsystem the press started even if the conversation flips before release", () => {
+    const current = voice("idle");
+    let active = true;
+    const convo = conversation(true);
+    const handlers = createVoiceHotkeyHandlers(
+      () => current,
+      null,
+      "code:AltRight",
+      () => false,
+      () => ({ ...convo, active }),
+    );
+
+    handlers.onKeyDown(keyEvent(altRightDown));
+    expect(convo.beginHold).toHaveBeenCalledTimes(1);
+
+    // Conversation ends mid-hold; the release must still go to endHold, not stop.
+    active = false;
+    handlers.onKeyUp(keyEvent(altRightUp));
+    expect(convo.endHold).toHaveBeenCalledTimes(1);
+    expect(current.stop).not.toHaveBeenCalled();
+  });
+
+  it("suppresses the dictation toggle while a conversation owns the mic", () => {
+    const current = voice("idle");
+    const convo = conversation(true);
+    const handlers = createVoiceHotkeyHandlers(
+      () => current,
+      "mod+shift+m",
+      null,
+      () => false,
+      () => convo,
+    );
+
+    handlers.onKeyDown(keyEvent({}));
+    expect(current.start).not.toHaveBeenCalled();
+    expect(convo.beginHold).not.toHaveBeenCalled();
   });
 
   it("does not start while input is blocked", () => {

--- a/src/hooks/useVoiceHotkey.test.ts
+++ b/src/hooks/useVoiceHotkey.test.ts
@@ -171,6 +171,32 @@ describe("voice hotkeys", () => {
     expect(convo.beginHold).not.toHaveBeenCalled();
   });
 
+  it("keeps the toggle as a mic-off escape hatch for live dictation under a conversation", () => {
+    // A dictation recording already running when the HUD opens must stay
+    // stoppable — only the idle start path is suppressed.
+    const recording = voice("recording");
+    const stopHandlers = createVoiceHotkeyHandlers(
+      () => recording,
+      "mod+shift+m",
+      null,
+      () => false,
+      () => conversation(true),
+    );
+    stopHandlers.onKeyDown(keyEvent({}));
+    expect(recording.stop).toHaveBeenCalledTimes(1);
+
+    const transcribing = voice("transcribing");
+    const cancelHandlers = createVoiceHotkeyHandlers(
+      () => transcribing,
+      "mod+shift+m",
+      null,
+      () => false,
+      () => conversation(true),
+    );
+    cancelHandlers.onKeyDown(keyEvent({}));
+    expect(transcribing.cancel).toHaveBeenCalledTimes(1);
+  });
+
   it("does not start while input is blocked", () => {
     const current = voice("idle");
     const handlers = createVoiceHotkeyHandlers(

--- a/src/hooks/useVoiceHotkey.ts
+++ b/src/hooks/useVoiceHotkey.ts
@@ -131,19 +131,18 @@ export function createVoiceHotkeyHandlers(
 
       if (toggleHotkey && matchesToggle(e, toggleHotkey)) {
         e.preventDefault();
-        // A live conversation owns the mic; don't let the dictation toggle
-        // open a second recording on the same device.
-        if (getConversation()?.active) return;
         if (v.state === "recording") {
           v.stop();
         } else if (v.state === "starting" || v.state === "transcribing") {
           v.cancel();
-        } else if (!isInputBlocked()) {
+        } else if (!isInputBlocked() && !getConversation()?.active) {
           // idle, setup-required, or error — try start (only when no overlay
           // owns input focus). Mirrors the mic button's catchall: from
           // setup-required, start() re-runs the provider check (now
           // succeeding after the user granted perms); from error it clears
-          // the error and re-attempts.
+          // the error and re-attempts. Suppressed while a conversation owns
+          // the mic so the toggle can't open a second recording — but stop/
+          // cancel above stay reachable as a mic-off escape hatch.
           void v.start();
         }
         return;

--- a/src/hooks/useVoiceHotkey.ts
+++ b/src/hooks/useVoiceHotkey.ts
@@ -1,5 +1,14 @@
 import { useEffect, useLayoutEffect, useRef } from "react";
 import type { VoiceInputController } from "./useVoiceInput";
+import type { VoiceConversationController } from "./useVoiceConversation";
+
+/** The slice of the conversation controller the hold hotkey drives. When a
+ * conversation is active the hold key is its push-to-talk: press suppresses
+ * VAD, release ends the utterance — so the same key never also fires dictation. */
+export type ConversationHotkeyHandle = Pick<
+  VoiceConversationController,
+  "active" | "beginHold" | "endHold"
+>;
 
 // Re-export so existing call sites (KeyboardSettings, tests) keep working.
 export {
@@ -92,12 +101,18 @@ export function createVoiceHotkeyHandlers(
    * or settings panel is open). Stop/cancel/release actions still run so an
    * in-flight recording can always be ended. */
   isInputBlocked: () => boolean = () => false,
+  /** When a voice conversation is active, the hold key is its push-to-talk
+   * instead of a dictation trigger. Null/absent → dictation only. */
+  getConversation: () => ConversationHotkeyHandle | null = () => null,
 ): {
   onKeyDown: (e: KeyboardEvent) => void;
   onKeyUp: (e: KeyboardEvent) => void;
   onBlur: () => void;
 } {
   let holdActive = false;
+  // Which subsystem the current hold drives, captured at keydown so the matching
+  // keyup ends the same one even if the conversation flips mid-press.
+  let holdTarget: "voice" | "conversation" | null = null;
   const holdCode = holdBindingToCode(holdBinding);
 
   return {
@@ -116,6 +131,9 @@ export function createVoiceHotkeyHandlers(
 
       if (toggleHotkey && matchesToggle(e, toggleHotkey)) {
         e.preventDefault();
+        // A live conversation owns the mic; don't let the dictation toggle
+        // open a second recording on the same device.
+        if (getConversation()?.active) return;
         if (v.state === "recording") {
           v.stop();
         } else if (v.state === "starting" || v.state === "transcribing") {
@@ -140,20 +158,42 @@ export function createVoiceHotkeyHandlers(
         holdBinding &&
         holdBindingMatchesEvent(holdBinding, e) &&
         !holdActive &&
-        v.state !== "recording" &&
-        v.state !== "starting" &&
-        v.state !== "transcribing" &&
         !isInputBlocked()
       ) {
-        e.preventDefault();
-        holdActive = true;
-        void v.start();
+        // Conversation push-to-talk takes precedence: the held key suppresses
+        // VAD and the release sends, rather than starting a dictation pass.
+        const conversation = getConversation();
+        if (conversation?.active) {
+          e.preventDefault();
+          holdActive = true;
+          holdTarget = "conversation";
+          conversation.beginHold();
+          return;
+        }
+        // Dictation: hold to record, release auto-sends (push-to-talk). Only
+        // start from a settled state so a release/timeout mid-press is clean.
+        if (
+          v.state !== "recording" &&
+          v.state !== "starting" &&
+          v.state !== "transcribing"
+        ) {
+          e.preventDefault();
+          holdActive = true;
+          holdTarget = "voice";
+          void v.start({ autoSend: true });
+        }
       }
     },
 
     onKeyUp(e: KeyboardEvent) {
       if (!holdCode || !holdActive || e.code !== holdCode) return;
       holdActive = false;
+      const target = holdTarget;
+      holdTarget = null;
+      if (target === "conversation") {
+        getConversation()?.endHold();
+        return;
+      }
       const v = getVoice();
       if (v.state === "recording" || v.state === "starting") {
         v.stop();
@@ -167,6 +207,7 @@ export function createVoiceHotkeyHandlers(
     // toggle hotkey, hold-to-talk).
     onBlur() {
       holdActive = false;
+      holdTarget = null;
     },
   };
 }
@@ -184,15 +225,20 @@ export function useVoiceHotkey(
   toggleHotkey: string | null,
   holdHotkey: string | null,
   isInputBlocked: () => boolean = () => false,
+  conversation?: ConversationHotkeyHandle | null,
 ): void {
   const voiceRef = useRef<VoiceInputController>(voice);
+  const conversationRef = useRef<ConversationHotkeyHandle | null>(
+    conversation ?? null,
+  );
 
-  // Keep the ref in sync after every render so event handlers always read
-  // the latest voice state without being re-registered on every state change.
-  // useLayoutEffect (not render-time assignment) satisfies the React Compiler's
-  // requirement that refs are only mutated outside of render.
+  // Keep the refs in sync after every render so event handlers always read
+  // the latest voice/conversation state without being re-registered on every
+  // state change. useLayoutEffect (not render-time assignment) satisfies the
+  // React Compiler's requirement that refs are only mutated outside of render.
   useLayoutEffect(() => {
     voiceRef.current = voice;
+    conversationRef.current = conversation ?? null;
   });
 
   useEffect(() => {
@@ -203,6 +249,7 @@ export function useVoiceHotkey(
       toggleBinding,
       holdBinding,
       isInputBlocked,
+      () => conversationRef.current,
     );
     window.addEventListener("keydown", onKeyDown);
     window.addEventListener("keyup", onKeyUp);

--- a/src/hooks/useVoiceInput.test.ts
+++ b/src/hooks/useVoiceInput.test.ts
@@ -74,7 +74,26 @@ describe("useVoiceInput", () => {
     expect(service.stopAndTranscribeVoice).toHaveBeenCalledWith(
       "voice-platform-system",
     );
-    expect(onTranscript).toHaveBeenCalledWith("hello world");
+    expect(onTranscript).toHaveBeenCalledWith("hello world", {
+      autoSend: false,
+    });
+  });
+
+  it("forwards the autoSend intent captured at start to the transcript", async () => {
+    const onTranscript = vi.fn();
+    const { result } = renderHook(() => useVoiceInput(onTranscript, vi.fn()));
+
+    await act(async () => {
+      await result.current.start({ autoSend: true });
+    });
+    act(() => {
+      result.current.stop();
+    });
+
+    await waitFor(() => expect(result.current.state).toBe("idle"));
+    expect(onTranscript).toHaveBeenCalledWith("hello world", {
+      autoSend: true,
+    });
   });
 
   it("routes setup-required native providers to settings", async () => {

--- a/src/hooks/useVoiceInput.ts
+++ b/src/hooks/useVoiceInput.ts
@@ -73,6 +73,14 @@ function isMacPlatform(): boolean {
   return /Mac/.test(navigator.platform) || /Mac OS X/.test(navigator.userAgent);
 }
 
+/** Options for a single recording gesture. */
+export interface VoiceStartOptions {
+  /** Submit the transcript immediately when it resolves (push-to-talk) rather
+   *  than inserting it into the composer for review. Captured at start so the
+   *  intent survives the async transcription. */
+  autoSend?: boolean;
+}
+
 export interface VoiceInputController {
   state: VoiceState;
   elapsedSeconds: number;
@@ -80,13 +88,13 @@ export interface VoiceInputController {
   error: string | null;
   activeProvider: VoiceProviderInfo | null;
   webSpeechSupported: boolean;
-  start: () => Promise<void>;
+  start: (options?: VoiceStartOptions) => Promise<void>;
   stop: () => void;
   cancel: () => void;
 }
 
 export function useVoiceInput(
-  onTranscript: (transcript: string) => void,
+  onTranscript: (transcript: string, options: { autoSend: boolean }) => void,
   onNeedsSetup: (providerId: string) => void,
 ): VoiceInputController {
   const [state, setState] = useState<VoiceState>("idle");
@@ -100,6 +108,9 @@ export function useVoiceInput(
   const nativeRequestIdRef = useRef(0);
   const finalTranscriptRef = useRef("");
   const cancelledRef = useRef(false);
+  // Whether the in-flight recording should auto-send its transcript. Set when
+  // start() is invoked, read when the transcript resolves (async, so a ref).
+  const autoSendRef = useRef(false);
   const platformSpeechDisabled = useMemo(() => isMacPlatform(), []);
 
   const Recognition = useMemo(() => {
@@ -151,6 +162,7 @@ export function useVoiceInput(
       transcribingProviderRef.current = null;
     }
     finalTranscriptRef.current = "";
+    autoSendRef.current = false;
     setInterimTranscript("");
     setError(null);
     setActiveProvider(null);
@@ -159,8 +171,9 @@ export function useVoiceInput(
 
   useEffect(() => cancel, [cancel]);
 
-  const start = useCallback(async () => {
+  const start = useCallback(async (options?: VoiceStartOptions) => {
     nativeRequestIdRef.current += 1;
+    autoSendRef.current = options?.autoSend ?? false;
     setError(null);
     setInterimTranscript("");
     setActiveProvider(null);
@@ -305,7 +318,7 @@ export function useVoiceInput(
       const transcript = finalTranscriptRef.current.trim();
       finalTranscriptRef.current = "";
       setInterimTranscript("");
-      if (transcript) onTranscript(transcript);
+      if (transcript) onTranscript(transcript, { autoSend: autoSendRef.current });
       setState("idle");
     };
     recognitionRef.current = recognition;
@@ -337,7 +350,7 @@ export function useVoiceInput(
             return;
           }
           const normalized = transcript.trim();
-          if (normalized) onTranscript(normalized);
+          if (normalized) onTranscript(normalized, { autoSend: autoSendRef.current });
           setState("idle");
         })
         .catch((err) => {


### PR DESCRIPTION
## What

Make the voice **hold hotkey** a true push-to-talk that sends on release, in both voice modes:

- **Dictation (no conversation):** hold the voice hotkey → record; **release → transcribe _and send_** — no manual Enter. Previously the release only dropped the text into the composer.
- **Active voice conversation:** the same hold key is its push-to-talk. **Press suppresses VAD** (so _you_, not the 1.1 s silence timer, own the end-of-message), and **release ends the utterance and sends it** to the agent — an intuitive override of the hands-free silence detection.

## How

- **`useVoiceInput`** — `start({ autoSend })` captures the intent at gesture start and replays it when the async transcript resolves (both native + web-speech paths), so it survives the await gap. `onTranscript(text, { autoSend })`.
- **`useVoiceConversation`** — new `beginHold`/`endHold`. While held, `manualHoldRef` suppresses VAD auto-end (silence _and_ ceiling). Release finishes + sends. Blur, start-error, and exit all clear the hold so the mic can't wedge open. A press from `idle` opens the mic; a release that lands before the recorder is ready finishes it the moment it opens (no stuck-open mic).
- **`useVoiceHotkey`** — hold routing is conversation-aware: when a conversation is active the key drives its PTT, otherwise dictation `start({ autoSend: true })`. The driven subsystem is captured at keydown so the matching keyup ends the same one even if the conversation flips mid-press. The dictation **toggle** hotkey is suppressed while a conversation owns the mic (no double recording).
- **`chat-input`** — auto-send transcript path; `attachments` memoized (it's now a `useCallback` dep).

The mic button and toggle hotkey are unchanged — they still insert-for-review. Only the **hold gesture** sends, matching the push-to-talk mental model.

## Tests

13 new/updated unit tests across the three hooks: autoSend threading, conversation PTT (VAD suppression + release-sends + idle re-open), toggle suppression, hold-target capture across a mid-press flip, and the release-before-mic-opens race. Full suite green: **2287 vitest**, `tsc -b`, ESLint 0/0.

## Review

Codex peer-reviewed. One **P1** (privacy: a press+release during recorder startup could leave the conversation mic recording indefinitely) found and fixed in `42f69f0`, with a regression test.

## Follow-up (not in this PR)

The conversation HUD's "Listening… (pause when done)" copy stays binding-agnostic — it doesn't yet hint that you can hold the talk key, because the hold key is configurable and unbound by default on Linux. A future change could plumb the resolved binding into the HUD to advertise PTT when it's actually bound.
