### PR TITLE
feat(voice): auto-listen toggle in conversation HUD, off by default

### DIFF
--- a/src-tauri/src/helpers/config.rs
+++ b/src-tauri/src/helpers/config.rs
@@ -434,7 +434,7 @@ pub fn parse_config_toml(input: &str) -> serde_json::Value {
             "holdHotkey": cfg.voice.hold_hotkey.or_else(|| default_voice_hold_hotkey().map(str::to_string)),
             "speakAgentReplies": cfg.voice.speak_agent_replies.unwrap_or(false),
             "speakMaxChars": cfg.voice.speak_max_chars.unwrap_or(600),
-            "conversationContinuous": cfg.voice.conversation_continuous.unwrap_or(true),
+            "conversationContinuous": cfg.voice.conversation_continuous.unwrap_or(false),
         },
         "extensions": {
             "stateWarnKb": state_warn_kb,
@@ -696,7 +696,8 @@ mod tests {
         assert_eq!(v["voice"]["holdHotkey"], serde_json::Value::Null);
         assert_eq!(v["voice"]["speakAgentReplies"], false);
         assert_eq!(v["voice"]["speakMaxChars"], 600);
-        assert_eq!(v["voice"]["conversationContinuous"], true);
+        // Auto-listen is opt-in (push-to-talk drives each turn by default).
+        assert_eq!(v["voice"]["conversationContinuous"], false);
     }
 
     #[test]
@@ -715,6 +716,14 @@ conversation_continuous = false
         assert_eq!(v["voice"]["speakAgentReplies"], true);
         assert_eq!(v["voice"]["speakMaxChars"], 250);
         // Explicit opt-out of hands-free auto-loop.
+        assert_eq!(v["voice"]["conversationContinuous"], false);
+    }
+
+    #[test]
+    fn conversation_continuous_defaults_off_when_absent() {
+        // Auto-listen is opt-in: with no [voice] conversation_continuous key,
+        // the hands-free auto-reopen loop must default off (push-to-talk).
+        let v = parse_config_toml("[voice]\ntoggle_hotkey = \"mod+shift+m\"\n");
         assert_eq!(v["voice"]["conversationContinuous"], false);
     }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -171,7 +171,9 @@ const DEFAULTS: AethonConfig = {
         : null,
     speakAgentReplies: false,
     speakMaxChars: 600,
-    conversationContinuous: true,
+    // Auto-listen (hands-free auto-reopen of the mic after the agent speaks)
+    // is opt-in: with push-to-talk the user drives each turn explicitly.
+    conversationContinuous: false,
   },
   updates: { channel: "stable", disableAutoCheck: false },
   devshell: {
@@ -292,8 +294,9 @@ export function getConfig(): Promise<AethonConfig> {
             Number.isFinite(obj.voice.speakMaxChars)
               ? Math.min(5000, Math.max(50, Math.round(obj.voice.speakMaxChars)))
               : DEFAULTS.voice.speakMaxChars,
-          conversationContinuous:
-            obj?.voice?.conversationContinuous !== false,
+          // Opt-in: only an explicit `true` enables auto-listen; absent or
+          // false → off (matches the Rust default).
+          conversationContinuous: obj?.voice?.conversationContinuous === true,
         },
         updates: {
           channel: obj?.updates?.channel === "nightly" ? "nightly" : "stable",

--- a/src/eventRoutes/chatInput.test.ts
+++ b/src/eventRoutes/chatInput.test.ts
@@ -128,6 +128,48 @@ describe("handleChatInput", () => {
     });
   });
 
+  it("voice:auto-listen live-applies and persists the toggle", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    const handled = await handleChatInput(
+      {
+        component: { id: "chat-input" },
+        eventType: "voice:auto-listen",
+        data: { value: true },
+      },
+      ctx,
+    );
+
+    expect(handled).toBe(true);
+    // Live: the running conversation reads /voice/conversationContinuous.
+    expect(
+      (ctx.stateRef.current.voice as { conversationContinuous?: boolean })
+        .conversationContinuous,
+    ).toBe(true);
+    // Persisted under the same key the Settings panel writes.
+    expect(mocks.applySettingsPatch).toHaveBeenCalledWith({
+      voice: { conversationContinuous: true },
+    });
+  });
+
+  it("voice:auto-listen coerces a non-true value to off", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    await handleChatInput(
+      {
+        component: { id: "chat-input" },
+        eventType: "voice:auto-listen",
+        data: { value: false },
+      },
+      ctx,
+    );
+    expect(
+      (ctx.stateRef.current.voice as { conversationContinuous?: boolean })
+        .conversationContinuous,
+    ).toBe(false);
+    expect(mocks.applySettingsPatch).toHaveBeenCalledWith({
+      voice: { conversationContinuous: false },
+    });
+  });
+
   // Wrong-id rejection is no longer the handler's responsibility — the
   // route table dispatches by `type:chat-input`, so a non-chat-input
   // event simply never reaches this handler. See index.test.ts for the

--- a/src/eventRoutes/chatInput.ts
+++ b/src/eventRoutes/chatInput.ts
@@ -101,5 +101,20 @@ export const handleChatInput: EventRouteHandler = async (
     }));
     return true;
   }
+  if (eventType === "voice:auto-listen") {
+    const value = (data as { value?: unknown } | undefined)?.value === true;
+    // Live-apply so the running conversation picks it up immediately (the
+    // hook reads /voice/conversationContinuous), and persist so the choice
+    // sticks — same config key the Settings panel writes.
+    ctx.setState((prev) => ({
+      ...prev,
+      voice: {
+        ...(prev.voice ?? {}),
+        conversationContinuous: value,
+      },
+    }));
+    ctx.applySettingsPatch({ voice: { conversationContinuous: value } });
+    return true;
+  }
   return false;
 };

--- a/src/extensions/default-layout/chat-input.tsx
+++ b/src/extensions/default-layout/chat-input.tsx
@@ -188,7 +188,7 @@ export function ChatInput({
   const conversation = useVoiceConversation({
     submitText: (text) => onEvent("submit", { value: text, mode: "normal" }),
     getActiveTabId: () => state.activeTabId as string | undefined,
-    continuous: voiceConfig.conversationContinuous ?? true,
+    continuous: voiceConfig.conversationContinuous ?? false,
     maxSpokenChars: voiceConfig.speakMaxChars ?? 600,
     onNeedsSetup: (providerId) => onEvent("voice:setup", { providerId }),
   });
@@ -470,7 +470,13 @@ export function ChatInput({
         <ConversationHud
           phase={conversation.phase}
           error={conversation.error}
+          autoListen={voiceConfig.conversationContinuous ?? false}
           onPrimary={conversation.primaryAction}
+          onToggleAutoListen={() =>
+            onEvent("voice:auto-listen", {
+              value: !(voiceConfig.conversationContinuous ?? false),
+            })
+          }
           onExit={conversation.exit}
         />
       )}

--- a/src/extensions/default-layout/conversation-hud.test.tsx
+++ b/src/extensions/default-layout/conversation-hud.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { ConversationHud } from "./conversation-hud";
+
+afterEach(() => cleanup());
+
+describe("ConversationHud auto-listen toggle", () => {
+  it("reflects auto-listen state on the switch", () => {
+    const { rerender } = render(
+      <ConversationHud
+        phase="listening"
+        error={null}
+        autoListen={false}
+        onPrimary={vi.fn()}
+        onToggleAutoListen={vi.fn()}
+        onExit={vi.fn()}
+      />,
+    );
+    const toggle = screen.getByRole("switch");
+    expect(toggle.getAttribute("aria-checked")).toBe("false");
+    expect(toggle.className).not.toContain("a2ui-conversation-hud-auto-on");
+
+    rerender(
+      <ConversationHud
+        phase="listening"
+        error={null}
+        autoListen={true}
+        onPrimary={vi.fn()}
+        onToggleAutoListen={vi.fn()}
+        onExit={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("switch").getAttribute("aria-checked")).toBe("true");
+    expect(screen.getByRole("switch").className).toContain(
+      "a2ui-conversation-hud-auto-on",
+    );
+  });
+
+  it("fires onToggleAutoListen when clicked", () => {
+    const onToggleAutoListen = vi.fn();
+    render(
+      <ConversationHud
+        phase="idle"
+        error={null}
+        autoListen={false}
+        onPrimary={vi.fn()}
+        onToggleAutoListen={onToggleAutoListen}
+        onExit={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole("switch"));
+    expect(onToggleAutoListen).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/extensions/default-layout/conversation-hud.tsx
+++ b/src/extensions/default-layout/conversation-hud.tsx
@@ -19,16 +19,22 @@ const PRIMARY_LABEL: Record<ConversationPhase, string> = {
 export interface ConversationHudProps {
   phase: ConversationPhase;
   error: string | null;
+  /** Hands-free auto-reopen of the mic after the agent speaks. */
+  autoListen: boolean;
   onPrimary: () => void;
+  onToggleAutoListen: () => void;
   onExit: () => void;
 }
 
 /** Compact in-composer panel for the LFM2-Audio conversation voice mode:
- *  shows the current phase plus a context-aware primary action and an exit. */
+ *  shows the current phase plus a context-aware primary action, an
+ *  auto-listen toggle, and an exit. */
 export function ConversationHud({
   phase,
   error,
+  autoListen,
   onPrimary,
+  onToggleAutoListen,
   onExit,
 }: ConversationHudProps) {
   return (
@@ -44,6 +50,22 @@ export function ConversationHud({
       <span className="a2ui-conversation-hud-status" aria-live="polite">
         {error ?? STATUS_LABEL[phase]}
       </span>
+      <button
+        type="button"
+        className={`a2ui-conversation-hud-auto${
+          autoListen ? " a2ui-conversation-hud-auto-on" : ""
+        }`}
+        role="switch"
+        aria-checked={autoListen}
+        onClick={onToggleAutoListen}
+        title={
+          autoListen
+            ? "Auto-listen on — mic reopens after each reply. Click for push-to-talk only."
+            : "Auto-listen off — push-to-talk for each turn. Click to go hands-free."
+        }
+      >
+        Auto
+      </button>
       <button
         type="button"
         className="a2ui-conversation-hud-primary"

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -3986,6 +3986,21 @@ body.ae-resizing-composer * {
   opacity: var(--opacity-disabled);
   cursor: default;
 }
+.a2ui-conversation-hud-auto {
+  flex: 0 0 auto;
+  padding: 3px 10px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-size: inherit;
+}
+.a2ui-conversation-hud-auto-on {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  color: var(--accent);
+}
 .a2ui-chat-input-voice-spinner {
   animation: a2ui-voice-spin 0.9s linear infinite;
 }


### PR DESCRIPTION
## What

Make hands-free **auto-listening** in voice agent mode opt-in, with an easy in-HUD toggle.

Now that push-to-talk (#293) lets you drive each conversation turn explicitly (hold to talk, release to send), continuously auto-reopening the mic after every agent reply shouldn't be the default. This:

- **Defaults auto-listen off.** A fresh conversation waits for you after each agent turn (push-to-talk / tap to talk again) instead of immediately reopening the mic.
- **Adds an "Auto" toggle to the conversation HUD** (`role="switch"`, `aria-checked`) so you can flip hands-free on/off mid-conversation without opening Settings.

## How

- **Default flip** — `conversationContinuous` now defaults `false`:
  - Rust `helpers/config.rs`: `unwrap_or(false)` (+ a test that an absent key reads off).
  - TS `config.ts`: `DEFAULTS` off; parse treats only an explicit `true` as on (absent/false → off), matching Rust.
  - `chat-input` fallback `?? false`.
- **HUD toggle** — `ConversationHud` gains `autoListen` + `onToggleAutoListen`. The switch reads from `/voice/conversationContinuous` and emits `voice:auto-listen`.
- **`voice:auto-listen` route** (`eventRoutes/chatInput.ts`) — live-applies the value to `/voice/conversationContinuous` via `ctx.setState` (the running conversation reads it immediately) **and** persists it through the same `applySettingsPatch` the Settings panel uses. One config key, two writers.

The existing Settings → "Hands-free conversation (auto-reopen mic)" checkbox continues to work and now reflects the same off-by-default.

## Behavior

| Auto-listen | After the agent replies |
|---|---|
| **Off** (default) | Conversation goes idle — you push-to-talk or tap "Speak" for the next turn |
| **On** | Mic auto-reopens — fully hands-free loop (the prior default) |

Entering conversation mode still opens the mic for the first turn either way; the toggle governs the post-reply loop.

## Tests

- Rust: absent `conversation_continuous` → off; explicit `false` still off.
- `voice:auto-listen` route: live `setState` + persisted `applySettingsPatch`, and non-`true` coerces to off.
- `ConversationHud`: switch reflects `autoListen` (`aria-checked` + on-class) and fires the toggle on click.

Full suite green: **2293 vitest**, `tsc -b`, ESLint 0/0, Rust config tests.

## Review

Codex peer-reviewed.
