### PR TITLE
fix(agent): persist reasoning defaults

### DIFF
--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -330,6 +330,10 @@ pub fn write_config(config: serde_json::Value, app: AppHandle) -> Result<(), Str
         .and_then(|m| m.get("model"))
         .and_then(|v| v.as_str())
         .filter(|s| !s.is_empty());
+    let thinking_level = agent
+        .and_then(|m| m.get("thinkingLevel"))
+        .and_then(|v| v.as_str())
+        .and_then(|s| helpers::normalize_thinking_level(Some(s)));
     let provider_timeout_seconds = agent
         .and_then(|m| m.get("providerTimeoutSeconds"))
         .and_then(|v| v.as_u64())
@@ -487,6 +491,7 @@ pub fn write_config(config: serde_json::Value, app: AppHandle) -> Result<(), Str
     {
         let agent_table = ensure_table(&mut doc, "agent");
         set_or_clear_str(agent_table, "model", model);
+        set_or_clear_str(agent_table, "thinking_level", thinking_level);
         set_or_clear_int(
             agent_table,
             "provider_timeout_seconds",

--- a/src-tauri/src/helpers/config.rs
+++ b/src-tauri/src/helpers/config.rs
@@ -40,6 +40,9 @@ pub struct UiConfig {
 #[derive(Default, Deserialize)]
 pub struct AgentConfig {
     pub model: Option<String>,
+    /// Default reasoning effort for new sessions on models that expose it.
+    /// Allowed: off/minimal/low/medium/high/xhigh. Unknown values are ignored.
+    pub thinking_level: Option<String>,
     /// Optional Aethon-owned override for the provider/SDK request timeout,
     /// in seconds. Omitted leaves pi's own `retry.provider.timeoutMs` behavior
     /// unchanged. Exposed to the bridge as seconds; the bridge converts to ms.
@@ -352,6 +355,13 @@ pub fn normalize_timeout_seconds(value: Option<u32>) -> u32 {
     normalize_optional_timeout_seconds(value).unwrap_or(AGENT_TIMEOUT_SECONDS_DEFAULT)
 }
 
+pub fn normalize_thinking_level(value: Option<&str>) -> Option<&str> {
+    match value {
+        Some("off" | "minimal" | "low" | "medium" | "high" | "xhigh") => value,
+        _ => None,
+    }
+}
+
 /// Parse a TOML config string into the canonical JSON shape the frontend
 /// consumes. Falls back to defaults on parse error so a malformed user
 /// file never blocks app boot. Returns the same shape regardless of what
@@ -372,6 +382,7 @@ pub fn parse_config_toml(input: &str) -> serde_json::Value {
     let new_tab_kind = normalize_new_tab_kind(cfg.shortcuts.new_tab_kind.as_deref());
     let thinking_visibility = normalize_visibility(cfg.ui.thinking_visibility.as_deref());
     let tool_calls_visibility = normalize_tool_visibility(cfg.ui.tool_calls_visibility.as_deref());
+    let thinking_level = normalize_thinking_level(cfg.agent.thinking_level.as_deref());
     let provider_timeout_seconds =
         normalize_optional_timeout_seconds(cfg.agent.provider_timeout_seconds);
     let codex_fast_mode = cfg.agent.codex_fast_mode.unwrap_or(false);
@@ -412,6 +423,7 @@ pub fn parse_config_toml(input: &str) -> serde_json::Value {
         },
         "agent": {
             "model": cfg.agent.model,
+            "thinkingLevel": thinking_level,
             "providerTimeoutSeconds": provider_timeout_seconds,
             "codexFastMode": codex_fast_mode,
             "bashTimeoutFloorSeconds": bash_timeout_floor_seconds,
@@ -506,6 +518,7 @@ mod tests {
         assert_eq!(v["ui"]["fontSize"], serde_json::Value::Null);
         assert_eq!(v["ui"]["restoreTabs"], serde_json::Value::Null);
         assert_eq!(v["agent"]["model"], serde_json::Value::Null);
+        assert_eq!(v["agent"]["thinkingLevel"], serde_json::Value::Null);
         assert_eq!(
             v["agent"]["providerTimeoutSeconds"],
             serde_json::Value::Null
@@ -539,14 +552,21 @@ mod tests {
     #[test]
     fn parse_config_toml_extracts_agent_section() {
         let v = parse_config_toml(
-            "[agent]\nmodel = \"anthropic/claude-sonnet-4-6\"\nprovider_timeout_seconds = 120\ncodex_fast_mode = true\nbash_timeout_floor_seconds = 45\nsubagent_timeout_seconds = 900\n",
+            "[agent]\nmodel = \"anthropic/claude-sonnet-4-6\"\nthinking_level = \"high\"\nprovider_timeout_seconds = 120\ncodex_fast_mode = true\nbash_timeout_floor_seconds = 45\nsubagent_timeout_seconds = 900\n",
         );
         assert_eq!(v["agent"]["model"], "anthropic/claude-sonnet-4-6");
+        assert_eq!(v["agent"]["thinkingLevel"], "high");
         assert_eq!(v["agent"]["providerTimeoutSeconds"], 120);
         assert_eq!(v["agent"]["codexFastMode"], true);
         assert_eq!(v["agent"]["bashTimeoutFloorSeconds"], 45);
         assert_eq!(v["agent"]["subagentTimeoutSeconds"], 900);
         assert_eq!(v["ui"]["theme"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn parse_config_toml_ignores_unknown_thinking_level() {
+        let v = parse_config_toml("[agent]\nthinking_level = \"turbo\"\n");
+        assert_eq!(v["agent"]["thinkingLevel"], serde_json::Value::Null);
     }
 
     #[test]
@@ -772,6 +792,12 @@ prompt_before_close = false
             assert!(v["ui"].as_object().unwrap().contains_key("fontSize"));
             assert!(v["ui"].as_object().unwrap().contains_key("restoreTabs"));
             assert!(v["agent"].as_object().unwrap().contains_key("model"));
+            assert!(
+                v["agent"]
+                    .as_object()
+                    .unwrap()
+                    .contains_key("thinkingLevel")
+            );
             assert!(
                 v["agent"]
                     .as_object()

--- a/src-tauri/src/helpers/mod.rs
+++ b/src-tauri/src/helpers/mod.rs
@@ -24,8 +24,9 @@ pub mod paths;
 pub use config::{
     AGENT_TIMEOUT_SECONDS_DEFAULT, FONT_SIZE_MAX, FONT_SIZE_MIN, clamp_font_size,
     normalize_default_share_mode, normalize_devshell_enabled, normalize_devshell_mode,
-    normalize_new_tab_kind, normalize_optional_timeout_seconds, normalize_timeout_seconds,
-    normalize_tool_visibility, normalize_update_channel, normalize_visibility, parse_config_toml,
+    normalize_new_tab_kind, normalize_optional_timeout_seconds, normalize_thinking_level,
+    normalize_timeout_seconds, normalize_tool_visibility, normalize_update_channel,
+    normalize_visibility, parse_config_toml,
 };
 pub use names::{sanitize_filename_segment, validate_state_name};
 pub use paths::{aethon_dir, resolve_inside_root};

--- a/src/config.ts
+++ b/src/config.ts
@@ -52,6 +52,8 @@ export interface AethonConfig {
   };
   agent: {
     model: string | null;
+    /** Default reasoning effort for new sessions on models that expose it. */
+    thinkingLevel: string | null;
     /** Optional Aethon-owned provider/SDK request timeout override. */
     providerTimeoutSeconds: number | null;
     /** Request Codex Fast mode (priority service tier) for supported Codex models. */
@@ -148,6 +150,7 @@ const DEFAULTS: AethonConfig = {
   },
   agent: {
     model: null,
+    thinkingLevel: null,
     providerTimeoutSeconds: null,
     codexFastMode: false,
     bashTimeoutFloorSeconds: DEFAULT_AGENT_TIMEOUT_SECONDS,
@@ -237,6 +240,7 @@ export function getConfig(): Promise<AethonConfig> {
         },
         agent: {
           model: typeof obj?.agent?.model === "string" ? obj.agent.model : null,
+          thinkingLevel: normalizeThinkingLevel(obj?.agent?.thinkingLevel),
           providerTimeoutSeconds: normalizeOptionalTimeoutSeconds(
             obj?.agent?.providerTimeoutSeconds,
           ),
@@ -292,7 +296,10 @@ export function getConfig(): Promise<AethonConfig> {
           speakMaxChars:
             typeof obj?.voice?.speakMaxChars === "number" &&
             Number.isFinite(obj.voice.speakMaxChars)
-              ? Math.min(5000, Math.max(50, Math.round(obj.voice.speakMaxChars)))
+              ? Math.min(
+                  5000,
+                  Math.max(50, Math.round(obj.voice.speakMaxChars)),
+                )
               : DEFAULTS.voice.speakMaxChars,
           // Opt-in: only an explicit `true` enables auto-listen; absent or
           // false → off (matches the Rust default).
@@ -335,6 +342,17 @@ export function getConfig(): Promise<AethonConfig> {
 
 function normalizeTheme(t: unknown): string | null {
   return typeof t === "string" && t.length > 0 ? t : null;
+}
+
+function normalizeThinkingLevel(value: unknown): string | null {
+  return value === "off" ||
+    value === "minimal" ||
+    value === "low" ||
+    value === "medium" ||
+    value === "high" ||
+    value === "xhigh"
+    ? value
+    : null;
 }
 
 /** Mirrors `normalize_visibility` in helpers.rs — unknown/missing → "show". */

--- a/src/hooks/uiOverlays/settings.test.ts
+++ b/src/hooks/uiOverlays/settings.test.ts
@@ -29,6 +29,7 @@ const baseConfig: AethonConfig = {
   },
   agent: {
     model: "openai/gpt-5.5",
+    thinkingLevel: null,
     providerTimeoutSeconds: null,
     codexFastMode: false,
     bashTimeoutFloorSeconds: 300,

--- a/src/hooks/useBootConfig.ts
+++ b/src/hooks/useBootConfig.ts
@@ -137,6 +137,12 @@ export function useBootConfig(ctx: UseBootConfigContext): UseBootConfigActions {
         hardEnforceProjectRoot: fresh.guardrails.hardEnforceProjectRoot,
       },
       codexFastMode: fresh.agent.codexFastMode,
+      ...(fresh.agent.thinkingLevel
+        ? {
+            thinkingLevel: fresh.agent.thinkingLevel,
+            defaultThinkingLevel: fresh.agent.thinkingLevel,
+          }
+        : {}),
     }));
     if (fresh.agent.model) {
       piDefaultModelRef.current = fresh.agent.model;
@@ -231,6 +237,12 @@ export function useBootConfig(ctx: UseBootConfigContext): UseBootConfigActions {
             hardEnforceProjectRoot: config.guardrails.hardEnforceProjectRoot,
           },
           codexFastMode: config.agent.codexFastMode,
+          ...(config.agent.thinkingLevel
+            ? {
+                thinkingLevel: config.agent.thinkingLevel,
+                defaultThinkingLevel: config.agent.thinkingLevel,
+              }
+            : {}),
         }));
 
         // [agent] model: when set, seed the picker default for this

--- a/src/hooks/useChat.test.ts
+++ b/src/hooks/useChat.test.ts
@@ -828,50 +828,75 @@ describe("useChat setModel", () => {
     );
   });
 
-  it("records reasoning defaults when no agent tab is active", async () => {
-    const { ctx, stateRef } = buildContext({
-      activeTabId: undefined,
-      tabs: [],
-    });
-    const { result } = renderHook(() => useChat(ctx));
+  it("records and persists reasoning defaults when no agent tab is active", async () => {
+    vi.useFakeTimers();
+    try {
+      const { ctx, stateRef } = buildContext({
+        activeTabId: undefined,
+        tabs: [],
+      });
+      const { result } = renderHook(() => useChat(ctx));
 
-    await act(async () => {
-      await result.current.setThinkingLevel("high");
-    });
+      await act(async () => {
+        await result.current.setThinkingLevel("high");
+      });
 
-    expect(invoke).not.toHaveBeenCalledWith("agent_command", expect.anything());
-    expect(stateRef.current.thinkingLevel).toBe("high");
-    expect(stateRef.current.defaultThinkingLevel).toBe("high");
-    expect(stateRef.current.status).toBe("reasoning default: high");
+      expect(invoke).not.toHaveBeenCalledWith(
+        "agent_command",
+        expect.anything(),
+      );
+      expect(stateRef.current.thinkingLevel).toBe("high");
+      expect(stateRef.current.defaultThinkingLevel).toBe("high");
+      expect(stateRef.current.status).toBe("reasoning default: high");
+
+      await vi.advanceTimersByTimeAsync(450);
+      const write = invoke.mock.calls.find((c) => c[0] === "write_config");
+      expect(write).toBeTruthy();
+      expect(
+        (write?.[1] as { config: { agent: { thinkingLevel: string } } }).config
+          .agent.thinkingLevel,
+      ).toBe("high");
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
   });
 
   it("rolls back optimistic reasoning changes when the bridge command fails", async () => {
-    const tab = {
-      ...makeEmptyTab("tab-1", "Tab 1"),
-      model: "openai-codex/gpt-5.5",
-      thinkingLevel: "medium",
-    };
-    const { ctx, stateRef } = buildContext({
-      model: "openai-codex/gpt-5.5",
-      thinkingLevel: "medium",
-      defaultThinkingLevel: "medium",
-      tabs: [tab],
-    });
-    invoke.mockImplementation((cmd) =>
-      cmd === "agent_command"
-        ? Promise.reject(new Error("offline"))
-        : Promise.resolve(),
-    );
-    const { result } = renderHook(() => useChat(ctx));
+    vi.useFakeTimers();
+    try {
+      const tab = {
+        ...makeEmptyTab("tab-1", "Tab 1"),
+        model: "openai-codex/gpt-5.5",
+        thinkingLevel: "medium",
+      };
+      const { ctx, stateRef } = buildContext({
+        model: "openai-codex/gpt-5.5",
+        thinkingLevel: "medium",
+        defaultThinkingLevel: "medium",
+        tabs: [tab],
+      });
+      invoke.mockImplementation((cmd) =>
+        cmd === "agent_command"
+          ? Promise.reject(new Error("offline"))
+          : Promise.resolve(),
+      );
+      const { result } = renderHook(() => useChat(ctx));
 
-    await act(async () => {
-      await result.current.setThinkingLevel("xhigh");
-    });
+      await act(async () => {
+        await result.current.setThinkingLevel("xhigh");
+      });
 
-    expect(stateRef.current.thinkingLevel).toBe("medium");
-    expect(stateRef.current.defaultThinkingLevel).toBe("medium");
-    expect((stateRef.current.tabs as Tab[])[0].thinkingLevel).toBe("medium");
-    expect(stateRef.current.status).toBe("reasoning switch failed");
+      expect(stateRef.current.thinkingLevel).toBe("medium");
+      // The live session rolls back, but the user's chosen default remains for
+      // new tabs (same persistence semantics as model selection).
+      expect(stateRef.current.defaultThinkingLevel).toBe("xhigh");
+      expect((stateRef.current.tabs as Tab[])[0].thinkingLevel).toBe("medium");
+      expect(stateRef.current.status).toBe("reasoning switch failed");
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
   });
 
   it("does not apply reasoning changes while the active prompt is busy", async () => {
@@ -901,6 +926,39 @@ describe("useChat setModel", () => {
     expect(stateRef.current.status).toBe(
       "agent busy — stop the current prompt before switching reasoning",
     );
+  });
+
+  it("persists active-session reasoning choices to [agent] thinking_level", async () => {
+    vi.useFakeTimers();
+    try {
+      const tab = {
+        ...makeEmptyTab("tab-1", "Tab 1"),
+        model: "openai-codex/gpt-5.5",
+        thinkingLevel: "medium",
+      };
+      const { ctx } = buildContext({
+        model: "openai-codex/gpt-5.5",
+        thinkingLevel: "medium",
+        defaultThinkingLevel: "medium",
+        tabs: [tab],
+      });
+      const { result } = renderHook(() => useChat(ctx));
+
+      await act(async () => {
+        await result.current.setThinkingLevel("high");
+      });
+      await vi.advanceTimersByTimeAsync(450);
+
+      const write = invoke.mock.calls.find((c) => c[0] === "write_config");
+      expect(write).toBeTruthy();
+      expect(
+        (write?.[1] as { config: { agent: { thinkingLevel: string } } }).config
+          .agent.thinkingLevel,
+      ).toBe("high");
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
   });
 
   it("rolls back optimistic Codex Fast mode changes when persistence fails", async () => {
@@ -1007,6 +1065,7 @@ describe("useChat setModel", () => {
           .agent.model,
       ).toBeNull();
     } finally {
+      vi.clearAllTimers();
       vi.useRealTimers();
     }
   });
@@ -1029,6 +1088,7 @@ describe("useChat setModel", () => {
           .model,
       ).toBe("openai/gpt-5.5");
     } finally {
+      vi.clearAllTimers();
       vi.useRealTimers();
     }
   });

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -180,19 +180,20 @@ export function useChat(ctx: UseChatContext): UseChatActions {
   // completion notification gate.
   const turnStartedAtRef = useRef<Map<string, number>>(new Map());
 
-  // Debounced persistence of the chosen default model to [agent] model.
-  // Clicking through several models in the header picker would otherwise
-  // do a disk read + full TOML rewrite per click; we coalesce to a single
-  // trailing write that captures the latest id.
-  const defaultModelTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+  // Debounced persistence of header-selected agent defaults to [agent].
+  // Clicking through models / reasoning levels would otherwise do a disk read +
+  // full TOML rewrite per click; coalesce to a single trailing write.
+  const agentDefaultsTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
-  const pendingDefaultModelRef = useRef<string | null>(null);
+  const pendingAgentDefaultsRef = useRef<
+    Partial<{ model: string | null; thinkingLevel: string | null }>
+  >({});
 
-  async function flushDefaultModelWrite() {
-    const model = pendingDefaultModelRef.current;
-    if (model === null) return;
-    pendingDefaultModelRef.current = null;
+  async function flushAgentDefaultsWrite() {
+    const patch = pendingAgentDefaultsRef.current;
+    if (Object.keys(patch).length === 0) return;
+    pendingAgentDefaultsRef.current = {};
     let live: AethonConfig | null = null;
     try {
       live = await getConfig();
@@ -205,7 +206,7 @@ export function useChat(ctx: UseChatContext): UseChatActions {
     // (uiOverlays/settings.ts) so unrelated sections survive the round-trip.
     const merged = {
       ui: { ...(live?.ui ?? {}) },
-      agent: { ...(live?.agent ?? {}), model: model || null },
+      agent: { ...(live?.agent ?? {}), ...patch },
       shell: { ...(live?.shell ?? {}) },
       shortcuts: { ...(live?.shortcuts ?? {}) },
       voice: { ...(live?.voice ?? {}) },
@@ -216,22 +217,35 @@ export function useChat(ctx: UseChatContext): UseChatActions {
     try {
       await invoke("write_config", { config: merged });
       // Drop the read-once cache so an open Settings panel + the next
-      // getConfig() reflect the header-chosen model.
+      // getConfig() reflect the header-chosen defaults.
       clearConfigCache();
     } catch (err) {
-      console.warn("persist default model failed:", err);
+      console.warn("persist agent defaults failed:", err);
     }
   }
 
-  function persistDefaultModel(model: string) {
-    pendingDefaultModelRef.current = model;
-    if (defaultModelTimerRef.current) {
-      clearTimeout(defaultModelTimerRef.current);
+  function persistAgentDefaults(
+    patch: Partial<{ model: string | null; thinkingLevel: string | null }>,
+  ) {
+    pendingAgentDefaultsRef.current = {
+      ...pendingAgentDefaultsRef.current,
+      ...patch,
+    };
+    if (agentDefaultsTimerRef.current) {
+      clearTimeout(agentDefaultsTimerRef.current);
     }
-    defaultModelTimerRef.current = setTimeout(() => {
-      defaultModelTimerRef.current = null;
-      void flushDefaultModelWrite();
+    agentDefaultsTimerRef.current = setTimeout(() => {
+      agentDefaultsTimerRef.current = null;
+      void flushAgentDefaultsWrite();
     }, 400);
+  }
+
+  function persistDefaultModel(model: string) {
+    persistAgentDefaults({ model: model || null });
+  }
+
+  function persistDefaultThinkingLevel(level: string) {
+    persistAgentDefaults({ thinkingLevel: level || null });
   }
 
   // Append a chat message, or replace in place if a message with the same
@@ -748,6 +762,9 @@ export function useChat(ctx: UseChatContext): UseChatActions {
       updateTab(activeId, (tab) => ({ ...tab, model: trimmed }));
     }
     persistDefaultModel(trimmed);
+    if (parsed.thinkingLevel) {
+      persistDefaultThinkingLevel(parsed.thinkingLevel);
+    }
 
     // No live session to retarget — the default pick is all that's needed.
     if (!hasActiveAgentTab || !activeId) return;
@@ -797,6 +814,7 @@ export function useChat(ctx: UseChatContext): UseChatActions {
         defaultThinkingLevel: level,
         status: `reasoning default: ${level}`,
       }));
+      persistDefaultThinkingLevel(level);
       return;
     }
     if (stateRef.current.waiting === true || isAgentTabInFlight(activeTab)) {
@@ -812,10 +830,6 @@ export function useChat(ctx: UseChatContext): UseChatActions {
       typeof stateRef.current.thinkingLevel === "string"
         ? stateRef.current.thinkingLevel
         : undefined;
-    const previousDefaultThinkingLevel =
-      typeof stateRef.current.defaultThinkingLevel === "string"
-        ? stateRef.current.defaultThinkingLevel
-        : undefined;
     updateTab(activeId, (tab) => ({ ...tab, thinkingLevel: level }));
     setState((prev) => ({
       ...prev,
@@ -823,6 +837,7 @@ export function useChat(ctx: UseChatContext): UseChatActions {
       defaultThinkingLevel: level,
       status: `reasoning: ${level}`,
     }));
+    persistDefaultThinkingLevel(level);
     try {
       await invoke("agent_command", {
         payload: JSON.stringify({
@@ -851,11 +866,8 @@ export function useChat(ctx: UseChatContext): UseChatActions {
         } else {
           delete next.thinkingLevel;
         }
-        if (previousDefaultThinkingLevel) {
-          next.defaultThinkingLevel = previousDefaultThinkingLevel;
-        } else {
-          delete next.defaultThinkingLevel;
-        }
+        // Keep defaultThinkingLevel as the user's new-session default; only
+        // the active live-session mirror rolls back on bridge failure.
         return next;
       });
       appendMessage(


### PR DESCRIPTION
## Summary
- persist header-selected reasoning level to `[agent] thinking_level`, matching model and Codex Fast mode persistence
- hydrate persisted reasoning defaults on boot for new tabs/sessions
- add Rust config parse/write support and regression coverage

## Validation
- Codex peer review: no issues found
- `bunx vitest run src/hooks/useChat.test.ts src/hooks/uiOverlays/settings.test.ts`
- `bunx tsc -b --noEmit`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib parse_config_toml`
