### PR TITLE
fix(subagents): surface @mentions mid-message

### DIFF
--- a/agent/system-prompt.test.ts
+++ b/agent/system-prompt.test.ts
@@ -147,6 +147,16 @@ describe("buildSubagentsSection", () => {
     expect(out).toContain("opens its own tab");
   });
 
+  it("advertises @<name> handoff for mentions anywhere in a message", () => {
+    const out = buildSubagentsSection([
+      { name: "reviewer", description: "Reviews diffs", surface: "inline" },
+    ]);
+    // Handoff is triggered by a mention *in* a message, not just a prefix, so
+    // mid-message mentions like "when done, have @reviewer check it" delegate.
+    expect(out).toContain("a message includes `@<name>`");
+    expect(out).not.toContain("prefixes a message");
+  });
+
   it("is not rendered by buildRuntimeSection (advertisement is per-turn)", () => {
     expect(buildRuntimeSection(snapshot())).not.toContain(
       "Available subagents",

--- a/agent/system-prompt.ts
+++ b/agent/system-prompt.ts
@@ -50,9 +50,11 @@ export function buildSubagentsSection(
     "Delegate focused work to one with the `task` tool " +
       '(`task({ subagent_type: "<name>", prompt: "<self-contained task>" })`). ' +
       "Choose the subagent whose description best fits; pass everything it needs " +
-      "in `prompt` (it runs in an isolated session and sees only that). When the " +
-      "user prefixes a message with `@<name>`, delegate to that subagent. Do NOT " +
-      "delegate trivial work you can do directly.",
+      "in `prompt` (it runs in an isolated session and sees only that). When a " +
+      "message includes `@<name>`, hand that work to the named subagent — a " +
+      "message that starts with `@<name>` is entirely for it; a mention later in " +
+      "the message (e.g. \"when done, have @<name> review\") delegates just that " +
+      "part. Do NOT delegate trivial work you can do directly.",
   ];
   for (const s of subagents) {
     const model = s.model ? `, model \`${s.model}\`` : "";

--- a/src/extensions/default-layout/at-mention.test.ts
+++ b/src/extensions/default-layout/at-mention.test.ts
@@ -9,6 +9,7 @@ import {
   matchAtMentions,
   matchAtSubagents,
   matchAtFiles,
+  shouldOfferAgents,
   subagentSuggestionsFromFiles,
   type AtFileMatch,
   type AtSubagentMatch,
@@ -153,6 +154,34 @@ describe("subagent mention matching", () => {
     const later = findActiveAtToken("hello @kimi", 11);
     expect(later).not.toBeNull();
     expect(isLeadingAtToken("hello @kimi", later!)).toBe(false);
+  });
+
+  it("offers agents for leading tokens and any non-empty name fragment", () => {
+    const offer = (value: string, cursor: number): boolean => {
+      const token = findActiveAtToken(value, cursor);
+      expect(token).not.toBeNull();
+      return shouldOfferAgents(value, token!);
+    };
+    // Leading `@` (even with no query yet) — the delegation prefix.
+    expect(offer("@", 1)).toBe(true);
+    expect(offer("@ki", 3)).toBe(true);
+    // Mid-message mention with a name fragment still completes to an agent.
+    expect(offer("hello @ki", 9)).toBe(true);
+    // Bare mid-message `@` stays file-focused (no agent clutter).
+    expect(offer("hello @", 7)).toBe(false);
+  });
+
+  it("surfaces a subagent for a mid-message mention via shouldOfferAgents", () => {
+    const value = "when done have @glm";
+    const token = findActiveAtToken(value, value.length);
+    expect(token).not.toBeNull();
+    const matches = matchAtMentions({
+      query: token!.query,
+      files: files("src/glmd.ts"),
+      subagents: [agent("glm-5-2", "zhipu coding model")],
+      includeAgents: shouldOfferAgents(value, token!),
+    });
+    expect(matches[0]).toMatchObject({ kind: "agent", name: "glm-5-2" });
   });
 
   it("ranks matching subagents by name and description", () => {

--- a/src/extensions/default-layout/at-mention.ts
+++ b/src/extensions/default-layout/at-mention.ts
@@ -158,6 +158,18 @@ export function isLeadingAtToken(value: string, token: AtToken): boolean {
   return firstNonSpace >= 0 && token.start === firstNonSpace;
 }
 
+/**
+ * Whether to offer subagent suggestions for this `@token`. Agents surface when
+ * the `@` is the leading token (the delegation prefix) OR the user has typed a
+ * name fragment — so `when done have @glm` mid-message still completes to an
+ * agent, while a bare mid-message `@` (empty query) stays focused on file
+ * references. `matchAtSubagents` self-filters non-agent-shaped queries, so a
+ * path-like token like `@src/foo` never surfaces an agent even when offered.
+ */
+export function shouldOfferAgents(value: string, token: AtToken): boolean {
+  return isLeadingAtToken(value, token) || token.query.length > 0;
+}
+
 export function matchAtSubagents(
   query: string,
   subagents: AtSubagentMatch[],

--- a/src/extensions/default-layout/use-at-mention.ts
+++ b/src/extensions/default-layout/use-at-mention.ts
@@ -2,8 +2,8 @@ import { useEffect, useMemo, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import {
   findActiveAtToken,
-  isLeadingAtToken,
   matchAtMentions,
+  shouldOfferAgents,
   type AtFileMatch,
   type AtMention,
   type AtSubagentMatch,
@@ -92,7 +92,7 @@ export function useAtMention({
       query: token.query,
       files: root ? files : [],
       subagents,
-      includeAgents: isLeadingAtToken(value, token),
+      includeAgents: shouldOfferAgents(value, token),
     });
     return matches.length > 0 ? { ...token, matches } : null;
   }, [token, root, files, subagents, value, dismissedDraft]);


### PR DESCRIPTION
## Problem

User-scope subagents in \`~/.aethon/agents/\` (e.g. \`@glm-5-2\`, \`@kimi\`) appeared to "only work at the host-level workspace." The workspace framing was a red herring — verified live against the running build, user-scope agents resolve in **every** workspace (Rust \`subagents_list\` always lists user scope; the bridge's \`getSubagentsForCwd\` always merges it; the \`task\` tool is registered per-tab in every bridge).

The real cause is **positional**: the \`@\`-mention picker, the bridge's hard-delegation, and the model advertisement were all keyed on the mention being the **leading** (first non-whitespace) token. A composer reading \`when done have @glm\` puts \`@glm\` mid-sentence, so the picker fell back to file-only completion and the agent was never told to hand off.

## Fix

Make mid-message \`@agent\` discoverable + actionable without introducing ambiguous hard-delegation:

- **\`at-mention.ts\`** — add \`shouldOfferAgents()\`: offer agent suggestions when the \`@\` is leading **or** the user has typed a name fragment. A bare mid-message \`@\` (empty query) stays file-focused; \`matchAtSubagents\` already self-filters non-agent-shaped queries, so path-like tokens like \`@src/foo\` never surface an agent.
- **\`use-at-mention.ts\`** — gate the picker's \`includeAgents\` on \`shouldOfferAgents\`.
- **\`system-prompt.ts\`** — the subagent advertisement now tells the model to hand off on \`@<name>\` **anywhere** in a message (leading = whole turn is for it; a mention later in the message delegates just that part), instead of only a message prefix.

### Semantics preserved

A **leading** \`@name\` keeps its deterministic whole-turn hard-delegation (the explicit steer in \`detectSubagentMention\` is unchanged). A **mid-message** \`@name\` is a soft, advertisement-driven handoff — so phrasings like "compare @glm and @kimi outputs" don't accidentally route the entire turn to \`glm\`.

## Tests / gates

- New unit coverage: \`shouldOfferAgents\` (leading, mid-fragment, bare-mid) + mid-message surfacing of \`glm-5-2\`; new advertisement wording asserted.
- \`vitest\` (composer + subagent suites), \`tsc -b --noEmit\` (CI build mode), ESLint 0/0 all green locally.