### PR TITLE
fix(subagents): exempt @mentions from file-ref expansion anywhere

### DIFF
--- a/agent/chat.ts
+++ b/agent/chat.ts
@@ -49,11 +49,10 @@ export async function handleChat(
   // Resolve against this tab's cwd so the mention matches the tab's project.
   const tabCwdForMention =
     cwdOverride ?? state.tabProjectCwds.get(tabId) ?? state.currentProjectCwd;
+  const tabSubagents = getSubagentsForCwd(state, tabCwdForMention).byName;
   const mention = detectSubagentMention(msg.content);
   const explicitSubagent =
-    mention && getSubagentsForCwd(state, tabCwdForMention).byName.has(mention)
-      ? mention
-      : null;
+    mention && tabSubagents.has(mention) ? mention : null;
   if (explicitSubagent) {
     state.pendingExplicitSubagent.set(tabId, explicitSubagent);
   }
@@ -105,7 +104,9 @@ export async function handleChat(
       // refreshing tabProjectCwds, so falling back to it alone resolves @file
       // refs against a stale cwd when the caller passed a fresh cwd.
       cwd: tabCwdForMention ?? process.cwd(),
-      leadingSubagentName: explicitSubagent,
+      // Exempt every configured subagent name (not just a leading mention) so a
+      // mid-message `@reviewer` is treated as an agent mention, not a file ref.
+      subagentNames: tabSubagents.keys(),
     });
     if (expanded.issues?.length) {
       deps.send({

--- a/agent/file-references.test.ts
+++ b/agent/file-references.test.ts
@@ -163,28 +163,42 @@ describe("expandFileReferencesInPrompt", () => {
     expect(outsideOut.issues).toEqual([expect.stringContaining("outside")]);
   });
 
-  it("does not treat a leading accepted @subagent as a file reference", async () => {
+  it("does not treat a leading @subagent as a file reference", async () => {
     const out = await expandFileReferencesInPrompt(
       "@reviewer check @src/App.tsx",
-      { cwd: root, leadingSubagentName: "reviewer" },
+      { cwd: root, subagentNames: ["reviewer"] },
     );
     expect(out.references.map((ref) => ref.displayPath)).toEqual([
       "src/App.tsx",
     ]);
   });
 
-  it("does not treat a punctuated leading accepted @subagent as a file reference", async () => {
-    const out = await expandFileReferencesInPrompt("@reviewer. please check", {
-      cwd: root,
-      leadingSubagentName: "reviewer",
-    });
-    expect(out.references).toEqual([]);
+  it("exempts a mid-message @subagent without emitting an issue", async () => {
+    const out = await expandFileReferencesInPrompt(
+      "when done, have @reviewer check @src/App.tsx",
+      { cwd: root, subagentNames: ["Reviewer"] },
+    );
+    // The subagent mention is skipped (no "not found" notice); the genuine
+    // file reference alongside it still resolves.
+    expect(out.references.map((ref) => ref.displayPath)).toEqual([
+      "src/App.tsx",
+    ]);
+    expect(out.issues ?? []).toEqual([]);
   });
 
-  it("still treats a path-like leading @name.ext as a file reference", async () => {
-    const out = await expandFileReferencesInPrompt("@reviewer.md check this", {
+  it("does not treat a punctuated @subagent as a file reference", async () => {
+    const out = await expandFileReferencesInPrompt(
+      "please ask @reviewer. then continue",
+      { cwd: root, subagentNames: ["reviewer"] },
+    );
+    expect(out.references).toEqual([]);
+    expect(out.issues ?? []).toEqual([]);
+  });
+
+  it("still treats a path-like @name.ext as a file reference", async () => {
+    const out = await expandFileReferencesInPrompt("read @reviewer.md please", {
       cwd: root,
-      leadingSubagentName: "reviewer",
+      subagentNames: ["reviewer"],
     });
     expect(out.references[0]?.displayPath).toBe("reviewer.md");
   });

--- a/agent/file-references.ts
+++ b/agent/file-references.ts
@@ -35,8 +35,15 @@ export interface FileReferenceExpansion {
 export interface FileReferenceExpansionOptions {
   /** Active tab/project/workspace cwd. All relative refs resolve under here. */
   cwd: string;
-  /** Leading explicit subagent name, if one was accepted for this turn. */
-  leadingSubagentName?: string | null;
+  /**
+   * Canonical names of the subagents configured for this cwd. Any `@<name>`
+   * token matching one (anywhere in the message, not just the leading prefix)
+   * is treated as a subagent mention and skipped — never expanded as a file
+   * reference. Names are matched case-insensitively after stripping trailing
+   * punctuation, so `@reviewer.` is exempt while the path-like `@reviewer.md`
+   * is not.
+   */
+  subagentNames?: Iterable<string> | null;
   maxRefs?: number;
   maxFileBytes?: number;
   maxTotalBytes?: number;
@@ -112,8 +119,11 @@ export async function expandFileReferencesInPrompt(
     return { prompt: content, references: [] };
   }
 
+  const subagentNames = options.subagentNames
+    ? new Set([...options.subagentNames].map((name) => name.toLowerCase()))
+    : undefined;
   const parsed = parseFileReferences(content).filter((ref) =>
-    shouldConsiderReference(ref, content, options.leadingSubagentName),
+    shouldConsiderReference(ref, subagentNames),
   );
   if (parsed.length === 0) return { prompt: content, references: [] };
 
@@ -223,18 +233,14 @@ function readUnquoted(
 
 function shouldConsiderReference(
   ref: ParsedFileReference,
-  content: string,
-  leadingSubagentName: string | null | undefined,
+  subagentNames: ReadonlySet<string> | undefined,
 ): boolean {
-  const mentionValue = stripReferencePunctuation(ref.value);
-  if (
-    leadingSubagentName &&
-    mentionValue.toLowerCase() === leadingSubagentName.toLowerCase()
-  ) {
-    const trimmedStart = content.length - content.trimStart().length;
-    if (ref.start === trimmedStart) return false;
-  }
-  return true;
+  if (!subagentNames || subagentNames.size === 0) return true;
+  // A `@<name>` matching a configured subagent is an agent mention, not a file
+  // — skip it wherever it appears so mid-message mentions (e.g. "when done,
+  // have @reviewer check it") never surface a spurious "not found" notice.
+  const mentionValue = stripReferencePunctuation(ref.value).toLowerCase();
+  return !subagentNames.has(mentionValue);
 }
 
 type ResolvedReferenceTarget = {

--- a/agent/subagents/task-tool.ts
+++ b/agent/subagents/task-tool.ts
@@ -147,7 +147,12 @@ async function runSubagentTask(
   // the total-byte cap applies once. Skip the await entirely when there are no
   // refs so non-expanding delegations keep their original microtask timing.
   const expandedBody = hasTaskFileReferences(params)
-    ? (await expandFileReferencesInPrompt(taskBody, { cwd })).prompt
+    ? (
+        await expandFileReferencesInPrompt(taskBody, {
+          cwd,
+          subagentNames: registry.byName.keys(),
+        })
+      ).prompt
     : taskBody;
   const composedPrompt = composePrompt(sub, expandedBody);
   if (sub.surface === "tab") {


### PR DESCRIPTION
## Context

Follow-up to #296 (mid-message `@agent` mentions). Copilot's review of #296 flagged that the `@file`-reference expander only exempts a **leading** accepted subagent from being treated as a file reference (`leadingSubagentName` + a start-of-message position check in `shouldConsiderReference`). A mid-message mention like "when done, have `@reviewer` check it" was only spared mis-expansion by the *accident* that subagent names contain no `.`/`/` and therefore fail `isLikelyPathReference` (so they're silently ignored).

Now that mid-message mentions are a first-class, encouraged path, make the exemption **explicit and position-independent** rather than incidental.

## Change

- **`agent/file-references.ts`** — replace the single `leadingSubagentName` option with `subagentNames` (the configured subagent names for the cwd). `shouldConsiderReference` now skips any `@<name>` token matching one of those names **anywhere** in the message, case-insensitively after stripping trailing punctuation. A path-like `@reviewer.md` is still treated as a file reference (it doesn't match the bare name).
- **`agent/chat.ts`** — capture the tab's subagent registry once; pass its keys as `subagentNames` (and reuse it for the existing leading-mention hard-delegation check).
- **`agent/subagents/task-tool.ts`** — pass the resolved registry's names through when expanding a task body.

## Why this is safe

The previous behavior was already non-broken in practice (dotless names never look path-like), so this is a robustness/intent change, not a bug fix for an observed regression. It also future-proofs against any change to `isLikelyPathReference`.

## Tests

- New: a mid-message `@reviewer` alongside a real `@src/App.tsx` resolves only the file and emits **no** issue; a punctuated mid-message `@reviewer.` is exempt with no issue.
- Updated the existing leading-mention tests to the `subagentNames` option; `@reviewer.md` still resolves as a file.
- `vitest` (file-references + subagents + chat suites, 79 passed), `tsc -b --noEmit`, ESLint 0/0 green locally.