### PR TITLE
feat: add silent session tab title tool

### DIFF
--- a/agent/nativeSlash.ts
+++ b/agent/nativeSlash.ts
@@ -3,13 +3,10 @@ import { basename, extname, join } from "node:path";
 import type { AethonAgentState } from "./state";
 import type { DispatcherDeps, InboundMessage } from "./dispatcherTypes";
 import { emitGlobalReady } from "./dispatcherTypes";
-import {
-  normalizeSessionLabel,
-  readSessionMetadata,
-  writeSessionLabel,
-} from "./session-history";
-import { ensureTab, modelKey, tabSessionDir } from "./tab-lifecycle";
+import { normalizeSessionLabel } from "./session-history";
+import { ensureTab, modelKey } from "./tab-lifecycle";
 import { formatMemorySummary } from "./memory/tools";
+import { setSessionLabelForTab } from "./session-label";
 
 interface NativeContextUsage {
   tokens: number | null;
@@ -262,14 +259,7 @@ export async function handleNativeSlashCommand(
       }
       tab.session.setSessionName(nextName);
       try {
-        await writeSessionLabel(tabSessionDir(state, tabId), nextName);
-        const refreshed = await readSessionMetadata(tabSessionDir(state, tabId));
-        if (refreshed) {
-          const idx = state.discoveredTabs.findIndex((t) => t.tabId === tabId);
-          const entry = { tabId, ...refreshed };
-          if (idx >= 0) state.discoveredTabs[idx] = entry;
-          else state.discoveredTabs.push(entry);
-        }
+        await setSessionLabelForTab(state, deps, tabId, nextName);
       } catch {
         /* pi session name still succeeded; label replay is best effort */
       }

--- a/agent/session-history.test.ts
+++ b/agent/session-history.test.ts
@@ -12,6 +12,7 @@ import {
   readSessionTranscript,
   writeSessionLabel,
 } from "./session-history";
+import { SESSION_TITLE_TOOL_NAME } from "./silent-tools";
 
 const roots: string[] = [];
 
@@ -224,6 +225,47 @@ describe("parseSessionHistoryLines", () => {
             },
           ],
         },
+      },
+    ]);
+  });
+
+  it("does not restore silent session-title tool calls as visible cards", () => {
+    const restored = parseSessionHistoryLines([
+      JSON.stringify({
+        type: "message",
+        id: "assistant-tool",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "text", text: "I will take a look." },
+            {
+              type: "toolCall",
+              id: "call-title-1",
+              name: SESSION_TITLE_TOOL_NAME,
+              arguments: { title: "Prompt polish" },
+            },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: "message",
+        id: "result-tool",
+        message: {
+          role: "toolResult",
+          toolCallId: "call-title-1",
+          toolName: SESSION_TITLE_TOOL_NAME,
+          content: [{ type: "text", text: "ok" }],
+          isError: false,
+        },
+      }),
+    ]);
+
+    expect(restored).toEqual([
+      {
+        id: "assistant-tool",
+        entryId: "assistant-tool",
+        role: "agent",
+        text: "I will take a look.",
       },
     ]);
   });

--- a/agent/session-history/parse-pi.ts
+++ b/agent/session-history/parse-pi.ts
@@ -7,6 +7,7 @@
  */
 
 import { stripExpandedFileReferences } from "../file-references";
+import { isSilentTool } from "../silent-tools";
 import { summarizeToolArgs, toolCardPayload } from "../tool-card";
 import {
   MAX_RESTORED_MESSAGES,
@@ -152,6 +153,7 @@ export function parseSessionHistoryLines(
         typeof msg.toolName === "string" && msg.toolName.length > 0
           ? msg.toolName
           : "tool";
+      if (isSilentTool(toolName)) continue;
       const endedAt = parseMessageTime(record, msg);
       const result = {
         content: msg.content,
@@ -234,6 +236,7 @@ export function parseSessionHistoryLines(
         typeof toolCall.name === "string" && toolCall.name.length > 0
           ? toolCall.name
           : "tool";
+      if (isSilentTool(toolName)) continue;
       const args = "arguments" in toolCall ? toolCall.arguments : undefined;
       const argsSummary = summarizeToolArgs(toolName, args);
       const startedAt = parseMessageTime(record, msg);

--- a/agent/session-label.ts
+++ b/agent/session-label.ts
@@ -30,6 +30,7 @@ function upsertDiscoveredTab(
   const idx = state.discoveredTabs.findIndex((t) => t.tabId === tabId);
   if (idx >= 0) state.discoveredTabs[idx] = entry;
   else state.discoveredTabs.push(entry);
+  state.discoveredTabs.sort((a, b) => b.lastModified - a.lastModified);
   return entry;
 }
 

--- a/agent/session-label.ts
+++ b/agent/session-label.ts
@@ -1,0 +1,63 @@
+import type { AethonAgentState, DiscoveredTab } from "./state";
+import {
+  normalizeSessionLabel,
+  readSessionMetadata,
+  writeSessionLabel,
+} from "./session-history";
+import { tabSessionDir } from "./tab-lifecycle/utils";
+
+interface SessionLabelDeps {
+  send: (obj: Record<string, unknown>) => void;
+}
+
+export interface SetSessionLabelOptions {
+  requireNonEmpty?: boolean;
+  syncPiSessionName?: (label: string) => void;
+}
+
+export interface SetSessionLabelResult {
+  label: string;
+  session?: DiscoveredTab;
+}
+
+function upsertDiscoveredTab(
+  state: AethonAgentState,
+  tabId: string,
+  refreshed: Omit<DiscoveredTab, "tabId"> | null,
+): DiscoveredTab | undefined {
+  if (!refreshed) return undefined;
+  const entry = { tabId, ...refreshed };
+  const idx = state.discoveredTabs.findIndex((t) => t.tabId === tabId);
+  if (idx >= 0) state.discoveredTabs[idx] = entry;
+  else state.discoveredTabs.push(entry);
+  return entry;
+}
+
+export async function setSessionLabelForTab(
+  state: AethonAgentState,
+  deps: SessionLabelDeps,
+  tabId: string,
+  rawLabel: string,
+  options: SetSessionLabelOptions = {},
+): Promise<SetSessionLabelResult> {
+  const label = normalizeSessionLabel(rawLabel);
+  if (options.requireNonEmpty === true && !label) {
+    throw new Error("setSessionTabTitle: title required");
+  }
+  await writeSessionLabel(tabSessionDir(state, tabId), label);
+  if (label && options.syncPiSessionName) {
+    options.syncPiSessionName(label);
+  }
+  const session = upsertDiscoveredTab(
+    state,
+    tabId,
+    await readSessionMetadata(tabSessionDir(state, tabId)),
+  );
+  deps.send({
+    type: "session_label_changed",
+    tabId,
+    label,
+    ...(session ? { session } : {}),
+  });
+  return { label, ...(session ? { session } : {}) };
+}

--- a/agent/session-title-tool.test.ts
+++ b/agent/session-title-tool.test.ts
@@ -125,6 +125,23 @@ describe("buildSessionTitleTools", () => {
     });
   });
 
+  it("keeps discovered tabs sorted after metadata refresh", async () => {
+    const { state, deps } = await makeFixture();
+    state.discoveredTabs = [
+      { tabId: "tab-2", lastModified: 1, cwd: "/repo/newer" },
+      { tabId: "tab-1", lastModified: 0, cwd: "/repo/old" },
+    ];
+
+    await getTool(state, deps).execute("call-1", {
+      title: "Prompt polish",
+    });
+
+    expect(state.discoveredTabs.map((tab) => tab.tabId)).toEqual([
+      "tab-1",
+      "tab-2",
+    ]);
+  });
+
   it("rejects an empty title", async () => {
     const { state, deps } = await makeFixture();
 

--- a/agent/session-title-tool.test.ts
+++ b/agent/session-title-tool.test.ts
@@ -1,0 +1,135 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  AethonAgentState,
+  type AethonAgentStateOptions,
+  type TabRecord,
+} from "./state";
+import { buildSessionTitleTools } from "./session-title-tool";
+import { tabSessionDir } from "./tab-lifecycle";
+
+const roots: string[] = [];
+
+const baseOpts: AethonAgentStateOptions = {
+  userDir: "/tmp/aethon-test",
+  stateFile: "/tmp/aethon-test/state.json",
+  sessionsDir: "/tmp/aethon-test/sessions",
+  docsDir: undefined,
+  projectRoot: undefined,
+  releaseMode: false,
+  bootLayoutFile: undefined,
+  layoutSlotsFile: undefined,
+  statePayloadWarnBytes: 64 * 1024,
+  statePayloadHardBytes: 512 * 1024,
+  statePayloadWarnKb: 64,
+  statePayloadHardKb: 512,
+};
+
+async function makeFixture() {
+  const root = await mkdtemp(join(tmpdir(), "aethon-session-title-tool-"));
+  roots.push(root);
+  const state = new AethonAgentState({
+    ...baseOpts,
+    userDir: root,
+    stateFile: join(root, "state.json"),
+    sessionsDir: join(root, "sessions"),
+  });
+  const sent: Record<string, unknown>[] = [];
+  const setSessionName = vi.fn();
+  state.tabs.set("tab-1", {
+    id: "tab-1",
+    session: { setSessionName } as unknown as TabRecord["session"],
+    toolArgsCache: new Map(),
+    promptInFlight: false,
+    agentEndFired: false,
+    queuedCount: 0,
+    toolCardSeq: 0,
+    responseMessageSeq: 0,
+  });
+  const sessionDir = tabSessionDir(state, "tab-1");
+  await mkdir(sessionDir, { recursive: true });
+  await writeFile(
+    join(sessionDir, "session.jsonl"),
+    `${JSON.stringify({ type: "session", id: "s", cwd: "/repo/a" })}\n`,
+    "utf8",
+  );
+  return {
+    state,
+    sent,
+    setSessionName,
+    deps: { send: (m: Record<string, unknown>) => sent.push(m) },
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+  );
+});
+
+function getTool(state: AethonAgentState, deps: { send: (m: Record<string, unknown>) => void }) {
+  const tool = buildSessionTitleTools(state, deps, "tab-1").find(
+    (t) => t.name === "setSessionTabTitle",
+  );
+  if (!tool) throw new Error("setSessionTabTitle not registered");
+  return tool;
+}
+
+describe("buildSessionTitleTools", () => {
+  it("registers the silent session-title tool", async () => {
+    const { state, deps } = await makeFixture();
+
+    expect(buildSessionTitleTools(state, deps, "tab-1").map((t) => t.name)).toEqual([
+      "setSessionTabTitle",
+    ]);
+  });
+
+  it("sets the Aethon label, pi session name, discovered metadata, and bridge event", async () => {
+    const { state, deps, sent, setSessionName } = await makeFixture();
+
+    const result = await getTool(state, deps).execute("call-1", {
+      title: "  Refactor auth flow  ",
+    });
+
+    expect(setSessionName).toHaveBeenCalledWith("Refactor auth flow");
+    await expect(
+      readFile(join(tabSessionDir(state, "tab-1"), "label.txt"), "utf8"),
+    ).resolves.toBe("Refactor auth flow\n");
+    expect(state.discoveredTabs).toHaveLength(1);
+    expect(state.discoveredTabs[0]).toMatchObject({
+      tabId: "tab-1",
+      cwd: "/repo/a",
+      customLabel: "Refactor auth flow",
+    });
+    expect(sent).toContainEqual(
+      expect.objectContaining({
+        type: "session_label_changed",
+        tabId: "tab-1",
+        label: "Refactor auth flow",
+        session: expect.objectContaining({
+          tabId: "tab-1",
+          customLabel: "Refactor auth flow",
+        }),
+      }),
+    );
+    expect(result).toMatchObject({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({ ok: true, title: "Refactor auth flow" }, null, 2),
+        },
+      ],
+      details: { ok: true, title: "Refactor auth flow" },
+    });
+  });
+
+  it("rejects an empty title", async () => {
+    const { state, deps } = await makeFixture();
+
+    await expect(
+      getTool(state, deps).execute("call-1", { title: "   " }),
+    ).rejects.toThrow("setSessionTabTitle: title required");
+  });
+});

--- a/agent/session-title-tool.ts
+++ b/agent/session-title-tool.ts
@@ -1,0 +1,61 @@
+import type { ToolDefinition } from "@mariozechner/pi-coding-agent";
+import { defineTool } from "@mariozechner/pi-coding-agent";
+import { Type, type Static } from "typebox";
+import type { AethonAgentState } from "./state";
+import { setSessionLabelForTab } from "./session-label";
+import { SESSION_TITLE_TOOL_NAME } from "./silent-tools";
+
+interface SessionTitleDeps {
+  send: (obj: Record<string, unknown>) => void;
+}
+
+const SetSessionTabTitleParams = Type.Object({
+  title: Type.String({
+    description:
+      "Brief descriptive title for this session tab, usually 2-5 words.",
+  }),
+});
+
+type SetSessionTabTitleParamsT = Static<typeof SetSessionTabTitleParams>;
+
+function asJson(value: unknown): {
+  content: { type: "text"; text: string }[];
+  details: unknown;
+} {
+  return {
+    content: [{ type: "text", text: JSON.stringify(value ?? null, null, 2) }],
+    details: value ?? null,
+  };
+}
+
+export function buildSessionTitleTools(
+  state: AethonAgentState,
+  deps: SessionTitleDeps,
+  tabId: string,
+): ToolDefinition[] {
+  const setTitleTool = defineTool({
+    name: SESSION_TITLE_TOOL_NAME,
+    label: "Set session tab title",
+    description:
+      "Silently rename the current Aethon session tab. Use this as the first step for a new user request; choose a short, descriptive title based on the prompt.",
+    promptSnippet:
+      "setSessionTabTitle: silently set the current Aethon tab title",
+    parameters: SetSessionTabTitleParams,
+    async execute(_callId: string, params: SetSessionTabTitleParamsT) {
+      const tab = state.tabs.get(tabId);
+      const result = await setSessionLabelForTab(
+        state,
+        deps,
+        tabId,
+        params.title,
+        {
+          requireNonEmpty: true,
+          syncPiSessionName: (label) => tab?.session.setSessionName(label),
+        },
+      );
+      return asJson({ ok: true, title: result.label });
+    },
+  }) as ToolDefinition;
+
+  return [setTitleTool];
+}

--- a/agent/silent-tools.ts
+++ b/agent/silent-tools.ts
@@ -1,0 +1,7 @@
+export const SESSION_TITLE_TOOL_NAME = "setSessionTabTitle";
+
+const SILENT_TOOL_NAMES = new Set<string>([SESSION_TITLE_TOOL_NAME]);
+
+export function isSilentTool(toolName: string): boolean {
+  return SILENT_TOOL_NAMES.has(toolName);
+}

--- a/agent/system-prompt.test.ts
+++ b/agent/system-prompt.test.ts
@@ -4,6 +4,7 @@ import {
   buildSubagentsSection,
   type RuntimeSnapshot,
 } from "./system-prompt";
+import { DEFAULT_AETHON_PROMPT } from "./system-prompt/prompt-template";
 
 function snapshot(overrides: Partial<RuntimeSnapshot> = {}): RuntimeSnapshot {
   return {
@@ -120,6 +121,14 @@ describe("buildRuntimeSection failedExtensions", () => {
     );
     expect(out).toContain("cwd `/repo/a`");
     expect(out).toContain("`t2` — model `(none)`, 0 messages");
+  });
+});
+
+describe("DEFAULT_AETHON_PROMPT", () => {
+  it("instructs the agent to title the tab and narrate progress", () => {
+    expect(DEFAULT_AETHON_PROMPT).toContain("setSessionTabTitle");
+    expect(DEFAULT_AETHON_PROMPT).toContain("brief and descriptive");
+    expect(DEFAULT_AETHON_PROMPT).toContain("inform the user");
   });
 });
 

--- a/agent/system-prompt/prompt-template.ts
+++ b/agent/system-prompt/prompt-template.ts
@@ -9,6 +9,18 @@ React UI built from A2UI components (text, heading, paragraph, card, button,
 container, code, image, icon, form controls, lists, and tables). Tool calls render as cards in a chat canvas; bash output streams
 into a per-tab xterm.js terminal panel.
 
+## Working style in Aethon
+
+At the start of each new user request, first call \`setSessionTabTitle\` with a
+brief and descriptive title for the current session tab. Choose 2-5 words based
+on the prompt. This is a silent operation: do not mention that you renamed the
+tab unless the user asks.
+
+Always inform the user as to what you are doing as you do it. Send short,
+useful progress updates before meaningful exploration, file edits, long-running
+commands, or waits, and keep the user oriented when you learn something that
+changes the plan.
+
 ## Where to look first
 
 The authoritative reference for the runtime API and A2UI components ships

--- a/agent/tab-lifecycle.test.ts
+++ b/agent/tab-lifecycle.test.ts
@@ -4,6 +4,7 @@ import {
   type AethonAgentStateOptions,
   type TabRecord,
 } from "./state";
+import { SESSION_TITLE_TOOL_NAME } from "./silent-tools";
 import {
   buildPickerModels,
   cancelRunningToolCards,
@@ -862,6 +863,37 @@ describe("handleSessionEvent", () => {
     expect(f.sent.find((m) => m.type === "terminal_output")).toMatchObject({
       content: "\r\n$ ls\r\n",
     });
+  });
+
+  it("keeps session-title tool calls silent in the live transcript", () => {
+    const f = makeFixture();
+    const rec = fakeRec();
+    handleSessionEvent(f.state, f.deps, rec, "tab-1", {
+      type: "message_update",
+      assistantMessageEvent: { type: "text_delta", delta: "Starting" },
+    });
+    handleSessionEvent(f.state, f.deps, rec, "tab-1", {
+      type: "tool_execution_start",
+      toolCallId: "c-title",
+      toolName: SESSION_TITLE_TOOL_NAME,
+      args: { title: "Prompt polish" },
+    });
+    handleSessionEvent(f.state, f.deps, rec, "tab-1", {
+      type: "tool_execution_end",
+      toolCallId: "c-title",
+      toolName: SESSION_TITLE_TOOL_NAME,
+      result: { content: [{ type: "text", text: "ok" }] },
+    });
+    handleSessionEvent(f.state, f.deps, rec, "tab-1", {
+      type: "message_update",
+      assistantMessageEvent: { type: "text_delta", delta: " now." },
+    });
+
+    expect(f.sent.some((m) => m.type === "a2ui")).toBe(false);
+    expect(f.sent.some((m) => m.type === "terminal_output")).toBe(false);
+    const deltas = f.sent.filter((m) => m.type === "response_delta");
+    expect(deltas).toHaveLength(2);
+    expect(deltas[1].messageId).toBe(deltas[0].messageId);
   });
 
   it("tool_execution_update streams task partials into the existing card", () => {

--- a/agent/tab-lifecycle/events.ts
+++ b/agent/tab-lifecycle/events.ts
@@ -40,6 +40,7 @@ import { cancelAethonRetry, scheduleAethonRetry } from "./retry";
 import type { TabLifecycleDeps } from "./utils";
 import { modelKey } from "./utils";
 import { supportsCodexFastMode } from "../codex-fast-mode";
+import { isSilentTool } from "../silent-tools";
 import {
   addLiveContextUsageEstimate,
   clearLiveContextUsageEstimate,
@@ -320,6 +321,10 @@ export function handleSessionEvent(
         toolName: string;
         args: unknown;
       };
+      if (isSilentTool(ev.toolName)) {
+        rec.toolArgsCache.delete(ev.toolCallId);
+        return;
+      }
       const summary = summarizeToolArgs(ev.toolName, ev.args);
       const startedAt = Date.now();
       const uiId = `tool-${++rec.toolCardSeq}-${ev.toolCallId}`;
@@ -359,6 +364,9 @@ export function handleSessionEvent(
         args: unknown;
         partialResult: unknown;
       };
+      if (isSilentTool(ev.toolName)) {
+        return;
+      }
       if (ev.toolName === "bash") {
         let cached = rec.toolArgsCache.get(ev.toolCallId);
         if (!cached) {
@@ -415,6 +423,10 @@ export function handleSessionEvent(
         result: unknown;
         isError?: boolean;
       };
+      if (isSilentTool(ev.toolName)) {
+        rec.toolArgsCache.delete(ev.toolCallId);
+        return;
+      }
       const cached = rec.toolArgsCache.get(ev.toolCallId);
       const uiId = cached?.uiId ?? `tool-${++rec.toolCardSeq}-${ev.toolCallId}`;
       const payload = toolCardPayload({

--- a/agent/tab-lifecycle/lifecycle.ts
+++ b/agent/tab-lifecycle/lifecycle.ts
@@ -22,6 +22,7 @@ import { buildA2uiTools } from "../a2ui-tools";
 import { createAethonBashToolDefinition } from "../bash-tool";
 import { buildDashboardTools } from "../dashboard-tools";
 import { buildEditorTools } from "../editor-tools";
+import { buildSessionTitleTools } from "../session-title-tool";
 import { buildSubagentTaskTool } from "../subagents/task-tool";
 import { buildMemoryTools } from "../memory/tools";
 import {
@@ -175,6 +176,7 @@ export async function ensureTab(
     resourceLoader: state.resourceLoader,
     customTools: [
       devshellBashTool,
+      ...buildSessionTitleTools(state, deps, tabId),
       ...buildA2uiTools(),
       ...buildShellTools(),
       ...buildDashboardTools(),

--- a/agent/tabs.ts
+++ b/agent/tabs.ts
@@ -9,14 +9,13 @@ import {
   appendLocalChatMessage,
   hasA2ui,
   parseChatAttachments,
-  readSessionMetadata,
   readSessionTranscript,
-  writeSessionLabel,
 } from "./session-history";
 import { ensureTab, tabSessionDir } from "./tab-lifecycle";
 import { unloadProjectExtensions } from "./projectLifecycle";
 import { modelRegistryForModelId } from "./auth-profiles";
 import { clearPendingContextUsageEmit } from "./context-usage";
+import { setSessionLabelForTab } from "./session-label";
 
 export async function handleTabOpen(
   state: AethonAgentState,
@@ -200,23 +199,13 @@ export async function handleSetSessionLabel(
   }
   const label = typeof labelField === "string" ? labelField : "";
   try {
-    await writeSessionLabel(tabSessionDir(state, tabId), label);
+    await setSessionLabelForTab(state, deps, tabId, label);
   } catch (err) {
     deps.send({
       type: "error",
       message: `set_session_label: ${(err as Error).message}`,
     });
     return;
-  }
-  // Refresh the discovered-tabs cache so the next emitReady (which the
-  // frontend triggers by sending `report` after this command finishes)
-  // reflects the new label. Cheap to re-read just the one entry.
-  const refreshed = await readSessionMetadata(tabSessionDir(state, tabId));
-  if (refreshed) {
-    const idx = state.discoveredTabs.findIndex((t) => t.tabId === tabId);
-    const entry = { tabId, ...refreshed };
-    if (idx >= 0) state.discoveredTabs[idx] = entry;
-    else state.discoveredTabs.push(entry);
   }
   await emitGlobalReady(state, deps);
 }

--- a/src/eventRoutes/sessionRename.ts
+++ b/src/eventRoutes/sessionRename.ts
@@ -27,7 +27,7 @@ export function renameSessionLabel(
  *  open session. Empty input restores the auto-derived sequential
  *  "Tab N" label using the tab's existing index in the array. */
 export function applyOptimisticTabLabel(
-  ctx: EventRouteContext,
+  ctx: Pick<EventRouteContext, "setState">,
   tabId: string,
   label: string,
 ): void {

--- a/src/hooks/bridgeMessageHandlers/index.ts
+++ b/src/hooks/bridgeMessageHandlers/index.ts
@@ -48,6 +48,7 @@ import { handleResponseDelta } from "./responseDelta";
 import { handleResponseEnd } from "./responseEnd";
 import { handleSessionForked } from "./sessionForked";
 import { handleSessionHistory } from "./sessionHistory";
+import { handleSessionLabelChanged } from "./sessionLabelChanged";
 import { handleSessionRolledBack } from "./sessionRolledBack";
 import { handleShellQuery } from "./shellQuery";
 import { handleDashboardQuery } from "./dashboardQuery";
@@ -101,6 +102,7 @@ export const bridgeMessageHandlers: Readonly<
   response_end: handleResponseEnd,
   session_forked: handleSessionForked,
   session_history: handleSessionHistory,
+  session_label_changed: handleSessionLabelChanged,
   session_rolled_back: handleSessionRolledBack,
   shell_query: handleShellQuery,
   dashboard_query: handleDashboardQuery,

--- a/src/hooks/bridgeMessageHandlers/sessionLabelChanged.test.ts
+++ b/src/hooks/bridgeMessageHandlers/sessionLabelChanged.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { handleSessionLabelChanged } from "./sessionLabelChanged";
+import { buildHandlerFixture } from "./testFixtures";
+import { makeEmptyTab } from "../../types/tab";
+
+describe("handleSessionLabelChanged", () => {
+  it("updates the matching open tab label immediately", () => {
+    const { ctx, applySetState } = buildHandlerFixture({
+      state: {
+        tabs: [
+          makeEmptyTab("tab-1", "Tab 1"),
+          makeEmptyTab("tab-2", "Tab 2"),
+        ],
+      },
+    });
+
+    handleSessionLabelChanged(
+      {
+        type: "session_label_changed",
+        tabId: "tab-1",
+        label: "Prompt polish",
+      },
+      ctx,
+    );
+
+    const next = applySetState();
+    expect((next.tabs as { id: string; label: string }[])[0]).toMatchObject({
+      id: "tab-1",
+      label: "Prompt polish",
+    });
+    expect((next.tabs as { id: string; label: string }[])[1]).toMatchObject({
+      id: "tab-2",
+      label: "Tab 2",
+    });
+  });
+
+  it("updates discovered-session metadata when the bridge includes it", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    ctx.allDiscoveredSessionsRef.current = [
+      { tabId: "tab-1", lastModified: 1, customLabel: "Old" },
+    ];
+
+    handleSessionLabelChanged(
+      {
+        type: "session_label_changed",
+        tabId: "tab-1",
+        label: "Prompt polish",
+        session: {
+          tabId: "tab-1",
+          lastModified: 42,
+          cwd: "/repo/a",
+          customLabel: "Prompt polish",
+        },
+      },
+      ctx,
+    );
+
+    expect(ctx.allDiscoveredSessionsRef.current).toEqual([
+      {
+        tabId: "tab-1",
+        lastModified: 42,
+        cwd: "/repo/a",
+        customLabel: "Prompt polish",
+      },
+    ]);
+    expect(mocks.syncRecentSessionsToState).toHaveBeenCalledOnce();
+  });
+});

--- a/src/hooks/bridgeMessageHandlers/sessionLabelChanged.test.ts
+++ b/src/hooks/bridgeMessageHandlers/sessionLabelChanged.test.ts
@@ -65,4 +65,31 @@ describe("handleSessionLabelChanged", () => {
     ]);
     expect(mocks.syncRecentSessionsToState).toHaveBeenCalledOnce();
   });
+
+  it("keeps discovered-session metadata sorted by lastModified", () => {
+    const { ctx } = buildHandlerFixture();
+    ctx.allDiscoveredSessionsRef.current = [
+      { tabId: "tab-2", lastModified: 2, customLabel: "Newer" },
+      { tabId: "tab-1", lastModified: 1, customLabel: "Old" },
+    ];
+
+    handleSessionLabelChanged(
+      {
+        type: "session_label_changed",
+        tabId: "tab-1",
+        label: "Prompt polish",
+        session: {
+          tabId: "tab-1",
+          lastModified: 42,
+          customLabel: "Prompt polish",
+        },
+      },
+      ctx,
+    );
+
+    expect(ctx.allDiscoveredSessionsRef.current.map((s) => s.tabId)).toEqual([
+      "tab-1",
+      "tab-2",
+    ]);
+  });
 });

--- a/src/hooks/bridgeMessageHandlers/sessionLabelChanged.ts
+++ b/src/hooks/bridgeMessageHandlers/sessionLabelChanged.ts
@@ -34,10 +34,12 @@ function upsertDiscoveredSession(
   session: DiscoveredSession,
 ): DiscoveredSession[] {
   const idx = list.findIndex((s) => s.tabId === session.tabId);
-  if (idx < 0) return [...list, session];
+  if (idx < 0) {
+    return [...list, session].sort((a, b) => b.lastModified - a.lastModified);
+  }
   const next = [...list];
   next[idx] = session;
-  return next;
+  return next.sort((a, b) => b.lastModified - a.lastModified);
 }
 
 export const handleSessionLabelChanged: BridgeMessageHandler = (

--- a/src/hooks/bridgeMessageHandlers/sessionLabelChanged.ts
+++ b/src/hooks/bridgeMessageHandlers/sessionLabelChanged.ts
@@ -1,0 +1,59 @@
+import { applyOptimisticTabLabel } from "../../eventRoutes/sessionRename";
+import type {
+  BridgeMessage,
+  BridgeMessageHandler,
+  DiscoveredSession,
+} from "./types";
+
+function discoveredSessionFromMessage(
+  value: unknown,
+): DiscoveredSession | null {
+  if (!value || typeof value !== "object") return null;
+  const record = value as Record<string, unknown>;
+  if (
+    typeof record.tabId !== "string" ||
+    typeof record.lastModified !== "number"
+  ) {
+    return null;
+  }
+  return {
+    tabId: record.tabId,
+    lastModified: record.lastModified,
+    ...(typeof record.cwd === "string" ? { cwd: record.cwd } : {}),
+    ...(typeof record.firstUserMessage === "string"
+      ? { firstUserMessage: record.firstUserMessage }
+      : {}),
+    ...(typeof record.customLabel === "string"
+      ? { customLabel: record.customLabel }
+      : {}),
+  };
+}
+
+function upsertDiscoveredSession(
+  list: DiscoveredSession[],
+  session: DiscoveredSession,
+): DiscoveredSession[] {
+  const idx = list.findIndex((s) => s.tabId === session.tabId);
+  if (idx < 0) return [...list, session];
+  const next = [...list];
+  next[idx] = session;
+  return next;
+}
+
+export const handleSessionLabelChanged: BridgeMessageHandler = (
+  message: BridgeMessage,
+  ctx,
+) => {
+  const tabId = typeof message.tabId === "string" ? message.tabId : "";
+  if (!tabId) return;
+  const label = typeof message.label === "string" ? message.label : "";
+  applyOptimisticTabLabel(ctx, tabId, label);
+
+  const session = discoveredSessionFromMessage(message.session);
+  if (!session) return;
+  ctx.allDiscoveredSessionsRef.current = upsertDiscoveredSession(
+    ctx.allDiscoveredSessionsRef.current,
+    session,
+  );
+  ctx.syncRecentSessionsToState();
+};


### PR DESCRIPTION
## Summary

This PR teaches Aethon agents to quietly name each session tab at the start of a user request and updates the system prompt so agents keep users oriented while work is happening.

## What changed

- Added a silent `setSessionTabTitle` custom tool that accepts a short title and persists it as the tab/session label.
- Updated the system prompt with explicit working-style guidance: set a brief descriptive tab title first, do it silently, and provide concise progress updates during meaningful work.
- Added shared session-label persistence logic so the new tool, `/name`, and explicit session-label events all refresh discovered-session metadata consistently.
- Filtered silent tools out of live tool-card rendering, terminal echoes, restored session history, and response-segment bookkeeping so the rename operation stays invisible in chat.
- Added a frontend `session_label_changed` bridge handler so live tabs and recent-session metadata update immediately after an agent-driven rename.

## Why

The user should get useful tab names without seeing implementation noise. The agent needs a tiny, reliable way to name the current session based on the prompt, and the UI should reflect that title immediately while preserving clean chat history.

## Validation

- `bunx vitest run agent/session-title-tool.test.ts agent/tab-lifecycle.test.ts agent/session-history.test.ts agent/system-prompt.test.ts src/hooks/bridgeMessageHandlers/sessionLabelChanged.test.ts`
- `bun run typecheck`
- `bunx vitest run`
- `bun run lint`
- `git diff --check`