### PR TITLE
feat(subagents): add parallel background delegation

### DIFF
--- a/agent/aethon-api-dashboard.test.ts
+++ b/agent/aethon-api-dashboard.test.ts
@@ -51,6 +51,8 @@ describe("buildTasksApi", () => {
       newWorkspace: true,
       model: "openai/gpt-5",
       bridgePrompt: "hidden context",
+      activate: false,
+      label: "Background task",
     });
     const msg = sent.at(-1)!;
     expect(msg).toMatchObject({
@@ -62,6 +64,8 @@ describe("buildTasksApi", () => {
         newWorkspace: true,
         model: "openai/gpt-5",
         bridgePrompt: "hidden context",
+        activate: false,
+        label: "Background task",
       },
     });
     // branch/baseBranch were omitted, so they must not appear in args.

--- a/agent/aethon-api-dashboard.ts
+++ b/agent/aethon-api-dashboard.ts
@@ -83,6 +83,12 @@ export function buildTasksApi(
           ...(typeof input.bridgePrompt === "string" && input.bridgePrompt
             ? { bridgePrompt: input.bridgePrompt }
             : {}),
+          ...(typeof input.activate === "boolean"
+            ? { activate: input.activate }
+            : {}),
+          ...(typeof input.label === "string" && input.label
+            ? { label: input.label }
+            : {}),
         },
         // Workspace-create + tab-open + send can take several seconds on a
         // large repo. 30s is the same ceiling as the shell-write ack

--- a/agent/aethon-api.ts
+++ b/agent/aethon-api.ts
@@ -114,6 +114,10 @@ export interface TasksApi {
     model?: string;
     /** Optional hidden bridge prompt; `prompt` remains the visible tab text. */
     bridgePrompt?: string;
+    /** Defaults true. False creates the tab without switching focus. */
+    activate?: boolean;
+    /** Optional label for the launched tab. */
+    label?: string;
   }): Promise<MutationResult>;
 }
 

--- a/agent/chat.ts
+++ b/agent/chat.ts
@@ -14,7 +14,10 @@ import {
   refreshAuthServicesForTab,
   refreshTabSessionModelFromAuthServices,
 } from "./auth-profiles";
-import { detectSubagentMention } from "./subagents/steer";
+import {
+  detectBackgroundSubagentIntent,
+  detectLeadingSubagentMentions,
+} from "./subagents/steer";
 import { getSubagentsForCwd } from "./subagents";
 import { emitContextUsage } from "./context-usage";
 import { supportsCodexFastMode } from "./codex-fast-mode";
@@ -50,11 +53,16 @@ export async function handleChat(
   const tabCwdForMention =
     cwdOverride ?? state.tabProjectCwds.get(tabId) ?? state.currentProjectCwd;
   const tabSubagents = getSubagentsForCwd(state, tabCwdForMention).byName;
-  const mention = detectSubagentMention(msg.content);
-  const explicitSubagent =
-    mention && tabSubagents.has(mention) ? mention : null;
-  if (explicitSubagent) {
-    state.pendingExplicitSubagent.set(tabId, explicitSubagent);
+  const mentions = detectLeadingSubagentMentions(msg.content).filter((name) =>
+    tabSubagents.has(name),
+  );
+  if (mentions.length > 0) {
+    state.pendingExplicitSubagent.set(tabId, {
+      names: [...new Set(mentions)],
+      surface: detectBackgroundSubagentIntent(msg.content)
+        ? "background"
+        : "inline",
+    });
   }
   const requestedModel = parseModelAndThinking(
     typeof msg.model === "string" && msg.model.length > 0
@@ -117,7 +125,7 @@ export async function handleChat(
     }
     content = expanded.prompt;
   } catch (err) {
-    if (explicitSubagent) state.pendingExplicitSubagent.delete(tabId);
+    if (mentions.length > 0) state.pendingExplicitSubagent.delete(tabId);
     const message =
       err instanceof FileReferenceError
         ? err.issues.join("\n")

--- a/agent/dashboard-tools.test.ts
+++ b/agent/dashboard-tools.test.ts
@@ -70,6 +70,8 @@ describe("startTask tool", () => {
       baseBranch: "main",
       model: "openai/gpt-5",
       bridgePrompt: "hidden context",
+      activate: false,
+      label: "Background task",
     });
     expect(fakeTasks.start).toHaveBeenCalledWith({
       projectPath: "/p",
@@ -79,6 +81,8 @@ describe("startTask tool", () => {
       baseBranch: "main",
       model: "openai/gpt-5",
       bridgePrompt: "hidden context",
+      activate: false,
+      label: "Background task",
     });
   });
 

--- a/agent/dashboard-tools.ts
+++ b/agent/dashboard-tools.ts
@@ -26,6 +26,8 @@ interface TasksApi {
     baseBranch?: string;
     model?: string;
     bridgePrompt?: string;
+    activate?: boolean;
+    label?: string;
   }): Promise<{ ok: boolean; error?: string; data?: unknown }>;
 }
 
@@ -95,6 +97,17 @@ const StartTaskParams = Type.Object({
     Type.String({
       description:
         "Optional hidden bridge prompt to send to the launched tab; prompt remains the visible user text.",
+    }),
+  ),
+  activate: Type.Optional(
+    Type.Boolean({
+      description:
+        "Defaults true. Set false to create the task tab without switching the visible project/workspace or focusing it.",
+    }),
+  ),
+  label: Type.Optional(
+    Type.String({
+      description: "Optional label for the launched task tab.",
     }),
   ),
 });
@@ -169,6 +182,10 @@ export function buildDashboardTools(): ToolDefinition[] {
         ...(typeof params.bridgePrompt === "string"
           ? { bridgePrompt: params.bridgePrompt }
           : {}),
+        ...(typeof params.activate === "boolean"
+          ? { activate: params.activate }
+          : {}),
+        ...(typeof params.label === "string" ? { label: params.label } : {}),
       });
       if (!r.ok) fail(r.error ?? "unknown");
       return {

--- a/agent/main.ts
+++ b/agent/main.ts
@@ -264,9 +264,13 @@ async function main(): Promise<void> {
       // (clearing it prevents the subagent's own turn from re-triggering it).
       if (tabId) {
         const explicit = state.pendingExplicitSubagent.get(tabId);
-        if (explicit && subagents.has(explicit)) {
+        const names =
+          explicit?.names.filter((name) => subagents.has(name)) ?? [];
+        if (explicit && names.length > 0) {
           state.pendingExplicitSubagent.delete(tabId);
-          systemPrompt += `\n\n${buildExplicitSubagentSteer(explicit)}`;
+          systemPrompt += `\n\n${buildExplicitSubagentSteer(names, {
+            surface: explicit.surface,
+          })}`;
         } else if (explicit) {
           state.pendingExplicitSubagent.delete(tabId);
         }

--- a/agent/state.ts
+++ b/agent/state.ts
@@ -424,12 +424,15 @@ export class AethonAgentState {
    *  when the UI edits a definition. Keying by cwd keeps subagents correct when
    *  tabs on different projects are open simultaneously. */
   readonly subagentsByCwd = new Map<string, LoadSubagentsResult>();
-  /** One-shot per-tab steer: when the user opens a message with `@<name>`
-   *  matching a known subagent, the tabId → name is recorded here and the
+  /** One-shot per-tab steer: when the user opens a message with leading
+   *  `@<name>` mentions matching known subagents, the tabId → invocation is recorded here and the
    *  `before_agent_start` hook consumes (and clears) it to strongly steer the
    *  model to delegate. One-shot + clear prevents the subagent's own turn from
    *  re-triggering delegation. */
-  readonly pendingExplicitSubagent = new Map<string, string>();
+  readonly pendingExplicitSubagent = new Map<
+    string,
+    { names: string[]; surface: "inline" | "background" }
+  >();
   /** Persisted per-tab session directories discovered at boot. Shipped
    *  in `ready` so the frontend can offer "Recent sessions". */
   discoveredTabs: DiscoveredTab[] = [];

--- a/agent/subagents/index.ts
+++ b/agent/subagents/index.ts
@@ -19,7 +19,12 @@ export {
   refreshSubagents,
   userAgentsDir,
 } from "./loader";
-export { buildSubagentTaskTool } from "./task-tool";
+export { buildSubagentTaskBatchTool, buildSubagentTaskTool } from "./task-tool";
 export type { SubagentTaskDeps } from "./task-tool";
-export { buildExplicitSubagentSteer, detectSubagentMention } from "./steer";
+export {
+  buildExplicitSubagentSteer,
+  detectBackgroundSubagentIntent,
+  detectLeadingSubagentMentions,
+  detectSubagentMention,
+} from "./steer";
 export { handleSubagentsChanged } from "./changed";

--- a/agent/subagents/steer.test.ts
+++ b/agent/subagents/steer.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { buildExplicitSubagentSteer, detectSubagentMention } from "./steer";
+import {
+  buildExplicitSubagentSteer,
+  detectBackgroundSubagentIntent,
+  detectLeadingSubagentMentions,
+  detectSubagentMention,
+} from "./steer";
 
 describe("detectSubagentMention", () => {
   it("detects a leading @name", () => {
@@ -28,11 +33,65 @@ describe("detectSubagentMention", () => {
   });
 });
 
+describe("detectLeadingSubagentMentions", () => {
+  it("detects multiple leading @name mentions joined by words or punctuation", () => {
+    expect(
+      detectLeadingSubagentMentions("@kimi and @glm-5-2 peer review"),
+    ).toEqual(["kimi", "glm-5-2"]);
+    expect(
+      detectLeadingSubagentMentions(" @Reviewer, @Planner; @coder go"),
+    ).toEqual(["reviewer", "planner", "coder"]);
+  });
+
+  it("keeps non-leading mentions out of whole-prompt delegation", () => {
+    expect(
+      detectLeadingSubagentMentions("implement it, then have @reviewer check"),
+    ).toEqual([]);
+  });
+
+  it("does not treat path-like suffixes as subagent chains", () => {
+    expect(detectLeadingSubagentMentions("@reviewer.md please")).toEqual([]);
+    expect(detectLeadingSubagentMentions("@reviewer/check this")).toEqual([]);
+  });
+});
+
+describe("detectBackgroundSubagentIntent", () => {
+  it("recognizes async/background wording", () => {
+    expect(detectBackgroundSubagentIntent("@kimi async review")).toBe(true);
+    expect(detectBackgroundSubagentIntent("@kimi run in background")).toBe(
+      true,
+    );
+    expect(detectBackgroundSubagentIntent("@kimi don't wait")).toBe(true);
+    expect(detectBackgroundSubagentIntent("@kimi separate tabs")).toBe(true);
+  });
+
+  it("does not mark ordinary delegation as background", () => {
+    expect(detectBackgroundSubagentIntent("@kimi review inline")).toBe(false);
+  });
+});
+
 describe("buildExplicitSubagentSteer", () => {
   it("names the subagent and instructs delegation via the task tool", () => {
     const steer = buildExplicitSubagentSteer("reviewer");
     expect(steer).toContain('"reviewer"');
     expect(steer).toContain("task");
     expect(steer).toContain('subagent_type="reviewer"');
+  });
+
+  it("instructs batch delegation when multiple subagents are named", () => {
+    const steer = buildExplicitSubagentSteer(["kimi", "glm-5-2"]);
+    expect(steer).toContain("task_batch");
+    expect(steer).toContain('"kimi"');
+    expect(steer).toContain('"glm-5-2"');
+    expect(steer).toContain('surface="inline"');
+  });
+
+  it("requests background tabs only when the user asked for them", () => {
+    const steer = buildExplicitSubagentSteer(["kimi", "glm-5-2"], {
+      surface: "background",
+    });
+    expect(steer).toContain("task_batch");
+    expect(steer).toContain('surface="background"');
+    expect(steer).toContain("non-focused");
   });
 });

--- a/agent/subagents/steer.ts
+++ b/agent/subagents/steer.ts
@@ -8,18 +8,53 @@
  * separate from the parser so it has no IO and is trivially unit-tested.
  */
 
+export type ExplicitSubagentSurface = "inline" | "background";
+
 /** A leading `@name` mention. Case-insensitive on input; the captured name is
  *  lower-cased by the caller to match the canonical registry key. */
 const MENTION_RE =
   /^@([A-Za-z0-9][A-Za-z0-9_-]{0,63})(?=$|\s|[,;:!?)}\]]|\.(?:\s|$))/;
+
+const BACKGROUND_RE =
+  /\b(async|background|separate\s+tabs?|don'?t\s+wait|do\s+not\s+wait)\b/i;
 
 /**
  * Detect a leading `@name` mention in a chat message. Returns the lowercased
  * name (caller checks it against the registry) or null when absent.
  */
 export function detectSubagentMention(content: string): string | null {
-  const match = MENTION_RE.exec(content.trimStart());
-  return match ? match[1].toLowerCase() : null;
+  return detectLeadingSubagentMentions(content)[0] ?? null;
+}
+
+/** Detect one or more leading `@name` mentions. Allows natural chains like
+ *  `@kimi and @glm-5-2 review`, but stops before ordinary prompt text so a
+ *  single `@reviewer check this` stays a one-agent handoff. */
+export function detectLeadingSubagentMentions(content: string): string[] {
+  let rest = content.trimStart();
+  const names: string[] = [];
+  let expectMention = true;
+
+  while (expectMention) {
+    const match = MENTION_RE.exec(rest);
+    if (!match) break;
+    names.push(match[1].toLowerCase());
+    rest = rest.slice(match[0].length).trimStart();
+    if (!rest.startsWith("@")) {
+      const separator = /^(?:[,;]\s*)?(?:and|&)\s+/i.exec(rest);
+      if (separator) rest = rest.slice(separator[0].length).trimStart();
+      else if (/^[,;]\s*@/.test(rest)) {
+        rest = rest.replace(/^[,;]\s*/, "");
+      } else {
+        expectMention = false;
+      }
+    }
+  }
+
+  return names;
+}
+
+export function detectBackgroundSubagentIntent(content: string): boolean {
+  return BACKGROUND_RE.test(content);
 }
 
 /**
@@ -28,10 +63,32 @@ export function detectSubagentMention(content: string): string | null {
  * the model to notice the `@name` convention, while keeping the user's message
  * intact in the transcript.
  */
-export function buildExplicitSubagentSteer(name: string): string {
+export function buildExplicitSubagentSteer(
+  names: string | string[],
+  opts: { surface?: ExplicitSubagentSurface } = {},
+): string {
+  const list = Array.isArray(names) ? names : [names];
+  const surface = opts.surface ?? "inline";
+  if (list.length > 1) {
+    const quoted = list.map((name) => `"${name}"`).join(", ");
+    const background =
+      surface === "background"
+        ? " Launch them as non-focused background tabs."
+        : "";
+    return (
+      `The user explicitly invoked multiple subagents: ${quoted}. Delegate ` +
+      `this whole request by calling the \`task_batch\` tool with one ordered ` +
+      `task per named subagent and surface="${surface}". Each task prompt must ` +
+      `be complete and self-contained. Do not perform the task yourself.` +
+      background
+    );
+  }
+  const name = list[0];
+  const surfaceClause =
+    surface === "background" ? ' and surface="background"' : "";
   return (
     `The user explicitly invoked the "${name}" subagent. Delegate this request ` +
-    `to it by calling the \`task\` tool with subagent_type="${name}" and a ` +
+    `to it by calling the \`task\` tool with subagent_type="${name}"${surfaceClause} and a ` +
     `complete, self-contained prompt. Do not perform the task yourself.`
   );
 }

--- a/agent/subagents/task-tool.test.ts
+++ b/agent/subagents/task-tool.test.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ToolDefinition } from "@mariozechner/pi-coding-agent";
 import type { AethonAgentState } from "../state";
 import type { Subagent } from "./types";
-import { buildSubagentTaskTool } from "./task-tool";
+import { buildSubagentTaskBatchTool, buildSubagentTaskTool } from "./task-tool";
 
 const fakeModel = { provider: "ollama", id: "llama3.3", name: "Llama 3.3" };
 
@@ -104,7 +104,21 @@ type ExecResult = {
 };
 type Exec = (
   callId: string,
-  params: { subagent_type: string; prompt: string; context?: string },
+  params: {
+    subagent_type: string;
+    prompt: string;
+    context?: string;
+    surface?: "inline" | "background" | "auto";
+  },
+  signal?: AbortSignal,
+  onUpdate?: (p: { content: { type: string; text: string }[] }) => void,
+) => Promise<ExecResult>;
+type BatchExec = (
+  callId: string,
+  params: {
+    tasks: Array<{ subagent_type: string; prompt: string; context?: string }>;
+    surface?: "inline" | "background" | "auto";
+  },
   signal?: AbortSignal,
   onUpdate?: (p: { content: { type: string; text: string }[] }) => void,
 ) => Promise<ExecResult>;
@@ -113,25 +127,46 @@ function execOf(tool: ToolDefinition): Exec {
   return (tool as unknown as { execute: Exec }).execute;
 }
 
+function batchExecOf(tool: ToolDefinition): BatchExec {
+  return (tool as unknown as { execute: BatchExec }).execute;
+}
+
 function makeState(sub: Partial<Subagent> & { name: string }): {
   state: AethonAgentState;
   findSpy: ReturnType<typeof vi.fn>;
 } {
-  const full: Subagent = {
-    name: sub.name,
-    description: sub.description ?? "does things",
-    model: sub.model,
-    tools: sub.tools,
-    surface: sub.surface ?? "inline",
-    timeoutSeconds: sub.timeoutSeconds,
-    systemPrompt: sub.systemPrompt ?? "You are a helper.",
-    scope: "user",
-    filePath: `/agents/${sub.name}.md`,
-  };
+  return makeStateWithSubagents([sub]);
+}
+
+function makeStateWithSubagents(
+  subs: Array<Partial<Subagent> & { name: string }>,
+): {
+  state: AethonAgentState;
+  findSpy: ReturnType<typeof vi.fn>;
+} {
+  const full = subs.map(
+    (sub): Subagent => ({
+      name: sub.name,
+      description: sub.description ?? "does things",
+      model: sub.model,
+      tools: sub.tools,
+      surface: sub.surface ?? "inline",
+      timeoutSeconds: sub.timeoutSeconds,
+      systemPrompt: sub.systemPrompt ?? `You are ${sub.name}.`,
+      scope: "user",
+      filePath: `/agents/${sub.name}.md`,
+    }),
+  );
   const findSpy = vi.fn((_provider: string, _id: string) => fakeModel);
   const state = {
     subagentsByCwd: new Map([
-      ["/proj", { byName: new Map([[full.name, full]]), issues: [] }],
+      [
+        "/proj",
+        {
+          byName: new Map(full.map((sub) => [sub.name, sub])),
+          issues: [],
+        },
+      ],
     ]),
     tabProjectCwds: new Map<string, string>(),
     tabAuthProfileIds: new Map<string, string>(),
@@ -556,6 +591,34 @@ describe("buildSubagentTaskTool", () => {
     expect(h.createAgentSession).not.toHaveBeenCalled();
   });
 
+  it("can force an inline subagent into a background tab", async () => {
+    const start = vi.fn(() =>
+      Promise.resolve({ ok: true, data: { tabId: "t-bg" } }),
+    );
+    (globalThis as { aethon?: unknown }).aethon = { tasks: { start } };
+    const { state } = makeState({
+      name: "builder",
+      model: "ollama/llama3.3",
+      surface: "inline",
+    });
+    const tool = buildSubagentTaskTool(state, { send: vi.fn() }, "default");
+    const result = await execOf(tool)("c", {
+      subagent_type: "builder",
+      prompt: "do it",
+      surface: "background",
+    });
+    expect(start).toHaveBeenCalledWith({
+      projectPath: "/proj",
+      prompt: expect.stringContaining("do it"),
+      model: "ollama/llama3.3",
+      activate: false,
+      label: expect.stringContaining("builder"),
+    });
+    expect(result.details.surface).toBe("background");
+    expect(result.content[0].text).toMatch(/background tab/);
+    expect(h.createAgentSession).not.toHaveBeenCalled();
+  });
+
   it("passes expanded context as a hidden bridge prompt for tab-surface subagents", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "aethon-task-file-ref-tab-"));
     try {
@@ -589,5 +652,200 @@ describe("buildSubagentTaskTool", () => {
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
+  });
+});
+
+describe("buildSubagentTaskBatchTool", () => {
+  it("runs multiple inline subagents concurrently and returns results in request order", async () => {
+    let releaseA!: () => void;
+    let releaseB!: () => void;
+    h.nextSessions = [
+      {
+        promptImpl: (session) =>
+          new Promise<void>((resolve) => {
+            releaseA = () => {
+              emitSessionEvents(session, [
+                {
+                  type: "message_update",
+                  assistantMessageEvent: {
+                    type: "text_delta",
+                    delta: "A done",
+                  },
+                },
+                {
+                  type: "agent_end",
+                  messages: [
+                    { role: "assistant", content: [], stopReason: "stop" },
+                  ],
+                },
+              ]);
+              resolve();
+            };
+          }),
+      },
+      {
+        promptImpl: (session) =>
+          new Promise<void>((resolve) => {
+            releaseB = () => {
+              emitSessionEvents(session, [
+                {
+                  type: "message_update",
+                  assistantMessageEvent: {
+                    type: "text_delta",
+                    delta: "B done",
+                  },
+                },
+                {
+                  type: "agent_end",
+                  messages: [
+                    { role: "assistant", content: [], stopReason: "stop" },
+                  ],
+                },
+              ]);
+              resolve();
+            };
+          }),
+      },
+    ];
+    const { state } = makeStateWithSubagents([
+      { name: "kimi", model: "ollama/llama3.3" },
+      { name: "glm-5-2", model: "ollama/llama3.3" },
+    ]);
+    const send = vi.fn();
+    const tool = buildSubagentTaskBatchTool(state, { send }, "default");
+
+    const pending = batchExecOf(tool)("batch-call", {
+      tasks: [
+        { subagent_type: "kimi", prompt: "first" },
+        { subagent_type: "glm-5-2", prompt: "second" },
+      ],
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(h.sessions).toHaveLength(2);
+    releaseB();
+    await Promise.resolve();
+    releaseA();
+
+    const result = await pending;
+    expect(result.content[0].text).toMatch(
+      /## kimi[\s\S]*A done[\s\S]*## glm-5-2[\s\S]*B done/,
+    );
+    const progress = send.mock.calls
+      .map((c) => c[0] as Record<string, unknown>)
+      .filter((m) => m.type === "subagent_progress");
+    expect(progress).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          parentCallId: "batch-call",
+          batchItemId: "0:kimi",
+          phase: "start",
+        }),
+        expect.objectContaining({
+          parentCallId: "batch-call",
+          batchItemId: "1:glm-5-2",
+          phase: "start",
+        }),
+      ]),
+    );
+  });
+
+  it("keeps successful batch results when one subagent fails", async () => {
+    h.nextSessions = [
+      { scriptedEvents: successEvents },
+      {
+        scriptedEvents: [
+          {
+            type: "agent_end",
+            messages: [
+              {
+                role: "assistant",
+                stopReason: "error",
+                errorMessage: "model overloaded",
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    const { state } = makeStateWithSubagents([
+      { name: "kimi", model: "ollama/llama3.3" },
+      { name: "glm-5-2", model: "ollama/llama3.3" },
+    ]);
+    const tool = buildSubagentTaskBatchTool(
+      state,
+      { send: vi.fn() },
+      "default",
+    );
+
+    const result = await batchExecOf(tool)("batch-call", {
+      tasks: [
+        { subagent_type: "kimi", prompt: "first" },
+        { subagent_type: "glm-5-2", prompt: "second" },
+      ],
+    });
+
+    expect(result.content[0].text).toContain("## kimi");
+    expect(result.content[0].text).toContain("Found 2 bugs.");
+    expect(result.content[0].text).toContain("## glm-5-2");
+    expect(result.content[0].text).toContain("model overloaded");
+  });
+
+  it("rejects only when every subagent fails", async () => {
+    h.promptImpl = () => Promise.reject(new Error("boom"));
+    const { state } = makeStateWithSubagents([
+      { name: "kimi", model: "ollama/llama3.3" },
+      { name: "glm-5-2", model: "ollama/llama3.3" },
+    ]);
+    const tool = buildSubagentTaskBatchTool(
+      state,
+      { send: vi.fn() },
+      "default",
+    );
+
+    await expect(
+      batchExecOf(tool)("batch-call", {
+        tasks: [
+          { subagent_type: "kimi", prompt: "first" },
+          { subagent_type: "glm-5-2", prompt: "second" },
+        ],
+      }),
+    ).rejects.toThrow(/all subagents failed/i);
+  });
+
+  it("launches batch tasks as non-focused background tabs when requested", async () => {
+    const start = vi.fn(() =>
+      Promise.resolve({ ok: true, data: { tabId: crypto.randomUUID() } }),
+    );
+    (globalThis as { aethon?: unknown }).aethon = { tasks: { start } };
+    const { state } = makeStateWithSubagents([
+      { name: "kimi", model: "ollama/llama3.3" },
+      { name: "glm-5-2", model: "ollama/llama3.3" },
+    ]);
+    const tool = buildSubagentTaskBatchTool(
+      state,
+      { send: vi.fn() },
+      "default",
+    );
+
+    const result = await batchExecOf(tool)("batch-call", {
+      surface: "background",
+      tasks: [
+        { subagent_type: "kimi", prompt: "first" },
+        { subagent_type: "glm-5-2", prompt: "second" },
+      ],
+    });
+
+    expect(start).toHaveBeenCalledTimes(2);
+    expect(start.mock.calls.map((call) => call[0])).toEqual([
+      expect.objectContaining({ activate: false, label: expect.stringContaining("kimi") }),
+      expect.objectContaining({
+        activate: false,
+        label: expect.stringContaining("glm-5-2"),
+      }),
+    ]);
+    expect(h.createAgentSession).not.toHaveBeenCalled();
+    expect(result.content[0].text).toMatch(/## kimi[\s\S]*background tab/);
   });
 });

--- a/agent/subagents/task-tool.ts
+++ b/agent/subagents/task-tool.ts
@@ -9,12 +9,13 @@
  * and returns its final text to the caller as the tool result.
  *
  * Three requested surfaces:
- *  - `inline` (default): the subagent runs here, streaming live progress into
+ *  - `inline`: the subagent runs here, streaming live progress into
  *    the outer tool card (via `onUpdate`) and a richer `subagent_progress`
  *    sidecar stream. Its summary becomes the tool result.
  *  - `background`: the subagent is launched as its own non-focused agent tab
  *    via `aethon.tasks.start`; the tool result just confirms the launch.
- *  - `auto`: the subagent definition decides (`inline` or focused `tab`).
+ *  - `auto` (the `task` default): the subagent definition decides (`inline` or
+ *    focused `tab`). `task_batch` defaults to inline fan-out.
  *
  * The subagent never receives the `task` tool itself, so it can't recurse.
  */

--- a/agent/subagents/task-tool.ts
+++ b/agent/subagents/task-tool.ts
@@ -8,12 +8,13 @@
  * (`SessionManager.inMemory()`) with the subagent's own model + tool allowlist
  * and returns its final text to the caller as the tool result.
  *
- * Two surfaces:
+ * Three requested surfaces:
  *  - `inline` (default): the subagent runs here, streaming live progress into
  *    the outer tool card (via `onUpdate`) and a richer `subagent_progress`
  *    sidecar stream. Its summary becomes the tool result.
- *  - `tab`: the subagent is launched as its own agent tab via
- *    `aethon.tasks.start`; the tool result just confirms the launch.
+ *  - `background`: the subagent is launched as its own non-focused agent tab
+ *    via `aethon.tasks.start`; the tool result just confirms the launch.
+ *  - `auto`: the subagent definition decides (`inline` or focused `tab`).
  *
  * The subagent never receives the `task` tool itself, so it can't recurse.
  */
@@ -38,7 +39,7 @@ import { summarizeToolArgs } from "../tool-card";
 import { logger } from "../logger";
 import { getSubagentsForCwd } from "./loader";
 import { resolveSubagentTools } from "./parse";
-import type { Subagent, SubagentSurface } from "./types";
+import type { Subagent } from "./types";
 import { timeoutMsFromSeconds } from "../runtime-config";
 import {
   expandFileReferencesInPrompt,
@@ -47,6 +48,8 @@ import {
 } from "../file-references";
 /** Cap on the text returned to the parent (and streamed partials). */
 const MAX_RESULT_CHARS = 100_000;
+type RequestedTaskSurface = "inline" | "background" | "auto";
+type ExecutionSurface = "inline" | "tab" | "background";
 
 export interface SubagentTaskDeps {
   send: (obj: Record<string, unknown>) => void;
@@ -55,7 +58,7 @@ export interface SubagentTaskDeps {
 interface SubagentRunDetails {
   subagent: string;
   model: string;
-  surface: SubagentSurface;
+  surface: ExecutionSurface;
 }
 
 type TextBlock = { type: "text"; text: string };
@@ -78,8 +81,54 @@ const TaskParams = Type.Object({
         "Optional extra context (file paths, constraints) prepended to the task. @file references are resolved like prompt references.",
     }),
   ),
+  surface: Type.Optional(
+    Type.Union([
+      Type.Literal("inline"),
+      Type.Literal("background"),
+      Type.Literal("auto"),
+    ], {
+      description:
+        "Where to run this delegation. `auto` (default for `task`) preserves the subagent's configured surface; `inline` waits for the result in this tool call; `background` launches a non-focused tab and returns immediately.",
+    }),
+  ),
 });
 type TaskParamsT = Static<typeof TaskParams>;
+
+const BatchTaskItemParams = Type.Object({
+  subagent_type: Type.String({
+    description:
+      "Name of the subagent to delegate to. Must match one of the available subagents listed in the system prompt.",
+  }),
+  prompt: Type.String({
+    description:
+      "The full, self-contained task for this subagent. It runs in a fresh isolated session and only sees this text — include all context it needs.",
+  }),
+  context: Type.Optional(
+    Type.String({
+      description:
+        "Optional extra context (file paths, constraints) prepended to this task.",
+    }),
+  ),
+});
+
+const BatchTaskParams = Type.Object({
+  tasks: Type.Array(BatchTaskItemParams, {
+    minItems: 1,
+    description:
+      "Ordered independent subagent delegations. Results are returned in this same order even when subagents finish out of order.",
+  }),
+  surface: Type.Optional(
+    Type.Union([
+      Type.Literal("inline"),
+      Type.Literal("background"),
+      Type.Literal("auto"),
+    ], {
+      description:
+        "`inline` (default) runs all delegates concurrently and waits for partial results; `background` launches non-focused tabs; `auto` uses each subagent's configured surface.",
+    }),
+  ),
+});
+type BatchTaskParamsT = Static<typeof BatchTaskParams>;
 
 /** Build the `task` tool bound to a specific parent tab. The captured
  *  `parentTabId` routes nested progress events and resolves the inherited
@@ -116,6 +165,38 @@ export function buildSubagentTaskTool(
   }) as ToolDefinition;
 }
 
+export function buildSubagentTaskBatchTool(
+  state: AethonAgentState,
+  deps: SubagentTaskDeps,
+  parentTabId: string,
+): ToolDefinition {
+  return defineTool({
+    name: "task_batch",
+    label: "Delegate to multiple subagents",
+    description:
+      "Delegate multiple independent tasks to configured subagents concurrently. Use this when the user explicitly names more than one subagent or when several subagents should peer-review/research/build in parallel. Inline mode waits for all delegates and returns one section per subagent; background mode launches non-focused tabs and returns immediately.",
+    promptSnippet:
+      "task_batch: fan out independent tasks to multiple configured subagents",
+    parameters: BatchTaskParams,
+    async execute(
+      callId: string,
+      params: BatchTaskParamsT,
+      signal: AbortSignal | undefined,
+      onUpdate: UpdateFn | undefined,
+    ): Promise<SubagentToolResult> {
+      return runSubagentTaskBatch(
+        state,
+        deps,
+        parentTabId,
+        callId,
+        params,
+        signal,
+        onUpdate,
+      );
+    },
+  }) as ToolDefinition;
+}
+
 async function runSubagentTask(
   state: AethonAgentState,
   deps: SubagentTaskDeps,
@@ -124,6 +205,10 @@ async function runSubagentTask(
   params: TaskParamsT,
   signal: AbortSignal | undefined,
   onUpdate: UpdateFn | undefined,
+  options: {
+    defaultSurface?: RequestedTaskSurface;
+    progress?: BatchProgressMeta;
+  } = {},
 ): Promise<SubagentToolResult> {
   const cwd =
     state.tabProjectCwds.get(parentTabId) ??
@@ -155,8 +240,18 @@ async function runSubagentTask(
       ).prompt
     : taskBody;
   const composedPrompt = composePrompt(sub, expandedBody);
-  if (sub.surface === "tab") {
-    return launchSubagentTab(sub, cwd, composedPrompt);
+  const surface = resolveExecutionSurface(
+    sub,
+    params.surface ?? options.defaultSurface ?? "auto",
+  );
+  if (surface === "tab" || surface === "background") {
+    return launchSubagentTab(sub, cwd, composedPrompt, {
+      activate: surface !== "background",
+      surface,
+      ...(surface === "background"
+        ? { label: backgroundTabLabel(sub, params.prompt) }
+        : {}),
+    });
   }
 
   return runInlineSubagent(
@@ -169,7 +264,127 @@ async function runSubagentTask(
     composedPrompt,
     signal,
     onUpdate,
+    options.progress,
   );
+}
+
+function resolveExecutionSurface(
+  sub: Subagent,
+  requested: RequestedTaskSurface,
+): ExecutionSurface {
+  if (requested === "inline") return "inline";
+  if (requested === "background") return "background";
+  return sub.surface === "tab" ? "tab" : "inline";
+}
+
+function backgroundTabLabel(sub: Subagent, prompt: string): string {
+  const firstLine = prompt.trim().split(/\r?\n/, 1)[0]?.trim() ?? "";
+  const summary =
+    firstLine.length > 36 ? `${firstLine.slice(0, 35)}...` : firstLine;
+  return summary ? `${sub.name}: ${summary}` : sub.name;
+}
+
+async function runSubagentTaskBatch(
+  state: AethonAgentState,
+  deps: SubagentTaskDeps,
+  parentTabId: string,
+  callId: string,
+  params: BatchTaskParamsT,
+  signal: AbortSignal | undefined,
+  onUpdate: UpdateFn | undefined,
+): Promise<SubagentToolResult> {
+  if (params.tasks.length === 0) {
+    throw new Error("task_batch requires at least one task");
+  }
+  const surface = params.surface ?? "inline";
+  const partials = new Map<number, string>();
+  const emitBatchUpdate = (): void => {
+    if (!onUpdate) return;
+    const text = params.tasks
+      .map((task, index) => {
+        const partial = partials.get(index);
+        if (!partial) return "";
+        return `## ${task.subagent_type}\n${partial}`;
+      })
+      .filter(Boolean)
+      .join("\n\n");
+    if (!text) return;
+    onUpdate({
+      content: [{ type: "text", text: text.slice(-MAX_RESULT_CHARS) }],
+      details: {
+        subagent: "batch",
+        model: "mixed",
+        surface: surface === "background" ? "background" : "inline",
+      },
+    });
+  };
+
+  const jobs = params.tasks.map((task, index) =>
+    runSubagentTask(
+      state,
+      deps,
+      parentTabId,
+      callId,
+      { ...task, surface },
+      signal,
+      (partial) => {
+        const text = partial.content
+          .map((block) => block.text)
+          .join("\n")
+          .trim();
+        if (text) {
+          partials.set(index, text);
+          emitBatchUpdate();
+        }
+      },
+      {
+        defaultSurface: surface,
+        progress: {
+          batchItemId: `${index}:${task.subagent_type.trim().toLowerCase()}`,
+          batchIndex: index,
+        },
+      },
+    ),
+  );
+
+  const settled = await Promise.allSettled(jobs);
+  const failures = settled.filter(
+    (result): result is PromiseRejectedResult => result.status === "rejected",
+  );
+  if (failures.length === settled.length) {
+    const messages = failures
+      .map((failure) =>
+        failure.reason instanceof Error
+          ? failure.reason.message
+          : String(failure.reason),
+      )
+      .join("; ");
+    throw new Error(`all subagents failed: ${messages}`);
+  }
+
+  const sections = settled.map((result, index) => {
+    const name = params.tasks[index]?.subagent_type ?? `task ${index + 1}`;
+    if (result.status === "fulfilled") {
+      const text =
+        result.value.content.map((block) => block.text).join("\n").trim() ||
+        "(subagent produced no text output)";
+      return `## ${name}\n${text}`;
+    }
+    const message =
+      result.reason instanceof Error
+        ? result.reason.message
+        : String(result.reason);
+    return `## ${name}\nFailed: ${message}`;
+  });
+
+  return {
+    content: [{ type: "text", text: sections.join("\n\n") }],
+    details: {
+      subagent: "batch",
+      model: "mixed",
+      surface: surface === "background" ? "background" : "inline",
+    },
+  };
 }
 
 /** The delegated task body: an optional context block followed by the prompt.
@@ -242,6 +457,7 @@ async function runInlineSubagent(
   composedPrompt: string,
   signal: AbortSignal | undefined,
   onUpdate: UpdateFn | undefined,
+  progress?: BatchProgressMeta,
 ): Promise<SubagentToolResult> {
   const resolved = resolveModelServices(state, parentTabId, sub.model);
   if (!resolved) {
@@ -294,25 +510,25 @@ async function runInlineSubagent(
           emitProgress(deps, parentTabId, callId, details, {
             phase: "text",
             delta,
-          });
+          }, progress);
         },
         onThinking: (delta) =>
           emitProgress(deps, parentTabId, callId, details, {
             phase: "thinking",
             delta,
-          }),
+          }, progress),
         onToolStart: (toolName, toolSummary) =>
           emitProgress(deps, parentTabId, callId, details, {
             phase: "tool_start",
             toolName,
             toolSummary,
-          }),
+          }, progress),
         onToolEnd: (toolName, isError) =>
           emitProgress(deps, parentTabId, callId, details, {
             phase: "tool_end",
             toolName,
             isError,
-          }),
+          }, progress),
         onEnd: (messages) => {
           errorMessage = extractAgentEndError(messages);
           if (!finalText.trim()) {
@@ -342,7 +558,7 @@ async function runInlineSubagent(
   };
   signal?.addEventListener("abort", onAbort);
 
-  emitProgress(deps, parentTabId, callId, details, { phase: "start" });
+  emitProgress(deps, parentTabId, callId, details, { phase: "start" }, progress);
   try {
     await withTimeout(
       session.prompt(composedPrompt),
@@ -355,7 +571,7 @@ async function runInlineSubagent(
     emitProgress(deps, parentTabId, callId, details, {
       phase: "error",
       error: (err as Error).message,
-    });
+    }, progress);
     throw new Error(
       `subagent "${sub.name}" failed: ${(err as Error).message}`,
       {
@@ -381,11 +597,11 @@ async function runInlineSubagent(
     emitProgress(deps, parentTabId, callId, details, {
       phase: "error",
       error: errorMessage,
-    });
+    }, progress);
     throw new Error(`subagent "${sub.name}" error: ${errorMessage}`);
   }
 
-  emitProgress(deps, parentTabId, callId, details, { phase: "done" });
+  emitProgress(deps, parentTabId, callId, details, { phase: "done" }, progress);
   const text = finalText.trim() || "(subagent produced no text output)";
   return {
     content: [{ type: "text", text: text.slice(0, MAX_RESULT_CHARS) }],
@@ -399,6 +615,8 @@ interface TasksApi {
     prompt: string;
     model?: string;
     bridgePrompt?: string;
+    activate?: boolean;
+    label?: string;
   }): Promise<{ ok: boolean; error?: string; data?: unknown }>;
 }
 
@@ -411,6 +629,11 @@ async function launchSubagentTab(
   sub: Subagent,
   cwd: string,
   composedPrompt: string,
+  options: {
+    activate: boolean;
+    surface: "tab" | "background";
+    label?: string;
+  },
 ): Promise<SubagentToolResult> {
   const api = getTasksApi();
   if (!api)
@@ -425,6 +648,8 @@ async function launchSubagentTab(
       ? { bridgePrompt: composedPrompt }
       : {}),
     ...(sub.model ? { model: sub.model } : {}),
+    ...(options.activate === false ? { activate: false } : {}),
+    ...(options.label ? { label: options.label } : {}),
   });
   if (!result.ok) {
     throw new Error(
@@ -434,11 +659,16 @@ async function launchSubagentTab(
   const details: SubagentRunDetails = {
     subagent: sub.name,
     model: sub.model ?? "inherited",
-    surface: "tab",
+    surface: options.surface,
   };
+  const surfaceText =
+    options.surface === "background" ? "a background tab" : "a new tab";
   return {
     content: [
-      { type: "text", text: `Launched subagent \`${sub.name}\` in a new tab.` },
+      {
+        type: "text",
+        text: `Launched subagent \`${sub.name}\` in ${surfaceText}.`,
+      },
     ],
     details,
   };
@@ -533,12 +763,18 @@ interface ProgressInfo {
   error?: string;
 }
 
+interface BatchProgressMeta {
+  batchItemId: string;
+  batchIndex: number;
+}
+
 function emitProgress(
   deps: SubagentTaskDeps,
   parentTabId: string,
   callId: string,
   details: SubagentRunDetails,
   info: ProgressInfo,
+  batch?: BatchProgressMeta,
 ): void {
   deps.send({
     type: "subagent_progress",
@@ -546,6 +782,9 @@ function emitProgress(
     parentCallId: callId,
     subagent: details.subagent,
     model: details.model,
+    ...(batch
+      ? { batchItemId: batch.batchItemId, batchIndex: batch.batchIndex }
+      : {}),
     ...info,
   });
 }

--- a/agent/system-prompt.test.ts
+++ b/agent/system-prompt.test.ts
@@ -149,6 +149,7 @@ describe("buildSubagentsSection", () => {
     ]);
     expect(out).toContain("Available subagents");
     expect(out).toContain("`task`");
+    expect(out).toContain("`task_batch`");
     expect(out).toContain("@<name>");
     expect(out).toContain("`reviewer`");
     expect(out).toContain("ollama/llama3.3");
@@ -156,14 +157,14 @@ describe("buildSubagentsSection", () => {
     expect(out).toContain("opens its own tab");
   });
 
-  it("advertises @<name> handoff for mentions anywhere in a message", () => {
+  it("advertises batch handoff for leading mentions and partial delegation for non-leading mentions", () => {
     const out = buildSubagentsSection([
       { name: "reviewer", description: "Reviews diffs", surface: "inline" },
     ]);
-    // Handoff is triggered by a mention *in* a message, not just a prefix, so
-    // mid-message mentions like "when done, have @reviewer check it" delegate.
-    expect(out).toContain("a message includes `@<name>`");
-    expect(out).not.toContain("prefixes a message");
+    expect(out).toContain("Multiple leading mentions");
+    expect(out).toContain('surface: "inline"');
+    expect(out).toContain('surface: "background"');
+    expect(out).toContain("Non-leading mentions");
   });
 
   it("is not rendered by buildRuntimeSection (advertisement is per-turn)", () => {

--- a/agent/system-prompt.ts
+++ b/agent/system-prompt.ts
@@ -48,13 +48,17 @@ export function buildSubagentsSection(
   const lines: string[] = [
     "# Available subagents",
     "Delegate focused work to one with the `task` tool " +
-      '(`task({ subagent_type: "<name>", prompt: "<self-contained task>" })`). ' +
+      '(`task({ subagent_type: "<name>", prompt: "<self-contained task>" })`) ' +
+      "or to several independent subagents with `task_batch`. " +
       "Choose the subagent whose description best fits; pass everything it needs " +
-      "in `prompt` (it runs in an isolated session and sees only that). When a " +
-      "message includes `@<name>`, hand that work to the named subagent — a " +
-      "message that starts with `@<name>` is entirely for it; a mention later in " +
-      "the message (e.g. \"when done, have @<name> review\") delegates just that " +
-      "part. Do NOT delegate trivial work you can do directly.",
+      "in `prompt` (it runs in an isolated session and sees only that). Multiple " +
+      "leading mentions such as `@a and @b ...` mean the whole prompt should fan " +
+      "out with `task_batch` and `surface: \"inline\"` by default. Use " +
+      '`surface: "background"` only when the user asks for async/background/' +
+      "don't-wait/separate-tabs behavior. Non-leading mentions (e.g. \"when " +
+      "done, have @<name> review\") are guidance to delegate just that part, not " +
+      "an automatic whole-prompt hijack. Do NOT delegate trivial work you can do " +
+      "directly.",
   ];
   for (const s of subagents) {
     const model = s.model ? `, model \`${s.model}\`` : "";

--- a/agent/tab-lifecycle/events.ts
+++ b/agent/tab-lifecycle/events.ts
@@ -386,7 +386,7 @@ export function handleSessionEvent(
         emitBashResult(deps, streamed.delta, tabId);
         addLiveContextUsageEstimate(rec, streamed.delta);
         emitContextUsageThrottled(state, deps, tabId, rec);
-      } else if (ev.toolName === "task") {
+      } else if (ev.toolName === "task" || ev.toolName === "task_batch") {
         let cached = rec.toolArgsCache.get(ev.toolCallId);
         if (!cached) {
           cached = {

--- a/agent/tab-lifecycle/lifecycle.ts
+++ b/agent/tab-lifecycle/lifecycle.ts
@@ -23,7 +23,10 @@ import { createAethonBashToolDefinition } from "../bash-tool";
 import { buildDashboardTools } from "../dashboard-tools";
 import { buildEditorTools } from "../editor-tools";
 import { buildSessionTitleTools } from "../session-title-tool";
-import { buildSubagentTaskTool } from "../subagents/task-tool";
+import {
+  buildSubagentTaskBatchTool,
+  buildSubagentTaskTool,
+} from "../subagents/task-tool";
 import { buildMemoryTools } from "../memory/tools";
 import {
   installCodexFastModePayloadHook,
@@ -183,6 +186,7 @@ export async function ensureTab(
       ...buildEditorTools(),
       ...buildMemoryTools(state, tabId),
       buildSubagentTaskTool(state, deps, tabId),
+      buildSubagentTaskBatchTool(state, deps, tabId),
     ],
     ...(options.initialModel ? { model: options.initialModel } : {}),
     ...(options.thinkingLevel ? { thinkingLevel: options.thinkingLevel } : {}),

--- a/agent/tool-card.ts
+++ b/agent/tool-card.ts
@@ -50,6 +50,21 @@ export function summarizeToolArgs(toolName: string, args: unknown): string {
         String(a.subagent_type ?? "subagent"),
         firstLine(a.prompt),
       ]);
+    case "task_batch": {
+      const tasks = Array.isArray(a.tasks) ? a.tasks : [];
+      const names = tasks
+        .map((item) =>
+          item && typeof item === "object"
+            ? String((item as Record<string, unknown>).subagent_type ?? "")
+            : "",
+        )
+        .filter(Boolean)
+        .join(", ");
+      return compactSummary([
+        names || "subagents",
+        String(a.surface ?? "inline"),
+      ]);
+    }
     case "subagent":
       return compactSummary([String(a.agent ?? "agent"), firstLine(a.task)]);
     case "startTask":
@@ -218,7 +233,7 @@ export function toolCardPayload(opts: {
   if (result !== undefined) {
     const extracted = extractToolContent(result);
     if (extracted.text) {
-      if (toolName === "task") {
+      if (toolName === "task" || toolName === "task_batch") {
         children.push({
           id: `${id}-result`,
           type: "subagent-result",

--- a/docs/aethon-agent/api.md
+++ b/docs/aethon-agent/api.md
@@ -674,8 +674,10 @@ aethon.tasks.start({
   baseBranch?: string,        // base to fork from (project default, then origin/main)
   model?: string,             // optional model id for the launched tab
   bridgePrompt?: string,      // hidden bridge prompt; prompt remains visible text
+  activate?: boolean,         // default true; false opens without focusing/switching
+  label?: string,             // optional tab label
 });
-// → { ok: true, data: { projectId } }
+// → { ok: true, data: { projectId, tabId, cwd, activated } }
 //   Workspace-create + new-tab + send first message run as one chain;
 //   the resolved Promise fires after the prompt lands in the new tab.
 //   `bridgePrompt` is extension-trusted hidden context, not user-visible text.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { ExtensionRegistry } from "./extensions/ExtensionRegistry";
 import { defaultLayoutExtension } from "./extensions/default-layout";
@@ -48,6 +48,10 @@ import {
 import { useDerivedRenderState } from "./hooks/useDerivedRenderState";
 import { useTabBucketHydration } from "./hooks/useTabBucketHydration";
 import { useTaskLauncher } from "./hooks/useTaskLauncher";
+import {
+  findTabAcrossBuckets,
+  updateTabAcrossBuckets,
+} from "./hooks/tabRouting";
 import { useAppEventRouting } from "./hooks/useAppEventRouting";
 import { useAppStateRefs } from "./hooks/useAppStateRefs";
 import { useProjectModelRecorder } from "./hooks/useProjectModelRecorder";
@@ -424,6 +428,21 @@ export default function App() {
   // last-active tab rather than the empty landing card.
   useTabBucketHydration(state.persistedTabBuckets, tabBucketsRef);
 
+  const updateTabRouted = useCallback(
+    (tabId: string, mutator: (tab: Tab) => Tab) => {
+      updateTabAcrossBuckets(
+        { setState, stateRef, projectsRef, tabBucketsRef },
+        tabId,
+        mutator,
+      );
+    },
+    [projectsRef, setState, stateRef, tabBucketsRef],
+  );
+  const findTabRouted = useCallback(
+    (tabId: string) => findTabAcrossBuckets(stateRef, tabBucketsRef, tabId),
+    [stateRef, tabBucketsRef],
+  );
+
   // ---------------------------------------------------------------------
   // Toast stack + OS completion notification. Owned by useNotifications.
   // pushNotification's eviction path resolves any pending consent prompt
@@ -512,7 +531,7 @@ export default function App() {
   } = useChat({
     setState,
     stateRef,
-    updateTab,
+    updateTab: updateTabRouted,
     updateActiveTab,
     pendingTabOpens,
     slashCommandsRef,
@@ -521,6 +540,7 @@ export default function App() {
     persistLocalChatMessage,
     recordProjectModel,
     piDefaultModelRef,
+    findTabById: findTabRouted,
   });
 
   // All forward-ref slots — used by earlier hooks to call through to
@@ -550,7 +570,7 @@ export default function App() {
   useQueuedDispatch({
     tabs: (state.tabs as Tab[] | undefined) ?? [],
     sendChat,
-    updateTab,
+    updateTab: updateTabRouted,
   });
 
   // Dashboard task launch orchestrator. Shared by the per-project
@@ -564,6 +584,10 @@ export default function App() {
     newTab,
     pendingTabOpens,
     sendChat,
+    setState,
+    stateRef,
+    tabBucketsRef,
+    piDefaultModelRef,
   });
 
   // Updater (Cmd menu / tray "Check for Updates" + agent-driven path).
@@ -669,7 +693,7 @@ export default function App() {
     turnStartedAtRef,
     lastExtensionStateKeysRef,
     pendingTabOpens,
-    updateTab,
+    updateTab: updateTabRouted,
     updateActiveTab,
     newTab,
     newEditorTab,

--- a/src/eventRoutes/types.ts
+++ b/src/eventRoutes/types.ts
@@ -179,7 +179,10 @@ export interface EventRouteContext {
     workspaceId?: string;
     /** Model the launched session should use (task-launcher model chip). */
     model?: string;
-  }) => Promise<void>;
+    bridgePrompt?: string;
+    activate?: boolean;
+    label?: string;
+  }) => Promise<unknown>;
   removeWorkspaceById: (
     workspaceId: string,
     opts?: { confirmed?: boolean },

--- a/src/extensions/default-layout/tool-card.subagent.test.tsx
+++ b/src/extensions/default-layout/tool-card.subagent.test.tsx
@@ -58,6 +58,38 @@ describe("ToolCard subagent activity", () => {
     expect(screen.getByText("final summary")).toBeTruthy();
   });
 
+  it("renders multiple subagent activity blocks for batch progress", () => {
+    taskCard({
+      subagentProgress: {
+        "call-abc": {
+          kind: "batch",
+          order: ["0:kimi", "1:glm"],
+          items: {
+            "0:kimi": {
+              subagent: "kimi",
+              model: "m1",
+              steps: [{ kind: "tool", label: "read src/a.ts" }],
+              text: "kimi notes",
+              done: false,
+            },
+            "1:glm": {
+              subagent: "glm",
+              model: "m2",
+              steps: [],
+              text: "glm notes",
+              done: true,
+            },
+          },
+        },
+      },
+    });
+    expect(screen.getAllByText(/kimi/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/glm/).length).toBeGreaterThan(0);
+    expect(screen.getByText("read src/a.ts")).toBeTruthy();
+    expect(screen.getByText("kimi notes")).toBeTruthy();
+    expect(screen.getByText("glm notes")).toBeTruthy();
+  });
+
   it("renders task result output as prose", () => {
     render(
       <SubagentResult

--- a/src/extensions/default-layout/tool-card.tsx
+++ b/src/extensions/default-layout/tool-card.tsx
@@ -10,7 +10,11 @@ import {
   resolveNumber,
   resolveString,
 } from "../../utils/dataBinding";
-import type { SubagentProgress } from "../../hooks/bridgeMessageHandlers/subagentProgress";
+import type {
+  SubagentProgress,
+  SubagentProgressBatch,
+  SubagentProgressEntry,
+} from "../../hooks/bridgeMessageHandlers/subagentProgress";
 
 const TOOL_LONG_RUN_THRESHOLD_MS = 30 * 1000;
 
@@ -19,11 +23,11 @@ const TOOL_LONG_RUN_THRESHOLD_MS = 30 * 1000;
 function readSubagentProgress(
   state: Record<string, unknown>,
   componentId: string | undefined,
-): SubagentProgress | null {
+): SubagentProgressEntry | null {
   if (!componentId) return null;
   const callId = componentId.replace(/^tool-\d+-/, "");
   const map = state.subagentProgress as
-    | Record<string, SubagentProgress>
+    | Record<string, SubagentProgressEntry>
     | undefined;
   return map?.[callId] ?? null;
 }
@@ -54,6 +58,30 @@ function SubagentActivity({ progress }: { progress: SubagentProgress }) {
           {progress.text}
         </div>
       )}
+    </div>
+  );
+}
+
+function isBatchProgress(
+  progress: SubagentProgressEntry,
+): progress is SubagentProgressBatch {
+  return "kind" in progress && progress.kind === "batch";
+}
+
+function SubagentActivityStack({
+  progress,
+}: {
+  progress: SubagentProgressEntry;
+}) {
+  if (!isBatchProgress(progress)) {
+    return <SubagentActivity progress={progress} />;
+  }
+  return (
+    <div className="ae-subagent-activity-stack">
+      {progress.order.map((id) => {
+        const item = progress.items[id];
+        return item ? <SubagentActivity key={id} progress={item} /> : null;
+      })}
     </div>
   );
 }
@@ -157,7 +185,9 @@ export function ToolCard({
   const isError = props.isError ? resolveBoolean(props.isError, state) : false;
   const toolName = props.toolName ? resolveString(props.toolName, state) : "";
   const subagentProgress =
-    toolName === "task" ? readSubagentProgress(state, component.id) : null;
+    toolName === "task" || toolName === "task_batch"
+      ? readSubagentProgress(state, component.id)
+      : null;
   const status = props.status ? resolveString(props.status, state) : undefined;
   const isCancelled = status === "cancelled";
   const running = startedAt !== undefined && endedAt === undefined;
@@ -216,7 +246,9 @@ export function ToolCard({
         )}
       </summary>
       <div className="ae-tool-card-body">
-        {subagentProgress && <SubagentActivity progress={subagentProgress} />}
+        {subagentProgress && (
+          <SubagentActivityStack progress={subagentProgress} />
+        )}
         {hasChildren ? (
           renderChildren?.()
         ) : subagentProgress ? null : (

--- a/src/hooks/bridgeMessageHandlers/dashboardQuery.test.ts
+++ b/src/hooks/bridgeMessageHandlers/dashboardQuery.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+import { handleDashboardQuery } from "./dashboardQuery";
+import { buildHandlerFixture } from "./testFixtures";
+
+const flushPromises = () =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, 0);
+  });
+
+describe("handleDashboardQuery", () => {
+  it("resolves start_task project paths from known workspace roots", async () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    const startTaskInProject = vi.fn(() =>
+      Promise.resolve({
+        tabId: "tab-bg",
+        projectId: "p1",
+        cwd: "/repo/aethon-work",
+        activated: false,
+      }),
+    );
+    ctx.startTaskInProject = startTaskInProject;
+    ctx.projectsRef.current = {
+      activeId: "p1",
+      activeWorkspaceId: null,
+      activeHostId: null,
+      projects: [
+        { id: "p1", label: "Aethon", path: "/repo/aethon", lastUsed: 1 },
+      ],
+      workspacesByProject: {
+        p1: [
+          {
+            id: "wt-1",
+            projectId: "p1",
+            path: "/repo/aethon-work",
+            branch: "feat/work",
+            isMain: false,
+          },
+        ],
+      },
+    };
+
+    handleDashboardQuery(
+      {
+        type: "dashboard_query",
+        mutationId: "m1",
+        op: "start_task",
+        args: {
+          projectPath: "/repo/aethon-work",
+          prompt: "review this",
+          activate: false,
+        },
+      },
+      ctx,
+    );
+    await flushPromises();
+
+    expect(startTaskInProject).toHaveBeenCalledWith({
+      projectId: "p1",
+      workspaceId: "wt-1",
+      prompt: "review this",
+      newWorkspace: false,
+      branch: undefined,
+      baseBranch: undefined,
+      activate: false,
+    });
+    expect(mocks.ackMutation).toHaveBeenCalledWith(
+      "m1",
+      true,
+      undefined,
+      expect.objectContaining({
+        ok: true,
+        projectId: "p1",
+        tabId: "tab-bg",
+        cwd: "/repo/aethon-work",
+      }),
+    );
+  });
+});

--- a/src/hooks/bridgeMessageHandlers/dashboardQuery.ts
+++ b/src/hooks/bridgeMessageHandlers/dashboardQuery.ts
@@ -44,7 +44,7 @@ export const handleDashboardQuery: BridgeMessageHandler = (data, ctx) => {
       if (!project) {
         throw new Error(`unknown project path: ${projectPath}`);
       }
-      await ctx.startTaskInProject({
+      const launched = await ctx.startTaskInProject({
         projectId: project.id,
         prompt,
         newWorkspace: args.newWorkspace === true,
@@ -56,8 +56,14 @@ export const handleDashboardQuery: BridgeMessageHandler = (data, ctx) => {
         ...(typeof args.bridgePrompt === "string" && args.bridgePrompt.length > 0
           ? { bridgePrompt: args.bridgePrompt }
           : {}),
+        ...(typeof args.activate === "boolean"
+          ? { activate: args.activate }
+          : {}),
+        ...(typeof args.label === "string" && args.label.length > 0
+          ? { label: args.label }
+          : {}),
       });
-      return { ok: true, projectId: project.id };
+      return { ok: true, projectId: project.id, ...(launched ?? {}) };
     }
 
     if (op === "get_repo_overview") {

--- a/src/hooks/bridgeMessageHandlers/dashboardQuery.ts
+++ b/src/hooks/bridgeMessageHandlers/dashboardQuery.ts
@@ -9,6 +9,32 @@ import {
   getIssueDetail,
   getIssues,
 } from "../../ghIssuesCache";
+import type { Project, ProjectsState } from "../../projects";
+import { normalizeSessionPath } from "../projectOps/tabBuckets";
+
+function resolveTaskProject(
+  projects: ProjectsState,
+  projectPath: string,
+): { project: Project; workspaceId?: string } | null {
+  const target = normalizeSessionPath(projectPath);
+  const project = projects.projects.find(
+    (candidate) => normalizeSessionPath(candidate.path) === target,
+  );
+  if (project) return { project };
+
+  for (const candidate of projects.projects) {
+    const workspace = (
+      projects.workspacesByProject[candidate.id] ?? []
+    ).find((item) => normalizeSessionPath(item.path) === target);
+    if (workspace) {
+      return {
+        project: candidate,
+        ...(workspace.isMain ? {} : { workspaceId: workspace.id }),
+      };
+    }
+  }
+  return null;
+}
 
 /** Bridge proxy for `aethon.tasks.start` + `aethon.dashboard.{getRepoOverview, refresh}`.
  *
@@ -38,15 +64,15 @@ export const handleDashboardQuery: BridgeMessageHandler = (data, ctx) => {
       if (!projectPath || !prompt) {
         throw new Error("start_task requires projectPath + prompt");
       }
-      const project = ctx.projectsRef.current.projects.find(
-        (p) => p.path === projectPath,
-      );
-      if (!project) {
+      const resolved = resolveTaskProject(ctx.projectsRef.current, projectPath);
+      if (!resolved) {
         throw new Error(`unknown project path: ${projectPath}`);
       }
+      const { project, workspaceId } = resolved;
       const launched = await ctx.startTaskInProject({
         projectId: project.id,
         prompt,
+        ...(workspaceId ? { workspaceId } : {}),
         newWorkspace: args.newWorkspace === true,
         branch: args.branch as string | undefined,
         baseBranch: args.baseBranch as string | undefined,

--- a/src/hooks/bridgeMessageHandlers/stashedTabs.test.ts
+++ b/src/hooks/bridgeMessageHandlers/stashedTabs.test.ts
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from "vitest";
+import { makeEmptyTab, type Tab } from "../../types/tab";
+import type { ChatMessage } from "../../types/a2ui";
+import type { TabBucket } from "../projectOps/types";
+import { updateTabAcrossBuckets } from "../tabRouting";
+import { handleA2ui } from "./a2ui";
+import { handlePromptStarted } from "./promptStarted";
+import { handleResponseDelta, flushResponseDeltas } from "./responseDelta";
+import { handleResponseEnd } from "./responseEnd";
+import { buildHandlerFixture } from "./testFixtures";
+
+function bucketTab(bucket: TabBucket): Tab {
+  const tab = bucket.tabs[0];
+  if (!tab) throw new Error("missing bucket tab");
+  return tab;
+}
+
+describe("bridge handlers for stashed tabs", () => {
+  it("routes prompt, text, a2ui, and completion updates into hidden buckets", () => {
+    const hidden = {
+      ...makeEmptyTab("hidden", "Hidden", "p2", "agent"),
+      cwd: "/repo/other-work",
+    };
+    const tabBucketsRef = {
+      current: new Map<string, TabBucket>([
+        ["p2::workspace::wt-2", { tabs: [hidden], activeTabId: "hidden" }],
+      ]),
+    };
+    const { ctx } = buildHandlerFixture({
+      state: {
+        activeTabId: "main",
+        tabs: [makeEmptyTab("main", "Main", "p1", "agent")],
+        persistedTabBuckets: {
+          "p2::workspace::wt-2": { tabs: [hidden], activeTabId: "hidden" },
+        },
+      },
+    });
+    ctx.projectsRef.current = {
+      activeId: "p1",
+      activeWorkspaceId: null,
+      activeHostId: null,
+      projects: [
+        { id: "p1", label: "Main", path: "/repo/main", lastUsed: 1 },
+        { id: "p2", label: "Other", path: "/repo/other", lastUsed: 2 },
+      ],
+      workspacesByProject: {
+        p2: [
+          {
+            id: "wt-2",
+            projectId: "p2",
+            path: "/repo/other-work",
+            branch: "feat/other",
+            isMain: false,
+          },
+        ],
+      },
+    };
+    ctx.updateTab = (tabId, mutator) =>
+      updateTabAcrossBuckets(
+        {
+          setState: ctx.setState,
+          stateRef: ctx.stateRef,
+          projectsRef: ctx.projectsRef,
+          tabBucketsRef,
+        },
+        tabId,
+        mutator,
+      );
+    ctx.appendOrAmendAgentText = (
+      delta: string,
+      messageId?: string,
+      tabId = "default",
+    ) => {
+      ctx.updateTab(tabId, (tab) => {
+        const messages = tab.messages.slice();
+        const id = messageId ?? "legacy";
+        const idx = messages.findIndex((message) => message.id === id);
+        const next: ChatMessage =
+          idx >= 0
+            ? { ...messages[idx], text: `${messages[idx].text ?? ""}${delta}` }
+            : { id, role: "agent", text: delta };
+        if (idx >= 0) messages[idx] = next;
+        else messages.push(next);
+        return { ...tab, messages };
+      });
+    };
+    ctx.appendMessage = (message, tabId = "default") => {
+      ctx.updateTab(tabId, (tab) => ({
+        ...tab,
+        messages: [...tab.messages, message],
+      }));
+    };
+
+    handlePromptStarted({ type: "prompt_started", tabId: "hidden" }, ctx);
+    expect(bucketTab(tabBucketsRef.current.get("p2::workspace::wt-2")!).waiting)
+      .toBe(true);
+    expect(ctx.stateRef.current.agentRunningTabs).toEqual({ hidden: true });
+
+    handleResponseDelta(
+      {
+        type: "response_delta",
+        tabId: "hidden",
+        messageId: "msg-1",
+        content: "hello",
+      },
+      ctx,
+    );
+    flushResponseDeltas("hidden");
+    expect(
+      bucketTab(tabBucketsRef.current.get("p2::workspace::wt-2")!).messages,
+    ).toEqual([expect.objectContaining({ id: "msg-1", text: "hello" })]);
+
+    const payload = { components: [{ id: "tool-1", type: "tool-card" }] };
+    handleA2ui(
+      { type: "a2ui", tabId: "hidden", id: "tool-1", payload },
+      ctx,
+    );
+    expect(
+      bucketTab(tabBucketsRef.current.get("p2::workspace::wt-2")!).messages,
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "tool-1", a2ui: payload }),
+      ]),
+    );
+
+    handleResponseEnd({ type: "response_end", tabId: "hidden" }, ctx);
+    expect(bucketTab(tabBucketsRef.current.get("p2::workspace::wt-2")!).waiting)
+      .toBe(false);
+    expect(ctx.stateRef.current.agentRunningTabs).toEqual({});
+    expect(
+      (
+        ctx.stateRef.current.persistedTabBuckets as Record<string, TabBucket>
+      )["p2::workspace::wt-2"].tabs[0]?.waiting,
+    ).toBe(false);
+  });
+});

--- a/src/hooks/bridgeMessageHandlers/subagentProgress.test.ts
+++ b/src/hooks/bridgeMessageHandlers/subagentProgress.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
   handleSubagentProgress,
+  type SubagentProgressBatch,
   type SubagentProgress,
+  type SubagentProgressEntry,
 } from "./subagentProgress";
 import { buildHandlerFixture } from "./testFixtures";
 import type { BridgeMessageContext } from "./types";
@@ -51,6 +53,55 @@ describe("handleSubagentProgress", () => {
     expect(progress(ctx)?.steps).toEqual([
       { kind: "error", label: "model overloaded" },
     ]);
+  });
+
+  it("groups batch progress by parent call id and subagent item", () => {
+    const { ctx } = buildHandlerFixture();
+    handleSubagentProgress(
+      {
+        type: "subagent_progress",
+        tabId: "t1",
+        parentCallId: "c1",
+        batchItemId: "0:kimi",
+        batchIndex: 0,
+        phase: "start",
+        subagent: "kimi",
+        model: "m1",
+      },
+      ctx,
+    );
+    handleSubagentProgress(
+      {
+        type: "subagent_progress",
+        tabId: "t1",
+        parentCallId: "c1",
+        batchItemId: "1:glm",
+        batchIndex: 1,
+        phase: "text",
+        subagent: "glm",
+        model: "m2",
+        delta: "done",
+      },
+      ctx,
+    );
+
+    const entry = (
+      ctx.stateRef.current.subagentProgress as Record<
+        string,
+        SubagentProgressEntry
+      >
+    ).c1 as SubagentProgressBatch;
+    expect(entry.kind).toBe("batch");
+    expect(entry.order).toEqual(["0:kimi", "1:glm"]);
+    expect(entry.items["0:kimi"]).toMatchObject({
+      subagent: "kimi",
+      model: "m1",
+    });
+    expect(entry.items["1:glm"]).toMatchObject({
+      subagent: "glm",
+      model: "m2",
+      text: "done",
+    });
   });
 
   it("ignores events without a parentCallId", () => {

--- a/src/hooks/bridgeMessageHandlers/subagentProgress.ts
+++ b/src/hooks/bridgeMessageHandlers/subagentProgress.ts
@@ -10,6 +10,14 @@ export interface SubagentProgress {
   done: boolean;
 }
 
+export interface SubagentProgressBatch {
+  kind: "batch";
+  order: string[];
+  items: Record<string, SubagentProgress>;
+}
+
+export type SubagentProgressEntry = SubagentProgress | SubagentProgressBatch;
+
 const MAX_TEXT = 4000;
 const MAX_STEPS = 60;
 
@@ -23,6 +31,51 @@ function toolLabel(data: Record<string, unknown>): string {
   return summary ? `${name} ${summary}` : name;
 }
 
+function emptyProgress(subagent: string, model: string): SubagentProgress {
+  return {
+    subagent,
+    model,
+    steps: [],
+    text: "",
+    done: false,
+  };
+}
+
+function applyProgressPhase(
+  cur: SubagentProgress,
+  data: Record<string, unknown>,
+): SubagentProgress {
+  const phase = str(data.phase);
+  const next: SubagentProgress = {
+    ...cur,
+    subagent: str(data.subagent) || cur.subagent,
+    model: str(data.model) || cur.model,
+  };
+  switch (phase) {
+    case "text":
+      next.text = (cur.text + str(data.delta)).slice(-MAX_TEXT);
+      break;
+    case "tool_start":
+      next.steps = [
+        ...cur.steps,
+        { kind: "tool" as const, label: toolLabel(data) },
+      ].slice(-MAX_STEPS);
+      break;
+    case "error":
+      next.steps = [
+        ...cur.steps,
+        { kind: "error" as const, label: str(data.error) || "error" },
+      ].slice(-MAX_STEPS);
+      break;
+    case "done":
+      next.done = true;
+      break;
+    default:
+      break;
+  }
+  return next;
+}
+
 /**
  * Translate a subagent_progress event (emitted by the `task` tool while a
  * subagent runs inline) into the `/subagentProgress/<parentCallId>` state slice.
@@ -32,48 +85,51 @@ function toolLabel(data: Record<string, unknown>): string {
 export const handleSubagentProgress: BridgeMessageHandler = (data, ctx) => {
   const parentCallId = str(data.parentCallId);
   if (!parentCallId) return;
-  const phase = str(data.phase);
   const subagent = str(data.subagent);
   const model = str(data.model);
+  const batchItemId = str(data.batchItemId);
 
   ctx.setState((prev) => {
     const map =
-      (prev.subagentProgress as Record<string, SubagentProgress> | undefined) ??
+      (prev.subagentProgress as
+        | Record<string, SubagentProgressEntry>
+        | undefined) ??
       {};
-    const cur: SubagentProgress = map[parentCallId] ?? {
-      subagent,
-      model,
-      steps: [],
-      text: "",
-      done: false,
-    };
-    const next: SubagentProgress = {
-      ...cur,
-      subagent: subagent || cur.subagent,
-      model: model || cur.model,
-    };
-    switch (phase) {
-      case "text":
-        next.text = (cur.text + str(data.delta)).slice(-MAX_TEXT);
-        break;
-      case "tool_start":
-        next.steps = [
-          ...cur.steps,
-          { kind: "tool" as const, label: toolLabel(data) },
-        ].slice(-MAX_STEPS);
-        break;
-      case "error":
-        next.steps = [
-          ...cur.steps,
-          { kind: "error" as const, label: str(data.error) || "error" },
-        ].slice(-MAX_STEPS);
-        break;
-      case "done":
-        next.done = true;
-        break;
-      default:
-        break;
+    if (batchItemId) {
+      const curEntry = map[parentCallId];
+      const curBatch: SubagentProgressBatch =
+        curEntry && "kind" in curEntry && curEntry.kind === "batch"
+          ? curEntry
+          : { kind: "batch", order: [], items: {} };
+      const curItem =
+        curBatch.items[batchItemId] ?? emptyProgress(subagent, model);
+      const nextItem = applyProgressPhase(curItem, data);
+      const order = curBatch.order.includes(batchItemId)
+        ? curBatch.order
+        : [...curBatch.order, batchItemId].sort((a, b) => {
+            const ai = Number(a.split(":", 1)[0]);
+            const bi = Number(b.split(":", 1)[0]);
+            if (Number.isFinite(ai) && Number.isFinite(bi)) return ai - bi;
+            return a.localeCompare(b);
+          });
+      return {
+        ...prev,
+        subagentProgress: {
+          ...map,
+          [parentCallId]: {
+            kind: "batch",
+            order,
+            items: { ...curBatch.items, [batchItemId]: nextItem },
+          },
+        },
+      };
     }
+    const curEntry = map[parentCallId];
+    const cur =
+      curEntry && !("kind" in curEntry)
+        ? curEntry
+        : emptyProgress(subagent, model);
+    const next = applyProgressPhase(cur, data);
     return { ...prev, subagentProgress: { ...map, [parentCallId]: next } };
   });
 };

--- a/src/hooks/bridgeMessageHandlers/types.ts
+++ b/src/hooks/bridgeMessageHandlers/types.ts
@@ -13,6 +13,7 @@ import type {
   NotificationKind,
 } from "../../extensions/default-layout/notifications";
 import type { ProjectsState } from "../../projects";
+import type { StartTaskResult } from "../useTaskLauncher";
 
 /** A bridge-to-frontend message. The `type` discriminator routes to a
  *  handler in the registry; other keys are payload-specific and typed
@@ -183,7 +184,9 @@ export interface BridgeMessageContext {
     baseBranch?: string;
     model?: string;
     bridgePrompt?: string;
-  }) => Promise<void>;
+    activate?: boolean;
+    label?: string;
+  }) => Promise<StartTaskResult | void>;
 
   // ─── Hook-owned ────────────────────────────────────────────────────
   /** Startup/reload paint gate. The first bridge ready can still represent

--- a/src/hooks/projectOps/types.ts
+++ b/src/hooks/projectOps/types.ts
@@ -129,6 +129,7 @@ export interface UseProjectOpsActions {
     branch?: string;
     targetPath?: string;
     baseBranch?: string;
+    activate?: boolean;
   }) => Promise<string | null>;
   removeWorkspaceById: (
     workspaceId: string,

--- a/src/hooks/projectOps/workspaceOps/git.ts
+++ b/src/hooks/projectOps/workspaceOps/git.ts
@@ -201,6 +201,7 @@ export async function createWorkspaceWithParams(
     branch?: string;
     targetPath?: string;
     baseBranch?: string;
+    activate?: boolean;
   },
 ): Promise<string | null> {
   const project = deps.lookups.findProject(opts.projectId);
@@ -257,7 +258,11 @@ export async function createWorkspaceWithParams(
       (w) =>
         w.id === pending.id || w.path === created.path || w.path === targetPath,
     );
-    navigateToWorkspace(deps, opts.projectId, live?.id ?? pending.id);
+    if (opts.activate !== false) {
+      navigateToWorkspace(deps, opts.projectId, live?.id ?? pending.id);
+    } else {
+      deps.syncProjectsToState();
+    }
     return live?.path ?? created.path ?? targetPath;
   } catch (err) {
     deps.projectsRef.current = setProjectWorkspaces(

--- a/src/hooks/projectOps/workspaceOps/types.ts
+++ b/src/hooks/projectOps/workspaceOps/types.ts
@@ -44,6 +44,7 @@ export interface WorkspaceOperations {
     branch?: string;
     targetPath?: string;
     baseBranch?: string;
+    activate?: boolean;
   }) => Promise<string | null>;
   removeWorkspaceById: (
     workspaceId: string,

--- a/src/hooks/tabRouting.ts
+++ b/src/hooks/tabRouting.ts
@@ -1,0 +1,93 @@
+import type { Dispatch, MutableRefObject, SetStateAction } from "react";
+import type { ProjectsState } from "../projects";
+import type { Tab } from "../types/tab";
+import { TAB_MIRROR_KEYS } from "./tabOps/constants";
+import { projectScopeBucketKey } from "./projectOps/tabBuckets";
+import type { TabBucket } from "./projectOps/types";
+
+export interface TabRoutingDeps {
+  setState: Dispatch<SetStateAction<Record<string, unknown>>>;
+  stateRef: MutableRefObject<Record<string, unknown>>;
+  projectsRef: MutableRefObject<ProjectsState>;
+  tabBucketsRef: MutableRefObject<Map<string, TabBucket>>;
+}
+
+function activeBucketKey(projects: ProjectsState): string {
+  return projectScopeBucketKey(projects.activeId, projects.activeWorkspaceId);
+}
+
+function persistedBuckets(
+  buckets: Map<string, TabBucket>,
+  activeKey: string,
+): Record<string, TabBucket> {
+  const result: Record<string, TabBucket> = {};
+  for (const [key, bucket] of buckets.entries()) {
+    if (key === activeKey) continue;
+    result[key] = {
+      tabs: bucket.tabs,
+      activeTabId: bucket.activeTabId,
+    };
+  }
+  return result;
+}
+
+export function findTabAcrossBuckets(
+  stateRef: MutableRefObject<Record<string, unknown>>,
+  tabBucketsRef: MutableRefObject<Map<string, TabBucket>>,
+  tabId: string,
+): Tab | undefined {
+  const visible = ((stateRef.current.tabs as Tab[] | undefined) ?? []).find(
+    (tab) => tab.id === tabId,
+  );
+  if (visible) return visible;
+  for (const bucket of tabBucketsRef.current.values()) {
+    const hidden = bucket.tabs.find((tab) => tab.id === tabId);
+    if (hidden) return hidden;
+  }
+  return undefined;
+}
+
+export function updateTabAcrossBuckets(
+  deps: TabRoutingDeps,
+  tabId: string,
+  mutator: (tab: Tab) => Tab,
+): void {
+  const { setState, projectsRef, tabBucketsRef } = deps;
+  setState((prev) => {
+    const tabs = ((prev.tabs as Tab[] | undefined) ?? []).slice();
+    const visibleIndex = tabs.findIndex((tab) => tab.id === tabId);
+    if (visibleIndex >= 0) {
+      const next = mutator(tabs[visibleIndex]);
+      tabs[visibleIndex] = next;
+      const result: Record<string, unknown> = { ...prev, tabs };
+      if (prev.activeTabId === tabId) {
+        const rec = next as unknown as Record<string, unknown>;
+        for (const key of TAB_MIRROR_KEYS) {
+          result[key as string] = rec[key as string];
+        }
+      }
+      return result;
+    }
+
+    const activeKey = activeBucketKey(projectsRef.current);
+    for (const [key, bucket] of tabBucketsRef.current.entries()) {
+      const hiddenIndex = bucket.tabs.findIndex((tab) => tab.id === tabId);
+      if (hiddenIndex < 0) continue;
+      const hiddenTabs = bucket.tabs.slice();
+      hiddenTabs[hiddenIndex] = mutator(hiddenTabs[hiddenIndex]);
+      tabBucketsRef.current.set(key, {
+        tabs: hiddenTabs,
+        activeTabId: bucket.activeTabId ?? hiddenTabs[0]?.id,
+      });
+      return {
+        ...prev,
+        persistedTabBuckets: persistedBuckets(
+          tabBucketsRef.current,
+          activeKey,
+        ),
+      };
+    }
+
+    return prev;
+  });
+}

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -81,6 +81,7 @@ export interface UseChatContext {
   slashContext: () => SlashCommandContext;
   persistLocalChatMessage: (msg: ChatMessage, tabId: string) => void;
   recordProjectModel: (model: string, tabId?: string) => void;
+  findTabById?: (tabId: string) => Tab | undefined;
   /** pi's boot/default model, used as the new-tab fallback. Cleared when
    *  the user resets to "(pi default)" so the next new session sends no
    *  explicit model and the agent picks its env-driven default. */
@@ -166,6 +167,7 @@ export function useChat(ctx: UseChatContext): UseChatActions {
     slashContext,
     persistLocalChatMessage,
     recordProjectModel,
+    findTabById,
     piDefaultModelRef,
   } = ctx;
 
@@ -533,9 +535,11 @@ export function useChat(ctx: UseChatContext): UseChatActions {
     const bridgeText = options?.bridgeText?.trim() || displayText;
     const mode = options?.mode === "steer" ? "steer" : "normal";
     const tabId = explicitTabId ?? activeTabId ?? "default";
-    const targetTab = ((stateRef.current.tabs as Tab[] | undefined) ?? []).find(
-      (tab) => tab.id === tabId,
-    );
+    const targetTab =
+      findTabById?.(tabId) ??
+      ((stateRef.current.tabs as Tab[] | undefined) ?? []).find(
+        (tab) => tab.id === tabId,
+      );
     const wasBusy =
       isAgentTabInFlight(targetTab) ||
       ((targetTab === undefined || tabId === activeTabId) &&

--- a/src/hooks/useProjectOps.test.ts
+++ b/src/hooks/useProjectOps.test.ts
@@ -1137,6 +1137,66 @@ describe("useProjectOps workspace creation", () => {
     expect(projectsRef.current.projects[0].uiExpanded).toBe(true);
   });
 
+  it("can create workspaces without activating the result", async () => {
+    const harness = installTauriMocks();
+    harness.invoke.mockImplementation((cmd: string) => {
+      if (cmd === "git_worktree_add") {
+        return Promise.resolve({
+          path: "/tmp/aethon/aethon/fix-thing",
+          branch: "fix/thing",
+          head: "def456",
+          isMain: false,
+          locked: false,
+        });
+      }
+      if (cmd === "git_worktrees") {
+        return Promise.resolve([
+          {
+            path: "/projects/aethon",
+            branch: "main",
+            head: "abc123",
+            isMain: true,
+            locked: false,
+          },
+          {
+            path: "/tmp/aethon/aethon/fix-thing",
+            branch: "fix/thing",
+            head: "def456",
+            isMain: false,
+            locked: false,
+          },
+        ]);
+      }
+      return Promise.resolve(undefined);
+    });
+    const initial = makeProjectsState({ activeId: "project-1" });
+    const { result, projectsRef, stateRef } = renderProjectOps(initial);
+    stateRef.current.aethonRoot = "/tmp/aethon";
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    projectsRef.current = initial;
+
+    await act(async () => {
+      const created = await result.current.createWorkspaceWithParams({
+        projectId: "project-1",
+        branch: "fix/thing",
+        activate: false,
+      });
+      expect(created).toBe("/tmp/aethon/aethon/fix-thing");
+    });
+
+    expect(projectsRef.current.activeId).toBe("project-1");
+    expect(projectsRef.current.activeWorkspaceId).toBeNull();
+    expect(projectsRef.current.projects[0].uiExpanded).not.toBe(true);
+    expect(
+      projectsRef.current.workspacesByProject["project-1"]?.some(
+        (workspace) => workspace.path === "/tmp/aethon/aethon/fix-thing",
+      ),
+    ).toBe(true);
+  });
+
   it("auto-generates blank workspace branches under the Aethon user dir", async () => {
     const harness = installTauriMocks();
     harness.invoke.mockImplementation((cmd: string, args) => {

--- a/src/hooks/useTaskLauncher.test.ts
+++ b/src/hooks/useTaskLauncher.test.ts
@@ -2,9 +2,16 @@
 
 import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import { invoke } from "@tauri-apps/api/core";
 import type { ProjectsState } from "../projects";
+import { makeEmptyTab, type Tab } from "../types/tab";
 import { useTaskLauncher } from "./useTaskLauncher";
 import type { NotificationInput } from "./useNotifications";
+import type { TabBucket } from "./projectOps/types";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(() => Promise.resolve(null)),
+}));
 
 const ref = <T,>(value: T) => ({ current: value });
 
@@ -101,6 +108,7 @@ describe("useTaskLauncher", () => {
       projectId: "p1",
       branch: "feat/task",
       baseBranch: "main",
+      activate: true,
     });
     expect(activateWorkspace).toHaveBeenCalledWith("wt-1");
     expect(newTab).toHaveBeenCalledWith(tabId, undefined, {
@@ -185,7 +193,233 @@ describe("useTaskLauncher", () => {
     expect(createWorkspaceWithParams).toHaveBeenCalledWith({
       projectId: "p1",
       baseBranch: undefined,
+      activate: true,
     });
     expect(activateWorkspace).toHaveBeenCalledWith("wt-auto");
+  });
+
+  it("creates background workspace tabs without requesting workspace activation", async () => {
+    vi.mocked(invoke).mockResolvedValue(null);
+    const projects = makeProjects();
+    projects.activeId = "p1";
+    projects.workspacesByProject.p1 = [
+      {
+        id: "wt-bg",
+        projectId: "p1",
+        path: "/repo/aethon-bg",
+        branch: "feat/bg",
+        isMain: false,
+      },
+    ];
+    const stateRef = ref<Record<string, unknown>>({
+      activeTabId: "main",
+      tabs: [makeEmptyTab("main", "Main", "p1", "agent")],
+    });
+    const setState = vi.fn((arg: unknown) => {
+      stateRef.current =
+        typeof arg === "function"
+          ? (arg as (prev: Record<string, unknown>) => Record<string, unknown>)(
+              stateRef.current,
+            )
+          : (arg as Record<string, unknown>);
+    });
+    const createWorkspaceWithParams = vi.fn(() =>
+      Promise.resolve("/repo/aethon-bg"),
+    );
+    const setActiveProjectById = vi.fn(() => true);
+    const activateWorkspace = vi.fn();
+    const sendChat = vi.fn(() => Promise.resolve());
+    const tabBucketsRef = ref(new Map<string, TabBucket>());
+    const { result } = renderHook(() =>
+      useTaskLauncher({
+        projectsRef: ref(projects),
+        pushNotificationRef: ref((_: NotificationInput) => {}),
+        setActiveProjectById,
+        createWorkspaceWithParams,
+        activateWorkspace,
+        newTab: vi.fn(),
+        pendingTabOpens: ref(new Map()),
+        sendChat,
+        setState,
+        stateRef,
+        tabBucketsRef,
+        piDefaultModelRef: ref("openai/gpt-5"),
+      }),
+    );
+
+    await act(async () => {
+      await result.current({
+        projectId: "p1",
+        prompt: "background workspace review",
+        newWorkspace: true,
+        branch: "feat/bg",
+        activate: false,
+      });
+    });
+
+    expect(createWorkspaceWithParams).toHaveBeenCalledWith({
+      projectId: "p1",
+      branch: "feat/bg",
+      baseBranch: undefined,
+      activate: false,
+    });
+    expect(setActiveProjectById).not.toHaveBeenCalled();
+    expect(activateWorkspace).not.toHaveBeenCalled();
+    expect(stateRef.current.activeTabId).toBe("main");
+    const bucket = tabBucketsRef.current.get("p1::workspace::wt-bg");
+    expect(bucket?.tabs[0]).toMatchObject({
+      projectId: "p1",
+      cwd: "/repo/aethon-bg",
+    });
+    expect(sendChat).toHaveBeenCalledWith("background workspace review", {
+      tabId: bucket?.tabs[0]?.id,
+    });
+  });
+
+  it("adds an inactive task tab to the active bucket without focusing it", async () => {
+    vi.mocked(invoke).mockResolvedValue(null);
+    const existing = makeEmptyTab("existing", "Existing", "p1", "agent");
+    const stateRef = ref<Record<string, unknown>>({
+      activeTabId: "existing",
+      tabs: [existing],
+      defaultModel: "openai/gpt-5.5",
+    });
+    const setState = vi.fn((arg: unknown) => {
+      stateRef.current =
+        typeof arg === "function"
+          ? (arg as (prev: Record<string, unknown>) => Record<string, unknown>)(
+              stateRef.current,
+            )
+          : (arg as Record<string, unknown>);
+    });
+    const projects = makeProjects();
+    projects.activeId = "p1";
+    const newTab = vi.fn();
+    const setActiveProjectById = vi.fn(() => true);
+    const activateWorkspace = vi.fn();
+    const sendChat = vi.fn(() => Promise.resolve());
+    const { result } = renderHook(() =>
+      useTaskLauncher({
+        projectsRef: ref(projects),
+        pushNotificationRef: ref((_: NotificationInput) => {}),
+        setActiveProjectById,
+        createWorkspaceWithParams: vi.fn(),
+        activateWorkspace,
+        newTab,
+        pendingTabOpens: ref(new Map()),
+        sendChat,
+        setState,
+        stateRef,
+        tabBucketsRef: ref(new Map<string, TabBucket>()),
+        piDefaultModelRef: ref("openai/gpt-5"),
+      }),
+    );
+
+    await act(async () => {
+      await result.current({
+        projectId: "p1",
+        prompt: "background review",
+        activate: false,
+        label: "Kimi review",
+      });
+    });
+
+    const tabs = stateRef.current.tabs as Tab[];
+    const created = tabs.find((tab) => tab.id !== "existing");
+    expect(created).toMatchObject({
+      label: "Kimi review",
+      projectId: "p1",
+      cwd: "/repo/aethon",
+      model: "openai/gpt-5.5",
+    });
+    expect(stateRef.current.activeTabId).toBe("existing");
+    expect(setActiveProjectById).not.toHaveBeenCalled();
+    expect(activateWorkspace).not.toHaveBeenCalled();
+    expect(newTab).not.toHaveBeenCalled();
+    expect(sendChat).toHaveBeenCalledWith("background review", {
+      tabId: created?.id,
+    });
+  });
+
+  it("adds an inactive task tab to a stashed workspace bucket", async () => {
+    vi.mocked(invoke).mockResolvedValue(null);
+    const stateRef = ref<Record<string, unknown>>({
+      activeTabId: "main",
+      tabs: [makeEmptyTab("main", "Main", "p1", "agent")],
+    });
+    const setState = vi.fn((arg: unknown) => {
+      stateRef.current =
+        typeof arg === "function"
+          ? (arg as (prev: Record<string, unknown>) => Record<string, unknown>)(
+              stateRef.current,
+            )
+          : (arg as Record<string, unknown>);
+    });
+    const projects = makeProjects();
+    projects.activeId = "p1";
+    projects.projects.push({
+      id: "p2",
+      label: "Other",
+      path: "/repo/other",
+      lastUsed: 2,
+    });
+    projects.workspacesByProject.p2 = [
+      {
+        id: "wt-2",
+        projectId: "p2",
+        path: "/repo/other-work",
+        branch: "feat/other",
+        isMain: false,
+      },
+    ];
+    const tabBucketsRef = ref(new Map<string, TabBucket>());
+    const setActiveProjectById = vi.fn(() => true);
+    const activateWorkspace = vi.fn();
+    const sendChat = vi.fn(() => Promise.resolve());
+    const { result } = renderHook(() =>
+      useTaskLauncher({
+        projectsRef: ref(projects),
+        pushNotificationRef: ref((_: NotificationInput) => {}),
+        setActiveProjectById,
+        createWorkspaceWithParams: vi.fn(),
+        activateWorkspace,
+        newTab: vi.fn(),
+        pendingTabOpens: ref(new Map()),
+        sendChat,
+        setState,
+        stateRef,
+        tabBucketsRef,
+        piDefaultModelRef: ref("openai/gpt-5"),
+      }),
+    );
+
+    await act(async () => {
+      await result.current({
+        projectId: "p2",
+        workspaceId: "wt-2",
+        prompt: "background workspace task",
+        activate: false,
+        label: "GLM task",
+      });
+    });
+
+    expect(setActiveProjectById).not.toHaveBeenCalled();
+    expect(activateWorkspace).not.toHaveBeenCalled();
+    expect(stateRef.current.activeTabId).toBe("main");
+    const bucket = tabBucketsRef.current.get("p2::workspace::wt-2");
+    expect(bucket?.activeTabId).toBe(bucket?.tabs[0]?.id);
+    expect(bucket?.tabs[0]).toMatchObject({
+      label: "GLM task",
+      projectId: "p2",
+      cwd: "/repo/other-work",
+    });
+    expect(
+      (stateRef.current.persistedTabBuckets as Record<string, TabBucket>)[
+        "p2::workspace::wt-2"
+      ].tabs[0]?.id,
+    ).toBe(bucket?.tabs[0]?.id);
+    expect(sendChat).toHaveBeenCalledWith("background workspace task", {
+      tabId: bucket?.tabs[0]?.id,
+    });
   });
 });

--- a/src/hooks/useTaskLauncher.test.ts
+++ b/src/hooks/useTaskLauncher.test.ts
@@ -341,6 +341,60 @@ describe("useTaskLauncher", () => {
     });
   });
 
+  it("does not count an active-bucket snapshot twice when naming background tabs", async () => {
+    vi.mocked(invoke).mockResolvedValue(null);
+    const existing = makeEmptyTab("existing", "Existing", "p1", "agent");
+    const stateRef = ref<Record<string, unknown>>({
+      activeTabId: "existing",
+      tabs: [existing],
+    });
+    const setState = vi.fn((arg: unknown) => {
+      stateRef.current =
+        typeof arg === "function"
+          ? (arg as (prev: Record<string, unknown>) => Record<string, unknown>)(
+              stateRef.current,
+            )
+          : (arg as Record<string, unknown>);
+    });
+    const projects = makeProjects();
+    projects.activeId = "p1";
+    const tabBucketsRef = ref(
+      new Map<string, TabBucket>([
+        ["p1", { tabs: [existing], activeTabId: "existing" }],
+      ]),
+    );
+    const sendChat = vi.fn(() => Promise.resolve());
+    const { result } = renderHook(() =>
+      useTaskLauncher({
+        projectsRef: ref(projects),
+        pushNotificationRef: ref((_: NotificationInput) => {}),
+        setActiveProjectById: vi.fn(() => true),
+        createWorkspaceWithParams: vi.fn(),
+        activateWorkspace: vi.fn(),
+        newTab: vi.fn(),
+        pendingTabOpens: ref(new Map()),
+        sendChat,
+        setState,
+        stateRef,
+        tabBucketsRef,
+        piDefaultModelRef: ref("openai/gpt-5"),
+      }),
+    );
+
+    await act(async () => {
+      await result.current({
+        projectId: "p1",
+        prompt: "background review",
+        activate: false,
+      });
+    });
+
+    const created = (stateRef.current.tabs as Tab[]).find(
+      (tab) => tab.id !== "existing",
+    );
+    expect(created?.label).toBe("Tab 2");
+  });
+
   it("adds an inactive task tab to a stashed workspace bucket", async () => {
     vi.mocked(invoke).mockResolvedValue(null);
     const stateRef = ref<Record<string, unknown>>({

--- a/src/hooks/useTaskLauncher.ts
+++ b/src/hooks/useTaskLauncher.ts
@@ -1,7 +1,24 @@
-import { useCallback, type MutableRefObject } from "react";
+import {
+  useCallback,
+  type Dispatch,
+  type MutableRefObject,
+  type SetStateAction,
+} from "react";
+import { invoke } from "@tauri-apps/api/core";
 import type { ChatAttachment } from "../types/a2ui";
 import type { ProjectsState } from "../projects";
 import type { NotificationInput } from "./useNotifications";
+import { makeEmptyTab, type Tab } from "../types/tab";
+import { modelForNewProjectTab } from "./tabOps/helpers";
+import {
+  devshellNeedsPreparation,
+  initialDevshellTerminalBuffer,
+} from "./tabOps/devshellTerminal";
+import {
+  projectScopeBucketKey,
+  workspaceIdForCwd,
+} from "./projectOps/tabBuckets";
+import type { TabBucket } from "./projectOps/types";
 
 export interface StartTaskOptions {
   projectId: string;
@@ -11,6 +28,11 @@ export interface StartTaskOptions {
   branch?: string;
   baseBranch?: string;
   workspaceId?: string;
+  /** When false, create the task tab without switching the visible
+   *  project/workspace or focusing the new tab. */
+  activate?: boolean;
+  /** Optional tab label for agent-launched/background tasks. */
+  label?: string;
   /** Model the launched session should use (task-launcher model chip).
    *  Overrides the global default + per-project memory for this launch. */
   model?: string;
@@ -29,6 +51,7 @@ export interface UseTaskLauncherOptions {
     branch?: string;
     targetPath?: string;
     baseBranch?: string;
+    activate?: boolean;
   }) => Promise<string | null>;
   activateWorkspace: (workspaceId: string | null) => void;
   newTab: (
@@ -50,6 +73,45 @@ export interface UseTaskLauncherOptions {
       bridgeText?: string;
     },
   ) => Promise<void>;
+  setState?: Dispatch<SetStateAction<Record<string, unknown>>>;
+  stateRef?: MutableRefObject<Record<string, unknown>>;
+  tabBucketsRef?: MutableRefObject<Map<string, TabBucket>>;
+  piDefaultModelRef?: MutableRefObject<string>;
+}
+
+export interface StartTaskResult {
+  tabId: string;
+  projectId: string;
+  cwd: string;
+  activated: boolean;
+}
+
+function mirrorPersistedBuckets(
+  tabBucketsRef: MutableRefObject<Map<string, TabBucket>>,
+  activeBucketKey: string,
+): Record<string, TabBucket> {
+  const persisted: Record<string, TabBucket> = {};
+  for (const [key, bucket] of tabBucketsRef.current.entries()) {
+    if (key === activeBucketKey) continue;
+    persisted[key] = {
+      tabs: bucket.tabs,
+      activeTabId: bucket.activeTabId,
+    };
+  }
+  return persisted;
+}
+
+function countKnownTabs(
+  stateRef: MutableRefObject<Record<string, unknown>>,
+  tabBucketsRef: MutableRefObject<Map<string, TabBucket>>,
+): number {
+  const activeCount = ((stateRef.current.tabs as Tab[] | undefined) ?? [])
+    .length;
+  let hiddenCount = 0;
+  for (const bucket of tabBucketsRef.current.values()) {
+    hiddenCount += bucket.tabs.length;
+  }
+  return activeCount + hiddenCount;
 }
 
 export function useTaskLauncher({
@@ -61,9 +123,13 @@ export function useTaskLauncher({
   newTab,
   pendingTabOpens,
   sendChat,
-}: UseTaskLauncherOptions): (opts: StartTaskOptions) => Promise<void> {
+  setState,
+  stateRef,
+  tabBucketsRef,
+  piDefaultModelRef,
+}: UseTaskLauncherOptions): (opts: StartTaskOptions) => Promise<StartTaskResult | void> {
   return useCallback(
-    async (opts: StartTaskOptions): Promise<void> => {
+    async (opts: StartTaskOptions): Promise<StartTaskResult | void> => {
       const project = projectsRef.current.projects.find(
         (p) => p.id === opts.projectId,
       );
@@ -75,16 +141,19 @@ export function useTaskLauncher({
         });
         return;
       }
-      if (projectsRef.current.activeId !== opts.projectId) {
+      const shouldActivate = opts.activate !== false;
+      if (shouldActivate && projectsRef.current.activeId !== opts.projectId) {
         setActiveProjectById(opts.projectId);
       }
       let cwd = project.path;
+      let workspaceIdForBucket: string | null | undefined = null;
       if (opts.newWorkspace) {
         const branch = (opts.branch ?? "").trim();
         const created = await createWorkspaceWithParams({
           projectId: opts.projectId,
           ...(branch ? { branch } : {}),
           baseBranch: opts.baseBranch,
+          activate: shouldActivate,
         });
         if (!created) {
           pushNotificationRef.current({
@@ -101,21 +170,151 @@ export function useTaskLauncher({
           projectsRef.current.workspacesByProject[opts.projectId]?.find(
             (w) => w.path === created,
           );
-        if (createdWorkspace) activateWorkspace(createdWorkspace.id);
+        workspaceIdForBucket = createdWorkspace?.id ?? null;
+        if (shouldActivate && createdWorkspace)
+          activateWorkspace(createdWorkspace.id);
       } else if (opts.workspaceId) {
         const list =
           projectsRef.current.workspacesByProject[opts.projectId] ?? [];
         const wt = list.find((w) => w.id === opts.workspaceId);
         if (wt) {
           cwd = wt.path;
-          activateWorkspace(wt.id);
+          workspaceIdForBucket = wt.id;
+          if (shouldActivate) activateWorkspace(wt.id);
         }
       }
       const tabId = crypto.randomUUID();
-      newTab(tabId, undefined, {
-        cwd,
-        ...(opts.model ? { model: opts.model } : {}),
-      });
+      if (shouldActivate || !setState || !stateRef || !tabBucketsRef) {
+        newTab(tabId, opts.label, {
+          cwd,
+          ...(opts.model ? { model: opts.model } : {}),
+        });
+      } else {
+        const activeBucketKey = projectScopeBucketKey(
+          projectsRef.current.activeId,
+          projectsRef.current.activeWorkspaceId,
+        );
+        const targetWorkspaceId =
+          workspaceIdForBucket ??
+          workspaceIdForCwd(projectsRef.current, cwd, opts.projectId) ??
+          null;
+        const targetBucketKey = projectScopeBucketKey(
+          opts.projectId,
+          targetWorkspaceId,
+        );
+        const inheritedModel = modelForNewProjectTab(
+          stateRef.current,
+          opts.projectId,
+          piDefaultModelRef?.current ?? "",
+          opts.model,
+        );
+        const inheritedThinkingLevel =
+          typeof stateRef.current.defaultThinkingLevel === "string"
+            ? stateRef.current.defaultThinkingLevel
+            : undefined;
+        const initialTerminalBuffer = initialDevshellTerminalBuffer(
+          stateRef.current,
+          cwd,
+        );
+        const preparingDevshell = devshellNeedsPreparation(
+          stateRef.current,
+          cwd,
+        );
+        const tab: Tab = {
+          ...makeEmptyTab(
+            tabId,
+            opts.label ?? `Tab ${countKnownTabs(stateRef, tabBucketsRef) + 1}`,
+            opts.projectId,
+          ),
+          model: inheritedModel,
+          terminalBuffer: initialTerminalBuffer,
+          waiting: preparingDevshell,
+          ...(inheritedThinkingLevel
+            ? { thinkingLevel: inheritedThinkingLevel }
+            : {}),
+          cwd,
+        };
+        if (targetBucketKey === activeBucketKey) {
+          setState((prev) => {
+            const tabs = ((prev.tabs as Tab[] | undefined) ?? []).slice();
+            tabs.push(tab);
+            return {
+              ...prev,
+              tabs,
+              empty: false,
+              hasTabs: true,
+            };
+          });
+        } else {
+          const existing = tabBucketsRef.current.get(targetBucketKey);
+          const bucket: TabBucket = {
+            tabs: [...(existing?.tabs ?? []), tab],
+            activeTabId: tab.id,
+          };
+          tabBucketsRef.current.set(targetBucketKey, bucket);
+          setState((prev) => ({
+            ...prev,
+            persistedTabBuckets: mirrorPersistedBuckets(
+              tabBucketsRef,
+              activeBucketKey,
+            ),
+          }));
+        }
+        const opening = (async () => {
+          if (cwd) {
+            await invoke("devshell_prepare_for_path", {
+              args: { cwd, includeEnv: false },
+            }).catch(() => undefined);
+            setState((prev) => {
+              const clearWaiting = (candidate: Tab): Tab =>
+                candidate.id === tabId && candidate.waiting === true
+                  ? { ...candidate, waiting: false }
+                  : candidate;
+              const tabs = ((prev.tabs as Tab[] | undefined) ?? []).map(
+                clearWaiting,
+              );
+              const bucket = tabBucketsRef.current.get(targetBucketKey);
+              if (bucket) {
+                tabBucketsRef.current.set(targetBucketKey, {
+                  ...bucket,
+                  tabs: bucket.tabs.map(clearWaiting),
+                });
+              }
+              return {
+                ...prev,
+                tabs,
+                persistedTabBuckets: mirrorPersistedBuckets(
+                  tabBucketsRef,
+                  activeBucketKey,
+                ),
+              };
+            });
+          }
+          return await invoke("agent_command", {
+            payload: JSON.stringify({
+              type: "tab_open",
+              tabId,
+              ...(inheritedModel ? { model: inheritedModel } : {}),
+              ...(inheritedThinkingLevel
+                ? { thinkingLevel: inheritedThinkingLevel }
+                : {}),
+              cwd,
+            }),
+          });
+        })();
+        pendingTabOpens.current.set(tabId, opening);
+        opening
+          .catch((err) => {
+            pushNotificationRef.current({
+              title: "Could not start task",
+              message: `Failed to open background tab: ${err}`,
+              kind: "warning",
+            });
+          })
+          .finally(() => {
+            pendingTabOpens.current.delete(tabId);
+          });
+      }
       const opening = pendingTabOpens.current.get(tabId);
       if (opening) {
         try {
@@ -132,16 +331,21 @@ export function useTaskLauncher({
           ...(opts.bridgePrompt ? { bridgeText: opts.bridgePrompt } : {}),
         });
       }
+      return { tabId, projectId: opts.projectId, cwd, activated: shouldActivate };
     },
     [
       activateWorkspace,
       createWorkspaceWithParams,
       newTab,
       pendingTabOpens,
+      piDefaultModelRef,
       projectsRef,
       pushNotificationRef,
       sendChat,
       setActiveProjectById,
+      setState,
+      stateRef,
+      tabBucketsRef,
     ],
   );
 }

--- a/src/hooks/useTaskLauncher.ts
+++ b/src/hooks/useTaskLauncher.ts
@@ -104,14 +104,17 @@ function mirrorPersistedBuckets(
 function countKnownTabs(
   stateRef: MutableRefObject<Record<string, unknown>>,
   tabBucketsRef: MutableRefObject<Map<string, TabBucket>>,
+  activeBucketKey: string,
 ): number {
-  const activeCount = ((stateRef.current.tabs as Tab[] | undefined) ?? [])
-    .length;
-  let hiddenCount = 0;
-  for (const bucket of tabBucketsRef.current.values()) {
-    hiddenCount += bucket.tabs.length;
+  const ids = new Set<string>();
+  for (const tab of (stateRef.current.tabs as Tab[] | undefined) ?? []) {
+    ids.add(tab.id);
   }
-  return activeCount + hiddenCount;
+  for (const [bucketKey, bucket] of tabBucketsRef.current.entries()) {
+    if (bucketKey === activeBucketKey) continue;
+    for (const tab of bucket.tabs) ids.add(tab.id);
+  }
+  return ids.size;
 }
 
 export function useTaskLauncher({
@@ -223,7 +226,8 @@ export function useTaskLauncher({
         const tab: Tab = {
           ...makeEmptyTab(
             tabId,
-            opts.label ?? `Tab ${countKnownTabs(stateRef, tabBucketsRef) + 1}`,
+            opts.label ??
+              `Tab ${countKnownTabs(stateRef, tabBucketsRef, activeBucketKey) + 1}`,
             opts.projectId,
           ),
           model: inheritedModel,

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -9199,6 +9199,11 @@ button.ae-vcs-chip:focus-visible {
 /* --------------------------------------------------------------------------
  * Subagent activity timeline (nested inside a `task` tool card).
  * ------------------------------------------------------------------------ */
+.ae-subagent-activity-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
 .ae-subagent-activity {
   display: flex;
   flex-direction: column;

--- a/website/guide/agents.md
+++ b/website/guide/agents.md
@@ -229,6 +229,18 @@ task({
 });
 ```
 
+For independent fan-out, the main agent uses `task_batch`:
+
+```ts
+task_batch({
+  surface: "inline", // default; use "background" only when requested
+  tasks: [
+    { subagent_type: "kimi", prompt: "<self-contained task>" },
+    { subagent_type: "glm-5-2", prompt: "<self-contained task>" },
+  ],
+});
+```
+
 There are two ways a subagent gets picked:
 
 - **Auto-delegation**: the system-prompt advertisement (generated from
@@ -237,7 +249,10 @@ There are two ways a subagent gets picked:
 - **Explicit invocation**: prefix a chat message with `@<name>` (for
   example `@reviewer`) to force delegation. Detection is case-insensitive;
   Aethon appends a one-shot steer telling the model to call `task`
-  immediately with that subagent's name.
+  immediately with that subagent's name. Multiple leading mentions such as
+  `@kimi and @glm-5-2 peer review` steer the model to `task_batch`. Words
+  like `async`, `background`, `don't wait`, or `separate tabs` request
+  non-focused background task tabs; otherwise fan-out runs inline.
 
 ### Inline vs tab surface
 

--- a/website/reference/runtime-api.md
+++ b/website/reference/runtime-api.md
@@ -75,7 +75,7 @@ separately via `aethon.onEvent({ componentType, descendantId }, handler)`
 
 | Call | Purpose |
 |---|---|
-| `aethon.tasks.start({ projectPath, prompt, newWorkspace?, branch?, baseBranch? })` | Start a dashboard task: optionally create a workspace, open an agent tab at the target cwd, and send the first prompt. |
+| `aethon.tasks.start({ projectPath, prompt, newWorkspace?, branch?, baseBranch?, model?, activate?, label? })` | Start a dashboard task: optionally create a workspace, open an agent tab at the target cwd, and send the first prompt. Set `activate: false` to launch without focusing/switching. |
 | `aethon.dashboard.getRepoOverview({ projectPath })` | Read the cached GitHub/repo overview used by the project dashboard. |
 | `aethon.dashboard.refresh({ projectPath? })` | Refresh dashboard data. |
 | `aethon.dashboard.listIssues({ projectPath, limit? })` | Return cached open issues for a project. |


### PR DESCRIPTION
## Summary
- add `task_batch` for concurrent inline subagent fan-out with partial-failure handling
- support explicit multi-mention steering and background/tab delegation wording
- launch background subagent tasks into non-focused active or stashed project buckets and route bridge updates by tab id
- render grouped subagent progress and document the updated runtime/task API

## Tests
- `bunx vitest run agent/subagents/task-tool.test.ts agent/subagents/steer.test.ts`
- `bunx vitest run src/hooks/useTaskLauncher.test.ts src/hooks/bridgeMessageHandlers/*.test.ts src/extensions/default-layout/tool-card.subagent.test.tsx`
- `bunx vitest run src/hooks/useTaskLauncher.test.ts src/hooks/useProjectOps.test.ts src/hooks/bridgeMessageHandlers/stashedTabs.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bunx vitest run`

## Review
- initial `codex review --base main` found helper staging, background workspace activation, and stashed-tab routing issues; all addressed
- attempted rerun was blocked by local Codex auth token revocation, after all fixes and gates passed
