### PR TITLE
fix: prevent subagent timeout crash loops

### DIFF
--- a/agent/subagents/task-tool.test.ts
+++ b/agent/subagents/task-tool.test.ts
@@ -565,6 +565,32 @@ describe("buildSubagentTaskTool", () => {
     expect(h.disposeSpy).toHaveBeenCalled();
   });
 
+  it("does not hang forever when timeout abort cleanup never settles", async () => {
+    vi.useFakeTimers();
+    h.promptImpl = () => new Promise<void>(() => {});
+    const { state } = makeState({
+      name: "reviewer",
+      model: "ollama/llama3.3",
+      timeoutSeconds: 1,
+    });
+    const tool = buildSubagentTaskTool(state, { send: vi.fn() }, "default");
+    const pending = execOf(tool)("c", {
+      subagent_type: "reviewer",
+      prompt: "x",
+    });
+    const rejection = expect(pending).rejects.toThrow(/timed out after 1s/);
+    await Promise.resolve();
+    h.abortSpy.mockImplementationOnce(() => new Promise<void>(() => {}));
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(h.abortSpy).toHaveBeenCalled();
+    expect(h.disposeSpy).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(2000);
+    await rejection;
+    expect(h.disposeSpy).toHaveBeenCalled();
+  });
+
   it("launches a tab for surface: tab subagents", async () => {
     const start = vi.fn(() =>
       Promise.resolve({ ok: true, data: { tabId: "t2" } }),

--- a/agent/subagents/task-tool.ts
+++ b/agent/subagents/task-tool.ts
@@ -49,6 +49,7 @@ import {
 } from "../file-references";
 /** Cap on the text returned to the parent (and streamed partials). */
 const MAX_RESULT_CHARS = 100_000;
+const ABORT_CLEANUP_GRACE_MS = 2_000;
 type RequestedTaskSurface = "inline" | "background" | "auto";
 type ExecutionSurface = "inline" | "tab" | "background";
 
@@ -582,7 +583,7 @@ async function runInlineSubagent(
   } finally {
     signal?.removeEventListener("abort", onAbort);
     if (abortPromise) {
-      await abortPromise;
+      await waitForAbortCleanup(abortPromise, sub.name);
     }
     unsubscribe();
     try {
@@ -608,6 +609,31 @@ async function runInlineSubagent(
     content: [{ type: "text", text: text.slice(0, MAX_RESULT_CHARS) }],
     details,
   };
+}
+
+async function waitForAbortCleanup(
+  abortPromise: Promise<void>,
+  subagentName: string,
+): Promise<void> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<"timeout">((resolve) => {
+    timeout = setTimeout(
+      () => resolve("timeout"),
+      ABORT_CLEANUP_GRACE_MS,
+    );
+  });
+  const result = await Promise.race([
+    abortPromise.then(() => "settled" as const),
+    timeoutPromise,
+  ]);
+  if (timeout) clearTimeout(timeout);
+  if (result === "timeout") {
+    logger
+      .scope("subagent")
+      .warn(
+        `abort did not settle within ${ABORT_CLEANUP_GRACE_MS}ms for "${subagentName}"; disposing session anyway`,
+      );
+  }
 }
 
 interface TasksApi {

--- a/src/hooks/osEdges/agentCrash.test.ts
+++ b/src/hooks/osEdges/agentCrash.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import {
+  selectAgentCrashDiagnostic,
+  summarizeRunningToolCrash,
+} from "./agentCrash";
+import type { Tab } from "../../types/tab";
+
+describe("agent crash diagnostics", () => {
+  it("prefers actionable crash lines over runtime version banners", () => {
+    expect(
+      selectAgentCrashDiagnostic(
+        [
+          "2026-06-18T14:34:20.000Z ERROR subagent: timed out after 600s",
+          "Bun v1.3.14 (macOS arm64)",
+        ],
+        "tab:abc",
+      ),
+    ).toContain("timed out after 600s");
+  });
+
+  it("falls back when the tail only contains a runtime banner", () => {
+    expect(
+      selectAgentCrashDiagnostic(["Bun v1.3.14 (macOS arm64)"], "tab:abc"),
+    ).toBe("Agent worker exited unexpectedly (tab:abc).");
+  });
+
+  it("summarizes the running task when a worker exits mid-tool", () => {
+    const tabs = [
+      {
+        id: "tab-1",
+        kind: "agent",
+        messages: [
+          {
+            id: "m1",
+            role: "agent",
+            a2ui: {
+              components: [
+                {
+                  id: "tool-1",
+                  type: "tool-card",
+                  props: {
+                    toolName: "task_batch",
+                    description: "kimi, glm-5-2 · inline",
+                    startedAt: 1000,
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ] as unknown as Tab[];
+
+    expect(summarizeRunningToolCrash(tabs, "tab-1")).toBe(
+      "task_batch kimi, glm-5-2 · inline",
+    );
+    expect(summarizeRunningToolCrash(tabs)).toBeUndefined();
+  });
+});

--- a/src/hooks/osEdges/agentCrash.ts
+++ b/src/hooks/osEdges/agentCrash.ts
@@ -19,6 +19,94 @@ export interface AgentCrashDeps {
   pushNotification: (n: NotificationInput) => string;
 }
 
+function defaultCrashDiagnostic(key?: string): string {
+  return key
+    ? `Agent worker exited unexpectedly (${key}).`
+    : "Agent worker exited unexpectedly.";
+}
+
+function normalizeTailLine(line: string): string {
+  return line.trim().replace(/^stdout:\s*/i, "").trim();
+}
+
+function isRuntimeBanner(line: string): boolean {
+  return (
+    /^Bun v\d+(?:\.\d+)*/i.test(line) ||
+    /^Node\.js v\d+(?:\.\d+)*/i.test(line)
+  );
+}
+
+function isActionableDiagnostic(line: string): boolean {
+  return /fatal|panic|error|failed|timed?\s*out|timeout|exception|crash|closed unexpectedly|aborted/i.test(
+    line,
+  );
+}
+
+export function selectAgentCrashDiagnostic(
+  tail: readonly string[],
+  key?: string,
+): string {
+  const candidates = [...tail]
+    .reverse()
+    .map(normalizeTailLine)
+    .filter((line) => line.length > 0 && !isRuntimeBanner(line));
+  return (
+    candidates.find(isActionableDiagnostic) ??
+    candidates[0] ??
+    defaultCrashDiagnostic(key)
+  );
+}
+
+function summarizeRunningToolComponent(
+  component: {
+    type?: unknown;
+    props?: Record<string, unknown>;
+    children?: unknown[];
+  },
+): string | undefined {
+  if (
+    component.type === "tool-card" &&
+    component.props?.startedAt !== undefined &&
+    component.props.endedAt === undefined
+  ) {
+    const toolName = String(
+      component.props.toolName ?? component.props.title ?? "tool",
+    ).trim();
+    const description =
+      typeof component.props.description === "string"
+        ? component.props.description.trim()
+        : "";
+    return [toolName, description].filter(Boolean).join(" ");
+  }
+  for (const child of component.children ?? []) {
+    if (!child || typeof child !== "object") continue;
+    const summary = summarizeRunningToolComponent(child);
+    if (summary) return summary;
+  }
+  return undefined;
+}
+
+export function summarizeRunningToolCrash(
+  tabs: readonly Tab[] | undefined,
+  crashedTabId?: string,
+): string | undefined {
+  if (!crashedTabId) return undefined;
+  const matchingTabs = (tabs ?? []).filter(
+    (tab) =>
+      (tab.kind ?? "agent") === "agent" &&
+      tab.id === crashedTabId,
+  );
+  for (const tab of matchingTabs) {
+    for (const message of tab.messages ?? []) {
+      for (const component of message.a2ui?.components ?? []) {
+        const summary = summarizeRunningToolComponent(component);
+        if (summary) return summary;
+      }
+    }
+  }
+  return undefined;
+}
+
 /** P5 bridge crash recovery. The Rust supervisor emits this when the
  *  bun child exits unexpectedly (intentional hot-reload kills go
  *  through `agent-reloaded` instead). Clears per-tab waiting state,
@@ -72,12 +160,14 @@ export function subscribeAgentCrash(deps: AgentCrashDeps): () => void {
         ? event.payload.tabId
         : undefined;
     const globalOnlyCrash = !crashedTabId && crashedKey === "__global__";
-    const lastLine =
-      tail.length > 0
-        ? tail[tail.length - 1]
-        : crashedKey
-          ? `agent stdout closed unexpectedly (${crashedKey})`
-          : "agent stdout closed unexpectedly";
+    const diagnostic = selectAgentCrashDiagnostic(tail, crashedKey);
+    const runningTool = summarizeRunningToolCrash(
+      (stateRef.current.tabs as Tab[] | undefined) ?? [],
+      crashedTabId,
+    );
+    const crashMessage = runningTool
+      ? `${runningTool} did not finish before the agent worker exited. ${diagnostic}`
+      : diagnostic;
     activeResponseIdRef.current = null;
     if (crashedTabId) {
       const h = hangWarnTimersRef.current.get(crashedTabId);
@@ -98,7 +188,7 @@ export function subscribeAgentCrash(deps: AgentCrashDeps): () => void {
         if (globalOnlyCrash) return t;
         if (crashedTabId && t.id !== crashedTabId) return t;
         const closedTools = closeRunningToolCards(t.messages, {
-          notice: "Tool call did not finish before the agent crashed.",
+          notice: crashMessage,
         });
         return {
           ...t,
@@ -139,7 +229,7 @@ export function subscribeAgentCrash(deps: AgentCrashDeps): () => void {
     pushNotification({
       id: notificationId,
       title: "Agent process exited unexpectedly",
-      message: lastLine.slice(0, 200),
+      message: crashMessage.slice(0, 240),
       kind: "error",
       // Keep visible until dismissed or restart succeeds — a transient
       // toast would race a user away from the keyboard while a long


### PR DESCRIPTION
## Summary
- bound inline subagent abort cleanup so a timed-out subagent cannot leave `task`/`task_batch` promises stuck forever
- improve agent-crash notifications to ignore runtime version banners like `Bun v...` and include the running tool context when a worker exits mid-tool
- add regressions for stuck subagent abort cleanup and crash-tail diagnostics

## Root Cause
When an inline subagent hit its timeout, Aethon called `session.abort()` and then awaited that abort promise unbounded in `finally`. If the provider/SDK abort never settled, the parent `task_batch` tool never resolved or rejected back to pi. The parent turn then could not emit `tool_execution_end` or `response_end`, so the worker appeared to crash/reload and the frontend closed the still-running tool card as cancelled. The crash toast then used the last raw stderr/stdout tail line, which could be a low-signal runtime banner such as `Bun v1.3.14`.

## Validation
- `bunx vitest run agent/subagents/task-tool.test.ts`
- `bunx vitest run src/hooks/osEdges/agentCrash.test.ts`
- `bunx vitest run src/hooks/osEdges/agentCrash.test.ts src/hooks/osEdges/agentStderr.test.ts src/hooks/osEdges/shellStreams.test.ts src/hooks/bridgeMessageHandlers/responseEnd.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bunx vitest run`
- `git diff --check`
