### PR TITLE
feat: add workspace startup commands

### DIFF
--- a/docs/aethon-agent/project-config.md
+++ b/docs/aethon-agent/project-config.md
@@ -2,6 +2,38 @@
 
 Aethon can read lightweight project-local configuration from a repository's `.aethon/` directory. These files travel with the repo and do not require shipping a UI extension.
 
+## Workspace startup commands
+
+Agent tabs opened in a project or workspace run startup work for that root before the agent session starts. Aethon prepares the devshell/env provider first, then runs approved commands from `<project>/.aethon/startup.toml`.
+
+Commands are required by default, run once per root per app launch, and changed command config requires approval again.
+
+```toml
+[startup]
+timeout_seconds = 600
+
+[[startup.commands]]
+id = "deps"
+label = "Install dependencies"
+command = "bun install"
+
+[[startup.commands]]
+id = "codegen"
+label = "Generate local types"
+command = "bun run codegen"
+required = false
+timeout_seconds = 120
+```
+
+Fields:
+
+- `[startup].timeout_seconds` — default command timeout in seconds.
+- `id` — stable command id; defaults to `command-N`.
+- `label` — task label; defaults to `id`.
+- `command` — shell command run from the workspace root.
+- `required` — failure blocks startup unless `false`; defaults to `true`.
+- `timeout_seconds` — per-command timeout.
+
 ## Issue-to-agent templates
 
 The project dashboard's **Open issues** section reads optional templates from `<project>/.aethon/issues.toml`.

--- a/docs/project-config.md
+++ b/docs/project-config.md
@@ -2,6 +2,47 @@
 
 Aethon can read lightweight project-local configuration from a repository's `.aethon/` directory. These files travel with the repo and do not require shipping a UI extension.
 
+## Workspace startup commands
+
+Agent tabs opened in a project or workspace run the startup sequence for that root before the agent session starts. Aethon first prepares the configured devshell/env provider, then runs approved commands from:
+
+```text
+<project>/.aethon/startup.toml
+```
+
+Startup commands are required by default. Required failures block agent startup and show Retry / Continue controls; optional failures are shown but do not block. Commands run once per root per app launch, and changed startup config must be approved again before commands run.
+
+```toml
+[startup]
+timeout_seconds = 600
+
+[[startup.commands]]
+id = "deps"
+label = "Install dependencies"
+command = "bun install"
+
+[[startup.commands]]
+id = "codegen"
+label = "Generate local types"
+command = "bun run codegen"
+required = false
+timeout_seconds = 120
+```
+
+### Startup fields
+
+The top-level `[startup]` table supports:
+
+- `timeout_seconds` — default timeout for commands in this file. Defaults to 600 seconds and is capped at 24 hours.
+
+Each `[[startup.commands]]` entry supports:
+
+- `id` — stable command id for UI state. Defaults to `command-N` when omitted.
+- `label` — human-readable task label. Defaults to `id`.
+- `command` — shell command to run from the workspace root. Required.
+- `required` — when `false`, failure is visible but non-blocking. Defaults to `true`.
+- `timeout_seconds` — per-command timeout. Defaults to `[startup].timeout_seconds`.
+
 ## Issue-to-agent templates
 
 The project dashboard's **Open issues** section reads optional templates from:

--- a/e2e/support/aethon-harness.ts
+++ b/e2e/support/aethon-harness.ts
@@ -337,6 +337,22 @@ export async function installAethonHarness(page: Page): Promise<void> {
           case "set_extension_menu_items":
           case "start_agent":
             return undefined;
+          case "workspace_startup_prepare_for_path": {
+            const cwdArgs =
+              args.args && typeof args.args === "object"
+                ? (args.args as Record<string, unknown>)
+                : args;
+            const root = stringArg(cwdArgs.cwd, projectRoot);
+            return {
+              root,
+              fingerprint: "e2e-no-startup-config",
+              state: "disabled",
+              approved: true,
+              commands: [],
+              warning: null,
+              reason: null,
+            };
+          }
           case "agent_command": {
             const parsed: unknown = JSON.parse(stringArg(args.payload, "{}"));
             const payload =

--- a/src-tauri/src/agent_commands.rs
+++ b/src-tauri/src/agent_commands.rs
@@ -94,7 +94,6 @@ pub(crate) async fn send_message(
     let key = route_payload_key(&state, &payload);
     let worker = worker_for_payload(&key, &payload, true);
     prepare_worker_startup(&app, &startup, &devshell, worker.as_ref()).await?;
-    prepare_worker_devshell(&app, &devshell, worker.as_ref()).await?;
     write_agent_payload(&state, &app, key, payload, worker).await
 }
 
@@ -245,7 +244,6 @@ pub(crate) async fn agent_command(
     let should_retire = payload_value.get("type").and_then(|v| v.as_str()) == Some("tab_close")
         && key != GLOBAL_AGENT_KEY;
     prepare_worker_startup(&app, &startup, &devshell, worker.as_ref()).await?;
-    prepare_worker_devshell(&app, &devshell, worker.as_ref()).await?;
     write_agent_payload(&state, &app, key.clone(), payload_value, worker).await?;
     if should_retire {
         retire_agent_key(&state, &key)?;
@@ -266,69 +264,6 @@ async fn prepare_worker_startup(
         return Ok(());
     };
     crate::commands::startup::ensure_workspace_startup_ready(app, startup, devshell, cwd).await
-}
-
-async fn prepare_worker_devshell(
-    app: &AppHandle,
-    cache: &Arc<DevshellCache>,
-    worker: Option<&AgentWorker>,
-) -> Result<(), String> {
-    let Some(cwd) = worker
-        .and_then(|w| w.cwd.as_deref())
-        .filter(|cwd| !cwd.is_empty())
-    else {
-        return Ok(());
-    };
-    let cwd = PathBuf::from(cwd);
-    let (enabled, configured_mode) = crate::commands::devshell::effective_config(app, &cwd);
-    if enabled == "never" {
-        return Ok(());
-    }
-    if let Some(reason) =
-        crate::commands::devshell::forced_mode_mismatch_reason(&cwd, configured_mode)
-    {
-        return Err(format!("devshell prepare: {reason}"));
-    }
-    let Some(kind) = crate::devshell::detect_mode(&cwd, configured_mode) else {
-        let reason = format!("no devshell detected at {}", cwd.display());
-        if let Some(error) =
-            crate::commands::devshell::required_devshell_missing_error(&enabled, reason)
-        {
-            return Err(format!("devshell prepare: {error}"));
-        }
-        return Ok(());
-    };
-    if kind.as_str() == "direnv"
-        && let Err(reason) = crate::commands::devshell::direnv_allow(&cwd).await
-    {
-        if crate::commands::devshell::devshell_prepare_is_required(&enabled) {
-            return Err(reason);
-        }
-        tracing::warn!(
-            target: "aethon::devshell",
-            "agent worker devshell direnv allow failed for {}: {reason}; opening host worker",
-            cwd.display()
-        );
-        return Ok(());
-    }
-    let emitter = crate::commands::devshell::emitter_for(app);
-    match cache
-        .prepare_for(Some(&emitter), &cwd, configured_mode)
-        .await
-    {
-        Ok(_) => Ok(()),
-        Err(reason) => {
-            if crate::commands::devshell::devshell_prepare_is_required(&enabled) {
-                return Err(format!("devshell prepare: {reason}"));
-            }
-            tracing::warn!(
-                target: "aethon::devshell",
-                "agent worker devshell prepare failed for {}: {reason}; opening host worker",
-                cwd.display()
-            );
-            Ok(())
-        }
-    }
 }
 
 /// Forward a JSON payload to every currently running agent worker without

--- a/src-tauri/src/agent_commands.rs
+++ b/src-tauri/src/agent_commands.rs
@@ -58,6 +58,7 @@ pub(crate) async fn send_message(
     request: SendMessageRequest,
     state: State<'_, AgentProcesses>,
     devshell: State<'_, Arc<DevshellCache>>,
+    startup: State<'_, crate::commands::startup::WorkspaceStartupState>,
     app: AppHandle,
 ) -> Result<(), String> {
     let tab_id = request.tab_id.unwrap_or_else(|| "default".to_string());
@@ -92,6 +93,7 @@ pub(crate) async fn send_message(
 
     let key = route_payload_key(&state, &payload);
     let worker = worker_for_payload(&key, &payload, true);
+    prepare_worker_startup(&app, &startup, &devshell, worker.as_ref()).await?;
     prepare_worker_devshell(&app, &devshell, worker.as_ref()).await?;
     write_agent_payload(&state, &app, key, payload, worker).await
 }
@@ -233,6 +235,7 @@ pub(crate) async fn agent_command(
     payload: String,
     state: State<'_, AgentProcesses>,
     devshell: State<'_, Arc<DevshellCache>>,
+    startup: State<'_, crate::commands::startup::WorkspaceStartupState>,
     app: AppHandle,
 ) -> Result<(), String> {
     let payload_value: serde_json::Value =
@@ -241,12 +244,28 @@ pub(crate) async fn agent_command(
     let worker = worker_for_payload(&key, &payload_value, true);
     let should_retire = payload_value.get("type").and_then(|v| v.as_str()) == Some("tab_close")
         && key != GLOBAL_AGENT_KEY;
+    prepare_worker_startup(&app, &startup, &devshell, worker.as_ref()).await?;
     prepare_worker_devshell(&app, &devshell, worker.as_ref()).await?;
     write_agent_payload(&state, &app, key.clone(), payload_value, worker).await?;
     if should_retire {
         retire_agent_key(&state, &key)?;
     }
     Ok(())
+}
+
+async fn prepare_worker_startup(
+    app: &AppHandle,
+    startup: &crate::commands::startup::WorkspaceStartupState,
+    devshell: &Arc<DevshellCache>,
+    worker: Option<&AgentWorker>,
+) -> Result<(), String> {
+    let Some(cwd) = worker
+        .and_then(|w| w.cwd.as_deref())
+        .filter(|cwd| !cwd.is_empty())
+    else {
+        return Ok(());
+    };
+    crate::commands::startup::ensure_workspace_startup_ready(app, startup, devshell, cwd).await
 }
 
 async fn prepare_worker_devshell(

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -28,6 +28,7 @@ pub mod git;
 pub mod host;
 pub mod server;
 pub mod session;
+pub mod startup;
 pub mod subagents;
 pub mod updater;
 pub mod voice;

--- a/src-tauri/src/commands/startup.rs
+++ b/src-tauri/src/commands/startup.rs
@@ -1,0 +1,1132 @@
+//! Project/workspace startup command support.
+//!
+//! The implementation lives here because startup commands need the same
+//! OS-near process control and launch-safe PATH handling as devshell
+//! preparation, while the frontend only needs a compact IPC/event surface.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use sha1::{Digest, Sha1};
+use tauri::{AppHandle, Emitter, Manager, State};
+use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
+use tokio::sync::Mutex as AsyncMutex;
+
+use crate::devshell::DevshellCache;
+
+const STARTUP_CONFIG_MAX_BYTES: usize = 64 * 1024;
+const STARTUP_APPROVALS_FILE: &str = "startup-approvals.json";
+const STARTUP_DEFAULT_TIMEOUT_SECONDS: u64 = 600;
+const STARTUP_MAX_TIMEOUT_SECONDS: u64 = 24 * 60 * 60;
+const STARTUP_DEVSHELL_TASK_ID: &str = "aethon-devshell";
+const STARTUP_DEVSHELL_TASK_LABEL: &str = "Prepare environment";
+
+#[derive(Default)]
+pub struct WorkspaceStartupState {
+    locks: parking_lot::Mutex<BTreeMap<PathBuf, Arc<AsyncMutex<()>>>>,
+    records: parking_lot::Mutex<BTreeMap<PathBuf, StartupRecord>>,
+}
+
+#[derive(Debug, Clone)]
+struct StartupRecord {
+    fingerprint: String,
+    state: StartupState,
+    reason: Option<String>,
+    active_task_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum StartupState {
+    Ready,
+    ApprovalRequired,
+    Running,
+    Failed,
+    Continued,
+}
+
+impl StartupState {
+    fn as_str(&self) -> &'static str {
+        match self {
+            StartupState::Ready => "ready",
+            StartupState::ApprovalRequired => "approval_required",
+            StartupState::Running => "running",
+            StartupState::Failed => "failed",
+            StartupState::Continued => "continued",
+        }
+    }
+}
+
+impl WorkspaceStartupState {
+    fn root_lock(&self, root: &Path) -> Arc<AsyncMutex<()>> {
+        let mut locks = self.locks.lock();
+        Arc::clone(
+            locks
+                .entry(root.to_path_buf())
+                .or_insert_with(|| Arc::new(AsyncMutex::new(()))),
+        )
+    }
+
+    fn record(&self, root: &Path) -> Option<StartupRecord> {
+        self.records.lock().get(root).cloned()
+    }
+
+    fn set_record(&self, root: &Path, record: StartupRecord) {
+        self.records.lock().insert(root.to_path_buf(), record);
+    }
+
+    fn clear_record(&self, root: &Path) {
+        self.records.lock().remove(root);
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StartupConfig {
+    pub timeout_seconds: u64,
+    pub commands: Vec<StartupCommandConfig>,
+    pub warning: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StartupCommandConfig {
+    pub id: String,
+    pub label: String,
+    pub command: String,
+    pub required: bool,
+    pub timeout_seconds: u64,
+}
+
+#[derive(Default, Deserialize)]
+struct RawStartupToml {
+    #[serde(default)]
+    startup: RawStartupSection,
+}
+
+#[derive(Default, Deserialize)]
+struct RawStartupSection {
+    timeout_seconds: Option<u64>,
+    commands: Option<Vec<RawStartupCommand>>,
+}
+
+#[derive(Default, Deserialize)]
+struct RawStartupCommand {
+    id: Option<String>,
+    label: Option<String>,
+    command: Option<String>,
+    required: Option<bool>,
+    timeout_seconds: Option<u64>,
+}
+
+pub(crate) fn parse_startup_config(input: &str) -> StartupConfig {
+    let parsed = if input.trim().is_empty() {
+        RawStartupToml::default()
+    } else {
+        toml::from_str::<RawStartupToml>(input).unwrap_or_default()
+    };
+    let timeout_seconds = normalize_timeout(parsed.startup.timeout_seconds);
+    let mut warnings = Vec::new();
+    let commands = parsed
+        .startup
+        .commands
+        .unwrap_or_default()
+        .into_iter()
+        .enumerate()
+        .filter_map(|(idx, raw)| {
+            let command = raw.command.unwrap_or_default().trim().to_string();
+            if command.is_empty() {
+                warnings.push(format!(
+                    "Skipped startup command {} because command is missing",
+                    idx + 1
+                ));
+                return None;
+            }
+            let id = raw
+                .id
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| format!("command-{}", idx + 1));
+            let label = raw
+                .label
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| id.clone());
+            Some(StartupCommandConfig {
+                id,
+                label,
+                command,
+                required: raw.required.unwrap_or(true),
+                timeout_seconds: normalize_timeout(raw.timeout_seconds.or(Some(timeout_seconds))),
+            })
+        })
+        .collect();
+    StartupConfig {
+        timeout_seconds,
+        commands,
+        warning: (!warnings.is_empty()).then(|| warnings.join("; ")),
+    }
+}
+
+fn normalize_timeout(value: Option<u64>) -> u64 {
+    value
+        .filter(|n| *n > 0)
+        .unwrap_or(STARTUP_DEFAULT_TIMEOUT_SECONDS)
+        .min(STARTUP_MAX_TIMEOUT_SECONDS)
+}
+
+pub(crate) fn startup_fingerprint(config: &StartupConfig) -> String {
+    let mut hasher = Sha1::new();
+    hasher.update(b"aethon-startup:v1");
+    hasher.update(config.timeout_seconds.to_le_bytes());
+    for command in &config.commands {
+        hasher.update(command.id.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(command.label.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(command.command.as_bytes());
+        hasher.update(b"\0");
+        hasher.update([u8::from(command.required)]);
+        hasher.update(command.timeout_seconds.to_le_bytes());
+    }
+    hex_sha1(hasher.finalize().as_slice())
+}
+
+fn hex_sha1(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        out.push_str(&format!("{b:02x}"));
+    }
+    out
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StartupPathArgs {
+    pub root: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StartupPrepareArgs {
+    pub cwd: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StartupApproveArgs {
+    pub root: String,
+    pub fingerprint: String,
+}
+
+#[derive(Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct StartupTaskStatus {
+    pub id: String,
+    pub label: String,
+    pub required: bool,
+    pub state: String,
+}
+
+#[derive(Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct StartupStatusResponse {
+    pub root: String,
+    pub fingerprint: String,
+    pub state: String,
+    pub approved: bool,
+    pub commands: Vec<StartupTaskStatus>,
+    pub warning: Option<String>,
+    pub reason: Option<String>,
+}
+
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct StartupEvent {
+    root: String,
+    fingerprint: String,
+    state: String,
+    task_id: Option<String>,
+    task_label: Option<String>,
+    required: Option<bool>,
+    message: Option<String>,
+    reason: Option<String>,
+}
+
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct StartupOutputEvent {
+    root: String,
+    fingerprint: String,
+    task_id: String,
+    task_label: String,
+    stream: String,
+    content: String,
+}
+
+#[derive(Default, Serialize, Deserialize)]
+struct ApprovalStore {
+    approvals: BTreeMap<String, String>,
+}
+
+#[tauri::command]
+pub async fn workspace_startup_status(
+    app: AppHandle,
+    state: State<'_, WorkspaceStartupState>,
+    args: StartupPathArgs,
+) -> Result<StartupStatusResponse, String> {
+    let root = canonicalize_root(&PathBuf::from(args.root));
+    let config = read_startup_config(&root);
+    let fingerprint = startup_fingerprint(&config);
+    let approved = config.commands.is_empty() || approval_matches(&app, &root, &fingerprint)?;
+    let record = state.record(&root);
+    Ok(status_response(
+        &root,
+        &config,
+        &fingerprint,
+        approved,
+        record,
+    ))
+}
+
+#[tauri::command]
+pub async fn workspace_startup_approve(
+    app: AppHandle,
+    state: State<'_, WorkspaceStartupState>,
+    args: StartupApproveArgs,
+) -> Result<StartupStatusResponse, String> {
+    let root = canonicalize_root(&PathBuf::from(args.root));
+    let config = read_startup_config(&root);
+    let fingerprint = startup_fingerprint(&config);
+    if fingerprint != args.fingerprint {
+        return Err("startup config changed; review the updated commands".to_string());
+    }
+    write_approval(&app, &root, &fingerprint)?;
+    state.clear_record(&root);
+    emit_startup_event(
+        &app,
+        StartupEvent {
+            root: root.display().to_string(),
+            fingerprint: fingerprint.clone(),
+            state: "approved".to_string(),
+            task_id: None,
+            task_label: None,
+            required: None,
+            message: Some("Startup commands approved".to_string()),
+            reason: None,
+        },
+    );
+    Ok(status_response(&root, &config, &fingerprint, true, None))
+}
+
+#[tauri::command]
+pub async fn workspace_startup_continue(
+    app: AppHandle,
+    state: State<'_, WorkspaceStartupState>,
+    args: StartupApproveArgs,
+) -> Result<StartupStatusResponse, String> {
+    let root = canonicalize_root(&PathBuf::from(args.root));
+    let config = read_startup_config(&root);
+    let fingerprint = startup_fingerprint(&config);
+    if fingerprint != args.fingerprint {
+        return Err("startup config changed; review the updated commands".to_string());
+    }
+    state.set_record(
+        &root,
+        StartupRecord {
+            fingerprint: fingerprint.clone(),
+            state: StartupState::Continued,
+            reason: Some("continued by user".to_string()),
+            active_task_id: None,
+        },
+    );
+    emit_startup_event(
+        &app,
+        StartupEvent {
+            root: root.display().to_string(),
+            fingerprint: fingerprint.clone(),
+            state: "continued".to_string(),
+            task_id: None,
+            task_label: None,
+            required: None,
+            message: Some("Continuing without completed startup commands".to_string()),
+            reason: Some("continued by user".to_string()),
+        },
+    );
+    let approved = config.commands.is_empty() || approval_matches(&app, &root, &fingerprint)?;
+    Ok(status_response(
+        &root,
+        &config,
+        &fingerprint,
+        approved,
+        state.record(&root),
+    ))
+}
+
+#[tauri::command]
+pub async fn workspace_startup_retry(
+    app: AppHandle,
+    startup: State<'_, WorkspaceStartupState>,
+    devshell: State<'_, Arc<DevshellCache>>,
+    args: StartupPathArgs,
+) -> Result<StartupStatusResponse, String> {
+    let root = canonicalize_root(&PathBuf::from(&args.root));
+    startup.clear_record(&root);
+    prepare_workspace_startup(&app, &startup, &devshell, &root).await
+}
+
+#[tauri::command]
+pub async fn workspace_startup_prepare_for_path(
+    app: AppHandle,
+    startup: State<'_, WorkspaceStartupState>,
+    devshell: State<'_, Arc<DevshellCache>>,
+    args: StartupPrepareArgs,
+) -> Result<StartupStatusResponse, String> {
+    let root = canonicalize_root(&PathBuf::from(args.cwd));
+    prepare_workspace_startup(&app, &startup, &devshell, &root).await
+}
+
+pub(crate) async fn ensure_workspace_startup_ready(
+    app: &AppHandle,
+    startup: &WorkspaceStartupState,
+    devshell: &Arc<DevshellCache>,
+    cwd: &str,
+) -> Result<(), String> {
+    let root = canonicalize_root(&PathBuf::from(cwd));
+    let response = prepare_workspace_startup_inner(app, startup, devshell, &root).await?;
+    match response.state.as_str() {
+        "ready" | "continued" | "disabled" => Ok(()),
+        "approval_required" => Err(format!(
+            "workspace startup approval required for {}",
+            root.display()
+        )),
+        "failed" => Err(format!(
+            "workspace startup failed for {}{}",
+            root.display(),
+            response
+                .reason
+                .as_deref()
+                .map(|reason| format!(": {reason}"))
+                .unwrap_or_default()
+        )),
+        other => Err(format!("workspace startup not ready ({other})")),
+    }
+}
+
+async fn prepare_workspace_startup(
+    app: &AppHandle,
+    startup: &WorkspaceStartupState,
+    devshell: &Arc<DevshellCache>,
+    root: &Path,
+) -> Result<StartupStatusResponse, String> {
+    prepare_workspace_startup_inner(app, startup, devshell, root).await
+}
+
+async fn prepare_workspace_startup_inner(
+    app: &AppHandle,
+    startup: &WorkspaceStartupState,
+    devshell: &Arc<DevshellCache>,
+    root: &Path,
+) -> Result<StartupStatusResponse, String> {
+    let lock = startup.root_lock(root);
+    let _guard = lock.lock().await;
+
+    let config = read_startup_config(root);
+    let fingerprint = startup_fingerprint(&config);
+    let approved = config.commands.is_empty() || approval_matches(app, root, &fingerprint)?;
+    if let Some(record) = startup.record(root)
+        && record.fingerprint == fingerprint
+        && matches!(record.state, StartupState::Ready | StartupState::Continued)
+    {
+        return Ok(status_response(
+            root,
+            &config,
+            &fingerprint,
+            approved,
+            Some(record),
+        ));
+    }
+
+    startup.set_record(
+        root,
+        StartupRecord {
+            fingerprint: fingerprint.clone(),
+            state: StartupState::Running,
+            reason: None,
+            active_task_id: Some(STARTUP_DEVSHELL_TASK_ID.to_string()),
+        },
+    );
+    emit_startup_event(
+        app,
+        StartupEvent {
+            root: root.display().to_string(),
+            fingerprint: fingerprint.clone(),
+            state: "running".to_string(),
+            task_id: Some(STARTUP_DEVSHELL_TASK_ID.to_string()),
+            task_label: Some(STARTUP_DEVSHELL_TASK_LABEL.to_string()),
+            required: Some(false),
+            message: Some("Preparing workspace environment".to_string()),
+            reason: None,
+        },
+    );
+    let devshell_env = match prepare_devshell_env(app, devshell, root).await {
+        Ok(env) => env,
+        Err(reason) => {
+            let record = StartupRecord {
+                fingerprint: fingerprint.clone(),
+                state: StartupState::Failed,
+                reason: Some(reason.clone()),
+                active_task_id: Some(STARTUP_DEVSHELL_TASK_ID.to_string()),
+            };
+            startup.set_record(root, record.clone());
+            emit_startup_event(
+                app,
+                StartupEvent {
+                    root: root.display().to_string(),
+                    fingerprint: fingerprint.clone(),
+                    state: "failed".to_string(),
+                    task_id: Some(STARTUP_DEVSHELL_TASK_ID.to_string()),
+                    task_label: Some(STARTUP_DEVSHELL_TASK_LABEL.to_string()),
+                    required: Some(false),
+                    message: Some("Workspace environment failed".to_string()),
+                    reason: Some(reason),
+                },
+            );
+            return Ok(status_response(
+                root,
+                &config,
+                &fingerprint,
+                approved,
+                Some(record),
+            ));
+        }
+    };
+    emit_startup_event(
+        app,
+        StartupEvent {
+            root: root.display().to_string(),
+            fingerprint: fingerprint.clone(),
+            state: "ready".to_string(),
+            task_id: Some(STARTUP_DEVSHELL_TASK_ID.to_string()),
+            task_label: Some(STARTUP_DEVSHELL_TASK_LABEL.to_string()),
+            required: Some(false),
+            message: Some("Workspace environment ready".to_string()),
+            reason: None,
+        },
+    );
+
+    if !approved {
+        let record = StartupRecord {
+            fingerprint: fingerprint.clone(),
+            state: StartupState::ApprovalRequired,
+            reason: Some("startup commands require approval".to_string()),
+            active_task_id: None,
+        };
+        startup.set_record(root, record.clone());
+        emit_startup_event(
+            app,
+            StartupEvent {
+                root: root.display().to_string(),
+                fingerprint: fingerprint.clone(),
+                state: "approval_required".to_string(),
+                task_id: None,
+                task_label: None,
+                required: None,
+                message: Some("Startup commands require approval".to_string()),
+                reason: record.reason.clone(),
+            },
+        );
+        return Ok(status_response(
+            root,
+            &config,
+            &fingerprint,
+            false,
+            Some(record),
+        ));
+    }
+
+    startup.set_record(
+        root,
+        StartupRecord {
+            fingerprint: fingerprint.clone(),
+            state: StartupState::Running,
+            reason: None,
+            active_task_id: None,
+        },
+    );
+
+    for command in &config.commands {
+        startup.set_record(
+            root,
+            StartupRecord {
+                fingerprint: fingerprint.clone(),
+                state: StartupState::Running,
+                reason: None,
+                active_task_id: Some(command.id.clone()),
+            },
+        );
+        emit_startup_event(
+            app,
+            StartupEvent {
+                root: root.display().to_string(),
+                fingerprint: fingerprint.clone(),
+                state: "running".to_string(),
+                task_id: Some(command.id.clone()),
+                task_label: Some(command.label.clone()),
+                required: Some(command.required),
+                message: Some(format!("Running {}", command.label)),
+                reason: None,
+            },
+        );
+        let result = run_startup_command(app, root, &fingerprint, command, &devshell_env).await;
+        match result {
+            Ok(()) => emit_startup_event(
+                app,
+                StartupEvent {
+                    root: root.display().to_string(),
+                    fingerprint: fingerprint.clone(),
+                    state: "ready".to_string(),
+                    task_id: Some(command.id.clone()),
+                    task_label: Some(command.label.clone()),
+                    required: Some(command.required),
+                    message: Some(format!("{} completed", command.label)),
+                    reason: None,
+                },
+            ),
+            Err(reason) if command.required => {
+                let record = StartupRecord {
+                    fingerprint: fingerprint.clone(),
+                    state: StartupState::Failed,
+                    reason: Some(reason.clone()),
+                    active_task_id: Some(command.id.clone()),
+                };
+                startup.set_record(root, record.clone());
+                emit_startup_event(
+                    app,
+                    StartupEvent {
+                        root: root.display().to_string(),
+                        fingerprint: fingerprint.clone(),
+                        state: "failed".to_string(),
+                        task_id: Some(command.id.clone()),
+                        task_label: Some(command.label.clone()),
+                        required: Some(command.required),
+                        message: Some(format!("{} failed", command.label)),
+                        reason: Some(reason),
+                    },
+                );
+                return Ok(status_response(
+                    root,
+                    &config,
+                    &fingerprint,
+                    true,
+                    Some(record),
+                ));
+            }
+            Err(reason) => emit_startup_event(
+                app,
+                StartupEvent {
+                    root: root.display().to_string(),
+                    fingerprint: fingerprint.clone(),
+                    state: "failed".to_string(),
+                    task_id: Some(command.id.clone()),
+                    task_label: Some(command.label.clone()),
+                    required: Some(command.required),
+                    message: Some(format!("{} failed; continuing", command.label)),
+                    reason: Some(reason),
+                },
+            ),
+        }
+    }
+
+    let record = StartupRecord {
+        fingerprint: fingerprint.clone(),
+        state: StartupState::Ready,
+        reason: None,
+        active_task_id: None,
+    };
+    startup.set_record(root, record.clone());
+    emit_startup_event(
+        app,
+        StartupEvent {
+            root: root.display().to_string(),
+            fingerprint: fingerprint.clone(),
+            state: "ready".to_string(),
+            task_id: None,
+            task_label: None,
+            required: None,
+            message: Some("Workspace startup complete".to_string()),
+            reason: None,
+        },
+    );
+    Ok(status_response(
+        root,
+        &config,
+        &fingerprint,
+        true,
+        Some(record),
+    ))
+}
+
+async fn prepare_devshell_env(
+    app: &AppHandle,
+    cache: &Arc<DevshellCache>,
+    root: &Path,
+) -> Result<BTreeMap<String, String>, String> {
+    let (enabled, configured_mode) = crate::commands::devshell::effective_config(app, root);
+    if enabled == "never" {
+        return Ok(BTreeMap::new());
+    }
+    if let Some(reason) =
+        crate::commands::devshell::forced_mode_mismatch_reason(root, configured_mode)
+    {
+        return Err(format!("devshell prepare: {reason}"));
+    }
+    let Some(kind) = crate::devshell::detect_mode(root, configured_mode) else {
+        let reason = format!("no devshell detected at {}", root.display());
+        if let Some(error) =
+            crate::commands::devshell::required_devshell_missing_error(&enabled, reason)
+        {
+            return Err(format!("devshell prepare: {error}"));
+        }
+        return Ok(BTreeMap::new());
+    };
+    if kind.as_str() == "direnv"
+        && let Err(reason) = crate::commands::devshell::direnv_allow(root).await
+    {
+        if crate::commands::devshell::devshell_prepare_is_required(&enabled) {
+            return Err(reason);
+        }
+        tracing::warn!(
+            target: "aethon::startup",
+            "startup devshell direnv allow failed for {}: {reason}; continuing with host env",
+            root.display()
+        );
+        return Ok(BTreeMap::new());
+    }
+    let emitter = crate::commands::devshell::emitter_for(app);
+    match cache
+        .prepare_for(Some(&emitter), root, configured_mode)
+        .await
+    {
+        Ok(prepared) => Ok(prepared.env),
+        Err(reason) => {
+            if crate::commands::devshell::devshell_prepare_is_required(&enabled) {
+                Err(format!("devshell prepare: {reason}"))
+            } else {
+                tracing::warn!(
+                    target: "aethon::startup",
+                    "startup devshell prepare failed for {}: {reason}; continuing with host env",
+                    root.display()
+                );
+                Ok(BTreeMap::new())
+            }
+        }
+    }
+}
+
+async fn run_startup_command(
+    app: &AppHandle,
+    root: &Path,
+    fingerprint: &str,
+    cfg: &StartupCommandConfig,
+    devshell_env: &BTreeMap<String, String>,
+) -> Result<(), String> {
+    let mut command = shell_command(&cfg.command);
+    command
+        .current_dir(root)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    for (key, value) in devshell_env {
+        command.env(key, value);
+    }
+    let mut child = command
+        .spawn()
+        .map_err(|e| format!("{} failed to start: {e}", cfg.label))?;
+    let stdout = child.stdout.take();
+    let stderr = child.stderr.take();
+    let stdout_task = stdout.map(|stream| {
+        tokio::spawn(read_command_stream(
+            app.clone(),
+            root.display().to_string(),
+            fingerprint.to_string(),
+            cfg.id.clone(),
+            cfg.label.clone(),
+            "stdout".to_string(),
+            stream,
+        ))
+    });
+    let stderr_task = stderr.map(|stream| {
+        tokio::spawn(read_command_stream(
+            app.clone(),
+            root.display().to_string(),
+            fingerprint.to_string(),
+            cfg.id.clone(),
+            cfg.label.clone(),
+            "stderr".to_string(),
+            stream,
+        ))
+    });
+    let wait = child.wait();
+    let status = match tokio::time::timeout(Duration::from_secs(cfg.timeout_seconds), wait).await {
+        Ok(result) => result.map_err(|e| format!("{} wait failed: {e}", cfg.label))?,
+        Err(_) => {
+            let _ = child.kill().await;
+            let _ = child.wait().await;
+            return Err(format!(
+                "{} timed out after {}s",
+                cfg.label, cfg.timeout_seconds
+            ));
+        }
+    };
+    if let Some(task) = stdout_task {
+        let _ = task.await;
+    }
+    if let Some(task) = stderr_task {
+        let _ = task.await;
+    }
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!("{} exited with {}", cfg.label, status))
+    }
+}
+
+async fn read_command_stream<R: AsyncRead + Unpin>(
+    app: AppHandle,
+    root: String,
+    fingerprint: String,
+    task_id: String,
+    task_label: String,
+    stream: String,
+    reader: R,
+) {
+    let mut lines = BufReader::new(reader).lines();
+    while let Ok(Some(line)) = lines.next_line().await {
+        let content = format!("{line}\n");
+        let _ = app.emit(
+            "workspace-startup-output",
+            StartupOutputEvent {
+                root: root.clone(),
+                fingerprint: fingerprint.clone(),
+                task_id: task_id.clone(),
+                task_label: task_label.clone(),
+                stream: stream.clone(),
+                content,
+            },
+        );
+    }
+}
+
+fn shell_command(script: &str) -> tokio::process::Command {
+    if cfg!(windows) {
+        let mut command = crate::env::tokio_command("cmd");
+        command.args(["/C", script]);
+        command
+    } else {
+        let mut command = crate::env::tokio_command("sh");
+        command.args(["-lc", script]);
+        command
+    }
+}
+
+fn read_startup_config(root: &Path) -> StartupConfig {
+    let path = root.join(".aethon").join("startup.toml");
+    let text = match std::fs::read_to_string(&path) {
+        Ok(mut text) => {
+            if text.len() > STARTUP_CONFIG_MAX_BYTES {
+                text.truncate(STARTUP_CONFIG_MAX_BYTES);
+            }
+            text
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(e) => {
+            tracing::warn!(
+                target: "aethon::startup",
+                "read {} failed: {e}; using empty startup config",
+                path.display()
+            );
+            String::new()
+        }
+    };
+    parse_startup_config(&text)
+}
+
+fn status_response(
+    root: &Path,
+    config: &StartupConfig,
+    fingerprint: &str,
+    approved: bool,
+    record: Option<StartupRecord>,
+) -> StartupStatusResponse {
+    let matching_record = record
+        .as_ref()
+        .filter(|record| record.fingerprint == fingerprint)
+        .cloned();
+    let state = matching_record
+        .as_ref()
+        .map(|record| record.state.as_str())
+        .unwrap_or(if config.commands.is_empty() {
+            "disabled"
+        } else if approved {
+            "idle"
+        } else {
+            "approval_required"
+        });
+    let mut commands = Vec::with_capacity(config.commands.len() + 1);
+    commands.push(StartupTaskStatus {
+        id: STARTUP_DEVSHELL_TASK_ID.to_string(),
+        label: STARTUP_DEVSHELL_TASK_LABEL.to_string(),
+        required: false,
+        state: devshell_task_state(matching_record.as_ref()).to_string(),
+    });
+    commands.extend(config.commands.iter().map(|command| StartupTaskStatus {
+        id: command.id.clone(),
+        label: command.label.clone(),
+        required: command.required,
+        state: command_task_state(command, matching_record.as_ref()).to_string(),
+    }));
+    StartupStatusResponse {
+        root: root.display().to_string(),
+        fingerprint: fingerprint.to_string(),
+        state: state.to_string(),
+        approved,
+        commands,
+        warning: config.warning.clone(),
+        reason: matching_record.and_then(|record| record.reason),
+    }
+}
+
+fn devshell_task_state(record: Option<&StartupRecord>) -> &'static str {
+    let Some(record) = record else {
+        return "idle";
+    };
+    match record.state {
+        StartupState::Failed
+            if record.active_task_id.as_deref() == Some(STARTUP_DEVSHELL_TASK_ID) =>
+        {
+            "failed"
+        }
+        StartupState::Running
+            if record.active_task_id.as_deref() == Some(STARTUP_DEVSHELL_TASK_ID) =>
+        {
+            "running"
+        }
+        StartupState::ApprovalRequired | StartupState::Running | StartupState::Ready => "succeeded",
+        StartupState::Failed | StartupState::Continued => "idle",
+    }
+}
+
+fn command_task_state(
+    command: &StartupCommandConfig,
+    record: Option<&StartupRecord>,
+) -> &'static str {
+    let Some(record) = record else {
+        return "idle";
+    };
+    match record.state {
+        StartupState::Ready => "succeeded",
+        StartupState::Running if record.active_task_id.as_deref() == Some(command.id.as_str()) => {
+            "running"
+        }
+        StartupState::Failed if record.active_task_id.as_deref() == Some(command.id.as_str()) => {
+            "failed"
+        }
+        _ => "idle",
+    }
+}
+
+fn approval_matches(app: &AppHandle, root: &Path, fingerprint: &str) -> Result<bool, String> {
+    let store = read_approval_store(app)?;
+    Ok(store
+        .approvals
+        .get(&root.display().to_string())
+        .is_some_and(|stored| stored == fingerprint))
+}
+
+fn write_approval(app: &AppHandle, root: &Path, fingerprint: &str) -> Result<(), String> {
+    let mut store = read_approval_store(app)?;
+    store
+        .approvals
+        .insert(root.display().to_string(), fingerprint.to_string());
+    let path = approvals_path(app)?;
+    let text = serde_json::to_string_pretty(&store).map_err(|e| e.to_string())?;
+    std::fs::write(&path, text).map_err(|e| format!("write {}: {e}", path.display()))
+}
+
+fn read_approval_store(app: &AppHandle) -> Result<ApprovalStore, String> {
+    let path = approvals_path(app)?;
+    let text = match std::fs::read_to_string(&path) {
+        Ok(text) => text,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(ApprovalStore::default()),
+        Err(e) => return Err(format!("read {}: {e}", path.display())),
+    };
+    serde_json::from_str(&text).map_err(|e| format!("parse {}: {e}", path.display()))
+}
+
+fn approvals_path(app: &AppHandle) -> Result<PathBuf, String> {
+    let home = app
+        .path()
+        .home_dir()
+        .map_err(|e| format!("home_dir: {e}"))?;
+    let dir = crate::helpers::aethon_dir(Some(home))
+        .ok_or_else(|| "aethon dir unresolved".to_string())?;
+    std::fs::create_dir_all(&dir).map_err(|e| format!("create_dir_all: {e}"))?;
+    Ok(dir.join(STARTUP_APPROVALS_FILE))
+}
+
+fn canonicalize_root(root: &Path) -> PathBuf {
+    std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf())
+}
+
+fn emit_startup_event(app: &AppHandle, event: StartupEvent) {
+    if let Err(err) = app.emit("workspace-startup-status", event) {
+        tracing::warn!(target: "aethon::startup", "emit workspace-startup-status failed: {err}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_startup_config_defaults_commands_to_required() {
+        let cfg = parse_startup_config(
+            r#"[startup]
+timeout_seconds = 42
+
+[[startup.commands]]
+id = "deps"
+label = "Install dependencies"
+command = "bun install"
+"#,
+        );
+
+        assert_eq!(cfg.timeout_seconds, 42);
+        assert_eq!(cfg.commands.len(), 1);
+        assert_eq!(cfg.commands[0].id, "deps");
+        assert_eq!(cfg.commands[0].label, "Install dependencies");
+        assert_eq!(cfg.commands[0].command, "bun install");
+        assert!(cfg.commands[0].required);
+        assert_eq!(cfg.commands[0].timeout_seconds, 42);
+    }
+
+    #[test]
+    fn parse_startup_config_honors_optional_and_per_command_timeout() {
+        let cfg = parse_startup_config(
+            r#"[startup]
+timeout_seconds = 600
+
+[[startup.commands]]
+id = "assets"
+command = "bun run assets"
+required = false
+timeout_seconds = 5
+"#,
+        );
+
+        assert_eq!(cfg.commands.len(), 1);
+        assert!(!cfg.commands[0].required);
+        assert_eq!(cfg.commands[0].timeout_seconds, 5);
+    }
+
+    #[test]
+    fn startup_fingerprint_changes_when_command_changes() {
+        let a = startup_fingerprint(&parse_startup_config(
+            r#"[[startup.commands]]
+id = "deps"
+command = "bun install"
+"#,
+        ));
+        let b = startup_fingerprint(&parse_startup_config(
+            r#"[[startup.commands]]
+id = "deps"
+command = "bun install --frozen-lockfile"
+"#,
+        ));
+
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn status_response_keeps_environment_task_visible_after_approval_gate() {
+        let cfg = parse_startup_config(
+            r#"[[startup.commands]]
+id = "deps"
+command = "bun install"
+"#,
+        );
+        let fingerprint = startup_fingerprint(&cfg);
+        let response = status_response(
+            Path::new("/tmp/example"),
+            &cfg,
+            &fingerprint,
+            false,
+            Some(StartupRecord {
+                fingerprint: fingerprint.clone(),
+                state: StartupState::ApprovalRequired,
+                reason: Some("startup commands require approval".to_string()),
+                active_task_id: None,
+            }),
+        );
+
+        assert_eq!(response.state, "approval_required");
+        assert_eq!(response.commands[0].id, STARTUP_DEVSHELL_TASK_ID);
+        assert_eq!(response.commands[0].state, "succeeded");
+        assert_eq!(response.commands[1].id, "deps");
+        assert_eq!(response.commands[1].state, "idle");
+    }
+
+    #[test]
+    fn status_response_marks_failed_startup_command() {
+        let cfg = parse_startup_config(
+            r#"[[startup.commands]]
+id = "deps"
+command = "bun install"
+"#,
+        );
+        let fingerprint = startup_fingerprint(&cfg);
+        let response = status_response(
+            Path::new("/tmp/example"),
+            &cfg,
+            &fingerprint,
+            true,
+            Some(StartupRecord {
+                fingerprint: fingerprint.clone(),
+                state: StartupState::Failed,
+                reason: Some("deps exited with 1".to_string()),
+                active_task_id: Some("deps".to_string()),
+            }),
+        );
+
+        assert_eq!(response.state, "failed");
+        assert_eq!(response.commands[0].state, "idle");
+        assert_eq!(response.commands[1].state, "failed");
+    }
+
+    #[test]
+    fn status_response_marks_failed_environment_task() {
+        let cfg = parse_startup_config("");
+        let fingerprint = startup_fingerprint(&cfg);
+        let response = status_response(
+            Path::new("/tmp/example"),
+            &cfg,
+            &fingerprint,
+            true,
+            Some(StartupRecord {
+                fingerprint: fingerprint.clone(),
+                state: StartupState::Failed,
+                reason: Some("devshell prepare failed".to_string()),
+                active_task_id: Some(STARTUP_DEVSHELL_TASK_ID.to_string()),
+            }),
+        );
+
+        assert_eq!(response.state, "failed");
+        assert_eq!(response.commands.len(), 1);
+        assert_eq!(response.commands[0].id, STARTUP_DEVSHELL_TASK_ID);
+        assert_eq!(response.commands[0].state, "failed");
+    }
+}

--- a/src-tauri/src/commands/startup.rs
+++ b/src-tauri/src/commands/startup.rs
@@ -311,7 +311,7 @@ pub async fn workspace_startup_approve(
         StartupEvent {
             root: root.display().to_string(),
             fingerprint: fingerprint.clone(),
-            state: "approved".to_string(),
+            state: "idle".to_string(),
             task_id: None,
             task_label: None,
             required: None,
@@ -836,12 +836,7 @@ fn shell_command(script: &str) -> tokio::process::Command {
 fn read_startup_config(root: &Path) -> StartupConfig {
     let path = root.join(".aethon").join("startup.toml");
     let text = match std::fs::read_to_string(&path) {
-        Ok(mut text) => {
-            if text.len() > STARTUP_CONFIG_MAX_BYTES {
-                text.truncate(STARTUP_CONFIG_MAX_BYTES);
-            }
-            text
-        }
+        Ok(text) => truncate_utf8(text, STARTUP_CONFIG_MAX_BYTES),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
         Err(e) => {
             tracing::warn!(
@@ -915,7 +910,7 @@ fn devshell_task_state(record: Option<&StartupRecord>) -> &'static str {
         {
             "running"
         }
-        StartupState::ApprovalRequired | StartupState::Running | StartupState::Ready => "succeeded",
+        StartupState::ApprovalRequired | StartupState::Running | StartupState::Ready => "ready",
         StartupState::Failed | StartupState::Continued => "idle",
     }
 }
@@ -928,7 +923,7 @@ fn command_task_state(
         return "idle";
     };
     match record.state {
-        StartupState::Ready => "succeeded",
+        StartupState::Ready => "ready",
         StartupState::Running if record.active_task_id.as_deref() == Some(command.id.as_str()) => {
             "running"
         }
@@ -937,6 +932,18 @@ fn command_task_state(
         }
         _ => "idle",
     }
+}
+
+fn truncate_utf8(mut text: String, max_bytes: usize) -> String {
+    if text.len() <= max_bytes {
+        return text;
+    }
+    let mut end = max_bytes;
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    text.truncate(end);
+    text
 }
 
 fn approval_matches(app: &AppHandle, root: &Path, fingerprint: &str) -> Result<bool, String> {
@@ -1075,7 +1082,7 @@ command = "bun install"
 
         assert_eq!(response.state, "approval_required");
         assert_eq!(response.commands[0].id, STARTUP_DEVSHELL_TASK_ID);
-        assert_eq!(response.commands[0].state, "succeeded");
+        assert_eq!(response.commands[0].state, "ready");
         assert_eq!(response.commands[1].id, "deps");
         assert_eq!(response.commands[1].state, "idle");
     }
@@ -1128,5 +1135,14 @@ command = "bun install"
         assert_eq!(response.commands.len(), 1);
         assert_eq!(response.commands[0].id, STARTUP_DEVSHELL_TASK_ID);
         assert_eq!(response.commands[0].state, "failed");
+    }
+
+    #[test]
+    fn truncate_utf8_keeps_char_boundary() {
+        let input = format!("{}é", "a".repeat(STARTUP_CONFIG_MAX_BYTES - 1));
+        let truncated = truncate_utf8(input, STARTUP_CONFIG_MAX_BYTES);
+
+        assert_eq!(truncated.len(), STARTUP_CONFIG_MAX_BYTES - 1);
+        assert!(truncated.is_char_boundary(truncated.len()));
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -133,7 +133,8 @@ pub fn run() {
         .manage(window_state::WindowStateStore::new())
         .manage(updater_state::UpdaterState::new())
         .manage(Arc::new(server::ServerState::new()))
-        .manage(devshell::DevshellCache::shared());
+        .manage(devshell::DevshellCache::shared())
+        .manage(commands::startup::WorkspaceStartupState::default());
     #[cfg(feature = "voice")]
     let builder = builder
         .manage(voice::VoiceProviderRegistry::new(
@@ -248,6 +249,11 @@ pub fn run() {
             commands::devshell::devshell_prepare_for_path,
             commands::devshell::devshell_env_for_path,
             commands::devshell::devshell_refresh,
+            commands::startup::workspace_startup_status,
+            commands::startup::workspace_startup_approve,
+            commands::startup::workspace_startup_prepare_for_path,
+            commands::startup::workspace_startup_retry,
+            commands::startup::workspace_startup_continue,
             shell::shell_open,
             shell::shell_input,
             shell::shell_resize,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,7 @@ import { useFrontendStateMirror } from "./hooks/useFrontendStateMirror";
 import { usePersistEditorTabs } from "./hooks/usePersistEditorTabs";
 import { useUiOverlays } from "./hooks/useUiOverlays";
 import { useUpdater } from "./hooks/useUpdater";
+import { useWorkspaceStartup } from "./hooks/useWorkspaceStartup";
 import { UpdateBanner } from "./components/UpdateBanner";
 import type { AethonConfig } from "./config";
 import {
@@ -126,6 +127,14 @@ export default function App() {
     pushNotificationRef,
     chatActionsRef,
   } = useAppStateRefs(appStore);
+
+  const {
+    view: workspaceStartupView,
+    prepareWorkspaceStartup,
+    approveStartup,
+    retryStartup,
+    continueStartup,
+  } = useWorkspaceStartup({ state, setState, stateRef });
 
   useSessionPersistence({ appStore, hasSyncSessionSnapshot });
   useAgentActivityHydration(setState);
@@ -295,6 +304,7 @@ export default function App() {
     shellDefaultArgsRef,
     shellInheritEnvRef,
     shellPromptBeforeCloseRef,
+    prepareWorkspaceStartup,
     isShellBusy: async (tabId: string) => {
       const v = await invoke("shell_is_busy", { tabId });
       return v === true;
@@ -588,6 +598,7 @@ export default function App() {
     stateRef,
     tabBucketsRef,
     piDefaultModelRef,
+    prepareWorkspaceStartup,
   });
 
   // Updater (Cmd menu / tray "Check for Updates" + agent-driven path).
@@ -697,6 +708,7 @@ export default function App() {
     updateActiveTab,
     newTab,
     newEditorTab,
+    prepareWorkspaceStartup,
     dispatchTerminalReplay,
     autoRestoreDiscoveredSessions,
     hydrateThemes,
@@ -972,6 +984,10 @@ export default function App() {
       authProfilesOpen={authProfilesOpen}
       chromeReady={chromeReady}
       startupLogoUrl={logoUrl}
+      workspaceStartup={workspaceStartupView}
+      onStartupApprove={approveStartup}
+      onStartupRetry={retryStartup}
+      onStartupContinue={continueStartup}
       topBanner={
         <UpdateBanner
           state={updaterState}

--- a/src/app/AppRoot.tsx
+++ b/src/app/AppRoot.tsx
@@ -7,6 +7,8 @@ import { ExtensionRegistryProvider } from "../extensions/ExtensionRegistryProvid
 import type { ExtensionRegistry } from "../extensions/ExtensionRegistry";
 import type { A2UIPayload } from "../types/a2ui";
 import { isMacOS } from "../utils/platform";
+import { StartupCurtain } from "./StartupCurtain";
+import type { WorkspaceStartupView } from "../hooks/useWorkspaceStartup";
 
 export interface AppRootProps {
   registry: ExtensionRegistry;
@@ -22,6 +24,10 @@ export interface AppRootProps {
   authProfilesOpen: boolean;
   chromeReady: boolean;
   startupLogoUrl: string;
+  workspaceStartup?: WorkspaceStartupView | null;
+  onStartupApprove?: () => void;
+  onStartupRetry?: () => void;
+  onStartupContinue?: () => void;
   /** Optional banner row rendered above the layout. Sits in flow as the
    *  first flex child of `.app` so it pushes the rest of the chrome
    *  down instead of floating over it. */
@@ -49,8 +55,18 @@ export function AppRoot({
   authProfilesOpen,
   chromeReady,
   startupLogoUrl,
+  workspaceStartup,
+  onStartupApprove,
+  onStartupRetry,
+  onStartupContinue,
   topBanner,
 }: AppRootProps) {
+  const showStartupOverlay =
+    chromeReady &&
+    workspaceStartup?.entry &&
+    ["running", "approval_required", "failed"].includes(
+      workspaceStartup.entry.state,
+    );
   return (
     <ExtensionRegistryProvider registry={registry}>
       {/* `data-platform="mac"` gates the overlay-titlebar chrome (traffic-
@@ -66,10 +82,23 @@ export function AppRoot({
             tabId={activeTabId}
           />
         ) : (
-          <div className="ae-boot-curtain" aria-hidden="true">
-            <img src={startupLogoUrl} alt="" />
-          </div>
+          <StartupCurtain
+            logoUrl={startupLogoUrl}
+            startup={workspaceStartup}
+            onApprove={onStartupApprove}
+            onRetry={onStartupRetry}
+            onContinue={onStartupContinue}
+          />
         )}
+        {showStartupOverlay ? (
+          <StartupCurtain
+            logoUrl={startupLogoUrl}
+            startup={workspaceStartup}
+            onApprove={onStartupApprove}
+            onRetry={onStartupRetry}
+            onContinue={onStartupContinue}
+          />
+        ) : null}
         {chromeReady && notificationsOpen && (
           <RegistryComponent
             type="notification-stack"

--- a/src/app/StartupCurtain.test.tsx
+++ b/src/app/StartupCurtain.test.tsx
@@ -1,0 +1,35 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { StartupCurtain } from "./StartupCurtain";
+
+describe("StartupCurtain", () => {
+  it("renders an interactive approval state for startup commands", () => {
+    const html = renderToStaticMarkup(
+      <StartupCurtain
+        logoUrl="/logo.svg"
+        startup={{
+          output: "",
+          entry: {
+            root: "/repo",
+            fingerprint: "abc",
+            state: "approval_required",
+            approved: false,
+            commands: [
+              {
+                id: "deps",
+                label: "Install dependencies",
+                required: true,
+                state: "idle",
+              },
+            ],
+          },
+        }}
+      />,
+    );
+
+    expect(html).toContain("Approve Workspace Startup");
+    expect(html).toContain("Install dependencies");
+    expect(html).toContain("<button");
+    expect(html).not.toContain("aria-hidden=\"true\"");
+  });
+});

--- a/src/app/StartupCurtain.test.tsx
+++ b/src/app/StartupCurtain.test.tsx
@@ -29,6 +29,8 @@ describe("StartupCurtain", () => {
 
     expect(html).toContain("Approve Workspace Startup");
     expect(html).toContain("Install dependencies");
+    expect(html).toContain("role=\"dialog\"");
+    expect(html).toContain("aria-modal=\"true\"");
     expect(html).toContain("<button");
     expect(html).not.toContain("aria-hidden=\"true\"");
   });

--- a/src/app/StartupCurtain.tsx
+++ b/src/app/StartupCurtain.tsx
@@ -1,0 +1,89 @@
+import type { WorkspaceStartupView } from "../hooks/useWorkspaceStartup";
+
+export interface StartupCurtainProps {
+  logoUrl: string;
+  startup?: WorkspaceStartupView | null;
+  onApprove?: () => void;
+  onRetry?: () => void;
+  onContinue?: () => void;
+}
+
+export function StartupCurtain({
+  logoUrl,
+  startup,
+  onApprove,
+  onRetry,
+  onContinue,
+}: StartupCurtainProps) {
+  const entry = startup?.entry ?? null;
+  if (!entry) {
+    return (
+      <div className="ae-boot-curtain" aria-hidden="true">
+        <img src={logoUrl} alt="" />
+      </div>
+    );
+  }
+  const pendingApproval = entry.state === "approval_required";
+  const failed = entry.state === "failed";
+  const running = entry.state === "running";
+  const title = pendingApproval
+    ? "Approve Workspace Startup"
+    : failed
+      ? "Workspace Startup Failed"
+      : running
+        ? "Preparing Workspace"
+        : "Workspace Startup";
+
+  return (
+    <div className="ae-startup-curtain" role="status" aria-live="polite">
+      <div className="ae-startup-panel">
+        <div className="ae-startup-header">
+          <img src={logoUrl} alt="" />
+          <div>
+            <h1>{title}</h1>
+            <p>{entry.root}</p>
+          </div>
+        </div>
+        <div className="ae-startup-tasks">
+          {entry.commands.length === 0 ? (
+            <div className="ae-startup-task">
+              <span className="ae-startup-task-dot is-running" />
+              <span>Preparing environment</span>
+            </div>
+          ) : (
+            entry.commands.map((task) => (
+              <div className="ae-startup-task" key={task.id}>
+                <span className={`ae-startup-task-dot is-${task.state}`} />
+                <span>{task.label}</span>
+                {!task.required ? (
+                  <span className="ae-startup-task-meta">optional</span>
+                ) : null}
+              </div>
+            ))
+          )}
+        </div>
+        {entry.reason ? <p className="ae-startup-reason">{entry.reason}</p> : null}
+        {startup?.output ? (
+          <pre className="ae-startup-output">{startup.output}</pre>
+        ) : null}
+        {pendingApproval || failed ? (
+          <div className="ae-startup-actions">
+            {pendingApproval ? (
+              <button type="button" onClick={onApprove}>
+                Approve
+              </button>
+            ) : null}
+            {failed ? (
+              <button type="button" onClick={onRetry}>
+                Retry
+              </button>
+            ) : null}
+            <button type="button" className="is-secondary" onClick={onContinue}>
+              Continue
+            </button>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/app/StartupCurtain.tsx
+++ b/src/app/StartupCurtain.tsx
@@ -1,3 +1,4 @@
+import { useId } from "react";
 import type { WorkspaceStartupView } from "../hooks/useWorkspaceStartup";
 
 export interface StartupCurtainProps {
@@ -15,6 +16,9 @@ export function StartupCurtain({
   onRetry,
   onContinue,
 }: StartupCurtainProps) {
+  const titleId = useId();
+  const reasonId = useId();
+  const outputId = useId();
   const entry = startup?.entry ?? null;
   if (!entry) {
     return (
@@ -26,6 +30,13 @@ export function StartupCurtain({
   const pendingApproval = entry.state === "approval_required";
   const failed = entry.state === "failed";
   const running = entry.state === "running";
+  const interactive = pendingApproval || failed;
+  const describedBy = [
+    entry.reason ? reasonId : null,
+    startup?.output ? outputId : null,
+  ]
+    .filter(Boolean)
+    .join(" ");
   const title = pendingApproval
     ? "Approve Workspace Startup"
     : failed
@@ -35,12 +46,19 @@ export function StartupCurtain({
         : "Workspace Startup";
 
   return (
-    <div className="ae-startup-curtain" role="status" aria-live="polite">
+    <div
+      className="ae-startup-curtain"
+      role={interactive ? "dialog" : "status"}
+      aria-modal={interactive ? "true" : undefined}
+      aria-live={interactive ? undefined : "polite"}
+      aria-labelledby={titleId}
+      aria-describedby={describedBy || undefined}
+    >
       <div className="ae-startup-panel">
         <div className="ae-startup-header">
           <img src={logoUrl} alt="" />
           <div>
-            <h1>{title}</h1>
+            <h1 id={titleId}>{title}</h1>
             <p>{entry.root}</p>
           </div>
         </div>
@@ -62,9 +80,15 @@ export function StartupCurtain({
             ))
           )}
         </div>
-        {entry.reason ? <p className="ae-startup-reason">{entry.reason}</p> : null}
+        {entry.reason ? (
+          <p className="ae-startup-reason" id={reasonId}>
+            {entry.reason}
+          </p>
+        ) : null}
         {startup?.output ? (
-          <pre className="ae-startup-output">{startup.output}</pre>
+          <pre className="ae-startup-output" id={outputId}>
+            {startup.output}
+          </pre>
         ) : null}
         {pendingApproval || failed ? (
           <div className="ae-startup-actions">

--- a/src/extensions/default-layout/layout/status-bar.tsx
+++ b/src/extensions/default-layout/layout/status-bar.tsx
@@ -85,6 +85,16 @@ export function StatusBar({ component, state }: BuiltinComponentProps) {
   const devshellClass = devshellEntry
     ? `a2ui-status-devshell-chip is-${devshellEntry.state}`
     : "a2ui-status-devshell-chip";
+  const startupSlice = resolveValue(state, "/workspaceStartup") as
+    | {
+        activeRoot?: string | null;
+        entries?: Record<string, { state?: string; reason?: string | null }>;
+      }
+    | undefined;
+  const startupRoot = startupSlice?.activeRoot ?? null;
+  const startupEntry =
+    startupRoot && startupSlice?.entries ? startupSlice.entries[startupRoot] : null;
+  const startupLabel = startupEntry ? startupChipLabel(startupEntry.state) : null;
 
   return (
     <footer className="a2ui-status-bar">
@@ -133,11 +143,33 @@ export function StatusBar({ component, state }: BuiltinComponentProps) {
           <span className="a2ui-status-devshell-label">{devshellLabel}</span>
         </span>
       ) : null}
+      {startupLabel ? (
+        <span
+          className={`a2ui-status-startup-chip is-${startupEntry?.state ?? "idle"}`}
+          title={startupEntry?.reason ?? undefined}
+        >
+          <span className="a2ui-status-startup-dot" aria-hidden="true" />
+          <span className="a2ui-status-startup-label">{startupLabel}</span>
+        </span>
+      ) : null}
       {contextUsage ? <ContextMeter usage={contextUsage} /> : null}
       <span className="a2ui-status-center">{center}</span>
       <span className="a2ui-status-right">{right}</span>
     </footer>
   );
+}
+
+function startupChipLabel(state: string | undefined): string | null {
+  switch (state) {
+    case "running":
+      return "startup running";
+    case "approval_required":
+      return "startup approval";
+    case "failed":
+      return "startup failed";
+    default:
+      return null;
+  }
 }
 
 /** Read a state pointer for non-string values (resolveString coerces). */

--- a/src/hooks/bridgeMessageHandlers/ready.ts
+++ b/src/hooks/bridgeMessageHandlers/ready.ts
@@ -485,16 +485,22 @@ export const handleReady: BridgeMessageHandler = (data, ctx) => {
       ? ctx.projectsRef.current.projects.find((p) => p.id === t.projectId)
       : null;
     const restoredCwd = t.cwd ?? tabProject?.path;
-    const opening = invoke("agent_command", {
-      payload: JSON.stringify({
-        type: "tab_open",
-        tabId: t.id,
-        ...(t.model ? { model: t.model } : {}),
-        ...(restoredCwd ? { cwd: restoredCwd } : {}),
-        ...(t.authProfileId ? { authProfileId: t.authProfileId } : {}),
-        restoreHistory: true,
-      }),
-    });
+    const opening = (async () => {
+      if (restoredCwd && ctx.prepareWorkspaceStartup) {
+        const ready = await ctx.prepareWorkspaceStartup(restoredCwd);
+        if (!ready) return;
+      }
+      return await invoke("agent_command", {
+        payload: JSON.stringify({
+          type: "tab_open",
+          tabId: t.id,
+          ...(t.model ? { model: t.model } : {}),
+          ...(restoredCwd ? { cwd: restoredCwd } : {}),
+          ...(t.authProfileId ? { authProfileId: t.authProfileId } : {}),
+          restoreHistory: true,
+        }),
+      });
+    })();
     ctx.pendingTabOpens.current.set(t.id, opening);
     opening
       .catch(() => {

--- a/src/hooks/bridgeMessageHandlers/types.ts
+++ b/src/hooks/bridgeMessageHandlers/types.ts
@@ -93,6 +93,7 @@ export interface BridgeMessageContext {
     opts?: { rootPath?: string; diff?: boolean },
   ) => void;
   dispatchTerminalReplay: (buffer: string) => void;
+  prepareWorkspaceStartup?: (cwd: string) => Promise<boolean>;
   autoRestoreDiscoveredSessions: (
     discovered: DiscoveredSession[],
     knownIds: Set<string>,

--- a/src/hooks/tabOps/agentTab.test.ts
+++ b/src/hooks/tabOps/agentTab.test.ts
@@ -100,7 +100,7 @@ describe("newTab restore handling", () => {
     });
   });
 
-  it("prepares the devshell before opening a cwd-backed agent tab", async () => {
+  it("prepares workspace startup before opening a cwd-backed agent tab", async () => {
     const invokeMock = vi.mocked(invoke);
     invokeMock.mockResolvedValue(null);
     let state: Record<string, unknown> = { tabs: [] };
@@ -140,17 +140,17 @@ describe("newTab restore handling", () => {
     await pending.current.get("tab-1");
 
     expect(invokeMock.mock.calls[0]).toEqual([
-      "devshell_prepare_for_path",
-      { args: { cwd: "/proj", includeEnv: false } },
+      "workspace_startup_prepare_for_path",
+      { args: { cwd: "/proj" } },
     ]);
     expect(invokeMock.mock.calls[1]?.[0]).toBe("agent_command");
   });
 
-  it("still opens the agent tab when frontend devshell prepare rejects", async () => {
+  it("does not open the agent tab when required workspace startup rejects", async () => {
     const invokeMock = vi.mocked(invoke);
     invokeMock.mockImplementation((command) =>
-      command === "devshell_prepare_for_path"
-        ? Promise.reject(new Error("ipc unavailable"))
+      command === "workspace_startup_prepare_for_path"
+        ? Promise.reject(new Error("startup approval required"))
         : Promise.resolve(null),
     );
     let state: Record<string, unknown> = { tabs: [] };
@@ -190,10 +190,10 @@ describe("newTab restore handling", () => {
     newTab("tab-1", "Project");
     await pending.current.get("tab-1");
 
-    expect(invokeMock.mock.calls[0]?.[0]).toBe("devshell_prepare_for_path");
-    expect(invokeMock.mock.calls[1]?.[0]).toBe("agent_command");
+    expect(invokeMock.mock.calls[0]?.[0]).toBe("workspace_startup_prepare_for_path");
+    expect(invokeMock.mock.calls.some((call) => call[0] === "agent_command")).toBe(false);
     expect(appendSystem).toHaveBeenCalledWith(
-      "Devshell prepare failed for /proj: ipc unavailable. Opening tab with the host environment.",
+      "Workspace startup blocked for /proj: startup approval required",
     );
     expect((state.tabs as Array<{ waiting: boolean }>)[0].waiting).toBe(false);
   });

--- a/src/hooks/tabOps/agentTab.ts
+++ b/src/hooks/tabOps/agentTab.ts
@@ -22,6 +22,7 @@ export interface NewTabDeps {
   pendingTabOpens: MutableRefObject<Map<string, Promise<unknown>>>;
   appendSystem: (text: string) => void;
   dispatchTerminalReplay: (buffer: string) => void;
+  prepareWorkspaceStartup?: (cwd: string) => Promise<boolean>;
 }
 
 /** Build the agent-tab creator. Owns the heavy lifting around restoring
@@ -38,6 +39,7 @@ export function useNewTab(deps: NewTabDeps) {
     pendingTabOpens,
     appendSystem,
     dispatchTerminalReplay,
+    prepareWorkspaceStartup,
   } = deps;
 
   return function newTab(
@@ -162,27 +164,25 @@ export function useNewTab(deps: NewTabDeps) {
     const opening = (async () => {
       if (inheritedCwd) {
         try {
-          const prepared = await invoke<{
-            state?: string;
-            kind?: string | null;
-            reason?: string | null;
-          }>("devshell_prepare_for_path", {
-            args: { cwd: inheritedCwd, includeEnv: false },
-          });
-          if (prepared?.state === "failed") {
-            appendSystem(
-              `Devshell prepare failed for ${inheritedCwd}${
-                prepared.reason ? `: ${prepared.reason}` : ""
-              }. Opening tab with the host environment.`,
-            );
+          const ok = prepareWorkspaceStartup
+            ? await prepareWorkspaceStartup(inheritedCwd)
+            : await invoke<{ state?: string }>(
+                "workspace_startup_prepare_for_path",
+                {
+                  args: { cwd: inheritedCwd },
+                },
+              ).then((prepared) =>
+                ["ready", "continued", "disabled"].includes(
+                  prepared?.state ?? "ready",
+                ),
+              );
+          if (!ok) {
+            return;
           }
         } catch (err) {
           const reason = err instanceof Error ? err.message : String(err);
-          appendSystem(
-            `Devshell prepare failed for ${inheritedCwd}${
-              reason ? `: ${reason}` : ""
-            }. Opening tab with the host environment.`,
-          );
+          appendSystem(`Workspace startup blocked for ${inheritedCwd}: ${reason}`);
+          return;
         } finally {
           setState((prev) => {
             const tabs = ((prev.tabs as Tab[] | undefined) ?? []).map((tab) =>

--- a/src/hooks/tabOps/devshellTerminal.ts
+++ b/src/hooks/tabOps/devshellTerminal.ts
@@ -7,7 +7,10 @@ export function initialDevshellTerminalBuffer(
   state: Record<string, unknown>,
   cwd: string,
 ): string {
-  const existing = devshellOutputForCwd(state, cwd);
+  const existing = `${devshellOutputForCwd(state, cwd)}${startupOutputForCwd(
+    state,
+    cwd,
+  )}`;
   if (existing) return existing;
   return devshellNeedsPreparation(state, cwd) ? PREPARING_MESSAGE : "";
 }
@@ -28,6 +31,27 @@ function devshellOutputForCwd(
   const devshell = state.devshell as Record<string, unknown> | undefined;
   const outputByRoot =
     (devshell?.outputByRoot as Record<string, string> | undefined) ?? {};
+  let bestRoot = "";
+  let bestBuffer = "";
+  for (const [root, buffer] of Object.entries(outputByRoot)) {
+    if (typeof buffer !== "string") continue;
+    if (isUnderRoot(cwd, root) && root.length > bestRoot.length) {
+      bestRoot = root;
+      bestBuffer = buffer;
+    }
+  }
+  return bestBuffer.length > TERMINAL_REPLAY_MAX
+    ? bestBuffer.slice(bestBuffer.length - TERMINAL_REPLAY_MAX)
+    : bestBuffer;
+}
+
+function startupOutputForCwd(
+  state: Record<string, unknown>,
+  cwd: string,
+): string {
+  const startup = state.workspaceStartup as Record<string, unknown> | undefined;
+  const outputByRoot =
+    (startup?.outputByRoot as Record<string, string> | undefined) ?? {};
   let bestRoot = "";
   let bestBuffer = "";
   for (const [root, buffer] of Object.entries(outputByRoot)) {

--- a/src/hooks/tabOps/types.ts
+++ b/src/hooks/tabOps/types.ts
@@ -38,6 +38,9 @@ export interface UseTabsContext {
   /** Default model id from pi `ready`. New tabs inherit this when no per-
    *  tab model has been set, preventing a blank picker on race startup. */
   piDefaultModelRef: MutableRefObject<string>;
+  /** Project/workspace startup gate. Resolves once env providers and
+   *  approved bootstrapping commands have completed for the cwd. */
+  prepareWorkspaceStartup?: (cwd: string) => Promise<boolean>;
   /** Reopen-flow callbacks: when the closed tab belongs to a different
    *  project bucket, switch buckets first so it lands in the correct
    *  visible tab list. */

--- a/src/hooks/useTabs.ts
+++ b/src/hooks/useTabs.ts
@@ -75,6 +75,7 @@ export function useTabs(ctx: UseTabsContext): UseTabsActions {
     pendingTabOpens,
     appendSystem: ctx.appendSystem,
     dispatchTerminalReplay,
+    prepareWorkspaceStartup: ctx.prepareWorkspaceStartup,
   });
 
   const newShellTab = useNewShellTab({

--- a/src/hooks/useTaskLauncher.ts
+++ b/src/hooks/useTaskLauncher.ts
@@ -77,6 +77,7 @@ export interface UseTaskLauncherOptions {
   stateRef?: MutableRefObject<Record<string, unknown>>;
   tabBucketsRef?: MutableRefObject<Map<string, TabBucket>>;
   piDefaultModelRef?: MutableRefObject<string>;
+  prepareWorkspaceStartup?: (cwd: string) => Promise<boolean>;
 }
 
 export interface StartTaskResult {
@@ -130,6 +131,7 @@ export function useTaskLauncher({
   stateRef,
   tabBucketsRef,
   piDefaultModelRef,
+  prepareWorkspaceStartup,
 }: UseTaskLauncherOptions): (opts: StartTaskOptions) => Promise<StartTaskResult | void> {
   return useCallback(
     async (opts: StartTaskOptions): Promise<StartTaskResult | void> => {
@@ -266,9 +268,17 @@ export function useTaskLauncher({
         }
         const opening = (async () => {
           if (cwd) {
-            await invoke("devshell_prepare_for_path", {
-              args: { cwd, includeEnv: false },
-            }).catch(() => undefined);
+            const ready = prepareWorkspaceStartup
+              ? await prepareWorkspaceStartup(cwd)
+              : await invoke<{ state?: string }>(
+                  "workspace_startup_prepare_for_path",
+                  { args: { cwd } },
+                ).then((status) =>
+                  ["ready", "continued", "disabled"].includes(
+                    status?.state ?? "ready",
+                  ),
+                );
+            if (!ready) throw new Error("workspace startup not ready");
             setState((prev) => {
               const clearWaiting = (candidate: Tab): Tab =>
                 candidate.id === tabId && candidate.waiting === true
@@ -320,13 +330,15 @@ export function useTaskLauncher({
           });
       }
       const opening = pendingTabOpens.current.get(tabId);
+      let opened = true;
       if (opening) {
         try {
           await opening;
         } catch {
-          /* tab open failed; sendChat below will no-op */
+          opened = false;
         }
       }
+      if (!opened) return;
       const trimmed = opts.prompt.trim();
       if (trimmed || (opts.attachments?.length ?? 0) > 0) {
         await sendChat(trimmed, {
@@ -343,6 +355,7 @@ export function useTaskLauncher({
       newTab,
       pendingTabOpens,
       piDefaultModelRef,
+      prepareWorkspaceStartup,
       projectsRef,
       pushNotificationRef,
       sendChat,

--- a/src/hooks/useWorkspaceStartup.ts
+++ b/src/hooks/useWorkspaceStartup.ts
@@ -1,0 +1,436 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  type Dispatch,
+  type MutableRefObject,
+  type SetStateAction,
+} from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { TERMINAL_REPLAY_MAX } from "./tabOps/constants";
+
+export interface WorkspaceStartupTask {
+  id: string;
+  label: string;
+  required: boolean;
+  state: string;
+}
+
+export interface WorkspaceStartupEntry {
+  root: string;
+  fingerprint: string;
+  state: string;
+  approved: boolean;
+  commands: WorkspaceStartupTask[];
+  warning?: string | null;
+  reason?: string | null;
+  activeTaskId?: string | null;
+}
+
+export interface WorkspaceStartupSlice {
+  activeRoot?: string | null;
+  entries?: Record<string, WorkspaceStartupEntry>;
+  outputByRoot?: Record<string, string>;
+}
+
+export interface WorkspaceStartupView {
+  entry: WorkspaceStartupEntry | null;
+  output: string;
+}
+
+interface WorkspaceStartupStatus {
+  root: string;
+  fingerprint: string;
+  state: string;
+  approved: boolean;
+  commands: WorkspaceStartupTask[];
+  warning?: string | null;
+  reason?: string | null;
+}
+
+interface WorkspaceStartupEvent {
+  root?: string;
+  fingerprint?: string;
+  state?: string;
+  taskId?: string | null;
+  taskLabel?: string | null;
+  required?: boolean | null;
+  message?: string | null;
+  reason?: string | null;
+}
+
+interface WorkspaceStartupOutputEvent {
+  root?: string;
+  fingerprint?: string;
+  taskId?: string;
+  taskLabel?: string;
+  stream?: string;
+  content?: string;
+}
+
+interface PendingPrepare {
+  cwd: string;
+  resolve: (ready: boolean) => void;
+  reject: (err: unknown) => void;
+}
+
+export interface UseWorkspaceStartupOptions {
+  state: Record<string, unknown>;
+  setState: Dispatch<SetStateAction<Record<string, unknown>>>;
+  stateRef: MutableRefObject<Record<string, unknown>>;
+}
+
+export interface UseWorkspaceStartupActions {
+  view: WorkspaceStartupView;
+  prepareWorkspaceStartup: (cwd: string) => Promise<boolean>;
+  approveStartup: () => Promise<void>;
+  retryStartup: () => Promise<void>;
+  continueStartup: () => Promise<void>;
+}
+
+const READY_STATES = new Set(["ready", "continued", "disabled"]);
+const BLOCKING_STATES = new Set(["approval_required", "failed"]);
+
+export function useWorkspaceStartup({
+  state,
+  setState,
+  stateRef,
+}: UseWorkspaceStartupOptions): UseWorkspaceStartupActions {
+  const pendingRef = useRef<Map<string, PendingPrepare[]>>(new Map());
+
+  const applyStatus = useCallback(
+    (status: WorkspaceStartupStatus): WorkspaceStartupStatus => {
+      setState((prev) => {
+        const slice = workspaceStartupSlice(prev);
+        const entries = { ...(slice.entries ?? {}) };
+        entries[status.root] = {
+          root: status.root,
+          fingerprint: status.fingerprint,
+          state: status.state,
+          approved: status.approved,
+          commands: status.commands,
+          warning: status.warning ?? null,
+          reason: status.reason ?? null,
+          activeTaskId: entries[status.root]?.activeTaskId ?? null,
+        };
+        return {
+          ...prev,
+          workspaceStartup: {
+            ...slice,
+            activeRoot:
+              isVisibleStartupState(status.state) || slice.activeRoot === status.root
+                ? status.root
+                : slice.activeRoot,
+            entries,
+          },
+        };
+      });
+      settlePendingIfReady(status.root, status, pendingRef.current);
+      return status;
+    },
+    [setState],
+  );
+
+  const prepareOnce = useCallback(
+    async (cwd: string): Promise<WorkspaceStartupStatus> => {
+      const status = await invoke<WorkspaceStartupStatus>(
+        "workspace_startup_prepare_for_path",
+        { args: { cwd } },
+      );
+      return applyStatus(status);
+    },
+    [applyStatus],
+  );
+
+  const prepareWorkspaceStartup = useCallback(
+    async (cwd: string): Promise<boolean> => {
+      const status = await prepareOnce(cwd);
+      if (READY_STATES.has(status.state)) return true;
+      if (!BLOCKING_STATES.has(status.state)) return false;
+      return new Promise<boolean>((resolve, reject) => {
+        const list = pendingRef.current.get(status.root) ?? [];
+        list.push({ cwd, resolve, reject });
+        pendingRef.current.set(status.root, list);
+      });
+    },
+    [prepareOnce],
+  );
+
+  const rerunPendingForRoot = useCallback(
+    async (root: string) => {
+      const pending = pendingRef.current.get(root);
+      const cwd = pending?.[0]?.cwd ?? root;
+      try {
+        const status = await prepareOnce(cwd);
+        if (BLOCKING_STATES.has(status.state)) return;
+        settlePendingIfReady(root, status, pendingRef.current);
+      } catch (err) {
+        rejectPending(root, err, pendingRef.current);
+      }
+    },
+    [prepareOnce],
+  );
+
+  const approveStartup = useCallback(async () => {
+    const entry = activeEntry(stateRef.current);
+    if (!entry) return;
+    const status = await invoke<WorkspaceStartupStatus>(
+      "workspace_startup_approve",
+      { args: { root: entry.root, fingerprint: entry.fingerprint } },
+    );
+    applyStatus(status);
+    await rerunPendingForRoot(entry.root);
+  }, [applyStatus, rerunPendingForRoot, stateRef]);
+
+  const retryStartup = useCallback(async () => {
+    const entry = activeEntry(stateRef.current);
+    if (!entry) return;
+    const status = await invoke<WorkspaceStartupStatus>(
+      "workspace_startup_retry",
+      { args: { root: entry.root } },
+    );
+    applyStatus(status);
+    if (READY_STATES.has(status.state)) {
+      settlePendingIfReady(entry.root, status, pendingRef.current);
+    }
+  }, [applyStatus, stateRef]);
+
+  const continueStartup = useCallback(async () => {
+    const entry = activeEntry(stateRef.current);
+    if (!entry) return;
+    const status = await invoke<WorkspaceStartupStatus>(
+      "workspace_startup_continue",
+      { args: { root: entry.root, fingerprint: entry.fingerprint } },
+    );
+    applyStatus(status);
+    settlePendingIfReady(entry.root, status, pendingRef.current);
+  }, [applyStatus, stateRef]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const unlisteners: UnlistenFn[] = [];
+    void (async () => {
+      try {
+        const offStatus = await listen<WorkspaceStartupEvent>(
+          "workspace-startup-status",
+          (event) => applyStartupEvent(event.payload, setState),
+        );
+        const offOutput = await listen<WorkspaceStartupOutputEvent>(
+          "workspace-startup-output",
+          (event) => applyStartupOutput(event.payload, setState),
+        );
+        if (cancelled) {
+          safeUnlisten(offStatus);
+          safeUnlisten(offOutput);
+          return;
+        }
+        unlisteners.push(offStatus, offOutput);
+      } catch {
+        // Outside Tauri.
+      }
+    })();
+    return () => {
+      cancelled = true;
+      for (const fn of unlisteners) safeUnlisten(fn);
+    };
+  }, [setState]);
+
+  const slice = workspaceStartupSlice(state);
+  const entry = activeEntry(state);
+  const output =
+    entry && slice.outputByRoot ? (slice.outputByRoot[entry.root] ?? "") : "";
+
+  return useMemo(
+    () => ({
+      view: { entry, output },
+      prepareWorkspaceStartup,
+      approveStartup,
+      retryStartup,
+      continueStartup,
+    }),
+    [
+      approveStartup,
+      continueStartup,
+      entry,
+      output,
+      prepareWorkspaceStartup,
+      retryStartup,
+    ],
+  );
+}
+
+function applyStartupEvent(
+  event: WorkspaceStartupEvent,
+  setState: Dispatch<SetStateAction<Record<string, unknown>>>,
+): void {
+  const root = event.root;
+  const state = event.state;
+  if (!root || !state) return;
+  setState((prev) => {
+    const slice = workspaceStartupSlice(prev);
+    const entries = { ...(slice.entries ?? {}) };
+    const existing = entries[root] ?? {
+      root,
+      fingerprint: event.fingerprint ?? "",
+      state,
+      approved: false,
+      commands: [],
+      reason: null,
+      warning: null,
+      activeTaskId: null,
+    };
+    const commands = mergeTaskEvent(existing.commands, event);
+    entries[root] = {
+      ...existing,
+      fingerprint: event.fingerprint ?? existing.fingerprint,
+      state,
+      commands,
+      reason: event.reason ?? existing.reason ?? null,
+      activeTaskId: event.taskId ?? existing.activeTaskId ?? null,
+    };
+    return {
+      ...prev,
+      workspaceStartup: {
+        ...slice,
+        activeRoot: isVisibleStartupState(state) ? root : slice.activeRoot,
+        entries,
+      },
+    };
+  });
+}
+
+function applyStartupOutput(
+  event: WorkspaceStartupOutputEvent,
+  setState: Dispatch<SetStateAction<Record<string, unknown>>>,
+): void {
+  if (!event.root || typeof event.content !== "string" || event.content.length === 0) {
+    return;
+  }
+  const prefix =
+    event.taskLabel && event.stream
+      ? `[startup:${event.taskLabel}:${event.stream}] `
+      : "[startup] ";
+  const content = `${prefix}${event.content}`.replace(/\r?\n/g, "\r\n");
+  setState((prev) => {
+    const slice = workspaceStartupSlice(prev);
+    const outputByRoot = { ...(slice.outputByRoot ?? {}) };
+    outputByRoot[event.root!] = trimOutput((outputByRoot[event.root!] ?? "") + content);
+    const tabs = Array.isArray(prev.tabs)
+      ? (prev.tabs as Array<Record<string, unknown>>)
+      : [];
+    const term = (prev.terminal as Record<string, unknown> | undefined) ?? {};
+    const buffers = (term.buffer as Record<string, string> | undefined) ?? {};
+    const nextBuffers = { ...buffers };
+    const nextTabs = tabs.map((tab) => {
+      const cwd = cwdForTab(tab);
+      if (!cwd || !isUnderRoot(cwd, event.root!)) return tab;
+      const terminalBuffer = trimOutput(
+        `${typeof tab.terminalBuffer === "string" ? tab.terminalBuffer : ""}${content}`,
+      );
+      nextBuffers[String(tab.id)] = terminalBuffer;
+      return { ...tab, terminalBuffer };
+    });
+    return {
+      ...prev,
+      tabs: nextTabs,
+      workspaceStartup: {
+        ...slice,
+        activeRoot: slice.activeRoot ?? event.root,
+        outputByRoot,
+      },
+      terminal: {
+        ...term,
+        buffer: nextBuffers,
+      },
+    };
+  });
+}
+
+function mergeTaskEvent(
+  commands: WorkspaceStartupTask[],
+  event: WorkspaceStartupEvent,
+): WorkspaceStartupTask[] {
+  if (!event.taskId) return commands;
+  const next = commands.slice();
+  const idx = next.findIndex((task) => task.id === event.taskId);
+  const task: WorkspaceStartupTask = {
+    id: event.taskId,
+    label: event.taskLabel ?? event.taskId,
+    required: event.required ?? true,
+    state: event.state ?? "idle",
+  };
+  if (idx >= 0) {
+    next[idx] = { ...next[idx], ...task };
+  } else {
+    next.push(task);
+  }
+  return next;
+}
+
+function workspaceStartupSlice(state: Record<string, unknown>): WorkspaceStartupSlice {
+  return (state.workspaceStartup as WorkspaceStartupSlice | undefined) ?? {};
+}
+
+function activeEntry(state: Record<string, unknown>): WorkspaceStartupEntry | null {
+  const slice = workspaceStartupSlice(state);
+  const root = slice.activeRoot;
+  if (!root || !slice.entries) return null;
+  return slice.entries[root] ?? null;
+}
+
+function isVisibleStartupState(state: string): boolean {
+  return state === "running" || state === "approval_required" || state === "failed";
+}
+
+function settlePendingIfReady(
+  root: string,
+  status: WorkspaceStartupStatus,
+  pending: Map<string, PendingPrepare[]>,
+): void {
+  if (!READY_STATES.has(status.state)) return;
+  const list = pending.get(root);
+  if (!list) return;
+  pending.delete(root);
+  for (const item of list) item.resolve(true);
+}
+
+function rejectPending(
+  root: string,
+  err: unknown,
+  pending: Map<string, PendingPrepare[]>,
+): void {
+  const list = pending.get(root);
+  if (!list) return;
+  pending.delete(root);
+  for (const item of list) item.reject(err);
+}
+
+function trimOutput(value: string): string {
+  return value.length > TERMINAL_REPLAY_MAX
+    ? value.slice(value.length - TERMINAL_REPLAY_MAX)
+    : value;
+}
+
+function cwdForTab(tab: Record<string, unknown>): string | null {
+  if (tab.kind === "shell") {
+    const shell = tab.shell as { cwd?: unknown } | undefined;
+    return typeof shell?.cwd === "string" ? shell.cwd : null;
+  }
+  return typeof tab.cwd === "string" ? tab.cwd : null;
+}
+
+function isUnderRoot(cwd: string, root: string): boolean {
+  if (cwd === root) return true;
+  const prefix = root.endsWith("/") ? root : `${root}/`;
+  return cwd.startsWith(prefix);
+}
+
+function safeUnlisten(fn: UnlistenFn): void {
+  try {
+    fn();
+  } catch {
+    // Best-effort during reload/shutdown.
+  }
+}

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -164,12 +164,15 @@ body {
 }
 
 .ae-startup-curtain {
+  position: fixed;
+  inset: 0;
+  z-index: 80;
   display: grid;
-  flex: 1;
   min-width: 0;
   min-height: 0;
   place-items: center;
   padding: 24px;
+  overflow: auto;
   background: var(--gradient-app-backdrop, var(--bg));
 }
 

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -163,6 +163,137 @@ body {
   opacity: 0.9;
 }
 
+.ae-startup-curtain {
+  display: grid;
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  place-items: center;
+  padding: 24px;
+  background: var(--gradient-app-backdrop, var(--bg));
+}
+
+.ae-startup-panel {
+  width: min(620px, 100%);
+  max-height: min(620px, calc(var(--app-viewport-height) - 48px));
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  overflow: hidden;
+}
+
+.ae-startup-header {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  min-width: 0;
+}
+
+.ae-startup-header img {
+  width: 44px;
+  height: auto;
+  flex: 0 0 auto;
+  opacity: 0.9;
+}
+
+.ae-startup-header h1 {
+  margin: 0;
+  color: var(--text);
+  font-size: 18px;
+  font-weight: 650;
+  line-height: 1.2;
+}
+
+.ae-startup-header p,
+.ae-startup-reason {
+  margin: 4px 0 0;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+
+.ae-startup-tasks {
+  display: grid;
+  gap: 8px;
+}
+
+.ae-startup-task {
+  display: grid;
+  grid-template-columns: 12px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 9px;
+  min-height: 28px;
+  color: var(--text);
+  font-size: 13px;
+}
+
+.ae-startup-task-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--text-muted);
+}
+
+.ae-startup-task-dot.is-running,
+.ae-startup-task-dot.is-idle {
+  background: var(--accent);
+}
+
+.ae-startup-task-dot.is-ready {
+  background: var(--success, #2f9e44);
+}
+
+.ae-startup-task-dot.is-failed {
+  background: var(--danger, #d94848);
+}
+
+.ae-startup-task-meta {
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.ae-startup-output {
+  margin: 0;
+  min-height: 0;
+  max-height: 220px;
+  overflow: auto;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.ae-startup-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.ae-startup-actions button {
+  height: 30px;
+  padding: 0 12px;
+  border: 1px solid var(--accent);
+  border-radius: var(--radius-sm);
+  background: var(--accent);
+  color: var(--accent-contrast, #fff);
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.ae-startup-actions button.is-secondary {
+  border-color: var(--border);
+  background: var(--surface);
+  color: var(--text);
+}
+
 .a2ui-renderer {
   display: flex;
   flex-direction: column;
@@ -4616,6 +4747,40 @@ body.ae-resizing-composer * {
   opacity: 0.7;
 }
 .a2ui-status-devshell-label {
+  color: var(--text);
+  font-family: var(--font-ui);
+}
+
+.a2ui-status-startup-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: 0 var(--space-2);
+  border-right: 1px solid var(--border);
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  font-size: var(--chrome-text-muted);
+  white-space: nowrap;
+}
+
+.a2ui-status-startup-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--warn);
+}
+
+.a2ui-status-startup-chip.is-running .a2ui-status-startup-dot {
+  animation: ae-devshell-pulse 1.2s ease-in-out infinite;
+}
+
+.a2ui-status-startup-chip.is-failed .a2ui-status-startup-dot,
+.a2ui-status-startup-chip.is-failed .a2ui-status-startup-label {
+  color: var(--err, #c0392b);
+  background: var(--err, #c0392b);
+}
+
+.a2ui-status-startup-label {
   color: var(--text);
   font-family: var(--font-ui);
 }


### PR DESCRIPTION
## Summary
- add project-level `.aethon/startup.toml` support for workspace startup commands
- run env/devshell preparation and approved startup commands before cwd-scoped agent sessions start
- add a startup curtain/status UI with approval, retry, continue, and command output states
- document the project config format for app and bundled agent docs

## Validation
- `bun run lint`
- `bun run typecheck`
- `bunx vitest run`
- `cargo test --lib`
- `cargo clippy --lib -- -D warnings`
- `cargo fmt --check`
- `bun run build`
- `git diff --check`

## Rendered QA
- Browser plugin was installed but had no active `iab` target, so I used Playwright with system Chrome against `http://127.0.0.1:1420/`
- Verified startup approval curtain at desktop and mobile widths
- Verified Approve invokes `workspace_startup_approve` then `workspace_startup_prepare_for_path`
- Verified overlay clears once startup status becomes ready
