### PR TITLE
fix: scope startup overlay to workspace

### DIFF
--- a/src/app/AppRoot.test.tsx
+++ b/src/app/AppRoot.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { AppRoot } from "./AppRoot";
+import { ExtensionRegistry } from "../extensions/ExtensionRegistry";
+import { Layout } from "../extensions/default-layout/layout";
+import type { A2UIPayload } from "../types/a2ui";
+
+afterEach(() => cleanup());
+
+const noop = () => {};
+
+function registry() {
+  const reg = new ExtensionRegistry();
+  reg.register({ name: "test-layout", components: { layout: Layout } });
+  return reg;
+}
+
+function layoutPayload(): A2UIPayload {
+  return {
+    components: [
+      {
+        id: "root-layout",
+        type: "layout",
+        props: {
+          columns: "120px minmax(0, 1fr)",
+          rows: "38px minmax(0, 1fr)",
+          areas: ["sidebar header", "sidebar canvas"],
+        },
+        children: [
+          {
+            id: "sidebar",
+            type: "container",
+            props: { area: "sidebar", className: "test-sidebar" },
+            children: [{ id: "sidebar-text", type: "text", props: { text: "Sidebar" } }],
+          },
+          {
+            id: "header",
+            type: "container",
+            props: { area: "header", className: "test-header" },
+            children: [{ id: "header-text", type: "text", props: { text: "Header" } }],
+          },
+          {
+            id: "canvas",
+            type: "container",
+            props: { area: "canvas", className: "test-canvas" },
+            children: [{ id: "canvas-text", type: "text", props: { text: "Workspace" } }],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe("AppRoot workspace startup overlay", () => {
+  it("mounts running workspace startup inside the canvas cell after chrome is ready", async () => {
+    const { container } = render(
+      <AppRoot
+        registry={registry()}
+        layout={layoutPayload()}
+        renderState={{}}
+        setState={noop}
+        onEvent={noop}
+        activeTabId="default"
+        notificationsOpen={false}
+        paletteOpen={false}
+        settingsOpen={false}
+        searchOpen={false}
+        authProfilesOpen={false}
+        chromeReady
+        startupLogoUrl="/logo.svg"
+        workspaceStartup={{
+          output: "",
+          entry: {
+            root: "/repo",
+            fingerprint: "abc",
+            state: "running",
+            approved: true,
+            commands: [],
+          },
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen
+          .getByRole("status")
+          .classList.contains("ae-startup-curtain--workspace"),
+      ).toBe(true);
+    });
+
+    const startup = screen.getByRole("status");
+    const canvasCell = container.querySelector<HTMLElement>(
+      '.a2ui-layout-cell[data-area="canvas"]',
+    );
+    const sidebarCell = container.querySelector<HTMLElement>(
+      '.a2ui-layout-cell[data-area="sidebar"]',
+    );
+
+    expect(canvasCell).not.toBeNull();
+    expect(canvasCell?.contains(startup)).toBe(true);
+    expect(sidebarCell?.contains(startup)).toBe(false);
+    expect(startup.parentElement).toBe(canvasCell);
+  });
+});

--- a/src/app/AppRoot.test.tsx
+++ b/src/app/AppRoot.test.tsx
@@ -26,7 +26,8 @@ function layoutPayload(): A2UIPayload {
         props: {
           columns: "120px minmax(0, 1fr)",
           rows: "38px minmax(0, 1fr)",
-          areas: ["sidebar header", "sidebar canvas"],
+          areas: ["sidebar header", "sidebar workspace"],
+          slotMap: { canvas: "workspace" },
         },
         children: [
           {
@@ -93,15 +94,18 @@ describe("AppRoot workspace startup overlay", () => {
 
     const startup = screen.getByRole("status");
     const canvasCell = container.querySelector<HTMLElement>(
-      '.a2ui-layout-cell[data-area="canvas"]',
+      '.a2ui-layout-cell[data-slot="canvas"]',
     );
     const sidebarCell = container.querySelector<HTMLElement>(
       '.a2ui-layout-cell[data-area="sidebar"]',
     );
+    const startupHost = startup.closest(".ae-workspace-startup-host");
 
     expect(canvasCell).not.toBeNull();
+    expect(canvasCell?.dataset.area).toBe("workspace");
     expect(canvasCell?.contains(startup)).toBe(true);
+    expect(startupHost).not.toBeNull();
+    expect(canvasCell?.contains(startupHost)).toBe(true);
     expect(sidebarCell?.contains(startup)).toBe(false);
-    expect(startup.parentElement).toBe(canvasCell);
   });
 });

--- a/src/app/AppRoot.tsx
+++ b/src/app/AppRoot.tsx
@@ -1,3 +1,5 @@
+import { useSyncExternalStore } from "react";
+import { createPortal } from "react-dom";
 import type { Dispatch, ReactNode, SetStateAction } from "react";
 import A2UIRenderer, {
   RegistryComponent,
@@ -9,6 +11,52 @@ import type { A2UIPayload } from "../types/a2ui";
 import { isMacOS } from "../utils/platform";
 import { StartupCurtain } from "./StartupCurtain";
 import type { WorkspaceStartupView } from "../hooks/useWorkspaceStartup";
+
+const WORKSPACE_STARTUP_HOST_SELECTOR =
+  '.a2ui-layout-cell[data-area="canvas"][data-visible="true"]';
+
+function readWorkspaceStartupHost(active: boolean): HTMLElement | null {
+  if (!active || typeof document === "undefined") return null;
+  return document.querySelector<HTMLElement>(WORKSPACE_STARTUP_HOST_SELECTOR);
+}
+
+function subscribeWorkspaceStartupHost(onStoreChange: () => void): () => void {
+  if (
+    typeof document === "undefined" ||
+    !document.body ||
+    typeof MutationObserver === "undefined"
+  ) {
+    return () => {};
+  }
+
+  const observer = new MutationObserver(onStoreChange);
+  observer.observe(document.body, {
+    attributes: true,
+    attributeFilter: ["data-area", "data-visible"],
+    childList: true,
+    subtree: true,
+  });
+  queueMicrotask(onStoreChange);
+
+  return () => observer.disconnect();
+}
+
+function WorkspaceStartupPortal({
+  active,
+  children,
+}: {
+  active: boolean;
+  children: ReactNode;
+}) {
+  const host = useSyncExternalStore(
+    subscribeWorkspaceStartupHost,
+    () => readWorkspaceStartupHost(active),
+    () => null,
+  );
+
+  if (!active || !host) return null;
+  return createPortal(children, host);
+}
 
 export interface AppRootProps {
   registry: ExtensionRegistry;
@@ -61,12 +109,13 @@ export function AppRoot({
   onStartupContinue,
   topBanner,
 }: AppRootProps) {
-  const showStartupOverlay =
+  const showStartupOverlay = Boolean(
     chromeReady &&
-    workspaceStartup?.entry &&
-    ["running", "approval_required", "failed"].includes(
-      workspaceStartup.entry.state,
-    );
+      workspaceStartup?.entry &&
+      ["running", "approval_required", "failed"].includes(
+        workspaceStartup.entry.state,
+      ),
+  );
   return (
     <ExtensionRegistryProvider registry={registry}>
       {/* `data-platform="mac"` gates the overlay-titlebar chrome (traffic-
@@ -91,13 +140,16 @@ export function AppRoot({
           />
         )}
         {showStartupOverlay ? (
-          <StartupCurtain
-            logoUrl={startupLogoUrl}
-            startup={workspaceStartup}
-            onApprove={onStartupApprove}
-            onRetry={onStartupRetry}
-            onContinue={onStartupContinue}
-          />
+          <WorkspaceStartupPortal active={showStartupOverlay}>
+            <StartupCurtain
+              logoUrl={startupLogoUrl}
+              startup={workspaceStartup}
+              scope="workspace"
+              onApprove={onStartupApprove}
+              onRetry={onStartupRetry}
+              onContinue={onStartupContinue}
+            />
+          </WorkspaceStartupPortal>
         ) : null}
         {chromeReady && notificationsOpen && (
           <RegistryComponent

--- a/src/app/AppRoot.tsx
+++ b/src/app/AppRoot.tsx
@@ -13,7 +13,7 @@ import { StartupCurtain } from "./StartupCurtain";
 import type { WorkspaceStartupView } from "../hooks/useWorkspaceStartup";
 
 const WORKSPACE_STARTUP_HOST_SELECTOR =
-  '.a2ui-layout-cell[data-area="canvas"][data-visible="true"]';
+  '.a2ui-layout-cell[data-slot="canvas"][data-visible="true"]';
 
 function readWorkspaceStartupHost(active: boolean): HTMLElement | null {
   if (!active || typeof document === "undefined") return null;
@@ -55,7 +55,10 @@ function WorkspaceStartupPortal({
   );
 
   if (!active || !host) return null;
-  return createPortal(children, host);
+  return createPortal(
+    <div className="ae-workspace-startup-host">{children}</div>,
+    host,
+  );
 }
 
 export interface AppRootProps {

--- a/src/app/StartupCurtain.test.tsx
+++ b/src/app/StartupCurtain.test.tsx
@@ -27,11 +27,43 @@ describe("StartupCurtain", () => {
       />,
     );
 
-    expect(html).toContain("Approve Workspace Startup");
+    expect(html).toContain("Review Workspace Startup");
     expect(html).toContain("Install dependencies");
     expect(html).toContain("role=\"dialog\"");
     expect(html).toContain("aria-modal=\"true\"");
-    expect(html).toContain("<button");
+    expect(html).toContain("Approve and run");
+    expect(html).toContain("Skip startup");
     expect(html).not.toContain("aria-hidden=\"true\"");
+  });
+
+  it("labels failed startup actions by their effect", () => {
+    const html = renderToStaticMarkup(
+      <StartupCurtain
+        logoUrl="/logo.svg"
+        startup={{
+          output: "install failed",
+          entry: {
+            root: "/repo",
+            fingerprint: "abc",
+            state: "failed",
+            approved: true,
+            reason: "command exited 1",
+            commands: [
+              {
+                id: "deps",
+                label: "Install dependencies",
+                required: true,
+                state: "failed",
+              },
+            ],
+          },
+        }}
+      />,
+    );
+
+    expect(html).toContain("Workspace Startup Failed");
+    expect(html).toContain("Retry startup");
+    expect(html).toContain("Skip startup");
+    expect(html).not.toContain(">Continue<");
   });
 });

--- a/src/app/StartupCurtain.tsx
+++ b/src/app/StartupCurtain.tsx
@@ -4,6 +4,7 @@ import type { WorkspaceStartupView } from "../hooks/useWorkspaceStartup";
 export interface StartupCurtainProps {
   logoUrl: string;
   startup?: WorkspaceStartupView | null;
+  scope?: "window" | "workspace";
   onApprove?: () => void;
   onRetry?: () => void;
   onContinue?: () => void;
@@ -12,6 +13,7 @@ export interface StartupCurtainProps {
 export function StartupCurtain({
   logoUrl,
   startup,
+  scope = "window",
   onApprove,
   onRetry,
   onContinue,
@@ -38,18 +40,22 @@ export function StartupCurtain({
     .filter(Boolean)
     .join(" ");
   const title = pendingApproval
-    ? "Approve Workspace Startup"
+    ? "Review Workspace Startup"
     : failed
       ? "Workspace Startup Failed"
       : running
         ? "Preparing Workspace"
         : "Workspace Startup";
+  const className =
+    scope === "workspace"
+      ? "ae-startup-curtain ae-startup-curtain--workspace"
+      : "ae-startup-curtain";
 
   return (
     <div
-      className="ae-startup-curtain"
+      className={className}
       role={interactive ? "dialog" : "status"}
-      aria-modal={interactive ? "true" : undefined}
+      aria-modal={interactive && scope === "window" ? "true" : undefined}
       aria-live={interactive ? undefined : "polite"}
       aria-labelledby={titleId}
       aria-describedby={describedBy || undefined}
@@ -94,16 +100,16 @@ export function StartupCurtain({
           <div className="ae-startup-actions">
             {pendingApproval ? (
               <button type="button" onClick={onApprove}>
-                Approve
+                Approve and run
               </button>
             ) : null}
             {failed ? (
               <button type="button" onClick={onRetry}>
-                Retry
+                Retry startup
               </button>
             ) : null}
             <button type="button" className="is-secondary" onClick={onContinue}>
-              Continue
+              Skip startup
             </button>
           </div>
         ) : null}

--- a/src/extensions/default-layout/layout/grid.tsx
+++ b/src/extensions/default-layout/layout/grid.tsx
@@ -99,12 +99,14 @@ export function Layout({
           minWidth: 0,
           minHeight: 0,
           display: visible || keepsMountedForMotion ? "flex" : "none",
+          position: slotName === "canvas" ? "relative" : undefined,
         };
         return (
           <div
             key={child.id}
             className="a2ui-layout-cell"
             data-area={area}
+            data-slot={slotName}
             data-visible={visible ? "true" : "false"}
             style={cellStyle}
           >

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -176,6 +176,12 @@ body {
   background: var(--gradient-app-backdrop, var(--bg));
 }
 
+.ae-startup-curtain--workspace {
+  position: absolute;
+  z-index: 20;
+  background: var(--bg);
+}
+
 .ae-startup-panel {
   width: min(620px, 100%);
   max-height: min(620px, calc(var(--app-viewport-height) - 48px));
@@ -183,6 +189,10 @@ body {
   flex-direction: column;
   gap: 14px;
   overflow: hidden;
+}
+
+.ae-startup-curtain--workspace .ae-startup-panel {
+  max-height: min(620px, calc(100% - 48px));
 }
 
 .ae-startup-header {
@@ -350,6 +360,9 @@ body.ae-resizing-composer .a2ui-layout {
 .a2ui-layout-cell[data-visible="false"] {
   opacity: 0;
   pointer-events: none;
+}
+.a2ui-layout-cell[data-area="canvas"] {
+  position: relative;
 }
 
 .a2ui-layout-cell > .a2ui-renderer,

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -178,8 +178,17 @@ body {
 
 .ae-startup-curtain--workspace {
   position: absolute;
-  z-index: 20;
+  z-index: auto;
   background: var(--bg);
+}
+
+.ae-workspace-startup-host {
+  position: absolute;
+  inset: 0;
+  z-index: 20;
+  min-width: 0;
+  min-height: 0;
+  pointer-events: auto;
 }
 
 .ae-startup-panel {
@@ -360,9 +369,6 @@ body.ae-resizing-composer .a2ui-layout {
 .a2ui-layout-cell[data-visible="false"] {
   opacity: 0;
   pointer-events: none;
-}
-.a2ui-layout-cell[data-area="canvas"] {
-  position: relative;
 }
 
 .a2ui-layout-cell > .a2ui-renderer,


### PR DESCRIPTION
## Summary
- Mount in-app workspace startup states inside the visible workspace/canvas cell instead of covering the whole app chrome.
- Keep the pre-chrome boot curtain full-window.
- Rename ambiguous approval/failure actions to "Approve and run", "Retry startup", and "Skip startup".

## Validation
- bunx vitest run src/app/StartupCurtain.test.tsx src/app/AppRoot.test.tsx
- bunx vitest run src/extensions/default-layout/layout.test.tsx src/app/StartupCurtain.test.tsx src/app/AppRoot.test.tsx
- bun run typecheck
- bun run lint
- bunx vitest run
- bun run build
- Browser visual QA: desktop and compact-width harness confirmed the startup curtain is parented to the canvas cell, matches the canvas rect, and does not overlap sidebar/header/composer.