### PR TITLE
fix: persist xhigh reasoning defaults

### DIFF
--- a/.github/workflows/_ci.yml
+++ b/.github/workflows/_ci.yml
@@ -50,6 +50,18 @@ jobs:
         run: bun install --frozen-lockfile
       - name: Version files are synced
         run: bun run version:check
+      - name: Use public Ubuntu apt archive
+        run: |
+          if [ -f /etc/apt/apt-mirrors.txt ]; then
+            sudo sed -i \
+              's|http://azure.archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' \
+              /etc/apt/apt-mirrors.txt
+          fi
+          sudo grep -rl 'azure.archive.ubuntu.com' \
+            /etc/apt/sources.list \
+            /etc/apt/sources.list.d 2>/dev/null \
+            | xargs -r sudo sed -i \
+              's|http://azure.archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g'
       - name: Install Playwright Chromium
         run: bunx playwright install --with-deps chromium
       - name: Playwright

--- a/src/hooks/bridgeMessageHandlers/ready.test.ts
+++ b/src/hooks/bridgeMessageHandlers/ready.test.ts
@@ -193,6 +193,53 @@ describe("handleReady", () => {
     ]);
   });
 
+  it("keeps the configured default reasoning level ahead of the bridge fallback", () => {
+    const configuredThinkingLevel = "xhigh";
+    const bridgeFallbackThinkingLevel = "high";
+    const { ctx, applySetState } = buildHandlerFixture({
+      state: {
+        activeTabId: "default",
+        defaultThinkingLevel: configuredThinkingLevel,
+        thinkingLevel: configuredThinkingLevel,
+        tabs: [{ id: "default", model: "openai/gpt-5.5" }],
+        sidebar: {},
+      },
+    });
+
+    handleReady(
+      {
+        type: "ready",
+        model: "openai/gpt-5.5",
+        thinkingLevel: bridgeFallbackThinkingLevel,
+        models: [
+          {
+            id: "openai/gpt-5.5",
+            label: "GPT-5.5",
+            provider: "openai",
+            thinkingLevels: ["off", "minimal", "low", "medium", "high", "xhigh"],
+          },
+        ],
+        extensionStateKeys: [],
+        discoveredTabs: [],
+        tabs: [
+          {
+            id: "default",
+            model: "openai/gpt-5.5",
+            thinkingLevel: bridgeFallbackThinkingLevel,
+          },
+        ],
+      },
+      ctx,
+    );
+
+    const next = applySetState();
+    expect(next.thinkingLevel).toBe(configuredThinkingLevel);
+    expect(next.defaultThinkingLevel).toBe(configuredThinkingLevel);
+    expect((next.tabs as { thinkingLevel?: string }[])[0].thinkingLevel).toBe(
+      configuredThinkingLevel,
+    );
+  });
+
   it("prunes extension state keys that disappeared between readies", () => {
     const { ctx, applySetState } = buildHandlerFixture({
       state: { activeTabId: "default", tabs: [{ id: "default" }], sidebar: {} },
@@ -562,6 +609,57 @@ describe("handleReady", () => {
         tabId: "tab-2",
         restoreHistory: true,
         cwd: "/repo/a",
+      }),
+    ]);
+  });
+
+  it("replays restored tab reasoning levels to the bridge", () => {
+    const harness = installTauriMocks();
+    const { ctx } = buildHandlerFixture({
+      state: {
+        activeTabId: "default",
+        defaultThinkingLevel: "xhigh",
+        tabs: [
+          { id: "default", model: "claude", projectId: "p2" },
+          {
+            id: "tab-2",
+            model: "openai/gpt-5.5",
+            thinkingLevel: "xhigh",
+            projectId: "p1",
+          },
+        ],
+      },
+    });
+    ctx.projectsRef.current = {
+      activeId: "p2",
+      activeWorkspaceId: null,
+      workspacesByProject: {},
+      activeHostId: null,
+      projects: [
+        { id: "p1", label: "A", path: "/repo/a", lastUsed: 1 },
+        { id: "p2", label: "B", path: "/repo/b", lastUsed: 2 },
+      ],
+    };
+
+    handleReady(
+      {
+        type: "ready",
+        model: "claude",
+        tabs: [{ id: "default", model: "claude" }],
+      },
+      ctx,
+    );
+
+    const payloads = harness.invoke.mock.calls
+      .filter((call) => call[0] === "agent_command")
+      .map((call) => JSON.parse(call[1].payload as string));
+    expect(payloads).toEqual([
+      expect.objectContaining({
+        type: "tab_open",
+        tabId: "tab-2",
+        restoreHistory: true,
+        cwd: "/repo/a",
+        thinkingLevel: "xhigh",
       }),
     ]);
   });

--- a/src/hooks/bridgeMessageHandlers/ready.ts
+++ b/src/hooks/bridgeMessageHandlers/ready.ts
@@ -325,6 +325,11 @@ export const handleReady: BridgeMessageHandler = (data, ctx) => {
     // reload they're the only way to restore tab UI state that was
     // driven by the agent (React state didn't survive).
     {
+      const configuredDefaultThinkingLevel =
+        typeof next.defaultThinkingLevel === "string" &&
+        next.defaultThinkingLevel.length > 0
+          ? next.defaultThinkingLevel
+          : undefined;
       const localTabs = ((next.tabs as Tab[] | undefined) ?? []).slice();
       const bridgeTabs =
         (data.tabs as
@@ -359,8 +364,15 @@ export const handleReady: BridgeMessageHandler = (data, ctx) => {
         if (bt?.model && !localTabs[i].model) {
           localTabs[i] = { ...localTabs[i], model: bt.model };
         }
-        if (bt?.thinkingLevel) {
-          localTabs[i] = { ...localTabs[i], thinkingLevel: bt.thinkingLevel };
+        const tabThinkingLevel = localTabs[i]?.thinkingLevel;
+        const localThinkingLevel =
+          typeof tabThinkingLevel === "string" && tabThinkingLevel.length > 0
+            ? tabThinkingLevel
+            : undefined;
+        const readyThinkingLevel =
+          localThinkingLevel ?? configuredDefaultThinkingLevel ?? bt?.thinkingLevel;
+        if (readyThinkingLevel) {
+          localTabs[i] = { ...localTabs[i], thinkingLevel: readyThinkingLevel };
         }
         if (bt?.cwd && !localTabs[i].cwd) {
           localTabs[i] = { ...localTabs[i], cwd: bt.cwd };
@@ -429,7 +441,7 @@ export const handleReady: BridgeMessageHandler = (data, ctx) => {
       ...(userDir ? { aethonRoot: userDir } : {}),
       model: activeModel,
       ...(activeThinkingLevel ? { thinkingLevel: activeThinkingLevel } : {}),
-      defaultThinkingLevel: activeThinkingLevel ?? existingDefaultThinkingLevel,
+      defaultThinkingLevel: existingDefaultThinkingLevel ?? activeThinkingLevel,
       codexFastMode:
         typeof data.codexFastMode === "boolean"
           ? data.codexFastMode
@@ -495,6 +507,7 @@ export const handleReady: BridgeMessageHandler = (data, ctx) => {
           type: "tab_open",
           tabId: t.id,
           ...(t.model ? { model: t.model } : {}),
+          ...(t.thinkingLevel ? { thinkingLevel: t.thinkingLevel } : {}),
           ...(restoredCwd ? { cwd: restoredCwd } : {}),
           ...(t.authProfileId ? { authProfileId: t.authProfileId } : {}),
           restoreHistory: true,


### PR DESCRIPTION
## Summary

- Preserve a configured default reasoning level like `xhigh` when the bridge `ready` payload reports a fallback session level.
- Re-send restored tab reasoning levels in `tab_open` so reload/session replay keeps the bridge aligned with the UI.
- Add regression coverage for both startup hydration and restored tab replay.
- Stabilize the Playwright e2e install step by applying the existing public Ubuntu apt archive workaround before `playwright install --with-deps`.

## Root Cause

Aethon loaded `[agent] thinking_level = "xhigh"` into React state, but `ready` hydration could overwrite that durable default with the bridge's current/fallback session reasoning level. Restored non-default tabs also replayed model/cwd without forwarding `thinkingLevel`, so the UI and bridge could drift after reload.

## Validation

- `bunx vitest run src/hooks/bridgeMessageHandlers/ready.test.ts -t "configured default reasoning|restored tab reasoning"` (red before fix, green after)
- `bunx vitest run src/hooks/bridgeMessageHandlers/ready.test.ts src/hooks/useChat.test.ts src/hooks/tabOps/agentTab.test.ts`
- `bunx vitest run`
- `bun run typecheck`
- `bun run lint`
- `git diff --check`
