### PR TITLE
fix: retain active workspace tab

### DIFF
--- a/src/hooks/useProjectOps.test.ts
+++ b/src/hooks/useProjectOps.test.ts
@@ -633,7 +633,7 @@ describe("useProjectOps overview terminal project switches", () => {
     });
   }
 
-  it("preserves overview and spawns a shell when switching projects with the terminal open", () => {
+  it("restores the destination project session when switching projects with the terminal open", () => {
     const newShellTab = vi.fn();
     const { result, stateRef } = renderProjectOps(twoProjectState(), {
       newShellTab,
@@ -657,11 +657,11 @@ describe("useProjectOps overview terminal project switches", () => {
       expect(result.current.setActiveProjectById("project-2")).toBe(true);
     });
 
-    expect(stateRef.current.activeTabId).toBe(OVERVIEW_TAB_ID);
+    expect(stateRef.current.activeTabId).toBe("beta-agent");
     expect((stateRef.current.tabs as Tab[]).map((t) => t.id)).toEqual([
       "beta-agent",
     ]);
-    expect(newShellTab).toHaveBeenCalledTimes(1);
+    expect(newShellTab).not.toHaveBeenCalled();
   });
 
   it("does not spawn another shell when the destination bucket already has one", () => {
@@ -697,7 +697,7 @@ describe("useProjectOps overview terminal project switches", () => {
       expect(result.current.setActiveProjectById("project-2")).toBe(true);
     });
 
-    expect(stateRef.current.activeTabId).toBe(OVERVIEW_TAB_ID);
+    expect(stateRef.current.activeTabId).toBe("beta-shell");
     expect(newShellTab).not.toHaveBeenCalled();
   });
 
@@ -730,7 +730,39 @@ describe("useProjectOps overview terminal project switches", () => {
     expect(newShellTab).not.toHaveBeenCalled();
   });
 
-  it("preserves overview without spawning a shell when the terminal is closed", () => {
+  it("restores the destination workspace session instead of carrying overview across buckets", () => {
+    const newShellTab = vi.fn();
+    const { result, stateRef } = renderProjectOps(twoProjectState(), {
+      newShellTab,
+    });
+    const alphaAgent = nonEmptyAgentTab("alpha-agent", "Alpha", "project-1");
+    const betaAgent = nonEmptyAgentTab("beta-agent", "Beta", "project-2");
+    result.current.tabBucketsRef.current.set(
+      projectScopeBucketKey("project-2", null),
+      {
+        tabs: [betaAgent],
+        activeTabId: "beta-agent",
+      },
+    );
+    stateRef.current = {
+      ...stateRef.current,
+      activeTabId: OVERVIEW_TAB_ID,
+      terminal: { open: true },
+      tabs: [alphaAgent],
+    };
+
+    act(() => {
+      expect(result.current.setActiveProjectById("project-2")).toBe(true);
+    });
+
+    expect(stateRef.current.activeTabId).toBe("beta-agent");
+    expect((stateRef.current.tabs as Tab[]).map((t) => t.id)).toEqual([
+      "beta-agent",
+    ]);
+    expect(newShellTab).not.toHaveBeenCalled();
+  });
+
+  it("restores the destination project session when the terminal is closed", () => {
     const newShellTab = vi.fn();
     const { result, stateRef } = renderProjectOps(twoProjectState(), {
       newShellTab,
@@ -754,11 +786,11 @@ describe("useProjectOps overview terminal project switches", () => {
       expect(result.current.setActiveProjectById("project-2")).toBe(true);
     });
 
-    expect(stateRef.current.activeTabId).toBe(OVERVIEW_TAB_ID);
+    expect(stateRef.current.activeTabId).toBe("beta-agent");
     expect(newShellTab).not.toHaveBeenCalled();
   });
 
-  it("preserves overview and spawns a shell when clearing to the host bucket", () => {
+  it("restores the host session when clearing to the host bucket", () => {
     const newShellTab = vi.fn();
     const { result, stateRef } = renderProjectOps(twoProjectState(), {
       newShellTab,
@@ -779,11 +811,11 @@ describe("useProjectOps overview terminal project switches", () => {
       result.current.clearActiveProject();
     });
 
-    expect(stateRef.current.activeTabId).toBe(OVERVIEW_TAB_ID);
+    expect(stateRef.current.activeTabId).toBe("host-agent");
     expect((stateRef.current.tabs as Tab[]).map((t) => t.id)).toEqual([
       "host-agent",
     ]);
-    expect(newShellTab).toHaveBeenCalledTimes(1);
+    expect(newShellTab).not.toHaveBeenCalled();
   });
 
   it("does not spawn another shell when clearing to a host bucket with a shell", () => {
@@ -816,11 +848,11 @@ describe("useProjectOps overview terminal project switches", () => {
       result.current.clearActiveProject();
     });
 
-    expect(stateRef.current.activeTabId).toBe(OVERVIEW_TAB_ID);
+    expect(stateRef.current.activeTabId).toBe("host-shell");
     expect(newShellTab).not.toHaveBeenCalled();
   });
 
-  it("preserves overview and spawns a shell when switching to a workspace", () => {
+  it("restores the destination workspace session when switching to a workspace", () => {
     const newShellTab = vi.fn();
     const { result, stateRef } = renderProjectOps(projectWithWorkspaceState(), {
       newShellTab,
@@ -849,11 +881,11 @@ describe("useProjectOps overview terminal project switches", () => {
       result.current.activateWorkspace("wt-alpha-feature");
     });
 
-    expect(stateRef.current.activeTabId).toBe(OVERVIEW_TAB_ID);
+    expect(stateRef.current.activeTabId).toBe("workspace-agent");
     expect((stateRef.current.tabs as Tab[]).map((t) => t.id)).toEqual([
       "workspace-agent",
     ]);
-    expect(newShellTab).toHaveBeenCalledTimes(1);
+    expect(newShellTab).not.toHaveBeenCalled();
   });
 
   it("does not spawn another shell when switching to a workspace bucket with a shell", () => {
@@ -889,7 +921,7 @@ describe("useProjectOps overview terminal project switches", () => {
       result.current.activateWorkspace("wt-alpha-feature");
     });
 
-    expect(stateRef.current.activeTabId).toBe(OVERVIEW_TAB_ID);
+    expect(stateRef.current.activeTabId).toBe("workspace-shell");
     expect(newShellTab).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/useProjectOps.test.ts
+++ b/src/hooks/useProjectOps.test.ts
@@ -664,6 +664,27 @@ describe("useProjectOps overview terminal project switches", () => {
     expect(newShellTab).not.toHaveBeenCalled();
   });
 
+  it("spawns an overview shell when switching into an empty project bucket with the terminal open", () => {
+    const newShellTab = vi.fn();
+    const { result, stateRef } = renderProjectOps(twoProjectState(), {
+      newShellTab,
+    });
+    stateRef.current = {
+      ...stateRef.current,
+      activeTabId: OVERVIEW_TAB_ID,
+      terminal: { open: true },
+      tabs: [],
+    };
+
+    act(() => {
+      expect(result.current.setActiveProjectById("project-2")).toBe(true);
+    });
+
+    expect(stateRef.current.activeTabId).toBeUndefined();
+    expect(stateRef.current.tabs).toEqual([]);
+    expect(newShellTab).toHaveBeenCalledTimes(1);
+  });
+
   it("does not spawn another shell when the destination bucket already has one", () => {
     const newShellTab = vi.fn();
     const { result, stateRef } = renderProjectOps(twoProjectState(), {
@@ -730,7 +751,7 @@ describe("useProjectOps overview terminal project switches", () => {
     expect(newShellTab).not.toHaveBeenCalled();
   });
 
-  it("restores the destination workspace session instead of carrying overview across buckets", () => {
+  it("restores the destination project session instead of carrying overview across buckets", () => {
     const newShellTab = vi.fn();
     const { result, stateRef } = renderProjectOps(twoProjectState(), {
       newShellTab,

--- a/src/hooks/useProjectOps.ts
+++ b/src/hooks/useProjectOps.ts
@@ -11,7 +11,6 @@ import {
   isOverviewActive,
   makeEmptyTab,
   NO_PROJECT_KEY,
-  OVERVIEW_TAB_ID,
   type Tab,
 } from "../types/tab";
 import {
@@ -112,10 +111,6 @@ export function useProjectOps(ctx: UseProjectOpsContext): UseProjectOpsActions {
     toKey: string,
     opts: { mirrorProjects?: boolean } = {},
   ): string | undefined {
-    // Preserve only an explicitly selected overview. An unset activeTabId
-    // usually means the source bucket was empty; it must not suppress a
-    // real active tab restored from the destination bucket.
-    const wasOverview = stateRef.current.activeTabId === OVERVIEW_TAB_ID;
     const nextTabId = switchTabBucket(
       {
         setState,
@@ -129,7 +124,6 @@ export function useProjectOps(ctx: UseProjectOpsContext): UseProjectOpsActions {
       toKey,
       opts,
     );
-    preserveOverviewIfNeeded(wasOverview);
     maybeSpawnOverviewShell();
     return nextTabId;
   }
@@ -144,14 +138,6 @@ export function useProjectOps(ctx: UseProjectOpsContext): UseProjectOpsActions {
     const tabs = (state.tabs as Tab[] | undefined) ?? [];
     if (tabs.some((t) => t.kind === "shell")) return;
     newShellTab();
-  }
-
-  function preserveOverviewIfNeeded(wasOverview: boolean): void {
-    if (!wasOverview) return;
-    setState((prev) => {
-      if (prev.activeTabId === OVERVIEW_TAB_ID) return prev;
-      return { ...prev, activeTabId: OVERVIEW_TAB_ID };
-    });
   }
 
   async function openProjectFromPicker(): Promise<string | null> {


### PR DESCRIPTION
## Summary
- Stop carrying the overview pseudo-tab across project/workspace bucket switches.
- Let the destination bucket restore its own remembered active session or shell tab.
- Update workspace/project bucket tests to cover switching back to a saved session from overview state.

## Root Cause
`useProjectOps` restored the destination bucket and then unconditionally rewrote `activeTabId` back to `__overview__` whenever the source bucket was on overview. That made switching back to a workspace with an active saved session show the overview instead of the session.

## Validation
- `bunx vitest run src/hooks/useProjectOps.test.ts -t "restores the destination workspace session"`
- `bunx vitest run src/hooks/useProjectOps.test.ts src/hooks/projectOps/tabBuckets.test.ts`
- `bunx vitest run src/eventRoutes/sidebar.test.ts src/eventRoutes/dashboard.test.ts src/eventRoutes/tabStrip.test.ts src/hooks/useProjectOps.test.ts src/hooks/projectOps/tabBuckets.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bunx vitest run`
- `bun run build`

Note: `bun run build` still emits the existing Vite large-chunk warning.