### PR TITLE
fix: refresh file tree after agent writes

### DIFF
--- a/src/extensions/default-layout/sidebar/file-tree.test.tsx
+++ b/src/extensions/default-layout/sidebar/file-tree.test.tsx
@@ -11,6 +11,7 @@ import {
 
 import { FileTreePanel } from "./file-tree";
 import { visibleChangedDirs } from "./file-tree-watch";
+import { AGENT_TURN_COMPLETE_EVENT } from "../../../utils/agentTurnEvents";
 
 // Mock persist + tauri invoke per-test so the component sees a known
 // "empty" persisted-store + a controllable directory listing.
@@ -829,7 +830,7 @@ describe("FileTreePanel", () => {
     });
   });
 
-  it("refreshes expanded folders when an agent turn ends after creating a nested file", async () => {
+  it("refreshes expanded folders when one agent turn completes while another tab is still busy", async () => {
     let agentFileCreated = false;
     invokeMock.mockImplementation((cmd: string, args?: { path?: string }) => {
       if (cmd === "fs_list_dir" && args?.path === "/projects/aethon") {
@@ -866,7 +867,22 @@ describe("FileTreePanel", () => {
         {...panelProps({
           state: {
             project: { path: "/projects/aethon", name: "aethon" },
+            activeTabId: "tab-a",
             waiting: true,
+            tabs: [
+              {
+                id: "tab-a",
+                kind: "agent",
+                cwd: "/projects/aethon",
+                waiting: true,
+              },
+              {
+                id: "tab-b",
+                kind: "agent",
+                cwd: "/projects/aethon",
+                waiting: true,
+              },
+            ],
           },
         })}
       />,
@@ -880,11 +896,33 @@ describe("FileTreePanel", () => {
         {...panelProps({
           state: {
             project: { path: "/projects/aethon", name: "aethon" },
+            activeTabId: "tab-a",
             waiting: false,
+            tabs: [
+              {
+                id: "tab-a",
+                kind: "agent",
+                cwd: "/projects/aethon",
+                waiting: false,
+              },
+              {
+                id: "tab-b",
+                kind: "agent",
+                cwd: "/projects/aethon",
+                waiting: true,
+              },
+            ],
           },
         })}
       />,
     );
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(AGENT_TURN_COMPLETE_EVENT, {
+          detail: { tabId: "tab-a", text: "done" },
+        }),
+      );
+    });
 
     await screen.findByText("agent-created.ts");
   });

--- a/src/extensions/default-layout/sidebar/file-tree.test.tsx
+++ b/src/extensions/default-layout/sidebar/file-tree.test.tsx
@@ -326,7 +326,7 @@ describe("FileTreePanel", () => {
 
     render(<FileTreePanel {...panelProps()} />);
     await waitFor(() => screen.getByText("src"));
-    for (const label of ["New File", "New Folder", "Refresh"]) {
+    for (const label of ["New File", "New Folder", "Refresh files"]) {
       expect(screen.getByLabelText(label)).toBeTruthy();
     }
     // Expand/Collapse-all live in the header right-click menu, not the toolbar.
@@ -827,6 +827,108 @@ describe("FileTreePanel", () => {
         screen.getByText("src").closest("li")?.getAttribute("aria-expanded"),
       ).toBe("true");
     });
+  });
+
+  it("refreshes expanded folders when an agent turn ends after creating a nested file", async () => {
+    let agentFileCreated = false;
+    invokeMock.mockImplementation((cmd: string, args?: { path?: string }) => {
+      if (cmd === "fs_list_dir" && args?.path === "/projects/aethon") {
+        return Promise.resolve([
+          { name: "src", path: "/projects/aethon/src", kind: "dir" },
+        ]);
+      }
+      if (cmd === "fs_list_dir" && args?.path === "/projects/aethon/src") {
+        return Promise.resolve([
+          {
+            name: "old.ts",
+            path: "/projects/aethon/src/old.ts",
+            kind: "file",
+          },
+          ...(agentFileCreated
+            ? [
+                {
+                  name: "agent-created.ts",
+                  path: "/projects/aethon/src/agent-created.ts",
+                  kind: "file",
+                },
+              ]
+            : []),
+        ]);
+      }
+      if (cmd === "git_file_status" || cmd === "git_ignored_paths") {
+        return Promise.resolve([]);
+      }
+      return Promise.resolve(1);
+    });
+
+    const { rerender } = render(
+      <FileTreePanel
+        {...panelProps({
+          state: {
+            project: { path: "/projects/aethon", name: "aethon" },
+            waiting: true,
+          },
+        })}
+      />,
+    );
+    fireEvent.click(await screen.findByText("src"));
+    await screen.findByText("old.ts");
+
+    agentFileCreated = true;
+    rerender(
+      <FileTreePanel
+        {...panelProps({
+          state: {
+            project: { path: "/projects/aethon", name: "aethon" },
+            waiting: false,
+          },
+        })}
+      />,
+    );
+
+    await screen.findByText("agent-created.ts");
+  });
+
+  it("manual refresh reloads expanded folders, not just the root listing", async () => {
+    let agentFileCreated = false;
+    invokeMock.mockImplementation((cmd: string, args?: { path?: string }) => {
+      if (cmd === "fs_list_dir" && args?.path === "/projects/aethon") {
+        return Promise.resolve([
+          { name: "src", path: "/projects/aethon/src", kind: "dir" },
+        ]);
+      }
+      if (cmd === "fs_list_dir" && args?.path === "/projects/aethon/src") {
+        return Promise.resolve([
+          {
+            name: "old.ts",
+            path: "/projects/aethon/src/old.ts",
+            kind: "file",
+          },
+          ...(agentFileCreated
+            ? [
+                {
+                  name: "agent-created.ts",
+                  path: "/projects/aethon/src/agent-created.ts",
+                  kind: "file",
+                },
+              ]
+            : []),
+        ]);
+      }
+      if (cmd === "git_file_status" || cmd === "git_ignored_paths") {
+        return Promise.resolve([]);
+      }
+      return Promise.resolve(1);
+    });
+
+    render(<FileTreePanel {...panelProps()} />);
+    fireEvent.click(await screen.findByText("src"));
+    await screen.findByText("old.ts");
+
+    agentFileCreated = true;
+    fireEvent.click(screen.getByLabelText("Refresh files"));
+
+    await screen.findByText("agent-created.ts");
   });
 
   it("refreshes git decorations when a git-state-changed event fires for the root", async () => {

--- a/src/extensions/default-layout/sidebar/file-tree.tsx
+++ b/src/extensions/default-layout/sidebar/file-tree.tsx
@@ -45,6 +45,7 @@ import {
   useFileTreePrefs,
 } from "./useFileTreePrefs";
 import { useFileTreeWatch } from "./useFileTreeWatch";
+import { onAgentTurnComplete } from "../../../utils/agentTurnEvents";
 
 const EMPTY_TABS: EditorTabShape[] = [];
 
@@ -62,6 +63,7 @@ export function FileTreePanel({
   const fillsContainer = embedMode === "right-sidebar";
   const project = state["project"] as ProjectShape | undefined;
   const tabs = (state["tabs"] as EditorTabShape[] | undefined) ?? EMPTY_TABS;
+  const tabsRef = useRef(tabs);
   const activeTabId = state["activeTabId"] as string | undefined;
   const activeTab = activeTabId
     ? tabs.find((t) => t.id === activeTabId)
@@ -69,6 +71,10 @@ export function FileTreePanel({
   const activeEditorRoot =
     activeTab?.kind === "editor" ? activeTab.editor?.rootPath : undefined;
   const [aethonRoot, setAethonRoot] = useState<string>("");
+
+  useEffect(() => {
+    tabsRef.current = tabs;
+  }, [tabs]);
 
   useEffect(() => {
     if (project?.path || activeEditorRoot || aethonRoot) return;
@@ -152,17 +158,6 @@ export function FileTreePanel({
     expandAll,
     collapseUnder,
   });
-  const agentBusy = useMemo(() => {
-    const activeTabWaiting = state["waiting"] === true;
-    const visibleTabWaiting = tabs.some(
-      (tab) =>
-        tab.kind === "agent" &&
-        tab.waiting === true &&
-        (!tab.cwd || tab.cwd === projectPath),
-    );
-    return activeTabWaiting || visibleTabWaiting;
-  }, [projectPath, state, tabs]);
-  const wasAgentBusyRef = useRef(agentBusy);
   const [refreshingFiles, setRefreshingFiles] = useState(false);
   const refreshFiles = useCallback(async () => {
     if (!projectPath || refreshingFiles) return;
@@ -175,11 +170,15 @@ export function FileTreePanel({
   }, [projectPath, refreshVisibleFolders, refreshingFiles]);
 
   useEffect(() => {
-    if (wasAgentBusyRef.current && !agentBusy && projectPath) {
+    return onAgentTurnComplete(({ tabId }) => {
+      const projectKey = projectPathRef.current;
+      if (!projectKey) return;
+      const tab = tabsRef.current.find((candidate) => candidate.id === tabId);
+      if (!tab || tab.kind !== "agent") return;
+      if (tab.cwd && tab.cwd !== projectKey) return;
       void refreshVisibleFolders();
-    }
-    wasAgentBusyRef.current = agentBusy;
-  }, [agentBusy, projectPath, refreshVisibleFolders]);
+    });
+  }, [projectPathRef, refreshVisibleFolders]);
 
   // Native File menu → "New File…" routes here (the file tree owns the
   // create flow). No-op when no project is active.

--- a/src/extensions/default-layout/sidebar/file-tree.tsx
+++ b/src/extensions/default-layout/sidebar/file-tree.tsx
@@ -8,6 +8,7 @@
  */
 
 import {
+  useCallback,
   useEffect,
   useMemo,
   useRef,
@@ -45,6 +46,8 @@ import {
 } from "./useFileTreePrefs";
 import { useFileTreeWatch } from "./useFileTreeWatch";
 
+const EMPTY_TABS: EditorTabShape[] = [];
+
 export function FileTreePanel({
   component,
   state,
@@ -58,7 +61,7 @@ export function FileTreePanel({
   const embedMode = componentProps.embed ?? "left-stack";
   const fillsContainer = embedMode === "right-sidebar";
   const project = state["project"] as ProjectShape | undefined;
-  const tabs = (state["tabs"] as EditorTabShape[] | undefined) ?? [];
+  const tabs = (state["tabs"] as EditorTabShape[] | undefined) ?? EMPTY_TABS;
   const activeTabId = state["activeTabId"] as string | undefined;
   const activeTab = activeTabId
     ? tabs.find((t) => t.id === activeTabId)
@@ -115,6 +118,7 @@ export function FileTreePanel({
     ignoreMatcher,
     projectPathRef,
     refreshFolder,
+    refreshVisibleFolders,
     revealPath,
     revealTarget,
     clearRevealTarget,
@@ -148,6 +152,34 @@ export function FileTreePanel({
     expandAll,
     collapseUnder,
   });
+  const agentBusy = useMemo(() => {
+    const activeTabWaiting = state["waiting"] === true;
+    const visibleTabWaiting = tabs.some(
+      (tab) =>
+        tab.kind === "agent" &&
+        tab.waiting === true &&
+        (!tab.cwd || tab.cwd === projectPath),
+    );
+    return activeTabWaiting || visibleTabWaiting;
+  }, [projectPath, state, tabs]);
+  const wasAgentBusyRef = useRef(agentBusy);
+  const [refreshingFiles, setRefreshingFiles] = useState(false);
+  const refreshFiles = useCallback(async () => {
+    if (!projectPath || refreshingFiles) return;
+    setRefreshingFiles(true);
+    try {
+      await refreshVisibleFolders();
+    } finally {
+      setRefreshingFiles(false);
+    }
+  }, [projectPath, refreshVisibleFolders, refreshingFiles]);
+
+  useEffect(() => {
+    if (wasAgentBusyRef.current && !agentBusy && projectPath) {
+      void refreshVisibleFolders();
+    }
+    wasAgentBusyRef.current = agentBusy;
+  }, [agentBusy, projectPath, refreshVisibleFolders]);
 
   // Native File menu → "New File…" routes here (the file tree owns the
   // create flow). No-op when no project is active.
@@ -332,15 +364,16 @@ export function FileTreePanel({
                 case "new-folder":
                   void createEntry(projectPath, "dir");
                   break;
-                case "refresh":
-                  void refreshFolder(projectPath);
-                  break;
               }
             }}
           >
             <TreeActionIcon name={action.key} />
           </button>
         ))}
+        <FileTreeRefreshButton
+          refreshing={refreshingFiles}
+          onRefresh={refreshFiles}
+        />
       </div>
     ) : null;
 
@@ -673,8 +706,33 @@ type TreeActionKey = "new-file" | "new-folder" | "refresh";
 const TREE_ACTIONS: { key: TreeActionKey; label: string }[] = [
   { key: "new-file", label: "New File" },
   { key: "new-folder", label: "New Folder" },
-  { key: "refresh", label: "Refresh" },
 ];
+
+function FileTreeRefreshButton({
+  refreshing,
+  onRefresh,
+}: {
+  refreshing: boolean;
+  onRefresh: () => void;
+}) {
+  const label = refreshing ? "Refreshing files" : "Refresh files";
+  return (
+    <button
+      type="button"
+      className={`ae-file-tree-action${refreshing ? " is-refreshing" : ""}`}
+      aria-label={label}
+      aria-busy={refreshing}
+      title={label}
+      disabled={refreshing}
+      onClick={(e) => {
+        e.stopPropagation();
+        onRefresh();
+      }}
+    >
+      <TreeActionIcon name="refresh" />
+    </button>
+  );
+}
 
 /** Compact 16px line icons for the file-tree header toolbar. */
 function TreeActionIcon({ name }: { name: TreeActionKey }) {

--- a/src/extensions/default-layout/sidebar/fileTreeModel.ts
+++ b/src/extensions/default-layout/sidebar/fileTreeModel.ts
@@ -42,6 +42,8 @@ interface TreeNode {
 interface EditorTabShape {
   id?: string;
   kind?: string;
+  cwd?: string;
+  waiting?: boolean;
   editor?: {
     rootPath?: string;
     filePath?: string;

--- a/src/extensions/default-layout/sidebar/useFileTreeData.ts
+++ b/src/extensions/default-layout/sidebar/useFileTreeData.ts
@@ -542,6 +542,18 @@ function useFileTreeData({
     [invalidateFolder, scheduleGitStatusRefresh],
   );
 
+  const refreshVisibleFolders = useCallback(async () => {
+    const projectKey = projectPathRef.current;
+    if (!projectKey) return;
+    const dirs = [projectKey, ...expandedRef.current].sort(
+      (a, b) => a.length - b.length || a.localeCompare(b),
+    );
+    for (const dir of dirs) {
+      if (projectPathRef.current !== projectKey) return;
+      await refreshFolder(dir);
+    }
+  }, [refreshFolder]);
+
   useEffect(() => {
     return () => {
       if (gitStatusRefreshTimerRef.current) {
@@ -560,6 +572,7 @@ function useFileTreeData({
     ignoreMatcher,
     projectPathRef,
     refreshFolder,
+    refreshVisibleFolders,
     revealPath,
     revealTarget,
     clearRevealTarget,

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -583,6 +583,14 @@ body.ae-resizing-composer .a2ui-layout {
   color: var(--text);
   background: var(--bg-hover);
 }
+.ae-file-tree-action:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+.ae-file-tree-action:disabled:hover {
+  color: var(--text-dim);
+  background: transparent;
+}
 .ae-file-tree-resize-handle {
   position: absolute;
   top: -3px;


### PR DESCRIPTION
## Summary
- refresh all visible file-tree folders after an agent turn settles so externally-created files appear without a reload
- wire the file tree refresh toolbar button through the same visible-folder refresh path
- add regression coverage for agent-created nested files and manual refresh of expanded folders

Fixes #302

## Verification
- bunx vitest run src/extensions/default-layout/sidebar/file-tree.test.tsx -t "agent turn ends|manual refresh"
- bunx vitest run src/extensions/default-layout/sidebar/file-tree.test.tsx
- bunx vitest run src/extensions/default-layout/sidebar/fileTreeModel.test.ts
- bun run typecheck
- bun run lint
- bunx vitest run
- bun run build
- Browser QA at http://127.0.0.1:5179/ loaded the app shell; standalone browser lacks Tauri internals, so file-system interaction could not be exercised there.