### PR TITLE
fix: add voice input to overview task launcher

### DIFF
--- a/src/extensions/default-layout/chat-input.tsx
+++ b/src/extensions/default-layout/chat-input.tsx
@@ -41,8 +41,12 @@ import {
   insertTranscriptAtSelection,
   shouldOpenVoiceSettingsForError,
 } from "../../utils/voice";
-import { VoiceMeter } from "./voice-meter";
 import { ConversationHud } from "./conversation-hud";
+import {
+  VoiceConversationButton,
+  VoiceInputButton,
+  VoiceStatus,
+} from "./voice-controls";
 import {
   type ArgMatch,
   type CommandMatch,
@@ -506,58 +510,11 @@ export function ChatInput({
             onEvent("voice:setup", { providerId: voice.activeProvider?.id })
           }
         />
-        <button
-          type="button"
-          className={`a2ui-chat-input-voice ${voice.state === "recording" ? "a2ui-chat-input-voice-recording" : ""} ${
-            voice.state === "starting" || voice.state === "transcribing"
-              ? "a2ui-chat-input-voice-busy"
-              : ""
-          }`}
-          onClick={() => {
-            if (voice.state === "recording") voice.stop();
-            else if (
-              voice.state === "starting" ||
-              voice.state === "transcribing"
-            ) {
-              voice.cancel();
-            } else {
-              void voice.start();
-            }
-          }}
-          disabled={busy}
-          aria-label={voiceButtonLabel(voice.state)}
-          title={voiceButtonLabel(voice.state)}
-        >
-          {voice.state === "starting" || voice.state === "transcribing" ? (
-            <SpinnerIcon />
-          ) : voice.state === "recording" ? (
-            <StopVoiceIcon />
-          ) : (
-            <MicIcon />
-          )}
-        </button>
-        <button
-          type="button"
-          className={`a2ui-chat-input-voice a2ui-chat-input-conversation ${
-            conversation.active ? "a2ui-chat-input-conversation-active" : ""
-          }`}
-          onClick={() =>
-            conversation.active ? conversation.exit() : conversation.enter()
-          }
+        <VoiceInputButton voice={voice} disabled={busy} />
+        <VoiceConversationButton
+          conversation={conversation}
           disabled={busy && !conversation.active}
-          aria-label={
-            conversation.active
-              ? "Exit voice conversation"
-              : "Start voice conversation"
-          }
-          title={
-            conversation.active
-              ? "Exit voice conversation"
-              : "Start voice conversation"
-          }
-        >
-          <ConversationIcon />
-        </button>
+        />
         {busy ? (
           <button
             type="button"
@@ -617,8 +574,6 @@ export function ChatInput({
   );
 }
 
-type VoiceView = ReturnType<typeof useVoiceInput>;
-
 function AttachmentTray({
   attachments,
   onRemove,
@@ -656,151 +611,5 @@ function AttachmentTray({
         <ImageLightbox attachment={open} onClose={() => setOpen(null)} />
       )}
     </>
-  );
-}
-
-function VoiceStatus({
-  voice,
-  useDynamicMeter,
-  errorOpensSettings,
-  onOpenSettings,
-}: {
-  voice: VoiceView;
-  useDynamicMeter: boolean;
-  errorOpensSettings: boolean;
-  onOpenSettings: () => void;
-}) {
-  if (voice.state === "recording") {
-    return (
-      <div className="a2ui-chat-input-voice-status">
-        <VoiceMeter
-          elapsedSeconds={voice.elapsedSeconds}
-          useDynamicMeter={useDynamicMeter}
-        />
-      </div>
-    );
-  }
-  if (voice.state === "starting" || voice.state === "transcribing") {
-    return (
-      <div className="a2ui-chat-input-voice-status" aria-live="polite">
-        <SpinnerIcon />
-        <span>
-          {voice.state === "starting"
-            ? "Starting..."
-            : voice.activeProvider?.name
-              ? `Transcribing with ${voice.activeProvider.name}`
-              : "Transcribing..."}
-        </span>
-      </div>
-    );
-  }
-  if (voice.state === "error" && voice.error) {
-    return (
-      <button
-        type="button"
-        className="a2ui-chat-input-voice-error"
-        onClick={errorOpensSettings ? onOpenSettings : voice.cancel}
-        title={voice.error}
-      >
-        <span aria-hidden="true">!</span>
-        <span>{voice.error}</span>
-      </button>
-    );
-  }
-  if (voice.state === "setup-required" && voice.error) {
-    return (
-      <button
-        type="button"
-        className="a2ui-chat-input-voice-error"
-        onClick={onOpenSettings}
-        title={voice.error}
-      >
-        <span aria-hidden="true">!</span>
-        <span>{voice.error}</span>
-      </button>
-    );
-  }
-  return null;
-}
-
-function ConversationIcon() {
-  // A speech / conversation glyph (two overlapping bubbles).
-  return (
-    <svg
-      width="16"
-      height="16"
-      viewBox="0 0 16 16"
-      fill="none"
-      aria-hidden="true"
-    >
-      <path
-        d="M2 4.5A1.5 1.5 0 0 1 3.5 3h6A1.5 1.5 0 0 1 11 4.5v3A1.5 1.5 0 0 1 9.5 9H6L3.5 11V9A1.5 1.5 0 0 1 2 7.5v-3Z"
-        stroke="currentColor"
-        strokeWidth="1.3"
-        strokeLinejoin="round"
-      />
-      <path
-        d="M6.5 11.5A1.5 1.5 0 0 0 8 13h3l1.5 1.5V13A1.5 1.5 0 0 0 14 11.5V9"
-        stroke="currentColor"
-        strokeWidth="1.3"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
-
-function voiceButtonLabel(state: VoiceView["state"]): string {
-  if (state === "recording") return "Stop voice input";
-  if (state === "starting") return "Cancel voice input";
-  if (state === "transcribing") return "Cancel transcription";
-  return "Voice input";
-}
-
-function MicIcon() {
-  return (
-    <svg width="16" height="16" viewBox="0 0 16 16" aria-hidden="true">
-      <path
-        d="M8 2.25a2.25 2.25 0 0 0-2.25 2.25V8a2.25 2.25 0 0 0 4.5 0V4.5A2.25 2.25 0 0 0 8 2.25Z"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.45"
-      />
-      <path
-        d="M3.75 7.25V8a4.25 4.25 0 0 0 8.5 0v-.75M8 12.25v1.5M5.75 13.75h4.5"
-        fill="none"
-        stroke="currentColor"
-        strokeLinecap="round"
-        strokeWidth="1.45"
-      />
-    </svg>
-  );
-}
-
-function StopVoiceIcon() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 16 16" aria-hidden="true">
-      <rect x="3.5" y="3.5" width="9" height="9" rx="1.5" fill="currentColor" />
-    </svg>
-  );
-}
-
-function SpinnerIcon() {
-  return (
-    <svg
-      className="a2ui-chat-input-voice-spinner"
-      width="16"
-      height="16"
-      viewBox="0 0 16 16"
-      aria-hidden="true"
-    >
-      <path
-        d="M8 2.25a5.75 5.75 0 1 1-5.16 3.22"
-        fill="none"
-        stroke="currentColor"
-        strokeLinecap="round"
-        strokeWidth="1.7"
-      />
-    </svg>
   );
 }

--- a/src/extensions/default-layout/dashboard/task-launcher.test.tsx
+++ b/src/extensions/default-layout/dashboard/task-launcher.test.tsx
@@ -11,6 +11,7 @@ import {
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { TaskLauncher } from "./task-launcher";
 import type { A2UIComponent } from "../../../types/a2ui";
+import type { VoiceProviderInfo } from "../../../types/voice";
 
 const { invoke } = vi.hoisted(() => ({
   invoke: vi.fn(),
@@ -26,6 +27,32 @@ function launcher(props: Record<string, unknown>): A2UIComponent {
     id: "task-launcher",
     type: "task-launcher",
     props,
+  };
+}
+
+function voiceProvider(
+  overrides: Partial<VoiceProviderInfo> & Pick<VoiceProviderInfo, "id">,
+): VoiceProviderInfo {
+  return {
+    name: overrides.id,
+    description: "",
+    kind: "platform",
+    recordingMode: "native",
+    privacyLabel: "",
+    offline: false,
+    downloadRequired: false,
+    modelSizeLabel: null,
+    cachePath: null,
+    acceleratorLabel: null,
+    status: "ready",
+    statusLabel: "Ready",
+    enabled: true,
+    selected: true,
+    setupRequired: false,
+    canRemoveModel: false,
+    error: null,
+    ...overrides,
+    id: overrides.id,
   };
 }
 
@@ -71,6 +98,67 @@ describe("TaskLauncher", () => {
     );
     expect(html).toContain("aethon");
     expect(html).toContain("Start");
+  });
+
+  it("renders the voice input control on the overview task launcher", () => {
+    render(
+      <TaskLauncher
+        component={launcher({
+          project: { id: "p1", label: "aethon", path: "/a" },
+        })}
+        state={{}}
+        onEvent={() => {}}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Voice input" })).toBeTruthy();
+  });
+
+  it("inserts a voice transcript into the task prompt and submits it", async () => {
+    invoke.mockImplementation((cmd: string) => {
+      if (cmd === "voice_list_providers") {
+        return Promise.resolve([
+          voiceProvider({ id: "voice-platform-system" }),
+        ]);
+      }
+      if (cmd === "voice_start_recording") return Promise.resolve(undefined);
+      if (cmd === "voice_stop_and_transcribe") {
+        return Promise.resolve("review the open issues");
+      }
+      return Promise.reject(new Error(`invoke not mocked: ${cmd}`));
+    });
+    const onEvent = vi.fn();
+    render(
+      <TaskLauncher
+        component={launcher({
+          project: { id: "p1", label: "aethon", path: "/a" },
+        })}
+        state={{}}
+        onEvent={onEvent}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Voice input" }));
+    await screen.findByRole("button", { name: "Stop voice input" });
+    fireEvent.click(screen.getByRole("button", { name: "Stop voice input" }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByLabelText<HTMLTextAreaElement>("Task prompt").value,
+      ).toBe("review the open issues"),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Start" }));
+
+    await waitFor(() =>
+      expect(onEvent).toHaveBeenCalledWith(
+        "start-task",
+        expect.objectContaining({
+          projectId: "p1",
+          prompt: "review the open issues",
+        }),
+      ),
+    );
   });
 
   it("disables OS autocorrection on branch inputs", () => {

--- a/src/extensions/default-layout/dashboard/task-launcher.tsx
+++ b/src/extensions/default-layout/dashboard/task-launcher.tsx
@@ -16,17 +16,31 @@
  * fully live-mutable. An extension can register a custom task-launcher
  * with `aethon.registerComponent("task-launcher", …)`.
  */
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import type { BuiltinComponentProps } from "../../../components/A2UIRenderer";
 import type { ChatAttachment } from "../../../types/a2ui";
 import { resolvePointer } from "../../../utils/jsonPointer";
 import { DEFAULT_WORKSPACE_BASE_BRANCH } from "../../../projects";
 import { saveClipboardImageAttachment } from "../../../utils/imageAttachments";
+import { useVoiceHotkey } from "../../../hooks/useVoiceHotkey";
+import { useVoiceInput } from "../../../hooks/useVoiceInput";
+import {
+  insertTranscriptAtSelection,
+  shouldOpenVoiceSettingsForError,
+} from "../../../utils/voice";
 import { ImageAttachmentImage } from "../image-attachment-image";
 import { ImageLightbox } from "../image-lightbox";
 import { AtPicker } from "../at-picker";
 import { formatAtMentionInsertion, type AtMentionMatch } from "../at-mention";
 import { useAtMention } from "../use-at-mention";
+import { VoiceInputButton, VoiceStatus } from "../voice-controls";
 
 interface ProjectLite {
   id: string;
@@ -246,9 +260,9 @@ export function TaskLauncher({
     [atMatch, promptText],
   );
 
-  const submit = useCallback(() => {
+  const submitPrompt = useCallback((rawPrompt: string) => {
     if (submitting) return;
-    const text = promptText.trim();
+    const text = rawPrompt.trim();
     if (!text && attachments.length === 0) return;
     if (!data.project) return;
     setSubmitting(true);
@@ -282,7 +296,6 @@ export function TaskLauncher({
     setSubmitting(false);
   }, [
     submitting,
-    promptText,
     attachments,
     data.project,
     workspaceChoice,
@@ -292,6 +305,96 @@ export function TaskLauncher({
     defaultModelId,
     onEvent,
   ]);
+
+  const submit = useCallback(() => {
+    submitPrompt(promptText);
+  }, [promptText, submitPrompt]);
+
+  const handleTranscript = useCallback(
+    (transcript: string, options?: { autoSend?: boolean }) => {
+      const textarea = textareaRef.current;
+      const start = textarea?.selectionStart ?? promptText.length;
+      const end = textarea?.selectionEnd ?? promptText.length;
+      const next = insertTranscriptAtSelection(
+        textarea?.value ?? promptText,
+        transcript,
+        start,
+        end,
+      );
+      setPromptText(next.text);
+      setTouched(true);
+      setCursor(next.cursor);
+      if (options?.autoSend && next.text.trim().length > 0) {
+        submitPrompt(next.text);
+        return;
+      }
+      requestAnimationFrame(() => {
+        const el = textareaRef.current;
+        if (!el) return;
+        el.focus();
+        el.selectionStart = el.selectionEnd = next.cursor;
+      });
+    },
+    [promptText, submitPrompt],
+  );
+  const voice = useVoiceInput(handleTranscript, (providerId) => {
+    onEvent("voice:setup", { providerId });
+  });
+  const voiceState = voice.state;
+  const cancelVoice = voice.cancel;
+  const voiceConfig = (state.voice as
+    | {
+        toggleHotkey?: string | null;
+        holdHotkey?: string | null;
+      }
+    | undefined) ?? { toggleHotkey: "mod+shift+m", holdHotkey: null };
+  const settings = state.settings as { open?: boolean } | undefined;
+  const palette = state.commandPalette as { open?: boolean } | undefined;
+  const search = state.search as { open?: boolean } | undefined;
+  const voiceInputBlocked =
+    submitting || !!settings?.open || !!palette?.open || !!search?.open;
+  const voiceInputBlockedRef = useRef(voiceInputBlocked);
+  useLayoutEffect(() => {
+    voiceInputBlockedRef.current = voiceInputBlocked;
+  }, [voiceInputBlocked]);
+  const isVoiceInputBlocked = useCallback(
+    () => voiceInputBlockedRef.current,
+    [],
+  );
+  useVoiceHotkey(
+    voice,
+    voiceConfig.toggleHotkey ?? "mod+shift+m",
+    voiceConfig.holdHotkey ?? null,
+    isVoiceInputBlocked,
+  );
+  useEffect(() => {
+    if (voiceState !== "recording") return;
+    const onKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      cancelVoice();
+    };
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => window.removeEventListener("keydown", onKeyDown, true);
+  }, [voiceState, cancelVoice]);
+  const [reducedMotion, setReducedMotion] = useState(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return false;
+    return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  });
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const onChange = (event: MediaQueryListEvent) =>
+      setReducedMotion(event.matches);
+    mq.addEventListener?.("change", onChange);
+    return () => mq.removeEventListener?.("change", onChange);
+  }, []);
+  const useDynamicMeter =
+    !reducedMotion && voice.activeProvider?.recordingMode === "native";
+  const voiceErrorOpensSettings = shouldOpenVoiceSettingsForError(
+    voice.activeProvider,
+  );
 
   const onKey = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (atMatch) {
@@ -336,6 +439,9 @@ export function TaskLauncher({
     // modifiers out of habit.
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
+      if (voice.state === "recording" || voice.state === "starting") {
+        voice.cancel();
+      }
       submit();
     }
   };
@@ -542,6 +648,17 @@ export function TaskLauncher({
             />
           </>
         )}
+        <div className="a2ui-task-launcher-voice-controls">
+          <VoiceStatus
+            voice={voice}
+            useDynamicMeter={useDynamicMeter}
+            errorOpensSettings={voiceErrorOpensSettings}
+            onOpenSettings={() =>
+              onEvent("voice:setup", { providerId: voice.activeProvider?.id })
+            }
+          />
+          <VoiceInputButton voice={voice} disabled={submitting} />
+        </div>
         <button
           type="button"
           className="a2ui-task-launcher-submit"

--- a/src/extensions/default-layout/voice-controls.tsx
+++ b/src/extensions/default-layout/voice-controls.tsx
@@ -1,0 +1,219 @@
+import type { VoiceConversationController } from "../../hooks/useVoiceConversation";
+import type { VoiceInputController } from "../../hooks/useVoiceInput";
+import { VoiceMeter } from "./voice-meter";
+
+export function VoiceStatus({
+  voice,
+  useDynamicMeter,
+  errorOpensSettings,
+  onOpenSettings,
+}: {
+  voice: VoiceInputController;
+  useDynamicMeter: boolean;
+  errorOpensSettings: boolean;
+  onOpenSettings: () => void;
+}) {
+  if (voice.state === "recording") {
+    return (
+      <div className="a2ui-chat-input-voice-status">
+        <VoiceMeter
+          elapsedSeconds={voice.elapsedSeconds}
+          useDynamicMeter={useDynamicMeter}
+        />
+      </div>
+    );
+  }
+  if (voice.state === "starting" || voice.state === "transcribing") {
+    return (
+      <div className="a2ui-chat-input-voice-status" aria-live="polite">
+        <SpinnerIcon />
+        <span>
+          {voice.state === "starting"
+            ? "Starting..."
+            : voice.activeProvider?.name
+              ? `Transcribing with ${voice.activeProvider.name}`
+              : "Transcribing..."}
+        </span>
+      </div>
+    );
+  }
+  if (voice.state === "error" && voice.error) {
+    return (
+      <button
+        type="button"
+        className="a2ui-chat-input-voice-error"
+        onClick={errorOpensSettings ? onOpenSettings : voice.cancel}
+        title={voice.error}
+      >
+        <span aria-hidden="true">!</span>
+        <span>{voice.error}</span>
+      </button>
+    );
+  }
+  if (voice.state === "setup-required" && voice.error) {
+    return (
+      <button
+        type="button"
+        className="a2ui-chat-input-voice-error"
+        onClick={onOpenSettings}
+        title={voice.error}
+      >
+        <span aria-hidden="true">!</span>
+        <span>{voice.error}</span>
+      </button>
+    );
+  }
+  return null;
+}
+
+export function VoiceInputButton({
+  voice,
+  disabled,
+}: {
+  voice: VoiceInputController;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      className={`a2ui-chat-input-voice ${voice.state === "recording" ? "a2ui-chat-input-voice-recording" : ""} ${
+        voice.state === "starting" || voice.state === "transcribing"
+          ? "a2ui-chat-input-voice-busy"
+          : ""
+      }`}
+      onClick={() => {
+        if (voice.state === "recording") voice.stop();
+        else if (voice.state === "starting" || voice.state === "transcribing") {
+          voice.cancel();
+        } else {
+          void voice.start();
+        }
+      }}
+      disabled={disabled}
+      aria-label={voiceButtonLabel(voice.state)}
+      title={voiceButtonLabel(voice.state)}
+    >
+      {voice.state === "starting" || voice.state === "transcribing" ? (
+        <SpinnerIcon />
+      ) : voice.state === "recording" ? (
+        <StopVoiceIcon />
+      ) : (
+        <MicIcon />
+      )}
+    </button>
+  );
+}
+
+export function VoiceConversationButton({
+  conversation,
+  disabled,
+}: {
+  conversation: VoiceConversationController;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      className={`a2ui-chat-input-voice a2ui-chat-input-conversation ${
+        conversation.active ? "a2ui-chat-input-conversation-active" : ""
+      }`}
+      onClick={() =>
+        conversation.active ? conversation.exit() : conversation.enter()
+      }
+      disabled={disabled}
+      aria-label={
+        conversation.active
+          ? "Exit voice conversation"
+          : "Start voice conversation"
+      }
+      title={
+        conversation.active
+          ? "Exit voice conversation"
+          : "Start voice conversation"
+      }
+    >
+      <ConversationIcon />
+    </button>
+  );
+}
+
+function voiceButtonLabel(state: VoiceInputController["state"]): string {
+  if (state === "recording") return "Stop voice input";
+  if (state === "starting") return "Cancel voice input";
+  if (state === "transcribing") return "Cancel transcription";
+  return "Voice input";
+}
+
+function ConversationIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      aria-hidden="true"
+    >
+      <path
+        d="M2 4.5A1.5 1.5 0 0 1 3.5 3h6A1.5 1.5 0 0 1 11 4.5v3A1.5 1.5 0 0 1 9.5 9H6L3.5 11V9A1.5 1.5 0 0 1 2 7.5v-3Z"
+        stroke="currentColor"
+        strokeWidth="1.3"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M6.5 11.5A1.5 1.5 0 0 0 8 13h3l1.5 1.5V13A1.5 1.5 0 0 0 14 11.5V9"
+        stroke="currentColor"
+        strokeWidth="1.3"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function MicIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" aria-hidden="true">
+      <path
+        d="M8 2.25a2.25 2.25 0 0 0-2.25 2.25V8a2.25 2.25 0 0 0 4.5 0V4.5A2.25 2.25 0 0 0 8 2.25Z"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.45"
+      />
+      <path
+        d="M3.75 7.25V8a4.25 4.25 0 0 0 8.5 0v-.75M8 12.25v1.5M5.75 13.75h4.5"
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeWidth="1.45"
+      />
+    </svg>
+  );
+}
+
+function StopVoiceIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 16 16" aria-hidden="true">
+      <rect x="3.5" y="3.5" width="9" height="9" rx="1.5" fill="currentColor" />
+    </svg>
+  );
+}
+
+function SpinnerIcon() {
+  return (
+    <svg
+      className="a2ui-chat-input-voice-spinner"
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      aria-hidden="true"
+    >
+      <path
+        d="M8 2.25a5.75 5.75 0 1 1-5.16 3.22"
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeWidth="1.7"
+      />
+    </svg>
+  );
+}

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -8228,6 +8228,29 @@ button.a2ui-gh-stat:hover {
   border-color: var(--accent);
 }
 
+.a2ui-task-launcher-voice-controls {
+  margin-left: auto;
+  min-height: 30px;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+.a2ui-task-launcher-voice-controls + .a2ui-task-launcher-submit {
+  margin-left: 0;
+}
+.a2ui-task-launcher-voice-controls .a2ui-chat-input-voice {
+  position: static;
+  right: auto;
+  bottom: auto;
+}
+.a2ui-task-launcher-voice-controls .a2ui-chat-input-voice-status,
+.a2ui-task-launcher-voice-controls .a2ui-chat-input-voice-error {
+  position: static;
+  right: auto;
+  bottom: auto;
+  max-width: min(260px, 40vw);
+}
+
 .a2ui-task-launcher-submit {
   margin-left: auto;
   padding: 4px var(--space-3);


### PR DESCRIPTION
## Summary

- Extract the shared chat-composer voice status/buttons into reusable default-layout controls.
- Wire the project overview task launcher to the same dictation hook, hotkey handling, setup routing, transcript insertion, and recording status used by normal sessions.
- Add launcher regression coverage for rendering the voice input control and submitting a transcribed initial prompt.

## Validation

- `bunx vitest run src/extensions/default-layout/dashboard/task-launcher.test.tsx` (red before implementation, green after)
- `bunx vitest run src/extensions/default-layout/chat.test.tsx src/hooks/useVoiceInput.test.ts src/hooks/useVoiceHotkey.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bunx vitest run`
- `bun run build` (passes; Vite still reports existing large-chunk/plugin-timing warnings)

## Rendered QA

- Loaded the local Vite app at `http://127.0.0.1:5177/`: title resolved to Aethon, page rendered, and Browser console logs had no warnings/errors.
- The plain browser app has no Tauri persistence/project bridge, so it lands on host overview with no projects; the project launcher path is covered by the focused component regression tests above.
