### PR TITLE
feat: add native loop scheduler

### DIFF
--- a/agent/chat.ts
+++ b/agent/chat.ts
@@ -34,11 +34,13 @@ export async function handleChat(
   deps: DispatcherDeps,
   msg: InboundMessage,
 ): Promise<void> {
+  const tabId = msg.tabId ?? "default";
+  const scheduledRun = scheduledRunFromMessage(msg);
   if (!msg.content) {
+    completeScheduledRun(deps, tabId, scheduledRun, false, "chat: missing content");
     deps.send({ type: "error", message: "chat: missing content" });
     return;
   }
-  const tabId = msg.tabId ?? "default";
   chatLog.info(`received tabId=${tabId} chars=${msg.content.length}`);
   // Per-tab hard-guardrail override rides each chat so the source guard sees
   // the current value before this turn's tool calls (and survives a respawn).
@@ -95,6 +97,9 @@ export async function handleChat(
         }
       : {},
   );
+  if (scheduledRun) {
+    tab.scheduledRun = scheduledRun;
+  }
   chatLog.info(`tab ready tabId=${tabId}`);
   if (authServicesRefreshed) {
     refreshTabSessionModelFromAuthServices(state, tabId);
@@ -137,6 +142,8 @@ export async function handleChat(
       tabId,
       message: `file references: ${message}`,
     });
+    completeScheduledRun(deps, tabId, scheduledRun, false, message);
+    if (scheduledRun) tab.scheduledRun = undefined;
     return;
   }
   const busyForTurn = tab.promptInFlight || isUnderlyingSessionBusy(tab);
@@ -156,6 +163,8 @@ export async function handleChat(
       .catch((err: unknown) => {
         const message = err instanceof Error ? err.message : String(err);
         deps.send({ type: "error", tabId, message: `steer: ${message}` });
+        completeScheduledRun(deps, tabId, scheduledRun, false, message);
+        if (scheduledRun) tab.scheduledRun = undefined;
       });
     return;
   }
@@ -177,6 +186,8 @@ export async function handleChat(
           queued: tab.queuedCount,
         });
         deps.send({ type: "error", tabId, message: `followUp: ${message}` });
+        completeScheduledRun(deps, tabId, scheduledRun, false, message);
+        if (scheduledRun) tab.scheduledRun = undefined;
       });
     deps.send({ type: "queued", tabId });
     return;
@@ -194,12 +205,16 @@ export async function handleChat(
     .catch((err: unknown) => {
       const message = err instanceof Error ? err.message : String(err);
       deps.send({ type: "error", tabId, message: `prompt: ${message}` });
+      completeScheduledRun(deps, tabId, scheduledRun, false, message);
+      if (scheduledRun) tab.scheduledRun = undefined;
     })
     .finally(() => {
       const stillStreamingOrRetrying = isUnderlyingSessionBusy(tab);
       if (!tab.agentEndFired && !stillStreamingOrRetrying) {
         tab.promptInFlight = false;
         deps.send({ type: "response_end", tabId });
+        completeScheduledRun(deps, tabId, tab.scheduledRun, true);
+        tab.scheduledRun = undefined;
       }
       if (state.currentAgentTabId === tabId && !stillStreamingOrRetrying) {
         state.currentAgentTabId = undefined;
@@ -207,6 +222,39 @@ export async function handleChat(
       maybeExitForReload(state, deps);
     });
   chatLog.info(`prompt dispatched tabId=${tabId}`);
+}
+
+function scheduledRunFromMessage(
+  msg: InboundMessage,
+): TabRecord["scheduledRun"] | undefined {
+  if (
+    typeof msg.scheduledTaskId !== "string" ||
+    msg.scheduledTaskId.length === 0 ||
+    typeof msg.scheduledRunId !== "string" ||
+    msg.scheduledRunId.length === 0
+  ) {
+    return undefined;
+  }
+  return { taskId: msg.scheduledTaskId, runId: msg.scheduledRunId };
+}
+
+function completeScheduledRun(
+  deps: DispatcherDeps,
+  tabId: string,
+  scheduledRun: TabRecord["scheduledRun"] | undefined,
+  success: boolean,
+  error?: string,
+): void {
+  if (!scheduledRun) return;
+  deps.send({
+    type: "scheduled_task_run_complete",
+    tabId,
+    taskId: scheduledRun.taskId,
+    runId: scheduledRun.runId,
+    success,
+    ...(error ? { error } : {}),
+    ...(scheduledRun.completeRequested ? { completeTask: true } : {}),
+  });
 }
 
 function isUnderlyingSessionBusy(tab: TabRecord): boolean {

--- a/agent/dispatcherTypes.ts
+++ b/agent/dispatcherTypes.ts
@@ -40,6 +40,10 @@ export interface InboundMessage {
   thinkingLevel?: string;
   /** Per-tab hard project-root guardrail override, carried on `chat`. */
   hardEnforce?: boolean;
+  /** Native scheduled-task metadata carried on scheduler-fired chat turns. */
+  scheduledTaskId?: string;
+  scheduledRunId?: string;
+  scheduledVisiblePrompt?: string;
   name?: string;
   args?: string;
   id?: string;

--- a/agent/scheduler-tools.test.ts
+++ b/agent/scheduler-tools.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import type { DispatcherDeps } from "./dispatcherTypes";
+import { ackMutation, markFrontendReady } from "./mutation-ack";
+import { buildSchedulerTools } from "./scheduler-tools";
+import {
+  AethonAgentState,
+  type AethonAgentStateOptions,
+  type TabRecord,
+} from "./state";
+
+const baseOpts: AethonAgentStateOptions = {
+  userDir: "/tmp/aethon-test",
+  stateFile: "/tmp/aethon-test/state.json",
+  sessionsDir: "/tmp/aethon-test/sessions",
+  docsDir: undefined,
+  projectRoot: undefined,
+  releaseMode: false,
+  bootLayoutFile: undefined,
+  layoutSlotsFile: undefined,
+  statePayloadWarnBytes: 64 * 1024,
+  statePayloadHardBytes: 512 * 1024,
+  statePayloadWarnKb: 64,
+  statePayloadHardKb: 512,
+};
+
+function makeFixture() {
+  const state = new AethonAgentState(baseOpts);
+  const sent: Record<string, unknown>[] = [];
+  const deps = {
+    send: (message: Record<string, unknown>) => sent.push(message),
+  } as unknown as DispatcherDeps;
+  state.tabs.set("tab-1", {
+    scheduledRun: { taskId: "task-1", runId: "run-1" },
+  } as TabRecord);
+  return { state, sent, deps };
+}
+
+function getTool(name: string) {
+  const { state, deps } = makeFixture();
+  const tool = buildSchedulerTools(state, deps, "tab-1").find(
+    (candidate) => candidate.name === name,
+  );
+  if (!tool) throw new Error(`tool ${name} not in catalogue`);
+  return tool;
+}
+
+describe("buildSchedulerTools", () => {
+  it("registers loop scheduler tools", () => {
+    expect(
+      buildSchedulerTools(
+        new AethonAgentState(baseOpts),
+        { send: () => {} } as unknown as DispatcherDeps,
+        "tab-1",
+      )
+        .map((tool) => tool.name)
+        .sort(),
+    ).toEqual(["completeLoopTask", "scheduleNextLoopWakeup"]);
+  });
+});
+
+describe("scheduleNextLoopWakeup", () => {
+  it("sends a scheduler query and marks the current scheduled run", async () => {
+    const { state, sent, deps } = makeFixture();
+    markFrontendReady(state);
+    const tool = buildSchedulerTools(state, deps, "tab-1").find(
+      (candidate) => candidate.name === "scheduleNextLoopWakeup",
+    );
+    if (!tool) throw new Error("tool not found");
+
+    const resultPromise = tool.execute("call-1", {
+      taskId: "task-1",
+      runId: "run-1",
+      delayMinutes: 2,
+      reason: "poll later",
+    });
+
+    const msg = sent.at(-1);
+    expect(msg).toMatchObject({
+      type: "scheduler_query",
+      op: "schedule_wakeup",
+      args: {
+        taskId: "task-1",
+        runId: "run-1",
+        delayMs: 120_000,
+        reason: "poll later",
+      },
+    });
+    ackMutation(state, msg?.mutationId as string, true, undefined, {
+      id: "task-1",
+    });
+    await expect(resultPromise).resolves.toMatchObject({
+      details: { id: "task-1" },
+    });
+    expect(state.tabs.get("tab-1")?.scheduledRun?.wakeupScheduled).toBe(true);
+  });
+
+  it("requires a concrete wakeup time", async () => {
+    await expect(
+      getTool("scheduleNextLoopWakeup").execute("call-1", {
+        taskId: "task-1",
+        runId: "run-1",
+      }),
+    ).rejects.toThrow("delayMinutes or nextRunAt required");
+  });
+});
+
+describe("completeLoopTask", () => {
+  it("marks the current scheduled run complete", () => {
+    const { state, deps } = makeFixture();
+    const tool = buildSchedulerTools(state, deps, "tab-1").find(
+      (candidate) => candidate.name === "completeLoopTask",
+    );
+    if (!tool) throw new Error("tool not found");
+
+    const result = tool.execute("call-1", {
+      taskId: "task-1",
+      runId: "run-1",
+      reason: "done",
+    });
+
+    expect(state.tabs.get("tab-1")?.scheduledRun?.completeRequested).toBe(true);
+    expect(result).toMatchObject({ details: { reason: "done" } });
+  });
+
+  it("rejects task/run ids outside the current scheduled run", () => {
+    expect(() =>
+      getTool("completeLoopTask").execute("call-1", {
+        taskId: "task-2",
+        runId: "run-1",
+      }),
+    ).toThrow("taskId/runId do not match");
+  });
+});

--- a/agent/scheduler-tools.ts
+++ b/agent/scheduler-tools.ts
@@ -1,0 +1,150 @@
+import type { ToolDefinition } from "@mariozechner/pi-coding-agent";
+import { defineTool } from "@mariozechner/pi-coding-agent";
+import { Type, type Static } from "typebox";
+import type { AethonAgentState, MutationResult } from "./state";
+import type { DispatcherDeps } from "./dispatcherTypes";
+import { trackMutation } from "./mutation-ack";
+
+const FRONTEND_READY_TIMEOUT_MS = 5_000;
+
+async function schedulerQuery(
+  state: AethonAgentState,
+  deps: Pick<DispatcherDeps, "send">,
+  op: string,
+  args: Record<string, unknown>,
+): Promise<MutationResult> {
+  if (!state.frontendReady) {
+    const ready = await Promise.race<boolean>([
+      state.frontendReadyPromise.then(() => true),
+      new Promise<boolean>((resolve) =>
+        setTimeout(() => resolve(false), FRONTEND_READY_TIMEOUT_MS),
+      ),
+    ]);
+    if (!ready) return { ok: false, error: "frontend_not_ready" };
+  }
+  const { id, promise } = trackMutation(state);
+  deps.send({ type: "scheduler_query", mutationId: id, op, args });
+  return promise;
+}
+
+const ScheduleNextLoopWakeupParams = Type.Object({
+  taskId: Type.String({
+    description: "Scheduled task id from the current Aethon scheduled run.",
+  }),
+  runId: Type.String({
+    description: "Scheduled run id from the current Aethon scheduled run.",
+  }),
+  delayMinutes: Type.Optional(
+    Type.Number({
+      description:
+        "Minutes from now until Aethon should wake this loop again. Use this or nextRunAt.",
+      minimum: 1,
+    }),
+  ),
+  nextRunAt: Type.Optional(
+    Type.Number({
+      description:
+        "Unix epoch milliseconds for the next wakeup. Must be in the future and within the task lifetime.",
+    }),
+  ),
+  reason: Type.Optional(
+    Type.String({
+      description: "Short reason shown in the Scheduled Tasks manager.",
+    }),
+  ),
+});
+type ScheduleNextLoopWakeupParamsT = Static<
+  typeof ScheduleNextLoopWakeupParams
+>;
+
+const CompleteLoopTaskParams = Type.Object({
+  taskId: Type.String({
+    description: "Scheduled task id from the current Aethon scheduled run.",
+  }),
+  runId: Type.String({
+    description: "Scheduled run id from the current Aethon scheduled run.",
+  }),
+  reason: Type.Optional(
+    Type.String({
+      description: "Short completion note for the current loop.",
+    }),
+  ),
+});
+type CompleteLoopTaskParamsT = Static<typeof CompleteLoopTaskParams>;
+
+export function buildSchedulerTools(
+  state: AethonAgentState,
+  deps: DispatcherDeps,
+  tabId: string,
+): ToolDefinition[] {
+  const scheduleNextTool = defineTool({
+    name: "scheduleNextLoopWakeup",
+    label: "Schedule next loop wakeup",
+    description:
+      "For a self-paced Aethon /loop run, choose when the same task should wake up next. Call this before ending the turn when more follow-up work is useful.",
+    promptSnippet:
+      "scheduleNextLoopWakeup: set the next wake time for the current self-paced Aethon loop",
+    parameters: ScheduleNextLoopWakeupParams,
+    async execute(_callId: string, params: ScheduleNextLoopWakeupParamsT) {
+      const delayMs =
+        typeof params.delayMinutes === "number"
+          ? Math.max(1, Math.round(params.delayMinutes)) * 60_000
+          : undefined;
+      if (delayMs === undefined && typeof params.nextRunAt !== "number") {
+        throw new Error("delayMinutes or nextRunAt required");
+      }
+      const r = await schedulerQuery(state, deps, "schedule_wakeup", {
+        taskId: params.taskId,
+        runId: params.runId,
+        ...(delayMs !== undefined ? { delayMs } : {}),
+        ...(typeof params.nextRunAt === "number"
+          ? { nextRunAt: params.nextRunAt }
+          : {}),
+        ...(typeof params.reason === "string" && params.reason.trim()
+          ? { reason: params.reason.trim() }
+          : {}),
+      });
+      if (!r.ok) throw new Error(r.error ?? "unknown scheduler error");
+      const rec = state.tabs.get(tabId);
+      if (
+        rec?.scheduledRun?.taskId === params.taskId &&
+        rec.scheduledRun.runId === params.runId
+      ) {
+        rec.scheduledRun.wakeupScheduled = true;
+      }
+      return {
+        content: [{ type: "text" as const, text: "next wakeup scheduled" }],
+        details: r.data ?? null,
+      };
+    },
+  }) as ToolDefinition;
+
+  const completeLoopTool = defineTool({
+    name: "completeLoopTask",
+    label: "Complete loop task",
+    description:
+      "Mark the current self-paced Aethon loop as complete. Use this when the loop should not wake again.",
+    promptSnippet:
+      "completeLoopTask: finish the current self-paced Aethon loop without scheduling another wakeup",
+    parameters: CompleteLoopTaskParams,
+    execute(_callId: string, params: CompleteLoopTaskParamsT) {
+      const rec = state.tabs.get(tabId);
+      if (
+        rec?.scheduledRun?.taskId !== params.taskId ||
+        rec.scheduledRun.runId !== params.runId
+      ) {
+        throw new Error("taskId/runId do not match the current scheduled run");
+      }
+      rec.scheduledRun.completeRequested = true;
+      return {
+        content: [{ type: "text" as const, text: "loop marked complete" }],
+        details:
+          typeof params.reason === "string" && params.reason.trim()
+            ? { reason: params.reason.trim() }
+            : {},
+      };
+    },
+  }) as ToolDefinition;
+
+  return [scheduleNextTool, completeLoopTool];
+}

--- a/agent/state.ts
+++ b/agent/state.ts
@@ -265,6 +265,14 @@ export interface TabRecord {
   aethonRetryAttempt?: number;
   aethonRetryInFlight?: boolean;
   aethonRetryTimer?: ReturnType<typeof setTimeout>;
+  /** Current Rust-scheduled task run, when this prompt was fired by
+   *  Aethon's native scheduler instead of direct user input. */
+  scheduledRun?: {
+    taskId: string;
+    runId: string;
+    wakeupScheduled?: boolean;
+    completeRequested?: boolean;
+  };
   /** Live context-meter estimate for text/tool output that has streamed
    *  in this turn but has not yet landed in pi's authoritative usage. */
   contextUsageTransientTokens?: number;

--- a/agent/tab-lifecycle/events.ts
+++ b/agent/tab-lifecycle/events.ts
@@ -517,6 +517,7 @@ export function handleSessionEvent(
         // rollback / fork affordances work without a reload.
         emitEntryIds(deps, rec, tabId);
         deps.send({ type: "response_end", tabId });
+        emitScheduledRunComplete(deps, rec, tabId, !failedMessage, failedMessage);
       }
       break;
     }
@@ -560,10 +561,32 @@ export function handleSessionEvent(
         }
         rollResponseMessage(rec);
         deps.send({ type: "response_end", tabId });
+        emitScheduledRunComplete(deps, rec, tabId, false, ev.finalError);
       }
       break;
     }
   }
+}
+
+function emitScheduledRunComplete(
+  deps: TabLifecycleDeps,
+  rec: TabRecord,
+  tabId: string,
+  success: boolean,
+  error?: string,
+): void {
+  const scheduled = rec.scheduledRun;
+  if (!scheduled) return;
+  deps.send({
+    type: "scheduled_task_run_complete",
+    tabId,
+    taskId: scheduled.taskId,
+    runId: scheduled.runId,
+    success,
+    ...(error ? { error } : {}),
+    ...(scheduled.completeRequested ? { completeTask: true } : {}),
+  });
+  rec.scheduledRun = undefined;
 }
 
 function summarizeToolResult(result: unknown): string {

--- a/agent/tab-lifecycle/lifecycle.ts
+++ b/agent/tab-lifecycle/lifecycle.ts
@@ -23,6 +23,7 @@ import { createAethonBashToolDefinition } from "../bash-tool";
 import { buildDashboardTools } from "../dashboard-tools";
 import { buildEditorTools } from "../editor-tools";
 import { buildSessionTitleTools } from "../session-title-tool";
+import { buildSchedulerTools } from "../scheduler-tools";
 import {
   buildSubagentTaskBatchTool,
   buildSubagentTaskTool,
@@ -185,6 +186,7 @@ export async function ensureTab(
       ...buildDashboardTools(),
       ...buildEditorTools(),
       ...buildMemoryTools(state, tabId),
+      ...buildSchedulerTools(state, deps, tabId),
       buildSubagentTaskTool(state, deps, tabId),
       buildSubagentTaskBatchTool(state, deps, tabId),
     ],

--- a/src-tauri/src/agent_commands.rs
+++ b/src-tauri/src/agent_commands.rs
@@ -91,10 +91,7 @@ pub(crate) async fn send_message(
         payload["images"] = serde_json::Value::Array(images);
     }
 
-    let key = route_payload_key(&state, &payload);
-    let worker = worker_for_payload(&key, &payload, true);
-    prepare_worker_startup(&app, &startup, &devshell, worker.as_ref()).await?;
-    write_agent_payload(&state, &app, key, payload, worker).await
+    dispatch_agent_payload_value(payload, state, devshell, startup, app).await
 }
 
 fn attachments_to_agent_images(
@@ -249,6 +246,19 @@ pub(crate) async fn agent_command(
         retire_agent_key(&state, &key)?;
     }
     Ok(())
+}
+
+pub(crate) async fn dispatch_agent_payload_value(
+    payload_value: serde_json::Value,
+    state: State<'_, AgentProcesses>,
+    devshell: State<'_, Arc<DevshellCache>>,
+    startup: State<'_, crate::commands::startup::WorkspaceStartupState>,
+    app: AppHandle,
+) -> Result<(), String> {
+    let key = route_payload_key(&state, &payload_value);
+    let worker = worker_for_payload(&key, &payload_value, true);
+    prepare_worker_startup(&app, &startup, &devshell, worker.as_ref()).await?;
+    write_agent_payload(&state, &app, key, payload_value, worker).await
 }
 
 async fn prepare_worker_startup(

--- a/src-tauri/src/agent_process/mod.rs
+++ b/src-tauri/src/agent_process/mod.rs
@@ -30,8 +30,8 @@ mod sweep;
 
 pub(crate) use process::{
     AgentProcesses, AgentWorker, GLOBAL_AGENT_KEY, WorkerMeta, cleanup_orphaned_dev_agents,
-    ensure_global_agent, keys_to_reconcile, retire_agent_key, route_payload_key,
-    shutdown_all_agents, write_agent_payload,
+    ensure_global_agent, keys_to_reconcile, lock_recover, prompt_wedged, retire_agent_key,
+    route_payload_key, shutdown_all_agents, tab_agent_key, write_agent_payload,
 };
 pub(crate) use sidecar::project_root;
 pub(crate) use sweep::spawn_idle_sweep;

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -26,6 +26,7 @@ pub mod extensions;
 pub mod fs;
 pub mod git;
 pub mod host;
+pub mod scheduler;
 pub mod server;
 pub mod session;
 pub mod startup;

--- a/src-tauri/src/commands/scheduler.rs
+++ b/src-tauri/src/commands/scheduler.rs
@@ -562,9 +562,8 @@ pub(crate) fn scheduled_task_complete(
         if !input.success {
             task.status = ScheduledTaskStatus::Failed;
             task.next_run_at = None;
-            task.last_error = input
-                .error
-                .or_else(|| Some("scheduled run failed".to_string()));
+            task.last_error =
+                non_empty(input.error).or_else(|| Some("scheduled run failed".to_string()));
         } else {
             task.last_error = None;
             complete_success(task, now, input.complete_task == Some(true))?;

--- a/src-tauri/src/commands/scheduler.rs
+++ b/src-tauri/src/commands/scheduler.rs
@@ -1,0 +1,1634 @@
+//! Native scheduled tasks and `/loop` support.
+//!
+//! The scheduler is Rust-owned because per-tab agent workers are disposable:
+//! a tab worker may retire while its tab still exists, so timers cannot live
+//! inside the bridge process. React reports the currently restored/live tabs;
+//! only then do tasks arm and dispatch chat payloads through the normal agent
+//! supervisor path.
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::time::Duration;
+
+use chrono::{Datelike, Local, TimeZone, Timelike};
+use tauri::{AppHandle, Emitter, Manager, State};
+use tokio::sync::Notify;
+
+use crate::agent_process::{AgentProcesses, lock_recover, prompt_wedged, tab_agent_key};
+
+const STORE_FILE: &str = "scheduled-tasks.json";
+const STORE_VERSION: u8 = 1;
+const TASK_VERSION: u8 = 1;
+const TASK_TTL_MS: i64 = 7 * 24 * 60 * 60 * 1000;
+const MIN_INTERVAL_MS: u64 = 60 * 1000;
+const MAX_DELAY_MS: u64 = TASK_TTL_MS as u64;
+const IDLE_RETRY_MS: i64 = 10 * 1000;
+const MAX_FIRES_PER_TICK: usize = 3;
+const LOOP_PROMPT_MAX_BYTES: usize = 25_000;
+
+#[derive(Clone, Copy, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum ScheduledTaskMode {
+    LoopFixed,
+    LoopSelfPaced,
+    OneShot,
+    Cron,
+}
+
+#[derive(Clone, Copy, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum ScheduledTaskStatus {
+    Scheduled,
+    Running,
+    Paused,
+    Expired,
+    Cancelled,
+    Failed,
+    Completed,
+}
+
+impl ScheduledTaskStatus {
+    fn terminal(self) -> bool {
+        matches!(
+            self,
+            ScheduledTaskStatus::Expired
+                | ScheduledTaskStatus::Cancelled
+                | ScheduledTaskStatus::Completed
+        )
+    }
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum ScheduledTaskSchedule {
+    Interval {
+        #[serde(rename = "intervalMs")]
+        interval_ms: u64,
+        label: String,
+    },
+    SelfPaced {
+        #[serde(rename = "nextRunAt")]
+        next_run_at: Option<i64>,
+        reason: Option<String>,
+    },
+    OneShot {
+        #[serde(rename = "runAt")]
+        run_at: i64,
+    },
+    Cron {
+        expression: String,
+    },
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScheduledTaskRecord {
+    version: u8,
+    id: String,
+    tab_id: String,
+    cwd: String,
+    model: Option<String>,
+    thinking_level: Option<String>,
+    hard_enforce: Option<bool>,
+    auth_profile_id: Option<String>,
+    label: String,
+    prompt: String,
+    visible_prompt: String,
+    prompt_source: String,
+    mode: ScheduledTaskMode,
+    schedule: ScheduledTaskSchedule,
+    created_at: i64,
+    updated_at: i64,
+    next_run_at: Option<i64>,
+    last_run_at: Option<i64>,
+    last_completed_at: Option<i64>,
+    expires_at: i64,
+    run_count: u32,
+    coalesced_misses: u32,
+    last_error: Option<String>,
+    status: ScheduledTaskStatus,
+    current_run_id: Option<String>,
+}
+
+#[derive(Clone, Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScheduledTaskCreate {
+    tab_id: String,
+    cwd: String,
+    model: Option<String>,
+    thinking_level: Option<String>,
+    hard_enforce: Option<bool>,
+    auth_profile_id: Option<String>,
+    label: Option<String>,
+    prompt: String,
+    visible_prompt: Option<String>,
+    prompt_source: Option<String>,
+    mode: Option<ScheduledTaskMode>,
+    schedule: ScheduledTaskSchedule,
+}
+
+#[derive(Clone, Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScheduledTaskUpdate {
+    label: Option<String>,
+    prompt: Option<String>,
+    visible_prompt: Option<String>,
+    schedule: Option<ScheduledTaskSchedule>,
+}
+
+#[derive(Clone, Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScheduledTaskCompleteInput {
+    task_id: String,
+    run_id: String,
+    success: bool,
+    error: Option<String>,
+    complete_task: Option<bool>,
+}
+
+#[derive(Clone, Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScheduledTaskWakeupInput {
+    task_id: String,
+    run_id: Option<String>,
+    next_run_at: Option<i64>,
+    delay_ms: Option<u64>,
+    reason: Option<String>,
+}
+
+#[derive(Clone, Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScheduledTaskTabFailureInput {
+    tab_id: Option<String>,
+    message: Option<String>,
+}
+
+#[derive(Clone, Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LoopPromptResolution {
+    prompt: String,
+    source: String,
+}
+
+#[derive(Clone, Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ScheduledTaskFired {
+    task: ScheduledTaskRecord,
+    run_id: String,
+    visible_prompt: String,
+}
+
+#[derive(Clone, Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ScheduledTaskError {
+    task_id: String,
+    run_id: Option<String>,
+    message: String,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ScheduledTaskStore {
+    version: u8,
+    tasks: Vec<ScheduledTaskRecord>,
+}
+
+#[derive(Default)]
+struct SchedulerInner {
+    tasks: HashMap<String, ScheduledTaskRecord>,
+    storage_path: Option<PathBuf>,
+    loaded: bool,
+    live_tabs_known: bool,
+    live_tab_ids: HashSet<String>,
+}
+
+pub struct ScheduledTasksState {
+    inner: Mutex<SchedulerInner>,
+    notify: Arc<Notify>,
+}
+
+impl ScheduledTasksState {
+    pub fn new() -> Self {
+        Self {
+            inner: Mutex::new(SchedulerInner::default()),
+            notify: Arc::new(Notify::new()),
+        }
+    }
+
+    fn lock(&self) -> MutexGuard<'_, SchedulerInner> {
+        self.inner.lock().unwrap_or_else(|poisoned| {
+            tracing::warn!(target: "aethon::scheduler", "recovered poisoned scheduler state");
+            poisoned.into_inner()
+        })
+    }
+}
+
+pub(crate) fn boot(app: AppHandle) {
+    let state = app.state::<ScheduledTasksState>();
+    if let Err(err) = ensure_loaded(&state, &app) {
+        tracing::warn!(target: "aethon::scheduler", "scheduled task boot load failed: {err}");
+    }
+    let notify = state.notify.clone();
+    tauri::async_runtime::spawn(async move {
+        scheduler_loop(app, notify).await;
+    });
+}
+
+#[tauri::command]
+pub(crate) fn scheduled_tasks_list(
+    state: State<'_, ScheduledTasksState>,
+    app: AppHandle,
+) -> Result<Vec<ScheduledTaskRecord>, String> {
+    ensure_loaded(&state, &app)?;
+    refresh_expired(&state, &app)?;
+    Ok(task_list(&state))
+}
+
+#[tauri::command]
+pub(crate) fn scheduled_tasks_reconcile_live_tabs(
+    live_tab_ids: Vec<String>,
+    state: State<'_, ScheduledTasksState>,
+    app: AppHandle,
+) -> Result<Vec<ScheduledTaskRecord>, String> {
+    ensure_loaded(&state, &app)?;
+    let live: HashSet<String> = live_tab_ids
+        .into_iter()
+        .filter(|id| !id.trim().is_empty())
+        .collect();
+    {
+        let mut inner = state.lock();
+        inner.live_tabs_known = true;
+        inner.live_tab_ids = live;
+        let now = now_ms();
+        let live_tab_ids = inner.live_tab_ids.clone();
+        for task in inner.tasks.values_mut() {
+            if task.status.terminal() {
+                continue;
+            }
+            if !live_tab_ids.contains(&task.tab_id) {
+                task.status = ScheduledTaskStatus::Cancelled;
+                task.next_run_at = None;
+                task.current_run_id = None;
+                task.last_error = Some("owning tab is no longer restored".to_string());
+                task.updated_at = now;
+            }
+        }
+    }
+    persist_emit_notify(&state, &app)?;
+    Ok(task_list(&state))
+}
+
+#[tauri::command]
+pub(crate) fn scheduled_tasks_fail_running_for_tab(
+    input: ScheduledTaskTabFailureInput,
+    state: State<'_, ScheduledTasksState>,
+    app: AppHandle,
+) -> Result<Vec<ScheduledTaskRecord>, String> {
+    ensure_loaded(&state, &app)?;
+    let now = now_ms();
+    let reason = input
+        .message
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or("agent worker crashed before scheduled run completed")
+        .to_string();
+    let tab_id = input
+        .tab_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    let changed = {
+        let mut inner = state.lock();
+        fail_running_tasks_for_tab(&mut inner.tasks, tab_id, now, &reason, IDLE_RETRY_MS)
+    };
+    if changed {
+        persist_emit_notify(&state, &app)?;
+    }
+    Ok(task_list(&state))
+}
+
+#[tauri::command]
+pub(crate) fn scheduled_task_create(
+    input: ScheduledTaskCreate,
+    state: State<'_, ScheduledTasksState>,
+    app: AppHandle,
+) -> Result<ScheduledTaskRecord, String> {
+    ensure_loaded(&state, &app)?;
+    let now = now_ms();
+    let expires_at = now.saturating_add(TASK_TTL_MS);
+    let prompt = input.prompt.trim().to_string();
+    if prompt.is_empty() {
+        return Err("prompt required".to_string());
+    }
+    let tab_id = input.tab_id.trim().to_string();
+    if tab_id.is_empty() {
+        return Err("tabId required".to_string());
+    }
+    let cwd = input.cwd.trim().to_string();
+    if cwd.is_empty() {
+        return Err("cwd required".to_string());
+    }
+    let schedule = normalize_schedule(input.schedule, now, expires_at)?;
+    let mode = input.mode.unwrap_or_else(|| mode_for_schedule(&schedule));
+    validate_mode_schedule(mode, &schedule)?;
+    let next_run_at = initial_next_run_at(&schedule, now, expires_at)?;
+    let label = input
+        .label
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| label_from_prompt(&prompt));
+    let record = ScheduledTaskRecord {
+        version: TASK_VERSION,
+        id: uuid::Uuid::new_v4().simple().to_string(),
+        tab_id,
+        cwd,
+        model: non_empty(input.model),
+        thinking_level: non_empty(input.thinking_level),
+        hard_enforce: input.hard_enforce,
+        auth_profile_id: non_empty(input.auth_profile_id),
+        label,
+        visible_prompt: input
+            .visible_prompt
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .unwrap_or(prompt.as_str())
+            .to_string(),
+        prompt,
+        prompt_source: input
+            .prompt_source
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .unwrap_or("inline")
+            .to_string(),
+        mode,
+        schedule,
+        created_at: now,
+        updated_at: now,
+        next_run_at,
+        last_run_at: None,
+        last_completed_at: None,
+        expires_at,
+        run_count: 0,
+        coalesced_misses: 0,
+        last_error: None,
+        status: ScheduledTaskStatus::Scheduled,
+        current_run_id: None,
+    };
+    {
+        let mut inner = state.lock();
+        inner.tasks.insert(record.id.clone(), record.clone());
+    }
+    persist_emit_notify(&state, &app)?;
+    Ok(record)
+}
+
+#[tauri::command]
+pub(crate) fn scheduled_task_update(
+    id: String,
+    patch: ScheduledTaskUpdate,
+    state: State<'_, ScheduledTasksState>,
+    app: AppHandle,
+) -> Result<ScheduledTaskRecord, String> {
+    ensure_loaded(&state, &app)?;
+    let now = now_ms();
+    let updated = {
+        let mut inner = state.lock();
+        let task = inner
+            .tasks
+            .get_mut(&id)
+            .ok_or_else(|| format!("unknown task: {id}"))?;
+        if matches!(task.status, ScheduledTaskStatus::Running) {
+            return Err("cannot edit a running task".to_string());
+        }
+        if let Some(label) = patch.label.as_deref().map(str::trim)
+            && !label.is_empty()
+        {
+            task.label = label.to_string();
+        }
+        if let Some(prompt) = patch.prompt.as_deref().map(str::trim)
+            && !prompt.is_empty()
+        {
+            task.prompt = prompt.to_string();
+            task.visible_prompt = patch
+                .visible_prompt
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .unwrap_or(prompt)
+                .to_string();
+        }
+        if let Some(schedule) = patch.schedule {
+            let normalized = normalize_schedule(schedule, now, task.expires_at)?;
+            validate_mode_schedule(task.mode, &normalized)?;
+            task.next_run_at = initial_next_run_at(&normalized, now, task.expires_at)?;
+            task.schedule = normalized;
+            if !task.status.terminal() {
+                task.status = ScheduledTaskStatus::Scheduled;
+            }
+        }
+        task.updated_at = now;
+        task.last_error = None;
+        task.clone()
+    };
+    persist_emit_notify(&state, &app)?;
+    Ok(updated)
+}
+
+#[tauri::command]
+pub(crate) fn scheduled_task_pause(
+    id: String,
+    state: State<'_, ScheduledTasksState>,
+    app: AppHandle,
+) -> Result<ScheduledTaskRecord, String> {
+    set_status(id, ScheduledTaskStatus::Paused, state, app)
+}
+
+#[tauri::command]
+pub(crate) fn scheduled_task_resume(
+    id: String,
+    state: State<'_, ScheduledTasksState>,
+    app: AppHandle,
+) -> Result<ScheduledTaskRecord, String> {
+    ensure_loaded(&state, &app)?;
+    let now = now_ms();
+    let updated = {
+        let mut inner = state.lock();
+        let task = inner
+            .tasks
+            .get_mut(&id)
+            .ok_or_else(|| format!("unknown task: {id}"))?;
+        if task.status == ScheduledTaskStatus::Running {
+            return Err("task is already running".to_string());
+        }
+        resume_task_record(task, now)?;
+        task.updated_at = now;
+        task.clone()
+    };
+    persist_emit_notify(&state, &app)?;
+    Ok(updated)
+}
+
+#[tauri::command]
+pub(crate) fn scheduled_task_cancel(
+    id: String,
+    state: State<'_, ScheduledTasksState>,
+    app: AppHandle,
+) -> Result<ScheduledTaskRecord, String> {
+    set_status(id, ScheduledTaskStatus::Cancelled, state, app)
+}
+
+#[tauri::command]
+pub(crate) async fn scheduled_task_run_now(
+    id: String,
+    state: State<'_, ScheduledTasksState>,
+    app: AppHandle,
+) -> Result<ScheduledTaskRecord, String> {
+    ensure_loaded(&state, &app)?;
+    start_task_run(&app, &state, &id, true).await
+}
+
+#[tauri::command]
+pub(crate) fn scheduled_task_schedule_wakeup(
+    input: ScheduledTaskWakeupInput,
+    state: State<'_, ScheduledTasksState>,
+    app: AppHandle,
+) -> Result<ScheduledTaskRecord, String> {
+    ensure_loaded(&state, &app)?;
+    let now = now_ms();
+    let next = match (input.next_run_at, input.delay_ms) {
+        (Some(at), _) => at,
+        (None, Some(delay)) => now.saturating_add(delay.min(MAX_DELAY_MS) as i64),
+        (None, None) => return Err("nextRunAt or delayMs required".to_string()),
+    };
+    let updated = {
+        let mut inner = state.lock();
+        let task = inner
+            .tasks
+            .get_mut(&input.task_id)
+            .ok_or_else(|| format!("unknown task: {}", input.task_id))?;
+        if task.mode != ScheduledTaskMode::LoopSelfPaced {
+            return Err("only self-paced loop tasks accept wakeups".to_string());
+        }
+        if let Some(run_id) = input.run_id.as_deref()
+            && task.current_run_id.as_deref() != Some(run_id)
+        {
+            return Err("wakeup runId does not match current run".to_string());
+        }
+        if next <= now {
+            return Err("next wakeup must be in the future".to_string());
+        }
+        if next > task.expires_at {
+            return Err("next wakeup exceeds the task's 7-day lifetime".to_string());
+        }
+        task.schedule = ScheduledTaskSchedule::SelfPaced {
+            next_run_at: Some(next),
+            reason: non_empty(input.reason),
+        };
+        task.next_run_at = Some(next);
+        task.last_error = None;
+        task.updated_at = now;
+        task.clone()
+    };
+    persist_emit_notify(&state, &app)?;
+    Ok(updated)
+}
+
+#[tauri::command]
+pub(crate) fn scheduled_task_complete(
+    input: ScheduledTaskCompleteInput,
+    state: State<'_, ScheduledTasksState>,
+    app: AppHandle,
+) -> Result<ScheduledTaskRecord, String> {
+    ensure_loaded(&state, &app)?;
+    let now = now_ms();
+    let updated = {
+        let mut inner = state.lock();
+        let task = inner
+            .tasks
+            .get_mut(&input.task_id)
+            .ok_or_else(|| format!("unknown task: {}", input.task_id))?;
+        if task.current_run_id.as_deref() != Some(input.run_id.as_str()) {
+            return Err("completion runId does not match current run".to_string());
+        }
+        task.last_completed_at = Some(now);
+        task.current_run_id = None;
+        task.updated_at = now;
+        if !input.success {
+            task.status = ScheduledTaskStatus::Failed;
+            task.next_run_at = None;
+            task.last_error = input
+                .error
+                .or_else(|| Some("scheduled run failed".to_string()));
+        } else {
+            task.last_error = None;
+            complete_success(task, now, input.complete_task == Some(true))?;
+        }
+        task.clone()
+    };
+    persist_emit_notify(&state, &app)?;
+    Ok(updated)
+}
+
+#[tauri::command]
+pub(crate) fn scheduled_task_resolve_loop_prompt(
+    cwd: Option<String>,
+    app: AppHandle,
+) -> Result<LoopPromptResolution, String> {
+    resolve_loop_prompt(cwd.as_deref(), &app)
+}
+
+async fn scheduler_loop(app: AppHandle, notify: Arc<Notify>) {
+    loop {
+        match scheduler_delay(&app) {
+            Ok(Some(delay)) => {
+                tokio::select! {
+                    _ = tokio::time::sleep(delay) => {}
+                    _ = notify.notified() => continue,
+                }
+            }
+            Ok(None) => {
+                notify.notified().await;
+                continue;
+            }
+            Err(err) => {
+                tracing::warn!(target: "aethon::scheduler", "scheduler tick failed: {err}");
+                tokio::time::sleep(Duration::from_secs(10)).await;
+                continue;
+            }
+        }
+        if let Err(err) = fire_due_tasks(&app).await {
+            tracing::warn!(target: "aethon::scheduler", "scheduled task dispatch failed: {err}");
+        }
+    }
+}
+
+fn scheduler_delay(app: &AppHandle) -> Result<Option<Duration>, String> {
+    let state = app.state::<ScheduledTasksState>();
+    ensure_loaded(&state, app)?;
+    refresh_expired(&state, app)?;
+    let now = now_ms();
+    let inner = state.lock();
+    if !inner.live_tabs_known {
+        return Ok(None);
+    }
+    let next = inner
+        .tasks
+        .values()
+        .filter(|task| task.status == ScheduledTaskStatus::Scheduled)
+        .filter_map(|task| task.next_run_at)
+        .min();
+    Ok(next.map(|due| {
+        if due <= now {
+            Duration::from_millis(0)
+        } else {
+            Duration::from_millis((due - now) as u64)
+        }
+    }))
+}
+
+async fn fire_due_tasks(app: &AppHandle) -> Result<(), String> {
+    let state = app.state::<ScheduledTasksState>();
+    ensure_loaded(&state, app)?;
+    for _ in 0..MAX_FIRES_PER_TICK {
+        refresh_expired(&state, app)?;
+        let now = now_ms();
+        let candidate = {
+            let inner = state.lock();
+            if !inner.live_tabs_known {
+                return Ok(());
+            }
+            inner
+                .tasks
+                .values()
+                .filter(|task| task.status == ScheduledTaskStatus::Scheduled)
+                .filter(|task| task.next_run_at.is_some_and(|due| due <= now))
+                .filter(|task| inner.live_tab_ids.contains(&task.tab_id))
+                .min_by_key(|task| task.next_run_at.unwrap_or(i64::MAX))
+                .map(|task| task.id.clone())
+        };
+        let Some(id) = candidate else {
+            break;
+        };
+        if let Err(err) = start_task_run(app, &state, &id, false).await {
+            let _ = delay_due_task(&state, app, &id, err);
+        }
+    }
+    Ok(())
+}
+
+async fn start_task_run(
+    app: &AppHandle,
+    state: &State<'_, ScheduledTasksState>,
+    id: &str,
+    force: bool,
+) -> Result<ScheduledTaskRecord, String> {
+    let now = now_ms();
+    let task_snapshot = {
+        let inner = state.lock();
+        let task = inner
+            .tasks
+            .get(id)
+            .ok_or_else(|| format!("unknown task: {id}"))?;
+        if !inner.live_tabs_known || !inner.live_tab_ids.contains(&task.tab_id) {
+            return Err("owning tab is not restored".to_string());
+        }
+        if now >= task.expires_at {
+            return Err("task has expired".to_string());
+        }
+        if task.status == ScheduledTaskStatus::Running {
+            return Err("task is already running".to_string());
+        }
+        if force && task.status.terminal() {
+            return Err(format!("cannot run terminal task: {:?}", task.status));
+        }
+        if !force && task.status != ScheduledTaskStatus::Scheduled {
+            return Err(format!("task is not scheduled: {:?}", task.status));
+        }
+        if !force && task.next_run_at.is_none_or(|due| due > now) {
+            return Err("task is not due".to_string());
+        }
+        task.clone()
+    };
+    if tab_busy(app, &task_snapshot.tab_id) {
+        return Err("owning tab is busy".to_string());
+    }
+    let run_id = uuid::Uuid::new_v4().simple().to_string();
+    let running = {
+        let mut inner = state.lock();
+        let task = inner
+            .tasks
+            .get_mut(id)
+            .ok_or_else(|| format!("unknown task: {id}"))?;
+        task.status = ScheduledTaskStatus::Running;
+        task.last_run_at = Some(now);
+        task.run_count = task.run_count.saturating_add(1);
+        task.current_run_id = Some(run_id.clone());
+        task.updated_at = now;
+        task.last_error = None;
+        task.clone()
+    };
+    persist_emit(state, app)?;
+    let _ = app.emit(
+        "scheduled-task-fired",
+        ScheduledTaskFired {
+            task: running.clone(),
+            run_id: run_id.clone(),
+            visible_prompt: running.visible_prompt.clone(),
+        },
+    );
+    if let Err(err) = dispatch_scheduled_run(app, &running, &run_id).await {
+        mark_run_failed(state, app, id, Some(run_id), err.clone())?;
+        return Err(err);
+    }
+    Ok(running)
+}
+
+async fn dispatch_scheduled_run(
+    app: &AppHandle,
+    task: &ScheduledTaskRecord,
+    run_id: &str,
+) -> Result<(), String> {
+    let tab_open = serde_json::json!({
+        "type": "tab_open",
+        "tabId": task.tab_id,
+        "cwd": task.cwd,
+        "model": task.model,
+        "thinkingLevel": task.thinking_level,
+        "authProfileId": task.auth_profile_id,
+    });
+    let chat = serde_json::json!({
+        "type": "chat",
+        "tabId": task.tab_id,
+        "cwd": task.cwd,
+        "model": task.model,
+        "thinkingLevel": task.thinking_level,
+        "hardEnforce": task.hard_enforce,
+        "mode": "normal",
+        "content": scheduled_prompt(task, run_id),
+        "scheduledTaskId": task.id,
+        "scheduledRunId": run_id,
+        "scheduledVisiblePrompt": task.visible_prompt,
+    });
+    dispatch_payload(app, tab_open).await?;
+    dispatch_payload(app, chat).await
+}
+
+async fn dispatch_payload(app: &AppHandle, payload: serde_json::Value) -> Result<(), String> {
+    let agent_state = app.state::<AgentProcesses>();
+    let devshell = app.state::<Arc<crate::devshell::DevshellCache>>();
+    let startup = app.state::<crate::commands::startup::WorkspaceStartupState>();
+    crate::agent_commands::dispatch_agent_payload_value(
+        payload,
+        agent_state,
+        devshell,
+        startup,
+        app.clone(),
+    )
+    .await
+}
+
+fn scheduled_prompt(task: &ScheduledTaskRecord, run_id: &str) -> String {
+    let mut header = format!(
+        "This is an Aethon scheduled task run.\nTask id: {}\nRun id: {}\nTask label: {}\n\n",
+        task.id, run_id, task.label
+    );
+    if task.mode == ScheduledTaskMode::LoopSelfPaced {
+        header.push_str(
+            "This loop is self-paced. When the useful work for this run is complete, call the `scheduleNextLoopWakeup` tool with the task id and run id to choose the next wakeup before ending the turn. If the loop is finished, call `completeLoopTask` instead.\n\n",
+        );
+    }
+    header.push_str("User request:\n");
+    header.push_str(&task.prompt);
+    header
+}
+
+fn complete_success(
+    task: &mut ScheduledTaskRecord,
+    now: i64,
+    complete_task: bool,
+) -> Result<(), String> {
+    if now >= task.expires_at {
+        task.status = ScheduledTaskStatus::Expired;
+        task.next_run_at = None;
+        return Ok(());
+    }
+    match &task.schedule {
+        ScheduledTaskSchedule::Interval { interval_ms, .. } => {
+            let next = now.saturating_add(*interval_ms as i64);
+            if next > task.expires_at {
+                task.status = ScheduledTaskStatus::Expired;
+                task.next_run_at = None;
+            } else {
+                task.status = ScheduledTaskStatus::Scheduled;
+                task.next_run_at = Some(next);
+            }
+        }
+        ScheduledTaskSchedule::SelfPaced { next_run_at, .. } => {
+            if complete_task {
+                task.status = ScheduledTaskStatus::Completed;
+                task.next_run_at = None;
+                return Ok(());
+            }
+            if let Some(next) = *next_run_at
+                && next > now
+                && next <= task.expires_at
+            {
+                task.status = ScheduledTaskStatus::Scheduled;
+                task.next_run_at = Some(next);
+            } else {
+                task.status = ScheduledTaskStatus::Paused;
+                task.next_run_at = None;
+                task.last_error =
+                    Some("self-paced loop did not schedule a next wakeup".to_string());
+            }
+        }
+        ScheduledTaskSchedule::OneShot { .. } => {
+            task.status = ScheduledTaskStatus::Completed;
+            task.next_run_at = None;
+        }
+        ScheduledTaskSchedule::Cron { expression } => {
+            let next = cron_next_run(expression, now)
+                .ok_or_else(|| "cron expression produced no future run".to_string())?;
+            if next > task.expires_at {
+                task.status = ScheduledTaskStatus::Expired;
+                task.next_run_at = None;
+            } else {
+                task.status = ScheduledTaskStatus::Scheduled;
+                task.next_run_at = Some(next);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn mark_run_failed(
+    state: &State<'_, ScheduledTasksState>,
+    app: &AppHandle,
+    id: &str,
+    run_id: Option<String>,
+    error: String,
+) -> Result<(), String> {
+    {
+        let mut inner = state.lock();
+        if let Some(task) = inner.tasks.get_mut(id) {
+            task.status = ScheduledTaskStatus::Failed;
+            task.next_run_at = None;
+            task.current_run_id = None;
+            task.last_error = Some(error.clone());
+            task.updated_at = now_ms();
+        }
+    }
+    persist_emit_notify(state, app)?;
+    let _ = app.emit(
+        "scheduled-task-error",
+        ScheduledTaskError {
+            task_id: id.to_string(),
+            run_id,
+            message: error,
+        },
+    );
+    Ok(())
+}
+
+fn delay_due_task(
+    state: &State<'_, ScheduledTasksState>,
+    app: &AppHandle,
+    id: &str,
+    reason: String,
+) -> Result<(), String> {
+    {
+        let mut inner = state.lock();
+        if let Some(task) = inner.tasks.get_mut(id)
+            && task.status == ScheduledTaskStatus::Scheduled
+        {
+            task.next_run_at = Some(now_ms().saturating_add(IDLE_RETRY_MS));
+            task.coalesced_misses = task.coalesced_misses.saturating_add(1);
+            task.last_error = Some(reason);
+            task.updated_at = now_ms();
+        }
+    }
+    persist_emit_notify(state, app)
+}
+
+fn set_status(
+    id: String,
+    status: ScheduledTaskStatus,
+    state: State<'_, ScheduledTasksState>,
+    app: AppHandle,
+) -> Result<ScheduledTaskRecord, String> {
+    ensure_loaded(&state, &app)?;
+    let now = now_ms();
+    let updated = {
+        let mut inner = state.lock();
+        let task = inner
+            .tasks
+            .get_mut(&id)
+            .ok_or_else(|| format!("unknown task: {id}"))?;
+        if task.status == ScheduledTaskStatus::Running {
+            return Err("cannot change a running task; stop or wait for completion".to_string());
+        }
+        if status == ScheduledTaskStatus::Paused && task.status.terminal() {
+            return Err(format!("cannot pause terminal task: {:?}", task.status));
+        }
+        task.status = status;
+        task.updated_at = now;
+        task.current_run_id = None;
+        if status == ScheduledTaskStatus::Cancelled {
+            task.next_run_at = None;
+        }
+        task.clone()
+    };
+    persist_emit_notify(&state, &app)?;
+    Ok(updated)
+}
+
+fn tab_busy(app: &AppHandle, tab_id: &str) -> bool {
+    let key = tab_agent_key(tab_id);
+    let state = app.state::<AgentProcesses>();
+    let meta = lock_recover(&state.meta, "worker meta (scheduler busy check)");
+    meta.get(&key)
+        .map(|m| m.prompt_in_flight && !prompt_wedged(m, std::time::Instant::now()))
+        .unwrap_or(false)
+}
+
+fn task_list(state: &ScheduledTasksState) -> Vec<ScheduledTaskRecord> {
+    let mut list: Vec<_> = state.lock().tasks.values().cloned().collect();
+    list.sort_by(|a, b| {
+        a.created_at
+            .cmp(&b.created_at)
+            .then_with(|| a.id.cmp(&b.id))
+    });
+    list
+}
+
+fn ensure_loaded(state: &ScheduledTasksState, app: &AppHandle) -> Result<(), String> {
+    {
+        let inner = state.lock();
+        if inner.loaded {
+            return Ok(());
+        }
+    }
+    let path = storage_path(app)?;
+    let mut tasks = read_store(&path)?;
+    let recovered = recover_loaded_running_tasks(&mut tasks, now_ms());
+    {
+        let mut inner = state.lock();
+        if inner.loaded {
+            return Ok(());
+        }
+        inner.storage_path = Some(path.clone());
+        inner.tasks = tasks;
+        inner.loaded = true;
+    }
+    if recovered {
+        persist_emit_notify(state, app)?;
+    }
+    Ok(())
+}
+
+fn refresh_expired(state: &ScheduledTasksState, app: &AppHandle) -> Result<(), String> {
+    let now = now_ms();
+    let mut changed = false;
+    {
+        let mut inner = state.lock();
+        for task in inner.tasks.values_mut() {
+            if task.status.terminal() {
+                continue;
+            }
+            if now >= task.expires_at {
+                task.status = ScheduledTaskStatus::Expired;
+                task.next_run_at = None;
+                task.current_run_id = None;
+                task.updated_at = now;
+                changed = true;
+            }
+        }
+    }
+    if changed {
+        persist_emit_notify(state, app)?;
+    }
+    Ok(())
+}
+
+fn persist_emit_notify(state: &ScheduledTasksState, app: &AppHandle) -> Result<(), String> {
+    persist_emit(state, app)?;
+    state.notify.notify_waiters();
+    Ok(())
+}
+
+fn persist_emit(state: &ScheduledTasksState, app: &AppHandle) -> Result<(), String> {
+    let list = task_list(state);
+    let path = {
+        let inner = state.lock();
+        inner
+            .storage_path
+            .clone()
+            .ok_or_else(|| "scheduled task store not initialized".to_string())?
+    };
+    write_store(&path, &list)?;
+    let _ = app.emit("scheduled-tasks-changed", &list);
+    Ok(())
+}
+
+fn storage_path(app: &AppHandle) -> Result<PathBuf, String> {
+    let home = app
+        .path()
+        .home_dir()
+        .map_err(|e| format!("home_dir: {e}"))?;
+    let dir = crate::helpers::aethon_dir(Some(home))
+        .ok_or_else(|| "aethon dir unresolved".to_string())?;
+    std::fs::create_dir_all(&dir).map_err(|e| format!("create {}: {e}", dir.display()))?;
+    Ok(dir.join(STORE_FILE))
+}
+
+fn read_store(path: &Path) -> Result<HashMap<String, ScheduledTaskRecord>, String> {
+    if !path.exists() {
+        return Ok(HashMap::new());
+    }
+    let raw = std::fs::read_to_string(path).map_err(|e| format!("read {}: {e}", path.display()))?;
+    let store: ScheduledTaskStore =
+        serde_json::from_str(&raw).map_err(|e| format!("parse {}: {e}", path.display()))?;
+    Ok(store
+        .tasks
+        .into_iter()
+        .filter(|task| task.version == TASK_VERSION)
+        .map(|task| (task.id.clone(), task))
+        .collect())
+}
+
+fn recover_loaded_running_tasks(
+    tasks: &mut HashMap<String, ScheduledTaskRecord>,
+    now: i64,
+) -> bool {
+    let mut changed = false;
+    for task in tasks.values_mut() {
+        if task.status != ScheduledTaskStatus::Running {
+            continue;
+        }
+        task.current_run_id = None;
+        task.updated_at = now;
+        task.last_error = Some("app closed before scheduled run completed".to_string());
+        if now >= task.expires_at {
+            task.status = ScheduledTaskStatus::Expired;
+            task.next_run_at = None;
+        } else {
+            task.status = ScheduledTaskStatus::Scheduled;
+            task.next_run_at = Some(now);
+            task.coalesced_misses = task.coalesced_misses.saturating_add(1);
+        }
+        changed = true;
+    }
+    changed
+}
+
+fn fail_running_tasks_for_tab(
+    tasks: &mut HashMap<String, ScheduledTaskRecord>,
+    tab_id: Option<&str>,
+    now: i64,
+    reason: &str,
+    retry_delay_ms: i64,
+) -> bool {
+    let mut changed = false;
+    for task in tasks.values_mut() {
+        if task.status != ScheduledTaskStatus::Running {
+            continue;
+        }
+        if let Some(tab_id) = tab_id
+            && task.tab_id != tab_id
+        {
+            continue;
+        }
+        task.current_run_id = None;
+        task.updated_at = now;
+        task.last_error = Some(reason.to_string());
+        if now >= task.expires_at {
+            task.status = ScheduledTaskStatus::Expired;
+            task.next_run_at = None;
+        } else {
+            task.status = ScheduledTaskStatus::Scheduled;
+            task.next_run_at = Some(now.saturating_add(retry_delay_ms.max(0)));
+            task.coalesced_misses = task.coalesced_misses.saturating_add(1);
+        }
+        changed = true;
+    }
+    changed
+}
+
+fn write_store(path: &Path, tasks: &[ScheduledTaskRecord]) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("create {}: {e}", parent.display()))?;
+    }
+    let store = ScheduledTaskStore {
+        version: STORE_VERSION,
+        tasks: tasks.to_vec(),
+    };
+    let body = serde_json::to_string_pretty(&store).map_err(|e| format!("serialize: {e}"))?;
+    std::fs::write(path, body).map_err(|e| format!("write {}: {e}", path.display()))
+}
+
+fn non_empty(value: Option<String>) -> Option<String> {
+    value
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+fn label_from_prompt(prompt: &str) -> String {
+    prompt
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .unwrap_or("Scheduled task")
+        .chars()
+        .take(80)
+        .collect()
+}
+
+fn now_ms() -> i64 {
+    chrono::Utc::now().timestamp_millis()
+}
+
+fn mode_for_schedule(schedule: &ScheduledTaskSchedule) -> ScheduledTaskMode {
+    match schedule {
+        ScheduledTaskSchedule::Interval { .. } => ScheduledTaskMode::LoopFixed,
+        ScheduledTaskSchedule::SelfPaced { .. } => ScheduledTaskMode::LoopSelfPaced,
+        ScheduledTaskSchedule::OneShot { .. } => ScheduledTaskMode::OneShot,
+        ScheduledTaskSchedule::Cron { .. } => ScheduledTaskMode::Cron,
+    }
+}
+
+fn validate_mode_schedule(
+    mode: ScheduledTaskMode,
+    schedule: &ScheduledTaskSchedule,
+) -> Result<(), String> {
+    let expected = mode_for_schedule(schedule);
+    if mode != expected {
+        return Err(format!(
+            "mode/schedule mismatch: {:?} cannot use {:?}",
+            mode, schedule
+        ));
+    }
+    Ok(())
+}
+
+fn normalize_schedule(
+    schedule: ScheduledTaskSchedule,
+    now: i64,
+    expires_at: i64,
+) -> Result<ScheduledTaskSchedule, String> {
+    match schedule {
+        ScheduledTaskSchedule::Interval { interval_ms, label } => {
+            if interval_ms < MIN_INTERVAL_MS {
+                return Err("interval must be at least 1 minute".to_string());
+            }
+            if interval_ms > MAX_DELAY_MS {
+                return Err("interval must be no more than 7 days".to_string());
+            }
+            Ok(ScheduledTaskSchedule::Interval { interval_ms, label })
+        }
+        ScheduledTaskSchedule::SelfPaced {
+            next_run_at,
+            reason,
+        } => {
+            if let Some(next) = next_run_at
+                && (next < now || next > expires_at)
+            {
+                return Err("self-paced nextRunAt must be within the task lifetime".to_string());
+            }
+            Ok(ScheduledTaskSchedule::SelfPaced {
+                next_run_at,
+                reason,
+            })
+        }
+        ScheduledTaskSchedule::OneShot { run_at } => {
+            if run_at <= now {
+                return Err("runAt must be in the future".to_string());
+            }
+            if run_at > expires_at {
+                return Err("runAt must be within 7 days".to_string());
+            }
+            Ok(ScheduledTaskSchedule::OneShot { run_at })
+        }
+        ScheduledTaskSchedule::Cron { expression } => {
+            if cron_next_run(&expression, now).is_none() {
+                return Err("cron expression has no run in the next 7 days".to_string());
+            }
+            Ok(ScheduledTaskSchedule::Cron { expression })
+        }
+    }
+}
+
+fn initial_next_run_at(
+    schedule: &ScheduledTaskSchedule,
+    now: i64,
+    expires_at: i64,
+) -> Result<Option<i64>, String> {
+    let next = match schedule {
+        ScheduledTaskSchedule::Interval { interval_ms, .. } => {
+            now.saturating_add(*interval_ms as i64)
+        }
+        ScheduledTaskSchedule::SelfPaced { next_run_at, .. } => next_run_at.unwrap_or(now),
+        ScheduledTaskSchedule::OneShot { run_at } => *run_at,
+        ScheduledTaskSchedule::Cron { expression } => cron_next_run(expression, now)
+            .ok_or_else(|| "cron expression has no run in the next 7 days".to_string())?,
+    };
+    if next > expires_at {
+        return Err("next run exceeds the task's 7-day lifetime".to_string());
+    }
+    Ok(Some(next))
+}
+
+fn resume_next_run_at(
+    schedule: &ScheduledTaskSchedule,
+    now: i64,
+    expires_at: i64,
+) -> Result<Option<i64>, String> {
+    match schedule {
+        ScheduledTaskSchedule::Interval { interval_ms, .. } => Ok(Some(
+            now.saturating_add(*interval_ms as i64).min(expires_at),
+        )),
+        ScheduledTaskSchedule::SelfPaced { next_run_at, .. } => {
+            Ok(Some(next_run_at.unwrap_or(now).min(expires_at)))
+        }
+        ScheduledTaskSchedule::OneShot { run_at } => Ok(Some((*run_at).min(expires_at))),
+        ScheduledTaskSchedule::Cron { expression } => Ok(cron_next_run(expression, now)),
+    }
+}
+
+fn resume_task_record(task: &mut ScheduledTaskRecord, now: i64) -> Result<(), String> {
+    if task.status.terminal() {
+        return Err(format!("cannot resume terminal task: {:?}", task.status));
+    }
+    if now >= task.expires_at {
+        task.status = ScheduledTaskStatus::Expired;
+        task.next_run_at = None;
+    } else {
+        task.status = ScheduledTaskStatus::Scheduled;
+        if task.next_run_at.is_none_or(|n| n <= now) {
+            task.next_run_at = resume_next_run_at(&task.schedule, now, task.expires_at)?;
+        }
+        task.last_error = None;
+    }
+    Ok(())
+}
+
+fn cron_next_run(expression: &str, after_ms: i64) -> Option<i64> {
+    let spec = CronSpec::parse(expression).ok()?;
+    let base = Local.timestamp_millis_opt(after_ms).single()?;
+    let mut cursor = base
+        .with_second(0)?
+        .with_nanosecond(0)?
+        .checked_add_signed(chrono::Duration::minutes(1))?;
+    for _ in 0..(7 * 24 * 60) {
+        if spec.matches(cursor) {
+            return Some(cursor.timestamp_millis());
+        }
+        cursor = cursor.checked_add_signed(chrono::Duration::minutes(1))?;
+    }
+    None
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct CronSpec {
+    minutes: HashSet<u32>,
+    hours: HashSet<u32>,
+    days: HashSet<u32>,
+    months: HashSet<u32>,
+    weekdays: HashSet<u32>,
+}
+
+impl CronSpec {
+    fn parse(expression: &str) -> Result<Self, String> {
+        let parts: Vec<_> = expression.split_whitespace().collect();
+        if parts.len() != 5 {
+            return Err("cron must have 5 fields".to_string());
+        }
+        Ok(Self {
+            minutes: parse_cron_field(parts[0], 0, 59, false)?,
+            hours: parse_cron_field(parts[1], 0, 23, false)?,
+            days: parse_cron_field(parts[2], 1, 31, false)?,
+            months: parse_cron_field(parts[3], 1, 12, false)?,
+            weekdays: parse_cron_field(parts[4], 0, 7, true)?,
+        })
+    }
+
+    fn matches<Tz: chrono::TimeZone>(&self, dt: chrono::DateTime<Tz>) -> bool {
+        let weekday = dt.weekday().num_days_from_sunday();
+        self.minutes.contains(&dt.minute())
+            && self.hours.contains(&dt.hour())
+            && self.days.contains(&dt.day())
+            && self.months.contains(&dt.month())
+            && self.weekdays.contains(&weekday)
+    }
+}
+
+fn parse_cron_field(
+    field: &str,
+    min: u32,
+    max: u32,
+    weekday: bool,
+) -> Result<HashSet<u32>, String> {
+    let mut out = HashSet::new();
+    for part in field.split(',') {
+        let part = part.trim();
+        if part.is_empty() {
+            return Err("empty cron field part".to_string());
+        }
+        let (range, step) = if let Some((range, step)) = part.split_once('/') {
+            let step = step
+                .parse::<u32>()
+                .map_err(|_| "invalid cron step".to_string())?;
+            if step == 0 {
+                return Err("cron step must be positive".to_string());
+            }
+            (range, step)
+        } else {
+            (part, 1)
+        };
+        let (start, end) = if range == "*" {
+            (min, max)
+        } else if let Some((start, end)) = range.split_once('-') {
+            (
+                parse_cron_value(start, min, max)?,
+                parse_cron_value(end, min, max)?,
+            )
+        } else {
+            let value = parse_cron_value(range, min, max)?;
+            (value, value)
+        };
+        if start > end {
+            return Err("cron range start exceeds end".to_string());
+        }
+        let mut value = start;
+        while value <= end {
+            out.insert(if weekday && value == 7 { 0 } else { value });
+            match value.checked_add(step) {
+                Some(next) => value = next,
+                None => break,
+            }
+        }
+    }
+    if out.is_empty() {
+        return Err("cron field matched no values".to_string());
+    }
+    Ok(out)
+}
+
+fn parse_cron_value(value: &str, min: u32, max: u32) -> Result<u32, String> {
+    let parsed = value
+        .parse::<u32>()
+        .map_err(|_| format!("invalid cron value: {value}"))?;
+    if parsed < min || parsed > max {
+        return Err(format!("cron value out of range: {parsed}"));
+    }
+    Ok(parsed)
+}
+
+fn resolve_loop_prompt(cwd: Option<&str>, app: &AppHandle) -> Result<LoopPromptResolution, String> {
+    let mut candidates: Vec<(PathBuf, &str)> = Vec::new();
+    if let Some(cwd) = cwd.filter(|s| !s.trim().is_empty()) {
+        let root = PathBuf::from(cwd);
+        candidates.push((
+            root.join(".aethon").join("loop.md"),
+            "projectAethonLoopFile",
+        ));
+        candidates.push((
+            root.join(".claude").join("loop.md"),
+            "projectClaudeLoopFile",
+        ));
+    }
+    if let Ok(home) = app.path().home_dir() {
+        candidates.push((home.join(".aethon").join("loop.md"), "userAethonLoopFile"));
+        candidates.push((home.join(".claude").join("loop.md"), "userClaudeLoopFile"));
+    }
+    for (path, source) in candidates {
+        if !path.is_file() {
+            continue;
+        }
+        let bytes = std::fs::read(&path).map_err(|e| format!("read {}: {e}", path.display()))?;
+        let limited = if bytes.len() > LOOP_PROMPT_MAX_BYTES {
+            &bytes[..LOOP_PROMPT_MAX_BYTES]
+        } else {
+            &bytes
+        };
+        let prompt = String::from_utf8_lossy(limited).trim().to_string();
+        if !prompt.is_empty() {
+            return Ok(LoopPromptResolution {
+                prompt,
+                source: source.to_string(),
+            });
+        }
+    }
+    Ok(LoopPromptResolution {
+        prompt: "Review the current project for useful next steps, check status, run lightweight verification if appropriate, and report or act only on actionable work.".to_string(),
+        source: "builtInMaintenance".to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_task(now: i64, status: ScheduledTaskStatus) -> ScheduledTaskRecord {
+        ScheduledTaskRecord {
+            version: TASK_VERSION,
+            id: "t".into(),
+            tab_id: "tab".into(),
+            cwd: "/tmp".into(),
+            model: None,
+            thinking_level: None,
+            hard_enforce: None,
+            auth_profile_id: None,
+            label: "one".into(),
+            prompt: "do it".into(),
+            visible_prompt: "do it".into(),
+            prompt_source: "inline".into(),
+            mode: ScheduledTaskMode::OneShot,
+            schedule: ScheduledTaskSchedule::OneShot { run_at: now },
+            created_at: now - 1,
+            updated_at: now - 1,
+            next_run_at: Some(now),
+            last_run_at: Some(now),
+            last_completed_at: None,
+            expires_at: now + TASK_TTL_MS,
+            run_count: 1,
+            coalesced_misses: 0,
+            last_error: None,
+            status,
+            current_run_id: (status == ScheduledTaskStatus::Running).then(|| "r".into()),
+        }
+    }
+
+    #[test]
+    fn interval_schedule_requires_at_least_one_minute() {
+        let now = 1_700_000_000_000;
+        let err = normalize_schedule(
+            ScheduledTaskSchedule::Interval {
+                interval_ms: 30_000,
+                label: "30s".to_string(),
+            },
+            now,
+            now + TASK_TTL_MS,
+        )
+        .unwrap_err();
+        assert!(err.contains("at least 1 minute"));
+    }
+
+    #[test]
+    fn self_paced_defaults_to_immediate_first_run() {
+        let now = 1_700_000_000_000;
+        let schedule = ScheduledTaskSchedule::SelfPaced {
+            next_run_at: None,
+            reason: None,
+        };
+        assert_eq!(
+            initial_next_run_at(&schedule, now, now + TASK_TTL_MS).unwrap(),
+            Some(now)
+        );
+    }
+
+    #[test]
+    fn cron_field_parses_steps_ranges_and_sunday_alias() {
+        let spec = CronSpec::parse("*/15 9-17 * * 0,7").unwrap();
+        assert!(spec.minutes.contains(&0));
+        assert!(spec.minutes.contains(&45));
+        assert!(spec.hours.contains(&9));
+        assert!(spec.hours.contains(&17));
+        assert!(spec.weekdays.contains(&0));
+    }
+
+    #[test]
+    fn cron_rejects_bad_expression() {
+        assert!(CronSpec::parse("* * *").is_err());
+        assert!(CronSpec::parse("*/0 * * * *").is_err());
+        assert!(CronSpec::parse("61 * * * *").is_err());
+    }
+
+    #[test]
+    fn successful_one_shot_completes() {
+        let now = 1_700_000_000_000;
+        let mut task = test_task(now, ScheduledTaskStatus::Running);
+        complete_success(&mut task, now, false).unwrap();
+        assert_eq!(task.status, ScheduledTaskStatus::Completed);
+        assert_eq!(task.next_run_at, None);
+    }
+
+    #[test]
+    fn running_tasks_recover_to_scheduled_on_load() {
+        let now = 1_700_000_000_000;
+        let mut tasks = HashMap::from([(
+            "t".to_string(),
+            test_task(now - 60_000, ScheduledTaskStatus::Running),
+        )]);
+        assert!(recover_loaded_running_tasks(&mut tasks, now));
+        let task = tasks.get("t").unwrap();
+        assert_eq!(task.status, ScheduledTaskStatus::Scheduled);
+        assert_eq!(task.next_run_at, Some(now));
+        assert_eq!(task.current_run_id, None);
+        assert_eq!(task.coalesced_misses, 1);
+        assert!(
+            task.last_error
+                .as_deref()
+                .unwrap_or("")
+                .contains("app closed")
+        );
+    }
+
+    #[test]
+    fn expired_running_tasks_recover_to_expired_on_load() {
+        let now = 1_700_000_000_000;
+        let mut task = test_task(now - TASK_TTL_MS - 1, ScheduledTaskStatus::Running);
+        task.expires_at = now - 1;
+        let mut tasks = HashMap::from([("t".to_string(), task)]);
+        assert!(recover_loaded_running_tasks(&mut tasks, now));
+        let task = tasks.get("t").unwrap();
+        assert_eq!(task.status, ScheduledTaskStatus::Expired);
+        assert_eq!(task.next_run_at, None);
+        assert_eq!(task.current_run_id, None);
+    }
+
+    #[test]
+    fn tab_crash_requeues_only_matching_running_tasks() {
+        let now = 1_700_000_000_000;
+        let crash_at = now + 100;
+        let mut other = test_task(now, ScheduledTaskStatus::Running);
+        other.id = "other".to_string();
+        other.tab_id = "other-tab".to_string();
+        let mut paused = test_task(now, ScheduledTaskStatus::Paused);
+        paused.id = "paused".to_string();
+        let mut tasks = HashMap::from([
+            (
+                "t".to_string(),
+                test_task(now, ScheduledTaskStatus::Running),
+            ),
+            ("other".to_string(), other),
+            ("paused".to_string(), paused),
+        ]);
+        assert!(fail_running_tasks_for_tab(
+            &mut tasks,
+            Some("tab"),
+            crash_at,
+            "worker died",
+            IDLE_RETRY_MS,
+        ));
+
+        let task = tasks.get("t").unwrap();
+        assert_eq!(task.status, ScheduledTaskStatus::Scheduled);
+        assert_eq!(task.next_run_at, Some(crash_at + IDLE_RETRY_MS));
+        assert_eq!(task.current_run_id, None);
+        assert_eq!(task.coalesced_misses, 1);
+        assert_eq!(task.last_error.as_deref(), Some("worker died"));
+        assert_eq!(
+            tasks.get("other").unwrap().status,
+            ScheduledTaskStatus::Running
+        );
+        assert_eq!(
+            tasks.get("paused").unwrap().status,
+            ScheduledTaskStatus::Paused
+        );
+    }
+
+    #[test]
+    fn process_crash_can_requeue_all_running_tasks() {
+        let now = 1_700_000_000_000;
+        let mut one = test_task(now, ScheduledTaskStatus::Running);
+        one.id = "one".to_string();
+        let mut two = test_task(now, ScheduledTaskStatus::Running);
+        two.id = "two".to_string();
+        two.tab_id = "two-tab".to_string();
+        let mut tasks = HashMap::from([("one".to_string(), one), ("two".to_string(), two)]);
+        assert!(fail_running_tasks_for_tab(
+            &mut tasks,
+            None,
+            now,
+            "agent crashed",
+            IDLE_RETRY_MS,
+        ));
+
+        for task in tasks.values() {
+            assert_eq!(task.status, ScheduledTaskStatus::Scheduled);
+            assert_eq!(task.next_run_at, Some(now + IDLE_RETRY_MS));
+            assert_eq!(task.current_run_id, None);
+            assert_eq!(task.last_error.as_deref(), Some("agent crashed"));
+        }
+    }
+
+    #[test]
+    fn tab_crash_expires_running_task_past_lifetime() {
+        let now = 1_700_000_000_000;
+        let mut task = test_task(now, ScheduledTaskStatus::Running);
+        task.expires_at = now - 1;
+        let mut tasks = HashMap::from([("t".to_string(), task)]);
+        assert!(fail_running_tasks_for_tab(
+            &mut tasks,
+            Some("tab"),
+            now,
+            "worker died",
+            IDLE_RETRY_MS,
+        ));
+        let task = tasks.get("t").unwrap();
+        assert_eq!(task.status, ScheduledTaskStatus::Expired);
+        assert_eq!(task.next_run_at, None);
+        assert_eq!(task.current_run_id, None);
+    }
+
+    #[test]
+    fn terminal_tasks_cannot_resume() {
+        let now = 1_700_000_000_000;
+        for status in [
+            ScheduledTaskStatus::Cancelled,
+            ScheduledTaskStatus::Completed,
+            ScheduledTaskStatus::Expired,
+        ] {
+            let mut task = test_task(now, status);
+            let err = resume_task_record(&mut task, now).unwrap_err();
+            assert!(err.contains("cannot resume terminal task"));
+            assert_eq!(task.status, status);
+        }
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -132,6 +132,7 @@ pub fn run() {
         .manage(commands::git::GitWatchState::default())
         .manage(window_state::WindowStateStore::new())
         .manage(updater_state::UpdaterState::new())
+        .manage(commands::scheduler::ScheduledTasksState::new())
         .manage(Arc::new(server::ServerState::new()))
         .manage(devshell::DevshellCache::shared())
         .manage(commands::startup::WorkspaceStartupState::default());
@@ -178,6 +179,18 @@ pub fn run() {
             commands::session::delete_session,
             commands::session::export_chat_markdown,
             commands::session::copy_session_file,
+            commands::scheduler::scheduled_tasks_list,
+            commands::scheduler::scheduled_tasks_reconcile_live_tabs,
+            commands::scheduler::scheduled_tasks_fail_running_for_tab,
+            commands::scheduler::scheduled_task_create,
+            commands::scheduler::scheduled_task_update,
+            commands::scheduler::scheduled_task_pause,
+            commands::scheduler::scheduled_task_resume,
+            commands::scheduler::scheduled_task_cancel,
+            commands::scheduler::scheduled_task_run_now,
+            commands::scheduler::scheduled_task_schedule_wakeup,
+            commands::scheduler::scheduled_task_complete,
+            commands::scheduler::scheduled_task_resolve_loop_prompt,
             commands::subagents::subagents_list,
             commands::subagents::subagents_write,
             commands::subagents::subagents_delete,
@@ -356,6 +369,7 @@ pub fn run() {
             // retires `tab:<id>` workers that have sat idle past the configured
             // TTL; they respawn lazily from their session on next use.
             agent_process::spawn_idle_sweep(app.handle().clone());
+            commands::scheduler::boot(app.handle().clone());
 
             // Release app launches can start with a skeletal PATH. Warm
             // the launch-safe tool path off the setup thread so the

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -59,6 +59,7 @@ import { useProjectModelRecorder } from "./hooks/useProjectModelRecorder";
 import { useProjectSyncEffects } from "./hooks/useProjectSyncEffects";
 import { useAppSlashCommandContext } from "./hooks/useAppSlashCommandContext";
 import { useAppBridgeMessages } from "./hooks/useAppBridgeMessages";
+import { useScheduledTasks } from "./hooks/useScheduledTasks";
 import { closeAllWorkspaceSessions } from "./hooks/tabOps/closeWorkspaceSessions";
 import { writeState } from "./persist";
 import { useAppState } from "./state/appStore";
@@ -553,6 +554,14 @@ export default function App() {
     findTabById: findTabRouted,
   });
 
+  useScheduledTasks({
+    state,
+    setState,
+    appendMessage,
+    persistLocalChatMessage,
+    pushNotification,
+  });
+
   // All forward-ref slots — used by earlier hooks to call through to
   // functions that aren't defined until after them — are mirrored here
   // in a single commit-phase pass. See `useAppForwardRefs` for the
@@ -966,6 +975,7 @@ export default function App() {
     settingsOpen,
     searchOpen,
     authProfilesOpen,
+    scheduledTasksOpen,
   } = useDerivedRenderState({ state, buildSidebarHistory, hostInfo });
   const chromeReady = bootConfigReady && startupChromeReady;
 
@@ -982,6 +992,7 @@ export default function App() {
       settingsOpen={settingsOpen}
       searchOpen={searchOpen}
       authProfilesOpen={authProfilesOpen}
+      scheduledTasksOpen={scheduledTasksOpen}
       chromeReady={chromeReady}
       startupLogoUrl={logoUrl}
       workspaceStartup={workspaceStartupView}

--- a/src/app/AppRoot.test.tsx
+++ b/src/app/AppRoot.test.tsx
@@ -69,6 +69,7 @@ describe("AppRoot workspace startup overlay", () => {
         settingsOpen={false}
         searchOpen={false}
         authProfilesOpen={false}
+        scheduledTasksOpen={false}
         chromeReady
         startupLogoUrl="/logo.svg"
         workspaceStartup={{

--- a/src/app/AppRoot.tsx
+++ b/src/app/AppRoot.tsx
@@ -73,6 +73,7 @@ export interface AppRootProps {
   settingsOpen: boolean;
   searchOpen: boolean;
   authProfilesOpen: boolean;
+  scheduledTasksOpen: boolean;
   chromeReady: boolean;
   startupLogoUrl: string;
   workspaceStartup?: WorkspaceStartupView | null;
@@ -85,7 +86,7 @@ export interface AppRootProps {
   topBanner?: ReactNode;
 }
 
-/** App-root render. The four overlays mount through `RegistryComponent`
+/** App-root render. Root overlays mount through `RegistryComponent`
  *  so an extension can swap each with `aethon.registerComponent("<type>",
  *  custom)`. Each overlay still gates its own visibility on state
  *  (e.g. /commandPalette/open) — the boolean flags here just keep the
@@ -104,6 +105,7 @@ export function AppRoot({
   settingsOpen,
   searchOpen,
   authProfilesOpen,
+  scheduledTasksOpen,
   chromeReady,
   startupLogoUrl,
   workspaceStartup,
@@ -189,6 +191,14 @@ export function AppRoot({
         {chromeReady && authProfilesOpen && (
           <RegistryComponent
             type="auth-profile-panel"
+            state={renderState}
+            onEvent={onEvent}
+            tabId={activeTabId}
+          />
+        )}
+        {chromeReady && scheduledTasksOpen && (
+          <RegistryComponent
+            type="scheduled-tasks-panel"
             state={renderState}
             onEvent={onEvent}
             tabId={activeTabId}

--- a/src/eventRoutes/index.ts
+++ b/src/eventRoutes/index.ts
@@ -36,6 +36,7 @@ import { handleQueuedMessages } from "./queue";
 import { handleSettings } from "./settings";
 import { handleAuthProfiles } from "./authProfiles";
 import { handleSearch } from "./search";
+import { handleScheduledTasks } from "./scheduledTasks";
 import { handlePalette } from "./palette";
 import { handleNotifications } from "./notifications";
 import { handleTerminalPanel, handleShareModeCycle } from "./terminal";
@@ -91,6 +92,7 @@ export const BUILTIN_ROUTE_TABLE: ReadonlyMap<string, readonly EventRouteHandler
     ["type:settings-panel", [handleSettings]],
     ["type:auth-profile-panel", [handleAuthProfiles]],
     ["type:search-panel", [handleSearch]],
+    ["type:scheduled-tasks-panel", [handleScheduledTasks]],
     ["type:command-palette", [handlePalette]],
     // Order matters: handleQueuedMessages runs FIRST and only matches
     // `queue:*` events, returning false for everything else. That lets

--- a/src/eventRoutes/scheduledTasks.test.ts
+++ b/src/eventRoutes/scheduledTasks.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { handleScheduledTasks } from "./scheduledTasks";
+import { buildRouteFixture } from "./testFixtures";
+
+describe("handleScheduledTasks", () => {
+  it("closes the scheduled tasks modal on close events", async () => {
+    const { ctx, applySetState } = buildRouteFixture({
+      state: {
+        scheduledTasks: {
+          open: true,
+          tasks: [{ id: "task-1", label: "Daily check" }],
+        },
+      },
+    });
+
+    const handled = await handleScheduledTasks(
+      { component: { id: "scheduled-tasks-panel" }, eventType: "close" },
+      ctx,
+    );
+
+    expect(handled).toBe(true);
+    expect(applySetState().scheduledTasks).toEqual({
+      open: false,
+      tasks: [{ id: "task-1", label: "Daily check" }],
+    });
+  });
+
+  it("returns false for non-close events", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+
+    const handled = await handleScheduledTasks(
+      { component: { id: "scheduled-tasks-panel" }, eventType: "submit" },
+      ctx,
+    );
+
+    expect(handled).toBe(false);
+    expect(mocks.setState).not.toHaveBeenCalled();
+  });
+});

--- a/src/eventRoutes/scheduledTasks.ts
+++ b/src/eventRoutes/scheduledTasks.ts
@@ -1,0 +1,13 @@
+import type { EventRouteHandler } from "./types";
+
+export const handleScheduledTasks: EventRouteHandler = ({ eventType }, ctx) => {
+  if (eventType !== "close") return false;
+  ctx.setState((prev) => ({
+    ...prev,
+    scheduledTasks: {
+      ...(prev.scheduledTasks ?? {}),
+      open: false,
+    },
+  }));
+  return true;
+};

--- a/src/extensions/default-layout/index.ts
+++ b/src/extensions/default-layout/index.ts
@@ -42,6 +42,7 @@ import { CommandPalette } from "./command-palette";
 import { NotificationStack } from "./notifications";
 import { SettingsPanel } from "./settings-panel";
 import { SearchPanel } from "./search-panel";
+import { ScheduledTasksPanel } from "./scheduled-tasks-panel";
 import { ShareModeBadge } from "./share-mode-badge";
 import { GhStatsStrip } from "./dashboard/gh-stats-strip";
 import { ProjectCard } from "./dashboard/project-card";
@@ -137,6 +138,7 @@ export const defaultLayoutExtension: A2UIExtension = {
     "settings-panel": SettingsPanel,
     "auth-profile-panel": AuthProfilePanel,
     "search-panel": SearchPanel,
+    "scheduled-tasks-panel": ScheduledTasksPanel,
     // M6 P2: shell tab share-mode badge — extracted as its own
     // registerable component so an extension can replace it (e.g. with a
     // custom click-flow or icon set) without rewriting the whole shell

--- a/src/extensions/default-layout/scheduled-tasks-panel.tsx
+++ b/src/extensions/default-layout/scheduled-tasks-panel.tsx
@@ -1,0 +1,307 @@
+import { useMemo, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import type { BuiltinComponentProps } from "../../components/A2UIRenderer";
+import type { Tab } from "../../types/tab";
+import {
+  cancelScheduledTask,
+  createScheduledTask,
+  formatRelativeTime,
+  formatTaskStatus,
+  parseLoopArgs,
+  pauseScheduledTask,
+  resolveLoopPrompt,
+  resumeScheduledTask,
+  runScheduledTaskNow,
+  type ScheduledTaskRecord,
+  type ScheduledTaskSchedule,
+} from "../../scheduledTasks";
+
+type DraftMode = "loopSelfPaced" | "loopFixed" | "oneShot" | "cron";
+
+interface ScheduledTasksState {
+  open?: boolean;
+  tasks?: ScheduledTaskRecord[];
+}
+
+function readScheduledTasksState(
+  state: Record<string, unknown>,
+): ScheduledTasksState {
+  return (state.scheduledTasks as ScheduledTasksState | undefined) ?? {};
+}
+
+function activeAgentTab(state: Record<string, unknown>): Tab | null {
+  const tabs = (state.tabs as Tab[] | undefined) ?? [];
+  const activeId = state.activeTabId as string | undefined;
+  const tab = tabs.find((t) => t.id === activeId);
+  return tab?.kind === "agent" ? tab : null;
+}
+
+function activeProjectPath(state: Record<string, unknown>): string | null {
+  const project = state.project as { path?: string } | null | undefined;
+  return typeof project?.path === "string" && project.path
+    ? project.path
+    : null;
+}
+
+function datetimeLocalToMs(value: string): number | null {
+  if (!value) return null;
+  const ms = new Date(value).getTime();
+  return Number.isFinite(ms) ? ms : null;
+}
+
+function defaultRunAtValue(): string {
+  const date = new Date(Date.now() + 60 * 60_000);
+  date.setSeconds(0, 0);
+  const local = new Date(date.getTime() - date.getTimezoneOffset() * 60_000);
+  return local.toISOString().slice(0, 16);
+}
+
+export function ScheduledTasksPanel({ state, onEvent }: BuiltinComponentProps) {
+  const scheduled = readScheduledTasksState(state);
+  const tasks = useMemo(
+    () => [...(scheduled.tasks ?? [])],
+    [scheduled.tasks],
+  );
+  const [mode, setMode] = useState<DraftMode>("loopSelfPaced");
+  const [prompt, setPrompt] = useState("");
+  const [interval, setIntervalValue] = useState("30m");
+  const [cron, setCron] = useState("*/30 * * * *");
+  const [runAt, setRunAt] = useState(defaultRunAtValue);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!scheduled.open) return null;
+
+  const close = () => onEvent("close");
+  const tab = activeAgentTab(state);
+  const canCreate = !!tab && !busy;
+
+  async function createTask() {
+    if (!tab) {
+      setError("Open an agent tab first.");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      const cwd =
+        tab.cwd ??
+        activeProjectPath(state) ??
+        (await invoke<string>("aethon_home_dir").catch(() => ""));
+      if (!cwd) throw new Error("Could not resolve a working directory.");
+      let schedule: ScheduledTaskSchedule;
+      let taskMode: "loopFixed" | "loopSelfPaced" | "oneShot" | "cron";
+      if (mode === "loopFixed") {
+        const parsed = parseLoopArgs(`${interval} ${prompt}`.trim());
+        if (!parsed.ok || parsed.mode !== "loopFixed") {
+          throw new Error(parsed.ok ? "Interval required." : parsed.error);
+        }
+        taskMode = "loopFixed";
+        schedule = parsed.schedule;
+      } else if (mode === "loopSelfPaced") {
+        taskMode = "loopSelfPaced";
+        schedule = { kind: "selfPaced" };
+      } else if (mode === "oneShot") {
+        const ms = datetimeLocalToMs(runAt);
+        if (!ms || ms <= Date.now()) throw new Error("Run time must be future.");
+        taskMode = "oneShot";
+        schedule = { kind: "oneShot", runAt: ms };
+      } else {
+        taskMode = "cron";
+        schedule = { kind: "cron", expression: cron.trim() };
+      }
+      let body = prompt.trim();
+      let promptSource = "inline";
+      if (!body && (mode === "loopSelfPaced" || mode === "loopFixed")) {
+        const resolved = await resolveLoopPrompt(cwd);
+        body = resolved.prompt;
+        promptSource = resolved.source;
+      }
+      if (!body) throw new Error("Prompt required.");
+      await createScheduledTask({
+        tabId: tab.id,
+        cwd,
+        model: tab.model || null,
+        thinkingLevel: tab.thinkingLevel ?? null,
+        hardEnforce: tab.hardEnforceProjectRoot ?? null,
+        authProfileId: tab.authProfileId ?? null,
+        prompt: body,
+        visiblePrompt: body,
+        promptSource,
+        mode: taskMode,
+        schedule,
+      });
+      setPrompt("");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function act(
+    fn: (id: string) => Promise<ScheduledTaskRecord>,
+    id: string,
+  ) {
+    setBusy(true);
+    setError(null);
+    try {
+      await fn(id);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div
+      className="ae-scheduled-overlay"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) close();
+      }}
+    >
+      <div
+        className="ae-scheduled-panel"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Scheduled Tasks"
+      >
+        <div className="ae-scheduled-header">
+          <h2>Scheduled Tasks</h2>
+          <button className="ae-settings-close" onClick={close} aria-label="Close">
+            x
+          </button>
+        </div>
+        <div className="ae-scheduled-body">
+          <section className="ae-scheduled-create">
+            <div className="ae-scheduled-grid">
+              <label className="ae-scheduled-field">
+                <span>Mode</span>
+                <select
+                  value={mode}
+                  onChange={(e) => setMode(e.target.value as DraftMode)}
+                >
+                  <option value="loopSelfPaced">Self-paced loop</option>
+                  <option value="loopFixed">Fixed loop</option>
+                  <option value="oneShot">One-shot</option>
+                  <option value="cron">Cron</option>
+                </select>
+              </label>
+              {mode === "loopFixed" ? (
+                <label className="ae-scheduled-field">
+                  <span>Interval</span>
+                  <input
+                    value={interval}
+                    onChange={(e) => setIntervalValue(e.target.value)}
+                    placeholder="30m"
+                  />
+                </label>
+              ) : null}
+              {mode === "oneShot" ? (
+                <label className="ae-scheduled-field">
+                  <span>Run at</span>
+                  <input
+                    type="datetime-local"
+                    value={runAt}
+                    onChange={(e) => setRunAt(e.target.value)}
+                  />
+                </label>
+              ) : null}
+              {mode === "cron" ? (
+                <label className="ae-scheduled-field">
+                  <span>Cron</span>
+                  <input
+                    value={cron}
+                    onChange={(e) => setCron(e.target.value)}
+                    placeholder="*/30 * * * *"
+                  />
+                </label>
+              ) : null}
+            </div>
+            <label className="ae-scheduled-field ae-scheduled-field--wide">
+              <span>Prompt</span>
+              <textarea
+                value={prompt}
+                onChange={(e) => setPrompt(e.target.value)}
+                rows={4}
+              />
+            </label>
+            {error ? <div className="ae-scheduled-error">{error}</div> : null}
+            <div className="ae-scheduled-actions">
+              <span className="ae-scheduled-target">
+                {tab ? tab.label : "No agent tab"}
+              </span>
+              <button
+                className="ae-settings-primary"
+                disabled={!canCreate}
+                onClick={() => void createTask()}
+              >
+                Create
+              </button>
+            </div>
+          </section>
+          <section className="ae-scheduled-list">
+            {tasks.length === 0 ? (
+              <div className="ae-scheduled-empty">No scheduled tasks.</div>
+            ) : (
+              tasks.map((task) => (
+                <article key={task.id} className="ae-scheduled-row">
+                  <div className="ae-scheduled-row-main">
+                    <div className="ae-scheduled-title">
+                      <strong>{task.label}</strong>
+                      <code>{task.id.slice(0, 8)}</code>
+                    </div>
+                    <div className="ae-scheduled-meta">
+                      <span>{task.mode}</span>
+                      <span>{formatTaskStatus(task)}</span>
+                      {task.nextRunAt ? (
+                        <span>{formatRelativeTime(task.nextRunAt)}</span>
+                      ) : null}
+                    </div>
+                    <div className="ae-scheduled-prompt">
+                      {task.visiblePrompt}
+                    </div>
+                  </div>
+                  <div className="ae-scheduled-row-actions">
+                    <button
+                      title="Run now"
+                      onClick={() => void act(runScheduledTaskNow, task.id)}
+                      disabled={busy || task.status === "running"}
+                    >
+                      Run
+                    </button>
+                    {task.status === "paused" || task.status === "failed" ? (
+                      <button
+                        title="Resume"
+                        onClick={() => void act(resumeScheduledTask, task.id)}
+                        disabled={busy}
+                      >
+                        Resume
+                      </button>
+                    ) : (
+                      <button
+                        title="Pause"
+                        onClick={() => void act(pauseScheduledTask, task.id)}
+                        disabled={busy || task.status === "running"}
+                      >
+                        Pause
+                      </button>
+                    )}
+                    <button
+                      title="Cancel"
+                      onClick={() => void act(cancelScheduledTask, task.id)}
+                      disabled={busy || task.status === "running"}
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </article>
+              ))
+            )}
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/extensions/default-layout/scheduled-tasks-panel.tsx
+++ b/src/extensions/default-layout/scheduled-tasks-panel.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import type { BuiltinComponentProps } from "../../components/A2UIRenderer";
 import type { Tab } from "../../types/tab";
@@ -58,10 +58,7 @@ function defaultRunAtValue(): string {
 
 export function ScheduledTasksPanel({ state, onEvent }: BuiltinComponentProps) {
   const scheduled = readScheduledTasksState(state);
-  const tasks = useMemo(
-    () => [...(scheduled.tasks ?? [])],
-    [scheduled.tasks],
-  );
+  const tasks = useMemo(() => [...(scheduled.tasks ?? [])], [scheduled.tasks]);
   const [mode, setMode] = useState<DraftMode>("loopSelfPaced");
   const [prompt, setPrompt] = useState("");
   const [interval, setIntervalValue] = useState("30m");
@@ -69,6 +66,15 @@ export function ScheduledTasksPanel({ state, onEvent }: BuiltinComponentProps) {
   const [runAt, setRunAt] = useState(defaultRunAtValue);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!scheduled.open) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onEvent("close");
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [scheduled.open, onEvent]);
 
   if (!scheduled.open) return null;
 
@@ -103,7 +109,9 @@ export function ScheduledTasksPanel({ state, onEvent }: BuiltinComponentProps) {
         schedule = { kind: "selfPaced" };
       } else if (mode === "oneShot") {
         const ms = datetimeLocalToMs(runAt);
-        if (!ms || ms <= Date.now()) throw new Error("Run time must be future.");
+        if (!ms || ms <= Date.now()) {
+          throw new Error("Run time must be in the future.");
+        }
         taskMode = "oneShot";
         schedule = { kind: "oneShot", runAt: ms };
       } else {
@@ -169,8 +177,13 @@ export function ScheduledTasksPanel({ state, onEvent }: BuiltinComponentProps) {
       >
         <div className="ae-scheduled-header">
           <h2>Scheduled Tasks</h2>
-          <button className="ae-settings-close" onClick={close} aria-label="Close">
-            x
+          <button
+            type="button"
+            className="ae-settings-close"
+            onClick={close}
+            aria-label="Close"
+          >
+            ×
           </button>
         </div>
         <div className="ae-scheduled-body">
@@ -233,6 +246,7 @@ export function ScheduledTasksPanel({ state, onEvent }: BuiltinComponentProps) {
                 {tab ? tab.label : "No agent tab"}
               </span>
               <button
+                type="button"
                 className="ae-settings-primary"
                 disabled={!canCreate}
                 onClick={() => void createTask()}
@@ -265,6 +279,7 @@ export function ScheduledTasksPanel({ state, onEvent }: BuiltinComponentProps) {
                   </div>
                   <div className="ae-scheduled-row-actions">
                     <button
+                      type="button"
                       title="Run now"
                       onClick={() => void act(runScheduledTaskNow, task.id)}
                       disabled={busy || task.status === "running"}
@@ -273,6 +288,7 @@ export function ScheduledTasksPanel({ state, onEvent }: BuiltinComponentProps) {
                     </button>
                     {task.status === "paused" || task.status === "failed" ? (
                       <button
+                        type="button"
                         title="Resume"
                         onClick={() => void act(resumeScheduledTask, task.id)}
                         disabled={busy}
@@ -281,6 +297,7 @@ export function ScheduledTasksPanel({ state, onEvent }: BuiltinComponentProps) {
                       </button>
                     ) : (
                       <button
+                        type="button"
                         title="Pause"
                         onClick={() => void act(pauseScheduledTask, task.id)}
                         disabled={busy || task.status === "running"}
@@ -289,6 +306,7 @@ export function ScheduledTasksPanel({ state, onEvent }: BuiltinComponentProps) {
                       </button>
                     )}
                     <button
+                      type="button"
                       title="Cancel"
                       onClick={() => void act(cancelScheduledTask, task.id)}
                       disabled={busy || task.status === "running"}

--- a/src/hooks/bridgeMessageHandlers/index.ts
+++ b/src/hooks/bridgeMessageHandlers/index.ts
@@ -46,11 +46,13 @@ import { handleRegisterHighlightGrammar } from "./registerHighlightGrammar";
 import { handleResponse } from "./response";
 import { handleResponseDelta } from "./responseDelta";
 import { handleResponseEnd } from "./responseEnd";
+import { handleScheduledTaskRunComplete } from "./scheduledTaskRunComplete";
 import { handleSessionForked } from "./sessionForked";
 import { handleSessionHistory } from "./sessionHistory";
 import { handleSessionLabelChanged } from "./sessionLabelChanged";
 import { handleSessionRolledBack } from "./sessionRolledBack";
 import { handleShellQuery } from "./shellQuery";
+import { handleSchedulerQuery } from "./schedulerQuery";
 import { handleDashboardQuery } from "./dashboardQuery";
 import { handleDevshellQuery } from "./devshellQuery";
 import { handleGitQuery } from "./gitQuery";
@@ -100,10 +102,12 @@ export const bridgeMessageHandlers: Readonly<
   response: handleResponse,
   response_delta: handleResponseDelta,
   response_end: handleResponseEnd,
+  scheduled_task_run_complete: handleScheduledTaskRunComplete,
   session_forked: handleSessionForked,
   session_history: handleSessionHistory,
   session_label_changed: handleSessionLabelChanged,
   session_rolled_back: handleSessionRolledBack,
+  scheduler_query: handleSchedulerQuery,
   shell_query: handleShellQuery,
   dashboard_query: handleDashboardQuery,
   devshell_query: handleDevshellQuery,

--- a/src/hooks/bridgeMessageHandlers/scheduledTaskRunComplete.test.ts
+++ b/src/hooks/bridgeMessageHandlers/scheduledTaskRunComplete.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { handleScheduledTaskRunComplete } from "./scheduledTaskRunComplete";
+import { buildHandlerFixture } from "./testFixtures";
+import { clearTauriMocks, installTauriMocks } from "../../test/tauriMocks";
+
+describe("handleScheduledTaskRunComplete", () => {
+  let harness: ReturnType<typeof installTauriMocks>;
+  beforeEach(() => {
+    harness = installTauriMocks();
+  });
+  afterEach(() => {
+    clearTauriMocks();
+  });
+
+  it("completes the Rust run and updates scheduled task state", async () => {
+    const { ctx } = buildHandlerFixture({
+      state: { scheduledTasks: { tasks: [{ id: "old", label: "Old" }] } },
+    });
+    const task = {
+      id: "task-1",
+      label: "Check CI",
+      status: "scheduled",
+      createdAt: 1,
+    };
+    harness.invoke.mockResolvedValueOnce(task);
+
+    handleScheduledTaskRunComplete(
+      {
+        type: "scheduled_task_run_complete",
+        taskId: "task-1",
+        runId: "run-1",
+        success: true,
+        completeTask: true,
+      },
+      ctx,
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(harness.invoke).toHaveBeenCalledWith("scheduled_task_complete", {
+      input: {
+        taskId: "task-1",
+        runId: "run-1",
+        success: true,
+        completeTask: true,
+      },
+    });
+    expect(
+      (ctx.stateRef.current.scheduledTasks as { tasks: { id: string }[] })
+        .tasks[0].id,
+    ).toBe("task-1");
+  });
+});

--- a/src/hooks/bridgeMessageHandlers/scheduledTaskRunComplete.ts
+++ b/src/hooks/bridgeMessageHandlers/scheduledTaskRunComplete.ts
@@ -1,0 +1,41 @@
+import type { BridgeMessageHandler } from "./types";
+import {
+  completeScheduledTaskRun,
+  type ScheduledTaskRecord,
+} from "../../scheduledTasks";
+
+export const handleScheduledTaskRunComplete: BridgeMessageHandler = (
+  data,
+  ctx,
+) => {
+  const taskId = data.taskId;
+  const runId = data.runId;
+  if (typeof taskId !== "string" || typeof runId !== "string") return;
+  completeScheduledTaskRun({
+    taskId,
+    runId,
+    success: data.success !== false,
+    ...(typeof data.error === "string" ? { error: data.error } : {}),
+    ...(data.completeTask === true ? { completeTask: true } : {}),
+  })
+    .then((task) => {
+      ctx.setState((prev) => {
+        const cur =
+          (prev.scheduledTasks as
+            | { tasks?: ScheduledTaskRecord[] }
+            | undefined) ?? {};
+        const tasks = [
+          task,
+          ...(cur.tasks ?? []).filter((item) => item.id !== task.id),
+        ];
+        return { ...prev, scheduledTasks: { ...cur, tasks } };
+      });
+    })
+    .catch((err: unknown) => {
+      ctx.pushNotification({
+        title: "Scheduled task did not complete cleanly",
+        message: err instanceof Error ? err.message : String(err),
+        kind: "warning",
+      });
+    });
+};

--- a/src/hooks/bridgeMessageHandlers/schedulerQuery.test.ts
+++ b/src/hooks/bridgeMessageHandlers/schedulerQuery.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { handleSchedulerQuery } from "./schedulerQuery";
+import { buildHandlerFixture } from "./testFixtures";
+import { clearTauriMocks, installTauriMocks } from "../../test/tauriMocks";
+
+describe("handleSchedulerQuery", () => {
+  let harness: ReturnType<typeof installTauriMocks>;
+  beforeEach(() => {
+    harness = installTauriMocks();
+  });
+  afterEach(() => {
+    clearTauriMocks();
+  });
+
+  it("routes schedule_wakeup to the scheduler command", async () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    const task = { id: "task-1", status: "scheduled" };
+    harness.invoke.mockResolvedValueOnce(task);
+    handleSchedulerQuery(
+      {
+        type: "scheduler_query",
+        op: "schedule_wakeup",
+        mutationId: "m1",
+        args: {
+          taskId: "task-1",
+          runId: "run-1",
+          delayMs: 120_000,
+          reason: "poll later",
+        },
+      },
+      ctx,
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(harness.invoke).toHaveBeenCalledWith(
+      "scheduled_task_schedule_wakeup",
+      {
+        input: {
+          taskId: "task-1",
+          runId: "run-1",
+          delayMs: 120_000,
+          reason: "poll later",
+        },
+      },
+    );
+    expect(mocks.ackMutation).toHaveBeenCalledWith(
+      "m1",
+      true,
+      undefined,
+      task,
+    );
+  });
+
+  it("acks failure for unknown ops", async () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    handleSchedulerQuery(
+      { type: "scheduler_query", op: "explode", mutationId: "m2" },
+      ctx,
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(mocks.ackMutation).toHaveBeenCalledWith(
+      "m2",
+      false,
+      "unknown scheduler_query op: explode",
+    );
+  });
+});

--- a/src/hooks/bridgeMessageHandlers/schedulerQuery.ts
+++ b/src/hooks/bridgeMessageHandlers/schedulerQuery.ts
@@ -1,0 +1,37 @@
+import type { BridgeMessageHandler } from "./types";
+import { scheduleLoopWakeup } from "../../scheduledTasks";
+
+export const handleSchedulerQuery: BridgeMessageHandler = (data, ctx) => {
+  const op = typeof data.op === "string" ? data.op : "";
+  const args = (data.args as Record<string, unknown> | undefined) ?? {};
+  const mid = data.mutationId;
+
+  const route = async (): Promise<unknown> => {
+    if (op === "schedule_wakeup") {
+      const taskId = args.taskId;
+      if (typeof taskId !== "string" || !taskId) {
+        throw new Error("schedule_wakeup requires taskId");
+      }
+      return await scheduleLoopWakeup({
+        taskId,
+        ...(typeof args.runId === "string" ? { runId: args.runId } : {}),
+        ...(typeof args.nextRunAt === "number"
+          ? { nextRunAt: args.nextRunAt }
+          : {}),
+        ...(typeof args.delayMs === "number" ? { delayMs: args.delayMs } : {}),
+        ...(typeof args.reason === "string" ? { reason: args.reason } : {}),
+      });
+    }
+    throw new Error(`unknown scheduler_query op: ${op}`);
+  };
+
+  route()
+    .then((result) => ctx.ackMutation(mid, true, undefined, result))
+    .catch((err: unknown) => {
+      ctx.ackMutation(
+        mid,
+        false,
+        err instanceof Error ? err.message : String(err),
+      );
+    });
+};

--- a/src/hooks/osEdges/agentCrash.ts
+++ b/src/hooks/osEdges/agentCrash.ts
@@ -169,14 +169,12 @@ export function subscribeAgentCrash(deps: AgentCrashDeps): () => void {
     const crashMessage = runningTool
       ? `${runningTool} did not finish before the agent worker exited. ${diagnostic}`
       : diagnostic;
-    if (crashedTabId || !globalOnlyCrash) {
-      void failRunningScheduledTasksForTab({
-        tabId: crashedTabId ?? null,
-        message: crashMessage,
-      }).catch(() => {
-        /* scheduler state will recover from persisted running state on restart */
-      });
-    }
+    void failRunningScheduledTasksForTab({
+      tabId: crashedTabId ?? null,
+      message: crashMessage,
+    }).catch(() => {
+      /* scheduler state will recover from persisted running state on restart */
+    });
     activeResponseIdRef.current = null;
     if (crashedTabId) {
       const h = hangWarnTimersRef.current.get(crashedTabId);

--- a/src/hooks/osEdges/agentCrash.ts
+++ b/src/hooks/osEdges/agentCrash.ts
@@ -1,6 +1,7 @@
 import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
+import { failRunningScheduledTasksForTab } from "../../scheduledTasks";
 import type { Tab } from "../../types/tab";
 import { closeRunningToolCards } from "../../utils/agentBusy";
 import type { NotificationInput } from "../useNotifications";
@@ -168,6 +169,14 @@ export function subscribeAgentCrash(deps: AgentCrashDeps): () => void {
     const crashMessage = runningTool
       ? `${runningTool} did not finish before the agent worker exited. ${diagnostic}`
       : diagnostic;
+    if (crashedTabId || !globalOnlyCrash) {
+      void failRunningScheduledTasksForTab({
+        tabId: crashedTabId ?? null,
+        message: crashMessage,
+      }).catch(() => {
+        /* scheduler state will recover from persisted running state on restart */
+      });
+    }
     activeResponseIdRef.current = null;
     if (crashedTabId) {
       const h = hangWarnTimersRef.current.get(crashedTabId);

--- a/src/hooks/useAppSlashCommandContext.ts
+++ b/src/hooks/useAppSlashCommandContext.ts
@@ -15,6 +15,18 @@ import type { ExtensionRegistry } from "../extensions/ExtensionRegistry";
 import type { LayoutCatalogueEntry } from "../extensions/default-layout";
 import type { NotificationInput } from "./useNotifications";
 import type { AuthProfilesUiState } from "../auth-profiles";
+import {
+  cancelScheduledTask,
+  createScheduledTask,
+  listScheduledTasks,
+  pauseScheduledTask,
+  resolveLoopPrompt,
+  resumeScheduledTask,
+  runScheduledTaskNow,
+  type ScheduledTaskMode,
+  type ScheduledTaskRecord,
+  type ScheduledTaskSchedule,
+} from "../scheduledTasks";
 
 export interface UseAppSlashCommandContextOptions {
   bootLayout: A2UIPayload;
@@ -273,6 +285,78 @@ export function useAppSlashCommandContext({
           }),
         });
       },
+      openScheduledTasks: () => {
+        setState((prev) => ({
+          ...prev,
+          scheduledTasks: {
+            ...(prev.scheduledTasks ?? {}),
+            open: true,
+          },
+        }));
+      },
+      createScheduledTask: async (input: {
+        mode: ScheduledTaskMode;
+        schedule: ScheduledTaskSchedule;
+        prompt: string;
+        label?: string;
+        promptSource?: string;
+      }): Promise<ScheduledTaskRecord> => {
+        const tabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
+        const activeId = stateRef.current.activeTabId;
+        const tab = tabs.find((t) => t.id === activeId);
+        if (!tab || tab.kind !== "agent") {
+          throw new Error("Open an agent tab before creating a scheduled task.");
+        }
+        const project = activeProject(projectsRef.current);
+        const cwd =
+          tab.cwd ??
+          project?.path ??
+          (await invoke<string>("aethon_home_dir").catch(() => ""));
+        if (!cwd) throw new Error("Could not resolve a working directory.");
+        let prompt = input.prompt.trim();
+        let promptSource = input.promptSource ?? "inline";
+        if (!prompt) {
+          const resolved = await resolveLoopPrompt(cwd);
+          prompt = resolved.prompt;
+          promptSource = resolved.source;
+        }
+        const created = await createScheduledTask({
+          tabId: tab.id,
+          cwd,
+          model: tab.model || null,
+          thinkingLevel: tab.thinkingLevel ?? null,
+          hardEnforce: tab.hardEnforceProjectRoot ?? null,
+          authProfileId: tab.authProfileId ?? null,
+          label: input.label ?? null,
+          prompt,
+          visiblePrompt: prompt,
+          promptSource,
+          mode: input.mode,
+          schedule: input.schedule,
+        });
+        setState((prev) => {
+          const cur =
+            (prev.scheduledTasks as
+              | { tasks?: ScheduledTaskRecord[] }
+              | undefined) ?? {};
+          return {
+            ...prev,
+            scheduledTasks: {
+              ...cur,
+              tasks: [
+                created,
+                ...(cur.tasks ?? []).filter((task) => task.id !== created.id),
+              ],
+            },
+          };
+        });
+        return created;
+      },
+      listScheduledTasks,
+      runScheduledTask: runScheduledTaskNow,
+      pauseScheduledTask,
+      resumeScheduledTask,
+      cancelScheduledTask,
       activeTabId: () => {
         const id = stateRef.current.activeTabId;
         return typeof id === "string" && id.length > 0 ? id : null;

--- a/src/hooks/useDerivedRenderState.ts
+++ b/src/hooks/useDerivedRenderState.ts
@@ -36,6 +36,7 @@ export interface DerivedRenderStateResult {
   settingsOpen: boolean;
   searchOpen: boolean;
   authProfilesOpen: boolean;
+  scheduledTasksOpen: boolean;
 }
 
 export function useDerivedRenderState({
@@ -238,6 +239,9 @@ export function useDerivedRenderState({
     (renderRecord.authProfiles as { modal?: { open?: boolean } } | undefined)
       ?.modal?.open,
   );
+  const scheduledTasksOpen = Boolean(
+    (renderRecord.scheduledTasks as { open?: boolean } | undefined)?.open,
+  );
 
   return {
     renderState,
@@ -246,5 +250,6 @@ export function useDerivedRenderState({
     settingsOpen,
     searchOpen,
     authProfilesOpen,
+    scheduledTasksOpen,
   };
 }

--- a/src/hooks/useFrontendStateMirror.ts
+++ b/src/hooks/useFrontendStateMirror.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
+import type { ScheduledTaskRecord } from "../scheduledTasks";
 import type { Tab } from "../types/tab";
 
 export interface UseFrontendStateMirrorContext {
@@ -54,11 +55,11 @@ export function useFrontendStateMirror(
       const sidebar =
         (state.sidebar as Record<string, unknown> | undefined) ?? {};
       const tabs = (state.tabs as Tab[] | undefined) ?? [];
-      const messagesCount =
-        ((state.messages as unknown[] | undefined) ?? []).length;
+      const messagesCount = ((state.messages as unknown[] | undefined) ?? [])
+        .length;
       const scheduledTasks =
-        (state.scheduledTasks as { tasks?: unknown[] } | undefined)?.tasks ??
-        [];
+        (state.scheduledTasks as { tasks?: ScheduledTaskRecord[] } | undefined)
+          ?.tasks ?? [];
       const slices: Record<string, unknown> = {
         "/sidebar/models": sidebar.models ?? [],
         "/sidebar/themes": sidebar.themes ?? [],
@@ -66,7 +67,19 @@ export function useFrontendStateMirror(
         "/status": state.status ?? "",
         "/draft": state.draft ?? "",
         "/messagesCount": messagesCount,
-        "/scheduledTasks": scheduledTasks,
+        "/scheduledTasks": scheduledTasks.map((task) => ({
+          id: task.id,
+          label: task.label,
+          mode: task.mode,
+          status: task.status,
+          nextRunAt: task.nextRunAt ?? null,
+          lastRunAt: task.lastRunAt ?? null,
+          lastCompletedAt: task.lastCompletedAt ?? null,
+          expiresAt: task.expiresAt,
+          runCount: task.runCount,
+          coalescedMisses: task.coalescedMisses,
+          lastError: task.lastError ?? null,
+        })),
         "/tabs": tabs.map((t) => ({
           id: t.id,
           label: t.label,

--- a/src/hooks/useFrontendStateMirror.ts
+++ b/src/hooks/useFrontendStateMirror.ts
@@ -56,6 +56,9 @@ export function useFrontendStateMirror(
       const tabs = (state.tabs as Tab[] | undefined) ?? [];
       const messagesCount =
         ((state.messages as unknown[] | undefined) ?? []).length;
+      const scheduledTasks =
+        (state.scheduledTasks as { tasks?: unknown[] } | undefined)?.tasks ??
+        [];
       const slices: Record<string, unknown> = {
         "/sidebar/models": sidebar.models ?? [],
         "/sidebar/themes": sidebar.themes ?? [],
@@ -63,6 +66,7 @@ export function useFrontendStateMirror(
         "/status": state.status ?? "",
         "/draft": state.draft ?? "",
         "/messagesCount": messagesCount,
+        "/scheduledTasks": scheduledTasks,
         "/tabs": tabs.map((t) => ({
           id: t.id,
           label: t.label,

--- a/src/hooks/useScheduledTasks.ts
+++ b/src/hooks/useScheduledTasks.ts
@@ -1,0 +1,211 @@
+import { useEffect, useRef } from "react";
+import { listen } from "@tauri-apps/api/event";
+import type { ChatMessage } from "../types/a2ui";
+import type { Tab } from "../types/tab";
+import {
+  listScheduledTasks,
+  reconcileScheduledTaskTabs,
+  type ScheduledTaskRecord,
+} from "../scheduledTasks";
+
+interface ScheduledTaskFiredEvent {
+  task: ScheduledTaskRecord;
+  runId: string;
+  visiblePrompt: string;
+}
+
+export interface UseScheduledTasksOptions {
+  state: Record<string, unknown>;
+  setState: (
+    update:
+      | Record<string, unknown>
+      | ((prev: Record<string, unknown>) => Record<string, unknown>),
+  ) => void;
+  appendMessage: (msg: ChatMessage, tabId?: string) => void;
+  persistLocalChatMessage: (msg: ChatMessage, tabId: string) => void;
+  pushNotification: (input: {
+    title: string;
+    message?: string;
+    kind?: "info" | "success" | "warning" | "error";
+    durationMs?: number | null;
+  }) => void;
+}
+
+export function useScheduledTasks({
+  state,
+  setState,
+  appendMessage,
+  persistLocalChatMessage,
+  pushNotification,
+}: UseScheduledTasksOptions): void {
+  const appendMessageRef = useRef(appendMessage);
+  const persistLocalChatMessageRef = useRef(persistLocalChatMessage);
+  const pushNotificationRef = useRef(pushNotification);
+
+  useEffect(() => {
+    appendMessageRef.current = appendMessage;
+    persistLocalChatMessageRef.current = persistLocalChatMessage;
+    pushNotificationRef.current = pushNotification;
+  }, [appendMessage, persistLocalChatMessage, pushNotification]);
+
+  useEffect(() => {
+    let cancelled = false;
+    listScheduledTasks()
+      .then((tasks) => {
+        if (!cancelled) mergeTasks(setState, tasks);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        pushNotificationRef.current({
+          title: "Scheduled tasks unavailable",
+          message: err instanceof Error ? err.message : String(err),
+          kind: "warning",
+        });
+      });
+
+    const offChanged = listen<ScheduledTaskRecord[]>(
+      "scheduled-tasks-changed",
+      (event) => mergeTasks(setState, event.payload),
+    );
+    const offFired = listen<ScheduledTaskFiredEvent>(
+      "scheduled-task-fired",
+      (event) => {
+        const { task, runId, visiblePrompt } = event.payload;
+        const msg: ChatMessage = {
+          id: `scheduled-${task.id}-${runId}`,
+          role: "user",
+          text: visiblePrompt,
+          createdAt: Date.now(),
+          delivery: "sent",
+        };
+        appendMessageRef.current(msg, task.tabId);
+        persistLocalChatMessageRef.current(msg, task.tabId);
+        mergeTasks(setState, [task]);
+      },
+    );
+    const offError = listen<{ taskId: string; message: string }>(
+      "scheduled-task-error",
+      (event) => {
+        pushNotificationRef.current({
+          title: "Scheduled task failed",
+          message: event.payload.message,
+          kind: "error",
+        });
+      },
+    );
+
+    return () => {
+      cancelled = true;
+      offChanged.then((fn) => fn());
+      offFired.then((fn) => fn());
+      offError.then((fn) => fn());
+    };
+  }, [setState]);
+
+  useEffect(() => {
+    if (state.sessionUiRestored !== true) return;
+    const liveTabIds = collectLiveAgentTabIds(
+      state.tabs,
+      state.persistedTabBuckets,
+    );
+    void reconcileScheduledTaskTabs(liveTabIds)
+      .then((tasks) => mergeTasks(setState, tasks))
+      .catch(() => {
+        /* best-effort; the next list/event refresh will retry */
+      });
+  }, [
+    setState,
+    state.sessionUiRestored,
+    state.tabs,
+    state.persistedTabBuckets,
+  ]);
+}
+
+function collectLiveAgentTabIds(
+  tabsValue: unknown,
+  persistedTabBucketsValue: unknown,
+): string[] {
+  const ids = new Set<string>();
+  const collect = (tabs: Tab[] | undefined) => {
+    for (const tab of tabs ?? []) {
+      if (tab.kind === "agent") ids.add(tab.id);
+    }
+  };
+  collect(tabsValue as Tab[] | undefined);
+  const buckets = persistedTabBucketsValue as
+    | Record<string, { tabs?: Tab[] }>
+    | undefined;
+  for (const bucket of Object.values(buckets ?? {})) {
+    collect(bucket.tabs);
+  }
+  return [...ids];
+}
+
+function mergeTasks(
+  setState: UseScheduledTasksOptions["setState"],
+  incoming: ScheduledTaskRecord[],
+): void {
+  setState((prev) => {
+    const cur =
+      (prev.scheduledTasks as { tasks?: ScheduledTaskRecord[] } | undefined) ??
+      {};
+    const byId = new Map((cur.tasks ?? []).map((task) => [task.id, task]));
+    for (const task of incoming) byId.set(task.id, task);
+    const tasks = [...byId.values()].sort((a, b) => {
+      const nextA = a.nextRunAt ?? Number.MAX_SAFE_INTEGER;
+      const nextB = b.nextRunAt ?? Number.MAX_SAFE_INTEGER;
+      return nextA - nextB || b.createdAt - a.createdAt;
+    });
+    if (sameScheduledTaskList(cur.tasks ?? [], tasks)) {
+      return prev;
+    }
+    return {
+      ...prev,
+      scheduledTasks: {
+        ...cur,
+        tasks,
+      },
+    };
+  });
+}
+
+function sameScheduledTaskList(
+  left: ScheduledTaskRecord[],
+  right: ScheduledTaskRecord[],
+): boolean {
+  if (left.length !== right.length) return false;
+  return left.every((task, index) => sameScheduledTask(task, right[index]));
+}
+
+function sameScheduledTask(
+  left: ScheduledTaskRecord,
+  right: ScheduledTaskRecord,
+): boolean {
+  return (
+    left.version === right.version &&
+    left.id === right.id &&
+    left.tabId === right.tabId &&
+    left.cwd === right.cwd &&
+    left.model === right.model &&
+    left.thinkingLevel === right.thinkingLevel &&
+    left.hardEnforce === right.hardEnforce &&
+    left.authProfileId === right.authProfileId &&
+    left.label === right.label &&
+    left.prompt === right.prompt &&
+    left.visiblePrompt === right.visiblePrompt &&
+    left.promptSource === right.promptSource &&
+    left.mode === right.mode &&
+    JSON.stringify(left.schedule) === JSON.stringify(right.schedule) &&
+    left.createdAt === right.createdAt &&
+    left.updatedAt === right.updatedAt &&
+    left.nextRunAt === right.nextRunAt &&
+    left.lastRunAt === right.lastRunAt &&
+    left.lastCompletedAt === right.lastCompletedAt &&
+    left.expiresAt === right.expiresAt &&
+    left.runCount === right.runCount &&
+    left.coalescedMisses === right.coalescedMisses &&
+    left.lastError === right.lastError &&
+    left.status === right.status &&
+    left.currentRunId === right.currentRunId
+  );
+}

--- a/src/hooks/useSessionPersistence.ts
+++ b/src/hooks/useSessionPersistence.ts
@@ -91,6 +91,7 @@ export function buildInitialAppStore({
         ? { projectModels: restored.projectModels }
         : {}),
       closedSessionIds: restored?.closedSessionIds ?? [],
+      sessionUiRestored: Boolean(restored),
       logoUrl,
       appVersion,
       tabs,
@@ -230,6 +231,11 @@ export function useSessionPersistence({
       }, 100);
     };
     const startPersistence = () => {
+      appStore.setState((prev) =>
+        prev.sessionUiRestored === true
+          ? prev
+          : { ...prev, sessionUiRestored: true },
+      );
       persistenceStarted = true;
       persistNow();
       unsubscribe = appStore.subscribe(schedulePersist);

--- a/src/scheduledTasks.test.ts
+++ b/src/scheduledTasks.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { parseLoopArgs } from "./scheduledTasks";
+
+describe("parseLoopArgs", () => {
+  it("creates a self-paced loop with no args", () => {
+    expect(parseLoopArgs("")).toEqual({
+      ok: true,
+      mode: "loopSelfPaced",
+      schedule: { kind: "selfPaced" },
+      prompt: "",
+    });
+  });
+
+  it("parses fixed interval shorthand", () => {
+    expect(parseLoopArgs("30m check CI")).toEqual({
+      ok: true,
+      mode: "loopFixed",
+      schedule: { kind: "interval", intervalMs: 30 * 60_000, label: "30m" },
+      prompt: "check CI",
+    });
+  });
+
+  it("parses every-prefixed intervals", () => {
+    expect(parseLoopArgs("every 2h summarize open PRs")).toEqual({
+      ok: true,
+      mode: "loopFixed",
+      schedule: { kind: "interval", intervalMs: 2 * 60 * 60_000, label: "2h" },
+      prompt: "summarize open PRs",
+    });
+    expect(parseLoopArgs("every 2 hours summarize open PRs")).toEqual({
+      ok: true,
+      mode: "loopFixed",
+      schedule: { kind: "interval", intervalMs: 2 * 60 * 60_000, label: "2h" },
+      prompt: "summarize open PRs",
+    });
+    expect(parseLoopArgs("every 2h")).toEqual({
+      ok: true,
+      mode: "loopFixed",
+      schedule: { kind: "interval", intervalMs: 2 * 60 * 60_000, label: "2h" },
+      prompt: "",
+    });
+  });
+
+  it("rejects intervals under one minute", () => {
+    const parsed = parseLoopArgs("30s ping");
+    expect(parsed.ok).toBe(false);
+    if (!parsed.ok) expect(parsed.error).toContain("at least 1 minute");
+  });
+
+  it("treats non-interval text as a self-paced prompt", () => {
+    expect(parseLoopArgs("check the repo and decide the next wakeup")).toEqual({
+      ok: true,
+      mode: "loopSelfPaced",
+      schedule: { kind: "selfPaced" },
+      prompt: "check the repo and decide the next wakeup",
+    });
+  });
+});

--- a/src/scheduledTasks.ts
+++ b/src/scheduledTasks.ts
@@ -1,0 +1,297 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export type ScheduledTaskMode =
+  | "loopFixed"
+  | "loopSelfPaced"
+  | "oneShot"
+  | "cron";
+
+export type ScheduledTaskStatus =
+  | "scheduled"
+  | "running"
+  | "paused"
+  | "expired"
+  | "cancelled"
+  | "failed"
+  | "completed";
+
+export type ScheduledTaskSchedule =
+  | { kind: "interval"; intervalMs: number; label: string }
+  | { kind: "selfPaced"; nextRunAt?: number | null; reason?: string | null }
+  | { kind: "oneShot"; runAt: number }
+  | { kind: "cron"; expression: string };
+
+export interface ScheduledTaskRecord {
+  version: number;
+  id: string;
+  tabId: string;
+  cwd: string;
+  model?: string | null;
+  thinkingLevel?: string | null;
+  hardEnforce?: boolean | null;
+  authProfileId?: string | null;
+  label: string;
+  prompt: string;
+  visiblePrompt: string;
+  promptSource: string;
+  mode: ScheduledTaskMode;
+  schedule: ScheduledTaskSchedule;
+  createdAt: number;
+  updatedAt: number;
+  nextRunAt?: number | null;
+  lastRunAt?: number | null;
+  lastCompletedAt?: number | null;
+  expiresAt: number;
+  runCount: number;
+  coalescedMisses: number;
+  lastError?: string | null;
+  status: ScheduledTaskStatus;
+  currentRunId?: string | null;
+}
+
+export interface ScheduledTaskCreateInput {
+  tabId: string;
+  cwd: string;
+  model?: string | null;
+  thinkingLevel?: string | null;
+  hardEnforce?: boolean | null;
+  authProfileId?: string | null;
+  label?: string | null;
+  prompt: string;
+  visiblePrompt?: string | null;
+  promptSource?: string | null;
+  mode?: ScheduledTaskMode;
+  schedule: ScheduledTaskSchedule;
+}
+
+export interface LoopPromptResolution {
+  prompt: string;
+  source: string;
+}
+
+export type ParsedLoopCommand =
+  | {
+      ok: true;
+      mode: "loopFixed";
+      schedule: Extract<ScheduledTaskSchedule, { kind: "interval" }>;
+      prompt: string;
+    }
+  | {
+      ok: true;
+      mode: "loopSelfPaced";
+      schedule: Extract<ScheduledTaskSchedule, { kind: "selfPaced" }>;
+      prompt: string;
+    }
+  | { ok: false; error: string };
+
+const INTERVAL_MIN_MS = 60_000;
+const INTERVAL_MAX_MS = 7 * 24 * 60 * 60 * 1000;
+
+export async function listScheduledTasks(): Promise<ScheduledTaskRecord[]> {
+  return await invoke<ScheduledTaskRecord[]>("scheduled_tasks_list");
+}
+
+export async function createScheduledTask(
+  input: ScheduledTaskCreateInput,
+): Promise<ScheduledTaskRecord> {
+  return await invoke<ScheduledTaskRecord>("scheduled_task_create", { input });
+}
+
+export async function updateScheduledTask(
+  id: string,
+  patch: Partial<
+    Pick<
+      ScheduledTaskCreateInput,
+      "label" | "prompt" | "visiblePrompt" | "schedule"
+    >
+  >,
+): Promise<ScheduledTaskRecord> {
+  return await invoke<ScheduledTaskRecord>("scheduled_task_update", {
+    id,
+    patch,
+  });
+}
+
+export async function pauseScheduledTask(
+  id: string,
+): Promise<ScheduledTaskRecord> {
+  return await invoke<ScheduledTaskRecord>("scheduled_task_pause", { id });
+}
+
+export async function resumeScheduledTask(
+  id: string,
+): Promise<ScheduledTaskRecord> {
+  return await invoke<ScheduledTaskRecord>("scheduled_task_resume", { id });
+}
+
+export async function cancelScheduledTask(
+  id: string,
+): Promise<ScheduledTaskRecord> {
+  return await invoke<ScheduledTaskRecord>("scheduled_task_cancel", { id });
+}
+
+export async function runScheduledTaskNow(
+  id: string,
+): Promise<ScheduledTaskRecord> {
+  return await invoke<ScheduledTaskRecord>("scheduled_task_run_now", { id });
+}
+
+export async function completeScheduledTaskRun(input: {
+  taskId: string;
+  runId: string;
+  success: boolean;
+  error?: string;
+  completeTask?: boolean;
+}): Promise<ScheduledTaskRecord> {
+  return await invoke<ScheduledTaskRecord>("scheduled_task_complete", {
+    input,
+  });
+}
+
+export async function scheduleLoopWakeup(input: {
+  taskId: string;
+  runId?: string;
+  nextRunAt?: number;
+  delayMs?: number;
+  reason?: string;
+}): Promise<ScheduledTaskRecord> {
+  return await invoke<ScheduledTaskRecord>("scheduled_task_schedule_wakeup", {
+    input,
+  });
+}
+
+export async function reconcileScheduledTaskTabs(
+  liveTabIds: string[],
+): Promise<ScheduledTaskRecord[]> {
+  return await invoke<ScheduledTaskRecord[]>(
+    "scheduled_tasks_reconcile_live_tabs",
+    { liveTabIds },
+  );
+}
+
+export async function failRunningScheduledTasksForTab(input: {
+  tabId?: string | null;
+  message?: string | null;
+}): Promise<ScheduledTaskRecord[]> {
+  return await invoke<ScheduledTaskRecord[]>(
+    "scheduled_tasks_fail_running_for_tab",
+    { input },
+  );
+}
+
+export async function resolveLoopPrompt(
+  cwd?: string | null,
+): Promise<LoopPromptResolution> {
+  return await invoke<LoopPromptResolution>("scheduled_task_resolve_loop_prompt", {
+    cwd: cwd || null,
+  });
+}
+
+export function parseLoopArgs(args: string): ParsedLoopCommand {
+  const trimmed = args.trim();
+  if (!trimmed) {
+    return {
+      ok: true,
+      mode: "loopSelfPaced",
+      schedule: { kind: "selfPaced" },
+      prompt: "",
+    };
+  }
+
+  const everyMatch = trimmed.match(
+    /^every\s+(\d+\s*(?:s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours|d|day|days))(?:\s+([\s\S]+))?$/i,
+  );
+  if (everyMatch) {
+    const parsed = parseInterval(everyMatch[1]);
+    if (!parsed.ok) return parsed;
+    return {
+      ok: true,
+      mode: "loopFixed",
+      schedule: {
+        kind: "interval",
+        intervalMs: parsed.ms,
+        label: formatIntervalLabel(parsed.ms),
+      },
+      prompt: (everyMatch[2] ?? "").trim(),
+    };
+  }
+
+  const [first, ...rest] = trimmed.split(/\s+/);
+  const parsed = parseInterval(first);
+  if (parsed.ok) {
+    return {
+      ok: true,
+      mode: "loopFixed",
+      schedule: {
+        kind: "interval",
+        intervalMs: parsed.ms,
+        label: formatIntervalLabel(parsed.ms),
+      },
+      prompt: rest.join(" ").trim(),
+    };
+  }
+  if (/^\d+\s*[A-Za-z]+$/.test(first)) {
+    return parsed;
+  }
+
+  return {
+    ok: true,
+    mode: "loopSelfPaced",
+    schedule: { kind: "selfPaced" },
+    prompt: trimmed,
+  };
+}
+
+function parseInterval(raw: string): { ok: true; ms: number } | { ok: false; error: string } {
+  const match = raw
+    .trim()
+    .match(/^(\d+)\s*(s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours|d|day|days)$/i);
+  if (!match) return { ok: false, error: `Invalid interval: ${raw}` };
+  const count = Number(match[1]);
+  const unit = match[2].toLowerCase();
+  const factor = unit.startsWith("s")
+    ? 1000
+    : unit.startsWith("m")
+      ? 60_000
+      : unit.startsWith("h")
+        ? 60 * 60_000
+        : 24 * 60 * 60_000;
+  const ms = count * factor;
+  if (!Number.isFinite(ms) || ms < INTERVAL_MIN_MS) {
+    return { ok: false, error: "Loop interval must be at least 1 minute." };
+  }
+  if (ms > INTERVAL_MAX_MS) {
+    return { ok: false, error: "Loop interval must be no more than 7 days." };
+  }
+  return { ok: true, ms };
+}
+
+export function formatIntervalLabel(ms: number): string {
+  const minute = 60_000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+  if (ms % day === 0) return `${ms / day}d`;
+  if (ms % hour === 0) return `${ms / hour}h`;
+  if (ms % minute === 0) return `${ms / minute}m`;
+  return `${Math.round(ms / 1000)}s`;
+}
+
+export function formatTaskStatus(task: ScheduledTaskRecord): string {
+  const next = task.nextRunAt ? ` next ${formatRelativeTime(task.nextRunAt)}` : "";
+  const error = task.lastError ? ` - ${task.lastError}` : "";
+  return `${task.status}${next}${error}`;
+}
+
+export function formatRelativeTime(ms: number, now = Date.now()): string {
+  const diff = ms - now;
+  const abs = Math.abs(diff);
+  const unit =
+    abs >= 24 * 60 * 60_000
+      ? [Math.round(abs / (24 * 60 * 60_000)), "d"]
+      : abs >= 60 * 60_000
+        ? [Math.round(abs / (60 * 60_000)), "h"]
+        : abs >= 60_000
+          ? [Math.round(abs / 60_000), "m"]
+          : [Math.max(0, Math.round(abs / 1000)), "s"];
+  return diff >= 0 ? `in ${unit[0]}${unit[1]}` : `${unit[0]}${unit[1]} ago`;
+}

--- a/src/slashCommands.ts
+++ b/src/slashCommands.ts
@@ -7,6 +7,14 @@
 // passthrough entries. Submitting one sends the original text to pi's prompt
 // router.
 
+import {
+  formatTaskStatus,
+  parseLoopArgs,
+  type ScheduledTaskMode,
+  type ScheduledTaskRecord,
+  type ScheduledTaskSchedule,
+} from "./scheduledTasks";
+
 export interface SlashCommandContext {
   /** Append a chat-history bubble (system role). Use for output that
    *  belongs in the conversation surface — `/help` listings, `/extensions`
@@ -79,6 +87,19 @@ export interface SlashCommandContext {
   /** Rename a session by tabId. Empty `label` clears the custom label
    *  and falls back to the auto-derived first-user-message label. */
   renameSession: (tabId: string, label: string) => Promise<void>;
+  openScheduledTasks?: () => void;
+  createScheduledTask?: (input: {
+    mode: ScheduledTaskMode;
+    schedule: ScheduledTaskSchedule;
+    prompt: string;
+    label?: string;
+    promptSource?: string;
+  }) => Promise<ScheduledTaskRecord>;
+  listScheduledTasks?: () => Promise<ScheduledTaskRecord[]>;
+  runScheduledTask?: (id: string) => Promise<ScheduledTaskRecord>;
+  pauseScheduledTask?: (id: string) => Promise<ScheduledTaskRecord>;
+  resumeScheduledTask?: (id: string) => Promise<ScheduledTaskRecord>;
+  cancelScheduledTask?: (id: string) => Promise<ScheduledTaskRecord>;
   /** Currently active tab id, or null when none. Used by `/rename` so
    *  no-arg target inference can hit the right session. */
   activeTabId: () => string | null;
@@ -118,6 +139,18 @@ function helpFor(commands: SlashCommand[]): string {
     lines.push(`- ${usage} — ${c.description}`);
   }
   return lines.join("\n");
+}
+
+function matchTask(
+  tasks: ScheduledTaskRecord[],
+  idOrPrefix: string,
+): ScheduledTaskRecord | null {
+  const needle = idOrPrefix.trim();
+  if (!needle) return null;
+  const exact = tasks.find((t) => t.id === needle);
+  if (exact) return exact;
+  const matches = tasks.filter((t) => t.id.startsWith(needle));
+  return matches.length === 1 ? matches[0] : null;
 }
 
 export function buildBuiltinSlashCommands(): SlashCommand[] {
@@ -328,6 +361,121 @@ export function buildBuiltinSlashCommands(): SlashCommand[] {
       description: "Export the pi session as HTML, or JSONL when path ends in .jsonl",
       usage: "[path.html|path.jsonl]",
       run: (args, ctx) => ctx.runNativeCommand("export", args),
+    },
+    {
+      name: "loop",
+      description: "Run a repeated scheduled task in this session",
+      usage: "[interval] [prompt]",
+      run: async (args, ctx) => {
+        const parsed = parseLoopArgs(args);
+        if (!parsed.ok) {
+          ctx.notify({
+            title: "Invalid loop",
+            message: parsed.error,
+            kind: "error",
+          });
+          return;
+        }
+        try {
+          if (!ctx.createScheduledTask) {
+            throw new Error("Scheduled tasks are unavailable.");
+          }
+          const task = await ctx.createScheduledTask({
+            mode: parsed.mode,
+            schedule: parsed.schedule,
+            prompt: parsed.prompt,
+          });
+          ctx.notify({
+            title: "Loop scheduled",
+            message: `${task.label} (${task.id.slice(0, 8)})`,
+            kind: "success",
+          });
+        } catch (err) {
+          ctx.notify({
+            title: "Loop failed",
+            message: err instanceof Error ? err.message : String(err),
+            kind: "error",
+          });
+        }
+      },
+    },
+    {
+      name: "tasks",
+      description: "Open or control Scheduled Tasks",
+      usage: "[list|run|pause|resume|cancel <id>]",
+      run: async (args, ctx) => {
+        const [subRaw, ...rest] = args.trim().split(/\s+/).filter(Boolean);
+        const sub = subRaw?.toLowerCase();
+        if (!sub || sub === "open") {
+          if (ctx.openScheduledTasks) ctx.openScheduledTasks();
+          else {
+            ctx.notify({
+              title: "Scheduled tasks unavailable",
+              kind: "warning",
+            });
+          }
+          return;
+        }
+        if (!ctx.listScheduledTasks) {
+          ctx.notify({
+            title: "Scheduled tasks unavailable",
+            kind: "warning",
+          });
+          return;
+        }
+        if (sub === "list") {
+          const tasks = await ctx.listScheduledTasks();
+          if (tasks.length === 0) {
+            ctx.appendSystem("No scheduled tasks.");
+            return;
+          }
+          ctx.appendSystem(
+            [
+              "Scheduled tasks:",
+              ...tasks.map(
+                (task) =>
+                  `- \`${task.id.slice(0, 8)}\` — ${task.label} (${formatTaskStatus(task)})`,
+              ),
+            ].join("\n"),
+          );
+          return;
+        }
+        const id = rest[0] ?? "";
+        const tasks = await ctx.listScheduledTasks();
+        const task = matchTask(tasks, id);
+        if (!task) {
+          ctx.notify({
+            title: "Unknown task",
+            message: "Use `/tasks list` to find the id.",
+            kind: "error",
+          });
+          return;
+        }
+        const action =
+          sub === "run"
+            ? ctx.runScheduledTask
+            : sub === "pause"
+              ? ctx.pauseScheduledTask
+              : sub === "resume"
+                ? ctx.resumeScheduledTask
+                : sub === "cancel" || sub === "delete" || sub === "stop"
+                  ? ctx.cancelScheduledTask
+                  : null;
+        if (!action) {
+          ctx.notify({
+            title: `Unknown tasks command: ${sub}`,
+            message: "Usage: /tasks [list|run|pause|resume|cancel <id>]",
+            kind: "error",
+          });
+          return;
+        }
+        const updated = await action(task.id);
+        ctx.notify({
+          title: `Task ${updated.status}`,
+          message: updated.label,
+          kind: updated.status === "failed" ? "error" : "success",
+        });
+      },
     },
     {
       name: "terminal",

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -6243,6 +6243,208 @@ body.ae-resizing-terminal * {
   background: color-mix(in oklab, var(--accent) 8%, transparent);
 }
 
+/* =============================================================================
+   Scheduled Tasks manager
+   ============================================================================= */
+
+.ae-scheduled-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, var(--opacity-overlay-scrim, 0.45));
+  backdrop-filter: blur(2px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: var(--z-modal, 1200);
+}
+.ae-scheduled-panel {
+  width: min(980px, 94vw);
+  max-height: 86vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--modal-bg, var(--bg-elev));
+  border: 1px solid var(--modal-border, var(--border));
+  border-radius: var(--radius-lg, 12px);
+  box-shadow:
+    var(--modal-shadow, 0 24px 64px rgba(0, 0, 0, 0.45)),
+    var(--inner-highlight, none);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+}
+.ae-scheduled-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border);
+  background: var(--gradient-surface, transparent);
+}
+.ae-scheduled-header h2 {
+  flex: 1 1 auto;
+  margin: 0;
+  font-size: 1.05rem;
+}
+.ae-scheduled-body {
+  display: grid;
+  grid-template-columns: minmax(280px, 340px) minmax(0, 1fr);
+  min-height: 0;
+  overflow: hidden;
+}
+.ae-scheduled-create,
+.ae-scheduled-list {
+  min-width: 0;
+  min-height: 0;
+  padding: var(--space-4);
+  overflow-y: auto;
+}
+.ae-scheduled-create {
+  border-right: 1px solid var(--border);
+  background: color-mix(in oklab, var(--bg-elev) 92%, var(--bg));
+}
+.ae-scheduled-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-3);
+}
+.ae-scheduled-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  font-size: var(--chrome-text-muted);
+  color: var(--text-dim);
+}
+.ae-scheduled-field select,
+.ae-scheduled-field input,
+.ae-scheduled-field textarea {
+  width: 100%;
+  min-width: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-input);
+  color: var(--text);
+  padding: 7px 9px;
+  font: inherit;
+}
+.ae-scheduled-field textarea {
+  resize: vertical;
+  min-height: 96px;
+  font-family: var(--font-mono);
+  font-size: var(--chrome-text);
+}
+.ae-scheduled-error {
+  margin-top: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--state-error-border, var(--error));
+  border-radius: var(--radius-md);
+  color: var(--state-error-fg, var(--error));
+  background: var(--state-error-bg, transparent);
+  font-size: var(--chrome-text-muted);
+}
+.ae-scheduled-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin-top: var(--space-3);
+}
+.ae-scheduled-target {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-dim);
+  font-size: var(--chrome-text-muted);
+}
+.ae-scheduled-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.ae-scheduled-empty {
+  color: var(--text-dim);
+  font-size: var(--chrome-text);
+  text-align: center;
+  padding: var(--space-5);
+}
+.ae-scheduled-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  border: 1px solid var(--card-border, var(--border));
+  border-radius: var(--radius-md);
+  background: var(--card-bg, var(--bg-elev));
+}
+.ae-scheduled-row-main {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.ae-scheduled-title,
+.ae-scheduled-meta,
+.ae-scheduled-row-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+.ae-scheduled-title strong,
+.ae-scheduled-prompt {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.ae-scheduled-title code {
+  font-size: var(--chrome-text-muted);
+  color: var(--text-dim);
+}
+.ae-scheduled-meta {
+  color: var(--text-dim);
+  font-size: var(--chrome-text-muted);
+}
+.ae-scheduled-prompt {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  color: var(--text-secondary, var(--text));
+  font-size: var(--chrome-text);
+  line-height: 1.35;
+}
+.ae-scheduled-row-actions {
+  justify-content: flex-end;
+}
+.ae-scheduled-row-actions button {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text);
+  padding: 5px 9px;
+  cursor: pointer;
+}
+.ae-scheduled-row-actions button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+@media (max-width: 780px) {
+  .ae-scheduled-panel {
+    width: 96vw;
+  }
+  .ae-scheduled-body {
+    grid-template-columns: 1fr;
+  }
+  .ae-scheduled-create {
+    border-right: 0;
+    border-bottom: 1px solid var(--border);
+  }
+  .ae-scheduled-row {
+    grid-template-columns: 1fr;
+  }
+  .ae-scheduled-row-actions {
+    justify-content: flex-start;
+  }
+}
+
 @media (max-width: 720px) {
   .ae-settings-panel {
     width: min(96vw, 860px);


### PR DESCRIPTION
## Summary
- Add a native Rust scheduled-task engine backing `/loop`, `/tasks`, one-shot, cron, fixed-interval, and self-paced loop runs.
- Persist scheduled tasks under Aethon state, reconcile them against restored live tabs, recover interrupted runs, and requeue crashed scheduled runs instead of leaving them stuck.
- Add frontend Scheduled Tasks management UI, slash-command controls, bridge handlers, and agent-side tools for self-paced loop wakeups/completion.

## Verification
- `cargo fmt --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml scheduler --lib`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --all-features`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib`
- `bun run typecheck`
- `bun run lint`
- `bunx vitest run src/scheduledTasks.test.ts src/hooks/bridgeMessageHandlers/schedulerQuery.test.ts src/hooks/bridgeMessageHandlers/scheduledTaskRunComplete.test.ts src/slashCommands.test.ts`
- `bunx vitest run`
- `bun run build`

## Review Notes
- Addressed Codex review findings around persisted running-task recovery, terminal task resume guards, stable scheduler listeners, and worker-crash recovery.
- `bun run build` passes with the existing Vite large-chunk warning.
