### PR TITLE
Fix Linux dev startup, rendering, and Codex auth refresh

### DIFF
--- a/agent/auth-profiles/manager.test.ts
+++ b/agent/auth-profiles/manager.test.ts
@@ -8,9 +8,10 @@ import {
 } from "@mariozechner/pi-coding-agent";
 import type { Api, Model } from "@mariozechner/pi-ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { AethonAgentState } from "../state";
+import type { AethonAgentState, TabRecord } from "../state";
 import type { DispatcherDeps } from "../dispatcherTypes";
 import {
+  authRefreshTabIds,
   authProfileServicesForTab,
   defaultProfileIdForTab,
   handleAuthProfileMessage,
@@ -48,7 +49,24 @@ function makeState(userDir = tempUserDir()): AethonAgentState {
     authProfiles: loadAuthProfilesState(userDir),
     authProfileServices: new Map(),
     tabAuthProfileIds: new Map(),
+    tabs: new Map(),
   } as unknown as AethonAgentState;
+}
+
+function fakeTab(model: string, promptInFlight = false): TabRecord {
+  const [provider, ...rest] = model.split("/");
+  return {
+    id: "tab",
+    session: {
+      model: { provider, id: rest.join("/") },
+    } as unknown as TabRecord["session"],
+    toolArgsCache: new Map(),
+    promptInFlight,
+    agentEndFired: false,
+    queuedCount: 0,
+    toolCardSeq: 0,
+    responseMessageSeq: 0,
+  };
 }
 
 function addProfile(
@@ -201,6 +219,23 @@ describe("auth profile manager", () => {
     expect(refreshed).toBe(true);
     expect(reload).toHaveBeenCalledOnce();
     expect(refresh).toHaveBeenCalledOnce();
+  });
+
+  it("selects matching idle provider tabs for backend refresh after auth changes", () => {
+    const state = makeState();
+    state.tabs.set("active", fakeTab("openai-codex/gpt-5.4"));
+    state.tabs.set("other-provider", fakeTab("anthropic/claude-opus-4-7"));
+    state.tabs.set("busy", fakeTab("openai-codex/gpt-5.4", true));
+    state.tabs.set("other-profile", fakeTab("openai-codex/gpt-5.4"));
+    state.tabAuthProfileIds.set("other-profile", "different-profile");
+
+    expect(
+      authRefreshTabIds(state, {
+        profileId: "codex-work",
+        providerId: "openai-codex",
+        targetTabId: "active",
+      }),
+    ).toEqual(["active"]);
   });
 
   it("rejects deleting unknown or unsafe profile ids before removing files", async () => {

--- a/agent/auth-profiles/manager.test.ts
+++ b/agent/auth-profiles/manager.test.ts
@@ -238,6 +238,40 @@ describe("auth profile manager", () => {
     ).toEqual(["active"]);
   });
 
+  it("emits auth profiles after API key save even when session refresh fails", async () => {
+    const userDir = tempUserDir();
+    const state = makeState(userDir);
+    state.tabs.set("active", fakeTab("openai-codex/gpt-5.4"));
+    const sent: Record<string, unknown>[] = [];
+    const deps = {
+      send: (message: Record<string, unknown>) => sent.push(message),
+    } as DispatcherDeps;
+
+    await handleAuthProfileMessage(state, deps, {
+      type: "auth_profile_api_key_save",
+      providerId: "openai-codex",
+      key: "sk-test",
+      label: "Codex Work",
+      tabId: "active",
+    });
+
+    expect(loadAuthProfilesState(userDir).profiles).toHaveLength(1);
+    expect(state.authProfiles.defaultByProvider["openai-codex"]).toBe(
+      state.authProfiles.profiles[0]?.id,
+    );
+    expect(sent).toContainEqual(
+      expect.objectContaining({
+        type: "error",
+        message: expect.stringContaining(
+          "auth_profile_api_key_save: refresh session:",
+        ),
+      }),
+    );
+    expect(sent).toContainEqual(
+      expect.objectContaining({ type: "auth_profiles" }),
+    );
+  });
+
   it("rejects deleting unknown or unsafe profile ids before removing files", async () => {
     const state = makeState();
     const deps = {

--- a/agent/auth-profiles/manager.ts
+++ b/agent/auth-profiles/manager.ts
@@ -48,6 +48,7 @@ export interface AuthProfilesSnapshot {
 interface PendingOAuth {
   profileId: string;
   providerId: string;
+  targetTabId?: string;
   controller: AbortController;
   isReauth: boolean;
   resolvePrompt?: (value: string) => void;
@@ -236,7 +237,7 @@ export async function handleAuthProfileMessage(
       emitAuthProfiles(state, deps);
       return true;
     case "auth_profile_api_key_save":
-      handleApiKeySave(state, deps, msg);
+      await handleApiKeySave(state, deps, msg);
       return true;
     case "auth_profile_login_start":
       handleOAuthStart(state, deps, msg);
@@ -353,15 +354,16 @@ function authProfileProviders(state: AethonAgentState): AuthProfileProvider[] {
     .sort((a, b) => a.label.localeCompare(b.label));
 }
 
-function handleApiKeySave(
+async function handleApiKeySave(
   state: AethonAgentState,
   deps: DispatcherDeps,
   msg: InboundMessage,
-): void {
+): Promise<void> {
   const providerId = stringField(msg.providerId);
   const key = stringField(msg.key);
   if (!providerId || !key)
     throw new Error("auth_profile_api_key_save: providerId and key required");
+  const targetTabId = normalizedTabId(msg.tabId);
   const requestedProfileId = stringField(msg.profileId);
   const existing = requestedProfileId
     ? findProfile(state, requestedProfileId)
@@ -401,16 +403,13 @@ function handleApiKeySave(
   }
   saveAuthProfiles(state);
   servicesForProfile(state, meta.id, { forceRefresh: true });
-  void recreateIdleTabsUsingProfile(state, deps, meta.id).catch(
-    (err: unknown) => {
-      const message = err instanceof Error ? err.message : String(err);
-      deps.send({
-        type: "error",
-        message: `auth_profile_api_key_save: ${message}`,
-      });
-    },
-  );
+  await refreshTabsAfterAuthChange(state, deps, {
+    profileId: meta.id,
+    providerId,
+    targetTabId,
+  });
   emitAuthProfiles(state, deps);
+  await emitGlobalReady(state, deps);
 }
 
 function handleOAuthStart(
@@ -435,6 +434,7 @@ function handleOAuthStart(
     throw new Error("auth_profile_login_start: profile is not oauth");
   }
   const isReauth = Boolean(existing);
+  const targetTabId = normalizedTabId(msg.tabId);
   const meta =
     existing ??
     createProfileMeta(state.authProfiles, {
@@ -454,6 +454,7 @@ function handleOAuthStart(
   const pending: PendingOAuth = {
     profileId: meta.id,
     providerId,
+    targetTabId,
     controller: new AbortController(),
     isReauth,
   };
@@ -536,7 +537,19 @@ function handleOAuthStart(
       }
       saveAuthProfiles(state);
       servicesForProfile(state, meta.id, { forceRefresh: true });
-      await recreateIdleTabsUsingProfile(state, deps, meta.id);
+      try {
+        await refreshTabsAfterAuthChange(state, deps, {
+          profileId: meta.id,
+          providerId,
+          targetTabId: pending.targetTabId,
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        deps.send({
+          type: "error",
+          message: `auth_profile_login_start: refresh session: ${message}`,
+        });
+      }
       deps.send({
         type: "auth_profile_login_event",
         event: {
@@ -548,6 +561,15 @@ function handleOAuthStart(
         },
       });
       emitAuthProfiles(state, deps);
+      try {
+        await emitGlobalReady(state, deps);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        deps.send({
+          type: "error",
+          message: `auth_profile_login_start: emit ready: ${message}`,
+        });
+      }
     })
     .catch((err: unknown) => {
       pendingOAuth.delete(challengeId);
@@ -593,17 +615,54 @@ function handleOAuthCancel(
   emitAuthProfiles(state, deps);
 }
 
-async function recreateIdleTabsUsingProfile(
+async function refreshTabsAfterAuthChange(
   state: AethonAgentState,
   deps: DispatcherDeps,
-  profileId: string,
+  options: {
+    profileId: string;
+    providerId: string;
+    targetTabId?: string;
+  },
 ): Promise<void> {
+  for (const tabId of authRefreshTabIds(state, options)) {
+    state.tabAuthProfileIds.set(tabId, options.profileId);
+    await recreateTabSession(state, deps, tabId, options.profileId);
+  }
+}
+
+export function authRefreshTabIds(
+  state: AethonAgentState,
+  options: {
+    profileId: string;
+    providerId: string;
+    targetTabId?: string;
+  },
+): string[] {
+  const tabIds = new Set<string>();
   for (const [tabId, activeProfileId] of state.tabAuthProfileIds) {
-    if (activeProfileId !== profileId) continue;
+    if (activeProfileId === options.profileId) tabIds.add(tabId);
+  }
+  if (options.targetTabId) tabIds.add(options.targetTabId);
+  for (const [tabId, tab] of state.tabs) {
+    if (
+      !state.tabAuthProfileIds.has(tabId) &&
+      tab.session.model?.provider === options.providerId
+    ) {
+      tabIds.add(tabId);
+    }
+  }
+
+  const out: string[] = [];
+  for (const tabId of tabIds) {
     const existing = state.tabs.get(tabId);
     if (!existing || existing.promptInFlight) continue;
-    await recreateTabSession(state, deps, tabId, profileId);
+    const activeProfileId = state.tabAuthProfileIds.get(tabId);
+    if (activeProfileId && activeProfileId !== options.profileId) continue;
+    const modelProvider = existing.session.model?.provider;
+    if (modelProvider && modelProvider !== options.providerId) continue;
+    out.push(tabId);
   }
+  return out;
 }
 
 async function recreateTabSession(
@@ -764,6 +823,10 @@ function markProfileUsed(state: AethonAgentState, profileId: string): void {
     ),
   };
   saveAuthProfiles(state);
+}
+
+function normalizedTabId(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
 function stringField(value: unknown): string {

--- a/agent/auth-profiles/manager.ts
+++ b/agent/auth-profiles/manager.ts
@@ -403,13 +403,29 @@ async function handleApiKeySave(
   }
   saveAuthProfiles(state);
   servicesForProfile(state, meta.id, { forceRefresh: true });
-  await refreshTabsAfterAuthChange(state, deps, {
-    profileId: meta.id,
-    providerId,
-    targetTabId,
-  });
+  try {
+    await refreshTabsAfterAuthChange(state, deps, {
+      profileId: meta.id,
+      providerId,
+      targetTabId,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    deps.send({
+      type: "error",
+      message: `auth_profile_api_key_save: refresh session: ${message}`,
+    });
+  }
   emitAuthProfiles(state, deps);
-  await emitGlobalReady(state, deps);
+  try {
+    await emitGlobalReady(state, deps);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    deps.send({
+      type: "error",
+      message: `auth_profile_api_key_save: emit ready: ${message}`,
+    });
+  }
 }
 
 function handleOAuthStart(

--- a/agent/tab-lifecycle.test.ts
+++ b/agent/tab-lifecycle.test.ts
@@ -135,6 +135,33 @@ describe("buildPickerModels", () => {
       "openai-codex/gpt-5.1-codex",
     ]);
   });
+
+  it("includes models available through auth profile registries", () => {
+    const { state } = makeFixture();
+    const codex = {
+      id: "gpt-5.5",
+      provider: "openai-codex",
+      name: "GPT-5.5 Codex",
+    };
+    state.modelRegistry = {
+      getAll: () => [],
+      getAvailable: () => [],
+    } as unknown as AethonAgentState["modelRegistry"];
+    state.authProfileServices.set("codex-work", {
+      authStorage: { reload: vi.fn() },
+      modelRegistry: {
+        getAll: () => [codex],
+        getAvailable: () => [codex],
+      },
+    });
+    state.settingsManager = {
+      getEnabledModels: () => [],
+    } as unknown as AethonAgentState["settingsManager"];
+
+    expect(buildPickerModels(state).map(modelKey)).toEqual([
+      "openai-codex/gpt-5.5",
+    ]);
+  });
 });
 
 describe("refreshCachedModels", () => {

--- a/agent/tab-lifecycle/models.ts
+++ b/agent/tab-lifecycle/models.ts
@@ -11,20 +11,50 @@ import type { AethonAgentState } from "../state";
 import { compilePattern, modelDescriptor, modelKey } from "./utils";
 import type { TabLifecycleDeps } from "./utils";
 
+function uniqueModels(models: Model<Api>[]): Model<Api>[] {
+  const seen = new Set<string>();
+  const out: Model<Api>[] = [];
+  for (const model of models) {
+    const key = modelKey(model);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(model);
+  }
+  return out;
+}
+
+function allRegistryModels(state: AethonAgentState) {
+  return uniqueModels([
+    ...state.modelRegistry.getAll(),
+    ...[...state.authProfileServices.values()].flatMap((services) =>
+      services.modelRegistry.getAll(),
+    ),
+  ]);
+}
+
+function availableModels(state: AethonAgentState) {
+  return uniqueModels([
+    ...state.modelRegistry.getAvailable(),
+    ...[...state.authProfileServices.values()].flatMap((services) =>
+      services.modelRegistry.getAvailable(),
+    ),
+  ]);
+}
+
 /** Filter the picker to the user's enabledModels patterns from
  *  ~/.pi/agent/settings.json. Always include the current model. */
 export function buildPickerModels(
   state: AethonAgentState,
   currentModel?: Model<Api>,
 ): Model<Api>[] {
-  const all = state.modelRegistry.getAll();
+  const all = allRegistryModels(state);
   const enabled = state.settingsManager.getEnabledModels();
   let pickerModels: Model<Api>[];
   if (enabled && enabled.length > 0) {
     const patterns = enabled.map(compilePattern);
     pickerModels = all.filter((m) => patterns.some((p) => p.test(modelKey(m))));
   } else {
-    pickerModels = state.modelRegistry.getAvailable();
+    pickerModels = availableModels(state);
   }
   const seen = new Set(pickerModels.map(modelKey));
   if (currentModel && !seen.has(modelKey(currentModel))) {
@@ -66,6 +96,20 @@ export async function refreshCachedModels(
     logger
       .scope("picker")
       .warn(`model registry refresh failed: ${(err as Error).message}`);
+  }
+  for (const [profileId, services] of state.authProfileServices) {
+    try {
+      services.authStorage.reload();
+      services.modelRegistry.refresh();
+    } catch (err) {
+      logger
+        .scope("picker")
+        .warn(
+          `profile model registry refresh failed (${profileId}): ${
+            (err as Error).message
+          }`,
+        );
+    }
   }
   state.cachedModels = buildPickerModels(
     state,

--- a/flake.nix
+++ b/flake.nix
@@ -135,6 +135,11 @@
             pkgs.gsettings-desktop-schemas
           ];
 
+          linuxGSettingsSchemaDirs = lib.optionals pkgs.stdenv.isLinux [
+            "${pkgs.gtk3}/share/gsettings-schemas/${pkgs.gtk3.name}"
+            "${pkgs.gsettings-desktop-schemas}/share/gsettings-schemas/${pkgs.gsettings-desktop-schemas.name}"
+          ];
+
           # macOS gets libiconv from the SDK at link time (libiconv.2.tbd
           # under $SDKROOT/usr/lib), which produces a binary that loads
           # /usr/lib/libiconv.2.dylib at runtime — the path every notarized
@@ -272,6 +277,12 @@
               {
                 name = "GST_PLUGIN_SYSTEM_PATH_1_0";
                 value = lib.makeSearchPath "lib/gstreamer-1.0" linuxBuildInputs;
+              }
+              {
+                name = "XDG_DATA_DIRS";
+                prefix = lib.concatStringsSep ":" (
+                  (map (pkg: "${pkg}/share") linuxBuildInputs) ++ linuxGSettingsSchemaDirs
+                );
               }
               {
                 name = "CC";

--- a/flake.nix
+++ b/flake.nix
@@ -71,6 +71,10 @@
             rustc = rustToolchain;
           };
 
+          cargoTargetEnv = lib.toUpper (
+            builtins.replaceStrings [ "-" ] [ "_" ] pkgs.stdenv.hostPlatform.config
+          );
+
           cargoTauriHook = pkgs.cargo-tauri.hook.override {
             cargo = rustToolchain;
           };
@@ -119,8 +123,12 @@
             pkgs.atk
             pkgs.gdk-pixbuf
             pkgs.libsoup_3
+            pkgs.gst_all_1.gstreamer
+            pkgs.gst_all_1.gst-plugins-base
             pkgs.glib
             pkgs.glib-networking
+            pkgs.dbus
+            pkgs.zlib
             pkgs.alsa-lib
             pkgs.openssl
             pkgs.libayatana-appindicator
@@ -219,6 +227,9 @@
               # PATH, so without this the bare treefmt can't find its config.
               config.treefmt.build.wrapper
             ]
+            ++ lib.optionals pkgs.stdenv.isLinux [
+              pkgs.stdenv.cc
+            ]
             ++ linuxBuildInputs
             ++ darwinBuildInputs;
 
@@ -231,7 +242,10 @@
             ++ lib.optionals pkgs.stdenv.isLinux [
               {
                 name = "PKG_CONFIG_PATH";
-                value = lib.makeSearchPath "lib/pkgconfig" (map lib.getDev linuxBuildInputs);
+                value = lib.concatStringsSep ":" [
+                  (lib.makeSearchPath "lib/pkgconfig" (map lib.getDev linuxBuildInputs))
+                  (lib.makeSearchPath "share/pkgconfig" (map lib.getDev linuxBuildInputs))
+                ];
               }
               {
                 name = "LD_LIBRARY_PATH";
@@ -244,8 +258,38 @@
                 value = "1";
               }
               {
+                # WebKitGTK's native Wayland backend can report negative
+                # viewport/DPR values on Hyprland, collapsing the app grid.
+                # Prefer XWayland, but keep Wayland as a fallback for hosts
+                # without XWayland.
+                name = "GDK_BACKEND";
+                value = "x11,wayland";
+              }
+              {
                 name = "GIO_EXTRA_MODULES";
                 prefix = "${pkgs.glib-networking}/lib/gio/modules";
+              }
+              {
+                name = "GST_PLUGIN_SYSTEM_PATH_1_0";
+                value = lib.makeSearchPath "lib/gstreamer-1.0" linuxBuildInputs;
+              }
+              {
+                name = "CC";
+                value = "${pkgs.stdenv.cc}/bin/cc";
+              }
+              {
+                name = "CXX";
+                value = "${pkgs.stdenv.cc}/bin/c++";
+              }
+              {
+                name = "CARGO_TARGET_${cargoTargetEnv}_LINKER";
+                value = "${pkgs.stdenv.cc}/bin/cc";
+              }
+              {
+                # Keep Rust's final link on the same Nix glibc as the
+                # WebKitGTK closure instead of a host/profile compiler.
+                name = "RUSTC_LINKER";
+                value = "${pkgs.stdenv.cc}/bin/cc";
               }
             ]
             ++ lib.optionals pkgs.stdenv.isDarwin [

--- a/src-tauri/src/commands/extensions/app_menu.rs
+++ b/src-tauri/src/commands/extensions/app_menu.rs
@@ -108,6 +108,7 @@ pub fn install_app_menu(
     // macOS, so we omit it here — the user closes the window via the
     // red traffic light or Cmd+Q. Adding both would let macOS route
     // Cmd+W to whichever menu item it picks first.
+    #[cfg(target_os = "macos")]
     let file_menu = SubmenuBuilder::new(app, "File")
         .item(&new_file)
         .item(&save_file)
@@ -116,6 +117,18 @@ pub fn install_app_menu(
         .item(&new_tab)
         .item(&new_agent_tab)
         .item(&close_tab)
+        .build()?;
+    #[cfg(not(target_os = "macos"))]
+    let file_menu = SubmenuBuilder::new(app, "File")
+        .item(&new_file)
+        .item(&save_file)
+        .item(&revert_file)
+        .separator()
+        .item(&new_tab)
+        .item(&new_agent_tab)
+        .item(&close_tab)
+        .separator()
+        .item(&PredefinedMenuItem::quit(app, Some("Exit"))?)
         .build()?;
 
     let edit_menu = SubmenuBuilder::new(app, "Edit")
@@ -236,6 +249,15 @@ mod tests {
         assert!(
             src.contains("SubmenuBuilder::new(app, \"Extensions\").item(&manage_extensions)"),
             "the Extensions submenu should be created even when no extension-registered menu items exist",
+        );
+    }
+
+    #[test]
+    fn non_macos_file_menu_exposes_exit() {
+        let src = include_str!("app_menu.rs");
+        assert!(
+            src.contains("PredefinedMenuItem::quit(app, Some(\"Exit\"))"),
+            "Linux/Windows should expose File → Exit; macOS keeps Quit in the app menu",
         );
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -67,8 +67,24 @@ fn home_dir_for_logging() -> Option<std::path::PathBuf> {
     }
 }
 
+#[cfg(target_os = "linux")]
+fn prefer_stable_linux_webview_backend() {
+    if std::env::var_os("GDK_BACKEND").is_none() {
+        // WebKitGTK's native Wayland backend can report negative viewport
+        // dimensions/DPR on Hyprland, collapsing the React grid before the
+        // frontend can recover. Prefer XWayland, while preserving a Wayland
+        // fallback and respecting explicit user overrides.
+        unsafe { std::env::set_var("GDK_BACKEND", "x11,wayland") };
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn prefer_stable_linux_webview_backend() {}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    prefer_stable_linux_webview_backend();
+
     // Boot-rollback helper sub-invocation: when the post-update
     // probation timer fires, the parent spawns this same binary with
     // `--boot-rollback-helper <sentinel-path> <parent-pid>`. The

--- a/src-tauri/src/shell/lifecycle/registry.rs
+++ b/src-tauri/src/shell/lifecycle/registry.rs
@@ -157,7 +157,7 @@ pub(super) mod test_support {
             cwd: String::new(),
             command: command.to_string(),
             // Test slots default to false (direct command), matching how
-            // tests spawn `/bin/echo`, `/bin/sleep`, etc. — they're never
+            // tests spawn `echo`, `sleep`, etc. — they're never
             // interactive shells.
             is_interactive_shell: false,
         };
@@ -194,7 +194,7 @@ mod tests {
     #[test]
     fn echo_round_trip_via_input_command() {
         let reg = registry();
-        let mut child = open_raw(&reg, "t1", "/bin/echo", vec!["hello-aethon".into()]);
+        let mut child = open_raw(&reg, "t1", "echo", vec!["hello-aethon".into()]);
         let status = child.wait().expect("wait");
         assert!(status.success());
         reg.slots.lock().unwrap().remove("t1").unwrap();
@@ -203,7 +203,7 @@ mod tests {
     #[test]
     fn resize_propagates_when_slot_present() {
         let reg = registry();
-        let mut child = open_raw(&reg, "t2", "/bin/sleep", vec!["0.05".into()]);
+        let mut child = open_raw(&reg, "t2", "sleep", vec!["0.05".into()]);
         // Resize via the registry path — must succeed while child is alive.
         {
             let guard = reg.slots.lock().unwrap();
@@ -231,7 +231,7 @@ mod tests {
     #[test]
     fn cleanup_drops_slot() {
         let reg = registry();
-        let mut child = open_raw(&reg, "t3", "/bin/sleep", vec!["0.01".into()]);
+        let mut child = open_raw(&reg, "t3", "sleep", vec!["0.01".into()]);
         let _ = child.wait();
         let mut slot = reg
             .slots
@@ -254,7 +254,7 @@ mod tests {
         let mut children: Vec<Box<dyn portable_pty::Child + Send + Sync>> = Vec::new();
         for i in 0..n_tabs {
             let id = format!("t-concurrent-{i}");
-            children.push(open_raw(&reg, &id, "/bin/sleep", vec!["0.05".into()]));
+            children.push(open_raw(&reg, &id, "sleep", vec!["0.05".into()]));
         }
         assert_eq!(reg.slots.lock().unwrap().len(), n_tabs);
         let start = Instant::now();

--- a/src-tauri/src/shell/lifecycle/sharing.rs
+++ b/src-tauri/src/shell/lifecycle/sharing.rs
@@ -218,7 +218,7 @@ mod tests {
     #[test]
     fn write_keystrokes_rejects_private() {
         let reg = registry();
-        let mut child = open_raw(&reg, "wp", "/bin/sleep", vec!["0.05".into()]);
+        let mut child = open_raw(&reg, "wp", "sleep", vec!["0.05".into()]);
         let r = write_keystrokes(&reg, "wp", b"hi");
         assert!(r.is_err());
         assert!(
@@ -233,7 +233,7 @@ mod tests {
     #[test]
     fn write_keystrokes_rejects_read_only() {
         let reg = registry();
-        let mut child = open_raw(&reg, "wr", "/bin/sleep", vec!["0.05".into()]);
+        let mut child = open_raw(&reg, "wr", "sleep", vec!["0.05".into()]);
         force_mode(&reg, "wr", ShareMode::Read);
         let r = write_keystrokes(&reg, "wr", b"hi");
         assert!(r.is_err());
@@ -244,7 +244,7 @@ mod tests {
     #[test]
     fn write_keystrokes_succeeds_for_read_write() {
         let reg = registry();
-        let mut child = open_raw(&reg, "wrw", "/bin/sleep", vec!["0.05".into()]);
+        let mut child = open_raw(&reg, "wrw", "sleep", vec!["0.05".into()]);
         force_mode(&reg, "wrw", ShareMode::ReadWrite);
         // The PTY is already alive — write a benign byte.
         let r = write_keystrokes(&reg, "wrw", b"\x03");
@@ -256,7 +256,7 @@ mod tests {
     #[test]
     fn write_keystrokes_succeeds_for_read_write_trusted() {
         let reg = registry();
-        let mut child = open_raw(&reg, "wrwt", "/bin/sleep", vec!["0.05".into()]);
+        let mut child = open_raw(&reg, "wrwt", "sleep", vec!["0.05".into()]);
         force_mode(&reg, "wrwt", ShareMode::ReadWriteTrusted);
         let r = write_keystrokes(&reg, "wrwt", b"\x03");
         assert!(r.is_ok(), "{:?}", r.err());

--- a/src/extensions/default-layout/auth-profile-panel.tsx
+++ b/src/extensions/default-layout/auth-profile-panel.tsx
@@ -60,6 +60,7 @@ export function AuthProfilePanel({
           : "auth_profile_api_key_save",
       providerId: selectedProvider.id,
       label: label.trim() || selectedProvider.label,
+      tabId: activeTabId,
       ...(selectedProvider.kind === "api_key" ? { key: apiKey } : {}),
     });
     if (selectedProvider.kind === "api_key") {
@@ -88,6 +89,7 @@ export function AuthProfilePanel({
       providerId: profile.providerId,
       profileId: profile.id,
       label: profile.label,
+      tabId: activeTabId,
     });
 
   const deleteProfile = (profileId: string) =>

--- a/src/utils/viewport.test.ts
+++ b/src/utils/viewport.test.ts
@@ -1,11 +1,79 @@
 // @vitest-environment jsdom
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { applyUiScale } from "./viewport";
+import { applyUiScale, writeUiViewportVars } from "./viewport";
+
+const originalDescriptors = {
+  window: {
+    innerWidth: Object.getOwnPropertyDescriptor(window, "innerWidth"),
+    innerHeight: Object.getOwnPropertyDescriptor(window, "innerHeight"),
+    outerWidth: Object.getOwnPropertyDescriptor(window, "outerWidth"),
+    outerHeight: Object.getOwnPropertyDescriptor(window, "outerHeight"),
+    visualViewport: Object.getOwnPropertyDescriptor(window, "visualViewport"),
+  },
+  documentElement: {
+    clientWidth: Object.getOwnPropertyDescriptor(
+      document.documentElement,
+      "clientWidth",
+    ),
+    clientHeight: Object.getOwnPropertyDescriptor(
+      document.documentElement,
+      "clientHeight",
+    ),
+  },
+  body: {
+    clientWidth: Object.getOwnPropertyDescriptor(document.body, "clientWidth"),
+    clientHeight: Object.getOwnPropertyDescriptor(document.body, "clientHeight"),
+  },
+};
+
+function restoreProperty(
+  target: object,
+  key: string,
+  descriptor: PropertyDescriptor | undefined,
+) {
+  if (descriptor) {
+    Object.defineProperty(target, key, descriptor);
+  } else {
+    delete (target as Record<string, unknown>)[key];
+  }
+}
 
 afterEach(() => {
   document.documentElement.style.removeProperty("--app-ui-scale");
+  document.documentElement.style.removeProperty("--app-viewport-width");
+  document.documentElement.style.removeProperty("--app-viewport-height");
   document.documentElement.style.zoom = "";
+
+  restoreProperty(window, "innerWidth", originalDescriptors.window.innerWidth);
+  restoreProperty(window, "innerHeight", originalDescriptors.window.innerHeight);
+  restoreProperty(window, "outerWidth", originalDescriptors.window.outerWidth);
+  restoreProperty(window, "outerHeight", originalDescriptors.window.outerHeight);
+  restoreProperty(
+    window,
+    "visualViewport",
+    originalDescriptors.window.visualViewport,
+  );
+  restoreProperty(
+    document.documentElement,
+    "clientWidth",
+    originalDescriptors.documentElement.clientWidth,
+  );
+  restoreProperty(
+    document.documentElement,
+    "clientHeight",
+    originalDescriptors.documentElement.clientHeight,
+  );
+  restoreProperty(
+    document.body,
+    "clientWidth",
+    originalDescriptors.body.clientWidth,
+  );
+  restoreProperty(
+    document.body,
+    "clientHeight",
+    originalDescriptors.body.clientHeight,
+  );
 });
 
 describe("applyUiScale", () => {
@@ -22,5 +90,37 @@ describe("applyUiScale", () => {
     });
 
     window.removeEventListener("aethon:ui-scale-change", listener);
+  });
+});
+
+describe("writeUiViewportVars", () => {
+  it("falls back when WebKit reports negative viewport dimensions", () => {
+    Object.defineProperties(window, {
+      innerWidth: { configurable: true, value: -90816 },
+      innerHeight: { configurable: true, value: -92352 },
+      outerWidth: { configurable: true, value: 946 },
+      outerHeight: { configurable: true, value: 990 },
+      visualViewport: {
+        configurable: true,
+        value: { width: -90816, height: -92352 },
+      },
+    });
+    Object.defineProperties(document.documentElement, {
+      clientWidth: { configurable: true, value: 946000002 },
+      clientHeight: { configurable: true, value: 962000002 },
+    });
+    Object.defineProperties(document.body, {
+      clientWidth: { configurable: true, value: 33554432 },
+      clientHeight: { configurable: true, value: 33554432 },
+    });
+
+    writeUiViewportVars(1);
+
+    expect(
+      document.documentElement.style.getPropertyValue("--app-viewport-width"),
+    ).toBe("946px");
+    expect(
+      document.documentElement.style.getPropertyValue("--app-viewport-height"),
+    ).toBe("990px");
   });
 });

--- a/src/utils/viewport.test.ts
+++ b/src/utils/viewport.test.ts
@@ -94,6 +94,28 @@ describe("applyUiScale", () => {
 });
 
 describe("writeUiViewportVars", () => {
+  it("preserves window inner dimensions when they are sane", () => {
+    Object.defineProperties(window, {
+      innerWidth: { configurable: true, value: 1280 },
+      innerHeight: { configurable: true, value: 720 },
+      outerWidth: { configurable: true, value: 1440 },
+      outerHeight: { configurable: true, value: 900 },
+      visualViewport: {
+        configurable: true,
+        value: { width: 960, height: 540 },
+      },
+    });
+
+    writeUiViewportVars(1);
+
+    expect(
+      document.documentElement.style.getPropertyValue("--app-viewport-width"),
+    ).toBe("1280px");
+    expect(
+      document.documentElement.style.getPropertyValue("--app-viewport-height"),
+    ).toBe("720px");
+  });
+
   it("falls back when WebKit reports negative viewport dimensions", () => {
     Object.defineProperties(window, {
       innerWidth: { configurable: true, value: -90816 },

--- a/src/utils/viewport.ts
+++ b/src/utils/viewport.ts
@@ -16,8 +16,8 @@ function saneViewportSize(value: unknown): value is number {
 }
 
 function viewportSize(axis: "width" | "height"): number {
-  const visual = window.visualViewport?.[axis];
   const inner = axis === "width" ? window.innerWidth : window.innerHeight;
+  const visual = window.visualViewport?.[axis];
   const outer = axis === "width" ? window.outerWidth : window.outerHeight;
   const docClient =
     axis === "width"
@@ -31,8 +31,8 @@ function viewportSize(axis: "width" | "height"): number {
     axis === "width" ? window.screen?.width : window.screen?.height;
 
   for (const value of [
-    visual,
     inner,
+    visual,
     outer,
     docClient,
     bodyClient,

--- a/src/utils/viewport.ts
+++ b/src/utils/viewport.ts
@@ -4,10 +4,58 @@
 // helpers (sticky scroll, sidebar widths) read the var rather than
 // `window.inner*` so they match the rendered layout.
 
+const MAX_REASONABLE_VIEWPORT_PX = 100_000;
+
+function saneViewportSize(value: unknown): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isFinite(value) &&
+    value > 0 &&
+    value < MAX_REASONABLE_VIEWPORT_PX
+  );
+}
+
+function viewportSize(axis: "width" | "height"): number {
+  const visual = window.visualViewport?.[axis];
+  const inner = axis === "width" ? window.innerWidth : window.innerHeight;
+  const outer = axis === "width" ? window.outerWidth : window.outerHeight;
+  const docClient =
+    axis === "width"
+      ? document.documentElement.clientWidth
+      : document.documentElement.clientHeight;
+  const bodyClient =
+    axis === "width" ? document.body?.clientWidth : document.body?.clientHeight;
+  const screenAvail =
+    axis === "width" ? window.screen?.availWidth : window.screen?.availHeight;
+  const screenSize =
+    axis === "width" ? window.screen?.width : window.screen?.height;
+
+  for (const value of [
+    visual,
+    inner,
+    outer,
+    docClient,
+    bodyClient,
+    screenAvail,
+    screenSize,
+  ]) {
+    if (saneViewportSize(value)) return value;
+  }
+
+  return axis === "width" ? 1024 : 768;
+}
+
 export function writeUiViewportVars(scale: number) {
   const root = document.documentElement;
-  root.style.setProperty("--app-viewport-width", `${window.innerWidth / scale}px`);
-  root.style.setProperty("--app-viewport-height", `${window.innerHeight / scale}px`);
+  const safeScale = saneViewportSize(scale) ? scale : 1;
+  root.style.setProperty(
+    "--app-viewport-width",
+    `${viewportSize("width") / safeScale}px`,
+  );
+  root.style.setProperty(
+    "--app-viewport-height",
+    `${viewportSize("height") / safeScale}px`,
+  );
 }
 
 export function applyUiScale(scale: number) {
@@ -31,4 +79,3 @@ export function readZoom(): number {
   );
   return Number.isFinite(cur) ? cur : 1;
 }
-


### PR DESCRIPTION
## Summary

This PR makes the long-lived `linux` branch usable on Linux while keeping the macOS behavior isolated from the Linux-specific fixes.

### Linux dev shell and runtime

- Adds the missing Linux development dependencies needed by Tauri/WebKitGTK builds, including DBus, zlib, GStreamer base packages, and the Nix C compiler closure.
- Expands `PKG_CONFIG_PATH` to include both `lib/pkgconfig` and `share/pkgconfig`, which fixes crates such as `libdbus-sys` that discover system libraries through pkg-config.
- Pins `CC`, `CXX`, `RUSTC_LINKER`, and the Cargo target linker to the Nix compiler on Linux so Rust links against the same Nix glibc/WebKitGTK closure instead of a host/profile compiler.
- Sets Linux-only runtime environment values for WebKitGTK stability, including `WEBKIT_DISABLE_DMABUF_RENDERER`, `GDK_BACKEND=x11,wayland`, `GIO_EXTRA_MODULES`, and `GST_PLUGIN_SYSTEM_PATH_1_0`.
- Adds `XDG_DATA_DIRS` entries for GTK/GSettings schema roots so native dialogs do not crash with `No GSettings schemas are installed on the system`.

### Linux rendering stability

- Adds a Linux-only Rust startup default for `GDK_BACKEND=x11,wayland`, while respecting explicit user overrides.
- Hardens viewport CSS variable calculation against broken WebKitGTK/Wayland metrics, such as negative viewport dimensions or absurd client sizes.
- Preserves existing behavior on healthy platforms by continuing to prefer sane `window.innerWidth`/`innerHeight` values before using fallback sources.

### Codex auth and model picker refresh

- After OAuth/API-key auth completes, matching idle backend sessions are recreated so Codex can use the new credentials without requiring a manual agent restart.
- The account panel now passes the active tab id during login/reauth so the backend refresh targets the session the user actually authenticated from.
- The model picker now aggregates available models from pi `ModelRegistry` instances for auth profiles in addition to the global registry.
- Codex model availability is not hardcoded in Aethon; it remains sourced from pi/provider registry metadata, custom `models.json`, OAuth/API-key availability, and extension-registered providers.

### Native menu

- Adds `File -> Exit` on Linux/Windows using Tauri’s predefined quit item.
- Leaves macOS unchanged: Quit remains in the app menu, preserving platform convention.

### Test portability

- Replaces hard-coded `/bin/echo` and `/bin/sleep` in PTY tests with PATH-resolved `echo`/`sleep`, which works on Nix/Linux and remains compatible with macOS.

## Cross-platform notes

- Linux-only Nix env changes are gated with `pkgs.stdenv.isLinux`.
- Linux-only Rust runtime behavior is gated with `#[cfg(target_os = "linux")]`.
- macOS linker/menu behavior remains separate under existing Darwin/macOS cfg gates.
- The viewport fallback is platform-neutral but preserves the old sane `window.inner*` behavior first, so healthy macOS/browser-like webviews should not change.

## Verification

Ran during branch preparation:

- `bunx tsc -b --noEmit`
- `bunx eslint .`
- `bunx vitest run`
- `bunx vitest run src/utils/viewport.test.ts`
- `bunx vitest run agent/tab-lifecycle.test.ts agent/auth-profiles/manager.test.ts`
- `nix develop --command cargo check --manifest-path src-tauri/Cargo.toml`
- `nix develop --command cargo test --manifest-path src-tauri/Cargo.toml --lib`
- `nix develop --command cargo test --manifest-path src-tauri/Cargo.toml --lib commands::extensions::app_menu::tests`
- `nix develop --command treefmt --fail-on-change ...`
- `git diff --check`
- Linux and Darwin flake output evaluation

I could not run a macOS runtime/build from this Linux host, but the PR keeps the Linux-specific Nix/Rust changes behind Linux cfg/flake gates and evaluates the Darwin flake outputs.