### PR TITLE
fix(session): skip auto-restoring sessions from deleted workspaces

### DIFF
--- a/agent/session-history.test.ts
+++ b/agent/session-history.test.ts
@@ -986,6 +986,8 @@ describe("readSessionTranscript", () => {
   });
 
   it("reports cwdExists: false when the session cwd directory is missing", async () => {
+    const deleted = await tempRoot();
+    await rm(deleted, { recursive: true, force: true });
     const dir = await tempRoot();
     const path = join(dir, "session.jsonl");
     await writeFile(
@@ -993,11 +995,11 @@ describe("readSessionTranscript", () => {
       `${JSON.stringify({
         type: "session",
         id: "s",
-        cwd: "/nonexistent/deleted-workspace",
+        cwd: deleted,
       })}\n`,
     );
     const meta = await readSessionMetadata(dir);
-    expect(meta?.cwd).toBe("/nonexistent/deleted-workspace");
+    expect(meta?.cwd).toBe(deleted);
     expect(meta?.cwdExists).toBe(false);
   });
 

--- a/agent/session-history.test.ts
+++ b/agent/session-history.test.ts
@@ -985,6 +985,39 @@ describe("readSessionTranscript", () => {
     });
   });
 
+  it("reports cwdExists: false when the session cwd directory is missing", async () => {
+    const dir = await tempRoot();
+    const path = join(dir, "session.jsonl");
+    await writeFile(
+      path,
+      `${JSON.stringify({
+        type: "session",
+        id: "s",
+        cwd: "/nonexistent/deleted-workspace",
+      })}\n`,
+    );
+    const meta = await readSessionMetadata(dir);
+    expect(meta?.cwd).toBe("/nonexistent/deleted-workspace");
+    expect(meta?.cwdExists).toBe(false);
+  });
+
+  it("reports cwdExists: true when the session cwd directory exists", async () => {
+    const existingDir = await tempRoot();
+    const dir = await tempRoot();
+    const path = join(dir, "session.jsonl");
+    await writeFile(
+      path,
+      `${JSON.stringify({
+        type: "session",
+        id: "s",
+        cwd: existingDir,
+      })}\n`,
+    );
+    const meta = await readSessionMetadata(dir);
+    expect(meta?.cwd).toBe(existingDir);
+    expect(meta?.cwdExists).toBe(true);
+  });
+
   it("round-trips a custom session label and surfaces it through readSessionMetadata", async () => {
     const dir = await tempRoot();
     await writeFile(

--- a/agent/session-history/metadata.ts
+++ b/agent/session-history/metadata.ts
@@ -110,8 +110,7 @@ export async function readSessionMetadata(
   let cwdExists: boolean | undefined;
   if (cwd) {
     try {
-      await stat(cwd);
-      cwdExists = true;
+      cwdExists = (await stat(cwd)).isDirectory();
     } catch {
       cwdExists = false;
     }

--- a/agent/session-history/metadata.ts
+++ b/agent/session-history/metadata.ts
@@ -107,9 +107,18 @@ export async function readSessionMetadata(
   const raw = await readFile(latest.path, "utf8");
   const { cwd, firstUserMessage } = metaFromSessionLines(raw.split(/\r?\n/));
   const customLabel = await readSessionLabel(sessionDir);
+  let cwdExists: boolean | undefined;
+  if (cwd) {
+    try {
+      await stat(cwd);
+      cwdExists = true;
+    } catch {
+      cwdExists = false;
+    }
+  }
   return {
     lastModified: latest.mtimeMs,
-    ...(cwd ? { cwd } : {}),
+    ...(cwd ? { cwd, cwdExists } : {}),
     ...(firstUserMessage ? { firstUserMessage } : {}),
     ...(customLabel ? { customLabel } : {}),
   };

--- a/agent/session-history/shared.ts
+++ b/agent/session-history/shared.ts
@@ -45,6 +45,9 @@ export interface LatestSessionLog {
 
 export interface SessionLogMetadata {
   cwd?: string;
+  /** false when `cwd` is set but the directory no longer exists on disk
+   *  (e.g. a deleted workspace/worktree). Absent when cwd is unset. */
+  cwdExists?: boolean;
   lastModified: number;
   /** First user-turn text, trimmed to 60 chars. Used to label sessions
    *  meaningfully in the sidebar instead of showing raw UUID slices. */

--- a/agent/state.ts
+++ b/agent/state.ts
@@ -157,6 +157,9 @@ export interface DiscoveredTab {
   tabId: string;
   lastModified: number;
   cwd?: string;
+  /** false when `cwd` is set but the directory no longer exists on disk
+   *  (e.g. a deleted workspace/worktree). Absent when cwd is unset. */
+  cwdExists?: boolean;
   firstUserMessage?: string;
   /** User-supplied label (via the sidebar "Rename session…" action).
    *  When present, the sidebar shows this instead of `firstUserMessage`.

--- a/src/hooks/projectOps/projectStore.ts
+++ b/src/hooks/projectOps/projectStore.ts
@@ -155,6 +155,7 @@ export function useProjectStore(deps: ProjectStoreDeps): ProjectStore {
         }
       }
       return discovered.filter((session) => {
+        if (session.cwdExists === false) return false;
         const cwd = normalizeSessionPath(session.cwd);
         return !cwd || !projectPaths.has(cwd);
       });

--- a/src/hooks/projectOps/types.ts
+++ b/src/hooks/projectOps/types.ts
@@ -17,6 +17,8 @@ export interface DiscoveredSession {
   tabId: string;
   lastModified: number;
   cwd?: string;
+  /** false when `cwd` is set but the directory no longer exists on disk. */
+  cwdExists?: boolean;
   /** First user message text, trimmed to 60 chars by the bridge. Used to
    *  label sidebar history items meaningfully instead of UUID slices. */
   firstUserMessage?: string;

--- a/src/hooks/tabOps/autoRestore.test.ts
+++ b/src/hooks/tabOps/autoRestore.test.ts
@@ -46,6 +46,42 @@ describe("autoRestoreDiscoveredSessions", () => {
     );
   });
 
+  it("does not restore sessions whose cwd no longer exists", () => {
+    const newTab = vi.fn();
+    const autoRestore = useAutoRestoreDiscoveredSessions({
+      stateRef: ref({ tabs: [], closedSessionIds: [] }),
+      autoRestoredSessionIdsRef: ref(new Set<string>()),
+      pushNotification: vi.fn(),
+      newTab,
+    });
+
+    autoRestore(
+      [
+        {
+          tabId: "stale-workspace",
+          lastModified: 1,
+          firstUserMessage: "Please work on issue...",
+          cwd: "/deleted/workspace",
+          cwdExists: false,
+        },
+        {
+          tabId: "valid-session",
+          lastModified: 2,
+          firstUserMessage: "Hello",
+          cwd: "/valid/path",
+          cwdExists: true,
+        },
+      ],
+      new Set(),
+    );
+
+    expect(newTab).toHaveBeenCalledTimes(1);
+    expect(newTab).toHaveBeenCalledWith("valid-session", "Hello", {
+      restoredSession: true,
+      cwd: "/valid/path",
+    });
+  });
+
   it("does not restore already-open local tabs", () => {
     const newTab = vi.fn();
     const autoRestore = useAutoRestoreDiscoveredSessions({

--- a/src/hooks/tabOps/autoRestore.ts
+++ b/src/hooks/tabOps/autoRestore.ts
@@ -39,6 +39,7 @@ export function useAutoRestoreDiscoveredSessions(deps: AutoRestoreDeps) {
       .filter((d) => !liveIds.has(d.tabId))
       .filter((d) => !closedSessionIds.has(d.tabId))
       .filter((d) => !autoRestoredSessionIdsRef.current.has(d.tabId))
+      .filter((d) => d.cwdExists !== false)
       .slice(0, 8);
     if (toRestore.length === 0) return;
     // Open oldest first so the most recent session ends up active.

--- a/src/hooks/tabOps/types.ts
+++ b/src/hooks/tabOps/types.ts
@@ -9,6 +9,8 @@ export interface DiscoveredSession {
   tabId: string;
   lastModified: number;
   cwd?: string;
+  /** false when `cwd` is set but the directory no longer exists on disk. */
+  cwdExists?: boolean;
   firstUserMessage?: string;
   customLabel?: string;
 }


### PR DESCRIPTION
## Summary

- Sessions persisted under `~/.aethon/sessions/` survive workspace (worktree) deletion. On bridge restart, the orphaned sessions pass the host-workspace scope filter (exact-match against live workspace paths) and get auto-restored with `projectId: null` — creating ghost tabs in the host workspace that fail to spawn with "No such file or directory"
- Adds a `cwdExists` flag to session discovery metadata: the bridge stat-checks whether the session's cwd directory still exists on disk
- The frontend filters out sessions with `cwdExists: false` in both `autoRestoreDiscoveredSessions` (prevents ghost tab creation) and `scopedDiscoveredSessions` (excludes from the recent-sessions sidebar in host-workspace mode)

## Test plan

- [x] `bunx tsc -b --noEmit` passes
- [x] All 2364 tests pass including new tests for:
  - `readSessionMetadata` reports `cwdExists: false` for missing cwd dirs
  - `readSessionMetadata` reports `cwdExists: true` for existing cwd dirs
  - `autoRestoreDiscoveredSessions` skips sessions with `cwdExists: false`
- [ ] Manual: delete a workspace that has sessions, restart app, verify the deleted workspace's sessions don't create ghost tabs in the host workspace