### PR TITLE
fix: show global agent activity indicators

### DIFF
--- a/src/extensions/default-layout/sidebar/item-row.test.tsx
+++ b/src/extensions/default-layout/sidebar/item-row.test.tsx
@@ -56,4 +56,25 @@ describe("ItemRow agent activity", () => {
 
     expect(screen.queryByLabelText("Agent session idle")).toBeNull();
   });
+
+  it.each(["expanded", "collapsed"] as const)(
+    "shows project rollup attention while %s",
+    (disclosure) => {
+      renderItemRow(
+        {
+          id: "p1",
+          label: "aethon",
+          agent: { status: "none", runningCount: 0 },
+          agentRollup: { status: "needs-attention", runningCount: 0 },
+        },
+        disclosure,
+      );
+
+      const dot = screen.getByLabelText("Agent ready for your reply");
+      expect(dot.className).toContain("ae-sb-agent-dot--attention");
+      expect(dot.getAttribute("title")).toBe(
+        "Agent finished — ready for your reply",
+      );
+    },
+  );
 });

--- a/src/extensions/default-layout/sidebar/item-row.tsx
+++ b/src/extensions/default-layout/sidebar/item-row.tsx
@@ -116,24 +116,36 @@ export function ItemRow({
   const agent =
     rollupAgent?.status === "running"
       ? rollupAgent
-      : disclosure === "collapsed"
-        ? (rollupAgent ?? ownAgent)
-        : ownAgent;
+      : rollupAgent?.status === "needs-attention"
+        ? rollupAgent
+        : disclosure === "collapsed"
+          ? (rollupAgent ?? ownAgent)
+          : ownAgent;
+  const agentVisualState =
+    agent?.status === "running"
+      ? "running"
+      : agent?.status === "needs-attention"
+        ? "attention"
+        : "idle";
   const agentDotEl =
     agent && agent.status && agent.status !== "none" ? (
       <span
-        className={`ae-sb-agent-dot ae-sb-agent-dot--${
-          agent.status === "running" ? "running" : "idle"
-        }`}
+        className={`ae-sb-agent-dot ae-sb-agent-dot--${agentVisualState}`}
         aria-label={
-          agent.status === "running" ? "Agent running" : "Agent session idle"
+          agent.status === "running"
+            ? "Agent running"
+            : agent.status === "needs-attention"
+              ? "Agent ready for your reply"
+              : "Agent session idle"
         }
         title={
           agent.status === "running"
             ? `${agent.runningCount ?? 1} agent turn${
                 (agent.runningCount ?? 1) === 1 ? "" : "s"
               } running`
-            : "Idle agent session — awaiting your input"
+            : agent.status === "needs-attention"
+              ? "Agent finished — ready for your reply"
+              : "Idle agent session — awaiting your input"
         }
       />
     ) : null;

--- a/src/extensions/default-layout/sidebar/workspace-row.test.tsx
+++ b/src/extensions/default-layout/sidebar/workspace-row.test.tsx
@@ -124,6 +124,24 @@ describe("WorkspaceRow", () => {
     );
   });
 
+  it("renders needs-attention agent activity as an attention dot", () => {
+    harness(
+      wt({
+        agent: {
+          status: "needs-attention",
+          activeCount: 1,
+          runningCount: 0,
+        },
+      }),
+    );
+
+    const dot = screen.getByLabelText("Agent ready for your reply");
+    expect(dot.className).toContain("ae-sb-agent-dot--attention");
+    expect(dot.getAttribute("title")).toBe(
+      "Agent finished — ready for your reply",
+    );
+  });
+
   it("renders pending status with cancel button when queued/starting", () => {
     const { onEvent } = harness(
       wt({ pendingState: "starting", label: "wip" }),

--- a/src/extensions/default-layout/sidebar/workspace-row.tsx
+++ b/src/extensions/default-layout/sidebar/workspace-row.tsx
@@ -197,6 +197,12 @@ export function WorkspaceRow({
 
   const tooltip = isFailed && item.pendingError ? item.pendingError : item.path;
   const displayLabel = item.label || item.branch || "workspace";
+  const agentVisualState =
+    item.agent?.status === "running"
+      ? "running"
+      : item.agent?.status === "needs-attention"
+        ? "attention"
+        : "idle";
 
   useEffect(() => {
     if (!canRenameInline) return;
@@ -290,7 +296,11 @@ export function WorkspaceRow({
         if (consumeSuppressedClick?.()) return;
         if (isPendingActive || isFailed || confirmingRemove || canRenameInline)
           return;
-        onEvent("switch-workspace", { sectionId, workspaceId: item.id }, item.id);
+        onEvent(
+          "switch-workspace",
+          { sectionId, workspaceId: item.id },
+          item.id,
+        );
       }}
       onDoubleClick={() => {
         if (consumeSuppressedClick?.()) return;
@@ -316,20 +326,22 @@ export function WorkspaceRow({
       ) : null}
       {item.agent && item.agent.status !== "none" ? (
         <span
-          className={`ae-sb-agent-dot ae-sb-agent-dot--${
-            item.agent.status === "running" ? "running" : "idle"
-          }`}
+          className={`ae-sb-agent-dot ae-sb-agent-dot--${agentVisualState}`}
           aria-label={
             item.agent.status === "running"
               ? "Agent running"
-              : "Agent session idle"
+              : item.agent.status === "needs-attention"
+                ? "Agent ready for your reply"
+                : "Agent session idle"
           }
           title={
             item.agent.status === "running"
               ? `${item.agent.runningCount} agent turn${
                   item.agent.runningCount === 1 ? "" : "s"
                 } running`
-              : "Idle agent session — awaiting your input"
+              : item.agent.status === "needs-attention"
+                ? "Agent finished — ready for your reply"
+                : "Idle agent session — awaiting your input"
           }
         />
       ) : null}
@@ -367,7 +379,11 @@ export function WorkspaceRow({
       ) : null}
       {prEligible && !canRenameInline && (prLoading || prChip) ? (
         <span className="ae-workspace-pr-slot">
-          {prChip ? <WorkspacePrBadge chip={prChip} /> : <span aria-hidden="true" />}
+          {prChip ? (
+            <WorkspacePrBadge chip={prChip} />
+          ) : (
+            <span aria-hidden="true" />
+          )}
         </span>
       ) : null}
       {isPendingActive ? (

--- a/src/hooks/bridgeMessageHandlers/promptStarted.test.ts
+++ b/src/hooks/bridgeMessageHandlers/promptStarted.test.ts
@@ -42,8 +42,14 @@ describe("handlePromptStarted", () => {
     const runningUpdater = mocks.setState.mock.calls[0][0] as (
       prev: Record<string, unknown>,
     ) => Record<string, unknown>;
-    expect(runningUpdater({ agentRunningTabs: {} })).toMatchObject({
+    expect(
+      runningUpdater({
+        agentRunningTabs: {},
+        agentAttentionTabs: { default: true },
+      }),
+    ).toMatchObject({
       agentRunningTabs: { default: true },
+      agentAttentionTabs: {},
     });
   });
 

--- a/src/hooks/bridgeMessageHandlers/promptStarted.ts
+++ b/src/hooks/bridgeMessageHandlers/promptStarted.ts
@@ -50,8 +50,15 @@ export const handlePromptStarted: BridgeMessageHandler = (data, ctx) => {
   ctx.setState((prev) => {
     const running =
       (prev.agentRunningTabs as Record<string, true> | undefined) ?? {};
-    if (running[tabId]) return prev;
-    return { ...prev, agentRunningTabs: { ...running, [tabId]: true } };
+    const attention =
+      (prev.agentAttentionTabs as Record<string, true> | undefined) ?? {};
+    const result: Record<string, unknown> = running[tabId]
+      ? prev
+      : { ...prev, agentRunningTabs: { ...running, [tabId]: true } };
+    if (!attention[tabId]) return result;
+    const nextAttention = { ...attention };
+    delete nextAttention[tabId];
+    return { ...result, agentAttentionTabs: nextAttention };
   });
   if (ctx.stateRef.current.activeTabId === tabId) {
     ctx.setState((prev) => ({ ...prev, status: "thinking…" }));

--- a/src/hooks/bridgeMessageHandlers/responseEnd.test.ts
+++ b/src/hooks/bridgeMessageHandlers/responseEnd.test.ts
@@ -36,6 +36,22 @@ describe("handleResponseEnd", () => {
     expect(mocks.maybeFireCompletionNotification).toHaveBeenCalled();
   });
 
+  it("marks a completed non-active turn as needing attention", () => {
+    const { ctx, applySetState } = buildHandlerFixture({
+      state: {
+        activeTabId: "visible",
+        agentRunningTabs: { hidden: true },
+      },
+    });
+    ctx.turnStartedAtRef.current.set("hidden", Date.now() - 5000);
+
+    handleResponseEnd({ type: "response_end", tabId: "hidden" }, ctx);
+
+    const next = applySetState();
+    expect(next.agentRunningTabs).toEqual({});
+    expect(next.agentAttentionTabs).toEqual({ hidden: true });
+  });
+
   it("freezes running tool cards when the turn ends", () => {
     const { ctx, mocks } = buildHandlerFixture({
       state: { activeTabId: "default" },

--- a/src/hooks/bridgeMessageHandlers/responseEnd.ts
+++ b/src/hooks/bridgeMessageHandlers/responseEnd.ts
@@ -30,10 +30,35 @@ export const handleResponseEnd: BridgeMessageHandler = (data, ctx) => {
   // Drop the tab from the bucket-independent running set (see promptStarted).
   ctx.setState((prev) => {
     const running = prev.agentRunningTabs as Record<string, true> | undefined;
-    if (!running || !running[tabId]) return prev;
-    const next = { ...running };
-    delete next[tabId];
-    return { ...prev, agentRunningTabs: next };
+    const nextRunning = running ? { ...running } : {};
+    const wasRunning = nextRunning[tabId] === true;
+    if (wasRunning) delete nextRunning[tabId];
+    const attention =
+      (prev.agentAttentionTabs as Record<string, true> | undefined) ?? {};
+    const windowFocused =
+      typeof document !== "undefined" && document.hasFocus();
+    const shouldMarkAttention =
+      prev.activeTabId !== tabId || windowFocused === false;
+    const hadAttention = attention[tabId] === true;
+    const nextAttention = shouldMarkAttention
+      ? hadAttention
+        ? attention
+        : { ...attention, [tabId]: true }
+      : hadAttention
+        ? (() => {
+            const copy = { ...attention };
+            delete copy[tabId];
+            return copy;
+          })()
+        : attention;
+    if (!wasRunning && attention === nextAttention) {
+      return prev;
+    }
+    return {
+      ...prev,
+      agentRunningTabs: nextRunning,
+      agentAttentionTabs: nextAttention,
+    };
   });
   if (ctx.stateRef.current.activeTabId === tabId) {
     ctx.setState((prev) => ({ ...prev, status: "ready" }));

--- a/src/hooks/projectOps/agentActivity.test.ts
+++ b/src/hooks/projectOps/agentActivity.test.ts
@@ -1,9 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { makeEmptyTab, type Tab } from "../../types/tab";
-import {
-  attachAgentActivity,
-  summarizeAgentTabs,
-} from "./agentActivity";
+import { attachAgentActivity, summarizeAgentTabs } from "./agentActivity";
 
 function agentTab(id: string, projectId: string | null, cwd?: string): Tab {
   return { ...makeEmptyTab(id, id, projectId, "agent"), cwd };
@@ -36,6 +33,24 @@ describe("summarizeAgentTabs", () => {
     });
   });
 
+  it("returns needs-attention when a completed background turn is unread", () => {
+    const tabs = [agentTab("a", "p", "/p")];
+    expect(summarizeAgentTabs(tabs, new Set(), new Set(["a"]))).toEqual({
+      status: "needs-attention",
+      activeCount: 1,
+      runningCount: 0,
+    });
+  });
+
+  it("prioritizes running over needs-attention", () => {
+    const tabs = [agentTab("a", "p", "/p"), agentTab("b", "p", "/p")];
+    expect(summarizeAgentTabs(tabs, new Set(["b"]), new Set(["a"]))).toEqual({
+      status: "running",
+      activeCount: 2,
+      runningCount: 1,
+    });
+  });
+
   it("ignores non-agent tabs", () => {
     const shell = { ...makeEmptyTab("s", "s", "p", "shell"), cwd: "/p" };
     expect(summarizeAgentTabs([shell], new Set(["s"]))).toEqual({
@@ -56,7 +71,9 @@ describe("summarizeAgentTabs", () => {
 });
 
 describe("attachAgentActivity", () => {
-  const project = (workspaces: { id: string; path: string; isMain?: boolean }[]) => ({
+  const project = (
+    workspaces: { id: string; path: string; isMain?: boolean }[],
+  ) => ({
     id: "proj",
     label: "proj",
     workspaces: workspaces.map((w) => ({
@@ -69,9 +86,7 @@ describe("attachAgentActivity", () => {
   });
 
   it("scopes main-path tabs to the project line, leaving the main workspace dot-free", () => {
-    const projects = [
-      project([{ id: "wt-main", path: "/p", isMain: true }]),
-    ];
+    const projects = [project([{ id: "wt-main", path: "/p", isMain: true }])];
     const tabs = [agentTab("a", "proj", "/p")];
     const [out] = attachAgentActivity(projects, tabs, new Set(["a"]));
     expect(out.agent.status).toBe("running");
@@ -115,10 +130,37 @@ describe("attachAgentActivity", () => {
     expect(out.agentRollup.runningCount).toBe(1);
   });
 
+  it("rolls up completed workspace activity that needs attention", () => {
+    const projects = [
+      project([
+        { id: "wt-main", path: "/p", isMain: true },
+        { id: "wt-feat", path: "/p/.wt/feat" },
+      ]),
+    ];
+    const tabs = [agentTab("w", "proj", "/p/.wt/feat")];
+    const [out] = attachAgentActivity(
+      projects,
+      tabs,
+      new Set(),
+      new Set(["w"]),
+    );
+    const feat = out.workspaces.find((w) => w.id === "wt-feat");
+    expect(feat?.agent?.status).toBe("needs-attention");
+    expect(out.agentRollup.status).toBe("needs-attention");
+  });
+
   it("does not leak tabs across sibling projects", () => {
     const projects = [
-      { id: "p1", label: "p1", workspaces: [{ id: "m1", path: "/p1", isMain: true }] },
-      { id: "p2", label: "p2", workspaces: [{ id: "m2", path: "/p2", isMain: true }] },
+      {
+        id: "p1",
+        label: "p1",
+        workspaces: [{ id: "m1", path: "/p1", isMain: true }],
+      },
+      {
+        id: "p2",
+        label: "p2",
+        workspaces: [{ id: "m2", path: "/p2", isMain: true }],
+      },
     ];
     const tabs = [agentTab("a", "p1", "/p1")];
     const out = attachAgentActivity(projects, tabs, new Set(["a"]));

--- a/src/hooks/projectOps/agentActivity.ts
+++ b/src/hooks/projectOps/agentActivity.ts
@@ -4,10 +4,16 @@ import { normalizeSessionPath } from "./tabBuckets";
 /** Aggregate agent state for one sidebar scope (a project's main workspace,
  *  a specific workspace, or a project rollup):
  *   - `running`            — at least one agent turn is in flight.
+ *   - `needs-attention`    — a background/unfocused turn completed and is
+ *                            waiting for the user to look.
  *   - `idle-with-session`  — an agent session exists but no turn is running
  *                            (i.e. it's waiting on the user's next input).
  *   - `none`               — no agent session for this scope. */
-export type AgentActivity = "running" | "idle-with-session" | "none";
+export type AgentActivity =
+  | "running"
+  | "needs-attention"
+  | "idle-with-session"
+  | "none";
 
 export interface AgentActivitySummary {
   status: AgentActivity;
@@ -31,17 +37,25 @@ const NONE: AgentActivitySummary = {
 export function summarizeAgentTabs(
   tabs: readonly Tab[],
   runningIds: ReadonlySet<string>,
+  attentionIds: ReadonlySet<string> = new Set(),
 ): AgentActivitySummary {
   let activeCount = 0;
   let runningCount = 0;
+  let attentionCount = 0;
   for (const tab of tabs) {
     if (tab.kind !== "agent") continue;
     activeCount += 1;
     if (runningIds.has(tab.id)) runningCount += 1;
+    else if (attentionIds.has(tab.id)) attentionCount += 1;
   }
   if (activeCount === 0) return NONE;
   return {
-    status: runningCount > 0 ? "running" : "idle-with-session",
+    status:
+      runningCount > 0
+        ? "running"
+        : attentionCount > 0
+          ? "needs-attention"
+          : "idle-with-session",
     activeCount,
     runningCount,
   };
@@ -85,6 +99,7 @@ export function attachAgentActivity<P extends ProjectLike>(
   projects: readonly P[],
   agentTabs: readonly Tab[],
   runningIds: ReadonlySet<string>,
+  attentionIds: ReadonlySet<string> = new Set(),
 ): WithAgentActivity<P>[] {
   const tabsByCwd = new Map<string, Tab[]>();
   for (const tab of agentTabs) {
@@ -119,13 +134,16 @@ export function attachAgentActivity<P extends ProjectLike>(
       // surfaced on the project line, so leave its row dot-free.
       if (w.isMain) return w;
       const wtTabs = tabsByCwd.get(normalizeSessionPath(w.path)) ?? [];
-      return { ...w, agent: summarizeAgentTabs(wtTabs, runningIds) };
+      return {
+        ...w,
+        agent: summarizeAgentTabs(wtTabs, runningIds, attentionIds),
+      };
     });
 
     return {
       ...project,
-      agent: summarizeAgentTabs(mainTabs, runningIds),
-      agentRollup: summarizeAgentTabs(rollupTabs, runningIds),
+      agent: summarizeAgentTabs(mainTabs, runningIds, attentionIds),
+      agentRollup: summarizeAgentTabs(rollupTabs, runningIds, attentionIds),
       workspaces: nextWorkspaces,
     };
   });

--- a/src/hooks/projectOps/tabBuckets.test.ts
+++ b/src/hooks/projectOps/tabBuckets.test.ts
@@ -129,6 +129,24 @@ describe("switchProjectBucket", () => {
     expect(h.get().draft).toBe(tabA.draft);
   });
 
+  it("clears completed-turn attention when restoring a stashed active tab", () => {
+    const tabA = agentTab("a1", "P", "/P/A");
+    const h = makeHarness({
+      tabs: [],
+      activeTabId: undefined,
+      agentAttentionTabs: { a1: true, other: true },
+    });
+    h.tabBucketsRef.current.set("P::workspace::A", {
+      tabs: [tabA],
+      activeTabId: "a1",
+    });
+
+    switchProjectBucket(h.deps, "P::workspace::B", "P::workspace::A");
+
+    expect(h.get().activeTabId).toBe("a1");
+    expect(h.get().agentAttentionTabs).toEqual({ other: true });
+  });
+
   it("preserves landing when switching to an empty workspace", () => {
     const h = makeHarness({
       tabs: [],
@@ -181,14 +199,10 @@ describe("switchProjectBucket", () => {
     expect((h.get().tabs as Tab[]).map((t) => t.id)).toEqual(["a1"]);
     expect(h.get().activeTabId).toBe("a1");
     expect(
-      h.tabBucketsRef.current
-        .get("P::workspace::B")
-        ?.tabs.map((t) => t.id),
+      h.tabBucketsRef.current.get("P::workspace::B")?.tabs.map((t) => t.id),
     ).toEqual(["b1"]);
     expect(
-      h.tabBucketsRef.current
-        .get("P::workspace::A")
-        ?.tabs.map((t) => t.id),
+      h.tabBucketsRef.current.get("P::workspace::A")?.tabs.map((t) => t.id),
     ).toEqual(["a1"]);
   });
 
@@ -204,9 +218,6 @@ describe("switchProjectBucket", () => {
     switchProjectBucket(h.deps, "P::workspace::A", "P::workspace::B");
 
     expect(h.get().activeTabId).toBe("b1");
-    expect((h.get().tabs as Tab[]).map((t) => t.id)).toEqual([
-      "shell-b",
-      "b1",
-    ]);
+    expect((h.get().tabs as Tab[]).map((t) => t.id)).toEqual(["shell-b", "b1"]);
   });
 });

--- a/src/hooks/projectOps/tabBuckets.ts
+++ b/src/hooks/projectOps/tabBuckets.ts
@@ -243,6 +243,14 @@ export function switchProjectBucket(
       activeTabId,
       persistedTabBuckets,
     };
+    const attention = prev.agentAttentionTabs as
+      | Record<string, true>
+      | undefined;
+    if (activeTabId && attention?.[activeTabId]) {
+      const nextAttention = { ...attention };
+      delete nextAttention[activeTabId];
+      result.agentAttentionTabs = nextAttention;
+    }
     const activeTab = next.tabs.find((t) => t.id === activeTabId);
     if (activeTab) {
       const rec = activeTab as unknown as Record<string, unknown>;

--- a/src/hooks/tabOps/closeTab.ts
+++ b/src/hooks/tabOps/closeTab.ts
@@ -247,9 +247,9 @@ export function useCloseTabActions(deps: CloseTabDeps): CloseTabActions {
         const closedIds = Array.isArray(prev.closedSessionIds)
           ? (prev.closedSessionIds as string[])
           : [];
-        result.closedSessionIds = Array.from(new Set([...closedIds, tabId])).slice(
-          -200,
-        );
+        result.closedSessionIds = Array.from(
+          new Set([...closedIds, tabId]),
+        ).slice(-200);
       }
       // Drop a closed tab from the bucket-independent agent-running set so a
       // closed-mid-turn tab can't leave a stale entry behind.
@@ -258,6 +258,14 @@ export function useCloseTabActions(deps: CloseTabDeps): CloseTabActions {
         const nextRunning = { ...running };
         delete nextRunning[tabId];
         result.agentRunningTabs = nextRunning;
+      }
+      const attention = prev.agentAttentionTabs as
+        | Record<string, true>
+        | undefined;
+      if (attention && attention[tabId]) {
+        const nextAttention = { ...attention };
+        delete nextAttention[tabId];
+        result.agentAttentionTabs = nextAttention;
       }
       if (closing) {
         const closedSession = recentSessionItemFromClosedTab(

--- a/src/hooks/tabOps/mutations.test.ts
+++ b/src/hooks/tabOps/mutations.test.ts
@@ -35,6 +35,22 @@ describe("useMutations setActiveTab", () => {
     expect(setState).toHaveBeenCalledTimes(1);
     expect(stateRef.current.activeTabId).toBe(OVERVIEW_TAB_ID);
     expect(stateRef.current.landing).toBeNull();
-    expect(stateRef.current.messages).toEqual([{ role: "user", text: "hello" }]);
+    expect(stateRef.current.messages).toEqual([
+      { role: "user", text: "hello" },
+    ]);
+  });
+
+  it("clears a completed-turn attention marker when selecting that tab", () => {
+    const tab = makeEmptyTab("tab-1", "Session", null, "agent");
+    const { actions, stateRef } = setup({
+      tabs: [tab],
+      activeTabId: OVERVIEW_TAB_ID,
+      agentAttentionTabs: { "tab-1": true, other: true },
+    });
+
+    act(() => actions.setActiveTab("tab-1"));
+
+    expect(stateRef.current.activeTabId).toBe("tab-1");
+    expect(stateRef.current.agentAttentionTabs).toEqual({ other: true });
   });
 });

--- a/src/hooks/tabOps/mutations.ts
+++ b/src/hooks/tabOps/mutations.ts
@@ -116,6 +116,14 @@ export function useMutations(deps: MutationsDeps): MutationsActions {
       if (!target) return prev;
       nextBuffer = target.terminalBuffer ?? "";
       const result: Record<string, unknown> = { ...prev, activeTabId: tabId };
+      const attention = prev.agentAttentionTabs as
+        | Record<string, true>
+        | undefined;
+      if (attention?.[tabId]) {
+        const nextAttention = { ...attention };
+        delete nextAttention[tabId];
+        result.agentAttentionTabs = nextAttention;
+      }
       const targetRec = target as unknown as Record<string, unknown>;
       for (const key of TAB_MIRROR_KEYS) {
         result[key as string] = targetRec[key as string];

--- a/src/hooks/useAgentActivityHydration.test.ts
+++ b/src/hooks/useAgentActivityHydration.test.ts
@@ -7,6 +7,7 @@ import type { A2UIComponent } from "../types/a2ui";
 import { makeEmptyTab } from "../types/tab";
 import {
   AGENT_ACTIVITY_HYDRATION_RETRY_DELAYS_MS,
+  clearActiveAgentAttention,
   hydrateAgentActivityState,
   useAgentActivityHydration,
 } from "./useAgentActivityHydration";
@@ -20,6 +21,27 @@ vi.mock("@tauri-apps/api/core", () => ({
 afterEach(() => {
   vi.useRealTimers();
   invoke.mockReset();
+  vi.restoreAllMocks();
+});
+
+describe("clearActiveAgentAttention", () => {
+  it("clears the active tab's completed-turn attention marker", () => {
+    const next = clearActiveAgentAttention({
+      activeTabId: "tab-a",
+      agentAttentionTabs: { "tab-a": true, "tab-b": true },
+    });
+
+    expect(next.agentAttentionTabs).toEqual({ "tab-b": true });
+  });
+
+  it("leaves other tabs' attention markers alone", () => {
+    const state = {
+      activeTabId: "tab-a",
+      agentAttentionTabs: { "tab-b": true },
+    };
+
+    expect(clearActiveAgentAttention(state)).toBe(state);
+  });
 });
 
 describe("hydrateAgentActivityState", () => {
@@ -460,8 +482,9 @@ describe("hydrateAgentActivityState", () => {
       typeof stoppedTab,
       typeof concurrentTab,
     ];
-    const stoppedToolCard = nextStoppedTab.messages[0].a2ui
-      ?.components?.[0] as A2UIComponent | undefined;
+    const stoppedToolCard = nextStoppedTab.messages[0].a2ui?.components?.[0] as
+      | A2UIComponent
+      | undefined;
     const concurrentToolCard = nextConcurrentTab.messages[0].a2ui
       ?.components?.[0] as A2UIComponent | undefined;
     expect(nextStoppedTab.waiting).toBe(false);
@@ -543,5 +566,28 @@ describe("hydrateAgentActivityState", () => {
     expect((state.tabs as ReturnType<typeof makeEmptyTab>[])[0].waiting).toBe(
       true,
     );
+  });
+
+  it("clears active-tab attention when the window regains focus", () => {
+    vi.spyOn(document, "hasFocus").mockReturnValue(true);
+    invoke.mockResolvedValue([]);
+    let state: Record<string, unknown> = {
+      activeTabId: "tab-a",
+      agentAttentionTabs: { "tab-a": true, "tab-b": true },
+      tabs: [makeEmptyTab("tab-a", "A")],
+    };
+    const setState: Dispatch<SetStateAction<Record<string, unknown>>> = (
+      arg,
+    ) => {
+      state = typeof arg === "function" ? arg(state) : arg;
+    };
+
+    const { unmount } = renderHook(() => useAgentActivityHydration(setState));
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+    unmount();
+
+    expect(state.agentAttentionTabs).toEqual({ "tab-b": true });
   });
 });

--- a/src/hooks/useAgentActivityHydration.ts
+++ b/src/hooks/useAgentActivityHydration.ts
@@ -164,6 +164,20 @@ export function hydrateAgentActivityState(
   return next;
 }
 
+export function clearActiveAgentAttention(
+  state: Record<string, unknown>,
+): Record<string, unknown> {
+  const activeTabId = state.activeTabId as string | undefined;
+  if (!activeTabId) return state;
+  const attention = state.agentAttentionTabs as
+    | Record<string, true>
+    | undefined;
+  if (!attention?.[activeTabId]) return state;
+  const nextAttention = { ...attention };
+  delete nextAttention[activeTabId];
+  return { ...state, agentAttentionTabs: nextAttention };
+}
+
 export function useAgentActivityHydration(
   setState: Dispatch<SetStateAction<Record<string, unknown>>>,
 ): void {
@@ -187,6 +201,19 @@ export function useAgentActivityHydration(
     return () => {
       cancelled = true;
       for (const timer of timers) clearTimeout(timer);
+    };
+  }, [setState]);
+
+  useEffect(() => {
+    const clearIfFocused = () => {
+      if (typeof document !== "undefined" && !document.hasFocus()) return;
+      setState((prev) => clearActiveAgentAttention(prev));
+    };
+    window.addEventListener("focus", clearIfFocused);
+    document.addEventListener("visibilitychange", clearIfFocused);
+    return () => {
+      window.removeEventListener("focus", clearIfFocused);
+      document.removeEventListener("visibilitychange", clearIfFocused);
     };
   }, [setState]);
 }

--- a/src/hooks/useDerivedRenderState.test.ts
+++ b/src/hooks/useDerivedRenderState.test.ts
@@ -305,6 +305,63 @@ describe("useDerivedRenderState", () => {
     expect(wtMain && "agent" in wtMain).toBe(false);
   });
 
+  it("overlays completed background agent attention across stashed buckets", () => {
+    const visibleTab = {
+      ...makeEmptyTab("visible", "visible", "p2", "agent"),
+      cwd: "/repo/other",
+    };
+    const hiddenDone = {
+      ...makeEmptyTab("done", "done", "p1", "agent"),
+      cwd: "/repo/app-fix",
+    };
+    const { result } = renderHook(() =>
+      useDerivedRenderState({
+        state: {
+          tabs: [visibleTab],
+          activeTabId: "visible",
+          agentAttentionTabs: { done: true },
+          persistedTabBuckets: {
+            "p1::workspace::wt-1": { tabs: [hiddenDone], activeTabId: "done" },
+          },
+          sidebar: {
+            projects: [
+              {
+                id: "p1",
+                workspaces: [
+                  { id: "wt-main", path: "/repo/app", isMain: true },
+                  { id: "wt-1", path: "/repo/app-fix" },
+                ],
+              },
+              {
+                id: "p2",
+                workspaces: [
+                  { id: "wt-main-2", path: "/repo/other", isMain: true },
+                ],
+              },
+            ],
+          },
+        },
+        buildSidebarHistory: vi.fn(() => []),
+        hostInfo,
+      }),
+    );
+
+    const projects = (
+      result.current.renderState.sidebar as {
+        projects: {
+          id: string;
+          agentRollup: { status: string };
+          workspaces: { id: string; agent?: { status: string } }[];
+        }[];
+      }
+    ).projects;
+    const nxvLike = projects.find((p) => p.id === "p1");
+    expect(nxvLike?.agentRollup.status).toBe("needs-attention");
+    expect(
+      nxvLike?.workspaces.find((w) => w.id === "wt-1")?.agent?.status,
+    ).toBe("needs-attention");
+  });
+
   it("keeps sidebar activity running until a terminal turn event clears it", () => {
     // `waiting` can briefly drift false while the agent is still streaming
     // tool output. The running set owns lifecycle until response_end,
@@ -324,7 +381,9 @@ describe("useDerivedRenderState", () => {
             projects: [
               {
                 id: "p1",
-                workspaces: [{ id: "wt-main", path: "/repo/app", isMain: true }],
+                workspaces: [
+                  { id: "wt-main", path: "/repo/app", isMain: true },
+                ],
               },
             ],
           },
@@ -372,7 +431,9 @@ describe("useDerivedRenderState", () => {
             projects: [
               {
                 id: "p1",
-                workspaces: [{ id: "wt-main", path: "/repo/app", isMain: true }],
+                workspaces: [
+                  { id: "wt-main", path: "/repo/app", isMain: true },
+                ],
               },
             ],
           },

--- a/src/hooks/useDerivedRenderState.ts
+++ b/src/hooks/useDerivedRenderState.ts
@@ -170,6 +170,11 @@ export function useDerivedRenderState({
         (state.agentRunningTabs as Record<string, unknown> | undefined) ?? {},
       ),
     );
+    const attentionIds = new Set(
+      Object.keys(
+        (state.agentAttentionTabs as Record<string, unknown> | undefined) ?? {},
+      ),
+    );
     // The running set is the authoritative cross-workspace turn lifecycle:
     // prompt_started adds, response_end / explicit stop / crash removes. The
     // active tab can still promote itself when a visible tool card is live, but
@@ -187,6 +192,7 @@ export function useDerivedRenderState({
           }>,
           agentTabs,
           runningIds,
+          attentionIds,
         )
       : sidebar.projects;
 

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -1318,6 +1318,22 @@ body.ae-resizing-sidebar .a2ui-layout {
   box-shadow: 0 0 0 2px var(--state-success-border, transparent);
   animation: ae-tab-busy-pulse 1.6s ease-in-out infinite;
 }
+.ae-sb-agent-dot--attention {
+  background: var(--state-warning-fg, var(--warning));
+  box-shadow:
+    0 0 0 2px
+      color-mix(
+        in srgb,
+        var(--state-warning-fg, var(--warning)) 24%,
+        transparent
+      ),
+    0 0 8px
+      color-mix(
+        in srgb,
+        var(--state-warning-fg, var(--warning)) 34%,
+        transparent
+      );
+}
 .ae-sb-agent-dot--idle {
   background: transparent;
   box-shadow: inset 0 0 0 1.5px var(--state-success-border, var(--text-dim));


### PR DESCRIPTION
## Summary
- keep agent activity indicators global across project/workspace switches by rolling running and completed background turns up from all active and stashed workspace tabs
- add a distinct needs-attention state for completed off-screen/unfocused turns so the sidebar can show that an agent is done and waiting
- clear the attention state when the user returns to the tab, restores its workspace, starts a new turn, closes the tab, or refocuses the already-active tab

## Details
The previous sidebar rollup only distinguished running, idle, and none. That meant a background agent could finish while the user was looking at another workspace, but the sidebar had no persisted/tab-global state to communicate that the turn was now ready for the user.

This adds an agentAttentionTabs state alongside agentRunningTabs, threads it through the derived project/workspace activity summaries, and teaches the sidebar rows to render warning-colored attention dots separately from the pulsing running dots and idle rings. Running still wins over attention in mixed rollups.

## Peer review
- Ran Codex peer review before opening the PR.
- First pass found two valid edge cases: restoring a stashed workspace tab and refocusing an already-active tab should both clear attention.
- Implemented both fixes and reran peer review; the second pass found no correctness issues.

## Validation
- bun run test: 291 files / 2,379 tests passed
- bun run typecheck
- bun run lint
- git diff --check
- Focused Vitest coverage for activity rollups, derived render state, prompt start, response end, tab selection, tab close, stashed workspace restoration, and focus/visibility clearing

## Visual check
Started the Vite shell and confirmed the app renders, but browser-only verification hits expected Tauri API limitations outside the desktop runtime (listen/invoke transformCallback errors). The visual behavior here is covered through the derived sidebar state and rendering tests.