### PR TITLE
Add host-level task launcher

### DIFF
--- a/src/extensions/default-layout/dashboard/projects-dashboard.test.tsx
+++ b/src/extensions/default-layout/dashboard/projects-dashboard.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { ProjectsDashboard } from "./projects-dashboard";
+import type { A2UIComponent } from "../../../types/a2ui";
+import { ExtensionRegistry } from "../../ExtensionRegistry";
+import { ExtensionRegistryProvider } from "../../ExtensionRegistryProvider";
+import { TaskLauncher } from "./task-launcher";
+
+function dashboard(props: Record<string, unknown>): A2UIComponent {
+  return {
+    id: "projects-dashboard",
+    type: "projects-dashboard",
+    props,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ProjectsDashboard", () => {
+  it("renders a host-level task launcher with project selection", () => {
+    const registry = new ExtensionRegistry();
+    registry.register({
+      name: "test-dashboard-components",
+      components: {
+        "task-launcher": TaskLauncher,
+        "project-card": () => <div />,
+        "subagents-config": () => <div />,
+      },
+    });
+    render(
+      <ExtensionRegistryProvider registry={registry}>
+        <ProjectsDashboard
+          component={dashboard({
+            projects: [
+              { id: "p1", label: "aethon", path: "/repo/aethon" },
+              { id: "p2", label: "koban", path: "/repo/koban" },
+            ],
+            recentSessions: [],
+            extraCards: [],
+          })}
+          state={{}}
+          onEvent={() => {}}
+        />
+      </ExtensionRegistryProvider>,
+    );
+
+    expect(screen.getByLabelText("Task prompt")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Project" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Workspace" })).toBeTruthy();
+  });
+
+  it("routes the host-level task launcher through the extension registry", () => {
+    const registry = new ExtensionRegistry();
+    registry.register({
+      name: "test-task-launcher-override",
+      components: {
+        "task-launcher": ({ component }) => (
+          <div data-testid="host-launcher-override">
+            {String(component.props?.showProjectSelector)}
+          </div>
+        ),
+        "project-card": () => <div />,
+        "subagents-config": () => <div />,
+      },
+    });
+
+    render(
+      <ExtensionRegistryProvider registry={registry}>
+        <ProjectsDashboard
+          component={dashboard({
+            projects: [
+              { id: "p1", label: "aethon", path: "/repo/aethon" },
+              { id: "p2", label: "koban", path: "/repo/koban" },
+            ],
+            recentSessions: [],
+            extraCards: [],
+          })}
+          state={{}}
+          onEvent={() => {}}
+        />
+      </ExtensionRegistryProvider>,
+    );
+
+    expect(screen.getByTestId("host-launcher-override").textContent).toBe("true");
+  });
+});

--- a/src/extensions/default-layout/dashboard/projects-dashboard.tsx
+++ b/src/extensions/default-layout/dashboard/projects-dashboard.tsx
@@ -29,6 +29,7 @@ interface ProjectListItem {
   path: string;
   active?: boolean;
   iconUrl?: string;
+  workspaceBaseBranch?: string;
   gitStatus?: {
     branch?: string;
     dirty?: boolean;
@@ -67,6 +68,13 @@ interface ExtraCard {
   id: string;
   type: string;
   props?: Record<string, unknown>;
+}
+
+interface WorkspaceLite {
+  id: string;
+  label: string;
+  branch?: string;
+  path: string;
 }
 
 function isRef(v: unknown): v is { $ref: string } {
@@ -114,6 +122,18 @@ export function ProjectsDashboard({
     () => resolveArray<ExtraCard>(props?.extraCards, state),
     [props?.extraCards, state],
   );
+  const workspacesByProject = useMemo(() => {
+    const sidebarProjects =
+      (state.sidebar as
+        | { projects?: Array<{ id?: string; workspaces?: WorkspaceLite[] }> }
+        | undefined)?.projects ?? [];
+    const byProject: Record<string, WorkspaceLite[]> = {};
+    for (const project of sidebarProjects) {
+      if (!project.id || !Array.isArray(project.workspaces)) continue;
+      byProject[project.id] = project.workspaces;
+    }
+    return byProject;
+  }, [state.sidebar]);
 
   return (
     <div className="a2ui-projects-dashboard">
@@ -155,6 +175,25 @@ export function ProjectsDashboard({
             New Tab
           </button>
         </div>
+        {projects.length > 0 && (
+          <section className="a2ui-projects-dashboard-section">
+            <RegistryComponent
+              type="task-launcher"
+              state={state}
+              onEvent={(_component, eventType, data) =>
+                onEvent(eventType, data, "projects-dashboard-launcher")
+              }
+              componentProps={{
+                project: projects[0],
+                projects,
+                workspacesByProject,
+                showProjectSelector: true,
+                placeholder:
+                  "Start a task on this host… choose a project, use @<subagent> or @path",
+              }}
+            />
+          </section>
+        )}
         {projects.length > 0 && (
           <section className="a2ui-projects-dashboard-section">
             <h2>Recent projects</h2>

--- a/src/extensions/default-layout/dashboard/task-launcher.test.tsx
+++ b/src/extensions/default-layout/dashboard/task-launcher.test.tsx
@@ -86,18 +86,156 @@ describe("TaskLauncher", () => {
     expect(html).toBe("");
   });
 
-  it("renders the project chip label and start button", () => {
-    const html = renderToStaticMarkup(
+  it("omits the project chip on per-project launchers", () => {
+    render(
       <TaskLauncher
         component={launcher({
           project: { id: "p1", label: "aethon", path: "/a" },
+          otherProjects: [{ id: "p2", label: "koban", path: "/k" }],
         })}
         state={{}}
         onEvent={() => {}}
       />,
     );
-    expect(html).toContain("aethon");
-    expect(html).toContain("Start");
+    expect(screen.queryByRole("button", { name: "Project" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Workspace" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Start" })).toBeTruthy();
+  });
+
+  it("shows a local project selector for host-level launchers", async () => {
+    const onEvent = vi.fn();
+    render(
+      <TaskLauncher
+        component={launcher({
+          project: { id: "p1", label: "aethon", path: "/a" },
+          projects: [
+            { id: "p1", label: "aethon", path: "/a" },
+            { id: "p2", label: "koban", path: "/k" },
+          ],
+          workspacesByProject: {
+            p2: [{ id: "k-main", label: "main", path: "/k" }],
+          },
+          showProjectSelector: true,
+        })}
+        state={{}}
+        onEvent={onEvent}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Project" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "koban" }));
+    fireEvent.change(screen.getByLabelText("Task prompt"), {
+      target: { value: "ship it" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Start" }));
+
+    await waitFor(() =>
+      expect(onEvent).toHaveBeenCalledWith(
+        "start-task",
+        expect.objectContaining({
+          projectId: "p2",
+          prompt: "ship it",
+        }),
+      ),
+    );
+  });
+
+  it("resets workspace and base branch when a host-level selected project disappears", async () => {
+    const onEvent = vi.fn();
+    const { rerender } = render(
+      <TaskLauncher
+        component={launcher({
+          project: {
+            id: "p1",
+            label: "aethon",
+            path: "/a",
+            workspaceBaseBranch: "trunk",
+          },
+          projects: [
+            {
+              id: "p1",
+              label: "aethon",
+              path: "/a",
+              workspaceBaseBranch: "trunk",
+            },
+            {
+              id: "p2",
+              label: "koban",
+              path: "/k",
+              workspaceBaseBranch: "release",
+            },
+          ],
+          showProjectSelector: true,
+        })}
+        state={{}}
+        onEvent={onEvent}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Project" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "koban" }));
+    fireEvent.click(screen.getByRole("button", { name: "Workspace" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "+ New workspace" }));
+    expect(
+      screen.getByLabelText<HTMLInputElement>(
+        "Base branch (empty = project default)",
+      ).value,
+    ).toBe("release");
+
+    rerender(
+      <TaskLauncher
+        component={launcher({
+          project: {
+            id: "p1",
+            label: "aethon",
+            path: "/a",
+            workspaceBaseBranch: "trunk",
+          },
+          projects: [
+            {
+              id: "p1",
+              label: "aethon",
+              path: "/a",
+              workspaceBaseBranch: "trunk",
+            },
+          ],
+          showProjectSelector: true,
+        })}
+        state={{}}
+        onEvent={onEvent}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.queryByLabelText("Base branch (empty = project default)"),
+      ).toBeNull(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Workspace" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "+ New workspace" }));
+    expect(
+      screen.getByLabelText<HTMLInputElement>(
+        "Base branch (empty = project default)",
+      ).value,
+    ).toBe("trunk");
+    fireEvent.change(screen.getByLabelText("New branch name"), {
+      target: { value: "codex/check-selector" },
+    });
+    fireEvent.change(screen.getByLabelText("Task prompt"), {
+      target: { value: "ship it" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Start" }));
+
+    await waitFor(() =>
+      expect(onEvent).toHaveBeenCalledWith(
+        "start-task",
+        expect.objectContaining({
+          projectId: "p1",
+          branch: "codex/check-selector",
+          baseBranch: "trunk",
+        }),
+      ),
+    );
   });
 
   it("renders the voice input control on the overview task launcher", () => {

--- a/src/extensions/default-layout/dashboard/task-launcher.tsx
+++ b/src/extensions/default-layout/dashboard/task-launcher.tsx
@@ -6,7 +6,7 @@
  * point for the agent-side `startTask` pi tool (UI/pi parity).
  *
  * Chip row:
- *   - project — switcher across projects (selectable when multiple).
+ *   - project — optional host-level switcher across projects.
  *   - workspace — "current" (cwd), or one of the existing workspaces, or
  *     "+ New workspace" (opens the branch chip).
  *   - branch — only shown for "+ New workspace". Base branch picker
@@ -59,8 +59,12 @@ interface WorkspaceLite {
 interface LauncherData {
   /** The project this composer targets — usually `/project`. */
   project: ProjectLite | null;
+  /** Selectable projects for host-level launchers. */
+  projects: ProjectLite[];
   /** Other selectable projects, used by the project chip's menu. */
   otherProjects: ProjectLite[];
+  /** Existing workspaces keyed by project id for host-level launchers. */
+  workspacesByProject: Record<string, WorkspaceLite[]>;
   /** Existing workspaces for the active project. */
   workspaces: WorkspaceLite[];
   /** Currently-selected workspace id (or null for "project root"). */
@@ -102,19 +106,29 @@ export function TaskLauncher({
   const props = component.props as
     | {
         project?: unknown;
+        projects?: unknown;
         otherProjects?: unknown;
+        workspacesByProject?: unknown;
         workspaces?: unknown;
         activeWorkspaceId?: unknown;
         placeholder?: string;
         prompt?: unknown;
+        showProjectSelector?: boolean;
       }
     | undefined;
+  const showProjectSelector = props?.showProjectSelector === true;
 
   const data: LauncherData = useMemo(
     () => ({
       project: resolveOrInline<ProjectLite>(props?.project, state),
+      projects: resolveOrInline<ProjectLite[]>(props?.projects, state) ?? [],
       otherProjects:
         resolveOrInline<ProjectLite[]>(props?.otherProjects, state) ?? [],
+      workspacesByProject:
+        resolveOrInline<Record<string, WorkspaceLite[]>>(
+          props?.workspacesByProject,
+          state,
+        ) ?? {},
       workspaces:
         resolveOrInline<WorkspaceLite[]>(props?.workspaces, state) ?? [],
       activeWorkspaceId:
@@ -122,10 +136,46 @@ export function TaskLauncher({
     }),
     [
       props?.project,
+      props?.projects,
       props?.otherProjects,
+      props?.workspacesByProject,
       props?.workspaces,
       props?.activeWorkspaceId,
       state,
+    ],
+  );
+
+  const selectableProjects = useMemo(() => {
+    const seen = new Set<string>();
+    const list: ProjectLite[] = [];
+    for (const p of [data.project, ...data.projects, ...data.otherProjects]) {
+      if (!p || seen.has(p.id)) continue;
+      seen.add(p.id);
+      list.push(p);
+    }
+    return list;
+  }, [data.project, data.projects, data.otherProjects]);
+  const [selectedProjectId, setSelectedProjectId] = useState(
+    data.project?.id ?? selectableProjects[0]?.id ?? "",
+  );
+  const selectedProject = showProjectSelector
+    ? (selectableProjects.find((p) => p.id === selectedProjectId) ??
+      data.project ??
+      selectableProjects[0] ??
+      null)
+    : data.project;
+  const selectedWorkspaces = useMemo(
+    () =>
+      showProjectSelector
+        ? selectedProject
+          ? (data.workspacesByProject[selectedProject.id] ?? [])
+          : []
+        : data.workspaces,
+    [
+      data.workspaces,
+      data.workspacesByProject,
+      selectedProject,
+      showProjectSelector,
     ],
   );
 
@@ -178,8 +228,10 @@ export function TaskLauncher({
   // sidebar, not just "project root". Falls back to "current" (project
   // root) when no workspace is active.
   const initialChoice: WorkspaceChoice = useMemo(() => {
-    if (!data.activeWorkspaceId) return { kind: "current" };
-    const wt = data.workspaces.find((w) => w.id === data.activeWorkspaceId);
+    if (!data.activeWorkspaceId || showProjectSelector) {
+      return { kind: "current" };
+    }
+    const wt = selectedWorkspaces.find((w) => w.id === data.activeWorkspaceId);
     if (!wt) return { kind: "current" };
     return {
       kind: "existing",
@@ -187,7 +239,7 @@ export function TaskLauncher({
       path: wt.path,
       label: wt.label || wt.branch || "workspace",
     };
-  }, [data.activeWorkspaceId, data.workspaces]);
+  }, [data.activeWorkspaceId, selectedWorkspaces, showProjectSelector]);
   const [workspaceChoice, setWorkspaceChoice] =
     useState<WorkspaceChoice>(initialChoice);
   // Re-sync when the active workspace changes on the project (the user
@@ -201,9 +253,22 @@ export function TaskLauncher({
   }, [initialChoice, touched]);
   const [newBranch, setNewBranch] = useState("");
   const defaultBaseBranch =
-    data.project?.workspaceBaseBranch ?? DEFAULT_WORKSPACE_BASE_BRANCH;
+    selectedProject?.workspaceBaseBranch ?? DEFAULT_WORKSPACE_BASE_BRANCH;
   const [baseBranch, setBaseBranch] = useState(defaultBaseBranch);
   const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    const fallbackProject = data.project ?? selectableProjects[0] ?? null;
+    if (!fallbackProject) return;
+    if (selectableProjects.some((p) => p.id === selectedProjectId)) return;
+    queueMicrotask(() => {
+      setSelectedProjectId(fallbackProject.id);
+      setWorkspaceChoice({ kind: "current" });
+      setBaseBranch(
+        fallbackProject.workspaceBaseBranch ?? DEFAULT_WORKSPACE_BASE_BRANCH,
+      );
+    });
+  }, [data.project, selectableProjects, selectedProjectId]);
 
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   useEffect(() => {
@@ -225,7 +290,7 @@ export function TaskLauncher({
   const atRoot =
     workspaceChoice.kind === "existing"
       ? workspaceChoice.path
-      : (data.project?.path ?? null);
+      : (selectedProject?.path ?? null);
   const {
     atMatch,
     highlightIdx: atHighlightIdx,
@@ -264,11 +329,11 @@ export function TaskLauncher({
     if (submitting) return;
     const text = rawPrompt.trim();
     if (!text && attachments.length === 0) return;
-    if (!data.project) return;
+    if (!selectedProject) return;
     setSubmitting(true);
     const baseTrimmed = baseBranch.trim();
     onEvent("start-task", {
-      projectId: data.project.id,
+      projectId: selectedProject.id,
       prompt: text,
       attachments,
       newWorkspace: workspaceChoice.kind === "new",
@@ -297,7 +362,7 @@ export function TaskLauncher({
   }, [
     submitting,
     attachments,
-    data.project,
+    selectedProject,
     workspaceChoice,
     newBranch,
     baseBranch,
@@ -470,7 +535,7 @@ export function TaskLauncher({
       });
   };
 
-  if (!data.project) return null;
+  if (!selectedProject) return null;
 
   const workspaceLabel =
     workspaceChoice.kind === "current"
@@ -490,7 +555,7 @@ export function TaskLauncher({
         className="a2ui-task-launcher-input"
         placeholder={
           props?.placeholder ??
-          `Start a task in ${data.project.label}… use @<subagent> or @path`
+          `Start a task in ${selectedProject.label}… use @<subagent> or @path`
         }
         value={promptText}
         rows={3}
@@ -569,23 +634,27 @@ export function TaskLauncher({
             }}
           />
         )}
-        <ChipMenu
-          label={data.project.label}
-          icon="◰"
-          ariaLabel="Project"
-          items={[
-            { id: data.project.id, label: data.project.label, current: true },
-            ...data.otherProjects.map((p) => ({
+        {showProjectSelector && selectableProjects.length > 0 && (
+          <ChipMenu
+            label={selectedProject.label}
+            icon="◰"
+            ariaLabel="Project"
+            items={selectableProjects.map((p) => ({
               id: p.id,
               label: p.label,
-              current: false,
-            })),
-          ]}
-          onSelect={(id) => {
-            if (id === data.project!.id) return;
-            onEvent("select-project-card", { projectId: id });
-          }}
-        />
+              current: p.id === selectedProject.id,
+            }))}
+            onSelect={(id) => {
+              const project = selectableProjects.find((p) => p.id === id);
+              setSelectedProjectId(id);
+              setWorkspaceChoice({ kind: "current" });
+              setBaseBranch(
+                project?.workspaceBaseBranch ?? DEFAULT_WORKSPACE_BASE_BRANCH,
+              );
+              setTouched(true);
+            }}
+          />
+        )}
         <ChipMenu
           label={workspaceLabel}
           icon="⌥"
@@ -593,10 +662,10 @@ export function TaskLauncher({
           items={[
             {
               id: "current",
-              label: `project root (${data.project.label})`,
+              label: `project root (${selectedProject.label})`,
               current: workspaceChoice.kind === "current",
             },
-            ...data.workspaces.map((w) => ({
+            ...selectedWorkspaces.map((w) => ({
               id: w.id,
               label: w.label || w.branch || "workspace",
               current:
@@ -614,7 +683,7 @@ export function TaskLauncher({
             if (id === "current") setWorkspaceChoice({ kind: "current" });
             else if (id === "__new__") setWorkspaceChoice({ kind: "new" });
             else {
-              const found = data.workspaces.find((w) => w.id === id);
+              const found = selectedWorkspaces.find((w) => w.id === id);
               if (found)
                 setWorkspaceChoice({
                   kind: "existing",


### PR DESCRIPTION
## Summary
- Add the dashboard task launcher to the host-level projects overview when projects are available.
- Make the launcher project selector opt-in so per-project dashboards no longer show a redundant project chip.
- Keep host-level project selection local to the prompt, including project-specific workspace choices and new-workspace base-branch defaults.

## Validation
- bunx vitest run src/extensions/default-layout/dashboard/task-launcher.test.tsx src/extensions/default-layout/dashboard/projects-dashboard.test.tsx src/extensions/default-layout/dashboard/project-dashboard.test.tsx
- bun run typecheck
- bun run lint
- bunx vitest run
- bun run build

## UI QA Notes
- Verified the plain Vite surface loads in the in-app browser, but a fully seeded dashboard requires Tauri event/runtime APIs. A temporary non-Tauri browser harness was attempted and rejected/then failed on incomplete Tauri event mocks, so the behavior is covered with focused rendered component tests instead of a trustworthy browser screenshot.
- Existing production build warning remains: some chunks are larger than 500 kB after minification.
