### PR TITLE
feat(agent): add enforced plan mode

### DIFF
--- a/agent/chat.ts
+++ b/agent/chat.ts
@@ -47,6 +47,9 @@ export async function handleChat(
   if (typeof msg.hardEnforce === "boolean") {
     state.tabHardEnforce.set(tabId, msg.hardEnforce);
   }
+  if (typeof msg.planMode === "boolean") {
+    state.tabPlanMode.set(tabId, msg.planMode);
+  }
   const cwdOverride =
     typeof msg.cwd === "string" && msg.cwd.length > 0 ? msg.cwd : undefined;
   // Explicit `@name` subagent invocation: record a one-shot steer consumed by
@@ -107,6 +110,7 @@ export async function handleChat(
   if (requestedModel.thinkingLevel) {
     tab.session.setThinkingLevel(requestedModel.thinkingLevel);
   }
+  const planMode = state.tabPlanMode.get(tabId) === true;
   const wantsSteer = msg.mode === "steer";
   const images = normalizeImages(msg.images);
   let content: string;
@@ -128,7 +132,7 @@ export async function handleChat(
         message: `file references: ${expanded.issues.join("\n")}`,
       });
     }
-    content = expanded.prompt;
+    content = planMode ? withPlanModeInstruction(expanded.prompt) : expanded.prompt;
   } catch (err) {
     if (mentions.length > 0) state.pendingExplicitSubagent.delete(tabId);
     const message =
@@ -222,6 +226,13 @@ export async function handleChat(
       maybeExitForReload(state, deps);
     });
   chatLog.info(`prompt dispatched tabId=${tabId}`);
+}
+
+const PLAN_MODE_INSTRUCTION =
+  "You are in Aethon plan mode. Do not edit files, run shell commands, start implementation tasks, commit, push, or make persistent changes. Inspect read-only context as needed, then propose a concise implementation plan with risks and tests. Wait for the user to switch back to implementation mode or explicitly approve implementation.";
+
+function withPlanModeInstruction(prompt: string): string {
+  return `${PLAN_MODE_INSTRUCTION}\n\nUser request:\n${prompt}`;
 }
 
 function scheduledRunFromMessage(

--- a/agent/dispatcher.test.ts
+++ b/agent/dispatcher.test.ts
@@ -466,6 +466,62 @@ describe("handleChat", () => {
     expect(f.sent).not.toContainEqual({ type: "queued", tabId: "tab-1" });
   });
 
+  it("adds plan-mode instructions to normal prompts and records the tab mode", async () => {
+    const f = makeFixture();
+    const promptCalls: unknown[][] = [];
+    const tab = fakeTabRecord({
+      session: {
+        prompt: (...args: unknown[]) => {
+          promptCalls.push(args);
+          return Promise.resolve();
+        },
+        followUp: () => Promise.resolve(),
+        steer: () => Promise.resolve(),
+      } as unknown as TabRecord["session"],
+    });
+    f.state.tabs.set("tab-1", tab);
+
+    await handleChat(f.state, f.deps, {
+      type: "chat",
+      content: "design the fix",
+      tabId: "tab-1",
+      mode: "normal",
+      planMode: true,
+    });
+
+    expect(f.state.tabPlanMode.get("tab-1")).toBe(true);
+    expect(promptCalls[0][0]).toContain("Aethon plan mode");
+    expect(promptCalls[0][0]).toContain("User request:\ndesign the fix");
+  });
+
+  it("adds plan-mode instructions to steering prompts", async () => {
+    const f = makeFixture();
+    const steerCalls: unknown[][] = [];
+    const tab = fakeTabRecord({
+      promptInFlight: true,
+      session: {
+        prompt: () => Promise.resolve(),
+        followUp: () => Promise.resolve(),
+        steer: (...args: unknown[]) => {
+          steerCalls.push(args);
+          return Promise.resolve();
+        },
+      } as unknown as TabRecord["session"],
+    });
+    f.state.tabs.set("tab-1", tab);
+
+    await handleChat(f.state, f.deps, {
+      type: "chat",
+      content: "adjust the plan",
+      tabId: "tab-1",
+      mode: "steer",
+      planMode: true,
+    });
+
+    expect(steerCalls[0][0]).toContain("Aethon plan mode");
+    expect(steerCalls[0][0]).toContain("User request:\nadjust the plan");
+  });
+
   it("steers retry-active sessions even when Aethon's in-flight flag is stale", async () => {
     const f = makeFixture();
     const promptCalls: unknown[][] = [];

--- a/agent/dispatcherTypes.ts
+++ b/agent/dispatcherTypes.ts
@@ -40,6 +40,8 @@ export interface InboundMessage {
   thinkingLevel?: string;
   /** Per-tab hard project-root guardrail override, carried on `chat`. */
   hardEnforce?: boolean;
+  /** Per-tab plan-mode toggle, carried on `chat`. */
+  planMode?: boolean;
   /** Native scheduled-task metadata carried on scheduler-fired chat turns. */
   scheduledTaskId?: string;
   scheduledRunId?: string;

--- a/agent/source-guard.test.ts
+++ b/agent/source-guard.test.ts
@@ -157,6 +157,38 @@ describe("wrapWithSourceGuard hard project-root enforcement", () => {
     expect(r?.block).toBeFalsy();
   });
 
+  it("blocks mutating tools while plan mode is on", async () => {
+    const agent = makeAgent();
+    wrapWithSourceGuard(agent, undefined, {
+      tabRoot: TAB,
+      planMode: () => true,
+    });
+
+    for (const tool of [
+      "write",
+      "edit",
+      "bash",
+      "task",
+      "task_batch",
+      "startTask",
+      "writeShell",
+    ]) {
+      const r = await agent.beforeToolCall(ctx(tool, "src/file.ts"), undefined);
+      expect(r?.block).toBe(true);
+      expect(r?.reason).toContain("Plan mode is on");
+    }
+  });
+
+  it("allows read-only tools while plan mode is on", async () => {
+    const agent = makeAgent();
+    wrapWithSourceGuard(agent, undefined, {
+      tabRoot: TAB,
+      planMode: () => true,
+    });
+    const r = await agent.beforeToolCall(ctx("read", "src/file.ts"), undefined);
+    expect(r?.block).toBeFalsy();
+  });
+
   it("reads hardEnforce() live so a runtime toggle takes effect", async () => {
     let on = false;
     const agent = makeAgent();

--- a/agent/source-guard.ts
+++ b/agent/source-guard.ts
@@ -2,6 +2,15 @@ import { isAbsolute, join, resolve, sep } from "node:path";
 import type { Agent } from "@mariozechner/pi-agent-core";
 
 const GUARDED_TOOLS = new Set(["write", "edit"]);
+const PLAN_MODE_BLOCKED_TOOLS = new Set([
+  "write",
+  "edit",
+  "bash",
+  "task",
+  "task_batch",
+  "startTask",
+  "writeShell",
+]);
 
 const PROTECTED_DIRS = ["src", "src-tauri", "agent"] as const;
 
@@ -15,6 +24,9 @@ export interface HardGuardOptions {
   /** Live per-tab toggle, read on every tool call so a runtime flip (the
    *  composer guardrail switch) takes effect without re-wrapping the agent. */
   hardEnforce?: () => boolean;
+  /** Live per-tab plan-mode toggle. When true, mutating tools are blocked
+   *  even inside the project root. */
+  planMode?: () => boolean;
 }
 
 /**
@@ -63,6 +75,16 @@ function evaluateGuard(
 ): { block: true; reason: string } | undefined {
   const name = ctx.toolCall.name;
   const args = ctx.args as { path?: string; command?: string } | undefined;
+
+  if (hardGuard?.planMode?.() && PLAN_MODE_BLOCKED_TOOLS.has(name)) {
+    return {
+      block: true,
+      reason:
+        `Plan mode is on for this session, so the ${name} tool is blocked. ` +
+        "Inspect context with read-only tools and propose a plan. Ask the user " +
+        "to switch back to implementation mode before making changes.",
+    };
+  }
 
   // 1. Aethon source guard. Resolve relative paths against process.cwd()
   //    (the agent launch dir == the source root in dev), matching the

--- a/agent/state.ts
+++ b/agent/state.ts
@@ -409,6 +409,11 @@ export class AethonAgentState {
    *  per-tab toggle), so it's always current before a turn's tool calls and
    *  survives an agent respawn. Read live by the wrapWithSourceGuard closure. */
   readonly tabHardEnforce = new Map<string, boolean>();
+  /** Per-tab plan mode. When true, the source guard blocks mutating tools
+   *  while still allowing read/introspection so the model can inspect and
+   *  propose a plan. Carried on every chat from the frontend and read live by
+   *  the wrapWithSourceGuard closure. */
+  readonly tabPlanMode = new Map<string, boolean>();
   /** Global default for the hard project-root guardrail, from
    *  `[guardrails] hard_enforce_project_root` via the
    *  AETHON_HARD_ENFORCE_PROJECT_ROOT env at spawn. */

--- a/agent/tab-lifecycle/lifecycle.ts
+++ b/agent/tab-lifecycle/lifecycle.ts
@@ -200,6 +200,7 @@ export async function ensureTab(
     tabRoot: resolvedCwd,
     hardEnforce: () =>
       state.tabHardEnforce.get(tabId) ?? state.hardEnforceProjectRootDefault,
+    planMode: () => state.tabPlanMode.get(tabId) === true,
   });
 
   const rec: TabRecord = {

--- a/src-tauri/src/agent_commands.rs
+++ b/src-tauri/src/agent_commands.rs
@@ -46,6 +46,9 @@ pub(crate) struct SendMessageRequest {
     /// turn's tool calls. `None` leaves the per-tab value untouched (the
     /// agent falls back to the global default).
     hard_enforce: Option<bool>,
+    /// Per-tab plan-mode toggle. Forwarded to the agent so mutating tools can
+    /// be blocked while the user is asking for analysis/design only.
+    plan_mode: Option<bool>,
 }
 
 #[tauri::command]
@@ -85,6 +88,9 @@ pub(crate) async fn send_message(
     }
     if let Some(hard_enforce) = request.hard_enforce {
         payload["hardEnforce"] = serde_json::Value::Bool(hard_enforce);
+    }
+    if let Some(plan_mode) = request.plan_mode {
+        payload["planMode"] = serde_json::Value::Bool(plan_mode);
     }
     let images = attachments_to_agent_images(&app, request.attachments.unwrap_or_default())?;
     if !images.is_empty() {

--- a/src/eventRoutes/chatInput.test.ts
+++ b/src/eventRoutes/chatInput.test.ts
@@ -32,6 +32,27 @@ describe("handleChatInput", () => {
     expect(mocks.sendChat).toHaveBeenCalledWith("look now", { mode: "steer" });
   });
 
+  it("shift-tab route toggles plan mode on the active agent tab", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    const handled = await handleChatInput(
+      {
+        component: { id: "chat-input" },
+        eventType: "mode:toggle-plan",
+      },
+      ctx,
+    );
+
+    expect(handled).toBe(true);
+    expect(mocks.updateActiveTab).toHaveBeenCalledTimes(1);
+    const updater = mocks.updateActiveTab.mock.calls[0][0] as Parameters<
+      typeof ctx.updateActiveTab
+    >[0];
+    expect(updater(makeEmptyTab("tab-1", "Tab 1")).planMode).toBe(true);
+    expect(mocks.pushNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Plan mode on", kind: "success" }),
+    );
+  });
+
   it("empty command-enter promotes the only queued message to steering", async () => {
     const tab = {
       ...makeEmptyTab("tab-1", "Tab 1"),

--- a/src/eventRoutes/chatInput.test.ts
+++ b/src/eventRoutes/chatInput.test.ts
@@ -32,7 +32,7 @@ describe("handleChatInput", () => {
     expect(mocks.sendChat).toHaveBeenCalledWith("look now", { mode: "steer" });
   });
 
-  it("shift-tab route toggles plan mode on the active agent tab", async () => {
+  it("mode route toggles plan mode on the active agent tab", async () => {
     const { ctx, mocks } = buildRouteFixture();
     const handled = await handleChatInput(
       {
@@ -48,6 +48,7 @@ describe("handleChatInput", () => {
       typeof ctx.updateActiveTab
     >[0];
     expect(updater(makeEmptyTab("tab-1", "Tab 1")).planMode).toBe(true);
+    expect(mocks.setState).not.toHaveBeenCalled();
     expect(mocks.pushNotification).toHaveBeenCalledWith(
       expect.objectContaining({ title: "Plan mode on", kind: "success" }),
     );

--- a/src/eventRoutes/chatInput.ts
+++ b/src/eventRoutes/chatInput.ts
@@ -24,6 +24,26 @@ export const handleChatInput: EventRouteHandler = async (
   { eventType, data },
   ctx,
 ) => {
+  if (eventType === "mode:toggle-plan") {
+    const tabId = ctx.stateRef.current.activeTabId as string | undefined;
+    const tabs = (ctx.stateRef.current.tabs as Tab[] | undefined) ?? [];
+    const activeTab = tabs.find((tab) => tab.id === tabId);
+    const enabled =
+      activeTab?.kind === "agent" ? activeTab.planMode !== true : true;
+    ctx.updateActiveTab((tab) => {
+      if (tab.kind !== "agent") return tab;
+      return { ...tab, planMode: enabled };
+    });
+    ctx.setState((prev) => ({ ...prev, planMode: enabled }));
+    ctx.pushNotification({
+      title: enabled ? "Plan mode on" : "Implementation mode on",
+      message: enabled
+        ? "New prompts will ask for a plan before code changes."
+        : "New prompts may make code changes.",
+      kind: "success",
+    });
+    return true;
+  }
   if (eventType === "submit") {
     const payload =
       (data as

--- a/src/eventRoutes/chatInput.ts
+++ b/src/eventRoutes/chatInput.ts
@@ -34,7 +34,6 @@ export const handleChatInput: EventRouteHandler = async (
       if (tab.kind !== "agent") return tab;
       return { ...tab, planMode: enabled };
     });
-    ctx.setState((prev) => ({ ...prev, planMode: enabled }));
     ctx.pushNotification({
       title: enabled ? "Plan mode on" : "Implementation mode on",
       message: enabled

--- a/src/extensions/default-layout/chat-input.tsx
+++ b/src/extensions/default-layout/chat-input.tsx
@@ -88,7 +88,7 @@ export function ChatInput({
     ? resolveString(props.placeholder, state)
     : "";
   const busy = props.disabled ? resolveBoolean(props.disabled, state) : false;
-  const planMode = props.planMode
+  const planMode = props.planMode !== undefined
     ? resolveBoolean(props.planMode, state)
     : state.planMode === true;
   const queueCount = props.queueCount
@@ -497,6 +497,7 @@ export function ChatInput({
           onClick={() => onEvent("mode:toggle-plan")}
           title="Toggle plan mode"
           aria-label={planMode ? "Plan mode on" : "Implementation mode on"}
+          aria-pressed={planMode}
         >
           {planMode ? "Plan" : "Implement"}
         </button>

--- a/src/extensions/default-layout/chat-input.tsx
+++ b/src/extensions/default-layout/chat-input.tsx
@@ -68,6 +68,7 @@ export function ChatInput({
     value?: StringValue;
     placeholder?: StringValue;
     disabled?: BooleanValue;
+    planMode?: BooleanValue;
     onSubmit?: string;
     onChange?: string;
     commands?: SlashCommandSource;
@@ -87,6 +88,9 @@ export function ChatInput({
     ? resolveString(props.placeholder, state)
     : "";
   const busy = props.disabled ? resolveBoolean(props.disabled, state) : false;
+  const planMode = props.planMode
+    ? resolveBoolean(props.planMode, state)
+    : state.planMode === true;
   const queueCount = props.queueCount
     ? resolveNumber(props.queueCount, state)
     : 0;
@@ -485,6 +489,17 @@ export function ChatInput({
         />
       )}
       <div className="a2ui-chat-input-field-wrap">
+        <button
+          type="button"
+          className={`a2ui-chat-input-mode ${
+            planMode ? "a2ui-chat-input-mode-plan" : ""
+          }`}
+          onClick={() => onEvent("mode:toggle-plan")}
+          title="Toggle plan mode"
+          aria-label={planMode ? "Plan mode on" : "Implementation mode on"}
+        >
+          {planMode ? "Plan" : "Implement"}
+        </button>
         <textarea
           ref={textareaRef}
           className="a2ui-chat-input-field"

--- a/src/extensions/default-layout/chat.test.tsx
+++ b/src/extensions/default-layout/chat.test.tsx
@@ -382,6 +382,20 @@ describe("ChatInput", () => {
     expect(onEvent).not.toHaveBeenCalledWith("submit", expect.any(Object));
   });
 
+  it("renders a plan-mode chip that toggles the mode", () => {
+    const { onEvent } = renderInput(
+      vi.fn(),
+      { planMode: { $ref: "/planMode" } },
+      { planMode: true },
+    );
+
+    const chip = screen.getByRole("button", { name: "Plan mode on" });
+    expect(chip.textContent).toBe("Plan");
+    fireEvent.click(chip);
+
+    expect(onEvent).toHaveBeenLastCalledWith("mode:toggle-plan");
+  });
+
   it("cleans up composer resize state if unmounted mid-drag", () => {
     const { unmount } = renderInput();
 

--- a/src/extensions/default-layout/chat.test.tsx
+++ b/src/extensions/default-layout/chat.test.tsx
@@ -391,9 +391,20 @@ describe("ChatInput", () => {
 
     const chip = screen.getByRole("button", { name: "Plan mode on" });
     expect(chip.textContent).toBe("Plan");
+    expect(chip.getAttribute("aria-pressed")).toBe("true");
     fireEvent.click(chip);
 
     expect(onEvent).toHaveBeenLastCalledWith("mode:toggle-plan");
+  });
+
+  it("honors an explicit false plan-mode prop", () => {
+    renderInput(vi.fn(), { planMode: false }, { planMode: true });
+
+    const chip = screen.getByRole("button", {
+      name: "Implementation mode on",
+    });
+    expect(chip.textContent).toBe("Implement");
+    expect(chip.getAttribute("aria-pressed")).toBe("false");
   });
 
   it("cleans up composer resize state if unmounted mid-drag", () => {

--- a/src/extensions/default-layout/workstation.a2ui.json
+++ b/src/extensions/default-layout/workstation.a2ui.json
@@ -213,6 +213,7 @@
                 "value": { "$ref": "/draft" },
                 "placeholder": "Message Aethon… (@<subagent> to delegate, @file for context, / for commands)",
                 "disabled": { "$ref": "/waiting" },
+                "planMode": { "$ref": "/planMode" },
                 "queueCount": { "$ref": "/queueCount" },
                 "commands": { "$ref": "/slashCommands" },
                 "onSubmit": "chat:send"
@@ -241,6 +242,7 @@
     "contextUsage": null,
     "draft": "",
     "waiting": false,
+    "planMode": false,
     "queueCount": 0,
     "queuedMessages": [],
     "messages": [],

--- a/src/hooks/tabOps/constants.ts
+++ b/src/hooks/tabOps/constants.ts
@@ -20,6 +20,7 @@ export const TAB_MIRROR_KEYS: (keyof Tab)[] = [
   "canvas",
   "model",
   "thinkingLevel",
+  "planMode",
   "contextUsage",
   "cwd",
   // M6 P1: shell-tab fields. The "kind" + "shell" mirror lets layouts

--- a/src/hooks/useAppSlashCommandContext.ts
+++ b/src/hooks/useAppSlashCommandContext.ts
@@ -143,6 +143,28 @@ export function useAppSlashCommandContext({
       setTheme,
       listThemes,
       setModel,
+      setPlanMode: (enabled: boolean) => {
+        const activeId = stateRef.current.activeTabId;
+        if (typeof activeId !== "string" || activeId.length === 0) return;
+        setState((prev) => {
+          const tabs = (prev.tabs as Tab[] | undefined) ?? [];
+          const idx = tabs.findIndex((t) => t.id === activeId);
+          if (idx < 0 || tabs[idx].kind !== "agent") return prev;
+          const next = [...tabs];
+          next[idx] = { ...next[idx], planMode: enabled };
+          return {
+            ...prev,
+            tabs: next,
+            ...(prev.activeTabId === activeId ? { planMode: enabled } : {}),
+          };
+        });
+      },
+      getPlanMode: () => {
+        const activeId = stateRef.current.activeTabId;
+        const tabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
+        const tab = tabs.find((t) => t.id === activeId);
+        return tab?.kind === "agent" ? tab.planMode === true : false;
+      },
       resetLayout: () => setLayout(bootLayout),
       listExtensions: () => registry.list().map((s) => s.name),
       installExtension: async (spec: string) => {

--- a/src/hooks/useChat.test.ts
+++ b/src/hooks/useChat.test.ts
@@ -138,12 +138,60 @@ describe("useChat setModel", () => {
         tabId: "tab-1",
         mode: "normal",
         model: "anthropic/claude-opus-4-7",
+        planMode: false,
       },
     });
     expect((stateRef.current.tabs as Tab[])[0].messages.at(-1)).toMatchObject({
       role: "user",
       text: "hello",
       delivery: "sent",
+    });
+  });
+
+  it("sends plan-mode prompts with the plan-mode flag", async () => {
+    const tab = {
+      ...makeEmptyTab("tab-1", "Tab 1"),
+      model: "anthropic/claude-opus-4-7",
+      planMode: true,
+    };
+    const { ctx, stateRef } = buildContext({ tabs: [tab] });
+    const { result } = renderHook(() => useChat(ctx));
+
+    await act(async () => {
+      await result.current.sendChat("design the fix");
+    });
+
+    const call = invoke.mock.calls.find(([cmd]) => cmd === "send_message");
+    const request = (
+      call?.[1] as { request: { message: string; planMode: boolean } }
+    ).request;
+    expect(request.message).toBe("design the fix");
+    expect(request.planMode).toBe(true);
+    expect((stateRef.current.tabs as Tab[])[0].messages.at(-1)).toMatchObject({
+      role: "user",
+      text: "design the fix",
+    });
+  });
+
+  it("carries plan mode on steering sends too", async () => {
+    const tab = {
+      ...makeEmptyTab("tab-1", "Tab 1"),
+      model: "anthropic/claude-opus-4-7",
+      planMode: true,
+    };
+    const { ctx } = buildContext({ waiting: true, tabs: [tab] });
+    const { result } = renderHook(() => useChat(ctx));
+
+    await act(async () => {
+      await result.current.sendChat("adjust the plan", { mode: "steer" });
+    });
+
+    expect(invoke).toHaveBeenCalledWith("send_message", {
+      request: expect.objectContaining({
+        message: "adjust the plan",
+        mode: "steer",
+        planMode: true,
+      }),
     });
   });
 
@@ -195,6 +243,7 @@ describe("useChat setModel", () => {
         mode: "normal",
         model: "openai-codex/gpt-5.5",
         thinkingLevel: "high",
+        planMode: false,
       },
     });
   });
@@ -224,6 +273,7 @@ describe("useChat setModel", () => {
         mode: "normal",
         attachments: [attachment],
         model: "anthropic/claude-opus-4-7",
+        planMode: false,
       },
     });
     const tab = (stateRef.current.tabs as Tab[])[0];
@@ -260,6 +310,7 @@ describe("useChat setModel", () => {
         mode: "normal",
         cwd: "/projects/aethon-fix-86",
         model: "anthropic/claude-opus-4-7",
+        planMode: false,
       },
     });
     const tabs = stateRef.current.tabs as Tab[];
@@ -307,6 +358,7 @@ describe("useChat setModel", () => {
         tabId: "issue-tab",
         mode: "normal",
         model: "anthropic/claude-opus-4-7",
+        planMode: false,
       },
     });
     const tabs = stateRef.current.tabs as Tab[];
@@ -346,6 +398,7 @@ describe("useChat setModel", () => {
         tabId: "tab-1",
         mode: "steer",
         model: "anthropic/claude-opus-4-7",
+        planMode: false,
       },
     });
   });
@@ -663,6 +716,7 @@ describe("useChat setModel", () => {
         tabId: "tab-1",
         mode: "normal",
         model: "anthropic/claude-opus-4-7",
+        planMode: false,
       },
     });
     const tab = (stateRef.current.tabs as Tab[])[0];
@@ -711,6 +765,7 @@ describe("useChat setModel", () => {
         tabId: "tab-1",
         mode: "steer",
         model: "anthropic/claude-opus-4-7",
+        planMode: false,
       },
     });
     expect((stateRef.current.tabs as Tab[])[0].messages.at(-1)).toMatchObject({

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -25,7 +25,6 @@ import {
 import { isAgentTabInFlight } from "../utils/agentBusy";
 
 const STOP_CONFIRM_DELAYS_MS = [0, 150, 500, 1000, 2000] as const;
-
 /** Patch `queuedMessages` and the derived `queueCount` together so the
  *  composer badge can't drift out of sync with the popover list. */
 function withQueue(tab: Tab, next: QueuedMessage[]): Tab {
@@ -638,13 +637,16 @@ export function useChat(ctx: UseChatContext): UseChatActions {
         : typeof stateRef.current.thinkingLevel === "string" &&
             stateRef.current.thinkingLevel.length > 0
           ? stateRef.current.thinkingLevel
-          : undefined;
+        : undefined;
+    const targetPlanMode =
+      targetTab?.kind === "agent" ? targetTab.planMode === true : false;
     try {
       await invoke("send_message", {
         request: {
           message: bridgeText,
           tabId,
           mode,
+          planMode: targetPlanMode,
           ...(attachments.length > 0 ? { attachments } : {}),
           ...(targetCwd ? { cwd: targetCwd } : {}),
           ...(targetModel ? { model: targetModel } : {}),

--- a/src/slashCommands.test.ts
+++ b/src/slashCommands.test.ts
@@ -70,6 +70,7 @@ describe("buildBuiltinSlashCommands", () => {
       "help",
       "theme",
       "model",
+      "plan",
       "login",
       "context",
       "session",
@@ -95,6 +96,56 @@ describe("buildBuiltinSlashCommands", () => {
     for (const cmd of buildBuiltinSlashCommands()) {
       expect(typeof cmd.run).toBe("function");
     }
+  });
+
+  it("/plan toggles the active session mode", async () => {
+    const notifications: string[] = [];
+    const states: boolean[] = [];
+    let enabled = false;
+    const ctx: SlashCommandContext = {
+      appendSystem: () => {},
+      notify: (input) => notifications.push(input.title),
+      clearChat: () => {},
+      setTheme: () => {},
+      listThemes: () => [],
+      setModel: async () => {},
+      setPlanMode: (next) => {
+        enabled = next;
+        states.push(next);
+      },
+      getPlanMode: () => enabled,
+      resetLayout: () => {},
+      listExtensions: () => [],
+      installExtension: () => Promise.resolve(""),
+      listModels: () => [],
+      openLogin: () => {},
+      listAuthProfiles: () => [],
+      useAuthProfile: async () => {},
+      setDefaultAuthProfile: async () => {},
+      toggleTerminal: () => {},
+      toggleSidebar: () => {},
+      toggleFilesSidebar: () => {},
+      activateLayout: () => false,
+      listLayouts: () => [],
+      pickProject: () => Promise.resolve(null),
+      openProject: () => "",
+      setActiveProject: () => false,
+      clearProject: () => {},
+      removeProject: () => false,
+      listProjects: () => [],
+      activeProject: () => null,
+      reloadAgent: async () => {},
+      runNativeCommand: async () => {},
+      renameSession: async () => {},
+      activeTabId: () => "tab-1",
+    };
+    const plan = buildBuiltinSlashCommands().find((c) => c.name === "plan")!;
+
+    await plan.run("", ctx);
+    await plan.run("off", ctx);
+
+    expect(states).toEqual([true, false]);
+    expect(notifications).toEqual(["Plan mode on", "Implementation mode on"]);
   });
 
   it("/extensions install invokes the in-app installer", async () => {

--- a/src/slashCommands.ts
+++ b/src/slashCommands.ts
@@ -38,6 +38,8 @@ export interface SlashCommandContext {
   setTheme: (id: string) => void;
   listThemes: () => { id: string; label: string }[];
   setModel: (id: string) => Promise<void>;
+  setPlanMode?: (enabled: boolean) => void;
+  getPlanMode?: () => boolean;
   resetLayout: () => void;
   listExtensions: () => string[];
   installExtension: (spec: string) => Promise<string>;
@@ -209,6 +211,65 @@ export function buildBuiltinSlashCommands(): SlashCommand[] {
           return;
         }
         await ctx.setModel(id);
+      },
+    },
+    {
+      name: "plan",
+      description: "Toggle planning-only mode for the active session",
+      usage: "[on|off|toggle|status]",
+      run: (args, ctx) => {
+        if (!ctx.setPlanMode || !ctx.getPlanMode) {
+          ctx.notify({
+            title: "Plan mode unavailable",
+            kind: "warning",
+          });
+          return;
+        }
+        const sub = args.trim().toLowerCase();
+        const current = ctx.getPlanMode();
+        if (!sub || sub === "toggle") {
+          const enabled = !current;
+          ctx.setPlanMode(enabled);
+          ctx.notify({
+            title: enabled ? "Plan mode on" : "Implementation mode on",
+            message: enabled
+              ? "New prompts will ask for a plan before code changes."
+              : "New prompts may make code changes.",
+            kind: "success",
+          });
+          return;
+        }
+        if (sub === "on" || sub === "true") {
+          ctx.setPlanMode(true);
+          ctx.notify({
+            title: "Plan mode on",
+            message: "New prompts will ask for a plan before code changes.",
+            kind: "success",
+          });
+          return;
+        }
+        if (sub === "off" || sub === "false") {
+          ctx.setPlanMode(false);
+          ctx.notify({
+            title: "Implementation mode on",
+            message: "New prompts may make code changes.",
+            kind: "success",
+          });
+          return;
+        }
+        if (sub === "status") {
+          ctx.appendSystem(
+            current
+              ? "Plan mode is on for this session."
+              : "Implementation mode is on for this session.",
+          );
+          return;
+        }
+        ctx.notify({
+          title: `Unknown plan command: ${sub}`,
+          message: "Usage: /plan [on|off|toggle|status]",
+          kind: "error",
+        });
       },
     },
     {

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -4017,7 +4017,7 @@ body.ae-resizing-composer * {
      doesn't run under it. Bottom padding clears the Send button when
      the user types multiple lines. Right padding reserves room for the
      full three-button cluster (send + mic + conversation, out to ~108px). */
-  padding: 10px 116px 10px 14px;
+  padding: 10px 116px 10px 92px;
   font: inherit;
   outline: none;
   line-height: 1.5;
@@ -4029,6 +4029,45 @@ body.ae-resizing-composer * {
 .a2ui-chat-input-field:focus {
   border-color: var(--accent);
   box-shadow: var(--focus-ring);
+}
+
+.a2ui-chat-input-mode {
+  position: absolute;
+  left: 10px;
+  bottom: 10px;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 70px;
+  height: 26px;
+  padding: 0 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-elev);
+  color: var(--text-dim);
+  font-family: var(--font-ui);
+  font-size: var(--chrome-text-compact);
+  font-weight: 600;
+  line-height: 1;
+  cursor: pointer;
+  user-select: none;
+}
+
+.a2ui-chat-input-mode:hover {
+  border-color: var(--accent);
+  color: var(--text);
+}
+
+.a2ui-chat-input-mode:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.a2ui-chat-input-mode-plan {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  color: var(--accent);
 }
 
 .a2ui-chat-input-send {

--- a/src/types/tab.ts
+++ b/src/types/tab.ts
@@ -148,6 +148,10 @@ export interface Tab {
   model: string;
   /** Active pi reasoning/thinking level for this session, when available. */
   thinkingLevel?: string;
+  /** User-facing mode for this agent session. Plan mode asks the agent to
+   *  analyze and propose a plan without making changes until the user
+   *  switches back to implementation mode. */
+  planMode?: boolean;
   contextUsage?: ContextUsageState;
   // Rolling buffer of bash output for this tab. The Terminal component
   // writes to xterm directly for the active tab; this buffer survives
@@ -262,6 +266,7 @@ export function makeEmptyTab(
     queuedMessages: [],
     canvas: null,
     model: "",
+    planMode: false,
     terminalBuffer: "",
     projectId,
   };


### PR DESCRIPTION
## Summary
- add per-agent-tab plan mode state surfaced through the composer chip and /plan [on|off|toggle|status]
- forward planMode through the Tauri send_message bridge into the agent runtime
- enforce plan mode by wrapping prompts and blocking mutating tools (write/edit/bash/task/task_batch/startTask/writeShell) at the source guard

## Research
- Reviewed the official OpenAI Agents Python SDK docs for function tools and human-in-the-loop approvals/resumable run state.
- The SDK has useful approval primitives, but Aethon's agent runtime is TypeScript/pi over the existing Tauri stdio bridge, so a Py SDK drop-in would add another runtime boundary instead of protecting the tools actually used here.
- Implemented the native Aethon path instead: mode state lives with the tab, every prompt carries the mode flag, and the agent tool guard enforces it.

Docs reviewed:
- https://openai.github.io/openai-agents-python/human_in_the_loop/
- https://openai.github.io/openai-agents-python/tools/
- https://openai.github.io/openai-agents-python/ref/tool/
- https://openai.github.io/openai-agents-python/agents/

## Peer review
- Codex peer review found three issues before PR: steering sends skipped the flag, prompt-only plan mode lacked enforcement, and Shift+Tab would trap reverse focus.
- Addressed all three before opening this PR: steering carries planMode, the source guard blocks mutating tools, and the UI uses /plan plus a composer chip instead of hijacking Shift+Tab.

## Validation
- bunx vitest run src/hooks/useChat.test.ts src/extensions/default-layout/chat.test.tsx src/eventRoutes/chatInput.test.ts src/slashCommands.test.ts agent/source-guard.test.ts agent/dispatcher.test.ts
- bun run typecheck
- bun run lint
- bunx vitest run
- bun run build
- nix develop -c cargo test --manifest-path src-tauri/Cargo.toml --lib -p aethon agent_commands
- nix develop -c check

Notes:
- Vitest still emits existing test-environment warnings/logs, including jsdom canvas getContext not implemented.
- Vite build still emits the existing large chunk warning.