### PR TITLE
fix: name background agent completion toasts

### DIFF
--- a/src/hooks/useNotifications.test.ts
+++ b/src/hooks/useNotifications.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { makeEmptyTab, type Tab } from "../types/tab";
+import { useNotifications } from "./useNotifications";
+
+function ref<T>(current: T): { current: T } {
+  return { current };
+}
+
+function hiddenAgentTab(): Tab {
+  return {
+    ...makeEmptyTab("hidden", "NXV publish", "nxv", "agent"),
+    cwd: "/repo/nxv",
+    messages: [
+      {
+        id: "done",
+        role: "agent",
+        text: "Workflow lint is clean. Waiting for your next instruction.",
+      },
+    ],
+  };
+}
+
+describe("useNotifications", () => {
+  it("names completed background workspace turns in the in-app toast", async () => {
+    const focusSpy = vi.spyOn(document, "hasFocus").mockReturnValue(true);
+    let state: Record<string, unknown> = {
+      activeTabId: "koban",
+      tabs: [makeEmptyTab("koban", "koban", "koban", "agent")],
+      persistedTabBuckets: {
+        "nxv::workspace::publish": {
+          tabs: [hiddenAgentTab()],
+          activeTabId: "hidden",
+        },
+      },
+    };
+    const setState = vi.fn((update) => {
+      state = typeof update === "function" ? update(state) : update;
+      stateRef.current = state;
+    });
+    const stateRef = ref(state);
+    const { result } = renderHook(() =>
+      useNotifications({
+        setState,
+        stateRef,
+        notifyOnCompletionRef: ref(true),
+        notifyMinDurationMsRef: ref(0),
+        resolveShellWriteConsent: vi.fn(),
+        resolveShellCloseConsent: vi.fn(),
+        resolveWorkspacePrompt: vi.fn(),
+      }),
+    );
+
+    await act(async () => {
+      await result.current.maybeFireCompletionNotification({
+        tabId: "hidden",
+        turnDurationMs: 1,
+      });
+    });
+
+    expect(state.notifications).toEqual([
+      expect.objectContaining({
+        id: "agent-complete:hidden",
+        title: "NXV publish — ready for your reply",
+        message: "Workflow lint is clean. Waiting for your next instruction.",
+        durationMs: 10000,
+        actions: [{ label: "View", action: "activate-tab:hidden" }],
+      }),
+    ]);
+    focusSpy.mockRestore();
+  });
+});

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -44,6 +44,25 @@ export interface UseNotificationsActions {
 
 const MAX_VISIBLE = 6;
 
+function findTabForNotification(
+  state: Record<string, unknown>,
+  tabId: string,
+): Tab | undefined {
+  const tabs = (state.tabs as Tab[] | undefined) ?? [];
+  const visible = tabs.find((t) => t.id === tabId);
+  if (visible) return visible;
+
+  const buckets = state.persistedTabBuckets as
+    | Record<string, { tabs?: Tab[] }>
+    | undefined;
+  if (!buckets) return undefined;
+  for (const bucket of Object.values(buckets)) {
+    const hidden = bucket.tabs?.find((t) => t.id === tabId);
+    if (hidden) return hidden;
+  }
+  return undefined;
+}
+
 /**
  * Toast stack rendered at App root. Used for mutation feedback (theme
  * set, layout switched), agent-pushed `notice`s, and OS-level completion
@@ -148,8 +167,7 @@ export function useNotifications(
     const isActiveTab = stateRef.current.activeTabId === input.tabId;
     if (windowFocused && isActiveTab) return;
 
-    const tabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
-    const tab = tabs.find((t) => t.id === input.tabId);
+    const tab = findTabForNotification(stateRef.current, input.tabId);
     const lastMsg = tab?.messages?.at(-1);
     const snippet =
       typeof lastMsg?.text === "string" && lastMsg.text.length > 0
@@ -166,7 +184,7 @@ export function useNotifications(
           : "Agent ready for your reply",
         message: snippet,
         kind: "success",
-        durationMs: 6000,
+        durationMs: 10000,
         actions: [{ label: "View", action: `activate-tab:${input.tabId}` }],
       });
       return;


### PR DESCRIPTION
## Summary
- look up completed agent tabs across visible tabs and persisted background workspace buckets before building completion notifications
- show the real background session label and final response snippet in the ready-for-reply toast/OS notification
- keep the in-app completion toast visible longer and preserve the View action back to the finished session

## Why
When an agent completed in a background workspace, the completion notification only searched the currently visible tab list. Users switching away from an active NXV/worktree session could see generic completion feedback instead of a clear indicator for which agent was done and ready for input.

## Validation
- `bunx vitest run src/hooks/useNotifications.test.ts src/hooks/useDerivedRenderState.test.ts src/hooks/projectOps/agentActivity.test.ts src/hooks/bridgeMessageHandlers/stashedTabs.test.ts src/eventRoutes/notifications.test.ts`
- `bun run typecheck`
- `bunx eslint src/hooks/useNotifications.ts src/hooks/useNotifications.test.ts`
