### PR TITLE
feat: add Codex-style file change tool cards

### DIFF
--- a/agent/session-history.test.ts
+++ b/agent/session-history.test.ts
@@ -143,6 +143,58 @@ describe("parseSessionHistoryLines", () => {
     ]);
   });
 
+  it("restores edit tool cards with file-change metadata", () => {
+    const lines = [
+      JSON.stringify({
+        type: "message",
+        id: "assistant-tool",
+        message: {
+          role: "assistant",
+          timestamp: 1_000,
+          content: [
+            {
+              type: "toolCall",
+              id: "call-edit-1",
+              name: "edit",
+              arguments: { path: "src/App.tsx" },
+            },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: "message",
+        id: "result-tool",
+        message: {
+          role: "toolResult",
+          toolCallId: "call-edit-1",
+          toolName: "edit",
+          content: [
+            {
+              type: "text",
+              text: "--- a/src/App.tsx\n+++ b/src/App.tsx\n-old\n+new",
+            },
+          ],
+          isError: false,
+          timestamp: 2_500,
+        },
+      }),
+    ];
+
+    const restored = parseSessionHistoryLines(lines);
+    expect(restored[0]?.a2ui?.components[0]).toMatchObject({
+      type: "tool-card",
+      props: {
+        toolName: "edit",
+        fileChange: {
+          kind: "edited",
+          path: "src/App.tsx",
+          additions: 1,
+          deletions: 1,
+        },
+      },
+    });
+  });
+
   it("preserves failed tool result state when restoring tool cards", () => {
     const restored = parseSessionHistoryLines([
       JSON.stringify({

--- a/agent/session-history/parse-pi.ts
+++ b/agent/session-history/parse-pi.ts
@@ -82,6 +82,7 @@ interface RestoredToolCall {
   uiId: string;
   toolName: string;
   argsSummary: string;
+  args?: unknown;
   startedAt?: number;
 }
 
@@ -91,6 +92,7 @@ function toolCardMessage(opts: {
   argsSummary: string;
   result?: unknown;
   isError?: boolean;
+  args?: unknown;
   startedAt?: number;
   endedAt?: number;
 }): RestoredChatMessage {
@@ -102,6 +104,7 @@ function toolCardMessage(opts: {
       id: opts.uiId,
       toolName: opts.toolName,
       argsSummary: opts.argsSummary,
+      ...(opts.args !== undefined ? { args: opts.args } : {}),
       ...(opts.result !== undefined ? { result: opts.result } : {}),
       ...(opts.isError !== undefined ? { isError: opts.isError } : {}),
       ...(opts.startedAt !== undefined ? { startedAt: opts.startedAt } : {}),
@@ -165,6 +168,7 @@ export function parseSessionHistoryLines(
           uiId: cached.uiId,
           toolName: cached.toolName,
           argsSummary: cached.argsSummary,
+          ...(cached.args !== undefined ? { args: cached.args } : {}),
           result,
           isError,
           ...(cached.startedAt !== undefined
@@ -249,6 +253,7 @@ export function parseSessionHistoryLines(
           uiId,
           toolName,
           argsSummary,
+          ...(args !== undefined ? { args } : {}),
           ...(startedAt !== undefined ? { startedAt } : {}),
         }),
       );
@@ -257,6 +262,7 @@ export function parseSessionHistoryLines(
         uiId,
         toolName,
         argsSummary,
+        ...(args !== undefined ? { args } : {}),
         ...(startedAt !== undefined ? { startedAt } : {}),
       });
     }

--- a/agent/state.ts
+++ b/agent/state.ts
@@ -233,6 +233,8 @@ export interface TabRecord {
       name: string;
       summary: string;
       uiId: string;
+      args?: unknown;
+      rootPath?: string;
       bashStream?: BashTerminalStreamState;
       taskPartialStream?: BashTerminalStreamState;
       /** Epoch ms — when tool_execution_start fired. Used by the M6 P4

--- a/agent/tab-lifecycle.test.ts
+++ b/agent/tab-lifecycle.test.ts
@@ -371,6 +371,75 @@ describe("toolCardPayload", () => {
     expect(code.props.language).toBe("tsx");
   });
 
+  it("adds file-change metadata for edit tools", () => {
+    const payload = toolCardPayload({
+      id: "tool-c1",
+      toolName: "edit",
+      argsSummary: "src/App.tsx",
+      args: { path: "src/App.tsx" },
+      rootPath: "/repo",
+      result: "--- a/src/App.tsx\n+++ b/src/App.tsx\n-old\n+new",
+    });
+
+    expect(payload).toMatchObject({
+      components: [
+        {
+          props: {
+            fileChange: {
+              kind: "edited",
+              path: "src/App.tsx",
+              rootPath: "/repo",
+              preview: expect.stringContaining("+new"),
+              additions: 1,
+              deletions: 1,
+            },
+          },
+        },
+      ],
+    });
+  });
+
+  it("classifies write tools as created when the result says a file was created", () => {
+    const payload = toolCardPayload({
+      id: "tool-c1",
+      toolName: "write",
+      argsSummary: "src/new.ts",
+      args: { path: "src/new.ts" },
+      result: "Created file src/new.ts\n+export const ok = true;",
+    });
+
+    expect(payload).toMatchObject({
+      components: [
+        {
+          props: {
+            fileChange: {
+              kind: "created",
+              path: "src/new.ts",
+              additions: 1,
+            },
+          },
+        },
+      ],
+    });
+  });
+
+  it("keeps malformed edit args on the generic output path", () => {
+    const payload = toolCardPayload({
+      id: "tool-c1",
+      toolName: "edit",
+      argsSummary: "",
+      args: {},
+      result: "edited",
+    });
+
+    const root = payload.components[0] as {
+      props: Record<string, unknown>;
+      children: unknown[];
+    };
+    expect(root.props.fileChange).toBeUndefined();
+    expect(root.children[0]).toMatchObject({ type: "code" });
+  });
+
   it("marks cancelled cards as a terminal state", () => {
     const payload = toolCardPayload({
       id: "tool-c1",

--- a/agent/tab-lifecycle/events.ts
+++ b/agent/tab-lifecycle/events.ts
@@ -103,7 +103,7 @@ function responseMessageId(
 
 function currentToolRoot(state: AethonAgentState, tabId: string): string {
   return (
-    state.tabProjectCwds.get(tabId) ??
+    state.tabProjectCwds?.get(tabId) ??
     state.currentProjectCwd ??
     state.userDir ??
     process.cwd()

--- a/agent/tab-lifecycle/events.ts
+++ b/agent/tab-lifecycle/events.ts
@@ -101,6 +101,15 @@ function responseMessageId(
   return startResponseSegment(rec, canonical);
 }
 
+function currentToolRoot(state: AethonAgentState, tabId: string): string {
+  return (
+    state.tabProjectCwds.get(tabId) ??
+    state.currentProjectCwd ??
+    state.userDir ??
+    process.cwd()
+  );
+}
+
 function rollResponseMessage(rec: TabRecord): void {
   rec.activeResponseMessageId = undefined;
   rec.activeResponseCanonicalId = undefined;
@@ -328,16 +337,21 @@ export function handleSessionEvent(
       const summary = summarizeToolArgs(ev.toolName, ev.args);
       const startedAt = Date.now();
       const uiId = `tool-${++rec.toolCardSeq}-${ev.toolCallId}`;
+      const rootPath = currentToolRoot(state, tabId);
       rec.toolArgsCache.set(ev.toolCallId, {
         name: ev.toolName,
         summary,
         uiId,
+        args: ev.args,
+        rootPath,
         startedAt,
       });
       const payload = toolCardPayload({
         id: uiId,
         toolName: ev.toolName,
         argsSummary: summary,
+        args: ev.args,
+        rootPath,
         startedAt,
       });
       deps.send({ type: "a2ui", tabId, id: uiId, payload });
@@ -374,6 +388,8 @@ export function handleSessionEvent(
             name: ev.toolName,
             summary: summarizeToolArgs(ev.toolName, ev.args),
             uiId: `tool-${++rec.toolCardSeq}-${ev.toolCallId}`,
+            args: ev.args,
+            rootPath: currentToolRoot(state, tabId),
           };
           rec.toolArgsCache.set(ev.toolCallId, cached);
         }
@@ -393,6 +409,8 @@ export function handleSessionEvent(
             name: ev.toolName,
             summary: summarizeToolArgs(ev.toolName, ev.args),
             uiId: `tool-${++rec.toolCardSeq}-${ev.toolCallId}`,
+            args: ev.args,
+            rootPath: currentToolRoot(state, tabId),
             startedAt: Date.now(),
           };
           rec.toolArgsCache.set(ev.toolCallId, cached);
@@ -401,6 +419,8 @@ export function handleSessionEvent(
           id: cached.uiId,
           toolName: ev.toolName,
           argsSummary: cached.summary,
+          args: cached.args ?? ev.args,
+          rootPath: cached.rootPath,
           result: ev.partialResult,
           startedAt: cached.startedAt,
         });
@@ -433,6 +453,8 @@ export function handleSessionEvent(
         id: uiId,
         toolName: ev.toolName,
         argsSummary: cached?.summary ?? "",
+        args: cached?.args,
+        rootPath: cached?.rootPath,
         result: ev.result,
         isError: ev.isError,
         ...(cached?.status !== undefined ? { status: cached.status } : {}),

--- a/agent/tab-lifecycle/tools.ts
+++ b/agent/tab-lifecycle/tools.ts
@@ -42,6 +42,8 @@ export function cancelRunningToolCards(
       id: cached.uiId,
       toolName: cached.name,
       argsSummary: cached.summary,
+      args: cached.args,
+      rootPath: cached.rootPath,
       result: "Cancelled by user.",
       status: "cancelled",
       startedAt: cached.startedAt,

--- a/agent/tool-card.ts
+++ b/agent/tool-card.ts
@@ -1,5 +1,14 @@
 const MAX_IMAGES_PER_RESULT = 4;
 
+export interface ToolFileChange {
+  kind: "edited" | "created";
+  path: string;
+  rootPath?: string;
+  preview?: string;
+  additions?: number;
+  deletions?: number;
+}
+
 function firstLine(value: unknown, max = 180): string {
   if (typeof value !== "string") return "";
   const trimmed = value.trim();
@@ -78,6 +87,54 @@ export function summarizeToolArgs(toolName: string, args: unknown): string {
 
 function truncate(text: string, max: number): string {
   return text.length > max ? text.slice(0, max - 1) + "…" : text;
+}
+
+function stringArg(args: unknown, key: string): string {
+  if (!args || typeof args !== "object") return "";
+  const value = (args as Record<string, unknown>)[key];
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function countDiffStats(text: string): { additions: number; deletions: number } {
+  let additions = 0;
+  let deletions = 0;
+  for (const line of text.split(/\r?\n/)) {
+    if (line.startsWith("+++") || line.startsWith("---")) continue;
+    if (line.startsWith("+")) additions += 1;
+    else if (line.startsWith("-")) deletions += 1;
+  }
+  return { additions, deletions };
+}
+
+function writeLooksCreated(text: string): boolean {
+  return /\b(created|new file|wrote new|created file)\b/i.test(text);
+}
+
+function fileChangeForTool(opts: {
+  toolName: string;
+  args?: unknown;
+  result?: unknown;
+  rootPath?: string;
+}): ToolFileChange | undefined {
+  if (opts.toolName !== "edit" && opts.toolName !== "write") return undefined;
+  const path = stringArg(opts.args, "path");
+  if (!path) return undefined;
+  const extracted =
+    opts.result !== undefined ? extractToolContent(opts.result) : undefined;
+  const preview = extracted?.text ? truncate(extracted.text, 4000) : undefined;
+  const stats = preview ? countDiffStats(preview) : undefined;
+  const kind =
+    opts.toolName === "write" && preview && writeLooksCreated(preview)
+      ? "created"
+      : "edited";
+  return {
+    kind,
+    path,
+    ...(opts.rootPath ? { rootPath: opts.rootPath } : {}),
+    ...(preview ? { preview } : {}),
+    ...(stats && stats.additions > 0 ? { additions: stats.additions } : {}),
+    ...(stats && stats.deletions > 0 ? { deletions: stats.deletions } : {}),
+  };
 }
 
 const EXTENSION_LANGUAGES: Record<string, string> = {
@@ -213,6 +270,9 @@ export function toolCardPayload(opts: {
   id: string;
   toolName: string;
   argsSummary: string;
+  args?: unknown;
+  rootPath?: string;
+  fileChange?: ToolFileChange;
   result?: unknown;
   isError?: boolean;
   status?: "cancelled";
@@ -223,6 +283,9 @@ export function toolCardPayload(opts: {
     id,
     toolName,
     argsSummary,
+    args,
+    rootPath,
+    fileChange,
     result,
     isError,
     status,
@@ -230,6 +293,8 @@ export function toolCardPayload(opts: {
     endedAt,
   } = opts;
   const children: unknown[] = [];
+  const toolFileChange =
+    fileChange ?? fileChangeForTool({ toolName, args, result, rootPath });
   if (result !== undefined) {
     const extracted = extractToolContent(result);
     if (extracted.text) {
@@ -281,6 +346,7 @@ export function toolCardPayload(opts: {
           ...(endedAt !== undefined ? { endedAt } : {}),
           ...(isError ? { isError: true } : {}),
           ...(status !== undefined ? { status } : {}),
+          ...(toolFileChange ? { fileChange: toolFileChange } : {}),
         },
         children,
       },

--- a/src/eventRoutes/editor.test.ts
+++ b/src/eventRoutes/editor.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { handleEditorCanvas, handleFileTree } from "./editor";
+import { handleEditorCanvas, handleFileTree, handleToolCardFile } from "./editor";
 import { buildRouteFixture } from "./testFixtures";
 
 const editorEvent = (eventType: string, data: unknown) => ({
@@ -313,5 +313,60 @@ describe("handleFileTree", () => {
       fx.ctx,
     );
     expect(claimed).toBe(false);
+  });
+});
+
+describe("handleToolCardFile", () => {
+  it("opens a tool-card file in an editor tab", () => {
+    const fx = buildRouteFixture({
+      state: { project: { path: "/projects/aethon" } },
+    });
+    const claimed = handleToolCardFile(
+      {
+        component: { id: "tool-1", type: "tool-card" },
+        eventType: "tool-file-open",
+        data: { filePath: "src/App.tsx" },
+      },
+      fx.ctx,
+    );
+    expect(claimed).toBe(true);
+    expect(fx.mocks.newEditorTab).toHaveBeenCalledWith(
+      "/projects/aethon/src/App.tsx",
+      { rootPath: "/projects/aethon" },
+    );
+  });
+
+  it("opens a tool-card file in a diff tab", () => {
+    const fx = buildRouteFixture();
+    const claimed = handleToolCardFile(
+      {
+        component: { id: "tool-1", type: "tool-card" },
+        eventType: "tool-file-diff",
+        data: {
+          filePath: "/projects/aethon/src/App.tsx",
+          rootPath: "/projects/aethon",
+        },
+      },
+      fx.ctx,
+    );
+    expect(claimed).toBe(true);
+    expect(fx.mocks.newEditorTab).toHaveBeenCalledWith(
+      "/projects/aethon/src/App.tsx",
+      { diff: true, rootPath: "/projects/aethon" },
+    );
+  });
+
+  it("ignores unrelated tool-card events", () => {
+    const fx = buildRouteFixture();
+    expect(
+      handleToolCardFile(
+        {
+          component: { id: "tool-1", type: "tool-card" },
+          eventType: "tool-noop",
+          data: {},
+        },
+        fx.ctx,
+      ),
+    ).toBe(false);
   });
 });

--- a/src/eventRoutes/editor.ts
+++ b/src/eventRoutes/editor.ts
@@ -31,6 +31,55 @@ function asRecord(data: unknown): Record<string, unknown> {
     : {};
 }
 
+function isAbsolutePath(path: string): boolean {
+  return (
+    path.startsWith("/") ||
+    /^[A-Za-z]:[\\/]/.test(path) ||
+    /^[/\\]{2}[^/\\]/.test(path)
+  );
+}
+
+function joinRoot(root: string, relativePath: string): string {
+  const separator = root.includes("\\") && !root.includes("/") ? "\\" : "/";
+  const rel = relativePath
+    .replace(/^[\\/]+/, "")
+    .split(/[\\/]+/)
+    .filter((part) => part.length > 0 && part !== ".")
+    .join(separator);
+  return `${root.replace(/[\\/]+$/, "")}${separator}${rel}`;
+}
+
+function activeRoot(ctx: EventRouteContext): string {
+  const state = ctx.stateRef.current;
+  const payloadRoot = (state.project as { path?: string } | undefined)?.path;
+  const activeTabId =
+    typeof state.activeTabId === "string" ? state.activeTabId : "";
+  const tabs =
+    (state.tabs as
+      | Array<{ id?: string; cwd?: string; editor?: { rootPath?: string } }>
+      | undefined) ?? [];
+  const activeTab = tabs.find((tab) => tab.id === activeTabId);
+  return activeTab?.editor?.rootPath ?? activeTab?.cwd ?? payloadRoot ?? "";
+}
+
+function resolveToolFileTarget(
+  data: unknown,
+  ctx: EventRouteContext,
+): { filePath: string; rootPath?: string } | null {
+  const payload = asRecord(data);
+  const rawPath = typeof payload.filePath === "string" ? payload.filePath : "";
+  if (!rawPath) return null;
+  const payloadRoot =
+    typeof payload.rootPath === "string" ? payload.rootPath.trim() : "";
+  const rootPath = payloadRoot || activeRoot(ctx);
+  const filePath =
+    !isAbsolutePath(rawPath) && rootPath ? joinRoot(rootPath, rawPath) : rawPath;
+  return {
+    filePath,
+    ...(rootPath ? { rootPath } : {}),
+  };
+}
+
 const FILES_SIDEBAR_MIN_WIDTH = 220;
 const FILES_SIDEBAR_MAX_WIDTH = 640;
 
@@ -132,6 +181,25 @@ export const handleEditorCanvas: EventRouteHandler = async (
     default:
       return false;
   }
+};
+
+export const handleToolCardFile: EventRouteHandler = (
+  event: EventRouteEvent,
+  ctx: EventRouteContext,
+): boolean => {
+  if (
+    event.eventType !== "tool-file-open" &&
+    event.eventType !== "tool-file-diff"
+  ) {
+    return false;
+  }
+  const target = resolveToolFileTarget(event.data, ctx);
+  if (!target) return true;
+  ctx.newEditorTab(target.filePath, {
+    ...(target.rootPath ? { rootPath: target.rootPath } : {}),
+    ...(event.eventType === "tool-file-diff" ? { diff: true } : {}),
+  });
+  return true;
 };
 
 export const handleFileTree: EventRouteHandler = (

--- a/src/eventRoutes/editor.ts
+++ b/src/eventRoutes/editor.ts
@@ -23,30 +23,16 @@ import type {
   EventRouteEvent,
   EventRouteHandler,
 } from "./types";
+import {
+  isAbsolutePath,
+  joinRoot,
+} from "../hooks/bridgeMessageHandlers/editorQuery";
 import { WORKSTATION_AREAS } from "../hooks/useFocus";
 
 function asRecord(data: unknown): Record<string, unknown> {
   return data && typeof data === "object"
     ? (data as Record<string, unknown>)
     : {};
-}
-
-function isAbsolutePath(path: string): boolean {
-  return (
-    path.startsWith("/") ||
-    /^[A-Za-z]:[\\/]/.test(path) ||
-    /^[/\\]{2}[^/\\]/.test(path)
-  );
-}
-
-function joinRoot(root: string, relativePath: string): string {
-  const separator = root.includes("\\") && !root.includes("/") ? "\\" : "/";
-  const rel = relativePath
-    .replace(/^[\\/]+/, "")
-    .split(/[\\/]+/)
-    .filter((part) => part.length > 0 && part !== ".")
-    .join(separator);
-  return `${root.replace(/[\\/]+$/, "")}${separator}${rel}`;
 }
 
 function activeRoot(ctx: EventRouteContext): string {
@@ -73,7 +59,9 @@ function resolveToolFileTarget(
     typeof payload.rootPath === "string" ? payload.rootPath.trim() : "";
   const rootPath = payloadRoot || activeRoot(ctx);
   const filePath =
-    !isAbsolutePath(rawPath) && rootPath ? joinRoot(rootPath, rawPath) : rawPath;
+    !isAbsolutePath(rawPath) && rootPath
+      ? joinRoot(rootPath, rawPath)
+      : rawPath;
   return {
     filePath,
     ...(rootPath ? { rootPath } : {}),

--- a/src/eventRoutes/index.ts
+++ b/src/eventRoutes/index.ts
@@ -67,7 +67,7 @@ import {
   handleSidebarRenameProject,
   handleSidebarSetProjectWorkspaceBase,
 } from "./sidebar";
-import { handleEditorCanvas, handleFileTree } from "./editor";
+import { handleEditorCanvas, handleFileTree, handleToolCardFile } from "./editor";
 import {
   handleProjectsDashboard,
   handleProjectDashboard,
@@ -101,8 +101,9 @@ export const BUILTIN_ROUTE_TABLE: ReadonlyMap<string, readonly EventRouteHandler
     // handleChatInput unchanged.
     ["type:chat-input", [handleQueuedMessages, handleChatInput]],
     ["type:composer-visibility-pills", [handleComposerPills]],
-    ["type:chat-history", [handleChatMessages, handleSessionBranch]],
-    ["type:main-canvas", [handleChatMessages, handleSessionBranch]],
+    ["type:chat-history", [handleToolCardFile, handleChatMessages, handleSessionBranch]],
+    ["type:main-canvas", [handleToolCardFile, handleChatMessages, handleSessionBranch]],
+    ["type:tool-card", [handleToolCardFile]],
     ["type:queued-messages-popover", [handleQueuedMessages]],
     ["type:empty-state", [handleEmptyState]],
     // Workspace landing — session rows share dashboard restore/delete

--- a/src/extensions/default-layout/chat.test.tsx
+++ b/src/extensions/default-layout/chat.test.tsx
@@ -527,6 +527,68 @@ describe("ChatInput", () => {
     });
   });
 
+  it("handles nested tool-file events without forwarding them to the agent", async () => {
+    invokeMock.mockResolvedValue(undefined);
+    invokeMock.mockClear();
+    const registry = new ExtensionRegistry();
+    registry.register({
+      name: "test-tool-card",
+      components: { "tool-card": ToolCard },
+    });
+    const onEvent = vi.fn();
+    render(
+      <ExtensionRegistryProvider registry={registry}>
+        <ChatHistory
+          component={{
+            id: "chat-history",
+            type: "chat-history",
+            props: { messages: { $ref: "/messages" } },
+          }}
+          state={{
+            messages: [
+              {
+                id: "1",
+                role: "agent",
+                a2ui: {
+                  components: [
+                    {
+                      id: "tool-edit-preview",
+                      type: "tool-card",
+                      props: {
+                        title: "edit",
+                        endedAt: 2,
+                        fileChange: {
+                          kind: "edited",
+                          path: "src/App.tsx",
+                          rootPath: "/repo/aethon",
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          }}
+          onEvent={onEvent}
+        />
+      </ExtensionRegistryProvider>,
+    );
+
+    fireEvent.click(screen.getByText("Edited 1 file"));
+    fireEvent.click(screen.getByTitle("Open src/App.tsx"));
+
+    expect(onEvent).toHaveBeenCalledWith(
+      "tool-file-open",
+      { filePath: "src/App.tsx", rootPath: "/repo/aethon" },
+      "tool-edit-preview",
+    );
+    await Promise.resolve();
+    expect(invokeMock).not.toHaveBeenCalledWith(
+      "dispatch_a2ui_event",
+      expect.anything(),
+    );
+  });
+
   it("keeps the latest pill hidden when the feed is not scrollable", () => {
     renderHistory({
       messages: [{ id: "1", role: "agent", text: "short answer" }],

--- a/src/extensions/default-layout/message-list.tsx
+++ b/src/extensions/default-layout/message-list.tsx
@@ -16,7 +16,10 @@ import type {
   StringValue,
 } from "../../types/a2ui";
 import A2UIRenderer from "../../components/A2UIRenderer";
-import type { BuiltinComponentProps } from "../../components/A2UIRenderer";
+import type {
+  A2UIEventHandler,
+  BuiltinComponentProps,
+} from "../../components/A2UIRenderer";
 import { resolveString } from "../../utils/dataBinding";
 import { resolvePointer } from "../../utils/jsonPointer";
 import { splitThinkingBlocks } from "../../utils/thinkingBlocks";
@@ -47,6 +50,15 @@ import { ImageLightbox } from "./image-lightbox";
 // overflow check that gates the scroll-to-bottom pill.
 const DEFAULT_AT_BOTTOM_THRESHOLD = 60;
 const FENCED_CODE_MARKER_RE = /(^|\n)(```|~~~)/;
+
+function forwardNestedA2UIEvent(
+  onEvent: BuiltinComponentProps["onEvent"] | undefined,
+): A2UIEventHandler {
+  return (component, eventType, data) => {
+    onEvent?.(eventType, data, component.id);
+    return eventType === "tool-file-open" || eventType === "tool-file-diff";
+  };
+}
 
 // tabId → the message id at the top of the viewport when the tab was left
 // scrolled-up (absent when it was left following at the bottom). The message
@@ -412,9 +424,7 @@ export const ChatMessageRow = memo(
           <A2UIRenderer
             payload={message.a2ui}
             state={state}
-            onEvent={(component, eventType, data) =>
-              onEvent?.(eventType, data, component.id)
-            }
+            onEvent={forwardNestedA2UIEvent(onEvent)}
             tabId={tabId}
           />
         )}
@@ -576,9 +586,7 @@ function ToolGroupRow({
                 key={m.id}
                 payload={m.a2ui}
                 state={state}
-                onEvent={(component, eventType, data) =>
-                  onEvent?.(eventType, data, component.id)
-                }
+                onEvent={forwardNestedA2UIEvent(onEvent)}
                 tabId={tabId}
               />
             ) : null,

--- a/src/extensions/default-layout/message-list.tsx
+++ b/src/extensions/default-layout/message-list.tsx
@@ -409,7 +409,14 @@ export const ChatMessageRow = memo(
           <AttachmentGallery attachments={message.attachments} />
         )}
         {message.a2ui && (
-          <A2UIRenderer payload={message.a2ui} state={state} tabId={tabId} />
+          <A2UIRenderer
+            payload={message.a2ui}
+            state={state}
+            onEvent={(component, eventType, data) =>
+              onEvent?.(eventType, data, component.id)
+            }
+            tabId={tabId}
+          />
         )}
         {canBranch && (
           <div
@@ -532,12 +539,14 @@ function ToolGroupRow({
   group,
   state,
   tabId,
+  onEvent,
   expanded,
   onToggle,
 }: {
   group: Extract<MessageGroup, { type: "tool-group" }>;
   state: Record<string, unknown>;
   tabId?: string;
+  onEvent?: BuiltinComponentProps["onEvent"];
   expanded: boolean;
   onToggle: () => void;
 }) {
@@ -567,6 +576,9 @@ function ToolGroupRow({
                 key={m.id}
                 payload={m.a2ui}
                 state={state}
+                onEvent={(component, eventType, data) =>
+                  onEvent?.(eventType, data, component.id)
+                }
                 tabId={tabId}
               />
             ) : null,
@@ -913,6 +925,7 @@ function VirtualMessageList({
               group={group}
               state={state}
               tabId={tabId}
+              onEvent={onEvent}
               expanded={expandedGroups.has(group.id)}
               onToggle={() => toggleGroup(group.id)}
             />

--- a/src/extensions/default-layout/tool-card.subagent.test.tsx
+++ b/src/extensions/default-layout/tool-card.subagent.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { SubagentResult, ToolCard } from "./tool-card";
 import type { A2UIComponent } from "../../types/a2ui";
 
@@ -103,5 +103,79 @@ describe("ToolCard subagent activity", () => {
       />,
     );
     expect(screen.getByText(/Line one/)).toBeTruthy();
+  });
+});
+
+describe("ToolCard file changes", () => {
+  it("renders and expands an edited file preview", () => {
+    render(
+      <ToolCard
+        component={{
+          id: "tool-edit",
+          type: "tool-card",
+          props: {
+            title: "edit",
+            toolName: "edit",
+            startedAt: 1,
+            endedAt: 2,
+            fileChange: {
+              kind: "edited",
+              path: "src/App.tsx",
+              rootPath: "/repo",
+              preview: "--- a/src/App.tsx\n+++ b/src/App.tsx\n-old\n+new",
+              additions: 1,
+              deletions: 1,
+            },
+          },
+        }}
+        state={{}}
+        onEvent={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Edited 1 file"));
+
+    expect(screen.getByText("App.tsx")).toBeTruthy();
+    expect(screen.getByText("+1")).toBeTruthy();
+    expect(screen.getByText("-1")).toBeTruthy();
+    expect(screen.getByText("+new")).toBeTruthy();
+  });
+
+  it("emits file open and diff actions", () => {
+    const onEvent = vi.fn();
+    render(
+      <ToolCard
+        component={{
+          id: "tool-write",
+          type: "tool-card",
+          props: {
+            title: "write",
+            toolName: "write",
+            fileChange: {
+              kind: "created",
+              path: "src/new.ts",
+              rootPath: "/repo",
+              preview: "+export const ok = true;",
+              additions: 1,
+            },
+          },
+        }}
+        state={{}}
+        onEvent={onEvent}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Created 1 file"));
+    fireEvent.click(screen.getByTitle("Open src/new.ts"));
+    expect(onEvent).toHaveBeenCalledWith("tool-file-open", {
+      filePath: "src/new.ts",
+      rootPath: "/repo",
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Open diff for new.ts" }));
+    expect(onEvent).toHaveBeenCalledWith("tool-file-diff", {
+      filePath: "src/new.ts",
+      rootPath: "/repo",
+    });
   });
 });

--- a/src/extensions/default-layout/tool-card.tsx
+++ b/src/extensions/default-layout/tool-card.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { FileIcon } from "../../components/file-icon";
 import type {
   BooleanValue,
   NumberValue,
@@ -15,8 +16,18 @@ import type {
   SubagentProgressBatch,
   SubagentProgressEntry,
 } from "../../hooks/bridgeMessageHandlers/subagentProgress";
+import { Chevron } from "./sidebar/chevron";
 
 const TOOL_LONG_RUN_THRESHOLD_MS = 30 * 1000;
+
+interface ToolFileChange {
+  kind?: "edited" | "created";
+  path?: string;
+  rootPath?: string;
+  preview?: string;
+  additions?: number;
+  deletions?: number;
+}
 
 /** The tool-card's component id is `tool-<seq>-<callId>`; the subagent progress
  *  slice is keyed by the raw callId, so strip the prefix to look it up. */
@@ -158,10 +169,133 @@ function ToolStatusIcon({
   );
 }
 
+function basename(path: string): string {
+  return path.replace(/[/\\]+$/, "").split(/[/\\]/).pop() || path;
+}
+
+function parentPath(path: string): string {
+  const trimmed = path.replace(/[/\\]+$/, "");
+  const idx = Math.max(trimmed.lastIndexOf("/"), trimmed.lastIndexOf("\\"));
+  return idx > 0 ? trimmed.slice(0, idx) : "";
+}
+
+function previewLines(preview: string): string[] {
+  return preview.replace(/\n$/, "").split(/\r?\n/).slice(0, 80);
+}
+
+function lineTone(line: string): "add" | "del" | "hunk" | "meta" | "ctx" {
+  if (line.startsWith("+") && !line.startsWith("+++")) return "add";
+  if (line.startsWith("-") && !line.startsWith("---")) return "del";
+  if (line.startsWith("@@")) return "hunk";
+  if (
+    line.startsWith("diff --git ") ||
+    line.startsWith("index ") ||
+    line.startsWith("+++") ||
+    line.startsWith("---")
+  ) {
+    return "meta";
+  }
+  return "ctx";
+}
+
+function ToolFileChangePreview({
+  change,
+  onEvent,
+}: {
+  change: ToolFileChange;
+  onEvent: BuiltinComponentProps["onEvent"];
+}) {
+  const [open, setOpen] = useState(false);
+  const filePath = typeof change.path === "string" ? change.path : "";
+  if (!filePath) return null;
+  const kind = change.kind === "created" ? "created" : "edited";
+  const label = kind === "created" ? "Created 1 file" : "Edited 1 file";
+  const fileName = basename(filePath);
+  const dir = parentPath(filePath);
+  const additions =
+    typeof change.additions === "number" && Number.isFinite(change.additions)
+      ? change.additions
+      : 0;
+  const deletions =
+    typeof change.deletions === "number" && Number.isFinite(change.deletions)
+      ? change.deletions
+      : 0;
+  const eventPayload = {
+    filePath,
+    ...(change.rootPath ? { rootPath: change.rootPath } : {}),
+  };
+
+  return (
+    <details
+      className="ae-tool-file-change"
+      onToggle={(event) => setOpen(event.currentTarget.open)}
+    >
+      <summary className="ae-tool-file-change-summary">
+        <span className="ae-tool-file-change-chevron" aria-hidden="true">
+          <Chevron expanded={open} />
+        </span>
+        <span className="ae-tool-file-change-icon" aria-hidden="true">
+          ✎
+        </span>
+        <span className="ae-tool-file-change-label">{label}</span>
+      </summary>
+      <div className="ae-tool-file-change-body">
+        <div className="ae-tool-file-row">
+          <button
+            type="button"
+            className="ae-tool-file-open"
+            title={`Open ${filePath}`}
+            onClick={() => onEvent("tool-file-open", eventPayload)}
+          >
+            <FileIcon path={filePath} isDir={false} className="ae-tool-file-icon" />
+            <span className="ae-tool-file-name">{fileName}</span>
+            {dir ? <span className="ae-tool-file-dir">{dir}</span> : null}
+          </button>
+          <span className="ae-tool-file-stat" aria-label="Line changes">
+            {additions > 0 ? (
+              <span className="ae-tool-file-add">+{additions}</span>
+            ) : null}
+            {deletions > 0 ? (
+              <span className="ae-tool-file-del">-{deletions}</span>
+            ) : null}
+          </span>
+          <button
+            type="button"
+            className="ae-tool-file-diff"
+            title={`Open diff for ${filePath}`}
+            aria-label={`Open diff for ${fileName}`}
+            onClick={() => onEvent("tool-file-diff", eventPayload)}
+          >
+            ⧉
+          </button>
+        </div>
+        {change.preview ? (
+          <pre className="ae-tool-file-diff-preview">
+            <code>
+              {previewLines(change.preview).map((line, index) => (
+                <span
+                  key={`${index}-${line}`}
+                  className={`ae-tool-file-diff-line is-${lineTone(line)}`}
+                >
+                  <span className="ae-tool-file-diff-lineno">{index + 1}</span>
+                  <span className="ae-tool-file-diff-text">{line || " "}</span>
+                </span>
+              ))}
+            </code>
+          </pre>
+        ) : (
+          <div className="ae-tool-file-no-preview">No inline diff available</div>
+        )}
+      </div>
+    </details>
+  );
+}
+
 export function ToolCard({
   component,
   state,
   renderChildren,
+  onEvent,
 }: BuiltinComponentProps) {
   const props = component.props as {
     title?: StringValue;
@@ -171,6 +305,7 @@ export function ToolCard({
     isError?: BooleanValue;
     toolName?: StringValue;
     status?: StringValue;
+    fileChange?: ToolFileChange;
   };
   const baseTitle = props.title ? resolveString(props.title, state) : "";
   const description = props.description
@@ -209,6 +344,10 @@ export function ToolCard({
 
   const isLongRunning = running && elapsedMs >= TOOL_LONG_RUN_THRESHOLD_MS;
   const hasChildren = (component.children?.length ?? 0) > 0;
+  const fileChange =
+    props.fileChange && typeof props.fileChange === "object"
+      ? props.fileChange
+      : undefined;
 
   const timeSuffix = useMemo(() => {
     if (running) return formatToolDuration(elapsedMs);
@@ -249,11 +388,13 @@ export function ToolCard({
         {subagentProgress && (
           <SubagentActivityStack progress={subagentProgress} />
         )}
-        {hasChildren ? (
-          renderChildren?.()
-        ) : subagentProgress ? null : (
-          <div className="ae-tool-card-empty">No output</div>
+        {fileChange && (
+          <ToolFileChangePreview change={fileChange} onEvent={onEvent} />
         )}
+        {hasChildren && !fileChange?.preview ? renderChildren?.() : null}
+        {!hasChildren && !fileChange && !subagentProgress ? (
+          <div className="ae-tool-card-empty">No output</div>
+        ) : null}
       </div>
     </details>
   );

--- a/src/extensions/default-layout/tool-card.tsx
+++ b/src/extensions/default-layout/tool-card.tsx
@@ -1,10 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { FileIcon } from "../../components/file-icon";
-import type {
-  BooleanValue,
-  NumberValue,
-  StringValue,
-} from "../../types/a2ui";
+import type { BooleanValue, NumberValue, StringValue } from "../../types/a2ui";
 import type { BuiltinComponentProps } from "../../components/A2UIRenderer";
 import {
   resolveBoolean,
@@ -170,7 +166,12 @@ function ToolStatusIcon({
 }
 
 function basename(path: string): string {
-  return path.replace(/[/\\]+$/, "").split(/[/\\]/).pop() || path;
+  return (
+    path
+      .replace(/[/\\]+$/, "")
+      .split(/[/\\]/)
+      .pop() || path
+  );
 }
 
 function parentPath(path: string): string {
@@ -180,7 +181,10 @@ function parentPath(path: string): string {
 }
 
 function previewLines(preview: string): string[] {
-  return preview.replace(/\n$/, "").split(/\r?\n/).slice(0, 80);
+  return preview
+    .replace(/\r?\n$/, "")
+    .split(/\r?\n/)
+    .slice(0, 80);
 }
 
 function lineTone(line: string): "add" | "del" | "hunk" | "meta" | "ctx" {
@@ -247,7 +251,11 @@ function ToolFileChangePreview({
             title={`Open ${filePath}`}
             onClick={() => onEvent("tool-file-open", eventPayload)}
           >
-            <FileIcon path={filePath} isDir={false} className="ae-tool-file-icon" />
+            <FileIcon
+              path={filePath}
+              isDir={false}
+              className="ae-tool-file-icon"
+            />
             <span className="ae-tool-file-name">{fileName}</span>
             {dir ? <span className="ae-tool-file-dir">{dir}</span> : null}
           </button>
@@ -284,7 +292,9 @@ function ToolFileChangePreview({
             </code>
           </pre>
         ) : (
-          <div className="ae-tool-file-no-preview">No inline diff available</div>
+          <div className="ae-tool-file-no-preview">
+            No inline diff available
+          </div>
         )}
       </div>
     </details>

--- a/src/hooks/bridgeMessageHandlers/editorQuery.ts
+++ b/src/hooks/bridgeMessageHandlers/editorQuery.ts
@@ -7,7 +7,7 @@ function asRecord(data: unknown): Record<string, unknown> {
     : {};
 }
 
-function isAbsolutePath(path: string): boolean {
+export function isAbsolutePath(path: string): boolean {
   return (
     path.startsWith("/") ||
     /^[A-Za-z]:[\\/]/.test(path) ||
@@ -15,7 +15,7 @@ function isAbsolutePath(path: string): boolean {
   );
 }
 
-function joinRoot(root: string, relativePath: string): string {
+export function joinRoot(root: string, relativePath: string): string {
   const separator = root.includes("\\") && !root.includes("/") ? "\\" : "/";
   const rel = relativePath
     .replace(/^[\\/]+/, "")
@@ -75,8 +75,7 @@ export const handleEditorQuery: BridgeMessageHandler = (data, ctx) => {
     if (op !== "open_file") {
       throw new Error(`unknown editor_query op: ${op}`);
     }
-    const requestedPath =
-      typeof args.path === "string" ? args.path.trim() : "";
+    const requestedPath = typeof args.path === "string" ? args.path.trim() : "";
     if (!requestedPath) throw new Error("editor_query.open_file requires path");
 
     const cwd = typeof args.cwd === "string" ? args.cwd.trim() : "";

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -6780,7 +6780,7 @@ body.ae-resizing-terminal * {
 .ae-tool-card {
   background: transparent;
   border: 1px solid var(--border);
-  border-radius: 20px;
+  border-radius: var(--radius-md);
   padding: 0;
   min-width: 0;
   max-width: 100%;
@@ -6790,7 +6790,7 @@ body.ae-resizing-terminal * {
     background 120ms ease;
 }
 .ae-tool-card[open] {
-  border-radius: 10px;
+  border-radius: var(--radius-md);
   width: 100%;
   background: var(--bg-elev);
 }
@@ -6827,7 +6827,7 @@ body.ae-resizing-terminal * {
 .ae-tool-card[open] .ae-tool-card-summary {
   padding-bottom: 6px;
   border-bottom: 1px solid var(--border);
-  border-radius: 10px 10px 0 0;
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
   white-space: normal;
 }
 
@@ -6952,6 +6952,201 @@ body.ae-resizing-terminal * {
   color: var(--text-dim);
   font-size: var(--chrome-text-muted);
   font-style: italic;
+}
+
+.ae-tool-file-change {
+  min-width: 0;
+}
+
+.ae-tool-file-change-summary {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 100%;
+  color: var(--text-secondary, var(--text-dim));
+  font-size: var(--chrome-text);
+  list-style: none;
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+}
+
+.ae-tool-file-change-summary::-webkit-details-marker {
+  display: none;
+}
+
+.ae-tool-file-change-chevron {
+  display: inline-flex;
+  color: var(--text-dim);
+}
+
+.ae-tool-file-change-icon {
+  color: var(--text-dim);
+  font-size: var(--chrome-text);
+}
+
+.ae-tool-file-change-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 500;
+}
+
+.ae-tool-file-change-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  margin-top: 8px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--bg) 72%, transparent);
+}
+
+.ae-tool-file-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  overflow: hidden;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-elev);
+}
+
+.ae-tool-file-open {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  flex: 1;
+  min-width: 0;
+  padding: 7px 10px;
+  border: 0;
+  background: transparent;
+  color: var(--text);
+  text-align: left;
+  cursor: pointer;
+}
+
+.ae-tool-file-open:hover {
+  background: var(--bg-hover);
+}
+
+.ae-tool-file-icon {
+  flex: 0 0 auto;
+}
+
+.ae-tool-file-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-family: var(--font-mono);
+  font-size: var(--chrome-text);
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.ae-tool-file-dir {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  font-size: var(--chrome-text-muted);
+  white-space: nowrap;
+}
+
+.ae-tool-file-stat {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  flex: 0 0 auto;
+  font-family: var(--font-mono);
+  font-size: var(--chrome-text);
+  font-weight: 600;
+}
+
+.ae-tool-file-add {
+  color: var(--state-success-fg, var(--success));
+}
+
+.ae-tool-file-del {
+  color: var(--state-error-fg, var(--danger));
+}
+
+.ae-tool-file-diff {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 30px;
+  height: 30px;
+  margin-right: 4px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-dim);
+  cursor: pointer;
+}
+
+.ae-tool-file-diff:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+.ae-tool-file-diff-preview {
+  margin: 0;
+  max-height: 360px;
+  overflow: auto;
+  background: color-mix(in srgb, var(--bg) 84%, transparent);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: var(--type-code-size);
+  line-height: var(--type-code-line);
+}
+
+.ae-tool-file-diff-preview code {
+  display: block;
+  min-width: max-content;
+}
+
+.ae-tool-file-diff-line {
+  display: grid;
+  grid-template-columns: 4.25ch minmax(0, 1fr);
+  min-height: 1.55em;
+}
+
+.ae-tool-file-diff-line.is-add {
+  background: color-mix(in srgb, var(--state-success-bg, var(--success)) 28%, transparent);
+  color: var(--state-success-fg, var(--text));
+}
+
+.ae-tool-file-diff-line.is-del {
+  background: color-mix(in srgb, var(--state-error-bg, var(--danger)) 28%, transparent);
+  color: var(--state-error-fg, var(--text));
+}
+
+.ae-tool-file-diff-line.is-hunk,
+.ae-tool-file-diff-line.is-meta {
+  color: var(--text-dim);
+}
+
+.ae-tool-file-diff-lineno {
+  padding: 0 8px;
+  border-right: 1px solid var(--border);
+  color: var(--text-dim);
+  text-align: right;
+  user-select: none;
+}
+
+.ae-tool-file-diff-text {
+  padding: 0 10px;
+  white-space: pre;
+}
+
+.ae-tool-file-no-preview {
+  padding: 10px;
+  color: var(--text-dim);
+  font-size: var(--chrome-text-muted);
 }
 
 .ae-subagent-result {


### PR DESCRIPTION
## Summary
- add structured file-change metadata for edit/write tool cards
- render Codex-style edited/created file previews with inline diff snippets
- route tool-card file and diff actions into the existing Monaco editor/diff tabs

## Validation
- `bunx vitest run agent/tab-lifecycle.test.ts agent/session-history.test.ts src/extensions/default-layout/tool-card.subagent.test.tsx src/eventRoutes/editor.test.ts src/extensions/default-layout/chat.test.tsx`
- `bun run typecheck`
- `bun run lint`
- Playwright visual QA for Ember desktop, narrow chat-visible layout, and Paper theme
