### PR TITLE
fix: require explicit update install

### DIFF
--- a/src/components/UpdateBanner.module.css
+++ b/src/components/UpdateBanner.module.css
@@ -16,11 +16,12 @@
     );
   font-size: 0.85rem;
   line-height: 1.3;
-  -webkit-app-region: no-drag;
 }
 
 [data-platform="mac"] .banner {
   padding-left: max(94px, 0.9rem);
+  -webkit-app-region: drag;
+  app-region: drag;
 }
 
 .message {
@@ -44,6 +45,8 @@
   display: flex;
   gap: 0.4rem;
   flex: 0 0 auto;
+  -webkit-app-region: no-drag;
+  app-region: no-drag;
 }
 
 .btn,
@@ -74,6 +77,8 @@
   align-items: center;
   gap: 0.5rem;
   flex: 0 0 220px;
+  -webkit-app-region: no-drag;
+  app-region: no-drag;
 }
 
 .progressTrack {

--- a/src/components/UpdateBanner.test.ts
+++ b/src/components/UpdateBanner.test.ts
@@ -14,6 +14,10 @@ vi.mock("@tauri-apps/plugin-opener", () => ({
   openUrl: vi.fn(() => Promise.resolve()),
 }));
 
+vi.mock("../utils/platform", () => ({
+  isMacOS: () => true,
+}));
+
 const here = dirname(fileURLToPath(import.meta.url));
 const css = readFileSync(join(here, "UpdateBanner.module.css"), "utf8");
 const themeCss = readFileSync(join(here, "../styles/themes.css"), "utf8");
@@ -43,7 +47,10 @@ function declarationValue(rule: string, property: string): string {
 }
 
 function normalizeCssValue(value: string): string {
-  return value.replace(/\s+/g, " ").replace(/\s*,\s*/g, ", ").trim();
+  return value
+    .replace(/\s+/g, " ")
+    .replace(/\s*,\s*/g, ", ")
+    .trim();
 }
 
 function themeVars(themeId: string): Record<string, string> {
@@ -80,9 +87,7 @@ function parseHexColor(hex: string): [number, number, number] {
 function relativeLuminance(hex: string): number {
   const [red, green, blue] = parseHexColor(hex).map((channel) => {
     const value = channel / 255;
-    return value <= 0.04045
-      ? value / 12.92
-      : ((value + 0.055) / 1.055) ** 2.4;
+    return value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
   });
   return 0.2126 * red + 0.7152 * green + 0.0722 * blue;
 }
@@ -97,7 +102,10 @@ function contrastRatio(foreground: string, background: string): number {
 
 function updateBannerPrimaryContrast(themeId: string): number {
   const vars = themeVars(themeId);
-  return contrastRatio(updateBannerPrimaryForegroundFor(vars), vars["--accent"]);
+  return contrastRatio(
+    updateBannerPrimaryForegroundFor(vars),
+    vars["--accent"],
+  );
 }
 
 const baseState: UpdaterStateView = {
@@ -117,6 +125,12 @@ describe("UpdateBanner stylesheet", () => {
   it("reserves macOS overlay titlebar space for the traffic lights", () => {
     expect(css).toMatch(/\[data-platform="mac"\]\s+\.banner\s*\{/);
     expect(css).toMatch(/padding-left:\s*max\(94px,\s*0\.9rem\)/);
+  });
+
+  it("keeps the banner surface draggable while preserving button clicks", () => {
+    expect(css).toMatch(/\[data-platform="mac"\]\s+\.banner\s*\{/);
+    expect(css).toMatch(/-webkit-app-region:\s*drag/);
+    expect(css).toMatch(/\.actions\s*\{[\s\S]*?-webkit-app-region:\s*no-drag/);
   });
 
   it("uses theme accent foreground fallbacks for the primary action", () => {
@@ -157,6 +171,7 @@ describe("UpdateBanner", () => {
   it("renders the available nightly update controls", () => {
     const html = render(baseState);
 
+    expect(html).toContain('data-tauri-drag-region="deep"');
     expect(html).toContain("Aethon Nightly");
     expect(html).toContain("v0.4.0-dev.66.g4e64993");
     expect(html).toContain("Install Now");

--- a/src/components/UpdateBanner.tsx
+++ b/src/components/UpdateBanner.tsx
@@ -21,6 +21,8 @@
 import type { JSX } from "react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { releaseUrl, type UpdaterStateView } from "../hooks/useUpdater";
+import { isMacOS } from "../utils/platform";
+import { onWindowDragMouseDown } from "../utils/windowDrag";
 import styles from "./UpdateBanner.module.css";
 
 export interface UpdateBannerProps {
@@ -36,10 +38,17 @@ export function UpdateBanner({
   onDismiss,
   onRetry,
 }: UpdateBannerProps): JSX.Element | null {
+  const dragProps = isMacOS()
+    ? ({
+        "data-tauri-drag-region": "deep",
+        onMouseDown: onWindowDragMouseDown,
+      } as const)
+    : {};
+
   if (state.error) {
     const url = releaseUrl(state.channel);
     return (
-      <div className={styles.banner} role="alert">
+      <div className={styles.banner} role="alert" {...dragProps}>
         <span className={`${styles.message} ${styles.errorMessage}`}>
           Update failed: {state.error}
         </span>
@@ -74,7 +83,7 @@ export function UpdateBanner({
         ? "Preparing rollback backup…"
         : "Downloading update…";
     return (
-      <div className={styles.banner}>
+      <div className={styles.banner} {...dragProps}>
         <span className={styles.message}>{phaseLabel}</span>
         <div className={styles.progressWrap}>
           <div className={styles.progressTrack}>
@@ -90,10 +99,10 @@ export function UpdateBanner({
   }
 
   return (
-    <div className={styles.banner}>
+    <div className={styles.banner} {...dragProps}>
       <span className={styles.message}>
-        {productLabel}{" "}
-        <span className={styles.version}>v{state.version}</span> is available
+        {productLabel} <span className={styles.version}>v{state.version}</span>{" "}
+        is available
       </span>
       <div className={styles.actions}>
         <button className={styles.btnPrimary} onClick={onInstallNow}>

--- a/src/components/UpdateBanner.tsx
+++ b/src/components/UpdateBanner.tsx
@@ -52,7 +52,7 @@ export function UpdateBanner({
         <span className={`${styles.message} ${styles.errorMessage}`}>
           Update failed: {state.error}
         </span>
-        <div className={styles.actions}>
+        <div className={styles.actions} data-no-drag>
           <button className={styles.btnPrimary} onClick={onRetry}>
             Try again
           </button>
@@ -85,7 +85,7 @@ export function UpdateBanner({
     return (
       <div className={styles.banner} {...dragProps}>
         <span className={styles.message}>{phaseLabel}</span>
-        <div className={styles.progressWrap}>
+        <div className={styles.progressWrap} data-no-drag>
           <div className={styles.progressTrack}>
             <div
               className={styles.progressBar}
@@ -104,7 +104,7 @@ export function UpdateBanner({
         {productLabel} <span className={styles.version}>v{state.version}</span>{" "}
         is available
       </span>
-      <div className={styles.actions}>
+      <div className={styles.actions} data-no-drag>
         <button className={styles.btnPrimary} onClick={onInstallNow}>
           Install Now
         </button>

--- a/src/hooks/useUpdater.test.tsx
+++ b/src/hooks/useUpdater.test.tsx
@@ -18,13 +18,17 @@ declare global {
   }
 }
 
-const invoke = vi.fn((cmd: string, _args?: unknown) => {
-  if (cmd === "updater_available") return Promise.resolve(true);
-  if (cmd === "check_for_updates_with_channel") return Promise.resolve(null);
-  return Promise.resolve(undefined);
-});
+const invoke = vi.fn<(cmd: string, _args?: unknown) => Promise<unknown>>(
+  (cmd) => {
+    if (cmd === "updater_available") return Promise.resolve(true);
+    if (cmd === "check_for_updates_with_channel") return Promise.resolve(null);
+    return Promise.resolve(undefined);
+  },
+);
 
-const listen = vi.fn((_event: string, _cb: unknown) => Promise.resolve(vi.fn()));
+const listen = vi.fn((_event: string, _cb: unknown) =>
+  Promise.resolve(vi.fn()),
+);
 const getConfig = vi.fn(() =>
   Promise.resolve({
     updates: { channel: "nightly", disableAutoCheck: false },
@@ -85,6 +89,74 @@ describe("useUpdater", () => {
         ([cmd]) => cmd === "check_for_updates_with_channel",
       ),
     ).toHaveLength(1);
+
+    unmount();
+  });
+
+  it("manual check surfaces an available update without installing it", async () => {
+    vi.stubEnv("DEV", true);
+    invoke.mockImplementation((cmd: string, _args?: unknown) => {
+      if (cmd === "updater_available") return Promise.resolve(true);
+      if (cmd === "check_for_updates_with_channel") {
+        return Promise.resolve({
+          version: "0.5.0",
+          current_version: "0.4.0",
+          body: null,
+          date: null,
+        });
+      }
+      return Promise.resolve(undefined);
+    });
+    const appendSystem = vi.fn();
+    const { useUpdater } = await import("./useUpdater");
+
+    const { result, unmount } = renderHook(() => useUpdater({ appendSystem }));
+
+    await act(async () => {
+      await result.current.actions.checkForUpdates();
+    });
+
+    expect(invoke).toHaveBeenCalledWith("check_for_updates_with_channel", {
+      channel: "stable",
+    });
+    expect(
+      invoke.mock.calls.some(([cmd]) => cmd === "install_pending_update"),
+    ).toBe(false);
+    expect(result.current.state).toMatchObject({
+      available: true,
+      version: "0.5.0",
+      downloading: false,
+      dismissed: false,
+    });
+    expect(appendSystem.mock.calls.map(([text]) => text)).toEqual([
+      "Checking for updates…",
+      "Update available: 0.5.0.",
+    ]);
+
+    act(() => {
+      result.current.actions.dismiss();
+    });
+    await waitFor(() => expect(result.current.state.dismissed).toBe(true));
+
+    invoke.mockClear();
+    appendSystem.mockClear();
+    await act(async () => {
+      await result.current.actions.checkForUpdates();
+    });
+
+    expect(
+      invoke.mock.calls.some(([cmd]) => cmd === "install_pending_update"),
+    ).toBe(false);
+    expect(result.current.state).toMatchObject({
+      available: true,
+      version: "0.5.0",
+      downloading: false,
+      dismissed: false,
+    });
+    expect(appendSystem.mock.calls.map(([text]) => text)).toEqual([
+      "Checking for updates…",
+      "Update available: 0.5.0.",
+    ]);
 
     unmount();
   });

--- a/src/hooks/useUpdater.ts
+++ b/src/hooks/useUpdater.ts
@@ -42,8 +42,8 @@ export interface UseUpdaterContext {
 }
 
 export interface UseUpdaterActions {
-  /** Manual menu trigger. Forces a check immediately and downloads if
-   *  one is available. */
+  /** Manual menu trigger. Forces a check immediately and surfaces the
+   *  pending update banner if one is available. */
   checkForUpdates: () => Promise<void>;
   /** Banner "Install Now" click. */
   installNow: () => Promise<void>;
@@ -103,8 +103,8 @@ export function releaseUrl(channel: UpdateChannel): string {
 /**
  * Manual + auto-updater. Wires the menu's "Check for Updates" action
  * to the new Rust `check_for_updates_with_channel` command (which engages
- * boot probation on install) and runs a 30-minute background poll on
- * release builds.
+ * boot probation only when the user clicks the banner install action) and
+ * runs a 30-minute background poll on release builds.
  *
  * The Rust shell only registers the updater plugin when a pubkey is
  * configured; if not, `updater_available` returns false and we report
@@ -131,9 +131,10 @@ export function useUpdater(ctx: UseUpdaterContext): {
     stateRef.current = state;
   }, [state]);
   const lastDismissedVersion = useRef<string | null>(null);
-  const checkInFlightRef = useRef<
-    Promise<"available" | "up-to-date" | "error" | "disabled"> | null
-  >(null);
+  const lastAvailableVersion = useRef<string | null>(null);
+  const checkInFlightRef = useRef<Promise<
+    "available" | "up-to-date" | "error" | "disabled"
+  > | null>(null);
 
   const update = useCallback(
     (patch: Partial<UpdaterStateView>) => {
@@ -225,7 +226,7 @@ export function useUpdater(ctx: UseUpdaterContext): {
   // posts system messages for the manual path.
   const runCheck = useCallback(
     async (
-      opts: { announce?: boolean } = {},
+      opts: { announce?: boolean; revealDismissed?: boolean } = {},
     ): Promise<"available" | "up-to-date" | "error" | "disabled"> => {
       if (checkInFlightRef.current) {
         return checkInFlightRef.current;
@@ -247,9 +248,11 @@ export function useUpdater(ctx: UseUpdaterContext): {
             { channel: stateRef.current.channel },
           );
           if (info) {
+            lastAvailableVersion.current = info.version;
             // Only un-dismiss if this is a different version than what
             // the user already dismissed.
             const dismissed =
+              !opts.revealDismissed &&
               stateRef.current.dismissed &&
               lastDismissedVersion.current === info.version;
             update({
@@ -261,6 +264,7 @@ export function useUpdater(ctx: UseUpdaterContext): {
             });
             return "available";
           }
+          lastAvailableVersion.current = null;
           update({ available: false, version: null, body: null, error: null });
           return "up-to-date";
         } catch (err) {
@@ -321,16 +325,16 @@ export function useUpdater(ctx: UseUpdaterContext): {
 
   const checkForUpdates = useCallback(async () => {
     appendSystemRef.current("Checking for updates…");
-    const result = await runCheck({ announce: true });
+    const result = await runCheck({ announce: true, revealDismissed: true });
     if (result === "up-to-date")
       appendSystemRef.current("Aethon is up to date.");
     else if (result === "available") {
+      update({ dismissed: false });
       appendSystemRef.current(
-        `Update available: ${stateRef.current.version}. Downloading…`,
+        `Update available: ${lastAvailableVersion.current ?? stateRef.current.version}.`,
       );
-      await installNow();
     }
-  }, [installNow, runCheck]);
+  }, [runCheck, update]);
 
   // Boot-probation lifecycle:
   //


### PR DESCRIPTION
## Summary
- stop the File menu “Check for Updates” action from installing/restarting automatically
- keep pending updates surfaced through the existing banner, including after a same-version dismissal when the user manually checks again
- make the update banner draggable on macOS overlay-titlebar chrome while preserving Install/Dismiss button clicks

## Validation
- bunx vitest run src/hooks/useUpdater.test.tsx src/components/UpdateBanner.test.ts
- bun run typecheck
- bun run lint
- bunx vitest run
- codex review --base main (addressed findings around dismissed updates, macOS drag gating, and in-flight check reveal)
