### PR TITLE
fix(menu): add Exit to File menu

### DIFF
--- a/src-tauri/src/commands/extensions/app_menu.rs
+++ b/src-tauri/src/commands/extensions/app_menu.rs
@@ -88,7 +88,7 @@ pub fn install_app_menu(
     let check_updates =
         MenuItemBuilder::with_id("check_updates", "Check for Updates…").build(app)?;
 
-    // App submenu (macOS-only first slot — Linux/Windows put these in File).
+    // App submenu (macOS-only first slot — File still exposes Exit for discoverability).
     #[cfg(target_os = "macos")]
     let app_menu = SubmenuBuilder::new(app, "Aethon")
         .item(&PredefinedMenuItem::about(app, Some("About Aethon"), None)?)
@@ -106,8 +106,9 @@ pub fn install_app_menu(
     // Cmd+W is reserved for `close_tab` (browser/IDE convention).
     // Tauri's PredefinedMenuItem::close_window also binds Cmd+W on
     // macOS, so we omit it here — the user closes the window via the
-    // red traffic light or Cmd+Q. Adding both would let macOS route
-    // Cmd+W to whichever menu item it picks first.
+    // red traffic light, Cmd+Q, or the final File → Exit item. Adding
+    // both close-window and close-tab would let macOS route Cmd+W to
+    // whichever menu item it picks first.
     #[cfg(target_os = "macos")]
     let file_menu = SubmenuBuilder::new(app, "File")
         .item(&new_file)
@@ -117,6 +118,8 @@ pub fn install_app_menu(
         .item(&new_tab)
         .item(&new_agent_tab)
         .item(&close_tab)
+        .separator()
+        .item(&PredefinedMenuItem::quit(app, Some("Exit"))?)
         .build()?;
     #[cfg(not(target_os = "macos"))]
     let file_menu = SubmenuBuilder::new(app, "File")
@@ -253,11 +256,11 @@ mod tests {
     }
 
     #[test]
-    fn non_macos_file_menu_exposes_exit() {
+    fn file_menu_exposes_exit_as_final_action() {
         let src = include_str!("app_menu.rs");
         assert!(
-            src.contains("PredefinedMenuItem::quit(app, Some(\"Exit\"))"),
-            "Linux/Windows should expose File → Exit; macOS keeps Quit in the app menu",
+            src.contains(".item(&close_tab)\n        .separator()\n        .item(&PredefinedMenuItem::quit(app, Some(\"Exit\"))?)\n        .build()?;"),
+            "File → Exit should be the final File menu action on every desktop platform",
         );
     }
 }

--- a/src-tauri/src/commands/extensions/app_menu.rs
+++ b/src-tauri/src/commands/extensions/app_menu.rs
@@ -105,23 +105,10 @@ pub fn install_app_menu(
 
     // Cmd+W is reserved for `close_tab` (browser/IDE convention).
     // Tauri's PredefinedMenuItem::close_window also binds Cmd+W on
-    // macOS, so we omit it here — the user closes the window via the
-    // red traffic light, Cmd+Q, or the final File → Exit item. Adding
-    // both close-window and close-tab would let macOS route Cmd+W to
-    // whichever menu item it picks first.
-    #[cfg(target_os = "macos")]
-    let file_menu = SubmenuBuilder::new(app, "File")
-        .item(&new_file)
-        .item(&save_file)
-        .item(&revert_file)
-        .separator()
-        .item(&new_tab)
-        .item(&new_agent_tab)
-        .item(&close_tab)
-        .separator()
-        .item(&PredefinedMenuItem::quit(app, Some("Exit"))?)
-        .build()?;
-    #[cfg(not(target_os = "macos"))]
+    // macOS, so we omit it here. The user can close the window via
+    // the red traffic light, while Cmd+Q and the final File → Exit item
+    // quit the app. Adding both close-window and close-tab would let
+    // macOS route Cmd+W to whichever menu item it picks first.
     let file_menu = SubmenuBuilder::new(app, "File")
         .item(&new_file)
         .item(&save_file)
@@ -258,9 +245,33 @@ mod tests {
     #[test]
     fn file_menu_exposes_exit_as_final_action() {
         let src = include_str!("app_menu.rs");
+        let marker = "let file_menu = SubmenuBuilder::new(app, \"File\")";
+        let start = src
+            .find(marker)
+            .expect("the native app menu should build a File submenu");
+        assert_eq!(
+            src.matches(marker).count(),
+            1,
+            "the shared File menu block should not drift by platform",
+        );
+
+        let block = &src[start..];
+        let build_start = block
+            .find(".build()?;")
+            .expect("the File submenu builder should be terminated");
+        let block = &block[..build_start];
+        let exit_item = "PredefinedMenuItem::quit(app, Some(\"Exit\"))?";
+
         assert!(
-            src.contains(".item(&close_tab)\n        .separator()\n        .item(&PredefinedMenuItem::quit(app, Some(\"Exit\"))?)\n        .build()?;"),
-            "File → Exit should be the final File menu action on every desktop platform",
+            block.contains(exit_item),
+            "File → Exit should be present on every desktop platform",
+        );
+        let final_item_start = block
+            .rfind(".item(")
+            .expect("the File submenu should contain menu items");
+        assert!(
+            block[final_item_start..].contains(exit_item),
+            "File → Exit should be the final File menu action",
         );
     }
 }


### PR DESCRIPTION
## Summary
- add File → Exit as the final File menu item on macOS
- keep existing Linux/Windows File → Exit behavior
- update the menu regression test to require Exit as the final File menu action

## Validation
- cargo test --manifest-path src-tauri/Cargo.toml -p aethon --lib commands::extensions::app_menu::tests
- cargo test --manifest-path src-tauri/Cargo.toml -p aethon --lib
- codex review --uncommitted --title "File menu Exit item"