### PR TITLE
fix: refresh workspace branches before PR status

### DIFF
--- a/src-tauri/src/commands/git/github.rs
+++ b/src-tauri/src/commands/git/github.rs
@@ -31,6 +31,7 @@ pub struct GhBranchStatus {
     /// (gh missing) and `repo=None` (no GitHub remote) — those are
     /// healthy states, this one means the user should clean up the
     /// stale entry.
+    #[serde(rename = "workspaceBroken")]
     pub worktree_broken: bool,
 }
 
@@ -558,6 +559,18 @@ mod tests {
         assert!(json.get("defaultBranch").is_some());
         assert!(json.get("pushedAt").is_some());
         assert!(json.get("open_issues_count").is_none());
+    }
+
+    #[test]
+    fn gh_branch_status_serializes_workspace_broken_for_frontend() {
+        let status = GhBranchStatus {
+            worktree_broken: true,
+            ..GhBranchStatus::default()
+        };
+        let json = serde_json::to_value(&status).unwrap();
+        assert_eq!(json["workspaceBroken"], serde_json::json!(true));
+        assert!(json.get("worktreeBroken").is_none());
+        assert!(json.get("worktree_broken").is_none());
     }
 
     #[test]

--- a/src/extensions/default-layout/sidebar/workspace-row.test.tsx
+++ b/src/extensions/default-layout/sidebar/workspace-row.test.tsx
@@ -11,9 +11,10 @@ import {
 } from "@testing-library/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 
-const { branchStatusMock, checksMock } = vi.hoisted(() => ({
+const { branchStatusMock, checksMock, worktreesMock } = vi.hoisted(() => ({
   branchStatusMock: vi.fn(),
   checksMock: vi.fn(),
+  worktreesMock: vi.fn(),
 }));
 
 vi.mock("../../../ghBranchStatusCache", () => ({
@@ -21,6 +22,9 @@ vi.mock("../../../ghBranchStatusCache", () => ({
 }));
 vi.mock("../../../ghChecksCache", () => ({
   getGhChecks: checksMock,
+}));
+vi.mock("../../../workspaces", () => ({
+  gitWorktrees: worktreesMock,
 }));
 vi.mock("@tauri-apps/plugin-opener", () => ({
   openUrl: vi.fn(),
@@ -38,6 +42,7 @@ afterEach(() => {
   vi.useRealTimers();
   branchStatusMock.mockReset();
   checksMock.mockReset();
+  worktreesMock.mockReset();
   vi.mocked(openUrl).mockReset();
   cleanup();
 });
@@ -102,6 +107,15 @@ describe("WorkspaceRow", () => {
       skipped: 0,
       checks: [],
     });
+    worktreesMock.mockResolvedValue([
+      {
+        path: "/repo-feature-x",
+        branch: "feature-x",
+        head: "abc123",
+        isMain: false,
+        locked: false,
+      },
+    ]);
   });
 
   it("emits switch-workspace on row click", () => {
@@ -393,6 +407,55 @@ describe("WorkspaceRow", () => {
     await waitFor(() => expect(branchStatusMock).toHaveBeenCalled());
     expect(checksMock).not.toHaveBeenCalled();
     expect(screen.queryByText(/#/)).toBeNull();
+  });
+
+  it("skips a focus-triggered PR status fetch when live git reports a different branch", async () => {
+    harness(wt());
+
+    await waitFor(() =>
+      expect(branchStatusMock).toHaveBeenCalledWith(
+        "/repo-feature-x",
+        "feature-x",
+      ),
+    );
+    branchStatusMock.mockClear();
+    checksMock.mockClear();
+    worktreesMock.mockResolvedValueOnce([
+      {
+        path: "/repo-feature-x",
+        branch: "fix/file-menu-exit",
+        head: "def456",
+        isMain: false,
+        locked: false,
+      },
+    ]);
+
+    window.dispatchEvent(new Event("focus"));
+
+    await waitFor(() => expect(worktreesMock).toHaveBeenCalledTimes(2));
+    expect(branchStatusMock).not.toHaveBeenCalled();
+    expect(checksMock).not.toHaveBeenCalled();
+  });
+
+  it("allows a PR status fetch when live git cannot match the row path", async () => {
+    worktreesMock.mockResolvedValueOnce([
+      {
+        path: "/private/tmp/repo-feature-x",
+        branch: "feature-x",
+        head: "abc123",
+        isMain: false,
+        locked: false,
+      },
+    ]);
+
+    harness(wt());
+
+    await waitFor(() =>
+      expect(branchStatusMock).toHaveBeenCalledWith(
+        "/repo-feature-x",
+        "feature-x",
+      ),
+    );
   });
 
   it("opens inline confirmation from the remove icon", () => {

--- a/src/extensions/default-layout/sidebar/workspace-row.tsx
+++ b/src/extensions/default-layout/sidebar/workspace-row.tsx
@@ -19,6 +19,7 @@ import type { BuiltinComponentProps } from "../../../components/A2UIRenderer";
 import type { AgentActivitySummary } from "../../../hooks/projectOps/agentActivity";
 import { getGhBranchStatus } from "../../../ghBranchStatusCache";
 import { getGhChecks } from "../../../ghChecksCache";
+import { gitWorktrees } from "../../../workspaces";
 import {
   summarizeWorkspacePrStatus,
   type WorkspacePrChip,
@@ -26,6 +27,20 @@ import {
 
 export const WORKSPACE_PR_REFRESH_MS = 60_000;
 export const WORKSPACE_PENDING_CI_REFRESH_MS = 45_000;
+
+async function liveBranchStillMatches(
+  path: string,
+  branch: string,
+): Promise<boolean> {
+  try {
+    const live = await gitWorktrees(path);
+    const row = live.find((w) => w.path === path);
+    if (!row) return true;
+    return row.branch === branch;
+  } catch {
+    return true;
+  }
+}
 
 export interface WorkspaceSidebarItem {
   id: string;
@@ -137,6 +152,14 @@ export function WorkspaceRow({
         setPrChip(null);
       }
       try {
+        if (!(await liveBranchStillMatches(item.path, branch))) {
+          if (!cancelled) {
+            loadedOnce = true;
+            setPrChip(null);
+            scheduleRefresh(null);
+          }
+          return;
+        }
         const status = await getGhBranchStatus(item.path, branch);
         const checks =
           status.ghAvailable &&

--- a/src/hooks/projectOps/workspaceOperations.ts
+++ b/src/hooks/projectOps/workspaceOperations.ts
@@ -58,6 +58,7 @@ export function useWorkspaceOperations(
   const refreshDeps = {
     projectsRef: deps.projectsRef,
     lookups,
+    syncProjectsToState: deps.syncProjectsToState,
     persistProjects: deps.persistProjects,
     tabCleanup: tabCleanupDeps,
   };

--- a/src/hooks/projectOps/workspaceOps/git.ts
+++ b/src/hooks/projectOps/workspaceOps/git.ts
@@ -117,7 +117,11 @@ export function navigateToWorkspace(
 export async function refreshProjectWorkspaces(
   deps: Pick<
     GitDeps,
-    "projectsRef" | "lookups" | "persistProjects" | "tabCleanup"
+    | "projectsRef"
+    | "lookups"
+    | "syncProjectsToState"
+    | "persistProjects"
+    | "tabCleanup"
   >,
   projectId: string,
 ): Promise<void> {
@@ -165,6 +169,7 @@ export async function refreshProjectWorkspaces(
       nextState = { ...nextState, activeWorkspaceId: null };
     }
     deps.projectsRef.current = nextState;
+    deps.syncProjectsToState();
     void deps.persistProjects();
   } catch {
     // Project may not be a git repo; keep the prior list intact.

--- a/src/hooks/useProjectOps.test.ts
+++ b/src/hooks/useProjectOps.test.ts
@@ -9,6 +9,7 @@ import {
   type Tab,
 } from "../types/tab";
 import type { ProjectsState } from "../projects";
+import { _resetLocalHostCacheForTests } from "../hosts";
 import { installTauriMocks, clearTauriMocks } from "../test/tauriMocks";
 import { disposeEditorBuffer } from "../monaco/editor-buffers";
 import {
@@ -26,6 +27,8 @@ vi.mock("../monaco/editor-buffers", () => ({
 }));
 
 afterEach(() => {
+  delete (window as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
+  _resetLocalHostCacheForTests();
   clearTauriMocks();
 });
 
@@ -948,6 +951,118 @@ describe("useProjectOps overview terminal project switches", () => {
 });
 
 describe("useProjectOps workspace refresh", () => {
+  it("reconciles visible workspace branches from live git before mirroring boot sidebar state", async () => {
+    (window as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {};
+    const harness = installTauriMocks();
+    harness.invoke.mockImplementation(
+      (cmd: string, args?: Record<string, unknown>) => {
+        if (cmd === "host_info") {
+          return Promise.resolve({ id: "local:test" });
+        }
+        if (cmd === "read_state") {
+          if (args?.name === "projects.json") {
+            return Promise.resolve(
+              JSON.stringify({
+                schemaVersion: 5,
+                projects: [
+                  {
+                    id: "project-1",
+                    label: "aethon",
+                    path: "/projects/aethon",
+                    lastUsed: 1,
+                    uiExpanded: true,
+                    hostId: "local:test",
+                  },
+                ],
+                activeId: "project-1",
+                activeWorkspaceId: "wt-stale",
+                activeHostId: "local:test",
+                workspacesByProject: {
+                  "project-1": [
+                    {
+                      id: "main",
+                      projectId: "project-1",
+                      path: "/projects/aethon",
+                      branch: "main",
+                      isMain: true,
+                    },
+                    {
+                      id: "wt-stale",
+                      projectId: "project-1",
+                      path: "/projects/aethon-feat-helios",
+                      branch: "feat/helios",
+                      isMain: false,
+                    },
+                  ],
+                },
+              }),
+            );
+          }
+          if (args?.name === "project-icons.json") {
+            return Promise.resolve("{}");
+          }
+        }
+        if (cmd === "git_worktrees") {
+          return Promise.resolve([
+            {
+              path: "/projects/aethon",
+              branch: "main",
+              head: "abc123",
+              isMain: true,
+              locked: false,
+            },
+            {
+              path: "/projects/aethon-feat-helios",
+              branch: "fix/file-menu-exit",
+              head: "def456",
+              isMain: false,
+              locked: false,
+            },
+          ]);
+        }
+        return Promise.resolve(undefined);
+      },
+    );
+
+    const { stateRef, setState } = renderProjectOps(makeProjectsState());
+
+    await waitFor(() => {
+      const sidebar = stateRef.current.sidebar as
+        | {
+            projects?: Array<{
+              id: string;
+              workspaces?: Array<{ id: string; branch: string | null }>;
+            }>;
+          }
+        | undefined;
+      const project = sidebar?.projects?.find((p) => p.id === "project-1");
+      const workspace = project?.workspaces?.find((w) => w.id === "wt-stale");
+      expect(workspace?.branch).toBe("fix/file-menu-exit");
+    });
+
+    const mirroredStaleBranch = setState.mock.calls.some((call) => {
+      const next = call[0];
+      if (typeof next !== "function") return false;
+      const mirrored = next({ tabs: [] }) as {
+        sidebar?: {
+          projects?: Array<{
+            workspaces?: Array<{ id: string; branch: string | null }>;
+          }>;
+        };
+      };
+      return mirrored.sidebar?.projects?.some((project) =>
+        project.workspaces?.some(
+          (workspace) =>
+            workspace.id === "wt-stale" && workspace.branch === "feat/helios",
+        ),
+      );
+    });
+    expect(mirroredStaleBranch).toBe(false);
+    expect(harness.invoke).toHaveBeenCalledWith("git_worktrees", {
+      projectPath: "/projects/aethon",
+    });
+  });
+
   it("refreshes workspaces when reselecting a project with cached rows", async () => {
     const harness = installTauriMocks();
     harness.invoke.mockImplementation((cmd: string) => {
@@ -986,6 +1101,79 @@ describe("useProjectOps workspace refresh", () => {
         projectPath: "/projects/aethon",
       });
     });
+  });
+
+  it("refreshes active and expanded workspace branches on window focus", async () => {
+    const harness = installTauriMocks();
+    harness.invoke.mockImplementation((cmd: string) => {
+      if (cmd === "git_worktrees") {
+        return Promise.resolve([
+          {
+            path: "/projects/aethon",
+            branch: "main",
+            head: "abc123",
+            isMain: true,
+            locked: false,
+          },
+          {
+            path: "/projects/aethon-feat-helios",
+            branch: "fix/file-menu-exit",
+            head: "def456",
+            isMain: false,
+            locked: false,
+          },
+        ]);
+      }
+      return Promise.resolve(undefined);
+    });
+    const staleWorkspace = {
+      id: "wt-stale",
+      projectId: "project-1",
+      path: "/projects/aethon-feat-helios",
+      branch: "feat/helios",
+      isMain: false,
+    };
+    const initial = makeProjectsState({
+      activeId: "project-1",
+      activeWorkspaceId: "wt-stale",
+      projects: [
+        {
+          id: "project-1",
+          label: "aethon",
+          path: "/projects/aethon",
+          lastUsed: 1,
+          uiExpanded: true,
+        },
+      ],
+      workspacesByProject: { "project-1": [staleWorkspace] },
+    });
+    const { projectsRef, stateRef } = renderProjectOps(initial);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    projectsRef.current = initial;
+
+    window.dispatchEvent(new Event("focus"));
+
+    await waitFor(() => {
+      const workspace =
+        projectsRef.current.workspacesByProject["project-1"]?.find(
+          (w) => w.id === "wt-stale",
+        );
+      expect(workspace?.branch).toBe("fix/file-menu-exit");
+    });
+    const sidebar = stateRef.current.sidebar as
+      | {
+          projects?: Array<{
+            id: string;
+            workspaces?: Array<{ id: string; branch: string | null }>;
+          }>;
+        }
+      | undefined;
+    const project = sidebar?.projects?.find((p) => p.id === "project-1");
+    const workspace = project?.workspaces?.find((w) => w.id === "wt-stale");
+    expect(workspace?.branch).toBe("fix/file-menu-exit");
   });
 
   it("clears a stale active workspace missing from a fresh git listing", async () => {

--- a/src/hooks/useProjectOps.ts
+++ b/src/hooks/useProjectOps.ts
@@ -281,6 +281,24 @@ export function useProjectOps(ctx: UseProjectOpsContext): UseProjectOpsActions {
     workspacePrompts,
   });
 
+  function projectIdsNeedingWorkspaceRefresh(
+    ps = projectsRef.current,
+  ): string[] {
+    const ids = new Set<string>();
+    if (ps.activeId) ids.add(ps.activeId);
+    for (const project of ps.projects) {
+      if (project.uiExpanded === true) ids.add(project.id);
+    }
+    return [...ids];
+  }
+
+  async function refreshVisibleProjectWorkspaces(): Promise<void> {
+    const ids = projectIdsNeedingWorkspaceRefresh();
+    for (const id of ids) {
+      await workspaceOps.refreshProjectWorkspaces(id);
+    }
+  }
+
   // Load projects once at boot. Mirrors into state on resolve so the
   // sidebar populates without requiring a React state owner for projects.
   useEffect(() => {
@@ -288,6 +306,7 @@ export function useProjectOps(ctx: UseProjectOpsContext): UseProjectOpsActions {
       const ps = await loadProjects();
       projectsRef.current = ps;
       projectsLoadedRef.current = true;
+      await refreshVisibleProjectWorkspaces();
       syncProjectsToState();
       void refreshAllGitStatus();
       const active = activeProject(ps);
@@ -319,6 +338,21 @@ export function useProjectOps(ctx: UseProjectOpsContext): UseProjectOpsActions {
       syncRecentSessionsToState();
       if (active) await restoreEditorTabs(active.id, active.path);
     })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    const refresh = () => {
+      if (!projectsLoadedRef.current || document.hidden) return;
+      void refreshVisibleProjectWorkspaces();
+    };
+    window.addEventListener("focus", refresh);
+    document.addEventListener("visibilitychange", refresh);
+    return () => {
+      window.removeEventListener("focus", refresh);
+      document.removeEventListener("visibilitychange", refresh);
+    };
+    // The hook is mounted once with stable App-root refs and actions.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 


### PR DESCRIPTION
## Summary
- Reconcile active and expanded project workspaces from live `git_worktrees` on boot, focus, and visibility return before sidebar PR badge state relies on persisted branch metadata.
- Sync `/sidebar/projects` immediately after `refreshProjectWorkspaces()` updates workspace rows.
- Guard `WorkspaceRow` PR badge refreshes by checking live git branch metadata first, preventing focus-triggered stale branch GitHub queries.
- Serialize Rust `GhBranchStatus.worktree_broken` as frontend key `workspaceBroken`.

## Root Cause
Persisted workspace metadata could keep an old branch name after the actual worktree branch changed outside Aethon. The sidebar PR badge path read that stale branch from the mirrored sidebar row and queried GitHub before live git reconciliation updated the row.

## Validation
- Codex xhigh peer review dispatched; fixed the reported focus-event stale-query race.
- `bunx vitest run src/extensions/default-layout/sidebar/workspace-row.test.tsx`
- `bunx vitest run src/hooks/useProjectOps.test.ts`
- `bun run typecheck`
- `nix develop -c cargo test --manifest-path src-tauri/Cargo.toml --lib commands::git::github`

Fixes #321
