### PR TITLE
feat(accounts): multi-account Codex — usage stats, isolation, switching, auto-switch

### DIFF
--- a/agent/agent-errors.test.ts
+++ b/agent/agent-errors.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { extractAgentEndError, isRetryableAgentEndError } from "./agent-errors";
+import {
+  extractAgentEndError,
+  formatAgentErrorMessage,
+  isRetryableAgentEndError,
+  isUsageLimitError,
+} from "./agent-errors";
+
+// Real Codex usage-limit 429 payload (truncated headers) — the raw string
+// the agent surfaces when an account hits its quota.
+const CODEX_USAGE_LIMIT_RAW =
+  'Codex error: {"type":"error","error":{"type":"usage_limit_reached","message":"The usage limit has been reached","plan_type":"pro","resets_at":1781838269,"resets_in_seconds":1621},"status_code":429,"headers":{"X-Codex-Primary-Used-Percent":"100"}}';
 
 describe("extractAgentEndError", () => {
   it("returns undefined for an empty or missing list", () => {
@@ -67,5 +77,51 @@ describe("isRetryableAgentEndError", () => {
         "Your credit balance is too low to access the Anthropic API.",
       ),
     ).toBe(false);
+  });
+
+  it("does NOT retry a usage-limit 429 even though it carries '429'", () => {
+    // Without the usage-limit guard the "429" substring would make this
+    // look retryable and burn the whole retry budget on a dead quota.
+    expect(isRetryableAgentEndError(CODEX_USAGE_LIMIT_RAW)).toBe(false);
+  });
+});
+
+describe("isUsageLimitError", () => {
+  it("detects the Codex usage_limit_reached payload", () => {
+    expect(isUsageLimitError(CODEX_USAGE_LIMIT_RAW)).toBe(true);
+  });
+
+  it("detects the human-readable phrasing", () => {
+    expect(isUsageLimitError("The usage limit has been reached")).toBe(true);
+  });
+
+  it("returns false for unrelated errors", () => {
+    expect(isUsageLimitError("WebSocket closed 1006")).toBe(false);
+  });
+});
+
+describe("formatAgentErrorMessage", () => {
+  it("rewrites a raw usage-limit 429 into a clean, actionable sentence", () => {
+    const out = formatAgentErrorMessage(CODEX_USAGE_LIMIT_RAW);
+    expect(out).toContain("Usage limit reached for this account");
+    expect(out).toContain("(pro)");
+    expect(out).toContain("Resets in 27m"); // 1621s → 27m
+    expect(out).toContain("Cmd+Shift+A");
+    // None of the raw JSON / header noise should leak through.
+    expect(out).not.toContain("X-Codex");
+    expect(out).not.toContain("status_code");
+  });
+
+  it("passes non-usage-limit errors through unchanged", () => {
+    const raw = "Your credit balance is too low to access the Anthropic API.";
+    expect(formatAgentErrorMessage(raw)).toBe(raw);
+  });
+
+  it("omits the reset clause when resets_in_seconds is absent", () => {
+    const out = formatAgentErrorMessage(
+      '{"error":{"type":"usage_limit_reached","message":"The usage limit has been reached"}}',
+    );
+    expect(out).toContain("Usage limit reached for this account");
+    expect(out).not.toContain("Resets in");
   });
 });

--- a/agent/agent-errors.ts
+++ b/agent/agent-errors.ts
@@ -35,6 +35,60 @@ export function extractAgentEndError(
 const RETRYABLE_AGENT_ERROR_RE =
   /overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|network.?error|connection.?error|connection.?refused|connection.?lost|connection.?ended|websocket.?closed|1006|other side closed|fetch failed|upstream.?connect|reset before headers|socket hang up|ended without|http2 request did not get a response|timed? out|timeout|terminated|retry delay/i;
 
+/**
+ * A hit on the account's usage quota (Codex `usage_limit_reached`). This is
+ * NOT retryable — retrying just burns attempts against a quota that won't
+ * replenish until its reset window. Detected so we can both skip the retry
+ * loop and surface a clean, actionable message instead of the raw 429 JSON.
+ */
+export function isUsageLimitError(message: string): boolean {
+  return /usage_limit_reached|usage limit has been reached/i.test(message);
+}
+
 export function isRetryableAgentEndError(message: string): boolean {
+  // Usage-limit 429s carry "429" so they'd otherwise look retryable; bail
+  // first so we don't waste the retry budget on an unrecoverable quota hit.
+  if (isUsageLimitError(message)) return false;
   return RETRYABLE_AGENT_ERROR_RE.test(message);
+}
+
+/**
+ * Turn a raw agent error string into a clean, user-facing message. Today
+ * this special-cases the Codex usage-limit 429 (whose payload is a wall of
+ * JSON + X-Codex-* headers) into a short sentence with the reset countdown
+ * and a hint to switch accounts. Everything else passes through unchanged.
+ *
+ * Reusable: any surface that renders an agent error can call this.
+ */
+export function formatAgentErrorMessage(raw: string): string {
+  if (!isUsageLimitError(raw)) return raw;
+  const resetsInSeconds = readNumericField(raw, "resets_in_seconds");
+  const planType = readStringField(raw, "plan_type");
+  const planLabel = planType ? ` (${planType})` : "";
+  const when =
+    resetsInSeconds !== undefined
+      ? ` Resets in ${formatDuration(resetsInSeconds)}.`
+      : "";
+  return `Usage limit reached for this account${planLabel}.${when} Switch to another account (Cmd+Shift+A) to keep working.`;
+}
+
+function readNumericField(raw: string, key: string): number | undefined {
+  const match = raw.match(new RegExp(`"${key}"\\s*:\\s*(\\d+)`));
+  return match ? Number(match[1]) : undefined;
+}
+
+function readStringField(raw: string, key: string): string | undefined {
+  const match = raw.match(new RegExp(`"${key}"\\s*:\\s*"([^"]+)"`));
+  return match ? match[1] : undefined;
+}
+
+function formatDuration(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`;
+  const mins = Math.round(seconds / 60);
+  if (mins < 60) return `${mins}m`;
+  const hours = Math.floor(mins / 60);
+  const remMins = mins % 60;
+  if (hours < 24) return remMins ? `${hours}h ${remMins}m` : `${hours}h`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ${hours % 24}h`;
 }

--- a/agent/auth-profiles/auto-switch.test.ts
+++ b/agent/auth-profiles/auto-switch.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest";
+import { pickAvailableAccount, type AccountCandidate } from "./auto-switch";
+
+const PROFILES: AccountCandidate[] = [
+  { id: "codex-a", providerId: "openai-codex" },
+  { id: "codex-b", providerId: "openai-codex" },
+  { id: "codex-c", providerId: "openai-codex" },
+  { id: "anthropic-x", providerId: "anthropic" },
+];
+
+describe("pickAvailableAccount", () => {
+  it("returns the first same-provider account with headroom, skipping the current one", async () => {
+    // a = current, b = limited, c = available → pick c.
+    const probe = vi.fn((id: string) => Promise.resolve(id === "codex-b"));
+    const chosen = await pickAvailableAccount(
+      PROFILES,
+      "openai-codex",
+      "codex-a",
+      new Set(["codex-a"]),
+      probe,
+    );
+    expect(chosen).toBe("codex-c");
+    // Never probed the current account or the other-provider one.
+    expect(probe).not.toHaveBeenCalledWith("codex-a", expect.anything());
+    expect(probe).not.toHaveBeenCalledWith("anthropic-x", expect.anything());
+  });
+
+  it("skips already-tried accounts (loop guard)", async () => {
+    const probe = vi.fn(() => Promise.resolve(false)); // everything has headroom
+    const chosen = await pickAvailableAccount(
+      PROFILES,
+      "openai-codex",
+      "codex-a",
+      new Set(["codex-a", "codex-b"]),
+      probe,
+    );
+    expect(chosen).toBe("codex-c");
+  });
+
+  it("returns undefined when every alternative is rate-limited", async () => {
+    const probe = vi.fn(() => Promise.resolve(true)); // all limited
+    const chosen = await pickAvailableAccount(
+      PROFILES,
+      "openai-codex",
+      "codex-a",
+      new Set(["codex-a"]),
+      probe,
+    );
+    expect(chosen).toBeUndefined();
+  });
+
+  it("treats an unprobeable account as unusable and moves on", async () => {
+    const probe = vi.fn((id: string) => {
+      if (id === "codex-b") return Promise.reject(new Error("token dead"));
+      return Promise.resolve(false);
+    });
+    const chosen = await pickAvailableAccount(
+      PROFILES,
+      "openai-codex",
+      "codex-a",
+      new Set(["codex-a"]),
+      probe,
+    );
+    expect(chosen).toBe("codex-c");
+  });
+
+  it("never crosses providers", async () => {
+    const probe = vi.fn(() => Promise.resolve(false));
+    const chosen = await pickAvailableAccount(
+      PROFILES,
+      "openai-codex",
+      "codex-a",
+      new Set(["codex-a", "codex-b", "codex-c"]),
+      probe,
+    );
+    // Only anthropic-x remains, but it's a different provider → undefined.
+    expect(chosen).toBeUndefined();
+  });
+});

--- a/agent/auth-profiles/auto-switch.ts
+++ b/agent/auth-profiles/auto-switch.ts
@@ -1,0 +1,60 @@
+/**
+ * Usage-limit auto-switch: when an account hits its quota mid-session, pick
+ * another stored account for the same provider that still has headroom so
+ * the caller can transparently switch and continue.
+ *
+ * The picker is isolated here (and dependency-injected for the usage probe)
+ * so it can be unit-tested without spawning sessions or hitting the network.
+ */
+import { fetchCodexProfileUsage } from "./codex-usage";
+import { authProfileAuthPath } from "./store";
+
+export interface AccountCandidate {
+  id: string;
+  providerId: string;
+}
+
+/** Probe a single profile's live usage. Returns `true` when the account is
+ *  rate-limited (or cannot be probed — treated as unusable). */
+export type LimitProbe = (
+  profileId: string,
+  providerId: string,
+) => Promise<boolean>;
+
+/**
+ * Pick the first candidate for `provider` (other than `currentId`, and not
+ * already tried) whose account is NOT rate-limited. Returns `undefined` when
+ * every alternative is exhausted, tried, or unprobeable.
+ */
+export async function pickAvailableAccount(
+  candidates: readonly AccountCandidate[],
+  provider: string,
+  currentId: string | undefined,
+  tried: ReadonlySet<string>,
+  probe: LimitProbe,
+): Promise<string | undefined> {
+  for (const candidate of candidates) {
+    if (candidate.providerId !== provider) continue;
+    if (candidate.id === currentId) continue;
+    if (tried.has(candidate.id)) continue;
+    let limited: boolean;
+    try {
+      limited = await probe(candidate.id, candidate.providerId);
+    } catch {
+      continue; // unprobeable → skip, don't risk switching to a dead account
+    }
+    if (!limited) return candidate.id;
+  }
+  return undefined;
+}
+
+/** Default {@link LimitProbe} backed by the real Codex usage API. */
+export function makeCodexLimitProbe(userDir: string): LimitProbe {
+  return async (profileId, providerId) => {
+    const usage = await fetchCodexProfileUsage(
+      authProfileAuthPath(userDir, profileId),
+      providerId,
+    );
+    return usage.limitReached === true;
+  };
+}

--- a/agent/auth-profiles/auto-switch.ts
+++ b/agent/auth-profiles/auto-switch.ts
@@ -6,9 +6,6 @@
  * The picker is isolated here (and dependency-injected for the usage probe)
  * so it can be unit-tested without spawning sessions or hitting the network.
  */
-import { fetchCodexProfileUsage } from "./codex-usage";
-import { authProfileAuthPath } from "./store";
-
 export interface AccountCandidate {
   id: string;
   providerId: string;
@@ -46,15 +43,4 @@ export async function pickAvailableAccount(
     if (!limited) return candidate.id;
   }
   return undefined;
-}
-
-/** Default {@link LimitProbe} backed by the real Codex usage API. */
-export function makeCodexLimitProbe(userDir: string): LimitProbe {
-  return async (profileId, providerId) => {
-    const usage = await fetchCodexProfileUsage(
-      authProfileAuthPath(userDir, profileId),
-      providerId,
-    );
-    return usage.limitReached === true;
-  };
 }

--- a/agent/auth-profiles/codex-usage.test.ts
+++ b/agent/auth-profiles/codex-usage.test.ts
@@ -61,6 +61,16 @@ describe("parseCodexUsageBody", () => {
     expect(out.secondary?.usedPercent).toBe(7);
   });
 
+  it("reads rate_limit_reached_type from the body top level (sibling form)", () => {
+    const out = parseCodexUsageBody({
+      rate_limit_reached_type: "rate_limit_reached",
+      rate_limits: {
+        primary: { used_percent: 100, window_minutes: 300 },
+      },
+    });
+    expect(out.limitReached).toBe(true);
+  });
+
   it("treats a null rate_limit_reached_type as not limited", () => {
     const out = parseCodexUsageBody({
       rate_limits: {

--- a/agent/auth-profiles/codex-usage.test.ts
+++ b/agent/auth-profiles/codex-usage.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+import { fetchCodexUsage, parseCodexUsageBody } from "./codex-usage";
+
+describe("parseCodexUsageBody", () => {
+  it("parses the /backend-api/codex/usage shape (primary_window + limit_reached)", () => {
+    const out = parseCodexUsageBody({
+      email: "user@example.com",
+      plan_type: "pro",
+      rate_limit: {
+        limit_reached: true,
+        primary_window: {
+          used_percent: 100,
+          limit_window_seconds: 18000,
+          reset_at: 1781838270,
+        },
+        secondary_window: {
+          used_percent: 35,
+          limit_window_seconds: 604800,
+          reset_at: 1782397309,
+        },
+      },
+      credits: { has_credits: false, unlimited: false, balance: 0 },
+    });
+    expect(out.email).toBe("user@example.com");
+    expect(out.planType).toBe("pro");
+    expect(out.limitReached).toBe(true);
+    expect(out.primary).toEqual({
+      usedPercent: 100,
+      windowDurationMins: 300, // 18000s → 300m (5-hour)
+      resetsAt: 1781838270,
+    });
+    expect(out.secondary?.usedPercent).toBe(35);
+    expect(out.secondary?.windowDurationMins).toBe(10080); // weekly
+    expect(out.credits).toEqual({
+      balance: "0",
+      hasCredits: false,
+      unlimited: false,
+    });
+  });
+
+  it("parses the app-server rate_limits shape (window_minutes + reached_type)", () => {
+    const out = parseCodexUsageBody({
+      rate_limits: {
+        plan_type: "pro",
+        rate_limit_reached_type: "rate_limit_reached",
+        primary: {
+          used_percent: 96,
+          window_minutes: 300,
+          resets_at: 1780339066,
+        },
+        secondary: { used_percent: 7, window_minutes: 10080 },
+      },
+    });
+    expect(out.planType).toBe("pro");
+    expect(out.limitReached).toBe(true); // non-null reached_type
+    expect(out.primary).toEqual({
+      usedPercent: 96,
+      windowDurationMins: 300,
+      resetsAt: 1780339066,
+    });
+    expect(out.secondary?.usedPercent).toBe(7);
+  });
+
+  it("treats a null rate_limit_reached_type as not limited", () => {
+    const out = parseCodexUsageBody({
+      rate_limits: {
+        rate_limit_reached_type: null,
+        primary: { used_percent: 10, window_minutes: 300 },
+      },
+    });
+    expect(out.limitReached).toBe(false);
+  });
+
+  it("returns an empty object for a bodyless / unknown payload", () => {
+    expect(parseCodexUsageBody({})).toEqual({});
+  });
+});
+
+describe("fetchCodexUsage", () => {
+  it("throws when the account cannot produce an access token", async () => {
+    const probe = vi.fn(() => Promise.resolve(undefined));
+    await expect(fetchCodexUsage(probe)).rejects.toThrow(/no access token/);
+  });
+});

--- a/agent/auth-profiles/codex-usage.ts
+++ b/agent/auth-profiles/codex-usage.ts
@@ -1,22 +1,23 @@
 /**
  * Codex account usage + identity, fetched directly from OpenAI's HTTP API
- * using a profile's own stored OAuth credentials. No dependency on the
- * `codex` binary — this keeps each account fully isolated (the bearer
- * token scopes the request to exactly one account) and avoids PATH /
- * temp-dir fragility.
+ * using a profile's own access token. No dependency on the `codex` binary —
+ * the bearer token scopes the request to exactly one account, so each
+ * account stays fully isolated, and there is no PATH / temp-dir fragility.
  *
- * Self-contained and side-effect-light: the only write is rotating the
- * refreshed token back into the profile's auth.json. Designed to be
- * reusable anywhere in the UI that needs Codex usage/identity, not just
- * the Accounts panel.
+ * Token handling is delegated to a caller-supplied `getAccessToken` (backed
+ * by pi's `AuthStorage`), so OAuth refresh + single-use refresh-token
+ * rotation happen through the same cross-process lock pi uses — this module
+ * never reads or writes auth.json itself. Designed to be reusable anywhere
+ * in the UI that needs Codex usage/identity, not just the Accounts panel.
  */
-import { readFileSync, writeFileSync } from "node:fs";
-
-const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
-const TOKEN_URL = "https://auth.openai.com/oauth/token";
 const USAGE_URL = "https://chatgpt.com/backend-api/codex/usage";
 const USER_AGENT = "codex_cli_rs/0.136.0 (Aethon)";
 const ORIGINATOR = "codex_cli_rs";
+
+/** Returns a valid access token for the account, refreshing through the
+ *  locked auth store if needed. `undefined` means the account can't
+ *  currently authenticate. */
+export type TokenProvider = () => Promise<string | undefined>;
 
 export interface CodexUsageWindow {
   /** 0-100 percent of the window consumed. */
@@ -38,14 +39,6 @@ export interface CodexUsageResult {
   credits?: { balance?: string; hasCredits?: boolean; unlimited?: boolean };
 }
 
-interface RefreshedTokens {
-  access: string;
-  refresh: string;
-  idToken?: string;
-  expires: number;
-  accountId?: string;
-}
-
 function decodeJwtPayload(token: string): Record<string, unknown> | undefined {
   const parts = token.split(".");
   const segment = parts[1];
@@ -65,8 +58,7 @@ function decodeJwtPayload(token: string): Record<string, unknown> | undefined {
   }
 }
 
-function jwtEmail(token: string | undefined): string | undefined {
-  if (!token) return undefined;
+function jwtEmail(token: string): string | undefined {
   const payload = decodeJwtPayload(token);
   if (!payload) return undefined;
   if (typeof payload.email === "string") return payload.email;
@@ -76,8 +68,7 @@ function jwtEmail(token: string | undefined): string | undefined {
   return typeof auth?.email === "string" ? auth.email : undefined;
 }
 
-function jwtAccountId(token: string | undefined): string | undefined {
-  if (!token) return undefined;
+function jwtAccountId(token: string): string | undefined {
   const payload = decodeJwtPayload(token);
   const auth = payload?.["https://api.openai.com/auth"] as
     | Record<string, unknown>
@@ -86,55 +77,40 @@ function jwtAccountId(token: string | undefined): string | undefined {
   return typeof id === "string" && id.length > 0 ? id : undefined;
 }
 
-/** Exchange a stored refresh token for a fresh access/id token set.
- *  OpenAI rotates refresh tokens (single-use), so the caller must persist
- *  the returned `refresh` value. */
-async function refreshTokens(refreshToken: string): Promise<RefreshedTokens> {
-  const response = await fetch(TOKEN_URL, {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      grant_type: "refresh_token",
-      refresh_token: refreshToken,
-      client_id: CLIENT_ID,
-    }),
-  });
-  if (!response.ok) {
-    const text = await response.text().catch(() => "");
-    throw new Error(
-      `token refresh failed: ${response.status} ${text.slice(0, 200)}`,
-    );
-  }
-  const json = (await response.json()) as Record<string, unknown>;
-  if (
-    typeof json.access_token !== "string" ||
-    typeof json.refresh_token !== "string" ||
-    typeof json.expires_in !== "number"
-  ) {
-    throw new Error("token refresh response missing required fields");
-  }
-  return {
-    access: json.access_token,
-    refresh: json.refresh_token,
-    idToken: typeof json.id_token === "string" ? json.id_token : undefined,
-    expires: Date.now() + json.expires_in * 1000,
-    accountId: jwtAccountId(json.access_token),
-  };
+function num(value: unknown): number | undefined {
+  return typeof value === "number" ? value : undefined;
 }
 
+/** Normalise one rate-limit window. Accepts both the `/codex/usage` shape
+ *  (`used_percent` + `limit_window_seconds` + `reset_at`) and the
+ *  app-server `rate_limits` shape (`used_percent` + `window_minutes` +
+ *  `resets_at`). */
 function windowFrom(value: unknown): CodexUsageWindow | undefined {
   if (!value || typeof value !== "object") return undefined;
   const rec = value as Record<string, unknown>;
-  if (typeof rec.used_percent !== "number") return undefined;
-  const w: CodexUsageWindow = { usedPercent: rec.used_percent };
-  if (typeof rec.reset_at === "number") w.resetsAt = rec.reset_at;
-  if (typeof rec.limit_window_seconds === "number") {
-    w.windowDurationMins = Math.round(rec.limit_window_seconds / 60);
+  const usedPercent = num(rec.used_percent);
+  if (usedPercent === undefined) return undefined;
+  const w: CodexUsageWindow = { usedPercent };
+  const resetsAt = num(rec.reset_at) ?? num(rec.resets_at);
+  if (resetsAt !== undefined) w.resetsAt = resetsAt;
+  const windowSeconds = num(rec.limit_window_seconds);
+  const windowMinutes = num(rec.window_minutes);
+  if (windowSeconds !== undefined) {
+    w.windowDurationMins = Math.round(windowSeconds / 60);
+  } else if (windowMinutes !== undefined) {
+    w.windowDurationMins = windowMinutes;
   }
   return w;
 }
 
-/** Parse the `/backend-api/codex/usage` response body into our shape. */
+/**
+ * Parse the Codex usage response into our shape. Tolerant of both payload
+ * variants seen in the wild:
+ *   - `/backend-api/codex/usage`: `rate_limit.{primary,secondary}_window`,
+ *     `rate_limit.limit_reached`.
+ *   - app-server `rate_limits`: `rate_limits.{primary,secondary}`,
+ *     `rate_limit_reached_type` (non-null ⇒ limit reached).
+ */
 export function parseCodexUsageBody(
   body: Record<string, unknown>,
 ): Omit<CodexUsageResult, "accountId"> {
@@ -142,14 +118,27 @@ export function parseCodexUsageBody(
   if (typeof body.email === "string") result.email = body.email;
   if (typeof body.plan_type === "string") result.planType = body.plan_type;
 
-  const rateLimit = body.rate_limit as Record<string, unknown> | undefined;
+  const rateLimit = (body.rate_limit ?? body.rate_limits) as
+    | Record<string, unknown>
+    | undefined;
   if (rateLimit && typeof rateLimit === "object") {
     if (typeof rateLimit.limit_reached === "boolean") {
       result.limitReached = rateLimit.limit_reached;
+    } else if ("rate_limit_reached_type" in rateLimit) {
+      result.limitReached =
+        rateLimit.rate_limit_reached_type != null &&
+        rateLimit.rate_limit_reached_type !== "";
     }
-    const primary = windowFrom(rateLimit.primary_window);
+    if (typeof rateLimit.plan_type === "string" && !result.planType) {
+      result.planType = rateLimit.plan_type;
+    }
+    const primary = windowFrom(
+      rateLimit.primary_window ?? rateLimit.primary,
+    );
     if (primary) result.primary = primary;
-    const secondary = windowFrom(rateLimit.secondary_window);
+    const secondary = windowFrom(
+      rateLimit.secondary_window ?? rateLimit.secondary,
+    );
     if (secondary) result.secondary = secondary;
   }
 
@@ -174,63 +163,26 @@ export function parseCodexUsageBody(
 }
 
 /**
- * Fetch usage + identity for a single Codex profile. Refreshes the token,
- * persists the rotated refresh token back to the profile, then calls the
- * usage API scoped to that account.
+ * Fetch usage + identity for a single Codex account, scoped to the token
+ * `getAccessToken` returns. Identity (email/accountId) is read from the
+ * access-token JWT and the response body; usage from the response body.
+ * Returns identity-only on any network/HTTP failure so the caller can still
+ * show who the account is.
  */
-export async function fetchCodexProfileUsage(
-  profileAuthPath: string,
-  providerId: string,
+export async function fetchCodexUsage(
+  getAccessToken: TokenProvider,
 ): Promise<CodexUsageResult> {
-  const stored = JSON.parse(readFileSync(profileAuthPath, "utf8")) as Record<
-    string,
-    unknown
-  >;
-  const entry = stored[providerId];
-  if (!entry || typeof entry !== "object") {
-    throw new Error("no stored credentials for provider");
-  }
-  const creds = entry as Record<string, unknown>;
-  const storedRefresh =
-    typeof creds.refresh === "string"
-      ? creds.refresh
-      : typeof creds.refresh_token === "string"
-        ? creds.refresh_token
-        : undefined;
-  if (!storedRefresh) throw new Error("no refresh token stored");
+  const accessToken = await getAccessToken();
+  if (!accessToken) throw new Error("no access token for account");
 
-  const tokens = await refreshTokens(storedRefresh);
-
-  // Persist rotated tokens — refresh tokens are single-use.
-  writeFileSync(
-    profileAuthPath,
-    JSON.stringify(
-      {
-        ...stored,
-        [providerId]: {
-          ...creds,
-          access: tokens.access,
-          refresh: tokens.refresh,
-          expires: tokens.expires,
-          ...(tokens.accountId ? { accountId: tokens.accountId } : {}),
-        },
-      },
-      null,
-      2,
-    ),
-  );
-
-  const accountId =
-    tokens.accountId ??
-    (typeof creds.accountId === "string" ? creds.accountId : undefined);
-
+  const accountId = jwtAccountId(accessToken);
   const result: CodexUsageResult = {};
-  const email = jwtEmail(tokens.idToken) ?? jwtEmail(tokens.access);
-  if (email) result.email = email;
+  const jwtMail = jwtEmail(accessToken);
+  if (jwtMail) result.email = jwtMail;
   if (accountId) result.accountId = accountId;
 
   const headers: Record<string, string> = {
-    Authorization: `Bearer ${tokens.access}`,
+    Authorization: `Bearer ${accessToken}`,
     "User-Agent": USER_AGENT,
     originator: ORIGINATOR,
   };
@@ -245,9 +197,10 @@ export async function fetchCodexProfileUsage(
   if (!response.ok) return result;
 
   const body = (await response.json()) as Record<string, unknown>;
-  Object.assign(result, parseCodexUsageBody(body));
-  // Prefer JWT email if the API omitted it.
-  if (!result.email && email) result.email = email;
+  const parsed = parseCodexUsageBody(body);
+  // Body email is authoritative (the Codex access JWT often omits it).
+  Object.assign(result, parsed);
+  if (!result.email && jwtMail) result.email = jwtMail;
   if (accountId) result.accountId = accountId;
   return result;
 }

--- a/agent/auth-profiles/codex-usage.ts
+++ b/agent/auth-profiles/codex-usage.ts
@@ -1,0 +1,189 @@
+import { readFileSync, writeFileSync } from "node:fs";
+
+const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
+const TOKEN_URL = "https://auth.openai.com/oauth/token";
+const RATE_LIMITS_URL = "https://chatgpt.com/backend-api/codex/rate_limits";
+
+export interface CodexUsageWindow {
+  usedPercent: number;
+  resetsAt?: number;
+  windowDurationMins?: number;
+}
+
+export interface CodexUsageResult {
+  email?: string;
+  planType?: string;
+  primary?: CodexUsageWindow;
+  secondary?: CodexUsageWindow;
+  credits?: { balance?: string; hasCredits?: boolean; unlimited?: boolean };
+}
+
+interface TokenResult {
+  access: string;
+  refresh: string;
+  expires: number;
+  accountId?: string;
+  idToken?: string;
+}
+
+function decodeJwtPayload(token: string): Record<string, unknown> | undefined {
+  const parts = token.split(".");
+  if (parts.length < 2) return undefined;
+  const segment = parts[1]!;
+  const normalized = segment.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = normalized.padEnd(
+    normalized.length + ((4 - (normalized.length % 4)) % 4),
+    "=",
+  );
+  try {
+    return JSON.parse(Buffer.from(padded, "base64").toString("utf8")) as Record<
+      string,
+      unknown
+    >;
+  } catch {
+    return undefined;
+  }
+}
+
+function extractEmail(accessToken: string): string | undefined {
+  const payload = decodeJwtPayload(accessToken);
+  if (!payload) return undefined;
+  if (typeof payload.email === "string") return payload.email;
+  const auth = payload["https://api.openai.com/auth"] as
+    | Record<string, unknown>
+    | undefined;
+  if (typeof auth?.email === "string") return auth.email;
+  return undefined;
+}
+
+function extractAccountId(accessToken: string): string | undefined {
+  const payload = decodeJwtPayload(accessToken);
+  const auth = payload?.["https://api.openai.com/auth"] as
+    | Record<string, unknown>
+    | undefined;
+  const id = auth?.chatgpt_account_id;
+  return typeof id === "string" && id.length > 0 ? id : undefined;
+}
+
+async function refreshToken(refreshToken: string): Promise<TokenResult> {
+  const response = await fetch(TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+      client_id: CLIENT_ID,
+    }),
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(`token refresh failed: ${response.status} ${text.slice(0, 200)}`);
+  }
+  const json = (await response.json()) as Record<string, unknown>;
+  if (
+    typeof json.access_token !== "string" ||
+    typeof json.refresh_token !== "string" ||
+    typeof json.expires_in !== "number"
+  ) {
+    throw new Error("token refresh response missing required fields");
+  }
+  return {
+    access: json.access_token,
+    refresh: json.refresh_token,
+    expires: Date.now() + (json.expires_in as number) * 1000,
+    accountId: extractAccountId(json.access_token),
+    idToken:
+      typeof json.id_token === "string" ? json.id_token : undefined,
+  };
+}
+
+function parseWindow(value: unknown): CodexUsageWindow | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const rec = value as Record<string, unknown>;
+  if (typeof rec.usedPercent !== "number") return undefined;
+  const w: CodexUsageWindow = { usedPercent: rec.usedPercent };
+  if (typeof rec.resetsAt === "number") w.resetsAt = rec.resetsAt;
+  if (typeof rec.windowDurationMins === "number") {
+    w.windowDurationMins = rec.windowDurationMins;
+  }
+  return w;
+}
+
+export async function fetchCodexProfileUsage(
+  profileAuthPath: string,
+  providerId: string,
+): Promise<CodexUsageResult> {
+  const stored = JSON.parse(readFileSync(profileAuthPath, "utf8")) as Record<
+    string,
+    unknown
+  >;
+  const entry = stored[providerId];
+  if (!entry || typeof entry !== "object") {
+    throw new Error("no stored credentials for provider");
+  }
+  const creds = entry as Record<string, unknown>;
+  const storedRefresh =
+    typeof creds.refresh === "string"
+      ? creds.refresh
+      : typeof creds.refresh_token === "string"
+        ? creds.refresh_token
+        : undefined;
+  if (!storedRefresh) {
+    throw new Error("no refresh token stored");
+  }
+
+  const tokens = await refreshToken(storedRefresh);
+
+  // Persist the refreshed tokens back to the profile's auth.json
+  const updated = {
+    ...stored,
+    [providerId]: {
+      ...creds,
+      access: tokens.access,
+      refresh: tokens.refresh,
+      expires: tokens.expires,
+      ...(tokens.accountId ? { accountId: tokens.accountId } : {}),
+    },
+  };
+  writeFileSync(profileAuthPath, JSON.stringify(updated, null, 2));
+
+  const email =
+    (tokens.idToken ? extractEmail(tokens.idToken) : undefined) ??
+    extractEmail(tokens.access);
+  const result: CodexUsageResult = {};
+  if (email) result.email = email;
+
+  let response: Response | undefined;
+  try {
+    response = await fetch(RATE_LIMITS_URL, {
+      headers: { Authorization: `Bearer ${tokens.access}` },
+    });
+  } catch {
+    return result;
+  }
+  if (!response.ok) {
+    return result;
+  }
+  const body = (await response.json()) as Record<string, unknown>;
+  if (typeof body.planType === "string") result.planType = body.planType;
+  const primary = parseWindow(body.primary);
+  if (primary) result.primary = primary;
+  const secondary = parseWindow(body.secondary);
+  if (secondary) result.secondary = secondary;
+  if (body.credits && typeof body.credits === "object") {
+    const credits = body.credits as Record<string, unknown>;
+    result.credits = {
+      balance:
+        typeof credits.balance === "string" ? credits.balance : undefined,
+      hasCredits:
+        typeof credits.hasCredits === "boolean"
+          ? credits.hasCredits
+          : undefined,
+      unlimited:
+        typeof credits.unlimited === "boolean"
+          ? credits.unlimited
+          : undefined,
+    };
+  }
+  return result;
+}

--- a/agent/auth-profiles/codex-usage.ts
+++ b/agent/auth-profiles/codex-usage.ts
@@ -48,8 +48,8 @@ interface RefreshedTokens {
 
 function decodeJwtPayload(token: string): Record<string, unknown> | undefined {
   const parts = token.split(".");
-  if (parts.length < 2) return undefined;
-  const segment = parts[1]!;
+  const segment = parts[1];
+  if (!segment) return undefined;
   const normalized = segment.replace(/-/g, "+").replace(/_/g, "/");
   const padded = normalized.padEnd(
     normalized.length + ((4 - (normalized.length % 4)) % 4),
@@ -117,7 +117,7 @@ async function refreshTokens(refreshToken: string): Promise<RefreshedTokens> {
     access: json.access_token,
     refresh: json.refresh_token,
     idToken: typeof json.id_token === "string" ? json.id_token : undefined,
-    expires: Date.now() + (json.expires_in as number) * 1000,
+    expires: Date.now() + json.expires_in * 1000,
     accountId: jwtAccountId(json.access_token),
   };
 }

--- a/agent/auth-profiles/codex-usage.ts
+++ b/agent/auth-profiles/codex-usage.ts
@@ -1,29 +1,49 @@
+/**
+ * Codex account usage + identity, fetched directly from OpenAI's HTTP API
+ * using a profile's own stored OAuth credentials. No dependency on the
+ * `codex` binary — this keeps each account fully isolated (the bearer
+ * token scopes the request to exactly one account) and avoids PATH /
+ * temp-dir fragility.
+ *
+ * Self-contained and side-effect-light: the only write is rotating the
+ * refreshed token back into the profile's auth.json. Designed to be
+ * reusable anywhere in the UI that needs Codex usage/identity, not just
+ * the Accounts panel.
+ */
 import { readFileSync, writeFileSync } from "node:fs";
 
 const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
 const TOKEN_URL = "https://auth.openai.com/oauth/token";
-const RATE_LIMITS_URL = "https://chatgpt.com/backend-api/codex/rate_limits";
+const USAGE_URL = "https://chatgpt.com/backend-api/codex/usage";
+const USER_AGENT = "codex_cli_rs/0.136.0 (Aethon)";
+const ORIGINATOR = "codex_cli_rs";
 
 export interface CodexUsageWindow {
+  /** 0-100 percent of the window consumed. */
   usedPercent: number;
+  /** Unix epoch (seconds) when the window resets. */
   resetsAt?: number;
+  /** Window length in minutes (300 = 5-hour, 10080 = weekly). */
   windowDurationMins?: number;
 }
 
 export interface CodexUsageResult {
   email?: string;
+  accountId?: string;
   planType?: string;
+  /** True when the account has hit its limit and prompts will be rejected. */
+  limitReached?: boolean;
   primary?: CodexUsageWindow;
   secondary?: CodexUsageWindow;
   credits?: { balance?: string; hasCredits?: boolean; unlimited?: boolean };
 }
 
-interface TokenResult {
+interface RefreshedTokens {
   access: string;
   refresh: string;
+  idToken?: string;
   expires: number;
   accountId?: string;
-  idToken?: string;
 }
 
 function decodeJwtPayload(token: string): Record<string, unknown> | undefined {
@@ -45,19 +65,20 @@ function decodeJwtPayload(token: string): Record<string, unknown> | undefined {
   }
 }
 
-function extractEmail(accessToken: string): string | undefined {
-  const payload = decodeJwtPayload(accessToken);
+function jwtEmail(token: string | undefined): string | undefined {
+  if (!token) return undefined;
+  const payload = decodeJwtPayload(token);
   if (!payload) return undefined;
   if (typeof payload.email === "string") return payload.email;
   const auth = payload["https://api.openai.com/auth"] as
     | Record<string, unknown>
     | undefined;
-  if (typeof auth?.email === "string") return auth.email;
-  return undefined;
+  return typeof auth?.email === "string" ? auth.email : undefined;
 }
 
-function extractAccountId(accessToken: string): string | undefined {
-  const payload = decodeJwtPayload(accessToken);
+function jwtAccountId(token: string | undefined): string | undefined {
+  if (!token) return undefined;
+  const payload = decodeJwtPayload(token);
   const auth = payload?.["https://api.openai.com/auth"] as
     | Record<string, unknown>
     | undefined;
@@ -65,7 +86,10 @@ function extractAccountId(accessToken: string): string | undefined {
   return typeof id === "string" && id.length > 0 ? id : undefined;
 }
 
-async function refreshToken(refreshToken: string): Promise<TokenResult> {
+/** Exchange a stored refresh token for a fresh access/id token set.
+ *  OpenAI rotates refresh tokens (single-use), so the caller must persist
+ *  the returned `refresh` value. */
+async function refreshTokens(refreshToken: string): Promise<RefreshedTokens> {
   const response = await fetch(TOKEN_URL, {
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
@@ -77,7 +101,9 @@ async function refreshToken(refreshToken: string): Promise<TokenResult> {
   });
   if (!response.ok) {
     const text = await response.text().catch(() => "");
-    throw new Error(`token refresh failed: ${response.status} ${text.slice(0, 200)}`);
+    throw new Error(
+      `token refresh failed: ${response.status} ${text.slice(0, 200)}`,
+    );
   }
   const json = (await response.json()) as Record<string, unknown>;
   if (
@@ -90,25 +116,68 @@ async function refreshToken(refreshToken: string): Promise<TokenResult> {
   return {
     access: json.access_token,
     refresh: json.refresh_token,
+    idToken: typeof json.id_token === "string" ? json.id_token : undefined,
     expires: Date.now() + (json.expires_in as number) * 1000,
-    accountId: extractAccountId(json.access_token),
-    idToken:
-      typeof json.id_token === "string" ? json.id_token : undefined,
+    accountId: jwtAccountId(json.access_token),
   };
 }
 
-function parseWindow(value: unknown): CodexUsageWindow | undefined {
+function windowFrom(value: unknown): CodexUsageWindow | undefined {
   if (!value || typeof value !== "object") return undefined;
   const rec = value as Record<string, unknown>;
-  if (typeof rec.usedPercent !== "number") return undefined;
-  const w: CodexUsageWindow = { usedPercent: rec.usedPercent };
-  if (typeof rec.resetsAt === "number") w.resetsAt = rec.resetsAt;
-  if (typeof rec.windowDurationMins === "number") {
-    w.windowDurationMins = rec.windowDurationMins;
+  if (typeof rec.used_percent !== "number") return undefined;
+  const w: CodexUsageWindow = { usedPercent: rec.used_percent };
+  if (typeof rec.reset_at === "number") w.resetsAt = rec.reset_at;
+  if (typeof rec.limit_window_seconds === "number") {
+    w.windowDurationMins = Math.round(rec.limit_window_seconds / 60);
   }
   return w;
 }
 
+/** Parse the `/backend-api/codex/usage` response body into our shape. */
+export function parseCodexUsageBody(
+  body: Record<string, unknown>,
+): Omit<CodexUsageResult, "accountId"> {
+  const result: Omit<CodexUsageResult, "accountId"> = {};
+  if (typeof body.email === "string") result.email = body.email;
+  if (typeof body.plan_type === "string") result.planType = body.plan_type;
+
+  const rateLimit = body.rate_limit as Record<string, unknown> | undefined;
+  if (rateLimit && typeof rateLimit === "object") {
+    if (typeof rateLimit.limit_reached === "boolean") {
+      result.limitReached = rateLimit.limit_reached;
+    }
+    const primary = windowFrom(rateLimit.primary_window);
+    if (primary) result.primary = primary;
+    const secondary = windowFrom(rateLimit.secondary_window);
+    if (secondary) result.secondary = secondary;
+  }
+
+  const credits = body.credits as Record<string, unknown> | undefined;
+  if (credits && typeof credits === "object") {
+    result.credits = {
+      balance:
+        typeof credits.balance === "number"
+          ? String(credits.balance)
+          : typeof credits.balance === "string"
+            ? credits.balance
+            : undefined,
+      hasCredits:
+        typeof credits.has_credits === "boolean"
+          ? credits.has_credits
+          : undefined,
+      unlimited:
+        typeof credits.unlimited === "boolean" ? credits.unlimited : undefined,
+    };
+  }
+  return result;
+}
+
+/**
+ * Fetch usage + identity for a single Codex profile. Refreshes the token,
+ * persists the rotated refresh token back to the profile, then calls the
+ * usage API scoped to that account.
+ */
 export async function fetchCodexProfileUsage(
   profileAuthPath: string,
   providerId: string,
@@ -128,62 +197,57 @@ export async function fetchCodexProfileUsage(
       : typeof creds.refresh_token === "string"
         ? creds.refresh_token
         : undefined;
-  if (!storedRefresh) {
-    throw new Error("no refresh token stored");
-  }
+  if (!storedRefresh) throw new Error("no refresh token stored");
 
-  const tokens = await refreshToken(storedRefresh);
+  const tokens = await refreshTokens(storedRefresh);
 
-  // Persist the refreshed tokens back to the profile's auth.json
-  const updated = {
-    ...stored,
-    [providerId]: {
-      ...creds,
-      access: tokens.access,
-      refresh: tokens.refresh,
-      expires: tokens.expires,
-      ...(tokens.accountId ? { accountId: tokens.accountId } : {}),
-    },
-  };
-  writeFileSync(profileAuthPath, JSON.stringify(updated, null, 2));
+  // Persist rotated tokens — refresh tokens are single-use.
+  writeFileSync(
+    profileAuthPath,
+    JSON.stringify(
+      {
+        ...stored,
+        [providerId]: {
+          ...creds,
+          access: tokens.access,
+          refresh: tokens.refresh,
+          expires: tokens.expires,
+          ...(tokens.accountId ? { accountId: tokens.accountId } : {}),
+        },
+      },
+      null,
+      2,
+    ),
+  );
 
-  const email =
-    (tokens.idToken ? extractEmail(tokens.idToken) : undefined) ??
-    extractEmail(tokens.access);
+  const accountId =
+    tokens.accountId ??
+    (typeof creds.accountId === "string" ? creds.accountId : undefined);
+
   const result: CodexUsageResult = {};
+  const email = jwtEmail(tokens.idToken) ?? jwtEmail(tokens.access);
   if (email) result.email = email;
+  if (accountId) result.accountId = accountId;
 
-  let response: Response | undefined;
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${tokens.access}`,
+    "User-Agent": USER_AGENT,
+    originator: ORIGINATOR,
+  };
+  if (accountId) headers["chatgpt-account-id"] = accountId;
+
+  let response: Response;
   try {
-    response = await fetch(RATE_LIMITS_URL, {
-      headers: { Authorization: `Bearer ${tokens.access}` },
-    });
+    response = await fetch(USAGE_URL, { headers });
   } catch {
-    return result;
+    return result; // network error — identity is still useful
   }
-  if (!response.ok) {
-    return result;
-  }
+  if (!response.ok) return result;
+
   const body = (await response.json()) as Record<string, unknown>;
-  if (typeof body.planType === "string") result.planType = body.planType;
-  const primary = parseWindow(body.primary);
-  if (primary) result.primary = primary;
-  const secondary = parseWindow(body.secondary);
-  if (secondary) result.secondary = secondary;
-  if (body.credits && typeof body.credits === "object") {
-    const credits = body.credits as Record<string, unknown>;
-    result.credits = {
-      balance:
-        typeof credits.balance === "string" ? credits.balance : undefined,
-      hasCredits:
-        typeof credits.hasCredits === "boolean"
-          ? credits.hasCredits
-          : undefined,
-      unlimited:
-        typeof credits.unlimited === "boolean"
-          ? credits.unlimited
-          : undefined,
-    };
-  }
+  Object.assign(result, parseCodexUsageBody(body));
+  // Prefer JWT email if the API omitted it.
+  if (!result.email && email) result.email = email;
+  if (accountId) result.accountId = accountId;
   return result;
 }

--- a/agent/auth-profiles/codex-usage.ts
+++ b/agent/auth-profiles/codex-usage.ts
@@ -122,12 +122,17 @@ export function parseCodexUsageBody(
     | Record<string, unknown>
     | undefined;
   if (rateLimit && typeof rateLimit === "object") {
+    // `rate_limit_reached_type` appears either inside the rate-limit object
+    // or as a sibling at the body top level depending on the payload variant;
+    // a non-null/non-empty value means the account is exhausted.
+    const reachedType =
+      "rate_limit_reached_type" in rateLimit
+        ? rateLimit.rate_limit_reached_type
+        : body.rate_limit_reached_type;
     if (typeof rateLimit.limit_reached === "boolean") {
       result.limitReached = rateLimit.limit_reached;
-    } else if ("rate_limit_reached_type" in rateLimit) {
-      result.limitReached =
-        rateLimit.rate_limit_reached_type != null &&
-        rateLimit.rate_limit_reached_type !== "";
+    } else if (reachedType !== undefined) {
+      result.limitReached = reachedType != null && reachedType !== "";
     }
     if (typeof rateLimit.plan_type === "string" && !result.planType) {
       result.planType = rateLimit.plan_type;

--- a/agent/auth-profiles/index.ts
+++ b/agent/auth-profiles/index.ts
@@ -27,4 +27,5 @@ export {
   refreshTabSessionModelFromAuthServices,
   saveAuthProfiles,
   servicesForProvider,
+  tryAutoSwitchOnUsageLimit,
 } from "./manager";

--- a/agent/auth-profiles/manager.test.ts
+++ b/agent/auth-profiles/manager.test.ts
@@ -16,6 +16,7 @@ import {
   defaultProfileIdForTab,
   handleAuthProfileMessage,
   modelRegistryForModelId,
+  parseIdTokenEmail,
   refreshAuthServicesForTab,
 } from "./manager";
 import {
@@ -270,6 +271,26 @@ describe("auth profile manager", () => {
     expect(sent).toContainEqual(
       expect.objectContaining({ type: "auth_profiles" }),
     );
+  });
+
+  it("parses the email claim out of a JWT id_token", () => {
+    const payload = { email: "codex-user@example.com", sub: "abc" };
+    const encoded = Buffer.from(JSON.stringify(payload), "utf8")
+      .toString("base64")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+    const idToken = `header.${encoded}.signature`;
+
+    expect(parseIdTokenEmail(idToken)).toBe("codex-user@example.com");
+  });
+
+  it("returns undefined for malformed id_tokens or missing email", () => {
+    expect(parseIdTokenEmail("not-a-jwt")).toBeUndefined();
+    const noEmail = Buffer.from(JSON.stringify({ sub: "abc" }), "utf8")
+      .toString("base64url");
+    expect(parseIdTokenEmail(`header.${noEmail}.sig`)).toBeUndefined();
+    expect(parseIdTokenEmail("header.!!!notbase64!!!.sig")).toBeUndefined();
   });
 
   it("rejects deleting unknown or unsafe profile ids before removing files", async () => {

--- a/agent/auth-profiles/manager.test.ts
+++ b/agent/auth-profiles/manager.test.ts
@@ -23,6 +23,7 @@ import {
   authProfileAuthPath,
   createProfileMeta,
   loadAuthProfilesState,
+  saveAuthProfilesState,
   upsertProfileMeta,
 } from "./store";
 
@@ -271,6 +272,47 @@ describe("auth profile manager", () => {
     expect(sent).toContainEqual(
       expect.objectContaining({ type: "auth_profiles" }),
     );
+  });
+
+  it("auth_profile_apply refuses to switch a worker tab mid-prompt", async () => {
+    const userDir = tempUserDir();
+    const state = makeState(userDir);
+    const profileId = addProfile(state, "openai-codex", "Codex Two");
+    // handleApplyForTab reloads profiles from disk (the worker's in-memory
+    // list may be stale), so the profile must be persisted.
+    saveAuthProfilesState(userDir, state.authProfiles);
+    const busy = fakeTab("openai-codex/gpt-5.5", true);
+    state.tabs.set("tab-worker", busy);
+    state.tabAuthProfileIds.set("tab-worker", "openai-codex-other");
+    const sent: Record<string, unknown>[] = [];
+    const deps = {
+      send: (m: Record<string, unknown>) => sent.push(m),
+    } as DispatcherDeps;
+
+    await handleAuthProfileMessage(state, deps, {
+      type: "auth_profile_apply",
+      tabId: "tab-worker",
+      profileId,
+    });
+
+    // Busy guard: assignment unchanged, a notice is emitted, no recreate.
+    expect(state.tabAuthProfileIds.get("tab-worker")).toBe("openai-codex-other");
+    expect(sent).toContainEqual(
+      expect.objectContaining({ type: "notice", tabId: "tab-worker" }),
+    );
+  });
+
+  it("auth_profile_apply is a no-op for an unknown profile id", async () => {
+    const state = makeState();
+    const deps = { send: vi.fn() } as unknown as DispatcherDeps;
+
+    await handleAuthProfileMessage(state, deps, {
+      type: "auth_profile_apply",
+      tabId: "tab-worker",
+      profileId: "does-not-exist",
+    });
+
+    expect(state.tabAuthProfileIds.has("tab-worker")).toBe(false);
   });
 
   it("parses the email claim out of a JWT id_token", () => {

--- a/agent/auth-profiles/manager.ts
+++ b/agent/auth-profiles/manager.ts
@@ -807,8 +807,6 @@ function handleDelete(
 }
 
 const CODEX_PROVIDER_ID = "openai-codex";
-const CODEX_RATE_LIMITS_URL =
-  "https://chatgpt.com/backend-api/codex/rate_limits";
 
 interface AuthProfileUsageWindow {
   usedPercent: number;
@@ -858,6 +856,95 @@ function parseUsageWindow(value: unknown): AuthProfileUsageWindow | undefined {
   return window;
 }
 
+function readCodexEmail(): string | undefined {
+  const codexHome =
+    process.env.CODEX_HOME ?? join(process.env.HOME ?? "", ".codex");
+  const authPath = join(codexHome, "auth.json");
+  try {
+    const data = JSON.parse(readFileSync(authPath, "utf8")) as Record<
+      string,
+      unknown
+    >;
+    const tokens = data.tokens as Record<string, unknown> | undefined;
+    const idToken =
+      typeof tokens?.id_token === "string" ? tokens.id_token : undefined;
+    return idToken ? parseIdTokenEmail(idToken) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveCodexBinary(): string {
+  return (
+    process.env.BURNRATE_CODEX_BIN ??
+    process.env.CODEX_BIN ??
+    "codex"
+  );
+}
+
+async function fetchCodexRateLimits(): Promise<Record<string, unknown>> {
+  const { spawn } = await import("node:child_process");
+  return new Promise((resolve, reject) => {
+    const child = spawn(resolveCodexBinary(), [
+      "app-server",
+      "--listen",
+      "stdio://",
+    ]);
+    const timeout = setTimeout(() => {
+      child.kill();
+      reject(new Error("codex app-server timed out"));
+    }, 10_000);
+    let buffer = "";
+    child.stdout.on("data", (chunk: Buffer) => {
+      buffer += chunk.toString("utf8");
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        try {
+          const msg = JSON.parse(trimmed) as { id?: number; result?: unknown };
+          if (msg.id === 2 && msg.result) {
+            clearTimeout(timeout);
+            child.kill();
+            resolve(msg.result as Record<string, unknown>);
+          }
+        } catch {
+          /* non-JSON line, skip */
+        }
+      }
+    });
+    child.on("error", (err: Error) => {
+      clearTimeout(timeout);
+      reject(new Error(`codex not found: ${err.message}`));
+    });
+    child.on("close", (code: number | null) => {
+      clearTimeout(timeout);
+      reject(new Error(`codex exited with code ${code}`));
+    });
+    const init = JSON.stringify({
+      id: 1,
+      method: "initialize",
+      params: {
+        clientInfo: { name: "aethon", title: "Aethon", version: "0.1.0" },
+        capabilities: { experimentalApi: true },
+      },
+    });
+    const initialized = JSON.stringify({ method: "initialized" });
+    const read = JSON.stringify({
+      id: 2,
+      method: "account/rateLimits/read",
+    });
+    child.stdin.write(init + "\n");
+    setTimeout(() => {
+      child.stdin.write(initialized + "\n");
+      setTimeout(() => {
+        child.stdin.write(read + "\n");
+      }, 100);
+    }, 100);
+  });
+}
+
 async function handleFetchUsage(
   state: AethonAgentState,
   deps: Pick<DispatcherDeps, "send">,
@@ -867,45 +954,27 @@ async function handleFetchUsage(
   try {
     const profile = findProfile(state, profileId);
     if (!profile) throw new Error("unknown profileId");
-    const authPath = authProfileAuthPath(state.userDir, profile.id);
-    const parsed = JSON.parse(readFileSync(authPath, "utf8")) as Record<
-      string,
-      unknown
-    >;
-    const entry = parsed[profile.providerId];
-    if (!entry || typeof entry !== "object") {
-      throw new Error("no stored credentials for provider");
-    }
-    const creds = entry as Record<string, unknown>;
-    const accessToken =
-      typeof creds.access_token === "string" ? creds.access_token : undefined;
-    const idToken =
-      typeof creds.id_token === "string" ? creds.id_token : undefined;
-    const email = idToken ? parseIdTokenEmail(idToken) : undefined;
 
     const result: AuthProfileUsageMessage = {
       type: "auth_profile_usage",
       profileId: profile.id,
     };
-    if (email) result.email = email;
 
-    if (profile.providerId === CODEX_PROVIDER_ID && accessToken) {
-      const response = await fetch(CODEX_RATE_LIMITS_URL, {
-        headers: { Authorization: `Bearer ${accessToken}` },
-      });
-      if (!response.ok) {
-        throw new Error(
-          `rate_limits request failed: ${response.status} ${response.statusText}`,
-        );
+    if (profile.providerId === CODEX_PROVIDER_ID) {
+      const email = readCodexEmail();
+      if (email) result.email = email;
+
+      const body = await fetchCodexRateLimits();
+      const rateLimits = (body.rateLimits ?? body) as Record<string, unknown>;
+      if (typeof rateLimits.planType === "string") {
+        result.planType = rateLimits.planType;
       }
-      const body = (await response.json()) as Record<string, unknown>;
-      if (typeof body.planType === "string") result.planType = body.planType;
-      const primary = parseUsageWindow(body.primary);
+      const primary = parseUsageWindow(rateLimits.primary);
       if (primary) result.primary = primary;
-      const secondary = parseUsageWindow(body.secondary);
+      const secondary = parseUsageWindow(rateLimits.secondary);
       if (secondary) result.secondary = secondary;
-      if (body.credits && typeof body.credits === "object") {
-        const credits = body.credits as Record<string, unknown>;
+      if (rateLimits.credits && typeof rateLimits.credits === "object") {
+        const credits = rateLimits.credits as Record<string, unknown>;
         result.credits = {
           balance:
             typeof credits.balance === "string" ? credits.balance : undefined,
@@ -918,6 +987,30 @@ async function handleFetchUsage(
               ? credits.unlimited
               : undefined,
         };
+      }
+    } else {
+      const authPath = authProfileAuthPath(state.userDir, profile.id);
+      try {
+        const parsed = JSON.parse(readFileSync(authPath, "utf8")) as Record<
+          string,
+          unknown
+        >;
+        const entry = parsed[profile.providerId];
+        if (entry && typeof entry === "object") {
+          const creds = entry as Record<string, unknown>;
+          const idToken =
+            typeof creds.id_token === "string"
+              ? creds.id_token
+              : typeof creds.idToken === "string"
+                ? creds.idToken
+                : undefined;
+          if (idToken) {
+            const email = parseIdTokenEmail(idToken);
+            if (email) result.email = email;
+          }
+        }
+      } catch {
+        /* no credentials to read email from */
       }
     }
 

--- a/agent/auth-profiles/manager.ts
+++ b/agent/auth-profiles/manager.ts
@@ -258,6 +258,9 @@ export async function handleAuthProfileMessage(
     case "auth_profile_apply":
       await handleApplyForTab(state, deps, msg);
       return true;
+    case "auth_profile_record":
+      handleRecordForTab(state, msg);
+      return true;
     case "auth_profile_set_default":
       handleSetDefault(state, deps, msg);
       return true;
@@ -824,6 +827,29 @@ async function handleApplyForTab(
     initialModel: nextModel || desiredModel,
   });
   markProfileUsed(state, profile.id);
+}
+
+/**
+ * Record a tab's account selection in the GLOBAL bridge's map without
+ * touching the session or re-emitting. The frontend relays every
+ * `auth_profile_changed` here so the global bridge's `tabAuthProfileIds`
+ * stays in sync with worker-side switches (e.g. usage-limit auto-switch) —
+ * otherwise a later global `auth_profiles` snapshot would revert the tab to
+ * the stale account. Deliberately emit-free so it can't loop with the
+ * `auth_profile_changed` that triggered it.
+ */
+function handleRecordForTab(
+  state: AethonAgentState,
+  msg: InboundMessage,
+): void {
+  const tabId = stringField(msg.tabId);
+  const profileId = stringField(msg.profileId);
+  if (!tabId || !profileId) return;
+  if (!state.authProfiles.profiles.some((p) => p.id === profileId)) {
+    state.authProfiles = loadAuthProfilesState(state.userDir);
+    if (!state.authProfiles.profiles.some((p) => p.id === profileId)) return;
+  }
+  state.tabAuthProfileIds.set(tabId, profileId);
 }
 
 /** Resolve a `provider/id` model string (from an apply payload) against a

--- a/agent/auth-profiles/manager.ts
+++ b/agent/auth-profiles/manager.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { mkdirSync, statSync } from "node:fs";
+import { mkdirSync, readFileSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
 import {
   AuthStorage,
@@ -259,6 +259,9 @@ export async function handleAuthProfileMessage(
       return true;
     case "auth_profile_delete":
       handleDelete(state, deps, msg);
+      return true;
+    case "auth_profile_fetch_usage":
+      void handleFetchUsage(state, deps, msg);
       return true;
     default:
       return false;
@@ -801,6 +804,132 @@ function handleDelete(
   removeProfile(state, profileId);
   saveAuthProfiles(state);
   emitAuthProfiles(state, deps);
+}
+
+const CODEX_PROVIDER_ID = "openai-codex";
+const CODEX_RATE_LIMITS_URL =
+  "https://chatgpt.com/backend-api/codex/rate_limits";
+
+interface AuthProfileUsageWindow {
+  usedPercent: number;
+  resetsAt?: number;
+  windowDurationMins?: number;
+}
+
+interface AuthProfileUsageMessage {
+  type: "auth_profile_usage";
+  profileId: string;
+  email?: string;
+  planType?: string;
+  primary?: AuthProfileUsageWindow;
+  secondary?: AuthProfileUsageWindow;
+  credits?: { balance?: string; hasCredits?: boolean; unlimited?: boolean };
+  error?: string;
+}
+
+export function parseIdTokenEmail(idToken: string): string | undefined {
+  const segments = idToken.split(".");
+  if (segments.length < 2) return undefined;
+  const payload = segments[1];
+  if (!payload) return undefined;
+  const normalized = payload.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = normalized.padEnd(
+    normalized.length + ((4 - (normalized.length % 4)) % 4),
+    "=",
+  );
+  try {
+    const json = Buffer.from(padded, "base64").toString("utf8");
+    const claims = JSON.parse(json) as { email?: unknown };
+    return typeof claims.email === "string" ? claims.email : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function parseUsageWindow(value: unknown): AuthProfileUsageWindow | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const rec = value as Record<string, unknown>;
+  if (typeof rec.usedPercent !== "number") return undefined;
+  const window: AuthProfileUsageWindow = { usedPercent: rec.usedPercent };
+  if (typeof rec.resetsAt === "number") window.resetsAt = rec.resetsAt;
+  if (typeof rec.windowDurationMins === "number") {
+    window.windowDurationMins = rec.windowDurationMins;
+  }
+  return window;
+}
+
+async function handleFetchUsage(
+  state: AethonAgentState,
+  deps: Pick<DispatcherDeps, "send">,
+  msg: InboundMessage,
+): Promise<void> {
+  const profileId = stringField(msg.profileId);
+  try {
+    const profile = findProfile(state, profileId);
+    if (!profile) throw new Error("unknown profileId");
+    const authPath = authProfileAuthPath(state.userDir, profile.id);
+    const parsed = JSON.parse(readFileSync(authPath, "utf8")) as Record<
+      string,
+      unknown
+    >;
+    const entry = parsed[profile.providerId];
+    if (!entry || typeof entry !== "object") {
+      throw new Error("no stored credentials for provider");
+    }
+    const creds = entry as Record<string, unknown>;
+    const accessToken =
+      typeof creds.access_token === "string" ? creds.access_token : undefined;
+    const idToken =
+      typeof creds.id_token === "string" ? creds.id_token : undefined;
+    const email = idToken ? parseIdTokenEmail(idToken) : undefined;
+
+    const result: AuthProfileUsageMessage = {
+      type: "auth_profile_usage",
+      profileId: profile.id,
+    };
+    if (email) result.email = email;
+
+    if (profile.providerId === CODEX_PROVIDER_ID && accessToken) {
+      const response = await fetch(CODEX_RATE_LIMITS_URL, {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+      if (!response.ok) {
+        throw new Error(
+          `rate_limits request failed: ${response.status} ${response.statusText}`,
+        );
+      }
+      const body = (await response.json()) as Record<string, unknown>;
+      if (typeof body.planType === "string") result.planType = body.planType;
+      const primary = parseUsageWindow(body.primary);
+      if (primary) result.primary = primary;
+      const secondary = parseUsageWindow(body.secondary);
+      if (secondary) result.secondary = secondary;
+      if (body.credits && typeof body.credits === "object") {
+        const credits = body.credits as Record<string, unknown>;
+        result.credits = {
+          balance:
+            typeof credits.balance === "string" ? credits.balance : undefined,
+          hasCredits:
+            typeof credits.hasCredits === "boolean"
+              ? credits.hasCredits
+              : undefined,
+          unlimited:
+            typeof credits.unlimited === "boolean"
+              ? credits.unlimited
+              : undefined,
+        };
+      }
+    }
+
+    deps.send(result);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    deps.send({
+      type: "auth_profile_usage",
+      profileId,
+      error: message,
+    });
+  }
 }
 
 function removeProfile(state: AethonAgentState, profileId: string): void {

--- a/agent/auth-profiles/manager.ts
+++ b/agent/auth-profiles/manager.ts
@@ -971,7 +971,13 @@ export async function tryAutoSwitchOnUsageLimit(
   state.currentAgentTabId = tabId;
   void state.tabContext.run(tabId, () => continueTurn.call(agent)).catch(
     (err: unknown) => {
+      // Mirror the retry path's full cleanup so the tab doesn't stay "busy"
+      // and later mutations aren't misattributed to it.
       rec.promptInFlight = false;
+      rec.agentEndFired = true;
+      if (state.currentAgentTabId === tabId) {
+        state.currentAgentTabId = undefined;
+      }
       const message = err instanceof Error ? err.message : String(err);
       deps.send({ type: "error", tabId, message: `auto-switch: ${message}` });
       deps.send({ type: "response_end", tabId });
@@ -1072,7 +1078,7 @@ async function handleFetchUsage(
   msg: InboundMessage,
 ): Promise<void> {
   const profileId = stringField(msg.profileId);
-  logger.scope("auth-usage").info(`fetch usage for ${profileId}`);
+  logger.scope("auth-usage").debug(`fetch usage for ${profileId}`);
   try {
     const profile = findProfile(state, profileId);
     if (!profile) throw new Error("unknown profileId");
@@ -1081,10 +1087,12 @@ async function handleFetchUsage(
       const usage = await fetchCodexUsage(
         profileTokenProvider(state, profile.id, profile.providerId),
       );
+      // debug-level + no email — the account address is PII and the bridge
+      // logger defaults to info.
       logger
         .scope("auth-usage")
-        .info(
-          `${profileId} → email=${usage.email ?? "none"} plan=${usage.planType ?? "none"} primary=${usage.primary?.usedPercent ?? "none"}`,
+        .debug(
+          `${profileId} → hasEmail=${usage.email ? "y" : "n"} plan=${usage.planType ?? "none"} primary=${usage.primary?.usedPercent ?? "none"}`,
         );
       deps.send({
         type: "auth_profile_usage",

--- a/agent/auth-profiles/manager.ts
+++ b/agent/auth-profiles/manager.ts
@@ -24,7 +24,8 @@ import {
   type AuthProfileMeta,
   type AuthProfilesState,
 } from "./store";
-import { makeCodexLimitProbe, pickAvailableAccount } from "./auto-switch";
+import { pickAvailableAccount, type LimitProbe } from "./auto-switch";
+import { fetchCodexUsage, type TokenProvider } from "./codex-usage";
 
 export interface AuthProfileServices {
   authStorage: AuthStorage;
@@ -853,12 +854,18 @@ export async function tryAutoSwitchOnUsageLimit(
   const tried = existing.autoSwitchTried ?? new Set<string>();
   if (currentId) tried.add(currentId);
 
+  const probe: LimitProbe = async (profileId, providerId) => {
+    const usage = await fetchCodexUsage(
+      profileTokenProvider(state, profileId, providerId),
+    );
+    return usage.limitReached === true;
+  };
   const chosen = await pickAvailableAccount(
     state.authProfiles.profiles,
     provider,
     currentId,
     tried,
-    makeCodexLimitProbe(state.userDir),
+    probe,
   );
   if (!chosen) return false;
   tried.add(chosen);
@@ -971,6 +978,17 @@ function handleDelete(
 
 const CODEX_PROVIDER_ID = "openai-codex";
 
+/** A {@link TokenProvider} backed by a profile's pi AuthStorage, so OAuth
+ *  refresh + single-use refresh-token rotation go through pi's cross-process
+ *  lock instead of an unsynchronised file read/write. */
+function profileTokenProvider(
+  state: AethonAgentState,
+  profileId: string,
+  providerId: string,
+): TokenProvider {
+  return () => servicesForProfile(state, profileId).authStorage.getApiKey(providerId);
+}
+
 export function parseIdTokenEmail(idToken: string): string | undefined {
   const segments = idToken.split(".");
   if (segments.length < 2) return undefined;
@@ -1002,9 +1020,9 @@ async function handleFetchUsage(
     if (!profile) throw new Error("unknown profileId");
 
     if (profile.providerId === CODEX_PROVIDER_ID) {
-      const { fetchCodexProfileUsage } = await import("./codex-usage");
-      const authPath = authProfileAuthPath(state.userDir, profile.id);
-      const usage = await fetchCodexProfileUsage(authPath, profile.providerId);
+      const usage = await fetchCodexUsage(
+        profileTokenProvider(state, profile.id, profile.providerId),
+      );
       logger
         .scope("auth-usage")
         .info(

--- a/agent/auth-profiles/manager.ts
+++ b/agent/auth-profiles/manager.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { mkdirSync, readFileSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { logger } from "../logger";
 import {
   AuthStorage,
   getAgentDir,
@@ -843,6 +844,7 @@ async function handleFetchUsage(
   msg: InboundMessage,
 ): Promise<void> {
   const profileId = stringField(msg.profileId);
+  logger.scope("auth-usage").info(`fetch usage for ${profileId}`);
   try {
     const profile = findProfile(state, profileId);
     if (!profile) throw new Error("unknown profileId");
@@ -851,6 +853,11 @@ async function handleFetchUsage(
       const { fetchCodexProfileUsage } = await import("./codex-usage");
       const authPath = authProfileAuthPath(state.userDir, profile.id);
       const usage = await fetchCodexProfileUsage(authPath, profile.providerId);
+      logger
+        .scope("auth-usage")
+        .info(
+          `${profileId} → email=${usage.email ?? "none"} plan=${usage.planType ?? "none"} primary=${usage.primary?.usedPercent ?? "none"}`,
+        );
       deps.send({
         type: "auth_profile_usage",
         profileId: profile.id,

--- a/agent/auth-profiles/manager.ts
+++ b/agent/auth-profiles/manager.ts
@@ -908,7 +908,10 @@ export async function tryAutoSwitchOnUsageLimit(
     tabId,
     message: `Switched to ${chosenProfile?.label ?? "another account"} — previous account hit its usage limit. Continuing…`,
   });
-  emitAuthProfiles(state, deps);
+  // NB: no full `auth_profiles` snapshot here. This may run in a tab worker
+  // whose `tabAuthProfileIds` is worker-local; emitting the snapshot would
+  // clobber the frontend's `activeByTab` for other tabs. The
+  // `auth_profile_changed` delta above updates just this tab's selection.
 
   // Drop the trailing error and re-run the last user turn on the new
   // account (same mechanism the retry path uses, but on fresh credentials).

--- a/agent/auth-profiles/manager.ts
+++ b/agent/auth-profiles/manager.ts
@@ -843,6 +843,10 @@ export async function tryAutoSwitchOnUsageLimit(
 ): Promise<boolean> {
   const existing = state.tabs.get(tabId);
   if (!existing) return false;
+  // A worker bridge's in-memory profile list can be stale (accounts added
+  // after it spawned live only in the global bridge until persisted); reload
+  // from disk so a freshly-added spare account is considered.
+  state.authProfiles = loadAuthProfilesState(state.userDir);
   const currentId = state.tabAuthProfileIds.get(tabId);
   const current = currentId
     ? state.authProfiles.profiles.find((p) => p.id === currentId)
@@ -854,11 +858,15 @@ export async function tryAutoSwitchOnUsageLimit(
   const tried = existing.autoSwitchTried ?? new Set<string>();
   if (currentId) tried.add(currentId);
 
+  // Only choose an account whose usage is *definitively* not limited. A
+  // network/HTTP failure leaves `limitReached` undefined — treat that as
+  // unavailable rather than risk switching onto an unprobeable (possibly
+  // exhausted) account.
   const probe: LimitProbe = async (profileId, providerId) => {
     const usage = await fetchCodexUsage(
       profileTokenProvider(state, profileId, providerId),
     );
-    return usage.limitReached === true;
+    return usage.limitReached !== false;
   };
   const chosen = await pickAvailableAccount(
     state.authProfiles.profiles,

--- a/agent/auth-profiles/manager.ts
+++ b/agent/auth-profiles/manager.ts
@@ -805,23 +805,40 @@ async function handleApplyForTab(
     return;
   }
   const previousModel = existing?.session.model;
-  // Prefer the cwd carried by the message — when this relay is what spawns
-  // an idle-retired/never-spawned worker, the recorded cwd may be missing
-  // and a fallback cwd would land the session in the wrong workspace.
+  // Prefer the cwd/model carried by the message — when this relay is what
+  // spawns an idle-retired/never-spawned worker, `existing` is undefined, so
+  // the recorded cwd may be missing (wrong-workspace fallback) and there is
+  // no previous model (silent reset to the default model).
   const msgCwd = stringField(msg.cwd);
   const cwd = msgCwd || state.tabProjectCwds.get(tabId);
   if (existing) clearPendingContextUsageEmit(existing);
   state.tabs.delete(tabId);
   state.tabAuthProfileIds.set(tabId, profile.id);
   const services = servicesForProfile(state, profile.id, { forceRefresh: true });
+  const desiredModel = previousModel ?? modelFromIdField(services, msg.model);
   const nextModel =
-    previousModel &&
-    services.modelRegistry.find(previousModel.provider, previousModel.id);
+    desiredModel &&
+    services.modelRegistry.find(desiredModel.provider, desiredModel.id);
   await ensureTab(state, deps, tabId, {
     cwdOverride: cwd,
-    initialModel: nextModel || previousModel,
+    initialModel: nextModel || desiredModel,
   });
   markProfileUsed(state, profile.id);
+}
+
+/** Resolve a `provider/id` model string (from an apply payload) against a
+ *  profile's registry, so a respawned worker keeps the tab's current model
+ *  instead of falling back to the default. */
+function modelFromIdField(
+  services: AuthProfileServices,
+  field: unknown,
+): Model<Api> | undefined {
+  const id = stringField(field);
+  if (!id.includes("/")) return undefined;
+  const [provider, ...rest] = id.split("/");
+  return (
+    services.modelRegistry.find(provider, rest.join("/")) ?? undefined
+  );
 }
 
 interface ContinuableSession {

--- a/agent/auth-profiles/manager.ts
+++ b/agent/auth-profiles/manager.ts
@@ -805,7 +805,11 @@ async function handleApplyForTab(
     return;
   }
   const previousModel = existing?.session.model;
-  const cwd = state.tabProjectCwds.get(tabId);
+  // Prefer the cwd carried by the message — when this relay is what spawns
+  // an idle-retired/never-spawned worker, the recorded cwd may be missing
+  // and a fallback cwd would land the session in the wrong workspace.
+  const msgCwd = stringField(msg.cwd);
+  const cwd = msgCwd || state.tabProjectCwds.get(tabId);
   if (existing) clearPendingContextUsageEmit(existing);
   state.tabs.delete(tabId);
   state.tabAuthProfileIds.set(tabId, profile.id);

--- a/agent/auth-profiles/manager.ts
+++ b/agent/auth-profiles/manager.ts
@@ -252,6 +252,9 @@ export async function handleAuthProfileMessage(
     case "auth_profile_use_for_tab":
       await handleUseForTab(state, deps, msg);
       return true;
+    case "auth_profile_apply":
+      await handleApplyForTab(state, deps, msg);
+      return true;
     case "auth_profile_set_default":
       handleSetDefault(state, deps, msg);
       return true;
@@ -761,6 +764,57 @@ async function handleUseForTab(
   });
   emitAuthProfiles(state, deps);
   await emitGlobalReady(state, deps);
+}
+
+/**
+ * Apply an account switch inside a per-tab WORKER bridge. The global bridge
+ * owns the auth surface (snapshot + `auth_profile_changed` emit) via
+ * {@link handleUseForTab}, but a worker runs that tab's prompts in a
+ * separate process and never sees `auth_profile_use_for_tab`. The frontend
+ * relays the switch here (tab-scoped routing) so the worker rebuilds its
+ * session against the new profile's credentials — otherwise the worker
+ * keeps using the old account and a rate-limited account never recovers.
+ *
+ * Deliberately silent: no snapshot/ready emit (those would be a partial,
+ * worker-local view that clobbers the global activeByTab). Just swaps the
+ * session so the next prompt uses the new account.
+ */
+async function handleApplyForTab(
+  state: AethonAgentState,
+  deps: DispatcherDeps,
+  msg: InboundMessage,
+): Promise<void> {
+  const tabId = stringField(msg.tabId);
+  const profileId = stringField(msg.profileId);
+  if (!tabId || !profileId) return;
+  // The profile may have been created after this worker spawned; reload the
+  // persisted profile list so the lookup succeeds.
+  state.authProfiles = loadAuthProfilesState(state.userDir);
+  const profile = state.authProfiles.profiles.find((p) => p.id === profileId);
+  if (!profile) return;
+  const existing = state.tabs.get(tabId);
+  if (existing?.promptInFlight) {
+    deps.send({
+      type: "notice",
+      tabId,
+      message: "agent busy — stop the current prompt before switching accounts",
+    });
+    return;
+  }
+  const previousModel = existing?.session.model;
+  const cwd = state.tabProjectCwds.get(tabId);
+  if (existing) clearPendingContextUsageEmit(existing);
+  state.tabs.delete(tabId);
+  state.tabAuthProfileIds.set(tabId, profile.id);
+  const services = servicesForProfile(state, profile.id, { forceRefresh: true });
+  const nextModel =
+    previousModel &&
+    services.modelRegistry.find(previousModel.provider, previousModel.id);
+  await ensureTab(state, deps, tabId, {
+    cwdOverride: cwd,
+    initialModel: nextModel || previousModel,
+  });
+  markProfileUsed(state, profile.id);
 }
 
 function handleSetDefault(

--- a/agent/auth-profiles/manager.ts
+++ b/agent/auth-profiles/manager.ts
@@ -818,23 +818,6 @@ function handleDelete(
 
 const CODEX_PROVIDER_ID = "openai-codex";
 
-interface AuthProfileUsageWindow {
-  usedPercent: number;
-  resetsAt?: number;
-  windowDurationMins?: number;
-}
-
-interface AuthProfileUsageMessage {
-  type: "auth_profile_usage";
-  profileId: string;
-  email?: string;
-  planType?: string;
-  primary?: AuthProfileUsageWindow;
-  secondary?: AuthProfileUsageWindow;
-  credits?: { balance?: string; hasCredits?: boolean; unlimited?: boolean };
-  error?: string;
-}
-
 export function parseIdTokenEmail(idToken: string): string | undefined {
   const segments = idToken.split(".");
   if (segments.length < 2) return undefined;
@@ -854,107 +837,6 @@ export function parseIdTokenEmail(idToken: string): string | undefined {
   }
 }
 
-function parseUsageWindow(value: unknown): AuthProfileUsageWindow | undefined {
-  if (!value || typeof value !== "object") return undefined;
-  const rec = value as Record<string, unknown>;
-  if (typeof rec.usedPercent !== "number") return undefined;
-  const window: AuthProfileUsageWindow = { usedPercent: rec.usedPercent };
-  if (typeof rec.resetsAt === "number") window.resetsAt = rec.resetsAt;
-  if (typeof rec.windowDurationMins === "number") {
-    window.windowDurationMins = rec.windowDurationMins;
-  }
-  return window;
-}
-
-function readCodexEmail(): string | undefined {
-  const codexHome =
-    process.env.CODEX_HOME ?? join(process.env.HOME ?? "", ".codex");
-  const authPath = join(codexHome, "auth.json");
-  try {
-    const data = JSON.parse(readFileSync(authPath, "utf8")) as Record<
-      string,
-      unknown
-    >;
-    const tokens = data.tokens as Record<string, unknown> | undefined;
-    const idToken =
-      typeof tokens?.id_token === "string" ? tokens.id_token : undefined;
-    return idToken ? parseIdTokenEmail(idToken) : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-function resolveCodexBinary(): string {
-  return (
-    process.env.BURNRATE_CODEX_BIN ??
-    process.env.CODEX_BIN ??
-    "codex"
-  );
-}
-
-async function fetchCodexRateLimits(): Promise<Record<string, unknown>> {
-  const { spawn } = await import("node:child_process");
-  return new Promise((resolve, reject) => {
-    const child = spawn(resolveCodexBinary(), [
-      "app-server",
-      "--listen",
-      "stdio://",
-    ]);
-    const timeout = setTimeout(() => {
-      child.kill();
-      reject(new Error("codex app-server timed out"));
-    }, 10_000);
-    let buffer = "";
-    child.stdout.on("data", (chunk: Buffer) => {
-      buffer += chunk.toString("utf8");
-      const lines = buffer.split("\n");
-      buffer = lines.pop() ?? "";
-      for (const line of lines) {
-        const trimmed = line.trim();
-        if (!trimmed) continue;
-        try {
-          const msg = JSON.parse(trimmed) as { id?: number; result?: unknown };
-          if (msg.id === 2 && msg.result) {
-            clearTimeout(timeout);
-            child.kill();
-            resolve(msg.result as Record<string, unknown>);
-          }
-        } catch {
-          /* non-JSON line, skip */
-        }
-      }
-    });
-    child.on("error", (err: Error) => {
-      clearTimeout(timeout);
-      reject(new Error(`codex not found: ${err.message}`));
-    });
-    child.on("close", (code: number | null) => {
-      clearTimeout(timeout);
-      reject(new Error(`codex exited with code ${code}`));
-    });
-    const init = JSON.stringify({
-      id: 1,
-      method: "initialize",
-      params: {
-        clientInfo: { name: "aethon", title: "Aethon", version: "0.1.0" },
-        capabilities: { experimentalApi: true },
-      },
-    });
-    const initialized = JSON.stringify({ method: "initialized" });
-    const read = JSON.stringify({
-      id: 2,
-      method: "account/rateLimits/read",
-    });
-    child.stdin.write(init + "\n");
-    setTimeout(() => {
-      child.stdin.write(initialized + "\n");
-      setTimeout(() => {
-        child.stdin.write(read + "\n");
-      }, 100);
-    }, 100);
-  });
-}
-
 async function handleFetchUsage(
   state: AethonAgentState,
   deps: Pick<DispatcherDeps, "send">,
@@ -965,41 +847,18 @@ async function handleFetchUsage(
     const profile = findProfile(state, profileId);
     if (!profile) throw new Error("unknown profileId");
 
-    const result: AuthProfileUsageMessage = {
-      type: "auth_profile_usage",
-      profileId: profile.id,
-    };
-
     if (profile.providerId === CODEX_PROVIDER_ID) {
-      const email = readCodexEmail();
-      if (email) result.email = email;
-
-      const body = await fetchCodexRateLimits();
-      const rateLimits = (body.rateLimits ?? body) as Record<string, unknown>;
-      if (typeof rateLimits.planType === "string") {
-        result.planType = rateLimits.planType;
-      }
-      const primary = parseUsageWindow(rateLimits.primary);
-      if (primary) result.primary = primary;
-      const secondary = parseUsageWindow(rateLimits.secondary);
-      if (secondary) result.secondary = secondary;
-      if (rateLimits.credits && typeof rateLimits.credits === "object") {
-        const credits = rateLimits.credits as Record<string, unknown>;
-        result.credits = {
-          balance:
-            typeof credits.balance === "string" ? credits.balance : undefined,
-          hasCredits:
-            typeof credits.hasCredits === "boolean"
-              ? credits.hasCredits
-              : undefined,
-          unlimited:
-            typeof credits.unlimited === "boolean"
-              ? credits.unlimited
-              : undefined,
-        };
-      }
+      const { fetchCodexProfileUsage } = await import("./codex-usage");
+      const authPath = authProfileAuthPath(state.userDir, profile.id);
+      const usage = await fetchCodexProfileUsage(authPath, profile.providerId);
+      deps.send({
+        type: "auth_profile_usage",
+        profileId: profile.id,
+        ...usage,
+      });
     } else {
       const authPath = authProfileAuthPath(state.userDir, profile.id);
+      let email: string | undefined;
       try {
         const parsed = JSON.parse(readFileSync(authPath, "utf8")) as Record<
           string,
@@ -1014,17 +873,17 @@ async function handleFetchUsage(
               : typeof creds.idToken === "string"
                 ? creds.idToken
                 : undefined;
-          if (idToken) {
-            const email = parseIdTokenEmail(idToken);
-            if (email) result.email = email;
-          }
+          if (idToken) email = parseIdTokenEmail(idToken);
         }
       } catch {
         /* no credentials to read email from */
       }
+      deps.send({
+        type: "auth_profile_usage",
+        profileId: profile.id,
+        ...(email ? { email } : {}),
+      });
     }
-
-    deps.send(result);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     deps.send({

--- a/agent/auth-profiles/manager.ts
+++ b/agent/auth-profiles/manager.ts
@@ -468,6 +468,16 @@ function handleOAuthStart(
     };
     saveAuthProfiles(state);
   }
+  // Abort any lingering OAuth flow for this provider — pi-ai's callback
+  // server binds to a hardcoded port per provider, so a stale server from
+  // a previous login blocks the new flow's state from registering.
+  for (const [oldId, oldPending] of pendingOAuth) {
+    if (oldPending.providerId === providerId) {
+      oldPending.controller.abort();
+      pendingOAuth.delete(oldId);
+    }
+  }
+
   const services = servicesForProfile(state, meta.id, { forceRefresh: true });
   const challengeId = randomUUID();
   const pending: PendingOAuth = {

--- a/agent/auth-profiles/manager.ts
+++ b/agent/auth-profiles/manager.ts
@@ -13,6 +13,7 @@ import type { DispatcherDeps, InboundMessage } from "../dispatcherTypes";
 import { emitGlobalReady } from "../dispatcherTypes";
 import { clearPendingContextUsageEmit } from "../context-usage";
 import { ensureTab } from "../tab-lifecycle";
+import { removeTrailingFailureMessage } from "../tab-lifecycle/retry";
 import {
   authProfileAuthPath,
   createProfileMeta,
@@ -23,6 +24,7 @@ import {
   type AuthProfileMeta,
   type AuthProfilesState,
 } from "./store";
+import { makeCodexLimitProbe, pickAvailableAccount } from "./auto-switch";
 
 export interface AuthProfileServices {
   authStorage: AuthStorage;
@@ -815,6 +817,102 @@ async function handleApplyForTab(
     initialModel: nextModel || previousModel,
   });
   markProfileUsed(state, profile.id);
+}
+
+interface ContinuableSession {
+  agent?: { continue?: () => Promise<void> };
+}
+
+/**
+ * Recover from a usage-limit hit by transparently switching the tab to
+ * another account that still has headroom, then re-running the failed turn.
+ * Runs inside the bridge that owns the tab's session (so the re-run uses the
+ * new credentials). Returns `true` when it switched + resumed — the caller
+ * then suppresses the error so the turn "continues on its own". Returns
+ * `false` when no alternative account is available (caller surfaces the
+ * clean error).
+ *
+ * Loop-safe: each bounced account is recorded on the tab record and skipped
+ * on subsequent hits within the same prompt; a clean turn clears the set.
+ */
+export async function tryAutoSwitchOnUsageLimit(
+  state: AethonAgentState,
+  deps: DispatcherDeps,
+  tabId: string,
+): Promise<boolean> {
+  const existing = state.tabs.get(tabId);
+  if (!existing) return false;
+  const currentId = state.tabAuthProfileIds.get(tabId);
+  const current = currentId
+    ? state.authProfiles.profiles.find((p) => p.id === currentId)
+    : undefined;
+  const provider =
+    current?.providerId ?? existing.session.model?.provider ?? undefined;
+  if (provider !== CODEX_PROVIDER_ID) return false;
+
+  const tried = existing.autoSwitchTried ?? new Set<string>();
+  if (currentId) tried.add(currentId);
+
+  const chosen = await pickAvailableAccount(
+    state.authProfiles.profiles,
+    provider,
+    currentId,
+    tried,
+    makeCodexLimitProbe(state.userDir),
+  );
+  if (!chosen) return false;
+  tried.add(chosen);
+
+  const chosenProfile = state.authProfiles.profiles.find((p) => p.id === chosen);
+  const previousModel = existing.session.model;
+  const cwd = state.tabProjectCwds.get(tabId);
+  clearPendingContextUsageEmit(existing);
+  state.tabs.delete(tabId);
+  state.tabAuthProfileIds.set(tabId, chosen);
+  const services = servicesForProfile(state, chosen, { forceRefresh: true });
+  const nextModel =
+    previousModel &&
+    services.modelRegistry.find(previousModel.provider, previousModel.id);
+  const rec = await ensureTab(state, deps, tabId, {
+    cwdOverride: cwd,
+    initialModel: nextModel || previousModel,
+  });
+  rec.autoSwitchTried = tried;
+  markProfileUsed(state, chosen);
+
+  deps.send({
+    type: "auth_profile_changed",
+    tabId,
+    profileId: chosen,
+    model: rec.session.model
+      ? `${rec.session.model.provider}/${rec.session.model.id}`
+      : "",
+  });
+  deps.send({
+    type: "notice",
+    tabId,
+    message: `Switched to ${chosenProfile?.label ?? "another account"} — previous account hit its usage limit. Continuing…`,
+  });
+  emitAuthProfiles(state, deps);
+
+  // Drop the trailing error and re-run the last user turn on the new
+  // account (same mechanism the retry path uses, but on fresh credentials).
+  removeTrailingFailureMessage(rec.session);
+  const agent = (rec.session as ContinuableSession).agent;
+  const continueTurn = agent?.continue;
+  if (typeof continueTurn !== "function") return false;
+  rec.promptInFlight = true;
+  rec.agentEndFired = false;
+  state.currentAgentTabId = tabId;
+  void state.tabContext.run(tabId, () => continueTurn.call(agent)).catch(
+    (err: unknown) => {
+      rec.promptInFlight = false;
+      const message = err instanceof Error ? err.message : String(err);
+      deps.send({ type: "error", tabId, message: `auto-switch: ${message}` });
+      deps.send({ type: "response_end", tabId });
+    },
+  );
+  return true;
 }
 
 function handleSetDefault(

--- a/agent/chat.ts
+++ b/agent/chat.ts
@@ -69,6 +69,17 @@ export async function handleChat(
         : "inline",
     });
   }
+  // Adopt the tab's account when this is a fresh (respawned) worker that
+  // doesn't yet know it. Only fill the gap — never override a live
+  // assignment (e.g. a mid-session usage-limit auto-switch), so the frontend
+  // value can't clobber a more recent worker-side switch.
+  const msgAuthProfileId =
+    typeof msg.authProfileId === "string" && msg.authProfileId.length > 0
+      ? msg.authProfileId
+      : undefined;
+  if (msgAuthProfileId && !state.tabAuthProfileIds.has(tabId)) {
+    state.tabAuthProfileIds.set(tabId, msgAuthProfileId);
+  }
   const requestedModel = parseModelAndThinking(
     typeof msg.model === "string" && msg.model.length > 0
       ? msg.model

--- a/agent/state.ts
+++ b/agent/state.ts
@@ -298,6 +298,10 @@ export interface TabRecord {
   aethonRetryAttempt?: number;
   aethonRetryInFlight?: boolean;
   aethonRetryTimer?: ReturnType<typeof setTimeout>;
+  /** Auth profile ids already tried by the usage-limit auto-switch for the
+   *  current prompt. Prevents looping back onto an account we just bounced
+   *  off; cleared on the next successful (non-error) turn. */
+  autoSwitchTried?: Set<string>;
   /** Current Rust-scheduled task run, when this prompt was fired by
    *  Aethon's native scheduler instead of direct user input. */
   scheduledRun?: {

--- a/agent/tab-lifecycle/events.ts
+++ b/agent/tab-lifecycle/events.ts
@@ -497,23 +497,28 @@ export function handleSessionEvent(
       const keepTurnOpenForRetry =
         retryableFailure &&
         (retrying || scheduleAethonRetry(state, deps, rec, tabId));
-      if (failedMessage && !keepTurnOpenForRetry) {
-        if (isUsageLimitError(failedMessage)) {
-          // Try to hop to an account with headroom and resume; only surface
-          // the (clean) error if every alternative is also exhausted.
-          const clean = formatAgentErrorMessage(failedMessage);
-          void tryAutoSwitchOnUsageLimit(state, deps, tabId).then(
-            (switched) => {
-              if (!switched) deps.send({ type: "error", tabId, message: clean });
-            },
-          );
-        } else {
-          deps.send({
-            type: "error",
-            tabId,
-            message: formatAgentErrorMessage(failedMessage),
-          });
-        }
+      // A usage-limit hit triggers an async account hop. Keep the turn open
+      // until that decision resolves — finalizing now would clear `waiting`
+      // and could drain queued messages onto the rate-limited account before
+      // the resumed turn starts.
+      const usageLimitFailure =
+        failedMessage !== undefined &&
+        !keepTurnOpenForRetry &&
+        isUsageLimitError(failedMessage);
+      const keepTurnOpenForAutoSwitch = usageLimitFailure;
+      if (usageLimitFailure) {
+        const clean = formatAgentErrorMessage(failedMessage);
+        void tryAutoSwitchOnUsageLimit(state, deps, tabId).then((switched) => {
+          if (switched) return; // the resumed turn owns finalization
+          deps.send({ type: "error", tabId, message: clean });
+          finalizeFailedTurn(state, deps, tabId, failedMessage);
+        });
+      } else if (failedMessage && !keepTurnOpenForRetry) {
+        deps.send({
+          type: "error",
+          tabId,
+          message: formatAgentErrorMessage(failedMessage),
+        });
       } else if (!failedMessage) {
         // Clean turn — reset the auto-switch loop guard so a future limit
         // can switch accounts again.
@@ -546,7 +551,7 @@ export function handleSessionEvent(
       for (const [toolCallId, cached] of rec.toolArgsCache) {
         if (cached.endedAt !== undefined) rec.toolArgsCache.delete(toolCallId);
       }
-      if (!keepTurnOpenForRetry) {
+      if (!keepTurnOpenForRetry && !keepTurnOpenForAutoSwitch) {
         cancelAethonRetry(rec);
         rec.agentEndFired = true;
         rec.promptInFlight = false;
@@ -595,23 +600,27 @@ export function handleSessionEvent(
       if (!ev.success && ev.finalError) {
         const finalError = ev.finalError;
         if (isUsageLimitError(finalError)) {
-          // Hop to an account with headroom and resume; only surface the
-          // clean error if every alternative is also exhausted.
+          // Hop to an account with headroom and resume. Keep the turn open
+          // until the decision resolves — finalizing now would clear
+          // `waiting` and could drain queued messages onto the rate-limited
+          // account before the resumed turn starts.
           const clean = formatAgentErrorMessage(finalError);
           void tryAutoSwitchOnUsageLimit(state, deps, tabId).then(
             (switched) => {
-              if (!switched) deps.send({ type: "error", tabId, message: clean });
+              if (switched) return; // the resumed turn owns finalization
+              deps.send({ type: "error", tabId, message: clean });
+              finalizeFailedTurn(state, deps, tabId, finalError);
             },
           );
-        } else {
-          // Transient failures keep the "auto-retry exhausted:" prefix so the
-          // user knows we already retried.
-          deps.send({
-            type: "error",
-            tabId,
-            message: `auto-retry exhausted: ${finalError}`,
-          });
+          break;
         }
+        // Transient failures keep the "auto-retry exhausted:" prefix so the
+        // user knows we already retried.
+        deps.send({
+          type: "error",
+          tabId,
+          message: `auto-retry exhausted: ${finalError}`,
+        });
         rec.agentEndFired = true;
         rec.promptInFlight = false;
         if (state.currentAgentTabId === tabId) {
@@ -624,6 +633,31 @@ export function handleSessionEvent(
       break;
     }
   }
+}
+
+/**
+ * Finalize a turn that ended in failure — used by the usage-limit
+ * auto-switch path when no alternative account was available, so the turn
+ * was held open during the (async) hop decision. Operates on the tab's
+ * current record (the auto-switch may have replaced it) and is idempotent.
+ */
+function finalizeFailedTurn(
+  state: AethonAgentState,
+  deps: TabLifecycleDeps,
+  tabId: string,
+  failedMessage: string | undefined,
+): void {
+  const rec = state.tabs.get(tabId);
+  if (!rec || rec.agentEndFired) return;
+  cancelAethonRetry(rec);
+  rec.agentEndFired = true;
+  rec.promptInFlight = false;
+  if (state.currentAgentTabId === tabId) {
+    state.currentAgentTabId = undefined;
+  }
+  rollResponseMessage(rec);
+  deps.send({ type: "response_end", tabId });
+  emitScheduledRunComplete(deps, rec, tabId, false, failedMessage);
 }
 
 function emitScheduledRunComplete(

--- a/agent/tab-lifecycle/events.ts
+++ b/agent/tab-lifecycle/events.ts
@@ -21,6 +21,7 @@
 
 import {
   extractAgentEndError,
+  formatAgentErrorMessage,
   isRetryableAgentEndError,
 } from "../agent-errors";
 import { logger } from "../logger";
@@ -495,7 +496,11 @@ export function handleSessionEvent(
         retryableFailure &&
         (retrying || scheduleAethonRetry(state, deps, rec, tabId));
       if (failedMessage && !keepTurnOpenForRetry) {
-        deps.send({ type: "error", tabId, message: failedMessage });
+        deps.send({
+          type: "error",
+          tabId,
+          message: formatAgentErrorMessage(failedMessage),
+        });
       }
       const startMs = state.turnStartTimes.get(tabId);
       state.turnStartTimes.delete(tabId);
@@ -571,11 +576,15 @@ export function handleSessionEvent(
       const ev = event as { success?: boolean; finalError?: string };
       cancelAethonRetry(rec);
       if (!ev.success && ev.finalError) {
-        deps.send({
-          type: "error",
-          tabId,
-          message: `auto-retry exhausted: ${ev.finalError}`,
-        });
+        // Usage-limit hits get a clean, self-contained message; transient
+        // failures keep the "auto-retry exhausted:" prefix so the user knows
+        // we already retried.
+        const clean = formatAgentErrorMessage(ev.finalError);
+        const message =
+          clean === ev.finalError
+            ? `auto-retry exhausted: ${ev.finalError}`
+            : clean;
+        deps.send({ type: "error", tabId, message });
         rec.agentEndFired = true;
         rec.promptInFlight = false;
         if (state.currentAgentTabId === tabId) {

--- a/agent/tab-lifecycle/events.ts
+++ b/agent/tab-lifecycle/events.ts
@@ -508,11 +508,18 @@ export function handleSessionEvent(
       const keepTurnOpenForAutoSwitch = usageLimitFailure;
       if (usageLimitFailure) {
         const clean = formatAgentErrorMessage(failedMessage);
-        void tryAutoSwitchOnUsageLimit(state, deps, tabId).then((switched) => {
-          if (switched) return; // the resumed turn owns finalization
-          deps.send({ type: "error", tabId, message: clean });
-          finalizeFailedTurn(state, deps, tabId, failedMessage);
-        });
+        void tryAutoSwitchOnUsageLimit(state, deps, tabId)
+          .then((switched) => {
+            if (switched) return; // the resumed turn owns finalization
+            deps.send({ type: "error", tabId, message: clean });
+            finalizeFailedTurn(state, deps, tabId, failedMessage);
+          })
+          .catch(() => {
+            // Auto-switch setup threw (e.g. session recreate failed). The
+            // turn was held open, so finalize it now or the tab stays busy.
+            deps.send({ type: "error", tabId, message: clean });
+            finalizeFailedTurn(state, deps, tabId, failedMessage);
+          });
       } else if (failedMessage && !keepTurnOpenForRetry) {
         deps.send({
           type: "error",
@@ -605,13 +612,17 @@ export function handleSessionEvent(
           // `waiting` and could drain queued messages onto the rate-limited
           // account before the resumed turn starts.
           const clean = formatAgentErrorMessage(finalError);
-          void tryAutoSwitchOnUsageLimit(state, deps, tabId).then(
-            (switched) => {
+          void tryAutoSwitchOnUsageLimit(state, deps, tabId)
+            .then((switched) => {
               if (switched) return; // the resumed turn owns finalization
               deps.send({ type: "error", tabId, message: clean });
               finalizeFailedTurn(state, deps, tabId, finalError);
-            },
-          );
+            })
+            .catch(() => {
+              // Auto-switch setup threw; finalize so the tab doesn't hang.
+              deps.send({ type: "error", tabId, message: clean });
+              finalizeFailedTurn(state, deps, tabId, finalError);
+            });
           break;
         }
         // Transient failures keep the "auto-retry exhausted:" prefix so the

--- a/agent/tab-lifecycle/events.ts
+++ b/agent/tab-lifecycle/events.ts
@@ -23,7 +23,9 @@ import {
   extractAgentEndError,
   formatAgentErrorMessage,
   isRetryableAgentEndError,
+  isUsageLimitError,
 } from "../agent-errors";
+import { tryAutoSwitchOnUsageLimit } from "../auth-profiles";
 import { logger } from "../logger";
 import type { AethonAgentState, TabRecord } from "../state";
 import {
@@ -496,11 +498,26 @@ export function handleSessionEvent(
         retryableFailure &&
         (retrying || scheduleAethonRetry(state, deps, rec, tabId));
       if (failedMessage && !keepTurnOpenForRetry) {
-        deps.send({
-          type: "error",
-          tabId,
-          message: formatAgentErrorMessage(failedMessage),
-        });
+        if (isUsageLimitError(failedMessage)) {
+          // Try to hop to an account with headroom and resume; only surface
+          // the (clean) error if every alternative is also exhausted.
+          const clean = formatAgentErrorMessage(failedMessage);
+          void tryAutoSwitchOnUsageLimit(state, deps, tabId).then(
+            (switched) => {
+              if (!switched) deps.send({ type: "error", tabId, message: clean });
+            },
+          );
+        } else {
+          deps.send({
+            type: "error",
+            tabId,
+            message: formatAgentErrorMessage(failedMessage),
+          });
+        }
+      } else if (!failedMessage) {
+        // Clean turn — reset the auto-switch loop guard so a future limit
+        // can switch accounts again.
+        rec.autoSwitchTried = undefined;
       }
       const startMs = state.turnStartTimes.get(tabId);
       state.turnStartTimes.delete(tabId);
@@ -576,15 +593,25 @@ export function handleSessionEvent(
       const ev = event as { success?: boolean; finalError?: string };
       cancelAethonRetry(rec);
       if (!ev.success && ev.finalError) {
-        // Usage-limit hits get a clean, self-contained message; transient
-        // failures keep the "auto-retry exhausted:" prefix so the user knows
-        // we already retried.
-        const clean = formatAgentErrorMessage(ev.finalError);
-        const message =
-          clean === ev.finalError
-            ? `auto-retry exhausted: ${ev.finalError}`
-            : clean;
-        deps.send({ type: "error", tabId, message });
+        const finalError = ev.finalError;
+        if (isUsageLimitError(finalError)) {
+          // Hop to an account with headroom and resume; only surface the
+          // clean error if every alternative is also exhausted.
+          const clean = formatAgentErrorMessage(finalError);
+          void tryAutoSwitchOnUsageLimit(state, deps, tabId).then(
+            (switched) => {
+              if (!switched) deps.send({ type: "error", tabId, message: clean });
+            },
+          );
+        } else {
+          // Transient failures keep the "auto-retry exhausted:" prefix so the
+          // user knows we already retried.
+          deps.send({
+            type: "error",
+            tabId,
+            message: `auto-retry exhausted: ${finalError}`,
+          });
+        }
         rec.agentEndFired = true;
         rec.promptInFlight = false;
         if (state.currentAgentTabId === tabId) {

--- a/agent/tab-lifecycle/retry.ts
+++ b/agent/tab-lifecycle/retry.ts
@@ -52,7 +52,7 @@ function retrySettings(session: unknown): Required<RetrySettings> {
   };
 }
 
-function removeTrailingFailureMessage(session: unknown): void {
+export function removeTrailingFailureMessage(session: unknown): void {
   const agent = (session as AethonRetrySession).agent;
   const messages = agent?.state?.messages;
   if (!Array.isArray(messages) || messages.length === 0) return;

--- a/src-tauri/src/agent_process/process.rs
+++ b/src-tauri/src/agent_process/process.rs
@@ -468,6 +468,7 @@ fn route_payload_key_without_mutation(payload: &serde_json::Value) -> String {
         payload.get("type").and_then(|v| v.as_str()),
         Some(
             "a2ui_event"
+                | "auth_profile_apply"
                 | "chat"
                 | "local_chat_message"
                 | "native_slash_command"
@@ -668,7 +669,13 @@ mod tests {
 
     #[test]
     fn tab_scoped_control_payloads_route_to_tab_worker() {
-        for ty in ["set_model", "set_thinking_level", "stop", "tab_open"] {
+        for ty in [
+            "set_model",
+            "set_thinking_level",
+            "stop",
+            "tab_open",
+            "auth_profile_apply",
+        ] {
             assert_eq!(
                 route_payload_key_without_mutation(&serde_json::json!({
                     "type": ty,
@@ -690,6 +697,15 @@ mod tests {
         );
         assert_eq!(
             route_payload_key_without_mutation(&serde_json::json!({ "type": "report" })),
+            GLOBAL_AGENT_KEY
+        );
+        // auth_profile_apply on the DEFAULT tab stays on the global bridge
+        // (it owns the default tab's session + the auth surface).
+        assert_eq!(
+            route_payload_key_without_mutation(&serde_json::json!({
+                "type": "auth_profile_apply",
+                "tabId": "default",
+            })),
             GLOBAL_AGENT_KEY
         );
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -752,6 +752,17 @@ export default function App() {
     });
   }, [pushNotification, stateRef, updateActiveTab]);
 
+  const toggleAccounts = useCallback(() => {
+    setState((prev) => {
+      const auth = (prev.authProfiles ?? {}) as Record<string, unknown>;
+      const modal = (auth.modal ?? {}) as Record<string, unknown>;
+      return {
+        ...prev,
+        authProfiles: { ...auth, modal: { ...modal, open: !modal.open } },
+      };
+    });
+  }, [setState]);
+
   // Bridge IPC: spawns the agent on mount, runs the boot handshake
   // (start_agent → boot_layout → report), and routes every
   // `agent-response` event through the per-type handler registry under
@@ -849,6 +860,7 @@ export default function App() {
     focusActiveContextInput,
     exportActiveChatMarkdown,
     pushNotification,
+    toggleAccounts,
   });
 
   // window.aethon runtime API + dev-only __AETHON_* debug hooks.

--- a/src/auth-profiles/commands.test.ts
+++ b/src/auth-profiles/commands.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const invoke = vi.fn((_cmd: string, _args: { payload: string }) =>
+  Promise.resolve(),
+);
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (cmd: string, args: { payload: string }) => invoke(cmd, args),
+}));
+
+import { switchAccountForTab } from "./commands";
+
+function payloads(): Array<Record<string, unknown>> {
+  return invoke.mock.calls.map(
+    (call) => JSON.parse(call[1].payload) as Record<string, unknown>,
+  );
+}
+
+describe("switchAccountForTab", () => {
+  beforeEach(() => invoke.mockClear());
+
+  it("relays both use_for_tab and apply for a non-default (worker) tab", async () => {
+    await switchAccountForTab("tab-worker", "openai-codex-secondary");
+    const types = payloads().map((p) => p.type);
+    // The worker bridge must also re-auth, or it keeps the old account.
+    expect(types).toEqual([
+      "auth_profile_use_for_tab",
+      "auth_profile_apply",
+    ]);
+    for (const p of payloads()) {
+      expect(p.tabId).toBe("tab-worker");
+      expect(p.profileId).toBe("openai-codex-secondary");
+    }
+  });
+
+  it("only sends use_for_tab for the default tab (global bridge owns it)", async () => {
+    await switchAccountForTab("default", "openai-codex-primary");
+    expect(payloads().map((p) => p.type)).toEqual(["auth_profile_use_for_tab"]);
+  });
+});

--- a/src/auth-profiles/commands.test.ts
+++ b/src/auth-profiles/commands.test.ts
@@ -36,4 +36,10 @@ describe("switchAccountForTab", () => {
     await switchAccountForTab("default", "openai-codex-primary");
     expect(payloads().map((p) => p.type)).toEqual(["auth_profile_use_for_tab"]);
   });
+
+  it("carries the tab cwd on the worker apply so a respawned worker lands in the right workspace", async () => {
+    await switchAccountForTab("tab-worker", "p1", "/repo/feature");
+    const apply = payloads().find((p) => p.type === "auth_profile_apply");
+    expect(apply?.cwd).toBe("/repo/feature");
+  });
 });

--- a/src/auth-profiles/commands.test.ts
+++ b/src/auth-profiles/commands.test.ts
@@ -7,7 +7,20 @@ vi.mock("@tauri-apps/api/core", () => ({
   invoke: (cmd: string, args: { payload: string }) => invoke(cmd, args),
 }));
 
-import { switchAccountForTab } from "./commands";
+import { resolveAccountSwitchTarget, switchAccountForTab } from "./commands";
+import type { Tab } from "../types/tab";
+
+function agentTab(over: Partial<Tab> = {}): Tab {
+  return {
+    id: "tab-1",
+    kind: "agent",
+    title: "Tab",
+    cwd: "/repo",
+    model: "openai-codex/gpt-5.5",
+    messages: [],
+    ...over,
+  } as Tab;
+}
 
 function payloads(): Array<Record<string, unknown>> {
   return invoke.mock.calls.map(
@@ -45,5 +58,41 @@ describe("switchAccountForTab", () => {
     const apply = payloads().find((p) => p.type === "auth_profile_apply");
     expect(apply?.cwd).toBe("/repo/feature");
     expect(apply?.model).toBe("openai-codex/gpt-5.5");
+  });
+});
+
+describe("resolveAccountSwitchTarget", () => {
+  it("maps a real agent tab to itself with its cwd + model", () => {
+    const tabs = [agentTab({ id: "t-real", cwd: "/x", model: "openai-codex/m" })];
+    expect(resolveAccountSwitchTarget(tabs, "t-real")).toEqual({
+      tabId: "t-real",
+      cwd: "/x",
+      model: "openai-codex/m",
+      busy: false,
+    });
+  });
+
+  it("falls back to the default (global) path for the overview pseudo-tab", () => {
+    // The overview id is not a real session — switching it must not spawn a
+    // worker, so it collapses to the default account path.
+    expect(resolveAccountSwitchTarget([], "__overview__")).toEqual({
+      tabId: "default",
+      busy: false,
+    });
+  });
+
+  it("falls back to default when the active tab id has no matching agent tab", () => {
+    expect(resolveAccountSwitchTarget([agentTab()], "missing")).toEqual({
+      tabId: "default",
+      busy: false,
+    });
+  });
+
+  it("reports busy for a tab that is mid-prompt", () => {
+    const target = resolveAccountSwitchTarget(
+      [agentTab({ id: "t-busy", waiting: true })],
+      "t-busy",
+    );
+    expect(target.busy).toBe(true);
   });
 });

--- a/src/auth-profiles/commands.test.ts
+++ b/src/auth-profiles/commands.test.ts
@@ -37,9 +37,13 @@ describe("switchAccountForTab", () => {
     expect(payloads().map((p) => p.type)).toEqual(["auth_profile_use_for_tab"]);
   });
 
-  it("carries the tab cwd on the worker apply so a respawned worker lands in the right workspace", async () => {
-    await switchAccountForTab("tab-worker", "p1", "/repo/feature");
+  it("carries the tab cwd + model on the worker apply so a respawned worker keeps its workspace and model", async () => {
+    await switchAccountForTab("tab-worker", "p1", {
+      cwd: "/repo/feature",
+      model: "openai-codex/gpt-5.5",
+    });
     const apply = payloads().find((p) => p.type === "auth_profile_apply");
     expect(apply?.cwd).toBe("/repo/feature");
+    expect(apply?.model).toBe("openai-codex/gpt-5.5");
   });
 });

--- a/src/auth-profiles/commands.ts
+++ b/src/auth-profiles/commands.ts
@@ -20,12 +20,18 @@ export async function requestAuthProfiles(): Promise<void> {
  * (possibly rate-limited) account. For non-default tabs we relay a
  * tab-scoped `auth_profile_apply` so the worker re-auths too.
  *
+ * Pass the tab's `cwd` so the relay carries it: if the worker was
+ * idle-retired (or never spawned), `auth_profile_apply` is what spawns it,
+ * and without the cwd the rebuilt session would fall back to the wrong
+ * workspace and run tools in the wrong directory.
+ *
  * Shared by the Accounts panel and the header account selector so both
  * entry points stay in sync.
  */
 export async function switchAccountForTab(
   tabId: string,
   profileId: string,
+  cwd?: string,
 ): Promise<void> {
   await sendAuthProfileCommand({
     type: "auth_profile_use_for_tab",
@@ -37,6 +43,7 @@ export async function switchAccountForTab(
       type: "auth_profile_apply",
       tabId,
       profileId,
+      ...(cwd ? { cwd } : {}),
     });
   }
 }

--- a/src/auth-profiles/commands.ts
+++ b/src/auth-profiles/commands.ts
@@ -1,4 +1,39 @@
 import { invoke } from "@tauri-apps/api/core";
+import { isAgentTabBusy } from "../utils/agentBusy";
+import { OVERVIEW_TAB_ID, type Tab } from "../types/tab";
+
+export interface AccountSwitchTarget {
+  /** Tab the switch should target. Overview / non-agent / missing tabs
+   *  collapse to `"default"` (the global account path) so we never spawn a
+   *  worker for a session that doesn't exist. */
+  tabId: string;
+  cwd?: string;
+  model?: string;
+  /** True when the resolved tab is mid-prompt; callers must not switch
+   *  (the global + worker states would diverge — see switchAccountForTab). */
+  busy: boolean;
+}
+
+/** Resolve the target + busy state for an account switch from the active
+ *  tab. Shared by the Accounts panel and the header selector. */
+export function resolveAccountSwitchTarget(
+  tabs: Tab[],
+  activeTabId: string | undefined,
+): AccountSwitchTarget {
+  const tab = tabs.find(
+    (t) =>
+      t.id === activeTabId &&
+      t.id !== OVERVIEW_TAB_ID &&
+      (t.kind ?? "agent") === "agent",
+  );
+  if (!tab) return { tabId: "default", busy: false };
+  return {
+    tabId: tab.id,
+    cwd: tab.cwd,
+    model: tab.model,
+    busy: isAgentTabBusy(tab, { includeQueue: true }),
+  };
+}
 
 export async function sendAuthProfileCommand(
   payload: Record<string, unknown>,

--- a/src/auth-profiles/commands.ts
+++ b/src/auth-profiles/commands.ts
@@ -20,10 +20,11 @@ export async function requestAuthProfiles(): Promise<void> {
  * (possibly rate-limited) account. For non-default tabs we relay a
  * tab-scoped `auth_profile_apply` so the worker re-auths too.
  *
- * Pass the tab's `cwd` so the relay carries it: if the worker was
- * idle-retired (or never spawned), `auth_profile_apply` is what spawns it,
- * and without the cwd the rebuilt session would fall back to the wrong
- * workspace and run tools in the wrong directory.
+ * Pass the tab's `cwd` and `model` so the relay carries them: if the worker
+ * was idle-retired (or never spawned), `auth_profile_apply` is what spawns
+ * it, and without the cwd/model the rebuilt session falls back to the wrong
+ * workspace (tools in the wrong directory) and the default model (silently
+ * changing the tab's model).
  *
  * Shared by the Accounts panel and the header account selector so both
  * entry points stay in sync.
@@ -31,7 +32,7 @@ export async function requestAuthProfiles(): Promise<void> {
 export async function switchAccountForTab(
   tabId: string,
   profileId: string,
-  cwd?: string,
+  opts: { cwd?: string; model?: string } = {},
 ): Promise<void> {
   await sendAuthProfileCommand({
     type: "auth_profile_use_for_tab",
@@ -43,7 +44,8 @@ export async function switchAccountForTab(
       type: "auth_profile_apply",
       tabId,
       profileId,
-      ...(cwd ? { cwd } : {}),
+      ...(opts.cwd ? { cwd: opts.cwd } : {}),
+      ...(opts.model ? { model: opts.model } : {}),
     });
   }
 }

--- a/src/auth-profiles/commands.ts
+++ b/src/auth-profiles/commands.ts
@@ -11,3 +11,32 @@ export async function sendAuthProfileCommand(
 export async function requestAuthProfiles(): Promise<void> {
   await sendAuthProfileCommand({ type: "auth_profiles_list" });
 }
+
+/**
+ * Switch the active account for a tab. The global bridge owns the auth
+ * surface (`auth_profile_use_for_tab`), but a non-default tab runs its
+ * prompts in a separate worker bridge that must also rebuild its session
+ * against the new account — otherwise the worker keeps using the old
+ * (possibly rate-limited) account. For non-default tabs we relay a
+ * tab-scoped `auth_profile_apply` so the worker re-auths too.
+ *
+ * Shared by the Accounts panel and the header account selector so both
+ * entry points stay in sync.
+ */
+export async function switchAccountForTab(
+  tabId: string,
+  profileId: string,
+): Promise<void> {
+  await sendAuthProfileCommand({
+    type: "auth_profile_use_for_tab",
+    tabId,
+    profileId,
+  });
+  if (tabId && tabId !== "default") {
+    await sendAuthProfileCommand({
+      type: "auth_profile_apply",
+      tabId,
+      profileId,
+    });
+  }
+}

--- a/src/auth-profiles/types.ts
+++ b/src/auth-profiles/types.ts
@@ -39,11 +39,34 @@ export interface AuthProfileLoginEvent {
   error?: string;
 }
 
+export interface AuthProfileUsageWindow {
+  usedPercent: number;
+  resetsAt?: number;
+  windowDurationMins?: number;
+}
+
+export interface AuthProfileUsageCredits {
+  balance?: string;
+  hasCredits?: boolean;
+  unlimited?: boolean;
+}
+
+export interface AuthProfileUsage {
+  email?: string;
+  planType?: string;
+  primary?: AuthProfileUsageWindow;
+  secondary?: AuthProfileUsageWindow;
+  credits?: AuthProfileUsageCredits;
+  error?: string;
+  fetchedAt: number;
+}
+
 export interface AuthProfilesUiState extends AuthProfilesSnapshot {
   modal?: {
     open?: boolean;
   };
   login?: AuthProfileLoginEvent;
+  usage?: Record<string, AuthProfileUsage>;
 }
 
 export const EMPTY_AUTH_PROFILES: AuthProfilesSnapshot = {

--- a/src/auth-profiles/types.ts
+++ b/src/auth-profiles/types.ts
@@ -53,7 +53,9 @@ export interface AuthProfileUsageCredits {
 
 export interface AuthProfileUsage {
   email?: string;
+  accountId?: string;
   planType?: string;
+  limitReached?: boolean;
   primary?: AuthProfileUsageWindow;
   secondary?: AuthProfileUsageWindow;
   credits?: AuthProfileUsageCredits;

--- a/src/extensions/default-layout/auth-profile-panel.tsx
+++ b/src/extensions/default-layout/auth-profile-panel.tsx
@@ -276,12 +276,14 @@ export function AuthProfilePanel({
                             </span>
                           )}
                         </div>
-                        <span>
+                        {usage?.email && (
+                          <span className="ae-auth-row-email" title={usage.email}>
+                            {usage.email}
+                          </span>
+                        )}
+                        <span className="ae-auth-row-meta">
                           {profile.provider.label} · {profile.kind}
-                          {usage?.email ? ` · ${usage.email}` : ""}
-                          {usage?.planType
-                            ? ` · ${usage.planType}`
-                            : ""}
+                          {usage?.planType ? ` · ${usage.planType}` : ""}
                         </span>
                         {usage && !usage.error && usage.primary && (
                           <UsageMeter usage={usage} />

--- a/src/extensions/default-layout/auth-profile-panel.tsx
+++ b/src/extensions/default-layout/auth-profile-panel.tsx
@@ -3,6 +3,7 @@ import type { BuiltinComponentProps } from "../../components/A2UIRenderer";
 import {
   EMPTY_AUTH_PROFILES,
   sendAuthProfileCommand,
+  switchAccountForTab,
   type AuthProfileLoginEvent,
   type AuthProfileProvider,
   type AuthProfileUsage,
@@ -94,11 +95,7 @@ export function AuthProfilePanel({
   };
 
   const activateProfile = (profileId: string) =>
-    sendAuthProfileCommand({
-      type: "auth_profile_use_for_tab",
-      tabId: activeTabId,
-      profileId,
-    });
+    switchAccountForTab(activeTabId, profileId);
 
   const setDefault = (profileId: string) =>
     sendAuthProfileCommand({ type: "auth_profile_set_default", profileId });

--- a/src/extensions/default-layout/auth-profile-panel.tsx
+++ b/src/extensions/default-layout/auth-profile-panel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import type { BuiltinComponentProps } from "../../components/A2UIRenderer";
 import {
   EMPTY_AUTH_PROFILES,
+  resolveAccountSwitchTarget,
   sendAuthProfileCommand,
   switchAccountForTab,
   type AuthProfileLoginEvent,
@@ -9,6 +10,7 @@ import {
   type AuthProfileUsage,
   type AuthProfilesUiState,
 } from "../../auth-profiles";
+import type { Tab } from "../../types/tab";
 
 function readAuthProfiles(state: Record<string, unknown>): AuthProfilesUiState {
   return {
@@ -32,6 +34,7 @@ export function AuthProfilePanel({
   const [renamingId, setRenamingId] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState("");
   const renameInputRef = useRef<HTMLInputElement>(null);
+  const cancelRenameRef = useRef(false);
 
   const providers = auth.providers;
   const selectedProvider =
@@ -40,12 +43,10 @@ export function AuthProfilePanel({
     tabId ??
     (typeof state.activeTabId === "string" ? state.activeTabId : "default");
   const activeProfileId = auth.activeByTab[activeTabId];
-  const activeTab = (() => {
-    const tabs =
-      (state.tabs as { id: string; cwd?: string; model?: string }[] | undefined) ??
-      [];
-    return tabs.find((t) => t.id === activeTabId);
-  })();
+  const switchTarget = resolveAccountSwitchTarget(
+    (state.tabs as Tab[] | undefined) ?? [],
+    activeTabId,
+  );
 
   const groupedProfiles = useMemo(
     () =>
@@ -115,10 +116,12 @@ export function AuthProfilePanel({
   };
 
   const activateProfile = (profileId: string) =>
-    switchAccountForTab(activeTabId, profileId, {
-      cwd: activeTab?.cwd,
-      model: activeTab?.model,
-    });
+    switchTarget.busy
+      ? undefined // can't switch mid-prompt; the Use button is disabled too
+      : switchAccountForTab(switchTarget.tabId, profileId, {
+          cwd: switchTarget.cwd,
+          model: switchTarget.model,
+        });
 
   const setDefault = (profileId: string) =>
     sendAuthProfileCommand({ type: "auth_profile_set_default", profileId });
@@ -140,11 +143,23 @@ export function AuthProfilePanel({
     sendAuthProfileCommand({ type: "auth_profile_delete", profileId });
 
   const startRename = (profileId: string, currentLabel: string) => {
+    cancelRenameRef.current = false;
     setRenamingId(profileId);
     setRenameValue(currentLabel);
   };
 
+  const cancelRename = () => {
+    // Flag the cancel BEFORE unmounting the input — the resulting blur would
+    // otherwise fire commitRename and submit the rename we meant to discard.
+    cancelRenameRef.current = true;
+    setRenamingId(null);
+  };
+
   const commitRename = () => {
+    if (cancelRenameRef.current) {
+      cancelRenameRef.current = false;
+      return;
+    }
     if (!renamingId || !renameValue.trim()) {
       setRenamingId(null);
       return;
@@ -271,7 +286,7 @@ export function AuthProfilePanel({
                               onBlur={commitRename}
                               onKeyDown={(e) => {
                                 if (e.key === "Enter") commitRename();
-                                if (e.key === "Escape") setRenamingId(null);
+                                if (e.key === "Escape") cancelRename();
                               }}
                             />
                           ) : (
@@ -318,7 +333,12 @@ export function AuthProfilePanel({
                         <button
                           type="button"
                           className="ae-settings-secondary"
-                          disabled={isActive}
+                          disabled={isActive || switchTarget.busy}
+                          title={
+                            switchTarget.busy
+                              ? "Stop the current prompt before switching accounts"
+                              : undefined
+                          }
                           onClick={() => void activateProfile(profile.id)}
                         >
                           Use

--- a/src/extensions/default-layout/auth-profile-panel.tsx
+++ b/src/extensions/default-layout/auth-profile-panel.tsx
@@ -85,10 +85,15 @@ export function AuthProfilePanel({
         continue;
       }
       if (usageInFlightRef.current.has(profile.id)) continue; // pending
-      usageInFlightRef.current.add(profile.id);
+      const id = profile.id;
+      usageInFlightRef.current.add(id);
       void sendAuthProfileCommand({
         type: "auth_profile_fetch_usage",
-        profileId: profile.id,
+        profileId: id,
+      }).catch(() => {
+        // Bridge down / webview reload — clear the flag so the next effect
+        // run retries instead of leaving the profile stuck pending.
+        usageInFlightRef.current.delete(id);
       });
     }
   }, [auth.modal?.open, auth.profiles, auth.usage]);
@@ -168,6 +173,8 @@ export function AuthProfilePanel({
       type: "auth_profile_rename",
       profileId: renamingId,
       label: renameValue.trim(),
+    }).catch(() => {
+      /* bridge down / reload — rename is non-critical, ignore */
     });
     setRenamingId(null);
   };

--- a/src/extensions/default-layout/auth-profile-panel.tsx
+++ b/src/extensions/default-layout/auth-profile-panel.tsx
@@ -40,9 +40,11 @@ export function AuthProfilePanel({
     tabId ??
     (typeof state.activeTabId === "string" ? state.activeTabId : "default");
   const activeProfileId = auth.activeByTab[activeTabId];
-  const activeTabCwd = (() => {
-    const tabs = (state.tabs as { id: string; cwd?: string }[] | undefined) ?? [];
-    return tabs.find((t) => t.id === activeTabId)?.cwd;
+  const activeTab = (() => {
+    const tabs =
+      (state.tabs as { id: string; cwd?: string; model?: string }[] | undefined) ??
+      [];
+    return tabs.find((t) => t.id === activeTabId);
   })();
 
   const groupedProfiles = useMemo(
@@ -62,13 +64,27 @@ export function AuthProfilePanel({
     [auth.profiles, providers],
   );
 
+  // Profiles whose usage fetch is awaiting a response. Each
+  // `auth_profile_usage` reply mutates `auth.usage` and re-runs this effect;
+  // without the guard it would re-issue fetches for every still-pending
+  // profile (O(n²) on open). Cleared per-profile when its reply lands, and
+  // fully when the panel closes so a reopen refetches.
+  const usageInFlightRef = useRef<Set<string>>(new Set());
   useEffect(() => {
-    if (!auth.modal?.open) return;
+    if (!auth.modal?.open) {
+      usageInFlightRef.current.clear();
+      return;
+    }
     const now = Date.now();
     for (const profile of auth.profiles) {
       if (profile.kind !== "oauth") continue;
       const cached = auth.usage?.[profile.id];
-      if (cached && now - cached.fetchedAt < USAGE_STALE_MS) continue;
+      if (cached && now - cached.fetchedAt < USAGE_STALE_MS) {
+        usageInFlightRef.current.delete(profile.id); // reply landed
+        continue;
+      }
+      if (usageInFlightRef.current.has(profile.id)) continue; // pending
+      usageInFlightRef.current.add(profile.id);
       void sendAuthProfileCommand({
         type: "auth_profile_fetch_usage",
         profileId: profile.id,
@@ -99,7 +115,10 @@ export function AuthProfilePanel({
   };
 
   const activateProfile = (profileId: string) =>
-    switchAccountForTab(activeTabId, profileId, activeTabCwd);
+    switchAccountForTab(activeTabId, profileId, {
+      cwd: activeTab?.cwd,
+      model: activeTab?.model,
+    });
 
   const setDefault = (profileId: string) =>
     sendAuthProfileCommand({ type: "auth_profile_set_default", profileId });

--- a/src/extensions/default-layout/auth-profile-panel.tsx
+++ b/src/extensions/default-layout/auth-profile-panel.tsx
@@ -40,6 +40,10 @@ export function AuthProfilePanel({
     tabId ??
     (typeof state.activeTabId === "string" ? state.activeTabId : "default");
   const activeProfileId = auth.activeByTab[activeTabId];
+  const activeTabCwd = (() => {
+    const tabs = (state.tabs as { id: string; cwd?: string }[] | undefined) ?? [];
+    return tabs.find((t) => t.id === activeTabId)?.cwd;
+  })();
 
   const groupedProfiles = useMemo(
     () =>
@@ -95,7 +99,7 @@ export function AuthProfilePanel({
   };
 
   const activateProfile = (profileId: string) =>
-    switchAccountForTab(activeTabId, profileId);
+    switchAccountForTab(activeTabId, profileId, activeTabCwd);
 
   const setDefault = (profileId: string) =>
     sendAuthProfileCommand({ type: "auth_profile_set_default", profileId });

--- a/src/extensions/default-layout/auth-profile-panel.tsx
+++ b/src/extensions/default-layout/auth-profile-panel.tsx
@@ -1,10 +1,11 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { BuiltinComponentProps } from "../../components/A2UIRenderer";
 import {
   EMPTY_AUTH_PROFILES,
   sendAuthProfileCommand,
   type AuthProfileLoginEvent,
   type AuthProfileProvider,
+  type AuthProfileUsage,
   type AuthProfilesUiState,
 } from "../../auth-profiles";
 
@@ -14,6 +15,8 @@ function readAuthProfiles(state: Record<string, unknown>): AuthProfilesUiState {
     ...((state.authProfiles as AuthProfilesUiState | undefined) ?? {}),
   };
 }
+
+const USAGE_STALE_MS = 5 * 60 * 1000;
 
 export function AuthProfilePanel({
   state,
@@ -25,6 +28,9 @@ export function AuthProfilePanel({
   const [label, setLabel] = useState("");
   const [apiKey, setApiKey] = useState("");
   const [promptValue, setPromptValue] = useState("");
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+  const [renameValue, setRenameValue] = useState("");
+  const renameInputRef = useRef<HTMLInputElement>(null);
 
   const providers = auth.providers;
   const selectedProvider =
@@ -50,6 +56,24 @@ export function AuthProfilePanel({
       })),
     [auth.profiles, providers],
   );
+
+  useEffect(() => {
+    if (!auth.modal?.open) return;
+    const now = Date.now();
+    for (const profile of auth.profiles) {
+      if (profile.kind !== "oauth") continue;
+      const cached = auth.usage?.[profile.id];
+      if (cached && now - cached.fetchedAt < USAGE_STALE_MS) continue;
+      void sendAuthProfileCommand({
+        type: "auth_profile_fetch_usage",
+        profileId: profile.id,
+      });
+    }
+  }, [auth.modal?.open, auth.profiles, auth.usage]);
+
+  useEffect(() => {
+    if (renamingId) renameInputRef.current?.focus();
+  }, [renamingId]);
 
   const startLogin = async () => {
     if (!selectedProvider) return;
@@ -94,6 +118,24 @@ export function AuthProfilePanel({
 
   const deleteProfile = (profileId: string) =>
     sendAuthProfileCommand({ type: "auth_profile_delete", profileId });
+
+  const startRename = (profileId: string, currentLabel: string) => {
+    setRenamingId(profileId);
+    setRenameValue(currentLabel);
+  };
+
+  const commitRename = () => {
+    if (!renamingId || !renameValue.trim()) {
+      setRenamingId(null);
+      return;
+    }
+    void sendAuthProfileCommand({
+      type: "auth_profile_rename",
+      profileId: renamingId,
+      label: renameValue.trim(),
+    });
+    setRenamingId(null);
+  };
 
   const submitPrompt = async (event: AuthProfileLoginEvent) => {
     await sendAuthProfileCommand({
@@ -191,15 +233,64 @@ export function AuthProfilePanel({
                   const isActive = activeProfileId === profile.id;
                   const isDefault =
                     auth.defaultByProvider[profile.providerId] === profile.id;
+                  const usage = auth.usage?.[profile.id];
+                  const isRenaming = renamingId === profile.id;
                   return (
-                    <li key={profile.id} className="ae-auth-row">
+                    <li
+                      key={profile.id}
+                      className={`ae-auth-row${isActive ? " ae-auth-row--active" : ""}`}
+                    >
                       <div className="ae-auth-row-main">
-                        <strong>{profile.label}</strong>
+                        <div className="ae-auth-row-label">
+                          {isRenaming ? (
+                            <input
+                              ref={renameInputRef}
+                              className="ae-settings-input ae-auth-rename-input"
+                              value={renameValue}
+                              onChange={(e) => setRenameValue(e.target.value)}
+                              onBlur={commitRename}
+                              onKeyDown={(e) => {
+                                if (e.key === "Enter") commitRename();
+                                if (e.key === "Escape") setRenamingId(null);
+                              }}
+                            />
+                          ) : (
+                            <strong
+                              className="ae-auth-row-name"
+                              onDoubleClick={() =>
+                                startRename(profile.id, profile.label)
+                              }
+                              title="Double-click to rename"
+                            >
+                              {profile.label}
+                            </strong>
+                          )}
+                          {isActive && (
+                            <span className="ae-auth-badge ae-auth-badge--active">
+                              Active
+                            </span>
+                          )}
+                          {isDefault && (
+                            <span className="ae-auth-badge ae-auth-badge--default">
+                              Default
+                            </span>
+                          )}
+                        </div>
                         <span>
                           {profile.provider.label} · {profile.kind}
-                          {isActive ? " · active" : ""}
-                          {isDefault ? " · default" : ""}
+                          {usage?.email ? ` · ${usage.email}` : ""}
+                          {usage?.planType
+                            ? ` · ${usage.planType}`
+                            : ""}
                         </span>
+                        {usage && !usage.error && usage.primary && (
+                          <UsageMeter usage={usage} />
+                        )}
+                        {usage?.error && (
+                          <span className="ae-auth-usage-error">
+                            {usage.error}
+                          </span>
+                        )}
                       </div>
                       <div className="ae-auth-row-actions">
                         <button
@@ -218,6 +309,15 @@ export function AuthProfilePanel({
                         >
                           Default
                         </button>
+                        <button
+                          type="button"
+                          className="ae-settings-secondary"
+                          onClick={() =>
+                            startRename(profile.id, profile.label)
+                          }
+                        >
+                          Rename
+                        </button>
                         {profile.kind === "oauth" && (
                           <button
                             type="button"
@@ -229,7 +329,7 @@ export function AuthProfilePanel({
                         )}
                         <button
                           type="button"
-                          className="ae-settings-secondary"
+                          className="ae-settings-secondary ae-auth-btn-danger"
                           onClick={() => void deleteProfile(profile.id)}
                         >
                           Delete
@@ -245,6 +345,84 @@ export function AuthProfilePanel({
       </div>
     </div>
   );
+}
+
+function UsageMeter({ usage }: { usage: AuthProfileUsage }) {
+  const { primary, secondary, credits } = usage;
+  return (
+    <div className="ae-auth-usage">
+      {primary && (
+        <div className="ae-auth-usage-bar-group">
+          <div className="ae-auth-usage-bar-header">
+            <span>{windowLabel(primary.windowDurationMins, "Primary")}</span>
+            <span>{primary.usedPercent}%</span>
+          </div>
+          <div className="ae-auth-usage-bar-track">
+            <div
+              className={`ae-auth-usage-bar-fill${primary.usedPercent >= 90 ? " ae-auth-usage-bar-fill--danger" : primary.usedPercent >= 70 ? " ae-auth-usage-bar-fill--warn" : ""}`}
+              style={{ width: `${Math.min(primary.usedPercent, 100)}%` }}
+            />
+          </div>
+          {primary.resetsAt != null && (
+            <span className="ae-auth-usage-reset">
+              Resets {formatResetTime(primary.resetsAt)}
+            </span>
+          )}
+        </div>
+      )}
+      {secondary && (
+        <div className="ae-auth-usage-bar-group">
+          <div className="ae-auth-usage-bar-header">
+            <span>{windowLabel(secondary.windowDurationMins, "Secondary")}</span>
+            <span>{secondary.usedPercent}%</span>
+          </div>
+          <div className="ae-auth-usage-bar-track">
+            <div
+              className={`ae-auth-usage-bar-fill${secondary.usedPercent >= 90 ? " ae-auth-usage-bar-fill--danger" : secondary.usedPercent >= 70 ? " ae-auth-usage-bar-fill--warn" : ""}`}
+              style={{ width: `${Math.min(secondary.usedPercent, 100)}%` }}
+            />
+          </div>
+          {secondary.resetsAt != null && (
+            <span className="ae-auth-usage-reset">
+              Resets {formatResetTime(secondary.resetsAt)}
+            </span>
+          )}
+        </div>
+      )}
+      {credits && credits.balance != null && (
+        <span className="ae-auth-usage-credits">
+          Credits: ${credits.balance}
+          {credits.unlimited ? " (unlimited)" : ""}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function windowLabel(durationMins: number | undefined, fallback: string): string {
+  switch (durationMins) {
+    case 300:
+      return "5-hour";
+    case 10080:
+      return "Weekly";
+    case 43200:
+      return "Monthly";
+    default:
+      return fallback;
+  }
+}
+
+function formatResetTime(epochMs: number): string {
+  const ms = epochMs > 1e12 ? epochMs : epochMs * 1000;
+  const diff = ms - Date.now();
+  if (diff <= 0) return "now";
+  const mins = Math.ceil(diff / 60_000);
+  if (mins < 60) return `in ${mins}m`;
+  const hrs = Math.floor(mins / 60);
+  const remMins = mins % 60;
+  if (hrs < 24) return `in ${hrs}h ${remMins}m`;
+  const days = Math.floor(hrs / 24);
+  return `in ${days}d ${hrs % 24}h`;
 }
 
 function LoginStatus({

--- a/src/extensions/default-layout/index.ts
+++ b/src/extensions/default-layout/index.ts
@@ -31,6 +31,7 @@ import {
   AuthProfilePanel,
 } from "./components";
 import {
+  AccountSelector,
   AgentStatusPill,
   AppearanceMenu,
   ModelPicker,
@@ -131,6 +132,7 @@ export const defaultLayoutExtension: A2UIExtension = {
     "agent-status-pill": AgentStatusPill,
     "model-picker": ModelPicker,
     "appearance-menu": AppearanceMenu,
+    "account-selector": AccountSelector,
     "vcs-status": VcsStatus,
     "source-control-panel": SourceControlPanel,
     "command-palette": CommandPalette,

--- a/src/extensions/default-layout/palette-items.ts
+++ b/src/extensions/default-layout/palette-items.ts
@@ -100,6 +100,7 @@ export const BUILTIN_KEYBINDINGS: BuiltinKeybinding[] = [
   { combo: "meta+shift+f", description: "Search across sessions" },
   { combo: "meta+shift+v", description: "Toggle Markdown preview" },
   { combo: "meta+,", description: "Open Settings" },
+  { combo: "meta+shift+a", description: "Toggle Accounts" },
   { combo: "meta+ctrl+f", description: "Toggle fullscreen (mac)" },
   { combo: "F11", description: "Toggle fullscreen" },
   { combo: "F12", description: "Toggle DevTools (debug builds)" },

--- a/src/extensions/default-layout/variation-components.tsx
+++ b/src/extensions/default-layout/variation-components.tsx
@@ -683,10 +683,15 @@ export function AccountSelector({
       ]}
       onSelect={(_sectionId, itemId) => {
         const tabs =
-          (state.tabs as { id: string; cwd?: string }[] | undefined) ?? [];
-        const cwd = tabs.find((t) => t.id === activeTabId)?.cwd;
+          (state.tabs as
+            | { id: string; cwd?: string; model?: string }[]
+            | undefined) ?? [];
+        const tab = tabs.find((t) => t.id === activeTabId);
         import("../../auth-profiles").then(({ switchAccountForTab }) => {
-          void switchAccountForTab(activeTabId, itemId, cwd);
+          void switchAccountForTab(activeTabId, itemId, {
+            cwd: tab?.cwd,
+            model: tab?.model,
+          });
         });
       }}
     />

--- a/src/extensions/default-layout/variation-components.tsx
+++ b/src/extensions/default-layout/variation-components.tsx
@@ -682,8 +682,11 @@ export function AccountSelector({
         },
       ]}
       onSelect={(_sectionId, itemId) => {
+        const tabs =
+          (state.tabs as { id: string; cwd?: string }[] | undefined) ?? [];
+        const cwd = tabs.find((t) => t.id === activeTabId)?.cwd;
         import("../../auth-profiles").then(({ switchAccountForTab }) => {
-          void switchAccountForTab(activeTabId, itemId);
+          void switchAccountForTab(activeTabId, itemId, cwd);
         });
       }}
     />

--- a/src/extensions/default-layout/variation-components.tsx
+++ b/src/extensions/default-layout/variation-components.tsx
@@ -583,6 +583,86 @@ export function AppearanceMenu({
 }
 
 // ---------------------------------------------------------------------------
+// AccountSelector — header dropdown that shows the active auth profile for
+// the current tab and lets the user switch between stored accounts. Read
+// from `/authProfiles` and the active tab's profile binding. Selecting
+// fires `auth_profile_use_for_tab` directly rather than going through the
+// sidebar select route, because account switching is a per-tab bridge
+// command.
+// ---------------------------------------------------------------------------
+
+interface AuthProfileMeta {
+  id: string;
+  providerId: string;
+  label: string;
+  kind: string;
+}
+
+interface AuthProfileUsageSlim {
+  email?: string;
+  planType?: string;
+  primary?: { usedPercent: number };
+}
+
+export function AccountSelector({
+  state,
+}: BuiltinComponentProps) {
+  const auth = (state.authProfiles ?? {}) as {
+    profiles?: AuthProfileMeta[];
+    activeByTab?: Record<string, string>;
+    usage?: Record<string, AuthProfileUsageSlim>;
+  };
+  const profiles = auth.profiles ?? [];
+  if (profiles.length === 0) return null;
+
+  const activeTabId =
+    typeof state.activeTabId === "string" ? state.activeTabId : "default";
+  const activeProfileId = auth.activeByTab?.[activeTabId];
+  const activeProfile = profiles.find((p) => p.id === activeProfileId);
+  const usage = activeProfileId ? auth.usage?.[activeProfileId] : undefined;
+
+  const buttonLabel = activeProfile
+    ? `${activeProfile.label}${usage?.planType ? ` · ${usage.planType}` : ""}`
+    : "account";
+
+  const items: DropdownItem[] = profiles.map((p) => {
+    const u = auth.usage?.[p.id];
+    const hint = [u?.email, u?.planType].filter(Boolean).join(" · ") || p.kind;
+    return {
+      id: p.id,
+      label: p.label,
+      hint,
+      active: p.id === activeProfileId,
+    };
+  });
+
+  return (
+    <DropdownPickerCore
+      className="a2ui-account-selector"
+      buttonLabel={buttonLabel}
+      align="right"
+      sections={[
+        {
+          id: "accounts",
+          title: "account",
+          items,
+          emptyLabel: "no accounts stored",
+        },
+      ]}
+      onSelect={(_sectionId, itemId) => {
+        import("../../auth-profiles").then(({ sendAuthProfileCommand }) => {
+          void sendAuthProfileCommand({
+            type: "auth_profile_use_for_tab",
+            tabId: activeTabId,
+            profileId: itemId,
+          });
+        });
+      }}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
 // VcsStatus — compact header cluster reading the `/vcs` slice: branch (with
 // ahead/behind), working-tree change count, PR state, and CI status. PR/CI
 // pills open GitHub via the `open-url` event. Hidden gracefully when the

--- a/src/extensions/default-layout/variation-components.tsx
+++ b/src/extensions/default-layout/variation-components.tsx
@@ -642,23 +642,32 @@ export function AccountSelector({
   const activeTabId =
     typeof state.activeTabId === "string" ? state.activeTabId : "default";
 
+  // Only offer accounts for the active tab's model provider — switching to a
+  // profile from another provider would point the tab's auth at a provider
+  // that can't back the current model. When the provider is unknown (no
+  // model yet), fall back to all profiles.
+  const tabProvider = activeTabModelProvider(state, activeTabId);
+  const selectable = tabProvider
+    ? profiles.filter((p) => p.providerId === tabProvider)
+    : profiles;
+  if (selectable.length === 0) return null;
+
   // Resolve the *effective* account so the chip always reflects which one a
   // prompt would actually use — even before the user explicitly picks one:
   //   tab assignment → provider default → sole default → first profile.
-  const tabProvider = activeTabModelProvider(state, activeTabId);
   const resolvedId =
     auth.activeByTab?.[activeTabId] ??
     (tabProvider ? auth.defaultByProvider?.[tabProvider] : undefined) ??
     soleDefault(auth.defaultByProvider) ??
-    profiles[0]?.id;
-  const activeProfile = profiles.find((p) => p.id === resolvedId);
+    selectable[0]?.id;
+  const activeProfile = selectable.find((p) => p.id === resolvedId);
   const usage = resolvedId ? auth.usage?.[resolvedId] : undefined;
 
   const buttonLabel = activeProfile
     ? `${activeProfile.label}${usage?.planType ? ` · ${usage.planType}` : ""}`
     : "account";
 
-  const items: DropdownItem[] = profiles.map((p) => {
+  const items: DropdownItem[] = selectable.map((p) => {
     const u = auth.usage?.[p.id];
     const hint = [u?.email, u?.planType].filter(Boolean).join(" · ") || p.kind;
     return {

--- a/src/extensions/default-layout/variation-components.tsx
+++ b/src/extensions/default-layout/variation-components.tsx
@@ -16,6 +16,7 @@ import { resolveBoolean, resolveString } from "../../utils/dataBinding";
 import { resolvePointer } from "../../utils/jsonPointer";
 import { PI_DEFAULT_MODEL_SENTINEL } from "../../utils/modelPicker";
 import type { BuiltinComponentProps } from "../../components/A2UIRenderer";
+import type { Tab } from "../../types/tab";
 import type { VcsSlice } from "../../hooks/useVcsStatus";
 import { ciMeta, prMeta } from "./sidebar/vcs-presentation";
 import { absolutePathFor } from "./sidebar/fileTreeModel";
@@ -682,17 +683,21 @@ export function AccountSelector({
         },
       ]}
       onSelect={(_sectionId, itemId) => {
-        const tabs =
-          (state.tabs as
-            | { id: string; cwd?: string; model?: string }[]
-            | undefined) ?? [];
-        const tab = tabs.find((t) => t.id === activeTabId);
-        import("../../auth-profiles").then(({ switchAccountForTab }) => {
-          void switchAccountForTab(activeTabId, itemId, {
-            cwd: tab?.cwd,
-            model: tab?.model,
-          });
-        });
+        import("../../auth-profiles").then(
+          ({ resolveAccountSwitchTarget, switchAccountForTab }) => {
+            const target = resolveAccountSwitchTarget(
+              (state.tabs as Tab[] | undefined) ?? [],
+              activeTabId,
+            );
+            // Don't switch mid-prompt — the global + worker auth states would
+            // diverge (UI shows the new account, worker keeps the old creds).
+            if (target.busy) return;
+            void switchAccountForTab(target.tabId, itemId, {
+              cwd: target.cwd,
+              model: target.model,
+            });
+          },
+        );
       }}
     />
   );

--- a/src/extensions/default-layout/variation-components.tsx
+++ b/src/extensions/default-layout/variation-components.tsx
@@ -604,12 +604,35 @@ interface AuthProfileUsageSlim {
   primary?: { usedPercent: number };
 }
 
+/** Provider id ("openai-codex") of the active tab's model, for resolving
+ *  the provider-default account. */
+function activeTabModelProvider(
+  state: Record<string, unknown>,
+  activeTabId: string,
+): string | undefined {
+  const tabs = (state.tabs as Array<{ id: string; model?: string }>) ?? [];
+  const model = tabs.find((t) => t.id === activeTabId)?.model;
+  return typeof model === "string" && model.includes("/")
+    ? model.split("/")[0]
+    : undefined;
+}
+
+/** When exactly one provider default is configured, use it as the global
+ *  fallback selection. */
+function soleDefault(
+  defaultByProvider: Record<string, string> | undefined,
+): string | undefined {
+  const values = Object.values(defaultByProvider ?? {});
+  return values.length === 1 ? values[0] : undefined;
+}
+
 export function AccountSelector({
   state,
 }: BuiltinComponentProps) {
   const auth = (state.authProfiles ?? {}) as {
     profiles?: AuthProfileMeta[];
     activeByTab?: Record<string, string>;
+    defaultByProvider?: Record<string, string>;
     usage?: Record<string, AuthProfileUsageSlim>;
   };
   const profiles = auth.profiles ?? [];
@@ -617,9 +640,18 @@ export function AccountSelector({
 
   const activeTabId =
     typeof state.activeTabId === "string" ? state.activeTabId : "default";
-  const activeProfileId = auth.activeByTab?.[activeTabId];
-  const activeProfile = profiles.find((p) => p.id === activeProfileId);
-  const usage = activeProfileId ? auth.usage?.[activeProfileId] : undefined;
+
+  // Resolve the *effective* account so the chip always reflects which one a
+  // prompt would actually use — even before the user explicitly picks one:
+  //   tab assignment → provider default → sole default → first profile.
+  const tabProvider = activeTabModelProvider(state, activeTabId);
+  const resolvedId =
+    auth.activeByTab?.[activeTabId] ??
+    (tabProvider ? auth.defaultByProvider?.[tabProvider] : undefined) ??
+    soleDefault(auth.defaultByProvider) ??
+    profiles[0]?.id;
+  const activeProfile = profiles.find((p) => p.id === resolvedId);
+  const usage = resolvedId ? auth.usage?.[resolvedId] : undefined;
 
   const buttonLabel = activeProfile
     ? `${activeProfile.label}${usage?.planType ? ` · ${usage.planType}` : ""}`
@@ -632,7 +664,7 @@ export function AccountSelector({
       id: p.id,
       label: p.label,
       hint,
-      active: p.id === activeProfileId,
+      active: p.id === resolvedId,
     };
   });
 
@@ -650,12 +682,8 @@ export function AccountSelector({
         },
       ]}
       onSelect={(_sectionId, itemId) => {
-        import("../../auth-profiles").then(({ sendAuthProfileCommand }) => {
-          void sendAuthProfileCommand({
-            type: "auth_profile_use_for_tab",
-            tabId: activeTabId,
-            profileId: itemId,
-          });
+        import("../../auth-profiles").then(({ switchAccountForTab }) => {
+          void switchAccountForTab(activeTabId, itemId);
         });
       }}
     />

--- a/src/extensions/default-layout/workstation.a2ui.json
+++ b/src/extensions/default-layout/workstation.a2ui.json
@@ -50,6 +50,11 @@
               "props": {}
             },
             {
+              "id": "account-selector",
+              "type": "account-selector",
+              "props": {}
+            },
+            {
               "id": "appearance-menu",
               "type": "appearance-menu",
               "props": {}

--- a/src/hooks/bridgeMessageHandlers/authProfileUsage.test.ts
+++ b/src/hooks/bridgeMessageHandlers/authProfileUsage.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from "vitest";
+import { handleAuthProfileUsage } from "./authProfileUsage";
+import type { BridgeMessageContext } from "./types";
+
+function makeCtx() {
+  let captured: Record<string, unknown> | undefined;
+  const setState = vi.fn((updater: (prev: Record<string, unknown>) => Record<string, unknown>) => {
+    captured = updater({
+      authProfiles: {
+        profiles: [{ id: "p1", providerId: "openai-codex", label: "Test", kind: "oauth", createdAt: 0, updatedAt: 0 }],
+        defaultByProvider: {},
+        providers: [],
+        activeByTab: {},
+      },
+    });
+  });
+  return { setState, captured: () => captured } as unknown as {
+    setState: typeof setState;
+    captured: () => Record<string, unknown> | undefined;
+  } & { ctx: BridgeMessageContext };
+}
+
+describe("handleAuthProfileUsage", () => {
+  it("stores usage data keyed by profileId", () => {
+    const { setState, captured } = makeCtx();
+    handleAuthProfileUsage(
+      {
+        type: "auth_profile_usage",
+        profileId: "p1",
+        email: "user@example.com",
+        planType: "pro",
+        primary: { usedPercent: 42, resetsAt: 999, windowDurationMins: 300 },
+      },
+      { setState } as unknown as BridgeMessageContext,
+    );
+    expect(setState).toHaveBeenCalledOnce();
+    const state = captured();
+    const auth = state?.authProfiles as Record<string, unknown>;
+    const usage = auth.usage as Record<string, Record<string, unknown>>;
+    expect(usage.p1.email).toBe("user@example.com");
+    expect(usage.p1.planType).toBe("pro");
+    const primary = usage.p1.primary as { usedPercent: number };
+    expect(primary.usedPercent).toBe(42);
+  });
+
+  it("ignores messages without profileId", () => {
+    const { setState } = makeCtx();
+    handleAuthProfileUsage(
+      { type: "auth_profile_usage" },
+      { setState } as unknown as BridgeMessageContext,
+    );
+    expect(setState).not.toHaveBeenCalled();
+  });
+
+  it("stores error messages", () => {
+    const { setState, captured } = makeCtx();
+    handleAuthProfileUsage(
+      {
+        type: "auth_profile_usage",
+        profileId: "p1",
+        error: "rate_limits request failed: 401 Unauthorized",
+      },
+      { setState } as unknown as BridgeMessageContext,
+    );
+    const state = captured();
+    const auth = state?.authProfiles as Record<string, unknown>;
+    const usage = auth.usage as Record<string, Record<string, unknown>>;
+    expect(usage.p1.error).toBe("rate_limits request failed: 401 Unauthorized");
+  });
+});

--- a/src/hooks/bridgeMessageHandlers/authProfileUsage.ts
+++ b/src/hooks/bridgeMessageHandlers/authProfileUsage.ts
@@ -8,8 +8,14 @@ export const handleAuthProfileUsage: BridgeMessageHandler = (message, ctx) => {
 
   const usage: AuthProfileUsage = {
     email: typeof message.email === "string" ? message.email : undefined,
+    accountId:
+      typeof message.accountId === "string" ? message.accountId : undefined,
     planType:
       typeof message.planType === "string" ? message.planType : undefined,
+    limitReached:
+      typeof message.limitReached === "boolean"
+        ? message.limitReached
+        : undefined,
     primary: isUsageWindow(message.primary) ? message.primary : undefined,
     secondary: isUsageWindow(message.secondary) ? message.secondary : undefined,
     credits: isCredits(message.credits) ? message.credits : undefined,

--- a/src/hooks/bridgeMessageHandlers/authProfileUsage.ts
+++ b/src/hooks/bridgeMessageHandlers/authProfileUsage.ts
@@ -1,0 +1,49 @@
+import type { AuthProfileUsage, AuthProfilesUiState } from "../../auth-profiles";
+import type { BridgeMessageHandler } from "./types";
+
+export const handleAuthProfileUsage: BridgeMessageHandler = (message, ctx) => {
+  const profileId =
+    typeof message.profileId === "string" ? message.profileId : undefined;
+  if (!profileId) return;
+
+  const usage: AuthProfileUsage = {
+    email: typeof message.email === "string" ? message.email : undefined,
+    planType:
+      typeof message.planType === "string" ? message.planType : undefined,
+    primary: isUsageWindow(message.primary) ? message.primary : undefined,
+    secondary: isUsageWindow(message.secondary) ? message.secondary : undefined,
+    credits: isCredits(message.credits) ? message.credits : undefined,
+    error: typeof message.error === "string" ? message.error : undefined,
+    fetchedAt: Date.now(),
+  };
+
+  ctx.setState((prev) => {
+    const current =
+      (prev.authProfiles as Partial<AuthProfilesUiState> | undefined) ?? {};
+    return {
+      ...prev,
+      authProfiles: {
+        profiles: [],
+        defaultByProvider: {},
+        providers: [],
+        activeByTab: {},
+        ...current,
+        usage: { ...(current.usage ?? {}), [profileId]: usage },
+      },
+    };
+  });
+};
+
+function isUsageWindow(
+  v: unknown,
+): v is { usedPercent: number; resetsAt?: number; windowDurationMins?: number } {
+  if (!v || typeof v !== "object") return false;
+  const r = v as Record<string, unknown>;
+  return typeof r.usedPercent === "number";
+}
+
+function isCredits(
+  v: unknown,
+): v is { balance?: string; hasCredits?: boolean; unlimited?: boolean } {
+  return !!v && typeof v === "object";
+}

--- a/src/hooks/bridgeMessageHandlers/authProfiles.ts
+++ b/src/hooks/bridgeMessageHandlers/authProfiles.ts
@@ -11,6 +11,7 @@ import type { BridgeMessageHandler } from "./types";
 type AuthProfilesState = AuthProfilesSnapshot & {
   modal?: { open?: boolean };
   login?: AuthProfileLoginEvent;
+  usage?: Record<string, unknown>;
 };
 
 function snapshotFrom(value: unknown): AuthProfilesSnapshot | null {
@@ -84,6 +85,9 @@ export const handleAuthProfiles: BridgeMessageHandler = (message, ctx) => {
         ...snapshot,
         modal: current.modal,
         login: current.login,
+        // Preserve the per-profile usage cache — it arrives via separate
+        // `auth_profile_usage` messages and must survive snapshot refreshes.
+        usage: current.usage,
       },
     };
   });

--- a/src/hooks/bridgeMessageHandlers/authProfiles.ts
+++ b/src/hooks/bridgeMessageHandlers/authProfiles.ts
@@ -1,9 +1,10 @@
 import { openUrl } from "@tauri-apps/plugin-opener";
-import type {
-  AuthProfileLoginEvent,
-  AuthProfileMeta,
-  AuthProfileProvider,
-  AuthProfilesSnapshot,
+import {
+  sendAuthProfileCommand,
+  type AuthProfileLoginEvent,
+  type AuthProfileMeta,
+  type AuthProfileProvider,
+  type AuthProfilesSnapshot,
 } from "../../auth-profiles";
 import type { Tab } from "../../types/tab";
 import type { BridgeMessageHandler } from "./types";
@@ -158,4 +159,13 @@ export const handleAuthProfileChanged: BridgeMessageHandler = (message, ctx) => 
       },
     },
   }));
+  // Relay the selection to the global bridge so its tabAuthProfileIds stays
+  // in sync with worker-side switches (e.g. usage-limit auto-switch). Without
+  // this, a later global auth_profiles snapshot would revert this tab to the
+  // stale account. The record handler is emit-free, so this can't loop.
+  void sendAuthProfileCommand({
+    type: "auth_profile_record",
+    tabId,
+    profileId,
+  });
 };

--- a/src/hooks/bridgeMessageHandlers/authProfiles.ts
+++ b/src/hooks/bridgeMessageHandlers/authProfiles.ts
@@ -167,5 +167,7 @@ export const handleAuthProfileChanged: BridgeMessageHandler = (message, ctx) => 
     type: "auth_profile_record",
     tabId,
     profileId,
+  }).catch(() => {
+    /* bridge restart / reload — best-effort sync, ignore */
   });
 };

--- a/src/hooks/bridgeMessageHandlers/index.ts
+++ b/src/hooks/bridgeMessageHandlers/index.ts
@@ -14,6 +14,7 @@ import {
   handleAuthProfileLoginEvent,
   handleAuthProfiles,
 } from "./authProfiles";
+import { handleAuthProfileUsage } from "./authProfileUsage";
 import { handleA2ui } from "./a2ui";
 import { handleContextUsage } from "./contextUsage";
 import { handleEntryIds } from "./entryIds";
@@ -69,6 +70,7 @@ export const bridgeMessageHandlers: Readonly<
   a2ui: handleA2ui,
   auth_profile_changed: handleAuthProfileChanged,
   auth_profile_login_event: handleAuthProfileLoginEvent,
+  auth_profile_usage: handleAuthProfileUsage,
   auth_profiles: handleAuthProfiles,
   context_usage: handleContextUsage,
   editor_query: handleEditorQuery,

--- a/src/hooks/useChat.test.ts
+++ b/src/hooks/useChat.test.ts
@@ -148,6 +148,26 @@ describe("useChat setModel", () => {
     });
   });
 
+  it("carries the tab's authProfileId so a respawned worker keeps the account", async () => {
+    const tab = {
+      ...makeEmptyTab("tab-1", "Tab 1"),
+      model: "openai-codex/gpt-5.5",
+      authProfileId: "openai-codex-secondary",
+    };
+    const { ctx } = buildContext({ tabs: [tab] });
+    const { result } = renderHook(() => useChat(ctx));
+
+    await act(async () => {
+      await result.current.sendChat("hello");
+    });
+
+    expect(invoke).toHaveBeenCalledWith("send_message", {
+      request: expect.objectContaining({
+        authProfileId: "openai-codex-secondary",
+      }),
+    });
+  });
+
   it("sends plan-mode prompts with the plan-mode flag", async () => {
     const tab = {
       ...makeEmptyTab("tab-1", "Tab 1"),

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -656,6 +656,12 @@ export function useChat(ctx: UseChatContext): UseChatActions {
           ...(typeof targetTab?.hardEnforceProjectRoot === "boolean"
             ? { hardEnforce: targetTab.hardEnforceProjectRoot }
             : {}),
+          // Carry the tab's account so a freshly (re)spawned worker resolves
+          // the right profile instead of falling back to the provider
+          // default (which could be the account the user switched away from).
+          ...(targetTab?.authProfileId
+            ? { authProfileId: targetTab.authProfileId }
+            : {}),
         },
       });
     } catch (err) {

--- a/src/hooks/useKeyboardShortcuts.test.tsx
+++ b/src/hooks/useKeyboardShortcuts.test.tsx
@@ -53,6 +53,7 @@ function buildContext(
     focusActiveContextInput: vi.fn(),
     exportActiveChatMarkdown: vi.fn(() => Promise.resolve()),
     pushNotification: vi.fn(),
+    toggleAccounts: vi.fn(),
   };
 }
 

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -72,6 +72,7 @@ export interface UseKeyboardShortcutsContext {
   focusActiveContextInput: () => void;
   exportActiveChatMarkdown: () => Promise<void>;
   pushNotification: (n: NotificationInput) => void;
+  toggleAccounts: () => void;
 }
 
 /**
@@ -350,6 +351,15 @@ export function useKeyboardShortcuts(ctx: UseKeyboardShortcutsContext): void {
           ctx.closeSettings();
           return;
         }
+        const authProfiles = state.authProfiles as
+          | { modal?: { open?: boolean } }
+          | undefined;
+        if (authProfiles?.modal?.open) {
+          e.preventDefault();
+          e.stopPropagation();
+          ctx.toggleAccounts();
+          return;
+        }
         if (activeAgentTabIsBusy(state)) {
           e.preventDefault();
           e.stopPropagation();
@@ -422,6 +432,13 @@ export function useKeyboardShortcuts(ctx: UseKeyboardShortcutsContext): void {
         invoke("toggle_fullscreen").catch((err: unknown) => {
           console.warn("toggle_fullscreen failed:", err);
         });
+        return;
+      }
+      // Cmd+Shift+A: toggle Accounts panel.
+      if (mod && e.shiftKey && !e.altKey && e.key.toLowerCase() === "a") {
+        e.preventDefault();
+        e.stopPropagation();
+        ctx.toggleAccounts();
         return;
       }
       // Cmd+Shift+S: export active agent chat as Markdown.

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -355,6 +355,10 @@ export function useKeyboardShortcuts(ctx: UseKeyboardShortcutsContext): void {
           | { modal?: { open?: boolean } }
           | undefined;
         if (authProfiles?.modal?.open) {
+          // Let an in-progress inline rename swallow Escape (to cancel the
+          // edit) rather than closing the whole panel out from under it.
+          const focused = document.activeElement;
+          if (focused?.classList.contains("ae-auth-rename-input")) return;
           e.preventDefault();
           e.stopPropagation();
           ctx.toggleAccounts();

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -2230,6 +2230,9 @@ body.ae-resizing-sidebar .a2ui-layout {
 .a2ui-appearance-menu .a2ui-dropdown-trigger {
   max-width: min(46ch, calc(var(--app-viewport-width) - 32px));
 }
+.a2ui-account-selector .a2ui-dropdown-trigger {
+  max-width: min(30ch, calc(var(--app-viewport-width) - 32px));
+}
 
 .app-header .a2ui-dropdown {
   flex-shrink: 0;

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -9937,6 +9937,10 @@ button.ae-vcs-chip:focus-visible {
   opacity: 0;
   transition: opacity var(--motion-fast) ease;
   pointer-events: none;
+  /* Keep the action row on one line — the parent message sets
+     `overflow-wrap: anywhere`, which otherwise wraps these labels
+     character-by-character into a vertical column. */
+  white-space: nowrap;
 }
 .a2ui-chat-message:hover .ae-msg-branch-actions,
 .a2ui-canvas-message:hover .ae-msg-branch-actions,
@@ -9953,6 +9957,11 @@ button.ae-vcs-chip:focus-visible {
   border-radius: var(--radius-pill);
   cursor: pointer;
   line-height: 1.4;
+  /* Don't inherit the message body's character-level wrapping, and don't
+     let flex shrink the pill below its label width. */
+  white-space: nowrap;
+  flex-shrink: 0;
+  overflow-wrap: normal;
 }
 .ae-msg-branch-btn:hover {
   background: var(--bg-hover);

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -6545,13 +6545,46 @@ body.ae-resizing-terminal * {
   border-radius: var(--radius-md);
   background: var(--bg-elev);
 }
+.ae-auth-row--active {
+  border-color: color-mix(in oklab, var(--accent) 40%, var(--border));
+  border-left: 3px solid var(--accent);
+  background: color-mix(in oklab, var(--accent) 6%, var(--bg-elev));
+}
 .ae-auth-row-main {
   min-width: 0;
   display: flex;
   flex-direction: column;
   gap: 2px;
 }
-.ae-auth-row-main strong,
+.ae-auth-row-label {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+}
+.ae-auth-row-label strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ae-auth-badge {
+  flex-shrink: 0;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  padding: 1px 6px;
+  border-radius: var(--radius-sm);
+  line-height: 1.4;
+}
+.ae-auth-badge--active {
+  background: color-mix(in oklab, var(--accent) 20%, transparent);
+  color: var(--accent);
+}
+.ae-auth-badge--default {
+  background: color-mix(in oklab, var(--text-dim) 15%, transparent);
+  color: var(--text-dim);
+}
 .ae-auth-row-main span {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -6561,9 +6594,71 @@ body.ae-resizing-terminal * {
   color: var(--text-dim);
   font-size: var(--chrome-text-muted);
 }
+.ae-auth-row-name {
+  cursor: default;
+}
+.ae-auth-rename-input {
+  max-width: 200px;
+  font-weight: 600;
+  padding: 2px 6px;
+}
+.ae-auth-btn-danger:hover {
+  color: var(--danger, #e55);
+  border-color: var(--danger, #e55);
+}
+.ae-auth-usage {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 4px;
+}
+.ae-auth-usage-bar-group {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.ae-auth-usage-bar-header {
+  display: flex;
+  justify-content: space-between;
+  font-size: 10px;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+.ae-auth-usage-bar-track {
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in oklab, var(--text-dim) 15%, transparent);
+  overflow: hidden;
+}
+.ae-auth-usage-bar-fill {
+  height: 100%;
+  border-radius: 2px;
+  background: var(--accent);
+  transition: width 0.3s ease;
+}
+.ae-auth-usage-bar-fill--warn {
+  background: var(--warning, #e8a83e);
+}
+.ae-auth-usage-bar-fill--danger {
+  background: var(--danger, #e55);
+}
+.ae-auth-usage-reset {
+  font-size: 10px;
+  color: var(--text-dim);
+}
+.ae-auth-usage-credits {
+  font-size: var(--chrome-text-muted);
+  color: var(--text-dim);
+}
+.ae-auth-usage-error {
+  font-size: var(--chrome-text-muted);
+  color: var(--danger, #e55);
+}
 .ae-auth-row-actions {
   display: flex;
   gap: var(--space-2);
+  flex-wrap: wrap;
 }
 @media (max-width: 640px) {
   .ae-auth-row {

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -6597,6 +6597,15 @@ body.ae-resizing-terminal * {
   color: var(--text-dim);
   font-size: var(--chrome-text-muted);
 }
+.ae-auth-row-email {
+  color: var(--text) !important;
+  font-size: var(--chrome-text-muted);
+  font-weight: 500;
+}
+.ae-auth-row-meta {
+  color: var(--text-dim);
+  font-size: var(--chrome-text-muted);
+}
 .ae-auth-row-name {
   cursor: default;
 }

--- a/website/reference/keyboard-shortcuts.md
+++ b/website/reference/keyboard-shortcuts.md
@@ -47,8 +47,9 @@ the same combos under `Ctrl` (`Cmd+T` ≡ `Ctrl+T`).
 | `Cmd+D`       | Toggle the right-hand files sidebar.                                                                      |
 | `Cmd+J`       | Toggle the sidebar's file-tree panel.                                                                     |
 | `Cmd+,`       | Open Settings panel.                                                                                      |
+| `Cmd+Shift+A` | Toggle the Accounts panel (per-provider auth profiles + usage).                                           |
 | `Cmd+Shift+F` | Cross-session search overlay.                                                                             |
-| `Esc`         | Close palette / settings / search overlay (when open).                                                    |
+| `Esc`         | Close palette / settings / search / accounts overlay (when open).                                         |
 
 ## Editor
 


### PR DESCRIPTION
## Summary

Makes the Accounts panel genuinely usable for multiple Codex (ChatGPT OAuth) accounts: each account is fully isolated, shows live usage + email, can be switched per-tab, and the agent transparently hops to a fresh account when one hits its usage limit.

## What's included

**Accounts panel**
- Active / Default badges with an accent-highlighted active row (previously all rows looked identical).
- Per-account **email**, plan type, 5-hour + weekly **usage bars** (warn/danger thresholds), credits — fetched live and isolated per account via each profile's own credentials.
- Inline **rename** (double-click label or Rename button; Esc cancels, Enter commits).
- `Cmd+Shift+A` hotkey to toggle the panel (Esc closes).

**Header account selector**
- Dropdown chip (next to the model picker) showing the active account; switch accounts per-tab in one click.
- Always shows a real account (resolves tab → provider-default → first); filtered to the active model's provider.

**Per-tab account switching**
- Works for worker tabs, not just the default tab: a tab-scoped `auth_profile_apply` rebuilds the worker's session on the new credentials (carrying cwd + model so a respawned worker keeps its workspace and model).
- Account selection persists across worker respawn (carried on `send_message`) and is kept in sync with the global bridge.

**Usage-limit handling**
- Clean, actionable error instead of the raw 429 JSON: *"Usage limit reached for this account (pro). Resets in 5m. Switch to another account (Cmd+Shift+A) to keep working."*
- **Auto-switch**: on a usage-limit hit the agent picks another account with headroom (verified via live probe), switches, and resumes the turn on its own; only surfaces the clean error when every alternative is exhausted. Loop-guarded and turn-lifecycle-safe.

**Also**
- Direct OAuth usage fetch through pi's locked `AuthStorage` (no `codex` binary dependency, no token-rotation races).
- Unrelated fix requested on this branch: chat Rollback/Fork buttons no longer wrap one character per line.

## Testing

- New unit tests: usage parser (both response shapes), error formatting + retry classification, account picker (headroom/loop-guard/provider isolation), switch-target resolver (overview/busy), dual-send + cwd/model relay, worker apply guard, `send_message` carrying the account.
- Full gate green: `cargo clippy` + `cargo test --lib` (465), `tsc -b`, `eslint` (0/0), `vitest` (2466).
- UAT in the dev app: isolated per-account usage/email confirmed; manual switch from a rate-limited account to a healthy one resumes and keeps working.

## Review

Peer-reviewed by Codex across 10 rounds; all flagged issues (token-rotation locking, response-shape tolerance, turn lifecycle during auto-switch, worker/global state sync, provider filtering, overview routing, rename cancel) addressed. Final round: clean.