### PR TITLE
fix(chat): stop message rollback/fork actions stacking vertically during reflow

### DIFF
--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -9937,9 +9937,16 @@ button.ae-vcs-chip:focus-visible {
   opacity: 0;
   transition: opacity var(--motion-fast) ease;
   pointer-events: none;
-  /* Keep the action row on one line — the parent message sets
-     `overflow-wrap: anywhere`, which otherwise wraps these labels
-     character-by-character into a vertical column. */
+  /* Keep the action row on one line. The parent message is
+     `overflow-wrap: anywhere` + `min-width: 0`, so as an absolutely
+     positioned child this row's shrink-to-fit width can collapse during a
+     list reflow and stack the pills into a vertical column ("renders
+     vertically at times"). Pin the row to its content width and forbid
+     wrapping so the horizontal layout is invariant regardless of the
+     containing block's transient width. */
+  width: max-content;
+  max-width: none;
+  flex-wrap: nowrap;
   white-space: nowrap;
 }
 .a2ui-chat-message:hover .ae-msg-branch-actions,


### PR DESCRIPTION
## Summary

Follow-up to the rollback/fork button wrapping fix in #323. The message action row (Rollback / Fork) still **intermittently rendered vertically** — the labels would stack one character / one pill per line "at times", then look fine on the next render.

## Root cause

`.ae-msg-branch-actions` is an **absolutely-positioned** child of `.a2ui-chat-message`, which is `overflow-wrap: anywhere` + `min-width: 0`. As a shrink-to-fit absolute box, its resolved width depends on the containing block's width — and during a chat-list (Virtuoso) reflow that width can momentarily collapse, squeezing the pills into a vertical column. The per-button `white-space: nowrap` from #323 stops *character* wrapping, but the row width was still reflow-dependent.

## Fix

Pin the row to its content width so the horizontal layout is invariant regardless of the containing block's transient width:

```css
.ae-msg-branch-actions {
  width: max-content;
  max-width: none;
  flex-wrap: nowrap;
  /* + white-space: nowrap (already present) */
}
```

Visual alignment is unchanged in the normal case — this only removes the reflow-dependent collapse. CSS-only change.