### PR TITLE
fix: clear collapsed header traffic controls

### DIFF
--- a/src/app/AppRoot.test.tsx
+++ b/src/app/AppRoot.test.tsx
@@ -55,6 +55,31 @@ function layoutPayload(): A2UIPayload {
 }
 
 describe("AppRoot workspace startup overlay", () => {
+  it("mirrors collapsed sidebar state onto the app root for titlebar CSS", () => {
+    const { container } = render(
+      <AppRoot
+        registry={registry()}
+        layout={layoutPayload()}
+        renderState={{ layout: { sidebarVisible: false } }}
+        setState={noop}
+        onEvent={noop}
+        activeTabId="default"
+        notificationsOpen={false}
+        paletteOpen={false}
+        settingsOpen={false}
+        searchOpen={false}
+        authProfilesOpen={false}
+        scheduledTasksOpen={false}
+        chromeReady
+        startupLogoUrl="/logo.svg"
+      />,
+    );
+
+    expect(container.querySelector(".app")?.getAttribute("data-sidebar-collapsed")).toBe(
+      "true",
+    );
+  });
+
   it("mounts running workspace startup inside the canvas cell after chrome is ready", async () => {
     const { container } = render(
       <AppRoot

--- a/src/app/AppRoot.tsx
+++ b/src/app/AppRoot.tsx
@@ -121,11 +121,20 @@ export function AppRoot({
         workspaceStartup.entry.state,
       ),
   );
+  const sidebarCollapsed =
+    (renderState.layout as { sidebarVisible?: unknown } | undefined)
+      ?.sidebarVisible === false;
   return (
     <ExtensionRegistryProvider registry={registry}>
       {/* `data-platform="mac"` gates the overlay-titlebar chrome (traffic-
           light clearance + drag regions) so non-mac builds render unchanged. */}
-      <div className="app" {...(isMacOS() ? { "data-platform": "mac" } : {})}>
+      <div
+        className="app"
+        {...(isMacOS() ? { "data-platform": "mac" } : {})}
+        {...(sidebarCollapsed
+          ? { "data-sidebar-collapsed": "true" }
+          : {})}
+      >
         {chromeReady ? topBanner : null}
         {chromeReady ? (
           <A2UIRenderer

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -2041,6 +2041,17 @@ body.ae-resizing-sidebar .a2ui-layout {
   overflow: hidden;
 }
 
+/* macOS overlay titlebar: when the sidebar is collapsed, the header becomes
+   the leftmost drag row and must inherit the traffic-light clearance that the
+   sidebar brand strip normally owns. */
+[data-platform="mac"]
+  .a2ui-layout:has(
+    > .a2ui-layout-cell[data-area="sidebar"][data-visible="false"]
+  )
+  .app-header {
+  padding-left: 94px !important;
+}
+
 .app-header-brand {
   display: flex;
   align-items: center;

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -2044,11 +2044,7 @@ body.ae-resizing-sidebar .a2ui-layout {
 /* macOS overlay titlebar: when the sidebar is collapsed, the header becomes
    the leftmost drag row and must inherit the traffic-light clearance that the
    sidebar brand strip normally owns. */
-[data-platform="mac"]
-  .a2ui-layout:has(
-    > .a2ui-layout-cell[data-area="sidebar"][data-visible="false"]
-  )
-  .app-header {
+[data-platform="mac"][data-sidebar-collapsed="true"] .app-header {
   padding-left: 94px !important;
 }
 

--- a/src/styles/titlebar-clearance.test.ts
+++ b/src/styles/titlebar-clearance.test.ts
@@ -12,8 +12,8 @@ const css = readFileSync(join(here, "chrome.css"), "utf8");
 describe("macOS overlay titlebar clearance", () => {
   it("reserves traffic-light space in the header when the sidebar is collapsed", () => {
     expect(css).toMatch(
-      /\[data-platform="mac"\]\s+\.a2ui-layout:has\(\s*>\s*\.a2ui-layout-cell\[data-area="sidebar"\]\[data-visible="false"\]\s*\)\s+\.app-header\s*\{/,
+      /\[data-platform="mac"\]\[data-sidebar-collapsed="true"\]\s+\.app-header\s*\{[\s\S]*?padding-left:\s*94px\s*!important/,
     );
-    expect(css).toMatch(/padding-left:\s*94px\s*!important/);
+    expect(css).not.toMatch(/:has\(/);
   });
 });

--- a/src/styles/titlebar-clearance.test.ts
+++ b/src/styles/titlebar-clearance.test.ts
@@ -1,0 +1,19 @@
+// @ts-expect-error - app tsconfig omits Node types; Vitest runs this file in Node.
+import { readFileSync } from "node:fs";
+// @ts-expect-error - app tsconfig omits Node types; Vitest runs this file in Node.
+import { fileURLToPath } from "node:url";
+// @ts-expect-error - app tsconfig omits Node types; Vitest runs this file in Node.
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const css = readFileSync(join(here, "chrome.css"), "utf8");
+
+describe("macOS overlay titlebar clearance", () => {
+  it("reserves traffic-light space in the header when the sidebar is collapsed", () => {
+    expect(css).toMatch(
+      /\[data-platform="mac"\]\s+\.a2ui-layout:has\(\s*>\s*\.a2ui-layout-cell\[data-area="sidebar"\]\[data-visible="false"\]\s*\)\s+\.app-header\s*\{/,
+    );
+    expect(css).toMatch(/padding-left:\s*94px\s*!important/);
+  });
+});


### PR DESCRIPTION
## Summary
- reserve macOS traffic-light clearance for the header when the sidebar is collapsed
- add a focused CSS regression test for the collapsed-sidebar titlebar state

## Root cause
When the sidebar collapses to a 0px grid track, the header becomes the leftmost overlay-titlebar row. The sidebar brand strip already reserved the macOS traffic-light space, but the header kept its normal 14px padding, so the status text could overlap the traffic controls.

## Validation
- Reproduced before fix in browser UAT: collapsed sidebar, mac platform, first header content x=14 inside the 94px traffic-light reserve
- Verified after fix: first header content x=94 and no overlap; expanded sidebar still uses normal 14px header padding
- `bunx vitest run src/styles/titlebar-clearance.test.ts`
- `bunx vitest run src/styles/titlebar-clearance.test.ts src/styles/scrollbar.test.ts src/styles/vcs-badges.test.ts src/extensions/default-layout/layout.test.tsx`
- `bun run typecheck`
- `bun run lint`