### PR TITLE
fix: move terminal toggle to control backtick

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,7 +238,7 @@ console) can swap chrome at runtime:
 | `Cmd+1`..`Cmd+8`              | Jump to agent tab N. When focus is inside the bottom panel, jumps between sub-tabs instead (1 = agent-bash).                                                                                                 |
 | `Cmd+9`                       | Jump to last agent tab (or last shell sub-tab when focus is in panel).                                                                                                                                       |
 | `Cmd+P` / `Cmd+Shift+P`       | Command palette (switcher / commands)                                                                                                                                                                        |
-| `Cmd+\``                      | Toggle bottom terminal panel (Agent bash sub-tab + each user shell as a sub-tab)                                                                                                                             |
+| `Ctrl+\``                     | Toggle bottom terminal panel (Agent bash sub-tab + each user shell as a sub-tab)                                                                                                                             |
 | `Cmd+B`                       | Toggle sidebar                                                                                                                                                                                               |
 | `Cmd+K`                       | Clear chat                                                                                                                                                                                                   |
 | `Cmd+.`                       | Stop current prompt                                                                                                                                                                                          |
@@ -262,7 +262,7 @@ unchanged: extensions run first and may override built-ins.
 
 ### Terminal panel mental model
 
-The **bottom terminal panel** (toggle `Cmd+\``) is a tabbed surface
+The **bottom terminal panel** (toggle `Ctrl+\``) is a tabbed surface
 hosting two kinds of sub-tabs:
 
 1. **Agent bash** (always present, sub-tab id `"agent-bash"`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,7 +182,7 @@ commands directly; security floors live with the data source.
 ### Tab kinds + terminal panel
 
 `Tab.kind` is `"agent" | "shell"`. The top tab strip carries only agent
-tabs (shells are filtered). The bottom panel (toggle `` Cmd+` ``) hosts
+tabs (shells are filtered). The bottom panel (toggle `` Ctrl+` ``) hosts
 two sub-tab kinds: the always-present read-only `agent-bash` stream
 (buffered tool stdout) and zero or more interactive `portable-pty` shells
 (TUI-capable, 256-color, mouse). State paths: `/terminalPanel/activeSubId`

--- a/src-tauri/src/commands/extensions/app_menu.rs
+++ b/src-tauri/src/commands/extensions/app_menu.rs
@@ -70,7 +70,7 @@ pub fn install_app_menu(
         .accelerator("CmdOrCtrl+Shift+[")
         .build(app)?;
     let toggle_terminal = MenuItemBuilder::with_id("toggle_terminal", "Toggle Terminal")
-        .accelerator("CmdOrCtrl+`")
+        .accelerator("Ctrl+`")
         .build(app)?;
     let toggle_files = MenuItemBuilder::with_id("toggle_files", "Toggle Files")
         .accelerator("CmdOrCtrl+J")

--- a/src/extensions/default-layout/palette-items.ts
+++ b/src/extensions/default-layout/palette-items.ts
@@ -81,7 +81,7 @@ export const BUILTIN_KEYBINDINGS: BuiltinKeybinding[] = [
   { combo: "meta+7", description: "Jump to tab 7" },
   { combo: "meta+8", description: "Jump to tab 8" },
   { combo: "meta+9", description: "Jump to last tab" },
-  { combo: "meta+`", description: "Toggle terminal panel + focus" },
+  { combo: "ctrl+`", description: "Toggle terminal panel + focus" },
   { combo: "meta+j", description: "Toggle files panel" },
   {
     combo: "meta+0",

--- a/src/extensions/default-layout/shell/canvas.test.ts
+++ b/src/extensions/default-layout/shell/canvas.test.ts
@@ -41,7 +41,7 @@ describe("shouldSkipResize", () => {
   });
 
   it("returns true when width collapses to zero", () => {
-    // Cmd+` collapses the terminal grid track to 0px; the ResizeObserver
+    // Ctrl+` collapses the terminal grid track to 0px; the ResizeObserver
     // fires with width=0. Skipping the fit+resize keeps us from sending
     // a tiny `shell_resize` that would raise SIGWINCH on the PTY.
     expect(shouldSkipResize(entry(0, 240))).toBe(true);

--- a/src/extensions/default-layout/shell/resize.ts
+++ b/src/extensions/default-layout/shell/resize.ts
@@ -5,7 +5,7 @@ export interface ShellDims {
 
 /** True when the ResizeObserver fires while the terminal is not actually
  *  visible. The bottom panel stays mounted for chrome animation, so a
- *  Cmd+` close can still report resize events with tiny or stale non-zero
+ *  Ctrl+` close can still report resize events with tiny or stale non-zero
  *  dimensions. Skipping fit + shell_resize there prevents SIGWINCH spam
  *  that makes prompts like starship redraw and stack prompt lines. */
 export function shouldSkipResize(

--- a/src/hooks/uiOverlays/palette.ts
+++ b/src/hooks/uiOverlays/palette.ts
@@ -187,7 +187,7 @@ export function usePaletteOverlay(ctx: PaletteOverlayContext) {
           if (id) closeTab(id);
         } else if (p.action === "builtin:meta+shift+]") nextTab(1);
         else if (p.action === "builtin:meta+shift+[") nextTab(-1);
-        else if (p.action === "builtin:meta+`") toggleTerminalAndFocus();
+        else if (p.action === "builtin:ctrl+`") toggleTerminalAndFocus();
         else if (p.action === "builtin:meta+0") toggleFocusComposerTerminal();
         else if (p.action === "builtin:meta+k") clearChat();
         else if (p.action === "builtin:meta+.") void stopPrompt();

--- a/src/hooks/useKeyboardShortcuts.test.tsx
+++ b/src/hooks/useKeyboardShortcuts.test.tsx
@@ -57,12 +57,29 @@ function buildContext(
   };
 }
 
-describe("useKeyboardShortcuts Escape handling", () => {
+describe("useKeyboardShortcuts built-in handling", () => {
   it("toggles the terminal panel with Ctrl+`", () => {
     const ctx = buildContext({});
     render(<Harness ctx={ctx} />);
 
-    fireEvent.keyDown(document, { key: "`", ctrlKey: true });
+    fireEvent.keyDown(document, {
+      key: "`",
+      code: "Backquote",
+      ctrlKey: true,
+    });
+
+    expect(ctx.toggleTerminalAndFocus).toHaveBeenCalledTimes(1);
+  });
+
+  it("matches Ctrl+` by physical key across keyboard layouts", () => {
+    const ctx = buildContext({});
+    render(<Harness ctx={ctx} />);
+
+    fireEvent.keyDown(document, {
+      key: "Dead",
+      code: "Backquote",
+      ctrlKey: true,
+    });
 
     expect(ctx.toggleTerminalAndFocus).toHaveBeenCalledTimes(1);
   });
@@ -71,7 +88,11 @@ describe("useKeyboardShortcuts Escape handling", () => {
     const ctx = buildContext({});
     render(<Harness ctx={ctx} />);
 
-    fireEvent.keyDown(document, { key: "`", metaKey: true });
+    fireEvent.keyDown(document, {
+      key: "`",
+      code: "Backquote",
+      metaKey: true,
+    });
 
     expect(ctx.toggleTerminalAndFocus).not.toHaveBeenCalled();
   });

--- a/src/hooks/useKeyboardShortcuts.test.tsx
+++ b/src/hooks/useKeyboardShortcuts.test.tsx
@@ -58,6 +58,24 @@ function buildContext(
 }
 
 describe("useKeyboardShortcuts Escape handling", () => {
+  it("toggles the terminal panel with Ctrl+`", () => {
+    const ctx = buildContext({});
+    render(<Harness ctx={ctx} />);
+
+    fireEvent.keyDown(document, { key: "`", ctrlKey: true });
+
+    expect(ctx.toggleTerminalAndFocus).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves Cmd+` for the macOS window switcher", () => {
+    const ctx = buildContext({});
+    render(<Harness ctx={ctx} />);
+
+    fireEvent.keyDown(document, { key: "`", metaKey: true });
+
+    expect(ctx.toggleTerminalAndFocus).not.toHaveBeenCalled();
+  });
+
   it("toggles plan mode on Shift+Tab", () => {
     const ctx = buildContext({
       activeTabId: "agent-1",

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -129,8 +129,15 @@ export function useKeyboardShortcuts(ctx: UseKeyboardShortcutsContext): void {
         ctx.togglePlanMode();
         return;
       }
-      // Cmd+`: toggle bottom terminal panel + move focus there/back.
-      if (e.key === "`" && mod && !e.shiftKey && !e.altKey) {
+      // Ctrl+`: toggle bottom terminal panel + move focus there/back.
+      // Cmd+` is macOS's standard window switcher, so leave it alone.
+      if (
+        e.key === "`" &&
+        e.ctrlKey &&
+        !e.metaKey &&
+        !e.shiftKey &&
+        !e.altKey
+      ) {
         e.preventDefault();
         e.stopPropagation();
         ctx.toggleTerminalAndFocus();

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -132,7 +132,7 @@ export function useKeyboardShortcuts(ctx: UseKeyboardShortcutsContext): void {
       // Ctrl+`: toggle bottom terminal panel + move focus there/back.
       // Cmd+` is macOS's standard window switcher, so leave it alone.
       if (
-        e.key === "`" &&
+        e.code === "Backquote" &&
         e.ctrlKey &&
         !e.metaKey &&
         !e.shiftKey &&


### PR DESCRIPTION
## Summary
- move the terminal panel shortcut from `Cmd+\`` / `CmdOrCtrl+\`` to `Ctrl+\``
- leave macOS `Cmd+\`` available for normal window cycling
- update palette-discoverable keybinding metadata and repo shortcut docs

## Validation
- `bunx vitest run src/hooks/useKeyboardShortcuts.test.tsx`
- `bunx vitest run src/extensions/default-layout/palette-items.test.ts src/hooks/uiOverlays/palette.test.ts src/utils/keybindings.test.ts`
- `bun run typecheck`
- `bun run lint`
- `CC=/usr/bin/clang CXX=/usr/bin/clang++ CFLAGS= RUSTFLAGS='-C linker=/usr/bin/clang' cargo check -p aethon` from `src-tauri/`
- `bunx vitest run`

## Notes
Plain `cargo check -p aethon` from this shell initially failed before reaching project code because the default linker was Nix GCC, which could not link macOS build scripts against system `libiconv`. Re-running with `/usr/bin/clang` as the Rust linker completed successfully.
