### PR TITLE
fix: resume sticky scroll on new prompt

### DIFF
--- a/src/extensions/default-layout/chat.test.tsx
+++ b/src/extensions/default-layout/chat.test.tsx
@@ -749,6 +749,46 @@ describe("ChatInput", () => {
     ).toBeTruthy();
   });
 
+  it("resumes following when a new user message is appended after scroll-away", () => {
+    const messages = [
+      { id: "1", role: "user", text: "start" },
+      { id: "2", role: "agent", text: "previous answer" },
+    ];
+    const { onEvent, rerender } = renderHistory({ messages });
+
+    const scroller = screen.getByTestId("virtuoso-mock");
+    act(() => userScrollUp(scroller));
+    expect(
+      screen.getByRole("button", { name: "Scroll to latest message" }),
+    ).toBeTruthy();
+    const before = virtuosoMockState.scrollToCalls.length;
+
+    rerender(
+      <ChatHistory
+        component={{
+          id: "chat-history",
+          type: "chat-history",
+          props: { messages: { $ref: "/messages" } },
+        }}
+        state={{
+          messages: [
+            ...messages,
+            { id: "3", role: "user", text: "follow this new prompt" },
+          ],
+        }}
+        onEvent={onEvent}
+      />,
+    );
+
+    expect(virtuosoMockState.scrollToCalls.length).toBeGreaterThan(before);
+    expect(virtuosoMockState.scrollToCalls).toContainEqual({
+      top: Number.MAX_SAFE_INTEGER,
+    });
+    expect(
+      screen.queryByRole("button", { name: "Scroll to latest message" }),
+    ).toBeNull();
+  });
+
   it("does not treat non-scrolling keydowns as a scroll-away", () => {
     renderHistory({
       messages: [

--- a/src/extensions/default-layout/message-list.tsx
+++ b/src/extensions/default-layout/message-list.tsx
@@ -724,6 +724,7 @@ function VirtualMessageList({
   const userScrollRef = useRef(false);
   const [flashIndex, setFlashIndex] = useState<number | null>(null);
   const prevScrollToMatch = useRef<string | undefined>(undefined);
+  const prevLastMessageId = useRef(messages[messages.length - 1]?.id);
   // Topmost visible group index, fed by Virtuoso's rangeChanged — used to
   // recover the reading anchor when a filter toggle rebuilds the group list.
   const lastRangeRef = useRef<ListRange | null>(null);
@@ -1040,6 +1041,20 @@ function VirtualMessageList({
       scrollToBottom();
     }
   }, [restoreAnchorId, restoreIndex, scrollToBottom, setFollowing, tabId]);
+
+  // A new user turn is an explicit request to continue the conversation, so the
+  // transcript should resume following even if the user had been reading above
+  // the bottom before they sent it. Streaming output still respects manual
+  // scroll-away because only a newly appended user message reaches this branch.
+  useLayoutEffect(() => {
+    const latest = messages[messages.length - 1];
+    const previousId = prevLastMessageId.current;
+    prevLastMessageId.current = latest?.id;
+    if (!latest || latest.id === previousId || latest.role !== "user") return;
+    if (tabId !== undefined) tabScrollCache.delete(tabId);
+    if (!followingRef.current) setFollowing(true);
+    scrollToBottom();
+  }, [messages, scrollToBottom, setFollowing, tabId]);
 
   // Toggling a transcript filter (tool-call grouping / thinking visibility)
   // rebuilds `groups` with a different length + identity. Re-anchor exactly once


### PR DESCRIPTION
## Summary
- resume sticky-scroll follow mode when a newly appended user prompt starts a fresh turn
- clear any saved scrolled-up anchor for that tab before pinning to the latest output
- add a regression test for sending a new message after scrolling away

## Root Cause
The chat list correctly preserved scroll-away intent during streaming, but it treated a newly sent user prompt like any other content append. If follow mode was already disabled, the new prompt did not re-enable it, so the latest-output pill could remain visible while the next response streamed below the viewport.

## Validation
- `bunx vitest run src/extensions/default-layout/chat.test.tsx -t "resumes following when a new user message is appended after scroll-away"`
- `bunx vitest run src/extensions/default-layout/chat.test.tsx src/utils/stickyScrollController.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bunx vitest run`
