### PR TITLE
fix(voice/agent): mic toggle, conversation auto-record, and backgrounded-workspace activity dots

### DIFF
--- a/agent/chat.ts
+++ b/agent/chat.ts
@@ -211,6 +211,13 @@ export async function handleChat(
   tab.promptInFlight = true;
   tab.agentEndFired = false;
   state.currentAgentTabId = tabId;
+  // Announce the turn start so the frontend's bucket-independent running set
+  // (agentRunningTabs) lights up this tab's sidebar dot even when its
+  // workspace is backgrounded. Symmetric with the response_end below; without
+  // it a normal prompt only shows "running" for the active workspace (which
+  // infers it from the optimistic `waiting` flag). `source: "chat"` keeps the
+  // handler from running its queue-promotion branch.
+  deps.send({ type: "prompt_started", tabId, source: "chat" });
   state.tabContext
     .run(tabId, () =>
       images.length > 0

--- a/agent/dispatcher.test.ts
+++ b/agent/dispatcher.test.ts
@@ -394,6 +394,43 @@ describe("handleChat", () => {
     expect(followUpCalls).toEqual([["after this"]]);
     expect(steerCalls).toEqual([]);
     expect(f.sent).toContainEqual({ type: "queued", tabId: "tab-1" });
+    // A queued message must NOT announce a fresh turn start — the
+    // queue-drained agent_start emits prompt_started later instead.
+    expect(
+      f.sent.some((m) => m.type === "prompt_started"),
+    ).toBe(false);
+  });
+
+  it("announces prompt_started for a normal turn so backgrounded workspaces show a running dot", async () => {
+    const f = makeFixture();
+    const tab = fakeTabRecord({
+      session: {
+        prompt: () => Promise.resolve(),
+        followUp: () => Promise.resolve(),
+        steer: () => Promise.resolve(),
+      } as unknown as TabRecord["session"],
+    });
+    f.state.tabs.set("tab-1", tab);
+
+    await handleChat(f.state, f.deps, {
+      type: "chat",
+      content: "do the thing",
+      tabId: "tab-1",
+      mode: "normal",
+    });
+
+    // prompt_started populates the frontend's bucket-independent running set,
+    // which is the only "running" signal for a non-active workspace — without
+    // it a backgrounded agent shows no activity dot until you select its tab.
+    expect(f.sent).toContainEqual({
+      type: "prompt_started",
+      tabId: "tab-1",
+      source: "chat",
+    });
+    // ...and the turn still closes with the matching response_end.
+    await vi.waitFor(() =>
+      expect(f.sent).toContainEqual({ type: "response_end", tabId: "tab-1" }),
+    );
   });
 
   it("rolls back the queue count when followUp rejects", async () => {

--- a/src/extensions/default-layout/chat-input.tsx
+++ b/src/extensions/default-layout/chat-input.tsx
@@ -176,9 +176,14 @@ export function ChatInput({
     },
     [attachments, commitDraft, onEvent, setValue, value],
   );
-  const voice = useVoiceInput(handleTranscript, (providerId) => {
-    onEvent("voice:setup", { providerId });
-  });
+  const voiceSurfaceVisible = !!state.agentTabActive;
+  const voice = useVoiceInput(
+    handleTranscript,
+    (providerId) => {
+      onEvent("voice:setup", { providerId });
+    },
+    { surfaceActive: voiceSurfaceVisible },
+  );
   const voiceState = voice.state;
   const cancelVoice = voice.cancel;
   const voiceConfig = (state.voice as
@@ -199,8 +204,15 @@ export function ChatInput({
   const settings = state.settings as { open?: boolean } | undefined;
   const palette = state.commandPalette as { open?: boolean } | undefined;
   const search = state.search as { open?: boolean } | undefined;
+  // The composer and the dashboard task-launcher both mount at once — the
+  // layout grid hides cells with display:none rather than unmounting — so each
+  // registers the same global voice hotkey against one shared mic. Block START
+  // unless this surface actually owns the canvas (`voiceSurfaceVisible` mirrors
+  // the composer-area's `visible: /agentTabActive` binding); otherwise both
+  // hotkeys fire and the loser reports "Voice recording is already active".
+  // Stop/cancel stay live.
   const voiceInputBlocked =
-    !!settings?.open || !!palette?.open || !!search?.open;
+    !voiceSurfaceVisible || !!settings?.open || !!palette?.open || !!search?.open;
   const voiceInputBlockedRef = useRef(voiceInputBlocked);
   useLayoutEffect(() => {
     voiceInputBlockedRef.current = voiceInputBlocked;

--- a/src/extensions/default-layout/dashboard/task-launcher.test.tsx
+++ b/src/extensions/default-layout/dashboard/task-launcher.test.tsx
@@ -2,6 +2,7 @@
 
 import { renderToStaticMarkup } from "react-dom/server";
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -297,6 +298,88 @@ describe("TaskLauncher", () => {
         }),
       ),
     );
+  });
+
+  // The dashboard task-launcher and the composer both stay mounted (the layout
+  // grid toggles display:none), each registering the same global voice hotkey
+  // against one shared mic. The launcher must ignore the hotkey while its
+  // dashboard is hidden, otherwise pressing it fires both surfaces and the
+  // loser reports "Voice recording is already active".
+  it("ignores the voice hotkey while its dashboard is hidden", async () => {
+    invoke.mockImplementation((cmd: string) => {
+      if (cmd === "voice_list_providers") {
+        return Promise.resolve([
+          voiceProvider({ id: "voice-platform-system" }),
+        ]);
+      }
+      if (cmd === "voice_start_recording") return Promise.resolve(undefined);
+      return Promise.reject(new Error(`invoke not mocked: ${cmd}`));
+    });
+    render(
+      <TaskLauncher
+        component={launcher({
+          project: { id: "p1", label: "aethon", path: "/a" },
+        })}
+        state={{ emptyAndProject: false }}
+        onEvent={vi.fn()}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.keyDown(window, {
+        key: "m",
+        code: "KeyM",
+        metaKey: true,
+        shiftKey: true,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+
+    expect(invoke).not.toHaveBeenCalledWith(
+      "voice_list_providers",
+      expect.anything(),
+    );
+    expect(invoke).not.toHaveBeenCalledWith(
+      "voice_start_recording",
+      expect.anything(),
+    );
+  });
+
+  it("starts recording from the voice hotkey while its dashboard is visible", async () => {
+    invoke.mockImplementation((cmd: string) => {
+      if (cmd === "voice_list_providers") {
+        return Promise.resolve([
+          voiceProvider({ id: "voice-platform-system" }),
+        ]);
+      }
+      if (cmd === "voice_start_recording") return Promise.resolve(undefined);
+      return Promise.reject(new Error(`invoke not mocked: ${cmd}`));
+    });
+    render(
+      <TaskLauncher
+        component={launcher({
+          project: { id: "p1", label: "aethon", path: "/a" },
+        })}
+        state={{ emptyAndProject: true }}
+        onEvent={vi.fn()}
+      />,
+    );
+
+    act(() => {
+      fireEvent.keyDown(window, {
+        key: "m",
+        code: "KeyM",
+        metaKey: true,
+        shiftKey: true,
+      });
+    });
+
+    await waitFor(() =>
+      expect(invoke).toHaveBeenCalledWith("voice_start_recording", {
+        providerId: "voice-platform-system",
+      }),
+    );
+    await screen.findByRole("button", { name: "Stop voice input" });
   });
 
   it("disables OS autocorrection on branch inputs", () => {

--- a/src/extensions/default-layout/dashboard/task-launcher.tsx
+++ b/src/extensions/default-layout/dashboard/task-launcher.tsx
@@ -402,9 +402,21 @@ export function TaskLauncher({
     },
     [promptText, submitPrompt],
   );
-  const voice = useVoiceInput(handleTranscript, (providerId) => {
-    onEvent("voice:setup", { providerId });
-  });
+  // The dashboard task-launcher and the composer both mount at once — the
+  // layout grid hides cells with display:none rather than unmounting — so each
+  // registers the same global voice hotkey against one shared mic. Track
+  // whether this dashboard actually owns the canvas (mirrors the
+  // project-dashboard's `visible: /emptyAndProject` binding) so it neither
+  // starts while hidden nor keeps holding the slot after being hidden;
+  // otherwise both hotkeys fire and the loser reports "already active".
+  const voiceSurfaceVisible = !!state.emptyAndProject;
+  const voice = useVoiceInput(
+    handleTranscript,
+    (providerId) => {
+      onEvent("voice:setup", { providerId });
+    },
+    { surfaceActive: voiceSurfaceVisible },
+  );
   const voiceState = voice.state;
   const cancelVoice = voice.cancel;
   const voiceConfig = (state.voice as
@@ -417,7 +429,11 @@ export function TaskLauncher({
   const palette = state.commandPalette as { open?: boolean } | undefined;
   const search = state.search as { open?: boolean } | undefined;
   const voiceInputBlocked =
-    submitting || !!settings?.open || !!palette?.open || !!search?.open;
+    submitting ||
+    !voiceSurfaceVisible ||
+    !!settings?.open ||
+    !!palette?.open ||
+    !!search?.open;
   const voiceInputBlockedRef = useRef(voiceInputBlocked);
   useLayoutEffect(() => {
     voiceInputBlockedRef.current = voiceInputBlocked;

--- a/src/hooks/useVoiceConversation.test.ts
+++ b/src/hooks/useVoiceConversation.test.ts
@@ -66,16 +66,23 @@ describe("useVoiceConversation", () => {
   });
   afterEach(() => cleanup());
 
-  it("runs a full turn: listen → transcribe → submit → speak → idle", async () => {
+  it("runs a full turn: tap → listen → transcribe → submit → speak → idle", async () => {
     const { result, submitText } = makeController(false);
 
+    // Auto off: entering lands paused, not recording.
     act(() => result.current.enter());
+    await flush();
+    expect(mocks.startVoiceRecording).not.toHaveBeenCalled();
+    expect(result.current.phase).toBe("idle");
+    expect(isConversationActive()).toBe(true);
+
+    // Tap "Speak" to open the mic for the first turn.
+    act(() => result.current.primaryAction());
     await flush();
     expect(mocks.startVoiceRecording).toHaveBeenCalledWith(
       "voice-lfm2-audio-llamacpp",
     );
     expect(result.current.phase).toBe("listening");
-    expect(isConversationActive()).toBe(true);
 
     act(() => result.current.primaryAction());
     await flush();
@@ -91,6 +98,29 @@ describe("useVoiceConversation", () => {
     act(() => ev.fn?.());
     await flush();
     expect(result.current.phase).toBe("idle");
+  });
+
+  it("does not open the mic on entry when auto-listen is off", async () => {
+    const { result } = makeController(false);
+
+    act(() => result.current.enter());
+    await flush();
+
+    expect(mocks.startVoiceRecording).not.toHaveBeenCalled();
+    expect(result.current.phase).toBe("idle");
+    expect(result.current.active).toBe(true);
+  });
+
+  it("opens the mic immediately on entry when auto-listen is on", async () => {
+    const { result } = makeController(true);
+
+    act(() => result.current.enter());
+    await flush();
+
+    expect(mocks.startVoiceRecording).toHaveBeenCalledWith(
+      "voice-lfm2-audio-llamacpp",
+    );
+    expect(result.current.phase).toBe("listening");
   });
 
   it("re-opens the mic after speaking in continuous mode", async () => {
@@ -157,7 +187,9 @@ describe("useVoiceConversation", () => {
     const { result } = makeController(false);
     act(() => result.current.enter());
     await flush();
-    act(() => result.current.primaryAction());
+    act(() => result.current.primaryAction()); // tap to start listening
+    await flush();
+    act(() => result.current.primaryAction()); // finish → submit → thinking
     await flush();
 
     act(() => emitAgentTurnComplete({ tabId: "other", text: "Not mine." }));
@@ -171,7 +203,9 @@ describe("useVoiceConversation", () => {
     mocks.stopAndTranscribeVoice.mockResolvedValueOnce("   ");
     act(() => result.current.enter());
     await flush();
-    act(() => result.current.primaryAction());
+    act(() => result.current.primaryAction()); // tap to start listening
+    await flush();
+    act(() => result.current.primaryAction()); // finish → empty → idle
     await flush();
     expect(submitText).not.toHaveBeenCalled();
     expect(result.current.phase).toBe("idle");
@@ -187,7 +221,8 @@ describe("useVoiceConversation", () => {
     );
     const { result } = makeController(false);
 
-    act(() => result.current.enter()); // first start — hangs in the open window
+    act(() => result.current.enter()); // paused (Auto off)
+    act(() => result.current.primaryAction()); // first start — hangs in the open window
     act(() => result.current.primaryAction()); // second tap during the window
     expect(mocks.startVoiceRecording).toHaveBeenCalledTimes(1);
 
@@ -201,6 +236,8 @@ describe("useVoiceConversation", () => {
   it("exit cancels recording/playback and clears the active flag", async () => {
     const { result } = makeController(false);
     act(() => result.current.enter());
+    await flush();
+    act(() => result.current.primaryAction()); // tap to start listening
     await flush();
 
     act(() => result.current.exit());
@@ -247,6 +284,8 @@ describe("useVoiceConversation", () => {
     const { result } = makeController(false);
     act(() => result.current.enter());
     await flush();
+    act(() => result.current.primaryAction()); // tap to start listening
+    await flush();
     act(() => result.current.primaryAction()); // finish → submit → thinking
     await flush();
     // An empty reply drops a non-continuous conversation back to idle.
@@ -266,7 +305,9 @@ describe("useVoiceConversation", () => {
     // Drive one turn so the conversation settles back to idle.
     act(() => result.current.enter());
     await flush();
-    act(() => result.current.primaryAction());
+    act(() => result.current.primaryAction()); // tap to start listening
+    await flush();
+    act(() => result.current.primaryAction()); // finish → thinking
     await flush();
     act(() => emitAgentTurnComplete({ tabId: "t1", text: "" }));
     await flush();

--- a/src/hooks/useVoiceConversation.ts
+++ b/src/hooks/useVoiceConversation.ts
@@ -185,8 +185,15 @@ export function useVoiceConversation(
     activeRef.current = true;
     setActive(true);
     setConversationActive(true);
-    void startListening();
-  }, [startListening]);
+    // Auto-listen (continuous) is hands-free, so open the mic immediately on
+    // entry. With it off the user drives every turn — including the first — so
+    // land on the paused "tap to talk" state instead of recording on entry.
+    if (optionsRef.current.continuous) {
+      void startListening();
+    } else {
+      setPhase("idle");
+    }
+  }, [setPhase, startListening]);
 
   const exit = useCallback(() => {
     activeRef.current = false;

--- a/src/hooks/useVoiceInput.test.ts
+++ b/src/hooks/useVoiceInput.test.ts
@@ -136,4 +136,63 @@ describe("useVoiceInput", () => {
       "voice-platform-system",
     );
   });
+
+  // The composer and the dashboard task-launcher stay mounted together (the
+  // layout grid toggles display:none, it doesn't unmount), sharing one mic.
+  // A controller whose surface is hidden mid-capture must release the slot so
+  // the now-visible surface's next start doesn't fail with "already active".
+  it("releases the mic when its surface is hidden mid-recording", async () => {
+    const { result, rerender } = renderHook(
+      ({ active }: { active: boolean }) =>
+        useVoiceInput(vi.fn(), vi.fn(), { surfaceActive: active }),
+      { initialProps: { active: true } },
+    );
+
+    await act(async () => {
+      await result.current.start();
+    });
+    expect(result.current.state).toBe("recording");
+
+    act(() => {
+      rerender({ active: false });
+    });
+
+    expect(result.current.state).toBe("idle");
+    expect(service.cancelVoiceRecording).toHaveBeenCalledWith(
+      "voice-platform-system",
+    );
+  });
+
+  it("keeps recording while its surface stays visible", async () => {
+    const { result, rerender } = renderHook(
+      ({ active }: { active: boolean }) =>
+        useVoiceInput(vi.fn(), vi.fn(), { surfaceActive: active }),
+      { initialProps: { active: true } },
+    );
+
+    await act(async () => {
+      await result.current.start();
+    });
+    act(() => {
+      rerender({ active: true });
+    });
+
+    expect(result.current.state).toBe("recording");
+    expect(service.cancelVoiceRecording).not.toHaveBeenCalled();
+  });
+
+  it("does not touch the mic when an idle surface is hidden", () => {
+    const { result, rerender } = renderHook(
+      ({ active }: { active: boolean }) =>
+        useVoiceInput(vi.fn(), vi.fn(), { surfaceActive: active }),
+      { initialProps: { active: true } },
+    );
+
+    act(() => {
+      rerender({ active: false });
+    });
+
+    expect(result.current.state).toBe("idle");
+    expect(service.cancelVoiceRecording).not.toHaveBeenCalled();
+  });
 });

--- a/src/hooks/useVoiceInput.ts
+++ b/src/hooks/useVoiceInput.ts
@@ -93,10 +93,20 @@ export interface VoiceInputController {
   cancel: () => void;
 }
 
+export interface UseVoiceInputOptions {
+  /** Whether the surface hosting this controller is currently visible. The
+   *  shared mic slot is app-wide, so a controller whose surface gets hidden
+   *  mid-capture must release it — otherwise the now-visible surface's next
+   *  start fails with "Voice recording is already active". Defaults to true. */
+  surfaceActive?: boolean;
+}
+
 export function useVoiceInput(
   onTranscript: (transcript: string, options: { autoSend: boolean }) => void,
   onNeedsSetup: (providerId: string) => void,
+  options?: UseVoiceInputOptions,
 ): VoiceInputController {
+  const surfaceActive = options?.surfaceActive ?? true;
   const [state, setState] = useState<VoiceState>("idle");
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
   const [interimTranscript, setInterimTranscript] = useState("");
@@ -385,6 +395,25 @@ export function useVoiceInput(
   useLayoutEffect(() => {
     stateRef.current = state;
   });
+
+  // Release the mic if this surface is hidden mid-capture. The composer and the
+  // dashboard task-launcher both stay mounted (the layout grid toggles
+  // display:none, it doesn't unmount), so a recording started while visible
+  // would otherwise keep holding the shared slot after the user navigates away,
+  // blocking the next start on whichever surface is now visible. cancel()
+  // discards rather than transcribing into a surface the user has left.
+  const surfaceActiveRef = useRef(surfaceActive);
+  useEffect(() => {
+    const wasActive = surfaceActiveRef.current;
+    surfaceActiveRef.current = surfaceActive;
+    if (
+      wasActive &&
+      !surfaceActive &&
+      (stateRef.current === "recording" || stateRef.current === "starting")
+    ) {
+      cancel();
+    }
+  }, [surfaceActive, cancel]);
 
   useEffect(() => {
     const onBlur = () => {


### PR DESCRIPTION
Papercuts pass — three independent fixes to voice input and sidebar agent-activity.

## 1. Mic toggle reporting "Voice recording is already active" (`3cef52e`)
The composer (`chat-input`) and the dashboard `task-launcher` stay mounted at the same time — the layout grid toggles `display:none` rather than unmounting — so each registered the **same** global `mod+shift+m` voice hotkey and its own `useVoiceInput` controller against one shared Rust mic slot. Pressing the hotkey fired both surfaces: one grabbed the mic, the other reported "already active". A related leak: a recording started while a surface was visible kept holding the slot after the user navigated away.

**Fix:** gate each surface's voice **start** on its own layout-visibility flag (`/agentTabActive` for the composer, `/emptyAndProject` for the task launcher) via the existing `isInputBlocked` predicate, and release the mic when a surface is hidden mid-capture (new `surfaceActive` option on `useVoiceInput`). Stop/cancel stay reachable so a recording can always be ended.

## 2. Conversation mode auto-recording on entry (`b3f03f1`)
Entering LFM2 conversation mode unconditionally opened the mic, so toggling it on immediately started recording even with **Auto** (continuous) off.

**Fix:** `enter()` only opens the mic when continuous is on; otherwise it lands on the paused "tap to talk" state and the user taps **Speak** to begin. Consistent with what already happens between turns (`goIdleOrContinue`).

## 3. No running dot for agents in backgrounded workspaces (`40275c4`)
The longstanding one. The normal chat-prompt path (`agent/chat.ts`) dispatched the turn and sent `response_end` on completion but **never sent `prompt_started`** — that message was only emitted for queue-drained and handler-driven prompts. `prompt_started` is what populates the frontend's bucket-independent `agentRunningTabs` set, the only "running" signal for a non-active workspace. So a running agent only lit its sidebar dot for the **active** workspace; any backgrounded workspace showed no activity until you selected its tab.

**Fix:** emit `prompt_started` (`source: "chat"`) when dispatching a normal turn, symmetric with the `response_end` already sent. Also restores the hang-warn timer and OS completion notification for normal turns, which depended on the same missing signal. Verified live: a backgrounded workspace's dot now turns green while its agent runs and clears when the turn ends.

## Tests
- `useVoiceInput`: releases mic on surface hide; keeps recording while visible; leaves an idle hidden surface alone.
- `task-launcher`: ignores the voice hotkey while its dashboard is hidden; starts on the hotkey while visible.
- `useVoiceConversation`: entry doesn't open the mic with Auto off; opens immediately with Auto on; existing turn flow updated to the tap-to-start model.
- `dispatcher`: a normal turn emits `prompt_started`; a queued message does not.

Full gate green locally: `tsc -b`, ESLint (0 warnings), and the full vitest suite (303 files / 2484 tests).