### PR TITLE
test(voice): make hidden-dashboard hotkey gate test deterministic

### DIFF
--- a/src/extensions/default-layout/dashboard/task-launcher.test.tsx
+++ b/src/extensions/default-layout/dashboard/task-launcher.test.tsx
@@ -325,14 +325,19 @@ describe("TaskLauncher", () => {
       />,
     );
 
-    await act(async () => {
+    act(() => {
       fireEvent.keyDown(window, {
         key: "m",
         code: "KeyM",
         metaKey: true,
         shiftKey: true,
       });
-      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+    // Drain microtasks deterministically (no real timer): if the gate
+    // regressed, start() would have invoked voice_list_providers by now.
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
     });
 
     expect(invoke).not.toHaveBeenCalledWith(


### PR DESCRIPTION
Follow-up to #328 addressing Copilot's review finding.

The "ignores the voice hotkey while its dashboard is hidden" test slept on a real `setTimeout(10)` to let any async `voice.start()` settle before its negative assertion — timing-dependent and a flake risk on slow CI runners.

**Fix:** replace the real timer with a deterministic microtask flush via `act`.

The flush is load-bearing, not cosmetic. Verified adversarially:
- gate intact → test passes
- visibility gate removed → test **fails** (the hotkey reaches `voice_list_providers`)

So the assertion now genuinely guards the fix. (The previous real-timer form was actually a vacuous pass — the negative assertion ran before `start()` had progressed.)

Test-only change; `tsc -b`, ESLint, and the full task-launcher suite are green.