### PR TITLE
fix: clarify running session warning

### DIFF
--- a/src/hooks/bridgeMessageHandlers/promptStarted.test.ts
+++ b/src/hooks/bridgeMessageHandlers/promptStarted.test.ts
@@ -116,7 +116,7 @@ describe("handlePromptStarted", () => {
             ...makeEmptyTab(tabId, "Tab 1"),
             waiting: true,
             model: "gpt-5",
-            cwd: "/Users/jamesbrink/Projects/utensils/aethon",
+            cwd: "C:\\Users\\jamesbrink\\Projects\\utensils\\aethon",
             queuedMessages: [{ id: "q1", content: "next" }],
             queueCount: 1,
           },
@@ -131,7 +131,7 @@ describe("handlePromptStarted", () => {
         id: `ae-hang-warn:${tabId}`,
         title: "Tab 1 is still working (gpt-5)",
         message:
-          "This session has been running longer than expected. Working directory: .../utensils/aethon. 1 queued message waiting.",
+          "This session has been running longer than expected. Working directory: …/utensils/aethon. 1 queued message waiting.",
         kind: "warning",
         actions: [
           { label: "Open session", action: `activate-tab:${tabId}` },

--- a/src/hooks/bridgeMessageHandlers/promptStarted.test.ts
+++ b/src/hooks/bridgeMessageHandlers/promptStarted.test.ts
@@ -106,12 +106,21 @@ describe("handlePromptStarted", () => {
     ]);
   });
 
-  it("schedules a hang-warn notification after hangWarnMs", () => {
+  it("schedules an actionable hang-warn notification with session context after hangWarnMs", () => {
     const tabId = "default";
     const { ctx, mocks } = buildHandlerFixture({
       state: {
         activeTabId: tabId,
-        tabs: [{ ...makeEmptyTab(tabId, "Tab 1"), waiting: true }],
+        tabs: [
+          {
+            ...makeEmptyTab(tabId, "Tab 1"),
+            waiting: true,
+            model: "gpt-5",
+            cwd: "/Users/jamesbrink/Projects/utensils/aethon",
+            queuedMessages: [{ id: "q1", content: "next" }],
+            queueCount: 1,
+          },
+        ],
       },
     });
     handlePromptStarted({ type: "prompt_started", tabId }, ctx);
@@ -120,8 +129,15 @@ describe("handlePromptStarted", () => {
     expect(mocks.pushNotification).toHaveBeenCalledWith(
       expect.objectContaining({
         id: `ae-hang-warn:${tabId}`,
-        title: "Still working…",
+        title: "Tab 1 is still working (gpt-5)",
+        message:
+          "This session has been running longer than expected. Working directory: .../utensils/aethon. 1 queued message waiting.",
         kind: "warning",
+        actions: [
+          { label: "Open session", action: `activate-tab:${tabId}` },
+          { label: "Stop", action: `hang-warn:stop:${tabId}` },
+          { label: "Force restart", action: "hang-warn:force-restart" },
+        ],
       }),
     );
     expect(ctx.hangWarnActiveRef.current.has(tabId)).toBe(true);

--- a/src/hooks/bridgeMessageHandlers/promptStarted.ts
+++ b/src/hooks/bridgeMessageHandlers/promptStarted.ts
@@ -1,6 +1,33 @@
 import type { Tab } from "../../types/tab";
 import type { BridgeMessageHandler } from "./types";
 
+function shortPath(path: string | undefined): string | undefined {
+  if (!path) return undefined;
+  const parts = path.split("/").filter(Boolean);
+  if (parts.length <= 2) return path;
+  return `.../${parts.slice(-2).join("/")}`;
+}
+
+function hangWarnTitle(tab: Tab): string {
+  const label = tab.label?.trim() || "Agent session";
+  const model = tab.model?.trim();
+  return model
+    ? `${label} is still working (${model})`
+    : `${label} is still working`;
+}
+
+function hangWarnMessage(tab: Tab): string {
+  const cwd = shortPath(tab.cwd);
+  const bits = ["This session has been running longer than expected."];
+  if (cwd) bits.push(`Working directory: ${cwd}.`);
+  if (tab.queueCount > 0) {
+    bits.push(
+      `${tab.queueCount} queued message${tab.queueCount === 1 ? "" : "s"} waiting.`,
+    );
+  }
+  return bits.join(" ");
+}
+
 /** Bridge tells us a prompt has begun. Sent for handler-driven
  *  ctx.pi.prompt AND every queue-drained turn (source: "queue") so Stop
  *  stays visible across followUp boundaries instead of flashing back to
@@ -78,11 +105,12 @@ export const handlePromptStarted: BridgeMessageHandler = (data, ctx) => {
       ctx.hangWarnActiveRef.current.add(tabId);
       ctx.pushNotification({
         id: ctx.hangWarnNotifId(tabId),
-        title: "Still working…",
-        message: "The agent is taking longer than expected.",
+        title: hangWarnTitle(tab),
+        message: hangWarnMessage(tab),
         kind: "warning",
         durationMs: null,
         actions: [
+          { label: "Open session", action: `activate-tab:${tabId}` },
           { label: "Stop", action: `hang-warn:stop:${tabId}` },
           { label: "Force restart", action: "hang-warn:force-restart" },
         ],

--- a/src/hooks/bridgeMessageHandlers/promptStarted.ts
+++ b/src/hooks/bridgeMessageHandlers/promptStarted.ts
@@ -3,9 +3,9 @@ import type { BridgeMessageHandler } from "./types";
 
 function shortPath(path: string | undefined): string | undefined {
   if (!path) return undefined;
-  const parts = path.split("/").filter(Boolean);
+  const parts = path.split(/[\\/]+/).filter(Boolean);
   if (parts.length <= 2) return path;
-  return `.../${parts.slice(-2).join("/")}`;
+  return `…/${parts.slice(-2).join("/")}`;
 }
 
 function hangWarnTitle(tab: Tab): string {


### PR DESCRIPTION
## Summary
- Clarify the long-running agent warning with the session label, model, working directory, and queued-message count.
- Add an `Open session` action that reuses the existing `activate-tab:` route so the toast can jump directly to the running session.
- Extend the prompt-started regression test to cover the improved copy and actions.

## Root Cause
The hang warning in `handlePromptStarted` emitted a generic sticky toast (`Still working...`) with only Stop and Force restart actions, so the user could not tell which agent session was running or jump back to it from the notification.

## Validation
- `bunx vitest run src/hooks/bridgeMessageHandlers/promptStarted.test.ts src/eventRoutes/notifications.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bunx vitest run` (passes; existing jsdom/canvas warnings are still printed)
