### PR TITLE
fix: clarify workspace startup progress

### DIFF
--- a/src/app/StartupCurtain.test.tsx
+++ b/src/app/StartupCurtain.test.tsx
@@ -66,4 +66,40 @@ describe("StartupCurtain", () => {
     expect(html).toContain("Skip startup");
     expect(html).not.toContain(">Continue<");
   });
+
+  it("shows useful progress metadata instead of optional flags", () => {
+    const html = renderToStaticMarkup(
+      <StartupCurtain
+        logoUrl="/logo.svg"
+        startup={{
+          output: "",
+          entry: {
+            root: "/repo",
+            fingerprint: "abc",
+            state: "running",
+            approved: true,
+            commands: [
+              {
+                id: "aethon-devshell",
+                label: "Prepare environment",
+                required: false,
+                state: "running",
+              },
+              {
+                id: "deps",
+                label: "Install dependencies",
+                required: true,
+                state: "idle",
+              },
+            ],
+          },
+        }}
+      />,
+    );
+
+    expect(html).toContain("Prepare environment");
+    expect(html).toContain("checking dev shell");
+    expect(html).toContain("waiting");
+    expect(html).not.toContain("optional");
+  });
 });

--- a/src/app/StartupCurtain.tsx
+++ b/src/app/StartupCurtain.tsx
@@ -1,5 +1,10 @@
 import { useId } from "react";
-import type { WorkspaceStartupView } from "../hooks/useWorkspaceStartup";
+import type {
+  WorkspaceStartupTask,
+  WorkspaceStartupView,
+} from "../hooks/useWorkspaceStartup";
+
+const DEVSHELL_STARTUP_TASK_ID = "aethon-devshell";
 
 export interface StartupCurtainProps {
   logoUrl: string;
@@ -79,9 +84,9 @@ export function StartupCurtain({
               <div className="ae-startup-task" key={task.id}>
                 <span className={`ae-startup-task-dot is-${task.state}`} />
                 <span>{task.label}</span>
-                {!task.required ? (
-                  <span className="ae-startup-task-meta">optional</span>
-                ) : null}
+                <span className="ae-startup-task-meta">
+                  {startupTaskMeta(task)}
+                </span>
               </div>
             ))
           )}
@@ -116,4 +121,18 @@ export function StartupCurtain({
       </div>
     </div>
   );
+}
+
+function startupTaskMeta(task: WorkspaceStartupTask): string {
+  switch (task.state) {
+    case "running":
+      return task.id === DEVSHELL_STARTUP_TASK_ID ? "checking dev shell" : "running";
+    case "ready":
+      return "ready";
+    case "failed":
+      return task.required ? "failed" : "non-blocking failed";
+    case "idle":
+    default:
+      return "waiting";
+  }
 }


### PR DESCRIPTION
## Summary
- Replaces the startup curtain's internal `optional` task metadata with user-facing progress labels such as `checking dev shell`, `waiting`, `ready`, and `non-blocking failed`.
- Adds regression coverage for the workspace preparation state shown before an agent tab opens.

## Why
The built-in environment preparation task is intentionally non-blocking in the startup data model, but surfacing that as `optional` on the loading screen made the UI look like it was describing configuration instead of explaining what Aethon was doing. The curtain now reports the task state and what is loading.

## Validation
- `bunx vitest run src/app/StartupCurtain.test.tsx`
- `bunx vitest run src/app/AppRoot.test.tsx src/app/StartupCurtain.test.tsx`
- `bun run typecheck`
- `bun run lint`
- In-app browser QA with a localhost fixture at desktop and 390px mobile widths: no `optional` text, no horizontal overflow, no console warnings.
