### PR TITLE
fix: refresh session watchdog on agent activity

### DIFF
--- a/src/hooks/bridgeMessageHandlers/a2ui.ts
+++ b/src/hooks/bridgeMessageHandlers/a2ui.ts
@@ -3,6 +3,7 @@ import type { Tab } from "../../types/tab";
 import { closeRunningToolCards } from "../../utils/agentBusy";
 import { toolCardIdentityFromId } from "../../utils/toolCardIdentity";
 import type { BridgeMessageHandler } from "./types";
+import { clearHangWarn } from "./hangWarn";
 import { flushResponseDeltas } from "./responseDelta";
 
 function completedToolCard(payload: A2UIPayload): A2UIComponent | undefined {
@@ -250,5 +251,6 @@ export const handleA2ui: BridgeMessageHandler = (data, ctx) => {
       delete next[tabId];
       return { ...prev, agentRunningTabs: next };
     });
+    clearHangWarn(ctx, tabId);
   }
 };

--- a/src/hooks/bridgeMessageHandlers/error.ts
+++ b/src/hooks/bridgeMessageHandlers/error.ts
@@ -1,4 +1,5 @@
 import { closeRunningToolCards } from "../../utils/agentBusy";
+import { clearHangWarn } from "./hangWarn";
 import type { BridgeMessageHandler } from "./types";
 
 export const handleError: BridgeMessageHandler = (data, ctx) => {
@@ -29,4 +30,5 @@ export const handleError: BridgeMessageHandler = (data, ctx) => {
   if (ctx.stateRef.current.activeTabId === tabId) {
     ctx.setStatusFlags({ status: "error" });
   }
+  clearHangWarn(ctx, tabId);
 };

--- a/src/hooks/bridgeMessageHandlers/hangWarn.ts
+++ b/src/hooks/bridgeMessageHandlers/hangWarn.ts
@@ -95,6 +95,48 @@ function hasText(value: unknown): boolean {
   return typeof value === "string" && value.length > 0;
 }
 
+const pendingRefreshes = new Map<string, BridgeMessageContext>();
+let refreshScheduled = false;
+
+function scheduleRefreshFlush() {
+  if (refreshScheduled) return;
+  refreshScheduled = true;
+  const flush = () => {
+    refreshScheduled = false;
+    const pending = [...pendingRefreshes];
+    pendingRefreshes.clear();
+    for (const [tabId, ctx] of pending) {
+      const tab = tabById(ctx, tabId);
+      if (tab?.waiting) armHangWarn(ctx, tabId);
+    }
+  };
+  if (typeof window !== "undefined" && "requestAnimationFrame" in window) {
+    window.requestAnimationFrame(flush);
+  } else {
+    setTimeout(flush, 16);
+  }
+}
+
+export function scheduleHangWarnRefresh(
+  ctx: BridgeMessageContext,
+  tabId: string,
+): void {
+  const handle = ctx.hangWarnTimersRef.current.get(tabId);
+  const wasActive = ctx.hangWarnActiveRef.current.has(tabId);
+  if (handle === undefined && !wasActive) return;
+
+  if (handle !== undefined) {
+    clearTimeout(handle);
+    ctx.hangWarnTimersRef.current.delete(tabId);
+  }
+  if (wasActive) {
+    ctx.hangWarnActiveRef.current.delete(tabId);
+    ctx.dismissNotification(ctx.hangWarnNotifId(tabId));
+  }
+  pendingRefreshes.set(tabId, ctx);
+  scheduleRefreshFlush();
+}
+
 export function bridgeMessageRefreshesHangWarn(
   message: BridgeMessage,
 ): boolean {
@@ -109,7 +151,7 @@ export function bridgeMessageRefreshesHangWarn(
     case "subagent_progress":
       return true;
     case "notice":
-      return message.busy === true;
+      return message.busy === true || hasText(message.message);
     default:
       return false;
   }
@@ -120,5 +162,8 @@ export function refreshHangWarnForBridgeMessage(
   ctx: BridgeMessageContext,
 ): void {
   if (!bridgeMessageRefreshesHangWarn(message)) return;
-  refreshHangWarn(ctx, (message.tabId as string | undefined) ?? "default");
+  scheduleHangWarnRefresh(
+    ctx,
+    (message.tabId as string | undefined) ?? "default",
+  );
 }

--- a/src/hooks/bridgeMessageHandlers/hangWarn.ts
+++ b/src/hooks/bridgeMessageHandlers/hangWarn.ts
@@ -1,0 +1,124 @@
+import type { Tab } from "../../types/tab";
+import type { BridgeMessage, BridgeMessageContext } from "./types";
+
+function shortPath(path: string | undefined): string | undefined {
+  if (!path) return undefined;
+  const parts = path.split(/[\\/]+/).filter(Boolean);
+  if (parts.length <= 2) return path;
+  return `…/${parts.slice(-2).join("/")}`;
+}
+
+function hangWarnTitle(tab: Tab): string {
+  const label = tab.label?.trim() || "Agent session";
+  const model = tab.model?.trim();
+  return model
+    ? `${label} is still working (${model})`
+    : `${label} is still working`;
+}
+
+function hangWarnMessage(tab: Tab): string {
+  const cwd = shortPath(tab.cwd);
+  const bits = ["This session has not shown activity for a while."];
+  if (cwd) bits.push(`Working directory: ${cwd}.`);
+  if (tab.queueCount > 0) {
+    bits.push(
+      `${tab.queueCount} queued message${tab.queueCount === 1 ? "" : "s"} waiting.`,
+    );
+  }
+  return bits.join(" ");
+}
+
+function tabById(ctx: BridgeMessageContext, tabId: string): Tab | undefined {
+  const tabs = (ctx.stateRef.current.tabs as Tab[] | undefined) ?? [];
+  return tabs.find((t) => t.id === tabId);
+}
+
+export function clearHangWarn(ctx: BridgeMessageContext, tabId: string): void {
+  const handle = ctx.hangWarnTimersRef.current.get(tabId);
+  if (handle !== undefined) {
+    clearTimeout(handle);
+    ctx.hangWarnTimersRef.current.delete(tabId);
+  }
+  if (ctx.hangWarnActiveRef.current.delete(tabId)) {
+    ctx.dismissNotification(ctx.hangWarnNotifId(tabId));
+  }
+}
+
+export function armHangWarn(ctx: BridgeMessageContext, tabId: string): void {
+  const prev = ctx.hangWarnTimersRef.current.get(tabId);
+  if (prev !== undefined) clearTimeout(prev);
+  const handle = setTimeout(() => {
+    ctx.hangWarnTimersRef.current.delete(tabId);
+    const cur = ctx.stateRef.current;
+    if ((cur.activeTabId as string | undefined) !== tabId) return;
+    const tab = tabById(ctx, tabId);
+    if (!tab?.waiting) return;
+    ctx.hangWarnActiveRef.current.add(tabId);
+    ctx.pushNotification({
+      id: ctx.hangWarnNotifId(tabId),
+      title: hangWarnTitle(tab),
+      message: hangWarnMessage(tab),
+      kind: "warning",
+      durationMs: null,
+      actions: [
+        { label: "Open session", action: `activate-tab:${tabId}` },
+        { label: "Stop", action: `hang-warn:stop:${tabId}` },
+        { label: "Force restart", action: "hang-warn:force-restart" },
+      ],
+    });
+  }, ctx.hangWarnMs);
+  ctx.hangWarnTimersRef.current.set(tabId, handle);
+}
+
+export function refreshHangWarn(
+  ctx: BridgeMessageContext,
+  tabId: string,
+): void {
+  const hasTimer = ctx.hangWarnTimersRef.current.has(tabId);
+  const wasActive = ctx.hangWarnActiveRef.current.has(tabId);
+  if (!hasTimer && !wasActive) return;
+
+  const tab = tabById(ctx, tabId);
+  if (!tab?.waiting) {
+    clearHangWarn(ctx, tabId);
+    return;
+  }
+
+  if (wasActive) {
+    ctx.hangWarnActiveRef.current.delete(tabId);
+    ctx.dismissNotification(ctx.hangWarnNotifId(tabId));
+  }
+  armHangWarn(ctx, tabId);
+}
+
+function hasText(value: unknown): boolean {
+  return typeof value === "string" && value.length > 0;
+}
+
+export function bridgeMessageRefreshesHangWarn(
+  message: BridgeMessage,
+): boolean {
+  switch (message.type) {
+    case "response_delta":
+      return hasText(message.content);
+    case "terminal_output":
+      return hasText(message.content);
+    case "response":
+      return hasText(message.content);
+    case "a2ui":
+    case "subagent_progress":
+      return true;
+    case "notice":
+      return message.busy === true;
+    default:
+      return false;
+  }
+}
+
+export function refreshHangWarnForBridgeMessage(
+  message: BridgeMessage,
+  ctx: BridgeMessageContext,
+): void {
+  if (!bridgeMessageRefreshesHangWarn(message)) return;
+  refreshHangWarn(ctx, (message.tabId as string | undefined) ?? "default");
+}

--- a/src/hooks/bridgeMessageHandlers/promptStarted.test.ts
+++ b/src/hooks/bridgeMessageHandlers/promptStarted.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { handlePromptStarted } from "./promptStarted";
-import { refreshHangWarn } from "./hangWarn";
+import { refreshHangWarn, scheduleHangWarnRefresh } from "./hangWarn";
 import { buildHandlerFixture } from "./testFixtures";
 import { makeEmptyTab } from "../../types/tab";
 
@@ -185,5 +185,34 @@ describe("handlePromptStarted", () => {
     );
     expect(ctx.hangWarnActiveRef.current.has(tabId)).toBe(false);
     expect(ctx.hangWarnTimersRef.current.has(tabId)).toBe(true);
+  });
+
+  it("coalesces streamed activity refreshes to one timer re-arm per frame", () => {
+    const tabId = "default";
+    const { ctx, mocks } = buildHandlerFixture({
+      state: {
+        activeTabId: tabId,
+        tabs: [{ ...makeEmptyTab(tabId, "Tab 1"), waiting: true }],
+      },
+    });
+    handlePromptStarted({ type: "prompt_started", tabId }, ctx);
+    const originalTimer = ctx.hangWarnTimersRef.current.get(tabId);
+    expect(originalTimer).toBeDefined();
+
+    scheduleHangWarnRefresh(ctx, tabId);
+    scheduleHangWarnRefresh(ctx, tabId);
+
+    expect(ctx.hangWarnTimersRef.current.has(tabId)).toBe(false);
+    vi.advanceTimersByTime(15);
+    expect(ctx.hangWarnTimersRef.current.has(tabId)).toBe(false);
+    vi.advanceTimersByTime(1);
+
+    const refreshedTimer = ctx.hangWarnTimersRef.current.get(tabId);
+    expect(refreshedTimer).toBeDefined();
+    expect(refreshedTimer).not.toBe(originalTimer);
+    vi.advanceTimersByTime(ctx.hangWarnMs - 1);
+    expect(mocks.pushNotification).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(mocks.pushNotification).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/hooks/bridgeMessageHandlers/promptStarted.test.ts
+++ b/src/hooks/bridgeMessageHandlers/promptStarted.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { handlePromptStarted } from "./promptStarted";
+import { refreshHangWarn } from "./hangWarn";
 import { buildHandlerFixture } from "./testFixtures";
 import { makeEmptyTab } from "../../types/tab";
 
@@ -131,7 +132,7 @@ describe("handlePromptStarted", () => {
         id: `ae-hang-warn:${tabId}`,
         title: "Tab 1 is still working (gpt-5)",
         message:
-          "This session has been running longer than expected. Working directory: …/utensils/aethon. 1 queued message waiting.",
+          "This session has not shown activity for a while. Working directory: …/utensils/aethon. 1 queued message waiting.",
         kind: "warning",
         actions: [
           { label: "Open session", action: `activate-tab:${tabId}` },
@@ -141,5 +142,48 @@ describe("handlePromptStarted", () => {
       }),
     );
     expect(ctx.hangWarnActiveRef.current.has(tabId)).toBe(true);
+  });
+
+  it("refreshes the hang-warn timer on live activity instead of warning during a healthy long turn", () => {
+    const tabId = "default";
+    const { ctx, mocks } = buildHandlerFixture({
+      state: {
+        activeTabId: tabId,
+        tabs: [{ ...makeEmptyTab(tabId, "Tab 1"), waiting: true }],
+      },
+    });
+    handlePromptStarted({ type: "prompt_started", tabId }, ctx);
+
+    vi.advanceTimersByTime(ctx.hangWarnMs - 1);
+    refreshHangWarn(ctx, tabId);
+    vi.advanceTimersByTime(1);
+    expect(mocks.pushNotification).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(ctx.hangWarnMs - 2);
+    expect(mocks.pushNotification).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(mocks.pushNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it("dismisses an active hang-warn notification when activity resumes", () => {
+    const tabId = "default";
+    const { ctx, mocks } = buildHandlerFixture({
+      state: {
+        activeTabId: tabId,
+        tabs: [{ ...makeEmptyTab(tabId, "Tab 1"), waiting: true }],
+      },
+    });
+    handlePromptStarted({ type: "prompt_started", tabId }, ctx);
+    vi.advanceTimersByTime(ctx.hangWarnMs);
+    expect(mocks.pushNotification).toHaveBeenCalledTimes(1);
+    expect(ctx.hangWarnActiveRef.current.has(tabId)).toBe(true);
+
+    refreshHangWarn(ctx, tabId);
+
+    expect(mocks.dismissNotification).toHaveBeenCalledWith(
+      `ae-hang-warn:${tabId}`,
+    );
+    expect(ctx.hangWarnActiveRef.current.has(tabId)).toBe(false);
+    expect(ctx.hangWarnTimersRef.current.has(tabId)).toBe(true);
   });
 });

--- a/src/hooks/bridgeMessageHandlers/promptStarted.ts
+++ b/src/hooks/bridgeMessageHandlers/promptStarted.ts
@@ -1,32 +1,5 @@
-import type { Tab } from "../../types/tab";
 import type { BridgeMessageHandler } from "./types";
-
-function shortPath(path: string | undefined): string | undefined {
-  if (!path) return undefined;
-  const parts = path.split(/[\\/]+/).filter(Boolean);
-  if (parts.length <= 2) return path;
-  return `…/${parts.slice(-2).join("/")}`;
-}
-
-function hangWarnTitle(tab: Tab): string {
-  const label = tab.label?.trim() || "Agent session";
-  const model = tab.model?.trim();
-  return model
-    ? `${label} is still working (${model})`
-    : `${label} is still working`;
-}
-
-function hangWarnMessage(tab: Tab): string {
-  const cwd = shortPath(tab.cwd);
-  const bits = ["This session has been running longer than expected."];
-  if (cwd) bits.push(`Working directory: ${cwd}.`);
-  if (tab.queueCount > 0) {
-    bits.push(
-      `${tab.queueCount} queued message${tab.queueCount === 1 ? "" : "s"} waiting.`,
-    );
-  }
-  return bits.join(" ");
-}
+import { armHangWarn } from "./hangWarn";
 
 /** Bridge tells us a prompt has begun. Sent for handler-driven
  *  ctx.pi.prompt AND every queue-drained turn (source: "queue") so Stop
@@ -90,32 +63,7 @@ export const handlePromptStarted: BridgeMessageHandler = (data, ctx) => {
   if (ctx.stateRef.current.activeTabId === tabId) {
     ctx.setState((prev) => ({ ...prev, status: "thinking…" }));
   }
-  // Start hang-warn timer. Reset if a queue-drained prompt_started fires
-  // for the same tab (the 30s clock restarts on each new turn).
-  {
-    const prev = ctx.hangWarnTimersRef.current.get(tabId);
-    if (prev !== undefined) clearTimeout(prev);
-    const handle = setTimeout(() => {
-      ctx.hangWarnTimersRef.current.delete(tabId);
-      const cur = ctx.stateRef.current;
-      if ((cur.activeTabId as string | undefined) !== tabId) return;
-      const tabs = (cur.tabs as Tab[] | undefined) ?? [];
-      const tab = tabs.find((t) => t.id === tabId);
-      if (!tab?.waiting) return;
-      ctx.hangWarnActiveRef.current.add(tabId);
-      ctx.pushNotification({
-        id: ctx.hangWarnNotifId(tabId),
-        title: hangWarnTitle(tab),
-        message: hangWarnMessage(tab),
-        kind: "warning",
-        durationMs: null,
-        actions: [
-          { label: "Open session", action: `activate-tab:${tabId}` },
-          { label: "Stop", action: `hang-warn:stop:${tabId}` },
-          { label: "Force restart", action: "hang-warn:force-restart" },
-        ],
-      });
-    }, ctx.hangWarnMs);
-    ctx.hangWarnTimersRef.current.set(tabId, handle);
-  }
+  // Start the silence watchdog. Progress events refresh this timer, so the
+  // warning means "no agent activity lately" rather than "long healthy turn".
+  armHangWarn(ctx, tabId);
 };

--- a/src/hooks/bridgeMessageHandlers/response.ts
+++ b/src/hooks/bridgeMessageHandlers/response.ts
@@ -1,4 +1,5 @@
 import { closeRunningToolCards } from "../../utils/agentBusy";
+import { clearHangWarn } from "./hangWarn";
 import type { BridgeMessageHandler } from "./types";
 
 /** Legacy single-shot response (kept so old bridge builds still render). */
@@ -30,5 +31,6 @@ export const handleResponse: BridgeMessageHandler = (data, ctx) => {
       delete next[tabId];
       return { ...prev, agentRunningTabs: next };
     });
+    clearHangWarn(ctx, tabId);
   }
 };

--- a/src/hooks/bridgeMessageHandlers/responseEnd.ts
+++ b/src/hooks/bridgeMessageHandlers/responseEnd.ts
@@ -2,6 +2,7 @@ import { closeRunningToolCards } from "../../utils/agentBusy";
 import { emitAgentTurnComplete } from "../../utils/agentTurnEvents";
 import { lastAgentText } from "../../utils/messages";
 import type { BridgeMessageHandler } from "./types";
+import { clearHangWarn } from "./hangWarn";
 import { flushResponseDeltas } from "./responseDelta";
 
 export const handleResponseEnd: BridgeMessageHandler = (data, ctx) => {
@@ -66,16 +67,7 @@ export const handleResponseEnd: BridgeMessageHandler = (data, ctx) => {
   // Clear the hang-warn timer and dismiss this tab's notification (if it
   // appeared). Per-tab id so an unrelated tab's response_end doesn't
   // dismiss a still-hung tab's warning.
-  {
-    const h = ctx.hangWarnTimersRef.current.get(tabId);
-    if (h !== undefined) {
-      clearTimeout(h);
-      ctx.hangWarnTimersRef.current.delete(tabId);
-    }
-    if (ctx.hangWarnActiveRef.current.delete(tabId)) {
-      ctx.dismissNotification(ctx.hangWarnNotifId(tabId));
-    }
-  }
+  clearHangWarn(ctx, tabId);
   // Fire native OS notification when an agent turn completes while the
   // window is unfocused (or the originating tab isn't active). Only for
   // "real" turns (≥ notifyMinDurationSeconds) and only if the user hasn't

--- a/src/hooks/useBridgeMessages.test.ts
+++ b/src/hooks/useBridgeMessages.test.ts
@@ -3,6 +3,7 @@ import {
   bridgeDispatchDecision,
   createBridgePayloadPump,
 } from "./useBridgeMessages";
+import { bridgeMessageRefreshesHangWarn } from "./bridgeMessageHandlers/hangWarn";
 
 const activeTabs = () => new Set(["tab-active", "tab-two"]);
 
@@ -115,5 +116,41 @@ describe("createBridgePayloadPump", () => {
     vi.runOnlyPendingTimers();
 
     expect(processed).toEqual([]);
+  });
+});
+
+describe("bridgeMessageRefreshesHangWarn", () => {
+  test("treats visible agent progress as watchdog activity", () => {
+    expect(
+      bridgeMessageRefreshesHangWarn({
+        type: "response_delta",
+        content: "working",
+      }),
+    ).toBe(true);
+    expect(
+      bridgeMessageRefreshesHangWarn({
+        type: "terminal_output",
+        content: "stdout",
+      }),
+    ).toBe(true);
+    expect(bridgeMessageRefreshesHangWarn({ type: "a2ui" })).toBe(true);
+    expect(bridgeMessageRefreshesHangWarn({ type: "subagent_progress" })).toBe(
+      true,
+    );
+  });
+
+  test("ignores lifecycle and empty progress messages", () => {
+    expect(bridgeMessageRefreshesHangWarn({ type: "prompt_started" })).toBe(
+      false,
+    );
+    expect(bridgeMessageRefreshesHangWarn({ type: "response_end" })).toBe(
+      false,
+    );
+    expect(
+      bridgeMessageRefreshesHangWarn({
+        type: "response_delta",
+        content: "",
+      }),
+    ).toBe(false);
   });
 });

--- a/src/hooks/useBridgeMessages.test.ts
+++ b/src/hooks/useBridgeMessages.test.ts
@@ -137,6 +137,12 @@ describe("bridgeMessageRefreshesHangWarn", () => {
     expect(bridgeMessageRefreshesHangWarn({ type: "subagent_progress" })).toBe(
       true,
     );
+    expect(
+      bridgeMessageRefreshesHangWarn({
+        type: "notice",
+        message: "compaction complete",
+      }),
+    ).toBe(true);
   });
 
   test("ignores lifecycle and empty progress messages", () => {

--- a/src/hooks/useBridgeMessages.ts
+++ b/src/hooks/useBridgeMessages.ts
@@ -7,6 +7,7 @@ import {
   type BridgeMessage,
   type BridgeMessageContext,
 } from "./bridgeMessageHandlers";
+import { refreshHangWarnForBridgeMessage } from "./bridgeMessageHandlers/hangWarn";
 
 export interface UseBridgeMessagesOptions {
   /** Everything handlers close over. The hook layers `ackMutation`,
@@ -260,6 +261,7 @@ export function useBridgeMessages(
           hangWarnMs: opts.hangWarnMs ?? DEFAULT_HANG_WARN_MS,
           bootLayout: opts.bootLayout,
         };
+        refreshHangWarnForBridgeMessage(data, fullCtx);
         handler(data, fullCtx);
       } catch {
         // Non-JSON line from the bridge — ignore.


### PR DESCRIPTION
## Summary
- change the session hang warning from elapsed-time-based to activity/silence-based
- refresh the watchdog on visible agent progress such as streamed text, terminal output, A2UI tool cards, subagent progress, and busy notices
- centralize watchdog arm/refresh/clear behavior and clear it across normal, legacy, and error completion paths

## Root Cause
The frontend hang warning was armed on `prompt_started` and fired after the timeout even when a long-running turn was actively producing output. That made healthy sessions look stuck.

## Validation
- `bunx vitest run src/hooks/bridgeMessageHandlers/promptStarted.test.ts src/hooks/bridgeMessageHandlers/responseEnd.test.ts src/hooks/bridgeMessageHandlers/error.test.ts src/hooks/bridgeMessageHandlers/response.test.ts src/hooks/bridgeMessageHandlers/a2ui.test.ts src/hooks/useBridgeMessages.test.ts`
- `bun run typecheck`
- `bun run lint`