### PR TITLE
fix: show host workspace agent activity

### DIFF
--- a/src/hooks/projectOps/agentActivity.test.ts
+++ b/src/hooks/projectOps/agentActivity.test.ts
@@ -85,14 +85,14 @@ describe("attachAgentActivity", () => {
     })),
   });
 
-  it("scopes main-path tabs to the project line, leaving the main workspace dot-free", () => {
+  it("scopes main-path tabs to both the project line and main workspace row", () => {
     const projects = [project([{ id: "wt-main", path: "/p", isMain: true }])];
     const tabs = [agentTab("a", "proj", "/p")];
     const [out] = attachAgentActivity(projects, tabs, new Set(["a"]));
     expect(out.agent.status).toBe("running");
     expect(out.agentRollup.status).toBe("running");
-    // Main workspace row carries no agent summary (no double dot).
-    expect("agent" in out.workspaces[0]).toBe(false);
+    expect(out.workspaces[0].agent?.status).toBe("running");
+    expect(out.workspaces[0].agent?.runningCount).toBe(1);
   });
 
   it("scopes workspace-path tabs to that workspace row", () => {

--- a/src/hooks/projectOps/agentActivity.ts
+++ b/src/hooks/projectOps/agentActivity.ts
@@ -72,7 +72,7 @@ interface ProjectLike {
 }
 
 /** A sidebar project item with agent-activity overlaid. The workspace shape is
- *  preserved apart from an optional `agent` summary added on non-main rows. */
+ *  preserved apart from an optional `agent` summary added on workspace rows. */
 export type WithAgentActivity<P extends ProjectLike> = Omit<P, "workspaces"> & {
   agent: AgentActivitySummary;
   agentRollup: AgentActivitySummary;
@@ -85,11 +85,12 @@ export type WithAgentActivity<P extends ProjectLike> = Omit<P, "workspaces"> & {
  *
  *  Scoping rules:
  *   - A non-main workspace row gets the agent tabs whose cwd matches its path.
+ *   - A main workspace row gets the agent tabs for the project's host path,
+ *     matching non-main workspace rows so expanded host sessions show the
+ *     same activity indicator as worktree sessions.
  *   - The project line gets its "main scope" tabs: agent tabs with this
  *     `projectId` whose cwd is NOT one of the project's non-main workspaces
- *     (so a main-workspace session surfaces on the project line and the main
- *     workspace row stays dot-free — they share a path and would otherwise
- *     double up).
+ *     (so a main-workspace session still surfaces on the project line).
  *   - `agentRollup` summarises main ∪ every workspace, used when the project
  *     row is collapsed so a hidden active workspace still shows a dot.
  *
@@ -130,9 +131,6 @@ export function attachAgentActivity<P extends ProjectLike>(
     }
 
     const nextWorkspaces = workspaces.map((w) => {
-      // Main workspace shares the project path — its activity is already
-      // surfaced on the project line, so leave its row dot-free.
-      if (w.isMain) return w;
       const wtTabs = tabsByCwd.get(normalizeSessionPath(w.path)) ?? [];
       return {
         ...w,

--- a/src/hooks/useDerivedRenderState.test.ts
+++ b/src/hooks/useDerivedRenderState.test.ts
@@ -261,8 +261,8 @@ describe("useDerivedRenderState", () => {
         state: {
           tabs: [mainTab],
           activeTabId: "m",
-          // bucket-independent running set: the backgrounded workspace turn.
-          agentRunningTabs: { w: true },
+          // bucket-independent running set: host + background workspace turns.
+          agentRunningTabs: { m: true, w: true },
           persistedTabBuckets: {
             "p1::workspace::wt-1": { tabs: [bgTab], activeTabId: "w" },
           },
@@ -288,21 +288,25 @@ describe("useDerivedRenderState", () => {
         projects: {
           agent: { status: string };
           agentRollup: { status: string };
-          workspaces: { id: string; agent?: { status: string } }[];
+          workspaces: {
+            id: string;
+            agent?: { status: string; runningCount: number };
+          }[];
         }[];
       }
     ).projects;
-    // Main scope has an idle session (mainTab is not running).
-    expect(projects[0].agent.status).toBe("idle-with-session");
+    // Main scope sees the host workspace turn.
+    expect(projects[0].agent.status).toBe("running");
     // The workspace row reports "running" even though its tab is stashed —
     // liveness comes from the running set, not the bucket's stale waiting.
     const wt1 = projects[0].workspaces.find((w) => w.id === "wt-1");
     expect(wt1?.agent?.status).toBe("running");
     // Rollup is running (a workspace turn is in flight).
     expect(projects[0].agentRollup.status).toBe("running");
-    // The main workspace row stays dot-free (activity shown on project line).
+    // The main workspace row mirrors host-session activity, matching worktree rows.
     const wtMain = projects[0].workspaces.find((w) => w.id === "wt-main");
-    expect(wtMain && "agent" in wtMain).toBe(false);
+    expect(wtMain?.agent?.status).toBe("running");
+    expect(wtMain?.agent?.runningCount).toBe(1);
   });
 
   it("overlays completed background agent attention across stashed buckets", () => {


### PR DESCRIPTION
## Summary
- show the same running-agent activity summary on main/host workspace rows as non-main workspace rows
- keep the project-level main-scope and collapsed rollup summaries intact
- update activity helper and render-state regressions for host workspace sessions

## Validation
- bunx vitest run src/hooks/projectOps/agentActivity.test.ts src/hooks/useDerivedRenderState.test.ts
- bun run typecheck
- bun run lint
- bunx vitest run

## Notes
Full Vitest passed with existing jsdom canvas/document warning output from unrelated tests.