### PR TITLE
fix: render host workspace activity row

### DIFF
--- a/src/extensions/default-layout/sidebar/index.test.tsx
+++ b/src/extensions/default-layout/sidebar/index.test.tsx
@@ -334,6 +334,53 @@ describe("Sidebar extension controls", () => {
 });
 
 describe("Sidebar project menu", () => {
+  it("renders host workspace agent activity on the expanded main workspace row", () => {
+    renderSidebar({
+      props: {
+        sections: [
+          {
+            id: "projects",
+            title: "projects",
+            items: [
+              {
+                id: "project-1",
+                label: "aethon",
+                expanded: true,
+                workspaces: [
+                  {
+                    id: "main",
+                    label: "main",
+                    branch: "main",
+                    path: "/repo",
+                    active: false,
+                    isMain: true,
+                    agent: {
+                      status: "running",
+                      activeCount: 1,
+                      runningCount: 1,
+                    },
+                  },
+                  {
+                    id: "wt-1",
+                    label: "feature-x",
+                    branch: "feature-x",
+                    path: "/repo-feature-x",
+                    active: false,
+                    isMain: false,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    expect(screen.getByText("main").closest(".ae-workspace-row")).toBeTruthy();
+    const dot = screen.getByLabelText("Agent running");
+    expect(dot.closest(".ae-workspace-row")?.textContent).toContain("main");
+  });
+
   it("starts inline workspace rename from the context menu without prompt", () => {
     vi.useFakeTimers();
     const prompt = vi.spyOn(window, "prompt").mockReturnValue("prompt label");

--- a/src/extensions/default-layout/sidebar/index.tsx
+++ b/src/extensions/default-layout/sidebar/index.tsx
@@ -567,9 +567,7 @@ function SidebarSectionBlock({
             // "no extra workspaces" and the chevron is meaningless.
             // Surface the chevron only when workspaces.length > 1.
             const hasExtraWorkspaces = !!workspaces && workspaces.length > 1;
-            const extraWorkspaces = hasExtraWorkspaces
-              ? workspaces.filter((w) => !w.isMain)
-              : [];
+            const visibleWorkspaces = hasExtraWorkspaces ? workspaces : [];
             return (
               <Fragment key={item.id}>
                 <ItemRow
@@ -617,7 +615,7 @@ function SidebarSectionBlock({
                   trailingControl={trailingControl}
                 />
                 {hasExtraWorkspaces && expanded
-                  ? extraWorkspaces.map((wt) => (
+                  ? visibleWorkspaces.map((wt) => (
                       <WorkspaceRow
                         key={wt.id}
                         item={wt}

--- a/src/extensions/default-layout/sidebar/workspace-row.tsx
+++ b/src/extensions/default-layout/sidebar/workspace-row.tsx
@@ -56,9 +56,7 @@ export interface WorkspaceSidebarItem {
   pendingState?: "queued" | "starting" | "removing" | "succeeded" | "failed";
   pendingError?: string;
   locked?: boolean;
-  /** Live agent-activity for this workspace's session scope. Only attached
-   *  to non-main rows (the main workspace shares the project path, so its
-   *  activity surfaces on the project line instead). */
+  /** Live agent-activity for this workspace's session scope. */
   agent?: AgentActivitySummary;
 }
 


### PR DESCRIPTION
## Summary
- render the main/host workspace row when an expanded project has additional workspaces
- let the host workspace consume the agent activity summary added in PR #333
- update the workspace-row activity comment and add a Sidebar-level regression for the rendered host row

## Root Cause
PR #333 attached agent activity to main workspace records, but the expanded project renderer still filtered main workspaces out with `workspaces.filter((w) => !w.isMain)`. The host row never mounted, so its activity dot could not render.

## UAT
- Flow: localhost sidebar fixture -> expanded host group/project -> main workspace with `agent.status = running` -> visible main row has `Agent running` dot
- Browser: in-app browser against Vite at `http://127.0.0.1:1420/uat-host-workspace.html` using a temporary uncommitted fixture, then removed
- Evidence: DOM showed `.ae-workspace-row--main` text `main`, `aria-label="Agent running"`, title `1 agent turn running`; screenshot showed green dot on the host/main row

## Validation
- bunx vitest run src/extensions/default-layout/sidebar/index.test.tsx -t "host workspace agent activity" (failed before fix, passed after)
- bunx vitest run src/extensions/default-layout/sidebar/index.test.tsx src/extensions/default-layout/sidebar/workspace-row.test.tsx src/hooks/projectOps/agentActivity.test.ts src/hooks/useDerivedRenderState.test.ts
- bun run typecheck
- bun run lint
- bunx vitest run

## Notes
Full Vitest passed with existing jsdom/canvas warning output unrelated to this change.