### PR TITLE
Add release-safe Aethon control CLI transport

### DIFF
--- a/agent/auth-profiles/manager.test.ts
+++ b/agent/auth-profiles/manager.test.ts
@@ -55,6 +55,43 @@ function makeState(userDir = tempUserDir()): AethonAgentState {
   } as unknown as AethonAgentState;
 }
 
+/**
+ * Augment a bare {@link makeState} with the empty extension collections that
+ * the `ready` handshake (`emitGlobalReady` → `emitReady`) serializes, so a
+ * handler that ends by emitting `ready` can run without a half-built state.
+ * Kept out of `makeState` so tests that deliberately rely on a minimal state
+ * (e.g. forcing a session-refresh failure) are unaffected.
+ */
+function withReadyState(state: AethonAgentState): AethonAgentState {
+  Object.assign(state as unknown as Record<string, unknown>, {
+    tabProjectCwds: new Map(),
+    cachedModels: [],
+    extensionComponents: new Map(),
+    extensionStateTree: {},
+    extensionStateKeys: new Set(),
+    perTabExtState: new Map(),
+    extensionLayout: null,
+    pendingLayoutPatches: [],
+    extensionThemes: new Map(),
+    extensionSlashCommands: new Map(),
+    piSlashCommands: [],
+    piSkills: [],
+    extensionKeybindings: new Map(),
+    extensionMenuItems: new Map(),
+    extensionEventRoutes: new Map(),
+    extensionLayouts: new Map(),
+    extensionFrontendModules: new Map(),
+    extensionHighlightGrammars: new Map(),
+    loadedExtensions: new Map(),
+    projectExtensionRoots: new Map(),
+    loadFailures: new Map(),
+    disabledExtensions: new Set(),
+    disabledExtensionMeta: new Map(),
+    discoveredTabs: [],
+  });
+  return state;
+}
+
 function fakeTab(model: string, promptInFlight = false): TabRecord {
   const [provider, ...rest] = model.split("/");
   return {
@@ -267,6 +304,41 @@ describe("auth profile manager", () => {
         message: expect.stringContaining(
           "auth_profile_api_key_save: refresh session:",
         ),
+      }),
+    );
+    expect(sent).toContainEqual(
+      expect.objectContaining({ type: "auth_profiles" }),
+    );
+  });
+
+  it("auth_profile_use_for_tab records a worker tab without rebuilding the global session", async () => {
+    const userDir = tempUserDir();
+    const state = withReadyState(makeState(userDir));
+    const profileId = addProfile(state, "openai-codex", "Codex Two");
+    saveAuthProfilesState(userDir, state.authProfiles);
+    const sent: Record<string, unknown>[] = [];
+    const deps = {
+      send: (m: Record<string, unknown>) => sent.push(m),
+    } as DispatcherDeps;
+
+    await handleAuthProfileMessage(state, deps, {
+      type: "auth_profile_use_for_tab",
+      tabId: "tab-worker",
+      profileId,
+    });
+
+    // The mapping is recorded and surfaced, but the global bridge must NOT
+    // spawn a session for the worker-owned tab (that blocks on a devshell
+    // prepare it can't satisfy) and must NOT emit a model override (which would
+    // silently reset the tab's model). The worker's apply owns the session.
+    expect(state.tabAuthProfileIds.get("tab-worker")).toBe(profileId);
+    expect(state.tabs.has("tab-worker")).toBe(false);
+    expect(sent).toContainEqual(
+      expect.objectContaining({
+        type: "auth_profile_changed",
+        tabId: "tab-worker",
+        profileId,
+        model: "",
       }),
     );
     expect(sent).toContainEqual(

--- a/agent/auth-profiles/manager.ts
+++ b/agent/auth-profiles/manager.ts
@@ -746,27 +746,51 @@ async function handleUseForTab(
     });
     return;
   }
-  const previousModel = existing?.session.model;
-  const cwd = state.tabProjectCwds.get(tabId);
-  if (existing) clearPendingContextUsageEmit(existing);
-  state.tabs.delete(tabId);
   state.tabAuthProfileIds.set(tabId, profile.id);
-  const services = servicesForProfile(state, profile.id, { forceRefresh: true });
-  const nextModel =
-    previousModel &&
-    services.modelRegistry.find(previousModel.provider, previousModel.id);
-  const rec = await ensureTab(state, deps, tabId, {
-    cwdOverride: cwd,
-    initialModel: nextModel || previousModel,
-  });
   markProfileUsed(state, profile.id);
+
+  // The global bridge owns ONLY the default tab's session. Every non-default
+  // tab runs its prompts in a per-tab worker bridge that rebuilds its own
+  // session against the new account via `auth_profile_apply` (which this same
+  // switch relays tab-scoped). Recreating the session here for a worker tab
+  // would (a) spawn a spurious duplicate session on the global bridge, (b)
+  // block the global message loop on an `ensureDevshellPrepared` for a cwd the
+  // global bridge doesn't own — frequently timing out — which makes the whole
+  // account switch appear to hang, and (c) emit the duplicate session's model
+  // back as `auth_profile_changed.model`, silently resetting the tab's model.
+  // So only rebuild the session for the default tab; for worker tabs just
+  // record the mapping and let the worker's apply handle the session.
+  let changedModel = "";
+  if (tabId === "default") {
+    const previousModel = existing?.session.model;
+    const cwd = state.tabProjectCwds.get(tabId);
+    if (existing) clearPendingContextUsageEmit(existing);
+    state.tabs.delete(tabId);
+    const services = servicesForProfile(state, profile.id, {
+      forceRefresh: true,
+    });
+    const nextModel =
+      previousModel &&
+      services.modelRegistry.find(previousModel.provider, previousModel.id);
+    const rec = await ensureTab(state, deps, tabId, {
+      cwdOverride: cwd,
+      initialModel: nextModel || previousModel,
+    });
+    changedModel = rec.session.model
+      ? `${rec.session.model.provider}/${rec.session.model.id}`
+      : "";
+  } else {
+    // Warm the profile's services so a later global read (usage fetch, model
+    // registry) sees the freshly-selected creds — without touching the tab's
+    // session or model (the worker owns those).
+    servicesForProfile(state, profile.id, { forceRefresh: true });
+  }
+
   deps.send({
     type: "auth_profile_changed",
     tabId,
     profileId: profile.id,
-    model: rec.session.model
-      ? `${rec.session.model.provider}/${rec.session.model.id}`
-      : "",
+    model: changedModel,
   });
   emitAuthProfiles(state, deps);
   await emitGlobalReady(state, deps);

--- a/agent/chat.ts
+++ b/agent/chat.ts
@@ -35,10 +35,14 @@ export async function handleChat(
   msg: InboundMessage,
 ): Promise<void> {
   const tabId = msg.tabId ?? "default";
+  const controlRequestId =
+    typeof msg.controlRequestId === "string" && msg.controlRequestId.length > 0
+      ? msg.controlRequestId
+      : undefined;
   const scheduledRun = scheduledRunFromMessage(msg);
   if (!msg.content) {
     completeScheduledRun(deps, tabId, scheduledRun, false, "chat: missing content");
-    deps.send({ type: "error", message: "chat: missing content" });
+    deps.send({ type: "error", message: "chat: missing content", controlRequestId });
     return;
   }
   chatLog.info(`received tabId=${tabId} chars=${msg.content.length}`);
@@ -156,6 +160,7 @@ export async function handleChat(
       type: "error",
       tabId,
       message: `file references: ${message}`,
+      ...(controlRequestId ? { controlRequestId } : {}),
     });
     completeScheduledRun(deps, tabId, scheduledRun, false, message);
     if (scheduledRun) tab.scheduledRun = undefined;
@@ -177,7 +182,12 @@ export async function handleChat(
       )
       .catch((err: unknown) => {
         const message = err instanceof Error ? err.message : String(err);
-        deps.send({ type: "error", tabId, message: `steer: ${message}` });
+        deps.send({
+          type: "error",
+          tabId,
+          message: `steer: ${message}`,
+          ...(controlRequestId ? { controlRequestId } : {}),
+        });
         completeScheduledRun(deps, tabId, scheduledRun, false, message);
         if (scheduledRun) tab.scheduledRun = undefined;
       });
@@ -200,7 +210,12 @@ export async function handleChat(
           tabId,
           queued: tab.queuedCount,
         });
-        deps.send({ type: "error", tabId, message: `followUp: ${message}` });
+        deps.send({
+          type: "error",
+          tabId,
+          message: `followUp: ${message}`,
+          ...(controlRequestId ? { controlRequestId } : {}),
+        });
         completeScheduledRun(deps, tabId, scheduledRun, false, message);
         if (scheduledRun) tab.scheduledRun = undefined;
       });
@@ -217,7 +232,12 @@ export async function handleChat(
   // it a normal prompt only shows "running" for the active workspace (which
   // infers it from the optimistic `waiting` flag). `source: "chat"` keeps the
   // handler from running its queue-promotion branch.
-  deps.send({ type: "prompt_started", tabId, source: "chat" });
+  deps.send({
+    type: "prompt_started",
+    tabId,
+    source: "chat",
+    ...(controlRequestId ? { controlRequestId } : {}),
+  });
   state.tabContext
     .run(tabId, () =>
       images.length > 0
@@ -226,7 +246,12 @@ export async function handleChat(
     )
     .catch((err: unknown) => {
       const message = err instanceof Error ? err.message : String(err);
-      deps.send({ type: "error", tabId, message: `prompt: ${message}` });
+      deps.send({
+        type: "error",
+        tabId,
+        message: `prompt: ${message}`,
+        ...(controlRequestId ? { controlRequestId } : {}),
+      });
       completeScheduledRun(deps, tabId, scheduledRun, false, message);
       if (scheduledRun) tab.scheduledRun = undefined;
     })
@@ -234,7 +259,11 @@ export async function handleChat(
       const stillStreamingOrRetrying = isUnderlyingSessionBusy(tab);
       if (!tab.agentEndFired && !stillStreamingOrRetrying) {
         tab.promptInFlight = false;
-        deps.send({ type: "response_end", tabId });
+        deps.send({
+          type: "response_end",
+          tabId,
+          ...(controlRequestId ? { controlRequestId } : {}),
+        });
         completeScheduledRun(deps, tabId, tab.scheduledRun, true);
         tab.scheduledRun = undefined;
       }

--- a/agent/dispatcherTypes.ts
+++ b/agent/dispatcherTypes.ts
@@ -42,6 +42,8 @@ export interface InboundMessage {
   hardEnforce?: boolean;
   /** Per-tab plan-mode toggle, carried on `chat`. */
   planMode?: boolean;
+  /** Opaque id supplied by release-control clients for turn-specific waits. */
+  controlRequestId?: string;
   /** Native scheduled-task metadata carried on scheduler-fired chat turns. */
   scheduledTaskId?: string;
   scheduledRunId?: string;

--- a/cli/aethonControl.test.ts
+++ b/cli/aethonControl.test.ts
@@ -1,6 +1,7 @@
-import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { createServer, type Server, type Socket } from "node:net";
 import { describe, expect, it } from "vitest";
 import {
   activeTargetFromState,
@@ -11,6 +12,7 @@ import {
   planSkillInstall,
 } from "./aethonControl.ts";
 import { resolveDebugPort } from "./debugClient.ts";
+import { AethonControlClient, readControlInfo } from "./controlClient.ts";
 
 describe("aethonctl helpers", () => {
   it("builds the same two-step account switch used by the UI for tab workers", () => {
@@ -116,5 +118,48 @@ describe("aethonctl helpers", () => {
     mkdirSync(join(home, ".aethon"));
     writeFileSync(join(home, ".aethon", "dev-info.json"), JSON.stringify({ debugPort: 20123 }));
     expect(resolveDebugPort({ home, env: {} })).toBe(20123);
+  });
+
+  it("reads release control info and sends token-authenticated socket requests", async () => {
+    const root = mkdtempSync(join(tmpdir(), "aethon-control-"));
+    const controlDir = join(root, ".aethon", "control");
+    mkdirSync(controlDir, { recursive: true });
+    const socketPath = join(controlDir, "control.sock");
+    const tokenPath = join(controlDir, "token");
+    writeFileSync(tokenPath, "test-token");
+    writeFileSync(
+      join(controlDir, "control.json"),
+      JSON.stringify({
+        protocolVersion: 1,
+        mode: "local",
+        socketPath,
+        tokenPath,
+        pid: 123,
+        version: "0.0.0-test",
+        instanceId: "instance",
+      }),
+    );
+    rmSync(socketPath, { force: true });
+    const server: Server = createServer((socket: Socket) => {
+      let body = "";
+      socket.on("data", (chunk) => {
+        body += chunk.toString("utf8");
+        if (!body.includes("\n")) return;
+        const request = JSON.parse(body) as { token: string; method: string };
+        socket.end(JSON.stringify({ ok: true, result: request }) + "\n");
+      });
+    });
+    await new Promise<void>((resolve) => server.listen(socketPath, resolve));
+    try {
+      expect(readControlInfo({ home: root })?.socketPath).toBe(socketPath);
+      const client = new AethonControlClient({ home: root });
+      await expect(client.request("status")).resolves.toEqual({
+        token: "test-token",
+        method: "status",
+        params: {},
+      });
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
   });
 });

--- a/cli/aethonControl.test.ts
+++ b/cli/aethonControl.test.ts
@@ -1,0 +1,120 @@
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  activeTargetFromState,
+  buildAccountSwitchPayloads,
+  installSkill,
+  jsonPointerGet,
+  normalizeTabs,
+  planSkillInstall,
+} from "./aethonControl.ts";
+import { resolveDebugPort } from "./debugClient.ts";
+
+describe("aethonctl helpers", () => {
+  it("builds the same two-step account switch used by the UI for tab workers", () => {
+    expect(
+      buildAccountSwitchPayloads("openai-codex-secondary", {
+        tabId: "tab-worker",
+        cwd: "/repo",
+        model: "openai-codex/gpt-5.5",
+      }),
+    ).toEqual([
+      {
+        type: "auth_profile_use_for_tab",
+        tabId: "tab-worker",
+        profileId: "openai-codex-secondary",
+      },
+      {
+        type: "auth_profile_apply",
+        tabId: "tab-worker",
+        profileId: "openai-codex-secondary",
+        cwd: "/repo",
+        model: "openai-codex/gpt-5.5",
+      },
+    ]);
+  });
+
+  it("keeps default account switches on the global bridge", () => {
+    expect(buildAccountSwitchPayloads("primary", { tabId: "default" })).toEqual([
+      {
+        type: "auth_profile_use_for_tab",
+        tabId: "default",
+        profileId: "primary",
+      },
+    ]);
+  });
+
+  it("resolves active tabs from object-shaped app state", () => {
+    const target = activeTargetFromState(
+      {
+        activeTabId: "t1",
+        tabs: {
+          t1: {
+            id: "t1",
+            kind: "agent",
+            cwd: "/repo",
+            model: "openai-codex/gpt-5.5",
+          },
+        },
+      },
+      "active",
+    );
+
+    expect(target).toEqual({
+      tabId: "t1",
+      cwd: "/repo",
+      model: "openai-codex/gpt-5.5",
+    });
+  });
+
+  it("falls back to default when the active surface is not an agent tab", () => {
+    expect(
+      activeTargetFromState(
+        { activeTabId: "shell", tabs: { shell: { id: "shell", kind: "shell" } } },
+        "active",
+      ),
+    ).toEqual({ tabId: "default" });
+  });
+
+  it("keeps explicit tab ids even when the frontend snapshot is stale", () => {
+    expect(activeTargetFromState({ activeTabId: "other", tabs: [] }, "new-tab")).toEqual({
+      tabId: "new-tab",
+    });
+  });
+
+  it("reads JSON Pointer state paths", () => {
+    expect(jsonPointerGet({ a: { "b/c": ["zero", "one"] } }, "/a/b~1c/1")).toBe("one");
+  });
+
+  it("normalizes object and array tab containers", () => {
+    expect(normalizeTabs({ a: { id: "a" } })).toEqual([{ id: "a" }]);
+    expect(normalizeTabs([{ id: "b", label: "Bee" }])).toEqual([{ id: "b", label: "Bee" }]);
+  });
+
+  it("plans project skill installs using claude plus generic agents targets", () => {
+    const root = mkdtempSync(join(tmpdir(), "aethon-skill-"));
+    const plan = planSkillInstall({ project: true, dir: root });
+    expect(plan.paths).toEqual([
+      join(root, ".claude", "skills", "aethon-control", "SKILL.md"),
+      join(root, ".agents", "skills", "aethon-control", "SKILL.md"),
+    ]);
+  });
+
+  it("writes skill files with account guidance", () => {
+    const root = mkdtempSync(join(tmpdir(), "aethon-skill-"));
+    const plan = planSkillInstall({ targets: ["codex"], project: true, dir: root });
+    const [path] = installSkill(plan, true);
+    const body = readFileSync(path, "utf8");
+    expect(body).toContain("accounts use <profile-id>");
+    expect(body).toContain("--account <profile-id>");
+  });
+
+  it("resolves debug port from the conventional dev-info file", () => {
+    const home = mkdtempSync(join(tmpdir(), "aethon-home-"));
+    mkdirSync(join(home, ".aethon"));
+    writeFileSync(join(home, ".aethon", "dev-info.json"), JSON.stringify({ debugPort: 20123 }));
+    expect(resolveDebugPort({ home, env: {} })).toBe(20123);
+  });
+});

--- a/cli/aethonControl.ts
+++ b/cli/aethonControl.ts
@@ -89,14 +89,14 @@ export function buildAccountSwitchPayloads(
 export function skillMarkdown(commandName = "aethonctl"): string {
   return `---
 name: aethon-control
-description: Control a running Aethon dev application from the command line. Inspect state, dispatch agent prompts, switch configured accounts, and install this skill.
+description: Control a running Aethon application from the command line. Inspect state, dispatch agent prompts, switch configured accounts, and install this skill.
 when_to_use: Use when you need to drive or inspect Aethon from an agent session without manual UI interaction.
 allowed-tools: Bash
 ---
 
 # Aethon Control
 
-Use \`${commandName}\` to control the running Aethon dev app over its local debug bridge.
+Use \`${commandName}\` to control the running Aethon app over its local authenticated control socket.
 
 Core commands:
 
@@ -107,14 +107,12 @@ ${commandName} models
 ${commandName} accounts list
 ${commandName} accounts use <profile-id> --tab active
 ${commandName} chat send "implement the next step" --account <profile-id> --wait
-${commandName} agent command '{"type":"stop","tabId":"active"}'
-${commandName} state /authProfiles --json
-${commandName} invoke agent_diagnostics '{}'
+${commandName} agent stop --tab active
 \`\`\`
 
 Account rule: when dispatching to Codex-backed models, choose the intended configured account explicitly with \`--account <profile-id>\` or run \`accounts use\` first. The CLI applies the same global plus tab-worker account switch payloads as the Aethon UI.
 
-The app must be running as a dev build. The CLI reads \`~/.aethon/dev-info.json\` for the debug port, or use \`AETHON_DEBUG_PORT\` / \`--port\`.
+Release builds are supported. The CLI reads \`~/.aethon/control/control.json\` and authenticates with the per-launch token in \`~/.aethon/control/token\`. Debug-only commands such as \`eval\` and raw \`invoke\` require \`--transport debug\`.
 `;
 }
 

--- a/cli/aethonControl.ts
+++ b/cli/aethonControl.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { AethonDebugClient, type DebugClientOptions, invokeJs } from "./debugClient.ts";
 
@@ -185,13 +185,8 @@ function pathExists(path: string): boolean {
 
 export function installSkill(plan: SkillInstallPlan, force = false): string[] {
   for (const path of plan.paths) {
-    if (!force) {
-      try {
-        readFileSync(path, "utf8");
-        throw new Error(`${path} already exists; pass --force to overwrite`);
-      } catch (err) {
-        if (err instanceof Error && !err.message.includes("ENOENT")) throw err;
-      }
+    if (!force && existsSync(path)) {
+      throw new Error(`${path} already exists; pass --force to overwrite`);
     }
     mkdirSync(dirname(path), { recursive: true });
     writeFileSync(path, plan.content);

--- a/cli/aethonControl.ts
+++ b/cli/aethonControl.ts
@@ -1,0 +1,388 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { AethonDebugClient, type DebugClientOptions, invokeJs } from "./debugClient.ts";
+
+export type JsonRecord = Record<string, unknown>;
+
+export interface AuthProfileMeta {
+  id: string;
+  providerId: string;
+  label: string;
+  kind: "oauth" | "api_key";
+  createdAt: number;
+  updatedAt: number;
+  lastUsedAt?: number;
+}
+
+export interface TabSummary {
+  id: string;
+  label?: string;
+  kind?: string;
+  cwd?: string;
+  model?: string;
+  waiting?: boolean;
+  authProfileId?: string;
+}
+
+export interface AccountSwitchTarget {
+  tabId: string;
+  cwd?: string;
+  model?: string;
+}
+
+export function jsonPointerGet(value: unknown, pointer = ""): unknown {
+  if (!pointer || pointer === "/") return pointer === "/" ? getChild(value, "") : value;
+  if (!pointer.startsWith("/")) throw new Error(`state path must be a JSON Pointer, got ${pointer}`);
+  return pointer
+    .slice(1)
+    .split("/")
+    .reduce((current, part) => getChild(current, part.replace(/~1/g, "/").replace(/~0/g, "~")), value);
+}
+
+function getChild(value: unknown, key: string): unknown {
+  if (value == null) return undefined;
+  if (Array.isArray(value)) return value[Number(key)];
+  if (typeof value !== "object") return undefined;
+  return (value as Record<string, unknown>)[key];
+}
+
+export function normalizeTabs(value: unknown): TabSummary[] {
+  if (Array.isArray(value)) return value.filter(isObject).map(tabSummary);
+  if (isObject(value)) return Object.values(value).filter(isObject).map(tabSummary);
+  return [];
+}
+
+function tabSummary(value: JsonRecord): TabSummary {
+  return {
+    id: typeof value.id === "string" ? value.id : "",
+    label: typeof value.label === "string" ? value.label : undefined,
+    kind: typeof value.kind === "string" ? value.kind : undefined,
+    cwd: typeof value.cwd === "string" ? value.cwd : undefined,
+    model: typeof value.model === "string" ? value.model : undefined,
+    waiting: typeof value.waiting === "boolean" ? value.waiting : undefined,
+    authProfileId: typeof value.authProfileId === "string" ? value.authProfileId : undefined,
+  };
+}
+
+export function buildAccountSwitchPayloads(
+  profileId: string,
+  target: AccountSwitchTarget,
+): JsonRecord[] {
+  const base = {
+    type: "auth_profile_use_for_tab",
+    tabId: target.tabId,
+    profileId,
+  };
+  if (!target.tabId || target.tabId === "default") return [base];
+  return [
+    base,
+    {
+      type: "auth_profile_apply",
+      tabId: target.tabId,
+      profileId,
+      ...(target.cwd ? { cwd: target.cwd } : {}),
+      ...(target.model ? { model: target.model } : {}),
+    },
+  ];
+}
+
+export function skillMarkdown(commandName = "aethonctl"): string {
+  return `---
+name: aethon-control
+description: Control a running Aethon dev application from the command line. Inspect state, dispatch agent prompts, switch configured accounts, and install this skill.
+when_to_use: Use when you need to drive or inspect Aethon from an agent session without manual UI interaction.
+allowed-tools: Bash
+---
+
+# Aethon Control
+
+Use \`${commandName}\` to control the running Aethon dev app over its local debug bridge.
+
+Core commands:
+
+\`\`\`bash
+${commandName} status --json
+${commandName} tabs
+${commandName} models
+${commandName} accounts list
+${commandName} accounts use <profile-id> --tab active
+${commandName} chat send "implement the next step" --account <profile-id> --wait
+${commandName} agent command '{"type":"stop","tabId":"active"}'
+${commandName} state /authProfiles --json
+${commandName} invoke agent_diagnostics '{}'
+\`\`\`
+
+Account rule: when dispatching to Codex-backed models, choose the intended configured account explicitly with \`--account <profile-id>\` or run \`accounts use\` first. The CLI applies the same global plus tab-worker account switch payloads as the Aethon UI.
+
+The app must be running as a dev build. The CLI reads \`~/.aethon/dev-info.json\` for the debug port, or use \`AETHON_DEBUG_PORT\` / \`--port\`.
+`;
+}
+
+export const SKILL_DIR_NAME = "aethon-control";
+export type SkillTarget = "claude" | "codex" | "agents";
+
+const TARGETS: Record<SkillTarget, { user: string[]; project: string[]; detect: string[] }> = {
+  claude: { user: [".claude", "skills"], project: [".claude", "skills"], detect: [".claude"] },
+  codex: { user: [".codex", "skills"], project: [".agents", "skills"], detect: [".codex"] },
+  agents: { user: [".agents", "skills"], project: [".agents", "skills"], detect: [".agents"] },
+};
+
+export interface SkillInstallPlan {
+  targets: SkillTarget[];
+  paths: string[];
+  content: string;
+}
+
+export function planSkillInstall(options: {
+  targets?: string[];
+  project?: boolean;
+  dir?: string;
+  home?: string;
+  commandName?: string;
+}): SkillInstallPlan {
+  const project = options.project === true || Boolean(options.dir);
+  const root = resolve(options.dir ?? (project ? "." : (options.home ?? process.env.HOME ?? ".")));
+  const requested = expandSkillTargets(options.targets, project, options.home);
+  const paths = dedupe(
+    requested.map((target) =>
+      join(root, ...TARGETS[target][project ? "project" : "user"], SKILL_DIR_NAME, "SKILL.md"),
+    ),
+  );
+  return {
+    targets: requested,
+    paths,
+    content: skillMarkdown(options.commandName),
+  };
+}
+
+function expandSkillTargets(
+  targets: string[] | undefined,
+  project: boolean,
+  home = process.env.HOME,
+): SkillTarget[] {
+  if (!targets || targets.length === 0) {
+    if (project) return ["claude", "agents"];
+    const detected = (Object.keys(TARGETS) as SkillTarget[]).filter((target) => {
+      if (target === "agents") return false;
+      return pathExists(join(home ?? "", ...TARGETS[target].detect));
+    });
+    return detected.length > 0 ? detected : ["agents"];
+  }
+  const expanded: SkillTarget[] = [];
+  for (const target of targets) {
+    if (target === "all") {
+      expanded.push("claude", "codex", "agents");
+    } else if (target === "claude" || target === "codex" || target === "agents") {
+      expanded.push(target);
+    } else {
+      throw new Error(`unknown skill target: ${target}`);
+    }
+  }
+  return dedupe(expanded);
+}
+
+function pathExists(path: string): boolean {
+  return existsSync(path);
+}
+
+export function installSkill(plan: SkillInstallPlan, force = false): string[] {
+  for (const path of plan.paths) {
+    if (!force) {
+      try {
+        readFileSync(path, "utf8");
+        throw new Error(`${path} already exists; pass --force to overwrite`);
+      } catch (err) {
+        if (err instanceof Error && !err.message.includes("ENOENT")) throw err;
+      }
+    }
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, plan.content);
+  }
+  return plan.paths;
+}
+
+function dedupe<T>(values: T[]): T[] {
+  return [...new Set(values)];
+}
+
+function isObject(value: unknown): value is JsonRecord {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+export interface AethonStateSnapshot {
+  location: string;
+  state: JsonRecord;
+}
+
+export async function fetchSnapshot(client: AethonDebugClient): Promise<AethonStateSnapshot> {
+  return client.evalJson<AethonStateSnapshot>(`
+return {
+  location: window.location.href,
+  state: window.__AETHON_STATE__ ? window.__AETHON_STATE__() : {},
+};
+`);
+}
+
+export function activeTargetFromState(state: JsonRecord, requestedTab: string | undefined): AccountSwitchTarget {
+  const tabs = normalizeTabs(state.tabs);
+  const tabId = requestedTab && requestedTab !== "active"
+    ? requestedTab
+    : typeof state.activeTabId === "string"
+      ? state.activeTabId
+      : undefined;
+  const tab = tabId ? tabs.find((candidate) => candidate.id === tabId) : undefined;
+  if (!tab && requestedTab && requestedTab !== "active" && requestedTab !== "default") {
+    return { tabId: requestedTab };
+  }
+  if (!tab || tab.kind === "shell" || tab.kind === "editor") return { tabId: "default" };
+  return {
+    tabId: tab.id,
+    cwd: tab.cwd,
+    model: tab.model,
+  };
+}
+
+export async function applyAccountSwitch(
+  client: AethonDebugClient,
+  profileId: string,
+  target: AccountSwitchTarget,
+): Promise<JsonRecord[]> {
+  const payloads = buildAccountSwitchPayloads(profileId, target);
+  for (const payload of payloads) {
+    await client.invoke("agent_command", { payload: JSON.stringify(payload) });
+  }
+  return payloads;
+}
+
+export async function sendChat(
+  client: AethonDebugClient,
+  message: string,
+  options: {
+    tabId?: string;
+    cwd?: string;
+    model?: string;
+    thinkingLevel?: string;
+    account?: string;
+    planMode?: boolean;
+    mode?: string;
+  },
+): Promise<void> {
+  await client.invoke("send_message", {
+    request: {
+      message,
+      mode: options.mode ?? "normal",
+      ...(options.tabId ? { tabId: options.tabId } : {}),
+      ...(options.cwd ? { cwd: options.cwd } : {}),
+      ...(options.model ? { model: options.model } : {}),
+      ...(options.thinkingLevel ? { thinkingLevel: options.thinkingLevel } : {}),
+      ...(options.planMode !== undefined ? { planMode: options.planMode } : {}),
+      ...(options.account ? { authProfileId: options.account } : {}),
+    },
+  });
+}
+
+export async function openAgentTab(
+  client: AethonDebugClient,
+  options: {
+    tabId?: string;
+    cwd?: string;
+    label?: string;
+    model?: string;
+    account?: string;
+  } = {},
+): Promise<TabSummary> {
+  const tab = await client.evalJson<TabSummary>(`
+const invoke = window.__AETHON_INVOKE__ || window.__TAURI_INTERNALS__?.invoke;
+const s = window.__AETHON_STATE__();
+const tabId = ${JSON.stringify(options.tabId)} || crypto.randomUUID();
+const cwd = ${JSON.stringify(options.cwd)} ||
+  (Array.isArray(s.projects) ? s.projects.find((p) => p.id === s.activeProjectId)?.path : undefined) ||
+  s.projectRoot ||
+  s.aethonRoot;
+if (!cwd) throw new Error("tabs new could not resolve a cwd; pass --cwd");
+const model = ${JSON.stringify(options.model)} || s.model || s.defaultModel || "";
+const tab = {
+  id: tabId,
+  kind: "agent",
+  label: ${JSON.stringify(options.label)} || "CLI",
+  messages: [],
+  draft: "",
+  waiting: false,
+  queuedMessages: [],
+  queueCount: 0,
+  canvas: null,
+  terminalBuffer: "",
+  projectId: typeof s.activeProjectId === "string" ? s.activeProjectId : null,
+  cwd,
+  model,
+  ${options.account ? `authProfileId: ${JSON.stringify(options.account)},` : ""}
+};
+const tabs = Array.isArray(s.tabs)
+  ? [...s.tabs.filter((candidate) => candidate?.id !== tabId), tab]
+  : { ...(s.tabs || {}), [tabId]: tab };
+window.__AETHON_SET_STATE__({ ...s, tabs, activeTabId: tabId, hasTabs: true, model });
+await invoke("agent_command", {
+  payload: JSON.stringify({
+    type: "tab_open",
+    tabId,
+    cwd,
+    ...(model ? { model } : {}),
+  }),
+});
+return { id: tabId, kind: "agent", label: tab.label, cwd, model };
+`);
+  if (options.account) {
+    await applyAccountSwitch(client, options.account, {
+      tabId: tab.id,
+      cwd: tab.cwd,
+      model: tab.model,
+    });
+  }
+  return tab;
+}
+
+export async function closeAgentTab(client: AethonDebugClient, tabId: string): Promise<void> {
+  await client.eval(`
+const invoke = window.__AETHON_INVOKE__ || window.__TAURI_INTERNALS__?.invoke;
+const s = window.__AETHON_STATE__();
+const tabs = Array.isArray(s.tabs)
+  ? s.tabs.filter((candidate) => candidate?.id !== ${JSON.stringify(tabId)})
+  : Object.fromEntries(Object.entries(s.tabs || {}).filter(([id]) => id !== ${JSON.stringify(tabId)}));
+const activeTabId = s.activeTabId === ${JSON.stringify(tabId)}
+  ? (Array.isArray(tabs) ? tabs.find((tab) => tab?.kind === "agent")?.id : Object.values(tabs).find((tab) => tab?.kind === "agent")?.id)
+  : s.activeTabId;
+window.__AETHON_SET_STATE__({ ...s, tabs, activeTabId, hasTabs: Array.isArray(tabs) ? tabs.length > 0 : Object.keys(tabs).length > 0 });
+await invoke("agent_command", { payload: JSON.stringify({ type: "tab_close", tabId: ${JSON.stringify(tabId)} }) });
+return "closed";
+`);
+}
+
+export async function waitUntilIdle(
+  client: AethonDebugClient,
+  timeoutMs: number,
+): Promise<JsonRecord> {
+  return client.evalJson<JsonRecord>(`
+const deadline = Date.now() + ${JSON.stringify(timeoutMs)};
+while (Date.now() < deadline) {
+  const s = window.__AETHON_STATE__();
+  if (s.waiting !== true) {
+    return {
+      waiting: false,
+      status: s.status,
+      activeTabId: s.activeTabId,
+      messageCount: Array.isArray(s.messages) ? s.messages.length : undefined,
+    };
+  }
+  await new Promise((resolve) => setTimeout(resolve, 250));
+}
+return { waiting: true, timeoutMs: ${JSON.stringify(timeoutMs)} };
+`);
+}
+
+export function rawAgentCommandJs(payload: unknown): string {
+  return invokeJs("agent_command", { payload: JSON.stringify(payload) });
+}
+
+export function createClient(options: DebugClientOptions): AethonDebugClient {
+  return new AethonDebugClient(options);
+}

--- a/cli/aethonctl.ts
+++ b/cli/aethonctl.ts
@@ -1,0 +1,319 @@
+#!/usr/bin/env bun
+import { readFileSync } from "node:fs";
+import {
+  activeTargetFromState,
+  applyAccountSwitch,
+  createClient,
+  fetchSnapshot,
+  installSkill,
+  jsonPointerGet,
+  normalizeTabs,
+  closeAgentTab,
+  openAgentTab,
+  planSkillInstall,
+  rawAgentCommandJs,
+  sendChat,
+  skillMarkdown,
+  waitUntilIdle,
+  type JsonRecord,
+} from "./aethonControl.ts";
+
+interface CliOptions {
+  json: boolean;
+  port?: number;
+}
+
+function print(value: unknown, json = false): void {
+  if (json || typeof value !== "string") {
+    console.log(JSON.stringify(value, null, 2));
+  } else {
+    console.log(value);
+  }
+}
+
+function parseGlobal(argv: string[]): { options: CliOptions; args: string[] } {
+  const options: CliOptions = { json: false };
+  const args: string[] = [];
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--json") {
+      options.json = true;
+    } else if (arg === "--port") {
+      const next = argv[++i];
+      if (!next) throw new Error("--port requires a value");
+      options.port = Number(next);
+    } else {
+      args.push(arg);
+    }
+  }
+  return { options, args };
+}
+
+function optionValue(args: string[], name: string): string | undefined {
+  const index = args.indexOf(name);
+  if (index === -1) return undefined;
+  const value = args[index + 1];
+  if (!value) throw new Error(`${name} requires a value`);
+  args.splice(index, 2);
+  return value;
+}
+
+function optionFlag(args: string[], name: string): boolean {
+  const index = args.indexOf(name);
+  if (index === -1) return false;
+  args.splice(index, 1);
+  return true;
+}
+
+function readMessage(args: string[]): string {
+  const file = optionValue(args, "--file");
+  if (file) return readFileSync(file, "utf8");
+  if (args.length > 0) return args.join(" ");
+  return readFileSync(0, "utf8");
+}
+
+async function run(argv: string[]): Promise<void> {
+  const { options, args } = parseGlobal(argv);
+  const command = args.shift();
+  if (!command || command === "help" || command === "--help" || command === "-h") {
+    printHelp();
+    return;
+  }
+
+  const client = createClient({ port: options.port });
+  switch (command) {
+    case "status": {
+      const snapshot = await fetchSnapshot(client);
+      const tabs = normalizeTabs(snapshot.state.tabs);
+      const authProfiles = (snapshot.state.authProfiles as JsonRecord | undefined) ?? {};
+      print({
+        location: snapshot.location,
+        status: snapshot.state.status,
+        connection: snapshot.state.connection,
+        waiting: snapshot.state.waiting,
+        model: snapshot.state.model,
+        activeTabId: snapshot.state.activeTabId,
+        tabs: tabs.length,
+        accounts: Array.isArray(authProfiles.profiles) ? authProfiles.profiles.length : 0,
+      }, true);
+      break;
+    }
+    case "state": {
+      const path = args.shift() ?? "";
+      const snapshot = await fetchSnapshot(client);
+      print(jsonPointerGet(snapshot.state, path), true);
+      break;
+    }
+    case "eval": {
+      const js = readMessage(args);
+      const result = await client.eval(js);
+      print(result, options.json);
+      break;
+    }
+    case "invoke": {
+      const name = args.shift();
+      if (!name) throw new Error("invoke requires a Tauri command name");
+      const raw = args.length > 0 ? args.join(" ") : "{}";
+      const parsed = JSON.parse(raw) as unknown;
+      print(await client.invoke(name, parsed), true);
+      break;
+    }
+    case "models": {
+      const snapshot = await fetchSnapshot(client);
+      const models = jsonPointerGet(snapshot.state, "/sidebar/models");
+      print(models ?? [], true);
+      break;
+    }
+    case "tabs": {
+      await runTabs(client, args, options);
+      break;
+    }
+    case "accounts": {
+      await runAccounts(client, args, options);
+      break;
+    }
+    case "chat": {
+      await runChat(client, args, options);
+      break;
+    }
+    case "agent": {
+      await runAgent(client, args, options);
+      break;
+    }
+    case "skills":
+    case "skill": {
+      runSkills(args, options);
+      break;
+    }
+    case "wait": {
+      const timeout = Number(optionValue(args, "--timeout") ?? "300000");
+      print(await waitUntilIdle(client, timeout), true);
+      break;
+    }
+    default:
+      throw new Error(`unknown command: ${command}`);
+  }
+}
+
+async function runTabs(
+  client: ReturnType<typeof createClient>,
+  args: string[],
+  options: CliOptions,
+): Promise<void> {
+  const subcommand = args[0];
+  if (!subcommand || subcommand === "list") {
+    if (subcommand === "list") args.shift();
+    const snapshot = await fetchSnapshot(client);
+    print(normalizeTabs(snapshot.state.tabs), true);
+    return;
+  }
+  args.shift();
+  if (subcommand === "new") {
+    const tab = await openAgentTab(client, {
+      tabId: optionValue(args, "--id"),
+      cwd: optionValue(args, "--cwd"),
+      label: optionValue(args, "--label"),
+      model: optionValue(args, "--model"),
+      account: optionValue(args, "--account"),
+    });
+    print(tab, true);
+    return;
+  }
+  if (subcommand === "close") {
+    const tabId = args.shift();
+    if (!tabId) throw new Error("tabs close requires a tab id");
+    await closeAgentTab(client, tabId);
+    print({ closed: tabId }, options.json);
+    return;
+  }
+  throw new Error(`unknown tabs command: ${subcommand}`);
+}
+
+async function runAccounts(
+  client: ReturnType<typeof createClient>,
+  args: string[],
+  options: CliOptions,
+): Promise<void> {
+  const subcommand = args.shift() ?? "list";
+  if (subcommand === "list") {
+    const snapshot = await fetchSnapshot(client);
+    print(jsonPointerGet(snapshot.state, "/authProfiles") ?? {}, true);
+    return;
+  }
+  if (subcommand !== "use") throw new Error(`unknown accounts command: ${subcommand}`);
+  const profileId = args.shift();
+  if (!profileId) throw new Error("accounts use requires a profile id");
+  const requestedTab = optionValue(args, "--tab") ?? "active";
+  const snapshot = await fetchSnapshot(client);
+  const target = activeTargetFromState(snapshot.state, requestedTab);
+  const payloads = await applyAccountSwitch(client, profileId, target);
+  print({ profileId, target, payloads }, options.json);
+}
+
+async function runChat(
+  client: ReturnType<typeof createClient>,
+  args: string[],
+  options: CliOptions,
+): Promise<void> {
+  const subcommand = args.shift();
+  if (subcommand !== "send") throw new Error("usage: aethonctl chat send [options] <message>");
+  const account = optionValue(args, "--account");
+  const requestedTab = optionValue(args, "--tab") ?? "active";
+  const cwd = optionValue(args, "--cwd");
+  const model = optionValue(args, "--model");
+  const thinkingLevel = optionValue(args, "--thinking-level");
+  const planMode = optionFlag(args, "--plan");
+  const wait = optionFlag(args, "--wait");
+  const message = readMessage(args);
+  const snapshot = await fetchSnapshot(client);
+  const target = activeTargetFromState(snapshot.state, requestedTab);
+  if (account) await applyAccountSwitch(client, account, target);
+  await sendChat(client, message, {
+    tabId: target.tabId,
+    cwd: cwd ?? target.cwd,
+    model: model ?? target.model,
+    thinkingLevel,
+    account,
+    planMode,
+  });
+  const result: JsonRecord = { sent: true, tabId: target.tabId };
+  if (account) result.account = account;
+  if (wait) result.wait = await waitUntilIdle(client, 300_000);
+  print(result, options.json);
+}
+
+async function runAgent(
+  client: ReturnType<typeof createClient>,
+  args: string[],
+  options: CliOptions,
+): Promise<void> {
+  const subcommand = args.shift() ?? "diagnostics";
+  if (subcommand === "diagnostics" || subcommand === "diag") {
+    print(await client.invoke("agent_diagnostics", {}), true);
+    return;
+  }
+  if (subcommand === "command") {
+    const raw = args.length > 0 ? args.join(" ") : readFileSync(0, "utf8");
+    const payload = JSON.parse(raw) as unknown;
+    const result = await client.eval(rawAgentCommandJs(payload));
+    print(result || "ok", options.json);
+    return;
+  }
+  if (subcommand === "stop") {
+    const tabId = optionValue(args, "--tab") ?? "active";
+    const snapshot = await fetchSnapshot(client);
+    const target = activeTargetFromState(snapshot.state, tabId);
+    await client.invoke("agent_command", { payload: JSON.stringify({ type: "stop", tabId: target.tabId }) });
+    print({ stopped: true, tabId: target.tabId }, options.json);
+    return;
+  }
+  throw new Error(`unknown agent command: ${subcommand}`);
+}
+
+function runSkills(args: string[], options: CliOptions): void {
+  const subcommand = args.shift() ?? "show";
+  if (subcommand === "show") {
+    print(skillMarkdown(), false);
+    return;
+  }
+  if (subcommand !== "install") throw new Error(`unknown skills command: ${subcommand}`);
+  const project = optionFlag(args, "--project");
+  const global = optionFlag(args, "--global");
+  const force = optionFlag(args, "--force");
+  const dir = optionValue(args, "--dir");
+  if (project && global) throw new Error("--project and --global are mutually exclusive");
+  const plan = planSkillInstall({ targets: args, project: project || !global ? project : false, dir });
+  const written = installSkill(plan, force);
+  print({ installed: written }, options.json);
+}
+
+function printHelp(): void {
+  console.log(`aethonctl - control a running Aethon dev app
+
+Usage:
+  aethonctl status --json
+  aethonctl state /authProfiles --json
+  aethonctl tabs
+  aethonctl tabs new --cwd /path/to/project --account <profile-id>
+  aethonctl tabs close <tab-id>
+  aethonctl models
+  aethonctl accounts list
+  aethonctl accounts use <profile-id> [--tab active|default|<id>]
+  aethonctl chat send [--account <profile-id>] [--tab active|default|<id>] [--wait] <message>
+  aethonctl agent diagnostics
+  aethonctl agent command '{"type":"stop","tabId":"default"}'
+  aethonctl invoke <tauri-command> [args-json]
+  aethonctl eval 'return window.__AETHON_STATE__()'
+  aethonctl skills show
+  aethonctl skills install [claude|codex|agents|all] [--project|--global] [--dir PATH] [--force]
+
+Global options:
+  --json              Print JSON where applicable
+  --port <port>       Override AETHON_DEBUG_PORT / ~/.aethon/dev-info.json
+`);
+}
+
+run(process.argv.slice(2)).catch((err) => {
+  console.error(`aethonctl: ${err instanceof Error ? err.message : String(err)}`);
+  process.exitCode = 1;
+});

--- a/cli/aethonctl.ts
+++ b/cli/aethonctl.ts
@@ -26,6 +26,11 @@ interface CliOptions {
   transport: "auto" | "control" | "debug";
 }
 
+/** Default `--wait` / `wait` ceiling. Agent turns routinely run for minutes, so
+ *  the old 5-minute default reported false timeouts on long turns; this is the
+ *  ceiling, not a fixed delay — a `--wait` returns the instant the turn ends. */
+const DEFAULT_WAIT_MS = 30 * 60 * 1000;
+
 function print(value: unknown, json = false): void {
   if (json || typeof value !== "string") {
     console.log(JSON.stringify(value, null, 2));
@@ -171,7 +176,7 @@ async function run(argv: string[]): Promise<void> {
       break;
     }
     case "wait": {
-      const timeout = Number(optionValue(args, "--timeout") ?? "300000");
+      const timeout = Number(optionValue(args, "--timeout") ?? String(DEFAULT_WAIT_MS));
       if (client.kind === "control") {
         print(await client.control.request("chat.wait", { timeoutMs: timeout }), true);
       } else {
@@ -305,6 +310,7 @@ async function runChat(
   const thinkingLevel = optionValue(args, "--thinking-level");
   const planMode = optionFlag(args, "--plan");
   const wait = optionFlag(args, "--wait");
+  const waitTimeoutMs = Number(optionValue(args, "--timeout") ?? String(DEFAULT_WAIT_MS));
   const message = readMessage(args);
   if (client.kind === "control") {
     let targetTab = requestedTab;
@@ -322,7 +328,7 @@ async function runChat(
         message,
         tabId: targetTab,
         ...(account ? { account } : {}),
-        ...(wait ? { wait: true, timeoutMs: 300_000 } : {}),
+        ...(wait ? { wait: true, timeoutMs: waitTimeoutMs } : {}),
         ...(planMode ? { planMode } : {}),
         ...(thinkingLevel ? { thinkingLevel } : {}),
       }),
@@ -342,7 +348,7 @@ async function runChat(
     });
     const result: JsonRecord = { sent: true, tabId: target.tabId };
     if (account) result.account = account;
-    if (wait) result.wait = await waitUntilIdle(client.debug, 300_000);
+    if (wait) result.wait = await waitUntilIdle(client.debug, waitTimeoutMs);
     print(result, options.json);
   }
 }
@@ -395,7 +401,7 @@ function runSkills(args: string[], options: CliOptions): void {
   const force = optionFlag(args, "--force");
   const dir = optionValue(args, "--dir");
   if (project && global) throw new Error("--project and --global are mutually exclusive");
-  const plan = planSkillInstall({ targets: args, project: project || !global ? project : false, dir });
+  const plan = planSkillInstall({ targets: args, project, dir });
   const written = installSkill(plan, force);
   print({ installed: written }, options.json);
 }
@@ -411,7 +417,7 @@ Usage:
   aethonctl models
   aethonctl accounts list
   aethonctl accounts use <profile-id> [--tab active|default|<id>]
-  aethonctl chat send [--account <profile-id>] [--tab active|default|<id>] [--wait] <message>
+  aethonctl chat send [--account <profile-id>] [--tab active|default|<id>] [--wait] [--timeout <ms>] [--plan] [--thinking-level <level>] <message>
   aethonctl agent stop [--tab active|default|<id>]
   aethonctl skills show
   aethonctl skills install [claude|codex|agents|all] [--project|--global] [--dir PATH] [--force]

--- a/cli/aethonctl.ts
+++ b/cli/aethonctl.ts
@@ -17,10 +17,13 @@ import {
   waitUntilIdle,
   type JsonRecord,
 } from "./aethonControl.ts";
+import { AethonControlClient } from "./controlClient.ts";
 
 interface CliOptions {
   json: boolean;
   port?: number;
+  socket?: string;
+  transport: "auto" | "control" | "debug";
 }
 
 function print(value: unknown, json = false): void {
@@ -32,7 +35,7 @@ function print(value: unknown, json = false): void {
 }
 
 function parseGlobal(argv: string[]): { options: CliOptions; args: string[] } {
-  const options: CliOptions = { json: false };
+  const options: CliOptions = { json: false, transport: "auto" };
   const args: string[] = [];
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
@@ -42,6 +45,16 @@ function parseGlobal(argv: string[]): { options: CliOptions; args: string[] } {
       const next = argv[++i];
       if (!next) throw new Error("--port requires a value");
       options.port = Number(next);
+    } else if (arg === "--socket") {
+      const next = argv[++i];
+      if (!next) throw new Error("--socket requires a value");
+      options.socket = next;
+    } else if (arg === "--transport") {
+      const next = argv[++i];
+      if (next !== "auto" && next !== "control" && next !== "debug") {
+        throw new Error("--transport must be auto, control, or debug");
+      }
+      options.transport = next;
     } else {
       args.push(arg);
     }
@@ -80,48 +93,60 @@ async function run(argv: string[]): Promise<void> {
     return;
   }
 
-  const client = createClient({ port: options.port });
+  const client = createRuntime(options);
   switch (command) {
     case "status": {
-      const snapshot = await fetchSnapshot(client);
-      const tabs = normalizeTabs(snapshot.state.tabs);
-      const authProfiles = (snapshot.state.authProfiles as JsonRecord | undefined) ?? {};
-      print({
-        location: snapshot.location,
-        status: snapshot.state.status,
-        connection: snapshot.state.connection,
-        waiting: snapshot.state.waiting,
-        model: snapshot.state.model,
-        activeTabId: snapshot.state.activeTabId,
-        tabs: tabs.length,
-        accounts: Array.isArray(authProfiles.profiles) ? authProfiles.profiles.length : 0,
-      }, true);
+      if (client.kind === "control") {
+        print(await client.control.request("status"), true);
+      } else {
+        const snapshot = await fetchSnapshot(client.debug);
+        const tabs = normalizeTabs(snapshot.state.tabs);
+        const authProfiles = (snapshot.state.authProfiles as JsonRecord | undefined) ?? {};
+        print({
+          location: snapshot.location,
+          status: snapshot.state.status,
+          connection: snapshot.state.connection,
+          waiting: snapshot.state.waiting,
+          model: snapshot.state.model,
+          activeTabId: snapshot.state.activeTabId,
+          tabs: tabs.length,
+          accounts: Array.isArray(authProfiles.profiles) ? authProfiles.profiles.length : 0,
+          transport: "debug",
+        }, true);
+      }
       break;
     }
     case "state": {
+      requireDebug(client, "state");
       const path = args.shift() ?? "";
-      const snapshot = await fetchSnapshot(client);
+      const snapshot = await fetchSnapshot(client.debug);
       print(jsonPointerGet(snapshot.state, path), true);
       break;
     }
     case "eval": {
+      requireDebug(client, "eval");
       const js = readMessage(args);
-      const result = await client.eval(js);
+      const result = await client.debug.eval(js);
       print(result, options.json);
       break;
     }
     case "invoke": {
+      requireDebug(client, "invoke");
       const name = args.shift();
       if (!name) throw new Error("invoke requires a Tauri command name");
       const raw = args.length > 0 ? args.join(" ") : "{}";
       const parsed = JSON.parse(raw) as unknown;
-      print(await client.invoke(name, parsed), true);
+      print(await client.debug.invoke(name, parsed), true);
       break;
     }
     case "models": {
-      const snapshot = await fetchSnapshot(client);
-      const models = jsonPointerGet(snapshot.state, "/sidebar/models");
-      print(models ?? [], true);
+      if (client.kind === "control") {
+        print(await client.control.request("models.list"), true);
+      } else {
+        const snapshot = await fetchSnapshot(client.debug);
+        const models = jsonPointerGet(snapshot.state, "/sidebar/models");
+        print(models ?? [], true);
+      }
       break;
     }
     case "tabs": {
@@ -147,7 +172,11 @@ async function run(argv: string[]): Promise<void> {
     }
     case "wait": {
       const timeout = Number(optionValue(args, "--timeout") ?? "300000");
-      print(await waitUntilIdle(client, timeout), true);
+      if (client.kind === "control") {
+        print(await client.control.request("chat.wait", { timeoutMs: timeout }), true);
+      } else {
+        print(await waitUntilIdle(client.debug, timeout), true);
+      }
       break;
     }
     default:
@@ -155,21 +184,61 @@ async function run(argv: string[]): Promise<void> {
   }
 }
 
+type RuntimeClient =
+  | { kind: "control"; control: AethonControlClient }
+  | { kind: "debug"; debug: ReturnType<typeof createClient> };
+
+function createRuntime(options: CliOptions): RuntimeClient {
+  if (options.transport === "debug") {
+    return { kind: "debug", debug: createClient({ port: options.port }) };
+  }
+  if (options.transport === "control") {
+    return { kind: "control", control: new AethonControlClient({ socketPath: options.socket }) };
+  }
+  try {
+    return { kind: "control", control: new AethonControlClient({ socketPath: options.socket }) };
+  } catch (err) {
+    if (options.socket) throw err;
+    return { kind: "debug", debug: createClient({ port: options.port }) };
+  }
+}
+
+function requireDebug(
+  client: RuntimeClient,
+  command: string,
+): asserts client is { kind: "debug"; debug: ReturnType<typeof createClient> } {
+  if (client.kind !== "debug") {
+    throw new Error(`${command} is debug-only; pass --transport debug to use the dev bridge`);
+  }
+}
+
 async function runTabs(
-  client: ReturnType<typeof createClient>,
+  client: RuntimeClient,
   args: string[],
   options: CliOptions,
 ): Promise<void> {
   const subcommand = args[0];
   if (!subcommand || subcommand === "list") {
     if (subcommand === "list") args.shift();
-    const snapshot = await fetchSnapshot(client);
-    print(normalizeTabs(snapshot.state.tabs), true);
+    if (client.kind === "control") {
+      print(await client.control.request("tabs.list"), true);
+    } else {
+      const snapshot = await fetchSnapshot(client.debug);
+      print(normalizeTabs(snapshot.state.tabs), true);
+    }
     return;
   }
   args.shift();
   if (subcommand === "new") {
-    const tab = await openAgentTab(client, {
+    const tab = client.kind === "control"
+      ? await client.control.request("tabs.open", {
+          tabId: optionValue(args, "--id"),
+          cwd: optionValue(args, "--cwd"),
+          label: optionValue(args, "--label"),
+          model: optionValue(args, "--model"),
+          account: optionValue(args, "--account"),
+        })
+      : await openAgentTab(client.debug, {
       tabId: optionValue(args, "--id"),
       cwd: optionValue(args, "--cwd"),
       label: optionValue(args, "--label"),
@@ -182,7 +251,11 @@ async function runTabs(
   if (subcommand === "close") {
     const tabId = args.shift();
     if (!tabId) throw new Error("tabs close requires a tab id");
-    await closeAgentTab(client, tabId);
+    if (client.kind === "control") {
+      await client.control.request("tabs.close", { tabId });
+    } else {
+      await closeAgentTab(client.debug, tabId);
+    }
     print({ closed: tabId }, options.json);
     return;
   }
@@ -190,28 +263,36 @@ async function runTabs(
 }
 
 async function runAccounts(
-  client: ReturnType<typeof createClient>,
+  client: RuntimeClient,
   args: string[],
   options: CliOptions,
 ): Promise<void> {
   const subcommand = args.shift() ?? "list";
   if (subcommand === "list") {
-    const snapshot = await fetchSnapshot(client);
-    print(jsonPointerGet(snapshot.state, "/authProfiles") ?? {}, true);
+    if (client.kind === "control") {
+      print(await client.control.request("accounts.list"), true);
+    } else {
+      const snapshot = await fetchSnapshot(client.debug);
+      print(jsonPointerGet(snapshot.state, "/authProfiles") ?? {}, true);
+    }
     return;
   }
   if (subcommand !== "use") throw new Error(`unknown accounts command: ${subcommand}`);
   const profileId = args.shift();
   if (!profileId) throw new Error("accounts use requires a profile id");
   const requestedTab = optionValue(args, "--tab") ?? "active";
-  const snapshot = await fetchSnapshot(client);
-  const target = activeTargetFromState(snapshot.state, requestedTab);
-  const payloads = await applyAccountSwitch(client, profileId, target);
-  print({ profileId, target, payloads }, options.json);
+  if (client.kind === "control") {
+    print(await client.control.request("accounts.use", { profileId, tabId: requestedTab }), options.json);
+  } else {
+    const snapshot = await fetchSnapshot(client.debug);
+    const target = activeTargetFromState(snapshot.state, requestedTab);
+    const payloads = await applyAccountSwitch(client.debug, profileId, target);
+    print({ profileId, target, payloads }, options.json);
+  }
 }
 
 async function runChat(
-  client: ReturnType<typeof createClient>,
+  client: RuntimeClient,
   args: string[],
   options: CliOptions,
 ): Promise<void> {
@@ -225,46 +306,78 @@ async function runChat(
   const planMode = optionFlag(args, "--plan");
   const wait = optionFlag(args, "--wait");
   const message = readMessage(args);
-  const snapshot = await fetchSnapshot(client);
-  const target = activeTargetFromState(snapshot.state, requestedTab);
-  if (account) await applyAccountSwitch(client, account, target);
-  await sendChat(client, message, {
-    tabId: target.tabId,
-    cwd: cwd ?? target.cwd,
-    model: model ?? target.model,
-    thinkingLevel,
-    account,
-    planMode,
-  });
-  const result: JsonRecord = { sent: true, tabId: target.tabId };
-  if (account) result.account = account;
-  if (wait) result.wait = await waitUntilIdle(client, 300_000);
-  print(result, options.json);
+  if (client.kind === "control") {
+    let targetTab = requestedTab;
+    if ((cwd || model) && requestedTab === "active") {
+      const opened = await client.control.request<JsonRecord>("tabs.open", {
+        cwd,
+        model,
+        account,
+        label: "CLI",
+      });
+      targetTab = typeof opened.id === "string" ? opened.id : targetTab;
+    }
+    print(
+      await client.control.request("chat.send", {
+        message,
+        tabId: targetTab,
+        ...(account ? { account } : {}),
+        ...(wait ? { wait: true, timeoutMs: 300_000 } : {}),
+        ...(planMode ? { planMode } : {}),
+        ...(thinkingLevel ? { thinkingLevel } : {}),
+      }),
+      options.json,
+    );
+  } else {
+    const snapshot = await fetchSnapshot(client.debug);
+    const target = activeTargetFromState(snapshot.state, requestedTab);
+    if (account) await applyAccountSwitch(client.debug, account, target);
+    await sendChat(client.debug, message, {
+      tabId: target.tabId,
+      cwd: cwd ?? target.cwd,
+      model: model ?? target.model,
+      thinkingLevel,
+      account,
+      planMode,
+    });
+    const result: JsonRecord = { sent: true, tabId: target.tabId };
+    if (account) result.account = account;
+    if (wait) result.wait = await waitUntilIdle(client.debug, 300_000);
+    print(result, options.json);
+  }
 }
 
 async function runAgent(
-  client: ReturnType<typeof createClient>,
+  client: RuntimeClient,
   args: string[],
   options: CliOptions,
 ): Promise<void> {
   const subcommand = args.shift() ?? "diagnostics";
   if (subcommand === "diagnostics" || subcommand === "diag") {
-    print(await client.invoke("agent_diagnostics", {}), true);
+    if (client.kind === "control") {
+      throw new Error("agent diagnostics is not on the release transport yet; use --transport debug");
+    }
+    print(await client.debug.invoke("agent_diagnostics", {}), true);
     return;
   }
   if (subcommand === "command") {
+    requireDebug(client, "agent command");
     const raw = args.length > 0 ? args.join(" ") : readFileSync(0, "utf8");
     const payload = JSON.parse(raw) as unknown;
-    const result = await client.eval(rawAgentCommandJs(payload));
+    const result = await client.debug.eval(rawAgentCommandJs(payload));
     print(result || "ok", options.json);
     return;
   }
   if (subcommand === "stop") {
     const tabId = optionValue(args, "--tab") ?? "active";
-    const snapshot = await fetchSnapshot(client);
-    const target = activeTargetFromState(snapshot.state, tabId);
-    await client.invoke("agent_command", { payload: JSON.stringify({ type: "stop", tabId: target.tabId }) });
-    print({ stopped: true, tabId: target.tabId }, options.json);
+    if (client.kind === "control") {
+      print(await client.control.request("agent.stop", { tabId }), options.json);
+    } else {
+      const snapshot = await fetchSnapshot(client.debug);
+      const target = activeTargetFromState(snapshot.state, tabId);
+      await client.debug.invoke("agent_command", { payload: JSON.stringify({ type: "stop", tabId: target.tabId }) });
+      print({ stopped: true, tabId: target.tabId }, options.json);
+    }
     return;
   }
   throw new Error(`unknown agent command: ${subcommand}`);
@@ -288,11 +401,10 @@ function runSkills(args: string[], options: CliOptions): void {
 }
 
 function printHelp(): void {
-  console.log(`aethonctl - control a running Aethon dev app
+  console.log(`aethonctl - control a running Aethon app
 
 Usage:
   aethonctl status --json
-  aethonctl state /authProfiles --json
   aethonctl tabs
   aethonctl tabs new --cwd /path/to/project --account <profile-id>
   aethonctl tabs close <tab-id>
@@ -300,16 +412,21 @@ Usage:
   aethonctl accounts list
   aethonctl accounts use <profile-id> [--tab active|default|<id>]
   aethonctl chat send [--account <profile-id>] [--tab active|default|<id>] [--wait] <message>
-  aethonctl agent diagnostics
-  aethonctl agent command '{"type":"stop","tabId":"default"}'
-  aethonctl invoke <tauri-command> [args-json]
-  aethonctl eval 'return window.__AETHON_STATE__()'
+  aethonctl agent stop [--tab active|default|<id>]
   aethonctl skills show
   aethonctl skills install [claude|codex|agents|all] [--project|--global] [--dir PATH] [--force]
 
+Debug-only:
+  aethonctl --transport debug state /authProfiles --json
+  aethonctl --transport debug agent diagnostics
+  aethonctl --transport debug invoke <tauri-command> [args-json]
+  aethonctl --transport debug eval 'return window.__AETHON_STATE__()'
+
 Global options:
   --json              Print JSON where applicable
-  --port <port>       Override AETHON_DEBUG_PORT / ~/.aethon/dev-info.json
+  --transport <mode>  auto | control | debug (default: auto)
+  --socket <path>     Override ~/.aethon/control/control.json socket path
+  --port <port>       Debug transport only: override AETHON_DEBUG_PORT / ~/.aethon/dev-info.json
 `);
 }
 

--- a/cli/controlClient.ts
+++ b/cli/controlClient.ts
@@ -1,0 +1,106 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import net from "node:net";
+
+export interface ControlInfo {
+  protocolVersion: number;
+  mode: string;
+  socketPath: string;
+  tokenPath: string;
+  pid: number;
+  version: string;
+  instanceId: string;
+}
+
+export interface ControlClientOptions {
+  socketPath?: string;
+  home?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+export function defaultControlInfoPath(options: ControlClientOptions = {}): string {
+  const env = options.env ?? process.env;
+  const root = env.AETHON_USER_DIR && env.AETHON_USER_DIR.length > 0
+    ? env.AETHON_USER_DIR
+    : join(options.home ?? env.HOME ?? ".", ".aethon");
+  return join(root, "control", "control.json");
+}
+
+export function readControlInfo(options: ControlClientOptions = {}): ControlInfo | undefined {
+  const path = defaultControlInfoPath(options);
+  if (!existsSync(path)) return undefined;
+  const parsed = JSON.parse(readFileSync(path, "utf8")) as Partial<ControlInfo>;
+  if (!parsed.socketPath || !parsed.tokenPath) return undefined;
+  return parsed as ControlInfo;
+}
+
+export class AethonControlClient {
+  readonly info: ControlInfo;
+  readonly token: string;
+
+  constructor(options: ControlClientOptions = {}) {
+    const info = readControlInfo(options);
+    const socketPath = options.socketPath ?? info?.socketPath;
+    const tokenPath = info?.tokenPath;
+    if (!socketPath || !tokenPath) {
+      throw new Error("Aethon control socket not found; is the app running?");
+    }
+    this.info = {
+      protocolVersion: info?.protocolVersion ?? 1,
+      mode: info?.mode ?? "local",
+      socketPath,
+      tokenPath,
+      pid: info?.pid ?? 0,
+      version: info?.version ?? "",
+      instanceId: info?.instanceId ?? "",
+    };
+    this.token = readFileSync(tokenPath, "utf8").trim();
+    if (!this.token) throw new Error(`Aethon control token is empty: ${tokenPath}`);
+  }
+
+  request<T = unknown>(method: string, params: Record<string, unknown> = {}): Promise<T> {
+    const payload = JSON.stringify({ token: this.token, method, params }) + "\n";
+    return new Promise<T>((resolve, reject) => {
+      const socket = net.createConnection(this.info.socketPath);
+      let buffer = "";
+      const timer = setTimeout(() => {
+        socket.destroy();
+        reject(new Error(`control request timed out: ${method}`));
+      }, 310_000);
+      socket.on("connect", () => {
+        socket.write(payload);
+      });
+      socket.on("data", (chunk) => {
+        buffer += chunk.toString("utf8");
+        const newline = buffer.indexOf("\n");
+        if (newline === -1) return;
+        clearTimeout(timer);
+        socket.end();
+        try {
+          const parsed = JSON.parse(buffer.slice(0, newline)) as {
+            ok?: boolean;
+            result?: T;
+            error?: string;
+          };
+          if (parsed.ok) {
+            resolve(parsed.result as T);
+          } else {
+            reject(new Error(parsed.error ?? `control request failed: ${method}`));
+          }
+        } catch (err) {
+          reject(err instanceof Error ? err : new Error(String(err)));
+        }
+      });
+      socket.on("error", (err) => {
+        clearTimeout(timer);
+        reject(err);
+      });
+      socket.on("close", () => {
+        clearTimeout(timer);
+        if (buffer.length === 0) {
+          reject(new Error(`control socket closed without a response: ${method}`));
+        }
+      });
+    });
+  }
+}

--- a/cli/controlClient.ts
+++ b/cli/controlClient.ts
@@ -60,13 +60,21 @@ export class AethonControlClient {
 
   request<T = unknown>(method: string, params: Record<string, unknown> = {}): Promise<T> {
     const payload = JSON.stringify({ token: this.token, method, params }) + "\n";
+    // A waited request (`chat.send --wait` / `chat.wait`) carries its own
+    // `timeoutMs` and may legitimately block for the whole agent turn. Derive
+    // the socket timer from it (with a margin larger than the backend's own
+    // margin) so the client never gives up before the app does.
+    const requestedTimeout =
+      typeof params.timeoutMs === "number" && Number.isFinite(params.timeoutMs)
+        ? params.timeoutMs + 120_000
+        : 310_000;
     return new Promise<T>((resolve, reject) => {
       const socket = net.createConnection(this.info.socketPath);
       let buffer = "";
       const timer = setTimeout(() => {
         socket.destroy();
         reject(new Error(`control request timed out: ${method}`));
-      }, 310_000);
+      }, requestedTimeout);
       socket.on("connect", () => {
         socket.write(payload);
       });

--- a/cli/debugClient.ts
+++ b/cli/debugClient.ts
@@ -1,0 +1,155 @@
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { execFile } from "node:child_process";
+import { join } from "node:path";
+
+export interface DebugClientOptions {
+  port?: number;
+  host?: string;
+  home?: string;
+  tmpdir?: string;
+  env?: Record<string, string | undefined>;
+  timeoutMs?: number;
+}
+
+export interface DevInfo {
+  debugPort?: number;
+  vitePort?: number;
+  pid?: number;
+  [key: string]: unknown;
+}
+
+const DEFAULT_HOST = "127.0.0.1";
+const DEFAULT_PORT = 19433;
+
+export function readDevInfo(path: string): DevInfo | null {
+  try {
+    return JSON.parse(readFileSync(path, "utf8")) as DevInfo;
+  } catch {
+    return null;
+  }
+}
+
+export function resolveDevInfoPath(options: DebugClientOptions = {}): string | null {
+  const home = options.home ?? process.env.HOME ?? "";
+  const tmpdir = options.tmpdir ?? process.env.TMPDIR ?? "/tmp";
+  const conventional = join(home, ".aethon", "dev-info.json");
+  if (existsSync(conventional)) return conventional;
+
+  const sandboxRoot = join(tmpdir, "aethon-dev");
+  if (!existsSync(sandboxRoot)) return null;
+  let newest: { path: string; mtimeMs: number } | null = null;
+  for (const entry of readdirSync(sandboxRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory() || !entry.name.startsWith("new-")) continue;
+    const candidate = join(sandboxRoot, entry.name, "dev-info.json");
+    if (!existsSync(candidate)) continue;
+    const mtimeMs = statSync(candidate).mtimeMs;
+    if (!newest || mtimeMs > newest.mtimeMs) newest = { path: candidate, mtimeMs };
+  }
+  return newest?.path ?? null;
+}
+
+export function resolveDebugPort(options: DebugClientOptions = {}): number {
+  if (options.port && Number.isFinite(options.port)) return options.port;
+  const env = options.env ?? process.env;
+  const envPort = Number(env.AETHON_DEBUG_PORT);
+  if (Number.isInteger(envPort) && envPort > 0) return envPort;
+  const devInfoPath = resolveDevInfoPath(options);
+  const devInfo = devInfoPath ? readDevInfo(devInfoPath) : null;
+  const infoPort = devInfo?.debugPort;
+  return typeof infoPort === "number" && Number.isInteger(infoPort) && infoPort > 0
+    ? infoPort
+    : DEFAULT_PORT;
+}
+
+export class AethonDebugClient {
+  private readonly host: string;
+  private readonly port: number;
+  private readonly timeoutMs: number;
+
+  constructor(options: DebugClientOptions = {}) {
+    this.host = options.host ?? DEFAULT_HOST;
+    this.port = resolveDebugPort(options);
+    this.timeoutMs = options.timeoutMs ?? 12_000;
+  }
+
+  eval(js: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const child = execFile(
+        "python3",
+        [
+          "-c",
+          `
+import socket, sys
+s = socket.socket()
+s.settimeout(${JSON.stringify(Math.ceil(this.timeoutMs / 1000))})
+try:
+    s.connect((${JSON.stringify(this.host)}, ${JSON.stringify(this.port)}))
+except Exception as e:
+    sys.stderr.write(str(e))
+    sys.exit(2)
+s.sendall(sys.stdin.buffer.read())
+s.shutdown(socket.SHUT_WR)
+data = b""
+while True:
+    try:
+        chunk = s.recv(4096)
+    except socket.timeout:
+        break
+    if not chunk:
+        break
+    data += chunk
+s.close()
+sys.stdout.buffer.write(data)
+`,
+        ],
+        { maxBuffer: 64 * 1024 * 1024, timeout: this.timeoutMs },
+        (err, stdout, stderr) => {
+          if (err) {
+            reject(
+              new Error(
+                `could not talk to Aethon debug server on ${this.host}:${this.port}: ${
+                  stderr || err.message
+                }`,
+              ),
+            );
+            return;
+          }
+          resolve(stdout.trimEnd());
+        },
+      );
+      child.stdin?.end(js);
+    });
+  }
+
+  async evalJson<T = unknown>(js: string): Promise<T> {
+    const raw = await this.eval(js);
+    if (raw.startsWith("ERROR:")) throw new Error(raw.slice("ERROR:".length).trim());
+    try {
+      return JSON.parse(raw) as T;
+    } catch (err) {
+      throw new Error(`Aethon returned non-JSON output: ${String(err)}\n${raw}`, {
+        cause: err,
+      });
+    }
+  }
+
+  async invoke<T = unknown>(command: string, args: unknown = {}): Promise<T> {
+    const raw = await this.eval(invokeJs(command, args));
+    if (raw.startsWith("ERROR:")) throw new Error(raw.slice("ERROR:".length).trim());
+    if (raw === "" || raw === "undefined") return undefined as T;
+    try {
+      return JSON.parse(raw) as T;
+    } catch {
+      return raw as T;
+    }
+  }
+}
+
+export function invokeJs(command: string, args: unknown = {}): string {
+  return `
+const invoke = window.__AETHON_INVOKE__ || window.__TAURI_INTERNALS__?.invoke;
+if (!invoke) throw new Error("Aethon debug invoke hook is not available");
+const result = await invoke(${JSON.stringify(command)}, ${JSON.stringify(args)});
+return result;
+`;
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -45,6 +45,7 @@ export default tseslint.config(
             // tseslint disallows `**` here; one level of nesting matches
             // the bridge's actual layout (no deeper subtrees).
             "agent/*/*.ts",
+            "cli/*.test.ts",
             "eslint.config.js",
             "*.{js,mjs,cjs}",
           ],

--- a/package.json
+++ b/package.json
@@ -3,7 +3,11 @@
   "private": true,
   "version": "0.9.0",
   "type": "module",
+  "bin": {
+    "aethonctl": "./cli/aethonctl.ts"
+  },
   "scripts": {
+    "aethonctl": "bun cli/aethonctl.ts",
     "dev": "vite",
     "build": "bun run version:check && tsc -b && vite build",
     "preview": "vite preview",

--- a/src-tauri/src/agent_commands.rs
+++ b/src-tauri/src/agent_commands.rs
@@ -49,6 +49,13 @@ pub(crate) struct SendMessageRequest {
     /// Per-tab plan-mode toggle. Forwarded to the agent so mutating tools can
     /// be blocked while the user is asking for analysis/design only.
     plan_mode: Option<bool>,
+    /// Per-tab auth profile selected in the UI/CLI. Forwarded so a respawned
+    /// worker adopts the tab's configured account before constructing its
+    /// model registry.
+    auth_profile_id: Option<String>,
+    /// Opaque release-control request id. The bridge echoes it on lifecycle
+    /// events so external callers can wait for the specific turn they sent.
+    control_request_id: Option<String>,
 }
 
 #[tauri::command]
@@ -91,6 +98,16 @@ pub(crate) async fn send_message(
     }
     if let Some(plan_mode) = request.plan_mode {
         payload["planMode"] = serde_json::Value::Bool(plan_mode);
+    }
+    if let Some(auth_profile_id) = request.auth_profile_id
+        && !auth_profile_id.is_empty()
+    {
+        payload["authProfileId"] = serde_json::Value::String(auth_profile_id);
+    }
+    if let Some(control_request_id) = request.control_request_id
+        && !control_request_id.is_empty()
+    {
+        payload["controlRequestId"] = serde_json::Value::String(control_request_id);
     }
     let images = attachments_to_agent_images(&app, request.attachments.unwrap_or_default())?;
     if !images.is_empty() {

--- a/src-tauri/src/control.rs
+++ b/src-tauri/src/control.rs
@@ -318,22 +318,42 @@ fn aethon_control_dir(app: &AppHandle) -> Result<PathBuf, String> {
 #[cfg(unix)]
 mod unix {
     use super::*;
-    use std::os::unix::fs::PermissionsExt;
+    use std::io::Write;
+    use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+    use std::path::Path;
     use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
     use tokio::net::{UnixListener, UnixStream};
 
+    /// Create + write a file owner-only (0o600) atomically: the `mode` is
+    /// applied at `open` time, so the file never exists with broader
+    /// permissions (no chmod-after-write TOCTOU window). `0o600 & ~umask` can
+    /// only be more restrictive, never looser.
+    fn write_owner_only(path: &Path, contents: &[u8]) -> Result<(), String> {
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(path)
+            .map_err(|e| format!("open {}: {e}", path.display()))?;
+        file.write_all(contents)
+            .map_err(|e| format!("write {}: {e}", path.display()))
+    }
+
     pub(super) async fn run(app: AppHandle, state: Arc<ControlState>) -> Result<(), String> {
         let dir = aethon_control_dir(&app)?;
+        // Lock the control dir to the owner before writing anything into it.
+        // With the dir at 0o700, no other local user can even reach the token,
+        // control.json, or socket regardless of the individual file modes.
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700))
+            .map_err(|e| format!("chmod {}: {e}", dir.display()))?;
         let socket_path = dir.join("control.sock");
         let token_path = dir.join("token");
         let info_path = dir.join("control.json");
         let _ = std::fs::remove_file(&socket_path);
 
         let token = uuid::Uuid::new_v4().to_string();
-        std::fs::write(&token_path, &token)
-            .map_err(|e| format!("write {}: {e}", token_path.display()))?;
-        std::fs::set_permissions(&token_path, std::fs::Permissions::from_mode(0o600))
-            .map_err(|e| format!("chmod {}: {e}", token_path.display()))?;
+        write_owner_only(&token_path, token.as_bytes())?;
 
         let info = ControlInfo {
             protocol_version: PROTOCOL_VERSION,
@@ -344,13 +364,12 @@ mod unix {
             version: env!("CARGO_PKG_VERSION").to_string(),
             instance_id: uuid::Uuid::new_v4().to_string(),
         };
-        std::fs::write(
+        write_owner_only(
             &info_path,
-            serde_json::to_string_pretty(&info).map_err(|e| e.to_string())?,
-        )
-        .map_err(|e| format!("write {}: {e}", info_path.display()))?;
-        std::fs::set_permissions(&info_path, std::fs::Permissions::from_mode(0o600))
-            .map_err(|e| format!("chmod {}: {e}", info_path.display()))?;
+            serde_json::to_string_pretty(&info)
+                .map_err(|e| e.to_string())?
+                .as_bytes(),
+        )?;
 
         *state.token.lock().map_err(|e| e.to_string())? = Some(token);
         *state.info.lock().map_err(|e| e.to_string())? = Some(info);
@@ -397,6 +416,33 @@ mod unix {
         writer.write_all(&body).await.map_err(|e| e.to_string())?;
         writer.write_all(b"\n").await.map_err(|e| e.to_string())?;
         writer.shutdown().await.map_err(|e| e.to_string())
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn write_owner_only_grants_no_group_or_other_access() {
+            let dir = std::env::temp_dir().join(format!(
+                "aethon-control-test-{}-{}",
+                std::process::id(),
+                "token"
+            ));
+            let path = dir.join("token");
+            std::fs::create_dir_all(&dir).unwrap();
+            let _ = std::fs::remove_file(&path);
+
+            write_owner_only(&path, b"secret-token").unwrap();
+
+            let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+            // The security property: no group/other bits, regardless of umask.
+            assert_eq!(mode & 0o077, 0, "mode was {:o}", mode & 0o777);
+            assert_eq!(std::fs::read_to_string(&path).unwrap(), "secret-token");
+
+            let _ = std::fs::remove_file(&path);
+            let _ = std::fs::remove_dir(&dir);
+        }
     }
 }
 

--- a/src-tauri/src/control.rs
+++ b/src-tauri/src/control.rs
@@ -16,7 +16,46 @@ use tauri::{AppHandle, Emitter, Manager, State};
 use tokio::sync::oneshot;
 
 const PROTOCOL_VERSION: u32 = 1;
-const REQUEST_TIMEOUT: Duration = Duration::from_secs(300);
+/// Timeout for a forwarded request that carries no explicit `timeoutMs` (the
+/// quick UI-owned mutations: open/close/focus/account/stop).
+const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(300);
+/// Hard ceiling for a forwarded request, even one that asks to wait. `chat.send
+/// --wait` / `chat.wait` legitimately block for the whole agent turn (minutes),
+/// so the frontend passes its own `timeoutMs`; we honor it up to this cap so a
+/// long turn never reports a false timeout, while a wedged frontend can't pin a
+/// request open forever.
+const MAX_REQUEST_TIMEOUT: Duration = Duration::from_secs(24 * 60 * 60);
+/// Cap on a single control request line. Requests are small (method + params);
+/// a `chat.send` message is the largest field. Generous enough for a sizeable
+/// `--file` prompt, bounded so a local client can't stream unbounded memory.
+const MAX_REQUEST_BYTES: u64 = 16 * 1024 * 1024;
+
+/// Resolve the await timeout for a forwarded request, honoring a caller-supplied
+/// `timeoutMs` (plus a margin so the backend never beats the frontend's own
+/// wait) up to [`MAX_REQUEST_TIMEOUT`].
+fn request_timeout(params: &Value) -> Duration {
+    match params.get("timeoutMs").and_then(Value::as_u64) {
+        Some(ms) => Duration::from_millis(ms)
+            .saturating_add(Duration::from_secs(60))
+            .min(MAX_REQUEST_TIMEOUT),
+        None => DEFAULT_REQUEST_TIMEOUT,
+    }
+}
+
+/// Constant-time string compare for the per-launch token, so an authorized-vs-
+/// not decision doesn't leak via timing. Length is allowed to short-circuit
+/// (the token is a fixed-length uuid).
+fn token_eq(a: &str, b: &str) -> bool {
+    let (a, b) = (a.as_bytes(), b.as_bytes());
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
 
 #[derive(Default)]
 pub(crate) struct ControlState {
@@ -92,13 +131,26 @@ pub(crate) fn control_request_complete(
         .pending
         .lock()
         .map_err(|e| e.to_string())?
-        .remove(&request_id)
-        .ok_or_else(|| format!("unknown control request id: {request_id}"))?;
-    let _ = sender.send(ControlCompletion {
-        success,
-        data,
-        error,
-    });
+        .remove(&request_id);
+    match sender {
+        Some(sender) => {
+            let _ = sender.send(ControlCompletion {
+                success,
+                data,
+                error,
+            });
+        }
+        None => {
+            // Late or duplicate completion: the forward already timed out and
+            // purged this entry (or the frontend completed twice). There's
+            // nothing left to resolve — treat it as a no-op rather than failing
+            // the command, which would surface as a noisy invoke error.
+            tracing::debug!(
+                target: "aethon::control",
+                "control_request_complete: no pending request {request_id}"
+            );
+        }
+    }
     Ok(())
 }
 
@@ -131,7 +183,7 @@ async fn handle_request(
         Ok(guard) => guard.clone(),
         Err(err) => return err_response(format!("control token lock: {err}")),
     };
-    if expected.as_deref() != Some(req.token.as_str()) {
+    if !expected.is_some_and(|token| token_eq(&token, &req.token)) {
         return err_response("unauthorized".to_string());
     }
 
@@ -203,6 +255,7 @@ async fn forward_to_frontend(
     req: ControlRequest,
 ) -> ControlResponse {
     let request_id = uuid::Uuid::new_v4().to_string();
+    let timeout = request_timeout(&req.params);
     let (tx, rx) = oneshot::channel();
     {
         let mut pending = match state.pending.lock() {
@@ -220,7 +273,7 @@ async fn forward_to_frontend(
         let _ = state.pending.lock().map(|mut p| p.remove(&request_id));
         return err_response(format!("emit control-request: {err}"));
     }
-    match tokio::time::timeout(REQUEST_TIMEOUT, rx).await {
+    match tokio::time::timeout(timeout, rx).await {
         Ok(Ok(done)) if done.success => ok_response(done.data.unwrap_or(Value::Null)),
         Ok(Ok(done)) => err_response(
             done.error
@@ -266,7 +319,7 @@ fn aethon_control_dir(app: &AppHandle) -> Result<PathBuf, String> {
 mod unix {
     use super::*;
     use std::os::unix::fs::PermissionsExt;
-    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+    use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
     use tokio::net::{UnixListener, UnixStream};
 
     pub(super) async fn run(app: AppHandle, state: Arc<ControlState>) -> Result<(), String> {
@@ -330,7 +383,9 @@ mod unix {
         stream: UnixStream,
     ) -> Result<(), String> {
         let (reader, mut writer) = stream.into_split();
-        let mut lines = BufReader::new(reader).lines();
+        // Cap the request so a local client can't stream unbounded memory; a
+        // truncated request just fails to parse below.
+        let mut lines = BufReader::new(reader.take(MAX_REQUEST_BYTES)).lines();
         let Some(line) = lines.next_line().await.map_err(|e| e.to_string())? else {
             return Ok(());
         };
@@ -348,6 +403,27 @@ mod unix {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn request_timeout_honors_param_with_margin_and_cap() {
+        assert_eq!(request_timeout(&json!({})), DEFAULT_REQUEST_TIMEOUT);
+        assert_eq!(
+            request_timeout(&json!({ "timeoutMs": 1000_u64 })),
+            Duration::from_millis(1000) + Duration::from_secs(60)
+        );
+        assert_eq!(
+            request_timeout(&json!({ "timeoutMs": u64::MAX })),
+            MAX_REQUEST_TIMEOUT
+        );
+    }
+
+    #[test]
+    fn token_eq_matches_only_identical_tokens() {
+        assert!(token_eq("a1b2c3", "a1b2c3"));
+        assert!(!token_eq("a1b2c3", "a1b2c4"));
+        assert!(!token_eq("a1b2c3", "a1b2c3x"));
+        assert!(!token_eq("", "x"));
+    }
 
     #[test]
     fn readonly_status_counts_tabs_and_accounts() {

--- a/src-tauri/src/control.rs
+++ b/src-tauri/src/control.rs
@@ -1,0 +1,371 @@
+//! Release-safe local control service for `aethonctl`.
+//!
+//! This is deliberately separate from the debug eval server. The service binds
+//! a user-local Unix socket, writes a per-launch token under `~/.aethon/control`,
+//! and only exposes typed request methods. UI-owned mutations are forwarded to
+//! the webview as `control-request` events and completed by the frontend via
+//! `control_request_complete`.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use serde_json::{Value, json};
+use tauri::{AppHandle, Emitter, Manager, State};
+use tokio::sync::oneshot;
+
+const PROTOCOL_VERSION: u32 = 1;
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(300);
+
+#[derive(Default)]
+pub(crate) struct ControlState {
+    token: Mutex<Option<String>>,
+    info: Mutex<Option<ControlInfo>>,
+    frontend_state: Mutex<Value>,
+    pending: Mutex<HashMap<String, oneshot::Sender<ControlCompletion>>>,
+}
+
+#[derive(Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ControlInfo {
+    protocol_version: u32,
+    mode: String,
+    socket_path: String,
+    token_path: String,
+    pid: u32,
+    version: String,
+    instance_id: String,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ControlRequest {
+    token: String,
+    method: String,
+    #[serde(default)]
+    params: Value,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ControlResponse {
+    ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+}
+
+#[derive(Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct FrontendControlRequest {
+    request_id: String,
+    method: String,
+    params: Value,
+}
+
+struct ControlCompletion {
+    success: bool,
+    data: Option<Value>,
+    error: Option<String>,
+}
+
+#[tauri::command]
+pub(crate) fn control_update_state(
+    snapshot: Value,
+    state: State<'_, Arc<ControlState>>,
+) -> Result<(), String> {
+    *state.frontend_state.lock().map_err(|e| e.to_string())? = snapshot;
+    Ok(())
+}
+
+#[tauri::command]
+pub(crate) fn control_request_complete(
+    request_id: String,
+    success: bool,
+    data: Option<Value>,
+    error: Option<String>,
+    state: State<'_, Arc<ControlState>>,
+) -> Result<(), String> {
+    let sender = state
+        .pending
+        .lock()
+        .map_err(|e| e.to_string())?
+        .remove(&request_id)
+        .ok_or_else(|| format!("unknown control request id: {request_id}"))?;
+    let _ = sender.send(ControlCompletion {
+        success,
+        data,
+        error,
+    });
+    Ok(())
+}
+
+pub(crate) fn start_control_server(app: AppHandle, state: Arc<ControlState>) {
+    #[cfg(unix)]
+    {
+        tauri::async_runtime::spawn(async move {
+            if let Err(err) = unix::run(app, state).await {
+                tracing::error!(target: "aethon::control", "control server failed: {err}");
+            }
+        });
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = (app, state);
+        tracing::warn!(
+            target: "aethon::control",
+            "aethonctl release control is not implemented on this platform yet"
+        );
+    }
+}
+
+async fn handle_request(
+    app: &AppHandle,
+    state: &Arc<ControlState>,
+    req: ControlRequest,
+) -> ControlResponse {
+    let expected = match state.token.lock() {
+        Ok(guard) => guard.clone(),
+        Err(err) => return err_response(format!("control token lock: {err}")),
+    };
+    if expected.as_deref() != Some(req.token.as_str()) {
+        return err_response("unauthorized".to_string());
+    }
+
+    match req.method.as_str() {
+        "control.info" => {
+            let info = match state.info.lock() {
+                Ok(guard) => guard.clone(),
+                Err(err) => return err_response(format!("control info lock: {err}")),
+            };
+            ok_response(json!({ "info": info }))
+        }
+        "status" | "tabs.list" | "models.list" | "accounts.list" => {
+            readonly_response(&req.method, state)
+        }
+        "tabs.open" | "tabs.close" | "tabs.focus" | "chat.send" | "chat.wait" | "accounts.use"
+        | "agent.stop" => forward_to_frontend(app, state, req).await,
+        "eval" | "invoke" | "agent.command" => err_response(
+            "raw debug commands are not available on the release control transport".to_string(),
+        ),
+        other => err_response(format!("unknown control method: {other}")),
+    }
+}
+
+fn readonly_response(method: &str, state: &Arc<ControlState>) -> ControlResponse {
+    let snapshot = match state.frontend_state.lock() {
+        Ok(guard) => guard.clone(),
+        Err(err) => return err_response(format!("frontend state lock: {err}")),
+    };
+    match method {
+        "status" => {
+            let accounts = snapshot
+                .get("authProfiles")
+                .and_then(|a| a.get("profiles"))
+                .and_then(Value::as_array)
+                .map(|a| a.len())
+                .unwrap_or(0);
+            let tabs = snapshot
+                .get("tabs")
+                .and_then(Value::as_array)
+                .map(|a| a.len())
+                .unwrap_or(0);
+            ok_response(json!({
+                "location": snapshot.get("location").cloned().unwrap_or(Value::Null),
+                "status": snapshot.get("status").cloned().unwrap_or(Value::Null),
+                "connection": snapshot.get("connection").cloned().unwrap_or(Value::Null),
+                "waiting": snapshot.get("waiting").cloned().unwrap_or(Value::Bool(false)),
+                "model": snapshot.get("model").cloned().unwrap_or(Value::Null),
+                "activeTabId": snapshot.get("activeTabId").cloned().unwrap_or(Value::Null),
+                "tabs": tabs,
+                "accounts": accounts,
+                "transport": "control",
+            }))
+        }
+        "tabs.list" => ok_response(snapshot.get("tabs").cloned().unwrap_or_else(|| json!([]))),
+        "models.list" => ok_response(snapshot.get("models").cloned().unwrap_or_else(|| json!([]))),
+        "accounts.list" => ok_response(
+            snapshot
+                .get("authProfiles")
+                .cloned()
+                .unwrap_or_else(|| json!({ "profiles": [] })),
+        ),
+        _ => err_response(format!("unknown readonly method: {method}")),
+    }
+}
+
+async fn forward_to_frontend(
+    app: &AppHandle,
+    state: &Arc<ControlState>,
+    req: ControlRequest,
+) -> ControlResponse {
+    let request_id = uuid::Uuid::new_v4().to_string();
+    let (tx, rx) = oneshot::channel();
+    {
+        let mut pending = match state.pending.lock() {
+            Ok(guard) => guard,
+            Err(err) => return err_response(format!("pending lock: {err}")),
+        };
+        pending.insert(request_id.clone(), tx);
+    }
+    let payload = FrontendControlRequest {
+        request_id: request_id.clone(),
+        method: req.method,
+        params: req.params,
+    };
+    if let Err(err) = app.emit("control-request", payload) {
+        let _ = state.pending.lock().map(|mut p| p.remove(&request_id));
+        return err_response(format!("emit control-request: {err}"));
+    }
+    match tokio::time::timeout(REQUEST_TIMEOUT, rx).await {
+        Ok(Ok(done)) if done.success => ok_response(done.data.unwrap_or(Value::Null)),
+        Ok(Ok(done)) => err_response(
+            done.error
+                .unwrap_or_else(|| "control request failed".to_string()),
+        ),
+        Ok(Err(_)) => err_response("control request was cancelled".to_string()),
+        Err(_) => {
+            let _ = state.pending.lock().map(|mut p| p.remove(&request_id));
+            err_response("control request timed out".to_string())
+        }
+    }
+}
+
+fn ok_response(result: Value) -> ControlResponse {
+    ControlResponse {
+        ok: true,
+        result: Some(result),
+        error: None,
+    }
+}
+
+fn err_response(error: String) -> ControlResponse {
+    ControlResponse {
+        ok: false,
+        result: None,
+        error: Some(error),
+    }
+}
+
+fn aethon_control_dir(app: &AppHandle) -> Result<PathBuf, String> {
+    let home = app
+        .path()
+        .home_dir()
+        .map_err(|e| format!("home_dir: {e}"))?;
+    let dir = crate::helpers::aethon_dir(Some(home))
+        .ok_or_else(|| "aethon dir unresolved".to_string())?
+        .join("control");
+    std::fs::create_dir_all(&dir).map_err(|e| format!("create_dir_all {}: {e}", dir.display()))?;
+    Ok(dir)
+}
+
+#[cfg(unix)]
+mod unix {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+    use tokio::net::{UnixListener, UnixStream};
+
+    pub(super) async fn run(app: AppHandle, state: Arc<ControlState>) -> Result<(), String> {
+        let dir = aethon_control_dir(&app)?;
+        let socket_path = dir.join("control.sock");
+        let token_path = dir.join("token");
+        let info_path = dir.join("control.json");
+        let _ = std::fs::remove_file(&socket_path);
+
+        let token = uuid::Uuid::new_v4().to_string();
+        std::fs::write(&token_path, &token)
+            .map_err(|e| format!("write {}: {e}", token_path.display()))?;
+        std::fs::set_permissions(&token_path, std::fs::Permissions::from_mode(0o600))
+            .map_err(|e| format!("chmod {}: {e}", token_path.display()))?;
+
+        let info = ControlInfo {
+            protocol_version: PROTOCOL_VERSION,
+            mode: "local".to_string(),
+            socket_path: socket_path.to_string_lossy().into_owned(),
+            token_path: token_path.to_string_lossy().into_owned(),
+            pid: std::process::id(),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            instance_id: uuid::Uuid::new_v4().to_string(),
+        };
+        std::fs::write(
+            &info_path,
+            serde_json::to_string_pretty(&info).map_err(|e| e.to_string())?,
+        )
+        .map_err(|e| format!("write {}: {e}", info_path.display()))?;
+        std::fs::set_permissions(&info_path, std::fs::Permissions::from_mode(0o600))
+            .map_err(|e| format!("chmod {}: {e}", info_path.display()))?;
+
+        *state.token.lock().map_err(|e| e.to_string())? = Some(token);
+        *state.info.lock().map_err(|e| e.to_string())? = Some(info);
+
+        let listener = UnixListener::bind(&socket_path)
+            .map_err(|e| format!("bind {}: {e}", socket_path.display()))?;
+        std::fs::set_permissions(&socket_path, std::fs::Permissions::from_mode(0o600))
+            .map_err(|e| format!("chmod {}: {e}", socket_path.display()))?;
+        tracing::info!(
+            target: "aethon::control",
+            "control socket listening at {}",
+            socket_path.display()
+        );
+
+        loop {
+            let (stream, _) = listener.accept().await.map_err(|e| e.to_string())?;
+            let app = app.clone();
+            let state = Arc::clone(&state);
+            tauri::async_runtime::spawn(async move {
+                if let Err(err) = handle_stream(app, state, stream).await {
+                    tracing::warn!(target: "aethon::control", "request failed: {err}");
+                }
+            });
+        }
+    }
+
+    async fn handle_stream(
+        app: AppHandle,
+        state: Arc<ControlState>,
+        stream: UnixStream,
+    ) -> Result<(), String> {
+        let (reader, mut writer) = stream.into_split();
+        let mut lines = BufReader::new(reader).lines();
+        let Some(line) = lines.next_line().await.map_err(|e| e.to_string())? else {
+            return Ok(());
+        };
+        let response = match serde_json::from_str::<ControlRequest>(&line) {
+            Ok(req) => handle_request(&app, &state, req).await,
+            Err(err) => err_response(format!("invalid control request: {err}")),
+        };
+        let body = serde_json::to_vec(&response).map_err(|e| e.to_string())?;
+        writer.write_all(&body).await.map_err(|e| e.to_string())?;
+        writer.write_all(b"\n").await.map_err(|e| e.to_string())?;
+        writer.shutdown().await.map_err(|e| e.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn readonly_status_counts_tabs_and_accounts() {
+        let state = Arc::new(ControlState::default());
+        *state.frontend_state.lock().unwrap() = json!({
+            "status": "ready",
+            "connection": "connected",
+            "waiting": false,
+            "model": "openai-codex/gpt-5.5",
+            "activeTabId": "t1",
+            "tabs": [{ "id": "t1" }, { "id": "t2" }],
+            "authProfiles": { "profiles": [{ "id": "p1" }] }
+        });
+        let response = readonly_response("status", &state);
+        assert!(response.ok);
+        let result = response.result.unwrap();
+        assert_eq!(result["tabs"], 2);
+        assert_eq!(result["accounts"], 1);
+        assert_eq!(result["transport"], "control");
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -34,6 +34,7 @@ mod agent_commands;
 pub(crate) mod agent_process;
 mod boot_probation;
 mod commands;
+mod control;
 mod devshell;
 mod env;
 mod helpers;
@@ -141,8 +142,10 @@ pub fn run() {
             );
         }
     }
+    let control_state = Arc::new(control::ControlState::default());
     let builder = builder
         .manage(agent_process::AgentProcesses::new())
+        .manage(Arc::clone(&control_state))
         .manage(shell::ShellRegistry::new())
         .manage(commands::fs::FsWatchState::default())
         .manage(commands::git::GitFetchState::default())
@@ -186,6 +189,8 @@ pub fn run() {
             agent_commands::agent_diagnostics,
             agent_commands::reconcile_agent_workers,
             agent_commands::dispatch_a2ui_event,
+            control::control_update_state,
+            control::control_request_complete,
             paste::save_paste_image,
             paste::read_paste_image_base64,
             commands::config::read_state,
@@ -314,11 +319,12 @@ pub fn run() {
         ]);
 
     let app = builder
-        .setup(|app| {
+        .setup(move |app| {
             agent_process::cleanup_orphaned_dev_agents();
             if let Some(watcher) = commands::extensions::start_agent_watcher(app.handle().clone()) {
                 app.manage(watcher);
             }
+            control::start_control_server(app.handle().clone(), Arc::clone(&control_state));
             #[cfg(debug_assertions)]
             debug::start_debug_server(app.handle().clone());
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ import { useWorkspacePrompts } from "./hooks/useWorkspacePrompts";
 import { useFocus } from "./hooks/useFocus";
 import { useChat } from "./hooks/useChat";
 import { useQueuedDispatch } from "./hooks/useQueuedDispatch";
+import { useControlRequests } from "./hooks/useControlRequests";
 import { useFrontendStateMirror } from "./hooks/useFrontendStateMirror";
 import { usePersistEditorTabs } from "./hooks/usePersistEditorTabs";
 import { useUiOverlays } from "./hooks/useUiOverlays";
@@ -622,6 +623,17 @@ export default function App() {
     recordProjectModel,
     piDefaultModelRef,
     findTabById: findTabRouted,
+  });
+
+  useControlRequests({
+    stateRef,
+    pendingTabOpens,
+    newTab,
+    closeTabNow,
+    setActiveTab,
+    updateTab: updateTabRouted,
+    sendChat,
+    stopPrompt,
   });
 
   useScheduledTasks({

--- a/src/hooks/bridgeMessageHandlers/error.ts
+++ b/src/hooks/bridgeMessageHandlers/error.ts
@@ -1,10 +1,16 @@
 import { closeRunningToolCards } from "../../utils/agentBusy";
+import { resolveControlWait } from "../controlWaitRegistry";
 import { clearHangWarn } from "./hangWarn";
 import type { BridgeMessageHandler } from "./types";
 
 export const handleError: BridgeMessageHandler = (data, ctx) => {
   const message = (data.message as string) ?? "unknown error";
   const tabId = (data.tabId as string | undefined) ?? "default";
+  // A control-dispatched turn that errors must unblock its `--wait` caller too,
+  // surfacing the failure rather than hanging until the timeout.
+  if (typeof data.controlRequestId === "string" && data.controlRequestId) {
+    resolveControlWait(data.controlRequestId, "error", tabId, message);
+  }
   ctx.activeResponseIdRef.current = null;
   ctx.appendMessage(
     { id: crypto.randomUUID(), role: "agent", text: `Error: ${message}` },

--- a/src/hooks/bridgeMessageHandlers/promptStarted.ts
+++ b/src/hooks/bridgeMessageHandlers/promptStarted.ts
@@ -1,3 +1,4 @@
+import { markControlTurnStarted } from "../controlWaitRegistry";
 import type { BridgeMessageHandler } from "./types";
 import { armHangWarn } from "./hangWarn";
 
@@ -9,6 +10,12 @@ import { armHangWarn } from "./hangWarn";
  *  bar text only flips for the active tab. */
 export const handlePromptStarted: BridgeMessageHandler = (data, ctx) => {
   const tabId = (data.tabId as string | undefined) ?? "default";
+  // A control-dispatched send that produced a real turn echoes its id here.
+  // The wait fallback uses this to tell a genuine turn apart from a locally
+  // handled slash command (which never reaches the bridge).
+  if (typeof data.controlRequestId === "string" && data.controlRequestId) {
+    markControlTurnStarted(data.controlRequestId);
+  }
   // Record turn start so response_end can compute duration and decide
   // whether to fire the OS completion notification.
   ctx.turnStartedAtRef.current.set(tabId, Date.now());

--- a/src/hooks/bridgeMessageHandlers/responseEnd.ts
+++ b/src/hooks/bridgeMessageHandlers/responseEnd.ts
@@ -1,6 +1,7 @@
 import { closeRunningToolCards } from "../../utils/agentBusy";
 import { emitAgentTurnComplete } from "../../utils/agentTurnEvents";
 import { lastAgentText } from "../../utils/messages";
+import { resolveControlWait } from "../controlWaitRegistry";
 import type { BridgeMessageHandler } from "./types";
 import { clearHangWarn } from "./hangWarn";
 import { flushResponseDeltas } from "./responseDelta";
@@ -8,6 +9,12 @@ import { flushResponseDeltas } from "./responseDelta";
 export const handleResponseEnd: BridgeMessageHandler = (data, ctx) => {
   ctx.activeResponseIdRef.current = null;
   const tabId = (data.tabId as string | undefined) ?? "default";
+  // Release-control `chat.send --wait` waiters key off the opaque id the
+  // bridge echoes here. Resolve before the state work so the CLI unblocks the
+  // instant the turn ends.
+  if (typeof data.controlRequestId === "string" && data.controlRequestId) {
+    resolveControlWait(data.controlRequestId, "completed", tabId);
+  }
   flushResponseDeltas(tabId);
   // Always clear waiting on response_end. The queue is now held client
   // side: `useQueuedDispatch` watches the `waiting` transition and

--- a/src/hooks/bridgeMessageHandlers/types.ts
+++ b/src/hooks/bridgeMessageHandlers/types.ts
@@ -86,6 +86,7 @@ export interface BridgeMessageContext {
       restoredSession?: boolean;
       cwd?: string;
       scrollToMatch?: string;
+      model?: string;
     },
   ) => void;
   /** Open (or focus) a Monaco editor tab. Used by the agent-side

--- a/src/hooks/controlWaitRegistry.test.ts
+++ b/src/hooks/controlWaitRegistry.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  cancelControlWait,
+  registerControlWait,
+  resolveControlWait,
+} from "./controlWaitRegistry";
+
+describe("controlWaitRegistry", () => {
+  it("resolves a registered wait when the turn completes", async () => {
+    const pending = registerControlWait("req-1", "t1", 10_000);
+    expect(resolveControlWait("req-1", "completed", "t1")).toBe(true);
+    await expect(pending).resolves.toMatchObject({
+      waiting: false,
+      outcome: "completed",
+      tabId: "t1",
+    });
+  });
+
+  it("surfaces an error outcome with its message", async () => {
+    const pending = registerControlWait("req-2", "t1", 10_000);
+    resolveControlWait("req-2", "error", "t1", "boom");
+    await expect(pending).resolves.toMatchObject({
+      waiting: false,
+      outcome: "error",
+      error: "boom",
+    });
+  });
+
+  it("resolves as a timeout when the turn never ends", async () => {
+    vi.useFakeTimers();
+    try {
+      const pending = registerControlWait("req-3", "t1", 1_000);
+      vi.advanceTimersByTime(1_001);
+      await expect(pending).resolves.toMatchObject({
+        waiting: true,
+        outcome: "timeout",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("is a no-op for an unknown id", () => {
+    expect(resolveControlWait("never-registered", "completed", "t1")).toBe(
+      false,
+    );
+  });
+
+  it("cancel resolves the waiter as a timeout so it can't leak", async () => {
+    const pending = registerControlWait("req-4", "t1", 10_000);
+    cancelControlWait("req-4");
+    await expect(pending).resolves.toMatchObject({
+      waiting: true,
+      outcome: "timeout",
+    });
+  });
+});

--- a/src/hooks/controlWaitRegistry.test.ts
+++ b/src/hooks/controlWaitRegistry.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   cancelControlWait,
+  hasControlTurnStarted,
+  markControlTurnStarted,
   registerControlWait,
   resolveControlWait,
 } from "./controlWaitRegistry";
@@ -53,5 +55,18 @@ describe("controlWaitRegistry", () => {
       waiting: true,
       outcome: "timeout",
     });
+  });
+
+  it("tracks whether a real turn started for a registered id", () => {
+    expect(hasControlTurnStarted("req-5")).toBe(false);
+    const pending = registerControlWait("req-5", "t1", 10_000);
+    expect(hasControlTurnStarted("req-5")).toBe(false);
+    markControlTurnStarted("req-5");
+    expect(hasControlTurnStarted("req-5")).toBe(true);
+    // markControlTurnStarted is a no-op for unknown ids.
+    markControlTurnStarted("not-registered");
+    expect(hasControlTurnStarted("not-registered")).toBe(false);
+    resolveControlWait("req-5", "completed", "t1");
+    return pending;
   });
 });

--- a/src/hooks/controlWaitRegistry.ts
+++ b/src/hooks/controlWaitRegistry.ts
@@ -1,0 +1,107 @@
+// Deterministic completion for release-control `chat.send --wait`.
+//
+// The bridge echoes the opaque `controlRequestId` supplied by a control client
+// on the turn's terminal events (`response_end` / `error`). Instead of polling
+// the optimistic `waiting` flag — which can miss a fast turn and imposes an
+// artificial timeout ceiling — a waiter registers its id here BEFORE the chat
+// is dispatched, and the bridge-message handlers resolve it the moment the
+// matching terminal event lands. That makes the wait exact and unbounded by
+// anything but the caller-supplied timeout, so multi-minute agent turns no
+// longer report a false timeout.
+
+export interface ControlWaitResult {
+  waiting: boolean;
+  tabId: string;
+  outcome: "completed" | "error" | "timeout";
+  elapsedMs: number;
+  error?: string;
+}
+
+interface PendingControlWait {
+  tabId: string;
+  startedAt: number;
+  resolve: (result: ControlWaitResult) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+const pending = new Map<string, PendingControlWait>();
+
+/**
+ * Register interest in a control turn's completion. Must be called before the
+ * chat is dispatched so the terminal event can't race ahead of registration.
+ * Resolves when {@link resolveControlWait} fires for `requestId`, or after
+ * `timeoutMs` with `{ waiting: true, outcome: "timeout" }`.
+ */
+export function registerControlWait(
+  requestId: string,
+  tabId: string,
+  timeoutMs: number,
+  now: number = Date.now(),
+): Promise<ControlWaitResult> {
+  // A duplicate id (shouldn't happen — ids are unique per request) resolves the
+  // older waiter as a timeout so it can't leak.
+  pending.get(requestId)?.resolve({
+    waiting: true,
+    tabId,
+    outcome: "timeout",
+    elapsedMs: 0,
+  });
+  return new Promise<ControlWaitResult>((resolve) => {
+    const timer = setTimeout(() => {
+      const entry = pending.get(requestId);
+      pending.delete(requestId);
+      resolve({
+        waiting: true,
+        tabId,
+        outcome: "timeout",
+        elapsedMs: Date.now() - (entry?.startedAt ?? now),
+      });
+    }, timeoutMs);
+    // Don't keep the process alive on this timer (no-op in the browser, guards
+    // any node-based test runner).
+    (timer as { unref?: () => void }).unref?.();
+    pending.set(requestId, { tabId, startedAt: now, resolve, timer });
+  });
+}
+
+/**
+ * Resolve a registered control wait. Called by the `response_end` / `error`
+ * bridge-message handlers when the turn they carry was started by a control
+ * client (non-empty `controlRequestId`). A no-op for unknown ids — most turns
+ * are UI-driven and carry no id.
+ */
+export function resolveControlWait(
+  requestId: string,
+  outcome: "completed" | "error",
+  tabId: string,
+  error?: string,
+  now: number = Date.now(),
+): boolean {
+  const entry = pending.get(requestId);
+  if (!entry) return false;
+  pending.delete(requestId);
+  clearTimeout(entry.timer);
+  entry.resolve({
+    waiting: false,
+    tabId: tabId || entry.tabId,
+    outcome,
+    elapsedMs: now - entry.startedAt,
+    ...(error ? { error } : {}),
+  });
+  return true;
+}
+
+/** Cancel a wait without resolving its promise's consumer path — used when the
+ *  dispatch that the wait was registered for fails before the turn starts. */
+export function cancelControlWait(requestId: string): void {
+  const entry = pending.get(requestId);
+  if (!entry) return;
+  pending.delete(requestId);
+  clearTimeout(entry.timer);
+  entry.resolve({
+    waiting: true,
+    tabId: entry.tabId,
+    outcome: "timeout",
+    elapsedMs: 0,
+  });
+}

--- a/src/hooks/controlWaitRegistry.ts
+++ b/src/hooks/controlWaitRegistry.ts
@@ -12,7 +12,7 @@
 export interface ControlWaitResult {
   waiting: boolean;
   tabId: string;
-  outcome: "completed" | "error" | "timeout";
+  outcome: "completed" | "error" | "timeout" | "idle";
   elapsedMs: number;
   error?: string;
 }
@@ -20,6 +20,9 @@ export interface ControlWaitResult {
 interface PendingControlWait {
   tabId: string;
   startedAt: number;
+  /** Set once the bridge echoes a `prompt_started` for this id, i.e. the send
+   *  actually produced an agent turn (vs. a locally-handled slash command). */
+  turnStarted: boolean;
   resolve: (result: ControlWaitResult) => void;
   timer: ReturnType<typeof setTimeout>;
 }
@@ -60,8 +63,30 @@ export function registerControlWait(
     // Don't keep the process alive on this timer (no-op in the browser, guards
     // any node-based test runner).
     (timer as { unref?: () => void }).unref?.();
-    pending.set(requestId, { tabId, startedAt: now, resolve, timer });
+    pending.set(requestId, {
+      tabId,
+      startedAt: now,
+      turnStarted: false,
+      resolve,
+      timer,
+    });
   });
+}
+
+/**
+ * Mark that the bridge echoed a `prompt_started` for this control turn — i.e.
+ * the send produced a real agent turn. The idle-poll fallback uses this to tell
+ * a genuine (possibly unobservable) turn apart from a locally-handled slash
+ * command that never reaches the bridge. A no-op for unknown ids.
+ */
+export function markControlTurnStarted(requestId: string): void {
+  const entry = pending.get(requestId);
+  if (entry) entry.turnStarted = true;
+}
+
+/** True once a `prompt_started` has been seen for this id. */
+export function hasControlTurnStarted(requestId: string): boolean {
+  return pending.get(requestId)?.turnStarted ?? false;
 }
 
 /**

--- a/src/hooks/tabOps/types.ts
+++ b/src/hooks/tabOps/types.ts
@@ -87,6 +87,7 @@ export interface UseTabsActions {
       restoredSession?: boolean;
       cwd?: string;
       scrollToMatch?: string;
+      model?: string;
     },
   ) => void;
   newShellTab: (options?: {

--- a/src/hooks/useAppSlashCommandContext.test.ts
+++ b/src/hooks/useAppSlashCommandContext.test.ts
@@ -246,4 +246,84 @@ describe("useAppSlashCommandContext", () => {
       },
     ]);
   });
+
+  it("login `use` switches a worker tab via both use_for_tab and apply", async () => {
+    const { result } = renderHook(() =>
+      useAppSlashCommandContext({
+        bootLayout: { components: [] },
+        setState: vi.fn(),
+        setLayout: vi.fn(),
+        stateRef: ref({
+          activeTabId: "tab-1",
+          tabs: [
+            {
+              id: "tab-1",
+              kind: "agent",
+              cwd: "/repo",
+              model: "openai-codex/gpt-5.5",
+              waiting: false,
+              messages: [],
+              queueCount: 0,
+              queuedMessages: [],
+            },
+          ],
+          authProfiles: {
+            profiles: [
+              {
+                id: "openai-codex-secondary",
+                label: "Secondary",
+                providerId: "openai-codex",
+                kind: "oauth",
+                createdAt: 1,
+                updatedAt: 1,
+              },
+            ],
+          },
+        }),
+        projectsRef: ref(makeProjects()),
+        layoutCatalogueRef: ref([]),
+        registry: new ExtensionRegistry(),
+        appendMessage: vi.fn(),
+        pushNotification: vi.fn(() => "toast-1"),
+        clearChat: vi.fn(),
+        setTheme: vi.fn(),
+        listThemes: vi.fn(() => []),
+        setModel: vi.fn(() => Promise.resolve()),
+        toggleTerminal: vi.fn(),
+        toggleSidebar: vi.fn(),
+        toggleFilesSidebar: vi.fn(),
+        activateLayoutById: vi.fn(() => true),
+        openProjectFromPicker: vi.fn(() => Promise.resolve(null)),
+        openProjectByPath: vi.fn((path: string) => path),
+        setActiveProjectById: vi.fn(() => true),
+        clearActiveProject: vi.fn(),
+        removeProjectById: vi.fn(() => true),
+      }),
+    );
+
+    await act(async () => {
+      await result.current
+        .slashContext()
+        .useAuthProfile("openai-codex-secondary");
+    });
+
+    // A worker tab needs both the global mapping AND the tab-scoped worker
+    // re-auth; use_for_tab alone would leave the worker on the old account.
+    expect(invokeMock).toHaveBeenCalledWith("agent_command", {
+      payload: JSON.stringify({
+        type: "auth_profile_use_for_tab",
+        tabId: "tab-1",
+        profileId: "openai-codex-secondary",
+      }),
+    });
+    expect(invokeMock).toHaveBeenCalledWith("agent_command", {
+      payload: JSON.stringify({
+        type: "auth_profile_apply",
+        tabId: "tab-1",
+        profileId: "openai-codex-secondary",
+        cwd: "/repo",
+        model: "openai-codex/gpt-5.5",
+      }),
+    });
+  });
 });

--- a/src/hooks/useAppSlashCommandContext.ts
+++ b/src/hooks/useAppSlashCommandContext.ts
@@ -14,7 +14,11 @@ import type { SlashCommandContext } from "../slashCommands";
 import type { ExtensionRegistry } from "../extensions/ExtensionRegistry";
 import type { LayoutCatalogueEntry } from "../extensions/default-layout";
 import type { NotificationInput } from "./useNotifications";
-import type { AuthProfilesUiState } from "../auth-profiles";
+import {
+  resolveAccountSwitchTarget,
+  switchAccountForTab,
+  type AuthProfilesUiState,
+} from "../auth-profiles";
 import {
   cancelScheduledTask,
   createScheduledTask,
@@ -220,16 +224,24 @@ export function useAppSlashCommandContext({
           (p) => p.id === idOrLabel || p.label === idOrLabel,
         );
         if (!profile) throw new Error(`Unknown account: ${idOrLabel}`);
-        const activeId = stateRef.current.activeTabId;
-        await invoke("agent_command", {
-          payload: JSON.stringify({
-            type: "auth_profile_use_for_tab",
-            tabId:
-              typeof activeId === "string" && activeId.length > 0
-                ? activeId
-                : "default",
-            profileId: profile.id,
-          }),
+        const activeId =
+          typeof stateRef.current.activeTabId === "string"
+            ? stateRef.current.activeTabId
+            : undefined;
+        // Route through the shared switch so a non-default (worker) tab also
+        // gets the tab-scoped `auth_profile_apply` — `auth_profile_use_for_tab`
+        // alone updates only the global mapping, leaving the worker on the old
+        // account for its next prompt.
+        const target = resolveAccountSwitchTarget(
+          (stateRef.current.tabs as Tab[] | undefined) ?? [],
+          activeId,
+        );
+        if (target.busy) {
+          throw new Error("Stop the current prompt before switching accounts");
+        }
+        await switchAccountForTab(target.tabId, profile.id, {
+          cwd: target.cwd,
+          model: target.model,
         });
       },
       setDefaultAuthProfile: async (idOrLabel: string) => {

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -115,6 +115,7 @@ export interface UseChatActions {
       tabId?: string;
       attachments?: ChatAttachment[];
       bridgeText?: string;
+      controlRequestId?: string;
     },
   ) => Promise<void>;
   setModel: (id: string) => Promise<void>;
@@ -472,6 +473,7 @@ export function useChat(ctx: UseChatContext): UseChatActions {
       tabId?: string;
       attachments?: ChatAttachment[];
       bridgeText?: string;
+      controlRequestId?: string;
     },
   ) {
     const trimmed = text.trim();
@@ -661,6 +663,9 @@ export function useChat(ctx: UseChatContext): UseChatActions {
           // default (which could be the account the user switched away from).
           ...(targetTab?.authProfileId
             ? { authProfileId: targetTab.authProfileId }
+            : {}),
+          ...(options?.controlRequestId
+            ? { controlRequestId: options.controlRequestId }
             : {}),
         },
       });

--- a/src/hooks/useControlRequests.test.ts
+++ b/src/hooks/useControlRequests.test.ts
@@ -4,6 +4,7 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { installTauriMocks, type TauriMockHarness } from "../test/tauriMocks";
 import type { Tab } from "../types/tab";
+import { resolveControlWait } from "./controlWaitRegistry";
 import { useControlRequests } from "./useControlRequests";
 
 function tab(patch: Partial<Tab> = {}): Tab {
@@ -124,5 +125,93 @@ describe("useControlRequests", () => {
         }),
       ),
     );
+  });
+
+  it("blocks chat.send --wait until the turn's terminal event resolves it", async () => {
+    const stateRef = { current: { activeTabId: "t1", tabs: [tab()] } };
+    const sendChat = vi.fn(() => Promise.resolve());
+    renderHook(() =>
+      useControlRequests({
+        stateRef,
+        pendingTabOpens: { current: new Map() },
+        newTab: vi.fn(),
+        closeTabNow: vi.fn(),
+        setActiveTab: vi.fn(),
+        updateTab: vi.fn(),
+        sendChat,
+        stopPrompt: vi.fn(),
+      }),
+    );
+
+    harness.fireEvent("control-request", {
+      requestId: "control-wait",
+      method: "chat.send",
+      params: { message: "go", tabId: "active", wait: true, timeoutMs: 10_000 },
+    });
+
+    // The chat is dispatched immediately, but the control request must NOT
+    // complete until the matching terminal event lands.
+    await waitFor(() =>
+      expect(sendChat).toHaveBeenCalledWith("go", {
+        tabId: "t1",
+        controlRequestId: "control-wait",
+      }),
+    );
+    expect(harness.invoke).not.toHaveBeenCalledWith(
+      "control_request_complete",
+      expect.objectContaining({ requestId: "control-wait" }),
+    );
+
+    // The bridge handler resolves the wait when response_end echoes the id.
+    resolveControlWait("control-wait", "completed", "t1");
+
+    await waitFor(() =>
+      expect(harness.invoke).toHaveBeenCalledWith(
+        "control_request_complete",
+        expect.objectContaining({
+          requestId: "control-wait",
+          success: true,
+          data: expect.objectContaining({
+            sent: true,
+            tabId: "t1",
+            wait: expect.objectContaining({ outcome: "completed" }),
+          }),
+        }),
+      ),
+    );
+  });
+
+  it("applies --plan / --thinking-level onto the target tab before dispatch", async () => {
+    const stateRef = { current: { activeTabId: "t1", tabs: [tab()] } };
+    const updateTab = vi.fn();
+    const sendChat = vi.fn(() => Promise.resolve());
+    renderHook(() =>
+      useControlRequests({
+        stateRef,
+        pendingTabOpens: { current: new Map() },
+        newTab: vi.fn(),
+        closeTabNow: vi.fn(),
+        setActiveTab: vi.fn(),
+        updateTab,
+        sendChat,
+        stopPrompt: vi.fn(),
+      }),
+    );
+
+    harness.fireEvent("control-request", {
+      requestId: "control-opts",
+      method: "chat.send",
+      params: {
+        message: "x",
+        tabId: "active",
+        planMode: true,
+        thinkingLevel: "high",
+      },
+    });
+
+    await waitFor(() => expect(sendChat).toHaveBeenCalled());
+    const mutator = updateTab.mock.calls.find((call) => call[0] === "t1")?.[1];
+    expect(mutator).toBeTypeOf("function");
+    expect(mutator(tab())).toMatchObject({ planMode: true, thinkingLevel: "high" });
   });
 });

--- a/src/hooks/useControlRequests.test.ts
+++ b/src/hooks/useControlRequests.test.ts
@@ -231,6 +231,52 @@ describe("useControlRequests", () => {
     );
   });
 
+  it("returns promptly for a waited send that produces no turn (local slash)", async () => {
+    // `chat send --wait /clear` is handled locally by sendChat: no bridge turn,
+    // the tab never goes busy, and no controlRequestId is ever echoed. The wait
+    // must return via the grace path instead of blocking to the full timeout.
+    const stateRef = { current: { activeTabId: "t1", tabs: [tab()] } };
+    const sendChat = vi.fn(() => Promise.resolve());
+    renderHook(() =>
+      useControlRequests({
+        stateRef,
+        pendingTabOpens: { current: new Map() },
+        newTab: vi.fn(),
+        closeTabNow: vi.fn(),
+        setActiveTab: vi.fn(),
+        updateTab: vi.fn(),
+        sendChat,
+        stopPrompt: vi.fn(),
+      }),
+    );
+
+    harness.fireEvent("control-request", {
+      requestId: "control-local",
+      method: "chat.send",
+      params: {
+        message: "/clear",
+        tabId: "active",
+        wait: true,
+        timeoutMs: 600_000,
+      },
+    });
+
+    await waitFor(
+      () =>
+        expect(harness.invoke).toHaveBeenCalledWith(
+          "control_request_complete",
+          expect.objectContaining({
+            requestId: "control-local",
+            success: true,
+            data: expect.objectContaining({
+              wait: expect.objectContaining({ outcome: "idle" }),
+            }),
+          }),
+        ),
+      { timeout: 4000 },
+    );
+  });
+
   it("applies --plan / --thinking-level onto the target tab before dispatch", async () => {
     const stateRef = { current: { activeTabId: "t1", tabs: [tab()] } };
     const updateTab = vi.fn();

--- a/src/hooks/useControlRequests.test.ts
+++ b/src/hooks/useControlRequests.test.ts
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { installTauriMocks, type TauriMockHarness } from "../test/tauriMocks";
+import type { Tab } from "../types/tab";
+import { useControlRequests } from "./useControlRequests";
+
+function tab(patch: Partial<Tab> = {}): Tab {
+  return {
+    id: "t1",
+    kind: "agent",
+    label: "Tab 1",
+    projectId: null,
+    messages: [],
+    draft: "",
+    waiting: false,
+    queueCount: 0,
+    queuedMessages: [],
+    canvas: null,
+    model: "openai-codex/gpt-5.5",
+    terminalBuffer: "",
+    cwd: "/repo",
+    ...patch,
+  };
+}
+
+describe("useControlRequests", () => {
+  let harness: TauriMockHarness;
+
+  beforeEach(() => {
+    harness = installTauriMocks();
+  });
+
+  it("switches the requested account before dispatching a controlled chat turn", async () => {
+    const stateRef = { current: { activeTabId: "t1", tabs: [tab()] } };
+    const sendChat = vi.fn(() => Promise.resolve());
+    const updateTab = vi.fn((tabId: string, updater: (t: Tab) => Tab) => {
+      stateRef.current.tabs = stateRef.current.tabs.map((candidate) =>
+        candidate.id === tabId ? updater(candidate) : candidate,
+      );
+    });
+    renderHook(() =>
+      useControlRequests({
+        stateRef,
+        pendingTabOpens: { current: new Map() },
+        newTab: vi.fn(),
+        closeTabNow: vi.fn(),
+        setActiveTab: vi.fn(),
+        updateTab,
+        sendChat,
+        stopPrompt: vi.fn(),
+      }),
+    );
+
+    harness.fireEvent("control-request", {
+      requestId: "control-1",
+      method: "chat.send",
+      params: {
+        message: "hello",
+        tabId: "active",
+        account: "openai-codex-secondary",
+      },
+    });
+
+    await waitFor(() =>
+      expect(sendChat).toHaveBeenCalledWith("hello", {
+        tabId: "t1",
+        controlRequestId: "control-1",
+      }),
+    );
+    expect(harness.invoke).toHaveBeenCalledWith("agent_command", {
+      payload: JSON.stringify({
+        type: "auth_profile_use_for_tab",
+        tabId: "t1",
+        profileId: "openai-codex-secondary",
+      }),
+    });
+    expect(harness.invoke).toHaveBeenCalledWith("agent_command", {
+      payload: JSON.stringify({
+        type: "auth_profile_apply",
+        tabId: "t1",
+        profileId: "openai-codex-secondary",
+        cwd: "/repo",
+        model: "openai-codex/gpt-5.5",
+      }),
+    });
+    await waitFor(() =>
+      expect(harness.invoke).toHaveBeenCalledWith("control_request_complete", {
+        requestId: "control-1",
+        success: true,
+        data: { sent: true, tabId: "t1", account: "openai-codex-secondary" },
+      }),
+    );
+  });
+
+  it("rejects account switches while the target tab is busy", async () => {
+    const stateRef = { current: { activeTabId: "t1", tabs: [tab({ waiting: true })] } };
+    renderHook(() =>
+      useControlRequests({
+        stateRef,
+        pendingTabOpens: { current: new Map() },
+        newTab: vi.fn(),
+        closeTabNow: vi.fn(),
+        setActiveTab: vi.fn(),
+        updateTab: vi.fn(),
+        sendChat: vi.fn(),
+        stopPrompt: vi.fn(),
+      }),
+    );
+
+    harness.fireEvent("control-request", {
+      requestId: "control-2",
+      method: "accounts.use",
+      params: { profileId: "openai-codex-secondary", tabId: "active" },
+    });
+
+    await waitFor(() =>
+      expect(harness.invoke).toHaveBeenCalledWith(
+        "control_request_complete",
+        expect.objectContaining({
+          requestId: "control-2",
+          success: false,
+        }),
+      ),
+    );
+  });
+});

--- a/src/hooks/useControlRequests.test.ts
+++ b/src/hooks/useControlRequests.test.ts
@@ -181,6 +181,56 @@ describe("useControlRequests", () => {
     );
   });
 
+  it("falls back to an idle poll when a waited send is queued (no echoed id)", async () => {
+    // A send to a busy tab is queued client-side and drained later WITHOUT the
+    // controlRequestId, so the deterministic waiter never fires. The wait must
+    // still resolve when the tab drains to idle.
+    const stateRef = {
+      current: { activeTabId: "t1", tabs: [tab({ waiting: true })] },
+    };
+    const sendChat = vi.fn(() => {
+      // Simulate the queued turn draining shortly after dispatch.
+      setTimeout(() => {
+        stateRef.current = { activeTabId: "t1", tabs: [tab({ waiting: false })] };
+      }, 30);
+      return Promise.resolve();
+    });
+    renderHook(() =>
+      useControlRequests({
+        stateRef,
+        pendingTabOpens: { current: new Map() },
+        newTab: vi.fn(),
+        closeTabNow: vi.fn(),
+        setActiveTab: vi.fn(),
+        updateTab: vi.fn(),
+        sendChat,
+        stopPrompt: vi.fn(),
+      }),
+    );
+
+    harness.fireEvent("control-request", {
+      requestId: "control-queued",
+      method: "chat.send",
+      params: { message: "later", tabId: "active", wait: true, timeoutMs: 10_000 },
+    });
+
+    // Resolves via the poll (never via resolveControlWait) once the tab is idle.
+    await waitFor(
+      () =>
+        expect(harness.invoke).toHaveBeenCalledWith(
+          "control_request_complete",
+          expect.objectContaining({
+            requestId: "control-queued",
+            success: true,
+            data: expect.objectContaining({
+              wait: expect.objectContaining({ waiting: false }),
+            }),
+          }),
+        ),
+      { timeout: 4000 },
+    );
+  });
+
   it("applies --plan / --thinking-level onto the target tab before dispatch", async () => {
     const stateRef = { current: { activeTabId: "t1", tabs: [tab()] } };
     const updateTab = vi.fn();

--- a/src/hooks/useControlRequests.ts
+++ b/src/hooks/useControlRequests.ts
@@ -1,0 +1,283 @@
+import { useEffect, type MutableRefObject } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import {
+  switchAccountForTab,
+  type AccountSwitchTarget,
+} from "../auth-profiles/commands";
+import { OVERVIEW_TAB_ID, type Tab } from "../types/tab";
+import { isAgentTabBusy } from "../utils/agentBusy";
+
+export interface ControlRequestPayload {
+  requestId: string;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+export interface UseControlRequestsContext {
+  stateRef: MutableRefObject<Record<string, unknown>>;
+  pendingTabOpens: MutableRefObject<Map<string, Promise<unknown>>>;
+  newTab: (
+    tabId?: string,
+    label?: string,
+    options?: { cwd?: string; model?: string; restoredSession?: boolean },
+  ) => void;
+  closeTabNow: (tabId: string) => void;
+  setActiveTab: (tabId: string) => void;
+  updateTab: (tabId: string, updater: (tab: Tab) => Tab) => void;
+  sendChat: (
+    text: string,
+    options?: { tabId?: string; bridgeText?: string; controlRequestId?: string },
+  ) => Promise<void>;
+  stopPrompt: (tabId?: string) => Promise<void>;
+}
+
+export function useControlRequests(ctx: UseControlRequestsContext): void {
+  useEffect(() => {
+    let disposed = false;
+    const unlisten = listen<ControlRequestPayload>(
+      "control-request",
+      async (event) => {
+        const request = event.payload;
+        if (!request?.requestId) return;
+        try {
+          const data = await handleControlRequest(ctx, request);
+          if (!disposed) {
+            await completeControlRequest(request.requestId, true, data);
+          }
+        } catch (err) {
+          if (!disposed) {
+            await completeControlRequest(
+              request.requestId,
+              false,
+              undefined,
+              err instanceof Error ? err.message : String(err),
+            );
+          }
+        }
+      },
+    );
+    return () => {
+      disposed = true;
+      unlisten.then((fn) => fn());
+    };
+  }, [ctx]);
+}
+
+async function completeControlRequest(
+  requestId: string,
+  success: boolean,
+  data?: unknown,
+  error?: string,
+): Promise<void> {
+  await invoke("control_request_complete", {
+    requestId,
+    success,
+    ...(data !== undefined ? { data } : {}),
+    ...(error ? { error } : {}),
+  });
+}
+
+async function handleControlRequest(
+  ctx: UseControlRequestsContext,
+  request: ControlRequestPayload,
+): Promise<unknown> {
+  const params = request.params ?? {};
+  switch (request.method) {
+    case "tabs.open":
+      return openTab(ctx, params);
+    case "tabs.close":
+      return closeTab(ctx, params);
+    case "tabs.focus":
+      return focusTab(ctx, params);
+    case "accounts.use":
+      return applyAccount(ctx, params);
+    case "chat.send":
+      return sendChat(ctx, request.requestId, params);
+    case "chat.wait":
+      return waitForIdle(ctx, params);
+    case "agent.stop":
+      return stopAgent(ctx, params);
+    default:
+      throw new Error(`unsupported control request: ${request.method}`);
+  }
+}
+
+async function openTab(
+  ctx: UseControlRequestsContext,
+  params: Record<string, unknown>,
+): Promise<unknown> {
+  const tabId = stringParam(params, "tabId") ?? crypto.randomUUID();
+  const label = stringParam(params, "label") ?? "CLI";
+  const cwd = stringParam(params, "cwd");
+  const model = stringParam(params, "model");
+  const account = stringParam(params, "account");
+  ctx.newTab(tabId, label, { cwd, model });
+  await ctx.pendingTabOpens.current.get(tabId);
+  if (account) {
+    await switchAccountForTab(tabId, account, { cwd, model });
+    ctx.updateTab(tabId, (tab) => ({ ...tab, authProfileId: account }));
+  }
+  return { id: tabId, kind: "agent", label, cwd, model, authProfileId: account };
+}
+
+function closeTab(
+  ctx: UseControlRequestsContext,
+  params: Record<string, unknown>,
+): unknown {
+  const tabId = requiredString(params, "tabId", "tabs.close requires tabId");
+  ctx.closeTabNow(tabId);
+  return { closed: tabId };
+}
+
+function focusTab(
+  ctx: UseControlRequestsContext,
+  params: Record<string, unknown>,
+): unknown {
+  const tabId = requiredString(params, "tabId", "tabs.focus requires tabId");
+  ctx.setActiveTab(tabId);
+  return { activeTabId: tabId };
+}
+
+async function applyAccount(
+  ctx: UseControlRequestsContext,
+  params: Record<string, unknown>,
+): Promise<unknown> {
+  const profileId = requiredString(params, "profileId", "accounts.use requires profileId");
+  const target = resolveControlAccountTarget(ctx, stringParam(params, "tabId") ?? "active");
+  if (target.busy) {
+    throw new Error(`tab ${target.tabId} is busy; stop or wait before switching accounts`);
+  }
+  await switchAccountForTab(target.tabId, profileId, {
+    cwd: target.cwd,
+    model: target.model,
+  });
+  if (target.tabId !== "default") {
+    ctx.updateTab(target.tabId, (tab) => ({ ...tab, authProfileId: profileId }));
+  }
+  return { profileId, target };
+}
+
+async function sendChat(
+  ctx: UseControlRequestsContext,
+  requestId: string,
+  params: Record<string, unknown>,
+): Promise<unknown> {
+  const message = requiredString(params, "message", "chat.send requires message");
+  const tabId = resolveControlTabId(ctx, stringParam(params, "tabId") ?? "active");
+  const account = stringParam(params, "account");
+  if (account) {
+    const target = resolveControlAccountTarget(ctx, tabId);
+    if (target.busy) {
+      throw new Error(`tab ${target.tabId} is busy; stop or wait before switching accounts`);
+    }
+    await switchAccountForTab(target.tabId, account, {
+      cwd: target.cwd,
+      model: target.model,
+    });
+    if (target.tabId !== "default") {
+      ctx.updateTab(target.tabId, (tab) => ({ ...tab, authProfileId: account }));
+    }
+  }
+  await ctx.sendChat(message, {
+    tabId,
+    controlRequestId: requestId,
+  });
+  const wait = params.wait === true;
+  const result: Record<string, unknown> = { sent: true, tabId };
+  if (account) result.account = account;
+  if (wait) result.wait = await waitForIdle(ctx, { tabId, timeoutMs: params.timeoutMs });
+  return result;
+}
+
+async function waitForIdle(
+  ctx: UseControlRequestsContext,
+  params: Record<string, unknown>,
+): Promise<unknown> {
+  const tabId = resolveControlTabId(ctx, stringParam(params, "tabId") ?? "active");
+  const timeoutMs =
+    typeof params.timeoutMs === "number" && Number.isFinite(params.timeoutMs)
+      ? params.timeoutMs
+      : 300_000;
+  const start = Date.now();
+  let sawBusy = false;
+  while (Date.now() - start < timeoutMs) {
+    const busy = isControlTabBusy(ctx.stateRef.current, tabId);
+    sawBusy = sawBusy || busy;
+    if (!busy && sawBusy) {
+      return { waiting: false, tabId, elapsedMs: Date.now() - start };
+    }
+    if (!busy && !sawBusy && Date.now() - start > 300) {
+      return { waiting: false, tabId, elapsedMs: Date.now() - start };
+    }
+    await new Promise((resolve) => window.setTimeout(resolve, 250));
+  }
+  return { waiting: true, tabId, timeoutMs };
+}
+
+async function stopAgent(
+  ctx: UseControlRequestsContext,
+  params: Record<string, unknown>,
+): Promise<unknown> {
+  const tabId = resolveControlTabId(ctx, stringParam(params, "tabId") ?? "active");
+  await ctx.stopPrompt(tabId);
+  return { stopped: true, tabId };
+}
+
+function resolveControlAccountTarget(
+  ctx: UseControlRequestsContext,
+  requestedTabId: string,
+): AccountSwitchTarget {
+  const tabId = resolveControlTabId(ctx, requestedTabId);
+  const tab = tabs(ctx.stateRef.current).find(
+    (candidate) =>
+      candidate.id === tabId &&
+      candidate.id !== OVERVIEW_TAB_ID &&
+      (candidate.kind ?? "agent") === "agent",
+  );
+  if (!tab) return { tabId: "default", busy: false };
+  return {
+    tabId: tab.id,
+    cwd: tab.cwd,
+    model: tab.model,
+    busy: isAgentTabBusy(tab, { includeQueue: true }),
+  };
+}
+
+function resolveControlTabId(
+  ctx: UseControlRequestsContext,
+  requestedTabId: string,
+): string {
+  if (requestedTabId !== "active") return requestedTabId;
+  const active = ctx.stateRef.current.activeTabId;
+  return typeof active === "string" && active.length > 0 ? active : "default";
+}
+
+function isControlTabBusy(state: Record<string, unknown>, tabId: string): boolean {
+  const tab = tabs(state).find((candidate) => candidate.id === tabId);
+  if (tab) return isAgentTabBusy(tab, { includeQueue: false });
+  if (tabId === state.activeTabId) return state.waiting === true;
+  return false;
+}
+
+function tabs(state: Record<string, unknown>): Tab[] {
+  return Array.isArray(state.tabs) ? (state.tabs as Tab[]) : [];
+}
+
+function stringParam(
+  params: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const value = params[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function requiredString(
+  params: Record<string, unknown>,
+  key: string,
+  message: string,
+): string {
+  const value = stringParam(params, key);
+  if (!value) throw new Error(message);
+  return value;
+}

--- a/src/hooks/useControlRequests.ts
+++ b/src/hooks/useControlRequests.ts
@@ -1,4 +1,4 @@
-import { useEffect, type MutableRefObject } from "react";
+import { useEffect, useRef, type MutableRefObject } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import {
@@ -7,6 +7,15 @@ import {
 } from "../auth-profiles/commands";
 import { OVERVIEW_TAB_ID, type Tab } from "../types/tab";
 import { isAgentTabBusy } from "../utils/agentBusy";
+import {
+  cancelControlWait,
+  registerControlWait,
+} from "./controlWaitRegistry";
+
+/** Default ceiling for `chat.send --wait` / `chat.wait` when the caller does
+ *  not pass `timeoutMs`. Generous because real agent turns routinely run for
+ *  minutes; the caller can always Ctrl-C the CLI. */
+const DEFAULT_WAIT_MS = 30 * 60 * 1000;
 
 export interface ControlRequestPayload {
   requestId: string;
@@ -33,6 +42,15 @@ export interface UseControlRequestsContext {
 }
 
 export function useControlRequests(ctx: UseControlRequestsContext): void {
+  // Keep the live context in a ref so the listener can read the latest actions
+  // without re-subscribing on every App render. Subscribing with `[ctx]` (a
+  // fresh object literal each render) would tear down and re-register the
+  // `control-request` listener constantly and could briefly run duplicate
+  // handlers (Tauri's unlisten is async).
+  const ctxRef = useRef(ctx);
+  useEffect(() => {
+    ctxRef.current = ctx;
+  });
   useEffect(() => {
     let disposed = false;
     const unlisten = listen<ControlRequestPayload>(
@@ -41,7 +59,7 @@ export function useControlRequests(ctx: UseControlRequestsContext): void {
         const request = event.payload;
         if (!request?.requestId) return;
         try {
-          const data = await handleControlRequest(ctx, request);
+          const data = await handleControlRequest(ctxRef.current, request);
           if (!disposed) {
             await completeControlRequest(request.requestId, true, data);
           }
@@ -61,7 +79,7 @@ export function useControlRequests(ctx: UseControlRequestsContext): void {
       disposed = true;
       unlisten.then((fn) => fn());
     };
-  }, [ctx]);
+  }, []);
 }
 
 async function completeControlRequest(
@@ -70,12 +88,19 @@ async function completeControlRequest(
   data?: unknown,
   error?: string,
 ): Promise<void> {
-  await invoke("control_request_complete", {
-    requestId,
-    success,
-    ...(data !== undefined ? { data } : {}),
-    ...(error ? { error } : {}),
-  });
+  try {
+    await invoke("control_request_complete", {
+      requestId,
+      success,
+      ...(data !== undefined ? { data } : {}),
+      ...(error ? { error } : {}),
+    });
+  } catch {
+    // The backend already dropped this pending request (e.g. its own timeout
+    // fired and purged the entry) or the command isn't registered yet on an
+    // older shell. Either way there's nothing left to complete — swallow it so
+    // a late completion can't turn into a second, also-failing attempt.
+  }
 }
 
 async function handleControlRequest(
@@ -179,15 +204,51 @@ async function sendChat(
       ctx.updateTab(target.tabId, (tab) => ({ ...tab, authProfileId: account }));
     }
   }
-  await ctx.sendChat(message, {
-    tabId,
-    controlRequestId: requestId,
-  });
+  // Wire --plan / --thinking-level onto the target tab so the dispatched turn
+  // picks them up (useChat reads planMode/thinkingLevel from the tab, not from
+  // sendChat options). Previously these CLI flags were silently ignored.
+  applyTurnOptions(ctx, tabId, params);
+
   const wait = params.wait === true;
+  const timeoutMs = finiteNumber(params.timeoutMs) ?? DEFAULT_WAIT_MS;
+  // Register the wait BEFORE dispatching so the turn's terminal event can't
+  // land before we're listening for it.
+  const waitPromise = wait
+    ? registerControlWait(requestId, tabId, timeoutMs)
+    : undefined;
+  try {
+    await ctx.sendChat(message, { tabId, controlRequestId: requestId });
+  } catch (err) {
+    if (wait) cancelControlWait(requestId);
+    throw err;
+  }
   const result: Record<string, unknown> = { sent: true, tabId };
   if (account) result.account = account;
-  if (wait) result.wait = await waitForIdle(ctx, { tabId, timeoutMs: params.timeoutMs });
+  if (waitPromise) result.wait = await waitPromise;
   return result;
+}
+
+function applyTurnOptions(
+  ctx: UseControlRequestsContext,
+  tabId: string,
+  params: Record<string, unknown>,
+): void {
+  const planMode =
+    typeof params.planMode === "boolean" ? params.planMode : undefined;
+  const thinkingLevel = stringParam(params, "thinkingLevel");
+  if (planMode === undefined && !thinkingLevel) return;
+  // Only real agent tabs carry these per-tab toggles; the default-tab fallback
+  // has no Tab object to patch.
+  if (!tabs(ctx.stateRef.current).some((t) => t.id === tabId)) return;
+  ctx.updateTab(tabId, (tab) => ({
+    ...tab,
+    ...(planMode !== undefined ? { planMode } : {}),
+    ...(thinkingLevel ? { thinkingLevel } : {}),
+  }));
+}
+
+function finiteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
 async function waitForIdle(
@@ -195,10 +256,7 @@ async function waitForIdle(
   params: Record<string, unknown>,
 ): Promise<unknown> {
   const tabId = resolveControlTabId(ctx, stringParam(params, "tabId") ?? "active");
-  const timeoutMs =
-    typeof params.timeoutMs === "number" && Number.isFinite(params.timeoutMs)
-      ? params.timeoutMs
-      : 300_000;
+  const timeoutMs = finiteNumber(params.timeoutMs) ?? DEFAULT_WAIT_MS;
   const start = Date.now();
   let sawBusy = false;
   while (Date.now() - start < timeoutMs) {

--- a/src/hooks/useControlRequests.ts
+++ b/src/hooks/useControlRequests.ts
@@ -10,6 +10,7 @@ import { isAgentTabBusy } from "../utils/agentBusy";
 import {
   cancelControlWait,
   registerControlWait,
+  type ControlWaitResult,
 } from "./controlWaitRegistry";
 
 /** Default ceiling for `chat.send --wait` / `chat.wait` when the caller does
@@ -211,9 +212,9 @@ async function sendChat(
 
   const wait = params.wait === true;
   const timeoutMs = finiteNumber(params.timeoutMs) ?? DEFAULT_WAIT_MS;
-  // Register the wait BEFORE dispatching so the turn's terminal event can't
-  // land before we're listening for it.
-  const waitPromise = wait
+  // Register the deterministic wait BEFORE dispatching so the turn's terminal
+  // event can't land before we're listening for it.
+  const deterministic = wait
     ? registerControlWait(requestId, tabId, timeoutMs)
     : undefined;
   try {
@@ -224,7 +225,57 @@ async function sendChat(
   }
   const result: Record<string, unknown> = { sent: true, tabId };
   if (account) result.account = account;
-  if (waitPromise) result.wait = await waitPromise;
+  if (deterministic) {
+    result.wait = await raceControlWait(ctx, requestId, tabId, timeoutMs, deterministic);
+  }
+  return result;
+}
+
+/**
+ * Resolve a waited control send. The deterministic registry resolves the
+ * instant the bridge echoes this `controlRequestId` on `response_end`/`error`.
+ * But a normal-mode send to a BUSY tab is queued client-side and drained later
+ * WITHOUT this id, so the deterministic waiter would never fire — fall back to
+ * an idle poll that detects the tab draining. Whichever fires first wins; the
+ * loser is torn down so neither leaks a timer.
+ */
+async function raceControlWait(
+  ctx: UseControlRequestsContext,
+  requestId: string,
+  tabId: string,
+  timeoutMs: number,
+  deterministic: Promise<ControlWaitResult>,
+): Promise<ControlWaitResult> {
+  let stopped = false;
+  const poll = (async (): Promise<ControlWaitResult> => {
+    const start = Date.now();
+    let sawBusy = false;
+    while (!stopped && Date.now() - start < timeoutMs) {
+      const busy = isControlTabBusy(ctx.stateRef.current, tabId);
+      sawBusy = sawBusy || busy;
+      // Only a busy→idle transition counts: the never-busy case belongs to the
+      // deterministic waiter (a non-queued turn echoes its id), so we must not
+      // short-circuit "idle" here and return mid-turn.
+      if (!busy && sawBusy) {
+        return {
+          waiting: false,
+          tabId,
+          outcome: "completed",
+          elapsedMs: Date.now() - start,
+        };
+      }
+      await new Promise((resolve) => window.setTimeout(resolve, 250));
+    }
+    return {
+      waiting: true,
+      tabId,
+      outcome: "timeout",
+      elapsedMs: Date.now() - start,
+    };
+  })();
+  const result = await Promise.race([deterministic, poll]);
+  stopped = true;
+  cancelControlWait(requestId);
   return result;
 }
 

--- a/src/hooks/useControlRequests.ts
+++ b/src/hooks/useControlRequests.ts
@@ -9,6 +9,7 @@ import { OVERVIEW_TAB_ID, type Tab } from "../types/tab";
 import { isAgentTabBusy } from "../utils/agentBusy";
 import {
   cancelControlWait,
+  hasControlTurnStarted,
   registerControlWait,
   type ControlWaitResult,
 } from "./controlWaitRegistry";
@@ -17,6 +18,12 @@ import {
  *  not pass `timeoutMs`. Generous because real agent turns routinely run for
  *  minutes; the caller can always Ctrl-C the CLI. */
 const DEFAULT_WAIT_MS = 30 * 60 * 1000;
+
+/** Window the idle poll allows for a `prompt_started` to arrive (or the tab to
+ *  go busy) before concluding the send produced no agent turn — e.g. a locally
+ *  handled slash command like `/clear`. Long enough to absorb bridge latency,
+ *  short enough that such a `--wait` returns promptly. */
+const NO_TURN_GRACE_MS = 1500;
 
 export interface ControlRequestPayload {
   requestId: string;
@@ -253,14 +260,30 @@ async function raceControlWait(
     while (!stopped && Date.now() - start < timeoutMs) {
       const busy = isControlTabBusy(ctx.stateRef.current, tabId);
       sawBusy = sawBusy || busy;
-      // Only a busy→idle transition counts: the never-busy case belongs to the
-      // deterministic waiter (a non-queued turn echoes its id), so we must not
-      // short-circuit "idle" here and return mid-turn.
+      // A busy→idle transition means a queued turn drained.
       if (!busy && sawBusy) {
         return {
           waiting: false,
           tabId,
           outcome: "completed",
+          elapsedMs: Date.now() - start,
+        };
+      }
+      // No turn was produced: the tab never went busy AND the bridge never
+      // echoed a prompt_started for this id within the grace window — i.e. a
+      // locally handled slash command (e.g. `/clear`). Return promptly instead
+      // of blocking to the full timeout. A genuine turn (even on an
+      // unobservable tab) sets turnStarted, so this can't fire mid-turn — the
+      // deterministic waiter resolves those.
+      if (
+        !sawBusy &&
+        !hasControlTurnStarted(requestId) &&
+        Date.now() - start > NO_TURN_GRACE_MS
+      ) {
+        return {
+          waiting: false,
+          tabId,
+          outcome: "idle",
           elapsedMs: Date.now() - start,
         };
       }

--- a/src/hooks/useFrontendStateMirror.ts
+++ b/src/hooks/useFrontendStateMirror.ts
@@ -29,6 +29,7 @@ export function useFrontendStateMirror(
 ): void {
   const { state } = ctx;
   const lastFrontendStateRef = useRef<Record<string, string>>({});
+  const lastControlSnapshotRef = useRef<string>("");
   const frontendPatchTimerRef = useRef<number | null>(null);
 
   useEffect(() => {
@@ -92,21 +93,32 @@ export function useFrontendStateMirror(
           active: t.id === (state.activeTabId as string | undefined),
         })),
       };
-      invoke("control_update_state", {
-        snapshot: {
-          location: typeof window !== "undefined" ? window.location.href : null,
-          status: state.status ?? "",
-          connection: state.connection ?? "disconnected",
-          waiting: state.waiting === true,
-          model: state.model ?? "",
-          activeTabId: state.activeTabId ?? null,
-          authProfiles: state.authProfiles ?? { profiles: [] },
-          models: sidebar.models ?? [],
-          tabs: slices["/tabs"],
-        },
-      }).catch(() => {
-        // Older app builds or early boot before the command is registered.
-      });
+      // Mirror the control snapshot, but only when it actually changed.
+      // Without this diff-gate every state tick (composer keystroke, streaming
+      // delta) would re-push an identical full snapshot — the same churn the
+      // per-slice patches below take pains to avoid.
+      const controlSnapshot = {
+        location: typeof window !== "undefined" ? window.location.href : null,
+        status: state.status ?? "",
+        connection: state.connection ?? "disconnected",
+        waiting: state.waiting === true,
+        model: state.model ?? "",
+        activeTabId: state.activeTabId ?? null,
+        authProfiles: state.authProfiles ?? { profiles: [] },
+        models: sidebar.models ?? [],
+        tabs: slices["/tabs"],
+      };
+      const controlSerialized = JSON.stringify(controlSnapshot);
+      if (controlSerialized !== lastControlSnapshotRef.current) {
+        lastControlSnapshotRef.current = controlSerialized;
+        invoke("control_update_state", { snapshot: controlSnapshot }).catch(
+          () => {
+            // Older app builds or early boot before the command is registered;
+            // reset so the next change re-pushes.
+            lastControlSnapshotRef.current = "";
+          },
+        );
+      }
       const last = lastFrontendStateRef.current;
       const next: Record<string, string> = { ...last };
       let changed = false;

--- a/src/hooks/useFrontendStateMirror.ts
+++ b/src/hooks/useFrontendStateMirror.ts
@@ -84,10 +84,29 @@ export function useFrontendStateMirror(
         "/tabs": tabs.map((t) => ({
           id: t.id,
           label: t.label,
+          kind: t.kind,
+          cwd: t.cwd,
           model: t.model ?? "",
+          waiting: t.waiting === true,
+          authProfileId: t.authProfileId,
           active: t.id === (state.activeTabId as string | undefined),
         })),
       };
+      invoke("control_update_state", {
+        snapshot: {
+          location: typeof window !== "undefined" ? window.location.href : null,
+          status: state.status ?? "",
+          connection: state.connection ?? "disconnected",
+          waiting: state.waiting === true,
+          model: state.model ?? "",
+          activeTabId: state.activeTabId ?? null,
+          authProfiles: state.authProfiles ?? { profiles: [] },
+          models: sidebar.models ?? [],
+          tabs: slices["/tabs"],
+        },
+      }).catch(() => {
+        // Older app builds or early boot before the command is registered.
+      });
       const last = lastFrontendStateRef.current;
       const next: Record<string, string> = { ...last };
       let changed = false;

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -8,6 +8,7 @@
 
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
+    "types": ["node"],
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",
     "noEmit": true,
@@ -19,5 +20,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "cli/**/*.ts"],
+  "exclude": ["cli/**/*.test.ts"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -44,7 +44,12 @@ export default defineConfig({
     // per-file basis with `// @vitest-environment jsdom` at the top —
     // vitest 4 dropped environmentMatchGlobs in favor of the directive.
     environment: "node",
-    include: ["src/**/*.test.ts", "src/**/*.test.tsx", "agent/**/*.test.ts"],
+    include: [
+      "src/**/*.test.ts",
+      "src/**/*.test.tsx",
+      "agent/**/*.test.ts",
+      "cli/**/*.test.ts",
+    ],
     setupFiles: ["src/test/setup.ts"],
     coverage: {
       provider: "v8",


### PR DESCRIPTION
## Summary

- add a release-safe local `aethonctl` control transport backed by a Tauri Unix socket and per-launch token under `~/.aethon/control`
- route CLI tab/chat/account operations through typed frontend `control-request` events instead of dev-only debug eval
- carry `authProfileId` and `controlRequestId` through Rust, the agent bridge, and frontend chat dispatch so Codex account selection and `chat --wait` are tied to the intended turn
- keep debug-only escape hatches (`eval`, raw `invoke`, `agent command`) behind `--transport debug`

## Why

The first CLI pass only worked against the dev debug server. Release builds do not expose that server or the webview debug globals, so this adds the production control boundary required for a shipped build while preserving the existing debug fallback for older dev processes.

## Review fixes (peer review + Copilot + Codex)

Follow-up commits address review feedback and a related account-switch bug found while validating:

**`chat.send --wait` is now correct and deterministic**
- The forward timeout honors a caller-supplied `timeoutMs` (+margin, capped 24h) instead of a flat 300s, so multi-minute agent turns no longer report a false timeout. The CLI gains `--timeout` (default 30 min) and the socket client derives its timer from it.
- `--wait` resolves on the turn's actual terminal event via the `controlRequestId` the bridge already echoes (new `controlWaitRegistry`, wired into `response_end`/`error`), replacing a racy busy-flag poll. A send that is **queued** behind a busy tab (no echoed id) falls back to an idle poll, so it still resolves when the tab drains.

**Account switching**
- Fixed: switching a non-default tab's account appeared to hang ("can't select the secondary Codex account"). `auth_profile_use_for_tab` always runs on the global bridge, but `handleUseForTab` unconditionally rebuilt the session — for a worker tab that spawned a spurious duplicate session and blocked the bridge on a devshell-prepare timeout, and could reset the tab's model. It now only rebuilds the default tab; worker tabs just record the mapping (the tab-scoped `auth_profile_apply` rebuilds the worker session).
- `/login use` now routes through the shared `switchAccountForTab` so a worker tab also receives the `auth_profile_apply` (previously it sent only `use_for_tab`, leaving the worker on the old account).
- `chat.send` now honors `--plan` / `--thinking-level` (previously silently ignored on the control transport).

**Robustness / hardening**
- `control_update_state` is diff-gated so it no longer re-pushes an identical snapshot on every state tick.
- `useControlRequests` no longer re-subscribes its listener on every render; completion errors are swallowed; `control_request_complete` treats an unknown/late id as a no-op instead of a noisy error.
- Constant-time token compare and a bounded request line on the control socket.

## Validation

- `check` gate: clippy + `tsc -b` + ESLint (0 warnings) + `cargo test --lib` (469) + vitest (2533) — all green
- Live-verified in the dev app: a worker-tab switch to the Secondary Codex account now lands in ~1s (was 5s+/silent) with the tab's model preserved
- Two rounds of `codex review` against the base commit

## Notes

- The currently running dev app process still predates the new release socket until it is restarted/rebuilt; `aethonctl --transport auto` falls back to the debug bridge for that old process.
- Windows named-pipe support remains future work; this PR covers the current macOS/Linux local Unix-socket release path.
