### PR TITLE
fix: keep closed workspace tabs closed

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,6 +43,7 @@ import {
   projectIdFromBucketKey,
   workspaceIdFromBucketKey,
 } from "./hooks/useProjectOps";
+import type { TabBucket } from "./hooks/projectOps/types";
 import { useOsEdges } from "./hooks/useOsEdges";
 import {
   buildInitialAppStore,
@@ -119,6 +120,7 @@ export default function App() {
   const nativeWindowsRef = useRef<Map<string, NativeCanvasWindowRecord>>(
     new Map(),
   );
+  const tabBucketsRef = useRef<Map<string, TabBucket>>(new Map());
 
   // Active layout payload — replaceable. Extensions can swap the chrome wholesale
   // by calling window.aethon.setLayout(payload), or register a new extension via
@@ -347,6 +349,7 @@ export default function App() {
     appendSystem: (text) => chatActionsRef.current.appendSystem(text),
     promptCloseShellTabConfirmation,
     projectsRef,
+    tabBucketsRef,
     piDefaultModelRef,
     clearActiveProject: () => projectOpsHandleRef.current.clearActiveProject(),
     setActiveProjectById: (id) =>
@@ -422,7 +425,6 @@ export default function App() {
   const {
     projectsLoadedRef,
     allDiscoveredSessionsRef,
-    tabBucketsRef,
     buildSidebarHistory,
     knownTabIds,
     scopedDiscoveredSessions,
@@ -452,6 +454,7 @@ export default function App() {
     setState,
     stateRef,
     projectsRef,
+    tabBucketsRef,
     piDefaultModelRef,
     gitStatusRef,
     refreshGitStatusFor,

--- a/src/hooks/projectOps/types.ts
+++ b/src/hooks/projectOps/types.ts
@@ -39,6 +39,9 @@ export interface UseProjectOpsContext {
   /** Owned at App-root so useTabs can share the same ref without a
    *  shadow. The hook mutates `.current` in place. */
   projectsRef: MutableRefObject<ProjectsState>;
+  /** Shared per-project/workspace tab buckets. App owns this so useTabs can
+   *  prune closed visible tabs from the same mirror useProjectOps switches. */
+  tabBucketsRef?: MutableRefObject<Map<string, TabBucket>>;
   /** Pi's default model from the last `ready` event. Owned at App-root
    *  so tab creation can use the same shared default elsewhere. */
   piDefaultModelRef: MutableRefObject<string>;

--- a/src/hooks/tabOps/closeTab.test.ts
+++ b/src/hooks/tabOps/closeTab.test.ts
@@ -6,6 +6,8 @@ import { OVERVIEW_TAB_ID, makeEmptyTab, type Tab } from "../../types/tab";
 import type { ProjectsState } from "../../projects";
 import { focusTerminalPanelSoon } from "../../utils/focus";
 import { SESSION_UI_SNAPSHOT_FLUSH_EVENT } from "../../state/sessionUiSnapshot";
+import { projectScopeBucketKey } from "../projectOps/tabBuckets";
+import type { TabBucket } from "../projectOps/types";
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn(() => Promise.resolve(null)),
@@ -165,6 +167,80 @@ describe("closeTabNow → overview fallback", () => {
     expect(next.closedSessionIds).toEqual(["already-closed", "agent-2"]);
     expect(flushSpy).toHaveBeenCalledTimes(1);
     window.removeEventListener(SESSION_UI_SNAPSHOT_FLUSH_EVENT, flushSpy);
+  });
+
+  it("removes closed workspace tabs from the active bucket mirror", () => {
+    const workspaceKey = projectScopeBucketKey("project-1", "wt-1");
+    const t1 = makeTab("agent-1", "agent");
+    const t2 = makeTab("agent-2", "agent");
+    const tabBucketsRef = ref(
+      new Map<string, TabBucket>([
+        [
+          workspaceKey,
+          {
+            tabs: [t1, t2],
+            activeTabId: "agent-2",
+          },
+        ],
+      ]),
+    );
+    const { deps, apply } = buildDeps(
+      {
+        tabs: [t1, t2],
+        activeTabId: "agent-2",
+        persistedTabBuckets: {
+          [workspaceKey]: {
+            tabs: [t1, t2],
+            activeTabId: "agent-2",
+          },
+        },
+      },
+      {
+        projectsRef: ref<ProjectsState>({
+          activeId: "project-1",
+          activeWorkspaceId: "wt-1",
+          activeHostId: null,
+          projects: [
+            {
+              id: "project-1",
+              label: "Aethon",
+              path: "/repo/aethon",
+              lastUsed: 1,
+            },
+          ],
+          workspacesByProject: {
+            "project-1": [
+              {
+                id: "wt-1",
+                projectId: "project-1",
+                path: "/repo/aethon-fix",
+                branch: "fix/workspace-closed-tab-restore",
+                isMain: false,
+              },
+            ],
+          },
+        }),
+        tabBucketsRef,
+      },
+    );
+    const { closeTabNow } = useCloseTabActions(deps);
+
+    closeTabNow("agent-2");
+
+    expect((apply().tabs as Tab[]).map((t) => t.id)).toEqual(["agent-1"]);
+    expect(tabBucketsRef.current.get(workspaceKey)).toEqual({
+      tabs: [t1],
+      activeTabId: "agent-1",
+    });
+    expect(
+      (
+        apply().persistedTabBuckets as Record<string, TabBucket>
+      )[workspaceKey],
+    ).toEqual({
+      tabs: [t1],
+      activeTabId: "agent-1",
+    });
+    expect(apply().closedSessionIds).toEqual(["agent-2"]);
   });
 
   it("bounds closed agent session suppression to the most recent entries", () => {

--- a/src/hooks/tabOps/closeTab.ts
+++ b/src/hooks/tabOps/closeTab.ts
@@ -12,6 +12,8 @@ import { focusTerminalPanelSoon } from "../../utils/focus";
 import { CLOSED_TAB_STACK_MAX, TAB_MIRROR_KEYS } from "./constants";
 import { recentSessionItemFromClosedTab } from "./helpers";
 import { SESSION_UI_SNAPSHOT_FLUSH_EVENT } from "../../state/sessionUiSnapshot";
+import { projectScopeBucketKey } from "../projectOps/tabBuckets";
+import type { TabBucket } from "../projectOps/types";
 
 export interface CloseTabDeps {
   setState: Dispatch<SetStateAction<Record<string, unknown>>>;
@@ -28,6 +30,7 @@ export interface CloseTabDeps {
   isShellBusy?: (tabId: string) => Promise<boolean>;
   dispatchTerminalReplay: (buffer: string) => void;
   closedTabsRef: MutableRefObject<ClosedTabEntry[]>;
+  tabBucketsRef?: MutableRefObject<Map<string, TabBucket>>;
   /** Bucket switching — the reopen flow needs to land closed tabs back
    *  in their original project bucket, even when the user is currently
    *  in a different one. */
@@ -56,6 +59,34 @@ export interface CloseTabActions {
   closeEditorTabsForPath: (path: string, kind: string) => void;
 }
 
+function preferredBucketActiveTabId(
+  tabs: Tab[],
+  currentActive: string | undefined,
+): string | undefined {
+  if (currentActive && tabs.some((tab) => tab.id === currentActive)) {
+    return currentActive;
+  }
+  return (
+    tabs.find((tab) => tab.kind === "agent" || tab.kind === "editor")?.id ??
+    tabs[0]?.id
+  );
+}
+
+function pruneTabFromBucket(
+  bucket: TabBucket | undefined,
+  tabId: string,
+  nextActiveTabId: string | undefined,
+): TabBucket | undefined {
+  if (!bucket) return undefined;
+  const tabs = bucket.tabs.filter((tab) => tab.id !== tabId);
+  if (tabs.length === bucket.tabs.length) return bucket;
+  if (tabs.length === 0) return undefined;
+  return {
+    tabs,
+    activeTabId: preferredBucketActiveTabId(tabs, nextActiveTabId),
+  };
+}
+
 /** Close + reopen family. Owns the closed-tab undo stack, the
  *  dirty-buffer / running-shell confirm prompts, the bridge
  *  `tab_close` / `shell_close` teardown, and the Monaco buffer
@@ -75,6 +106,7 @@ export function useCloseTabActions(deps: CloseTabDeps): CloseTabActions {
     isShellBusy,
     dispatchTerminalReplay,
     closedTabsRef,
+    tabBucketsRef,
     clearActiveProject,
     setActiveProjectById,
     newTab,
@@ -243,6 +275,44 @@ export function useCloseTabActions(deps: CloseTabDeps): CloseTabActions {
             }
           : {}),
       };
+      const bucketKey = projectScopeBucketKey(
+        projectsRef.current.activeId,
+        projectsRef.current.activeWorkspaceId,
+      );
+      const bucketRef = tabBucketsRef;
+      const inMemoryBucket = bucketRef?.current.get(bucketKey);
+      if (bucketRef && inMemoryBucket) {
+        const nextBucket = pruneTabFromBucket(
+          inMemoryBucket,
+          tabId,
+          activeTabId,
+        );
+        if (nextBucket) {
+          bucketRef.current.set(bucketKey, nextBucket);
+        } else {
+          bucketRef.current.delete(bucketKey);
+        }
+      }
+      const persistedBuckets =
+        prev.persistedTabBuckets &&
+        typeof prev.persistedTabBuckets === "object" &&
+        !Array.isArray(prev.persistedTabBuckets)
+          ? (prev.persistedTabBuckets as Record<string, TabBucket>)
+          : undefined;
+      if (persistedBuckets?.[bucketKey]) {
+        const nextPersisted = { ...persistedBuckets };
+        const nextBucket = pruneTabFromBucket(
+          persistedBuckets[bucketKey],
+          tabId,
+          activeTabId,
+        );
+        if (nextBucket) {
+          nextPersisted[bucketKey] = nextBucket;
+        } else {
+          delete nextPersisted[bucketKey];
+        }
+        result.persistedTabBuckets = nextPersisted;
+      }
       if (closedKind === "agent") {
         const closedIds = Array.isArray(prev.closedSessionIds)
           ? (prev.closedSessionIds as string[])

--- a/src/hooks/tabOps/types.ts
+++ b/src/hooks/tabOps/types.ts
@@ -1,6 +1,7 @@
 import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 import type { EditorMeta, ShellMeta, Tab } from "../../types/tab";
 import type { ProjectsState } from "../../projects";
+import type { TabBucket } from "../projectOps/types";
 
 /** Bridge-discovered persistent session awaiting restore.
  *  Surfaced by useProjectOps; useTabs.autoRestoreDiscoveredSessions
@@ -37,6 +38,9 @@ export interface UseTabsContext {
   /** Live ref to projects state so newTab/newShellTab inherit the active
    *  project's path as cwd. Project bucket swap stays in App.tsx. */
   projectsRef: MutableRefObject<ProjectsState>;
+  /** Shared project/workspace tab buckets. Individual close operations prune
+   *  this mirror so a later workspace switch cannot resurrect closed tabs. */
+  tabBucketsRef?: MutableRefObject<Map<string, TabBucket>>;
   /** Default model id from pi `ready`. New tabs inherit this when no per-
    *  tab model has been set, preventing a blank picker on race startup. */
   piDefaultModelRef: MutableRefObject<string>;

--- a/src/hooks/useProjectOps.ts
+++ b/src/hooks/useProjectOps.ts
@@ -70,6 +70,7 @@ export function useProjectOps(ctx: UseProjectOpsContext): UseProjectOpsActions {
     setState,
     stateRef,
     projectsRef,
+    tabBucketsRef: sharedTabBucketsRef,
     gitStatusRef,
     refreshGitStatusFor,
     refreshAllGitStatus,
@@ -85,7 +86,8 @@ export function useProjectOps(ctx: UseProjectOpsContext): UseProjectOpsActions {
 
   const projectsLoadedRef = useRef(false);
   const allDiscoveredSessionsRef = useRef<DiscoveredSession[]>([]);
-  const tabBucketsRef = useRef<Map<string, TabBucket>>(new Map());
+  const ownedTabBucketsRef = useRef<Map<string, TabBucket>>(new Map());
+  const tabBucketsRef = sharedTabBucketsRef ?? ownedTabBucketsRef;
 
   const projectStore = useProjectStore({
     setState,

--- a/src/hooks/useTabs.ts
+++ b/src/hooks/useTabs.ts
@@ -105,6 +105,7 @@ export function useTabs(ctx: UseTabsContext): UseTabsActions {
     setState: ctx.setState,
     stateRef: ctx.stateRef,
     projectsRef: ctx.projectsRef,
+    tabBucketsRef: ctx.tabBucketsRef,
     promptCloseShellTabConfirmation: ctx.promptCloseShellTabConfirmation,
     shellPromptBeforeCloseRef: ctx.shellPromptBeforeCloseRef,
     isShellBusy: ctx.isShellBusy,


### PR DESCRIPTION
## Summary
- Share the project/workspace tab bucket ref between `useTabs` and `useProjectOps` so close operations and workspace switches operate on the same bucket mirror.
- Prune closed tabs from the active workspace bucket and persisted bucket mirror inside `closeTabNow`.
- Add a regression test covering the stale hydrated workspace bucket that previously resurrected closed tabs when returning to a workspace.

## Root Cause
Individual tab closes updated the visible `state.tabs` list and closed-session suppression, but they did not update the active workspace's bucket mirror. If the bucket had already been hydrated or snapshotted, switching away and back could load that stale bucket and reopen sessions the user had explicitly closed.

## User Impact
Closing tabs in a workspace is now authoritative: returning to that workspace no longer reopens closed sessions from stale bucket state.

## Validation
- `bunx vitest run src/hooks/tabOps/closeTab.test.ts -t "removes closed workspace tabs"`
- `bunx vitest run src/hooks/tabOps/closeTab.test.ts src/hooks/tabOps/closeWorkspaceSessions.test.ts`
- `bunx vitest run src/hooks/useProjectOps.test.ts -t "workspace|bucket|scopes discovered|restores the destination workspace"`
- `bun run typecheck`
- `bunx vitest run`
- `bun run lint`
- `git diff --check`