### PR TITLE
feat(extensions): close extension API gaps

### DIFF
--- a/agent/aethon-api-sessions.test.ts
+++ b/agent/aethon-api-sessions.test.ts
@@ -1,0 +1,513 @@
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, expect, it } from "vitest";
+import { AethonAgentState, type AethonAgentStateOptions } from "./state";
+import { buildAethonApi } from "./aethon-api";
+import { emitSessionEvent } from "./aethon-api-sessions";
+import type { RuntimeSnapshot } from "./system-prompt";
+
+function opts(root: string): AethonAgentStateOptions {
+  return {
+    userDir: root,
+    stateFile: join(root, "state.json"),
+    sessionsDir: join(root, "sessions"),
+    docsDir: undefined,
+    projectRoot: undefined,
+    releaseMode: false,
+    bootLayoutFile: undefined,
+    layoutSlotsFile: undefined,
+    statePayloadWarnBytes: 64 * 1024,
+    statePayloadHardBytes: 512 * 1024,
+    statePayloadWarnKb: 64,
+    statePayloadHardKb: 512,
+  };
+}
+
+function fakeSnapshot(): RuntimeSnapshot {
+  return {
+    release: false,
+    cwd: "/tmp",
+    docsDir: undefined,
+    projectRoot: undefined,
+    userDir: "/tmp",
+    stateFile: "/tmp/state.json",
+    extensions: [],
+    failedExtensions: [],
+    disabledExtensions: [],
+    themes: [],
+    subagents: [],
+    components: [],
+    layoutSummary: "",
+    tabs: [],
+    eventHandlers: [],
+    slashCommands: [],
+    keybindings: [],
+    menuItems: [],
+    eventRoutes: [],
+    eventRoutingMode: "builtin",
+    uiState: {},
+    layoutStructure: null,
+    layoutSlots: null,
+    layouts: [],
+    frontendModules: [],
+    highlightGrammars: [],
+    nativeWindows: [],
+  };
+}
+
+async function makeFixture() {
+  const root = await mkdtemp(join(tmpdir(), "aethon-sessions-api-"));
+  const state = new AethonAgentState(opts(root));
+  const api = buildAethonApi(state, {
+    send: () => {},
+    scheduleStateFileWrite: () => {},
+    getRuntimeSnapshot: fakeSnapshot,
+  });
+  return { root, state, api };
+}
+
+function fakeTabRecord(messages: unknown[] = [], model = "test/model") {
+  return {
+    id: "tab-1",
+    session: {
+      model: {
+        provider: model.split("/")[0],
+        id: model.split("/").slice(1).join("/"),
+      },
+      messages,
+    },
+    toolArgsCache: new Map(),
+    promptInFlight: false,
+    agentEndFired: false,
+    queuedCount: 0,
+    toolCardSeq: 0,
+    responseMessageSeq: 0,
+  };
+}
+
+describe("aethon.sessions API", () => {
+  it("lists live and discovered sessions with active metadata", async () => {
+    const { state, api } = await makeFixture();
+    state.tabs.set(
+      "live",
+      fakeTabRecord([{ role: "user", content: "hi" }]) as never,
+    );
+    state.tabProjectCwds.set("live", "/repo/live");
+    state.discoveredTabs = [
+      {
+        tabId: "old",
+        lastModified: 1234,
+        cwd: "/repo/old",
+        firstUserMessage: "Earlier prompt",
+      },
+    ];
+    state.frontendState.set("/tabs", [
+      {
+        id: "live",
+        label: "Live tab",
+        kind: "agent",
+        cwd: "/repo/live",
+        model: "openai/gpt-test",
+        waiting: false,
+        active: true,
+      },
+      {
+        id: "editor-1",
+        label: "README.md",
+        kind: "editor",
+        cwd: "/repo/live",
+        active: false,
+      },
+    ]);
+
+    const sessions = await api.sessions.list();
+    expect(sessions).toEqual([
+      expect.objectContaining({
+        id: "live",
+        label: "Live tab",
+        active: true,
+        model: "openai/gpt-test",
+        cwd: "/repo/live",
+        messageCount: 1,
+      }),
+      expect.objectContaining({
+        id: "old",
+        label: "Earlier prompt",
+        active: false,
+        cwd: "/repo/old",
+        updatedAt: 1234,
+      }),
+    ]);
+    expect(sessions.some((session) => session.id === "editor-1")).toBe(false);
+  });
+
+  it("returns the active session summary", async () => {
+    const { state, api } = await makeFixture();
+    state.tabs.set("a", fakeTabRecord() as never);
+    state.tabs.set("b", fakeTabRecord() as never);
+    state.frontendState.set("/tabs", [
+      { id: "a", label: "A", kind: "agent", active: false },
+      { id: "b", label: "B", kind: "agent", active: true },
+    ]);
+
+    await expect(api.sessions.getActive()).resolves.toMatchObject({
+      id: "b",
+      label: "B",
+      active: true,
+    });
+  });
+
+  it("normalizes live pi messages", async () => {
+    const { state, api } = await makeFixture();
+    state.tabs.set(
+      "live",
+      fakeTabRecord([
+        {
+          id: "u1",
+          role: "user",
+          content:
+            "You are in Aethon plan mode. Do not edit files, run shell commands, start implementation tasks, commit, push, or make persistent changes. Inspect read-only context as needed, then propose a concise implementation plan with risks and tests. Wait for the user to switch back to implementation mode or explicitly approve implementation.\n\nUser request:\nhello\n\n<aethon_file_references>\nsecret file body\n</aethon_file_references>",
+          createdAt: 10,
+        },
+        {
+          id: "a1",
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "plan" },
+            { type: "text", text: "world" },
+          ],
+          createdAt: 20,
+        },
+      ]) as never,
+    );
+
+    await expect(api.sessions.getMessages("live")).resolves.toEqual([
+      expect.objectContaining({
+        id: "u1",
+        role: "user",
+        content: "hello",
+        text: "hello",
+        createdAt: 10,
+      }),
+      expect.objectContaining({
+        id: "a1",
+        role: "agent",
+        content: "world",
+        text: "world",
+        thinking: "plan",
+        createdAt: 20,
+      }),
+    ]);
+  });
+
+  it("merges durable local transcript entries for live sessions", async () => {
+    const { root, state, api } = await makeFixture();
+    const sessionDir = join(root, "sessions", "live");
+    await mkdir(sessionDir, { recursive: true });
+    await writeFile(
+      join(sessionDir, "aethon-chat.jsonl"),
+      [
+        JSON.stringify({
+          type: "aethon_chat",
+          id: "local-user",
+          role: "user",
+          text: "hello",
+          attachments: [
+            {
+              id: "img-1",
+              kind: "image",
+              path: "/repo/live/screenshot.png",
+              name: "screenshot.png",
+              mimeType: "image/png",
+              sizeBytes: 123,
+            },
+          ],
+          createdAt: 10,
+          cwd: "/repo/live",
+        }),
+        JSON.stringify({
+          type: "aethon_chat",
+          id: "local-system",
+          role: "system",
+          text: "local only",
+          createdAt: 20,
+          cwd: "/repo/live",
+        }),
+      ].join("\n") + "\n",
+    );
+    state.tabs.set(
+      "live",
+      fakeTabRecord([
+        { id: "u1", role: "user", content: "hello", createdAt: 10 },
+      ]) as never,
+    );
+    state.tabProjectCwds.set("live", "/repo/live");
+
+    await expect(api.sessions.getMessages("live")).resolves.toEqual([
+      expect.objectContaining({
+        id: "u1",
+        role: "user",
+        content: "hello",
+        attachments: [
+          expect.objectContaining({ id: "img-1", mimeType: "image/png" }),
+        ],
+      }),
+      expect.objectContaining({
+        id: "local-system",
+        role: "system",
+        content: "local only",
+      }),
+    ]);
+  });
+
+  it("reads dormant session messages from the supported transcript parser", async () => {
+    const { root, state, api } = await makeFixture();
+    const sessionDir = join(root, "sessions", "old");
+    await mkdir(sessionDir, { recursive: true });
+    await writeFile(
+      join(sessionDir, "aethon-chat.jsonl"),
+      JSON.stringify({
+        type: "aethon_chat",
+        id: "m1",
+        role: "user",
+        text: "from disk",
+        createdAt: 42,
+        cwd: "/repo/old",
+      }) + "\n",
+    );
+    state.discoveredTabs = [
+      { tabId: "old", lastModified: 42, cwd: "/repo/old" },
+    ];
+
+    await expect(api.sessions.getMessages("old")).resolves.toEqual([
+      expect.objectContaining({
+        id: "m1",
+        role: "user",
+        content: "from disk",
+        createdAt: 42,
+      }),
+    ]);
+  });
+
+  it("includes in-flight assistant messages", async () => {
+    const { state, api } = await makeFixture();
+    const rec = fakeTabRecord([]) as never;
+    state.tabs.set("live", rec);
+
+    Object.assign(rec, {
+      activeResponseMessageId: "text-stream-1",
+      activeResponseText: "streaming answer",
+    });
+
+    await expect(api.sessions.getMessages("live")).resolves.toEqual([
+      expect.objectContaining({
+        id: "text-stream-1",
+        role: "agent",
+        content: "streaming answer",
+      }),
+    ]);
+  });
+
+  it("prefers in-flight assistant text over persisted deltas with the same id", async () => {
+    const { root, state, api } = await makeFixture();
+    const sessionDir = join(root, "sessions", "live");
+    await mkdir(sessionDir, { recursive: true });
+    await writeFile(
+      join(sessionDir, "aethon-chat.jsonl"),
+      JSON.stringify({
+        type: "aethon_chat",
+        id: "text-stream-1",
+        role: "agent",
+        text: "old partial",
+        thinking: "old thought",
+        createdAt: 10,
+        cwd: "/repo/live",
+      }) + "\n",
+    );
+    const rec = fakeTabRecord([]) as never;
+    state.tabs.set("live", rec);
+    state.tabProjectCwds.set("live", "/repo/live");
+    Object.assign(rec, {
+      activeResponseMessageId: "text-stream-1",
+      activeResponseText: "new streamed text",
+      activeResponseThinking: "new thought",
+    });
+
+    await expect(api.sessions.getMessages("live")).resolves.toEqual([
+      expect.objectContaining({
+        id: "text-stream-1",
+        content: "new streamed text",
+        text: "new streamed text",
+        thinking: "new thought",
+        createdAt: 10,
+      }),
+    ]);
+  });
+
+  it("orders in-flight assistant messages after restored history", async () => {
+    const { root, state, api } = await makeFixture();
+    const sessionDir = join(root, "sessions", "live");
+    await mkdir(sessionDir, { recursive: true });
+    await writeFile(
+      join(sessionDir, "aethon-chat.jsonl"),
+      JSON.stringify({
+        type: "aethon_chat",
+        id: "local-user",
+        role: "user",
+        text: "prompt first",
+        createdAt: 10,
+        cwd: "/repo/live",
+      }) + "\n",
+    );
+    const rec = fakeTabRecord([]) as never;
+    state.tabs.set("live", rec);
+    state.tabProjectCwds.set("live", "/repo/live");
+    Object.assign(rec, {
+      activeResponseMessageId: "text-stream-1",
+      activeResponseText: "answer second",
+    });
+
+    await expect(api.sessions.getMessages("live")).resolves.toEqual([
+      expect.objectContaining({ id: "local-user", content: "prompt first" }),
+      expect.objectContaining({
+        id: "text-stream-1",
+        content: "answer second",
+      }),
+    ]);
+  });
+
+  it("does not hide repeated same-content in-flight assistant messages", async () => {
+    const { state, api } = await makeFixture();
+    const rec = fakeTabRecord([
+      { id: "a1", role: "assistant", content: "Done", createdAt: 10 },
+    ]) as never;
+    state.tabs.set("live", rec);
+    Object.assign(rec, {
+      activeResponseMessageId: "text-stream-1",
+      activeResponseText: "Done",
+    });
+
+    await expect(api.sessions.getMessages("live")).resolves.toEqual([
+      expect.objectContaining({ id: "a1", content: "Done" }),
+      expect.objectContaining({ id: "text-stream-1", content: "Done" }),
+    ]);
+  });
+
+  it("preserves local metadata for repeated same-content live messages", async () => {
+    const { root, state, api } = await makeFixture();
+    const sessionDir = join(root, "sessions", "live");
+    await mkdir(sessionDir, { recursive: true });
+    await writeFile(
+      join(sessionDir, "aethon-chat.jsonl"),
+      [
+        JSON.stringify({
+          type: "aethon_chat",
+          id: "local-1",
+          role: "user",
+          text: "same prompt",
+          attachments: [
+            {
+              id: "img-1",
+              kind: "image",
+              path: "/repo/live/one.png",
+              name: "one.png",
+              mimeType: "image/png",
+              sizeBytes: 1,
+            },
+          ],
+          createdAt: 10,
+          cwd: "/repo/live",
+        }),
+        JSON.stringify({
+          type: "aethon_chat",
+          id: "local-2",
+          role: "user",
+          text: "same prompt",
+          attachments: [
+            {
+              id: "img-2",
+              kind: "image",
+              path: "/repo/live/two.png",
+              name: "two.png",
+              mimeType: "image/png",
+              sizeBytes: 2,
+            },
+          ],
+          createdAt: 20,
+          cwd: "/repo/live",
+        }),
+      ].join("\n") + "\n",
+    );
+    state.tabs.set(
+      "live",
+      fakeTabRecord([
+        { id: "u1", role: "user", content: "same prompt", createdAt: 10 },
+        { id: "u2", role: "user", content: "same prompt", createdAt: 20 },
+      ]) as never,
+    );
+    state.tabProjectCwds.set("live", "/repo/live");
+
+    await expect(api.sessions.getMessages("live")).resolves.toEqual([
+      expect.objectContaining({
+        id: "u1",
+        attachments: [expect.objectContaining({ id: "img-1" })],
+      }),
+      expect.objectContaining({
+        id: "u2",
+        attachments: [expect.objectContaining({ id: "img-2" })],
+      }),
+    ]);
+  });
+
+  it("contains rejected async session handlers", async () => {
+    const { state, api } = await makeFixture();
+    const calls: unknown[] = [];
+    api.sessions.on("messageAppended", (payload) => {
+      calls.push(payload);
+      return Promise.reject(new Error("handler failed"));
+    });
+
+    emitSessionEvent(state, "messageAppended", {
+      sessionId: "live",
+      message: { id: "m", role: "user", content: "hi" },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(calls).toHaveLength(1);
+  });
+
+  it("registers project-scoped subscriptions for project unload cleanup", async () => {
+    const { state, api } = await makeFixture();
+    state.currentExtensionLoadScope = "project";
+    const handler = () => {};
+
+    const off = api.sessions.on("messageAppended", handler);
+
+    expect(
+      state.sessionEventHandlers.get("messageAppended")?.has(handler),
+    ).toBe(true);
+    expect(state.projectExtensionTeardowns).toHaveLength(1);
+    state.projectExtensionTeardowns[0]?.();
+    expect(
+      state.sessionEventHandlers.get("messageAppended")?.has(handler),
+    ).toBe(false);
+    off();
+  });
+
+  it("formats a markdown transcript", async () => {
+    const { state, api } = await makeFixture();
+    state.tabs.set(
+      "live",
+      fakeTabRecord([
+        { role: "user", content: "hello" },
+        { role: "assistant", content: "hi back" },
+      ]) as never,
+    );
+
+    await expect(api.sessions.getTranscript("live")).resolves.toBe(
+      "## User\n\nhello\n\n## Agent\n\nhi back",
+    );
+  });
+});

--- a/agent/aethon-api-sessions.test.ts
+++ b/agent/aethon-api-sessions.test.ts
@@ -4,7 +4,10 @@ import { tmpdir } from "node:os";
 import { describe, expect, it } from "vitest";
 import { AethonAgentState, type AethonAgentStateOptions } from "./state";
 import { buildAethonApi } from "./aethon-api";
-import { emitSessionEvent } from "./aethon-api-sessions";
+import {
+  emitSessionEvent,
+  handleMirroredTabsChanged,
+} from "./aethon-api-sessions";
 import type { RuntimeSnapshot } from "./system-prompt";
 
 function opts(root: string): AethonAgentStateOptions {
@@ -476,6 +479,101 @@ describe("aethon.sessions API", () => {
     await Promise.resolve();
 
     expect(calls).toHaveLength(1);
+  });
+
+  it("does not emit sessionChanged for waiting-only frontend tab patches", async () => {
+    const { state, api } = await makeFixture();
+    state.tabs.set("live", fakeTabRecord() as never);
+    state.frontendState.set("/tabs", [
+      {
+        id: "live",
+        label: "Live",
+        kind: "agent",
+        cwd: "/repo",
+        model: "openai/gpt-test",
+        active: true,
+        waiting: false,
+      },
+    ]);
+    const calls: unknown[] = [];
+    api.sessions.on("sessionChanged", (payload) => calls.push(payload));
+
+    handleMirroredTabsChanged(
+      state,
+      [
+        {
+          id: "live",
+          label: "Live",
+          kind: "agent",
+          cwd: "/repo",
+          model: "openai/gpt-test",
+          active: true,
+          waiting: false,
+        },
+      ],
+      [
+        {
+          id: "live",
+          label: "Live",
+          kind: "agent",
+          cwd: "/repo",
+          model: "openai/gpt-test",
+          active: true,
+          waiting: true,
+        },
+      ],
+    );
+    await Promise.resolve();
+
+    expect(calls).toEqual([]);
+  });
+
+  it("emits sessionChanged for stable frontend tab metadata patches", async () => {
+    const { state, api } = await makeFixture();
+    state.tabs.set("live", fakeTabRecord() as never);
+    state.frontendState.set("/tabs", [
+      {
+        id: "live",
+        label: "Renamed",
+        kind: "agent",
+        cwd: "/repo",
+        model: "openai/gpt-test",
+        active: true,
+      },
+    ]);
+    const calls: unknown[] = [];
+    api.sessions.on("sessionChanged", (payload) => calls.push(payload));
+
+    handleMirroredTabsChanged(
+      state,
+      [
+        {
+          id: "live",
+          label: "Live",
+          kind: "agent",
+          cwd: "/repo",
+          model: "openai/gpt-test",
+          active: true,
+        },
+      ],
+      [
+        {
+          id: "live",
+          label: "Renamed",
+          kind: "agent",
+          cwd: "/repo",
+          model: "openai/gpt-test",
+          active: true,
+        },
+      ],
+    );
+    await Promise.resolve();
+
+    expect(calls).toEqual([
+      expect.objectContaining({
+        session: expect.objectContaining({ id: "live", label: "Renamed" }),
+      }),
+    ]);
   });
 
   it("registers project-scoped subscriptions for project unload cleanup", async () => {

--- a/agent/aethon-api-sessions.ts
+++ b/agent/aethon-api-sessions.ts
@@ -1,0 +1,579 @@
+import type { Api, Model } from "@mariozechner/pi-ai";
+import { stripExpandedFileReferences } from "./file-references";
+import type { AethonAgentState, TabRecord } from "./state";
+import {
+  readSessionTranscript,
+  type RestoredChatMessage,
+} from "./session-history";
+import { textFromContent, thinkingFromContent } from "./session-history/shared";
+import { tabSessionDir } from "./tab-lifecycle";
+
+export interface SessionSummary {
+  id: string;
+  label: string;
+  active: boolean;
+  model: string;
+  cwd?: string;
+  messageCount: number;
+  createdAt?: number;
+  updatedAt?: number;
+}
+
+export interface SessionMessage {
+  id: string;
+  role: "user" | "agent" | "system";
+  /** Canonical plain-text body for extension consumers. */
+  content: string;
+  /** Alias retained for Aethon's chat message shape. */
+  text?: string;
+  thinking?: string;
+  createdAt?: number;
+  metadata?: Record<string, unknown>;
+  attachments?: unknown[];
+  a2ui?: { components: unknown[] };
+}
+
+export interface SessionMessageOptions {
+  /** Return only the most recent N messages. Values below 1 are ignored. */
+  limit?: number;
+}
+
+export interface SessionsApi {
+  list(): Promise<SessionSummary[]>;
+  getActive(): Promise<SessionSummary | null>;
+  getMessages(
+    sessionId: string,
+    options?: SessionMessageOptions,
+  ): Promise<SessionMessage[]>;
+  getTranscript(
+    sessionId: string,
+    options?: SessionMessageOptions,
+  ): Promise<string>;
+  on(event: SessionEventName, handler: SessionEventHandler): () => void;
+}
+
+type FrontendTabSummary = {
+  id?: unknown;
+  label?: unknown;
+  kind?: unknown;
+  cwd?: unknown;
+  model?: unknown;
+  active?: unknown;
+};
+
+export type SessionEventName =
+  | "activeChanged"
+  | "messageAppended"
+  | "messageUpdated"
+  | "sessionChanged";
+
+export type SessionEventPayload =
+  | { sessionId: string | null; session?: SessionSummary }
+  | { sessionId: string; message: SessionMessage }
+  | { sessionId: string; messageId: string; message: SessionMessage }
+  | { session: SessionSummary };
+
+export type SessionEventHandler = (
+  payload: SessionEventPayload,
+) => void | Promise<void>;
+
+function sessionMessageKey(sessionId: string, messageId: string): string {
+  return `${sessionId}\0${messageId}`;
+}
+
+function emittedSessionMessageIds(state: AethonAgentState): Set<string> {
+  const holder = state as { emittedSessionMessageIds?: Set<string> };
+  holder.emittedSessionMessageIds ??= new Set<string>();
+  return holder.emittedSessionMessageIds;
+}
+
+export function hasEmittedSessionMessage(
+  state: AethonAgentState,
+  sessionId: string,
+  messageId: string,
+): boolean {
+  return emittedSessionMessageIds(state).has(
+    sessionMessageKey(sessionId, messageId),
+  );
+}
+
+function rememberEmittedMessage(
+  state: AethonAgentState,
+  payload: SessionEventPayload,
+): void {
+  if (!("message" in payload) || typeof payload.sessionId !== "string") return;
+  emittedSessionMessageIds(state).add(
+    sessionMessageKey(payload.sessionId, payload.message.id),
+  );
+}
+
+function modelKey(model: Model<Api> | undefined): string {
+  if (!model) return "";
+  return `${model.provider}/${model.id}`;
+}
+
+function fallbackLabel(id: string): string {
+  return id === "default" ? "Default" : `Session ${id.slice(0, 8)}`;
+}
+
+function isAgentFrontendTab(tab: FrontendTabSummary): boolean {
+  // Older mirrors did not include `kind`; treat missing as an agent tab for
+  // compatibility, but exclude explicit shell/editor tabs from session APIs.
+  return tab.kind === undefined || tab.kind === "agent";
+}
+
+function frontendTabs(
+  state: AethonAgentState,
+): Map<string, FrontendTabSummary> {
+  const value = state.frontendState.get("/tabs");
+  const map = new Map<string, FrontendTabSummary>();
+  if (!Array.isArray(value)) return map;
+  for (const item of value) {
+    if (!item || typeof item !== "object") continue;
+    const tab = item as FrontendTabSummary;
+    if (typeof tab.id !== "string" || !isAgentFrontendTab(tab)) continue;
+    map.set(tab.id, tab);
+  }
+  return map;
+}
+
+function messageCountFor(record: TabRecord | undefined): number {
+  return Array.isArray(record?.session.messages)
+    ? record.session.messages.length
+    : 0;
+}
+
+export function listSessionSummaries(
+  state: AethonAgentState,
+): SessionSummary[] {
+  const front = frontendTabs(state);
+  const summaries = new Map<string, SessionSummary>();
+
+  for (const [id, tab] of front) {
+    const record = state.tabs.get(id);
+    const label =
+      typeof tab.label === "string" && tab.label
+        ? tab.label
+        : fallbackLabel(id);
+    const cwd =
+      typeof tab.cwd === "string"
+        ? tab.cwd
+        : (state.tabProjectCwds.get(id) ?? undefined);
+    summaries.set(id, {
+      id,
+      label,
+      active: tab.active === true,
+      model:
+        typeof tab.model === "string"
+          ? tab.model
+          : modelKey(record?.session.model),
+      ...(cwd ? { cwd } : {}),
+      messageCount: messageCountFor(record),
+    });
+  }
+
+  for (const [id, record] of state.tabs) {
+    const existing = summaries.get(id);
+    if (existing) {
+      summaries.set(id, {
+        ...existing,
+        model: existing.model || modelKey(record.session.model),
+        messageCount: Math.max(existing.messageCount, messageCountFor(record)),
+        ...(state.tabProjectCwds.has(id)
+          ? { cwd: state.tabProjectCwds.get(id) }
+          : {}),
+      });
+      continue;
+    }
+    const cwd = state.tabProjectCwds.get(id);
+    summaries.set(id, {
+      id,
+      label: fallbackLabel(id),
+      active: false,
+      model: modelKey(record.session.model),
+      ...(cwd ? { cwd } : {}),
+      messageCount: messageCountFor(record),
+    });
+  }
+
+  for (const tab of state.discoveredTabs) {
+    if (summaries.has(tab.tabId)) continue;
+    const label =
+      tab.customLabel ?? tab.firstUserMessage ?? fallbackLabel(tab.tabId);
+    summaries.set(tab.tabId, {
+      id: tab.tabId,
+      label,
+      active: false,
+      model: "",
+      ...(tab.cwd ? { cwd: tab.cwd } : {}),
+      messageCount: 0,
+      updatedAt: tab.lastModified,
+    });
+  }
+
+  return [...summaries.values()];
+}
+
+export function activeSessionSummary(
+  state: AethonAgentState,
+): SessionSummary | null {
+  return listSessionSummaries(state).find((session) => session.active) ?? null;
+}
+
+function roleFromPi(role: unknown): SessionMessage["role"] | undefined {
+  if (role === "assistant" || role === "agent") return "agent";
+  if (role === "user" || role === "system") return role;
+  return undefined;
+}
+
+function timestampFrom(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Date.parse(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+const PLAN_MODE_PREFIX =
+  "You are in Aethon plan mode. Do not edit files, run shell commands, start implementation tasks, commit, push, or make persistent changes. Inspect read-only context as needed, then propose a concise implementation plan with risks and tests. Wait for the user to switch back to implementation mode or explicitly approve implementation.\n\nUser request:\n";
+
+function visibleUserContent(content: string): string {
+  const stripped = stripExpandedFileReferences(content);
+  return stripped.startsWith(PLAN_MODE_PREFIX)
+    ? stripped.slice(PLAN_MODE_PREFIX.length)
+    : stripped;
+}
+
+function messageId(record: Record<string, unknown>, index: number): string {
+  for (const key of ["id", "messageId", "entryId"]) {
+    const value = record[key];
+    if (typeof value === "string" && value.length > 0) return value;
+  }
+  return `message-${index}`;
+}
+
+function liveMessageFromPi(raw: unknown, index: number): SessionMessage | null {
+  if (!raw || typeof raw !== "object") return null;
+  const record = raw as Record<string, unknown>;
+  const role = roleFromPi(record.role);
+  if (!role) return null;
+  const rawContent = textFromContent(record.content);
+  const content = role === "user" ? visibleUserContent(rawContent) : rawContent;
+  const thinking = thinkingFromContent(record.content);
+  if (!content && !thinking) return null;
+  const metadata: Record<string, unknown> = {};
+  for (const key of ["stopReason", "usage", "model", "provider"]) {
+    if (record[key] !== undefined) metadata[key] = record[key];
+  }
+  const createdAt = timestampFrom(record.createdAt ?? record.timestamp);
+  return {
+    id: messageId(record, index),
+    role,
+    content,
+    ...(content ? { text: content } : {}),
+    ...(thinking ? { thinking } : {}),
+    ...(createdAt !== undefined ? { createdAt } : {}),
+    ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
+  };
+}
+
+function messageFromRestored(message: RestoredChatMessage): SessionMessage {
+  const content = message.text ?? "";
+  return {
+    id: message.id,
+    role: message.role,
+    content,
+    ...(message.text ? { text: message.text } : {}),
+    ...(message.thinking ? { thinking: message.thinking } : {}),
+    ...(message.createdAt !== undefined
+      ? { createdAt: message.createdAt }
+      : {}),
+    ...(message.attachments ? { attachments: message.attachments } : {}),
+    ...(message.a2ui ? { a2ui: message.a2ui } : {}),
+  };
+}
+
+function applyOptions(
+  messages: SessionMessage[],
+  options: SessionMessageOptions | undefined,
+): SessionMessage[] {
+  const limit = options?.limit;
+  if (typeof limit !== "number" || !Number.isFinite(limit) || limit < 1) {
+    return messages;
+  }
+  return messages.slice(-Math.floor(limit));
+}
+
+function normalizedContentKey(message: SessionMessage): string | undefined {
+  const content = message.content.replace(/\s+/g, " ").trim();
+  const thinking = message.thinking?.replace(/\s+/g, " ").trim() ?? "";
+  if (!content && !thinking) return undefined;
+  return `${message.role}\0${content}\0${thinking}`;
+}
+
+function activeResponseMessage(
+  record: TabRecord | undefined,
+): SessionMessage[] {
+  if (!record?.activeResponseMessageId) return [];
+  const content = record.activeResponseText ?? "";
+  const thinking = record.activeResponseThinking ?? "";
+  if (!content && !thinking) return [];
+  return [
+    {
+      id: record.activeResponseMessageId,
+      role: "agent",
+      content,
+      ...(content ? { text: content } : {}),
+      ...(thinking ? { thinking } : {}),
+    },
+  ];
+}
+
+function enrichMessage(
+  base: SessionMessage,
+  addition: SessionMessage,
+  options: { preferAdditionContent?: boolean } = {},
+): SessionMessage {
+  const next: SessionMessage = { ...base };
+  if (options.preferAdditionContent) {
+    next.content = addition.content;
+    if (addition.text !== undefined) next.text = addition.text;
+    else delete next.text;
+    if (addition.thinking !== undefined) next.thinking = addition.thinking;
+    else delete next.thinking;
+  }
+  if (base.createdAt === undefined && addition.createdAt !== undefined) {
+    next.createdAt = addition.createdAt;
+  }
+  if (base.attachments === undefined && addition.attachments !== undefined) {
+    next.attachments = addition.attachments;
+  }
+  if (base.a2ui === undefined && addition.a2ui !== undefined) {
+    next.a2ui = addition.a2ui;
+  }
+  if (base.metadata === undefined && addition.metadata !== undefined) {
+    next.metadata = addition.metadata;
+  }
+  return next;
+}
+
+function mergeMessages(
+  liveMessages: SessionMessage[],
+  restoredMessages: SessionMessage[],
+  options: { matchContent?: boolean; preferAdditionContentOnId?: boolean } = {},
+): SessionMessage[] {
+  if (liveMessages.length === 0) return restoredMessages;
+  if (restoredMessages.length === 0) return liveMessages;
+  const matchContent = options.matchContent !== false;
+  const contentIndex = new Map<string, number[]>();
+  const merged = [...liveMessages];
+  const idIndex = new Map(merged.map((message, index) => [message.id, index]));
+  const consumeContentIndex = (
+    key: string | undefined,
+    index?: number,
+  ): number | undefined => {
+    if (!key) return undefined;
+    const queue = contentIndex.get(key);
+    if (!queue || queue.length === 0) return undefined;
+    if (index === undefined) return queue.shift();
+    const position = queue.indexOf(index);
+    if (position >= 0) queue.splice(position, 1);
+    return index;
+  };
+  if (matchContent) {
+    for (let index = 0; index < merged.length; index += 1) {
+      const key = normalizedContentKey(merged[index]);
+      if (!key) continue;
+      const queue = contentIndex.get(key) ?? [];
+      queue.push(index);
+      contentIndex.set(key, queue);
+    }
+  }
+  for (const restored of restoredMessages) {
+    const key = normalizedContentKey(restored);
+    const idMatch = idIndex.get(restored.id);
+    const existingIndex =
+      idMatch ?? (matchContent && key ? consumeContentIndex(key) : undefined);
+    if (existingIndex !== undefined) {
+      if (idMatch !== undefined) consumeContentIndex(key, existingIndex);
+      merged[existingIndex] = enrichMessage(merged[existingIndex], restored, {
+        preferAdditionContent:
+          options.preferAdditionContentOnId === true && idMatch !== undefined,
+      });
+      continue;
+    }
+    idIndex.set(restored.id, merged.length);
+    merged.push(restored);
+  }
+  return merged
+    .map((message, order) => ({ message, order }))
+    .sort((a, b) => {
+      if (
+        typeof a.message.createdAt === "number" &&
+        typeof b.message.createdAt === "number" &&
+        a.message.createdAt !== b.message.createdAt
+      ) {
+        return a.message.createdAt - b.message.createdAt;
+      }
+      return a.order - b.order;
+    })
+    .map((entry) => entry.message);
+}
+
+async function messagesForSession(
+  state: AethonAgentState,
+  sessionId: string,
+  options?: SessionMessageOptions,
+): Promise<SessionMessage[]> {
+  const live = state.tabs.get(sessionId);
+  const livePiMessages = Array.isArray(live?.session.messages)
+    ? live.session.messages.flatMap((message, index) => {
+        const normalized = liveMessageFromPi(message, index);
+        return normalized ? [normalized] : [];
+      })
+    : [];
+  const summary = listSessionSummaries(state).find((s) => s.id === sessionId);
+  const expectedCwd =
+    state.tabProjectCwds.get(sessionId) ?? summary?.cwd ?? undefined;
+  const restored = await readSessionTranscript(
+    tabSessionDir(state, sessionId),
+    expectedCwd,
+  );
+  const durableMessages = mergeMessages(
+    livePiMessages,
+    restored.map(messageFromRestored),
+  );
+  return applyOptions(
+    mergeMessages(durableMessages, activeResponseMessage(live), {
+      matchContent: false,
+      preferAdditionContentOnId: true,
+    }),
+    options,
+  );
+}
+
+function transcriptFromMessages(messages: SessionMessage[]): string {
+  return messages
+    .map((message) => {
+      const title =
+        message.role === "agent"
+          ? "Agent"
+          : message.role[0].toUpperCase() + message.role.slice(1);
+      const chunks: string[] = [];
+      if (message.thinking)
+        chunks.push(
+          `> Thinking\n>\n${message.thinking
+            .split("\n")
+            .map((line) => `> ${line}`)
+            .join("\n")}`,
+        );
+      if (message.content) chunks.push(message.content);
+      if (!message.content && message.a2ui) chunks.push("[A2UI content]");
+      if (!chunks.length) chunks.push("[empty]");
+      return `## ${title}\n\n${chunks.join("\n\n")}`;
+    })
+    .join("\n\n");
+}
+
+export function emitSessionEvent(
+  state: AethonAgentState,
+  event: SessionEventName,
+  payload: SessionEventPayload,
+): void {
+  const registry = (
+    state as { sessionEventHandlers?: AethonAgentState["sessionEventHandlers"] }
+  ).sessionEventHandlers;
+  rememberEmittedMessage(state, payload);
+  const handlers = registry?.get(event) as Set<SessionEventHandler> | undefined;
+  if (!handlers || handlers.size === 0) return;
+  for (const handler of handlers) {
+    queueMicrotask(() => {
+      try {
+        Promise.resolve(handler(payload)).catch(() => {
+          // Extension event handlers should not break bridge/session flow.
+        });
+      } catch {
+        // Extension event handlers should not break bridge/session flow.
+      }
+    });
+  }
+}
+
+function activeAgentIdFromMirroredTabs(value: unknown): string | undefined {
+  if (!Array.isArray(value)) return undefined;
+  for (const item of value) {
+    if (!item || typeof item !== "object") continue;
+    const tab = item as FrontendTabSummary;
+    if (
+      tab.active === true &&
+      typeof tab.id === "string" &&
+      isAgentFrontendTab(tab)
+    ) {
+      return tab.id;
+    }
+  }
+  return undefined;
+}
+
+export function handleMirroredTabsChanged(
+  state: AethonAgentState,
+  previous: unknown,
+  next: unknown,
+): void {
+  if (!Array.isArray(next)) return;
+  const previousActive = activeAgentIdFromMirroredTabs(previous);
+  const nextActive = activeAgentIdFromMirroredTabs(next);
+  if (previousActive !== nextActive) {
+    const session =
+      typeof nextActive === "string"
+        ? listSessionSummaries(state).find((s) => s.id === nextActive)
+        : undefined;
+    emitSessionEvent(state, "activeChanged", {
+      sessionId: typeof nextActive === "string" ? nextActive : null,
+      ...(session ? { session } : {}),
+    });
+  }
+  for (const item of next) {
+    if (!item || typeof item !== "object") continue;
+    const tab = item as FrontendTabSummary;
+    if (typeof tab.id !== "string" || !isAgentFrontendTab(tab)) continue;
+    const session = listSessionSummaries(state).find((s) => s.id === tab.id);
+    if (session) emitSessionEvent(state, "sessionChanged", { session });
+  }
+}
+
+export function buildSessionsApi(state: AethonAgentState): SessionsApi {
+  return {
+    list: () => Promise.resolve(listSessionSummaries(state)),
+    getActive: () => Promise.resolve(activeSessionSummary(state)),
+    getMessages: async (sessionId, options) => {
+      if (typeof sessionId !== "string" || sessionId.length === 0) return [];
+      return messagesForSession(state, sessionId, options);
+    },
+    getTranscript: async (sessionId, options) => {
+      if (typeof sessionId !== "string" || sessionId.length === 0) return "";
+      return transcriptFromMessages(
+        await messagesForSession(state, sessionId, options),
+      );
+    },
+    on(event: SessionEventName, handler: SessionEventHandler) {
+      if (typeof handler !== "function") return () => {};
+      let handlers = state.sessionEventHandlers.get(event) as
+        | Set<SessionEventHandler>
+        | undefined;
+      if (!handlers) {
+        handlers = new Set<SessionEventHandler>();
+        state.sessionEventHandlers.set(event, handlers);
+      }
+      handlers.add(handler);
+      const off = () => {
+        handlers?.delete(handler);
+      };
+      if (state.currentExtensionLoadScope === "project") {
+        state.projectExtensionTeardowns.push(off);
+      }
+      return off;
+    },
+  };
+}

--- a/agent/aethon-api-sessions.ts
+++ b/agent/aethon-api-sessions.ts
@@ -516,6 +516,34 @@ function activeAgentIdFromMirroredTabs(value: unknown): string | undefined {
   return undefined;
 }
 
+function mirroredAgentTabsById(
+  value: unknown,
+): Map<string, FrontendTabSummary> {
+  const tabs = new Map<string, FrontendTabSummary>();
+  if (!Array.isArray(value)) return tabs;
+  for (const item of value) {
+    if (!item || typeof item !== "object") continue;
+    const tab = item as FrontendTabSummary;
+    if (typeof tab.id === "string" && isAgentFrontendTab(tab)) {
+      tabs.set(tab.id, tab);
+    }
+  }
+  return tabs;
+}
+
+function sessionMetadataChanged(
+  previous: FrontendTabSummary | undefined,
+  next: FrontendTabSummary,
+): boolean {
+  if (!previous) return true;
+  return (
+    previous.label !== next.label ||
+    previous.model !== next.model ||
+    previous.cwd !== next.cwd ||
+    previous.active !== next.active
+  );
+}
+
 export function handleMirroredTabsChanged(
   state: AethonAgentState,
   previous: unknown,
@@ -534,10 +562,12 @@ export function handleMirroredTabsChanged(
       ...(session ? { session } : {}),
     });
   }
+  const previousTabs = mirroredAgentTabsById(previous);
   for (const item of next) {
     if (!item || typeof item !== "object") continue;
     const tab = item as FrontendTabSummary;
     if (typeof tab.id !== "string" || !isAgentFrontendTab(tab)) continue;
+    if (!sessionMetadataChanged(previousTabs.get(tab.id), tab)) continue;
     const session = listSessionSummaries(state).find((s) => s.id === tab.id);
     if (session) emitSessionEvent(state, "sessionChanged", { session });
   }

--- a/agent/aethon-api-shells.test.ts
+++ b/agent/aethon-api-shells.test.ts
@@ -65,6 +65,52 @@ describe("buildShellsApi", () => {
     }
   });
 
+  it("create uses a startup-sized timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      const { state, sent, api } = makeFixture();
+      markFrontendReady(state);
+      let settled = false;
+      const p = api.create({ cwd: "/repo" }).then((result) => {
+        settled = true;
+        return result;
+      });
+      expect(sent.at(-1)).toMatchObject({ op: "create" });
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(settled).toBe(false);
+      await vi.advanceTimersByTimeAsync(55_000);
+      await expect(p).resolves.toEqual({ ok: false, error: "timeout" });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("create forwards shell creation queries", async () => {
+    const { state, sent, api } = makeFixture();
+    markFrontendReady(state);
+    const p = api.create({
+      cwd: "/repo",
+      command: "zsh",
+      args: ["-l"],
+      activate: false,
+    });
+    const msg = sent.at(-1)!;
+    expect(msg).toMatchObject({
+      type: "shell_query",
+      op: "create",
+      args: {
+        cwd: "/repo",
+        command: "zsh",
+        args: ["-l"],
+        activate: false,
+      },
+    });
+    ackMutation(state, msg.mutationId as string, true, undefined, {
+      tabId: "shell-1",
+    });
+    await expect(p).resolves.toEqual({ ok: true, data: { tabId: "shell-1" } });
+  });
+
   it("read forwards a shell_query with optional bounds once ready", async () => {
     const { state, sent, api } = makeFixture();
     markFrontendReady(state);
@@ -75,7 +121,9 @@ describe("buildShellsApi", () => {
       op: "read",
       args: { tabId: "tab-1", sinceTotal: 10, maxBytes: 256 },
     });
-    ackMutation(state, msg.mutationId as string, true, undefined, { lines: [] });
+    ackMutation(state, msg.mutationId as string, true, undefined, {
+      lines: [],
+    });
     await expect(p).resolves.toEqual({ ok: true, data: { lines: [] } });
   });
 

--- a/agent/aethon-api-shells.ts
+++ b/agent/aethon-api-shells.ts
@@ -16,6 +16,7 @@ export interface ShellsApiDeps {
 }
 
 const SHELL_WRITE_ACK_TIMEOUT_MS = 5 * 60 * 1000; // 5 min — user may step away
+const SHELL_CREATE_ACK_TIMEOUT_MS = 60_000;
 const MUTATION_ACK_TIMEOUT_MS_DEFAULT = 5_000;
 
 export function buildShellsApi(
@@ -24,7 +25,7 @@ export function buildShellsApi(
 ): ShellsApi {
   // -- shells.list/read/write --------------------------------------------
   async function shellQuery(
-    op: "list" | "read" | "write",
+    op: "list" | "create" | "read" | "write",
     args: Record<string, unknown> = {},
     timeoutMs?: number,
   ): Promise<MutationResult> {
@@ -45,6 +46,34 @@ export function buildShellsApi(
 
   return {
     list: () => shellQuery("list"),
+    create: (input = {}) => {
+      const args = input && typeof input === "object" ? input : {};
+      return shellQuery(
+        "create",
+        {
+          ...(typeof args.tabId === "string" && args.tabId.trim()
+            ? { tabId: args.tabId.trim() }
+            : {}),
+          ...(typeof args.cwd === "string" && args.cwd.length > 0
+            ? { cwd: args.cwd }
+            : {}),
+          ...(typeof args.command === "string" && args.command.length > 0
+            ? { command: args.command }
+            : {}),
+          ...(Array.isArray(args.args) &&
+          args.args.every((a) => typeof a === "string")
+            ? { args: args.args }
+            : {}),
+          ...(typeof args.activate === "boolean"
+            ? { activate: args.activate }
+            : {}),
+          ...(typeof args.inheritEnv === "boolean"
+            ? { inheritEnv: args.inheritEnv }
+            : {}),
+        },
+        SHELL_CREATE_ACK_TIMEOUT_MS,
+      );
+    },
     read: (input) => {
       if (!input || typeof input.tabId !== "string" || !input.tabId) {
         return Promise.resolve({ ok: false, error: "tabId required" });

--- a/agent/aethon-api-windows.test.ts
+++ b/agent/aethon-api-windows.test.ts
@@ -97,6 +97,39 @@ describe("buildWindowsApi", () => {
     expect(sent).toHaveLength(0);
   });
 
+  it("get/getState/getCanvas forward read queries for a window id", async () => {
+    const { state, sent, api } = makeFixture();
+    markFrontendReady(state);
+
+    const p = api.get("Workpad");
+    await Promise.resolve();
+    let msg = sent.at(-1)!;
+    expect(msg).toMatchObject({
+      type: "native_window_query",
+      op: "get",
+      args: { id: "Workpad" },
+    });
+    ackMutation(state, msg.mutationId as string, true, undefined, {
+      id: "Workpad",
+      label: "aethon-canvas-Workpad",
+      kind: "canvas",
+      title: "Workpad",
+      components: [],
+      state: { count: 1 },
+    });
+    await expect(p).resolves.toMatchObject({ ok: true });
+
+    void api.getState("Workpad");
+    await Promise.resolve();
+    msg = sent.at(-1)!;
+    expect(msg).toMatchObject({ op: "get_state", args: { id: "Workpad" } });
+
+    void api.getCanvas("Workpad");
+    await Promise.resolve();
+    msg = sent.at(-1)!;
+    expect(msg).toMatchObject({ op: "get_canvas", args: { id: "Workpad" } });
+  });
+
   it("list replaces the known window summary cache", async () => {
     const { state, sent, api } = makeFixture();
     state.nativeWindows.set("Old", {

--- a/agent/aethon-api-windows.test.ts
+++ b/agent/aethon-api-windows.test.ts
@@ -97,6 +97,63 @@ describe("buildWindowsApi", () => {
     expect(sent).toHaveLength(0);
   });
 
+  it("openTerminal uses a PTY-startup-sized timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      const { state, sent, api } = makeFixture();
+      markFrontendReady(state);
+      let settled = false;
+      const p = api.openTerminal({ cwd: "/repo" }).then((result) => {
+        settled = true;
+        return result;
+      });
+      await Promise.resolve();
+      expect(sent.at(-1)).toMatchObject({ op: "open_terminal" });
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(settled).toBe(false);
+      await vi.advanceTimersByTimeAsync(30_000);
+      await expect(p).resolves.toEqual({ ok: false, error: "timeout" });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("openTerminal forwards terminal window queries", async () => {
+    const { state, sent, api } = makeFixture();
+    markFrontendReady(state);
+    const p = api.openTerminal({
+      id: "Term",
+      title: "Terminal",
+      cwd: "/repo",
+      command: "zsh",
+      args: ["-l"],
+      activateShell: false,
+    });
+    await Promise.resolve();
+    const msg = sent.at(-1)!;
+    expect(msg).toMatchObject({
+      type: "native_window_query",
+      op: "open_terminal",
+      args: {
+        id: "Term",
+        title: "Terminal",
+        cwd: "/repo",
+        command: "zsh",
+        args: ["-l"],
+        activateShell: false,
+      },
+    });
+    ackMutation(state, msg.mutationId as string, true, undefined, {
+      id: "Term",
+      label: "aethon-canvas-Term",
+      kind: "canvas",
+      title: "Terminal",
+      components: [],
+      state: {},
+    });
+    await expect(p).resolves.toMatchObject({ ok: true });
+  });
+
   it("get/getState/getCanvas forward read queries for a window id", async () => {
     const { state, sent, api } = makeFixture();
     markFrontendReady(state);

--- a/agent/aethon-api-windows.ts
+++ b/agent/aethon-api-windows.ts
@@ -24,6 +24,9 @@ const WINDOW_LONG_ACK_TIMEOUT_MS = 30_000;
 type NativeWindowOp =
   | "open_canvas"
   | "list"
+  | "get"
+  | "get_state"
+  | "get_canvas"
   | "focus"
   | "close"
   | "set_title"
@@ -146,6 +149,24 @@ export function buildWindowsApi(
           ? { ...result, data: [...state.nativeWindows.values()] }
           : result,
       );
+    },
+    get(id) {
+      if (!idRequired(id)) {
+        return Promise.resolve({ ok: false, error: "id required" });
+      }
+      return windowQuery("get", { id });
+    },
+    getState(id) {
+      if (!idRequired(id)) {
+        return Promise.resolve({ ok: false, error: "id required" });
+      }
+      return windowQuery("get_state", { id });
+    },
+    getCanvas(id) {
+      if (!idRequired(id)) {
+        return Promise.resolve({ ok: false, error: "id required" });
+      }
+      return windowQuery("get_canvas", { id });
     },
     focus(id) {
       if (!idRequired(id)) {

--- a/agent/aethon-api-windows.ts
+++ b/agent/aethon-api-windows.ts
@@ -20,9 +20,11 @@ export interface WindowsApiDeps {
 
 const MUTATION_ACK_TIMEOUT_MS_DEFAULT = 5_000;
 const WINDOW_LONG_ACK_TIMEOUT_MS = 30_000;
+const WINDOW_TERMINAL_ACK_TIMEOUT_MS = 60_000;
 
 type NativeWindowOp =
   | "open_canvas"
+  | "open_terminal"
   | "list"
   | "get"
   | "get_state"
@@ -142,6 +144,14 @@ export function buildWindowsApi(
           : {};
       if (typeof args.tabId !== "string") args.tabId = ownerTabId(state);
       return windowQuery("open_canvas", args, WINDOW_LONG_ACK_TIMEOUT_MS);
+    },
+    openTerminal(input = {}) {
+      const args =
+        input && typeof input === "object"
+          ? { ...(input as Record<string, unknown>) }
+          : {};
+      if (typeof args.tabId !== "string") args.tabId = ownerTabId(state);
+      return windowQuery("open_terminal", args, WINDOW_TERMINAL_ACK_TIMEOUT_MS);
     },
     list() {
       return windowQuery("list").then((result) =>

--- a/agent/aethon-api.test.ts
+++ b/agent/aethon-api.test.ts
@@ -77,6 +77,7 @@ describe("buildAethonApi", () => {
     expect(typeof api.canvas).toBe("object");
     expect(typeof api.shells).toBe("object");
     expect(typeof api.editor).toBe("object");
+    expect(typeof api.sessions).toBe("object");
     expect(typeof api.windows).toBe("object");
   });
 

--- a/agent/aethon-api.ts
+++ b/agent/aethon-api.ts
@@ -54,6 +54,7 @@ import type { RuntimeSnapshot } from "./system-prompt";
 import { buildShellsApi } from "./aethon-api-shells";
 import { buildDashboardApi, buildTasksApi } from "./aethon-api-dashboard";
 import { buildEditorApi } from "./aethon-api-editor";
+import { buildSessionsApi, type SessionsApi } from "./aethon-api-sessions";
 import { buildWindowsApi } from "./aethon-api-windows";
 
 export interface AethonApiDeps {
@@ -230,6 +231,7 @@ export interface AethonApi {
   tasks: TasksApi;
   dashboard: DashboardApi;
   editor: EditorApi;
+  sessions: SessionsApi;
   windows: WindowsApi;
 }
 
@@ -469,6 +471,7 @@ export function buildAethonApi(
   const tasks = buildTasksApi(state, queryDeps);
   const dashboard = buildDashboardApi(state, queryDeps);
   const editor = buildEditorApi(state, queryDeps);
+  const sessions = buildSessionsApi(state);
   const windows = buildWindowsApi(state, queryDeps);
 
   return {
@@ -525,6 +528,7 @@ export function buildAethonApi(
     tasks,
     dashboard,
     editor,
+    sessions,
     windows,
   };
 }

--- a/agent/aethon-api.ts
+++ b/agent/aethon-api.ts
@@ -90,6 +90,14 @@ const BUILTIN_SLASH_NAMES = new Set([
 
 export interface ShellsApi {
   list(): Promise<MutationResult>;
+  create(input?: {
+    tabId?: string;
+    cwd?: string;
+    command?: string;
+    args?: string[];
+    activate?: boolean;
+    inheritEnv?: boolean;
+  }): Promise<MutationResult>;
   read(input: {
     tabId: string;
     sinceTotal?: number;
@@ -165,6 +173,21 @@ export interface WindowsApi {
     focus?: boolean;
     restoreOnLaunch?: boolean;
     tabId?: string;
+  }): Promise<MutationResult>;
+  openTerminal(input?: {
+    id?: string;
+    title?: string;
+    shellTabId?: string;
+    cwd?: string;
+    command?: string;
+    args?: string[];
+    activateShell?: boolean;
+    width?: number;
+    height?: number;
+    x?: number;
+    y?: number;
+    focus?: boolean;
+    restoreOnLaunch?: false;
   }): Promise<MutationResult>;
   list(): Promise<MutationResult>;
   get(id: string): Promise<MutationResult>;

--- a/agent/aethon-api.ts
+++ b/agent/aethon-api.ts
@@ -167,6 +167,9 @@ export interface WindowsApi {
     tabId?: string;
   }): Promise<MutationResult>;
   list(): Promise<MutationResult>;
+  get(id: string): Promise<MutationResult>;
+  getState(id: string): Promise<MutationResult>;
+  getCanvas(id: string): Promise<MutationResult>;
   focus(id: string): Promise<MutationResult>;
   close(id: string): Promise<MutationResult>;
   setTitle(id: string, title: string): Promise<MutationResult>;

--- a/agent/chat.ts
+++ b/agent/chat.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import type { Api, ImageContent, Model } from "@mariozechner/pi-ai";
 import type { ThinkingLevel } from "@mariozechner/pi-agent-core";
 import type { AethonAgentState, TabRecord } from "./state";
@@ -25,6 +26,7 @@ import {
   FileReferenceError,
   expandFileReferencesInPrompt,
 } from "./file-references";
+import { emitSessionEvent } from "./aethon-api-sessions";
 import { logger } from "./logger";
 
 const chatLog = logger.scope("chat");
@@ -41,8 +43,18 @@ export async function handleChat(
       : undefined;
   const scheduledRun = scheduledRunFromMessage(msg);
   if (!msg.content) {
-    completeScheduledRun(deps, tabId, scheduledRun, false, "chat: missing content");
-    deps.send({ type: "error", message: "chat: missing content", controlRequestId });
+    completeScheduledRun(
+      deps,
+      tabId,
+      scheduledRun,
+      false,
+      "chat: missing content",
+    );
+    deps.send({
+      type: "error",
+      message: "chat: missing content",
+      controlRequestId,
+    });
     return;
   }
   chatLog.info(`received tabId=${tabId} chars=${msg.content.length}`);
@@ -147,7 +159,9 @@ export async function handleChat(
         message: `file references: ${expanded.issues.join("\n")}`,
       });
     }
-    content = planMode ? withPlanModeInstruction(expanded.prompt) : expanded.prompt;
+    content = planMode
+      ? withPlanModeInstruction(expanded.prompt)
+      : expanded.prompt;
   } catch (err) {
     if (mentions.length > 0) state.pendingExplicitSubagent.delete(tabId);
     const message =
@@ -166,6 +180,19 @@ export async function handleChat(
     if (scheduledRun) tab.scheduledRun = undefined;
     return;
   }
+  if (msg.suppressUserSessionEvent !== true && !scheduledRun) {
+    emitSessionEvent(state, "messageAppended", {
+      sessionId: tabId,
+      message: {
+        id: randomUUID(),
+        role: "user",
+        content: msg.content,
+        text: msg.content,
+        createdAt: Date.now(),
+      },
+    });
+  }
+
   const busyForTurn = tab.promptInFlight || isUnderlyingSessionBusy(tab);
   if (busyForTurn && !tab.promptInFlight) {
     tab.promptInFlight = true;

--- a/agent/dispatcher.test.ts
+++ b/agent/dispatcher.test.ts
@@ -20,6 +20,7 @@ import {
   handleStop,
   unloadProjectExtensions,
 } from "./dispatcher";
+import { emitSessionEvent } from "./aethon-api-sessions";
 import { handleSetExtensionDisabled } from "./extensionControl";
 import { projectDisplayName } from "./projectLifecycle";
 
@@ -396,9 +397,7 @@ describe("handleChat", () => {
     expect(f.sent).toContainEqual({ type: "queued", tabId: "tab-1" });
     // A queued message must NOT announce a fresh turn start — the
     // queue-drained agent_start emits prompt_started later instead.
-    expect(
-      f.sent.some((m) => m.type === "prompt_started"),
-    ).toBe(false);
+    expect(f.sent.some((m) => m.type === "prompt_started")).toBe(false);
   });
 
   it("announces prompt_started for a normal turn so backgrounded workspaces show a running dot", async () => {
@@ -626,6 +625,110 @@ describe("handleChat", () => {
     expect(promptCalls).toEqual([]);
     expect(followUpCalls).toEqual([["update?"]]);
     expect(f.sent).toContainEqual({ type: "queued", tabId: "tab-1" });
+  });
+
+  it("does not emit hidden scheduler prompts as direct user events", async () => {
+    const f = makeFixture();
+    const events: unknown[] = [];
+    f.state.tabs.set("tab-1", fakeTabRecord());
+    f.state.sessionEventHandlers.set(
+      "messageAppended",
+      new Set([(payload) => events.push(payload)]),
+    );
+
+    await handleChat(f.state, f.deps, {
+      type: "chat",
+      content:
+        "This is an Aethon scheduled task run.\n\nUser request:\nvisible",
+      tabId: "tab-1",
+      mode: "normal",
+      scheduledTaskId: "task-1",
+      scheduledRunId: "run-1",
+      scheduledVisiblePrompt: "visible",
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(events).toEqual([]);
+  });
+
+  it("does not re-append already streamed assistant messages from local persistence", async () => {
+    const f = makeFixture({
+      sessionsDir: mkdtempSync(join(tmpdir(), "aethon-local-")),
+    });
+    const events: unknown[] = [];
+    emitSessionEvent(f.state, "messageUpdated", {
+      sessionId: "tab-1",
+      messageId: "agent-1",
+      message: { id: "agent-1", role: "agent", content: "hi", text: "hi" },
+    });
+    f.state.sessionEventHandlers.set(
+      "messageAppended",
+      new Set([(payload) => events.push(payload)]),
+    );
+
+    await dispatchInboundMessage(
+      f.state,
+      f.deps,
+      fakeAethonApi(),
+      fakeExtensionApi,
+      {
+        type: "local_chat_message",
+        tabId: "tab-1",
+        payload: { id: "agent-1", role: "agent", text: "hi!" },
+      },
+    );
+
+    expect(events).toEqual([]);
+  });
+
+  it("emits session user events for direct chat unless frontend already mirrored it", async () => {
+    const f = makeFixture();
+    const events: unknown[] = [];
+    const tab = fakeTabRecord({
+      session: {
+        prompt: () => new Promise<void>(() => {}),
+        followUp: () => Promise.resolve(),
+        steer: () => Promise.resolve(),
+      } as unknown as TabRecord["session"],
+    });
+    f.state.tabs.set("tab-1", tab);
+    f.state.sessionEventHandlers.set(
+      "messageAppended",
+      new Set([(payload) => events.push(payload)]),
+    );
+
+    await handleChat(f.state, f.deps, {
+      type: "chat",
+      content: "direct prompt",
+      tabId: "tab-1",
+      mode: "normal",
+      planMode: true,
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        sessionId: "tab-1",
+        message: expect.objectContaining({
+          role: "user",
+          content: "direct prompt",
+        }),
+      }),
+    ]);
+
+    await handleChat(f.state, f.deps, {
+      type: "chat",
+      content: "frontend prompt",
+      tabId: "tab-1",
+      mode: "normal",
+      suppressUserSessionEvent: true,
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(events).toHaveLength(1);
   });
 
   it("passes image attachments to prompt, steer, and followUp", async () => {

--- a/agent/dispatcher.ts
+++ b/agent/dispatcher.ts
@@ -26,6 +26,7 @@ import {
   runtimeConfigFromConfig,
 } from "./runtime-config";
 import { handleForkSession, handleRollbackSession } from "./session-branch";
+import { handleMirroredTabsChanged } from "./aethon-api-sessions";
 import { handleNativeSlashCommand } from "./nativeSlash";
 import { handleSetProject } from "./projectLifecycle";
 import { handleAuthProfileMessage } from "./auth-profiles";
@@ -236,9 +237,14 @@ export async function dispatchInboundMessage(
         break;
       case "frontend_state_patch":
         if (!msg.path || typeof msg.path !== "string") break;
-        state.frontendState.set(msg.path, msg.value);
-        if (msg.path === "/nativeWindows") {
-          mirrorNativeWindowsFromFrontend(state, msg.value);
+        {
+          const previous = state.frontendState.get(msg.path);
+          state.frontendState.set(msg.path, msg.value);
+          if (msg.path === "/nativeWindows") {
+            mirrorNativeWindowsFromFrontend(state, msg.value);
+          } else if (msg.path === "/tabs") {
+            handleMirroredTabsChanged(state, previous, msg.value);
+          }
         }
         deps.scheduleStateFileWrite();
         break;

--- a/agent/dispatcherTypes.ts
+++ b/agent/dispatcherTypes.ts
@@ -44,6 +44,8 @@ export interface InboundMessage {
   planMode?: boolean;
   /** Opaque id supplied by release-control clients for turn-specific waits. */
   controlRequestId?: string;
+  /** Frontend already emitted the visible user bubble through local_chat_message. */
+  suppressUserSessionEvent?: boolean;
   /** Native scheduled-task metadata carried on scheduler-fired chat turns. */
   scheduledTaskId?: string;
   scheduledRunId?: string;

--- a/agent/extension-loader.test.ts
+++ b/agent/extension-loader.test.ts
@@ -19,6 +19,7 @@ import {
   RESERVED_THEME_IDS,
   discoverPersistedTabs,
   loadAethonExtensionDirectory,
+  loadAethonExtensionPackages,
   loadAethonExtensions,
   loadProjectAethonExtensions,
   normalizeTheme,
@@ -75,13 +76,19 @@ describe("normalizeTheme", () => {
         "--text": 12, // non-string value dropped
       },
     });
-    expect(t).toEqual({ id: "twilight", label: "twilight", vars: { "--bg": "#000" } });
+    expect(t).toEqual({
+      id: "twilight",
+      label: "twilight",
+      vars: { "--bg": "#000" },
+    });
   });
 
   it("trims label", () => {
-    expect(normalizeTheme({ id: "x", label: "  X  ", vars: {} })).toMatchObject({
-      label: "X",
-    });
+    expect(normalizeTheme({ id: "x", label: "  X  ", vars: {} })).toMatchObject(
+      {
+        label: "X",
+      },
+    );
   });
 
   it("RESERVED_THEME_IDS exported", () => {
@@ -100,9 +107,9 @@ describe("projectExtensionDisplayName", () => {
   });
 
   it("falls back to projectName:base when scope is empty", () => {
-    expect(projectExtensionDisplayName("/", "/.aethon/extensions", "x.ts")).toBe(
-      "project:x",
-    );
+    expect(
+      projectExtensionDisplayName("/", "/.aethon/extensions", "x.ts"),
+    ).toBe("project:x");
   });
 });
 
@@ -124,11 +131,14 @@ describe("discoverPersistedTabs", () => {
       const defaultFile = join(sessionsDir, "default", "1.jsonl");
       const aFile = join(sessionsDir, "tab-a", "1.jsonl");
       const bFile = join(sessionsDir, "tab-b", "1.jsonl");
-      writeFileSync(defaultFile, `${JSON.stringify({
-        type: "session",
-        id: "default",
-        cwd: "/tmp/default",
-      })}\n`);
+      writeFileSync(
+        defaultFile,
+        `${JSON.stringify({
+          type: "session",
+          id: "default",
+          cwd: "/tmp/default",
+        })}\n`,
+      );
       writeFileSync(aFile, "");
       writeFileSync(bFile, "");
       const stateOpts = makeOpts(root);
@@ -161,9 +171,7 @@ describe("refreshPersistedTabs", () => {
       stateOpts.sessionsDir = join(root, "sessions-as-file");
       writeFileSync(stateOpts.sessionsDir, "not a directory");
       const state = new AethonAgentState(stateOpts);
-      const existing = [
-        { tabId: "existing", lastModified: 123, cwd: "/proj" },
-      ];
+      const existing = [{ tabId: "existing", lastModified: 123, cwd: "/proj" }];
       state.discoveredTabs = existing;
 
       expect(await refreshPersistedTabs(state)).toBe(existing);
@@ -197,9 +205,7 @@ describe("loadAethonExtensions", () => {
       await loadAethonExtensions(f.state, f.deps, api, registry);
       expect(seen).toEqual({ type: "hello", template: { type: "card" } });
       expect(registry.get("hello")).toBe("directory");
-      const lifecycle = f.sent.find(
-        (m) => m.type === "extension_lifecycle",
-      );
+      const lifecycle = f.sent.find((m) => m.type === "extension_lifecycle");
       expect(lifecycle).toMatchObject({ status: "loaded", name: "hello" });
     } finally {
       rmSync(root, { recursive: true, force: true });
@@ -326,6 +332,98 @@ describe("loadAethonExtensions", () => {
         (m) => m.type === "extension_lifecycle" && m.status === "failed",
       ).length;
       expect(failuresAfterSecond).toBe(1);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("loadAethonExtensionPackages", () => {
+  it("loads package folders placed directly under ~/.aethon/extensions", async () => {
+    const root = mkdtempSync(join(tmpdir(), "aethon-pkg-"));
+    try {
+      const pkgDir = join(root, "extensions", "direct-package");
+      mkdirSync(pkgDir, { recursive: true });
+      writeFileSync(
+        join(pkgDir, "package.json"),
+        JSON.stringify({
+          name: "direct-package",
+          aethon: { entry: "./index.mjs", frontendEntry: "./frontend.js" },
+        }),
+      );
+      writeFileSync(
+        join(pkgDir, "index.mjs"),
+        `export function register(api) { api.registerTheme({ id: "direct-pkg", vars: { "--bg": "#000" } }); }`,
+      );
+      writeFileSync(join(pkgDir, "frontend.js"), `// frontend`);
+      const f = makeFixture(root);
+      const frontendEntries: {
+        name: string;
+        entryPath: string;
+        code: string;
+      }[] = [];
+
+      await loadAethonExtensionPackages(
+        f.state,
+        f.deps,
+        {
+          registerTheme(theme) {
+            f.state.extensionThemes.set(theme.id, theme);
+            return Promise.resolve({ ok: true });
+          },
+        } as unknown as AethonExtensionApi,
+        f.state.loadedExtensions,
+        { onFrontendEntry: (entry) => frontendEntries.push(entry) },
+      );
+
+      expect(f.state.loadedExtensions.get("direct-package")).toBe(
+        "extension-package",
+      );
+      expect(f.state.extensionThemes.has("direct-pkg")).toBe(true);
+      expect(frontendEntries).toEqual([
+        expect.objectContaining({
+          name: "direct-package",
+          code: "// frontend",
+        }),
+      ]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("surfaces malformed direct package manifests as load failures", async () => {
+    const root = mkdtempSync(join(tmpdir(), "aethon-pkg-"));
+    try {
+      const pkgDir = join(root, "extensions", "broken-package");
+      mkdirSync(pkgDir, { recursive: true });
+      writeFileSync(join(pkgDir, "package.json"), `{ nope`);
+      const f = makeFixture(root);
+      const failures: Record<string, unknown>[] = [];
+
+      await loadAethonExtensionPackages(
+        f.state,
+        f.deps,
+        {} as AethonExtensionApi,
+        f.state.loadedExtensions,
+        { onFailure: (failure) => failures.push(failure) },
+      );
+
+      expect(failures).toEqual([
+        expect.objectContaining({
+          name: "broken-package",
+          source: "extension-package",
+          status: "failed",
+          path: join(pkgDir, "package.json"),
+        }),
+      ]);
+      expect(f.sent).toContainEqual(
+        expect.objectContaining({
+          type: "extension_lifecycle",
+          name: "broken-package",
+          source: "extension-package",
+          status: "failed",
+        }),
+      );
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/agent/extension-loader/packages.ts
+++ b/agent/extension-loader/packages.ts
@@ -11,7 +11,7 @@
  * so the sidebar's Failures group can render the user-facing message.
  */
 
-import { readdir } from "node:fs/promises";
+import { readFile, readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { logger } from "../logger";
@@ -39,13 +39,21 @@ interface LoadPackagesOptions {
   }) => void;
 }
 
+interface PackageManifest {
+  name?: string;
+  aethon?: { entry?: string; frontendEntry?: string };
+}
+
 interface PackageCandidate {
   name: string;
   dir: string;
-  manifest: {
-    name?: string;
-    aethon?: { entry?: string; frontendEntry?: string };
-  };
+  manifest: PackageManifest;
+}
+
+interface PackageManifestFailure {
+  name: string;
+  path: string;
+  error: string;
 }
 
 export async function loadAethonExtensionPackages(
@@ -55,54 +63,99 @@ export async function loadAethonExtensionPackages(
   registry: Map<string, ExtensionSource>,
   options?: LoadPackagesOptions,
 ): Promise<void> {
-  const extensionsRoot = join(state.userDir, "extensions", "node_modules");
-  const candidates: PackageCandidate[] = [];
+  const candidates = new Map<string, PackageCandidate>();
 
   async function readManifest(
     packageDir: string,
-  ): Promise<PackageCandidate | null> {
+    fallbackName: string,
+  ): Promise<PackageCandidate | PackageManifestFailure | null> {
+    const pkgPath = join(packageDir, "package.json");
     try {
-      const pkgPath = join(packageDir, "package.json");
-      const text = await Bun.file(pkgPath).text();
-      const manifest = JSON.parse(text) as PackageCandidate["manifest"];
+      const text = await readFile(pkgPath, "utf8");
+      const manifest = JSON.parse(text) as PackageManifest;
       if (!manifest.aethon) return null;
-      return { name: manifest.name ?? packageDir, dir: packageDir, manifest };
-    } catch {
-      return null;
+      return { name: manifest.name ?? fallbackName, dir: packageDir, manifest };
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === "ENOENT" || code === "ENOTDIR") return null;
+      return {
+        name: fallbackName,
+        path: pkgPath,
+        error: `package.json: ${(err as Error).message}`,
+      };
     }
   }
 
-  let entries: string[];
-  try {
-    entries = await readdir(extensionsRoot);
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-      logger
-        .scope("ext-package")
-        .warn(`readdir ${extensionsRoot}: ${(err as Error).message}`);
-    }
-    return;
+  function recordManifestFailure(failure: PackageManifestFailure) {
+    logger.scope("ext-package").warn(`${failure.name}: ${failure.error}`);
+    deps.send({
+      type: "extension_lifecycle",
+      name: failure.name,
+      source: "extension-package",
+      status: "failed",
+      error: failure.error,
+      path: failure.path,
+    });
+    options?.onFailure?.({
+      name: failure.name,
+      source: "extension-package",
+      status: "failed",
+      error: failure.error,
+      path: failure.path,
+    });
   }
-  for (const entry of entries) {
-    const entryPath = join(extensionsRoot, entry);
-    if (entry.startsWith("@")) {
-      // Scoped namespace — recurse one level.
-      let scoped: string[];
-      try {
-        scoped = await readdir(entryPath);
-      } catch {
-        continue;
-      }
-      for (const sub of scoped) {
-        const c = await readManifest(join(entryPath, sub));
-        if (c) candidates.push(c);
-      }
+
+  async function maybeAddPackage(packageDir: string, fallbackName: string) {
+    const result = await readManifest(packageDir, fallbackName);
+    if (!result) return;
+    if ("manifest" in result) {
+      if (!candidates.has(result.name)) candidates.set(result.name, result);
     } else {
-      const c = await readManifest(entryPath);
-      if (c) candidates.push(c);
+      recordManifestFailure(result);
     }
   }
-  for (const c of candidates) {
+
+  async function discoverPackages(
+    root: string,
+    options?: { skipNodeModules?: boolean },
+  ) {
+    let entries: string[];
+    try {
+      entries = await readdir(root);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+        logger
+          .scope("ext-package")
+          .warn(`readdir ${root}: ${(err as Error).message}`);
+      }
+      return;
+    }
+    for (const entry of entries) {
+      if (options?.skipNodeModules && entry === "node_modules") continue;
+      const entryPath = join(root, entry);
+      if (entry.startsWith("@")) {
+        // Scoped namespace — recurse one level.
+        let scoped: string[];
+        try {
+          scoped = await readdir(entryPath);
+        } catch {
+          continue;
+        }
+        for (const sub of scoped) {
+          await maybeAddPackage(join(entryPath, sub), `${entry}/${sub}`);
+        }
+      } else {
+        await maybeAddPackage(entryPath, entry);
+      }
+    }
+  }
+
+  await discoverPackages(join(state.userDir, "extensions"), {
+    skipNodeModules: true,
+  });
+  await discoverPackages(join(state.userDir, "extensions", "node_modules"));
+
+  for (const c of candidates.values()) {
     if (state.disabledExtensions.has(c.name)) {
       logger.scope("ext-package").info(`${c.name}: disabled by user, skipping`);
       deps.send({
@@ -116,7 +169,9 @@ export async function loadAethonExtensionPackages(
     }
     const entry = c.manifest.aethon?.entry;
     if (typeof entry !== "string" || entry.length === 0) {
-      logger.scope("ext-package").warn(`${c.name}: aethon.entry not set, skipping`);
+      logger
+        .scope("ext-package")
+        .warn(`${c.name}: aethon.entry not set, skipping`);
       deps.send({
         type: "extension_lifecycle",
         name: c.name,
@@ -189,7 +244,7 @@ export async function loadAethonExtensionPackages(
       ) {
         const fePath = join(c.dir, frontendEntry);
         try {
-          const code = await Bun.file(fePath).text();
+          const code = await readFile(fePath, "utf8");
           options.onFrontendEntry({
             name: c.name,
             entryPath: fePath,

--- a/agent/state.ts
+++ b/agent/state.ts
@@ -464,6 +464,10 @@ export class AethonAgentState {
   /** Per-tab wall-clock turn start times. Set in agent_start, consumed in
    *  agent_end to compute durationMs. */
   readonly turnStartTimes = new Map<string, number>();
+  /** Session/message ids already emitted through aethon.sessions events.
+   *  Lets local transcript persistence skip duplicate append events for
+   *  assistant bubbles that were already announced while streaming. */
+  readonly emittedSessionMessageIds = new Set<string>();
   /** Cached model picker. First populated when the default tab is created. */
   cachedModels: ModelDescriptor[] = [];
 
@@ -532,6 +536,13 @@ export class AethonAgentState {
     RegisteredHighlightGrammar
   >();
   readonly nativeWindows = new Map<string, NativeCanvasWindowSummary>();
+  /** Extension subscriptions registered through `aethon.sessions.on(...)`.
+   *  Kept loosely typed here to avoid a state.ts -> aethon-api-sessions.ts
+   *  runtime cycle; the API module narrows event names/payloads. */
+  readonly sessionEventHandlers = new Map<
+    string,
+    Set<(payload: unknown) => void>
+  >();
   readonly a2uiEventHandlers: {
     match: A2UIEventMatch;
     handler: A2UIEventHandler;

--- a/agent/system-prompt/prompt-template.ts
+++ b/agent/system-prompt/prompt-template.ts
@@ -128,6 +128,7 @@ runtime API below and report failures through normal tool errors.
 - \`aethon.registerTheme({id, label?, vars})\` — register a CSS color scheme.
   vars is a map of CSS custom properties (\`--bg\`, \`--text\`, \`--accent\`, …).
 - \`aethon.windows.openCanvas({id?, title?, components?, state?, width?, height?, x?, y?, focus?, restoreOnLaunch?})\` — open a native OS window that renders bare A2UI canvas content. Use this for custom/exploratory UI unless the main layout is explicitly requested.
+- \`aethon.windows.openTerminal({id?, title?, cwd?, command?, args?})\` — create a private PTY shell and open an interactive native terminal window.
 - \`aethon.windows.emitCanvas/appendCanvas/patchCanvas/clearCanvas/setState(id, ...)\` — update a window's canvas or window-local JSON Pointer state.
 - \`aethon.windows.list/get/getState/getCanvas/focus/close/setTitle(...)\` — inspect and manage native canvas windows.
 - \`aethon.sessions.list/getActive/getMessages/getTranscript/on\` — list sessions, read supported message transcripts, and subscribe to session/message invalidation events for extension apps.
@@ -145,7 +146,7 @@ Advanced (read \`$AETHON_DOCS_DIR/api.md\` for full details):
 - \`aethon.canvas.*\` — progressive canvas UI (emit, append, patch, clear)
 - \`aethon.windows.*\` — native A2UI canvas windows for isolated custom surfaces
 - \`aethon.editor.*\` — open or focus files in the Monaco editor
-- \`aethon.shells.*\` — read/write shared PTY shell tabs
+- \`aethon.shells.*\` — create PTY shell tabs and read/write shared shell tabs
 - \`aethon.sessions.*\` — supported session/message transcript APIs
 - \`aethon.tasks.*\` — launch background tasks in workspaces
 - \`aethon.dashboard.*\` — project dashboard data (repo overview, issues)

--- a/agent/system-prompt/prompt-template.ts
+++ b/agent/system-prompt/prompt-template.ts
@@ -129,7 +129,7 @@ runtime API below and report failures through normal tool errors.
   vars is a map of CSS custom properties (\`--bg\`, \`--text\`, \`--accent\`, …).
 - \`aethon.windows.openCanvas({id?, title?, components?, state?, width?, height?, x?, y?, focus?, restoreOnLaunch?})\` — open a native OS window that renders bare A2UI canvas content. Use this for custom/exploratory UI unless the main layout is explicitly requested.
 - \`aethon.windows.emitCanvas/appendCanvas/patchCanvas/clearCanvas/setState(id, ...)\` — update a window's canvas or window-local JSON Pointer state.
-- \`aethon.windows.list/focus/close/setTitle(...)\` — manage native canvas windows.
+- \`aethon.windows.list/get/getState/getCanvas/focus/close/setTitle(...)\` — inspect and manage native canvas windows.
 - \`aethon.sessions.list/getActive/getMessages/getTranscript/on\` — list sessions, read supported message transcripts, and subscribe to session/message invalidation events for extension apps.
 
 Introspection (read-only):
@@ -222,7 +222,8 @@ Four places can register Aethon UI via \`globalThis.aethon\`:
 2. **\`<project>/.aethon/extensions/<name>.ts\`** — project-local Aethon
    extensions discovered from the selected cwd up to its nearest git root.
    Use this when the UI should travel with a repository.
-3. **\`$AETHON_USER_DIR/extensions/node_modules/<pkg>/\`** — npm-distributed
+3. **\`$AETHON_USER_DIR/extensions/node_modules/<pkg>/\`** or
+   **\`$AETHON_USER_DIR/extensions/<pkg>/\`** — npm-distributed or local-dev
    Aethon extension packages with an \`aethon\` field in package.json.
    Install in-app with \`/extensions install <npm-package|git-url>\`, or
    from a shell with \`npm install --prefix $AETHON_USER_DIR/extensions <pkg>\`.

--- a/agent/system-prompt/prompt-template.ts
+++ b/agent/system-prompt/prompt-template.ts
@@ -130,6 +130,7 @@ runtime API below and report failures through normal tool errors.
 - \`aethon.windows.openCanvas({id?, title?, components?, state?, width?, height?, x?, y?, focus?, restoreOnLaunch?})\` — open a native OS window that renders bare A2UI canvas content. Use this for custom/exploratory UI unless the main layout is explicitly requested.
 - \`aethon.windows.emitCanvas/appendCanvas/patchCanvas/clearCanvas/setState(id, ...)\` — update a window's canvas or window-local JSON Pointer state.
 - \`aethon.windows.list/focus/close/setTitle(...)\` — manage native canvas windows.
+- \`aethon.sessions.list/getActive/getMessages/getTranscript/on\` — list sessions, read supported message transcripts, and subscribe to session/message invalidation events for extension apps.
 
 Introspection (read-only):
 - \`aethon.listExtensions()\`, \`aethon.listComponents()\`, \`aethon.listThemes()\`,
@@ -145,6 +146,7 @@ Advanced (read \`$AETHON_DOCS_DIR/api.md\` for full details):
 - \`aethon.windows.*\` — native A2UI canvas windows for isolated custom surfaces
 - \`aethon.editor.*\` — open or focus files in the Monaco editor
 - \`aethon.shells.*\` — read/write shared PTY shell tabs
+- \`aethon.sessions.*\` — supported session/message transcript APIs
 - \`aethon.tasks.*\` — launch background tasks in workspaces
 - \`aethon.dashboard.*\` — project dashboard data (repo overview, issues)
 - \`aethon.onUnload(fn)\` — teardown callback for project extension lifecycle

--- a/agent/tab-lifecycle.test.ts
+++ b/agent/tab-lifecycle.test.ts
@@ -788,9 +788,14 @@ describe("handleSessionEvent", () => {
     });
   });
 
-  it("agent_end emits missing final text when streaming only delivered thinking", () => {
+  it("agent_end emits missing final text when streaming only delivered thinking", async () => {
     const f = makeFixture();
     const rec = fakeRec();
+    const sessionEvents: unknown[] = [];
+    f.state.sessionEventHandlers.set(
+      "messageUpdated",
+      new Set([(payload) => sessionEvents.push(payload)]),
+    );
     rec.promptInFlight = true;
 
     handleSessionEvent(f.state, f.deps, rec, "tab-1", {
@@ -832,6 +837,16 @@ describe("handleSessionEvent", () => {
     );
     expect(finalTextIndex).toBeGreaterThan(-1);
     expect(finalTextIndex).toBeLessThan(responseEndIndex);
+    await Promise.resolve();
+    expect(sessionEvents).toEqual([
+      expect.objectContaining({
+        sessionId: "tab-1",
+        message: expect.objectContaining({
+          role: "agent",
+          content: "No. The PR did not add a rake task.",
+        }),
+      }),
+    ]);
   });
 
   it("agent_end only emits the unstreamed suffix of final text", () => {

--- a/agent/tab-lifecycle/events.ts
+++ b/agent/tab-lifecycle/events.ts
@@ -26,6 +26,7 @@ import {
   isUsageLimitError,
 } from "../agent-errors";
 import { tryAutoSwitchOnUsageLimit } from "../auth-profiles";
+import { emitSessionEvent } from "../aethon-api-sessions";
 import { logger } from "../logger";
 import type { AethonAgentState, TabRecord } from "../state";
 import {
@@ -132,6 +133,36 @@ function rememberResponseDelta(
   }
 }
 
+function emitResponseSessionEvent(
+  state: AethonAgentState,
+  rec: TabRecord,
+  tabId: string,
+  messageId: string,
+  previousMessageId: string | undefined,
+): void {
+  const message = {
+    id: messageId,
+    role: "agent" as const,
+    content: rec.activeResponseText ?? "",
+    ...(rec.activeResponseText ? { text: rec.activeResponseText } : {}),
+    ...(rec.activeResponseThinking
+      ? { thinking: rec.activeResponseThinking }
+      : {}),
+  };
+  if (previousMessageId !== messageId) {
+    emitSessionEvent(state, "messageAppended", {
+      sessionId: tabId,
+      message,
+    });
+  } else {
+    emitSessionEvent(state, "messageUpdated", {
+      sessionId: tabId,
+      messageId,
+      message,
+    });
+  }
+}
+
 function assistantMessageCanonicalId(message: {
   id?: unknown;
   messageId?: unknown;
@@ -154,6 +185,7 @@ function missingSuffix(
 }
 
 function emitFinalAssistantContent(
+  state: AethonAgentState,
   deps: TabLifecycleDeps,
   rec: TabRecord,
   tabId: string,
@@ -169,6 +201,7 @@ function emitFinalAssistantContent(
   const finalText = textFromContent(assistant.content);
   if (!finalThinking && !finalText) return;
 
+  const previousMessageId = rec.activeResponseMessageId;
   const messageId =
     rec.activeResponseMessageId ??
     startResponseSegment(rec, assistantMessageCanonicalId(assistant));
@@ -185,6 +218,7 @@ function emitFinalAssistantContent(
       channel: "thinking",
     });
     rememberResponseDelta(rec, "thinking", thinkingDelta);
+    emitResponseSessionEvent(state, rec, tabId, messageId, previousMessageId);
   }
   const textDelta = missingSuffix(finalText, rec.activeResponseText);
   if (textDelta) {
@@ -195,7 +229,9 @@ function emitFinalAssistantContent(
       content: textDelta,
       channel: "text",
     });
+    const beforeTextMessageId = thinkingDelta ? messageId : previousMessageId;
     rememberResponseDelta(rec, "text", textDelta);
+    emitResponseSessionEvent(state, rec, tabId, messageId, beforeTextMessageId);
   }
 }
 
@@ -313,14 +349,23 @@ export function handleSessionEvent(
       ) {
         const delta = ame.delta ?? "";
         if (delta) {
+          const previousMessageId = rec.activeResponseMessageId;
+          const messageId = responseMessageId(rec, ame);
           deps.send({
             type: "response_delta",
             tabId,
-            messageId: responseMessageId(rec, ame),
+            messageId,
             content: delta,
             channel,
           });
           rememberResponseDelta(rec, channel, delta);
+          emitResponseSessionEvent(
+            state,
+            rec,
+            tabId,
+            messageId,
+            previousMessageId,
+          );
           addLiveContextUsageEstimate(rec, delta);
           emitContextUsageThrottled(state, deps, tabId, rec);
         }
@@ -565,7 +610,7 @@ export function handleSessionEvent(
         if (state.currentAgentTabId === tabId) {
           state.currentAgentTabId = undefined;
         }
-        emitFinalAssistantContent(deps, rec, tabId, lastAssistant);
+        emitFinalAssistantContent(state, deps, rec, tabId, lastAssistant);
         rollResponseMessage(rec);
         clearLiveContextUsageEstimate(rec);
         emitContextUsage(state, deps, tabId, rec);
@@ -573,7 +618,13 @@ export function handleSessionEvent(
         // rollback / fork affordances work without a reload.
         emitEntryIds(deps, rec, tabId);
         deps.send({ type: "response_end", tabId });
-        emitScheduledRunComplete(deps, rec, tabId, !failedMessage, failedMessage);
+        emitScheduledRunComplete(
+          deps,
+          rec,
+          tabId,
+          !failedMessage,
+          failedMessage,
+        );
       }
       break;
     }

--- a/agent/tabs.ts
+++ b/agent/tabs.ts
@@ -15,6 +15,10 @@ import { ensureTab, tabSessionDir } from "./tab-lifecycle";
 import { unloadProjectExtensions } from "./projectLifecycle";
 import { modelRegistryForModelId } from "./auth-profiles";
 import { clearPendingContextUsageEmit } from "./context-usage";
+import {
+  emitSessionEvent,
+  hasEmittedSessionMessage,
+} from "./aethon-api-sessions";
 import { setSessionLabelForTab } from "./session-label";
 
 export async function handleTabOpen(
@@ -255,11 +259,12 @@ export async function handleLocalChatMessage(
       (tabId === "default"
         ? (state.currentProjectCwd ?? process.cwd())
         : undefined);
-    await appendLocalChatMessage(tabSessionDir(state, tabId), {
-      id:
-        typeof record.id === "string" && record.id.length > 0
-          ? record.id
-          : randomUUID(),
+    const id =
+      typeof record.id === "string" && record.id.length > 0
+        ? record.id
+        : randomUUID();
+    const persisted = {
+      id,
       role,
       ...(hasText ? { text } : {}),
       ...(hasThinking ? { thinking } : {}),
@@ -269,6 +274,23 @@ export async function handleLocalChatMessage(
       ...(typeof record.createdAt === "number"
         ? { createdAt: record.createdAt }
         : {}),
+    };
+    await appendLocalChatMessage(tabSessionDir(state, tabId), persisted);
+    if (hasEmittedSessionMessage(state, tabId, id)) return;
+    emitSessionEvent(state, "messageAppended", {
+      sessionId: tabId,
+      message: {
+        id,
+        role,
+        content: hasText ? text : "",
+        ...(hasText ? { text } : {}),
+        ...(hasThinking ? { thinking } : {}),
+        ...(attachments.length > 0 ? { attachments } : {}),
+        ...(a2ui ? { a2ui } : {}),
+        ...(typeof record.createdAt === "number"
+          ? { createdAt: record.createdAt }
+          : {}),
+      },
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/cli/aethonControl.test.ts
+++ b/cli/aethonControl.test.ts
@@ -1,4 +1,10 @@
-import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  rmSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createServer, type Server, type Socket } from "node:net";
@@ -39,13 +45,15 @@ describe("aethonctl helpers", () => {
   });
 
   it("keeps default account switches on the global bridge", () => {
-    expect(buildAccountSwitchPayloads("primary", { tabId: "default" })).toEqual([
-      {
-        type: "auth_profile_use_for_tab",
-        tabId: "default",
-        profileId: "primary",
-      },
-    ]);
+    expect(buildAccountSwitchPayloads("primary", { tabId: "default" })).toEqual(
+      [
+        {
+          type: "auth_profile_use_for_tab",
+          tabId: "default",
+          profileId: "primary",
+        },
+      ],
+    );
   });
 
   it("resolves active tabs from object-shaped app state", () => {
@@ -74,25 +82,34 @@ describe("aethonctl helpers", () => {
   it("falls back to default when the active surface is not an agent tab", () => {
     expect(
       activeTargetFromState(
-        { activeTabId: "shell", tabs: { shell: { id: "shell", kind: "shell" } } },
+        {
+          activeTabId: "shell",
+          tabs: { shell: { id: "shell", kind: "shell" } },
+        },
         "active",
       ),
     ).toEqual({ tabId: "default" });
   });
 
   it("keeps explicit tab ids even when the frontend snapshot is stale", () => {
-    expect(activeTargetFromState({ activeTabId: "other", tabs: [] }, "new-tab")).toEqual({
+    expect(
+      activeTargetFromState({ activeTabId: "other", tabs: [] }, "new-tab"),
+    ).toEqual({
       tabId: "new-tab",
     });
   });
 
   it("reads JSON Pointer state paths", () => {
-    expect(jsonPointerGet({ a: { "b/c": ["zero", "one"] } }, "/a/b~1c/1")).toBe("one");
+    expect(jsonPointerGet({ a: { "b/c": ["zero", "one"] } }, "/a/b~1c/1")).toBe(
+      "one",
+    );
   });
 
   it("normalizes object and array tab containers", () => {
     expect(normalizeTabs({ a: { id: "a" } })).toEqual([{ id: "a" }]);
-    expect(normalizeTabs([{ id: "b", label: "Bee" }])).toEqual([{ id: "b", label: "Bee" }]);
+    expect(normalizeTabs([{ id: "b", label: "Bee" }])).toEqual([
+      { id: "b", label: "Bee" },
+    ]);
   });
 
   it("plans project skill installs using claude plus generic agents targets", () => {
@@ -106,7 +123,11 @@ describe("aethonctl helpers", () => {
 
   it("writes skill files with account guidance", () => {
     const root = mkdtempSync(join(tmpdir(), "aethon-skill-"));
-    const plan = planSkillInstall({ targets: ["codex"], project: true, dir: root });
+    const plan = planSkillInstall({
+      targets: ["codex"],
+      project: true,
+      dir: root,
+    });
     const [path] = installSkill(plan, true);
     const body = readFileSync(path, "utf8");
     expect(body).toContain("accounts use <profile-id>");
@@ -116,7 +137,10 @@ describe("aethonctl helpers", () => {
   it("resolves debug port from the conventional dev-info file", () => {
     const home = mkdtempSync(join(tmpdir(), "aethon-home-"));
     mkdirSync(join(home, ".aethon"));
-    writeFileSync(join(home, ".aethon", "dev-info.json"), JSON.stringify({ debugPort: 20123 }));
+    writeFileSync(
+      join(home, ".aethon", "dev-info.json"),
+      JSON.stringify({ debugPort: 20123 }),
+    );
     expect(resolveDebugPort({ home, env: {} })).toBe(20123);
   });
 
@@ -151,8 +175,11 @@ describe("aethonctl helpers", () => {
     });
     await new Promise<void>((resolve) => server.listen(socketPath, resolve));
     try {
-      expect(readControlInfo({ home: root })?.socketPath).toBe(socketPath);
-      const client = new AethonControlClient({ home: root });
+      const testEnv: NodeJS.ProcessEnv = {};
+      expect(readControlInfo({ home: root, env: testEnv })?.socketPath).toBe(
+        socketPath,
+      );
+      const client = new AethonControlClient({ home: root, env: testEnv });
       await expect(client.request("status")).resolves.toEqual({
         token: "test-token",
         method: "status",

--- a/docs/aethon-agent/api.md
+++ b/docs/aethon-agent/api.md
@@ -663,6 +663,52 @@ switched", "Update available"). Don't use them for chat content — push
 into the conversation via `ctx.pi.notify(...)` if a message belongs in
 history.
 
+### `sessions.list / getActive / getMessages / getTranscript / on`
+
+Supported session/chat introspection for extension apps. Use this instead of
+reading `~/.aethon/sessions/<id>/` files directly or expecting full message
+bodies under `getFrontendState('/messages')`.
+
+```ts
+const sessions = await aethon.sessions.list();
+// [{ id, label, active, model, cwd, messageCount, updatedAt? }, …]
+
+const active = await aethon.sessions.getActive();
+// { id, label, active: true, … } | null
+
+const messages = await aethon.sessions.getMessages(active.id, { limit: 100 });
+// [{ id, role: "user" | "agent" | "system", content, text?, thinking?, createdAt?, a2ui? }, …]
+
+const markdown = await aethon.sessions.getTranscript(active.id);
+```
+
+`list()` merges live bridge sessions, frontend-visible tab metadata, and
+durable sessions discovered at startup. `getMessages()` prefers live pi
+session messages when the session is open, and otherwise uses Aethon's
+supported transcript parser over the durable local session logs. `limit`
+returns the most recent N messages.
+
+Live subscriptions are available for app-like windows that should refresh
+without polling:
+
+```ts
+const off = aethon.sessions.on("messageAppended", ({ sessionId, message }) => {
+  console.log("new message", sessionId, message.content);
+});
+
+aethon.sessions.on("activeChanged", ({ sessionId, session }) => {});
+aethon.sessions.on("messageUpdated", ({ sessionId, messageId, message }) => {});
+aethon.sessions.on("sessionChanged", ({ session }) => {});
+
+// Later:
+off();
+```
+
+Session events are best-effort extension notifications; handlers should be
+fast and tolerate missed intermediate streaming deltas. For large transcript
+visualizers, treat the event as an invalidation signal and call
+`getMessages()` or `getTranscript()` to resync.
+
 ### `shells.list / shells.read / shells.write`
 
 Opt-in agent ↔ shell-tab sharing (M6 P2). The `shells` namespace exposes
@@ -972,6 +1018,10 @@ globalThis.aethon.getFrontendState("/sidebar/themes"); // theme list
 globalThis.aethon.getFrontendState("/messagesCount"); // active tab message count
 ```
 
+Message bodies are intentionally not mirrored through `getFrontendState()`;
+use `await aethon.sessions.getMessages(sessionId)` or
+`await aethon.sessions.getTranscript(sessionId)` for supported chat access.
+
 The frontend pushes patches into the bridge whenever these slices change,
 so the bridge sees the live UI state — not just what extensions have
 written via `setState`. Best-effort mirror; small lag (<100 ms) is normal
@@ -1006,6 +1056,7 @@ One-call summary suitable for chat output:
     "/tabs": [...],
     "/draft": "",
     "/messagesCount": 0,
+    "/nativeWindows": [...],
   },
 }
 ```

--- a/docs/aethon-agent/api.md
+++ b/docs/aethon-agent/api.md
@@ -173,7 +173,7 @@ write targets the _current_ active tab as of the call, not the active
 tab at apply time. If the user switches tabs mid-call the result lands
 on the originally-selected tab.
 
-### `windows.openCanvas / emitCanvas / setState / list / focus / close`
+### `windows.openCanvas / get / emitCanvas / setState / list / focus / close`
 
 Native canvas windows are separate OS windows that host bare A2UI content.
 Use them for exploratory dashboards, custom workpads, visual inspectors,
@@ -216,6 +216,9 @@ API:
   Size defaults to `900x650`; windows restore on app relaunch unless
   `restoreOnLaunch: false`.
 - `list()` returns open window summaries.
+- `get(id)` returns the full native canvas window record.
+- `getState(id)` returns the window-local JSON Pointer state object.
+- `getCanvas(id)` returns `{ components }` for the window-local A2UI payload.
 - `focus(id)`, `close(id)`, and `setTitle(id, title)` control the native
   window.
 - `emitCanvas(id, components)`, `appendCanvas(id, components)`,
@@ -471,8 +474,8 @@ the full set of modules replaces the previous set. Components from a
 removed module are unregistered; components from a re-evaluated module
 replace their prior bindings (so `npm install --prefix
 ~/.aethon/extensions <pkg>` hot-reloads cleanly). Errors per module are
-caught and surfaced as a system notice; one broken module can't kill
-the others.
+caught and surfaced as a system notice and in frontend state at
+`/extensionFrontendModules`; one broken module can't kill the others.
 
 **Trust.** Same model as bridge-side extension code: the user installed
 the package, they trust it. `new Function` is essentially eval — no
@@ -482,7 +485,10 @@ threat model.
 
 `RuntimeSnapshot.frontendModules` lists `{ name, entryPath, bytes }`
 for each shipped module — code body omitted (read it from
-`entryPath` if you need to inspect).
+`entryPath` if you need to inspect). The frontend mirror also exposes
+`RuntimeSnapshot.uiState["/extensionFrontendModules"]` as an array of
+`{ name, status, componentTypes, error? }`, reflecting browser-side
+registration/evaluation status for React frontend components.
 
 ### `registerMenuItem({ label, action, location?, id?, parent? })` / `unregisterMenuItem(id)`
 

--- a/docs/aethon-agent/api.md
+++ b/docs/aethon-agent/api.md
@@ -215,6 +215,10 @@ API:
   creates or updates a native window. Ids must match `/^[A-Za-z][\w-]*$/`.
   Size defaults to `900x650`; windows restore on app relaunch unless
   `restoreOnLaunch: false`.
+- `openTerminal({ id?, title?, cwd?, command?, args?, width?, height?, x?, y?, focus? })`
+  creates a private PTY shell and opens an interactive native terminal window
+  backed by the built-in `shell-canvas` component. Terminal windows are
+  non-restoring so app relaunches never reopen a terminal without a backing PTY.
 - `list()` returns open window summaries.
 - `get(id)` returns the full native canvas window record.
 - `getState(id)` returns the window-local JSON Pointer state object.
@@ -715,7 +719,7 @@ fast and tolerate missed intermediate streaming deltas. For large transcript
 visualizers, treat the event as an invalidation signal and call
 `getMessages()` or `getTranscript()` to resync.
 
-### `shells.list / shells.read / shells.write`
+### `shells.create / shells.list / shells.read / shells.write`
 
 Opt-in agent ↔ shell-tab sharing (M6 P2). The `shells` namespace exposes
 the user's shareable PTY-backed shell tabs. The user picks who can see
@@ -724,6 +728,9 @@ returns tabs whose mode is `read`, `read-write`, or
 `read-write-trusted`. Private tabs are invisible.
 
 ```ts
+aethon.shells.create({ cwd: "/repo", command: "zsh" });
+// → { ok: true, data: { tabId, cwd, command, args, shareMode: "private" } }
+
 aethon.shells.list();
 // → { ok: true, data: [{ tabId, cwd, command, shareMode }, …] }
 
@@ -748,14 +755,22 @@ that would be denied.
 Writes inject keystrokes verbatim — include `\n` to submit a command.
 In `read-write` mode, every call pops an Allow / Deny toast and resolves
 when the user clicks (or auto-denies after ~4m30s). In
-`read-write-trusted` the prompt is skipped. The bridge waits for the
-frontend handshake before resolving any of these calls; calls placed
-during register-time return `frontend_not_ready` rather than dangling.
+`read-write-trusted` the prompt is skipped. Shells created by
+`shells.create()` are always private until the user changes the visible
+share-mode badge; agent-facing APIs cannot seed or escalate sharing. The
+bridge waits for the frontend handshake before resolving any of these calls;
+calls placed during register-time return `frontend_not_ready` rather than
+dangling.
 
 The same surface is exposed to event-handler `ctx` as `ctx.shells.*`
 so handlers can read or drive shells without going through the global.
 Tools `listShells` / `readShell` / `writeShell` register automatically;
 the model can use them via the standard tool-use protocol.
+
+For app-like terminals, `aethon.windows.openTerminal({ id?, title?, cwd?, command?, args? })`
+creates a private PTY shell and opens a non-restoring native canvas window with
+an interactive `shell-canvas` bound to that shell. Use `aethon.shells.read/write`
+only after the user chooses an appropriate opt-in mode.
 
 ### `editor.openFile`
 

--- a/docs/aethon-agent/extensions.md
+++ b/docs/aethon-agent/extensions.md
@@ -75,6 +75,8 @@ per bridge process and appear in `listExtensions()` with source
 
 ## npm-Distributed Extension Package
 
+Installed packages live under `node_modules`:
+
 ```
 ~/.aethon/extensions/node_modules/@vendor/aethon-pretty-themes/
 ├── package.json
@@ -103,9 +105,13 @@ npm install --prefix ~/.aethon/extensions @vendor/aethon-pretty-themes
 The in-app installer also accepts GitHub shorthands and git URLs, for
 example `/extensions install github:vendor/aethon-pretty-themes`. After
 install, the current agent sidecar is restarted so the next request
-loads the new package. The bridge walks `~/.aethon/extensions/node_modules/`
-(including `@scope` namespaces), finds packages with an `aethon` field,
-imports `aethon.entry`, and calls `register(api)`.
+loads the new package. The bridge walks both
+`~/.aethon/extensions/node_modules/` and direct local package folders
+such as `~/.aethon/extensions/my-dev-extension/` (including `@scope`
+namespaces in both locations), finds packages with an `aethon` field,
+imports `aethon.entry`, and calls `register(api)`. Direct package
+folders are useful while developing an extension before publishing or
+installing it through npm.
 
 ## API Surface
 

--- a/examples/pi-extensions/aethon-types.d.ts
+++ b/examples/pi-extensions/aethon-types.d.ts
@@ -141,6 +141,9 @@ interface AethonWindowsApi {
     restoreOnLaunch?: boolean;
   }): AethonMutationResult;
   list(): AethonMutationResult<AethonNativeCanvasWindowSummary[]>;
+  get(id: string): AethonMutationResult<unknown>;
+  getState(id: string): AethonMutationResult<unknown>;
+  getCanvas(id: string): AethonMutationResult<{ components: unknown[] }>;
   focus(id: string): AethonMutationResult;
   close(id: string): AethonMutationResult;
   setTitle(id: string, title: string): AethonMutationResult;

--- a/examples/pi-extensions/aethon-types.d.ts
+++ b/examples/pi-extensions/aethon-types.d.ts
@@ -117,6 +117,33 @@ interface AethonEditorApi {
   }): Promise<{ ok: boolean; error?: string; data?: unknown }>;
 }
 
+type AethonShareMode = "private" | "read" | "read-write" | "read-write-trusted";
+
+interface AethonShellSummary {
+  tabId: string;
+  cwd?: string;
+  command?: string;
+  shareMode?: AethonShareMode;
+}
+
+interface AethonShellsApi {
+  create(input?: {
+    tabId?: string;
+    cwd?: string;
+    command?: string;
+    args?: string[];
+    activate?: boolean;
+    inheritEnv?: boolean;
+  }): AethonMutationResult<AethonShellSummary>;
+  list(): AethonMutationResult<AethonShellSummary[]>;
+  read(input: {
+    tabId: string;
+    sinceTotal?: number;
+    maxBytes?: number;
+  }): AethonMutationResult<unknown>;
+  write(input: { tabId: string; text: string }): AethonMutationResult;
+}
+
 interface AethonNativeCanvasWindowSummary {
   id: string;
   label: string;
@@ -139,6 +166,20 @@ interface AethonWindowsApi {
     y?: number;
     focus?: boolean;
     restoreOnLaunch?: boolean;
+  }): AethonMutationResult;
+  openTerminal(input?: {
+    id?: string;
+    title?: string;
+    shellTabId?: string;
+    cwd?: string;
+    command?: string;
+    args?: string[];
+    width?: number;
+    height?: number;
+    x?: number;
+    y?: number;
+    focus?: boolean;
+    restoreOnLaunch?: false;
   }): AethonMutationResult;
   list(): AethonMutationResult<AethonNativeCanvasWindowSummary[]>;
   get(id: string): AethonMutationResult<unknown>;
@@ -185,6 +226,8 @@ interface AethonEventCtx {
   canvas: AethonCanvasApi;
   /** Native canvas window API. */
   windows: AethonWindowsApi;
+  /** PTY-backed shell APIs. */
+  shells: AethonShellsApi;
   /** Present when this handler was invoked by a native canvas window. */
   window?: AethonWindowHandlerCtx;
 }
@@ -285,6 +328,9 @@ declare global {
 
         /** Native OS windows that render bare A2UI canvas content. */
         windows: AethonWindowsApi;
+
+        /** PTY-backed shell tab creation and opt-in shell read/write APIs. */
+        shells: AethonShellsApi;
 
         /**
          * Agent-side Monaco editor actions. `openFile` validates through

--- a/src-tauri/src/agent_commands.rs
+++ b/src-tauri/src/agent_commands.rs
@@ -56,6 +56,10 @@ pub(crate) struct SendMessageRequest {
     /// Opaque release-control request id. The bridge echoes it on lifecycle
     /// events so external callers can wait for the specific turn they sent.
     control_request_id: Option<String>,
+    /// Frontend already mirrored the visible user bubble through
+    /// local_chat_message; forwarded so the bridge doesn't emit a duplicate
+    /// session message event for extension subscribers.
+    suppress_user_session_event: Option<bool>,
 }
 
 #[tauri::command]
@@ -108,6 +112,9 @@ pub(crate) async fn send_message(
         && !control_request_id.is_empty()
     {
         payload["controlRequestId"] = serde_json::Value::String(control_request_id);
+    }
+    if let Some(suppress) = request.suppress_user_session_event {
+        payload["suppressUserSessionEvent"] = serde_json::Value::Bool(suppress);
     }
     let images = attachments_to_agent_images(&app, request.attachments.unwrap_or_default())?;
     if !images.is_empty() {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { BOOT_LAYOUT, hangWarnNotifId } from "./app/bootConstants";
 import { useAppForwardRefs } from "./app/useAppForwardRefs";
 import type { A2UIPayload } from "./types/a2ui";
 import type { Tab } from "./types/tab";
+import type { ShareMode } from "./utils/shareMode";
 import { useZoomAndTheme } from "./hooks/useZoomAndTheme";
 import { useSpeakReplies } from "./hooks/useSpeakReplies";
 import { useShellConsent } from "./hooks/useShellConsent";
@@ -65,6 +66,7 @@ import { useScheduledTasks } from "./hooks/useScheduledTasks";
 import { closeAllWorkspaceSessions } from "./hooks/tabOps/closeWorkspaceSessions";
 import {
   syncNativeWindowsToState as syncNativeWindowsToStateSlice,
+  terminalShellTabIds,
   type NativeCanvasWindowRecord,
 } from "./nativeWindows";
 import { writeState } from "./persist";
@@ -174,21 +176,60 @@ export default function App() {
         syncNativeWindowsToState();
       },
     );
+    const unlistenShareMode = listen<{
+      tabId?: string;
+      shareMode?: ShareMode;
+    }>("native-terminal-share-mode", (event) => {
+      const { tabId, shareMode } = event.payload ?? {};
+      if (typeof tabId !== "string" || typeof shareMode !== "string") return;
+      setState((prev) => ({
+        ...prev,
+        tabs: ((prev.tabs as Tab[] | undefined) ?? []).map((tab) =>
+          tab.id === tabId && tab.kind === "shell" && tab.shell
+            ? { ...tab, shell: { ...tab.shell, shareMode } }
+            : tab,
+        ),
+      }));
+    });
     const unlistenClosed = listen<{ id?: string }>(
       "native-window-closed",
       (event) => {
         const id = event.payload?.id;
         if (typeof id !== "string") return;
+        const record = nativeWindowsRef.current.get(id);
+        const ownedShellIds = terminalShellTabIds(record);
         nativeWindowsRef.current.delete(id);
+        if (ownedShellIds.length > 0) {
+          for (const shellId of ownedShellIds) {
+            invoke("shell_close", { tabId: shellId }).catch(() => {
+              /* best-effort terminal-window cleanup */
+            });
+          }
+          setState((prev) => {
+            const tabs = (prev.tabs as Tab[] | undefined) ?? [];
+            const owned = new Set(ownedShellIds);
+            const panel =
+              (prev.terminalPanel as { activeSubId?: string } | undefined) ??
+              {};
+            return {
+              ...prev,
+              tabs: tabs.filter((tab) => !owned.has(tab.id)),
+              ...(panel.activeSubId && owned.has(panel.activeSubId)
+                ? { terminalPanel: { ...panel, activeSubId: "agent-bash" } }
+                : {}),
+            };
+          });
+        }
         syncNativeWindowsToState();
       },
     );
     return () => {
       disposed = true;
       unlistenRecord.then((fn) => fn());
+      unlistenShareMode.then((fn) => fn());
       unlistenClosed.then((fn) => fn());
     };
-  }, [syncNativeWindowsToState]);
+  }, [setState, syncNativeWindowsToState]);
 
   const recordProjectModel = useProjectModelRecorder(setState);
 

--- a/src/NativeCanvasWindowApp.test.tsx
+++ b/src/NativeCanvasWindowApp.test.tsx
@@ -34,6 +34,28 @@ describe("NativeCanvasWindowApp", () => {
 
   beforeEach(() => {
     harness = installTauriMocks();
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: vi.fn(() => ({
+        matches: false,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+      })),
+    });
+    class ResizeObserverStub {
+      observe = vi.fn();
+      disconnect = vi.fn();
+    }
+    Object.defineProperty(window, "ResizeObserver", {
+      configurable: true,
+      value: ResizeObserverStub,
+    });
+    Object.defineProperty(globalThis, "ResizeObserver", {
+      configurable: true,
+      value: window.ResizeObserver,
+    });
   });
 
   afterEach(() => {
@@ -67,6 +89,96 @@ describe("NativeCanvasWindowApp", () => {
     expect(harness.invoke).not.toHaveBeenCalledWith("start_agent");
     expect(harness.invoke).toHaveBeenCalledWith("agent_command", {
       payload: JSON.stringify({ type: "report" }),
+    });
+  });
+
+  it("ignores shell output for windows that do not own the shell tab", async () => {
+    const saved: NativeCanvasWindowRecord[] = [];
+    harness.invoke.mockImplementation((command, args) => {
+      if (command === "native_window_get_canvas")
+        return Promise.resolve(baseRecord);
+      if (command === "native_window_save_canvas") {
+        saved.push(args.record);
+        return Promise.resolve(args.record);
+      }
+      return Promise.resolve(undefined);
+    });
+
+    render(<NativeCanvasWindowApp id="Workpad" />);
+    await screen.findByPlaceholderText("Draft");
+
+    act(() => {
+      harness.fireEvent("shell-output", {
+        tabId: "shell-elsewhere",
+        content: "hi",
+      });
+    });
+    await Promise.resolve();
+
+    expect(saved).toHaveLength(0);
+  });
+
+  it("routes shell-canvas share-mode badge clicks inside native windows", async () => {
+    const saved: NativeCanvasWindowRecord[] = [];
+    harness.invoke.mockImplementation((command, args) => {
+      if (command === "native_window_get_canvas") {
+        return Promise.resolve({
+          ...baseRecord,
+          components: [
+            {
+              id: "terminal",
+              type: "shell-canvas",
+              props: { tabId: "shell-1" },
+            },
+          ],
+          state: {
+            tabs: [
+              {
+                id: "shell-1",
+                label: "Shell 1",
+                kind: "shell",
+                terminalBuffer: "",
+                shell: {
+                  cwd: "/repo",
+                  command: "zsh",
+                  args: [],
+                  shareMode: "private",
+                  shellState: "running",
+                },
+              },
+            ],
+          },
+        });
+      }
+      if (command === "shell_set_share_mode") return Promise.resolve("read");
+      if (command === "native_window_save_canvas") {
+        saved.push(args.record);
+        return Promise.resolve(args.record);
+      }
+      return Promise.resolve(undefined);
+    });
+
+    render(<NativeCanvasWindowApp id="Workpad" />);
+
+    const badge = await screen.findByRole("button", {
+      name: /Share mode: private/i,
+    });
+    fireEvent.click(badge);
+
+    await waitFor(() =>
+      expect(harness.invoke).toHaveBeenCalledWith("shell_set_share_mode", {
+        tabId: "shell-1",
+        mode: "read",
+      }),
+    );
+    await waitFor(() => expect(saved.length).toBeGreaterThan(0));
+    expect(saved.at(-1)?.state).toMatchObject({
+      tabs: [
+        expect.objectContaining({
+          id: "shell-1",
+          shell: expect.objectContaining({ shareMode: "read" }),
+        }),
+      ],
     });
   });
 

--- a/src/NativeCanvasWindowApp.tsx
+++ b/src/NativeCanvasWindowApp.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
-import { listen } from "@tauri-apps/api/event";
+import { emit, listen } from "@tauri-apps/api/event";
 import A2UIRenderer from "./components/A2UIRenderer";
 import { ExtensionRegistry } from "./extensions/ExtensionRegistry";
 import { ExtensionRegistryProvider } from "./extensions/ExtensionRegistryProvider";
@@ -10,6 +10,7 @@ import {
   type ExtensionFrontendModule,
 } from "./extensions/extensionFrontendLoader";
 import { injectThemeStyle } from "./hooks/extensionsHydration/themes";
+import { TERMINAL_REPLAY_MAX } from "./hooks/useTabs";
 import {
   replayHighlightGrammars,
   type ExtensionHighlightGrammar,
@@ -19,6 +20,8 @@ import {
   normalizeWindowState,
   type NativeCanvasWindowRecord,
 } from "./nativeWindows";
+import { cycleShareMode, type ShareMode } from "./utils/shareMode";
+import type { A2UIComponent } from "./types/a2ui";
 
 export interface NativeCanvasWindowAppProps {
   id: string;
@@ -30,6 +33,21 @@ type BridgeHydrationMessage = {
 };
 
 const SAVE_DEBOUNCE_MS = 150;
+
+function shellShareModeFromRecord(
+  record: NativeCanvasWindowRecord | null,
+  tabId: string,
+): ShareMode {
+  const tabs =
+    (normalizeWindowState(record?.state).tabs as
+      | Array<Record<string, unknown>>
+      | undefined) ?? [];
+  const tab = tabs.find((item) => item.id === tabId);
+  const shell = tab?.shell;
+  if (!shell || typeof shell !== "object") return "private";
+  const mode = (shell as Record<string, unknown>).shareMode;
+  return typeof mode === "string" ? (mode as ShareMode) : "private";
+}
 
 export default function NativeCanvasWindowApp({
   id,
@@ -50,6 +68,11 @@ export default function NativeCanvasWindowApp({
     recordRef.current = next;
     setError(null);
     setRecord(next);
+    if (next) {
+      emit("native-canvas-window-ready", { id: next.id }).catch(() => {
+        /* readiness is best-effort; callers also have bounded waits */
+      });
+    }
   }, []);
 
   const scheduleSave = useCallback((next: NativeCanvasWindowRecord) => {
@@ -169,6 +192,49 @@ export default function NativeCanvasWindowApp({
   );
 
   useEffect(() => {
+    const unlisten = listen<{ tabId: string; content: string }>(
+      "shell-output",
+      (event) => {
+        const { tabId, content } = event.payload;
+        if (!tabId || typeof content !== "string" || content.length === 0) {
+          return;
+        }
+        const currentState = normalizeWindowState(recordRef.current?.state);
+        const tabs = currentState.tabs;
+        if (!Array.isArray(tabs) || !tabs.some((tab) => tab?.id === tabId)) {
+          return;
+        }
+        window.dispatchEvent(
+          new CustomEvent(`aethon:shell-output:${tabId}`, { detail: content }),
+        );
+        updateRecord((prev) => {
+          const state = normalizeWindowState(prev.state);
+          const prevTabs = state.tabs;
+          if (!Array.isArray(prevTabs)) return prev;
+          let matched = false;
+          const nextTabs = prevTabs.map((tab) => {
+            if (!tab || typeof tab !== "object" || tab.id !== tabId) return tab;
+            matched = true;
+            const next = `${String(tab.terminalBuffer ?? "")}${content}`;
+            return {
+              ...tab,
+              terminalBuffer:
+                next.length > TERMINAL_REPLAY_MAX
+                  ? next.slice(next.length - TERMINAL_REPLAY_MAX)
+                  : next,
+            };
+          });
+          if (!matched) return prev;
+          return { ...prev, state: { ...state, tabs: nextTabs } };
+        });
+      },
+    );
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, [updateRecord]);
+
+  useEffect(() => {
     let disposed = false;
     invoke<NativeCanvasWindowRecord | null>("native_window_get_canvas", { id })
       .then((next) => {
@@ -251,6 +317,61 @@ export default function NativeCanvasWindowApp({
     [updateRecord],
   );
 
+  const handleA2UIEvent = useCallback(
+    (component: A2UIComponent, eventType: string, data?: unknown) => {
+      if (
+        component.type !== "shell-canvas" ||
+        eventType !== "cycle-share-mode"
+      ) {
+        return false;
+      }
+      const payload =
+        data && typeof data === "object"
+          ? (data as Record<string, unknown>)
+          : {};
+      const tabId = typeof payload.tabId === "string" ? payload.tabId : "";
+      if (!tabId) return true;
+      const nextMode = cycleShareMode(
+        shellShareModeFromRecord(recordRef.current, tabId),
+      );
+      invoke<ShareMode>("shell_set_share_mode", { tabId, mode: nextMode })
+        .then((applied) => {
+          emit("native-terminal-share-mode", {
+            tabId,
+            shareMode: applied,
+          }).catch(() => {
+            /* main app mirror is best-effort; Rust remains authoritative */
+          });
+          updateRecord((prev) => ({
+            ...prev,
+            state: {
+              ...normalizeWindowState(prev.state),
+              tabs: (
+                (normalizeWindowState(prev.state).tabs as
+                  | Array<Record<string, unknown>>
+                  | undefined) ?? []
+              ).map((tab) =>
+                tab.id === tabId && tab.shell && typeof tab.shell === "object"
+                  ? {
+                      ...tab,
+                      shell: {
+                        ...(tab.shell as Record<string, unknown>),
+                        shareMode: applied,
+                      },
+                    }
+                  : tab,
+              ),
+            },
+          }));
+        })
+        .catch((err) => {
+          setError(err instanceof Error ? err.message : String(err));
+        });
+      return true;
+    },
+    [updateRecord],
+  );
+
   if (error) {
     return (
       <div className="app ae-native-canvas-window">
@@ -277,6 +398,7 @@ export default function NativeCanvasWindowApp({
           payload={{ components: record.components }}
           state={record.state}
           onStateChange={handleStateChange}
+          onEvent={handleA2UIEvent}
           tabId={record.tabId}
           surfaceId={canvasWindowSurfaceId(record.id)}
           windowId={record.id}

--- a/src/extensions/default-layout/shell/canvas.tsx
+++ b/src/extensions/default-layout/shell/canvas.tsx
@@ -15,10 +15,7 @@ import { FitAddon } from "@xterm/addon-fit";
 import { WebglAddon } from "@xterm/addon-webgl";
 import "@xterm/xterm/css/xterm.css";
 
-import type {
-  NumberValue,
-  StringValue,
-} from "../../../types/a2ui";
+import type { NumberValue, StringValue } from "../../../types/a2ui";
 import type { ShareMode } from "../../../utils/shareMode";
 import { resolveNumber, resolveString } from "../../../utils/dataBinding";
 import { RegistryComponent } from "../../../components/A2UIRenderer";
@@ -38,15 +35,15 @@ import {
   TERMINAL_UI_SCALE_SETTLE_MS,
 } from "../terminal-helpers";
 import { registerTerminalUrlLinks } from "../terminal-linkifier";
-import {
-  decideShellResize,
-  shouldSkipResize,
-  type ShellDims,
-} from "./resize";
+import { decideShellResize, shouldSkipResize, type ShellDims } from "./resize";
 
 const TERMINAL_PTY_RESIZE_SETTLE_MS = 120;
 
-export function ShellCanvas({ component, state, onEvent }: BuiltinComponentProps) {
+export function ShellCanvas({
+  component,
+  state,
+  onEvent,
+}: BuiltinComponentProps) {
   const props = component.props as {
     /** Shell tab id this canvas is bound to. Resolved via $ref so the
      *  layout can pass `/activeTabId` and have the canvas track the
@@ -70,9 +67,10 @@ export function ShellCanvas({ component, state, onEvent }: BuiltinComponentProps
     shareMode?: ShareMode;
     shellState?: string;
   };
-  const tabs = (state["tabs"] as
-    | Array<{ id: string; kind?: string; shell?: ShellMetaShape }>
-    | undefined) ?? [];
+  const tabs =
+    (state["tabs"] as
+      | Array<{ id: string; kind?: string; shell?: ShellMetaShape }>
+      | undefined) ?? [];
   const boundTab = tabs.find((t) => t.id === tabId);
   const shell = boundTab?.shell;
 
@@ -84,6 +82,8 @@ export function ShellCanvas({ component, state, onEvent }: BuiltinComponentProps
   // Live cols×rows for the status line. Updated in the same ResizeObserver
   // callback that resizes the PTY so the displayed value never drifts.
   const [dims, setDims] = useState<{ cols: number; rows: number } | null>(null);
+  const shellStateRef = useRef({ tabId, shellState: shell?.shellState });
+  const resizeReplayPendingRef = useRef(false);
   useEffect(() => {
     tabIdRef.current = tabId;
   }, [tabId]);
@@ -255,7 +255,10 @@ export function ShellCanvas({ component, state, onEvent }: BuiltinComponentProps
     // Replay any already-buffered scrollback (when the tab was mounted
     // after some output had already streamed). App.tsx writes buffer to
     // /tabs/<idx>/terminalBuffer; we read it via state.
-    const tabs = (state["tabs"] as Array<{ id: string; terminalBuffer?: string }> | undefined) ?? [];
+    const tabs =
+      (state["tabs"] as
+        | Array<{ id: string; terminalBuffer?: string }>
+        | undefined) ?? [];
     const tab = tabs.find((t) => t.id === tabId);
     if (tab?.terminalBuffer) term.write(tab.terminalBuffer);
 
@@ -277,12 +280,38 @@ export function ShellCanvas({ component, state, onEvent }: BuiltinComponentProps
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tabId]);
 
+  useEffect(() => {
+    const previous = shellStateRef.current;
+    const sameTab = previous.tabId === tabId;
+    resizeReplayPendingRef.current =
+      sameTab &&
+      previous.shellState !== "running" &&
+      shell?.shellState === "running";
+    shellStateRef.current = { tabId, shellState: shell?.shellState };
+  }, [shell?.shellState, tabId]);
+
+  useEffect(() => {
+    if (
+      shell?.shellState !== "running" ||
+      !tabId ||
+      !dims ||
+      !resizeReplayPendingRef.current
+    ) {
+      return;
+    }
+    resizeReplayPendingRef.current = false;
+    void invoke("shell_resize", {
+      tabId,
+      cols: dims.cols,
+      rows: dims.rows,
+    }).catch(() => {
+      /* PTY may have exited between state update and replay */
+    });
+  }, [dims, shell?.shellState, tabId]);
+
   return (
     <div className="ae-shell-canvas-wrap" style={{ gridArea: "canvas" }}>
-      <div
-        ref={containerRef}
-        className="ae-shell-canvas-term"
-      />
+      <div ref={containerRef} className="ae-shell-canvas-term" />
       <ShellStatusBar
         cwd={shell?.cwd ?? ""}
         command={shell?.command ?? ""}
@@ -325,10 +354,7 @@ function ShellStatusBar(props: {
   }, [cwd]);
   // Live shareMode + tabId pass through componentProps; both the default
   // React badge and any override template see them via component.props.
-  const badgeProps = useMemo(
-    () => ({ shareMode, tabId }),
-    [shareMode, tabId],
-  );
+  const badgeProps = useMemo(() => ({ shareMode, tabId }), [shareMode, tabId]);
   // Adapter: the default React badge fires `cycle-share-mode`, which
   // App.tsx routes from the surrounding shell-canvas. Re-emit through
   // the parent BuiltinComponentProps onEvent so it lands on the
@@ -369,11 +395,15 @@ function ShellStatusBar(props: {
       )}
       {command && (
         <>
-          <span className="ae-shell-status-sep" aria-hidden="true">·</span>
+          <span className="ae-shell-status-sep" aria-hidden="true">
+            ·
+          </span>
           <span className="ae-shell-status-cmd">{command}</span>
         </>
       )}
-      <span className="ae-shell-status-sep" aria-hidden="true">·</span>
+      <span className="ae-shell-status-sep" aria-hidden="true">
+        ·
+      </span>
       <RegistryComponent
         type="share-mode-badge"
         state={state}

--- a/src/extensions/default-layout/shell/canvas.zoom.test.tsx
+++ b/src/extensions/default-layout/shell/canvas.zoom.test.tsx
@@ -105,7 +105,46 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
+function shellResizeCalls() {
+  return vi
+    .mocked(invoke)
+    .mock.calls.filter(([command]) => command === "shell_resize");
+}
+
 describe("ShellCanvas zoom synchronization", () => {
+  it("does not replay an immediate duplicate resize for already-running shells", async () => {
+    const state = {
+      tabs: [
+        {
+          id: "shell-1",
+          kind: "shell",
+          shell: {
+            cwd: "/repo",
+            command: "zsh",
+            shareMode: "private",
+            shellState: "running",
+          },
+        },
+      ],
+    };
+
+    render(
+      <ShellCanvas
+        component={{
+          id: "shell-canvas",
+          type: "shell-canvas",
+          props: { tabId: "shell-1", fontSize: 13 },
+        }}
+        state={state}
+        onEvent={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(shellResizeCalls()).toHaveLength(1));
+    await Promise.resolve();
+    expect(shellResizeCalls()).toHaveLength(1);
+  });
+
   it("refits xterm and resizes the PTY when app zoom changes", async () => {
     const state = {
       tabs: [

--- a/src/hooks/bridgeMessageHandlers/nativeWindowQuery.test.ts
+++ b/src/hooks/bridgeMessageHandlers/nativeWindowQuery.test.ts
@@ -132,6 +132,253 @@ describe("handleNativeWindowQuery", () => {
     expect(ctx.nativeWindowsRef.current.get("Workpad")).toEqual(record);
   });
 
+  it("opens a terminal window by creating a shell and binding shell-canvas", async () => {
+    const { ctx, mocks } = buildHandlerFixture({ state: { tabs: [] } });
+    const opened: NativeCanvasWindowRecord = {
+      ...record,
+      id: "Term",
+      label: "aethon-canvas-Term",
+      title: "Terminal",
+    };
+    harness.invoke.mockImplementation((command, args) => {
+      if (command === "shell_open") return Promise.resolve(undefined);
+      if (command === "native_window_open_canvas") {
+        return Promise.resolve({ ...opened, ...args.input });
+      }
+      if (command === "native_window_save_canvas") {
+        return Promise.resolve(args.record);
+      }
+      return Promise.resolve(undefined);
+    });
+
+    handleNativeWindowQuery(
+      {
+        type: "native_window_query",
+        op: "open_terminal",
+        mutationId: "m-terminal",
+        args: {
+          id: "Term",
+          title: "Terminal",
+          shellTabId: "shell-term",
+          cwd: "/repo",
+          command: "zsh",
+        },
+      },
+      ctx,
+    );
+
+    await vi.waitFor(() =>
+      expect(harness.invoke).toHaveBeenCalledWith("native_window_open_canvas", {
+        input: expect.objectContaining({
+          id: "Term",
+          title: "Terminal",
+          components: [
+            expect.objectContaining({
+              type: "shell-canvas",
+              props: expect.objectContaining({ tabId: "shell-term" }),
+            }),
+          ],
+          restoreOnLaunch: false,
+          state: expect.objectContaining({
+            tabs: [
+              expect.objectContaining({ id: "shell-term", kind: "shell" }),
+            ],
+          }),
+        }),
+      }),
+    );
+    harness.fireEvent("native-canvas-window-ready", { id: "Term" });
+    await vi.waitFor(() =>
+      expect(harness.invoke).toHaveBeenCalledWith("shell_open", {
+        args: expect.objectContaining({ tabId: "shell-term" }),
+      }),
+    );
+    const openWindowOrder =
+      harness.invoke.mock.invocationCallOrder[
+        harness.invoke.mock.calls.findIndex(
+          ([command]) => command === "native_window_open_canvas",
+        )
+      ];
+    const shellOpenOrder =
+      harness.invoke.mock.invocationCallOrder[
+        harness.invoke.mock.calls.findIndex(
+          ([command]) => command === "shell_open",
+        )
+      ];
+    expect(openWindowOrder).toBeLessThan(shellOpenOrder);
+    expect(mocks.ackMutation).toHaveBeenCalledWith(
+      "m-terminal",
+      true,
+      undefined,
+      expect.objectContaining({ id: "Term" }),
+    );
+  });
+
+  it("cleans up shells and native windows when terminal open partially fails", async () => {
+    const { ctx, mocks } = buildHandlerFixture({ state: { tabs: [] } });
+    harness.invoke.mockImplementation((command, args) => {
+      if (command === "native_window_open_canvas") {
+        return Promise.resolve({ ...record, id: "Term", ...args.input });
+      }
+      if (command === "shell_open") return Promise.resolve(undefined);
+      if (command === "native_window_save_canvas") {
+        return Promise.reject(new Error("save failed"));
+      }
+      return Promise.resolve(undefined);
+    });
+
+    handleNativeWindowQuery(
+      {
+        type: "native_window_query",
+        op: "open_terminal",
+        mutationId: "m-terminal-fail",
+        args: {
+          id: "Term",
+          shellTabId: "shell-term",
+          cwd: "/repo",
+        },
+      },
+      ctx,
+    );
+
+    await vi.waitFor(() =>
+      expect(harness.invoke).toHaveBeenCalledWith(
+        "native_window_open_canvas",
+        expect.anything(),
+      ),
+    );
+    harness.fireEvent("native-canvas-window-ready", { id: "Term" });
+    await vi.waitFor(() =>
+      expect(mocks.ackMutation).toHaveBeenCalledWith(
+        "m-terminal-fail",
+        false,
+        "save failed",
+      ),
+    );
+    expect(harness.invoke).toHaveBeenCalledWith("shell_close", {
+      tabId: "shell-term",
+    });
+    expect(harness.invoke).toHaveBeenCalledWith("native_window_close", {
+      id: "Term",
+    });
+    expect(ctx.stateRef.current.tabs).toEqual([]);
+    expect(ctx.nativeWindowsRef.current.has("Term")).toBe(false);
+  });
+
+  it("restores existing windows instead of closing them when terminal reuse fails", async () => {
+    const previous: NativeCanvasWindowRecord = {
+      ...record,
+      id: "Term",
+      title: "Existing",
+      components: [{ id: "existing", type: "text", props: { content: "old" } }],
+      state: { old: true },
+    };
+    const { ctx, mocks } = buildHandlerFixture({ state: { tabs: [] } });
+    ctx.nativeWindowsRef.current.set("Term", previous);
+    harness.invoke.mockImplementation((command, args) => {
+      if (command === "native_window_open_canvas") {
+        return Promise.resolve({
+          ...previous,
+          ...args.input,
+          title: "Terminal",
+        });
+      }
+      if (command === "shell_open") return Promise.resolve(undefined);
+      if (command === "native_window_save_canvas") {
+        return Promise.reject(new Error("save failed"));
+      }
+      return Promise.resolve(undefined);
+    });
+
+    handleNativeWindowQuery(
+      {
+        type: "native_window_query",
+        op: "open_terminal",
+        mutationId: "m-reuse-fail",
+        args: { id: "Term", shellTabId: "shell-term" },
+      },
+      ctx,
+    );
+
+    await vi.waitFor(() =>
+      expect(harness.invoke).toHaveBeenCalledWith(
+        "native_window_open_canvas",
+        expect.anything(),
+      ),
+    );
+    harness.fireEvent("native-canvas-window-ready", { id: "Term" });
+    await vi.waitFor(() =>
+      expect(mocks.ackMutation).toHaveBeenCalledWith(
+        "m-reuse-fail",
+        false,
+        "save failed",
+      ),
+    );
+    expect(harness.invoke).not.toHaveBeenCalledWith("native_window_close", {
+      id: "Term",
+    });
+    expect(harness.invoke).toHaveBeenCalledWith("native_window_set_title", {
+      id: "Term",
+      title: "Existing",
+    });
+    expect(ctx.nativeWindowsRef.current.get("Term")).toEqual(previous);
+  });
+
+  it("closes owned terminal shells when a terminal window is closed programmatically", async () => {
+    const terminalRecord: NativeCanvasWindowRecord = {
+      ...record,
+      id: "Term",
+      label: "aethon-canvas-Term",
+      components: [
+        {
+          id: "terminal",
+          type: "shell-canvas",
+          props: { tabId: "shell-term" },
+        },
+      ],
+      state: {
+        tabs: [{ id: "shell-term", kind: "shell" }],
+      },
+    };
+    const { ctx, mocks } = buildHandlerFixture({
+      state: {
+        tabs: [{ id: "shell-term", kind: "shell" }],
+        terminalPanel: { activeSubId: "shell-term" },
+      },
+    });
+    ctx.nativeWindowsRef.current.set("Term", terminalRecord);
+
+    handleNativeWindowQuery(
+      {
+        type: "native_window_query",
+        op: "close",
+        mutationId: "m-close-terminal",
+        args: { id: "Term" },
+      },
+      ctx,
+    );
+
+    await vi.waitFor(() =>
+      expect(mocks.ackMutation).toHaveBeenCalledWith(
+        "m-close-terminal",
+        true,
+        undefined,
+        { ok: true },
+      ),
+    );
+    expect(harness.invoke).toHaveBeenCalledWith("native_window_close", {
+      id: "Term",
+    });
+    expect(harness.invoke).toHaveBeenCalledWith("shell_close", {
+      tabId: "shell-term",
+    });
+    expect(ctx.nativeWindowsRef.current.has("Term")).toBe(false);
+    expect(ctx.stateRef.current.tabs).toEqual([]);
+    expect(ctx.stateRef.current.terminalPanel).toEqual({
+      activeSubId: "agent-bash",
+    });
+  });
+
   it("returns window record, state, and canvas for read queries", async () => {
     const { ctx, mocks } = buildHandlerFixture();
     ctx.nativeWindowsRef.current.set("Workpad", record);

--- a/src/hooks/bridgeMessageHandlers/nativeWindowQuery.test.ts
+++ b/src/hooks/bridgeMessageHandlers/nativeWindowQuery.test.ts
@@ -180,6 +180,7 @@ describe("handleNativeWindowQuery", () => {
           ],
           restoreOnLaunch: false,
           state: expect.objectContaining({
+            ownedShellTabIds: ["shell-term"],
             tabs: [
               expect.objectContaining({ id: "shell-term", kind: "shell" }),
             ],
@@ -337,6 +338,7 @@ describe("handleNativeWindowQuery", () => {
         },
       ],
       state: {
+        ownedShellTabIds: ["shell-term"],
         tabs: [{ id: "shell-term", kind: "shell" }],
       },
     };
@@ -377,6 +379,56 @@ describe("handleNativeWindowQuery", () => {
     expect(ctx.stateRef.current.terminalPanel).toEqual({
       activeSubId: "agent-bash",
     });
+  });
+
+  it("does not close shell-canvas tabs that are not explicitly owned by the native window", async () => {
+    const terminalRecord: NativeCanvasWindowRecord = {
+      ...record,
+      id: "Viewer",
+      label: "aethon-canvas-Viewer",
+      components: [
+        {
+          id: "terminal-view",
+          type: "shell-canvas",
+          props: { tabId: "existing-shell" },
+        },
+      ],
+      state: {
+        tabs: [{ id: "existing-shell", kind: "shell" }],
+      },
+    };
+    const { ctx, mocks } = buildHandlerFixture({
+      state: {
+        tabs: [{ id: "existing-shell", kind: "shell" }],
+        terminalPanel: { activeSubId: "existing-shell" },
+      },
+    });
+    ctx.nativeWindowsRef.current.set("Viewer", terminalRecord);
+
+    handleNativeWindowQuery(
+      {
+        type: "native_window_query",
+        op: "close",
+        mutationId: "m-close-viewer",
+        args: { id: "Viewer" },
+      },
+      ctx,
+    );
+
+    await vi.waitFor(() =>
+      expect(mocks.ackMutation).toHaveBeenCalledWith(
+        "m-close-viewer",
+        true,
+        undefined,
+        { ok: true },
+      ),
+    );
+    expect(harness.invoke).not.toHaveBeenCalledWith("shell_close", {
+      tabId: "existing-shell",
+    });
+    expect(ctx.stateRef.current.tabs).toEqual([
+      { id: "existing-shell", kind: "shell" },
+    ]);
   });
 
   it("returns window record, state, and canvas for read queries", async () => {

--- a/src/hooks/bridgeMessageHandlers/nativeWindowQuery.test.ts
+++ b/src/hooks/bridgeMessageHandlers/nativeWindowQuery.test.ts
@@ -102,6 +102,90 @@ describe("handleNativeWindowQuery", () => {
     );
   });
 
+  it("falls back to Rust-owned records for read queries", async () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    harness.invoke.mockResolvedValueOnce(record);
+
+    handleNativeWindowQuery(
+      {
+        type: "native_window_query",
+        op: "get",
+        mutationId: "m-get-rust",
+        args: { id: "Workpad" },
+      },
+      ctx,
+    );
+
+    await vi.waitFor(() =>
+      expect(harness.invoke).toHaveBeenCalledWith("native_window_get_canvas", {
+        id: "Workpad",
+      }),
+    );
+    await vi.waitFor(() =>
+      expect(mocks.ackMutation).toHaveBeenCalledWith(
+        "m-get-rust",
+        true,
+        undefined,
+        record,
+      ),
+    );
+    expect(ctx.nativeWindowsRef.current.get("Workpad")).toEqual(record);
+  });
+
+  it("returns window record, state, and canvas for read queries", async () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    ctx.nativeWindowsRef.current.set("Workpad", record);
+
+    handleNativeWindowQuery(
+      {
+        type: "native_window_query",
+        op: "get",
+        mutationId: "m-get",
+        args: { id: "Workpad" },
+      },
+      ctx,
+    );
+    handleNativeWindowQuery(
+      {
+        type: "native_window_query",
+        op: "get_state",
+        mutationId: "m-state",
+        args: { id: "Workpad" },
+      },
+      ctx,
+    );
+    handleNativeWindowQuery(
+      {
+        type: "native_window_query",
+        op: "get_canvas",
+        mutationId: "m-canvas",
+        args: { id: "Workpad" },
+      },
+      ctx,
+    );
+
+    await vi.waitFor(() =>
+      expect(mocks.ackMutation).toHaveBeenCalledWith(
+        "m-get",
+        true,
+        undefined,
+        record,
+      ),
+    );
+    expect(mocks.ackMutation).toHaveBeenCalledWith(
+      "m-state",
+      true,
+      undefined,
+      record.state,
+    );
+    expect(mocks.ackMutation).toHaveBeenCalledWith(
+      "m-canvas",
+      true,
+      undefined,
+      { components: record.components },
+    );
+  });
+
   it("lists windows as a plain record array", async () => {
     const { ctx, mocks } = buildHandlerFixture();
     harness.invoke.mockResolvedValueOnce([record]);
@@ -152,6 +236,7 @@ describe("handleNativeWindowQuery", () => {
 
   it("acks failure for missing windows", async () => {
     const { ctx, mocks } = buildHandlerFixture();
+    harness.invoke.mockResolvedValueOnce(null);
     handleNativeWindowQuery(
       {
         type: "native_window_query",
@@ -161,12 +246,12 @@ describe("handleNativeWindowQuery", () => {
       },
       ctx,
     );
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(mocks.ackMutation).toHaveBeenCalledWith(
-      "m4",
-      false,
-      "window not found: Missing",
+    await vi.waitFor(() =>
+      expect(mocks.ackMutation).toHaveBeenCalledWith(
+        "m4",
+        false,
+        "window not found: Missing",
+      ),
     );
   });
 });

--- a/src/hooks/bridgeMessageHandlers/nativeWindowQuery.ts
+++ b/src/hooks/bridgeMessageHandlers/nativeWindowQuery.ts
@@ -66,7 +66,11 @@ async function waitForNativeCanvasReady(id: string): Promise<void> {
       finish();
     })
       .then((unlisten) => {
-        cleanup = unlisten;
+        if (done) {
+          unlisten();
+        } else {
+          cleanup = unlisten;
+        }
       })
       .catch(() => {
         clearTimeout(timer);
@@ -218,6 +222,7 @@ export const handleNativeWindowQuery: BridgeMessageHandler = (data, ctx) => {
           ]),
           state: normalizeWindowState({
             ...asRecord(args.state),
+            ownedShellTabIds: [shell.tabId],
             tabs: shellTab ? [shellTab] : [],
           }),
         };
@@ -238,6 +243,7 @@ export const handleNativeWindowQuery: BridgeMessageHandler = (data, ctx) => {
             ...record,
             state: normalizeWindowState({
               ...asRecord(record.state),
+              ownedShellTabIds: [shell.tabId],
               tabs: [runningShellTab],
             }),
           });

--- a/src/hooks/bridgeMessageHandlers/nativeWindowQuery.ts
+++ b/src/hooks/bridgeMessageHandlers/nativeWindowQuery.ts
@@ -1,11 +1,18 @@
 import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 import {
   normalizeCanvasComponents,
   normalizeWindowState,
   syncNativeWindowsToState,
+  terminalShellTabIds,
   type NativeCanvasWindowRecord,
 } from "../../nativeWindows";
 import { setPointer } from "../../utils/jsonPointer";
+import {
+  removeReservedShellTab,
+  reserveShellTab,
+  startReservedShell,
+} from "./shellQuery";
 import type { BridgeMessageHandler, BridgeMessageContext } from "./types";
 
 function asRecord(value: unknown): Record<string, unknown> {
@@ -26,6 +33,46 @@ function requireId(args: Record<string, unknown>): string {
   const id = typeof args.id === "string" ? args.id.trim() : "";
   if (!id) throw new Error("id required");
   return id;
+}
+
+const NATIVE_TERMINAL_READY_TIMEOUT_MS = 5_000;
+
+function shellTabFromState(
+  ctx: BridgeMessageContext,
+  tabId: string,
+): Record<string, unknown> | undefined {
+  return ((ctx.stateRef.current.tabs as unknown[]) ?? []).find(
+    (tab): tab is Record<string, unknown> =>
+      Boolean(tab) &&
+      typeof tab === "object" &&
+      (tab as { id?: unknown }).id === tabId,
+  );
+}
+
+async function waitForNativeCanvasReady(id: string): Promise<void> {
+  await new Promise<void>((resolve) => {
+    let done = false;
+    let cleanup: (() => void) | undefined;
+    const finish = () => {
+      if (done) return;
+      done = true;
+      if (cleanup) cleanup();
+      resolve();
+    };
+    const timer = setTimeout(finish, NATIVE_TERMINAL_READY_TIMEOUT_MS);
+    listen<{ id?: string }>("native-canvas-window-ready", (event) => {
+      if (event.payload?.id !== id) return;
+      clearTimeout(timer);
+      finish();
+    })
+      .then((unlisten) => {
+        cleanup = unlisten;
+      })
+      .catch(() => {
+        clearTimeout(timer);
+        finish();
+      });
+  });
 }
 
 function recordFromRef(
@@ -76,6 +123,36 @@ function replaceRecords(
   syncNativeWindowsToState(ctx.setState, ctx.nativeWindowsRef);
 }
 
+async function cleanupOwnedTerminalShells(
+  ctx: BridgeMessageContext,
+  shellIds: string[],
+): Promise<void> {
+  if (shellIds.length === 0) return;
+  await Promise.allSettled(
+    shellIds.map((tabId) => invoke("shell_close", { tabId })),
+  );
+  const owned = new Set(shellIds);
+  ctx.setState((prev) => {
+    const tabs = (prev.tabs as unknown[] | undefined) ?? [];
+    const panel =
+      (prev.terminalPanel as { activeSubId?: string } | undefined) ?? {};
+    return {
+      ...prev,
+      tabs: tabs.filter(
+        (tab) =>
+          !(
+            tab &&
+            typeof tab === "object" &&
+            owned.has((tab as { id?: string }).id ?? "")
+          ),
+      ),
+      ...(panel.activeSubId && owned.has(panel.activeSubId)
+        ? { terminalPanel: { ...panel, activeSubId: "agent-bash" } }
+        : {}),
+    };
+  });
+}
+
 export const handleNativeWindowQuery: BridgeMessageHandler = (data, ctx) => {
   const op = data.op as string | undefined;
   const args = asRecord(data.args);
@@ -95,6 +172,107 @@ export const handleNativeWindowQuery: BridgeMessageHandler = (data, ctx) => {
       ctx.nativeWindowsRef.current.set(record.id, record);
       syncNativeWindowsToState(ctx.setState, ctx.nativeWindowsRef);
       return record;
+    }
+
+    if (op === "open_terminal") {
+      const requestedId =
+        typeof args.id === "string" && args.id.trim()
+          ? args.id.trim()
+          : undefined;
+      const previousRecord = requestedId
+        ? (ctx.nativeWindowsRef.current.get(requestedId) ??
+          (await invoke<NativeCanvasWindowRecord | null>(
+            "native_window_get_canvas",
+            { id: requestedId },
+          )) ??
+          undefined)
+        : undefined;
+      const shell = reserveShellTab(
+        {
+          ...args,
+          tabId:
+            typeof args.shellTabId === "string" && args.shellTabId.length > 0
+              ? args.shellTabId
+              : undefined,
+          activate: args.activateShell === true,
+        },
+        ctx,
+      );
+      let openedRecordId: string | undefined;
+      try {
+        const shellTab = shellTabFromState(ctx, shell.tabId);
+        const title =
+          typeof args.title === "string" && args.title.trim()
+            ? args.title
+            : "Terminal";
+        const input = {
+          ...args,
+          title,
+          restoreOnLaunch: false,
+          components: normalizeCanvasComponents([
+            {
+              id: "terminal",
+              type: "shell-canvas",
+              props: { tabId: shell.tabId, fontSize: args.fontSize ?? 13 },
+            },
+          ]),
+          state: normalizeWindowState({
+            ...asRecord(args.state),
+            tabs: shellTab ? [shellTab] : [],
+          }),
+        };
+        let record = await invoke<NativeCanvasWindowRecord>(
+          "native_window_open_canvas",
+          { input },
+        );
+        openedRecordId = record.id;
+        ctx.nativeWindowsRef.current.set(record.id, record);
+        syncNativeWindowsToState(ctx.setState, ctx.nativeWindowsRef);
+
+        await waitForNativeCanvasReady(record.id);
+        await startReservedShell(shell, ctx);
+
+        const runningShellTab = shellTabFromState(ctx, shell.tabId);
+        if (runningShellTab) {
+          record = await persistRecord(ctx, {
+            ...record,
+            state: normalizeWindowState({
+              ...asRecord(record.state),
+              tabs: [runningShellTab],
+            }),
+          });
+        }
+        return record;
+      } catch (err) {
+        removeReservedShellTab(shell.tabId, ctx);
+        await invoke("shell_close", { tabId: shell.tabId }).catch(() => {
+          /* best-effort cleanup */
+        });
+        if (openedRecordId) {
+          if (previousRecord && previousRecord.id === openedRecordId) {
+            ctx.nativeWindowsRef.current.set(previousRecord.id, previousRecord);
+            syncNativeWindowsToState(ctx.setState, ctx.nativeWindowsRef);
+            await persistRecord(ctx, previousRecord).catch(() => {
+              /* best-effort restore */
+            });
+            await invoke("native_window_set_title", {
+              id: previousRecord.id,
+              title: previousRecord.title,
+            }).catch(() => {
+              /* best-effort restore */
+            });
+          } else {
+            ctx.nativeWindowsRef.current.delete(openedRecordId);
+            syncNativeWindowsToState(ctx.setState, ctx.nativeWindowsRef);
+            await invoke("native_window_close", { id: openedRecordId }).catch(
+              () => {
+                /* best-effort cleanup */
+              },
+            );
+          }
+        }
+        throw err;
+      }
     }
 
     if (op === "list") {
@@ -123,7 +301,9 @@ export const handleNativeWindowQuery: BridgeMessageHandler = (data, ctx) => {
 
     if (op === "close") {
       const id = requireId(args);
+      const ownedShellIds = terminalShellTabIds(recordFromRef(ctx, id));
       await invoke("native_window_close", { id });
+      await cleanupOwnedTerminalShells(ctx, ownedShellIds);
       ctx.nativeWindowsRef.current.delete(id);
       syncNativeWindowsToState(ctx.setState, ctx.nativeWindowsRef);
       return { ok: true };

--- a/src/hooks/bridgeMessageHandlers/nativeWindowQuery.ts
+++ b/src/hooks/bridgeMessageHandlers/nativeWindowQuery.ts
@@ -31,9 +31,23 @@ function requireId(args: Record<string, unknown>): string {
 function recordFromRef(
   ctx: BridgeMessageContext,
   id: string,
-): NativeCanvasWindowRecord {
-  const record = ctx.nativeWindowsRef.current.get(id);
+): NativeCanvasWindowRecord | undefined {
+  return ctx.nativeWindowsRef.current.get(id);
+}
+
+async function getRecord(
+  ctx: BridgeMessageContext,
+  id: string,
+): Promise<NativeCanvasWindowRecord> {
+  const cached = recordFromRef(ctx, id);
+  if (cached) return cached;
+  const record = await invoke<NativeCanvasWindowRecord | null>(
+    "native_window_get_canvas",
+    { id },
+  );
   if (!record) throw new Error(`window not found: ${id}`);
+  ctx.nativeWindowsRef.current.set(record.id, record);
+  syncNativeWindowsToState(ctx.setState, ctx.nativeWindowsRef);
   return record;
 }
 
@@ -90,6 +104,18 @@ export const handleNativeWindowQuery: BridgeMessageHandler = (data, ctx) => {
       return records;
     }
 
+    if (op === "get") {
+      return await getRecord(ctx, requireId(args));
+    }
+
+    if (op === "get_state") {
+      return (await getRecord(ctx, requireId(args))).state ?? {};
+    }
+
+    if (op === "get_canvas") {
+      return { components: (await getRecord(ctx, requireId(args))).components };
+    }
+
     if (op === "focus") {
       await invoke("native_window_focus", { id: requireId(args) });
       return { ok: true };
@@ -118,7 +144,7 @@ export const handleNativeWindowQuery: BridgeMessageHandler = (data, ctx) => {
 
     if (op === "emit_canvas") {
       const id = requireId(args);
-      const record = recordFromRef(ctx, id);
+      const record = await getRecord(ctx, id);
       return await persistRecord(ctx, {
         ...record,
         components: normalizeCanvasComponents(args.components),
@@ -127,7 +153,7 @@ export const handleNativeWindowQuery: BridgeMessageHandler = (data, ctx) => {
 
     if (op === "append_canvas") {
       const id = requireId(args);
-      const record = recordFromRef(ctx, id);
+      const record = await getRecord(ctx, id);
       const additions = normalizeCanvasComponents(args.components);
       if (additions.length === 0) return record;
       return await persistRecord(ctx, {
@@ -138,7 +164,7 @@ export const handleNativeWindowQuery: BridgeMessageHandler = (data, ctx) => {
 
     if (op === "patch_canvas") {
       const id = requireId(args);
-      const record = recordFromRef(ctx, id);
+      const record = await getRecord(ctx, id);
       const path = normalizePointer(args.path);
       const canvasPath = path.startsWith("/components")
         ? path.slice("/components".length) || "/"
@@ -156,13 +182,13 @@ export const handleNativeWindowQuery: BridgeMessageHandler = (data, ctx) => {
 
     if (op === "clear_canvas") {
       const id = requireId(args);
-      const record = recordFromRef(ctx, id);
+      const record = await getRecord(ctx, id);
       return await persistRecord(ctx, { ...record, components: [] });
     }
 
     if (op === "set_state") {
       const id = requireId(args);
-      const record = recordFromRef(ctx, id);
+      const record = await getRecord(ctx, id);
       const path = normalizePointer(args.path);
       return await persistRecord(ctx, {
         ...record,

--- a/src/hooks/bridgeMessageHandlers/shellQuery.test.ts
+++ b/src/hooks/bridgeMessageHandlers/shellQuery.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { handleShellQuery } from "./shellQuery";
 import { buildHandlerFixture } from "./testFixtures";
 import { clearTauriMocks, installTauriMocks } from "../../test/tauriMocks";
@@ -26,6 +26,137 @@ describe("handleShellQuery", () => {
       "tab-1",
       "tab-2",
     ]);
+  });
+
+  it("creates shell tabs without opening the terminal panel by default", async () => {
+    const { ctx, mocks } = buildHandlerFixture({
+      state: { tabs: [], terminal: { open: false }, terminalPanel: {} },
+    });
+    harness.invoke.mockResolvedValueOnce(undefined);
+
+    handleShellQuery(
+      {
+        type: "shell_query",
+        op: "create",
+        mutationId: "m-create",
+        args: {
+          tabId: "shell-test",
+          cwd: "/repo",
+          command: "zsh",
+          args: ["-l"],
+          shareMode: "read-write-trusted",
+          activate: false,
+        },
+      },
+      ctx,
+    );
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(harness.invoke).toHaveBeenCalledWith("shell_open", {
+      args: {
+        tabId: "shell-test",
+        command: "zsh",
+        args: ["-l"],
+        cwd: "/repo",
+      },
+    });
+    expect(ctx.stateRef.current).toMatchObject({
+      terminal: { open: false },
+      terminalPanel: {},
+      tabs: [
+        expect.objectContaining({
+          id: "shell-test",
+          kind: "shell",
+          terminalBuffer: "",
+          shell: expect.objectContaining({
+            cwd: "/repo",
+            command: "zsh",
+            args: ["-l"],
+            shareMode: "private",
+            shellState: "running",
+          }),
+        }),
+      ],
+    });
+    await vi.waitFor(() =>
+      expect(mocks.ackMutation).toHaveBeenCalledWith(
+        "m-create",
+        true,
+        undefined,
+        expect.objectContaining({ tabId: "shell-test" }),
+      ),
+    );
+  });
+
+  it("resets active sub-tab when activated shell creation fails", async () => {
+    const { ctx, mocks } = buildHandlerFixture({
+      state: { tabs: [], terminalPanel: {}, terminal: { open: false } },
+    });
+    harness.invoke.mockRejectedValueOnce(new Error("spawn failed"));
+
+    handleShellQuery(
+      {
+        type: "shell_query",
+        op: "create",
+        mutationId: "m-fail",
+        args: { tabId: "shell-fail", activate: true },
+      },
+      ctx,
+    );
+
+    await vi.waitFor(() =>
+      expect(mocks.ackMutation).toHaveBeenCalledWith(
+        "m-fail",
+        false,
+        "spawn failed",
+      ),
+    );
+    expect(ctx.stateRef.current).toMatchObject({
+      tabs: [],
+      terminalPanel: { activeSubId: "agent-bash" },
+      terminal: { open: true },
+    });
+  });
+
+  it("rejects duplicate shell ids without mutating existing tabs", async () => {
+    const existing = {
+      id: "shell-test",
+      label: "Existing",
+      kind: "shell",
+      terminalBuffer: "keep",
+      shell: {
+        cwd: "/old",
+        command: "zsh",
+        args: [],
+        shareMode: "read",
+        shellState: "running",
+      },
+    };
+    const { ctx, mocks } = buildHandlerFixture({ state: { tabs: [existing] } });
+
+    handleShellQuery(
+      {
+        type: "shell_query",
+        op: "create",
+        mutationId: "m-dup",
+        args: { tabId: "shell-test", cwd: "/repo" },
+      },
+      ctx,
+    );
+
+    await vi.waitFor(() =>
+      expect(mocks.ackMutation).toHaveBeenCalledWith(
+        "m-dup",
+        false,
+        "shell tab already exists: shell-test",
+      ),
+    );
+    expect(harness.invoke).not.toHaveBeenCalledWith(
+      "shell_open",
+      expect.anything(),
+    );
+    expect(ctx.stateRef.current.tabs).toEqual([existing]);
   });
 
   it("acks failure for unknown ops", async () => {

--- a/src/hooks/bridgeMessageHandlers/shellQuery.ts
+++ b/src/hooks/bridgeMessageHandlers/shellQuery.ts
@@ -1,5 +1,9 @@
 import { invoke } from "@tauri-apps/api/core";
-import type { BridgeMessageHandler } from "./types";
+import { makeEmptyTab, type ShellMeta, type Tab } from "../../types/tab";
+import type { ShareMode } from "../../utils/shareMode";
+import { initialDevshellTerminalBuffer } from "../tabOps/devshellTerminal";
+import { cwdForNewTab } from "../tabOps/helpers";
+import type { BridgeMessageContext, BridgeMessageHandler } from "./types";
 
 /** Bridge proxy for `aethon.shells.{list, read, write}`. Mode changes go
  *  through the status-bar badge (frontend invokes `shell_set_share_mode`
@@ -10,6 +14,144 @@ import type { BridgeMessageHandler } from "./types";
  *  For write: we check share mode here (read-write → overlay confirm;
  *  read-write-trusted → write directly; private/read → refuse), then
  *  invoke the Rust shell_write which gates again as defense-in-depth. */
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function optionalStringArray(value: unknown): string[] | undefined {
+  return Array.isArray(value) && value.every((item) => typeof item === "string")
+    ? value
+    : undefined;
+}
+
+export interface CreatedShell {
+  tabId: string;
+  cwd: string;
+  command: string;
+  args: string[];
+  shareMode: ShareMode;
+  inheritEnv: boolean;
+}
+
+function shellOpenPayload(shell: CreatedShell): Record<string, unknown> {
+  return {
+    tabId: shell.tabId,
+    ...(shell.command ? { command: shell.command } : {}),
+    ...(shell.args.length > 0 ? { args: shell.args } : {}),
+    ...(shell.cwd ? { cwd: shell.cwd } : {}),
+    ...(shell.shareMode !== "private" ? { shareMode: shell.shareMode } : {}),
+    ...(shell.inheritEnv === false ? { inheritEnv: false } : {}),
+  };
+}
+
+function shellTabExists(ctx: BridgeMessageContext, tabId: string): boolean {
+  const tabs = (ctx.stateRef.current.tabs as Tab[] | undefined) ?? [];
+  return tabs.some((tab) => tab.id === tabId);
+}
+
+export function reserveShellTab(
+  args: Record<string, unknown>,
+  ctx: BridgeMessageContext,
+): CreatedShell {
+  const tabId = optionalString(args.tabId) ?? crypto.randomUUID();
+  if (shellTabExists(ctx, tabId)) {
+    throw new Error(`shell tab already exists: ${tabId}`);
+  }
+  const cwd =
+    optionalString(args.cwd) ??
+    cwdForNewTab(ctx.projectsRef.current, ctx.stateRef.current) ??
+    "";
+  const command = optionalString(args.command) ?? "";
+  const commandArgs = optionalStringArray(args.args) ?? [];
+  const shareMode: ShareMode = "private";
+  const activate = args.activate === true;
+  const inheritEnv = args.inheritEnv !== false;
+  const initialTerminalBuffer = cwd
+    ? initialDevshellTerminalBuffer(ctx.stateRef.current, cwd)
+    : "";
+
+  ctx.setState((prev) => {
+    const tabs = ((prev.tabs as Tab[] | undefined) ?? []).slice();
+    const label = `Shell ${tabs.filter((t) => t.kind === "shell").length + 1}`;
+    const projectId = ctx.projectsRef.current.activeId;
+    const shell: ShellMeta = {
+      cwd,
+      command,
+      args: commandArgs,
+      shareMode,
+      shellState: "starting",
+    };
+    tabs.push({
+      ...makeEmptyTab(tabId, label, projectId, "shell"),
+      terminalBuffer: initialTerminalBuffer,
+      shell,
+    });
+    if (!activate) return { ...prev, tabs };
+    const panel =
+      (prev.terminalPanel as { activeSubId?: string } | undefined) ?? {};
+    const term = (prev.terminal as { open?: boolean } | undefined) ?? {};
+    return {
+      ...prev,
+      tabs,
+      terminalPanel: { ...panel, activeSubId: tabId },
+      terminal: { ...term, open: true },
+    };
+  });
+
+  return { tabId, cwd, command, args: commandArgs, shareMode, inheritEnv };
+}
+
+export function removeReservedShellTab(
+  tabId: string,
+  ctx: BridgeMessageContext,
+): void {
+  ctx.setState((prev) => {
+    const panel =
+      (prev.terminalPanel as { activeSubId?: string } | undefined) ?? {};
+    return {
+      ...prev,
+      tabs: ((prev.tabs as Tab[] | undefined) ?? []).filter(
+        (tab) => tab.id !== tabId,
+      ),
+      ...(panel.activeSubId === tabId
+        ? { terminalPanel: { ...panel, activeSubId: "agent-bash" } }
+        : {}),
+    };
+  });
+}
+
+export async function startReservedShell(
+  shell: CreatedShell,
+  ctx: BridgeMessageContext,
+): Promise<CreatedShell> {
+  await invoke("shell_open", { args: shellOpenPayload(shell) });
+  ctx.setState((prev) => ({
+    ...prev,
+    tabs: ((prev.tabs as Tab[] | undefined) ?? []).map((tab) =>
+      tab.id === shell.tabId && tab.kind === "shell" && tab.shell
+        ? {
+            ...tab,
+            shell: { ...tab.shell, shellState: "running" },
+          }
+        : tab,
+    ),
+  }));
+  return shell;
+}
+
+export async function createShell(
+  args: Record<string, unknown>,
+  ctx: BridgeMessageContext,
+): Promise<CreatedShell> {
+  const shell = reserveShellTab(args, ctx);
+  try {
+    return await startReservedShell(shell, ctx);
+  } catch (err) {
+    removeReservedShellTab(shell.tabId, ctx);
+    throw err;
+  }
+}
+
 export const handleShellQuery: BridgeMessageHandler = (data, ctx) => {
   const op = data.op as string | undefined;
   const args = (data.args as Record<string, unknown> | undefined) ?? {};
@@ -17,6 +159,9 @@ export const handleShellQuery: BridgeMessageHandler = (data, ctx) => {
   const route = async (): Promise<unknown> => {
     if (op === "list") {
       return await invoke("shell_list_shareable");
+    }
+    if (op === "create") {
+      return await createShell(args, ctx);
     }
     if (op === "read") {
       return await invoke("shell_read_scrollback", { args });

--- a/src/hooks/bridgeMessageHandlers/types.ts
+++ b/src/hooks/bridgeMessageHandlers/types.ts
@@ -137,7 +137,10 @@ export interface BridgeMessageContext {
 
   // ─── Chat / status helpers (defined on App) ─────────────────────────
   appendMessage: (msg: ChatMessage, tabId?: string) => void;
-  persistLocalChatMessage: (msg: ChatMessage, tabId: string) => void;
+  persistLocalChatMessage: (
+    msg: ChatMessage,
+    tabId: string,
+  ) => Promise<boolean>;
   recordProjectModel: (model: string, tabId?: string) => void;
   appendOrAmendAgentText: (
     delta: string,

--- a/src/hooks/extensionsHydration/frontendModules.test.ts
+++ b/src/hooks/extensionsHydration/frontendModules.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Dispatch, SetStateAction } from "react";
+import { ExtensionRegistry } from "../../extensions/ExtensionRegistry";
+import { useHydrateFrontendModules } from "./frontendModules";
+
+function makeSetState(state: Record<string, unknown>) {
+  return vi.fn((update: SetStateAction<Record<string, unknown>>) => {
+    Object.assign(
+      state,
+      typeof update === "function" ? update({ ...state }) : update,
+    );
+  }) as Dispatch<SetStateAction<Record<string, unknown>>>;
+}
+
+describe("useHydrateFrontendModules", () => {
+  it("records loaded component types and frontend eval failures in state", () => {
+    const state: Record<string, unknown> = {};
+    const appendSystem = vi.fn();
+    const registry = new ExtensionRegistry();
+    const hydrate = useHydrateFrontendModules({
+      setState: makeSetState(state),
+      frontendModulesRef: { current: new Map() },
+      registry,
+      appendSystem,
+    });
+
+    hydrate([
+      {
+        name: "ok-ext",
+        code: "extension.registerComponent('ok-widget', function OkWidget(){ return React.createElement('div'); });",
+      },
+      {
+        name: "bad-ext",
+        code: "throw new Error('frontend boom')",
+      },
+    ]);
+
+    expect(state.extensionFrontendModules).toEqual([
+      {
+        name: "ok-ext",
+        status: "loaded",
+        componentTypes: ["ok-widget"],
+      },
+      {
+        name: "bad-ext",
+        status: "failed",
+        componentTypes: [],
+        error: "frontend boom",
+      },
+    ]);
+    expect(registry.resolve("ok-widget")).toBeTypeOf("function");
+    expect(appendSystem).toHaveBeenCalledWith(
+      "extension frontend module bad-ext: frontend boom",
+    );
+  });
+
+  it("removes status for unregistered modules", () => {
+    const state: Record<string, unknown> = {};
+    const registry = new ExtensionRegistry();
+    const frontendModulesRef = { current: new Map<string, string>() };
+    const hydrate = useHydrateFrontendModules({
+      setState: makeSetState(state),
+      frontendModulesRef,
+      registry,
+      appendSystem: vi.fn(),
+    });
+
+    hydrate([
+      {
+        name: "ok-ext",
+        code: "extension.registerComponent('ok-widget', function OkWidget(){ return React.createElement('div'); });",
+      },
+    ]);
+    hydrate([]);
+
+    expect(state.extensionFrontendModules).toEqual([]);
+    expect(registry.resolve("ok-widget")).toBeUndefined();
+  });
+});

--- a/src/hooks/extensionsHydration/frontendModules.ts
+++ b/src/hooks/extensionsHydration/frontendModules.ts
@@ -2,11 +2,44 @@ import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 import { reconcileFrontendModules } from "../../extensions/extensionFrontendLoader";
 import type { ExtensionRegistry } from "../../extensions/ExtensionRegistry";
 
+export interface FrontendModuleStatus {
+  name: string;
+  status: "loaded" | "failed";
+  componentTypes: string[];
+  error?: string;
+}
+
 export interface FrontendModulesDeps {
   setState: Dispatch<SetStateAction<Record<string, unknown>>>;
   frontendModulesRef: MutableRefObject<Map<string, string>>;
   registry: ExtensionRegistry;
   appendSystem: (text: string) => void;
+}
+
+function previousStatuses(
+  prev: Record<string, unknown>,
+): FrontendModuleStatus[] {
+  const raw = prev.extensionFrontendModules;
+  if (!Array.isArray(raw)) return [];
+  return raw.flatMap((item) => {
+    if (!item || typeof item !== "object") return [];
+    const record = item as Record<string, unknown>;
+    if (typeof record.name !== "string") return [];
+    if (record.status !== "loaded" && record.status !== "failed") return [];
+    const componentTypes = Array.isArray(record.componentTypes)
+      ? record.componentTypes.filter(
+          (type): type is string => typeof type === "string",
+        )
+      : [];
+    return [
+      {
+        name: record.name,
+        status: record.status,
+        componentTypes,
+        ...(typeof record.error === "string" ? { error: record.error } : {}),
+      },
+    ];
+  });
 }
 
 export function useHydrateFrontendModules(deps: FrontendModulesDeps) {
@@ -26,16 +59,39 @@ export function useHydrateFrontendModules(deps: FrontendModulesDeps) {
         appendSystem(`extension frontend module ${m.name}: ${m.error}`);
       }
     }
-    if (loaded.length > 0 || unregistered.length > 0) {
-      // Bump a counter so any A2UIRenderer subtree using a now-changed
-      // component type re-resolves through the ExtensionRegistry on the
-      // next render. The registry itself doesn't trigger React updates;
-      // bumping a piece of state owned by App.tsx does.
-      setState((prev) => ({
+    setState((prev) => {
+      const unregisteredSet = new Set(unregistered);
+      const statuses = new Map(
+        previousStatuses(prev)
+          .filter((status) => !unregisteredSet.has(status.name))
+          .map((status) => [status.name, status]),
+      );
+      for (const m of loaded) {
+        statuses.set(m.name, {
+          name: m.name,
+          status: m.error ? "failed" : "loaded",
+          componentTypes: m.componentTypes,
+          ...(m.error ? { error: m.error } : {}),
+        });
+      }
+      const nextStatuses = list.flatMap((m) => {
+        const status = statuses.get(m.name);
+        return status ? [status] : [];
+      });
+      return {
         ...prev,
-        extensionModulesGen:
-          ((prev.extensionModulesGen as number | undefined) ?? 0) + 1,
-      }));
-    }
+        extensionFrontendModules: nextStatuses,
+        ...(loaded.length > 0 || unregistered.length > 0
+          ? {
+              // Bump a counter so any A2UIRenderer subtree using a now-changed
+              // component type re-resolves through the ExtensionRegistry on the
+              // next render. The registry itself doesn't trigger React updates;
+              // bumping a piece of state owned by App.tsx does.
+              extensionModulesGen:
+                ((prev.extensionModulesGen as number | undefined) ?? 0) + 1,
+            }
+          : {}),
+      };
+    });
   };
 }

--- a/src/hooks/osEdges/agentStderr.ts
+++ b/src/hooks/osEdges/agentStderr.ts
@@ -3,7 +3,10 @@ import type { ChatMessage } from "../../types/a2ui";
 
 export interface AgentStderrDeps {
   appendMessage: (msg: ChatMessage, tabId?: string) => void;
-  persistLocalChatMessage: (msg: ChatMessage, tabId: string) => void;
+  persistLocalChatMessage: (
+    msg: ChatMessage,
+    tabId: string,
+  ) => Promise<boolean>;
 }
 
 export function tabIdFromAgentStderr(text: string): string | undefined {

--- a/src/hooks/osEdges/types.ts
+++ b/src/hooks/osEdges/types.ts
@@ -33,7 +33,10 @@ export interface UseOsEdgesContext {
 
   // Chat helpers (from useChat).
   appendMessage: (msg: ChatMessage, tabId?: string) => void;
-  persistLocalChatMessage: (msg: ChatMessage, tabId: string) => void;
+  persistLocalChatMessage: (
+    msg: ChatMessage,
+    tabId: string,
+  ) => Promise<boolean>;
   appendSystem: (text: string) => void;
   setStatusFlags: (
     flags: Partial<{ waiting: boolean; status: string; connection: string }>,

--- a/src/hooks/useAppSlashCommandContext.ts
+++ b/src/hooks/useAppSlashCommandContext.ts
@@ -60,7 +60,10 @@ export interface UseAppSlashCommandContextOptions {
 
 export interface AppSlashCommandContextResult {
   slashContext: () => SlashCommandContext;
-  persistLocalChatMessage: (msg: ChatMessage, tabId: string) => void;
+  persistLocalChatMessage: (
+    msg: ChatMessage,
+    tabId: string,
+  ) => Promise<boolean>;
 }
 
 export function useAppSlashCommandContext({
@@ -100,9 +103,9 @@ export function useAppSlashCommandContext({
         !a2ui &&
         attachments.length === 0
       ) {
-        return;
+        return Promise.resolve(true);
       }
-      invoke("agent_command", {
+      return invoke("agent_command", {
         payload: JSON.stringify({
           type: "local_chat_message",
           tabId,
@@ -125,9 +128,12 @@ export function useAppSlashCommandContext({
                 : Date.now(),
           },
         }),
-      }).catch(() => {
-        /* bridge gone — visible state remains in-memory until reload */
-      });
+      })
+        .then(() => true)
+        .catch(() => {
+          /* bridge gone — visible state remains in-memory until reload */
+          return false;
+        });
     },
     [],
   );

--- a/src/hooks/useChat.test.ts
+++ b/src/hooks/useChat.test.ts
@@ -91,7 +91,7 @@ function buildContext(overrides: Record<string, unknown> = {}): {
           setTheme: vi.fn(),
           setModel: vi.fn(),
         }) as unknown as ReturnType<UseChatContext["slashContext"]>,
-      persistLocalChatMessage: vi.fn(),
+      persistLocalChatMessage: vi.fn().mockResolvedValue(true),
       recordProjectModel,
       piDefaultModelRef,
     },
@@ -139,12 +139,30 @@ describe("useChat setModel", () => {
         mode: "normal",
         model: "anthropic/claude-opus-4-7",
         planMode: false,
+        suppressUserSessionEvent: true,
       },
     });
     expect((stateRef.current.tabs as Tab[])[0].messages.at(-1)).toMatchObject({
       role: "user",
       text: "hello",
       delivery: "sent",
+    });
+  });
+
+  it("lets the bridge emit the user session event when local mirroring fails", async () => {
+    const { ctx } = buildContext();
+    ctx.persistLocalChatMessage = vi.fn().mockResolvedValue(false);
+    const { result } = renderHook(() => useChat(ctx));
+
+    await act(async () => {
+      await result.current.sendChat("hello");
+    });
+
+    expect(invoke).toHaveBeenCalledWith("send_message", {
+      request: expect.objectContaining({
+        message: "hello",
+        suppressUserSessionEvent: false,
+      }),
     });
   });
 
@@ -264,6 +282,7 @@ describe("useChat setModel", () => {
         model: "openai-codex/gpt-5.5",
         thinkingLevel: "high",
         planMode: false,
+        suppressUserSessionEvent: true,
       },
     });
   });
@@ -294,6 +313,7 @@ describe("useChat setModel", () => {
         attachments: [attachment],
         model: "anthropic/claude-opus-4-7",
         planMode: false,
+        suppressUserSessionEvent: true,
       },
     });
     const tab = (stateRef.current.tabs as Tab[])[0];
@@ -331,6 +351,7 @@ describe("useChat setModel", () => {
         cwd: "/projects/aethon-fix-86",
         model: "anthropic/claude-opus-4-7",
         planMode: false,
+        suppressUserSessionEvent: true,
       },
     });
     const tabs = stateRef.current.tabs as Tab[];
@@ -379,6 +400,7 @@ describe("useChat setModel", () => {
         mode: "normal",
         model: "anthropic/claude-opus-4-7",
         planMode: false,
+        suppressUserSessionEvent: true,
       },
     });
     const tabs = stateRef.current.tabs as Tab[];
@@ -419,6 +441,7 @@ describe("useChat setModel", () => {
         mode: "steer",
         model: "anthropic/claude-opus-4-7",
         planMode: false,
+        suppressUserSessionEvent: true,
       },
     });
   });
@@ -737,6 +760,7 @@ describe("useChat setModel", () => {
         mode: "normal",
         model: "anthropic/claude-opus-4-7",
         planMode: false,
+        suppressUserSessionEvent: true,
       },
     });
     const tab = (stateRef.current.tabs as Tab[])[0];
@@ -786,6 +810,7 @@ describe("useChat setModel", () => {
         mode: "steer",
         model: "anthropic/claude-opus-4-7",
         planMode: false,
+        suppressUserSessionEvent: true,
       },
     });
     expect((stateRef.current.tabs as Tab[])[0].messages.at(-1)).toMatchObject({

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -78,7 +78,10 @@ export interface UseChatContext {
    *  invocation so handlers see fresh state without re-creating the
    *  command registry. */
   slashContext: () => SlashCommandContext;
-  persistLocalChatMessage: (msg: ChatMessage, tabId: string) => void;
+  persistLocalChatMessage: (
+    msg: ChatMessage,
+    tabId: string,
+  ) => Promise<boolean>;
   recordProjectModel: (model: string, tabId?: string) => void;
   findTabById?: (tabId: string) => Tab | undefined;
   /** pi's boot/default model, used as the new-tab fallback. Cleared when
@@ -620,7 +623,10 @@ export function useChat(ctx: UseChatContext): UseChatActions {
         /* ignore */
       }
     }
-    persistLocalChatMessage(userMessage, tabId);
+    const userSessionEventMirrored = await persistLocalChatMessage(
+      userMessage,
+      tabId,
+    );
     const targetCwd =
       typeof targetTab?.cwd === "string" && targetTab.cwd.length > 0
         ? targetTab.cwd
@@ -639,7 +645,7 @@ export function useChat(ctx: UseChatContext): UseChatActions {
         : typeof stateRef.current.thinkingLevel === "string" &&
             stateRef.current.thinkingLevel.length > 0
           ? stateRef.current.thinkingLevel
-        : undefined;
+          : undefined;
     const targetPlanMode =
       targetTab?.kind === "agent" ? targetTab.planMode === true : false;
     try {
@@ -655,6 +661,7 @@ export function useChat(ctx: UseChatContext): UseChatActions {
           ...(targetThinkingLevel
             ? { thinkingLevel: targetThinkingLevel }
             : {}),
+          suppressUserSessionEvent: userSessionEventMirrored,
           ...(typeof targetTab?.hardEnforceProjectRoot === "boolean"
             ? { hardEnforce: targetTab.hardEnforceProjectRoot }
             : {}),

--- a/src/hooks/useFrontendStateMirror.ts
+++ b/src/hooks/useFrontendStateMirror.ts
@@ -69,6 +69,7 @@ export function useFrontendStateMirror(
         "/draft": state.draft ?? "",
         "/messagesCount": messagesCount,
         "/nativeWindows": state.nativeWindows ?? [],
+        "/extensionFrontendModules": state.extensionFrontendModules ?? [],
         "/scheduledTasks": scheduledTasks.map((task) => ({
           id: task.id,
           label: task.label,

--- a/src/hooks/useScheduledTasks.ts
+++ b/src/hooks/useScheduledTasks.ts
@@ -22,7 +22,10 @@ export interface UseScheduledTasksOptions {
       | ((prev: Record<string, unknown>) => Record<string, unknown>),
   ) => void;
   appendMessage: (msg: ChatMessage, tabId?: string) => void;
-  persistLocalChatMessage: (msg: ChatMessage, tabId: string) => void;
+  persistLocalChatMessage: (
+    msg: ChatMessage,
+    tabId: string,
+  ) => Promise<boolean>;
   pushNotification: (input: {
     title: string;
     message?: string;

--- a/src/nativeWindows.ts
+++ b/src/nativeWindows.ts
@@ -107,3 +107,33 @@ export function syncNativeWindowsToState(
 export function canvasWindowSurfaceId(id: string): string {
   return `${CANVAS_WINDOW_SURFACE_PREFIX}${id}`;
 }
+
+export function terminalShellTabIds(
+  record: NativeCanvasWindowRecord | undefined,
+): string[] {
+  if (!record) return [];
+  const componentIds = new Set<string>();
+  for (const component of record.components) {
+    if (
+      component &&
+      typeof component === "object" &&
+      (component as { type?: unknown }).type === "shell-canvas"
+    ) {
+      const props = (component as { props?: Record<string, unknown> }).props;
+      if (typeof props?.tabId === "string") componentIds.add(props.tabId);
+    }
+  }
+  if (componentIds.size === 0) return [];
+  const tabs = (record.state as { tabs?: unknown }).tabs;
+  if (!Array.isArray(tabs)) return [];
+  return tabs
+    .filter(
+      (tab): tab is { id: string; kind?: string } =>
+        Boolean(tab) &&
+        typeof tab === "object" &&
+        typeof (tab as { id?: unknown }).id === "string" &&
+        componentIds.has((tab as { id: string }).id) &&
+        (tab as { kind?: unknown }).kind === "shell",
+    )
+    .map((tab) => tab.id);
+}

--- a/src/nativeWindows.ts
+++ b/src/nativeWindows.ts
@@ -112,28 +112,10 @@ export function terminalShellTabIds(
   record: NativeCanvasWindowRecord | undefined,
 ): string[] {
   if (!record) return [];
-  const componentIds = new Set<string>();
-  for (const component of record.components) {
-    if (
-      component &&
-      typeof component === "object" &&
-      (component as { type?: unknown }).type === "shell-canvas"
-    ) {
-      const props = (component as { props?: Record<string, unknown> }).props;
-      if (typeof props?.tabId === "string") componentIds.add(props.tabId);
-    }
-  }
-  if (componentIds.size === 0) return [];
-  const tabs = (record.state as { tabs?: unknown }).tabs;
-  if (!Array.isArray(tabs)) return [];
-  return tabs
-    .filter(
-      (tab): tab is { id: string; kind?: string } =>
-        Boolean(tab) &&
-        typeof tab === "object" &&
-        typeof (tab as { id?: unknown }).id === "string" &&
-        componentIds.has((tab as { id: string }).id) &&
-        (tab as { kind?: unknown }).kind === "shell",
-    )
-    .map((tab) => tab.id);
+  const owned = (record.state as { ownedShellTabIds?: unknown })
+    .ownedShellTabIds;
+  if (!Array.isArray(owned)) return [];
+  return [
+    ...new Set(owned.filter((id): id is string => typeof id === "string")),
+  ];
 }

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -15,6 +15,7 @@ vi.mock("@tauri-apps/api/core", () => ({
 
 vi.mock("@tauri-apps/api/event", () => ({
   listen: vi.fn(() => Promise.resolve(() => {})),
+  emit: vi.fn(() => Promise.resolve()),
 }));
 
 // Monaco editor binds to browser globals (document.queryCommandSupported,

--- a/src/test/tauriMocks.ts
+++ b/src/test/tauriMocks.ts
@@ -16,7 +16,7 @@
  *  shape Tauri's `listen` callback expects. */
 import { vi, type Mock } from "vitest";
 import { invoke as realInvoke } from "@tauri-apps/api/core";
-import { listen as realListen } from "@tauri-apps/api/event";
+import { emit as realEmit, listen as realListen } from "@tauri-apps/api/event";
 
 type ListenCallback<T = unknown> = (event: { payload: T }) => void;
 
@@ -26,6 +26,8 @@ export interface TauriMockHarness {
   /** The mocked `listen`. Use `harness.listen.mock.calls` to assert
    *  registrations; prefer `fireEvent` for delivering payloads. */
   listen: Mock;
+  /** The mocked `emit`. */
+  emit: Mock;
   /** Fire a synthetic event to every handler registered via `listen` for
    *  the given event name. Returns the number of handlers invoked. */
   fireEvent: <T = unknown>(name: string, payload: T) => number;
@@ -40,12 +42,15 @@ export interface TauriMockHarness {
 export function installTauriMocks(): TauriMockHarness {
   const invoke = realInvoke as unknown as Mock;
   const listen = realListen as unknown as Mock;
+  const emit = realEmit as unknown as Mock;
   const handlers = new Map<string, Set<ListenCallback>>();
 
   const reset = () => {
     invoke.mockReset();
     invoke.mockImplementation(() => Promise.resolve(undefined));
     listen.mockReset();
+    emit.mockReset();
+    emit.mockImplementation(() => Promise.resolve());
     listen.mockImplementation((name: string, cb: ListenCallback) => {
       let bucket = handlers.get(name);
       if (!bucket) {
@@ -62,14 +67,14 @@ export function installTauriMocks(): TauriMockHarness {
 
   reset();
 
-  const fireEvent = <T,>(name: string, payload: T): number => {
+  const fireEvent = <T>(name: string, payload: T): number => {
     const bucket = handlers.get(name);
     if (!bucket || bucket.size === 0) return 0;
     for (const cb of bucket) cb({ payload });
     return bucket.size;
   };
 
-  return { invoke, listen, fireEvent, handlers, reset };
+  return { invoke, listen, emit, fireEvent, handlers, reset };
 }
 
 /** Restore the default no-op behavior. Call from `afterEach` if the harness
@@ -79,6 +84,11 @@ export function clearTauriMocks(): void {
   vi.restoreAllMocks();
   // Re-install the default no-ops so other mocks layered on top of the
   // setup mock module don't crash when subsequent tests import `invoke`.
-  (realInvoke as unknown as Mock).mockImplementation(() => Promise.resolve(undefined));
-  (realListen as unknown as Mock).mockImplementation(() => Promise.resolve(() => {}));
+  (realInvoke as unknown as Mock).mockImplementation(() =>
+    Promise.resolve(undefined),
+  );
+  (realListen as unknown as Mock).mockImplementation(() =>
+    Promise.resolve(() => {}),
+  );
+  (realEmit as unknown as Mock).mockImplementation(() => Promise.resolve());
 }


### PR DESCRIPTION
## Summary

Closes #334.

This fills the remaining extension API gaps needed by richer Aethon extensions:

- expose supported session/message APIs instead of requiring extensions to scrape private session files
- improve package extension discovery and frontend-module diagnostics
- add native-window read APIs and Rust-backed cache fallback
- add extension-created private shell tabs and non-restoring native terminal windows
- wire terminal-window output, resize, share-mode, and cleanup behavior through the supported app surfaces

## What changed

### Sessions/messages API

- Added `aethon.sessions` with:
  - `list()`
  - `getActive()`
  - `getMessages(sessionId, { limit? })`
  - `getTranscript(sessionId, { limit? })`
  - `on("activeChanged" | "messageAppended" | "messageUpdated" | "sessionChanged", handler)`
- Wired session events through frontend tab/message state and bridge-side chat paths.
- Avoided duplicate user-message events by suppressing bridge fallback only when frontend local persistence succeeds.
- Preserved durable message metadata while merging live/streaming updates.
- Sanitized visible user messages by stripping expanded file refs and plan-mode prefixes.

### Package/frontend extension debugging

- Added direct package-folder discovery for extension packages under `~/.aethon/extensions/<pkg>/`, including scoped package variants.
- Report malformed package manifests through `extension_lifecycle` failures instead of silently skipping them.
- Switched package manifest reads to `fs/promises.readFile`.
- Added frontend module status state at `/extensionFrontendModules` and mirrored it into runtime snapshots so extension authors can inspect eval/registration failures structurally.

### Native windows API

- Added native window read APIs:
  - `aethon.windows.get(id)`
  - `aethon.windows.getState(id)`
  - `aethon.windows.getCanvas(id)`
- Native-window reads/mutations now fall back to the Rust authoritative native-window store when the frontend cache misses.

### Shells and terminal windows

- Added `aethon.shells.create({ tabId?, cwd?, command?, args?, activate?, inheritEnv? })`.
- Added `aethon.windows.openTerminal({ id?, title?, shellTabId?, cwd?, command?, args?, activateShell?, width?, height?, x?, y?, focus? })`.
- Agent-created shells are always private; public APIs cannot seed or escalate share mode. The user must opt in through the visible share-mode badge.
- Terminal windows force `restoreOnLaunch: false` so app relaunch does not reopen terminal UI without a backing PTY.
- Native terminal windows now:
  - open a `shell-canvas` in a native canvas window
  - wait for native canvas readiness before starting the PTY
  - forward and buffer shell output into the window-local state
  - sync share-mode changes back to the main app tab state
  - close/remove owned shell tabs and PTYs on native-window close, including programmatic closes
  - clean up partial failures and restore existing native-window records when reuse fails
- Shell resize replay now only fires on the transition into `running`, preserving the existing debounce/last-sent guards for normal shell resize traffic.

### Docs/types/tests

- Updated bundled API docs, system prompt surface, and extension typings for sessions/windows/shells/terminal support.
- Added focused regression tests for session APIs, shell creation, native terminal windows, terminal cleanup, share-mode mirroring, frontend-module status, and resize behavior.
- Made the control CLI test isolate `AETHON_USER_DIR` so it is stable when run from inside an Aethon-launched agent environment.

## Validation

- `env -u AETHON_WORKER_TAB_ID bunx vitest run`
  - 309 test files passed
  - 2573 tests passed
- `bunx eslint .`
- `bunx tsc -b --noEmit`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `git diff --check`
- Codex review was run before the final fixes; no further Codex review was run per maintainer request.

Known test-environment noise during Vitest remains unchanged, including jsdom canvas/WebGL warnings and expected unknown-component warnings in targeted tests.
