### PR TITLE
fix(agent): recover from Codex context overflow

### DIFF
--- a/agent/a2uiEvents.ts
+++ b/agent/a2uiEvents.ts
@@ -6,6 +6,7 @@ import {
   type InboundMessage,
 } from "./dispatcherTypes";
 import { setState, makeCanvasApi } from "./state-mutation";
+import { isUnderlyingSessionBusy } from "./session-busy";
 import { ensureTab, modelKey } from "./tab-lifecycle";
 
 export async function handleA2UIEvent(
@@ -124,11 +125,12 @@ function buildPiHandlerCtx(
         });
         throw err;
       } finally {
-        if (!handlerTab.agentEndFired) {
+        const stillStreamingOrRetrying = isUnderlyingSessionBusy(handlerTab);
+        if (!handlerTab.agentEndFired && !stillStreamingOrRetrying) {
           handlerTab.promptInFlight = false;
           deps.send({ type: "response_end", tabId: handlerTabId });
         }
-        if (state.currentAgentTabId === handlerTabId) {
+        if (state.currentAgentTabId === handlerTabId && !stillStreamingOrRetrying) {
           state.currentAgentTabId = undefined;
         }
         maybeExitForReload(state, deps);

--- a/agent/agent-errors.test.ts
+++ b/agent/agent-errors.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   extractAgentEndError,
   formatAgentErrorMessage,
+  isContextLengthExceededError,
   isRetryableAgentEndError,
   isUsageLimitError,
 } from "./agent-errors";
@@ -10,6 +11,9 @@ import {
 // the agent surfaces when an account hits its quota.
 const CODEX_USAGE_LIMIT_RAW =
   'Codex error: {"type":"error","error":{"type":"usage_limit_reached","message":"The usage limit has been reached","plan_type":"pro","resets_at":1781838269,"resets_in_seconds":1621},"status_code":429,"headers":{"X-Codex-Primary-Used-Percent":"100"}}';
+
+const CODEX_CONTEXT_LENGTH_RAW =
+  'Codex error: {"type":"error","error":{"type":"invalid_request_error","code":"context_length_exceeded","message":"Your input exceeds the context window of this model. Please adjust your input and try again.","param":"input"},"sequence_number":2}';
 
 describe("extractAgentEndError", () => {
   it("returns undefined for an empty or missing list", () => {
@@ -86,6 +90,24 @@ describe("isRetryableAgentEndError", () => {
   });
 });
 
+describe("isContextLengthExceededError", () => {
+  it("detects Codex context_length_exceeded payloads", () => {
+    expect(isContextLengthExceededError(CODEX_CONTEXT_LENGTH_RAW)).toBe(true);
+  });
+
+  it("detects the human-readable Codex context-window phrasing", () => {
+    expect(
+      isContextLengthExceededError(
+        "Your input exceeds the context window of this model.",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not confuse usage-limit errors with context overflow", () => {
+    expect(isContextLengthExceededError(CODEX_USAGE_LIMIT_RAW)).toBe(false);
+  });
+});
+
 describe("isUsageLimitError", () => {
   it("detects the Codex usage_limit_reached payload", () => {
     expect(isUsageLimitError(CODEX_USAGE_LIMIT_RAW)).toBe(true);
@@ -112,7 +134,16 @@ describe("formatAgentErrorMessage", () => {
     expect(out).not.toContain("status_code");
   });
 
-  it("passes non-usage-limit errors through unchanged", () => {
+  it("rewrites a raw Codex context-length payload into a clean recovery message", () => {
+    const out = formatAgentErrorMessage(CODEX_CONTEXT_LENGTH_RAW);
+    expect(out).toBe(
+      "Context window exceeded. Compacting context and resuming automatically.",
+    );
+    expect(out).not.toContain("context_length_exceeded");
+    expect(out).not.toContain("sequence_number");
+  });
+
+  it("passes unrelated non-usage-limit errors through unchanged", () => {
     const raw = "Your credit balance is too low to access the Anthropic API.";
     expect(formatAgentErrorMessage(raw)).toBe(raw);
   });

--- a/agent/agent-errors.ts
+++ b/agent/agent-errors.ts
@@ -61,9 +61,9 @@ export function isRetryableAgentEndError(message: string): boolean {
 
 /**
  * Turn a raw agent error string into a clean, user-facing message. Today
- * this special-cases the Codex usage-limit 429 (whose payload is a wall of
- * JSON + X-Codex-* headers) into a short sentence with the reset countdown
- * and a hint to switch accounts. Everything else passes through unchanged.
+ * this special-cases Codex usage-limit 429s and context-window overflow
+ * failures whose raw provider payloads are otherwise noisy and hard to act on.
+ * Everything else passes through unchanged.
  *
  * Reusable: any surface that renders an agent error can call this.
  */

--- a/agent/agent-errors.ts
+++ b/agent/agent-errors.ts
@@ -45,6 +45,13 @@ export function isUsageLimitError(message: string): boolean {
   return /usage_limit_reached|usage limit has been reached/i.test(message);
 }
 
+export function isContextLengthExceededError(message: string): boolean {
+  if (isUsageLimitError(message)) return false;
+  return /context[_ ]length[_ ]exceeded|exceeds the context window|context window[^.]*exceeded/i.test(
+    message,
+  );
+}
+
 export function isRetryableAgentEndError(message: string): boolean {
   // Usage-limit 429s carry "429" so they'd otherwise look retryable; bail
   // first so we don't waste the retry budget on an unrecoverable quota hit.
@@ -61,6 +68,9 @@ export function isRetryableAgentEndError(message: string): boolean {
  * Reusable: any surface that renders an agent error can call this.
  */
 export function formatAgentErrorMessage(raw: string): string {
+  if (isContextLengthExceededError(raw)) {
+    return "Context window exceeded. Compacting context and resuming automatically.";
+  }
   if (!isUsageLimitError(raw)) return raw;
   const resetsInSeconds = readNumericField(raw, "resets_in_seconds");
   const planType = readStringField(raw, "plan_type");

--- a/agent/chat-stop.test.ts
+++ b/agent/chat-stop.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  AethonAgentState,
+  type AethonAgentStateOptions,
+  type TabRecord,
+} from "./state";
+import { handleStop } from "./chat";
+
+const baseOpts: AethonAgentStateOptions = {
+  userDir: "/tmp/aethon-test",
+  stateFile: "/tmp/aethon-test/state.json",
+  sessionsDir: "/tmp/aethon-test/sessions",
+  docsDir: undefined,
+  projectRoot: undefined,
+  releaseMode: false,
+  bootLayoutFile: undefined,
+  layoutSlotsFile: undefined,
+  statePayloadWarnBytes: 64 * 1024,
+  statePayloadHardBytes: 512 * 1024,
+  statePayloadWarnKb: 64,
+  statePayloadHardKb: 512,
+};
+
+function fakeRec(overrides: Partial<TabRecord> = {}): TabRecord {
+  return {
+    id: "tab-1",
+    session: {
+      messages: [],
+      abort: vi.fn(() => Promise.resolve()),
+    } as unknown as TabRecord["session"],
+    toolArgsCache: new Map(),
+    promptInFlight: true,
+    agentEndFired: false,
+    queuedCount: 0,
+    toolCardSeq: 0,
+    responseMessageSeq: 0,
+    ...overrides,
+  };
+}
+
+describe("handleStop", () => {
+  it("cancels pending context-overflow recovery so stop cannot resume itself", async () => {
+    vi.useFakeTimers();
+    try {
+      const state = new AethonAgentState(baseOpts);
+      const sent: Record<string, unknown>[] = [];
+      const timerCallback = vi.fn();
+      const abortCompaction = vi.fn();
+      const rec = fakeRec({
+        contextOverflowRecoveryAttempted: true,
+        contextOverflowRecoveryInFlight: true,
+        contextOverflowRecoveryCompactionStarted: false,
+        contextOverflowRecoveryErrorMessage: "context overflow",
+        contextOverflowRecoveryTimer: setTimeout(timerCallback, 250),
+        session: {
+          messages: [],
+          abort: vi.fn(() => Promise.resolve()),
+          abortCompaction,
+        } as unknown as TabRecord["session"],
+      });
+      state.tabs.set("tab-1", rec);
+      state.currentAgentTabId = "tab-1";
+
+      handleStop(
+        state,
+        { send: (m) => sent.push(m), scheduleStateFileWrite: vi.fn() },
+        { type: "stop", tabId: "tab-1" },
+      );
+      await vi.advanceTimersByTimeAsync(250);
+
+      expect(timerCallback).not.toHaveBeenCalled();
+      expect(abortCompaction).toHaveBeenCalledOnce();
+      expect(rec.contextOverflowRecoveryInFlight).toBe(false);
+      expect(rec.contextOverflowRecoveryTimer).toBeUndefined();
+      expect(rec.promptInFlight).toBe(false);
+      expect(rec.agentEndFired).toBe(true);
+      expect(state.currentAgentTabId).toBeUndefined();
+      expect(sent).toContainEqual({ type: "queue_reset", tabId: "tab-1" });
+      expect(sent).toContainEqual({ type: "response_end", tabId: "tab-1" });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/agent/chat.ts
+++ b/agent/chat.ts
@@ -20,12 +20,14 @@ import {
 } from "./subagents/steer";
 import { getSubagentsForCwd } from "./subagents";
 import { emitContextUsage } from "./context-usage";
+import { resetContextOverflowRecovery } from "./context-overflow-recovery";
 import { supportsCodexFastMode } from "./codex-fast-mode";
 import {
   FileReferenceError,
   expandFileReferencesInPrompt,
 } from "./file-references";
 import { logger } from "./logger";
+import { isUnderlyingSessionBusy } from "./session-busy";
 
 const chatLog = logger.scope("chat");
 
@@ -315,18 +317,6 @@ function completeScheduledRun(
   });
 }
 
-function isUnderlyingSessionBusy(tab: TabRecord): boolean {
-  const sessionFlags = tab.session as {
-    isStreaming?: unknown;
-    isRetrying?: unknown;
-  };
-  return (
-    tab.aethonRetryInFlight === true ||
-    sessionFlags.isStreaming === true ||
-    sessionFlags.isRetrying === true
-  );
-}
-
 function normalizeImages(images: InboundMessage["images"]): ImageContent[] {
   if (!Array.isArray(images)) return [];
   return images
@@ -542,10 +532,28 @@ export function handleStop(
       /* best effort */
     }
   }
+  const wasContextOverflowRecovery =
+    tab.contextOverflowRecoveryInFlight === true;
   tab.queuedCount = 0;
   cancelAethonRetry(tab);
+  resetContextOverflowRecovery(tab);
   deps.send({ type: "queue_reset", tabId });
   cancelRunningToolCards(deps, tab, tabId);
+  if (
+    typeof (tab.session as { abortCompaction?: () => unknown })
+      .abortCompaction === "function"
+  ) {
+    try {
+      (tab.session as { abortCompaction: () => unknown }).abortCompaction();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      deps.send({
+        type: "error",
+        tabId,
+        message: `abort compaction: ${message}`,
+      });
+    }
+  }
   if (
     typeof (tab.session as { abortBash?: () => unknown }).abortBash ===
     "function"
@@ -561,4 +569,12 @@ export function handleStop(
     const message = err instanceof Error ? err.message : String(err);
     deps.send({ type: "error", tabId, message: `abort: ${message}` });
   });
+  if (wasContextOverflowRecovery) {
+    tab.promptInFlight = false;
+    tab.agentEndFired = true;
+    if (state.currentAgentTabId === tabId) {
+      state.currentAgentTabId = undefined;
+    }
+    deps.send({ type: "response_end", tabId });
+  }
 }

--- a/agent/context-overflow-recovery.ts
+++ b/agent/context-overflow-recovery.ts
@@ -1,0 +1,25 @@
+import type { TabRecord } from "./state";
+
+export function cancelContextOverflowRecoveryTimer(rec: TabRecord): void {
+  if (rec.contextOverflowRecoveryTimer) {
+    clearTimeout(rec.contextOverflowRecoveryTimer);
+    rec.contextOverflowRecoveryTimer = undefined;
+  }
+}
+
+export function resetContextOverflowRecovery(rec: TabRecord): void {
+  cancelContextOverflowRecoveryTimer(rec);
+  rec.contextOverflowRecoveryAttempted = false;
+  rec.contextOverflowRecoveryInFlight = false;
+  rec.contextOverflowRecoveryCompactionStarted = false;
+  rec.contextOverflowRecoveryFallbackRunning = false;
+  rec.contextOverflowRecoveryErrorMessage = undefined;
+}
+
+export function clearActiveContextOverflowRecovery(rec: TabRecord): void {
+  cancelContextOverflowRecoveryTimer(rec);
+  rec.contextOverflowRecoveryInFlight = false;
+  rec.contextOverflowRecoveryCompactionStarted = false;
+  rec.contextOverflowRecoveryFallbackRunning = false;
+  rec.contextOverflowRecoveryErrorMessage = undefined;
+}

--- a/agent/session-busy.test.ts
+++ b/agent/session-busy.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import type { TabRecord } from "./state";
+import { isUnderlyingSessionBusy } from "./session-busy";
+
+function fakeTab(overrides: Partial<TabRecord> = {}): TabRecord {
+  return {
+    id: "tab-1",
+    session: { messages: [] } as unknown as TabRecord["session"],
+    toolArgsCache: new Map(),
+    promptInFlight: false,
+    agentEndFired: false,
+    queuedCount: 0,
+    toolCardSeq: 0,
+    responseMessageSeq: 0,
+    ...overrides,
+  };
+}
+
+describe("isUnderlyingSessionBusy", () => {
+  it("treats context-overflow recovery as an active turn", () => {
+    expect(
+      isUnderlyingSessionBusy(
+        fakeTab({ contextOverflowRecoveryInFlight: true }),
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps existing retry and SDK busy signals", () => {
+    expect(isUnderlyingSessionBusy(fakeTab({ aethonRetryInFlight: true }))).toBe(
+      true,
+    );
+    expect(
+      isUnderlyingSessionBusy(
+        fakeTab({
+          session: { isStreaming: true } as unknown as TabRecord["session"],
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isUnderlyingSessionBusy(
+        fakeTab({
+          session: { isRetrying: true } as unknown as TabRecord["session"],
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false when no underlying recovery or SDK work is active", () => {
+    expect(isUnderlyingSessionBusy(fakeTab())).toBe(false);
+  });
+});

--- a/agent/session-busy.ts
+++ b/agent/session-busy.ts
@@ -1,0 +1,14 @@
+import type { TabRecord } from "./state";
+
+export function isUnderlyingSessionBusy(tab: TabRecord): boolean {
+  const sessionFlags = tab.session as {
+    isStreaming?: unknown;
+    isRetrying?: unknown;
+  };
+  return (
+    tab.aethonRetryInFlight === true ||
+    tab.contextOverflowRecoveryInFlight === true ||
+    sessionFlags.isStreaming === true ||
+    sessionFlags.isRetrying === true
+  );
+}

--- a/agent/state.ts
+++ b/agent/state.ts
@@ -298,6 +298,14 @@ export interface TabRecord {
   aethonRetryAttempt?: number;
   aethonRetryInFlight?: boolean;
   aethonRetryTimer?: ReturnType<typeof setTimeout>;
+  /** Context-overflow recovery state for provider errors that need a
+   *  compact-and-resume turn instead of surfacing as terminal failures. */
+  contextOverflowRecoveryAttempted?: boolean;
+  contextOverflowRecoveryInFlight?: boolean;
+  contextOverflowRecoveryCompactionStarted?: boolean;
+  contextOverflowRecoveryFallbackRunning?: boolean;
+  contextOverflowRecoveryTimer?: ReturnType<typeof setTimeout>;
+  contextOverflowRecoveryErrorMessage?: string;
   /** Auth profile ids already tried by the usage-limit auto-switch for the
    *  current prompt. Prevents looping back onto an account we just bounced
    *  off; cleared on the next successful (non-error) turn. */

--- a/agent/tab-lifecycle.test.ts
+++ b/agent/tab-lifecycle.test.ts
@@ -1235,6 +1235,198 @@ describe("handleSessionEvent", () => {
     }
   });
 
+  it("agent_end for Codex context overflow keeps the turn open, compacts, and resumes", async () => {
+    vi.useFakeTimers();
+    try {
+      const f = makeFixture();
+      const rec = fakeRec("openai-codex/gpt-5.5");
+      const failure = {
+        role: "assistant",
+        stopReason: "error",
+        errorMessage:
+          'Codex error: {"type":"error","error":{"type":"invalid_request_error","code":"context_length_exceeded","message":"Your input exceeds the context window of this model. Please adjust your input and try again.","param":"input"},"sequence_number":2}',
+      };
+      const compact = vi.fn(() => Promise.resolve({ tokensBefore: 159_747 }));
+      const agent = {
+        state: { messages: [{ role: "user" }, failure] },
+        resumed: false,
+        continue: vi.fn(function (this: { resumed: boolean }) {
+          this.resumed = true;
+          return Promise.resolve();
+        }),
+      };
+      rec.promptInFlight = true;
+      rec.session = {
+        ...rec.session,
+        compact,
+        agent,
+      } as TabRecord["session"];
+      f.state.tabs.set("tab-1", rec);
+      f.state.currentAgentTabId = "tab-1";
+
+      handleSessionEvent(f.state, f.deps, rec, "tab-1", {
+        type: "agent_end",
+        messages: [failure],
+      });
+
+      expect(rec.promptInFlight).toBe(true);
+      expect(rec.agentEndFired).toBe(false);
+      expect(f.state.currentAgentTabId).toBe("tab-1");
+      expect(f.sent).toContainEqual({
+        type: "notice",
+        tabId: "tab-1",
+        busy: true,
+        message:
+          "Context window exceeded. Compacting context and resuming automatically.",
+      });
+      expect(f.sent.some((m) => m.type === "error")).toBe(false);
+      expect(f.sent.some((m) => m.type === "response_end")).toBe(false);
+      expect(
+        (rec.session as never as { agent: { state: { messages: unknown[] } } })
+          .agent.state.messages,
+      ).toEqual([{ role: "user" }, failure]);
+
+      await vi.advanceTimersByTimeAsync(250);
+
+      expect(compact).toHaveBeenCalledOnce();
+      expect(agent.continue).toHaveBeenCalledOnce();
+      expect(agent.resumed).toBe(true);
+      expect(
+        (rec.session as never as { agent: { state: { messages: unknown[] } } })
+          .agent.state.messages,
+      ).toEqual([{ role: "user" }]);
+      expect(f.sent.some((m) => m.type === "response_end")).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("resumes after overflow compaction when pi does not mark willRetry", async () => {
+    vi.useFakeTimers();
+    try {
+      const f = makeFixture();
+      const rec = fakeRec("openai-codex/gpt-5.5");
+      const failure = {
+        role: "assistant",
+        stopReason: "error",
+        errorMessage:
+          'Codex error: {"type":"error","error":{"type":"invalid_request_error","code":"context_length_exceeded","message":"Your input exceeds the context window of this model. Please adjust your input and try again.","param":"input"},"sequence_number":2}',
+      };
+      const compact = vi.fn(() => Promise.resolve({ tokensBefore: 159_747 }));
+      const agent = {
+        state: { messages: [{ role: "user" }, failure] },
+        resumed: false,
+        continue: vi.fn(function (this: { resumed: boolean }) {
+          this.resumed = true;
+          return Promise.resolve();
+        }),
+      };
+      rec.promptInFlight = true;
+      rec.session = {
+        ...rec.session,
+        compact,
+        agent,
+      } as TabRecord["session"];
+      f.state.tabs.set("tab-1", rec);
+
+      handleSessionEvent(f.state, f.deps, rec, "tab-1", {
+        type: "agent_end",
+        messages: [failure],
+      });
+      handleSessionEvent(f.state, f.deps, rec, "tab-1", {
+        type: "compaction_start",
+        reason: "overflow",
+      });
+      expect(
+        (rec.session as never as { agent: { state: { messages: unknown[] } } })
+          .agent.state.messages,
+      ).toEqual([{ role: "user" }, failure]);
+      await vi.advanceTimersByTimeAsync(250);
+      expect(compact).not.toHaveBeenCalled();
+
+      handleSessionEvent(f.state, f.deps, rec, "tab-1", {
+        type: "compaction_end",
+        reason: "overflow",
+        result: { tokensBefore: 159_747 },
+        willRetry: false,
+      });
+      await Promise.resolve();
+
+      expect(agent.continue).toHaveBeenCalledOnce();
+      expect(agent.resumed).toBe(true);
+      expect(f.sent.some((m) => m.type === "response_end")).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not resume after overflow compaction is aborted", async () => {
+    vi.useFakeTimers();
+    try {
+      const f = makeFixture();
+      const rec = fakeRec("openai-codex/gpt-5.5");
+      const failure = {
+        role: "assistant",
+        stopReason: "error",
+        errorMessage:
+          'Codex error: {"type":"error","error":{"type":"invalid_request_error","code":"context_length_exceeded","message":"Your input exceeds the context window of this model. Please adjust your input and try again.","param":"input"},"sequence_number":2}',
+      };
+      const compact = vi.fn(() => Promise.resolve({ tokensBefore: 159_747 }));
+      const continueRun = vi.fn(() => Promise.resolve());
+      rec.promptInFlight = true;
+      rec.session = {
+        ...rec.session,
+        compact,
+        agent: {
+          state: { messages: [{ role: "user" }, failure] },
+          continue: continueRun,
+        },
+      } as TabRecord["session"];
+      f.state.tabs.set("tab-1", rec);
+
+      handleSessionEvent(f.state, f.deps, rec, "tab-1", {
+        type: "agent_end",
+        messages: [failure],
+      });
+      handleSessionEvent(f.state, f.deps, rec, "tab-1", {
+        type: "compaction_start",
+        reason: "overflow",
+      });
+      handleSessionEvent(f.state, f.deps, rec, "tab-1", {
+        type: "compaction_end",
+        reason: "overflow",
+        result: undefined,
+        aborted: true,
+        willRetry: false,
+      });
+      await Promise.resolve();
+
+      expect(compact).not.toHaveBeenCalled();
+      expect(continueRun).not.toHaveBeenCalled();
+      expect(f.sent).toContainEqual({
+        type: "notice",
+        tabId: "tab-1",
+        message: "Context compaction cancelled.",
+      });
+      expect(f.sent).toContainEqual({
+        type: "error",
+        tabId: "tab-1",
+        message: "Context overflow recovery cancelled during compaction.",
+      });
+      expect(f.sent).toContainEqual({ type: "response_end", tabId: "tab-1" });
+      expect(
+        f.sent.some(
+          (m) => m.type === "notice" && m.message === "Context compacted",
+        ),
+      ).toBe(false);
+      expect(rec.promptInFlight).toBe(false);
+      await vi.advanceTimersByTimeAsync(250);
+      expect(compact).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("agent_end during auto-retry surfaces non-retryable failures and ends the turn", () => {
     const f = makeFixture();
     const rec = fakeRec();

--- a/agent/tab-lifecycle.test.ts
+++ b/agent/tab-lifecycle.test.ts
@@ -1360,6 +1360,61 @@ describe("handleSessionEvent", () => {
     }
   });
 
+  it("resumes after native overflow compaction events that omit a result", async () => {
+    vi.useFakeTimers();
+    try {
+      const f = makeFixture();
+      const rec = fakeRec("openai-codex/gpt-5.5");
+      const failure = {
+        role: "assistant",
+        stopReason: "error",
+        errorMessage:
+          'Codex error: {"type":"error","error":{"type":"invalid_request_error","code":"context_length_exceeded","message":"Your input exceeds the context window of this model. Please adjust your input and try again.","param":"input"},"sequence_number":2}',
+      };
+      const compact = vi.fn(() => Promise.resolve({ tokensBefore: 159_747 }));
+      const continueRun = vi.fn(() => Promise.resolve());
+      rec.promptInFlight = true;
+      rec.session = {
+        ...rec.session,
+        compact,
+        agent: {
+          state: { messages: [{ role: "user" }, failure] },
+          continue: continueRun,
+        },
+      } as TabRecord["session"];
+      f.state.tabs.set("tab-1", rec);
+
+      handleSessionEvent(f.state, f.deps, rec, "tab-1", {
+        type: "agent_end",
+        messages: [failure],
+      });
+      handleSessionEvent(f.state, f.deps, rec, "tab-1", {
+        type: "auto_compaction_start",
+        reason: "overflow",
+      });
+      await vi.advanceTimersByTimeAsync(250);
+      expect(compact).not.toHaveBeenCalled();
+
+      handleSessionEvent(f.state, f.deps, rec, "tab-1", {
+        type: "auto_compaction_end",
+        reason: "overflow",
+        willRetry: false,
+      });
+      await Promise.resolve();
+
+      expect(continueRun).toHaveBeenCalledOnce();
+      expect(f.sent).toContainEqual({
+        type: "notice",
+        tabId: "tab-1",
+        message: "Context compacted",
+      });
+      expect(f.sent.some((m) => m.type === "error")).toBe(false);
+      expect(f.sent.some((m) => m.type === "response_end")).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not resume after overflow compaction is aborted", async () => {
     vi.useFakeTimers();
     try {

--- a/agent/tab-lifecycle/events.ts
+++ b/agent/tab-lifecycle/events.ts
@@ -22,6 +22,7 @@
 import {
   extractAgentEndError,
   formatAgentErrorMessage,
+  isContextLengthExceededError,
   isRetryableAgentEndError,
   isUsageLimitError,
 } from "../agent-errors";
@@ -39,7 +40,11 @@ import {
   toolCardPayload,
 } from "../tool-card";
 import { emitBashResult } from "./terminal";
-import { cancelAethonRetry, scheduleAethonRetry } from "./retry";
+import {
+  cancelAethonRetry,
+  removeTrailingFailureMessage,
+  scheduleAethonRetry,
+} from "./retry";
 import type { TabLifecycleDeps } from "./utils";
 import { modelKey } from "./utils";
 import { supportsCodexFastMode } from "../codex-fast-mode";
@@ -50,8 +55,14 @@ import {
   emitContextUsage,
   emitContextUsageThrottled,
 } from "../context-usage";
+import {
+  cancelContextOverflowRecoveryTimer,
+  clearActiveContextOverflowRecovery,
+  resetContextOverflowRecovery,
+} from "../context-overflow-recovery";
 
 const turnLog = logger.scope("turn");
+const CONTEXT_OVERFLOW_RECOVERY_FALLBACK_DELAY_MS = 250;
 
 function assistantEventMessageId(ame: {
   id?: unknown;
@@ -202,19 +213,36 @@ function emitFinalAssistantContent(
 function compactionNotice(
   event: { type: string } & Record<string, unknown>,
 ): { message: string; busy?: true } | undefined {
-  const type = event.type.toLowerCase();
-  if (!type.includes("compact")) return undefined;
-  if (type.includes("start") || type.includes("begin")) {
+  const phase = compactionPhase(event);
+  if (!phase) return undefined;
+  if (phase === "start") {
     return { message: "Compacting context...", busy: true };
   }
-  if (type.includes("fail") || type.includes("error")) {
-    const reason =
-      typeof event.error === "string"
-        ? event.error
-        : typeof event.message === "string"
-          ? event.message
-          : "unknown error";
-    return { message: `Context compaction failed: ${reason}` };
+  if (phase === "failure") {
+    return { message: compactionFailureMessage(event) };
+  }
+  const tokens = compactionTokensBefore(event);
+  const tokensBefore =
+    tokens === undefined
+      ? ""
+      : ` · ${tokens.toLocaleString("en-US")} tokens summarized`;
+  return { message: `Context compacted${tokensBefore}` };
+}
+
+function compactionPhase(
+  event: { type: string } & Record<string, unknown>,
+): "start" | "success" | "failure" | undefined {
+  const type = event.type.toLowerCase();
+  if (!type.includes("compact")) return undefined;
+  if (type.includes("start") || type.includes("begin")) return "start";
+  if (
+    typeof event.errorMessage === "string" ||
+    event.aborted === true ||
+    (event.type === "compaction_end" && event.result === undefined) ||
+    type.includes("fail") ||
+    type.includes("error")
+  ) {
+    return "failure";
   }
   if (
     type.includes("end") ||
@@ -222,14 +250,219 @@ function compactionNotice(
     type.includes("complete") ||
     type.includes("success")
   ) {
-    const tokensBefore =
-      typeof event.tokensBefore === "number" &&
-      Number.isFinite(event.tokensBefore)
-        ? ` · ${event.tokensBefore.toLocaleString("en-US")} tokens summarized`
-        : "";
-    return { message: `Context compacted${tokensBefore}` };
+    return "success";
   }
   return undefined;
+}
+
+function compactionFailureMessage(
+  event: { type: string } & Record<string, unknown>,
+): string {
+  if (typeof event.errorMessage === "string" && event.errorMessage.length > 0) {
+    return event.errorMessage;
+  }
+  if (event.aborted === true) {
+    return "Context compaction cancelled.";
+  }
+  if (event.type === "compaction_end" && event.result === undefined) {
+    return "Context compaction failed: no summary produced.";
+  }
+  const reason =
+    typeof event.error === "string"
+      ? event.error
+      : typeof event.message === "string"
+        ? event.message
+        : "unknown error";
+  return `Context compaction failed: ${reason}`;
+}
+
+function compactionTokensBefore(
+  event: { type: string } & Record<string, unknown>,
+): number | undefined {
+  if (
+    typeof event.tokensBefore === "number" &&
+    Number.isFinite(event.tokensBefore)
+  ) {
+    return event.tokensBefore;
+  }
+  const result = event.result as { tokensBefore?: unknown } | undefined;
+  return typeof result?.tokensBefore === "number" &&
+    Number.isFinite(result.tokensBefore)
+    ? result.tokensBefore
+    : undefined;
+}
+
+interface CompactAndContinueSession {
+  compact?: (customInstructions?: string) => Promise<unknown>;
+  agent?: {
+    continue?: () => Promise<void>;
+  };
+}
+
+function startContextOverflowRecovery(
+  state: AethonAgentState,
+  deps: TabLifecycleDeps,
+  rec: TabRecord,
+  tabId: string,
+  failedMessage: string,
+): void {
+  cancelAethonRetry(rec);
+  cancelContextOverflowRecoveryTimer(rec);
+  rec.contextOverflowRecoveryAttempted = true;
+  rec.contextOverflowRecoveryInFlight = true;
+  rec.contextOverflowRecoveryCompactionStarted = false;
+  rec.contextOverflowRecoveryFallbackRunning = false;
+  rec.contextOverflowRecoveryErrorMessage = failedMessage;
+  rec.promptInFlight = true;
+  rec.agentEndFired = false;
+  state.currentAgentTabId = tabId;
+  deps.send({
+    type: "notice",
+    tabId,
+    busy: true,
+    message: formatAgentErrorMessage(failedMessage),
+  });
+  rec.contextOverflowRecoveryTimer = setTimeout(() => {
+    rec.contextOverflowRecoveryTimer = undefined;
+    void runContextOverflowRecoveryFallback(state, deps, tabId, failedMessage);
+  }, CONTEXT_OVERFLOW_RECOVERY_FALLBACK_DELAY_MS);
+}
+
+async function runContextOverflowRecoveryFallback(
+  state: AethonAgentState,
+  deps: TabLifecycleDeps,
+  tabId: string,
+  failedMessage: string,
+): Promise<void> {
+  const rec = state.tabs.get(tabId);
+  if (!rec?.contextOverflowRecoveryInFlight) return;
+  if (rec.contextOverflowRecoveryCompactionStarted) return;
+  const session = rec.session as CompactAndContinueSession;
+  const agent = session.agent;
+  if (
+    typeof session.compact !== "function" ||
+    typeof agent?.continue !== "function"
+  ) {
+    deps.send({
+      type: "error",
+      tabId,
+      message:
+        "Context window exceeded, but this session cannot compact and resume automatically.",
+    });
+    finalizeFailedTurn(state, deps, tabId, failedMessage);
+    return;
+  }
+
+  rec.contextOverflowRecoveryFallbackRunning = true;
+  rec.contextOverflowRecoveryCompactionStarted = true;
+  deps.send({
+    type: "notice",
+    tabId,
+    busy: true,
+    message: "Context overflow detected; compacting before resuming...",
+  });
+  try {
+    await session.compact();
+    await continueAfterContextCompaction(state, deps, tabId, failedMessage);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    deps.send({
+      type: "error",
+      tabId,
+      message: `Context overflow recovery failed: ${message}`,
+    });
+    finalizeFailedTurn(state, deps, tabId, failedMessage);
+  } finally {
+    const live = state.tabs.get(tabId);
+    if (live) live.contextOverflowRecoveryFallbackRunning = false;
+  }
+}
+
+async function continueAfterContextCompaction(
+  state: AethonAgentState,
+  deps: TabLifecycleDeps,
+  tabId: string,
+  failedMessage: string,
+): Promise<void> {
+  const rec = state.tabs.get(tabId);
+  if (!rec?.contextOverflowRecoveryInFlight) return;
+  const session = rec.session as CompactAndContinueSession;
+  const agent = session.agent;
+  if (typeof agent?.continue !== "function") {
+    deps.send({
+      type: "error",
+      tabId,
+      message:
+        "Context compacted, but this session cannot resume automatically.",
+    });
+    finalizeFailedTurn(state, deps, tabId, failedMessage);
+    return;
+  }
+  removeTrailingFailureMessage(rec.session);
+  rec.promptInFlight = true;
+  rec.agentEndFired = false;
+  state.currentAgentTabId = tabId;
+  deps.send({
+    type: "notice",
+    tabId,
+    busy: true,
+    message: "Context compacted; resuming...",
+  });
+  try {
+    await agent.continue();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    deps.send({ type: "error", tabId, message: `resume: ${message}` });
+    finalizeFailedTurn(state, deps, tabId, failedMessage);
+  }
+}
+
+function handleContextOverflowCompactionEvent(
+  state: AethonAgentState,
+  deps: TabLifecycleDeps,
+  rec: TabRecord,
+  tabId: string,
+  event: { type: string } & Record<string, unknown>,
+): void {
+  if (!rec.contextOverflowRecoveryInFlight) return;
+  const failedMessage = rec.contextOverflowRecoveryErrorMessage;
+  if (!failedMessage) return;
+  const phase = compactionPhase(event);
+  if (!phase) return;
+  if (phase === "start") {
+    cancelContextOverflowRecoveryTimer(rec);
+    rec.contextOverflowRecoveryCompactionStarted = true;
+    return;
+  }
+  cancelContextOverflowRecoveryTimer(rec);
+  if (phase === "failure") {
+    if (rec.contextOverflowRecoveryFallbackRunning) return;
+    deps.send({
+      type: "error",
+      tabId,
+      message:
+        event.aborted === true
+          ? "Context overflow recovery cancelled during compaction."
+          : compactionFailureMessage(event),
+    });
+    finalizeFailedTurn(state, deps, tabId, failedMessage);
+    return;
+  }
+  if (rec.contextOverflowRecoveryFallbackRunning) return;
+  if (event.aborted === true || event.result === undefined) {
+    deps.send({
+      type: "error",
+      tabId,
+      message:
+        event.aborted === true
+          ? "Context overflow recovery cancelled during compaction."
+          : "Context overflow recovery failed: compaction produced no summary.",
+    });
+    finalizeFailedTurn(state, deps, tabId, failedMessage);
+    return;
+  }
+  if (event.willRetry === true) return;
+  void continueAfterContextCompaction(state, deps, tabId, failedMessage);
 }
 
 /** Per-tab pi session event subscriber. Extracted so tests can drive it
@@ -259,9 +492,15 @@ export function handleSessionEvent(
       compacting: compacting.busy === true,
     });
   }
+  handleContextOverflowCompactionEvent(state, deps, rec, tabId, event);
 
   switch (event.type) {
     case "agent_start": {
+      if (rec.contextOverflowRecoveryInFlight) {
+        clearActiveContextOverflowRecovery(rec);
+      } else {
+        rec.contextOverflowRecoveryAttempted = false;
+      }
       rollResponseMessage(rec);
       clearLiveContextUsageEstimate(rec);
       state.currentAgentTabId = tabId;
@@ -497,6 +736,22 @@ export function handleSessionEvent(
       const keepTurnOpenForRetry =
         retryableFailure &&
         (retrying || scheduleAethonRetry(state, deps, rec, tabId));
+      // Codex can surface context-window overflow as a raw JSON payload after
+      // agent_end. Keep the turn open while pi (or Aethon as fallback)
+      // compacts and resumes instead of rendering that payload as terminal.
+      const contextLengthFailure =
+        failedMessage !== undefined &&
+        !keepTurnOpenForRetry &&
+        isContextLengthExceededError(failedMessage);
+      let terminalContextLengthError: string | undefined;
+      const keepTurnOpenForContextRecovery =
+        contextLengthFailure && rec.contextOverflowRecoveryAttempted !== true;
+      if (contextLengthFailure && keepTurnOpenForContextRecovery) {
+        startContextOverflowRecovery(state, deps, rec, tabId, failedMessage);
+      } else if (contextLengthFailure) {
+        terminalContextLengthError =
+          "Context window is still too large after compacting. Try reducing context or switching to a larger-context model.";
+      }
       // A usage-limit hit triggers an async account hop. Keep the turn open
       // until that decision resolves — finalizing now would clear `waiting`
       // and could drain queued messages onto the rate-limited account before
@@ -504,6 +759,7 @@ export function handleSessionEvent(
       const usageLimitFailure =
         failedMessage !== undefined &&
         !keepTurnOpenForRetry &&
+        !keepTurnOpenForContextRecovery &&
         isUsageLimitError(failedMessage);
       const keepTurnOpenForAutoSwitch = usageLimitFailure;
       if (usageLimitFailure) {
@@ -520,16 +776,27 @@ export function handleSessionEvent(
             deps.send({ type: "error", tabId, message: clean });
             finalizeFailedTurn(state, deps, tabId, failedMessage);
           });
-      } else if (failedMessage && !keepTurnOpenForRetry) {
+      } else if (terminalContextLengthError) {
+        deps.send({
+          type: "error",
+          tabId,
+          message: terminalContextLengthError,
+        });
+      } else if (
+        failedMessage &&
+        !keepTurnOpenForRetry &&
+        !keepTurnOpenForContextRecovery
+      ) {
         deps.send({
           type: "error",
           tabId,
           message: formatAgentErrorMessage(failedMessage),
         });
       } else if (!failedMessage) {
-        // Clean turn — reset the auto-switch loop guard so a future limit
-        // can switch accounts again.
+        // Clean turn — reset recovery loop guards so future turns can switch
+        // accounts or compact again.
         rec.autoSwitchTried = undefined;
+        resetContextOverflowRecovery(rec);
       }
       const startMs = state.turnStartTimes.get(tabId);
       state.turnStartTimes.delete(tabId);
@@ -558,8 +825,13 @@ export function handleSessionEvent(
       for (const [toolCallId, cached] of rec.toolArgsCache) {
         if (cached.endedAt !== undefined) rec.toolArgsCache.delete(toolCallId);
       }
-      if (!keepTurnOpenForRetry && !keepTurnOpenForAutoSwitch) {
+      if (
+        !keepTurnOpenForRetry &&
+        !keepTurnOpenForAutoSwitch &&
+        !keepTurnOpenForContextRecovery
+      ) {
         cancelAethonRetry(rec);
+        if (failedMessage) resetContextOverflowRecovery(rec);
         rec.agentEndFired = true;
         rec.promptInFlight = false;
         if (state.currentAgentTabId === tabId) {
@@ -632,6 +904,7 @@ export function handleSessionEvent(
           tabId,
           message: `auto-retry exhausted: ${finalError}`,
         });
+        resetContextOverflowRecovery(rec);
         rec.agentEndFired = true;
         rec.promptInFlight = false;
         if (state.currentAgentTabId === tabId) {
@@ -661,6 +934,7 @@ function finalizeFailedTurn(
   const rec = state.tabs.get(tabId);
   if (!rec || rec.agentEndFired) return;
   cancelAethonRetry(rec);
+  resetContextOverflowRecovery(rec);
   rec.agentEndFired = true;
   rec.promptInFlight = false;
   if (state.currentAgentTabId === tabId) {

--- a/agent/tab-lifecycle/events.ts
+++ b/agent/tab-lifecycle/events.ts
@@ -238,7 +238,6 @@ function compactionPhase(
   if (
     typeof event.errorMessage === "string" ||
     event.aborted === true ||
-    (event.type === "compaction_end" && event.result === undefined) ||
     type.includes("fail") ||
     type.includes("error")
   ) {
@@ -263,9 +262,6 @@ function compactionFailureMessage(
   }
   if (event.aborted === true) {
     return "Context compaction cancelled.";
-  }
-  if (event.type === "compaction_end" && event.result === undefined) {
-    return "Context compaction failed: no summary produced.";
   }
   const reason =
     typeof event.error === "string"
@@ -449,18 +445,6 @@ function handleContextOverflowCompactionEvent(
     return;
   }
   if (rec.contextOverflowRecoveryFallbackRunning) return;
-  if (event.aborted === true || event.result === undefined) {
-    deps.send({
-      type: "error",
-      tabId,
-      message:
-        event.aborted === true
-          ? "Context overflow recovery cancelled during compaction."
-          : "Context overflow recovery failed: compaction produced no summary.",
-    });
-    finalizeFailedTurn(state, deps, tabId, failedMessage);
-    return;
-  }
   if (event.willRetry === true) return;
   void continueAfterContextCompaction(state, deps, tabId, failedMessage);
 }


### PR DESCRIPTION
## Summary
- detect Codex `context_length_exceeded` errors and replace the raw provider JSON with a friendly automatic-recovery notice
- keep the agent turn open while context-overflow recovery compacts and resumes, including Aethon fallback recovery when pi does not own the retry
- add stop/busy-state cleanup so held-open recovery turns can be cancelled safely without leaking timers or emitting stale resume work
- cover fallback, native pi compaction, abort, empty compaction, and bound `continue()` behavior with regression tests

## Details
Codex can return an `invalid_request_error` with `code: "context_length_exceeded"` when the current session exceeds the model context window. Previously that escaped to users as raw JSON and ended the turn. This change recognizes that failure mode, suppresses the failed assistant message from the resumed context, compacts the session, and resumes automatically unless pi explicitly reports that it will retry itself.

Recovery now tracks per-tab overflow state so chat sends, A2UI dispatch, and stop handling treat the tab as busy while compaction/resume is in flight. Stop cancels recovery timers, aborts any active compaction, clears recovery state, and emits the held `response_end` once the recovery turn is cancelled.

## Validation
- `bunx vitest run agent/chat-stop.test.ts agent/session-busy.test.ts agent/agent-errors.test.ts agent/tab-lifecycle.test.ts`
- `bun run typecheck`
- targeted `bun run lint -- agent/a2uiEvents.ts agent/agent-errors.ts agent/agent-errors.test.ts agent/chat.ts agent/chat-stop.test.ts agent/context-overflow-recovery.ts agent/session-busy.ts agent/session-busy.test.ts agent/state.ts agent/tab-lifecycle/events.ts agent/tab-lifecycle.test.ts`
- `bun run lint` (run during Codex review)
- `git diff --check`
- Codex peer review after fixes: no findings

## Known unrelated failures
`bunx vitest run` was run and still fails in two existing tests unrelated to this branch:
- `agent/dispatcher.test.ts > refreshes persisted session discovery before report ready payloads`
- `cli/aethonControl.test.ts > reads release control info and sends token-authenticated socket requests`

The full run otherwise reported `307 passed` files / `2544 passed` tests.
