### PR TITLE
chore(understand): re-pin graph artifacts to on-main baseline

### DIFF
--- a/.understand-anything/domain-graph.json
+++ b/.understand-anything/domain-graph.json
@@ -15,7 +15,7 @@
     ],
     "description": "Aethon is a developer-facing desktop application: a thin Tauri 2 + React 19 shell that embeds the pi coding agent as a bun subprocess and renders its output as live, interactive UI via the A2UI protocol. The agent drives the interface (layout-as-payload) instead of a fixed IDE, while the Rust shell owns OS boundaries — agent process supervision, PTY shells, git/GitHub status, voice capture, auto-update, and LAN peer discovery.",
     "analyzedAt": "2026-06-22T03:05:08Z",
-    "gitCommitHash": "24a58b2290611832965ce20eb7a30310551d83b2"
+    "gitCommitHash": "7b019865d57eabd5468268a3e4548e01c62e6de7"
   },
   "nodes": [
     {

--- a/.understand-anything/fingerprints.json
+++ b/.understand-anything/fingerprints.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
-  "gitCommitHash": "24a58b2290611832965ce20eb7a30310551d83b2",
-  "generatedAt": "2026-06-22T03:30:12.550Z",
+  "gitCommitHash": "7b019865d57eabd5468268a3e4548e01c62e6de7",
+  "generatedAt": "2026-06-22T04:12:57.153Z",
   "files": {
     ".claude/skills/aethon-debug/scripts/debug-agent-diag.sh": {
       "filePath": ".claude/skills/aethon-debug/scripts/debug-agent-diag.sh",
@@ -70443,7 +70443,7 @@
     },
     "docs/ONBOARDING.md": {
       "filePath": "docs/ONBOARDING.md",
-      "contentHash": "c5108bb72fce0c2798105cadf9c5e3f059adff978ec149abf3124ccba75f3b11",
+      "contentHash": "e743b4eeb7613b58eb6ed063e96d1e69986b6461d77c94a58601d85d643735da",
       "functions": [],
       "classes": [],
       "imports": [],

--- a/.understand-anything/knowledge-graph.json
+++ b/.understand-anything/knowledge-graph.json
@@ -28,8 +28,8 @@
       "GitHub Actions"
     ],
     "description": "Aethon is a Tauri 2 + React 19 + TypeScript desktop shell that embeds the pi coding agent and renders its output as live, interactive UI via the A2UI protocol, where the agent dynamically populates the interface rather than a fixed IDE layout. Note: this project has over 100 source files; consider scoping analysis to a subdirectory for faster results.",
-    "analyzedAt": "2026-06-22T03:29:45.567Z",
-    "gitCommitHash": "24a58b2290611832965ce20eb7a30310551d83b2"
+    "analyzedAt": "2026-06-22T04:12:55.991Z",
+    "gitCommitHash": "7b019865d57eabd5468268a3e4548e01c62e6de7"
   },
   "nodes": [
     {

--- a/.understand-anything/meta.json
+++ b/.understand-anything/meta.json
@@ -1,6 +1,6 @@
 {
-  "lastAnalyzedAt": "2026-06-22T03:30:12.607Z",
-  "gitCommitHash": "24a58b2290611832965ce20eb7a30310551d83b2",
+  "lastAnalyzedAt": "2026-06-22T04:12:56.002Z",
+  "gitCommitHash": "7b019865d57eabd5468268a3e4548e01c62e6de7",
   "version": "1.0.0",
   "analyzedFiles": 1030
 }

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -2,7 +2,7 @@
 
 > Generated from the project knowledge graph (2674 nodes / 5903 edges / 10 layers / 14 tour
 > steps). This guide is a high-level map for new contributors. Every file, layer, and concept
-> below is grounded in the analyzed codebase at commit `24a58b2`.
+> below is grounded in the analyzed codebase at commit `7b01986`.
 
 ---
 


### PR DESCRIPTION
Follow-up to #341. The squash-merge collapsed the branch commit `24a58b2` that the committed graph artifacts pinned, leaving `meta.json`/`knowledge-graph.json`/`domain-graph.json`/`fingerprints.json` referencing a commit absent from `main`'s history (a fresh clone can't `git diff` against it, so the plugin's auto-update hook would fail). Re-pins all four to `7b019865` (the #341 squash commit, an ancestor of `main`) and regenerates fingerprints. Resolves the stale-hash note from #341.