### PR TITLE
fix(website): unbreak `docs` token gate + auto-update version badge

### DIFF
--- a/scripts/understand-dashboard.sh
+++ b/scripts/understand-dashboard.sh
@@ -19,6 +19,9 @@
 #
 # Usage: understand-dashboard [extra vite args...]
 #        understand-dashboard --host 0.0.0.0      # reachable on the LAN
+#        understand-dashboard --port 5999         # override the default port
+# Binds 127.0.0.1:5273 by default (NOT Vite's 5173) so it never collides with
+# the `docs` helper's vitepress dev server. Override with UNDERSTAND_DASHBOARD_PORT.
 set -euo pipefail
 
 # --- repo root (this script lives in <root>/scripts/) ---
@@ -101,11 +104,19 @@ echo "==> graph:     $GRAPH"
 echo "==> launching Vite (look for the http://127.0.0.1:<port>?token=<token> line; Ctrl+C to stop)"
 
 cd "$DASH"
+# Default to a dedicated port (NOT Vite's 5173): the `docs` helper runs
+# `vitepress dev` on 5173, and a dashboard left running there binds
+# 127.0.0.1:5173 which silently shadows vitepress's 0.0.0.0:5173 on localhost
+# (the kernel prefers the more-specific bind) — so `docs` would serve this
+# token-gated dashboard instead of the site. Passing `--port` here keeps the
+# two helpers off each other's toes. A user-supplied `--port` in "$@" comes
+# after and wins (last Vite flag takes precedence).
+DASH_PORT="${UNDERSTAND_DASHBOARD_PORT:-5273}"
 # Run the dashboard's own vite binary directly. `pnpm exec`/`pnpm run` would
 # first run an implicit deps-status check that calls `pnpm install`, which
 # fails against the read-only plugin cache even though node_modules is present.
 VITE_BIN="$DASH/node_modules/.bin/vite"
 if [ -x "$VITE_BIN" ]; then
-  exec env GRAPH_DIR="$PROJECT_ROOT" "$VITE_BIN" --host 127.0.0.1 "$@"
+  exec env GRAPH_DIR="$PROJECT_ROOT" "$VITE_BIN" --host 127.0.0.1 --port "$DASH_PORT" "$@"
 fi
-exec env GRAPH_DIR="$PROJECT_ROOT" npx --no-install vite --host 127.0.0.1 "$@"
+exec env GRAPH_DIR="$PROJECT_ROOT" npx --no-install vite --host 127.0.0.1 --port "$DASH_PORT" "$@"

--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -1,9 +1,20 @@
+import { readFileSync } from "node:fs";
 import { defineConfig } from "vitepress";
 
 // utensils.io is the org's GitHub Pages custom domain — every repo
 // Pages site is served at https://utensils.io/<repo>/.
 const SITE_URL = "https://utensils.io/aethon/";
 const REPO = "utensils/aethon";
+
+// Single source of truth for the nav version badge: read the app version from
+// the repo-root package.json (kept in lockstep with Cargo.toml / tauri.conf.json
+// by scripts/sync-version.mjs) at build time, so the badge tracks releases
+// automatically instead of drifting out of date as a hardcoded string.
+const APP_VERSION = (
+  JSON.parse(
+    readFileSync(new URL("../../package.json", import.meta.url), "utf-8"),
+  ) as { version: string }
+).version;
 
 export default defineConfig({
   lang: "en-US",
@@ -45,7 +56,7 @@ export default defineConfig({
       { text: "Troubleshooting", link: "/troubleshooting" },
       { text: "Knowledge Graph", link: "/knowledge-graph" },
       {
-        text: "v0.3.3",
+        text: `v${APP_VERSION}`,
         items: [
           {
             text: "Releases",


### PR DESCRIPTION
Two website/docs-tooling fixes that were causing real friction.

## 1. `docs` no longer demands an access token (port-5173 collision)

**Symptom:** running the `docs` devshell helper served a "Access Token Required" gate at `localhost:5173/aethon/` instead of the site.

**Root cause:** the `understand-dashboard` helper launched its Vite server on the default port **5173** — the same port `docs` uses for `vitepress dev`. A dashboard left running binds `127.0.0.1:5173`, which silently **shadows** vitepress's `0.0.0.0:5173` on localhost (the kernel routes `localhost` to the more-specific `127.0.0.1` bind). So `docs` reported `Local: http://localhost:5173/aethon/` but that URL was actually served by the token-gated dashboard. No service worker, no cache — a port collision.

**Fix:** bind the dashboard to `127.0.0.1:5273` by default (override via `--port` or `UNDERSTAND_DASHBOARD_PORT`). The two helpers can never collide again. A user-supplied `--port` still wins.

## 2. Website version badge auto-updates (no more hardcoded version)

**Symptom:** the nav release dropdown read **v0.3.3** — six minor versions behind the real app version (**0.9.0**).

**Root cause:** the badge was a hardcoded string in `website/.vitepress/config.ts` that `scripts/sync-version.mjs` never touched.

**Fix:** read the version from the repo-root `package.json` (the source of truth kept in lockstep with `Cargo.toml` / `tauri.conf.json`) at build time. The badge now tracks releases automatically.

## Verified
- Killed the stale dashboard squatting 5173; `curl localhost:5173/aethon/` now returns the vitepress shell (`id="app"`), not the gate.
- Launched the patched helper: binds `127.0.0.1:5273`, leaves vitepress's `5173` untouched, answers 200 on 5273.
- `vitepress build`: rendered HTML contains **`v0.9.0`** on every page and **zero** occurrences of `v0.3.3`. Build clean.
