### PR TITLE
ci(docs): rebuild site on package.json bump so the version badge tracks releases

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,11 +10,17 @@ on:
     paths:
       - "website/**"
       - ".github/workflows/docs.yml"
+      # The nav version badge is read from package.json at build time, so a
+      # release bump (release-please, release-type: node) must rebuild the
+      # site even though it touches no website/** files — otherwise the badge
+      # goes stale until the next docs edit.
+      - "package.json"
   pull_request:
     branches: [main]
     paths:
       - "website/**"
       - ".github/workflows/docs.yml"
+      - "package.json"
   workflow_dispatch:
 
 # Only one deploy to Pages at a time. Build runs on PR + main; deploy


### PR DESCRIPTION
Follow-up to #344. Makes the website version badge **stay** accurate on every release.

## The gap
#344 made the nav version badge read from `package.json` at build time. But the Docs workflow's `paths` filter only matched `website/**` and the workflow file:

```yaml
push:
  paths:
    - "website/**"
    - ".github/workflows/docs.yml"
```

A release bump (release-please, `release-type: node`) changes `package.json` / `Cargo.toml` / `CHANGELOG.md` — **nothing under `website/**`** — so on a future release the Docs workflow would not trigger, the site would not rebuild, and the badge would stay stale until the next docs edit. (#344 itself only deployed because it touched `website/.vitepress/config.ts`.)

## The fix
Add `package.json` to the `push` and `pull_request` paths filters. Now a version bump landing on `main` rebuilds the site and the badge tracks the release automatically.

## Why this is the right trigger
`package.json` is the single source of truth the badge reads, and the source release-please bumps (the rest of the version files are synced from it by `scripts/sync-version.mjs`). Triggering on it — and only it, beyond the existing website paths — keeps the rebuild targeted.
