### PR TITLE
fix: refresh codex account selector immediately

### DIFF
--- a/src/auth-profiles/commands.test.ts
+++ b/src/auth-profiles/commands.test.ts
@@ -95,4 +95,19 @@ describe("resolveAccountSwitchTarget", () => {
     );
     expect(target.busy).toBe(true);
   });
+
+  it("allows switching accounts before queued messages drain", () => {
+    const target = resolveAccountSwitchTarget(
+      [
+        agentTab({
+          id: "t-queued",
+          waiting: false,
+          queueCount: 1,
+          queuedMessages: [{ id: "q1", content: "retry on secondary" }],
+        }),
+      ],
+      "t-queued",
+    );
+    expect(target.busy).toBe(false);
+  });
 });

--- a/src/auth-profiles/commands.ts
+++ b/src/auth-profiles/commands.ts
@@ -1,5 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
-import { isAgentTabBusy } from "../utils/agentBusy";
+import { isAgentTabInFlight } from "../utils/agentBusy";
 import { OVERVIEW_TAB_ID, type Tab } from "../types/tab";
 
 export interface AccountSwitchTarget {
@@ -31,7 +31,7 @@ export function resolveAccountSwitchTarget(
     tabId: tab.id,
     cwd: tab.cwd,
     model: tab.model,
-    busy: isAgentTabBusy(tab, { includeQueue: true }),
+    busy: isAgentTabInFlight(tab),
   };
 }
 

--- a/src/extensions/default-layout/variation-components.test.tsx
+++ b/src/extensions/default-layout/variation-components.test.tsx
@@ -1,8 +1,26 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 
-import { ModelPicker } from "./variation-components";
+const authProfileMocks = vi.hoisted(() => ({
+  switchAccountForTab: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("../../auth-profiles", async (importOriginal) => {
+  const actual = await importOriginal<object>();
+  return {
+    ...actual,
+    switchAccountForTab: authProfileMocks.switchAccountForTab,
+  };
+});
+
+import { AccountSelector, ModelPicker } from "./variation-components";
 
 beforeEach(() => {
   vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
@@ -14,6 +32,7 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   vi.unstubAllGlobals();
+  authProfileMocks.switchAccountForTab.mockClear();
 });
 
 describe("ModelPicker", () => {
@@ -161,6 +180,116 @@ describe("ModelPicker", () => {
       "select",
       { sectionId: "models", itemId: "openai/gpt-5.5" },
       "openai/gpt-5.5",
+    );
+  });
+});
+
+describe("AccountSelector", () => {
+  it("shows the active tab auth profile even when the snapshot map is stale", () => {
+    render(
+      <AccountSelector
+        component={{
+          id: "account-selector",
+          type: "account-selector",
+          props: {},
+        }}
+        state={{
+          activeTabId: "tab-1",
+          tabs: [
+            {
+              id: "tab-1",
+              kind: "agent",
+              title: "Tab 1",
+              cwd: "/repo",
+              model: "openai-codex/gpt-5.5",
+              waiting: false,
+              authProfileId: "openai-codex-secondary",
+              messages: [],
+            },
+          ],
+          authProfiles: {
+            profiles: [
+              {
+                id: "openai-codex-primary",
+                providerId: "openai-codex",
+                label: "Primary",
+                kind: "oauth",
+              },
+              {
+                id: "openai-codex-secondary",
+                providerId: "openai-codex",
+                label: "Secondary",
+                kind: "oauth",
+              },
+            ],
+            activeByTab: { "tab-1": "openai-codex-primary" },
+            defaultByProvider: { "openai-codex": "openai-codex-primary" },
+          },
+        }}
+        onEvent={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /Secondary/i })).toBeTruthy();
+  });
+
+  it("switches accounts from the header when a tab only has queued messages", async () => {
+    render(
+      <AccountSelector
+        component={{
+          id: "account-selector",
+          type: "account-selector",
+          props: {},
+        }}
+        state={{
+          activeTabId: "tab-1",
+          tabs: [
+            {
+              id: "tab-1",
+              kind: "agent",
+              title: "Tab 1",
+              cwd: "/repo",
+              model: "openai-codex/gpt-5.5",
+              waiting: false,
+              queueCount: 1,
+              queuedMessages: [
+                { id: "q1", content: "continue on secondary" },
+              ],
+              messages: [],
+            },
+          ],
+          authProfiles: {
+            profiles: [
+              {
+                id: "openai-codex-primary",
+                providerId: "openai-codex",
+                label: "Primary",
+                kind: "oauth",
+              },
+              {
+                id: "openai-codex-secondary",
+                providerId: "openai-codex",
+                label: "Secondary",
+                kind: "oauth",
+              },
+            ],
+            activeByTab: { "tab-1": "openai-codex-primary" },
+            defaultByProvider: { "openai-codex": "openai-codex-primary" },
+          },
+        }}
+        onEvent={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Primary/i }));
+    fireEvent.click(screen.getByText("Secondary").closest("li")!);
+
+    await waitFor(() =>
+      expect(authProfileMocks.switchAccountForTab).toHaveBeenCalledWith(
+        "tab-1",
+        "openai-codex-secondary",
+        { cwd: "/repo", model: "openai-codex/gpt-5.5" },
+      ),
     );
   });
 });

--- a/src/extensions/default-layout/variation-components.tsx
+++ b/src/extensions/default-layout/variation-components.tsx
@@ -641,6 +641,13 @@ export function AccountSelector({
 
   const activeTabId =
     typeof state.activeTabId === "string" ? state.activeTabId : "default";
+  const activeTab = (
+    (state.tabs as Array<{
+      id: string;
+      model?: string;
+      authProfileId?: string;
+    }>) ?? []
+  ).find((t) => t.id === activeTabId);
 
   // Only offer accounts for the active tab's model provider — switching to a
   // profile from another provider would point the tab's auth at a provider
@@ -653,13 +660,20 @@ export function AccountSelector({
   if (selectable.length === 0) return null;
 
   // Resolve the *effective* account so the chip always reflects which one a
-  // prompt would actually use — even before the user explicitly picks one:
-  //   tab assignment → provider default → sole default → first profile.
+  // prompt would actually use — even before the user explicitly picks one.
+  // The tab mirror updates immediately on auth_profile_changed, while the
+  // snapshot map can lag until a later auth_profiles refresh; prefer the tab
+  // value so the header flips as soon as the switch lands.
+  const selectableIds = new Set(selectable.map((p) => p.id));
+  const firstSelectable = (...ids: Array<string | undefined>) =>
+    ids.find((id) => id && selectableIds.has(id));
   const resolvedId =
-    auth.activeByTab?.[activeTabId] ??
-    (tabProvider ? auth.defaultByProvider?.[tabProvider] : undefined) ??
-    soleDefault(auth.defaultByProvider) ??
-    selectable[0]?.id;
+    firstSelectable(
+      activeTab?.authProfileId,
+      auth.activeByTab?.[activeTabId],
+      tabProvider ? auth.defaultByProvider?.[tabProvider] : undefined,
+      soleDefault(auth.defaultByProvider),
+    ) ?? selectable[0]?.id;
   const activeProfile = selectable.find((p) => p.id === resolvedId);
   const usage = resolvedId ? auth.usage?.[resolvedId] : undefined;
 


### PR DESCRIPTION
## Summary
- prefer the active tab auth profile mirror when rendering the header account selector so the visible chip updates as soon as auth_profile_changed lands
- keep stale authProfiles.activeByTab/default snapshots as fallback only, which fixes Primary -> Secondary appearing stuck until the next message/auth refresh
- allow account switching while messages are only queued, while still blocking true in-flight prompts/running tool cards

## Root Cause
The account selector resolved the visible profile from authProfiles.activeByTab/defaults. During a switch, the tab mirror can update immediately while the auth profile snapshot lags until a later refresh. When the stale snapshot still pointed at Primary, switching Primary -> Secondary applied underneath but the header kept rendering Primary until another message caused the auth state to refresh.

## Tests
- TDD red: new AccountSelector regression failed because the button still rendered Primary when tab.authProfileId was Secondary and authProfiles.activeByTab was stale
- TDD red: queued-only account switch regression failed because queue state marked the tab busy
- bunx vitest run src/auth-profiles/commands.test.ts src/extensions/default-layout/variation-components.test.tsx
- bunx vitest run src/auth-profiles/commands.test.ts src/extensions/default-layout/variation-components.test.tsx src/hooks/useAppSlashCommandContext.test.ts src/hooks/useControlRequests.test.ts src/hooks/bridgeMessageHandlers/authProfiles.test.ts agent/auth-profiles/manager.test.ts
- bun run typecheck
- bun run lint
- bun run build
- bunx vitest run: one unrelated timeout in agent/session-history.test.ts, then isolated rerun of agent/session-history.test.ts passed

## UAT
- launched the real desktop shell with bun tauri dev
- verified live selector showed Secondary initially
- switched Secondary -> Primary and the header chip updated to Primary immediately
- switched Primary -> Secondary and the header chip updated to Secondary immediately, without sending a message between clicks