### PR TITLE
fix(auth): switch the codex account from the overview header

### DIFF
--- a/src/auth-profiles/commands.ts
+++ b/src/auth-profiles/commands.ts
@@ -48,6 +48,22 @@ export async function requestAuthProfiles(): Promise<void> {
 }
 
 /**
+ * Set the default account for a profile's provider. This is the account new
+ * tabs/tasks inherit (a fresh tab with no explicit binding resolves its
+ * account from `defaultByProvider` via the bridge's `defaultProfileIdForTab`).
+ * Used by the header account selector when no live agent tab is active (the
+ * overview), where there's no session to rebind — picking an account means
+ * "use this for new work on this provider".
+ */
+export async function setDefaultAccount(profileId: string): Promise<void> {
+  if (!profileId) return;
+  await sendAuthProfileCommand({
+    type: "auth_profile_set_default",
+    profileId,
+  });
+}
+
+/**
  * Switch the active account for a tab. The global bridge owns the auth
  * surface (`auth_profile_use_for_tab`), but a non-default tab runs its
  * prompts in a separate worker bridge that must also rebuild its session

--- a/src/auth-profiles/index.ts
+++ b/src/auth-profiles/index.ts
@@ -1,2 +1,3 @@
 export * from "./types";
 export * from "./commands";
+export * from "./selection";

--- a/src/auth-profiles/selection.test.ts
+++ b/src/auth-profiles/selection.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  accountsForProvider,
+  providerOfModelId,
+  resolveSelectableProfileId,
+  soleDefaultProfileId,
+} from "./selection";
+
+const codexPrimary = { id: "codex-primary", providerId: "openai-codex" };
+const codexSecondary = { id: "codex-secondary", providerId: "openai-codex" };
+const anthropic = { id: "anthropic-main", providerId: "anthropic" };
+const profiles = [codexPrimary, codexSecondary, anthropic];
+
+describe("providerOfModelId", () => {
+  it("extracts the provider prefix", () => {
+    expect(providerOfModelId("openai-codex/gpt-5.5")).toBe("openai-codex");
+  });
+  it("returns undefined without a provider prefix", () => {
+    expect(providerOfModelId("gpt-5.5")).toBeUndefined();
+    expect(providerOfModelId(undefined)).toBeUndefined();
+    expect(providerOfModelId("")).toBeUndefined();
+  });
+});
+
+describe("accountsForProvider", () => {
+  it("filters to the model's provider", () => {
+    expect(accountsForProvider(profiles, "openai-codex")).toEqual([
+      codexPrimary,
+      codexSecondary,
+    ]);
+  });
+  it("returns all profiles when the provider is unknown", () => {
+    expect(accountsForProvider(profiles, undefined)).toEqual(profiles);
+  });
+  it("returns an empty list when no profile backs the provider", () => {
+    expect(accountsForProvider(profiles, "google")).toEqual([]);
+  });
+});
+
+describe("soleDefaultProfileId", () => {
+  it("returns the only default when exactly one provider is configured", () => {
+    expect(soleDefaultProfileId({ "openai-codex": "codex-primary" })).toBe(
+      "codex-primary",
+    );
+  });
+  it("returns undefined when zero or multiple defaults exist", () => {
+    expect(soleDefaultProfileId({})).toBeUndefined();
+    expect(soleDefaultProfileId(undefined)).toBeUndefined();
+    expect(
+      soleDefaultProfileId({ a: "codex-primary", b: "anthropic-main" }),
+    ).toBeUndefined();
+  });
+});
+
+describe("resolveSelectableProfileId", () => {
+  const selectable = [codexPrimary, codexSecondary];
+  it("picks the first candidate that is selectable", () => {
+    expect(
+      resolveSelectableProfileId(
+        selectable,
+        "anthropic-main", // not selectable for codex — skipped
+        "codex-secondary",
+      ),
+    ).toBe("codex-secondary");
+  });
+  it("falls back to the first selectable account when no candidate matches", () => {
+    expect(
+      resolveSelectableProfileId(selectable, undefined, "anthropic-main"),
+    ).toBe("codex-primary");
+  });
+  it("returns undefined when nothing is selectable", () => {
+    expect(resolveSelectableProfileId([], "codex-primary")).toBeUndefined();
+  });
+});

--- a/src/auth-profiles/selection.ts
+++ b/src/auth-profiles/selection.ts
@@ -1,0 +1,61 @@
+/**
+ * Account-selection helpers shared by the header `AccountSelector` and the
+ * task-launcher account chip. Both surfaces answer the same two questions:
+ *
+ *   1. which stored accounts can back a given model provider, and
+ *   2. which one would a prompt actually use by default
+ *
+ * Keeping the resolution in one place means the header and the launcher can
+ * never disagree about which account is "active" for a provider.
+ */
+
+/** Minimal account shape these helpers need — a subset of `AuthProfileMeta`. */
+export interface ProviderScopedProfile {
+  id: string;
+  providerId: string;
+}
+
+/** Provider id ("openai-codex") embedded in a model id
+ *  ("openai-codex/gpt-5.5"). Undefined when the model has no provider
+ *  prefix (or no model is selected yet). */
+export function providerOfModelId(
+  modelId: string | undefined,
+): string | undefined {
+  return typeof modelId === "string" && modelId.includes("/")
+    ? modelId.split("/")[0]
+    : undefined;
+}
+
+/** Accounts that can back `provider`. Switching to a profile from another
+ *  provider would point the session's auth at a provider that can't back the
+ *  current model, so we filter to the model's provider. When the provider is
+ *  unknown (no model yet), every profile is selectable. */
+export function accountsForProvider<T extends ProviderScopedProfile>(
+  profiles: readonly T[],
+  provider: string | undefined,
+): T[] {
+  return provider
+    ? profiles.filter((p) => p.providerId === provider)
+    : [...profiles];
+}
+
+/** When exactly one provider default is configured, use it as the global
+ *  fallback selection (covers the common single-provider setup where the
+ *  provider can't be inferred from the model id yet). */
+export function soleDefaultProfileId(
+  defaultByProvider: Record<string, string> | undefined,
+): string | undefined {
+  const values = Object.values(defaultByProvider ?? {});
+  return values.length === 1 ? values[0] : undefined;
+}
+
+/** Resolve the effective profile id from an ordered list of candidates,
+ *  keeping only ids that are actually selectable. Falls back to the first
+ *  selectable account so the chip always reflects a concrete choice. */
+export function resolveSelectableProfileId(
+  selectable: readonly ProviderScopedProfile[],
+  ...candidates: Array<string | undefined>
+): string | undefined {
+  const ids = new Set(selectable.map((p) => p.id));
+  return candidates.find((id) => id && ids.has(id)) ?? selectable[0]?.id;
+}

--- a/src/extensions/default-layout/variation-components.test.tsx
+++ b/src/extensions/default-layout/variation-components.test.tsx
@@ -10,6 +10,7 @@ import {
 
 const authProfileMocks = vi.hoisted(() => ({
   switchAccountForTab: vi.fn(() => Promise.resolve()),
+  setDefaultAccount: vi.fn(() => Promise.resolve()),
 }));
 
 vi.mock("../../auth-profiles", async (importOriginal) => {
@@ -17,6 +18,7 @@ vi.mock("../../auth-profiles", async (importOriginal) => {
   return {
     ...actual,
     switchAccountForTab: authProfileMocks.switchAccountForTab,
+    setDefaultAccount: authProfileMocks.setDefaultAccount,
   };
 });
 
@@ -33,6 +35,7 @@ afterEach(() => {
   cleanup();
   vi.unstubAllGlobals();
   authProfileMocks.switchAccountForTab.mockClear();
+  authProfileMocks.setDefaultAccount.mockClear();
 });
 
 describe("ModelPicker", () => {
@@ -291,5 +294,117 @@ describe("AccountSelector", () => {
         { cwd: "/repo", model: "openai-codex/gpt-5.5" },
       ),
     );
+  });
+
+  // The overview has no live agent session. Picking an account there must set
+  // the provider DEFAULT (which new tasks inherit), not rebind a phantom
+  // "default" tab — otherwise the header shows the unchanged provider default
+  // and the pick appears to do nothing.
+  const overviewState = {
+    activeTabId: "__overview__",
+    tabs: [],
+    defaultModel: "openai-codex/gpt-5.5",
+    authProfiles: {
+      profiles: [
+        {
+          id: "openai-codex-primary",
+          providerId: "openai-codex",
+          label: "Primary",
+          kind: "oauth",
+        },
+        {
+          id: "openai-codex-secondary",
+          providerId: "openai-codex",
+          label: "Secondary",
+          kind: "oauth",
+        },
+      ],
+      activeByTab: {},
+      defaultByProvider: { "openai-codex": "openai-codex-secondary" },
+    },
+  };
+
+  it("shows the provider default on the overview (no active agent tab)", () => {
+    render(
+      <AccountSelector
+        component={{ id: "account-selector", type: "account-selector", props: {} }}
+        state={overviewState}
+        onEvent={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /Secondary/i })).toBeTruthy();
+  });
+
+  it("sets the provider default (not a tab switch) when picking on the overview", async () => {
+    render(
+      <AccountSelector
+        component={{ id: "account-selector", type: "account-selector", props: {} }}
+        state={overviewState}
+        onEvent={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Secondary/i }));
+    fireEvent.click(screen.getByText("Primary").closest("li")!);
+
+    await waitFor(() =>
+      expect(authProfileMocks.setDefaultAccount).toHaveBeenCalledWith(
+        "openai-codex-primary",
+      ),
+    );
+    expect(authProfileMocks.switchAccountForTab).not.toHaveBeenCalled();
+  });
+
+  // A new tab launched from the overview resolves its model via
+  // modelForNewProjectTab, which prefers the active project's remembered model
+  // over the pi default. The selector must scope to *that* provider — not the
+  // pi default's — or it would show/set the wrong account.
+  it("scopes the overview selector to the project's remembered model provider", () => {
+    render(
+      <AccountSelector
+        component={{
+          id: "account-selector",
+          type: "account-selector",
+          props: {},
+        }}
+        state={{
+          activeTabId: "__overview__",
+          activeProjectId: "proj-a",
+          tabs: [],
+          // Header default empty → per-project memory wins over the pi default.
+          defaultModel: "",
+          piDefaultModel: "openai-codex/gpt-5.5",
+          projectModels: { "proj-a": "anthropic/claude-opus" },
+          authProfiles: {
+            profiles: [
+              {
+                id: "openai-codex-primary",
+                providerId: "openai-codex",
+                label: "Primary",
+                kind: "oauth",
+              },
+              {
+                id: "anthropic-main",
+                providerId: "anthropic",
+                label: "Anthropic",
+                kind: "oauth",
+              },
+            ],
+            activeByTab: {},
+            defaultByProvider: {
+              "openai-codex": "openai-codex-primary",
+              anthropic: "anthropic-main",
+            },
+          },
+        }}
+        onEvent={vi.fn()}
+      />,
+    );
+
+    // Scoped to anthropic (the project's remembered model) — shows the
+    // Anthropic account and offers no OpenAI account.
+    expect(screen.getByRole("button", { name: /Anthropic/i })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /Anthropic/i }));
+    expect(screen.queryByText("Primary")).toBeNull();
   });
 });

--- a/src/extensions/default-layout/variation-components.tsx
+++ b/src/extensions/default-layout/variation-components.tsx
@@ -17,6 +17,13 @@ import { resolvePointer } from "../../utils/jsonPointer";
 import { PI_DEFAULT_MODEL_SENTINEL } from "../../utils/modelPicker";
 import type { BuiltinComponentProps } from "../../components/A2UIRenderer";
 import type { Tab } from "../../types/tab";
+import {
+  accountsForProvider,
+  providerOfModelId,
+  resolveSelectableProfileId,
+  soleDefaultProfileId,
+} from "../../auth-profiles/selection";
+import { modelForNewProjectTab } from "../../hooks/tabOps/helpers";
 import type { VcsSlice } from "../../hooks/useVcsStatus";
 import { ciMeta, prMeta } from "./sidebar/vcs-presentation";
 import { absolutePathFor } from "./sidebar/fileTreeModel";
@@ -612,19 +619,7 @@ function activeTabModelProvider(
   activeTabId: string,
 ): string | undefined {
   const tabs = (state.tabs as Array<{ id: string; model?: string }>) ?? [];
-  const model = tabs.find((t) => t.id === activeTabId)?.model;
-  return typeof model === "string" && model.includes("/")
-    ? model.split("/")[0]
-    : undefined;
-}
-
-/** When exactly one provider default is configured, use it as the global
- *  fallback selection. */
-function soleDefault(
-  defaultByProvider: Record<string, string> | undefined,
-): string | undefined {
-  const values = Object.values(defaultByProvider ?? {});
-  return values.length === 1 ? values[0] : undefined;
+  return providerOfModelId(tabs.find((t) => t.id === activeTabId)?.model);
 }
 
 export function AccountSelector({
@@ -646,34 +641,57 @@ export function AccountSelector({
       id: string;
       model?: string;
       authProfileId?: string;
+      kind?: string;
     }>) ?? []
   ).find((t) => t.id === activeTabId);
+  // An active *agent* tab has a live session to rebind; the overview (or a
+  // shell/editor tab) does not — there a pick sets the provider default that
+  // new tasks inherit instead.
+  const isAgentTab = !!activeTab && (activeTab.kind ?? "agent") === "agent";
 
-  // Only offer accounts for the active tab's model provider — switching to a
-  // profile from another provider would point the tab's auth at a provider
-  // that can't back the current model. When the provider is unknown (no
-  // model yet), fall back to all profiles.
-  const tabProvider = activeTabModelProvider(state, activeTabId);
-  const selectable = tabProvider
-    ? profiles.filter((p) => p.providerId === tabProvider)
-    : profiles;
+  // Provider scoping. An agent tab scopes to its own model's provider.
+  // Otherwise (overview) scope to the provider of the model a task launched
+  // from here would actually boot with — `modelForNewProjectTab` folds in
+  // `/defaultModel`, per-project memory (`projectModels`), and the pi default
+  // in the same precedence the new tab uses — so the selector reflects and its
+  // `setDefaultAccount` targets the provider new work will run as.
+  const activeProjectId =
+    typeof state.activeProjectId === "string" ? state.activeProjectId : null;
+  const piDefaultModel =
+    typeof state.piDefaultModel === "string" ? state.piDefaultModel : "";
+  const newTabModel = modelForNewProjectTab(
+    state,
+    activeProjectId,
+    piDefaultModel,
+  );
+  const provider = isAgentTab
+    ? activeTabModelProvider(state, activeTabId)
+    : providerOfModelId(newTabModel);
+
+  // Only offer accounts for that provider — switching to a profile from
+  // another provider would point auth at a provider that can't back the
+  // model. When the provider is unknown, fall back to all profiles.
+  const selectable = accountsForProvider(profiles, provider);
   if (selectable.length === 0) return null;
 
   // Resolve the *effective* account so the chip always reflects which one a
   // prompt would actually use — even before the user explicitly picks one.
-  // The tab mirror updates immediately on auth_profile_changed, while the
-  // snapshot map can lag until a later auth_profiles refresh; prefer the tab
-  // value so the header flips as soon as the switch lands.
-  const selectableIds = new Set(selectable.map((p) => p.id));
-  const firstSelectable = (...ids: Array<string | undefined>) =>
-    ids.find((id) => id && selectableIds.has(id));
-  const resolvedId =
-    firstSelectable(
-      activeTab?.authProfileId,
-      auth.activeByTab?.[activeTabId],
-      tabProvider ? auth.defaultByProvider?.[tabProvider] : undefined,
-      soleDefault(auth.defaultByProvider),
-    ) ?? selectable[0]?.id;
+  // For an agent tab the tab mirror updates immediately on
+  // auth_profile_changed (snapshot can lag), so prefer it. For the overview
+  // the source of truth is the provider default (set via auth_profile_set_default).
+  const resolvedId = isAgentTab
+    ? resolveSelectableProfileId(
+        selectable,
+        activeTab?.authProfileId,
+        auth.activeByTab?.[activeTabId],
+        provider ? auth.defaultByProvider?.[provider] : undefined,
+        soleDefaultProfileId(auth.defaultByProvider),
+      )
+    : resolveSelectableProfileId(
+        selectable,
+        provider ? auth.defaultByProvider?.[provider] : undefined,
+        soleDefaultProfileId(auth.defaultByProvider),
+      );
   const activeProfile = selectable.find((p) => p.id === resolvedId);
   const usage = resolvedId ? auth.usage?.[resolvedId] : undefined;
 
@@ -707,7 +725,18 @@ export function AccountSelector({
       ]}
       onSelect={(_sectionId, itemId) => {
         import("../../auth-profiles").then(
-          ({ resolveAccountSwitchTarget, switchAccountForTab }) => {
+          ({
+            resolveAccountSwitchTarget,
+            switchAccountForTab,
+            setDefaultAccount,
+          }) => {
+            // No live agent session (overview / shell / editor): the pick sets
+            // the provider default that new tasks inherit, rather than binding
+            // a phantom "default" session whose change the header never shows.
+            if (!isAgentTab) {
+              void setDefaultAccount(itemId);
+              return;
+            }
             const target = resolveAccountSwitchTarget(
               (state.tabs as Tab[] | undefined) ?? [],
               activeTabId,


### PR DESCRIPTION
## Summary

The header account selector did nothing on the **overview** tab. With no active agent session, the switch targeted a phantom `"default"` tab via `auth_profile_use_for_tab`, while the display resolved to the (unchanged) provider default — so picking Primary/Secondary never stuck, and new work kept using the old account. This is the bug in the screenshot the user reported.

## Fix

On the overview (or a shell/editor tab) there is no live session to rebind. Picking an account there now sets the **provider default** (`auth_profile_set_default`) — which is exactly what a freshly-launched tab inherits, since the bridge's `defaultProfileIdForTab` resolves an unbound tab's account from `defaultByProvider`.

The header scopes to and displays the provider of the model a new tab would actually boot with, resolved through `modelForNewProjectTab` so **per-project remembered models** (not just `/defaultModel`) are honored. Active agent tabs keep their existing per-tab switch behavior.

- Extract shared account-resolution helpers into `auth-profiles/selection.ts` (provider scoping + effective-default resolution), used by the header.
- Add `setDefaultAccount` to the commands module.

## Scope note

An earlier iteration added a per-launch account chip to the task launcher plus `authProfileId` plumbing through the whole start-task path. That turned out unnecessary — a new tab with no explicit binding already inherits the provider default via `defaultProfileIdForTab` — so it was reverted. This PR is the minimal correct fix: the header is the single source of truth.

## Codex review

Codex flagged a P2: the overview selector originally scoped to `/defaultModel`, but new tabs resolve their model via `modelForNewProjectTab`, which can prefer a per-project remembered model of a different provider. Fixed by reusing `modelForNewProjectTab` for the scoping, with a regression test.

## Tests
- New `auth-profiles/selection.test.ts` (helper units).
- New `AccountSelector` cases: overview shows the provider default; picking on the overview calls `setDefaultAccount` (not a tab switch); overview scopes to the project's remembered-model provider.
- `tsc -b`, eslint (`src` + `agent`), full vitest (2605) all green.

## UAT (dev shell)
- On the overview, switching Secondary → Primary updates the header immediately and sets `defaultByProvider.openai-codex = openai-codex-primary`; switching back updates both.
- Verified a launched task with Primary selected runs its worker as Primary (agent replied; logs show the turn under the Primary account).