### PR TITLE
Fix Copilot auth device flow

### DIFF
--- a/agent/auth-profiles/manager.test.ts
+++ b/agent/auth-profiles/manager.test.ts
@@ -30,6 +30,7 @@ import {
 const tempDirs: string[] = [];
 
 afterEach(() => {
+  vi.restoreAllMocks();
   for (const dir of tempDirs.splice(0)) {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -183,6 +184,55 @@ describe("auth profile manager", () => {
           (message as { event?: { ok?: boolean } }).event?.ok === false,
       ),
     ).toBe(true);
+  });
+
+  it("emits OAuth completion target without pre-recording worker tab state", async () => {
+    const userDir = tempUserDir();
+    const state = withReadyState(makeState(userDir));
+    const sent: Record<string, unknown>[] = [];
+    const deps = {
+      send: (message: Record<string, unknown>) => sent.push(message),
+    } as DispatcherDeps;
+    vi.spyOn(AuthStorage.prototype, "login").mockImplementation(
+      (_providerId, callbacks) => {
+        callbacks.onAuth?.({
+          url: "https://github.com/login/device",
+          instructions: "Enter code: 1A2B-3C4D",
+        });
+        return Promise.resolve();
+      },
+    );
+
+    await handleAuthProfileMessage(state, deps, {
+      type: "auth_profile_login_start",
+      providerId: "github-copilot",
+      label: "Copilot Work",
+      tabId: "tab-worker",
+    });
+
+    await vi.waitFor(() => {
+      expect(sent).toContainEqual(
+        expect.objectContaining({
+          type: "auth_profile_login_event",
+          event: expect.objectContaining({
+            type: "complete",
+            targetTabId: "tab-worker",
+            ok: true,
+          }),
+        }),
+      );
+    });
+    const profileId = state.authProfiles.profiles[0]?.id;
+    expect(profileId).toBeTruthy();
+    expect(state.tabAuthProfileIds.has("tab-worker")).toBe(false);
+    expect(sent).toContainEqual(
+      expect.objectContaining({
+        type: "auth_profiles",
+        authProfiles: expect.objectContaining({
+          activeByTab: {},
+        }),
+      }),
+    );
   });
 
   it("falls back to the global model registry for stale or unsafe profile ids", () => {
@@ -371,6 +421,33 @@ describe("auth profile manager", () => {
     expect(state.tabAuthProfileIds.get("tab-worker")).toBe("openai-codex-other");
     expect(sent).toContainEqual(
       expect.objectContaining({ type: "notice", tabId: "tab-worker" }),
+    );
+  });
+
+  it("auth_profile_apply emits a change event after a worker tab switches", async () => {
+    const userDir = tempUserDir();
+    const state = withReadyState(makeState(userDir));
+    const profileId = addProfile(state, "openai-codex", "Codex Two");
+    saveAuthProfilesState(userDir, state.authProfiles);
+    state.tabs.set("tab-worker", fakeTab("openai-codex/gpt-5.5"));
+    const sent: Record<string, unknown>[] = [];
+    const deps = {
+      send: (m: Record<string, unknown>) => sent.push(m),
+    } as DispatcherDeps;
+
+    await handleAuthProfileMessage(state, deps, {
+      type: "auth_profile_apply",
+      tabId: "tab-worker",
+      profileId,
+    });
+
+    expect(state.tabAuthProfileIds.get("tab-worker")).toBe(profileId);
+    expect(sent).toContainEqual(
+      expect.objectContaining({
+        type: "auth_profile_changed",
+        tabId: "tab-worker",
+        profileId,
+      }),
     );
   });
 

--- a/agent/auth-profiles/manager.ts
+++ b/agent/auth-profiles/manager.ts
@@ -596,6 +596,7 @@ function handleOAuthStart(
           challengeId,
           profileId: meta.id,
           providerId,
+          targetTabId: pending.targetTabId,
           ok: true,
         },
       });
@@ -851,6 +852,11 @@ async function handleApplyForTab(
     initialModel: nextModel || desiredModel,
   });
   markProfileUsed(state, profile.id);
+  deps.send({
+    type: "auth_profile_changed",
+    tabId,
+    profileId: profile.id,
+  });
 }
 
 /**

--- a/src/auth-profiles/types.ts
+++ b/src/auth-profiles/types.ts
@@ -30,6 +30,7 @@ export interface AuthProfileLoginEvent {
   challengeId: string;
   profileId: string;
   providerId: string;
+  targetTabId?: string;
   url?: string;
   instructions?: string;
   message?: string;

--- a/src/extensions/default-layout/auth-profile-panel.test.tsx
+++ b/src/extensions/default-layout/auth-profile-panel.test.tsx
@@ -1,0 +1,158 @@
+// @vitest-environment jsdom
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AuthProfilePanel } from "./auth-profile-panel";
+import type { A2UIComponent } from "../../types/a2ui";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+const originalClipboardDescriptor = Object.getOwnPropertyDescriptor(
+  navigator,
+  "clipboard",
+);
+const originalExecCommandDescriptor = Object.getOwnPropertyDescriptor(
+  document,
+  "execCommand",
+);
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  if (originalClipboardDescriptor) {
+    Object.defineProperty(navigator, "clipboard", originalClipboardDescriptor);
+  } else {
+    Reflect.deleteProperty(navigator, "clipboard");
+  }
+  if (originalExecCommandDescriptor) {
+    Object.defineProperty(document, "execCommand", originalExecCommandDescriptor);
+  } else {
+    Reflect.deleteProperty(document, "execCommand");
+  }
+});
+
+function authPanel(): A2UIComponent {
+  return {
+    id: "auth-profile-panel",
+    type: "auth-profile-panel",
+  };
+}
+
+describe("AuthProfilePanel", () => {
+  it("shows OAuth device-code instructions from the provider auth event", async () => {
+    const writeText = vi.fn(() => Promise.resolve());
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+
+    render(
+      <AuthProfilePanel
+        component={authPanel()}
+        state={{
+          activeTabId: "default",
+          tabs: [],
+          authProfiles: {
+            modal: { open: true },
+            profiles: [],
+            defaultByProvider: {},
+            activeByTab: {},
+            providers: [
+              {
+                id: "github-copilot",
+                label: "GitHub Copilot",
+                kind: "oauth",
+                configured: false,
+                modelCount: 1,
+              },
+            ],
+            login: {
+              type: "auth",
+              challengeId: "challenge-1",
+              profileId: "copilot-work",
+              providerId: "github-copilot",
+              url: "https://github.com/login/device",
+              instructions: "Enter code: 1A2B-3C4D",
+            },
+          },
+        }}
+        onEvent={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/Enter code:/)).toBeTruthy();
+    const codeInput = screen.getByLabelText("Authentication code");
+    expect(codeInput).toBeInstanceOf(HTMLInputElement);
+    if (!(codeInput instanceof HTMLInputElement)) {
+      throw new Error("Expected authentication code input");
+    }
+    expect(codeInput.value).toBe("1A2B-3C4D");
+
+    fireEvent.focus(codeInput);
+    expect(codeInput.selectionStart).toBe(0);
+    expect(codeInput.selectionEnd).toBe("1A2B-3C4D".length);
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy" }));
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith("1A2B-3C4D"));
+    expect(screen.getByRole("button", { name: "Copied" })).toBeTruthy();
+  });
+
+  it("does not show copied when the fallback copy command fails", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: undefined,
+    });
+    const execCommand = vi.fn(() => false);
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand,
+    });
+
+    render(
+      <AuthProfilePanel
+        component={authPanel()}
+        state={{
+          activeTabId: "default",
+          tabs: [],
+          authProfiles: {
+            modal: { open: true },
+            profiles: [],
+            defaultByProvider: {},
+            activeByTab: {},
+            providers: [
+              {
+                id: "github-copilot",
+                label: "GitHub Copilot",
+                kind: "oauth",
+                configured: false,
+                modelCount: 1,
+              },
+            ],
+            login: {
+              type: "auth",
+              challengeId: "challenge-1",
+              profileId: "copilot-work",
+              providerId: "github-copilot",
+              url: "https://github.com/login/device",
+              instructions: "Enter code: 1A2B-3C4D",
+            },
+          },
+        }}
+        onEvent={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy" }));
+
+    await waitFor(() => expect(execCommand).toHaveBeenCalledWith("copy"));
+    expect(screen.getByRole("button", { name: "Copy" })).toBeTruthy();
+  });
+});

--- a/src/extensions/default-layout/auth-profile-panel.tsx
+++ b/src/extensions/default-layout/auth-profile-panel.tsx
@@ -485,6 +485,10 @@ function LoginStatus({
   onChange: (value: string) => void;
   onSubmit: (event: AuthProfileLoginEvent) => Promise<void>;
 }) {
+  const [copiedChallengeId, setCopiedChallengeId] = useState<string | null>(
+    null,
+  );
+
   if (!event) return null;
   if (event.type === "prompt") {
     return (
@@ -510,15 +514,79 @@ function LoginStatus({
     );
   }
   if (event.type === "auth" && event.url) {
+    const instructions = event.instructions?.trim();
+    const codeMatch = instructions?.match(
+      /^(.*?\bcode:\s*)([A-Za-z0-9-]+)(.*)$/i,
+    );
+    const codePrefix = codeMatch?.[1];
+    const deviceCode = codeMatch?.[2];
+    const codeSuffix = codeMatch?.[3]?.trim();
+    const copiedCode = copiedChallengeId === event.challengeId;
+    const copyDeviceCode = async () => {
+      if (!deviceCode) return;
+      const copied = await copyText(deviceCode);
+      setCopiedChallengeId(copied ? event.challengeId : null);
+    };
     return (
-      <p className="ae-settings-note">
-        Browser login opened. If it did not, open the provider login URL from
-        your browser.
-      </p>
+      <div className="ae-auth-login">
+        <p className="ae-settings-note">
+          Browser login opened. If it did not, open the provider login URL from
+          your browser.
+        </p>
+        {instructions && codePrefix && deviceCode ? (
+          <div className="ae-auth-instructions">
+            <span>{codePrefix}</span>
+            <div className="ae-auth-code-copy">
+              <input
+                className="ae-auth-code-input"
+                aria-label="Authentication code"
+                readOnly
+                value={deviceCode}
+                onClick={(e) => e.currentTarget.select()}
+                onFocus={(e) => e.currentTarget.select()}
+              />
+              <button
+                type="button"
+                className="ae-settings-secondary"
+                onClick={() => void copyDeviceCode()}
+              >
+                {copiedCode ? "Copied" : "Copy"}
+              </button>
+            </div>
+            {codeSuffix && <span>{codeSuffix}</span>}
+          </div>
+        ) : instructions ? (
+          <p className="ae-auth-instructions">{instructions}</p>
+        ) : null}
+      </div>
     );
   }
   if (event.message || event.error) {
     return <p className="ae-settings-note">{event.error ?? event.message}</p>;
   }
   return null;
+}
+
+async function copyText(text: string): Promise<boolean> {
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Fall back to selection copy below.
+    }
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.opacity = "0";
+  document.body.appendChild(textarea);
+  try {
+    textarea.select();
+    return document.execCommand("copy");
+  } finally {
+    textarea.remove();
+  }
 }

--- a/src/hooks/bridgeMessageHandlers/authProfiles.test.ts
+++ b/src/hooks/bridgeMessageHandlers/authProfiles.test.ts
@@ -1,12 +1,24 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { makeEmptyTab } from "../../types/tab";
 import {
   handleAuthProfileChanged,
+  handleAuthProfileLoginEvent,
   handleAuthProfiles,
 } from "./authProfiles";
 import { buildHandlerFixture } from "./testFixtures";
+import { clearTauriMocks, installTauriMocks } from "../../test/tauriMocks";
 
 describe("auth profile bridge handlers", () => {
+  let harness: ReturnType<typeof installTauriMocks>;
+
+  beforeEach(() => {
+    harness = installTauriMocks();
+  });
+
+  afterEach(() => {
+    clearTauriMocks();
+  });
+
   it("hydrates auth profiles and mirrors active profile ids onto tabs", () => {
     const tab = makeEmptyTab("default", "Tab 1");
     const { ctx, applySetState } = buildHandlerFixture({
@@ -129,6 +141,110 @@ describe("auth profile bridge handlers", () => {
     });
     expect(applySetState().authProfiles).toMatchObject({
       activeByTab: { default: "anthropic-work" },
+    });
+  });
+
+  it("asks an idle target worker tab to apply completed OAuth login", async () => {
+    const tab = {
+      ...makeEmptyTab("tab-1", "Tab 1"),
+      cwd: "/repo",
+      model: "github-copilot/gpt-5.5",
+    };
+    const { ctx, applySetState } = buildHandlerFixture({
+      state: {
+        activeTabId: "tab-1",
+        tabs: [tab],
+        authProfiles: {
+          profiles: [],
+          defaultByProvider: {},
+          providers: [],
+          activeByTab: {},
+        },
+      },
+    });
+
+    handleAuthProfileLoginEvent(
+      {
+        type: "auth_profile_login_event",
+        event: {
+          type: "complete",
+          challengeId: "challenge-1",
+          profileId: "copilot-work",
+          providerId: "github-copilot",
+          targetTabId: "tab-1",
+          ok: true,
+        },
+      },
+      ctx,
+    );
+
+    await vi.waitFor(() => {
+      expect(harness.invoke).toHaveBeenCalledWith("agent_command", {
+        payload: JSON.stringify({
+          type: "auth_profile_apply",
+          tabId: "tab-1",
+          profileId: "copilot-work",
+          cwd: "/repo",
+          model: "github-copilot/gpt-5.5",
+        }),
+      });
+    });
+    expect(applySetState().authProfiles).toMatchObject({
+      activeByTab: {},
+      login: expect.objectContaining({ ok: true }),
+    });
+  });
+
+  it("does not apply completed OAuth login to a busy target worker tab", () => {
+    const tab = {
+      ...makeEmptyTab("tab-1", "Tab 1"),
+      cwd: "/repo",
+      model: "github-copilot/gpt-5.5",
+      waiting: true,
+    };
+    const { ctx, mocks, applySetState } = buildHandlerFixture({
+      state: {
+        activeTabId: "tab-1",
+        tabs: [tab],
+        authProfiles: {
+          profiles: [],
+          defaultByProvider: {},
+          providers: [],
+          activeByTab: {},
+        },
+      },
+    });
+
+    handleAuthProfileLoginEvent(
+      {
+        type: "auth_profile_login_event",
+        event: {
+          type: "complete",
+          challengeId: "challenge-1",
+          profileId: "copilot-work",
+          providerId: "github-copilot",
+          targetTabId: "tab-1",
+          ok: true,
+        },
+      },
+      ctx,
+    );
+
+    expect(harness.invoke).not.toHaveBeenCalledWith(
+      "agent_command",
+      expect.objectContaining({
+        payload: expect.stringContaining("auth_profile_apply"),
+      }),
+    );
+    expect(mocks.pushNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Account ready",
+        kind: "info",
+      }),
+    );
+    expect(applySetState().authProfiles).toMatchObject({
+      activeByTab: {},
+      login: expect.objectContaining({ ok: true }),
     });
   });
 });

--- a/src/hooks/bridgeMessageHandlers/authProfiles.ts
+++ b/src/hooks/bridgeMessageHandlers/authProfiles.ts
@@ -7,7 +7,8 @@ import {
   type AuthProfilesSnapshot,
 } from "../../auth-profiles";
 import type { Tab } from "../../types/tab";
-import type { BridgeMessageHandler } from "./types";
+import { isAgentTabInFlight } from "../../utils/agentBusy";
+import type { BridgeMessageContext, BridgeMessageHandler } from "./types";
 
 type AuthProfilesState = AuthProfilesSnapshot & {
   modal?: { open?: boolean };
@@ -115,6 +116,7 @@ export const handleAuthProfileLoginEvent: BridgeMessageHandler = (
       message: event.error,
       kind: event.ok ? "success" : "error",
     });
+    applyCompletedLoginToWorker(event, ctx);
   }
   ctx.setState((prev) => {
     const current = (prev.authProfiles as AuthProfilesState | undefined) ?? {};
@@ -132,7 +134,41 @@ export const handleAuthProfileLoginEvent: BridgeMessageHandler = (
   });
 };
 
-export const handleAuthProfileChanged: BridgeMessageHandler = (message, ctx) => {
+function applyCompletedLoginToWorker(
+  event: AuthProfileLoginEvent,
+  ctx: BridgeMessageContext,
+): void {
+  if (event.ok !== true || !event.profileId) return;
+  const tabId = event.targetTabId;
+  if (!tabId || tabId === "default") return;
+  const tab = ((ctx.stateRef.current.tabs as Tab[] | undefined) ?? []).find(
+    (candidate) =>
+      candidate.id === tabId && (candidate.kind ?? "agent") === "agent",
+  );
+  if (!tab) return;
+  if (isAgentTabInFlight(tab)) {
+    ctx.pushNotification({
+      title: "Account ready",
+      message: "Stop the current prompt before switching this tab to the new account.",
+      kind: "info",
+    });
+    return;
+  }
+  void sendAuthProfileCommand({
+    type: "auth_profile_apply",
+    tabId,
+    profileId: event.profileId,
+    ...(tab?.cwd ? { cwd: tab.cwd } : {}),
+    ...(tab?.model ? { model: tab.model } : {}),
+  }).catch(() => {
+    /* bridge restart / reload — auth profile is persisted, ignore */
+  });
+}
+
+export const handleAuthProfileChanged: BridgeMessageHandler = (
+  message,
+  ctx,
+) => {
   const tabId = typeof message.tabId === "string" ? message.tabId : undefined;
   const profileId =
     typeof message.profileId === "string" ? message.profileId : undefined;
@@ -147,14 +183,14 @@ export const handleAuthProfileChanged: BridgeMessageHandler = (message, ctx) => 
     ...prev,
     authProfiles: {
       ...(prev.authProfiles ?? {
-          profiles: [],
-          defaultByProvider: {},
-          providers: [],
-          activeByTab: {},
-        }),
+        profiles: [],
+        defaultByProvider: {},
+        providers: [],
+        activeByTab: {},
+      }),
       activeByTab: {
-        ...((prev.authProfiles as AuthProfilesState | undefined)
-          ?.activeByTab ?? {}),
+        ...((prev.authProfiles as AuthProfilesState | undefined)?.activeByTab ??
+          {}),
         [tabId]: profileId,
       },
     },

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -6548,6 +6548,36 @@ body.ae-resizing-terminal * {
   border-radius: var(--radius-md);
   background: color-mix(in oklab, var(--accent) 5%, transparent);
 }
+.ae-auth-instructions {
+  margin: var(--space-2) 0 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  align-items: center;
+  color: var(--fg);
+  font-size: 13px;
+}
+.ae-auth-code-copy {
+  display: inline-flex;
+  gap: var(--space-2);
+  align-items: center;
+  min-width: 0;
+}
+.ae-auth-code-input {
+  width: 132px;
+  max-width: 100%;
+  padding: 4px 8px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  background: var(--bg-elev);
+  color: var(--fg);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-align: center;
+  user-select: all;
+}
 .ae-auth-list {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- show provider-supplied OAuth device codes in the Accounts panel instead of only opening the browser
- render GitHub Copilot device codes as a selectable read-only field with a Copy button and clipboard fallback
- apply completed OAuth logins to the target worker tab without requiring a full app restart
- avoid split-brain auth state by only recording worker tab profile changes after successful `auth_profile_apply`

## Root Cause
Copilot OAuth was already receiving device-code instructions from the provider (`Enter code: ...`), but the Accounts UI ignored those instructions and only displayed that the browser login opened. Separately, a completed OAuth login updated persisted/global auth state but did not reliably refresh the already-running per-tab worker, so the tab could keep using old credentials until app restart.

## Fix
The auth panel now parses and displays provider instructions, extracting the device code into a copy-friendly input. OAuth completion now carries `targetTabId` through the event, asks an idle target worker to apply the profile, and waits for the worker's successful `auth_profile_changed` event to update frontend/global active state. Busy target tabs are not updated optimistically; users get a notice to stop the current prompt before switching that tab.

## Validation
- Codex subagent peer review: initial blocking race found and fixed; follow-up review reported no blockers
- Live Aethon UAT via debug webview: synthetic Copilot auth event rendered `1A2B-3C4D`, selected the full code on focus, Copy changed to Copied, and synthetic state was restored
- `bunx vitest run agent/auth-profiles/manager.test.ts src/hooks/bridgeMessageHandlers/authProfiles.test.ts src/extensions/default-layout/auth-profile-panel.test.tsx`
- `bun run typecheck`
- `bunx vitest run`
- `bunx eslint . --ignore-pattern '.understand-anything/.trash-*'`
- `git diff --check`

## Note
Local `bun run lint` currently trips over ignored `.understand-anything/.trash-*` files in this checkout. The full-tree ESLint command above excludes only that ignored local trash directory and passes.
