### PR TITLE
fix: restore root workspace tabs from main row

### DIFF
--- a/src/eventRoutes/sidebar.test.ts
+++ b/src/eventRoutes/sidebar.test.ts
@@ -312,6 +312,13 @@ describe("handleSidebarSwitchWorkspace", () => {
           iconUrl: "asset://localhost/project-icons/aethon.png",
           workspaces: [
             {
+              id: "wt-main",
+              label: "main",
+              branch: "main",
+              path: "/repo/aethon",
+              isMain: true,
+            },
+            {
               id: "wt-1",
               label: "fix/issue",
               branch: "fix/issue",
@@ -344,6 +351,36 @@ describe("handleSidebarSwitchWorkspace", () => {
       iconUrl: "asset://localhost/project-icons/aethon.png",
       workspaceId: "wt-1",
       path: "/repo/aethon-fix-issue",
+    });
+  });
+
+  it("routes the expanded main workspace row through the project root scope", async () => {
+    const { ctx, mocks, applySetState } = buildRouteFixture({
+      state: {
+        ...sidebarState,
+        activeProjectId: "proj-2",
+        activeWorkspaceId: "wt-other",
+      },
+    });
+
+    const handled = await handleSidebarSwitchWorkspace(
+      {
+        component: { id: "sidebar" },
+        eventType: "switch-workspace",
+        data: { workspaceId: "wt-main" },
+      },
+      ctx,
+    );
+
+    expect(handled).toBe(true);
+    expect(mocks.setActiveProjectById).toHaveBeenCalledWith("proj-1");
+    expect(mocks.activateWorkspace).toHaveBeenCalledWith(null);
+    expect(applySetState().landing).toMatchObject({
+      kind: "workspace",
+      projectId: "proj-1",
+      workspaceId: "wt-main",
+      isMain: true,
+      path: "/repo/aethon",
     });
   });
 

--- a/src/eventRoutes/sidebar/workspace.ts
+++ b/src/eventRoutes/sidebar/workspace.ts
@@ -54,9 +54,17 @@ export const handleSidebarSwitchWorkspace: EventRouteHandler = (
   for (const project of sidebar.projects ?? []) {
     const workspace = project.workspaces?.find((w) => w.id === workspaceId);
     if (workspace) {
+      const activeProjectId = ctx.stateRef.current.activeProjectId;
+      const activeWorkspaceId = ctx.stateRef.current.activeWorkspaceId;
+      const routeWorkspaceId = workspace.isMain === true ? null : workspace.id;
       const wasAlreadyActiveWorkspace =
-        ctx.stateRef.current.activeWorkspaceId === workspaceId;
-      ctx.activateWorkspace(workspaceId);
+        workspace.isMain === true
+          ? activeProjectId === project.id && activeWorkspaceId == null
+          : activeWorkspaceId === workspace.id;
+      if (workspace.isMain === true) {
+        ctx.setActiveProjectById(project.id);
+      }
+      ctx.activateWorkspace(routeWorkspaceId);
       const tabs = Array.isArray(ctx.stateRef.current.tabs)
         ? ctx.stateRef.current.tabs
         : [];

--- a/src/hooks/projectOps/workspaceOps/state.ts
+++ b/src/hooks/projectOps/workspaceOps/state.ts
@@ -81,12 +81,12 @@ export function activateWorkspace(
   workspaceId: string | null,
 ): void {
   const current = deps.projectsRef.current;
-  if (current.activeWorkspaceId === workspaceId) return;
   const fromKey = projectScopeBucketKey(
     current.activeId,
     current.activeWorkspaceId,
   );
   let activeProjectId = current.activeId;
+  let nextWorkspaceId = workspaceId;
   let nextCwd: string | null;
   let nextProjectPath: string | null;
   if (workspaceId) {
@@ -95,10 +95,19 @@ export function activateWorkspace(
     activeProjectId = hit.project.id;
     nextCwd = hit.workspace.path;
     nextProjectPath = hit.project.path;
+    if (hit.workspace.isMain) {
+      nextWorkspaceId = null;
+    }
   } else {
     const project = activeProject(current);
     nextCwd = project?.path ?? null;
     nextProjectPath = project?.path ?? null;
+  }
+  if (
+    current.activeId === activeProjectId &&
+    current.activeWorkspaceId === nextWorkspaceId
+  ) {
+    return;
   }
   const previousActive = activeProject(current);
   const crossingProjects =
@@ -108,11 +117,11 @@ export function activateWorkspace(
     previousActive.path !== nextProjectPath;
   deps.projectsRef.current = setActiveWorkspaceState(
     { ...current, activeId: activeProjectId },
-    workspaceId,
+    nextWorkspaceId,
   );
   const nextTabId = deps.switchProjectBucket(
     fromKey,
-    projectScopeBucketKey(activeProjectId, workspaceId),
+    projectScopeBucketKey(activeProjectId, nextWorkspaceId),
     { mirrorProjects: true },
   );
   deps.scheduleProjectsSave();

--- a/src/hooks/useProjectOps.test.ts
+++ b/src/hooks/useProjectOps.test.ts
@@ -360,6 +360,72 @@ describe("useProjectOps session scoping", () => {
     expect(stateRef.current.activeTabId).toBe("root-tab");
   });
 
+  it("treats the expanded main workspace row as the project root bucket", () => {
+    const rootTab = nonEmptyAgentTab(
+      "root-tab",
+      "Root chat",
+      "project-1",
+      "/projects/aethon",
+    );
+    const workspaceTab = nonEmptyAgentTab(
+      "workspace-tab",
+      "Workspace chat",
+      "project-1",
+      "/projects/aethon-fix-issue",
+    );
+    const { result, stateRef, projectsRef } = renderProjectOps(
+      makeProjectsState({
+        activeId: "project-1",
+        activeWorkspaceId: "wt-issue",
+        workspacesByProject: {
+          "project-1": [
+            {
+              id: "wt-main",
+              projectId: "project-1",
+              path: "/projects/aethon",
+              branch: "main",
+              isMain: true,
+            },
+            {
+              id: "wt-issue",
+              projectId: "project-1",
+              path: "/projects/aethon-fix-issue",
+              branch: "fix/issue",
+              isMain: false,
+            },
+          ],
+        },
+      }),
+    );
+    result.current.tabBucketsRef.current.set(
+      projectScopeBucketKey("project-1", null),
+      {
+        tabs: [rootTab],
+        activeTabId: "root-tab",
+      },
+    );
+    stateRef.current = {
+      ...stateRef.current,
+      tabs: [workspaceTab],
+      activeTabId: "workspace-tab",
+    };
+
+    act(() => {
+      result.current.activateWorkspace("wt-main");
+    });
+
+    expect(projectsRef.current.activeWorkspaceId).toBeNull();
+    expect((stateRef.current.tabs as Tab[]).map((t) => t.id)).toEqual([
+      "root-tab",
+    ]);
+    expect(stateRef.current.activeTabId).toBe("root-tab");
+    expect(
+      result.current.tabBucketsRef.current.has(
+        projectScopeBucketKey("project-1", "wt-main"),
+      ),
+    ).toBe(false);
+  });
+
   it("clears stale landing when activateWorkspace restores a saved tab", () => {
     const workspaceTab = {
       ...nonEmptyAgentTab("workspace-tab", "Workspace chat", "project-1"),


### PR DESCRIPTION
## Summary
- canonicalize the expanded `main` workspace row back to the project root bucket
- route sidebar clicks on a main workspace through `setActiveProjectById(project.id)` + `activateWorkspace(null)`
- add regression coverage for both the hook bucket restore and sidebar route behavior

## Root Cause
The expanded `main` workspace row has a workspace id, but root checkout sessions are scoped to the project bucket where `workspaceId === null`. Clicking the nested main row routed through the synthetic workspace id and restored from `project::workspace::<main-id>`, so the real root session bucket was skipped when returning from another project/workspace.

## Verification
- red first: `bunx vitest run src/hooks/useProjectOps.test.ts -t "treats the expanded main workspace row"` failed before the fix with `expected 'wt-main' to be null`
- `bunx vitest run src/hooks/useProjectOps.test.ts -t "treats the expanded main workspace row"`
- `bunx vitest run src/eventRoutes/sidebar.test.ts -t "routes the expanded main workspace row"`
- `bunx vitest run src/hooks/useProjectOps.test.ts`
- `bunx vitest run src/eventRoutes/sidebar.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bunx vitest run` (313 files / 2613 tests)

## UAT
- launched the patched dev app with `nix develop -c dev`
- from Aethon feature workspace, clicked the nested Aethon `main` workspace row
- confirmed app state selected the root bucket: `activeWorkspaceId === null`
- confirmed the restored root session tab stayed selected: `Duplicate Tool Cards` with cwd `/Users/jamesbrink/Projects/utensils/aethon`
- navigated away to `nxv`, then back to the top-level Aethon project
- confirmed the same root session tab remained active on return

Note: the dev UAT console still printed existing React duplicate-key warnings from the `nxv` project view (`Update Package Index`), unrelated to this patch.
