### PR TITLE
fix: preserve error message chronology

### DIFF
--- a/src/hooks/bridgeMessageHandlers/error.test.ts
+++ b/src/hooks/bridgeMessageHandlers/error.test.ts
@@ -1,9 +1,15 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { handleError } from "./error";
+import { handleSessionHistory } from "./sessionHistory";
 import { buildHandlerFixture } from "./testFixtures";
 import { makeEmptyTab } from "../../types/tab";
+import type { ChatMessage } from "../../types/a2ui";
 
 describe("handleError", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("appends an error message, clears waiting, sets error status when active", () => {
     const { ctx, mocks } = buildHandlerFixture({
       state: { activeTabId: "default" },
@@ -21,5 +27,64 @@ describe("handleError", () => {
     const [, updater] = mocks.updateTab.mock.calls[0];
     expect(updater(makeEmptyTab("default", "Tab 1")).waiting).toBe(false);
     expect(mocks.setStatusFlags).toHaveBeenCalledWith({ status: "error" });
+  });
+
+  it("keeps API errors chronological when restored history rehydrates later", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-22T10:00:02.000Z"));
+
+    const errorFixture = buildHandlerFixture({
+      state: { activeTabId: "tab-1" },
+    });
+    handleError(
+      {
+        type: "error",
+        message:
+          '{"type":"error","error":{"type":"invalid_request_error","message":"Your credit balance is too low"}}',
+        tabId: "tab-1",
+      },
+      errorFixture.ctx,
+    );
+    const localError = errorFixture.mocks.appendMessage.mock
+      .calls[0][0] as ChatMessage;
+
+    const historyFixture = buildHandlerFixture();
+    handleSessionHistory(
+      {
+        type: "session_history",
+        tabId: "tab-1",
+        messages: [
+          {
+            id: "before-error",
+            role: "agent",
+            text: "Tool output before the API error",
+            createdAt: Date.parse("2026-06-22T10:00:01.000Z"),
+          },
+          {
+            id: "after-error",
+            role: "agent",
+            text: "Later restored response",
+            createdAt: Date.parse("2026-06-22T10:00:03.000Z"),
+          },
+        ],
+      },
+      historyFixture.ctx,
+    );
+    const [, updater] = historyFixture.mocks.updateTab.mock.calls[0];
+    const out = updater({
+      ...makeEmptyTab("tab-1", "Tab 1"),
+      messages: [localError],
+    });
+
+    expect(out.messages.map((m: ChatMessage) => m.id)).toEqual([
+      "before-error",
+      localError.id,
+      "after-error",
+    ]);
+    expect(localError).toMatchObject({
+      role: "agent",
+      text: expect.stringContaining("Your credit balance is too low"),
+      createdAt: Date.parse("2026-06-22T10:00:02.000Z"),
+    });
   });
 });

--- a/src/hooks/bridgeMessageHandlers/error.ts
+++ b/src/hooks/bridgeMessageHandlers/error.ts
@@ -13,7 +13,12 @@ export const handleError: BridgeMessageHandler = (data, ctx) => {
   }
   ctx.activeResponseIdRef.current = null;
   ctx.appendMessage(
-    { id: crypto.randomUUID(), role: "agent", text: `Error: ${message}` },
+    {
+      id: crypto.randomUUID(),
+      role: "agent",
+      text: `Error: ${message}`,
+      createdAt: Date.now(),
+    },
     tabId,
   );
   ctx.updateTab(tabId, (tab) => {


### PR DESCRIPTION
## Summary

- timestamp bridge error chat messages when they are created
- add a regression that reproduces an API error being pushed below later restored history during hydration
- verify the timestamp lets the existing session-history merge keep the error at its original chronological position

## Root Cause

`handleError` appended API/provider errors as agent messages without `createdAt`. When a tab later rehydrated restored session history, the session-history merge could sort timestamped local messages, but untimestamped error bubbles had to be appended after restored messages. That made an older API error jump to the bottom of the chat after workspace switches or other rerenders.

## Validation

- Red first: `bunx vitest run src/hooks/bridgeMessageHandlers/error.test.ts` failed with `before-error`, `after-error`, then the API error
- Green focused: `bunx vitest run src/hooks/bridgeMessageHandlers/error.test.ts`
- Nearby slice: `bunx vitest run src/hooks/bridgeMessageHandlers/error.test.ts src/hooks/bridgeMessageHandlers/sessionHistory.test.ts src/hooks/useChat.test.ts`
- Full frontend tests: `bunx vitest run` (313 files, 2612 tests)
- Typecheck: `bun run typecheck`
- Lint: `bun run lint`
- UAT before: running dev app rendered `UAT BEFORE API ERROR` -> `UAT AFTER RESTORED WORK` -> `Error: UAT CREDIT BALANCE API ERROR`
- UAT after: running dev app rendered `UAT BEFORE API ERROR` -> `Error: UAT CREDIT BALANCE API ERROR` -> `UAT AFTER RESTORED WORK`
