### PR TITLE
fix: prevent voice composer status overlap

### DIFF
--- a/e2e/aethon.spec.ts
+++ b/e2e/aethon.spec.ts
@@ -66,6 +66,46 @@ async function getActiveTurnState(page: Page): Promise<ActiveTurnState> {
   }
 }
 
+async function getComposerRightOverlayGeometry(
+  page: Page,
+  overlaySelector: string,
+): Promise<{
+  overlayRight: number;
+  firstActionLeft: number;
+  actionLane: string;
+  textareaPaddingRight: string;
+}> {
+  return await page.locator(".a2ui-chat-input-field-wrap").evaluate(
+    (wrap, selector) => {
+      const overlay = wrap.querySelector(selector);
+      const conversation = wrap.querySelector(".a2ui-chat-input-conversation");
+      const voice = wrap.querySelector(
+        ".a2ui-chat-input-voice:not(.a2ui-chat-input-conversation)",
+      );
+      const send = wrap.querySelector(".a2ui-chat-input-send");
+      const textarea = wrap.querySelector(".a2ui-chat-input-field");
+      if (!overlay || !conversation || !voice || !send || !textarea) {
+        throw new Error("expected composer overlay and voice controls");
+      }
+      const overlayRect = overlay.getBoundingClientRect();
+      const actionRects = [conversation, voice, send].map((el) =>
+        el.getBoundingClientRect(),
+      );
+      const wrapStyle = getComputedStyle(wrap);
+      const textareaStyle = getComputedStyle(textarea);
+      return {
+        overlayRight: overlayRect.right,
+        firstActionLeft: Math.min(...actionRects.map((rect) => rect.left)),
+        actionLane: wrapStyle
+          .getPropertyValue("--a2ui-chat-input-action-lane")
+          .trim(),
+        textareaPaddingRight: textareaStyle.paddingRight,
+      };
+    },
+    overlaySelector,
+  );
+}
+
 async function completeActiveTurn(page: Page): Promise<void> {
   await page.evaluate(() => {
     window.__AETHON_E2E__?.completeActiveTurn();
@@ -212,6 +252,36 @@ test("chat canvas contains wide content without horizontal scrolling", async ({
   );
 });
 
+test("voice transcribing status does not overlap composer action buttons", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 900, height: 700 });
+  await waitForAethonReady(page);
+
+  await page.getByRole("button", { name: "New Tab" }).click();
+  await expect(page.locator(".a2ui-chat-input-field")).toBeVisible();
+
+  await page.getByRole("button", { name: "Voice input" }).click();
+  await expect(
+    page.getByRole("button", { name: "Stop voice input" }),
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: "Stop voice input" }).click();
+  await expect(page.locator(".a2ui-chat-input-voice-status")).toContainText(
+    "Transcribing",
+  );
+
+  const geometry = await getComposerRightOverlayGeometry(
+    page,
+    ".a2ui-chat-input-voice-status",
+  );
+
+  expect(geometry.overlayRight).toBeLessThanOrEqual(
+    geometry.firstActionLeft - 4,
+  );
+  expect(geometry.textareaPaddingRight).toBe(geometry.actionLane);
+});
+
 test("queues normal Enter messages behind an in-flight turn and drains cleanly", async ({
   page,
 }) => {
@@ -236,6 +306,13 @@ test("queues normal Enter messages behind an in-flight turn and drains cleanly",
   await page.keyboard.press("Enter");
 
   await expect(page.locator(".a2ui-chat-input-queue")).toHaveText("+1");
+  const queueGeometry = await getComposerRightOverlayGeometry(
+    page,
+    ".a2ui-chat-input-queue",
+  );
+  expect(queueGeometry.overlayRight).toBeLessThanOrEqual(
+    queueGeometry.firstActionLeft - 4,
+  );
   await expect(page.locator(".a2ui-tab-active")).toContainText("+1");
   await expect(page.locator(".a2ui-queued-popover")).toBeVisible();
   await expect(page.locator(".a2ui-queued-message")).toHaveCount(1);

--- a/e2e/support/aethon-harness.ts
+++ b/e2e/support/aethon-harness.ts
@@ -272,6 +272,13 @@ export async function installAethonHarness(page: Page): Promise<void> {
                 inheritEnv: true,
                 promptBeforeClose: true,
               },
+              voice: {
+                toggleHotkey: "mod+shift+m",
+                holdHotkey: null,
+                speakAgentReplies: false,
+                speakMaxChars: 600,
+                conversationContinuous: false,
+              },
               shortcuts: { newTabKind: "agent" },
             };
           case "read_state":
@@ -337,6 +344,37 @@ export async function installAethonHarness(page: Page): Promise<void> {
           case "set_extension_menu_items":
           case "start_agent":
             return undefined;
+          case "voice_list_providers":
+            return [
+              {
+                id: "voice-platform-system",
+                name: "System dictation",
+                description: "E2E voice provider",
+                kind: "platform",
+                recordingMode: "native",
+                privacyLabel: "Local",
+                offline: true,
+                downloadRequired: false,
+                modelSizeLabel: null,
+                cachePath: null,
+                acceleratorLabel: null,
+                status: "ready",
+                statusLabel: "Ready",
+                enabled: true,
+                selected: true,
+                setupRequired: false,
+                canRemoveModel: false,
+                error: null,
+              },
+            ];
+          case "voice_start_recording":
+          case "voice_cancel_recording":
+            return undefined;
+          case "voice_stop_and_transcribe":
+            return new Promise(() => {
+              // Keep the composer in its transcribing state so visual layout
+              // regressions around the status strip can be measured.
+            });
           case "workspace_startup_prepare_for_path": {
             const cwdArgs =
               args.args && typeof args.args === "object"

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -3817,6 +3817,7 @@ body.ae-resizing-composer * {
    absolute-positioned INSIDE the textarea's visual footprint. The
    textarea fills the wrap; the button overlays its bottom-right. */
 .a2ui-chat-input-field-wrap {
+  --a2ui-chat-input-action-lane: 116px;
   position: relative;
   display: flex;
   min-width: 0;
@@ -4074,8 +4075,8 @@ body.ae-resizing-composer * {
   /* Right padding clears the absolute-positioned Send button so text
      doesn't run under it. Bottom padding clears the Send button when
      the user types multiple lines. Right padding reserves room for the
-     full three-button cluster (send + mic + conversation, out to ~108px). */
-  padding: 10px 116px 10px 12px;
+     full three-button cluster (send + mic + conversation). */
+  padding: 10px var(--a2ui-chat-input-action-lane) 10px 12px;
   font: inherit;
   outline: none;
   line-height: 1.5;
@@ -4226,9 +4227,9 @@ body.ae-resizing-composer * {
 .a2ui-chat-input-voice-status,
 .a2ui-chat-input-voice-error {
   position: absolute;
-  right: 82px;
+  right: var(--a2ui-chat-input-action-lane);
   bottom: 12px;
-  max-width: min(340px, calc(100% - 120px));
+  max-width: min(340px, calc(100% - var(--a2ui-chat-input-action-lane) - 16px));
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -4453,7 +4454,7 @@ body.ae-resizing-composer * {
    with the action buttons. */
 .a2ui-chat-input-queue {
   position: absolute;
-  right: 82px;
+  right: var(--a2ui-chat-input-action-lane);
   bottom: 12px;
   padding: 2px 8px;
   border-radius: 999px;


### PR DESCRIPTION
## Summary
- reserve the composer action lane with a shared CSS variable so voice status/error text ends before the action buttons
- add E2E voice IPC stubs and a browser geometry regression for the transcribing state

## UAT
- Before: live composer voice status right edge was 824px while the first action button started at 798px, overlapping by about 26px
- After: live composer status right edge is 790px while the first action button starts at 798px, leaving an 8px gap
- Before screenshot: /tmp/aethon-voice-overlap-before.png
- After screenshot: /tmp/aethon-voice-overlap-after.png

## Validation
- bun run typecheck
- bun run lint
- bunx tsc -p tsconfig.e2e.json --noEmit
- bunx playwright test e2e/aethon.spec.ts -g "voice transcribing status"