### PR TITLE
fix: compact completed turns after live threshold

### DIFF
--- a/agent/tab-lifecycle.test.ts
+++ b/agent/tab-lifecycle.test.ts
@@ -1316,6 +1316,59 @@ describe("handleSessionEvent", () => {
     }
   });
 
+  it("auto-compacts after a completed turn when live output crossed the threshold", async () => {
+    const f = makeFixture();
+    f.state.settingsManager = {
+      getCompactionSettings: () => ({
+        enabled: true,
+        reserveTokens: 200,
+        keepRecentTokens: 100,
+      }),
+    } as unknown as AethonAgentState["settingsManager"];
+    const compact = vi.fn(() => Promise.resolve({ tokensBefore: 1_850 }));
+    const rec = fakeRec("anthropic/claude-x");
+    rec.promptInFlight = true;
+    rec.contextUsageTransientTokens = 150;
+    rec.session = {
+      ...rec.session,
+      model: {
+        id: "claude-x",
+        provider: "anthropic",
+        name: "Claude X",
+        contextWindow: 2_000,
+      },
+      getContextUsage: () => ({
+        tokens: 1_700,
+        contextWindow: 2_000,
+        percent: 85,
+      }),
+      compact,
+    } as unknown as TabRecord["session"];
+    f.state.tabs.set("tab-1", rec);
+    f.state.currentAgentTabId = "tab-1";
+
+    handleSessionEvent(f.state, f.deps, rec, "tab-1", {
+      type: "agent_end",
+      messages: [{ role: "assistant", stopReason: "stop" }],
+    });
+
+    expect(compact).toHaveBeenCalledOnce();
+    expect(rec.promptInFlight).toBe(true);
+    expect(f.sent).toContainEqual({
+      type: "notice",
+      tabId: "tab-1",
+      busy: true,
+      message: "Context threshold reached; compacting before the next turn...",
+    });
+    expect(f.sent.some((m) => m.type === "response_end")).toBe(false);
+
+    await vi.waitFor(() => {
+      expect(f.sent.some((m) => m.type === "response_end")).toBe(true);
+    });
+    expect(rec.promptInFlight).toBe(false);
+    expect(rec.contextUsageTransientTokens).toBe(0);
+  });
+
   it("resumes after overflow compaction when pi does not mark willRetry", async () => {
     vi.useFakeTimers();
     try {

--- a/agent/tab-lifecycle/events.ts
+++ b/agent/tab-lifecycle/events.ts
@@ -53,6 +53,7 @@ import { isSilentTool } from "../silent-tools";
 import {
   addLiveContextUsageEstimate,
   clearLiveContextUsageEstimate,
+  contextUsageSnapshot,
   emitContextUsage,
   emitContextUsageThrottled,
 } from "../context-usage";
@@ -485,6 +486,63 @@ function handleContextOverflowCompactionEvent(
   void continueAfterContextCompaction(state, deps, tabId, failedMessage);
 }
 
+function shouldCompactCompletedTurn(
+  state: AethonAgentState,
+  tabId: string,
+  rec: TabRecord,
+): boolean {
+  const snapshot = contextUsageSnapshot(state, tabId, rec);
+  if (!snapshot?.autoCompactEnabled) return false;
+  if (rec.contextUsageTransientTokens === undefined) return false;
+  if (rec.contextUsageTransientTokens <= 0) return false;
+  if (
+    typeof (rec.session as CompactAndContinueSession).compact !== "function"
+  ) {
+    return false;
+  }
+  return snapshot.estimatedTokensUntilCompact === 0;
+}
+
+function compactCompletedTurnThenFinalize(
+  state: AethonAgentState,
+  deps: TabLifecycleDeps,
+  rec: TabRecord,
+  tabId: string,
+  lastAssistant:
+    | {
+        role?: string;
+        stopReason?: string;
+        content?: unknown;
+        id?: unknown;
+        messageId?: unknown;
+      }
+    | undefined,
+): void {
+  rec.promptInFlight = true;
+  rec.agentEndFired = false;
+  state.currentAgentTabId = tabId;
+  deps.send({
+    type: "notice",
+    tabId,
+    busy: true,
+    message: "Context threshold reached; compacting before the next turn...",
+  });
+  const session = rec.session as CompactAndContinueSession;
+  void session
+    .compact?.()
+    .catch((err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err);
+      deps.send({
+        type: "error",
+        tabId,
+        message: `auto-compaction failed: ${message}`,
+      });
+    })
+    .finally(() => {
+      finalizeCompletedTurn(state, deps, rec, tabId, lastAssistant);
+    });
+}
+
 /** Per-tab pi session event subscriber. Extracted so tests can drive it
  *  directly with synthetic event payloads. */
 export function handleSessionEvent(
@@ -859,26 +917,22 @@ export function handleSessionEvent(
         !keepTurnOpenForAutoSwitch &&
         !keepTurnOpenForContextRecovery
       ) {
-        cancelAethonRetry(rec);
-        if (failedMessage) resetContextOverflowRecovery(rec);
-        rec.agentEndFired = true;
-        rec.promptInFlight = false;
-        if (state.currentAgentTabId === tabId) {
-          state.currentAgentTabId = undefined;
+        if (!failedMessage && shouldCompactCompletedTurn(state, tabId, rec)) {
+          compactCompletedTurnThenFinalize(
+            state,
+            deps,
+            rec,
+            tabId,
+            lastAssistant,
+          );
+          break;
         }
-        emitFinalAssistantContent(state, deps, rec, tabId, lastAssistant);
-        rollResponseMessage(rec);
-        clearLiveContextUsageEstimate(rec);
-        emitContextUsage(state, deps, tabId, rec);
-        // Back-fill pi entry ids onto the just-streamed messages so the
-        // rollback / fork affordances work without a reload.
-        emitEntryIds(deps, rec, tabId);
-        deps.send({ type: "response_end", tabId });
-        emitScheduledRunComplete(
+        finalizeCompletedTurn(
+          state,
           deps,
           rec,
           tabId,
-          !failedMessage,
+          lastAssistant,
           failedMessage,
         );
       }
@@ -952,6 +1006,40 @@ export function handleSessionEvent(
       break;
     }
   }
+}
+
+function finalizeCompletedTurn(
+  state: AethonAgentState,
+  deps: TabLifecycleDeps,
+  rec: TabRecord,
+  tabId: string,
+  lastAssistant:
+    | {
+        role?: string;
+        stopReason?: string;
+        content?: unknown;
+        id?: unknown;
+        messageId?: unknown;
+      }
+    | undefined,
+  failedMessage?: string,
+): void {
+  cancelAethonRetry(rec);
+  if (failedMessage) resetContextOverflowRecovery(rec);
+  rec.agentEndFired = true;
+  rec.promptInFlight = false;
+  if (state.currentAgentTabId === tabId) {
+    state.currentAgentTabId = undefined;
+  }
+  emitFinalAssistantContent(state, deps, rec, tabId, lastAssistant);
+  rollResponseMessage(rec);
+  clearLiveContextUsageEstimate(rec);
+  emitContextUsage(state, deps, tabId, rec);
+  // Back-fill pi entry ids onto the just-streamed messages so the rollback /
+  // fork affordances work without a reload.
+  emitEntryIds(deps, rec, tabId);
+  deps.send({ type: "response_end", tabId });
+  emitScheduledRunComplete(deps, rec, tabId, !failedMessage, failedMessage);
 }
 
 /**

--- a/src/extensions/default-layout/shell/tab-strip.test.tsx
+++ b/src/extensions/default-layout/shell/tab-strip.test.tsx
@@ -83,19 +83,33 @@ describe("TabStrip", () => {
   });
 
   it("copies the agent session id from the tab context menu", async () => {
+    const clipboardDescriptor = Object.getOwnPropertyDescriptor(
+      Navigator.prototype,
+      "clipboard",
+    );
     const writeText = vi.fn(() => Promise.resolve());
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,
       value: { writeText },
     });
-    renderTabStrip();
+    try {
+      renderTabStrip();
 
-    fireEvent.contextMenu(screen.getByText("Tab 1").closest('[role="tab"]')!);
-    fireEvent.click(screen.getByRole("menuitem", { name: "Copy Session ID" }));
+      fireEvent.contextMenu(screen.getByText("Tab 1").closest('[role="tab"]')!);
+      fireEvent.click(
+        screen.getByRole("menuitem", { name: "Copy Session ID" }),
+      );
 
-    await vi.waitFor(() => {
-      expect(writeText).toHaveBeenCalledWith("tab-1");
-    });
+      await vi.waitFor(() => {
+        expect(writeText).toHaveBeenCalledWith("tab-1");
+      });
+    } finally {
+      if (clipboardDescriptor) {
+        Object.defineProperty(navigator, "clipboard", clipboardDescriptor);
+      } else {
+        Reflect.deleteProperty(navigator, "clipboard");
+      }
+    }
   });
 
   it("keeps rename input focused while active agent state re-renders", () => {

--- a/src/extensions/default-layout/shell/tab-strip.test.tsx
+++ b/src/extensions/default-layout/shell/tab-strip.test.tsx
@@ -82,6 +82,22 @@ describe("TabStrip", () => {
     });
   });
 
+  it("copies the agent session id from the tab context menu", async () => {
+    const writeText = vi.fn(() => Promise.resolve());
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    renderTabStrip();
+
+    fireEvent.contextMenu(screen.getByText("Tab 1").closest('[role="tab"]')!);
+    fireEvent.click(screen.getByRole("menuitem", { name: "Copy Session ID" }));
+
+    await vi.waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith("tab-1");
+    });
+  });
+
   it("keeps rename input focused while active agent state re-renders", () => {
     const onEvent = vi.fn<TabStripOnEvent>();
     const { rerender } = render(

--- a/src/extensions/default-layout/shell/tab-strip.tsx
+++ b/src/extensions/default-layout/shell/tab-strip.tsx
@@ -403,6 +403,11 @@ export function TabStrip({ component, state, onEvent }: BuiltinComponentProps) {
         label: "Rename Session",
         onSelect: () => beginRename(tab),
       },
+      {
+        id: "copy-session-id",
+        label: "Copy Session ID",
+        onSelect: () => copyToClipboard(tab.id),
+      },
       { type: "separator" },
       ...closeFamily,
     ];


### PR DESCRIPTION
## Summary
- auto-compact completed turns when Aethon's live current-turn/tool-output estimate crosses the configured compaction threshold
- keep the tab busy while that post-turn compaction runs, then finalize the turn normally
- add a tab context-menu action to copy the Aethon session/tab id for faster troubleshooting

## Root Cause
The context meter already tracked transient tokens from assistant streaming, bash output, and task partials, but that live estimate only affected UI. Auto-compaction waited for pi's provider-reported token count, so a large tool output could cross the threshold and still sit around until a later provider boundary or context-overflow recovery.

## Validation
- `bunx vitest run agent/tab-lifecycle.test.ts`
- `bunx vitest run src/extensions/default-layout/shell/tab-strip.test.tsx`
- `bunx vitest run agent/context-usage.test.ts src/extensions/default-layout/layout/status-bar.test.tsx`
- `bun run typecheck`
- `bunx eslint agent/tab-lifecycle/events.ts agent/tab-lifecycle.test.ts src/extensions/default-layout/shell/tab-strip.tsx src/extensions/default-layout/shell/tab-strip.test.tsx`
