### PR TITLE
fix: keep sidebar header static and left aligned

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,8 +25,31 @@ by the agent.
 
 ## Common Commands
 
-Run inside `nix develop` (or via direnv — `.envrc` is `use flake`). The
-devshell exposes these helpers (defined in `flake.nix`):
+Run commands inside the Nix devshell (or via direnv — `.envrc` is `use flake`).
+Before running native app commands, explicitly check whether the shell is
+already in that environment:
+
+```bash
+printenv IN_NIX_SHELL DIRENV_DIR
+command -v dev check build-app
+```
+
+If `IN_NIX_SHELL` / `DIRENV_DIR` are empty or the devshell helper commands are
+missing, do not run `bun tauri dev`, `cargo tauri dev`, `cargo test`, or
+`build-app` directly from the plain shell. Use `nix develop -c ...` instead:
+
+```bash
+nix develop -c dev
+nix develop -c check
+nix develop -c build-app
+nix develop -c cargo test --lib -p aethon -- helpers::test_name
+```
+
+This is mandatory for native macOS UAT. Plain shells often inherit incompatible
+flags or miss SDK/libiconv/toolchain paths, causing noisy linker failures that
+are not app regressions.
+
+The devshell exposes these helpers (defined in `flake.nix`):
 
 | Command     | What it does                                                                  |
 | ----------- | ----------------------------------------------------------------------------- |

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -113,6 +113,7 @@ body {
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  --ae-mac-titlebar-clearance: calc(94px / var(--app-ui-scale, 1));
 }
 
 /* Dark, slim scrollbars — defaults are jarring on the elevated panels. */
@@ -439,7 +440,7 @@ body.ae-resizing-composer .a2ui-layout {
   width: 100%;
   min-width: 0;
   min-height: 0;
-  overflow-y: auto;
+  overflow: hidden;
   overscroll-behavior: none;
   position: relative;
   /* Shared gutter geometry for the project → workspace hierarchy. The
@@ -931,6 +932,7 @@ body.ae-resizing-sidebar .a2ui-layout {
   letter-spacing: 0;
   min-width: 0;
   border-bottom: 1px solid var(--border);
+  position: relative;
 }
 
 .a2ui-sidebar-title .ae-mark {
@@ -941,16 +943,38 @@ body.ae-resizing-sidebar .a2ui-layout {
    reserve the top-left for the floating traffic lights — with extra gap
    so the Æthon wordmark clears the green control. Only on mac. */
 [data-platform="mac"] .a2ui-sidebar-title {
-  padding-left: 94px;
+  padding-left: var(--ae-mac-titlebar-clearance);
+}
+
+[data-platform="mac"] .a2ui-sidebar-title .ae-wordmark {
+  position: absolute;
+  left: var(--ae-mac-titlebar-clearance);
+  top: 50%;
+  transform: translateY(-50%);
 }
 
 .a2ui-sidebar-title-version {
   margin-left: auto;
-  flex-shrink: 0;
+  max-width: 100%;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   color: var(--text-dim);
   font-size: var(--chrome-text-compact);
   font-family: var(--font-mono);
   letter-spacing: 0.02em;
+}
+
+[data-platform="mac"] .a2ui-sidebar-title-version {
+  position: absolute;
+  right: var(--space-3);
+  top: 50%;
+  max-width: max(
+    0px,
+    calc(100% - var(--ae-mac-titlebar-clearance) - 96px)
+  );
+  transform: translateY(-50%);
 }
 
 /* ---- Host group (top tier of host → project → workspace) --------------- */
@@ -1084,9 +1108,12 @@ body.ae-resizing-sidebar .a2ui-layout {
 .a2ui-sidebar-sections {
   display: flex;
   flex-direction: column;
+  flex: 1 1 auto;
   gap: var(--space-1);
   padding: var(--space-2) 0;
   min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: none;
 }
 
 .a2ui-sidebar-section {
@@ -2045,7 +2072,7 @@ body.ae-resizing-sidebar .a2ui-layout {
    the leftmost drag row and must inherit the traffic-light clearance that the
    sidebar brand strip normally owns. */
 [data-platform="mac"][data-sidebar-collapsed="true"] .app-header {
-  padding-left: 94px !important;
+  padding-left: var(--ae-mac-titlebar-clearance) !important;
 }
 
 .app-header-brand {

--- a/src/styles/scrollbar.test.ts
+++ b/src/styles/scrollbar.test.ts
@@ -16,6 +16,14 @@ function cssRuleBody(css: string, selector: string): string {
   return match?.[1] ?? "";
 }
 
+function exactCssRuleBody(css: string, selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = css.match(
+    new RegExp(`(?:^|\\n)${escaped}\\s*\\{([\\s\\S]*?)\\}`),
+  );
+  return match?.[1] ?? "";
+}
+
 describe("scrollbar sizing CSS", () => {
   it("uses one slim token for native and xterm scrollbars", () => {
     expect(tokensCss).toMatch(/--scrollbar-size:\s*4px;/);
@@ -106,5 +114,18 @@ describe("chat overflow containment CSS", () => {
     expect(codeBlock).toMatch(/min-width:\s*0;/);
     expect(codeBlock).toMatch(/max-width:\s*100%;/);
     expect(codeBlock).toMatch(/overflow-x:\s*auto;/);
+  });
+});
+
+describe("sidebar scroll containment CSS", () => {
+  it("keeps the sidebar titlebar outside the scrollable region", () => {
+    const sidebar = exactCssRuleBody(chromeCss, ".a2ui-sidebar");
+    expect(sidebar).not.toMatch(/overflow-y:\s*auto;/);
+    expect(sidebar).toMatch(/overflow:\s*hidden;/);
+
+    const sections = cssRuleBody(chromeCss, ".a2ui-sidebar-sections");
+    expect(sections).toMatch(/flex:\s*1 1 auto;/);
+    expect(sections).toMatch(/overflow-y:\s*auto;/);
+    expect(sections).toMatch(/overscroll-behavior:\s*none;/);
   });
 });

--- a/src/styles/titlebar-clearance.test.ts
+++ b/src/styles/titlebar-clearance.test.ts
@@ -10,9 +10,21 @@ const here = dirname(fileURLToPath(import.meta.url));
 const css = readFileSync(join(here, "chrome.css"), "utf8");
 
 describe("macOS overlay titlebar clearance", () => {
-  it("reserves traffic-light space in the header when the sidebar is collapsed", () => {
+  it("left-aligns the sidebar wordmark after the macOS traffic lights", () => {
     expect(css).toMatch(
-      /\[data-platform="mac"\]\[data-sidebar-collapsed="true"\]\s+\.app-header\s*\{[\s\S]*?padding-left:\s*94px\s*!important/,
+      /--ae-mac-titlebar-clearance:\s*calc\(94px \/ var\(--app-ui-scale,\s*1\)\);/,
+    );
+    expect(css).toMatch(
+      /\[data-platform="mac"\]\s+\.a2ui-sidebar-title\s*\{[\s\S]*?padding-left:\s*var\(--ae-mac-titlebar-clearance\);/,
+    );
+    expect(css).toMatch(
+      /\[data-platform="mac"\]\s+\.a2ui-sidebar-title\s+\.ae-wordmark\s*\{[\s\S]*?position:\s*absolute;[\s\S]*?left:\s*var\(--ae-mac-titlebar-clearance\);/,
+    );
+    expect(css).toMatch(
+      /\[data-platform="mac"\]\s+\.a2ui-sidebar-title-version\s*\{[\s\S]*?position:\s*absolute;[\s\S]*?right:\s*var\(--space-3\);[\s\S]*?max-width:\s*max\(/,
+    );
+    expect(css).toMatch(
+      /\[data-platform="mac"\]\[data-sidebar-collapsed="true"\]\s+\.app-header\s*\{[\s\S]*?padding-left:\s*var\(--ae-mac-titlebar-clearance\)\s*!important/,
     );
     expect(css).not.toMatch(/:has\(/);
   });


### PR DESCRIPTION
## Summary

- Keeps the sidebar brand/header strip outside the scrollable sidebar body so scrolling project/workspace lists cannot drag the header with it.
- Anchors the macOS `Æthon` wordmark to the confirmed left-side traffic-light clearance instead of letting it read as centered in the title strip.
- Keeps the version label right-aligned and clipped safely so zoom changes do not shove the wordmark around.
- Documents the required Nix/direnv devshell check in `AGENTS.md` before running native Aethon commands or UAT.

## Root Cause

The sidebar itself owned vertical scrolling, so the titlebar/header area could participate in the scrollable region and visually drift or clip. While fixing that, the macOS titlebar clearance for the `Æthon` SVG was widened too far, which made the wordmark look centered instead of historically left-aligned just after the traffic-light controls.

## User Impact

The sidebar header now stays static while the sidebar body scrolls. The `Æthon` wordmark is left-aligned in the macOS title strip, and the layout remains stable when the UI is zoomed in or out.

## Validation

- Live UAT in the running Aethon Dev app with Computer Use screenshots. The final wordmark placement was visually confirmed before adding tests.
- `nix develop -c bunx vitest run src/styles/titlebar-clearance.test.ts src/styles/scrollbar.test.ts`
- `git diff --check`

## Notes

The regression tests now pin both parts of the fix: the sidebar titlebar remains outside the scrollable region, and the macOS wordmark uses the confirmed left-aligned clearance.