### PR TITLE
fix(agent): notify parent on cancelled subagent delegation

### DIFF
--- a/agent/chat.ts
+++ b/agent/chat.ts
@@ -9,6 +9,7 @@ import {
   cancelRunningToolCards,
   ensurePickerHasModel,
   ensureTab,
+  synthesizeCancelledSubagentToolResults,
 } from "./tab-lifecycle";
 import {
   modelRegistryForModelId,
@@ -287,6 +288,7 @@ export async function handleChat(
     .finally(() => {
       const stillStreamingOrRetrying = isUnderlyingSessionBusy(tab);
       if (!tab.agentEndFired && !stillStreamingOrRetrying) {
+        synthesizeCancelledSubagentToolResults(state, tab, tabId);
         tab.promptInFlight = false;
         deps.send({
           type: "response_end",

--- a/agent/session-history.test.ts
+++ b/agent/session-history.test.ts
@@ -1,15 +1,25 @@
-import { mkdir, mkdtemp, rm, symlink, utimes, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  symlink,
+  utimes,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   appendLocalChatMessage,
+  findDanglingSubagentToolCalls,
   findSessionFileMatchingCwd,
   normalizeSessionLabel,
   parseSessionHistoryLines,
   readSessionLabel,
   readSessionMetadata,
   readSessionTranscript,
+  repairDanglingSubagentToolResults,
   writeSessionLabel,
 } from "./session-history";
 import { SESSION_TITLE_TOOL_NAME } from "./silent-tools";
@@ -278,6 +288,35 @@ describe("parseSessionHistoryLines", () => {
           ],
         },
       },
+    ]);
+  });
+
+  it("detects dangling task and task_batch tool calls that lack results", () => {
+    const lines = [
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "toolCall", id: "call_task", name: "task" },
+            { type: "toolCall", id: "call_batch", name: "task_batch" },
+            { type: "toolCall", id: "call_bash", name: "bash" },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "toolResult",
+          toolCallId: "call_task",
+          toolName: "task",
+          content: [{ type: "text", text: "done" }],
+        },
+      }),
+    ];
+
+    expect(findDanglingSubagentToolCalls(lines)).toEqual([
+      { toolCallId: "call_batch", toolName: "task_batch" },
     ]);
   });
 
@@ -906,6 +945,255 @@ describe("readSessionTranscript", () => {
     expect(restored[0].a2ui?.components[0].props).toMatchObject({
       status: "cancelled",
       endedAt: 4_000,
+    });
+  });
+
+  it("repairs dangling subagent tool calls with synthetic error results", async () => {
+    const dir = await tempRoot();
+    const path = join(dir, "session.jsonl");
+    await writeFile(
+      path,
+      `${JSON.stringify({
+        type: "message",
+        id: "assistant-tool",
+        timestamp: 3_000,
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "call_batch_1",
+              name: "task_batch",
+              arguments: { tasks: [] },
+            },
+          ],
+        },
+      })}\n`,
+    );
+
+    await expect(repairDanglingSubagentToolResults(path)).resolves.toBe(1);
+    const repairedLines = (await readFile(path, "utf8")).trim().split(/\r?\n/);
+    const repairedRecord = JSON.parse(repairedLines.at(-1) ?? "{}");
+    expect(repairedRecord).toMatchObject({
+      type: "message",
+      parentId: "assistant-tool",
+      message: {
+        role: "toolResult",
+        toolCallId: "call_batch_1",
+        isError: true,
+      },
+    });
+
+    const restored = await readSessionTranscript(dir);
+    expect(restored).toHaveLength(1);
+    expect(restored[0].a2ui?.components[0]).toMatchObject({
+      type: "tool-card",
+      props: {
+        toolName: "task_batch",
+        isError: true,
+      },
+    });
+    expect(restored[0].a2ui?.components[0]).toMatchObject({
+      children: [
+        {
+          props: {
+            content: expect.stringContaining("delegation as cancelled/failed"),
+          },
+        },
+      ],
+    });
+    await expect(repairDanglingSubagentToolResults(path)).resolves.toBe(0);
+  });
+
+  it("does not repair dangling subagent calls from inactive branches", async () => {
+    const dir = await tempRoot();
+    const path = join(dir, "session.jsonl");
+    await writeFile(
+      path,
+      [
+        JSON.stringify({
+          type: "session",
+          id: "session-1",
+          cwd: "/repo",
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "u1",
+          message: { role: "user", content: [{ type: "text", text: "hi" }] },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "abandoned-assistant",
+          parentId: "u1",
+          message: {
+            role: "assistant",
+            content: [{ type: "toolCall", id: "call_old", name: "task_batch" }],
+          },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "active-assistant",
+          parentId: "u1",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "new branch" }],
+          },
+        }),
+      ].join("\n") + "\n",
+    );
+
+    await expect(repairDanglingSubagentToolResults(path)).resolves.toBe(0);
+    const raw = await readFile(path, "utf8");
+    expect(raw).not.toContain("aethon-synthetic-tool-result");
+  });
+
+  it("uses non-message entries when identifying the active repair branch", async () => {
+    const dir = await tempRoot();
+    const path = join(dir, "session.jsonl");
+    await writeFile(
+      path,
+      [
+        JSON.stringify({ type: "session", id: "session-1", cwd: "/repo" }),
+        JSON.stringify({
+          type: "message",
+          id: "u1",
+          message: { role: "user", content: [{ type: "text", text: "hi" }] },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "abandoned-assistant",
+          parentId: "u1",
+          message: {
+            role: "assistant",
+            content: [{ type: "toolCall", id: "call_old", name: "task_batch" }],
+          },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "active-assistant",
+          parentId: "u1",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "new branch" }],
+          },
+        }),
+        JSON.stringify({
+          type: "model_change",
+          id: "active-model",
+          parentId: "active-assistant",
+          timestamp: "2026-06-23T00:00:00.000Z",
+          provider: "anthropic",
+          modelId: "claude",
+        }),
+      ].join("\n") + "\n",
+    );
+
+    await expect(repairDanglingSubagentToolResults(path)).resolves.toBe(0);
+    const raw = await readFile(path, "utf8");
+    expect(raw).not.toContain("aethon-synthetic-tool-result");
+  });
+
+  it("does not repair stale dangling subagent calls after conversation continued", async () => {
+    const dir = await tempRoot();
+    const path = join(dir, "session.jsonl");
+    await writeFile(
+      path,
+      [
+        JSON.stringify({ type: "session", id: "session-1", cwd: "/repo" }),
+        JSON.stringify({
+          type: "message",
+          id: "u1",
+          message: { role: "user", content: [{ type: "text", text: "hi" }] },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "assistant-tool",
+          parentId: "u1",
+          message: {
+            role: "assistant",
+            content: [{ type: "toolCall", id: "call_old", name: "task_batch" }],
+          },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "u2",
+          parentId: "assistant-tool",
+          message: {
+            role: "user",
+            content: [{ type: "text", text: "continue" }],
+          },
+        }),
+      ].join("\n") + "\n",
+    );
+
+    await expect(repairDanglingSubagentToolResults(path)).resolves.toBe(0);
+    const raw = await readFile(path, "utf8");
+    expect(raw).not.toContain("aethon-synthetic-tool-result");
+  });
+
+  it("keeps repaired subagent pi results ahead of local cancelled cards", async () => {
+    const dir = await tempRoot();
+    const path = join(dir, "session.jsonl");
+    await writeFile(
+      path,
+      `${JSON.stringify({
+        type: "message",
+        id: "assistant-tool",
+        timestamp: 3_000,
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "call_batch_1",
+              name: "task_batch",
+              arguments: { tasks: [] },
+            },
+          ],
+        },
+      })}\n${JSON.stringify({
+        type: "message",
+        id: "tool-result",
+        timestamp: 4_000,
+        message: {
+          role: "toolResult",
+          toolCallId: "call_batch_1",
+          toolName: "task_batch",
+          content: [{ type: "text", text: "cancelled synthetic result" }],
+          isError: true,
+        },
+      })}\n`,
+    );
+    await appendLocalChatMessage(dir, {
+      id: "tool-7-call_batch_1",
+      role: "agent",
+      a2ui: {
+        components: [
+          {
+            id: "tool-7-call_batch_1",
+            type: "tool-card",
+            props: {
+              toolName: "task_batch",
+              startedAt: 3_000,
+              endedAt: 3_500,
+              status: "cancelled",
+            },
+          },
+        ],
+      },
+      createdAt: 3_500,
+    });
+
+    const restored = await readSessionTranscript(dir);
+    expect(restored.map((message) => message.id)).toEqual([
+      "restored-tool-call_batch_1",
+    ]);
+    expect(restored[0].a2ui?.components[0]).toMatchObject({
+      props: {
+        toolName: "task_batch",
+        isError: true,
+      },
+      children: [{ props: { content: "cancelled synthetic result" } }],
     });
   });
 

--- a/agent/session-history/index.ts
+++ b/agent/session-history/index.ts
@@ -39,3 +39,15 @@ export {
 export { latestSessionLog, readSessionMetadata } from "./metadata";
 export { findSessionFileMatchingCwd } from "./lookup";
 export { readSessionTranscript } from "./restore";
+export {
+  appendSyntheticSubagentToolResults,
+  findDanglingSubagentToolCalls,
+  isSubagentToolName,
+  repairDanglingSubagentToolResults,
+  syntheticSubagentCancellationText,
+  syntheticSubagentToolResultMessage,
+} from "./subagent-tool-results";
+export type {
+  DanglingSubagentToolCall,
+  SyntheticSubagentToolResult,
+} from "./subagent-tool-results";

--- a/agent/session-history/restore.ts
+++ b/agent/session-history/restore.ts
@@ -19,6 +19,7 @@ import { latestSessionLog } from "./metadata";
 import { findSessionFileMatchingCwd } from "./lookup";
 import { readLocalChatTranscript } from "./parse-local";
 import { parseSessionHistoryLines } from "./parse-pi";
+import { isSubagentToolName } from "./subagent-tool-results";
 import {
   MAX_RESTORED_MESSAGES,
   type RestoredChatAttachment,
@@ -111,9 +112,13 @@ function toolCardIdentityFromId(id: string): string | undefined {
 
 function toolCardRecords(
   message: RestoredChatMessage,
-): Array<{ identity: string; status?: unknown }> {
+): Array<{ identity: string; status?: unknown; toolName?: unknown }> {
   const components = message.a2ui?.components ?? [];
-  const records: Array<{ identity: string; status?: unknown }> = [];
+  const records: Array<{
+    identity: string;
+    status?: unknown;
+    toolName?: unknown;
+  }> = [];
   for (const component of components) {
     if (!component || typeof component !== "object") continue;
     const record = component as Record<string, unknown>;
@@ -126,7 +131,11 @@ function toolCardRecords(
       record.props && typeof record.props === "object"
         ? (record.props as Record<string, unknown>)
         : undefined;
-    records.push({ identity, status: props?.status });
+    records.push({
+      identity,
+      status: props?.status,
+      toolName: props?.toolName,
+    });
   }
   return records;
 }
@@ -168,12 +177,17 @@ function isCoveredByPiToolCard(
   message: RestoredChatMessage,
   piToolCards: ReadonlySet<string>,
 ): boolean {
-  if (isCancelledToolCardMessage(message)) return false;
-  const identities = toolCardIdentities(message);
-  return (
-    identities.length > 0 &&
-    identities.every((identity) => piToolCards.has(identity))
-  );
+  const records = toolCardRecords(message);
+  if (records.length === 0) return false;
+  if (isCancelledToolCardMessage(message)) {
+    return records.every(
+      (record) =>
+        record.status === "cancelled" &&
+        isSubagentToolName(record.toolName) &&
+        piToolCards.has(record.identity),
+    );
+  }
+  return records.every((record) => piToolCards.has(record.identity));
 }
 
 function removePiToolCardsCoveredByLocalCancellation(
@@ -183,10 +197,14 @@ function removePiToolCardsCoveredByLocalCancellation(
   const cancelledIdentities = cancelledToolCardIdentitySet(localMessages);
   if (cancelledIdentities.size === 0) return piMessages;
   return piMessages.filter((message) => {
-    const identities = toolCardIdentities(message);
+    const records = toolCardRecords(message);
     return (
-      identities.length === 0 ||
-      !identities.every((identity) => cancelledIdentities.has(identity))
+      records.length === 0 ||
+      !records.every(
+        (record) =>
+          cancelledIdentities.has(record.identity) &&
+          !isSubagentToolName(record.toolName),
+      )
     );
   });
 }

--- a/agent/session-history/subagent-tool-results.ts
+++ b/agent/session-history/subagent-tool-results.ts
@@ -1,0 +1,286 @@
+import { appendFile, readFile } from "node:fs/promises";
+
+export const SUBAGENT_TOOL_NAMES = new Set(["task", "task_batch"]);
+
+export interface DanglingSubagentToolCall {
+  toolCallId: string;
+  toolName: string;
+}
+
+export interface SyntheticSubagentToolResult {
+  toolCallId: string;
+  toolName: string;
+  partialText?: string;
+}
+
+interface SessionEntry {
+  type?: string;
+  id?: string;
+  parentId?: string | null;
+  message?: Record<string, unknown>;
+}
+
+function safeIdPart(value: string): string {
+  return value.replace(/[^A-Za-z0-9_-]+/g, "-").slice(0, 96) || "tool";
+}
+
+export function isSubagentToolName(
+  value: unknown,
+): value is "task" | "task_batch" {
+  return typeof value === "string" && SUBAGENT_TOOL_NAMES.has(value);
+}
+
+export function syntheticSubagentCancellationText(
+  toolName: string,
+  partialText?: string,
+): string {
+  const label = toolName === "task_batch" ? "task_batch" : "task";
+  const base = `Aethon interrupted the inline ${label} subagent delegation before a tool result was delivered to the parent agent. Treat this delegation as cancelled/failed and continue with an alternate plan.`;
+  const partial = partialText?.trim();
+  if (!partial) return base;
+  return `${base}\n\nPartial output before interruption:\n\n${partial}`;
+}
+
+export function syntheticSubagentToolResultMessage(
+  result: SyntheticSubagentToolResult,
+  timestamp: number | string = Date.now(),
+): Record<string, unknown> {
+  return {
+    role: "toolResult",
+    toolCallId: result.toolCallId,
+    toolName: result.toolName,
+    content: [
+      {
+        type: "text",
+        text: syntheticSubagentCancellationText(
+          result.toolName,
+          result.partialText,
+        ),
+      },
+    ],
+    isError: true,
+    timestamp,
+  };
+}
+
+export function syntheticSubagentToolResultRecord(
+  result: SyntheticSubagentToolResult,
+  timestamp = Date.now(),
+  index = 0,
+  parentId?: string,
+): Record<string, unknown> {
+  return {
+    type: "message",
+    id: `aethon-synthetic-tool-result-${safeIdPart(
+      result.toolCallId,
+    )}-${timestamp}-${index}`,
+    ...(parentId ? { parentId } : {}),
+    timestamp,
+    message: syntheticSubagentToolResultMessage(result, timestamp),
+  };
+}
+
+export function findDanglingSubagentToolCalls(
+  lines: Iterable<string>,
+): DanglingSubagentToolCall[] {
+  const calls = new Map<string, DanglingSubagentToolCall>();
+  const completed = new Set<string>();
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+    if (!parsed || typeof parsed !== "object") continue;
+    const record = parsed as Record<string, unknown>;
+    if (record.type !== "message") continue;
+    const message = record.message;
+    if (!message || typeof message !== "object") continue;
+    const msg = message as Record<string, unknown>;
+
+    if (msg.role === "toolResult") {
+      if (typeof msg.toolCallId === "string" && msg.toolCallId.length > 0) {
+        completed.add(msg.toolCallId);
+        calls.delete(msg.toolCallId);
+      }
+      continue;
+    }
+
+    if (msg.role !== "assistant" || !Array.isArray(msg.content)) continue;
+    for (const part of msg.content) {
+      if (!part || typeof part !== "object") continue;
+      const toolCall = part as Record<string, unknown>;
+      if (toolCall.type !== "toolCall") continue;
+      if (!isSubagentToolName(toolCall.name)) continue;
+      const toolCallId =
+        typeof toolCall.id === "string" && toolCall.id.length > 0
+          ? toolCall.id
+          : undefined;
+      if (!toolCallId || completed.has(toolCallId)) continue;
+      calls.set(toolCallId, {
+        toolCallId,
+        toolName: toolCall.name,
+      });
+    }
+  }
+
+  return [...calls.values()];
+}
+
+function latestSessionEntryId(lines: Iterable<string>): string | undefined {
+  let latest: string | undefined;
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+    if (!parsed || typeof parsed !== "object") continue;
+    const record = parsed as Record<string, unknown>;
+    if (record.type === "session") continue;
+    if (typeof record.id === "string" && record.id.length > 0) {
+      latest = record.id;
+    }
+  }
+  return latest;
+}
+
+export async function appendSyntheticSubagentToolResults(
+  sessionFile: string,
+  results: SyntheticSubagentToolResult[],
+): Promise<number> {
+  if (results.length === 0) return 0;
+  const raw = await readFile(sessionFile, "utf8").catch(() => "");
+  const timestamp = Date.now();
+  let parentId = latestSessionEntryId(raw.split(/\r?\n/));
+  const records = results.map((result, index) => {
+    const record = syntheticSubagentToolResultRecord(
+      result,
+      timestamp,
+      index,
+      parentId,
+    );
+    parentId = typeof record.id === "string" ? record.id : parentId;
+    return record;
+  });
+  const payload = records.map((record) => JSON.stringify(record)).join("\n");
+  await appendFile(sessionFile, `${payload}\n`, "utf8");
+  return results.length;
+}
+
+function parseSessionEntries(lines: Iterable<string>): SessionEntry[] {
+  const entries: SessionEntry[] = [];
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+    if (!parsed || typeof parsed !== "object") continue;
+    const record = parsed as Record<string, unknown>;
+    if (record.type === "session") continue;
+    entries.push(record);
+  }
+  return entries;
+}
+
+function activeBranch(entries: readonly SessionEntry[]): SessionEntry[] {
+  const byId = new Map<string, SessionEntry>();
+  let leafId: string | undefined;
+  for (const entry of entries) {
+    if (typeof entry.id !== "string" || entry.id.length === 0) continue;
+    byId.set(entry.id, entry);
+    leafId = entry.id;
+  }
+  const branch: SessionEntry[] = [];
+  const seen = new Set<string>();
+  let current = leafId ? byId.get(leafId) : undefined;
+  while (current) {
+    const id = current.id;
+    if (typeof id !== "string" || seen.has(id)) break;
+    seen.add(id);
+    branch.unshift(current);
+    const parentId =
+      typeof current.parentId === "string" && current.parentId.length > 0
+        ? current.parentId
+        : undefined;
+    current = parentId ? byId.get(parentId) : undefined;
+  }
+  return branch;
+}
+
+function contentToolCalls(message: Record<string, unknown>): Array<{
+  id: string;
+  name: string;
+}> {
+  if (!Array.isArray(message.content)) return [];
+  return message.content.flatMap((part) => {
+    if (!part || typeof part !== "object") return [];
+    const toolCall = part as Record<string, unknown>;
+    if (toolCall.type !== "toolCall") return [];
+    if (!isSubagentToolName(toolCall.name)) return [];
+    if (typeof toolCall.id !== "string" || toolCall.id.length === 0) return [];
+    return [{ id: toolCall.id, name: toolCall.name }];
+  });
+}
+
+function hasLaterConversationMessage(
+  branch: readonly SessionEntry[],
+  index: number,
+): boolean {
+  return branch.slice(index + 1).some((entry) => {
+    const role = entry.message?.role;
+    return role === "user" || role === "assistant";
+  });
+}
+
+function findDanglingSubagentToolCallsInActiveBranch(
+  lines: Iterable<string>,
+): DanglingSubagentToolCall[] {
+  const branch = activeBranch(parseSessionEntries(lines));
+  const completed = new Set<string>();
+  const calls = new Map<string, DanglingSubagentToolCall>();
+  for (let index = 0; index < branch.length; index += 1) {
+    const msg = branch[index]?.message;
+    if (!msg) continue;
+    if (msg.role === "toolResult") {
+      if (typeof msg.toolCallId === "string" && msg.toolCallId.length > 0) {
+        completed.add(msg.toolCallId);
+        calls.delete(msg.toolCallId);
+      }
+      continue;
+    }
+    if (msg.role !== "assistant") continue;
+    if (hasLaterConversationMessage(branch, index)) continue;
+    for (const toolCall of contentToolCalls(msg)) {
+      if (!completed.has(toolCall.id)) {
+        calls.set(toolCall.id, {
+          toolCallId: toolCall.id,
+          toolName: toolCall.name,
+        });
+      }
+    }
+  }
+  return [...calls.values()];
+}
+
+export async function repairDanglingSubagentToolResults(
+  sessionFile: string,
+): Promise<number> {
+  const raw = await readFile(sessionFile, "utf8");
+  const dangling = findDanglingSubagentToolCallsInActiveBranch(
+    raw.split(/\r?\n/),
+  );
+  return appendSyntheticSubagentToolResults(sessionFile, dangling);
+}

--- a/agent/state.ts
+++ b/agent/state.ts
@@ -265,6 +265,10 @@ export interface TabRecord {
       rootPath?: string;
       bashStream?: BashTerminalStreamState;
       taskPartialStream?: BashTerminalStreamState;
+      /** Latest text streamed by task/task_batch partial updates, used when
+       *  Aethon has to synthesize an error result after an interrupted
+       *  delegation before pi emits tool_execution_end. */
+      taskPartialText?: string;
       /** Epoch ms — when tool_execution_start fired. Used by the M6 P4
        *  `tool-card` component to render a live elapsed-time clock. */
       startedAt?: number;
@@ -272,6 +276,9 @@ export interface TabRecord {
        *  emitted tool_execution_end (e.g. user pressed Stop). */
       endedAt?: number;
       status?: "cancelled";
+      /** Set once Aethon has inserted a model-visible synthetic error for an
+       *  interrupted subagent delegation, preventing duplicate backfills. */
+      syntheticResultEmitted?: boolean;
     }
   >;
   promptInFlight: boolean;

--- a/agent/tab-lifecycle.test.ts
+++ b/agent/tab-lifecycle.test.ts
@@ -23,6 +23,7 @@ import {
   installAethonRetryClassifier,
   resolveTabCwd,
   summarizeToolArgs,
+  synthesizeCancelledSubagentToolResults,
   tabSessionDir,
   toolCardPayload,
 } from "./tab-lifecycle";
@@ -1148,6 +1149,91 @@ describe("handleSessionEvent", () => {
       },
     });
     expect(rec.toolArgsCache.has("c1")).toBe(false);
+  });
+
+  it("synthesizes model-visible errors for cancelled subagent delegations", () => {
+    const f = makeFixture();
+    const rec = fakeRec();
+    const messages: unknown[] = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call_batch_1",
+            name: "task_batch",
+            arguments: { tasks: [] },
+          },
+        ],
+      },
+    ];
+    const appendMessage = vi.fn();
+    rec.session = {
+      ...rec.session,
+      agent: { state: { messages } },
+      sessionManager: {
+        appendMessage,
+        getEntries: () => [],
+      },
+    } as TabRecord["session"];
+    rec.toolArgsCache.set("call_batch_1", {
+      name: "task_batch",
+      summary: "3 agents",
+      uiId: "tool-1-call_batch_1",
+      startedAt: 1_000,
+      endedAt: 2_000,
+      status: "cancelled",
+      taskPartialText: "## qwen\npartial progress",
+    });
+
+    const count = synthesizeCancelledSubagentToolResults(f.state, rec, "tab-1");
+
+    expect(count).toBe(1);
+    expect(messages.at(-1)).toMatchObject({
+      role: "toolResult",
+      toolCallId: "call_batch_1",
+      toolName: "task_batch",
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: expect.stringContaining("Partial output before interruption"),
+        },
+      ],
+    });
+    expect(appendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        role: "toolResult",
+        toolCallId: "call_batch_1",
+        isError: true,
+      }),
+    );
+    expect(synthesizeCancelledSubagentToolResults(f.state, rec, "tab-1")).toBe(
+      0,
+    );
+  });
+
+  it("does not synthesize model-visible errors for cancelled bash tools", () => {
+    const f = makeFixture();
+    const rec = fakeRec();
+    const messages: unknown[] = [];
+    rec.session = {
+      ...rec.session,
+      agent: { state: { messages } },
+    } as TabRecord["session"];
+    rec.toolArgsCache.set("call_bash_1", {
+      name: "bash",
+      summary: "sleep 60",
+      uiId: "tool-1-call_bash_1",
+      startedAt: 1_000,
+      endedAt: 2_000,
+      status: "cancelled",
+    });
+
+    expect(synthesizeCancelledSubagentToolResults(f.state, rec, "tab-1")).toBe(
+      0,
+    );
+    expect(messages).toEqual([]);
   });
 
   it("agent_end clears promptInFlight, sets agentEndFired, emits response_end", () => {

--- a/agent/tab-lifecycle.test.ts
+++ b/agent/tab-lifecycle.test.ts
@@ -1,3 +1,6 @@
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
   AethonAgentState,
@@ -1211,6 +1214,69 @@ describe("handleSessionEvent", () => {
     expect(synthesizeCancelledSubagentToolResults(f.state, rec, "tab-1")).toBe(
       0,
     );
+  });
+
+  it("does not raw-append duplicates when the session manager already has the synthetic result", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "aethon-tab-lifecycle-"));
+    const sessionsDir = join(dir, "sessions");
+    const tabDir = join(sessionsDir, "tab-1");
+    const sessionFile = join(tabDir, "session.jsonl");
+    await mkdir(tabDir, { recursive: true });
+    await writeFile(
+      sessionFile,
+      [
+        JSON.stringify({ type: "session", id: "session-1", cwd: "/repo" }),
+        JSON.stringify({
+          type: "message",
+          id: "existing-tool-result",
+          message: {
+            role: "toolResult",
+            toolCallId: "call_batch_1",
+            toolName: "task_batch",
+            content: [{ type: "text", text: "already synthesized" }],
+            isError: true,
+          },
+        }),
+      ].join("\n") + "\n",
+      "utf8",
+    );
+    const f = makeFixture({ sessionsDir });
+    f.state.tabProjectCwds.set("tab-1", "/repo");
+    const rec = fakeRec();
+    const appendMessage = vi.fn();
+    rec.session = {
+      ...rec.session,
+      agent: { state: { messages: [] } },
+      sessionManager: {
+        appendMessage,
+        getEntries: () => [
+          {
+            message: {
+              role: "toolResult",
+              toolCallId: "call_batch_1",
+            },
+          },
+        ],
+      },
+    } as TabRecord["session"];
+    rec.toolArgsCache.set("call_batch_1", {
+      name: "task_batch",
+      summary: "3 agents",
+      uiId: "tool-1-call_batch_1",
+      startedAt: 1_000,
+      endedAt: 2_000,
+      status: "cancelled",
+    });
+
+    expect(synthesizeCancelledSubagentToolResults(f.state, rec, "tab-1")).toBe(
+      1,
+    );
+    await Promise.resolve();
+
+    expect(appendMessage).not.toHaveBeenCalled();
+    const raw = await readFile(sessionFile, "utf8");
+    expect(raw.trim().split(/\r?\n/)).toHaveLength(2);
+    expect(raw).not.toContain("aethon-synthetic-tool-result");
   });
 
   it("does not synthesize model-visible errors for cancelled bash tools", () => {

--- a/agent/tab-lifecycle/events.ts
+++ b/agent/tab-lifecycle/events.ts
@@ -756,9 +756,7 @@ export function handleSessionEvent(
         });
         deps.send({ type: "a2ui", tabId, id: cached.uiId, payload });
         const extracted = extractToolContent(ev.partialResult);
-        if (ev.toolName === "task" || ev.toolName === "task_batch") {
-          cached.taskPartialText = extracted.text;
-        }
+        cached.taskPartialText = extracted.text;
         const streamed = consumeBashTerminalSnapshot(
           extracted.text,
           cached.taskPartialStream,

--- a/agent/tab-lifecycle/events.ts
+++ b/agent/tab-lifecycle/events.ts
@@ -41,6 +41,7 @@ import {
   toolCardPayload,
 } from "../tool-card";
 import { emitBashResult } from "./terminal";
+import { synthesizeCancelledSubagentToolResults } from "./tools";
 import {
   cancelAethonRetry,
   removeTrailingFailureMessage,
@@ -755,6 +756,9 @@ export function handleSessionEvent(
         });
         deps.send({ type: "a2ui", tabId, id: cached.uiId, payload });
         const extracted = extractToolContent(ev.partialResult);
+        if (ev.toolName === "task" || ev.toolName === "task_batch") {
+          cached.taskPartialText = extracted.text;
+        }
         const streamed = consumeBashTerminalSnapshot(
           extracted.text,
           cached.taskPartialStream,
@@ -909,6 +913,7 @@ export function handleSessionEvent(
       } else {
         turnLog.info(log);
       }
+      synthesizeCancelledSubagentToolResults(state, rec, tabId);
       for (const [toolCallId, cached] of rec.toolArgsCache) {
         if (cached.endedAt !== undefined) rec.toolArgsCache.delete(toolCallId);
       }
@@ -1058,6 +1063,7 @@ function finalizeFailedTurn(
   if (!rec || rec.agentEndFired) return;
   cancelAethonRetry(rec);
   resetContextOverflowRecovery(rec);
+  synthesizeCancelledSubagentToolResults(state, rec, tabId);
   rec.agentEndFired = true;
   rec.promptInFlight = false;
   if (state.currentAgentTabId === tabId) {

--- a/agent/tab-lifecycle/index.ts
+++ b/agent/tab-lifecycle/index.ts
@@ -34,7 +34,10 @@ export {
   tabSessionDir,
 } from "./utils";
 export { emitBashResult } from "./terminal";
-export { cancelRunningToolCards } from "./tools";
+export {
+  cancelRunningToolCards,
+  synthesizeCancelledSubagentToolResults,
+} from "./tools";
 export {
   buildPickerModels,
   defaultModelKey,

--- a/agent/tab-lifecycle/lifecycle.ts
+++ b/agent/tab-lifecycle/lifecycle.ts
@@ -41,7 +41,10 @@ import {
 import { wrapWithSourceGuard } from "../source-guard";
 import { logger } from "../logger";
 import { authProfileServicesForTab } from "../auth-profiles";
-import { findSessionFileMatchingCwd } from "../session-history";
+import {
+  findSessionFileMatchingCwd,
+  repairDanglingSubagentToolResults,
+} from "../session-history";
 import type { AethonAgentState, TabRecord } from "../state";
 import { contextUsageSnapshot, emitContextUsage } from "../context-usage";
 import { handleSessionEvent } from "./events";
@@ -119,6 +122,17 @@ export async function ensureTab(
     // fresh under the same dir rather than picking up an unrelated
     // project's history (`continueRecent` would).
     const matching = await findSessionFileMatchingCwd(dir, resolvedCwd);
+    if (matching) {
+      await repairDanglingSubagentToolResults(matching).catch(
+        (err: unknown) => {
+          lifecycleLog.warn(
+            `subagent result repair failed for ${matching}: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          );
+        },
+      );
+    }
     sessionManager = matching
       ? SessionManager.open(matching, dir)
       : SessionManager.create(resolvedCwd, dir);

--- a/agent/tab-lifecycle/tools.ts
+++ b/agent/tab-lifecycle/tools.ts
@@ -79,15 +79,18 @@ function appendLiveSyntheticToolResult(
   ) {
     messages.push(message);
   }
+  const alreadyPersisted = sessionManagerHasToolResult(
+    session,
+    result.toolCallId,
+  );
   const appendMessage = session.sessionManager?.appendMessage;
-  if (
-    typeof appendMessage === "function" &&
-    !sessionManagerHasToolResult(session, result.toolCallId)
-  ) {
-    appendMessage.call(session.sessionManager, message);
+  if (typeof appendMessage === "function") {
+    if (!alreadyPersisted) {
+      appendMessage.call(session.sessionManager, message);
+    }
     return true;
   }
-  return false;
+  return alreadyPersisted;
 }
 
 async function persistSyntheticToolResults(

--- a/agent/tab-lifecycle/tools.ts
+++ b/agent/tab-lifecycle/tools.ts
@@ -14,10 +14,142 @@
 
 import { logger } from "../logger";
 import { toolCardPayload } from "../tool-card";
-import type { TabRecord } from "../state";
-import type { TabLifecycleDeps } from "./utils";
+import type { AethonAgentState, TabRecord } from "../state";
+import {
+  appendSyntheticSubagentToolResults,
+  findSessionFileMatchingCwd,
+  isSubagentToolName,
+  latestSessionLog,
+  syntheticSubagentToolResultMessage,
+  type SyntheticSubagentToolResult,
+} from "../session-history";
+import { tabSessionDir, type TabLifecycleDeps } from "./utils";
 
 const turnLog = logger.scope("turn");
+const subagentLog = logger.scope("subagent");
+
+interface ToolResultSessionState {
+  agent?: {
+    state?: {
+      messages?: unknown[];
+    };
+  };
+  sessionManager?: {
+    appendMessage?: (message: unknown) => unknown;
+    getEntries?: () => unknown[];
+  };
+}
+
+function hasToolResultMessage(
+  messages: readonly unknown[],
+  toolCallId: string,
+): boolean {
+  return messages.some((message) => {
+    if (!message || typeof message !== "object") return false;
+    const record = message as Record<string, unknown>;
+    return record.role === "toolResult" && record.toolCallId === toolCallId;
+  });
+}
+
+function sessionManagerHasToolResult(
+  session: ToolResultSessionState,
+  toolCallId: string,
+): boolean {
+  const entries = session.sessionManager?.getEntries?.();
+  if (!Array.isArray(entries)) return false;
+  return entries.some((entry) => {
+    if (!entry || typeof entry !== "object") return false;
+    const message = (entry as Record<string, unknown>).message;
+    if (!message || typeof message !== "object") return false;
+    const record = message as Record<string, unknown>;
+    return record.role === "toolResult" && record.toolCallId === toolCallId;
+  });
+}
+
+function appendLiveSyntheticToolResult(
+  rec: TabRecord,
+  result: SyntheticSubagentToolResult,
+): boolean {
+  const session = rec.session as ToolResultSessionState;
+  const message = syntheticSubagentToolResultMessage(result);
+  const messages = session.agent?.state?.messages;
+  if (
+    Array.isArray(messages) &&
+    !hasToolResultMessage(messages, result.toolCallId)
+  ) {
+    messages.push(message);
+  }
+  const appendMessage = session.sessionManager?.appendMessage;
+  if (
+    typeof appendMessage === "function" &&
+    !sessionManagerHasToolResult(session, result.toolCallId)
+  ) {
+    appendMessage.call(session.sessionManager, message);
+    return true;
+  }
+  return false;
+}
+
+async function persistSyntheticToolResults(
+  state: AethonAgentState,
+  tabId: string,
+  results: SyntheticSubagentToolResult[],
+): Promise<void> {
+  if (results.length === 0) return;
+  const dir = tabSessionDir(state, tabId);
+  const cwd =
+    state.tabProjectCwds.get(tabId) ?? state.currentProjectCwd ?? undefined;
+  const matching = cwd ? await findSessionFileMatchingCwd(dir, cwd) : undefined;
+  const fallback =
+    !matching && tabId !== "default" ? await latestSessionLog(dir) : undefined;
+  const path = matching ?? fallback?.path;
+  if (!path) return;
+  await appendSyntheticSubagentToolResults(path, results);
+}
+
+export function synthesizeCancelledSubagentToolResults(
+  state: AethonAgentState,
+  rec: TabRecord,
+  tabId: string,
+): number {
+  const results: SyntheticSubagentToolResult[] = [];
+  const rawPersistResults: SyntheticSubagentToolResult[] = [];
+  for (const [toolCallId, cached] of rec.toolArgsCache) {
+    if (
+      cached.status !== "cancelled" ||
+      cached.syntheticResultEmitted === true ||
+      !isSubagentToolName(cached.name)
+    ) {
+      continue;
+    }
+    const result = {
+      toolCallId,
+      toolName: cached.name,
+      ...(cached.taskPartialText
+        ? { partialText: cached.taskPartialText }
+        : {}),
+    };
+    const persistedThroughSessionManager = appendLiveSyntheticToolResult(
+      rec,
+      result,
+    );
+    cached.syntheticResultEmitted = true;
+    results.push(result);
+    if (!persistedThroughSessionManager) rawPersistResults.push(result);
+  }
+  if (rawPersistResults.length > 0) {
+    void persistSyntheticToolResults(state, tabId, rawPersistResults).catch(
+      (err: unknown) => {
+        subagentLog.warn(
+          `failed to persist synthetic subagent tool result tabId=${tabId}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      },
+    );
+  }
+  return results.length;
+}
 
 /** Stop visible timers for tools that were in-flight when the user aborted.
  *  Pi normally emits tool_execution_end, but abort paths can terminate the


### PR DESCRIPTION
## Summary
- synthesize model-visible error tool results when inline `task` / `task_batch` delegations are interrupted before pi emits `tool_execution_end`
- persist synthetic results through the live session manager when possible and repair dangling subagent calls during session restore
- keep repair scoped to the active session branch so stale rollback/fork branches are not resurrected

Closes #351

## Validation
- `codex review --uncommitted --title "Issue 351 synthetic subagent cancellations"` — no findings
- `bunx vitest run agent/session-history.test.ts agent/tab-lifecycle.test.ts`
- `bun run typecheck`
- `bun run lint`
- `env -u AETHON_WORKER_TAB_ID bunx vitest run`
