### PR TITLE
fix(tool-cards): dedupe task batch updates

### DIFF
--- a/agent/session-history.test.ts
+++ b/agent/session-history.test.ts
@@ -1269,6 +1269,63 @@ describe("readSessionTranscript", () => {
     ]);
   });
 
+  it("keeps the latest local tool-card snapshot by logical identity", async () => {
+    const dir = await tempRoot();
+    await appendLocalChatMessage(dir, {
+      id: "tool-1-call_batch_3-fc_ghi",
+      role: "agent",
+      a2ui: {
+        components: [
+          {
+            id: "tool-1-call_batch_3-fc_ghi",
+            type: "tool-card",
+            props: {
+              toolName: "task_batch",
+              startedAt: 1_000,
+            },
+            children: [],
+          },
+        ],
+      },
+      createdAt: 1_000,
+    });
+    await appendLocalChatMessage(dir, {
+      id: "tool-2-call_batch_3-fc_ghi",
+      role: "agent",
+      a2ui: {
+        components: [
+          {
+            id: "tool-2-call_batch_3-fc_ghi",
+            type: "tool-card",
+            props: {
+              toolName: "task_batch",
+              startedAt: 1_000,
+            },
+            children: [
+              {
+                id: "tool-2-call_batch_3-fc_ghi-result",
+                type: "subagent-result",
+                props: { content: "partial body" },
+              },
+            ],
+          },
+        ],
+      },
+      createdAt: 1_100,
+    });
+
+    const restored = await readSessionTranscript(dir);
+    expect(restored.map((message) => message.id)).toEqual([
+      "tool-2-call_batch_3-fc_ghi",
+    ]);
+    expect(restored[0].a2ui?.components[0].children).toEqual([
+      expect.objectContaining({
+        type: "subagent-result",
+        props: { content: "partial body" },
+      }),
+    ]);
+  });
+
   it("bounds the Aethon-local slash command overlay on append", async () => {
     const dir = await tempRoot();
     await writeFile(

--- a/agent/session-history/parse-local.ts
+++ b/agent/session-history/parse-local.ts
@@ -18,8 +18,46 @@ import {
   isChatRole,
   normalizeCwd,
   parseChatAttachments,
+  toolCardRecordsFromA2ui,
   trimText,
 } from "./shared";
+
+function toolCardDedupeKeys(message: RestoredChatMessage): string[] {
+  return toolCardRecordsFromA2ui(message.a2ui).map(
+    (record) => `${record.identity}\0${record.startedAt ?? ""}`,
+  );
+}
+
+function clearSeenToolCardKeys(
+  seenToolCards: Map<string, number>,
+  message: RestoredChatMessage,
+  index: number,
+): void {
+  for (const key of toolCardDedupeKeys(message)) {
+    if (seenToolCards.get(key) === index) seenToolCards.delete(key);
+  }
+}
+
+function rememberToolCardKeys(
+  seenToolCards: Map<string, number>,
+  message: RestoredChatMessage,
+  index: number,
+): void {
+  for (const key of toolCardDedupeKeys(message)) {
+    seenToolCards.set(key, index);
+  }
+}
+
+function firstSeenToolCardIndex(
+  seenToolCards: ReadonlyMap<string, number>,
+  message: RestoredChatMessage,
+): number | undefined {
+  for (const key of toolCardDedupeKeys(message)) {
+    const index = seenToolCards.get(key);
+    if (index !== undefined) return index;
+  }
+  return undefined;
+}
 
 export function parseLocalChatLines(
   lines: Iterable<string>,
@@ -27,6 +65,7 @@ export function parseLocalChatLines(
 ): RestoredChatMessage[] {
   const messages: RestoredChatMessage[] = [];
   const seen = new Map<string, number>();
+  const seenToolCards = new Map<string, number>();
   const targetCwd = normalizeCwd(expectedCwd);
   for (const line of lines) {
     const trimmed = line.trim();
@@ -70,11 +109,18 @@ export function parseLocalChatLines(
         : {}),
       ...(entryCwd ? { cwd: entryCwd } : {}),
     };
-    const existingIndex = seen.get(id);
+    const existingIndex =
+      seen.get(id) ?? firstSeenToolCardIndex(seenToolCards, message);
     if (existingIndex !== undefined) {
+      const previous = messages[existingIndex];
+      seen.delete(previous.id);
+      clearSeenToolCardKeys(seenToolCards, previous, existingIndex);
       messages[existingIndex] = message;
+      seen.set(id, existingIndex);
+      rememberToolCardKeys(seenToolCards, message, existingIndex);
     } else {
       seen.set(id, messages.length);
+      rememberToolCardKeys(seenToolCards, message, messages.length);
       messages.push(message);
     }
   }

--- a/agent/session-history/restore.ts
+++ b/agent/session-history/restore.ts
@@ -22,6 +22,7 @@ import { parseSessionHistoryLines } from "./parse-pi";
 import { isSubagentToolName } from "./subagent-tool-results";
 import {
   MAX_RESTORED_MESSAGES,
+  toolCardRecordsFromA2ui,
   type RestoredChatAttachment,
   type RestoredChatMessage,
 } from "./shared";
@@ -97,47 +98,8 @@ function isCoveredByPiContent(
   });
 }
 
-function normalizeToolCallId(value: string): string {
-  return value.replace(/[^A-Za-z0-9_-]+/g, "-").slice(0, 96);
-}
-
-function toolCardIdentityFromId(id: string): string | undefined {
-  if (id.startsWith("restored-tool-")) {
-    return id.slice("restored-tool-".length);
-  }
-  const liveMatch = /^tool-\d+-(.+)$/.exec(id);
-  if (liveMatch) return normalizeToolCallId(liveMatch[1]);
-  return undefined;
-}
-
-function toolCardRecords(
-  message: RestoredChatMessage,
-): Array<{ identity: string; status?: unknown; toolName?: unknown }> {
-  const components = message.a2ui?.components ?? [];
-  const records: Array<{
-    identity: string;
-    status?: unknown;
-    toolName?: unknown;
-  }> = [];
-  for (const component of components) {
-    if (!component || typeof component !== "object") continue;
-    const record = component as Record<string, unknown>;
-    if (record.type !== "tool-card" || typeof record.id !== "string") {
-      continue;
-    }
-    const identity = toolCardIdentityFromId(record.id);
-    if (!identity) continue;
-    const props =
-      record.props && typeof record.props === "object"
-        ? (record.props as Record<string, unknown>)
-        : undefined;
-    records.push({
-      identity,
-      status: props?.status,
-      toolName: props?.toolName,
-    });
-  }
-  return records;
+function toolCardRecords(message: RestoredChatMessage) {
+  return toolCardRecordsFromA2ui(message.a2ui);
 }
 
 function toolCardIdentities(message: RestoredChatMessage): string[] {

--- a/agent/session-history/shared.ts
+++ b/agent/session-history/shared.ts
@@ -69,6 +69,55 @@ export function hasA2ui(value: unknown): value is { components: unknown[] } {
   );
 }
 
+export interface ToolCardRecord {
+  identity: string;
+  startedAt?: number;
+  status?: unknown;
+  toolName?: unknown;
+}
+
+export function normalizeToolCallId(value: string): string {
+  return value.replace(/[^A-Za-z0-9_-]+/g, "-").slice(0, 96);
+}
+
+export function toolCardIdentityFromId(id: string): string | undefined {
+  if (id.startsWith("restored-tool-")) {
+    return id.slice("restored-tool-".length);
+  }
+  const liveMatch = /^tool-\d+-(.+)$/.exec(id);
+  if (liveMatch) return normalizeToolCallId(liveMatch[1]);
+  return undefined;
+}
+
+export function toolCardRecordsFromA2ui(
+  a2ui: { components: unknown[] } | undefined,
+): ToolCardRecord[] {
+  const records: ToolCardRecord[] = [];
+  for (const component of a2ui?.components ?? []) {
+    if (!component || typeof component !== "object") continue;
+    const record = component as Record<string, unknown>;
+    if (record.type !== "tool-card" || typeof record.id !== "string") {
+      continue;
+    }
+    const identity = toolCardIdentityFromId(record.id);
+    if (!identity) continue;
+    const props =
+      record.props && typeof record.props === "object"
+        ? (record.props as Record<string, unknown>)
+        : undefined;
+    records.push({
+      identity,
+      ...(typeof props?.startedAt === "number" &&
+      Number.isFinite(props.startedAt)
+        ? { startedAt: props.startedAt }
+        : {}),
+      ...(props && "status" in props ? { status: props.status } : {}),
+      ...(props && "toolName" in props ? { toolName: props.toolName } : {}),
+    });
+  }
+  return records;
+}
+
 export function parseChatAttachments(value: unknown): RestoredChatAttachment[] {
   if (!Array.isArray(value)) return [];
   return value.flatMap((item) => {

--- a/src/hooks/bridgeMessageHandlers/a2ui.test.ts
+++ b/src/hooks/bridgeMessageHandlers/a2ui.test.ts
@@ -5,6 +5,17 @@ import { buildHandlerFixture } from "./testFixtures";
 import { makeEmptyTab } from "../../types/tab";
 import type { ChatMessage } from "../../types/a2ui";
 
+function applyAppendByMessageId(
+  tab: ReturnType<typeof makeEmptyTab>,
+  msg: ChatMessage,
+) {
+  const messages = [...tab.messages];
+  const index = messages.findIndex((message) => message.id === msg.id);
+  if (index >= 0) messages[index] = msg;
+  else messages.push(msg);
+  return { ...tab, messages };
+}
+
 describe("handleA2ui", () => {
   it("appends an a2ui bubble and flips waiting on done", () => {
     const { ctx, mocks } = buildHandlerFixture({
@@ -91,6 +102,256 @@ describe("handleA2ui", () => {
       }),
       "tab-1",
     );
+  });
+
+  it("updates a running task_batch tool card by identity when message ids differ", () => {
+    let tab = makeEmptyTab("tab-1", "Tab 1");
+    const { ctx, mocks } = buildHandlerFixture({
+      state: { activeTabId: "tab-1", tabs: [tab] },
+    });
+    ctx.updateTab = vi.fn((_tabId, updater) => {
+      tab = updater(tab);
+    });
+    ctx.appendMessage = vi.fn((message: ChatMessage) => {
+      tab = applyAppendByMessageId(tab, message);
+    });
+
+    const startPayload = {
+      components: [
+        {
+          id: "tool-1-call_batch_1-fc_abc",
+          type: "tool-card",
+          props: {
+            title: "task_batch",
+            toolName: "task_batch",
+            description: "gpt-5-4-mini, qwen3-coder · inline",
+            startedAt: 1_000,
+          },
+          children: [],
+        },
+      ],
+    };
+    const updatePayload = {
+      components: [
+        {
+          id: "tool-2-call_batch_1-fc_abc",
+          type: "tool-card",
+          props: {
+            title: "task_batch",
+            toolName: "task_batch",
+            description: "gpt-5-4-mini, qwen3-coder · inline",
+            startedAt: 1_000,
+          },
+          children: [
+            {
+              id: "tool-2-call_batch_1-fc_abc-result",
+              type: "subagent-result",
+              props: { content: "partial audit from subagents" },
+            },
+          ],
+        },
+      ],
+    };
+
+    handleA2ui(
+      {
+        type: "a2ui",
+        payload: startPayload,
+        id: "tool-1-call_batch_1-fc_abc",
+        tabId: "tab-1",
+      },
+      ctx,
+    );
+    handleA2ui(
+      {
+        type: "a2ui",
+        payload: updatePayload,
+        id: "tool-2-call_batch_1-fc_abc",
+        tabId: "tab-1",
+      },
+      ctx,
+    );
+
+    expect(tab.messages).toHaveLength(1);
+    expect(tab.messages[0]).toMatchObject({
+      id: "tool-2-call_batch_1-fc_abc",
+      role: "agent",
+      a2ui: updatePayload,
+    });
+    expect(tab.messages[0].a2ui?.components[0].children).toEqual([
+      expect.objectContaining({
+        type: "subagent-result",
+        props: { content: "partial audit from subagents" },
+      }),
+    ]);
+    expect(mocks.persistLocalChatMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({ id: "tool-2-call_batch_1-fc_abc" }),
+      "tab-1",
+    );
+  });
+
+  it("replaces a running task_batch card with a synthetic cancellation by identity", () => {
+    let tab = makeEmptyTab("tab-1", "Tab 1");
+    const { ctx } = buildHandlerFixture({
+      state: { activeTabId: "tab-1", tabs: [tab] },
+    });
+    ctx.updateTab = vi.fn((_tabId, updater) => {
+      tab = updater(tab);
+    });
+    ctx.appendMessage = vi.fn((message: ChatMessage) => {
+      tab = applyAppendByMessageId(tab, message);
+    });
+
+    const startPayload = {
+      components: [
+        {
+          id: "tool-1-call_batch_2-fc_def",
+          type: "tool-card",
+          props: {
+            title: "task_batch",
+            toolName: "task_batch",
+            startedAt: 1_000,
+          },
+          children: [],
+        },
+      ],
+    };
+    const cancelPayload = {
+      components: [
+        {
+          id: "tool-2-call_batch_2-fc_def",
+          type: "tool-card",
+          props: {
+            title: "task_batch",
+            toolName: "task_batch",
+            startedAt: 1_000,
+            endedAt: 1_500,
+            status: "cancelled",
+          },
+          children: [
+            {
+              id: "tool-2-call_batch_2-fc_def-result",
+              type: "subagent-result",
+              props: { content: "Cancelled by user.", isError: true },
+            },
+          ],
+        },
+      ],
+    };
+
+    handleA2ui(
+      {
+        type: "a2ui",
+        payload: startPayload,
+        id: "tool-1-call_batch_2-fc_def",
+        tabId: "tab-1",
+      },
+      ctx,
+    );
+    handleA2ui(
+      {
+        type: "a2ui",
+        payload: cancelPayload,
+        id: "tool-2-call_batch_2-fc_def",
+        tabId: "tab-1",
+      },
+      ctx,
+    );
+
+    expect(tab.messages).toHaveLength(1);
+    expect(tab.messages[0]).toMatchObject({
+      id: "tool-2-call_batch_2-fc_def",
+      a2ui: cancelPayload,
+    });
+  });
+
+  it("preserves cancellation state when a late running update has a sibling id", () => {
+    const cancelledId = "tool-1-call_batch_late-fc_jkl";
+    const updateId = "tool-2-call_batch_late-fc_jkl";
+    const tab = {
+      ...makeEmptyTab("tab-1", "Tab 1"),
+      messages: [
+        {
+          id: cancelledId,
+          role: "agent",
+          a2ui: {
+            components: [
+              {
+                id: cancelledId,
+                type: "tool-card",
+                props: {
+                  title: "task_batch",
+                  toolName: "task_batch",
+                  startedAt: 1_000,
+                  endedAt: 1_500,
+                  status: "cancelled",
+                },
+              },
+            ],
+          },
+        } satisfies ChatMessage,
+      ],
+    };
+    const { ctx, mocks } = buildHandlerFixture({
+      state: { activeTabId: "tab-1", tabs: [tab] },
+    });
+    const payload = {
+      components: [
+        {
+          id: updateId,
+          type: "tool-card",
+          props: {
+            title: "task_batch",
+            toolName: "task_batch",
+            startedAt: 1_000,
+          },
+          children: [
+            {
+              id: `${updateId}-result`,
+              type: "subagent-result",
+              props: { content: "late partial body" },
+            },
+          ],
+        },
+      ],
+    };
+
+    handleA2ui({ type: "a2ui", payload, id: updateId, tabId: "tab-1" }, ctx);
+
+    expect(mocks.appendMessage).not.toHaveBeenCalled();
+    const [, updater] = mocks.updateTab.mock.calls[0];
+    const out = updater(tab);
+    expect(out.messages).toHaveLength(1);
+    expect(out.messages[0]).toMatchObject({
+      id: updateId,
+      role: "agent",
+      a2ui: {
+        components: [
+          {
+            id: updateId,
+            props: {
+              status: "cancelled",
+              startedAt: 1_000,
+              endedAt: 1_500,
+            },
+            children: [
+              {
+                id: `${updateId}-late-completion-notice`,
+                props: {
+                  content: expect.stringContaining(
+                    "reported a final result after it had already been marked stopped",
+                  ),
+                },
+              },
+              {
+                id: `${updateId}-result`,
+                props: { content: "late partial body" },
+              },
+            ],
+          },
+        ],
+      },
+    });
   });
 
   it("preserves cancellation state when a late final event has a sibling id", () => {

--- a/src/hooks/bridgeMessageHandlers/a2ui.ts
+++ b/src/hooks/bridgeMessageHandlers/a2ui.ts
@@ -6,7 +6,7 @@ import type { BridgeMessageHandler } from "./types";
 import { clearHangWarn } from "./hangWarn";
 import { flushResponseDeltas } from "./responseDelta";
 
-function completedToolCard(payload: A2UIPayload): A2UIComponent | undefined {
+function upsertableToolCard(payload: A2UIPayload): A2UIComponent | undefined {
   const toolCards = (payload.components ?? []).filter(
     (component) =>
       component?.type === "tool-card" && typeof component.id === "string",
@@ -14,7 +14,6 @@ function completedToolCard(payload: A2UIPayload): A2UIComponent | undefined {
   if (toolCards.length !== 1) return undefined;
   const component = toolCards[0];
   if (component.props?.startedAt === undefined) return undefined;
-  if (component.props.endedAt === undefined) return undefined;
   return component;
 }
 
@@ -67,36 +66,39 @@ function componentMatchesIncomingToolId(
 function componentMatchesToolIdentity(
   component: A2UIComponent | undefined,
   identity: string,
+  incomingStartedAt: number | undefined,
 ): boolean {
   if (component?.type !== "tool-card") return false;
-  if (component.props?.startedAt === undefined) return false;
+  const currentStartedAt = numericProp(component, "startedAt");
+  if (currentStartedAt === undefined) return false;
+  if (
+    incomingStartedAt !== undefined &&
+    currentStartedAt !== incomingStartedAt
+  ) {
+    return false;
+  }
   return (
     typeof component.id === "string" &&
     toolCardIdentityFromId(component.id) === identity
   );
 }
 
-function findCurrentToolCardMatch(
+function findCurrentToolCardMatches(
   messages: ChatMessage[],
   incomingId: string | undefined,
   identity: string | undefined,
-): { index: number; component: A2UIComponent } | undefined {
-  if (incomingId) {
-    for (let index = 0; index < messages.length; index += 1) {
-      const component = (messages[index].a2ui?.components ?? []).find((item) =>
-        componentMatchesIncomingToolId(item, incomingId),
-      );
-      if (component) return { index, component };
-    }
-  }
-  if (!identity) return undefined;
+  incomingStartedAt: number | undefined,
+): Array<{ index: number; component: A2UIComponent }> {
+  const matches: Array<{ index: number; component: A2UIComponent }> = [];
   for (let index = 0; index < messages.length; index += 1) {
-    const component = (messages[index].a2ui?.components ?? []).find((item) =>
-      componentMatchesToolIdentity(item, identity),
-    );
-    if (component) return { index, component };
+    const component = (messages[index].a2ui?.components ?? []).find((item) => {
+      if (componentMatchesIncomingToolId(item, incomingId ?? "")) return true;
+      if (!identity) return false;
+      return componentMatchesToolIdentity(item, identity, incomingStartedAt);
+    });
+    if (component) matches.push({ index, component });
   }
-  return undefined;
+  return matches;
 }
 
 function insertChronologically(
@@ -107,8 +109,7 @@ function insertChronologically(
   if (typeof createdAt !== "number") return [...messages, message];
   const insertAt = messages.findIndex(
     (current) =>
-      typeof current.createdAt === "number" &&
-      current.createdAt > createdAt,
+      typeof current.createdAt === "number" && current.createdAt > createdAt,
   );
   if (insertAt < 0) return [...messages, message];
   const next = [...messages];
@@ -128,15 +129,20 @@ function cancellationHistoryNotice(componentId: string): A2UIComponent {
   };
 }
 
-function preserveCancelledToolState(payload: A2UIPayload): A2UIPayload {
+function preserveCancelledToolState(
+  payload: A2UIPayload,
+  fallbackEndedAt?: number,
+): A2UIPayload {
   return {
     ...payload,
     components: (payload.components ?? []).map((component) => {
       if (component?.type !== "tool-card") return component;
+      const endedAt = numericProp(component, "endedAt") ?? fallbackEndedAt;
       return {
         ...component,
         props: {
           ...(component.props ?? {}),
+          ...(endedAt !== undefined ? { endedAt } : {}),
           status: "cancelled",
         },
         children: [
@@ -148,29 +154,48 @@ function preserveCancelledToolState(payload: A2UIPayload): A2UIPayload {
   };
 }
 
-function upsertCompletedToolCardMessage(
+function upsertToolCardMessage(
   current: Tab,
   message: ChatMessage,
   payload: A2UIPayload,
-  completedCard: A2UIComponent,
+  toolCard: A2UIComponent,
   identity: string | undefined,
 ): { tab: Tab; message: ChatMessage } {
-  const incomingId = completedCard.id;
-  const matched = findCurrentToolCardMatch(
+  const incomingId = toolCard.id;
+  const incomingStartedAt = numericProp(toolCard, "startedAt");
+  const matches = findCurrentToolCardMatches(
     current.messages,
     incomingId,
     identity,
+    incomingStartedAt,
   );
-  if (matched) {
+  if (matches.length > 0) {
+    const targetIndex = matches[0].index;
+    const duplicateIndexes = new Set(
+      matches.slice(1).map((match) => match.index),
+    );
+    const matchedCancelled = matches.some((match) =>
+      isCancelledToolCard(match.component),
+    );
+    const matchedCancelledEndedAt = matches
+      .map((match) => numericProp(match.component, "endedAt"))
+      .find((value) => value !== undefined);
+    const incomingCancelled =
+      payload.components?.some(isCancelledToolCard) === true;
     const finalPayload =
-      isCancelledToolCard(matched.component) &&
-      payload.components?.some(isCancelledToolCard) !== true
-        ? preserveCancelledToolState(payload)
+      matchedCancelled && !incomingCancelled
+        ? preserveCancelledToolState(payload, matchedCancelledEndedAt)
         : payload;
-    const nextMessages = [...current.messages];
     const finalMessage = { ...message, a2ui: finalPayload };
-    nextMessages[matched.index] = finalMessage;
-    return { tab: { ...current, messages: nextMessages }, message: finalMessage };
+    const nextMessages = current.messages.flatMap((currentMessage, index) => {
+      if (index === targetIndex) return [finalMessage];
+      if (duplicateIndexes.has(index)) return [];
+      return [currentMessage];
+    });
+    return {
+      tab: { ...current, messages: nextMessages },
+      message: finalMessage,
+    };
   }
 
   const sameMessageIndex = current.messages.findIndex(
@@ -203,24 +228,22 @@ export const handleA2ui: BridgeMessageHandler = (data, ctx) => {
   flushResponseDeltas(tabId);
   if (payload) {
     const createdAt = createdAtFromPayload(payload);
-    const completedCard = completedToolCard(payload);
-    const identity = completedCard
-      ? toolCardIdentityFromId(completedCard.id)
-      : undefined;
+    const toolCard = upsertableToolCard(payload);
+    const identity = toolCard ? toolCardIdentityFromId(toolCard.id) : undefined;
     const message: ChatMessage = {
       id,
       role: "agent",
       a2ui: payload,
       ...(createdAt !== undefined ? { createdAt } : {}),
     };
-    if (completedCard) {
+    if (toolCard) {
       let durableMessage = message;
       ctx.updateTab(tabId, (current) => {
-        const result = upsertCompletedToolCardMessage(
+        const result = upsertToolCardMessage(
           current,
           message,
           payload,
-          completedCard,
+          toolCard,
           identity,
         );
         durableMessage = result.message;


### PR DESCRIPTION
Closes #352.

## Summary
- upsert all started tool-card A2UI messages by stable tool identity, not only completed cards
- coalesce duplicate live cards and preserve cancelled terminal state across late partial/final updates
- dedupe local restored tool-card snapshots by logical identity so reload/reconcile keeps the latest useful card

## Validation
- `nix develop -c env -u AETHON_WORKER_TAB_ID bash -lc 'bun run typecheck && bun run lint && bunx vitest run src/hooks/bridgeMessageHandlers/a2ui.test.ts agent/session-history.test.ts && bunx vitest run'`\n- `nix develop -c env -u AETHON_WORKER_TAB_ID codex review --uncommitted`