### PR TITLE
fix(devshell): share effective config resolver

### DIFF
--- a/src-tauri/src/agent_process/spawn.rs
+++ b/src-tauri/src/agent_process/spawn.rs
@@ -313,7 +313,7 @@ fn apply_worker_devshell_env(app: &AppHandle, command: &mut Command, worker: Opt
         return;
     };
     let cwd = std::path::PathBuf::from(cwd);
-    let (enabled, configured_mode) = crate::commands::devshell::effective_config(app, &cwd);
+    let (enabled, configured_mode) = crate::devshell::effective_config(app, &cwd).into_parts();
     if enabled == "never" {
         return;
     }

--- a/src-tauri/src/commands/devshell.rs
+++ b/src-tauri/src/commands/devshell.rs
@@ -28,10 +28,6 @@ use tauri::{AppHandle, Emitter, Manager, Runtime, State};
 use crate::devshell::{
     AppEmitter, DetectMode, DevshellCache, DevshellEmitter, EnvForPath, StatusSnapshot,
 };
-use crate::helpers::config::{
-    normalize_devshell_enabled, normalize_devshell_mode, parse_config_toml,
-    parse_project_devshell_override,
-};
 
 /// Adapter so the devshell cache can emit Tauri events without taking
 /// a direct dependency on `tauri::AppHandle`. The cache calls
@@ -60,59 +56,6 @@ impl<R: Runtime> DevshellEmitter for TauriEmitter<R> {
 
 pub(crate) fn emitter_for<R: Runtime>(app: &AppHandle<R>) -> AppEmitter {
     AppEmitter::new(Arc::new(TauriEmitter::new(app.clone())) as Arc<dyn DevshellEmitter>)
-}
-
-/// Resolve `[devshell]` config — global toml merged with the
-/// optional `<root>/.aethon/devshell.toml` override. Returns the
-/// effective `(enabled, mode)` strings already normalised.
-pub(crate) fn effective_config<R: Runtime>(
-    app: &AppHandle<R>,
-    root: &Path,
-) -> (String, DetectMode) {
-    use std::io::Read;
-
-    // 1) Global config. Replicate aethon_state_path's home-dir
-    // resolution inline because the helper is bound to the default
-    // Tauri runtime and we want this command surface to be
-    // generic-runtime so tests can swap in a mock.
-    let home = match app.path().home_dir() {
-        Ok(h) => h,
-        Err(_) => return ("auto".into(), DetectMode::Auto),
-    };
-    let global_path = match crate::helpers::aethon_dir(Some(home)) {
-        Some(dir) => dir.join("config.toml"),
-        None => return ("auto".into(), DetectMode::Auto),
-    };
-    let mut buf = String::new();
-    if let Ok(file) = std::fs::File::open(&global_path) {
-        let _ = file.take(64 * 1024).read_to_string(&mut buf);
-    }
-    let global = parse_config_toml(&buf);
-    let mut enabled = global["devshell"]["enabled"]
-        .as_str()
-        .unwrap_or("auto")
-        .to_string();
-    let mut mode_str = global["devshell"]["mode"]
-        .as_str()
-        .unwrap_or("auto")
-        .to_string();
-
-    // 2) Per-project override (best-effort — malformed files are ignored).
-    let override_path = root.join(".aethon").join("devshell.toml");
-    if let Ok(mut text) = std::fs::read_to_string(&override_path) {
-        // Cap the read size for symmetry with the global config.
-        if text.len() > 64 * 1024 {
-            text.truncate(64 * 1024);
-        }
-        let parsed = parse_project_devshell_override(&text);
-        if let Some(e) = parsed.devshell.enabled {
-            enabled = normalize_devshell_enabled(Some(&e)).to_string();
-        }
-        if let Some(m) = parsed.devshell.mode {
-            mode_str = normalize_devshell_mode(Some(&m)).to_string();
-        }
-    }
-    (enabled, DetectMode::from_str(&mode_str))
 }
 
 pub(crate) fn forced_mode_mismatch_reason(
@@ -167,7 +110,7 @@ pub async fn devshell_status<R: Runtime>(
     args: StatusArgs,
 ) -> Result<StatusResponse, String> {
     let root = PathBuf::from(&args.root);
-    let (enabled, configured_mode) = effective_config(&app, &root);
+    let (enabled, configured_mode) = crate::devshell::effective_config(&app, &root).into_parts();
     let detected_kind = if enabled == "never" {
         None
     } else {
@@ -285,7 +228,7 @@ pub async fn devshell_prepare_for_path<R: Runtime>(
 ) -> Result<PrepareForPathResponse, String> {
     let cwd = PathBuf::from(&args.cwd);
     let include_env = args.include_env.unwrap_or(false);
-    let (enabled, configured_mode) = effective_config(&app, &cwd);
+    let (enabled, configured_mode) = crate::devshell::effective_config(&app, &cwd).into_parts();
     if enabled == "never" {
         return Ok(PrepareForPathResponse {
             enabled,
@@ -429,7 +372,7 @@ pub async fn devshell_env_for_path<R: Runtime>(
     args: EnvForPathArgs,
 ) -> Result<EnvForPathResponse, String> {
     let cwd = PathBuf::from(&args.cwd);
-    let (enabled, configured_mode) = effective_config(&app, &cwd);
+    let (enabled, configured_mode) = crate::devshell::effective_config(&app, &cwd).into_parts();
     if enabled == "never" {
         return Ok(EnvForPathResponse {
             enabled,
@@ -469,7 +412,7 @@ pub async fn devshell_refresh<R: Runtime>(
     args: RefreshArgs,
 ) -> Result<(), String> {
     let root = PathBuf::from(&args.root);
-    let (enabled, configured_mode) = effective_config(&app, &root);
+    let (enabled, configured_mode) = crate::devshell::effective_config(&app, &root).into_parts();
     if enabled == "never" {
         return Ok(());
     }

--- a/src-tauri/src/commands/startup.rs
+++ b/src-tauri/src/commands/startup.rs
@@ -675,7 +675,7 @@ async fn prepare_devshell_env(
     cache: &Arc<DevshellCache>,
     root: &Path,
 ) -> Result<BTreeMap<String, String>, String> {
-    let (enabled, configured_mode) = crate::commands::devshell::effective_config(app, root);
+    let (enabled, configured_mode) = crate::devshell::effective_config(app, root).into_parts();
     if enabled == "never" {
         return Ok(BTreeMap::new());
     }

--- a/src-tauri/src/devshell/config.rs
+++ b/src-tauri/src/devshell/config.rs
@@ -1,0 +1,267 @@
+//! Effective `[devshell]` config resolution shared by IPC, startup,
+//! agent spawn, and interactive PTY launch paths.
+//!
+//! The user-facing config can come from two places: the global
+//! `~/.aethon/config.toml` `[devshell]` section and an optional
+//! `<project>/.aethon/devshell.toml` override. Keep that merge in one
+//! non-IPC helper so command status/prepare and shell opens cannot drift.
+
+use std::io::Read;
+use std::path::Path;
+
+use tauri::{AppHandle, Manager, Runtime};
+
+use crate::helpers::config::{
+    normalize_devshell_enabled, normalize_devshell_mode, parse_config_toml,
+    parse_project_devshell_override,
+};
+
+use super::DetectMode;
+
+const CONFIG_READ_LIMIT_BYTES: u64 = 64 * 1024;
+const PROJECT_OVERRIDE_READ_LIMIT_BYTES: usize = 64 * 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EffectiveDevshellConfig {
+    /// Normalized `"auto" | "always" | "never"` policy.
+    pub enabled: String,
+    /// Normalized resolver mode as a typed value for cache/detect callers.
+    pub mode: DetectMode,
+}
+
+impl Default for EffectiveDevshellConfig {
+    fn default() -> Self {
+        Self {
+            enabled: "auto".to_string(),
+            mode: DetectMode::Auto,
+        }
+    }
+}
+
+impl EffectiveDevshellConfig {
+    pub fn new(enabled: String, mode: DetectMode) -> Self {
+        Self { enabled, mode }
+    }
+
+    pub fn into_parts(self) -> (String, DetectMode) {
+        (self.enabled, self.mode)
+    }
+}
+
+/// Resolve `[devshell]` config — global TOML merged with the optional
+/// `<root>/.aethon/devshell.toml` override. The result is normalized and
+/// ready for cache/detect callers.
+pub fn effective_config<R: Runtime>(app: &AppHandle<R>, root: &Path) -> EffectiveDevshellConfig {
+    // Replicate aethon_state_path's home-dir resolution here instead of using
+    // the default-runtime helper, so this stays generic over `Runtime` for
+    // tests and alternate app handles.
+    let home = match app.path().home_dir() {
+        Ok(home) => home,
+        Err(_) => return EffectiveDevshellConfig::default(),
+    };
+    let global_config_path = match crate::helpers::aethon_dir(Some(home)) {
+        Some(dir) => dir.join("config.toml"),
+        None => return EffectiveDevshellConfig::default(),
+    };
+    effective_config_from_paths(Some(&global_config_path), root)
+}
+
+fn effective_config_from_paths(
+    global_config_path: Option<&Path>,
+    root: &Path,
+) -> EffectiveDevshellConfig {
+    let global = parse_config_toml(&read_global_config(global_config_path));
+    let mut enabled = global["devshell"]["enabled"]
+        .as_str()
+        .unwrap_or("auto")
+        .to_string();
+    let mut mode = global["devshell"]["mode"]
+        .as_str()
+        .unwrap_or("auto")
+        .to_string();
+
+    let override_path = root.join(".aethon").join("devshell.toml");
+    if let Ok(mut text) = std::fs::read_to_string(&override_path) {
+        // Cap the read size for symmetry with the global config.
+        if text.len() > PROJECT_OVERRIDE_READ_LIMIT_BYTES {
+            text.truncate(PROJECT_OVERRIDE_READ_LIMIT_BYTES);
+        }
+        let parsed = parse_project_devshell_override(&text);
+        if let Some(value) = parsed.devshell.enabled {
+            enabled = normalize_devshell_enabled(Some(&value)).to_string();
+        }
+        if let Some(value) = parsed.devshell.mode {
+            mode = normalize_devshell_mode(Some(&value)).to_string();
+        }
+    }
+
+    EffectiveDevshellConfig::new(enabled, DetectMode::from_str(&mode))
+}
+
+fn read_global_config(global_config_path: Option<&Path>) -> String {
+    let Some(path) = global_config_path else {
+        return String::new();
+    };
+    let mut buf = String::new();
+    if let Ok(file) = std::fs::File::open(path) {
+        let _ = file.take(CONFIG_READ_LIMIT_BYTES).read_to_string(&mut buf);
+    }
+    buf
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{EffectiveDevshellConfig, effective_config_from_paths};
+    use crate::devshell::DetectMode;
+
+    fn write(path: &std::path::Path, content: &str) {
+        std::fs::create_dir_all(path.parent().expect("parent")).expect("mkdir");
+        std::fs::write(path, content).expect("write");
+    }
+
+    #[test]
+    fn defaults_when_global_config_is_missing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config = effective_config_from_paths(None, dir.path());
+
+        assert_eq!(config, EffectiveDevshellConfig::default());
+    }
+
+    #[test]
+    fn reads_global_defaults() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let global_path = dir.path().join("config.toml");
+        write(
+            &global_path,
+            r#"
+[devshell]
+enabled = "always"
+mode = "nix"
+"#,
+        );
+
+        let config = effective_config_from_paths(Some(&global_path), dir.path());
+
+        assert_eq!(config.enabled, "always");
+        assert_eq!(config.mode, DetectMode::Nix);
+    }
+
+    #[test]
+    fn normalizes_unknown_global_values() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let global_path = dir.path().join("config.toml");
+        write(
+            &global_path,
+            r#"
+[devshell]
+enabled = "sometimes"
+mode = "flake-ish"
+"#,
+        );
+
+        let config = effective_config_from_paths(Some(&global_path), dir.path());
+
+        assert_eq!(config.enabled, "auto");
+        assert_eq!(config.mode, DetectMode::Auto);
+    }
+
+    #[test]
+    fn project_override_takes_precedence_over_global_values() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let global_path = dir.path().join("config.toml");
+        write(
+            &global_path,
+            r#"
+[devshell]
+enabled = "always"
+mode = "nix"
+"#,
+        );
+        write(
+            &dir.path().join("project/.aethon/devshell.toml"),
+            r#"
+[devshell]
+enabled = "never"
+mode = "direnv"
+"#,
+        );
+
+        let config = effective_config_from_paths(Some(&global_path), &dir.path().join("project"));
+
+        assert_eq!(config.enabled, "never");
+        assert_eq!(config.mode, DetectMode::Direnv);
+    }
+
+    #[test]
+    fn malformed_project_override_falls_back_to_global_values() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let global_path = dir.path().join("config.toml");
+        write(
+            &global_path,
+            r#"
+[devshell]
+enabled = "always"
+mode = "nix-shell"
+"#,
+        );
+        write(
+            &dir.path().join("project/.aethon/devshell.toml"),
+            "=== broken ===",
+        );
+
+        let config = effective_config_from_paths(Some(&global_path), &dir.path().join("project"));
+
+        assert_eq!(config.enabled, "always");
+        assert_eq!(config.mode, DetectMode::NixShell);
+    }
+
+    #[test]
+    fn global_config_read_is_truncated_at_64_kib() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let global_path = dir.path().join("config.toml");
+        let mut content = " ".repeat(64 * 1024);
+        content.push_str(
+            r#"
+[devshell]
+enabled = "always"
+mode = "nix"
+"#,
+        );
+        write(&global_path, &content);
+
+        let config = effective_config_from_paths(Some(&global_path), dir.path());
+
+        assert_eq!(config, EffectiveDevshellConfig::default());
+    }
+
+    #[test]
+    fn project_override_read_is_truncated_at_64_kib() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let global_path = dir.path().join("config.toml");
+        write(
+            &global_path,
+            r#"
+[devshell]
+enabled = "always"
+mode = "nix"
+"#,
+        );
+        let mut override_content = " ".repeat(64 * 1024);
+        override_content.push_str(
+            r#"
+[devshell]
+enabled = "never"
+mode = "direnv"
+"#,
+        );
+        write(
+            &dir.path().join("project/.aethon/devshell.toml"),
+            &override_content,
+        );
+
+        let config = effective_config_from_paths(Some(&global_path), &dir.path().join("project"));
+
+        assert_eq!(config.enabled, "always");
+        assert_eq!(config.mode, DetectMode::Nix);
+    }
+}

--- a/src-tauri/src/devshell/mod.rs
+++ b/src-tauri/src/devshell/mod.rs
@@ -21,10 +21,12 @@
 //! [`crate::lib::run`] for the wiring.
 
 pub mod cache;
+pub mod config;
 pub mod detect;
 pub mod resolve;
 
 pub use cache::{
     AppEmitter, DevshellCache, DevshellEmitter, EnvForPath, StatusSnapshot, evict_stale_snapshots,
 };
+pub use config::effective_config;
 pub use detect::{DetectMode, detect_mode, forced_mode_mismatch};

--- a/src-tauri/src/shell/lifecycle/open.rs
+++ b/src-tauri/src/shell/lifecycle/open.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, Mutex};
 
 use portable_pty::{CommandBuilder, PtySize, native_pty_system};
 use serde::Deserialize;
-use tauri::{AppHandle, Manager, Runtime, State};
+use tauri::{AppHandle, Runtime, State};
 
 use super::reader::spawn_reader_thread;
 use super::registry::{
@@ -16,7 +16,7 @@ use super::registry::{
 };
 use crate::commands::devshell::TauriEmitter;
 use crate::devshell::detect::DevshellKind;
-use crate::devshell::{AppEmitter, DetectMode, DevshellCache, DevshellEmitter};
+use crate::devshell::{AppEmitter, DevshellCache, DevshellEmitter};
 use crate::shell::scrollback::Scrollback;
 use crate::shell::sharemode::{ShareMode, ShareState};
 
@@ -102,7 +102,8 @@ pub async fn shell_open<R: Runtime>(
 
     if let Some(cwd) = args.cwd.as_ref() {
         let cwd_path = std::path::PathBuf::from(cwd);
-        let (enabled, configured_mode) = devshell_effective_config(&app, &cwd_path);
+        let (enabled, configured_mode) =
+            crate::devshell::effective_config(&app, &cwd_path).into_parts();
         if enabled != "never" {
             if let Some(reason) =
                 crate::commands::devshell::forced_mode_mismatch_reason(&cwd_path, configured_mode)
@@ -405,60 +406,6 @@ fn clear_inherited_devshell_identity(cmd: &mut CommandBuilder) {
     ] {
         cmd.env(key, "");
     }
-}
-
-/// Read `[devshell] enabled` + `mode` from the global config (and any
-/// per-project override), returning the normalised pair the cache
-/// expects. Duplicates `commands::devshell::effective_config` rather
-/// than calling it because that function is `pub(crate)` and lives
-/// next to the IPC types — splitting hairs to avoid a circular
-/// crate-internal dependency.
-fn devshell_effective_config<R: Runtime>(
-    app: &AppHandle<R>,
-    root: &std::path::Path,
-) -> (String, DetectMode) {
-    use std::io::Read;
-
-    use crate::helpers::config::{
-        normalize_devshell_enabled, normalize_devshell_mode, parse_config_toml,
-        parse_project_devshell_override,
-    };
-
-    let home = match app.path().home_dir() {
-        Ok(h) => h,
-        Err(_) => return ("auto".into(), DetectMode::Auto),
-    };
-    let global_path = match crate::helpers::aethon_dir(Some(home)) {
-        Some(dir) => dir.join("config.toml"),
-        None => return ("auto".into(), DetectMode::Auto),
-    };
-    let mut buf = String::new();
-    if let Ok(file) = std::fs::File::open(&global_path) {
-        let _ = file.take(64 * 1024).read_to_string(&mut buf);
-    }
-    let global = parse_config_toml(&buf);
-    let mut enabled = global["devshell"]["enabled"]
-        .as_str()
-        .unwrap_or("auto")
-        .to_string();
-    let mut mode_str = global["devshell"]["mode"]
-        .as_str()
-        .unwrap_or("auto")
-        .to_string();
-    let override_path = root.join(".aethon").join("devshell.toml");
-    if let Ok(mut text) = std::fs::read_to_string(&override_path) {
-        if text.len() > 64 * 1024 {
-            text.truncate(64 * 1024);
-        }
-        let parsed = parse_project_devshell_override(&text);
-        if let Some(e) = parsed.devshell.enabled {
-            enabled = normalize_devshell_enabled(Some(&e)).to_string();
-        }
-        if let Some(m) = parsed.devshell.mode {
-            mode_str = normalize_devshell_mode(Some(&m)).to_string();
-        }
-    }
-    (enabled, DetectMode::from_str(&mode_str))
 }
 
 /// True when `command` names an interactive shell binary whose child


### PR DESCRIPTION
Closes #372.

## Summary
- Add a shared `crate::devshell::effective_config` resolver returning a typed `EffectiveDevshellConfig`.
- Route devshell IPC, shell open, startup prep, and agent worker spawn through the shared resolver.
- Remove the duplicate shell-local effective config implementation.
- Add focused Rust coverage for defaults, normalization, project override precedence, malformed override fallback, and 64 KiB truncation.

## Validation
- `nix develop -c cargo fmt --manifest-path src-tauri/Cargo.toml`
- `nix develop -c cargo test --manifest-path src-tauri/Cargo.toml --lib devshell`
- `codex review --uncommitted` (no findings)

Note: the first focused test attempt exposed missing JS dependencies for the sidecar build; ran `nix develop -c bun install` and reran successfully.