### PR TITLE
fix(config): centralize safe frontend writes

### DIFF
--- a/src/configWrites.test.ts
+++ b/src/configWrites.test.ts
@@ -1,0 +1,157 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  buildConfigWritePayload,
+  CONFIG_WRITE_SECTIONS,
+  mergeConfigPatch,
+  writeConfigPatch,
+} from "./configWrites";
+import { clearConfigCache, getConfig, type AethonConfig } from "./config";
+
+const invokeMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: invokeMock,
+}));
+
+const liveConfig: AethonConfig = {
+  ui: {
+    theme: "ember",
+    fontSize: 14,
+    restoreTabs: false,
+    notifyOnCompletion: true,
+    notifyMinDurationSeconds: 8,
+    thinkingVisibility: "show",
+    toolCallsVisibility: "hide",
+  },
+  agent: {
+    model: "openai/gpt-5.5",
+    thinkingLevel: "medium",
+    providerTimeoutSeconds: null,
+    codexFastMode: false,
+    bashTimeoutFloorSeconds: 300,
+    subagentTimeoutSeconds: 300,
+  },
+  shell: {
+    defaultShareMode: "private",
+    autoRestartAgent: true,
+    defaultCommand: null,
+    defaultArgs: [],
+    inheritEnv: true,
+    promptBeforeClose: true,
+  },
+  shortcuts: { newTabKind: "agent" },
+  voice: {
+    toggleHotkey: "mod+shift+m",
+    holdHotkey: "AltRight",
+    speakAgentReplies: false,
+    speakMaxChars: 600,
+    conversationContinuous: false,
+  },
+  updates: { channel: "nightly", disableAutoCheck: false },
+  devshell: {
+    enabled: "auto",
+    mode: "auto",
+    cacheTtlHours: 720,
+    refreshOnLockfileChange: true,
+  },
+  startup: { autoApprove: true },
+  guardrails: { softPromptAnchor: "stay inside repo", hardEnforceProjectRoot: true },
+};
+
+afterEach(() => {
+  invokeMock.mockReset();
+  clearConfigCache();
+  delete (window as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
+});
+
+describe("config write payload helpers", () => {
+  it("preserves every known config section while applying nested patches", () => {
+    const payload = buildConfigWritePayload(liveConfig, {
+      ui: { theme: "brink" },
+      agent: { model: "openai-codex/gpt-5.5", thinkingLevel: "high" },
+    });
+
+    expect(Object.keys(payload)).toEqual([...CONFIG_WRITE_SECTIONS]);
+    expect(payload).toMatchObject({
+      ui: { ...liveConfig.ui, theme: "brink" },
+      agent: {
+        ...liveConfig.agent,
+        model: "openai-codex/gpt-5.5",
+        thinkingLevel: "high",
+      },
+      shell: liveConfig.shell,
+      shortcuts: liveConfig.shortcuts,
+      voice: liveConfig.voice,
+      updates: liveConfig.updates,
+      devshell: liveConfig.devshell,
+      startup: liveConfig.startup,
+      guardrails: liveConfig.guardrails,
+    });
+  });
+
+  it("keeps null values in patches meaningful", () => {
+    const payload = buildConfigWritePayload(liveConfig, {
+      agent: { model: null, thinkingLevel: null },
+      guardrails: { softPromptAnchor: null },
+    });
+
+    expect(payload.agent.model).toBeNull();
+    expect(payload.agent.thinkingLevel).toBeNull();
+    expect(payload.guardrails.softPromptAnchor).toBeNull();
+  });
+
+  it("can build a destructive-write-safe payload when the live read fails", () => {
+    const payload = buildConfigWritePayload(null, {
+      startup: { autoApprove: false },
+    });
+
+    expect(Object.keys(payload)).toEqual([...CONFIG_WRITE_SECTIONS]);
+    expect(payload.startup).toEqual({ autoApprove: false });
+    expect(payload.ui).toEqual({});
+    expect(payload.guardrails).toEqual({});
+  });
+
+  it("writeConfigPatch reads through stale cache before destructive writes", async () => {
+    const cachedConfig: AethonConfig = {
+      ...liveConfig,
+      updates: { channel: "stable", disableAutoCheck: false },
+    };
+    const currentConfig: AethonConfig = {
+      ...liveConfig,
+      updates: { channel: "nightly", disableAutoCheck: true },
+      voice: { ...liveConfig.voice, speakMaxChars: 2400 },
+    };
+    (window as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {};
+    invokeMock
+      .mockResolvedValueOnce(cachedConfig)
+      .mockResolvedValueOnce(currentConfig)
+      .mockResolvedValueOnce(undefined);
+
+    await getConfig();
+    await writeConfigPatch({ startup: { autoApprove: false } });
+
+    expect(invokeMock).toHaveBeenNthCalledWith(1, "read_config");
+    expect(invokeMock).toHaveBeenNthCalledWith(2, "read_config");
+    expect(invokeMock).toHaveBeenNthCalledWith(3, "write_config", {
+      config: expect.objectContaining({
+        updates: currentConfig.updates,
+        voice: currentConfig.voice,
+        startup: { autoApprove: false },
+      }),
+    });
+  });
+
+  it("merges pending patches one top-level section at a time", () => {
+    expect(
+      mergeConfigPatch(
+        { ui: { theme: "ember" }, agent: { model: "old" } },
+        { ui: { fontSize: 16 }, agent: { model: null } },
+      ),
+    ).toEqual({
+      ui: { theme: "ember", fontSize: 16 },
+      agent: { model: null },
+    });
+  });
+});

--- a/src/configWrites.ts
+++ b/src/configWrites.ts
@@ -1,0 +1,95 @@
+import { invoke } from "@tauri-apps/api/core";
+
+import { clearConfigCache, getConfig, type AethonConfig } from "./config";
+
+export const CONFIG_WRITE_SECTIONS = [
+  "ui",
+  "agent",
+  "shell",
+  "shortcuts",
+  "voice",
+  "updates",
+  "devshell",
+  "startup",
+  "guardrails",
+] as const satisfies readonly (keyof AethonConfig)[];
+
+export type ConfigWriteSection = (typeof CONFIG_WRITE_SECTIONS)[number];
+
+export type ConfigWritePatch = Partial<{
+  [K in ConfigWriteSection]: Partial<AethonConfig[K]>;
+}>;
+
+export type ConfigWritePayload = {
+  [K in ConfigWriteSection]: Record<string, unknown>;
+};
+
+export function mergeConfigPatch(
+  pending: Record<string, unknown>,
+  patch: Record<string, unknown>,
+): Record<string, unknown> {
+  const merged = { ...pending };
+  for (const [key, value] of Object.entries(patch)) {
+    const previous = merged[key];
+    merged[key] =
+      isPlainObject(previous) && isPlainObject(value)
+        ? { ...previous, ...value }
+        : value;
+  }
+  return merged;
+}
+
+/** Build the full payload required by the destructive `write_config` IPC.
+ *
+ * `write_config` replaces the whole TOML document, so every known top-level
+ * section must be included even when the caller only wants to patch one nested
+ * field. Null values inside a patch are preserved intentionally: `[agent]
+ * model = null` is how the UI records "(pi default)".
+ */
+export function buildConfigWritePayload(
+  live: Partial<AethonConfig> | null | undefined,
+  patch: ConfigWritePatch,
+): ConfigWritePayload {
+  const payload = {} as ConfigWritePayload;
+  for (const section of CONFIG_WRITE_SECTIONS) {
+    payload[section] = mergeConfigSection(live?.[section], patch[section]);
+  }
+  return payload;
+}
+
+export async function writeConfigPatch(
+  patch: ConfigWritePatch,
+  options?: { live?: Partial<AethonConfig> | null },
+): Promise<ConfigWritePayload> {
+  let live = options?.live;
+  if (live === undefined) {
+    try {
+      // Destructive writes must merge against the current file, not the
+      // read-once cache. Users can edit config.toml outside Settings, and a
+      // stale cached snapshot would otherwise overwrite those changes.
+      clearConfigCache();
+      live = await getConfig();
+    } catch {
+      live = null;
+    }
+  }
+  const config = buildConfigWritePayload(live, patch);
+  await invoke("write_config", { config });
+  return config;
+}
+
+function mergeConfigSection(
+  liveSection: unknown,
+  patchSection: unknown,
+): Record<string, unknown> {
+  if (isPlainObject(liveSection) && isPlainObject(patchSection)) {
+    return { ...liveSection, ...patchSection };
+  }
+  if (isPlainObject(patchSection)) return { ...patchSection };
+  if (isPlainObject(liveSection)) return { ...liveSection };
+  return {};
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/extensions/default-layout/dashboard/projects-dashboard.tsx
+++ b/src/extensions/default-layout/dashboard/projects-dashboard.tsx
@@ -24,6 +24,7 @@ import { AeMarkInline } from "../layout";
 import { RegistryComponent } from "../../../components/A2UIRenderer";
 import { DashboardSessionRow } from "./session-row";
 import { clearConfigCache } from "../../../config";
+import { writeConfigPatch } from "../../../configWrites";
 
 interface ProjectListItem {
   id: string;
@@ -181,19 +182,7 @@ export function ProjectsDashboard({
     setHostStartupSaving(true);
     setHostStartupError(null);
     try {
-      const config = await invoke<Record<string, unknown>>("read_config");
-      const currentStartup =
-        typeof config.startup === "object" && config.startup !== null
-          ? (config.startup as Record<string, unknown>)
-          : {};
-      const next = {
-        ...config,
-        startup: {
-          ...currentStartup,
-          autoApprove: enabled,
-        },
-      };
-      await invoke("write_config", { config: next });
+      await writeConfigPatch({ startup: { autoApprove: enabled } });
       clearConfigCache();
       setHostStartupAutoApprove(enabled);
     } catch (err) {

--- a/src/hooks/chatModelSelection.ts
+++ b/src/hooks/chatModelSelection.ts
@@ -3,7 +3,8 @@ import { invoke } from "@tauri-apps/api/core";
 
 import type { ChatMessage } from "../types/a2ui";
 import type { Tab } from "../types/tab";
-import { getConfig, clearConfigCache, type AethonConfig } from "../config";
+import { clearConfigCache } from "../config";
+import { writeConfigPatch } from "../configWrites";
 import {
   recomputeModelPicker,
   PI_DEFAULT_MODEL_SENTINEL,
@@ -85,28 +86,8 @@ export function useChatModelSelectionController(
     const patch = pendingAgentDefaultsRef.current;
     if (Object.keys(patch).length === 0) return;
     pendingAgentDefaultsRef.current = {};
-    let live: AethonConfig | null = null;
     try {
-      live = await getConfig();
-    } catch {
-      /* fall through with nulls — write_config seeds a fresh document */
-    }
-    // write_config is whole-config destructive: it removes keys it does
-    // not see and always re-emits [shell] default_share_mode. Merge the
-    // full live config before writing, mirroring the Settings save path
-    // (uiOverlays/settings.ts) so unrelated sections survive the round-trip.
-    const merged = {
-      ui: { ...(live?.ui ?? {}) },
-      agent: { ...(live?.agent ?? {}), ...patch },
-      shell: { ...(live?.shell ?? {}) },
-      shortcuts: { ...(live?.shortcuts ?? {}) },
-      voice: { ...(live?.voice ?? {}) },
-      updates: { ...(live?.updates ?? {}) },
-      devshell: { ...(live?.devshell ?? {}) },
-      guardrails: { ...(live?.guardrails ?? {}) },
-    };
-    try {
-      await invoke("write_config", { config: merged });
+      await writeConfigPatch({ agent: patch });
       // Drop the read-once cache so an open Settings panel + the next
       // getConfig() reflect the header-chosen defaults.
       clearConfigCache();
@@ -355,24 +336,8 @@ export function useChatModelSelectionController(
   async function setCodexFastMode(enabled: boolean) {
     const previousCodexFastMode = stateRef.current.codexFastMode === true;
     setState((prev) => ({ ...prev, codexFastMode: enabled }));
-    let live: AethonConfig | null = null;
     try {
-      try {
-        live = await getConfig();
-      } catch {
-        /* fall through with defaults */
-      }
-      const merged = {
-        ui: { ...(live?.ui ?? {}) },
-        agent: { ...(live?.agent ?? {}), codexFastMode: enabled },
-        shell: { ...(live?.shell ?? {}) },
-        shortcuts: { ...(live?.shortcuts ?? {}) },
-        voice: { ...(live?.voice ?? {}) },
-        updates: { ...(live?.updates ?? {}) },
-        devshell: { ...(live?.devshell ?? {}) },
-        guardrails: { ...(live?.guardrails ?? {}) },
-      };
-      await invoke("write_config", { config: merged });
+      await writeConfigPatch({ agent: { codexFastMode: enabled } });
       clearConfigCache();
       await invoke("agent_broadcast_command", {
         payload: JSON.stringify({

--- a/src/hooks/uiOverlays/settings.test.ts
+++ b/src/hooks/uiOverlays/settings.test.ts
@@ -160,6 +160,9 @@ describe("useSettingsOverlay", () => {
     expect(invoke).toHaveBeenCalledWith("agent_broadcast_command", {
       payload: expect.stringContaining("runtime_config_changed"),
     });
+    expect(vi.mocked(clearConfigCache).mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(getConfig).mock.invocationCallOrder[0],
+    );
   });
 
   it("reapplies fresh config after autosave without closing settings", async () => {
@@ -180,7 +183,7 @@ describe("useSettingsOverlay", () => {
     });
     await vi.advanceTimersByTimeAsync(SETTINGS_AUTOSAVE_DELAY_MS);
 
-    expect(clearConfigCache).toHaveBeenCalledTimes(1);
+    expect(clearConfigCache).toHaveBeenCalledTimes(2);
     expect(ctx.reapplyConfig).toHaveBeenCalledWith(fresh);
     expect(stateRef.current.settings).toEqual({
       open: true,

--- a/src/hooks/uiOverlays/settings.test.ts
+++ b/src/hooks/uiOverlays/settings.test.ts
@@ -153,6 +153,8 @@ describe("useSettingsOverlay", () => {
         updates: baseConfig.updates,
         voice: baseConfig.voice,
         devshell: baseConfig.devshell,
+        startup: baseConfig.startup,
+        guardrails: baseConfig.guardrails,
       }),
     });
     expect(invoke).toHaveBeenCalledWith("agent_broadcast_command", {

--- a/src/hooks/uiOverlays/settings.ts
+++ b/src/hooks/uiOverlays/settings.ts
@@ -1,6 +1,11 @@
 import { invoke } from "@tauri-apps/api/core";
 import { useEffect, useRef } from "react";
 import { clearConfigCache, getConfig, type AethonConfig } from "../../config";
+import {
+  buildConfigWritePayload,
+  mergeConfigPatch,
+  type ConfigWritePatch,
+} from "../../configWrites";
 import type { UseUiOverlaysContext } from "./types";
 
 export const SETTINGS_AUTOSAVE_DELAY_MS = 350;
@@ -83,18 +88,7 @@ export function useSettingsOverlay(ctx: SettingsOverlayContext) {
 
   /** Apply a partial AethonConfig patch to `/settings/pending` and
    *  schedule a debounced autosave. */
-  function applySettingsPatch(
-    patch: Partial<{
-      ui: unknown;
-      agent: unknown;
-      shell: unknown;
-      shortcuts: unknown;
-      voice: unknown;
-      updates: unknown;
-      devshell: unknown;
-      guardrails: unknown;
-    }>,
-  ) {
+  function applySettingsPatch(patch: ConfigWritePatch) {
     setState((prev) => {
       const cur =
         (prev.settings as
@@ -167,48 +161,7 @@ export function useSettingsOverlay(ctx: SettingsOverlayContext) {
     } catch (err) {
       console.warn("settings save: getConfig failed:", err);
     }
-    const merged = {
-      ui: {
-        ...(live?.ui ?? {}),
-        ...((pendingSnapshot as { ui?: object }).ui ?? {}),
-      },
-      agent: {
-        ...(live?.agent ?? {}),
-        ...((pendingSnapshot as { agent?: object }).agent ?? {}),
-      },
-      shell: {
-        ...(live?.shell ?? {}),
-        ...((pendingSnapshot as { shell?: object }).shell ?? {}),
-      },
-      // Keep deprecated `[shortcuts] new_tab_kind` round-tripping when
-      // users save unrelated settings. write_config drops sections it
-      // doesn't see.
-      shortcuts: {
-        ...(live?.shortcuts ?? {}),
-        ...((pendingSnapshot as { shortcuts?: object }).shortcuts ?? {}),
-      },
-      voice: {
-        ...(live?.voice ?? {}),
-        ...((pendingSnapshot as { voice?: object }).voice ?? {}),
-      },
-      // Likewise for `[updates]` — preserve channel + auto-check settings
-      // across saves of unrelated sections.
-      updates: {
-        ...(live?.updates ?? {}),
-        ...((pendingSnapshot as { updates?: object }).updates ?? {}),
-      },
-      devshell: {
-        ...(live?.devshell ?? {}),
-        ...((pendingSnapshot as { devshell?: object }).devshell ?? {}),
-      },
-      // Preserve `[guardrails]` (soft anchor + hard-enforce default) across
-      // saves of unrelated sections — write_config drops any section it
-      // isn't handed, so omitting this would wipe the user's guardrails.
-      guardrails: {
-        ...(live?.guardrails ?? {}),
-        ...((pendingSnapshot as { guardrails?: object }).guardrails ?? {}),
-      },
-    };
+    const merged = buildConfigWritePayload(live, pendingSnapshot);
     try {
       await invoke("write_config", { config: merged });
       clearConfigCache();
@@ -319,21 +272,6 @@ export function useSettingsOverlay(ctx: SettingsOverlayContext) {
     applySettingsPatch,
     saveSettings,
   };
-}
-
-function mergeConfigPatch(
-  pending: Record<string, unknown>,
-  patch: Record<string, unknown>,
-): Record<string, unknown> {
-  const merged = { ...pending };
-  for (const [key, value] of Object.entries(patch)) {
-    const previous = merged[key];
-    merged[key] =
-      isPlainObject(previous) && isPlainObject(value)
-        ? { ...previous, ...value }
-        : value;
-  }
-  return merged;
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {

--- a/src/hooks/uiOverlays/settings.ts
+++ b/src/hooks/uiOverlays/settings.ts
@@ -157,6 +157,10 @@ export function useSettingsOverlay(ctx: SettingsOverlayContext) {
     const saveGeneration = ++saveGenerationRef.current;
     let live: AethonConfig | null = null;
     try {
+      // Build destructive write_config payloads from the current file, not
+      // the read-once cache. Users may have edited config.toml externally
+      // after the Settings panel first loaded.
+      clearConfigCache();
       live = await getConfig();
     } catch (err) {
       console.warn("settings save: getConfig failed:", err);

--- a/src/hooks/uiOverlays/types.ts
+++ b/src/hooks/uiOverlays/types.ts
@@ -8,6 +8,7 @@ import type {
   PaletteMode,
 } from "../../extensions/default-layout/palette-items";
 import type { AethonConfig } from "../../config";
+import type { ConfigWritePatch } from "../../configWrites";
 import type { SlashCommand } from "../../slashCommands";
 import type { NotificationInput } from "../useNotifications";
 
@@ -61,18 +62,8 @@ export interface UseUiOverlaysActions {
   openSettings: (section?: string) => void;
   toggleSettings: () => void;
   closeSettings: () => void;
-  applySettingsPatch: (
-    patch: Partial<{
-      ui: unknown;
-      agent: unknown;
-      shell: unknown;
-      shortcuts: unknown;
-      voice: unknown;
-      updates: unknown;
-      devshell: unknown;
-    }>,
-  ) => void;
-  saveSettings: () => Promise<void>;
+  applySettingsPatch: (patch: ConfigWritePatch) => void;
+  saveSettings: (options?: { reopenOnFailure?: boolean }) => Promise<void>;
 
   // Session search.
   toggleSessionSearch: () => void;

--- a/src/hooks/useChat.test.ts
+++ b/src/hooks/useChat.test.ts
@@ -4,6 +4,7 @@ import { act, renderHook } from "@testing-library/react";
 import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 
 import { makeEmptyTab, type Tab } from "../types/tab";
+import { clearConfigCache, type AethonConfig } from "../config";
 import { useChat, type UseChatContext } from "./useChat";
 import { PI_DEFAULT_MODEL_SENTINEL } from "../utils/modelPicker";
 import {
@@ -19,12 +20,70 @@ vi.mock("@tauri-apps/api/core", () => ({
   invoke: (cmd: string, args?: unknown) => invoke(cmd, args),
 }));
 
+const fullConfig: AethonConfig = {
+  ui: {
+    theme: "ember",
+    fontSize: 14,
+    restoreTabs: false,
+    notifyOnCompletion: true,
+    notifyMinDurationSeconds: 8,
+    thinkingVisibility: "show",
+    toolCallsVisibility: "hide",
+  },
+  agent: {
+    model: "anthropic/claude-opus-4-7",
+    thinkingLevel: "medium",
+    providerTimeoutSeconds: null,
+    codexFastMode: false,
+    bashTimeoutFloorSeconds: 300,
+    subagentTimeoutSeconds: 300,
+  },
+  shell: {
+    defaultShareMode: "read",
+    autoRestartAgent: false,
+    defaultCommand: "/bin/zsh",
+    defaultArgs: ["-l"],
+    inheritEnv: false,
+    promptBeforeClose: false,
+  },
+  shortcuts: { newTabKind: "shell" },
+  voice: {
+    toggleHotkey: "mod+shift+m",
+    holdHotkey: "AltRight",
+    speakAgentReplies: true,
+    speakMaxChars: 1200,
+    conversationContinuous: true,
+  },
+  updates: { channel: "nightly", disableAutoCheck: true },
+  devshell: {
+    enabled: "always",
+    mode: "direnv",
+    cacheTtlHours: 12,
+    refreshOnLockfileChange: false,
+  },
+  startup: { autoApprove: true },
+  guardrails: {
+    softPromptAnchor: "stay inside the repo",
+    hardEnforceProjectRoot: true,
+  },
+};
+
+function mockConfigRead(config: AethonConfig = fullConfig) {
+  clearConfigCache();
+  (window as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {};
+  invoke.mockImplementation((cmd) =>
+    cmd === "read_config" ? Promise.resolve(config) : Promise.resolve(),
+  );
+}
+
 afterEach(() => {
   // Reset both call history AND any per-test implementation override
   // (the live-switch-failure test installs a rejecting impl) so nothing
   // leaks into the next test.
   invoke.mockReset();
   invoke.mockImplementation(() => Promise.resolve(undefined));
+  clearConfigCache();
+  delete (window as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
   window.sessionStorage.clear();
 });
 
@@ -1060,6 +1119,35 @@ describe("useChat setModel", () => {
     );
   });
 
+  it("model and reasoning default writes preserve unrelated config sections", async () => {
+    vi.useFakeTimers();
+    try {
+      mockConfigRead();
+      const { ctx } = buildContext();
+      const { result } = renderHook(() => useChat(ctx));
+
+      await act(async () => {
+        await result.current.setModel("openai-codex/gpt-5.5:high");
+      });
+      await vi.advanceTimersByTimeAsync(450);
+
+      const write = invoke.mock.calls.find((c) => c[0] === "write_config");
+      const config = write?.[1] as { config: AethonConfig } | undefined;
+      expect(config?.config.agent).toMatchObject({
+        model: "openai-codex/gpt-5.5",
+        thinkingLevel: "high",
+      });
+      expect(config?.config.updates).toEqual(fullConfig.updates);
+      expect(config?.config.voice).toEqual(fullConfig.voice);
+      expect(config?.config.devshell).toEqual(fullConfig.devshell);
+      expect(config?.config.startup).toEqual(fullConfig.startup);
+      expect(config?.config.guardrails).toEqual(fullConfig.guardrails);
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
+  });
+
   it("persists active-session reasoning choices to [agent] thinking_level", async () => {
     vi.useFakeTimers();
     try {
@@ -1091,6 +1179,31 @@ describe("useChat setModel", () => {
       vi.clearAllTimers();
       vi.useRealTimers();
     }
+  });
+
+  it("Codex Fast mode writes preserve unrelated config sections", async () => {
+    mockConfigRead();
+    const { ctx } = buildContext({ codexFastMode: false });
+    const { result } = renderHook(() => useChat(ctx));
+
+    await act(async () => {
+      await result.current.setCodexFastMode(true);
+    });
+
+    const write = invoke.mock.calls.find((c) => c[0] === "write_config");
+    const config = write?.[1] as { config: AethonConfig } | undefined;
+    expect(config?.config.agent).toMatchObject({ codexFastMode: true });
+    expect(config?.config.updates).toEqual(fullConfig.updates);
+    expect(config?.config.voice).toEqual(fullConfig.voice);
+    expect(config?.config.devshell).toEqual(fullConfig.devshell);
+    expect(config?.config.startup).toEqual(fullConfig.startup);
+    expect(config?.config.guardrails).toEqual(fullConfig.guardrails);
+    expect(invoke).toHaveBeenCalledWith("agent_broadcast_command", {
+      payload: JSON.stringify({
+        type: "set_codex_fast_mode",
+        codexFastMode: true,
+      }),
+    });
   });
 
   it("rolls back optimistic Codex Fast mode changes when persistence fails", async () => {
@@ -1164,6 +1277,7 @@ describe("useChat setModel", () => {
   it("'(pi default)' clears every runtime fallback and persists null without retargeting", async () => {
     vi.useFakeTimers();
     try {
+      mockConfigRead();
       const { ctx, stateRef, piDefaultModelRef } = buildContext({
         activeTabId: undefined,
         tabs: [],
@@ -1192,10 +1306,13 @@ describe("useChat setModel", () => {
       await vi.advanceTimersByTimeAsync(450);
       const write = invoke.mock.calls.find((c) => c[0] === "write_config");
       expect(write).toBeTruthy();
-      expect(
-        (write?.[1] as { config: { agent: { model: string | null } } }).config
-          .agent.model,
-      ).toBeNull();
+      const config = write?.[1] as { config: AethonConfig } | undefined;
+      expect(config?.config.agent.model).toBeNull();
+      expect(config?.config.updates).toEqual(fullConfig.updates);
+      expect(config?.config.voice).toEqual(fullConfig.voice);
+      expect(config?.config.devshell).toEqual(fullConfig.devshell);
+      expect(config?.config.startup).toEqual(fullConfig.startup);
+      expect(config?.config.guardrails).toEqual(fullConfig.guardrails);
     } finally {
       vi.clearAllTimers();
       vi.useRealTimers();


### PR DESCRIPTION
Closes #375.

## Summary
- add `src/configWrites.ts` with the canonical frontend config section list plus shared patch/payload/write helpers
- route Settings autosave, model default persistence, Codex Fast mode persistence, and dashboard startup policy writes through the shared safe write path
- force patch writes to re-read config before destructive `write_config` payload construction so stale cached config cannot overwrite external edits
- expand regression coverage for section preservation, nested patch merging, null model resets, stale-cache handling, and caller lifecycle behavior

## Validation
- `bunx vitest run src/configWrites.test.ts src/hooks/uiOverlays/settings.test.ts src/hooks/useChat.test.ts src/extensions/default-layout/dashboard/projects-dashboard.test.tsx`
- `bunx tsc -b --noEmit`
- `bunx eslint src/configWrites.ts src/configWrites.test.ts src/hooks/uiOverlays/settings.ts src/hooks/uiOverlays/types.ts src/hooks/uiOverlays/settings.test.ts src/hooks/chatModelSelection.ts src/hooks/useChat.test.ts src/extensions/default-layout/dashboard/projects-dashboard.tsx src/extensions/default-layout/dashboard/projects-dashboard.test.tsx`
- Codex peer review: fixed stale-cache finding; follow-up review reported no blocking regressions
- Full `bunx vitest run` passed during follow-up review (319 files, 2716 tests); emitted existing test-environment warnings only