### PR TITLE
fix(devshell): centralize prepare policy

### DIFF
--- a/src-tauri/src/commands/devshell.rs
+++ b/src-tauri/src/commands/devshell.rs
@@ -17,60 +17,17 @@
 //! don't apply the env".
 
 use std::collections::BTreeMap;
-use std::path::{Path, PathBuf};
-use std::process::Stdio;
+use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
-use tauri::{AppHandle, Emitter, Manager, Runtime, State};
+use tauri::{AppHandle, Manager, Runtime, State};
 
-use crate::devshell::{
-    AppEmitter, DetectMode, DevshellCache, DevshellEmitter, EnvForPath, StatusSnapshot,
+use crate::devshell::prepare_policy::{
+    emitter_for, forced_mode_mismatch_reason, mode_str, prepare_is_required,
+    required_devshell_missing_error,
 };
-
-/// Adapter so the devshell cache can emit Tauri events without taking
-/// a direct dependency on `tauri::AppHandle`. The cache calls
-/// [`DevshellEmitter::emit`]; we forward to the real Tauri emitter
-/// here.
-pub struct TauriEmitter<R: Runtime> {
-    app: AppHandle<R>,
-}
-
-impl<R: Runtime> TauriEmitter<R> {
-    pub fn new(app: AppHandle<R>) -> Self {
-        Self { app }
-    }
-}
-
-impl<R: Runtime> DevshellEmitter for TauriEmitter<R> {
-    fn emit(&self, event: &str, payload: serde_json::Value) {
-        if let Err(e) = self.app.emit(event, payload) {
-            tracing::warn!(
-                target: "aethon::devshell",
-                "emit {event} failed: {e}"
-            );
-        }
-    }
-}
-
-pub(crate) fn emitter_for<R: Runtime>(app: &AppHandle<R>) -> AppEmitter {
-    AppEmitter::new(Arc::new(TauriEmitter::new(app.clone())) as Arc<dyn DevshellEmitter>)
-}
-
-pub(crate) fn forced_mode_mismatch_reason(
-    root: &Path,
-    configured_mode: DetectMode,
-) -> Option<String> {
-    let natural = crate::devshell::forced_mode_mismatch(root, configured_mode)?;
-    Some(format!(
-        "configured [devshell].mode = \"{}\", but {} is detected as a {} devshell. Aethon will not fall back to a different resolver; change Resolver mode or add the expected {} marker.",
-        mode_str(configured_mode),
-        root.display(),
-        natural.as_str(),
-        expected_marker(configured_mode)
-    ))
-}
+use crate::devshell::{DevshellCache, EnvForPath, StatusSnapshot};
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -146,31 +103,8 @@ pub async fn devshell_status<R: Runtime>(
     })
 }
 
-fn mode_str(mode: DetectMode) -> &'static str {
-    match mode {
-        DetectMode::Auto => "auto",
-        DetectMode::Direnv => "direnv",
-        DetectMode::Nix => "nix",
-        DetectMode::NixShell => "nix-shell",
-    }
-}
-
-fn expected_marker(mode: DetectMode) -> &'static str {
-    match mode {
-        DetectMode::Auto => "devshell",
-        DetectMode::Direnv => ".envrc with use flake/use nix",
-        DetectMode::Nix => "flake.nix",
-        DetectMode::NixShell => "flake.nix or shell.nix",
-    }
-}
-
-pub(crate) fn devshell_prepare_is_required(enabled: &str) -> bool {
-    enabled == "always"
-}
-
-pub(crate) fn required_devshell_missing_error(enabled: &str, reason: String) -> Option<String> {
-    devshell_prepare_is_required(enabled)
-        .then(|| format!("{reason} and [devshell] enabled = \"always\""))
+fn devshell_prepare_is_required(enabled: &str) -> bool {
+    prepare_is_required(enabled)
 }
 
 #[derive(Deserialize)]
@@ -296,7 +230,8 @@ pub async fn devshell_prepare_for_path<R: Runtime>(
         }
         crate::devshell::PrepareDecision::ForcedModeMismatch { reason } => {
             if devshell_prepare_is_required(&enabled) {
-                Err(reason)
+                Err(required_devshell_missing_error(&enabled, reason)
+                    .unwrap_or_else(|| "required devshell mode mismatch".to_string()))
             } else {
                 Ok(PrepareForPathResponse {
                     enabled,
@@ -315,40 +250,6 @@ pub async fn devshell_prepare_for_path<R: Runtime>(
         crate::devshell::PrepareDecision::DirenvAllowFailedRequired { reason }
         | crate::devshell::PrepareDecision::CachePrepareFailedRequired { reason } => Err(reason),
     }
-}
-
-pub(crate) async fn direnv_allow(root: &Path) -> Result<(), String> {
-    let Some(bin) = crate::env::resolve_program("direnv") else {
-        return Err("direnv binary not found on Aethon tool PATH".to_string());
-    };
-    let mut command = tokio::process::Command::new(bin);
-    command
-        .arg("allow")
-        .arg(root)
-        .current_dir(root)
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-    let output = tokio::time::timeout(Duration::from_secs(30), command.output())
-        .await
-        .map_err(|_| format!("direnv allow {} timed out after 30s", root.display()))?
-        .map_err(|e| format!("direnv allow {} failed to start: {e}", root.display()))?;
-    if output.status.success() {
-        return Ok(());
-    }
-    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    let detail = if !stderr.is_empty() { stderr } else { stdout };
-    Err(format!(
-        "direnv allow {} exited with {}{}",
-        root.display(),
-        output.status,
-        if detail.is_empty() {
-            String::new()
-        } else {
-            format!(": {detail}")
-        }
-    ))
 }
 
 /// Non-blocking env lookup. Returns immediately even if a resolver is

--- a/src-tauri/src/commands/devshell.rs
+++ b/src-tauri/src/commands/devshell.rs
@@ -229,8 +229,12 @@ pub async fn devshell_prepare_for_path<R: Runtime>(
     let cwd = PathBuf::from(&args.cwd);
     let include_env = args.include_env.unwrap_or(false);
     let (enabled, configured_mode) = crate::devshell::effective_config(&app, &cwd).into_parts();
-    if enabled == "never" {
-        return Ok(PrepareForPathResponse {
+    let emitter = crate::devshell::prepare_policy::emitter_for(&app);
+    let decision = crate::devshell::prepare_env_for_root(&app, &cache, &cwd, Some(&emitter)).await;
+
+    let empty_env = || include_env.then(BTreeMap::new);
+    match decision {
+        crate::devshell::PrepareDecision::Disabled => Ok(PrepareForPathResponse {
             enabled,
             mode: mode_str(configured_mode).to_string(),
             state: "disabled".to_string(),
@@ -240,60 +244,23 @@ pub async fn devshell_prepare_for_path<R: Runtime>(
             var_count: 0,
             direnv_allowed: false,
             reason: None,
-            env: include_env.then(BTreeMap::new),
-        });
-    }
-
-    let detected_kind = crate::devshell::detect_mode(&cwd, configured_mode);
-    let Some(kind) = detected_kind else {
-        let reason = forced_mode_mismatch_reason(&cwd, configured_mode)
-            .unwrap_or_else(|| format!("no devshell detected at {}", cwd.display()));
-        if let Some(error) = required_devshell_missing_error(&enabled, reason.clone()) {
-            return Err(error);
-        }
-        let is_mismatch = crate::devshell::forced_mode_mismatch(&cwd, configured_mode).is_some();
-        return Ok(PrepareForPathResponse {
-            enabled,
-            mode: mode_str(configured_mode).to_string(),
-            state: if is_mismatch { "failed" } else { "none" }.to_string(),
-            kind: None,
-            stale: false,
-            duration_ms: None,
-            var_count: 0,
-            direnv_allowed: false,
-            reason: Some(reason),
-            env: include_env.then(BTreeMap::new),
-        });
-    };
-
-    let mut direnv_allowed = false;
-    if kind.as_str() == "direnv" {
-        if let Err(reason) = direnv_allow(&cwd).await {
-            if enabled == "always" {
-                return Err(reason);
-            }
-            return Ok(PrepareForPathResponse {
+            env: empty_env(),
+        }),
+        crate::devshell::PrepareDecision::MissingOptional { reason } => {
+            Ok(PrepareForPathResponse {
                 enabled,
                 mode: mode_str(configured_mode).to_string(),
-                state: "failed".to_string(),
-                kind: Some(kind.as_str().to_string()),
+                state: "none".to_string(),
+                kind: None,
                 stale: false,
                 duration_ms: None,
                 var_count: 0,
                 direnv_allowed: false,
                 reason: Some(reason),
-                env: include_env.then(BTreeMap::new),
-            });
+                env: empty_env(),
+            })
         }
-        direnv_allowed = true;
-    }
-
-    let emitter = emitter_for(&app);
-    match cache
-        .prepare_for(Some(&emitter), &cwd, configured_mode)
-        .await
-    {
-        Ok(prepared) => {
+        crate::devshell::PrepareDecision::Prepared { kind, prepared } => {
             let var_count = prepared.env.len();
             Ok(PrepareForPathResponse {
                 enabled,
@@ -303,15 +270,13 @@ pub async fn devshell_prepare_for_path<R: Runtime>(
                 stale: prepared.stale,
                 duration_ms: prepared.duration_ms,
                 var_count,
-                direnv_allowed,
+                direnv_allowed: kind == crate::devshell::detect::DevshellKind::Direnv,
                 reason: None,
                 env: include_env.then_some(prepared.env),
             })
         }
-        Err(reason) => {
-            if enabled == "always" {
-                return Err(reason);
-            }
+        crate::devshell::PrepareDecision::DirenvAllowFailedOptional { kind, reason }
+        | crate::devshell::PrepareDecision::CachePrepareFailedOptional { kind, reason } => {
             Ok(PrepareForPathResponse {
                 enabled,
                 mode: mode_str(configured_mode).to_string(),
@@ -320,11 +285,35 @@ pub async fn devshell_prepare_for_path<R: Runtime>(
                 stale: false,
                 duration_ms: None,
                 var_count: 0,
-                direnv_allowed,
+                direnv_allowed: false,
                 reason: Some(reason),
-                env: include_env.then(BTreeMap::new),
+                env: empty_env(),
             })
         }
+        crate::devshell::PrepareDecision::MissingRequired { reason } => {
+            Err(required_devshell_missing_error(&enabled, reason)
+                .unwrap_or_else(|| format!("no devshell detected at {}", cwd.display())))
+        }
+        crate::devshell::PrepareDecision::ForcedModeMismatch { reason } => {
+            if devshell_prepare_is_required(&enabled) {
+                Err(reason)
+            } else {
+                Ok(PrepareForPathResponse {
+                    enabled,
+                    mode: mode_str(configured_mode).to_string(),
+                    state: "failed".to_string(),
+                    kind: None,
+                    stale: false,
+                    duration_ms: None,
+                    var_count: 0,
+                    direnv_allowed: false,
+                    reason: Some(reason),
+                    env: empty_env(),
+                })
+            }
+        }
+        crate::devshell::PrepareDecision::DirenvAllowFailedRequired { reason }
+        | crate::devshell::PrepareDecision::CachePrepareFailedRequired { reason } => Err(reason),
     }
 }
 

--- a/src-tauri/src/commands/startup.rs
+++ b/src-tauri/src/commands/startup.rs
@@ -768,8 +768,13 @@ async fn prepare_devshell_env(
             );
             Ok(BTreeMap::new())
         }
-        crate::devshell::PrepareDecision::MissingRequired { reason }
-        | crate::devshell::PrepareDecision::ForcedModeMismatch { reason }
+        crate::devshell::PrepareDecision::MissingRequired { reason } => {
+            let error =
+                crate::devshell::prepare_policy::required_devshell_missing_error("always", reason)
+                    .unwrap_or_else(|| "missing required devshell".to_string());
+            Err(format!("devshell prepare: {error}"))
+        }
+        crate::devshell::PrepareDecision::ForcedModeMismatch { reason }
         | crate::devshell::PrepareDecision::CachePrepareFailedRequired { reason } => {
             Err(format!("devshell prepare: {reason}"))
         }

--- a/src-tauri/src/commands/startup.rs
+++ b/src-tauri/src/commands/startup.rs
@@ -746,55 +746,34 @@ async fn prepare_devshell_env(
     cache: &Arc<DevshellCache>,
     root: &Path,
 ) -> Result<BTreeMap<String, String>, String> {
-    let (enabled, configured_mode) = crate::devshell::effective_config(app, root).into_parts();
-    if enabled == "never" {
-        return Ok(BTreeMap::new());
-    }
-    if let Some(reason) =
-        crate::commands::devshell::forced_mode_mismatch_reason(root, configured_mode)
-    {
-        return Err(format!("devshell prepare: {reason}"));
-    }
-    let Some(kind) = crate::devshell::detect_mode(root, configured_mode) else {
-        let reason = format!("no devshell detected at {}", root.display());
-        if let Some(error) =
-            crate::commands::devshell::required_devshell_missing_error(&enabled, reason)
-        {
-            return Err(format!("devshell prepare: {error}"));
+    let emitter = crate::devshell::prepare_policy::emitter_for(app);
+    let decision = crate::devshell::prepare_env_for_root(app, cache, root, Some(&emitter)).await;
+    match decision {
+        crate::devshell::PrepareDecision::Disabled
+        | crate::devshell::PrepareDecision::MissingOptional { .. } => Ok(BTreeMap::new()),
+        crate::devshell::PrepareDecision::Prepared { prepared, .. } => Ok(prepared.env),
+        crate::devshell::PrepareDecision::DirenvAllowFailedOptional { reason, .. } => {
+            tracing::warn!(
+                target: "aethon::startup",
+                "startup devshell direnv allow failed for {}: {reason}; continuing with host env",
+                root.display()
+            );
+            Ok(BTreeMap::new())
         }
-        return Ok(BTreeMap::new());
-    };
-    if kind.as_str() == "direnv"
-        && let Err(reason) = crate::commands::devshell::direnv_allow(root).await
-    {
-        if crate::commands::devshell::devshell_prepare_is_required(&enabled) {
-            return Err(reason);
+        crate::devshell::PrepareDecision::CachePrepareFailedOptional { reason, .. } => {
+            tracing::warn!(
+                target: "aethon::startup",
+                "startup devshell prepare failed for {}: {reason}; continuing with host env",
+                root.display()
+            );
+            Ok(BTreeMap::new())
         }
-        tracing::warn!(
-            target: "aethon::startup",
-            "startup devshell direnv allow failed for {}: {reason}; continuing with host env",
-            root.display()
-        );
-        return Ok(BTreeMap::new());
-    }
-    let emitter = crate::commands::devshell::emitter_for(app);
-    match cache
-        .prepare_for(Some(&emitter), root, configured_mode)
-        .await
-    {
-        Ok(prepared) => Ok(prepared.env),
-        Err(reason) => {
-            if crate::commands::devshell::devshell_prepare_is_required(&enabled) {
-                Err(format!("devshell prepare: {reason}"))
-            } else {
-                tracing::warn!(
-                    target: "aethon::startup",
-                    "startup devshell prepare failed for {}: {reason}; continuing with host env",
-                    root.display()
-                );
-                Ok(BTreeMap::new())
-            }
+        crate::devshell::PrepareDecision::MissingRequired { reason }
+        | crate::devshell::PrepareDecision::ForcedModeMismatch { reason }
+        | crate::devshell::PrepareDecision::CachePrepareFailedRequired { reason } => {
+            Err(format!("devshell prepare: {reason}"))
         }
+        crate::devshell::PrepareDecision::DirenvAllowFailedRequired { reason } => Err(reason),
     }
 }
 

--- a/src-tauri/src/devshell/cache.rs
+++ b/src-tauri/src/devshell/cache.rs
@@ -106,7 +106,7 @@ pub struct EnvForPath {
     pub env: BTreeMap<String, String>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PreparedEnv {
     pub kind: Option<String>,

--- a/src-tauri/src/devshell/mod.rs
+++ b/src-tauri/src/devshell/mod.rs
@@ -26,9 +26,7 @@ pub mod detect;
 pub mod prepare_policy;
 pub mod resolve;
 
-pub use cache::{
-    AppEmitter, DevshellCache, DevshellEmitter, EnvForPath, StatusSnapshot, evict_stale_snapshots,
-};
+pub use cache::{DevshellCache, EnvForPath, StatusSnapshot, evict_stale_snapshots};
 pub use config::effective_config;
 pub use detect::{DetectMode, detect_mode, forced_mode_mismatch};
 pub use prepare_policy::{PrepareDecision, prepare_env_for_root};

--- a/src-tauri/src/devshell/mod.rs
+++ b/src-tauri/src/devshell/mod.rs
@@ -23,6 +23,7 @@
 pub mod cache;
 pub mod config;
 pub mod detect;
+pub mod prepare_policy;
 pub mod resolve;
 
 pub use cache::{
@@ -30,3 +31,4 @@ pub use cache::{
 };
 pub use config::effective_config;
 pub use detect::{DetectMode, detect_mode, forced_mode_mismatch};
+pub use prepare_policy::{PrepareDecision, prepare_env_for_root};

--- a/src-tauri/src/devshell/prepare_policy.rs
+++ b/src-tauri/src/devshell/prepare_policy.rs
@@ -1,0 +1,284 @@
+use std::path::Path;
+use std::sync::Arc;
+
+use tauri::{AppHandle, Runtime};
+
+use super::cache::{AppEmitter, DevshellCache, DevshellEmitter, PreparedEnv};
+use super::detect::DevshellKind;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PrepareDecision {
+    Disabled,
+    MissingOptional {
+        reason: String,
+    },
+    MissingRequired {
+        reason: String,
+    },
+    ForcedModeMismatch {
+        reason: String,
+    },
+    DirenvAllowFailedOptional {
+        kind: DevshellKind,
+        reason: String,
+    },
+    DirenvAllowFailedRequired {
+        reason: String,
+    },
+    CachePrepareFailedOptional {
+        kind: DevshellKind,
+        reason: String,
+    },
+    CachePrepareFailedRequired {
+        reason: String,
+    },
+    Prepared {
+        kind: DevshellKind,
+        prepared: PreparedEnv,
+    },
+}
+
+pub(crate) fn prepare_is_required(enabled: &str) -> bool {
+    enabled == "always"
+}
+
+pub fn decide_prepare_policy(
+    enabled: &str,
+    forced_mismatch: Option<String>,
+    detected_kind: Option<DevshellKind>,
+    root_display: &str,
+    direnv_allow_error: Option<String>,
+    cache_prepare: Result<Option<PreparedEnv>, String>,
+) -> PrepareDecision {
+    if enabled == "never" {
+        return PrepareDecision::Disabled;
+    }
+    if let Some(reason) = forced_mismatch {
+        return PrepareDecision::ForcedModeMismatch { reason };
+    }
+    let Some(kind) = detected_kind else {
+        let reason = format!("no devshell detected at {root_display}");
+        return if prepare_is_required(enabled) {
+            PrepareDecision::MissingRequired { reason }
+        } else {
+            PrepareDecision::MissingOptional { reason }
+        };
+    };
+    if let Some(reason) = direnv_allow_error {
+        return if prepare_is_required(enabled) {
+            PrepareDecision::DirenvAllowFailedRequired { reason }
+        } else {
+            PrepareDecision::DirenvAllowFailedOptional { kind, reason }
+        };
+    }
+    match cache_prepare {
+        Ok(Some(prepared)) => PrepareDecision::Prepared { kind, prepared },
+        Ok(None) => PrepareDecision::MissingOptional {
+            reason: format!("no devshell detected at {root_display}"),
+        },
+        Err(reason) => {
+            if prepare_is_required(enabled) {
+                PrepareDecision::CachePrepareFailedRequired { reason }
+            } else {
+                PrepareDecision::CachePrepareFailedOptional { kind, reason }
+            }
+        }
+    }
+}
+
+pub async fn prepare_env_for_root<R: Runtime>(
+    app: &AppHandle<R>,
+    cache: &Arc<DevshellCache>,
+    root: &Path,
+    emitter: Option<&AppEmitter>,
+) -> PrepareDecision {
+    let (enabled, configured_mode) = crate::devshell::effective_config(app, root).into_parts();
+    if enabled == "never" {
+        return decide_prepare_policy(
+            &enabled,
+            None,
+            None,
+            &root.display().to_string(),
+            None,
+            Ok(None),
+        );
+    }
+
+    let mismatch = crate::commands::devshell::forced_mode_mismatch_reason(root, configured_mode);
+    if mismatch.is_some() {
+        return decide_prepare_policy(
+            &enabled,
+            mismatch,
+            None,
+            &root.display().to_string(),
+            None,
+            Ok(None),
+        );
+    }
+
+    let detected_kind = crate::devshell::detect_mode(root, configured_mode);
+    let mut direnv_error = None;
+    if matches!(detected_kind, Some(DevshellKind::Direnv)) {
+        direnv_error = crate::commands::devshell::direnv_allow(root).await.err();
+    }
+    if direnv_error.is_some() || detected_kind.is_none() {
+        return decide_prepare_policy(
+            &enabled,
+            None,
+            detected_kind,
+            &root.display().to_string(),
+            direnv_error,
+            Ok(None),
+        );
+    }
+
+    let prepared = cache
+        .prepare_for(emitter, root, configured_mode)
+        .await
+        .map(Some);
+    decide_prepare_policy(
+        &enabled,
+        None,
+        detected_kind,
+        &root.display().to_string(),
+        None,
+        prepared,
+    )
+}
+
+pub fn emitter_for<R: Runtime>(app: &AppHandle<R>) -> AppEmitter {
+    AppEmitter::new(
+        Arc::new(crate::commands::devshell::TauriEmitter::new(app.clone()))
+            as Arc<dyn DevshellEmitter>,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+
+    fn prepared(kind: &str) -> PreparedEnv {
+        PreparedEnv {
+            kind: Some(kind.to_string()),
+            stale: false,
+            env: BTreeMap::from([("A".to_string(), "B".to_string())]),
+            duration_ms: Some(1),
+        }
+    }
+
+    #[test]
+    fn decision_disabled_when_enabled_never() {
+        assert_eq!(
+            decide_prepare_policy(
+                "never",
+                None,
+                Some(DevshellKind::Flake),
+                "/repo",
+                None,
+                Ok(Some(prepared("flake"))),
+            ),
+            PrepareDecision::Disabled
+        );
+    }
+
+    #[test]
+    fn decision_auto_missing_devshell_is_optional() {
+        assert_eq!(
+            decide_prepare_policy("auto", None, None, "/repo", None, Ok(None)),
+            PrepareDecision::MissingOptional {
+                reason: "no devshell detected at /repo".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn decision_always_missing_devshell_is_required() {
+        assert_eq!(
+            decide_prepare_policy("always", None, None, "/repo", None, Ok(None)),
+            PrepareDecision::MissingRequired {
+                reason: "no devshell detected at /repo".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn decision_forced_mode_mismatch_is_hard_error() {
+        assert_eq!(
+            decide_prepare_policy(
+                "auto",
+                Some("configured devshell mode direnv does not match flake project".to_string()),
+                Some(DevshellKind::Flake),
+                "/repo",
+                None,
+                Ok(Some(prepared("flake"))),
+            ),
+            PrepareDecision::ForcedModeMismatch {
+                reason: "configured devshell mode direnv does not match flake project".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn decision_direnv_allow_failure_respects_required_policy() {
+        assert_eq!(
+            decide_prepare_policy(
+                "auto",
+                None,
+                Some(DevshellKind::Direnv),
+                "/repo",
+                Some("direnv failed".to_string()),
+                Ok(None),
+            ),
+            PrepareDecision::DirenvAllowFailedOptional {
+                kind: DevshellKind::Direnv,
+                reason: "direnv failed".to_string()
+            }
+        );
+        assert_eq!(
+            decide_prepare_policy(
+                "always",
+                None,
+                Some(DevshellKind::Direnv),
+                "/repo",
+                Some("direnv failed".to_string()),
+                Ok(None),
+            ),
+            PrepareDecision::DirenvAllowFailedRequired {
+                reason: "direnv failed".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn decision_cache_prepare_failure_respects_required_policy() {
+        assert_eq!(
+            decide_prepare_policy(
+                "auto",
+                None,
+                Some(DevshellKind::Flake),
+                "/repo",
+                None,
+                Err("nix failed".to_string()),
+            ),
+            PrepareDecision::CachePrepareFailedOptional {
+                kind: DevshellKind::Flake,
+                reason: "nix failed".to_string()
+            }
+        );
+        assert_eq!(
+            decide_prepare_policy(
+                "always",
+                None,
+                Some(DevshellKind::Flake),
+                "/repo",
+                None,
+                Err("nix failed".to_string()),
+            ),
+            PrepareDecision::CachePrepareFailedRequired {
+                reason: "nix failed".to_string()
+            }
+        );
+    }
+}

--- a/src-tauri/src/devshell/prepare_policy.rs
+++ b/src-tauri/src/devshell/prepare_policy.rs
@@ -1,10 +1,12 @@
 use std::path::Path;
+use std::process::Stdio;
 use std::sync::Arc;
+use std::time::Duration;
 
-use tauri::{AppHandle, Runtime};
+use tauri::{AppHandle, Emitter, Runtime};
 
 use super::cache::{AppEmitter, DevshellCache, DevshellEmitter, PreparedEnv};
-use super::detect::DevshellKind;
+use super::detect::{DetectMode, DevshellKind};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PrepareDecision {
@@ -42,6 +44,42 @@ pub(crate) fn prepare_is_required(enabled: &str) -> bool {
     enabled == "always"
 }
 
+pub(crate) fn required_devshell_missing_error(enabled: &str, reason: String) -> Option<String> {
+    prepare_is_required(enabled).then(|| format!("{reason} and [devshell] enabled = \"always\""))
+}
+
+pub(crate) fn mode_str(mode: DetectMode) -> &'static str {
+    match mode {
+        DetectMode::Auto => "auto",
+        DetectMode::Direnv => "direnv",
+        DetectMode::Nix => "nix",
+        DetectMode::NixShell => "nix-shell",
+    }
+}
+
+fn expected_marker(mode: DetectMode) -> &'static str {
+    match mode {
+        DetectMode::Auto => "devshell",
+        DetectMode::Direnv => ".envrc with use flake/use nix",
+        DetectMode::Nix => "flake.nix",
+        DetectMode::NixShell => "flake.nix or shell.nix",
+    }
+}
+
+pub(crate) fn forced_mode_mismatch_reason(
+    root: &Path,
+    configured_mode: DetectMode,
+) -> Option<String> {
+    let natural = crate::devshell::forced_mode_mismatch(root, configured_mode)?;
+    Some(format!(
+        "configured [devshell].mode = \"{}\", but {} is detected as a {} devshell. Aethon will not fall back to a different resolver; change Resolver mode or add the expected {} marker.",
+        mode_str(configured_mode),
+        root.display(),
+        natural.as_str(),
+        expected_marker(configured_mode)
+    ))
+}
+
 pub fn decide_prepare_policy(
     enabled: &str,
     forced_mismatch: Option<String>,
@@ -73,9 +111,14 @@ pub fn decide_prepare_policy(
     }
     match cache_prepare {
         Ok(Some(prepared)) => PrepareDecision::Prepared { kind, prepared },
-        Ok(None) => PrepareDecision::MissingOptional {
-            reason: format!("no devshell detected at {root_display}"),
-        },
+        Ok(None) => {
+            let reason = format!("no devshell detected at {root_display}");
+            if prepare_is_required(enabled) {
+                PrepareDecision::MissingRequired { reason }
+            } else {
+                PrepareDecision::MissingOptional { reason }
+            }
+        }
         Err(reason) => {
             if prepare_is_required(enabled) {
                 PrepareDecision::CachePrepareFailedRequired { reason }
@@ -104,7 +147,7 @@ pub async fn prepare_env_for_root<R: Runtime>(
         );
     }
 
-    let mismatch = crate::commands::devshell::forced_mode_mismatch_reason(root, configured_mode);
+    let mismatch = forced_mode_mismatch_reason(root, configured_mode);
     if mismatch.is_some() {
         return decide_prepare_policy(
             &enabled,
@@ -119,7 +162,7 @@ pub async fn prepare_env_for_root<R: Runtime>(
     let detected_kind = crate::devshell::detect_mode(root, configured_mode);
     let mut direnv_error = None;
     if matches!(detected_kind, Some(DevshellKind::Direnv)) {
-        direnv_error = crate::commands::devshell::direnv_allow(root).await.err();
+        direnv_error = direnv_allow(root).await.err();
     }
     if direnv_error.is_some() || detected_kind.is_none() {
         return decide_prepare_policy(
@@ -146,11 +189,66 @@ pub async fn prepare_env_for_root<R: Runtime>(
     )
 }
 
+/// Adapter so the devshell cache can emit Tauri events without taking
+/// a direct dependency on `tauri::AppHandle`. The cache calls
+/// [`DevshellEmitter::emit`]; we forward to the real Tauri emitter here.
+struct TauriEmitter<R: Runtime> {
+    app: AppHandle<R>,
+}
+
+impl<R: Runtime> TauriEmitter<R> {
+    fn new(app: AppHandle<R>) -> Self {
+        Self { app }
+    }
+}
+
+impl<R: Runtime> DevshellEmitter for TauriEmitter<R> {
+    fn emit(&self, event: &str, payload: serde_json::Value) {
+        if let Err(e) = self.app.emit(event, payload) {
+            tracing::warn!(
+                target: "aethon::devshell",
+                "emit {event} failed: {e}"
+            );
+        }
+    }
+}
+
 pub fn emitter_for<R: Runtime>(app: &AppHandle<R>) -> AppEmitter {
-    AppEmitter::new(
-        Arc::new(crate::commands::devshell::TauriEmitter::new(app.clone()))
-            as Arc<dyn DevshellEmitter>,
-    )
+    AppEmitter::new(Arc::new(TauriEmitter::new(app.clone())) as Arc<dyn DevshellEmitter>)
+}
+
+pub(crate) async fn direnv_allow(root: &Path) -> Result<(), String> {
+    let Some(bin) = crate::env::resolve_program("direnv") else {
+        return Err("direnv binary not found on Aethon tool PATH".to_string());
+    };
+    let mut command = tokio::process::Command::new(bin);
+    command
+        .arg("allow")
+        .arg(root)
+        .current_dir(root)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let output = tokio::time::timeout(Duration::from_secs(30), command.output())
+        .await
+        .map_err(|_| format!("direnv allow {} timed out after 30s", root.display()))?
+        .map_err(|e| format!("direnv allow {} failed to start: {e}", root.display()))?;
+    if output.status.success() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let detail = if !stderr.is_empty() { stderr } else { stdout };
+    Err(format!(
+        "direnv allow {} exited with {}{}",
+        root.display(),
+        output.status,
+        if detail.is_empty() {
+            String::new()
+        } else {
+            format!(": {detail}")
+        }
+    ))
 }
 
 #[cfg(test)]
@@ -197,6 +295,23 @@ mod tests {
     fn decision_always_missing_devshell_is_required() {
         assert_eq!(
             decide_prepare_policy("always", None, None, "/repo", None, Ok(None)),
+            PrepareDecision::MissingRequired {
+                reason: "no devshell detected at /repo".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn decision_always_cache_none_is_required() {
+        assert_eq!(
+            decide_prepare_policy(
+                "always",
+                None,
+                Some(DevshellKind::Flake),
+                "/repo",
+                None,
+                Ok(None),
+            ),
             PrepareDecision::MissingRequired {
                 reason: "no devshell detected at /repo".to_string()
             }

--- a/src-tauri/src/shell/lifecycle/open.rs
+++ b/src-tauri/src/shell/lifecycle/open.rs
@@ -14,9 +14,8 @@ use super::reader::spawn_reader_thread;
 use super::registry::{
     ChildHandle, SCROLLBACK_BYTES, ScrollbackHandle, ShareHandle, ShellRegistry, ShellSlot,
 };
-use crate::commands::devshell::TauriEmitter;
+use crate::devshell::DevshellCache;
 use crate::devshell::detect::DevshellKind;
-use crate::devshell::{AppEmitter, DevshellCache, DevshellEmitter};
 use crate::shell::scrollback::Scrollback;
 use crate::shell::sharemode::{ShareMode, ShareState};
 
@@ -102,82 +101,57 @@ pub async fn shell_open<R: Runtime>(
 
     if let Some(cwd) = args.cwd.as_ref() {
         let cwd_path = std::path::PathBuf::from(cwd);
-        let (enabled, configured_mode) =
-            crate::devshell::effective_config(&app, &cwd_path).into_parts();
-        if enabled != "never" {
-            if let Some(reason) =
-                crate::commands::devshell::forced_mode_mismatch_reason(&cwd_path, configured_mode)
-            {
+        let emitter = crate::devshell::prepare_policy::emitter_for(&app);
+        let decision =
+            crate::devshell::prepare_env_for_root(&app, &devshell, &cwd_path, Some(&emitter)).await;
+        match decision {
+            crate::devshell::PrepareDecision::Disabled
+            | crate::devshell::PrepareDecision::MissingOptional { .. } => {}
+            crate::devshell::PrepareDecision::Prepared { kind, prepared } => {
+                detected_launch_kind = Some(kind);
+                tracing::debug!(
+                    target: "aethon::devshell",
+                    "shell_open: prepared {} devshell vars for tab {}",
+                    prepared.env.len(),
+                    args.tab_id
+                );
+                match kind {
+                    DevshellKind::Flake | DevshellKind::Direnv => {
+                        launch_kind = Some(kind);
+                    }
+                    DevshellKind::Shell => {
+                        prepared_env = Some((prepared.kind, prepared.env));
+                    }
+                }
+            }
+            crate::devshell::PrepareDecision::DirenvAllowFailedOptional { kind, reason } => {
+                detected_launch_kind = Some(kind);
+                tracing::warn!(
+                    target: "aethon::devshell",
+                    "shell_open: direnv allow failed for {}: {reason}; opening host shell",
+                    cwd_path.display()
+                );
+            }
+            crate::devshell::PrepareDecision::CachePrepareFailedOptional { kind, reason } => {
+                detected_launch_kind = Some(kind);
+                tracing::warn!(
+                    target: "aethon::devshell",
+                    "shell_open: devshell prepare failed for {}: {reason}; opening host shell",
+                    cwd_path.display()
+                );
+            }
+            crate::devshell::PrepareDecision::MissingRequired { reason } => {
+                return Err(format!(
+                    "devshell prepare: {} and [devshell] enabled = \"always\"",
+                    reason
+                ));
+            }
+            crate::devshell::PrepareDecision::ForcedModeMismatch { reason }
+            | crate::devshell::PrepareDecision::CachePrepareFailedRequired { reason } => {
                 return Err(format!("devshell prepare: {reason}"));
             }
-            let detected_kind = crate::devshell::detect_mode(&cwd_path, configured_mode);
-            match detected_kind {
-                Some(kind) => {
-                    detected_launch_kind = Some(kind);
-                    let mut can_prepare = true;
-                    if kind.as_str() == "direnv"
-                        && let Err(reason) =
-                            crate::commands::devshell::direnv_allow(&cwd_path).await
-                    {
-                        if crate::commands::devshell::devshell_prepare_is_required(&enabled) {
-                            return Err(reason);
-                        }
-                        tracing::warn!(
-                            target: "aethon::devshell",
-                            "shell_open: direnv allow failed for {}: {reason}; opening host shell",
-                            cwd_path.display()
-                        );
-                        can_prepare = false;
-                    }
-                    if can_prepare {
-                        let emitter: AppEmitter =
-                            AppEmitter::new(Arc::new(TauriEmitter::new(app.clone()))
-                                as Arc<dyn DevshellEmitter>);
-                        let prepared = match devshell
-                            .prepare_for(Some(&emitter), &cwd_path, configured_mode)
-                            .await
-                        {
-                            Ok(prepared) => Some(prepared),
-                            Err(reason) => {
-                                if crate::commands::devshell::devshell_prepare_is_required(&enabled)
-                                {
-                                    return Err(format!("devshell prepare: {reason}"));
-                                }
-                                tracing::warn!(
-                                    target: "aethon::devshell",
-                                    "shell_open: devshell prepare failed for {}: {reason}; opening host shell",
-                                    cwd_path.display()
-                                );
-                                None
-                            }
-                        };
-                        if let Some(prepared) = prepared {
-                            tracing::debug!(
-                                target: "aethon::devshell",
-                                "shell_open: prepared {} devshell vars for tab {}",
-                                prepared.env.len(),
-                                args.tab_id
-                            );
-                            match kind {
-                                DevshellKind::Flake | DevshellKind::Direnv => {
-                                    launch_kind = Some(kind);
-                                }
-                                DevshellKind::Shell => {
-                                    prepared_env = Some((prepared.kind, prepared.env));
-                                }
-                            }
-                        }
-                    }
-                }
-                None if enabled == "always" => {
-                    let reason = format!("no devshell detected at {}", cwd_path.display());
-                    if let Some(error) =
-                        crate::commands::devshell::required_devshell_missing_error(&enabled, reason)
-                    {
-                        return Err(format!("devshell prepare: {error}"));
-                    }
-                }
-                None => {}
+            crate::devshell::PrepareDecision::DirenvAllowFailedRequired { reason } => {
+                return Err(reason);
             }
         }
     }
@@ -545,6 +519,21 @@ mod shell_classification_tests {
                 "-il"
             ]
         );
+        assert_eq!(cmd.get_cwd(), Some(&OsString::from("/repo/worktree")));
+    }
+
+    #[test]
+    fn shell_devshell_launches_command_directly_for_env_injection() {
+        let cmd = devshell_launch_command_with_resolver(
+            Some(DevshellKind::Shell),
+            Some("/repo/worktree"),
+            "/bin/zsh",
+            &["-il".to_string()],
+            fake_resolver,
+        )
+        .unwrap();
+
+        assert_eq!(argv(&cmd), ["/bin/zsh", "-il"]);
         assert_eq!(cmd.get_cwd(), Some(&OsString::from("/repo/worktree")));
     }
 


### PR DESCRIPTION
## Summary

- Introduce a shared `devshell::prepare_policy` layer that returns structured prepare decisions for disabled, missing optional/required devshells, forced-mode mismatch, direnv allow failures, cache prepare failures, and prepared environments.
- Convert startup preparation, `devshell_prepare_for_path`, and shell open to consume the shared policy while preserving each caller's existing UI/IPC/error presentation.
- Preserve shell launch semantics: legacy `shell.nix` devshells inject prepared env directly, while flake and direnv shell opens launch through wrapper commands.

Closes #373.

## Validation

- `cargo test --manifest-path src-tauri/Cargo.toml devshell`
- `cargo test --manifest-path src-tauri/Cargo.toml startup`
- `cargo test --manifest-path src-tauri/Cargo.toml shell::lifecycle::open::shell_classification_tests`
- `cargo test --manifest-path src-tauri/Cargo.toml devshell::resolve::tests::run_with_timeout_streams_nix_prelude_before_process_exit`
- `codex review --uncommitted --title "Issue 373 devshell prepare policy final"` — no actionable correctness issues found

## Notes

- A broad `cargo test --manifest-path src-tauri/Cargo.toml --lib` run had one timing-sensitive resolver test fail once, then the same test passed on direct rerun. Codex later ran `cargo test --lib --quiet` successfully during review.
