### PR TITLE
fix: persist tool diff snapshots

### DIFF
--- a/agent/session-history.test.ts
+++ b/agent/session-history.test.ts
@@ -1396,6 +1396,66 @@ describe("readSessionTranscript", () => {
     });
   });
 
+  it("restores multi-edit file-change snapshots from pi transcripts", async () => {
+    const dir = await tempRoot();
+    await writeFile(
+      join(dir, "session.jsonl"),
+      [
+        JSON.stringify({
+          type: "message",
+          id: "assistant-tool",
+          timestamp: 3_000,
+          message: {
+            role: "assistant",
+            content: [
+              {
+                type: "toolCall",
+                id: "call_edit_multi",
+                name: "edit",
+                arguments: {
+                  path: "src/App.tsx",
+                  edits: [
+                    { oldText: "old one", newText: "new one" },
+                    { oldText: "old two", newText: "new two\nnew extra" },
+                  ],
+                },
+              },
+            ],
+          },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "tool-result",
+          timestamp: 3_100,
+          message: {
+            role: "toolResult",
+            toolCallId: "call_edit_multi",
+            toolName: "edit",
+            content: [
+              {
+                type: "text",
+                text: "Successfully replaced 2 block(s) in src/App.tsx",
+              },
+            ],
+          },
+        }),
+      ].join("\n") + "\n",
+    );
+
+    const restored = await readSessionTranscript(dir);
+    expect(restored).toHaveLength(1);
+    expect(restored[0].a2ui?.components[0]).toMatchObject({
+      props: {
+        fileChange: {
+          path: "src/App.tsx",
+          preview: expect.stringContaining("@@ edit 2 @@"),
+          additions: 3,
+          deletions: 2,
+        },
+      },
+    });
+  });
+
   it("prefers durable unified diff snapshots over non-diff tool status text", () => {
     const merged = restoreTesting.mergeFileChange(
       {

--- a/agent/session-history/parse-pi.ts
+++ b/agent/session-history/parse-pi.ts
@@ -193,6 +193,7 @@ export function parseSessionHistoryLines(
       const endedAt = parseMessageTime(record, msg);
       const result = {
         content: msg.content,
+        ...(msg.details !== undefined ? { details: msg.details } : {}),
       };
       const isError = msg.isError === true;
       const cached = toolCallId ? toolCalls.get(toolCallId) : undefined;

--- a/agent/tab-lifecycle.test.ts
+++ b/agent/tab-lifecycle.test.ts
@@ -442,6 +442,47 @@ describe("toolCardPayload", () => {
     expect(root.props.fileChange.preview).toContain("+third new line");
   });
 
+  it("captures multi-edit argument snapshots when the tool result is status text", () => {
+    const payload = toolCardPayload({
+      id: "tool-c1",
+      toolName: "edit",
+      argsSummary: "src/App.tsx",
+      args: {
+        path: "src/App.tsx",
+        edits: [
+          { oldText: "old one", newText: "new one\nnew extra" },
+          { oldText: "old two\nold three", newText: "new two" },
+        ],
+      },
+      rootPath: "/repo",
+      result: "Successfully replaced 2 block(s)",
+    });
+
+    expect(payload).toMatchObject({
+      components: [
+        {
+          props: {
+            fileChange: {
+              kind: "edited",
+              path: "src/App.tsx",
+              rootPath: "/repo",
+              preview: expect.stringContaining("@@ edit 2 @@"),
+              additions: 3,
+              deletions: 3,
+            },
+          },
+        },
+      ],
+    });
+    const root = payload.components[0] as {
+      props: { fileChange: { preview: string } };
+    };
+    expect(root.props.fileChange.preview).toContain("-old one");
+    expect(root.props.fileChange.preview).toContain("+new extra");
+    expect(root.props.fileChange.preview).toContain("-old three");
+    expect(root.props.fileChange.preview).toContain("+new two");
+  });
+
   it("classifies write tools as created when the result says a file was created", () => {
     const payload = toolCardPayload({
       id: "tool-c1",

--- a/agent/tool-card.ts
+++ b/agent/tool-card.ts
@@ -95,6 +95,14 @@ function stringArg(args: unknown, key: string): string {
   return typeof value === "string" ? value.trim() : "";
 }
 
+function stringValue(record: Record<string, unknown>, keys: string[]): string {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string") return value.trim();
+  }
+  return "";
+}
+
 function countDiffStats(text: string): { additions: number; deletions: number } {
   let additions = 0;
   let deletions = 0;
@@ -116,23 +124,61 @@ function lineCount(value: string): number {
   return value.replace(/\r?\n$/, "").split(/\r?\n/).length;
 }
 
+function editPairsFromArgs(
+  args: unknown,
+): Array<{ oldText: string; newText: string }> {
+  if (!args || typeof args !== "object") return [];
+  const raw = args as Record<string, unknown>;
+  if (Array.isArray(raw.edits)) {
+    return raw.edits
+      .map((edit) => {
+        if (!edit || typeof edit !== "object") return undefined;
+        const record = edit as Record<string, unknown>;
+        const oldText = stringValue(record, [
+          "oldText",
+          "old_text",
+          "oldString",
+          "old_string",
+          "old_str",
+          "old",
+        ]);
+        const newText = stringValue(record, [
+          "newText",
+          "new_text",
+          "newString",
+          "new_string",
+          "new_str",
+          "new",
+        ]);
+        return oldText || newText ? { oldText, newText } : undefined;
+      })
+      .filter((pair): pair is { oldText: string; newText: string } =>
+        Boolean(pair),
+      );
+  }
+  const oldText = stringValue(raw, [
+    "oldString",
+    "old_string",
+    "old_str",
+    "old",
+  ]);
+  const newText = stringValue(raw, [
+    "newString",
+    "new_string",
+    "new_str",
+    "new",
+  ]);
+  return oldText || newText ? [{ oldText, newText }] : [];
+}
+
 function editStatsFromArgs(args: unknown): { additions: number; deletions: number } | undefined {
   if (!args || typeof args !== "object") return undefined;
   const raw = args as Record<string, unknown>;
-  const oldText =
-    stringArg(raw, "oldString") ||
-    stringArg(raw, "old_string") ||
-    stringArg(raw, "old_str") ||
-    stringArg(raw, "old");
-  const newText =
-    stringArg(raw, "newString") ||
-    stringArg(raw, "new_string") ||
-    stringArg(raw, "new_str") ||
-    stringArg(raw, "new");
-  if (oldText || newText) {
+  const pairs = editPairsFromArgs(raw);
+  if (pairs.length > 0) {
     return {
-      additions: lineCount(newText),
-      deletions: lineCount(oldText),
+      additions: pairs.reduce((sum, pair) => sum + lineCount(pair.newText), 0),
+      deletions: pairs.reduce((sum, pair) => sum + lineCount(pair.oldText), 0),
     };
   }
   const content =
@@ -155,26 +201,19 @@ function prefixedLines(prefix: string, value: string): string {
 function syntheticDiffFromArgs(path: string, args: unknown): string | undefined {
   if (!args || typeof args !== "object") return undefined;
   const raw = args as Record<string, unknown>;
-  const oldText =
-    stringArg(raw, "oldString") ||
-    stringArg(raw, "old_string") ||
-    stringArg(raw, "old_str") ||
-    stringArg(raw, "old");
-  const newText =
-    stringArg(raw, "newString") ||
-    stringArg(raw, "new_string") ||
-    stringArg(raw, "new_str") ||
-    stringArg(raw, "new");
-  if (oldText || newText) {
-    return [
-      `--- a/${path}`,
-      `+++ b/${path}`,
-      "@@ replacement @@",
-      prefixedLines("-", oldText),
-      prefixedLines("+", newText),
-    ]
-      .filter(Boolean)
-      .join("\n");
+  const pairs = editPairsFromArgs(raw);
+  if (pairs.length > 0) {
+    const lines = [`--- a/${path}`, `+++ b/${path}`];
+    pairs.forEach((pair, index) => {
+      lines.push(
+        pairs.length === 1 ? "@@ replacement @@" : `@@ edit ${index + 1} @@`,
+      );
+      const oldLines = prefixedLines("-", pair.oldText);
+      const newLines = prefixedLines("+", pair.newText);
+      if (oldLines) lines.push(oldLines);
+      if (newLines) lines.push(newLines);
+    });
+    return lines.join("\n");
   }
   const content =
     stringArg(raw, "content") || stringArg(raw, "text") || stringArg(raw, "body");
@@ -188,6 +227,29 @@ function syntheticDiffFromArgs(path: string, args: unknown): string | undefined 
     ].join("\n");
   }
   return undefined;
+}
+
+function diffFromResultDetails(
+  path: string,
+  result: unknown,
+): string | undefined {
+  if (!result || typeof result !== "object") return undefined;
+  const details = (result as Record<string, unknown>).details;
+  const diff =
+    typeof details === "string"
+      ? details
+      : details && typeof details === "object"
+        ? (details as Record<string, unknown>).diff
+        : undefined;
+  if (typeof diff !== "string" || !diff.trim()) return undefined;
+  const trimmed = truncate(diff.trim(), 4000);
+  if (looksLikeUnifiedDiff(trimmed)) return trimmed;
+  return [
+    `--- a/${path}`,
+    `+++ b/${path}`,
+    "@@ tool result diff @@",
+    trimmed,
+  ].join("\n");
 }
 
 function writeLooksCreated(text: string): boolean {
@@ -208,7 +270,8 @@ function fileChangeForTool(opts: {
   const resultText = extracted?.text ? truncate(extracted.text, 4000) : undefined;
   const preview = looksLikeUnifiedDiff(resultText)
     ? resultText
-    : syntheticDiffFromArgs(path, opts.args);
+    : (diffFromResultDetails(path, opts.result) ??
+      syntheticDiffFromArgs(path, opts.args));
   const stats = preview
     ? countDiffStats(preview)
     : (editStatsFromArgs(opts.args) ??

--- a/src/editorTabs.test.ts
+++ b/src/editorTabs.test.ts
@@ -44,6 +44,30 @@ describe("editorTabsFromTabs", () => {
     const tabs = [editorTab("e2", "/r/x.ts", { diff: true })];
     expect(editorTabsFromTabs(tabs, "e2").activeFilePath).toBeUndefined();
   });
+
+  it("keeps distinct snapshot-backed diff tabs for the same file", () => {
+    const firstSnapshot = {
+      format: "unified" as const,
+      content: "--- a/x.ts\n+++ b/x.ts\n@@\n-a\n+b",
+      source: "tool-card" as const,
+    };
+    const secondSnapshot = {
+      format: "unified" as const,
+      content: "--- a/x.ts\n+++ b/x.ts\n@@\n-c\n+d",
+      source: "tool-card" as const,
+    };
+    const tabs = [
+      editorTab("e1", "/r/x.ts", { diff: true, diffSnapshot: firstSnapshot }),
+      editorTab("e2", "/r/x.ts", { diff: true, diffSnapshot: secondSnapshot }),
+      editorTab("e3", "/r/x.ts", { diff: true, diffSnapshot: firstSnapshot }),
+    ];
+    const result = editorTabsFromTabs(tabs, "e1");
+    expect(result.tabs).toHaveLength(2);
+    expect(result.tabs.map((tab) => tab.diffSnapshot?.content)).toEqual([
+      firstSnapshot.content,
+      secondSnapshot.content,
+    ]);
+  });
 });
 
 describe("hydration gate (no clobber before restore)", () => {
@@ -79,13 +103,29 @@ describe("parseEditorTabsStore", () => {
   });
 
   it("keeps well-formed entries and drops malformed tabs", () => {
+    const diffSnapshot = {
+      format: "unified",
+      content: "--- a/r.ts\n+++ b/r.ts\n@@\n-old\n+new",
+      source: "tool-card",
+    };
     const raw = JSON.stringify({
       byProject: {
         p1: {
           activeFilePath: "/r/a.ts",
           tabs: [
             { filePath: "/r/a.ts", language: "typescript" },
+            {
+              filePath: "/r/diff.ts",
+              language: "typescript",
+              diff: true,
+              diffSnapshot,
+            },
             { filePath: 123, language: "x" }, // bad path → dropped
+            {
+              filePath: "/r/bad.ts",
+              language: "typescript",
+              diffSnapshot: { format: "unified", content: "x" },
+            },
             { language: "x" }, // no path → dropped
           ],
         },
@@ -97,7 +137,15 @@ describe("parseEditorTabsStore", () => {
       byProject: {
         p1: {
           activeFilePath: "/r/a.ts",
-          tabs: [{ filePath: "/r/a.ts", language: "typescript" }],
+          tabs: [
+            { filePath: "/r/a.ts", language: "typescript" },
+            {
+              filePath: "/r/diff.ts",
+              language: "typescript",
+              diff: true,
+              diffSnapshot,
+            },
+          ],
         },
       },
     });

--- a/src/editorTabs.ts
+++ b/src/editorTabs.ts
@@ -9,7 +9,11 @@
 // `useProjectOps`.
 
 import { readState, writeState } from "./persist";
-import type { Tab } from "./types/tab";
+import type { EditorDiffSnapshot, Tab } from "./types/tab";
+import {
+  diffSnapshotKey,
+  isEditorDiffSnapshot,
+} from "./utils/editorDiffSnapshot";
 
 const FILE = "editor-tabs.json";
 /** Bucket key for tabs opened with no active project. */
@@ -20,6 +24,7 @@ export interface PersistedEditorTab {
   rootPath?: string;
   language: string;
   diff?: boolean;
+  diffSnapshot?: EditorDiffSnapshot;
   cursorLine?: number;
   cursorColumn?: number;
 }
@@ -50,6 +55,7 @@ export function toPersistedEditorTab(tab: Tab): PersistedEditorTab | null {
     ...(e.rootPath ? { rootPath: e.rootPath } : {}),
     language: e.language,
     ...(e.diff ? { diff: true } : {}),
+    ...(e.diffSnapshot ? { diffSnapshot: e.diffSnapshot } : {}),
     ...(typeof e.cursorLine === "number" ? { cursorLine: e.cursorLine } : {}),
     ...(typeof e.cursorColumn === "number"
       ? { cursorColumn: e.cursorColumn }
@@ -69,7 +75,11 @@ export function editorTabsFromTabs(
   for (const t of tabs) {
     const p = toPersistedEditorTab(t);
     if (!p) continue;
-    const key = `${p.filePath}::${p.diff ? "d" : "e"}`;
+    const key = [
+      p.filePath,
+      p.diff ? "d" : "e",
+      diffSnapshotKey(p.diffSnapshot),
+    ].join("::");
     if (seen.has(key)) continue;
     seen.add(key);
     out.push(p);
@@ -79,11 +89,13 @@ export function editorTabsFromTabs(
 }
 
 function isPersistedTab(v: unknown): v is PersistedEditorTab {
+  if (!v || typeof v !== "object") return false;
+  const tab = v as PersistedEditorTab;
   return (
-    !!v &&
-    typeof v === "object" &&
-    typeof (v as PersistedEditorTab).filePath === "string" &&
-    typeof (v as PersistedEditorTab).language === "string"
+    typeof tab.filePath === "string" &&
+    typeof tab.language === "string" &&
+    (tab.diffSnapshot === undefined ||
+      isEditorDiffSnapshot(tab.diffSnapshot))
   );
 }
 

--- a/src/eventRoutes/editor.test.ts
+++ b/src/eventRoutes/editor.test.ts
@@ -73,6 +73,7 @@ describe("handleEditorCanvas", () => {
     expect(claimed).toBe(true);
     expect(fx.mocks.updateEditorMeta).toHaveBeenCalledWith("tab-1", {
       diff: false,
+      diffSnapshot: undefined,
     });
   });
 
@@ -336,7 +337,35 @@ describe("handleToolCardFile", () => {
     );
   });
 
-  it("opens a tool-card file in a diff tab", () => {
+  it("opens a tool-card file in a snapshot-backed diff tab", () => {
+    const fx = buildRouteFixture();
+    const diffSnapshot = {
+      format: "unified" as const,
+      content: "--- a/src/App.tsx\n+++ b/src/App.tsx\n@@\n-old\n+new",
+      additions: 1,
+      deletions: 1,
+      source: "tool-card" as const,
+    };
+    const claimed = handleToolCardFile(
+      {
+        component: { id: "tool-1", type: "tool-card" },
+        eventType: "tool-file-diff",
+        data: {
+          filePath: "/projects/aethon/src/App.tsx",
+          rootPath: "/projects/aethon",
+          diffSnapshot,
+        },
+      },
+      fx.ctx,
+    );
+    expect(claimed).toBe(true);
+    expect(fx.mocks.newEditorTab).toHaveBeenCalledWith(
+      "/projects/aethon/src/App.tsx",
+      { diff: true, rootPath: "/projects/aethon", diffSnapshot },
+    );
+  });
+
+  it("warns instead of opening a live git diff for tool-card records without snapshots", () => {
     const fx = buildRouteFixture();
     const claimed = handleToolCardFile(
       {
@@ -350,9 +379,12 @@ describe("handleToolCardFile", () => {
       fx.ctx,
     );
     expect(claimed).toBe(true);
-    expect(fx.mocks.newEditorTab).toHaveBeenCalledWith(
-      "/projects/aethon/src/App.tsx",
-      { diff: true, rootPath: "/projects/aethon" },
+    expect(fx.mocks.newEditorTab).not.toHaveBeenCalled();
+    expect(fx.mocks.pushNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Diff snapshot unavailable",
+        kind: "warning",
+      }),
     );
   });
 

--- a/src/eventRoutes/editor.ts
+++ b/src/eventRoutes/editor.ts
@@ -28,6 +28,7 @@ import {
   joinRoot,
 } from "../hooks/bridgeMessageHandlers/editorQuery";
 import { WORKSTATION_AREAS } from "../hooks/useFocus";
+import { isEditorDiffSnapshot } from "../utils/editorDiffSnapshot";
 
 function asRecord(data: unknown): Record<string, unknown> {
   return data && typeof data === "object"
@@ -114,7 +115,7 @@ export const handleEditorCanvas: EventRouteHandler = async (
     case "editor-diff-to-edit": {
       // "Edit file" affordance in the diff view: drop the diff flag so
       // this tab becomes the editable Monaco editor for the same path.
-      ctx.updateEditorMeta(tabId, { diff: false });
+      ctx.updateEditorMeta(tabId, { diff: false, diffSnapshot: undefined });
       return true;
     }
     case "markdown-link-open": {
@@ -183,9 +184,29 @@ export const handleToolCardFile: EventRouteHandler = (
   }
   const target = resolveToolFileTarget(event.data, ctx);
   if (!target) return true;
+  const payload = asRecord(event.data);
+  if (event.eventType === "tool-file-diff") {
+    const diffSnapshot = isEditorDiffSnapshot(payload.diffSnapshot)
+      ? payload.diffSnapshot
+      : undefined;
+    if (!diffSnapshot) {
+      ctx.pushNotification({
+        title: "Diff snapshot unavailable",
+        message: "This older tool record did not save a diff snapshot.",
+        kind: "warning",
+        durationMs: 4000,
+      });
+      return true;
+    }
+    ctx.newEditorTab(target.filePath, {
+      ...(target.rootPath ? { rootPath: target.rootPath } : {}),
+      diff: true,
+      diffSnapshot,
+    });
+    return true;
+  }
   ctx.newEditorTab(target.filePath, {
     ...(target.rootPath ? { rootPath: target.rootPath } : {}),
-    ...(event.eventType === "tool-file-diff" ? { diff: true } : {}),
   });
   return true;
 };

--- a/src/eventRoutes/types.ts
+++ b/src/eventRoutes/types.ts
@@ -1,5 +1,5 @@
 import type { Dispatch, MutableRefObject, SetStateAction } from "react";
-import type { EditorMeta, Tab } from "../types/tab";
+import type { EditorDiffSnapshot, EditorMeta, Tab } from "../types/tab";
 import type { ChatAttachment } from "../types/a2ui";
 import type { ShareMode } from "../utils/shareMode";
 import type {
@@ -97,7 +97,11 @@ export interface EventRouteContext {
   newShellTab: () => void;
   newEditorTab: (
     filePath: string,
-    opts?: { rootPath?: string; diff?: boolean },
+    opts?: {
+      rootPath?: string;
+      diff?: boolean;
+      diffSnapshot?: EditorDiffSnapshot;
+    },
   ) => void;
   updateEditorMeta: (tabId: string, patch: Partial<EditorMeta>) => void;
   /** Toggle markdown preview on the active editor tab. No-op unless the

--- a/src/extensions/default-layout/chat.test.tsx
+++ b/src/extensions/default-layout/chat.test.tsx
@@ -2815,98 +2815,83 @@ describe("ChatHistory turn activity feed (mocked Virtuoso renders rows)", () => 
     });
   });
 
-  it("fetches a real inline diff instead of showing non-diff edit status text", async () => {
+  it("renders captured inline diffs without fetching or persisting live git snapshots", () => {
     invokeMock.mockImplementation((cmd: string) =>
-      cmd === "git_file_diff_stat"
-        ? Promise.resolve({ insertions: 1, deletions: 1 })
-        : cmd === "git_file_diff"
-          ? Promise.resolve(
-              "diff --git a/src/App.tsx b/src/App.tsx\n@@ -1 +1 @@\n-old title\n+new title\n",
-            )
-          : Promise.reject(new Error(`invoke not mocked: ${cmd}`)),
+      Promise.reject(new Error(`invoke not mocked: ${cmd}`)),
     );
+    const onEvent = vi.fn();
 
-    renderGroupedHistory({
-      messages: [
-        { id: "u1", role: "user", text: "change files" },
+    render(
+      groupedHistoryElement(
         {
-          id: "t1",
-          role: "agent",
-          a2ui: {
-            components: [
-              {
-                id: "tool-edit",
-                type: "tool-card",
-                props: {
-                  title: "edit",
-                  startedAt: 1,
-                  endedAt: 2,
-                  fileChange: {
-                    kind: "edited",
-                    path: "src/App.tsx",
-                    rootPath: "/repo/aethon",
-                    preview: "Successfully replaced 1 block(s)",
+          messages: [
+            { id: "u1", role: "user", text: "change files" },
+            {
+              id: "t1",
+              role: "agent",
+              a2ui: {
+                components: [
+                  {
+                    id: "tool-edit",
+                    type: "tool-card",
+                    props: {
+                      title: "edit",
+                      startedAt: 1,
+                      endedAt: 2,
+                      fileChange: {
+                        kind: "edited",
+                        path: "src/App.tsx",
+                        rootPath: "/repo/aethon",
+                        preview:
+                          "diff --git a/src/App.tsx b/src/App.tsx\n@@ -1 +1 @@\n-old title\n+new title\n",
+                        additions: 1,
+                        deletions: 1,
+                      },
+                    },
                   },
-                },
+                ],
               },
-            ],
-          },
+            },
+          ],
+          transcriptVisibility: { toolCalls: "hide" },
         },
-      ],
-      transcriptVisibility: { toolCalls: "hide" },
-    });
-
-    expect(screen.queryByText("Successfully replaced 1 block(s)")).toBeNull();
+        new ExtensionRegistry(),
+        onEvent,
+      ),
+    );
 
     fireEvent.click(
       screen.getByRole("button", { name: "Show inline diff for App.tsx" }),
     );
 
-    expect(await screen.findByText("+new title")).toBeTruthy();
+    expect(screen.getByText("+new title")).toBeTruthy();
     expect(screen.getByText("-old title")).toBeTruthy();
-    expect(screen.queryByText("Successfully replaced 1 block(s)")).toBeNull();
-    expect(invokeMock).toHaveBeenCalledWith("git_file_diff", {
-      root: "/repo/aethon",
-      path: "src/App.tsx",
-    });
-    expect(invokeMock).toHaveBeenCalledWith("agent_command", {
-      payload: expect.stringContaining("file-diff-snapshot-tool-edit"),
-    });
-    const persistedCall = invokeMock.mock.calls.find(
-      ([cmd, payload]) =>
-        cmd === "agent_command" &&
-        typeof (payload as { payload?: unknown })?.payload === "string" &&
-        (payload as { payload: string }).payload.includes(
-          "file-diff-snapshot-tool-edit",
-        ),
+    expect(invokeMock).not.toHaveBeenCalledWith(
+      "git_file_diff",
+      expect.anything(),
     );
-    expect(persistedCall).toBeTruthy();
-    const persistedPayload = JSON.parse(
-      (persistedCall?.[1] as { payload: string }).payload,
+    expect(invokeMock).not.toHaveBeenCalledWith(
+      "agent_command",
+      expect.anything(),
     );
-    expect(persistedPayload).toMatchObject({
-      type: "local_chat_message",
-      tabId: "tab-1",
-      payload: {
-        role: "agent",
-        a2ui: {
-          components: [
-            {
-              id: "tool-edit",
-              type: "tool-card",
-              props: {
-                fileChange: {
-                  path: "src/App.tsx",
-                  preview: expect.stringContaining("+new title"),
-                  additions: 1,
-                  deletions: 1,
-                },
-              },
-            },
-          ],
+
+    fireEvent.click(screen.getByTitle("Open diff for src/App.tsx"));
+    expect(onEvent).toHaveBeenCalledWith(
+      "tool-file-diff",
+      {
+        filePath: "src/App.tsx",
+        rootPath: "/repo/aethon",
+        diffSnapshot: {
+          format: "unified",
+          content:
+            "diff --git a/src/App.tsx b/src/App.tsx\n@@ -1 +1 @@\n-old title\n+new title\n",
+          additions: 1,
+          deletions: 1,
+          source: "tool-card",
         },
       },
-    });
+      "tool-edit",
+    );
   });
 
   it("keeps stopped generic tool output hidden when tool calls are off", () => {

--- a/src/extensions/default-layout/editor/canvas.tsx
+++ b/src/extensions/default-layout/editor/canvas.tsx
@@ -34,6 +34,7 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import * as monaco from "monaco-editor";
 
 import type { StringValue } from "../../../types/a2ui";
+import type { EditorDiffSnapshot } from "../../../types/tab";
 import { resolveString } from "../../../utils/dataBinding";
 import {
   RegistryComponent,
@@ -86,6 +87,7 @@ interface EditorTabLike {
     /** When true, render the read-only side-by-side diff (HEAD vs working
      *  tree) instead of the editable Monaco editor. */
     diff?: boolean;
+    diffSnapshot?: EditorDiffSnapshot;
   };
 }
 
@@ -637,6 +639,7 @@ export function EditorCanvas({
             refreshKey: `${vcs?.changes?.total ?? 0}:${
               vcs?.changes?.additions ?? 0
             }:${vcs?.changes?.deletions ?? 0}`,
+            diffSnapshot: editorMeta?.diffSnapshot,
           }}
         />
       )}

--- a/src/extensions/default-layout/editor/diff-canvas.tsx
+++ b/src/extensions/default-layout/editor/diff-canvas.tsx
@@ -20,10 +20,15 @@ import { invoke } from "@tauri-apps/api/core";
 import * as monaco from "monaco-editor";
 
 import type { BuiltinComponentProps } from "../../../components/A2UIRenderer";
+import type { EditorDiffSnapshot } from "../../../types/tab";
 import { applyMonacoTheme } from "../../../monaco/theme";
 import { ensureShikiMonacoReady } from "../../../monaco/shiki";
 import { languageFromPath } from "../../../monaco/language-detection";
 import { compressPath } from "./path";
+import {
+  isEditorDiffSnapshot,
+  parseUnifiedDiffSnapshot,
+} from "../../../utils/editorDiffSnapshot";
 
 interface DiffCanvasProps {
   filePath: string;
@@ -34,6 +39,9 @@ interface DiffCanvasProps {
    *  saving — which leaves the changed-file *count* unchanged — still
    *  refreshes the diff. */
   refreshKey?: number | string;
+  /** Captured tool-card diff. When present, render this immutable snapshot
+   *  instead of reading current git/disk state. */
+  diffSnapshot?: EditorDiffSnapshot;
 }
 
 function disposeModels(
@@ -49,6 +57,9 @@ export function DiffCanvas(props: BuiltinComponentProps) {
   const projectPath = cp.projectPath ?? "";
   const tabId = cp.tabId ?? "";
   const refreshKey = cp.refreshKey ?? 0;
+  const diffSnapshot = isEditorDiffSnapshot(cp.diffSnapshot)
+    ? cp.diffSnapshot
+    : undefined;
 
   const containerRef = useRef<HTMLDivElement>(null);
   const diffRef = useRef<monaco.editor.IStandaloneDiffEditor | null>(null);
@@ -107,8 +118,25 @@ export function DiffCanvas(props: BuiltinComponentProps) {
   // ─── Load HEAD + working-tree content into the diff models ──────────
   useEffect(() => {
     const ed = diffRef.current;
-    if (!ed || !filePath || !projectPath) return;
+    if (!ed || !filePath) return;
     let cancelled = false;
+    if (diffSnapshot) {
+      void Promise.resolve().then(() => {
+        if (cancelled) return;
+        const prev = ed.getModel();
+        const language = languageFromPath(filePath);
+        const models = parseUnifiedDiffSnapshot(diffSnapshot.content);
+        const original = monaco.editor.createModel(models.original, language);
+        const modified = monaco.editor.createModel(models.modified, language);
+        ed.setModel({ original, modified });
+        disposeModels(prev);
+        setError("");
+      });
+      return () => {
+        cancelled = true;
+      };
+    }
+    if (!projectPath) return;
     const language = languageFromPath(filePath);
     void Promise.all([
       invoke<string | null>("git_show_head", {
@@ -137,7 +165,7 @@ export function DiffCanvas(props: BuiltinComponentProps) {
     return () => {
       cancelled = true;
     };
-  }, [filePath, projectPath, refreshKey]);
+  }, [filePath, projectPath, refreshKey, diffSnapshot]);
 
   return (
     <div className="ae-diff-canvas-wrap" style={{ gridArea: "canvas" }}>
@@ -146,8 +174,11 @@ export function DiffCanvas(props: BuiltinComponentProps) {
         <span className="ae-editor-status-path" title={filePath}>
           {compressPath(filePath)}
         </span>
-        <span className="ae-diff-canvas-badge" aria-label="Diff against HEAD">
-          HEAD ↔ Working Tree
+        <span
+          className="ae-diff-canvas-badge"
+          aria-label={diffSnapshot ? "Captured tool diff" : "Diff against HEAD"}
+        >
+          {diffSnapshot ? "Captured Tool Diff" : "HEAD ↔ Working Tree"}
         </span>
         <span className="ae-editor-status-spacer" />
         {error && <span className="ae-editor-status-lang">{error}</span>}

--- a/src/extensions/default-layout/message-groups.tsx
+++ b/src/extensions/default-layout/message-groups.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useRef, useState } from "react";
-import { invoke } from "@tauri-apps/api/core";
 import type { A2UIComponent, ChatMessage } from "../../types/a2ui";
 import A2UIRenderer, {
   type BuiltinComponentProps,
@@ -174,72 +173,6 @@ interface ToolFileChangeEntry {
 interface LineChangeStats {
   additions: number;
   deletions: number;
-}
-
-function diffStatsFromPreview(preview: string): LineChangeStats {
-  let additions = 0;
-  let deletions = 0;
-  for (const line of preview.split(/\r?\n/)) {
-    if (line.startsWith("+++") || line.startsWith("---")) continue;
-    if (line.startsWith("+")) additions += 1;
-    else if (line.startsWith("-")) deletions += 1;
-  }
-  return { additions, deletions };
-}
-
-async function persistFileChangeDiffSnapshot({
-  tabId,
-  componentId,
-  change,
-  preview,
-}: {
-  tabId?: string;
-  componentId?: string;
-  change: ToolCardFileChange;
-  preview: string;
-}): Promise<void> {
-  if (
-    !tabId ||
-    !componentId ||
-    !change.path ||
-    !looksLikeUnifiedDiff(preview)
-  ) {
-    return;
-  }
-  const stats = diffStatsFromPreview(preview);
-  const fileChange: ToolCardFileChange = {
-    ...change,
-    preview,
-    ...(stats.additions > 0 ? { additions: stats.additions } : {}),
-    ...(stats.deletions > 0 ? { deletions: stats.deletions } : {}),
-  };
-  const createdAt = Date.now();
-  await invoke("agent_command", {
-    payload: JSON.stringify({
-      type: "local_chat_message",
-      tabId,
-      payload: {
-        id: `file-diff-snapshot-${componentId}`,
-        role: "agent",
-        a2ui: {
-          components: [
-            {
-              id: componentId,
-              type: "tool-card",
-              props: {
-                fileChange,
-                startedAt: createdAt,
-                endedAt: createdAt,
-              },
-            },
-          ],
-        },
-        createdAt,
-      },
-    }),
-  }).catch(() => {
-    /* best effort: the visible fetched diff still works for this render */
-  });
 }
 
 function collectFileChangeEntries(
@@ -431,61 +364,36 @@ function ToolFileChangeRow({
   change,
   onEvent,
   componentId,
-  tabId,
 }: {
   change: ToolCardFileChange;
   onEvent?: BuiltinComponentProps["onEvent"];
   componentId?: string;
-  tabId?: string;
 }) {
   const [previewOpen, setPreviewOpen] = useState(false);
-  const [fetchedDiff, setFetchedDiff] = useState<string | null>(null);
-  const [diffLoading, setDiffLoading] = useState(false);
-  const [diffError, setDiffError] = useState<string | null>(null);
   const filePath = change.path ?? "";
   if (!filePath) return null;
-  const eventPayload = {
-    filePath,
-    ...(change.rootPath ? { rootPath: change.rootPath } : {}),
-  };
   const { additions, deletions } = effectiveStats(change);
   const dir = parentPath(filePath);
   const capturedDiff = looksLikeUnifiedDiff(change.preview)
     ? change.preview
     : "";
-  const previewText = capturedDiff || fetchedDiff || "";
-  const hasPreview = Boolean(capturedDiff || change.rootPath);
-  const fetchDiff = async () => {
-    if (capturedDiff || fetchedDiff || !change.rootPath || diffLoading) return;
-    setDiffLoading(true);
-    setDiffError(null);
-    try {
-      const diff = await invoke<string | null>("git_file_diff", {
-        root: change.rootPath,
-        path: filePath,
-      });
-      const durableDiff = diff ?? "";
-      if (looksLikeUnifiedDiff(durableDiff)) {
-        setFetchedDiff(durableDiff);
-        void persistFileChangeDiffSnapshot({
-          tabId,
-          componentId,
-          change,
-          preview: durableDiff,
-        });
-      } else {
-        setFetchedDiff("");
-      }
-    } catch (error) {
-      setDiffError(error instanceof Error ? error.message : String(error));
-    } finally {
-      setDiffLoading(false);
-    }
+  const eventPayload = {
+    filePath,
+    ...(change.rootPath ? { rootPath: change.rootPath } : {}),
+    ...(capturedDiff
+      ? {
+          diffSnapshot: {
+            format: "unified",
+            content: capturedDiff,
+            ...(additions > 0 ? { additions } : {}),
+            ...(deletions > 0 ? { deletions } : {}),
+            source: "tool-card",
+          },
+        }
+      : {}),
   };
   const togglePreview = () => {
-    const nextOpen = !previewOpen;
-    setPreviewOpen(nextOpen);
-    if (nextOpen) void fetchDiff();
+    setPreviewOpen((open) => !open);
   };
   return (
     <div className="ae-tool-activity-file-item">
@@ -530,7 +438,7 @@ function ToolFileChangeRow({
         >
           Open
         </button>
-        {hasPreview ? (
+        {capturedDiff ? (
           <button
             type="button"
             className="ae-tool-activity-file-preview-toggle"
@@ -543,10 +451,10 @@ function ToolFileChangeRow({
           </button>
         ) : null}
       </div>
-      {previewOpen && previewText ? (
+      {previewOpen && capturedDiff ? (
         <pre className="ae-tool-file-diff-preview ae-tool-activity-file-preview">
           <code>
-            {previewLines(previewText).map((line, index) => (
+            {previewLines(capturedDiff).map((line, index) => (
               <span
                 key={`${index}-${line}`}
                 className={`ae-tool-file-diff-line is-${lineTone(line)}`}
@@ -559,11 +467,7 @@ function ToolFileChangeRow({
         </pre>
       ) : previewOpen ? (
         <div className="ae-tool-activity-file-preview-empty">
-          {diffLoading
-            ? "Loading diff..."
-            : diffError
-              ? "Diff unavailable. Open Monaco diff to review this file."
-              : "No working-tree diff available for this file."}
+          No stored diff snapshot is available for this tool record.
         </div>
       ) : null}
     </div>
@@ -574,12 +478,10 @@ function ToolFileChangesCard({
   entries,
   summary,
   onEvent,
-  tabId,
 }: {
   entries: ToolFileChangeEntry[];
   summary: ToolMessageSummary;
   onEvent?: BuiltinComponentProps["onEvent"];
-  tabId?: string;
 }) {
   const label = fileChangeLabel(summary);
   if (entries.length === 0) return null;
@@ -601,7 +503,6 @@ function ToolFileChangesCard({
             change={change}
             onEvent={onEvent}
             componentId={componentId}
-            tabId={tabId}
           />
         ))}
       </div>
@@ -612,11 +513,9 @@ function ToolFileChangesCard({
 function ToolActivityRow({
   message,
   onEvent,
-  tabId,
 }: {
   message: ChatMessage;
   onEvent?: BuiltinComponentProps["onEvent"];
-  tabId?: string;
 }) {
   const details = toolCardDetails(message);
   if (!details.isToolCard) return null;
@@ -659,7 +558,6 @@ function ToolActivityRow({
             change={details.fileChange}
             onEvent={onEvent}
             componentId={details.componentId}
-            tabId={tabId}
           />
         ) : null}
       </div>
@@ -883,14 +781,12 @@ function TurnActivity({
             entries={fileChangeEntries}
             summary={summary}
             onEvent={onEvent}
-            tabId={tabId}
           />
           {detailToolRows.map((message) => (
             <ToolActivityRow
               key={message.id}
               message={message}
               onEvent={onEvent}
-              tabId={tabId}
             />
           ))}
         </div>
@@ -902,7 +798,6 @@ function TurnActivity({
               key={message.id}
               message={message}
               onEvent={onEvent}
-              tabId={tabId}
             />
           ))}
         </div>

--- a/src/extensions/default-layout/message-groups.tsx
+++ b/src/extensions/default-layout/message-groups.tsx
@@ -15,6 +15,7 @@ import {
 import type { ConversationTurn } from "../../utils/transcriptRows";
 import type { ToolCallsMode, VisibilityMode } from "../../config";
 import { ChatMessageRow, tabIsRunning, TypingIndicator } from "./message-row";
+import { truncateDiffSnapshotContent } from "../../utils/editorDiffSnapshot";
 
 const ACTIVITY_DISCLOSURE_EXIT_MS = 240;
 
@@ -384,7 +385,7 @@ function ToolFileChangeRow({
       ? {
           diffSnapshot: {
             format: "unified",
-            content: capturedDiff,
+            content: truncateDiffSnapshotContent(capturedDiff),
             ...(additions > 0 ? { additions } : {}),
             ...(deletions > 0 ? { deletions } : {}),
             source: "tool-card",

--- a/src/extensions/default-layout/tool-card.tsx
+++ b/src/extensions/default-layout/tool-card.tsx
@@ -187,6 +187,11 @@ function previewLines(preview: string): string[] {
     .slice(0, 80);
 }
 
+function looksLikeUnifiedDiff(preview: string | undefined): preview is string {
+  if (!preview) return false;
+  return /(^|\n)(diff --git |@@ |--- |\+\+\+ )/.test(preview);
+}
+
 function lineTone(line: string): "add" | "del" | "hunk" | "meta" | "ctx" {
   if (line.startsWith("+") && !line.startsWith("+++")) return "add";
   if (line.startsWith("-") && !line.startsWith("---")) return "del";
@@ -224,9 +229,23 @@ function ToolFileChangePreview({
     typeof change.deletions === "number" && Number.isFinite(change.deletions)
       ? change.deletions
       : 0;
+  const capturedDiff = looksLikeUnifiedDiff(change.preview)
+    ? change.preview
+    : "";
   const eventPayload = {
     filePath,
     ...(change.rootPath ? { rootPath: change.rootPath } : {}),
+    ...(capturedDiff
+      ? {
+          diffSnapshot: {
+            format: "unified",
+            content: capturedDiff,
+            ...(additions > 0 ? { additions } : {}),
+            ...(deletions > 0 ? { deletions } : {}),
+            source: "tool-card",
+          },
+        }
+      : {}),
   };
 
   return (

--- a/src/extensions/default-layout/tool-card.tsx
+++ b/src/extensions/default-layout/tool-card.tsx
@@ -13,6 +13,7 @@ import type {
   SubagentProgressEntry,
 } from "../../hooks/bridgeMessageHandlers/subagentProgress";
 import { Chevron } from "./sidebar/chevron";
+import { truncateDiffSnapshotContent } from "../../utils/editorDiffSnapshot";
 
 const TOOL_LONG_RUN_THRESHOLD_MS = 30 * 1000;
 
@@ -239,7 +240,7 @@ function ToolFileChangePreview({
       ? {
           diffSnapshot: {
             format: "unified",
-            content: capturedDiff,
+            content: truncateDiffSnapshotContent(capturedDiff),
             ...(additions > 0 ? { additions } : {}),
             ...(deletions > 0 ? { deletions } : {}),
             source: "tool-card",

--- a/src/hooks/bridgeMessageHandlers/types.ts
+++ b/src/hooks/bridgeMessageHandlers/types.ts
@@ -1,6 +1,6 @@
 import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 import type { A2UIPayload, ChatMessage } from "../../types/a2ui";
-import type { Tab } from "../../types/tab";
+import type { EditorDiffSnapshot, Tab } from "../../types/tab";
 import type { ExtensionRegistry } from "../../extensions/ExtensionRegistry";
 import type {
   DisabledExtensionRecord,
@@ -93,7 +93,11 @@ export interface BridgeMessageContext {
    *  `openFileInEditor` tool via `editor_query`. */
   newEditorTab: (
     filePath: string,
-    opts?: { rootPath?: string; diff?: boolean },
+    opts?: {
+      rootPath?: string;
+      diff?: boolean;
+      diffSnapshot?: EditorDiffSnapshot;
+    },
   ) => void;
   dispatchTerminalReplay: (buffer: string) => void;
   prepareWorkspaceStartup?: (cwd: string) => Promise<boolean>;

--- a/src/hooks/tabOps/closeTab.ts
+++ b/src/hooks/tabOps/closeTab.ts
@@ -2,6 +2,7 @@ import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import {
   OVERVIEW_TAB_ID,
+  type EditorDiffSnapshot,
   type ClosedTabEntry,
   type Tab,
 } from "../../types/tab";
@@ -48,7 +49,14 @@ export interface CloseTabDeps {
     args?: string[];
     cwd?: string;
   }) => void;
-  newEditorTab: (filePath: string, opts?: { rootPath?: string }) => void;
+  newEditorTab: (
+    filePath: string,
+    opts?: {
+      rootPath?: string;
+      diff?: boolean;
+      diffSnapshot?: EditorDiffSnapshot;
+    },
+  ) => void;
 }
 
 export interface CloseTabActions {
@@ -129,7 +137,14 @@ export function useCloseTabActions(deps: CloseTabDeps): CloseTabActions {
         : {}),
       ...(tab.kind === "agent" && tab.cwd ? { cwd: tab.cwd } : {}),
       ...(tab.kind === "editor" && tab.editor
-        ? { filePath: tab.editor.filePath }
+        ? {
+            filePath: tab.editor.filePath,
+            ...(tab.editor.rootPath ? { rootPath: tab.editor.rootPath } : {}),
+            ...(tab.editor.diff ? { diff: true } : {}),
+            ...(tab.editor.diffSnapshot
+              ? { diffSnapshot: tab.editor.diffSnapshot }
+              : {}),
+          }
         : {}),
     };
     closedTabsRef.current.push(entry);
@@ -169,7 +184,11 @@ export function useCloseTabActions(deps: CloseTabDeps): CloseTabActions {
     } else if (entry.kind === "editor" && entry.filePath) {
       // Re-open the same file. EditorCanvas reads it from disk on mount;
       // unsaved buffer state is intentionally not preserved across close.
-      newEditorTab(entry.filePath);
+      newEditorTab(entry.filePath, {
+        ...(entry.rootPath ? { rootPath: entry.rootPath } : {}),
+        ...(entry.diff ? { diff: true } : {}),
+        ...(entry.diffSnapshot ? { diffSnapshot: entry.diffSnapshot } : {}),
+      });
     } else {
       newTab(entry.id, entry.label, {
         restoredSession: true,

--- a/src/hooks/tabOps/editorTab.test.ts
+++ b/src/hooks/tabOps/editorTab.test.ts
@@ -75,3 +75,34 @@ describe("toggleEditorPreview", () => {
     expect(tabOf("t2").editor?.previewMode).toBeUndefined();
   });
 });
+
+describe("updateEditorMeta", () => {
+  it("clears diff metadata when converting a snapshot diff tab to edit mode", () => {
+    const diffSnapshot = {
+      format: "unified" as const,
+      content: "--- a/src/App.tsx\n+++ b/src/App.tsx\n@@\n-old\n+new",
+      source: "tool-card" as const,
+    };
+    const tab = {
+      id: "diff",
+      kind: "editor",
+      label: "App.tsx (diff)",
+      editor: {
+        filePath: "/r/src/App.tsx",
+        language: "typescript",
+        isDirty: false,
+        diff: true,
+        diffSnapshot,
+      },
+    } as unknown as Tab;
+    const { actions, tabOf } = makeActions([tab], "diff");
+
+    actions.updateEditorMeta("diff", {
+      diff: false,
+      diffSnapshot: undefined,
+    });
+
+    expect(tabOf("diff").editor?.diff).toBe(false);
+    expect(tabOf("diff").editor?.diffSnapshot).toBeUndefined();
+  });
+});

--- a/src/hooks/tabOps/editorTab.ts
+++ b/src/hooks/tabOps/editorTab.ts
@@ -1,9 +1,15 @@
 import type { Dispatch, MutableRefObject, SetStateAction } from "react";
-import { makeEmptyTab, type EditorMeta, type Tab } from "../../types/tab";
+import {
+  makeEmptyTab,
+  type EditorDiffSnapshot,
+  type EditorMeta,
+  type Tab,
+} from "../../types/tab";
 import type { ProjectsState } from "../../projects";
 import { languageFromPath } from "../../monaco/language-detection";
 import { TAB_MIRROR_KEYS } from "./constants";
 import { editorLabelForPath } from "./helpers";
+import { diffSnapshotKey } from "../../utils/editorDiffSnapshot";
 
 export interface EditorTabDeps {
   setState: Dispatch<SetStateAction<Record<string, unknown>>>;
@@ -20,7 +26,11 @@ export interface EditorTabDeps {
 export interface EditorTabActions {
   newEditorTab: (
     filePath: string,
-    opts?: { rootPath?: string; diff?: boolean },
+    opts?: {
+      rootPath?: string;
+      diff?: boolean;
+      diffSnapshot?: EditorDiffSnapshot;
+    },
   ) => void;
   updateEditorMeta: (tabId: string, patch: Partial<EditorMeta>) => void;
   toggleEditorPreview: () => void;
@@ -38,11 +48,17 @@ export function useEditorTabActions(deps: EditorTabDeps): EditorTabActions {
    *  switch to it instead of creating a duplicate. */
   function newEditorTab(
     filePath: string,
-    opts: { rootPath?: string; diff?: boolean } = {},
+    opts: {
+      rootPath?: string;
+      diff?: boolean;
+      diffSnapshot?: EditorDiffSnapshot;
+    } = {},
   ): void {
     if (!filePath) return;
     const rootPath = opts.rootPath;
     const diff = opts.diff === true;
+    const diffSnapshot = diff ? opts.diffSnapshot : undefined;
+    const snapshotKey = diffSnapshotKey(diffSnapshot);
     const tabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
     // A diff tab and an editable tab for the same path coexist — match on
     // the diff flag too so "open changes" doesn't just focus the editor.
@@ -51,7 +67,8 @@ export function useEditorTabActions(deps: EditorTabDeps): EditorTabActions {
         t.kind === "editor" &&
         t.editor?.filePath === filePath &&
         (t.editor.rootPath ?? "") === (rootPath ?? "") &&
-        !!t.editor.diff === diff,
+        !!t.editor.diff === diff &&
+        diffSnapshotKey(t.editor.diffSnapshot) === snapshotKey,
     );
     if (existing) {
       setActiveTab(existing.id);
@@ -74,6 +91,7 @@ export function useEditorTabActions(deps: EditorTabDeps): EditorTabActions {
         language,
         isDirty: false,
         ...(diff ? { diff: true } : {}),
+        ...(diffSnapshot ? { diffSnapshot } : {}),
       },
     };
     setState((prev) => {
@@ -113,6 +131,10 @@ export function useEditorTabActions(deps: EditorTabDeps): EditorTabActions {
       const samePreview = merged.previewMode === t.editor.previewMode;
       const sameRefresh =
         merged.previewRefreshKey === t.editor.previewRefreshKey;
+      const sameDiff = merged.diff === t.editor.diff;
+      const sameSnapshot =
+        diffSnapshotKey(merged.diffSnapshot) ===
+        diffSnapshotKey(t.editor.diffSnapshot);
       if (
         samePath &&
         sameLang &&
@@ -120,7 +142,9 @@ export function useEditorTabActions(deps: EditorTabDeps): EditorTabActions {
         sameLine &&
         sameCol &&
         samePreview &&
-        sameRefresh
+        sameRefresh &&
+        sameDiff &&
+        sameSnapshot
       )
         return t;
       return { ...t, editor: merged };

--- a/src/hooks/tabOps/types.ts
+++ b/src/hooks/tabOps/types.ts
@@ -1,5 +1,10 @@
 import type { Dispatch, MutableRefObject, SetStateAction } from "react";
-import type { EditorMeta, ShellMeta, Tab } from "../../types/tab";
+import type {
+  EditorDiffSnapshot,
+  EditorMeta,
+  ShellMeta,
+  Tab,
+} from "../../types/tab";
 import type { ProjectsState } from "../../projects";
 import type { TabBucket } from "../projectOps/types";
 
@@ -102,7 +107,14 @@ export interface UseTabsActions {
   /** Open (or focus, if already open) an editor tab for `filePath`.
    *  `filePath` must be inside the active project; the EditorCanvas
    *  composite handles the actual fs_read_file call on mount. */
-  newEditorTab: (filePath: string, opts?: { rootPath?: string }) => void;
+  newEditorTab: (
+    filePath: string,
+    opts?: {
+      rootPath?: string;
+      diff?: boolean;
+      diffSnapshot?: EditorDiffSnapshot;
+    },
+  ) => void;
   /** Set the dirty flag + cursor on the active editor tab. Used by
    *  EditorCanvas to mirror Monaco's model state back to the layout. */
   updateEditorMeta: (tabId: string, patch: Partial<EditorMeta>) => void;

--- a/src/hooks/useProjectOps.ts
+++ b/src/hooks/useProjectOps.ts
@@ -36,6 +36,7 @@ import type {
   UseProjectOpsActions,
   UseProjectOpsContext,
 } from "./projectOps/types";
+import { diffSnapshotKey } from "../utils/editorDiffSnapshot";
 
 export type {
   DiscoveredSession,
@@ -402,6 +403,7 @@ export function useProjectOps(ctx: UseProjectOpsContext): UseProjectOpsActions {
           language: p.language,
           isDirty: false,
           ...(p.diff ? { diff: true } : {}),
+          ...(p.diffSnapshot ? { diffSnapshot: p.diffSnapshot } : {}),
           ...(typeof p.cursorLine === "number"
             ? { cursorLine: p.cursorLine }
             : {}),
@@ -413,7 +415,11 @@ export function useProjectOps(ctx: UseProjectOpsContext): UseProjectOpsActions {
     });
     if (restored.length === 0) return;
     const dedupeKey = (t: Tab) =>
-      `${t.editor?.filePath}::${t.editor?.diff ? "d" : "e"}`;
+      [
+        t.editor?.filePath,
+        t.editor?.diff ? "d" : "e",
+        diffSnapshotKey(t.editor?.diffSnapshot),
+      ].join("::");
     const activeRestored = persisted.activeFilePath
       ? restored.find(
           (t) =>

--- a/src/state/sessionUiSnapshot.test.ts
+++ b/src/state/sessionUiSnapshot.test.ts
@@ -665,6 +665,41 @@ describe("sessionUiSnapshot", () => {
     });
   });
 
+  it("preserves snapshot-backed editor diff metadata", () => {
+    const diffSnapshot = {
+      format: "unified" as const,
+      content: "--- a/src/App.tsx\n+++ b/src/App.tsx\n@@\n-old\n+new",
+      additions: 1,
+      deletions: 1,
+      source: "tool-card" as const,
+    };
+    const tab = {
+      ...makeEmptyTab("editor", "App.tsx (diff)", null, "editor"),
+      editor: {
+        filePath: "/repo/src/App.tsx",
+        rootPath: "/repo",
+        language: "typescript",
+        isDirty: true,
+        diff: true,
+        diffSnapshot,
+      },
+    };
+
+    saveSessionUiSnapshot({
+      tabs: [tab],
+      activeTabId: "editor",
+    });
+
+    expect(loadSessionUiSnapshot()?.tabs[0]?.editor).toMatchObject({
+      filePath: "/repo/src/App.tsx",
+      rootPath: "/repo",
+      language: "typescript",
+      isDirty: false,
+      diff: true,
+      diffSnapshot,
+    });
+  });
+
   it("persists blank empty new tabs and keeps them active", () => {
     saveSessionUiSnapshot({
       tabs: [

--- a/src/state/sessionUiSnapshot.ts
+++ b/src/state/sessionUiSnapshot.ts
@@ -5,6 +5,7 @@ import {
   collapseAmendedAgentMessages,
   dedupeToolResultTextMessages,
 } from "../utils/messages";
+import { isEditorDiffSnapshot } from "../utils/editorDiffSnapshot";
 
 export const SESSION_UI_SNAPSHOT_FILE = "session_ui_snapshot";
 export const SESSION_UI_SNAPSHOT_FLUSH_EVENT =
@@ -404,6 +405,10 @@ function restoreTabRecord(
                 ? t.editor.language
                 : "plaintext",
             isDirty: false,
+            ...(t.editor.diff ? { diff: true } : {}),
+            ...(isEditorDiffSnapshot(t.editor.diffSnapshot)
+              ? { diffSnapshot: t.editor.diffSnapshot }
+              : {}),
             ...(typeof t.editor.cursorLine === "number"
               ? { cursorLine: t.editor.cursorLine }
               : {}),

--- a/src/types/tab.ts
+++ b/src/types/tab.ts
@@ -31,6 +31,14 @@ export interface ShellMeta {
   restartOnMount?: boolean;
 }
 
+export interface EditorDiffSnapshot {
+  format: "unified";
+  content: string;
+  additions?: number;
+  deletions?: number;
+  source: "tool-card";
+}
+
 /**
  * Editor-tab metadata. Present iff Tab.kind === "editor".
  *
@@ -64,6 +72,9 @@ export interface EditorMeta {
    *  (HEAD vs working tree) instead of the editable Monaco editor.
    *  Set by the Source Control / CI panel's "open changes" flow. */
   diff?: boolean;
+  /** Captured diff payload for tool-card diff views. When present the
+   *  diff canvas renders this immutable snapshot instead of consulting git. */
+  diffSnapshot?: EditorDiffSnapshot;
 }
 
 export interface ContextUsageState {
@@ -204,6 +215,9 @@ export interface ClosedTabEntry {
   /** Editor tabs only — passed back to newEditorTab so reopen lands on
    *  the same file. */
   filePath?: string;
+  rootPath?: string;
+  diff?: boolean;
+  diffSnapshot?: EditorDiffSnapshot;
 }
 
 // Sentinel key for the "no project" bucket. Project ids are UUIDs so a

--- a/src/utils/editorDiffSnapshot.test.ts
+++ b/src/utils/editorDiffSnapshot.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  diffSnapshotKey,
+  isEditorDiffSnapshot,
+  parseUnifiedDiffSnapshot,
+} from "./editorDiffSnapshot";
+
+describe("parseUnifiedDiffSnapshot", () => {
+  it("builds original and modified model text from a unified diff", () => {
+    const models = parseUnifiedDiffSnapshot(
+      [
+        "diff --git a/src/App.tsx b/src/App.tsx",
+        "--- a/src/App.tsx",
+        "+++ b/src/App.tsx",
+        "@@ -1,3 +1,3 @@",
+        " const title =",
+        "-  'Old'",
+        "+  'New'",
+        " export default title",
+      ].join("\n"),
+    );
+
+    expect(models.original).toBe(
+      "@@ -1,3 +1,3 @@\nconst title =\n  'Old'\nexport default title",
+    );
+    expect(models.modified).toBe(
+      "@@ -1,3 +1,3 @@\nconst title =\n  'New'\nexport default title",
+    );
+  });
+});
+
+describe("isEditorDiffSnapshot", () => {
+  it("accepts only durable tool-card unified snapshots", () => {
+    const snapshot = {
+      format: "unified" as const,
+      content: "--- a/x\n+++ b/x\n@@\n-a\n+b",
+      source: "tool-card" as const,
+    };
+    expect(isEditorDiffSnapshot(snapshot)).toBe(true);
+    expect(diffSnapshotKey(snapshot)).toContain(snapshot.content);
+    expect(isEditorDiffSnapshot({ ...snapshot, source: "git" })).toBe(false);
+  });
+});

--- a/src/utils/editorDiffSnapshot.test.ts
+++ b/src/utils/editorDiffSnapshot.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 import {
   diffSnapshotKey,
   isEditorDiffSnapshot,
+  MAX_EDITOR_DIFF_SNAPSHOT_CHARS,
   parseUnifiedDiffSnapshot,
+  truncateDiffSnapshotContent,
 } from "./editorDiffSnapshot";
 
 describe("parseUnifiedDiffSnapshot", () => {
@@ -39,5 +41,16 @@ describe("isEditorDiffSnapshot", () => {
     expect(isEditorDiffSnapshot(snapshot)).toBe(true);
     expect(diffSnapshotKey(snapshot)).toContain(snapshot.content);
     expect(isEditorDiffSnapshot({ ...snapshot, source: "git" })).toBe(false);
+    expect(isEditorDiffSnapshot({ ...snapshot, additions: -1 })).toBe(false);
+    expect(isEditorDiffSnapshot({ ...snapshot, deletions: 1.5 })).toBe(false);
+  });
+});
+
+describe("truncateDiffSnapshotContent", () => {
+  it("caps stored snapshot content to a bounded size", () => {
+    const content = "x".repeat(MAX_EDITOR_DIFF_SNAPSHOT_CHARS + 10);
+    const truncated = truncateDiffSnapshotContent(content);
+    expect(truncated).toHaveLength(MAX_EDITOR_DIFF_SNAPSHOT_CHARS);
+    expect(truncated.endsWith("…")).toBe(true);
   });
 });

--- a/src/utils/editorDiffSnapshot.ts
+++ b/src/utils/editorDiffSnapshot.ts
@@ -5,8 +5,19 @@ export interface DiffSnapshotModels {
   modified: string;
 }
 
-function isFiniteNumber(value: unknown): value is number {
-  return typeof value === "number" && Number.isFinite(value);
+export const MAX_EDITOR_DIFF_SNAPSHOT_CHARS = 64 * 1024;
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isInteger(value) &&
+    value >= 0
+  );
+}
+
+export function truncateDiffSnapshotContent(content: string): string {
+  if (content.length <= MAX_EDITOR_DIFF_SNAPSHOT_CHARS) return content;
+  return `${content.slice(0, MAX_EDITOR_DIFF_SNAPSHOT_CHARS - 1)}…`;
 }
 
 export function isEditorDiffSnapshot(
@@ -19,8 +30,10 @@ export function isEditorDiffSnapshot(
     typeof snapshot.content === "string" &&
     snapshot.content.length > 0 &&
     snapshot.source === "tool-card" &&
-    (snapshot.additions === undefined || isFiniteNumber(snapshot.additions)) &&
-    (snapshot.deletions === undefined || isFiniteNumber(snapshot.deletions))
+    (snapshot.additions === undefined ||
+      isNonNegativeInteger(snapshot.additions)) &&
+    (snapshot.deletions === undefined ||
+      isNonNegativeInteger(snapshot.deletions))
   );
 }
 

--- a/src/utils/editorDiffSnapshot.ts
+++ b/src/utils/editorDiffSnapshot.ts
@@ -1,0 +1,88 @@
+import type { EditorDiffSnapshot } from "../types/tab";
+
+export interface DiffSnapshotModels {
+  original: string;
+  modified: string;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+export function isEditorDiffSnapshot(
+  value: unknown,
+): value is EditorDiffSnapshot {
+  if (!value || typeof value !== "object") return false;
+  const snapshot = value as Partial<EditorDiffSnapshot>;
+  return (
+    snapshot.format === "unified" &&
+    typeof snapshot.content === "string" &&
+    snapshot.content.length > 0 &&
+    snapshot.source === "tool-card" &&
+    (snapshot.additions === undefined || isFiniteNumber(snapshot.additions)) &&
+    (snapshot.deletions === undefined || isFiniteNumber(snapshot.deletions))
+  );
+}
+
+export function diffSnapshotKey(
+  snapshot: EditorDiffSnapshot | undefined,
+): string {
+  if (!snapshot) return "";
+  return [
+    snapshot.format,
+    snapshot.source,
+    snapshot.additions ?? "",
+    snapshot.deletions ?? "",
+    snapshot.content,
+  ].join("\0");
+}
+
+export function parseUnifiedDiffSnapshot(
+  content: string,
+): DiffSnapshotModels {
+  const original: string[] = [];
+  const modified: string[] = [];
+  for (const line of content.replace(/\r\n/g, "\n").split("\n")) {
+    if (
+      line.startsWith("diff --git ") ||
+      line.startsWith("index ") ||
+      line.startsWith("new file mode ") ||
+      line.startsWith("deleted file mode ") ||
+      line.startsWith("similarity index ") ||
+      line.startsWith("rename from ") ||
+      line.startsWith("rename to ") ||
+      line.startsWith("\\ No newline")
+    ) {
+      continue;
+    }
+    if (line.startsWith("--- ") || line.startsWith("+++ ")) continue;
+    if (line.startsWith("@@")) {
+      original.push(line);
+      modified.push(line);
+      continue;
+    }
+    if (line.startsWith("+")) {
+      modified.push(line.slice(1));
+      continue;
+    }
+    if (line.startsWith("-")) {
+      original.push(line.slice(1));
+      continue;
+    }
+    if (line.startsWith(" ")) {
+      const text = line.slice(1);
+      original.push(text);
+      modified.push(text);
+      continue;
+    }
+    original.push(line);
+    modified.push(line);
+  }
+  if (original.length === 0 && modified.length === 0 && content) {
+    return { original: "", modified: content };
+  }
+  return {
+    original: original.join("\n"),
+    modified: modified.join("\n"),
+  };
+}

--- a/src/utils/messages.test.ts
+++ b/src/utils/messages.test.ts
@@ -170,6 +170,13 @@ describe("trimMessage", () => {
               toolName: "bash",
               description: "nix flake check",
               startedAt: 1,
+              fileChange: {
+                kind: "edited",
+                path: "src/App.tsx",
+                preview: "--- a/src/App.tsx\n+++ b/src/App.tsx\n@@\n-old\n+new",
+                additions: 1,
+                deletions: 1,
+              },
             },
             children: Array.from({ length: 16 }, (_, index) => ({
               id: `tool-1-call-1-result-${index}`,
@@ -190,6 +197,10 @@ describe("trimMessage", () => {
         toolName: "bash",
         description: "nix flake check",
         startedAt: 1,
+        fileChange: {
+          path: "src/App.tsx",
+          preview: expect.stringContaining("+new"),
+        },
       },
       children: [],
     });

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -118,6 +118,7 @@ function summarizedA2uiComponent(component: unknown): unknown {
       "isError",
       "startedAt",
       "endedAt",
+      "fileChange",
     ].flatMap((key) => (key in props ? [[key, props[key]]] : [])),
   );
   return {


### PR DESCRIPTION
## Summary

- capture durable tool-card file diff snapshots from edit/write metadata, including Pi's current multi-edit `edits[]` argument shape
- route tool-card diff opens through stored snapshots only, avoiding live git lookups after a branch has changed or merged
- persist snapshot-backed diff tabs through session restore, editor-tab restore, close/reopen, and oversized A2UI trimming
- render captured snapshots in the Monaco diff canvas while keeping source-control/file-tree diffs on the existing live git path

## Root Cause

Inline tool diff views were partially reconstructed from the current git working tree. That made them fragile: once the branch was merged, cleaned, or restored later, the original tool-card diff could disappear or show unrelated current state.

## Validation

- `git diff --check`
- `bun run typecheck`
- `bunx vitest run agent/tab-lifecycle.test.ts agent/session-history.test.ts src/extensions/default-layout/chat.test.tsx src/eventRoutes/editor.test.ts src/hooks/tabOps/editorTab.test.ts src/editorTabs.test.ts src/state/sessionUiSnapshot.test.ts src/utils/editorDiffSnapshot.test.ts src/utils/messages.test.ts`
- `bunx vitest run`
- `bun run lint` (passes with existing `message-row.tsx` fast-refresh warning)
- native dev UAT: started `dev`, injected a snapshot-backed diff tab via `aethon-debug`, verified the running app rendered `Captured Tool Diff` with no diff error, then removed the temporary tab and stopped the dev server
