### PR TITLE
refactor(app): split remaining root orchestration hooks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,5 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
-import { listen } from "@tauri-apps/api/event";
 import { ExtensionRegistry } from "./extensions/ExtensionRegistry";
 import { defaultLayoutExtension } from "./extensions/default-layout";
 import { AppRoot } from "./app/AppRoot";
@@ -8,7 +7,6 @@ import { BOOT_LAYOUT, hangWarnNotifId } from "./app/bootConstants";
 import { useAppForwardRefs } from "./app/useAppForwardRefs";
 import type { A2UIPayload } from "./types/a2ui";
 import type { Tab } from "./types/tab";
-import type { ShareMode } from "./utils/shareMode";
 import { useZoomAndTheme } from "./hooks/useZoomAndTheme";
 import { useSpeakReplies } from "./hooks/useSpeakReplies";
 import { useShellConsent } from "./hooks/useShellConsent";
@@ -38,12 +36,7 @@ import { useUiOverlays } from "./hooks/useUiOverlays";
 import { useUpdater } from "./hooks/useUpdater";
 import { useWorkspaceStartup } from "./hooks/useWorkspaceStartup";
 import { UpdateBanner } from "./components/UpdateBanner";
-import type { AethonConfig } from "./config";
-import {
-  useProjectOps,
-  projectIdFromBucketKey,
-  workspaceIdFromBucketKey,
-} from "./hooks/useProjectOps";
+import { useProjectOps } from "./hooks/useProjectOps";
 import type { TabBucket } from "./hooks/projectOps/types";
 import { useOsEdges } from "./hooks/useOsEdges";
 import {
@@ -64,12 +57,12 @@ import { useProjectSyncEffects } from "./hooks/useProjectSyncEffects";
 import { useAppSlashCommandContext } from "./hooks/useAppSlashCommandContext";
 import { useAppBridgeMessages } from "./hooks/useAppBridgeMessages";
 import { useScheduledTasks } from "./hooks/useScheduledTasks";
+import { useNativeWindowSync } from "./hooks/useNativeWindowSync";
+import { useRootChromeActions } from "./hooks/useRootChromeActions";
+import { useActivateTabAnywhere } from "./hooks/useActivateTabAnywhere";
+import { useUpdaterConfigBridge } from "./hooks/useUpdaterConfigBridge";
 import { closeAllWorkspaceSessions } from "./hooks/tabOps/closeWorkspaceSessions";
-import {
-  syncNativeWindowsToState as syncNativeWindowsToStateSlice,
-  terminalShellTabIds,
-  type NativeCanvasWindowRecord,
-} from "./nativeWindows";
+import type { NativeCanvasWindowRecord } from "./nativeWindows";
 import { writeState } from "./persist";
 import { useAppState } from "./state/appStore";
 import { activeWorkspaceCwd } from "./utils/activeWorkspaceRoot";
@@ -129,10 +122,6 @@ export default function App() {
   // window.aethon.registerExtension(extension) and switch to its layout.
   const [layout, setLayout] = useState<A2UIPayload>(BOOT_LAYOUT);
   const [startupChromeReady, setStartupChromeReady] = useState(false);
-  const syncNativeWindowsToState = useCallback(() => {
-    syncNativeWindowsToStateSlice(setState, nativeWindowsRef);
-  }, [setState]);
-
   const {
     stateRef,
     projectsRef,
@@ -145,6 +134,11 @@ export default function App() {
     chatActionsRef,
   } = useAppStateRefs(appStore);
 
+  const { syncNativeWindowsToState } = useNativeWindowSync({
+    setState,
+    nativeWindowsRef,
+  });
+
   const {
     view: workspaceStartupView,
     prepareWorkspaceStartup,
@@ -155,83 +149,6 @@ export default function App() {
 
   useSessionPersistence({ appStore, hasSyncSessionSnapshot });
   useAgentActivityHydration(setState);
-
-  useEffect(() => {
-    let disposed = false;
-    invoke<NativeCanvasWindowRecord[]>("native_window_list")
-      .then((records) => {
-        if (disposed || !Array.isArray(records)) return;
-        nativeWindowsRef.current = new Map(
-          records.map((record) => [record.id, record]),
-        );
-        syncNativeWindowsToState();
-      })
-      .catch(() => {
-        /* native-window state is best-effort mirror data */
-      });
-    const unlistenRecord = listen<NativeCanvasWindowRecord>(
-      "native-window-record",
-      (event) => {
-        const record = event.payload;
-        if (!record || typeof record.id !== "string") return;
-        nativeWindowsRef.current.set(record.id, record);
-        syncNativeWindowsToState();
-      },
-    );
-    const unlistenShareMode = listen<{
-      tabId?: string;
-      shareMode?: ShareMode;
-    }>("native-terminal-share-mode", (event) => {
-      const { tabId, shareMode } = event.payload ?? {};
-      if (typeof tabId !== "string" || typeof shareMode !== "string") return;
-      setState((prev) => ({
-        ...prev,
-        tabs: ((prev.tabs as Tab[] | undefined) ?? []).map((tab) =>
-          tab.id === tabId && tab.kind === "shell" && tab.shell
-            ? { ...tab, shell: { ...tab.shell, shareMode } }
-            : tab,
-        ),
-      }));
-    });
-    const unlistenClosed = listen<{ id?: string }>(
-      "native-window-closed",
-      (event) => {
-        const id = event.payload?.id;
-        if (typeof id !== "string") return;
-        const record = nativeWindowsRef.current.get(id);
-        const ownedShellIds = terminalShellTabIds(record);
-        nativeWindowsRef.current.delete(id);
-        if (ownedShellIds.length > 0) {
-          for (const shellId of ownedShellIds) {
-            invoke("shell_close", { tabId: shellId }).catch(() => {
-              /* best-effort terminal-window cleanup */
-            });
-          }
-          setState((prev) => {
-            const tabs = (prev.tabs as Tab[] | undefined) ?? [];
-            const owned = new Set(ownedShellIds);
-            const panel =
-              (prev.terminalPanel as { activeSubId?: string } | undefined) ??
-              {};
-            return {
-              ...prev,
-              tabs: tabs.filter((tab) => !owned.has(tab.id)),
-              ...(panel.activeSubId && owned.has(panel.activeSubId)
-                ? { terminalPanel: { ...panel, activeSubId: "agent-bash" } }
-                : {}),
-            };
-          });
-        }
-        syncNativeWindowsToState();
-      },
-    );
-    return () => {
-      disposed = true;
-      unlistenRecord.then((fn) => fn());
-      unlistenShareMode.then((fn) => fn());
-      unlistenClosed.then((fn) => fn());
-    };
-  }, [setState, syncNativeWindowsToState]);
 
   const recordProjectModel = useProjectModelRecorder(setState);
 
@@ -585,25 +502,17 @@ export default function App() {
     newShellTabOnOverviewOpen: () => newShellTab(),
   });
 
-  const openScheduledTasks = useCallback(() => {
-    setState((prev) => ({
-      ...prev,
-      scheduledTasks: {
-        ...((prev.scheduledTasks ?? {}) as Record<string, unknown>),
-        open: true,
-      },
-    }));
-  }, [setState]);
-
-  const closeScheduledTasks = useCallback(() => {
-    setState((prev) => ({
-      ...prev,
-      scheduledTasks: {
-        ...((prev.scheduledTasks ?? {}) as Record<string, unknown>),
-        open: false,
-      },
-    }));
-  }, [setState]);
+  const {
+    openScheduledTasks,
+    closeScheduledTasks,
+    togglePlanMode,
+    toggleAccounts,
+  } = useRootChromeActions({
+    setState,
+    stateRef,
+    updateActiveTab,
+    pushNotification,
+  });
 
   const { slashContext, persistLocalChatMessage } = useAppSlashCommandContext({
     bootLayout: BOOT_LAYOUT,
@@ -736,6 +645,15 @@ export default function App() {
     prepareWorkspaceStartup,
   });
 
+  const activateTabAnywhere = useActivateTabAnywhere({
+    stateRef,
+    tabBucketsRef,
+    setActiveTab,
+    setActiveProjectById,
+    clearActiveProject,
+    activateWorkspace,
+  });
+
   // Updater (Cmd menu / tray "Check for Updates" + agent-driven path).
   // The hook reads the persisted channel + auto-check toggle from
   // `config.toml` during its own boot lifecycle, so we don't have to
@@ -754,14 +672,11 @@ export default function App() {
       setDisableAutoCheck: setUpdateDisableAutoCheck,
     },
   } = useUpdater({ appendSystem });
-  const reapplyConfigWithUpdater = useMemo(
-    () => (fresh: AethonConfig) => {
-      reapplyConfig(fresh);
-      setUpdateChannel(fresh.updates.channel);
-      setUpdateDisableAutoCheck(fresh.updates.disableAutoCheck);
-    },
-    [reapplyConfig, setUpdateChannel, setUpdateDisableAutoCheck],
-  );
+  const reapplyConfigWithUpdater = useUpdaterConfigBridge({
+    reapplyConfig,
+    setUpdateChannel,
+    setUpdateDisableAutoCheck,
+  });
 
   // ---------------------------------------------------------------------
   // Settings panel + session search + command palette. Three modal
@@ -808,36 +723,6 @@ export default function App() {
     slashCommandsRef,
     slashContext: () => slashContext(),
   });
-
-  const togglePlanMode = useCallback(() => {
-    const activeId = stateRef.current.activeTabId as string | undefined;
-    const tabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
-    const activeTab = tabs.find((tab) => tab.id === activeId);
-    if (!activeTab || activeTab.kind !== "agent") return;
-    const enabled = activeTab.planMode !== true;
-    updateActiveTab((tab) =>
-      tab.kind === "agent" ? { ...tab, planMode: enabled } : tab,
-    );
-    pushNotification({
-      title: enabled ? "Plan mode on" : "Implementation mode on",
-      message: enabled
-        ? "New prompts will ask for a plan before code changes."
-        : "New prompts may make code changes.",
-      kind: "success",
-      durationMs: 1600,
-    });
-  }, [pushNotification, stateRef, updateActiveTab]);
-
-  const toggleAccounts = useCallback(() => {
-    setState((prev) => {
-      const auth = (prev.authProfiles ?? {}) as Record<string, unknown>;
-      const modal = (auth.modal ?? {}) as Record<string, unknown>;
-      return {
-        ...prev,
-        authProfiles: { ...auth, modal: { ...modal, open: !modal.open } },
-      };
-    });
-  }, [setState]);
 
   // Bridge IPC: spawns the agent on mount, runs the boot handshake
   // (start_agent → boot_layout → report), and routes every
@@ -1062,32 +947,7 @@ export default function App() {
         closeTab,
       }),
     setActiveTab,
-    activateTabAnywhere: (tabId: string) => {
-      const tabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
-      if (tabs.some((t) => t.id === tabId)) {
-        setActiveTab(tabId);
-        return;
-      }
-      // Not in the active workspace — find the bucket that owns it, switch
-      // into that project/workspace, then select. setState is synchronous so
-      // the bucket load lands before setActiveTab reads state.tabs.
-      for (const [key, bucket] of tabBucketsRef.current.entries()) {
-        if (!bucket.tabs.some((t) => t.id === tabId)) continue;
-        const projectId = projectIdFromBucketKey(key);
-        const currentProjectId =
-          (stateRef.current.activeProjectId as string | null | undefined) ??
-          null;
-        if (projectId !== currentProjectId) {
-          if (projectId) setActiveProjectById(projectId);
-          else clearActiveProject();
-        }
-        activateWorkspace(workspaceIdFromBucketKey(key));
-        setActiveTab(tabId);
-        return;
-      }
-      // Unknown tab — best effort (no-op if it's truly gone).
-      setActiveTab(tabId);
-    },
+    activateTabAnywhere,
     setActiveSubTab,
     applyShareModeToTab,
     closeSettings,

--- a/src/hooks/useActivateTabAnywhere.test.ts
+++ b/src/hooks/useActivateTabAnywhere.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Tab } from "../types/tab";
+import type { TabBucket } from "./projectOps/types";
+import { activateTabAnywhereNow } from "./useActivateTabAnywhere";
+
+const agentTab = (id: string): Tab => ({
+  id,
+  kind: "agent",
+  label: id,
+  messages: [],
+  draft: "",
+  waiting: false,
+  queueCount: 0,
+  queuedMessages: [],
+  canvas: null,
+  model: "gpt",
+  terminalBuffer: "",
+  projectId: null,
+});
+
+function deps(seed: {
+  tabs?: Tab[];
+  buckets?: [string, TabBucket][];
+  activeProjectId?: string | null;
+}) {
+  const calls: string[] = [];
+  return {
+    calls,
+    stateRef: {
+      current: {
+        tabs: seed.tabs ?? [],
+        activeProjectId: seed.activeProjectId ?? null,
+      },
+    },
+    tabBucketsRef: { current: new Map(seed.buckets ?? []) },
+    setActiveTab: vi.fn((tabId: string) => calls.push(`tab:${tabId}`)),
+    setActiveProjectById: vi.fn((projectId: string) => {
+      calls.push(`project:${projectId}`);
+      return true;
+    }),
+    clearActiveProject: vi.fn(() => calls.push("project:null")),
+    activateWorkspace: vi.fn((workspaceId: string | null) =>
+      calls.push(`workspace:${workspaceId ?? "null"}`),
+    ),
+  };
+}
+
+describe("activateTabAnywhereNow", () => {
+  it("selects already-visible tabs directly", () => {
+    const ctx = deps({ tabs: [agentTab("tab-1")], activeProjectId: "p1" });
+
+    activateTabAnywhereNow(ctx, "tab-1");
+
+    expect(ctx.setActiveTab).toHaveBeenCalledWith("tab-1");
+    expect(ctx.setActiveProjectById).not.toHaveBeenCalled();
+    expect(ctx.activateWorkspace).not.toHaveBeenCalled();
+    expect(ctx.calls).toEqual(["tab:tab-1"]);
+  });
+
+  it("switches project and workspace before selecting a bucketed tab", () => {
+    const ctx = deps({
+      activeProjectId: "old-project",
+      buckets: [
+        [
+          "new-project::workspace::workspace-1",
+          { tabs: [agentTab("hidden-tab")], activeTabId: "hidden-tab" },
+        ],
+      ],
+    });
+
+    activateTabAnywhereNow(ctx, "hidden-tab");
+
+    expect(ctx.calls).toEqual([
+      "project:new-project",
+      "workspace:workspace-1",
+      "tab:hidden-tab",
+    ]);
+  });
+
+  it("clears the active project for no-project bucketed tabs", () => {
+    const ctx = deps({
+      activeProjectId: "project-1",
+      buckets: [
+        ["__no_project__", { tabs: [agentTab("loose-tab")], activeTabId: "loose-tab" }],
+      ],
+    });
+
+    activateTabAnywhereNow(ctx, "loose-tab");
+
+    expect(ctx.calls).toEqual([
+      "project:null",
+      "workspace:null",
+      "tab:loose-tab",
+    ]);
+  });
+
+  it("best-effort selects unknown tabs without switching project/workspace", () => {
+    const ctx = deps({ activeProjectId: "project-1" });
+
+    activateTabAnywhereNow(ctx, "missing-tab");
+
+    expect(ctx.calls).toEqual(["tab:missing-tab"]);
+  });
+});

--- a/src/hooks/useActivateTabAnywhere.ts
+++ b/src/hooks/useActivateTabAnywhere.ts
@@ -1,0 +1,88 @@
+import { useCallback, type MutableRefObject } from "react";
+import type { Tab } from "../types/tab";
+import type { TabBucket } from "./projectOps/types";
+import {
+  projectIdFromBucketKey,
+  workspaceIdFromBucketKey,
+} from "./useProjectOps";
+
+export interface ActivateTabAnywhereDeps {
+  stateRef: MutableRefObject<Record<string, unknown>>;
+  tabBucketsRef: MutableRefObject<Map<string, TabBucket>>;
+  setActiveTab: (tabId: string) => void;
+  setActiveProjectById: (projectId: string) => boolean;
+  clearActiveProject: () => void;
+  activateWorkspace: (workspaceId: string | null) => void;
+}
+
+export function activateTabAnywhereNow(
+  deps: ActivateTabAnywhereDeps,
+  tabId: string,
+): void {
+  const {
+    stateRef,
+    tabBucketsRef,
+    setActiveTab,
+    setActiveProjectById,
+    clearActiveProject,
+    activateWorkspace,
+  } = deps;
+  const tabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
+  if (tabs.some((tab) => tab.id === tabId)) {
+    setActiveTab(tabId);
+    return;
+  }
+
+  // Not in the active workspace — find the bucket that owns it, switch into
+  // that project/workspace, then select. setState is synchronous, so the
+  // bucket load lands before setActiveTab reads state.tabs.
+  for (const [key, bucket] of tabBucketsRef.current.entries()) {
+    if (!bucket.tabs.some((tab) => tab.id === tabId)) continue;
+    const projectId = projectIdFromBucketKey(key);
+    const currentProjectId =
+      (stateRef.current.activeProjectId as string | null | undefined) ?? null;
+    if (projectId !== currentProjectId) {
+      if (projectId) setActiveProjectById(projectId);
+      else clearActiveProject();
+    }
+    activateWorkspace(workspaceIdFromBucketKey(key));
+    setActiveTab(tabId);
+    return;
+  }
+
+  // Unknown tab — best effort (no-op if it's truly gone).
+  setActiveTab(tabId);
+}
+
+export function useActivateTabAnywhere({
+  stateRef,
+  tabBucketsRef,
+  setActiveTab,
+  setActiveProjectById,
+  clearActiveProject,
+  activateWorkspace,
+}: ActivateTabAnywhereDeps): (tabId: string) => void {
+  return useCallback(
+    (tabId: string) => {
+      activateTabAnywhereNow(
+        {
+          stateRef,
+          tabBucketsRef,
+          setActiveTab,
+          setActiveProjectById,
+          clearActiveProject,
+          activateWorkspace,
+        },
+        tabId,
+      );
+    },
+    [
+      activateWorkspace,
+      clearActiveProject,
+      setActiveProjectById,
+      setActiveTab,
+      stateRef,
+      tabBucketsRef,
+    ],
+  );
+}

--- a/src/hooks/useNativeWindowSync.test.tsx
+++ b/src/hooks/useNativeWindowSync.test.tsx
@@ -1,0 +1,150 @@
+// @vitest-environment jsdom
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Tab } from "../types/tab";
+import type { NativeCanvasWindowRecord } from "../nativeWindows";
+import { useNativeWindowSync } from "./useNativeWindowSync";
+
+const invoke = vi.fn<(cmd: string, args?: unknown) => Promise<unknown>>();
+const listeners = new Map<string, (event: { payload: unknown }) => void>();
+const unlisten = vi.fn();
+const listen = vi.fn((event: string, cb: (event: { payload: unknown }) => void) => {
+  listeners.set(event, cb);
+  return Promise.resolve(unlisten);
+});
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (cmd: string, args?: unknown) => invoke(cmd, args),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: (event: string, cb: (event: { payload: unknown }) => void) =>
+    listen(event, cb),
+}));
+
+const record = (id: string, ownedShellTabIds: string[] = []): NativeCanvasWindowRecord => ({
+  id,
+  label: id,
+  kind: "canvas",
+  title: id,
+  restoreOnLaunch: false,
+  components: [],
+  state: { ownedShellTabIds },
+});
+
+const shellTab = (id: string): Tab =>
+  ({
+    id,
+    kind: "shell",
+    label: id,
+    shell: { shareMode: "private" },
+  }) as Tab;
+
+function statefulSetState(seed: Record<string, unknown>) {
+  let state = seed;
+  const setState = vi.fn((updater: unknown) => {
+    state =
+      typeof updater === "function"
+        ? (updater as (prev: Record<string, unknown>) => Record<string, unknown>)(
+            state,
+          )
+        : (updater as Record<string, unknown>);
+  });
+  return { setState, getState: () => state };
+}
+
+describe("useNativeWindowSync", () => {
+  beforeEach(() => {
+    invoke.mockReset();
+    listen.mockClear();
+    unlisten.mockClear();
+    listeners.clear();
+    invoke.mockImplementation((cmd) => {
+      if (cmd === "native_window_list") return Promise.resolve([]);
+      return Promise.resolve(undefined);
+    });
+  });
+
+  it("mirrors initial native window records into app state", async () => {
+    invoke.mockImplementation((cmd) => {
+      if (cmd === "native_window_list") return Promise.resolve([record("Win")]);
+      return Promise.resolve(undefined);
+    });
+    const store = statefulSetState({ keep: true });
+    const nativeWindowsRef = { current: new Map<string, NativeCanvasWindowRecord>() };
+
+    renderHook(() =>
+      useNativeWindowSync({ setState: store.setState, nativeWindowsRef }),
+    );
+
+    await waitFor(() =>
+      expect(store.getState().nativeWindows).toEqual([
+        {
+          id: "Win",
+          label: "Win",
+          kind: "canvas",
+          title: "Win",
+          restoreOnLaunch: false,
+          componentCount: 0,
+        },
+      ]),
+    );
+    expect(nativeWindowsRef.current.has("Win")).toBe(true);
+  });
+
+  it("updates records from native-window-record events", async () => {
+    const store = statefulSetState({});
+    const nativeWindowsRef = { current: new Map<string, NativeCanvasWindowRecord>() };
+
+    renderHook(() =>
+      useNativeWindowSync({ setState: store.setState, nativeWindowsRef }),
+    );
+    await waitFor(() => expect(listen).toHaveBeenCalled());
+
+    listeners.get("native-window-record")?.({ payload: record("Live") });
+
+    expect(store.getState().nativeWindows).toEqual([
+      {
+        id: "Live",
+        label: "Live",
+        kind: "canvas",
+        title: "Live",
+        restoreOnLaunch: false,
+        componentCount: 0,
+      },
+    ]);
+  });
+
+  it("cleans up owned shell tabs when a native terminal window closes best-effort", async () => {
+    invoke.mockImplementation((cmd) => {
+      if (cmd === "native_window_list") {
+        return Promise.resolve([record("Term", ["owned", "owned"])]);
+      }
+      if (cmd === "shell_close") return Promise.reject(new Error("already gone"));
+      return Promise.resolve(undefined);
+    });
+    const store = statefulSetState({
+      tabs: [shellTab("owned"), shellTab("kept")],
+      terminalPanel: { activeSubId: "owned" },
+    });
+    const nativeWindowsRef = {
+      current: new Map<string, NativeCanvasWindowRecord>([
+        ["Term", record("Term", ["owned", "owned"])],
+      ]),
+    };
+
+    renderHook(() =>
+      useNativeWindowSync({ setState: store.setState, nativeWindowsRef }),
+    );
+    await waitFor(() => expect(listen).toHaveBeenCalled());
+
+    listeners.get("native-window-closed")?.({ payload: { id: "Term" } });
+
+    expect(invoke).toHaveBeenCalledWith("shell_close", { tabId: "owned" });
+    expect((store.getState().tabs as Tab[]).map((tab) => tab.id)).toEqual([
+      "kept",
+    ]);
+    expect(store.getState().terminalPanel).toEqual({ activeSubId: "agent-bash" });
+    expect(nativeWindowsRef.current.has("Term")).toBe(false);
+  });
+});

--- a/src/hooks/useNativeWindowSync.ts
+++ b/src/hooks/useNativeWindowSync.ts
@@ -1,0 +1,114 @@
+import {
+  useCallback,
+  useEffect,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import type { Tab } from "../types/tab";
+import type { ShareMode } from "../utils/shareMode";
+import {
+  syncNativeWindowsToState as syncNativeWindowsToStateSlice,
+  terminalShellTabIds,
+  type NativeCanvasWindowRecord,
+  type NativeWindowsRef,
+} from "../nativeWindows";
+
+export interface UseNativeWindowSyncContext {
+  setState: Dispatch<SetStateAction<Record<string, unknown>>>;
+  nativeWindowsRef: NativeWindowsRef;
+}
+
+export function cleanupClosedNativeWindow(
+  setState: Dispatch<SetStateAction<Record<string, unknown>>>,
+  record: NativeCanvasWindowRecord | undefined,
+): void {
+  const ownedShellIds = terminalShellTabIds(record);
+  if (ownedShellIds.length === 0) return;
+  for (const shellId of ownedShellIds) {
+    invoke("shell_close", { tabId: shellId }).catch(() => {
+      /* best-effort terminal-window cleanup */
+    });
+  }
+  setState((prev) => {
+    const tabs = (prev.tabs as Tab[] | undefined) ?? [];
+    const owned = new Set(ownedShellIds);
+    const panel =
+      (prev.terminalPanel as { activeSubId?: string } | undefined) ?? {};
+    return {
+      ...prev,
+      tabs: tabs.filter((tab) => !owned.has(tab.id)),
+      ...(panel.activeSubId && owned.has(panel.activeSubId)
+        ? { terminalPanel: { ...panel, activeSubId: "agent-bash" } }
+        : {}),
+    };
+  });
+}
+
+export function useNativeWindowSync(ctx: UseNativeWindowSyncContext): {
+  syncNativeWindowsToState: () => void;
+} {
+  const { setState, nativeWindowsRef } = ctx;
+  const syncNativeWindowsToState = useCallback(() => {
+    syncNativeWindowsToStateSlice(setState, nativeWindowsRef);
+  }, [setState, nativeWindowsRef]);
+
+  useEffect(() => {
+    let disposed = false;
+    invoke<NativeCanvasWindowRecord[]>("native_window_list")
+      .then((records) => {
+        if (disposed || !Array.isArray(records)) return;
+        nativeWindowsRef.current = new Map(
+          records.map((record) => [record.id, record]),
+        );
+        syncNativeWindowsToState();
+      })
+      .catch(() => {
+        /* native-window state is best-effort mirror data */
+      });
+    const unlistenRecord = listen<NativeCanvasWindowRecord>(
+      "native-window-record",
+      (event) => {
+        const record = event.payload;
+        if (!record || typeof record.id !== "string") return;
+        nativeWindowsRef.current.set(record.id, record);
+        syncNativeWindowsToState();
+      },
+    );
+    const unlistenShareMode = listen<{
+      tabId?: string;
+      shareMode?: ShareMode;
+    }>("native-terminal-share-mode", (event) => {
+      const { tabId, shareMode } = event.payload ?? {};
+      if (typeof tabId !== "string" || typeof shareMode !== "string") return;
+      setState((prev) => ({
+        ...prev,
+        tabs: ((prev.tabs as Tab[] | undefined) ?? []).map((tab) =>
+          tab.id === tabId && tab.kind === "shell" && tab.shell
+            ? { ...tab, shell: { ...tab.shell, shareMode } }
+            : tab,
+        ),
+      }));
+    });
+    const unlistenClosed = listen<{ id?: string }>(
+      "native-window-closed",
+      (event) => {
+        const id = event.payload?.id;
+        if (typeof id !== "string") return;
+        const record = nativeWindowsRef.current.get(id);
+        nativeWindowsRef.current.delete(id);
+        cleanupClosedNativeWindow(setState, record);
+        syncNativeWindowsToState();
+      },
+    );
+    return () => {
+      disposed = true;
+      unlistenRecord.then((fn) => fn());
+      unlistenShareMode.then((fn) => fn());
+      unlistenClosed.then((fn) => fn());
+    };
+  }, [setState, nativeWindowsRef, syncNativeWindowsToState]);
+
+  return { syncNativeWindowsToState };
+}

--- a/src/hooks/useRootChromeActions.test.tsx
+++ b/src/hooks/useRootChromeActions.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { Tab } from "../types/tab";
+import { useRootChromeActions } from "./useRootChromeActions";
+
+const agentTab = (patch: Partial<Tab> = {}): Tab =>
+  ({ id: "agent-1", kind: "agent", label: "Agent", messages: [], draft: "", ...patch }) as Tab;
+const shellTab = (): Tab =>
+  ({ id: "shell-1", kind: "shell", label: "Shell", shell: {} }) as Tab;
+
+function statefulSetState(seed: Record<string, unknown>) {
+  let state = seed;
+  const setState = vi.fn((updater: unknown) => {
+    state =
+      typeof updater === "function"
+        ? (updater as (prev: Record<string, unknown>) => Record<string, unknown>)(
+            state,
+          )
+        : (updater as Record<string, unknown>);
+  });
+  return { setState, getState: () => state };
+}
+
+describe("useRootChromeActions", () => {
+  it("toggles plan mode only for the active agent tab and emits the existing notification", () => {
+    const stateRef = { current: { activeTabId: "agent-1", tabs: [agentTab()] } };
+    const updateActiveTab = vi.fn();
+    const pushNotification = vi.fn();
+    const { setState } = statefulSetState({});
+    const { result } = renderHook(() =>
+      useRootChromeActions({
+        setState,
+        stateRef,
+        updateActiveTab,
+        pushNotification,
+      }),
+    );
+
+    act(() => result.current.togglePlanMode());
+
+    expect(updateActiveTab).toHaveBeenCalledTimes(1);
+    const mutator = updateActiveTab.mock.calls[0][0] as (tab: Tab) => Tab;
+    expect(mutator(agentTab()).planMode).toBe(true);
+    expect(pushNotification).toHaveBeenCalledWith({
+      title: "Plan mode on",
+      message: "New prompts will ask for a plan before code changes.",
+      kind: "success",
+      durationMs: 1600,
+    });
+  });
+
+  it("ignores plan mode toggles when the active tab is not an agent", () => {
+    const stateRef = { current: { activeTabId: "shell-1", tabs: [shellTab()] } };
+    const updateActiveTab = vi.fn();
+    const pushNotification = vi.fn();
+    const { setState } = statefulSetState({});
+    const { result } = renderHook(() =>
+      useRootChromeActions({
+        setState,
+        stateRef,
+        updateActiveTab,
+        pushNotification,
+      }),
+    );
+
+    act(() => result.current.togglePlanMode());
+
+    expect(updateActiveTab).not.toHaveBeenCalled();
+    expect(pushNotification).not.toHaveBeenCalled();
+  });
+
+  it("scheduled-task open and close mutate only scheduledTasks.open", () => {
+    const store = statefulSetState({
+      keep: true,
+      scheduledTasks: { tasks: [{ id: "t1" }], open: false },
+    });
+    const { result } = renderHook(() =>
+      useRootChromeActions({
+        setState: store.setState,
+        stateRef: { current: {} },
+        updateActiveTab: vi.fn(),
+        pushNotification: vi.fn(),
+      }),
+    );
+
+    act(() => result.current.openScheduledTasks());
+    expect(store.getState()).toEqual({
+      keep: true,
+      scheduledTasks: { tasks: [{ id: "t1" }], open: true },
+    });
+
+    act(() => result.current.closeScheduledTasks());
+    expect(store.getState()).toEqual({
+      keep: true,
+      scheduledTasks: { tasks: [{ id: "t1" }], open: false },
+    });
+  });
+
+  it("account modal toggle preserves existing auth modal state", () => {
+    const store = statefulSetState({
+      authProfiles: {
+        activeId: "work",
+        modal: { open: false, provider: "openai", step: "choose" },
+      },
+    });
+    const { result } = renderHook(() =>
+      useRootChromeActions({
+        setState: store.setState,
+        stateRef: { current: {} },
+        updateActiveTab: vi.fn(),
+        pushNotification: vi.fn(),
+      }),
+    );
+
+    act(() => result.current.toggleAccounts());
+
+    expect(store.getState()).toEqual({
+      authProfiles: {
+        activeId: "work",
+        modal: { open: true, provider: "openai", step: "choose" },
+      },
+    });
+  });
+});

--- a/src/hooks/useRootChromeActions.ts
+++ b/src/hooks/useRootChromeActions.ts
@@ -1,0 +1,86 @@
+import {
+  useCallback,
+  type Dispatch,
+  type MutableRefObject,
+  type SetStateAction,
+} from "react";
+import type { NotificationInput } from "./useNotifications";
+import type { Tab } from "../types/tab";
+
+export interface UseRootChromeActionsContext {
+  setState: Dispatch<SetStateAction<Record<string, unknown>>>;
+  stateRef: MutableRefObject<Record<string, unknown>>;
+  updateActiveTab: (updater: (tab: Tab) => Tab) => void;
+  pushNotification: (notification: NotificationInput) => void;
+}
+
+export interface RootChromeActions {
+  openScheduledTasks: () => void;
+  closeScheduledTasks: () => void;
+  togglePlanMode: () => void;
+  toggleAccounts: () => void;
+}
+
+function setScheduledTasksOpen(
+  setState: Dispatch<SetStateAction<Record<string, unknown>>>,
+  open: boolean,
+): void {
+  setState((prev) => ({
+    ...prev,
+    scheduledTasks: {
+      ...((prev.scheduledTasks ?? {}) as Record<string, unknown>),
+      open,
+    },
+  }));
+}
+
+export function useRootChromeActions(
+  ctx: UseRootChromeActionsContext,
+): RootChromeActions {
+  const { setState, stateRef, updateActiveTab, pushNotification } = ctx;
+
+  const openScheduledTasks = useCallback(() => {
+    setScheduledTasksOpen(setState, true);
+  }, [setState]);
+
+  const closeScheduledTasks = useCallback(() => {
+    setScheduledTasksOpen(setState, false);
+  }, [setState]);
+
+  const togglePlanMode = useCallback(() => {
+    const activeId = stateRef.current.activeTabId as string | undefined;
+    const tabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
+    const activeTab = tabs.find((tab) => tab.id === activeId);
+    if (!activeTab || activeTab.kind !== "agent") return;
+    const enabled = activeTab.planMode !== true;
+    updateActiveTab((tab) =>
+      tab.kind === "agent" ? { ...tab, planMode: enabled } : tab,
+    );
+    pushNotification({
+      title: enabled ? "Plan mode on" : "Implementation mode on",
+      message: enabled
+        ? "New prompts will ask for a plan before code changes."
+        : "New prompts may make code changes.",
+      kind: "success",
+      durationMs: 1600,
+    });
+  }, [pushNotification, stateRef, updateActiveTab]);
+
+  const toggleAccounts = useCallback(() => {
+    setState((prev) => {
+      const auth = (prev.authProfiles ?? {}) as Record<string, unknown>;
+      const modal = (auth.modal ?? {}) as Record<string, unknown>;
+      return {
+        ...prev,
+        authProfiles: { ...auth, modal: { ...modal, open: !modal.open } },
+      };
+    });
+  }, [setState]);
+
+  return {
+    openScheduledTasks,
+    closeScheduledTasks,
+    togglePlanMode,
+    toggleAccounts,
+  };
+}

--- a/src/hooks/useUpdaterConfigBridge.test.tsx
+++ b/src/hooks/useUpdaterConfigBridge.test.tsx
@@ -1,0 +1,30 @@
+// @vitest-environment jsdom
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { AethonConfig } from "../config";
+import { useUpdaterConfigBridge } from "./useUpdaterConfigBridge";
+
+const config = {
+  updates: { channel: "nightly", disableAutoCheck: true },
+} as AethonConfig;
+
+describe("useUpdaterConfigBridge", () => {
+  it("reapplies config and immediately mirrors updater settings", () => {
+    const reapplyConfig = vi.fn();
+    const setUpdateChannel = vi.fn();
+    const setUpdateDisableAutoCheck = vi.fn();
+    const { result } = renderHook(() =>
+      useUpdaterConfigBridge({
+        reapplyConfig,
+        setUpdateChannel,
+        setUpdateDisableAutoCheck,
+      }),
+    );
+
+    result.current(config);
+
+    expect(reapplyConfig).toHaveBeenCalledWith(config);
+    expect(setUpdateChannel).toHaveBeenCalledWith("nightly");
+    expect(setUpdateDisableAutoCheck).toHaveBeenCalledWith(true);
+  });
+});

--- a/src/hooks/useUpdaterConfigBridge.ts
+++ b/src/hooks/useUpdaterConfigBridge.ts
@@ -1,0 +1,25 @@
+import { useMemo } from "react";
+import type { AethonConfig } from "../config";
+
+export interface UseUpdaterConfigBridgeContext {
+  reapplyConfig: (fresh: AethonConfig) => void;
+  setUpdateChannel: (channel: AethonConfig["updates"]["channel"]) => void;
+  setUpdateDisableAutoCheck: (
+    disabled: AethonConfig["updates"]["disableAutoCheck"],
+  ) => void;
+}
+
+export function useUpdaterConfigBridge({
+  reapplyConfig,
+  setUpdateChannel,
+  setUpdateDisableAutoCheck,
+}: UseUpdaterConfigBridgeContext): (fresh: AethonConfig) => void {
+  return useMemo(
+    () => (fresh: AethonConfig) => {
+      reapplyConfig(fresh);
+      setUpdateChannel(fresh.updates.channel);
+      setUpdateDisableAutoCheck(fresh.updates.disableAutoCheck);
+    },
+    [reapplyConfig, setUpdateChannel, setUpdateDisableAutoCheck],
+  );
+}


### PR DESCRIPTION
Closes #376.

## Summary
- extract native canvas window list/event sync and owned shell cleanup into `useNativeWindowSync`
- extract root chrome actions for plan mode, account modal toggling, and scheduled-task open/close into `useRootChromeActions`
- extract cross-project/workspace tab activation into `useActivateTabAnywhere`
- move updater config reapply glue into `useUpdaterConfigBridge`

## Validation
- `bunx vitest run src/hooks/useActivateTabAnywhere.test.ts src/hooks/useRootChromeActions.test.tsx src/hooks/useNativeWindowSync.test.tsx src/hooks/useUpdaterConfigBridge.test.tsx src/eventRoutes/scheduledTasks.test.ts src/eventRoutes/composerPills.test.ts src/eventRoutes/chatInput.test.ts src/hooks/useKeyboardShortcuts.test.tsx`
- `bunx tsc -b --noEmit`
- `bunx eslint src/App.tsx src/hooks/useNativeWindowSync.ts src/hooks/useNativeWindowSync.test.tsx src/hooks/useRootChromeActions.ts src/hooks/useRootChromeActions.test.tsx src/hooks/useActivateTabAnywhere.ts src/hooks/useActivateTabAnywhere.test.ts src/hooks/useUpdaterConfigBridge.ts src/hooks/useUpdaterConfigBridge.test.tsx`
- `bunx vitest run`
- `bunx eslint .` (passes with existing warning in `src/extensions/default-layout/message-row.tsx` about `react-refresh/only-export-components`)
- `codex review --uncommitted` before commit: no findings
