### PR TITLE
feat: link GitHub issues to active sessions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,6 +62,10 @@ import { useRootChromeActions } from "./hooks/useRootChromeActions";
 import { useActivateTabAnywhere } from "./hooks/useActivateTabAnywhere";
 import { useUpdaterConfigBridge } from "./hooks/useUpdaterConfigBridge";
 import { closeAllWorkspaceSessions } from "./hooks/tabOps/closeWorkspaceSessions";
+import {
+  clearClosedIssueLinks,
+  clearClosedIssueLinksInBuckets,
+} from "./extensions/default-layout/dashboard/issue-sessions";
 import type { NativeCanvasWindowRecord } from "./nativeWindows";
 import { writeState } from "./persist";
 import { useAppState } from "./state/appStore";
@@ -654,6 +658,20 @@ export default function App() {
     activateWorkspace,
   });
 
+  const clearClosedIssueLinksForProject = useCallback(
+    (projectId: string, openIssueNumbers: ReadonlySet<number>) => {
+      clearClosedIssueLinksInBuckets(
+        tabBucketsRef.current,
+        projectId,
+        openIssueNumbers,
+      );
+      setState((prev) =>
+        clearClosedIssueLinks(prev, projectId, openIssueNumbers),
+      );
+    },
+    [setState, tabBucketsRef],
+  );
+
   // Updater (Cmd menu / tray "Check for Updates" + agent-driven path).
   // The hook reads the persisted channel + auto-check toggle from
   // `config.toml` during its own boot lifecycle, so we don't have to
@@ -980,6 +998,7 @@ export default function App() {
     activateWorkspace,
     createWorkspaceForProject,
     startTaskInProject,
+    clearClosedIssueLinksForProject,
     removeWorkspaceById,
     dismissPendingWorkspace,
     retryPendingWorkspace,

--- a/src/eventRoutes/dashboard.test.ts
+++ b/src/eventRoutes/dashboard.test.ts
@@ -6,6 +6,7 @@ import {
   handleTaskLauncher,
 } from "./dashboard";
 import { buildRouteFixture } from "./testFixtures";
+import { makeEmptyTab } from "../types/tab";
 
 describe("handleProjectsDashboard", () => {
   it("new-tab calls ctx.newTab", async () => {
@@ -305,6 +306,81 @@ describe("handleProjectDashboard", () => {
     );
   });
 
+  it("forwards issue-section existing-session clicks emitted through the project dashboard", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    const handled = await handleProjectDashboard(
+      {
+        component: { id: "project-dashboard", type: "project-dashboard" },
+        eventType: "open-issue-session",
+        data: { tabId: "issue-tab", issueNumber: 927 },
+      },
+      ctx,
+    );
+
+    expect(handled).toBe(true);
+    expect(mocks.activateTabAnywhere).toHaveBeenCalledWith("issue-tab");
+  });
+
+  it("forwards issue-section refresh cleanup emitted through the project dashboard", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    const handled = await handleProjectDashboard(
+      {
+        component: { id: "project-dashboard", type: "project-dashboard" },
+        eventType: "issues-refreshed",
+        data: {
+          projectId: "p1",
+          openIssueNumbers: [84, "86", 84.5, "87.5", 0, -1, "bad"],
+        },
+      },
+      ctx,
+    );
+
+    expect(handled).toBe(true);
+    expect(mocks.clearClosedIssueLinksForProject).toHaveBeenCalledWith(
+      "p1",
+      new Set([84, 86]),
+    );
+  });
+
+  it("opens an existing issue session instead of launching a duplicate", async () => {
+    const linked = {
+      ...makeEmptyTab("issue-tab", "Issue 927", "p1"),
+      sourceIssue: {
+        kind: "github-issue" as const,
+        projectId: "p1",
+        number: 927,
+        url: "https://github.com/utensils/aethon/issues/927",
+        title: "Crash on boot",
+        branch: "fix/issue-927-crash-on-boot",
+        workspaceId: "wt-927",
+        workspacePath: "/repo/aethon-fix-927",
+        createdAt: 1,
+      },
+    };
+    const { ctx, mocks } = buildRouteFixture({ state: { tabs: [linked] } });
+    const handled = await handleProjectDashboard(
+      {
+        component: { id: "project-dashboard", type: "project-dashboard" },
+        eventType: "start-task",
+        data: {
+          projectId: "p1",
+          prompt: "Please work on issue #927",
+          newWorkspace: true,
+          branch: "fix/issue-927-crash-on-boot",
+          source: "github-issue",
+          issueNumber: 927,
+          issueUrl: "https://github.com/utensils/aethon/issues/927",
+          issueTitle: "Crash on boot",
+        },
+      },
+      ctx,
+    );
+
+    expect(handled).toBe(true);
+    expect(mocks.activateTabAnywhere).toHaveBeenCalledWith("issue-tab");
+    expect(ctx.startTaskInProject).not.toHaveBeenCalled();
+  });
+
   it("forwards task-launcher paste failures emitted through the project dashboard", async () => {
     const { ctx } = buildRouteFixture();
     const handled = await handleProjectDashboard(
@@ -352,6 +428,61 @@ describe("handleTaskLauncher", () => {
       baseBranch: "main",
       workspaceId: undefined,
     });
+  });
+
+  it("start-task forwards GitHub issue origin metadata", async () => {
+    const { ctx } = buildRouteFixture();
+    await handleTaskLauncher(
+      {
+        component: { id: "x", type: "task-launcher" },
+        eventType: "start-task",
+        data: {
+          projectId: "p1",
+          prompt: "fix issue",
+          newWorkspace: true,
+          branch: "fix/issue-85-cannot-rename-session-tab",
+          source: "github-issue",
+          issueNumber: 85,
+          issueUrl: "https://github.com/utensils/aethon/issues/85",
+          issueTitle: "Cannot rename session tab while agent is running",
+        },
+      },
+      ctx,
+    );
+
+    expect(ctx.startTaskInProject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceIssue: expect.objectContaining({
+          kind: "github-issue",
+          projectId: "p1",
+          number: 85,
+          url: "https://github.com/utensils/aethon/issues/85",
+          title: "Cannot rename session tab while agent is running",
+          branch: "fix/issue-85-cannot-rename-session-tab",
+        }),
+      }),
+    );
+  });
+
+  it("issues-refreshed clears issue links that are no longer open", async () => {
+    const { ctx, mocks } = buildRouteFixture();
+    const handled = await handleTaskLauncher(
+      {
+        component: { id: "x", type: "issues-section" },
+        eventType: "issues-refreshed",
+        data: {
+          projectId: "p1",
+          openIssueNumbers: [84, "86", 84.5, "87.5", 0, -1, "bad"],
+        },
+      },
+      ctx,
+    );
+
+    expect(handled).toBe(true);
+    expect(mocks.clearClosedIssueLinksForProject).toHaveBeenCalledWith(
+      "p1",
+      new Set([84, 86]),
+    );
   });
 
   it("start-task forwards workspaceId for existing-workspace submits", async () => {

--- a/src/eventRoutes/dashboard.ts
+++ b/src/eventRoutes/dashboard.ts
@@ -15,12 +15,47 @@
  * the same handlers.
  */
 import type { EventRouteHandler } from "./types";
+import type { GitHubIssueSource } from "../types/tab";
 import {
   handleSidebarDeleteSession,
   handleSidebarRemoveWorkspace,
   handleSidebarSwitchWorkspace,
 } from "./sidebar";
 import { restoreSessionFromSelection } from "./sessionRestore";
+import { firstIssueSessionTab } from "../extensions/default-layout/dashboard/issue-sessions";
+
+function issueSourceFromStartTask(data: {
+  projectId?: string;
+  source?: string;
+  issueNumber?: unknown;
+  issueUrl?: unknown;
+  issueTitle?: unknown;
+  branch?: string;
+  workspaceId?: string;
+}): GitHubIssueSource | null {
+  const number =
+    typeof data.issueNumber === "number"
+      ? data.issueNumber
+      : Number(data.issueNumber);
+  if (
+    data.source !== "github-issue" ||
+    !data.projectId ||
+    !Number.isInteger(number) ||
+    number <= 0
+  ) {
+    return null;
+  }
+  return {
+    kind: "github-issue",
+    projectId: data.projectId,
+    number,
+    url: typeof data.issueUrl === "string" ? data.issueUrl : "",
+    title: typeof data.issueTitle === "string" ? data.issueTitle : "",
+    ...(data.branch ? { branch: data.branch } : {}),
+    ...(data.workspaceId ? { workspaceId: data.workspaceId } : {}),
+    createdAt: Date.now(),
+  };
+}
 
 /** New-tab / Open Project… / restore-session / select-project-card
  *  for the global projects-dashboard surface. */
@@ -88,7 +123,12 @@ export const handleProjectDashboard: EventRouteHandler = (
       ctx,
     );
   }
-  if (eventType === "start-task" || eventType === "paste-image-failed") {
+  if (
+    eventType === "start-task" ||
+    eventType === "open-issue-session" ||
+    eventType === "issues-refreshed" ||
+    eventType === "paste-image-failed"
+  ) {
     return handleTaskLauncher(
       { component: { id: "", type: "task-launcher" }, eventType, data },
       ctx,
@@ -136,6 +176,35 @@ export const handleTaskLauncher: EventRouteHandler = (
   { eventType, data },
   ctx,
 ) => {
+  if (eventType === "open-issue-session") {
+    const tabId = (data as { tabId?: string } | undefined)?.tabId;
+    if (tabId) ctx.activateTabAnywhere(tabId);
+    return true;
+  }
+  if (eventType === "issues-refreshed") {
+    const sel =
+      (data as
+        | {
+            projectId?: string;
+            openIssueNumbers?: unknown;
+          }
+        | undefined) ?? {};
+    const numbers = Array.isArray(sel.openIssueNumbers)
+      ? new Set(
+          sel.openIssueNumbers
+            .map((value) =>
+              typeof value === "number" ? value : Number(value),
+            )
+            .filter(
+              (value) => Number.isInteger(value) && value > 0,
+            ),
+        )
+      : null;
+    if (sel.projectId && numbers) {
+      ctx.clearClosedIssueLinksForProject(sel.projectId, numbers);
+    }
+    return true;
+  }
   if (eventType === "paste-image-failed") {
     const sel = data as { message?: unknown } | undefined;
     ctx.pushNotification({
@@ -161,9 +230,27 @@ export const handleTaskLauncher: EventRouteHandler = (
           baseBranch?: string;
           workspaceId?: string;
           model?: string;
+          source?: string;
+          issueNumber?: unknown;
+          issueUrl?: unknown;
+          issueTitle?: unknown;
+          issueTemplateId?: string;
+          issueTemplateLabel?: string;
         }
       | undefined;
     if (!sel?.projectId || !sel.prompt) return true;
+    const sourceIssue = issueSourceFromStartTask(sel);
+    if (sourceIssue) {
+      const existing = firstIssueSessionTab(
+        ctx.stateRef.current,
+        sourceIssue.projectId,
+        sourceIssue.number,
+      );
+      if (existing) {
+        ctx.activateTabAnywhere(existing.id);
+        return true;
+      }
+    }
     void ctx.startTaskInProject({
       projectId: sel.projectId,
       prompt: sel.prompt,
@@ -175,6 +262,7 @@ export const handleTaskLauncher: EventRouteHandler = (
       ...(typeof sel.model === "string" && sel.model.length > 0
         ? { model: sel.model }
         : {}),
+      ...(sourceIssue ? { sourceIssue } : {}),
     });
     return true;
   }

--- a/src/eventRoutes/testFixtures.ts
+++ b/src/eventRoutes/testFixtures.ts
@@ -76,6 +76,7 @@ export interface RouteFixture {
     activateWorkspace: Mock;
     reorderWorkspace: Mock;
     sortProjectWorkspacesNewest: Mock;
+    clearClosedIssueLinksForProject: Mock;
     invoke: Mock;
     writeState: Mock;
   };
@@ -169,6 +170,7 @@ export function buildRouteFixture(
   const activateWorkspace = vi.fn();
   const reorderWorkspace = vi.fn();
   const sortProjectWorkspacesNewest = vi.fn();
+  const clearClosedIssueLinksForProject = vi.fn();
   const invoke = vi.fn(() => Promise.resolve(undefined));
   const writeState = vi.fn(() => Promise.resolve(true));
 
@@ -239,6 +241,7 @@ export function buildRouteFixture(
     activateWorkspace,
     createWorkspaceForProject: vi.fn(() => Promise.resolve()),
     startTaskInProject: vi.fn(() => Promise.resolve()),
+    clearClosedIssueLinksForProject,
     removeWorkspaceById: vi.fn(() => Promise.resolve()),
     dismissPendingWorkspace: vi.fn(),
     retryPendingWorkspace: vi.fn(() => Promise.resolve()),
@@ -323,6 +326,7 @@ export function buildRouteFixture(
       activateWorkspace,
       reorderWorkspace,
       sortProjectWorkspacesNewest,
+      clearClosedIssueLinksForProject,
       invoke,
       writeState,
     },

--- a/src/eventRoutes/types.ts
+++ b/src/eventRoutes/types.ts
@@ -1,5 +1,10 @@
 import type { Dispatch, MutableRefObject, SetStateAction } from "react";
-import type { EditorDiffSnapshot, EditorMeta, Tab } from "../types/tab";
+import type {
+  EditorDiffSnapshot,
+  EditorMeta,
+  GitHubIssueSource,
+  Tab,
+} from "../types/tab";
 import type { ChatAttachment } from "../types/a2ui";
 import type { ShareMode } from "../utils/shareMode";
 import type {
@@ -92,6 +97,7 @@ export interface EventRouteContext {
       restoredSession?: boolean;
       cwd?: string;
       scrollToMatch?: string;
+      sourceIssue?: GitHubIssueSource;
     },
   ) => void;
   newShellTab: () => void;
@@ -187,7 +193,12 @@ export interface EventRouteContext {
     bridgePrompt?: string;
     activate?: boolean;
     label?: string;
+    sourceIssue?: GitHubIssueSource;
   }) => Promise<unknown>;
+  clearClosedIssueLinksForProject: (
+    projectId: string,
+    openIssueNumbers: ReadonlySet<number>,
+  ) => void;
   removeWorkspaceById: (
     workspaceId: string,
     opts?: { confirmed?: boolean },

--- a/src/extensions/default-layout/dashboard/issue-sessions.test.ts
+++ b/src/extensions/default-layout/dashboard/issue-sessions.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { makeEmptyTab } from "../../../types/tab";
+import type { TabBucket } from "../../../hooks/projectOps/types";
+import {
+  clearClosedIssueLinks,
+  clearClosedIssueLinksInBuckets,
+  firstIssueSessionTab,
+} from "./issue-sessions";
+
+const sourceIssue = {
+  kind: "github-issue" as const,
+  projectId: "p1",
+  number: 85,
+  url: "https://github.com/utensils/aethon/issues/85",
+  title: "Cannot rename session tab while agent is running",
+  branch: "fix/issue-85-existing",
+  workspaceId: "wt-85",
+  workspacePath: "/repo/aethon-issue-85",
+  createdAt: 1,
+};
+
+describe("issue session links", () => {
+  it("finds issue sessions across active tabs and persisted buckets", () => {
+    const hidden = {
+      ...makeEmptyTab("hidden", "Hidden", "p1"),
+      sourceIssue,
+    };
+    const state = {
+      tabs: [makeEmptyTab("active", "Active", "p1")],
+      persistedTabBuckets: {
+        "p1::workspace::wt-85": { tabs: [hidden], activeTabId: "hidden" },
+      },
+    };
+
+    expect(firstIssueSessionTab(state, "p1", 85)?.id).toBe("hidden");
+  });
+
+  it("clears closed issue links from state and live buckets", () => {
+    const active = {
+      ...makeEmptyTab("active", "Active", "p1"),
+      sourceIssue,
+    };
+    const hidden = {
+      ...makeEmptyTab("hidden", "Hidden", "p1"),
+      sourceIssue,
+    };
+    const state = clearClosedIssueLinks(
+      {
+        tabs: [active],
+        persistedTabBuckets: {
+          "p1::workspace::wt-85": { tabs: [hidden], activeTabId: "hidden" },
+        },
+      },
+      "p1",
+      new Set([84]),
+    );
+    const buckets = new Map<string, TabBucket>([
+      ["p1::workspace::wt-85", { tabs: [hidden], activeTabId: "hidden" }],
+    ]);
+
+    expect((state.tabs as Array<typeof active>)[0].sourceIssue).toBeUndefined();
+    expect(
+      (state.persistedTabBuckets as Record<string, TabBucket>)[
+        "p1::workspace::wt-85"
+      ].tabs[0].sourceIssue,
+    ).toBeUndefined();
+    expect(clearClosedIssueLinksInBuckets(buckets, "p1", new Set([84]))).toBe(
+      true,
+    );
+    expect(
+      buckets.get("p1::workspace::wt-85")?.tabs[0].sourceIssue,
+    ).toBeUndefined();
+  });
+});

--- a/src/extensions/default-layout/dashboard/issue-sessions.ts
+++ b/src/extensions/default-layout/dashboard/issue-sessions.ts
@@ -1,0 +1,136 @@
+import type { Tab } from "../../../types/tab";
+import type { TabBucket } from "../../../hooks/projectOps/types";
+
+function collectTabs(state: Record<string, unknown>): Tab[] {
+  const tabs: Tab[] = [];
+  const seen = new Set<string>();
+  const collect = (list: readonly Tab[] | undefined) => {
+    for (const tab of list ?? []) {
+      if (seen.has(tab.id)) continue;
+      seen.add(tab.id);
+      tabs.push(tab);
+    }
+  };
+  collect((state.tabs as Tab[] | undefined) ?? []);
+  const buckets = state.persistedTabBuckets as
+    | Record<string, { tabs?: Tab[] }>
+    | undefined;
+  if (buckets) {
+    for (const bucket of Object.values(buckets)) collect(bucket.tabs);
+  }
+  return tabs;
+}
+
+export function issueSessionTabs(
+  state: Record<string, unknown>,
+  projectId: string,
+  issueNumber: number,
+): Tab[] {
+  return collectTabs(state).filter((tab) => {
+    const source = tab.sourceIssue;
+    return (
+      tab.kind === "agent" &&
+      source?.kind === "github-issue" &&
+      source.projectId === projectId &&
+      source.number === issueNumber
+    );
+  });
+}
+
+export function firstIssueSessionTab(
+  state: Record<string, unknown>,
+  projectId: string,
+  issueNumber: number,
+): Tab | null {
+  return issueSessionTabs(state, projectId, issueNumber)[0] ?? null;
+}
+
+function stripSourceIssue(tab: Tab): Tab {
+  const { sourceIssue: _sourceIssue, ...rest } = tab;
+  return rest;
+}
+
+function clearClosedIssueLinksFromTab(
+  tab: Tab,
+  projectId: string,
+  openIssueNumbers: ReadonlySet<number>,
+): Tab {
+  const source = tab.sourceIssue;
+  if (
+    source?.kind !== "github-issue" ||
+    source.projectId !== projectId ||
+    openIssueNumbers.has(source.number)
+  ) {
+    return tab;
+  }
+  return stripSourceIssue(tab);
+}
+
+function clearClosedIssueLinksFromBucket(
+  bucket: TabBucket,
+  projectId: string,
+  openIssueNumbers: ReadonlySet<number>,
+): TabBucket {
+  let changed = false;
+  const tabs = bucket.tabs.map((tab) => {
+    const next = clearClosedIssueLinksFromTab(tab, projectId, openIssueNumbers);
+    if (next !== tab) changed = true;
+    return next;
+  });
+  return changed ? { ...bucket, tabs } : bucket;
+}
+
+export function clearClosedIssueLinks(
+  state: Record<string, unknown>,
+  projectId: string,
+  openIssueNumbers: ReadonlySet<number>,
+): Record<string, unknown> {
+  let changed = false;
+  const tabs = ((state.tabs as Tab[] | undefined) ?? []).map((tab) => {
+    const next = clearClosedIssueLinksFromTab(tab, projectId, openIssueNumbers);
+    if (next !== tab) changed = true;
+    return next;
+  });
+
+  const persisted = state.persistedTabBuckets as
+    | Record<string, TabBucket>
+    | undefined;
+  let persistedTabBuckets = persisted;
+  if (persisted) {
+    const nextBuckets: Record<string, TabBucket> = {};
+    for (const [key, bucket] of Object.entries(persisted)) {
+      const next = clearClosedIssueLinksFromBucket(
+        bucket,
+        projectId,
+        openIssueNumbers,
+      );
+      if (next !== bucket) changed = true;
+      nextBuckets[key] = next;
+    }
+    persistedTabBuckets = nextBuckets;
+  }
+
+  if (!changed) return state;
+  return persisted
+    ? { ...state, tabs, persistedTabBuckets }
+    : { ...state, tabs };
+}
+
+export function clearClosedIssueLinksInBuckets(
+  buckets: Map<string, TabBucket>,
+  projectId: string,
+  openIssueNumbers: ReadonlySet<number>,
+): boolean {
+  let changed = false;
+  for (const [key, bucket] of buckets.entries()) {
+    const next = clearClosedIssueLinksFromBucket(
+      bucket,
+      projectId,
+      openIssueNumbers,
+    );
+    if (next === bucket) continue;
+    changed = true;
+    buckets.set(key, next);
+  }
+  return changed;
+}

--- a/src/extensions/default-layout/dashboard/issues-section.test.ts
+++ b/src/extensions/default-layout/dashboard/issues-section.test.ts
@@ -21,6 +21,7 @@ import {
   type IssueTemplate,
 } from "./issue-templates";
 import type { GhIssue } from "../../../ghIssuesCache";
+import { makeEmptyTab } from "../../../types/tab";
 
 const { getIssueDetail, refreshIssues, openUrl, invoke } = vi.hoisted(() => ({
   getIssueDetail: vi.fn(),
@@ -61,6 +62,7 @@ const issue: GhIssue = {
 function renderIssues(
   onEvent = vi.fn(),
   templateConfig: unknown = { templates: [], warning: null },
+  stateOverrides: Record<string, unknown> = {},
 ) {
   refreshIssues.mockResolvedValue([issue]);
   getIssueDetail.mockResolvedValue({
@@ -90,6 +92,7 @@ function renderIssues(
             },
           ],
         },
+        ...stateOverrides,
       },
       onEvent,
     }),
@@ -387,6 +390,47 @@ describe("IssuesSection", () => {
         }),
         "issue-85",
       ),
+    );
+  });
+
+  it("shows linked issue-session status and opens it instead of dispatching", async () => {
+    const linked = {
+      ...makeEmptyTab("issue-tab", "Issue #85", "p1"),
+      cwd: "/repo/aethon-issue-85",
+      sourceIssue: {
+        kind: "github-issue" as const,
+        projectId: "p1",
+        number: 85,
+        url: issue.url,
+        title: issue.title,
+        branch: "fix/issue-85-existing",
+        workspaceId: "wt-other",
+        workspacePath: "/repo/aethon-issue-85",
+        createdAt: 1,
+      },
+    };
+    const { onEvent } = renderIssues(
+      vi.fn(),
+      { templates: [], warning: null },
+      {
+        tabs: [linked],
+        agentRunningTabs: { "issue-tab": true },
+      },
+    );
+
+    await screen.findByText(issue.title);
+    expect(screen.getByText("Working · fix/issue-85-existing")).toBeTruthy();
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /open existing session for issue #85/i,
+      }),
+    );
+
+    expect(getIssueDetail).not.toHaveBeenCalled();
+    expect(onEvent).toHaveBeenCalledWith(
+      "open-issue-session",
+      { tabId: "issue-tab", issueNumber: 85 },
+      "issue-85",
     );
   });
 

--- a/src/extensions/default-layout/dashboard/issues-section.tsx
+++ b/src/extensions/default-layout/dashboard/issues-section.tsx
@@ -43,6 +43,7 @@ import {
   matchingIssueTemplates,
   type IssueTemplate,
 } from "./issue-templates";
+import { firstIssueSessionTab } from "./issue-sessions";
 
 interface ProjectInfo {
   id: string;
@@ -77,6 +78,12 @@ interface ContextMenuState {
   issue: GhIssue;
   x: number;
   y: number;
+}
+
+interface IssueSessionStatus {
+  tabId: string;
+  stateLabel: "Working" | "Ready" | "Session";
+  detail: string;
 }
 
 function projectWorkspaceBranches(
@@ -123,6 +130,66 @@ function currentProjectWorkspaceId(
     project?.workspaces?.find((w) => w.id && w.id === activeWorkspaceId) ??
     project?.workspaces?.find((w) => w.id && w.active === true);
   return workspace?.id;
+}
+
+function workspaceLabelForIssueSession(
+  state: Record<string, unknown>,
+  projectId: string,
+  workspaceId?: string,
+  workspacePath?: string,
+  branch?: string,
+): string {
+  if (branch) return branch;
+  const sidebar =
+    (state.sidebar as
+      | {
+          projects?: {
+            id: string;
+            workspaces?: {
+              id?: string;
+              label?: string;
+              branch?: string | null;
+              path?: string;
+            }[];
+          }[];
+        }
+      | undefined) ?? {};
+  const project = sidebar.projects?.find((p) => p.id === projectId);
+  const workspace =
+    project?.workspaces?.find((w) => w.id && w.id === workspaceId) ??
+    project?.workspaces?.find((w) => w.path && w.path === workspacePath);
+  return (
+    workspace?.label ??
+    workspace?.branch ??
+    workspacePath?.split(/[/\\]/).filter(Boolean).at(-1) ??
+    "project root"
+  );
+}
+
+function issueSessionStatus(
+  state: Record<string, unknown>,
+  projectId: string,
+  issue: GhIssue,
+): IssueSessionStatus | null {
+  const tab = firstIssueSessionTab(state, projectId, issue.number);
+  if (!tab?.sourceIssue) return null;
+  const running = Boolean(
+    (state.agentRunningTabs as Record<string, unknown> | undefined)?.[tab.id],
+  );
+  const attention = Boolean(
+    (state.agentAttentionTabs as Record<string, unknown> | undefined)?.[tab.id],
+  );
+  return {
+    tabId: tab.id,
+    stateLabel: running ? "Working" : attention ? "Ready" : "Session",
+    detail: workspaceLabelForIssueSession(
+      state,
+      projectId,
+      tab.sourceIssue.workspaceId,
+      tab.sourceIssue.workspacePath ?? tab.cwd,
+      tab.sourceIssue.branch,
+    ),
+  };
 }
 
 export function IssuesSection({
@@ -184,6 +251,14 @@ export function IssuesSection({
       ]);
       if (cancelled) return;
       setIssues(fetched);
+      onEvent(
+        "issues-refreshed",
+        {
+          projectId: project.id,
+          openIssueNumbers: fetched.map((issue) => issue.number),
+        },
+        "issues-section",
+      );
       setIssueTemplates(templateConfig.templates);
       setTemplateWarning(templateConfig.warning);
       if (templateConfig.warning) {
@@ -194,7 +269,7 @@ export function IssuesSection({
     return () => {
       cancelled = true;
     };
-  }, [visible, project, limit, loadedFor]);
+  }, [visible, project, limit, loadedFor, onEvent]);
 
   // Close the menu on outside-click / Esc / scroll. Capture phase so a
   // click on a sibling card row doesn't leak into the row's click
@@ -233,6 +308,15 @@ export function IssuesSection({
       } = {},
     ) => {
       if (!project) return;
+      const existing = firstIssueSessionTab(state, project.id, issue.number);
+      if (existing) {
+        onEvent(
+          "open-issue-session",
+          { tabId: existing.id, issueNumber: issue.number },
+          `issue-${issue.number}`,
+        );
+        return;
+      }
       setSending(issue.number);
       try {
         const detail = await getIssueDetail(project.path, issue.number);
@@ -260,13 +344,12 @@ export function IssuesSection({
             newWorkspace: task.newWorkspace,
             branch: task.branch,
             workspaceId,
-            // Tag the payload so tests (and future telemetry) can spot
-            // an issue-originated launch. The start-task route handler
-            // forwards only its known keys, so these extra fields are
-            // observational and intentionally not consumed there yet.
+            // Tag the payload so the route can associate this issue
+            // with the launched session and guard future duplicate clicks.
             source: "github-issue",
             issueNumber: issue.number,
             issueUrl: issue.url,
+            issueTitle: issue.title,
             issueTemplateId: task.templateId,
             issueTemplateLabel: task.templateLabel,
           },
@@ -333,6 +416,14 @@ export function IssuesSection({
                   loadIssueTemplates(project.path),
                 ]);
                 setIssues(fresh);
+                onEvent(
+                  "issues-refreshed",
+                  {
+                    projectId: project.id,
+                    openIssueNumbers: fresh.map((issue) => issue.number),
+                  },
+                  "issues-section",
+                );
                 setIssueTemplates(templateConfig.templates);
                 setTemplateWarning(templateConfig.warning);
                 if (templateConfig.warning) {
@@ -370,10 +461,14 @@ export function IssuesSection({
         <ul className="a2ui-dashboard-issues-list">
           {issues.map((issue) => {
             const isSending = sending === issue.number;
+            const session = issueSessionStatus(state, project.id, issue);
             return (
               <li
                 key={issue.number}
-                className="a2ui-dashboard-issue-row"
+                className={
+                  "a2ui-dashboard-issue-row" +
+                  (session ? " is-linked-session" : "")
+                }
                 title="Left-click: open on GitHub · Right-click: more actions"
                 onClick={() => openIssueInBrowser(issue.url)}
                 onContextMenu={(e) => onRowContextMenu(e, issue)}
@@ -398,6 +493,31 @@ export function IssuesSection({
                       updated {formatRelativeTime(Date.parse(issue.updatedAt))}
                     </span>
                   )}
+                  {session ? (
+                    <button
+                      type="button"
+                      className="a2ui-dashboard-issue-session"
+                      data-state={session.stateLabel.toLowerCase()}
+                      title={`Open ${session.detail}`}
+                      aria-label={`Open session for issue #${issue.number}`}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onEvent(
+                          "open-issue-session",
+                          { tabId: session.tabId, issueNumber: issue.number },
+                          `issue-${issue.number}`,
+                        );
+                      }}
+                    >
+                      <span
+                        className="a2ui-dashboard-issue-session-dot"
+                        aria-hidden="true"
+                      />
+                      <span className="a2ui-dashboard-issue-session-text">
+                        {session.stateLabel} · {session.detail}
+                      </span>
+                    </button>
+                  ) : null}
                   {issue.comments > 0 && (
                     <span className="a2ui-dashboard-issue-comments">
                       💬 {issue.comments}
@@ -427,15 +547,31 @@ export function IssuesSection({
                 <button
                   type="button"
                   className="a2ui-dashboard-issue-send"
-                  aria-label={`Send issue #${issue.number} to agent`}
-                  title="Send to agent in new workspace"
+                  aria-label={
+                    session
+                      ? `Open existing session for issue #${issue.number}`
+                      : `Send issue #${issue.number} to agent`
+                  }
+                  title={
+                    session
+                      ? "Open existing session"
+                      : "Send to agent in new workspace"
+                  }
                   disabled={isSending}
                   onClick={(e) => {
                     e.stopPropagation();
-                    void sendIssueToNewWorkspace(issue);
+                    if (session) {
+                      onEvent(
+                        "open-issue-session",
+                        { tabId: session.tabId, issueNumber: issue.number },
+                        `issue-${issue.number}`,
+                      );
+                    } else {
+                      void sendIssueToNewWorkspace(issue);
+                    }
                   }}
                 >
-                  {isSending ? "…" : "→ Agent"}
+                  {isSending ? "…" : session ? "Open" : "→ Agent"}
                 </button>
               </li>
             );

--- a/src/hooks/bridgeMessageHandlers/types.ts
+++ b/src/hooks/bridgeMessageHandlers/types.ts
@@ -1,6 +1,10 @@
 import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 import type { A2UIPayload, ChatMessage } from "../../types/a2ui";
-import type { EditorDiffSnapshot, Tab } from "../../types/tab";
+import type {
+  EditorDiffSnapshot,
+  GitHubIssueSource,
+  Tab,
+} from "../../types/tab";
 import type { ExtensionRegistry } from "../../extensions/ExtensionRegistry";
 import type {
   DisabledExtensionRecord,
@@ -199,6 +203,7 @@ export interface BridgeMessageContext {
     bridgePrompt?: string;
     activate?: boolean;
     label?: string;
+    sourceIssue?: GitHubIssueSource;
   }) => Promise<StartTaskResult | void>;
 
   // ─── Hook-owned ────────────────────────────────────────────────────

--- a/src/hooks/tabOps/agentTab.ts
+++ b/src/hooks/tabOps/agentTab.ts
@@ -1,6 +1,6 @@
 import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 import { invoke } from "@tauri-apps/api/core";
-import { makeEmptyTab, type Tab } from "../../types/tab";
+import { makeEmptyTab, type GitHubIssueSource, type Tab } from "../../types/tab";
 import type { ProjectsState } from "../../projects";
 import { recomputeModelPicker } from "../../utils/modelPicker";
 import { TAB_MIRROR_KEYS } from "./constants";
@@ -52,6 +52,7 @@ export function useNewTab(deps: NewTabDeps) {
       /** Per-launch model override (task-launcher model chip). Wins over
        *  the global default + per-project memory in modelForNewProjectTab. */
       model?: string;
+      sourceIssue?: GitHubIssueSource;
     },
   ): void {
     // restoreId lets the caller open a tab with a specific tabId so the
@@ -129,6 +130,7 @@ export function useNewTab(deps: NewTabDeps) {
           ? { thinkingLevel: inheritedThinkingLevel }
           : {}),
         ...(inheritedCwd ? { cwd: inheritedCwd } : {}),
+        ...(options?.sourceIssue ? { sourceIssue: options.sourceIssue } : {}),
       };
       tabs.push(tab);
       const result: Record<string, unknown> = {

--- a/src/hooks/useTaskLauncher.test.ts
+++ b/src/hooks/useTaskLauncher.test.ts
@@ -117,6 +117,65 @@ describe("useTaskLauncher", () => {
     expect(sendChat).toHaveBeenCalledWith("implement this", { tabId });
   });
 
+  it("attaches GitHub issue source metadata to active task tabs", async () => {
+    const projects = makeProjects();
+    projects.workspacesByProject.p1 = [
+      {
+        id: "wt-85",
+        projectId: "p1",
+        path: "/repo/aethon-issue-85",
+        branch: "fix/issue-85-existing",
+        isMain: false,
+      },
+    ];
+    const projectsRef = ref(projects);
+    const newTab = vi.fn();
+    const sendChat = vi.fn(() => Promise.resolve());
+    const { result } = renderHook(() =>
+      useTaskLauncher({
+        projectsRef,
+        pushNotificationRef: ref((_: NotificationInput) => {}),
+        setActiveProjectById: vi.fn(() => true),
+        createWorkspaceWithParams: vi.fn(() =>
+          Promise.resolve("/repo/aethon-issue-85"),
+        ),
+        activateWorkspace: vi.fn(),
+        newTab,
+        pendingTabOpens: ref(new Map()),
+        sendChat,
+      }),
+    );
+
+    await act(async () => {
+      await result.current({
+        projectId: "p1",
+        prompt: "fix issue",
+        newWorkspace: true,
+        branch: "fix/issue-85-existing",
+        sourceIssue: {
+          kind: "github-issue",
+          projectId: "p1",
+          number: 85,
+          url: "https://github.com/utensils/aethon/issues/85",
+          title: "Cannot rename session tab while agent is running",
+          createdAt: 1,
+        },
+      });
+    });
+
+    const tabId = newTab.mock.calls[0]?.[0];
+    expect(newTab).toHaveBeenCalledWith(tabId, undefined, {
+      cwd: "/repo/aethon-issue-85",
+      sourceIssue: expect.objectContaining({
+        kind: "github-issue",
+        number: 85,
+        branch: "fix/issue-85-existing",
+        workspaceId: "wt-85",
+        workspacePath: "/repo/aethon-issue-85",
+      }),
+    });
+  });
+
   it("threads the per-launch model through to the new tab", async () => {
     const projectsRef = ref(makeProjects());
     const newTab = vi.fn();
@@ -454,6 +513,14 @@ describe("useTaskLauncher", () => {
         prompt: "background workspace task",
         activate: false,
         label: "GLM task",
+        sourceIssue: {
+          kind: "github-issue",
+          projectId: "p2",
+          number: 52,
+          url: "https://github.com/example/other/issues/52",
+          title: "Background issue",
+          createdAt: 1,
+        },
       });
     });
 
@@ -466,6 +533,14 @@ describe("useTaskLauncher", () => {
       label: "GLM task",
       projectId: "p2",
       cwd: "/repo/other-work",
+      sourceIssue: {
+        kind: "github-issue",
+        projectId: "p2",
+        number: 52,
+        workspaceId: "wt-2",
+        workspacePath: "/repo/other-work",
+        branch: "feat/other",
+      },
     });
     expect(
       (stateRef.current.persistedTabBuckets as Record<string, TabBucket>)[

--- a/src/hooks/useTaskLauncher.ts
+++ b/src/hooks/useTaskLauncher.ts
@@ -8,7 +8,7 @@ import { invoke } from "@tauri-apps/api/core";
 import type { ChatAttachment } from "../types/a2ui";
 import type { ProjectsState } from "../projects";
 import type { NotificationInput } from "./useNotifications";
-import { makeEmptyTab, type Tab } from "../types/tab";
+import { makeEmptyTab, type GitHubIssueSource, type Tab } from "../types/tab";
 import { modelForNewProjectTab } from "./tabOps/helpers";
 import {
   devshellNeedsPreparation,
@@ -40,6 +40,7 @@ export interface StartTaskOptions {
    *  visible/local-history text. Used when agent-side launchers need to pass
    *  deterministic context without polluting the chat transcript. */
   bridgePrompt?: string;
+  sourceIssue?: GitHubIssueSource;
 }
 
 export interface UseTaskLauncherOptions {
@@ -62,6 +63,7 @@ export interface UseTaskLauncherOptions {
       cwd?: string;
       scrollToMatch?: string;
       model?: string;
+      sourceIssue?: GitHubIssueSource;
     },
   ) => void;
   pendingTabOpens: MutableRefObject<Map<string, Promise<unknown>>>;
@@ -152,6 +154,7 @@ export function useTaskLauncher({
       }
       let cwd = project.path;
       let workspaceIdForBucket: string | null | undefined = null;
+      let workspaceBranch: string | undefined;
       if (opts.newWorkspace) {
         const branch = (opts.branch ?? "").trim();
         const created = await createWorkspaceWithParams({
@@ -176,6 +179,7 @@ export function useTaskLauncher({
             (w) => w.path === created,
           );
         workspaceIdForBucket = createdWorkspace?.id ?? null;
+        workspaceBranch = (createdWorkspace?.branch ?? branch) || undefined;
         if (shouldActivate && createdWorkspace)
           activateWorkspace(createdWorkspace.id);
       } else if (opts.workspaceId) {
@@ -185,14 +189,24 @@ export function useTaskLauncher({
         if (wt) {
           cwd = wt.path;
           workspaceIdForBucket = wt.id;
+          workspaceBranch = wt.branch ?? undefined;
           if (shouldActivate) activateWorkspace(wt.id);
         }
       }
       const tabId = crypto.randomUUID();
+      const sourceIssue = opts.sourceIssue
+        ? {
+            ...opts.sourceIssue,
+            branch: workspaceBranch ?? opts.branch ?? opts.sourceIssue.branch,
+            ...(workspaceIdForBucket ? { workspaceId: workspaceIdForBucket } : {}),
+            workspacePath: cwd,
+          }
+        : undefined;
       if (shouldActivate || !setState || !stateRef || !tabBucketsRef) {
         newTab(tabId, opts.label, {
           cwd,
           ...(opts.model ? { model: opts.model } : {}),
+          ...(sourceIssue ? { sourceIssue } : {}),
         });
       } else {
         const activeBucketKey = projectScopeBucketKey(
@@ -239,6 +253,7 @@ export function useTaskLauncher({
             ? { thinkingLevel: inheritedThinkingLevel }
             : {}),
           cwd,
+          ...(sourceIssue ? { sourceIssue } : {}),
         };
         if (targetBucketKey === activeBucketKey) {
           setState((prev) => {

--- a/src/state/sessionUiSnapshot.test.ts
+++ b/src/state/sessionUiSnapshot.test.ts
@@ -102,6 +102,49 @@ describe("sessionUiSnapshot", () => {
     });
   });
 
+  it("round-trips GitHub issue source metadata across save + restore", () => {
+    const sourceIssue = {
+      kind: "github-issue" as const,
+      projectId: "project-1",
+      number: 85,
+      url: "https://github.com/utensils/aethon/issues/85",
+      title: "Cannot rename session tab while agent is running",
+      branch: "fix/issue-85-existing",
+      workspaceId: "wt-85",
+      workspacePath: "/repo/aethon-issue-85",
+      createdAt: 1,
+    };
+    saveSessionUiSnapshot({
+      tabs: [
+        {
+          ...makeEmptyTab("issue-active", "Issue Active", "project-1"),
+          sourceIssue,
+        },
+      ],
+      activeTabId: "issue-active",
+      persistedTabBuckets: {
+        "project-1::workspace::wt-85": {
+          tabs: [
+            {
+              ...makeEmptyTab("issue-hidden", "Issue Hidden", "project-1"),
+              sourceIssue,
+            },
+          ],
+          activeTabId: "issue-hidden",
+        },
+      },
+    });
+
+    expect(loadSessionUiSnapshot()).toMatchObject({
+      tabs: [{ id: "issue-active", sourceIssue }],
+      buckets: {
+        "project-1::workspace::wt-85": {
+          tabs: [{ id: "issue-hidden", sourceIssue }],
+        },
+      },
+    });
+  });
+
   it("persists buckets-only when the active workspace has no sessions", () => {
     // User sitting on a project overview while agents run in its workspaces:
     // state.tabs is empty but a backgrounded bucket has a session.

--- a/src/styles/chrome.css
+++ b/src/styles/chrome.css
@@ -8699,6 +8699,9 @@ button.a2ui-gh-stat:hover {
   background: var(--bg-hover);
   border-color: var(--border-strong, var(--border));
 }
+.a2ui-dashboard-issue-row.is-linked-session {
+  border-color: color-mix(in oklab, var(--accent) 32%, var(--border));
+}
 .a2ui-dashboard-issue-line {
   display: flex;
   gap: var(--space-2);
@@ -8734,6 +8737,45 @@ button.a2ui-gh-stat:hover {
 .a2ui-dashboard-issue-author,
 .a2ui-dashboard-issue-updated,
 .a2ui-dashboard-issue-comments {
+  white-space: nowrap;
+}
+.a2ui-dashboard-issue-session {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: min(100%, 24rem);
+  min-width: 0;
+  padding: 1px var(--space-2);
+  border: 1px solid color-mix(in oklab, var(--accent) 40%, var(--border));
+  border-radius: var(--radius-pill);
+  background: color-mix(in oklab, var(--accent) 12%, transparent);
+  color: var(--text);
+  font: inherit;
+  line-height: 1.2;
+  cursor: pointer;
+}
+.a2ui-dashboard-issue-session[data-state="working"] {
+  background: color-mix(in oklab, var(--accent) 16%, transparent);
+}
+.a2ui-dashboard-issue-session:hover {
+  background: color-mix(in oklab, var(--accent) 18%, transparent);
+  border-color: color-mix(in oklab, var(--accent) 62%, var(--border));
+}
+.a2ui-dashboard-issue-session:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+.a2ui-dashboard-issue-session-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: var(--radius-circle);
+  background: var(--accent);
+  flex: 0 0 auto;
+}
+.a2ui-dashboard-issue-session-text {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 .a2ui-dashboard-issue-label {

--- a/src/types/tab.ts
+++ b/src/types/tab.ts
@@ -108,6 +108,18 @@ export interface ContextUsageState {
 
 export type TabKind = "agent" | "shell" | "editor";
 
+export interface GitHubIssueSource {
+  kind: "github-issue";
+  projectId: string;
+  number: number;
+  url: string;
+  title: string;
+  branch?: string;
+  workspaceId?: string;
+  workspacePath?: string;
+  createdAt: number;
+}
+
 /**
  * A user message held on the client-side queue while a turn is in flight.
  * The popover above the composer renders the list, and the user can edit /
@@ -188,6 +200,10 @@ export interface Tab {
    *  absent → follow the global default. Rides each chat message to the
    *  agent's source guard. Persisted with the tab. */
   hardEnforceProjectRoot?: boolean;
+  /** Origin marker for dashboard-launched sessions. Used to avoid launching
+   *  duplicate agents for the same open GitHub issue and to render issue-row
+   *  status in project dashboards. */
+  sourceIssue?: GitHubIssueSource;
   /** Present iff kind === "shell". */
   shell?: ShellMeta;
   /** Present iff kind === "editor". */


### PR DESCRIPTION
## Summary
- add per-tab GitHub issue source metadata so issue-launched agent sessions can be found across active tabs and stashed workspace buckets
- show a clear working/session indicator on linked GitHub issue rows with branch/worktree context
- route duplicate issue dispatches to the existing session instead of launching a second agent, and clear stale links when issues close or disappear from refresh results

## Validation
- `bunx vitest run src/eventRoutes/dashboard.test.ts src/extensions/default-layout/dashboard/issues-section.test.ts src/extensions/default-layout/dashboard/issue-sessions.test.ts`
- `bunx vitest run src/hooks/useTaskLauncher.test.ts src/state/sessionUiSnapshot.test.ts`
- `bun run typecheck`
- `bun run lint` (passes with existing fast-refresh warning in `src/extensions/default-layout/message-row.tsx`)
- Native dev UAT via `dev`: verified issue #377 rendered with linked-session/worktree indicator and activation landed in the existing issue session/workspace
