### PR TITLE
fix(composer): share textarea input semantics

### DIFF
--- a/src/extensions/default-layout/chat-input.tsx
+++ b/src/extensions/default-layout/chat-input.tsx
@@ -1,8 +1,5 @@
 import {
   createElement,
-  useCallback,
-  useEffect,
-  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -26,21 +23,11 @@ import { useExtensionRegistry } from "../ExtensionRegistry";
 import type { QueuedMessage } from "../../types/tab";
 import { SlashPicker } from "./slash-picker";
 import { AtPicker } from "./at-picker";
-import {
-  atMentionRoot,
-  formatAtMentionInsertion,
-  type AtMentionMatch,
-} from "./at-mention";
-import { useAtMention } from "./use-at-mention";
+import { atMentionRoot } from "./at-mention";
+import { useAtMentionTextarea } from "./use-at-mention-textarea";
 import { useComposerResize } from "./use-composer-resize";
 import { useDraftCommit } from "./use-draft-commit";
-import { useVoiceHotkey } from "../../hooks/useVoiceHotkey";
-import { useVoiceInput } from "../../hooks/useVoiceInput";
 import { useVoiceConversation } from "../../hooks/useVoiceConversation";
-import {
-  insertTranscriptAtSelection,
-  shouldOpenVoiceSettingsForError,
-} from "../../utils/voice";
 import { ConversationHud } from "./conversation-hud";
 import {
   VoiceConversationButton,
@@ -56,6 +43,7 @@ import {
 } from "./use-slash-matching";
 import { ImageAttachmentImage } from "./image-attachment-image";
 import { ImageLightbox } from "./image-lightbox";
+import { useTextareaVoiceInput } from "./use-textarea-voice-input";
 
 export function ChatInput({
   component,
@@ -123,69 +111,27 @@ export function ChatInput({
       commandsRaw: props.commands,
       state,
     });
-  // Caret offset in the draft, tracked so the @file picker knows which
-  // token the user is editing. Updated on change + select (clicks,
-  // arrow keys) and after programmatic insertions.
-  const [cursor, setCursor] = useState(0);
+  const inputContainerRef = useRef<HTMLDivElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const { composerHeight, startComposerResize } = useComposerResize();
   const {
     atMatch,
-    highlightIdx: atHighlightIdx,
-    setHighlightIdx: setAtHighlightIdx,
-    dismissPicker: dismissAtPicker,
-  } = useAtMention({
+    atHighlightIdx,
+    setAtHighlightIdx,
+    setCursor,
+    insertAtMention,
+    handleAtMentionKeyDown,
+  } = useAtMentionTextarea({
     value,
-    cursor,
+    setValue,
+    onValueCommit: commitDraft,
+    textareaRef,
     root: atMentionRoot(state),
     // The slash picker owns the keyboard while it's open; `/command @arg`
     // drafts stay slash-flavored.
     enabled: !slashMatch,
   });
-  const inputContainerRef = useRef<HTMLDivElement>(null);
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const { composerHeight, startComposerResize } = useComposerResize();
-  const handleTranscript = useCallback(
-    (transcript: string, options?: { autoSend?: boolean }) => {
-      const textarea = textareaRef.current;
-      const start = textarea?.selectionStart ?? value.length;
-      const end = textarea?.selectionEnd ?? value.length;
-      const next = insertTranscriptAtSelection(
-        textarea?.value ?? value,
-        transcript,
-        start,
-        end,
-      );
-      setValue(next.text);
-      commitDraft(next.text);
-      setCursor(next.cursor);
-      // Push-to-talk (hold-hotkey release) sends straight away rather than
-      // parking the dictation in the composer for a manual Enter.
-      if (options?.autoSend && next.text.trim().length > 0) {
-        onEvent("submit", {
-          value: next.text,
-          mode: "normal",
-          ...(attachments.length > 0 ? { attachments } : {}),
-        });
-        return;
-      }
-      requestAnimationFrame(() => {
-        const current = textareaRef.current;
-        if (!current) return;
-        current.focus();
-        current.selectionStart = current.selectionEnd = next.cursor;
-      });
-    },
-    [attachments, commitDraft, onEvent, setValue, value],
-  );
   const voiceSurfaceVisible = !!state.agentTabActive;
-  const voice = useVoiceInput(
-    handleTranscript,
-    (providerId) => {
-      onEvent("voice:setup", { providerId });
-    },
-    { surfaceActive: voiceSurfaceVisible },
-  );
-  const voiceState = voice.state;
-  const cancelVoice = voice.cancel;
   const voiceConfig = (state.voice as
     | {
         toggleHotkey?: string | null;
@@ -204,58 +150,30 @@ export function ChatInput({
   const settings = state.settings as { open?: boolean } | undefined;
   const palette = state.commandPalette as { open?: boolean } | undefined;
   const search = state.search as { open?: boolean } | undefined;
-  // The composer and the dashboard task-launcher both mount at once — the
-  // layout grid hides cells with display:none rather than unmounting — so each
-  // registers the same global voice hotkey against one shared mic. Block START
-  // unless this surface actually owns the canvas (`voiceSurfaceVisible` mirrors
-  // the composer-area's `visible: /agentTabActive` binding); otherwise both
-  // hotkeys fire and the loser reports "Voice recording is already active".
-  // Stop/cancel stay live.
-  const voiceInputBlocked =
-    !voiceSurfaceVisible || !!settings?.open || !!palette?.open || !!search?.open;
-  const voiceInputBlockedRef = useRef(voiceInputBlocked);
-  useLayoutEffect(() => {
-    voiceInputBlockedRef.current = voiceInputBlocked;
-  }, [voiceInputBlocked]);
-  const isVoiceInputBlocked = useCallback(
-    () => voiceInputBlockedRef.current,
-    [],
-  );
-  useVoiceHotkey(
-    voice,
-    voiceConfig.toggleHotkey ?? "mod+shift+m",
-    voiceConfig.holdHotkey ?? null,
-    isVoiceInputBlocked,
-    conversation,
-  );
-  const [reducedMotion, setReducedMotion] = useState(() => {
-    if (typeof window === "undefined" || !window.matchMedia) return false;
-    return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-  });
-  useEffect(() => {
-    if (typeof window === "undefined" || !window.matchMedia) return;
-    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
-    const onChange = (event: MediaQueryListEvent) =>
-      setReducedMotion(event.matches);
-    mq.addEventListener?.("change", onChange);
-    return () => mq.removeEventListener?.("change", onChange);
-  }, []);
-  useEffect(() => {
-    if (voiceState !== "recording") return;
-    const onKey = (event: globalThis.KeyboardEvent) => {
-      if (event.key !== "Escape") return;
-      event.preventDefault();
-      event.stopPropagation();
-      cancelVoice();
-    };
-    window.addEventListener("keydown", onKey, true);
-    return () => window.removeEventListener("keydown", onKey, true);
-  }, [voiceState, cancelVoice]);
-  const useDynamicMeter =
-    !reducedMotion && voice.activeProvider?.recordingMode === "native";
-  const voiceErrorOpensSettings = shouldOpenVoiceSettingsForError(
-    voice.activeProvider,
-  );
+  const { voice, useDynamicMeter, voiceErrorOpensSettings } =
+    useTextareaVoiceInput({
+      value,
+      setValue,
+      onValueCommit: commitDraft,
+      setCursor,
+      textareaRef,
+      surfaceActive: voiceSurfaceVisible,
+      overlays: {
+        settingsOpen: settings?.open,
+        paletteOpen: palette?.open,
+        searchOpen: search?.open,
+      },
+      voiceConfig,
+      onNeedsSetup: (providerId) => onEvent("voice:setup", { providerId }),
+      onAutoSend: (text) => {
+        onEvent("submit", {
+          value: text,
+          mode: "normal",
+          ...(attachments.length > 0 ? { attachments } : {}),
+        });
+      },
+      conversation,
+    });
 
   const insertMatch = (m: PickerMatch) => {
     const text =
@@ -264,25 +182,6 @@ export function ChatInput({
         : `/${m.cmd.name} ${m.choice.value}`;
     setValue(text);
     commitDraft(text);
-  };
-
-  // Replace the active `@token` with the chosen mention and park
-  // the caret after the trailing space so typing continues naturally.
-  const insertAtMention = (m: AtMentionMatch) => {
-    if (!atMatch) return;
-    const insertion = formatAtMentionInsertion(m);
-    const next =
-      value.slice(0, atMatch.start) + insertion + value.slice(atMatch.end);
-    const nextCursor = atMatch.start + insertion.length;
-    setValue(next);
-    commitDraft(next);
-    setCursor(nextCursor);
-    requestAnimationFrame(() => {
-      const current = textareaRef.current;
-      if (!current) return;
-      current.focus();
-      current.selectionStart = current.selectionEnd = nextCursor;
-    });
   };
 
   const submitPayload = (value: string, mode: "normal" | "steer") => ({
@@ -370,43 +269,7 @@ export function ChatInput({
         return;
       }
     }
-    if (!slashMatch && atMatch) {
-      const list = atMatch.matches;
-      if (e.key === "ArrowDown") {
-        e.preventDefault();
-        setAtHighlightIdx((i) => (i + 1) % list.length);
-        return;
-      }
-      if (e.key === "ArrowUp") {
-        e.preventDefault();
-        setAtHighlightIdx((i) => (i - 1 + list.length) % list.length);
-        return;
-      }
-      if (e.key === "Tab") {
-        e.preventDefault();
-        const match = list[atHighlightIdx] ?? list[0];
-        if (match) insertAtMention(match);
-        return;
-      }
-      if (e.key === "Enter" && !e.shiftKey) {
-        const match = list[atHighlightIdx] ?? list[0];
-        // Exact file references submit like before. Agent mentions complete
-        // first so `@kimi` becomes `@kimi ` before a later Enter sends.
-        const exactFile = list.some(
-          (m) => m.kind === "file" && m.rel === atMatch.query,
-        );
-        if (match?.kind === "agent" || !exactFile) {
-          e.preventDefault();
-          if (match) insertAtMention(match);
-          return;
-        }
-      }
-      if (e.key === "Escape") {
-        e.preventDefault();
-        dismissAtPicker();
-        return;
-      }
-    }
+    if (!slashMatch && handleAtMentionKeyDown(e)) return;
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       submit("normal");

--- a/src/extensions/default-layout/dashboard/task-launcher.tsx
+++ b/src/extensions/default-layout/dashboard/task-launcher.tsx
@@ -19,7 +19,6 @@
 import {
   useCallback,
   useEffect,
-  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -29,17 +28,11 @@ import type { ChatAttachment } from "../../../types/a2ui";
 import { resolvePointer } from "../../../utils/jsonPointer";
 import { DEFAULT_WORKSPACE_BASE_BRANCH } from "../../../projects";
 import { saveClipboardImageAttachment } from "../../../utils/imageAttachments";
-import { useVoiceHotkey } from "../../../hooks/useVoiceHotkey";
-import { useVoiceInput } from "../../../hooks/useVoiceInput";
-import {
-  insertTranscriptAtSelection,
-  shouldOpenVoiceSettingsForError,
-} from "../../../utils/voice";
 import { ImageAttachmentImage } from "../image-attachment-image";
 import { ImageLightbox } from "../image-lightbox";
 import { AtPicker } from "../at-picker";
-import { formatAtMentionInsertion, type AtMentionMatch } from "../at-mention";
-import { useAtMention } from "../use-at-mention";
+import { useAtMentionTextarea } from "../use-at-mention-textarea";
+import { useTextareaVoiceInput } from "../use-textarea-voice-input";
 import { VoiceInputButton, VoiceStatus } from "../voice-controls";
 
 interface ProjectLite {
@@ -286,44 +279,25 @@ export function TaskLauncher({
   // workspace, else the project root (a "+ New workspace" forks from the
   // project, so its files are the right suggestions too).
   const launcherRef = useRef<HTMLDivElement | null>(null);
-  const [cursor, setCursor] = useState(0);
   const atRoot =
     workspaceChoice.kind === "existing"
       ? workspaceChoice.path
       : (selectedProject?.path ?? null);
   const {
     atMatch,
-    highlightIdx: atHighlightIdx,
-    setHighlightIdx: setAtHighlightIdx,
-    dismissPicker: dismissAtPicker,
-  } = useAtMention({
+    atHighlightIdx,
+    setAtHighlightIdx,
+    setCursor,
+    insertAtMention,
+    handleAtMentionKeyDown,
+  } = useAtMentionTextarea({
     value: promptText,
-    cursor,
+    setValue: setPromptText,
+    onValueCommit: () => setTouched(true),
+    textareaRef,
     root: atRoot,
     enabled: !submitting,
   });
-
-  const insertAtMention = useCallback(
-    (m: AtMentionMatch) => {
-      if (!atMatch) return;
-      const insertion = formatAtMentionInsertion(m);
-      const next =
-        promptText.slice(0, atMatch.start) +
-        insertion +
-        promptText.slice(atMatch.end);
-      const nextCursor = atMatch.start + insertion.length;
-      setPromptText(next);
-      setTouched(true);
-      setCursor(nextCursor);
-      requestAnimationFrame(() => {
-        const el = textareaRef.current;
-        if (!el) return;
-        el.focus();
-        el.selectionStart = el.selectionEnd = nextCursor;
-      });
-    },
-    [atMatch, promptText],
-  );
 
   const submitPrompt = useCallback((rawPrompt: string) => {
     if (submitting) return;
@@ -375,50 +349,13 @@ export function TaskLauncher({
     submitPrompt(promptText);
   }, [promptText, submitPrompt]);
 
-  const handleTranscript = useCallback(
-    (transcript: string, options?: { autoSend?: boolean }) => {
-      const textarea = textareaRef.current;
-      const start = textarea?.selectionStart ?? promptText.length;
-      const end = textarea?.selectionEnd ?? promptText.length;
-      const next = insertTranscriptAtSelection(
-        textarea?.value ?? promptText,
-        transcript,
-        start,
-        end,
-      );
-      setPromptText(next.text);
-      setTouched(true);
-      setCursor(next.cursor);
-      if (options?.autoSend && next.text.trim().length > 0) {
-        submitPrompt(next.text);
-        return;
-      }
-      requestAnimationFrame(() => {
-        const el = textareaRef.current;
-        if (!el) return;
-        el.focus();
-        el.selectionStart = el.selectionEnd = next.cursor;
-      });
-    },
-    [promptText, submitPrompt],
-  );
   // The dashboard task-launcher and the composer both mount at once — the
   // layout grid hides cells with display:none rather than unmounting — so each
   // registers the same global voice hotkey against one shared mic. Track
   // whether this dashboard actually owns the canvas (mirrors the
   // project-dashboard's `visible: /emptyAndProject` binding) so it neither
-  // starts while hidden nor keeps holding the slot after being hidden;
-  // otherwise both hotkeys fire and the loser reports "already active".
+  // starts while hidden nor keeps holding the slot after being hidden.
   const voiceSurfaceVisible = !!state.emptyAndProject;
-  const voice = useVoiceInput(
-    handleTranscript,
-    (providerId) => {
-      onEvent("voice:setup", { providerId });
-    },
-    { surfaceActive: voiceSurfaceVisible },
-  );
-  const voiceState = voice.state;
-  const cancelVoice = voice.cancel;
   const voiceConfig = (state.voice as
     | {
         toggleHotkey?: string | null;
@@ -428,93 +365,27 @@ export function TaskLauncher({
   const settings = state.settings as { open?: boolean } | undefined;
   const palette = state.commandPalette as { open?: boolean } | undefined;
   const search = state.search as { open?: boolean } | undefined;
-  const voiceInputBlocked =
-    submitting ||
-    !voiceSurfaceVisible ||
-    !!settings?.open ||
-    !!palette?.open ||
-    !!search?.open;
-  const voiceInputBlockedRef = useRef(voiceInputBlocked);
-  useLayoutEffect(() => {
-    voiceInputBlockedRef.current = voiceInputBlocked;
-  }, [voiceInputBlocked]);
-  const isVoiceInputBlocked = useCallback(
-    () => voiceInputBlockedRef.current,
-    [],
-  );
-  useVoiceHotkey(
-    voice,
-    voiceConfig.toggleHotkey ?? "mod+shift+m",
-    voiceConfig.holdHotkey ?? null,
-    isVoiceInputBlocked,
-  );
-  useEffect(() => {
-    if (voiceState !== "recording") return;
-    const onKeyDown = (event: globalThis.KeyboardEvent) => {
-      if (event.key !== "Escape") return;
-      event.preventDefault();
-      event.stopPropagation();
-      cancelVoice();
-    };
-    window.addEventListener("keydown", onKeyDown, true);
-    return () => window.removeEventListener("keydown", onKeyDown, true);
-  }, [voiceState, cancelVoice]);
-  const [reducedMotion, setReducedMotion] = useState(() => {
-    if (typeof window === "undefined" || !window.matchMedia) return false;
-    return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-  });
-  useEffect(() => {
-    if (typeof window === "undefined" || !window.matchMedia) return;
-    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
-    const onChange = (event: MediaQueryListEvent) =>
-      setReducedMotion(event.matches);
-    mq.addEventListener?.("change", onChange);
-    return () => mq.removeEventListener?.("change", onChange);
-  }, []);
-  const useDynamicMeter =
-    !reducedMotion && voice.activeProvider?.recordingMode === "native";
-  const voiceErrorOpensSettings = shouldOpenVoiceSettingsForError(
-    voice.activeProvider,
-  );
+  const { voice, useDynamicMeter, voiceErrorOpensSettings } =
+    useTextareaVoiceInput({
+      value: promptText,
+      setValue: setPromptText,
+      onValueCommit: () => setTouched(true),
+      setCursor,
+      textareaRef,
+      surfaceActive: voiceSurfaceVisible,
+      disabled: submitting,
+      overlays: {
+        settingsOpen: settings?.open,
+        paletteOpen: palette?.open,
+        searchOpen: search?.open,
+      },
+      voiceConfig,
+      onNeedsSetup: (providerId) => onEvent("voice:setup", { providerId }),
+      onAutoSend: submitPrompt,
+    });
 
   const onKey = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (atMatch) {
-      const list = atMatch.matches;
-      if (e.key === "ArrowDown") {
-        e.preventDefault();
-        setAtHighlightIdx((i) => (i + 1) % list.length);
-        return;
-      }
-      if (e.key === "ArrowUp") {
-        e.preventDefault();
-        setAtHighlightIdx((i) => (i - 1 + list.length) % list.length);
-        return;
-      }
-      if (e.key === "Tab") {
-        e.preventDefault();
-        const match = list[atHighlightIdx] ?? list[0];
-        if (match) insertAtMention(match);
-        return;
-      }
-      if (e.key === "Enter" && !e.shiftKey) {
-        const match = list[atHighlightIdx] ?? list[0];
-        // A hand-typed exact file reference submits; partial tokens and agent
-        // mentions complete first.
-        const exactFile = list.some(
-          (m) => m.kind === "file" && m.rel === atMatch.query,
-        );
-        if (match?.kind === "agent" || !exactFile) {
-          e.preventDefault();
-          if (match) insertAtMention(match);
-          return;
-        }
-      }
-      if (e.key === "Escape") {
-        e.preventDefault();
-        dismissAtPicker();
-        return;
-      }
-    }
+    if (handleAtMentionKeyDown(e)) return;
     // Plain Enter submits; Shift+Enter adds a newline. Matches the main
     // chat composer. Cmd/Ctrl+Enter also submits for users who hold
     // modifiers out of habit.

--- a/src/extensions/default-layout/textarea-input-semantics.test.ts
+++ b/src/extensions/default-layout/textarea-input-semantics.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import type { AtMention } from "./at-mention";
+import {
+  insertMentionAtCursor,
+  isVoiceSurfaceBlocked,
+  shouldSubmitAtMentionEnter,
+} from "./textarea-input-semantics";
+
+const agent = { kind: "agent" as const, name: "kimi", description: "review", surface: "inline" as const };
+const file = (rel: string) => ({ kind: "file" as const, rel, path: `/repo/${rel}` });
+
+function at(query: string, matches = [agent, file("src/App.tsx")]): AtMention {
+  return { query, start: 0, end: query.length + 1, matches };
+}
+
+describe("shared textarea input semantics", () => {
+  it("cycles @ picker rows with Arrow navigation outside surface code", () => {
+    const list = [0, 1, 2];
+    expect((0 + 1) % list.length).toBe(1);
+    expect((0 - 1 + list.length) % list.length).toBe(2);
+  });
+
+  it("inserts the selected @ mention text and cursor position for Tab-style completion", () => {
+    expect(
+      insertMentionAtCursor({
+        value: "please @ki now",
+        atMatch: { ...at("ki", [agent]), start: 7, end: 10 },
+        match: agent,
+      }),
+    ).toEqual({ text: "please @kimi  now", cursor: 13 });
+  });
+
+  it("completes partial file mentions on Enter before submit", () => {
+    expect(
+      shouldSubmitAtMentionEnter({
+        atMatch: at("app", [file("src/App.tsx")]),
+        highlightedMatch: file("src/App.tsx"),
+      }),
+    ).toBe(false);
+  });
+
+  it("completes exact agent mentions on Enter before submit", () => {
+    expect(
+      shouldSubmitAtMentionEnter({
+        atMatch: at("kimi", [agent]),
+        highlightedMatch: agent,
+      }),
+    ).toBe(false);
+  });
+
+  it("submits exact file path mentions on Enter", () => {
+    expect(
+      shouldSubmitAtMentionEnter({
+        atMatch: at("src/App.tsx", [file("src/App.tsx")]),
+        highlightedMatch: file("src/App.tsx"),
+      }),
+    ).toBe(true);
+  });
+
+  it.each([
+    ["hidden surface", { surfaceActive: false }, true],
+    ["Settings open", { surfaceActive: true, settingsOpen: true }, true],
+    ["palette open", { surfaceActive: true, paletteOpen: true }, true],
+    ["search open", { surfaceActive: true, searchOpen: true }, true],
+    ["visible surface", { surfaceActive: true }, false],
+  ] as const)("blocks voice start for %s", (_label, state, expected) => {
+    expect(isVoiceSurfaceBlocked(state)).toBe(expected);
+  });
+});

--- a/src/extensions/default-layout/textarea-input-semantics.test.ts
+++ b/src/extensions/default-layout/textarea-input-semantics.test.ts
@@ -6,20 +6,23 @@ import {
   shouldSubmitAtMentionEnter,
 } from "./textarea-input-semantics";
 
-const agent = { kind: "agent" as const, name: "kimi", description: "review", surface: "inline" as const };
-const file = (rel: string) => ({ kind: "file" as const, rel, path: `/repo/${rel}` });
+const agent = {
+  kind: "agent" as const,
+  name: "kimi",
+  description: "review",
+  surface: "inline" as const,
+};
+const file = (rel: string) => ({
+  kind: "file" as const,
+  rel,
+  path: `/repo/${rel}`,
+});
 
 function at(query: string, matches = [agent, file("src/App.tsx")]): AtMention {
   return { query, start: 0, end: query.length + 1, matches };
 }
 
 describe("shared textarea input semantics", () => {
-  it("cycles @ picker rows with Arrow navigation outside surface code", () => {
-    const list = [0, 1, 2];
-    expect((0 + 1) % list.length).toBe(1);
-    expect((0 - 1 + list.length) % list.length).toBe(2);
-  });
-
   it("inserts the selected @ mention text and cursor position for Tab-style completion", () => {
     expect(
       insertMentionAtCursor({
@@ -62,6 +65,7 @@ describe("shared textarea input semantics", () => {
     ["Settings open", { surfaceActive: true, settingsOpen: true }, true],
     ["palette open", { surfaceActive: true, paletteOpen: true }, true],
     ["search open", { surfaceActive: true, searchOpen: true }, true],
+    ["disabled textarea", { surfaceActive: true, disabled: true }, true],
     ["visible surface", { surfaceActive: true }, false],
   ] as const)("blocks voice start for %s", (_label, state, expected) => {
     expect(isVoiceSurfaceBlocked(state)).toBe(expected);

--- a/src/extensions/default-layout/textarea-input-semantics.ts
+++ b/src/extensions/default-layout/textarea-input-semantics.ts
@@ -1,0 +1,66 @@
+import type { RefObject } from "react";
+import type { AtMention, AtMentionMatch } from "./at-mention";
+import { formatAtMentionInsertion } from "./at-mention";
+
+export interface VoiceSurfaceBlockState {
+  surfaceActive: boolean;
+  settingsOpen?: boolean;
+  paletteOpen?: boolean;
+  searchOpen?: boolean;
+  disabled?: boolean;
+}
+
+export function isVoiceSurfaceBlocked({
+  surfaceActive,
+  settingsOpen,
+  paletteOpen,
+  searchOpen,
+  disabled,
+}: VoiceSurfaceBlockState): boolean {
+  return (
+    !!disabled ||
+    !surfaceActive ||
+    !!settingsOpen ||
+    !!paletteOpen ||
+    !!searchOpen
+  );
+}
+
+export function shouldSubmitAtMentionEnter({
+  atMatch,
+  highlightedMatch,
+}: {
+  atMatch: AtMention;
+  highlightedMatch: AtMentionMatch | undefined;
+}): boolean {
+  if (highlightedMatch?.kind === "agent") return false;
+  return atMatch.matches.some(
+    (match) => match.kind === "file" && match.rel === atMatch.query,
+  );
+}
+
+export function insertMentionAtCursor({
+  value,
+  atMatch,
+  match,
+}: {
+  value: string;
+  atMatch: AtMention;
+  match: AtMentionMatch;
+}): { text: string; cursor: number } {
+  const insertion = formatAtMentionInsertion(match);
+  const text = value.slice(0, atMatch.start) + insertion + value.slice(atMatch.end);
+  return { text, cursor: atMatch.start + insertion.length };
+}
+
+export function restoreTextareaCursor(
+  textareaRef: RefObject<HTMLTextAreaElement | null>,
+  cursor: number,
+): void {
+  requestAnimationFrame(() => {
+    const current = textareaRef.current;
+    if (!current) return;
+    current.focus();
+    current.selectionStart = current.selectionEnd = cursor;
+  });
+}

--- a/src/extensions/default-layout/use-at-mention-textarea.ts
+++ b/src/extensions/default-layout/use-at-mention-textarea.ts
@@ -1,0 +1,94 @@
+import { useCallback, useState, type KeyboardEvent, type RefObject } from "react";
+import type { AtMentionMatch } from "./at-mention";
+import { useAtMention } from "./use-at-mention";
+import {
+  insertMentionAtCursor,
+  restoreTextareaCursor,
+  shouldSubmitAtMentionEnter,
+} from "./textarea-input-semantics";
+
+export function useAtMentionTextarea({
+  value,
+  setValue,
+  onValueCommit,
+  textareaRef,
+  root,
+  enabled,
+}: {
+  value: string;
+  setValue: (value: string) => void;
+  onValueCommit?: (value: string) => void;
+  textareaRef: RefObject<HTMLTextAreaElement | null>;
+  root: string | null;
+  enabled: boolean;
+}) {
+  const [cursor, setCursor] = useState(0);
+  const {
+    atMatch,
+    highlightIdx,
+    setHighlightIdx,
+    dismissPicker,
+  } = useAtMention({ value, cursor, root, enabled });
+
+  const insertAtMention = useCallback(
+    (match: AtMentionMatch) => {
+      if (!atMatch) return;
+      const next = insertMentionAtCursor({ value, atMatch, match });
+      setValue(next.text);
+      onValueCommit?.(next.text);
+      setCursor(next.cursor);
+      restoreTextareaCursor(textareaRef, next.cursor);
+    },
+    [atMatch, onValueCommit, setValue, textareaRef, value],
+  );
+
+  const handleAtMentionKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLTextAreaElement>): boolean => {
+      if (!atMatch) return false;
+      const list = atMatch.matches;
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        setHighlightIdx((i) => (i + 1) % list.length);
+        return true;
+      }
+      if (event.key === "ArrowUp") {
+        event.preventDefault();
+        setHighlightIdx((i) => (i - 1 + list.length) % list.length);
+        return true;
+      }
+      if (event.key === "Tab") {
+        event.preventDefault();
+        const match = list[highlightIdx] ?? list[0];
+        if (match) insertAtMention(match);
+        return true;
+      }
+      if (event.key === "Enter" && !event.shiftKey) {
+        const match = list[highlightIdx] ?? list[0];
+        if (!shouldSubmitAtMentionEnter({ atMatch, highlightedMatch: match })) {
+          event.preventDefault();
+          if (match) insertAtMention(match);
+          return true;
+        }
+        return false;
+      }
+      if (event.key === "Escape") {
+        event.preventDefault();
+        dismissPicker();
+        return true;
+      }
+      return false;
+    },
+    [atMatch, dismissPicker, highlightIdx, insertAtMention, setHighlightIdx],
+  );
+
+  return {
+    atMatch,
+    atHighlightIdx: highlightIdx,
+    setAtHighlightIdx: setHighlightIdx,
+    cursor,
+    setCursor,
+    insertAtMention,
+    dismissAtPicker: dismissPicker,
+    handleAtMentionKeyDown,
+  };
+}

--- a/src/extensions/default-layout/use-textarea-voice-input.ts
+++ b/src/extensions/default-layout/use-textarea-voice-input.ts
@@ -1,0 +1,132 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type RefObject,
+} from "react";
+import type { ConversationHotkeyHandle } from "../../hooks/useVoiceHotkey";
+import { useVoiceHotkey } from "../../hooks/useVoiceHotkey";
+import { useVoiceInput } from "../../hooks/useVoiceInput";
+import { insertTranscriptAtSelection, shouldOpenVoiceSettingsForError } from "../../utils/voice";
+import { isVoiceSurfaceBlocked, restoreTextareaCursor } from "./textarea-input-semantics";
+
+export interface TextareaVoiceInputConfig {
+  toggleHotkey?: string | null;
+  holdHotkey?: string | null;
+}
+
+export interface TextareaVoiceInputOverlayState {
+  settingsOpen?: boolean;
+  paletteOpen?: boolean;
+  searchOpen?: boolean;
+}
+
+export function useTextareaVoiceInput({
+  value,
+  setValue,
+  onValueCommit,
+  setCursor,
+  textareaRef,
+  surfaceActive,
+  disabled = false,
+  overlays,
+  voiceConfig,
+  onNeedsSetup,
+  onAutoSend,
+  conversation,
+}: {
+  value: string;
+  setValue: (value: string) => void;
+  onValueCommit?: (value: string) => void;
+  setCursor?: (cursor: number) => void;
+  textareaRef: RefObject<HTMLTextAreaElement | null>;
+  surfaceActive: boolean;
+  disabled?: boolean;
+  overlays?: TextareaVoiceInputOverlayState;
+  voiceConfig: TextareaVoiceInputConfig;
+  onNeedsSetup: (providerId: string) => void;
+  onAutoSend: (text: string) => void;
+  conversation?: ConversationHotkeyHandle;
+}) {
+  const handleTranscript = useCallback(
+    (transcript: string, options?: { autoSend?: boolean }) => {
+      const textarea = textareaRef.current;
+      const start = textarea?.selectionStart ?? value.length;
+      const end = textarea?.selectionEnd ?? value.length;
+      const next = insertTranscriptAtSelection(
+        textarea?.value ?? value,
+        transcript,
+        start,
+        end,
+      );
+      setValue(next.text);
+      onValueCommit?.(next.text);
+      setCursor?.(next.cursor);
+      if (options?.autoSend && next.text.trim().length > 0) {
+        onAutoSend(next.text);
+        return;
+      }
+      restoreTextareaCursor(textareaRef, next.cursor);
+    },
+    [onAutoSend, onValueCommit, setCursor, setValue, textareaRef, value],
+  );
+
+  const voice = useVoiceInput(handleTranscript, onNeedsSetup, { surfaceActive });
+  const voiceInputBlocked = isVoiceSurfaceBlocked({
+    surfaceActive,
+    disabled,
+    settingsOpen: overlays?.settingsOpen,
+    paletteOpen: overlays?.paletteOpen,
+    searchOpen: overlays?.searchOpen,
+  });
+  const voiceInputBlockedRef = useRef(voiceInputBlocked);
+  useLayoutEffect(() => {
+    voiceInputBlockedRef.current = voiceInputBlocked;
+  }, [voiceInputBlocked]);
+  const isVoiceInputBlocked = useCallback(
+    () => voiceInputBlockedRef.current,
+    [],
+  );
+  useVoiceHotkey(
+    voice,
+    voiceConfig.toggleHotkey ?? "mod+shift+m",
+    voiceConfig.holdHotkey ?? null,
+    isVoiceInputBlocked,
+    conversation,
+  );
+
+  const voiceState = voice.state;
+  const cancelVoice = voice.cancel;
+  useEffect(() => {
+    if (voiceState !== "recording") return;
+    const onKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      cancelVoice();
+    };
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => window.removeEventListener("keydown", onKeyDown, true);
+  }, [voiceState, cancelVoice]);
+
+  const [reducedMotion, setReducedMotion] = useState(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return false;
+    return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  });
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const onChange = (event: MediaQueryListEvent) => setReducedMotion(event.matches);
+    mq.addEventListener?.("change", onChange);
+    return () => mq.removeEventListener?.("change", onChange);
+  }, []);
+
+  return {
+    voice,
+    useDynamicMeter: !reducedMotion && voice.activeProvider?.recordingMode === "native",
+    voiceErrorOpensSettings: shouldOpenVoiceSettingsForError(voice.activeProvider),
+    voiceInputBlocked,
+  };
+}


### PR DESCRIPTION
## Summary
- Extract shared textarea semantics for @mention insertion/Enter decisions and voice surface blocking.
- Add narrow hooks for @mention textarea behavior and textarea voice input reuse across ChatInput and TaskLauncher.
- Rewire ChatInput and TaskLauncher while keeping slash/queue semantics and task payload/chip behavior local.

Closes #377.

## Validation
- bunx vitest run src/extensions/default-layout/textarea-input-semantics.test.ts src/extensions/default-layout/chat.test.tsx src/extensions/default-layout/dashboard/task-launcher.test.tsx
- bun run typecheck
- bunx eslint src/extensions/default-layout/chat-input.tsx src/extensions/default-layout/dashboard/task-launcher.tsx src/extensions/default-layout/textarea-input-semantics.ts src/extensions/default-layout/use-at-mention-textarea.ts src/extensions/default-layout/use-textarea-voice-input.ts src/extensions/default-layout/textarea-input-semantics.test.ts
- bunx vitest run
- codex review --uncommitted --title "Issue 377 shared textarea semantics" (no correctness issues found)

Note: full Vitest run passed with existing jsdom/WebGL/unknown-component warning noise.