### PR TITLE
refactor(chat): split scroll-follow controllers

### DIFF
--- a/src/extensions/default-layout/scrollFollowStore.test.ts
+++ b/src/extensions/default-layout/scrollFollowStore.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import type { ChatMessage } from "../../types/a2ui";
+import { buildTranscriptRows } from "../../utils/transcriptRows";
+import {
+  createTabScrollAnchorStore,
+  dropStaleRestoreAnchor,
+  initialIndexForRestoreAnchor,
+  updateAnchorFromRange,
+  updateAnchorFromUserScroll,
+} from "./scrollFollowStore";
+
+const messages: ChatMessage[] = [
+  { id: "m0", role: "user", text: "zero" },
+  { id: "m1", role: "agent", text: "one" },
+  { id: "m2", role: "user", text: "two" },
+];
+const rows = buildTranscriptRows(messages, "show", new Set()).rows;
+
+describe("scrollFollowStore", () => {
+  it("stores anchors only while not following and maps restore indexes", () => {
+    const store = createTabScrollAnchorStore();
+
+    updateAnchorFromRange({
+      following: true,
+      range: { startIndex: 1, endIndex: 2 },
+      rows,
+      store,
+      tabId: "tab",
+    });
+    expect(store.get("tab")).toBeUndefined();
+
+    updateAnchorFromRange({
+      following: false,
+      range: { startIndex: 1, endIndex: 2 },
+      rows,
+      store,
+      tabId: "tab",
+    });
+    expect(store.get("tab")).toBe("m2");
+    expect(
+      initialIndexForRestoreAnchor({ rows, restoreAnchorId: "m2" })
+        .initialTopMostItemIndex,
+    ).toEqual({ index: 1, align: "start" });
+  });
+
+  it("deletes cached anchors when a genuine user scroll reaches bottom", () => {
+    const store = createTabScrollAnchorStore();
+    store.set("tab", "m1");
+
+    updateAnchorFromUserScroll({
+      atBottom: true,
+      range: { startIndex: 1, endIndex: 2 },
+      rows,
+      store,
+      tabId: "tab",
+    });
+
+    expect(store.get("tab")).toBeUndefined();
+  });
+
+  it("drops stale restore anchors and reports whether it deleted one", () => {
+    const store = createTabScrollAnchorStore();
+    store.set("tab", "missing");
+
+    expect(
+      dropStaleRestoreAnchor({
+        restoreAnchorId: "missing",
+        restoreIndex: -1,
+        store,
+        tabId: "tab",
+      }),
+    ).toBe(true);
+    expect(store.get("tab")).toBeUndefined();
+  });
+});

--- a/src/extensions/default-layout/scrollFollowStore.ts
+++ b/src/extensions/default-layout/scrollFollowStore.ts
@@ -1,0 +1,112 @@
+import type { ListRange } from "react-virtuoso";
+import {
+  anchorMessageIdForRow,
+  findRowIndexForMessageId,
+  type TranscriptRow,
+} from "../../utils/transcriptRows";
+
+export interface TabScrollAnchorStore {
+  clear(): void;
+  delete(tabId: string): void;
+  get(tabId: string): string | undefined;
+  has(tabId: string): boolean;
+  set(tabId: string, anchorId: string): void;
+}
+
+export function createTabScrollAnchorStore(): TabScrollAnchorStore {
+  const anchors = new Map<string, string>();
+  return {
+    clear: () => anchors.clear(),
+    delete: (tabId) => anchors.delete(tabId),
+    get: (tabId) => anchors.get(tabId),
+    has: (tabId) => anchors.has(tabId),
+    set: (tabId, anchorId) => anchors.set(tabId, anchorId),
+  };
+}
+
+export const defaultTabScrollAnchorStore = createTabScrollAnchorStore();
+
+export function restoreAnchorForTab(
+  store: TabScrollAnchorStore,
+  tabId: string | undefined,
+): string | undefined {
+  return tabId === undefined ? undefined : store.get(tabId);
+}
+
+export function initialIndexForRestoreAnchor({
+  rows,
+  restoreAnchorId,
+}: {
+  rows: TranscriptRow[];
+  restoreAnchorId: string | undefined;
+}): {
+  initialTopMostItemIndex: { index: number; align: "start" | "end" };
+  restoreIndex: number;
+} {
+  const restoreIndex = restoreAnchorId
+    ? findRowIndexForMessageId(rows, restoreAnchorId)
+    : -1;
+  return {
+    restoreIndex,
+    initialTopMostItemIndex:
+      restoreIndex >= 0
+        ? { index: restoreIndex, align: "start" }
+        : { index: Math.max(0, rows.length - 1), align: "end" },
+  };
+}
+
+export function updateAnchorFromRange({
+  following,
+  range,
+  rows,
+  store,
+  tabId,
+}: {
+  following: boolean;
+  range: ListRange;
+  rows: TranscriptRow[];
+  store: TabScrollAnchorStore;
+  tabId: string | undefined;
+}): void {
+  if (tabId === undefined || following) return;
+  const anchorId = anchorMessageIdForRow(rows[range.startIndex]);
+  if (anchorId) store.set(tabId, anchorId);
+}
+
+export function updateAnchorFromUserScroll({
+  atBottom,
+  range,
+  rows,
+  store,
+  tabId,
+}: {
+  atBottom: boolean;
+  range: ListRange | null;
+  rows: TranscriptRow[];
+  store: TabScrollAnchorStore;
+  tabId: string | undefined;
+}): void {
+  if (tabId === undefined) return;
+  if (atBottom) {
+    store.delete(tabId);
+    return;
+  }
+  const anchorId = anchorMessageIdForRow(rows[range?.startIndex ?? 0]);
+  if (anchorId) store.set(tabId, anchorId);
+}
+
+export function dropStaleRestoreAnchor({
+  restoreAnchorId,
+  restoreIndex,
+  store,
+  tabId,
+}: {
+  restoreAnchorId: string | undefined;
+  restoreIndex: number;
+  store: TabScrollAnchorStore;
+  tabId: string | undefined;
+}): boolean {
+  if (!restoreAnchorId || restoreIndex >= 0 || tabId === undefined) return false;
+  store.delete(tabId);
+  return true;
+}

--- a/src/extensions/default-layout/scrollIntentTracker.test.ts
+++ b/src/extensions/default-layout/scrollIntentTracker.test.ts
@@ -28,12 +28,12 @@ describe("scrollIntentTracker", () => {
     const input = document.createElement("input");
     scroller.append(input);
 
-    expect(isUserScrollIntentEvent(new KeyboardEvent("keydown", { key: "PageUp" }))).toBe(
-      true,
-    );
-    expect(isUserScrollIntentEvent(new KeyboardEvent("keydown", { key: "Enter" }))).toBe(
-      false,
-    );
+    expect(
+      isUserScrollIntentEvent(new KeyboardEvent("keydown", { key: "PageUp" })),
+    ).toBe(true);
+    expect(
+      isUserScrollIntentEvent(new KeyboardEvent("keydown", { key: "Enter" })),
+    ).toBe(false);
     input.dispatchEvent(new KeyboardEvent("keydown", { key: "PageDown" }));
     const event = new KeyboardEvent("keydown", { key: "PageDown" });
     Object.defineProperty(event, "target", { value: input });
@@ -45,6 +45,7 @@ describe("scrollIntentTracker", () => {
     const scroller = document.createElement("div");
     const tracker = createScrollIntentTracker(onScroll);
     tracker.attach(scroller);
+    scroller.dispatchEvent(new WheelEvent("wheel"));
     tracker.detach();
 
     scroller.dispatchEvent(new WheelEvent("wheel"));

--- a/src/extensions/default-layout/scrollIntentTracker.test.ts
+++ b/src/extensions/default-layout/scrollIntentTracker.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+import {
+  createScrollIntentTracker,
+  isUserScrollIntentEvent,
+} from "./scrollIntentTracker";
+
+describe("scrollIntentTracker", () => {
+  it("distinguishes user scroll intent from programmatic scroll events", () => {
+    const onScroll = vi.fn();
+    const scroller = document.createElement("div");
+    const tracker = createScrollIntentTracker(onScroll);
+    tracker.attach(scroller);
+
+    scroller.dispatchEvent(new Event("scroll"));
+    expect(onScroll).toHaveBeenCalledTimes(1);
+    expect(tracker.consumeUserIntent()).toBe(false);
+
+    scroller.dispatchEvent(new WheelEvent("wheel"));
+    scroller.dispatchEvent(new Event("scroll"));
+    expect(onScroll).toHaveBeenCalledTimes(2);
+    expect(tracker.consumeUserIntent()).toBe(true);
+    expect(tracker.consumeUserIntent()).toBe(false);
+  });
+
+  it("treats only scroll keys outside interactive controls as keyboard intent", () => {
+    const scroller = document.createElement("div");
+    const input = document.createElement("input");
+    scroller.append(input);
+
+    expect(isUserScrollIntentEvent(new KeyboardEvent("keydown", { key: "PageUp" }))).toBe(
+      true,
+    );
+    expect(isUserScrollIntentEvent(new KeyboardEvent("keydown", { key: "Enter" }))).toBe(
+      false,
+    );
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "PageDown" }));
+    const event = new KeyboardEvent("keydown", { key: "PageDown" });
+    Object.defineProperty(event, "target", { value: input });
+    expect(isUserScrollIntentEvent(event)).toBe(false);
+  });
+
+  it("detaches all listeners", () => {
+    const onScroll = vi.fn();
+    const scroller = document.createElement("div");
+    const tracker = createScrollIntentTracker(onScroll);
+    tracker.attach(scroller);
+    tracker.detach();
+
+    scroller.dispatchEvent(new WheelEvent("wheel"));
+    scroller.dispatchEvent(new Event("scroll"));
+
+    expect(onScroll).not.toHaveBeenCalled();
+    expect(tracker.consumeUserIntent()).toBe(false);
+  });
+});

--- a/src/extensions/default-layout/scrollIntentTracker.ts
+++ b/src/extensions/default-layout/scrollIntentTracker.ts
@@ -1,0 +1,80 @@
+const USER_SCROLL_INTENT_EVENTS = [
+  "wheel",
+  "touchstart",
+  "touchmove",
+  "pointerdown",
+  "keydown",
+] as const;
+
+const SCROLL_INTENT_KEYS = new Set([
+  "ArrowUp",
+  "ArrowDown",
+  "PageUp",
+  "PageDown",
+  "Home",
+  "End",
+  " ",
+  "Spacebar",
+]);
+
+function isInteractiveKeyboardTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target.isContentEditable) return true;
+  return Boolean(
+    target.closest(
+      "button,a,input,textarea,select,[role='button'],[role='link'],[role='textbox'],[tabindex]:not([tabindex='-1'])",
+    ),
+  );
+}
+
+export function isUserScrollIntentEvent(event: Event): boolean {
+  if (!(event instanceof KeyboardEvent)) return true;
+  if (!SCROLL_INTENT_KEYS.has(event.key)) return false;
+  if (isInteractiveKeyboardTarget(event.target)) return false;
+  return true;
+}
+
+export interface ScrollIntentTracker {
+  attach(el: HTMLElement): void;
+  detach(): void;
+  consumeUserIntent(): boolean;
+  markUserIntent(event: Event): void;
+}
+
+export function createScrollIntentTracker(
+  onScroll: EventListener,
+): ScrollIntentTracker {
+  let el: HTMLElement | null = null;
+  let userIntent = false;
+
+  const markUserIntent = (event: Event) => {
+    if (isUserScrollIntentEvent(event)) userIntent = true;
+  };
+
+  const detach = () => {
+    if (!el) return;
+    el.removeEventListener("scroll", onScroll);
+    for (const eventName of USER_SCROLL_INTENT_EVENTS) {
+      el.removeEventListener(eventName, markUserIntent);
+    }
+    el = null;
+  };
+
+  return {
+    attach(nextEl) {
+      detach();
+      el = nextEl;
+      nextEl.addEventListener("scroll", onScroll, { passive: true });
+      for (const eventName of USER_SCROLL_INTENT_EVENTS) {
+        nextEl.addEventListener(eventName, markUserIntent, { passive: true });
+      }
+    },
+    detach,
+    consumeUserIntent() {
+      const hadIntent = userIntent;
+      userIntent = false;
+      return hadIntent;
+    },
+    markUserIntent,
+  };
+}

--- a/src/extensions/default-layout/scrollIntentTracker.ts
+++ b/src/extensions/default-layout/scrollIntentTracker.ts
@@ -52,6 +52,7 @@ export function createScrollIntentTracker(
   };
 
   const detach = () => {
+    userIntent = false;
     if (!el) return;
     el.removeEventListener("scroll", onScroll);
     for (const eventName of USER_SCROLL_INTENT_EVENTS) {

--- a/src/extensions/default-layout/scrollPinScheduler.test.ts
+++ b/src/extensions/default-layout/scrollPinScheduler.test.ts
@@ -101,6 +101,38 @@ describe("scrollPinScheduler", () => {
     expect(scrollTo).toHaveBeenCalledTimes(1);
   });
 
+  it("resets the settle deadline on cancel before future schedules", () => {
+    const callbacks: FrameRequestCallback[] = [];
+    requestAnimationFrameSpy.mockImplementation(
+      (callback: FrameRequestCallback) => {
+        callbacks.push(callback);
+        return callbacks.length;
+      },
+    );
+    const scroller = document.createElement("div");
+    setScrollerMetrics(scroller, {
+      scrollHeight: 1200,
+      clientHeight: 500,
+      scrollTop: 0,
+    });
+    const { virtuoso } = createVirtuosoMock();
+    const scheduler = createScrollPinScheduler({
+      getScroller: () => scroller,
+      getRowsLength: () => 2,
+      getVirtuoso: () => virtuoso,
+      isFollowing: () => true,
+      updateCanScroll: vi.fn(),
+    });
+
+    scheduler.schedulePin(900);
+    scheduler.cancel();
+    scheduler.schedulePin(50);
+    vi.advanceTimersByTime(60);
+    callbacks[1]?.(60);
+
+    expect(requestAnimationFrameSpy).toHaveBeenCalledTimes(2);
+  });
+
   it("does not run delayed pins after follow is disabled", () => {
     const scroller = document.createElement("div");
     setScrollerMetrics(scroller, {

--- a/src/extensions/default-layout/scrollPinScheduler.test.ts
+++ b/src/extensions/default-layout/scrollPinScheduler.test.ts
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { VirtuosoHandle } from "react-virtuoso";
+import { createScrollPinScheduler } from "./scrollPinScheduler";
+
+function setScrollerMetrics(
+  el: HTMLElement,
+  metrics: { scrollTop: number; clientHeight: number; scrollHeight: number },
+) {
+  Object.defineProperties(el, {
+    scrollHeight: { value: metrics.scrollHeight, configurable: true },
+    clientHeight: { value: metrics.clientHeight, configurable: true },
+    scrollTop: { value: metrics.scrollTop, writable: true, configurable: true },
+  });
+}
+
+function createVirtuosoMock() {
+  const scrollTo = vi.fn();
+  const scrollToIndex = vi.fn();
+  const virtuoso = { scrollTo, scrollToIndex } as unknown as VirtuosoHandle;
+  return { scrollTo, scrollToIndex, virtuoso };
+}
+
+let requestAnimationFrameSpy: ReturnType<typeof vi.spyOn>;
+let cancelAnimationFrameSpy: ReturnType<typeof vi.spyOn>;
+let clearTimeoutSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  requestAnimationFrameSpy = vi
+    .spyOn(window, "requestAnimationFrame")
+    .mockReturnValue(1);
+  cancelAnimationFrameSpy = vi
+    .spyOn(window, "cancelAnimationFrame")
+    .mockImplementation(() => {});
+  clearTimeoutSpy = vi.spyOn(window, "clearTimeout");
+});
+
+afterEach(() => {
+  requestAnimationFrameSpy.mockRestore();
+  cancelAnimationFrameSpy.mockRestore();
+  clearTimeoutSpy.mockRestore();
+  vi.useRealTimers();
+});
+
+describe("scrollPinScheduler", () => {
+  it("coalesces animation-frame pinning while replacing delayed pins", () => {
+    const scroller = document.createElement("div");
+    setScrollerMetrics(scroller, {
+      scrollHeight: 1200,
+      clientHeight: 500,
+      scrollTop: 0,
+    });
+    const { scrollTo, scrollToIndex, virtuoso } = createVirtuosoMock();
+    const scheduler = createScrollPinScheduler({
+      getScroller: () => scroller,
+      getRowsLength: () => 4,
+      getVirtuoso: () => virtuoso,
+      isFollowing: () => true,
+      updateCanScroll: vi.fn(),
+    });
+
+    scheduler.schedulePin(900);
+    scheduler.schedulePin(900);
+
+    expect(requestAnimationFrameSpy).toHaveBeenCalledTimes(1);
+    expect(scrollToIndex).toHaveBeenLastCalledWith({
+      index: 3,
+      align: "end",
+    });
+    expect(scrollTo).toHaveBeenLastCalledWith({
+      top: Number.MAX_SAFE_INTEGER,
+    });
+
+    // The second schedule keeps the pending RAF and replaces the delayed
+    // settle timers from the first schedule.
+    expect(clearTimeoutSpy).toHaveBeenCalledTimes(5);
+  });
+
+  it("cancels pending animation-frame and delayed pins", () => {
+    const scroller = document.createElement("div");
+    setScrollerMetrics(scroller, {
+      scrollHeight: 1200,
+      clientHeight: 500,
+      scrollTop: 0,
+    });
+    const { scrollTo, virtuoso } = createVirtuosoMock();
+    const scheduler = createScrollPinScheduler({
+      getScroller: () => scroller,
+      getRowsLength: () => 2,
+      getVirtuoso: () => virtuoso,
+      isFollowing: () => true,
+      updateCanScroll: vi.fn(),
+    });
+
+    scheduler.schedulePin(900);
+    scheduler.cancel();
+    vi.advanceTimersByTime(900);
+
+    expect(cancelAnimationFrameSpy).toHaveBeenCalledWith(1);
+    expect(scrollTo).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not run delayed pins after follow is disabled", () => {
+    const scroller = document.createElement("div");
+    setScrollerMetrics(scroller, {
+      scrollHeight: 1200,
+      clientHeight: 500,
+      scrollTop: 0,
+    });
+    const { scrollTo, virtuoso } = createVirtuosoMock();
+    let following = true;
+    const scheduler = createScrollPinScheduler({
+      getScroller: () => scroller,
+      getRowsLength: () => 2,
+      getVirtuoso: () => virtuoso,
+      isFollowing: () => following,
+      updateCanScroll: vi.fn(),
+    });
+
+    scheduler.schedulePin(900);
+    following = false;
+    vi.advanceTimersByTime(900);
+
+    expect(scrollTo).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/extensions/default-layout/scrollPinScheduler.ts
+++ b/src/extensions/default-layout/scrollPinScheduler.ts
@@ -37,6 +37,7 @@ export function createScrollPinScheduler({
     for (const timeoutId of pinTimeouts) {
       window.clearTimeout(timeoutId);
     }
+    pinDeadline = 0;
     pinTimeouts = [];
   };
 

--- a/src/extensions/default-layout/scrollPinScheduler.ts
+++ b/src/extensions/default-layout/scrollPinScheduler.ts
@@ -1,0 +1,94 @@
+import type { VirtuosoHandle } from "react-virtuoso";
+
+export interface ScrollPinScheduler {
+  schedulePin(settleMs?: number): void;
+  pinNow(): void;
+  cancel(): void;
+}
+
+export interface ScrollPinSchedulerArgs {
+  getScroller: () => HTMLElement | null;
+  getRowsLength: () => number;
+  getVirtuoso: () => VirtuosoHandle | null;
+  isFollowing: () => boolean;
+  updateCanScroll: () => void;
+}
+
+function currentTime(): number {
+  return typeof performance === "undefined" ? Date.now() : performance.now();
+}
+
+export function createScrollPinScheduler({
+  getScroller,
+  getRowsLength,
+  getVirtuoso,
+  isFollowing,
+  updateCanScroll,
+}: ScrollPinSchedulerArgs): ScrollPinScheduler {
+  let pinRaf: number | null = null;
+  let pinDeadline = 0;
+  let pinTimeouts: number[] = [];
+
+  const cancel = () => {
+    if (pinRaf !== null) {
+      window.cancelAnimationFrame(pinRaf);
+      pinRaf = null;
+    }
+    for (const timeoutId of pinTimeouts) {
+      window.clearTimeout(timeoutId);
+    }
+    pinTimeouts = [];
+  };
+
+  const pinNow = () => {
+    const el = getScroller();
+    const bottomGap = el
+      ? el.scrollHeight - el.clientHeight - el.scrollTop
+      : Number.POSITIVE_INFINITY;
+    if (bottomGap <= 2) {
+      updateCanScroll();
+      return;
+    }
+    const lastIndex = Math.max(0, getRowsLength() - 1);
+    const virtuoso = getVirtuoso();
+    virtuoso?.scrollToIndex({ index: lastIndex, align: "end" });
+    virtuoso?.scrollTo({ top: Number.MAX_SAFE_INTEGER });
+    if (el) el.scrollTop = el.scrollHeight;
+    updateCanScroll();
+  };
+
+  const pinIfStillFollowing = () => {
+    if (isFollowing()) pinNow();
+  };
+
+  const schedulePin = (settleMs = 150) => {
+    const startedAt = currentTime();
+    pinDeadline = Math.max(pinDeadline, startedAt + settleMs);
+    pinNow();
+
+    const frame = () => {
+      pinRaf = null;
+      if (!isFollowing()) return;
+      pinNow();
+      if (currentTime() < pinDeadline) {
+        pinRaf = window.requestAnimationFrame(frame);
+      }
+    };
+
+    if (pinRaf === null) {
+      pinRaf = window.requestAnimationFrame(frame);
+    }
+
+    for (const timeoutId of pinTimeouts) {
+      window.clearTimeout(timeoutId);
+    }
+    pinTimeouts = [];
+    for (const delay of [50, 150, 300, 600, 900]) {
+      if (delay <= settleMs) {
+        pinTimeouts.push(window.setTimeout(pinIfStillFollowing, delay));
+      }
+    }
+  };
+
+  return { schedulePin, pinNow, cancel };
+}

--- a/src/extensions/default-layout/scrollReanchorPolicies.test.ts
+++ b/src/extensions/default-layout/scrollReanchorPolicies.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import type { ChatMessage } from "../../types/a2ui";
+import { buildTranscriptRows, type TranscriptRow } from "../../utils/transcriptRows";
+import {
+  appendedUserTurnResumesFollow,
+  visibilityReanchorIndex,
+} from "./scrollReanchorPolicies";
+
+const messages: ChatMessage[] = [
+  { id: "u1", role: "user", text: "start" },
+  { id: "a1", role: "agent", text: "answer" },
+  {
+    id: "tool1",
+    role: "agent",
+    a2ui: {
+      components: [
+        {
+          id: "tool-card",
+          type: "tool-card",
+          props: { title: "bash", description: "hidden when tools collapse" },
+        },
+      ],
+    },
+  },
+  { id: "u2", role: "user", text: "next" },
+];
+
+function rowFor(message: ChatMessage): TranscriptRow {
+  return {
+    type: "conversation-turn",
+    turn: {
+      id: message.id,
+      messages: [message],
+      agentMessages: message.role === "agent" ? [message] : [],
+      progressMessages: [],
+      toolMessages: [],
+      systemMessages: [],
+      ...(message.role === "user" ? { userMessage: message } : {}),
+      ...(message.role === "agent" ? { finalMessage: message } : {}),
+    },
+  };
+}
+
+describe("scrollReanchorPolicies", () => {
+  it("maps a visibility-toggle anchor to the same surviving message", () => {
+    const oldRows = buildTranscriptRows(messages, "show", new Set()).rows;
+    const newRows = buildTranscriptRows(messages, "group-block", new Set()).rows;
+
+    expect(
+      visibilityReanchorIndex({
+        messages,
+        oldRows,
+        newRows,
+        startIndex: 1,
+      }),
+    ).toBe(1);
+  });
+
+  it("falls back to the nearest preceding message when the anchor row disappears", () => {
+    const oldRows = messages.map(rowFor);
+    const newRows = [messages[0], messages[1], messages[3]].map(rowFor);
+
+    expect(
+      visibilityReanchorIndex({
+        messages,
+        oldRows,
+        newRows,
+        startIndex: 2,
+      }),
+    ).toBe(1);
+  });
+
+  it("resumes follow when any appended message after the previous tail is a user turn", () => {
+    expect(
+      appendedUserTurnResumesFollow({
+        messages: [
+          { id: "1", role: "agent", text: "old" },
+          { id: "2", role: "user", text: "new prompt" },
+          { id: "3", role: "agent", text: "first token" },
+        ],
+        previousTailId: "1",
+      }),
+    ).toBe(true);
+
+    expect(
+      appendedUserTurnResumesFollow({
+        messages: [
+          { id: "1", role: "agent", text: "old" },
+          { id: "2", role: "agent", text: "streaming" },
+        ],
+        previousTailId: "1",
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/extensions/default-layout/scrollReanchorPolicies.ts
+++ b/src/extensions/default-layout/scrollReanchorPolicies.ts
@@ -1,0 +1,56 @@
+import type { ChatMessage } from "../../types/a2ui";
+import {
+  anchorMessageIdForRow,
+  findRowIndexForMessageId,
+  type TranscriptRow,
+} from "../../utils/transcriptRows";
+
+export function visibilityReanchorIndex({
+  messages,
+  newRows,
+  oldRows,
+  startIndex,
+}: {
+  messages: ChatMessage[];
+  newRows: TranscriptRow[];
+  oldRows: TranscriptRow[];
+  startIndex: number;
+}): number {
+  const anchorId = anchorMessageIdForRow(oldRows[startIndex]);
+  const newIndex = findRowIndexForMessageId(newRows, anchorId);
+  if (newIndex >= 0 || !anchorId) return newIndex;
+
+  const anchorMsgIdx = messages.findIndex((message) => message.id === anchorId);
+  for (let i = anchorMsgIdx - 1; i >= 0; i--) {
+    const idx = findRowIndexForMessageId(newRows, messages[i].id);
+    if (idx >= 0) return idx;
+  }
+  return -1;
+}
+
+export function appendedMessagesAfterPreviousTail({
+  messages,
+  previousTailId,
+}: {
+  messages: ChatMessage[];
+  previousTailId: string | undefined;
+}): ChatMessage[] {
+  const previousIndex = previousTailId
+    ? messages.findIndex((message) => message.id === previousTailId)
+    : -1;
+  return previousIndex >= 0 ? messages.slice(previousIndex + 1) : messages;
+}
+
+export function appendedUserTurnResumesFollow({
+  messages,
+  previousTailId,
+}: {
+  messages: ChatMessage[];
+  previousTailId: string | undefined;
+}): boolean {
+  const latest = messages[messages.length - 1];
+  if (!latest || latest.id === previousTailId) return false;
+  return appendedMessagesAfterPreviousTail({ messages, previousTailId }).some(
+    (message) => message.role === "user",
+  );
+}

--- a/src/extensions/default-layout/useScrollFollowController.ts
+++ b/src/extensions/default-layout/useScrollFollowController.ts
@@ -10,88 +10,33 @@ import type { VirtuosoHandle, ListRange } from "react-virtuoso";
 import type { ChatMessage } from "../../types/a2ui";
 import { isAtBottom as metricsAtBottom } from "../../utils/stickyScrollController";
 import {
-  anchorMessageIdForRow,
-  findRowIndexForMessageId,
   searchableTextForRow,
   type TranscriptRow,
 } from "../../utils/transcriptRows";
 import type { ResolvedVisibility } from "../../utils/visibilityResolver";
+import {
+  createScrollPinScheduler,
+  type ScrollPinScheduler,
+} from "./scrollPinScheduler";
+import {
+  appendedUserTurnResumesFollow,
+  visibilityReanchorIndex,
+} from "./scrollReanchorPolicies";
+import { createScrollIntentTracker } from "./scrollIntentTracker";
+import {
+  defaultTabScrollAnchorStore,
+  dropStaleRestoreAnchor,
+  initialIndexForRestoreAnchor,
+  restoreAnchorForTab,
+  updateAnchorFromRange,
+  updateAnchorFromUserScroll,
+  type TabScrollAnchorStore,
+} from "./scrollFollowStore";
 
 // Distance (px) from the bottom still treated as "at the bottom" — used by the
 // scroll handler's metricsAtBottom check (follow on/off) and the canScroll
 // overflow check that gates the scroll-to-bottom pill.
 const DEFAULT_AT_BOTTOM_THRESHOLD = 60;
-
-// tabId → the message id at the top of the viewport when the tab was left
-// scrolled-up (absent when it was left following at the bottom). The message
-// list is keyed by tab id (see ChatHistory / MainCanvas), so each tab mounts its
-// own Virtuoso instance; on the next mount we map this id back to its current
-// row index and open there via initialTopMostItemIndex. Keyed by message id, not
-// pixels, so it survives new messages arriving while the tab is backgrounded and
-// avoids react-virtuoso's fragile getState/restoreStateFrom scrollTop timing.
-// Module-level so it survives the keyed remount.
-const tabScrollCache = new Map<string, string>();
-
-// Follow state must flip only on a genuine USER scroll, never on the
-// programmatic re-pins we issue while following (those would otherwise be read
-// back as "the user scrolled"). Content reflow/growth does NOT fire a scroll
-// event, so the only scroll events to disambiguate are user gestures vs our own
-// scrollTo. We mark a user gesture (wheel / touch / scroll-key) and let the
-// resulting scroll event recompute follow; un-gestured scroll events (our
-// re-pins) are ignored. This is what makes a scroll-away win the race against an
-// in-flight streaming re-pin.
-const USER_SCROLL_INTENT_EVENTS = [
-  "wheel",
-  "touchstart",
-  "touchmove",
-  "pointerdown",
-  "keydown",
-] as const;
-const SCROLL_INTENT_KEYS = new Set([
-  "ArrowUp",
-  "ArrowDown",
-  "PageUp",
-  "PageDown",
-  "Home",
-  "End",
-  " ",
-  "Spacebar",
-]);
-
-function isInteractiveKeyboardTarget(target: EventTarget | null): boolean {
-  if (!(target instanceof HTMLElement)) return false;
-  if (target.isContentEditable) return true;
-  return Boolean(
-    target.closest(
-      "button,a,input,textarea,select,[role='button'],[role='link'],[role='textbox'],[tabindex]:not([tabindex='-1'])",
-    ),
-  );
-}
-
-function isUserScrollIntentEvent(event: Event): boolean {
-  if (!(event instanceof KeyboardEvent)) return true;
-  if (!SCROLL_INTENT_KEYS.has(event.key)) return false;
-  if (isInteractiveKeyboardTarget(event.target)) return false;
-  return true;
-}
-
-function addUserScrollIntentListeners(
-  el: HTMLElement,
-  listener: EventListener,
-): void {
-  for (const eventName of USER_SCROLL_INTENT_EVENTS) {
-    el.addEventListener(eventName, listener, { passive: true });
-  }
-}
-
-function removeUserScrollIntentListeners(
-  el: HTMLElement,
-  listener: EventListener,
-): void {
-  for (const eventName of USER_SCROLL_INTENT_EVENTS) {
-    el.removeEventListener(eventName, listener);
-  }
-}
 
 interface UseScrollFollowControllerArgs {
   messages: ChatMessage[];
@@ -102,6 +47,7 @@ interface UseScrollFollowControllerArgs {
   terminalOpen: boolean;
   layoutRows: unknown;
   virtuosoRef: RefObject<VirtuosoHandle | null>;
+  anchorStore?: TabScrollAnchorStore;
 }
 
 export interface ScrollFollowController {
@@ -118,19 +64,23 @@ export interface ScrollFollowController {
 }
 
 export function resetScrollFollowCacheForTests(): void {
-  tabScrollCache.clear();
+  defaultTabScrollAnchorStore.clear();
 }
 
 export function getScrollFollowCacheAnchorForTests(
   tabId: string,
 ): string | undefined {
-  return tabScrollCache.get(tabId);
+  return defaultTabScrollAnchorStore.get(tabId);
 }
 
-/** Owns chat transcript follow/pin behavior. Virtuoso's `followOutput` remains
- *  disabled; this hook is the single source of truth for user scroll intent,
- *  per-tab restore anchors, content-growth pinning, terminal resize repins,
- *  search jumps, and visibility-toggle re-anchoring. */
+/** React orchestration layer for chat transcript follow/pin behavior.
+ *  Ownership is split across explicit collaborators:
+ *  - scrollFollowStore owns per-tab restore anchors,
+ *  - scrollIntentTracker owns user-vs-programmatic scroll detection,
+ *  - scrollPinScheduler owns imperative bottom pin coalescing/cleanup,
+ *  - scrollReanchorPolicies owns visibility/new-turn re-anchor decisions.
+ *  Virtuoso's `followOutput` remains disabled; this hook wires the pieces to
+ *  React lifecycle, refs, and transcript state. */
 export function useScrollFollowController({
   messages,
   rows,
@@ -140,24 +90,23 @@ export function useScrollFollowController({
   terminalOpen,
   layoutRows,
   virtuosoRef,
+  anchorStore = defaultTabScrollAnchorStore,
 }: UseScrollFollowControllerArgs): ScrollFollowController {
   // `following` drives the pill (render); `followingRef` is the synchronous
   // source of truth the re-pin + filter effects read. They move together via
   // setFollowing(). This flag is the single owner of stick-to-bottom intent.
-  // A cached snapshot exists only for a tab left scrolled-up (see handleScroll),
-  // so seed follow=false when restoring one — otherwise default to following.
-  const initialFollowing = !(tabId !== undefined && tabScrollCache.has(tabId));
+  // A cached snapshot exists only for a tab left scrolled-up, so seed
+  // follow=false when restoring one — otherwise default to following.
+  const initialFollowing = !(tabId !== undefined && anchorStore.has(tabId));
   const [following, setFollowingState] = useState(initialFollowing);
   const followingRef = useRef(initialFollowing);
   const [canScroll, setCanScroll] = useState(false);
   const [scrollerEl, setScrollerEl] = useState<HTMLElement | null>(null);
   const scrollerElRef = useRef<HTMLElement | null>(null);
-  // Set by a user gesture (wheel/touch/scroll-key); the next scroll event reads
-  // and clears it. Distinguishes a real scroll-away from our own re-pins.
-  const userScrollRef = useRef(false);
-  const pinRafRef = useRef<number | null>(null);
-  const pinDeadlineRef = useRef(0);
-  const pinTimeoutsRef = useRef<number[]>([]);
+  const intentTrackerRef = useRef<ReturnType<
+    typeof createScrollIntentTracker
+  > | null>(null);
+  const pinSchedulerRef = useRef<ScrollPinScheduler | null>(null);
   const [flashIndex, setFlashIndex] = useState<number | null>(null);
   const prevScrollToMatch = useRef<string | undefined>(undefined);
   const prevLastMessageId = useRef(messages[messages.length - 1]?.id);
@@ -192,79 +141,23 @@ export function useScrollFollowController({
     );
   }, []);
 
-  const scrollToBottom = useCallback(
-    (settleMs = 150) => {
-      const startedAt =
-        typeof performance === "undefined" ? Date.now() : performance.now();
-      const now = () =>
-        typeof performance === "undefined" ? Date.now() : performance.now();
-      pinDeadlineRef.current = Math.max(
-        pinDeadlineRef.current,
-        startedAt + settleMs,
-      );
-
-      // Scroll to the true bottom of the scroller — this includes the footer's
-      // live subtree / typing indicator, which sit below the last data row.
-      const pinDomScroller = () => {
-        const el = scrollerElRef.current;
-        const bottomGap = el
-          ? el.scrollHeight - el.clientHeight - el.scrollTop
-          : Number.POSITIVE_INFINITY;
-        if (bottomGap <= 2) {
-          updateCanScroll();
-          return;
-        }
-        const lastIndex = Math.max(0, rowsRef.current.length - 1);
-        virtuosoRef.current?.scrollToIndex({ index: lastIndex, align: "end" });
-        virtuosoRef.current?.scrollTo({ top: Number.MAX_SAFE_INTEGER });
-        if (el) el.scrollTop = el.scrollHeight;
-        updateCanScroll();
-      };
-      const pinIfStillFollowing = () => {
-        if (followingRef.current) pinDomScroller();
-      };
-      pinDomScroller();
-      const frame = () => {
-        pinRafRef.current = null;
-        if (!followingRef.current) return;
-        pinDomScroller();
-        if (now() < pinDeadlineRef.current) {
-          pinRafRef.current = window.requestAnimationFrame(frame);
-        }
-      };
-      if (pinRafRef.current === null) {
-        pinRafRef.current = window.requestAnimationFrame(frame);
-      }
-      for (const timeoutId of pinTimeoutsRef.current) {
-        window.clearTimeout(timeoutId);
-      }
-      pinTimeoutsRef.current = [];
-      for (const delay of [50, 150, 300, 600, 900]) {
-        if (delay <= settleMs) {
-          pinTimeoutsRef.current.push(
-            window.setTimeout(pinIfStillFollowing, delay),
-          );
-        }
-      }
-    },
-    [updateCanScroll, virtuosoRef],
-  );
-
-  useEffect(() => {
+  useLayoutEffect(() => {
+    const scheduler = createScrollPinScheduler({
+      getScroller: () => scrollerElRef.current,
+      getRowsLength: () => rowsRef.current.length,
+      getVirtuoso: () => virtuosoRef.current,
+      isFollowing: () => followingRef.current,
+      updateCanScroll,
+    });
+    pinSchedulerRef.current = scheduler;
     return () => {
-      if (pinRafRef.current !== null) {
-        window.cancelAnimationFrame(pinRafRef.current);
-        pinRafRef.current = null;
-      }
-      for (const timeoutId of pinTimeoutsRef.current) {
-        window.clearTimeout(timeoutId);
-      }
-      pinTimeoutsRef.current = [];
+      scheduler.cancel();
+      if (pinSchedulerRef.current === scheduler) pinSchedulerRef.current = null;
     };
-  }, []);
+  }, [updateCanScroll, virtuosoRef]);
 
-  const markUserScrollIntent = useCallback((event: Event) => {
-    if (isUserScrollIntentEvent(event)) userScrollRef.current = true;
+  const scrollToBottom = useCallback((settleMs = 150) => {
+    pinSchedulerRef.current?.schedulePin(settleMs);
   }, []);
 
   // Sole follow on/off path. Only a gesture-flagged scroll recomputes follow
@@ -273,8 +166,7 @@ export function useScrollFollowController({
   // never be flipped off by streaming — only by a real user scroll-away.
   const handleScroll = useCallback(() => {
     updateCanScroll();
-    if (!userScrollRef.current) return;
-    userScrollRef.current = false;
+    if (!intentTrackerRef.current?.consumeUserIntent()) return;
     const el = scrollerElRef.current;
     if (!el) return;
     const atBottom = metricsAtBottom(
@@ -286,23 +178,25 @@ export function useScrollFollowController({
       DEFAULT_AT_BOTTOM_THRESHOLD,
     );
     setFollowing(atBottom);
-    // Per-tab scroll restore: remember the top-of-viewport message id while
-    // scrolled-up; clear it when the user returns to the bottom (so the tab
-    // reopens following at the live bottom). ONLY user-gestured scrolls touch
-    // the cache — programmatic re-pins and the restore itself are un-gestured,
-    // so a transient mount-time position (e.g. React StrictMode's dev remount)
-    // can never clobber it. rangeChanged keeps this fresh as the user scrolls.
-    if (tabId !== undefined) {
-      if (atBottom) {
-        tabScrollCache.delete(tabId);
-      } else {
-        const anchorId = anchorMessageIdForRow(
-          rowsRef.current[lastRangeRef.current?.startIndex ?? 0],
-        );
-        if (anchorId) tabScrollCache.set(tabId, anchorId);
-      }
-    }
-  }, [setFollowing, tabId, updateCanScroll]);
+    updateAnchorFromUserScroll({
+      atBottom,
+      range: lastRangeRef.current,
+      rows: rowsRef.current,
+      store: anchorStore,
+      tabId,
+    });
+  }, [anchorStore, setFollowing, tabId, updateCanScroll]);
+
+  useLayoutEffect(() => {
+    const tracker = createScrollIntentTracker(handleScroll);
+    intentTrackerRef.current = tracker;
+    const el = scrollerElRef.current;
+    if (el) tracker.attach(el);
+    return () => {
+      tracker.detach();
+      if (intentTrackerRef.current === tracker) intentTrackerRef.current = null;
+    };
+  }, [handleScroll]);
 
   // Track the topmost visible row and, while scrolled-up, keep the per-tab
   // restore anchor current as the user scrolls (so switching away restores the
@@ -310,34 +204,30 @@ export function useScrollFollowController({
   const handleRangeChanged = useCallback(
     (range: ListRange) => {
       lastRangeRef.current = range;
-      if (tabId !== undefined && !followingRef.current) {
-        const anchorId = anchorMessageIdForRow(rowsRef.current[range.startIndex]);
-        if (anchorId) tabScrollCache.set(tabId, anchorId);
-      }
+      updateAnchorFromRange({
+        following: followingRef.current,
+        range,
+        rows: rowsRef.current,
+        store: anchorStore,
+        tabId,
+      });
     },
-    [tabId],
+    [anchorStore, tabId],
   );
 
   const handleScrollerRef = useCallback(
     (ref: HTMLElement | Window | null) => {
-      const prev = scrollerElRef.current;
-      if (prev) {
-        prev.removeEventListener("scroll", handleScroll);
-        removeUserScrollIntentListeners(prev, markUserScrollIntent);
-      }
+      intentTrackerRef.current?.detach();
       const el =
         typeof HTMLElement !== "undefined" && ref instanceof HTMLElement
           ? ref
           : null;
       scrollerElRef.current = el;
       setScrollerEl(el);
-      if (el) {
-        el.addEventListener("scroll", handleScroll, { passive: true });
-        addUserScrollIntentListeners(el, markUserScrollIntent);
-      }
+      if (el) intentTrackerRef.current?.attach(el);
       updateCanScroll();
     },
-    [handleScroll, markUserScrollIntent, updateCanScroll],
+    [updateCanScroll],
   );
 
   // Content grew/shrank (append, streamed token, tool/thinking expand, late
@@ -355,15 +245,7 @@ export function useScrollFollowController({
   // user scrolls), so there is deliberately NO getState-on-unmount here — that
   // would capture a transient pre-restore scrollTop under React StrictMode's
   // dev double-mount and clobber the cached position.
-  useLayoutEffect(() => {
-    return () => {
-      const el = scrollerElRef.current;
-      if (el) {
-        el.removeEventListener("scroll", handleScroll);
-        removeUserScrollIntentListeners(el, markUserScrollIntent);
-      }
-    };
-  }, [handleScroll, markUserScrollIntent]);
+  useLayoutEffect(() => () => intentTrackerRef.current?.detach(), []);
 
   // Terminal open/resize changes the chat viewport height without changing the
   // list height, so Virtuoso's totalListHeightChanged callback never fires. If
@@ -412,15 +294,10 @@ export function useScrollFollowController({
   // index. When present, open there (aligned to the top); otherwise open pinned
   // to the bottom. These are mutually exclusive — a bottom initial index would
   // otherwise win over any restore.
-  const restoreAnchorId =
-    tabId !== undefined ? tabScrollCache.get(tabId) : undefined;
-  const restoreIndex = restoreAnchorId
-    ? findRowIndexForMessageId(rows, restoreAnchorId)
-    : -1;
-  const initialTopMostItemIndex =
-    restoreIndex >= 0
-      ? { index: restoreIndex, align: "start" as const }
-      : { index: Math.max(0, rows.length - 1), align: "end" as const };
+  const restoreAnchorId = restoreAnchorForTab(anchorStore, tabId);
+  const { restoreIndex, initialTopMostItemIndex } = initialIndexForRestoreAnchor(
+    { rows, restoreAnchorId },
+  );
 
   // A cached restore anchor that no longer exists (chat cleared via Cmd+K, or a
   // session rollback truncated it away) is stale: restoreIndex is -1 so the list
@@ -428,13 +305,16 @@ export function useScrollFollowController({
   // pill showing at the bottom with content-growth re-pins disabled. Drop the
   // stale entry and resume following at the live bottom.
   useLayoutEffect(() => {
-    if (!restoreAnchorId || restoreIndex >= 0) return;
-    if (tabId !== undefined) tabScrollCache.delete(tabId);
-    if (!followingRef.current) {
-      setFollowing(true);
-      scrollToBottom();
-    }
-  }, [restoreAnchorId, restoreIndex, scrollToBottom, setFollowing, tabId]);
+    const dropped = dropStaleRestoreAnchor({
+      restoreAnchorId,
+      restoreIndex,
+      store: anchorStore,
+      tabId,
+    });
+    if (!dropped || followingRef.current) return;
+    setFollowing(true);
+    scrollToBottom();
+  }, [anchorStore, restoreAnchorId, restoreIndex, scrollToBottom, setFollowing, tabId]);
 
   // A new user turn is an explicit request to continue the conversation, so the
   // transcript should resume following even if the user had been reading above
@@ -444,20 +324,15 @@ export function useScrollFollowController({
   // one render, so scan everything appended after the previous tail instead of
   // checking only the latest row.
   useLayoutEffect(() => {
-    const latest = messages[messages.length - 1];
     const previousId = prevLastMessageId.current;
-    prevLastMessageId.current = latest?.id;
-    if (!latest || latest.id === previousId) return;
-    const previousIndex = previousId
-      ? messages.findIndex((message) => message.id === previousId)
-      : -1;
-    const appended =
-      previousIndex >= 0 ? messages.slice(previousIndex + 1) : messages;
-    if (!appended.some((message) => message.role === "user")) return;
-    if (tabId !== undefined) tabScrollCache.delete(tabId);
+    prevLastMessageId.current = messages[messages.length - 1]?.id;
+    if (!appendedUserTurnResumesFollow({ messages, previousTailId: previousId })) {
+      return;
+    }
+    if (tabId !== undefined) anchorStore.delete(tabId);
     if (!followingRef.current) setFollowing(true);
     scrollToBottom(900);
-  }, [messages, scrollToBottom, setFollowing, tabId]);
+  }, [anchorStore, messages, scrollToBottom, setFollowing, tabId]);
 
   // Toggling a transcript filter (tool-call grouping / thinking visibility)
   // rebuilds `rows` with a different length + identity. Re-anchor exactly once
@@ -484,21 +359,12 @@ export function useScrollFollowController({
 
     // Map the topmost visible message id from the OLD rows to its index in
     // the NEW rows and pin it to the top (preserves the reading position).
-    const startIndex = lastRangeRef.current?.startIndex ?? 0;
-    const anchorId = anchorMessageIdForRow(prevRows[startIndex]);
-    let newIndex = findRowIndexForMessageId(rows, anchorId);
-    if (newIndex < 0 && anchorId) {
-      // Anchor dropped (e.g. its tool card was hidden): fall back to the nearest
-      // preceding message that still survives in the new groups.
-      const anchorMsgIdx = messages.findIndex((m) => m.id === anchorId);
-      for (let i = anchorMsgIdx - 1; i >= 0; i--) {
-        const idx = findRowIndexForMessageId(rows, messages[i].id);
-        if (idx >= 0) {
-          newIndex = idx;
-          break;
-        }
-      }
-    }
+    const newIndex = visibilityReanchorIndex({
+      messages,
+      newRows: rows,
+      oldRows: prevRows,
+      startIndex: lastRangeRef.current?.startIndex ?? 0,
+    });
     if (newIndex >= 0) {
       virtuosoRef.current?.scrollToIndex({ index: newIndex, align: "start" });
     }


### PR DESCRIPTION
## Summary
- split scroll-follow anchor storage into an injectable tab anchor store with default runtime storage
- extract user intent tracking, imperative pin scheduling, and re-anchor/new-turn policies into named helpers
- keep useScrollFollowController as the React orchestration layer while adding focused helper tests

Closes #378.

## Validation
- bunx vitest run src/extensions/default-layout/useScrollFollowController.test.tsx src/extensions/default-layout/chat.test.tsx src/extensions/default-layout/scrollFollowStore.test.ts src/extensions/default-layout/scrollIntentTracker.test.ts src/extensions/default-layout/scrollPinScheduler.test.ts src/extensions/default-layout/scrollReanchorPolicies.test.ts
- bunx tsc -b --noEmit
- bunx eslint src/extensions/default-layout/useScrollFollowController.ts src/extensions/default-layout/scrollFollowStore.ts src/extensions/default-layout/scrollIntentTracker.ts src/extensions/default-layout/scrollPinScheduler.ts src/extensions/default-layout/scrollReanchorPolicies.ts src/extensions/default-layout/scrollFollowStore.test.ts src/extensions/default-layout/scrollIntentTracker.test.ts src/extensions/default-layout/scrollPinScheduler.test.ts src/extensions/default-layout/scrollReanchorPolicies.test.ts
- bunx vitest run src/extensions/default-layout
- bunx vitest run

## Review
- Codex review: no issues found