### PR TITLE
fix: keep overview model selection stable

### DIFF
--- a/src/eventRoutes/tabStrip.test.ts
+++ b/src/eventRoutes/tabStrip.test.ts
@@ -58,6 +58,34 @@ describe("handleTabStrip", () => {
     expect(next).toEqual({ activeTabId: OVERVIEW_TAB_ID, foo: "bar" });
   });
 
+  it("selecting overview repairs stale shell model state", async () => {
+    const { ctx, mocks, applySetState } = buildRouteFixture({
+      state: {
+        activeTabId: "shell-1",
+        project: { id: "p1" },
+        defaultModel: "openai-codex/gpt-5.5",
+        piDefaultModel: "openai-codex/gpt-5.5",
+        defaultThinkingLevel: "medium",
+        model: "anthropic/claude-opus-4-7",
+        thinkingLevel: "high",
+      },
+    });
+    await handleTabStrip(
+      {
+        component: { id: "header-tabs", type: "tab-strip" },
+        eventType: "select",
+        data: { tabId: OVERVIEW_TAB_ID },
+      },
+      ctx,
+    );
+    expect(mocks.setActiveTab).not.toHaveBeenCalled();
+    const next = applySetState();
+    expect(next.activeTabId).toBe(OVERVIEW_TAB_ID);
+    expect(next.landing).toBeNull();
+    expect(next.model).toBe("openai-codex/gpt-5.5");
+    expect(next.thinkingLevel).toBe("medium");
+  });
+
   it("close removes the chosen tab", async () => {
     const { ctx, mocks } = buildRouteFixture();
     await handleTabStrip(

--- a/src/eventRoutes/tabStrip.ts
+++ b/src/eventRoutes/tabStrip.ts
@@ -3,14 +3,26 @@ import { OVERVIEW_TAB_ID, type Tab } from "../types/tab";
 import { restoreSessionFromSelection } from "./sessionRestore";
 import { renameSessionLabel } from "./sessionRename";
 import { reorderTabToIndex } from "../utils/tabReorder";
+import { mirrorOverviewSurfaceSelection } from "../hooks/tabOps/helpers";
 
 /** Switch the active tab to the overview sentinel. Used both by the
  *  permanent overview pill in the tab strip and by the sidebar
  *  re-click gestures in `sidebar/chrome.ts` + `sidebar/workspace.ts`. */
 export function activateOverview(ctx: EventRouteContext): void {
   ctx.setState((prev) => {
-    if (prev.activeTabId === OVERVIEW_TAB_ID) return prev;
-    return { ...prev, activeTabId: OVERVIEW_TAB_ID };
+    const result: Record<string, unknown> = {
+      ...prev,
+      activeTabId: OVERVIEW_TAB_ID,
+      landing: null,
+    };
+    const visibleModel = mirrorOverviewSurfaceSelection(result, prev);
+    const desiredThinkingLevel = result.thinkingLevel;
+    const alreadyClean =
+      prev.activeTabId === OVERVIEW_TAB_ID &&
+      prev.landing == null &&
+      (visibleModel ? prev.model === visibleModel : true) &&
+      prev.thinkingLevel === desiredThinkingLevel;
+    return alreadyClean ? prev : result;
   });
 }
 

--- a/src/hooks/bridgeMessageHandlers/ready.test.ts
+++ b/src/hooks/bridgeMessageHandlers/ready.test.ts
@@ -240,6 +240,101 @@ describe("handleReady", () => {
     );
   });
 
+  it("keeps overview reasoning defaults ahead of bridge fallback ready data", () => {
+    const { ctx, applySetState } = buildHandlerFixture({
+      state: {
+        activeTabId: "__overview__",
+        defaultModel: "openai-codex/gpt-5.5",
+        piDefaultModel: "openai-codex/gpt-5.5",
+        defaultThinkingLevel: "medium",
+        model: "openai-codex/gpt-5.5",
+        thinkingLevel: "medium",
+        tabs: [
+          {
+            id: "shell-1",
+            kind: "shell",
+            model: "anthropic/claude-opus-4-7",
+            thinkingLevel: "high",
+            messages: [],
+          },
+        ],
+        sidebar: {},
+      },
+    });
+
+    handleReady(
+      {
+        type: "ready",
+        model: "openai-codex/gpt-5.5",
+        thinkingLevel: "high",
+        models: [
+          {
+            id: "openai-codex/gpt-5.5",
+            label: "GPT-5.5",
+            provider: "openai",
+            thinkingLevels: ["medium", "high"],
+          },
+          {
+            id: "anthropic/claude-opus-4-7",
+            label: "Claude Opus 4.7",
+            provider: "anthropic",
+            thinkingLevels: ["high"],
+          },
+        ],
+        tabs: [
+          {
+            id: "shell-1",
+            model: "anthropic/claude-opus-4-7",
+            thinkingLevel: "high",
+          },
+        ],
+      },
+      ctx,
+    );
+
+    const next = applySetState();
+    expect(next.activeTabId).toBe("__overview__");
+    expect(next.model).toBe("openai-codex/gpt-5.5");
+    expect(next.thinkingLevel).toBe("medium");
+    expect(next.defaultThinkingLevel).toBe("medium");
+  });
+
+  it("uses bridge ready reasoning when overview has no local default", () => {
+    const { ctx, applySetState } = buildHandlerFixture({
+      state: {
+        activeTabId: "__overview__",
+        defaultModel: "openai-codex/gpt-5.5",
+        piDefaultModel: "openai-codex/gpt-5.5",
+        model: "openai-codex/gpt-5.5",
+        tabs: [],
+        sidebar: {},
+      },
+    });
+
+    handleReady(
+      {
+        type: "ready",
+        model: "openai-codex/gpt-5.5",
+        thinkingLevel: "high",
+        models: [
+          {
+            id: "openai-codex/gpt-5.5",
+            label: "GPT-5.5",
+            provider: "openai",
+            thinkingLevels: ["medium", "high"],
+          },
+        ],
+      },
+      ctx,
+    );
+
+    const next = applySetState();
+    expect(next.activeTabId).toBe("__overview__");
+    expect(next.model).toBe("openai-codex/gpt-5.5");
+    expect(next.thinkingLevel).toBe("high");
+    expect(next.defaultThinkingLevel).toBe("high");
+  });
+
   it("prunes extension state keys that disappeared between readies", () => {
     const { ctx, applySetState } = buildHandlerFixture({
       state: { activeTabId: "default", tabs: [{ id: "default" }], sidebar: {} },

--- a/src/hooks/bridgeMessageHandlers/ready.ts
+++ b/src/hooks/bridgeMessageHandlers/ready.ts
@@ -2,7 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 import type { A2UIPayload } from "../../types/a2ui";
 import { activeCwd, activeProject } from "../../projects";
 import { TAB_MIRROR_KEYS } from "../useTabs";
-import type { Tab } from "../../types/tab";
+import { OVERVIEW_TAB_ID, type Tab } from "../../types/tab";
 import {
   EMPTY_AUTH_PROFILES,
   type AuthProfilesSnapshot,
@@ -26,6 +26,7 @@ import {
   replayHighlightGrammars,
   type ExtensionHighlightGrammar,
 } from "./extensionHighlightGrammars";
+import { mirrorOverviewSurfaceToRoot } from "../tabOps/helpers";
 
 function isWorkstationBootLayout(layout: A2UIPayload): boolean {
   const state = layout.state as
@@ -422,10 +423,24 @@ export const handleReady: BridgeMessageHandler = (data, ctx) => {
     const activeId = (next.activeTabId as string | undefined) ?? "default";
     const tabsList = (next.tabs as Tab[] | undefined) ?? [];
     const activeTab = tabsList.find((t) => t.id === activeId);
-    const activeModel = activeTab?.model || fallbackModel;
-    const activeThinkingLevel =
-      activeTab?.thinkingLevel ||
-      (typeof data.thinkingLevel === "string" ? data.thinkingLevel : undefined);
+    const overviewOwnsSurface =
+      activeId === OVERVIEW_TAB_ID || !activeTab || activeTab.kind === "shell";
+    const overviewMirror: Record<string, unknown> = {};
+    const overviewModel = overviewOwnsSurface
+      ? mirrorOverviewSurfaceToRoot(overviewMirror, next)
+      : "";
+    const overviewThinkingLevel =
+      typeof overviewMirror.thinkingLevel === "string"
+        ? overviewMirror.thinkingLevel
+        : undefined;
+    const readyThinkingLevel =
+      typeof data.thinkingLevel === "string" ? data.thinkingLevel : undefined;
+    const activeModel = overviewOwnsSurface
+      ? overviewModel || fallbackModel
+      : activeTab.model || fallbackModel;
+    const activeThinkingLevel = overviewOwnsSurface
+      ? (overviewThinkingLevel ?? readyThinkingLevel)
+      : activeTab.thinkingLevel || readyThinkingLevel;
     const existingDefaultThinkingLevel =
       typeof next.defaultThinkingLevel === "string"
         ? next.defaultThinkingLevel
@@ -466,11 +481,13 @@ export const handleReady: BridgeMessageHandler = (data, ctx) => {
     // only on the tab record but the layout binds via the root mirror,
     // so the user wouldn't see the restored state until they switched
     // tabs and back.
-    if (activeTab) {
+    if (activeTab && !overviewOwnsSurface) {
       const tabRec = activeTab as unknown as Record<string, unknown>;
       for (const key of TAB_MIRROR_KEYS) {
         next[key as string] = tabRec[key as string];
       }
+    } else if (overviewOwnsSurface) {
+      mirrorOverviewSurfaceToRoot(next, next);
     }
     return next;
   });

--- a/src/hooks/projectOps/tabBuckets.test.ts
+++ b/src/hooks/projectOps/tabBuckets.test.ts
@@ -220,4 +220,34 @@ describe("switchProjectBucket", () => {
     expect(h.get().activeTabId).toBe("b1");
     expect((h.get().tabs as Tab[]).map((t) => t.id)).toEqual(["shell-b", "b1"]);
   });
+
+  it("keeps the overview model when restoring a shell-only project bucket", () => {
+    const shellMain = {
+      ...shellTab("shell-main", "P", "/P"),
+      model: "anthropic/claude-opus-4-7",
+      thinkingLevel: "high",
+    };
+    const h = makeHarness({
+      tabs: [],
+      activeTabId: "a1",
+      project: { id: "P" },
+      defaultModel: "openai-codex/gpt-5.5",
+      piDefaultModel: "openai-codex/gpt-5.5",
+      defaultThinkingLevel: "medium",
+      model: "openai-codex/gpt-5.5",
+      thinkingLevel: "medium",
+    });
+    h.tabBucketsRef.current.set("P", {
+      tabs: [shellMain],
+      activeTabId: "shell-main",
+    });
+
+    const restored = switchProjectBucket(h.deps, "P::workspace::A", "P");
+
+    expect(restored).toBe("shell-main");
+    expect(h.get().activeTabId).toBe("shell-main");
+    expect(h.get().kind).toBe("shell");
+    expect(h.get().model).toBe("openai-codex/gpt-5.5");
+    expect(h.get().thinkingLevel).toBe("medium");
+  });
 });

--- a/src/hooks/projectOps/tabBuckets.ts
+++ b/src/hooks/projectOps/tabBuckets.ts
@@ -3,6 +3,7 @@ import { NO_PROJECT_KEY, OVERVIEW_TAB_ID, type Tab } from "../../types/tab";
 import { recomputeModelPicker } from "../../utils/modelPicker";
 import type { ProjectsState } from "../../projects";
 import { TAB_MIRROR_KEYS } from "../useTabs";
+import { mirrorOverviewSurfaceToRoot } from "../tabOps/helpers";
 import type { TabBucket } from "./types";
 
 const WORKSPACE_BUCKET_SEPARATOR = "::workspace::";
@@ -262,6 +263,10 @@ export function switchProjectBucket(
       for (const key of TAB_MIRROR_KEYS) {
         result[key as string] = rec[key as string];
       }
+      const visibleModel =
+        activeTab.kind === "shell"
+          ? mirrorOverviewSurfaceToRoot(result, prev)
+          : activeTab.model;
       result.empty = false;
       result.hasTabs = true;
       // Restoring a real tab must clear any workspace-landing override,
@@ -270,7 +275,7 @@ export function switchProjectBucket(
       result.landing = null;
       result.sidebar = recomputeModelPicker(
         prev.sidebar as Record<string, unknown> | undefined,
-        activeTab.model,
+        visibleModel,
       );
       nextTerminalBuffer = activeTab.terminalBuffer ?? "";
     } else {

--- a/src/hooks/tabOps/helpers.ts
+++ b/src/hooks/tabOps/helpers.ts
@@ -1,6 +1,7 @@
 import type { Tab } from "../../types/tab";
 import { activeCwd, type ProjectsState } from "../../projects";
 import type { DiscoveredSession } from "./types";
+import { recomputeModelPicker } from "../../utils/modelPicker";
 
 /** Tab-strip label for a bridge-discovered persistent session. Prefers
  *  an explicit `customLabel` from the bridge, then the first user
@@ -56,6 +57,72 @@ export function modelForNewProjectTab(
     projectModel ||
     fallbackModel
   ).trim();
+}
+
+export function activeProjectIdForModelDefaults(
+  state: Record<string, unknown>,
+): string | null {
+  const project = state.project as { id?: unknown } | null | undefined;
+  if (typeof project?.id === "string" && project.id.length > 0) {
+    return project.id;
+  }
+  return typeof state.activeProjectId === "string" &&
+    state.activeProjectId.length > 0
+    ? state.activeProjectId
+    : null;
+}
+
+/** Model displayed by overview-owned surfaces. Shell tabs can be the
+ *  active tab for terminal focus, but the overview still owns the composer
+ *  and header in that state, so the visible model must be the model a new
+ *  task would inherit rather than stale shell metadata. */
+export function modelForOverviewSurface(
+  state: Record<string, unknown>,
+): string {
+  const piDefaultModel =
+    typeof state.piDefaultModel === "string" ? state.piDefaultModel : "";
+  return modelForNewProjectTab(
+    state,
+    activeProjectIdForModelDefaults(state),
+    piDefaultModel,
+  );
+}
+
+export function thinkingLevelForOverviewSurface(
+  state: Record<string, unknown>,
+): string | undefined {
+  return typeof state.defaultThinkingLevel === "string"
+    ? state.defaultThinkingLevel
+    : undefined;
+}
+
+export function mirrorOverviewSurfaceToRoot(
+  result: Record<string, unknown>,
+  sourceState: Record<string, unknown>,
+): string {
+  const overviewModel = modelForOverviewSurface(sourceState);
+  const overviewThinkingLevel = thinkingLevelForOverviewSurface(sourceState);
+  if (overviewModel) {
+    result.model = overviewModel;
+  }
+  if (overviewThinkingLevel) {
+    result.thinkingLevel = overviewThinkingLevel;
+  } else {
+    delete result.thinkingLevel;
+  }
+  return overviewModel;
+}
+
+export function mirrorOverviewSurfaceSelection(
+  result: Record<string, unknown>,
+  sourceState: Record<string, unknown>,
+): string {
+  const overviewModel = mirrorOverviewSurfaceToRoot(result, sourceState);
+  result.sidebar = recomputeModelPicker(
+    sourceState.sidebar as Record<string, unknown> | undefined,
+    overviewModel,
+  );
+  return overviewModel;
 }
 
 /** Resolve the cwd a freshly-opened tab should inherit. Active project

--- a/src/hooks/tabOps/mutations.test.ts
+++ b/src/hooks/tabOps/mutations.test.ts
@@ -40,6 +40,31 @@ describe("useMutations setActiveTab", () => {
     ]);
   });
 
+  it("restores overview model defaults when activating the overview sentinel", () => {
+    const shell = {
+      ...makeEmptyTab("shell-1", "Shell", "p1", "shell"),
+      model: "anthropic/claude-opus-4-7",
+      thinkingLevel: "high",
+    };
+    const { actions, stateRef } = setup({
+      tabs: [shell],
+      activeTabId: "shell-1",
+      project: { id: "p1" },
+      defaultModel: "openai-codex/gpt-5.5",
+      piDefaultModel: "openai-codex/gpt-5.5",
+      defaultThinkingLevel: "medium",
+      model: "anthropic/claude-opus-4-7",
+      thinkingLevel: "high",
+    });
+
+    act(() => actions.setActiveTab(OVERVIEW_TAB_ID));
+
+    expect(stateRef.current.activeTabId).toBe(OVERVIEW_TAB_ID);
+    expect(stateRef.current.landing).toBeNull();
+    expect(stateRef.current.model).toBe("openai-codex/gpt-5.5");
+    expect(stateRef.current.thinkingLevel).toBe("medium");
+  });
+
   it("clears a completed-turn attention marker when selecting that tab", () => {
     const tab = makeEmptyTab("tab-1", "Session", null, "agent");
     const { actions, stateRef } = setup({
@@ -52,5 +77,30 @@ describe("useMutations setActiveTab", () => {
 
     expect(stateRef.current.activeTabId).toBe("tab-1");
     expect(stateRef.current.agentAttentionTabs).toEqual({ other: true });
+  });
+
+  it("uses overview defaults instead of shell metadata when a shell tab is selected", () => {
+    const shell = {
+      ...makeEmptyTab("shell-1", "Shell", "p1", "shell"),
+      model: "anthropic/claude-opus-4-7",
+      thinkingLevel: "high",
+    };
+    const { actions, stateRef } = setup({
+      tabs: [shell],
+      activeTabId: OVERVIEW_TAB_ID,
+      project: { id: "p1" },
+      defaultModel: "openai-codex/gpt-5.5",
+      piDefaultModel: "openai-codex/gpt-5.5",
+      defaultThinkingLevel: "medium",
+      model: "openai-codex/gpt-5.5",
+      thinkingLevel: "medium",
+    });
+
+    act(() => actions.setActiveTab("shell-1"));
+
+    expect(stateRef.current.activeTabId).toBe("shell-1");
+    expect(stateRef.current.kind).toBe("shell");
+    expect(stateRef.current.model).toBe("openai-codex/gpt-5.5");
+    expect(stateRef.current.thinkingLevel).toBe("medium");
   });
 });

--- a/src/hooks/tabOps/mutations.ts
+++ b/src/hooks/tabOps/mutations.ts
@@ -3,6 +3,10 @@ import type { ShellMeta, Tab } from "../../types/tab";
 import { OVERVIEW_TAB_ID } from "../../types/tab";
 import { recomputeModelPicker } from "../../utils/modelPicker";
 import { TAB_MIRROR_KEYS, VALID_SHARE_MODES } from "./constants";
+import {
+  mirrorOverviewSurfaceSelection,
+  mirrorOverviewSurfaceToRoot,
+} from "./helpers";
 
 /** Tell the shared xterm panel to clear and replay a tab's terminal
  *  buffer. Microtask deferral so xterm's mount-once useEffect has
@@ -30,6 +34,20 @@ export interface MutationsActions {
   setActiveSubTab: (subId: string) => void;
 }
 
+function mirrorTabToRoot(
+  result: Record<string, unknown>,
+  sourceState: Record<string, unknown>,
+  tab: Tab,
+): string {
+  const tabRec = tab as unknown as Record<string, unknown>;
+  for (const key of TAB_MIRROR_KEYS) {
+    result[key as string] = tabRec[key as string];
+  }
+  if (tab.kind !== "shell") return tab.model || "";
+
+  return mirrorOverviewSurfaceToRoot(result, sourceState);
+}
+
 /** Mirror writes + active-tab switching. These are the lowest-level
  *  tab mutations — everything else builds on `updateTab` /
  *  `updateActiveTab` (which copy TAB_MIRROR_KEYS into the root state
@@ -47,10 +65,7 @@ export function useMutations(deps: MutationsDeps): MutationsActions {
       tabs[idx] = next;
       const result: Record<string, unknown> = { ...prev, tabs };
       if (prev.activeTabId === tabId) {
-        const nextRec = next as unknown as Record<string, unknown>;
-        for (const key of TAB_MIRROR_KEYS) {
-          result[key as string] = nextRec[key as string];
-        }
+        mirrorTabToRoot(result, prev, next);
       }
       return result;
     });
@@ -66,10 +81,7 @@ export function useMutations(deps: MutationsDeps): MutationsActions {
       const next = mutator(tabs[idx]);
       tabs[idx] = next;
       const result: Record<string, unknown> = { ...prev, tabs };
-      const nextRec = next as unknown as Record<string, unknown>;
-      for (const key of TAB_MIRROR_KEYS) {
-        result[key as string] = nextRec[key as string];
-      }
+      mirrorTabToRoot(result, prev, next);
       return result;
     });
   }
@@ -101,10 +113,22 @@ export function useMutations(deps: MutationsDeps): MutationsActions {
   function setActiveTab(tabId: string): void {
     if (tabId === OVERVIEW_TAB_ID) {
       setState((prev) => {
-        if (prev.activeTabId === OVERVIEW_TAB_ID && prev.landing == null) {
+        const result: Record<string, unknown> = {
+          ...prev,
+          activeTabId: OVERVIEW_TAB_ID,
+          landing: null,
+        };
+        const visibleModel = mirrorOverviewSurfaceSelection(result, prev);
+        const desiredThinkingLevel = result.thinkingLevel;
+        const alreadyClean =
+          prev.activeTabId === OVERVIEW_TAB_ID &&
+          prev.landing == null &&
+          (visibleModel ? prev.model === visibleModel : true) &&
+          prev.thinkingLevel === desiredThinkingLevel;
+        if (alreadyClean) {
           return prev;
         }
-        return { ...prev, activeTabId: OVERVIEW_TAB_ID, landing: null };
+        return result;
       });
       dispatchTerminalReplay("");
       return;
@@ -124,13 +148,10 @@ export function useMutations(deps: MutationsDeps): MutationsActions {
         delete nextAttention[tabId];
         result.agentAttentionTabs = nextAttention;
       }
-      const targetRec = target as unknown as Record<string, unknown>;
-      for (const key of TAB_MIRROR_KEYS) {
-        result[key as string] = targetRec[key as string];
-      }
+      const visibleModel = mirrorTabToRoot(result, prev, target);
       result.sidebar = recomputeModelPicker(
         prev.sidebar as Record<string, unknown> | undefined,
-        target.model,
+        visibleModel,
       );
       // Selecting any tab clears a workspace-landing override so the
       // chat canvas can render. Without this, clicking a tab while the

--- a/src/hooks/useSessionPersistence.test.tsx
+++ b/src/hooks/useSessionPersistence.test.tsx
@@ -53,6 +53,60 @@ describe("useSessionPersistence", () => {
     expect(appStore.getState().activeTabId).toBe("__overview__");
   });
 
+  it("uses overview defaults instead of shell metadata from sync reload snapshots", () => {
+    window.sessionStorage.setItem(
+      "aethon:session-ui-snapshot:v1",
+      JSON.stringify({
+        tabs: [
+          {
+            id: "shell-tab",
+            kind: "shell",
+            label: "Shell",
+            messages: [],
+            draft: "",
+            waiting: false,
+            queueCount: 0,
+            queuedMessages: [],
+            canvas: null,
+            model: "anthropic/claude-opus-4-7",
+            thinkingLevel: "high",
+            terminalBuffer: "",
+            projectId: null,
+            shell: {
+              cwd: "/repo/app",
+              command: "",
+              args: [],
+              shareMode: "private",
+              shellState: "running",
+            },
+          },
+        ],
+        activeTabId: "__overview__",
+        savedAt: 1,
+      }),
+    );
+
+    const { appStore } = buildInitialAppStore({
+      bootLayout: {
+        components: [],
+        state: {
+          terminalPanel: {},
+          defaultModel: "openai-codex/gpt-5.5",
+          piDefaultModel: "openai-codex/gpt-5.5",
+          defaultThinkingLevel: "medium",
+        },
+      },
+      logoUrl: "/logo.svg",
+      appVersion: "v0.0.0",
+    });
+
+    expect(appStore.getState()).toMatchObject({
+      activeTabId: "__overview__",
+      model: "openai-codex/gpt-5.5",
+      thinkingLevel: "medium",
+    });
+  });
+
   it("mirrors restored hot-reload busy state onto the active root tab", () => {
     window.sessionStorage.setItem(
       "aethon:session-ui-snapshot:v1",
@@ -158,6 +212,66 @@ describe("useSessionPersistence", () => {
       expect(appStore.getState().activeTabId).toBe("__overview__");
     });
     expect(appStore.getState().tabs).toHaveLength(1);
+  });
+
+  it("uses overview defaults instead of shell metadata during durable restore", async () => {
+    vi.mocked(readState).mockResolvedValue(
+      JSON.stringify({
+        tabs: [
+          {
+            id: "shell-tab",
+            kind: "shell",
+            label: "Shell",
+            messages: [],
+            draft: "",
+            waiting: false,
+            queueCount: 0,
+            queuedMessages: [],
+            canvas: null,
+            model: "anthropic/claude-opus-4-7",
+            thinkingLevel: "high",
+            terminalBuffer: "",
+            projectId: null,
+            shell: {
+              cwd: "/repo/app",
+              command: "",
+              args: [],
+              shareMode: "private",
+              shellState: "running",
+            },
+          },
+        ],
+        activeTabId: "__overview__",
+        savedAt: 1,
+      }),
+    );
+    const appStore = createAppStore({
+      tabs: [],
+      activeTabId: null,
+      layout: {},
+      terminalPanel: {},
+      defaultModel: "openai-codex/gpt-5.5",
+      piDefaultModel: "openai-codex/gpt-5.5",
+      defaultThinkingLevel: "medium",
+      model: "openai-codex/gpt-5.5",
+      thinkingLevel: "medium",
+    });
+
+    renderHook(() =>
+      useSessionPersistence({
+        appStore,
+        hasSyncSessionSnapshot: false,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(appStore.getState().tabs).toHaveLength(1);
+    });
+    expect(appStore.getState()).toMatchObject({
+      activeTabId: "__overview__",
+      model: "openai-codex/gpt-5.5",
+      thinkingLevel: "medium",
+    });
   });
 
   it("restores cold shell snapshots as exited instead of restarting commands", async () => {

--- a/src/hooks/useSessionPersistence.ts
+++ b/src/hooks/useSessionPersistence.ts
@@ -20,6 +20,7 @@ import {
 } from "../layoutPrefs";
 import { shouldReloadForHmrPayload } from "../utils/hmr";
 import { OVERVIEW_TAB_ID, type Tab } from "../types/tab";
+import { mirrorOverviewSurfaceToRoot } from "./tabOps/helpers";
 
 export interface BuildInitialAppStoreOptions {
   bootLayout: A2UIPayload;
@@ -43,6 +44,26 @@ function restoredActiveTabId(
   return tabs[0]?.id ?? null;
 }
 
+function rootMirrorForActiveSurface(
+  tabs: readonly Tab[],
+  activeTabId: string | null | undefined,
+  sourceState: Record<string, unknown>,
+): Record<string, unknown> {
+  const activeTab =
+    activeTabId && activeTabId !== OVERVIEW_TAB_ID
+      ? tabs.find((t) => t.id === activeTabId && t.kind !== "shell")
+      : undefined;
+  if (activeTab) {
+    const activeRecord = activeTab as unknown as Record<string, unknown>;
+    return Object.fromEntries(
+      TAB_MIRROR_KEYS.map((key) => [key, activeRecord[key]]),
+    );
+  }
+  const result: Record<string, unknown> = {};
+  mirrorOverviewSurfaceToRoot(result, sourceState);
+  return result;
+}
+
 export function buildInitialAppStore({
   bootLayout,
   logoUrl,
@@ -52,7 +73,6 @@ export function buildInitialAppStore({
   const layoutPrefs = loadLayoutPrefsSync();
   const tabs = restored?.tabs.length ? restored.tabs : [];
   const activeTabId = restoredActiveTabId(tabs, restored?.activeTabId);
-  const activeTab = tabs.find((t) => t.id === activeTabId) ?? tabs[0] ?? null;
   const restoredLayout =
     restored?.layout && typeof restored.layout === "object"
       ? (restored.layout as Record<string, unknown>)
@@ -73,15 +93,12 @@ export function buildInitialAppStore({
     (restored?.terminal as { open?: boolean } | undefined)?.open ?? false;
   const terminalHeight =
     typeof terminalPanel.height === "number" ? terminalPanel.height : 240;
-  const activeRecord =
-    (activeTab as unknown as Record<string, unknown> | null) ?? {};
-  const rootMirror = Object.fromEntries(
-    TAB_MIRROR_KEYS.map((key) => [key, activeRecord[key]]),
-  );
+  const bootState = bootLayout.state ?? {};
+  const rootMirror = rootMirrorForActiveSurface(tabs, activeTabId, bootState);
 
   return {
     appStore: createAppStore({
-      ...(bootLayout.state ?? {}),
+      ...bootState,
       ...(restored?.terminal ? { terminal: restored.terminal } : {}),
       terminalPanel,
       ...(restored?.scrollToMatchByTab
@@ -152,14 +169,7 @@ export function useSessionPersistence({
         const activeTabId = hasActiveTabs
           ? (restoredActiveTabId(tabs, snapshot.activeTabId) ?? tabs[0].id)
           : OVERVIEW_TAB_ID;
-        const activeTab = hasActiveTabs
-          ? (tabs.find((t) => t.id === activeTabId) ?? tabs[0])
-          : undefined;
-        const activeRecord =
-          (activeTab as unknown as Record<string, unknown>) ?? {};
-        const rootMirror = Object.fromEntries(
-          TAB_MIRROR_KEYS.map((key) => [key, activeRecord[key]]),
-        );
+        const rootMirror = rootMirrorForActiveSurface(tabs, activeTabId, prev);
         const restoredLayout =
           snapshot.layout && typeof snapshot.layout === "object"
             ? (snapshot.layout as Record<string, unknown>)


### PR DESCRIPTION
## Summary
- keep overview-owned surfaces mirrored to the default/new-session model instead of shell-tab metadata
- reset overview model/reasoning through tab selection, project bucket restore, session persistence, and bridge ready hydration
- add regressions for shell-only overview state, overview activation, reload restore, and bridge reconnects

## Validation
- bunx vitest run src/hooks/tabOps/mutations.test.ts src/hooks/projectOps/tabBuckets.test.ts src/eventRoutes/tabStrip.test.ts src/hooks/useSessionPersistence.test.tsx src/hooks/bridgeMessageHandlers/ready.test.ts
- bun run typecheck
- bun run lint (passes with existing react-refresh warning in src/extensions/default-layout/message-row.tsx)
- Computer Use UAT in Aethon Dev: clicked issue workspace session -> Back to overview -> project root; header stayed GPT-5.5 / medium and debug state stayed model=openai-codex/gpt-5.5, thinkingLevel=medium while shell tab metadata remained Claude/high
