### PR TITLE
refactor(app): extract shell orchestration hooks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,8 @@ import { defaultLayoutExtension } from "./extensions/default-layout";
 import { AppRoot } from "./app/AppRoot";
 import { BOOT_LAYOUT, hangWarnNotifId } from "./app/bootConstants";
 import { useAppForwardRefs } from "./app/useAppForwardRefs";
+import { useAppInteractions } from "./app/useAppInteractions";
+import { useAppRuntimeSurfaces } from "./app/useAppRuntimeSurfaces";
 import type { A2UIPayload } from "./types/a2ui";
 import type { Tab } from "./types/tab";
 import { useZoomAndTheme } from "./hooks/useZoomAndTheme";
@@ -21,8 +23,6 @@ import { useTabNavigation } from "./hooks/useTabNavigation";
 import { useTabs } from "./hooks/useTabs";
 import { useRestoreShellTabs } from "./hooks/useRestoreShellTabs";
 import { useExtensionsHydration } from "./hooks/useExtensionsHydration";
-import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
-import { useWindowApi } from "./runtime/windowApi";
 import { useBootConfig } from "./hooks/useBootConfig";
 import { useNotifications } from "./hooks/useNotifications";
 import { useWorkspacePrompts } from "./hooks/useWorkspacePrompts";
@@ -30,15 +30,12 @@ import { useFocus } from "./hooks/useFocus";
 import { useChat } from "./hooks/useChat";
 import { useQueuedDispatch } from "./hooks/useQueuedDispatch";
 import { useControlRequests } from "./hooks/useControlRequests";
-import { useFrontendStateMirror } from "./hooks/useFrontendStateMirror";
-import { usePersistEditorTabs } from "./hooks/usePersistEditorTabs";
 import { useUiOverlays } from "./hooks/useUiOverlays";
 import { useUpdater } from "./hooks/useUpdater";
 import { useWorkspaceStartup } from "./hooks/useWorkspaceStartup";
 import { UpdateBanner } from "./components/UpdateBanner";
 import { useProjectOps } from "./hooks/useProjectOps";
 import type { TabBucket } from "./hooks/projectOps/types";
-import { useOsEdges } from "./hooks/useOsEdges";
 import {
   buildInitialAppStore,
   useSessionPersistence,
@@ -50,7 +47,6 @@ import {
   findTabAcrossBuckets,
   updateTabAcrossBuckets,
 } from "./hooks/tabRouting";
-import { useAppEventRouting } from "./hooks/useAppEventRouting";
 import { useAppStateRefs } from "./hooks/useAppStateRefs";
 import { useProjectModelRecorder } from "./hooks/useProjectModelRecorder";
 import { useProjectSyncEffects } from "./hooks/useProjectSyncEffects";
@@ -805,127 +801,11 @@ export default function App() {
     markStartupChromeReady: () => setStartupChromeReady(true),
   });
 
-  // Global keyboard shortcuts. Lives in useKeyboardShortcuts which
-  // binds a document-level keydown listener with useCapture so we run
-  // before xterm sees the keystroke.
-  useKeyboardShortcuts({
+  // Keyboard shortcuts + A2UI event routing.
+  const onEvent = useAppInteractions({
     stateRef,
     extensionKeybindingsRef,
-    toggleTerminalAndFocus,
-    toggleSidebar,
-    toggleFilesSidebar,
-    toggleEditorPreview,
-    clearChat,
-    stopPrompt,
-    newTab,
-    newShellTab,
-    nextTab,
-    nextShellSubTab,
-    moveActiveTab,
-    moveActiveShellSubTab,
-    jumpToTab,
-    jumpToShellSubTab,
-    reopenLastClosedTab,
-    closeTab,
-    toggleSessionSearch,
-    openPalette,
-    closePalette,
-    togglePlanMode,
-    adjustZoom,
-    resetZoom,
-    toggleFocusComposerTerminal,
-    toggleSettings,
-    closeSettings,
-    openScheduledTasks,
-    closeScheduledTasks,
-    focusActiveContextInput,
-    exportActiveChatMarkdown,
-    pushNotification,
-    toggleAccounts,
-  });
-
-  // window.aethon runtime API + dev-only __AETHON_* debug hooks.
-  // Lives in src/runtime/windowApi.ts; mounts via useWindowApi.
-  useWindowApi({
-    layout,
-    bootLayout: BOOT_LAYOUT,
-    setLayout,
     setState,
-    stateRef,
-    registry,
-    layoutCatalogueRef,
-    projectsRef,
-    newTab,
-    closeTab,
-    setActiveTab,
-    activateLayoutById,
-    openProjectFromPicker,
-    openProjectByPath,
-    setActiveProjectById,
-    clearActiveProject,
-    removeProjectById,
-  });
-
-  // Mirror an allowlisted set of frontend state slices back to the bridge
-  // so extensions can introspect them. Debounced at 16 ms so a flurry of
-  // state changes (typing into the composer) coalesces into a single
-  // patch per slice.
-  useFrontendStateMirror({ state });
-
-  // Persist open editor tabs (debounced) so they restore on next launch.
-  usePersistEditorTabs({
-    stateRef,
-    projectsRef,
-    projectsLoadedRef,
-    tabsSignal: state.tabs,
-    activeTabId: state.activeTabId,
-  });
-
-  // OS-edge event listeners — PTY streams, agent supervisor signals,
-  // native menu, drag-drop file paths, clipboard image paste. Bridge
-  // response IPC stays in useBridgeMessages; this hook only owns
-  // listeners that aren't routed through the bridge response stream.
-  useOsEdges({
-    bootLayout: BOOT_LAYOUT,
-    setState,
-    stateRef,
-    activeResponseIdRef,
-    hangWarnTimersRef,
-    hangWarnActiveRef,
-    hangWarnNotifId,
-    autoRestartAgentRef,
-    shellInheritEnvRef,
-    updateTab,
-    newTab,
-    newShellTab,
-    closeTab,
-    nextTab,
-    appendMessage,
-    persistLocalChatMessage,
-    appendSystem,
-    setStatusFlags,
-    clearChat,
-    stopPrompt,
-    toggleTerminal,
-    toggleFilesSidebar,
-    togglePlanMode,
-    openSettings,
-    openScheduledTasks,
-    pushNotification,
-    dismissNotification,
-    checkForUpdates,
-  });
-
-  // Intercept events from layout-level components before they reach
-  // the agent. The layout speaks A2UI, but a few interactions need to
-  // drive native APIs (Tauri IPC for chat send, model picker) — the
-  // dispatcher lives in `src/eventRoutes/` and is wired here. Three
-  // precedence layers, in order: shell-consent reserved prefixes
-  // (security boundary), extension event-routes (extensibility),
-  // built-in route table.
-  const onEvent = useAppEventRouting({
-    setState,
-    stateRef,
     extensionEventRoutesRef,
     extensionEventRoutingModeRef,
     allDiscoveredSessionsRef,
@@ -1009,6 +889,76 @@ export default function App() {
     sortProjectWorkspacesNewest,
     invoke,
     writeState,
+    toggleTerminalAndFocus,
+    toggleSidebar,
+    toggleFilesSidebar,
+    nextTab,
+    nextShellSubTab,
+    moveActiveTab,
+    moveActiveShellSubTab,
+    jumpToTab,
+    jumpToShellSubTab,
+    reopenLastClosedTab,
+    toggleSessionSearch,
+    openPalette,
+    togglePlanMode,
+    adjustZoom,
+    resetZoom,
+    toggleFocusComposerTerminal,
+    toggleSettings,
+    openScheduledTasks,
+    closeScheduledTasks,
+    focusActiveContextInput,
+    exportActiveChatMarkdown,
+    toggleAccounts,
+  });
+
+  // Runtime API, bridge mirror, editor-tab persistence, and OS-edge listeners.
+  useAppRuntimeSurfaces({
+    layout,
+    bootLayout: BOOT_LAYOUT,
+    setLayout,
+    setState,
+    stateRef,
+    registry,
+    layoutCatalogueRef,
+    projectsRef,
+    newTab,
+    closeTab,
+    setActiveTab,
+    activateLayoutById,
+    openProjectFromPicker,
+    openProjectByPath,
+    setActiveProjectById,
+    clearActiveProject,
+    removeProjectById,
+    projectsLoadedRef,
+    tabsSignal: state.tabs,
+    activeTabId: state.activeTabId,
+    state,
+    activeResponseIdRef,
+    hangWarnTimersRef,
+    hangWarnActiveRef,
+    hangWarnNotifId,
+    autoRestartAgentRef,
+    shellInheritEnvRef,
+    updateTab,
+    newShellTab,
+    nextTab,
+    appendMessage,
+    persistLocalChatMessage,
+    appendSystem,
+    setStatusFlags,
+    clearChat,
+    stopPrompt,
+    toggleTerminal,
+    toggleFilesSidebar,
+    togglePlanMode,
+    openSettings,
+    openScheduledTasks,
+    pushNotification,
+    dismissNotification,
+    checkForUpdates,
   });
 
   const {

--- a/src/app/useAppInteractions.test.tsx
+++ b/src/app/useAppInteractions.test.tsx
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  useAppInteractions,
+  type UseAppInteractionsContext,
+} from "./useAppInteractions";
+
+const mocks = vi.hoisted(() => ({
+  eventHandler: vi.fn(),
+  useAppEventRouting: vi.fn(),
+  useKeyboardShortcuts: vi.fn(),
+}));
+
+vi.mock("../hooks/useAppEventRouting", () => ({
+  useAppEventRouting: mocks.useAppEventRouting,
+}));
+
+vi.mock("../hooks/useKeyboardShortcuts", () => ({
+  useKeyboardShortcuts: mocks.useKeyboardShortcuts,
+}));
+
+describe("useAppInteractions", () => {
+  it("mounts shortcuts and returns the routed A2UI event handler", () => {
+    mocks.useAppEventRouting.mockReturnValue(mocks.eventHandler);
+    const ctx = {
+      stateRef: { current: {} },
+    } as unknown as UseAppInteractionsContext;
+
+    const { result } = renderHook(() => useAppInteractions(ctx));
+
+    expect(mocks.useKeyboardShortcuts).toHaveBeenCalledWith(ctx);
+    expect(mocks.useAppEventRouting).toHaveBeenCalledWith(ctx);
+    expect(result.current).toBe(mocks.eventHandler);
+  });
+});

--- a/src/app/useAppInteractions.ts
+++ b/src/app/useAppInteractions.ts
@@ -1,0 +1,32 @@
+import {
+  useKeyboardShortcuts,
+  type UseKeyboardShortcutsContext,
+} from "../hooks/useKeyboardShortcuts";
+import { useAppEventRouting } from "../hooks/useAppEventRouting";
+import type { EventRouteContext } from "../eventRoutes";
+
+export type AppEventHandler = (
+  component: { id: string; type?: string },
+  eventType: string,
+  data?: unknown,
+) => Promise<boolean>;
+
+export type UseAppInteractionsContext = EventRouteContext &
+  UseKeyboardShortcutsContext;
+
+/**
+ * Installs the app's two interaction entrypoints:
+ *
+ * - document-level keyboard shortcuts
+ * - A2UI event routing for rendered layout components
+ *
+ * `AppRoot` only needs the returned `onEvent` handler; keeping shortcut
+ * subscription beside event routing makes the app shell's interaction
+ * boundary explicit.
+ */
+export function useAppInteractions(
+  ctx: UseAppInteractionsContext,
+): AppEventHandler {
+  useKeyboardShortcuts(ctx);
+  return useAppEventRouting(ctx);
+}

--- a/src/app/useAppRuntimeSurfaces.test.tsx
+++ b/src/app/useAppRuntimeSurfaces.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  useAppRuntimeSurfaces,
+  type UseAppRuntimeSurfacesContext,
+} from "./useAppRuntimeSurfaces";
+
+const hooks = vi.hoisted(() => ({
+  useFrontendStateMirror: vi.fn(),
+  useOsEdges: vi.fn(),
+  usePersistEditorTabs: vi.fn(),
+  useWindowApi: vi.fn(),
+}));
+
+vi.mock("../hooks/useFrontendStateMirror", () => ({
+  useFrontendStateMirror: hooks.useFrontendStateMirror,
+}));
+
+vi.mock("../hooks/useOsEdges", () => ({
+  useOsEdges: hooks.useOsEdges,
+}));
+
+vi.mock("../hooks/usePersistEditorTabs", () => ({
+  usePersistEditorTabs: hooks.usePersistEditorTabs,
+}));
+
+vi.mock("../runtime/windowApi", () => ({
+  useWindowApi: hooks.useWindowApi,
+}));
+
+describe("useAppRuntimeSurfaces", () => {
+  it("mounts every App runtime surface with the shared shell context", () => {
+    const ctx = {
+      state: { status: "ready" },
+    } as unknown as UseAppRuntimeSurfacesContext;
+
+    renderHook(() => useAppRuntimeSurfaces(ctx));
+
+    expect(hooks.useWindowApi).toHaveBeenCalledWith(ctx);
+    expect(hooks.useFrontendStateMirror).toHaveBeenCalledWith(ctx);
+    expect(hooks.usePersistEditorTabs).toHaveBeenCalledWith(ctx);
+    expect(hooks.useOsEdges).toHaveBeenCalledWith(ctx);
+  });
+});

--- a/src/app/useAppRuntimeSurfaces.ts
+++ b/src/app/useAppRuntimeSurfaces.ts
@@ -1,0 +1,43 @@
+import {
+  useFrontendStateMirror,
+  type UseFrontendStateMirrorContext,
+} from "../hooks/useFrontendStateMirror";
+import {
+  useOsEdges,
+  type UseOsEdgesContext,
+} from "../hooks/useOsEdges";
+import {
+  usePersistEditorTabs,
+  type UsePersistEditorTabsContext,
+} from "../hooks/usePersistEditorTabs";
+import {
+  useWindowApi,
+  type UseWindowApiContext,
+} from "../runtime/windowApi";
+
+export type UseAppRuntimeSurfacesContext = UseWindowApiContext &
+  UseFrontendStateMirrorContext &
+  UsePersistEditorTabsContext &
+  UseOsEdgesContext;
+
+/**
+ * Runtime surfaces mounted by the app shell after the core chat/project
+ * actions exist:
+ *
+ * - `window.aethon` API and debug hooks
+ * - frontend-state mirror back to the bridge
+ * - editor-tab persistence
+ * - OS-edge listeners that live outside the bridge JSON stream
+ *
+ * Keeping these together gives `App.tsx` one named boundary for the
+ * external runtime wiring while preserving each underlying hook's
+ * focused ownership.
+ */
+export function useAppRuntimeSurfaces(
+  ctx: UseAppRuntimeSurfacesContext,
+): void {
+  useWindowApi(ctx);
+  useFrontendStateMirror(ctx);
+  usePersistEditorTabs(ctx);
+  useOsEdges(ctx);
+}


### PR DESCRIPTION
## Summary

- Extract App interaction wiring into `useAppInteractions`, grouping keyboard shortcuts with A2UI event routing.
- Extract runtime surface wiring into `useAppRuntimeSurfaces`, grouping the window API, frontend-state mirror, editor-tab persistence, and OS-edge listeners.
- Add focused hook tests so future App cleanup keeps those orchestration boundaries wired.

## Validation

- `bunx vitest run src/app/useAppRuntimeSurfaces.test.tsx src/app/useAppInteractions.test.tsx`
- `bunx vitest run src/app/useAppRuntimeSurfaces.test.tsx src/app/useAppInteractions.test.tsx src/app/AppRoot.test.tsx src/hooks/useKeyboardShortcuts.test.tsx src/eventRoutes/index.test.ts src/eventRoutes/chatInput.test.ts src/eventRoutes/tabStrip.test.ts src/eventRoutes/terminal.test.ts src/eventRoutes/sidebar.test.ts src/eventRoutes/dashboard.test.ts`
- `bun run typecheck`
- `bun run lint` (passes with the existing Fast Refresh warning in `src/extensions/default-layout/message-row.tsx`)
- `bun run test`
- `bun run build`
- `check` (clippy, typecheck, lint wrapper, Rust tests, Vitest)

## UAT

- Launched the native dev app from the devshell with `dev`.
- Verified `window.aethon` is present, default-layout is registered, status is ready, and connection is connected through the debug webview eval server.
- Verified keyboard/runtime behavior via webview eval: terminal toggle, command palette open/escape close, and `window.aethon.closeTab()` roundtrip.
