### PR TITLE
refactor(app): extract routed tab helpers

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { ExtensionRegistry } from "./extensions/ExtensionRegistry";
 import { defaultLayoutExtension } from "./extensions/default-layout";
@@ -43,10 +43,7 @@ import {
 import { useDerivedRenderState } from "./hooks/useDerivedRenderState";
 import { useTabBucketHydration } from "./hooks/useTabBucketHydration";
 import { useTaskLauncher } from "./hooks/useTaskLauncher";
-import {
-  findTabAcrossBuckets,
-  updateTabAcrossBuckets,
-} from "./hooks/tabRouting";
+import { useRoutedTabHelpers } from "./hooks/useRoutedTabHelpers";
 import { useAppStateRefs } from "./hooks/useAppStateRefs";
 import { useProjectModelRecorder } from "./hooks/useProjectModelRecorder";
 import { useProjectSyncEffects } from "./hooks/useProjectSyncEffects";
@@ -58,10 +55,6 @@ import { useRootChromeActions } from "./hooks/useRootChromeActions";
 import { useActivateTabAnywhere } from "./hooks/useActivateTabAnywhere";
 import { useUpdaterConfigBridge } from "./hooks/useUpdaterConfigBridge";
 import { closeAllWorkspaceSessions } from "./hooks/tabOps/closeWorkspaceSessions";
-import {
-  clearClosedIssueLinks,
-  clearClosedIssueLinksInBuckets,
-} from "./extensions/default-layout/dashboard/issue-sessions";
 import type { NativeCanvasWindowRecord } from "./nativeWindows";
 import { writeState } from "./persist";
 import { useAppState } from "./state/appStore";
@@ -451,20 +444,11 @@ export default function App() {
   // last-active tab rather than the empty landing card.
   useTabBucketHydration(state.persistedTabBuckets, tabBucketsRef);
 
-  const updateTabRouted = useCallback(
-    (tabId: string, mutator: (tab: Tab) => Tab) => {
-      updateTabAcrossBuckets(
-        { setState, stateRef, projectsRef, tabBucketsRef },
-        tabId,
-        mutator,
-      );
-    },
-    [projectsRef, setState, stateRef, tabBucketsRef],
-  );
-  const findTabRouted = useCallback(
-    (tabId: string) => findTabAcrossBuckets(stateRef, tabBucketsRef, tabId),
-    [stateRef, tabBucketsRef],
-  );
+  const {
+    updateTabRouted,
+    findTabRouted,
+    clearClosedIssueLinksForProject,
+  } = useRoutedTabHelpers({ setState, stateRef, projectsRef, tabBucketsRef });
 
   // ---------------------------------------------------------------------
   // Toast stack + OS completion notification. Owned by useNotifications.
@@ -653,20 +637,6 @@ export default function App() {
     clearActiveProject,
     activateWorkspace,
   });
-
-  const clearClosedIssueLinksForProject = useCallback(
-    (projectId: string, openIssueNumbers: ReadonlySet<number>) => {
-      clearClosedIssueLinksInBuckets(
-        tabBucketsRef.current,
-        projectId,
-        openIssueNumbers,
-      );
-      setState((prev) =>
-        clearClosedIssueLinks(prev, projectId, openIssueNumbers),
-      );
-    },
-    [setState, tabBucketsRef],
-  );
 
   // Updater (Cmd menu / tray "Check for Updates" + agent-driven path).
   // The hook reads the persisted channel + auto-check toggle from

--- a/src/hooks/useRoutedTabHelpers.test.ts
+++ b/src/hooks/useRoutedTabHelpers.test.ts
@@ -1,0 +1,189 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { ProjectsState } from "../projects";
+import type { Tab } from "../types/tab";
+import type { TabBucket } from "./projectOps/types";
+import { useRoutedTabHelpers } from "./useRoutedTabHelpers";
+
+const ref = <T,>(value: T) => ({ current: value });
+
+const agentTab = (id: string, projectId: string | null = null): Tab => ({
+  id,
+  kind: "agent",
+  label: id,
+  messages: [],
+  draft: "",
+  waiting: false,
+  queueCount: 0,
+  queuedMessages: [],
+  canvas: null,
+  model: "gpt",
+  terminalBuffer: "",
+  projectId,
+});
+
+function makeProjects(): ProjectsState {
+  return {
+    projects: [],
+    activeId: "project-1",
+    activeWorkspaceId: null,
+    workspacesByProject: {},
+    activeHostId: null,
+  };
+}
+
+function makeHarness(seed: {
+  state: Record<string, unknown>;
+  buckets?: [string, TabBucket][];
+  projects?: ProjectsState;
+}) {
+  let state = seed.state;
+  const stateRef = ref(state);
+  const setState = (
+    next:
+      | Record<string, unknown>
+      | ((prev: Record<string, unknown>) => Record<string, unknown>),
+  ) => {
+    state = typeof next === "function" ? next(state) : next;
+    stateRef.current = state;
+  };
+  return {
+    get state() {
+      return state;
+    },
+    setState,
+    stateRef,
+    projectsRef: ref(seed.projects ?? makeProjects()),
+    tabBucketsRef: ref(new Map(seed.buckets ?? [])),
+  };
+}
+
+describe("useRoutedTabHelpers", () => {
+  it("updates and finds visible tabs while refreshing the active tab mirror", () => {
+    const visible = agentTab("visible-tab");
+    const ctx = makeHarness({
+      state: {
+        tabs: [visible],
+        activeTabId: "visible-tab",
+        draft: visible.draft,
+      },
+    });
+
+    const { result } = renderHook(() => useRoutedTabHelpers(ctx));
+
+    act(() => {
+      result.current.updateTabRouted("visible-tab", (tab) => ({
+        ...tab,
+        draft: "Mirrored draft",
+        label: "Renamed",
+      }));
+    });
+
+    expect(result.current.findTabRouted("visible-tab")?.label).toBe("Renamed");
+    expect(ctx.state.tabs).toMatchObject([{ id: "visible-tab", label: "Renamed" }]);
+    expect(ctx.state.draft).toBe("Mirrored draft");
+  });
+
+  it("updates and finds hidden bucket tabs without replacing visible tabs", () => {
+    const visible = agentTab("visible-tab");
+    const hidden = agentTab("hidden-tab");
+    const ctx = makeHarness({
+      state: { tabs: [visible], activeTabId: "visible-tab" },
+      buckets: [
+        [
+          "project-2",
+          {
+            tabs: [hidden],
+            activeTabId: "hidden-tab",
+          },
+        ],
+      ],
+    });
+
+    const { result } = renderHook(() => useRoutedTabHelpers(ctx));
+
+    act(() => {
+      result.current.updateTabRouted("hidden-tab", (tab) => ({
+        ...tab,
+        label: "Hidden renamed",
+      }));
+    });
+
+    expect(ctx.state.tabs).toEqual([visible]);
+    expect(result.current.findTabRouted("hidden-tab")?.label).toBe(
+      "Hidden renamed",
+    );
+    expect(ctx.state.persistedTabBuckets).toMatchObject({
+      "project-2": {
+        tabs: [{ id: "hidden-tab", label: "Hidden renamed" }],
+      },
+    });
+  });
+
+  it("clears closed issue links from visible state and hidden buckets", () => {
+    const visibleOpen = {
+      ...agentTab("visible-open", "project-1"),
+      sourceIssue: {
+        kind: "github-issue" as const,
+        projectId: "project-1",
+        number: 101,
+        url: "https://example.test/101",
+        title: "Open",
+        createdAt: 1,
+      },
+    };
+    const visibleClosed = {
+      ...agentTab("visible-closed", "project-1"),
+      sourceIssue: {
+        kind: "github-issue" as const,
+        projectId: "project-1",
+        number: 102,
+        url: "https://example.test/102",
+        title: "Closed",
+        createdAt: 1,
+      },
+    };
+    const hiddenClosed = {
+      ...agentTab("hidden-closed", "project-1"),
+      sourceIssue: {
+        kind: "github-issue" as const,
+        projectId: "project-1",
+        number: 103,
+        url: "https://example.test/103",
+        title: "Closed hidden",
+        createdAt: 1,
+      },
+    };
+    const ctx = makeHarness({
+      state: {
+        tabs: [visibleOpen, visibleClosed],
+        activeTabId: "visible-open",
+      },
+      buckets: [
+        [
+          "project-1::workspace::wt-1",
+          { tabs: [hiddenClosed], activeTabId: "hidden-closed" },
+        ],
+      ],
+    });
+
+    const { result } = renderHook(() => useRoutedTabHelpers(ctx));
+
+    act(() => {
+      result.current.clearClosedIssueLinksForProject(
+        "project-1",
+        new Set([101]),
+      );
+    });
+
+    const tabs = ctx.state.tabs as Tab[];
+    expect(tabs[0].sourceIssue?.number).toBe(101);
+    expect(tabs[1].sourceIssue).toBeUndefined();
+    expect(
+      ctx.tabBucketsRef.current.get("project-1::workspace::wt-1")?.tabs[0]
+        .sourceIssue,
+    ).toBeUndefined();
+  });
+});

--- a/src/hooks/useRoutedTabHelpers.ts
+++ b/src/hooks/useRoutedTabHelpers.ts
@@ -1,0 +1,64 @@
+import { useCallback, type Dispatch, type MutableRefObject, type SetStateAction } from "react";
+import type { ProjectsState } from "../projects";
+import type { Tab } from "../types/tab";
+import {
+  clearClosedIssueLinks,
+  clearClosedIssueLinksInBuckets,
+} from "../extensions/default-layout/dashboard/issue-sessions";
+import type { TabBucket } from "./projectOps/types";
+import { findTabAcrossBuckets, updateTabAcrossBuckets } from "./tabRouting";
+
+interface UseRoutedTabHelpersArgs {
+  setState: Dispatch<SetStateAction<Record<string, unknown>>>;
+  stateRef: MutableRefObject<Record<string, unknown>>;
+  projectsRef: MutableRefObject<ProjectsState>;
+  tabBucketsRef: MutableRefObject<Map<string, TabBucket>>;
+}
+
+export interface RoutedTabHelpers {
+  updateTabRouted: (tabId: string, mutator: (tab: Tab) => Tab) => void;
+  findTabRouted: (tabId: string) => Tab | undefined;
+  clearClosedIssueLinksForProject: (
+    projectId: string,
+    openIssueNumbers: ReadonlySet<number>,
+  ) => void;
+}
+
+export function useRoutedTabHelpers({
+  setState,
+  stateRef,
+  projectsRef,
+  tabBucketsRef,
+}: UseRoutedTabHelpersArgs): RoutedTabHelpers {
+  const updateTabRouted = useCallback(
+    (tabId: string, mutator: (tab: Tab) => Tab) => {
+      updateTabAcrossBuckets(
+        { setState, stateRef, projectsRef, tabBucketsRef },
+        tabId,
+        mutator,
+      );
+    },
+    [projectsRef, setState, stateRef, tabBucketsRef],
+  );
+
+  const findTabRouted = useCallback(
+    (tabId: string) => findTabAcrossBuckets(stateRef, tabBucketsRef, tabId),
+    [stateRef, tabBucketsRef],
+  );
+
+  const clearClosedIssueLinksForProject = useCallback(
+    (projectId: string, openIssueNumbers: ReadonlySet<number>) => {
+      clearClosedIssueLinksInBuckets(
+        tabBucketsRef.current,
+        projectId,
+        openIssueNumbers,
+      );
+      setState((prev) =>
+        clearClosedIssueLinks(prev, projectId, openIssueNumbers),
+      );
+    },
+    [setState, tabBucketsRef],
+  );
+
+  return { updateTabRouted, findTabRouted, clearClosedIssueLinksForProject };
+}


### PR DESCRIPTION
## Summary
- Extract routed tab update/lookup and closed issue link cleanup wiring from `App.tsx` into `useRoutedTabHelpers`
- Keep App as the composition layer while moving cross-bucket tab routing ownership into a focused hook
- Add focused coverage for visible active-tab mirror updates, hidden bucket routing, and closed issue link cleanup across visible + stashed tabs

Closes #400

## Validation
- `bun run typecheck`
- `bun run lint`
- `bunx vitest run src/hooks/useActivateTabAnywhere.test.ts src/hooks/useAppBridgeMessages.test.ts src/eventRoutes/sidebar.test.ts src/hooks/useRoutedTabHelpers.test.ts` (`useAppBridgeMessages.test.ts` is not present in this worktree; Vitest ran the existing matching paths)
- `bunx vitest run src/hooks/useBridgeMessages.test.ts`
- `bunx vitest run`
- `codex review --uncommitted` (no findings)
