### PR TITLE
fix: keep Pi UI status out of Aethon chat

### DIFF
--- a/agent/tab-lifecycle.test.ts
+++ b/agent/tab-lifecycle.test.ts
@@ -15,6 +15,7 @@ import {
   collectPiSlashCommands,
   emitReady,
   emitBashResult,
+  extensionUiContextForTab,
   extractToolContent,
   handleSessionEvent,
   inferToolResultLanguage,
@@ -628,6 +629,37 @@ describe("resolveTabCwd", () => {
       ),
     ).toBe("/projects/active");
     expect(resolveTabCwd("fresh-tab", {}, base)).toBe("/home/u/.aethon");
+  });
+});
+
+describe("extensionUiContextForTab", () => {
+  it("does not turn transient Pi status lines into chat output", () => {
+    const sent: Record<string, unknown>[] = [];
+    const ui = extensionUiContextForTab(
+      { send: (m) => sent.push(m) },
+      "tab-1",
+    );
+
+    ui.setStatus("jazz-bat", "bat:100%");
+    ui.setStatus("jazz-load", "load:20%");
+    ui.setStatus("jazz-git", "git:●1");
+    ui.setStatus("jazz-clock", "09:23");
+    ui.setStatus("jazz-bat", undefined);
+
+    expect(sent).toEqual([]);
+  });
+
+  it("does not surface generic Pi UI notifications as app notifications", () => {
+    const sent: Record<string, unknown>[] = [];
+    const ui = extensionUiContextForTab(
+      { send: (m) => sent.push(m) },
+      "tab-1",
+    );
+
+    ui.notify("MCP connected", "info");
+    ui.notify("OpenAI service tier: priority", "info");
+
+    expect(sent).toEqual([]);
   });
 });
 

--- a/agent/tab-lifecycle.test.ts
+++ b/agent/tab-lifecycle.test.ts
@@ -635,10 +635,7 @@ describe("resolveTabCwd", () => {
 describe("extensionUiContextForTab", () => {
   it("does not turn transient Pi status lines into chat output", () => {
     const sent: Record<string, unknown>[] = [];
-    const ui = extensionUiContextForTab(
-      { send: (m) => sent.push(m) },
-      "tab-1",
-    );
+    const ui = extensionUiContextForTab();
 
     ui.setStatus("jazz-bat", "bat:100%");
     ui.setStatus("jazz-load", "load:20%");
@@ -651,10 +648,7 @@ describe("extensionUiContextForTab", () => {
 
   it("does not surface generic Pi UI notifications as app notifications", () => {
     const sent: Record<string, unknown>[] = [];
-    const ui = extensionUiContextForTab(
-      { send: (m) => sent.push(m) },
-      "tab-1",
-    );
+    const ui = extensionUiContextForTab();
 
     ui.notify("MCP connected", "info");
     ui.notify("OpenAI service tier: priority", "info");

--- a/agent/tab-lifecycle/index.ts
+++ b/agent/tab-lifecycle/index.ts
@@ -58,7 +58,7 @@ export { emitReady } from "./ready-handshake";
 export { handleSessionEvent } from "./events";
 export { cancelAethonRetry, installAethonRetryClassifier } from "./retry";
 export type { EnsureTabOptions } from "./lifecycle";
-export { ensureTab, resolveTabCwd } from "./lifecycle";
+export { ensureTab, extensionUiContextForTab, resolveTabCwd } from "./lifecycle";
 export {
   contextUsageSnapshot,
   emitContextUsage,

--- a/agent/tab-lifecycle/lifecycle.ts
+++ b/agent/tab-lifecycle/lifecycle.ts
@@ -100,10 +100,7 @@ function resourceLoaderForTab(
   };
 }
 
-export function extensionUiContextForTab(
-  deps: TabLifecycleDeps,
-  tabId: string,
-): ExtensionUIContext {
+export function extensionUiContextForTab(): ExtensionUIContext {
   const passthroughTheme = {
     fg: (_color: string, text: string) => text,
     bg: (_color: string, text: string) => text,
@@ -346,7 +343,7 @@ export async function ensureTab(
   });
   emitContextUsage(state, deps, tabId, rec);
   await session.bindExtensions({
-    uiContext: extensionUiContextForTab(deps, tabId),
+    uiContext: extensionUiContextForTab(),
     onError: (error) => {
       lifecycleLog.warn(
         `pi extension error tabId=${tabId} event=${error.event}: ${error.error}`,

--- a/agent/tab-lifecycle/lifecycle.ts
+++ b/agent/tab-lifecycle/lifecycle.ts
@@ -100,23 +100,10 @@ function resourceLoaderForTab(
   };
 }
 
-function extensionUiContextForTab(
+export function extensionUiContextForTab(
   deps: TabLifecycleDeps,
   tabId: string,
 ): ExtensionUIContext {
-  const sendResult = (
-    message: string,
-    kind: "info" | "warning" | "error" = "info",
-  ) => {
-    if (!message.trim()) return;
-    deps.send({
-      type: "native_slash_result",
-      tabId,
-      command: "extension",
-      kind: kind === "error" ? "error" : "info",
-      message,
-    });
-  };
   const passthroughTheme = {
     fg: (_color: string, text: string) => text,
     bg: (_color: string, text: string) => text,
@@ -135,11 +122,9 @@ function extensionUiContextForTab(
     select: () => Promise.resolve(undefined),
     confirm: () => Promise.resolve(false),
     input: () => Promise.resolve(undefined),
-    notify: sendResult,
+    notify: () => {},
     onTerminalInput: () => () => {},
-    setStatus: (_key, text) => {
-      if (text) sendResult(text);
-    },
+    setStatus: () => {},
     setWorkingMessage: () => {},
     setWorkingVisible: () => {},
     setWorkingIndicator: () => {},

--- a/src/styles/chrome/chat.css
+++ b/src/styles/chrome/chat.css
@@ -2682,9 +2682,9 @@ body.ae-resizing-composer * {
 }
 
 .a2ui-status-center {
-  text-align: center;
+  text-align: left;
   color: var(--text);
-  flex: 1 1 auto;
+  flex: 0 1 auto;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -2694,6 +2694,7 @@ body.ae-resizing-composer * {
 .a2ui-status-right {
   text-align: right;
   flex: 0 1 auto;
+  margin-left: auto;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
## Summary
- make the Pi extension UI shim ignore generic `ctx.ui.setStatus` and `ctx.ui.notify` calls so personal Pi CLI status providers do not leak into Aethon chat or app toasts
- keep Aethon native slash command results on their separate existing path
- left-align the footer connection/status segment and keep the model segment pinned right

## Why
Personal Pi extensions such as status-jazz, pi-openai-service-tier, and pi-mcp-adapter treat `setStatus`/`notify` as transient CLI UI. Aethon was mapping that UI traffic into persisted chat messages or visible app notifications, producing repeated `bat/load/git`, MCP, and service-tier noise.

## Validation
- `bunx vitest run agent/tab-lifecycle.test.ts -t "extensionUiContextForTab"`
- `bunx vitest run agent/tab-lifecycle.test.ts agent/tab-lifecycle-bind.test.ts src/extensions/default-layout/layout/status-bar.test.tsx`
- `bun run typecheck`
- Live UAT in the already-running dev app: restarted only the agent bridge; Pi status/notify updates stopped appending to chat and stopped creating app notifications; `ping` settled back to `pong`.

## Notes
- Existing spam already written into a tab history is not removed by this change.
- A future dedicated status surface can reintroduce structured Pi status rendering without using chat or notifications.
