### PR TITLE
fix(devshell): resync node_modules when bun.lock changes

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -5,4 +5,10 @@ fi
 
 use flake
 
+# Reload the devshell when the JS lockfile moves (e.g. a `git pull` adds a
+# dependency). nix-direnv already watches flake.nix/flake.lock; adding
+# bun.lock makes the devshell's `frontend-deps` startup hook re-run and
+# resync node_modules without a manual `bun install`.
+watch_file bun.lock
+
 dotenv_if_exists .envrc.local

--- a/flake.nix
+++ b/flake.nix
@@ -343,6 +343,20 @@
               }
             ];
 
+            # Keep node_modules in sync with bun.lock on every devshell
+            # entry. The check is hash-guarded so it's a sub-ms no-op unless
+            # the lockfile moved (e.g. a `git pull` adding a dependency) —
+            # see scripts/ensure-frontend-deps.sh. `.envrc` does
+            # `watch_file bun.lock`, so nix-direnv reloads the shell (and
+            # re-fires this hook) the moment the lockfile changes. A failed
+            # sync warns but never aborts shell entry.
+            devshell.startup."frontend-deps".text = ''
+              if [ -x "$PRJ_ROOT/scripts/ensure-frontend-deps.sh" ]; then
+                "$PRJ_ROOT/scripts/ensure-frontend-deps.sh" \
+                  || echo "[deps] sync failed; run 'bun install' manually" >&2
+              fi
+            '';
+
             commands = [
               {
                 category = "dev";

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -116,30 +116,12 @@ else
   DEV_INFO="${HOME}/.aethon/dev-info.json"
 fi
 
+# Keep node_modules in sync with bun.lock before launching. The real work
+# (lockfile-hash staleness check + install) lives in a shared script so the
+# Nix devshell startup hook and this launcher use one source of truth — see
+# scripts/ensure-frontend-deps.sh. Honors AETHON_SKIP_BUN_INSTALL.
 ensure_frontend_deps() {
-  if [[ "${AETHON_SKIP_BUN_INSTALL:-0}" == "1" ]]; then
-    return
-  fi
-  if [[ -x "node_modules/.bin/vite" ]]; then
-    return
-  fi
-  if ! command -v bun >/dev/null 2>&1; then
-    echo "[dev] local Vite is missing and bun is not on PATH; run bun install" >&2
-    return 1
-  fi
-  echo "[dev] local Vite is missing; running bun install" >&2
-  if [[ -f bun.lock || -f bun.lockb ]]; then
-    if ! bun install --frozen-lockfile; then
-      echo "[dev] frozen bun install failed; retrying without --frozen-lockfile" >&2
-      bun install
-    fi
-  else
-    bun install
-  fi
-  if [[ ! -x "node_modules/.bin/vite" ]]; then
-    echo "[dev] bun install completed but node_modules/.bin/vite is still missing" >&2
-    return 1
-  fi
+  "$(dirname "$0")/ensure-frontend-deps.sh"
 }
 
 # Test whether ANY process is listening on TCP $1 on any interface or

--- a/scripts/ensure-frontend-deps.sh
+++ b/scripts/ensure-frontend-deps.sh
@@ -48,18 +48,25 @@ done
 hash_file() {
   if command -v sha256sum >/dev/null 2>&1; then
     sha256sum "$1" | cut -d' ' -f1
-  else
+  elif command -v shasum >/dev/null 2>&1; then
     shasum -a 256 "$1" | cut -d' ' -f1
+  else
+    echo "[deps] neither sha256sum nor shasum is on PATH; cannot hash $1" >&2
+    return 1
   fi
 }
 
 stamp="node_modules/.aethon-deps-lock-hash"
 want="$(hash_file "$lock_file")"
 
+# Read the stamp into a variable with an explicit `|| true` so a missing
+# stamp (first run) never trips errexit via the command substitution.
+current="$(cat "$stamp" 2>/dev/null || true)"
+
 # In sync iff node_modules is populated AND its stamp matches the lockfile.
 # The stamp lives inside node_modules, so wiping the tree also clears the
 # stamp and forces a reinstall.
-if [[ -x node_modules/.bin/vite && "$(cat "$stamp" 2>/dev/null)" == "$want" ]]; then
+if [[ -x node_modules/.bin/vite && "$current" == "$want" ]]; then
   exit 0
 fi
 

--- a/scripts/ensure-frontend-deps.sh
+++ b/scripts/ensure-frontend-deps.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Sync the JS dependency tree (node_modules) with bun.lock.
+#
+# Why this exists:
+#   node_modules drifts out of sync whenever bun.lock moves — e.g. a
+#   `git pull` lands a commit that adds a dependency. The old check ("is
+#   node_modules/.bin/vite present?") couldn't see that: vite was already
+#   installed, so it returned early and the new packages (smol-toml,
+#   pi-mcp-adapter, ...) were never installed. The first thing to notice
+#   was the build.rs sidecar `bun build` failing with "Could not resolve".
+#
+#   The correct staleness signal is the lockfile itself. We stamp a hash of
+#   bun.lock into node_modules after a successful install and re-run only
+#   when that hash changes. In steady state this is a sub-millisecond no-op,
+#   which matters because it runs on every devshell entry (see below).
+#
+# Used by:
+#   - the Nix devshell startup hook (flake.nix) — so entering / reloading the
+#     devshell auto-heals deps. `.envrc` does `watch_file bun.lock`, which
+#     makes nix-direnv reload the shell (and re-fire this hook) the moment a
+#     pull changes the lockfile.
+#   - scripts/dev.sh — belt-and-braces for non-direnv launches (CI,
+#     `nix develop -c dev`, direnv disabled).
+#
+# Skip entirely with AETHON_SKIP_BUN_INSTALL=1.
+#
+# Exit status:
+#   0  tree is in sync (no-op) or was successfully installed
+#   1  out of sync and could not be fixed (bun missing, install failed)
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+[[ "${AETHON_SKIP_BUN_INSTALL:-0}" == "1" ]] && exit 0
+
+# Pick the lockfile bun actually uses; nothing to sync against without one.
+lock_file=""
+for candidate in bun.lock bun.lockb; do
+  if [[ -f "$candidate" ]]; then
+    lock_file="$candidate"
+    break
+  fi
+done
+[[ -n "$lock_file" ]] || exit 0
+
+# Portable content hash: GNU coreutils (Linux) -> sha256sum, macOS -> shasum.
+hash_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | cut -d' ' -f1
+  else
+    shasum -a 256 "$1" | cut -d' ' -f1
+  fi
+}
+
+stamp="node_modules/.aethon-deps-lock-hash"
+want="$(hash_file "$lock_file")"
+
+# In sync iff node_modules is populated AND its stamp matches the lockfile.
+# The stamp lives inside node_modules, so wiping the tree also clears the
+# stamp and forces a reinstall.
+if [[ -x node_modules/.bin/vite && "$(cat "$stamp" 2>/dev/null)" == "$want" ]]; then
+  exit 0
+fi
+
+if ! command -v bun >/dev/null 2>&1; then
+  echo "[deps] node_modules is out of sync with $lock_file but bun is not on PATH; run 'bun install'" >&2
+  exit 1
+fi
+
+echo "[deps] $lock_file changed (or node_modules incomplete); running bun install" >&2
+# Prefer a frozen install so a stale lockfile is surfaced rather than
+# silently rewritten; fall back to a normal install if the lockfile and
+# package.json genuinely disagree.
+if ! bun install --frozen-lockfile; then
+  echo "[deps] frozen install failed; retrying without --frozen-lockfile" >&2
+  bun install
+fi
+
+if [[ ! -x node_modules/.bin/vite ]]; then
+  echo "[deps] bun install completed but node_modules/.bin/vite is still missing" >&2
+  exit 1
+fi
+
+printf '%s\n' "$want" >"$stamp"


### PR DESCRIPTION
## Problem

`dev` failed after a `git pull` with:

```
error: Could not resolve: "smol-toml". Maybe you need to "bun install"?
error: Could not resolve: "pi-mcp-adapter/index.ts". Maybe you need to "bun install"?
```

(surfaced from the `build.rs` sidecar `bun build`).

Root cause: `scripts/dev.sh`'s `ensure_frontend_deps` reinstalled deps only when `node_modules/.bin/vite` was **absent**. Vite was already installed from a prior run, so the guard returned early and never noticed that commit `9580ce6` had moved `bun.lock` (adding `smol-toml` + `pi-mcp-adapter`). Vite itself flagged it (*"Re-optimizing dependencies because lockfile has changed"*) but nothing acted on it.

## Fix

Key dependency sync off the **lockfile**, not Vite's presence, and make it the devshell's job (per request).

- **`scripts/ensure-frontend-deps.sh`** (new) — shared, hash-stamped sync. Stamps a `sha256` of `bun.lock` into `node_modules/.aethon-deps-lock-hash` after install; a sub-ms no-op unless the lockfile moved. Prefers `bun install --frozen-lockfile`, falls back to a normal install. Honors `AETHON_SKIP_BUN_INSTALL=1`. Portable hasher (`sha256sum` on Linux, `shasum -a 256` on macOS); resolves repo root from `BASH_SOURCE` so it's cwd-independent.
- **`flake.nix`** — `devshell.startup."frontend-deps"` hook runs the script on every shell entry. Hash-guarded so it's a no-op in steady state; a failed sync warns but never aborts shell entry.
- **`.envrc`** — `watch_file bun.lock` so nix-direnv reloads the devshell (re-firing the hook) the moment a pull changes the lockfile.
- **`scripts/dev.sh`** — `ensure_frontend_deps` now delegates to the shared script (belt-and-braces for non-direnv paths: CI, `nix develop -c dev`, direnv disabled).

## Verification

- Script scenarios: install+stamp on missing stamp, 0.011s no-op when in sync, immediate exit on `AETHON_SKIP_BUN_INSTALL=1`, reinstall+re-stamp on stale stamp, cwd-independent invocation.
- Confirmed the hook is baked into the realized devshell (`env.bash`) and end-to-end: corrupting the stamp then entering `nix develop` auto-resynced and restored the stamp to match `bun.lock`.
- `bash -n` clean on both scripts; `nix eval` of the devshell drv succeeds.
- Codex peer review: no correctness issues found.