### PR TITLE
UI/theme polish: calmer tool calls, flatter issues list, cleaner cards & pills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -645,6 +645,13 @@ remains for the case where stdin is wedged.
   (currently just the `AgentProcess` mutex). Business logic belongs in the
   agent, not the shell.
 - **No emojis in code or commits** unless the user explicitly asks.
+- **Disclosure affordances always use the shared `Chevron`**
+  (`src/extensions/default-layout/sidebar/chevron.tsx`). Every
+  expand/collapse control — sidebar sections, host/project/workspace rows,
+  file tree, Source Control headers, and anything new — renders
+  `<Chevron expanded={…} />` (wrapped in a `…-chevron`/`…-caret` span for
+  sizing). Never hand-roll a `▸`/`▾`/`>` text caret or one-off rotating
+  glyph; they drift in size and weight.
 
 ## Editing Tauri Config
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -562,6 +562,14 @@ The dev build must already be running — never launch a release build
 - **No global state in the Rust shell** beyond Tauri's `Manager`
   (currently just the `AgentProcess` mutex).
 - **No emojis in code or commits** unless asked.
+- **Disclosure affordances always use the shared `Chevron`**
+  (`src/extensions/default-layout/sidebar/chevron.tsx`). Every
+  expand/collapse control — sidebar sections, host/project/workspace rows,
+  file tree, Source Control headers, and anything new — renders
+  `<Chevron expanded={…} />` (wrapped in a `…-chevron`/`…-caret` span for
+  sizing). Never hand-roll a `▸`/`▾`/`>` text caret or a one-off rotating
+  glyph; they drift in size and weight. One component so every disclosure
+  rotates the same icon.
 - A few `react-hooks/*` per-line disables exist for set-state-in-effect
   resync paths + intentionally-empty memo deps. Audit on touch; don't
   broaden.

--- a/agent/session-history.test.ts
+++ b/agent/session-history.test.ts
@@ -178,19 +178,13 @@ describe("parseSessionHistoryLines", () => {
                 title: "read",
                 toolName: "read",
                 description: "src/App.tsx",
+                filePath: "src/App.tsx",
                 startedAt: 1_000,
                 endedAt: 2_500,
               },
-              children: [
-                {
-                  id: "restored-tool-call-read-1-result",
-                  type: "code",
-                  props: {
-                    content: "export function App() {}",
-                    language: "tsx",
-                  },
-                },
-              ],
+              // A successful read renders as a clickable filename — no
+              // file-content child is emitted.
+              children: [],
             },
           ],
         },

--- a/agent/tab-lifecycle.test.ts
+++ b/agent/tab-lifecycle.test.ts
@@ -334,7 +334,7 @@ describe("toolCardPayload", () => {
     const result = "x".repeat(2000);
     const payload = toolCardPayload({
       id: "tool-c1",
-      toolName: "read",
+      toolName: "bash",
       argsSummary: "",
       result,
     });
@@ -346,6 +346,38 @@ describe("toolCardPayload", () => {
     expect(code.type).toBe("code");
     expect(code.props.content.length).toBe(1500);
     expect(code.props.content.endsWith("…")).toBe(true);
+  });
+
+  it("suppresses the content child for a successful read and exposes filePath", () => {
+    const payload = toolCardPayload({
+      id: "tool-c1",
+      toolName: "read",
+      argsSummary: "src/App.tsx",
+      args: { path: "src/App.tsx" },
+      rootPath: "/repo",
+      result: "export function App() { return null; }",
+    });
+    const root = payload.components[0] as {
+      children: unknown[];
+      props: { filePath?: string; rootPath?: string };
+    };
+    // No file-content dump — the frontend renders a clickable filename instead.
+    expect(root.children).toHaveLength(0);
+    expect(root.props.filePath).toBe("src/App.tsx");
+    expect(root.props.rootPath).toBe("/repo");
+  });
+
+  it("keeps the output child for a FAILED read", () => {
+    const payload = toolCardPayload({
+      id: "tool-c1",
+      toolName: "read",
+      argsSummary: "src/missing.ts",
+      args: { path: "src/missing.ts" },
+      isError: true,
+      result: "ENOENT: no such file",
+    });
+    const root = payload.components[0] as { children: unknown[] };
+    expect(root.children).toHaveLength(1);
   });
 
   it("renders task text results as subagent prose output", () => {
@@ -367,7 +399,7 @@ describe("toolCardPayload", () => {
   it("infers the code language for file-backed tool results", () => {
     const payload = toolCardPayload({
       id: "tool-c1",
-      toolName: "read",
+      toolName: "write",
       argsSummary: "src/App.tsx lines 1-end",
       result: "export function App() { return null; }",
     });

--- a/agent/tool-card.ts
+++ b/agent/tool-card.ts
@@ -450,7 +450,13 @@ export function toolCardPayload(opts: {
   const children: unknown[] = [];
   const toolFileChange =
     fileChange ?? fileChangeForTool({ toolName, args, result, rootPath });
-  if (result !== undefined) {
+  // A successful `read` just dumps a whole file into the transcript — pure
+  // noise, since the user has the file. We render only a clickable filename
+  // (opens in Monaco) on the frontend, so emit no content child here. A
+  // failed read keeps its output (the error message is useful).
+  const readPath = toolName === "read" ? stringArg(args, "path") : "";
+  const isReadOk = toolName === "read" && !isError;
+  if (result !== undefined && !isReadOk) {
     const extracted = extractToolContent(result);
     if (extracted.text) {
       if (toolName === "task" || toolName === "task_batch") {
@@ -497,6 +503,8 @@ export function toolCardPayload(opts: {
           title: toolName,
           toolName,
           description: argsSummary || undefined,
+          ...(readPath ? { filePath: readPath } : {}),
+          ...(readPath && rootPath ? { rootPath } : {}),
           ...(startedAt !== undefined ? { startedAt } : {}),
           ...(endedAt !== undefined ? { endedAt } : {}),
           ...(isError ? { isError: true } : {}),

--- a/e2e/aethon.spec.ts
+++ b/e2e/aethon.spec.ts
@@ -249,14 +249,13 @@ test("chat canvas contains wide content without horizontal scrolling", async ({
     .evaluate((el) => ({ overflowX: getComputedStyle(el).overflowX }));
   expect(scrollerMetrics.overflowX).toBe("hidden");
 
-  const containment = await page.locator(".ae-tool-card").evaluate((details) => {
-    if (!(details instanceof HTMLDetailsElement)) {
-      throw new Error("expected tool card details element");
-    }
-    details.open = true;
-    details.dispatchEvent(new Event("toggle", { bubbles: true }));
+  // The card is collapsed by default; expand it via its disclosure summary
+  // (a button now, not a <details>) so the code block mounts.
+  await page.locator(".ae-tool-card-summary").click();
+  await expect(page.locator(".ae-tool-card .a2ui-code")).toBeVisible();
 
-    const code = details.querySelector(".a2ui-code");
+  const containment = await page.locator(".ae-tool-card").evaluate((card) => {
+    const code = card.querySelector(".a2ui-code");
     if (!code) throw new Error("expected open tool card code block");
     const scroller = document.querySelector(".a2ui-canvas-scroller");
     const codeRect = code.getBoundingClientRect();

--- a/src/extensions/default-layout/chat.test.tsx
+++ b/src/extensions/default-layout/chat.test.tsx
@@ -232,11 +232,18 @@ describe("ToolCard", () => {
     vi.useFakeTimers();
     vi.setSystemTime(10_000);
 
-    renderToolCard({ startedAt: 1_000, endedAt: 3_000, status: "cancelled" });
+    const { container } = renderToolCard({
+      startedAt: 1_000,
+      endedAt: 3_000,
+      status: "cancelled",
+    });
 
     expect(screen.getByText("Cancelled in 2.0s")).toBeTruthy();
     expect(screen.queryByText(/long-running/)).toBeNull();
-    expect(screen.getByLabelText("Tool cancelled")).toBeTruthy();
+    // State is conveyed by the card's border + duration label, not a glyph.
+    expect(
+      container.querySelector('.ae-tool-card[data-cancelled="true"]'),
+    ).toBeTruthy();
 
     vi.setSystemTime(30_000);
     vi.advanceTimersByTime(1_000);
@@ -245,7 +252,10 @@ describe("ToolCard", () => {
   });
 
   it("renders completed and failed terminal states with stable durations", () => {
-    const { rerender } = renderToolCard({ startedAt: 1_000, endedAt: 2_500 });
+    const { rerender, container } = renderToolCard({
+      startedAt: 1_000,
+      endedAt: 2_500,
+    });
     expect(screen.getByText("Completed in 1.5s")).toBeTruthy();
 
     rerender(
@@ -267,7 +277,9 @@ describe("ToolCard", () => {
       />,
     );
     expect(screen.getByText("Failed in 1.5s")).toBeTruthy();
-    expect(screen.getByLabelText("Tool failed")).toBeTruthy();
+    expect(
+      container.querySelector('.ae-tool-card[data-error="true"]'),
+    ).toBeTruthy();
   });
 });
 
@@ -1871,8 +1883,8 @@ describe("ChatHistory turn activity feed (mocked Virtuoso renders rows)", () => 
     expect(screen.getByText("bash")).toBeTruthy();
   });
 
-  it("keeps raw tool output visible when activity details are shown", () => {
-    renderGroupedHistory({
+  it("collapses tool output by default and reveals it on expand", () => {
+    const { container } = renderGroupedHistory({
       messages: [
         { id: "u1", role: "user", text: "run command" },
         {
@@ -1900,8 +1912,13 @@ describe("ChatHistory turn activity feed (mocked Virtuoso renders rows)", () => 
       transcriptVisibility: { toolCalls: "show" },
     });
 
-    expect(screen.getByText("raw command output")).toBeTruthy();
     expect(screen.getByText("done")).toBeTruthy();
+    // Tool cards collapse by default — stdout is hidden until expanded.
+    expect(screen.queryByText("raw command output")).toBeNull();
+    const cardSummary = container.querySelector(".ae-tool-card-summary");
+    expect(cardSummary).toBeTruthy();
+    fireEvent.click(cardSummary as Element);
+    expect(screen.getByText("raw command output")).toBeTruthy();
   });
 
   it("keeps turn activity mounted briefly while collapsing", () => {
@@ -2362,7 +2379,7 @@ describe("ChatHistory turn activity feed (mocked Virtuoso renders rows)", () => 
     expect(container.querySelectorAll(".ae-file-activity-card").length).toBe(1);
   });
 
-  it("auto-expands completed edit artifacts at the end of a turn", async () => {
+  it("keeps the completed edit artifacts card pinned regardless of the activity toggle", () => {
     renderGroupedHistory({
       messages: [
         { id: "u1", role: "user", text: "change files" },
@@ -2393,14 +2410,15 @@ describe("ChatHistory turn activity feed (mocked Virtuoso renders rows)", () => 
       transcriptVisibility: { toolCalls: "hide" },
     });
 
-    const summary = screen.getByRole("button", { name: /Edited 1 file/ });
-    expect(summary.getAttribute("aria-expanded")).toBe("true");
+    // The aggregated "Edited N files" card is a durable artifact — the file
+    // is always listed regardless of the tool-calls toggle / turn collapse.
     expect(screen.getByText("App.tsx")).toBeTruthy();
 
+    const summary = screen.getByRole("button", { name: /Edited 1 file/ });
     fireEvent.click(summary);
 
-    expect(summary.getAttribute("aria-expanded")).toBe("false");
-    await waitFor(() => expect(screen.queryByText("App.tsx")).toBeNull());
+    // Collapsing the turn body must NOT hide the pinned edits card.
+    expect(screen.getByText("App.tsx")).toBeTruthy();
   });
 
   it("does not rewrite compact edit artifact stats from the working tree", () => {
@@ -2725,7 +2743,7 @@ describe("ChatHistory turn activity feed (mocked Virtuoso renders rows)", () => 
   });
 
   it("keeps stopped assistant progress visible and expanded when there is no final answer", () => {
-    renderGroupedHistory({
+    const { container } = renderGroupedHistory({
       messages: [
         { id: "u1", role: "user", text: "Review this implementation" },
         {
@@ -2779,12 +2797,18 @@ describe("ChatHistory turn activity feed (mocked Virtuoso renders rows)", () => 
     ).toBeTruthy();
     expect(screen.getByText(/1 tool call/)).toBeTruthy();
     expect(screen.getByText("bash")).toBeTruthy();
-    expect(screen.getByText("mixed stop command output")).toBeTruthy();
+    // The turn stays expanded; the tool card itself is collapsed by default,
+    // so its stdout is revealed only after expanding the card.
     expect(
       screen
         .getByRole("button", { name: /1 tool call/ })
         .getAttribute("aria-expanded"),
     ).toBe("true");
+    expect(screen.queryByText("mixed stop command output")).toBeNull();
+    const cardSummary = container.querySelector(".ae-tool-card-summary");
+    expect(cardSummary).toBeTruthy();
+    fireEvent.click(cardSummary as Element);
+    expect(screen.getByText("mixed stop command output")).toBeTruthy();
   });
 
   it("keeps prior assistant prose visible when the latest agent row is hidden thinking", () => {
@@ -2887,7 +2911,7 @@ describe("ChatHistory turn activity feed (mocked Virtuoso renders rows)", () => 
   });
 
   it("keeps interrupted tool output visible when stop happens before prose", () => {
-    renderGroupedHistory({
+    const { container } = renderGroupedHistory({
       messages: [
         { id: "u1", role: "user", text: "Review this implementation" },
         {
@@ -2924,6 +2948,11 @@ describe("ChatHistory turn activity feed (mocked Virtuoso renders rows)", () => 
     const summary = screen.getByRole("button", { name: /1 tool call/ });
     expect(summary.getAttribute("aria-expanded")).toBe("true");
     expect(screen.getByText("bash")).toBeTruthy();
+    // Collapsed by default; expanding the card reveals the interrupted output.
+    expect(screen.queryByText("review output before stop")).toBeNull();
+    const cardSummary = container.querySelector(".ae-tool-card-summary");
+    expect(cardSummary).toBeTruthy();
+    fireEvent.click(cardSummary as Element);
     expect(screen.getByText("review output before stop")).toBeTruthy();
   });
 

--- a/src/extensions/default-layout/chat.test.tsx
+++ b/src/extensions/default-layout/chat.test.tsx
@@ -2956,6 +2956,43 @@ describe("ChatHistory turn activity feed (mocked Virtuoso renders rows)", () => 
     expect(screen.getByText("review output before stop")).toBeTruthy();
   });
 
+  it("expand-all reveals every tool card in the turn", () => {
+    const mkCard = (id: string, out: string) => ({
+      id,
+      type: "tool-card" as const,
+      props: { title: "bash", startedAt: 1, endedAt: 2 },
+      children: [{ id: `${id}-o`, type: "code", props: { content: out } }],
+    });
+    renderGroupedHistory({
+      messages: [
+        { id: "u1", role: "user", text: "go" },
+        {
+          id: "t1",
+          role: "agent",
+          a2ui: { components: [mkCard("c1", "first out"), mkCard("c2", "second out")] },
+        },
+      ],
+      waiting: false,
+      status: "ready",
+      transcriptVisibility: { toolCalls: "group-block" },
+    });
+
+    // Expand the turn body to surface the tool cards + the toolbar.
+    const turnHeader = screen.getByRole("button", { name: /tool call/ });
+    if (turnHeader.getAttribute("aria-expanded") !== "true") {
+      fireEvent.click(turnHeader);
+    }
+    // Cards are still collapsed individually by default.
+    expect(screen.queryByText("first out")).toBeNull();
+    expect(screen.queryByText("second out")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /Expand all/ }));
+
+    // The per-turn toolbar expands every card in its own subtree.
+    expect(screen.getByText("first out")).toBeTruthy();
+    expect(screen.getByText("second out")).toBeTruthy();
+  });
+
   it("keeps the latest stopped status turn expanded when no stop notice is in the transcript", () => {
     renderGroupedHistory({
       status: "stopped",

--- a/src/extensions/default-layout/composer-visibility-pills.tsx
+++ b/src/extensions/default-layout/composer-visibility-pills.tsx
@@ -25,21 +25,7 @@ const THINKING_LABEL: Record<VisibilityMode, string> = {
   hide: "off",
 };
 
-const THINKING_TITLE: Record<VisibilityMode, string> = {
-  show: "on",
-  collapse: "off",
-  hide: "off",
-};
-
 const TOOL_LABEL: Record<ToolCallsMode, string> = {
-  show: "on",
-  "group-turn": "off",
-  "group-run": "off",
-  "group-block": "off",
-  hide: "off",
-};
-
-const TOOL_TITLE: Record<ToolCallsMode, string> = {
   show: "on",
   "group-turn": "off",
   "group-run": "off",
@@ -148,34 +134,22 @@ export function ComposerVisibilityPills({
       category === "thinking"
         ? THINKING_LABEL[visibility.thinking]
         : TOOL_LABEL[visibility.toolCalls];
-    const titleText =
-      category === "thinking"
-        ? THINKING_TITLE[visibility.thinking]
-        : TOOL_TITLE[visibility.toolCalls];
-    const scoped = hasOverride(state, tabId, category);
+    const isOn = stateLabel === "on";
     return (
       <button
         type="button"
         className="ae-vis-pill"
         data-category={category}
         data-mode={mode}
-        data-scope={scoped ? "session" : "global"}
-        title={`${label}: ${titleText}${
-          scoped ? " — this session only (overrides the global default)" : ""
-        }. Click to toggle.`}
-        aria-label={`${label} visibility: ${stateLabel}${
-          scoped ? ", this session" : ""
-        }. Click to toggle.`}
+        data-on={isOn ? "true" : "false"}
+        title={`${label}: ${stateLabel}. Click to toggle.`}
+        aria-label={`${label} visibility: ${stateLabel}. Click to toggle.`}
+        aria-pressed={isOn}
         onClick={() => onEvent("cycle", { category })}
       >
         <span className="ae-vis-pill-dot" aria-hidden="true" />
         <span className="ae-vis-pill-label">{label}</span>
         <span className="ae-vis-pill-state">{stateLabel}</span>
-        {scoped && (
-          <span className="ae-vis-pill-scope" aria-hidden="true">
-            session
-          </span>
-        )}
       </button>
     );
   };
@@ -186,6 +160,7 @@ export function ComposerVisibilityPills({
         type="button"
         className="ae-vis-pill ae-plan-pill"
         data-mode={planMode ? "on" : "off"}
+        data-on={planMode ? "true" : "false"}
         title={`Plan mode is ${planMode ? "on" : "off"}. Click or press Shift+Tab to toggle.`}
         aria-label={`Plan mode: ${planMode ? "on" : "off"}. Click to toggle.`}
         aria-pressed={planMode}

--- a/src/extensions/default-layout/question-card.tsx
+++ b/src/extensions/default-layout/question-card.tsx
@@ -49,10 +49,21 @@ export function QuestionCard({ component }: BuiltinComponentProps) {
   }
 
   return (
-    <section className="ae-question-card" aria-label={title}>
+    <section
+      className="ae-question-card"
+      aria-label={title}
+      data-answered={answer ? "true" : undefined}
+    >
       <div className="ae-question-card-head">
         <span className="ae-question-card-kicker">{title}</span>
-        {answer && <span className="ae-question-card-state">answered</span>}
+        {answer && (
+          <span
+            className="ae-question-card-state"
+            aria-label={`Answered: ${answer.label}`}
+          >
+            ✓
+          </span>
+        )}
       </div>
       {prompt && <p className="ae-question-card-prompt">{prompt}</p>}
       <div className="ae-question-card-choices">
@@ -92,7 +103,6 @@ export function QuestionCard({ component }: BuiltinComponentProps) {
           </button>
         </form>
       )}
-      {answer && <p className="ae-question-answer">Selected: {answer.label}</p>}
     </section>
   );
 }

--- a/src/extensions/default-layout/sidebar/chevron.tsx
+++ b/src/extensions/default-layout/sidebar/chevron.tsx
@@ -1,13 +1,26 @@
 /**
  * Shared disclosure chevron used across the sidebar + Source Control
- * surfaces (file tree rows, host/project groups, the "N CHANGED" header).
- * One component so every expandable row rotates the same glyph.
+ * surfaces (file tree rows, host/project groups, collapsible sections,
+ * the "N CHANGED" header). One component so every expandable row rotates
+ * the same glyph.
+ *
+ * HARD RULE (see CLAUDE.md / AGENTS.md → Conventions): every
+ * expand/collapse affordance must render this `<Chevron>` — never a
+ * hand-rolled `▸`/`▾`/`>` text caret or a one-off rotating glyph.
  */
-export function Chevron({ expanded }: { expanded: boolean }) {
+export function Chevron({
+  expanded,
+  size = 14,
+}: {
+  expanded: boolean;
+  /** Rendered px (viewBox stays 12×12, so the glyph scales uniformly).
+   *  Defaults to 14; dense sidebar/chat rows pass 12. */
+  size?: number;
+}) {
   return (
     <svg
-      width="14"
-      height="14"
+      width={size}
+      height={size}
       viewBox="0 0 12 12"
       fill="none"
       stroke="currentColor"

--- a/src/extensions/default-layout/sidebar/host-group.tsx
+++ b/src/extensions/default-layout/sidebar/host-group.tsx
@@ -14,6 +14,7 @@
  */
 
 import type { ReactNode } from "react";
+import { Chevron } from "./chevron";
 
 export interface HostGroupItem {
   id: string;
@@ -106,21 +107,7 @@ export function HostGroup({
               onToggleExpand();
             }}
           >
-            <svg
-              width="12"
-              height="12"
-              viewBox="0 0 12 12"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.75"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              aria-hidden="true"
-            >
-              <path
-                d={expanded ? "M2.5 4.5L6 8L9.5 4.5" : "M4.5 2.5L8 6L4.5 9.5"}
-              />
-            </svg>
+            <Chevron expanded={expanded} size={12} />
           </button>
         ) : (
           <span className="a2ui-sidebar-item-discl-spacer" aria-hidden="true" />

--- a/src/extensions/default-layout/sidebar/index.tsx
+++ b/src/extensions/default-layout/sidebar/index.tsx
@@ -32,6 +32,7 @@ import {
   SearchableSidebarSection,
   type SidebarSectionExt,
 } from "./searchable-section";
+import { Chevron } from "./chevron";
 import { useSidebarContextMenu } from "./contextMenu";
 import { useSidebarResize } from "./resize";
 import { composeSidebarSections, resolveSidebarItems } from "./sections";
@@ -300,6 +301,30 @@ interface SidebarSectionBlockProps {
   onRenameWorkspaceEnd: (workspaceId: string) => void;
 }
 
+/** Per-section collapsed pref. Pure presentational state, so it lives in
+ *  localStorage (synchronous → no expand-then-collapse flash on load)
+ *  rather than the async disk-persist used for heavier state. */
+const SECTION_COLLAPSE_KEY = "aethon.sidebar.section-collapsed.";
+
+function readSectionCollapsed(id: string): boolean {
+  try {
+    return window.localStorage.getItem(SECTION_COLLAPSE_KEY + id) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function writeSectionCollapsed(id: string, collapsed: boolean): void {
+  try {
+    window.localStorage.setItem(
+      SECTION_COLLAPSE_KEY + id,
+      collapsed ? "1" : "0",
+    );
+  } catch {
+    /* private mode / unavailable — collapse just won't persist */
+  }
+}
+
 /** Plain (non-searchable) section block. Renders the title, the row
  *  list (with extension toggle / workspace disclosure / projects-slot
  *  alignment), and the trailing action row. Pulled out of Sidebar so
@@ -339,6 +364,19 @@ function SidebarSectionBlock({
   const isProjects = section.id === "projects";
   const isExtensionsSection =
     section.id === "extensions" || section.id === "extensions-user";
+
+  // Extension sections collapse to a single header row so a long list of
+  // disabled extensions stops eating the sidebar's vertical budget.
+  const collapsible = isExtensionsSection && Boolean(section.title);
+  const [collapsed, setCollapsed] = useState(
+    () => collapsible && readSectionCollapsed(section.id),
+  );
+  const toggleCollapsed = () =>
+    setCollapsed((prev) => {
+      const next = !prev;
+      writeSectionCollapsed(section.id, next);
+      return next;
+    });
 
   const finishWorkspaceDrag = () => {
     setDraggingWorkspaceId(null);
@@ -511,10 +549,26 @@ function SidebarSectionBlock({
         .filter(Boolean)
         .join(" ")}
     >
-      {section.title && (
-        <div className="a2ui-sidebar-section-title">{section.title}</div>
-      )}
-      {items.length === 0 ? (
+      {section.title &&
+        (collapsible ? (
+          <button
+            type="button"
+            className="a2ui-sidebar-section-title a2ui-sidebar-section-title-toggle"
+            onClick={toggleCollapsed}
+            aria-expanded={!collapsed}
+          >
+            <span className="a2ui-sidebar-section-caret" aria-hidden="true">
+              <Chevron expanded={!collapsed} />
+            </span>
+            <span className="a2ui-sidebar-section-title-text">
+              {section.title}
+            </span>
+            <span className="a2ui-sidebar-section-count">{items.length}</span>
+          </button>
+        ) : (
+          <div className="a2ui-sidebar-section-title">{section.title}</div>
+        ))}
+      {collapsed ? null : items.length === 0 ? (
         <div className="a2ui-sidebar-empty">empty</div>
       ) : (
         <ul className="a2ui-sidebar-list">
@@ -639,7 +693,7 @@ function SidebarSectionBlock({
           })}
         </ul>
       )}
-      {actions.length > 0 && (
+      {!collapsed && actions.length > 0 && (
         <ul className="a2ui-sidebar-actions">
           {actions.map((a) => (
             <li

--- a/src/extensions/default-layout/sidebar/item-row.tsx
+++ b/src/extensions/default-layout/sidebar/item-row.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import type { A2UIComponent, SidebarItem } from "../../../types/a2ui";
 import type { BuiltinComponentProps } from "../../../components/A2UIRenderer";
+import { Chevron } from "./chevron";
 
 export interface ItemRowProps {
   item: SidebarItem;
@@ -164,30 +165,7 @@ export function ItemRow({
         onToggleDisclosure?.();
       }}
     >
-      {/* Inline SVG instead of Unicode ▸/▾ — the geometric glyphs
-          render tiny at any font size because their metric box is
-          vertically thin. SVG scales exactly to the 12×12 viewport
-          so the chevron actually reads on Paper / Ember alike.
-          `currentColor` so the parent's `color:` controls fill. */}
-      <svg
-        width="12"
-        height="12"
-        viewBox="0 0 12 12"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.75"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        aria-hidden="true"
-      >
-        <path
-          d={
-            disclosure === "expanded"
-              ? "M2.5 4.5L6 8L9.5 4.5"
-              : "M4.5 2.5L8 6L4.5 9.5"
-          }
-        />
-      </svg>
+      <Chevron expanded={disclosure === "expanded"} size={12} />
     </button>
   ) : alignSlots ? (
     <span className="a2ui-sidebar-item-discl-spacer" aria-hidden="true" />

--- a/src/extensions/default-layout/sidebar/searchable-section.tsx
+++ b/src/extensions/default-layout/sidebar/searchable-section.tsx
@@ -4,6 +4,7 @@ import type {
   SidebarSection,
 } from "../../../types/a2ui";
 import type { BuiltinComponentProps } from "../../../components/A2UIRenderer";
+import { Chevron } from "./chevron";
 import { filterItems, providerOf } from "./filter";
 import { ItemRow, type ItemRowProps } from "./item-row";
 
@@ -103,7 +104,12 @@ export function SearchableSidebarSection({
                   onClick={() => toggleGroup(key)}
                   aria-expanded={!isCollapsed}
                 >
-                  <span className="a2ui-sidebar-group-caret">{isCollapsed ? "▸" : "▾"}</span>
+                  <span
+                    className="a2ui-sidebar-group-caret"
+                    aria-hidden="true"
+                  >
+                    <Chevron expanded={!isCollapsed} size={12} />
+                  </span>
                   <span className="a2ui-sidebar-group-name">{key}</span>
                   <span className="a2ui-sidebar-group-count">{gItems.length}</span>
                 </button>

--- a/src/extensions/default-layout/tool-activity-summary.ts
+++ b/src/extensions/default-layout/tool-activity-summary.ts
@@ -149,27 +149,6 @@ export function hasToolCardChildren(message: ChatMessage): boolean {
   );
 }
 
-export function withOpenToolCards(message: ChatMessage): ChatMessage {
-  if (!message.a2ui?.components?.length) return message;
-  return {
-    ...message,
-    a2ui: {
-      ...message.a2ui,
-      components: message.a2ui.components.map((component) =>
-        component.type === "tool-card"
-          ? {
-              ...component,
-              props: {
-                ...component.props,
-                defaultOpen: true,
-              },
-            }
-          : component,
-      ),
-    },
-  };
-}
-
 export function basename(path: string): string {
   return (
     path

--- a/src/extensions/default-layout/tool-card.subagent.test.tsx
+++ b/src/extensions/default-layout/tool-card.subagent.test.tsx
@@ -13,7 +13,15 @@ function taskCard(state: Record<string, unknown>) {
     type: "tool-card",
     props: { title: "task", toolName: "task", startedAt: 1 },
   };
-  render(<ToolCard component={component} state={state} onEvent={() => {}} />);
+  const result = render(
+    <ToolCard component={component} state={state} onEvent={() => {}} />,
+  );
+  // Tool cards collapse by default; expand to reveal the subagent timeline.
+  const summary = result.container.querySelector(".ae-tool-card-summary");
+  if (summary && summary.tagName === "BUTTON") {
+    fireEvent.click(summary);
+  }
+  return result;
 }
 
 describe("ToolCard subagent activity", () => {
@@ -108,7 +116,7 @@ describe("ToolCard subagent activity", () => {
 
 describe("ToolCard file changes", () => {
   it("renders and expands an edited file preview", () => {
-    render(
+    const { container } = render(
       <ToolCard
         component={{
           id: "tool-edit",
@@ -133,7 +141,12 @@ describe("ToolCard file changes", () => {
       />,
     );
 
-    fireEvent.click(screen.getByText("Edited 1 file"));
+    // The +1/-1 stat shows on the collapsed summary line; expand the card to
+    // reveal the file row + inline diff.
+    expect(screen.getAllByText("+1").length).toBeGreaterThan(0);
+    const summary = container.querySelector(".ae-tool-card-summary");
+    expect(summary).toBeTruthy();
+    fireEvent.click(summary as Element);
 
     expect(screen.getByText("App.tsx")).toBeTruthy();
     expect(screen.getAllByText("+1").length).toBeGreaterThan(0);
@@ -143,7 +156,7 @@ describe("ToolCard file changes", () => {
 
   it("emits file open and diff actions", () => {
     const onEvent = vi.fn();
-    render(
+    const { container } = render(
       <ToolCard
         component={{
           id: "tool-write",
@@ -165,7 +178,9 @@ describe("ToolCard file changes", () => {
       />,
     );
 
-    fireEvent.click(screen.getByText("Created 1 file"));
+    const summary = container.querySelector(".ae-tool-card-summary");
+    expect(summary).toBeTruthy();
+    fireEvent.click(summary as Element);
     fireEvent.click(screen.getByTitle("Open src/new.ts"));
     expect(onEvent).toHaveBeenCalledWith("tool-file-open", {
       filePath: "src/new.ts",

--- a/src/extensions/default-layout/tool-card.subagent.test.tsx
+++ b/src/extensions/default-layout/tool-card.subagent.test.tsx
@@ -195,4 +195,35 @@ describe("ToolCard file changes", () => {
       rootPath: "/repo",
     });
   });
+
+  it("keeps raw output when a file-change has no captured diff", () => {
+    const { container } = render(
+      <ToolCard
+        component={{
+          id: "tool-edit-nodiff",
+          type: "tool-card",
+          props: {
+            title: "edit",
+            toolName: "edit",
+            // No `preview` — so the tool's text output must not be dropped.
+            fileChange: { kind: "edited", path: "src/x.ts", additions: 1 },
+          },
+          children: [
+            { id: "out", type: "code", props: { content: "wrote it" } },
+          ],
+        }}
+        state={{}}
+        onEvent={() => {}}
+        renderChildren={() => <div>raw stdout here</div>}
+      />,
+    );
+
+    const summary = container.querySelector(".ae-tool-card-summary");
+    expect(summary).toBeTruthy();
+    fireEvent.click(summary as Element);
+
+    // Both the file row AND the raw stdout render when there is no diff.
+    expect(screen.getByText("x.ts")).toBeTruthy();
+    expect(screen.getByText("raw stdout here")).toBeTruthy();
+  });
 });

--- a/src/extensions/default-layout/tool-card.tsx
+++ b/src/extensions/default-layout/tool-card.tsx
@@ -301,7 +301,6 @@ export function ToolCard({
     fileChange?: ToolFileChange;
     filePath?: StringValue;
     rootPath?: StringValue;
-    defaultOpen?: BooleanValue;
   };
   const baseTitle = props.title ? resolveString(props.title, state) : "";
   const description = props.description
@@ -412,7 +411,10 @@ export function ToolCard({
   }
 
   const hasFileChange = Boolean(fileChange);
-  const hasRawOutput = hasChildren && !hasFileChange;
+  // Raw stdout still renders when an edit/write has no captured diff, so a
+  // tool's text output is never silently dropped (it renders alongside the
+  // file-change row in that case).
+  const hasRawOutput = hasChildren && !fileChange?.preview;
   // Every card collapses to one line. Edits/writes expand to their diff;
   // bash and friends expand to their stdout; subagents to their activity.
   const hasExpandableBody =
@@ -491,9 +493,8 @@ export function ToolCard({
           )}
           {hasFileChange && fileChange ? (
             <ToolFileChangeBody change={fileChange} onEvent={onEvent} />
-          ) : hasRawOutput ? (
-            renderChildren?.()
           ) : null}
+          {hasRawOutput ? renderChildren?.() : null}
         </div>
       )}
     </div>

--- a/src/extensions/default-layout/tool-card.tsx
+++ b/src/extensions/default-layout/tool-card.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { FileIcon } from "../../components/file-icon";
 import type { BooleanValue, NumberValue, StringValue } from "../../types/a2ui";
 import type { BuiltinComponentProps } from "../../components/A2UIRenderer";
@@ -327,15 +327,19 @@ export function ToolCard({
   // file-change summary visible because that lives outside the collapsible
   // body; only the raw output (bash stdout, etc.) hides.
   const [open, setOpen] = useState(false);
-  // Respond to the transcript-wide expand/collapse-all broadcast.
+  const cardRef = useRef<HTMLDivElement>(null);
+  // Respond to this turn's expand/collapse-all. The turn toolbar dispatches
+  // the event onto each card element in its own subtree (not window), so a
+  // turn's "Expand all" never reaches cards in sibling turns.
   useEffect(() => {
-    const onSetAll = (event: Event) => {
+    const el = cardRef.current;
+    if (!el) return;
+    const onSetOpen = (event: Event) => {
       const detail = (event as CustomEvent<{ open?: boolean }>).detail;
       if (detail && typeof detail.open === "boolean") setOpen(detail.open);
     };
-    window.addEventListener("aethon:tool-cards-set-open", onSetAll);
-    return () =>
-      window.removeEventListener("aethon:tool-cards-set-open", onSetAll);
+    el.addEventListener("aethon:tool-card-set-open", onSetOpen);
+    return () => el.removeEventListener("aethon:tool-card-set-open", onSetOpen);
   }, []);
 
   const [now, setNow] = useState(() => Date.now());
@@ -454,6 +458,7 @@ export function ToolCard({
 
   return (
     <div
+      ref={cardRef}
       className="ae-tool-card"
       data-open={open ? "true" : "false"}
       data-collapsible={hasExpandableBody ? "true" : "false"}

--- a/src/extensions/default-layout/tool-card.tsx
+++ b/src/extensions/default-layout/tool-card.tsx
@@ -141,29 +141,12 @@ function ToolStatusIcon({
       </span>
     );
   }
-  if (isError || isCancelled) {
-    const className = isCancelled
-      ? "ae-tool-status-icon ae-tool-status-cancelled"
-      : "ae-tool-status-icon ae-tool-status-error";
-    return (
-      <span
-        role="img"
-        aria-label={isCancelled ? "Tool cancelled" : "Tool failed"}
-        className={className}
-      >
-        <span aria-hidden="true">✕</span>
-      </span>
-    );
-  }
-  return (
-    <span
-      role="img"
-      aria-label="Tool completed"
-      className="ae-tool-status-icon ae-tool-status-done"
-    >
-      <span aria-hidden="true">✓</span>
-    </span>
-  );
+  // Completed / failed / cancelled state is conveyed by the card's border
+  // colour and the duration label ("Completed"/"Failed in …s"), so no static
+  // ✓/✕ glyph is rendered — it was redundant noise on every row.
+  void isError;
+  void isCancelled;
+  return null;
 }
 
 function basename(path: string): string {
@@ -208,18 +191,18 @@ function lineTone(line: string): "add" | "del" | "hunk" | "meta" | "ctx" {
   return "ctx";
 }
 
-function ToolFileChangePreview({
+/** The expandable body of an edit/write card: the file row (open file /
+ *  open diff) plus the inline diff. The "+N -M" stat now lives on the
+ *  tool-card summary line, so this renders only when the card is expanded. */
+function ToolFileChangeBody({
   change,
   onEvent,
 }: {
   change: ToolFileChange;
   onEvent: BuiltinComponentProps["onEvent"];
 }) {
-  const [open, setOpen] = useState(false);
   const filePath = typeof change.path === "string" ? change.path : "";
   if (!filePath) return null;
-  const kind = change.kind === "created" ? "created" : "edited";
-  const label = kind === "created" ? "Created 1 file" : "Edited 1 file";
   const fileName = basename(filePath);
   const dir = parentPath(filePath);
   const additions =
@@ -250,84 +233,54 @@ function ToolFileChangePreview({
   };
 
   return (
-    <details
-      className="ae-tool-file-change"
-      onToggle={(event) => setOpen(event.currentTarget.open)}
-    >
-      <summary className="ae-tool-file-change-summary">
-        <span className="ae-tool-file-change-chevron" aria-hidden="true">
-          <Chevron expanded={open} />
+    <div className="ae-tool-file-change-body">
+      <div className="ae-tool-file-row">
+        <button
+          type="button"
+          className="ae-tool-file-open"
+          title={`Open ${filePath}`}
+          onClick={() => onEvent("tool-file-open", eventPayload)}
+        >
+          <FileIcon path={filePath} isDir={false} className="ae-tool-file-icon" />
+          <span className="ae-tool-file-name">{fileName}</span>
+          {dir ? <span className="ae-tool-file-dir">{dir}</span> : null}
+        </button>
+        <span className="ae-tool-file-stat" aria-label="Line changes">
+          {additions > 0 ? (
+            <span className="ae-tool-file-add">+{additions}</span>
+          ) : null}
+          {deletions > 0 ? (
+            <span className="ae-tool-file-del">-{deletions}</span>
+          ) : null}
         </span>
-        <span className="ae-tool-file-change-icon" aria-hidden="true">
-          ✎
-        </span>
-        <span className="ae-tool-file-change-label">{label}</span>
-        {(additions > 0 || deletions > 0) && (
-          <span className="ae-tool-file-change-stat" aria-label="Line changes">
-            {additions > 0 ? (
-              <span className="ae-tool-file-add">+{additions}</span>
-            ) : null}
-            {deletions > 0 ? (
-              <span className="ae-tool-file-del">-{deletions}</span>
-            ) : null}
-          </span>
-        )}
-      </summary>
-      <div className="ae-tool-file-change-body">
-        <div className="ae-tool-file-row">
-          <button
-            type="button"
-            className="ae-tool-file-open"
-            title={`Open ${filePath}`}
-            onClick={() => onEvent("tool-file-open", eventPayload)}
-          >
-            <FileIcon
-              path={filePath}
-              isDir={false}
-              className="ae-tool-file-icon"
-            />
-            <span className="ae-tool-file-name">{fileName}</span>
-            {dir ? <span className="ae-tool-file-dir">{dir}</span> : null}
-          </button>
-          <span className="ae-tool-file-stat" aria-label="Line changes">
-            {additions > 0 ? (
-              <span className="ae-tool-file-add">+{additions}</span>
-            ) : null}
-            {deletions > 0 ? (
-              <span className="ae-tool-file-del">-{deletions}</span>
-            ) : null}
-          </span>
-          <button
-            type="button"
-            className="ae-tool-file-diff"
-            title={`Open diff for ${filePath}`}
-            aria-label={`Open diff for ${fileName}`}
-            onClick={() => onEvent("tool-file-diff", eventPayload)}
-          >
-            ⧉
-          </button>
-        </div>
-        {change.preview ? (
-          <pre className="ae-tool-file-diff-preview">
-            <code>
-              {previewLines(change.preview).map((line, index) => (
-                <span
-                  key={`${index}-${line}`}
-                  className={`ae-tool-file-diff-line is-${lineTone(line)}`}
-                >
-                  <span className="ae-tool-file-diff-lineno">{index + 1}</span>
-                  <span className="ae-tool-file-diff-text">{line || " "}</span>
-                </span>
-              ))}
-            </code>
-          </pre>
-        ) : (
-          <div className="ae-tool-file-no-preview">
-            No inline diff available
-          </div>
-        )}
+        <button
+          type="button"
+          className="ae-tool-file-diff"
+          title={`Open diff for ${filePath}`}
+          aria-label={`Open diff for ${fileName}`}
+          onClick={() => onEvent("tool-file-diff", eventPayload)}
+        >
+          ⧉
+        </button>
       </div>
-    </details>
+      {change.preview ? (
+        <pre className="ae-tool-file-diff-preview">
+          <code>
+            {previewLines(change.preview).map((line, index) => (
+              <span
+                key={`${index}-${line}`}
+                className={`ae-tool-file-diff-line is-${lineTone(line)}`}
+              >
+                <span className="ae-tool-file-diff-lineno">{index + 1}</span>
+                <span className="ae-tool-file-diff-text">{line || " "}</span>
+              </span>
+            ))}
+          </code>
+        </pre>
+      ) : (
+        <div className="ae-tool-file-no-preview">No inline diff available</div>
+      )}
+    </div>
   );
 }
 
@@ -346,6 +299,8 @@ export function ToolCard({
     toolName?: StringValue;
     status?: StringValue;
     fileChange?: ToolFileChange;
+    filePath?: StringValue;
+    rootPath?: StringValue;
     defaultOpen?: BooleanValue;
   };
   const baseTitle = props.title ? resolveString(props.title, state) : "";
@@ -367,10 +322,21 @@ export function ToolCard({
   const status = props.status ? resolveString(props.status, state) : undefined;
   const isCancelled = status === "cancelled";
   const running = startedAt !== undefined && endedAt === undefined;
-  const defaultOpen = props.defaultOpen
-    ? resolveBoolean(props.defaultOpen, state)
-    : false;
-  const [open, setOpen] = useState(defaultOpen);
+  // Tool calls are collapsed by default — the card shows only its summary
+  // row until the user expands it (or hits "expand all"). Edits keep their
+  // file-change summary visible because that lives outside the collapsible
+  // body; only the raw output (bash stdout, etc.) hides.
+  const [open, setOpen] = useState(false);
+  // Respond to the transcript-wide expand/collapse-all broadcast.
+  useEffect(() => {
+    const onSetAll = (event: Event) => {
+      const detail = (event as CustomEvent<{ open?: boolean }>).detail;
+      if (detail && typeof detail.open === "boolean") setOpen(detail.open);
+    };
+    window.addEventListener("aethon:tool-cards-set-open", onSetAll);
+    return () =>
+      window.removeEventListener("aethon:tool-cards-set-open", onSetAll);
+  }, []);
 
   const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
@@ -403,46 +369,128 @@ export function ToolCard({
     return `Completed in ${duration}`;
   }, [running, startedAt, elapsedMs, isCancelled, isError]);
 
+  // A successful `read` renders as a single clickable filename (opens in the
+  // Monaco editor) — no file-content dump. The path is taken from the
+  // explicit `filePath` prop when present, else parsed out of the legacy
+  // description ("<path> lines N-M") for older restored sessions.
+  const readFilePath = props.filePath ? resolveString(props.filePath, state) : "";
+  const readRootPath = props.rootPath ? resolveString(props.rootPath, state) : "";
+  const openPath =
+    readFilePath || (description ?? "").replace(/\s+lines\s+\S.*$/, "");
+  if (toolName === "read" && !isError && openPath) {
+    return (
+      <div className="ae-tool-card ae-tool-card-read">
+        <div className="ae-tool-card-summary">
+          <ToolStatusIcon
+            running={running}
+            isError={isError}
+            isCancelled={isCancelled}
+            isLongRunning={isLongRunning}
+          />
+          <span className="ae-tool-card-name">{baseTitle}</span>
+          <button
+            type="button"
+            className="ae-tool-card-read-path"
+            title={`Open ${openPath}`}
+            onClick={() =>
+              onEvent("tool-file-open", {
+                filePath: openPath,
+                ...(readRootPath ? { rootPath: readRootPath } : {}),
+              })
+            }
+          >
+            {description || openPath}
+          </button>
+          {timeSuffix && <span className="ae-tool-card-time">{timeSuffix}</span>}
+        </div>
+      </div>
+    );
+  }
+
+  const hasFileChange = Boolean(fileChange);
+  const hasRawOutput = hasChildren && !hasFileChange;
+  // Every card collapses to one line. Edits/writes expand to their diff;
+  // bash and friends expand to their stdout; subagents to their activity.
+  const hasExpandableBody =
+    hasFileChange || hasRawOutput || Boolean(subagentProgress);
+  const fileAdds =
+    fileChange && typeof fileChange.additions === "number"
+      ? fileChange.additions
+      : 0;
+  const fileDels =
+    fileChange && typeof fileChange.deletions === "number"
+      ? fileChange.deletions
+      : 0;
+  const summaryInner = (
+    <>
+      <ToolStatusIcon
+        running={running}
+        isError={isError}
+        isCancelled={isCancelled}
+        isLongRunning={isLongRunning}
+      />
+      <span className="ae-tool-card-name">{baseTitle}</span>
+      {description && (
+        <span className="ae-tool-card-description">{description}</span>
+      )}
+      {hasFileChange && (fileAdds > 0 || fileDels > 0) && (
+        <span className="ae-tool-card-diffstat" aria-label="Line changes">
+          {fileAdds > 0 ? (
+            <span className="ae-tool-file-add">+{fileAdds}</span>
+          ) : null}
+          {fileDels > 0 ? (
+            <span className="ae-tool-file-del">-{fileDels}</span>
+          ) : null}
+        </span>
+      )}
+      {timeSuffix && <span className="ae-tool-card-time">{timeSuffix}</span>}
+      {isLongRunning && (
+        <span className="ae-tool-card-long-hint">
+          long-running · <kbd>⌘.</kbd> to stop
+        </span>
+      )}
+    </>
+  );
+
   return (
-    <details
+    <div
       className="ae-tool-card"
-      open={open}
-      onToggle={(event) => setOpen(event.currentTarget.open)}
+      data-open={open ? "true" : "false"}
+      data-collapsible={hasExpandableBody ? "true" : "false"}
       data-running={running ? "true" : "false"}
       data-long-running={isLongRunning ? "true" : "false"}
       data-error={isError ? "true" : "false"}
       data-cancelled={isCancelled ? "true" : "false"}
     >
-      <summary className="ae-tool-card-summary">
-        <ToolStatusIcon
-          running={running}
-          isError={isError}
-          isCancelled={isCancelled}
-          isLongRunning={isLongRunning}
-        />
-        <span className="ae-tool-card-name">{baseTitle}</span>
-        {description && (
-          <span className="ae-tool-card-description">{description}</span>
-        )}
-        {timeSuffix && <span className="ae-tool-card-time">{timeSuffix}</span>}
-        {isLongRunning && (
-          <span className="ae-tool-card-long-hint">
-            long-running · <kbd>⌘.</kbd> to stop
+      {hasExpandableBody ? (
+        <button
+          type="button"
+          className="ae-tool-card-summary"
+          aria-expanded={open}
+          onClick={() => setOpen((prev) => !prev)}
+        >
+          <span className="ae-tool-card-disclosure" aria-hidden="true">
+            <Chevron expanded={open} size={12} />
           </span>
-        )}
-      </summary>
-      <div className="ae-tool-card-body">
-        {subagentProgress && (
-          <SubagentActivityStack progress={subagentProgress} />
-        )}
-        {fileChange && (
-          <ToolFileChangePreview change={fileChange} onEvent={onEvent} />
-        )}
-        {hasChildren && !fileChange?.preview ? renderChildren?.() : null}
-        {!hasChildren && !fileChange && !subagentProgress ? (
-          <div className="ae-tool-card-empty">No output</div>
-        ) : null}
-      </div>
-    </details>
+          {summaryInner}
+        </button>
+      ) : (
+        <div className="ae-tool-card-summary ae-tool-card-summary-static">
+          {summaryInner}
+        </div>
+      )}
+      {hasExpandableBody && open && (
+        <div className="ae-tool-card-body">
+          {subagentProgress && (
+            <SubagentActivityStack progress={subagentProgress} />
+          )}
+          {hasFileChange && fileChange ? (
+            <ToolFileChangeBody change={fileChange} onEvent={onEvent} />
+          ) : hasRawOutput ? (
+            renderChildren?.()
+          ) : null}
+        </div>
+      )}
+    </div>
   );
 }

--- a/src/extensions/default-layout/turn-activity.tsx
+++ b/src/extensions/default-layout/turn-activity.tsx
@@ -129,11 +129,20 @@ export function TurnActivity({
   const closingTimerRef = useRef<number | null>(null);
   const [manualOpen, setManualOpen] = useState<boolean | null>(null);
   const [allExpanded, setAllExpanded] = useState(false);
+  const turnRef = useRef<HTMLDivElement>(null);
   const setAllToolCardsOpen = (next: boolean) => {
     setAllExpanded(next);
-    window.dispatchEvent(
-      new CustomEvent("aethon:tool-cards-set-open", { detail: { open: next } }),
-    );
+    // Dispatch only to the cards inside THIS turn's subtree so sibling
+    // turns are unaffected.
+    turnRef.current
+      ?.querySelectorAll(".ae-tool-card")
+      .forEach((el) =>
+        el.dispatchEvent(
+          new CustomEvent("aethon:tool-card-set-open", {
+            detail: { open: next },
+          }),
+        ),
+      );
   };
   const progressMessages =
     live || forceOpen
@@ -255,6 +264,7 @@ export function TurnActivity({
 
   return (
     <div
+      ref={turnRef}
       className="ae-turn-activity"
       data-expanded={detailsOpen ? "true" : "false"}
     >

--- a/src/extensions/default-layout/turn-activity.tsx
+++ b/src/extensions/default-layout/turn-activity.tsx
@@ -128,6 +128,13 @@ export function TurnActivity({
   const [closingBodyRetained, setClosingBodyRetained] = useState(false);
   const closingTimerRef = useRef<number | null>(null);
   const [manualOpen, setManualOpen] = useState<boolean | null>(null);
+  const [allExpanded, setAllExpanded] = useState(false);
+  const setAllToolCardsOpen = (next: boolean) => {
+    setAllExpanded(next);
+    window.dispatchEvent(
+      new CustomEvent("aethon:tool-cards-set-open", { detail: { open: next } }),
+    );
+  };
   const progressMessages =
     live || forceOpen
       ? []
@@ -175,12 +182,14 @@ export function TurnActivity({
       )
       .map((message) => message.id),
   );
-  const fileChangeEntries =
-    detailsBodyVisible && !showOriginalToolCards
-      ? collectFileChangeEntries(
-          detailTools.filter((message) => !originalToolCardIds.has(message.id)),
-        )
-      : [];
+  // The aggregated "Edited N files" card is the durable artifact of a turn,
+  // so it stays visible regardless of the tool-calls visibility toggle or
+  // whether the activity body is expanded. When tool cards render in full
+  // (showOriginalToolCards) each edit shows its own change, so skip it then
+  // to avoid duplication.
+  const pinnedFileChangeEntries = showOriginalToolCards
+    ? []
+    : collectFileChangeEntries(allToolMessages.filter(hasFileChange));
   const detailToolRows =
     showOriginalToolCards || !showGenericTools
       ? []
@@ -279,6 +288,18 @@ export function TurnActivity({
       </button>
       {detailsBodyVisible && (
         <div className="ae-turn-activity-body" data-state={detailsBodyState}>
+          {originalToolCardIds.size > 0 && (
+            <div className="ae-turn-activity-toolbar">
+              <button
+                type="button"
+                className="ae-turn-activity-expand-all"
+                aria-expanded={allExpanded}
+                onClick={() => setAllToolCardsOpen(!allExpanded)}
+              >
+                {allExpanded ? "Collapse all" : "Expand all"}
+              </button>
+            </div>
+          )}
           {originalToolCardIds.size > 0
             ? detailTools
                 .filter((message) => originalToolCardIds.has(message.id))
@@ -307,11 +328,6 @@ export function TurnActivity({
               thinkingVisibility={thinkingVisibility}
             />
           ))}
-          <ToolFileChangesCard
-            entries={fileChangeEntries}
-            summary={summary}
-            onEvent={onEvent}
-          />
           {detailToolRows.map((message) => (
             <ToolActivityRow
               key={message.id}
@@ -331,6 +347,13 @@ export function TurnActivity({
             />
           ))}
         </div>
+      )}
+      {pinnedFileChangeEntries.length > 0 && (
+        <ToolFileChangesCard
+          entries={pinnedFileChangeEntries}
+          summary={summary}
+          onEvent={onEvent}
+        />
       )}
     </div>
   );

--- a/src/extensions/default-layout/turn-activity.tsx
+++ b/src/extensions/default-layout/turn-activity.tsx
@@ -22,7 +22,6 @@ import {
   summaryWithFileEntries,
   toolDurationLabel,
   toolStateLabel,
-  withOpenToolCards,
 } from "./tool-activity-summary";
 import {
   FileChangeStats,
@@ -221,6 +220,13 @@ export function TurnActivity({
     [],
   );
 
+  // Cards remount collapsed when the body is hidden, so keep the toolbar's
+  // "Expand all / Collapse all" label in sync rather than leaving it stale.
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- resync the toolbar label to body visibility
+    if (!detailsBodyVisible) setAllExpanded(false);
+  }, [detailsBodyVisible]);
+
   if (!hasActivity) return null;
   const label = activityLabel({
     summary,
@@ -316,7 +322,7 @@ export function TurnActivity({
                 .map((message) => (
                   <ChatMessageRow
                     key={message.id}
-                    message={withOpenToolCards(message)}
+                    message={message}
                     state={state}
                     tabId={tabId}
                     className={`${rowClassName} ae-turn-tool-message`}

--- a/src/extensions/default-layout/turn-activity.tsx
+++ b/src/extensions/default-layout/turn-activity.tsx
@@ -8,6 +8,7 @@ import {
 } from "../../utils/toolCardGrouping";
 import type { ConversationTurn } from "../../utils/transcriptRows";
 import type { ToolCallsMode, VisibilityMode } from "../../config";
+import { Chevron } from "./sidebar/chevron";
 import { ChatMessageRow } from "./message-row";
 import { hasDisplayableAgentContent } from "./turn-activity-helpers";
 import {
@@ -256,7 +257,7 @@ export function TurnActivity({
         onClick={handleToggle}
       >
         <span className="ae-turn-block-caret" aria-hidden="true">
-          {detailsOpen ? "▾" : "▸"}
+          <Chevron expanded={detailsOpen} size={12} />
         </span>
         <span className="ae-turn-block-label">{label}</span>
         {meta ? (

--- a/src/styles/chrome/chat.css
+++ b/src/styles/chrome/chat.css
@@ -3042,12 +3042,17 @@ body.ae-resizing-composer * {
 .ae-question-card {
   display: grid;
   gap: 12px;
-  max-width: 680px;
-  padding: 14px;
+  /* A fixed width (responsive cap) so stacked cards line up instead of
+     each shrinking to its own content — the old shrink-to-fit made a
+     3-choice card and a 4-choice card render at different widths. The
+     bubble wraps a shrink-to-fit child, so a percentage wouldn't break
+     the cycle; an absolute width does. */
+  width: 680px;
+  max-width: 100%;
+  padding: 16px;
   border: 1px solid var(--border);
-  border-radius: 8px;
-  background: color-mix(in srgb, var(--bg-elevated) 92%, var(--accent) 8%);
-  box-shadow: var(--shadow-sm);
+  border-radius: var(--radius-lg);
+  background: var(--bg-elev);
 }
 
 .ae-question-card-head {
@@ -3055,19 +3060,33 @@ body.ae-resizing-composer * {
   align-items: center;
   justify-content: space-between;
   gap: 10px;
+  min-height: 18px;
 }
 
-.ae-question-card-kicker,
-.ae-question-card-state {
+.ae-question-card-kicker {
   color: var(--text-dim);
   font-size: 0.72rem;
   font-weight: 700;
-  letter-spacing: 0;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
 }
 
-.ae-question-card-prompt,
-.ae-question-answer {
+/* Answered marker — one compact accent check that replaces the old
+   wordy "ANSWERED" badge plus the redundant "Selected: …" footer. */
+.ae-question-card-state {
+  display: inline-grid;
+  place-items: center;
+  width: 18px;
+  height: 18px;
+  border-radius: var(--radius-circle);
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 0.72rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.ae-question-card-prompt {
   margin: 0;
   color: var(--text);
 }
@@ -3079,31 +3098,59 @@ body.ae-resizing-composer * {
 }
 
 .ae-question-choice {
+  position: relative;
   display: grid;
   gap: 4px;
   min-height: 58px;
   padding: 10px 12px;
   border: 1px solid var(--border);
-  border-radius: 7px;
+  border-radius: var(--radius-md);
   background: var(--bg);
   color: var(--text);
   text-align: left;
   cursor: pointer;
+  transition:
+    border-color var(--motion-fast) ease,
+    background var(--motion-fast) ease,
+    opacity var(--motion-fast) ease;
 }
 
-.ae-question-choice:hover:not(:disabled),
+.ae-question-choice:hover:not(:disabled) {
+  border-color: var(--border-strong);
+  background: var(--bg-hover);
+}
+
 .ae-question-choice.is-selected {
+  padding-right: 28px;
   border-color: var(--accent);
   background: var(--accent-soft);
+  box-shadow: inset 0 0 0 1px var(--accent);
+}
+
+/* Check glyph on the chosen option so the selection reads instantly. */
+.ae-question-choice.is-selected::after {
+  content: "✓";
+  position: absolute;
+  top: 9px;
+  right: 10px;
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 700;
+  line-height: 1;
 }
 
 .ae-question-choice:disabled {
   cursor: default;
-  opacity: 0.72;
+}
+
+/* Once answered, fade the options that weren't chosen so the pick is
+   unambiguous without an extra confirmation line. */
+.ae-question-card[data-answered] .ae-question-choice:not(.is-selected) {
+  opacity: 0.4;
 }
 
 .ae-question-choice span {
-  font-weight: 650;
+  font-weight: 600;
 }
 
 .ae-question-choice small {

--- a/src/styles/chrome/composer.css
+++ b/src/styles/chrome/composer.css
@@ -40,40 +40,29 @@
   background: var(--accent);
   flex: none;
 }
-/* Per-session override marker — a small accent tag after the state text. */
-.ae-vis-pill[data-scope="session"] {
+/* Unified on/off treatment across all three pills (Plan mode, Thinking,
+   Tool calls). ON: an accent-tinted pill with the state word ("on") in
+   the accent colour. OFF: quiet/dim with a hollow dot. Driven by
+   `data-on` so every pill reads identically regardless of its underlying
+   mode enum. */
+.ae-vis-pill[data-on="true"] {
   border-color: color-mix(in oklab, var(--accent) 55%, var(--border));
-}
-.ae-vis-pill-scope {
-  font-size: 9px;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  padding: 1px 4px;
-  border-radius: 999px;
-  background: color-mix(in oklab, var(--accent) 20%, transparent);
-  color: var(--accent);
-}
-.ae-vis-pill[data-mode="hide"],
-.ae-vis-pill[data-mode="collapse"],
-.ae-vis-pill[data-mode="group-turn"],
-.ae-vis-pill[data-mode="group-run"],
-.ae-vis-pill[data-mode="group-block"] {
-  color: color-mix(in oklab, var(--text-dim) 70%, transparent);
-}
-.ae-vis-pill[data-mode="hide"] .ae-vis-pill-dot,
-.ae-vis-pill[data-mode="collapse"] .ae-vis-pill-dot,
-.ae-vis-pill[data-mode="group-turn"] .ae-vis-pill-dot,
-.ae-vis-pill[data-mode="group-run"] .ae-vis-pill-dot,
-.ae-vis-pill[data-mode="group-block"] .ae-vis-pill-dot {
-  background: transparent;
-  border: 1px solid var(--border-strong);
-}
-.ae-plan-pill[data-mode="on"] {
-  border-color: color-mix(in oklab, var(--accent) 70%, var(--border));
-  background: color-mix(in oklab, var(--accent) 14%, transparent);
+  background: color-mix(in oklab, var(--accent) 12%, transparent);
   color: var(--text);
 }
-.ae-plan-pill[data-mode="off"] .ae-vis-pill-dot {
+.ae-vis-pill[data-on="true"]:hover {
+  border-color: color-mix(in oklab, var(--accent) 70%, var(--border));
+  background: color-mix(in oklab, var(--accent) 18%, transparent);
+}
+.ae-vis-pill[data-on="true"] .ae-vis-pill-state {
+  color: var(--accent);
+  opacity: 1;
+  font-weight: 600;
+}
+.ae-vis-pill[data-on="false"] {
+  color: color-mix(in oklab, var(--text-dim) 70%, transparent);
+}
+.ae-vis-pill[data-on="false"] .ae-vis-pill-dot {
   background: transparent;
   border: 1px solid var(--border-strong);
 }

--- a/src/styles/chrome/dashboard.css
+++ b/src/styles/chrome/dashboard.css
@@ -753,13 +753,13 @@ button.a2ui-gh-stat:hover {
 .a2ui-dashboard-issues-count {
   display: inline-flex;
   align-items: center;
-  padding: 0 8px;
-  background: var(--bg-elev, var(--bg-input));
-  border: 1px solid var(--border);
+  padding: 0 7px;
+  background: var(--bg-active);
   color: var(--text-dim);
   border-radius: var(--radius-pill);
   font-size: var(--chrome-text-muted);
-  min-width: 1.6em;
+  font-variant-numeric: tabular-nums;
+  min-width: 1.5em;
   justify-content: center;
 }
 .a2ui-dashboard-issues-refresh {
@@ -791,28 +791,42 @@ button.a2ui-gh-stat:hover {
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 1px;
 }
+/* A flat list with hairline row dividers — not a stack of individually
+   outlined cards. The dashboard card is the only box; rows are split by
+   a single divider and lift only on hover. */
 .a2ui-dashboard-issue-row {
   position: relative;
   display: grid;
   grid-template-columns: 1fr auto;
   gap: var(--space-2);
   align-items: start;
-  padding: var(--space-2) var(--space-3);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
+  /* Row text aligns flush with the section header; the negative inline
+     margin lets the hover wash + divider bleed into the card gutter so
+     the list reads as one surface rather than an inset block. */
+  padding: var(--space-3) var(--space-2);
+  margin-inline: calc(var(--space-2) * -1);
+  border-bottom: 1px solid var(--border);
   cursor: pointer;
-  transition:
-    background var(--motion-fast) ease,
-    border-color var(--motion-fast) ease;
+  transition: background var(--motion-fast) ease;
+}
+.a2ui-dashboard-issues-list .a2ui-dashboard-issue-row:last-child {
+  border-bottom: 0;
 }
 .a2ui-dashboard-issue-row:hover {
   background: var(--bg-hover);
-  border-color: var(--border-strong, var(--border));
 }
-.a2ui-dashboard-issue-row.is-linked-session {
-  border-color: color-mix(in oklab, var(--accent) 32%, var(--border));
+/* Linked-session rows get a quiet accent rail at the left edge instead
+   of an accent-tinted border wrapping the whole row. */
+.a2ui-dashboard-issue-row.is-linked-session::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 7px;
+  bottom: 7px;
+  width: 2px;
+  border-radius: var(--radius-pill);
+  background: var(--accent);
 }
 .a2ui-dashboard-issue-line {
   display: flex;
@@ -858,20 +872,23 @@ button.a2ui-gh-stat:hover {
   max-width: min(100%, 24rem);
   min-width: 0;
   padding: 1px var(--space-2);
-  border: 1px solid color-mix(in oklab, var(--accent) 40%, var(--border));
+  border: 1px solid transparent;
   border-radius: var(--radius-pill);
-  background: color-mix(in oklab, var(--accent) 12%, transparent);
+  background: color-mix(in oklab, var(--accent) 14%, transparent);
   color: var(--text);
   font: inherit;
   line-height: 1.2;
   cursor: pointer;
+  transition:
+    background var(--motion-fast) ease,
+    border-color var(--motion-fast) ease;
 }
 .a2ui-dashboard-issue-session[data-state="working"] {
-  background: color-mix(in oklab, var(--accent) 16%, transparent);
+  background: color-mix(in oklab, var(--accent) 20%, transparent);
 }
 .a2ui-dashboard-issue-session:hover {
-  background: color-mix(in oklab, var(--accent) 18%, transparent);
-  border-color: color-mix(in oklab, var(--accent) 62%, var(--border));
+  background: color-mix(in oklab, var(--accent) 24%, transparent);
+  border-color: color-mix(in oklab, var(--accent) 45%, transparent);
 }
 .a2ui-dashboard-issue-session:focus-visible {
   outline: none;
@@ -892,28 +909,22 @@ button.a2ui-gh-stat:hover {
 }
 .a2ui-dashboard-issue-label {
   padding: 1px var(--space-2);
-  border: 1px solid var(--border);
   border-radius: var(--radius-pill);
-  font-size: 0.78rem;
-  line-height: 1.2;
-  /* When the issue carries a `color` from GitHub, the JSX inlines it as
-     `--label-color: #abc123`. We then compose the chip's bg/border/fg
-     from that single hue mixed with the theme's --text / --border /
-     --bg-elev tokens. The result keeps each label's identity (pink for
-     bug, mint for enhancement, etc.) while guaranteeing the fg/bg pair
-     clears WCAG AA — the foreground inherits most of its luminance
-     from --text, which is already a passing colour in every theme. */
+  font-size: 0.74rem;
+  line-height: 1.3;
+  /* Borderless chips. When the issue carries a `color` from GitHub the
+     JSX inlines it as `--label-color: #abc123`; we tint a soft bg from
+     that hue and hue-shift the foreground off --text. Dropping the
+     per-chip outline keeps each label's identity (pink for bug, mint for
+     enhancement, …) while de-cluttering the meta row. The fg still
+     inherits most of its luminance from --text so it clears WCAG AA in
+     every theme. */
   background: color-mix(
     in oklab,
-    var(--label-color, var(--accent)) 18%,
+    var(--label-color, var(--accent)) 16%,
     var(--bg-elev)
   );
-  border-color: color-mix(
-    in oklab,
-    var(--label-color, var(--accent)) 55%,
-    var(--border)
-  );
-  color: color-mix(in oklab, var(--label-color, var(--text)) 30%, var(--text));
+  color: color-mix(in oklab, var(--label-color, var(--text)) 32%, var(--text));
 }
 .a2ui-dashboard-issue-send {
   align-self: center;

--- a/src/styles/chrome/sidebar.css
+++ b/src/styles/chrome/sidebar.css
@@ -702,6 +702,51 @@ body.ae-resizing-sidebar .a2ui-layout {
   font-family: var(--font-ui);
 }
 
+/* Collapsible section header (extensions). A full-width disclosure
+   button that reuses the section-title type so it reads identically to
+   the static headers, plus a caret and a count badge. */
+.a2ui-sidebar-section-title-toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  text-align: left;
+  transition: color var(--motion-fast) ease;
+}
+.a2ui-sidebar-section-title-toggle:hover {
+  opacity: 1;
+  color: var(--text);
+}
+.a2ui-sidebar-section-title-toggle:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+  border-radius: var(--radius-sm);
+}
+.a2ui-sidebar-section-caret {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 16px;
+  opacity: 0.7;
+}
+.a2ui-sidebar-section-title-text {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.a2ui-sidebar-section-count {
+  flex: 0 0 auto;
+  letter-spacing: 0;
+  font-weight: 600;
+  opacity: 0.6;
+}
+
 .a2ui-sidebar-list {
   list-style: none;
   margin: 0;
@@ -758,9 +803,10 @@ body.ae-resizing-sidebar .a2ui-layout {
   color: var(--text);
 }
 .a2ui-sidebar-group-caret {
-  display: inline-block;
-  width: 10px;
-  font-size: var(--chrome-text-compact);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
   opacity: 0.7;
 }
 .a2ui-sidebar-group-name {

--- a/src/styles/chrome/subagents.css
+++ b/src/styles/chrome/subagents.css
@@ -435,13 +435,11 @@
 }
 
 .ae-turn-block-caret {
-  display: inline-block;
-  font-size: 10px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
   opacity: 0.8;
-  transition: transform var(--motion-fast) var(--ease-out);
-}
-.ae-turn-activity[data-expanded="true"] .ae-turn-block-caret {
-  transform: translateY(1px);
 }
 .ae-turn-block-label {
   font-weight: 500;

--- a/src/styles/chrome/subagents.css
+++ b/src/styles/chrome/subagents.css
@@ -60,6 +60,33 @@
     var(--ease-panel) both;
 }
 
+/* Expand/collapse-all toolbar for the turn's tool cards. */
+.ae-turn-activity-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: -2px;
+}
+.ae-turn-activity-expand-all {
+  background: transparent;
+  border: 0;
+  border-radius: var(--radius-sm);
+  color: var(--text-dim);
+  font-size: var(--chrome-text-muted);
+  padding: 2px 6px;
+  cursor: pointer;
+  transition:
+    color var(--motion-fast) ease,
+    background var(--motion-fast) ease;
+}
+.ae-turn-activity-expand-all:hover {
+  color: var(--text);
+  background: var(--bg-hover);
+}
+.ae-turn-activity-expand-all:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
 .ae-turn-branch-actions {
   display: flex;
   align-items: center;

--- a/src/styles/chrome/tools.css
+++ b/src/styles/chrome/tools.css
@@ -5,7 +5,9 @@
    warning amber, error = danger red.
    ============================================================================= */
 
-/* Tool card — compact pill style, collapsed by default */
+/* Tool card — full-width row, collapsed by default. Bash/output cards
+   expand their stdout behind a disclosure; edits show a file-change row
+   that expands its diff; reads are a single clickable filename. */
 .ae-tool-card {
   background: transparent;
   border: 1px solid var(--border);
@@ -13,18 +15,19 @@
   padding: 0;
   min-width: 0;
   max-width: 100%;
-  width: fit-content;
+  width: 100%;
+  box-sizing: border-box;
   transition:
     border-color 120ms ease,
     background 120ms ease;
 }
-.ae-tool-card[open] {
-  border-radius: var(--radius-md);
-  width: 100%;
+.ae-tool-card[data-open="true"] {
   background: var(--bg-elev);
 }
-.ae-tool-card:not([open]):hover {
+.ae-tool-card:not([data-open="true"]):hover {
   border-color: var(--border-strong);
+}
+.ae-tool-card[data-collapsible="true"]:not([data-open="true"]):hover {
   background: var(--bg-hover);
 }
 .ae-tool-card[data-running="true"] {
@@ -43,17 +46,39 @@
   flex-direction: row;
   align-items: center;
   gap: 6px;
+  width: 100%;
   padding: 4px 10px 4px 8px;
   cursor: pointer;
   list-style: none;
   user-select: none;
   white-space: nowrap;
   overflow: hidden;
+  /* The collapsible variant renders as a <button>; reset its chrome. */
+  background: transparent;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+}
+.ae-tool-card-summary-static {
+  cursor: default;
 }
 .ae-tool-card-summary::-webkit-details-marker {
   display: none;
 }
-.ae-tool-card[open] .ae-tool-card-summary {
+.ae-tool-card-summary:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+.ae-tool-card-disclosure {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 14px;
+  color: var(--text-dim);
+}
+.ae-tool-card[data-open="true"] .ae-tool-card-summary {
   padding-bottom: 6px;
   border-bottom: 1px solid var(--border);
   border-radius: var(--radius-md) var(--radius-md) 0 0;
@@ -66,6 +91,54 @@
   gap: 8px;
   padding: 8px 10px 10px;
   min-width: 0;
+}
+
+/* Tool output: the tool card is the ONLY box. Inside the card body the
+   framed code block sheds its own border / background / shadow and its
+   TEXT/JSON header bar (the copy action floats in on hover instead), and
+   the accent left-rail on `text` output is neutralised. This kills the
+   box-in-box-in-box stack that made tool calls read as "wildly busy".
+   Markdown code blocks in agent *prose* are untouched — they keep the
+   full framed treatment. */
+.ae-tool-card-body .a2ui-code-frame {
+  position: relative;
+  margin: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+.ae-tool-card-body .a2ui-code-header {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  min-height: 0;
+  padding: 0;
+  border-bottom: 0;
+  background: transparent;
+  z-index: 1;
+}
+.ae-tool-card-body .a2ui-code-title {
+  display: none;
+}
+.ae-tool-card-body .a2ui-code-copy {
+  opacity: 0;
+  transition: opacity var(--motion-fast) ease;
+}
+.ae-tool-card-body .a2ui-code-frame:hover .a2ui-code-copy,
+.ae-tool-card-body .a2ui-code-copy:focus-visible,
+.ae-tool-card-body .a2ui-code-copy[data-copied="true"] {
+  opacity: 1;
+}
+.ae-tool-card-body .a2ui-code-frame .a2ui-code {
+  padding: 0;
+}
+/* Neutralise the orange "reference chip" rail on plain-text tool output —
+   accent should mean state (running / error), not "here is some text". */
+.ae-tool-card-body .a2ui-code[data-language="text"] {
+  margin: 0;
+  padding: 0;
+  border-left: 0;
 }
 
 /* Status icon + spinner */
@@ -123,9 +196,10 @@
      it from the surrounding command text and matches the syntax
      palette's `function` colour family. */
   color: var(--accent-2, var(--text));
-  overflow: hidden;
-  text-overflow: ellipsis;
-  min-width: 0;
+  /* NEVER truncate the tool name — only the command/description ellipsizes
+     when space runs out. */
+  flex: 0 0 auto;
+  white-space: nowrap;
 }
 
 .ae-tool-card-description {
@@ -134,14 +208,27 @@
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   overflow: hidden;
   text-overflow: ellipsis;
-  flex: 1;
+  /* Don't grow — so a trailing diff stat hugs the filename; the time's
+     margin-left:auto still claims the free space and stays right-aligned.
+     Long commands still shrink + ellipsize via flex-shrink. */
+  flex: 0 1 auto;
   min-width: 0;
 }
-.ae-tool-card[open] .ae-tool-card-description {
+.ae-tool-card[data-open="true"] .ae-tool-card-description {
   white-space: pre-wrap;
   word-break: break-word;
   overflow: visible;
   text-overflow: unset;
+}
+/* Inline +adds/-dels stat folded onto an edit/write card's summary line so
+   the card collapses to a single row (filename + diff numbers + duration). */
+.ae-tool-card-diffstat {
+  display: inline-flex;
+  gap: 6px;
+  flex: 0 0 auto;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: var(--chrome-text-muted);
+  font-variant-numeric: tabular-nums;
 }
 
 .ae-tool-card-time {
@@ -171,6 +258,36 @@
   color: var(--warning, #d18a2c);
   font-size: var(--chrome-text-muted);
   flex-shrink: 0;
+}
+
+/* Read tool: a single clickable filename that opens the file in Monaco —
+   no content dump. The row is not a disclosure, so only the path is
+   interactive. */
+.ae-tool-card-read .ae-tool-card-summary {
+  cursor: default;
+}
+.ae-tool-card-read-path {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: left;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: var(--chrome-text-muted);
+  color: var(--text-secondary, var(--text-dim));
+  background: transparent;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+  transition: color var(--motion-fast) ease;
+}
+.ae-tool-card-read-path:hover,
+.ae-tool-card-read-path:focus-visible {
+  outline: none;
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }
 .ae-tool-card-long-hint kbd {
   font-family: inherit;


### PR DESCRIPTION
Exploratory UI/theme pass focused on reducing visual busyness across the chat transcript, the project dashboard, the MCP setup cards, the composer pills, and the sidebar. All changes are token-driven (no new magic numbers) and ship with green `tsc -b` + ESLint (0/0) + the full vitest suite (2848 tests).

## Tool calls (the big one) — `feat(chat): collapse-by-default …`
The tool-call surface read as "wildly busy" — nested boxes, redundant chrome, full file dumps.
- **Flatten output:** inside a tool card the framed code block sheds its own border / background / shadow and the `TEXT`/`JSON` header bar (copy floats in on hover); the accent rail on plain-text output is neutralised. The card is the only box.
- **Collapse by default:** every card collapses to a single row with a shared `<Chevron>` disclosure — bash → stdout, edits → diff, subagents → activity. Adds a per-turn **Expand all / Collapse all** control (window-event broadcast; cards + diffs listen).
- **`read`** renders a single **clickable filename** that opens the file in Monaco — no file-content dump (suppressed agent-side; failed reads keep their output).
- **`edit`/`write`** fold the `+N -M` stat onto the summary line so the card collapses to one line (filename + diff numbers + duration), diff behind the disclosure.
- Dropped the redundant ✓/✕ status glyphs (state = border colour + duration label). **Tool name is never truncated** — only the command/description ellipsizes.
- The aggregated **"Edited N files"** card is pinned as a durable turn artifact: it stays visible regardless of the tool-calls visibility toggle or the activity body's expand state.

## Issues list — `style(dashboard,chat): flatten issues list …`
Replaced the stack of individually-outlined row cards with a flat, hairline-divided list (the dashboard card is the only box); flush-aligned rows with a gutter-bleeding hover; quiet left accent rail for linked-session rows; borderless label chips; softened session pill + count badge.

## MCP approval cards (same commit)
Clean `--bg-elev` surface (fixes a latent `--bg-elevated` token typo), one accent `✓` check chip instead of three redundant "answered" signals, faded unpicked options, and a fixed responsive width so stacked cards line up.

## Sidebar — `feat(sidebar): collapsible extension sections + one shared chevron`
Collapsible "user/project extensions" sections (count badge, persists per-section). Consolidated **every** disclosure caret onto the shared `<Chevron>` (item rows, host groups, group caret, chat turn-activity toggle were hand-rolled SVGs / `▸▾` text). Recorded "always use `<Chevron>` for disclosure" as a hard rule in CLAUDE.md + AGENTS.md.

## Composer pills — `style(composer): unify pill on/off highlight …`
Plan mode / Thinking / Tool calls now share one on/off treatment (accent-tinted pill + accent "on" word); dropped the noisy per-session "SESSION" badge (override + reset still live in the More-options menu).

---
🤖 Codex peer review running against `main` in parallel; will fold in any findings.