### PR TITLE
fix(session): persist system status messages

### DIFF
--- a/src/hooks/chatMessages.ts
+++ b/src/hooks/chatMessages.ts
@@ -150,12 +150,16 @@ export function useChatMessageController(
   }
 
   function appendSystem(text: string) {
-    appendMessage({
+    const tabId =
+      (stateRef.current.activeTabId as string | undefined) ?? "default";
+    const message = {
       id: crypto.randomUUID(),
-      role: "system",
+      role: "system" as const,
       text,
       createdAt: Date.now(),
-    });
+    };
+    appendMessage(message, tabId);
+    persistLocalChatMessage(message, tabId);
   }
 
   function clearChat() {

--- a/src/hooks/useChat.test.ts
+++ b/src/hooks/useChat.test.ts
@@ -189,6 +189,23 @@ describe("useChat setModel", () => {
     ).toEqual(["u1", "stderr", "a1"]);
   });
 
+  it("persists generic system messages with their chronological timestamp", () => {
+    const { ctx, stateRef } = buildContext();
+    const { result } = renderHook(() => useChat(ctx));
+
+    act(() => {
+      result.current.appendSystem("MCP servers\n- nixos (stdio) — uvx");
+    });
+
+    const message = (stateRef.current.tabs as Tab[])[0].messages.at(-1);
+    expect(message).toMatchObject({
+      role: "system",
+      text: "MCP servers\n- nixos (stdio) — uvx",
+      createdAt: expect.any(Number),
+    });
+    expect(ctx.persistLocalChatMessage).toHaveBeenCalledWith(message, "tab-1");
+  });
+
   it("sends normal chat messages with normal mode", async () => {
     const { ctx, stateRef } = buildContext();
     const { result } = renderHook(() => useChat(ctx));


### PR DESCRIPTION
## Summary
- persist generic system/status chat rows through the local session-history bridge
- keep the same createdAt timestamp for UI insertion and durable history ordering
- add regression coverage for MCP-style status output emitted via appendSystem

Closes #414.

## Validation
- bunx vitest run src/hooks/useChat.test.ts -t "persists generic system messages|inserts timestamped system messages"
- bunx vitest run agent/session-history.test.ts -t "restores Aethon-local system messages inline by creation time|appends Aethon-local slash command messages"
- bunx vitest run src/hooks/useChat.test.ts src/hooks/useAppSlashCommandContext.test.ts agent/session-history.test.ts
- bunx tsc -b --noEmit
- bunx eslint src/hooks/chatMessages.ts src/hooks/useChat.test.ts
- codex review --uncommitted