### PR TITLE
fix(devshell): refresh generated direnv env before ready

### DIFF
--- a/src-tauri/src/commands/startup/mod.rs
+++ b/src-tauri/src/commands/startup/mod.rs
@@ -518,6 +518,75 @@ async fn prepare_workspace_startup_inner(
         }
     }
 
+    if !config.commands.is_empty() {
+        startup.set_record(
+            root,
+            StartupRecord {
+                fingerprint: fingerprint.clone(),
+                state: StartupState::Running,
+                reason: None,
+                active_task_id: Some(STARTUP_DEVSHELL_TASK_ID.to_string()),
+                task_states: task_states.clone(),
+            },
+        );
+        emit_startup_event(
+            app,
+            StartupEvent {
+                root: root.display().to_string(),
+                fingerprint: fingerprint.clone(),
+                state: "running".to_string(),
+                task_id: Some(STARTUP_DEVSHELL_TASK_ID.to_string()),
+                task_label: Some(STARTUP_DEVSHELL_TASK_LABEL.to_string()),
+                required: Some(false),
+                message: Some("Refreshing workspace environment".to_string()),
+                reason: None,
+            },
+        );
+        if let Err(reason) = prepare_devshell_env(app, devshell, root).await {
+            let record = StartupRecord {
+                fingerprint: fingerprint.clone(),
+                state: StartupState::Failed,
+                reason: Some(reason.clone()),
+                active_task_id: Some(STARTUP_DEVSHELL_TASK_ID.to_string()),
+                task_states: task_states.clone(),
+            };
+            startup.set_record(root, record.clone());
+            emit_startup_event(
+                app,
+                StartupEvent {
+                    root: root.display().to_string(),
+                    fingerprint: fingerprint.clone(),
+                    state: "failed".to_string(),
+                    task_id: Some(STARTUP_DEVSHELL_TASK_ID.to_string()),
+                    task_label: Some(STARTUP_DEVSHELL_TASK_LABEL.to_string()),
+                    required: Some(false),
+                    message: Some("Workspace environment refresh failed".to_string()),
+                    reason: Some(reason),
+                },
+            );
+            return Ok(status_response(
+                root,
+                &config,
+                &fingerprint,
+                policy,
+                Some(record),
+            ));
+        }
+        emit_startup_event(
+            app,
+            StartupEvent {
+                root: root.display().to_string(),
+                fingerprint: fingerprint.clone(),
+                state: "ready".to_string(),
+                task_id: Some(STARTUP_DEVSHELL_TASK_ID.to_string()),
+                task_label: Some(STARTUP_DEVSHELL_TASK_LABEL.to_string()),
+                required: Some(false),
+                message: Some("Workspace environment ready".to_string()),
+                reason: None,
+            },
+        );
+    }
+
     let record = StartupRecord {
         fingerprint: fingerprint.clone(),
         state: StartupState::Ready,

--- a/src-tauri/src/devshell/cache.rs
+++ b/src-tauri/src/devshell/cache.rs
@@ -694,18 +694,38 @@ impl AppEmitter {
     }
 }
 
+/// Files whose metadata invalidates a prepared devshell snapshot.
+///
+/// Keep this intentionally conservative: `.envrc` commonly delegates to
+/// worktree-local dotenv files with `source_env` / `dotenv`, and startup
+/// commands may generate those files after the first direnv prepare. If the
+/// fingerprint ignores them, Aethon can report a pre-generation env as ready.
+const FINGERPRINT_STAT_INPUTS: &[&str] = &[
+    ".envrc",
+    ".envrc.local",
+    ".env",
+    ".env.local",
+    ".env.development",
+    ".env.development.local",
+    ".env.test",
+    ".env.test.local",
+    ".env.worktree",
+    "flake.nix",
+    "shell.nix",
+];
+
 /// Fingerprint that gates "is the cached env still valid?". Combines
 /// the lockfile contents (when present) with (mtime, size) for each
-/// marker file. The lock dominates the cost so we only read its
+/// marker / dotenv input. The lock dominates the cost so we only read its
 /// bytes once.
 pub fn fingerprint_inputs(root: &Path) -> String {
     let mut hasher = Sha1::new();
-    hasher.update(b"resolver:v2:nix-develop-env");
+    hasher.update(b"resolver:v3:nix-develop-env-and-dotenv-inputs");
     if let Ok(bytes) = std::fs::read(root.join("flake.lock")) {
         hasher.update(b"lock:");
         hasher.update(&bytes);
     }
-    for name in [".envrc", "flake.nix", "shell.nix"] {
+    for name in FINGERPRINT_STAT_INPUTS {
         if let Ok(meta) = std::fs::metadata(root.join(name)) {
             hasher.update(name.as_bytes());
             hasher.update(b":");
@@ -845,6 +865,32 @@ mod tests {
         let fp3 = fingerprint_inputs(td.path());
         assert_ne!(fp1, fp2);
         assert_ne!(fp2, fp3);
+    }
+
+    #[test]
+    fn fingerprint_changes_when_generated_worktree_env_appears() {
+        let td = TempDir::new().unwrap();
+        fs::write(
+            td.path().join(".envrc"),
+            "source_env_if_exists .env.worktree\n",
+        )
+        .unwrap();
+        let before = fingerprint_inputs(td.path());
+        fs::write(td.path().join(".env.worktree"), "PORT=3056\n").unwrap();
+        let after = fingerprint_inputs(td.path());
+        assert_ne!(before, after);
+    }
+
+    #[test]
+    fn fingerprint_changes_when_dotenv_dependency_changes() {
+        let td = TempDir::new().unwrap();
+        fs::write(td.path().join(".envrc"), "dotenv .env.development\n").unwrap();
+        fs::write(td.path().join(".env.development"), "RACK_ENV=development\n").unwrap();
+        let before = fingerprint_inputs(td.path());
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        fs::write(td.path().join(".env.development"), "RACK_ENV=test\n").unwrap();
+        let after = fingerprint_inputs(td.path());
+        assert_ne!(before, after);
     }
 
     #[test]

--- a/src-tauri/src/shell/lifecycle/open.rs
+++ b/src-tauri/src/shell/lifecycle/open.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, Mutex};
 
 use portable_pty::{CommandBuilder, PtySize, native_pty_system};
 use serde::Deserialize;
-use tauri::{AppHandle, Runtime, State};
+use tauri::{AppHandle, State};
 
 use super::reader::spawn_reader_thread;
 use super::registry::{
@@ -50,10 +50,11 @@ pub struct ShellOpenArgs {
 }
 
 #[tauri::command]
-pub async fn shell_open<R: Runtime>(
-    app: AppHandle<R>,
+pub async fn shell_open(
+    app: AppHandle,
     state: State<'_, ShellRegistry>,
     devshell: State<'_, Arc<DevshellCache>>,
+    startup: State<'_, crate::commands::startup::WorkspaceStartupState>,
     args: ShellOpenArgs,
 ) -> Result<(), String> {
     if args.tab_id.is_empty() {
@@ -64,6 +65,11 @@ pub async fn shell_open<R: Runtime>(
         if guard.contains_key(&args.tab_id) {
             return Err(format!("shell already open for tab {}", args.tab_id));
         }
+    }
+
+    if let Some(cwd) = args.cwd.as_deref().filter(|cwd| !cwd.is_empty()) {
+        crate::commands::startup::ensure_workspace_startup_ready(&app, &startup, &devshell, cwd)
+            .await?;
     }
 
     let pty_system = native_pty_system();
@@ -94,7 +100,7 @@ pub async fn shell_open<R: Runtime>(
     let command_program = effective_command
         .map(str::to_string)
         .unwrap_or_else(default_shell_label);
-    let mut launch_kind: Option<DevshellKind> = None;
+    let launch_kind: Option<DevshellKind> = None;
     let mut prepared_env: Option<(Option<String>, std::collections::BTreeMap<String, String>)> =
         None;
     let mut detected_launch_kind: Option<DevshellKind> = None;
@@ -115,14 +121,7 @@ pub async fn shell_open<R: Runtime>(
                     prepared.env.len(),
                     args.tab_id
                 );
-                match kind {
-                    DevshellKind::Flake | DevshellKind::Direnv => {
-                        launch_kind = Some(kind);
-                    }
-                    DevshellKind::Shell => {
-                        prepared_env = Some((prepared.kind, prepared.env));
-                    }
-                }
+                prepared_env = Some((prepared.kind, prepared.env));
             }
             crate::devshell::PrepareDecision::DirenvAllowFailedOptional { kind, reason } => {
                 detected_launch_kind = Some(kind);
@@ -197,7 +196,7 @@ pub async fn shell_open<R: Runtime>(
     if let Some((_kind, env)) = prepared_env {
         tracing::debug!(
             target: "aethon::devshell",
-            "shell_open: applying {} legacy devshell vars to tab {}",
+            "shell_open: applying {} prepared devshell vars to tab {}",
             env.len(),
             args.tab_id
         );

--- a/src/hooks/tabOps/shellTab.test.ts
+++ b/src/hooks/tabOps/shellTab.test.ts
@@ -15,12 +15,13 @@ describe("newShellTab", () => {
     vi.mocked(invoke).mockClear();
   });
 
-  it("opens a project shell tab with retained devshell output visible immediately", () => {
+  it("opens a project shell tab with retained devshell output visible immediately", async () => {
     let state: Record<string, unknown> = {
       tabs: [],
       devshell: {
         outputByRoot: {
-          "/proj": "[devshell] Preparing Nix devshell for this workspace...\r\n",
+          "/proj":
+            "[devshell] Preparing Nix devshell for this workspace...\r\n",
         },
         entries: {
           "/proj": { state: "resolving" },
@@ -75,12 +76,135 @@ describe("newShellTab", () => {
     );
     expect(tab.shell).toMatchObject({ cwd: "/proj", shellState: "starting" });
     expect(state.terminalPanel).toMatchObject({ activeSubId: tab.id });
-    expect(invoke).toHaveBeenCalledWith("shell_open", {
-      args: {
-        tabId: tab.id,
-        cwd: "/proj",
-        shareMode: "read",
-      },
+    await vi.waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith(
+        "workspace_startup_prepare_for_path",
+        {
+          args: { cwd: "/proj" },
+        },
+      );
+      expect(invoke).toHaveBeenCalledWith("shell_open", {
+        args: {
+          tabId: tab.id,
+          cwd: "/proj",
+          shareMode: "read",
+        },
+      });
+    });
+  });
+
+  it("does not open a shell when the tab closes before startup finishes", async () => {
+    let releaseStartup: ((ready: boolean) => void) | undefined;
+    const prepareWorkspaceStartup = vi.fn(
+      () => new Promise<boolean>((resolve) => (releaseStartup = resolve)),
+    );
+    let state: Record<string, unknown> = { tabs: [] };
+    const stateRef = ref(state);
+    const setState = vi.fn((updater: unknown) => {
+      if (typeof updater !== "function") return;
+      state = (
+        updater as (prev: Record<string, unknown>) => Record<string, unknown>
+      )(state);
+      stateRef.current = state;
+    });
+    const updateTab = vi.fn();
+    const appendSystem = vi.fn();
+
+    const newShellTab = useNewShellTab({
+      setState,
+      stateRef,
+      projectsRef: ref<ProjectsState>({
+        activeId: "p1",
+        activeWorkspaceId: null,
+        activeHostId: null,
+        projects: [
+          {
+            id: "p1",
+            label: "Project",
+            path: "/proj",
+            lastUsed: 1,
+          },
+        ],
+        workspacesByProject: {},
+      }),
+      appendSystem,
+      defaultShareModeRef: ref("private"),
+      shellDefaultCommandRef: ref(null),
+      shellDefaultArgsRef: ref([]),
+      shellInheritEnvRef: ref(true),
+      prepareWorkspaceStartup,
+      updateTab,
+    });
+
+    newShellTab();
+    expect((state.tabs as unknown[]).length).toBe(1);
+
+    state = { ...state, tabs: [] };
+    stateRef.current = state;
+    releaseStartup?.(true);
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(invoke).not.toHaveBeenCalledWith("shell_open", expect.anything());
+    expect(updateTab).not.toHaveBeenCalled();
+    expect(appendSystem).not.toHaveBeenCalled();
+  });
+
+  it("waits for workspace startup before opening a project shell", async () => {
+    let releaseStartup: ((ready: boolean) => void) | undefined;
+    const prepareWorkspaceStartup = vi.fn(
+      () => new Promise<boolean>((resolve) => (releaseStartup = resolve)),
+    );
+    let state: Record<string, unknown> = { tabs: [] };
+    const stateRef = ref(state);
+    const setState = vi.fn((updater: unknown) => {
+      if (typeof updater !== "function") return;
+      state = (
+        updater as (prev: Record<string, unknown>) => Record<string, unknown>
+      )(state);
+      stateRef.current = state;
+    });
+
+    const newShellTab = useNewShellTab({
+      setState,
+      stateRef,
+      projectsRef: ref<ProjectsState>({
+        activeId: "p1",
+        activeWorkspaceId: null,
+        activeHostId: null,
+        projects: [
+          {
+            id: "p1",
+            label: "Project",
+            path: "/proj",
+            lastUsed: 1,
+          },
+        ],
+        workspacesByProject: {},
+      }),
+      appendSystem: vi.fn(),
+      defaultShareModeRef: ref("private"),
+      shellDefaultCommandRef: ref(null),
+      shellDefaultArgsRef: ref([]),
+      shellInheritEnvRef: ref(true),
+      prepareWorkspaceStartup,
+      updateTab: vi.fn(),
+    });
+
+    newShellTab();
+
+    expect(prepareWorkspaceStartup).toHaveBeenCalledWith("/proj");
+    expect(invoke).not.toHaveBeenCalledWith("shell_open", expect.anything());
+
+    releaseStartup?.(true);
+
+    await vi.waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith("shell_open", {
+        args: {
+          tabId: expect.any(String),
+          cwd: "/proj",
+        },
+      });
     });
   });
 });

--- a/src/hooks/tabOps/shellTab.test.ts
+++ b/src/hooks/tabOps/shellTab.test.ts
@@ -150,6 +150,63 @@ describe("newShellTab", () => {
     expect(appendSystem).not.toHaveBeenCalled();
   });
 
+  it("does not report startup failures after the shell tab closes", async () => {
+    let rejectStartup: ((error: Error) => void) | undefined;
+    const prepareWorkspaceStartup = vi.fn(
+      () => new Promise<boolean>((_, reject) => (rejectStartup = reject)),
+    );
+    let state: Record<string, unknown> = { tabs: [] };
+    const stateRef = ref(state);
+    const setState = vi.fn((updater: unknown) => {
+      if (typeof updater !== "function") return;
+      state = (
+        updater as (prev: Record<string, unknown>) => Record<string, unknown>
+      )(state);
+      stateRef.current = state;
+    });
+    const updateTab = vi.fn();
+    const appendSystem = vi.fn();
+
+    const newShellTab = useNewShellTab({
+      setState,
+      stateRef,
+      projectsRef: ref<ProjectsState>({
+        activeId: "p1",
+        activeWorkspaceId: null,
+        activeHostId: null,
+        projects: [
+          {
+            id: "p1",
+            label: "Project",
+            path: "/proj",
+            lastUsed: 1,
+          },
+        ],
+        workspacesByProject: {},
+      }),
+      appendSystem,
+      defaultShareModeRef: ref("private"),
+      shellDefaultCommandRef: ref(null),
+      shellDefaultArgsRef: ref([]),
+      shellInheritEnvRef: ref(true),
+      prepareWorkspaceStartup,
+      updateTab,
+    });
+
+    newShellTab();
+    expect((state.tabs as unknown[]).length).toBe(1);
+
+    state = { ...state, tabs: [] };
+    stateRef.current = state;
+    rejectStartup?.(new Error("startup failed"));
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(invoke).not.toHaveBeenCalledWith("shell_open", expect.anything());
+    expect(updateTab).not.toHaveBeenCalled();
+    expect(appendSystem).not.toHaveBeenCalled();
+  });
+
   it("waits for workspace startup before opening a project shell", async () => {
     let releaseStartup: ((ready: boolean) => void) | undefined;
     const prepareWorkspaceStartup = vi.fn(

--- a/src/hooks/tabOps/shellTab.ts
+++ b/src/hooks/tabOps/shellTab.ts
@@ -139,6 +139,7 @@ export function useNewShellTab(deps: NewShellTabDeps) {
         }));
       })
       .catch((err: unknown) => {
+        if (!shellTabStillExists(stateRef.current, id)) return;
         appendSystem(`Failed to open shell tab: ${String(err)}`);
         updateTab(id, (t) => ({
           ...t,

--- a/src/hooks/tabOps/shellTab.ts
+++ b/src/hooks/tabOps/shellTab.ts
@@ -16,6 +16,9 @@ export interface NewShellTabDeps {
   shellDefaultCommandRef: MutableRefObject<string | null>;
   shellDefaultArgsRef: MutableRefObject<string[]>;
   shellInheritEnvRef: MutableRefObject<boolean>;
+  /** Project/workspace startup gate. Resolves once env providers and
+   *  approved bootstrapping commands have completed for the cwd. */
+  prepareWorkspaceStartup?: (cwd: string) => Promise<boolean>;
   /** Callback into mutations.updateTab — patches the tab's shellState
    *  on bridge success/failure without re-implementing the mirror dance. */
   updateTab: (tabId: string, mutator: (tab: Tab) => Tab) => void;
@@ -37,6 +40,7 @@ export function useNewShellTab(deps: NewShellTabDeps) {
     shellDefaultCommandRef,
     shellDefaultArgsRef,
     shellInheritEnvRef,
+    prepareWorkspaceStartup,
     updateTab,
   } = deps;
 
@@ -92,22 +96,43 @@ export function useNewShellTab(deps: NewShellTabDeps) {
         terminal: { ...term, open: true },
       };
     });
-    invoke("shell_open", {
-      args: {
-        tabId: id,
-        ...(resolvedCommand ? { command: resolvedCommand } : {}),
-        ...(resolvedArgs ? { args: resolvedArgs } : {}),
-        ...(inheritedCwd ? { cwd: inheritedCwd } : {}),
-        // Seed the share mode atomically inside shell_open so the
-        // privacy floor pins at total_appended=0 — every byte from the
-        // first prompt forward is visible to the agent when the user
-        // configured a non-private default. Applying the mode post-open
-        // would race the login banner and pin it below the floor.
-        ...(seedShareMode !== "private" ? { shareMode: seedShareMode } : {}),
-        ...(inheritEnv === false ? { inheritEnv: false } : {}),
-      },
-    })
-      .then(() => {
+    const openShell = async (): Promise<boolean> => {
+      if (inheritedCwd) {
+        const ready = prepareWorkspaceStartup
+          ? await prepareWorkspaceStartup(inheritedCwd)
+          : await invoke<{ state?: string }>(
+              "workspace_startup_prepare_for_path",
+              {
+                args: { cwd: inheritedCwd },
+              },
+            ).then((status) =>
+              ["ready", "continued", "disabled"].includes(
+                status?.state ?? "ready",
+              ),
+            );
+        if (!ready) throw new Error("workspace startup not ready");
+      }
+      if (!shellTabStillExists(stateRef.current, id)) return false;
+      await invoke("shell_open", {
+        args: {
+          tabId: id,
+          ...(resolvedCommand ? { command: resolvedCommand } : {}),
+          ...(resolvedArgs ? { args: resolvedArgs } : {}),
+          ...(inheritedCwd ? { cwd: inheritedCwd } : {}),
+          // Seed the share mode atomically inside shell_open so the
+          // privacy floor pins at total_appended=0 — every byte from the
+          // first prompt forward is visible to the agent when the user
+          // configured a non-private default. Applying the mode post-open
+          // would race the login banner and pin it below the floor.
+          ...(seedShareMode !== "private" ? { shareMode: seedShareMode } : {}),
+          ...(inheritEnv === false ? { inheritEnv: false } : {}),
+        },
+      });
+      return true;
+    };
+    openShell()
+      .then((opened) => {
+        if (!opened) return;
         updateTab(id, (t) => ({
           ...t,
           shell: t.shell ? { ...t.shell, shellState: "running" } : t.shell,
@@ -123,4 +148,12 @@ export function useNewShellTab(deps: NewShellTabDeps) {
         }));
       });
   };
+}
+
+function shellTabStillExists(
+  state: Record<string, unknown>,
+  id: string,
+): boolean {
+  const tabs = (state.tabs as Tab[] | undefined) ?? [];
+  return tabs.some((tab) => tab.id === id && tab.kind === "shell");
 }

--- a/src/hooks/useTabs.ts
+++ b/src/hooks/useTabs.ts
@@ -87,6 +87,7 @@ export function useTabs(ctx: UseTabsContext): UseTabsActions {
     shellDefaultCommandRef: ctx.shellDefaultCommandRef,
     shellDefaultArgsRef: ctx.shellDefaultArgsRef,
     shellInheritEnvRef: ctx.shellInheritEnvRef,
+    prepareWorkspaceStartup: ctx.prepareWorkspaceStartup,
     updateTab: mutations.updateTab,
   });
 


### PR DESCRIPTION
## Summary

- refresh the prepared devshell after approved workspace startup commands so generated env files are included before startup reports ready
- include common `.envrc`/dotenv inputs such as `.env.worktree` and `.env.development` in the devshell cache fingerprint
- make shell tabs wait for workspace startup, use the prepared devshell env snapshot directly, and avoid spawning a PTY if the tab was closed while startup was pending

Closes #413.

## Validation

- `bunx vitest run src/hooks/tabOps/shellTab.test.ts src/hooks/tabOps/agentTab.test.ts src/hooks/useTabs.test.ts`
- `bunx tsc -b --noEmit`
- `bunx eslint .`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib devshell::cache::tests -- --nocapture`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib commands::startup -- --nocapture`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib shell::lifecycle::open::shell_classification_tests -- --nocapture`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
- `bunx vitest run`
- Codex peer review: clean after addressing one valid shell-close race finding
