### PR TITLE
fix(mcp): load workspace MCP config for native slash commands

### DIFF
--- a/agent/mcp.test.ts
+++ b/agent/mcp.test.ts
@@ -608,7 +608,7 @@ project_configs = "require-approval"
     );
     expect(process.argv).toEqual(previousArgv);
     expect(process.env.MCP_DIRECT_TOOLS).toBe(previousDirectTools);
-  });
+  }, 15_000);
 
   it(
     "refreshes the pi adapter config for the executing session cwd",

--- a/agent/nativeSlash.test.ts
+++ b/agent/nativeSlash.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const ensureTabMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./tab-lifecycle", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./tab-lifecycle")>();
+  return {
+    ...actual,
+    ensureTab: ensureTabMock,
+  };
+});
+
+import { handleNativeSlashCommand } from "./nativeSlash";
+import type { AethonAgentState } from "./state";
+import type { DispatcherDeps } from "./dispatcherTypes";
+
+function makeDeps(): { deps: DispatcherDeps; sent: Record<string, unknown>[] } {
+  const sent: Record<string, unknown>[] = [];
+  return {
+    deps: {
+      send: (message: Record<string, unknown>) => sent.push(message),
+      scheduleStateFileWrite: () => {},
+      loadHooks: {},
+    },
+    sent,
+  };
+}
+
+function makeState(): AethonAgentState {
+  return {
+    tabProjectCwds: new Map<string, string>(),
+  } as unknown as AethonAgentState;
+}
+
+describe("handleNativeSlashCommand", () => {
+  beforeEach(() => {
+    ensureTabMock.mockReset();
+  });
+
+  it("opens a slash-command session with the cwd carried by the frontend", async () => {
+    const runExtensionCommand = vi.fn(() => Promise.resolve(true));
+    ensureTabMock.mockResolvedValue({
+      session: {
+        _tryExecuteExtensionCommand: runExtensionCommand,
+      },
+    });
+    const state = makeState();
+    const { deps, sent } = makeDeps();
+
+    await handleNativeSlashCommand(state, deps, {
+      type: "native_slash_command",
+      name: "mcp",
+      args: "tools",
+      tabId: "tab-1",
+      cwd: "/repo/worktree",
+    });
+
+    expect(ensureTabMock).toHaveBeenCalledWith(state, deps, "tab-1", {
+      cwdOverride: "/repo/worktree",
+    });
+    expect(state.tabProjectCwds.get("tab-1")).toBe("/repo/worktree");
+    expect(runExtensionCommand).toHaveBeenCalledWith("/mcp tools");
+    expect(sent).toEqual([]);
+  });
+
+  it("runs extension slash commands with cwd override even when ensureTab reuses an existing session", async () => {
+    const session = {
+      _extensionRunner: { cwd: "/repo/old" },
+      _tryExecuteExtensionCommand: vi.fn(function (this: {
+        _extensionRunner: { cwd: string };
+      }) {
+        return Promise.resolve(this._extensionRunner.cwd === "/repo/worktree");
+      }),
+    };
+    ensureTabMock.mockResolvedValue({ session });
+    const state = makeState();
+    const { deps, sent } = makeDeps();
+
+    await handleNativeSlashCommand(state, deps, {
+      type: "native_slash_command",
+      name: "mcp",
+      args: "tools",
+      tabId: "default",
+      cwd: "/repo/worktree",
+    });
+
+    expect(session._tryExecuteExtensionCommand).toHaveBeenCalledWith(
+      "/mcp tools",
+    );
+    expect(session._extensionRunner.cwd).toBe("/repo/old");
+    expect(state.tabProjectCwds.get("default")).toBe("/repo/worktree");
+    expect(sent).toEqual([]);
+  });
+
+  it("sets and removes the temporary cwd override when the runner had no cwd", async () => {
+    const session = {
+      _extensionRunner: {} as { cwd?: string },
+      _tryExecuteExtensionCommand: vi.fn(function (this: {
+        _extensionRunner: { cwd?: string };
+      }) {
+        return Promise.resolve(this._extensionRunner.cwd === "/repo/worktree");
+      }),
+    };
+    ensureTabMock.mockResolvedValue({ session });
+    const state = makeState();
+    const { deps, sent } = makeDeps();
+
+    await handleNativeSlashCommand(state, deps, {
+      type: "native_slash_command",
+      name: "mcp",
+      args: "tools",
+      tabId: "tab-1",
+      cwd: "/repo/worktree",
+    });
+
+    expect(session._tryExecuteExtensionCommand).toHaveBeenCalledWith(
+      "/mcp tools",
+    );
+    expect(session._extensionRunner).not.toHaveProperty("cwd");
+    expect(state.tabProjectCwds.get("tab-1")).toBe("/repo/worktree");
+    expect(sent).toEqual([]);
+  });
+});

--- a/agent/nativeSlash.ts
+++ b/agent/nativeSlash.ts
@@ -129,16 +129,32 @@ function tryRunExtensionSlashCommand(
   tab: Awaited<ReturnType<typeof ensureTab>>,
   command: string,
   args: unknown,
+  cwdOverride?: string,
 ): Promise<boolean> {
-  const runExtensionCommand = (
-    tab.session as {
-      _tryExecuteExtensionCommand?: (text: string) => Promise<boolean>;
-    }
-  )._tryExecuteExtensionCommand;
+  const session = tab.session as {
+    _tryExecuteExtensionCommand?: (text: string) => Promise<boolean>;
+    _extensionRunner?: { cwd?: string };
+  };
+  const runExtensionCommand = session._tryExecuteExtensionCommand;
   if (typeof runExtensionCommand !== "function") return Promise.resolve(false);
   const rawArgs = typeof args === "string" ? args.trim() : "";
   const text = rawArgs ? `/${command} ${rawArgs}` : `/${command}`;
-  return Promise.resolve(runExtensionCommand.call(tab.session, text));
+  const runner = session._extensionRunner;
+  const hadCwd = runner
+    ? Object.prototype.hasOwnProperty.call(runner, "cwd")
+    : false;
+  const previousCwd = runner?.cwd;
+  if (cwdOverride && runner) {
+    runner.cwd = cwdOverride;
+  }
+  return Promise.resolve(runExtensionCommand.call(tab.session, text)).finally(
+    () => {
+      if (cwdOverride && runner) {
+        if (hadCwd) runner.cwd = previousCwd;
+        else delete runner.cwd;
+      }
+    },
+  );
 }
 
 export async function handleNativeSlashCommand(
@@ -158,7 +174,12 @@ export async function handleNativeSlashCommand(
     });
     return;
   }
-  const tab = await ensureTab(state, deps, tabId);
+  const cwdOverride =
+    typeof msg.cwd === "string" && msg.cwd.length > 0 ? msg.cwd : undefined;
+  if (cwdOverride) state.tabProjectCwds.set(tabId, cwdOverride);
+  const tab = await ensureTab(state, deps, tabId, {
+    ...(cwdOverride ? { cwdOverride } : {}),
+  });
   const command = name.toLowerCase();
   switch (command) {
     case "memory": {
@@ -314,7 +335,9 @@ export async function handleNativeSlashCommand(
       return;
     }
     default: {
-      if (await tryRunExtensionSlashCommand(tab, command, msg.args)) {
+      if (
+        await tryRunExtensionSlashCommand(tab, command, msg.args, cwdOverride)
+      ) {
         return;
       }
       deps.send({

--- a/src/hooks/useAppSlashCommandContext.test.ts
+++ b/src/hooks/useAppSlashCommandContext.test.ts
@@ -153,6 +153,169 @@ describe("useAppSlashCommandContext", () => {
     });
   });
 
+  it("uses the active workspace as the project root when the invoking tab has no cwd", () => {
+    const projects = makeProjects();
+    projects.activeWorkspaceId = "wt-1";
+    projects.workspacesByProject = {
+      "project-1": [
+        {
+          id: "wt-1",
+          projectId: "project-1",
+          label: "feature-worktree",
+          path: "/repo/aethon-worktree",
+          isMain: false,
+          branch: "feature/worktree",
+        },
+      ],
+    };
+    const { result } = renderHook(() =>
+      useAppSlashCommandContext({
+        bootLayout: { components: [] },
+        setState: vi.fn(),
+        setLayout: vi.fn(),
+        stateRef: ref({
+          activeTabId: "tab-1",
+          tabs: [{ id: "tab-1", kind: "agent", label: "One" }],
+        }),
+        projectsRef: ref(projects),
+        layoutCatalogueRef: ref([]),
+        registry: new ExtensionRegistry(),
+        appendMessage: vi.fn(),
+        pushNotification: vi.fn(() => "toast-1"),
+        clearChat: vi.fn(),
+        setTheme: vi.fn(),
+        listThemes: vi.fn(() => []),
+        setModel: vi.fn(() => Promise.resolve()),
+        toggleTerminal: vi.fn(),
+        toggleSidebar: vi.fn(),
+        toggleFilesSidebar: vi.fn(),
+        activateLayoutById: vi.fn(() => true),
+        openProjectFromPicker: vi.fn(() => Promise.resolve(null)),
+        openProjectByPath: vi.fn((path: string) => path),
+        setActiveProjectById: vi.fn(() => true),
+        clearActiveProject: vi.fn(),
+        removeProjectById: vi.fn(() => true),
+      }),
+    );
+
+    expect(result.current.slashContext().activeProjectRoot?.()).toBe(
+      "/repo/aethon-worktree",
+    );
+  });
+
+  it("carries the invoking tab cwd when forwarding native slash commands", async () => {
+    const { result } = renderHook(() =>
+      useAppSlashCommandContext({
+        bootLayout: { components: [] },
+        setState: vi.fn(),
+        setLayout: vi.fn(),
+        stateRef: ref({
+          activeTabId: "tab-1",
+          tabs: [
+            {
+              id: "tab-1",
+              kind: "agent",
+              label: "One",
+              cwd: "/repo/aethon-worktree",
+            },
+          ],
+        }),
+        projectsRef: ref(makeProjects()),
+        layoutCatalogueRef: ref([]),
+        registry: new ExtensionRegistry(),
+        appendMessage: vi.fn(),
+        pushNotification: vi.fn(() => "toast-1"),
+        clearChat: vi.fn(),
+        setTheme: vi.fn(),
+        listThemes: vi.fn(() => []),
+        setModel: vi.fn(() => Promise.resolve()),
+        toggleTerminal: vi.fn(),
+        toggleSidebar: vi.fn(),
+        toggleFilesSidebar: vi.fn(),
+        activateLayoutById: vi.fn(() => true),
+        openProjectFromPicker: vi.fn(() => Promise.resolve(null)),
+        openProjectByPath: vi.fn((path: string) => path),
+        setActiveProjectById: vi.fn(() => true),
+        clearActiveProject: vi.fn(),
+        removeProjectById: vi.fn(() => true),
+      }),
+    );
+
+    await act(async () => {
+      await result.current.slashContext().runNativeCommand("mcp", "tools");
+    });
+
+    expect(invokeMock).toHaveBeenCalledWith("agent_command", {
+      payload: JSON.stringify({
+        type: "native_slash_command",
+        tabId: "tab-1",
+        name: "mcp",
+        args: "tools",
+        cwd: "/repo/aethon-worktree",
+      }),
+    });
+  });
+
+  it("carries the active workspace cwd for native slash commands when the tab has no cwd", async () => {
+    const projects = makeProjects();
+    projects.activeWorkspaceId = "wt-1";
+    projects.workspacesByProject = {
+      "project-1": [
+        {
+          id: "wt-1",
+          projectId: "project-1",
+          label: "feature-worktree",
+          path: "/repo/aethon-worktree",
+          isMain: false,
+          branch: "feature/worktree",
+        },
+      ],
+    };
+    const { result } = renderHook(() =>
+      useAppSlashCommandContext({
+        bootLayout: { components: [] },
+        setState: vi.fn(),
+        setLayout: vi.fn(),
+        stateRef: ref({
+          activeTabId: "tab-1",
+          tabs: [{ id: "tab-1", kind: "agent", label: "One" }],
+        }),
+        projectsRef: ref(projects),
+        layoutCatalogueRef: ref([]),
+        registry: new ExtensionRegistry(),
+        appendMessage: vi.fn(),
+        pushNotification: vi.fn(() => "toast-1"),
+        clearChat: vi.fn(),
+        setTheme: vi.fn(),
+        listThemes: vi.fn(() => []),
+        setModel: vi.fn(() => Promise.resolve()),
+        toggleTerminal: vi.fn(),
+        toggleSidebar: vi.fn(),
+        toggleFilesSidebar: vi.fn(),
+        activateLayoutById: vi.fn(() => true),
+        openProjectFromPicker: vi.fn(() => Promise.resolve(null)),
+        openProjectByPath: vi.fn((path: string) => path),
+        setActiveProjectById: vi.fn(() => true),
+        clearActiveProject: vi.fn(),
+        removeProjectById: vi.fn(() => true),
+      }),
+    );
+
+    await act(async () => {
+      await result.current.slashContext().runNativeCommand("mcp", "tools");
+    });
+
+    expect(invokeMock).toHaveBeenCalledWith("agent_command", {
+      payload: JSON.stringify({
+        type: "native_slash_command",
+        tabId: "tab-1",
+        name: "mcp",
+        args: "tools",
+        cwd: "/repo/aethon-worktree",
+      }),
+    });
+  });
+
   it("does not persist empty local chat messages", () => {
     const { result } = renderHook(() =>
       useAppSlashCommandContext({

--- a/src/hooks/useAppSlashCommandContext.ts
+++ b/src/hooks/useAppSlashCommandContext.ts
@@ -7,7 +7,7 @@ import {
 import { invoke } from "@tauri-apps/api/core";
 import type { A2UIPayload, ChatMessage } from "../types/a2ui";
 import type { Tab } from "../types/tab";
-import { activeProject, type ProjectsState } from "../projects";
+import { activeCwd, activeProject, type ProjectsState } from "../projects";
 import { durableImageAttachments } from "../utils/imageAttachments";
 import { trimMessage } from "../utils/messages";
 import type { SlashCommandContext } from "../slashCommands";
@@ -177,6 +177,11 @@ export function useAppSlashCommandContext({
         lastCreatedAt = createdAt;
         return createdAt;
       };
+      const effectiveProjectRoot = () => {
+        const tab = invocationTab();
+        if (tab?.kind === "agent" && tab.cwd) return tab.cwd;
+        return activeCwd(projectsRef.current);
+      };
       return {
         appendSystem: (text: string) => {
           const msg = {
@@ -200,11 +205,7 @@ export function useAppSlashCommandContext({
             createdAt: nextCreatedAt(),
           });
         },
-        activeProjectRoot: () => {
-          const tab = invocationTab();
-          if (tab?.kind === "agent" && tab.cwd) return tab.cwd;
-          return activeProject(projectsRef.current)?.path ?? null;
-        },
+        activeProjectRoot: effectiveProjectRoot,
         clearChat,
         setTheme,
         listThemes,
@@ -347,12 +348,14 @@ export function useAppSlashCommandContext({
           await invoke("reload_agent");
         },
         runNativeCommand: async (name: string, args: string) => {
+          const cwd = effectiveProjectRoot() ?? undefined;
           await invoke("agent_command", {
             payload: JSON.stringify({
               type: "native_slash_command",
               tabId: persistenceTabId,
               name,
               args,
+              ...(cwd ? { cwd } : {}),
             }),
           });
         },


### PR DESCRIPTION
## Summary
- Resolve `/mcp` project roots from the invoking tab cwd or active workspace cwd instead of falling back to the main project path.
- Forward that cwd through native slash command dispatch so newly created sessions/workspaces load the expected approved `.aethon/mcp.toml` / project MCP configuration.
- Apply the cwd override when executing extension slash commands even if the pi session already exists, so reused sessions refresh MCP visibility for the correct workspace.
- Add frontend and bridge regressions for tab cwd, active workspace fallback, and existing-session native slash command behavior.

Closes #416.

## Validation
- `codex review --uncommitted` (clean after addressing two valid cwd edge-case findings)
- `bunx vitest run` (344 files / 2856 tests)
- `bunx tsc -b --noEmit`
- `bunx eslint .`

Note: Vitest still emits existing jsdom/xterm/component-registration warnings during the full suite, but all tests passed.
