### PR TITLE
fix(session): preserve generated tab titles

### DIFF
--- a/agent/session-branch.ts
+++ b/agent/session-branch.ts
@@ -213,11 +213,13 @@ export async function handleForkSession(
     () => undefined,
   );
   const label = forkLabel(srcLabel);
-  await writeSessionLabel(newDir, label).catch(() => {
-    /* best effort */
-  });
   const cwd =
     state.tabProjectCwds.get(tabId) ?? mirroredTabCwd(state, tabId) ?? cwdHint;
+  await writeSessionLabel(newDir, label, {
+    ...(cwd ? { cwd } : {}),
+  }).catch(() => {
+    /* best effort */
+  });
   deps.send({
     type: "session_forked",
     tabId,

--- a/agent/session-history/index.ts
+++ b/agent/session-history/index.ts
@@ -25,6 +25,7 @@
 export type {
   RestoredChatAttachment,
   RestoredChatMessage,
+  SessionLabelMetadata,
   SessionLogMetadata,
 } from "./shared";
 export { hasA2ui, parseChatAttachments } from "./shared";
@@ -33,6 +34,7 @@ export {
   appendLocalChatMessage,
   normalizeSessionLabel,
   readSessionLabel,
+  readSessionLabelMetadata,
   truncateLocalChatAfterEntry,
   writeSessionLabel,
 } from "./io";

--- a/agent/session-history/io.test.ts
+++ b/agent/session-history/io.test.ts
@@ -2,7 +2,12 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { appendLocalChatMessage, truncateLocalChatAfterEntry } from "./io";
+import {
+  appendLocalChatMessage,
+  readSessionLabelMetadata,
+  truncateLocalChatAfterEntry,
+  writeSessionLabel,
+} from "./io";
 import { LOCAL_CHAT_FILE } from "./shared";
 
 let dir: string;
@@ -19,6 +24,18 @@ beforeEach(() => {
 
 afterEach(() => {
   rmSync(dir, { recursive: true, force: true });
+});
+
+describe("writeSessionLabel", () => {
+  it("trims cwd metadata and skips whitespace-only cwd values", async () => {
+    await writeSessionLabel(dir, "Named", { cwd: "  /repo/app  " });
+    await expect(readSessionLabelMetadata(dir)).resolves.toEqual({
+      cwd: "/repo/app",
+    });
+
+    await writeSessionLabel(dir, "Named", { cwd: "   " });
+    await expect(readSessionLabelMetadata(dir)).resolves.toEqual({});
+  });
 });
 
 describe("truncateLocalChatAfterEntry", () => {

--- a/agent/session-history/io.ts
+++ b/agent/session-history/io.ts
@@ -57,6 +57,12 @@ export async function readSessionLabel(
   }
 }
 
+function normalizeMetadataCwd(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
 export async function readSessionLabelMetadata(
   sessionDir: string,
 ): Promise<SessionLabelMetadata | undefined> {
@@ -65,10 +71,9 @@ export async function readSessionLabelMetadata(
     const parsed: unknown = JSON.parse(raw);
     if (!parsed || typeof parsed !== "object") return undefined;
     const record = parsed as Record<string, unknown>;
+    const cwd = normalizeMetadataCwd(record.cwd);
     return {
-      ...(typeof record.cwd === "string" && record.cwd.length > 0
-        ? { cwd: record.cwd }
-        : {}),
+      ...(cwd ? { cwd } : {}),
     };
   } catch {
     return undefined;
@@ -98,7 +103,8 @@ export async function writeSessionLabel(
     return;
   }
   await writeFile(path, trimmed + "\n", "utf8");
-  await writeFile(metaPath, `${JSON.stringify(metadata)}\n`, "utf8");
+  const cwd = normalizeMetadataCwd(metadata.cwd);
+  await writeFile(metaPath, `${JSON.stringify({ ...(cwd ? { cwd } : {}) })}\n`, "utf8");
 }
 
 export async function appendLocalChatMessage(

--- a/agent/session-history/io.ts
+++ b/agent/session-history/io.ts
@@ -15,16 +15,19 @@ import {
   mkdir,
   readFile,
   rename,
+  unlink,
   writeFile,
 } from "node:fs/promises";
 import { join } from "node:path";
 import { parseLocalChatLines } from "./parse-local";
 import {
   LABEL_FILE,
+  LABEL_META_FILE,
   LOCAL_CHAT_FILE,
   MAX_CUSTOM_LABEL_CHARS,
   MAX_LOCAL_CHAT_MESSAGES,
   type RestoredChatMessage,
+  type SessionLabelMetadata,
   hasA2ui,
   isChatRole,
   parseChatAttachments,
@@ -54,26 +57,48 @@ export async function readSessionLabel(
   }
 }
 
+export async function readSessionLabelMetadata(
+  sessionDir: string,
+): Promise<SessionLabelMetadata | undefined> {
+  try {
+    const raw = await readFile(join(sessionDir, LABEL_META_FILE), "utf8");
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return undefined;
+    const record = parsed as Record<string, unknown>;
+    return {
+      ...(typeof record.cwd === "string" && record.cwd.length > 0
+        ? { cwd: record.cwd }
+        : {}),
+    };
+  } catch {
+    return undefined;
+  }
+}
+
 /** Write a custom label for the given session. Empty / whitespace-only
  *  input clears the label (deletes the file). The session dir is
  *  created if missing so the call is safe before any chat turn. */
 export async function writeSessionLabel(
   sessionDir: string,
   label: string,
+  metadata: SessionLabelMetadata = {},
 ): Promise<void> {
   await mkdir(sessionDir, { recursive: true });
   const trimmed = normalizeSessionLabel(label);
   const path = join(sessionDir, LABEL_FILE);
+  const metaPath = join(sessionDir, LABEL_META_FILE);
   if (!trimmed) {
-    try {
-      const fs = await import("node:fs/promises");
-      await fs.unlink(path);
-    } catch {
-      // Already absent — the desired end state.
+    for (const target of [path, metaPath]) {
+      try {
+        await unlink(target);
+      } catch {
+        // Already absent — the desired end state.
+      }
     }
     return;
   }
   await writeFile(path, trimmed + "\n", "utf8");
+  await writeFile(metaPath, `${JSON.stringify(metadata)}\n`, "utf8");
 }
 
 export async function appendLocalChatMessage(

--- a/agent/session-history/lookup.ts
+++ b/agent/session-history/lookup.ts
@@ -22,9 +22,9 @@ function stripTrailingSlashes(p: string): string {
  *  miss on exact string compare and silently start a fresh session
  *  instead of resuming. A vanished path (deleted workspace) falls back
  *  to the normalized string so old sessions still compare predictably. */
-async function canonicalCwd(
+export async function canonicalCwdForComparison(
   p: string,
-  cache: Map<string, string>,
+  cache: Map<string, string> = new Map(),
 ): Promise<string> {
   const norm = stripTrailingSlashes(p);
   const hit = cache.get(norm);
@@ -116,7 +116,7 @@ export async function findSessionFileMatchingCwd(
     return undefined;
   }
   const realpathCache = new Map<string, string>();
-  const target = await canonicalCwd(expectedCwd, realpathCache);
+  const target = await canonicalCwdForComparison(expectedCwd, realpathCache);
   const matches: LatestSessionLog[] = [];
   for (const name of entries) {
     if (name === LOCAL_CHAT_FILE) continue;
@@ -130,7 +130,7 @@ export async function findSessionFileMatchingCwd(
     }
     const cwd = await readSessionHeaderCwd(path);
     if (!cwd) continue;
-    if ((await canonicalCwd(cwd, realpathCache)) !== target) continue;
+    if ((await canonicalCwdForComparison(cwd, realpathCache)) !== target) continue;
     matches.push({ path, mtimeMs, name });
   }
   if (matches.length === 0) return undefined;

--- a/agent/session-history/shared.ts
+++ b/agent/session-history/shared.ts
@@ -6,6 +6,7 @@
  */
 
 export const LABEL_FILE = "label.txt";
+export const LABEL_META_FILE = "label-meta.json";
 export const LOCAL_CHAT_FILE = "aethon-chat.jsonl";
 export const MAX_CUSTOM_LABEL_CHARS = 120;
 export const MAX_RESTORED_MESSAGES = 200;
@@ -42,6 +43,10 @@ export interface LatestSessionLog {
   path: string;
   mtimeMs: number;
   name: string;
+}
+
+export interface SessionLabelMetadata {
+  cwd?: string;
 }
 
 export interface SessionLogMetadata {

--- a/agent/session-label.ts
+++ b/agent/session-label.ts
@@ -21,12 +21,21 @@ export interface SetSessionLabelResult {
   session?: DiscoveredTab;
 }
 
+function nonEmptyCwd(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
 function labelOwnerCwd(
   state: AethonAgentState,
   tabId: string,
   explicitCwd: string | undefined,
 ): string | undefined {
-  return explicitCwd ?? state.tabProjectCwds.get(tabId) ?? state.currentProjectCwd ?? undefined;
+  return (
+    nonEmptyCwd(explicitCwd) ??
+    nonEmptyCwd(state.tabProjectCwds.get(tabId)) ??
+    nonEmptyCwd(state.currentProjectCwd)
+  );
 }
 
 function upsertDiscoveredTab(

--- a/agent/session-label.ts
+++ b/agent/session-label.ts
@@ -13,11 +13,20 @@ interface SessionLabelDeps {
 export interface SetSessionLabelOptions {
   requireNonEmpty?: boolean;
   syncPiSessionName?: (label: string) => void;
+  ownerCwd?: string;
 }
 
 export interface SetSessionLabelResult {
   label: string;
   session?: DiscoveredTab;
+}
+
+function labelOwnerCwd(
+  state: AethonAgentState,
+  tabId: string,
+  explicitCwd: string | undefined,
+): string | undefined {
+  return explicitCwd ?? state.tabProjectCwds.get(tabId) ?? state.currentProjectCwd ?? undefined;
 }
 
 function upsertDiscoveredTab(
@@ -45,7 +54,10 @@ export async function setSessionLabelForTab(
   if (options.requireNonEmpty === true && !label) {
     throw new Error("setSessionTabTitle: title required");
   }
-  await writeSessionLabel(tabSessionDir(state, tabId), label);
+  const ownerCwd = labelOwnerCwd(state, tabId, options.ownerCwd);
+  await writeSessionLabel(tabSessionDir(state, tabId), label, {
+    ...(ownerCwd ? { cwd: ownerCwd } : {}),
+  });
   if (label && options.syncPiSessionName) {
     options.syncPiSessionName(label);
   }

--- a/agent/session-title-tool.test.ts
+++ b/agent/session-title-tool.test.ts
@@ -7,7 +7,7 @@ import {
   type AethonAgentStateOptions,
   type TabRecord,
 } from "./state";
-import { writeSessionLabel } from "./session-history";
+import { readSessionLabelMetadata, writeSessionLabel } from "./session-history";
 import { buildSessionTitleTools } from "./session-title-tool";
 import { tabSessionDir } from "./tab-lifecycle";
 
@@ -129,6 +129,21 @@ describe("buildSessionTitleTools", () => {
         },
       ],
       details: { ok: true, title: "Refactor auth flow" },
+    });
+  });
+
+  it("records trimmed fallback cwd ownership when tab cwd is blank", async () => {
+    const { state, deps } = await makeFixture();
+    const sessionDir = tabSessionDir(state, "tab-1");
+    state.tabProjectCwds.set("tab-1", "   ");
+    state.currentProjectCwd = "  /repo/current  ";
+
+    await getTool(state, deps).execute("call-1", {
+      title: "Prompt polish",
+    });
+
+    await expect(readSessionLabelMetadata(sessionDir)).resolves.toEqual({
+      cwd: "/repo/current",
     });
   });
 

--- a/agent/session-title-tool.test.ts
+++ b/agent/session-title-tool.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -7,6 +7,7 @@ import {
   type AethonAgentStateOptions,
   type TabRecord,
 } from "./state";
+import { writeSessionLabel } from "./session-history";
 import { buildSessionTitleTools } from "./session-title-tool";
 import { tabSessionDir } from "./tab-lifecycle";
 
@@ -37,10 +38,16 @@ async function makeFixture() {
     sessionsDir: join(root, "sessions"),
   });
   const sent: Record<string, unknown>[] = [];
-  const setSessionName = vi.fn();
+  let sessionName: string | undefined;
+  const setSessionName = vi.fn((name: string) => {
+    sessionName = name;
+  });
   state.tabs.set("tab-1", {
     id: "tab-1",
-    session: { setSessionName } as unknown as TabRecord["session"],
+    session: {
+      setSessionName,
+      sessionManager: { getSessionName: () => sessionName },
+    } as unknown as TabRecord["session"],
     toolArgsCache: new Map(),
     promptInFlight: false,
     agentEndFired: false,
@@ -122,6 +129,122 @@ describe("buildSessionTitleTools", () => {
         },
       ],
       details: { ok: true, title: "Refactor auth flow" },
+    });
+  });
+
+  it("keeps the first generated title stable across follow-up prompts", async () => {
+    const { state, deps, sent, setSessionName } = await makeFixture();
+    const sessionDir = tabSessionDir(state, "tab-1");
+    state.tabProjectCwds.set("tab-1", "/repo/a");
+    await getTool(state, deps).execute("call-1", {
+      title: "Fix login flow",
+    });
+    sent.length = 0;
+    setSessionName.mockClear();
+
+    const result = await getTool(state, deps).execute("call-2", {
+      title: "Update tests",
+    });
+
+    expect(setSessionName).not.toHaveBeenCalled();
+    await expect(readFile(join(sessionDir, "label.txt"), "utf8")).resolves.toBe(
+      "Fix login flow\n",
+    );
+    expect(sent).not.toContainEqual(
+      expect.objectContaining({ type: "session_label_changed" }),
+    );
+    expect(result).toMatchObject({
+      details: { ok: true, title: "Fix login flow", skipped: "already_named" },
+    });
+  });
+
+  it("allows an explicit override when the conversation clearly pivots", async () => {
+    const { state, deps, setSessionName } = await makeFixture();
+    const sessionDir = tabSessionDir(state, "tab-1");
+    await writeFile(join(sessionDir, "label.txt"), "Fix login flow\n", "utf8");
+
+    const result = await getTool(state, deps).execute("call-2", {
+      title: "Design billing dashboard",
+      force: true,
+    });
+
+    expect(setSessionName).toHaveBeenCalledWith("Design billing dashboard");
+    await expect(readFile(join(sessionDir, "label.txt"), "utf8")).resolves.toBe(
+      "Design billing dashboard\n",
+    );
+    expect(result).toMatchObject({
+      details: { ok: true, title: "Design billing dashboard" },
+    });
+  });
+
+  it("replaces a stale label when a reused tab directory starts a different cwd session", async () => {
+    const { state, deps, setSessionName } = await makeFixture();
+    const sessionDir = tabSessionDir(state, "tab-1");
+    state.tabProjectCwds.set("tab-1", "/repo/b");
+    await writeFile(join(sessionDir, "label.txt"), "Old project task\n", "utf8");
+
+    const result = await getTool(state, deps).execute("call-2", {
+      title: "New project task",
+    });
+
+    expect(setSessionName).toHaveBeenCalledWith("New project task");
+    await expect(readFile(join(sessionDir, "label.txt"), "utf8")).resolves.toBe(
+      "New project task\n",
+    );
+    expect(result).toMatchObject({
+      details: { ok: true, title: "New project task" },
+    });
+  });
+
+  it("does not trust a stale unowned label just because the latest log matches the current cwd", async () => {
+    const { state, deps, setSessionName } = await makeFixture();
+    const sessionDir = tabSessionDir(state, "tab-1");
+    state.tabProjectCwds.set("tab-1", "/repo/b");
+    await writeFile(
+      join(sessionDir, "session.jsonl"),
+      `${JSON.stringify({ type: "session", id: "s", cwd: "/repo/b" })}\n`,
+      "utf8",
+    );
+    await writeFile(join(sessionDir, "label.txt"), "Old project task\n", "utf8");
+
+    const result = await getTool(state, deps).execute("call-2", {
+      title: "New project task",
+    });
+
+    expect(setSessionName).toHaveBeenCalledWith("New project task");
+    await expect(readFile(join(sessionDir, "label.txt"), "utf8")).resolves.toBe(
+      "New project task\n",
+    );
+    expect(result).toMatchObject({
+      details: { ok: true, title: "New project task" },
+    });
+  });
+
+  it("keeps a sticky title when the current cwd is a canonical-equivalent path", async () => {
+    const { state, deps, setSessionName } = await makeFixture();
+    const sessionDir = tabSessionDir(state, "tab-1");
+    const realProject = join(state.userDir, "real-project");
+    const linkedProject = join(state.userDir, "linked-project");
+    await mkdir(realProject);
+    await symlink(realProject, linkedProject, "dir");
+    await writeFile(
+      join(sessionDir, "session.jsonl"),
+      `${JSON.stringify({ type: "session", id: "s", cwd: realProject })}\n`,
+      "utf8",
+    );
+    state.tabProjectCwds.set("tab-1", linkedProject);
+    await writeSessionLabel(sessionDir, "Canonical task", { cwd: realProject });
+
+    const result = await getTool(state, deps).execute("call-2", {
+      title: "Follow up task",
+    });
+
+    expect(setSessionName).not.toHaveBeenCalled();
+    await expect(readFile(join(sessionDir, "label.txt"), "utf8")).resolves.toBe(
+      "Canonical task\n",
+    );
+    expect(result).toMatchObject({
+      details: { ok: true, title: "Canonical task", skipped: "already_named" },
     });
   });
 

--- a/agent/session-title-tool.ts
+++ b/agent/session-title-tool.ts
@@ -3,7 +3,14 @@ import { defineTool } from "@mariozechner/pi-coding-agent";
 import { Type, type Static } from "typebox";
 import type { AethonAgentState } from "./state";
 import { setSessionLabelForTab } from "./session-label";
+import {
+  normalizeSessionLabel,
+  readSessionLabel,
+  readSessionLabelMetadata,
+} from "./session-history";
+import { canonicalCwdForComparison } from "./session-history/lookup";
 import { SESSION_TITLE_TOOL_NAME } from "./silent-tools";
+import { tabSessionDir } from "./tab-lifecycle/utils";
 
 interface SessionTitleDeps {
   send: (obj: Record<string, unknown>) => void;
@@ -14,6 +21,12 @@ const SetSessionTabTitleParams = Type.Object({
     description:
       "Brief descriptive title for this session tab, usually 2-5 words.",
   }),
+  force: Type.Optional(
+    Type.Boolean({
+      description:
+        "Set true only for an explicit user-requested rename or clear task/topic pivot. Normal follow-up prompts should omit this so the first generated title stays stable.",
+    }),
+  ),
 });
 
 type SetSessionTabTitleParamsT = Static<typeof SetSessionTabTitleParams>;
@@ -28,6 +41,41 @@ function asJson(value: unknown): {
   };
 }
 
+function isPlaceholderSessionTitle(label: string): boolean {
+  return ["new chat", "new session", "untitled", "untitled session"].includes(
+    label.trim().toLowerCase(),
+  );
+}
+
+function currentPiSessionName(
+  state: AethonAgentState,
+  tabId: string,
+): string | undefined {
+  const manager = state.tabs.get(tabId)?.session.sessionManager as
+    | { getSessionName?: () => string | undefined }
+    | undefined;
+  return manager?.getSessionName?.();
+}
+
+async function existingTitleBelongsToCurrentSession(
+  state: AethonAgentState,
+  tabId: string,
+  sessionDir: string,
+  existingTitle: string,
+): Promise<boolean> {
+  if (currentPiSessionName(state, tabId) === existingTitle) return true;
+
+  const currentCwd = state.tabProjectCwds.get(tabId) ?? state.currentProjectCwd;
+  if (!currentCwd) return true;
+  const metadata = await readSessionLabelMetadata(sessionDir);
+  if (!metadata?.cwd) return false;
+  const realpathCache = new Map<string, string>();
+  return (
+    (await canonicalCwdForComparison(metadata.cwd, realpathCache)) ===
+    (await canonicalCwdForComparison(currentCwd, realpathCache))
+  );
+}
+
 export function buildSessionTitleTools(
   state: AethonAgentState,
   deps: SessionTitleDeps,
@@ -37,22 +85,39 @@ export function buildSessionTitleTools(
     name: SESSION_TITLE_TOOL_NAME,
     label: "Set session tab title",
     description:
-      "Silently rename the current Aethon session tab. Use this as the first step for a new user request; choose a short, descriptive title based on the prompt.",
+      "Silently title the current Aethon session tab. The first generated title is sticky: later calls preserve an existing non-placeholder title unless force=true is used for an explicit user-requested rename or clear task/topic pivot.",
     promptSnippet:
       "setSessionTabTitle: silently set the current Aethon tab title",
     parameters: SetSessionTabTitleParams,
     async execute(_callId: string, params: SetSessionTabTitleParamsT) {
+      const title = normalizeSessionLabel(params.title);
+      if (!title) throw new Error("setSessionTabTitle: title required");
+
+      const sessionDir = tabSessionDir(state, tabId);
+      const existingTitle = await readSessionLabel(sessionDir);
+      if (
+        existingTitle &&
+        !isPlaceholderSessionTitle(existingTitle) &&
+        params.force !== true &&
+        (await existingTitleBelongsToCurrentSession(
+          state,
+          tabId,
+          sessionDir,
+          existingTitle,
+        ))
+      ) {
+        return asJson({
+          ok: true,
+          title: existingTitle,
+          skipped: "already_named",
+        });
+      }
+
       const tab = state.tabs.get(tabId);
-      const result = await setSessionLabelForTab(
-        state,
-        deps,
-        tabId,
-        params.title,
-        {
-          requireNonEmpty: true,
-          syncPiSessionName: (label) => tab?.session.setSessionName(label),
-        },
-      );
+      const result = await setSessionLabelForTab(state, deps, tabId, title, {
+        requireNonEmpty: true,
+        syncPiSessionName: (label) => tab?.session.setSessionName(label),
+      });
       return asJson({ ok: true, title: result.label });
     },
   }) as ToolDefinition;

--- a/agent/system-prompt.test.ts
+++ b/agent/system-prompt.test.ts
@@ -166,6 +166,8 @@ describe("DEFAULT_AETHON_PROMPT", () => {
   it("instructs the agent to title the tab and keep transcript output compact", () => {
     expect(DEFAULT_AETHON_PROMPT).toContain("setSessionTabTitle");
     expect(DEFAULT_AETHON_PROMPT).toContain("brief and descriptive");
+    expect(DEFAULT_AETHON_PROMPT).toContain("first generated title is sticky");
+    expect(DEFAULT_AETHON_PROMPT).toContain("force: true");
     expect(DEFAULT_AETHON_PROMPT).toContain("Codex Desktop style");
     expect(DEFAULT_AETHON_PROMPT).toContain("meaningful phase changes");
     expect(DEFAULT_AETHON_PROMPT).toContain("Do not mirror routine");

--- a/agent/system-prompt/prompt-template.ts
+++ b/agent/system-prompt/prompt-template.ts
@@ -13,8 +13,10 @@ into a per-tab xterm.js terminal panel.
 
 At the start of each new user request, first call \`setSessionTabTitle\` with a
 brief and descriptive title for the current session tab. Choose 2-5 words based
-on the prompt. This is a silent operation: do not mention that you renamed the
-tab unless the user asks.
+on the prompt. The first generated title is sticky: normal follow-up prompts
+keep it, and you should use \`force: true\` only for an explicit user-requested
+rename or a clear task/topic pivot. This is a silent operation: do not mention
+that you renamed the tab unless the user asks.
 
 Keep the chat transcript close to Codex Desktop style: prose first, tool
 details in tool surfaces, and only the amount of narration the user needs to

--- a/agent/tabs.ts
+++ b/agent/tabs.ts
@@ -202,8 +202,15 @@ export async function handleSetSessionLabel(
     return;
   }
   const label = typeof labelField === "string" ? labelField : "";
+  const ownerCwdField = (msg as { cwd?: unknown }).cwd;
+  const ownerCwd =
+    typeof ownerCwdField === "string" && ownerCwdField.length > 0
+      ? ownerCwdField
+      : undefined;
   try {
-    await setSessionLabelForTab(state, deps, tabId, label);
+    await setSessionLabelForTab(state, deps, tabId, label, {
+      ...(ownerCwd ? { ownerCwd } : {}),
+    });
   } catch (err) {
     deps.send({
       type: "error",

--- a/src/eventRoutes/sessionRename.ts
+++ b/src/eventRoutes/sessionRename.ts
@@ -1,7 +1,9 @@
 import type { EventRouteContext } from "./types";
 
 function nonEmptyString(value: unknown): string | undefined {
-  return typeof value === "string" && value.length > 0 ? value : undefined;
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
 }
 
 function cwdForSession(

--- a/src/eventRoutes/sessionRename.ts
+++ b/src/eventRoutes/sessionRename.ts
@@ -1,17 +1,48 @@
 import type { EventRouteContext } from "./types";
 
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function cwdForSession(
+  ctx: EventRouteContext,
+  tabId: string,
+): string | undefined {
+  const tabs =
+    (ctx.stateRef.current.tabs as { id?: unknown; cwd?: unknown }[] | undefined) ??
+    [];
+  const tab = tabs.find((item) => item.id === tabId);
+  const tabCwd = nonEmptyString(tab?.cwd);
+  if (tabCwd) return tabCwd;
+
+  const recentSessions =
+    (ctx.stateRef.current.recentSessions as
+      | { id?: unknown; cwd?: unknown }[]
+      | undefined) ?? [];
+  const recent = recentSessions.find((item) => item.id === tabId);
+  const recentCwd = nonEmptyString(recent?.cwd);
+  if (recentCwd) return recentCwd;
+
+  const discovered = ctx.allDiscoveredSessionsRef.current.find(
+    (item) => item.tabId === tabId,
+  );
+  return nonEmptyString(discovered?.cwd);
+}
+
 export function renameSessionLabel(
   ctx: EventRouteContext,
   tabId: string,
   label: string,
 ): void {
   applyOptimisticTabLabel(ctx, tabId, label);
+  const cwd = cwdForSession(ctx, tabId);
   ctx
     .invoke("agent_command", {
       payload: JSON.stringify({
         type: "set_session_label",
         tabId,
         label,
+        ...(cwd ? { cwd } : {}),
       }),
     })
     .catch((err: unknown) => {

--- a/src/eventRoutes/sidebar.test.ts
+++ b/src/eventRoutes/sidebar.test.ts
@@ -242,7 +242,11 @@ describe("handleSidebarDeleteSession", () => {
 
 describe("handleSidebarRenameSession", () => {
   it("forwards a set_session_label command to the bridge", async () => {
-    const { ctx, mocks } = buildRouteFixture();
+    const { ctx, mocks } = buildRouteFixture({
+      state: {
+        tabs: [{ id: "tab-7", kind: "agent", label: "Tab 1", cwd: "/repo/a" }],
+      },
+    });
     const handled = await handleSidebarRenameSession(
       {
         component: { id: "sidebar" },
@@ -257,6 +261,63 @@ describe("handleSidebarRenameSession", () => {
         type: "set_session_label",
         tabId: "tab-7",
         label: "Refactor pass",
+        cwd: "/repo/a",
+      }),
+    });
+  });
+
+  it("includes the recent session cwd when renaming a closed session", async () => {
+    const { ctx, mocks } = buildRouteFixture({
+      state: {
+        tabs: [],
+        recentSessions: [
+          { id: "sess-closed", label: "Old name", cwd: "/repo/closed" },
+        ],
+      },
+    });
+    const handled = await handleSidebarRenameSession(
+      {
+        component: { id: "sidebar" },
+        eventType: "rename-session",
+        data: { sessionId: "sess-closed", label: "Manual name" },
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.invoke).toHaveBeenCalledWith("agent_command", {
+      payload: JSON.stringify({
+        type: "set_session_label",
+        tabId: "sess-closed",
+        label: "Manual name",
+        cwd: "/repo/closed",
+      }),
+    });
+  });
+
+  it("falls back to discovered session cwd when renaming a closed session", async () => {
+    const { ctx, mocks } = buildRouteFixture({
+      state: { tabs: [] },
+    });
+    ctx.allDiscoveredSessionsRef.current = [
+      { tabId: "sess-discovered", lastModified: 1, cwd: "/repo/discovered" },
+    ];
+
+    const handled = await handleSidebarRenameSession(
+      {
+        component: { id: "sidebar" },
+        eventType: "rename-session",
+        data: { sessionId: "sess-discovered", label: "Discovered name" },
+      },
+      ctx,
+    );
+
+    expect(handled).toBe(true);
+    expect(mocks.invoke).toHaveBeenCalledWith("agent_command", {
+      payload: JSON.stringify({
+        type: "set_session_label",
+        tabId: "sess-discovered",
+        label: "Discovered name",
+        cwd: "/repo/discovered",
       }),
     });
   });

--- a/src/eventRoutes/sidebar.test.ts
+++ b/src/eventRoutes/sidebar.test.ts
@@ -266,6 +266,40 @@ describe("handleSidebarRenameSession", () => {
     });
   });
 
+  it("trims cwd before forwarding a rename", async () => {
+    const { ctx, mocks } = buildRouteFixture({
+      state: {
+        tabs: [
+          {
+            id: "tab-spaced",
+            kind: "agent",
+            label: "Tab 1",
+            cwd: "  /repo/spaced  ",
+          },
+        ],
+      },
+    });
+
+    const handled = await handleSidebarRenameSession(
+      {
+        component: { id: "sidebar" },
+        eventType: "rename-session",
+        data: { sessionId: "tab-spaced", label: "Trimmed cwd" },
+      },
+      ctx,
+    );
+
+    expect(handled).toBe(true);
+    expect(mocks.invoke).toHaveBeenCalledWith("agent_command", {
+      payload: JSON.stringify({
+        type: "set_session_label",
+        tabId: "tab-spaced",
+        label: "Trimmed cwd",
+        cwd: "/repo/spaced",
+      }),
+    });
+  });
+
   it("includes the recent session cwd when renaming a closed session", async () => {
     const { ctx, mocks } = buildRouteFixture({
       state: {

--- a/src/eventRoutes/tabStrip.test.ts
+++ b/src/eventRoutes/tabStrip.test.ts
@@ -172,7 +172,7 @@ describe("handleTabStrip", () => {
     const { ctx, mocks, applySetState } = buildRouteFixture({
       state: {
         tabs: [
-          { id: "tab-4", kind: "agent", label: "Tab 1" },
+          { id: "tab-4", kind: "agent", label: "Tab 1", cwd: "/repo/a" },
           { id: "tab-5", kind: "agent", label: "Tab 2" },
         ],
       },
@@ -191,6 +191,7 @@ describe("handleTabStrip", () => {
         type: "set_session_label",
         tabId: "tab-4",
         label: "Planning",
+        cwd: "/repo/a",
       }),
     });
     const next = applySetState({


### PR DESCRIPTION
## Summary
- make auto-generated session titles sticky by default unless `force: true` is used for explicit renames or clear pivots
- persist cwd ownership metadata with session labels so reused/restored tab dirs do not protect stale labels
- propagate tab/recent-session cwd through manual renames and forked sessions
- update the system prompt guidance for stable first titles

Closes #415.

## Validation
- `bunx vitest run agent/session-title-tool.test.ts agent/session-history/io.test.ts src/eventRoutes/sidebar.test.ts src/eventRoutes/tabStrip.test.ts`
- `bun run typecheck && bun run lint && bunx vitest run`
- `codex review --uncommitted --title "Issue 415 stable session titles"`

Codex review was rerun after addressing the closed-session rename cwd edge case and came back clean.