### PR TITLE
fix(queue): drain queued messages for background workspaces

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -604,6 +604,8 @@ export default function App() {
   // `queuedSteeringId`, and a private in-flight set.
   useQueuedDispatch({
     tabs: (state.tabs as Tab[] | undefined) ?? [],
+    tabBucketsRef,
+    persistedTabBuckets: state.persistedTabBuckets,
     sendChat,
     updateTab: updateTabRouted,
   });

--- a/src/hooks/useQueuedDispatch.test.ts
+++ b/src/hooks/useQueuedDispatch.test.ts
@@ -3,6 +3,11 @@ import { describe, expect, it, vi } from "vitest";
 import { act, renderHook } from "@testing-library/react";
 import { useQueuedDispatch } from "./useQueuedDispatch";
 import { makeEmptyTab, type Tab } from "../types/tab";
+import type { ProjectsState } from "../projects";
+import type { TabBucket } from "./projectOps/types";
+import { updateTabAcrossBuckets } from "./tabRouting";
+import { handleResponseEnd } from "./bridgeMessageHandlers/responseEnd";
+import { buildHandlerFixture } from "./bridgeMessageHandlers/testFixtures";
 
 function tabWithQueue(
   partial: Partial<Tab> = {},
@@ -17,6 +22,103 @@ function tabWithQueue(
 }
 
 describe("useQueuedDispatch", () => {
+  it("drains queued messages for hidden workspace tabs after response_end", () => {
+    const sendChat = vi.fn(() => Promise.resolve());
+    const hidden = tabWithQueue(
+      {
+        id: "tab-a",
+        label: "Workspace A",
+        projectId: "project-a",
+        cwd: "/repo/a-worktree",
+        waiting: true,
+      },
+      { id: "q1", content: "next" },
+    );
+    const visible = tabWithQueue({
+      id: "tab-b",
+      label: "Workspace B",
+      projectId: "project-b",
+      cwd: "/repo/b",
+      waiting: false,
+    });
+    const hiddenBucketKey = "project-a::workspace::wt-a";
+    const tabBucketsRef = {
+      current: new Map<string, TabBucket>([
+        [hiddenBucketKey, { tabs: [hidden], activeTabId: "tab-a" }],
+      ]),
+    };
+    const { ctx } = buildHandlerFixture({
+      state: {
+        activeTabId: "tab-b",
+        tabs: [visible],
+        persistedTabBuckets: {
+          [hiddenBucketKey]: { tabs: [hidden], activeTabId: "tab-a" },
+        },
+        agentRunningTabs: { "tab-a": true },
+      },
+    });
+    ctx.projectsRef.current = {
+      activeId: "project-b",
+      activeWorkspaceId: null,
+      activeHostId: null,
+      projects: [
+        { id: "project-a", label: "Workspace A", path: "/repo/a", lastUsed: 1 },
+        { id: "project-b", label: "Workspace B", path: "/repo/b", lastUsed: 2 },
+      ],
+      workspacesByProject: {
+        "project-a": [
+          {
+            id: "wt-a",
+            projectId: "project-a",
+            path: "/repo/a-worktree",
+            branch: "feat/a",
+            isMain: false,
+          },
+        ],
+      },
+    } satisfies ProjectsState;
+    ctx.updateTab = (tabId, mutator) =>
+      updateTabAcrossBuckets(
+        {
+          setState: ctx.setState,
+          stateRef: ctx.stateRef,
+          projectsRef: ctx.projectsRef,
+          tabBucketsRef,
+        },
+        tabId,
+        mutator,
+      );
+
+    const { rerender } = renderHook(
+      ({ state }: { state: Record<string, unknown> }) =>
+        useQueuedDispatch({
+          tabs: (state.tabs as Tab[] | undefined) ?? [],
+          tabBucketsRef,
+          persistedTabBuckets: state.persistedTabBuckets,
+          sendChat,
+          updateTab: ctx.updateTab,
+        }),
+      { initialProps: { state: ctx.stateRef.current } },
+    );
+
+    expect(sendChat).not.toHaveBeenCalled();
+
+    act(() => {
+      handleResponseEnd({ type: "response_end", tabId: "tab-a" }, ctx);
+    });
+    rerender({ state: ctx.stateRef.current });
+
+    expect(sendChat).toHaveBeenCalledWith("next", {
+      mode: "normal",
+      tabId: "tab-a",
+    });
+    expect(ctx.stateRef.current.activeTabId).toBe("tab-b");
+    expect(ctx.stateRef.current.tabs).toEqual([visible]);
+    const hiddenTab = tabBucketsRef.current.get(hiddenBucketKey)?.tabs[0];
+    expect(hiddenTab?.queuedMessages).toEqual([]);
+    expect(hiddenTab?.queueCount).toBe(0);
+  });
+
   it("drains the head when waiting transitions false and hands off to sendChat", () => {
     const sendChat = vi.fn(() => Promise.resolve());
     const updateTab = vi.fn();

--- a/src/hooks/useQueuedDispatch.ts
+++ b/src/hooks/useQueuedDispatch.ts
@@ -1,7 +1,8 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, type MutableRefObject } from "react";
 import type { ChatAttachment } from "../types/a2ui";
 import type { Tab } from "../types/tab";
 import { isAgentTabInFlight } from "../utils/agentBusy";
+import type { TabBucket } from "./projectOps/types";
 
 /**
  * Drains client-held queues. Watches every agent tab's in-flight state;
@@ -28,8 +29,60 @@ import { isAgentTabInFlight } from "../utils/agentBusy";
  *   shell and editor tabs have queue arrays only because they share
  *   the Tab interface.
  */
+type BucketRecord = Record<string, TabBucket | undefined>;
+
+function appendUniqueTabs(
+  result: Tab[],
+  seen: Set<string>,
+  tabs: readonly Tab[] | undefined,
+): void {
+  for (const tab of tabs ?? []) {
+    if (seen.has(tab.id)) continue;
+    seen.add(tab.id);
+    result.push(tab);
+  }
+}
+
+function bucketValues(source: unknown): TabBucket[] {
+  if (!source || typeof source !== "object") return [];
+  if (source instanceof Map) return Array.from(source.values());
+  if (Array.isArray(source)) return [];
+  return Object.values(source as BucketRecord).filter(
+    (bucket): bucket is TabBucket =>
+      Boolean(bucket) && Array.isArray(bucket?.tabs),
+  );
+}
+
+export function collectQueuedDispatchTabs(
+  visibleTabs: readonly Tab[],
+  tabBuckets?: Map<string, TabBucket> | null,
+  persistedTabBuckets?: unknown,
+): Tab[] {
+  const result: Tab[] = [];
+  const seen = new Set<string>();
+
+  // Prefer the visible active-bucket record when a tab is present in both
+  // places. Stashed bucket snapshots can be older than state.tabs.
+  appendUniqueTabs(result, seen, visibleTabs);
+
+  for (const bucket of bucketValues(tabBuckets)) {
+    appendUniqueTabs(result, seen, bucket.tabs);
+  }
+
+  // Restored persisted buckets are included as a boot-time safety net: the
+  // hydration effect that copies them into tabBucketsRef runs after render,
+  // while this hook's drain effect is registered in the same commit.
+  for (const bucket of bucketValues(persistedTabBuckets)) {
+    appendUniqueTabs(result, seen, bucket.tabs);
+  }
+
+  return result;
+}
+
 export interface UseQueuedDispatchParams {
   tabs: Tab[];
+  tabBucketsRef?: MutableRefObject<Map<string, TabBucket>>;
+  persistedTabBuckets?: unknown;
   sendChat: (
     text: string,
     options?: {
@@ -44,13 +97,21 @@ export interface UseQueuedDispatchParams {
 
 export function useQueuedDispatch({
   tabs,
+  tabBucketsRef,
+  persistedTabBuckets,
   sendChat,
   updateTab,
 }: UseQueuedDispatchParams): void {
   const dispatchingRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
-    for (const tab of tabs) {
+    const dispatchTabs = collectQueuedDispatchTabs(
+      tabs,
+      tabBucketsRef?.current,
+      persistedTabBuckets,
+    );
+
+    for (const tab of dispatchTabs) {
       if (tab.kind !== "agent") continue;
       if (isAgentTabInFlight(tab)) continue;
       // Defensive: persisted tabs created before this feature don't have
@@ -94,5 +155,5 @@ export function useQueuedDispatch({
         dispatchingRef.current.delete(tab.id);
       });
     }
-  }, [tabs, sendChat, updateTab]);
+  }, [tabs, tabBucketsRef, persistedTabBuckets, sendChat, updateTab]);
 }


### PR DESCRIPTION
Closes #422.

## Summary
- Make client-held queued prompt dispatch bucket-independent by having `useQueuedDispatch` inspect visible tabs, live hidden workspace buckets, and restored persisted buckets.
- Keep queue popping and send handoff routed through `updateTabRouted`, so hidden/background tabs mutate in `tabBucketsRef` and `persistedTabBuckets` without selecting their workspace.
- Add a regression covering a hidden workspace tab becoming idle via `response_end` while another workspace remains active.

## Validation
- `bunx vitest run src/hooks/useQueuedDispatch.test.ts` (red before fix, green after)
- `bunx vitest run src/hooks/bridgeMessageHandlers/stashedTabs.test.ts src/hooks/useRoutedTabHelpers.test.ts src/hooks/useChat.test.ts`
- `bunx tsc -b --noEmit`
- `bunx eslint src/App.tsx src/hooks/useQueuedDispatch.ts src/hooks/useQueuedDispatch.test.ts`
- `bunx vitest run` (344 files / 2871 tests passed; existing jsdom/xterm warning noise observed)
- `bun run lint`
- `codex review --uncommitted` (no blocking findings)
