### PR TITLE
fix(layout): materialize numeric patch branches as arrays

### DIFF
--- a/agent/layout-manager.test.ts
+++ b/agent/layout-manager.test.ts
@@ -66,6 +66,12 @@ describe("patchLayoutTree", () => {
     expect(Array.isArray(patched.items)).toBe(true);
   });
 
+  it("materializes missing numeric branches as arrays", () => {
+    expect(patchLayoutTree({}, "/items/0/x", 1)).toEqual({
+      items: [{ x: 1 }],
+    });
+  });
+
   it("decodes ~0/~1 escapes per RFC 6901", () => {
     const tree = { "a/b": { "~c": 1 } };
     const patched = patchLayoutTree(tree, "/a~1b/~0c", 42) as Record<

--- a/agent/layout-manager.ts
+++ b/agent/layout-manager.ts
@@ -40,6 +40,10 @@ function decodePointerToken(t: string): string {
   return t.replace(/~1/g, "/").replace(/~0/g, "~");
 }
 
+function isArrayIndex(token: string | undefined): boolean {
+  return token !== undefined && /^(0|[1-9]\d*)$/.test(token);
+}
+
 /** Layout-aware patch that preserves arrays (mirror of the frontend's
  *  layoutPatch). Used to fold patch_layout calls into the retained
  *  layout so ready/report replay matches the live frontend state. */
@@ -51,20 +55,23 @@ export function patchLayoutTree(
   if (!pointer || pointer === "" || pointer === "/") return payload;
   const path = pointer.startsWith("/") ? pointer.slice(1) : pointer;
   const tokens = path.split("/").map(decodePointerToken);
-  const cloneNode = (node: unknown): Record<string, unknown> | unknown[] => {
+  const cloneNode = (
+    node: unknown,
+    nextToken: string | undefined,
+  ): Record<string, unknown> | unknown[] => {
     if (Array.isArray(node)) return [...node];
     if (node && typeof node === "object") {
       return { ...(node as Record<string, unknown>) };
     }
-    return {};
+    return isArrayIndex(nextToken) ? [] : {};
   };
-  const root = cloneNode(payload);
+  const root = cloneNode(payload, tokens[0]);
   let cursor: Record<string, unknown> | unknown[] = root;
   for (let i = 0; i < tokens.length - 1; i++) {
     const key = tokens[i];
     const idx = Array.isArray(cursor) ? Number(key) : key;
     const existing = (cursor as Record<string | number, unknown>)[idx as never];
-    const child = cloneNode(existing);
+    const child = cloneNode(existing, tokens[i + 1]);
     (cursor as Record<string | number, unknown>)[idx as never] = child;
     cursor = child;
   }

--- a/src/utils/stateMutation.test.ts
+++ b/src/utils/stateMutation.test.ts
@@ -53,6 +53,12 @@ describe("layoutPatch", () => {
     expect(out).toEqual({ a: { b: { c: 7 } } });
   });
 
+  it("materializes missing numeric branches as arrays", () => {
+    expect(layoutPatch({}, "/items/0/x", 1)).toEqual({
+      items: [{ x: 1 }],
+    });
+  });
+
   it("decodes escape sequences in keys", () => {
     const out = layoutPatch({}, "/foo~1bar/baz", 1);
     expect(out).toEqual({ "foo/bar": { baz: 1 } });

--- a/src/utils/stateMutation.ts
+++ b/src/utils/stateMutation.ts
@@ -7,22 +7,33 @@ export function decodeToken(t: string): string {
   return t.replace(/~1/g, "/").replace(/~0/g, "~");
 }
 
+function isArrayIndex(token: string | undefined): boolean {
+  return token !== undefined && /^(0|[1-9]\d*)$/.test(token);
+}
+
 export function layoutPatch<T>(payload: T, pointer: string, value: unknown): T {
   if (!pointer || pointer === "" || pointer === "/") return payload;
   const path = pointer.startsWith("/") ? pointer.slice(1) : pointer;
   const tokens = path.split("/").map(decodeToken);
-  const cloneNode = (node: unknown): unknown => {
+  const cloneNode = (
+    node: unknown,
+    nextToken: string | undefined,
+  ): unknown => {
     if (Array.isArray(node)) return [...node];
-    if (node && typeof node === "object") return { ...(node as Record<string, unknown>) };
-    return {};
+    if (node && typeof node === "object") {
+      return { ...(node as Record<string, unknown>) };
+    }
+    return isArrayIndex(nextToken) ? [] : {};
   };
-  const root = cloneNode(payload) as Record<string, unknown> | unknown[];
+  const root = cloneNode(payload, tokens[0]) as
+    | Record<string, unknown>
+    | unknown[];
   let cursor: Record<string, unknown> | unknown[] = root;
   for (let i = 0; i < tokens.length - 1; i++) {
     const key = tokens[i];
     const idx = Array.isArray(cursor) ? Number(key) : key;
     const existing = (cursor as Record<string | number, unknown>)[idx as never];
-    const child = cloneNode(existing);
+    const child = cloneNode(existing, tokens[i + 1]);
     (cursor as Record<string | number, unknown>)[idx as never] = child;
     cursor = child as Record<string, unknown> | unknown[];
   }


### PR DESCRIPTION
## Summary
- fix bridge-side `patchLayoutTree` to create arrays for missing numeric JSON Pointer branches
- mirror the same behavior in the frontend `layoutPatch` live patcher
- add regression coverage for `/items/0/x` producing `{ items: [{ x: 1 }] }` on both sides

Closes #430.

## Validation
- `bunx vitest run agent/layout-manager.test.ts` (red before fix, green after)
- `bunx vitest run src/utils/stateMutation.test.ts` (red before frontend mirror fix, green after)
- `bunx vitest run src/utils/stateMutation.test.ts agent/jsonPointer.test.ts agent/layout-manager.test.ts`
- `bunx tsc -b --noEmit`
- `bunx eslint agent/layout-manager.ts agent/layout-manager.test.ts src/utils/stateMutation.ts src/utils/stateMutation.test.ts`
- `codex review --uncommitted` (initial review found frontend drift; addressed)
- `codex review --uncommitted` (clean)
