### PR TITLE
fix(workspaces): namespace managed worktree paths

### DIFF
--- a/src/hooks/projectOps/workspaceOps/git.ts
+++ b/src/hooks/projectOps/workspaceOps/git.ts
@@ -82,12 +82,16 @@ function uniqueWorkspacePath(
 }
 
 function workspacePathKey(path: string): string {
-  return trimTrailingSeparators(path).replace(/\\/g, "/").toLowerCase();
+  return normalizedWorkspacePath(path).toLowerCase();
+}
+
+function normalizedWorkspacePath(path: string): string {
+  return trimTrailingSeparators(path).replace(/\\/g, "/");
 }
 
 function stablePathHash(path: string): string {
   let hash = 0x811c9dc5;
-  for (const char of workspacePathKey(path)) {
+  for (const char of normalizedWorkspacePath(path)) {
     hash ^= char.charCodeAt(0);
     hash = Math.imul(hash, 0x01000193) >>> 0;
   }

--- a/src/hooks/projectOps/workspaceOps/git.ts
+++ b/src/hooks/projectOps/workspaceOps/git.ts
@@ -54,9 +54,44 @@ export function defaultWorkspacePath(
   if (root) {
     const sep = root.includes("\\") && !root.includes("/") ? "\\" : "/";
     const repoName = safePathSegment(pathBasename(projectPath), "repo");
-    return `${trimTrailingSeparators(root)}${sep}${repoName}${sep}${workspaceName}`;
+    const projectKey = `${repoName}-${stablePathHash(projectPath)}`;
+    return `${trimTrailingSeparators(root)}${sep}worktrees${sep}${projectKey}${sep}${workspaceName}`;
   }
   return `${projectPath.replace(/[\\/]+$/, "")}-${workspaceName}`;
+}
+
+function uniqueWorkspacePath(
+  projects: ProjectsState,
+  proposedPath: string,
+): string {
+  const used = new Set<string>();
+  for (const list of Object.values(projects.workspacesByProject)) {
+    for (const workspace of list) {
+      used.add(workspacePathKey(workspace.path));
+    }
+  }
+  if (!used.has(workspacePathKey(proposedPath))) return proposedPath;
+
+  let suffix = 2;
+  let candidate = `${proposedPath}-${suffix}`;
+  while (used.has(workspacePathKey(candidate))) {
+    suffix += 1;
+    candidate = `${proposedPath}-${suffix}`;
+  }
+  return candidate;
+}
+
+function workspacePathKey(path: string): string {
+  return trimTrailingSeparators(path).replace(/\\/g, "/").toLowerCase();
+}
+
+function stablePathHash(path: string): string {
+  let hash = 0x811c9dc5;
+  for (const char of workspacePathKey(path)) {
+    hash ^= char.charCodeAt(0);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash.toString(36).padStart(7, "0");
 }
 
 function trimTrailingSeparators(path: string): string {
@@ -217,9 +252,12 @@ export async function createWorkspaceWithParams(
     typeof deps.stateRef?.current.aethonRoot === "string"
       ? deps.stateRef.current.aethonRoot
       : undefined;
-  const targetPath =
-    opts.targetPath?.trim() ||
-    defaultWorkspacePath(project.path, branch, aethonRoot);
+  const targetPath = opts.targetPath?.trim()
+    ? opts.targetPath.trim()
+    : uniqueWorkspacePath(
+        deps.projectsRef.current,
+        defaultWorkspacePath(project.path, branch, aethonRoot),
+      );
   const pending = newPendingWorkspace(opts.projectId, branch, targetPath);
   const baseBranch = resolveWorkspaceBaseBranch(project, opts.baseBranch);
   const before =

--- a/src/hooks/useProjectOps.test.ts
+++ b/src/hooks/useProjectOps.test.ts
@@ -21,6 +21,7 @@ import {
   workspaceIdForCwd,
   type UseProjectOpsContext,
 } from "./useProjectOps";
+import { defaultWorkspacePath } from "./projectOps/workspaceOps/git";
 
 vi.mock("../monaco/editor-buffers", () => ({
   disposeEditorBuffer: vi.fn(),
@@ -1604,6 +1605,13 @@ describe("useProjectOps workspace creation", () => {
       /^\/tmp\/aethon\/worktrees\/aethon-01m6jvq\/feat-/,
     );
     expect(created).toBe(addCall?.[1]?.targetPath);
+  });
+
+  it("keeps the project hash case-preserving for managed path namespaces", () => {
+    expect(defaultWorkspacePath("/Work/aethon", "fix/thing", "/tmp/aethon"))
+      .toBe("/tmp/aethon/worktrees/aethon-1yl0o23/fix-thing");
+    expect(defaultWorkspacePath("/work/aethon", "fix/thing", "/tmp/aethon"))
+      .toBe("/tmp/aethon/worktrees/aethon-1dg8obv/fix-thing");
   });
 
   it("namespaces managed paths for same-name projects", async () => {

--- a/src/hooks/useProjectOps.test.ts
+++ b/src/hooks/useProjectOps.test.ts
@@ -1423,7 +1423,7 @@ describe("useProjectOps workspace creation", () => {
     harness.invoke.mockImplementation((cmd: string) => {
       if (cmd === "git_worktree_add") {
         return Promise.resolve({
-          path: "/tmp/aethon/aethon/fix-thing",
+          path: "/tmp/aethon/worktrees/aethon-01m6jvq/fix-thing",
           branch: "fix/thing",
           head: "def456",
           isMain: false,
@@ -1440,7 +1440,7 @@ describe("useProjectOps workspace creation", () => {
             locked: false,
           },
           {
-            path: "/tmp/aethon/aethon/fix-thing",
+            path: "/tmp/aethon/worktrees/aethon-01m6jvq/fix-thing",
             branch: "fix/thing",
             head: "def456",
             isMain: false,
@@ -1464,12 +1464,12 @@ describe("useProjectOps workspace creation", () => {
         projectId: "project-1",
         branch: "fix/thing",
       });
-      expect(created).toBe("/tmp/aethon/aethon/fix-thing");
+      expect(created).toBe("/tmp/aethon/worktrees/aethon-01m6jvq/fix-thing");
     });
 
     expect(harness.invoke).toHaveBeenCalledWith("git_worktree_add", {
       projectPath: "/projects/aethon",
-      targetPath: "/tmp/aethon/aethon/fix-thing",
+      targetPath: "/tmp/aethon/worktrees/aethon-01m6jvq/fix-thing",
       branch: "fix/thing",
       base: "origin/main",
     });
@@ -1477,7 +1477,7 @@ describe("useProjectOps workspace creation", () => {
     const active = projectsRef.current.workspacesByProject["project-1"]?.find(
       (w) => w.id === projectsRef.current.activeWorkspaceId,
     );
-    expect(active?.path).toBe("/tmp/aethon/aethon/fix-thing");
+    expect(active?.path).toBe("/tmp/aethon/worktrees/aethon-01m6jvq/fix-thing");
     expect(projectsRef.current.projects[0].uiExpanded).toBe(true);
   });
 
@@ -1486,7 +1486,7 @@ describe("useProjectOps workspace creation", () => {
     harness.invoke.mockImplementation((cmd: string) => {
       if (cmd === "git_worktree_add") {
         return Promise.resolve({
-          path: "/tmp/aethon/aethon/fix-thing",
+          path: "/tmp/aethon/worktrees/aethon-01m6jvq/fix-thing",
           branch: "fix/thing",
           head: "def456",
           isMain: false,
@@ -1503,7 +1503,7 @@ describe("useProjectOps workspace creation", () => {
             locked: false,
           },
           {
-            path: "/tmp/aethon/aethon/fix-thing",
+            path: "/tmp/aethon/worktrees/aethon-01m6jvq/fix-thing",
             branch: "fix/thing",
             head: "def456",
             isMain: false,
@@ -1528,7 +1528,7 @@ describe("useProjectOps workspace creation", () => {
         branch: "fix/thing",
         activate: false,
       });
-      expect(created).toBe("/tmp/aethon/aethon/fix-thing");
+      expect(created).toBe("/tmp/aethon/worktrees/aethon-01m6jvq/fix-thing");
     });
 
     expect(projectsRef.current.activeId).toBe("project-1");
@@ -1536,7 +1536,9 @@ describe("useProjectOps workspace creation", () => {
     expect(projectsRef.current.projects[0].uiExpanded).not.toBe(true);
     expect(
       projectsRef.current.workspacesByProject["project-1"]?.some(
-        (workspace) => workspace.path === "/tmp/aethon/aethon/fix-thing",
+        (workspace) =>
+          workspace.path ===
+          "/tmp/aethon/worktrees/aethon-01m6jvq/fix-thing",
       ),
     ).toBe(true);
   });
@@ -1598,8 +1600,163 @@ describe("useProjectOps workspace creation", () => {
       base: "origin/main",
     });
     expect(addCall?.[1]?.branch).toMatch(/^feat\//);
-    expect(addCall?.[1]?.targetPath).toMatch(/^\/tmp\/aethon\/aethon\/feat-/);
+    expect(addCall?.[1]?.targetPath).toMatch(
+      /^\/tmp\/aethon\/worktrees\/aethon-01m6jvq\/feat-/,
+    );
     expect(created).toBe(addCall?.[1]?.targetPath);
+  });
+
+  it("namespaces managed paths for same-name projects", async () => {
+    const harness = installTauriMocks();
+    harness.invoke.mockImplementation((cmd: string, args) => {
+      if (cmd === "git_worktree_add") {
+        return Promise.resolve({
+          path: args.targetPath,
+          branch: args.branch,
+          head: "def456",
+          isMain: false,
+          locked: false,
+        });
+      }
+      if (cmd === "git_worktrees") {
+        const projectPath = args.projectPath;
+        const addCalls = harness.invoke.mock.calls.filter(
+          ([name, callArgs]) =>
+            name === "git_worktree_add" &&
+            callArgs?.projectPath === projectPath,
+        );
+        return Promise.resolve([
+          {
+            path: projectPath,
+            branch: "main",
+            head: "abc123",
+            isMain: true,
+            locked: false,
+          },
+          ...addCalls.map(([, callArgs]) => ({
+            path: callArgs.targetPath,
+            branch: callArgs.branch,
+            head: "def456",
+            isMain: false,
+            locked: false,
+          })),
+        ]);
+      }
+      return Promise.resolve(undefined);
+    });
+    const initial = makeProjectsState({
+      activeId: "project-1",
+      projects: [
+        {
+          id: "project-1",
+          label: "aethon",
+          path: "/work/aethon",
+          lastUsed: 1,
+        },
+        {
+          id: "project-2",
+          label: "aethon fork",
+          path: "/forks/aethon",
+          lastUsed: 2,
+        },
+      ],
+    });
+    const { result, projectsRef, stateRef } = renderProjectOps(initial);
+    stateRef.current.aethonRoot = "/tmp/aethon";
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    projectsRef.current = initial;
+
+    await act(async () => {
+      await result.current.createWorkspaceWithParams({
+        projectId: "project-1",
+        branch: "fix/thing",
+        activate: false,
+      });
+      await result.current.createWorkspaceWithParams({
+        projectId: "project-2",
+        branch: "fix/thing",
+        activate: false,
+      });
+    });
+
+    const addCalls = harness.invoke.mock.calls.filter(
+      ([cmd]) => cmd === "git_worktree_add",
+    );
+    const targetPaths = addCalls.map(([, args]) => args.targetPath);
+    expect(targetPaths).toEqual([
+      "/tmp/aethon/worktrees/aethon-1dg8obv/fix-thing",
+      "/tmp/aethon/worktrees/aethon-077lgv7/fix-thing",
+    ]);
+    expect(new Set(targetPaths).size).toBe(2);
+  });
+
+  it("deduplicates managed paths for explicit branches with the same safe segment", async () => {
+    const harness = installTauriMocks();
+    harness.invoke.mockImplementation((cmd: string, args) => {
+      if (cmd === "git_worktree_add") {
+        return Promise.resolve({
+          path: args.targetPath,
+          branch: args.branch,
+          head: "def456",
+          isMain: false,
+          locked: false,
+        });
+      }
+      if (cmd === "git_worktrees") {
+        const addCalls = harness.invoke.mock.calls.filter(
+          ([name]) => name === "git_worktree_add",
+        );
+        return Promise.resolve([
+          {
+            path: "/projects/aethon",
+            branch: "main",
+            head: "abc123",
+            isMain: true,
+            locked: false,
+          },
+          ...addCalls.map(([, callArgs]) => ({
+            path: callArgs.targetPath,
+            branch: callArgs.branch,
+            head: "def456",
+            isMain: false,
+            locked: false,
+          })),
+        ]);
+      }
+      return Promise.resolve(undefined);
+    });
+    const initial = makeProjectsState({ activeId: "project-1" });
+    const { result, projectsRef, stateRef } = renderProjectOps(initial);
+    stateRef.current.aethonRoot = "/tmp/aethon";
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    projectsRef.current = initial;
+
+    await act(async () => {
+      await result.current.createWorkspaceWithParams({
+        projectId: "project-1",
+        branch: "feat/x",
+        activate: false,
+      });
+      await result.current.createWorkspaceWithParams({
+        projectId: "project-1",
+        branch: "feat-x",
+        activate: false,
+      });
+    });
+
+    const targetPaths = harness.invoke.mock.calls
+      .filter(([cmd]) => cmd === "git_worktree_add")
+      .map(([, args]) => args.targetPath);
+    expect(targetPaths).toEqual([
+      "/tmp/aethon/worktrees/aethon-01m6jvq/feat-x",
+      "/tmp/aethon/worktrees/aethon-01m6jvq/feat-x-2",
+    ]);
   });
 
   it("uses project and explicit base branch overrides in priority order", async () => {


### PR DESCRIPTION
## Summary
- namespace managed worktree paths under `<userDir>/worktrees/<repo>-<hash(project.path)>/<branch>`
- add cross-project path preflighting for generated managed paths, including explicit branch names that sanitize to the same segment
- add regressions for same-basename projects and `feat/x` vs `feat-x` path collisions

Closes #424.

## Validation
- `bunx vitest run src/hooks/useProjectOps.test.ts`
- `bunx tsc -b --noEmit`
- `bunx eslint src/hooks/projectOps/workspaceOps/git.ts src/hooks/useProjectOps.test.ts`
- `codex review --uncommitted --title "Issue 424 managed workspace paths"`
- `git diff --check`

## Notes
- `bunx vitest run` was attempted; unrelated tests outside this change timed out/failed (for example `agent/mcp.test.ts`, `agent/session-history.test.ts`, native canvas/dashboard/settings tests, and one file-tree async expectation). The focused workspace regression suite passes.
