### PR TITLE
fix(agent): dedupe sessions event handlers

### DIFF
--- a/agent/aethon-api-sessions.test.ts
+++ b/agent/aethon-api-sessions.test.ts
@@ -576,9 +576,106 @@ describe("aethon.sessions API", () => {
     ]);
   });
 
+  it("preserves unscoped same-source session handlers", async () => {
+    const { state, api } = await makeFixture();
+    const calls: unknown[] = [];
+
+    api.sessions.on("messageAppended", (payload) => calls.push(payload));
+    api.sessions.on("messageAppended", (payload) => calls.push(payload));
+
+    emitSessionEvent(state, "messageAppended", {
+      sessionId: "live",
+      message: { id: "m", role: "user", content: "hi" },
+    });
+    await Promise.resolve();
+
+    expect(calls).toHaveLength(2);
+    expect(state.sessionEventHandlers.get("messageAppended")?.size).toBe(2);
+    expect(state.registeredHandlerKeys.size).toBe(0);
+  });
+
+  it("dedupes logically identical session handlers across extension reruns", async () => {
+    const { state, api } = await makeFixture();
+    state.currentExtensionLoadScope = "project";
+    state.currentExtensionName = "dup-ext";
+    const calls: unknown[] = [];
+
+    api.sessions.on("messageAppended", (payload) => calls.push(payload));
+    state.currentExtensionHandlerOrdinals.clear();
+    const rerunOff = api.sessions.on("messageAppended", (payload) =>
+      calls.push(payload),
+    );
+
+    emitSessionEvent(state, "messageAppended", {
+      sessionId: "live",
+      message: { id: "m", role: "user", content: "hi" },
+    });
+    await Promise.resolve();
+
+    expect(calls).toHaveLength(1);
+    expect(state.sessionEventHandlers.get("messageAppended")?.size).toBe(1);
+    expect(state.registeredHandlerKeys.size).toBe(1);
+
+    rerunOff();
+    emitSessionEvent(state, "messageAppended", {
+      sessionId: "live",
+      message: { id: "m2", role: "user", content: "again" },
+    });
+    await Promise.resolve();
+
+    expect(calls).toHaveLength(1);
+    expect(state.sessionEventHandlers.has("messageAppended")).toBe(false);
+    expect(state.registeredHandlerKeys.size).toBe(0);
+  });
+
+  it("re-registers when a scoped dedupe key has no teardown", async () => {
+    const { state, api } = await makeFixture();
+    state.currentExtensionLoadScope = "project";
+    state.currentExtensionName = "stale-ext";
+    const calls: unknown[] = [];
+
+    api.sessions.on("messageAppended", (payload) => calls.push(payload));
+    state.sessionEventHandlerTeardowns.clear();
+    state.sessionEventHandlers.clear();
+    state.currentExtensionHandlerOrdinals.clear();
+
+    api.sessions.on("messageAppended", (payload) => calls.push(payload));
+    emitSessionEvent(state, "messageAppended", {
+      sessionId: "live",
+      message: { id: "m", role: "user", content: "hi" },
+    });
+    await Promise.resolve();
+
+    expect(calls).toHaveLength(1);
+    expect(state.sessionEventHandlers.get("messageAppended")?.size).toBe(1);
+    expect(state.sessionEventHandlerTeardowns.size).toBe(1);
+    expect(state.registeredHandlerKeys.size).toBe(1);
+  });
+
+  it("preserves distinct same-source session handlers in one extension run", async () => {
+    const { state, api } = await makeFixture();
+    state.currentExtensionLoadScope = "project";
+    state.currentExtensionName = "multi-ext";
+    const calls: unknown[] = [];
+
+    api.sessions.on("messageAppended", (payload) => calls.push(payload));
+    api.sessions.on("messageAppended", (payload) => calls.push(payload));
+
+    emitSessionEvent(state, "messageAppended", {
+      sessionId: "live",
+      message: { id: "m", role: "user", content: "hi" },
+    });
+    await Promise.resolve();
+
+    expect(calls).toHaveLength(2);
+    expect(state.sessionEventHandlers.get("messageAppended")?.size).toBe(2);
+    expect(state.registeredHandlerKeys.size).toBe(2);
+  });
+
   it("registers project-scoped subscriptions for project unload cleanup", async () => {
     const { state, api } = await makeFixture();
     state.currentExtensionLoadScope = "project";
+    state.currentExtensionName = "cleanup-ext";
     const handler = () => {};
 
     const off = api.sessions.on("messageAppended", handler);
@@ -589,8 +686,9 @@ describe("aethon.sessions API", () => {
     expect(state.projectExtensionTeardowns).toHaveLength(1);
     state.projectExtensionTeardowns[0]?.();
     expect(
-      state.sessionEventHandlers.get("messageAppended")?.has(handler),
+      state.sessionEventHandlers.get("messageAppended")?.has(handler) ?? false,
     ).toBe(false);
+    expect(state.registeredHandlerKeys.size).toBe(0);
     off();
   });
 

--- a/agent/aethon-api-sessions.ts
+++ b/agent/aethon-api-sessions.ts
@@ -573,6 +573,21 @@ export function handleMirroredTabsChanged(
   }
 }
 
+function sessionEventHandlerKey(
+  state: AethonAgentState,
+  event: SessionEventName,
+  handler: SessionEventHandler,
+): string | undefined {
+  if (!state.currentExtensionName || !state.currentExtensionLoadScope) {
+    return undefined;
+  }
+  const scope = `${state.currentExtensionLoadScope}:${state.currentExtensionName}`;
+  const base = `sessions:on::${scope}::${event}::${handler.toString()}`;
+  const ordinal = state.currentExtensionHandlerOrdinals.get(base) ?? 0;
+  state.currentExtensionHandlerOrdinals.set(base, ordinal + 1);
+  return `${base}::${ordinal}`;
+}
+
 export function buildSessionsApi(state: AethonAgentState): SessionsApi {
   return {
     list: () => Promise.resolve(listSessionSummaries(state)),
@@ -589,6 +604,13 @@ export function buildSessionsApi(state: AethonAgentState): SessionsApi {
     },
     on(event: SessionEventName, handler: SessionEventHandler) {
       if (typeof handler !== "function") return () => {};
+      const key = sessionEventHandlerKey(state, event, handler);
+      if (key && state.registeredHandlerKeys.has(key)) {
+        const existingOff = state.sessionEventHandlerTeardowns.get(key);
+        if (existingOff) return existingOff;
+        state.registeredHandlerKeys.delete(key);
+      }
+      if (key) state.registeredHandlerKeys.add(key);
       let handlers = state.sessionEventHandlers.get(event) as
         | Set<SessionEventHandler>
         | undefined;
@@ -599,9 +621,17 @@ export function buildSessionsApi(state: AethonAgentState): SessionsApi {
       handlers.add(handler);
       const off = () => {
         handlers?.delete(handler);
+        if (handlers?.size === 0) state.sessionEventHandlers.delete(event);
+        if (key) {
+          state.registeredHandlerKeys.delete(key);
+          state.sessionEventHandlerTeardowns.delete(key);
+        }
       };
+      if (key) state.sessionEventHandlerTeardowns.set(key, off);
       if (state.currentExtensionLoadScope === "project") {
         state.projectExtensionTeardowns.push(off);
+      } else if (state.currentExtensionLoadScope === "user") {
+        state.userExtensionTeardowns.push(off);
       }
       return off;
     },

--- a/agent/extension-loader/directory.ts
+++ b/agent/extension-loader/directory.ts
@@ -171,14 +171,20 @@ export async function loadAethonExtensionDirectory(
       // teardowns fire on project switch; user-level teardowns persist.
       const prevScope = state.currentExtensionLoadScope;
       const prevExtName = state.currentExtensionName;
+      const prevHandlerOrdinals = new Map(state.currentExtensionHandlerOrdinals);
       state.currentExtensionLoadScope =
         options.source === "project-directory" ? "project" : "user";
       state.currentExtensionName = displayName;
+      state.currentExtensionHandlerOrdinals.clear();
       try {
         await register(api);
       } finally {
         state.currentExtensionLoadScope = prevScope;
         state.currentExtensionName = prevExtName;
+        state.currentExtensionHandlerOrdinals.clear();
+        for (const [k, v] of prevHandlerOrdinals) {
+          state.currentExtensionHandlerOrdinals.set(k, v);
+        }
       }
       registry.set(displayName, options.source);
       options.loadedFiles?.add(file);

--- a/agent/extension-loader/packages.ts
+++ b/agent/extension-loader/packages.ts
@@ -218,13 +218,19 @@ export async function loadAethonExtensionPackages(
       }
       const prevScope = state.currentExtensionLoadScope;
       const prevExtName = state.currentExtensionName;
+      const prevHandlerOrdinals = new Map(state.currentExtensionHandlerOrdinals);
       state.currentExtensionLoadScope = "user";
       state.currentExtensionName = c.name;
+      state.currentExtensionHandlerOrdinals.clear();
       try {
         await register(api);
       } finally {
         state.currentExtensionLoadScope = prevScope;
         state.currentExtensionName = prevExtName;
+        state.currentExtensionHandlerOrdinals.clear();
+        for (const [k, v] of prevHandlerOrdinals) {
+          state.currentExtensionHandlerOrdinals.set(k, v);
+        }
       }
       registry.set(c.name, "extension-package");
       options?.onLoaded?.(c.name);

--- a/agent/state.ts
+++ b/agent/state.ts
@@ -558,6 +558,8 @@ export class AethonAgentState {
     string,
     Set<(payload: unknown) => void>
   >();
+  /** Unsubscribe callbacks keyed by the logical sessions.on dedupe key. */
+  readonly sessionEventHandlerTeardowns = new Map<string, () => void>();
   readonly a2uiEventHandlers: {
     match: A2UIEventMatch;
     handler: A2UIEventHandler;
@@ -566,6 +568,10 @@ export class AethonAgentState {
    *  sessions on demand — so without dedup, every new tab would re-add
    *  every extension handler, multiplying side effects on each click. */
   readonly registeredHandlerKeys = new Set<string>();
+  /** Per-register() ordinal counters for handlers with the same logical key.
+   *  Reset around each extension register() call so repeated runs dedupe the
+   *  same ordinal while same-source handlers in one run remain distinct. */
+  readonly currentExtensionHandlerOrdinals = new Map<string, number>();
 
   // -- Loading state -------------------------------------------------------
   readonly loadedExtensions = new Map<string, ExtensionSource>();


### PR DESCRIPTION
## Summary

- Dedupe loader-scoped `aethon.sessions.on()` handlers by extension scope/name, event, handler body, and per-register ordinal so repeated extension `register()` runs do not accumulate duplicate session event side effects.
- Preserve legitimate same-source handlers registered in the same extension run and preserve unscoped runtime subscriptions.
- Keep returned `off()` callbacks symmetric for deduped reruns and teardown paths, including project/user extension unload bookkeeping.

Closes #428.

## Validation

- `bunx vitest run agent/aethon-api-sessions.test.ts`
- `bunx vitest run agent/extension-loader.test.ts`
- `bunx eslint agent/aethon-api-sessions.ts agent/extension-loader/directory.ts agent/extension-loader/packages.ts agent/state.ts agent/aethon-api-sessions.test.ts`
- `bunx tsc -b --noEmit`
- `codex review --uncommitted` (clean after addressing findings)
