### PR TITLE
fix(server): honor disabled config for boot listener

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -489,13 +489,13 @@ port in TXT, the other **browses** and emits Tauri events
 auth, no TLS** — this is explicit scaffolding for an upcoming pairing
 PR; do not lean on it for trusted IPC. `commands/server.rs` exposes
 `server_start` / `server_stop`; `commands/host.rs` surfaces discovered
-peers to the frontend. The mDNS **advertiser** is gated on `[server]
-enabled` (default true) via `server_advertise_enabled()` in
-`server/mod.rs`; `boot()` reads it during Tauri `setup()` and skips the
-announcement when it's `false`. The HTTP server and the mDNS **browser**
-are NOT gated — they always run, so peer discovery stays read-only and
-useful even with the advertiser off. An explicit `server_start` IPC
-always advertises regardless of the flag.
+peers to the frontend. The boot-time HTTP listener and mDNS **advertiser**
+are gated on `[server] enabled` (default true) via `server_enabled()` in
+`server/mod.rs`; `boot()` reads it during Tauri `setup()` and skips local
+listening/advertisement when it's `false`. The mDNS **browser** is NOT
+gated — it always runs, so peer discovery stays read-only and useful even
+with the local server off. An explicit `server_start` IPC always starts the
+listener and advertises regardless of the flag.
 
 ### Voice-to-text input
 

--- a/src-tauri/src/helpers/config.rs
+++ b/src-tauri/src/helpers/config.rs
@@ -129,12 +129,11 @@ pub struct UpdatesConfig {
 
 #[derive(Default, Deserialize)]
 pub struct ServerConfig {
-    /// Whether to advertise this host over mDNS (`_aethon._tcp.local.`) on
-    /// boot. Default `true`. Set `false` to stop the LAN announcement — and
-    /// the "No route to host" send-failure log churn it can produce on
-    /// networks without multicast — while keeping peer *discovery* (the
+    /// Whether to start the unauthenticated local HTTP listener and advertise
+    /// this host over mDNS (`_aethon._tcp.local.`) on boot. Default `true`.
+    /// Set `false` to stop LAN exposure while keeping peer *discovery* (the
     /// browser) running, since that's read-only. The `server_start` IPC
-    /// (explicit user action) always advertises regardless of this flag.
+    /// (explicit user action) starts and advertises regardless of this flag.
     pub enabled: Option<bool>,
 }
 

--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -64,8 +64,7 @@ pub(crate) fn init_tracing() {
     };
     // Quiet the mdns_sd crate's below-warn chatter (routine multicast send
     // retries on interfaces without a route) in the DEFAULT filter only — an
-    // explicit AETHON_LOG / RUST_LOG override wins and can re-enable it. The
-    // `[server] enabled = false` gate is the full off-switch.
+    // explicit AETHON_LOG / RUST_LOG override wins and can re-enable it.
     let filter = EnvFilter::try_from_env("AETHON_LOG")
         .or_else(|_| EnvFilter::try_from_default_env())
         .unwrap_or_else(|_| EnvFilter::new(format!("{default_level},mdns_sd=warn")));

--- a/src-tauri/src/server/mod.rs
+++ b/src-tauri/src/server/mod.rs
@@ -10,8 +10,8 @@
 //! Lifecycle: `boot(app)` binds HTTP and registers mDNS advertisement only
 //! when `[server] enabled` is true (the default). The mDNS browser runs even
 //! when the local server is disabled — discovery is read-only and useful in
-//! isolation. `shutdown(state)` aborts the join handles and drops both
-//! `ServiceDaemon`s.
+//! isolation. `ServerState::stop` (via `server_stop`) aborts the HTTP task
+//! and drops the advertisement daemon.
 
 use std::future::Future;
 use std::sync::Arc;

--- a/src-tauri/src/server/mod.rs
+++ b/src-tauri/src/server/mod.rs
@@ -7,13 +7,13 @@
 //! `GET /health` + `GET /status`. No auth, no TLS — explicitly scaffold
 //! until the pairing PR replaces fingerprint + adds tokens.
 //!
-//! Lifecycle: `boot(app)` unconditionally binds HTTP, registers mDNS
-//! advertise, and starts the browser (a `[server] enabled` config gate
-//! is planned alongside the pairing PR but not wired yet). Browser runs
-//! even when advertiser is off — discovery is read-only and useful in
+//! Lifecycle: `boot(app)` binds HTTP and registers mDNS advertisement only
+//! when `[server] enabled` is true (the default). The mDNS browser runs even
+//! when the local server is disabled — discovery is read-only and useful in
 //! isolation. `shutdown(state)` aborts the join handles and drops both
 //! `ServiceDaemon`s.
 
+use std::future::Future;
 use std::sync::Arc;
 use tauri::AppHandle;
 use tauri::async_runtime::JoinHandle;
@@ -29,9 +29,8 @@ pub struct ServerHandle {
     pub port: u16,
     pub http_task: JoinHandle<()>,
     // Held for the lifetime of the announcement — dropping the daemon
-    // stops the mDNS advertisement. `None` when advertising is gated off
-    // via `[server] enabled = false` (HTTP + browser still run). Never
-    // read directly.
+    // stops the mDNS advertisement. `None` when callers start the HTTP
+    // listener without advertising. Never read directly.
     #[allow(dead_code)]
     pub advertise_daemon: Option<mdns_sd::ServiceDaemon>,
 }
@@ -75,16 +74,19 @@ impl ServerState {
 }
 
 /// Start the server on app boot. Failures log + carry on — a network
-/// hiccup must never block the UI. The mDNS advertiser is gated on
-/// `[server] enabled` (default true); the browser always runs.
+/// hiccup must never block the UI. The HTTP listener and mDNS advertiser
+/// are gated on `[server] enabled` (default true); the browser always runs.
 pub fn boot(app: AppHandle, state: Arc<ServerState>) {
     tauri::async_runtime::spawn(async move {
-        let advertise = server_advertise_enabled(&app);
-        if let Err(e) = start(&app, &state, advertise).await {
-            tracing::warn!(target: "aethon::server", "boot failed: {e}");
-        }
-        if !advertise {
-            tracing::info!(target: "aethon::server", "mDNS advertiser disabled via [server] enabled = false");
+        let enabled = server_enabled(&app);
+        match start_on_boot_if_enabled(enabled, || start(&app, &state, true)).await {
+            Ok(Some(_)) => {}
+            Ok(None) => {
+                tracing::info!(target: "aethon::server", "local HTTP listener and mDNS advertiser disabled via [server] enabled = false");
+            }
+            Err(e) => {
+                tracing::warn!(target: "aethon::server", "boot failed: {e}");
+            }
         }
         if let Err(e) = mdns::start_browser(app.clone()) {
             tracing::warn!(target: "aethon::server::mdns", "browser failed: {e}");
@@ -93,7 +95,7 @@ pub fn boot(app: AppHandle, state: Arc<ServerState>) {
 }
 
 /// Read `[server] enabled` from `~/.aethon/config.toml` (default true).
-fn server_advertise_enabled(app: &AppHandle) -> bool {
+fn server_enabled(app: &AppHandle) -> bool {
     use tauri::Manager;
     let Ok(home) = app.path().home_dir() else {
         return true;
@@ -101,15 +103,34 @@ fn server_advertise_enabled(app: &AppHandle) -> bool {
     let user_dir =
         crate::helpers::aethon_dir(Some(home.clone())).unwrap_or_else(|| home.join(".aethon"));
     let raw = std::fs::read_to_string(user_dir.join("config.toml")).unwrap_or_default();
-    crate::helpers::parse_config_toml(&raw)["server"]["enabled"]
+    server_enabled_from_config_text(&raw)
+}
+
+fn server_enabled_from_config_text(raw: &str) -> bool {
+    crate::helpers::parse_config_toml(raw)["server"]["enabled"]
         .as_bool()
         .unwrap_or(true)
 }
 
+async fn start_on_boot_if_enabled<F, Fut>(
+    enabled: bool,
+    start_listener: F,
+) -> Result<Option<u16>, String>
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = Result<u16, String>>,
+{
+    if enabled {
+        start_listener().await.map(Some)
+    } else {
+        Ok(None)
+    }
+}
+
 /// Bind HTTP + (optionally) register the mDNS advertiser. Pulled out so the
-/// `server_start` IPC can reuse it after a user-triggered stop — that path
-/// passes `advertise = true` so an explicit start always announces,
-/// regardless of the config gate.
+/// `server_start` IPC can reuse it after a disabled boot or user-triggered
+/// stop — that path passes `advertise = true` so an explicit start always
+/// announces, regardless of the config gate.
 pub async fn start(_app: &AppHandle, state: &ServerState, advertise: bool) -> Result<u16, String> {
     let info = crate::commands::host::local_host_info();
     let (port, http_task) = http::serve(info.clone()).await?;
@@ -129,4 +150,44 @@ pub async fn start(_app: &AppHandle, state: &ServerState, advertise: bool) -> Re
     state.set(handle).await;
     tracing::info!(target: "aethon::server", "listening on 0.0.0.0:{port}");
     Ok(port)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use super::{server_enabled_from_config_text, start_on_boot_if_enabled};
+
+    #[tokio::test]
+    async fn disabled_server_config_skips_boot_http_listener() {
+        let called = Arc::new(AtomicBool::new(false));
+        let starter_called = Arc::clone(&called);
+        let enabled = server_enabled_from_config_text("[server]\nenabled = false\n");
+
+        let result = start_on_boot_if_enabled(enabled, || async move {
+            starter_called.store(true, Ordering::SeqCst);
+            Ok(123)
+        })
+        .await;
+
+        assert_eq!(result, Ok(None));
+        assert!(!called.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn enabled_server_config_runs_boot_http_listener() {
+        let called = Arc::new(AtomicBool::new(false));
+        let starter_called = Arc::clone(&called);
+        let enabled = server_enabled_from_config_text("");
+
+        let result = start_on_boot_if_enabled(enabled, || async move {
+            starter_called.store(true, Ordering::SeqCst);
+            Ok(123)
+        })
+        .await;
+
+        assert_eq!(result, Ok(Some(123)));
+        assert!(called.load(Ordering::SeqCst));
+    }
 }

--- a/website/guide/configuration.md
+++ b/website/guide/configuration.md
@@ -301,16 +301,17 @@ disable_auto_check = false
 in-development builds. Set `disable_auto_check = true` to stop background
 checks; the manual "Check for Updates" menu item still works.
 
-## Stop LAN advertisement
+## Stop LAN listener and advertisement
 
 ```toml
 [server]
 enabled = false
 ```
 
-This silences the mDNS advertiser (`_aethon._tcp.local.`) so other hosts
-stop discovering this one. Read-only peer discovery still runs, and a
-manual `server_start` action advertises regardless.
+This prevents Aethon from starting its unauthenticated LAN HTTP listener
+and silences the mDNS advertiser (`_aethon._tcp.local.`) on boot. Read-only
+peer discovery still runs, and a manual `server_start` action starts and
+advertises the local server regardless.
 
 ::: warning
 The discovery server has no authentication and no TLS today. It is

--- a/website/reference/config-reference.md
+++ b/website/reference/config-reference.md
@@ -220,14 +220,14 @@ enabled = true
 
 | Key | Type | Default | Notes |
 |---|---|---|---|
-| `enabled` | boolean | `true` | Whether to advertise this host over mDNS (`_aethon._tcp.local.`) at boot. Set `false` to stop the LAN announcement while keeping peer discovery (the browser) running read-only. A manual `server_start` action always advertises regardless of this flag. |
+| `enabled` | boolean | `true` | Whether to start the unauthenticated LAN HTTP listener and advertise this host over mDNS (`_aethon._tcp.local.`) at boot. Set `false` to stop LAN exposure while keeping peer discovery (the browser) running read-only. A manual `server_start` action starts and advertises regardless of this flag. |
 
 ::: warning
 The discovery server has **no authentication and no TLS**. It is explicit
 scaffolding for an upcoming pairing feature; do not treat the HTTP
-endpoints as a trusted IPC channel. `enabled = false` only silences the
-mDNS advertiser; the HTTP server and the read-only discovery browser keep
-running.
+endpoints as a trusted IPC channel. `enabled = false` prevents the local
+HTTP listener and mDNS advertiser from starting on boot; the read-only
+discovery browser keeps running.
 :::
 
 ## `[startup]`


### PR DESCRIPTION
## Summary
- Gate the boot-time HTTP listener behind `[server] enabled`, so `enabled = false` no longer binds the unauthenticated `0.0.0.0` LAN listener.
- Keep read-only mDNS browsing running when the local server is disabled.
- Preserve explicit `server_start` behavior as an opt-in manual start/advertise path.
- Update config comments and website docs to describe the setting as a LAN listener + advertisement off-switch.

Closes #426.

## Validation
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib server::tests -- --nocapture`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib helpers::config::tests::server_enabled_defaults_true_and_honors_override -- --nocapture`
- `git diff --check`
- `codex review --uncommitted --title "Issue 426 server disabled config follow-up"`

## Notes
- `cargo test --manifest-path src-tauri/Cargo.toml --lib` passes the new server/config coverage but hit an unrelated timing-sensitive failure in `devshell::resolve::tests::run_with_timeout_streams_nix_prelude_before_process_exit`; rerunning that single test passes.
