### PR TITLE
fix(a2ui): scope observer overlays by pointer

### DIFF
--- a/src/components/A2UIRenderer.observer-overlay.test.tsx
+++ b/src/components/A2UIRenderer.observer-overlay.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import A2UIRenderer from "./A2UIRenderer";
+import { ExtensionRegistry } from "../extensions/ExtensionRegistry";
+import { ExtensionRegistryProvider } from "../extensions/ExtensionRegistryProvider";
+import type { A2UIPayload } from "../types/a2ui";
+
+function renderObserver(payload: A2UIPayload, state: Record<string, unknown>) {
+  return render(
+    <ExtensionRegistryProvider registry={new ExtensionRegistry()}>
+      <A2UIRenderer payload={payload} state={state} onEvent={() => true} />
+    </ExtensionRegistryProvider>,
+  );
+}
+
+describe("A2UIRenderer observer overlay", () => {
+  it("keeps external sibling updates live after a nested optimistic write", () => {
+    const payload: A2UIPayload = {
+      components: [
+        {
+          id: "card-local-input",
+          type: "text-input",
+          props: {
+            value: { $ref: "/foo/bar" },
+            placeholder: "bar",
+          },
+        },
+        {
+          id: "extension-sibling-value",
+          type: "text",
+          props: {
+            content: { $ref: "/foo/baz" },
+          },
+        },
+      ],
+    };
+
+    const { rerender } = renderObserver(payload, {
+      foo: { bar: "local before", baz: "external before" },
+    });
+
+    fireEvent.change(screen.getByPlaceholderText("bar"), {
+      target: { value: "local after" },
+    });
+
+    expect(screen.getByPlaceholderText("bar")).toMatchObject({
+      value: "local after",
+    });
+    expect(screen.getByText("external before")).toBeTruthy();
+
+    rerender(
+      <ExtensionRegistryProvider registry={new ExtensionRegistry()}>
+        <A2UIRenderer
+          payload={payload}
+          state={{ foo: { bar: "external bar", baz: "external after" } }}
+          onEvent={() => true}
+        />
+      </ExtensionRegistryProvider>,
+    );
+
+    expect(screen.getByPlaceholderText("bar")).toMatchObject({
+      value: "local after",
+    });
+    expect(screen.getByText("external after")).toBeTruthy();
+    expect(screen.queryByText("external before")).toBeNull();
+  });
+
+  it("keeps whole-object optimistic replacements from deep-merging external siblings", () => {
+    const payload: A2UIPayload = {
+      components: [
+        {
+          id: "replace-object",
+          type: "button",
+          props: {
+            label: "Replace",
+            event: "change",
+            value: { $ref: "/foo" },
+            data: { value: { bar: "local object" } },
+          },
+        },
+        {
+          id: "object-bar",
+          type: "text",
+          props: { content: { $ref: "/foo/bar" } },
+        },
+        {
+          id: "object-baz",
+          type: "text",
+          props: { content: { $ref: "/foo/baz" } },
+        },
+      ],
+    };
+
+    renderObserver(payload, {
+      foo: { bar: "external bar", baz: "external baz" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Replace" }));
+
+    expect(screen.getByText("local object")).toBeTruthy();
+    expect(screen.queryByText("external baz")).toBeNull();
+  });
+});

--- a/src/components/A2UIRenderer.tsx
+++ b/src/components/A2UIRenderer.tsx
@@ -91,6 +91,54 @@ function applyOptimisticUpdate(
   return setPointer(prev, valueProp.$ref, next);
 }
 
+function escapePointerToken(token: string): string {
+  return token.replace(/~/g, "~0").replace(/\//g, "~1");
+}
+
+function topLevelOverlayPaths(state: Record<string, unknown>): Set<string> {
+  return new Set(Object.keys(state).map((key) => `/${escapePointerToken(key)}`));
+}
+
+function optimisticUpdatePath(
+  component: A2UIComponent,
+  eventType: string,
+  data: unknown,
+): string | undefined {
+  if (eventType !== "change" && eventType !== "submit") return undefined;
+  const valueProp = component.props?.value;
+  if (!isDynamicRef(valueProp)) return undefined;
+  const next = (data as { value?: unknown } | undefined)?.value;
+  return next === undefined ? undefined : valueProp.$ref;
+}
+
+function mergeStateOverlay(
+  base: Record<string, unknown>,
+  overlay: Record<string, unknown>,
+  overlayPaths: Set<string>,
+): Record<string, unknown> {
+  let merged: Record<string, unknown> = { ...base };
+  for (const path of overlayPaths) {
+    merged = setPointer(merged, path, resolvePointer(overlay, path));
+  }
+  return merged;
+}
+
+function diffStateOverlay(
+  next: Record<string, unknown>,
+  base: Record<string, unknown>,
+  overlayPaths: Set<string>,
+): { diff: Record<string, unknown>; paths: Set<string> } {
+  let diff: Record<string, unknown> = {};
+  const paths = new Set<string>();
+  for (const path of overlayPaths) {
+    const nextValue = resolvePointer(next, path);
+    if (Object.is(nextValue, resolvePointer(base, path))) continue;
+    diff = setPointer(diff, path, nextValue);
+    paths.add(path);
+  }
+  return { diff, paths };
+}
+
 export interface BuiltinComponentProps {
   component: A2UIComponent;
   state: Record<string, unknown>;
@@ -244,9 +292,15 @@ export default function A2UIRenderer({
   bare = false,
 }: A2UIRendererProps) {
   const registry = useExtensionRegistry();
-  const [internalState, setInternalState] = useState<Record<string, unknown>>(
-    payload.state || {},
-  );
+  const [internalOverlay, setInternalOverlay] = useState<{
+    state: Record<string, unknown>;
+    paths: Set<string>;
+  }>(() => ({
+    state: payload.state || {},
+    paths: topLevelOverlayPaths(payload.state || {}),
+  }));
+  const internalState = internalOverlay.state;
+  const overlayPaths = internalOverlay.paths;
   // Bump on extension template registry changes so the renderer re-evaluates
   // any `<Unknown>` types into newly-registered templates without unmounting.
   const [, setTemplateVersion] = useState(0);
@@ -275,16 +329,18 @@ export default function A2UIRenderer({
   const state = useMemo(() => {
     if (mode === "controlled") return externalState as Record<string, unknown>;
     if (mode === "observer") {
-      return {
-        ...(externalState as Record<string, unknown>),
-        ...internalState,
-      };
+      return mergeStateOverlay(
+        externalState as Record<string, unknown>,
+        internalState,
+        overlayPaths,
+      );
     }
     return internalState;
-  }, [mode, externalState, internalState]);
+  }, [mode, externalState, internalState, overlayPaths]);
 
   const updateState = (
     updater: (prev: Record<string, unknown>) => Record<string, unknown>,
+    overlayPath?: string,
   ) => {
     if (mode === "controlled") {
       // Pass the updater to React's setState so it composes against the
@@ -296,32 +352,27 @@ export default function A2UIRenderer({
       // the first event's real mutation.
       onStateChange!((prev) => updater(prev));
     } else if (mode === "observer") {
-      // Compute the post-update merged state, then DIFF against the parent
-      // external state so internalState only retains keys that diverge.
-      // Without the diff, snapshotted external keys would freeze in
-      // internal and shadow future global updates (e.g. extension
-      // state_patch values arriving after a local click).
-      //
-      // Known limitation: the diff is top-level only. If a chat-card
-      // text-input writes `/foo/bar` while extension state ALSO writes
-      // under `/foo/...`, the entire `foo` subtree freezes in the
-      // overlay and live extension updates to siblings stop reflecting
-      // in this card. The contrived collision (extension key namespace
-      // overlapping with a card-local input path) is unlikely in
-      // practice; deeper-path tracking would require threading the
-      // optimistic-update path out of applyOptimisticUpdate.
-      setInternalState((prev) => {
+      // Compute the post-update merged state, then DIFF only the JSON Pointer
+      // paths currently owned by the internal overlay. Without path-scoped
+      // overlay tracking, a local optimistic write such as `/foo/bar` would
+      // retain the whole `foo` object internally and mask later external
+      // sibling updates under `/foo/...`. Keeping explicit paths also preserves
+      // whole-object writes: an intentional `/foo` replacement still shadows
+      // external `/foo/*` children instead of deep-merging them back in.
+      setInternalOverlay((prev) => {
         const ext = externalState as Record<string, unknown>;
-        const merged = { ...ext, ...prev };
+        const nextOverlayPaths = new Set(prev.paths);
+        if (overlayPath) nextOverlayPaths.add(overlayPath);
+        const merged = mergeStateOverlay(ext, prev.state, prev.paths);
         const next = updater(merged);
-        const diff: Record<string, unknown> = {};
-        for (const k of Object.keys(next)) {
-          if (!Object.is(next[k], ext[k])) diff[k] = next[k];
-        }
-        return diff;
+        const { diff, paths } = diffStateOverlay(next, ext, nextOverlayPaths);
+        return { state: diff, paths };
       });
     } else {
-      setInternalState(updater);
+      setInternalOverlay((prev) => ({
+        state: updater(prev.state),
+        paths: prev.paths,
+      }));
     }
   };
 
@@ -335,7 +386,10 @@ export default function A2UIRenderer({
   useEffect(() => {
     if (mode === "controlled") return;
     // eslint-disable-next-line react-hooks/set-state-in-effect
-    setInternalState(payload.state || {});
+    setInternalOverlay({
+      state: payload.state || {},
+      paths: topLevelOverlayPaths(payload.state || {}),
+    });
   }, [payload, mode]);
 
   const handleEvent = async (
@@ -345,8 +399,9 @@ export default function A2UIRenderer({
     templateRootType?: string,
     descendantId?: string,
   ) => {
-    updateState((prev) =>
-      applyOptimisticUpdate(prev, component, eventType, data),
+    updateState(
+      (prev) => applyOptimisticUpdate(prev, component, eventType, data),
+      optimisticUpdatePath(component, eventType, data),
     );
 
     if (externalOnEvent) {


### PR DESCRIPTION
## Summary
- Track observer-mode A2UI local overlays by JSON Pointer path instead of top-level keys.
- Keep optimistic nested writes such as `/foo/bar` from freezing external sibling updates like `/foo/baz`.
- Preserve whole-object optimistic replacements such as `/foo` so they do not accidentally deep-merge external children back in.

Closes #431.

## Validation
- `bunx vitest run src/components/A2UIRenderer.observer-overlay.test.tsx src/components/A2UIRenderer.window-events.test.tsx src/components/RegistryComponent.test.tsx`
- `bun run typecheck`
- `bun run lint`
- Codex peer review: no remaining findings after addressing the object-replacement edge case.
