### PR TITLE
fix: duplicate tool cards, auto-spawned shells, and test-polluted bridge log

### DIFF
--- a/agent/logger.test.ts
+++ b/agent/logger.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * The bridge logger writes a rotating daily file alongside stderr. Under test
+ * runs that file must NOT land in the real `~/.aethon/logs/` — the agent runs
+ * `bunx vitest` via its bash tool, which loads these very modules and would
+ * otherwise flood the production `bridge.<date>.log` with test fixtures.
+ *
+ * The module reads its env (AETHON_LOG_DIR / VITEST) at load time, so each case
+ * resets the module registry and re-imports with the env it wants.
+ */
+describe("bridge logger file sink", () => {
+  const savedEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...savedEnv };
+    vi.resetModules();
+    vi.doUnmock("node:os");
+  });
+
+  it("writes to AETHON_LOG_DIR when the override is set", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "aethon-log-override-"));
+    try {
+      process.env.AETHON_LOG_DIR = dir;
+      vi.resetModules();
+      const { logger } = await import("./logger");
+      logger.scope("probe").info("override-line");
+
+      const files = readdirSync(dir).filter((f) => f.startsWith("bridge."));
+      expect(files).toHaveLength(1);
+      expect(readFileSync(join(dir, files[0]), "utf8")).toContain(
+        "override-line",
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("disables the file sink under vitest when no override is set", async () => {
+    const fakeHome = mkdtempSync(join(tmpdir(), "aethon-home-"));
+    try {
+      vi.doMock("node:os", () => ({
+        homedir: () => fakeHome,
+        tmpdir: () => tmpdir(),
+      }));
+      delete process.env.AETHON_LOG_DIR;
+      process.env.VITEST = "true";
+      vi.resetModules();
+      const { logger } = await import("./logger");
+      logger.scope("probe").info("must-not-be-filed");
+
+      // No file (and not even the logs dir) should be created in the
+      // would-be production location.
+      expect(existsSync(join(fakeHome, ".aethon", "logs"))).toBe(false);
+    } finally {
+      rmSync(fakeHome, { recursive: true, force: true });
+    }
+  });
+});

--- a/agent/logger.test.ts
+++ b/agent/logger.test.ts
@@ -19,10 +19,11 @@ import { join } from "node:path";
  * resets the module registry and re-imports with the env it wants.
  */
 describe("bridge logger file sink", () => {
-  const savedEnv = { ...process.env };
-
   afterEach(() => {
-    process.env = { ...savedEnv };
+    // Restore the individual stubbed vars without replacing the process.env
+    // reference — a fresh object would leak into other test files sharing this
+    // Vitest worker and break helpers like vi.stubEnv.
+    vi.unstubAllEnvs();
     vi.resetModules();
     vi.doUnmock("node:os");
   });
@@ -30,7 +31,7 @@ describe("bridge logger file sink", () => {
   it("writes to AETHON_LOG_DIR when the override is set", async () => {
     const dir = mkdtempSync(join(tmpdir(), "aethon-log-override-"));
     try {
-      process.env.AETHON_LOG_DIR = dir;
+      vi.stubEnv("AETHON_LOG_DIR", dir);
       vi.resetModules();
       const { logger } = await import("./logger");
       logger.scope("probe").info("override-line");
@@ -52,8 +53,8 @@ describe("bridge logger file sink", () => {
         homedir: () => fakeHome,
         tmpdir: () => tmpdir(),
       }));
-      delete process.env.AETHON_LOG_DIR;
-      process.env.VITEST = "true";
+      vi.stubEnv("AETHON_LOG_DIR", undefined);
+      vi.stubEnv("VITEST", "true");
       vi.resetModules();
       const { logger } = await import("./logger");
       logger.scope("probe").info("must-not-be-filed");

--- a/agent/logger.ts
+++ b/agent/logger.ts
@@ -57,8 +57,17 @@ const RETENTION_DAYS = 7;
 
 // Same dir the Rust shell uses, so `ls ~/.aethon/logs/` shows both
 // `aethon.YYYY-MM-DD` (Rust supervisor) and `bridge.YYYY-MM-DD.log`
-// (this process) side by side.
-const LOG_DIR = join(homedir(), ".aethon", "logs");
+// (this process) side by side. `AETHON_LOG_DIR` overrides the location
+// (used by tests, and available for ad-hoc redirection).
+const LOG_DIR_OVERRIDE = process.env.AETHON_LOG_DIR;
+const LOG_DIR = LOG_DIR_OVERRIDE ?? join(homedir(), ".aethon", "logs");
+
+// The rotating-file sink is disabled under test runs (vitest sets VITEST)
+// unless an explicit AETHON_LOG_DIR override is given. The agent runs
+// `bunx vitest` via its own bash tool, which loads these modules; without
+// this gate those runs append test fixtures to the real
+// `~/.aethon/logs/bridge.<date>.log`. stderr still carries every line.
+const FILE_SINK_ENABLED = Boolean(LOG_DIR_OVERRIDE) || !process.env.VITEST;
 
 function todayStamp(): string {
   // YYYY-MM-DD in local time. Matches `tracing-appender`'s daily
@@ -75,6 +84,7 @@ let currentDay = todayStamp();
 let currentFd: number | null = null;
 
 function openCurrentLog(): number | null {
+  if (!FILE_SINK_ENABLED) return null;
   try {
     if (!existsSync(LOG_DIR)) {
       mkdirSync(LOG_DIR, { recursive: true });
@@ -88,6 +98,7 @@ function openCurrentLog(): number | null {
 }
 
 function ensureFd(): number | null {
+  if (!FILE_SINK_ENABLED) return null;
   const today = todayStamp();
   if (today !== currentDay) {
     // Rotated past midnight — close the old fd and open today's file.
@@ -110,6 +121,7 @@ function ensureFd(): number | null {
 function pruneOldLogs(): void {
   // Best-effort retention sweep. Runs once at module load; daily
   // rotation handles the day-to-day churn.
+  if (!FILE_SINK_ENABLED) return;
   try {
     if (!existsSync(LOG_DIR)) return;
     const cutoff = Date.now() - RETENTION_DAYS * 24 * 60 * 60 * 1000;

--- a/agent/tab-lifecycle.test.ts
+++ b/agent/tab-lifecycle.test.ts
@@ -1218,6 +1218,44 @@ describe("handleSessionEvent", () => {
     expect(ids).toEqual(["tool-1-c1", "tool-1-c1", "tool-2-c1"]);
   });
 
+  it("collapses a replayed start for the same in-flight tool call into one card", () => {
+    // pi re-emits tool_execution_start for the same toolCallId on auto-retry /
+    // codex replay (no intervening tool_execution_end). The replay must reuse
+    // the existing card id + startedAt instead of minting a fresh card, so the
+    // user doesn't see two "Running" copies of the same long-running command.
+    const f = makeFixture();
+    const rec = fakeRec();
+    handleSessionEvent(f.state, f.deps, rec, "tab-1", {
+      type: "tool_execution_start",
+      toolCallId: "c1",
+      toolName: "bash",
+      args: { command: "bunx vitest run" },
+    });
+    const firstCard = f.sent.find((m) => m.type === "a2ui");
+    const firstStartedAt = (
+      (firstCard?.payload as { components?: { props?: { startedAt?: number } }[] })
+        ?.components?.[0]?.props ?? {}
+    ).startedAt;
+    handleSessionEvent(f.state, f.deps, rec, "tab-1", {
+      type: "tool_execution_start",
+      toolCallId: "c1",
+      toolName: "bash",
+      args: { command: "bunx vitest run" },
+    });
+
+    const cards = f.sent.filter((m) => m.type === "a2ui");
+    // Same uiId both times — not tool-1-c1 then tool-2-c1.
+    expect(cards.map((m) => m.id)).toEqual(["tool-1-c1", "tool-1-c1"]);
+    expect(rec.toolCardSeq).toBe(1);
+    const replayStartedAt = (
+      (cards.at(-1)?.payload as {
+        components?: { props?: { startedAt?: number } }[];
+      })?.components?.[0]?.props ?? {}
+    ).startedAt;
+    // startedAt is preserved so the frontend clock doesn't jump on replay.
+    expect(replayStartedAt).toBe(firstStartedAt);
+  });
+
   it("cancelRunningToolCards freezes active tool-card timers", () => {
     const f = makeFixture();
     const rec = fakeRec();

--- a/agent/tab-lifecycle/tool-events.ts
+++ b/agent/tab-lifecycle/tool-events.ts
@@ -49,10 +49,19 @@ export function handleToolExecutionStart(
     return;
   }
   const summary = summarizeToolArgs(ev.toolName, ev.args);
-  const startedAt = Date.now();
-  const uiId = `tool-${++rec.toolCardSeq}-${ev.toolCallId}`;
-  const rootPath = currentToolRoot(state, tabId);
+  // pi can re-emit tool_execution_start for the *same* toolCallId without an
+  // intervening tool_execution_end — auto-retry of a wedged turn, codex replay,
+  // etc. handleToolExecutionEnd deletes the cache entry, so a still-cached
+  // toolCallId means this is a replay of an in-flight call: reuse the existing
+  // card id + startedAt instead of minting a fresh card, otherwise the user
+  // sees two "Running" copies of the same long-running command (the original is
+  // orphaned because the single end event only closes the newest uiId).
+  const existing = rec.toolArgsCache.get(ev.toolCallId);
+  const startedAt = existing?.startedAt ?? Date.now();
+  const uiId = existing?.uiId ?? `tool-${++rec.toolCardSeq}-${ev.toolCallId}`;
+  const rootPath = existing?.rootPath ?? currentToolRoot(state, tabId);
   rec.toolArgsCache.set(ev.toolCallId, {
+    ...existing,
     name: ev.toolName,
     summary,
     uiId,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -480,7 +480,6 @@ export default function App() {
   } = useFocus({
     setState,
     stateRef,
-    newShellTabOnOverviewOpen: () => newShellTab(),
   });
 
   const {

--- a/src/hooks/bridgeMessageHandlers/a2ui.test.ts
+++ b/src/hooks/bridgeMessageHandlers/a2ui.test.ts
@@ -191,6 +191,79 @@ describe("handleA2ui", () => {
     );
   });
 
+  it("merges a replayed running tool card by identity even when startedAt drifts", () => {
+    // A re-emitted tool_execution_start (auto-retry / codex replay, or a worker
+    // respawn that lost its uiId cache) arrives with a fresh uiId AND a fresh
+    // startedAt for the same logical call. Both cards are still running (no
+    // endedAt), so they must collapse to ONE card rather than showing two
+    // "Running" copies of the same command.
+    let tab = makeEmptyTab("tab-1", "Tab 1");
+    const { ctx } = buildHandlerFixture({
+      state: { activeTabId: "tab-1", tabs: [tab] },
+    });
+    ctx.updateTab = vi.fn((_tabId, updater) => {
+      tab = updater(tab);
+    });
+    ctx.appendMessage = vi.fn((message: ChatMessage) => {
+      tab = applyAppendByMessageId(tab, message);
+    });
+
+    const firstStart = {
+      components: [
+        {
+          id: "tool-1-call_bash_1-fc_abc",
+          type: "tool-card",
+          props: {
+            toolName: "bash",
+            description: "bunx vitest run",
+            startedAt: 1_000,
+          },
+          children: [],
+        },
+      ],
+    };
+    const replayedStart = {
+      components: [
+        {
+          id: "tool-2-call_bash_1-fc_abc",
+          type: "tool-card",
+          props: {
+            toolName: "bash",
+            description: "bunx vitest run",
+            // Replay minted a new clock — the merge must ignore this drift.
+            startedAt: 5_000,
+          },
+          children: [],
+        },
+      ],
+    };
+
+    handleA2ui(
+      {
+        type: "a2ui",
+        payload: firstStart,
+        id: "tool-1-call_bash_1-fc_abc",
+        tabId: "tab-1",
+      },
+      ctx,
+    );
+    handleA2ui(
+      {
+        type: "a2ui",
+        payload: replayedStart,
+        id: "tool-2-call_bash_1-fc_abc",
+        tabId: "tab-1",
+      },
+      ctx,
+    );
+
+    expect(tab.messages).toHaveLength(1);
+    expect(tab.messages[0]).toMatchObject({
+      id: "tool-2-call_bash_1-fc_abc",
+      a2ui: replayedStart,
+    });
+  });
+
   it("replaces a running task_batch card with a synthetic cancellation by identity", () => {
     let tab = makeEmptyTab("tab-1", "Tab 1");
     const { ctx } = buildHandlerFixture({

--- a/src/hooks/bridgeMessageHandlers/a2ui.ts
+++ b/src/hooks/bridgeMessageHandlers/a2ui.ts
@@ -67,11 +67,22 @@ function componentMatchesToolIdentity(
   component: A2UIComponent | undefined,
   identity: string,
   incomingStartedAt: number | undefined,
+  incomingEndedAt: number | undefined,
 ): boolean {
   if (component?.type !== "tool-card") return false;
   const currentStartedAt = numericProp(component, "startedAt");
   if (currentStartedAt === undefined) return false;
+  // When both the existing card and the incoming one are still running (no
+  // endedAt), a replayed tool_execution_start mints a fresh startedAt for the
+  // same logical call (identity == normalized toolCallId, which is unique per
+  // call). Merge by identity alone in that case so a retry/respawn doesn't
+  // leave two "Running" copies. The strict startedAt match still gates merges
+  // that involve a finished card (e.g. late results onto a cancelled card).
+  const bothRunning =
+    numericProp(component, "endedAt") === undefined &&
+    incomingEndedAt === undefined;
   if (
+    !bothRunning &&
     incomingStartedAt !== undefined &&
     currentStartedAt !== incomingStartedAt
   ) {
@@ -88,13 +99,19 @@ function findCurrentToolCardMatches(
   incomingId: string | undefined,
   identity: string | undefined,
   incomingStartedAt: number | undefined,
+  incomingEndedAt: number | undefined,
 ): Array<{ index: number; component: A2UIComponent }> {
   const matches: Array<{ index: number; component: A2UIComponent }> = [];
   for (let index = 0; index < messages.length; index += 1) {
     const component = (messages[index].a2ui?.components ?? []).find((item) => {
       if (componentMatchesIncomingToolId(item, incomingId ?? "")) return true;
       if (!identity) return false;
-      return componentMatchesToolIdentity(item, identity, incomingStartedAt);
+      return componentMatchesToolIdentity(
+        item,
+        identity,
+        incomingStartedAt,
+        incomingEndedAt,
+      );
     });
     if (component) matches.push({ index, component });
   }
@@ -163,11 +180,13 @@ function upsertToolCardMessage(
 ): { tab: Tab; message: ChatMessage } {
   const incomingId = toolCard.id;
   const incomingStartedAt = numericProp(toolCard, "startedAt");
+  const incomingEndedAt = numericProp(toolCard, "endedAt");
   const matches = findCurrentToolCardMatches(
     current.messages,
     incomingId,
     identity,
     incomingStartedAt,
+    incomingEndedAt,
   );
   if (matches.length > 0) {
     const targetIndex = matches[0].index;

--- a/src/hooks/projectOps/types.ts
+++ b/src/hooks/projectOps/types.ts
@@ -71,8 +71,11 @@ export interface UseProjectOpsContext {
    *  is removed. Workspace deletion is already destructive, so there is
    *  no separate close confirmation for those session tabs. */
   closeTabNow: (tabId: string) => void;
-  /** From useTabs: create an interactive shell sub-tab when the project
-   *  overview is already showing an open terminal panel. */
+  /** From useTabs: create an interactive shell sub-tab. Injected so the
+   *  capability is available, but project/workspace bucket switches must
+   *  NOT auto-invoke it — interactive shells are created only by explicit
+   *  user action (Cmd+T / Cmd+Shift+T / the "+" button). A regression test
+   *  asserts switching buckets never calls this. */
   newShellTab?: () => void;
   /** Notification-backed prompts for destructive workspace removal flows. */
   workspacePrompts: WorkspaceRemovalPrompts;

--- a/src/hooks/useFocus.test.ts
+++ b/src/hooks/useFocus.test.ts
@@ -150,7 +150,7 @@ describe("workstationRows", () => {
   });
 });
 
-describe("toggleTerminal auto-spawn", () => {
+describe("toggleTerminal", () => {
   function useFocusHarness(initial: Record<string, unknown>) {
     let current = initial;
     const ref = <T,>(v: T): MutableRefObject<T> => ({ current: v });
@@ -163,53 +163,50 @@ describe("toggleTerminal auto-spawn", () => {
       current = fn(current);
       stateRef.current = current;
     });
-    const newShellTabOnOverviewOpen = vi.fn();
-    const actions = useFocus({ setState, stateRef, newShellTabOnOverviewOpen });
-    return { actions, setState, newShellTabOnOverviewOpen, get: () => current };
+    const actions = useFocus({ setState, stateRef });
+    return { actions, setState, get: () => current };
   }
 
-  it("auto-spawns a shell when opening the terminal on overview with no shells", () => {
-    const { actions, newShellTabOnOverviewOpen, get } = useFocusHarness({
+  // Opening the console panel must surface the read-only agent-bash stream /
+  // empty-state placeholder — never auto-spawn an interactive shell. The shell
+  // list is owned solely by explicit user actions (Cmd+T / Cmd+Shift+T / +).
+  it("opens the panel on overview with no shells without creating a shell", () => {
+    const { actions, get } = useFocusHarness({
       activeTabId: OVERVIEW_TAB_ID,
       tabs: [],
       terminal: { open: false },
       layout: {},
     });
     actions.toggleTerminal();
-    expect(newShellTabOnOverviewOpen).toHaveBeenCalledTimes(1);
     expect((get().terminal as { open: boolean }).open).toBe(true);
+    expect(get().tabs).toEqual([]);
+    expect((get().tabs as { kind?: string }[]).some((t) => t.kind === "shell")).toBe(
+      false,
+    );
   });
 
-  it("does NOT auto-spawn when the terminal is closing", () => {
-    const { actions, newShellTabOnOverviewOpen } = useFocusHarness({
+  it("never adds a shell tab when an agent session owns the canvas", () => {
+    const agentTab = makeEmptyTab("agent-1", "Tab 1");
+    const { actions, get } = useFocusHarness({
+      activeTabId: "agent-1",
+      tabs: [agentTab],
+      terminal: { open: false },
+      layout: {},
+    });
+    actions.toggleTerminal();
+    expect((get().terminal as { open: boolean }).open).toBe(true);
+    expect(get().tabs).toEqual([agentTab]);
+  });
+
+  it("toggles the panel closed when already open", () => {
+    const { actions, get } = useFocusHarness({
       activeTabId: OVERVIEW_TAB_ID,
       tabs: [],
       terminal: { open: true },
       layout: {},
     });
     actions.toggleTerminal();
-    expect(newShellTabOnOverviewOpen).not.toHaveBeenCalled();
-  });
-
-  it("does NOT auto-spawn when a shell already exists", () => {
-    const { actions, newShellTabOnOverviewOpen } = useFocusHarness({
-      activeTabId: OVERVIEW_TAB_ID,
-      tabs: [makeEmptyTab("sh-1", "Shell 1", null, "shell")],
-      terminal: { open: false },
-      layout: {},
-    });
-    actions.toggleTerminal();
-    expect(newShellTabOnOverviewOpen).not.toHaveBeenCalled();
-  });
-
-  it("does NOT auto-spawn when an agent session owns the canvas", () => {
-    const { actions, newShellTabOnOverviewOpen } = useFocusHarness({
-      activeTabId: "agent-1",
-      tabs: [makeEmptyTab("agent-1", "Tab 1")],
-      terminal: { open: false },
-      layout: {},
-    });
-    actions.toggleTerminal();
-    expect(newShellTabOnOverviewOpen).not.toHaveBeenCalled();
+    expect((get().terminal as { open: boolean }).open).toBe(false);
+    expect(get().tabs).toEqual([]);
   });
 });

--- a/src/hooks/useFocus.ts
+++ b/src/hooks/useFocus.ts
@@ -1,17 +1,10 @@
 import type { Dispatch, MutableRefObject, SetStateAction } from "react";
-import { isOverviewActive, type Tab } from "../types/tab";
+import type { Tab } from "../types/tab";
 import { focusTerminalPanel, isFocusInTerminalPanel } from "../utils/focus";
 
 export interface UseFocusContext {
   setState: Dispatch<SetStateAction<Record<string, unknown>>>;
   stateRef: MutableRefObject<Record<string, unknown>>;
-  /** Optional: invoked when the user opens the terminal panel on the
-   *  overview pseudo-tab and no interactive shell tabs exist yet.
-   *  Lets the panel land in a real shell instead of the empty-state
-   *  placeholder. Closing every shell afterwards does NOT re-trigger
-   *  the auto-spawn — the user explicitly closed them, so respect that
-   *  until the next deliberate open. */
-  newShellTabOnOverviewOpen?: () => void;
 }
 
 export interface UseFocusActions {
@@ -169,11 +162,13 @@ export function workstationRows(
  * shifting the call site.
  */
 export function useFocus(ctx: UseFocusContext): UseFocusActions {
-  const { setState, stateRef, newShellTabOnOverviewOpen } = ctx;
+  const { setState, stateRef } = ctx;
 
   function toggleTerminal() {
-    const prev = stateRef.current;
-    const wasOpen = !!(prev.terminal as { open?: boolean } | undefined)?.open;
+    // Toggling the console panel only flips visibility. It must never spawn a
+    // shell — the panel defaults to the read-only agent-bash stream (or the
+    // empty-state placeholder), and interactive shells are created solely by
+    // explicit user actions (Cmd+T / Cmd+Shift+T / the "+" button).
     setState((p) => {
       const term = (p.terminal as { open?: boolean; output?: string }) ?? {};
       const nextOpen = !term.open;
@@ -188,17 +183,6 @@ export function useFocus(ctx: UseFocusContext): UseFocusActions {
         },
       };
     });
-    // Closed → open transition on the overview with no interactive
-    // shells: hand off to the auto-spawn so the user lands in a real
-    // shell instead of the panel's empty placeholder.
-    if (!wasOpen && newShellTabOnOverviewOpen) {
-      const overview = isOverviewActive(prev.activeTabId as string | undefined);
-      const tabs = (prev.tabs as Tab[] | undefined) ?? [];
-      const hasShell = tabs.some((t) => t.kind === "shell");
-      if (overview && !hasShell) {
-        newShellTabOnOverviewOpen();
-      }
-    }
   }
 
   function focusComposer() {

--- a/src/hooks/useProjectOps.test.ts
+++ b/src/hooks/useProjectOps.test.ts
@@ -734,7 +734,12 @@ describe("useProjectOps overview terminal project switches", () => {
     expect(newShellTab).not.toHaveBeenCalled();
   });
 
-  it("spawns an overview shell when switching into an empty project bucket with the terminal open", () => {
+  it("does NOT spawn a shell when switching into an empty project bucket with the terminal open", () => {
+    // Regression: switching workspace/project buckets must never auto-spawn an
+    // interactive shell. Dispatching agents from GitHub issues churns bucket
+    // switches; each one used to leave a stuck "Shell N starting" tab the user
+    // never asked for. Opening the panel surfaces the read-only agent-bash
+    // stream (or the empty-state placeholder) — not a new PTY.
     const newShellTab = vi.fn();
     const { result, stateRef } = renderProjectOps(twoProjectState(), {
       newShellTab,
@@ -752,7 +757,7 @@ describe("useProjectOps overview terminal project switches", () => {
 
     expect(stateRef.current.activeTabId).toBeUndefined();
     expect(stateRef.current.tabs).toEqual([]);
-    expect(newShellTab).toHaveBeenCalledTimes(1);
+    expect(newShellTab).not.toHaveBeenCalled();
   });
 
   it("does not spawn another shell when the destination bucket already has one", () => {

--- a/src/hooks/useProjectOps.ts
+++ b/src/hooks/useProjectOps.ts
@@ -81,7 +81,6 @@ export function useProjectOps(ctx: UseProjectOpsContext): UseProjectOpsActions {
     dispatchTerminalReplay,
     autoRestoreDiscoveredSessions,
     closeTabNow,
-    newShellTab,
     workspacePrompts,
   } = ctx;
 
@@ -127,20 +126,10 @@ export function useProjectOps(ctx: UseProjectOpsContext): UseProjectOpsActions {
       toKey,
       opts,
     );
-    maybeSpawnOverviewShell();
+    // Switching buckets must not auto-spawn a shell — interactive shells are
+    // created only by explicit user action. The panel falls back to the
+    // read-only agent-bash stream / empty-state placeholder otherwise.
     return nextTabId;
-  }
-
-  function maybeSpawnOverviewShell(): void {
-    if (!newShellTab) return;
-    const state = stateRef.current;
-    const terminal = state.terminal as { open?: boolean } | undefined;
-    if (terminal?.open !== true) return;
-    const activeTabId = state.activeTabId as string | undefined;
-    if (!isOverviewActive(activeTabId)) return;
-    const tabs = (state.tabs as Tab[] | undefined) ?? [];
-    if (tabs.some((t) => t.kind === "shell")) return;
-    newShellTab();
   }
 
   async function openProjectFromPicker(): Promise<string | null> {


### PR DESCRIPTION
## Summary

Three defects observed in a **release build** while dispatching agents from GitHub issues across many workspaces. Root-caused by inspecting the running instance (logs + process table) plus source, then fixed TDD.

### 1. Duplicate "Running" tool-call cards (`fix(toolcards)`)
The same long-running `bash` command rendered as **two cards, both "Running"** at once, though it ran once. Reads rendered once.

- **Root cause:** pi re-emits `tool_execution_start` for the *same* `toolCallId` without an intervening end on auto-retry / codex replay of a wedged turn. `handleToolExecutionStart` minted a fresh `uiId` + `startedAt` on every start, and the frontend merge (`componentMatchesToolIdentity`) required an *identical* `startedAt` — so the replay produced a second, un-mergeable card while the original was orphaned (the single `tool_execution_end` only closes the newest `uiId`). Reads survive because they finish before any retry. Confirmed via the bridge log: the worker tab got **exactly one** prompt dispatch, ruling out double-dispatch.
- **Fix:**
  - Agent (`agent/tab-lifecycle/tool-events.ts`): `handleToolExecutionStart` reuses the cached `uiId`/`startedAt` when the `toolCallId` is still in `toolArgsCache`. `tool_execution_end` deletes the entry, so a genuinely new call after completion still gets a fresh card (existing "distinct cards for repeated SDK ids" behavior preserved).
  - Frontend (`src/hooks/bridgeMessageHandlers/a2ui.ts`): `componentMatchesToolIdentity` merges same-identity cards that are **both still running** (no `endedAt`), ignoring `startedAt` drift. Strict `startedAt` matching still gates merges involving a finished/cancelled card.

### 2. Auto-spawned / stuck "Shell N starting" (`fix(terminal)`)
Opening the console panel (or switching project/workspace buckets) on the overview with no shells silently spawned an interactive PTY the user never created; with many dispatched workspaces, each bucket switch left a stuck `Shell N starting` tab (cold `nix-direnv` keeps `shellState` at `starting`).

- **Root cause:** two auto-spawn paths — `useFocus.toggleTerminal` → `newShellTabOnOverviewOpen`, and `useProjectOps.switchProjectBucket` → `maybeSpawnOverviewShell`.
- **Fix:** removed both. The panel now defaults to the read-only `agent-bash` stream / empty-state placeholder; interactive shells are created only by explicit user action (`Cmd+T` / `Cmd+Shift+T` / `+`). `newShellTab` remains an injected capability, guarded by a regression test asserting bucket switches never call it.

### 3. Test-polluted bridge log (`fix(logger)`)
The agent runs `bunx vitest` via its own bash tool, which loads the bridge logger; the file sink wrote to the real `~/.aethon/logs/bridge.<date>.log`, flooding it with test fixtures (`tabId=tab-1`, `/proj`, ...).

- **Fix:** disable the rotating-file sink when `VITEST` is set (stderr still flows), unless an explicit `AETHON_LOG_DIR` override is given (which also relocates the dir).

## Tests (TDD — red first, then green)
- `agent/tab-lifecycle.test.ts`: a replayed in-flight `tool_execution_start` reuses the card id (`toolCardSeq` bumped once, `startedAt` preserved).
- `src/hooks/bridgeMessageHandlers/a2ui.test.ts`: a running card with drifted `startedAt` merges by identity.
- `src/hooks/useFocus.test.ts`: toggling the panel never creates a shell tab.
- `src/hooks/useProjectOps.test.ts`: switching into an empty bucket with the terminal open never calls `newShellTab` (verified RED against pre-fix source).
- `agent/logger.test.ts`: file sink disabled under VITEST; `AETHON_LOG_DIR` override writes there.

## Validation
- `bunx tsc -b --noEmit` ✓
- `bun run lint` (ESLint, 0 warnings) ✓
- `bunx vitest run` — **345 files / 2874 tests** ✓
- No Rust changed (clippy / cargo test not run).
- `codex review --base origin/main`: clean — _"The changes are covered by focused tests and the reviewed logic does not appear to introduce regressions. Relevant TypeScript and targeted Vitest suites pass."_

## Note
Requires a fresh build to observe — the running release `.app` predates these commits.
