### PR TITLE
feat(state): persist app state in sqlite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -424,13 +424,16 @@ via `src/workspaces.ts` (Rust commands in `commands/git/`); the active
 workspace is mirrored to `/activeWorkspaceId` so the file tree and new tabs
 follow the sidebar selection.
 
-Pi sessions are scoped to a working directory. `src/projects.ts` persists
-the project list at `~/.aethon/projects.json` (max 16, MRU-ordered,
-schemaVersion 5; older schemas — including v4's `activeWorktreeId` /
-`worktreesByProject` spellings — migrate on read). The active project's
-path is passed as `cwd` on `tab_open`. **Existing tabs keep the cwd they
-were created with** — switching the active project only affects new tabs.
-When updating tab/session code, treat the per-tab cwd as immutable.
+Pi sessions are scoped to a working directory, but Aethon's application
+state is SQLite-backed. `src/projects.ts` still reads/writes the logical
+`projects.json` state key for compatibility, but `read_state` / `write_state`
+persist that key in `~/.aethon/state/aethon.sqlite3`; generated per-project
+data lives under `~/.aethon/projects/<projectId>/`. Older project schemas —
+including v4's `activeWorktreeId` / `worktreesByProject` spellings — migrate
+on read. The active project's path is passed as `cwd` on `tab_open`.
+**Existing tabs keep the cwd they were created with** — switching the active
+project only affects new tabs. When updating tab/session code, treat the
+per-tab cwd as immutable.
 
 The sidebar tree is **host → project → workspace**
 (`src/extensions/default-layout/sidebar/`). Tabs bucket per workspace
@@ -460,8 +463,8 @@ to the OS trash via the `trash` crate, never `unlink`.
 ### Window state persistence
 
 `src-tauri/src/window_state/` saves window position, size, and
-`maximized` flag to `~/.aethon/window-state.json` (keyed by window
-label). Everything is stored in **logical** units — physical pixels
+`maximized` flag through the SQLite-backed `window-state.json` state key
+(keyed by window label). Everything is stored in **logical** units — physical pixels
 aren't portable across monitors with different scale factors, so a
 window saved on Retina (2×) would render at the wrong size when
 restored to a 1× monitor.
@@ -548,9 +551,11 @@ The Tauri shell sets these env vars when spawning the bridge (`agent/main.ts`):
 | Env var                             | Purpose                                                                                                                                                                                                                                                      |
 | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `AETHON_DOCS_DIR`                   | Bundled docs dir (`docs/aethon-agent/` in dev, `<resource_dir>/docs/aethon-agent/` in release). Contains `README.md`, `api.md`, `components.md`, `extensions.md`. The system prompt points the model at these for the authoritative API/component reference. |
-| `AETHON_USER_DIR`                   | `~/.aethon/` — user extensions, sessions, state file.                                                                                                                                                                                                        |
-| `AETHON_STATE_FILE`                 | `~/.aethon/state.json` — JSON snapshot of loaded extensions, themes, custom components, layout summary, and tab list. Rewritten (debounced 200 ms) on every registration.                                                                                    |
-| `AETHON_SESSIONS_DIR`               | `~/.aethon/sessions/<tabId>/` per tab. Each tab uses `SessionManager.continueRecent` so pi context survives bun restarts.                                                                                                                                    |
+| `AETHON_USER_DIR`                   | `~/.aethon/` — user extensions, config, logs, and the SQLite-backed app state directory.                                                                                                                                                                      |
+| `AETHON_DB_FILE`                    | `~/.aethon/state/aethon.sqlite3` — canonical Aethon app state, projects, sessions, search index, and small managed state slices.                                                                                                                             |
+| `AETHON_PROJECTS_DIR`               | `~/.aethon/projects/` — stable per-project generated data directories keyed by project id.                                                                                                                                                                    |
+| `AETHON_STATE_FILE`                 | `~/.aethon/state.json` — compatibility/debug JSON snapshot of loaded extensions, themes, custom components, layout summary, and tab list. Rewritten (debounced 200 ms) on every registration.                                                               |
+| `AETHON_SESSIONS_DIR`               | Legacy Aethon session-import location. New Aethon session state is SQLite-backed; pi still writes sidecar transcripts to pi's default session location for later pi pickup and analytics.                                                                    |
 | `AETHON_RELEASE_MODE`               | `"1"` in release, `"0"` in dev. The system prompt branches on this to (a) avoid telling the model to read source files that aren't there, (b) point at `~/.aethon/extensions/` for new extensions instead.                                                   |
 | `AETHON_PROJECT_ROOT`               | Source tree path (dev only). Lets the model reference `agent/main.ts` etc. by absolute path during dev work.                                                                                                                                                 |
 | `AETHON_PROVIDER_TIMEOUT_SECONDS`   | Optional Aethon-owned provider/SDK request timeout override from `[agent] provider_timeout_seconds`; omitted leaves pi's provider retry settings unchanged.                                                                                                  |

--- a/agent/active-project-cwd.ts
+++ b/agent/active-project-cwd.ts
@@ -1,5 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
+import { readSqliteStateValue } from "./session-sqlite";
 
 interface PersistedProject {
   id?: unknown;
@@ -71,6 +72,10 @@ export function activeProjectCwdFromJson(text: string): string | undefined {
 export async function readActiveProjectCwd(
   userDir: string,
 ): Promise<string | undefined> {
+  const sqliteProjects = readSqliteStateValue("projects.json");
+  if (sqliteProjects !== undefined) {
+    return activeProjectCwdFromJson(sqliteProjects);
+  }
   try {
     return activeProjectCwdFromJson(
       await readFile(join(userDir, "projects.json"), "utf8"),

--- a/agent/extension-loader/discovery.ts
+++ b/agent/extension-loader/discovery.ts
@@ -12,6 +12,10 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { logger } from "../logger";
 import { latestSessionLog, readSessionMetadata } from "../session-history";
+import {
+  importLegacySessionsDir,
+  listSqliteDiscoveredTabs,
+} from "../session-sqlite";
 import type {
   AethonAgentState,
   DiscoveredTab,
@@ -65,6 +69,9 @@ export async function discoverPiAethonExtensions(
 export async function discoverPersistedTabs(
   state: AethonAgentState,
 ): Promise<DiscoveredTab[]> {
+  importLegacySessionsDir(state.sessionsDir);
+  const sqliteTabs = listSqliteDiscoveredTabs();
+  if (sqliteTabs && sqliteTabs.length > 0) return sqliteTabs;
   let entries: string[];
   try {
     entries = await readdir(state.sessionsDir);
@@ -96,6 +103,9 @@ export async function discoverPersistedTabs(
 export async function refreshPersistedTabs(
   state: AethonAgentState,
 ): Promise<DiscoveredTab[]> {
+  importLegacySessionsDir(state.sessionsDir);
+  const sqliteTabs = listSqliteDiscoveredTabs();
+  if (sqliteTabs && sqliteTabs.length > 0) return sqliteTabs;
   let entries: string[];
   try {
     entries = await readdir(state.sessionsDir);

--- a/agent/main.ts
+++ b/agent/main.ts
@@ -109,6 +109,8 @@ async function main(): Promise<void> {
   const userDir = process.env.AETHON_USER_DIR ?? join(homedir(), ".aethon");
   const stateFile =
     process.env.AETHON_STATE_FILE ?? join(userDir, "state.json");
+  const dbFile = process.env.AETHON_DB_FILE ?? join(userDir, "state", "aethon.sqlite3");
+  const projectsDir = process.env.AETHON_PROJECTS_DIR ?? join(userDir, "projects");
   const sessionsDir =
     process.env.AETHON_SESSIONS_DIR ?? join(userDir, "sessions");
   const docsDir = process.env.AETHON_DOCS_DIR;
@@ -134,6 +136,8 @@ async function main(): Promise<void> {
   const state = new AethonAgentState({
     userDir,
     stateFile,
+    dbFile,
+    projectsDir,
     sessionsDir,
     docsDir,
     projectRoot,

--- a/agent/memory/resolver.ts
+++ b/agent/memory/resolver.ts
@@ -5,6 +5,7 @@ import { basename, dirname, join, resolve, sep } from "node:path";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import type { ProjectMemoryIdentity, ResolvedMemoryContext, ResolvedMemoryScope } from "./types";
+import { readSqliteStateValue } from "../session-sqlite";
 
 interface PersistedProject {
   id?: unknown;
@@ -159,6 +160,8 @@ export function projectIdentityFromProjectsJson(
 }
 
 async function defaultReadProjectsJson(userDir: string): Promise<string | undefined> {
+  const sqliteProjects = readSqliteStateValue("projects.json");
+  if (sqliteProjects !== undefined) return sqliteProjects;
   try {
     return await readFile(join(userDir, "projects.json"), "utf8");
   } catch {

--- a/agent/session-branch.test.ts
+++ b/agent/session-branch.test.ts
@@ -4,12 +4,21 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const ensureTabMock = vi.hoisted(() => vi.fn());
+const forkSqliteSessionMock = vi.hoisted(() => vi.fn(() => true));
 
 vi.mock("./tab-lifecycle", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./tab-lifecycle")>();
   return {
     ...actual,
     ensureTab: ensureTabMock,
+  };
+});
+
+vi.mock("./session-sqlite", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./session-sqlite")>();
+  return {
+    ...actual,
+    forkSqliteSession: forkSqliteSessionMock,
   };
 });
 
@@ -86,6 +95,8 @@ function msg(extra: Partial<InboundMessage>): InboundMessage {
 beforeEach(() => {
   sessionsDir = mkdtempSync(join(tmpdir(), "aethon-branch-"));
   ensureTabMock.mockReset();
+  forkSqliteSessionMock.mockReset();
+  forkSqliteSessionMock.mockReturnValue(true);
 });
 
 afterEach(() => {
@@ -194,16 +205,29 @@ describe("handleForkSession", () => {
     expect(forked).toBeTruthy();
     expect(typeof forked?.newTabId).toBe("string");
     expect((forked?.newTabId as string).length).toBeGreaterThan(0);
-    expect(forked?.sourcePath).toBe(join(sessionsDir, "t1", "branch.jsonl"));
+    expect(forked).not.toHaveProperty("sourcePath");
     expect(forked?.label).toMatch(/^Fork of /);
     expect(forked?.cwd).toBe("/proj");
   });
 
-  it("errors when the session is in-memory (no branched path)", async () => {
+  it("emits a fork event even when pi does not produce a sidecar path", async () => {
     const { state } = makeState({ branchedPath: undefined });
     const { deps, sent } = makeDeps();
     await handleForkSession(state, deps, msg({ tabId: "t1", entryId: "e2" }));
-    expect(sent.some((m) => m.type === "error")).toBe(true);
+    expect(sent.some((m) => m.type === "error")).toBe(false);
+    expect(sent.some((m) => m.type === "session_forked")).toBe(true);
+  });
+
+  it("does not emit session_forked when sqlite state copy fails", async () => {
+    forkSqliteSessionMock.mockReturnValue(false);
+    const { state } = makeState();
+    const { deps, sent } = makeDeps();
+    await handleForkSession(state, deps, msg({ tabId: "t1", entryId: "e2" }));
+    expect(sent).toContainEqual({
+      type: "error",
+      tabId: "t1",
+      message: "fork_session: failed to copy session state",
+    });
     expect(sent.some((m) => m.type === "session_forked")).toBe(false);
   });
 

--- a/agent/session-branch.ts
+++ b/agent/session-branch.ts
@@ -6,14 +6,12 @@
  *    earlier message. Non-destructive — the abandoned path stays in the file,
  *    so a later restore still sees it; we just realign the Aethon-local chat
  *    so it doesn't resurrect post-rollback rows.
- *  - fork: `createBranchedSession(entryId)` extracts the path root→entry into a
- *    fresh jsonl (in the source tab's dir) *without* disturbing the source
- *    session. The frontend then moves that file into a new tab's dir (via the
- *    `copy_session_file` Rust command) and opens the tab.
+ *  - fork: SQLite copies the path root→entry into a new Aethon session.
+ *    Pi still receives a sidecar branch file in its default session location,
+ *    but Aethon does not read or copy that file.
  */
 
 import { randomUUID } from "node:crypto";
-import { mkdirSync } from "node:fs";
 import type { AethonAgentState, TabRecord } from "./state";
 import type { DispatcherDeps, InboundMessage } from "./dispatcherTypes";
 import { ensureTab, tabSessionDir } from "./tab-lifecycle";
@@ -22,6 +20,7 @@ import {
   truncateLocalChatAfterEntry,
   writeSessionLabel,
 } from "./session-history";
+import { forkSqliteSession } from "./session-sqlite";
 
 function stringField(value: unknown): string {
   return typeof value === "string" ? value : "";
@@ -183,9 +182,8 @@ export async function handleForkSession(
     });
     return;
   }
-  let sourcePath: string | undefined;
   try {
-    sourcePath = sm.createBranchedSession(entryId);
+    sm.createBranchedSession(entryId);
   } catch (err) {
     deps.send({
       type: "error",
@@ -194,27 +192,22 @@ export async function handleForkSession(
     });
     return;
   }
-  if (!sourcePath) {
-    deps.send({
-      type: "error",
-      tabId,
-      message: "fork_session: cannot fork an in-memory session",
-    });
-    return;
-  }
   const newTabId = randomUUID();
-  const newDir = tabSessionDir(state, newTabId);
-  try {
-    mkdirSync(newDir, { recursive: true });
-  } catch {
-    /* the Rust copy command also creates it */
-  }
   const srcLabel = await readSessionLabel(tabSessionDir(state, tabId)).catch(
     () => undefined,
   );
   const label = forkLabel(srcLabel);
   const cwd =
     state.tabProjectCwds.get(tabId) ?? mirroredTabCwd(state, tabId) ?? cwdHint;
+  const newDir = tabSessionDir(state, newTabId);
+  if (!forkSqliteSession(tabId, newTabId, entryId, label, cwd)) {
+    deps.send({
+      type: "error",
+      tabId,
+      message: "fork_session: failed to copy session state",
+    });
+    return;
+  }
   await writeSessionLabel(newDir, label, {
     ...(cwd ? { cwd } : {}),
   }).catch(() => {
@@ -224,7 +217,6 @@ export async function handleForkSession(
     type: "session_forked",
     tabId,
     newTabId,
-    sourcePath,
     label,
     ...(cwd ? { cwd } : {}),
   });

--- a/agent/session-history/io.ts
+++ b/agent/session-history/io.ts
@@ -19,6 +19,13 @@ import {
   writeFile,
 } from "node:fs/promises";
 import { join } from "node:path";
+import {
+  appendSqliteLocalChatMessage,
+  readSqliteSessionLabel,
+  sessionTabIdFromDir,
+  truncateSqliteLocalChatAfter,
+  writeSqliteSessionLabel,
+} from "../session-sqlite";
 import { parseLocalChatLines } from "./parse-local";
 import {
   LABEL_FILE,
@@ -44,6 +51,8 @@ export function normalizeSessionLabel(label: string): string {
 export async function readSessionLabel(
   sessionDir: string,
 ): Promise<string | undefined> {
+  const sqliteLabel = readSqliteSessionLabel(sessionTabIdFromDir(sessionDir));
+  if (sqliteLabel !== undefined) return sqliteLabel;
   try {
     const text = await readFile(join(sessionDir, LABEL_FILE), "utf8");
     const trimmed = text.trim();
@@ -88,6 +97,15 @@ export async function writeSessionLabel(
   label: string,
   metadata: SessionLabelMetadata = {},
 ): Promise<void> {
+  if (
+    writeSqliteSessionLabel(
+      sessionTabIdFromDir(sessionDir),
+      label,
+      metadata.cwd,
+    )
+  ) {
+    return;
+  }
   await mkdir(sessionDir, { recursive: true });
   const trimmed = normalizeSessionLabel(label);
   const path = join(sessionDir, LABEL_FILE);
@@ -111,6 +129,9 @@ export async function appendLocalChatMessage(
   sessionDir: string,
   message: RestoredChatMessage,
 ): Promise<void> {
+  if (appendSqliteLocalChatMessage(sessionTabIdFromDir(sessionDir), message)) {
+    return;
+  }
   if (!isChatRole(message.role)) return;
   const text = typeof message.text === "string" ? trimText(message.text) : "";
   const thinking =
@@ -200,6 +221,9 @@ export async function truncateLocalChatAfterEntry(
   sessionDir: string,
   cutoffMs: number,
 ): Promise<void> {
+  if (truncateSqliteLocalChatAfter(sessionTabIdFromDir(sessionDir), cutoffMs)) {
+    return;
+  }
   const path = join(sessionDir, LOCAL_CHAT_FILE);
   try {
     const raw = await readFile(path, "utf8");

--- a/agent/session-history/metadata.ts
+++ b/agent/session-history/metadata.ts
@@ -10,6 +10,11 @@
 
 import { readdir, readFile, stat } from "node:fs/promises";
 import { join } from "node:path";
+import {
+  importLegacySessionDir,
+  readSqliteSessionMetadata,
+  sessionTabIdFromDir,
+} from "../session-sqlite";
 import { readSessionLabel } from "./io";
 import {
   LOCAL_CHAT_FILE,
@@ -101,6 +106,9 @@ export async function latestSessionLog(
 export async function readSessionMetadata(
   sessionDir: string,
 ): Promise<SessionLogMetadata | null> {
+  importLegacySessionDir(sessionDir);
+  const sqliteMeta = readSqliteSessionMetadata(sessionTabIdFromDir(sessionDir));
+  if (sqliteMeta) return sqliteMeta;
   const latest = await latestSessionLog(sessionDir);
   if (!latest) return null;
 

--- a/agent/session-history/restore.ts
+++ b/agent/session-history/restore.ts
@@ -15,6 +15,11 @@
  */
 
 import { readFile } from "node:fs/promises";
+import {
+  importLegacySessionDir,
+  readSqliteSessionStreams,
+  sessionTabIdFromDir,
+} from "../session-sqlite";
 import { latestSessionLog } from "./metadata";
 import { findSessionFileMatchingCwd } from "./lookup";
 import { readLocalChatTranscript } from "./parse-local";
@@ -482,6 +487,37 @@ export async function readSessionTranscript(
   sessionDir: string,
   expectedCwd?: string,
 ): Promise<RestoredChatMessage[]> {
+  importLegacySessionDir(sessionDir);
+  const sqliteTranscript = readSqliteSessionStreams(
+    sessionTabIdFromDir(sessionDir),
+    expectedCwd,
+  );
+  if (
+    sqliteTranscript &&
+    (sqliteTranscript.piMessages.length > 0 ||
+      sqliteTranscript.localMessages.length > 0)
+  ) {
+    const piMessages = removePiToolCardsCoveredByLocalCancellation(
+      sqliteTranscript.piMessages,
+      sqliteTranscript.localMessages,
+    );
+    const piMessagesWithLocalFileChanges = mergeLocalFileChangesIntoPiMessages(
+      piMessages,
+      sqliteTranscript.localMessages,
+    );
+    const mergedPiMessages = mergeLocalAttachmentsIntoPiMessages(
+      piMessagesWithLocalFileChanges,
+      sqliteTranscript.localMessages,
+    );
+    const localOnly = dedupeLocalMessages(
+      mergedPiMessages,
+      sqliteTranscript.localMessages,
+    );
+    return mergeRestoredMessagesChronologically(
+      mergedPiMessages,
+      localOnly,
+    ).slice(-MAX_RESTORED_MESSAGES);
+  }
   // When `expectedCwd` is provided, only restore from a session whose
   // header cwd matches — the shared `default` tab dir collects sessions
   // from every project the user worked in, and the latest by mtime can

--- a/agent/session-sqlite.ts
+++ b/agent/session-sqlite.ts
@@ -1,0 +1,862 @@
+/**
+ * SQLite source of truth for Aethon sessions.
+ *
+ * Pi still receives a normal default-location session file as a sidecar. We
+ * hydrate that sidecar from SQLite and wrap append/branch methods so Aethon
+ * never needs to read pi JSONL files for restore/search/application state.
+ */
+
+import { createRequire } from "node:module";
+import {
+  existsSync,
+  readdirSync,
+  realpathSync,
+  readFileSync,
+  statSync,
+} from "node:fs";
+import { basename, join } from "node:path";
+import {
+  CURRENT_SESSION_VERSION,
+  type FileEntry,
+  type SessionEntry,
+  type SessionHeader,
+  type SessionManager,
+  type SessionTreeNode,
+} from "@mariozechner/pi-coding-agent";
+import type { Message } from "@mariozechner/pi-ai";
+import {
+  MAX_CUSTOM_LABEL_CHARS,
+  MAX_LABEL_CHARS,
+  MAX_LOCAL_CHAT_MESSAGES,
+  LOCAL_CHAT_FILE,
+  type RestoredChatMessage,
+  type SessionLogMetadata,
+  hasA2ui,
+  isChatRole,
+  normalizeCwd,
+  parseChatAttachments,
+  textFromContent,
+  thinkingFromContent,
+  trimText,
+} from "./session-history/shared";
+import { parseLocalChatLines } from "./session-history/parse-local";
+
+type DatabaseCtor = new (path: string) => Database;
+interface Database {
+  exec(sql: string): void;
+  query(sql: string): {
+    get(...params: unknown[]): Record<string, unknown> | null;
+    all(...params: unknown[]): Array<Record<string, unknown>>;
+    run(...params: unknown[]): unknown;
+  };
+  close(): void;
+}
+
+const require = createRequire(import.meta.url);
+let databaseCtor: DatabaseCtor | undefined;
+const cwdComparisonCache = new Map<string, string>();
+
+function sqliteDatabaseCtor(): DatabaseCtor | undefined {
+  if (databaseCtor) return databaseCtor;
+  try {
+    const mod = require("bun:sqlite") as { Database?: DatabaseCtor };
+    databaseCtor = mod.Database;
+    return databaseCtor;
+  } catch {
+    return undefined;
+  }
+}
+
+function dbPath(): string | undefined {
+  const path = process.env.AETHON_DB_FILE;
+  return typeof path === "string" && path.length > 0 ? path : undefined;
+}
+
+function openDb(): Database | undefined {
+  const path = dbPath();
+  const Ctor = sqliteDatabaseCtor();
+  if (!path || !Ctor) return undefined;
+  const db = new Ctor(path);
+  db.exec(`
+    PRAGMA journal_mode = WAL;
+    PRAGMA foreign_keys = ON;
+    PRAGMA busy_timeout = 5000;
+    CREATE TABLE IF NOT EXISTS kv_store (
+      namespace TEXT NOT NULL,
+      key TEXT NOT NULL,
+      value TEXT NOT NULL,
+      updated_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
+      PRIMARY KEY (namespace, key)
+    );
+    CREATE TABLE IF NOT EXISTS session_tabs (
+      tab_id TEXT PRIMARY KEY,
+      cwd TEXT,
+      custom_label TEXT,
+      label_cwd TEXT,
+      first_user_message TEXT,
+      last_modified INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
+      metadata_json TEXT NOT NULL DEFAULT '{}'
+    );
+    CREATE TABLE IF NOT EXISTS sessions (
+      session_id TEXT PRIMARY KEY,
+      tab_id TEXT NOT NULL,
+      cwd TEXT,
+      current_leaf_entry_id TEXT,
+      payload_json TEXT NOT NULL DEFAULT '{}',
+      created_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
+      updated_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000)
+    );
+    CREATE TABLE IF NOT EXISTS session_entries (
+      session_id TEXT NOT NULL,
+      entry_id TEXT NOT NULL,
+      parent_entry_id TEXT,
+      entry_type TEXT NOT NULL,
+      role TEXT,
+      text TEXT,
+      timestamp INTEGER,
+      payload_json TEXT NOT NULL,
+      ordinal INTEGER NOT NULL,
+      PRIMARY KEY (session_id, entry_id)
+    );
+    CREATE TABLE IF NOT EXISTS session_local_messages (
+      tab_id TEXT NOT NULL,
+      message_id TEXT NOT NULL,
+      role TEXT NOT NULL,
+      text TEXT,
+      thinking TEXT,
+      created_at INTEGER,
+      cwd TEXT,
+      payload_json TEXT NOT NULL,
+      PRIMARY KEY (tab_id, message_id)
+    );
+    CREATE VIRTUAL TABLE IF NOT EXISTS session_search_fts USING fts5(
+      tab_id UNINDEXED,
+      role UNINDEXED,
+      text,
+      timestamp UNINDEXED,
+      source UNINDEXED
+    );
+  `);
+  return db;
+}
+
+function nowMs(): number {
+  return Date.now();
+}
+
+function parseTime(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Date.parse(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+}
+
+function sessionText(entry: SessionEntry): string {
+  if (entry.type === "message") return textFromContent(entry.message.content);
+  if (entry.type === "custom_message") {
+    return typeof entry.content === "string" ? entry.content : textFromContent(entry.content);
+  }
+  if (entry.type === "compaction" || entry.type === "branch_summary") {
+    return entry.summary;
+  }
+  if (entry.type === "session_info") return entry.name ?? "";
+  return "";
+}
+
+function sessionRole(entry: SessionEntry): string | undefined {
+  if (entry.type !== "message") return undefined;
+  const role = entry.message.role;
+  if (role === "assistant") return "agent";
+  if (role === "user") return "user";
+  if (role === "system") return "system";
+  return typeof role === "string" ? role : undefined;
+}
+
+function rowString(row: Record<string, unknown> | null, key: string): string | undefined {
+  const value = row?.[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function rowNumber(row: Record<string, unknown> | null, key: string): number | undefined {
+  const value = row?.[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function normalizeOptionalCwd(cwd: string | undefined): string | undefined {
+  const normalized = normalizeCwd(cwd);
+  return normalized && normalized.length > 0 ? normalized : undefined;
+}
+
+function sessionMatchesCwd(sessionCwd: string | undefined, expectedCwd: string | undefined): boolean {
+  const expected = canonicalCwdForComparison(expectedCwd);
+  if (expected === undefined) return true;
+  return canonicalCwdForComparison(sessionCwd) === expected;
+}
+
+function canonicalCwdForComparison(cwd: string | undefined): string | undefined {
+  const normalized = normalizeOptionalCwd(cwd);
+  if (!normalized) return undefined;
+  const hit = cwdComparisonCache.get(normalized);
+  if (hit !== undefined) return hit;
+  let out = normalized;
+  try {
+    out = normalizeCwd(realpathSync(normalized)) ?? normalized;
+  } catch {
+    // Deleted workspaces still compare by their stored path.
+  }
+  cwdComparisonCache.set(normalized, out);
+  return out;
+}
+
+function parseSessionLine(line: string): FileEntry | undefined {
+  const trimmed = line.trim();
+  if (!trimmed) return undefined;
+  try {
+    const parsed = JSON.parse(trimmed) as FileEntry;
+    if (!parsed || typeof parsed !== "object") return undefined;
+    return parsed;
+  } catch {
+    return undefined;
+  }
+}
+
+function isSessionHeader(entry: FileEntry | undefined): entry is SessionHeader {
+  return Boolean(entry && entry.type === "session" && typeof entry.id === "string");
+}
+
+function isSessionEntry(entry: FileEntry | undefined): entry is SessionEntry {
+  return Boolean(entry && entry.type !== "session" && typeof entry.id === "string");
+}
+
+function activeSessionEntries(entries: SessionEntry[], currentLeafEntryId?: string): SessionEntry[] {
+  if (!currentLeafEntryId) return entries;
+  const byId = new Map(entries.map((entry) => [entry.id, entry] as const));
+  const path: SessionEntry[] = [];
+  const seen = new Set<string>();
+  let current = byId.get(currentLeafEntryId);
+  while (current && !seen.has(current.id)) {
+    seen.add(current.id);
+    path.unshift(current);
+    current = current.parentId ? byId.get(current.parentId) : undefined;
+  }
+  return path.length > 0 ? path : entries;
+}
+
+function loadSessionRows(db: Database, tabId: string, cwd: string): {
+  header: SessionHeader;
+  entries: SessionEntry[];
+  currentLeafEntryId?: string;
+} {
+  db.query(
+    `INSERT OR IGNORE INTO session_tabs(tab_id, cwd, metadata_json)
+     VALUES (?, ?, '{}')`,
+  ).run(tabId, cwd);
+  let session = db
+    .query(
+      `SELECT session_id, current_leaf_entry_id, payload_json
+       FROM sessions
+       WHERE tab_id = ? AND (cwd = ? OR cwd IS NULL)
+       ORDER BY updated_at DESC
+       LIMIT 1`,
+    )
+    .get(tabId, cwd);
+  if (!session) {
+    const timestamp = new Date().toISOString();
+    const sessionId = crypto.randomUUID();
+    const header: SessionHeader = {
+      type: "session",
+      version: CURRENT_SESSION_VERSION,
+      id: sessionId,
+      timestamp,
+      cwd,
+    };
+    db.query(
+      `INSERT INTO sessions(session_id, tab_id, cwd, payload_json, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run(sessionId, tabId, cwd, JSON.stringify({ header }), nowMs(), nowMs());
+    session = { session_id: sessionId, current_leaf_entry_id: null, payload_json: JSON.stringify({ header }) };
+  }
+  const currentLeafEntryId = rowString(session, "current_leaf_entry_id");
+  const payload = rowString(session, "payload_json");
+  const parsed = payload ? JSON.parse(payload) as { header?: SessionHeader } : {};
+  const header = parsed.header ?? {
+    type: "session",
+    version: CURRENT_SESSION_VERSION,
+    id: rowString(session, "session_id") ?? crypto.randomUUID(),
+    timestamp: new Date().toISOString(),
+    cwd,
+  };
+  const entries = db
+    .query(
+      `SELECT payload_json FROM session_entries
+       WHERE session_id = ?
+       ORDER BY ordinal ASC`,
+    )
+    .all(header.id)
+    .flatMap((row) => {
+      const raw = rowString(row, "payload_json");
+      if (!raw) return [];
+      try {
+        return [JSON.parse(raw) as SessionEntry];
+      } catch {
+        return [];
+      }
+    });
+  return {
+    header,
+    entries: activeSessionEntries(entries, currentLeafEntryId),
+    ...(currentLeafEntryId ? { currentLeafEntryId } : {}),
+  };
+}
+
+function persistEntryAtOrdinal(
+  db: Database,
+  tabId: string,
+  sessionId: string,
+  entry: SessionEntry,
+  ordinal: number,
+  options: { touch?: boolean; touchedAt?: number; index?: boolean } = {},
+): void {
+  const text = sessionText(entry);
+  const role = sessionRole(entry);
+  const timestamp = parseTime(entry.timestamp) ?? nowMs();
+  db.query(
+    `INSERT OR REPLACE INTO session_entries(
+       session_id, entry_id, parent_entry_id, entry_type, role, text, timestamp, payload_json, ordinal
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    sessionId,
+    entry.id,
+    entry.parentId,
+    entry.type,
+    role,
+    text,
+    timestamp,
+    JSON.stringify(entry),
+    ordinal,
+  );
+  if (options.touch !== false) {
+    const touchedAt = options.touchedAt ?? nowMs();
+    db.query(
+      `UPDATE sessions
+       SET current_leaf_entry_id = ?, updated_at = ?
+       WHERE session_id = ?`,
+    ).run(entry.id, touchedAt, sessionId);
+    db.query("UPDATE session_tabs SET last_modified = ? WHERE tab_id = ?").run(touchedAt, tabId);
+  }
+  if (text && options.index !== false) {
+    db.query(
+      "INSERT INTO session_search_fts(tab_id, role, text, timestamp, source) VALUES (?, ?, ?, ?, 'pi')",
+    ).run(tabId, role ?? "", text, timestamp);
+  }
+  if (entry.type === "message" && entry.message.role === "user") {
+    const first = db
+      .query("SELECT first_user_message FROM session_tabs WHERE tab_id = ?")
+      .get(tabId);
+    if (!rowString(first, "first_user_message") && text) {
+      const label = text.length > MAX_LABEL_CHARS ? `${text.slice(0, MAX_LABEL_CHARS - 1)}...` : text;
+      db.query("UPDATE session_tabs SET first_user_message = ? WHERE tab_id = ?").run(label, tabId);
+    }
+  }
+}
+
+function persistEntry(db: Database, tabId: string, sessionId: string, entry: SessionEntry): void {
+  const ordinalRow = db
+    .query("SELECT COALESCE(MAX(ordinal), -1) + 1 AS next FROM session_entries WHERE session_id = ?")
+    .get(sessionId);
+  persistEntryAtOrdinal(db, tabId, sessionId, entry, rowNumber(ordinalRow, "next") ?? 0);
+}
+
+function rebuildSidecar(manager: SessionManager, header: SessionHeader, entries: SessionEntry[]): void {
+  const mutable = manager as unknown as {
+    sessionId: string;
+    cwd: string;
+    fileEntries: FileEntry[];
+    byId: Map<string, SessionEntry>;
+    labelsById: Map<string, string>;
+    labelTimestampsById: Map<string, string>;
+    leafId: string | null;
+    flushed: boolean;
+    _buildIndex: () => void;
+    _rewriteFile: () => void;
+  };
+  mutable.sessionId = header.id;
+  mutable.cwd = header.cwd;
+  mutable.fileEntries = [header, ...entries];
+  mutable._buildIndex();
+  mutable._rewriteFile();
+  mutable.flushed = true;
+}
+
+function importLegacyLocalMessages(db: Database, tabId: string, sessionDir: string): void {
+  const path = join(sessionDir, LOCAL_CHAT_FILE);
+  if (!existsSync(path)) return;
+  const raw = readFileSync(path, "utf8");
+  const messages = parseLocalChatLines(raw.split(/\r?\n/));
+  for (const message of messages) {
+    persistLocalChatMessage(db, tabId, message);
+  }
+  rebuildLocalSearchIndex(db, tabId);
+}
+
+function importLegacySessionFile(db: Database, tabId: string, path: string, mtimeMs: number): void {
+  const lines = readFileSync(path, "utf8").split(/\r?\n/);
+  const header = parseSessionLine(lines[0] ?? "");
+  if (!isSessionHeader(header)) return;
+  const existing = db.query("SELECT 1 FROM sessions WHERE session_id = ?").get(header.id);
+  if (existing) return;
+  const entries = lines.slice(1).flatMap((line) => {
+    const entry = parseSessionLine(line);
+    return isSessionEntry(entry) ? [entry] : [];
+  });
+  const cwd = typeof header.cwd === "string" && header.cwd.length > 0 ? header.cwd : undefined;
+  const createdAt = parseTime(header.timestamp) ?? mtimeMs;
+  const lastEntry = entries[entries.length - 1];
+  db.query(
+    `INSERT INTO session_tabs(tab_id, cwd, metadata_json, last_modified)
+     VALUES (?, ?, '{}', ?)
+     ON CONFLICT(tab_id) DO UPDATE SET
+       cwd = COALESCE(session_tabs.cwd, excluded.cwd),
+       last_modified = MAX(session_tabs.last_modified, excluded.last_modified)`,
+  ).run(tabId, cwd ?? null, mtimeMs);
+  db.query(
+    `INSERT INTO sessions(session_id, tab_id, cwd, current_leaf_entry_id, payload_json, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    header.id,
+    tabId,
+    cwd ?? null,
+    lastEntry?.id ?? null,
+    JSON.stringify({ header }),
+    createdAt,
+    mtimeMs,
+  );
+  entries.forEach((entry, index) => {
+    persistEntryAtOrdinal(db, tabId, header.id, entry, index, {
+      touch: false,
+    });
+  });
+}
+
+export function importLegacySessionDir(sessionDir: string): boolean {
+  const db = openDb();
+  if (!db) return false;
+  const tabId = sessionTabIdFromDir(sessionDir);
+  try {
+    const entries = readdirSync(sessionDir);
+    for (const name of entries) {
+      if (name === LOCAL_CHAT_FILE || !name.endsWith(".jsonl")) continue;
+      const path = join(sessionDir, name);
+      try {
+        const stat = statSync(path);
+        if (!stat.isFile()) continue;
+        importLegacySessionFile(db, tabId, path, stat.mtimeMs);
+      } catch {
+        /* best effort per file */
+      }
+    }
+    importLegacyLocalMessages(db, tabId, sessionDir);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function importLegacySessionsDir(sessionsDir: string): boolean {
+  const db = openDb();
+  if (!db) return false;
+  try {
+    for (const name of readdirSync(sessionsDir)) {
+      if (!/^[A-Za-z0-9_-]{1,128}$/.test(name)) continue;
+      const sessionDir = join(sessionsDir, name);
+      try {
+        if (statSync(sessionDir).isDirectory()) importLegacySessionDir(sessionDir);
+      } catch {
+        /* best effort per tab */
+      }
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function createSqliteBackedSessionManager(
+  manager: SessionManager,
+  tabId: string,
+  cwd: string,
+): SessionManager {
+  const db = openDb();
+  if (!db) return manager;
+  const sessionsDir = process.env.AETHON_SESSIONS_DIR;
+  if (typeof sessionsDir === "string" && sessionsDir.length > 0) {
+    importLegacySessionDir(join(sessionsDir, tabId));
+  }
+  const { header, entries } = loadSessionRows(db, tabId, cwd);
+  rebuildSidecar(manager, header, entries);
+  const mutable = manager as unknown as {
+    getEntries: () => SessionEntry[];
+    getEntry: (id: string) => SessionEntry | undefined;
+    getHeader: () => SessionHeader | null;
+    getBranch: (fromId?: string) => SessionEntry[];
+    buildSessionContext: () => unknown;
+    appendMessage: (message: Message | unknown) => string;
+    appendThinkingLevelChange: (thinkingLevel: string) => string;
+    appendModelChange: (provider: string, modelId: string) => string;
+    appendCompaction: <T>(summary: string, firstKeptEntryId: string, tokensBefore: number, details?: T, fromHook?: boolean) => string;
+    appendCustomEntry: (customType: string, data?: unknown) => string;
+    appendSessionInfo: (name: string) => string;
+    appendCustomMessageEntry: <T>(customType: string, content: string | unknown[], display: boolean, details?: T) => string;
+    appendLabelChange?: (targetId: string, label: string | undefined) => string;
+    branch: (branchFromId: string) => void;
+    resetLeaf: () => void;
+    branchWithSummary: (branchFromId: string | null, summary: string, details?: unknown, fromHook?: boolean) => string;
+    getTree: () => SessionTreeNode[];
+    getSessionName: () => string | undefined;
+  };
+  const persistById = (id: string): string => {
+    const entry = manager.getEntry(id);
+    if (entry) persistEntry(db, tabId, header.id, entry);
+    return id;
+  };
+  const originalAppendMessage = mutable.appendMessage.bind(manager);
+  mutable.appendMessage = (message) => persistById(originalAppendMessage(message));
+  const originalThinking = mutable.appendThinkingLevelChange.bind(manager);
+  mutable.appendThinkingLevelChange = (thinkingLevel) => persistById(originalThinking(thinkingLevel));
+  const originalModel = mutable.appendModelChange.bind(manager);
+  mutable.appendModelChange = (provider, modelId) => persistById(originalModel(provider, modelId));
+  const originalCompaction = mutable.appendCompaction.bind(manager);
+  mutable.appendCompaction = (summary, firstKeptEntryId, tokensBefore, details, fromHook) =>
+    persistById(originalCompaction(summary, firstKeptEntryId, tokensBefore, details, fromHook));
+  const originalCustom = mutable.appendCustomEntry.bind(manager);
+  mutable.appendCustomEntry = (customType, data) => persistById(originalCustom(customType, data));
+  const originalInfo = mutable.appendSessionInfo.bind(manager);
+  mutable.appendSessionInfo = (name) => persistById(originalInfo(name));
+  const originalCustomMessage = mutable.appendCustomMessageEntry.bind(manager);
+  mutable.appendCustomMessageEntry = (customType, content, display, details) =>
+    persistById(originalCustomMessage(customType, content, display, details));
+  if (mutable.appendLabelChange) {
+    const originalLabel = mutable.appendLabelChange.bind(manager);
+    mutable.appendLabelChange = (targetId, label) => persistById(originalLabel(targetId, label));
+  }
+  const originalBranch = mutable.branch.bind(manager);
+  mutable.branch = (branchFromId) => {
+    originalBranch(branchFromId);
+    db.query("UPDATE sessions SET current_leaf_entry_id = ?, updated_at = ? WHERE session_id = ?").run(
+      branchFromId,
+      nowMs(),
+      header.id,
+    );
+  };
+  const originalResetLeaf = mutable.resetLeaf.bind(manager);
+  mutable.resetLeaf = () => {
+    originalResetLeaf();
+    db.query("UPDATE sessions SET current_leaf_entry_id = NULL, updated_at = ? WHERE session_id = ?").run(
+      nowMs(),
+      header.id,
+    );
+  };
+  const originalBranchWithSummary = mutable.branchWithSummary.bind(manager);
+  mutable.branchWithSummary = (branchFromId, summary, details, fromHook) =>
+    persistById(originalBranchWithSummary(branchFromId, summary, details, fromHook));
+  return manager;
+}
+
+export function sessionTabIdFromDir(sessionDir: string): string {
+  return basename(sessionDir);
+}
+
+export function readSqliteStateValue(key: string): string | undefined {
+  const db = openDb();
+  if (!db) return undefined;
+  return rowString(
+    db
+      .query("SELECT value FROM kv_store WHERE namespace = 'state' AND key = ?")
+      .get(key),
+    "value",
+  );
+}
+
+export function readSqliteSessionMetadata(tabId: string): SessionLogMetadata | null {
+  const db = openDb();
+  if (!db) return null;
+  const row = db.query("SELECT cwd, custom_label, first_user_message, last_modified FROM session_tabs WHERE tab_id = ?").get(tabId);
+  if (!row) return null;
+  return {
+    lastModified: typeof row.last_modified === "number" ? row.last_modified : nowMs(),
+    ...(rowString(row, "cwd") ? { cwd: rowString(row, "cwd") } : {}),
+    ...(rowString(row, "first_user_message") ? { firstUserMessage: rowString(row, "first_user_message") } : {}),
+    ...(rowString(row, "custom_label") ? { customLabel: rowString(row, "custom_label") } : {}),
+  };
+}
+
+export function listSqliteDiscoveredTabs(): Array<{ tabId: string } & SessionLogMetadata> | null {
+  const db = openDb();
+  if (!db) return null;
+  return db
+    .query("SELECT tab_id, cwd, custom_label, first_user_message, last_modified FROM session_tabs ORDER BY last_modified DESC")
+    .all()
+    .flatMap((row) => {
+      const tabId = rowString(row, "tab_id");
+      if (!tabId) return [];
+      return [{
+        tabId,
+        lastModified: typeof row.last_modified === "number" ? row.last_modified : nowMs(),
+        ...(rowString(row, "cwd") ? { cwd: rowString(row, "cwd") } : {}),
+        ...(rowString(row, "first_user_message") ? { firstUserMessage: rowString(row, "first_user_message") } : {}),
+        ...(rowString(row, "custom_label") ? { customLabel: rowString(row, "custom_label") } : {}),
+      }];
+    });
+}
+
+function localRowToMessage(row: Record<string, unknown>): RestoredChatMessage | undefined {
+  const raw = rowString(row, "payload_json");
+  if (!raw) return undefined;
+  try {
+    return JSON.parse(raw) as RestoredChatMessage;
+  } catch {
+    return undefined;
+  }
+}
+
+function piEntryToMessage(entry: SessionEntry): RestoredChatMessage | undefined {
+  if (entry.type === "compaction") {
+    return {
+      id: `compaction:${entry.id}`,
+      role: "system",
+      text: `Context compacted · ${entry.tokensBefore.toLocaleString()} tokens summarized`,
+      entryId: entry.id,
+      createdAt: parseTime(entry.timestamp),
+    };
+  }
+  if (entry.type !== "message") return undefined;
+  const role = entry.message.role === "assistant" ? "agent" : entry.message.role;
+  if (!isChatRole(role)) return undefined;
+  const text = trimText(textFromContent(entry.message.content));
+  const thinking = trimText(thinkingFromContent(entry.message.content));
+  return {
+    id: entry.id,
+    entryId: entry.id,
+    role,
+    ...(text ? { text } : {}),
+    ...(thinking ? { thinking } : {}),
+    createdAt: parseTime(entry.timestamp),
+  };
+}
+
+export function readSqliteSessionTranscript(tabId: string, expectedCwd?: string): RestoredChatMessage[] | null {
+  const transcript = readSqliteSessionStreams(tabId, expectedCwd);
+  if (!transcript) return null;
+  return [...transcript.piMessages, ...transcript.localMessages]
+    .sort((a, b) => (a.createdAt ?? 0) - (b.createdAt ?? 0))
+    .slice(-200);
+}
+
+export function readSqliteSessionStreams(tabId: string, expectedCwd?: string): {
+  piMessages: RestoredChatMessage[];
+  localMessages: RestoredChatMessage[];
+} | null {
+  const db = openDb();
+  if (!db) return null;
+  const session = expectedCwd !== undefined
+    ? db
+        .query("SELECT session_id, current_leaf_entry_id, cwd FROM sessions WHERE tab_id = ? ORDER BY updated_at DESC")
+        .all(tabId)
+        .find((row) => sessionMatchesCwd(rowString(row, "cwd"), expectedCwd)) ?? null
+    : db
+        .query("SELECT session_id, current_leaf_entry_id FROM sessions WHERE tab_id = ? ORDER BY updated_at DESC LIMIT 1")
+        .get(tabId);
+  const sessionId = rowString(session, "session_id");
+  const currentLeafEntryId = rowString(session, "current_leaf_entry_id");
+  const piMessages = sessionId
+    ? activeSessionEntries(
+        db.query("SELECT payload_json FROM session_entries WHERE session_id = ? ORDER BY ordinal ASC")
+          .all(sessionId)
+          .flatMap((row) => {
+            const raw = rowString(row, "payload_json");
+            if (!raw) return [];
+            try {
+              return [JSON.parse(raw) as SessionEntry];
+            } catch {
+              return [];
+            }
+          }),
+        currentLeafEntryId,
+      ).flatMap((entry) => {
+        const message = piEntryToMessage(entry);
+        return message ? [message] : [];
+      })
+    : [];
+  const localRows = expectedCwd !== undefined
+    ? db
+        .query("SELECT payload_json, cwd FROM session_local_messages WHERE tab_id = ? ORDER BY created_at ASC")
+        .all(tabId)
+        .filter((row) => sessionMatchesCwd(rowString(row, "cwd"), expectedCwd))
+    : db
+        .query("SELECT payload_json FROM session_local_messages WHERE tab_id = ? ORDER BY created_at ASC")
+        .all(tabId);
+  const localMessages = localRows
+    .flatMap((row) => {
+      const message = localRowToMessage(row);
+      return message ? [message] : [];
+    });
+  return { piMessages, localMessages };
+}
+
+export function readSqliteSessionLabel(tabId: string): string | undefined {
+  const db = openDb();
+  if (!db) return undefined;
+  return rowString(db.query("SELECT custom_label FROM session_tabs WHERE tab_id = ?").get(tabId), "custom_label");
+}
+
+export function writeSqliteSessionLabel(tabId: string, label: string, cwd?: string): boolean {
+  const db = openDb();
+  if (!db) return false;
+  const trimmed = label.trim().slice(0, MAX_CUSTOM_LABEL_CHARS);
+  db.query(
+    `INSERT INTO session_tabs(tab_id, cwd, custom_label, label_cwd, metadata_json, last_modified)
+     VALUES (?, ?, ?, ?, '{}', ?)
+     ON CONFLICT(tab_id) DO UPDATE SET
+       custom_label = excluded.custom_label,
+       label_cwd = excluded.label_cwd,
+       cwd = COALESCE(session_tabs.cwd, excluded.cwd),
+       last_modified = excluded.last_modified`,
+  ).run(tabId, cwd ?? null, trimmed || null, cwd ?? null, nowMs());
+  return true;
+}
+
+function persistLocalChatMessage(db: Database, tabId: string, message: RestoredChatMessage): boolean {
+  if (!isChatRole(message.role)) return true;
+  const text = typeof message.text === "string" ? trimText(message.text) : "";
+  const thinking = typeof message.thinking === "string" ? trimText(message.thinking) : "";
+  const attachments = parseChatAttachments(message.attachments);
+  const a2ui = hasA2ui(message.a2ui) ? message.a2ui : undefined;
+  if (!text && !thinking && !a2ui && attachments.length === 0) return true;
+  const id = message.id || crypto.randomUUID();
+  const createdAt = typeof message.createdAt === "number" && Number.isFinite(message.createdAt) ? message.createdAt : nowMs();
+  const payload = {
+    ...message,
+    id,
+    ...(text ? { text } : {}),
+    ...(thinking ? { thinking } : {}),
+    ...(attachments.length > 0 ? { attachments } : {}),
+    ...(a2ui ? { a2ui } : {}),
+    createdAt,
+  };
+  db.query(
+    `INSERT OR REPLACE INTO session_local_messages(
+       tab_id, message_id, role, text, thinking, created_at, cwd, payload_json
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(tabId, id, message.role, text, thinking, createdAt, message.cwd ?? null, JSON.stringify(payload));
+  db.query("UPDATE session_tabs SET last_modified = MAX(last_modified, ?), cwd = COALESCE(cwd, ?) WHERE tab_id = ?").run(
+    createdAt,
+    message.cwd ?? null,
+    tabId,
+  );
+  return true;
+}
+
+function rebuildLocalSearchIndex(db: Database, tabId: string): void {
+  db.query("DELETE FROM session_search_fts WHERE tab_id = ? AND source = 'local'").run(tabId);
+  const rows = db
+    .query("SELECT role, text, thinking, created_at FROM session_local_messages WHERE tab_id = ? ORDER BY created_at ASC")
+    .all(tabId);
+  for (const row of rows) {
+    const searchable = [rowString(row, "text") ?? "", rowString(row, "thinking") ?? ""]
+      .filter(Boolean)
+      .join("\n");
+    if (!searchable) continue;
+    db.query("INSERT INTO session_search_fts(tab_id, role, text, timestamp, source) VALUES (?, ?, ?, ?, 'local')").run(
+      tabId,
+      rowString(row, "role") ?? "",
+      searchable,
+      rowNumber(row, "created_at") ?? nowMs(),
+    );
+  }
+}
+
+export function appendSqliteLocalChatMessage(tabId: string, message: RestoredChatMessage): boolean {
+  const db = openDb();
+  if (!db) return false;
+  if (!persistLocalChatMessage(db, tabId, message)) return false;
+  const overflow = db
+    .query(
+      `SELECT message_id FROM session_local_messages
+       WHERE tab_id = ?
+       ORDER BY created_at DESC
+       LIMIT -1 OFFSET ?`,
+    )
+    .all(tabId, MAX_LOCAL_CHAT_MESSAGES);
+  for (const row of overflow) {
+    const messageId = rowString(row, "message_id");
+    if (messageId) {
+      db.query("DELETE FROM session_local_messages WHERE tab_id = ? AND message_id = ?").run(tabId, messageId);
+    }
+  }
+  rebuildLocalSearchIndex(db, tabId);
+  return true;
+}
+
+export function truncateSqliteLocalChatAfter(tabId: string, cutoffMs: number): boolean {
+  const db = openDb();
+  if (!db) return false;
+  db.query("DELETE FROM session_local_messages WHERE tab_id = ? AND created_at > ?").run(tabId, cutoffMs);
+  rebuildLocalSearchIndex(db, tabId);
+  return true;
+}
+
+export function forkSqliteSession(sourceTabId: string, destTabId: string, leafId: string, label: string, cwd?: string): boolean {
+  const db = openDb();
+  if (!db) return false;
+  const source = db
+    .query("SELECT session_id, payload_json, cwd FROM sessions WHERE tab_id = ? ORDER BY updated_at DESC")
+    .all(sourceTabId)
+    .find((row) => sessionMatchesCwd(rowString(row, "cwd"), cwd)) ?? null;
+  const sourceSessionId = rowString(source, "session_id");
+  if (!sourceSessionId) return false;
+  const rows = db
+    .query("SELECT payload_json FROM session_entries WHERE session_id = ? ORDER BY ordinal ASC")
+    .all(sourceSessionId)
+    .flatMap((row) => {
+      const raw = rowString(row, "payload_json");
+      if (!raw) return [];
+      try {
+        return [JSON.parse(raw) as SessionEntry];
+      } catch {
+        return [];
+      }
+    });
+  const byId = new Map(rows.map((entry) => [entry.id, entry] as const));
+  const path: SessionEntry[] = [];
+  let current = byId.get(leafId);
+  while (current) {
+    path.unshift(current);
+    current = current.parentId ? byId.get(current.parentId) : undefined;
+  }
+  if (path.length === 0) return false;
+  const sessionId = crypto.randomUUID();
+  const header: SessionHeader = {
+    type: "session",
+    version: CURRENT_SESSION_VERSION,
+    id: sessionId,
+    timestamp: new Date().toISOString(),
+    cwd: cwd ?? "",
+    parentSession: sourceSessionId,
+  };
+  db.query(
+    `INSERT OR REPLACE INTO session_tabs(tab_id, cwd, custom_label, metadata_json, last_modified)
+     VALUES (?, ?, ?, '{}', ?)`,
+  ).run(destTabId, cwd ?? null, label, nowMs());
+  db.query(
+    `INSERT INTO sessions(session_id, tab_id, cwd, current_leaf_entry_id, payload_json, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  ).run(sessionId, destTabId, cwd ?? null, leafId, JSON.stringify({ header }), nowMs(), nowMs());
+  path.forEach((entry, index) => {
+    persistEntryAtOrdinal(db, destTabId, sessionId, entry, index, {
+      touch: false,
+    });
+  });
+  return true;
+}

--- a/agent/state.ts
+++ b/agent/state.ts
@@ -373,6 +373,8 @@ export interface PendingMutation {
 export interface AethonAgentStateOptions {
   userDir: string;
   stateFile: string;
+  dbFile: string | undefined;
+  projectsDir: string | undefined;
   sessionsDir: string;
   docsDir: string | undefined;
   projectRoot: string | undefined;
@@ -413,6 +415,8 @@ export class AethonAgentState {
   // -- Configuration (read-only at boot) -----------------------------------
   readonly userDir: string;
   readonly stateFile: string;
+  readonly dbFile: string | undefined;
+  readonly projectsDir: string | undefined;
   readonly sessionsDir: string;
   readonly docsDir: string | undefined;
   readonly projectRoot: string | undefined;
@@ -657,6 +661,8 @@ export class AethonAgentState {
   constructor(opts: AethonAgentStateOptions) {
     this.userDir = opts.userDir;
     this.stateFile = opts.stateFile;
+    this.dbFile = opts.dbFile;
+    this.projectsDir = opts.projectsDir;
     this.sessionsDir = opts.sessionsDir;
     this.docsDir = opts.docsDir;
     this.projectRoot = opts.projectRoot;

--- a/agent/tab-lifecycle/lifecycle.ts
+++ b/agent/tab-lifecycle/lifecycle.ts
@@ -10,7 +10,6 @@
  * so one desktop session can switch between multiple signed-in accounts.
  */
 
-import { mkdirSync } from "node:fs";
 import {
   SessionManager,
   createAgentSession,
@@ -42,18 +41,15 @@ import {
 import { wrapWithSourceGuard } from "../source-guard";
 import { logger } from "../logger";
 import { authProfileServicesForTab } from "../auth-profiles";
-import {
-  findSessionFileMatchingCwd,
-  repairDanglingSubagentToolResults,
-} from "../session-history";
 import { emitGlobalReady } from "../dispatcherTypes";
 import type { AethonAgentState, TabRecord } from "../state";
 import { contextUsageSnapshot, emitContextUsage } from "../context-usage";
+import { createSqliteBackedSessionManager } from "../session-sqlite";
 import { handleSessionEvent } from "./events";
 import { installAethonRetryClassifier } from "./retry";
 import { buildPickerModels, ensurePickerHasModel } from "./models";
 import { refreshPiSlashCommands } from "./slash-commands";
-import { modelDescriptor, modelKey, tabSessionDir } from "./utils";
+import { modelDescriptor, modelKey } from "./utils";
 import type { TabLifecycleDeps } from "./utils";
 
 export interface EnsureTabOptions {
@@ -194,30 +190,13 @@ export async function ensureTab(
 
   let sessionManager;
   try {
-    const dir = tabSessionDir(state, tabId);
-    mkdirSync(dir, { recursive: true });
-    // Sessions are stored per-tabId, but `default` is shared across
-    // every project bucket — a plain `continueRecent` would resume
-    // whichever project last wrote there, leaking the wrong chat into
-    // a freshly-opened project. Open the most-recent session whose
-    // header cwd matches the active project; if none matches, start
-    // fresh under the same dir rather than picking up an unrelated
-    // project's history (`continueRecent` would).
-    const matching = await findSessionFileMatchingCwd(dir, resolvedCwd);
-    if (matching) {
-      await repairDanglingSubagentToolResults(matching).catch(
-        (err: unknown) => {
-          lifecycleLog.warn(
-            `subagent result repair failed for ${matching}: ${
-              err instanceof Error ? err.message : String(err)
-            }`,
-          );
-        },
-      );
-    }
-    sessionManager = matching
-      ? SessionManager.open(matching, dir)
-      : SessionManager.create(resolvedCwd, dir);
+    // Aethon session state is SQLite-backed; pi receives its own normal
+    // default-location session file as a write-through sidecar only.
+    sessionManager = createSqliteBackedSessionManager(
+      SessionManager.create(resolvedCwd),
+      tabId,
+      resolvedCwd,
+    );
   } catch (err) {
     logger
       .scope("session")

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -30,6 +30,7 @@ dependencies = [
  "portable-pty",
  "reqwest 0.12.28",
  "rubato",
+ "rusqlite",
  "serde",
  "serde_json",
  "sha1",
@@ -1490,6 +1491,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fancy-regex"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2328,6 +2341,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2982,6 +3004,17 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall 0.7.4",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -4647,6 +4680,20 @@ dependencies = [
  "num-traits",
  "visibility",
  "windowfunctions",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
+dependencies = [
+ "bitflags 2.11.1",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -6597,6 +6644,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,6 +22,7 @@ path = "src/main.rs"
 tauri = { version = "2", features = ["tray-icon"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+rusqlite = { version = "0.37.0", features = ["bundled"] }
 notify = "8"
 uuid = { version = "1.23.1", features = ["v4"] }
 tokio = { version = "1.52.1", features = [

--- a/src-tauri/src/agent_process/spawn.rs
+++ b/src-tauri/src/agent_process/spawn.rs
@@ -218,9 +218,13 @@ fn apply_user_env(app: &AppHandle, command: &mut Command) {
     let user_dir = helpers::aethon_dir(Some(home.clone())).unwrap_or_else(|| home.join(".aethon"));
     let state_file = user_dir.join("state.json");
     let sessions_dir = user_dir.join("sessions");
+    let db_file = user_dir.join("state").join("aethon.sqlite3");
+    let projects_dir = user_dir.join("projects");
     command.env("AETHON_USER_DIR", &user_dir);
     command.env("AETHON_STATE_FILE", &state_file);
     command.env("AETHON_SESSIONS_DIR", &sessions_dir);
+    command.env("AETHON_DB_FILE", &db_file);
+    command.env("AETHON_PROJECTS_DIR", &projects_dir);
 
     let cfg_path = user_dir.join("config.toml");
     let raw = std::fs::read_to_string(&cfg_path).unwrap_or_default();

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -23,14 +23,7 @@ use crate::helpers::{
 /// without env-var assumptions.
 pub(crate) fn aethon_state_path(app: &AppHandle, name: &str) -> Result<PathBuf, String> {
     validate_state_name(name)?;
-    let home = app
-        .path()
-        .home_dir()
-        .map_err(|e| format!("home_dir: {e}"))?;
-    let dir = crate::helpers::aethon_dir(Some(home))
-        .ok_or_else(|| "aethon dir unresolved".to_string())?;
-    std::fs::create_dir_all(&dir).map_err(|e| format!("create_dir_all: {e}"))?;
-    Ok(dir.join(name))
+    crate::storage::legacy_state_file_path(app, name)
 }
 
 /// Read a file from `~/.aethon/`. Returns an empty string when the file
@@ -38,6 +31,10 @@ pub(crate) fn aethon_state_path(app: &AppHandle, name: &str) -> Result<PathBuf, 
 /// missing from empty.
 #[tauri::command]
 pub fn read_state(name: String, app: AppHandle) -> Result<String, String> {
+    if !crate::storage::is_file_backed_state_name(&name) {
+        return crate::storage::read_state_value(&app, &name)
+            .map(|value| value.unwrap_or_default());
+    }
     let path = aethon_state_path(&app, &name)?;
     match std::fs::read_to_string(&path) {
         Ok(s) => Ok(s),
@@ -49,6 +46,9 @@ pub fn read_state(name: String, app: AppHandle) -> Result<String, String> {
 /// Write a file to `~/.aethon/`. Creates the directory if missing.
 #[tauri::command]
 pub fn write_state(name: String, content: String, app: AppHandle) -> Result<(), String> {
+    if !crate::storage::is_file_backed_state_name(&name) {
+        return crate::storage::write_state_value(&app, &name, &content);
+    }
     let path = aethon_state_path(&app, &name)?;
     std::fs::write(&path, content).map_err(|e| format!("write {}: {e}", path.display()))
 }

--- a/src-tauri/src/commands/native_windows.rs
+++ b/src-tauri/src/commands/native_windows.rs
@@ -171,6 +171,14 @@ fn store_path(app: &AppHandle) -> Result<PathBuf, String> {
 }
 
 fn load_store(app: &AppHandle) -> NativeWindowsStore {
+    if let Ok(Some(s)) = crate::storage::read_state_value(app, STORE_FILE)
+        && !s.trim().is_empty()
+    {
+        return serde_json::from_str::<NativeWindowsStore>(&s).unwrap_or_else(|e| {
+            tracing::warn!(target: "aethon::native_windows", "parse sqlite {STORE_FILE}: {e}");
+            NativeWindowsStore::default()
+        });
+    }
     let Ok(path) = store_path(app) else {
         return NativeWindowsStore::default();
     };
@@ -201,9 +209,12 @@ fn save_persisted(app: &AppHandle, state: &NativeWindowsState) -> Result<(), Str
         version: 1,
         windows: records,
     };
-    let path = store_path(app)?;
     let body = serde_json::to_string_pretty(&store).map_err(|e| format!("serialize: {e}"))?;
-    std::fs::write(&path, body).map_err(|e| format!("write {}: {e}", path.display()))
+    crate::storage::write_state_value(app, STORE_FILE, &body).or_else(|err| {
+        tracing::warn!(target: "aethon::native_windows", "sqlite write failed: {err}; writing legacy file");
+        let path = store_path(app)?;
+        std::fs::write(&path, body).map_err(|e| format!("write {}: {e}", path.display()))
+    })
 }
 
 fn upsert_record(

--- a/src-tauri/src/commands/scheduler/store.rs
+++ b/src-tauri/src/commands/scheduler/store.rs
@@ -64,7 +64,10 @@ pub(super) fn ensure_loaded(state: &ScheduledTasksState, app: &AppHandle) -> Res
         }
     }
     let path = storage_path(app)?;
-    let mut tasks = read_store(&path)?;
+    let mut tasks = read_store_for_app(app).or_else(|err| {
+        tracing::warn!(target: "aethon::scheduler", "sqlite read failed: {err}; trying legacy file");
+        read_store(&path)
+    })?;
     let recovered = recover_loaded_running_tasks(&mut tasks, now_ms());
     {
         let mut inner = state.lock();
@@ -111,7 +114,10 @@ pub(super) fn persist_emit(state: &ScheduledTasksState, app: &AppHandle) -> Resu
             .clone()
             .ok_or_else(|| "scheduled task store not initialized".to_string())?
     };
-    write_store(&path, &list)?;
+    write_store_for_app(app, &list).or_else(|err| {
+        tracing::warn!(target: "aethon::scheduler", "sqlite write failed: {err}; writing legacy file");
+        write_store(&path, &list)
+    })?;
     let _ = app.emit("scheduled-tasks-changed", &list);
     Ok(())
 }
@@ -142,6 +148,27 @@ fn read_store(path: &Path) -> Result<HashMap<String, ScheduledTaskRecord>, Strin
         .collect())
 }
 
+fn read_store_for_app(app: &AppHandle) -> Result<HashMap<String, ScheduledTaskRecord>, String> {
+    let Some(raw) = crate::storage::read_state_value(app, STORE_FILE)? else {
+        return Ok(HashMap::new());
+    };
+    if raw.trim().is_empty() {
+        return Ok(HashMap::new());
+    }
+    parse_store(&raw)
+}
+
+fn parse_store(raw: &str) -> Result<HashMap<String, ScheduledTaskRecord>, String> {
+    let store: ScheduledTaskStore =
+        serde_json::from_str(raw).map_err(|e| format!("parse {STORE_FILE}: {e}"))?;
+    Ok(store
+        .tasks
+        .into_iter()
+        .filter(|task| task.version == TASK_VERSION)
+        .map(|task| (task.id.clone(), task))
+        .collect())
+}
+
 fn write_store(path: &Path, tasks: &[ScheduledTaskRecord]) -> Result<(), String> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| format!("create {}: {e}", parent.display()))?;
@@ -152,6 +179,15 @@ fn write_store(path: &Path, tasks: &[ScheduledTaskRecord]) -> Result<(), String>
     };
     let body = serde_json::to_string_pretty(&store).map_err(|e| format!("serialize: {e}"))?;
     std::fs::write(path, body).map_err(|e| format!("write {}: {e}", path.display()))
+}
+
+fn write_store_for_app(app: &AppHandle, tasks: &[ScheduledTaskRecord]) -> Result<(), String> {
+    let store = ScheduledTaskStore {
+        version: STORE_VERSION,
+        tasks: tasks.to_vec(),
+    };
+    let body = serde_json::to_string_pretty(&store).map_err(|e| format!("serialize: {e}"))?;
+    crate::storage::write_state_value(app, STORE_FILE, &body)
 }
 
 #[cfg(test)]

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -1,21 +1,18 @@
-//! Pi session search / delete / chat-Markdown export.
+//! SQLite-backed session search / delete / chat-Markdown export.
 //!
-//! Pi persists each tab's transcript at
-//! `~/.aethon/sessions/<tabId>/*.jsonl`. These commands let the
-//! frontend search across all tabs, delete a tab's session, and write
-//! a rendered chat to `~/Downloads/`. Snippet building lives here too
-//! so UTF-16 / multibyte indexing pitfalls stay Rust-side.
+//! Pi may still write sidecar transcripts to its own default session
+//! directory, but Aethon's application state reads session data from SQLite.
+//! Snippet building lives here so UTF-16 / multibyte indexing pitfalls stay
+//! Rust-side.
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use tauri::{AppHandle, Manager};
 
-use crate::helpers::{resolve_inside_root, sanitize_filename_segment};
+use crate::helpers::sanitize_filename_segment;
 
-/// Cross-session search (M6 P6). Walks `~/.aethon/sessions/<tabId>/*.jsonl`
-/// and returns user / assistant messages whose text content contains
-/// the query (case-insensitive substring match — no regex parsing,
-/// keeps the bar low). Capped at `limit` matches.
+/// Cross-session search over Aethon's SQLite session tables. Capped at `limit`
+/// matches.
 #[derive(serde::Serialize)]
 pub struct SearchHit {
     #[serde(rename = "tabId")]
@@ -46,190 +43,76 @@ pub fn search_sessions(
         return Ok(Vec::new());
     }
     let cap = limit.unwrap_or(200).min(5000) as usize;
-    let home = app
-        .path()
-        .home_dir()
-        .map_err(|e| format!("home_dir: {e}"))?;
-    let sessions = crate::helpers::aethon_dir(Some(home))
-        .ok_or_else(|| "aethon dir unresolved".to_string())?
-        .join("sessions");
-    if !sessions.is_dir() {
-        return Ok(Vec::new());
-    }
-
+    let conn = crate::storage::connect(&app)?;
     let mut hits: Vec<SearchHit> = Vec::new();
-    let entries = match std::fs::read_dir(&sessions) {
-        Ok(e) => e,
-        Err(_) => return Ok(Vec::new()),
-    };
-    'tab_loop: for tab_entry in entries.flatten() {
-        let tab_dir = tab_entry.path();
-        if !tab_dir.is_dir() {
+    let like = format!("%{}%", escape_like(&needle));
+    let mut stmt = conn
+        .prepare(
+            r#"
+            SELECT tab_id, role, text, timestamp
+            FROM session_search_fts
+            WHERE lower(text) LIKE ?1 ESCAPE '\'
+            ORDER BY CAST(timestamp AS INTEGER) DESC
+            LIMIT ?2
+            "#,
+        )
+        .map_err(|e| format!("sqlite prepare search: {e}"))?;
+    let rows = stmt
+        .query_map(rusqlite::params![like, cap as i64], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, Option<i64>>(3)?,
+            ))
+        })
+        .map_err(|e| format!("sqlite search: {e}"))?;
+    for row in rows {
+        let (tab_id, role, content_text, timestamp) =
+            row.map_err(|e| format!("sqlite search row: {e}"))?;
+        let lower = content_text.to_lowercase();
+        let Some(pos) = lower.find(&needle) else {
             continue;
-        }
-        let tab_id = tab_dir
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("")
-            .to_string();
-        let files = match std::fs::read_dir(&tab_dir) {
-            Ok(f) => f,
-            Err(_) => continue,
         };
-        for file_entry in files.flatten() {
-            let path = file_entry.path();
-            if path.extension().and_then(|s| s.to_str()) != Some("jsonl") {
-                continue;
-            }
-            let text = match std::fs::read_to_string(&path) {
-                Ok(t) => t,
-                Err(_) => continue,
-            };
-            for line in text.lines() {
-                let trimmed = line.trim();
-                if trimmed.is_empty() {
-                    continue;
-                }
-                let v: serde_json::Value = match serde_json::from_str(trimmed) {
-                    Ok(v) => v,
-                    Err(_) => continue,
-                };
-                // Pi session JSONL envelope is `{type:"message", message:{role, content}}`
-                // (matches the restore path in `agent/session-history.ts`).
-                // Older v1 reads at the top level, which never matches —
-                // fall through to that as a tolerant fallback so any
-                // non-pi sources (e.g. a future raw export) still index.
-                if v.get("type").and_then(|t| t.as_str()) != Some("message") {
-                    continue;
-                }
-                let inner = match v.get("message") {
-                    Some(m) if m.is_object() => m,
-                    _ => continue,
-                };
-                let role = inner
-                    .get("role")
-                    .and_then(|r| r.as_str())
-                    .unwrap_or("")
-                    .to_string();
-                if role != "user" && role != "assistant" {
-                    continue;
-                }
-                let content_text = extract_text_from_content(inner);
-                if content_text.is_empty() {
-                    continue;
-                }
-                let lower = content_text.to_lowercase();
-                let pos = match lower.find(&needle) {
-                    Some(p) => p,
-                    None => continue,
-                };
-                let (before, match_, after) =
-                    build_snippet_parts(&content_text, pos, needle.len(), 60, 100);
-                // Timestamp lives on the outer envelope, not the message.
-                let timestamp = v.get("timestamp").and_then(|t| t.as_i64());
-                hits.push(SearchHit {
-                    tab_id: tab_id.clone(),
-                    role: role.clone(),
-                    snippet_before: before,
-                    snippet_match: match_,
-                    snippet_after: after,
-                    timestamp,
-                });
-                if hits.len() >= cap {
-                    break 'tab_loop;
-                }
-            }
-        }
+        let (before, match_, after) =
+            build_snippet_parts(&content_text, pos, needle.len(), 60, 100);
+        hits.push(SearchHit {
+            tab_id,
+            role,
+            snippet_before: before,
+            snippet_match: match_,
+            snippet_after: after,
+            timestamp,
+        });
     }
     Ok(hits)
 }
 
-/// Delete a persisted session directory at `~/.aethon/sessions/<tab_id>/`.
-/// `tab_id` must match the bridge's `discoverPersistedTabs` regex
-/// (`^[A-Za-z0-9_-]{1,128}$`) so a malicious caller can't path-traverse
-/// out of the sessions directory. `default` is intentionally allowed:
-/// it is a bootstrap implementation detail, not a protected user
-/// session.
+fn escape_like(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_")
+}
+
+/// Delete a persisted Aethon session from SQLite. Pi sidecar files are left in
+/// pi's default session directory for user pickup / analytics.
 #[tauri::command]
 pub fn delete_session(tab_id: String, app: AppHandle) -> Result<(), String> {
     validate_session_tab_id(&tab_id)?;
-    let home = app
-        .path()
-        .home_dir()
-        .map_err(|e| format!("home_dir: {e}"))?;
-    let sessions_root = crate::helpers::aethon_dir(Some(home))
-        .ok_or_else(|| "aethon dir unresolved".to_string())?
-        .join("sessions");
-    let target = sessions_root.join(&tab_id);
-    delete_session_dir(target, sessions_root)
-}
-
-/// Move a freshly-branched session file (produced by `createBranchedSession`
-/// into the *source* tab's dir) into a new tab's session directory, so the
-/// per-tab layout the bridge expects holds for the fork. Used by `fork_session`.
-///
-/// `source_path` is supplied by the bridge; we trust nothing about it — it must
-/// canonicalize to a real file that already lives under `~/.aethon/sessions`
-/// (blocking a spoofed path at `/etc/...`), and the destination is pinned to
-/// `<sessions>/<dest_tab_id>/` with a validated tab id + lexical inside-root
-/// check. Returns the absolute destination path.
-#[tauri::command]
-pub fn copy_session_file(
-    source_path: String,
-    dest_tab_id: String,
-    app: AppHandle,
-) -> Result<String, String> {
-    let home = app
-        .path()
-        .home_dir()
-        .map_err(|e| format!("home_dir: {e}"))?;
-    let sessions_root = crate::helpers::aethon_dir(Some(home))
-        .ok_or_else(|| "aethon dir unresolved".to_string())?
-        .join("sessions");
-    let dest = copy_session_into_tab(Path::new(&source_path), &sessions_root, &dest_tab_id)?;
-    Ok(dest.to_string_lossy().into_owned())
-}
-
-fn copy_session_into_tab(
-    source_path: &Path,
-    sessions_root: &Path,
-    dest_tab_id: &str,
-) -> Result<PathBuf, String> {
-    validate_session_tab_id(dest_tab_id)?;
-    // The source must exist and live under the sessions root (it was produced by
-    // createBranchedSession into a tab dir). Canonicalize both so a symlink or
-    // `..` can't smuggle a path outside the tree past the prefix check.
-    let canonical_root = std::fs::canonicalize(sessions_root)
-        .map_err(|e| format!("canonicalize sessions root: {e}"))?;
-    let canonical_source =
-        std::fs::canonicalize(source_path).map_err(|e| format!("canonicalize source: {e}"))?;
-    if !canonical_source.starts_with(&canonical_root) {
-        return Err("refusing to copy: source escapes the sessions root".to_string());
-    }
-    if !canonical_source.is_file() {
-        return Err("source is not a file".to_string());
-    }
-    let file_name = canonical_source
-        .file_name()
-        .and_then(|n| n.to_str())
-        .ok_or_else(|| "source has no file name".to_string())?;
-    let dest_dir = canonical_root.join(dest_tab_id);
-    std::fs::create_dir_all(&dest_dir)
-        .map_err(|e| format!("create_dir_all {}: {e}", dest_dir.display()))?;
-    // Symlink-aware: if `<sessions>/<dest_tab_id>` is (or resolves through) a
-    // symlink out of the sessions tree, reject before writing into it.
-    crate::commands::fs::ensure_symlink_safe(&dest_dir, &canonical_root)?;
-    let dest_path = dest_dir.join(file_name);
-    if resolve_inside_root(&dest_dir, &dest_path).is_none() {
-        return Err("refusing to copy: dest escapes the tab dir".to_string());
-    }
-    // Rename when same-filesystem (atomic); copy + remove for cross-device.
-    if std::fs::rename(&canonical_source, &dest_path).is_err() {
-        std::fs::copy(&canonical_source, &dest_path)
-            .map_err(|e| format!("copy {}: {e}", dest_path.display()))?;
-        let _ = std::fs::remove_file(&canonical_source);
-    }
-    Ok(dest_path)
+    let conn = crate::storage::connect(&app)?;
+    conn.execute(
+        "DELETE FROM session_search_fts WHERE tab_id = ?1",
+        rusqlite::params![tab_id],
+    )
+    .map_err(|e| format!("sqlite delete search rows: {e}"))?;
+    conn.execute(
+        "DELETE FROM session_tabs WHERE tab_id = ?1",
+        rusqlite::params![tab_id],
+    )
+    .map_err(|e| format!("sqlite delete session: {e}"))?;
+    tracing::info!(target: "aethon::session_delete", "deleted sqlite session {tab_id}");
+    Ok(())
 }
 
 fn validate_session_tab_id(tab_id: &str) -> Result<(), String> {
@@ -245,6 +128,7 @@ fn validate_session_tab_id(tab_id: &str) -> Result<(), String> {
     Ok(())
 }
 
+#[cfg(test)]
 fn delete_session_dir(target: PathBuf, sessions_root: PathBuf) -> Result<(), String> {
     // Defense in depth: even though the regex above forbids '/' and '..',
     // canonicalize and verify the result still lives directly under
@@ -268,30 +152,6 @@ fn delete_session_dir(target: PathBuf, sessions_root: PathBuf) -> Result<(), Str
         .map_err(|e| format!("remove_dir_all {}: {e}", canonical_target.display()))?;
     tracing::info!(target: "aethon::session_delete", "deleted {}", canonical_target.display());
     Ok(())
-}
-
-fn extract_text_from_content(v: &serde_json::Value) -> String {
-    let content = match v.get("content") {
-        Some(c) => c,
-        None => return String::new(),
-    };
-    if let Some(s) = content.as_str() {
-        return s.to_string();
-    }
-    if let Some(arr) = content.as_array() {
-        let mut chunks: Vec<String> = Vec::new();
-        for part in arr {
-            if let Some(s) = part.as_str() {
-                chunks.push(s.to_string());
-            } else if part.get("type").and_then(|t| t.as_str()) == Some("text")
-                && let Some(t) = part.get("text").and_then(|t| t.as_str())
-            {
-                chunks.push(t.to_string());
-            }
-        }
-        return chunks.join("\n");
-    }
-    String::new()
 }
 
 /// Build a three-way split snippet around the matched needle.
@@ -424,8 +284,7 @@ pub fn export_chat_markdown(
 
 #[cfg(test)]
 mod tests {
-    use super::{copy_session_into_tab, delete_session_dir, validate_session_tab_id};
-    use std::path::PathBuf;
+    use super::{delete_session_dir, escape_like, validate_session_tab_id};
 
     #[test]
     fn validate_session_tab_id_allows_default() {
@@ -453,75 +312,8 @@ mod tests {
         let _ = std::fs::remove_dir_all(root);
     }
 
-    fn copy_test_root() -> PathBuf {
-        std::env::temp_dir().join(format!("aethon-session-copy-{}", uuid::Uuid::new_v4()))
-    }
-
     #[test]
-    fn copy_session_into_tab_moves_file_and_preserves_header() {
-        let root = copy_test_root();
-        let sessions = root.join("sessions");
-        let src_dir = sessions.join("tab-a");
-        std::fs::create_dir_all(&src_dir).expect("create src tab dir");
-        let header = "{\"type\":\"session\",\"id\":\"s1\",\"cwd\":\"/proj\"}\n{\"type\":\"message\",\"id\":\"m1\"}\n";
-        let src = src_dir.join("123_branch.jsonl");
-        std::fs::write(&src, header).expect("write source session");
-
-        let dest = copy_session_into_tab(&src, &sessions, "tab-b").expect("copy into tab-b");
-
-        assert!(dest.ends_with("123_branch.jsonl"));
-        assert!(dest.starts_with(std::fs::canonicalize(&sessions).unwrap().join("tab-b")));
-        assert_eq!(std::fs::read_to_string(&dest).unwrap(), header);
-        // Move semantics: the branched source is gone.
-        assert!(!src.exists());
-        let _ = std::fs::remove_dir_all(&root);
-    }
-
-    #[test]
-    fn copy_session_into_tab_rejects_source_outside_sessions_root() {
-        let root = copy_test_root();
-        let sessions = root.join("sessions");
-        std::fs::create_dir_all(&sessions).expect("create sessions root");
-        // A real file, but outside the sessions tree.
-        let outside = root.join("outside.jsonl");
-        std::fs::write(&outside, "{}\n").expect("write outside file");
-
-        let err = copy_session_into_tab(&outside, &sessions, "tab-b").unwrap_err();
-        assert!(err.contains("escapes the sessions root"), "got: {err}");
-        let _ = std::fs::remove_dir_all(&root);
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn copy_session_into_tab_rejects_symlinked_dest_dir() {
-        use std::os::unix::fs::symlink;
-        let root = copy_test_root();
-        let sessions = root.join("sessions");
-        let src_dir = sessions.join("tab-a");
-        std::fs::create_dir_all(&src_dir).expect("create src tab dir");
-        let src = src_dir.join("x.jsonl");
-        std::fs::write(&src, "{}\n").expect("write source");
-        // A pre-existing dest tab dir that's a symlink pointing outside sessions.
-        let evil = root.join("evil");
-        std::fs::create_dir_all(&evil).expect("create evil dir");
-        symlink(&evil, sessions.join("tabb")).expect("symlink dest");
-
-        let err = copy_session_into_tab(&src, &sessions, "tabb").unwrap_err();
-        assert!(err.contains("symlink escapes"), "got: {err}");
-        let _ = std::fs::remove_dir_all(&root);
-    }
-
-    #[test]
-    fn copy_session_into_tab_rejects_invalid_dest_tab_id() {
-        let root = copy_test_root();
-        let sessions = root.join("sessions");
-        let src_dir = sessions.join("tab-a");
-        std::fs::create_dir_all(&src_dir).expect("create src tab dir");
-        let src = src_dir.join("x.jsonl");
-        std::fs::write(&src, "{}\n").expect("write source");
-
-        assert!(copy_session_into_tab(&src, &sessions, "../escape").is_err());
-        assert!(copy_session_into_tab(&src, &sessions, "nested/id").is_err());
-        let _ = std::fs::remove_dir_all(&root);
+    fn escape_like_escapes_wildcards_and_escape_character() {
+        assert_eq!(escape_like(r"a\b%c_d"), r"a\\b\%c\_d");
     }
 }

--- a/src-tauri/src/commands/startup/approval.rs
+++ b/src-tauri/src/commands/startup/approval.rs
@@ -139,24 +139,13 @@ fn path_contains(parent: &Path, child: &Path) -> bool {
 }
 
 fn read_project_registry(app: &AppHandle) -> Option<ProjectRegistry> {
-    let path = match crate::commands::config::aethon_state_path(app, "projects.json") {
-        Ok(path) => path,
+    let text = match crate::storage::read_state_value(app, "projects.json") {
+        Ok(Some(text)) if !text.trim().is_empty() => text,
+        Ok(_) => return None,
         Err(err) => {
             tracing::warn!(
                 target: "aethon::startup",
-                "resolve projects.json failed: {err}; project startup auto-approve disabled"
-            );
-            return None;
-        }
-    };
-    let text = match std::fs::read_to_string(&path) {
-        Ok(text) => text,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
-        Err(e) => {
-            tracing::warn!(
-                target: "aethon::startup",
-                "read {} failed: {e}; project startup auto-approve disabled",
-                path.display()
+                "read projects.json state failed: {err}; project startup auto-approve disabled"
             );
             return None;
         }
@@ -166,8 +155,7 @@ fn read_project_registry(app: &AppHandle) -> Option<ProjectRegistry> {
         Err(err) => {
             tracing::warn!(
                 target: "aethon::startup",
-                "parse {} failed: {err}; project startup auto-approve disabled",
-                path.display()
+                "parse projects.json state failed: {err}; project startup auto-approve disabled"
             );
             None
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -44,6 +44,7 @@ mod paste;
 mod platform_speech;
 mod server;
 mod shell;
+mod storage;
 mod updater_state;
 #[cfg(feature = "voice")]
 mod voice;
@@ -202,7 +203,6 @@ pub fn run() {
             commands::session::search_sessions,
             commands::session::delete_session,
             commands::session::export_chat_markdown,
-            commands::session::copy_session_file,
             commands::scheduler::scheduled_tasks_list,
             commands::scheduler::scheduled_tasks_reconcile_live_tabs,
             commands::scheduler::scheduled_tasks_fail_running_for_tab,
@@ -331,6 +331,9 @@ pub fn run() {
 
     let app = builder
         .setup(move |app| {
+            if let Err(e) = storage::initialize(app.handle()) {
+                tracing::warn!(target: "aethon::storage", "initialize sqlite storage: {e}");
+            }
             agent_process::cleanup_orphaned_dev_agents();
             if let Some(watcher) = commands::extensions::start_agent_watcher(app.handle().clone()) {
                 app.manage(watcher);
@@ -504,7 +507,6 @@ mod tests {
             "commands::subagents::subagents_list",
             "commands::subagents::subagents_write",
             "commands::subagents::subagents_delete",
-            "commands::session::copy_session_file",
         ] {
             assert!(
                 src.contains(command),

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -1,0 +1,663 @@
+//! SQLite-backed application state storage.
+//!
+//! The database is the canonical home for Aethon-managed state. User-authored
+//! files such as `config.toml` and system-prompt markdown remain plain files so
+//! users can keep editing them directly.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use rusqlite::{Connection, OptionalExtension, params};
+use tauri::{AppHandle, Manager};
+
+use crate::helpers::{sanitize_filename_segment, validate_state_name};
+
+const DB_RELATIVE_DIR: &str = "state";
+const DB_FILE: &str = "aethon.sqlite3";
+const KV_NAMESPACE_STATE: &str = "state";
+const CURRENT_SCHEMA: i64 = 1;
+
+const FILE_BACKED_STATE_NAMES: &[&str] = &[
+    "config.toml",
+    "system-prompt.md",
+    "system-prompt-append.md",
+    "ai-tools.md",
+];
+
+const LEGACY_STATE_FILES: &[&str] = &[
+    "disabled-extensions.json",
+    "editor-tabs.json",
+    "file-tree-prefs.json",
+    "file-tree.json",
+    "git-fetch-attempts.json",
+    "git-status.json",
+    "hosts.json",
+    "layout_prefs",
+    "mcp-approvals.json",
+    "messages.json",
+    "native-windows.json",
+    "project-icons.json",
+    "projects.json",
+    "scheduled-tasks.json",
+    "session_ui_snapshot",
+    "sidebar_width",
+    "startup-approvals.json",
+    "state.json",
+    "terminal_height",
+    "theme",
+    "ui_state",
+    "ui_zoom",
+    "vcs-status.json",
+    "voice.json",
+    "window-state.json",
+];
+
+const RESERVED_TOP_LEVEL_DIRS: &[&str] = &[
+    "agents",
+    "auth",
+    "control",
+    "devshell-cache",
+    "extension-packages",
+    "extensions",
+    "legacy-json",
+    "logs",
+    "mcp",
+    "memory",
+    "models",
+    "pastes",
+    "projects",
+    "sessions",
+    "skills",
+    "state",
+    "themes",
+    "updates",
+];
+
+pub(crate) fn aethon_dir(app: &AppHandle) -> Result<PathBuf, String> {
+    let home = app
+        .path()
+        .home_dir()
+        .map_err(|e| format!("home_dir: {e}"))?;
+    let dir = crate::helpers::aethon_dir(Some(home))
+        .ok_or_else(|| "aethon dir unresolved".to_string())?;
+    std::fs::create_dir_all(&dir).map_err(|e| format!("create {}: {e}", dir.display()))?;
+    Ok(dir)
+}
+
+pub(crate) fn db_path(app: &AppHandle) -> Result<PathBuf, String> {
+    let dir = aethon_dir(app)?.join(DB_RELATIVE_DIR);
+    std::fs::create_dir_all(&dir).map_err(|e| format!("create {}: {e}", dir.display()))?;
+    Ok(dir.join(DB_FILE))
+}
+
+pub(crate) fn is_file_backed_state_name(name: &str) -> bool {
+    FILE_BACKED_STATE_NAMES.contains(&name)
+}
+
+pub(crate) fn legacy_state_file_path(app: &AppHandle, name: &str) -> Result<PathBuf, String> {
+    validate_state_name(name)?;
+    Ok(aethon_dir(app)?.join(name))
+}
+
+fn connect_path(path: &Path) -> Result<Connection, String> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("create {}: {e}", parent.display()))?;
+    }
+    let conn =
+        Connection::open(path).map_err(|e| format!("open sqlite {}: {e}", path.display()))?;
+    conn.pragma_update(None, "journal_mode", "WAL")
+        .map_err(|e| format!("sqlite journal_mode: {e}"))?;
+    conn.pragma_update(None, "foreign_keys", "ON")
+        .map_err(|e| format!("sqlite foreign_keys: {e}"))?;
+    conn.pragma_update(None, "busy_timeout", 5000)
+        .map_err(|e| format!("sqlite busy_timeout: {e}"))?;
+    conn.pragma_update(None, "synchronous", "NORMAL")
+        .map_err(|e| format!("sqlite synchronous: {e}"))?;
+    migrate_connection(&conn)?;
+    Ok(conn)
+}
+
+pub(crate) fn connect(app: &AppHandle) -> Result<Connection, String> {
+    connect_path(&db_path(app)?)
+}
+
+pub(crate) fn initialize(app: &AppHandle) -> Result<(), String> {
+    let dir = aethon_dir(app)?;
+    initialize_dir(&dir)
+}
+
+fn initialize_dir(dir: &Path) -> Result<(), String> {
+    std::fs::create_dir_all(dir).map_err(|e| format!("create {}: {e}", dir.display()))?;
+    std::fs::create_dir_all(projects_dir_from_aethon_dir(dir)).map_err(|e| {
+        format!(
+            "create {}: {e}",
+            projects_dir_from_aethon_dir(dir).display()
+        )
+    })?;
+    let conn = connect_path(&db_path_from_aethon_dir(dir))?;
+    import_legacy_state_files_from_dir(dir, &conn)?;
+    migrate_project_data_dirs_from_dir(dir, &conn)?;
+    Ok(())
+}
+
+fn db_path_from_aethon_dir(dir: &Path) -> PathBuf {
+    dir.join(DB_RELATIVE_DIR).join(DB_FILE)
+}
+
+fn projects_dir_from_aethon_dir(dir: &Path) -> PathBuf {
+    dir.join("projects")
+}
+
+fn migrate_connection(conn: &Connection) -> Result<(), String> {
+    conn.execute_batch(
+        r#"
+        CREATE TABLE IF NOT EXISTS schema_migrations (
+          version INTEGER PRIMARY KEY,
+          applied_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000)
+        );
+
+        CREATE TABLE IF NOT EXISTS kv_store (
+          namespace TEXT NOT NULL,
+          key TEXT NOT NULL,
+          value TEXT NOT NULL,
+          updated_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
+          PRIMARY KEY (namespace, key)
+        );
+
+        CREATE TABLE IF NOT EXISTS projects (
+          id TEXT PRIMARY KEY,
+          label TEXT NOT NULL,
+          path TEXT NOT NULL,
+          host_id TEXT,
+          data_dir TEXT NOT NULL,
+          payload_json TEXT NOT NULL,
+          last_used INTEGER,
+          updated_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000)
+        );
+
+        CREATE TABLE IF NOT EXISTS project_workspaces (
+          id TEXT NOT NULL,
+          project_id TEXT NOT NULL,
+          path TEXT NOT NULL,
+          payload_json TEXT NOT NULL,
+          updated_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
+          PRIMARY KEY (project_id, id),
+          FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE
+        );
+
+        CREATE TABLE IF NOT EXISTS session_tabs (
+          tab_id TEXT PRIMARY KEY,
+          cwd TEXT,
+          custom_label TEXT,
+          label_cwd TEXT,
+          first_user_message TEXT,
+          last_modified INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
+          metadata_json TEXT NOT NULL DEFAULT '{}'
+        );
+
+        CREATE TABLE IF NOT EXISTS sessions (
+          session_id TEXT PRIMARY KEY,
+          tab_id TEXT NOT NULL,
+          cwd TEXT,
+          current_leaf_entry_id TEXT,
+          payload_json TEXT NOT NULL DEFAULT '{}',
+          created_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
+          updated_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
+          FOREIGN KEY (tab_id) REFERENCES session_tabs(tab_id) ON DELETE CASCADE
+        );
+
+        CREATE TABLE IF NOT EXISTS session_entries (
+          session_id TEXT NOT NULL,
+          entry_id TEXT NOT NULL,
+          parent_entry_id TEXT,
+          entry_type TEXT NOT NULL,
+          role TEXT,
+          text TEXT,
+          timestamp INTEGER,
+          payload_json TEXT NOT NULL,
+          ordinal INTEGER NOT NULL,
+          PRIMARY KEY (session_id, entry_id),
+          FOREIGN KEY (session_id) REFERENCES sessions(session_id) ON DELETE CASCADE
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_session_entries_session_ordinal
+          ON session_entries(session_id, ordinal);
+        CREATE INDEX IF NOT EXISTS idx_session_entries_parent
+          ON session_entries(session_id, parent_entry_id);
+
+        CREATE TABLE IF NOT EXISTS session_local_messages (
+          tab_id TEXT NOT NULL,
+          message_id TEXT NOT NULL,
+          role TEXT NOT NULL,
+          text TEXT,
+          thinking TEXT,
+          created_at INTEGER,
+          cwd TEXT,
+          payload_json TEXT NOT NULL,
+          PRIMARY KEY (tab_id, message_id),
+          FOREIGN KEY (tab_id) REFERENCES session_tabs(tab_id) ON DELETE CASCADE
+        );
+
+        CREATE VIRTUAL TABLE IF NOT EXISTS session_search_fts USING fts5(
+          tab_id UNINDEXED,
+          role UNINDEXED,
+          text,
+          timestamp UNINDEXED,
+          source UNINDEXED
+        );
+        "#,
+    )
+    .map_err(|e| format!("sqlite migrate: {e}"))?;
+    conn.execute(
+        "INSERT OR IGNORE INTO schema_migrations(version) VALUES (?1)",
+        params![CURRENT_SCHEMA],
+    )
+    .map_err(|e| format!("sqlite record migration: {e}"))?;
+    Ok(())
+}
+
+pub(crate) fn read_kv(
+    app: &AppHandle,
+    namespace: &str,
+    key: &str,
+) -> Result<Option<String>, String> {
+    let conn = connect(app)?;
+    conn.query_row(
+        "SELECT value FROM kv_store WHERE namespace = ?1 AND key = ?2",
+        params![namespace, key],
+        |row| row.get(0),
+    )
+    .optional()
+    .map_err(|e| format!("sqlite read kv {namespace}/{key}: {e}"))
+}
+
+pub(crate) fn write_kv(
+    app: &AppHandle,
+    namespace: &str,
+    key: &str,
+    value: &str,
+) -> Result<(), String> {
+    let conn = connect(app)?;
+    write_kv_conn(&conn, namespace, key, value)
+}
+
+fn write_kv_conn(conn: &Connection, namespace: &str, key: &str, value: &str) -> Result<(), String> {
+    conn.execute(
+        r#"
+        INSERT INTO kv_store(namespace, key, value, updated_at)
+        VALUES (?1, ?2, ?3, unixepoch() * 1000)
+        ON CONFLICT(namespace, key) DO UPDATE SET
+          value = excluded.value,
+          updated_at = excluded.updated_at
+        "#,
+        params![namespace, key, value],
+    )
+    .map_err(|e| format!("sqlite write kv {namespace}/{key}: {e}"))?;
+    Ok(())
+}
+
+pub(crate) fn read_state_value(app: &AppHandle, name: &str) -> Result<Option<String>, String> {
+    validate_state_name(name)?;
+    if let Some(value) = read_kv(app, KV_NAMESPACE_STATE, name)? {
+        return Ok(Some(value));
+    }
+    let path = legacy_state_file_path(app, name)?;
+    match std::fs::read_to_string(&path) {
+        Ok(value) => {
+            write_kv(app, KV_NAMESPACE_STATE, name, &value)?;
+            Ok(Some(value))
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(format!("read {}: {e}", path.display())),
+    }
+}
+
+pub(crate) fn write_state_value(app: &AppHandle, name: &str, value: &str) -> Result<(), String> {
+    validate_state_name(name)?;
+    write_kv(app, KV_NAMESPACE_STATE, name, value)
+}
+
+fn import_legacy_state_files_from_dir(dir: &Path, conn: &Connection) -> Result<(), String> {
+    for name in LEGACY_STATE_FILES {
+        let exists: Option<i64> = conn
+            .query_row(
+                "SELECT 1 FROM kv_store WHERE namespace = ?1 AND key = ?2",
+                params![KV_NAMESPACE_STATE, name],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(|e| format!("sqlite check legacy {name}: {e}"))?;
+        if exists.is_some() {
+            continue;
+        }
+        let path = dir.join(name);
+        let Ok(raw) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        write_kv_conn(conn, KV_NAMESPACE_STATE, name, &raw)?;
+    }
+    import_projects_json_from_dir(dir, conn)?;
+    Ok(())
+}
+
+fn import_projects_json_from_dir(dir: &Path, conn: &Connection) -> Result<(), String> {
+    let raw: Option<String> = conn
+        .query_row(
+            "SELECT value FROM kv_store WHERE namespace = ?1 AND key = ?2",
+            params![KV_NAMESPACE_STATE, "projects.json"],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(|e| format!("sqlite read project registry: {e}"))?;
+    let raw = match raw {
+        Some(raw) if !raw.trim().is_empty() => raw,
+        _ => return Ok(()),
+    };
+    let parsed: serde_json::Value = match serde_json::from_str(&raw) {
+        Ok(value) => value,
+        Err(_) => return Ok(()),
+    };
+    let projects = parsed
+        .get("projects")
+        .and_then(|value| value.as_array())
+        .cloned()
+        .unwrap_or_default();
+    let workspaces = parsed
+        .get("workspacesByProject")
+        .or_else(|| parsed.get("worktreesByProject"))
+        .and_then(|value| value.as_object())
+        .cloned()
+        .unwrap_or_default();
+    for project in projects {
+        let Some(id) = project.get("id").and_then(|value| value.as_str()) else {
+            continue;
+        };
+        let Some(path) = project.get("path").and_then(|value| value.as_str()) else {
+            continue;
+        };
+        let label = project
+            .get("label")
+            .and_then(|value| value.as_str())
+            .unwrap_or("project");
+        let host_id = project.get("hostId").and_then(|value| value.as_str());
+        let last_used = project.get("lastUsed").and_then(|value| value.as_i64());
+        let data_dir = projects_dir_from_aethon_dir(dir).join(safe_project_data_dir(id));
+        std::fs::create_dir_all(&data_dir)
+            .map_err(|e| format!("create {}: {e}", data_dir.display()))?;
+        conn.execute(
+            r#"
+            INSERT INTO projects(id, label, path, host_id, data_dir, payload_json, last_used, updated_at)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, unixepoch() * 1000)
+            ON CONFLICT(id) DO UPDATE SET
+              label = excluded.label,
+              path = excluded.path,
+              host_id = excluded.host_id,
+              data_dir = excluded.data_dir,
+              payload_json = excluded.payload_json,
+              last_used = excluded.last_used,
+              updated_at = excluded.updated_at
+            "#,
+            params![
+                id,
+                label,
+                path,
+                host_id,
+                data_dir.to_string_lossy(),
+                project.to_string(),
+                last_used
+            ],
+        )
+        .map_err(|e| format!("sqlite import project {id}: {e}"))?;
+        if let Some(list) = workspaces.get(id).and_then(|value| value.as_array()) {
+            for workspace in list {
+                let Some(workspace_id) = workspace.get("id").and_then(|value| value.as_str())
+                else {
+                    continue;
+                };
+                let Some(workspace_path) = workspace.get("path").and_then(|value| value.as_str())
+                else {
+                    continue;
+                };
+                conn.execute(
+                    r#"
+                    INSERT INTO project_workspaces(id, project_id, path, payload_json, updated_at)
+                    VALUES (?1, ?2, ?3, ?4, unixepoch() * 1000)
+                    ON CONFLICT(project_id, id) DO UPDATE SET
+                      path = excluded.path,
+                      payload_json = excluded.payload_json,
+                      updated_at = excluded.updated_at
+                    "#,
+                    params![workspace_id, id, workspace_path, workspace.to_string()],
+                )
+                .map_err(|e| format!("sqlite import workspace {workspace_id}: {e}"))?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn safe_project_data_dir(project_id: &str) -> String {
+    let safe = sanitize_filename_segment(project_id);
+    if safe.is_empty() {
+        format!("project-{}", uuid::Uuid::new_v4().simple())
+    } else {
+        safe
+    }
+}
+
+fn migrate_project_data_dirs_from_dir(dir: &Path, conn: &Connection) -> Result<(), String> {
+    let reserved: HashSet<&str> = RESERVED_TOP_LEVEL_DIRS.iter().copied().collect();
+    let mut stmt = conn
+        .prepare("SELECT id, label, path, data_dir FROM projects")
+        .map_err(|e| format!("sqlite prepare project dirs: {e}"))?;
+    let projects = stmt
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+            ))
+        })
+        .map_err(|e| format!("sqlite query project dirs: {e}"))?;
+
+    for project in projects {
+        let (id, label, project_path, data_dir): (String, String, String, String) =
+            project.map_err(|e| format!("sqlite read project dir row: {e}"))?;
+        let dest = PathBuf::from(data_dir);
+        std::fs::create_dir_all(&dest).map_err(|e| format!("create {}: {e}", dest.display()))?;
+
+        let mut candidates = Vec::new();
+        candidates.push(sanitize_filename_segment(&label));
+        if let Some(base) = Path::new(&project_path)
+            .file_name()
+            .and_then(|name| name.to_str())
+        {
+            candidates.push(sanitize_filename_segment(base));
+        }
+        candidates.push(safe_project_data_dir(&id));
+        candidates.sort();
+        candidates.dedup();
+
+        for candidate in candidates {
+            if candidate.is_empty() || reserved.contains(candidate.as_str()) {
+                continue;
+            }
+            let source = dir.join(&candidate);
+            if !source.is_dir() || source == dest {
+                continue;
+            }
+            move_project_dir_contents(&source, &dest)?;
+            if std::fs::read_dir(&source)
+                .map(|mut entries| entries.next().is_none())
+                .unwrap_or(false)
+            {
+                let _ = std::fs::remove_dir(&source);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn move_project_dir_contents(source: &Path, dest: &Path) -> Result<(), String> {
+    for entry in std::fs::read_dir(source).map_err(|e| format!("read {}: {e}", source.display()))? {
+        let entry = entry.map_err(|e| format!("read {}: {e}", source.display()))?;
+        let file_name = entry.file_name();
+        let target = dest.join(&file_name);
+        if target.exists() {
+            tracing::warn!(
+                target: "aethon::storage",
+                "leaving project data item in place because destination exists: {}",
+                target.display()
+            );
+            continue;
+        }
+        std::fs::rename(entry.path(), &target).map_err(|e| {
+            format!(
+                "move {} -> {}: {e}",
+                entry.path().display(),
+                target.display()
+            )
+        })?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn file_backed_state_names_are_explicit() {
+        assert!(is_file_backed_state_name("config.toml"));
+        assert!(is_file_backed_state_name("system-prompt.md"));
+        assert!(!is_file_backed_state_name("projects.json"));
+    }
+
+    #[test]
+    fn safe_project_data_dir_sanitizes_ids() {
+        assert_eq!(safe_project_data_dir("project:one"), "project_one");
+        assert_eq!(safe_project_data_dir("aethon"), "aethon");
+    }
+
+    #[test]
+    fn sqlite_kv_round_trips() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("state").join("aethon.sqlite3");
+        let conn = connect_path(&path).unwrap();
+        write_kv_conn(&conn, "state", "theme", "dark").unwrap();
+        let value: Option<String> = conn
+            .query_row(
+                "SELECT value FROM kv_store WHERE namespace='state' AND key='theme'",
+                [],
+                |row| row.get(0),
+            )
+            .optional()
+            .unwrap();
+        assert_eq!(value.as_deref(), Some("dark"));
+    }
+
+    #[test]
+    fn initialize_imports_legacy_projects_and_moves_project_data_dirs() {
+        let temp = tempfile::tempdir().unwrap();
+        let aethon_dir = temp.path().join(".aethon");
+        std::fs::create_dir_all(&aethon_dir).unwrap();
+        std::fs::write(
+            aethon_dir.join("projects.json"),
+            r#"{
+              "schemaVersion": 5,
+              "projects": [
+                {
+                  "id": "project-one",
+                  "label": "Example Project",
+                  "path": "/Users/example/Projects/example-project",
+                  "lastUsed": 123
+                }
+              ],
+              "workspacesByProject": {
+                "project-one": [
+                  {
+                    "id": "main",
+                    "path": "/Users/example/Projects/example-project",
+                    "isMain": true
+                  }
+                ]
+              }
+            }"#,
+        )
+        .unwrap();
+        let legacy_project_dir = aethon_dir.join("Example_Project");
+        std::fs::create_dir_all(&legacy_project_dir).unwrap();
+        std::fs::write(legacy_project_dir.join("state.json"), "{}").unwrap();
+
+        initialize_dir(&aethon_dir).unwrap();
+
+        let db = connect_path(&db_path_from_aethon_dir(&aethon_dir)).unwrap();
+        let project_count: i64 = db
+            .query_row("SELECT COUNT(*) FROM projects", [], |row| row.get(0))
+            .unwrap();
+        let workspace_count: i64 = db
+            .query_row("SELECT COUNT(*) FROM project_workspaces", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(project_count, 1);
+        assert_eq!(workspace_count, 1);
+        assert!(
+            aethon_dir
+                .join("projects")
+                .join("project-one")
+                .join("state.json")
+                .is_file()
+        );
+        assert!(!legacy_project_dir.exists());
+    }
+
+    #[test]
+    fn project_data_dir_migration_keeps_conflicting_files_in_legacy_dir() {
+        let temp = tempfile::tempdir().unwrap();
+        let aethon_dir = temp.path().join(".aethon");
+        std::fs::create_dir_all(aethon_dir.join("conflict-project")).unwrap();
+        std::fs::write(aethon_dir.join("conflict-project").join("keep.json"), "old").unwrap();
+        std::fs::create_dir_all(aethon_dir.join("projects").join("conflict-project")).unwrap();
+        std::fs::write(
+            aethon_dir
+                .join("projects")
+                .join("conflict-project")
+                .join("keep.json"),
+            "new",
+        )
+        .unwrap();
+        std::fs::write(
+            aethon_dir.join("projects.json"),
+            r#"{
+              "schemaVersion": 5,
+              "projects": [
+                {
+                  "id": "conflict-project",
+                  "label": "conflict-project",
+                  "path": "/Users/example/Projects/conflict-project"
+                }
+              ]
+            }"#,
+        )
+        .unwrap();
+
+        initialize_dir(&aethon_dir).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(
+                aethon_dir
+                    .join("projects")
+                    .join("conflict-project")
+                    .join("keep.json")
+            )
+            .unwrap(),
+            "new"
+        );
+        assert_eq!(
+            std::fs::read_to_string(aethon_dir.join("conflict-project").join("keep.json")).unwrap(),
+            "old"
+        );
+    }
+}

--- a/src-tauri/src/window_state/persistence.rs
+++ b/src-tauri/src/window_state/persistence.rs
@@ -24,6 +24,15 @@ fn state_file_path(app: &AppHandle) -> Result<PathBuf, String> {
 }
 
 pub(super) fn load_store(app: &AppHandle) -> PersistedStore {
+    if let Ok(Some(s)) = crate::storage::read_state_value(app, STATE_FILE)
+        && !s.trim().is_empty()
+    {
+        let raw: PersistedStore = serde_json::from_str(&s).unwrap_or_else(|e| {
+            tracing::warn!(target: "aethon::window_state", "parse sqlite {STATE_FILE}: {e}");
+            PersistedStore::default()
+        });
+        return migrate(raw);
+    }
     let Ok(path) = state_file_path(app) else {
         return PersistedStore::default();
     };
@@ -40,9 +49,12 @@ pub(super) fn load_store(app: &AppHandle) -> PersistedStore {
 }
 
 pub(super) fn save_store(app: &AppHandle, store: &PersistedStore) -> Result<(), String> {
-    let path = state_file_path(app)?;
     let body = serde_json::to_string_pretty(store).map_err(|e| format!("serialize: {e}"))?;
-    std::fs::write(&path, body).map_err(|e| format!("write {}: {e}", path.display()))
+    crate::storage::write_state_value(app, STATE_FILE, &body).or_else(|err| {
+        tracing::warn!(target: "aethon::window_state", "sqlite write failed: {err}; writing legacy file");
+        let path = state_file_path(app)?;
+        std::fs::write(&path, body).map_err(|e| format!("write {}: {e}", path.display()))
+    })
 }
 
 #[cfg(test)]

--- a/src/hooks/bridgeMessageHandlers/sessionForked.test.ts
+++ b/src/hooks/bridgeMessageHandlers/sessionForked.test.ts
@@ -1,12 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const { invoke } = vi.hoisted(() => ({
-  invoke: vi.fn((..._args: unknown[]) => Promise.resolve(undefined)),
-}));
-vi.mock("@tauri-apps/api/core", () => ({
-  invoke: (...args: unknown[]) => invoke(...args),
-}));
-
 import { handleSessionForked } from "./sessionForked";
 import { buildHandlerFixture } from "./testFixtures";
 import { handleSessionBranch } from "../../eventRoutes/session";
@@ -15,32 +8,22 @@ import { buildRouteFixture } from "../../eventRoutes/testFixtures";
 afterEach(() => vi.clearAllMocks());
 
 describe("handleSessionForked", () => {
-  it("copies the forked session file then opens the new tab", async () => {
-    invoke.mockResolvedValue(undefined);
+  it("opens the new tab from SQLite state", () => {
     const { ctx, mocks } = buildHandlerFixture();
     handleSessionForked(
       {
         type: "session_forked",
         tabId: "t1",
         newTabId: "t2",
-        sourcePath: "/s/x.jsonl",
         label: "Fork of foo",
         cwd: "/proj",
       },
       ctx,
     );
-    await vi.waitFor(() =>
-      expect(invoke).toHaveBeenCalledWith("copy_session_file", {
-        sourcePath: "/s/x.jsonl",
-        destTabId: "t2",
-      }),
-    );
-    await vi.waitFor(() =>
-      expect(mocks.newTab).toHaveBeenCalledWith("t2", "Fork of foo", {
-        restoredSession: true,
-        cwd: "/proj",
-      }),
-    );
+    expect(mocks.newTab).toHaveBeenCalledWith("t2", "Fork of foo", {
+      restoredSession: true,
+      cwd: "/proj",
+    });
     expect(mocks.dismissNotification).toHaveBeenCalledWith("session-fork-t1");
     expect(mocks.pushNotification).toHaveBeenCalledWith({
       title: "Forked session",
@@ -50,33 +33,7 @@ describe("handleSessionForked", () => {
     });
   });
 
-  it("does not open a tab when the copy fails", async () => {
-    invoke.mockRejectedValueOnce(new Error("boom"));
-    const { ctx, mocks } = buildHandlerFixture();
-    handleSessionForked(
-      {
-        type: "session_forked",
-        tabId: "t1",
-        newTabId: "t2",
-        sourcePath: "/s/x.jsonl",
-        label: "Fork",
-      },
-      ctx,
-    );
-    await vi.waitFor(() => expect(mocks.pushNotification).toHaveBeenCalled());
-    expect(mocks.dismissNotification).toHaveBeenCalledWith("session-fork-t1");
-    expect(mocks.pushNotification).toHaveBeenCalledWith(
-      expect.objectContaining({
-        title: "Fork failed",
-        message: "Couldn't copy the forked session: boom",
-        kind: "error",
-      }),
-    );
-    expect(mocks.newTab).not.toHaveBeenCalled();
-  });
-
-  it("clears the fork debounce after the frontend copy succeeds", async () => {
-    invoke.mockResolvedValue(undefined);
+  it("clears the fork debounce after the fork event arrives", async () => {
     const route = buildRouteFixture({ state: { activeTabId: "source-tab" } });
     const payload = {
       component: { id: "chat", type: "chat-history" },
@@ -93,54 +50,18 @@ describe("handleSessionForked", () => {
         type: "session_forked",
         tabId: "source-tab",
         newTabId: "fork-tab",
-        sourcePath: "/s/fork.jsonl",
         label: "Fork",
       },
       ctx,
-    );
-    await vi.waitFor(() => expect(invoke).toHaveBeenCalled());
-
-    expect(await handleSessionBranch(payload, route.ctx)).toBe(true);
-    expect(route.mocks.invoke).toHaveBeenCalledTimes(2);
-  });
-
-  it("clears the fork debounce after the frontend copy fails", async () => {
-    invoke.mockRejectedValueOnce(new Error("copy failed"));
-    const route = buildRouteFixture({ state: { activeTabId: "source-fail" } });
-    const payload = {
-      component: { id: "chat", type: "chat-history" },
-      eventType: "fork-to-tab",
-      data: { entryId: "entry-fail" },
-    };
-    expect(await handleSessionBranch(payload, route.ctx)).toBe(true);
-    expect(await handleSessionBranch(payload, route.ctx)).toBe(true);
-    expect(route.mocks.invoke).toHaveBeenCalledTimes(1);
-
-    const { ctx } = buildHandlerFixture();
-    handleSessionForked(
-      {
-        type: "session_forked",
-        tabId: "source-fail",
-        newTabId: "fork-fail",
-        sourcePath: "/s/fork-fail.jsonl",
-        label: "Fork",
-      },
-      ctx,
-    );
-    await vi.waitFor(() =>
-      expect(ctx.pushNotification).toHaveBeenCalledWith(
-        expect.objectContaining({ title: "Fork failed" }),
-      ),
     );
 
     expect(await handleSessionBranch(payload, route.ctx)).toBe(true);
     expect(route.mocks.invoke).toHaveBeenCalledTimes(2);
   });
 
-  it("ignores a message missing newTabId or sourcePath", () => {
+  it("ignores a message missing newTabId", () => {
     const { ctx, mocks } = buildHandlerFixture();
     handleSessionForked({ type: "session_forked", tabId: "t1" }, ctx);
-    expect(invoke).not.toHaveBeenCalled();
     expect(mocks.newTab).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/bridgeMessageHandlers/sessionForked.ts
+++ b/src/hooks/bridgeMessageHandlers/sessionForked.ts
@@ -1,52 +1,26 @@
-import { invoke } from "@tauri-apps/api/core";
 import type { BridgeMessageHandler } from "./types";
 import { clearPendingForksForTab } from "../../eventRoutes/session";
 
-function errMessage(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
-}
-
-/**
- * The bridge extracted a branch into a new session file (`sourcePath`) and
- * allocated `newTabId`. We move that file into the new tab's session dir via
- * the FS-safe `copy_session_file` command, then open the tab with its restored
- * history. The bridge can't invoke Tauri or open tabs, so this lands here.
- */
+/** The bridge forked the SQLite-backed session and allocated `newTabId`.
+ * Pi's default session file is a sidecar only; Aethon opens the new tab from
+ * SQLite state and never copies/reads pi session files. */
 export const handleSessionForked: BridgeMessageHandler = (data, ctx) => {
   const newTabId = typeof data.newTabId === "string" ? data.newTabId : "";
-  const sourcePath = typeof data.sourcePath === "string" ? data.sourcePath : "";
   const label = typeof data.label === "string" ? data.label : "Fork";
   const cwd = typeof data.cwd === "string" ? data.cwd : undefined;
   const sourceTabId = typeof data.tabId === "string" ? data.tabId : "";
-  if (!newTabId || !sourcePath) return;
+  if (!newTabId) return;
 
-  void (async () => {
-    try {
-      await invoke("copy_session_file", { sourcePath, destTabId: newTabId });
-    } catch (err) {
-      // Don't open a tab pointing at a session file that never landed.
-      if (sourceTabId) {
-        clearPendingForksForTab(sourceTabId);
-        ctx.dismissNotification(`session-fork-${sourceTabId}`);
-      }
-      ctx.pushNotification({
-        title: "Fork failed",
-        message: `Couldn't copy the forked session: ${errMessage(err)}`,
-        kind: "error",
-      });
-      return;
-    }
-    ctx.newTab(newTabId, label, {
-      restoredSession: true,
-      ...(cwd ? { cwd } : {}),
-    });
-    if (sourceTabId) ctx.dismissNotification(`session-fork-${sourceTabId}`);
-    if (sourceTabId) clearPendingForksForTab(sourceTabId);
-    ctx.pushNotification({
-      title: "Forked session",
-      message: `Opened ${label}.`,
-      kind: "success",
-      durationMs: 3000,
-    });
-  })();
+  ctx.newTab(newTabId, label, {
+    restoredSession: true,
+    ...(cwd ? { cwd } : {}),
+  });
+  if (sourceTabId) ctx.dismissNotification(`session-fork-${sourceTabId}`);
+  if (sourceTabId) clearPendingForksForTab(sourceTabId);
+  ctx.pushNotification({
+    title: "Forked session",
+    message: `Opened ${label}.`,
+    kind: "success",
+    durationMs: 3000,
+  });
 };

--- a/website/guide/configuration.md
+++ b/website/guide/configuration.md
@@ -88,23 +88,24 @@ falls back unknown enum values to safe defaults.
 ├── config.toml            # this file
 ├── agents/                # user-scope subagent definitions (<name>.md)
 ├── extensions/            # installed extension packages
-├── sessions/<tabId>/      # one pi session per agent tab
 ├── auth/                  # auth-profile metadata + per-profile credentials
 ├── logs/                  # daily-rotating Rust + bridge logs
-├── state.json             # tab / layout snapshot
-├── window-state.json      # window geometry restore
+├── state/aethon.sqlite3   # canonical app state, projects, sessions, caches
+├── projects/<projectId>/  # Aethon-managed per-project data
+├── state.json             # debug/runtime snapshot export
 ├── system-prompt.md       # optional full system-prompt override
 ├── system-prompt-append.md# optional system-prompt append
 ├── devshell-cache/        # resolved Nix devshell snapshots
-├── updates/               # update backups for boot-probation rollback
-└── projects.json          # recent project list
+└── updates/               # update backups for boot-probation rollback
 ```
 
 The hand-editable ones are `config.toml`, the subagent definitions under
 `agents/` (see [Agents](/guide/agents#subagents)), and the system-prompt
 override / append files (see
 [Agents](/guide/agents#system-prompt-customization)). The rest are managed
-by Aethon.
+by Aethon. Pi may also write its own session files in pi's default session
+directory so a conversation can be picked up from pi later, but Aethon restores
+its application state from SQLite.
 
 ## Set a theme
 

--- a/website/guide/projects.md
+++ b/website/guide/projects.md
@@ -24,8 +24,9 @@ Three ways to register a new project:
 2. **Command palette** (`Cmd+Shift+P`) → search "project" → **Add project…**
 3. **Slash command** → `/project /absolute/path/to/repo` — adds and activates.
 
-The project list is persisted at `~/.aethon/projects.json`. Maximum
-**16 entries**, MRU-ordered: opening a project moves it to the top.
+The project list is persisted in `~/.aethon/state/aethon.sqlite3`. Maximum
+**16 entries**, MRU-ordered: opening a project moves it to the top. Aethon
+stores generated per-project data under `~/.aethon/projects/<projectId>/`.
 
 ## Active project vs tab project
 

--- a/website/guide/quick-start.md
+++ b/website/guide/quick-start.md
@@ -15,7 +15,8 @@ To open a different project:
 - **Command palette** → `Cmd+Shift+P` → search the project name → press Enter.
 - **Slash command** → type `/project /path/to/repo` in the chat composer.
 
-The project list lives at `~/.aethon/projects.json` (MRU-ordered, max 16).
+The project list lives in `~/.aethon/state/aethon.sqlite3` (MRU-ordered,
+max 16), with generated project data under `~/.aethon/projects/<projectId>/`.
 Switching the active project affects **new tabs only** — existing tabs
 keep the cwd they were created with.
 

--- a/website/reference/runtime-api.md
+++ b/website/reference/runtime-api.md
@@ -123,8 +123,10 @@ extension keeps running.
 
 ## Runtime snapshot
 
-`aethon.getRuntimeSnapshot()` returns the same data Aethon writes to
-`~/.aethon/state.json` on every change (debounced 200 ms). It contains:
+`aethon.getRuntimeSnapshot()` returns the same data Aethon exports to
+`~/.aethon/state.json` on every change (debounced 200 ms). SQLite at
+`~/.aethon/state/aethon.sqlite3` is the canonical app-state store; this JSON
+file is a compatibility/debug snapshot. It contains:
 
 - Loaded extensions, themes, custom components.
 - Active layout summary.


### PR DESCRIPTION
## Summary

This PR moves Aethon-managed application state to a canonical SQLite database at `~/.aethon/state/aethon.sqlite3` and introduces `~/.aethon/projects/<project-id>/` as the generated per-project data root.

The migration keeps user-authored files such as `config.toml`, system prompts, and `ai-tools.md` as plain editable files, while routing app-managed JSON state through SQLite. It also preserves pi's default session files as writable sidecars for future pickup, metrics, and analytics, but stops using those files as Aethon's application source of truth.

## What changed

- Added a Rust SQLite storage layer (`src-tauri/src/storage.rs`) with schema initialization, WAL/foreign-key pragmas, key-value state storage, project/workspace tables, and session/search tables.
- Migrated `read_state` / `write_state` so app-managed state goes through SQLite while user-authored config/prompt files stay file-backed.
- Moved window state, native windows, scheduler state, startup project lookup, and session search/delete flows onto SQLite-backed state.
- Added `AETHON_DB_FILE` and `AETHON_PROJECTS_DIR` bridge environment variables.
- Added `agent/session-sqlite.ts` to make SQLite the canonical Aethon session store while hydrating pi sidecar files from SQLite for pi continuity.
- Imported legacy `~/.aethon/sessions/<tabId>/*.jsonl` and `aethon-chat.jsonl` data into SQLite so existing users do not lose restore/search history.
- Preserved cwd-scoped default-tab restore/fork behavior, including realpath-aware cwd matching for symlink-equivalent paths.
- Preserved active branch rollback state via `current_leaf_entry_id` so abandoned branches do not reappear after restart.
- Made forked sessions restore from SQLite and index their copied history for cross-session search.
- Made local-chat FTS indexing idempotent and rebuilt from canonical local-message rows to avoid duplicated/stale search rows.
- Removed the old frontend copy-session-file flow for session forks.
- Updated docs/AGENTS guidance for the new SQLite and `projects/` layout.

## User impact

Existing users keep their top-level `.aethon` project registry and session files, but app-managed state is now imported into SQLite. Project data directories that previously lived directly under `~/.aethon/<project-label>` are moved under `~/.aethon/projects/<project-id>/` when they match a persisted project label, checkout basename, or project id.

Pi session files are still written in pi's normal locations as sidecars. Aethon no longer treats those sidecars as source-of-truth for app restore/search; it restores from SQLite and regenerates sidecars from SQLite as needed.

## Restore performed locally

On my local Aethon profile, I restored/imported the existing backup/live state into SQLite and verified:

- 12 projects
- 13 workspaces
- 12 project data dirs under `~/.aethon/projects/`
- 377 imported session tabs
- 387 imported sessions
- 44,321 imported session entries

## Review notes

Codex peer review found several migration edge cases during the work, and this PR includes fixes for them:

- Existing legacy JSONL sessions being hidden after SQLite became available.
- Default-tab restore/fork leaking across projects when cwd scoping was missing.
- Rollback branch state not being honored on restore.
- Fork success being reported before SQLite state was copied.
- Stale/duplicated FTS rows for local chat.
- Legacy session mtime ordering being overwritten by import time.
- Forked sessions not being searchable.
- SQLite restore bypassing the legacy local-vs-pi merge/dedupe logic.
- Symlink-equivalent cwd paths not matching after migration.

## Validation

- `bun run lint && bun run typecheck`
- `bunx vitest run`
- `cargo clippy --manifest-path src-tauri/Cargo.toml -p aethon -- -D warnings`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib storage -- --nocapture`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib`
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- `git diff --check`
- Direct Bun smoke tests for:
  - SQLite legacy session import
  - mtime-ordered restore
  - cwd-scoped restore
  - active branch restore
  - idempotent local-chat FTS import
  - forked-session search indexing
  - realpath-aware cwd matching
  - SQLite restore using legacy merge/dedupe behavior
