### PR TITLE
fix(state): ignore legacy Aethon session roots

### DIFF
--- a/agent/session-sqlite.test.ts
+++ b/agent/session-sqlite.test.ts
@@ -1,0 +1,117 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  listSqliteDiscoveredTabs,
+  readSqliteSessionMetadata,
+  setSqliteDatabaseCtorForTests,
+} from "./session-sqlite";
+
+type SessionTabRow = {
+  tab_id: string;
+  cwd: string;
+  custom_label: string;
+  first_user_message: string;
+  last_modified: number;
+};
+
+let root: string;
+let previousDbFile: string | undefined;
+let rows: SessionTabRow[];
+
+class FakeDatabase {
+  constructor(_path: string) {}
+
+  exec(_sql: string): void {}
+
+  query(sql: string) {
+    if (sql.includes("FROM session_tabs WHERE tab_id = ?")) {
+      return {
+        get: (tabId: string) =>
+          rows.find((row) => row.tab_id === tabId) ?? null,
+        all: () => [],
+        run: () => undefined,
+      };
+    }
+    if (sql.includes("FROM session_tabs ORDER BY last_modified DESC")) {
+      return {
+        get: () => null,
+        all: () =>
+          [...rows].sort((a, b) => b.last_modified - a.last_modified),
+        run: () => undefined,
+      };
+    }
+    throw new Error(`unexpected SQL in fake database: ${sql}`);
+  }
+
+  close(): void {}
+}
+
+beforeEach(() => {
+  previousDbFile = process.env.AETHON_DB_FILE;
+  root = mkdtempSync(join(tmpdir(), "aethon-session-sqlite-"));
+  process.env.AETHON_DB_FILE = join(root, "state.sqlite3");
+  rows = [];
+  setSqliteDatabaseCtorForTests(FakeDatabase);
+});
+
+afterEach(() => {
+  setSqliteDatabaseCtorForTests(undefined);
+  if (previousDbFile === undefined) {
+    delete process.env.AETHON_DB_FILE;
+  } else {
+    process.env.AETHON_DB_FILE = previousDbFile;
+  }
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("SQLite session metadata", () => {
+  it("reports cwdExists for individual session metadata and discovered tabs", () => {
+    const existingCwd = join(root, "existing-workspace");
+    const missingCwd = join(root, "missing-workspace");
+    mkdirSync(existingCwd);
+    rows = [
+      {
+        tab_id: "missing-tab",
+        cwd: missingCwd,
+        custom_label: "missing-tab label",
+        first_user_message: "missing-tab first",
+        last_modified: 1000,
+      },
+      {
+        tab_id: "existing-tab",
+        cwd: existingCwd,
+        custom_label: "existing-tab label",
+        first_user_message: "existing-tab first",
+        last_modified: 2000,
+      },
+    ];
+
+    expect(readSqliteSessionMetadata("existing-tab")).toMatchObject({
+      cwd: existingCwd,
+      cwdExists: true,
+      customLabel: "existing-tab label",
+      firstUserMessage: "existing-tab first",
+      lastModified: 2000,
+    });
+    expect(readSqliteSessionMetadata("missing-tab")).toMatchObject({
+      cwd: missingCwd,
+      cwdExists: false,
+      lastModified: 1000,
+    });
+
+    expect(listSqliteDiscoveredTabs()).toEqual([
+      expect.objectContaining({
+        tabId: "existing-tab",
+        cwd: existingCwd,
+        cwdExists: true,
+      }),
+      expect.objectContaining({
+        tabId: "missing-tab",
+        cwd: missingCwd,
+        cwdExists: false,
+      }),
+    ]);
+  });
+});

--- a/agent/session-sqlite.ts
+++ b/agent/session-sqlite.ts
@@ -67,6 +67,10 @@ function sqliteDatabaseCtor(): DatabaseCtor | undefined {
   }
 }
 
+export function setSqliteDatabaseCtorForTests(ctor: DatabaseCtor | undefined): void {
+  databaseCtor = ctor;
+}
+
 function dbPath(): string | undefined {
   const path = process.env.AETHON_DB_FILE;
   return typeof path === "string" && path.length > 0 ? path : undefined;
@@ -187,6 +191,16 @@ function rowNumber(row: Record<string, unknown> | null, key: string): number | u
 function normalizeOptionalCwd(cwd: string | undefined): string | undefined {
   const normalized = normalizeCwd(cwd);
   return normalized && normalized.length > 0 ? normalized : undefined;
+}
+
+function cwdExists(cwd: string | undefined): boolean | undefined {
+  const normalized = normalizeOptionalCwd(cwd);
+  if (!normalized) return undefined;
+  try {
+    return statSync(normalized).isDirectory();
+  } catch {
+    return false;
+  }
 }
 
 function sessionMatchesCwd(sessionCwd: string | undefined, expectedCwd: string | undefined): boolean {
@@ -584,9 +598,11 @@ export function readSqliteSessionMetadata(tabId: string): SessionLogMetadata | n
   if (!db) return null;
   const row = db.query("SELECT cwd, custom_label, first_user_message, last_modified FROM session_tabs WHERE tab_id = ?").get(tabId);
   if (!row) return null;
+  const cwd = rowString(row, "cwd");
+  const exists = cwdExists(cwd);
   return {
     lastModified: typeof row.last_modified === "number" ? row.last_modified : nowMs(),
-    ...(rowString(row, "cwd") ? { cwd: rowString(row, "cwd") } : {}),
+    ...(cwd ? { cwd, cwdExists: exists } : {}),
     ...(rowString(row, "first_user_message") ? { firstUserMessage: rowString(row, "first_user_message") } : {}),
     ...(rowString(row, "custom_label") ? { customLabel: rowString(row, "custom_label") } : {}),
   };
@@ -601,10 +617,12 @@ export function listSqliteDiscoveredTabs(): Array<{ tabId: string } & SessionLog
     .flatMap((row) => {
       const tabId = rowString(row, "tab_id");
       if (!tabId) return [];
+      const cwd = rowString(row, "cwd");
+      const exists = cwdExists(cwd);
       return [{
         tabId,
         lastModified: typeof row.last_modified === "number" ? row.last_modified : nowMs(),
-        ...(rowString(row, "cwd") ? { cwd: rowString(row, "cwd") } : {}),
+        ...(cwd ? { cwd, cwdExists: exists } : {}),
         ...(rowString(row, "first_user_message") ? { firstUserMessage: rowString(row, "first_user_message") } : {}),
         ...(rowString(row, "custom_label") ? { customLabel: rowString(row, "custom_label") } : {}),
       }];

--- a/src/app/AppRoot.test.tsx
+++ b/src/app/AppRoot.test.tsx
@@ -134,4 +134,38 @@ describe("AppRoot workspace startup overlay", () => {
     expect(canvasCell?.contains(startupHost)).toBe(true);
     expect(sidebarCell?.contains(startup)).toBe(false);
   });
+
+  it("does not render workspace startup as the full-window boot curtain", () => {
+    render(
+      <AppRoot
+        registry={registry()}
+        layout={layoutPayload()}
+        renderState={{}}
+        setState={noop}
+        onEvent={noop}
+        activeTabId="default"
+        notificationsOpen={false}
+        paletteOpen={false}
+        settingsOpen={false}
+        searchOpen={false}
+        authProfilesOpen={false}
+        scheduledTasksOpen={false}
+        chromeReady={false}
+        startupLogoUrl="/logo.svg"
+        workspaceStartup={{
+          output: "",
+          entry: {
+            root: "/repo",
+            fingerprint: "abc",
+            state: "running",
+            approved: true,
+            commands: [],
+          },
+        }}
+      />,
+    );
+
+    expect(screen.queryByText("Preparing Workspace")).toBeNull();
+    expect(screen.queryByText("/repo")).toBeNull();
+  });
 });

--- a/src/app/AppRoot.tsx
+++ b/src/app/AppRoot.tsx
@@ -147,7 +147,6 @@ export function AppRoot({
         ) : (
           <StartupCurtain
             logoUrl={startupLogoUrl}
-            startup={workspaceStartup}
             onApprove={onStartupApprove}
             onRetry={onStartupRetry}
             onContinue={onStartupContinue}

--- a/src/hooks/bridgeMessageHandlers/ready.test.ts
+++ b/src/hooks/bridgeMessageHandlers/ready.test.ts
@@ -540,7 +540,7 @@ describe("handleReady", () => {
       "default",
       "/tmp/p1",
     );
-    expect(mocks.markStartupChromeReady).not.toHaveBeenCalled();
+    expect(mocks.markStartupChromeReady).toHaveBeenCalledTimes(1);
   });
 
   it("does not re-announce the active project when ready already reports that cwd", () => {

--- a/src/hooks/bridgeMessageHandlers/readyEffects.test.ts
+++ b/src/hooks/bridgeMessageHandlers/readyEffects.test.ts
@@ -77,6 +77,46 @@ describe("runReadyEffects", () => {
     );
   });
 
+  it("does not replay restored tabs rooted in legacy top-level .aethon state", async () => {
+    const { ctx } = buildHandlerFixture({
+      state: {
+        tabs: [
+          {
+            id: "state-root",
+            label: "State Root",
+            cwd: "/Users/jamesbrink/.aethon",
+          },
+          {
+            id: "legacy-project",
+            label: "Legacy Project",
+            cwd: "/Users/jamesbrink/.aethon/aethon/fix-old-worktree",
+          },
+          {
+            id: "managed-project",
+            label: "Managed Project",
+            cwd: "/Users/jamesbrink/.aethon/projects/project-id/worktree",
+          },
+        ],
+      },
+    });
+    ctx.prepareWorkspaceStartup = vi.fn().mockResolvedValue(true);
+
+    runReadyEffects(ctx, {
+      currentProjectCwd: null,
+      priorActiveTabCwd: null,
+      priorActiveTabId: "default",
+    });
+
+    expect(ctx.pendingTabOpens.current.has("state-root")).toBe(false);
+    expect(ctx.pendingTabOpens.current.has("legacy-project")).toBe(false);
+    expect(ctx.pendingTabOpens.current.has("managed-project")).toBe(true);
+    await ctx.pendingTabOpens.current.get("managed-project");
+    expect(ctx.prepareWorkspaceStartup).toHaveBeenCalledTimes(1);
+    expect(ctx.prepareWorkspaceStartup).toHaveBeenCalledWith(
+      "/Users/jamesbrink/.aethon/projects/project-id/worktree",
+    );
+  });
+
   it("re-announces the active path or marks startup chrome ready", () => {
     const { ctx, mocks } = buildHandlerFixture();
     ctx.projectsRef.current = {
@@ -97,15 +137,43 @@ describe("runReadyEffects", () => {
       "default",
       "/repo/p1",
     );
-    expect(mocks.markStartupChromeReady).not.toHaveBeenCalled();
+    expect(mocks.markStartupChromeReady).toHaveBeenCalledTimes(1);
 
     mocks.announceProjectToBridge.mockClear();
+    mocks.markStartupChromeReady.mockClear();
     runReadyEffects(ctx, {
       currentProjectCwd: "/repo/p1",
       priorActiveTabCwd: null,
       priorActiveTabId: "default",
     });
     expect(mocks.announceProjectToBridge).not.toHaveBeenCalled();
+    expect(mocks.markStartupChromeReady).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not re-announce a prior active tab rooted in legacy top-level .aethon state", () => {
+    const { ctx, mocks } = buildHandlerFixture();
+    ctx.projectsRef.current = {
+      activeId: "p1",
+      activeWorkspaceId: null,
+      activeHostId: null,
+      projects: [{ id: "p1", label: "p1", path: "/repo/p1", lastUsed: 1 }],
+      workspacesByProject: {},
+    };
+
+    runReadyEffects(ctx, {
+      currentProjectCwd: "/wrong",
+      priorActiveTabCwd: "/Users/jamesbrink/.aethon",
+      priorActiveTabId: "state-root",
+    });
+
+    expect(mocks.announceProjectToBridge).toHaveBeenCalledWith(
+      "state-root",
+      "/repo/p1",
+    );
+    expect(mocks.announceProjectToBridge).not.toHaveBeenCalledWith(
+      "state-root",
+      "/Users/jamesbrink/.aethon",
+    );
     expect(mocks.markStartupChromeReady).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/hooks/bridgeMessageHandlers/readyEffects.ts
+++ b/src/hooks/bridgeMessageHandlers/readyEffects.ts
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { activeCwd } from "../../projects";
+import { isLegacyAethonStateCwd } from "../../state/sessionUiSnapshot";
 import type { Tab } from "../../types/tab";
 import type { BridgeMessageContext } from "./types";
 
@@ -18,6 +19,7 @@ function replayRestoredAgentTabs(ctx: BridgeMessageContext): void {
       ? ctx.projectsRef.current.projects.find((p) => p.id === t.projectId)
       : null;
     const restoredCwd = t.cwd ?? tabProject?.path;
+    if (restoredCwd && isLegacyAethonStateCwd(restoredCwd)) continue;
     const opening = (async () => {
       if (restoredCwd && ctx.prepareWorkspaceStartup) {
         const ready = await ctx.prepareWorkspaceStartup(restoredCwd);
@@ -51,12 +53,15 @@ function finishProjectAnnouncement(
   input: ReadyEffectsInput,
 ): void {
   const projectActivePath = activeCwd(ctx.projectsRef.current);
+  const priorActiveTabCwd =
+    input.priorActiveTabCwd && !isLegacyAethonStateCwd(input.priorActiveTabCwd)
+      ? input.priorActiveTabCwd
+      : null;
   const activePath = ctx.projectsRef.current.activeWorkspaceId
     ? projectActivePath
-    : (input.priorActiveTabCwd ?? projectActivePath);
+    : (priorActiveTabCwd ?? projectActivePath);
   if (activePath && input.currentProjectCwd !== activePath) {
     ctx.announceProjectToBridge(input.priorActiveTabId, activePath);
-    return;
   }
   ctx.markStartupChromeReady();
 }

--- a/src/hooks/tabOps/autoRestore.test.ts
+++ b/src/hooks/tabOps/autoRestore.test.ts
@@ -82,6 +82,46 @@ describe("autoRestoreDiscoveredSessions", () => {
     });
   });
 
+  it("does not restore legacy top-level .aethon state sessions", () => {
+    const newTab = vi.fn();
+    const autoRestore = useAutoRestoreDiscoveredSessions({
+      stateRef: ref({ tabs: [], closedSessionIds: [] }),
+      autoRestoredSessionIdsRef: ref(new Set<string>()),
+      pushNotification: vi.fn(),
+      newTab,
+    });
+
+    autoRestore(
+      [
+        {
+          tabId: "state-root",
+          lastModified: 1,
+          firstUserMessage: "Old state root",
+          cwd: "/Users/jamesbrink/.aethon",
+        },
+        {
+          tabId: "legacy-project",
+          lastModified: 2,
+          firstUserMessage: "Old project mirror",
+          cwd: "/Users/jamesbrink/.aethon/aethon/fix-old-worktree",
+        },
+        {
+          tabId: "managed-project",
+          lastModified: 3,
+          firstUserMessage: "Managed project",
+          cwd: "/Users/jamesbrink/.aethon/projects/project-id/worktree",
+        },
+      ],
+      new Set(),
+    );
+
+    expect(newTab).toHaveBeenCalledTimes(1);
+    expect(newTab).toHaveBeenCalledWith("managed-project", "Managed project", {
+      restoredSession: true,
+      cwd: "/Users/jamesbrink/.aethon/projects/project-id/worktree",
+    });
+  });
+
   it("does not restore already-open local tabs", () => {
     const newTab = vi.fn();
     const autoRestore = useAutoRestoreDiscoveredSessions({

--- a/src/hooks/tabOps/autoRestore.ts
+++ b/src/hooks/tabOps/autoRestore.ts
@@ -1,5 +1,6 @@
 import type { MutableRefObject } from "react";
 import type { Tab } from "../../types/tab";
+import { isLegacyAethonStateCwd } from "../../state/sessionUiSnapshot";
 import { sessionLabel } from "./helpers";
 import type { DiscoveredSession, NotificationInput } from "./types";
 
@@ -40,6 +41,7 @@ export function useAutoRestoreDiscoveredSessions(deps: AutoRestoreDeps) {
       .filter((d) => !closedSessionIds.has(d.tabId))
       .filter((d) => !autoRestoredSessionIdsRef.current.has(d.tabId))
       .filter((d) => d.cwdExists !== false)
+      .filter((d) => !d.cwd || !isLegacyAethonStateCwd(d.cwd))
       .slice(0, 8);
     if (toRestore.length === 0) return;
     // Open oldest first so the most recent session ends up active.

--- a/src/hooks/useWorkspaceStartup.test.tsx
+++ b/src/hooks/useWorkspaceStartup.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useEffect, useRef, useState } from "react";
+import { clearTauriMocks, installTauriMocks } from "../test/tauriMocks";
+import { useWorkspaceStartup } from "./useWorkspaceStartup";
+
+function useHarness(initial: Record<string, unknown>) {
+  const [state, setState] = useState<Record<string, unknown>>(initial);
+  const stateRef = useRef(state);
+  useEffect(() => {
+    stateRef.current = state;
+  }, [state]);
+  const startup = useWorkspaceStartup({ state, setState, stateRef });
+  return { state, startup };
+}
+
+describe("useWorkspaceStartup", () => {
+  let tauri: ReturnType<typeof installTauriMocks>;
+
+  beforeEach(() => {
+    tauri = installTauriMocks();
+  });
+
+  afterEach(() => {
+    clearTauriMocks();
+  });
+
+  it("clears the visible active root when a prepare status becomes ready", async () => {
+    tauri.invoke.mockResolvedValue({
+      root: "/repo",
+      fingerprint: "abc",
+      state: "ready",
+      approved: true,
+      commands: [
+        {
+          id: "aethon-devshell",
+          label: "Prepare environment",
+          required: false,
+          state: "ready",
+        },
+      ],
+    });
+    const { result } = renderHook(() =>
+      useHarness({
+        workspaceStartup: {
+          activeRoot: "/repo",
+          entries: {
+            "/repo": {
+              root: "/repo",
+              fingerprint: "abc",
+              state: "running",
+              approved: true,
+              commands: [],
+            },
+          },
+        },
+      }),
+    );
+
+    await act(async () => {
+      await result.current.startup.prepareWorkspaceStartup("/repo");
+    });
+
+    expect(result.current.state.workspaceStartup).toMatchObject({
+      activeRoot: null,
+      entries: {
+        "/repo": expect.objectContaining({ state: "ready" }),
+      },
+    });
+    expect(result.current.startup.view.entry).toBeNull();
+  });
+
+  it("clears the visible active root when a status event becomes ready", async () => {
+    const { result } = renderHook(() =>
+      useHarness({
+        workspaceStartup: {
+          activeRoot: "/repo",
+          entries: {
+            "/repo": {
+              root: "/repo",
+              fingerprint: "abc",
+              state: "running",
+              approved: true,
+              commands: [],
+            },
+          },
+        },
+      }),
+    );
+    await vi.waitFor(() =>
+      expect(tauri.handlers.has("workspace-startup-status")).toBe(true),
+    );
+
+    act(() => {
+      tauri.fireEvent("workspace-startup-status", {
+        root: "/repo",
+        fingerprint: "abc",
+        state: "ready",
+        taskId: "aethon-devshell",
+        taskLabel: "Prepare environment",
+        required: false,
+      });
+    });
+
+    expect(result.current.state.workspaceStartup).toMatchObject({
+      activeRoot: null,
+      entries: {
+        "/repo": expect.objectContaining({ state: "ready" }),
+      },
+    });
+    expect(result.current.startup.view.entry).toBeNull();
+  });
+});

--- a/src/hooks/useWorkspaceStartup.ts
+++ b/src/hooks/useWorkspaceStartup.ts
@@ -126,9 +126,10 @@ export function useWorkspaceStartup({
           workspaceStartup: {
             ...slice,
             activeRoot:
-              isVisibleStartupState(status.state) ||
-              slice.activeRoot === status.root
+              isVisibleStartupState(status.state)
                 ? status.root
+                : slice.activeRoot === status.root
+                  ? null
                 : slice.activeRoot,
             entries,
           },
@@ -301,7 +302,11 @@ function applyStartupEvent(
       ...prev,
       workspaceStartup: {
         ...slice,
-        activeRoot: isVisibleStartupState(state) ? root : slice.activeRoot,
+        activeRoot: isVisibleStartupState(state)
+          ? root
+          : slice.activeRoot === root
+            ? null
+            : slice.activeRoot,
         entries,
       },
     };

--- a/src/state/sessionUiSnapshot.test.ts
+++ b/src/state/sessionUiSnapshot.test.ts
@@ -3,6 +3,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { makeEmptyTab } from "../types/tab";
 import {
+  isLegacyAethonStateCwd,
   loadSessionUiSnapshot,
   parseSessionUiSnapshot,
   saveSessionUiSnapshot,
@@ -219,6 +220,109 @@ describe("sessionUiSnapshot", () => {
     expect(loaded?.buckets?.["project-1::workspace::wt-1"]?.tabs).toMatchObject(
       [{ id: "empty-bucket", label: "Empty Bucket", messages: [] }],
     );
+  });
+
+  it("drops restored session tabs from legacy top-level .aethon project paths", () => {
+    const parsed = parseSessionUiSnapshot(
+      JSON.stringify({
+        tabs: [
+          {
+            ...makeEmptyTab("legacy", "Legacy"),
+            cwd: "/Users/jamesbrink/.aethon/aethon/fix-old-worktree",
+          },
+          {
+            ...makeEmptyTab("state-root", "State Root", null, "shell"),
+            shell: {
+              cwd: "/Users/jamesbrink/.aethon",
+              command: "",
+              args: [],
+              shareMode: "private",
+              shellState: "running",
+            },
+          },
+          {
+            ...makeEmptyTab("managed", "Managed"),
+            cwd: "/Users/jamesbrink/.aethon/projects/project-id/worktree",
+          },
+          {
+            ...makeEmptyTab("managed-root", "Managed Root"),
+            cwd: "/Users/jamesbrink/.aethon/projects",
+          },
+          {
+            ...makeEmptyTab("normal", "Normal"),
+            cwd: "/Users/jamesbrink/Projects/utensils/aethon",
+          },
+        ],
+        activeTabId: "legacy",
+        savedAt: 1,
+      }),
+    );
+
+    expect(parsed?.tabs.map((tab) => tab.id)).toEqual([
+      "managed",
+      "managed-root",
+      "normal",
+    ]);
+    expect(parsed?.activeTabId).toBe("managed");
+  });
+
+  it("does not treat project-local .aethon folders as legacy app state", () => {
+    expect(isLegacyAethonStateCwd("/Users/jamesbrink/.aethon")).toBe(true);
+    expect(isLegacyAethonStateCwd("/home/james/.aethon/aethon/old")).toBe(
+      true,
+    );
+    expect(isLegacyAethonStateCwd("/Users/jamesbrink/.aethon/projects")).toBe(
+      false,
+    );
+    expect(
+      isLegacyAethonStateCwd("/Users/jamesbrink/.aethon/projects/project-id"),
+    ).toBe(false);
+    expect(
+      isLegacyAethonStateCwd("/Users/jamesbrink/Projects/foo/.aethon/sandbox"),
+    ).toBe(false);
+    expect(isLegacyAethonStateCwd("/tmp/.aethon/sandbox")).toBe(false);
+  });
+
+  it("drops legacy .aethon cwd tabs from persisted buckets", () => {
+    const parsed = parseSessionUiSnapshot(
+      JSON.stringify({
+        tabs: [],
+        activeTabId: "__overview__",
+        buckets: {
+          "project::workspace::legacy": {
+            activeTabId: "legacy-bucket",
+            tabs: [
+              {
+                ...makeEmptyTab("legacy-bucket", "Legacy Bucket"),
+                cwd: "/Users/jamesbrink/.aethon/mold/fix-old-worktree",
+              },
+            ],
+          },
+          "project::workspace::valid": {
+            activeTabId: "valid-bucket",
+            tabs: [
+              {
+                ...makeEmptyTab("valid-bucket", "Valid Bucket"),
+                cwd: "/Users/jamesbrink/Projects/utensils/mold",
+              },
+            ],
+          },
+        },
+        savedAt: 1,
+      }),
+    );
+
+    expect(parsed?.buckets).toEqual({
+      "project::workspace::valid": {
+        activeTabId: "valid-bucket",
+        tabs: [
+          expect.objectContaining({
+            id: "valid-bucket",
+            cwd: "/Users/jamesbrink/Projects/utensils/mold",
+          }),
+        ],
+      },
+    });
   });
 
   it("repairs timestamped message order and drops stale stop notices on restore", () => {

--- a/src/state/sessionUiSnapshot.ts
+++ b/src/state/sessionUiSnapshot.ts
@@ -94,6 +94,7 @@ function durableQueuedMessages(
 }
 
 function shouldPersistTab(tab: Tab): boolean {
+  if (hasNonRestorableSessionCwd(tab)) return false;
   if (tab.kind === "shell") return tab.shell != null;
   // Editor tabs persist so the user reopens to the same files. The
   // on-disk content is the source of truth on restore — dirty buffers
@@ -101,6 +102,32 @@ function shouldPersistTab(tab: Tab): boolean {
   // could surprise the user on next launch).
   if (tab.kind === "editor") return tab.editor?.filePath != null;
   return true;
+}
+
+function sessionCwd(tab: Tab): string | undefined {
+  return tab.kind === "shell" ? tab.shell?.cwd : tab.cwd;
+}
+
+function hasNonRestorableSessionCwd(tab: Tab): boolean {
+  if (tab.kind === "editor") return false;
+  const cwd = sessionCwd(tab);
+  return typeof cwd === "string" && isLegacyAethonStateCwd(cwd);
+}
+
+export function isLegacyAethonStateCwd(cwd: string): boolean {
+  const normalized = cwd.replace(/\\/g, "/").replace(/\/+$/, "");
+  const match =
+    /^((?:\/Users\/[^/]+|\/home\/[^/]+|[A-Za-z]:\/Users\/[^/]+)\/\.aethon)(?:\/|$)/.exec(
+      normalized,
+    );
+  if (!match) return false;
+  const after = normalized.slice(match[1].length);
+  return (
+    after === "" ||
+    (after.startsWith("/") &&
+      after !== "/projects" &&
+      !after.startsWith("/projects/"))
+  );
 }
 
 function restoreShellTab(tab: Tab, restartShellTabs: boolean): Tab {
@@ -317,14 +344,16 @@ function serializePersistedBuckets(
 /** Minimal structural validation for a persisted tab record. */
 function validTabsFrom(value: unknown): Tab[] {
   return Array.isArray(value)
-    ? value.filter((t): t is Tab => {
-        const candidate = t as Partial<Tab>;
-        return (
-          typeof candidate.id === "string" &&
-          typeof candidate.label === "string" &&
-          Array.isArray(candidate.messages)
-        );
-      })
+    ? value
+        .filter((t): t is Tab => {
+          const candidate = t as Partial<Tab>;
+          return (
+            typeof candidate.id === "string" &&
+            typeof candidate.label === "string" &&
+            Array.isArray(candidate.messages)
+          );
+        })
+        .filter((tab) => !hasNonRestorableSessionCwd(tab))
     : [];
 }
 


### PR DESCRIPTION
## Summary

Fixes the post-SQLite migration startup regression where restored legacy sessions rooted in old top-level `~/.aethon` project mirrors could take over app startup and leave the full-window workspace startup curtain blocking the entire app.

## What Changed

- Scope the full-window boot curtain so workspace startup state is not rendered as app-wide startup UI after chrome is ready.
- Always mark startup chrome ready after project reannounce, so bridge reannouncement cannot hold the whole app hostage.
- Clear `workspaceStartup.activeRoot` once a workspace reaches a terminal non-visible state such as `ready`, `continued`, or `disabled`.
- Drop non-editor restored tabs whose cwd is a legacy home-level Aethon state root:
  - `~/.aethon`
  - `~/.aethon/<old-project-mirror>/...`
  - preserves managed project paths under `~/.aethon/projects/...`
  - preserves legitimate project-local `.aethon` folders such as `/repo/.aethon/...`
- Prevent legacy `~/.aethon` cwd sessions from being replayed or auto-restored even if they are still discovered by the bridge.
- Add `cwdExists` metadata for SQLite-backed session discovery so stale/deleted workspace sessions are filtered consistently with the JSON session path.

## Peer Review Follow-up

Codex peer review found two issues before publish:

1. The initial legacy cwd predicate was too broad and matched any path containing `/.aethon`; this is now anchored to home-level Aethon state roots only.
2. SQLite `cwdExists` parity had no direct regression coverage; added focused coverage for `readSqliteSessionMetadata()` and `listSqliteDiscoveredTabs()`.

## Validation

- `bunx vitest run agent/session-sqlite.test.ts src/state/sessionUiSnapshot.test.ts src/hooks/useWorkspaceStartup.test.tsx src/app/AppRoot.test.tsx src/hooks/bridgeMessageHandlers/readyEffects.test.ts src/hooks/bridgeMessageHandlers/ready.test.ts src/hooks/tabOps/autoRestore.test.ts`
- `bunx eslint agent/session-sqlite.ts agent/session-sqlite.test.ts src/state/sessionUiSnapshot.ts src/state/sessionUiSnapshot.test.ts src/hooks/useWorkspaceStartup.ts src/hooks/useWorkspaceStartup.test.tsx src/app/AppRoot.tsx src/app/AppRoot.test.tsx src/hooks/bridgeMessageHandlers/readyEffects.ts src/hooks/bridgeMessageHandlers/readyEffects.test.ts src/hooks/bridgeMessageHandlers/ready.test.ts src/hooks/tabOps/autoRestore.ts src/hooks/tabOps/autoRestore.test.ts`
- `bun run typecheck`
- `git diff --check`

## Dev App UAT

Verified against the already-running dev app via the Aethon debug bridge at `http://localhost:1420/`.

Settled state after flushing the session UI snapshot and reloading:

```json
{
  "hasBootCurtain": false,
  "hasStartupCurtain": false,
  "hasWorkspaceStartupCurtain": false,
  "status": "ready",
  "connection": "connected",
  "tabCount": 54,
  "badCount": 0,
  "activeRoot": null,
  "visibleStartupEntries": 0
}
```

Note: UAT intentionally used the running dev app/debug bridge only. It did not launch `/Applications/Aethon.app`.
