### PR TITLE
feat(tray): show active sessions in status menu

### DIFF
--- a/src-tauri/src/commands/extensions/menu_items.rs
+++ b/src-tauri/src/commands/extensions/menu_items.rs
@@ -1,6 +1,6 @@
-//! Extension-registered menu items: the wire type, the persisted
-//! store, and the `set_extension_menu_items` Tauri command that
-//! rebuilds both the App menu and the tray on every push.
+//! Native menu/tray state: extension-registered menu items, active
+//! tray sessions, and the commands that rebuild native surfaces when
+//! the frontend pushes a new snapshot.
 
 use std::sync::Mutex;
 
@@ -28,12 +28,32 @@ pub struct ExtensionMenuItem {
     pub parent: Option<String>,
 }
 
-/// App-state container for extension menu items. The bridge can register
-/// items at any time; the frontend forwards each delta into
-/// `set_extension_menu_items`, which persists the latest list here and
-/// rebuilds the native menu.
+/// Frontend-supplied active agent session row for the tray menu.
+/// The Rust side only renders and dispatches the row; session
+/// ownership/routing stays in the React project/workspace model.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct TraySessionItem {
+    pub id: String,
+    pub label: String,
+    pub detail: Option<String>,
+    pub active: bool,
+    pub running: bool,
+    pub needs_attention: bool,
+    pub queued_count: u32,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct NativeMenuState {
+    pub extension_items: Vec<ExtensionMenuItem>,
+    pub tray_sessions: Vec<TraySessionItem>,
+}
+
+/// App-state container for native menu/tray inputs. Extension menu
+/// replays and session snapshot updates arrive independently, so keep
+/// both slices in one mutex and rebuild the affected surface from the
+/// combined latest state.
 #[derive(Default)]
-pub struct ExtensionMenuStore(pub Mutex<Vec<ExtensionMenuItem>>);
+pub struct ExtensionMenuStore(pub Mutex<NativeMenuState>);
 
 /// Replace the persisted set of extension-registered menu items and
 /// rebuild both the App menu and the tray menu so the new entries
@@ -47,12 +67,30 @@ pub fn set_extension_menu_items(
     store: State<'_, ExtensionMenuStore>,
 ) -> Result<(), String> {
     let mut guard = store.0.lock().map_err(|e| format!("lock: {e}"))?;
-    if *guard == items {
+    if guard.extension_items == items {
         return Ok(());
     }
     install_app_menu(&app, &items).map_err(|e| format!("install_app_menu: {e}"))?;
-    install_tray(&app, &items).map_err(|e| format!("install_tray: {e}"))?;
-    *guard = items;
+    install_tray(&app, &items, &guard.tray_sessions).map_err(|e| format!("install_tray: {e}"))?;
+    guard.extension_items = items;
+    Ok(())
+}
+
+/// Replace the active-session rows shown in the tray while preserving
+/// extension-registered tray items. The frontend sends a compact
+/// snapshot whenever tab/activity state changes.
+#[tauri::command]
+pub fn set_tray_sessions(
+    items: Vec<TraySessionItem>,
+    app: AppHandle,
+    store: State<'_, ExtensionMenuStore>,
+) -> Result<(), String> {
+    let mut guard = store.0.lock().map_err(|e| format!("lock: {e}"))?;
+    if guard.tray_sessions == items {
+        return Ok(());
+    }
+    install_tray(&app, &guard.extension_items, &items).map_err(|e| format!("install_tray: {e}"))?;
+    guard.tray_sessions = items;
     Ok(())
 }
 
@@ -85,7 +123,7 @@ mod tests {
             .unwrap_or(src.len());
         let body = &src[body_start..body_end];
         assert!(
-            body.contains("if *guard == items"),
+            body.contains("if guard.extension_items == items"),
             "set_extension_menu_items must return early when the frontend replays an unchanged menu payload",
         );
         assert!(
@@ -93,10 +131,35 @@ mod tests {
             "changed tray entries still need to reach install_tray so extension items appear",
         );
         let install_pos = body.find("install_tray(").unwrap();
-        let store_pos = body.find("*guard = items").unwrap();
+        let store_pos = body.find("guard.extension_items = items").unwrap();
         assert!(
             install_pos < store_pos,
             "the cached payload must be updated only after native menu/tray installation succeeds so retries are not skipped after an error",
+        );
+    }
+
+    #[test]
+    fn set_tray_sessions_preserves_extension_items() {
+        let src = include_str!("menu_items.rs");
+        let body_start = src.find("pub fn set_tray_sessions(").unwrap();
+        let body_end = src[body_start..]
+            .find("\nfn ")
+            .or_else(|| src[body_start..].find("\npub fn "))
+            .or_else(|| src[body_start..].find("\n#[cfg(test)]"))
+            .map(|n| body_start + n)
+            .unwrap_or(src.len());
+        let body = &src[body_start..body_end];
+        assert!(
+            body.contains("guard.tray_sessions == items"),
+            "unchanged tray session snapshots should be skipped",
+        );
+        assert!(
+            body.contains("install_tray(&app, &guard.extension_items, &items)"),
+            "session updates must rebuild the tray with the latest extension items",
+        );
+        assert!(
+            body.contains("guard.tray_sessions = items"),
+            "the cached tray session snapshot should update after install succeeds",
         );
     }
 }

--- a/src-tauri/src/commands/extensions/tray.rs
+++ b/src-tauri/src/commands/extensions/tray.rs
@@ -1,19 +1,19 @@
 //! Status-bar / tray icon. Left-click focuses the main window; the
-//! menu carries Show / New Tab / Quit plus any `location: "tray"`
-//! extension items. Runtime updates keep the existing status item and
-//! replace only its menu, avoiding macOS `NSStatusItem` recreation
+//! menu carries Show, active agent sessions, utility actions, extension
+//! tray items, and Quit. Runtime updates keep the existing status item
+//! and replace only its menu, avoiding macOS `NSStatusItem` recreation
 //! while workspace/project switches are in flight.
 
 use tauri::AppHandle;
 
-use super::menu_items::ExtensionMenuItem;
+use super::menu_items::{ExtensionMenuItem, TraySessionItem};
 
 /// The tray's `with_id` / `remove_tray_by_id` keys must match — they
 /// share `TRAY_ID` so a refactor renaming one doesn't silently break
 /// the idempotency contract.
 pub const TRAY_ID: &str = "main-tray";
 
-/// Status-bar / tray icon with a tiny menu (Show, New Tab, Quit).
+/// Status-bar / tray icon with a session-aware menu.
 /// Left-click on the icon focuses the main window so users who hide
 /// Aethon (Cmd+H) can re-summon it without going through the dock.
 /// Reuses the bundled app icon as the tray glyph; macOS gets the
@@ -25,9 +25,10 @@ pub const TRAY_ID: &str = "main-tray";
 pub fn install_tray(
     app: &AppHandle,
     extension_items: &[ExtensionMenuItem],
+    session_items: &[TraySessionItem],
 ) -> Result<(), Box<dyn std::error::Error>> {
     use tauri::Manager;
-    use tauri::menu::{Menu, MenuItem};
+    use tauri::menu::{IsMenuItem, Menu, MenuItem, PredefinedMenuItem};
     use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
 
     fn focus_main(app: &AppHandle) {
@@ -44,9 +45,109 @@ pub fn install_tray(
         }
     }
 
+    fn trim_menu_text(input: &str, max_chars: usize) -> String {
+        let text = input.trim();
+        if text.chars().count() <= max_chars {
+            return text.to_string();
+        }
+        let mut out: String = text.chars().take(max_chars.saturating_sub(3)).collect();
+        out.push_str("...");
+        out
+    }
+
+    fn session_label(item: &TraySessionItem) -> String {
+        let mut label = trim_menu_text(&item.label, 56);
+        let mut prefix = "";
+        if item.running {
+            prefix = "[running] ";
+        } else if item.needs_attention {
+            prefix = "[new] ";
+        } else if item.active {
+            prefix = "[current] ";
+        } else if item.queued_count > 0 {
+            prefix = "[queued] ";
+        }
+        if !prefix.is_empty() {
+            label = format!("{prefix}{label}");
+        }
+        if let Some(detail) = item.detail.as_ref().filter(|d| !d.trim().is_empty()) {
+            label.push_str(" - ");
+            label.push_str(&trim_menu_text(detail, 28));
+        }
+        if item.queued_count > 0 {
+            label.push_str(&format!(" ({})", item.queued_count));
+        }
+        label
+    }
+
     let show_item = MenuItem::with_id(app, "tray:show", "Show Aethon", true, None::<&str>)?;
-    let new_tab_item = MenuItem::with_id(app, "tray:new_tab", "New Tab", true, None::<&str>)?;
     let quit_item = MenuItem::with_id(app, "tray:quit", "Quit Aethon", true, None::<&str>)?;
+    let sessions_header = MenuItem::with_id(
+        app,
+        "tray:sessions_header",
+        "Active Sessions",
+        false,
+        None::<&str>,
+    )?;
+    let no_sessions = MenuItem::with_id(
+        app,
+        "tray:no_sessions",
+        "No open agent sessions",
+        false,
+        None::<&str>,
+    )?;
+    let scheduled_tasks = MenuItem::with_id(
+        app,
+        "tray:scheduled_tasks",
+        "Scheduled Tasks...",
+        true,
+        None::<&str>,
+    )?;
+    let manage_extensions = MenuItem::with_id(
+        app,
+        "tray:manage_extensions",
+        "Manage Extensions...",
+        true,
+        None::<&str>,
+    )?;
+    let check_updates = MenuItem::with_id(
+        app,
+        "tray:check_updates",
+        "Check for Updates...",
+        true,
+        None::<&str>,
+    )?;
+    let sep_after_show = PredefinedMenuItem::separator(app)?;
+    let sep_after_sessions = PredefinedMenuItem::separator(app)?;
+    let sep_before_extensions = PredefinedMenuItem::separator(app)?;
+    let sep_before_quit = PredefinedMenuItem::separator(app)?;
+
+    let visible_sessions = session_items.iter().take(10);
+    let mut session_menu_items: Vec<MenuItem<tauri::Wry>> = Vec::new();
+    for item in visible_sessions {
+        let id = format!("tray:session:{}", item.id);
+        session_menu_items.push(MenuItem::with_id(
+            app,
+            &id,
+            session_label(item),
+            true,
+            None::<&str>,
+        )?);
+    }
+    let more_sessions = if session_items.len() > session_menu_items.len() {
+        Some(MenuItem::with_id(
+            app,
+            "tray:more_sessions",
+            format!(
+                "+{} more in Aethon",
+                session_items.len() - session_menu_items.len()
+            ),
+            false,
+            None::<&str>,
+        )?)
+    } else {
+        None
+    };
     // Extension-supplied tray items (location: "tray") appear after the
     // built-ins. Each id is prefixed `ext:` so the click handler below
     // can route them through Tauri's `menu` event with the existing
@@ -57,12 +158,32 @@ pub fn install_tray(
         let mi = MenuItem::with_id(app, &id, &item.label, true, None::<&str>)?;
         extension_menu_items.push(mi);
     }
-    // Build the menu's item slice. Mix built-ins with extension entries.
-    let mut item_refs: Vec<&dyn tauri::menu::IsMenuItem<tauri::Wry>> =
-        vec![&show_item, &new_tab_item, &quit_item];
+    // Build the menu's item slice. Mix built-ins with dynamic session
+    // rows and extension entries.
+    let mut item_refs: Vec<&dyn IsMenuItem<tauri::Wry>> =
+        vec![&show_item, &sep_after_show, &sessions_header];
+    if session_menu_items.is_empty() {
+        item_refs.push(&no_sessions);
+    } else {
+        for session in &session_menu_items {
+            item_refs.push(session);
+        }
+    }
+    if let Some(more) = &more_sessions {
+        item_refs.push(more);
+    }
+    item_refs.push(&sep_after_sessions);
+    item_refs.push(&scheduled_tasks);
+    item_refs.push(&manage_extensions);
+    item_refs.push(&check_updates);
+    if !extension_menu_items.is_empty() {
+        item_refs.push(&sep_before_extensions);
+    }
     for ext in &extension_menu_items {
         item_refs.push(ext);
     }
+    item_refs.push(&sep_before_quit);
+    item_refs.push(&quit_item);
     let menu = Menu::with_items(app, &item_refs)?;
 
     let icon = app
@@ -97,15 +218,23 @@ pub fn install_tray(
             let id = event.id().as_ref();
             match id {
                 "tray:show" => focus_main(app),
-                "tray:new_tab" => {
-                    // Forward as a "menu" event so the React side's
-                    // existing dispatcher fires the same handler the
-                    // app menu's New Tab uses. Bring the window forward
-                    // first so the user sees the new tab.
+                "tray:scheduled_tasks" => {
                     focus_main(app);
-                    let _ = tauri::Emitter::emit(app, "menu", "new_tab");
+                    let _ = tauri::Emitter::emit(app, "menu", "scheduled_tasks");
+                }
+                "tray:manage_extensions" => {
+                    focus_main(app);
+                    let _ = tauri::Emitter::emit(app, "menu", "manage_extensions");
+                }
+                "tray:check_updates" => {
+                    focus_main(app);
+                    let _ = tauri::Emitter::emit(app, "menu", "check_updates");
                 }
                 "tray:quit" => app.exit(0),
+                other if other.starts_with("tray:session:") => {
+                    focus_main(app);
+                    let _ = tauri::Emitter::emit(app, "menu", other);
+                }
                 other if other.starts_with("ext:") => {
                     // Extension item — bring window forward so the
                     // handler's UI changes are visible, then forward
@@ -181,6 +310,20 @@ mod tests {
         assert!(
             !src.contains("remove_tray_by_id("),
             "runtime tray updates must not remove/recreate the macOS status item",
+        );
+    }
+
+    #[test]
+    fn tray_menu_no_longer_exposes_new_tab() {
+        let src = include_str!("tray.rs");
+        let src = &src[..src.find("#[cfg(test)]").unwrap_or(src.len())];
+        assert!(
+            !src.contains("tray:new_tab"),
+            "the tray is a session switcher/status surface; New Tab stays in app chrome and the menu bar",
+        );
+        assert!(
+            src.contains("tray:session:"),
+            "active session rows should route through tray:session:<tabId>",
         );
     }
 }

--- a/src-tauri/src/commands/extensions/tray.rs
+++ b/src-tauri/src/commands/extensions/tray.rs
@@ -58,12 +58,12 @@ pub fn install_tray(
     fn session_label(item: &TraySessionItem) -> String {
         let mut label = trim_menu_text(&item.label, 56);
         let mut prefix = "";
-        if item.running {
+        if item.active {
+            prefix = "[current] ";
+        } else if item.running {
             prefix = "[running] ";
         } else if item.needs_attention {
             prefix = "[new] ";
-        } else if item.active {
-            prefix = "[current] ";
         } else if item.queued_count > 0 {
             prefix = "[queued] ";
         }
@@ -324,6 +324,25 @@ mod tests {
         assert!(
             src.contains("tray:session:"),
             "active session rows should route through tray:session:<tabId>",
+        );
+    }
+
+    #[test]
+    fn active_session_marker_wins_over_transient_state() {
+        let src = include_str!("tray.rs");
+        let src = &src[..src.find("#[cfg(test)]").unwrap_or(src.len())];
+        let active_pos = src
+            .find("if item.active")
+            .expect("session labels should test active state");
+        let running_pos = src
+            .find("else if item.running")
+            .expect("session labels should test running state");
+        let attention_pos = src
+            .find("else if item.needs_attention")
+            .expect("session labels should test attention state");
+        assert!(
+            active_pos < running_pos && running_pos < attention_pos,
+            "current session rows should keep the [current] marker even while running or unread",
         );
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -221,6 +221,7 @@ pub fn run() {
             commands::subagents::subagents_write,
             commands::subagents::subagents_delete,
             commands::extensions::set_extension_menu_items,
+            commands::extensions::set_tray_sessions,
             commands::extensions::install_aethon_extension,
             commands::extensions::watch_project_extensions,
             commands::extensions::unwatch_project_extensions,
@@ -377,7 +378,7 @@ pub fn run() {
                 let id = event.id().0.as_str();
                 let _ = app.emit("menu", id);
             });
-            commands::extensions::install_tray(app.handle(), &[])?;
+            commands::extensions::install_tray(app.handle(), &[], &[])?;
             // Initialize the extension menu store empty; the bridge
             // ships items via `extension_menu_items` events that the
             // frontend forwards to `set_extension_menu_items`, which
@@ -471,6 +472,15 @@ mod tests {
         assert!(
             src.contains("commands::extensions::set_extension_menu_items"),
             "set_extension_menu_items must be registered in the invoke_handler list",
+        );
+    }
+
+    #[test]
+    fn set_tray_sessions_is_wired_to_handler() {
+        let src = include_str!("lib.rs");
+        assert!(
+            src.contains("commands::extensions::set_tray_sessions"),
+            "set_tray_sessions must be registered in the invoke_handler list",
         );
     }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -912,6 +912,7 @@ export default function App() {
     shellInheritEnvRef,
     updateTab,
     newShellTab,
+    activateTabAnywhere,
     nextTab,
     appendMessage,
     persistLocalChatMessage,

--- a/src/app/useAppRuntimeSurfaces.ts
+++ b/src/app/useAppRuntimeSurfaces.ts
@@ -10,6 +10,7 @@ import {
   usePersistEditorTabs,
   type UsePersistEditorTabsContext,
 } from "../hooks/usePersistEditorTabs";
+import { useTraySessionsSync } from "../hooks/traySessions";
 import {
   useWindowApi,
   type UseWindowApiContext,
@@ -39,5 +40,6 @@ export function useAppRuntimeSurfaces(
   useWindowApi(ctx);
   useFrontendStateMirror(ctx);
   usePersistEditorTabs(ctx);
+  useTraySessionsSync(ctx.state);
   useOsEdges(ctx);
 }

--- a/src/hooks/osEdges/menu.test.ts
+++ b/src/hooks/osEdges/menu.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearTauriMocks, installTauriMocks } from "../../test/tauriMocks";
+import { subscribeMenu, type MenuDeps } from "./menu";
+
+function deps(overrides: Partial<MenuDeps> = {}): MenuDeps {
+  return {
+    stateRef: { current: {} },
+    newTab: vi.fn(),
+    newShellTab: vi.fn(),
+    closeTab: vi.fn(),
+    activateTabAnywhere: vi.fn(),
+    nextTab: vi.fn(),
+    toggleTerminal: vi.fn(),
+    toggleFilesSidebar: vi.fn(),
+    togglePlanMode: vi.fn(),
+    openSettings: vi.fn(),
+    openScheduledTasks: vi.fn(),
+    clearChat: vi.fn(),
+    stopPrompt: vi.fn(() => Promise.resolve()),
+    checkForUpdates: vi.fn(() => Promise.resolve()),
+    appendSystem: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("subscribeMenu", () => {
+  let harness: ReturnType<typeof installTauriMocks>;
+
+  beforeEach(() => {
+    harness = installTauriMocks();
+  });
+
+  afterEach(() => {
+    clearTauriMocks();
+  });
+
+  it("routes tray session rows through cross-workspace activation", () => {
+    const ctx = deps();
+    subscribeMenu(ctx);
+
+    harness.fireEvent("menu", "tray:session:tab-123");
+
+    expect(ctx.activateTabAnywhere).toHaveBeenCalledWith("tab-123");
+    expect(ctx.newTab).not.toHaveBeenCalled();
+  });
+
+  it("keeps app-menu new_tab routed to newTab", () => {
+    const ctx = deps();
+    subscribeMenu(ctx);
+
+    harness.fireEvent("menu", "new_tab");
+
+    expect(ctx.newTab).toHaveBeenCalledOnce();
+    expect(ctx.activateTabAnywhere).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/osEdges/menu.ts
+++ b/src/hooks/osEdges/menu.ts
@@ -8,6 +8,7 @@ export interface MenuDeps {
   newTab: () => void;
   newShellTab: () => void;
   closeTab: (tabId: string) => void;
+  activateTabAnywhere: (tabId: string) => void;
   nextTab: (direction: 1 | -1) => void;
   toggleTerminal: () => void;
   toggleFilesSidebar: () => void;
@@ -40,6 +41,7 @@ export function subscribeMenu(deps: MenuDeps): () => void {
     newTab,
     newShellTab,
     closeTab,
+    activateTabAnywhere,
     nextTab,
     toggleTerminal,
     toggleFilesSidebar,
@@ -68,6 +70,10 @@ export function subscribeMenu(deps: MenuDeps): () => void {
       }).catch(() => {
         /* bridge gone or webview reload mid-flight */
       });
+      return;
+    }
+    if (id.startsWith("tray:session:")) {
+      activateTabAnywhere(id.slice("tray:session:".length));
       return;
     }
     switch (id) {

--- a/src/hooks/osEdges/types.ts
+++ b/src/hooks/osEdges/types.ts
@@ -29,6 +29,7 @@ export interface UseOsEdgesContext {
   newTab: () => void;
   newShellTab: () => void;
   closeTab: (tabId: string) => void;
+  activateTabAnywhere: (tabId: string) => void;
   nextTab: (direction: 1 | -1) => void;
 
   // Chat helpers (from useChat).

--- a/src/hooks/traySessions.test.ts
+++ b/src/hooks/traySessions.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { makeEmptyTab, type Tab } from "../types/tab";
+import { buildTraySessionItems } from "./traySessions";
+
+function agent(id: string, label: string, patch: Partial<Tab> = {}): Tab {
+  return {
+    ...makeEmptyTab(id, label),
+    cwd: `/repo/${label.toLowerCase().replace(/\s+/g, "-")}`,
+    ...patch,
+  };
+}
+
+describe("buildTraySessionItems", () => {
+  it("includes visible and hidden agent sessions only", () => {
+    const visible = agent("a1", "Visible");
+    const hidden = agent("a2", "Hidden");
+    const shell = makeEmptyTab("sh1", "Shell", null, "shell");
+    const editor = makeEmptyTab("ed1", "Editor", null, "editor");
+
+    expect(
+      buildTraySessionItems({
+        tabs: [visible, shell],
+        persistedTabBuckets: {
+          "p1::workspace::w1": { tabs: [hidden, editor], activeTabId: "a2" },
+        },
+      }).map((item) => item.id),
+    ).toEqual(["a2", "a1"]);
+  });
+
+  it("reflects active, running, attention, and queued state", () => {
+    const current = agent("current", "Current", {
+      queuedMessages: [{ id: "q1", content: "queued" }],
+      queueCount: 1,
+    });
+    const running = agent("running", "Running");
+    const attention = agent("attention", "Attention");
+
+    const items = buildTraySessionItems({
+      activeTabId: "current",
+      tabs: [attention, running, current],
+      agentRunningTabs: { running: true },
+      agentAttentionTabs: { attention: true },
+    });
+
+    expect(items).toMatchObject([
+      { id: "current", active: true, queued_count: 1 },
+      { id: "running", running: true },
+      { id: "attention", needs_attention: true },
+    ]);
+  });
+
+  it("uses the first user message for untitled tabs", () => {
+    const tab = agent("a1", "Tab 1", {
+      messages: [
+        {
+          id: "m1",
+          role: "user",
+          text: "  Build the tray menu  ",
+        },
+      ],
+    });
+
+    expect(buildTraySessionItems({ tabs: [tab] })[0]).toMatchObject({
+      label: "Build the tray menu",
+      detail: "tab-1",
+    });
+  });
+});

--- a/src/hooks/traySessions.ts
+++ b/src/hooks/traySessions.ts
@@ -1,0 +1,138 @@
+import { useEffect, useRef } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import type { Tab } from "../types/tab";
+import { isAgentTabInFlight } from "../utils/agentBusy";
+
+export interface TraySessionItem {
+  id: string;
+  label: string;
+  detail?: string;
+  active: boolean;
+  running: boolean;
+  needs_attention: boolean;
+  queued_count: number;
+}
+
+interface CollectedTab {
+  tab: Tab;
+  visible: boolean;
+}
+
+function pathBasename(path: string | undefined): string | undefined {
+  const trimmed = (path ?? "").replace(/[/\\]+$/, "");
+  if (!trimmed) return undefined;
+  return trimmed.split(/[/\\]/).pop() || undefined;
+}
+
+function firstUserLabel(tab: Tab): string | undefined {
+  const first = tab.messages.find(
+    (message) =>
+      message.role === "user" &&
+      typeof message.text === "string" &&
+      message.text.trim().length > 0,
+  );
+  const text = first?.text?.replace(/\s+/g, " ").trim();
+  if (!text) return undefined;
+  return text.length > 56 ? `${text.slice(0, 53)}...` : text;
+}
+
+function displayLabel(tab: Tab): string {
+  if (/^Tab \d+$/.test(tab.label)) {
+    return firstUserLabel(tab) ?? tab.label;
+  }
+  return tab.label;
+}
+
+function collectAgentTabs(state: Record<string, unknown>): CollectedTab[] {
+  const result: CollectedTab[] = [];
+  const seen = new Set<string>();
+  const add = (tabs: Tab[] | undefined, visible: boolean) => {
+    for (const tab of tabs ?? []) {
+      if (tab.kind !== "agent") continue;
+      if (seen.has(tab.id)) continue;
+      seen.add(tab.id);
+      result.push({ tab, visible });
+    }
+  };
+  add((state.tabs as Tab[] | undefined) ?? [], true);
+  const buckets = state.persistedTabBuckets as
+    | Record<string, { tabs?: Tab[] }>
+    | undefined;
+  if (buckets) {
+    for (const bucket of Object.values(buckets)) {
+      add(bucket?.tabs, false);
+    }
+  }
+  return result;
+}
+
+export function buildTraySessionItems(
+  state: Record<string, unknown>,
+): TraySessionItem[] {
+  const activeTabId = state.activeTabId as string | undefined;
+  const running = new Set(
+    Object.keys(
+      (state.agentRunningTabs as Record<string, unknown> | undefined) ?? {},
+    ),
+  );
+  const attention = new Set(
+    Object.keys(
+      (state.agentAttentionTabs as Record<string, unknown> | undefined) ?? {},
+    ),
+  );
+
+  return collectAgentTabs(state)
+    .map(({ tab, visible }): TraySessionItem => {
+      const isRunning =
+        running.has(tab.id) || (visible && isAgentTabInFlight(tab));
+      const queuedCount = Math.max(
+        tab.queuedMessages?.length ?? 0,
+        tab.queueCount ?? 0,
+      );
+      return {
+        id: tab.id,
+        label: displayLabel(tab),
+        ...(pathBasename(tab.cwd) ? { detail: pathBasename(tab.cwd) } : {}),
+        active: tab.id === activeTabId,
+        running: isRunning,
+        needs_attention: !isRunning && attention.has(tab.id),
+        queued_count: queuedCount,
+      };
+    })
+    .sort((a, b) => {
+      const rank = (item: TraySessionItem) =>
+        item.active ? 0 : item.running ? 1 : item.needs_attention ? 2 : 3;
+      const rankDiff = rank(a) - rank(b);
+      if (rankDiff !== 0) return rankDiff;
+      return a.label.localeCompare(b.label);
+    });
+}
+
+export function useTraySessionsSync(state: Record<string, unknown>): void {
+  const lastSerializedRef = useRef<string>("");
+  const timerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current);
+    }
+    timerRef.current = window.setTimeout(() => {
+      timerRef.current = null;
+      const items = buildTraySessionItems(state);
+      const serialized = JSON.stringify(items);
+      if (serialized === lastSerializedRef.current) return;
+      lastSerializedRef.current = serialized;
+      invoke("set_tray_sessions", { items }).catch(() => {
+        // Tauri may be unavailable in unit tests or during early reload.
+        // Clear the diff so the next state change retries.
+        lastSerializedRef.current = "";
+      });
+    }, 50);
+    return () => {
+      if (timerRef.current !== null) {
+        window.clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [state]);
+}

--- a/src/hooks/traySessions.ts
+++ b/src/hooks/traySessions.ts
@@ -3,7 +3,7 @@ import { invoke } from "@tauri-apps/api/core";
 import type { Tab } from "../types/tab";
 import { isAgentTabInFlight } from "../utils/agentBusy";
 
-export interface TraySessionItem {
+interface TraySessionItemWire {
   id: string;
   label: string;
   detail?: string;
@@ -68,7 +68,7 @@ function collectAgentTabs(state: Record<string, unknown>): CollectedTab[] {
 
 export function buildTraySessionItems(
   state: Record<string, unknown>,
-): TraySessionItem[] {
+): TraySessionItemWire[] {
   const activeTabId = state.activeTabId as string | undefined;
   const running = new Set(
     Object.keys(
@@ -82,7 +82,7 @@ export function buildTraySessionItems(
   );
 
   return collectAgentTabs(state)
-    .map(({ tab, visible }): TraySessionItem => {
+    .map(({ tab, visible }): TraySessionItemWire => {
       const isRunning =
         running.has(tab.id) || (visible && isAgentTabInFlight(tab));
       const queuedCount = Math.max(
@@ -100,7 +100,7 @@ export function buildTraySessionItems(
       };
     })
     .sort((a, b) => {
-      const rank = (item: TraySessionItem) =>
+      const rank = (item: TraySessionItemWire) =>
         item.active ? 0 : item.running ? 1 : item.needs_attention ? 2 : 3;
       const rankDiff = rank(a) - rank(b);
       if (rankDiff !== 0) return rankDiff;

--- a/src/hooks/useOsEdges.ts
+++ b/src/hooks/useOsEdges.ts
@@ -87,6 +87,7 @@ export function useOsEdges(ctx: UseOsEdgesContext): void {
         newTab: ctx.newTab,
         newShellTab: ctx.newShellTab,
         closeTab: ctx.closeTab,
+        activateTabAnywhere: ctx.activateTabAnywhere,
         nextTab: ctx.nextTab,
         toggleTerminal: ctx.toggleTerminal,
         toggleFilesSidebar: ctx.toggleFilesSidebar,


### PR DESCRIPTION
## Summary
- replace stale tray actions with an Active Sessions section backed by live agent tabs
- add tray session sync from the React app into the native Tauri tray store
- route tray session clicks through existing cross-workspace tab activation

## Verification
- codex review --base main (clean on second pass after staging new files)
- bun run typecheck
- bun run lint
- bunx vitest run src/hooks/traySessions.test.ts src/hooks/osEdges/menu.test.ts
- bunx vitest run src/hooks/traySessions.test.ts src/hooks/osEdges/menu.test.ts src/hooks/useActivateTabAnywhere.test.ts src/hooks/bridgeMessageHandlers/extensionMenuItems.test.ts
- bunx vitest run
- cargo fmt --manifest-path src-tauri/Cargo.toml -- --check
- cargo clippy --manifest-path src-tauri/Cargo.toml --lib -- -D warnings
- cargo test --manifest-path src-tauri/Cargo.toml --lib commands::extensions
- cargo test --manifest-path src-tauri/Cargo.toml --lib
- dev UAT via Aethon debug eval against localhost:1420 / debug port 19433

Note: full Vitest exited 0 with existing noisy jsdom/Monaco fixture warnings.