### PR TITLE
fix(ci): tolerate nightly asset propagation

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -376,20 +376,23 @@ jobs:
           done
 
           # Anonymous-fetch smoke test — this is the actual contract
-          # the in-app updater relies on.
+          # the in-app updater relies on. GitHub's release API can show
+          # the retagged asset before the anonymous release-download URL
+          # is available through the asset CDN, so give propagation a few
+          # minutes before treating the nightly as broken.
           MANIFEST_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/nightly/latest.json"
-          for attempt in 1 2 3 4 5; do
+          for attempt in $(seq 1 20); do
             http=$(curl -sIL -o /dev/null -w "%{http_code}" "$MANIFEST_URL" || echo "000")
             if [ "$http" = "200" ]; then
               echo "latest.json reachable at $MANIFEST_URL (HTTP 200)"
               break
             fi
-            if [ "$attempt" -eq 5 ]; then
+            if [ "$attempt" -eq 20 ]; then
               echo "::error::latest.json at $MANIFEST_URL returned HTTP $http after promotion"
               exit 1
             fi
-            echo "latest.json HTTP $http (attempt $attempt); retrying in 10s"
-            sleep 10
+            echo "latest.json HTTP $http (attempt $attempt); retrying in 15s"
+            sleep 15
           done
 
           gh api -X DELETE "repos/${GITHUB_REPOSITORY}/git/refs/tags/nightly-staging" 2>/dev/null || true


### PR DESCRIPTION
## Summary
- extend the nightly updater-manifest smoke test from ~40 seconds to up to 5 minutes
- document the GitHub release API vs anonymous asset-CDN propagation gap in the workflow
- keep the anonymous `latest.json` check as the final contract instead of bypassing it

## Root cause
Nightly run `28418152141` built and promoted assets successfully, but failed in `Publish Nightly` because `https://github.com/utensils/aethon/releases/download/nightly/latest.json` returned 404 during the short post-promotion smoke-test window. The release API already showed `latest.json` on the retagged `nightly` release, and the same anonymous URL later returned 200, so this was release-asset propagation lag rather than a broken build artifact.

## Validation
- `bunx prettier --check .github/workflows/nightly.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/nightly.yml"); puts "yaml ok"'`\n- `git diff --check`\n- verified current anonymous nightly manifest URL now returns HTTP 200\n\n## Notes\n`actionlint` is not installed locally, so workflow syntax was checked via YAML parse plus GitHub PR checks.