### PR TITLE
fix(projects): sync active VCS branch labels

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
-import { useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { ExtensionRegistry } from "./extensions/ExtensionRegistry";
+import { persistStatusesDebounced } from "./gitStatusCache";
 import { defaultLayoutExtension } from "./extensions/default-layout";
 import { AppRoot } from "./app/AppRoot";
 import { BOOT_LAYOUT, hangWarnNotifId } from "./app/bootConstants";
@@ -14,7 +15,7 @@ import { useSpeakReplies } from "./hooks/useSpeakReplies";
 import { useShellConsent } from "./hooks/useShellConsent";
 import { useHostInfo } from "./hooks/useHostInfo";
 import { useDevshell, type DevshellEntry } from "./hooks/useDevshell";
-import { useProjects } from "./hooks/useProjects";
+import { useProjects, type GitStatus } from "./hooks/useProjects";
 import { useAgentWorkerReconcile } from "./hooks/useAgentWorkerReconcile";
 import { useAgentActivityHydration } from "./hooks/useAgentActivityHydration";
 import { useVcsStatus } from "./hooks/useVcsStatus";
@@ -35,6 +36,7 @@ import { useUpdater } from "./hooks/useUpdater";
 import { useWorkspaceStartup } from "./hooks/useWorkspaceStartup";
 import { UpdateBanner } from "./components/UpdateBanner";
 import { useProjectOps } from "./hooks/useProjectOps";
+import { applyActiveVcsGitStatusToProjects } from "./hooks/projectOps/vcsGitMirror";
 import type { TabBucket } from "./hooks/projectOps/types";
 import {
   buildInitialAppStore,
@@ -265,7 +267,12 @@ export default function App() {
   // file tree. The file tree's final `~/.aethon` fallback is intentionally
   // omitted: it is never a git repo, so `/vcs` would collapse anyway, and
   // replicating the async home-dir fetch here is noise.
-  useVcsStatus({ activeRoot: activeWorkspaceRoot, setState });
+  useVcsStatus({
+    activeRoot: activeWorkspaceRoot,
+    setState,
+    onGitStatusSettled: (root, status) =>
+      projectsHandleRef.current.applyVcsGitStatus(root, status),
+  });
   useGitWatch(activeWorkspaceRoot);
 
   // ---------------------------------------------------------------------
@@ -379,6 +386,7 @@ export default function App() {
     knownTabIds,
     scopedDiscoveredSessions,
     recentSessionItems,
+    buildProjectsMirror,
     syncProjectsToState,
     syncRecentSessionsToState,
     openProjectFromPicker,
@@ -417,6 +425,23 @@ export default function App() {
     newShellTab,
     workspacePrompts,
   });
+  const applyVcsGitStatus = useCallback(
+    (root: string, status: GitStatus | null) => {
+      const result = applyActiveVcsGitStatusToProjects({
+        projects: projectsRef.current,
+        gitStatuses: gitStatusRef.current,
+        root,
+        status,
+      });
+      if (!result.changed) return undefined;
+      persistStatusesDebounced(gitStatusRef.current);
+      projectsRef.current = result.projects;
+      return (nextState: Record<string, unknown>) =>
+        buildProjectsMirror(nextState);
+    },
+    [buildProjectsMirror, gitStatusRef, projectsRef],
+  );
+
   useProjectSyncEffects({
     state,
     stateRef,
@@ -593,6 +618,7 @@ export default function App() {
     clearActiveProject,
     setActiveProjectById,
     syncProjectsToState,
+    applyVcsGitStatus,
     pushNotification,
     appendMessage,
     appendSystem,

--- a/src/app/useAppForwardRefs.ts
+++ b/src/app/useAppForwardRefs.ts
@@ -5,6 +5,7 @@ import type {
   ProjectsHandle,
 } from "../hooks/useAppStateRefs";
 import type { NotificationInput } from "../hooks/useNotifications";
+import type { GitStatus } from "../hooks/useProjects";
 import type { ProjectsState } from "../projects";
 
 export interface UseAppForwardRefsContext {
@@ -23,6 +24,12 @@ export interface UseAppForwardRefsContext {
   clearActiveProject: () => void;
   setActiveProjectById: (id: string) => boolean;
   syncProjectsToState: () => void;
+  applyVcsGitStatus: (
+    root: string,
+    status: GitStatus | null,
+  ) =>
+    | ((nextState: Record<string, unknown>) => Partial<Record<string, unknown>>)
+    | undefined;
   pushNotification: (n: NotificationInput) => string;
   appendMessage: ChatActionsHandle["appendMessage"];
   appendSystem: ChatActionsHandle["appendSystem"];
@@ -56,6 +63,7 @@ export function useAppForwardRefs(ctx: UseAppForwardRefsContext): void {
     clearActiveProject,
     setActiveProjectById,
     syncProjectsToState,
+    applyVcsGitStatus,
     pushNotification,
     appendMessage,
     appendSystem,
@@ -71,6 +79,7 @@ export function useAppForwardRefs(ctx: UseAppForwardRefsContext): void {
     projectsHandleRef.current = {
       getPaths: () => projectsRef.current.projects.map((p) => p.path),
       onGitStatusChanged: () => syncProjectsToState(),
+      applyVcsGitStatus,
     };
     pushNotificationRef.current = pushNotification;
     chatActionsRef.current = {

--- a/src/hooks/projectOps/types.ts
+++ b/src/hooks/projectOps/types.ts
@@ -101,6 +101,10 @@ export interface UseProjectOpsActions {
     openIds: Set<string>,
   ) => RecentSessionItem[];
   syncRecentSessionsToState: () => void;
+  buildProjectsMirror: (
+    prev: Record<string, unknown>,
+    tabsForRecent?: Tab[],
+  ) => Record<string, unknown>;
 
   // ─── Project ops ────────────────────────────────────────────────────
   syncProjectsToState: () => void;

--- a/src/hooks/projectOps/vcsGitMirror.test.ts
+++ b/src/hooks/projectOps/vcsGitMirror.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import type { ProjectsState } from "../../projects";
+import { applyActiveVcsGitStatusToProjects } from "./vcsGitMirror";
+
+function projectsState(overrides: Partial<ProjectsState> = {}): ProjectsState {
+  return {
+    projects: [{ id: "project-1", label: "aethon", path: "/repo", lastUsed: 1 }],
+    activeId: "project-1",
+    activeWorkspaceId: null,
+    activeHostId: null,
+    workspacesByProject: {},
+    ...overrides,
+  };
+}
+
+describe("applyActiveVcsGitStatusToProjects", () => {
+  it("updates the project git cache for the active root", () => {
+    const gitStatuses = new Map([
+      ["/repo", { branch: "old", ahead: 0, behind: 0, dirty: false }],
+    ]);
+
+    const result = applyActiveVcsGitStatusToProjects({
+      projects: projectsState(),
+      gitStatuses,
+      root: "/repo",
+      status: { branch: "main", ahead: 6, behind: 1, dirty: false },
+    });
+
+    expect(result.changed).toBe(true);
+    expect(gitStatuses.get("/repo")).toEqual({
+      branch: "main",
+      ahead: 6,
+      behind: 1,
+      dirty: false,
+    });
+  });
+
+  it("updates the matching workspace branch and clears labels that tracked the old branch", () => {
+    const state = projectsState({
+      activeWorkspaceId: "main-wt",
+      workspacesByProject: {
+        "project-1": [
+          {
+            id: "main-wt",
+            projectId: "project-1",
+            path: "/repo",
+            branch: "fix/old",
+            label: "fix/old",
+            isMain: true,
+          },
+          {
+            id: "manual-label",
+            projectId: "project-1",
+            path: "/repo-linked",
+            branch: "fix/old",
+            label: "Release work",
+            isMain: false,
+          },
+        ],
+      },
+    });
+
+    const result = applyActiveVcsGitStatusToProjects({
+      projects: state,
+      gitStatuses: new Map(),
+      root: "/repo",
+      status: { branch: "main", ahead: 0, behind: 0, dirty: false },
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.projects.workspacesByProject["project-1"]?.[0]).toMatchObject({
+      branch: "main",
+      label: undefined,
+    });
+    expect(result.projects.workspacesByProject["project-1"]?.[1]).toMatchObject({
+      branch: "fix/old",
+      label: "Release work",
+    });
+  });
+
+  it("preserves detached workspace branch state when git_status reports a display SHA", () => {
+    const state = projectsState({
+      activeWorkspaceId: "main-wt",
+      workspacesByProject: {
+        "project-1": [
+          {
+            id: "main-wt",
+            projectId: "project-1",
+            path: "/repo",
+            branch: "fix/old",
+            label: "fix/old",
+            isMain: true,
+          },
+        ],
+      },
+    });
+    const gitStatuses = new Map();
+
+    const result = applyActiveVcsGitStatusToProjects({
+      projects: state,
+      gitStatuses,
+      root: "/repo",
+      status: { branch: "aace34f", ahead: 0, behind: 0, dirty: false },
+    });
+
+    expect(gitStatuses.get("/repo")?.branch).toBe("aace34f");
+    expect(result.projects.workspacesByProject["project-1"]?.[0]).toMatchObject({
+      branch: null,
+      label: undefined,
+    });
+  });
+
+  it("reports no change when the cache and workspace branch already match", () => {
+    const gitStatuses = new Map([
+      ["/repo", { branch: "main", ahead: 0, behind: 0, dirty: false }],
+    ]);
+    const state = projectsState({
+      workspacesByProject: {
+        "project-1": [
+          {
+            id: "main-wt",
+            projectId: "project-1",
+            path: "/repo",
+            branch: "main",
+            isMain: true,
+          },
+        ],
+      },
+    });
+
+    const result = applyActiveVcsGitStatusToProjects({
+      projects: state,
+      gitStatuses,
+      root: "/repo",
+      status: { branch: "main", ahead: 0, behind: 0, dirty: false },
+    });
+
+    expect(result).toEqual({ projects: state, changed: false });
+  });
+});

--- a/src/hooks/projectOps/vcsGitMirror.ts
+++ b/src/hooks/projectOps/vcsGitMirror.ts
@@ -1,0 +1,104 @@
+import type { ProjectsState } from "../../projects";
+import type { Workspace } from "../../workspaces";
+import type { GitStatus } from "../useProjects";
+
+function gitStatusEquals(
+  a: GitStatus | undefined,
+  b: GitStatus | undefined,
+): boolean {
+  if (!a || !b) return !a && !b;
+  return (
+    a.branch === b.branch &&
+    a.dirty === b.dirty &&
+    a.ahead === b.ahead &&
+    a.behind === b.behind
+  );
+}
+
+function workspaceBranchFromGitStatus(status: GitStatus | null): string | null {
+  const branch = status?.branch ?? null;
+  // git_status deliberately falls back to a short SHA on detached HEAD so the
+  // project git chip has a useful display value. Workspace.branch follows
+  // git_worktrees semantics instead: null means detached. Do not copy display
+  // SHAs into workspace rows or they become PR-eligible pseudo-branches.
+  if (branch && /^[0-9a-f]{7,40}$/i.test(branch)) return null;
+  return branch;
+}
+
+function workspaceWithBranch(workspace: Workspace, branch: string | null) {
+  if (workspace.branch === branch) return workspace;
+  const labelTracksPreviousBranch =
+    workspace.label !== undefined && workspace.label === workspace.branch;
+  return {
+    ...workspace,
+    branch,
+    ...(labelTracksPreviousBranch ? { label: undefined } : {}),
+  };
+}
+
+export interface ApplyActiveVcsGitStatusInput {
+  projects: ProjectsState;
+  gitStatuses: Map<string, GitStatus>;
+  root: string;
+  status: GitStatus | null;
+}
+
+export interface ApplyActiveVcsGitStatusResult {
+  projects: ProjectsState;
+  changed: boolean;
+}
+
+/**
+ * Fold the active-root git_status result from /vcs into the project mirror
+ * sources before the UI state is rebuilt. This keeps the sidebar project chip,
+ * workspace rows, and side-panel headers on the same HEAD branch as /vcs in one
+ * React store transaction instead of waiting for the colder project poller or a
+ * separate git_worktrees refresh.
+ */
+export function applyActiveVcsGitStatusToProjects({
+  projects,
+  gitStatuses,
+  root,
+  status,
+}: ApplyActiveVcsGitStatusInput): ApplyActiveVcsGitStatusResult {
+  let changed = false;
+  const previousStatus = gitStatuses.get(root);
+  if (status) {
+    if (!gitStatusEquals(previousStatus, status)) {
+      gitStatuses.set(root, status);
+      changed = true;
+    }
+  } else if (previousStatus) {
+    gitStatuses.delete(root);
+    changed = true;
+  }
+
+  const branch = workspaceBranchFromGitStatus(status);
+  let workspacesByProject = projects.workspacesByProject;
+  for (const [projectId, workspaces] of Object.entries(
+    projects.workspacesByProject,
+  )) {
+    let listChanged = false;
+    const next = workspaces.map((workspace) => {
+      if (workspace.path !== root) return workspace;
+      const updated = workspaceWithBranch(workspace, branch);
+      if (updated !== workspace) listChanged = true;
+      return updated;
+    });
+    if (listChanged) {
+      if (workspacesByProject === projects.workspacesByProject) {
+        workspacesByProject = { ...projects.workspacesByProject };
+      }
+      workspacesByProject[projectId] = next;
+      changed = true;
+    }
+  }
+
+  return {
+    projects:
+      workspacesByProject === projects.workspacesByProject
+        ? projects
+        : { ...projects, workspacesByProject },
+    changed,
+  };
+}

--- a/src/hooks/useAppStateRefs.ts
+++ b/src/hooks/useAppStateRefs.ts
@@ -3,6 +3,7 @@ import type { ChatMessage } from "../types/a2ui";
 import { emptyProjectsState, type ProjectsState } from "../projects";
 import type { AppStore } from "../state/appStore";
 import type { NotificationInput } from "./useNotifications";
+import type { GitStatus } from "./useProjects";
 
 export interface ProjectOpsHandle {
   clearActiveProject: () => void;
@@ -12,6 +13,12 @@ export interface ProjectOpsHandle {
 export interface ProjectsHandle {
   getPaths: () => string[];
   onGitStatusChanged: () => void;
+  applyVcsGitStatus: (
+    root: string,
+    status: GitStatus | null,
+  ) =>
+    | ((nextState: Record<string, unknown>) => Partial<Record<string, unknown>>)
+    | undefined;
 }
 
 export interface ChatActionsHandle {
@@ -59,6 +66,7 @@ export function useAppStateRefs(appStore: AppStore): AppStateRefs {
     projectsHandleRef: useRef<ProjectsHandle>({
       getPaths: () => [],
       onGitStatusChanged: () => {},
+      applyVcsGitStatus: () => undefined,
     }),
     pushNotificationRef: useRef<(n: NotificationInput) => void>(() => {}),
     chatActionsRef: useRef<ChatActionsHandle>({

--- a/src/hooks/useProjectOps.ts
+++ b/src/hooks/useProjectOps.ts
@@ -449,6 +449,7 @@ export function useProjectOps(ctx: UseProjectOpsContext): UseProjectOpsActions {
     scopedDiscoveredSessions,
     recentSessionItems,
     syncRecentSessionsToState,
+    buildProjectsMirror,
     syncProjectsToState,
     persistProjects,
     openProjectFromPicker,

--- a/src/hooks/useVcsStatus.test.ts
+++ b/src/hooks/useVcsStatus.test.ts
@@ -40,16 +40,27 @@ import { __TEST__ as vcsCacheTest } from "../vcsSliceCache";
 
 /** A setState double that applies the functional-update form and records
  *  the latest `/vcs` slice the hook wrote. */
-function makeSetState() {
+function makeSetState(opts: { replayFunctionalUpdaters?: boolean } = {}) {
   let store: Record<string, unknown> = {};
   const setState = (
     u:
       | Record<string, unknown>
       | ((s: Record<string, unknown>) => Record<string, unknown>),
   ) => {
-    store = typeof u === "function" ? u(store) : u;
+    if (typeof u !== "function") {
+      store = u;
+      return;
+    }
+    if (opts.replayFunctionalUpdaters) {
+      u(store);
+    }
+    store = u(store);
   };
-  return { setState, vcs: () => store.vcs as VcsSlice | undefined };
+  return {
+    setState,
+    state: () => store,
+    vcs: () => store.vcs as VcsSlice | undefined,
+  };
 }
 
 beforeEach(() => {
@@ -153,6 +164,58 @@ describe("useVcsStatus", () => {
     expect(vcs.ci).toBeNull();
     expect(branchMock).not.toHaveBeenCalled();
     expect(checksMock).not.toHaveBeenCalled();
+  });
+
+  it("commits active git status mirror with the settled /vcs slice", async () => {
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === "git_status") {
+        return Promise.resolve({
+          branch: "main",
+          ahead: 6,
+          behind: 1,
+          dirty: false,
+        });
+      }
+      if (cmd === "git_file_status") return Promise.resolve([]);
+      return Promise.resolve(null);
+    });
+    branchMock.mockResolvedValue(null);
+    checksMock.mockResolvedValue(null);
+    const mirror = vi.fn((_root, status) => () => ({
+      sidebar: { projects: [{ id: "project-1", git: status }] },
+    }));
+
+    const h = makeSetState({ replayFunctionalUpdaters: true });
+    renderHook(() =>
+      useVcsStatus({
+        activeRoot: "/repo",
+        setState: h.setState,
+        onGitStatusSettled: mirror,
+      }),
+    );
+
+    await waitFor(() => expect(h.vcs()?.loading).toBe(false));
+    expect(mirror).toHaveBeenLastCalledWith(
+      "/repo",
+      { branch: "main", ahead: 6, behind: 1, dirty: false },
+    );
+    expect(mirror.mock.results.at(-1)?.value).toEqual(expect.any(Function));
+    expect(mirror.mock.results.at(-1)?.value(h.state())).toEqual(
+      expect.objectContaining({
+        sidebar: {
+          projects: [
+            {
+              id: "project-1",
+              git: { branch: "main", ahead: 6, behind: 1, dirty: false },
+            },
+          ],
+        },
+      }),
+    );
+    expect(h.state()).toMatchObject({
+      vcs: { branch: "main", loading: false },
+      sidebar: { projects: [{ id: "project-1", git: { branch: "main" } }] },
+    });
   });
 
   it("fetches a newly selected root even while the previous poll is in flight", async () => {

--- a/src/hooks/useVcsStatus.ts
+++ b/src/hooks/useVcsStatus.ts
@@ -53,6 +53,13 @@ interface GitStatus {
   behind?: number;
 }
 
+export interface VcsGitStatus {
+  branch?: string;
+  dirty?: boolean;
+  ahead?: number;
+  behind?: number;
+}
+
 export interface VcsChanges {
   total: number;
   modified: number;
@@ -107,6 +114,19 @@ export interface UseVcsStatusContext {
   /** Active project/workspace cwd (workspace-aware). Null collapses /vcs. */
   activeRoot: string | null;
   setState: Dispatch<SetStateAction<Record<string, unknown>>>;
+  /**
+   * Optional project/sidebar mirror patcher. Called from the same setState
+   * updater that commits the settled /vcs slice so active-root branch changes
+   * paint atomically across all chrome surfaces.
+   */
+  onGitStatusSettled?: (
+    root: string,
+    status: VcsGitStatus | null,
+  ) =>
+    | ((nextState: Record<string, unknown>) =>
+        | Partial<Record<string, unknown>>
+        | void)
+    | void;
 }
 
 const POLL_INTERVAL_MS = 20_000;
@@ -153,6 +173,24 @@ function emptySlice(root: string | null, loading: boolean): VcsSlice {
     changes: EMPTY_CHANGES,
     pr: null,
     ci: null,
+  };
+}
+
+function gitStatusFromSlice(slice: VcsSlice): VcsGitStatus | null {
+  if (
+    !slice.branch &&
+    !slice.dirty &&
+    slice.ahead === 0 &&
+    slice.behind === 0 &&
+    slice.changes.total === 0
+  ) {
+    return null;
+  }
+  return {
+    ...(slice.branch ? { branch: slice.branch } : {}),
+    dirty: slice.dirty,
+    ahead: slice.ahead,
+    behind: slice.behind,
   };
 }
 
@@ -210,7 +248,11 @@ function pickPr(prs: GhPr[]): VcsPr | null {
   };
 }
 
-export function useVcsStatus({ activeRoot, setState }: UseVcsStatusContext): void {
+export function useVcsStatus({
+  activeRoot,
+  setState,
+  onGitStatusSettled,
+}: UseVcsStatusContext): void {
   useEffect(() => {
     let cancelled = false;
     // In-flight guard is effect-scoped (one per root), NOT a component-wide
@@ -239,7 +281,18 @@ export function useVcsStatus({ activeRoot, setState }: UseVcsStatusContext): voi
       if (slice.root && !slice.loading) {
         putCachedVcsSlice(slice.root, slice);
       }
-      setState((s) => ({ ...s, vcs: slice }));
+      const mirrorPatchForState =
+        !slice.loading && slice.root
+          ? onGitStatusSettled?.(slice.root, gitStatusFromSlice(slice))
+          : undefined;
+      setState((s) => {
+        const next = { ...s, vcs: slice };
+        const mirrorPatch = mirrorPatchForState?.(next);
+        if (mirrorPatch && Object.keys(mirrorPatch).length > 0) {
+          return { ...next, ...mirrorPatch };
+        }
+        return next;
+      });
     };
 
     if (!activeRoot) {


### PR DESCRIPTION
## Summary

- mirror settled active `/vcs` git status into the sidebar/project git cache in the same React state transaction
- update matching workspace branch metadata from the same active HEAD source, clearing stale auto branch-tracking labels while preserving manual labels
- persist the updated git-status cache and handle detached HEAD display SHAs without turning them into workspace branch names

Closes #440.

## Validation

- `bunx eslint .`
- `bunx tsc -b --noEmit`
- `bunx vitest run src/hooks/projectOps/vcsGitMirror.test.ts src/hooks/useVcsStatus.test.ts src/hooks/useProjectOps.test.ts src/hooks/useProjects.test.ts src/extensions/default-layout/sidebar/file-tree.test.tsx src/extensions/default-layout/sidebar/index.test.tsx src/extensions/default-layout/sidebar/workspace-row.test.tsx`
- `bunx vitest run`

Note: full Vitest passes with existing jsdom/Monaco canvas/document warnings in the environment.
