### PR TITLE
fix(transcript): suppress hidden live activity flashes

### DIFF
--- a/src/extensions/default-layout/chat.test.tsx
+++ b/src/extensions/default-layout/chat.test.tsx
@@ -642,6 +642,45 @@ describe("ChatInput", () => {
     expect(screen.getByText("Streaming the answer")).toBeTruthy();
   });
 
+  it("does not show live fallback activity derived only from hidden thinking", () => {
+    const { container } = renderMainCanvas({
+      waiting: true,
+      messages: [
+        { id: "1", role: "user", text: "start" },
+        { id: "2", role: "agent", thinking: "private reasoning" },
+      ],
+      transcriptVisibility: { thinking: "hide" },
+    });
+
+    expect(screen.queryByText("private reasoning")).toBeNull();
+    expect(screen.queryByText("Writing response")).toBeNull();
+    expect(screen.queryByText("Streaming the answer")).toBeNull();
+    expect(screen.queryByText("Thinking through next step")).toBeNull();
+    expect(container.querySelector(".a2ui-msg-row-footer")).toBeNull();
+  });
+
+  it("does not show live fallback activity derived only from hidden thinking tags", () => {
+    const { container } = renderMainCanvas({
+      waiting: true,
+      messages: [
+        { id: "1", role: "user", text: "start" },
+        {
+          id: "2",
+          role: "agent",
+          text: "<thinking>private reasoning</thinking>",
+        },
+      ],
+      transcriptVisibility: { thinking: "hide" },
+    });
+
+    expect(screen.queryByText("private reasoning")).toBeNull();
+    expect(screen.queryByText("Writing response")).toBeNull();
+    expect(screen.queryByText("Streaming the answer")).toBeNull();
+    expect(screen.queryByText("Thinking through next step")).toBeNull();
+    expect(container.querySelector(".a2ui-canvas-message.agent")).toBeNull();
+    expect(container.querySelector(".a2ui-msg-row-footer")).toBeNull();
+  });
+
   it("does not infer tool-specific footer activity from planning prose", () => {
     renderMainCanvas({
       waiting: true,
@@ -715,8 +754,8 @@ describe("ChatInput", () => {
     expect(screen.getByText("Streaming the answer")).toBeTruthy();
   });
 
-  it("does not show the footer activity indicator when running tool activity is visible", () => {
-    renderMainCanvas({
+  it("does not show tool-derived live activity when running tool cards are hidden", () => {
+    const { container } = renderMainCanvas({
       waiting: true,
       messages: [
         { id: "1", role: "user", text: "start" },
@@ -743,13 +782,18 @@ describe("ChatInput", () => {
       transcriptVisibility: { toolCalls: "hide" },
     });
 
-    expect(screen.getByText("Searching files")).toBeTruthy();
+    expect(screen.queryByText("Searching files")).toBeNull();
+    expect(screen.queryByText("Looking for relevant matches")).toBeNull();
+    expect(screen.queryByText("bash")).toBeNull();
+    expect(screen.queryByText("rg message-row")).toBeNull();
+    expect(container.querySelector(".ae-live-activity-card")).toBeNull();
+    expect(container.querySelector(".ae-turn-activity")).toBeNull();
     expect(screen.queryByText("Thinking through next step")).toBeNull();
   });
 
-  it("does not duplicate footer activity when hidden running tools already summarize it", () => {
+  it("does not show delayed agent activity when hidden running tools are present", () => {
     vi.useFakeTimers();
-    renderMainCanvas(
+    const { container } = renderMainCanvas(
       {
         waiting: true,
         agentActivityByTab: {
@@ -789,12 +833,15 @@ describe("ChatInput", () => {
 
     act(() => vi.runOnlyPendingTimers());
 
-    expect(screen.getAllByText("Running checks")).toHaveLength(1);
-    expect(screen.getAllByText("Waiting for results")).toHaveLength(1);
+    expect(screen.queryByText("Running checks")).toBeNull();
+    expect(screen.queryByText("Waiting for results")).toBeNull();
+    expect(screen.queryByText("bunx vitest run && bunx eslint .")).toBeNull();
+    expect(container.querySelector(".ae-live-activity-card")).toBeNull();
+    expect(container.querySelector(".a2ui-msg-row-footer")).toBeNull();
   });
 
-  it("labels hidden running directory tools as directory reading", () => {
-    renderMainCanvas({
+  it("keeps hidden running directory tools out of live activity", () => {
+    const { container } = renderMainCanvas({
       waiting: true,
       messages: [
         { id: "1", role: "user", text: "summarize this directory" },
@@ -821,9 +868,14 @@ describe("ChatInput", () => {
       transcriptVisibility: { toolCalls: "hide" },
     });
 
-    expect(screen.getByText("Reading directory contents")).toBeTruthy();
-    expect(screen.getByText("Inspecting files and folders")).toBeTruthy();
+    expect(screen.queryByText("Reading directory contents")).toBeNull();
+    expect(screen.queryByText("Inspecting files and folders")).toBeNull();
+    expect(
+      screen.queryByText("find . -maxdepth 2 -type f | head -200"),
+    ).toBeNull();
     expect(screen.queryByText("Writing response")).toBeNull();
+    expect(container.querySelector(".ae-live-activity-card")).toBeNull();
+    expect(container.querySelector(".ae-turn-activity")).toBeNull();
   });
 
   it("shows the pill and stops following when the user scrolls up", () => {
@@ -3169,7 +3221,9 @@ describe("ChatHistory turn activity feed (mocked Virtuoso renders rows)", () => 
         {
           id: "t1",
           role: "agent",
-          a2ui: { components: [mkCard("c1", "first out"), mkCard("c2", "second out")] },
+          a2ui: {
+            components: [mkCard("c1", "first out"), mkCard("c2", "second out")],
+          },
         },
       ],
       waiting: false,
@@ -3302,7 +3356,7 @@ describe("ChatHistory turn activity feed (mocked Virtuoso renders rows)", () => 
     ).toBeNull();
   });
 
-  it("hide still surfaces live running tool activity without persisting tool details", () => {
+  it("hide suppresses live running tool activity and tool details", () => {
     const { container } = renderGroupedHistory({
       messages: [
         { id: "u1", role: "user", text: "inspect files" },
@@ -3336,12 +3390,13 @@ describe("ChatHistory turn activity feed (mocked Virtuoso renders rows)", () => 
       transcriptVisibility: { toolCalls: "hide" },
     });
 
-    expect(screen.getByText("Searching files")).toBeTruthy();
-    expect(screen.getByText("Looking for relevant matches")).toBeTruthy();
+    expect(screen.queryByText("Searching files")).toBeNull();
+    expect(screen.queryByText("Looking for relevant matches")).toBeNull();
     expect(screen.queryByText("bash")).toBeNull();
     expect(screen.queryByText("rg message-row")).toBeNull();
     expect(screen.queryByText("raw running output")).toBeNull();
-    expect(container.querySelector(".ae-live-activity-card")).toBeTruthy();
+    expect(container.querySelector(".ae-live-activity-card")).toBeNull();
+    expect(container.querySelector(".ae-turn-activity")).toBeNull();
   });
 
   it("show expands activity by default", () => {

--- a/src/extensions/default-layout/layout/status-bar.tsx
+++ b/src/extensions/default-layout/layout/status-bar.tsx
@@ -8,6 +8,7 @@
 
 import { resolvePointer } from "../../../utils/jsonPointer";
 import { resolveString } from "../../../utils/dataBinding";
+import { resolveVisibility } from "../../../utils/visibilityResolver";
 import type { BuiltinComponentProps } from "../../../components/A2UIRenderer";
 import type { StringValue } from "../../../types/a2ui";
 import type { DevshellEntry } from "../../../hooks/useDevshell";
@@ -46,10 +47,12 @@ export function StatusBar({ component, state }: BuiltinComponentProps) {
   const messages = Array.isArray(state.messages)
     ? (state.messages as ChatMessage[])
     : [];
+  const visibility = resolveVisibility(state, activeTabId);
   const fallbackActivity = visibleAgentActivity
     ? null
     : fallbackAgentActivityForTab(state, activeTabId, messages, {
         allowEmpty: true,
+        thinkingVisibility: visibility.thinking,
       });
   const statusAgentActivity = visibleAgentActivity ?? fallbackActivity;
   const centerStatus = statusAgentActivity ?? {

--- a/src/extensions/default-layout/message-list.tsx
+++ b/src/extensions/default-layout/message-list.tsx
@@ -128,7 +128,9 @@ export function MainCanvas({
   const footerAgentActivity = hasRunningToolCard ? null : agentActivity;
   const fallbackActivity =
     !liveSubtree && !footerAgentActivity && !hasRunningToolCard
-      ? fallbackAgentActivityForTab(state, tabId, messages)
+      ? fallbackAgentActivityForTab(state, tabId, messages, {
+          thinkingVisibility: visibility.thinking,
+        })
       : null;
   const footerContext: CanvasFooterContext = {
     liveSubtree,

--- a/src/extensions/default-layout/message-row-state.test.ts
+++ b/src/extensions/default-layout/message-row-state.test.ts
@@ -89,6 +89,71 @@ describe("fallbackAgentActivityForTab", () => {
     });
   });
 
+  it("does not derive fallback activity from hidden thinking-only messages", () => {
+    expect(
+      fallbackAgentActivityForTab(
+        { waiting: true, activeTabId: "tab-1" },
+        "tab-1",
+        [
+          { role: "user", text: "start" },
+          { role: "agent", thinking: "internal chain" },
+        ],
+        { thinkingVisibility: "hide" },
+      ),
+    ).toBeNull();
+  });
+
+  it("does not derive fallback activity from hidden embedded thinking-only text", () => {
+    expect(
+      fallbackAgentActivityForTab(
+        { waiting: true, activeTabId: "tab-1" },
+        "tab-1",
+        [
+          { role: "user", text: "start" },
+          { role: "agent", text: "<thinking>internal chain</thinking>" },
+        ],
+        { thinkingVisibility: "hide" },
+      ),
+    ).toBeNull();
+  });
+
+  it("uses writing copy for thinking-only messages when thinking is visible", () => {
+    expect(
+      fallbackAgentActivityForTab(
+        { waiting: true, activeTabId: "tab-1" },
+        "tab-1",
+        [
+          { role: "user", text: "start" },
+          { role: "agent", thinking: "visible reasoning" },
+        ],
+        { thinkingVisibility: "show" },
+      ),
+    ).toEqual({
+      label: "Writing response",
+      detail: "Streaming the answer",
+    });
+  });
+
+  it("keeps writing copy when visible text surrounds hidden embedded thinking", () => {
+    expect(
+      fallbackAgentActivityForTab(
+        { waiting: true, activeTabId: "tab-1" },
+        "tab-1",
+        [
+          { role: "user", text: "start" },
+          {
+            role: "agent",
+            text: "<thinking>internal chain</thinking>visible answer",
+          },
+        ],
+        { thinkingVisibility: "hide" },
+      ),
+    ).toEqual({
+      label: "Writing response",
+      detail: "Streaming the answer",
+    });
+  });
+
   it("can provide generic status for footer-only empty transcripts", () => {
     expect(
       fallbackAgentActivityForTab(

--- a/src/extensions/default-layout/message-row-state.test.ts
+++ b/src/extensions/default-layout/message-row-state.test.ts
@@ -103,6 +103,23 @@ describe("fallbackAgentActivityForTab", () => {
     ).toBeNull();
   });
 
+  it("ignores whitespace-only thinking when choosing fallback activity", () => {
+    expect(
+      fallbackAgentActivityForTab(
+        { waiting: true, activeTabId: "tab-1" },
+        "tab-1",
+        [
+          { role: "user", text: "start" },
+          { role: "agent", thinking: "   \n\t  " },
+        ],
+        { thinkingVisibility: "hide" },
+      ),
+    ).toEqual({
+      label: "Thinking through next step",
+      detail: "Waiting for the next update",
+    });
+  });
+
   it("does not derive fallback activity from hidden embedded thinking-only text", () => {
     expect(
       fallbackAgentActivityForTab(

--- a/src/extensions/default-layout/message-row-state.ts
+++ b/src/extensions/default-layout/message-row-state.ts
@@ -1,3 +1,6 @@
+import type { VisibilityMode } from "../../config";
+import { textDisplayVisibility } from "./turn-activity-helpers";
+
 export function tabIsRunning(
   state: Record<string, unknown>,
   tabId?: string,
@@ -26,17 +29,32 @@ export function fallbackAgentActivityForTab(
   state: Record<string, unknown>,
   tabId: string | undefined,
   messages: readonly { role?: unknown; text?: unknown; thinking?: unknown }[],
-  options: { allowEmpty?: boolean } = {},
+  options: { allowEmpty?: boolean; thinkingVisibility?: VisibilityMode } = {},
 ): FallbackAgentActivity | null {
   if (!tabIsRunning(state, tabId)) return null;
   if (messages.length === 0 && options.allowEmpty !== true) return null;
   const latestMessage = messages.at(-1);
-  const latestAgentProseVisible =
+  const thinkingVisibility = options.thinkingVisibility ?? "show";
+  const textVisibility =
+    latestMessage?.role === "agent"
+      ? textDisplayVisibility(latestMessage.text, thinkingVisibility)
+      : { visible: false, hiddenThinkingOnly: false };
+  const latestAgentTextVisible = textVisibility.visible;
+  const latestAgentThinkingPresent =
     latestMessage?.role === "agent" &&
-    ((typeof latestMessage.text === "string" &&
-      latestMessage.text.length > 0) ||
-      (typeof latestMessage.thinking === "string" &&
-        latestMessage.thinking.length > 0));
+    typeof latestMessage.thinking === "string" &&
+    latestMessage.thinking.length > 0;
+  const latestAgentThinkingVisible =
+    thinkingVisibility === "show" && latestAgentThinkingPresent;
+  if (
+    (latestAgentThinkingPresent || textVisibility.hiddenThinkingOnly) &&
+    !latestAgentTextVisible &&
+    !latestAgentThinkingVisible
+  ) {
+    return null;
+  }
+  const latestAgentProseVisible =
+    latestAgentTextVisible || latestAgentThinkingVisible;
   return latestAgentProseVisible
     ? {
         label: "Writing response",

--- a/src/extensions/default-layout/message-row-state.ts
+++ b/src/extensions/default-layout/message-row-state.ts
@@ -43,7 +43,7 @@ export function fallbackAgentActivityForTab(
   const latestAgentThinkingPresent =
     latestMessage?.role === "agent" &&
     typeof latestMessage.thinking === "string" &&
-    latestMessage.thinking.length > 0;
+    latestMessage.thinking.trim().length > 0;
   const latestAgentThinkingVisible =
     thinkingVisibility === "show" && latestAgentThinkingPresent;
   if (

--- a/src/extensions/default-layout/turn-activity-helpers.ts
+++ b/src/extensions/default-layout/turn-activity-helpers.ts
@@ -1,11 +1,41 @@
 import type { ChatMessage } from "../../types/a2ui";
 import type { VisibilityMode } from "../../config";
+import { splitThinkingBlocks } from "../../utils/thinkingBlocks";
+
+export interface TextDisplayVisibility {
+  visible: boolean;
+  hiddenThinkingOnly: boolean;
+}
+
+export function textDisplayVisibility(
+  text: unknown,
+  thinkingVisibility: VisibilityMode,
+): TextDisplayVisibility {
+  if (typeof text !== "string" || text.length === 0) {
+    return { visible: false, hiddenThinkingOnly: false };
+  }
+  const segments = splitThinkingBlocks(text);
+  let hasHiddenThinking = false;
+  let hasVisibleContent = false;
+  for (const segment of segments) {
+    if (segment.content.trim().length === 0) continue;
+    if (segment.type === "thinking" && thinkingVisibility !== "show") {
+      hasHiddenThinking = true;
+      continue;
+    }
+    hasVisibleContent = true;
+  }
+  return {
+    visible: hasVisibleContent,
+    hiddenThinkingOnly: hasHiddenThinking && !hasVisibleContent,
+  };
+}
 
 export function hasDisplayableAgentContent(
   message: ChatMessage,
   thinkingVisibility: VisibilityMode,
 ): boolean {
-  if (typeof message.text === "string" && message.text.trim().length > 0) {
+  if (textDisplayVisibility(message.text, thinkingVisibility).visible) {
     return true;
   }
   if (message.a2ui) return true;

--- a/src/extensions/default-layout/turn-activity.tsx
+++ b/src/extensions/default-layout/turn-activity.tsx
@@ -19,7 +19,6 @@ import {
   fileChangeStatsLabel,
   hasFileChange,
   hasToolCardChildren,
-  liveActivitySummary,
   summaryWithFileEntries,
   toolDurationLabel,
   toolStateLabel,
@@ -29,7 +28,6 @@ import {
   ToolFileChangesCard,
   ToolFileChangeRow,
 } from "./tool-file-changes";
-import { LiveActivityCard } from "./live-activity-card";
 
 const ACTIVITY_DISCLOSURE_EXIT_MS = 240;
 
@@ -135,15 +133,13 @@ export function TurnActivity({
     setAllExpanded(next);
     // Dispatch only to the cards inside THIS turn's subtree so sibling
     // turns are unaffected.
-    turnRef.current
-      ?.querySelectorAll(".ae-tool-card")
-      .forEach((el) =>
-        el.dispatchEvent(
-          new CustomEvent("aethon:tool-card-set-open", {
-            detail: { open: next },
-          }),
-        ),
-      );
+    turnRef.current?.querySelectorAll(".ae-tool-card").forEach((el) =>
+      el.dispatchEvent(
+        new CustomEvent("aethon:tool-card-set-open", {
+          detail: { open: next },
+        }),
+      ),
+    );
   };
   const progressMessages =
     live || forceOpen
@@ -159,7 +155,7 @@ export function TurnActivity({
   const summarizedToolMessages = showGenericTools
     ? allToolMessages
     : live
-      ? runningTools
+      ? []
       : allToolMessages.filter(hasFileChange);
   const allFileChangeEntries = collectFileChangeEntries(summarizedToolMessages);
   const summary = summaryWithFileEntries(
@@ -172,10 +168,6 @@ export function TurnActivity({
     summary.running === 0 &&
     summary.failed === 0 &&
     summary.cancelled === 0;
-  const liveOnlyActivity = live && !showGenericTools && runningTools.length > 0;
-  const liveOnlySummary = liveOnlyActivity
-    ? liveActivitySummary(runningTools)
-    : null;
   const defaultDetailsOpen =
     expanded || toolCallsVisibility === "show" || completedFileActivity;
   const detailsOpen = forceOpen || (manualOpen ?? defaultDetailsOpen);
@@ -204,19 +196,17 @@ export function TurnActivity({
     ? []
     : collectFileChangeEntries(allToolMessages.filter(hasFileChange));
   const detailToolRows =
-    liveOnlyActivity && detailsBodyVisible
-      ? runningTools
-      : showOriginalToolCards || !showGenericTools
-        ? []
-        : detailTools.filter(
-            (message) =>
-              !hasFileChange(message) && !originalToolCardIds.has(message.id),
-          );
+    showOriginalToolCards || !showGenericTools
+      ? []
+      : detailTools.filter(
+          (message) =>
+            !hasFileChange(message) && !originalToolCardIds.has(message.id),
+        );
   const hasActivity =
     progressMessages.length > 0 ||
     summary.fileChanges.total > 0 ||
     summarizedToolMessages.length > 0 ||
-    runningTools.length > 0;
+    (showGenericTools && runningTools.length > 0);
 
   useEffect(
     () => () => {
@@ -235,17 +225,6 @@ export function TurnActivity({
   }, [detailsBodyVisible]);
 
   if (!hasActivity) return null;
-  if (liveOnlyActivity) {
-    if (!liveOnlySummary) return null;
-    return (
-      <div className="ae-turn-activity ae-turn-activity-live-summary">
-        <LiveActivityCard
-          label={liveOnlySummary.label}
-          detail={liveOnlySummary.detail}
-        />
-      </div>
-    );
-  }
   const label = activityLabel({
     summary,
     progressCount: progressMessages.length,
@@ -378,7 +357,7 @@ export function TurnActivity({
           )}
         </div>
       )}
-      {!detailsOpen && runningTools.length > 0 && (
+      {showGenericTools && !detailsOpen && runningTools.length > 0 && (
         <div className="ae-turn-activity-live-tools" data-state="open">
           {runningTools.map((message) => (
             <ToolActivityRow


### PR DESCRIPTION
## Summary

Closes #451.

- Stop rendering live running tool activity cards/rows when tool-call visibility is `hide`.
- Thread effective thinking visibility into live fallback activity so hidden thinking-only messages do not show a transient "Writing response" or generic thinking footer.
- Share thinking-tag-aware text visibility with row displayability so hidden `<think>` / `<thinking>` deltas do not create empty agent transcript rows.
- Add regressions for hidden running tools, hidden `thinking` fields, and hidden embedded thinking tags.

## Validation

- `bunx vitest run src/extensions/default-layout/message-row-state.test.ts src/extensions/default-layout/chat.test.tsx -t "hidden thinking|hidden running|hide suppresses live running|tool-derived live activity|delayed agent activity|fallbackAgentActivityForTab"`
- `bunx tsc -b --noEmit`
- `bun run lint`
- `bunx vitest run` (350 files / 2951 tests)
- `codex review --uncommitted --title "Issue 451 transcript visibility live activity fix"` (addressed two valid findings, final pass clean)

## Notes

The durable completed edit artifact path for hidden tool calls remains intact; this only suppresses transient/live affordances derived from hidden content.
