### PR TITLE
feat(remote): iOS companion gateway (Phase 1 — desktop remote gateway)

### DIFF
--- a/cli/aethonRemote.ts
+++ b/cli/aethonRemote.ts
@@ -1,0 +1,243 @@
+#!/usr/bin/env bun
+//! Smoke client for the Aethon remote gateway (the iOS companion's
+//! transport). Doubles as executable documentation of wire protocol v1:
+//! `pair` redeems a code for a device token; `chat` opens the WebSocket,
+//! authenticates, sends a turn, and streams the agent-response frames.
+//!
+//! Uses the plaintext `ws://` transport, which the desktop exposes only
+//! when `[server] allow_insecure_ws = true` (dev loop). The production
+//! iOS client speaks `wss://` with the pinned cert fingerprint from the
+//! QR payload; that pinning needs a native TLS stack, so it lives in the
+//! mobile shell, not here.
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { homedir } from "node:os";
+
+interface RemoteFrameResult {
+  t: "result";
+  id: string;
+  ok: boolean;
+  data?: unknown;
+  error?: string;
+}
+interface RemoteFrameEvent {
+  t: "event";
+  topic: string;
+  seq: number;
+  payload: unknown;
+}
+interface RemoteFrameHello {
+  t: "hello_ok";
+  protocol: number;
+  host: { displayName: string; fingerprint: string };
+  deviceId: string;
+  appVersion: string;
+}
+interface RemoteFrameBye {
+  t: "bye";
+  reason: string;
+}
+type ServerFrame = RemoteFrameResult | RemoteFrameEvent | RemoteFrameHello | RemoteFrameBye;
+
+interface Options {
+  host: string;
+  token?: string;
+  json: boolean;
+}
+
+const TOKEN_FILE = join(homedir(), ".aethon", "remote", "cli-token.json");
+
+function loadSavedToken(host: string): string | undefined {
+  try {
+    const saved = JSON.parse(readFileSync(TOKEN_FILE, "utf8")) as Record<string, string>;
+    return saved[host];
+  } catch {
+    return undefined;
+  }
+}
+
+function saveToken(host: string, token: string): void {
+  let saved: Record<string, string> = {};
+  try {
+    saved = JSON.parse(readFileSync(TOKEN_FILE, "utf8")) as Record<string, string>;
+  } catch {
+    // First token — the file doesn't exist yet.
+  }
+  saved[host] = token;
+  mkdirSync(dirname(TOKEN_FILE), { recursive: true });
+  writeFileSync(TOKEN_FILE, JSON.stringify(saved, null, 2), { mode: 0o600 });
+}
+
+/** Redeem an 8-digit pairing code (shown on the desktop) for a durable
+ *  device token, and cache it under the host key. */
+async function pair(host: string, code: string): Promise<void> {
+  const res = await fetch(`http://${host}/pair`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ code, deviceName: "aethonRemote CLI", platform: "cli" }),
+  });
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    throw new Error(`pair failed (${res.status}): ${body.error ?? res.statusText}`);
+  }
+  const body = (await res.json()) as { deviceId: string; deviceToken: string };
+  saveToken(host, body.deviceToken);
+  console.log(`paired as ${body.deviceId}; token cached in ${TOKEN_FILE}`);
+}
+
+/** Minimal correlated WebSocket client for the gateway. */
+class RemoteClient {
+  private ws: WebSocket;
+  private nextId = 1;
+  private pending = new Map<string, { resolve: (v: unknown) => void; reject: (e: Error) => void }>();
+  private eventHandlers: ((frame: RemoteFrameEvent) => void)[] = [];
+  private ready: Promise<RemoteFrameHello>;
+
+  constructor(host: string, token: string) {
+    this.ws = new WebSocket(`ws://${host}/ws`);
+    this.ready = new Promise<RemoteFrameHello>((resolve, reject) => {
+      this.ws.addEventListener("open", () => {
+        this.ws.send(JSON.stringify({ t: "hello", protocol: 1, token, deviceId: "cli", appVersion: "cli" }));
+      });
+      this.ws.addEventListener("error", () => reject(new Error("websocket error")));
+      this.ws.addEventListener("close", () => {
+        for (const { reject: rej } of this.pending.values()) rej(new Error("connection closed"));
+        this.pending.clear();
+      });
+      this.ws.addEventListener("message", (ev) => {
+        const frame = JSON.parse(String(ev.data)) as ServerFrame;
+        if (frame.t === "hello_ok") {
+          resolve(frame);
+        } else if (frame.t === "bye") {
+          reject(new Error(`gateway closed: ${frame.reason}`));
+        } else if (frame.t === "result") {
+          const entry = this.pending.get(frame.id);
+          if (entry) {
+            this.pending.delete(frame.id);
+            if (frame.ok) entry.resolve(frame.data);
+            else entry.reject(new Error(frame.error ?? "invoke failed"));
+          }
+        } else if (frame.t === "event") {
+          for (const handler of this.eventHandlers) handler(frame);
+        }
+      });
+    });
+  }
+
+  whenReady(): Promise<RemoteFrameHello> {
+    return this.ready;
+  }
+
+  onEvent(handler: (frame: RemoteFrameEvent) => void): void {
+    this.eventHandlers.push(handler);
+  }
+
+  invoke<T = unknown>(cmd: string, args: Record<string, unknown> = {}): Promise<T> {
+    const id = `i-${this.nextId++}`;
+    return new Promise<T>((resolve, reject) => {
+      this.pending.set(id, { resolve: resolve as (v: unknown) => void, reject });
+      this.ws.send(JSON.stringify({ t: "invoke", id, cmd, args }));
+    });
+  }
+
+  subscribe(topics: string[]): void {
+    this.ws.send(JSON.stringify({ t: "sub", topics }));
+  }
+
+  close(): void {
+    this.ws.close();
+  }
+}
+
+/** Parse the JSON-string payload of an agent-response event into a
+ *  bridge message; the gateway forwards it verbatim. */
+function bridgeMessage(frame: RemoteFrameEvent): Record<string, unknown> | undefined {
+  if (typeof frame.payload !== "string") return undefined;
+  try {
+    return JSON.parse(frame.payload) as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+}
+
+async function chat(opts: Options, message: string): Promise<void> {
+  const token = opts.token ?? loadSavedToken(opts.host);
+  if (!token) throw new Error(`no token for ${opts.host}; run: aethonRemote --host ${opts.host} pair <code>`);
+  const client = new RemoteClient(opts.host, token);
+  const hello = await client.whenReady();
+  if (!opts.json) console.error(`connected to ${hello.host.displayName} (aethon ${hello.appVersion})`);
+
+  const done = new Promise<void>((resolve) => {
+    client.onEvent((frame) => {
+      if (frame.topic !== "agent-response") return;
+      const msg = bridgeMessage(frame);
+      if (!msg) return;
+      if (opts.json) {
+        console.log(JSON.stringify(msg));
+      } else if (msg.type === "response_delta" && msg.channel !== "thinking") {
+        if (typeof msg.content === "string") process.stdout.write(msg.content);
+      }
+      if (msg.type === "response_end") resolve();
+    });
+  });
+
+  client.subscribe(["agent-response"]);
+  await client.invoke("start_agent");
+  await client.invoke("send_message", { request: { message } });
+  await done;
+  if (!opts.json) process.stdout.write("\n");
+  client.close();
+}
+
+async function status(opts: Options): Promise<void> {
+  const token = opts.token ?? loadSavedToken(opts.host);
+  if (!token) throw new Error(`no token for ${opts.host}; pair first`);
+  const client = new RemoteClient(opts.host, token);
+  await client.whenReady();
+  const info = await client.invoke("remote_status");
+  console.log(JSON.stringify(info, null, 2));
+  client.close();
+}
+
+function parseArgs(argv: string[]): { opts: Options; cmd: string; rest: string[] } {
+  const opts: Options = { host: "127.0.0.1:0", json: false };
+  const rest: string[] = [];
+  let cmd = "";
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--host") opts.host = argv[++i];
+    else if (a === "--token") opts.token = argv[++i];
+    else if (a === "--json") opts.json = true;
+    else if (!cmd) cmd = a;
+    else rest.push(a);
+  }
+  return { opts, cmd, rest };
+}
+
+async function main(): Promise<void> {
+  const { opts, cmd, rest } = parseArgs(process.argv.slice(2));
+  if (opts.host === "127.0.0.1:0") {
+    console.error("usage: aethonRemote --host <host:port> <pair <code> | chat <message> | status> [--json]");
+    process.exit(2);
+  }
+  switch (cmd) {
+    case "pair":
+      await pair(opts.host, rest[0]);
+      break;
+    case "chat":
+      await chat(opts, rest.join(" "));
+      break;
+    case "status":
+      await status(opts);
+      break;
+    default:
+      console.error(`unknown command: ${cmd || "(none)"}`);
+      process.exit(2);
+  }
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+});

--- a/cli/aethonRemote.ts
+++ b/cli/aethonRemote.ts
@@ -65,7 +65,9 @@ function saveToken(host: string, token: string): void {
     // First token — the file doesn't exist yet.
   }
   saved[host] = token;
-  mkdirSync(dirname(TOKEN_FILE), { recursive: true });
+  // 0o700 so other local users can't even list the token filenames,
+  // matching the Rust-side set_dir_owner_only intent.
+  mkdirSync(dirname(TOKEN_FILE), { recursive: true, mode: 0o700 });
   writeFileSync(TOKEN_FILE, JSON.stringify(saved, null, 2), { mode: 0o600 });
 }
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -409,6 +409,7 @@ checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
  "axum-core",
+ "base64 0.22.1",
  "bytes",
  "futures-util",
  "http",
@@ -427,8 +428,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -4525,6 +4528,8 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -4534,8 +4539,18 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4553,6 +4568,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "rand_core"
@@ -6309,6 +6327,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6625,6 +6655,24 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.6",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
 
 [[package]]
 name = "typed-path"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -14,6 +14,7 @@ version = "0.11.2"
 dependencies = [
  "async-trait",
  "axum",
+ "axum-server",
  "base64 0.22.1",
  "candle-core",
  "candle-nn",
@@ -28,12 +29,15 @@ dependencies = [
  "notify",
  "parking_lot",
  "portable-pty",
+ "rcgen",
  "reqwest 0.12.28",
  "rubato",
  "rusqlite",
+ "rustls",
  "serde",
  "serde_json",
  "sha1",
+ "sha2",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
@@ -143,6 +147,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
+]
+
+[[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -404,6 +456,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-server"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ab4a3ec9ea8a657c72d99a03a824af695bd0fb5ec639ccbd9cd3543b41a5f9"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "fs-err",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -427,7 +501,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -435,6 +509,15 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -1123,6 +1206,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "dbus"
 version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1131,6 +1220,20 @@ dependencies = [
  "libc",
  "libdbus-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -1651,6 +1754,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs-err"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
+dependencies = [
+ "autocfg",
+ "tokio",
 ]
 
 [[package]]
@@ -2292,6 +2405,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2444,6 +2576,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -3773,6 +3906,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3913,6 +4055,16 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -4467,6 +4619,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
 name = "reborrow"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4712,6 +4878,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4730,6 +4905,7 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -4748,6 +4924,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -7756,6 +7941,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7763,6 +7966,16 @@ checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix",
+]
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec 0.9.1",
+ "time",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -24,6 +24,7 @@ dependencies = [
  "futures-util",
  "gethostname",
  "hound",
+ "if-addrs",
  "libc",
  "mdns-sd",
  "notify",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -49,6 +49,7 @@ dependencies = [
  "tempfile",
  "tokenizers",
  "tokio",
+ "tokio-tungstenite",
  "toml 0.8.23",
  "toml_edit 0.22.27",
  "tracing",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -68,6 +68,9 @@ rcgen = { version = "0.14", default-features = false, features = [
   "ring",
 ] }
 sha2 = "0.10"
+# QR pairing payload enumerates dialable interface addresses (already
+# transitive via mdns-sd; promoted for direct use).
+if-addrs = "0.13"
 sha1 = "0.10"
 chrono = { version = "0.4", default-features = false, features = [
   "std",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -50,6 +50,24 @@ tracing-appender = "0.2"
 mdns-sd = "0.12"
 gethostname = "1"
 axum = "0.7"
+# Remote gateway TLS: ring-flavored everywhere so we stay on the crypto
+# provider reqwest already links (aws-lc-rs would add a second provider
+# and a cmake build dep).
+axum-server = { version = "0.7", default-features = false, features = [
+  "tls-rustls-no-provider",
+] }
+rustls = { version = "0.23", default-features = false, features = [
+  "ring",
+  "log",
+  "std",
+  "tls12",
+] }
+rcgen = { version = "0.14", default-features = false, features = [
+  "crypto",
+  "pem",
+  "ring",
+] }
+sha2 = "0.10"
 sha1 = "0.10"
 chrono = { version = "0.4", default-features = false, features = [
   "std",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -112,6 +112,7 @@ voice = [
 [dev-dependencies]
 tempfile = "3"
 tokio = { version = "1.52.1", features = ["macros", "rt"] }
+tauri = { version = "2", features = ["test"] }
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -132,8 +132,9 @@ voice = [
 
 [dev-dependencies]
 tempfile = "3"
-tokio = { version = "1.52.1", features = ["macros", "rt"] }
+tokio = { version = "1.52.1", features = ["macros", "rt", "rt-multi-thread"] }
 tauri = { version = "2", features = ["test"] }
+tokio-tungstenite = "0.24"
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -49,7 +49,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tracing-appender = "0.2"
 mdns-sd = "0.12"
 gethostname = "1"
-axum = "0.7"
+axum = { version = "0.7", features = ["ws"] }
 # Remote gateway TLS: ring-flavored everywhere so we stay on the crypto
 # provider reqwest already links (aws-lc-rs would add a second provider
 # and a cmake build dep).

--- a/src-tauri/src/commands/host.rs
+++ b/src-tauri/src/commands/host.rs
@@ -5,9 +5,10 @@
 //! survive hostname rename and reinstall, falling back to a hash of the
 //! hostname if neither uuid source is available.
 //!
-//! The fingerprint is a placeholder until the pairing PR lands — same
-//! shape as Claudette's mdns TXT record so the wire format is forward
-//! compatible.
+//! The fingerprint is the SHA-256 of the remote gateway's TLS
+//! certificate (see `server::tls`) — the value paired clients pin.
+//! When the identity can't be created (unwritable user dir) it degrades
+//! to the legacy deterministic placeholder so `host_info` never fails.
 
 use serde::Serialize;
 use sha1::{Digest, Sha1};
@@ -94,9 +95,9 @@ fn stable_id(hostname: &str) -> String {
 }
 
 fn fingerprint_placeholder(id: &str) -> String {
-    // Deterministic per-host placeholder so two boots of the same Aethon
-    // advertise the same TXT value. Real cert fingerprints replace this
-    // when pairing lands.
+    // Deterministic per-host fallback so two boots of the same Aethon
+    // advertise the same TXT value even when the TLS identity can't be
+    // created. Pairing refuses hosts without a real cert fingerprint.
     let mut h = Sha1::new();
     h.update(b"aethon-fingerprint-v0\n");
     h.update(id.as_bytes());
@@ -104,11 +105,22 @@ fn fingerprint_placeholder(id: &str) -> String {
     digest.iter().take(8).map(|b| format!("{b:02x}")).collect()
 }
 
+/// Real cert fingerprint when available, placeholder otherwise. Unit
+/// tests always take the placeholder branch — resolving the process-wide
+/// identity would write cert material into the developer's `~/.aethon`.
+fn host_fingerprint(id: &str) -> String {
+    #[cfg(not(test))]
+    if let Some(identity) = crate::server::tls::identity() {
+        return identity.fingerprint.clone();
+    }
+    fingerprint_placeholder(id)
+}
+
 pub fn local_host_info() -> HostInfo {
     let hostname = hostname_string();
     let display_name = pretty_display(&hostname);
     let id = stable_id(&hostname);
-    let fingerprint = fingerprint_placeholder(&id);
+    let fingerprint = host_fingerprint(&id);
     HostInfo {
         id,
         hostname,
@@ -132,7 +144,10 @@ mod tests {
         assert!(info.id.starts_with("local:"));
         assert!(!info.hostname.is_empty());
         assert!(!info.display_name.is_empty());
+        // Test builds always resolve the placeholder (16 hex); release
+        // builds carry the 64-hex TLS cert fingerprint.
         assert_eq!(info.fingerprint.len(), 16);
+        assert!(info.fingerprint.chars().all(|c| c.is_ascii_hexdigit()));
     }
 
     #[test]

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -29,6 +29,7 @@ pub mod git;
 pub mod host;
 pub mod mcp;
 pub mod native_windows;
+pub mod remote;
 pub mod scheduler;
 pub mod server;
 pub mod session;

--- a/src-tauri/src/commands/remote.rs
+++ b/src-tauri/src/commands/remote.rs
@@ -72,9 +72,10 @@ pub fn remote_devices_list(remote: State<'_, Arc<RemoteState>>) -> Result<Vec<De
 
 #[tauri::command]
 pub fn remote_device_revoke(id: String, remote: State<'_, Arc<RemoteState>>) -> Result<(), String> {
-    remote.devices.revoke(&id)
-    // The WS layer watches revocation and closes the device's live
-    // connections with `bye revoked` (wired with ws.rs).
+    remote.devices.revoke(&id)?;
+    // Token is dead for new connections; drop live ones immediately.
+    remote.close_device(&id);
+    Ok(())
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/remote.rs
+++ b/src-tauri/src/commands/remote.rs
@@ -1,0 +1,87 @@
+//! Frontend control surface for the remote gateway: pairing lifecycle
+//! and the paired-device list (Settings → Remote Devices).
+//!
+//! Pairing requires the TLS identity (clients pin its fingerprint — a
+//! placeholder would pin nothing) and a running server (the QR payload
+//! embeds the bound port).
+
+use std::sync::Arc;
+
+use tauri::State;
+
+use crate::server::ServerState;
+use crate::server::remote::pairing::{self, PairingBegin};
+use crate::server::remote::{RemoteState, devices::DeviceView};
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoteStatus {
+    pub running: bool,
+    pub port: Option<u16>,
+    pub tls_active: bool,
+    pub fingerprint: Option<String>,
+    pub pairing_active: bool,
+    pub devices: usize,
+}
+
+#[tauri::command]
+pub async fn remote_status(
+    server: State<'_, Arc<ServerState>>,
+    remote: State<'_, Arc<RemoteState>>,
+) -> Result<RemoteStatus, String> {
+    let identity = crate::server::tls::identity();
+    Ok(RemoteStatus {
+        running: server.is_running().await,
+        port: server.port().await,
+        tls_active: identity.is_some(),
+        fingerprint: identity.map(|i| i.fingerprint.clone()),
+        pairing_active: remote.pairing.lock().map_err(|e| e.to_string())?.is_some(),
+        devices: remote.devices.list().len(),
+    })
+}
+
+#[tauri::command]
+pub async fn remote_pairing_begin(
+    server: State<'_, Arc<ServerState>>,
+    remote: State<'_, Arc<RemoteState>>,
+) -> Result<PairingBegin, String> {
+    let Some(identity) = crate::server::tls::identity() else {
+        return Err("TLS identity unavailable — pairing is disabled on this host".to_string());
+    };
+    let Some(port) = server.port().await else {
+        return Err(
+            "server is not running — start it in Settings → Server before pairing".to_string(),
+        );
+    };
+    let display_name = crate::commands::host::local_host_info().display_name;
+    let (session, begin) = pairing::begin(&display_name, port, &identity.fingerprint);
+    *remote.pairing.lock().map_err(|e| e.to_string())? = Some(session);
+    Ok(begin)
+}
+
+#[tauri::command]
+pub fn remote_pairing_cancel(remote: State<'_, Arc<RemoteState>>) -> Result<(), String> {
+    *remote.pairing.lock().map_err(|e| e.to_string())? = None;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn remote_devices_list(remote: State<'_, Arc<RemoteState>>) -> Result<Vec<DeviceView>, String> {
+    Ok(remote.devices.list())
+}
+
+#[tauri::command]
+pub fn remote_device_revoke(id: String, remote: State<'_, Arc<RemoteState>>) -> Result<(), String> {
+    remote.devices.revoke(&id)
+    // The WS layer watches revocation and closes the device's live
+    // connections with `bye revoked` (wired with ws.rs).
+}
+
+#[tauri::command]
+pub fn remote_device_rename(
+    id: String,
+    name: String,
+    remote: State<'_, Arc<RemoteState>>,
+) -> Result<(), String> {
+    remote.devices.rename(&id, &name)
+}

--- a/src-tauri/src/control.rs
+++ b/src-tauri/src/control.rs
@@ -114,7 +114,14 @@ struct ControlCompletion {
 pub(crate) fn control_update_state(
     snapshot: Value,
     state: State<'_, Arc<ControlState>>,
+    remote: State<'_, Arc<crate::server::remote::RemoteState>>,
 ) -> Result<(), String> {
+    // Mirror the snapshot to remote clients as the `frontend-state`
+    // topic — the convergence signal that keeps every paired device's
+    // view of tabs/models/accounts in step regardless of who mutated.
+    if let Ok(json) = serde_json::to_string(&snapshot) {
+        remote.hub.publish("frontend-state", json);
+    }
     *state.frontend_state.lock().map_err(|e| e.to_string())? = snapshot;
     Ok(())
 }
@@ -254,35 +261,50 @@ async fn forward_to_frontend(
     state: &Arc<ControlState>,
     req: ControlRequest,
 ) -> ControlResponse {
+    match forward_ui_method(app, state, &req.method, req.params).await {
+        Ok(value) => ok_response(value),
+        Err(err) => err_response(err),
+    }
+}
+
+/// Round one UI-owned mutation through the desktop webview: emit a
+/// `control-request`, await the matching `control_request_complete`.
+/// Shared by the local control socket and the remote gateway's `ui.*`
+/// forwards, so both serialize on the same pending map + timeouts.
+pub(crate) async fn forward_ui_method(
+    app: &AppHandle,
+    state: &Arc<ControlState>,
+    method: &str,
+    params: Value,
+) -> Result<Value, String> {
     let request_id = uuid::Uuid::new_v4().to_string();
-    let timeout = request_timeout(&req.params);
+    let timeout = request_timeout(&params);
     let (tx, rx) = oneshot::channel();
     {
-        let mut pending = match state.pending.lock() {
-            Ok(guard) => guard,
-            Err(err) => return err_response(format!("pending lock: {err}")),
-        };
+        let mut pending = state
+            .pending
+            .lock()
+            .map_err(|err| format!("pending lock: {err}"))?;
         pending.insert(request_id.clone(), tx);
     }
     let payload = FrontendControlRequest {
         request_id: request_id.clone(),
-        method: req.method,
-        params: req.params,
+        method: method.to_string(),
+        params,
     };
     if let Err(err) = app.emit("control-request", payload) {
         let _ = state.pending.lock().map(|mut p| p.remove(&request_id));
-        return err_response(format!("emit control-request: {err}"));
+        return Err(format!("emit control-request: {err}"));
     }
     match tokio::time::timeout(timeout, rx).await {
-        Ok(Ok(done)) if done.success => ok_response(done.data.unwrap_or(Value::Null)),
-        Ok(Ok(done)) => err_response(
-            done.error
-                .unwrap_or_else(|| "control request failed".to_string()),
-        ),
-        Ok(Err(_)) => err_response("control request was cancelled".to_string()),
+        Ok(Ok(done)) if done.success => Ok(done.data.unwrap_or(Value::Null)),
+        Ok(Ok(done)) => Err(done
+            .error
+            .unwrap_or_else(|| "control request failed".to_string())),
+        Ok(Err(_)) => Err("control request was cancelled".to_string()),
         Err(_) => {
             let _ = state.pending.lock().map(|mut p| p.remove(&request_id));
-            err_response("control request timed out".to_string())
+            Err("control request timed out".to_string())
         }
     }
 }

--- a/src-tauri/src/control.rs
+++ b/src-tauri/src/control.rs
@@ -318,35 +318,18 @@ fn aethon_control_dir(app: &AppHandle) -> Result<PathBuf, String> {
 #[cfg(unix)]
 mod unix {
     use super::*;
-    use std::io::Write;
-    use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
-    use std::path::Path;
+    use std::os::unix::fs::PermissionsExt;
     use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
     use tokio::net::{UnixListener, UnixStream};
 
-    /// Create + write a file owner-only (0o600) atomically: the `mode` is
-    /// applied at `open` time, so the file never exists with broader
-    /// permissions (no chmod-after-write TOCTOU window). `0o600 & ~umask` can
-    /// only be more restrictive, never looser.
-    fn write_owner_only(path: &Path, contents: &[u8]) -> Result<(), String> {
-        let mut file = std::fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .mode(0o600)
-            .open(path)
-            .map_err(|e| format!("open {}: {e}", path.display()))?;
-        file.write_all(contents)
-            .map_err(|e| format!("write {}: {e}", path.display()))
-    }
+    use crate::helpers::secure_files::{set_dir_owner_only, write_owner_only};
 
     pub(super) async fn run(app: AppHandle, state: Arc<ControlState>) -> Result<(), String> {
         let dir = aethon_control_dir(&app)?;
         // Lock the control dir to the owner before writing anything into it.
         // With the dir at 0o700, no other local user can even reach the token,
         // control.json, or socket regardless of the individual file modes.
-        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700))
-            .map_err(|e| format!("chmod {}: {e}", dir.display()))?;
+        set_dir_owner_only(&dir)?;
         let socket_path = dir.join("control.sock");
         let token_path = dir.join("token");
         let info_path = dir.join("control.json");
@@ -418,32 +401,8 @@ mod unix {
         writer.shutdown().await.map_err(|e| e.to_string())
     }
 
-    #[cfg(test)]
-    mod tests {
-        use super::*;
-
-        #[test]
-        fn write_owner_only_grants_no_group_or_other_access() {
-            let dir = std::env::temp_dir().join(format!(
-                "aethon-control-test-{}-{}",
-                std::process::id(),
-                "token"
-            ));
-            let path = dir.join("token");
-            std::fs::create_dir_all(&dir).unwrap();
-            let _ = std::fs::remove_file(&path);
-
-            write_owner_only(&path, b"secret-token").unwrap();
-
-            let mode = std::fs::metadata(&path).unwrap().permissions().mode();
-            // The security property: no group/other bits, regardless of umask.
-            assert_eq!(mode & 0o077, 0, "mode was {:o}", mode & 0o777);
-            assert_eq!(std::fs::read_to_string(&path).unwrap(), "secret-token");
-
-            let _ = std::fs::remove_file(&path);
-            let _ = std::fs::remove_dir(&dir);
-        }
-    }
+    // write_owner_only's permission property is covered by the shared
+    // helper's tests in `helpers::secure_files`.
 }
 
 #[cfg(test)]

--- a/src-tauri/src/helpers/config.rs
+++ b/src-tauri/src/helpers/config.rs
@@ -129,12 +129,21 @@ pub struct UpdatesConfig {
 
 #[derive(Default, Deserialize)]
 pub struct ServerConfig {
-    /// Whether to start the unauthenticated local HTTP listener and advertise
-    /// this host over mDNS (`_aethon._tcp.local.`) on boot. Default `true`.
-    /// Set `false` to stop LAN exposure while keeping peer *discovery* (the
-    /// browser) running, since that's read-only. The `server_start` IPC
-    /// (explicit user action) starts and advertises regardless of this flag.
+    /// Whether to start the LAN HTTP listener and advertise this host over
+    /// mDNS (`_aethon._tcp.local.`) on boot. Default `true`. Set `false`
+    /// to stop LAN exposure while keeping peer *discovery* (the browser)
+    /// running, since that's read-only. The `server_start` IPC (explicit
+    /// user action) starts and advertises regardless of this flag.
     pub enabled: Option<bool>,
+    /// Fixed TCP port for the LAN listener. Default unset → the OS picks
+    /// a free port (advertised via mDNS). Pin it when firewall rules or
+    /// Tailscale ACLs need a stable target.
+    pub port: Option<u16>,
+    /// Dev-only: additionally accept remote-gateway connections without
+    /// TLS. Exists so a desktop browser (which can't pin a self-signed
+    /// cert) can drive the mobile UI against a local dev instance.
+    /// Default `false`; never enable on a network you don't trust.
+    pub allow_insecure_ws: Option<bool>,
 }
 
 #[derive(Default, Deserialize)]
@@ -512,6 +521,8 @@ pub fn parse_config_toml(input: &str) -> serde_json::Value {
         },
         "server": {
             "enabled": cfg.server.enabled.unwrap_or(true),
+            "port": cfg.server.port,
+            "allowInsecureWs": cfg.server.allow_insecure_ws.unwrap_or(false),
         },
         "startup": {
             "autoApprove": cfg.startup.auto_approve.unwrap_or(false),

--- a/src-tauri/src/helpers/mod.rs
+++ b/src-tauri/src/helpers/mod.rs
@@ -11,10 +11,13 @@
 //!   `resolve_inside_root` lexical traversal gate.
 //! - [`names`]  — `validate_state_name` and `sanitize_filename_segment`,
 //!   the leaf-filename guards.
+//! - [`secure_files`] — owner-only (0600/0700) file + dir writes shared
+//!   by the credential stores (control socket, remote gateway).
 
 pub mod config;
 pub mod names;
 pub mod paths;
+pub mod secure_files;
 
 // Flat re-exports of the surface external callers actually use. The
 // underlying structs (`AethonConfig`, `UiConfig`, etc.) stay reachable

--- a/src-tauri/src/helpers/secure_files.rs
+++ b/src-tauri/src/helpers/secure_files.rs
@@ -1,0 +1,84 @@
+//! Owner-only filesystem primitives shared by the credential stores
+//! (control socket dir, remote-gateway TLS identity + device tokens).
+//!
+//! `write_owner_only` applies the 0o600 mode at `open` time so the file
+//! never exists with broader permissions (no chmod-after-write TOCTOU
+//! window); `0o600 & ~umask` can only be more restrictive, never looser.
+//! `set_dir_owner_only` locks the containing directory to 0o700 so other
+//! local users can't even reach the entries regardless of file modes.
+//! Both are no-ops beyond the plain write on non-unix targets, where the
+//! per-user profile directory is the isolation boundary.
+
+use std::io::Write;
+use std::path::Path;
+
+#[cfg(unix)]
+pub fn write_owner_only(path: &Path, contents: &[u8]) -> Result<(), String> {
+    use std::os::unix::fs::OpenOptionsExt;
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(path)
+        .map_err(|e| format!("open {}: {e}", path.display()))?;
+    file.write_all(contents)
+        .map_err(|e| format!("write {}: {e}", path.display()))
+}
+
+#[cfg(not(unix))]
+pub fn write_owner_only(path: &Path, contents: &[u8]) -> Result<(), String> {
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(path)
+        .map_err(|e| format!("open {}: {e}", path.display()))?;
+    file.write_all(contents)
+        .map_err(|e| format!("write {}: {e}", path.display()))
+}
+
+pub fn set_dir_owner_only(dir: &Path) -> Result<(), String> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700))
+            .map_err(|e| format!("chmod {}: {e}", dir.display()))?;
+    }
+    let _ = dir;
+    Ok(())
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use std::os::unix::fs::PermissionsExt;
+
+    use super::*;
+
+    #[test]
+    fn write_owner_only_grants_no_group_or_other_access() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("secret");
+        write_owner_only(&path, b"secret-token").unwrap();
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode & 0o077, 0, "mode {mode:o} leaks beyond the owner");
+        assert_eq!(std::fs::read(&path).unwrap(), b"secret-token");
+    }
+
+    #[test]
+    fn write_owner_only_truncates_previous_contents() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("secret");
+        write_owner_only(&path, b"a-long-first-value").unwrap();
+        write_owner_only(&path, b"short").unwrap();
+        assert_eq!(std::fs::read(&path).unwrap(), b"short");
+    }
+
+    #[test]
+    fn set_dir_owner_only_locks_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        set_dir_owner_only(dir.path()).unwrap();
+        let mode = std::fs::metadata(dir.path()).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o700);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -156,6 +156,7 @@ pub fn run() {
         .manage(updater_state::UpdaterState::new())
         .manage(commands::scheduler::ScheduledTasksState::new())
         .manage(Arc::new(server::ServerState::new()))
+        .manage(Arc::new(server::remote::RemoteState::new()))
         .manage(devshell::DevshellCache::shared())
         .manage(commands::startup::WorkspaceStartupState::default());
     #[cfg(feature = "voice")]
@@ -285,6 +286,12 @@ pub fn run() {
             commands::server::server_status,
             commands::server::server_start,
             commands::server::server_stop,
+            commands::remote::remote_status,
+            commands::remote::remote_pairing_begin,
+            commands::remote::remote_pairing_cancel,
+            commands::remote::remote_devices_list,
+            commands::remote::remote_device_revoke,
+            commands::remote::remote_device_rename,
             commands::window::updater_available,
             commands::window::toggle_fullscreen,
             commands::window::toggle_devtools,

--- a/src-tauri/src/server/http.rs
+++ b/src-tauri/src/server/http.rs
@@ -13,25 +13,36 @@
 //! OS picks — and the chosen port flows back into mDNS advertising.
 
 use std::net::SocketAddr;
+use std::sync::Arc;
 
+use axum::routing::post;
 use axum::{Json, Router, routing::get};
 use axum_server::tls_rustls::RustlsConfig;
 use tauri::async_runtime::JoinHandle;
 use tokio::net::TcpListener;
 
 use crate::commands::host::HostInfo;
+use crate::server::remote::{GatewayCtx, RemoteState, pairing};
 use crate::server::tls::TlsIdentity;
 
-fn router(info: HostInfo) -> Router {
+fn router(info: HostInfo, remote: Arc<RemoteState>) -> Router {
+    let status_info = info.clone();
+    let ctx = GatewayCtx { info, remote };
     Router::new()
         .route("/health", get(|| async { "aethon" }))
         .route(
             "/status",
             get(move || {
-                let info = info.clone();
+                let info = status_info.clone();
                 async move { Json(info) }
             }),
         )
+        // Harmless on the plain-HTTP fallback listener: pairing sessions
+        // can only be armed while the TLS identity exists
+        // (remote_pairing_begin refuses otherwise), so without TLS this
+        // route is a guaranteed 404.
+        .route("/pair", post(pairing::pair_handler))
+        .with_state(ctx)
 }
 
 /// Bind the listener and spawn the serving task. Returns the bound port
@@ -40,11 +51,12 @@ pub async fn serve(
     info: HostInfo,
     port: u16,
     tls: Option<&TlsIdentity>,
+    remote: Arc<RemoteState>,
 ) -> Result<(u16, JoinHandle<()>), String> {
     let addr: SocketAddr = format!("0.0.0.0:{port}")
         .parse()
         .map_err(|e| format!("addr: {e}"))?;
-    let app = router(info);
+    let app = router(info, remote);
     match tls {
         Some(identity) => {
             crate::server::tls::install_crypto_provider();

--- a/src-tauri/src/server/http.rs
+++ b/src-tauri/src/server/http.rs
@@ -15,6 +15,9 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
+use axum::extract::{Query, State};
+use axum::http::{StatusCode, header};
+use axum::response::{IntoResponse, Response};
 use axum::routing::post;
 use axum::{Json, Router, routing::get};
 use axum_server::tls_rustls::RustlsConfig;
@@ -22,12 +25,17 @@ use tauri::async_runtime::JoinHandle;
 use tokio::net::TcpListener;
 
 use crate::commands::host::HostInfo;
-use crate::server::remote::{GatewayCtx, RemoteState, pairing};
+use crate::server::remote::relay::RelayExec;
+use crate::server::remote::{GatewayCtx, RemoteState, pairing, ws};
 use crate::server::tls::TlsIdentity;
 
-fn router(info: HostInfo, remote: Arc<RemoteState>) -> Router {
+pub fn router(info: HostInfo, remote: Arc<RemoteState>, relay: Arc<dyn RelayExec>) -> Router {
     let status_info = info.clone();
-    let ctx = GatewayCtx { info, remote };
+    let ctx = GatewayCtx {
+        info,
+        remote,
+        relay,
+    };
     Router::new()
         .route("/health", get(|| async { "aethon" }))
         .route(
@@ -40,9 +48,54 @@ fn router(info: HostInfo, remote: Arc<RemoteState>) -> Router {
         // Harmless on the plain-HTTP fallback listener: pairing sessions
         // can only be armed while the TLS identity exists
         // (remote_pairing_begin refuses otherwise), so without TLS this
-        // route is a guaranteed 404.
+        // route is a guaranteed 404. /ws still authenticates per-token
+        // on its first frame either way.
         .route("/pair", post(pairing::pair_handler))
+        .route("/ws", get(ws::ws_handler))
+        .route("/asset", get(asset_handler))
         .with_state(ctx)
+}
+
+#[derive(serde::Deserialize)]
+struct AssetQuery {
+    path: String,
+    token: String,
+}
+
+/// `GET /asset?path=…&token=…` — the mobile equivalent of Tauri's
+/// `convertFileSrc` for chat image attachments. Token in the query
+/// because `<img src>` can't carry headers; the URL never leaves the
+/// paired transport. Routed through the relay so it reuses the exact
+/// jailed read path (`read_paste_image_base64`: pastes dir only,
+/// 32 MiB cap) rather than growing a second file-serving surface.
+async fn asset_handler(
+    State(ctx): State<GatewayCtx>,
+    Query(query): Query<AssetQuery>,
+) -> Response {
+    use base64::Engine;
+    if ctx.remote.devices.verify_token(&query.token).is_none() {
+        return (StatusCode::UNAUTHORIZED, "unauthorized").into_response();
+    }
+    let args = serde_json::json!({ "path": query.path });
+    let b64 = match ctx.relay.invoke("read_paste_image_base64", args).await {
+        Ok(serde_json::Value::String(b64)) => b64,
+        Ok(_) => return (StatusCode::INTERNAL_SERVER_ERROR, "bad relay shape").into_response(),
+        Err(e) => {
+            tracing::debug!(target: "aethon::server::http", "asset denied: {e}");
+            return (StatusCode::NOT_FOUND, "not found").into_response();
+        }
+    };
+    let Ok(bytes) = base64::engine::general_purpose::STANDARD.decode(b64) else {
+        return (StatusCode::INTERNAL_SERVER_ERROR, "decode failed").into_response();
+    };
+    let mime = match query.path.rsplit('.').next().map(str::to_ascii_lowercase) {
+        Some(ext) if ext == "png" => "image/png",
+        Some(ext) if ext == "jpg" || ext == "jpeg" => "image/jpeg",
+        Some(ext) if ext == "gif" => "image/gif",
+        Some(ext) if ext == "webp" => "image/webp",
+        _ => "application/octet-stream",
+    };
+    ([(header::CONTENT_TYPE, mime)], bytes).into_response()
 }
 
 /// Bind the listener and spawn the serving task. Returns the bound port
@@ -52,11 +105,12 @@ pub async fn serve(
     port: u16,
     tls: Option<&TlsIdentity>,
     remote: Arc<RemoteState>,
+    relay: Arc<dyn RelayExec>,
 ) -> Result<(u16, JoinHandle<()>), String> {
     let addr: SocketAddr = format!("0.0.0.0:{port}")
         .parse()
         .map_err(|e| format!("addr: {e}"))?;
-    let app = router(info, remote);
+    let app = router(info, remote, relay);
     match tls {
         Some(identity) => {
             crate::server::tls::install_crypto_provider();

--- a/src-tauri/src/server/http.rs
+++ b/src-tauri/src/server/http.rs
@@ -45,11 +45,13 @@ pub fn router(info: HostInfo, remote: Arc<RemoteState>, relay: Arc<dyn RelayExec
                 async move { Json(info) }
             }),
         )
-        // Harmless on the plain-HTTP fallback listener: pairing sessions
-        // can only be armed while the TLS identity exists
-        // (remote_pairing_begin refuses otherwise), so without TLS this
-        // route is a guaranteed 404. /ws still authenticates per-token
-        // on its first frame either way.
+        // /pair is armed only during an active pairing window and
+        // 404s otherwise. In production the listener is always TLS
+        // (remote_pairing_begin refuses without a cert identity); the
+        // one path where pairing runs over plaintext is the dev-only
+        // `allow_insecure_ws` mode (debug builds), where the operator
+        // has explicitly opted into a trusted LAN. /ws authenticates
+        // per-token on its first frame regardless.
         .route("/pair", post(pairing::pair_handler))
         .route("/ws", get(ws::ws_handler))
         .route("/asset", get(asset_handler))

--- a/src-tauri/src/server/http.rs
+++ b/src-tauri/src/server/http.rs
@@ -1,31 +1,29 @@
-//! Minimal axum HTTP server.
+//! HTTP server for the LAN gateway.
 //!
-//! Two endpoints today: `GET /health` returns the literal string
-//! `aethon` (200 OK), `GET /status` returns the JSON `HostInfo` doc.
-//! Binds `0.0.0.0:0` so the OS picks the port; the chosen port flows
-//! back into mDNS advertising. **No auth, no TLS** — the pairing PR
-//! adds both.
+//! Serves `GET /health` (literal `aethon`) and `GET /status` (the JSON
+//! `HostInfo` doc) over TLS using the self-signed identity in
+//! [`crate::server::tls`] — paired clients pin its SHA-256 fingerprint
+//! instead of verifying a chain. When the identity can't be created the
+//! server degrades to the original plain-HTTP scaffold so discovery
+//! stays functional; the authenticated remote-gateway routes are only
+//! ever mounted on the TLS listener (or the dev-only insecure listener
+//! gated by `[server] allow_insecure_ws`).
+//!
+//! Binds `0.0.0.0:{port}` — `[server] port`, defaulting to `0` so the
+//! OS picks — and the chosen port flows back into mDNS advertising.
 
 use std::net::SocketAddr;
 
 use axum::{Json, Router, routing::get};
+use axum_server::tls_rustls::RustlsConfig;
 use tauri::async_runtime::JoinHandle;
 use tokio::net::TcpListener;
 
 use crate::commands::host::HostInfo;
+use crate::server::tls::TlsIdentity;
 
-/// Bind the listener and spawn the axum task. Returns the bound port
-/// + the join handle (abort on `server_stop`).
-pub async fn serve(info: HostInfo) -> Result<(u16, JoinHandle<()>), String> {
-    let addr: SocketAddr = "0.0.0.0:0".parse().map_err(|e| format!("addr: {e}"))?;
-    let listener = TcpListener::bind(addr)
-        .await
-        .map_err(|e| format!("bind: {e}"))?;
-    let port = listener
-        .local_addr()
-        .map_err(|e| format!("local_addr: {e}"))?
-        .port();
-    let app = Router::new()
+fn router(info: HostInfo) -> Router {
+    Router::new()
         .route("/health", get(|| async { "aethon" }))
         .route(
             "/status",
@@ -33,11 +31,60 @@ pub async fn serve(info: HostInfo) -> Result<(u16, JoinHandle<()>), String> {
                 let info = info.clone();
                 async move { Json(info) }
             }),
-        );
-    let task = tauri::async_runtime::spawn(async move {
-        if let Err(e) = axum::serve(listener, app).await {
-            tracing::warn!(target: "aethon::server::http", "serve ended: {e}");
+        )
+}
+
+/// Bind the listener and spawn the serving task. Returns the bound port
+/// + the join handle (abort on `server_stop`).
+pub async fn serve(
+    info: HostInfo,
+    port: u16,
+    tls: Option<&TlsIdentity>,
+) -> Result<(u16, JoinHandle<()>), String> {
+    let addr: SocketAddr = format!("0.0.0.0:{port}")
+        .parse()
+        .map_err(|e| format!("addr: {e}"))?;
+    let app = router(info);
+    match tls {
+        Some(identity) => {
+            crate::server::tls::install_crypto_provider();
+            let config = RustlsConfig::from_pem(
+                identity.cert_pem.clone().into_bytes(),
+                identity.key_pem.clone().into_bytes(),
+            )
+            .await
+            .map_err(|e| format!("tls config: {e}"))?;
+            let listener =
+                std::net::TcpListener::bind(addr).map_err(|e| format!("bind: {e}"))?;
+            listener
+                .set_nonblocking(true)
+                .map_err(|e| format!("nonblocking: {e}"))?;
+            let bound = listener
+                .local_addr()
+                .map_err(|e| format!("local_addr: {e}"))?
+                .port();
+            let server = axum_server::from_tcp_rustls(listener, config);
+            let task = tauri::async_runtime::spawn(async move {
+                if let Err(e) = server.serve(app.into_make_service()).await {
+                    tracing::warn!(target: "aethon::server::http", "tls serve ended: {e}");
+                }
+            });
+            Ok((bound, task))
         }
-    });
-    Ok((port, task))
+        None => {
+            let listener = TcpListener::bind(addr)
+                .await
+                .map_err(|e| format!("bind: {e}"))?;
+            let bound = listener
+                .local_addr()
+                .map_err(|e| format!("local_addr: {e}"))?
+                .port();
+            let task = tauri::async_runtime::spawn(async move {
+                if let Err(e) = axum::serve(listener, app).await {
+                    tracing::warn!(target: "aethon::server::http", "serve ended: {e}");
+                }
+            });
+            Ok((bound, task))
+        }
+    }
 }

--- a/src-tauri/src/server/mod.rs
+++ b/src-tauri/src/server/mod.rs
@@ -174,14 +174,23 @@ pub async fn start(app: &AppHandle, state: &ServerState, advertise: bool) -> Res
         );
     }
     if allow_insecure_ws_from_config_text(&raw_config) {
-        // Dev-only escape hatch for the browser dev loop (a desktop
-        // browser can't pin a self-signed cert). Phones will refuse the
-        // missing TLS — this is not a production mode.
-        tracing::warn!(
-            target: "aethon::server",
-            "[server] allow_insecure_ws = true — serving WITHOUT TLS (dev only)"
-        );
-        identity = None;
+        if cfg!(debug_assertions) {
+            // Dev-only escape hatch for the browser dev loop (a desktop
+            // browser can't pin a self-signed cert). Phones refuse the
+            // missing TLS — this is never a production mode, so release
+            // builds ignore the flag entirely rather than serving plain-
+            // text pairing/tokens over the LAN.
+            tracing::warn!(
+                target: "aethon::server",
+                "[server] allow_insecure_ws = true — serving WITHOUT TLS (dev build only)"
+            );
+            identity = None;
+        } else {
+            tracing::warn!(
+                target: "aethon::server",
+                "[server] allow_insecure_ws is ignored in release builds — keeping TLS"
+            );
+        }
     }
     let remote = Arc::clone(app.state::<Arc<remote::RemoteState>>().inner());
     let relay: Arc<dyn remote::relay::RelayExec> =

--- a/src-tauri/src/server/mod.rs
+++ b/src-tauri/src/server/mod.rs
@@ -152,6 +152,7 @@ where
 /// stop — that path passes `advertise = true` so an explicit start always
 /// announces, regardless of the config gate.
 pub async fn start(app: &AppHandle, state: &ServerState, advertise: bool) -> Result<u16, String> {
+    use tauri::Manager;
     let info = crate::commands::host::local_host_info();
     let identity = tls::identity();
     if identity.is_none() {
@@ -160,7 +161,8 @@ pub async fn start(app: &AppHandle, state: &ServerState, advertise: bool) -> Res
             "TLS identity unavailable — serving the plain scaffold; remote pairing disabled"
         );
     }
-    let (port, http_task) = http::serve(info.clone(), server_port(app), identity).await?;
+    let remote = Arc::clone(app.state::<Arc<remote::RemoteState>>().inner());
+    let (port, http_task) = http::serve(info.clone(), server_port(app), identity, remote).await?;
     let advertise_daemon = if advertise {
         Some(
             mdns::advertise(&info.display_name, port, &info.fingerprint)

--- a/src-tauri/src/server/mod.rs
+++ b/src-tauri/src/server/mod.rs
@@ -81,6 +81,14 @@ impl ServerState {
 /// are gated on `[server] enabled` (default true); the browser always runs.
 pub fn boot(app: AppHandle, state: Arc<ServerState>) {
     tauri::async_runtime::spawn(async move {
+        // Tap Tauri events for the remote hub exactly once per process —
+        // taps survive server stop/start, so this must not live in
+        // `start()` (a restart would double-publish every event).
+        {
+            use tauri::Manager;
+            let remote = Arc::clone(app.state::<Arc<remote::RemoteState>>().inner());
+            remote::events::install_taps(&remote.hub, &app);
+        }
         let enabled = server_enabled(&app);
         match start_on_boot_if_enabled(enabled, || start(&app, &state, true)).await {
             Ok(Some(_)) => {}
@@ -121,15 +129,18 @@ fn server_enabled_from_config_text(raw: &str) -> bool {
 
 /// Read `[server] port` (default 0 → OS-assigned). Out-of-range values
 /// fall back to 0 rather than failing boot.
-fn server_port(app: &AppHandle) -> u16 {
-    server_port_from_config_text(&server_config_raw(app))
-}
-
 fn server_port_from_config_text(raw: &str) -> u16 {
     crate::helpers::parse_config_toml(raw)["server"]["port"]
         .as_u64()
         .and_then(|p| u16::try_from(p).ok())
         .unwrap_or(0)
+}
+
+/// Read `[server] allow_insecure_ws` (default false). Dev-only.
+fn allow_insecure_ws_from_config_text(raw: &str) -> bool {
+    crate::helpers::parse_config_toml(raw)["server"]["allowInsecureWs"]
+        .as_bool()
+        .unwrap_or(false)
 }
 
 async fn start_on_boot_if_enabled<F, Fut>(
@@ -154,15 +165,35 @@ where
 pub async fn start(app: &AppHandle, state: &ServerState, advertise: bool) -> Result<u16, String> {
     use tauri::Manager;
     let info = crate::commands::host::local_host_info();
-    let identity = tls::identity();
+    let raw_config = server_config_raw(app);
+    let mut identity = tls::identity();
     if identity.is_none() {
         tracing::warn!(
             target: "aethon::server",
             "TLS identity unavailable — serving the plain scaffold; remote pairing disabled"
         );
     }
+    if allow_insecure_ws_from_config_text(&raw_config) {
+        // Dev-only escape hatch for the browser dev loop (a desktop
+        // browser can't pin a self-signed cert). Phones will refuse the
+        // missing TLS — this is not a production mode.
+        tracing::warn!(
+            target: "aethon::server",
+            "[server] allow_insecure_ws = true — serving WITHOUT TLS (dev only)"
+        );
+        identity = None;
+    }
     let remote = Arc::clone(app.state::<Arc<remote::RemoteState>>().inner());
-    let (port, http_task) = http::serve(info.clone(), server_port(app), identity, remote).await?;
+    let relay: Arc<dyn remote::relay::RelayExec> =
+        Arc::new(remote::relay::TauriRelay::new(app.clone()));
+    let (port, http_task) = http::serve(
+        info.clone(),
+        server_port_from_config_text(&raw_config),
+        identity,
+        remote,
+        relay,
+    )
+    .await?;
     let advertise_daemon = if advertise {
         Some(
             mdns::advertise(&info.display_name, port, &info.fingerprint)

--- a/src-tauri/src/server/mod.rs
+++ b/src-tauri/src/server/mod.rs
@@ -1,11 +1,12 @@
-//! Built-in HTTP + mDNS server scaffold.
+//! Built-in HTTP + mDNS server, growing into the remote gateway.
 //!
 //! Models Claudette's daemon pattern: one `ServiceDaemon` advertises
 //! `_aethon._tcp.local.`, a second `ServiceDaemon` browses for peers and
-//! emits `host-discovered` / `host-removed` Tauri events. An axum HTTP
-//! server binds `0.0.0.0:0` (OS picks the port → mDNS TXT) and exposes
-//! `GET /health` + `GET /status`. No auth, no TLS — explicitly scaffold
-//! until the pairing PR replaces fingerprint + adds tokens.
+//! emits `host-discovered` / `host-removed` Tauri events. An axum server
+//! binds `0.0.0.0` (`[server] port`, default OS-assigned → mDNS TXT) and
+//! exposes `GET /health` + `GET /status`, over TLS when the [`tls`]
+//! identity is available. The [`remote`] module adds pairing + an
+//! authenticated WebSocket relay for companion clients (iOS app).
 //!
 //! Lifecycle: `boot(app)` binds HTTP and registers mDNS advertisement only
 //! when `[server] enabled` is true (the default). The mDNS browser runs even
@@ -22,6 +23,7 @@ use tokio::sync::Mutex;
 pub mod http;
 pub mod mdns;
 pub mod remote;
+pub mod tls;
 
 /// Holds the running server's resources so we can shut down cleanly.
 /// All fields owned: dropping `ServerHandle` stops the advertisement
@@ -95,22 +97,39 @@ pub fn boot(app: AppHandle, state: Arc<ServerState>) {
     });
 }
 
-/// Read `[server] enabled` from `~/.aethon/config.toml` (default true).
-fn server_enabled(app: &AppHandle) -> bool {
+/// Read the raw `~/.aethon/config.toml` text ("" when unreadable).
+fn server_config_raw(app: &AppHandle) -> String {
     use tauri::Manager;
     let Ok(home) = app.path().home_dir() else {
-        return true;
+        return String::new();
     };
     let user_dir =
         crate::helpers::aethon_dir(Some(home.clone())).unwrap_or_else(|| home.join(".aethon"));
-    let raw = std::fs::read_to_string(user_dir.join("config.toml")).unwrap_or_default();
-    server_enabled_from_config_text(&raw)
+    std::fs::read_to_string(user_dir.join("config.toml")).unwrap_or_default()
+}
+
+/// Read `[server] enabled` from `~/.aethon/config.toml` (default true).
+fn server_enabled(app: &AppHandle) -> bool {
+    server_enabled_from_config_text(&server_config_raw(app))
 }
 
 fn server_enabled_from_config_text(raw: &str) -> bool {
     crate::helpers::parse_config_toml(raw)["server"]["enabled"]
         .as_bool()
         .unwrap_or(true)
+}
+
+/// Read `[server] port` (default 0 → OS-assigned). Out-of-range values
+/// fall back to 0 rather than failing boot.
+fn server_port(app: &AppHandle) -> u16 {
+    server_port_from_config_text(&server_config_raw(app))
+}
+
+fn server_port_from_config_text(raw: &str) -> u16 {
+    crate::helpers::parse_config_toml(raw)["server"]["port"]
+        .as_u64()
+        .and_then(|p| u16::try_from(p).ok())
+        .unwrap_or(0)
 }
 
 async fn start_on_boot_if_enabled<F, Fut>(
@@ -132,9 +151,16 @@ where
 /// `server_start` IPC can reuse it after a disabled boot or user-triggered
 /// stop — that path passes `advertise = true` so an explicit start always
 /// announces, regardless of the config gate.
-pub async fn start(_app: &AppHandle, state: &ServerState, advertise: bool) -> Result<u16, String> {
+pub async fn start(app: &AppHandle, state: &ServerState, advertise: bool) -> Result<u16, String> {
     let info = crate::commands::host::local_host_info();
-    let (port, http_task) = http::serve(info.clone()).await?;
+    let identity = tls::identity();
+    if identity.is_none() {
+        tracing::warn!(
+            target: "aethon::server",
+            "TLS identity unavailable — serving the plain scaffold; remote pairing disabled"
+        );
+    }
+    let (port, http_task) = http::serve(info.clone(), server_port(app), identity).await?;
     let advertise_daemon = if advertise {
         Some(
             mdns::advertise(&info.display_name, port, &info.fingerprint)

--- a/src-tauri/src/server/mod.rs
+++ b/src-tauri/src/server/mod.rs
@@ -21,6 +21,7 @@ use tokio::sync::Mutex;
 
 pub mod http;
 pub mod mdns;
+pub mod remote;
 
 /// Holds the running server's resources so we can shut down cleanly.
 /// All fields owned: dropping `ServerHandle` stops the advertisement

--- a/src-tauri/src/server/remote/devices.rs
+++ b/src-tauri/src/server/remote/devices.rs
@@ -135,14 +135,20 @@ impl DeviceStore {
     }
 
     /// Resolve a presented token to its non-revoked device. Scans every
-    /// record (no early exit on the hash compare itself); N is tiny.
+    /// record without early exit — `find` would leak, via wall-clock,
+    /// which record matched, undoing the constant-time compare. N is
+    /// tiny, so the full scan is free.
     pub fn verify_token(&self, token: &str) -> Option<DeviceView> {
         let hash = sha256_hex(token.as_bytes());
         let records = self.records.lock().ok()?;
-        records
-            .iter()
-            .find(|r| !r.revoked && constant_time_eq(&r.token_sha256, &hash))
-            .map(DeviceView::from)
+        let mut matched: Option<&DeviceRecord> = None;
+        for record in records.iter() {
+            let hit = !record.revoked && constant_time_eq(&record.token_sha256, &hash);
+            if hit {
+                matched = Some(record);
+            }
+        }
+        matched.map(DeviceView::from)
     }
 
     /// Record activity from a device (connect / reconnect).

--- a/src-tauri/src/server/remote/devices.rs
+++ b/src-tauri/src/server/remote/devices.rs
@@ -136,9 +136,6 @@ impl DeviceStore {
 
     /// Resolve a presented token to its non-revoked device. Scans every
     /// record (no early exit on the hash compare itself); N is tiny.
-    // TODO(remote-gateway): the WS hello handshake consumes this later
-    // on this branch; drop the allow when ws.rs lands.
-    #[allow(dead_code)]
     pub fn verify_token(&self, token: &str) -> Option<DeviceView> {
         let hash = sha256_hex(token.as_bytes());
         let records = self.records.lock().ok()?;
@@ -149,9 +146,6 @@ impl DeviceStore {
     }
 
     /// Record activity from a device (connect / reconnect).
-    // TODO(remote-gateway): the WS hello handshake consumes this later
-    // on this branch; drop the allow when ws.rs lands.
-    #[allow(dead_code)]
     pub fn touch(&self, id: &str) {
         let Ok(mut records) = self.records.lock() else {
             return;

--- a/src-tauri/src/server/remote/devices.rs
+++ b/src-tauri/src/server/remote/devices.rs
@@ -1,0 +1,275 @@
+//! Paired-device store at `~/.aethon/remote/devices.json` (0600).
+//!
+//! Only `sha256(token)` is persisted — the plaintext device token is
+//! shown to the phone exactly once at pairing time. Verification hashes
+//! the presented token and compares constant-time against non-revoked
+//! records. Small N (a handful of personal devices), so a flat JSON
+//! file mirrors the `control/` precedent and stays inspectable.
+
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use serde::{Deserialize, Serialize};
+
+use crate::helpers::secure_files::write_owner_only;
+use crate::server::tls::sha256_hex;
+
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeviceRecord {
+    pub id: String,
+    pub name: String,
+    pub platform: String,
+    pub token_sha256: String,
+    pub created_at: i64,
+    pub last_seen_at: i64,
+    #[serde(default)]
+    pub revoked: bool,
+}
+
+/// What the Settings device list sees — everything except the token hash.
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeviceView {
+    pub id: String,
+    pub name: String,
+    pub platform: String,
+    pub created_at: i64,
+    pub last_seen_at: i64,
+    pub revoked: bool,
+}
+
+impl From<&DeviceRecord> for DeviceView {
+    fn from(r: &DeviceRecord) -> Self {
+        DeviceView {
+            id: r.id.clone(),
+            name: r.name.clone(),
+            platform: r.platform.clone(),
+            created_at: r.created_at,
+            last_seen_at: r.last_seen_at,
+            revoked: r.revoked,
+        }
+    }
+}
+
+pub struct DeviceStore {
+    /// `None` → in-memory only (no resolvable user dir; also what most
+    /// unit tests use). Pairing still works for the session but devices
+    /// won't survive a restart — the pairing UI surfaces the warning.
+    path: Option<PathBuf>,
+    records: Mutex<Vec<DeviceRecord>>,
+}
+
+fn now_ms() -> i64 {
+    chrono::Utc::now().timestamp_millis()
+}
+
+/// Bitwise constant-time equality; both operands are hex digests of
+/// equal length in the non-error path, and length mismatch fails fast
+/// without revealing anything the length didn't already.
+pub(crate) fn constant_time_eq(a: &str, b: &str) -> bool {
+    let (a, b) = (a.as_bytes(), b.as_bytes());
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+impl DeviceStore {
+    /// Load from `<dir>/devices.json`; a missing or unparsable file is
+    /// an empty store (unparsable also logs — losing paired devices
+    /// should be loud).
+    pub fn load(dir: Option<PathBuf>) -> Self {
+        let path = dir.map(|d| d.join("devices.json"));
+        let records = match &path {
+            Some(p) if p.exists() => match std::fs::read_to_string(p)
+                .map_err(|e| e.to_string())
+                .and_then(|raw| serde_json::from_str(&raw).map_err(|e| e.to_string()))
+            {
+                Ok(records) => records,
+                Err(e) => {
+                    tracing::warn!(target: "aethon::server::remote", "devices.json unreadable, starting empty: {e}");
+                    Vec::new()
+                }
+            },
+            _ => Vec::new(),
+        };
+        Self {
+            path,
+            records: Mutex::new(records),
+        }
+    }
+
+    fn persist(&self, records: &[DeviceRecord]) -> Result<(), String> {
+        let Some(path) = &self.path else {
+            return Ok(());
+        };
+        if let Some(dir) = path.parent() {
+            std::fs::create_dir_all(dir).map_err(|e| format!("mkdir {}: {e}", dir.display()))?;
+        }
+        let json = serde_json::to_string_pretty(records).map_err(|e| e.to_string())?;
+        write_owner_only(path, json.as_bytes())
+    }
+
+    /// Register a freshly paired device. The caller generated `token`
+    /// and hands it to the device; only the hash is stored.
+    pub fn add(&self, name: &str, platform: &str, token: &str) -> Result<DeviceView, String> {
+        let now = now_ms();
+        let record = DeviceRecord {
+            id: format!("dev-{}", &uuid::Uuid::new_v4().simple().to_string()[..12]),
+            name: name.to_string(),
+            platform: platform.to_string(),
+            token_sha256: sha256_hex(token.as_bytes()),
+            created_at: now,
+            last_seen_at: now,
+            revoked: false,
+        };
+        let mut records = self.records.lock().map_err(|e| e.to_string())?;
+        records.push(record.clone());
+        self.persist(&records)?;
+        Ok(DeviceView::from(&record))
+    }
+
+    /// Resolve a presented token to its non-revoked device. Scans every
+    /// record (no early exit on the hash compare itself); N is tiny.
+    // TODO(remote-gateway): the WS hello handshake consumes this later
+    // on this branch; drop the allow when ws.rs lands.
+    #[allow(dead_code)]
+    pub fn verify_token(&self, token: &str) -> Option<DeviceView> {
+        let hash = sha256_hex(token.as_bytes());
+        let records = self.records.lock().ok()?;
+        records
+            .iter()
+            .find(|r| !r.revoked && constant_time_eq(&r.token_sha256, &hash))
+            .map(DeviceView::from)
+    }
+
+    /// Record activity from a device (connect / reconnect).
+    // TODO(remote-gateway): the WS hello handshake consumes this later
+    // on this branch; drop the allow when ws.rs lands.
+    #[allow(dead_code)]
+    pub fn touch(&self, id: &str) {
+        let Ok(mut records) = self.records.lock() else {
+            return;
+        };
+        if let Some(r) = records.iter_mut().find(|r| r.id == id) {
+            r.last_seen_at = now_ms();
+            let snapshot = records.clone();
+            let _ = self.persist(&snapshot);
+        }
+    }
+
+    pub fn list(&self) -> Vec<DeviceView> {
+        self.records
+            .lock()
+            .map(|records| records.iter().map(DeviceView::from).collect())
+            .unwrap_or_default()
+    }
+
+    /// Revocation keeps the record (audit trail + tombstone) but the
+    /// token stops verifying immediately; the WS layer also closes any
+    /// live connection for the id.
+    pub fn revoke(&self, id: &str) -> Result<(), String> {
+        self.mutate(id, |r| r.revoked = true)
+    }
+
+    pub fn rename(&self, id: &str, name: &str) -> Result<(), String> {
+        let name = name.trim();
+        if name.is_empty() {
+            return Err("device name must not be empty".to_string());
+        }
+        self.mutate(id, |r| r.name = name.to_string())
+    }
+
+    fn mutate(&self, id: &str, f: impl FnOnce(&mut DeviceRecord)) -> Result<(), String> {
+        let mut records = self.records.lock().map_err(|e| e.to_string())?;
+        let Some(record) = records.iter_mut().find(|r| r.id == id) else {
+            return Err(format!("unknown device {id}"));
+        };
+        f(record);
+        self.persist(&records)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn store(dir: &tempfile::TempDir) -> DeviceStore {
+        DeviceStore::load(Some(dir.path().to_path_buf()))
+    }
+
+    #[test]
+    fn add_then_verify_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let s = store(&dir);
+        let added = s.add("James's iPhone", "ios", "tok-abc").unwrap();
+        let found = s.verify_token("tok-abc").expect("token must verify");
+        assert_eq!(found.id, added.id);
+        assert!(s.verify_token("tok-abd").is_none(), "near-miss token");
+        assert!(s.verify_token("").is_none());
+    }
+
+    #[test]
+    fn revoked_device_stops_verifying_but_stays_listed() {
+        let dir = tempfile::tempdir().unwrap();
+        let s = store(&dir);
+        let added = s.add("iPad", "ios", "tok-1").unwrap();
+        s.revoke(&added.id).unwrap();
+        assert!(s.verify_token("tok-1").is_none());
+        let listed = s.list();
+        assert_eq!(listed.len(), 1);
+        assert!(listed[0].revoked);
+    }
+
+    #[test]
+    fn store_persists_across_reload() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let s = store(&dir);
+            s.add("Phone", "ios", "tok-persist").unwrap();
+        }
+        let reloaded = store(&dir);
+        assert!(reloaded.verify_token("tok-persist").is_some());
+        assert_eq!(reloaded.list().len(), 1);
+    }
+
+    #[test]
+    fn persisted_file_never_contains_the_token() {
+        let dir = tempfile::tempdir().unwrap();
+        store(&dir).add("Phone", "ios", "tok-secret").unwrap();
+        let raw = std::fs::read_to_string(dir.path().join("devices.json")).unwrap();
+        assert!(!raw.contains("tok-secret"));
+        assert!(raw.contains("tokenSha256"));
+    }
+
+    #[test]
+    fn rename_validates_and_applies() {
+        let dir = tempfile::tempdir().unwrap();
+        let s = store(&dir);
+        let added = s.add("Phone", "ios", "t").unwrap();
+        assert!(s.rename(&added.id, "  ").is_err());
+        s.rename(&added.id, "Renamed").unwrap();
+        assert_eq!(s.list()[0].name, "Renamed");
+        assert!(s.rename("dev-missing", "x").is_err());
+    }
+
+    #[test]
+    fn constant_time_eq_semantics() {
+        assert!(constant_time_eq("abc", "abc"));
+        assert!(!constant_time_eq("abc", "abd"));
+        assert!(!constant_time_eq("abc", "abcd"));
+        assert!(constant_time_eq("", ""));
+    }
+
+    #[test]
+    fn memory_only_store_works_without_dir() {
+        let s = DeviceStore::load(None);
+        s.add("Phone", "ios", "tok").unwrap();
+        assert!(s.verify_token("tok").is_some());
+    }
+}

--- a/src-tauri/src/server/remote/events.rs
+++ b/src-tauri/src/server/remote/events.rs
@@ -3,26 +3,26 @@
 //! Every Tauri event site in this codebase broadcasts via `app.emit(..)`
 //! (no targeted `emit_to`), so `listen_any` taps observe the exact
 //! payloads the desktop webview receives — no changes at the emit sites.
-//! The hub stamps a per-topic sequence number and rebroadcasts
-//! `Arc<EventFrame>`s; per-client connection tasks filter by their
-//! subscription set. Clients detect a `seq` gap after reconnect and
-//! rehydrate via invokes instead of relying on a replay buffer.
-
-// TODO(remote-gateway): consumed by the WS connection layer later on this
-// branch; drop this allow when ws.rs lands.
-#![allow(dead_code)]
+//! The hub stamps a per-topic sequence number, serializes the wire frame
+//! once, and rebroadcasts `Arc<EventFrame>`s; per-client connection
+//! tasks filter by their subscription set. Clients detect a `seq` gap
+//! after reconnect and rehydrate via invokes instead of relying on a
+//! replay buffer.
 
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
+use serde_json::value::RawValue;
 use tauri::Listener;
 use tokio::sync::broadcast;
 
-/// Topics remote clients may subscribe to. Phase 1 covers the agent
-/// bridge stream + host discovery; later phases append shell/fs/git
-/// topics here (the tap mechanism is topic-agnostic).
-pub const REMOTE_TOPICS: &[&str] = &[
+use crate::server::remote::protocol::ServerFrame;
+
+/// Topics tapped from Tauri events. Phase 1 covers the agent bridge
+/// stream + host discovery; later phases append shell/fs/git topics
+/// here (the tap mechanism is topic-agnostic).
+pub const TAPPED_TOPICS: &[&str] = &[
     "agent-response",
     "agent-reloaded",
     "agent-stderr",
@@ -31,14 +31,24 @@ pub const REMOTE_TOPICS: &[&str] = &[
     "host-removed",
 ];
 
-/// One tapped Tauri event, fanned out to subscribed clients.
+/// Topics published directly by Rust code rather than tapped from a
+/// Tauri event: `frontend-state` carries the `control_update_state`
+/// snapshot so every connected device converges on tab/model/account
+/// changes regardless of who caused them.
+pub const PUSHED_TOPICS: &[&str] = &["frontend-state"];
+
+/// Every topic a client may subscribe to.
+pub fn is_known_topic(topic: &str) -> bool {
+    TAPPED_TOPICS.contains(&topic) || PUSHED_TOPICS.contains(&topic)
+}
+
+/// One event, fanned out to subscribed clients. `wire` is the fully
+/// serialized `{"t":"event",...}` frame (seq stamped inside) —
+/// serialized once, written N times.
 #[derive(Debug)]
 pub struct EventFrame {
     pub topic: &'static str,
-    pub seq: u64,
-    /// Raw JSON exactly as Tauri serialized the emitted payload — a remote
-    /// client parses it the same way the webview's `listen` callback would.
-    pub payload: String,
+    pub wire: String,
 }
 
 /// Broadcast hub between the Tauri event taps and client connections.
@@ -55,8 +65,9 @@ const HUB_CAPACITY: usize = 1024;
 impl EventHub {
     pub fn new() -> Self {
         let (tx, _) = broadcast::channel(HUB_CAPACITY);
-        let seqs = REMOTE_TOPICS
+        let seqs = TAPPED_TOPICS
             .iter()
+            .chain(PUSHED_TOPICS.iter())
             .map(|&topic| (topic, AtomicU64::new(0)))
             .collect();
         Self { tx, seqs }
@@ -66,19 +77,34 @@ impl EventHub {
         self.tx.subscribe()
     }
 
-    /// Stamp and fan out one event. Send errors just mean no client is
-    /// connected right now — that's the idle steady state, not a fault.
+    /// Stamp, serialize, and fan out one event. `payload` is the raw
+    /// JSON Tauri serialized (or that the pusher produced). Send errors
+    /// just mean no client is connected right now — that's the idle
+    /// steady state, not a fault.
     pub fn publish(&self, topic: &'static str, payload: String) {
         let Some(seq) = self.seqs.get(topic) else {
             debug_assert!(false, "publish for unregistered topic {topic}");
             return;
         };
-        let frame = EventFrame {
-            topic,
-            seq: seq.fetch_add(1, Ordering::Relaxed) + 1,
-            payload,
+        let seq = seq.fetch_add(1, Ordering::Relaxed) + 1;
+        let raw = match RawValue::from_string(payload) {
+            Ok(raw) => raw,
+            Err(e) => {
+                // Tauri payloads are valid JSON by construction; treat a
+                // violation loudly but don't kill the stream.
+                tracing::warn!(target: "aethon::server::remote", "non-JSON payload on {topic}: {e}");
+                return;
+            }
         };
-        let _ = self.tx.send(Arc::new(frame));
+        let frame = ServerFrame::Event {
+            topic: topic.to_string(),
+            seq,
+            payload: raw,
+        };
+        let Ok(wire) = frame.wire() else {
+            return;
+        };
+        let _ = self.tx.send(Arc::new(EventFrame { topic, wire }));
     }
 }
 
@@ -88,11 +114,12 @@ impl Default for EventHub {
     }
 }
 
-/// Install `listen_any` taps for every remote topic. `listen_any` (rather
-/// than `listen`) so targeted emits would also be observed if an emit
-/// site ever switches to `emit_to`.
+/// Install `listen_any` taps for every tapped topic. `listen_any`
+/// (rather than `listen`) so targeted emits would also be observed if an
+/// emit site ever switches to `emit_to`. Call once per process — taps
+/// survive server stop/start.
 pub fn install_taps<R: tauri::Runtime>(hub: &Arc<EventHub>, app: &tauri::AppHandle<R>) {
-    for &topic in REMOTE_TOPICS {
+    for &topic in TAPPED_TOPICS {
         let hub = Arc::clone(hub);
         app.listen_any(topic, move |event| {
             hub.publish(topic, event.payload().to_string());
@@ -127,11 +154,13 @@ mod tests {
             .expect("tap must observe the emit promptly")
             .expect("hub closed");
         assert_eq!(frame.topic, "agent-response");
-        assert_eq!(frame.seq, 1);
-        // Tauri serializes the emitted String, so the tap sees its JSON
-        // encoding; decoding restores the exact bridge line.
-        let decoded: String = serde_json::from_str(&frame.payload).expect("json string");
-        assert_eq!(decoded, "{\"type\":\"ready\"}");
+        // The wire frame embeds Tauri's serialization of the emitted
+        // String; decoding restores the exact bridge line.
+        let parsed: serde_json::Value = serde_json::from_str(&frame.wire).unwrap();
+        assert_eq!(parsed["t"], "event");
+        assert_eq!(parsed["topic"], "agent-response");
+        assert_eq!(parsed["seq"], 1);
+        assert_eq!(parsed["payload"], "{\"type\":\"ready\"}");
     }
 
     #[tokio::test]
@@ -152,7 +181,8 @@ mod tests {
                 .await
                 .expect("timely")
                 .expect("open");
-            seen.push((frame.topic, frame.seq));
+            let parsed: serde_json::Value = serde_json::from_str(&frame.wire).unwrap();
+            seen.push((frame.topic, parsed["seq"].as_u64().unwrap()));
         }
         assert_eq!(
             seen,
@@ -163,5 +193,17 @@ mod tests {
             ]
         );
         assert!(rx.try_recv().is_err(), "menu must not be tapped");
+    }
+
+    #[test]
+    fn pushed_topics_publish_without_a_tap() {
+        let hub = EventHub::new();
+        let mut rx = hub.subscribe();
+        hub.publish("frontend-state", "{\"tabs\":[]}".to_string());
+        let frame = rx.try_recv().expect("published");
+        assert_eq!(frame.topic, "frontend-state");
+        assert!(is_known_topic("frontend-state"));
+        assert!(is_known_topic("agent-response"));
+        assert!(!is_known_topic("menu"));
     }
 }

--- a/src-tauri/src/server/remote/events.rs
+++ b/src-tauri/src/server/remote/events.rs
@@ -1,0 +1,167 @@
+//! Rust-side event tap + fan-out hub for remote clients.
+//!
+//! Every Tauri event site in this codebase broadcasts via `app.emit(..)`
+//! (no targeted `emit_to`), so `listen_any` taps observe the exact
+//! payloads the desktop webview receives — no changes at the emit sites.
+//! The hub stamps a per-topic sequence number and rebroadcasts
+//! `Arc<EventFrame>`s; per-client connection tasks filter by their
+//! subscription set. Clients detect a `seq` gap after reconnect and
+//! rehydrate via invokes instead of relying on a replay buffer.
+
+// TODO(remote-gateway): consumed by the WS connection layer later on this
+// branch; drop this allow when ws.rs lands.
+#![allow(dead_code)]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use tauri::Listener;
+use tokio::sync::broadcast;
+
+/// Topics remote clients may subscribe to. Phase 1 covers the agent
+/// bridge stream + host discovery; later phases append shell/fs/git
+/// topics here (the tap mechanism is topic-agnostic).
+pub const REMOTE_TOPICS: &[&str] = &[
+    "agent-response",
+    "agent-reloaded",
+    "agent-stderr",
+    "scheduled-tasks-changed",
+    "host-discovered",
+    "host-removed",
+];
+
+/// One tapped Tauri event, fanned out to subscribed clients.
+#[derive(Debug)]
+pub struct EventFrame {
+    pub topic: &'static str,
+    pub seq: u64,
+    /// Raw JSON exactly as Tauri serialized the emitted payload — a remote
+    /// client parses it the same way the webview's `listen` callback would.
+    pub payload: String,
+}
+
+/// Broadcast hub between the Tauri event taps and client connections.
+pub struct EventHub {
+    tx: broadcast::Sender<Arc<EventFrame>>,
+    seqs: HashMap<&'static str, AtomicU64>,
+}
+
+/// Bounded so a wedged consumer can't hold unbounded memory; a receiver
+/// that observes `Lagged` is disconnected by its connection task and the
+/// client rehydrates on reconnect.
+const HUB_CAPACITY: usize = 1024;
+
+impl EventHub {
+    pub fn new() -> Self {
+        let (tx, _) = broadcast::channel(HUB_CAPACITY);
+        let seqs = REMOTE_TOPICS
+            .iter()
+            .map(|&topic| (topic, AtomicU64::new(0)))
+            .collect();
+        Self { tx, seqs }
+    }
+
+    pub fn subscribe(&self) -> broadcast::Receiver<Arc<EventFrame>> {
+        self.tx.subscribe()
+    }
+
+    /// Stamp and fan out one event. Send errors just mean no client is
+    /// connected right now — that's the idle steady state, not a fault.
+    pub fn publish(&self, topic: &'static str, payload: String) {
+        let Some(seq) = self.seqs.get(topic) else {
+            debug_assert!(false, "publish for unregistered topic {topic}");
+            return;
+        };
+        let frame = EventFrame {
+            topic,
+            seq: seq.fetch_add(1, Ordering::Relaxed) + 1,
+            payload,
+        };
+        let _ = self.tx.send(Arc::new(frame));
+    }
+}
+
+impl Default for EventHub {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Install `listen_any` taps for every remote topic. `listen_any` (rather
+/// than `listen`) so targeted emits would also be observed if an emit
+/// site ever switches to `emit_to`.
+pub fn install_taps<R: tauri::Runtime>(hub: &Arc<EventHub>, app: &tauri::AppHandle<R>) {
+    for &topic in REMOTE_TOPICS {
+        let hub = Arc::clone(hub);
+        app.listen_any(topic, move |event| {
+            hub.publish(topic, event.payload().to_string());
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use tauri::Emitter;
+
+    use super::*;
+
+    /// The load-bearing assumption for the whole gateway fan-out: a
+    /// Rust-side `listen_any` tap receives payloads sent with the same
+    /// `app.emit(..)` call every event site in this codebase uses.
+    #[tokio::test]
+    async fn listen_any_tap_receives_app_emit_payloads() {
+        let app = tauri::test::mock_app();
+        let hub = Arc::new(EventHub::new());
+        install_taps(&hub, app.handle());
+        let mut rx = hub.subscribe();
+
+        app.handle()
+            .emit("agent-response", "{\"type\":\"ready\"}")
+            .expect("emit");
+
+        let frame = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+            .await
+            .expect("tap must observe the emit promptly")
+            .expect("hub closed");
+        assert_eq!(frame.topic, "agent-response");
+        assert_eq!(frame.seq, 1);
+        // Tauri serializes the emitted String, so the tap sees its JSON
+        // encoding; decoding restores the exact bridge line.
+        let decoded: String = serde_json::from_str(&frame.payload).expect("json string");
+        assert_eq!(decoded, "{\"type\":\"ready\"}");
+    }
+
+    #[tokio::test]
+    async fn seq_increments_per_topic_and_untapped_events_are_ignored() {
+        let app = tauri::test::mock_app();
+        let hub = Arc::new(EventHub::new());
+        install_taps(&hub, app.handle());
+        let mut rx = hub.subscribe();
+
+        app.handle().emit("agent-response", "a").expect("emit");
+        app.handle().emit("menu", "ignored-topic").expect("emit");
+        app.handle().emit("agent-stderr", "warn").expect("emit");
+        app.handle().emit("agent-response", "b").expect("emit");
+
+        let mut seen = Vec::new();
+        for _ in 0..3 {
+            let frame = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+                .await
+                .expect("timely")
+                .expect("open");
+            seen.push((frame.topic, frame.seq));
+        }
+        assert_eq!(
+            seen,
+            vec![
+                ("agent-response", 1),
+                ("agent-stderr", 1),
+                ("agent-response", 2),
+            ]
+        );
+        assert!(rx.try_recv().is_err(), "menu must not be tapped");
+    }
+}

--- a/src-tauri/src/server/remote/integration_tests.rs
+++ b/src-tauri/src/server/remote/integration_tests.rs
@@ -1,0 +1,184 @@
+//! End-to-end protocol tests: the real axum router served over a plain
+//! TCP loopback socket, driven by a real WebSocket client. TLS pinning
+//! is covered structurally in `tls.rs`; here we exercise the wire
+//! protocol — pairing, hello auth, invoke correlation, event fan-out,
+//! and revocation — with the `EchoRelay` so no Tauri runtime is needed.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures_util::{SinkExt, StreamExt};
+use serde_json::{Value, json};
+use tokio_tungstenite::tungstenite::Message;
+
+use super::relay::EchoRelay;
+use super::{GatewayCtx, RemoteState};
+use crate::commands::host::HostInfo;
+
+struct Harness {
+    addr: String,
+    remote: Arc<RemoteState>,
+}
+
+async fn spawn_gateway() -> Harness {
+    let remote = Arc::new(RemoteState::in_memory());
+    let ctx = GatewayCtx {
+        info: HostInfo {
+            id: "local:test".into(),
+            hostname: "test.local".into(),
+            display_name: "test".into(),
+            fingerprint: "f".repeat(64),
+        },
+        remote: Arc::clone(&remote),
+        relay: Arc::new(EchoRelay),
+    };
+    let router = crate::server::http::router(ctx.info.clone(), ctx.remote.clone(), ctx.relay.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, router).await;
+    });
+    Harness {
+        addr: format!("{addr}"),
+        remote,
+    }
+}
+
+/// Arm a pairing session, redeem it over HTTP, return the device token.
+async fn pair(h: &Harness) -> String {
+    let (session, begin) = super::pairing::begin("test", 0, &"f".repeat(64));
+    *h.remote.pairing.lock().unwrap() = Some(session);
+    let resp: Value = reqwest::Client::new()
+        .post(format!("http://{}/pair", h.addr))
+        .json(&json!({ "code": begin.code, "deviceName": "iPhone", "platform": "ios" }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    resp["deviceToken"].as_str().unwrap().to_string()
+}
+
+type Ws = tokio_tungstenite::WebSocketStream<
+    tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+>;
+
+async fn connect(h: &Harness) -> Ws {
+    let (ws, _) = tokio_tungstenite::connect_async(format!("ws://{}/ws", h.addr))
+        .await
+        .unwrap();
+    ws
+}
+
+async fn next_json(ws: &mut Ws) -> Value {
+    loop {
+        let msg = tokio::time::timeout(Duration::from_secs(3), ws.next())
+            .await
+            .expect("frame within timeout")
+            .expect("stream open")
+            .expect("no ws error");
+        if let Message::Text(text) = msg {
+            return serde_json::from_str(&text).unwrap();
+        }
+        // Skip ping/pong control frames.
+    }
+}
+
+async fn send(ws: &mut Ws, value: Value) {
+    ws.send(Message::Text(value.to_string())).await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn full_flow_pair_hello_invoke_subscribe_event() {
+    let h = spawn_gateway().await;
+    let token = pair(&h).await;
+    let mut ws = connect(&h).await;
+
+    send(&mut ws, json!({ "t": "hello", "protocol": 1, "token": token })).await;
+    let hello_ok = next_json(&mut ws).await;
+    assert_eq!(hello_ok["t"], "hello_ok");
+    assert_eq!(hello_ok["host"]["displayName"], "test");
+
+    // Invoke correlates by id; EchoRelay reflects cmd+args back.
+    send(
+        &mut ws,
+        json!({ "t": "invoke", "id": "i-1", "cmd": "host_info", "args": {} }),
+    )
+    .await;
+    let result = next_json(&mut ws).await;
+    assert_eq!(result["t"], "result");
+    assert_eq!(result["id"], "i-1");
+    assert_eq!(result["ok"], true);
+    assert_eq!(result["data"]["cmd"], "host_info");
+
+    // Subscribe, then publish through the hub — the event must arrive
+    // with the payload verbatim.
+    send(&mut ws, json!({ "t": "sub", "topics": ["agent-response"] })).await;
+    // Small yield so the sub frame is processed before we publish.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    h.remote
+        .hub
+        .publish("agent-response", "\"{\\\"type\\\":\\\"ready\\\"}\"".to_string());
+    let event = next_json(&mut ws).await;
+    assert_eq!(event["t"], "event");
+    assert_eq!(event["topic"], "agent-response");
+    assert_eq!(event["seq"], 1);
+    assert_eq!(event["payload"], "{\"type\":\"ready\"}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn bad_token_is_rejected_with_bye() {
+    let h = spawn_gateway().await;
+    let mut ws = connect(&h).await;
+    send(
+        &mut ws,
+        json!({ "t": "hello", "protocol": 1, "token": "not-a-real-token" }),
+    )
+    .await;
+    let bye = next_json(&mut ws).await;
+    assert_eq!(bye["t"], "bye");
+    assert_eq!(bye["reason"], "auth-failed");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn unsubscribed_topic_is_not_delivered() {
+    let h = spawn_gateway().await;
+    let token = pair(&h).await;
+    let mut ws = connect(&h).await;
+    send(&mut ws, json!({ "t": "hello", "protocol": 1, "token": token })).await;
+    assert_eq!(next_json(&mut ws).await["t"], "hello_ok");
+
+    // No sub for agent-response; publish, then invoke — the invoke
+    // result must be the next frame (event was filtered out).
+    h.remote
+        .hub
+        .publish("agent-response", "\"x\"".to_string());
+    send(
+        &mut ws,
+        json!({ "t": "invoke", "id": "i-9", "cmd": "host_info", "args": {} }),
+    )
+    .await;
+    let frame = next_json(&mut ws).await;
+    assert_eq!(frame["t"], "result");
+    assert_eq!(frame["id"], "i-9");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn revocation_closes_the_live_session() {
+    let h = spawn_gateway().await;
+    let token = pair(&h).await;
+    let mut ws = connect(&h).await;
+    send(&mut ws, json!({ "t": "hello", "protocol": 1, "token": token.clone() })).await;
+    let hello_ok = next_json(&mut ws).await;
+    let device_id = hello_ok["deviceId"].as_str().unwrap().to_string();
+
+    // Let the session register its live handle before revoking.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    h.remote.devices.revoke(&device_id).unwrap();
+    h.remote.close_device(&device_id);
+
+    let bye = next_json(&mut ws).await;
+    assert_eq!(bye["t"], "bye");
+    assert_eq!(bye["reason"], "revoked");
+}

--- a/src-tauri/src/server/remote/mod.rs
+++ b/src-tauri/src/server/remote/mod.rs
@@ -17,6 +17,9 @@ pub mod protocol;
 pub mod relay;
 pub mod ws;
 
+#[cfg(test)]
+mod integration_tests;
+
 use devices::DeviceStore;
 use events::EventHub;
 use pairing::PairingSession;

--- a/src-tauri/src/server/remote/mod.rs
+++ b/src-tauri/src/server/remote/mod.rs
@@ -1,48 +1,92 @@
 //! Remote-client gateway (paired devices over the LAN).
 //!
 //! Grows the scaffold in `server/` into an authenticated transport for
-//! companion clients (iOS app): TLS + pairing, a WebSocket protocol that
-//! relays an allowlisted subset of the Tauri command surface, and an
-//! event hub that fans Tauri events out to connected devices.
+//! companion clients (iOS app): TLS + pairing, a WebSocket protocol
+//! (`protocol`/`ws`) that relays an allowlisted subset of the Tauri
+//! command surface (`policy`/`relay`), and an event hub (`events`) that
+//! fans Tauri events out to connected devices.
 
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 pub mod devices;
 pub mod events;
 pub mod pairing;
+pub mod policy;
+pub mod protocol;
+pub mod relay;
+pub mod ws;
 
 use devices::DeviceStore;
 use events::EventHub;
 use pairing::PairingSession;
+use tokio::sync::Notify;
 
 /// Managed by Tauri (`.manage(Arc<RemoteState>)`) and shared with the
 /// axum router; owns everything the gateway needs across connections.
 pub struct RemoteState {
     pub devices: DeviceStore,
     pub pairing: Mutex<Option<PairingSession>>,
-    // TODO(remote-gateway): read by the WS connection layer later on
-    // this branch; drop the allow when ws.rs lands.
-    #[allow(dead_code)]
     pub hub: Arc<EventHub>,
+    /// Live-connection close signals keyed by device id, so revocation
+    /// can drop a device's sessions immediately (`bye revoked`).
+    live: Mutex<HashMap<String, Vec<Arc<Notify>>>>,
 }
 
 impl RemoteState {
     /// Production state, persisting devices under `~/.aethon/remote/`.
     pub fn new() -> Self {
+        Self::with_store(DeviceStore::load(crate::server::tls::default_remote_dir()))
+    }
+
+    fn with_store(devices: DeviceStore) -> Self {
         Self {
-            devices: DeviceStore::load(crate::server::tls::default_remote_dir()),
+            devices,
             pairing: Mutex::new(None),
             hub: Arc::new(EventHub::new()),
+            live: Mutex::new(HashMap::new()),
         }
     }
 
     /// Ephemeral state for tests.
     #[cfg(test)]
     pub fn in_memory() -> Self {
-        Self {
-            devices: DeviceStore::load(None),
-            pairing: Mutex::new(None),
-            hub: Arc::new(EventHub::new()),
+        Self::with_store(DeviceStore::load(None))
+    }
+
+    /// Register a live connection; the returned handle fires when the
+    /// device is revoked.
+    pub fn register_live(&self, device_id: &str) -> Arc<Notify> {
+        let notify = Arc::new(Notify::new());
+        if let Ok(mut live) = self.live.lock() {
+            live.entry(device_id.to_string())
+                .or_default()
+                .push(Arc::clone(&notify));
+        }
+        notify
+    }
+
+    pub fn deregister_live(&self, device_id: &str, handle: &Arc<Notify>) {
+        let Ok(mut live) = self.live.lock() else {
+            return;
+        };
+        if let Some(handles) = live.get_mut(device_id) {
+            handles.retain(|h| !Arc::ptr_eq(h, handle));
+            if handles.is_empty() {
+                live.remove(device_id);
+            }
+        }
+    }
+
+    /// Close every live session for a device (post-revocation).
+    pub fn close_device(&self, device_id: &str) {
+        let Ok(live) = self.live.lock() else {
+            return;
+        };
+        if let Some(handles) = live.get(device_id) {
+            for handle in handles {
+                handle.notify_waiters();
+            }
         }
     }
 }
@@ -58,4 +102,5 @@ impl Default for RemoteState {
 pub struct GatewayCtx {
     pub info: crate::commands::host::HostInfo,
     pub remote: Arc<RemoteState>,
+    pub relay: Arc<dyn relay::RelayExec>,
 }

--- a/src-tauri/src/server/remote/mod.rs
+++ b/src-tauri/src/server/remote/mod.rs
@@ -5,4 +5,57 @@
 //! relays an allowlisted subset of the Tauri command surface, and an
 //! event hub that fans Tauri events out to connected devices.
 
+use std::sync::{Arc, Mutex};
+
+pub mod devices;
 pub mod events;
+pub mod pairing;
+
+use devices::DeviceStore;
+use events::EventHub;
+use pairing::PairingSession;
+
+/// Managed by Tauri (`.manage(Arc<RemoteState>)`) and shared with the
+/// axum router; owns everything the gateway needs across connections.
+pub struct RemoteState {
+    pub devices: DeviceStore,
+    pub pairing: Mutex<Option<PairingSession>>,
+    // TODO(remote-gateway): read by the WS connection layer later on
+    // this branch; drop the allow when ws.rs lands.
+    #[allow(dead_code)]
+    pub hub: Arc<EventHub>,
+}
+
+impl RemoteState {
+    /// Production state, persisting devices under `~/.aethon/remote/`.
+    pub fn new() -> Self {
+        Self {
+            devices: DeviceStore::load(crate::server::tls::default_remote_dir()),
+            pairing: Mutex::new(None),
+            hub: Arc::new(EventHub::new()),
+        }
+    }
+
+    /// Ephemeral state for tests.
+    #[cfg(test)]
+    pub fn in_memory() -> Self {
+        Self {
+            devices: DeviceStore::load(None),
+            pairing: Mutex::new(None),
+            hub: Arc::new(EventHub::new()),
+        }
+    }
+}
+
+impl Default for RemoteState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Axum router state for the gateway routes.
+#[derive(Clone)]
+pub struct GatewayCtx {
+    pub info: crate::commands::host::HostInfo,
+    pub remote: Arc<RemoteState>,
+}

--- a/src-tauri/src/server/remote/mod.rs
+++ b/src-tauri/src/server/remote/mod.rs
@@ -1,0 +1,8 @@
+//! Remote-client gateway (paired devices over the LAN).
+//!
+//! Grows the scaffold in `server/` into an authenticated transport for
+//! companion clients (iOS app): TLS + pairing, a WebSocket protocol that
+//! relays an allowlisted subset of the Tauri command surface, and an
+//! event hub that fans Tauri events out to connected devices.
+
+pub mod events;

--- a/src-tauri/src/server/remote/pairing.rs
+++ b/src-tauri/src/server/remote/pairing.rs
@@ -1,0 +1,369 @@
+//! Device pairing: the desktop displays an 8-digit code (and a QR
+//! payload embedding it); the phone proves possession by POSTing the
+//! code to `/pair` within the window and receives its durable device
+//! token. Codes are single-use, expire after two minutes, lock out
+//! after five failed attempts, and are compared by hash in constant
+//! time. `/pair` answers 404 whenever no session is active, so outside
+//! a pairing window the route is indistinguishable from absent.
+
+use std::time::{Duration, Instant};
+
+use axum::Json;
+use axum::extract::State;
+use axum::http::StatusCode;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use crate::commands::host::HostInfo;
+use crate::server::remote::GatewayCtx;
+use crate::server::remote::devices::constant_time_eq;
+use crate::server::tls::sha256_hex;
+
+pub const PAIRING_WINDOW: Duration = Duration::from_secs(120);
+pub const PAIRING_MAX_ATTEMPTS: u8 = 5;
+
+pub struct PairingSession {
+    code_sha256: String,
+    expires_at: Instant,
+    attempts_left: u8,
+}
+
+/// What `remote_pairing_begin` hands the Settings UI.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PairingBegin {
+    /// Plaintext code — displayed once, never stored.
+    pub code: String,
+    /// Wall-clock expiry for the countdown, epoch ms.
+    pub expires_at: i64,
+    /// JSON string the QR code encodes.
+    pub qr_payload: String,
+}
+
+pub enum Redeem {
+    Ok,
+    /// Wrong code; attempts remain.
+    BadCode,
+    /// Wrong code and the session is exhausted — caller must drop it.
+    LockedOut,
+    Expired,
+}
+
+/// Derive an 8-digit code from UUID entropy (`Date::now`/`rand` are
+/// unavailable by convention here; 2^122 bits mod 10^8 has negligible
+/// bias).
+fn new_code() -> String {
+    let n = u128::from_le_bytes(*uuid::Uuid::new_v4().as_bytes()) % 100_000_000;
+    format!("{n:08}")
+}
+
+/// A 256-bit device token from two UUIDs' entropy.
+pub fn new_device_token() -> String {
+    format!(
+        "{}{}",
+        uuid::Uuid::new_v4().simple(),
+        uuid::Uuid::new_v4().simple()
+    )
+}
+
+/// Non-loopback addresses a phone could dial, most-useful first:
+/// IPv4 (incl. Tailscale's 100.x), then `<hostname>` mDNS name.
+fn candidate_hosts() -> Vec<String> {
+    let mut hosts: Vec<String> = Vec::new();
+    if let Ok(ifaces) = if_addrs::get_if_addrs() {
+        for iface in ifaces {
+            if iface.is_loopback() {
+                continue;
+            }
+            match iface.addr.ip() {
+                std::net::IpAddr::V4(v4) if !v4.is_link_local() => hosts.push(v4.to_string()),
+                _ => {}
+            }
+        }
+    }
+    let hostname = gethostname::gethostname().to_string_lossy().into_owned();
+    if !hostname.is_empty() {
+        let mdns = if hostname.ends_with(".local") {
+            hostname
+        } else {
+            format!("{hostname}.local")
+        };
+        hosts.push(mdns);
+    }
+    hosts
+}
+
+pub fn begin(display_name: &str, port: u16, fingerprint: &str) -> (PairingSession, PairingBegin) {
+    let code = new_code();
+    let session = PairingSession {
+        code_sha256: sha256_hex(code.as_bytes()),
+        expires_at: Instant::now() + PAIRING_WINDOW,
+        attempts_left: PAIRING_MAX_ATTEMPTS,
+    };
+    let qr_payload = json!({
+        "v": 1,
+        "name": display_name,
+        "hosts": candidate_hosts(),
+        "port": port,
+        "fp": fingerprint,
+        "code": code,
+    })
+    .to_string();
+    let begin = PairingBegin {
+        code,
+        expires_at: chrono::Utc::now().timestamp_millis() + PAIRING_WINDOW.as_millis() as i64,
+        qr_payload,
+    };
+    (session, begin)
+}
+
+impl PairingSession {
+    pub fn redeem(&mut self, code: &str) -> Redeem {
+        if Instant::now() >= self.expires_at {
+            return Redeem::Expired;
+        }
+        if constant_time_eq(&self.code_sha256, &sha256_hex(code.as_bytes())) {
+            return Redeem::Ok;
+        }
+        self.attempts_left = self.attempts_left.saturating_sub(1);
+        if self.attempts_left == 0 {
+            Redeem::LockedOut
+        } else {
+            Redeem::BadCode
+        }
+    }
+
+    #[cfg(test)]
+    fn expire_now(&mut self) {
+        self.expires_at = Instant::now();
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PairRequest {
+    pub code: String,
+    pub device_name: String,
+    #[serde(default)]
+    pub platform: Option<String>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PairResponse {
+    pub device_id: String,
+    pub device_token: String,
+    pub host: HostInfo,
+}
+
+fn err_body(status: StatusCode, msg: &str) -> (StatusCode, Json<serde_json::Value>) {
+    (status, Json(json!({ "error": msg })))
+}
+
+/// `POST /pair` — the only unauthenticated mutating route on the
+/// gateway. Kept deliberately boring: active-session gate, constant-time
+/// code check, single-use teardown on every terminal outcome.
+pub async fn pair_handler(
+    State(ctx): State<GatewayCtx>,
+    Json(req): Json<PairRequest>,
+) -> Result<Json<PairResponse>, (StatusCode, Json<serde_json::Value>)> {
+    let device_name = req.device_name.trim();
+    if device_name.is_empty() {
+        return Err(err_body(StatusCode::BAD_REQUEST, "deviceName required"));
+    }
+    let mut guard = ctx
+        .remote
+        .pairing
+        .lock()
+        .map_err(|e| err_body(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()))?;
+    let Some(session) = guard.as_mut() else {
+        return Err(err_body(StatusCode::NOT_FOUND, "pairing not active"));
+    };
+    match session.redeem(&req.code) {
+        Redeem::Expired => {
+            *guard = None;
+            Err(err_body(StatusCode::GONE, "pairing window expired"))
+        }
+        Redeem::LockedOut => {
+            *guard = None;
+            Err(err_body(
+                StatusCode::TOO_MANY_REQUESTS,
+                "too many attempts; pairing cancelled",
+            ))
+        }
+        Redeem::BadCode => Err(err_body(StatusCode::FORBIDDEN, "wrong code")),
+        Redeem::Ok => {
+            // Single-use: tear the session down before minting anything.
+            *guard = None;
+            drop(guard);
+            let token = new_device_token();
+            let platform = req.platform.as_deref().unwrap_or("unknown");
+            let device = ctx
+                .remote
+                .devices
+                .add(device_name, platform, &token)
+                .map_err(|e| err_body(StatusCode::INTERNAL_SERVER_ERROR, &e))?;
+            tracing::info!(
+                target: "aethon::server::remote",
+                "paired device {} ({})", device.id, device.name
+            );
+            Ok(Json(PairResponse {
+                device_id: device.id,
+                device_token: token,
+                host: ctx.info.clone(),
+            }))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::server::remote::RemoteState;
+
+    fn test_ctx() -> GatewayCtx {
+        GatewayCtx {
+            info: HostInfo {
+                id: "local:test".into(),
+                hostname: "test.local".into(),
+                display_name: "test".into(),
+                fingerprint: "f".repeat(64),
+            },
+            remote: Arc::new(RemoteState::in_memory()),
+        }
+    }
+
+    fn arm(ctx: &GatewayCtx) -> PairingBegin {
+        let (session, begin) = begin("test", 4242, &"f".repeat(64));
+        *ctx.remote.pairing.lock().unwrap() = Some(session);
+        begin
+    }
+
+    #[test]
+    fn begin_produces_wellformed_qr_payload() {
+        let (_, b) = begin("halcyon", 4242, "abcd");
+        assert_eq!(b.code.len(), 8);
+        assert!(b.code.chars().all(|c| c.is_ascii_digit()));
+        let payload: serde_json::Value = serde_json::from_str(&b.qr_payload).unwrap();
+        assert_eq!(payload["v"], 1);
+        assert_eq!(payload["port"], 4242);
+        assert_eq!(payload["fp"], "abcd");
+        assert_eq!(payload["code"], b.code);
+        assert!(payload["hosts"].as_array().is_some_and(|h| !h.is_empty()));
+    }
+
+    #[tokio::test]
+    async fn happy_path_mints_token_and_is_single_use() {
+        let ctx = test_ctx();
+        let b = arm(&ctx);
+        let res = pair_handler(
+            State(ctx.clone()),
+            Json(PairRequest {
+                code: b.code.clone(),
+                device_name: "iPhone".into(),
+                platform: Some("ios".into()),
+            }),
+        )
+        .await
+        .expect("pairs");
+        assert!(ctx.remote.devices.verify_token(&res.device_token).is_some());
+        assert_eq!(res.host.display_name, "test");
+
+        // Session consumed — replaying the same code must 404.
+        let replay = pair_handler(
+            State(ctx.clone()),
+            Json(PairRequest {
+                code: b.code,
+                device_name: "iPhone".into(),
+                platform: None,
+            }),
+        )
+        .await
+        .err()
+        .expect("must fail");
+        assert_eq!(replay.0, StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn wrong_code_locks_out_after_max_attempts() {
+        let ctx = test_ctx();
+        let b = arm(&ctx);
+        for attempt in 1..=PAIRING_MAX_ATTEMPTS {
+            let err = pair_handler(
+                State(ctx.clone()),
+                Json(PairRequest {
+                    code: "00000000".into(),
+                    device_name: "x".into(),
+                    platform: None,
+                }),
+            )
+            .await
+            .err()
+            .expect("wrong code fails");
+            if attempt == PAIRING_MAX_ATTEMPTS {
+                assert_eq!(err.0, StatusCode::TOO_MANY_REQUESTS);
+            } else {
+                assert_eq!(err.0, StatusCode::FORBIDDEN);
+            }
+        }
+        // Locked out → session dropped → even the right code is dead.
+        let err = pair_handler(
+            State(ctx.clone()),
+            Json(PairRequest {
+                code: b.code,
+                device_name: "x".into(),
+                platform: None,
+            }),
+        )
+        .await
+        .err()
+        .expect("session gone");
+        assert_eq!(err.0, StatusCode::NOT_FOUND);
+        assert!(ctx.remote.devices.list().is_empty());
+    }
+
+    #[tokio::test]
+    async fn expired_session_answers_gone_and_tears_down() {
+        let ctx = test_ctx();
+        let b = arm(&ctx);
+        ctx.remote
+            .pairing
+            .lock()
+            .unwrap()
+            .as_mut()
+            .unwrap()
+            .expire_now();
+        let err = pair_handler(
+            State(ctx.clone()),
+            Json(PairRequest {
+                code: b.code,
+                device_name: "x".into(),
+                platform: None,
+            }),
+        )
+        .await
+        .err()
+        .expect("expired");
+        assert_eq!(err.0, StatusCode::GONE);
+        assert!(ctx.remote.pairing.lock().unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn no_active_session_is_indistinguishable_404() {
+        let ctx = test_ctx();
+        let err = pair_handler(
+            State(ctx),
+            Json(PairRequest {
+                code: "12345678".into(),
+                device_name: "x".into(),
+                platform: None,
+            }),
+        )
+        .await
+        .err()
+        .expect("inactive");
+        assert_eq!(err.0, StatusCode::NOT_FOUND);
+    }
+}

--- a/src-tauri/src/server/remote/pairing.rs
+++ b/src-tauri/src/server/remote/pairing.rs
@@ -232,6 +232,7 @@ mod tests {
                 fingerprint: "f".repeat(64),
             },
             remote: Arc::new(RemoteState::in_memory()),
+            relay: Arc::new(crate::server::remote::relay::EchoRelay),
         }
     }
 

--- a/src-tauri/src/server/remote/policy.rs
+++ b/src-tauri/src/server/remote/policy.rs
@@ -1,0 +1,339 @@
+//! Remote command policy: every Tauri command registered in `lib.rs`
+//! has an explicit posture here, plus the `ui.*` virtual methods that
+//! forward through the desktop webview. A unit test parses `lib.rs` and
+//! fails when the two drift, so adding a command without deciding its
+//! remote posture fails CI.
+//!
+//! Grounding invariants (see the plan in the repo history):
+//! - The desktop webview is the sole `*_query` answerer, sole
+//!   `mutation_ack` sender, and single writer of persisted state.
+//! - Execution-boundary approvals (MCP, workspace startup, extension
+//!   install) happen physically at the desktop.
+//! - Root-bearing commands (fs/git/shell) stay denied until the phase
+//!   that adds `validate_root_arg` enforcement lands.
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RemotePolicy {
+    /// Dispatch straight to the Rust command.
+    Direct,
+    /// Dispatch after per-command payload inspection (`agent_command`).
+    DirectFiltered,
+    /// Forward to the desktop webview via the control-plane machinery;
+    /// the payload is the `control-request` method name.
+    ForwardToFrontend(&'static str),
+    /// Refused, with the reason returned to the client.
+    Deny(&'static str),
+}
+
+use RemotePolicy::*;
+
+const DESKTOP_WRITER: &str = "the desktop webview is the single writer of shared persisted state";
+const CONTROL_PLANE: &str = "control-plane internals are not remotely accessible";
+const DESKTOP_ONLY: &str = "operates on desktop-local UI or OS surfaces";
+const LIFECYCLE: &str = "the desktop owns agent/server process lifecycle";
+const APPROVAL: &str = "execution boundary — approve at the desktop";
+const DEBUG_ONLY: &str = "debug transport only";
+const PHASE_TERMINAL: &str = "not yet exposed remotely (planned: terminal/files/git phase)";
+const PHASE_SETTINGS: &str = "not yet exposed remotely (planned: settings/dashboards phase)";
+const GATEWAY_ADMIN: &str = "remote gateway administration is desktop-only";
+
+/// The exhaustive table. Keep grouped by module, mirroring the
+/// `generate_handler!` order where practical.
+pub const COMMAND_POLICIES: &[(&str, RemotePolicy)] = &[
+    // agent bridge
+    ("start_agent", Direct),
+    ("send_message", Direct),
+    ("agent_command", DirectFiltered),
+    ("agent_broadcast_command", Deny(LIFECYCLE)),
+    ("force_restart_agent", Deny(LIFECYCLE)),
+    ("reload_agent", Deny(LIFECYCLE)),
+    ("agent_diagnostics", Direct),
+    ("reconcile_agent_workers", Deny(LIFECYCLE)),
+    ("dispatch_a2ui_event", Direct),
+    // control plane
+    ("control_update_state", Deny(CONTROL_PLANE)),
+    ("control_request_complete", Deny(CONTROL_PLANE)),
+    // paste (already jailed to ~/.aethon/pastes with a 32 MiB cap)
+    ("save_paste_image", Direct),
+    ("read_paste_image_base64", Direct),
+    // config/state
+    ("read_state", Direct),
+    ("write_state", Deny(DESKTOP_WRITER)),
+    ("read_config", Direct),
+    ("write_config", Deny(DESKTOP_WRITER)),
+    ("read_issue_templates", Deny(PHASE_TERMINAL)),
+    ("aethon_home_dir", Direct),
+    // sessions
+    ("search_sessions", Direct),
+    ("delete_session", Direct),
+    ("fork_session", Direct),
+    ("export_chat_markdown", Direct),
+    // scheduler
+    ("scheduled_tasks_list", Direct),
+    ("scheduled_tasks_reconcile_live_tabs", Deny(PHASE_SETTINGS)),
+    ("scheduled_tasks_fail_running_for_tab", Deny(PHASE_SETTINGS)),
+    ("scheduled_task_create", Deny(PHASE_SETTINGS)),
+    ("scheduled_task_update", Deny(PHASE_SETTINGS)),
+    ("scheduled_task_pause", Deny(PHASE_SETTINGS)),
+    ("scheduled_task_resume", Deny(PHASE_SETTINGS)),
+    ("scheduled_task_cancel", Deny(PHASE_SETTINGS)),
+    ("scheduled_task_delete", Deny(PHASE_SETTINGS)),
+    ("scheduled_task_reuse", Deny(PHASE_SETTINGS)),
+    ("scheduled_task_run_now", Deny(PHASE_SETTINGS)),
+    ("scheduled_task_schedule_wakeup", Deny(PHASE_SETTINGS)),
+    ("scheduled_task_complete", Deny(PHASE_SETTINGS)),
+    ("scheduled_task_resolve_loop_prompt", Deny(PHASE_SETTINGS)),
+    // subagents
+    ("subagents_list", Direct),
+    ("subagents_write", Deny(PHASE_SETTINGS)),
+    ("subagents_delete", Deny(PHASE_SETTINGS)),
+    // setup + approvals
+    ("aethon_setup_status", Deny(PHASE_SETTINGS)),
+    ("aethon_setup_write_agents", Deny(APPROVAL)),
+    ("aethon_setup_set_host_mcp_policy", Deny(APPROVAL)),
+    ("aethon_setup_import_mcp_json", Deny(APPROVAL)),
+    ("aethon_setup_write_startup_command", Deny(APPROVAL)),
+    ("mcp_config_status", Deny(PHASE_SETTINGS)),
+    ("mcp_config_approve", Deny(APPROVAL)),
+    ("workspace_startup_status", Deny(PHASE_SETTINGS)),
+    ("workspace_startup_approve", Deny(APPROVAL)),
+    ("workspace_startup_continue", Deny(APPROVAL)),
+    ("workspace_startup_retry", Deny(APPROVAL)),
+    ("workspace_startup_prepare_for_path", Deny(APPROVAL)),
+    ("workspace_startup_set_auto_approve", Deny(APPROVAL)),
+    // extensions
+    ("set_extension_menu_items", Deny(DESKTOP_ONLY)),
+    ("set_tray_sessions", Deny(DESKTOP_ONLY)),
+    ("install_aethon_extension", Deny(APPROVAL)),
+    ("watch_project_extensions", Deny(LIFECYCLE)),
+    ("unwatch_project_extensions", Deny(LIFECYCLE)),
+    // fs (terminal/files/git phase; will require validate_root_arg)
+    ("fs_list_dir", Deny(PHASE_TERMINAL)),
+    ("fs_walk_project", Deny(PHASE_TERMINAL)),
+    ("fs_read_file", Deny(PHASE_TERMINAL)),
+    ("fs_read_file_base64", Deny(PHASE_TERMINAL)),
+    ("fs_exists", Deny(PHASE_TERMINAL)),
+    ("fs_file_mtime", Deny(PHASE_TERMINAL)),
+    ("fs_write_file", Deny(PHASE_TERMINAL)),
+    ("fs_create_file", Deny(PHASE_TERMINAL)),
+    ("fs_create_dir", Deny(PHASE_TERMINAL)),
+    ("fs_rename", Deny(PHASE_TERMINAL)),
+    ("fs_delete", Deny(PHASE_TERMINAL)),
+    ("fs_watch_dirs", Deny(PHASE_TERMINAL)),
+    ("fs_unwatch_root", Deny(PHASE_TERMINAL)),
+    ("fs_discover_project_icon", Deny(PHASE_TERMINAL)),
+    ("fs_reveal_in_file_manager", Deny(DESKTOP_ONLY)),
+    ("fs_open_in_file_manager", Deny(DESKTOP_ONLY)),
+    ("fs_open_in_default_app", Deny(DESKTOP_ONLY)),
+    // git + gh (terminal/files/git phase)
+    ("git_status", Deny(PHASE_TERMINAL)),
+    ("git_working_context", Deny(PHASE_TERMINAL)),
+    ("git_fetch_all", Deny(PHASE_TERMINAL)),
+    ("git_file_status", Deny(PHASE_TERMINAL)),
+    ("git_ignored_paths", Deny(PHASE_TERMINAL)),
+    ("git_watch_root", Deny(PHASE_TERMINAL)),
+    ("git_unwatch_root", Deny(PHASE_TERMINAL)),
+    ("git_file_diff", Deny(PHASE_TERMINAL)),
+    ("git_file_diff_hunks", Deny(PHASE_TERMINAL)),
+    ("git_file_diff_stat", Deny(PHASE_TERMINAL)),
+    ("git_show_head", Deny(PHASE_TERMINAL)),
+    ("git_diff_stat", Deny(PHASE_TERMINAL)),
+    ("git_worktrees", Deny(PHASE_TERMINAL)),
+    ("git_worktree_add", Deny(PHASE_TERMINAL)),
+    ("git_worktree_remove", Deny(PHASE_TERMINAL)),
+    ("git_worktree_remove_orphan", Deny(PHASE_TERMINAL)),
+    ("git_branch_list", Deny(PHASE_TERMINAL)),
+    ("gh_branch_status", Deny(PHASE_TERMINAL)),
+    ("gh_repo_overview", Deny(PHASE_TERMINAL)),
+    ("gh_repo_avatar_url", Deny(PHASE_TERMINAL)),
+    ("gh_checks", Deny(PHASE_TERMINAL)),
+    ("gh_issue_list", Deny(PHASE_TERMINAL)),
+    ("gh_issue_view", Deny(PHASE_TERMINAL)),
+    ("pick_project_directory", Deny(DESKTOP_ONLY)),
+    // shells (terminal/files/git phase)
+    ("shell_open", Deny(PHASE_TERMINAL)),
+    ("shell_input", Deny(PHASE_TERMINAL)),
+    ("shell_resize", Deny(PHASE_TERMINAL)),
+    ("shell_close", Deny(PHASE_TERMINAL)),
+    ("shell_is_busy", Deny(PHASE_TERMINAL)),
+    ("shell_set_share_mode", Deny(PHASE_TERMINAL)),
+    ("shell_read_scrollback", Deny(PHASE_TERMINAL)),
+    ("shell_list_shareable", Deny(PHASE_TERMINAL)),
+    ("shell_write", Deny(PHASE_TERMINAL)),
+    // devshell
+    ("devshell_status", Deny(PHASE_SETTINGS)),
+    ("devshell_prepare_for_path", Deny(PHASE_SETTINGS)),
+    ("devshell_env_for_path", Deny(PHASE_SETTINGS)),
+    ("devshell_refresh", Deny(PHASE_SETTINGS)),
+    // voice (device-local audio)
+    ("voice_list_providers", Deny(DESKTOP_ONLY)),
+    ("voice_set_selected_provider", Deny(DESKTOP_ONLY)),
+    ("voice_set_provider_enabled", Deny(DESKTOP_ONLY)),
+    ("voice_prepare_provider", Deny(DESKTOP_ONLY)),
+    ("voice_remove_provider_model", Deny(DESKTOP_ONLY)),
+    ("voice_start_recording", Deny(DESKTOP_ONLY)),
+    ("voice_stop_and_transcribe", Deny(DESKTOP_ONLY)),
+    ("voice_cancel_recording", Deny(DESKTOP_ONLY)),
+    ("voice_speak", Deny(DESKTOP_ONLY)),
+    ("voice_stop_playback", Deny(DESKTOP_ONLY)),
+    // native windows
+    ("native_window_open_canvas", Deny(DESKTOP_ONLY)),
+    ("native_window_save_canvas", Deny(DESKTOP_ONLY)),
+    ("native_window_get_canvas", Deny(DESKTOP_ONLY)),
+    ("native_window_list", Deny(DESKTOP_ONLY)),
+    ("native_window_focus", Deny(DESKTOP_ONLY)),
+    ("native_window_close", Deny(DESKTOP_ONLY)),
+    ("native_window_set_title", Deny(DESKTOP_ONLY)),
+    // host + server + gateway admin
+    ("host_info", Direct),
+    ("server_status", Deny("use remote_status instead")),
+    ("server_start", Deny(LIFECYCLE)),
+    ("server_stop", Deny(LIFECYCLE)),
+    ("remote_status", Direct),
+    ("remote_pairing_begin", Deny(GATEWAY_ADMIN)),
+    ("remote_pairing_cancel", Deny(GATEWAY_ADMIN)),
+    ("remote_devices_list", Deny(GATEWAY_ADMIN)),
+    ("remote_device_revoke", Deny(GATEWAY_ADMIN)),
+    ("remote_device_rename", Deny(GATEWAY_ADMIN)),
+    // window/updater/boot
+    ("updater_available", Deny(DESKTOP_ONLY)),
+    ("toggle_fullscreen", Deny(DESKTOP_ONLY)),
+    ("toggle_devtools", Deny(DESKTOP_ONLY)),
+    ("check_for_updates_with_channel", Deny(DESKTOP_ONLY)),
+    ("install_pending_update", Deny(DESKTOP_ONLY)),
+    ("boot_stage", Deny(LIFECYCLE)),
+    ("boot_ok", Deny(LIFECYCLE)),
+    // debug (registered in debug builds only)
+    ("debug_eval_js", Deny(DEBUG_ONLY)),
+    ("debug_eval_result", Deny(DEBUG_ONLY)),
+    ("debug_shell_snapshot", Deny(DEBUG_ONLY)),
+    ("debug_shell_write_raw", Deny(DEBUG_ONLY)),
+    // ui.* virtual methods — forwarded to the desktop webview through
+    // the control plane; the method set useControlRequests.ts handles.
+    ("ui.tabs.open", ForwardToFrontend("tabs.open")),
+    ("ui.tabs.close", ForwardToFrontend("tabs.close")),
+    ("ui.tabs.focus", ForwardToFrontend("tabs.focus")),
+    ("ui.chat.send", ForwardToFrontend("chat.send")),
+    ("ui.chat.wait", ForwardToFrontend("chat.wait")),
+    ("ui.accounts.use", ForwardToFrontend("accounts.use")),
+    ("ui.agent.stop", ForwardToFrontend("agent.stop")),
+];
+
+pub fn policy_for(cmd: &str) -> RemotePolicy {
+    COMMAND_POLICIES
+        .iter()
+        .find(|(name, _)| *name == cmd)
+        .map(|(_, policy)| *policy)
+        .unwrap_or(Deny("unknown command"))
+}
+
+/// `agent_command` payload filter: the desktop webview is the sole
+/// mutation-ack sender and frontend-state mirror — a remote client
+/// echoing either would race it (double-ack) or poison the mirror.
+pub fn agent_command_remote_denial(payload: &serde_json::Value) -> Option<&'static str> {
+    match payload.get("type").and_then(|t| t.as_str()) {
+        Some("mutation_ack") => Some("mutation_ack is reserved for the desktop webview"),
+        Some("frontend_state_patch") => {
+            Some("frontend_state_patch is reserved for the desktop webview")
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::*;
+
+    /// Pull the command idents out of the `generate_handler![...]` block
+    /// in lib.rs. Mirrors the macro's shape: one `path::to::command,`
+    /// per line (cfg attributes on their own lines don't match).
+    fn registered_commands() -> HashSet<String> {
+        let lib = include_str!("../../lib.rs");
+        let start = lib
+            .find("invoke_handler(tauri::generate_handler![")
+            .expect("generate_handler block");
+        let end = lib[start..].find("])").expect("block end") + start;
+        lib[start..end]
+            .lines()
+            .filter_map(|line| {
+                let line = line.trim().trim_end_matches(',');
+                if line.is_empty() || line.starts_with("//") || line.starts_with('#') {
+                    return None;
+                }
+                let ident = line.rsplit("::").next()?;
+                ident
+                    .chars()
+                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+                    .then(|| ident.to_string())
+            })
+            .filter(|ident| ident != "invoke_handler")
+            .collect()
+    }
+
+    #[test]
+    fn every_registered_command_has_an_explicit_policy() {
+        let registered = registered_commands();
+        assert!(
+            registered.len() > 100,
+            "lib.rs parse looks broken: {} commands",
+            registered.len()
+        );
+        let table: HashSet<&str> = COMMAND_POLICIES.iter().map(|(name, _)| *name).collect();
+        let missing: Vec<_> = registered
+            .iter()
+            .filter(|cmd| !table.contains(cmd.as_str()))
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "commands registered in lib.rs without a remote policy: {missing:?}"
+        );
+    }
+
+    #[test]
+    fn no_stale_policy_entries() {
+        let registered = registered_commands();
+        let stale: Vec<_> = COMMAND_POLICIES
+            .iter()
+            .map(|(name, _)| *name)
+            .filter(|name| !name.starts_with("ui.") && !registered.contains(*name))
+            .collect();
+        assert!(
+            stale.is_empty(),
+            "policy entries for commands no longer registered: {stale:?}"
+        );
+    }
+
+    #[test]
+    fn no_duplicate_policy_entries() {
+        let mut seen = HashSet::new();
+        for (name, _) in COMMAND_POLICIES {
+            assert!(seen.insert(*name), "duplicate policy entry: {name}");
+        }
+    }
+
+    #[test]
+    fn spot_checks() {
+        assert_eq!(policy_for("send_message"), Direct);
+        assert_eq!(policy_for("agent_command"), DirectFiltered);
+        assert_eq!(policy_for("ui.chat.send"), ForwardToFrontend("chat.send"));
+        assert!(matches!(policy_for("write_state"), Deny(_)));
+        assert!(matches!(policy_for("shell_write"), Deny(_)));
+        assert!(matches!(policy_for("not_a_command"), Deny(_)));
+    }
+
+    #[test]
+    fn agent_command_filter_blocks_webview_reserved_types() {
+        use serde_json::json;
+        assert!(
+            agent_command_remote_denial(&json!({"type": "mutation_ack", "mutationId": "m1"}))
+                .is_some()
+        );
+        assert!(
+            agent_command_remote_denial(&json!({"type": "frontend_state_patch"})).is_some()
+        );
+        assert!(agent_command_remote_denial(&json!({"type": "set_model"})).is_none());
+        assert!(agent_command_remote_denial(&json!({"no": "type"})).is_none());
+    }
+}

--- a/src-tauri/src/server/remote/protocol.rs
+++ b/src-tauri/src/server/remote/protocol.rs
@@ -1,0 +1,181 @@
+//! Wire protocol v1 for the remote-gateway WebSocket.
+//!
+//! One JSON text frame per message, discriminated by `t`. The client's
+//! first frame must be `hello` (5s deadline, enforced in `ws.rs`);
+//! everything after authentication is `invoke` (request/response by
+//! client-chosen correlation id, mapping 1:1 onto Tauri commands plus
+//! the `ui.*` forwards) and `sub`/`unsub` (topic = Tauri event name).
+//! Server events carry the Tauri payload verbatim so a client parses it
+//! exactly the way the desktop webview's `listen` callback would.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use serde_json::value::RawValue;
+
+use crate::commands::host::HostInfo;
+
+pub const PROTOCOL_VERSION: u32 = 1;
+
+#[derive(Deserialize)]
+#[serde(tag = "t", rename_all = "snake_case", rename_all_fields = "camelCase")]
+pub enum ClientFrame {
+    Hello {
+        protocol: u32,
+        token: String,
+        /// Informational — identity comes from the token.
+        #[serde(default)]
+        device_id: Option<String>,
+        #[serde(default)]
+        app_version: Option<String>,
+    },
+    Invoke {
+        id: String,
+        cmd: String,
+        #[serde(default)]
+        args: Value,
+    },
+    Sub {
+        topics: Vec<String>,
+    },
+    Unsub {
+        topics: Vec<String>,
+    },
+}
+
+#[derive(Serialize)]
+#[serde(tag = "t", rename_all = "snake_case", rename_all_fields = "camelCase")]
+pub enum ServerFrame {
+    HelloOk {
+        protocol: u32,
+        host: HostInfo,
+        device_id: String,
+        app_version: String,
+    },
+    Result {
+        id: String,
+        ok: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        data: Option<Value>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        error: Option<String>,
+    },
+    Event {
+        topic: String,
+        seq: u64,
+        /// Raw JSON, embedded verbatim (no re-encode round trip).
+        payload: Box<RawValue>,
+    },
+    Bye {
+        reason: String,
+    },
+}
+
+impl ServerFrame {
+    pub fn result_ok(id: String, data: Value) -> Self {
+        ServerFrame::Result {
+            id,
+            ok: true,
+            data: Some(data),
+            error: None,
+        }
+    }
+
+    pub fn result_err(id: String, error: String) -> Self {
+        ServerFrame::Result {
+            id,
+            ok: false,
+            data: None,
+            error: Some(error),
+        }
+    }
+
+    pub fn bye(reason: &str) -> Self {
+        ServerFrame::Bye {
+            reason: reason.to_string(),
+        }
+    }
+
+    /// Serialize to the wire text. Infallible by construction (no maps
+    /// with non-string keys, no NaN); a failure would be a programming
+    /// error surfaced as a close.
+    pub fn wire(&self) -> Result<String, String> {
+        serde_json::to_string(self).map_err(|e| format!("serialize frame: {e}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn client_frames_parse_from_documented_shapes() {
+        let hello: ClientFrame = serde_json::from_str(
+            r#"{"t":"hello","protocol":1,"deviceId":"dev-1","token":"tok","appVersion":"0.1"}"#,
+        )
+        .unwrap();
+        match hello {
+            ClientFrame::Hello {
+                protocol,
+                token,
+                device_id,
+                app_version,
+            } => {
+                assert_eq!(protocol, 1);
+                assert_eq!(token, "tok");
+                assert_eq!(device_id.as_deref(), Some("dev-1"));
+                assert_eq!(app_version.as_deref(), Some("0.1"));
+            }
+            _ => panic!("expected hello"),
+        }
+
+        let invoke: ClientFrame =
+            serde_json::from_str(r#"{"t":"invoke","id":"i-1","cmd":"host_info"}"#).unwrap();
+        match invoke {
+            ClientFrame::Invoke { id, cmd, args } => {
+                assert_eq!(id, "i-1");
+                assert_eq!(cmd, "host_info");
+                assert!(args.is_null());
+            }
+            _ => panic!("expected invoke"),
+        }
+
+        let sub: ClientFrame =
+            serde_json::from_str(r#"{"t":"sub","topics":["agent-response"]}"#).unwrap();
+        assert!(matches!(sub, ClientFrame::Sub { topics } if topics == ["agent-response"]));
+    }
+
+    #[test]
+    fn server_frames_serialize_with_camel_case_tags() {
+        let ok = ServerFrame::result_ok("i-1".into(), serde_json::json!({"a": 1}))
+            .wire()
+            .unwrap();
+        assert_eq!(ok, r#"{"t":"result","id":"i-1","ok":true,"data":{"a":1}}"#);
+
+        let err = ServerFrame::result_err("i-2".into(), "denied: nope".into())
+            .wire()
+            .unwrap();
+        assert_eq!(
+            err,
+            r#"{"t":"result","id":"i-2","ok":false,"error":"denied: nope"}"#
+        );
+
+        let bye = ServerFrame::bye("revoked").wire().unwrap();
+        assert_eq!(bye, r#"{"t":"bye","reason":"revoked"}"#);
+    }
+
+    #[test]
+    fn event_frame_embeds_payload_verbatim() {
+        let raw = RawValue::from_string(r#""{\"type\":\"ready\"}""#.to_string()).unwrap();
+        let event = ServerFrame::Event {
+            topic: "agent-response".into(),
+            seq: 7,
+            payload: raw,
+        }
+        .wire()
+        .unwrap();
+        assert_eq!(
+            event,
+            r#"{"t":"event","topic":"agent-response","seq":7,"payload":"{\"type\":\"ready\"}"}"#
+        );
+    }
+}

--- a/src-tauri/src/server/remote/relay.rs
+++ b/src-tauri/src/server/remote/relay.rs
@@ -1,0 +1,262 @@
+//! Invoke dispatch for remote clients.
+//!
+//! Tauri has no "invoke by name" from Rust, so every remotely allowed
+//! command gets an explicit dispatch arm calling the underlying command
+//! fn (state fetched via `Manager::state`). The arm set is asserted
+//! against the policy table by a unit test, so an allowlist entry
+//! without a dispatch arm (or vice versa) fails CI.
+//!
+//! Argument objects use the exact camelCase keys the desktop frontend
+//! passes to `invoke(cmd, args)` — the mobile IPC shim forwards its args
+//! object untouched.
+//!
+//! The trait boundary exists so the WS layer is testable with a fake
+//! executor (no Tauri runtime).
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::Value;
+use tauri::{AppHandle, Manager};
+
+use super::policy::{self, RemotePolicy};
+
+#[async_trait]
+pub trait RelayExec: Send + Sync {
+    async fn invoke(&self, cmd: &str, args: Value) -> Result<Value, String>;
+}
+
+pub struct TauriRelay {
+    app: AppHandle,
+}
+
+impl TauriRelay {
+    pub fn new(app: AppHandle) -> Self {
+        Self { app }
+    }
+}
+
+/// Commands with a dispatch arm below. Kept next to the match so the
+/// policy-parity test can compare mechanically; not consulted at
+/// runtime (the match's fallback arm is the enforcement).
+#[cfg_attr(not(test), allow(dead_code))]
+pub const DISPATCHABLE: &[&str] = &[
+    "host_info",
+    "read_state",
+    "read_config",
+    "aethon_home_dir",
+    "search_sessions",
+    "delete_session",
+    "fork_session",
+    "export_chat_markdown",
+    "start_agent",
+    "send_message",
+    "agent_command",
+    "dispatch_a2ui_event",
+    "agent_diagnostics",
+    "scheduled_tasks_list",
+    "save_paste_image",
+    "read_paste_image_base64",
+    "subagents_list",
+    "remote_status",
+];
+
+fn arg<T: serde::de::DeserializeOwned>(args: &Value, key: &str) -> Result<T, String> {
+    let value = args.get(key).cloned().unwrap_or(Value::Null);
+    serde_json::from_value(value).map_err(|e| format!("bad arg `{key}`: {e}"))
+}
+
+fn to_value<T: serde::Serialize>(value: T) -> Result<Value, String> {
+    serde_json::to_value(value).map_err(|e| e.to_string())
+}
+
+#[async_trait]
+impl RelayExec for TauriRelay {
+    async fn invoke(&self, cmd: &str, args: Value) -> Result<Value, String> {
+        match policy::policy_for(cmd) {
+            RemotePolicy::Deny(reason) => Err(format!("denied: {reason}")),
+            RemotePolicy::ForwardToFrontend(method) => {
+                let control = self.app.state::<Arc<crate::control::ControlState>>();
+                crate::control::forward_ui_method(&self.app, control.inner(), method, args).await
+            }
+            RemotePolicy::DirectFiltered => {
+                let payload: String = arg(&args, "payload")?;
+                let parsed: Value = serde_json::from_str(&payload)
+                    .map_err(|e| format!("invalid agent command: {e}"))?;
+                if let Some(reason) = policy::agent_command_remote_denial(&parsed) {
+                    return Err(format!("denied: {reason}"));
+                }
+                self.dispatch(cmd, args).await
+            }
+            RemotePolicy::Direct => self.dispatch(cmd, args).await,
+        }
+    }
+}
+
+impl TauriRelay {
+    async fn dispatch(&self, cmd: &str, args: Value) -> Result<Value, String> {
+        let app = self.app.clone();
+        match cmd {
+            "host_info" => to_value(crate::commands::host::host_info()?),
+            "read_state" => to_value(crate::commands::config::read_state(
+                arg(&args, "name")?,
+                app,
+            )?),
+            "read_config" => Ok(crate::commands::config::read_config(app)?),
+            "aethon_home_dir" => to_value(crate::commands::config::aethon_home_dir(app)?),
+            // Scans every session file — keep it off the async workers.
+            "search_sessions" => {
+                let query: String = arg(&args, "query")?;
+                let limit: Option<u32> = arg(&args, "limit")?;
+                let hits = tauri::async_runtime::spawn_blocking(move || {
+                    crate::commands::session::search_sessions(query, limit, app)
+                })
+                .await
+                .map_err(|e| e.to_string())??;
+                to_value(hits)
+            }
+            "delete_session" => to_value(crate::commands::session::delete_session(
+                arg(&args, "tabId")?,
+                app,
+            )?),
+            "fork_session" => to_value(crate::commands::session::fork_session(
+                arg(&args, "tabId")?,
+                arg(&args, "entryId")?,
+                arg(&args, "cwd")?,
+                app,
+            )?),
+            "export_chat_markdown" => to_value(crate::commands::session::export_chat_markdown(
+                arg(&args, "label")?,
+                arg(&args, "content")?,
+                app,
+            )?),
+            "start_agent" => {
+                let state = app.state::<crate::agent_process::AgentProcesses>();
+                to_value(crate::agent_commands::start_agent(state.clone(), app.clone())?)
+            }
+            "send_message" => {
+                let state = app.state::<crate::agent_process::AgentProcesses>();
+                let devshell = app.state::<Arc<crate::devshell::DevshellCache>>();
+                let startup = app.state::<crate::commands::startup::WorkspaceStartupState>();
+                to_value(
+                    crate::agent_commands::send_message(
+                        arg(&args, "request")?,
+                        state.clone(),
+                        devshell.clone(),
+                        startup.clone(),
+                        app.clone(),
+                    )
+                    .await?,
+                )
+            }
+            "agent_command" => {
+                let state = app.state::<crate::agent_process::AgentProcesses>();
+                let devshell = app.state::<Arc<crate::devshell::DevshellCache>>();
+                let startup = app.state::<crate::commands::startup::WorkspaceStartupState>();
+                to_value(
+                    crate::agent_commands::agent_command(
+                        arg(&args, "payload")?,
+                        state.clone(),
+                        devshell.clone(),
+                        startup.clone(),
+                        app.clone(),
+                    )
+                    .await?,
+                )
+            }
+            "dispatch_a2ui_event" => {
+                let state = app.state::<crate::agent_process::AgentProcesses>();
+                to_value(
+                    crate::agent_commands::dispatch_a2ui_event(
+                        arg(&args, "event")?,
+                        arg(&args, "tabId")?,
+                        state.clone(),
+                        app.clone(),
+                    )
+                    .await?,
+                )
+            }
+            "agent_diagnostics" => {
+                let state = app.state::<crate::agent_process::AgentProcesses>();
+                to_value(crate::agent_commands::agent_diagnostics(state.clone())?)
+            }
+            "scheduled_tasks_list" => {
+                let state = app.state::<crate::commands::scheduler::ScheduledTasksState>();
+                to_value(crate::commands::scheduler::scheduled_tasks_list(
+                    state.clone(),
+                    app.clone(),
+                )?)
+            }
+            "save_paste_image" => to_value(crate::paste::save_paste_image(
+                arg(&args, "bytes")?,
+                arg(&args, "extension")?,
+                app,
+            )?),
+            "read_paste_image_base64" => to_value(crate::paste::read_paste_image_base64(
+                arg(&args, "path")?,
+                app,
+            )?),
+            "subagents_list" => to_value(crate::commands::subagents::subagents_list(
+                arg(&args, "projectRoot")?,
+                app,
+            )?),
+            "remote_status" => {
+                let server = app.state::<Arc<crate::server::ServerState>>();
+                let remote = app.state::<Arc<super::RemoteState>>();
+                to_value(
+                    crate::commands::remote::remote_status(server.clone(), remote.clone())
+                        .await?,
+                )
+            }
+            other => Err(format!(
+                "no dispatch arm for `{other}` — policy table and relay disagree"
+            )),
+        }
+    }
+}
+
+/// Test double: records nothing, denies nothing, answers with a canned
+/// value so WS tests can assert plumbing without a Tauri runtime.
+#[cfg(test)]
+pub struct EchoRelay;
+
+#[cfg(test)]
+#[async_trait]
+impl RelayExec for EchoRelay {
+    async fn invoke(&self, cmd: &str, args: Value) -> Result<Value, String> {
+        Ok(serde_json::json!({ "cmd": cmd, "args": args }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::super::policy::{COMMAND_POLICIES, RemotePolicy};
+    use super::*;
+
+    /// The declarative gate (policy.rs) and the dispatch table (this
+    /// file) must agree exactly on what executes directly.
+    #[test]
+    fn dispatch_arms_match_policy_allowlist() {
+        let allowed: HashSet<&str> = COMMAND_POLICIES
+            .iter()
+            .filter(|(_, p)| matches!(p, RemotePolicy::Direct | RemotePolicy::DirectFiltered))
+            .map(|(name, _)| *name)
+            .collect();
+        let dispatchable: HashSet<&str> = DISPATCHABLE.iter().copied().collect();
+        assert_eq!(
+            allowed, dispatchable,
+            "policy allowlist and relay dispatch arms drifted"
+        );
+    }
+
+    #[test]
+    fn arg_extraction_reports_key_and_reason() {
+        let args = serde_json::json!({ "name": 42 });
+        let err = arg::<String>(&args, "name").expect_err("type mismatch");
+        assert!(err.contains("`name`"), "got: {err}");
+        let missing: Option<String> = arg(&args, "absent").expect("optional args parse as None");
+        assert!(missing.is_none());
+    }
+}

--- a/src-tauri/src/server/remote/ws.rs
+++ b/src-tauri/src/server/remote/ws.rs
@@ -1,0 +1,272 @@
+//! WebSocket session loop for paired remote clients.
+//!
+//! One multiplexed socket per client: first frame must be `hello`
+//! (token-authenticated, 5s deadline), then `invoke` frames dispatch
+//! through the relay (each as its own task; results return by
+//! correlation id, possibly out of order) while `sub`scribed hub topics
+//! stream as `event` frames.
+//!
+//! Ordering & backpressure: the loop owns the sink, so frames to one
+//! client are strictly ordered. `agent-response` is never dropped or
+//! coalesced — a client that can't drain within `EVENT_SEND_TIMEOUT`
+//! (or that lags the hub ring) is closed with `bye slow-consumer` and
+//! rehydrates on reconnect, which is cheaper to reason about than any
+//! replay buffer.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use axum::extract::State;
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::response::Response;
+use futures_util::{SinkExt, StreamExt, stream::SplitSink, stream::SplitStream};
+use tokio::sync::{broadcast, mpsc};
+
+use super::GatewayCtx;
+use super::devices::DeviceView;
+use super::events::is_known_topic;
+use super::protocol::{ClientFrame, PROTOCOL_VERSION, ServerFrame};
+
+pub const HELLO_DEADLINE: Duration = Duration::from_secs(5);
+/// Slow-consumer eviction: how long one event frame may block the sink.
+pub const EVENT_SEND_TIMEOUT: Duration = Duration::from_secs(3);
+const PING_INTERVAL: Duration = Duration::from_secs(20);
+/// Two missed pings.
+const IDLE_DEADLINE: Duration = Duration::from_secs(45);
+/// In-flight invoke results waiting for the sink.
+const RESULT_QUEUE: usize = 64;
+
+pub async fn ws_handler(State(ctx): State<GatewayCtx>, ws: WebSocketUpgrade) -> Response {
+    ws.on_upgrade(move |socket| async move {
+        client_session(ctx, socket).await;
+    })
+}
+
+/// Send one frame, ignoring failures — used on paths where the socket
+/// is already condemned.
+async fn send_bye(sink: &mut SplitSink<WebSocket, Message>, reason: &str) {
+    if let Ok(wire) = ServerFrame::bye(reason).wire() {
+        let _ = sink.send(Message::Text(wire)).await;
+    }
+    let _ = sink.close().await;
+}
+
+async fn client_session(ctx: GatewayCtx, socket: WebSocket) {
+    let (mut sink, mut stream) = socket.split();
+
+    let device = match authenticate(&ctx, &mut stream).await {
+        Ok(device) => device,
+        Err(reason) => {
+            send_bye(&mut sink, reason).await;
+            return;
+        }
+    };
+
+    let hello_ok = ServerFrame::HelloOk {
+        protocol: PROTOCOL_VERSION,
+        host: ctx.info.clone(),
+        device_id: device.id.clone(),
+        app_version: env!("CARGO_PKG_VERSION").to_string(),
+    };
+    match hello_ok.wire() {
+        Ok(wire) => {
+            if sink.send(Message::Text(wire)).await.is_err() {
+                return;
+            }
+        }
+        Err(_) => return,
+    }
+
+    ctx.remote.devices.touch(&device.id);
+    let revoked = ctx.remote.register_live(&device.id);
+    tracing::info!(
+        target: "aethon::server::remote",
+        "device {} ({}) connected", device.id, device.name
+    );
+    run_session(&ctx, &device, &mut sink, &mut stream, &revoked).await;
+    ctx.remote.deregister_live(&device.id, &revoked);
+    tracing::info!(target: "aethon::server::remote", "device {} disconnected", device.id);
+}
+
+async fn authenticate(
+    ctx: &GatewayCtx,
+    stream: &mut SplitStream<WebSocket>,
+) -> Result<DeviceView, &'static str> {
+    let first = tokio::time::timeout(HELLO_DEADLINE, stream.next())
+        .await
+        .map_err(|_| "hello-timeout")?;
+    let Some(Ok(Message::Text(text))) = first else {
+        return Err("hello-expected");
+    };
+    let frame: ClientFrame = serde_json::from_str(&text).map_err(|_| "hello-invalid")?;
+    let ClientFrame::Hello {
+        protocol,
+        token,
+        device_id,
+        app_version,
+    } = frame
+    else {
+        return Err("hello-expected");
+    };
+    if protocol != PROTOCOL_VERSION {
+        return Err("protocol-unsupported");
+    }
+    let device = ctx
+        .remote
+        .devices
+        .verify_token(&token)
+        .ok_or("auth-failed")?;
+    // Claimed id/version are informational — identity came from the token.
+    tracing::debug!(
+        target: "aethon::server::remote",
+        "hello from {} (claimed id {:?}, client v{})",
+        device.id,
+        device_id,
+        app_version.as_deref().unwrap_or("unknown")
+    );
+    Ok(device)
+}
+
+async fn run_session(
+    ctx: &GatewayCtx,
+    device: &DeviceView,
+    sink: &mut SplitSink<WebSocket, Message>,
+    stream: &mut SplitStream<WebSocket>,
+    revoked: &Arc<tokio::sync::Notify>,
+) {
+    let mut subs: HashSet<String> = HashSet::new();
+    let mut hub_rx = ctx.remote.hub.subscribe();
+    let (results_tx, mut results_rx) = mpsc::channel::<String>(RESULT_QUEUE);
+    let mut ping = tokio::time::interval(PING_INTERVAL);
+    ping.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    let mut last_inbound = Instant::now();
+
+    loop {
+        tokio::select! {
+            inbound = stream.next() => {
+                match inbound {
+                    None | Some(Err(_)) => return,
+                    Some(Ok(Message::Close(_))) => return,
+                    Some(Ok(Message::Text(text))) => {
+                        last_inbound = Instant::now();
+                        handle_text_frame(ctx, device, &text, &mut subs, &results_tx);
+                    }
+                    Some(Ok(_)) => {
+                        // Pong / Ping / Binary — liveness only.
+                        last_inbound = Instant::now();
+                    }
+                }
+            }
+            frame = hub_rx.recv() => {
+                match frame {
+                    Ok(frame) if subs.contains(frame.topic) => {
+                        let send = sink.send(Message::Text(frame.wire.clone()));
+                        match tokio::time::timeout(EVENT_SEND_TIMEOUT, send).await {
+                            Ok(Ok(())) => {}
+                            Ok(Err(_)) => return,
+                            Err(_) => {
+                                send_bye(sink, "slow-consumer").await;
+                                return;
+                            }
+                        }
+                    }
+                    Ok(_) => {}
+                    Err(broadcast::error::RecvError::Lagged(missed)) => {
+                        tracing::warn!(
+                            target: "aethon::server::remote",
+                            "device {} lagged {missed} events", device.id
+                        );
+                        send_bye(sink, "slow-consumer").await;
+                        return;
+                    }
+                    Err(broadcast::error::RecvError::Closed) => return,
+                }
+            }
+            result = results_rx.recv() => {
+                // Senders live in this fn's scope, so recv() can't yield
+                // None until the loop itself drops them.
+                if let Some(wire) = result
+                    && sink.send(Message::Text(wire)).await.is_err() {
+                        return;
+                    }
+            }
+            _ = ping.tick() => {
+                if last_inbound.elapsed() > IDLE_DEADLINE {
+                    send_bye(sink, "timeout").await;
+                    return;
+                }
+                if sink.send(Message::Ping(Vec::new())).await.is_err() {
+                    return;
+                }
+            }
+            _ = revoked.notified() => {
+                send_bye(sink, "revoked").await;
+                return;
+            }
+        }
+    }
+}
+
+fn handle_text_frame(
+    ctx: &GatewayCtx,
+    device: &DeviceView,
+    text: &str,
+    subs: &mut HashSet<String>,
+    results_tx: &mpsc::Sender<String>,
+) {
+    let frame: ClientFrame = match serde_json::from_str(text) {
+        Ok(frame) => frame,
+        Err(e) => {
+            tracing::debug!(
+                target: "aethon::server::remote",
+                "device {}: unparsable frame: {e}", device.id
+            );
+            return;
+        }
+    };
+    match frame {
+        ClientFrame::Hello { .. } => {
+            // Already authenticated; a stray hello is a no-op.
+        }
+        ClientFrame::Sub { topics } => {
+            for topic in topics {
+                if is_known_topic(&topic) {
+                    subs.insert(topic);
+                } else {
+                    tracing::debug!(
+                        target: "aethon::server::remote",
+                        "device {}: ignoring unknown topic {topic}", device.id
+                    );
+                }
+            }
+        }
+        ClientFrame::Unsub { topics } => {
+            for topic in topics {
+                subs.remove(&topic);
+            }
+        }
+        ClientFrame::Invoke { id, cmd, args } => {
+            let relay = Arc::clone(&ctx.relay);
+            let results_tx = results_tx.clone();
+            let device_id = device.id.clone();
+            tauri::async_runtime::spawn(async move {
+                let frame = match relay.invoke(&cmd, args).await {
+                    Ok(data) => ServerFrame::result_ok(id, data),
+                    Err(error) => {
+                        tracing::debug!(
+                            target: "aethon::server::remote",
+                            "device {device_id}: {cmd} failed: {error}"
+                        );
+                        ServerFrame::result_err(id, error)
+                    }
+                };
+                if let Ok(wire) = frame.wire() {
+                    // Await capacity: results must not be dropped; the
+                    // session loop drains this queue between events.
+                    let _ = results_tx.send(wire).await;
+                }
+            });
+        }
+    }
+}

--- a/src-tauri/src/server/tls.rs
+++ b/src-tauri/src/server/tls.rs
@@ -55,7 +55,9 @@ pub fn install_crypto_provider() {
     let _ = rustls::crypto::ring::default_provider().install_default();
 }
 
-fn default_remote_dir() -> Option<PathBuf> {
+/// `~/.aethon/remote/` — shared home of the TLS identity and the
+/// paired-device store.
+pub(crate) fn default_remote_dir() -> Option<PathBuf> {
     crate::helpers::aethon_dir(std::env::home_dir()).map(|d| d.join("remote"))
 }
 
@@ -122,7 +124,7 @@ fn pem_certificate_der(pem: &str) -> Option<Vec<u8>> {
     base64::engine::general_purpose::STANDARD.decode(b64).ok()
 }
 
-fn sha256_hex(bytes: &[u8]) -> String {
+pub(crate) fn sha256_hex(bytes: &[u8]) -> String {
     let digest = Sha256::digest(bytes);
     digest.iter().map(|b| format!("{b:02x}")).collect()
 }

--- a/src-tauri/src/server/tls.rs
+++ b/src-tauri/src/server/tls.rs
@@ -56,9 +56,23 @@ pub fn install_crypto_provider() {
 }
 
 /// `~/.aethon/remote/` — shared home of the TLS identity and the
-/// paired-device store.
+/// paired-device store. Resolves the home directory via `HOME` /
+/// `USERPROFILE` (matching `lib.rs::home_dir_for_logging`) so it works
+/// off the Tauri thread and dodges `std::env::home_dir` portability
+/// caveats.
 pub(crate) fn default_remote_dir() -> Option<PathBuf> {
-    crate::helpers::aethon_dir(std::env::home_dir()).map(|d| d.join("remote"))
+    crate::helpers::aethon_dir(home_dir()).map(|d| d.join("remote"))
+}
+
+fn home_dir() -> Option<PathBuf> {
+    #[cfg(windows)]
+    {
+        std::env::var_os("USERPROFILE").map(PathBuf::from)
+    }
+    #[cfg(not(windows))]
+    {
+        std::env::var_os("HOME").map(PathBuf::from)
+    }
 }
 
 /// Load the persisted identity or generate + persist a fresh one.

--- a/src-tauri/src/server/tls.rs
+++ b/src-tauri/src/server/tls.rs
@@ -1,0 +1,189 @@
+//! TLS identity for the remote gateway.
+//!
+//! A self-signed certificate persisted at `~/.aethon/remote/{cert,key}.pem`
+//! (dir 0700, files 0600). Paired clients don't verify a chain — they pin
+//! the certificate by its SHA-256 DER fingerprint, exchanged out-of-band
+//! during pairing (QR / PIN screen). That fingerprint is also what
+//! `host_info` and the mDNS TXT record now carry, replacing the
+//! placeholder the scaffold shipped with.
+//!
+//! The identity is process-wide and created lazily on first use. Creation
+//! failures degrade to `None` — callers fall back to the placeholder
+//! fingerprint and the plain-HTTP scaffold behaviour rather than blocking
+//! boot on a disk error.
+
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+use sha2::{Digest, Sha256};
+
+use crate::helpers::secure_files::{set_dir_owner_only, write_owner_only};
+
+pub struct TlsIdentity {
+    pub cert_pem: String,
+    pub key_pem: String,
+    /// Lowercase hex SHA-256 of the DER certificate — the value clients pin.
+    pub fingerprint: String,
+}
+
+static IDENTITY: OnceLock<Option<TlsIdentity>> = OnceLock::new();
+
+/// The process-wide identity, created on first use.
+pub fn identity() -> Option<&'static TlsIdentity> {
+    IDENTITY
+        .get_or_init(|| {
+            let Some(dir) = default_remote_dir() else {
+                tracing::warn!(target: "aethon::server::tls", "no user dir; TLS identity unavailable");
+                return None;
+            };
+            match load_or_create(&dir) {
+                Ok(identity) => Some(identity),
+                Err(e) => {
+                    tracing::warn!(target: "aethon::server::tls", "TLS identity unavailable: {e}");
+                    None
+                }
+            }
+        })
+        .as_ref()
+}
+
+/// Make the ring `CryptoProvider` the process default. rustls 0.23 needs
+/// one installed before any `ServerConfig` is built; ring (not aws-lc-rs)
+/// keeps us on the provider reqwest already links. Idempotent — a lost
+/// race just means another caller installed the same provider.
+pub fn install_crypto_provider() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+}
+
+fn default_remote_dir() -> Option<PathBuf> {
+    crate::helpers::aethon_dir(std::env::home_dir()).map(|d| d.join("remote"))
+}
+
+/// Load the persisted identity or generate + persist a fresh one.
+/// Exposed with an explicit dir for tests; production goes through
+/// [`identity`].
+pub fn load_or_create(dir: &Path) -> Result<TlsIdentity, String> {
+    std::fs::create_dir_all(dir).map_err(|e| format!("mkdir {}: {e}", dir.display()))?;
+    set_dir_owner_only(dir)?;
+    let cert_path = dir.join("cert.pem");
+    let key_path = dir.join("key.pem");
+
+    if cert_path.exists() && key_path.exists() {
+        let cert_pem = std::fs::read_to_string(&cert_path)
+            .map_err(|e| format!("read {}: {e}", cert_path.display()))?;
+        let key_pem = std::fs::read_to_string(&key_path)
+            .map_err(|e| format!("read {}: {e}", key_path.display()))?;
+        let der = pem_certificate_der(&cert_pem)
+            .ok_or_else(|| format!("{}: no CERTIFICATE block", cert_path.display()))?;
+        return Ok(TlsIdentity {
+            cert_pem,
+            key_pem,
+            fingerprint: sha256_hex(&der),
+        });
+    }
+
+    let hostname = gethostname::gethostname().to_string_lossy().into_owned();
+    let certified = rcgen::generate_simple_self_signed(vec![hostname, "localhost".to_string()])
+        .map_err(|e| format!("generate cert: {e}"))?;
+    let cert_pem = certified.cert.pem();
+    let key_pem = certified.signing_key.serialize_pem();
+    // Key first: if the second write fails we're left with an unreadable
+    // half-identity that the next boot's exists() check regenerates.
+    write_owner_only(&key_path, key_pem.as_bytes())?;
+    write_owner_only(&cert_path, cert_pem.as_bytes())?;
+    Ok(TlsIdentity {
+        fingerprint: sha256_hex(certified.cert.der().as_ref()),
+        cert_pem,
+        key_pem,
+    })
+}
+
+/// Extract the DER bytes of the first CERTIFICATE block in a PEM file.
+fn pem_certificate_der(pem: &str) -> Option<Vec<u8>> {
+    use base64::Engine;
+    let mut b64 = String::new();
+    let mut inside = false;
+    for line in pem.lines() {
+        let line = line.trim();
+        if line == "-----BEGIN CERTIFICATE-----" {
+            inside = true;
+            continue;
+        }
+        if line == "-----END CERTIFICATE-----" {
+            break;
+        }
+        if inside {
+            b64.push_str(line);
+        }
+    }
+    if b64.is_empty() {
+        return None;
+    }
+    base64::engine::general_purpose::STANDARD.decode(b64).ok()
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    digest.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn creates_identity_with_pinned_shape() {
+        let dir = tempfile::tempdir().unwrap();
+        let identity = load_or_create(dir.path()).unwrap();
+        assert_eq!(identity.fingerprint.len(), 64);
+        assert!(identity.fingerprint.chars().all(|c| c.is_ascii_hexdigit()));
+        assert!(identity.cert_pem.contains("BEGIN CERTIFICATE"));
+        assert!(identity.key_pem.contains("PRIVATE KEY"));
+        assert!(dir.path().join("cert.pem").exists());
+        assert!(dir.path().join("key.pem").exists());
+    }
+
+    #[test]
+    fn fingerprint_is_stable_across_reloads() {
+        let dir = tempfile::tempdir().unwrap();
+        let first = load_or_create(dir.path()).unwrap();
+        let second = load_or_create(dir.path()).unwrap();
+        assert_eq!(first.fingerprint, second.fingerprint);
+        assert_eq!(first.cert_pem, second.cert_pem);
+    }
+
+    #[test]
+    fn corrupt_cert_pem_is_an_error_not_a_silent_regen() {
+        let dir = tempfile::tempdir().unwrap();
+        load_or_create(dir.path()).unwrap();
+        std::fs::write(dir.path().join("cert.pem"), "garbage").unwrap();
+        // `.err()` rather than `unwrap_err()`: TlsIdentity deliberately
+        // has no Debug impl so key material can't reach logs.
+        let err = load_or_create(dir.path()).err().expect("must fail");
+        assert!(err.contains("no CERTIFICATE block"), "got: {err}");
+    }
+
+    #[test]
+    fn pem_der_roundtrip_matches_rcgen_der() {
+        let certified =
+            rcgen::generate_simple_self_signed(vec!["test.local".to_string()]).unwrap();
+        let der = pem_certificate_der(&certified.cert.pem()).unwrap();
+        assert_eq!(der, certified.cert.der().as_ref());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn key_material_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        load_or_create(dir.path()).unwrap();
+        for name in ["key.pem", "cert.pem"] {
+            let mode = std::fs::metadata(dir.path().join(name))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777;
+            assert_eq!(mode & 0o077, 0, "{name} mode {mode:o} leaks beyond owner");
+        }
+    }
+}

--- a/src/extensions/default-layout/settings-panel/panel.tsx
+++ b/src/extensions/default-layout/settings-panel/panel.tsx
@@ -26,6 +26,7 @@ import {
   useScrollToSection,
 } from "./hooks";
 import { NotificationsSection } from "./notifications-section";
+import { RemoteDevicesSection } from "./remote-section";
 import { SaveState, Section } from "./sections";
 import { readSettingsState } from "./state";
 import { ShellSection } from "./shell-section";
@@ -92,6 +93,7 @@ export function SettingsPanel({ state, onEvent }: BuiltinComponentProps) {
             <BehaviorSection config={eff} update={update} />
             <VoiceSection config={eff} update={update} />
             <UpdaterSection config={eff} update={update} />
+            <RemoteDevicesSection open={settings.open} />
             <DevshellSection config={eff} state={state} update={update} />
             <Section id="extensions" title="Extensions">
               <ExtensionsList state={state} onEvent={onEvent} />

--- a/src/extensions/default-layout/settings-panel/remote-section.tsx
+++ b/src/extensions/default-layout/settings-panel/remote-section.tsx
@@ -1,0 +1,154 @@
+// Settings → Remote Devices. Pairs companion clients (the iOS app) with
+// this running instance and lists / revokes the paired devices.
+//
+// The section drives the gateway commands directly (remote_status,
+// remote_pairing_begin/cancel, remote_devices_list, remote_device_*)
+// rather than routing through config writes — pairing is a live action,
+// not a persisted setting.
+
+import { useEffect, useState } from "react";
+
+import { Field, Section } from "./sections";
+import { useRemoteDevices } from "./useRemoteDevices";
+
+function shortFingerprint(fp: string): string {
+  return fp.length > 16 ? `${fp.slice(0, 8)}…${fp.slice(-8)}` : fp;
+}
+
+function relativeTime(epochMs: number): string {
+  const delta = Date.now() - epochMs;
+  if (delta < 60_000) return "just now";
+  const minutes = Math.floor(delta / 60_000);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+function PairingCode({
+  expiresAt,
+  code,
+  qrPayload,
+}: {
+  expiresAt: number;
+  code: string;
+  qrPayload: string;
+}) {
+  const [secondsLeft, setSecondsLeft] = useState(() =>
+    Math.max(0, Math.ceil((expiresAt - Date.now()) / 1000)),
+  );
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setSecondsLeft(Math.max(0, Math.ceil((expiresAt - Date.now()) / 1000)));
+    }, 1000);
+    return () => clearInterval(timer);
+  }, [expiresAt]);
+
+  return (
+    <div className="ae-remote-pairing" data-testid="remote-pairing-code">
+      <div className="ae-remote-pairing-code">{code}</div>
+      <p className="ae-remote-pairing-hint">
+        Enter this code on the device to pair. Expires in {secondsLeft}s.
+      </p>
+      <details className="ae-remote-pairing-payload">
+        <summary>Pairing payload (QR)</summary>
+        <code>{qrPayload}</code>
+      </details>
+    </div>
+  );
+}
+
+export function RemoteDevicesSection({ open }: { open: boolean }) {
+  const remote = useRemoteDevices(open);
+  const { status, devices, pairing, error, busy } = remote;
+
+  const canPair = status?.running && status.tlsActive;
+
+  return (
+    <Section id="remote" title="Remote Devices">
+      {error ? <p className="ae-settings-error">{error}</p> : null}
+
+      <Field label="Gateway">
+        <span className="ae-remote-status">
+          {status == null
+            ? "…"
+            : !status.running
+              ? "Server stopped"
+              : status.tlsActive
+                ? `Secure on port ${status.port ?? "?"}`
+                : `Insecure (dev) on port ${status.port ?? "?"}`}
+        </span>
+      </Field>
+
+      {status?.fingerprint ? (
+        <Field label="Certificate fingerprint">
+          <code className="ae-remote-fingerprint" title={status.fingerprint}>
+            {shortFingerprint(status.fingerprint)}
+          </code>
+        </Field>
+      ) : null}
+
+      {!canPair ? (
+        <p className="ae-remote-hint">
+          {status && !status.running
+            ? "Start the server (Settings → Server) to pair a device."
+            : "This host has no TLS identity, so pairing is unavailable."}
+        </p>
+      ) : pairing ? (
+        <>
+          <PairingCode
+            code={pairing.code}
+            expiresAt={pairing.expiresAt}
+            qrPayload={pairing.qrPayload}
+          />
+          <button
+            type="button"
+            className="ae-settings-secondary"
+            onClick={() => void remote.cancelPairing()}
+          >
+            Cancel pairing
+          </button>
+        </>
+      ) : (
+        <button
+          type="button"
+          className="ae-settings-secondary"
+          disabled={busy}
+          onClick={() => void remote.beginPairing()}
+        >
+          Pair a device
+        </button>
+      )}
+
+      <div className="ae-remote-devices">
+        {devices.length === 0 ? (
+          <p className="ae-remote-hint">No paired devices.</p>
+        ) : (
+          <ul className="ae-remote-device-list">
+            {devices.map((device) => (
+              <li
+                key={device.id}
+                className={`ae-remote-device${device.revoked ? " ae-remote-device--revoked" : ""}`}
+              >
+                <span className="ae-remote-device-name">{device.name}</span>
+                <span className="ae-remote-device-meta">
+                  {device.platform} · seen {relativeTime(device.lastSeenAt)}
+                  {device.revoked ? " · revoked" : ""}
+                </span>
+                {!device.revoked ? (
+                  <button
+                    type="button"
+                    className="ae-settings-secondary ae-remote-revoke"
+                    onClick={() => void remote.revoke(device.id)}
+                  >
+                    Revoke
+                  </button>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </Section>
+  );
+}

--- a/src/extensions/default-layout/settings-panel/useRemoteDevices.ts
+++ b/src/extensions/default-layout/settings-panel/useRemoteDevices.ts
@@ -1,0 +1,137 @@
+import { useCallback, useEffect, useState } from "react";
+
+import {
+  remoteDeviceRename,
+  remoteDeviceRevoke,
+  remoteDevicesList,
+  remotePairingBegin,
+  remotePairingCancel,
+  remoteStatus,
+  type PairingBegin,
+  type RemoteDevice,
+  type RemoteStatus,
+} from "../../../services/remote";
+
+export interface RemoteDevicesState {
+  status: RemoteStatus | null;
+  devices: RemoteDevice[];
+  pairing: PairingBegin | null;
+  error: string | null;
+  busy: boolean;
+  refresh: () => Promise<void>;
+  beginPairing: () => Promise<void>;
+  cancelPairing: () => Promise<void>;
+  revoke: (id: string) => Promise<void>;
+  rename: (id: string, name: string) => Promise<void>;
+}
+
+/** Loads gateway status + the paired-device list while the settings
+ *  panel is open, and drives the pairing lifecycle. Pairing auto-clears
+ *  when its window expires so the UI never shows a dead code. */
+export function useRemoteDevices(open: boolean): RemoteDevicesState {
+  const [status, setStatus] = useState<RemoteStatus | null>(null);
+  const [devices, setDevices] = useState<RemoteDevice[]>([]);
+  const [pairing, setPairing] = useState<PairingBegin | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const refresh = useCallback(async () => {
+    try {
+      const [nextStatus, nextDevices] = await Promise.all([
+        remoteStatus(),
+        remoteDevicesList(),
+      ]);
+      setStatus(nextStatus ?? null);
+      setDevices(Array.isArray(nextDevices) ? nextDevices : []);
+      setError(null);
+    } catch (err) {
+      setError(String(err));
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    // Async data fetch on open + light poll so lastSeen / connection
+    // count stay live; neither mutates state synchronously in the effect.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void refresh();
+    const timer = window.setInterval(() => {
+      if (!cancelled) void refresh();
+    }, 5000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
+  }, [open, refresh]);
+
+  // Auto-expire the displayed pairing code. The clear always goes
+  // through the timer (delay clamped to 0) so state never mutates
+  // synchronously inside the effect.
+  useEffect(() => {
+    if (!pairing) return;
+    const remaining = Math.max(0, pairing.expiresAt - Date.now());
+    const timer = setTimeout(() => setPairing(null), remaining);
+    return () => clearTimeout(timer);
+  }, [pairing]);
+
+  const beginPairing = useCallback(async () => {
+    setBusy(true);
+    try {
+      setPairing(await remotePairingBegin());
+      setError(null);
+      await refresh();
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setBusy(false);
+    }
+  }, [refresh]);
+
+  const cancelPairing = useCallback(async () => {
+    setPairing(null);
+    try {
+      await remotePairingCancel();
+      await refresh();
+    } catch (err) {
+      setError(String(err));
+    }
+  }, [refresh]);
+
+  const revoke = useCallback(
+    async (id: string) => {
+      try {
+        await remoteDeviceRevoke(id);
+        await refresh();
+      } catch (err) {
+        setError(String(err));
+      }
+    },
+    [refresh],
+  );
+
+  const rename = useCallback(
+    async (id: string, name: string) => {
+      try {
+        await remoteDeviceRename(id, name);
+        await refresh();
+      } catch (err) {
+        setError(String(err));
+      }
+    },
+    [refresh],
+  );
+
+  return {
+    status,
+    devices,
+    pairing,
+    error,
+    busy,
+    refresh,
+    beginPairing,
+    cancelPairing,
+    revoke,
+    rename,
+  };
+}

--- a/src/services/remote.test.ts
+++ b/src/services/remote.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { installTauriMocks, clearTauriMocks } from "../test/tauriMocks";
+import {
+  remoteDeviceRename,
+  remoteDeviceRevoke,
+  remoteDevicesList,
+  remotePairingBegin,
+  remotePairingCancel,
+  remoteStatus,
+} from "./remote";
+
+describe("remote gateway service", () => {
+  let harness: ReturnType<typeof installTauriMocks>;
+
+  beforeEach(() => {
+    harness = installTauriMocks();
+  });
+
+  afterEach(() => {
+    clearTauriMocks();
+  });
+
+  it("reads gateway status without extra payload", async () => {
+    harness.invoke.mockResolvedValueOnce({
+      running: true,
+      port: 4242,
+      tlsActive: true,
+      fingerprint: "ab".repeat(32),
+      pairingActive: false,
+      devices: 1,
+    });
+
+    await expect(remoteStatus()).resolves.toMatchObject({ port: 4242 });
+    expect(harness.invoke).toHaveBeenCalledWith("remote_status");
+  });
+
+  it("begins and cancels pairing", async () => {
+    harness.invoke.mockResolvedValueOnce({
+      code: "12345678",
+      expiresAt: 0,
+      qrPayload: "{}",
+    });
+    await remotePairingBegin();
+    await remotePairingCancel();
+
+    expect(harness.invoke).toHaveBeenNthCalledWith(1, "remote_pairing_begin");
+    expect(harness.invoke).toHaveBeenNthCalledWith(2, "remote_pairing_cancel");
+  });
+
+  it("lists, revokes, and renames devices with id payloads", async () => {
+    harness.invoke.mockResolvedValueOnce([]);
+    await remoteDevicesList();
+    await remoteDeviceRevoke("dev-1");
+    await remoteDeviceRename("dev-1", "James's iPhone");
+
+    expect(harness.invoke).toHaveBeenNthCalledWith(1, "remote_devices_list");
+    expect(harness.invoke).toHaveBeenNthCalledWith(2, "remote_device_revoke", {
+      id: "dev-1",
+    });
+    expect(harness.invoke).toHaveBeenNthCalledWith(3, "remote_device_rename", {
+      id: "dev-1",
+      name: "James's iPhone",
+    });
+  });
+});

--- a/src/services/remote.ts
+++ b/src/services/remote.ts
@@ -1,0 +1,53 @@
+import { invoke } from "@tauri-apps/api/core";
+
+/** Live gateway status for the Settings → Remote Devices section. */
+export interface RemoteStatus {
+  running: boolean;
+  port: number | null;
+  tlsActive: boolean;
+  fingerprint: string | null;
+  pairingActive: boolean;
+  devices: number;
+}
+
+/** A paired device, minus its token hash. */
+export interface RemoteDevice {
+  id: string;
+  name: string;
+  platform: string;
+  createdAt: number;
+  lastSeenAt: number;
+  revoked: boolean;
+}
+
+/** What `remote_pairing_begin` returns: a one-time code + the QR the
+ *  phone scans, valid until `expiresAt` (epoch ms). */
+export interface PairingBegin {
+  code: string;
+  expiresAt: number;
+  qrPayload: string;
+}
+
+export function remoteStatus(): Promise<RemoteStatus> {
+  return invoke("remote_status");
+}
+
+export function remotePairingBegin(): Promise<PairingBegin> {
+  return invoke("remote_pairing_begin");
+}
+
+export function remotePairingCancel(): Promise<void> {
+  return invoke("remote_pairing_cancel");
+}
+
+export function remoteDevicesList(): Promise<RemoteDevice[]> {
+  return invoke("remote_devices_list");
+}
+
+export function remoteDeviceRevoke(id: string): Promise<void> {
+  return invoke("remote_device_revoke", { id });
+}
+
+export function remoteDeviceRename(id: string, name: string): Promise<void> {
+  return invoke("remote_device_rename", { id, name });
+}

--- a/src/styles/chrome/overlays.css
+++ b/src/styles/chrome/overlays.css
@@ -248,6 +248,101 @@
 .ae-settings-secondary:hover {
   background: color-mix(in oklab, var(--accent) 8%, transparent);
 }
+.ae-settings-secondary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* =============================================================================
+   Remote Devices (companion pairing)
+   ============================================================================= */
+.ae-settings-error {
+  color: var(--danger, #e5484d);
+  font-size: 0.88rem;
+  margin: 0 0 8px 0;
+}
+.ae-remote-status,
+.ae-remote-fingerprint {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.88rem;
+  color: var(--text-dim);
+}
+.ae-remote-hint {
+  color: var(--text-dim);
+  font-size: 0.88rem;
+  margin: 8px 0;
+}
+.ae-remote-pairing {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 14px;
+  margin: 10px 0;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: color-mix(in oklab, var(--accent) 5%, transparent);
+}
+.ae-remote-pairing-code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 2rem;
+  letter-spacing: 0.35em;
+  text-align: center;
+  color: var(--text);
+}
+.ae-remote-pairing-hint {
+  margin: 0;
+  text-align: center;
+  color: var(--text-dim);
+  font-size: 0.85rem;
+}
+.ae-remote-pairing-payload code {
+  display: block;
+  margin-top: 6px;
+  padding: 8px;
+  word-break: break-all;
+  font-size: 0.75rem;
+  color: var(--text-dim);
+  background: var(--bg-input);
+  border-radius: 6px;
+}
+.ae-remote-devices {
+  margin-top: 12px;
+}
+.ae-remote-device-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.ae-remote-device {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  grid-template-areas: "name action" "meta action";
+  align-items: center;
+  gap: 2px 12px;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+.ae-remote-device--revoked {
+  opacity: 0.55;
+}
+.ae-remote-device-name {
+  grid-area: name;
+  font-size: 0.92rem;
+  color: var(--text);
+}
+.ae-remote-device-meta {
+  grid-area: meta;
+  font-size: 0.8rem;
+  color: var(--text-dim);
+}
+.ae-remote-revoke {
+  grid-area: action;
+  color: var(--danger, #e5484d);
+}
 
 /* =============================================================================
    Scheduled Tasks manager


### PR DESCRIPTION
## What & why

First phase of the **iOS companion app** effort (`/Users/jamesbrink/.claude/plans/study-and-understand-our-snuggly-brook.md`). The desktop grows an authenticated remote gateway so a paired mobile client can drive a running Aethon instance over the LAN (Tailscale-friendly; no internet relay). This PR is the **desktop side only** — the mobile app (Tauri iOS shell reusing the React A2UI frontend) lands in later phases.

It builds directly on the existing `server/` scaffold, whose in-code comments already anticipated this ("No auth, no TLS — the pairing PR adds both"; placeholder fingerprint "replaced when pairing lands").

## What's in it

- **TLS identity** (`server/tls.rs`): self-signed rcgen cert at `~/.aethon/remote/` (0700/0600). `host_info` + the mDNS TXT record now carry its **SHA-256 DER fingerprint** — the value paired clients pin — replacing the placeholder. Degrades to the plain scaffold when the identity can't be created. Everything stays ring-flavored (no second CryptoProvider / cmake dep).
- **Pairing + device store** (`server/remote/{pairing,devices}.rs`, `commands/remote.rs`): `POST /pair` redeems an 8-digit code (single-use, 2-min window, 5-attempt lockout, constant-time hash compare, 404 when idle). QR payload embeds dialable interface addresses (incl. Tailscale), port, and the pinned fingerprint. Only `sha256(token)` is persisted.
- **WebSocket gateway** (`server/remote/{protocol,ws,events,relay,policy}.rs`): protocol v1, first-frame token auth, invoke correlation, topic subscription. `EventHub` taps Tauri events via `listen_any` (spike-proven) and fans them out; `agent-response` is never dropped (slow consumers are evicted and rehydrate). **Every registered command has an explicit `RemotePolicy`** — a test parses `generate_handler!` and fails on drift. `agent_command` is filtered so `mutation_ack`/`frontend_state_patch` stay exclusive to the desktop webview (sole state authority); `ui.*` methods reuse the `control.rs` forward machinery; `control_update_state` snapshots republish as the `frontend-state` convergence topic.
- **Settings → Remote Devices** + **`cli/aethonRemote.ts`** smoke client (pairs, authenticates, streams a full turn).

## Second-frontend model

The desktop webview stays the sole state authority, `*_query` answerer, `mutation_ack` sender, and persisted-state writer. The mobile client is a read-write peer for *intent* and a read-only mirror for shared state — enforced at the shim, the gateway (backstop), and via the convergence topic.

## Tests

- Unit: TLS fingerprint stability, pairing expiry/lockout/single-use, token hashing + constant-time compare, frame serde, policy exhaustiveness vs `lib.rs`, relay↔policy parity, hub seq/tap.
- Integration (`integration_tests.rs`): real router over loopback driven by a real WebSocket client through pair → hello → invoke → subscribe → event, plus bad-token rejection, topic filtering, revocation-closes-live.
- Full `check` gate green (clippy, tsc -b, eslint 0-warn, 579 Rust lib tests, 2960 vitest).

## Security notes

- `/pair` is the only unauthenticated mutating route — gated to the active window, rate-limited, boring by design.
- `[server] allow_insecure_ws` (default false, dev-only) drops TLS for the browser dev loop; production phones require the pinned cert.

Part of a phased effort; subsequent phases add the mobile scaffold/shim, chat UI, terminal/files/git, and the parity tail.