### PR TITLE
feat(mobile): touch-first chat + sessions layout (Phase 3)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { ExtensionRegistry } from "./extensions/ExtensionRegistry";
 import { persistStatusesDebounced } from "./gitStatusCache";
 import { defaultLayoutExtension } from "./extensions/default-layout";
+import { mobileLayoutExtension } from "./mobile/mobileLayoutExtension";
 import { AppRoot } from "./app/AppRoot";
 import { BOOT_LAYOUT, hangWarnNotifId } from "./app/bootConstants";
 import { useAppForwardRefs } from "./app/useAppForwardRefs";
@@ -74,6 +75,11 @@ export default function App() {
   const [registry] = useState<ExtensionRegistry>(() => {
     const r = new ExtensionRegistry();
     r.register(defaultLayoutExtension);
+    // Mobile companion composites (nav, sessions screen, connection
+    // badge). Build-time define → tree-shaken from the desktop bundle.
+    if (import.meta.env.VITE_AETHON_SURFACE === "mobile") {
+      r.register(mobileLayoutExtension);
+    }
     return r;
   });
 

--- a/src/app/bootConstants.ts
+++ b/src/app/bootConstants.ts
@@ -1,11 +1,17 @@
 import type { A2UIPayload } from "../types/a2ui";
 import { defaultLayoutExtension } from "../extensions/default-layout";
+import mobilePayload from "../mobile/mobile.a2ui.json";
 
-/** The default-layout extension ships the boot layout payload. Components
- *  that need a "reset" target (slash commands, settings reset, the
- *  composer's empty-state click) read from here so they share a single
- *  source of truth with App's initial `layout` state. */
-export const BOOT_LAYOUT: A2UIPayload = defaultLayoutExtension.layout!;
+/** The boot layout payload. Components that need a "reset" target (slash
+ *  commands, settings reset, the composer's empty-state click) read from
+ *  here so they share a single source of truth with App's initial
+ *  `layout` state. The mobile surface boots the touch-first single-column
+ *  layout; the desktop boots the workstation. `VITE_AETHON_SURFACE` is a
+ *  build-time define, so the unused branch is tree-shaken per bundle. */
+export const BOOT_LAYOUT: A2UIPayload =
+  import.meta.env.VITE_AETHON_SURFACE === "mobile"
+    ? mobilePayload
+    : defaultLayoutExtension.layout!;
 
 /** Per-tab notification id used by the hang-warn flow. Centralized so
  *  the producer (`useOsEdges`) and the consumer (the dismiss path in

--- a/src/eventRoutes/index.ts
+++ b/src/eventRoutes/index.ts
@@ -34,6 +34,7 @@ import { handleSessionBranch } from "./session";
 import { handleComposerPills } from "./composerPills";
 import { handleQueuedMessages } from "./queue";
 import { handleSettings } from "./settings";
+import { handleMobileNav } from "./mobileNav";
 import { handleAuthProfiles } from "./authProfiles";
 import { handleSearch } from "./search";
 import { handleScheduledTasks } from "./scheduledTasks";
@@ -145,6 +146,10 @@ export const BUILTIN_ROUTE_TABLE: ReadonlyMap<string, readonly EventRouteHandler
     ["type:appearance-menu", [handleSectionedSelect]],
     ["type:terminal-panel", [handleTerminalPanel]],
     ["type:tab-strip", [handleTabStrip]],
+    // Companion (mobile) navigation + sessions screen. Inert on desktop
+    // (these component types never appear in the workstation layout).
+    ["type:mobile-nav", [handleMobileNav]],
+    ["type:mobile-sessions", [handleMobileNav]],
     ["type:shell-canvas", [handleShareModeCycle]],
     ["type:share-mode-badge", [handleShareModeCycle]],
     ["type:editor-canvas", [handleEditorCanvas]],

--- a/src/eventRoutes/mobileNav.test.ts
+++ b/src/eventRoutes/mobileNav.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import { handleMobileNav } from "./mobileNav";
+import { buildRouteFixture } from "./testFixtures";
+
+describe("handleMobileNav", () => {
+  it("switches screens by setting exactly one visibility flag", () => {
+    const { ctx, applySetState } = buildRouteFixture();
+    const handled = handleMobileNav(
+      { component: { id: "nav", type: "mobile-nav" }, eventType: "mobile-nav", data: { screen: "sessions" } },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    const state = applySetState({});
+    expect(state.mobileNav).toEqual({
+      active: "sessions",
+      isSessions: true,
+      isChat: false,
+      isSettings: false,
+    });
+  });
+
+  it("opens the settings overlay for the settings screen and closes it otherwise", () => {
+    const opened = buildRouteFixture();
+    handleMobileNav(
+      { component: { id: "nav", type: "mobile-nav" }, eventType: "mobile-nav", data: { screen: "settings" } },
+      opened.ctx,
+    );
+    expect((opened.applySetState({}).settings as { open?: boolean }).open).toBe(true);
+
+    const closed = buildRouteFixture();
+    handleMobileNav(
+      { component: { id: "nav", type: "mobile-nav" }, eventType: "mobile-nav", data: { screen: "chat" } },
+      closed.ctx,
+    );
+    expect((closed.applySetState({}).settings as { open?: boolean }).open).toBe(false);
+  });
+
+  it("select-tab activates the tab and jumps to chat", () => {
+    const { ctx, mocks, applySetState } = buildRouteFixture();
+    const handled = handleMobileNav(
+      { component: { id: "sessions", type: "mobile-sessions" }, eventType: "select-tab", data: { tabId: "t7" } },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.activateTabAnywhere).toHaveBeenCalledWith("t7");
+    expect((applySetState({}).mobileNav as { isChat?: boolean }).isChat).toBe(true);
+  });
+
+  it("new-session opens a tab and jumps to chat", () => {
+    const { ctx, mocks, applySetState } = buildRouteFixture();
+    handleMobileNav(
+      { component: { id: "sessions", type: "mobile-sessions" }, eventType: "new-session" },
+      ctx,
+    );
+    expect(mocks.newTab).toHaveBeenCalledTimes(1);
+    expect((applySetState({}).mobileNav as { active?: string }).active).toBe("chat");
+  });
+
+  it("ignores unrelated component types", () => {
+    const { ctx } = buildRouteFixture();
+    const handled = handleMobileNav(
+      { component: { id: "tabs", type: "tab-strip" }, eventType: "select", data: { tabId: "x" } },
+      ctx,
+    );
+    expect(handled).toBe(false);
+  });
+});

--- a/src/eventRoutes/mobileNav.test.ts
+++ b/src/eventRoutes/mobileNav.test.ts
@@ -57,6 +57,41 @@ describe("handleMobileNav", () => {
     expect((applySetState({}).mobileNav as { active?: string }).active).toBe("chat");
   });
 
+  it("restore-session reopens the session by id and jumps to chat", () => {
+    const { ctx, mocks, applySetState } = buildRouteFixture();
+    const handled = handleMobileNav(
+      {
+        component: { id: "sessions", type: "mobile-sessions" },
+        eventType: "restore-session",
+        data: { sessionId: "s42", cwd: "/repo", label: "My session" },
+      },
+      ctx,
+    );
+    expect(handled).toBe(true);
+    expect(mocks.newTab).toHaveBeenCalledWith(
+      "s42",
+      "My session",
+      expect.objectContaining({ restoredSession: true }),
+    );
+    expect((applySetState({}).mobileNav as { isChat?: boolean }).isChat).toBe(true);
+  });
+
+  it("rejects unknown screen values instead of blanking every flag", () => {
+    const { ctx, applySetState } = buildRouteFixture({
+      state: { mobileNav: { active: "chat", isChat: true } },
+    });
+    handleMobileNav(
+      {
+        component: { id: "nav", type: "mobile-nav" },
+        eventType: "mobile-nav",
+        data: { screen: "not-a-screen" },
+      },
+      ctx,
+    );
+    const state = applySetState({ mobileNav: { active: "chat", isChat: true } });
+    expect((state.mobileNav as { active?: string }).active).toBe("chat");
+  });
+
   it("ignores unrelated component types", () => {
     const { ctx } = buildRouteFixture();
     const handled = handleMobileNav(

--- a/src/eventRoutes/mobileNav.ts
+++ b/src/eventRoutes/mobileNav.ts
@@ -1,0 +1,75 @@
+// Companion (mobile) navigation. The bottom nav + the sessions screen
+// route here. Screen switching is expressed as per-screen boolean flags
+// under `/mobileNav` because the layout's `visible` binding only tests
+// truthiness (no equality) — exactly one flag is true at a time.
+//
+// Registered by `type:` so an extension replacing `mobile-nav` /
+// `mobile-sessions` keeps working. Inert on desktop: those component
+// types never appear in the workstation layout.
+
+import type { EventRouteHandler } from "./types";
+import { restoreSessionFromSelection } from "./sessionRestore";
+
+type Screen = "sessions" | "chat" | "settings";
+
+function screenFlags(active: Screen): Record<string, unknown> {
+  return {
+    active,
+    isSessions: active === "sessions",
+    isChat: active === "chat",
+    isSettings: active === "settings",
+  };
+}
+
+function setScreen(
+  ctx: Parameters<EventRouteHandler>[1],
+  active: Screen,
+): void {
+  ctx.setState((prev) => {
+    const next: Record<string, unknown> = {
+      ...prev,
+      mobileNav: screenFlags(active),
+    };
+    // The Settings overlay is state-driven; the nav "settings" tab opens
+    // it and any other tab closes it, so it behaves like a screen.
+    const settings = (prev.settings as Record<string, unknown>) ?? {};
+    next.settings = { ...settings, open: active === "settings" };
+    return next;
+  });
+}
+
+export const handleMobileNav: EventRouteHandler = ({ component, eventType, data }, ctx) => {
+  if (component.type === "mobile-nav") {
+    if (eventType === "mobile-nav") {
+      const screen = (data as { screen?: Screen } | undefined)?.screen;
+      if (screen) setScreen(ctx, screen);
+    }
+    return true;
+  }
+
+  if (component.type === "mobile-sessions") {
+    switch (eventType) {
+      case "new-session":
+        ctx.newTab();
+        setScreen(ctx, "chat");
+        return true;
+      case "select-tab": {
+        const tabId = (data as { tabId?: string } | undefined)?.tabId;
+        if (tabId) ctx.activateTabAnywhere(tabId);
+        setScreen(ctx, "chat");
+        return true;
+      }
+      case "restore-session": {
+        restoreSessionFromSelection(
+          ctx,
+          data as { sessionId?: string; cwd?: string; label?: string } | undefined,
+        );
+        setScreen(ctx, "chat");
+        return true;
+      }
+    }
+    return true;
+  }
+
+  return false;
+};

--- a/src/eventRoutes/mobileNav.ts
+++ b/src/eventRoutes/mobileNav.ts
@@ -38,10 +38,18 @@ function setScreen(
   });
 }
 
+const SCREENS: readonly Screen[] = ["sessions", "chat", "settings"];
+
+function asScreen(value: unknown): Screen | undefined {
+  return SCREENS.find((s) => s === value);
+}
+
 export const handleMobileNav: EventRouteHandler = ({ component, eventType, data }, ctx) => {
   if (component.type === "mobile-nav") {
     if (eventType === "mobile-nav") {
-      const screen = (data as { screen?: Screen } | undefined)?.screen;
+      // Validate, don't cast: events can arrive over the gateway, and an
+      // unknown screen would zero every visibility flag (blank canvas).
+      const screen = asScreen((data as { screen?: unknown } | undefined)?.screen);
       if (screen) setScreen(ctx, screen);
     }
     return true;

--- a/src/mobile/composites/connection-badge.tsx
+++ b/src/mobile/composites/connection-badge.tsx
@@ -1,0 +1,27 @@
+// Header chip reflecting the gateway connection state. Reads the
+// transport status store directly (not app state) so it updates the
+// instant the socket changes, independent of any bridge round-trip.
+
+import { useGatewayStatus } from "../../gateway/useGatewayStatus";
+
+const LABELS: Record<string, string> = {
+  idle: "Idle",
+  connecting: "Connecting",
+  connected: "Online",
+  reconnecting: "Reconnecting",
+  disconnected: "Offline",
+};
+
+export function ConnectionBadge() {
+  const status = useGatewayStatus();
+  return (
+    <span
+      className={`ae-mobile-conn ae-mobile-conn--${status}`}
+      role="status"
+      aria-label={`Gateway ${LABELS[status] ?? status}`}
+    >
+      <span className="ae-mobile-conn-dot" aria-hidden />
+      {LABELS[status] ?? status}
+    </span>
+  );
+}

--- a/src/mobile/composites/mobile-nav.tsx
+++ b/src/mobile/composites/mobile-nav.tsx
@@ -1,0 +1,40 @@
+// Bottom tab bar for the companion. Emits `mobile-nav {screen}` on tap;
+// the mobileNav event route flips the per-screen visibility flags the
+// layout gates on. Highlight follows `/mobileNav/active`.
+
+import type { BuiltinComponentProps } from "../../components/A2UIRenderer";
+
+interface NavItem {
+  screen: string;
+  label: string;
+  glyph: string;
+}
+
+const ITEMS: NavItem[] = [
+  { screen: "sessions", label: "Sessions", glyph: "☰" },
+  { screen: "chat", label: "Chat", glyph: "◆" },
+  { screen: "settings", label: "Settings", glyph: "⚙" },
+];
+
+export function MobileNav({ state, onEvent }: BuiltinComponentProps) {
+  const active =
+    ((state.mobileNav as { active?: string } | undefined)?.active) ?? "chat";
+  return (
+    <nav className="ae-mobile-nav" aria-label="Sections">
+      {ITEMS.map((item) => (
+        <button
+          key={item.screen}
+          type="button"
+          className={`ae-mobile-nav-item${active === item.screen ? " ae-mobile-nav-item--active" : ""}`}
+          aria-current={active === item.screen ? "page" : undefined}
+          onClick={() => onEvent("mobile-nav", { screen: item.screen })}
+        >
+          <span className="ae-mobile-nav-glyph" aria-hidden>
+            {item.glyph}
+          </span>
+          <span className="ae-mobile-nav-label">{item.label}</span>
+        </button>
+      ))}
+    </nav>
+  );
+}

--- a/src/mobile/composites/mobile-sessions.tsx
+++ b/src/mobile/composites/mobile-sessions.tsx
@@ -1,0 +1,103 @@
+// Sessions screen — the mobile stand-in for the desktop sidebar. Lists
+// the open agent tabs and recent sessions from the same state slices the
+// sidebar reads (`/tabs`, `/recentSessions`), and taps route through the
+// mobileNav handler to activate / restore and switch to the chat screen.
+
+import type { BuiltinComponentProps } from "../../components/A2UIRenderer";
+
+interface TabLike {
+  id: string;
+  kind?: string;
+  label?: string;
+  cwd?: string;
+}
+interface RecentLike {
+  id: string;
+  label: string;
+  cwd?: string;
+  lastModified?: string;
+}
+
+function baseName(cwd?: string): string | undefined {
+  if (!cwd) return undefined;
+  const parts = cwd.replace(/\/+$/, "").split("/");
+  return parts[parts.length - 1] || cwd;
+}
+
+export function MobileSessions({ state, onEvent }: BuiltinComponentProps) {
+  const tabs = (Array.isArray(state.tabs) ? state.tabs : []) as TabLike[];
+  const agentTabs = tabs.filter((t) => (t.kind ?? "agent") === "agent");
+  const recent = (
+    Array.isArray(state.recentSessions) ? state.recentSessions : []
+  ) as RecentLike[];
+  const openIds = new Set(agentTabs.map((t) => t.id));
+  const recentUnopened = recent.filter((r) => !openIds.has(r.id));
+
+  return (
+    <div className="ae-mobile-sessions">
+      <button
+        type="button"
+        className="ae-mobile-new-session"
+        onClick={() => onEvent("new-session")}
+      >
+        + New session
+      </button>
+
+      {agentTabs.length > 0 ? (
+        <section className="ae-mobile-session-group">
+          <h2 className="ae-mobile-session-heading">Open</h2>
+          {agentTabs.map((tab) => (
+            <button
+              key={tab.id}
+              type="button"
+              className="ae-mobile-session-row"
+              onClick={() => onEvent("select-tab", { tabId: tab.id })}
+            >
+              <span className="ae-mobile-session-name">
+                {tab.label || "Session"}
+              </span>
+              {baseName(tab.cwd) ? (
+                <span className="ae-mobile-session-cwd">{baseName(tab.cwd)}</span>
+              ) : null}
+            </button>
+          ))}
+        </section>
+      ) : null}
+
+      {recentUnopened.length > 0 ? (
+        <section className="ae-mobile-session-group">
+          <h2 className="ae-mobile-session-heading">Recent</h2>
+          {recentUnopened.map((session) => (
+            <button
+              key={session.id}
+              type="button"
+              className="ae-mobile-session-row"
+              onClick={() =>
+                onEvent("restore-session", {
+                  sessionId: session.id,
+                  cwd: session.cwd,
+                  label: session.label,
+                })
+              }
+            >
+              <span className="ae-mobile-session-name">
+                {session.label || "Session"}
+              </span>
+              {baseName(session.cwd) ? (
+                <span className="ae-mobile-session-cwd">
+                  {baseName(session.cwd)}
+                </span>
+              ) : null}
+            </button>
+          ))}
+        </section>
+      ) : null}
+
+      {agentTabs.length === 0 && recentUnopened.length === 0 ? (
+        <p className="ae-mobile-session-empty">
+          No sessions yet. Start one to begin.
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/mobile/composites/mobile-sessions.tsx
+++ b/src/mobile/composites/mobile-sessions.tsx
@@ -20,7 +20,8 @@ interface RecentLike {
 
 function baseName(cwd?: string): string | undefined {
   if (!cwd) return undefined;
-  const parts = cwd.replace(/\/+$/, "").split("/");
+  // Both separators: the paired desktop may be a Windows host.
+  const parts = cwd.replace(/[/\\]+$/, "").split(/[/\\]/);
   return parts[parts.length - 1] || cwd;
 }
 

--- a/src/mobile/mobile.a2ui.json
+++ b/src/mobile/mobile.a2ui.json
@@ -1,0 +1,92 @@
+{
+  "components": [
+    {
+      "id": "root-layout",
+      "type": "layout",
+      "props": {
+        "columns": { "$ref": "/layout/columns" },
+        "rows": { "$ref": "/layout/rows" },
+        "areas": { "$ref": "/layout/areas" },
+        "slotMap": { "sessions": "canvas" }
+      },
+      "children": [
+        {
+          "id": "mobile-header",
+          "type": "container",
+          "props": {
+            "area": "header",
+            "direction": "row",
+            "align": "center",
+            "gap": 8,
+            "className": "ae-mobile-header"
+          },
+          "children": [
+            {
+              "id": "mobile-pill",
+              "type": "agent-pulse",
+              "props": {
+                "label": { "$ref": "/agentStatus/label" },
+                "state": { "$ref": "/agentStatus/state" }
+              }
+            },
+            {
+              "id": "mobile-header-spacer",
+              "type": "container",
+              "props": { "direction": "row", "className": "ae-header-spacer" }
+            },
+            { "id": "mobile-model", "type": "model-picker", "props": {} },
+            { "id": "mobile-conn", "type": "connection-badge", "props": {} }
+          ]
+        },
+        {
+          "id": "mobile-chat-canvas",
+          "type": "main-canvas",
+          "props": {
+            "area": "canvas",
+            "visible": { "$ref": "/mobileNav/isChat" },
+            "messages": { "$ref": "/messages" }
+          }
+        },
+        {
+          "id": "mobile-sessions-screen",
+          "type": "mobile-sessions",
+          "props": {
+            "area": "sessions",
+            "visible": { "$ref": "/mobileNav/isSessions" }
+          }
+        },
+        {
+          "id": "mobile-composer",
+          "type": "container",
+          "props": {
+            "area": "composer",
+            "direction": "column",
+            "visible": { "$ref": "/mobileNav/isChat" },
+            "className": "ae-mobile-composer"
+          },
+          "children": [
+            { "id": "mobile-chat-input", "type": "chat-input", "props": {} }
+          ]
+        },
+        {
+          "id": "mobile-bottom-nav",
+          "type": "mobile-nav",
+          "props": { "area": "nav" }
+        }
+      ]
+    }
+  ],
+  "state": {
+    "layout": {
+      "columns": "minmax(0,1fr)",
+      "rows": "auto minmax(0,1fr) auto auto",
+      "areas": ["header", "canvas", "composer", "nav"]
+    },
+    "mobileNav": {
+      "active": "chat",
+      "isSessions": false,
+      "isChat": true,
+      "isSettings": false
+    }
+  }
+}

--- a/src/mobile/mobileLayoutExtension.ts
+++ b/src/mobile/mobileLayoutExtension.ts
@@ -1,0 +1,21 @@
+// The companion's extra composites + boot layout. Registered alongside
+// the default-layout extension on the mobile surface only, so the
+// desktop bundle never pulls these in. The default-layout extension
+// still supplies the shared composites the mobile layout reuses
+// (main-canvas, chat-input, model-picker, agent-pulse).
+
+import type { A2UIExtension } from "../extensions/types";
+import { ConnectionBadge } from "./composites/connection-badge";
+import { MobileNav } from "./composites/mobile-nav";
+import { MobileSessions } from "./composites/mobile-sessions";
+import mobilePayload from "./mobile.a2ui.json";
+
+export const mobileLayoutExtension: A2UIExtension = {
+  name: "mobile-layout",
+  components: {
+    "connection-badge": ConnectionBadge,
+    "mobile-nav": MobileNav,
+    "mobile-sessions": MobileSessions,
+  },
+  layout: mobilePayload,
+};

--- a/src/styles/mobile.css
+++ b/src/styles/mobile.css
@@ -118,3 +118,124 @@
   background: var(--accent);
   color: var(--bg);
 }
+
+/* Header + connection badge */
+.ae-mobile-header {
+  padding: calc(var(--ae-safe-top) + 6px) 12px 6px;
+  border-bottom: 1px solid var(--border);
+}
+.ae-mobile-conn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.78rem;
+  color: var(--text-dim);
+  white-space: nowrap;
+}
+.ae-mobile-conn-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--text-dim);
+}
+.ae-mobile-conn--connected .ae-mobile-conn-dot {
+  background: var(--success, #30a46c);
+}
+.ae-mobile-conn--reconnecting .ae-mobile-conn-dot,
+.ae-mobile-conn--connecting .ae-mobile-conn-dot {
+  background: var(--warning, #f5a623);
+}
+.ae-mobile-conn--disconnected .ae-mobile-conn-dot {
+  background: var(--danger, #e5484d);
+}
+
+/* Bottom nav */
+.ae-mobile-nav {
+  display: flex;
+  align-items: stretch;
+  border-top: 1px solid var(--border);
+  padding-bottom: var(--ae-safe-bottom);
+  background: var(--bg);
+}
+.ae-mobile-nav-item {
+  flex: 1 1 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  min-height: 52px;
+  padding: 6px 0;
+  border: none;
+  background: transparent;
+  color: var(--text-dim);
+  font-size: 0.7rem;
+  cursor: pointer;
+}
+.ae-mobile-nav-item--active {
+  color: var(--accent);
+}
+.ae-mobile-nav-glyph {
+  font-size: 1.15rem;
+  line-height: 1;
+}
+
+/* Sessions screen */
+.ae-mobile-sessions {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 14px;
+  overflow-y: auto;
+  height: 100%;
+}
+.ae-mobile-new-session {
+  min-height: 44px;
+  border-radius: 10px;
+  border: 1px dashed var(--border);
+  background: transparent;
+  color: var(--accent);
+  font-size: 0.95rem;
+  cursor: pointer;
+}
+.ae-mobile-session-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.ae-mobile-session-heading {
+  margin: 4px 0;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-dim);
+}
+.ae-mobile-session-row {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  align-items: flex-start;
+  min-height: 52px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: var(--bg-input);
+  color: var(--text);
+  text-align: left;
+  cursor: pointer;
+}
+.ae-mobile-session-name {
+  font-size: 0.95rem;
+}
+.ae-mobile-session-cwd {
+  font-size: 0.78rem;
+  color: var(--text-dim);
+}
+.ae-mobile-session-empty {
+  color: var(--text-dim);
+  text-align: center;
+  margin-top: 32px;
+}
+.ae-mobile-composer {
+  padding-bottom: var(--ae-safe-bottom);
+}


### PR DESCRIPTION
## What & why

Phase 3 of the **iOS companion app** (follows the gateway #454 and the scaffold/shim #455). Gives the companion its touch-first UI: a single-column layout with a bottom tab bar, a sessions screen, and full chat parity — all by **reusing the existing chat composites** over the gateway transport.

## How it works

- **`src/mobile/mobile.a2ui.json`** is the mobile boot layout (header / canvas / composer / bottom-nav rows), selected by `VITE_AETHON_SURFACE=mobile` in `bootConstants.ts` — a build-time define, so the desktop bundle tree-shakes the mobile branch and still boots workstation unchanged.
- **Screen switching is state-driven**, matching the workstation's own visibility pattern: per-screen boolean flags under `/mobileNav` gate `visible` bindings (the layout's `visible` tests truthiness, not equality), and the `mobileNav` event route flips exactly one flag at a time. The nav's Settings tab drives the existing `/settings/open` overlay, so Settings behaves like a screen.
- **New composites** (registered only on the mobile surface, keyed by type, inert on desktop):
  - `mobile-nav` — bottom tab bar (Sessions / Chat / Settings), 44px+ targets.
  - `mobile-sessions` — open agent tabs + recent sessions (same `/tabs` + `/recentSessions` slices the sidebar reads), tapping activates via the existing `activateTabAnywhere` / `restoreSessionFromSelection` paths and jumps to chat.
  - `connection-badge` — live gateway status straight from the transport store.
- **Chat itself is 100% reuse**: `main-canvas` transcript (virtuoso is touch-native), `chat-input`, `model-picker`, `agent-pulse` — streaming deltas, thinking channel, tool cards, stop/steer/queue all ride the same `agent-response` topic the shim already delivers.

## Verification

- New route tests: screen switching sets exactly one flag, settings overlay opens/closes with the nav, tab select/new-session activate and jump to chat, unrelated component types fall through.
- Full `check` gate green (2977 vitest; the one red Rust test in a full-load run was the known pre-existing `devshell::resolve` timing flake — passes in isolation and was untouched here).
- `build:mobile` bundles the new layout.

Next: Phase 4 (terminal / files / git on both sides), then the parity tail.