### PR TITLE
feat(mobile): terminal, files, git — both sides (Phase 4)

### DIFF
--- a/src-tauri/src/server/remote/events.rs
+++ b/src-tauri/src/server/remote/events.rs
@@ -29,6 +29,14 @@ pub const TAPPED_TOPICS: &[&str] = &[
     "scheduled-tasks-changed",
     "host-discovered",
     "host-removed",
+    // Phase 4 — terminal / files / git surfaces. shell-output is the
+    // highest-volume topic; the client coalesces per tab (the shell
+    // stream re-fans to per-tab CustomEvents frontend-side unchanged).
+    "shell-output",
+    "shell-title",
+    "shell-exit",
+    "fs-tree-changed",
+    "git-state-changed",
 ];
 
 /// Topics published directly by Rust code rather than tapped from a

--- a/src-tauri/src/server/remote/policy.rs
+++ b/src-tauri/src/server/remote/policy.rs
@@ -409,7 +409,11 @@ mod tests {
         assert_eq!(policy_for("agent_command"), DirectFiltered);
         assert_eq!(policy_for("ui.chat.send"), ForwardToFrontend("chat.send"));
         assert!(matches!(policy_for("write_state"), Deny(_)));
-        assert!(matches!(policy_for("shell_write"), Deny(_)));
+        assert_eq!(policy_for("shell_write"), Direct);
+        assert_eq!(policy_for("shell_open"), DirectRootChecked);
+        assert_eq!(policy_for("fs_read_file"), DirectRootChecked);
+        assert_eq!(policy_for("git_status"), DirectRootChecked);
+        assert!(matches!(policy_for("git_worktree_add"), Deny(_)));
         assert!(matches!(policy_for("not_a_command"), Deny(_)));
     }
 

--- a/src-tauri/src/server/remote/policy.rs
+++ b/src-tauri/src/server/remote/policy.rs
@@ -9,13 +9,18 @@
 //!   `mutation_ack` sender, and single writer of persisted state.
 //! - Execution-boundary approvals (MCP, workspace startup, extension
 //!   install) happen physically at the desktop.
-//! - Root-bearing commands (fs/git/shell) stay denied until the phase
-//!   that adds `validate_root_arg` enforcement lands.
+//! - Root-bearing commands (fs/git/shell) are `DirectRootChecked`: the
+//!   relay validates their root/cwd/projectPath arg against the host's
+//!   known project roots before dispatch, and the per-path fs jail still
+//!   applies beneath.
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum RemotePolicy {
     /// Dispatch straight to the Rust command.
     Direct,
+    /// Dispatch after validating the command's root/cwd/projectPath arg
+    /// against the host's known project roots (fs/git/shell surfaces).
+    DirectRootChecked,
     /// Dispatch after per-command payload inspection (`agent_command`).
     DirectFiltered,
     /// Forward to the desktop webview via the control-plane machinery;
@@ -107,59 +112,67 @@ pub const COMMAND_POLICIES: &[(&str, RemotePolicy)] = &[
     ("install_aethon_extension", Deny(APPROVAL)),
     ("watch_project_extensions", Deny(LIFECYCLE)),
     ("unwatch_project_extensions", Deny(LIFECYCLE)),
-    // fs (terminal/files/git phase; will require validate_root_arg)
-    ("fs_list_dir", Deny(PHASE_TERMINAL)),
-    ("fs_walk_project", Deny(PHASE_TERMINAL)),
-    ("fs_read_file", Deny(PHASE_TERMINAL)),
-    ("fs_read_file_base64", Deny(PHASE_TERMINAL)),
-    ("fs_exists", Deny(PHASE_TERMINAL)),
-    ("fs_file_mtime", Deny(PHASE_TERMINAL)),
-    ("fs_write_file", Deny(PHASE_TERMINAL)),
-    ("fs_create_file", Deny(PHASE_TERMINAL)),
-    ("fs_create_dir", Deny(PHASE_TERMINAL)),
-    ("fs_rename", Deny(PHASE_TERMINAL)),
-    ("fs_delete", Deny(PHASE_TERMINAL)),
-    ("fs_watch_dirs", Deny(PHASE_TERMINAL)),
-    ("fs_unwatch_root", Deny(PHASE_TERMINAL)),
-    ("fs_discover_project_icon", Deny(PHASE_TERMINAL)),
+    // fs — reads/writes jailed to a validated project root (the
+    // existing helpers::resolve_inside_root + canonicalize guard still
+    // applies beneath). Watch/discover/tab-id ops don't carry a root or
+    // touch desktop-local surfaces, so they stay denied.
+    ("fs_list_dir", DirectRootChecked),
+    ("fs_walk_project", DirectRootChecked),
+    ("fs_read_file", DirectRootChecked),
+    ("fs_read_file_base64", DirectRootChecked),
+    ("fs_exists", DirectRootChecked),
+    ("fs_file_mtime", DirectRootChecked),
+    ("fs_write_file", DirectRootChecked),
+    ("fs_create_file", DirectRootChecked),
+    ("fs_create_dir", DirectRootChecked),
+    ("fs_rename", DirectRootChecked),
+    ("fs_delete", DirectRootChecked),
+    ("fs_watch_dirs", Deny(DESKTOP_ONLY)),
+    ("fs_unwatch_root", Deny(DESKTOP_ONLY)),
+    ("fs_discover_project_icon", DirectRootChecked),
     ("fs_reveal_in_file_manager", Deny(DESKTOP_ONLY)),
     ("fs_open_in_file_manager", Deny(DESKTOP_ONLY)),
     ("fs_open_in_default_app", Deny(DESKTOP_ONLY)),
-    // git + gh (terminal/files/git phase)
-    ("git_status", Deny(PHASE_TERMINAL)),
-    ("git_working_context", Deny(PHASE_TERMINAL)),
-    ("git_fetch_all", Deny(PHASE_TERMINAL)),
-    ("git_file_status", Deny(PHASE_TERMINAL)),
-    ("git_ignored_paths", Deny(PHASE_TERMINAL)),
-    ("git_watch_root", Deny(PHASE_TERMINAL)),
-    ("git_unwatch_root", Deny(PHASE_TERMINAL)),
-    ("git_file_diff", Deny(PHASE_TERMINAL)),
-    ("git_file_diff_hunks", Deny(PHASE_TERMINAL)),
-    ("git_file_diff_stat", Deny(PHASE_TERMINAL)),
-    ("git_show_head", Deny(PHASE_TERMINAL)),
-    ("git_diff_stat", Deny(PHASE_TERMINAL)),
-    ("git_worktrees", Deny(PHASE_TERMINAL)),
-    ("git_worktree_add", Deny(PHASE_TERMINAL)),
-    ("git_worktree_remove", Deny(PHASE_TERMINAL)),
-    ("git_worktree_remove_orphan", Deny(PHASE_TERMINAL)),
-    ("git_branch_list", Deny(PHASE_TERMINAL)),
-    ("gh_branch_status", Deny(PHASE_TERMINAL)),
-    ("gh_repo_overview", Deny(PHASE_TERMINAL)),
-    ("gh_repo_avatar_url", Deny(PHASE_TERMINAL)),
-    ("gh_checks", Deny(PHASE_TERMINAL)),
-    ("gh_issue_list", Deny(PHASE_TERMINAL)),
-    ("gh_issue_view", Deny(PHASE_TERMINAL)),
+    // git + gh — read surfaces scoped to a validated root. Worktree
+    // add/remove mutate the on-disk repo layout; keep those desktop-only
+    // for now (they're a project-management action, not a mobile flow).
+    ("git_status", DirectRootChecked),
+    ("git_working_context", DirectRootChecked),
+    ("git_fetch_all", DirectRootChecked),
+    ("git_file_status", DirectRootChecked),
+    ("git_ignored_paths", DirectRootChecked),
+    ("git_watch_root", Deny(DESKTOP_ONLY)),
+    ("git_unwatch_root", Deny(DESKTOP_ONLY)),
+    ("git_file_diff", DirectRootChecked),
+    ("git_file_diff_hunks", DirectRootChecked),
+    ("git_file_diff_stat", DirectRootChecked),
+    ("git_show_head", DirectRootChecked),
+    ("git_diff_stat", DirectRootChecked),
+    ("git_worktrees", DirectRootChecked),
+    ("git_worktree_add", Deny(DESKTOP_ONLY)),
+    ("git_worktree_remove", Deny(DESKTOP_ONLY)),
+    ("git_worktree_remove_orphan", Deny(DESKTOP_ONLY)),
+    ("git_branch_list", DirectRootChecked),
+    ("gh_branch_status", DirectRootChecked),
+    ("gh_repo_overview", DirectRootChecked),
+    ("gh_repo_avatar_url", DirectRootChecked),
+    ("gh_checks", DirectRootChecked),
+    ("gh_issue_list", DirectRootChecked),
+    ("gh_issue_view", DirectRootChecked),
     ("pick_project_directory", Deny(DESKTOP_ONLY)),
-    // shells (terminal/files/git phase)
-    ("shell_open", Deny(PHASE_TERMINAL)),
-    ("shell_input", Deny(PHASE_TERMINAL)),
-    ("shell_resize", Deny(PHASE_TERMINAL)),
-    ("shell_close", Deny(PHASE_TERMINAL)),
-    ("shell_is_busy", Deny(PHASE_TERMINAL)),
-    ("shell_set_share_mode", Deny(PHASE_TERMINAL)),
-    ("shell_read_scrollback", Deny(PHASE_TERMINAL)),
-    ("shell_list_shareable", Deny(PHASE_TERMINAL)),
-    ("shell_write", Deny(PHASE_TERMINAL)),
+    // shells — the user's own interactive terminals. Per-tab ShareMode
+    // in shell/sharemode.rs gates *agent* access and is untouched; a
+    // paired device driving its own shell is the user, not the agent.
+    // shell_open validates its cwd; the rest key by an already-open tab.
+    ("shell_open", DirectRootChecked),
+    ("shell_input", Direct),
+    ("shell_resize", Direct),
+    ("shell_close", Direct),
+    ("shell_is_busy", Direct),
+    ("shell_set_share_mode", Direct),
+    ("shell_read_scrollback", Direct),
+    ("shell_list_shareable", Direct),
+    ("shell_write", Direct),
     // devshell
     ("devshell_status", Deny(PHASE_SETTINGS)),
     ("devshell_prepare_for_path", Deny(PHASE_SETTINGS)),
@@ -225,6 +238,83 @@ pub fn policy_for(cmd: &str) -> RemotePolicy {
         .find(|(name, _)| *name == cmd)
         .map(|(_, policy)| *policy)
         .unwrap_or(Deny("unknown command"))
+}
+
+/// The arg holding a project root for a root-checked command. Names
+/// vary across the command surface (`root` / `cwd` / `path` /
+/// `projectPath`), and `shell_open` nests its `cwd` inside `args`.
+/// Returns `None` when the command carries no root arg — for
+/// `shell_open` that means "open in the default cwd" (allowed); for
+/// everything else a missing root is a malformed call (denied).
+pub fn root_arg_value(cmd: &str, args: &serde_json::Value) -> Option<String> {
+    if cmd == "shell_open" {
+        return args
+            .get("args")
+            .and_then(|a| a.get("cwd"))
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(str::to_string);
+    }
+    let key = match cmd {
+        "git_status" => "path",
+        "git_working_context" => "cwd",
+        "git_worktrees" | "git_branch_list" | "git_fetch_all" | "gh_branch_status"
+        | "gh_checks" | "gh_repo_overview" | "gh_repo_avatar_url" | "gh_issue_list"
+        | "gh_issue_view" | "fs_discover_project_icon" => "projectPath",
+        // fs_* + git diff/status/show family all name it `root`.
+        _ => "root",
+    };
+    args.get(key)
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+}
+
+/// `shell_open` may omit its cwd (defaults to home); every other
+/// root-checked command requires one.
+pub fn root_is_optional(cmd: &str) -> bool {
+    cmd == "shell_open"
+}
+
+/// Extract the canonical project roots from a `projects.json` document:
+/// `projects[].path` ∪ `workspacesByProject[*][].path` (plus the pre-v5
+/// `worktreesByProject` spelling). Pure so it's unit-testable without a
+/// running app.
+pub fn allowed_roots_from_projects_json(raw: &str) -> Vec<String> {
+    let Ok(doc) = serde_json::from_str::<serde_json::Value>(raw) else {
+        return Vec::new();
+    };
+    let mut roots = Vec::new();
+    let mut push_paths = |arr: Option<&Vec<serde_json::Value>>| {
+        if let Some(items) = arr {
+            for item in items {
+                if let Some(p) = item.get("path").and_then(|v| v.as_str()) {
+                    roots.push(p.to_string());
+                }
+            }
+        }
+    };
+    push_paths(doc.get("projects").and_then(|v| v.as_array()));
+    for key in ["workspacesByProject", "worktreesByProject"] {
+        if let Some(map) = doc.get(key).and_then(|v| v.as_object()) {
+            for group in map.values() {
+                push_paths(group.as_array());
+            }
+        }
+    }
+    roots
+}
+
+/// Whether `candidate` resolves to one of the allowed roots. Both sides
+/// are canonicalized so `..`/symlinks can't dress a non-root up as one;
+/// a candidate that can't canonicalize (missing dir) never matches.
+pub fn root_is_allowed(candidate: &str, allowed: &[String]) -> bool {
+    let Ok(candidate) = std::fs::canonicalize(candidate) else {
+        return false;
+    };
+    allowed
+        .iter()
+        .filter_map(|r| std::fs::canonicalize(r).ok())
+        .any(|r| r == candidate)
 }
 
 /// `agent_command` payload filter: the desktop webview is the sole
@@ -335,5 +425,66 @@ mod tests {
         );
         assert!(agent_command_remote_denial(&json!({"type": "set_model"})).is_none());
         assert!(agent_command_remote_denial(&json!({"no": "type"})).is_none());
+    }
+
+    #[test]
+    fn root_arg_value_reads_the_right_key_per_command() {
+        use serde_json::json;
+        assert_eq!(
+            root_arg_value("fs_read_file", &json!({"root": "/a", "path": "b"})).as_deref(),
+            Some("/a")
+        );
+        assert_eq!(
+            root_arg_value("git_status", &json!({"path": "/repo"})).as_deref(),
+            Some("/repo")
+        );
+        assert_eq!(
+            root_arg_value("git_working_context", &json!({"cwd": "/w"})).as_deref(),
+            Some("/w")
+        );
+        assert_eq!(
+            root_arg_value("gh_checks", &json!({"projectPath": "/p", "branch": "main"}))
+                .as_deref(),
+            Some("/p")
+        );
+        assert_eq!(
+            root_arg_value("shell_open", &json!({"args": {"tabId": "t", "cwd": "/proj"}}))
+                .as_deref(),
+            Some("/proj")
+        );
+        // shell_open with no cwd → None (allowed default); others → None
+        // (missing required root).
+        assert!(root_arg_value("shell_open", &json!({"args": {"tabId": "t"}})).is_none());
+        assert!(root_is_optional("shell_open"));
+        assert!(!root_is_optional("fs_read_file"));
+    }
+
+    #[test]
+    fn allowed_roots_collects_projects_and_workspaces() {
+        let raw = r#"{
+            "projects": [{"path": "/a"}, {"path": "/b"}],
+            "workspacesByProject": {"p1": [{"path": "/a/wt"}]},
+            "worktreesByProject": {"p2": [{"path": "/legacy"}]}
+        }"#;
+        let mut roots = allowed_roots_from_projects_json(raw);
+        roots.sort();
+        assert_eq!(roots, vec!["/a", "/a/wt", "/b", "/legacy"]);
+        assert!(allowed_roots_from_projects_json("not json").is_empty());
+    }
+
+    #[test]
+    fn root_is_allowed_matches_only_canonical_known_roots() {
+        let root = tempfile::tempdir().unwrap();
+        let sub = root.path().join("sub");
+        std::fs::create_dir(&sub).unwrap();
+        let allowed = vec![root.path().to_string_lossy().into_owned()];
+
+        assert!(root_is_allowed(root.path().to_str().unwrap(), &allowed));
+        // A traversal that resolves back to the root still matches (both
+        // canonicalized); a genuine subdir does not (roots are exact).
+        let via_dotdot = sub.join("..");
+        assert!(root_is_allowed(via_dotdot.to_str().unwrap(), &allowed));
+        assert!(!root_is_allowed(sub.to_str().unwrap(), &allowed));
+        assert!(!root_is_allowed("/nonexistent/path", &allowed));
     }
 }

--- a/src-tauri/src/server/remote/relay.rs
+++ b/src-tauri/src/server/remote/relay.rs
@@ -28,11 +28,55 @@ pub trait RelayExec: Send + Sync {
 
 pub struct TauriRelay {
     app: AppHandle,
+    /// Allowed project roots for `DirectRootChecked` commands, read from
+    /// the persisted projects state with a short TTL so a just-added
+    /// project becomes reachable without restarting the gateway.
+    roots: std::sync::Mutex<Option<(std::time::Instant, Vec<String>)>>,
 }
+
+const ROOTS_TTL: std::time::Duration = std::time::Duration::from_secs(5);
 
 impl TauriRelay {
     pub fn new(app: AppHandle) -> Self {
-        Self { app }
+        Self {
+            app,
+            roots: std::sync::Mutex::new(None),
+        }
+    }
+
+    fn allowed_roots(&self) -> Vec<String> {
+        {
+            let cache = self.roots.lock().expect("roots lock");
+            if let Some((at, roots)) = cache.as_ref()
+                && at.elapsed() < ROOTS_TTL
+            {
+                return roots.clone();
+            }
+        }
+        let roots = crate::storage::read_state_value(&self.app, "projects.json")
+            .ok()
+            .flatten()
+            .map(|raw| policy::allowed_roots_from_projects_json(&raw))
+            .unwrap_or_default();
+        *self.roots.lock().expect("roots lock") =
+            Some((std::time::Instant::now(), roots.clone()));
+        roots
+    }
+
+    fn check_root(&self, cmd: &str, args: &Value) -> Result<(), String> {
+        let Some(root) = policy::root_arg_value(cmd, args) else {
+            if policy::root_is_optional(cmd) {
+                return Ok(());
+            }
+            return Err(format!("denied: {cmd} requires a project root argument"));
+        };
+        if policy::root_is_allowed(&root, &self.allowed_roots()) {
+            Ok(())
+        } else {
+            Err(format!(
+                "denied: {root} is not a known project or workspace root on this host"
+            ))
+        }
     }
 }
 
@@ -59,6 +103,46 @@ pub const DISPATCHABLE: &[&str] = &[
     "read_paste_image_base64",
     "subagents_list",
     "remote_status",
+    // terminal / files / git phase
+    "shell_open",
+    "shell_input",
+    "shell_resize",
+    "shell_close",
+    "shell_is_busy",
+    "shell_set_share_mode",
+    "shell_read_scrollback",
+    "shell_list_shareable",
+    "shell_write",
+    "fs_list_dir",
+    "fs_walk_project",
+    "fs_read_file",
+    "fs_read_file_base64",
+    "fs_exists",
+    "fs_file_mtime",
+    "fs_write_file",
+    "fs_create_file",
+    "fs_create_dir",
+    "fs_rename",
+    "fs_delete",
+    "fs_discover_project_icon",
+    "git_status",
+    "git_working_context",
+    "git_fetch_all",
+    "git_file_status",
+    "git_ignored_paths",
+    "git_file_diff",
+    "git_file_diff_hunks",
+    "git_file_diff_stat",
+    "git_show_head",
+    "git_diff_stat",
+    "git_worktrees",
+    "git_branch_list",
+    "gh_branch_status",
+    "gh_checks",
+    "gh_repo_overview",
+    "gh_repo_avatar_url",
+    "gh_issue_list",
+    "gh_issue_view",
 ];
 
 fn arg<T: serde::de::DeserializeOwned>(args: &Value, key: &str) -> Result<T, String> {
@@ -86,6 +170,10 @@ impl RelayExec for TauriRelay {
                 if let Some(reason) = policy::agent_command_remote_denial(&parsed) {
                     return Err(format!("denied: {reason}"));
                 }
+                self.dispatch(cmd, args).await
+            }
+            RemotePolicy::DirectRootChecked => {
+                self.check_root(cmd, &args)?;
                 self.dispatch(cmd, args).await
             }
             RemotePolicy::Direct => self.dispatch(cmd, args).await,
@@ -208,6 +296,232 @@ impl TauriRelay {
                         .await?,
                 )
             }
+            // ── shells — the user's own interactive terminals ─────────
+            "shell_open" => {
+                let state = app.state::<crate::shell::ShellRegistry>();
+                let devshell = app.state::<Arc<crate::devshell::DevshellCache>>();
+                let startup = app.state::<crate::commands::startup::WorkspaceStartupState>();
+                to_value(
+                    crate::shell::shell_open(
+                        app.clone(),
+                        state.clone(),
+                        devshell.clone(),
+                        startup.clone(),
+                        arg(&args, "args")?,
+                    )
+                    .await?,
+                )
+            }
+            "shell_input" => {
+                let state = app.state::<crate::shell::ShellRegistry>();
+                to_value(crate::shell::shell_input(
+                    state.clone(),
+                    arg(&args, "tabId")?,
+                    arg(&args, "data")?,
+                )?)
+            }
+            "shell_resize" => {
+                let state = app.state::<crate::shell::ShellRegistry>();
+                to_value(crate::shell::shell_resize(
+                    state.clone(),
+                    arg(&args, "tabId")?,
+                    arg(&args, "cols")?,
+                    arg(&args, "rows")?,
+                )?)
+            }
+            "shell_close" => {
+                let state = app.state::<crate::shell::ShellRegistry>();
+                to_value(crate::shell::shell_close(state.clone(), arg(&args, "tabId")?)?)
+            }
+            "shell_is_busy" => {
+                let state = app.state::<crate::shell::ShellRegistry>();
+                to_value(crate::shell::shell_is_busy(
+                    state.clone(),
+                    arg(&args, "tabId")?,
+                )?)
+            }
+            "shell_set_share_mode" => {
+                let state = app.state::<crate::shell::ShellRegistry>();
+                to_value(crate::shell::shell_set_share_mode(
+                    state.clone(),
+                    arg(&args, "tabId")?,
+                    arg(&args, "mode")?,
+                )?)
+            }
+            "shell_read_scrollback" => {
+                let state = app.state::<crate::shell::ShellRegistry>();
+                to_value(crate::shell::shell_read_scrollback(
+                    state.clone(),
+                    arg(&args, "args")?,
+                )?)
+            }
+            "shell_list_shareable" => {
+                let state = app.state::<crate::shell::ShellRegistry>();
+                to_value(crate::shell::shell_list_shareable(state.clone())?)
+            }
+            "shell_write" => {
+                let state = app.state::<crate::shell::ShellRegistry>();
+                to_value(crate::shell::shell_write(
+                    state.clone(),
+                    arg(&args, "tabId")?,
+                    arg(&args, "data")?,
+                )?)
+            }
+            // ── fs — root-validated above; the per-path jail applies
+            //    inside each command ─────────────────────────────────
+            "fs_list_dir" => to_value(crate::commands::fs::fs_list_dir(
+                arg(&args, "root")?,
+                arg(&args, "path")?,
+            )?),
+            "fs_walk_project" => {
+                let root: String = arg(&args, "root")?;
+                let files = tauri::async_runtime::spawn_blocking(move || {
+                    crate::commands::fs::fs_walk_project(root)
+                })
+                .await
+                .map_err(|e| e.to_string())??;
+                to_value(files)
+            }
+            "fs_read_file" => to_value(crate::commands::fs::fs_read_file(
+                arg(&args, "root")?,
+                arg(&args, "path")?,
+            )?),
+            "fs_read_file_base64" => to_value(crate::commands::fs::fs_read_file_base64(
+                arg(&args, "root")?,
+                arg(&args, "path")?,
+            )?),
+            "fs_exists" => to_value(crate::commands::fs::fs_exists(
+                arg(&args, "root")?,
+                arg(&args, "path")?,
+            )?),
+            "fs_file_mtime" => to_value(crate::commands::fs::fs_file_mtime(
+                arg(&args, "root")?,
+                arg(&args, "path")?,
+            )?),
+            "fs_write_file" => to_value(crate::commands::fs::fs_write_file(
+                arg(&args, "root")?,
+                arg(&args, "path")?,
+                arg(&args, "content")?,
+            )?),
+            "fs_create_file" => to_value(crate::commands::fs::fs_create_file(
+                arg(&args, "root")?,
+                arg(&args, "path")?,
+            )?),
+            "fs_create_dir" => to_value(crate::commands::fs::fs_create_dir(
+                arg(&args, "root")?,
+                arg(&args, "path")?,
+            )?),
+            "fs_rename" => to_value(crate::commands::fs::fs_rename(
+                arg(&args, "root")?,
+                arg(&args, "from")?,
+                arg(&args, "to")?,
+            )?),
+            "fs_delete" => to_value(crate::commands::fs::fs_delete(
+                arg(&args, "root")?,
+                arg(&args, "path")?,
+            )?),
+            "fs_discover_project_icon" => to_value(
+                crate::commands::fs::fs_discover_project_icon(arg(&args, "projectPath")?)
+                    .await?,
+            ),
+            // ── git + gh reads ────────────────────────────────────────
+            "git_status" => to_value(
+                crate::commands::git::status::git_status(arg(&args, "path")?).await?,
+            ),
+            "git_working_context" => to_value(
+                crate::commands::git::status::git_working_context(arg(&args, "cwd")?).await?,
+            ),
+            "git_fetch_all" => {
+                let state = app.state::<crate::commands::git::GitFetchState>();
+                to_value(
+                    crate::commands::git::status::git_fetch_all(
+                        arg(&args, "projectPath")?,
+                        state.clone(),
+                    )
+                    .await?,
+                )
+            }
+            "git_file_status" => to_value(
+                crate::commands::git::status::git_file_status(arg(&args, "root")?).await?,
+            ),
+            "git_ignored_paths" => to_value(
+                crate::commands::git::status::git_ignored_paths(arg(&args, "root")?).await?,
+            ),
+            "git_file_diff" => to_value(
+                crate::commands::git::diff::git_file_diff(
+                    arg(&args, "root")?,
+                    arg(&args, "path")?,
+                )
+                .await?,
+            ),
+            "git_file_diff_hunks" => to_value(
+                crate::commands::git::diff::git_file_diff_hunks(
+                    arg(&args, "root")?,
+                    arg(&args, "path")?,
+                )
+                .await?,
+            ),
+            "git_file_diff_stat" => to_value(
+                crate::commands::git::diff::git_file_diff_stat(
+                    arg(&args, "root")?,
+                    arg(&args, "path")?,
+                )
+                .await?,
+            ),
+            "git_show_head" => to_value(
+                crate::commands::git::diff::git_show_head(
+                    arg(&args, "root")?,
+                    arg(&args, "path")?,
+                )
+                .await?,
+            ),
+            "git_diff_stat" => to_value(
+                crate::commands::git::diff::git_diff_stat(arg(&args, "root")?).await?,
+            ),
+            "git_worktrees" => to_value(
+                crate::commands::git::worktrees::git_worktrees(arg(&args, "projectPath")?)
+                    .await?,
+            ),
+            "git_branch_list" => to_value(
+                crate::commands::git::worktrees::git_branch_list(arg(&args, "projectPath")?)
+                    .await?,
+            ),
+            "gh_branch_status" => to_value(
+                crate::commands::git::github::gh_branch_status(
+                    arg(&args, "projectPath")?,
+                    arg(&args, "branch")?,
+                )
+                .await?,
+            ),
+            "gh_checks" => to_value(
+                crate::commands::git::checks::gh_checks(
+                    arg(&args, "projectPath")?,
+                    arg(&args, "branch")?,
+                )
+                .await?,
+            ),
+            "gh_repo_overview" => to_value(
+                crate::commands::git::github::gh_repo_overview(arg(&args, "projectPath")?)
+                    .await?,
+            ),
+            "gh_repo_avatar_url" => to_value(
+                crate::commands::git::github::gh_repo_avatar_url(arg(&args, "projectPath")?)
+                    .await,
+            ),
+            "gh_issue_list" => to_value(
+                crate::commands::git::issues::gh_issue_list(
+                    arg(&args, "projectPath")?,
+                    arg(&args, "limit")?,
+                )
+                .await,
+            ),
+            "gh_issue_view" => to_value(
+                crate::commands::git::issues::gh_issue_view(
+                    arg(&args, "projectPath")?,
+                    arg(&args, "number")?,
+                )
+                .await?,
+            ),
             other => Err(format!(
                 "no dispatch arm for `{other}` — policy table and relay disagree"
             )),
@@ -241,7 +555,14 @@ mod tests {
     fn dispatch_arms_match_policy_allowlist() {
         let allowed: HashSet<&str> = COMMAND_POLICIES
             .iter()
-            .filter(|(_, p)| matches!(p, RemotePolicy::Direct | RemotePolicy::DirectFiltered))
+            .filter(|(_, p)| {
+                matches!(
+                    p,
+                    RemotePolicy::Direct
+                        | RemotePolicy::DirectFiltered
+                        | RemotePolicy::DirectRootChecked
+                )
+            })
             .map(|(name, _)| *name)
             .collect();
         let dispatchable: HashSet<&str> = DISPATCHABLE.iter().copied().collect();

--- a/src-tauri/src/server/remote/ws.rs
+++ b/src-tauri/src/server/remote/ws.rs
@@ -31,6 +31,11 @@ use super::protocol::{ClientFrame, PROTOCOL_VERSION, ServerFrame};
 pub const HELLO_DEADLINE: Duration = Duration::from_secs(5);
 /// Slow-consumer eviction: how long one event frame may block the sink.
 pub const EVENT_SEND_TIMEOUT: Duration = Duration::from_secs(3);
+/// Max hub frames drained per wakeup before writing to the socket.
+const EVENT_BATCH_MAX: usize = 256;
+/// A coalesced shell-output run larger than this is tail-truncated and
+/// flagged; the client resyncs the gap via `shell_read_scrollback`.
+const SHELL_MERGE_CAP: usize = 64 * 1024;
 const PING_INTERVAL: Duration = Duration::from_secs(20);
 /// Two missed pings.
 const IDLE_DEADLINE: Duration = Duration::from_secs(45);
@@ -170,18 +175,42 @@ async fn run_session(
             }
             frame = hub_rx.recv() => {
                 match frame {
-                    Ok(frame) if subs.contains(frame.topic) => {
-                        let send = sink.send(Message::Text(frame.wire.clone()));
-                        match tokio::time::timeout(EVENT_SEND_TIMEOUT, send).await {
-                            Ok(Ok(())) => {}
-                            Ok(Err(_)) => return,
-                            Err(_) => {
-                                send_bye(sink, "slow-consumer").await;
-                                return;
+                    Ok(frame) => {
+                        // Batch-drain whatever else the hub already has so
+                        // bursty streams (a TUI redraw hitting shell-output)
+                        // coalesce per tab instead of one socket write per
+                        // PTY chunk. Draining hits Lagged the same way
+                        // recv() does — treat it identically.
+                        let mut batch = vec![frame];
+                        let mut lagged = false;
+                        while batch.len() < EVENT_BATCH_MAX {
+                            match hub_rx.try_recv() {
+                                Ok(next) => batch.push(next),
+                                Err(broadcast::error::TryRecvError::Empty) => break,
+                                Err(broadcast::error::TryRecvError::Lagged(_)) => {
+                                    lagged = true;
+                                    break;
+                                }
+                                Err(broadcast::error::TryRecvError::Closed) => break,
+                            }
+                        }
+                        if lagged {
+                            send_bye(sink, "slow-consumer").await;
+                            return;
+                        }
+                        batch.retain(|f| subs.contains(f.topic));
+                        for wire in coalesce_batch(&batch) {
+                            let send = sink.send(Message::Text(wire));
+                            match tokio::time::timeout(EVENT_SEND_TIMEOUT, send).await {
+                                Ok(Ok(())) => {}
+                                Ok(Err(_)) => return,
+                                Err(_) => {
+                                    send_bye(sink, "slow-consumer").await;
+                                    return;
+                                }
                             }
                         }
                     }
-                    Ok(_) => {}
                     Err(broadcast::error::RecvError::Lagged(missed)) => {
                         tracing::warn!(
                             target: "aethon::server::remote",
@@ -278,5 +307,196 @@ fn handle_text_frame(
                 }
             });
         }
+    }
+}
+
+/// Merge ADJACENT `shell-output` frames for the same tab into one wire
+/// frame, preserving total frame order exactly (a run never spans a
+/// frame of another topic or tab, so per-tab output/exit ordering
+/// holds). Runs above [`SHELL_MERGE_CAP`] keep their tail and gain
+/// `"truncated": true` so the client knows to resync scrollback.
+/// Single-frame runs pass through byte-identical.
+fn coalesce_batch(batch: &[Arc<super::events::EventFrame>]) -> Vec<String> {
+    #[derive(serde::Deserialize)]
+    struct ShellWire {
+        seq: u64,
+        payload: ShellPayload,
+    }
+    #[derive(serde::Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct ShellPayload {
+        tab_id: String,
+        content: String,
+    }
+
+    struct Run {
+        tab_id: String,
+        content: String,
+        last_seq: u64,
+        first_wire: String,
+        frames: usize,
+    }
+
+    fn flush(run: Option<Run>, out: &mut Vec<String>) {
+        let Some(run) = run else {
+            return;
+        };
+        if run.frames == 1 {
+            out.push(run.first_wire);
+            return;
+        }
+        let truncated = run.content.len() > SHELL_MERGE_CAP;
+        let content = if truncated {
+            let mut start = run.content.len() - SHELL_MERGE_CAP;
+            while !run.content.is_char_boundary(start) {
+                start += 1;
+            }
+            &run.content[start..]
+        } else {
+            run.content.as_str()
+        };
+        let mut payload = serde_json::json!({
+            "tabId": run.tab_id,
+            "content": content,
+        });
+        if truncated {
+            payload["truncated"] = serde_json::Value::Bool(true);
+        }
+        let frame = serde_json::json!({
+            "t": "event",
+            "topic": "shell-output",
+            "seq": run.last_seq,
+            "payload": payload,
+        });
+        out.push(frame.to_string());
+    }
+
+    let mut out = Vec::with_capacity(batch.len());
+    let mut run: Option<Run> = None;
+    for frame in batch {
+        if frame.topic == "shell-output"
+            && let Ok(parsed) = serde_json::from_str::<ShellWire>(&frame.wire)
+        {
+            match run.as_mut() {
+                Some(open) if open.tab_id == parsed.payload.tab_id => {
+                    open.content.push_str(&parsed.payload.content);
+                    open.last_seq = parsed.seq;
+                    open.frames += 1;
+                }
+                _ => {
+                    flush(run.take(), &mut out);
+                    run = Some(Run {
+                        tab_id: parsed.payload.tab_id,
+                        content: parsed.payload.content,
+                        last_seq: parsed.seq,
+                        first_wire: frame.wire.clone(),
+                        frames: 1,
+                    });
+                }
+            }
+            continue;
+        }
+        flush(run.take(), &mut out);
+        out.push(frame.wire.clone());
+    }
+    flush(run, &mut out);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::events::EventFrame;
+    use super::*;
+
+    fn shell_frame(seq: u64, tab: &str, content: &str) -> Arc<EventFrame> {
+        Arc::new(EventFrame {
+            topic: "shell-output",
+            wire: serde_json::json!({
+                "t": "event", "topic": "shell-output", "seq": seq,
+                "payload": { "tabId": tab, "content": content },
+            })
+            .to_string(),
+        })
+    }
+
+    fn other_frame(seq: u64) -> Arc<EventFrame> {
+        Arc::new(EventFrame {
+            topic: "shell-exit",
+            wire: serde_json::json!({
+                "t": "event", "topic": "shell-exit", "seq": seq,
+                "payload": { "tabId": "t1", "code": 0 },
+            })
+            .to_string(),
+        })
+    }
+
+    #[test]
+    fn adjacent_same_tab_output_merges_with_last_seq() {
+        let batch = vec![
+            shell_frame(1, "t1", "a"),
+            shell_frame(2, "t1", "b"),
+            shell_frame(3, "t1", "c"),
+        ];
+        let out = coalesce_batch(&batch);
+        assert_eq!(out.len(), 1);
+        let parsed: serde_json::Value = serde_json::from_str(&out[0]).unwrap();
+        assert_eq!(parsed["seq"], 3);
+        assert_eq!(parsed["payload"]["content"], "abc");
+        assert!(parsed["payload"].get("truncated").is_none());
+    }
+
+    #[test]
+    fn runs_never_span_other_tabs_or_topics() {
+        let batch = vec![
+            shell_frame(1, "t1", "a"),
+            shell_frame(1, "t2", "x"),
+            shell_frame(2, "t1", "b"),
+            other_frame(1),
+            shell_frame(3, "t1", "c"),
+        ];
+        let out = coalesce_batch(&batch);
+        // Nothing adjacent shares a tab, so total order is preserved 1:1.
+        assert_eq!(out.len(), 5);
+        assert_eq!(out[0], batch[0].wire);
+        assert_eq!(out[3], batch[3].wire);
+    }
+
+    #[test]
+    fn oversized_run_keeps_tail_and_flags_truncation() {
+        let chunk = "x".repeat(40 * 1024);
+        let batch = vec![
+            shell_frame(1, "t1", &chunk),
+            shell_frame(2, "t1", &chunk),
+        ];
+        let out = coalesce_batch(&batch);
+        assert_eq!(out.len(), 1);
+        let parsed: serde_json::Value = serde_json::from_str(&out[0]).unwrap();
+        assert_eq!(parsed["payload"]["truncated"], true);
+        assert_eq!(
+            parsed["payload"]["content"].as_str().unwrap().len(),
+            SHELL_MERGE_CAP
+        );
+    }
+
+    #[test]
+    fn truncation_respects_utf8_boundaries() {
+        // 4-byte scorpions guarantee the naive cut lands mid-char.
+        let chunk = "🦂".repeat(20 * 1024);
+        let batch = vec![
+            shell_frame(1, "t1", &chunk),
+            shell_frame(2, "t1", &chunk),
+        ];
+        let out = coalesce_batch(&batch);
+        let parsed: serde_json::Value = serde_json::from_str(&out[0]).unwrap();
+        let content = parsed["payload"]["content"].as_str().unwrap();
+        assert!(content.len() <= SHELL_MERGE_CAP);
+        assert!(content.chars().all(|c| c == '🦂'));
+    }
+
+    #[test]
+    fn single_frames_pass_through_byte_identical() {
+        let batch = vec![shell_frame(9, "t1", "solo"), other_frame(2)];
+        let out = coalesce_batch(&batch);
+        assert_eq!(out, vec![batch[0].wire.clone(), batch[1].wire.clone()]);
     }
 }

--- a/src/eventRoutes/mobileNav.test.ts
+++ b/src/eventRoutes/mobileNav.test.ts
@@ -16,6 +16,9 @@ describe("handleMobileNav", () => {
       active: "sessions",
       isSessions: true,
       isChat: false,
+      isTerminal: false,
+      isFiles: false,
+      isGit: false,
       isSettings: false,
     });
   });

--- a/src/eventRoutes/mobileNav.ts
+++ b/src/eventRoutes/mobileNav.ts
@@ -10,13 +10,16 @@
 import type { EventRouteHandler } from "./types";
 import { restoreSessionFromSelection } from "./sessionRestore";
 
-type Screen = "sessions" | "chat" | "settings";
+type Screen = "sessions" | "chat" | "terminal" | "files" | "git" | "settings";
 
 function screenFlags(active: Screen): Record<string, unknown> {
   return {
     active,
     isSessions: active === "sessions",
     isChat: active === "chat",
+    isTerminal: active === "terminal",
+    isFiles: active === "files",
+    isGit: active === "git",
     isSettings: active === "settings",
   };
 }
@@ -38,7 +41,14 @@ function setScreen(
   });
 }
 
-const SCREENS: readonly Screen[] = ["sessions", "chat", "settings"];
+const SCREENS: readonly Screen[] = [
+  "sessions",
+  "chat",
+  "terminal",
+  "files",
+  "git",
+  "settings",
+];
 
 function asScreen(value: unknown): Screen | undefined {
   return SCREENS.find((s) => s === value);

--- a/src/mobile/composites/mobile-file-list.tsx
+++ b/src/mobile/composites/mobile-file-list.tsx
@@ -1,0 +1,130 @@
+// Files screen — a touch drill-down over the active workspace root,
+// backed by the gateway's fs_list_dir (root-checked desktop-side). Read-
+// only: tapping a directory descends, tapping a file opens it read-only
+// in the mobile file viewer overlay (Phase 5). Self-contained drill
+// state (no app-state slice) keyed off the active workspace root.
+
+import { invoke } from "@tauri-apps/api/core";
+import { useCallback, useEffect, useState } from "react";
+
+import type { BuiltinComponentProps } from "../../components/A2UIRenderer";
+import { activeWorkspaceCwd } from "../../utils/activeWorkspaceRoot";
+
+interface FsEntry {
+  name: string;
+  isDir: boolean;
+}
+
+function joinRel(rel: string, name: string): string {
+  return rel ? `${rel}/${name}` : name;
+}
+
+function parentRel(rel: string): string {
+  const idx = rel.lastIndexOf("/");
+  return idx === -1 ? "" : rel.slice(0, idx);
+}
+
+export function MobileFileList({ state, onEvent }: BuiltinComponentProps) {
+  const root = activeWorkspaceCwd(state);
+  const [rel, setRel] = useState("");
+  const [entries, setEntries] = useState<FsEntry[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const load = useCallback(
+    async (nextRel: string) => {
+      if (!root) return;
+      setLoading(true);
+      try {
+        const raw = await invoke<Array<{ name: string; isDir?: boolean; is_dir?: boolean }>>(
+          "fs_list_dir",
+          { root, path: nextRel },
+        );
+        const list = (Array.isArray(raw) ? raw : []).map((e) => ({
+          name: e.name,
+          isDir: Boolean(e.isDir ?? e.is_dir),
+        }));
+        // Directories first, then case-insensitive by name.
+        list.sort((a, b) =>
+          a.isDir === b.isDir
+            ? a.name.localeCompare(b.name, undefined, { sensitivity: "base" })
+            : a.isDir
+              ? -1
+              : 1,
+        );
+        setEntries(list);
+        setError(null);
+      } catch (err) {
+        setError(String(err));
+        setEntries([]);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [root],
+  );
+
+  // Reload from the top when the root changes (workspace switch) or on
+  // first mount — a resync to the new dependency, not ongoing state.
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setRel("");
+    void load("");
+  }, [load]);
+
+  if (!root) {
+    return <p className="ae-mobile-files-empty">Open a project to browse files.</p>;
+  }
+
+  return (
+    <div className="ae-mobile-files">
+      <div className="ae-mobile-files-crumb">{rel || "/"}</div>
+      {error ? <p className="ae-mobile-files-error">{error}</p> : null}
+      <ul className="ae-mobile-file-rows">
+        {rel ? (
+          <li>
+            <button
+              type="button"
+              className="ae-mobile-file-row ae-mobile-file-row--up"
+              onClick={() => {
+                const up = parentRel(rel);
+                setRel(up);
+                void load(up);
+              }}
+            >
+              <span className="ae-mobile-file-glyph" aria-hidden>
+                ↑
+              </span>
+              ..
+            </button>
+          </li>
+        ) : null}
+        {entries.map((entry) => (
+          <li key={entry.name}>
+            <button
+              type="button"
+              className="ae-mobile-file-row"
+              onClick={() => {
+                if (entry.isDir) {
+                  const next = joinRel(rel, entry.name);
+                  setRel(next);
+                  void load(next);
+                } else {
+                  onEvent("open-file", { root, path: joinRel(rel, entry.name) });
+                }
+              }}
+            >
+              <span className="ae-mobile-file-glyph" aria-hidden>
+                {entry.isDir ? "▸" : "·"}
+              </span>
+              {entry.name}
+            </button>
+          </li>
+        ))}
+        {!loading && entries.length === 0 && !error ? (
+          <li className="ae-mobile-files-empty">Empty directory.</li>
+        ) : null}
+      </ul>
+    </div>
+  );
+}

--- a/src/mobile/composites/mobile-nav.tsx
+++ b/src/mobile/composites/mobile-nav.tsx
@@ -13,6 +13,9 @@ interface NavItem {
 const ITEMS: NavItem[] = [
   { screen: "sessions", label: "Sessions", glyph: "☰" },
   { screen: "chat", label: "Chat", glyph: "◆" },
+  { screen: "terminal", label: "Terminal", glyph: "⌘" },
+  { screen: "files", label: "Files", glyph: "▤" },
+  { screen: "git", label: "Git", glyph: "⑃" },
   { screen: "settings", label: "Settings", glyph: "⚙" },
 ];
 

--- a/src/mobile/mobile.a2ui.json
+++ b/src/mobile/mobile.a2ui.json
@@ -7,7 +7,12 @@
         "columns": { "$ref": "/layout/columns" },
         "rows": { "$ref": "/layout/rows" },
         "areas": { "$ref": "/layout/areas" },
-        "slotMap": { "sessions": "canvas" }
+        "slotMap": {
+          "sessions": "canvas",
+          "terminal-screen": "canvas",
+          "files": "canvas",
+          "git": "canvas"
+        }
       },
       "children": [
         {
@@ -56,6 +61,32 @@
           }
         },
         {
+          "id": "mobile-terminal-screen",
+          "type": "terminal-panel",
+          "props": {
+            "area": "terminal-screen",
+            "visible": { "$ref": "/mobileNav/isTerminal" },
+            "activeSubId": { "$ref": "/terminalPanel/activeSubId" }
+          }
+        },
+        {
+          "id": "mobile-files-screen",
+          "type": "mobile-file-list",
+          "props": {
+            "area": "files",
+            "visible": { "$ref": "/mobileNav/isFiles" }
+          }
+        },
+        {
+          "id": "mobile-git-screen",
+          "type": "source-control-panel",
+          "props": {
+            "area": "git",
+            "visible": { "$ref": "/mobileNav/isGit" },
+            "source": { "$ref": "/vcs" }
+          }
+        },
+        {
           "id": "mobile-composer",
           "type": "container",
           "props": {
@@ -86,6 +117,9 @@
       "active": "chat",
       "isSessions": false,
       "isChat": true,
+      "isTerminal": false,
+      "isFiles": false,
+      "isGit": false,
       "isSettings": false
     }
   }

--- a/src/mobile/mobileLayoutExtension.ts
+++ b/src/mobile/mobileLayoutExtension.ts
@@ -6,16 +6,21 @@
 
 import type { A2UIExtension } from "../extensions/types";
 import { ConnectionBadge } from "./composites/connection-badge";
+import { MobileFileList } from "./composites/mobile-file-list";
 import { MobileNav } from "./composites/mobile-nav";
 import { MobileSessions } from "./composites/mobile-sessions";
 import mobilePayload from "./mobile.a2ui.json";
 
+// The terminal + git screens reuse the default-layout composites
+// (terminal-panel, source-control-panel) — no mobile-specific variant
+// needed, just a touch-sized cell in the mobile layout.
 export const mobileLayoutExtension: A2UIExtension = {
   name: "mobile-layout",
   components: {
     "connection-badge": ConnectionBadge,
     "mobile-nav": MobileNav,
     "mobile-sessions": MobileSessions,
+    "mobile-file-list": MobileFileList,
   },
   layout: mobilePayload,
 };

--- a/src/styles/mobile.css
+++ b/src/styles/mobile.css
@@ -239,3 +239,60 @@
 .ae-mobile-composer {
   padding-bottom: var(--ae-safe-bottom);
 }
+
+/* Files screen */
+.ae-mobile-files {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow-y: auto;
+}
+.ae-mobile-files-crumb {
+  position: sticky;
+  top: 0;
+  padding: 8px 14px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.8rem;
+  color: var(--text-dim);
+  background: var(--bg);
+  border-bottom: 1px solid var(--border);
+}
+.ae-mobile-files-error {
+  color: var(--danger, #e5484d);
+  padding: 8px 14px;
+  margin: 0;
+  font-size: 0.85rem;
+}
+.ae-mobile-files-empty {
+  color: var(--text-dim);
+  padding: 24px 14px;
+  text-align: center;
+  list-style: none;
+}
+.ae-mobile-file-rows {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.ae-mobile-file-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  min-height: 44px;
+  padding: 8px 14px;
+  border: none;
+  border-bottom: 1px solid var(--border);
+  background: transparent;
+  color: var(--text);
+  font-size: 0.95rem;
+  text-align: left;
+  cursor: pointer;
+}
+.ae-mobile-file-row--up {
+  color: var(--text-dim);
+}
+.ae-mobile-file-glyph {
+  width: 1em;
+  color: var(--text-dim);
+}


### PR DESCRIPTION
## What & why

Phase 4 of the **iOS companion** (after #454/#455/#456). Opens the terminal, filesystem, and git surfaces to paired devices — gateway side (allow + root-validate the commands, tap their event streams) and mobile side (three new screens).

## Gateway

- **`RemotePolicy::DirectRootChecked`** — the relay validates a command's `root`/`cwd`/`projectPath` (shell_open's nested `cwd`) against the host's known **project + workspace roots** before dispatch. Roots come from the persisted `projects.json` (canonicalized, exact-match, ~5s TTL cache); the existing per-path fs jail (`resolve_inside_root` + canonicalize) still applies beneath. `fs` reads/writes, `git`/`gh` reads, and `shell_open` are root-checked; shell i/o keys by an already-open tab.
- **Still denied**: `git_worktree_*` (mutates repo layout), `fs_watch_*`, desktop-local openers, `pick_project_directory`.
- **New tapped topics**: `shell-output` / `shell-title` / `shell-exit` / `fs-tree-changed` / `git-state-changed`. The shared `subscribeShellStreams` re-fans `shell-output` to per-tab CustomEvents unchanged.
- **shell-output coalescing**: the WS session drains the hub in batches and merges *adjacent same-tab* `shell-output` frames into one wire frame (total order preserved — a run never spans another tab/topic). Runs over 64 KiB keep their tail (UTF-8-safe) and set `truncated:true` so the client resyncs via `shell_read_scrollback`. `agent-response` is still never coalesced.
- Per-tab `ShareMode` (agent gating) is untouched: a paired device driving *its own* shell is the user, not the agent.

## Mobile

- Bottom nav grows to six screens; the `mobileNav` route validates the new screen values (unknown → ignored, never a blank canvas).
- **Terminal** and **Git** reuse the desktop composites verbatim — `terminal-panel` (agent-bash stream + shell sub-tabs) and `source-control-panel` bound to `/vcs` — as touch-sized cells.
- **Files** is a new `mobile-file-list`: a drill-down over the root-checked `fs_list_dir` (directories-first, breadcrumb, up-nav, tap-to-open event), rooted via the shared `activeWorkspaceCwd`.

## Verification

- Rust: policy exhaustiveness + relay↔policy parity (now covering `DirectRootChecked`), root-arg extraction per command, allowed-roots parsing, canonical root matching (incl. traversal + missing-dir), shell-output coalescing (merge / order-preservation / 64 KiB truncation / UTF-8 boundary / single-frame passthrough).
- TS: mobileNav route tests for the new screens; `build:mobile` bundles the new layout.
- Full `check` gate green (2980 vitest, all Rust + clippy + tsc + eslint).

Next: Phase 5 (settings/dashboards, read-only file viewer, scheduled tasks, keep-alive, per-device rate limits).