### PR TITLE
feat(voice): cascade conversational voice agent

### DIFF
--- a/agent/aethon-api-dashboard.ts
+++ b/agent/aethon-api-dashboard.ts
@@ -26,6 +26,7 @@ async function dashboardQuery(
   deps: DashboardApiDeps,
   op:
     | "start_task"
+    | "send_followup"
     | "get_repo_overview"
     | "refresh"
     | "list_issues"
@@ -95,6 +96,21 @@ export function buildTasksApi(
         // large repo. 30s is the same ceiling as the shell-write ack
         // pattern, which is the closest existing precedent.
         30_000,
+      );
+    },
+    sendFollowup: (input) => {
+      if (!input || typeof input.tabId !== "string" || !input.tabId) {
+        return Promise.resolve({ ok: false, error: "tabId required" });
+      }
+      if (typeof input.prompt !== "string" || !input.prompt.trim()) {
+        return Promise.resolve({ ok: false, error: "prompt required" });
+      }
+      return dashboardQuery(
+        state,
+        deps,
+        "send_followup",
+        { tabId: input.tabId, prompt: input.prompt },
+        15_000,
       );
     },
   };

--- a/agent/aethon-api.ts
+++ b/agent/aethon-api.ts
@@ -134,6 +134,9 @@ export interface TasksApi {
     /** Optional label for the launched tab. */
     label?: string;
   }): Promise<MutationResult>;
+  /** Send a follow-up message to an existing agent tab through the normal
+   *  chat pipeline (queues behind an in-flight prompt). */
+  sendFollowup(input: { tabId: string; prompt: string }): Promise<MutationResult>;
 }
 
 /** Agent-side counterpart to the repo overview / refresh affordances on

--- a/agent/dispatcher.ts
+++ b/agent/dispatcher.ts
@@ -50,6 +50,8 @@ function voiceBrainFor(
   return ensureVoiceBrain(state, {
     send: deps.send,
     startTask: (input) => buildTasksApi(state, { send: deps.send }).start(input),
+    sendFollowup: (input) =>
+      buildTasksApi(state, { send: deps.send }).sendFollowup(input),
   });
 }
 

--- a/agent/dispatcher.ts
+++ b/agent/dispatcher.ts
@@ -30,12 +30,28 @@ import { handleMirroredTabsChanged } from "./aethon-api-sessions";
 import { handleNativeSlashCommand } from "./nativeSlash";
 import { handleSetProject } from "./projectLifecycle";
 import { handleAuthProfileMessage } from "./auth-profiles";
+import { buildTasksApi } from "./aethon-api-dashboard";
+import { ensureVoiceBrain } from "./voice/brain";
+import { parseVoiceTaskEvent, parseVoiceTurn } from "./voice/protocol";
 import {
   handleLocalChatMessage,
   handleSetSessionLabel,
   handleTabClose,
   handleTabOpen,
 } from "./tabs";
+
+/** Voice-brain singleton bound to this bridge's send + task-launch path.
+ *  `tasks.start` rides the same `dashboard_query op:"start_task"` round-trip
+ *  the dashboard tools use. */
+function voiceBrainFor(
+  state: AethonAgentState,
+  deps: DispatcherDeps,
+): ReturnType<typeof ensureVoiceBrain> {
+  return ensureVoiceBrain(state, {
+    send: deps.send,
+    startTask: (input) => buildTasksApi(state, { send: deps.send }).start(input),
+  });
+}
 
 function mirrorNativeWindowsFromFrontend(
   state: AethonAgentState,
@@ -279,6 +295,33 @@ export async function dispatchInboundMessage(
         break;
       case "fork_session":
         await handleForkSession(state, deps, msg);
+        break;
+      case "voice_turn": {
+        const turn = parseVoiceTurn(msg);
+        if (!turn) {
+          deps.send({ type: "error", message: "voice_turn: missing text" });
+          break;
+        }
+        voiceBrainFor(state, deps).handleTurn(turn);
+        break;
+      }
+      case "voice_task_event": {
+        const event = parseVoiceTaskEvent(msg);
+        if (!event) {
+          deps.send({
+            type: "error",
+            message: "voice_task_event: missing taskTabId",
+          });
+          break;
+        }
+        voiceBrainFor(state, deps).handleTaskEvent(event);
+        break;
+      }
+      case "voice_brain_abort":
+        await state.voiceBrain?.abort();
+        break;
+      case "voice_session_reset":
+        await state.voiceBrain?.reset();
         break;
       case "devshell_event": {
         const status = msg.devshellStatus;

--- a/agent/dispatcherTypes.ts
+++ b/agent/dispatcherTypes.ts
@@ -91,6 +91,14 @@ export interface InboundMessage {
   devshellStatus?: "ready" | "failed" | "resolving";
   devshellRoot?: string;
   devshellKind?: string;
+  /** Voice-brain fields (`voice_turn` / `voice_task_event`). Tab references
+   *  ride as activeTabId/taskTabId inside these, never top-level `tabId`, so
+   *  the Rust router keeps them on the global bridge. */
+  text?: string;
+  context?: unknown;
+  taskTabId?: string;
+  status?: string;
+  finalText?: string;
 }
 
 export async function emitGlobalReady(

--- a/agent/state.ts
+++ b/agent/state.ts
@@ -80,6 +80,7 @@ import type { AethonApi } from "./aethon-api";
 export type AethonExtensionApi = AethonApi;
 
 import type { LoadSubagentsResult } from "./subagents/types";
+import type { VoiceBrain } from "./voice/brain";
 import { DEFAULT_AGENT_TIMEOUT_SECONDS } from "./runtime-config";
 
 export interface AethonExtensionModule {
@@ -509,6 +510,12 @@ export class AethonAgentState {
   /** Persisted per-tab session directories discovered at boot. Shipped
    *  in `ready` so the frontend can offer "Recent sessions". */
   discoveredTabs: DiscoveredTab[] = [];
+
+  // -- Voice brain ----------------------------------------------------------
+  /** Singleton conversational session for the hands-free voice mode. Lazily
+   *  created on the first `voice_turn` (global bridge only — the Rust router
+   *  never sends voice_* messages to tab workers). See agent/voice/brain.ts. */
+  voiceBrain: VoiceBrain | undefined = undefined;
 
   /** Per-turn tabId propagated through the async call chain that runs
    *  inside session.prompt(). Concurrent prompts on different tabs each

--- a/agent/subagents/inline-runner.ts
+++ b/agent/subagents/inline-runner.ts
@@ -38,8 +38,9 @@ interface ResolvedModelServices {
 
 /** Resolve the model AND its matching auth/model services together (see
  *  {@link servicesForProvider}). Returns null when an explicit model can't be
- *  found in its provider's registry. */
-function resolveModelServices(
+ *  found in its provider's registry. Also used by the voice brain
+ *  (agent/voice/brain.ts) to pin its own session model. */
+export function resolveModelServices(
   state: AethonAgentState,
   parentTabId: string,
   modelId: string | undefined,

--- a/agent/voice/brain.test.ts
+++ b/agent/voice/brain.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, it } from "vitest";
+import type { AethonAgentState } from "../state";
+import { VoiceBrain, type BrainSession } from "./brain";
+import { VOICE_BRAIN_PREAMBLE } from "./prompt";
+import type { ToolDefinition } from "@mariozechner/pi-coding-agent";
+
+type SentMessage = Record<string, unknown>;
+
+/** Deterministic BrainSession: `respond` scripts what the model "does" when
+ *  prompted (emit deltas, call tools, hang, throw). */
+class FakeSession implements BrainSession {
+  promptCalls: string[] = [];
+  aborted = 0;
+  disposed = 0;
+  respond:
+    | ((prompt: string, session: FakeSession) => Promise<void> | void)
+    | undefined;
+  private listener: ((ev: { type: string } & Record<string, unknown>) => void)
+    | undefined;
+  private hangResolve: (() => void) | undefined;
+
+  subscribe(
+    listener: (ev: { type: string } & Record<string, unknown>) => void,
+  ): () => void {
+    this.listener = listener;
+    return () => {
+      this.listener = undefined;
+    };
+  }
+
+  async prompt(text: string): Promise<void> {
+    this.promptCalls.push(text);
+    if (this.respond) {
+      await this.respond(text, this);
+      return;
+    }
+    // Default: hang until abort.
+    await new Promise<void>((resolve) => {
+      this.hangResolve = resolve;
+    });
+  }
+
+  abort(): Promise<void> {
+    this.aborted += 1;
+    this.hangResolve?.();
+    this.hangResolve = undefined;
+    return Promise.resolve();
+  }
+
+  dispose(): void {
+    this.disposed += 1;
+  }
+
+  emitText(delta: string): void {
+    this.listener?.({
+      type: "message_update",
+      assistantMessageEvent: { type: "text_delta", delta },
+    });
+  }
+
+  emitEnd(messages: unknown[] = []): void {
+    this.listener?.({ type: "agent_end", messages });
+  }
+}
+
+function makeState(): AethonAgentState {
+  return { tabs: new Map() } as unknown as AethonAgentState;
+}
+
+function makeBrain(session: FakeSession) {
+  const sent: SentMessage[] = [];
+  const startCalls: Record<string, unknown>[] = [];
+  let capturedTools: ToolDefinition[] = [];
+  const brain = new VoiceBrain(
+    makeState(),
+    {
+      send: (obj) => sent.push(obj),
+      startTask: (input) => {
+        startCalls.push(input);
+        return Promise.resolve({ ok: true, data: { tabId: "tab-7" } });
+      },
+    },
+    (options) => {
+      capturedTools = options.customTools;
+      return Promise.resolve(session);
+    },
+  );
+  return {
+    brain,
+    sent,
+    startCalls,
+    tools: () => capturedTools,
+  };
+}
+
+async function until(
+  condition: () => boolean,
+  what: string,
+  ms = 2_000,
+): Promise<void> {
+  const deadline = Date.now() + ms;
+  while (!condition()) {
+    if (Date.now() > deadline) throw new Error(`timed out waiting for ${what}`);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+const ofType = (sent: SentMessage[], type: string) =>
+  sent.filter((message) => message.type === type);
+
+describe("VoiceBrain turns", () => {
+  it("streams deltas and ends with the accumulated reply", async () => {
+    const session = new FakeSession();
+    session.respond = (_prompt, s) => {
+      s.emitText("Sure, ");
+      s.emitText("starting now.");
+      s.emitEnd();
+    };
+    const { brain, sent } = makeBrain(session);
+
+    brain.handleTurn({ type: "voice_turn", text: "fix the tests", context: {} });
+    await until(() => ofType(sent, "voice_brain_end").length === 1, "end");
+
+    expect(ofType(sent, "voice_brain_delta").map((m) => m.text)).toEqual([
+      "Sure, ",
+      "starting now.",
+    ]);
+    expect(ofType(sent, "voice_brain_end")[0]?.text).toBe(
+      "Sure, starting now.",
+    );
+    expect(ofType(sent, "voice_brain_error")).toHaveLength(0);
+  });
+
+  it("sends the preamble on the first prompt only", async () => {
+    const session = new FakeSession();
+    session.respond = (_prompt, s) => {
+      s.emitText("ok");
+      s.emitEnd();
+    };
+    const { brain, sent } = makeBrain(session);
+
+    brain.handleTurn({ type: "voice_turn", text: "one", context: {} });
+    await until(() => ofType(sent, "voice_brain_end").length === 1, "end 1");
+    brain.handleTurn({ type: "voice_turn", text: "two", context: {} });
+    await until(() => ofType(sent, "voice_brain_end").length === 2, "end 2");
+
+    expect(session.promptCalls[0]).toContain(VOICE_BRAIN_PREAMBLE);
+    expect(session.promptCalls[1]).not.toContain(VOICE_BRAIN_PREAMBLE);
+  });
+
+  it("reports dispatches made during the turn on voice_brain_end", async () => {
+    const session = new FakeSession();
+    const h = makeBrain(session);
+    session.respond = async (_prompt, s) => {
+      const dispatch = h
+        .tools()
+        .find((tool) => tool.name === "dispatch_task") as unknown as {
+        execute: (...args: unknown[]) => Promise<unknown>;
+      };
+      await dispatch.execute(
+        "call-1",
+        { prompt: "do the thing", label: "the thing" },
+        undefined,
+        undefined,
+      );
+      s.emitText("On it.");
+      s.emitEnd();
+    };
+
+    h.brain.handleTurn({
+      type: "voice_turn",
+      text: "please do the thing",
+      context: { projectPath: "/repo", defaultModel: "anthropic/claude-x" },
+    });
+    await until(() => ofType(h.sent, "voice_brain_end").length === 1, "end");
+
+    expect(h.startCalls).toHaveLength(1);
+    expect(ofType(h.sent, "voice_brain_end")[0]?.dispatched).toEqual({
+      tabId: "tab-7",
+      label: "the thing",
+    });
+  });
+
+  it("supersedes an in-flight turn without a stale terminal event", async () => {
+    const session = new FakeSession();
+    const { brain, sent } = makeBrain(session);
+
+    // First turn hangs (default respond) until superseded.
+    brain.handleTurn({ type: "voice_turn", text: "first", context: {} });
+    await until(() => session.promptCalls.length === 1, "first prompt");
+
+    session.respond = (_prompt, s) => {
+      s.emitText("second reply");
+      s.emitEnd();
+    };
+    brain.handleTurn({ type: "voice_turn", text: "second", context: {} });
+    await until(() => ofType(sent, "voice_brain_end").length === 1, "end");
+
+    expect(session.aborted).toBeGreaterThanOrEqual(1);
+    expect(ofType(sent, "voice_brain_end")).toHaveLength(1);
+    expect(ofType(sent, "voice_brain_end")[0]?.text).toBe("second reply");
+    expect(ofType(sent, "voice_brain_error")).toHaveLength(0);
+  });
+
+  it("emits voice_brain_error when the prompt rejects and retries the preamble", async () => {
+    const session = new FakeSession();
+    let failures = 0;
+    session.respond = (_prompt, s) => {
+      if (failures === 0) {
+        failures += 1;
+        throw new Error("provider exploded");
+      }
+      s.emitText("recovered");
+      s.emitEnd();
+    };
+    const { brain, sent } = makeBrain(session);
+
+    brain.handleTurn({ type: "voice_turn", text: "hello", context: {} });
+    await until(() => ofType(sent, "voice_brain_error").length === 1, "error");
+    expect(ofType(sent, "voice_brain_error")[0]?.message).toContain(
+      "provider exploded",
+    );
+
+    brain.handleTurn({ type: "voice_turn", text: "again", context: {} });
+    await until(() => ofType(sent, "voice_brain_end").length === 1, "recovery");
+    // The failed first prompt didn't burn the preamble.
+    expect(session.promptCalls[1]).toContain(VOICE_BRAIN_PREAMBLE);
+  });
+
+  it("falls back to agent_end text when no deltas streamed", async () => {
+    const session = new FakeSession();
+    session.respond = (_prompt, s) => {
+      s.emitEnd([
+        { role: "assistant", content: [{ type: "text", text: "from end" }] },
+      ]);
+    };
+    const { brain, sent } = makeBrain(session);
+    brain.handleTurn({ type: "voice_turn", text: "hi", context: {} });
+    await until(() => ofType(sent, "voice_brain_end").length === 1, "end");
+    expect(ofType(sent, "voice_brain_end")[0]?.text).toBe("from end");
+  });
+});
+
+describe("VoiceBrain task events", () => {
+  it("prompts a summary with the known label and marks the task done", async () => {
+    const session = new FakeSession();
+    const h = makeBrain(session);
+    // Seed a dispatch first.
+    session.respond = async (_prompt, s) => {
+      const dispatch = h
+        .tools()
+        .find((tool) => tool.name === "dispatch_task") as unknown as {
+        execute: (...args: unknown[]) => Promise<unknown>;
+      };
+      await dispatch.execute(
+        "call-1",
+        { prompt: "fix flaky test" },
+        undefined,
+        undefined,
+      );
+      s.emitText("Dispatched.");
+      s.emitEnd();
+    };
+    h.brain.handleTurn({
+      type: "voice_turn",
+      text: "fix the flaky test",
+      context: { projectPath: "/repo", defaultModel: "m/x" },
+    });
+    await until(() => ofType(h.sent, "voice_brain_end").length === 1, "turn");
+
+    session.respond = (_prompt, s) => {
+      s.emitText("All done, tests are green.");
+      s.emitEnd();
+    };
+    h.brain.handleTaskEvent({
+      type: "voice_task_event",
+      taskTabId: "tab-7",
+      status: "completed",
+      finalText: "Fixed by adding waitFor. All 42 tests pass.",
+    });
+    await until(
+      () => ofType(h.sent, "voice_brain_end").length === 2,
+      "summary",
+    );
+
+    const summaryPrompt = session.promptCalls[1] ?? "";
+    expect(summaryPrompt).toContain("system note");
+    expect(summaryPrompt).toContain("fix flaky test");
+    expect(summaryPrompt).toContain("All 42 tests pass.");
+    expect(h.brain.isDispatchedTab("tab-7")).toBe(true);
+  });
+});

--- a/agent/voice/brain.test.ts
+++ b/agent/voice/brain.test.ts
@@ -308,4 +308,68 @@ describe("VoiceBrain task events", () => {
     expect(progressPrompt).toContain("still working");
     expect(progressPrompt).toContain("Running vitest against the suite.");
   });
+
+  it("defers a completion arriving mid-turn instead of superseding it", async () => {
+    const session = new FakeSession();
+    const h = makeBrain(session);
+    let releaseTurn: (() => void) | undefined;
+    session.respond = (_prompt, s) =>
+      new Promise<void>((resolve) => {
+        releaseTurn = () => {
+          s.emitText("Here is your answer.");
+          s.emitEnd();
+          resolve();
+        };
+      });
+
+    h.brain.handleTurn({ type: "voice_turn", text: "explain the build" });
+    await until(() => session.promptCalls.length === 1, "turn start");
+
+    // Background task completes while the user's answer is streaming.
+    h.brain.handleTaskEvent({
+      type: "voice_task_event",
+      taskTabId: "tab-9",
+      status: "completed",
+      finalText: "Task finished cleanly.",
+    });
+    expect(session.promptCalls).toHaveLength(1);
+    expect(session.aborted).toBe(0);
+
+    session.respond = (_prompt, s) => {
+      s.emitText("That background task wrapped up.");
+      s.emitEnd();
+    };
+    releaseTurn?.();
+    await until(
+      () => ofType(h.sent, "voice_brain_end").length === 2,
+      "deferred announcement",
+    );
+    expect(ofType(h.sent, "voice_brain_end")[0]?.text).toBe(
+      "Here is your answer.",
+    );
+    expect(session.promptCalls[1]).toContain("Task finished cleanly.");
+
+    // Progress digests are dropped, not queued, while a turn is active.
+    session.respond = (_prompt, s) =>
+      new Promise<void>((resolve) => {
+        releaseTurn = () => {
+          s.emitEnd();
+          resolve();
+        };
+      });
+    h.brain.handleTurn({ type: "voice_turn", text: "another question" });
+    await until(() => session.promptCalls.length === 3, "third turn");
+    h.brain.handleTaskEvent({
+      type: "voice_task_event",
+      taskTabId: "tab-9",
+      status: "progress",
+      finalText: "still going",
+    });
+    releaseTurn?.();
+    await until(
+      () => ofType(h.sent, "voice_brain_end").length === 3,
+      "third end",
+    );
+    expect(session.promptCalls).toHaveLength(3);
+  });
 });

--- a/agent/voice/brain.test.ts
+++ b/agent/voice/brain.test.ts
@@ -289,5 +289,23 @@ describe("VoiceBrain task events", () => {
     expect(summaryPrompt).toContain("fix flaky test");
     expect(summaryPrompt).toContain("All 42 tests pass.");
     expect(h.brain.isDispatchedTab("tab-7")).toBe(true);
+
+    session.respond = (_prompt, s) => {
+      s.emitText("Still checking the test harness.");
+      s.emitEnd();
+    };
+    h.brain.handleTaskEvent({
+      type: "voice_task_event",
+      taskTabId: "tab-7",
+      status: "progress",
+      finalText: "Running vitest against the suite.",
+    });
+    await until(
+      () => ofType(h.sent, "voice_brain_end").length === 3,
+      "progress",
+    );
+    const progressPrompt = session.promptCalls[2] ?? "";
+    expect(progressPrompt).toContain("still working");
+    expect(progressPrompt).toContain("Running vitest against the suite.");
   });
 });

--- a/agent/voice/brain.test.ts
+++ b/agent/voice/brain.test.ts
@@ -79,6 +79,7 @@ function makeBrain(session: FakeSession) {
         startCalls.push(input);
         return Promise.resolve({ ok: true, data: { tabId: "tab-7" } });
       },
+      sendFollowup: () => Promise.resolve({ ok: true }),
     },
     (options) => {
       capturedTools = options.customTools;

--- a/agent/voice/brain.ts
+++ b/agent/voice/brain.ts
@@ -117,10 +117,11 @@ export class VoiceBrain {
     );
   }
 
-  /** A dispatched work agent finished a turn. */
+  /** A dispatched work agent finished a turn — or, for `progress` events,
+   *  is still mid-task (those must not flip the tracked status). */
   handleTaskEvent(msg: VoiceTaskEventMessage): void {
     const known = this.dispatched.get(msg.taskTabId);
-    if (known) {
+    if (known && msg.status !== "progress") {
       known.status = msg.status === "error" ? "error" : "completed";
     }
     void this.runPrompt(

--- a/agent/voice/brain.ts
+++ b/agent/voice/brain.ts
@@ -70,6 +70,8 @@ export interface BrainSession {
   prompt(text: string): Promise<unknown>;
   abort(): Promise<unknown>;
   dispose(): void;
+  /** Present on real pi sessions; the brain pins reasoning to the floor. */
+  setThinkingLevel?(level: "minimal"): void;
 }
 
 export type BrainSessionFactory = (options: {
@@ -330,6 +332,15 @@ export class VoiceBrain {
       noTools: "builtin",
       customTools: options.customTools,
     });
+    // Voice needs first-token latency, not reasoning depth. Without this the
+    // brain inherits the chat default (e.g. gpt-5.5 at "high"), and every
+    // spoken turn stalls for the model's whole thinking budget before a word
+    // comes back. No-op for models without thinking levels.
+    try {
+      session.setThinkingLevel?.("minimal");
+    } catch {
+      /* model rejects thinking control — proceed with its default */
+    }
     return session;
   }
 }

--- a/agent/voice/brain.ts
+++ b/agent/voice/brain.ts
@@ -54,6 +54,11 @@ export interface VoiceBrainDeps {
     activate: boolean;
     label?: string;
   }) => Promise<{ ok: boolean; error?: string; data?: unknown }>;
+  /** Steer an existing task tab (`aethon.tasks.sendFollowup`). */
+  sendFollowup: (input: {
+    tabId: string;
+    prompt: string;
+  }) => Promise<{ ok: boolean; error?: string; data?: unknown }>;
 }
 
 /** Structural slice of pi's AgentSession the brain needs — keeps tests to a
@@ -231,6 +236,7 @@ export class VoiceBrain {
       cwd: this.context.projectPath ?? process.cwd(),
       customTools: buildVoiceBrainTools({
         startTask: (input) => this.deps.startTask(input),
+        sendFollowup: (input) => this.deps.sendFollowup(input),
         getContext: () => this.context,
         onDispatched: (task) => {
           this.dispatched.set(task.tabId, task);

--- a/agent/voice/brain.ts
+++ b/agent/voice/brain.ts
@@ -26,6 +26,7 @@ import {
 } from "../subagents/progress-events";
 import { withTimeout } from "../subagents/timeout";
 import {
+  VOICE_BRAIN_PREAMBLE,
   buildTaskEventPrompt,
   buildTurnPrompt,
 } from "./prompt";
@@ -131,14 +132,21 @@ export class VoiceBrain {
    *  parked and delivered after the current turn settles (progress digests
    *  are dropped instead — they're periodic, the next tick re-reports). */
   handleTaskEvent(msg: VoiceTaskEventMessage): void {
+    if (msg.context) this.context = { ...this.context, ...msg.context };
     const known = this.dispatched.get(msg.taskTabId);
     if (known && msg.status !== "progress") {
       known.status = msg.status === "error" ? "error" : "completed";
     }
-    const prompt = buildTaskEventPrompt({
+    const body = buildTaskEventPrompt({
       ...msg,
       ...(msg.label ? {} : known?.label ? { label: known.label } : {}),
     });
+    // Task events are the brain's PRIMARY input (transcripts go straight to
+    // the work agent), so the speakable-prose preamble must ride the first
+    // one — it is no longer guaranteed that a voice_turn ever arrives.
+    const prompt = this.firstPrompt
+      ? `${VOICE_BRAIN_PREAMBLE}\n\n---\n\n${body}`
+      : body;
     if (this.turnActive) {
       if (msg.status !== "progress") this.deferredTaskPrompts.push(prompt);
       return;

--- a/agent/voice/brain.ts
+++ b/agent/voice/brain.ts
@@ -92,6 +92,9 @@ export class VoiceBrain {
   /** Monotonic turn id; stale turns must not emit terminal events. */
   private generation = 0;
   private turnActive = false;
+  /** Completion/error announcements that arrived mid-turn, delivered once
+   *  the active turn settles (never allowed to supersede a user exchange). */
+  private deferredTaskPrompts: string[] = [];
   private firstPrompt = true;
   private replyText = "";
   private endError: string | undefined;
@@ -118,18 +121,27 @@ export class VoiceBrain {
   }
 
   /** A dispatched work agent finished a turn — or, for `progress` events,
-   *  is still mid-task (those must not flip the tracked status). */
+   *  is still mid-task (those must not flip the tracked status).
+   *
+   *  A task event must never SUPERSEDE the user's in-flight exchange the way
+   *  a fresh voice turn does — a background task finishing mid-answer would
+   *  silently cancel the answer. While a turn is active the announcement is
+   *  parked and delivered after the current turn settles (progress digests
+   *  are dropped instead — they're periodic, the next tick re-reports). */
   handleTaskEvent(msg: VoiceTaskEventMessage): void {
     const known = this.dispatched.get(msg.taskTabId);
     if (known && msg.status !== "progress") {
       known.status = msg.status === "error" ? "error" : "completed";
     }
-    void this.runPrompt(
-      buildTaskEventPrompt({
-        ...msg,
-        ...(msg.label ? {} : known?.label ? { label: known.label } : {}),
-      }),
-    );
+    const prompt = buildTaskEventPrompt({
+      ...msg,
+      ...(msg.label ? {} : known?.label ? { label: known.label } : {}),
+    });
+    if (this.turnActive) {
+      if (msg.status !== "progress") this.deferredTaskPrompts.push(prompt);
+      return;
+    }
+    void this.runPrompt(prompt);
   }
 
   /** Barge-in: kill the in-flight brain turn (its terminal event is
@@ -162,6 +174,7 @@ export class VoiceBrain {
     this.session = undefined;
     this.sessionModelKey = undefined;
     this.dispatched.clear();
+    this.deferredTaskPrompts = [];
     this.firstPrompt = true;
   }
 
@@ -212,8 +225,27 @@ export class VoiceBrain {
       if (includedPreamble) this.firstPrompt = true;
       this.emitError(err, generation);
     } finally {
-      if (generation === this.generation) this.turnActive = false;
+      if (generation === this.generation) {
+        this.turnActive = false;
+        this.drainDeferredTaskPrompts();
+      }
     }
+  }
+
+  /** Deliver one parked task announcement after the active turn settled.
+   *  One at a time: each delivery is itself a turn whose completion drains
+   *  the next, so announcements queue instead of superseding each other. */
+  private drainDeferredTaskPrompts(): void {
+    const next = this.deferredTaskPrompts.shift();
+    if (next === undefined) return;
+    queueMicrotask(() => {
+      if (this.turnActive) {
+        // A user turn slipped in between settle and drain — re-park.
+        this.deferredTaskPrompts.unshift(next);
+        return;
+      }
+      void this.runPrompt(next);
+    });
   }
 
   private emitError(err: unknown, generation: number): void {

--- a/agent/voice/brain.ts
+++ b/agent/voice/brain.ts
@@ -1,0 +1,305 @@
+/**
+ * The voice brain — a persistent pi session that converses with the user by
+ * voice, dispatches real work to work-agent tabs, and summarizes results
+ * back into speakable prose.
+ *
+ * One in-memory session per bridge process (global bridge only — the Rust
+ * router never sends voice_* messages to tab workers). The session persists
+ * across turns so announcements stay grounded in conversation context
+ * ("that flaky-test fix you asked for is done"). Prompts are fire-and-forget
+ * from the dispatcher (mirroring chat.ts) — deltas stream out as
+ * `voice_brain_delta`, and each turn terminates with exactly one
+ * `voice_brain_end` or `voice_brain_error`.
+ */
+
+import {
+  SessionManager,
+  createAgentSession,
+} from "@mariozechner/pi-coding-agent";
+import type { AethonAgentState } from "../state";
+import { extractAgentEndError } from "../agent-errors";
+import { logger } from "../logger";
+import { resolveModelServices } from "../subagents/inline-runner";
+import {
+  extractLastAssistantText,
+  handleSubagentEvent,
+} from "../subagents/progress-events";
+import { withTimeout } from "../subagents/timeout";
+import {
+  buildTaskEventPrompt,
+  buildTurnPrompt,
+} from "./prompt";
+import type {
+  VoiceTaskEventMessage,
+  VoiceTurnContext,
+  VoiceTurnMessage,
+} from "./protocol";
+import {
+  buildVoiceBrainTools,
+  type DispatchedTask,
+} from "./tools";
+
+/** A spoken reply should come fast; a brain turn that runs this long is
+ *  wedged, not thinking. */
+const VOICE_BRAIN_TIMEOUT_MS = 120_000;
+
+export interface VoiceBrainDeps {
+  send: (obj: Record<string, unknown>) => void;
+  /** `aethon.tasks.start`-shaped launcher (the real one comes from
+   *  buildTasksApi; tests inject a fake). */
+  startTask: (input: {
+    projectPath: string;
+    prompt: string;
+    model: string;
+    activate: boolean;
+    label?: string;
+  }) => Promise<{ ok: boolean; error?: string; data?: unknown }>;
+}
+
+/** Structural slice of pi's AgentSession the brain needs — keeps tests to a
+ *  four-method fake. */
+export interface BrainSession {
+  subscribe(
+    listener: (event: { type: string } & Record<string, unknown>) => void,
+  ): () => void;
+  prompt(text: string): Promise<unknown>;
+  abort(): Promise<unknown>;
+  dispose(): void;
+}
+
+export type BrainSessionFactory = (options: {
+  modelId: string | undefined;
+  cwd: string;
+  customTools: ReturnType<typeof buildVoiceBrainTools>;
+}) => Promise<BrainSession>;
+
+export class VoiceBrain {
+  private readonly state: AethonAgentState;
+  private readonly deps: VoiceBrainDeps;
+  private readonly createSession: BrainSessionFactory;
+
+  private session: BrainSession | undefined;
+  private sessionModelKey: string | undefined;
+  private unsubscribe: (() => void) | undefined;
+  private context: VoiceTurnContext = {};
+  private readonly dispatched = new Map<string, DispatchedTask>();
+
+  /** Monotonic turn id; stale turns must not emit terminal events. */
+  private generation = 0;
+  private turnActive = false;
+  private firstPrompt = true;
+  private replyText = "";
+  private endError: string | undefined;
+  private lastDispatched: { tabId: string; label: string } | undefined;
+
+  constructor(
+    state: AethonAgentState,
+    deps: VoiceBrainDeps,
+    createSession?: BrainSessionFactory,
+  ) {
+    this.state = state;
+    this.deps = deps;
+    this.createSession =
+      createSession ?? ((options) => this.defaultCreateSession(options));
+  }
+
+  /** User finished a spoken turn. Fire-and-forget (dispatcher must not block
+   *  on a whole model turn — mirrors handleChat). */
+  handleTurn(msg: VoiceTurnMessage): void {
+    this.context = { ...this.context, ...msg.context };
+    void this.runPrompt(
+      buildTurnPrompt(msg.text, this.context, this.firstPrompt),
+    );
+  }
+
+  /** A dispatched work agent finished a turn. */
+  handleTaskEvent(msg: VoiceTaskEventMessage): void {
+    const known = this.dispatched.get(msg.taskTabId);
+    if (known) {
+      known.status = msg.status === "error" ? "error" : "completed";
+    }
+    void this.runPrompt(
+      buildTaskEventPrompt({
+        ...msg,
+        ...(msg.label ? {} : known?.label ? { label: known.label } : {}),
+      }),
+    );
+  }
+
+  /** Barge-in: kill the in-flight brain turn (its terminal event is
+   *  suppressed by the generation guard). */
+  async abort(): Promise<void> {
+    if (!this.session || !this.turnActive) return;
+    this.generation += 1;
+    this.turnActive = false;
+    try {
+      await this.session.abort();
+    } catch (err) {
+      logger
+        .scope("voice-brain")
+        .warn(
+          `abort failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+    }
+  }
+
+  /** Drop the session (conversation ended / model changed via settings). */
+  async reset(): Promise<void> {
+    await this.abort();
+    this.unsubscribe?.();
+    this.unsubscribe = undefined;
+    try {
+      this.session?.dispose();
+    } catch {
+      /* ignore */
+    }
+    this.session = undefined;
+    this.sessionModelKey = undefined;
+    this.dispatched.clear();
+    this.firstPrompt = true;
+  }
+
+  /** Is this tab one of ours? (Frontend also tracks this; defensive.) */
+  isDispatchedTab(tabId: string): boolean {
+    return this.dispatched.has(tabId);
+  }
+
+  private async runPrompt(prompt: string): Promise<void> {
+    if (this.turnActive) {
+      // Supersede: the newest input wins (matches how the conversation
+      // engine supersedes speech).
+      await this.abort();
+    }
+    const generation = ++this.generation;
+
+    let session: BrainSession;
+    try {
+      session = await this.ensureSession();
+    } catch (err) {
+      this.emitError(err, generation);
+      return;
+    }
+
+    this.turnActive = true;
+    this.replyText = "";
+    this.endError = undefined;
+    this.lastDispatched = undefined;
+    const includedPreamble = this.firstPrompt;
+    this.firstPrompt = false;
+
+    try {
+      await withTimeout(session.prompt(prompt), VOICE_BRAIN_TIMEOUT_MS, () => {
+        void session.abort();
+      });
+      if (generation !== this.generation) return;
+      if (this.endError) {
+        this.emitError(this.endError, generation);
+        return;
+      }
+      this.deps.send({
+        type: "voice_brain_end",
+        text: this.replyText.trim(),
+        ...(this.lastDispatched ? { dispatched: this.lastDispatched } : {}),
+      });
+    } catch (err) {
+      // A failed first prompt must not permanently swallow the preamble.
+      if (includedPreamble) this.firstPrompt = true;
+      this.emitError(err, generation);
+    } finally {
+      if (generation === this.generation) this.turnActive = false;
+    }
+  }
+
+  private emitError(err: unknown, generation: number): void {
+    if (generation !== this.generation) return;
+    const message = err instanceof Error ? err.message : String(err);
+    logger.scope("voice-brain").warn(`turn failed: ${message}`);
+    this.deps.send({ type: "voice_brain_error", message });
+  }
+
+  private async ensureSession(): Promise<BrainSession> {
+    const modelKey = this.context.brainModel?.trim() ?? "";
+    if (this.session && this.sessionModelKey === modelKey) {
+      return this.session;
+    }
+    // Model changed (or first turn): rebuild. Conversation context is lost on
+    // a model switch — acceptable; switching models mid-conversation is rare.
+    await this.reset();
+
+    const session = await this.createSession({
+      modelId: modelKey || undefined,
+      cwd: this.context.projectPath ?? process.cwd(),
+      customTools: buildVoiceBrainTools({
+        startTask: (input) => this.deps.startTask(input),
+        getContext: () => this.context,
+        onDispatched: (task) => {
+          this.dispatched.set(task.tabId, task);
+          this.lastDispatched = { tabId: task.tabId, label: task.label };
+        },
+        listTasks: () => [...this.dispatched.values()],
+        countRunningTabs: () =>
+          [...this.state.tabs.values()].filter((tab) => tab.promptInFlight)
+            .length,
+      }),
+    });
+
+    this.unsubscribe = session.subscribe((event) => {
+      handleSubagentEvent(event, {
+        onText: (delta) => {
+          this.replyText += delta;
+          this.deps.send({ type: "voice_brain_delta", text: delta });
+        },
+        onThinking: () => {},
+        onToolStart: () => {},
+        onToolEnd: () => {},
+        onEnd: (messages) => {
+          this.endError = extractAgentEndError(messages);
+          if (!this.replyText.trim()) {
+            this.replyText = extractLastAssistantText(messages);
+          }
+        },
+      });
+    });
+    this.session = session;
+    this.sessionModelKey = modelKey;
+    return session;
+  }
+
+  private async defaultCreateSession(options: {
+    modelId: string | undefined;
+    cwd: string;
+    customTools: ReturnType<typeof buildVoiceBrainTools>;
+  }): Promise<BrainSession> {
+    const resolved = resolveModelServices(
+      this.state,
+      this.context.activeTabId ?? "default",
+      options.modelId,
+    );
+    if (!resolved) {
+      throw new Error(
+        `voice brain model "${options.modelId}" is not available — check that its provider is signed in`,
+      );
+    }
+    const { session } = await createAgentSession({
+      ...(resolved.model ? { model: resolved.model } : {}),
+      authStorage: resolved.authStorage,
+      modelRegistry: resolved.modelRegistry,
+      settingsManager: this.state.settingsManager,
+      sessionManager: SessionManager.inMemory(),
+      resourceLoader: this.state.resourceLoader,
+      cwd: options.cwd,
+      noTools: "builtin",
+      customTools: options.customTools,
+    });
+    return session;
+  }
+}
+
+/** Lazily create the singleton brain on first voice message. */
+export function ensureVoiceBrain(
+  state: AethonAgentState,
+  deps: VoiceBrainDeps,
+): VoiceBrain {
+  state.voiceBrain ??= new VoiceBrain(state, deps);
+  return state.voiceBrain;
+}

--- a/agent/voice/prompt.test.ts
+++ b/agent/voice/prompt.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import {
+  VOICE_BRAIN_PREAMBLE,
+  buildTaskEventPrompt,
+  buildTurnPrompt,
+  stripUnspeakable,
+} from "./prompt";
+
+describe("buildTurnPrompt", () => {
+  it("includes the preamble only when asked", () => {
+    const first = buildTurnPrompt("hello", {}, true);
+    const later = buildTurnPrompt("hello", {}, false);
+    expect(first).toContain(VOICE_BRAIN_PREAMBLE);
+    expect(later).not.toContain(VOICE_BRAIN_PREAMBLE);
+    expect(later).toContain("The user said (via voice): hello");
+  });
+
+  it("carries the runtime context block when present", () => {
+    const prompt = buildTurnPrompt(
+      "fix the tests",
+      { projectPath: "/repo/aethon", defaultModel: "anthropic/claude-x" },
+      false,
+    );
+    expect(prompt).toContain("active project: /repo/aethon");
+    expect(prompt).toContain("work-agent model: anthropic/claude-x");
+    expect(prompt).toContain("The user said (via voice): fix the tests");
+  });
+
+  it("omits the context block when empty", () => {
+    expect(buildTurnPrompt("hi", {}, false)).not.toContain("[runtime context]");
+  });
+});
+
+describe("buildTaskEventPrompt", () => {
+  it("frames a completion with the report between markers", () => {
+    const prompt = buildTaskEventPrompt({
+      type: "voice_task_event",
+      taskTabId: "tab-3",
+      label: "fix flaky test",
+      status: "completed",
+      finalText: "All tests pass now.",
+    });
+    expect(prompt).toContain('The task "fix flaky test" finished');
+    expect(prompt).toContain("<report>\nAll tests pass now.\n</report>");
+    expect(prompt).toContain("[system note — not the user speaking]");
+  });
+
+  it("marks errors and survives an empty report", () => {
+    const prompt = buildTaskEventPrompt({
+      type: "voice_task_event",
+      taskTabId: "tab-7",
+      status: "error",
+      finalText: "",
+    });
+    expect(prompt).toContain("in tab tab-7 finished with an error");
+    expect(prompt).toContain("no text report");
+  });
+
+  it("drops fenced code from the report", () => {
+    const prompt = buildTaskEventPrompt({
+      type: "voice_task_event",
+      taskTabId: "tab-1",
+      status: "completed",
+      finalText: "Done.\n```rust\nfn main() {}\n```\nTests green.",
+    });
+    expect(prompt).not.toContain("fn main");
+    expect(prompt).toContain("Done.");
+    expect(prompt).toContain("Tests green.");
+  });
+});
+
+describe("stripUnspeakable", () => {
+  it("removes closed and unterminated fences", () => {
+    expect(stripUnspeakable("a ```x``` b")).toBe("a  (code omitted)  b");
+    expect(stripUnspeakable("a ```never closed")).toBe("a  (code omitted) ");
+  });
+});

--- a/agent/voice/prompt.test.ts
+++ b/agent/voice/prompt.test.ts
@@ -29,6 +29,22 @@ describe("buildTurnPrompt", () => {
   it("omits the context block when empty", () => {
     expect(buildTurnPrompt("hi", {}, false)).not.toContain("[runtime context]");
   });
+
+  it("lists known projects so dispatch works without an active project", () => {
+    const prompt = buildTurnPrompt(
+      "check out claudex",
+      {
+        knownProjects: [
+          { label: "claudex", path: "/repo/claudex" },
+          { label: "aethon", path: "/repo/aethon" },
+        ],
+      },
+      false,
+    );
+    expect(prompt).toContain(
+      "known projects (name: path): claudex: /repo/claudex; aethon: /repo/aethon",
+    );
+  });
 });
 
 describe("buildTaskEventPrompt", () => {

--- a/agent/voice/prompt.test.ts
+++ b/agent/voice/prompt.test.ts
@@ -67,6 +67,29 @@ describe("buildTaskEventPrompt", () => {
     expect(prompt).toContain("Done.");
     expect(prompt).toContain("Tests green.");
   });
+
+  it("frames progress events as a one-sentence update request", () => {
+    const prompt = buildTaskEventPrompt({
+      type: "voice_task_event",
+      taskTabId: "tab-3",
+      label: "audit the auth flow",
+      status: "progress",
+      finalText: "Reading the session middleware.",
+    });
+    expect(prompt).toContain('The task "audit the auth flow" is still working');
+    expect(prompt).toContain(
+      "<activity>\nReading the session middleware.\n</activity>",
+    );
+    expect(prompt).toContain("one short spoken sentence");
+    expect(prompt).not.toContain("finished");
+  });
+});
+
+describe("VOICE_BRAIN_PREAMBLE", () => {
+  it("forbids asking the user questions and mandates dispatch-first", () => {
+    expect(VOICE_BRAIN_PREAMBLE).toContain("Never ask the user questions");
+    expect(VOICE_BRAIN_PREAMBLE).not.toContain("clarifying question");
+  });
 });
 
 describe("stripUnspeakable", () => {

--- a/agent/voice/prompt.ts
+++ b/agent/voice/prompt.ts
@@ -19,7 +19,7 @@ export const VOICE_BRAIN_PREAMBLE = `You are Aethon's voice assistant. Everythin
 
 You do not do the work yourself — you coordinate a separate work agent:
 - When the user asks for work to be done, acknowledge it in one sentence, call the dispatch_task tool with a complete self-contained prompt, then confirm it's underway.
-- Never ask the user questions or for permission. If a request is ambiguous, pick the most reasonable interpretation, dispatch it, and say in one sentence what you assumed. When the user says "this directory", "this project", or similar, they mean the active project in the runtime context.
+- Never ask the user questions or for permission. If a request is ambiguous, pick the most reasonable interpretation, dispatch it, and say in one sentence what you assumed. When the user says "this directory", "this project", or similar, they mean the active project in the runtime context. If no project is active, match the user's words against the known-projects list and dispatch to that project's path; never tell the user to open a project themselves unless nothing in the list plausibly matches.
 - When a system note tells you a task finished, summarize the outcome and current state in one to three sentences: what was accomplished, whether it succeeded, and what needs the user next. Never read raw output, logs, tool names, or file lists aloud.
 - When a system note reports interim progress on a running task, give exactly one short sentence describing what the agent is doing right now, in plain terms.
 - When asked about progress, call the check_status tool and answer from its result.
@@ -31,6 +31,13 @@ function contextBlock(context: VoiceTurnContext): string {
   if (context.projectPath) lines.push(`active project: ${context.projectPath}`);
   if (context.defaultModel) {
     lines.push(`work-agent model: ${context.defaultModel}`);
+  }
+  if (context.knownProjects?.length) {
+    lines.push(
+      `known projects (name: path): ${context.knownProjects
+        .map((p) => `${p.label}: ${p.path}`)
+        .join("; ")}`,
+    );
   }
   if (lines.length === 0) return "";
   return `[runtime context]\n${lines.join("\n")}\n\n`;

--- a/agent/voice/prompt.ts
+++ b/agent/voice/prompt.ts
@@ -21,6 +21,7 @@ You do not do the work yourself — you coordinate a separate work agent:
 - When the user asks for work to be done, acknowledge it in one sentence, call the dispatch_task tool with a complete self-contained prompt, then confirm it's underway.
 - When a system note tells you a task finished, summarize the outcome and current state in one to three sentences: what was accomplished, whether it succeeded, and what needs the user next. Never read raw output, logs, tool names, or file lists aloud.
 - When asked about progress, call the check_status tool and answer from its result.
+- When the user wants to adjust or add to a task that is already running, call the send_followup tool with the task's label and a complete instruction — do not dispatch a duplicate task.
 - If a request is ambiguous, ask one short clarifying question instead of dispatching.
 - For quick questions or chit-chat, just answer — no dispatch needed.`;
 

--- a/agent/voice/prompt.ts
+++ b/agent/voice/prompt.ts
@@ -19,10 +19,11 @@ export const VOICE_BRAIN_PREAMBLE = `You are Aethon's voice assistant. Everythin
 
 You do not do the work yourself — you coordinate a separate work agent:
 - When the user asks for work to be done, acknowledge it in one sentence, call the dispatch_task tool with a complete self-contained prompt, then confirm it's underway.
+- Never ask the user questions or for permission. If a request is ambiguous, pick the most reasonable interpretation, dispatch it, and say in one sentence what you assumed. When the user says "this directory", "this project", or similar, they mean the active project in the runtime context.
 - When a system note tells you a task finished, summarize the outcome and current state in one to three sentences: what was accomplished, whether it succeeded, and what needs the user next. Never read raw output, logs, tool names, or file lists aloud.
+- When a system note reports interim progress on a running task, give exactly one short sentence describing what the agent is doing right now, in plain terms.
 - When asked about progress, call the check_status tool and answer from its result.
 - When the user wants to adjust or add to a task that is already running, call the send_followup tool with the task's label and a complete instruction — do not dispatch a duplicate task.
-- If a request is ambiguous, ask one short clarifying question instead of dispatching.
 - For quick questions or chit-chat, just answer — no dispatch needed.`;
 
 function contextBlock(context: VoiceTurnContext): string {
@@ -46,14 +47,21 @@ export function buildTurnPrompt(
   return `${preamble}${contextBlock(context)}The user said (via voice): ${text}`;
 }
 
-/** System note injected when a dispatched work agent finishes a turn. */
+/** System note injected when a dispatched work agent finishes a turn, or —
+ *  for `progress` events — while it is still working. */
 export function buildTaskEventPrompt(event: VoiceTaskEventMessage): string {
   const label = event.label ? `"${event.label}"` : `in tab ${event.taskTabId}`;
+  const report = stripUnspeakable(event.finalText).trim();
+  if (event.status === "progress") {
+    const body = report
+      ? `A digest of its recent activity follows between the markers — source material only, never read it verbatim.\n<activity>\n${report}\n</activity>`
+      : "No activity digest is available.";
+    return `[system note — not the user speaking] The task ${label} is still working. ${body}\n\nGive the user exactly one short spoken sentence on what it is doing right now. Do not ask anything.`;
+  }
   const outcome =
     event.status === "error"
       ? "finished with an error"
       : "finished its current turn";
-  const report = stripUnspeakable(event.finalText).trim();
   const body = report
     ? `Its final report follows between the markers — use it only as source material for a spoken summary, never read it verbatim.\n<report>\n${report}\n</report>`
     : "It produced no text report.";

--- a/agent/voice/prompt.ts
+++ b/agent/voice/prompt.ts
@@ -1,0 +1,66 @@
+/**
+ * Prompt contract for the voice-brain session.
+ *
+ * The brain shares the app's resource loader (so it gets the standard system
+ * prompt + working context); this preamble rides the first prompt of the
+ * session — the same pattern subagent `systemPrompt` bodies use
+ * (`composeSubagentPrompt` in subagents/task-params.ts). Everything it says
+ * exists to keep replies SPEAKABLE: short plain prose that a TTS engine can
+ * read without listing file paths or tool output.
+ */
+
+import type { VoiceTaskEventMessage, VoiceTurnContext } from "./protocol";
+
+export const VOICE_BRAIN_PREAMBLE = `You are Aethon's voice assistant. Everything you write is spoken aloud to the user through text-to-speech, so:
+- Reply in one to three short conversational sentences of plain prose.
+- Never use markdown, lists, headings, code, file paths, URLs, or emoji.
+- Say names and identifiers in a speech-friendly way ("the config helper" — not a path).
+- Do not narrate these rules or mention that you are a voice interface.
+
+You do not do the work yourself — you coordinate a separate work agent:
+- When the user asks for work to be done, acknowledge it in one sentence, call the dispatch_task tool with a complete self-contained prompt, then confirm it's underway.
+- When a system note tells you a task finished, summarize the outcome and current state in one to three sentences: what was accomplished, whether it succeeded, and what needs the user next. Never read raw output, logs, tool names, or file lists aloud.
+- When asked about progress, call the check_status tool and answer from its result.
+- If a request is ambiguous, ask one short clarifying question instead of dispatching.
+- For quick questions or chit-chat, just answer — no dispatch needed.`;
+
+function contextBlock(context: VoiceTurnContext): string {
+  const lines: string[] = [];
+  if (context.projectPath) lines.push(`active project: ${context.projectPath}`);
+  if (context.defaultModel) {
+    lines.push(`work-agent model: ${context.defaultModel}`);
+  }
+  if (lines.length === 0) return "";
+  return `[runtime context]\n${lines.join("\n")}\n\n`;
+}
+
+/** The user's spoken words, prefixed with a compact runtime-context block so
+ *  dispatch_task always has real arguments. */
+export function buildTurnPrompt(
+  text: string,
+  context: VoiceTurnContext,
+  includePreamble: boolean,
+): string {
+  const preamble = includePreamble ? `${VOICE_BRAIN_PREAMBLE}\n\n---\n\n` : "";
+  return `${preamble}${contextBlock(context)}The user said (via voice): ${text}`;
+}
+
+/** System note injected when a dispatched work agent finishes a turn. */
+export function buildTaskEventPrompt(event: VoiceTaskEventMessage): string {
+  const label = event.label ? `"${event.label}"` : `in tab ${event.taskTabId}`;
+  const outcome =
+    event.status === "error"
+      ? "finished with an error"
+      : "finished its current turn";
+  const report = stripUnspeakable(event.finalText).trim();
+  const body = report
+    ? `Its final report follows between the markers — use it only as source material for a spoken summary, never read it verbatim.\n<report>\n${report}\n</report>`
+    : "It produced no text report.";
+  return `[system note — not the user speaking] The task ${label} ${outcome}. ${body}\n\nTell the user what happened, following your spoken-reply rules.`;
+}
+
+/** Drop fenced code blocks — they are never speakable and just burn brain
+ *  context. Inline backticks survive (the model is told not to read them). */
+export function stripUnspeakable(text: string): string {
+  return text.replace(/```[\s\S]*?(```|$)/g, " (code omitted) ");
+}

--- a/agent/voice/protocol.ts
+++ b/agent/voice/protocol.ts
@@ -21,7 +21,14 @@ export interface VoiceTurnContext {
   /** Optional dedicated brain model (`[voice] brain_model`); empty inherits
    *  the default tab's model. */
   brainModel?: string;
+  /** The app's project list (label + root path). Lets the brain dispatch to
+   *  a project the user NAMES even when none is active — without this,
+   *  "check out claudex" with no active project had no path to dispatch to. */
+  knownProjects?: { label: string; path: string }[];
 }
+
+/** Ceiling on known-project entries carried per turn (prompt budget). */
+export const VOICE_KNOWN_PROJECTS_CAP = 12;
 
 export interface VoiceTurnMessage {
   type: "voice_turn";
@@ -70,6 +77,22 @@ export function parseVoiceTurn(msg: unknown): VoiceTurnMessage | null {
       if (typeof value === "string" && value.trim()) {
         context[key] = value.trim();
       }
+    }
+    if (Array.isArray(ctx.knownProjects)) {
+      const projects = ctx.knownProjects
+        .flatMap((entry) => {
+          const rec = asRecord(entry);
+          const label = rec?.label;
+          const path = rec?.path;
+          return typeof label === "string" &&
+            label.trim() &&
+            typeof path === "string" &&
+            path.trim()
+            ? [{ label: label.trim(), path: path.trim() }]
+            : [];
+        })
+        .slice(0, VOICE_KNOWN_PROJECTS_CAP);
+      if (projects.length > 0) context.knownProjects = projects;
     }
   }
   return { type: "voice_turn", text, context };

--- a/agent/voice/protocol.ts
+++ b/agent/voice/protocol.ts
@@ -33,7 +33,9 @@ export interface VoiceTaskEventMessage {
   type: "voice_task_event";
   taskTabId: string;
   label?: string;
-  status: "completed" | "error";
+  /** `progress` = the task is still running; `finalText` carries a digest of
+   *  recent activity rather than a final report. */
+  status: "completed" | "error" | "progress";
   /** Work agent's final prose (frontend strips code fences + caps length;
    *  the cap here is a defensive re-check). */
   finalText: string;
@@ -77,7 +79,12 @@ export function parseVoiceTaskEvent(msg: unknown): VoiceTaskEventMessage | null 
   const rec = asRecord(msg);
   if (!rec || rec.type !== "voice_task_event") return null;
   if (typeof rec.taskTabId !== "string" || !rec.taskTabId) return null;
-  const status = rec.status === "error" ? "error" : "completed";
+  const status =
+    rec.status === "error"
+      ? "error"
+      : rec.status === "progress"
+        ? "progress"
+        : "completed";
   const finalText =
     typeof rec.finalText === "string"
       ? rec.finalText.slice(0, VOICE_TASK_EVENT_TEXT_CAP)

--- a/agent/voice/protocol.ts
+++ b/agent/voice/protocol.ts
@@ -1,0 +1,92 @@
+/**
+ * Wire types for the voice-brain bridge protocol.
+ *
+ * Inbound (frontend → global bridge): `voice_turn`, `voice_task_event`,
+ * `voice_brain_abort`, `voice_session_reset`. Outbound: `voice_brain_delta`,
+ * `voice_brain_end`, `voice_brain_error`.
+ *
+ * These message types are deliberately NOT in the Rust router's tab-scoped
+ * list, so they always reach the global bridge (a worker respawn/retire must
+ * never take the brain session with it). Tab references ride as
+ * `activeTabId` / `taskTabId` — never a top-level `tabId`.
+ */
+
+export interface VoiceTurnContext {
+  /** Tab the user is looking at (dispatch defaults to its project). */
+  activeTabId?: string;
+  /** Active project root — required for dispatch_task. */
+  projectPath?: string;
+  /** Provider-qualified model dispatched work agents must use. */
+  defaultModel?: string;
+  /** Optional dedicated brain model (`[voice] brain_model`); empty inherits
+   *  the default tab's model. */
+  brainModel?: string;
+}
+
+export interface VoiceTurnMessage {
+  type: "voice_turn";
+  text: string;
+  context?: VoiceTurnContext;
+}
+
+export interface VoiceTaskEventMessage {
+  type: "voice_task_event";
+  taskTabId: string;
+  label?: string;
+  status: "completed" | "error";
+  /** Work agent's final prose (frontend strips code fences + caps length;
+   *  the cap here is a defensive re-check). */
+  finalText: string;
+}
+
+/** Defensive ceiling on work-agent text entering the brain's context. */
+export const VOICE_TASK_EVENT_TEXT_CAP = 4_000;
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+export function parseVoiceTurn(msg: unknown): VoiceTurnMessage | null {
+  const rec = asRecord(msg);
+  if (!rec || rec.type !== "voice_turn" || typeof rec.text !== "string") {
+    return null;
+  }
+  const text = rec.text.trim();
+  if (!text) return null;
+  const ctx = asRecord(rec.context);
+  const context: VoiceTurnContext = {};
+  if (ctx) {
+    for (const key of [
+      "activeTabId",
+      "projectPath",
+      "defaultModel",
+      "brainModel",
+    ] as const) {
+      const value = ctx[key];
+      if (typeof value === "string" && value.trim()) {
+        context[key] = value.trim();
+      }
+    }
+  }
+  return { type: "voice_turn", text, context };
+}
+
+export function parseVoiceTaskEvent(msg: unknown): VoiceTaskEventMessage | null {
+  const rec = asRecord(msg);
+  if (!rec || rec.type !== "voice_task_event") return null;
+  if (typeof rec.taskTabId !== "string" || !rec.taskTabId) return null;
+  const status = rec.status === "error" ? "error" : "completed";
+  const finalText =
+    typeof rec.finalText === "string"
+      ? rec.finalText.slice(0, VOICE_TASK_EVENT_TEXT_CAP)
+      : "";
+  return {
+    type: "voice_task_event",
+    taskTabId: rec.taskTabId,
+    ...(typeof rec.label === "string" && rec.label ? { label: rec.label } : {}),
+    status,
+    finalText,
+  };
+}

--- a/agent/voice/protocol.ts
+++ b/agent/voice/protocol.ts
@@ -46,6 +46,10 @@ export interface VoiceTaskEventMessage {
   /** Work agent's final prose (frontend strips code fences + caps length;
    *  the cap here is a defensive re-check). */
   finalText: string;
+  /** Runtime context (brain model, project). Task events are the brain's
+   *  primary input — transcripts go straight to the work agent — so the
+   *  context has to ride here too. */
+  context?: VoiceTurnContext;
 }
 
 /** Defensive ceiling on work-agent text entering the brain's context. */
@@ -57,6 +61,40 @@ function asRecord(value: unknown): Record<string, unknown> | null {
     : null;
 }
 
+function parseTurnContext(raw: unknown): VoiceTurnContext {
+  const ctx = asRecord(raw);
+  const context: VoiceTurnContext = {};
+  if (!ctx) return context;
+  for (const key of [
+    "activeTabId",
+    "projectPath",
+    "defaultModel",
+    "brainModel",
+  ] as const) {
+    const value = ctx[key];
+    if (typeof value === "string" && value.trim()) {
+      context[key] = value.trim();
+    }
+  }
+  if (Array.isArray(ctx.knownProjects)) {
+    const projects = ctx.knownProjects
+      .flatMap((entry) => {
+        const rec = asRecord(entry);
+        const label = rec?.label;
+        const path = rec?.path;
+        return typeof label === "string" &&
+          label.trim() &&
+          typeof path === "string" &&
+          path.trim()
+          ? [{ label: label.trim(), path: path.trim() }]
+          : [];
+      })
+      .slice(0, VOICE_KNOWN_PROJECTS_CAP);
+    if (projects.length > 0) context.knownProjects = projects;
+  }
+  return context;
+}
+
 export function parseVoiceTurn(msg: unknown): VoiceTurnMessage | null {
   const rec = asRecord(msg);
   if (!rec || rec.type !== "voice_turn" || typeof rec.text !== "string") {
@@ -64,38 +102,7 @@ export function parseVoiceTurn(msg: unknown): VoiceTurnMessage | null {
   }
   const text = rec.text.trim();
   if (!text) return null;
-  const ctx = asRecord(rec.context);
-  const context: VoiceTurnContext = {};
-  if (ctx) {
-    for (const key of [
-      "activeTabId",
-      "projectPath",
-      "defaultModel",
-      "brainModel",
-    ] as const) {
-      const value = ctx[key];
-      if (typeof value === "string" && value.trim()) {
-        context[key] = value.trim();
-      }
-    }
-    if (Array.isArray(ctx.knownProjects)) {
-      const projects = ctx.knownProjects
-        .flatMap((entry) => {
-          const rec = asRecord(entry);
-          const label = rec?.label;
-          const path = rec?.path;
-          return typeof label === "string" &&
-            label.trim() &&
-            typeof path === "string" &&
-            path.trim()
-            ? [{ label: label.trim(), path: path.trim() }]
-            : [];
-        })
-        .slice(0, VOICE_KNOWN_PROJECTS_CAP);
-      if (projects.length > 0) context.knownProjects = projects;
-    }
-  }
-  return { type: "voice_turn", text, context };
+  return { type: "voice_turn", text, context: parseTurnContext(rec.context) };
 }
 
 export function parseVoiceTaskEvent(msg: unknown): VoiceTaskEventMessage | null {
@@ -112,11 +119,13 @@ export function parseVoiceTaskEvent(msg: unknown): VoiceTaskEventMessage | null 
     typeof rec.finalText === "string"
       ? rec.finalText.slice(0, VOICE_TASK_EVENT_TEXT_CAP)
       : "";
+  const context = parseTurnContext(rec.context);
   return {
     type: "voice_task_event",
     taskTabId: rec.taskTabId,
     ...(typeof rec.label === "string" && rec.label ? { label: rec.label } : {}),
     status,
     finalText,
+    ...(Object.keys(context).length > 0 ? { context } : {}),
   };
 }

--- a/agent/voice/tools.test.ts
+++ b/agent/voice/tools.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import type { VoiceTurnContext } from "./protocol";
+import {
+  buildVoiceBrainTools,
+  summarizeAsLabel,
+  type DispatchedTask,
+} from "./tools";
+
+interface StartCall {
+  projectPath: string;
+  prompt: string;
+  model: string;
+  activate: boolean;
+  label?: string;
+}
+
+function harness(options?: {
+  context?: VoiceTurnContext;
+  startResult?: { ok: boolean; error?: string; data?: unknown };
+}) {
+  const startCalls: StartCall[] = [];
+  const dispatched: DispatchedTask[] = [];
+  const tools = buildVoiceBrainTools({
+    startTask: (input) => {
+      startCalls.push(input);
+      return Promise.resolve(
+        options?.startResult ?? { ok: true, data: { tabId: "tab-42" } },
+      );
+    },
+    getContext: () =>
+      options?.context ?? {
+        projectPath: "/repo/aethon",
+        defaultModel: "anthropic/claude-x",
+      },
+    onDispatched: (task) => dispatched.push(task),
+    listTasks: () => [...dispatched],
+    countRunningTabs: () => 2,
+  });
+  const byName = new Map(tools.map((tool) => [tool.name, tool]));
+  return { byName, startCalls, dispatched };
+}
+
+async function run(
+  tool: { execute: (...args: unknown[]) => Promise<unknown> } | undefined,
+  params: Record<string, unknown>,
+): Promise<string> {
+  if (!tool) throw new Error("tool missing");
+  const result = (await tool.execute("call-1", params, undefined, undefined)) as {
+    content: { type: string; text: string }[];
+  };
+  return result.content[0]?.text ?? "";
+}
+
+describe("dispatch_task", () => {
+  it("launches a non-focused task with the context project + model", async () => {
+    const h = harness();
+    const text = await run(h.byName.get("dispatch_task"), {
+      prompt: "Fix the flaky file-tree test",
+      label: "fix flaky test",
+    });
+    expect(h.startCalls).toEqual([
+      {
+        projectPath: "/repo/aethon",
+        prompt: "Fix the flaky file-tree test",
+        model: "anthropic/claude-x",
+        activate: false,
+        label: "fix flaky test",
+      },
+    ]);
+    expect(h.dispatched).toEqual([
+      { tabId: "tab-42", label: "fix flaky test", status: "running" },
+    ]);
+    expect(text).toContain("tab-42");
+  });
+
+  it("derives a label from the prompt when none is given", async () => {
+    const h = harness();
+    await run(h.byName.get("dispatch_task"), {
+      prompt: "Rename the config helper across the Rust shell",
+    });
+    expect(h.startCalls[0]?.label).toBe("Rename the config helper across the");
+  });
+
+  it("fails clearly without a project or model", async () => {
+    const noProject = harness({ context: { defaultModel: "m" } });
+    expect(
+      await run(noProject.byName.get("dispatch_task"), { prompt: "x" }),
+    ).toContain("no active project");
+    expect(noProject.startCalls).toHaveLength(0);
+
+    const noModel = harness({ context: { projectPath: "/p" } });
+    expect(
+      await run(noModel.byName.get("dispatch_task"), { prompt: "x" }),
+    ).toContain("no work-agent model");
+  });
+
+  it("surfaces launcher errors without recording a dispatch", async () => {
+    const h = harness({
+      startResult: { ok: false, error: "unknown project path" },
+    });
+    const text = await run(h.byName.get("dispatch_task"), { prompt: "x" });
+    expect(text).toContain("unknown project path");
+    expect(h.dispatched).toHaveLength(0);
+  });
+});
+
+describe("check_status", () => {
+  it("reports dispatched tasks and running tab count", async () => {
+    const h = harness();
+    await run(h.byName.get("dispatch_task"), {
+      prompt: "task one",
+      label: "task one",
+    });
+    const text = await run(h.byName.get("check_status"), {});
+    expect(text).toContain('"task one" (tab tab-42): running');
+    expect(text).toContain("currently working: 2");
+  });
+
+  it("says so when nothing was dispatched", async () => {
+    const h = harness();
+    const text = await run(h.byName.get("check_status"), {});
+    expect(text).toContain("No tasks have been dispatched");
+  });
+});
+
+describe("summarizeAsLabel", () => {
+  it("truncates long prompts and survives empties", () => {
+    expect(summarizeAsLabel("fix it")).toBe("fix it");
+    expect(summarizeAsLabel("   ")).toBe("voice task");
+    expect(
+      summarizeAsLabel("a".repeat(60) + " word two three four five six"),
+    ).toHaveLength(48);
+  });
+});

--- a/agent/voice/tools.test.ts
+++ b/agent/voice/tools.test.ts
@@ -19,6 +19,7 @@ function harness(options?: {
   startResult?: { ok: boolean; error?: string; data?: unknown };
 }) {
   const startCalls: StartCall[] = [];
+  const followupCalls: { tabId: string; prompt: string }[] = [];
   const dispatched: DispatchedTask[] = [];
   const tools = buildVoiceBrainTools({
     startTask: (input) => {
@@ -27,17 +28,25 @@ function harness(options?: {
         options?.startResult ?? { ok: true, data: { tabId: "tab-42" } },
       );
     },
+    sendFollowup: (input) => {
+      followupCalls.push(input);
+      return Promise.resolve({ ok: true });
+    },
     getContext: () =>
       options?.context ?? {
         projectPath: "/repo/aethon",
         defaultModel: "anthropic/claude-x",
       },
-    onDispatched: (task) => dispatched.push(task),
+    onDispatched: (task) => {
+      const existing = dispatched.find((t) => t.tabId === task.tabId);
+      if (existing) existing.status = task.status;
+      else dispatched.push(task);
+    },
     listTasks: () => [...dispatched],
     countRunningTabs: () => 2,
   });
   const byName = new Map(tools.map((tool) => [tool.name, tool]));
-  return { byName, startCalls, dispatched };
+  return { byName, startCalls, followupCalls, dispatched };
 }
 
 async function run(
@@ -101,6 +110,35 @@ describe("dispatch_task", () => {
     const text = await run(h.byName.get("dispatch_task"), { prompt: "x" });
     expect(text).toContain("unknown project path");
     expect(h.dispatched).toHaveLength(0);
+  });
+});
+
+describe("send_followup", () => {
+  it("steers a dispatched task by label and re-arms tracking", async () => {
+    const h = harness();
+    await run(h.byName.get("dispatch_task"), {
+      prompt: "fix the flaky test",
+      label: "fix flaky test",
+    });
+    const text = await run(h.byName.get("send_followup"), {
+      task: "fix flaky test",
+      prompt: "Also update the changelog",
+    });
+    expect(h.followupCalls).toEqual([
+      { tabId: "tab-42", prompt: "Also update the changelog" },
+    ]);
+    expect(text).toContain("Follow-up sent");
+    expect(h.dispatched[0]?.status).toBe("running");
+  });
+
+  it("rejects unknown or ambiguous task references", async () => {
+    const h = harness();
+    const text = await run(h.byName.get("send_followup"), {
+      task: "nothing",
+      prompt: "x",
+    });
+    expect(text).toContain("No dispatched task matches");
+    expect(h.followupCalls).toHaveLength(0);
   });
 });
 

--- a/agent/voice/tools.ts
+++ b/agent/voice/tools.ts
@@ -34,6 +34,11 @@ export interface VoiceToolDeps {
     activate: boolean;
     label?: string;
   }) => Promise<StartTaskResult>;
+  /** `aethon.tasks.sendFollowup`-shaped steer for an existing task tab. */
+  sendFollowup: (input: {
+    tabId: string;
+    prompt: string;
+  }) => Promise<StartTaskResult>;
   getContext: () => VoiceTurnContext;
   onDispatched: (task: DispatchedTask) => void;
   listTasks: () => DispatchedTask[];
@@ -108,6 +113,41 @@ export function buildVoiceBrainTools(deps: VoiceToolDeps): ToolDefinition[] {
     },
   }) as ToolDefinition;
 
+  const sendFollowup = defineTool({
+    name: "send_followup",
+    label: "Steer a dispatched task",
+    description:
+      "Send a follow-up instruction to a task you already dispatched (identified by its label or tab id). Queues politely if the work agent is mid-turn.",
+    parameters: FollowupParams,
+    async execute(_callId: string, params: { task: string; prompt: string }) {
+      const target = resolveTask(deps.listTasks(), params.task);
+      if (!target) {
+        return textResult(
+          `No dispatched task matches "${params.task}". Use check_status to see what's running.`,
+        );
+      }
+      const result = await deps.sendFollowup({
+        tabId: target.tabId,
+        prompt: params.prompt,
+      });
+      if (!result.ok) {
+        return textResult(
+          `Follow-up failed: ${result.error ?? "unknown error"}.`,
+        );
+      }
+      // Re-arm completion tracking: the next finished turn on that tab is
+      // this follow-up's result and should be announced.
+      deps.onDispatched({
+        tabId: target.tabId,
+        label: target.label,
+        status: "running",
+      });
+      return textResult(
+        `Follow-up sent to "${target.label}" (tab ${target.tabId}). You'll be notified when it finishes.`,
+      );
+    },
+  }) as ToolDefinition;
+
   const checkStatus = defineTool({
     name: "check_status",
     label: "Check task status",
@@ -130,7 +170,36 @@ export function buildVoiceBrainTools(deps: VoiceToolDeps): ToolDefinition[] {
     },
   }) as ToolDefinition;
 
-  return [dispatchTask, checkStatus];
+  return [dispatchTask, sendFollowup, checkStatus];
+}
+
+const FollowupParams = Type.Object({
+  task: Type.String({
+    description: "Label or tab id of a task you previously dispatched.",
+  }),
+  prompt: Type.String({
+    description: "Complete follow-up instruction for that work agent.",
+  }),
+});
+
+/** Match by exact tab id, then exact label (case-insensitive), then a unique
+ *  substring of the label. Ambiguity returns nothing — the model should ask. */
+export function resolveTask(
+  tasks: DispatchedTask[],
+  query: string,
+): DispatchedTask | undefined {
+  const needle = query.trim().toLowerCase();
+  if (!needle) return undefined;
+  const byId = tasks.find((task) => task.tabId.toLowerCase() === needle);
+  if (byId) return byId;
+  const byLabel = tasks.filter(
+    (task) => task.label.toLowerCase() === needle,
+  );
+  if (byLabel.length === 1) return byLabel[0];
+  const contains = tasks.filter((task) =>
+    task.label.toLowerCase().includes(needle),
+  );
+  return contains.length === 1 ? contains[0] : undefined;
 }
 
 /** First few words of the prompt as a fallback tab label. */

--- a/agent/voice/tools.ts
+++ b/agent/voice/tools.ts
@@ -1,0 +1,140 @@
+/**
+ * The voice brain's two tools. It gets NOTHING else (`noTools: "builtin"`) —
+ * the brain coordinates; the work agent works.
+ *
+ * `dispatch_task` rides the same `aethon.tasks.start` path the dashboard and
+ * `task` tool use (frontend `dashboardQuery op:"start_task"`), launching a
+ * non-focused work-agent tab. `check_status` answers "how's it going" from
+ * the brain's own dispatch registry plus the bridge's live prompt-in-flight
+ * view.
+ */
+
+import { Type } from "typebox";
+import { defineTool, type ToolDefinition } from "@mariozechner/pi-coding-agent";
+import type { VoiceTurnContext } from "./protocol";
+
+export interface DispatchedTask {
+  tabId: string;
+  label: string;
+  status: "running" | "completed" | "error";
+}
+
+interface StartTaskResult {
+  ok: boolean;
+  error?: string;
+  data?: unknown;
+}
+
+export interface VoiceToolDeps {
+  /** `aethon.tasks.start`-shaped launcher (injected for tests). */
+  startTask: (input: {
+    projectPath: string;
+    prompt: string;
+    model: string;
+    activate: boolean;
+    label?: string;
+  }) => Promise<StartTaskResult>;
+  getContext: () => VoiceTurnContext;
+  onDispatched: (task: DispatchedTask) => void;
+  listTasks: () => DispatchedTask[];
+  /** Count of bridge tabs with a prompt in flight (any origin). */
+  countRunningTabs: () => number;
+}
+
+const DispatchParams = Type.Object({
+  prompt: Type.String({
+    description:
+      "Complete, self-contained prompt for the work agent. Include everything it needs — it cannot hear the conversation.",
+  }),
+  label: Type.Optional(
+    Type.String({
+      description: "Short human-readable label for the task (a few words).",
+    }),
+  ),
+});
+
+function textResult(text: string): {
+  content: { type: "text"; text: string }[];
+} {
+  return { content: [{ type: "text", text }] };
+}
+
+export function buildVoiceBrainTools(deps: VoiceToolDeps): ToolDefinition[] {
+  const dispatchTask = defineTool({
+    name: "dispatch_task",
+    label: "Dispatch a task to the work agent",
+    description:
+      "Launch the work agent on a task in the active project. Returns the task's tab id; you will be told when it finishes.",
+    parameters: DispatchParams,
+    async execute(
+      _callId: string,
+      params: { prompt: string; label?: string },
+    ) {
+      const context = deps.getContext();
+      if (!context.projectPath) {
+        return textResult(
+          "Dispatch failed: no active project. Ask the user to open a project first.",
+        );
+      }
+      if (!context.defaultModel) {
+        return textResult(
+          "Dispatch failed: no work-agent model is configured. Ask the user to pick a model.",
+        );
+      }
+      const label = params.label?.trim() || summarizeAsLabel(params.prompt);
+      const result = await deps.startTask({
+        projectPath: context.projectPath,
+        prompt: params.prompt,
+        model: context.defaultModel,
+        activate: false,
+        label,
+      });
+      if (!result.ok) {
+        return textResult(
+          `Dispatch failed: ${result.error ?? "unknown error"}.`,
+        );
+      }
+      const data = (result.data ?? {}) as { tabId?: unknown };
+      const tabId = typeof data.tabId === "string" ? data.tabId : "";
+      if (!tabId) {
+        return textResult(
+          "Dispatch reported success but returned no tab id — treat the launch as uncertain.",
+        );
+      }
+      deps.onDispatched({ tabId, label, status: "running" });
+      return textResult(
+        `Task "${label}" dispatched (tab ${tabId}). You'll be notified when it finishes.`,
+      );
+    },
+  }) as ToolDefinition;
+
+  const checkStatus = defineTool({
+    name: "check_status",
+    label: "Check task status",
+    description:
+      "Report the status of tasks you dispatched plus how many agent tabs are currently working.",
+    parameters: Type.Object({}),
+    // eslint-disable-next-line @typescript-eslint/require-await -- ToolDefinition.execute must be async
+    async execute() {
+      const tasks = deps.listTasks();
+      const running = deps.countRunningTabs();
+      const lines = tasks.map(
+        (task) => `- "${task.label}" (tab ${task.tabId}): ${task.status}`,
+      );
+      const summary = lines.length
+        ? `Dispatched tasks:\n${lines.join("\n")}`
+        : "No tasks have been dispatched in this conversation.";
+      return textResult(
+        `${summary}\nAgent tabs currently working: ${running}.`,
+      );
+    },
+  }) as ToolDefinition;
+
+  return [dispatchTask, checkStatus];
+}
+
+/** First few words of the prompt as a fallback tab label. */
+export function summarizeAsLabel(prompt: string): string {
+  const words = prompt.trim().split(/\s+/).slice(0, 6).join(" ");
+  return words.length > 48 ? `${words.slice(0, 47)}…` : words || "voice task";
+}

--- a/agent/voice/tools.ts
+++ b/agent/voice/tools.ts
@@ -1,12 +1,13 @@
 /**
- * The voice brain's two tools. It gets NOTHING else (`noTools: "builtin"`) —
- * the brain coordinates; the work agent works.
+ * The voice brain's three tools. It gets NOTHING else (`noTools: "builtin"`)
+ * — the brain coordinates; the work agent works.
  *
  * `dispatch_task` rides the same `aethon.tasks.start` path the dashboard and
  * `task` tool use (frontend `dashboardQuery op:"start_task"`), launching a
- * non-focused work-agent tab. `check_status` answers "how's it going" from
- * the brain's own dispatch registry plus the bridge's live prompt-in-flight
- * view.
+ * non-focused work-agent tab. `send_followup` steers an already-running task
+ * (by id, label, or unique substring) instead of dispatching a duplicate.
+ * `check_status` answers "how's it going" from the brain's own dispatch
+ * registry plus the bridge's live prompt-in-flight view.
  */
 
 import { Type } from "typebox";

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -158,6 +158,16 @@ find_free_port() {
 
 ensure_frontend_deps
 
+# Stage the LFM2-Audio runner when absent (fresh clone / worktree) so the
+# local voice provider resolves in dev without AETHON_LFM2_AUDIO_BIN. The
+# staging script no-ops when the pinned binary is already present; a failed
+# download (offline) degrades to the voice provider reporting needs-setup.
+if [[ ! -x "src-tauri/binaries/lfm2-audio/llama-lfm2-audio" ]]; then
+  echo "[dev] staging LFM2-Audio runner (first run)…" >&2
+  bash scripts/stage-lfm2-runner.sh \
+    || echo "[dev] WARN: LFM2 runner staging failed — local voice TTS will report needs-setup" >&2
+fi
+
 VITE_PORT="$(find_free_port "$VITE_BASE")"
 DEBUG_PORT="$(find_free_port "$DEBUG_BASE")"
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6335,7 +6335,11 @@ checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
 dependencies = [
  "futures-util",
  "log",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
  "tokio",
+ "tokio-rustls",
  "tungstenite",
 ]
 
@@ -6670,6 +6674,8 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.6",
+ "rustls",
+ "rustls-pki-types",
  "sha1",
  "thiserror 1.0.69",
  "utf-8",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -96,6 +96,10 @@ tokenizers = { version = "0.22", default-features = false, features = [
 rubato = { version = "2", default-features = false, optional = true }
 hound = { version = "3", optional = true }
 tempfile = { version = "3", optional = true }
+tokio-tungstenite = { version = "0.24", default-features = false, features = [
+  "connect",
+  "rustls-tls-native-roots",
+], optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
@@ -128,6 +132,7 @@ voice = [
   "dep:rubato",
   "dep:hound",
   "dep:tempfile",
+  "dep:tokio-tungstenite",
 ]
 
 [dev-dependencies]

--- a/src-tauri/src/agent_process/process.rs
+++ b/src-tauri/src/agent_process/process.rs
@@ -21,7 +21,7 @@ use tauri::{AppHandle, State};
 use tokio::time::sleep;
 
 use super::sidecar::project_root;
-use super::spawn::ensure_agent_spawned;
+use super::spawn::{SpawnShared, ensure_agent_spawned};
 use crate::env;
 
 pub(crate) const GLOBAL_AGENT_KEY: &str = "__global__";
@@ -80,6 +80,11 @@ pub(crate) struct AgentProcesses {
     pub(crate) children: Mutex<HashMap<String, Arc<Mutex<Child>>>>,
     pub(crate) mutation_routes: Arc<Mutex<HashMap<String, String>>>,
     pub(crate) intentional_exits: Arc<Mutex<HashSet<String>>>,
+    /// Keys the file-watcher has asked to reload gracefully. Consumed at
+    /// stdout-EOF so a drain whose `_reload_done` sentinel got lost (or
+    /// corrupted in the pipe) still classifies as a reload — emitting
+    /// `agent-reloaded` — instead of popping a phantom crash toast.
+    pub(crate) pending_reloads: Arc<Mutex<HashSet<String>>>,
     pub(crate) meta: Arc<Mutex<HashMap<String, WorkerMeta>>>,
 }
 
@@ -89,7 +94,19 @@ impl AgentProcesses {
             children: Mutex::new(HashMap::new()),
             mutation_routes: Arc::new(Mutex::new(HashMap::new())),
             intentional_exits: Arc::new(Mutex::new(HashSet::new())),
+            pending_reloads: Arc::new(Mutex::new(HashSet::new())),
             meta: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// `'static` clones of the bookkeeping Arcs a spawn hands to its
+    /// reader threads.
+    pub(super) fn spawn_shared(&self) -> SpawnShared {
+        SpawnShared {
+            mutation_routes: Arc::clone(&self.mutation_routes),
+            intentional_exits: Arc::clone(&self.intentional_exits),
+            pending_reloads: Arc::clone(&self.pending_reloads),
+            meta: Arc::clone(&self.meta),
         }
     }
 }
@@ -284,15 +301,7 @@ pub(crate) async fn write_agent_payload(
     for _attempt in 0..2 {
         let child = {
             let mut guard = lock_recover(&state.children, "agent children (write)");
-            ensure_agent_spawned(
-                &mut guard,
-                &key,
-                app,
-                Arc::clone(&state.mutation_routes),
-                Arc::clone(&state.intentional_exits),
-                Arc::clone(&state.meta),
-                worker.as_ref(),
-            )?;
+            ensure_agent_spawned(&mut guard, &key, app, state.spawn_shared(), worker.as_ref())?;
             guard.get(&key).cloned().ok_or("agent not running")?
         };
 
@@ -353,9 +362,7 @@ pub(crate) fn ensure_global_agent(
         &mut guard,
         GLOBAL_AGENT_KEY,
         app,
-        Arc::clone(&state.mutation_routes),
-        Arc::clone(&state.intentional_exits),
-        Arc::clone(&state.meta),
+        state.spawn_shared(),
         None,
     )
 }

--- a/src-tauri/src/agent_process/readers.rs
+++ b/src-tauri/src/agent_process/readers.rs
@@ -60,6 +60,7 @@ pub(super) struct StdoutReaderCtx {
     pub(super) tab_id: Option<String>,
     pub(super) mutation_routes: Arc<Mutex<HashMap<String, String>>>,
     pub(super) intentional_exits: Arc<Mutex<HashSet<String>>>,
+    pub(super) pending_reloads: Arc<Mutex<HashSet<String>>>,
     pub(super) meta: Arc<Mutex<HashMap<String, WorkerMeta>>>,
     pub(super) stderr_tail: Arc<Mutex<VecDeque<String>>>,
 }
@@ -73,6 +74,7 @@ pub(super) fn spawn_stdout_reader(ctx: StdoutReaderCtx) {
         tab_id,
         mutation_routes,
         intentional_exits,
+        pending_reloads,
         meta,
         stderr_tail,
     } = ctx;
@@ -130,7 +132,22 @@ pub(super) fn spawn_stdout_reader(ctx: StdoutReaderCtx) {
         tracing::debug!(target: "aethon::agent", key = key, "stdout reader for pid={pid} exited");
         let intentional_exit =
             lock_recover(&intentional_exits, "intentional exits (eof)").remove(&key);
+        let reload_was_asked = lock_recover(&pending_reloads, "pending reloads (eof)").remove(&key);
         if intentional_exit || saw_reload_done {
+            cleanup_after_stdout_eof(&meta, &mutation_routes, &key, pid);
+            return;
+        }
+        // The watcher asked this child to reload but the `_reload_done`
+        // sentinel never arrived (lost or corrupted in the pipe). The exit
+        // was still requested — classify as a reload, not a crash, so the
+        // user doesn't get a phantom "exited unexpectedly" toast.
+        if reload_was_asked {
+            tracing::info!(
+                target: "aethon::agent",
+                key = key,
+                "reload-asked pid={pid} closed stdout without sentinel; treating as reload"
+            );
+            let _ = app.emit("agent-reloaded", "");
             cleanup_after_stdout_eof(&meta, &mutation_routes, &key, pid);
             return;
         }

--- a/src-tauri/src/agent_process/spawn.rs
+++ b/src-tauri/src/agent_process/spawn.rs
@@ -25,6 +25,15 @@ use super::readers::{
 };
 use super::sidecar::{find_sidecar_binary, project_root};
 
+/// The supervisor-shared bookkeeping a freshly spawned child's reader
+/// threads need to own (`'static` clones of the `AgentProcesses` Arcs).
+pub(super) struct SpawnShared {
+    pub(super) mutation_routes: Arc<Mutex<HashMap<String, String>>>,
+    pub(super) intentional_exits: Arc<Mutex<HashSet<String>>>,
+    pub(super) pending_reloads: Arc<Mutex<HashSet<String>>>,
+    pub(super) meta: Arc<Mutex<HashMap<String, WorkerMeta>>>,
+}
+
 /// Spawn the agent if no live child is held. Idempotent. Callers own the
 /// mutex around this. In dev (`debug_assertions`) we run `bun run
 /// agent/main.ts` from the project root. In release we run the bundled
@@ -34,11 +43,15 @@ pub(super) fn ensure_agent_spawned(
     guard: &mut HashMap<String, Arc<Mutex<Child>>>,
     key: &str,
     app: &AppHandle,
-    mutation_routes: Arc<Mutex<HashMap<String, String>>>,
-    intentional_exits: Arc<Mutex<HashSet<String>>>,
-    meta: Arc<Mutex<HashMap<String, WorkerMeta>>>,
+    shared: SpawnShared,
     worker: Option<&AgentWorker>,
 ) -> Result<(), String> {
+    let SpawnShared {
+        mutation_routes,
+        intentional_exits,
+        pending_reloads,
+        meta,
+    } = shared;
     let exited_status = guard.get(key).and_then(|child| {
         lock_recover(child, "agent child (exit check)")
             .try_wait()
@@ -90,6 +103,10 @@ pub(super) fn ensure_agent_spawned(
     let pid = child.id();
     tracing::info!(target: "aethon::agent", key = key, "spawned pid={pid}");
 
+    // A fresh child has not been asked to reload — drop any stale mark left
+    // by a prior generation so its future EOF classifies on its own merits.
+    lock_recover(&pending_reloads, "pending reloads (spawn)").remove(key);
+
     let stderr_tail: Arc<Mutex<VecDeque<String>>> =
         Arc::new(Mutex::new(VecDeque::with_capacity(STDERR_TAIL_CAP)));
 
@@ -102,6 +119,7 @@ pub(super) fn ensure_agent_spawned(
         tab_id: worker.map(|w| w.tab_id.clone()),
         mutation_routes,
         intentional_exits,
+        pending_reloads,
         meta: Arc::clone(&meta),
         stderr_tail: Arc::clone(&stderr_tail),
     });

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -402,6 +402,40 @@ pub fn write_config(config: serde_json::Value, app: AppHandle) -> Result<(), Str
     let voice_conversation_continuous = voice
         .and_then(|m| m.get("conversationContinuous"))
         .and_then(|v| v.as_bool());
+    let voice_conversation_engine = voice
+        .and_then(|m| m.get("conversationEngine"))
+        .and_then(|v| v.as_str())
+        .map(|s| helpers::normalize_conversation_engine(Some(s)));
+    let voice_brain_model = voice
+        .and_then(|m| m.get("brainModel"))
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    let voice_stt_provider = voice
+        .and_then(|m| m.get("sttProvider"))
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty());
+    let voice_tts_provider = voice
+        .and_then(|m| m.get("ttsProvider"))
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty());
+    let voice_tts_voice = voice
+        .and_then(|m| m.get("ttsVoice"))
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    // API keys are write-only from the Settings panel: the frontend never
+    // receives the stored value (read_config exposes `*ApiKeySet` booleans),
+    // so an absent field means "leave the stored key alone" — NOT "clear it".
+    // An explicitly-sent empty string clears.
+    let voice_deepgram_api_key = voice
+        .and_then(|m| m.get("deepgramApiKey"))
+        .and_then(|v| v.as_str())
+        .map(str::trim);
+    let voice_cartesia_api_key = voice
+        .and_then(|m| m.get("cartesiaApiKey"))
+        .and_then(|v| v.as_str())
+        .map(str::trim);
     let update_channel = updates
         .and_then(|m| m.get("channel"))
         .and_then(|v| v.as_str())
@@ -575,6 +609,34 @@ pub fn write_config(config: serde_json::Value, app: AppHandle) -> Result<(), Str
             "conversation_continuous",
             voice_conversation_continuous,
         );
+        match voice_conversation_engine {
+            // "auto" is the default — keep the file clean by omitting it.
+            Some("auto") | None => {
+                voice_table.remove("conversation_engine");
+            }
+            Some(engine) => {
+                voice_table.insert("conversation_engine", toml_edit::value(engine));
+            }
+        }
+        set_or_clear_str(voice_table, "brain_model", voice_brain_model);
+        set_or_clear_str(voice_table, "stt_provider", voice_stt_provider);
+        set_or_clear_str(voice_table, "tts_provider", voice_tts_provider);
+        set_or_clear_str(voice_table, "tts_voice", voice_tts_voice);
+        // Absent → untouched; explicit "" → cleared (see extraction comment).
+        for (key, value) in [
+            ("deepgram_api_key", voice_deepgram_api_key),
+            ("cartesia_api_key", voice_cartesia_api_key),
+        ] {
+            match value {
+                Some("") => {
+                    voice_table.remove(key);
+                }
+                Some(secret) => {
+                    voice_table.insert(key, toml_edit::value(secret));
+                }
+                None => {}
+            }
+        }
     }
 
     // ── [updates] ──

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -619,8 +619,18 @@ pub fn write_config(config: serde_json::Value, app: AppHandle) -> Result<(), Str
             }
         }
         set_or_clear_str(voice_table, "brain_model", voice_brain_model);
-        set_or_clear_str(voice_table, "stt_provider", voice_stt_provider);
-        set_or_clear_str(voice_table, "tts_provider", voice_tts_provider);
+        // "auto" is the implicit default — keep the file clean by omitting
+        // it, so future default changes aren't pinned by stale writes.
+        set_or_clear_str(
+            voice_table,
+            "stt_provider",
+            voice_stt_provider.filter(|v| *v != "auto"),
+        );
+        set_or_clear_str(
+            voice_table,
+            "tts_provider",
+            voice_tts_provider.filter(|v| *v != "auto"),
+        );
         set_or_clear_str(voice_table, "tts_voice", voice_tts_voice);
         // Absent → untouched; explicit "" → cleared (see extraction comment).
         for (key, value) in [

--- a/src-tauri/src/commands/extensions/reload.rs
+++ b/src-tauri/src/commands/extensions/reload.rs
@@ -82,6 +82,12 @@ pub(super) fn run_debounce_worker(rx: std::sync::mpsc::Receiver<DebounceMsg>, ap
                 };
                 match write_result {
                     Ok(()) => {
+                        // Mark the ask so a drain whose `_reload_done`
+                        // sentinel gets lost still classifies its EOF as a
+                        // reload rather than a crash.
+                        if let Ok(mut pending) = state.pending_reloads.lock() {
+                            pending.insert(key.clone());
+                        }
                         tracing::info!(
                             target: "aethon::agent_watch",
                             key = key,

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -38,4 +38,5 @@ pub mod startup;
 pub mod subagents;
 pub mod updater;
 pub mod voice;
+pub mod voice_convo;
 pub mod window;

--- a/src-tauri/src/commands/voice.rs
+++ b/src-tauri/src/commands/voice.rs
@@ -85,7 +85,7 @@ struct VoiceStartLatencyEvent {
 #[tauri::command]
 #[tracing::instrument(
     target = "aethon::voice",
-    skip(app, voice),
+    skip(app, voice, convo),
     fields(
         provider_id = tracing::field::Empty,
         total_ms = tracing::field::Empty,
@@ -97,7 +97,13 @@ pub async fn voice_start_recording(
     provider_id: Option<String>,
     app: AppHandle,
     voice: State<'_, VoiceProviderRegistry>,
+    convo: State<'_, crate::voice::ConversationEngine>,
 ) -> Result<(), String> {
+    if convo.is_active() {
+        return Err(
+            "A voice conversation is using the microphone — exit it to dictate".to_string(),
+        );
+    }
     let t0 = Instant::now();
     let resolved_provider_id = {
         let settings = open_voice_settings(&app)?;

--- a/src-tauri/src/commands/voice_convo.rs
+++ b/src-tauri/src/commands/voice_convo.rs
@@ -1,0 +1,194 @@
+//! IPC surface for the streaming conversation engine (cascade voice mode).
+//!
+//! Mirrors `commands/voice.rs`: real implementations behind the `voice`
+//! feature, shims otherwise so the JS binding surface (including parameter
+//! names) stays intact and callers get the intended error instead of a Tauri
+//! arg-parse failure.
+
+#[cfg(feature = "voice")]
+use std::sync::Arc;
+
+#[cfg(feature = "voice")]
+use serde::Serialize;
+#[cfg(feature = "voice")]
+use tauri::{AppHandle, State};
+
+#[cfg(feature = "voice")]
+use crate::helpers::config::{AethonConfig, VoiceConfig};
+#[cfg(feature = "voice")]
+use crate::voice::{
+    AudioPlayer, CartesiaConnector, ConversationEngine, ConvoState, DeepgramFluxConnector,
+    VoiceProviderRegistry, resolve_cascade_keys,
+};
+
+#[cfg(feature = "voice")]
+fn load_voice_config(app: &AppHandle) -> VoiceConfig {
+    let path = match crate::commands::config::aethon_state_path(app, "config.toml") {
+        Ok(path) => path,
+        Err(_) => return VoiceConfig::default(),
+    };
+    let raw = std::fs::read_to_string(path).unwrap_or_default();
+    toml::from_str::<AethonConfig>(&raw)
+        .unwrap_or_default()
+        .voice
+}
+
+#[cfg(feature = "voice")]
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VoiceConvoStatus {
+    /// Whether the cascade pipeline can start (both provider keys resolve).
+    pub available: bool,
+    pub state: ConvoState,
+    pub stt_provider: String,
+    pub tts_provider: String,
+    pub deepgram_key_present: bool,
+    pub cartesia_key_present: bool,
+    pub last_error: Option<String>,
+}
+
+#[cfg(feature = "voice")]
+#[tauri::command]
+pub async fn voice_convo_status(
+    app: AppHandle,
+    convo: State<'_, ConversationEngine>,
+) -> Result<VoiceConvoStatus, String> {
+    let config = load_voice_config(&app);
+    let keys = resolve_cascade_keys(&config);
+    Ok(VoiceConvoStatus {
+        available: keys.complete(),
+        state: convo.state(),
+        stt_provider: config
+            .stt_provider
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| "deepgram-flux".to_string()),
+        tts_provider: config
+            .tts_provider
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| "cartesia".to_string()),
+        deepgram_key_present: keys.deepgram.is_some(),
+        cartesia_key_present: keys.cartesia.is_some(),
+        last_error: convo.last_error(),
+    })
+}
+
+#[cfg(feature = "voice")]
+#[tauri::command]
+pub async fn voice_convo_start(
+    app: AppHandle,
+    voice: State<'_, VoiceProviderRegistry>,
+    convo: State<'_, ConversationEngine>,
+    player: State<'_, AudioPlayer>,
+) -> Result<(), String> {
+    if voice.recording_active() {
+        return Err("Dictation is using the microphone — stop it first".to_string());
+    }
+    let config = load_voice_config(&app);
+    let keys = resolve_cascade_keys(&config);
+    let deepgram = keys.deepgram.ok_or_else(|| {
+        "Deepgram API key missing — set DEEPGRAM_API_KEY or add it in Settings → Voice".to_string()
+    })?;
+    let cartesia = keys.cartesia.ok_or_else(|| {
+        "Cartesia API key missing — set CARTESIA_API_KEY or add it in Settings → Voice".to_string()
+    })?;
+
+    let stt = Arc::new(DeepgramFluxConnector::new(deepgram));
+    let tts = Arc::new(CartesiaConnector::new(cartesia, config.tts_voice.clone()));
+    convo
+        .start(
+            Some(app.clone()),
+            stt,
+            tts,
+            Arc::new(player.inner().clone()),
+        )
+        .await
+}
+
+#[cfg(feature = "voice")]
+#[tauri::command]
+pub async fn voice_convo_stop(
+    app: AppHandle,
+    convo: State<'_, ConversationEngine>,
+    player: State<'_, AudioPlayer>,
+) -> Result<(), String> {
+    convo.stop(Some(&app));
+    player.stop();
+    Ok(())
+}
+
+#[cfg(feature = "voice")]
+#[tauri::command]
+pub async fn voice_convo_speak_chunk(
+    text: String,
+    convo: State<'_, ConversationEngine>,
+) -> Result<(), String> {
+    convo.speak_chunk(text)
+}
+
+#[cfg(feature = "voice")]
+#[tauri::command]
+pub async fn voice_convo_speak_end(convo: State<'_, ConversationEngine>) -> Result<(), String> {
+    convo.speak_end()
+}
+
+#[cfg(feature = "voice")]
+#[tauri::command]
+pub async fn voice_convo_cancel_speech(convo: State<'_, ConversationEngine>) -> Result<(), String> {
+    convo.cancel_speech()
+}
+
+#[cfg(feature = "voice")]
+#[tauri::command]
+pub async fn voice_convo_force_end_turn(
+    convo: State<'_, ConversationEngine>,
+) -> Result<(), String> {
+    convo.force_end_turn()
+}
+
+// Shim implementations (compiled when the `voice` feature is disabled).
+#[cfg(not(feature = "voice"))]
+const VOICE_NOT_BUILT: &str = "voice support not built into this binary";
+
+#[cfg(not(feature = "voice"))]
+#[tauri::command]
+pub async fn voice_convo_status() -> Result<serde_json::Value, String> {
+    Err(VOICE_NOT_BUILT.into())
+}
+
+#[cfg(not(feature = "voice"))]
+#[tauri::command]
+pub async fn voice_convo_start() -> Result<(), String> {
+    Err(VOICE_NOT_BUILT.into())
+}
+
+#[cfg(not(feature = "voice"))]
+#[tauri::command]
+pub async fn voice_convo_stop() -> Result<(), String> {
+    Err(VOICE_NOT_BUILT.into())
+}
+
+#[cfg(not(feature = "voice"))]
+#[tauri::command]
+pub async fn voice_convo_speak_chunk(
+    #[allow(unused_variables)] text: String,
+) -> Result<(), String> {
+    Err(VOICE_NOT_BUILT.into())
+}
+
+#[cfg(not(feature = "voice"))]
+#[tauri::command]
+pub async fn voice_convo_speak_end() -> Result<(), String> {
+    Err(VOICE_NOT_BUILT.into())
+}
+
+#[cfg(not(feature = "voice"))]
+#[tauri::command]
+pub async fn voice_convo_cancel_speech() -> Result<(), String> {
+    Err(VOICE_NOT_BUILT.into())
+}
+
+#[cfg(not(feature = "voice"))]
+#[tauri::command]
+pub async fn voice_convo_force_end_turn() -> Result<(), String> {
+    Err(VOICE_NOT_BUILT.into())
+}

--- a/src-tauri/src/commands/voice_convo.rs
+++ b/src-tauri/src/commands/voice_convo.rs
@@ -18,7 +18,8 @@ use crate::helpers::config::{AethonConfig, VoiceConfig};
 #[cfg(feature = "voice")]
 use crate::voice::{
     AudioPlayer, CartesiaConnector, CartesiaVoiceInfo, ConversationEngine, ConvoState,
-    DeepgramFluxConnector, SttConnector, TtsConnector, VoiceProviderRegistry, list_cartesia_voices,
+    DeepgramFluxConnector, LOCAL_STT_PROVIDER, LOCAL_TTS_PROVIDER, Lfm2TtsConnector,
+    LocalWhisperConnector, SttConnector, TtsConnector, VoiceProviderRegistry, list_cartesia_voices,
     resolve_cascade_keys,
 };
 
@@ -49,24 +50,51 @@ pub struct VoiceConvoStatus {
 }
 
 #[cfg(feature = "voice")]
+fn configured_stt_provider(config: &VoiceConfig) -> String {
+    config
+        .stt_provider
+        .clone()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "deepgram-flux".to_string())
+}
+
+#[cfg(feature = "voice")]
+fn configured_tts_provider(config: &VoiceConfig) -> String {
+    config
+        .tts_provider
+        .clone()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "cartesia".to_string())
+}
+
+#[cfg(feature = "voice")]
 #[tauri::command]
 pub async fn voice_convo_status(
     app: AppHandle,
+    voice: State<'_, VoiceProviderRegistry>,
     convo: State<'_, ConversationEngine>,
 ) -> Result<VoiceConvoStatus, String> {
     let config = load_voice_config(&app);
     let keys = resolve_cascade_keys(&config);
+    let stt_provider = configured_stt_provider(&config);
+    let tts_provider = configured_tts_provider(&config);
+    // Availability follows the CONFIGURED providers: a local provider counts
+    // when its model is ready, a cloud one when its key resolves.
+    let stt_available = if stt_provider == LOCAL_STT_PROVIDER {
+        LocalWhisperConnector::ready(&voice)
+    } else {
+        keys.deepgram.is_some()
+    };
+    let tts_available = if tts_provider == LOCAL_TTS_PROVIDER {
+        Lfm2TtsConnector::ready(&voice)
+    } else {
+        keys.cartesia.is_some()
+    };
     Ok(VoiceConvoStatus {
-        available: keys.complete(),
+        available: stt_available && tts_available,
         state: convo.state(),
-        stt_provider: config
-            .stt_provider
-            .filter(|s| !s.is_empty())
-            .unwrap_or_else(|| "deepgram-flux".to_string()),
-        tts_provider: config
-            .tts_provider
-            .filter(|s| !s.is_empty())
-            .unwrap_or_else(|| "cartesia".to_string()),
+        stt_provider,
+        tts_provider,
         deepgram_key_present: keys.deepgram.is_some(),
         cartesia_key_present: keys.cartesia.is_some(),
         last_error: convo.last_error(),
@@ -86,15 +114,26 @@ pub async fn voice_convo_start(
     }
     let config = load_voice_config(&app);
     let keys = resolve_cascade_keys(&config);
-    let deepgram = keys.deepgram.ok_or_else(|| {
-        "Deepgram API key missing — set DEEPGRAM_API_KEY or add it in Settings → Voice".to_string()
-    })?;
-    let cartesia = keys.cartesia.ok_or_else(|| {
-        "Cartesia API key missing — set CARTESIA_API_KEY or add it in Settings → Voice".to_string()
-    })?;
 
-    let stt = Arc::new(DeepgramFluxConnector::new(deepgram));
-    let tts = Arc::new(CartesiaConnector::new(cartesia, config.tts_voice.clone()));
+    let stt: Arc<dyn SttConnector> = if configured_stt_provider(&config) == LOCAL_STT_PROVIDER {
+        Arc::new(LocalWhisperConnector::from_registry(&voice))
+    } else {
+        let deepgram = keys.deepgram.ok_or_else(|| {
+            "Deepgram API key missing — set DEEPGRAM_API_KEY or add it in Settings → Voice"
+                .to_string()
+        })?;
+        Arc::new(DeepgramFluxConnector::new(deepgram))
+    };
+    let tts: Arc<dyn TtsConnector> = if configured_tts_provider(&config) == LOCAL_TTS_PROVIDER {
+        Arc::new(Lfm2TtsConnector::from_registry(&voice))
+    } else {
+        let cartesia = keys.cartesia.ok_or_else(|| {
+            "Cartesia API key missing — set CARTESIA_API_KEY or add it in Settings → Voice"
+                .to_string()
+        })?;
+        Arc::new(CartesiaConnector::new(cartesia, config.tts_voice.clone()))
+    };
+
     convo
         .start(
             Some(app.clone()),

--- a/src-tauri/src/commands/voice_convo.rs
+++ b/src-tauri/src/commands/voice_convo.rs
@@ -39,32 +39,94 @@ fn load_voice_config(app: &AppHandle) -> VoiceConfig {
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct VoiceConvoStatus {
-    /// Whether the cascade pipeline can start (both provider keys resolve).
+    /// Whether the cascade pipeline can start (each stage resolves to a
+    /// usable provider — cloud key or ready local model).
     pub available: bool,
     pub state: ConvoState,
+    /// Resolved provider per stage (what a conversation would actually use),
+    /// or the configured name when unresolvable.
     pub stt_provider: String,
     pub tts_provider: String,
+    /// Why a stage can't run, when it can't.
+    pub stt_error: Option<String>,
+    pub tts_error: Option<String>,
     pub deepgram_key_present: bool,
     pub cartesia_key_present: bool,
     pub last_error: Option<String>,
 }
 
 #[cfg(feature = "voice")]
-fn configured_stt_provider(config: &VoiceConfig) -> String {
-    config
-        .stt_provider
-        .clone()
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| "deepgram-flux".to_string())
+const DEEPGRAM_PROVIDER: &str = "deepgram-flux";
+#[cfg(feature = "voice")]
+const CARTESIA_PROVIDER: &str = "cartesia";
+
+/// Resolve the STT stage to a concrete provider. `"auto"` (the default)
+/// prefers the cloud provider when its key resolves and falls back to the
+/// local model — so a single saved key is enough to light the cascade up.
+#[cfg(feature = "voice")]
+fn resolve_stt_provider(
+    config: &VoiceConfig,
+    registry: &VoiceProviderRegistry,
+    deepgram_key: bool,
+) -> Result<&'static str, String> {
+    match config.stt_provider.as_deref().unwrap_or("auto") {
+        LOCAL_STT_PROVIDER => {
+            if LocalWhisperConnector::ready(registry) {
+                Ok(LOCAL_STT_PROVIDER)
+            } else {
+                Err("the local Whisper model isn't downloaded".to_string())
+            }
+        }
+        DEEPGRAM_PROVIDER => {
+            if deepgram_key {
+                Ok(DEEPGRAM_PROVIDER)
+            } else {
+                Err("no Deepgram API key".to_string())
+            }
+        }
+        _ => {
+            if deepgram_key {
+                Ok(DEEPGRAM_PROVIDER)
+            } else if LocalWhisperConnector::ready(registry) {
+                Ok(LOCAL_STT_PROVIDER)
+            } else {
+                Err("no Deepgram API key and the local Whisper model isn't downloaded".to_string())
+            }
+        }
+    }
 }
 
 #[cfg(feature = "voice")]
-fn configured_tts_provider(config: &VoiceConfig) -> String {
-    config
-        .tts_provider
-        .clone()
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| "cartesia".to_string())
+fn resolve_tts_provider(
+    config: &VoiceConfig,
+    registry: &VoiceProviderRegistry,
+    cartesia_key: bool,
+) -> Result<&'static str, String> {
+    match config.tts_provider.as_deref().unwrap_or("auto") {
+        LOCAL_TTS_PROVIDER => {
+            if Lfm2TtsConnector::ready(registry) {
+                Ok(LOCAL_TTS_PROVIDER)
+            } else {
+                Err("the LFM2-Audio model isn't ready".to_string())
+            }
+        }
+        CARTESIA_PROVIDER => {
+            if cartesia_key {
+                Ok(CARTESIA_PROVIDER)
+            } else {
+                Err("no Cartesia API key".to_string())
+            }
+        }
+        _ => {
+            if cartesia_key {
+                Ok(CARTESIA_PROVIDER)
+            } else if Lfm2TtsConnector::ready(registry) {
+                Ok(LOCAL_TTS_PROVIDER)
+            } else {
+                Err("no Cartesia API key and the LFM2-Audio model isn't ready".to_string())
+            }
+        }
+    }
 }
 
 #[cfg(feature = "voice")]
@@ -76,25 +138,21 @@ pub async fn voice_convo_status(
 ) -> Result<VoiceConvoStatus, String> {
     let config = load_voice_config(&app);
     let keys = resolve_cascade_keys(&config);
-    let stt_provider = configured_stt_provider(&config);
-    let tts_provider = configured_tts_provider(&config);
-    // Availability follows the CONFIGURED providers: a local provider counts
-    // when its model is ready, a cloud one when its key resolves.
-    let stt_available = if stt_provider == LOCAL_STT_PROVIDER {
-        LocalWhisperConnector::ready(&voice)
-    } else {
-        keys.deepgram.is_some()
-    };
-    let tts_available = if tts_provider == LOCAL_TTS_PROVIDER {
-        Lfm2TtsConnector::ready(&voice)
-    } else {
-        keys.cartesia.is_some()
-    };
+    let stt = resolve_stt_provider(&config, &voice, keys.deepgram.is_some());
+    let tts = resolve_tts_provider(&config, &voice, keys.cartesia.is_some());
     Ok(VoiceConvoStatus {
-        available: stt_available && tts_available,
+        available: stt.is_ok() && tts.is_ok(),
         state: convo.state(),
-        stt_provider,
-        tts_provider,
+        stt_provider: stt
+            .as_ref()
+            .map(|name| (*name).to_string())
+            .unwrap_or_else(|_| config.stt_provider.clone().unwrap_or_else(|| "auto".into())),
+        tts_provider: tts
+            .as_ref()
+            .map(|name| (*name).to_string())
+            .unwrap_or_else(|_| config.tts_provider.clone().unwrap_or_else(|| "auto".into())),
+        stt_error: stt.err(),
+        tts_error: tts.err(),
         deepgram_key_present: keys.deepgram.is_some(),
         cartesia_key_present: keys.cartesia.is_some(),
         last_error: convo.last_error(),
@@ -115,22 +173,25 @@ pub async fn voice_convo_start(
     let config = load_voice_config(&app);
     let keys = resolve_cascade_keys(&config);
 
-    let stt: Arc<dyn SttConnector> = if configured_stt_provider(&config) == LOCAL_STT_PROVIDER {
+    let stt_choice = resolve_stt_provider(&config, &voice, keys.deepgram.is_some())
+        .map_err(|why| format!("Speech-to-text unavailable: {why} (Settings → Voice)"))?;
+    let tts_choice = resolve_tts_provider(&config, &voice, keys.cartesia.is_some())
+        .map_err(|why| format!("Text-to-speech unavailable: {why} (Settings → Voice)"))?;
+
+    let stt: Arc<dyn SttConnector> = if stt_choice == LOCAL_STT_PROVIDER {
         Arc::new(LocalWhisperConnector::from_registry(&voice))
     } else {
-        let deepgram = keys.deepgram.ok_or_else(|| {
-            "Deepgram API key missing — set DEEPGRAM_API_KEY or add it in Settings → Voice"
-                .to_string()
-        })?;
+        let deepgram = keys
+            .deepgram
+            .ok_or_else(|| "Deepgram API key missing".to_string())?;
         Arc::new(DeepgramFluxConnector::new(deepgram))
     };
-    let tts: Arc<dyn TtsConnector> = if configured_tts_provider(&config) == LOCAL_TTS_PROVIDER {
+    let tts: Arc<dyn TtsConnector> = if tts_choice == LOCAL_TTS_PROVIDER {
         Arc::new(Lfm2TtsConnector::from_registry(&voice))
     } else {
-        let cartesia = keys.cartesia.ok_or_else(|| {
-            "Cartesia API key missing — set CARTESIA_API_KEY or add it in Settings → Voice"
-                .to_string()
-        })?;
+        let cartesia = keys
+            .cartesia
+            .ok_or_else(|| "Cartesia API key missing".to_string())?;
         Arc::new(CartesiaConnector::new(cartesia, config.tts_voice.clone()))
     };
 

--- a/src-tauri/src/commands/voice_convo.rs
+++ b/src-tauri/src/commands/voice_convo.rs
@@ -17,8 +17,9 @@ use tauri::{AppHandle, State};
 use crate::helpers::config::{AethonConfig, VoiceConfig};
 #[cfg(feature = "voice")]
 use crate::voice::{
-    AudioPlayer, CartesiaConnector, ConversationEngine, ConvoState, DeepgramFluxConnector,
-    VoiceProviderRegistry, resolve_cascade_keys,
+    AudioPlayer, CartesiaConnector, CartesiaVoiceInfo, ConversationEngine, ConvoState,
+    DeepgramFluxConnector, SttConnector, TtsConnector, VoiceProviderRegistry, list_cartesia_voices,
+    resolve_cascade_keys,
 };
 
 #[cfg(feature = "voice")]
@@ -145,9 +146,83 @@ pub async fn voice_convo_force_end_turn(
     convo.force_end_turn()
 }
 
+#[cfg(feature = "voice")]
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VoiceConvoProviderTest {
+    pub deepgram_ok: bool,
+    pub deepgram_error: Option<String>,
+    pub cartesia_ok: bool,
+    pub cartesia_error: Option<String>,
+}
+
+/// Settings "Test" button: prove each cascade provider key actually opens a
+/// session (connect + immediate close), without starting a conversation.
+#[cfg(feature = "voice")]
+#[tauri::command]
+pub async fn voice_convo_test_providers(app: AppHandle) -> Result<VoiceConvoProviderTest, String> {
+    let config = load_voice_config(&app);
+    let keys = resolve_cascade_keys(&config);
+
+    let (deepgram_ok, deepgram_error) = match keys.deepgram {
+        None => (false, Some("no API key configured".to_string())),
+        Some(key) => match DeepgramFluxConnector::new(key).connect().await {
+            Ok((mut stream, _events)) => {
+                stream.close().await;
+                (true, None)
+            }
+            Err(err) => (false, Some(err)),
+        },
+    };
+    let (cartesia_ok, cartesia_error) = match keys.cartesia {
+        None => (false, Some("no API key configured".to_string())),
+        Some(key) => {
+            match CartesiaConnector::new(key, config.tts_voice.clone())
+                .connect()
+                .await
+            {
+                Ok(mut session) => {
+                    session.stream.stop().await;
+                    (true, None)
+                }
+                Err(err) => (false, Some(err)),
+            }
+        }
+    };
+    Ok(VoiceConvoProviderTest {
+        deepgram_ok,
+        deepgram_error,
+        cartesia_ok,
+        cartesia_error,
+    })
+}
+
+#[cfg(feature = "voice")]
+#[tauri::command]
+pub async fn voice_convo_list_voices(app: AppHandle) -> Result<Vec<CartesiaVoiceInfo>, String> {
+    let config = load_voice_config(&app);
+    let keys = resolve_cascade_keys(&config);
+    let key = keys
+        .cartesia
+        .ok_or_else(|| "Cartesia API key missing".to_string())?;
+    list_cartesia_voices(&key).await
+}
+
 // Shim implementations (compiled when the `voice` feature is disabled).
 #[cfg(not(feature = "voice"))]
 const VOICE_NOT_BUILT: &str = "voice support not built into this binary";
+
+#[cfg(not(feature = "voice"))]
+#[tauri::command]
+pub async fn voice_convo_test_providers() -> Result<serde_json::Value, String> {
+    Err(VOICE_NOT_BUILT.into())
+}
+
+#[cfg(not(feature = "voice"))]
+#[tauri::command]
+pub async fn voice_convo_list_voices() -> Result<Vec<serde_json::Value>, String> {
+    Err(VOICE_NOT_BUILT.into())
+}
 
 #[cfg(not(feature = "voice"))]
 #[tauri::command]

--- a/src-tauri/src/helpers/config.rs
+++ b/src-tauri/src/helpers/config.rs
@@ -112,6 +112,26 @@ pub struct VoiceConfig {
     pub speak_agent_replies: Option<bool>,
     pub speak_max_chars: Option<u32>,
     pub conversation_continuous: Option<bool>,
+    /// Which conversation pipeline the hands-free mode uses. Allowed values:
+    /// `"auto"` (default — cascade when its API keys resolve, else the local
+    /// LFM2 loop), `"cascade"` (streaming STT → voice brain → streaming TTS),
+    /// `"lfm2"` (force the local loop). Unknown values fall back to `"auto"`.
+    pub conversation_engine: Option<String>,
+    /// pi model id (`provider/model`) for the voice-brain session. Empty →
+    /// the tab's default model.
+    pub brain_model: Option<String>,
+    /// Cascade streaming STT provider. Currently only `"deepgram-flux"`.
+    pub stt_provider: Option<String>,
+    /// Cascade streaming TTS provider. Currently only `"cartesia"`.
+    pub tts_provider: Option<String>,
+    /// Cartesia voice id for spoken replies. Empty → provider default voice.
+    pub tts_voice: Option<String>,
+    /// API keys for the cascade providers. Env vars (`DEEPGRAM_API_KEY`,
+    /// `CARTESIA_API_KEY`) take precedence; these exist so keys can live in
+    /// config.toml when env plumbing is inconvenient. Never exposed through
+    /// `parse_config_toml` — the frontend only sees `*ApiKeySet` booleans.
+    pub deepgram_api_key: Option<String>,
+    pub cartesia_api_key: Option<String>,
 }
 
 #[derive(Default, Deserialize)]
@@ -409,6 +429,16 @@ pub fn normalize_thinking_level(value: Option<&str>) -> Option<&str> {
     }
 }
 
+/// Unknown values fall back to `"auto"` so a typo can't silently pin the
+/// conversation mode to a pipeline the user didn't ask for.
+pub fn normalize_conversation_engine(value: Option<&str>) -> &str {
+    match value {
+        Some("cascade") => "cascade",
+        Some("lfm2") => "lfm2",
+        _ => "auto",
+    }
+}
+
 pub fn parse_host_startup_auto_approve(input: &str) -> bool {
     if input.is_empty() {
         return false;
@@ -509,6 +539,14 @@ pub fn parse_config_toml(input: &str) -> serde_json::Value {
             "speakAgentReplies": cfg.voice.speak_agent_replies.unwrap_or(false),
             "speakMaxChars": cfg.voice.speak_max_chars.unwrap_or(600),
             "conversationContinuous": cfg.voice.conversation_continuous.unwrap_or(false),
+            "conversationEngine": normalize_conversation_engine(cfg.voice.conversation_engine.as_deref()),
+            "brainModel": cfg.voice.brain_model.as_deref().map(str::trim).filter(|s| !s.is_empty()),
+            "sttProvider": cfg.voice.stt_provider.as_deref().filter(|s| !s.is_empty()).unwrap_or("deepgram-flux"),
+            "ttsProvider": cfg.voice.tts_provider.as_deref().filter(|s| !s.is_empty()).unwrap_or("cartesia"),
+            "ttsVoice": cfg.voice.tts_voice.as_deref().map(str::trim).filter(|s| !s.is_empty()),
+            // Presence flags only — raw keys never cross into the frontend.
+            "deepgramApiKeySet": cfg.voice.deepgram_api_key.as_deref().is_some_and(|s| !s.trim().is_empty()),
+            "cartesiaApiKeySet": cfg.voice.cartesia_api_key.as_deref().is_some_and(|s| !s.trim().is_empty()),
         },
         "extensions": {
             "stateWarnKb": state_warn_kb,

--- a/src-tauri/src/helpers/config.rs
+++ b/src-tauri/src/helpers/config.rs
@@ -120,9 +120,10 @@ pub struct VoiceConfig {
     /// pi model id (`provider/model`) for the voice-brain session. Empty →
     /// the tab's default model.
     pub brain_model: Option<String>,
-    /// Cascade streaming STT provider. Currently only `"deepgram-flux"`.
+    /// Cascade STT provider: `"auto"` (default — cloud when its key
+    /// resolves, else the local model), `"deepgram-flux"`, `"local-whisper"`.
     pub stt_provider: Option<String>,
-    /// Cascade streaming TTS provider. Currently only `"cartesia"`.
+    /// Cascade TTS provider: `"auto"` (default), `"cartesia"`, `"lfm2"`.
     pub tts_provider: Option<String>,
     /// Cartesia voice id for spoken replies. Empty → provider default voice.
     pub tts_voice: Option<String>,
@@ -541,8 +542,8 @@ pub fn parse_config_toml(input: &str) -> serde_json::Value {
             "conversationContinuous": cfg.voice.conversation_continuous.unwrap_or(false),
             "conversationEngine": normalize_conversation_engine(cfg.voice.conversation_engine.as_deref()),
             "brainModel": cfg.voice.brain_model.as_deref().map(str::trim).filter(|s| !s.is_empty()),
-            "sttProvider": cfg.voice.stt_provider.as_deref().filter(|s| !s.is_empty()).unwrap_or("deepgram-flux"),
-            "ttsProvider": cfg.voice.tts_provider.as_deref().filter(|s| !s.is_empty()).unwrap_or("cartesia"),
+            "sttProvider": cfg.voice.stt_provider.as_deref().filter(|s| !s.is_empty()).unwrap_or("auto"),
+            "ttsProvider": cfg.voice.tts_provider.as_deref().filter(|s| !s.is_empty()).unwrap_or("auto"),
             "ttsVoice": cfg.voice.tts_voice.as_deref().map(str::trim).filter(|s| !s.is_empty()),
             // Presence flags only — raw keys never cross into the frontend.
             "deepgramApiKeySet": cfg.voice.deepgram_api_key.as_deref().is_some_and(|s| !s.trim().is_empty()),

--- a/src-tauri/src/helpers/mod.rs
+++ b/src-tauri/src/helpers/mod.rs
@@ -26,10 +26,10 @@ pub mod secure_files;
 // them.
 pub use config::{
     AGENT_TIMEOUT_SECONDS_DEFAULT, FONT_SIZE_MAX, FONT_SIZE_MIN, clamp_font_size,
-    normalize_default_share_mode, normalize_devshell_enabled, normalize_devshell_mode,
-    normalize_mcp_project_configs, normalize_new_tab_kind, normalize_optional_timeout_seconds,
-    normalize_thinking_level, normalize_timeout_seconds, normalize_tool_visibility,
-    normalize_update_channel, normalize_visibility, parse_config_toml,
+    normalize_conversation_engine, normalize_default_share_mode, normalize_devshell_enabled,
+    normalize_devshell_mode, normalize_mcp_project_configs, normalize_new_tab_kind,
+    normalize_optional_timeout_seconds, normalize_thinking_level, normalize_timeout_seconds,
+    normalize_tool_visibility, normalize_update_channel, normalize_visibility, parse_config_toml,
     parse_host_startup_auto_approve,
 };
 pub use names::{sanitize_filename_segment, validate_state_name};

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -315,6 +315,8 @@ pub fn run() {
             commands::voice_convo::voice_convo_speak_end,
             commands::voice_convo::voice_convo_cancel_speech,
             commands::voice_convo::voice_convo_force_end_turn,
+            commands::voice_convo::voice_convo_test_providers,
+            commands::voice_convo::voice_convo_list_voices,
             commands::boot::boot_stage,
             commands::boot::boot_ok,
             commands::devshell::devshell_status,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -164,7 +164,8 @@ pub fn run() {
         .manage(voice::VoiceProviderRegistry::new(
             voice::VoiceProviderRegistry::default_model_root(),
         ))
-        .manage(voice::AudioPlayer::new());
+        .manage(voice::AudioPlayer::new())
+        .manage(voice::ConversationEngine::new());
     let builder = builder
         .on_window_event(|window, event| match event {
             tauri::WindowEvent::Resized(_) | tauri::WindowEvent::Moved(_) => {
@@ -307,6 +308,13 @@ pub fn run() {
             commands::voice::voice_cancel_recording,
             commands::voice::voice_speak,
             commands::voice::voice_stop_playback,
+            commands::voice_convo::voice_convo_status,
+            commands::voice_convo::voice_convo_start,
+            commands::voice_convo::voice_convo_stop,
+            commands::voice_convo::voice_convo_speak_chunk,
+            commands::voice_convo::voice_convo_speak_end,
+            commands::voice_convo::voice_convo_cancel_speech,
+            commands::voice_convo::voice_convo_force_end_turn,
             commands::boot::boot_stage,
             commands::boot::boot_ok,
             commands::devshell::devshell_status,

--- a/src-tauri/src/server/http.rs
+++ b/src-tauri/src/server/http.rs
@@ -70,10 +70,7 @@ struct AssetQuery {
 /// paired transport. Routed through the relay so it reuses the exact
 /// jailed read path (`read_paste_image_base64`: pastes dir only,
 /// 32 MiB cap) rather than growing a second file-serving surface.
-async fn asset_handler(
-    State(ctx): State<GatewayCtx>,
-    Query(query): Query<AssetQuery>,
-) -> Response {
+async fn asset_handler(State(ctx): State<GatewayCtx>, Query(query): Query<AssetQuery>) -> Response {
     use base64::Engine;
     if ctx.remote.devices.verify_token(&query.token).is_none() {
         return (StatusCode::UNAUTHORIZED, "unauthorized").into_response();
@@ -122,8 +119,7 @@ pub async fn serve(
             )
             .await
             .map_err(|e| format!("tls config: {e}"))?;
-            let listener =
-                std::net::TcpListener::bind(addr).map_err(|e| format!("bind: {e}"))?;
+            let listener = std::net::TcpListener::bind(addr).map_err(|e| format!("bind: {e}"))?;
             listener
                 .set_nonblocking(true)
                 .map_err(|e| format!("nonblocking: {e}"))?;

--- a/src-tauri/src/server/remote/integration_tests.rs
+++ b/src-tauri/src/server/remote/integration_tests.rs
@@ -32,7 +32,8 @@ async fn spawn_gateway() -> Harness {
         remote: Arc::clone(&remote),
         relay: Arc::new(EchoRelay),
     };
-    let router = crate::server::http::router(ctx.info.clone(), ctx.remote.clone(), ctx.relay.clone());
+    let router =
+        crate::server::http::router(ctx.info.clone(), ctx.remote.clone(), ctx.relay.clone());
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     tokio::spawn(async move {
@@ -60,9 +61,8 @@ async fn pair(h: &Harness) -> String {
     resp["deviceToken"].as_str().unwrap().to_string()
 }
 
-type Ws = tokio_tungstenite::WebSocketStream<
-    tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
->;
+type Ws =
+    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
 
 async fn connect(h: &Harness) -> Ws {
     let (ws, _) = tokio_tungstenite::connect_async(format!("ws://{}/ws", h.addr))
@@ -95,7 +95,11 @@ async fn full_flow_pair_hello_invoke_subscribe_event() {
     let token = pair(&h).await;
     let mut ws = connect(&h).await;
 
-    send(&mut ws, json!({ "t": "hello", "protocol": 1, "token": token })).await;
+    send(
+        &mut ws,
+        json!({ "t": "hello", "protocol": 1, "token": token }),
+    )
+    .await;
     let hello_ok = next_json(&mut ws).await;
     assert_eq!(hello_ok["t"], "hello_ok");
     assert_eq!(hello_ok["host"]["displayName"], "test");
@@ -123,9 +127,10 @@ async fn full_flow_pair_hello_invoke_subscribe_event() {
     .await;
     let barrier = next_json(&mut ws).await;
     assert_eq!(barrier["id"], "i-2");
-    h.remote
-        .hub
-        .publish("agent-response", "\"{\\\"type\\\":\\\"ready\\\"}\"".to_string());
+    h.remote.hub.publish(
+        "agent-response",
+        "\"{\\\"type\\\":\\\"ready\\\"}\"".to_string(),
+    );
     let event = next_json(&mut ws).await;
     assert_eq!(event["t"], "event");
     assert_eq!(event["topic"], "agent-response");
@@ -152,14 +157,16 @@ async fn unsubscribed_topic_is_not_delivered() {
     let h = spawn_gateway().await;
     let token = pair(&h).await;
     let mut ws = connect(&h).await;
-    send(&mut ws, json!({ "t": "hello", "protocol": 1, "token": token })).await;
+    send(
+        &mut ws,
+        json!({ "t": "hello", "protocol": 1, "token": token }),
+    )
+    .await;
     assert_eq!(next_json(&mut ws).await["t"], "hello_ok");
 
     // No sub for agent-response; publish, then invoke — the invoke
     // result must be the next frame (event was filtered out).
-    h.remote
-        .hub
-        .publish("agent-response", "\"x\"".to_string());
+    h.remote.hub.publish("agent-response", "\"x\"".to_string());
     send(
         &mut ws,
         json!({ "t": "invoke", "id": "i-9", "cmd": "host_info", "args": {} }),
@@ -175,7 +182,11 @@ async fn revocation_closes_the_live_session() {
     let h = spawn_gateway().await;
     let token = pair(&h).await;
     let mut ws = connect(&h).await;
-    send(&mut ws, json!({ "t": "hello", "protocol": 1, "token": token.clone() })).await;
+    send(
+        &mut ws,
+        json!({ "t": "hello", "protocol": 1, "token": token.clone() }),
+    )
+    .await;
     let hello_ok = next_json(&mut ws).await;
     let device_id = hello_ok["deviceId"].as_str().unwrap().to_string();
 

--- a/src-tauri/src/server/remote/policy.rs
+++ b/src-tauri/src/server/remote/policy.rs
@@ -189,6 +189,16 @@ pub const COMMAND_POLICIES: &[(&str, RemotePolicy)] = &[
     ("voice_cancel_recording", Deny(DESKTOP_ONLY)),
     ("voice_speak", Deny(DESKTOP_ONLY)),
     ("voice_stop_playback", Deny(DESKTOP_ONLY)),
+    // voice conversation engine (device-local mic + speakers)
+    ("voice_convo_start", Deny(DESKTOP_ONLY)),
+    ("voice_convo_stop", Deny(DESKTOP_ONLY)),
+    ("voice_convo_status", Deny(DESKTOP_ONLY)),
+    ("voice_convo_force_end_turn", Deny(DESKTOP_ONLY)),
+    ("voice_convo_speak_chunk", Deny(DESKTOP_ONLY)),
+    ("voice_convo_speak_end", Deny(DESKTOP_ONLY)),
+    ("voice_convo_cancel_speech", Deny(DESKTOP_ONLY)),
+    ("voice_convo_test_providers", Deny(DESKTOP_ONLY)),
+    ("voice_convo_list_voices", Deny(DESKTOP_ONLY)),
     // native windows
     ("native_window_open_canvas", Deny(DESKTOP_ONLY)),
     ("native_window_save_canvas", Deny(DESKTOP_ONLY)),
@@ -261,15 +271,20 @@ pub fn root_arg_value(cmd: &str, args: &serde_json::Value) -> Option<String> {
     let key = match cmd {
         "git_status" => "path",
         "git_working_context" => "cwd",
-        "git_worktrees" | "git_branch_list" | "git_fetch_all" | "gh_branch_status"
-        | "gh_checks" | "gh_repo_overview" | "gh_repo_avatar_url" | "gh_issue_list"
-        | "gh_issue_view" | "fs_discover_project_icon" => "projectPath",
+        "git_worktrees"
+        | "git_branch_list"
+        | "git_fetch_all"
+        | "gh_branch_status"
+        | "gh_checks"
+        | "gh_repo_overview"
+        | "gh_repo_avatar_url"
+        | "gh_issue_list"
+        | "gh_issue_view"
+        | "fs_discover_project_icon" => "projectPath",
         // fs_* + git diff/status/show family all name it `root`.
         _ => "root",
     };
-    args.get(key)
-        .and_then(|v| v.as_str())
-        .map(str::to_string)
+    args.get(key).and_then(|v| v.as_str()).map(str::to_string)
 }
 
 /// `shell_open` may omit its cwd (defaults to home); every other
@@ -427,9 +442,7 @@ mod tests {
             agent_command_remote_denial(&json!({"type": "mutation_ack", "mutationId": "m1"}))
                 .is_some()
         );
-        assert!(
-            agent_command_remote_denial(&json!({"type": "frontend_state_patch"})).is_some()
-        );
+        assert!(agent_command_remote_denial(&json!({"type": "frontend_state_patch"})).is_some());
         assert!(agent_command_remote_denial(&json!({"type": "set_model"})).is_none());
         assert!(agent_command_remote_denial(&json!({"no": "type"})).is_none());
     }
@@ -450,13 +463,15 @@ mod tests {
             Some("/w")
         );
         assert_eq!(
-            root_arg_value("gh_checks", &json!({"projectPath": "/p", "branch": "main"}))
-                .as_deref(),
+            root_arg_value("gh_checks", &json!({"projectPath": "/p", "branch": "main"})).as_deref(),
             Some("/p")
         );
         assert_eq!(
-            root_arg_value("shell_open", &json!({"args": {"tabId": "t", "cwd": "/proj"}}))
-                .as_deref(),
+            root_arg_value(
+                "shell_open",
+                &json!({"args": {"tabId": "t", "cwd": "/proj"}})
+            )
+            .as_deref(),
             Some("/proj")
         );
         // shell_open with no cwd → None (allowed default); others → None

--- a/src-tauri/src/server/remote/relay.rs
+++ b/src-tauri/src/server/remote/relay.rs
@@ -58,8 +58,7 @@ impl TauriRelay {
             .flatten()
             .map(|raw| policy::allowed_roots_from_projects_json(&raw))
             .unwrap_or_default();
-        *self.roots.lock().expect("roots lock") =
-            Some((std::time::Instant::now(), roots.clone()));
+        *self.roots.lock().expect("roots lock") = Some((std::time::Instant::now(), roots.clone()));
         roots
     }
 
@@ -220,7 +219,10 @@ impl TauriRelay {
             )?),
             "start_agent" => {
                 let state = app.state::<crate::agent_process::AgentProcesses>();
-                to_value(crate::agent_commands::start_agent(state.clone(), app.clone())?)
+                to_value(crate::agent_commands::start_agent(
+                    state.clone(),
+                    app.clone(),
+                )?)
             }
             "send_message" => {
                 let state = app.state::<crate::agent_process::AgentProcesses>();
@@ -292,8 +294,7 @@ impl TauriRelay {
                 let server = app.state::<Arc<crate::server::ServerState>>();
                 let remote = app.state::<Arc<super::RemoteState>>();
                 to_value(
-                    crate::commands::remote::remote_status(server.clone(), remote.clone())
-                        .await?,
+                    crate::commands::remote::remote_status(server.clone(), remote.clone()).await?,
                 )
             }
             // ── shells — the user's own interactive terminals ─────────
@@ -331,7 +332,10 @@ impl TauriRelay {
             }
             "shell_close" => {
                 let state = app.state::<crate::shell::ShellRegistry>();
-                to_value(crate::shell::shell_close(state.clone(), arg(&args, "tabId")?)?)
+                to_value(crate::shell::shell_close(
+                    state.clone(),
+                    arg(&args, "tabId")?,
+                )?)
             }
             "shell_is_busy" => {
                 let state = app.state::<crate::shell::ShellRegistry>();
@@ -421,13 +425,12 @@ impl TauriRelay {
                 arg(&args, "path")?,
             )?),
             "fs_discover_project_icon" => to_value(
-                crate::commands::fs::fs_discover_project_icon(arg(&args, "projectPath")?)
-                    .await?,
+                crate::commands::fs::fs_discover_project_icon(arg(&args, "projectPath")?).await?,
             ),
             // ── git + gh reads ────────────────────────────────────────
-            "git_status" => to_value(
-                crate::commands::git::status::git_status(arg(&args, "path")?).await?,
-            ),
+            "git_status" => {
+                to_value(crate::commands::git::status::git_status(arg(&args, "path")?).await?)
+            }
             "git_working_context" => to_value(
                 crate::commands::git::status::git_working_context(arg(&args, "cwd")?).await?,
             ),
@@ -441,18 +444,15 @@ impl TauriRelay {
                     .await?,
                 )
             }
-            "git_file_status" => to_value(
-                crate::commands::git::status::git_file_status(arg(&args, "root")?).await?,
-            ),
+            "git_file_status" => {
+                to_value(crate::commands::git::status::git_file_status(arg(&args, "root")?).await?)
+            }
             "git_ignored_paths" => to_value(
                 crate::commands::git::status::git_ignored_paths(arg(&args, "root")?).await?,
             ),
             "git_file_diff" => to_value(
-                crate::commands::git::diff::git_file_diff(
-                    arg(&args, "root")?,
-                    arg(&args, "path")?,
-                )
-                .await?,
+                crate::commands::git::diff::git_file_diff(arg(&args, "root")?, arg(&args, "path")?)
+                    .await?,
             ),
             "git_file_diff_hunks" => to_value(
                 crate::commands::git::diff::git_file_diff_hunks(
@@ -469,18 +469,14 @@ impl TauriRelay {
                 .await?,
             ),
             "git_show_head" => to_value(
-                crate::commands::git::diff::git_show_head(
-                    arg(&args, "root")?,
-                    arg(&args, "path")?,
-                )
-                .await?,
-            ),
-            "git_diff_stat" => to_value(
-                crate::commands::git::diff::git_diff_stat(arg(&args, "root")?).await?,
-            ),
-            "git_worktrees" => to_value(
-                crate::commands::git::worktrees::git_worktrees(arg(&args, "projectPath")?)
+                crate::commands::git::diff::git_show_head(arg(&args, "root")?, arg(&args, "path")?)
                     .await?,
+            ),
+            "git_diff_stat" => {
+                to_value(crate::commands::git::diff::git_diff_stat(arg(&args, "root")?).await?)
+            }
+            "git_worktrees" => to_value(
+                crate::commands::git::worktrees::git_worktrees(arg(&args, "projectPath")?).await?,
             ),
             "git_branch_list" => to_value(
                 crate::commands::git::worktrees::git_branch_list(arg(&args, "projectPath")?)
@@ -501,12 +497,10 @@ impl TauriRelay {
                 .await?,
             ),
             "gh_repo_overview" => to_value(
-                crate::commands::git::github::gh_repo_overview(arg(&args, "projectPath")?)
-                    .await?,
+                crate::commands::git::github::gh_repo_overview(arg(&args, "projectPath")?).await?,
             ),
             "gh_repo_avatar_url" => to_value(
-                crate::commands::git::github::gh_repo_avatar_url(arg(&args, "projectPath")?)
-                    .await,
+                crate::commands::git::github::gh_repo_avatar_url(arg(&args, "projectPath")?).await,
             ),
             "gh_issue_list" => to_value(
                 crate::commands::git::issues::gh_issue_list(

--- a/src-tauri/src/server/remote/ws.rs
+++ b/src-tauri/src/server/remote/ws.rs
@@ -516,10 +516,7 @@ mod tests {
     #[test]
     fn oversized_run_keeps_tail_and_flags_truncation() {
         let chunk = "x".repeat(40 * 1024);
-        let batch = vec![
-            shell_frame(1, "t1", &chunk),
-            shell_frame(2, "t1", &chunk),
-        ];
+        let batch = vec![shell_frame(1, "t1", &chunk), shell_frame(2, "t1", &chunk)];
         let out = coalesce_batch(&batch);
         assert_eq!(out.len(), 1);
         let parsed: serde_json::Value = serde_json::from_str(&out[0]).unwrap();
@@ -534,10 +531,7 @@ mod tests {
     fn truncation_respects_utf8_boundaries() {
         // 4-byte scorpions guarantee the naive cut lands mid-char.
         let chunk = "🦂".repeat(20 * 1024);
-        let batch = vec![
-            shell_frame(1, "t1", &chunk),
-            shell_frame(2, "t1", &chunk),
-        ];
+        let batch = vec![shell_frame(1, "t1", &chunk), shell_frame(2, "t1", &chunk)];
         let out = coalesce_batch(&batch);
         let parsed: serde_json::Value = serde_json::from_str(&out[0]).unwrap();
         let content = parsed["payload"]["content"].as_str().unwrap();

--- a/src-tauri/src/server/tls.rs
+++ b/src-tauri/src/server/tls.rs
@@ -181,8 +181,7 @@ mod tests {
 
     #[test]
     fn pem_der_roundtrip_matches_rcgen_der() {
-        let certified =
-            rcgen::generate_simple_self_signed(vec!["test.local".to_string()]).unwrap();
+        let certified = rcgen::generate_simple_self_signed(vec!["test.local".to_string()]).unwrap();
         let der = pem_certificate_der(&certified.cert.pem()).unwrap();
         assert_eq!(der, certified.cert.der().as_ref());
     }

--- a/src-tauri/src/voice/audio.rs
+++ b/src-tauri/src/voice/audio.rs
@@ -137,7 +137,7 @@ pub(super) fn normalize_interleaved_f64(input: &[f64], channels: u16) -> Vec<f32
     normalize_interleaved_samples(input, channels)
 }
 
-fn normalize_interleaved_i8(input: &[i8], channels: u16) -> Vec<f32> {
+pub(super) fn normalize_interleaved_i8(input: &[i8], channels: u16) -> Vec<f32> {
     normalize_interleaved_samples(input, channels)
 }
 
@@ -145,7 +145,7 @@ pub(super) fn normalize_interleaved_i16(input: &[i16], channels: u16) -> Vec<f32
     normalize_interleaved_samples(input, channels)
 }
 
-fn normalize_interleaved_i24(input: &[cpal::I24], channels: u16) -> Vec<f32> {
+pub(super) fn normalize_interleaved_i24(input: &[cpal::I24], channels: u16) -> Vec<f32> {
     normalize_interleaved_samples(input, channels)
 }
 
@@ -153,7 +153,7 @@ pub(super) fn normalize_interleaved_i32(input: &[i32], channels: u16) -> Vec<f32
     normalize_interleaved_samples(input, channels)
 }
 
-fn normalize_interleaved_i64(input: &[i64], channels: u16) -> Vec<f32> {
+pub(super) fn normalize_interleaved_i64(input: &[i64], channels: u16) -> Vec<f32> {
     normalize_interleaved_samples(input, channels)
 }
 
@@ -165,15 +165,15 @@ pub(super) fn normalize_interleaved_u16(input: &[u16], channels: u16) -> Vec<f32
     normalize_interleaved_samples(input, channels)
 }
 
-fn normalize_interleaved_u24(input: &[cpal::U24], channels: u16) -> Vec<f32> {
+pub(super) fn normalize_interleaved_u24(input: &[cpal::U24], channels: u16) -> Vec<f32> {
     normalize_interleaved_samples(input, channels)
 }
 
-fn normalize_interleaved_u32(input: &[u32], channels: u16) -> Vec<f32> {
+pub(super) fn normalize_interleaved_u32(input: &[u32], channels: u16) -> Vec<f32> {
     normalize_interleaved_samples(input, channels)
 }
 
-fn normalize_interleaved_u64(input: &[u64], channels: u16) -> Vec<f32> {
+pub(super) fn normalize_interleaved_u64(input: &[u64], channels: u16) -> Vec<f32> {
     normalize_interleaved_samples(input, channels)
 }
 
@@ -225,6 +225,74 @@ pub(super) fn resample(samples: &[f32], from_rate: u32, to_rate: u32) -> Vec<f32
 
 pub(super) fn resample_to_target_rate(samples: &[f32], sample_rate: u32) -> Vec<f32> {
     resample(samples, sample_rate, TARGET_SAMPLE_RATE)
+}
+
+/// Stateful linear resampler for chunked audio streams.
+///
+/// The batch `resample()` above interpolates over a complete buffer; calling
+/// it once per chunk resets the fractional read position at every chunk
+/// boundary, which audibly clicks. This variant carries the read position and
+/// the previous chunk's trailing sample across calls, so a stream fed chunk by
+/// chunk produces the same samples as one batch call over the concatenation.
+pub(super) struct StreamResampler {
+    from_rate: u32,
+    to_rate: u32,
+    /// Fractional read position into the virtual input, where index 0 is the
+    /// carried sample from the previous chunk (once primed).
+    pos: f64,
+    carry: f32,
+    primed: bool,
+}
+
+impl StreamResampler {
+    pub(super) fn new(from_rate: u32, to_rate: u32) -> Self {
+        Self {
+            from_rate,
+            to_rate,
+            pos: 0.0,
+            carry: 0.0,
+            primed: false,
+        }
+    }
+
+    pub(super) fn process(&mut self, input: &[f32]) -> Vec<f32> {
+        if input.is_empty() {
+            return Vec::new();
+        }
+        if self.from_rate == self.to_rate {
+            return input.to_vec();
+        }
+
+        // Virtual input: the carried sample (when primed) followed by this
+        // chunk. `pos` indexes into that concatenation.
+        let prime_len = usize::from(self.primed);
+        let virtual_len = prime_len + input.len();
+        let sample_at = |index: usize| -> f32 {
+            if index < prime_len {
+                self.carry
+            } else {
+                input[index - prime_len]
+            }
+        };
+
+        let ratio = f64::from(self.from_rate) / f64::from(self.to_rate);
+        let mut output = Vec::new();
+        // Only emit samples whose right interpolation neighbour exists; the
+        // remainder waits for the next chunk (that's the carried state).
+        while self.pos.floor() as usize + 1 < virtual_len {
+            let left = self.pos.floor() as usize;
+            let frac = (self.pos - left as f64) as f32;
+            output.push(sample_at(left) * (1.0 - frac) + sample_at(left + 1) * frac);
+            self.pos += ratio;
+        }
+
+        // Rebase `pos` so index 0 of the next call's virtual input is this
+        // chunk's final sample.
+        self.pos -= (virtual_len - 1) as f64;
+        self.carry = input[input.len() - 1];
+        self.primed = true;
+        output
+    }
 }
 
 impl AudioRecorder for CpalAudioRecorder {

--- a/src-tauri/src/voice/catalog.rs
+++ b/src-tauri/src/voice/catalog.rs
@@ -40,6 +40,7 @@ pub(crate) const DISTIL_MODEL_FILES: [(&str, Option<u64>); 5] = [
 // / `-mv` flags. See `lfm2.rs` for the runtime contract distilled from the
 // Phase 0 spike.
 pub(crate) const LFM2_ID: &str = "voice-lfm2-audio-llamacpp";
+pub(crate) const DEEPGRAM_ID: &str = "voice-deepgram-nova";
 pub(crate) const LFM2_CACHE_DIR: &str = "lfm2-audio-1.5b";
 pub(crate) const LFM2_HF_REPO: &str = "LiquidAI/LFM2-Audio-1.5B-GGUF";
 pub(crate) const LFM2_READY_MESSAGE: &str = "Ready for offline speech";

--- a/src-tauri/src/voice/convo/keys.rs
+++ b/src-tauri/src/voice/convo/keys.rs
@@ -1,0 +1,42 @@
+//! API-key resolution for the cascade conversation providers.
+//!
+//! Environment variables win over config.toml so a shell-exported key can't
+//! be silently shadowed by a stale value saved from Settings. Key VALUES must
+//! never be logged or emitted through Tauri events — only presence booleans
+//! leave this module's callers.
+
+use crate::helpers::config::VoiceConfig;
+
+pub(crate) const DEEPGRAM_KEY_ENV: &str = "DEEPGRAM_API_KEY";
+pub(crate) const CARTESIA_KEY_ENV: &str = "CARTESIA_API_KEY";
+
+pub(crate) struct CascadeKeys {
+    pub(crate) deepgram: Option<String>,
+    pub(crate) cartesia: Option<String>,
+}
+
+impl CascadeKeys {
+    pub(crate) fn complete(&self) -> bool {
+        self.deepgram.is_some() && self.cartesia.is_some()
+    }
+}
+
+pub(crate) fn resolve_cascade_keys(config: &VoiceConfig) -> CascadeKeys {
+    CascadeKeys {
+        deepgram: resolve_key(DEEPGRAM_KEY_ENV, config.deepgram_api_key.as_deref()),
+        cartesia: resolve_key(CARTESIA_KEY_ENV, config.cartesia_api_key.as_deref()),
+    }
+}
+
+fn resolve_key(env_var: &str, config_value: Option<&str>) -> Option<String> {
+    std::env::var(env_var)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .or_else(|| {
+            config_value
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_string)
+        })
+}

--- a/src-tauri/src/voice/convo/keys.rs
+++ b/src-tauri/src/voice/convo/keys.rs
@@ -15,12 +15,6 @@ pub(crate) struct CascadeKeys {
     pub(crate) cartesia: Option<String>,
 }
 
-impl CascadeKeys {
-    pub(crate) fn complete(&self) -> bool {
-        self.deepgram.is_some() && self.cartesia.is_some()
-    }
-}
-
 pub(crate) fn resolve_cascade_keys(config: &VoiceConfig) -> CascadeKeys {
     CascadeKeys {
         deepgram: resolve_key(DEEPGRAM_KEY_ENV, config.deepgram_api_key.as_deref()),

--- a/src-tauri/src/voice/convo/local.rs
+++ b/src-tauri/src/voice/convo/local.rs
@@ -110,17 +110,7 @@ pub(super) fn test_local_stt(
 /// Test seam: an LFM2 TTS stream with an injected backend.
 #[cfg(test)]
 pub(super) fn test_lfm2_tts(lfm2: Arc<dyn Lfm2Backend>) -> TtsSession {
-    let (tx, rx) = mpsc::unbounded_channel();
-    TtsSession {
-        stream: Box::new(Lfm2Tts {
-            lfm2,
-            buffer: String::new(),
-            audio_tx: Some(tx),
-            cancel: Arc::new(AtomicBool::new(false)),
-        }),
-        audio_rx: rx,
-        sample_rate: LFM2_TTS_SAMPLE_RATE,
-    }
+    lfm2_tts_session(lfm2)
 }
 
 struct LocalWhisperStt {
@@ -265,51 +255,34 @@ impl TtsConnector for Lfm2TtsConnector {
                 "The LFM2-Audio model isn't ready — set it up in Settings → Voice".to_string(),
             );
         }
-        let (tx, rx) = mpsc::unbounded_channel();
-        Ok(TtsSession {
-            stream: Box::new(Lfm2Tts {
-                lfm2: Arc::clone(&self.lfm2),
-                buffer: String::new(),
-                audio_tx: Some(tx),
-                cancel: Arc::new(AtomicBool::new(false)),
-            }),
-            audio_rx: rx,
-            sample_rate: LFM2_TTS_SAMPLE_RATE,
-        })
+        Ok(lfm2_tts_session(Arc::clone(&self.lfm2)))
     }
 }
 
-struct Lfm2Tts {
-    lfm2: Arc<dyn Lfm2Backend>,
-    buffer: String,
-    audio_tx: Option<mpsc::UnboundedSender<Vec<f32>>>,
-    cancel: Arc<AtomicBool>,
-}
+/// Build the per-clause LFM2 synthesis pipeline. Each fed clause synthesizes
+/// as its own one-shot runner call, and its audio ships the moment it's done
+/// — the first clause plays while later ones are still synthesizing. The old
+/// whole-reply single shot produced no audio until the very end and hit the
+/// runner's ~60 s generation ceiling on long replies, cutting them off
+/// mid-sentence; per-clause inputs sit far below that ceiling. When `jobs_tx`
+/// drops (flush/stop) the worker drains the queue, then drops `audio_tx` —
+/// the engine's fully-synthesized signal.
+fn lfm2_tts_session(lfm2: Arc<dyn Lfm2Backend>) -> TtsSession {
+    let (audio_tx, audio_rx) = mpsc::unbounded_channel();
+    let (jobs_tx, mut jobs_rx) = mpsc::unbounded_channel::<String>();
+    let cancel = Arc::new(AtomicBool::new(false));
 
-#[async_trait]
-impl TtsStream for Lfm2Tts {
-    async fn feed(&mut self, text: &str) -> Result<(), String> {
-        // LFM2's runner is one-shot: buffer until flush, then synthesize the
-        // whole reply. The engine pipeline is unchanged — audio just arrives
-        // in one late chunk instead of streaming.
-        self.buffer.push_str(text);
-        Ok(())
-    }
-
-    async fn flush(&mut self) -> Result<(), String> {
-        let Some(tx) = self.audio_tx.take() else {
-            return Ok(());
-        };
-        let text = std::mem::take(&mut self.buffer);
-        if text.trim().is_empty() {
-            return Ok(()); // dropping tx closes the channel = synthesis done
-        }
-        let lfm2 = Arc::clone(&self.lfm2);
-        let cancel = Arc::clone(&self.cancel);
-        tokio::spawn(async move {
-            match lfm2.tts(text, cancel).await {
+    let worker_cancel = Arc::clone(&cancel);
+    tokio::spawn(async move {
+        while let Some(text) = jobs_rx.recv().await {
+            if worker_cancel.load(Ordering::SeqCst) {
+                break;
+            }
+            match lfm2.tts(text, Arc::clone(&worker_cancel)).await {
                 Ok(audio) => {
-                    let _ = tx.send(audio.samples);
+                    if audio_tx.send(audio.samples).is_err() {
+                        break; // engine gone (barge-in teardown)
+                    }
                 }
                 Err(err) => {
                     tracing::warn!(
@@ -317,15 +290,50 @@ impl TtsStream for Lfm2Tts {
                         error = %err,
                         "local TTS synthesis failed"
                     );
+                    break;
                 }
             }
-            // tx drops here → the engine seals the clip.
-        });
+        }
+        // audio_tx drops here → the engine seals the clip.
+    });
+
+    TtsSession {
+        stream: Box::new(Lfm2Tts {
+            jobs_tx: Some(jobs_tx),
+            cancel,
+        }),
+        audio_rx,
+        sample_rate: LFM2_TTS_SAMPLE_RATE,
+    }
+}
+
+struct Lfm2Tts {
+    jobs_tx: Option<mpsc::UnboundedSender<String>>,
+    cancel: Arc<AtomicBool>,
+}
+
+#[async_trait]
+impl TtsStream for Lfm2Tts {
+    async fn feed(&mut self, text: &str) -> Result<(), String> {
+        let trimmed = text.trim();
+        if trimmed.is_empty() {
+            return Ok(());
+        }
+        if let Some(tx) = &self.jobs_tx {
+            let _ = tx.send(trimmed.to_string());
+        }
+        Ok(())
+    }
+
+    async fn flush(&mut self) -> Result<(), String> {
+        // No more input: dropping the job sender lets the worker finish the
+        // queued clauses, then close the audio channel.
+        self.jobs_tx = None;
         Ok(())
     }
 
     async fn stop(&mut self) {
         self.cancel.store(true, Ordering::SeqCst);
-        self.audio_tx = None;
+        self.jobs_tx = None;
     }
 }

--- a/src-tauri/src/voice/convo/local.rs
+++ b/src-tauri/src/voice/convo/local.rs
@@ -1,0 +1,331 @@
+//! Fully-local cascade providers — the offline path through the SAME
+//! conversation engine the cloud cascade uses.
+//!
+//! - `LocalWhisperConnector`: streaming `SttStream` built from components
+//!   already in the tree — a Rust port of the frontend's amplitude VAD
+//!   (hysteresis + silence hang) segments utterances, and each utterance is
+//!   decoded by the existing candle Distil-Whisper transcriber off the driver
+//!   thread. No semantic turn detection and no interim transcripts, but the
+//!   engine, brain, and playback pipeline are identical to the cloud path.
+//! - `Lfm2TtsConnector`: `TtsStream` over the existing one-shot LFM2 runner.
+//!   Text buffers until `flush()` (LFM2 can't stream), then the whole reply
+//!   synthesizes in one subprocess call.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use async_trait::async_trait;
+use parking_lot::Mutex;
+use tokio::sync::mpsc;
+
+use super::stt::{SttConnector, SttEvent, SttStream};
+use super::tts::{TtsConnector, TtsSession, TtsStream};
+use crate::voice::audio::compute_rms;
+use crate::voice::catalog::{DISTIL_CACHE_DIR, DISTIL_TRANSCRIPTION_TIMEOUT, TARGET_SAMPLE_RATE};
+use crate::voice::lfm2::LFM2_TTS_SAMPLE_RATE;
+use crate::voice::{CapturedAudio, Lfm2Backend, VoiceTranscriber};
+
+pub(crate) const LOCAL_STT_PROVIDER: &str = "local-whisper";
+pub(crate) const LOCAL_TTS_PROVIDER: &str = "lfm2";
+
+// Mirror of the frontend VAD (useVoiceConversation.ts) in sample counts at
+// 16 kHz: speech onset above 0.05 RMS, utterance ends after 1.1 s below 0.03.
+const VAD_SPEECH_RMS: f32 = 0.05;
+const VAD_SILENCE_RMS: f32 = 0.03;
+const VAD_SILENCE_HANG_SAMPLES: usize = TARGET_SAMPLE_RATE as usize * 1100 / 1000;
+const VAD_MAX_UTTERANCE_SAMPLES: usize = TARGET_SAMPLE_RATE as usize * 30;
+/// Rolling onset buffer so the decoded utterance includes the syllables that
+/// tripped the VAD (~300 ms).
+const ONSET_BUFFER_SAMPLES: usize = TARGET_SAMPLE_RATE as usize * 300 / 1000;
+
+pub(crate) struct LocalWhisperConnector {
+    cache_path: PathBuf,
+    transcriber: Arc<dyn VoiceTranscriber>,
+}
+
+impl LocalWhisperConnector {
+    pub(crate) fn from_registry(registry: &crate::voice::VoiceProviderRegistry) -> Self {
+        Self {
+            cache_path: registry.model_root().join(DISTIL_CACHE_DIR),
+            transcriber: registry.whisper_transcriber(),
+        }
+    }
+
+    pub(crate) fn ready(registry: &crate::voice::VoiceProviderRegistry) -> bool {
+        crate::voice::distil_model_ready(&registry.model_root().join(DISTIL_CACHE_DIR))
+    }
+}
+
+#[async_trait]
+impl SttConnector for LocalWhisperConnector {
+    async fn connect(
+        &self,
+    ) -> Result<(Box<dyn SttStream>, mpsc::UnboundedReceiver<SttEvent>), String> {
+        if !crate::voice::distil_model_ready(&self.cache_path) {
+            return Err(
+                "The local Whisper model isn't downloaded — set it up in Settings → Voice"
+                    .to_string(),
+            );
+        }
+        let (tx, rx) = mpsc::unbounded_channel();
+        Ok((
+            Box::new(LocalWhisperStt {
+                events: tx,
+                cache_path: self.cache_path.clone(),
+                transcriber: Arc::clone(&self.transcriber),
+                onset: Vec::new(),
+                utterance: Vec::new(),
+                in_speech: false,
+                silence_samples: 0,
+                cancels: Arc::new(Mutex::new(Vec::new())),
+            }),
+            rx,
+        ))
+    }
+}
+
+/// Test seam: a stream with an injected transcriber and no on-disk model
+/// requirement.
+#[cfg(test)]
+pub(super) fn test_local_stt(
+    transcriber: Arc<dyn VoiceTranscriber>,
+) -> (Box<dyn SttStream>, mpsc::UnboundedReceiver<SttEvent>) {
+    let (tx, rx) = mpsc::unbounded_channel();
+    (
+        Box::new(LocalWhisperStt {
+            events: tx,
+            cache_path: PathBuf::from("/nonexistent"),
+            transcriber,
+            onset: Vec::new(),
+            utterance: Vec::new(),
+            in_speech: false,
+            silence_samples: 0,
+            cancels: Arc::new(Mutex::new(Vec::new())),
+        }),
+        rx,
+    )
+}
+
+/// Test seam: an LFM2 TTS stream with an injected backend.
+#[cfg(test)]
+pub(super) fn test_lfm2_tts(lfm2: Arc<dyn Lfm2Backend>) -> TtsSession {
+    let (tx, rx) = mpsc::unbounded_channel();
+    TtsSession {
+        stream: Box::new(Lfm2Tts {
+            lfm2,
+            buffer: String::new(),
+            audio_tx: Some(tx),
+            cancel: Arc::new(AtomicBool::new(false)),
+        }),
+        audio_rx: rx,
+        sample_rate: LFM2_TTS_SAMPLE_RATE,
+    }
+}
+
+struct LocalWhisperStt {
+    events: mpsc::UnboundedSender<SttEvent>,
+    cache_path: PathBuf,
+    transcriber: Arc<dyn VoiceTranscriber>,
+    onset: Vec<f32>,
+    utterance: Vec<f32>,
+    in_speech: bool,
+    silence_samples: usize,
+    /// Cancel flags for in-flight decodes, flipped on close().
+    cancels: Arc<Mutex<Vec<Arc<AtomicBool>>>>,
+}
+
+impl LocalWhisperStt {
+    fn finalize_utterance(&mut self) {
+        self.in_speech = false;
+        self.silence_samples = 0;
+        let samples = std::mem::take(&mut self.utterance);
+        // Anything below ~200 ms is a click, not speech.
+        if samples.len() < TARGET_SAMPLE_RATE as usize / 5 {
+            let _ = self.events.send(SttEvent::EndOfTurn {
+                transcript: String::new(),
+            });
+            return;
+        }
+        let events = self.events.clone();
+        let transcriber = Arc::clone(&self.transcriber);
+        let cache_path = self.cache_path.clone();
+        let cancel = Arc::new(AtomicBool::new(false));
+        self.cancels.lock().push(Arc::clone(&cancel));
+        // Decode off the driver thread; the conversation keeps listening
+        // while the previous utterance transcribes.
+        tokio::spawn(async move {
+            let decode = tokio::task::spawn_blocking(move || {
+                transcriber.transcribe(
+                    &cache_path,
+                    CapturedAudio {
+                        samples,
+                        sample_rate: TARGET_SAMPLE_RATE,
+                    },
+                    &cancel,
+                )
+            });
+            let outcome = tokio::time::timeout(DISTIL_TRANSCRIPTION_TIMEOUT, decode).await;
+            let event = match outcome {
+                Err(_) => SttEvent::Error("local transcription timed out".to_string()),
+                Ok(Err(join_err)) => {
+                    SttEvent::Error(format!("local transcription failed: {join_err}"))
+                }
+                Ok(Ok(Err(decode_err))) => SttEvent::Error(decode_err),
+                Ok(Ok(Ok(transcript))) => SttEvent::EndOfTurn { transcript },
+            };
+            let _ = events.send(event);
+        });
+    }
+}
+
+#[async_trait]
+impl SttStream for LocalWhisperStt {
+    async fn send_audio(&mut self, pcm_16k: &[f32]) -> Result<(), String> {
+        let rms = compute_rms(pcm_16k);
+        if !self.in_speech {
+            self.onset.extend_from_slice(pcm_16k);
+            let overflow = self.onset.len().saturating_sub(ONSET_BUFFER_SAMPLES);
+            if overflow > 0 {
+                self.onset.drain(..overflow);
+            }
+            if rms >= VAD_SPEECH_RMS {
+                self.in_speech = true;
+                self.silence_samples = 0;
+                self.utterance = std::mem::take(&mut self.onset);
+                let _ = self.events.send(SttEvent::StartOfTurn {
+                    transcript: String::new(),
+                });
+            }
+            return Ok(());
+        }
+
+        self.utterance.extend_from_slice(pcm_16k);
+        if rms < VAD_SILENCE_RMS {
+            self.silence_samples += pcm_16k.len();
+        } else {
+            self.silence_samples = 0;
+        }
+        if self.silence_samples >= VAD_SILENCE_HANG_SAMPLES
+            || self.utterance.len() >= VAD_MAX_UTTERANCE_SAMPLES
+        {
+            self.finalize_utterance();
+        }
+        Ok(())
+    }
+
+    async fn keepalive(&mut self) {}
+
+    async fn finalize_turn(&mut self) {
+        if self.in_speech {
+            self.finalize_utterance();
+        }
+    }
+
+    async fn close(&mut self) {
+        for cancel in self.cancels.lock().drain(..) {
+            cancel.store(true, Ordering::SeqCst);
+        }
+    }
+}
+
+pub(crate) struct Lfm2TtsConnector {
+    lfm2: Arc<dyn Lfm2Backend>,
+    model_root: PathBuf,
+}
+
+impl Lfm2TtsConnector {
+    pub(crate) fn from_registry(registry: &crate::voice::VoiceProviderRegistry) -> Self {
+        Self {
+            lfm2: registry.lfm2_backend(),
+            model_root: registry.model_root().to_path_buf(),
+        }
+    }
+
+    pub(crate) fn ready(registry: &crate::voice::VoiceProviderRegistry) -> bool {
+        let lfm2 = registry.lfm2_backend();
+        lfm2.binary_available()
+            && crate::voice::lfm2_model_ready(
+                &registry
+                    .model_root()
+                    .join(crate::voice::catalog::LFM2_CACHE_DIR),
+            )
+    }
+}
+
+#[async_trait]
+impl TtsConnector for Lfm2TtsConnector {
+    async fn connect(&self) -> Result<TtsSession, String> {
+        let ready = self.lfm2.binary_available()
+            && crate::voice::lfm2_model_ready(
+                &self.model_root.join(crate::voice::catalog::LFM2_CACHE_DIR),
+            );
+        if !ready {
+            return Err(
+                "The LFM2-Audio model isn't ready — set it up in Settings → Voice".to_string(),
+            );
+        }
+        let (tx, rx) = mpsc::unbounded_channel();
+        Ok(TtsSession {
+            stream: Box::new(Lfm2Tts {
+                lfm2: Arc::clone(&self.lfm2),
+                buffer: String::new(),
+                audio_tx: Some(tx),
+                cancel: Arc::new(AtomicBool::new(false)),
+            }),
+            audio_rx: rx,
+            sample_rate: LFM2_TTS_SAMPLE_RATE,
+        })
+    }
+}
+
+struct Lfm2Tts {
+    lfm2: Arc<dyn Lfm2Backend>,
+    buffer: String,
+    audio_tx: Option<mpsc::UnboundedSender<Vec<f32>>>,
+    cancel: Arc<AtomicBool>,
+}
+
+#[async_trait]
+impl TtsStream for Lfm2Tts {
+    async fn feed(&mut self, text: &str) -> Result<(), String> {
+        // LFM2's runner is one-shot: buffer until flush, then synthesize the
+        // whole reply. The engine pipeline is unchanged — audio just arrives
+        // in one late chunk instead of streaming.
+        self.buffer.push_str(text);
+        Ok(())
+    }
+
+    async fn flush(&mut self) -> Result<(), String> {
+        let Some(tx) = self.audio_tx.take() else {
+            return Ok(());
+        };
+        let text = std::mem::take(&mut self.buffer);
+        if text.trim().is_empty() {
+            return Ok(()); // dropping tx closes the channel = synthesis done
+        }
+        let lfm2 = Arc::clone(&self.lfm2);
+        let cancel = Arc::clone(&self.cancel);
+        tokio::spawn(async move {
+            match lfm2.tts(text, cancel).await {
+                Ok(audio) => {
+                    let _ = tx.send(audio.samples);
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        target: "aethon::voice::convo",
+                        error = %err,
+                        "local TTS synthesis failed"
+                    );
+                }
+            }
+            // tx drops here → the engine seals the clip.
+        });
+        Ok(())
+    }
+
+    async fn stop(&mut self) {
+        self.cancel.store(true, Ordering::SeqCst);
+        self.audio_tx = None;
+    }
+}

--- a/src-tauri/src/voice/convo/mic.rs
+++ b/src-tauri/src/voice/convo/mic.rs
@@ -1,0 +1,85 @@
+//! Streaming microphone capture for the conversation engine.
+//!
+//! Unlike the batch `CpalAudioRecorder` (record → stop → resample the whole
+//! clip), this opens the default input device and delivers mono 16 kHz f32
+//! frames continuously over a channel. Resampling happens in the callback via
+//! `StreamResampler`, which carries state across chunks so frame boundaries
+//! don't click.
+
+use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+use tokio::sync::mpsc;
+
+use crate::voice::audio::{
+    StreamResampler, normalize_interleaved_f32, normalize_interleaved_f64,
+    normalize_interleaved_i8, normalize_interleaved_i16, normalize_interleaved_i24,
+    normalize_interleaved_i32, normalize_interleaved_i64, normalize_interleaved_u8,
+    normalize_interleaved_u16, normalize_interleaved_u24, normalize_interleaved_u32,
+    normalize_interleaved_u64,
+};
+use crate::voice::catalog::TARGET_SAMPLE_RATE;
+
+/// Keeps the input stream alive; dropping it stops capture and closes the
+/// frames channel (the callback's sender fails and is ignored).
+pub(crate) struct MicHandle {
+    _stream: cpal::Stream,
+}
+
+pub(super) fn start_streaming_mic() -> Result<(MicHandle, mpsc::UnboundedReceiver<Vec<f32>>), String>
+{
+    let host = cpal::default_host();
+    let device = host
+        .default_input_device()
+        .ok_or_else(|| "No default microphone input device is available".to_string())?;
+    let supported_config = device
+        .default_input_config()
+        .map_err(|e| format!("Failed to read microphone input config: {e}"))?;
+    let device_rate = supported_config.sample_rate();
+    let channels = supported_config.channels();
+    let stream_config: cpal::StreamConfig = supported_config.clone().into();
+    let (tx, rx) = mpsc::unbounded_channel::<Vec<f32>>();
+
+    macro_rules! build_input_stream {
+        ($sample_ty:ty, $normalize:path) => {{
+            let tx = tx.clone();
+            let mut resampler = StreamResampler::new(device_rate, TARGET_SAMPLE_RATE);
+            device.build_input_stream(
+                &stream_config,
+                move |data: &[$sample_ty], _| {
+                    let frame = resampler.process(&$normalize(data, channels));
+                    if !frame.is_empty() {
+                        // Receiver gone = the driver ended; nothing to do.
+                        let _ = tx.send(frame);
+                    }
+                },
+                move |err| {
+                    tracing::warn!(target: "aethon::voice::convo", error = %err, "input stream error");
+                },
+                None,
+            )
+        }};
+    }
+
+    let stream = match supported_config.sample_format() {
+        cpal::SampleFormat::I8 => build_input_stream!(i8, normalize_interleaved_i8),
+        cpal::SampleFormat::I16 => build_input_stream!(i16, normalize_interleaved_i16),
+        cpal::SampleFormat::I24 => build_input_stream!(cpal::I24, normalize_interleaved_i24),
+        cpal::SampleFormat::I32 => build_input_stream!(i32, normalize_interleaved_i32),
+        cpal::SampleFormat::I64 => build_input_stream!(i64, normalize_interleaved_i64),
+        cpal::SampleFormat::U8 => build_input_stream!(u8, normalize_interleaved_u8),
+        cpal::SampleFormat::U16 => build_input_stream!(u16, normalize_interleaved_u16),
+        cpal::SampleFormat::U24 => build_input_stream!(cpal::U24, normalize_interleaved_u24),
+        cpal::SampleFormat::U32 => build_input_stream!(u32, normalize_interleaved_u32),
+        cpal::SampleFormat::U64 => build_input_stream!(u64, normalize_interleaved_u64),
+        cpal::SampleFormat::F32 => build_input_stream!(f32, normalize_interleaved_f32),
+        cpal::SampleFormat::F64 => build_input_stream!(f64, normalize_interleaved_f64),
+        other => {
+            return Err(format!("Unsupported microphone sample format: {other:?}"));
+        }
+    }
+    .map_err(|e| format!("Failed to open microphone input stream: {e}"))?;
+    stream
+        .play()
+        .map_err(|e| format!("Failed to start microphone input stream: {e}"))?;
+
+    Ok((MicHandle { _stream: stream }, rx))
+}

--- a/src-tauri/src/voice/convo/mod.rs
+++ b/src-tauri/src/voice/convo/mod.rs
@@ -1,0 +1,758 @@
+//! Streaming conversation engine — the "cascade" voice pipeline.
+//!
+//! The batch registry (`voice/registry.rs`) serves a record→stop→transcribe
+//! lifecycle; a hands-free conversation is a long-lived duplex session, so it
+//! gets its own subsystem instead of a fourth arm in the provider match. The
+//! engine owns the realtime audio plane only: streaming microphone → cloud
+//! STT (semantic turn detection) → turn events up to the frontend, and brain
+//! text back down → streaming TTS → streaming playback. Cognition (the voice
+//! brain) lives in the agent bridge; the frontend glues the two.
+//!
+//! Half-duplex by design: while synthesized speech plays, mic frames are
+//! captured (for the pre-roll ring + barge-in detection) but NOT forwarded to
+//! the STT socket, so the model never hears the app's own voice. A sustained
+//! loud interruption stops playback and replays the last ~500 ms of mic audio
+//! into the STT stream, so the recognizer sees the user's interjection from
+//! its first word.
+
+mod keys;
+mod mic;
+mod stt;
+#[cfg(test)]
+mod tests;
+mod tts;
+
+pub(crate) use keys::resolve_cascade_keys;
+pub(crate) use stt::{DeepgramFluxConnector, SttConnector, SttEvent, SttStream};
+pub(crate) use tts::{CartesiaConnector, TtsConnector, TtsStream};
+
+use std::collections::VecDeque;
+use std::ops::ControlFlow;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use parking_lot::Mutex;
+use serde::Serialize;
+use tauri::{AppHandle, Emitter};
+use tokio::sync::mpsc;
+
+use super::audio::compute_rms;
+use super::{AudioPlayer, StreamingPlaybackHandle, VoiceLevelPayload};
+
+/// 80 ms of 16 kHz mono — Deepgram's recommended streaming chunk size.
+const OUTBOUND_FRAME_SAMPLES: usize = 1280;
+/// ~500 ms of mic audio replayed into STT after a barge-in.
+const PRE_ROLL_SAMPLES: usize = 8000;
+/// Mic RMS that counts toward an interruption while speech is playing. Above
+/// typical speaker bleed, below normal close-mic speech (see
+/// `VoiceLevelPayload` docs: speech ≈ 0.05–0.3).
+const BARGE_IN_RMS: f32 = 0.08;
+/// How long the level must stay above `BARGE_IN_RMS` to trigger barge-in.
+const BARGE_IN_SUSTAIN_MS: usize = 200;
+/// Keep the STT socket alive while the mic gate is closed during playback
+/// (Deepgram idles out after ~10 s without audio).
+const KEEPALIVE_SECS: u64 = 5;
+/// Throttle for `voice://level` re-emission (~30 Hz, matches the batch path).
+const LEVEL_EMIT_MS: u64 = 33;
+/// Poll cadence for "has the sealed playback clip finished draining".
+const DRAIN_POLL_MS: u64 = 50;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum ConvoState {
+    Idle,
+    Listening,
+    UserSpeaking,
+    AwaitingBrain,
+    Speaking,
+}
+
+/// Playback abstraction so the driver is testable without an output device.
+/// `AudioPlayer` is the production implementation.
+pub(crate) trait PlaybackSink: Send + Sync {
+    fn start_stream(
+        &self,
+        source_rate: u32,
+        app: Option<AppHandle>,
+    ) -> Result<Box<dyn StreamingPlayback>, String>;
+    fn stop(&self);
+}
+
+pub(crate) trait StreamingPlayback: Send {
+    fn append(&mut self, samples: &[f32]);
+    fn mark_complete(&mut self);
+    fn is_drained(&self) -> bool;
+}
+
+impl StreamingPlayback for StreamingPlaybackHandle {
+    fn append(&mut self, samples: &[f32]) {
+        StreamingPlaybackHandle::append(self, samples);
+    }
+    fn mark_complete(&mut self) {
+        StreamingPlaybackHandle::mark_complete(self);
+    }
+    fn is_drained(&self) -> bool {
+        StreamingPlaybackHandle::is_drained(self)
+    }
+}
+
+impl PlaybackSink for AudioPlayer {
+    fn start_stream(
+        &self,
+        source_rate: u32,
+        app: Option<AppHandle>,
+    ) -> Result<Box<dyn StreamingPlayback>, String> {
+        AudioPlayer::start_stream(self, source_rate, app).map(|h| Box::new(h) as _)
+    }
+    fn stop(&self) {
+        AudioPlayer::stop(self);
+    }
+}
+
+enum EngineCommand {
+    SpeakChunk(String),
+    SpeakEnd,
+    CancelSpeech,
+    ForceEndTurn,
+}
+
+/// Microphone side of `start_with_io`: the frame channel plus the handle
+/// keeping the capture stream alive (`None` in tests, which feed frames
+/// directly).
+pub(crate) struct MicInput {
+    pub(crate) frames_rx: mpsc::UnboundedReceiver<Vec<f32>>,
+    pub(crate) handle: Option<mic::MicHandle>,
+}
+
+/// Observable engine state shared with status queries and tests.
+pub(crate) struct ConvoShared {
+    state: Mutex<ConvoState>,
+    last_turn: Mutex<Option<String>>,
+    last_error: Mutex<Option<String>>,
+}
+
+impl ConvoShared {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            state: Mutex::new(ConvoState::Listening),
+            last_turn: Mutex::new(None),
+            last_error: Mutex::new(None),
+        })
+    }
+
+    pub(crate) fn state(&self) -> ConvoState {
+        *self.state.lock()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn last_turn(&self) -> Option<String> {
+        self.last_turn.lock().clone()
+    }
+
+    pub(crate) fn last_error(&self) -> Option<String> {
+        self.last_error.lock().clone()
+    }
+}
+
+struct ActiveConvo {
+    id: u64,
+    cmd_tx: mpsc::UnboundedSender<EngineCommand>,
+    shared: Arc<ConvoShared>,
+    abort: tokio::task::AbortHandle,
+    /// Dropping stops mic capture. `None` in tests, which feed frames directly.
+    _mic: Option<mic::MicHandle>,
+}
+
+/// Tauri-managed singleton. One conversation at a time.
+pub(crate) struct ConversationEngine {
+    inner: Arc<Mutex<Option<ActiveConvo>>>,
+    next_id: AtomicU64,
+}
+
+impl Default for ConversationEngine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ConversationEngine {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(None)),
+            next_id: AtomicU64::new(0),
+        }
+    }
+
+    pub(crate) fn is_active(&self) -> bool {
+        self.inner.lock().is_some()
+    }
+
+    pub(crate) fn state(&self) -> ConvoState {
+        self.inner
+            .lock()
+            .as_ref()
+            .map(|active| active.shared.state())
+            .unwrap_or(ConvoState::Idle)
+    }
+
+    pub(crate) fn last_error(&self) -> Option<String> {
+        self.inner
+            .lock()
+            .as_ref()
+            .and_then(|active| active.shared.last_error())
+    }
+
+    /// Open the microphone, connect STT, and start the driver. Fails fast if
+    /// a conversation is already running or the STT connection is refused, so
+    /// the IPC caller gets a real error instead of a fire-and-forget event.
+    pub(crate) async fn start(
+        &self,
+        app: Option<AppHandle>,
+        stt: Arc<dyn SttConnector>,
+        tts: Arc<dyn TtsConnector>,
+        playback: Arc<dyn PlaybackSink>,
+    ) -> Result<(), String> {
+        // Reserve the slot before any await so two concurrent starts can't
+        // both pass the occupancy check.
+        {
+            let guard = self.inner.lock();
+            if guard.is_some() {
+                return Err("A voice conversation is already running".to_string());
+            }
+        }
+        let (stt_stream, stt_rx) = stt.connect().await?;
+        let (mic_handle, frames_rx) = mic::start_streaming_mic()?;
+        self.start_with_io(
+            app,
+            stt_stream,
+            stt_rx,
+            tts,
+            playback,
+            MicInput {
+                frames_rx,
+                handle: Some(mic_handle),
+            },
+        )
+    }
+
+    /// Test seam: identical to `start` after STT connect + mic open.
+    pub(crate) fn start_with_io(
+        &self,
+        app: Option<AppHandle>,
+        stt_stream: Box<dyn SttStream>,
+        stt_rx: mpsc::UnboundedReceiver<SttEvent>,
+        tts: Arc<dyn TtsConnector>,
+        playback: Arc<dyn PlaybackSink>,
+        mic: MicInput,
+    ) -> Result<(), String> {
+        let mut guard = self.inner.lock();
+        if guard.is_some() {
+            return Err("A voice conversation is already running".to_string());
+        }
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed) + 1;
+        let shared = ConvoShared::new();
+        let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
+        let ctx = DriverCtx {
+            app: app.clone(),
+            shared: Arc::clone(&shared),
+            stt: stt_stream,
+            tts_connector: tts,
+            playback,
+            tts_stream: None,
+            playback_handle: None,
+            state: ConvoState::Listening,
+            outbound: Vec::new(),
+            pre_roll: VecDeque::new(),
+            current_transcript: String::new(),
+            barge_sustain_samples: 0,
+            last_level_emit: Instant::now(),
+            speak_requested_at: None,
+            tts_first_audio_seen: false,
+        };
+        let driver = tokio::spawn(run_driver(ctx, mic.frames_rx, stt_rx, cmd_rx));
+        let abort = driver.abort_handle();
+
+        // Reap the slot when the driver ends on its own (STT error, mic
+        // gone), so the mic handle is dropped and a new start() can succeed
+        // without an explicit stop.
+        let inner = Arc::clone(&self.inner);
+        tokio::spawn(async move {
+            let _ = driver.await;
+            let mut slot = inner.lock();
+            if slot.as_ref().is_some_and(|active| active.id == id) {
+                *slot = None;
+            }
+        });
+
+        emit_state(&app, ConvoState::Listening, None);
+        *guard = Some(ActiveConvo {
+            id,
+            cmd_tx,
+            shared,
+            abort,
+            _mic: mic.handle,
+        });
+        Ok(())
+    }
+
+    pub(crate) fn stop(&self, app: Option<&AppHandle>) {
+        if let Some(active) = self.inner.lock().take() {
+            active.abort.abort();
+        }
+        if let Some(app) = app {
+            emit_state(&Some(app.clone()), ConvoState::Idle, None);
+        }
+    }
+
+    pub(crate) fn speak_chunk(&self, text: String) -> Result<(), String> {
+        self.send_command(EngineCommand::SpeakChunk(text))
+    }
+
+    pub(crate) fn speak_end(&self) -> Result<(), String> {
+        self.send_command(EngineCommand::SpeakEnd)
+    }
+
+    pub(crate) fn cancel_speech(&self) -> Result<(), String> {
+        self.send_command(EngineCommand::CancelSpeech)
+    }
+
+    pub(crate) fn force_end_turn(&self) -> Result<(), String> {
+        self.send_command(EngineCommand::ForceEndTurn)
+    }
+
+    fn send_command(&self, command: EngineCommand) -> Result<(), String> {
+        let guard = self.inner.lock();
+        let active = guard
+            .as_ref()
+            .ok_or_else(|| "No voice conversation is running".to_string())?;
+        active
+            .cmd_tx
+            .send(command)
+            .map_err(|_| "The voice conversation has ended".to_string())
+    }
+}
+
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct ConvoStateEvent {
+    state: ConvoState,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<&'static str>,
+}
+
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct ConvoTextEvent {
+    text: String,
+}
+
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct ConvoTurnEvent {
+    transcript: String,
+}
+
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct ConvoErrorEvent {
+    message: String,
+}
+
+#[cfg(debug_assertions)]
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct ConvoMetricEvent {
+    stage: &'static str,
+    ms: u64,
+}
+
+fn emit_state(app: &Option<AppHandle>, state: ConvoState, reason: Option<&'static str>) {
+    if let Some(app) = app {
+        let _ = app.emit("voice://convo/state", ConvoStateEvent { state, reason });
+    }
+}
+
+/// Everything the driver mutates outside of the four `select!` receivers.
+/// The receivers stay as locals in `run_driver` so the select arms can borrow
+/// them while handler methods borrow the context.
+struct DriverCtx {
+    app: Option<AppHandle>,
+    shared: Arc<ConvoShared>,
+    stt: Box<dyn SttStream>,
+    tts_connector: Arc<dyn TtsConnector>,
+    playback: Arc<dyn PlaybackSink>,
+    tts_stream: Option<Box<dyn TtsStream>>,
+    playback_handle: Option<Box<dyn StreamingPlayback>>,
+    state: ConvoState,
+    outbound: Vec<f32>,
+    pre_roll: VecDeque<f32>,
+    current_transcript: String,
+    barge_sustain_samples: usize,
+    last_level_emit: Instant,
+    speak_requested_at: Option<Instant>,
+    tts_first_audio_seen: bool,
+}
+
+impl DriverCtx {
+    fn set_state(&mut self, state: ConvoState, reason: Option<&'static str>) {
+        if self.state == state {
+            return;
+        }
+        self.state = state;
+        *self.shared.state.lock() = state;
+        emit_state(&self.app, state, reason);
+    }
+
+    fn fail(&mut self, message: String) {
+        tracing::warn!(target: "aethon::voice::convo", message = %message, "conversation error");
+        *self.shared.last_error.lock() = Some(message.clone());
+        if let Some(app) = &self.app {
+            let _ = app.emit("voice://convo/error", ConvoErrorEvent { message });
+        }
+    }
+
+    fn emit_level(&mut self, frame: &[f32]) {
+        if self.last_level_emit.elapsed() < Duration::from_millis(LEVEL_EMIT_MS) {
+            return;
+        }
+        self.last_level_emit = Instant::now();
+        if let Some(app) = &self.app {
+            let _ = app.emit(
+                "voice://level",
+                VoiceLevelPayload {
+                    level: compute_rms(frame),
+                },
+            );
+        }
+    }
+
+    fn push_pre_roll(&mut self, frame: &[f32]) {
+        self.pre_roll.extend(frame.iter().copied());
+        while self.pre_roll.len() > PRE_ROLL_SAMPLES {
+            self.pre_roll.pop_front();
+        }
+    }
+
+    async fn forward_outbound(&mut self) -> Result<(), String> {
+        while self.outbound.len() >= OUTBOUND_FRAME_SAMPLES {
+            let chunk: Vec<f32> = self.outbound.drain(..OUTBOUND_FRAME_SAMPLES).collect();
+            self.stt.send_audio(&chunk).await?;
+        }
+        Ok(())
+    }
+
+    /// One mic frame (mono f32 @ 16 kHz). Gate open → forward to STT; gate
+    /// closed (speaking) → barge-in detection only.
+    async fn handle_frame(
+        &mut self,
+        frame: Vec<f32>,
+        tts_audio_rx: &mut Option<mpsc::UnboundedReceiver<Vec<f32>>>,
+    ) -> ControlFlow<()> {
+        self.emit_level(&frame);
+        self.push_pre_roll(&frame);
+
+        match self.state {
+            ConvoState::Listening | ConvoState::UserSpeaking | ConvoState::AwaitingBrain => {
+                self.outbound.extend_from_slice(&frame);
+                if let Err(err) = self.forward_outbound().await {
+                    self.fail(format!("Speech streaming failed: {err}"));
+                    return ControlFlow::Break(());
+                }
+            }
+            ConvoState::Speaking => {
+                let sustain_target =
+                    BARGE_IN_SUSTAIN_MS * super::TARGET_SAMPLE_RATE as usize / 1000;
+                if compute_rms(&frame) >= BARGE_IN_RMS {
+                    self.barge_sustain_samples += frame.len();
+                } else {
+                    self.barge_sustain_samples = 0;
+                }
+                if self.barge_sustain_samples >= sustain_target {
+                    self.barge_sustain_samples = 0;
+                    if let Err(err) = self.barge_in(tts_audio_rx).await {
+                        self.fail(format!("Speech streaming failed: {err}"));
+                        return ControlFlow::Break(());
+                    }
+                }
+            }
+            ConvoState::Idle => {}
+        }
+        ControlFlow::Continue(())
+    }
+
+    /// The user interrupted playback: cut the audio, kill the in-flight TTS
+    /// context, and replay the pre-roll ring into STT so the recognizer sees
+    /// the interruption from its first word.
+    async fn barge_in(
+        &mut self,
+        tts_audio_rx: &mut Option<mpsc::UnboundedReceiver<Vec<f32>>>,
+    ) -> Result<(), String> {
+        self.playback.stop();
+        self.playback_handle = None;
+        *tts_audio_rx = None;
+        if let Some(mut stream) = self.tts_stream.take() {
+            stream.stop().await;
+        }
+        let replay: Vec<f32> = self.pre_roll.drain(..).collect();
+        if !replay.is_empty() {
+            self.stt.send_audio(&replay).await?;
+        }
+        self.set_state(ConvoState::Listening, Some("barge-in"));
+        Ok(())
+    }
+
+    fn handle_stt_event(&mut self, event: SttEvent) -> ControlFlow<()> {
+        match event {
+            SttEvent::StartOfTurn { transcript } => {
+                self.current_transcript = transcript.clone();
+                if matches!(
+                    self.state,
+                    ConvoState::Listening | ConvoState::AwaitingBrain
+                ) {
+                    self.set_state(ConvoState::UserSpeaking, None);
+                }
+                self.emit_interim(transcript);
+            }
+            SttEvent::Interim { transcript } => {
+                self.current_transcript = transcript.clone();
+                self.emit_interim(transcript);
+            }
+            SttEvent::EndOfTurn { transcript } => {
+                // Stale end-of-turns can arrive after a local force-end or
+                // while speech is already playing; the state guard drops them.
+                if matches!(
+                    self.state,
+                    ConvoState::Listening | ConvoState::UserSpeaking | ConvoState::AwaitingBrain
+                ) {
+                    self.finish_turn(transcript);
+                }
+            }
+            SttEvent::Error(message) => {
+                self.fail(format!("Speech recognition error: {message}"));
+                return ControlFlow::Break(());
+            }
+            SttEvent::Closed => {
+                self.fail("The speech service closed the connection".to_string());
+                return ControlFlow::Break(());
+            }
+        }
+        ControlFlow::Continue(())
+    }
+
+    fn emit_interim(&self, text: String) {
+        if let Some(app) = &self.app {
+            let _ = app.emit("voice://convo/interim", ConvoTextEvent { text });
+        }
+    }
+
+    fn finish_turn(&mut self, transcript: String) {
+        let transcript = transcript.trim().to_string();
+        self.current_transcript.clear();
+        if transcript.is_empty() {
+            self.set_state(ConvoState::Listening, None);
+            return;
+        }
+        *self.shared.last_turn.lock() = Some(transcript.clone());
+        self.set_state(ConvoState::AwaitingBrain, None);
+        if let Some(app) = &self.app {
+            let _ = app.emit("voice://convo/turn", ConvoTurnEvent { transcript });
+        }
+    }
+
+    async fn handle_command(
+        &mut self,
+        command: EngineCommand,
+        tts_audio_rx: &mut Option<mpsc::UnboundedReceiver<Vec<f32>>>,
+    ) -> ControlFlow<()> {
+        match command {
+            EngineCommand::SpeakChunk(text) => {
+                if self.tts_stream.is_none() {
+                    self.speak_requested_at = Some(Instant::now());
+                    self.tts_first_audio_seen = false;
+                    let session = match self.tts_connector.connect().await {
+                        Ok(session) => session,
+                        Err(err) => {
+                            self.fail(format!("Speech synthesis unavailable: {err}"));
+                            self.set_state(ConvoState::Listening, None);
+                            return ControlFlow::Continue(());
+                        }
+                    };
+                    let handle = match self
+                        .playback
+                        .start_stream(session.sample_rate, self.app.clone())
+                    {
+                        Ok(handle) => handle,
+                        Err(err) => {
+                            self.fail(format!("Audio output unavailable: {err}"));
+                            self.set_state(ConvoState::Listening, None);
+                            return ControlFlow::Continue(());
+                        }
+                    };
+                    self.playback_handle = Some(handle);
+                    self.tts_stream = Some(session.stream);
+                    *tts_audio_rx = Some(session.audio_rx);
+                    self.set_state(ConvoState::Speaking, None);
+                }
+                if let Some(stream) = self.tts_stream.as_mut()
+                    && let Err(err) = stream.feed(&text).await
+                {
+                    self.fail(format!("Speech synthesis failed: {err}"));
+                    self.abandon_speech(tts_audio_rx).await;
+                }
+            }
+            EngineCommand::SpeakEnd => {
+                if let Some(stream) = self.tts_stream.as_mut() {
+                    if let Err(err) = stream.flush().await {
+                        self.fail(format!("Speech synthesis failed: {err}"));
+                        self.abandon_speech(tts_audio_rx).await;
+                    }
+                } else if self.state == ConvoState::AwaitingBrain {
+                    // The brain produced no speakable text; go back to
+                    // listening so the loop doesn't wedge.
+                    self.set_state(ConvoState::Listening, None);
+                }
+            }
+            EngineCommand::CancelSpeech => {
+                self.abandon_speech(tts_audio_rx).await;
+            }
+            EngineCommand::ForceEndTurn => {
+                if matches!(self.state, ConvoState::Listening | ConvoState::UserSpeaking)
+                    && !self.current_transcript.trim().is_empty()
+                {
+                    let transcript = std::mem::take(&mut self.current_transcript);
+                    self.finish_turn(transcript);
+                }
+            }
+        }
+        ControlFlow::Continue(())
+    }
+
+    async fn abandon_speech(
+        &mut self,
+        tts_audio_rx: &mut Option<mpsc::UnboundedReceiver<Vec<f32>>>,
+    ) {
+        self.playback.stop();
+        self.playback_handle = None;
+        *tts_audio_rx = None;
+        if let Some(mut stream) = self.tts_stream.take() {
+            stream.stop().await;
+        }
+        if matches!(self.state, ConvoState::Speaking | ConvoState::AwaitingBrain) {
+            self.set_state(ConvoState::Listening, None);
+        }
+    }
+
+    fn handle_tts_audio(&mut self, samples: Vec<f32>) {
+        #[cfg(debug_assertions)]
+        if !self.tts_first_audio_seen
+            && let Some(requested) = self.speak_requested_at
+            && let Some(app) = &self.app
+        {
+            let _ = app.emit(
+                "voice://convo/metrics",
+                ConvoMetricEvent {
+                    stage: "tts-first-audio",
+                    ms: requested.elapsed().as_millis() as u64,
+                },
+            );
+        }
+        self.tts_first_audio_seen = true;
+        if let Some(handle) = self.playback_handle.as_mut() {
+            handle.append(&samples);
+        }
+    }
+
+    /// Synthesis is complete; the clip is sealed and drains on its own.
+    fn handle_tts_done(&mut self) {
+        if let Some(handle) = self.playback_handle.as_mut() {
+            handle.mark_complete();
+        }
+        self.tts_stream = None;
+    }
+
+    /// The sealed clip finished draining through the device.
+    fn finish_speaking(&mut self) {
+        self.playback_handle = None;
+        self.barge_sustain_samples = 0;
+        self.set_state(ConvoState::Listening, None);
+    }
+}
+
+async fn recv_or_pending(rx: &mut Option<mpsc::UnboundedReceiver<Vec<f32>>>) -> Option<Vec<f32>> {
+    match rx {
+        Some(rx) => rx.recv().await,
+        None => std::future::pending().await,
+    }
+}
+
+async fn run_driver(
+    mut ctx: DriverCtx,
+    mut frames_rx: mpsc::UnboundedReceiver<Vec<f32>>,
+    mut stt_rx: mpsc::UnboundedReceiver<SttEvent>,
+    mut cmd_rx: mpsc::UnboundedReceiver<EngineCommand>,
+) {
+    let mut tts_audio_rx: Option<mpsc::UnboundedReceiver<Vec<f32>>> = None;
+    let mut keepalive = tokio::time::interval(Duration::from_secs(KEEPALIVE_SECS));
+    let mut drain_poll = tokio::time::interval(Duration::from_millis(DRAIN_POLL_MS));
+
+    loop {
+        tokio::select! {
+            maybe_frame = frames_rx.recv() => {
+                let Some(frame) = maybe_frame else {
+                    ctx.fail("The microphone stream ended unexpectedly".to_string());
+                    break;
+                };
+                if ctx.handle_frame(frame, &mut tts_audio_rx).await.is_break() {
+                    break;
+                }
+            }
+            maybe_event = stt_rx.recv() => {
+                let Some(event) = maybe_event else {
+                    ctx.fail("The speech service disconnected".to_string());
+                    break;
+                };
+                if ctx.handle_stt_event(event).is_break() {
+                    break;
+                }
+            }
+            maybe_command = cmd_rx.recv() => {
+                // Channel closed = the engine slot was dropped; shut down.
+                let Some(command) = maybe_command else { break };
+                if ctx.handle_command(command, &mut tts_audio_rx).await.is_break() {
+                    break;
+                }
+            }
+            chunk = recv_or_pending(&mut tts_audio_rx), if tts_audio_rx.is_some() => {
+                match chunk {
+                    Some(samples) => ctx.handle_tts_audio(samples),
+                    None => {
+                        tts_audio_rx = None;
+                        ctx.handle_tts_done();
+                    }
+                }
+            }
+            _ = keepalive.tick(), if ctx.state == ConvoState::Speaking => {
+                ctx.stt.keepalive().await;
+            }
+            _ = drain_poll.tick(), if ctx.state == ConvoState::Speaking
+                && tts_audio_rx.is_none()
+                && ctx.tts_stream.is_none() =>
+            {
+                if ctx.playback_handle.as_ref().is_none_or(|h| h.is_drained()) {
+                    ctx.finish_speaking();
+                }
+            }
+        }
+    }
+
+    // Teardown — reached on any break. The reaper task clears the engine slot
+    // (dropping the mic) once this future returns.
+    ctx.playback.stop();
+    ctx.playback_handle = None;
+    if let Some(mut stream) = ctx.tts_stream.take() {
+        stream.stop().await;
+    }
+    ctx.stt.close().await;
+    ctx.set_state(ConvoState::Idle, None);
+}

--- a/src-tauri/src/voice/convo/mod.rs
+++ b/src-tauri/src/voice/convo/mod.rs
@@ -24,7 +24,9 @@ mod tts;
 
 pub(crate) use keys::resolve_cascade_keys;
 pub(crate) use stt::{DeepgramFluxConnector, SttConnector, SttEvent, SttStream};
-pub(crate) use tts::{CartesiaConnector, TtsConnector, TtsStream};
+pub(crate) use tts::{
+    CartesiaConnector, CartesiaVoiceInfo, TtsConnector, TtsStream, list_cartesia_voices,
+};
 
 use std::collections::VecDeque;
 use std::ops::ControlFlow;
@@ -57,6 +59,14 @@ const KEEPALIVE_SECS: u64 = 5;
 const LEVEL_EMIT_MS: u64 = 33;
 /// Poll cadence for "has the sealed playback clip finished draining".
 const DRAIN_POLL_MS: u64 = 50;
+/// Backoff schedule for reviving a dropped STT socket mid-conversation. Mic
+/// frames keep queueing while a reconnect is in flight, so speech across a
+/// brief network blip still reaches the recognizer (late but complete). The
+/// budget resets on every completed turn.
+#[cfg(not(test))]
+const STT_RECONNECT_BACKOFF_MS: [u64; 3] = [250, 1_000, 3_000];
+#[cfg(test)]
+const STT_RECONNECT_BACKOFF_MS: [u64; 3] = [10, 10, 10];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "kebab-case")]
@@ -123,6 +133,14 @@ enum EngineCommand {
 pub(crate) struct MicInput {
     pub(crate) frames_rx: mpsc::UnboundedReceiver<Vec<f32>>,
     pub(crate) handle: Option<mic::MicHandle>,
+}
+
+/// STT side of `start_with_io`: a pre-connected stream (so start fails fast
+/// on bad keys) plus the connector for mid-session reconnects.
+pub(crate) struct SttInput {
+    pub(crate) connector: Arc<dyn SttConnector>,
+    pub(crate) stream: Box<dyn SttStream>,
+    pub(crate) events: mpsc::UnboundedReceiver<SttEvent>,
 }
 
 /// Observable engine state shared with status queries and tests.
@@ -225,8 +243,11 @@ impl ConversationEngine {
         let (mic_handle, frames_rx) = mic::start_streaming_mic()?;
         self.start_with_io(
             app,
-            stt_stream,
-            stt_rx,
+            SttInput {
+                connector: stt,
+                stream: stt_stream,
+                events: stt_rx,
+            },
             tts,
             playback,
             MicInput {
@@ -240,8 +261,7 @@ impl ConversationEngine {
     pub(crate) fn start_with_io(
         &self,
         app: Option<AppHandle>,
-        stt_stream: Box<dyn SttStream>,
-        stt_rx: mpsc::UnboundedReceiver<SttEvent>,
+        stt: SttInput,
         tts: Arc<dyn TtsConnector>,
         playback: Arc<dyn PlaybackSink>,
         mic: MicInput,
@@ -256,7 +276,9 @@ impl ConversationEngine {
         let ctx = DriverCtx {
             app: app.clone(),
             shared: Arc::clone(&shared),
-            stt: stt_stream,
+            stt: stt.stream,
+            stt_connector: stt.connector,
+            reconnects_used: 0,
             tts_connector: tts,
             playback,
             tts_stream: None,
@@ -270,7 +292,7 @@ impl ConversationEngine {
             speak_requested_at: None,
             tts_first_audio_seen: false,
         };
-        let driver = tokio::spawn(run_driver(ctx, mic.frames_rx, stt_rx, cmd_rx));
+        let driver = tokio::spawn(run_driver(ctx, mic.frames_rx, stt.events, cmd_rx));
         let abort = driver.abort_handle();
 
         // Reap the slot when the driver ends on its own (STT error, mic
@@ -380,6 +402,9 @@ struct DriverCtx {
     app: Option<AppHandle>,
     shared: Arc<ConvoShared>,
     stt: Box<dyn SttStream>,
+    stt_connector: Arc<dyn SttConnector>,
+    /// Consecutive STT reconnects since the last completed turn.
+    reconnects_used: usize,
     tts_connector: Arc<dyn TtsConnector>,
     playback: Arc<dyn PlaybackSink>,
     tts_stream: Option<Box<dyn TtsStream>>,
@@ -394,7 +419,48 @@ struct DriverCtx {
     tts_first_audio_seen: bool,
 }
 
+/// Outcome of one driver step. `Reconnect` means the STT transport dropped
+/// but the conversation can survive if a fresh socket comes up.
+enum Step {
+    Continue,
+    Reconnect(String),
+}
+
 impl DriverCtx {
+    /// Revive the STT socket after a drop. Consumes one backoff slot per
+    /// attempt; the budget refills when a turn completes, so a flaky network
+    /// gets three tries per utterance rather than three for the whole
+    /// conversation.
+    async fn try_reconnect(&mut self, cause: &str) -> Option<mpsc::UnboundedReceiver<SttEvent>> {
+        while self.reconnects_used < STT_RECONNECT_BACKOFF_MS.len() {
+            let delay = STT_RECONNECT_BACKOFF_MS[self.reconnects_used];
+            self.reconnects_used += 1;
+            tracing::warn!(
+                target: "aethon::voice::convo",
+                cause,
+                attempt = self.reconnects_used,
+                delay_ms = delay,
+                "reconnecting speech socket"
+            );
+            tokio::time::sleep(Duration::from_millis(delay)).await;
+            match self.stt_connector.connect().await {
+                Ok((stream, rx)) => {
+                    let mut old = std::mem::replace(&mut self.stt, stream);
+                    old.close().await;
+                    return Some(rx);
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        target: "aethon::voice::convo",
+                        error = %err,
+                        "speech reconnect attempt failed"
+                    );
+                }
+            }
+        }
+        None
+    }
+
     fn set_state(&mut self, state: ConvoState, reason: Option<&'static str>) {
         if self.state == state {
             return;
@@ -448,7 +514,7 @@ impl DriverCtx {
         &mut self,
         frame: Vec<f32>,
         tts_audio_rx: &mut Option<mpsc::UnboundedReceiver<Vec<f32>>>,
-    ) -> ControlFlow<()> {
+    ) -> Step {
         self.emit_level(&frame);
         self.push_pre_roll(&frame);
 
@@ -456,8 +522,7 @@ impl DriverCtx {
             ConvoState::Listening | ConvoState::UserSpeaking | ConvoState::AwaitingBrain => {
                 self.outbound.extend_from_slice(&frame);
                 if let Err(err) = self.forward_outbound().await {
-                    self.fail(format!("Speech streaming failed: {err}"));
-                    return ControlFlow::Break(());
+                    return Step::Reconnect(format!("audio send failed: {err}"));
                 }
             }
             ConvoState::Speaking => {
@@ -471,14 +536,13 @@ impl DriverCtx {
                 if self.barge_sustain_samples >= sustain_target {
                     self.barge_sustain_samples = 0;
                     if let Err(err) = self.barge_in(tts_audio_rx).await {
-                        self.fail(format!("Speech streaming failed: {err}"));
-                        return ControlFlow::Break(());
+                        return Step::Reconnect(format!("barge-in replay failed: {err}"));
                     }
                 }
             }
             ConvoState::Idle => {}
         }
-        ControlFlow::Continue(())
+        Step::Continue
     }
 
     /// The user interrupted playback: cut the audio, kill the in-flight TTS
@@ -502,7 +566,7 @@ impl DriverCtx {
         Ok(())
     }
 
-    fn handle_stt_event(&mut self, event: SttEvent) -> ControlFlow<()> {
+    fn handle_stt_event(&mut self, event: SttEvent) -> Step {
         match event {
             SttEvent::StartOfTurn { transcript } => {
                 self.current_transcript = transcript.clone();
@@ -529,15 +593,13 @@ impl DriverCtx {
                 }
             }
             SttEvent::Error(message) => {
-                self.fail(format!("Speech recognition error: {message}"));
-                return ControlFlow::Break(());
+                return Step::Reconnect(format!("speech recognition error: {message}"));
             }
             SttEvent::Closed => {
-                self.fail("The speech service closed the connection".to_string());
-                return ControlFlow::Break(());
+                return Step::Reconnect("the speech service closed the connection".to_string());
             }
         }
-        ControlFlow::Continue(())
+        Step::Continue
     }
 
     fn emit_interim(&self, text: String) {
@@ -554,6 +616,9 @@ impl DriverCtx {
             return;
         }
         *self.shared.last_turn.lock() = Some(transcript.clone());
+        // A completed turn proves the transport healthy — refill the
+        // reconnect budget.
+        self.reconnects_used = 0;
         self.set_state(ConvoState::AwaitingBrain, None);
         if let Some(app) = &self.app {
             let _ = app.emit("voice://convo/turn", ConvoTurnEvent { transcript });
@@ -697,23 +762,20 @@ async fn run_driver(
     let mut drain_poll = tokio::time::interval(Duration::from_millis(DRAIN_POLL_MS));
 
     loop {
-        tokio::select! {
+        let step = tokio::select! {
             maybe_frame = frames_rx.recv() => {
-                let Some(frame) = maybe_frame else {
-                    ctx.fail("The microphone stream ended unexpectedly".to_string());
-                    break;
-                };
-                if ctx.handle_frame(frame, &mut tts_audio_rx).await.is_break() {
-                    break;
+                match maybe_frame {
+                    None => {
+                        ctx.fail("The microphone stream ended unexpectedly".to_string());
+                        break;
+                    }
+                    Some(frame) => ctx.handle_frame(frame, &mut tts_audio_rx).await,
                 }
             }
             maybe_event = stt_rx.recv() => {
-                let Some(event) = maybe_event else {
-                    ctx.fail("The speech service disconnected".to_string());
-                    break;
-                };
-                if ctx.handle_stt_event(event).is_break() {
-                    break;
+                match maybe_event {
+                    None => Step::Reconnect("the speech event stream ended".to_string()),
+                    Some(event) => ctx.handle_stt_event(event),
                 }
             }
             maybe_command = cmd_rx.recv() => {
@@ -722,6 +784,7 @@ async fn run_driver(
                 if ctx.handle_command(command, &mut tts_audio_rx).await.is_break() {
                     break;
                 }
+                Step::Continue
             }
             chunk = recv_or_pending(&mut tts_audio_rx), if tts_audio_rx.is_some() => {
                 match chunk {
@@ -731,9 +794,11 @@ async fn run_driver(
                         ctx.handle_tts_done();
                     }
                 }
+                Step::Continue
             }
             _ = keepalive.tick(), if ctx.state == ConvoState::Speaking => {
                 ctx.stt.keepalive().await;
+                Step::Continue
             }
             _ = drain_poll.tick(), if ctx.state == ConvoState::Speaking
                 && tts_audio_rx.is_none()
@@ -742,7 +807,21 @@ async fn run_driver(
                 if ctx.playback_handle.as_ref().is_none_or(|h| h.is_drained()) {
                     ctx.finish_speaking();
                 }
+                Step::Continue
             }
+        };
+
+        match step {
+            Step::Continue => {}
+            Step::Reconnect(cause) => match ctx.try_reconnect(&cause).await {
+                Some(new_rx) => {
+                    stt_rx = new_rx;
+                }
+                None => {
+                    ctx.fail(format!("Speech service unavailable: {cause}"));
+                    break;
+                }
+            },
         }
     }
 

--- a/src-tauri/src/voice/convo/mod.rs
+++ b/src-tauri/src/voice/convo/mod.rs
@@ -16,6 +16,7 @@
 //! its first word.
 
 mod keys;
+mod local;
 mod mic;
 mod stt;
 #[cfg(test)]
@@ -23,6 +24,9 @@ mod tests;
 mod tts;
 
 pub(crate) use keys::resolve_cascade_keys;
+pub(crate) use local::{
+    LOCAL_STT_PROVIDER, LOCAL_TTS_PROVIDER, Lfm2TtsConnector, LocalWhisperConnector,
+};
 pub(crate) use stt::{DeepgramFluxConnector, SttConnector, SttEvent, SttStream};
 pub(crate) use tts::{
     CartesiaConnector, CartesiaVoiceInfo, TtsConnector, TtsStream, list_cartesia_voices,
@@ -67,6 +71,14 @@ const DRAIN_POLL_MS: u64 = 50;
 const STT_RECONNECT_BACKOFF_MS: [u64; 3] = [250, 1_000, 3_000];
 #[cfg(test)]
 const STT_RECONNECT_BACKOFF_MS: [u64; 3] = [10, 10, 10];
+/// How long a suspected barge-in (sustained mic energy during playback) waits
+/// for the recognizer to confirm real speech. Playback pauses — not stops —
+/// for the window, so a cough or door slam costs a moment of silence instead
+/// of the rest of the reply. StartOfTurn inside the window kills the reply.
+#[cfg(not(test))]
+const BARGE_CONFIRM_MS: u64 = 1_500;
+#[cfg(test)]
+const BARGE_CONFIRM_MS: u64 = 100;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "kebab-case")]
@@ -92,6 +104,9 @@ pub(crate) trait PlaybackSink: Send + Sync {
 pub(crate) trait StreamingPlayback: Send {
     fn append(&mut self, samples: &[f32]);
     fn mark_complete(&mut self);
+    /// Hold the cursor (silence) without losing position.
+    fn pause(&mut self);
+    fn resume(&mut self);
     fn is_drained(&self) -> bool;
 }
 
@@ -101,6 +116,12 @@ impl StreamingPlayback for StreamingPlaybackHandle {
     }
     fn mark_complete(&mut self) {
         StreamingPlaybackHandle::mark_complete(self);
+    }
+    fn pause(&mut self) {
+        StreamingPlaybackHandle::pause(self);
+    }
+    fn resume(&mut self) {
+        StreamingPlaybackHandle::resume(self);
     }
     fn is_drained(&self) -> bool {
         StreamingPlaybackHandle::is_drained(self)
@@ -288,6 +309,7 @@ impl ConversationEngine {
             pre_roll: VecDeque::new(),
             current_transcript: String::new(),
             barge_sustain_samples: 0,
+            barge_confirm_deadline: None,
             last_level_emit: Instant::now(),
             speak_requested_at: None,
             tts_first_audio_seen: false,
@@ -414,6 +436,9 @@ struct DriverCtx {
     pre_roll: VecDeque<f32>,
     current_transcript: String,
     barge_sustain_samples: usize,
+    /// Set while a suspected barge-in awaits recognizer confirmation;
+    /// playback is paused and the mic gate is open until the deadline.
+    barge_confirm_deadline: Option<Instant>,
     last_level_emit: Instant,
     speak_requested_at: Option<Instant>,
     tts_first_audio_seen: bool,
@@ -510,11 +535,7 @@ impl DriverCtx {
 
     /// One mic frame (mono f32 @ 16 kHz). Gate open → forward to STT; gate
     /// closed (speaking) → barge-in detection only.
-    async fn handle_frame(
-        &mut self,
-        frame: Vec<f32>,
-        tts_audio_rx: &mut Option<mpsc::UnboundedReceiver<Vec<f32>>>,
-    ) -> Step {
+    async fn handle_frame(&mut self, frame: Vec<f32>) -> Step {
         self.emit_level(&frame);
         self.push_pre_roll(&frame);
 
@@ -526,6 +547,19 @@ impl DriverCtx {
                 }
             }
             ConvoState::Speaking => {
+                if let Some(deadline) = self.barge_confirm_deadline {
+                    // Confirm window: playback is paused and the gate is
+                    // open — forward audio so the recognizer can rule on
+                    // whether this is real speech.
+                    self.outbound.extend_from_slice(&frame);
+                    if let Err(err) = self.forward_outbound().await {
+                        return Step::Reconnect(format!("audio send failed: {err}"));
+                    }
+                    if Instant::now() >= deadline {
+                        self.resume_after_false_barge();
+                    }
+                    return Step::Continue;
+                }
                 let sustain_target =
                     BARGE_IN_SUSTAIN_MS * super::TARGET_SAMPLE_RATE as usize / 1000;
                 if compute_rms(&frame) >= BARGE_IN_RMS {
@@ -535,7 +569,7 @@ impl DriverCtx {
                 }
                 if self.barge_sustain_samples >= sustain_target {
                     self.barge_sustain_samples = 0;
-                    if let Err(err) = self.barge_in(tts_audio_rx).await {
+                    if let Err(err) = self.begin_barge_confirm().await {
                         return Step::Reconnect(format!("barge-in replay failed: {err}"));
                     }
                 }
@@ -545,30 +579,62 @@ impl DriverCtx {
         Step::Continue
     }
 
-    /// The user interrupted playback: cut the audio, kill the in-flight TTS
-    /// context, and replay the pre-roll ring into STT so the recognizer sees
-    /// the interruption from its first word.
-    async fn barge_in(
+    /// Sustained mic energy during playback: PAUSE (don't kill) the reply,
+    /// replay the pre-roll ring into STT so the recognizer hears the
+    /// interruption from its first word, and open the gate. A StartOfTurn
+    /// inside the window confirms the barge-in; silence resumes playback.
+    async fn begin_barge_confirm(&mut self) -> Result<(), String> {
+        if let Some(handle) = self.playback_handle.as_mut() {
+            handle.pause();
+        }
+        let replay: Vec<f32> = self.pre_roll.drain(..).collect();
+        if !replay.is_empty() {
+            self.stt.send_audio(&replay).await?;
+        }
+        self.barge_confirm_deadline =
+            Some(Instant::now() + Duration::from_millis(BARGE_CONFIRM_MS));
+        Ok(())
+    }
+
+    /// The recognizer confirmed real speech during playback: now cut the
+    /// audio and kill the in-flight TTS context.
+    async fn confirm_barge_in(
         &mut self,
         tts_audio_rx: &mut Option<mpsc::UnboundedReceiver<Vec<f32>>>,
-    ) -> Result<(), String> {
+    ) {
+        self.barge_confirm_deadline = None;
         self.playback.stop();
         self.playback_handle = None;
         *tts_audio_rx = None;
         if let Some(mut stream) = self.tts_stream.take() {
             stream.stop().await;
         }
-        let replay: Vec<f32> = self.pre_roll.drain(..).collect();
-        if !replay.is_empty() {
-            self.stt.send_audio(&replay).await?;
-        }
         self.set_state(ConvoState::Listening, Some("barge-in"));
-        Ok(())
     }
 
-    fn handle_stt_event(&mut self, event: SttEvent) -> Step {
+    /// Confirm window elapsed without recognized speech — a cough, not a
+    /// command. Resume the reply where it paused and close the gate.
+    fn resume_after_false_barge(&mut self) {
+        self.barge_confirm_deadline = None;
+        self.barge_sustain_samples = 0;
+        if let Some(handle) = self.playback_handle.as_mut() {
+            handle.resume();
+        }
+    }
+
+    async fn handle_stt_event(
+        &mut self,
+        event: SttEvent,
+        tts_audio_rx: &mut Option<mpsc::UnboundedReceiver<Vec<f32>>>,
+    ) -> Step {
+        let confirming =
+            self.state == ConvoState::Speaking && self.barge_confirm_deadline.is_some();
         match event {
             SttEvent::StartOfTurn { transcript } => {
+                if confirming {
+                    // Real speech over the reply — the barge-in is confirmed.
+                    self.confirm_barge_in(tts_audio_rx).await;
+                }
                 self.current_transcript = transcript.clone();
                 if matches!(
                     self.state,
@@ -583,6 +649,12 @@ impl DriverCtx {
                 self.emit_interim(transcript);
             }
             SttEvent::EndOfTurn { transcript } => {
+                if confirming {
+                    // A complete short command landed inside the confirm
+                    // window ("stop", "wait") — kill the reply AND take the
+                    // turn.
+                    self.confirm_barge_in(tts_audio_rx).await;
+                }
                 // Stale end-of-turns can arrive after a local force-end or
                 // while speech is already playing; the state guard drops them.
                 if matches!(
@@ -682,11 +754,16 @@ impl DriverCtx {
                 self.abandon_speech(tts_audio_rx).await;
             }
             EngineCommand::ForceEndTurn => {
-                if matches!(self.state, ConvoState::Listening | ConvoState::UserSpeaking)
-                    && !self.current_transcript.trim().is_empty()
-                {
-                    let transcript = std::mem::take(&mut self.current_transcript);
-                    self.finish_turn(transcript);
+                if matches!(self.state, ConvoState::Listening | ConvoState::UserSpeaking) {
+                    if self.current_transcript.trim().is_empty() {
+                        // No interim text to promote (local providers don't
+                        // stream interims) — ask the recognizer to end its
+                        // in-progress utterance instead.
+                        self.stt.finalize_turn().await;
+                    } else {
+                        let transcript = std::mem::take(&mut self.current_transcript);
+                        self.finish_turn(transcript);
+                    }
                 }
             }
         }
@@ -697,6 +774,7 @@ impl DriverCtx {
         &mut self,
         tts_audio_rx: &mut Option<mpsc::UnboundedReceiver<Vec<f32>>>,
     ) {
+        self.barge_confirm_deadline = None;
         self.playback.stop();
         self.playback_handle = None;
         *tts_audio_rx = None;
@@ -740,6 +818,7 @@ impl DriverCtx {
     fn finish_speaking(&mut self) {
         self.playback_handle = None;
         self.barge_sustain_samples = 0;
+        self.barge_confirm_deadline = None;
         self.set_state(ConvoState::Listening, None);
     }
 }
@@ -769,13 +848,13 @@ async fn run_driver(
                         ctx.fail("The microphone stream ended unexpectedly".to_string());
                         break;
                     }
-                    Some(frame) => ctx.handle_frame(frame, &mut tts_audio_rx).await,
+                    Some(frame) => ctx.handle_frame(frame).await,
                 }
             }
             maybe_event = stt_rx.recv() => {
                 match maybe_event {
                     None => Step::Reconnect("the speech event stream ended".to_string()),
-                    Some(event) => ctx.handle_stt_event(event),
+                    Some(event) => ctx.handle_stt_event(event, &mut tts_audio_rx).await,
                 }
             }
             maybe_command = cmd_rx.recv() => {

--- a/src-tauri/src/voice/convo/stt.rs
+++ b/src-tauri/src/voice/convo/stt.rs
@@ -49,6 +49,10 @@ pub(crate) trait SttStream: Send {
     async fn send_audio(&mut self, pcm_16k: &[f32]) -> Result<(), String>;
     /// Keep the socket alive while no audio is being forwarded (best-effort).
     async fn keepalive(&mut self);
+    /// Push-to-talk release landed before any transcript accumulated: end the
+    /// in-progress utterance now if the recognizer segments locally (the
+    /// engine synthesizes the turn itself when it already has interim text).
+    async fn finalize_turn(&mut self) {}
     async fn close(&mut self);
 }
 

--- a/src-tauri/src/voice/convo/stt.rs
+++ b/src-tauri/src/voice/convo/stt.rs
@@ -1,0 +1,209 @@
+//! Streaming speech-to-text with semantic turn detection.
+//!
+//! `SttStream`/`SttConnector` abstract the transport so the engine is
+//! testable with fakes; `DeepgramFluxStt` is the production implementation.
+//! Flux is a conversational STT model whose turn events (StartOfTurn /
+//! EndOfTurn) come from acoustic + semantic context, not silence thresholds —
+//! that's what makes the conversation feel like turn-taking instead of a
+//! walkie-talkie.
+
+use async_trait::async_trait;
+use futures_util::{SinkExt, StreamExt};
+use tokio::sync::mpsc;
+use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async};
+
+use crate::voice::catalog::TARGET_SAMPLE_RATE;
+
+const FLUX_MODEL: &str = "flux-general-en";
+/// End-of-turn confidence (Deepgram default). Raise for fewer premature
+/// turn-ends, lower for snappier responses.
+const EOT_THRESHOLD: &str = "0.7";
+/// Silence fallback (ms) that forces EndOfTurn when confidence never clears
+/// the threshold. Shorter than Deepgram's 5 s default — a hands-free UI
+/// should not hang that long on a trailing "um".
+const EOT_TIMEOUT_MS: &str = "3000";
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum SttEvent {
+    /// The recognizer heard the user start a turn (non-empty transcript).
+    StartOfTurn {
+        transcript: String,
+    },
+    /// Rolling transcript for the in-progress turn (cumulative).
+    Interim {
+        transcript: String,
+    },
+    /// The turn is complete; `transcript` is its final text.
+    EndOfTurn {
+        transcript: String,
+    },
+    Error(String),
+    Closed,
+}
+
+#[async_trait]
+pub(crate) trait SttStream: Send {
+    /// Forward mono 16 kHz f32 samples to the recognizer.
+    async fn send_audio(&mut self, pcm_16k: &[f32]) -> Result<(), String>;
+    /// Keep the socket alive while no audio is being forwarded (best-effort).
+    async fn keepalive(&mut self);
+    async fn close(&mut self);
+}
+
+#[async_trait]
+pub(crate) trait SttConnector: Send + Sync {
+    async fn connect(
+        &self,
+    ) -> Result<(Box<dyn SttStream>, mpsc::UnboundedReceiver<SttEvent>), String>;
+}
+
+type WsSink = futures_util::stream::SplitSink<
+    WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>,
+    Message,
+>;
+
+pub(crate) struct DeepgramFluxConnector {
+    api_key: String,
+}
+
+impl DeepgramFluxConnector {
+    pub(crate) fn new(api_key: String) -> Self {
+        Self { api_key }
+    }
+}
+
+#[async_trait]
+impl SttConnector for DeepgramFluxConnector {
+    async fn connect(
+        &self,
+    ) -> Result<(Box<dyn SttStream>, mpsc::UnboundedReceiver<SttEvent>), String> {
+        let url = format!(
+            "wss://api.deepgram.com/v2/listen?model={FLUX_MODEL}&encoding=linear16&sample_rate={TARGET_SAMPLE_RATE}&eot_threshold={EOT_THRESHOLD}&eot_timeout_ms={EOT_TIMEOUT_MS}"
+        );
+        let mut request = url
+            .into_client_request()
+            .map_err(|e| format!("invalid Deepgram request: {e}"))?;
+        let auth = format!("Token {}", self.api_key)
+            .parse()
+            .map_err(|_| "invalid Deepgram API key format".to_string())?;
+        request.headers_mut().insert("Authorization", auth);
+
+        let (socket, _response) = connect_async(request).await.map_err(friendly_ws_error)?;
+        let (sink, mut read) = socket.split();
+        let (tx, rx) = mpsc::unbounded_channel();
+
+        let reader = tokio::spawn(async move {
+            while let Some(message) = read.next().await {
+                match message {
+                    Ok(Message::Text(text)) => {
+                        if let Some(event) = parse_flux_message(&text)
+                            && tx.send(event).is_err()
+                        {
+                            return;
+                        }
+                    }
+                    Ok(Message::Close(_)) => break,
+                    Ok(_) => {}
+                    Err(err) => {
+                        let _ = tx.send(SttEvent::Error(err.to_string()));
+                        return;
+                    }
+                }
+            }
+            let _ = tx.send(SttEvent::Closed);
+        });
+
+        Ok((
+            Box::new(DeepgramFluxStt {
+                sink,
+                reader: Some(reader),
+            }),
+            rx,
+        ))
+    }
+}
+
+fn friendly_ws_error(err: tokio_tungstenite::tungstenite::Error) -> String {
+    use tokio_tungstenite::tungstenite::Error;
+    match &err {
+        Error::Http(response) if response.status().as_u16() == 401 => {
+            "Deepgram rejected the API key".to_string()
+        }
+        Error::Http(response) => {
+            format!("Deepgram connection failed (HTTP {})", response.status())
+        }
+        _ => format!("Deepgram connection failed: {err}"),
+    }
+}
+
+/// Map a Flux JSON message to an engine event. Unknown/irrelevant message
+/// types (Connected, etc.) return `None`.
+pub(super) fn parse_flux_message(raw: &str) -> Option<SttEvent> {
+    let value: serde_json::Value = serde_json::from_str(raw).ok()?;
+    let message_type = value["type"].as_str().unwrap_or_default();
+    if message_type.eq_ignore_ascii_case("error") {
+        let description = value["description"]
+            .as_str()
+            .or_else(|| value["message"].as_str())
+            .unwrap_or(raw);
+        return Some(SttEvent::Error(description.to_string()));
+    }
+    if message_type != "TurnInfo" {
+        return None;
+    }
+    let transcript = value["transcript"].as_str().unwrap_or_default().to_string();
+    match value["event"].as_str().unwrap_or_default() {
+        "StartOfTurn" => Some(SttEvent::StartOfTurn { transcript }),
+        "Update" | "EagerEndOfTurn" | "TurnResumed" => Some(SttEvent::Interim { transcript }),
+        "EndOfTurn" => Some(SttEvent::EndOfTurn { transcript }),
+        _ => None,
+    }
+}
+
+struct DeepgramFluxStt {
+    sink: WsSink,
+    reader: Option<tokio::task::JoinHandle<()>>,
+}
+
+#[async_trait]
+impl SttStream for DeepgramFluxStt {
+    async fn send_audio(&mut self, pcm_16k: &[f32]) -> Result<(), String> {
+        let mut bytes = Vec::with_capacity(pcm_16k.len() * 2);
+        for sample in pcm_16k {
+            let value = (sample.clamp(-1.0, 1.0) * f32::from(i16::MAX)) as i16;
+            bytes.extend_from_slice(&value.to_le_bytes());
+        }
+        self.sink
+            .send(Message::Binary(bytes))
+            .await
+            .map_err(|e| e.to_string())
+    }
+
+    async fn keepalive(&mut self) {
+        let _ = self
+            .sink
+            .send(Message::Text(r#"{"type":"KeepAlive"}"#.to_string()))
+            .await;
+    }
+
+    async fn close(&mut self) {
+        let _ = self
+            .sink
+            .send(Message::Text(r#"{"type":"CloseStream"}"#.to_string()))
+            .await;
+        let _ = self.sink.close().await;
+        if let Some(reader) = self.reader.take() {
+            reader.abort();
+        }
+    }
+}
+
+impl Drop for DeepgramFluxStt {
+    fn drop(&mut self) {
+        if let Some(reader) = self.reader.take() {
+            reader.abort();
+        }
+    }
+}

--- a/src-tauri/src/voice/convo/stt.rs
+++ b/src-tauri/src/voice/convo/stt.rs
@@ -186,10 +186,13 @@ impl SttStream for DeepgramFluxStt {
     }
 
     async fn keepalive(&mut self) {
-        let _ = self
-            .sink
-            .send(Message::Text(r#"{"type":"KeepAlive"}"#.to_string()))
-            .await;
+        // Flux's v2 socket accepts only `CloseStream`/`Configure` text
+        // messages — the v1-era `KeepAlive` control message makes the server
+        // reply with a deserialize error and the connection dies. Flux stays
+        // alive on continuous audio instead, so feed it silence while the mic
+        // is gated: zeros carry no speech, so no turn events fire.
+        let silence = vec![0u8; (TARGET_SAMPLE_RATE as usize / 5) * 2]; // 200 ms of i16 zeros
+        let _ = self.sink.send(Message::Binary(silence)).await;
     }
 
     async fn close(&mut self) {

--- a/src-tauri/src/voice/convo/tests.rs
+++ b/src-tauri/src/voice/convo/tests.rs
@@ -153,6 +153,7 @@ struct FakePlayback {
     appended: Arc<AtomicUsize>,
     completed: Arc<AtomicBool>,
     stopped: Arc<AtomicBool>,
+    paused: Arc<AtomicBool>,
     streams_opened: Arc<AtomicUsize>,
 }
 
@@ -162,6 +163,7 @@ impl FakePlayback {
             appended: Arc::new(AtomicUsize::new(0)),
             completed: Arc::new(AtomicBool::new(false)),
             stopped: Arc::new(AtomicBool::new(false)),
+            paused: Arc::new(AtomicBool::new(false)),
             streams_opened: Arc::new(AtomicUsize::new(0)),
         }
     }
@@ -170,6 +172,7 @@ impl FakePlayback {
 struct FakePlaybackStream {
     appended: Arc<AtomicUsize>,
     completed: Arc<AtomicBool>,
+    paused: Arc<AtomicBool>,
 }
 
 impl StreamingPlayback for FakePlaybackStream {
@@ -178,6 +181,12 @@ impl StreamingPlayback for FakePlaybackStream {
     }
     fn mark_complete(&mut self) {
         self.completed.store(true, Ordering::SeqCst);
+    }
+    fn pause(&mut self) {
+        self.paused.store(true, Ordering::SeqCst);
+    }
+    fn resume(&mut self) {
+        self.paused.store(false, Ordering::SeqCst);
     }
     fn is_drained(&self) -> bool {
         // Drained as soon as sealed — playback latency isn't under test.
@@ -196,6 +205,7 @@ impl PlaybackSink for FakePlayback {
         Ok(Box::new(FakePlaybackStream {
             appended: Arc::clone(&self.appended),
             completed: Arc::clone(&self.completed),
+            paused: Arc::clone(&self.paused),
         }))
     }
     fn stop(&self) {
@@ -384,7 +394,7 @@ async fn speak_end_without_chunks_unwedges_awaiting_brain() {
 }
 
 #[tokio::test]
-async fn barge_in_stops_playback_and_replays_pre_roll() {
+async fn confirmed_barge_in_pauses_then_stops_playback() {
     let h = start_harness(0);
     h.stt_tx
         .send(SttEvent::EndOfTurn {
@@ -396,18 +406,67 @@ async fn barge_in_stops_playback_and_replays_pre_roll() {
     wait_for_state(&h.engine, ConvoState::Speaking).await;
 
     let forwarded_before = h.sent_samples.load(Ordering::SeqCst);
-    // Loud frames worth >200 ms: gate is closed, so nothing forwards until
-    // the barge-in replays the pre-roll ring.
+    // Loud frames worth >200 ms: playback pauses (not stops) and the
+    // pre-roll ring replays into STT for confirmation.
     for _ in 0..6 {
         h.frames_tx.send(vec![0.5; 1024]).unwrap();
     }
-    wait_for_state(&h.engine, ConvoState::Listening).await;
-    assert!(h.playback.stopped.load(Ordering::SeqCst));
-    assert!(h.tts.stopped.load(Ordering::SeqCst));
+    wait_for(
+        || h.playback.paused.load(Ordering::SeqCst),
+        "playback paused for confirmation",
+    )
+    .await;
+    assert!(!h.playback.stopped.load(Ordering::SeqCst));
     assert!(
         h.sent_samples.load(Ordering::SeqCst) > forwarded_before,
         "pre-roll should replay into STT"
     );
+
+    // The recognizer confirms real speech → the reply dies for good.
+    h.stt_tx
+        .send(SttEvent::StartOfTurn {
+            transcript: "wait".into(),
+        })
+        .unwrap();
+    wait_for_state(&h.engine, ConvoState::UserSpeaking).await;
+    assert!(h.playback.stopped.load(Ordering::SeqCst));
+    assert!(h.tts.stopped.load(Ordering::SeqCst));
+}
+
+#[tokio::test]
+async fn false_barge_in_resumes_playback_after_the_confirm_window() {
+    let h = start_harness(0);
+    h.stt_tx
+        .send(SttEvent::EndOfTurn {
+            transcript: "explain".into(),
+        })
+        .unwrap();
+    wait_for_state(&h.engine, ConvoState::AwaitingBrain).await;
+    h.engine.speak_chunk("A long explanation".into()).unwrap();
+    wait_for_state(&h.engine, ConvoState::Speaking).await;
+
+    // A door slam: loud enough to pause…
+    for _ in 0..6 {
+        h.frames_tx.send(vec![0.5; 1024]).unwrap();
+    }
+    wait_for(
+        || h.playback.paused.load(Ordering::SeqCst),
+        "playback paused for confirmation",
+    )
+    .await;
+
+    // …but no recognized speech. After the (test-shortened) confirm window,
+    // quiet frames drive the deadline check and playback resumes.
+    tokio::time::sleep(Duration::from_millis(120)).await;
+    h.frames_tx.send(vec![0.0; 512]).unwrap();
+    wait_for(
+        || !h.playback.paused.load(Ordering::SeqCst),
+        "playback resumed",
+    )
+    .await;
+    assert_eq!(h.engine.state(), ConvoState::Speaking);
+    assert!(!h.playback.stopped.load(Ordering::SeqCst));
+    assert!(!h.tts.stopped.load(Ordering::SeqCst));
 }
 
 #[tokio::test]
@@ -541,6 +600,128 @@ async fn second_start_is_rejected_while_active() {
         )
         .expect_err("second start must fail");
     assert!(err.contains("already running"));
+}
+
+// ── local providers ──────────────────────────────────────────────────────
+
+struct FakeTranscriber {
+    transcript: String,
+}
+
+impl crate::voice::VoiceTranscriber for FakeTranscriber {
+    fn transcribe(
+        &self,
+        _cache_path: &std::path::Path,
+        _audio: crate::voice::CapturedAudio,
+        _cancel: &Arc<AtomicBool>,
+    ) -> Result<String, String> {
+        Ok(self.transcript.clone())
+    }
+}
+
+const SR: usize = 16_000;
+
+#[tokio::test]
+async fn local_stt_segments_an_utterance_and_decodes_it() {
+    let (mut stream, mut events) = super::local::test_local_stt(Arc::new(FakeTranscriber {
+        transcript: "hello there".into(),
+    }));
+    // Quiet lead-in → no events.
+    stream.send_audio(&vec![0.001; SR / 10]).await.unwrap();
+    // Speech onset (300 ms loud) → StartOfTurn.
+    stream.send_audio(&vec![0.3; SR * 3 / 10]).await.unwrap();
+    assert!(matches!(
+        events.try_recv(),
+        Ok(SttEvent::StartOfTurn { .. })
+    ));
+    // 1.2 s of silence → utterance ends → decode → EndOfTurn.
+    stream.send_audio(&vec![0.0; SR * 12 / 10]).await.unwrap();
+    let event = tokio::time::timeout(Duration::from_secs(2), events.recv())
+        .await
+        .expect("decode should finish")
+        .expect("channel open");
+    assert_eq!(
+        event,
+        SttEvent::EndOfTurn {
+            transcript: "hello there".into()
+        }
+    );
+}
+
+#[tokio::test]
+async fn local_stt_finalize_turn_ends_an_in_progress_utterance() {
+    let (mut stream, mut events) = super::local::test_local_stt(Arc::new(FakeTranscriber {
+        transcript: "forced".into(),
+    }));
+    stream.send_audio(&vec![0.3; SR * 3 / 10]).await.unwrap();
+    assert!(matches!(
+        events.try_recv(),
+        Ok(SttEvent::StartOfTurn { .. })
+    ));
+    // Push-to-talk release before any silence accumulated.
+    stream.finalize_turn().await;
+    let event = tokio::time::timeout(Duration::from_secs(2), events.recv())
+        .await
+        .expect("decode should finish")
+        .expect("channel open");
+    assert_eq!(
+        event,
+        SttEvent::EndOfTurn {
+            transcript: "forced".into()
+        }
+    );
+}
+
+struct FakeLfm2 {
+    samples: Vec<f32>,
+}
+
+#[async_trait]
+impl crate::voice::Lfm2Backend for FakeLfm2 {
+    fn binary_available(&self) -> bool {
+        true
+    }
+    async fn asr(
+        &self,
+        _audio: crate::voice::CapturedAudio,
+        _cancel: Arc<AtomicBool>,
+    ) -> Result<String, String> {
+        Err("unused".into())
+    }
+    async fn tts(
+        &self,
+        _text: String,
+        _cancel: Arc<AtomicBool>,
+    ) -> Result<crate::voice::CapturedAudio, String> {
+        Ok(crate::voice::CapturedAudio {
+            samples: self.samples.clone(),
+            sample_rate: 24_000,
+        })
+    }
+}
+
+#[tokio::test]
+async fn lfm2_tts_synthesizes_on_flush_then_closes() {
+    let mut session = super::local::test_lfm2_tts(Arc::new(FakeLfm2 {
+        samples: vec![0.5; 240],
+    }));
+    session.stream.feed("Hello ").await.unwrap();
+    session.stream.feed("world.").await.unwrap();
+    session.stream.flush().await.unwrap();
+    let chunk = tokio::time::timeout(Duration::from_secs(2), session.audio_rx.recv())
+        .await
+        .expect("synthesis should finish")
+        .expect("one chunk");
+    assert_eq!(chunk.len(), 240);
+    // Channel closes after the single chunk = synthesis complete.
+    assert!(session.audio_rx.recv().await.is_none());
+}
+
+#[tokio::test]
+async fn lfm2_tts_flush_with_no_text_just_closes() {
+    let mut session = super::local::test_lfm2_tts(Arc::new(FakeLfm2 { samples: vec![] }));
+    session.stream.flush().await.unwrap();
+    assert!(session.audio_rx.recv().await.is_none());
 }
 
 // ── protocol parsing ─────────────────────────────────────────────────────

--- a/src-tauri/src/voice/convo/tests.rs
+++ b/src-tauri/src/voice/convo/tests.rs
@@ -701,19 +701,24 @@ impl crate::voice::Lfm2Backend for FakeLfm2 {
 }
 
 #[tokio::test]
-async fn lfm2_tts_synthesizes_on_flush_then_closes() {
+async fn lfm2_tts_synthesizes_each_clause_then_closes() {
     let mut session = super::local::test_lfm2_tts(Arc::new(FakeLfm2 {
         samples: vec![0.5; 240],
     }));
-    session.stream.feed("Hello ").await.unwrap();
-    session.stream.feed("world.").await.unwrap();
+    // Each fed clause is its own synthesis call — the first chunk can play
+    // while later clauses are still synthesizing (and no single call ever
+    // approaches the runner's generation ceiling).
+    session.stream.feed("Hello there.").await.unwrap();
+    session.stream.feed("How are you?").await.unwrap();
     session.stream.flush().await.unwrap();
-    let chunk = tokio::time::timeout(Duration::from_secs(2), session.audio_rx.recv())
-        .await
-        .expect("synthesis should finish")
-        .expect("one chunk");
-    assert_eq!(chunk.len(), 240);
-    // Channel closes after the single chunk = synthesis complete.
+    for _ in 0..2 {
+        let chunk = tokio::time::timeout(Duration::from_secs(2), session.audio_rx.recv())
+            .await
+            .expect("synthesis should finish")
+            .expect("clause chunk");
+        assert_eq!(chunk.len(), 240);
+    }
+    // Channel closes after the queued clauses drain = synthesis complete.
     assert!(session.audio_rx.recv().await.is_none());
 }
 

--- a/src-tauri/src/voice/convo/tests.rs
+++ b/src-tauri/src/voice/convo/tests.rs
@@ -36,6 +36,49 @@ impl SttStream for FakeSttStream {
     async fn close(&mut self) {}
 }
 
+/// Reconnectable fake: each successful connect() hands its event sender to
+/// the test through `event_txs` and shares the same sample counter.
+struct FakeSttConnector {
+    sent_samples: Arc<AtomicUsize>,
+    event_txs: Arc<Mutex<Vec<mpsc::UnboundedSender<SttEvent>>>>,
+    connects: Arc<AtomicUsize>,
+    /// Connect attempts that should fail before succeeding again.
+    fail_next: Arc<AtomicUsize>,
+}
+
+impl FakeSttConnector {
+    fn new(sent_samples: Arc<AtomicUsize>) -> Self {
+        Self {
+            sent_samples,
+            event_txs: Arc::new(Mutex::new(Vec::new())),
+            connects: Arc::new(AtomicUsize::new(0)),
+            fail_next: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+}
+
+#[async_trait]
+impl SttConnector for FakeSttConnector {
+    async fn connect(
+        &self,
+    ) -> Result<(Box<dyn SttStream>, mpsc::UnboundedReceiver<SttEvent>), String> {
+        self.connects.fetch_add(1, Ordering::SeqCst);
+        if self.fail_next.load(Ordering::SeqCst) > 0 {
+            self.fail_next.fetch_sub(1, Ordering::SeqCst);
+            return Err("connect refused".to_string());
+        }
+        let (tx, rx) = mpsc::unbounded_channel();
+        self.event_txs.lock().push(tx);
+        Ok((
+            Box::new(FakeSttStream {
+                sent_samples: Arc::clone(&self.sent_samples),
+                keepalives: Arc::new(AtomicUsize::new(0)),
+            }),
+            rx,
+        ))
+    }
+}
+
 struct FakeTts {
     feeds: Arc<Mutex<Vec<String>>>,
     flushed: Arc<AtomicBool>,
@@ -167,6 +210,7 @@ struct Harness {
     frames_tx: mpsc::UnboundedSender<Vec<f32>>,
     stt_tx: mpsc::UnboundedSender<SttEvent>,
     sent_samples: Arc<AtomicUsize>,
+    stt_connector: Arc<FakeSttConnector>,
     tts: FakeTtsConnector,
     playback: FakePlayback,
 }
@@ -180,13 +224,17 @@ fn start_harness(flush_samples: usize) -> Harness {
         sent_samples: Arc::clone(&sent_samples),
         keepalives: Arc::new(AtomicUsize::new(0)),
     });
+    let stt_connector = Arc::new(FakeSttConnector::new(Arc::clone(&sent_samples)));
     let tts = FakeTtsConnector::new(flush_samples);
     let playback = FakePlayback::new();
     engine
         .start_with_io(
             None,
-            stt_stream,
-            stt_rx,
+            SttInput {
+                connector: Arc::clone(&stt_connector) as Arc<dyn SttConnector>,
+                stream: stt_stream,
+                events: stt_rx,
+            },
             Arc::new(tts.clone()),
             Arc::new(playback.clone()),
             MicInput {
@@ -200,6 +248,7 @@ fn start_harness(flush_samples: usize) -> Harness {
         frames_tx,
         stt_tx,
         sent_samples,
+        stt_connector,
         tts,
         playback,
     }
@@ -418,8 +467,32 @@ async fn force_end_turn_uses_running_transcript_and_ignores_late_eot() {
 }
 
 #[tokio::test]
-async fn stt_error_tears_down_and_frees_the_slot() {
+async fn stt_error_reconnects_and_the_conversation_survives() {
     let h = start_harness(0);
+    let shared = shared(&h.engine);
+    h.stt_tx.send(SttEvent::Error("blip".into())).unwrap();
+    wait_for(
+        || !h.stt_connector.event_txs.lock().is_empty(),
+        "replacement event channel",
+    )
+    .await;
+    // Drive a turn through the REPLACEMENT socket.
+    let new_tx = h.stt_connector.event_txs.lock()[0].clone();
+    new_tx
+        .send(SttEvent::EndOfTurn {
+            transcript: "still here".into(),
+        })
+        .unwrap();
+    wait_for_state(&h.engine, ConvoState::AwaitingBrain).await;
+    assert_eq!(shared.last_turn().as_deref(), Some("still here"));
+    assert!(h.engine.is_active());
+}
+
+#[tokio::test]
+async fn exhausted_reconnects_tear_down_and_free_the_slot() {
+    let h = start_harness(0);
+    // Every backoff slot fails → fatal.
+    h.stt_connector.fail_next.store(16, Ordering::SeqCst);
     h.stt_tx.send(SttEvent::Error("boom".into())).unwrap();
     wait_for(|| !h.engine.is_active(), "engine slot reaped").await;
     assert_eq!(h.engine.state(), ConvoState::Idle);
@@ -446,15 +519,19 @@ async fn second_start_is_rejected_while_active() {
     let h = start_harness(0);
     let (_tx, frames_rx) = mpsc::unbounded_channel();
     let (_stt_tx, stt_rx) = mpsc::unbounded_channel::<SttEvent>();
+    let counter = Arc::new(AtomicUsize::new(0));
     let err = h
         .engine
         .start_with_io(
             None,
-            Box::new(FakeSttStream {
-                sent_samples: Arc::new(AtomicUsize::new(0)),
-                keepalives: Arc::new(AtomicUsize::new(0)),
-            }),
-            stt_rx,
+            SttInput {
+                connector: Arc::new(FakeSttConnector::new(Arc::clone(&counter))),
+                stream: Box::new(FakeSttStream {
+                    sent_samples: counter,
+                    keepalives: Arc::new(AtomicUsize::new(0)),
+                }),
+                events: stt_rx,
+            },
             Arc::new(FakeTtsConnector::new(0)),
             Arc::new(FakePlayback::new()),
             MicInput {

--- a/src-tauri/src/voice/convo/tests.rs
+++ b/src-tauri/src/voice/convo/tests.rs
@@ -1,0 +1,550 @@
+//! Conversation-engine tests with fake STT/TTS/playback, mirroring the
+//! injected-fake pattern the batch registry uses (`Lfm2Backend` fakes).
+//! Frames are fed straight into the driver channel, so no microphone or
+//! output device is needed.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use parking_lot::Mutex;
+use tokio::sync::mpsc;
+
+use super::stt::parse_flux_message;
+use super::tts::TtsSession;
+use super::*;
+use crate::voice::audio::StreamResampler;
+use crate::voice::audio::resample;
+
+// ── fakes ────────────────────────────────────────────────────────────────
+
+struct FakeSttStream {
+    sent_samples: Arc<AtomicUsize>,
+    keepalives: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl SttStream for FakeSttStream {
+    async fn send_audio(&mut self, pcm_16k: &[f32]) -> Result<(), String> {
+        self.sent_samples.fetch_add(pcm_16k.len(), Ordering::SeqCst);
+        Ok(())
+    }
+    async fn keepalive(&mut self) {
+        self.keepalives.fetch_add(1, Ordering::SeqCst);
+    }
+    async fn close(&mut self) {}
+}
+
+struct FakeTts {
+    feeds: Arc<Mutex<Vec<String>>>,
+    flushed: Arc<AtomicBool>,
+    stopped: Arc<AtomicBool>,
+    audio_tx: Arc<Mutex<Option<mpsc::UnboundedSender<Vec<f32>>>>>,
+    /// Samples emitted on flush before the channel closes.
+    flush_samples: usize,
+}
+
+#[async_trait]
+impl TtsStream for FakeTts {
+    async fn feed(&mut self, text: &str) -> Result<(), String> {
+        self.feeds.lock().push(text.to_string());
+        Ok(())
+    }
+    async fn flush(&mut self) -> Result<(), String> {
+        self.flushed.store(true, Ordering::SeqCst);
+        // Taking (and dropping) tx closes audio_rx = synthesis complete.
+        let tx = self.audio_tx.lock().take();
+        if let Some(tx) = tx
+            && self.flush_samples > 0
+        {
+            let _ = tx.send(vec![0.25; self.flush_samples]);
+        }
+        Ok(())
+    }
+    async fn stop(&mut self) {
+        self.stopped.store(true, Ordering::SeqCst);
+        self.audio_tx.lock().take();
+    }
+}
+
+#[derive(Clone)]
+struct FakeTtsConnector {
+    feeds: Arc<Mutex<Vec<String>>>,
+    flushed: Arc<AtomicBool>,
+    stopped: Arc<AtomicBool>,
+    flush_samples: usize,
+}
+
+impl FakeTtsConnector {
+    fn new(flush_samples: usize) -> Self {
+        Self {
+            feeds: Arc::new(Mutex::new(Vec::new())),
+            flushed: Arc::new(AtomicBool::new(false)),
+            stopped: Arc::new(AtomicBool::new(false)),
+            flush_samples,
+        }
+    }
+}
+
+#[async_trait]
+impl TtsConnector for FakeTtsConnector {
+    async fn connect(&self) -> Result<TtsSession, String> {
+        let (tx, rx) = mpsc::unbounded_channel();
+        Ok(TtsSession {
+            stream: Box::new(FakeTts {
+                feeds: Arc::clone(&self.feeds),
+                flushed: Arc::clone(&self.flushed),
+                stopped: Arc::clone(&self.stopped),
+                audio_tx: Arc::new(Mutex::new(Some(tx))),
+                flush_samples: self.flush_samples,
+            }),
+            audio_rx: rx,
+            sample_rate: 24_000,
+        })
+    }
+}
+
+#[derive(Clone)]
+struct FakePlayback {
+    appended: Arc<AtomicUsize>,
+    completed: Arc<AtomicBool>,
+    stopped: Arc<AtomicBool>,
+    streams_opened: Arc<AtomicUsize>,
+}
+
+impl FakePlayback {
+    fn new() -> Self {
+        Self {
+            appended: Arc::new(AtomicUsize::new(0)),
+            completed: Arc::new(AtomicBool::new(false)),
+            stopped: Arc::new(AtomicBool::new(false)),
+            streams_opened: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+}
+
+struct FakePlaybackStream {
+    appended: Arc<AtomicUsize>,
+    completed: Arc<AtomicBool>,
+}
+
+impl StreamingPlayback for FakePlaybackStream {
+    fn append(&mut self, samples: &[f32]) {
+        self.appended.fetch_add(samples.len(), Ordering::SeqCst);
+    }
+    fn mark_complete(&mut self) {
+        self.completed.store(true, Ordering::SeqCst);
+    }
+    fn is_drained(&self) -> bool {
+        // Drained as soon as sealed — playback latency isn't under test.
+        self.completed.load(Ordering::SeqCst)
+    }
+}
+
+impl PlaybackSink for FakePlayback {
+    fn start_stream(
+        &self,
+        _source_rate: u32,
+        _app: Option<tauri::AppHandle>,
+    ) -> Result<Box<dyn StreamingPlayback>, String> {
+        self.streams_opened.fetch_add(1, Ordering::SeqCst);
+        self.stopped.store(false, Ordering::SeqCst);
+        Ok(Box::new(FakePlaybackStream {
+            appended: Arc::clone(&self.appended),
+            completed: Arc::clone(&self.completed),
+        }))
+    }
+    fn stop(&self) {
+        self.stopped.store(true, Ordering::SeqCst);
+    }
+}
+
+// ── harness ──────────────────────────────────────────────────────────────
+
+struct Harness {
+    engine: ConversationEngine,
+    frames_tx: mpsc::UnboundedSender<Vec<f32>>,
+    stt_tx: mpsc::UnboundedSender<SttEvent>,
+    sent_samples: Arc<AtomicUsize>,
+    tts: FakeTtsConnector,
+    playback: FakePlayback,
+}
+
+fn start_harness(flush_samples: usize) -> Harness {
+    let engine = ConversationEngine::new();
+    let (frames_tx, frames_rx) = mpsc::unbounded_channel();
+    let (stt_tx, stt_rx) = mpsc::unbounded_channel();
+    let sent_samples = Arc::new(AtomicUsize::new(0));
+    let stt_stream = Box::new(FakeSttStream {
+        sent_samples: Arc::clone(&sent_samples),
+        keepalives: Arc::new(AtomicUsize::new(0)),
+    });
+    let tts = FakeTtsConnector::new(flush_samples);
+    let playback = FakePlayback::new();
+    engine
+        .start_with_io(
+            None,
+            stt_stream,
+            stt_rx,
+            Arc::new(tts.clone()),
+            Arc::new(playback.clone()),
+            MicInput {
+                frames_rx,
+                handle: None,
+            },
+        )
+        .expect("engine should start");
+    Harness {
+        engine,
+        frames_tx,
+        stt_tx,
+        sent_samples,
+        tts,
+        playback,
+    }
+}
+
+async fn wait_for(mut condition: impl FnMut() -> bool, what: &str) {
+    for _ in 0..200 {
+        if condition() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    panic!("timed out waiting for {what}");
+}
+
+async fn wait_for_state(engine: &ConversationEngine, state: ConvoState) {
+    wait_for(|| engine.state() == state, &format!("state {state:?}")).await;
+}
+
+fn shared(engine: &ConversationEngine) -> Arc<ConvoShared> {
+    engine
+        .inner
+        .lock()
+        .as_ref()
+        .map(|active| Arc::clone(&active.shared))
+        .expect("engine should be active")
+}
+
+// ── tests ────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn turn_lifecycle_reaches_awaiting_brain() {
+    let h = start_harness(0);
+    assert_eq!(h.engine.state(), ConvoState::Listening);
+    let shared = shared(&h.engine);
+
+    h.stt_tx
+        .send(SttEvent::StartOfTurn {
+            transcript: "rename".into(),
+        })
+        .unwrap();
+    wait_for_state(&h.engine, ConvoState::UserSpeaking).await;
+
+    h.stt_tx
+        .send(SttEvent::Interim {
+            transcript: "rename the config helper".into(),
+        })
+        .unwrap();
+    h.stt_tx
+        .send(SttEvent::EndOfTurn {
+            transcript: "rename the config helper".into(),
+        })
+        .unwrap();
+    wait_for_state(&h.engine, ConvoState::AwaitingBrain).await;
+    assert_eq!(
+        shared.last_turn().as_deref(),
+        Some("rename the config helper")
+    );
+}
+
+#[tokio::test]
+async fn empty_end_of_turn_returns_to_listening() {
+    let h = start_harness(0);
+    h.stt_tx
+        .send(SttEvent::StartOfTurn {
+            transcript: "hm".into(),
+        })
+        .unwrap();
+    wait_for_state(&h.engine, ConvoState::UserSpeaking).await;
+    h.stt_tx
+        .send(SttEvent::EndOfTurn {
+            transcript: "  ".into(),
+        })
+        .unwrap();
+    wait_for_state(&h.engine, ConvoState::Listening).await;
+    assert_eq!(shared(&h.engine).last_turn(), None);
+}
+
+#[tokio::test]
+async fn mic_frames_forward_to_stt_in_batches() {
+    let h = start_harness(0);
+    // 2× the outbound batch size → exactly two sends.
+    for _ in 0..4 {
+        h.frames_tx.send(vec![0.01; 640]).unwrap();
+    }
+    wait_for(
+        || h.sent_samples.load(Ordering::SeqCst) >= 2 * OUTBOUND_FRAME_SAMPLES,
+        "audio forwarded to STT",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn speak_flow_feeds_tts_and_returns_to_listening() {
+    let h = start_harness(240);
+    let shared = shared(&h.engine);
+    h.stt_tx
+        .send(SttEvent::EndOfTurn {
+            transcript: "status".into(),
+        })
+        .unwrap();
+    wait_for_state(&h.engine, ConvoState::AwaitingBrain).await;
+    assert_eq!(shared.last_turn().as_deref(), Some("status"));
+
+    h.engine.speak_chunk("One task is running.".into()).unwrap();
+    wait_for_state(&h.engine, ConvoState::Speaking).await;
+    h.engine.speak_chunk(" Nearly done.".into()).unwrap();
+    h.engine.speak_end().unwrap();
+
+    // flush emits audio then closes the channel → sealed → drained →
+    // back to listening.
+    wait_for_state(&h.engine, ConvoState::Listening).await;
+    assert!(h.tts.flushed.load(Ordering::SeqCst));
+    assert_eq!(
+        h.tts.feeds.lock().as_slice(),
+        ["One task is running.", " Nearly done."]
+    );
+    assert!(h.playback.appended.load(Ordering::SeqCst) > 0);
+    assert!(h.playback.completed.load(Ordering::SeqCst));
+}
+
+#[tokio::test]
+async fn speak_end_without_chunks_unwedges_awaiting_brain() {
+    let h = start_harness(0);
+    h.stt_tx
+        .send(SttEvent::EndOfTurn {
+            transcript: "hello".into(),
+        })
+        .unwrap();
+    wait_for_state(&h.engine, ConvoState::AwaitingBrain).await;
+    h.engine.speak_end().unwrap();
+    wait_for_state(&h.engine, ConvoState::Listening).await;
+}
+
+#[tokio::test]
+async fn barge_in_stops_playback_and_replays_pre_roll() {
+    let h = start_harness(0);
+    h.stt_tx
+        .send(SttEvent::EndOfTurn {
+            transcript: "explain".into(),
+        })
+        .unwrap();
+    wait_for_state(&h.engine, ConvoState::AwaitingBrain).await;
+    h.engine.speak_chunk("A long explanation".into()).unwrap();
+    wait_for_state(&h.engine, ConvoState::Speaking).await;
+
+    let forwarded_before = h.sent_samples.load(Ordering::SeqCst);
+    // Loud frames worth >200 ms: gate is closed, so nothing forwards until
+    // the barge-in replays the pre-roll ring.
+    for _ in 0..6 {
+        h.frames_tx.send(vec![0.5; 1024]).unwrap();
+    }
+    wait_for_state(&h.engine, ConvoState::Listening).await;
+    assert!(h.playback.stopped.load(Ordering::SeqCst));
+    assert!(h.tts.stopped.load(Ordering::SeqCst));
+    assert!(
+        h.sent_samples.load(Ordering::SeqCst) > forwarded_before,
+        "pre-roll should replay into STT"
+    );
+}
+
+#[tokio::test]
+async fn quiet_audio_while_speaking_does_not_barge_in() {
+    let h = start_harness(0);
+    h.stt_tx
+        .send(SttEvent::EndOfTurn {
+            transcript: "explain".into(),
+        })
+        .unwrap();
+    wait_for_state(&h.engine, ConvoState::AwaitingBrain).await;
+    h.engine.speak_chunk("Text".into()).unwrap();
+    wait_for_state(&h.engine, ConvoState::Speaking).await;
+
+    let forwarded_before = h.sent_samples.load(Ordering::SeqCst);
+    for _ in 0..20 {
+        h.frames_tx.send(vec![0.02; 1024]).unwrap();
+    }
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert_eq!(h.engine.state(), ConvoState::Speaking);
+    assert_eq!(
+        h.sent_samples.load(Ordering::SeqCst),
+        forwarded_before,
+        "gated frames must not reach STT"
+    );
+    assert!(!h.playback.stopped.load(Ordering::SeqCst));
+}
+
+#[tokio::test]
+async fn force_end_turn_uses_running_transcript_and_ignores_late_eot() {
+    let h = start_harness(0);
+    let shared = shared(&h.engine);
+    h.stt_tx
+        .send(SttEvent::StartOfTurn {
+            transcript: "fix".into(),
+        })
+        .unwrap();
+    h.stt_tx
+        .send(SttEvent::Interim {
+            transcript: "fix the flaky test".into(),
+        })
+        .unwrap();
+    wait_for_state(&h.engine, ConvoState::UserSpeaking).await;
+
+    h.engine.force_end_turn().unwrap();
+    wait_for_state(&h.engine, ConvoState::AwaitingBrain).await;
+    assert_eq!(shared.last_turn().as_deref(), Some("fix the flaky test"));
+
+    // Flux's own EndOfTurn for that audio arrives late — must not re-fire.
+    h.stt_tx
+        .send(SttEvent::EndOfTurn {
+            transcript: "fix the flaky test".into(),
+        })
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(30)).await;
+    assert_eq!(h.engine.state(), ConvoState::AwaitingBrain);
+}
+
+#[tokio::test]
+async fn stt_error_tears_down_and_frees_the_slot() {
+    let h = start_harness(0);
+    h.stt_tx.send(SttEvent::Error("boom".into())).unwrap();
+    wait_for(|| !h.engine.is_active(), "engine slot reaped").await;
+    assert_eq!(h.engine.state(), ConvoState::Idle);
+}
+
+#[tokio::test]
+async fn cancel_speech_returns_to_listening() {
+    let h = start_harness(0);
+    h.stt_tx
+        .send(SttEvent::EndOfTurn {
+            transcript: "talk".into(),
+        })
+        .unwrap();
+    wait_for_state(&h.engine, ConvoState::AwaitingBrain).await;
+    h.engine.speak_chunk("Blah".into()).unwrap();
+    wait_for_state(&h.engine, ConvoState::Speaking).await;
+    h.engine.cancel_speech().unwrap();
+    wait_for_state(&h.engine, ConvoState::Listening).await;
+    assert!(h.playback.stopped.load(Ordering::SeqCst));
+}
+
+#[tokio::test]
+async fn second_start_is_rejected_while_active() {
+    let h = start_harness(0);
+    let (_tx, frames_rx) = mpsc::unbounded_channel();
+    let (_stt_tx, stt_rx) = mpsc::unbounded_channel::<SttEvent>();
+    let err = h
+        .engine
+        .start_with_io(
+            None,
+            Box::new(FakeSttStream {
+                sent_samples: Arc::new(AtomicUsize::new(0)),
+                keepalives: Arc::new(AtomicUsize::new(0)),
+            }),
+            stt_rx,
+            Arc::new(FakeTtsConnector::new(0)),
+            Arc::new(FakePlayback::new()),
+            MicInput {
+                frames_rx,
+                handle: None,
+            },
+        )
+        .expect_err("second start must fail");
+    assert!(err.contains("already running"));
+}
+
+// ── protocol parsing ─────────────────────────────────────────────────────
+
+#[test]
+fn parse_flux_turn_messages() {
+    assert_eq!(
+        parse_flux_message(
+            r#"{"type":"TurnInfo","event":"StartOfTurn","transcript":"hey","turn_index":0}"#
+        ),
+        Some(SttEvent::StartOfTurn {
+            transcript: "hey".into()
+        })
+    );
+    assert_eq!(
+        parse_flux_message(r#"{"type":"TurnInfo","event":"Update","transcript":"hey there"}"#),
+        Some(SttEvent::Interim {
+            transcript: "hey there".into()
+        })
+    );
+    assert_eq!(
+        parse_flux_message(
+            r#"{"type":"TurnInfo","event":"EndOfTurn","transcript":"hey there","end_of_turn_confidence":0.91}"#
+        ),
+        Some(SttEvent::EndOfTurn {
+            transcript: "hey there".into()
+        })
+    );
+    assert_eq!(
+        parse_flux_message(r#"{"type":"Connected","request_id":"x"}"#),
+        None
+    );
+    assert!(matches!(
+        parse_flux_message(r#"{"type":"Error","description":"bad model"}"#),
+        Some(SttEvent::Error(message)) if message == "bad model"
+    ));
+    assert_eq!(parse_flux_message("not json"), None);
+}
+
+// ── DSP ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn stream_resampler_matches_batch_resample_across_chunks() {
+    let input: Vec<f32> = (0..480).map(|i| (i as f32 * 0.13).sin()).collect();
+    let batch = resample(&input, 48_000, 16_000);
+
+    let mut streaming = StreamResampler::new(48_000, 16_000);
+    let mut chunked = Vec::new();
+    for chunk in input.chunks(77) {
+        chunked.extend(streaming.process(chunk));
+    }
+    // The tail beyond the last full interpolation window stays carried, so
+    // compare the shared prefix.
+    let shared_len = chunked.len().min(batch.len());
+    assert!(shared_len >= batch.len() - 2, "streaming output too short");
+    for (index, (a, b)) in batch[..shared_len]
+        .iter()
+        .zip(chunked[..shared_len].iter())
+        .enumerate()
+    {
+        assert!(
+            (a - b).abs() < 1e-4,
+            "sample {index} diverged: batch={a} streaming={b}"
+        );
+    }
+}
+
+#[test]
+fn stream_resampler_is_identity_at_equal_rates() {
+    let mut resampler = StreamResampler::new(16_000, 16_000);
+    let chunk = vec![0.1_f32, -0.2, 0.3];
+    assert_eq!(resampler.process(&chunk), chunk);
+}
+
+#[test]
+fn stream_resampler_upsamples_without_gaps() {
+    let mut resampler = StreamResampler::new(16_000, 48_000);
+    let mut total = 0usize;
+    for _ in 0..10 {
+        total += resampler.process(&vec![0.5_f32; 160]).len();
+    }
+    // 1600 input samples → ~4800 output samples (± carried edges).
+    assert!((4780..=4800).contains(&total), "got {total}");
+}

--- a/src-tauri/src/voice/convo/tts.rs
+++ b/src-tauri/src/voice/convo/tts.rs
@@ -158,9 +158,11 @@ pub(super) fn parse_cartesia_message(raw: &str) -> CartesiaMessage {
             let Ok(bytes) = base64::engine::general_purpose::STANDARD.decode(data) else {
                 return CartesiaMessage::Error("undecodable audio chunk".to_string());
             };
+            // Requested as raw pcm_s16le — the format every documented
+            // Cartesia example uses — then widened to the engine's f32.
             let samples = bytes
-                .chunks_exact(4)
-                .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+                .chunks_exact(2)
+                .map(|b| f32::from(i16::from_le_bytes([b[0], b[1]])) / f32::from(i16::MAX))
                 .collect();
             CartesiaMessage::Chunk(samples)
         }
@@ -191,7 +193,7 @@ impl CartesiaTts {
             "voice": { "mode": "id", "id": self.voice_id },
             "output_format": {
                 "container": "raw",
-                "encoding": "pcm_f32le",
+                "encoding": "pcm_s16le",
                 "sample_rate": TTS_SAMPLE_RATE,
             },
             "context_id": self.context_id,
@@ -276,4 +278,43 @@ pub(crate) async fn list_cartesia_voices(api_key: &str) -> Result<Vec<CartesiaVo
         })
         .take(200)
         .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cartesia_chunk_decodes_s16le_to_f32() {
+        // i16::MAX, 0, i16::MIN → 1.0, 0.0, ~-1.0 after widening.
+        let pcm: Vec<u8> = [i16::MAX, 0, i16::MIN]
+            .iter()
+            .flat_map(|s| s.to_le_bytes())
+            .collect();
+        let data = base64::engine::general_purpose::STANDARD.encode(pcm);
+        let raw = format!(r#"{{"type":"chunk","data":"{data}"}}"#);
+        let CartesiaMessage::Chunk(samples) = parse_cartesia_message(&raw) else {
+            panic!("expected chunk");
+        };
+        assert_eq!(samples.len(), 3);
+        assert!((samples[0] - 1.0).abs() < 1e-6);
+        assert_eq!(samples[1], 0.0);
+        assert!(samples[2] < -0.999);
+    }
+
+    #[test]
+    fn cartesia_error_and_done_messages_parse() {
+        assert!(matches!(
+            parse_cartesia_message(r#"{"type":"error","message":"bad key"}"#),
+            CartesiaMessage::Error(msg) if msg == "bad key"
+        ));
+        assert!(matches!(
+            parse_cartesia_message(r#"{"type":"done"}"#),
+            CartesiaMessage::Done
+        ));
+        assert!(matches!(
+            parse_cartesia_message("not json"),
+            CartesiaMessage::Other
+        ));
+    }
 }

--- a/src-tauri/src/voice/convo/tts.rs
+++ b/src-tauri/src/voice/convo/tts.rs
@@ -233,3 +233,47 @@ impl Drop for CartesiaTts {
         }
     }
 }
+
+#[derive(serde::Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CartesiaVoiceInfo {
+    pub(crate) id: String,
+    pub(crate) name: String,
+}
+
+/// Fetch the account's voice catalogue (Settings → Voice → Conversation).
+/// Tolerates both response shapes Cartesia has used (bare array and
+/// `{"data": [...]}`).
+pub(crate) async fn list_cartesia_voices(api_key: &str) -> Result<Vec<CartesiaVoiceInfo>, String> {
+    let client = reqwest::Client::new();
+    let response = client
+        .get("https://api.cartesia.ai/voices")
+        .header("X-API-Key", api_key)
+        .header("Cartesia-Version", CARTESIA_VERSION)
+        .timeout(std::time::Duration::from_secs(10))
+        .send()
+        .await
+        .map_err(|e| format!("voice list request failed: {e}"))?;
+    if !response.status().is_success() {
+        return Err(format!("voice list failed (HTTP {})", response.status()));
+    }
+    let value: serde_json::Value = response
+        .json()
+        .await
+        .map_err(|e| format!("voice list parse failed: {e}"))?;
+    let items = value
+        .as_array()
+        .cloned()
+        .or_else(|| value["data"].as_array().cloned())
+        .unwrap_or_default();
+    Ok(items
+        .iter()
+        .filter_map(|voice| {
+            Some(CartesiaVoiceInfo {
+                id: voice["id"].as_str()?.to_string(),
+                name: voice["name"].as_str().unwrap_or("(unnamed)").to_string(),
+            })
+        })
+        .take(200)
+        .collect())
+}

--- a/src-tauri/src/voice/convo/tts.rs
+++ b/src-tauri/src/voice/convo/tts.rs
@@ -1,0 +1,235 @@
+//! Streaming text-to-speech.
+//!
+//! One `TtsSession` per spoken reply: the engine feeds clause-sized text
+//! chunks as the voice brain streams them (`continue: true` input
+//! continuations), then flushes. Synthesized PCM arrives on `audio_rx` while
+//! generation is still running — the channel closing means the reply is fully
+//! synthesized (playback may still be draining).
+
+use async_trait::async_trait;
+use base64::Engine as _;
+use futures_util::{SinkExt, StreamExt};
+use tokio::sync::mpsc;
+use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async};
+
+const CARTESIA_WS_URL: &str = "wss://api.cartesia.ai/tts/websocket";
+const CARTESIA_VERSION: &str = "2025-04-16";
+const CARTESIA_MODEL: &str = "sonic-3.5";
+/// Cartesia's documented default voice ("Sarah"). Overridable via
+/// `[voice] tts_voice`.
+const DEFAULT_CARTESIA_VOICE: &str = "694f9389-aac1-45b6-b726-9d9369183238";
+/// PCM rate we ask Cartesia for; playback resamples to the device rate.
+pub(crate) const TTS_SAMPLE_RATE: u32 = 24_000;
+/// How long Cartesia may buffer a continuation waiting for more text before
+/// starting generation. The default (3 s) optimizes prosody over latency —
+/// exactly backwards for a live conversation.
+const MAX_BUFFER_DELAY_MS: u32 = 250;
+
+pub(crate) struct TtsSession {
+    pub(crate) stream: Box<dyn TtsStream>,
+    /// Mono f32 at `sample_rate`; closes once the reply is fully synthesized.
+    pub(crate) audio_rx: mpsc::UnboundedReceiver<Vec<f32>>,
+    pub(crate) sample_rate: u32,
+}
+
+#[async_trait]
+pub(crate) trait TtsStream: Send {
+    /// Queue a text chunk for synthesis (more may follow).
+    async fn feed(&mut self, text: &str) -> Result<(), String>;
+    /// Signal that no more text is coming for this reply.
+    async fn flush(&mut self) -> Result<(), String>;
+    /// Abandon the reply (barge-in / cancel).
+    async fn stop(&mut self);
+}
+
+#[async_trait]
+pub(crate) trait TtsConnector: Send + Sync {
+    async fn connect(&self) -> Result<TtsSession, String>;
+}
+
+type WsSink = futures_util::stream::SplitSink<
+    WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>,
+    Message,
+>;
+
+pub(crate) struct CartesiaConnector {
+    api_key: String,
+    voice_id: String,
+}
+
+impl CartesiaConnector {
+    pub(crate) fn new(api_key: String, voice_id: Option<String>) -> Self {
+        Self {
+            api_key,
+            voice_id: voice_id
+                .filter(|id| !id.trim().is_empty())
+                .unwrap_or_else(|| DEFAULT_CARTESIA_VOICE.to_string()),
+        }
+    }
+}
+
+#[async_trait]
+impl TtsConnector for CartesiaConnector {
+    async fn connect(&self) -> Result<TtsSession, String> {
+        let url = format!("{CARTESIA_WS_URL}?cartesia_version={CARTESIA_VERSION}");
+        let mut request = url
+            .into_client_request()
+            .map_err(|e| format!("invalid Cartesia request: {e}"))?;
+        let key = self
+            .api_key
+            .parse()
+            .map_err(|_| "invalid Cartesia API key format".to_string())?;
+        request.headers_mut().insert("X-API-Key", key);
+
+        let (socket, _response) = connect_async(request).await.map_err(friendly_ws_error)?;
+        let (sink, mut read) = socket.split();
+        let (tx, rx) = mpsc::unbounded_channel();
+
+        let reader = tokio::spawn(async move {
+            while let Some(message) = read.next().await {
+                match message {
+                    Ok(Message::Text(text)) => match parse_cartesia_message(&text) {
+                        CartesiaMessage::Chunk(samples) => {
+                            if tx.send(samples).is_err() {
+                                return;
+                            }
+                        }
+                        CartesiaMessage::Done => return,
+                        CartesiaMessage::Error(err) => {
+                            tracing::warn!(
+                                target: "aethon::voice::convo",
+                                error = %err,
+                                "cartesia synthesis error"
+                            );
+                            return;
+                        }
+                        CartesiaMessage::Other => {}
+                    },
+                    Ok(Message::Close(_)) | Err(_) => return,
+                    Ok(_) => {}
+                }
+            }
+        });
+
+        Ok(TtsSession {
+            stream: Box::new(CartesiaTts {
+                sink,
+                reader: Some(reader),
+                voice_id: self.voice_id.clone(),
+                context_id: uuid::Uuid::new_v4().to_string(),
+            }),
+            audio_rx: rx,
+            sample_rate: TTS_SAMPLE_RATE,
+        })
+    }
+}
+
+fn friendly_ws_error(err: tokio_tungstenite::tungstenite::Error) -> String {
+    use tokio_tungstenite::tungstenite::Error;
+    match &err {
+        Error::Http(response) if matches!(response.status().as_u16(), 401 | 403) => {
+            "Cartesia rejected the API key".to_string()
+        }
+        Error::Http(response) => {
+            format!("Cartesia connection failed (HTTP {})", response.status())
+        }
+        _ => format!("Cartesia connection failed: {err}"),
+    }
+}
+
+pub(super) enum CartesiaMessage {
+    Chunk(Vec<f32>),
+    Done,
+    Error(String),
+    Other,
+}
+
+pub(super) fn parse_cartesia_message(raw: &str) -> CartesiaMessage {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(raw) else {
+        return CartesiaMessage::Other;
+    };
+    match value["type"].as_str().unwrap_or_default() {
+        "chunk" => {
+            let Some(data) = value["data"].as_str() else {
+                return CartesiaMessage::Other;
+            };
+            let Ok(bytes) = base64::engine::general_purpose::STANDARD.decode(data) else {
+                return CartesiaMessage::Error("undecodable audio chunk".to_string());
+            };
+            let samples = bytes
+                .chunks_exact(4)
+                .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+                .collect();
+            CartesiaMessage::Chunk(samples)
+        }
+        "done" => CartesiaMessage::Done,
+        "error" => CartesiaMessage::Error(
+            value["message"]
+                .as_str()
+                .or_else(|| value["title"].as_str())
+                .unwrap_or(raw)
+                .to_string(),
+        ),
+        _ => CartesiaMessage::Other,
+    }
+}
+
+struct CartesiaTts {
+    sink: WsSink,
+    reader: Option<tokio::task::JoinHandle<()>>,
+    voice_id: String,
+    context_id: String,
+}
+
+impl CartesiaTts {
+    async fn send_request(&mut self, transcript: &str, more_follows: bool) -> Result<(), String> {
+        let payload = serde_json::json!({
+            "model_id": CARTESIA_MODEL,
+            "transcript": transcript,
+            "voice": { "mode": "id", "id": self.voice_id },
+            "output_format": {
+                "container": "raw",
+                "encoding": "pcm_f32le",
+                "sample_rate": TTS_SAMPLE_RATE,
+            },
+            "context_id": self.context_id,
+            "continue": more_follows,
+            "language": "en",
+            "max_buffer_delay_ms": MAX_BUFFER_DELAY_MS,
+        });
+        self.sink
+            .send(Message::Text(payload.to_string()))
+            .await
+            .map_err(|e| e.to_string())
+    }
+}
+
+#[async_trait]
+impl TtsStream for CartesiaTts {
+    async fn feed(&mut self, text: &str) -> Result<(), String> {
+        self.send_request(text, true).await
+    }
+
+    async fn flush(&mut self) -> Result<(), String> {
+        // The documented way to close an input continuation: a final (empty)
+        // transcript with `continue: false`.
+        self.send_request("", false).await
+    }
+
+    async fn stop(&mut self) {
+        let _ = self.sink.close().await;
+        if let Some(reader) = self.reader.take() {
+            reader.abort();
+        }
+    }
+}
+
+impl Drop for CartesiaTts {
+    fn drop(&mut self) {
+        if let Some(reader) = self.reader.take() {
+            reader.abort();
+        }
+    }
+}

--- a/src-tauri/src/voice/deepgram.rs
+++ b/src-tauri/src/voice/deepgram.rs
@@ -1,0 +1,75 @@
+//! Batch cloud dictation via Deepgram's prerecorded `listen` API — the
+//! dictation counterpart of the conversation engine's streaming Flux socket.
+//! Same key resolution as the cascade (env wins over config.toml), same
+//! record→stop→transcribe lifecycle as the local providers: the whole clip
+//! posts as raw 16 kHz PCM and the transcript comes back in one response.
+
+use super::*;
+
+/// Model for one-shot dictation clips. Nova-3 is Deepgram's general-purpose
+/// high-accuracy tier (Flux, used by the conversation engine, is
+/// streaming-only).
+const DEEPGRAM_BATCH_MODEL: &str = "nova-3";
+pub(super) const DEEPGRAM_BATCH_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Resolve the Deepgram key the same way the conversation cascade does:
+/// `DEEPGRAM_API_KEY` env, else `[voice] deepgram_api_key` in config.toml.
+/// Read from disk on demand — dictation status checks are infrequent and the
+/// key can change under us via Settings.
+pub(super) fn resolve_deepgram_key() -> Option<String> {
+    let home = std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(std::path::PathBuf::from);
+    let config = crate::helpers::aethon_dir(home)
+        .map(|dir| dir.join("config.toml"))
+        .and_then(|path| std::fs::read_to_string(path).ok())
+        .and_then(|raw| toml::from_str::<crate::helpers::config::AethonConfig>(&raw).ok())
+        .map(|cfg| cfg.voice)
+        .unwrap_or_default();
+    super::resolve_cascade_keys(&config).deepgram
+}
+
+pub(super) async fn deepgram_transcribe_batch(
+    api_key: &str,
+    audio: CapturedAudio,
+) -> Result<String, String> {
+    let mut body = Vec::with_capacity(audio.samples.len() * 2);
+    for sample in &audio.samples {
+        let value = (sample.clamp(-1.0, 1.0) * f32::from(i16::MAX)) as i16;
+        body.extend_from_slice(&value.to_le_bytes());
+    }
+    let url = format!(
+        "https://api.deepgram.com/v1/listen?model={DEEPGRAM_BATCH_MODEL}&smart_format=true&encoding=linear16&sample_rate={}&channels=1",
+        audio.sample_rate
+    );
+    let client = reqwest::Client::new();
+    let response = client
+        .post(url)
+        .header("Authorization", format!("Token {api_key}"))
+        .header("Content-Type", "application/octet-stream")
+        .timeout(DEEPGRAM_BATCH_TIMEOUT)
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| format!("Deepgram request failed: {e}"))?;
+    if response.status().as_u16() == 401 {
+        return Err("Deepgram rejected the API key".to_string());
+    }
+    if !response.status().is_success() {
+        return Err(format!(
+            "Deepgram transcription failed (HTTP {})",
+            response.status()
+        ));
+    }
+    let value: serde_json::Value = response
+        .json()
+        .await
+        .map_err(|e| format!("Deepgram response parse failed: {e}"))?;
+    Ok(
+        value["results"]["channels"][0]["alternatives"][0]["transcript"]
+            .as_str()
+            .unwrap_or("")
+            .trim()
+            .to_string(),
+    )
+}

--- a/src-tauri/src/voice/lfm2.rs
+++ b/src-tauri/src/voice/lfm2.rs
@@ -62,8 +62,10 @@ pub(super) fn lfm2_model_paths(cache_path: &Path) -> Lfm2ModelPaths {
 }
 
 /// Locate the `llama-lfm2-audio` binary. Order: explicit dev override, a
-/// sidecar staged next to the running executable (release bundle), then `PATH`
-/// through the shared resolver in `env.rs`.
+/// sidecar staged next to the running executable (release bundle), the
+/// repo's staged runner (debug builds only — `cargo tauri dev` runs from
+/// `target/debug` with no sidecar), then `PATH` through the shared resolver
+/// in `env.rs`.
 pub(super) fn resolve_lfm2_binary() -> Option<PathBuf> {
     if let Some(raw) = std::env::var_os(LFM2_BIN_ENV) {
         let path = PathBuf::from(raw);
@@ -76,6 +78,18 @@ pub(super) fn resolve_lfm2_binary() -> Option<PathBuf> {
         && let Some(found) = bundled_lfm2_binary(dir)
     {
         return Some(found);
+    }
+    // Debug-only: release binaries must never reference a build machine's
+    // source tree.
+    #[cfg(debug_assertions)]
+    {
+        let staged = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("binaries")
+            .join(LFM2_BUNDLE_SUBDIR)
+            .join(LFM2_BIN_NAME);
+        if staged.is_file() {
+            return Some(staged);
+        }
     }
     crate::env::resolve_program(LFM2_BIN_NAME)
 }

--- a/src-tauri/src/voice/mod.rs
+++ b/src-tauri/src/voice/mod.rs
@@ -27,8 +27,8 @@ pub(crate) use self::audio::{
     AudioRecorder, CpalAudioRecorder, LevelTask, RecordingSession, spawn_level_emitter,
     validate_captured_audio,
 };
-// Shared DSP helpers consumed by the playback module.
-use self::audio::{compute_rms, resample};
+// Shared DSP helpers consumed by the playback + conversation modules.
+use self::audio::{StreamResampler, compute_rms, resample};
 #[cfg(test)]
 use self::audio::{
     normalize_interleaved_f32, normalize_interleaved_f64, normalize_interleaved_i16,
@@ -36,6 +36,7 @@ use self::audio::{
     resample_to_target_rate,
 };
 
+mod convo;
 mod download;
 mod inference;
 mod lfm2;
@@ -45,6 +46,8 @@ mod providers;
 mod registry;
 mod settings;
 mod types;
+
+pub(crate) use convo::*;
 
 use download::*;
 use inference::*;

--- a/src-tauri/src/voice/mod.rs
+++ b/src-tauri/src/voice/mod.rs
@@ -37,6 +37,7 @@ use self::audio::{
 };
 
 mod convo;
+mod deepgram;
 mod download;
 mod inference;
 mod lfm2;
@@ -48,6 +49,8 @@ mod settings;
 mod types;
 
 pub(crate) use convo::*;
+
+use deepgram::*;
 
 use download::*;
 use inference::*;

--- a/src-tauri/src/voice/playback.rs
+++ b/src-tauri/src/voice/playback.rs
@@ -32,6 +32,9 @@ pub(super) struct PlaybackBuffer {
     samples: Vec<f32>,
     pos: usize,
     complete: bool,
+    /// While paused the callback emits silence without advancing the cursor,
+    /// so playback resumes exactly where it stopped (barge-in confirmation).
+    paused: bool,
 }
 
 impl PlaybackBuffer {
@@ -40,6 +43,7 @@ impl PlaybackBuffer {
             samples,
             pos: 0,
             complete: true,
+            paused: false,
         }
     }
 
@@ -48,6 +52,7 @@ impl PlaybackBuffer {
             samples: Vec::new(),
             pos: 0,
             complete: false,
+            paused: false,
         }
     }
 
@@ -59,8 +64,16 @@ impl PlaybackBuffer {
         self.complete = true;
     }
 
-    /// The next mono sample, or `None` once the buffer is drained.
+    pub(super) fn set_paused(&mut self, paused: bool) {
+        self.paused = paused;
+    }
+
+    /// The next mono sample, or `None` once the buffer is drained (or while
+    /// paused — the cursor holds position).
     pub(super) fn next_sample(&mut self) -> Option<f32> {
+        if self.paused {
+            return None;
+        }
         let sample = self.samples.get(self.pos).copied();
         if sample.is_some() {
             self.pos += 1;
@@ -68,8 +81,9 @@ impl PlaybackBuffer {
         sample
     }
 
+    /// A paused clip is never finished — the cursor can't reach the end.
     pub(super) fn finished(&self) -> bool {
-        self.complete && self.pos >= self.samples.len()
+        !self.paused && self.complete && self.pos >= self.samples.len()
     }
 }
 
@@ -240,6 +254,16 @@ impl StreamingPlaybackHandle {
     /// fires `voice://playback-finished` and frees the stream.
     pub(crate) fn mark_complete(&self) {
         self.buffer.lock().mark_complete();
+    }
+
+    /// Hold the cursor (device plays silence) without losing position —
+    /// used while a suspected barge-in awaits recognizer confirmation.
+    pub(crate) fn pause(&self) {
+        self.buffer.lock().set_paused(true);
+    }
+
+    pub(crate) fn resume(&self) {
+        self.buffer.lock().set_paused(false);
     }
 
     pub(crate) fn is_drained(&self) -> bool {

--- a/src-tauri/src/voice/playback.rs
+++ b/src-tauri/src/voice/playback.rs
@@ -17,19 +17,46 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use tauri::{AppHandle, Emitter};
 use tokio::task::AbortHandle;
 
-use super::{LevelTask, VoiceLevelPayload, compute_rms, resample};
+use super::{LevelTask, StreamResampler, VoiceLevelPayload, compute_rms, resample};
 
 /// Cursor over mono PCM samples, advanced one frame at a time by the audio
 /// callback. Factored out so the draining logic is unit-testable without a
 /// real output device.
+///
+/// Two modes share the type: a batch clip (`new`, complete from birth) and a
+/// streaming clip (`new_streaming`, fed via `append` while playing and sealed
+/// with `mark_complete`). A streaming buffer that runs dry before more audio
+/// arrives plays silence (`next_sample` → `None` → EQUILIBRIUM) rather than
+/// finishing, so `finished()` only fires after the producer seals it.
 pub(super) struct PlaybackBuffer {
     samples: Vec<f32>,
     pos: usize,
+    complete: bool,
 }
 
 impl PlaybackBuffer {
     pub(super) fn new(samples: Vec<f32>) -> Self {
-        Self { samples, pos: 0 }
+        Self {
+            samples,
+            pos: 0,
+            complete: true,
+        }
+    }
+
+    pub(super) fn new_streaming() -> Self {
+        Self {
+            samples: Vec::new(),
+            pos: 0,
+            complete: false,
+        }
+    }
+
+    pub(super) fn append(&mut self, more: &[f32]) {
+        self.samples.extend_from_slice(more);
+    }
+
+    pub(super) fn mark_complete(&mut self) {
+        self.complete = true;
     }
 
     /// The next mono sample, or `None` once the buffer is drained.
@@ -42,13 +69,16 @@ impl PlaybackBuffer {
     }
 
     pub(super) fn finished(&self) -> bool {
-        self.pos >= self.samples.len()
+        self.complete && self.pos >= self.samples.len()
     }
 }
 
+/// Clonable so the conversation engine's driver task can hold its own handle;
+/// every clone shares the single playback slot and generation counter.
+#[derive(Clone)]
 pub(crate) struct AudioPlayer {
     active: Arc<Mutex<Option<PlaybackHandle>>>,
-    generation: AtomicU64,
+    generation: Arc<AtomicU64>,
 }
 
 /// Holds a playing stream and its level/finished watcher. Dropping it stops
@@ -71,7 +101,7 @@ impl AudioPlayer {
     pub(crate) fn new() -> Self {
         Self {
             active: Arc::new(Mutex::new(None)),
-            generation: AtomicU64::new(0),
+            generation: Arc::new(AtomicU64::new(0)),
         }
     }
 
@@ -98,25 +128,45 @@ impl AudioPlayer {
             return Ok(());
         }
 
-        let host = cpal::default_host();
-        let device = host
-            .default_output_device()
-            .ok_or_else(|| "No default audio output device is available".to_string())?;
-        let supported = device
-            .default_output_config()
-            .map_err(|e| format!("Failed to read audio output config: {e}"))?;
-        let device_rate = supported.sample_rate();
-        let channels = usize::from(supported.channels().max(1));
-        let config: cpal::StreamConfig = supported.clone().into();
-
-        let resampled = resample(&samples, sample_rate, device_rate);
+        let target = default_output_target()?;
+        let resampled = resample(&samples, sample_rate, target.rate);
         let buffer = Arc::new(Mutex::new(PlaybackBuffer::new(resampled)));
+        self.start_with_buffer(&target, Arc::clone(&buffer), app)?;
+        Ok(())
+    }
 
+    /// Open the output device for a streaming clip: audio is fed through the
+    /// returned handle's `append` while the device plays, and the clip only
+    /// counts as finished (→ `voice://playback-finished`) after
+    /// `mark_complete()` + drain. The handle resamples appended audio from
+    /// `source_rate` to the device rate with carried state, so chunk
+    /// boundaries don't click.
+    pub(crate) fn start_stream(
+        &self,
+        source_rate: u32,
+        app: Option<AppHandle>,
+    ) -> Result<StreamingPlaybackHandle, String> {
+        *self.active.lock() = None;
+        let target = default_output_target()?;
+        let buffer = Arc::new(Mutex::new(PlaybackBuffer::new_streaming()));
+        self.start_with_buffer(&target, Arc::clone(&buffer), app)?;
+        Ok(StreamingPlaybackHandle {
+            buffer,
+            resampler: StreamResampler::new(source_rate, target.rate),
+        })
+    }
+
+    fn start_with_buffer(
+        &self,
+        target: &OutputTarget,
+        buffer: Arc<Mutex<PlaybackBuffer>>,
+        app: Option<AppHandle>,
+    ) -> Result<(), String> {
         let stream = build_output_stream(
-            &device,
-            &config,
-            supported.sample_format(),
-            channels,
+            &target.device,
+            &target.config,
+            target.sample_format,
+            target.channels,
             Arc::clone(&buffer),
         )?;
         stream
@@ -136,6 +186,64 @@ impl AudioPlayer {
     /// Stop any in-flight playback immediately (drops the stream + watcher).
     pub(crate) fn stop(&self) {
         *self.active.lock() = None;
+    }
+}
+
+struct OutputTarget {
+    device: cpal::Device,
+    config: cpal::StreamConfig,
+    sample_format: cpal::SampleFormat,
+    channels: usize,
+    rate: u32,
+}
+
+fn default_output_target() -> Result<OutputTarget, String> {
+    let host = cpal::default_host();
+    let device = host
+        .default_output_device()
+        .ok_or_else(|| "No default audio output device is available".to_string())?;
+    let supported = device
+        .default_output_config()
+        .map_err(|e| format!("Failed to read audio output config: {e}"))?;
+    let rate = supported.sample_rate();
+    let channels = usize::from(supported.channels().max(1));
+    let sample_format = supported.sample_format();
+    let config: cpal::StreamConfig = supported.into();
+    Ok(OutputTarget {
+        device,
+        config,
+        sample_format,
+        channels,
+        rate,
+    })
+}
+
+/// Producer side of a streaming playback: append synthesized audio as it
+/// arrives, then seal the clip. Dropping the handle does NOT stop playback —
+/// the device keeps draining what was appended; call `AudioPlayer::stop()` to
+/// cut it off.
+pub(crate) struct StreamingPlaybackHandle {
+    buffer: Arc<Mutex<PlaybackBuffer>>,
+    resampler: StreamResampler,
+}
+
+impl StreamingPlaybackHandle {
+    /// Append mono samples at the handle's source rate.
+    pub(crate) fn append(&mut self, samples: &[f32]) {
+        let resampled = self.resampler.process(samples);
+        if !resampled.is_empty() {
+            self.buffer.lock().append(&resampled);
+        }
+    }
+
+    /// Seal the clip: once the device drains what's buffered, the watcher
+    /// fires `voice://playback-finished` and frees the stream.
+    pub(crate) fn mark_complete(&self) {
+        self.buffer.lock().mark_complete();
+    }
+
+    pub(crate) fn is_drained(&self) -> bool {
+        self.buffer.lock().finished()
     }
 }
 

--- a/src-tauri/src/voice/providers.rs
+++ b/src-tauri/src/voice/providers.rs
@@ -189,6 +189,78 @@ impl VoiceProvider for PlatformVoiceProvider {
     }
 }
 
+pub(super) struct DeepgramVoiceProvider;
+
+#[async_trait]
+impl VoiceProvider for DeepgramVoiceProvider {
+    fn id(&self) -> &'static str {
+        DEEPGRAM_ID
+    }
+
+    fn metadata(&self, _registry: &VoiceProviderRegistry) -> VoiceProviderMetadata {
+        VoiceProviderMetadata {
+            id: DEEPGRAM_ID.to_string(),
+            name: "Deepgram Nova-3 (cloud)".to_string(),
+            description: "Cloud dictation via Deepgram's Nova-3 model. Fast and accurate; needs network and the Deepgram API key from the Conversation settings above.".to_string(),
+            kind: VoiceProviderKind::External,
+            recording_mode: VoiceRecordingMode::Native,
+            privacy_label: "Audio is sent to Deepgram for transcription".to_string(),
+            offline: false,
+            download_required: false,
+            model_size_label: None,
+            cache_path: None,
+            accelerator_label: Some("Deepgram cloud".to_string()),
+        }
+    }
+
+    fn status(&self, registry: &VoiceProviderRegistry, db: &VoiceSettings) -> VoiceProviderInfo {
+        let enabled = registry.enabled(db, self.id());
+        let has_key = resolve_deepgram_key().is_some();
+        let (status, status_label, setup_required) = if !enabled {
+            (
+                VoiceProviderStatus::Unavailable,
+                "Disabled".to_string(),
+                false,
+            )
+        } else if has_key {
+            (
+                VoiceProviderStatus::Ready,
+                "Ready (cloud)".to_string(),
+                false,
+            )
+        } else {
+            (
+                VoiceProviderStatus::NeedsSetup,
+                "Add a Deepgram API key (Conversation settings above, or DEEPGRAM_API_KEY)"
+                    .to_string(),
+                true,
+            )
+        };
+        VoiceProviderInfo {
+            metadata: self.metadata(registry),
+            status,
+            status_label,
+            enabled,
+            selected: registry.selected_provider(db).as_deref() == Some(self.id()),
+            setup_required,
+            can_remove_model: false,
+            error: None,
+        }
+    }
+
+    async fn prepare(
+        &self,
+        registry: &VoiceProviderRegistry,
+        _app: &AppHandle,
+        db_path: &Path,
+    ) -> Result<VoiceProviderInfo, String> {
+        // Nothing to download or authorize locally; "prepare" just re-checks
+        // the key so the Settings card refreshes.
+        let db = VoiceSettings::open(db_path).map_err(|e| e.to_string())?;
+        Ok(self.status(registry, &db))
+    }
+}
+
 pub(super) struct DistilWhisperCandleProvider;
 
 #[async_trait]

--- a/src-tauri/src/voice/registry.rs
+++ b/src-tauri/src/voice/registry.rs
@@ -170,6 +170,7 @@ impl VoiceProviderRegistry {
             PlatformVoiceProvider.status(self, db),
             DistilWhisperCandleProvider.status(self, db),
             Lfm2AudioProvider.status(self, db),
+            DeepgramVoiceProvider.status(self, db),
         ]
     }
 
@@ -217,6 +218,7 @@ impl VoiceProviderRegistry {
                     .await
             }
             LFM2_ID => Lfm2AudioProvider.prepare(self, app, db_path).await,
+            DEEPGRAM_ID => DeepgramVoiceProvider.prepare(self, app, db_path).await,
             _ => Err(format!("Unknown voice provider: {provider_id}")),
         }
     }
@@ -262,6 +264,7 @@ impl VoiceProviderRegistry {
             PLATFORM_ID => self.start_platform_recording(db_path, app).await,
             DISTIL_ID => self.start_distil_recording(db_path, app).await,
             LFM2_ID => self.start_lfm2_recording(db_path, app).await,
+            DEEPGRAM_ID => self.start_deepgram_recording(db_path, app).await,
             _ => Err(format!("Unknown voice provider: {provider_id}")),
         }?;
         Ok(VoiceStartLatency { stream_open_ms })
@@ -273,6 +276,7 @@ impl VoiceProviderRegistry {
             PLATFORM_ID => self.stop_platform_recording().await,
             DISTIL_ID => self.stop_distil_recording().await,
             LFM2_ID => self.stop_lfm2_recording().await,
+            DEEPGRAM_ID => self.stop_deepgram_recording().await,
             _ => Err(format!("Unknown voice provider: {provider_id}")),
         }
     }
@@ -283,6 +287,7 @@ impl VoiceProviderRegistry {
             PLATFORM_ID => self.cancel_platform_recording().await,
             DISTIL_ID => self.cancel_distil_recording().await,
             LFM2_ID => self.cancel_lfm2_recording().await,
+            DEEPGRAM_ID => self.cancel_deepgram_recording().await,
             _ => Err(format!("Unknown voice provider: {provider_id}")),
         }
     }
@@ -542,6 +547,68 @@ impl VoiceProviderRegistry {
         Ok(())
     }
 
+    async fn start_deepgram_recording(
+        &self,
+        db_path: &Path,
+        app: Option<AppHandle>,
+    ) -> Result<u128, String> {
+        {
+            let db = VoiceSettings::open(db_path).map_err(|e| e.to_string())?;
+            if !self.enabled(&db, DEEPGRAM_ID) {
+                return Err("Deepgram voice input is disabled".to_string());
+            }
+            if resolve_deepgram_key().is_none() {
+                return Err(
+                    "Add a Deepgram API key in Settings → Voice, or set DEEPGRAM_API_KEY"
+                        .to_string(),
+                );
+            }
+        }
+
+        let mut active = self.active_recording.lock();
+        if active.is_some() {
+            return Err("Voice recording is already active".to_string());
+        }
+        let t_stream = Instant::now();
+        let mut session = self.recorder.start()?;
+        let stream_open_ms = t_stream.elapsed().as_millis();
+        if let Some(app) = app {
+            let abort = spawn_level_emitter(app, Arc::clone(&session.samples));
+            session._level_task = Some(LevelTask(abort));
+        }
+        *active = Some(session);
+        Ok(stream_open_ms)
+    }
+
+    async fn stop_deepgram_recording(&self) -> Result<String, String> {
+        let session = self
+            .active_recording
+            .lock()
+            .take()
+            .ok_or_else(|| "No voice recording is active".to_string())?;
+        let audio = session.finish()?;
+        if audio.samples.is_empty() {
+            return Err("No audio was captured".to_string());
+        }
+        validate_captured_audio(&audio)?;
+
+        let api_key = resolve_deepgram_key().ok_or_else(|| {
+            "Add a Deepgram API key in Settings → Voice, or set DEEPGRAM_API_KEY".to_string()
+        })?;
+        let transcript = deepgram_transcribe_batch(&api_key, audio).await?;
+        if transcript.is_empty() {
+            return Err(
+                "No speech was recognized. Try again closer to the microphone.".to_string(),
+            );
+        }
+        Ok(transcript)
+    }
+
+    async fn cancel_deepgram_recording(&self) -> Result<(), String> {
+        let _ = self.active_recording.lock().take();
+        Ok(())
+    }
+
     /// Synthesize speech for `text` via the LFM2-Audio runner, returning 24 kHz
     /// mono PCM. Requires the LFM2 provider to be enabled with its model +
     /// binary present; cancellable via `cancel_speech` and bounded by the
@@ -607,7 +674,7 @@ impl VoiceProviderRegistry {
 
     fn ensure_known(&self, provider_id: &str) -> Result<(), String> {
         match provider_id {
-            PLATFORM_ID | DISTIL_ID | LFM2_ID => Ok(()),
+            PLATFORM_ID | DISTIL_ID | LFM2_ID | DEEPGRAM_ID => Ok(()),
             _ => Err(format!("Unknown voice provider: {provider_id}")),
         }
     }

--- a/src-tauri/src/voice/registry.rs
+++ b/src-tauri/src/voice/registry.rs
@@ -23,6 +23,23 @@ impl VoiceProviderRegistry {
         self.active_recording.lock().is_some()
     }
 
+    // Component accessors for the conversation engine's local providers —
+    // the streaming path reuses the batch registry's models and backends
+    // rather than loading its own copies. `pub(super)` because the trait
+    // objects are voice-internal; commands go through the connectors'
+    // `from_registry` constructors.
+    pub(super) fn model_root(&self) -> &Path {
+        &self.model_root
+    }
+
+    pub(super) fn whisper_transcriber(&self) -> Arc<dyn VoiceTranscriber> {
+        Arc::clone(&self.transcriber)
+    }
+
+    pub(super) fn lfm2_backend(&self) -> Arc<dyn Lfm2Backend> {
+        Arc::clone(&self.lfm2)
+    }
+
     pub fn new(model_root: PathBuf) -> Self {
         Self::with_runtime(
             model_root,

--- a/src-tauri/src/voice/registry.rs
+++ b/src-tauri/src/voice/registry.rs
@@ -16,6 +16,13 @@ pub struct VoiceProviderRegistry {
 }
 
 impl VoiceProviderRegistry {
+    /// Whether a batch dictation capture currently owns the microphone. The
+    /// conversation engine checks this before opening its streaming mic (and
+    /// vice versa) so the two capture paths never contend for the device.
+    pub(crate) fn recording_active(&self) -> bool {
+        self.active_recording.lock().is_some()
+    }
+
     pub fn new(model_root: PathBuf) -> Self {
         Self::with_runtime(
             model_root,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -800,6 +800,7 @@ export default function App() {
     syncNativeWindowsToState,
     routeShellWrite,
     startTaskInProject,
+    sendChat,
     markStartupChromeReady: () => setStartupChromeReady(true),
   });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -99,6 +99,27 @@ export interface AethonConfig {
     /** In conversation voice mode, auto-reopen the mic after the agent
      *  finishes speaking (hands-free) instead of waiting for a tap. */
     conversationContinuous: boolean;
+    /** Which pipeline the hands-free conversation uses. `"auto"` picks the
+     *  cascade (streaming STT → voice brain → streaming TTS) when its API
+     *  keys resolve, else the local LFM2 loop. */
+    conversationEngine: "auto" | "cascade" | "lfm2";
+    /** pi model id (`provider/model`) for the voice-brain session; null
+     *  inherits the default model. */
+    brainModel: string | null;
+    /** Cascade streaming STT / TTS providers (currently fixed). */
+    sttProvider: string;
+    ttsProvider: string;
+    /** Cartesia voice id; null uses the provider default voice. */
+    ttsVoice: string | null;
+    /** Whether API keys are stored in config.toml (write-only from the UI —
+     *  raw values never cross IPC; env vars also satisfy the cascade). */
+    deepgramApiKeySet: boolean;
+    cartesiaApiKeySet: boolean;
+    /** Write-only: present in a Settings save patch only while the user is
+     *  setting ("<key>") or clearing ("") a stored key. Never populated on
+     *  read — the Rust side leaves stored keys untouched when absent. */
+    deepgramApiKey?: string;
+    cartesiaApiKey?: string;
   };
   updates: {
     /** Release channel the auto-updater follows. `"stable"` (default)
@@ -190,6 +211,13 @@ const DEFAULTS: AethonConfig = {
     // Auto-listen (hands-free auto-reopen of the mic after the agent speaks)
     // is opt-in: with push-to-talk the user drives each turn explicitly.
     conversationContinuous: false,
+    conversationEngine: "auto",
+    brainModel: null,
+    sttProvider: "deepgram-flux",
+    ttsProvider: "cartesia",
+    ttsVoice: null,
+    deepgramApiKeySet: false,
+    cartesiaApiKeySet: false,
   },
   updates: { channel: "stable", disableAutoCheck: false },
   devshell: {
@@ -325,6 +353,33 @@ export function getConfig(): Promise<AethonConfig> {
           // Opt-in: only an explicit `true` enables auto-listen; absent or
           // false → off (matches the Rust default).
           conversationContinuous: obj?.voice?.conversationContinuous === true,
+          conversationEngine:
+            obj?.voice?.conversationEngine === "cascade"
+              ? "cascade"
+              : obj?.voice?.conversationEngine === "lfm2"
+                ? "lfm2"
+                : "auto",
+          brainModel:
+            typeof obj?.voice?.brainModel === "string" &&
+            obj.voice.brainModel.trim()
+              ? obj.voice.brainModel.trim()
+              : null,
+          sttProvider:
+            typeof obj?.voice?.sttProvider === "string" &&
+            obj.voice.sttProvider
+              ? obj.voice.sttProvider
+              : DEFAULTS.voice.sttProvider,
+          ttsProvider:
+            typeof obj?.voice?.ttsProvider === "string" &&
+            obj.voice.ttsProvider
+              ? obj.voice.ttsProvider
+              : DEFAULTS.voice.ttsProvider,
+          ttsVoice:
+            typeof obj?.voice?.ttsVoice === "string" && obj.voice.ttsVoice.trim()
+              ? obj.voice.ttsVoice.trim()
+              : null,
+          deepgramApiKeySet: obj?.voice?.deepgramApiKeySet === true,
+          cartesiaApiKeySet: obj?.voice?.cartesiaApiKeySet === true,
         },
         updates: {
           channel: obj?.updates?.channel === "nightly" ? "nightly" : "stable",

--- a/src/config.ts
+++ b/src/config.ts
@@ -106,7 +106,8 @@ export interface AethonConfig {
     /** pi model id (`provider/model`) for the voice-brain session; null
      *  inherits the default model. */
     brainModel: string | null;
-    /** Cascade streaming STT / TTS providers (currently fixed). */
+    /** Cascade STT/TTS providers: "auto" (cloud when its key resolves, else
+     *  the ready local model), or an explicit provider id. */
     sttProvider: string;
     ttsProvider: string;
     /** Cartesia voice id; null uses the provider default voice. */
@@ -213,8 +214,8 @@ const DEFAULTS: AethonConfig = {
     conversationContinuous: false,
     conversationEngine: "auto",
     brainModel: null,
-    sttProvider: "deepgram-flux",
-    ttsProvider: "cartesia",
+    sttProvider: "auto",
+    ttsProvider: "auto",
     ttsVoice: null,
     deepgramApiKeySet: false,
     cartesiaApiKeySet: false,

--- a/src/configWrites.test.ts
+++ b/src/configWrites.test.ts
@@ -48,6 +48,13 @@ const liveConfig: AethonConfig = {
     speakAgentReplies: false,
     speakMaxChars: 600,
     conversationContinuous: false,
+    conversationEngine: "auto" as const,
+    brainModel: null,
+    sttProvider: "deepgram-flux",
+    ttsProvider: "cartesia",
+    ttsVoice: null,
+    deepgramApiKeySet: false,
+    cartesiaApiKeySet: false,
   },
   updates: { channel: "nightly", disableAutoCheck: false },
   devshell: {

--- a/src/extensions/default-layout/chat-input.tsx
+++ b/src/extensions/default-layout/chat-input.tsx
@@ -1,5 +1,6 @@
 import {
   createElement,
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -28,6 +29,8 @@ import { useAtMentionTextarea } from "./use-at-mention-textarea";
 import { useComposerResize } from "./use-composer-resize";
 import { useDraftCommit } from "./use-draft-commit";
 import { useVoiceConversation } from "../../hooks/useVoiceConversation";
+import { useConversationEngineChoice } from "../../hooks/useCascadeConversation";
+import { activeWorkspaceCwd } from "../../utils/activeWorkspaceRoot";
 import { ConversationHud } from "./conversation-hud";
 import {
   VoiceConversationButton,
@@ -138,14 +141,44 @@ export function ChatInput({
         holdHotkey?: string | null;
         speakMaxChars?: number;
         conversationContinuous?: boolean;
+        conversationEngine?: string;
+        brainModel?: string | null;
       }
     | undefined) ?? { toggleHotkey: "mod+shift+m", holdHotkey: null };
+  const conversationEngine = useConversationEngineChoice(
+    voiceConfig.conversationEngine,
+  );
+  // Latest state for event-time context resolution (mirrors optionsRef in
+  // the conversation hooks — refs must not be written during render).
+  const stateRef = useRef(state);
+  useEffect(() => {
+    stateRef.current = state;
+  });
   const conversation = useVoiceConversation({
     submitText: (text) => onEvent("submit", { value: text, mode: "normal" }),
     getActiveTabId: () => state.activeTabId as string | undefined,
     continuous: voiceConfig.conversationContinuous ?? false,
     maxSpokenChars: voiceConfig.speakMaxChars ?? 600,
     onNeedsSetup: (providerId) => onEvent("voice:setup", { providerId }),
+    engine: conversationEngine,
+    getConvoContext: () => {
+      const current = stateRef.current;
+      const voice = current.voice as { brainModel?: string | null } | undefined;
+      const activeTabId =
+        typeof current.activeTabId === "string" ? current.activeTabId : undefined;
+      const model =
+        (typeof current.model === "string" && current.model) ||
+        (typeof current.piDefaultModel === "string" && current.piDefaultModel) ||
+        undefined;
+      return {
+        ...(activeTabId ? { activeTabId } : {}),
+        ...(activeWorkspaceCwd(current)
+          ? { projectPath: activeWorkspaceCwd(current) ?? undefined }
+          : {}),
+        ...(model ? { defaultModel: model } : {}),
+        ...(voice?.brainModel ? { brainModel: voice.brainModel } : {}),
+      };
+    },
   });
   const settings = state.settings as { open?: boolean } | undefined;
   const palette = state.commandPalette as { open?: boolean } | undefined;
@@ -349,6 +382,7 @@ export function ChatInput({
         <ConversationHud
           phase={conversation.phase}
           error={conversation.error}
+          interim={conversation.interimText}
           autoListen={voiceConfig.conversationContinuous ?? false}
           onPrimary={conversation.primaryAction}
           onToggleAutoListen={() =>

--- a/src/extensions/default-layout/chat-input.tsx
+++ b/src/extensions/default-layout/chat-input.tsx
@@ -161,6 +161,7 @@ export function ChatInput({
     maxSpokenChars: voiceConfig.speakMaxChars ?? 600,
     onNeedsSetup: (providerId) => onEvent("voice:setup", { providerId }),
     engine: conversationEngine,
+    allowFallback: (voiceConfig.conversationEngine ?? "auto") === "auto",
     getConvoContext: () => {
       const current = stateRef.current;
       const voice = current.voice as { brainModel?: string | null } | undefined;
@@ -383,6 +384,7 @@ export function ChatInput({
           phase={conversation.phase}
           error={conversation.error}
           interim={conversation.interimText}
+          latencyMs={conversation.latencyMs}
           autoListen={voiceConfig.conversationContinuous ?? false}
           onPrimary={conversation.primaryAction}
           onToggleAutoListen={() =>

--- a/src/extensions/default-layout/chat-input.tsx
+++ b/src/extensions/default-layout/chat-input.tsx
@@ -21,7 +21,7 @@ import {
   resolveString,
 } from "../../utils/dataBinding";
 import { useExtensionRegistry } from "../ExtensionRegistry";
-import type { QueuedMessage } from "../../types/tab";
+import type { QueuedMessage, Tab } from "../../types/tab";
 import { SlashPicker } from "./slash-picker";
 import { AtPicker } from "./at-picker";
 import { atMentionRoot } from "./at-mention";
@@ -179,6 +179,31 @@ export function ChatInput({
           : {}),
         ...(model ? { defaultModel: model } : {}),
         ...(voice?.brainModel ? { brainModel: voice.brainModel } : {}),
+      };
+    },
+    getTaskActivity: (tabId) => {
+      // A dispatched tab may sit in the visible strip or a backgrounded
+      // workspace bucket — check both.
+      const current = stateRef.current;
+      const buckets = current.persistedTabBuckets as
+        | Record<string, { tabs?: Tab[] }>
+        | undefined;
+      const tab =
+        ((current.tabs as Tab[] | undefined) ?? []).find(
+          (t) => t.id === tabId,
+        ) ??
+        Object.values(buckets ?? {})
+          .flatMap((bucket) => bucket.tabs ?? [])
+          .find((t) => t.id === tabId);
+      if (!tab) return null;
+      const lastAgentText =
+        [...(tab.messages ?? [])]
+          .reverse()
+          .find((m) => m.role === "agent" && (m.text ?? "").trim().length > 0)
+          ?.text ?? "";
+      return {
+        running: tab.waiting === true || (tab.queueCount ?? 0) > 0,
+        recentText: lastAgentText,
       };
     },
   });

--- a/src/extensions/default-layout/chat-input.tsx
+++ b/src/extensions/default-layout/chat-input.tsx
@@ -172,6 +172,18 @@ export function ChatInput({
         (typeof current.model === "string" && current.model) ||
         (typeof current.piDefaultModel === "string" && current.piDefaultModel) ||
         undefined;
+      // The project list (label + path) lets the brain dispatch to a project
+      // the user NAMES even when none is active in the sidebar.
+      const knownProjects = (
+        (current.projects as { label?: unknown; path?: unknown }[] | undefined) ??
+        []
+      )
+        .flatMap((p) =>
+          typeof p.label === "string" && typeof p.path === "string" && p.path
+            ? [{ label: p.label, path: p.path }]
+            : [],
+        )
+        .slice(0, 12);
       return {
         ...(activeTabId ? { activeTabId } : {}),
         ...(activeWorkspaceCwd(current)
@@ -179,6 +191,7 @@ export function ChatInput({
           : {}),
         ...(model ? { defaultModel: model } : {}),
         ...(voice?.brainModel ? { brainModel: voice.brainModel } : {}),
+        ...(knownProjects.length > 0 ? { knownProjects } : {}),
       };
     },
     getTaskActivity: (tabId) => {

--- a/src/extensions/default-layout/chat-input.tsx
+++ b/src/extensions/default-layout/chat-input.tsx
@@ -29,7 +29,6 @@ import { useAtMentionTextarea } from "./use-at-mention-textarea";
 import { useComposerResize } from "./use-composer-resize";
 import { useDraftCommit } from "./use-draft-commit";
 import { useVoiceConversation } from "../../hooks/useVoiceConversation";
-import { useConversationEngineChoice } from "../../hooks/useCascadeConversation";
 import { activeWorkspaceCwd } from "../../utils/activeWorkspaceRoot";
 import { ConversationHud } from "./conversation-hud";
 import {
@@ -145,9 +144,6 @@ export function ChatInput({
         brainModel?: string | null;
       }
     | undefined) ?? { toggleHotkey: "mod+shift+m", holdHotkey: null };
-  const conversationEngine = useConversationEngineChoice(
-    voiceConfig.conversationEngine,
-  );
   // Latest state for event-time context resolution (mirrors optionsRef in
   // the conversation hooks — refs must not be written during render).
   const stateRef = useRef(state);
@@ -160,7 +156,12 @@ export function ChatInput({
     continuous: voiceConfig.conversationContinuous ?? false,
     maxSpokenChars: voiceConfig.speakMaxChars ?? 600,
     onNeedsSetup: (providerId) => onEvent("voice:setup", { providerId }),
-    engine: conversationEngine,
+    engine:
+      voiceConfig.conversationEngine === "cascade"
+        ? "cascade"
+        : voiceConfig.conversationEngine === "lfm2"
+          ? "lfm2"
+          : "auto",
     allowFallback: (voiceConfig.conversationEngine ?? "auto") === "auto",
     getConvoContext: () => {
       const current = stateRef.current;

--- a/src/extensions/default-layout/conversation-hud.tsx
+++ b/src/extensions/default-layout/conversation-hud.tsx
@@ -19,6 +19,8 @@ const PRIMARY_LABEL: Record<ConversationPhase, string> = {
 export interface ConversationHudProps {
   phase: ConversationPhase;
   error: string | null;
+  /** Live partial transcript while listening (cascade engine only). */
+  interim?: string | null;
   /** Hands-free auto-reopen of the mic after the agent speaks. */
   autoListen: boolean;
   onPrimary: () => void;
@@ -26,17 +28,21 @@ export interface ConversationHudProps {
   onExit: () => void;
 }
 
-/** Compact in-composer panel for the LFM2-Audio conversation voice mode:
- *  shows the current phase plus a context-aware primary action, an
- *  auto-listen toggle, and an exit. */
+/** Compact in-composer panel for the conversation voice mode: shows the
+ *  current phase (or the live partial transcript while listening) plus a
+ *  context-aware primary action, an auto-listen toggle, and an exit. */
 export function ConversationHud({
   phase,
   error,
+  interim,
   autoListen,
   onPrimary,
   onToggleAutoListen,
   onExit,
 }: ConversationHudProps) {
+  const status =
+    error ??
+    (phase === "listening" && interim ? `“${interim}”` : STATUS_LABEL[phase]);
   return (
     <div
       className="a2ui-conversation-hud"
@@ -48,7 +54,7 @@ export function ConversationHud({
         aria-hidden="true"
       />
       <span className="a2ui-conversation-hud-status" aria-live="polite">
-        {error ?? STATUS_LABEL[phase]}
+        {status}
       </span>
       <button
         type="button"

--- a/src/extensions/default-layout/conversation-hud.tsx
+++ b/src/extensions/default-layout/conversation-hud.tsx
@@ -21,6 +21,8 @@ export interface ConversationHudProps {
   error: string | null;
   /** Live partial transcript while listening (cascade engine only). */
   interim?: string | null;
+  /** Last time-to-first-audio measurement in ms (cascade, debug builds). */
+  latencyMs?: number | null;
   /** Hands-free auto-reopen of the mic after the agent speaks. */
   autoListen: boolean;
   onPrimary: () => void;
@@ -35,6 +37,7 @@ export function ConversationHud({
   phase,
   error,
   interim,
+  latencyMs,
   autoListen,
   onPrimary,
   onToggleAutoListen,
@@ -56,6 +59,14 @@ export function ConversationHud({
       <span className="a2ui-conversation-hud-status" aria-live="polite">
         {status}
       </span>
+      {typeof latencyMs === "number" && (
+        <span
+          className="a2ui-conversation-hud-latency"
+          title="Time from reply start to first audio"
+        >
+          {(latencyMs / 1000).toFixed(1)}s
+        </span>
+      )}
       <button
         type="button"
         className={`a2ui-conversation-hud-auto${

--- a/src/extensions/default-layout/settings-panel/hooks.ts
+++ b/src/extensions/default-layout/settings-panel/hooks.ts
@@ -53,6 +53,70 @@ export function useEffectiveConfig(
 }
 
 /**
+ * Track which section currently owns the top of the settings scroll
+ * viewport, for the nav rail's active highlight. IntersectionObserver
+ * with a top-biased band (the section crossing the upper quarter wins)
+ * so the highlight flips as a section's title reaches the reading line,
+ * not when its last row leaves the screen.
+ */
+export function useActiveSection(
+  open: boolean,
+  ready: boolean,
+  initial: string,
+): [string, (id: string) => void] {
+  const [active, setActive] = useState(initial);
+  useEffect(() => {
+    if (!open || !ready) return;
+    // jsdom (tests) has no IntersectionObserver; the rail then only
+    // highlights on click, which is fine.
+    if (typeof IntersectionObserver === "undefined") return;
+    const sections = [
+      ...document.querySelectorAll<HTMLElement>("[data-settings-section]"),
+    ];
+    if (sections.length === 0) return;
+    const root = document.querySelector<HTMLElement>(".ae-settings-body");
+    const lastId = sections[sections.length - 1]?.dataset.settingsSection;
+    const visible = new Map<string, number>();
+    const pickActive = () => {
+      // The last sections can never reach the top band; scrolled to the
+      // end, the final section is the honest highlight. Checked here (not
+      // in a separate scroll handler) so a late observer callback can't
+      // overwrite it.
+      if (root && lastId && root.scrollTop + root.clientHeight >= root.scrollHeight - 4) {
+        setActive(lastId);
+        return;
+      }
+      if (visible.size === 0) return;
+      // Topmost visible section wins.
+      const top = [...visible.entries()].sort((a, b) => a[1] - b[1])[0];
+      if (top) setActive(top[0]);
+    };
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          const id = (entry.target as HTMLElement).dataset.settingsSection;
+          if (!id) continue;
+          if (entry.isIntersecting) visible.set(id, entry.boundingClientRect.top);
+          else visible.delete(id);
+        }
+        pickActive();
+      },
+      {
+        root,
+        rootMargin: "0px 0px -60% 0px",
+      },
+    );
+    sections.forEach((section) => observer.observe(section));
+    root?.addEventListener("scroll", pickActive, { passive: true });
+    return () => {
+      observer.disconnect();
+      root?.removeEventListener("scroll", pickActive);
+    };
+  }, [open, ready]);
+  return [active, setActive];
+}
+
+/**
  * Smooth-scroll the named section into view when the panel opens with
  * a focus target. Uses `requestAnimationFrame` so the section element
  * has been laid out before we measure it, and cancels on unmount /

--- a/src/extensions/default-layout/settings-panel/panel.test.tsx
+++ b/src/extensions/default-layout/settings-panel/panel.test.tsx
@@ -245,4 +245,26 @@ describe("SettingsPanel", () => {
       args: { root: "/repo" },
     });
   });
+
+  it("offers the header picker's models in the voice brain select", async () => {
+    renderSettings({
+      sidebar: {
+        models: [
+          { id: "anthropic/claude-haiku-4-5", label: "Claude Haiku 4.5" },
+          { id: "ollama/qwen3", label: "Qwen 3 (local)" },
+        ],
+      },
+    });
+
+    const select: HTMLSelectElement = await screen.findByLabelText(
+      "Voice brain model",
+    );
+    const labels = Array.from(select.options).map((o) => o.textContent);
+    expect(labels).toEqual([
+      "Default model (same as chat)",
+      "Claude Haiku 4.5",
+      "Qwen 3 (local)",
+    ]);
+    expect(select.value).toBe("");
+  });
 });

--- a/src/extensions/default-layout/settings-panel/panel.tsx
+++ b/src/extensions/default-layout/settings-panel/panel.tsx
@@ -57,6 +57,21 @@ const SETTINGS_NAV: { id: string; label: string }[] = [
   { id: "advanced", label: "Advanced" },
 ];
 
+/** The header model picker's entries (`/sidebar/models`), reused so the
+ *  voice-brain select offers the same registry as the rest of the app. */
+function readSidebarModels(
+  state: Record<string, unknown>,
+): { id: string; label: string }[] {
+  const sidebar = state.sidebar as
+    | { models?: { id?: unknown; label?: unknown }[] }
+    | undefined;
+  return (sidebar?.models ?? []).flatMap((m) =>
+    typeof m.id === "string" && m.id
+      ? [{ id: m.id, label: typeof m.label === "string" ? m.label : m.id }]
+      : [],
+  );
+}
+
 export function SettingsPanel({ state, onEvent }: BuiltinComponentProps) {
   const settings = readSettingsState(state);
   const configSnapshot = useConfigSnapshot(settings.open);
@@ -152,7 +167,11 @@ export function SettingsPanel({ state, onEvent }: BuiltinComponentProps) {
               />
               <ShellSection config={eff} update={update} />
               <BehaviorSection config={eff} update={update} />
-              <VoiceSection config={eff} update={update} />
+              <VoiceSection
+                config={eff}
+                update={update}
+                models={readSidebarModels(state)}
+              />
               <UpdaterSection config={eff} update={update} />
               <RemoteDevicesSection open={settings.open} />
               <DevshellSection config={eff} state={state} update={update} />

--- a/src/extensions/default-layout/settings-panel/panel.tsx
+++ b/src/extensions/default-layout/settings-panel/panel.tsx
@@ -10,6 +10,10 @@
 // The panel reads the current config state via `getConfig()` on mount
 // so the form reflects what's actually on disk, not stale in-memory
 // tab state.
+//
+// Layout: a fixed nav rail (one entry per section, scrollspy-highlighted)
+// beside one scrolling content pane. Clicking a rail entry scrolls its
+// section to the top; the rail collapses on narrow windows.
 
 import type { BuiltinComponentProps } from "../../../components/A2UIRenderer";
 import type { AethonConfig } from "../../../config";
@@ -21,6 +25,7 @@ import { DevshellSection } from "./devshell-section";
 import { ExtensionsList } from "./extensions-list";
 import { GuardrailsSection } from "./guardrails-section";
 import {
+  useActiveSection,
   useConfigSnapshot,
   useEffectiveConfig,
   useScrollToSection,
@@ -34,11 +39,34 @@ import { UpdaterSection } from "./updater-section";
 import { ViewSection } from "./view-section";
 import { VoiceSection } from "./voice-section";
 
+/** Nav rail entries, in render order. Ids match each section's
+ *  `data-settings-section` anchor. */
+const SETTINGS_NAV: { id: string; label: string }[] = [
+  { id: "appearance", label: "Appearance" },
+  { id: "view", label: "View" },
+  { id: "guardrails", label: "Guardrails" },
+  { id: "notifications", label: "Notifications" },
+  { id: "agent", label: "Agent" },
+  { id: "shell", label: "Shell" },
+  { id: "behavior", label: "Behavior" },
+  { id: "voice", label: "Voice" },
+  { id: "updater", label: "Updater" },
+  { id: "remote", label: "Remote devices" },
+  { id: "devshell", label: "Nix devshell" },
+  { id: "extensions", label: "Extensions" },
+  { id: "advanced", label: "Advanced" },
+];
+
 export function SettingsPanel({ state, onEvent }: BuiltinComponentProps) {
   const settings = readSettingsState(state);
   const configSnapshot = useConfigSnapshot(settings.open);
   const eff = useEffectiveConfig(configSnapshot, settings.pending);
   useScrollToSection(settings.open, eff, settings.focusSection);
+  const [activeSection, setActiveSection] = useActiveSection(
+    settings.open,
+    eff !== null,
+    settings.focusSection ?? "appearance",
+  );
 
   if (!settings.open) return null;
 
@@ -48,6 +76,19 @@ export function SettingsPanel({ state, onEvent }: BuiltinComponentProps) {
   const close = () => onEvent("close");
   const openSystemPromptFile = () => {
     onEvent("open-system-prompt");
+  };
+  const jumpToSection = (id: string) => {
+    setActiveSection(id);
+    const target = [
+      ...document.querySelectorAll<HTMLElement>("[data-settings-section]"),
+    ].find((el) => el.dataset.settingsSection === id);
+    const reduced = window.matchMedia(
+      "(prefers-reduced-motion: reduce)",
+    ).matches;
+    target?.scrollIntoView({
+      block: "start",
+      behavior: reduced ? "auto" : "smooth",
+    });
   };
 
   return (
@@ -79,26 +120,47 @@ export function SettingsPanel({ state, onEvent }: BuiltinComponentProps) {
         {!eff ? (
           <div className="ae-settings-body">Loading…</div>
         ) : (
-          <div className="ae-settings-body">
-            <AppearanceSection config={eff} update={update} />
-            <ViewSection config={eff} update={update} />
-            <GuardrailsSection config={eff} update={update} />
-            <NotificationsSection config={eff} update={update} />
-            <AgentSection
-              config={eff}
-              onOpenSystemPromptFile={openSystemPromptFile}
-              update={update}
-            />
-            <ShellSection config={eff} update={update} />
-            <BehaviorSection config={eff} update={update} />
-            <VoiceSection config={eff} update={update} />
-            <UpdaterSection config={eff} update={update} />
-            <RemoteDevicesSection open={settings.open} />
-            <DevshellSection config={eff} state={state} update={update} />
-            <Section id="extensions" title="Extensions">
-              <ExtensionsList state={state} onEvent={onEvent} />
-            </Section>
-            <AdvancedSection onEvent={onEvent} />
+          <div className="ae-settings-layout">
+            <nav className="ae-settings-nav" aria-label="Settings sections">
+              {SETTINGS_NAV.map((entry) => (
+                <button
+                  key={entry.id}
+                  type="button"
+                  className={`ae-settings-nav-item${
+                    activeSection === entry.id
+                      ? " ae-settings-nav-item--active"
+                      : ""
+                  }`}
+                  aria-current={
+                    activeSection === entry.id ? "true" : undefined
+                  }
+                  onClick={() => jumpToSection(entry.id)}
+                >
+                  {entry.label}
+                </button>
+              ))}
+            </nav>
+            <div className="ae-settings-body">
+              <AppearanceSection config={eff} update={update} />
+              <ViewSection config={eff} update={update} />
+              <GuardrailsSection config={eff} update={update} />
+              <NotificationsSection config={eff} update={update} />
+              <AgentSection
+                config={eff}
+                onOpenSystemPromptFile={openSystemPromptFile}
+                update={update}
+              />
+              <ShellSection config={eff} update={update} />
+              <BehaviorSection config={eff} update={update} />
+              <VoiceSection config={eff} update={update} />
+              <UpdaterSection config={eff} update={update} />
+              <RemoteDevicesSection open={settings.open} />
+              <DevshellSection config={eff} state={state} update={update} />
+              <Section id="extensions" title="Extensions">
+                <ExtensionsList state={state} onEvent={onEvent} />
+              </Section>
+              <AdvancedSection onEvent={onEvent} />
+            </div>
           </div>
         )}
       </div>

--- a/src/extensions/default-layout/settings-panel/voice-section.tsx
+++ b/src/extensions/default-layout/settings-panel/voice-section.tsx
@@ -1,9 +1,11 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type { AethonConfig } from "../../../config";
 import {
   listConvoVoices,
   testConvoProviders,
+  voiceConvoStatus,
   type CartesiaVoice,
+  type VoiceConvoStatus,
 } from "../../../services/voiceConvo";
 import { formatVoiceDownloadProgress } from "../../../utils/voice";
 import { Field, Section, type SettingsUpdate } from "./sections";
@@ -115,6 +117,25 @@ function ConversationSettings({
   const [testing, setTesting] = useState(false);
   const [voices, setVoices] = useState<CartesiaVoice[] | null>(null);
   const [voicesError, setVoicesError] = useState<string | null>(null);
+  const [engineStatus, setEngineStatus] = useState<VoiceConvoStatus | null>(
+    null,
+  );
+
+  // Live readiness readout, re-probed whenever a voice setting changes (the
+  // probe is a local file/model check — no network).
+  useEffect(() => {
+    let cancelled = false;
+    voiceConvoStatus()
+      .then((status) => {
+        if (!cancelled) setEngineStatus(status);
+      })
+      .catch(() => {
+        if (!cancelled) setEngineStatus(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [config.voice]);
 
   const runProviderTest = async () => {
     setTesting(true);
@@ -130,6 +151,7 @@ function ConversationSettings({
           : `Cartesia: ${result.cartesiaError ?? "failed"}`,
       ];
       setTestResult(parts.join(" · "));
+      setEngineStatus(await voiceConvoStatus().catch(() => null));
     } catch (err) {
       setTestResult(err instanceof Error ? err.message : String(err));
     } finally {
@@ -146,9 +168,25 @@ function ConversationSettings({
     }
   };
 
+  const statusLine =
+    engineStatus === null
+      ? "Checking availability…"
+      : engineStatus.available
+        ? `Ready — speech-to-text: ${engineStatus.sttProvider}, text-to-speech: ${engineStatus.ttsProvider}.`
+        : `Not ready — ${[engineStatus.sttError, engineStatus.ttsError]
+            .filter(Boolean)
+            .join("; ")}.`;
+
   return (
     <div className="ae-voice-conversation-settings">
       <h4 className="ae-settings-subhead">Conversation</h4>
+      <p
+        className={`ae-settings-note${
+          engineStatus && !engineStatus.available ? " ae-voice-error" : ""
+        }`}
+      >
+        {statusLine}
+      </p>
       <Field label="Conversation engine">
         <select
           className="ae-settings-input"
@@ -183,11 +221,14 @@ function ConversationSettings({
                 sttProvider:
                   e.target.value === "local-whisper"
                     ? "local-whisper"
-                    : "deepgram-flux",
+                    : e.target.value === "deepgram-flux"
+                      ? "deepgram-flux"
+                      : "auto",
               },
             })
           }
         >
+          <option value="auto">Auto (cloud when a key is set)</option>
           <option value="deepgram-flux">
             Deepgram Flux (cloud, semantic turn detection)
           </option>
@@ -202,11 +243,17 @@ function ConversationSettings({
             update({
               voice: {
                 ...config.voice,
-                ttsProvider: e.target.value === "lfm2" ? "lfm2" : "cartesia",
+                ttsProvider:
+                  e.target.value === "lfm2"
+                    ? "lfm2"
+                    : e.target.value === "cartesia"
+                      ? "cartesia"
+                      : "auto",
               },
             })
           }
         >
+          <option value="auto">Auto (cloud when a key is set)</option>
           <option value="cartesia">Cartesia (cloud, streaming)</option>
           <option value="lfm2">LFM2-Audio (offline)</option>
         </select>

--- a/src/extensions/default-layout/settings-panel/voice-section.tsx
+++ b/src/extensions/default-layout/settings-panel/voice-section.tsx
@@ -20,7 +20,16 @@ export function VoiceSection({
 }) {
   return (
     <Section id="voice" title="Voice">
-      <Field label="Toggle hotkey">
+      <p className="ae-settings-note">
+        Two voice features share this section: <strong>Dictation</strong>{" "}
+        (the composer mic button and hold-to-talk key type what you say) and{" "}
+        <strong>Conversation</strong> (hands-free voice chat that answers out
+        loud and can dispatch work — enter it with the composer's conversation
+        button).
+      </p>
+
+      <h4 className="ae-settings-subhead">Dictation</h4>
+      <Field label="Toggle hotkey (start/stop dictation)">
         <input
           type="text"
           className="ae-settings-input"
@@ -36,7 +45,7 @@ export function VoiceSection({
           }
         />
       </Field>
-      <Field label="Hold-to-talk key">
+      <Field label="Hold-to-talk key (hold to record, release to send)">
         <input
           type="text"
           className="ae-settings-input"
@@ -52,7 +61,15 @@ export function VoiceSection({
           }
         />
       </Field>
-      <Field label="Speak agent replies aloud (LFM2-Audio)">
+      <p className="ae-settings-note">
+        Dictation transcribes with the provider marked “Use” below.
+      </p>
+      <VoiceProviders />
+
+      <ConversationSettings config={config} update={update} />
+
+      <h4 className="ae-settings-subhead">Spoken replies</h4>
+      <Field label="Speak agent replies aloud (outside conversation mode)">
         <input
           type="checkbox"
           checked={config.voice.speakAgentReplies}
@@ -66,7 +83,7 @@ export function VoiceSection({
           }
         />
       </Field>
-      <Field label="Spoken reply length (characters)">
+      <Field label="Spoken reply length cap (characters)">
         <input
           type="number"
           className="ae-settings-input"
@@ -83,22 +100,6 @@ export function VoiceSection({
           }
         />
       </Field>
-      <Field label="Hands-free conversation (auto-reopen mic)">
-        <input
-          type="checkbox"
-          checked={config.voice.conversationContinuous}
-          onChange={(e) =>
-            update({
-              voice: {
-                ...config.voice,
-                conversationContinuous: e.target.checked,
-              },
-            })
-          }
-        />
-      </Field>
-      <ConversationSettings config={config} update={update} />
-      <VoiceProviders />
     </Section>
   );
 }
@@ -180,6 +181,12 @@ function ConversationSettings({
   return (
     <div className="ae-voice-conversation-settings">
       <h4 className="ae-settings-subhead">Conversation</h4>
+      <p className="ae-settings-note">
+        Speech-to-text hears you, the voice brain replies and dispatches
+        work, text-to-speech reads the answer back. Each stage picks its
+        provider below; “Auto” prefers the cloud provider when its API key is
+        set and falls back to the local model.
+      </p>
       <p
         className={`ae-settings-note${
           engineStatus && !engineStatus.available ? " ae-voice-error" : ""
@@ -187,6 +194,20 @@ function ConversationSettings({
       >
         {statusLine}
       </p>
+      <Field label="Auto-listen after replies (hands-free)">
+        <input
+          type="checkbox"
+          checked={config.voice.conversationContinuous}
+          onChange={(e) =>
+            update({
+              voice: {
+                ...config.voice,
+                conversationContinuous: e.target.checked,
+              },
+            })
+          }
+        />
+      </Field>
       <Field label="Conversation engine">
         <select
           className="ae-settings-input"

--- a/src/extensions/default-layout/settings-panel/voice-section.tsx
+++ b/src/extensions/default-layout/settings-panel/voice-section.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import type { AethonConfig } from "../../../config";
 import { formatVoiceDownloadProgress } from "../../../utils/voice";
 import { Field, Section, type SettingsUpdate } from "./sections";
@@ -89,8 +90,149 @@ export function VoiceSection({
           }
         />
       </Field>
+      <ConversationSettings config={config} update={update} />
       <VoiceProviders />
     </Section>
+  );
+}
+
+/** The cascade conversation pipeline: engine choice, voice-brain model, TTS
+ *  voice, and the two provider API keys (write-only — the UI only ever sees
+ *  presence booleans; env vars take precedence over stored keys). */
+function ConversationSettings({
+  config,
+  update,
+}: {
+  config: AethonConfig;
+  update: SettingsUpdate;
+}) {
+  return (
+    <div className="ae-voice-conversation-settings">
+      <h4 className="ae-settings-subhead">Conversation</h4>
+      <Field label="Conversation engine">
+        <select
+          className="ae-settings-input"
+          value={config.voice.conversationEngine}
+          onChange={(e) =>
+            update({
+              voice: {
+                ...config.voice,
+                conversationEngine:
+                  e.target.value === "cascade"
+                    ? "cascade"
+                    : e.target.value === "lfm2"
+                      ? "lfm2"
+                      : "auto",
+              },
+            })
+          }
+        >
+          <option value="auto">Auto (cascade when keys are set)</option>
+          <option value="cascade">Cascade (Deepgram + Cartesia)</option>
+          <option value="lfm2">Local (LFM2-Audio)</option>
+        </select>
+      </Field>
+      <Field label="Voice brain model (empty = default model)">
+        <input
+          type="text"
+          className="ae-settings-input"
+          value={config.voice.brainModel ?? ""}
+          placeholder="anthropic/claude-haiku-4-5"
+          onChange={(e) =>
+            update({
+              voice: {
+                ...config.voice,
+                brainModel: e.target.value.trim() || null,
+              },
+            })
+          }
+        />
+      </Field>
+      <Field label="Cartesia voice id (empty = default voice)">
+        <input
+          type="text"
+          className="ae-settings-input"
+          value={config.voice.ttsVoice ?? ""}
+          onChange={(e) =>
+            update({
+              voice: {
+                ...config.voice,
+                ttsVoice: e.target.value.trim() || null,
+              },
+            })
+          }
+        />
+      </Field>
+      <ApiKeyField
+        label="Deepgram API key"
+        stored={config.voice.deepgramApiKeySet}
+        envVar="DEEPGRAM_API_KEY"
+        onSave={(value) =>
+          update({ voice: { ...config.voice, deepgramApiKey: value } })
+        }
+      />
+      <ApiKeyField
+        label="Cartesia API key"
+        stored={config.voice.cartesiaApiKeySet}
+        envVar="CARTESIA_API_KEY"
+        onSave={(value) =>
+          update({ voice: { ...config.voice, cartesiaApiKey: value } })
+        }
+      />
+    </div>
+  );
+}
+
+/** Masked, write-only key input: the stored value never round-trips to the
+ *  UI. Saving sends the typed key once; clearing sends an explicit "". */
+function ApiKeyField({
+  label,
+  stored,
+  envVar,
+  onSave,
+}: {
+  label: string;
+  stored: boolean;
+  envVar: string;
+  onSave: (value: string) => void;
+}) {
+  const [draft, setDraft] = useState("");
+  return (
+    <Field label={label}>
+      <div className="ae-voice-key-row">
+        <input
+          type="password"
+          className="ae-settings-input"
+          value={draft}
+          placeholder={stored ? "•••••••• (stored)" : `or set ${envVar}`}
+          autoComplete="off"
+          onChange={(e) => setDraft(e.target.value)}
+        />
+        <button
+          type="button"
+          className="ae-settings-secondary"
+          disabled={!draft.trim()}
+          onClick={() => {
+            onSave(draft.trim());
+            setDraft("");
+          }}
+        >
+          Set key
+        </button>
+        {stored ? (
+          <button
+            type="button"
+            className="ae-settings-secondary"
+            onClick={() => {
+              onSave("");
+              setDraft("");
+            }}
+          >
+            Clear
+          </button>
+        ) : null}
+      </div>
+    </Field>
   );
 }
 

--- a/src/extensions/default-layout/settings-panel/voice-section.tsx
+++ b/src/extensions/default-layout/settings-panel/voice-section.tsx
@@ -172,6 +172,45 @@ function ConversationSettings({
           <option value="lfm2">Local (LFM2-Audio)</option>
         </select>
       </Field>
+      <Field label="Speech-to-text (cascade)">
+        <select
+          className="ae-settings-input"
+          value={config.voice.sttProvider}
+          onChange={(e) =>
+            update({
+              voice: {
+                ...config.voice,
+                sttProvider:
+                  e.target.value === "local-whisper"
+                    ? "local-whisper"
+                    : "deepgram-flux",
+              },
+            })
+          }
+        >
+          <option value="deepgram-flux">
+            Deepgram Flux (cloud, semantic turn detection)
+          </option>
+          <option value="local-whisper">Local Whisper (offline)</option>
+        </select>
+      </Field>
+      <Field label="Text-to-speech (cascade)">
+        <select
+          className="ae-settings-input"
+          value={config.voice.ttsProvider}
+          onChange={(e) =>
+            update({
+              voice: {
+                ...config.voice,
+                ttsProvider: e.target.value === "lfm2" ? "lfm2" : "cartesia",
+              },
+            })
+          }
+        >
+          <option value="cartesia">Cartesia (cloud, streaming)</option>
+          <option value="lfm2">LFM2-Audio (offline)</option>
+        </select>
+      </Field>
       <Field label="Voice brain model (empty = default model)">
         <input
           type="text"

--- a/src/extensions/default-layout/settings-panel/voice-section.tsx
+++ b/src/extensions/default-layout/settings-panel/voice-section.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import type { AethonConfig } from "../../../config";
+import { writeConfigPatch } from "../../../configWrites";
 import {
   listConvoVoices,
   testConvoProviders,
@@ -358,23 +359,15 @@ function ConversationSettings({
       </Field>
       <ApiKeyField
         label="Deepgram API key"
-        stored={
-          config.voice.deepgramApiKeySet || !!config.voice.deepgramApiKey
-        }
+        stored={config.voice.deepgramApiKeySet}
         envVar="DEEPGRAM_API_KEY"
-        onSave={(value) =>
-          update({ voice: { ...config.voice, deepgramApiKey: value } })
-        }
+        configField="deepgramApiKey"
       />
       <ApiKeyField
         label="Cartesia API key"
-        stored={
-          config.voice.cartesiaApiKeySet || !!config.voice.cartesiaApiKey
-        }
+        stored={config.voice.cartesiaApiKeySet}
         envVar="CARTESIA_API_KEY"
-        onSave={(value) =>
-          update({ voice: { ...config.voice, cartesiaApiKey: value } })
-        }
+        configField="cartesiaApiKey"
       />
       <Field label="Connection check">
         <div className="ae-voice-key-row">
@@ -396,24 +389,37 @@ function ConversationSettings({
 }
 
 /** Masked, write-only key input: the stored value never round-trips to the
- *  UI. Saving sends the typed key once; clearing sends an explicit "".
- *  `justSet` mirrors the action locally so the field flips to "stored"
+ *  UI. Saving writes the typed key straight to config.toml via a focused
+ *  `write_config` patch — one write-only IPC crossing, bypassing the shared
+ *  settings `pending` state entirely so the secret never sits in the app
+ *  state tree (or anything mirrored from it). Clearing writes an explicit
+ *  "". `justSet` mirrors the action locally so the field flips to "stored"
  *  immediately — the config snapshot's `*ApiKeySet` boolean only refreshes
  *  when the panel reopens. */
 function ApiKeyField({
   label,
   stored,
   envVar,
-  onSave,
+  configField,
 }: {
   label: string;
   stored: boolean;
   envVar: string;
-  onSave: (value: string) => void;
+  configField: "deepgramApiKey" | "cartesiaApiKey";
 }) {
   const [draft, setDraft] = useState("");
   const [justSet, setJustSet] = useState<boolean | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
   const hasKey = justSet ?? stored;
+  const writeKey = (value: string, storedAfter: boolean) => {
+    setSaveError(null);
+    setDraft("");
+    setJustSet(storedAfter);
+    writeConfigPatch({ voice: { [configField]: value } }).catch(() => {
+      setJustSet(null);
+      setSaveError("Saving the key failed — check config.toml permissions.");
+    });
+  };
   return (
     <Field label={label}>
       <div className="ae-voice-key-row">
@@ -429,11 +435,7 @@ function ApiKeyField({
           type="button"
           className="ae-settings-secondary"
           disabled={!draft.trim()}
-          onClick={() => {
-            onSave(draft.trim());
-            setDraft("");
-            setJustSet(true);
-          }}
+          onClick={() => writeKey(draft.trim(), true)}
         >
           {hasKey ? "Replace key" : "Set key"}
         </button>
@@ -441,16 +443,15 @@ function ApiKeyField({
           <button
             type="button"
             className="ae-settings-secondary"
-            onClick={() => {
-              onSave("");
-              setDraft("");
-              setJustSet(false);
-            }}
+            onClick={() => writeKey("", false)}
           >
             Clear
           </button>
         ) : null}
       </div>
+      {saveError ? (
+        <p className="ae-settings-note ae-voice-error">{saveError}</p>
+      ) : null}
     </Field>
   );
 }

--- a/src/extensions/default-layout/settings-panel/voice-section.tsx
+++ b/src/extensions/default-layout/settings-panel/voice-section.tsx
@@ -1,5 +1,10 @@
 import { useState } from "react";
 import type { AethonConfig } from "../../../config";
+import {
+  listConvoVoices,
+  testConvoProviders,
+  type CartesiaVoice,
+} from "../../../services/voiceConvo";
 import { formatVoiceDownloadProgress } from "../../../utils/voice";
 import { Field, Section, type SettingsUpdate } from "./sections";
 import { useVoiceProviders } from "./useVoiceProviders";
@@ -106,6 +111,41 @@ function ConversationSettings({
   config: AethonConfig;
   update: SettingsUpdate;
 }) {
+  const [testResult, setTestResult] = useState<string | null>(null);
+  const [testing, setTesting] = useState(false);
+  const [voices, setVoices] = useState<CartesiaVoice[] | null>(null);
+  const [voicesError, setVoicesError] = useState<string | null>(null);
+
+  const runProviderTest = async () => {
+    setTesting(true);
+    setTestResult(null);
+    try {
+      const result = await testConvoProviders();
+      const parts = [
+        result.deepgramOk
+          ? "Deepgram: ok"
+          : `Deepgram: ${result.deepgramError ?? "failed"}`,
+        result.cartesiaOk
+          ? "Cartesia: ok"
+          : `Cartesia: ${result.cartesiaError ?? "failed"}`,
+      ];
+      setTestResult(parts.join(" · "));
+    } catch (err) {
+      setTestResult(err instanceof Error ? err.message : String(err));
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  const loadVoices = async () => {
+    setVoicesError(null);
+    try {
+      setVoices(await listConvoVoices());
+    } catch (err) {
+      setVoicesError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
   return (
     <div className="ae-voice-conversation-settings">
       <h4 className="ae-settings-subhead">Conversation</h4>
@@ -149,19 +189,43 @@ function ConversationSettings({
         />
       </Field>
       <Field label="Cartesia voice id (empty = default voice)">
-        <input
-          type="text"
-          className="ae-settings-input"
-          value={config.voice.ttsVoice ?? ""}
-          onChange={(e) =>
-            update({
-              voice: {
-                ...config.voice,
-                ttsVoice: e.target.value.trim() || null,
-              },
-            })
-          }
-        />
+        <div className="ae-voice-key-row">
+          <input
+            type="text"
+            className="ae-settings-input"
+            value={config.voice.ttsVoice ?? ""}
+            list="ae-cartesia-voices"
+            onChange={(e) =>
+              update({
+                voice: {
+                  ...config.voice,
+                  ttsVoice: e.target.value.trim() || null,
+                },
+              })
+            }
+          />
+          <button
+            type="button"
+            className="ae-settings-secondary"
+            onClick={() => void loadVoices()}
+          >
+            Load voices
+          </button>
+        </div>
+        <datalist id="ae-cartesia-voices">
+          {(voices ?? []).map((voice) => (
+            <option key={voice.id} value={voice.id}>
+              {voice.name}
+            </option>
+          ))}
+        </datalist>
+        {voicesError ? (
+          <p className="ae-settings-note ae-voice-error">{voicesError}</p>
+        ) : voices ? (
+          <p className="ae-settings-note">
+            {voices.length} voices loaded — the id field now autocompletes.
+          </p>
+        ) : null}
       </Field>
       <ApiKeyField
         label="Deepgram API key"
@@ -179,6 +243,21 @@ function ConversationSettings({
           update({ voice: { ...config.voice, cartesiaApiKey: value } })
         }
       />
+      <Field label="Connection check">
+        <div className="ae-voice-key-row">
+          <button
+            type="button"
+            className="ae-settings-secondary"
+            disabled={testing}
+            onClick={() => void runProviderTest()}
+          >
+            {testing ? "Testing…" : "Test providers"}
+          </button>
+          {testResult ? (
+            <span className="ae-settings-note">{testResult}</span>
+          ) : null}
+        </div>
+      </Field>
     </div>
   );
 }

--- a/src/extensions/default-layout/settings-panel/voice-section.tsx
+++ b/src/extensions/default-layout/settings-panel/voice-section.tsx
@@ -11,12 +11,21 @@ import { formatVoiceDownloadProgress } from "../../../utils/voice";
 import { Field, Section, type SettingsUpdate } from "./sections";
 import { useVoiceProviders } from "./useVoiceProviders";
 
+/** Model entries mirrored from the header picker (`/sidebar/models`), so the
+ *  voice brain offers the same registry the rest of the app selects from. */
+export interface VoiceBrainModelOption {
+  id: string;
+  label: string;
+}
+
 export function VoiceSection({
   config,
   update,
+  models,
 }: {
   config: AethonConfig;
   update: SettingsUpdate;
+  models?: VoiceBrainModelOption[];
 }) {
   return (
     <Section id="voice" title="Voice">
@@ -66,7 +75,7 @@ export function VoiceSection({
       </p>
       <VoiceProviders />
 
-      <ConversationSettings config={config} update={update} />
+      <ConversationSettings config={config} update={update} models={models} />
 
       <h4 className="ae-settings-subhead">Spoken replies</h4>
       <Field label="Speak agent replies aloud (outside conversation mode)">
@@ -110,9 +119,11 @@ export function VoiceSection({
 function ConversationSettings({
   config,
   update,
+  models,
 }: {
   config: AethonConfig;
   update: SettingsUpdate;
+  models?: VoiceBrainModelOption[];
 }) {
   const [testResult, setTestResult] = useState<string | null>(null);
   const [testing, setTesting] = useState(false);
@@ -279,21 +290,32 @@ function ConversationSettings({
           <option value="lfm2">LFM2-Audio (offline)</option>
         </select>
       </Field>
-      <Field label="Voice brain model (empty = default model)">
-        <input
-          type="text"
+      <Field label="Voice brain model">
+        <select
           className="ae-settings-input"
           value={config.voice.brainModel ?? ""}
-          placeholder="anthropic/claude-haiku-4-5"
           onChange={(e) =>
             update({
               voice: {
                 ...config.voice,
-                brainModel: e.target.value.trim() || null,
+                brainModel: e.target.value || null,
               },
             })
           }
-        />
+        >
+          <option value="">Default model (same as chat)</option>
+          {(models ?? []).map((m) => (
+            <option key={m.id} value={m.id}>
+              {m.label}
+            </option>
+          ))}
+          {config.voice.brainModel &&
+            !(models ?? []).some((m) => m.id === config.voice.brainModel) && (
+              <option value={config.voice.brainModel}>
+                {config.voice.brainModel} (not in registry)
+              </option>
+            )}
+        </select>
       </Field>
       <Field label="Cartesia voice id (empty = default voice)">
         <div className="ae-voice-key-row">

--- a/src/extensions/default-layout/settings-panel/voice-section.tsx
+++ b/src/extensions/default-layout/settings-panel/voice-section.tsx
@@ -268,7 +268,9 @@ function ConversationSettings({
       </Field>
       <ApiKeyField
         label="Deepgram API key"
-        stored={config.voice.deepgramApiKeySet}
+        stored={
+          config.voice.deepgramApiKeySet || !!config.voice.deepgramApiKey
+        }
         envVar="DEEPGRAM_API_KEY"
         onSave={(value) =>
           update({ voice: { ...config.voice, deepgramApiKey: value } })
@@ -276,7 +278,9 @@ function ConversationSettings({
       />
       <ApiKeyField
         label="Cartesia API key"
-        stored={config.voice.cartesiaApiKeySet}
+        stored={
+          config.voice.cartesiaApiKeySet || !!config.voice.cartesiaApiKey
+        }
         envVar="CARTESIA_API_KEY"
         onSave={(value) =>
           update({ voice: { ...config.voice, cartesiaApiKey: value } })
@@ -302,7 +306,10 @@ function ConversationSettings({
 }
 
 /** Masked, write-only key input: the stored value never round-trips to the
- *  UI. Saving sends the typed key once; clearing sends an explicit "". */
+ *  UI. Saving sends the typed key once; clearing sends an explicit "".
+ *  `justSet` mirrors the action locally so the field flips to "stored"
+ *  immediately — the config snapshot's `*ApiKeySet` boolean only refreshes
+ *  when the panel reopens. */
 function ApiKeyField({
   label,
   stored,
@@ -315,6 +322,8 @@ function ApiKeyField({
   onSave: (value: string) => void;
 }) {
   const [draft, setDraft] = useState("");
+  const [justSet, setJustSet] = useState<boolean | null>(null);
+  const hasKey = justSet ?? stored;
   return (
     <Field label={label}>
       <div className="ae-voice-key-row">
@@ -322,7 +331,7 @@ function ApiKeyField({
           type="password"
           className="ae-settings-input"
           value={draft}
-          placeholder={stored ? "•••••••• (stored)" : `or set ${envVar}`}
+          placeholder={hasKey ? "•••••••• (key stored)" : `or set ${envVar}`}
           autoComplete="off"
           onChange={(e) => setDraft(e.target.value)}
         />
@@ -333,17 +342,19 @@ function ApiKeyField({
           onClick={() => {
             onSave(draft.trim());
             setDraft("");
+            setJustSet(true);
           }}
         >
-          Set key
+          {hasKey ? "Replace key" : "Set key"}
         </button>
-        {stored ? (
+        {hasKey ? (
           <button
             type="button"
             className="ae-settings-secondary"
             onClick={() => {
               onSave("");
               setDraft("");
+              setJustSet(false);
             }}
           >
             Clear

--- a/src/hooks/bridgeMessageHandlers/dashboardQuery.ts
+++ b/src/hooks/bridgeMessageHandlers/dashboardQuery.ts
@@ -116,6 +116,18 @@ export const handleDashboardQuery: BridgeMessageHandler = (data, ctx) => {
       return { ok: true, projectId: project.id, ...(launched ?? {}) };
     }
 
+    if (op === "send_followup") {
+      const tabId = args.tabId as string | undefined;
+      const prompt = args.prompt as string | undefined;
+      if (!tabId || !prompt?.trim()) {
+        throw new Error("send_followup requires tabId + prompt");
+      }
+      // Normal mode: the chat pipeline queues behind an in-flight prompt,
+      // so a follow-up never clobbers the work agent mid-turn.
+      await ctx.sendChat(prompt, { tabId });
+      return { ok: true, tabId };
+    }
+
     if (op === "get_repo_overview") {
       const projectPath = args.projectPath as string | undefined;
       if (!projectPath) {

--- a/src/hooks/bridgeMessageHandlers/index.ts
+++ b/src/hooks/bridgeMessageHandlers/index.ts
@@ -64,6 +64,11 @@ import { handleSubagentProgress } from "./subagentProgress";
 import { handleTabClosed } from "./tabClosed";
 import { handleTabReady } from "./tabReady";
 import { handleTerminalOutput } from "./terminalOutput";
+import {
+  handleVoiceBrainDelta,
+  handleVoiceBrainEnd,
+  handleVoiceBrainError,
+} from "./voiceBrain";
 
 export const bridgeMessageHandlers: Readonly<
   Record<string, BridgeMessageHandler>
@@ -123,6 +128,9 @@ export const bridgeMessageHandlers: Readonly<
   tab_closed: handleTabClosed,
   tab_ready: handleTabReady,
   terminal_output: handleTerminalOutput,
+  voice_brain_delta: handleVoiceBrainDelta,
+  voice_brain_end: handleVoiceBrainEnd,
+  voice_brain_error: handleVoiceBrainError,
 });
 
 export type {

--- a/src/hooks/bridgeMessageHandlers/readyEffects.test.ts
+++ b/src/hooks/bridgeMessageHandlers/readyEffects.test.ts
@@ -77,7 +77,7 @@ describe("runReadyEffects", () => {
     );
   });
 
-  it("does not replay restored tabs rooted in legacy top-level .aethon state", async () => {
+  it("replays exact .aethon-root tabs but not legacy project mirrors", async () => {
     const { ctx } = buildHandlerFixture({
       state: {
         tabs: [
@@ -107,13 +107,21 @@ describe("runReadyEffects", () => {
       priorActiveTabId: "default",
     });
 
-    expect(ctx.pendingTabOpens.current.has("state-root")).toBe(false);
+    // The exact `~/.aethon` root is the bridge's fallback cwd for tabs with
+    // no active project — a live session that must survive reload. Only
+    // legacy project MIRRORS under the state dir stay excluded.
+    expect(ctx.pendingTabOpens.current.has("state-root")).toBe(true);
     expect(ctx.pendingTabOpens.current.has("legacy-project")).toBe(false);
     expect(ctx.pendingTabOpens.current.has("managed-project")).toBe(true);
     await ctx.pendingTabOpens.current.get("managed-project");
-    expect(ctx.prepareWorkspaceStartup).toHaveBeenCalledTimes(1);
+    expect(ctx.prepareWorkspaceStartup).toHaveBeenCalledWith(
+      "/Users/jamesbrink/.aethon",
+    );
     expect(ctx.prepareWorkspaceStartup).toHaveBeenCalledWith(
       "/Users/jamesbrink/.aethon/projects/project-id/worktree",
+    );
+    expect(ctx.prepareWorkspaceStartup).not.toHaveBeenCalledWith(
+      "/Users/jamesbrink/.aethon/aethon/fix-old-worktree",
     );
   });
 
@@ -150,7 +158,7 @@ describe("runReadyEffects", () => {
     expect(mocks.markStartupChromeReady).toHaveBeenCalledTimes(1);
   });
 
-  it("does not re-announce a prior active tab rooted in legacy top-level .aethon state", () => {
+  it("re-announces a prior active tab at the exact .aethon root but not a legacy mirror", () => {
     const { ctx, mocks } = buildHandlerFixture();
     ctx.projectsRef.current = {
       activeId: "p1",
@@ -160,19 +168,35 @@ describe("runReadyEffects", () => {
       workspacesByProject: {},
     };
 
+    // Exact `~/.aethon` = the bridge's fallback cwd for project-less tabs;
+    // a live session there re-announces its own cwd after reload.
     runReadyEffects(ctx, {
       currentProjectCwd: "/wrong",
       priorActiveTabCwd: "/Users/jamesbrink/.aethon",
       priorActiveTabId: "state-root",
     });
-
     expect(mocks.announceProjectToBridge).toHaveBeenCalledWith(
       "state-root",
+      "/Users/jamesbrink/.aethon",
+    );
+    expect(mocks.markStartupChromeReady).toHaveBeenCalledTimes(1);
+
+    // A legacy mirror under the state dir still falls back to the active
+    // project path instead of resurrecting the junk cwd.
+    mocks.announceProjectToBridge.mockClear();
+    mocks.markStartupChromeReady.mockClear();
+    runReadyEffects(ctx, {
+      currentProjectCwd: "/wrong",
+      priorActiveTabCwd: "/Users/jamesbrink/.aethon/aethon/fix-old-worktree",
+      priorActiveTabId: "legacy-tab",
+    });
+    expect(mocks.announceProjectToBridge).toHaveBeenCalledWith(
+      "legacy-tab",
       "/repo/p1",
     );
     expect(mocks.announceProjectToBridge).not.toHaveBeenCalledWith(
-      "state-root",
-      "/Users/jamesbrink/.aethon",
+      "legacy-tab",
+      "/Users/jamesbrink/.aethon/aethon/fix-old-worktree",
     );
     expect(mocks.markStartupChromeReady).toHaveBeenCalledTimes(1);
   });

--- a/src/hooks/bridgeMessageHandlers/testFixtures.ts
+++ b/src/hooks/bridgeMessageHandlers/testFixtures.ts
@@ -109,6 +109,7 @@ export function buildHandlerFixture(
   const announceProjectToBridge = vi.fn();
   const routeShellWrite = vi.fn(() => Promise.resolve({ ok: true as const }));
   const startTaskInProject = vi.fn(() => Promise.resolve());
+  const sendChat = vi.fn(() => Promise.resolve());
   const ackMutation = vi.fn();
   const knownTabIds = vi.fn(() => new Set<string>(["default"]));
   const scopedDiscoveredSessions = vi.fn((d: DiscoveredSession[]) => d);
@@ -166,6 +167,7 @@ export function buildHandlerFixture(
 
     routeShellWrite,
     startTaskInProject,
+    sendChat,
     markStartupChromeReady,
 
     ackMutation,

--- a/src/hooks/bridgeMessageHandlers/types.ts
+++ b/src/hooks/bridgeMessageHandlers/types.ts
@@ -201,6 +201,13 @@ export interface BridgeMessageContext {
     label?: string;
     sourceIssue?: GitHubIssueSource;
   }) => Promise<StartTaskResult | void>;
+  /** Send a chat message to a tab through the normal composer pipeline
+   *  (queues as a follow-up when a prompt is in flight). Used by the
+   *  voice brain's `send_followup` tool to steer dispatched tasks. */
+  sendChat: (
+    text: string,
+    options?: { mode?: "normal" | "steer"; tabId?: string },
+  ) => Promise<void>;
 
   // ─── Hook-owned ────────────────────────────────────────────────────
   /** Startup/reload paint gate. The first bridge ready can still represent

--- a/src/hooks/bridgeMessageHandlers/voiceBrain.test.ts
+++ b/src/hooks/bridgeMessageHandlers/voiceBrain.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  handleVoiceBrainDelta,
+  handleVoiceBrainEnd,
+  handleVoiceBrainError,
+} from "./voiceBrain";
+import {
+  onVoiceBrainDelta,
+  onVoiceBrainEnd,
+  onVoiceBrainError,
+} from "../../utils/voiceBrainEvents";
+import type { BridgeMessageContext } from "./types";
+
+const ctx = {} as BridgeMessageContext;
+const cleanups: (() => void)[] = [];
+afterEach(() => {
+  cleanups.splice(0).forEach((fn) => fn());
+});
+
+describe("voice brain bridge handlers", () => {
+  it("fans deltas out as window events", () => {
+    const seen = vi.fn();
+    cleanups.push(onVoiceBrainDelta(seen));
+    handleVoiceBrainDelta({ type: "voice_brain_delta", text: "hi" }, ctx);
+    handleVoiceBrainDelta({ type: "voice_brain_delta", text: "" }, ctx);
+    handleVoiceBrainDelta({ type: "voice_brain_delta" }, ctx);
+    expect(seen).toHaveBeenCalledTimes(1);
+    expect(seen).toHaveBeenCalledWith({ text: "hi" });
+  });
+
+  it("fans end out with an optional dispatched task", () => {
+    const seen = vi.fn();
+    cleanups.push(onVoiceBrainEnd(seen));
+    handleVoiceBrainEnd(
+      {
+        type: "voice_brain_end",
+        text: "On it.",
+        dispatched: { tabId: "tab-1", label: "fix tests" },
+      },
+      ctx,
+    );
+    handleVoiceBrainEnd({ type: "voice_brain_end", text: "plain" }, ctx);
+    expect(seen).toHaveBeenNthCalledWith(1, {
+      text: "On it.",
+      dispatched: { tabId: "tab-1", label: "fix tests" },
+    });
+    expect(seen).toHaveBeenNthCalledWith(2, { text: "plain" });
+  });
+
+  it("fans errors out with a fallback message", () => {
+    const seen = vi.fn();
+    cleanups.push(onVoiceBrainError(seen));
+    handleVoiceBrainError({ type: "voice_brain_error", message: "boom" }, ctx);
+    handleVoiceBrainError({ type: "voice_brain_error" }, ctx);
+    expect(seen).toHaveBeenNthCalledWith(1, { message: "boom" });
+    expect(seen).toHaveBeenNthCalledWith(2, {
+      message: "The voice assistant failed to reply",
+    });
+  });
+});

--- a/src/hooks/bridgeMessageHandlers/voiceBrain.ts
+++ b/src/hooks/bridgeMessageHandlers/voiceBrain.ts
@@ -1,0 +1,41 @@
+import type { BridgeMessageHandler } from "./types";
+import {
+  emitVoiceBrainDelta,
+  emitVoiceBrainEnd,
+  emitVoiceBrainError,
+} from "../../utils/voiceBrainEvents";
+
+/** `voice_brain_delta` / `voice_brain_end` / `voice_brain_error` from the
+ *  global bridge's voice-brain session. Re-broadcast as window events for the
+ *  cascade conversation hook — no app state is touched, so the handler stays
+ *  a pure fan-out (the hook owns the conversation lifecycle). */
+export const handleVoiceBrainDelta: BridgeMessageHandler = (data) => {
+  const text = data.text;
+  if (typeof text === "string" && text.length > 0) {
+    emitVoiceBrainDelta({ text });
+  }
+};
+
+export const handleVoiceBrainEnd: BridgeMessageHandler = (data) => {
+  const text = typeof data.text === "string" ? data.text : "";
+  const rawDispatched = data.dispatched as
+    | { tabId?: unknown; label?: unknown }
+    | undefined;
+  const dispatched =
+    rawDispatched && typeof rawDispatched.tabId === "string"
+      ? {
+          tabId: rawDispatched.tabId,
+          label:
+            typeof rawDispatched.label === "string" ? rawDispatched.label : "",
+        }
+      : undefined;
+  emitVoiceBrainEnd({ text, ...(dispatched ? { dispatched } : {}) });
+};
+
+export const handleVoiceBrainError: BridgeMessageHandler = (data) => {
+  const message =
+    typeof data.message === "string" && data.message
+      ? data.message
+      : "The voice assistant failed to reply";
+  emitVoiceBrainError({ message });
+};

--- a/src/hooks/uiOverlays/settings.test.ts
+++ b/src/hooks/uiOverlays/settings.test.ts
@@ -50,6 +50,13 @@ const baseConfig: AethonConfig = {
     speakAgentReplies: false,
     speakMaxChars: 600,
     conversationContinuous: false,
+    conversationEngine: "auto" as const,
+    brainModel: null,
+    sttProvider: "deepgram-flux",
+    ttsProvider: "cartesia",
+    ttsVoice: null,
+    deepgramApiKeySet: false,
+    cartesiaApiKeySet: false,
   },
   updates: { channel: "nightly", disableAutoCheck: false },
   devshell: {

--- a/src/hooks/useBootConfig.ts
+++ b/src/hooks/useBootConfig.ts
@@ -126,6 +126,8 @@ export function useBootConfig(ctx: UseBootConfigContext): UseBootConfigActions {
         speakAgentReplies: fresh.voice.speakAgentReplies,
         speakMaxChars: fresh.voice.speakMaxChars,
         conversationContinuous: fresh.voice.conversationContinuous,
+        conversationEngine: fresh.voice.conversationEngine,
+        brainModel: fresh.voice.brainModel,
       },
       // Global transcript-visibility defaults, mirrored into state so the
       // renderer's resolver can read them via $ref. Per-tab overrides win.
@@ -228,6 +230,8 @@ export function useBootConfig(ctx: UseBootConfigContext): UseBootConfigActions {
             speakAgentReplies: config.voice.speakAgentReplies,
             speakMaxChars: config.voice.speakMaxChars,
             conversationContinuous: config.voice.conversationContinuous,
+            conversationEngine: config.voice.conversationEngine,
+            brainModel: config.voice.brainModel,
           },
           transcriptVisibility: {
             thinking: config.ui.thinkingVisibility,

--- a/src/hooks/useCascadeConversation.test.ts
+++ b/src/hooks/useCascadeConversation.test.ts
@@ -1,0 +1,224 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { useCascadeConversation } from "./useCascadeConversation";
+import { emitAgentTurnComplete } from "../utils/agentTurnEvents";
+import {
+  emitVoiceBrainDelta,
+  emitVoiceBrainEnd,
+  emitVoiceBrainError,
+} from "../utils/voiceBrainEvents";
+import { isConversationActive } from "../utils/conversationMode";
+
+const { mocks, ev } = vi.hoisted(() => ({
+  ev: {
+    listeners: new Map<string, (e: { payload: unknown }) => void>(),
+  },
+  mocks: {
+    startVoiceConvo: vi.fn(() => Promise.resolve()),
+    stopVoiceConvo: vi.fn(() => Promise.resolve()),
+    speakConvoChunk: vi.fn(() => Promise.resolve()),
+    endConvoSpeech: vi.fn(() => Promise.resolve()),
+    cancelConvoSpeech: vi.fn(() => Promise.resolve()),
+    forceConvoEndTurn: vi.fn(() => Promise.resolve()),
+    sendVoiceBridgeMessage: vi.fn(),
+    voiceConvoStatus: vi.fn(() =>
+      Promise.resolve({ available: true, state: "idle" }),
+    ),
+  },
+}));
+
+vi.mock("../services/voiceConvo", () => mocks);
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: (name: string, cb: (e: { payload: unknown }) => void) => {
+    ev.listeners.set(name, cb);
+    return Promise.resolve(() => {});
+  },
+}));
+
+function fire(event: string, payload: unknown) {
+  ev.listeners.get(event)?.({ payload });
+}
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function makeController() {
+  const { result, unmount } = renderHook(() =>
+    useCascadeConversation({
+      getContext: () => ({
+        activeTabId: "t1",
+        projectPath: "/repo",
+        defaultModel: "anthropic/claude-x",
+      }),
+    }),
+  );
+  return { result, unmount };
+}
+
+describe("useCascadeConversation", () => {
+  beforeEach(() => {
+    Object.values(mocks).forEach((mock) => {
+      if ("mockClear" in mock) mock.mockClear();
+    });
+    mocks.startVoiceConvo.mockResolvedValue(undefined);
+    ev.listeners.clear();
+  });
+  afterEach(() => cleanup());
+
+  it("enter starts the engine; a turn forwards to the brain with context", async () => {
+    const { result } = makeController();
+    act(() => result.current.enter());
+    await flush();
+    expect(mocks.startVoiceConvo).toHaveBeenCalledTimes(1);
+    expect(result.current.phase).toBe("listening");
+    expect(isConversationActive()).toBe(true);
+
+    act(() => {
+      fire("voice://convo/interim", { text: "fix the fl" });
+    });
+    expect(result.current.interimText).toBe("fix the fl");
+
+    act(() => {
+      fire("voice://convo/turn", { transcript: "fix the flaky test" });
+      fire("voice://convo/state", { state: "awaiting-brain" });
+    });
+    expect(mocks.sendVoiceBridgeMessage).toHaveBeenCalledWith({
+      type: "voice_turn",
+      text: "fix the flaky test",
+      context: {
+        activeTabId: "t1",
+        projectPath: "/repo",
+        defaultModel: "anthropic/claude-x",
+      },
+    });
+    expect(result.current.phase).toBe("thinking");
+    expect(result.current.interimText).toBeNull();
+
+    act(() => result.current.exit());
+    expect(isConversationActive()).toBe(false);
+    expect(mocks.stopVoiceConvo).toHaveBeenCalled();
+    expect(mocks.sendVoiceBridgeMessage).toHaveBeenCalledWith({
+      type: "voice_session_reset",
+    });
+  });
+
+  it("streams brain deltas as clause chunks and seals on end", async () => {
+    const { result } = makeController();
+    act(() => result.current.enter());
+    await flush();
+
+    act(() => {
+      emitVoiceBrainDelta({
+        text: "Sure — I'll take care of that right away. Also",
+      });
+    });
+    expect(mocks.speakConvoChunk).toHaveBeenCalledWith(
+      "Sure — I'll take care of that right away.",
+    );
+
+    act(() => {
+      emitVoiceBrainEnd({ text: "whole reply" });
+    });
+    // The buffered tail speaks, then the utterance seals.
+    expect(mocks.speakConvoChunk).toHaveBeenLastCalledWith("Also");
+    expect(mocks.endConvoSpeech).toHaveBeenCalledTimes(1);
+  });
+
+  it("announces a dispatched task's completion exactly once", async () => {
+    const { result } = makeController();
+    act(() => result.current.enter());
+    await flush();
+
+    act(() => {
+      emitVoiceBrainEnd({
+        text: "On it.",
+        dispatched: { tabId: "task-tab", label: "fix tests" },
+      });
+    });
+    mocks.sendVoiceBridgeMessage.mockClear();
+
+    act(() => {
+      emitAgentTurnComplete({
+        tabId: "task-tab",
+        text: "All 42 tests pass.\n```diff\n+fix\n```",
+      });
+    });
+    expect(mocks.sendVoiceBridgeMessage).toHaveBeenCalledTimes(1);
+    const message = mocks.sendVoiceBridgeMessage.mock.calls[0]?.[0] as {
+      type: string;
+      taskTabId: string;
+      finalText: string;
+    };
+    expect(message.type).toBe("voice_task_event");
+    expect(message.taskTabId).toBe("task-tab");
+    expect(message.finalText).not.toContain("+fix");
+
+    // A later turn on the same tab belongs to the user — no re-announcement.
+    act(() => {
+      emitAgentTurnComplete({ tabId: "task-tab", text: "later turn" });
+    });
+    expect(mocks.sendVoiceBridgeMessage).toHaveBeenCalledTimes(1);
+
+    // Untracked tabs never announce.
+    act(() => {
+      emitAgentTurnComplete({ tabId: "other-tab", text: "irrelevant" });
+    });
+    expect(mocks.sendVoiceBridgeMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("barge-in aborts the brain; brain errors unwedge the engine", async () => {
+    const { result } = makeController();
+    act(() => result.current.enter());
+    await flush();
+
+    act(() => {
+      fire("voice://convo/state", { state: "speaking" });
+    });
+    expect(result.current.phase).toBe("speaking");
+    act(() => {
+      fire("voice://convo/state", { state: "listening", reason: "barge-in" });
+    });
+    expect(mocks.sendVoiceBridgeMessage).toHaveBeenCalledWith({
+      type: "voice_brain_abort",
+    });
+    expect(result.current.phase).toBe("listening");
+
+    act(() => {
+      emitVoiceBrainError({ message: "provider down" });
+    });
+    expect(result.current.error).toBe("provider down");
+    expect(mocks.cancelConvoSpeech).toHaveBeenCalled();
+  });
+
+  it("surfaces a failed engine start and retries via primaryAction", async () => {
+    mocks.startVoiceConvo.mockRejectedValueOnce(
+      new Error("Deepgram API key missing"),
+    );
+    const { result } = makeController();
+    act(() => result.current.enter());
+    await flush();
+    expect(result.current.error).toContain("Deepgram API key missing");
+    expect(result.current.phase).toBe("idle");
+    expect(result.current.active).toBe(true);
+
+    act(() => result.current.primaryAction());
+    await flush();
+    expect(mocks.startVoiceConvo).toHaveBeenCalledTimes(2);
+    expect(result.current.phase).toBe("listening");
+    act(() => result.current.exit());
+  });
+
+  it("push-to-talk release forces the turn end while listening", async () => {
+    const { result } = makeController();
+    act(() => result.current.enter());
+    await flush();
+    act(() => result.current.endHold());
+    expect(mocks.forceConvoEndTurn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/useCascadeConversation.test.ts
+++ b/src/hooks/useCascadeConversation.test.ts
@@ -49,6 +49,7 @@ async function flush() {
 }
 
 function makeController() {
+  const submitTranscript = vi.fn();
   const { result, unmount } = renderHook(() =>
     useCascadeConversation({
       getContext: () => ({
@@ -56,9 +57,11 @@ function makeController() {
         projectPath: "/repo",
         defaultModel: "anthropic/claude-x",
       }),
+      submitTranscript,
+      getActiveTabId: () => "t1",
     }),
   );
-  return { result, unmount };
+  return { result, unmount, submitTranscript };
 }
 
 describe("useCascadeConversation", () => {
@@ -71,8 +74,8 @@ describe("useCascadeConversation", () => {
   });
   afterEach(() => cleanup());
 
-  it("enter starts the engine; a turn forwards to the brain with context", async () => {
-    const { result } = makeController();
+  it("enter starts the engine; a turn goes straight to the work agent", async () => {
+    const { result, submitTranscript } = makeController();
     act(() => result.current.enter());
     await flush();
     expect(mocks.startVoiceConvo).toHaveBeenCalledTimes(1);
@@ -86,19 +89,31 @@ describe("useCascadeConversation", () => {
 
     act(() => {
       fire("voice://convo/turn", { transcript: "fix the flaky test" });
-      fire("voice://convo/state", { state: "awaiting-brain" });
     });
-    expect(mocks.sendVoiceBridgeMessage).toHaveBeenCalledWith({
-      type: "voice_turn",
-      text: "fix the flaky test",
-      context: {
-        activeTabId: "t1",
-        projectPath: "/repo",
-        defaultModel: "anthropic/claude-x",
-      },
-    });
-    expect(result.current.phase).toBe("thinking");
+    // No LLM between speech and the agent: the transcript submits directly,
+    // a canned ack speaks, and the utterance seals.
+    expect(submitTranscript).toHaveBeenCalledWith("fix the flaky test");
+    expect(mocks.sendVoiceBridgeMessage).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "voice_turn" }),
+    );
+    expect(mocks.speakConvoChunk).toHaveBeenCalledWith("On it.");
+    expect(mocks.endConvoSpeech).toHaveBeenCalledTimes(1);
     expect(result.current.interimText).toBeNull();
+
+    // The submitted tab is tracked: its turn completion announces via the
+    // brain with a label derived from the transcript.
+    mocks.sendVoiceBridgeMessage.mockClear();
+    act(() => {
+      emitAgentTurnComplete({ tabId: "t1", text: "Fixed. Tests green." });
+    });
+    expect(mocks.sendVoiceBridgeMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "voice_task_event",
+        taskTabId: "t1",
+        label: "fix the flaky test",
+        status: "completed",
+      }),
+    );
 
     act(() => result.current.exit());
     expect(isConversationActive()).toBe(false);

--- a/src/hooks/useCascadeConversation.ts
+++ b/src/hooks/useCascadeConversation.ts
@@ -356,4 +356,3 @@ export function useCascadeConversation(
     endHold,
   };
 }
-

--- a/src/hooks/useCascadeConversation.ts
+++ b/src/hooks/useCascadeConversation.ts
@@ -75,6 +75,7 @@ export function useCascadeConversation(
   const [phase, setPhaseState] = useState<ConversationPhase>("idle");
   const [error, setError] = useState<string | null>(null);
   const [interimText, setInterimText] = useState<string | null>(null);
+  const [latencyMs, setLatencyMs] = useState<number | null>(null);
 
   const activeRef = useRef(false);
   const phaseRef = useRef<ConversationPhase>("idle");
@@ -215,6 +216,12 @@ export function useCascadeConversation(
     subscribe<{ message: string }>("voice://convo/error", (payload) => {
       setError(payload.message);
     });
+    subscribe<{ stage: string; ms: number }>(
+      "voice://convo/metrics",
+      (payload) => {
+        if (payload.stage === "tts-first-audio") setLatencyMs(payload.ms);
+      },
+    );
 
     return () => {
       cancelled = true;
@@ -291,6 +298,7 @@ export function useCascadeConversation(
     phase,
     error,
     interimText,
+    latencyMs,
     enter,
     exit,
     primaryAction,

--- a/src/hooks/useCascadeConversation.ts
+++ b/src/hooks/useCascadeConversation.ts
@@ -8,7 +8,6 @@ import {
   speakConvoChunk,
   startVoiceConvo,
   stopVoiceConvo,
-  voiceConvoStatus,
 } from "../services/voiceConvo";
 import { onAgentTurnComplete } from "../utils/agentTurnEvents";
 import { setConversationActive } from "../utils/conversationMode";
@@ -307,32 +306,3 @@ export function useCascadeConversation(
   };
 }
 
-/** Resolve `[voice] conversation_engine` to a concrete pipeline. `"auto"`
- *  asks the Rust engine whether the cascade's provider keys resolve and
- *  falls back to the local LFM2 loop when they don't (or when the probe
- *  fails — e.g. a non-voice build). */
-export function useConversationEngineChoice(
-  configured: string | undefined,
-): "cascade" | "lfm2" {
-  // Explicit choices resolve synchronously in render; only "auto" needs the
-  // async availability probe.
-  const [autoChoice, setAutoChoice] = useState<"cascade" | "lfm2">("lfm2");
-  const isAuto = configured !== "cascade" && configured !== "lfm2";
-  useEffect(() => {
-    if (!isAuto) return;
-    let cancelled = false;
-    voiceConvoStatus()
-      .then((status) => {
-        if (!cancelled) setAutoChoice(status.available ? "cascade" : "lfm2");
-      })
-      .catch(() => {
-        if (!cancelled) setAutoChoice("lfm2");
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [isAuto]);
-  if (configured === "cascade") return "cascade";
-  if (configured === "lfm2") return "lfm2";
-  return autoChoice;
-}

--- a/src/hooks/useCascadeConversation.ts
+++ b/src/hooks/useCascadeConversation.ts
@@ -33,6 +33,9 @@ export interface VoiceConvoContext {
   projectPath?: string;
   defaultModel?: string;
   brainModel?: string;
+  /** Project list (label + root path) so the brain can dispatch to a project
+   *  the user names even when none is active. */
+  knownProjects?: { label: string; path: string }[];
 }
 
 /** Live activity of a dispatched task tab, for spoken progress updates. */

--- a/src/hooks/useCascadeConversation.ts
+++ b/src/hooks/useCascadeConversation.ts
@@ -49,6 +49,11 @@ export interface VoiceTaskActivity {
 
 export interface UseCascadeConversationOptions {
   getContext: () => VoiceConvoContext;
+  /** Send the final transcript to the work agent (the composer submit path —
+   *  speech reaches the agent with no LLM in between). */
+  submitTranscript: (text: string) => void;
+  /** The tab the transcript lands in, so its progress/completion is spoken. */
+  getActiveTabId: () => string | undefined;
   /** Resolve a dispatched tab's live activity; null/undefined = unknown. */
   getTaskActivity?: (tabId: string) => VoiceTaskActivity | null;
 }
@@ -57,6 +62,16 @@ export interface UseCascadeConversationOptions {
 export const TASK_PROGRESS_INTERVAL_MS = 30_000;
 /** Cap on the activity digest forwarded to the brain per progress tick. */
 const TASK_PROGRESS_TEXT_CAP = 700;
+/** Instant spoken confirmation that the transcript reached the agent. */
+const SUBMIT_ACK_PHRASE = "On it.";
+
+/** A short speakable label for the submitted request (progress/completion
+ *  announcements name the task by it). */
+export function taskLabelFromTranscript(transcript: string): string {
+  const words = transcript.split(/\s+/).filter(Boolean);
+  const label = words.slice(0, 6).join(" ");
+  return words.length > 6 ? `${label}…` : label;
+}
 
 /** Rust ConversationEngine state (voice://convo/state payloads). */
 type EngineState =
@@ -227,12 +242,23 @@ export function useCascadeConversation(
     });
     subscribe<{ transcript: string }>("voice://convo/turn", (payload) => {
       setInterimText(null);
-      const context = optionsRef.current.getContext();
-      sendVoiceBridgeMessage({
-        type: "voice_turn",
-        text: payload.transcript,
-        context,
-      });
+      // The spoken words go STRAIGHT to the work agent — the same path as
+      // typing into the composer. No LLM sits between the user's speech and
+      // the agent; a canned ack plays immediately, and the voice brain's
+      // only job is summarizing the agent's progress/completion for speech.
+      const opts = optionsRef.current;
+      const transcript = payload.transcript.trim();
+      if (!transcript) {
+        void cancelConvoSpeech().catch(() => {});
+        return;
+      }
+      opts.submitTranscript(transcript);
+      const tabId = opts.getActiveTabId();
+      if (tabId) {
+        dispatchedRef.current.set(tabId, taskLabelFromTranscript(transcript));
+      }
+      void speakConvoChunk(SUBMIT_ACK_PHRASE).catch(() => {});
+      void endConvoSpeech().catch(() => {});
     });
     subscribe<{ message: string }>("voice://convo/error", (payload) => {
       setError(payload.message);
@@ -301,6 +327,7 @@ export function useCascadeConversation(
         label,
         status: "completed",
         finalText: stripForSpeechSource(text),
+        context: optionsRef.current.getContext(),
       });
     });
   }, []);
@@ -330,6 +357,7 @@ export function useCascadeConversation(
           label,
           status: "progress",
           finalText: digest,
+          context: optionsRef.current.getContext(),
         });
       }
     }, TASK_PROGRESS_INTERVAL_MS);

--- a/src/hooks/useCascadeConversation.ts
+++ b/src/hooks/useCascadeConversation.ts
@@ -35,9 +35,25 @@ export interface VoiceConvoContext {
   brainModel?: string;
 }
 
+/** Live activity of a dispatched task tab, for spoken progress updates. */
+export interface VoiceTaskActivity {
+  /** Still mid-turn (waiting/queued)? Completion is announced separately. */
+  running: boolean;
+  /** Most recent agent prose from the tab, already speech-safe or close to
+   *  it — the hook strips code fences and caps length before sending. */
+  recentText: string;
+}
+
 export interface UseCascadeConversationOptions {
   getContext: () => VoiceConvoContext;
+  /** Resolve a dispatched tab's live activity; null/undefined = unknown. */
+  getTaskActivity?: (tabId: string) => VoiceTaskActivity | null;
 }
+
+/** How often a still-running dispatched task is summarized aloud. */
+export const TASK_PROGRESS_INTERVAL_MS = 30_000;
+/** Cap on the activity digest forwarded to the brain per progress tick. */
+const TASK_PROGRESS_TEXT_CAP = 700;
 
 /** Rust ConversationEngine state (voice://convo/state payloads). */
 type EngineState =
@@ -83,6 +99,8 @@ export function useCascadeConversation(
   /** Task tabs the brain dispatched, awaiting a completion announcement
    *  (announced once, then dropped). */
   const dispatchedRef = useRef(new Map<string, string>());
+  /** Last progress digest sent per dispatched tab (dedupe between ticks). */
+  const lastProgressRef = useRef(new Map<string, string>());
   useEffect(() => {
     optionsRef.current = options;
   });
@@ -126,6 +144,7 @@ export function useCascadeConversation(
     setConversationActive(false);
     chunkerRef.current.reset();
     dispatchedRef.current.clear();
+    lastProgressRef.current.clear();
     setInterimText(null);
     setPhase("idle");
     setError(null);
@@ -272,6 +291,7 @@ export function useCascadeConversation(
       if (label === undefined) return;
       // Announce once per dispatch; later turns on that tab are the user's.
       dispatchedRef.current.delete(tabId);
+      lastProgressRef.current.delete(tabId);
       sendVoiceBridgeMessage({
         type: "voice_task_event",
         taskTabId: tabId,
@@ -280,6 +300,37 @@ export function useCascadeConversation(
         finalText: stripForSpeechSource(text),
       });
     });
+  }, []);
+
+  // ── Running tasks → periodic spoken progress updates ───────────────────
+  // While a dispatched task is still working, forward a digest of its recent
+  // activity so the brain can speak a one-sentence update. Skipped while the
+  // user is mid-exchange (speaking/being answered) so updates never talk over
+  // the conversation, and deduped per tab so an idle task stays silent.
+  useEffect(() => {
+    const timer = window.setInterval(() => {
+      if (!activeRef.current) return;
+      if (phaseRef.current !== "listening") return;
+      const getActivity = optionsRef.current.getTaskActivity;
+      if (!getActivity) return;
+      for (const [tabId, label] of dispatchedRef.current) {
+        const activity = getActivity(tabId);
+        if (!activity?.running) continue;
+        const digest = stripForSpeechSource(activity.recentText)
+          .trim()
+          .slice(-TASK_PROGRESS_TEXT_CAP);
+        if (!digest || lastProgressRef.current.get(tabId) === digest) continue;
+        lastProgressRef.current.set(tabId, digest);
+        sendVoiceBridgeMessage({
+          type: "voice_task_event",
+          taskTabId: tabId,
+          label,
+          status: "progress",
+          finalText: digest,
+        });
+      }
+    }, TASK_PROGRESS_INTERVAL_MS);
+    return () => window.clearInterval(timer);
   }, []);
 
   // Tear down the engine if we unmount mid-conversation.

--- a/src/hooks/useCascadeConversation.ts
+++ b/src/hooks/useCascadeConversation.ts
@@ -1,0 +1,330 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { listen } from "@tauri-apps/api/event";
+import {
+  cancelConvoSpeech,
+  endConvoSpeech,
+  forceConvoEndTurn,
+  sendVoiceBridgeMessage,
+  speakConvoChunk,
+  startVoiceConvo,
+  stopVoiceConvo,
+  voiceConvoStatus,
+} from "../services/voiceConvo";
+import { onAgentTurnComplete } from "../utils/agentTurnEvents";
+import { setConversationActive } from "../utils/conversationMode";
+import {
+  createSpeechChunker,
+  stripForSpeechSource,
+} from "../utils/speechChunker";
+import {
+  onVoiceBrainDelta,
+  onVoiceBrainEnd,
+  onVoiceBrainError,
+} from "../utils/voiceBrainEvents";
+import type {
+  ConversationPhase,
+  VoiceConversationController,
+} from "./useVoiceConversation";
+
+/** Context stamped onto every `voice_turn` so the brain's dispatch_task tool
+ *  has real arguments. Resolved lazily — the active tab/project can change
+ *  mid-conversation. */
+export interface VoiceConvoContext {
+  activeTabId?: string;
+  projectPath?: string;
+  defaultModel?: string;
+  brainModel?: string;
+}
+
+export interface UseCascadeConversationOptions {
+  getContext: () => VoiceConvoContext;
+}
+
+/** Rust ConversationEngine state (voice://convo/state payloads). */
+type EngineState =
+  | "idle"
+  | "listening"
+  | "user-speaking"
+  | "awaiting-brain"
+  | "speaking";
+
+const PHASE_FOR_STATE: Record<EngineState, ConversationPhase> = {
+  idle: "idle",
+  listening: "listening",
+  "user-speaking": "listening",
+  "awaiting-brain": "thinking",
+  speaking: "speaking",
+};
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/** The cascade voice conversation: streaming STT with semantic turn detection
+ *  (Rust `voice/convo/` engine) → voice-brain session on the bridge →
+ *  streaming TTS. This hook is the glue: it forwards engine turn events to
+ *  the brain, feeds brain deltas back as clause-sized speech chunks, and
+ *  announces completed work-agent tasks.
+ *
+ *  Mounted unconditionally next to the LFM2 loop (rules of hooks); completely
+ *  inert — no IPC — until `enter()` is called. */
+export function useCascadeConversation(
+  options: UseCascadeConversationOptions,
+): VoiceConversationController {
+  const [active, setActive] = useState(false);
+  const [phase, setPhaseState] = useState<ConversationPhase>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [interimText, setInterimText] = useState<string | null>(null);
+
+  const activeRef = useRef(false);
+  const phaseRef = useRef<ConversationPhase>("idle");
+  const optionsRef = useRef(options);
+  const chunkerRef = useRef(createSpeechChunker());
+  /** Task tabs the brain dispatched, awaiting a completion announcement
+   *  (announced once, then dropped). */
+  const dispatchedRef = useRef(new Map<string, string>());
+  useEffect(() => {
+    optionsRef.current = options;
+  });
+
+  const setPhase = useCallback((next: ConversationPhase) => {
+    phaseRef.current = next;
+    setPhaseState(next);
+  }, []);
+
+  const abortBrain = useCallback(() => {
+    chunkerRef.current.reset();
+    sendVoiceBridgeMessage({ type: "voice_brain_abort" });
+  }, []);
+
+  const startEngine = useCallback(async () => {
+    setError(null);
+    try {
+      await startVoiceConvo();
+      if (!activeRef.current) {
+        await stopVoiceConvo().catch(() => {});
+        return;
+      }
+      setPhase("listening");
+    } catch (caught) {
+      setError(errorMessage(caught));
+      setPhase("idle");
+    }
+  }, [setPhase]);
+
+  const enter = useCallback(() => {
+    if (activeRef.current) return;
+    activeRef.current = true;
+    setActive(true);
+    setConversationActive(true);
+    void startEngine();
+  }, [startEngine]);
+
+  const exit = useCallback(() => {
+    activeRef.current = false;
+    setActive(false);
+    setConversationActive(false);
+    chunkerRef.current.reset();
+    dispatchedRef.current.clear();
+    setInterimText(null);
+    setPhase("idle");
+    setError(null);
+    void stopVoiceConvo().catch(() => {});
+    sendVoiceBridgeMessage({ type: "voice_session_reset" });
+  }, [setPhase]);
+
+  const interrupt = useCallback(() => {
+    abortBrain();
+    void cancelConvoSpeech().catch(() => {});
+  }, [abortBrain]);
+
+  const primaryAction = useCallback(() => {
+    switch (phaseRef.current) {
+      case "idle":
+        // The engine died (error) while the HUD stayed open — retry.
+        void startEngine();
+        break;
+      case "listening":
+        void forceConvoEndTurn().catch(() => {});
+        break;
+      case "thinking":
+      case "speaking":
+        interrupt();
+        break;
+      case "transcribing":
+        break; // unused by the cascade engine
+    }
+  }, [interrupt, startEngine]);
+
+  // Push-to-talk: the cascade mic is always open while listening, so the
+  // press only matters as an interrupt (barge-in by key) and the release as
+  // an explicit end-of-turn.
+  const beginHold = useCallback(() => {
+    if (!activeRef.current) return;
+    if (phaseRef.current === "speaking" || phaseRef.current === "thinking") {
+      interrupt();
+    }
+  }, [interrupt]);
+
+  const endHold = useCallback(() => {
+    if (!activeRef.current) return;
+    if (phaseRef.current === "listening") {
+      void forceConvoEndTurn().catch(() => {});
+    }
+  }, []);
+
+  // ── Engine events (Rust → hook) ────────────────────────────────────────
+  useEffect(() => {
+    const unlistens: (() => void)[] = [];
+    let cancelled = false;
+    const subscribe = <T,>(event: string, handler: (payload: T) => void) => {
+      void listen<T>(event, ({ payload }) => {
+        if (!activeRef.current) return;
+        handler(payload);
+      }).then((fn) => {
+        if (cancelled) fn();
+        else unlistens.push(fn);
+      });
+    };
+
+    subscribe<{ state: EngineState; reason?: string }>(
+      "voice://convo/state",
+      (payload) => {
+        const next = PHASE_FOR_STATE[payload.state] ?? "idle";
+        if (payload.reason === "barge-in") {
+          // The user talked over the reply: the engine already cut playback;
+          // silence the brain so a stale reply can't resume.
+          abortBrain();
+        }
+        if (next !== "listening") setInterimText(null);
+        setPhase(next);
+      },
+    );
+    subscribe<{ text: string }>("voice://convo/interim", (payload) => {
+      setInterimText(payload.text || null);
+    });
+    subscribe<{ transcript: string }>("voice://convo/turn", (payload) => {
+      setInterimText(null);
+      const context = optionsRef.current.getContext();
+      sendVoiceBridgeMessage({
+        type: "voice_turn",
+        text: payload.transcript,
+        context,
+      });
+    });
+    subscribe<{ message: string }>("voice://convo/error", (payload) => {
+      setError(payload.message);
+    });
+
+    return () => {
+      cancelled = true;
+      unlistens.forEach((fn) => fn());
+    };
+  }, [abortBrain, setPhase]);
+
+  // ── Brain events (bridge → hook) ───────────────────────────────────────
+  useEffect(() => {
+    const offDelta = onVoiceBrainDelta(({ text }) => {
+      if (!activeRef.current) return;
+      for (const chunk of chunkerRef.current.push(text)) {
+        void speakConvoChunk(chunk).catch(() => {});
+      }
+    });
+    const offEnd = onVoiceBrainEnd(({ dispatched }) => {
+      if (!activeRef.current) return;
+      if (dispatched) {
+        dispatchedRef.current.set(dispatched.tabId, dispatched.label);
+      }
+      // Speak whatever the chunker still buffers (the reply tail that never
+      // hit a clause boundary), then seal the utterance. A reply with no
+      // speakable text still needs the seal — it unwedges awaiting-brain.
+      const rest = chunkerRef.current.flush();
+      if (rest) {
+        void speakConvoChunk(rest).catch(() => {});
+      }
+      void endConvoSpeech().catch(() => {});
+    });
+    const offError = onVoiceBrainError(({ message }) => {
+      if (!activeRef.current) return;
+      setError(message);
+      chunkerRef.current.reset();
+      // Unwedge the engine (awaiting-brain → listening).
+      void cancelConvoSpeech().catch(() => {});
+    });
+    return () => {
+      offDelta();
+      offEnd();
+      offError();
+    };
+  }, []);
+
+  // ── Work-agent completion → spoken announcement ────────────────────────
+  useEffect(() => {
+    return onAgentTurnComplete(({ tabId, text }) => {
+      if (!activeRef.current) return;
+      const label = dispatchedRef.current.get(tabId);
+      if (label === undefined) return;
+      // Announce once per dispatch; later turns on that tab are the user's.
+      dispatchedRef.current.delete(tabId);
+      sendVoiceBridgeMessage({
+        type: "voice_task_event",
+        taskTabId: tabId,
+        label,
+        status: "completed",
+        finalText: stripForSpeechSource(text),
+      });
+    });
+  }, []);
+
+  // Tear down the engine if we unmount mid-conversation.
+  useEffect(() => {
+    return () => {
+      if (activeRef.current) {
+        setConversationActive(false);
+        void stopVoiceConvo().catch(() => {});
+      }
+    };
+  }, []);
+
+  return {
+    active,
+    phase,
+    error,
+    interimText,
+    enter,
+    exit,
+    primaryAction,
+    beginHold,
+    endHold,
+  };
+}
+
+/** Resolve `[voice] conversation_engine` to a concrete pipeline. `"auto"`
+ *  asks the Rust engine whether the cascade's provider keys resolve and
+ *  falls back to the local LFM2 loop when they don't (or when the probe
+ *  fails — e.g. a non-voice build). */
+export function useConversationEngineChoice(
+  configured: string | undefined,
+): "cascade" | "lfm2" {
+  // Explicit choices resolve synchronously in render; only "auto" needs the
+  // async availability probe.
+  const [autoChoice, setAutoChoice] = useState<"cascade" | "lfm2">("lfm2");
+  const isAuto = configured !== "cascade" && configured !== "lfm2";
+  useEffect(() => {
+    if (!isAuto) return;
+    let cancelled = false;
+    voiceConvoStatus()
+      .then((status) => {
+        if (!cancelled) setAutoChoice(status.available ? "cascade" : "lfm2");
+      })
+      .catch(() => {
+        if (!cancelled) setAutoChoice("lfm2");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isAuto]);
+  if (configured === "cascade") return "cascade";
+  if (configured === "lfm2") return "lfm2";
+  return autoChoice;
+}

--- a/src/hooks/useChat.test.ts
+++ b/src/hooks/useChat.test.ts
@@ -53,6 +53,13 @@ const fullConfig: AethonConfig = {
     speakAgentReplies: true,
     speakMaxChars: 1200,
     conversationContinuous: true,
+    conversationEngine: "auto" as const,
+    brainModel: null,
+    sttProvider: "deepgram-flux",
+    ttsProvider: "cartesia",
+    ttsVoice: null,
+    deepgramApiKeySet: false,
+    cartesiaApiKeySet: false,
   },
   updates: { channel: "nightly", disableAutoCheck: true },
   devshell: {

--- a/src/hooks/useVoiceConversation.test.ts
+++ b/src/hooks/useVoiceConversation.test.ts
@@ -51,6 +51,9 @@ function makeController(continuous = false) {
       getActiveTabId: () => "t1",
       continuous,
       maxSpokenChars: 600,
+      // These tests exercise the LFM2 loop specifically; "auto" would probe
+      // cascade availability over IPC at enter time.
+      engine: "lfm2",
     }),
   );
   return { result, submitText, unmount };

--- a/src/hooks/useVoiceConversation.ts
+++ b/src/hooks/useVoiceConversation.ts
@@ -10,6 +10,10 @@ import {
 import { onAgentTurnComplete } from "../utils/agentTurnEvents";
 import { setConversationActive } from "../utils/conversationMode";
 import { LFM2_VOICE_PROVIDER_ID, capSpokenText } from "../utils/voice";
+import {
+  useCascadeConversation,
+  type VoiceConvoContext,
+} from "./useCascadeConversation";
 
 /** A full turn of the LFM2-Audio conversation loop:
  *  idle → listening → transcribing → thinking → speaking → (continue|idle). */
@@ -19,6 +23,8 @@ export type ConversationPhase =
   | "transcribing"
   | "thinking"
   | "speaking";
+
+export type ConversationEngineKind = "cascade" | "lfm2";
 
 export interface UseVoiceConversationOptions {
   /** Send the transcript to the agent (reuses the composer submit path). */
@@ -32,12 +38,22 @@ export interface UseVoiceConversationOptions {
   maxSpokenChars: number;
   /** Routed to Settings when the LFM2 model/binary isn't ready. */
   onNeedsSetup?: (providerId: string) => void;
+  /** Which pipeline drives the conversation. `"lfm2"` (default) is the local
+   *  batch loop below; `"cascade"` is the streaming engine
+   *  (useCascadeConversation) — resolve `"auto"` before passing it in
+   *  (useConversationEngineChoice). */
+  engine?: ConversationEngineKind;
+  /** Runtime context stamped on cascade voice turns (active tab, project,
+   *  models). Required for the cascade engine to dispatch tasks. */
+  getConvoContext?: () => VoiceConvoContext;
 }
 
 export interface VoiceConversationController {
   active: boolean;
   phase: ConversationPhase;
   error: string | null;
+  /** Live partial transcript while listening (cascade engine only). */
+  interimText: string | null;
   enter: () => void;
   exit: () => void;
   /** Context-aware tap: start speaking / finish speaking / interrupt. */
@@ -51,6 +67,19 @@ export interface VoiceConversationController {
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+/** Route to the configured conversation pipeline. Both hooks mount
+ *  unconditionally (rules of hooks); each is inert until entered, so the
+ *  inactive one costs a few no-op listeners. */
+export function useVoiceConversation(
+  options: UseVoiceConversationOptions,
+): VoiceConversationController {
+  const lfm2 = useLfm2Conversation(options);
+  const cascade = useCascadeConversation({
+    getContext: options.getConvoContext ?? (() => ({})),
+  });
+  return options.engine === "cascade" ? cascade : lfm2;
 }
 
 // Voice-activity detection thresholds (over the recorder's ~30 Hz
@@ -68,7 +97,8 @@ interface VoiceLevel {
   level: number;
 }
 
-export function useVoiceConversation(
+/** The original LFM2-Audio loop: batch ASR → composer submit → batch TTS. */
+function useLfm2Conversation(
   options: UseVoiceConversationOptions,
 ): VoiceConversationController {
   const [active, setActive] = useState(false);
@@ -357,5 +387,15 @@ export function useVoiceConversation(
     };
   }, []);
 
-  return { active, phase, error, enter, exit, primaryAction, beginHold, endHold };
+  return {
+    active,
+    phase,
+    error,
+    interimText: null,
+    enter,
+    exit,
+    primaryAction,
+    beginHold,
+    endHold,
+  };
 }

--- a/src/hooks/useVoiceConversation.ts
+++ b/src/hooks/useVoiceConversation.ts
@@ -46,6 +46,10 @@ export interface UseVoiceConversationOptions {
   /** Runtime context stamped on cascade voice turns (active tab, project,
    *  models). Required for the cascade engine to dispatch tasks. */
   getConvoContext?: () => VoiceConvoContext;
+  /** When true (engine came from "auto"), a cascade session that dies —
+   *  failed start or exhausted reconnects — hands the conversation to the
+   *  local LFM2 loop instead of stranding the user with an error. */
+  allowFallback?: boolean;
 }
 
 export interface VoiceConversationController {
@@ -54,6 +58,9 @@ export interface VoiceConversationController {
   error: string | null;
   /** Live partial transcript while listening (cascade engine only). */
   interimText: string | null;
+  /** Last measured time-to-first-audio for a spoken reply, in ms (cascade
+   *  engine, debug builds emit the metric). */
+  latencyMs: number | null;
   enter: () => void;
   exit: () => void;
   /** Context-aware tap: start speaking / finish speaking / interrupt. */
@@ -79,7 +86,40 @@ export function useVoiceConversation(
   const cascade = useCascadeConversation({
     getContext: options.getConvoContext ?? (() => ({})),
   });
-  return options.engine === "cascade" ? cascade : lfm2;
+  const [fellBack, setFellBack] = useState(false);
+  const usingCascade = options.engine === "cascade" && !fellBack;
+
+  // A dead cascade session (error while idle-but-active: failed start or
+  // exhausted mid-session reconnects) hands off to the local loop when the
+  // engine choice was automatic. The switch is spoken through the local TTS
+  // so a hands-free user isn't left talking to a dead mic.
+  const shouldFallBack =
+    options.allowFallback === true &&
+    usingCascade &&
+    cascade.active &&
+    cascade.phase === "idle" &&
+    cascade.error !== null;
+  const cascadeExit = cascade.exit;
+  const lfm2Enter = lfm2.enter;
+  useEffect(() => {
+    if (!shouldFallBack) return;
+    cascadeExit();
+    setFellBack(true);
+    lfm2Enter();
+    void speakVoice(
+      "Cloud voice is unavailable, switching to the local engine.",
+    ).catch(() => {});
+  }, [shouldFallBack, cascadeExit, lfm2Enter]);
+
+  const controller = usingCascade ? cascade : lfm2;
+  return {
+    ...controller,
+    exit: () => {
+      controller.exit();
+      // The next session gets a fresh shot at the cascade.
+      setFellBack(false);
+    },
+  };
 }
 
 // Voice-activity detection thresholds (over the recorder's ~30 Hz
@@ -392,6 +432,7 @@ function useLfm2Conversation(
     phase,
     error,
     interimText: null,
+    latencyMs: null,
     enter,
     exit,
     primaryAction,

--- a/src/hooks/useVoiceConversation.ts
+++ b/src/hooks/useVoiceConversation.ts
@@ -90,6 +90,8 @@ export function useVoiceConversation(
   const lfm2 = useLfm2Conversation(options);
   const cascade = useCascadeConversation({
     getContext: options.getConvoContext ?? (() => ({})),
+    submitTranscript: options.submitText,
+    getActiveTabId: options.getActiveTabId,
     ...(options.getTaskActivity
       ? { getTaskActivity: options.getTaskActivity }
       : {}),

--- a/src/hooks/useVoiceConversation.ts
+++ b/src/hooks/useVoiceConversation.ts
@@ -7,6 +7,7 @@ import {
   stopAndTranscribeVoice,
   stopVoicePlayback,
 } from "../services/voice";
+import { voiceConvoStatus } from "../services/voiceConvo";
 import { onAgentTurnComplete } from "../utils/agentTurnEvents";
 import { setConversationActive } from "../utils/conversationMode";
 import { LFM2_VOICE_PROVIDER_ID, capSpokenText } from "../utils/voice";
@@ -38,11 +39,11 @@ export interface UseVoiceConversationOptions {
   maxSpokenChars: number;
   /** Routed to Settings when the LFM2 model/binary isn't ready. */
   onNeedsSetup?: (providerId: string) => void;
-  /** Which pipeline drives the conversation. `"lfm2"` (default) is the local
-   *  batch loop below; `"cascade"` is the streaming engine
-   *  (useCascadeConversation) — resolve `"auto"` before passing it in
-   *  (useConversationEngineChoice). */
-  engine?: ConversationEngineKind;
+  /** Which pipeline drives the conversation. `"cascade"` is the streaming
+   *  engine (useCascadeConversation); `"lfm2"` the local batch loop below;
+   *  `"auto"` (default) probes cascade availability at ENTER time — so a key
+   *  saved in Settings takes effect on the next conversation, no reload. */
+  engine?: ConversationEngineKind | "auto";
   /** Runtime context stamped on cascade voice turns (active tab, project,
    *  models). Required for the cascade engine to dispatch tasks. */
   getConvoContext?: () => VoiceConvoContext;
@@ -87,7 +88,12 @@ export function useVoiceConversation(
     getContext: options.getConvoContext ?? (() => ({})),
   });
   const [fellBack, setFellBack] = useState(false);
-  const usingCascade = options.engine === "cascade" && !fellBack;
+  // Which pipeline the CURRENT (or most recent) session runs on. "auto"
+  // resolves here at enter time via a live availability probe.
+  const [resolvedEngine, setResolvedEngine] = useState<ConversationEngineKind>(
+    "lfm2",
+  );
+  const usingCascade = resolvedEngine === "cascade" && !fellBack;
 
   // A dead cascade session (error while idle-but-active: failed start or
   // exhausted mid-session reconnects) hands off to the local loop when the
@@ -104,6 +110,9 @@ export function useVoiceConversation(
   useEffect(() => {
     if (!shouldFallBack) return;
     cascadeExit();
+    // One-shot engine handoff reacting to the cascade's error state — the
+    // set is the transition itself, not a resync loop.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setFellBack(true);
     lfm2Enter();
     void speakVoice(
@@ -112,8 +121,39 @@ export function useVoiceConversation(
   }, [shouldFallBack, cascadeExit, lfm2Enter]);
 
   const controller = usingCascade ? cascade : lfm2;
+  const cascadeEnter = cascade.enter;
   return {
     ...controller,
+    enter: () => {
+      const configured = options.engine ?? "auto";
+      if (configured === "cascade") {
+        setFellBack(false);
+        setResolvedEngine("cascade");
+        cascadeEnter();
+        return;
+      }
+      if (configured === "lfm2") {
+        setResolvedEngine("lfm2");
+        lfm2Enter();
+        return;
+      }
+      // Auto: probe availability NOW, so keys/models added since boot count.
+      void voiceConvoStatus()
+        .then((status) => {
+          if (status.available) {
+            setFellBack(false);
+            setResolvedEngine("cascade");
+            cascadeEnter();
+          } else {
+            setResolvedEngine("lfm2");
+            lfm2Enter();
+          }
+        })
+        .catch(() => {
+          setResolvedEngine("lfm2");
+          lfm2Enter();
+        });
+    },
     exit: () => {
       controller.exit();
       // The next session gets a fresh shot at the cascade.

--- a/src/hooks/useVoiceConversation.ts
+++ b/src/hooks/useVoiceConversation.ts
@@ -14,6 +14,7 @@ import { LFM2_VOICE_PROVIDER_ID, capSpokenText } from "../utils/voice";
 import {
   useCascadeConversation,
   type VoiceConvoContext,
+  type VoiceTaskActivity,
 } from "./useCascadeConversation";
 
 /** A full turn of the LFM2-Audio conversation loop:
@@ -47,6 +48,9 @@ export interface UseVoiceConversationOptions {
   /** Runtime context stamped on cascade voice turns (active tab, project,
    *  models). Required for the cascade engine to dispatch tasks. */
   getConvoContext?: () => VoiceConvoContext;
+  /** Live activity of a dispatched task tab, polled for spoken progress
+   *  updates while the work agent runs (cascade engine). */
+  getTaskActivity?: (tabId: string) => VoiceTaskActivity | null;
   /** When true (engine came from "auto"), a cascade session that dies —
    *  failed start or exhausted reconnects — hands the conversation to the
    *  local LFM2 loop instead of stranding the user with an error. */
@@ -86,6 +90,9 @@ export function useVoiceConversation(
   const lfm2 = useLfm2Conversation(options);
   const cascade = useCascadeConversation({
     getContext: options.getConvoContext ?? (() => ({})),
+    ...(options.getTaskActivity
+      ? { getTaskActivity: options.getTaskActivity }
+      : {}),
   });
   const [fellBack, setFellBack] = useState(false);
   // Which pipeline the CURRENT (or most recent) session runs on. "auto"

--- a/src/hooks/useVoiceConversation.ts
+++ b/src/hooks/useVoiceConversation.ts
@@ -100,6 +100,10 @@ export function useVoiceConversation(
   const [resolvedEngine, setResolvedEngine] = useState<ConversationEngineKind>(
     "lfm2",
   );
+  // Invalidates in-flight "auto" probes: bumped on every enter() and exit()
+  // so a voiceConvoStatus() that resolves after the user left (or re-entered)
+  // can't re-activate a conversation they already ended.
+  const enterAttemptRef = useRef(0);
   const usingCascade = resolvedEngine === "cascade" && !fellBack;
 
   // A dead cascade session (error while idle-but-active: failed start or
@@ -132,6 +136,7 @@ export function useVoiceConversation(
   return {
     ...controller,
     enter: () => {
+      const attempt = ++enterAttemptRef.current;
       const configured = options.engine ?? "auto";
       if (configured === "cascade") {
         setFellBack(false);
@@ -145,8 +150,11 @@ export function useVoiceConversation(
         return;
       }
       // Auto: probe availability NOW, so keys/models added since boot count.
+      // The attempt token gates the resolution — an exit() (or re-enter)
+      // while the probe is in flight makes this resolution a no-op.
       void voiceConvoStatus()
         .then((status) => {
+          if (attempt !== enterAttemptRef.current) return;
           if (status.available) {
             setFellBack(false);
             setResolvedEngine("cascade");
@@ -157,11 +165,13 @@ export function useVoiceConversation(
           }
         })
         .catch(() => {
+          if (attempt !== enterAttemptRef.current) return;
           setResolvedEngine("lfm2");
           lfm2Enter();
         });
     },
     exit: () => {
+      enterAttemptRef.current += 1;
       controller.exit();
       // The next session gets a fresh shot at the cascade.
       setFellBack(false);

--- a/src/services/voiceConvo.ts
+++ b/src/services/voiceConvo.ts
@@ -9,8 +9,12 @@ export interface VoiceConvoStatus {
     | "user-speaking"
     | "awaiting-brain"
     | "speaking";
+  /** Resolved provider per stage (what a conversation would actually use). */
   sttProvider: string;
   ttsProvider: string;
+  /** Why a stage can't run, when it can't. */
+  sttError: string | null;
+  ttsError: string | null;
   deepgramKeyPresent: boolean;
   cartesiaKeyPresent: boolean;
   lastError: string | null;

--- a/src/services/voiceConvo.ts
+++ b/src/services/voiceConvo.ts
@@ -44,6 +44,27 @@ export function forceConvoEndTurn(): Promise<void> {
   return invoke("voice_convo_force_end_turn");
 }
 
+export interface VoiceConvoProviderTest {
+  deepgramOk: boolean;
+  deepgramError: string | null;
+  cartesiaOk: boolean;
+  cartesiaError: string | null;
+}
+
+/** Prove each cascade provider key opens a real session (connect + close). */
+export function testConvoProviders(): Promise<VoiceConvoProviderTest> {
+  return invoke("voice_convo_test_providers");
+}
+
+export interface CartesiaVoice {
+  id: string;
+  name: string;
+}
+
+export function listConvoVoices(): Promise<CartesiaVoice[]> {
+  return invoke("voice_convo_list_voices");
+}
+
 /** Fire-and-forget a voice-brain message to the global bridge (same
  *  `agent_command` path useDevshell uses for devshell_event). Voice types are
  *  not tab-scoped in the Rust router, so these always reach the global

--- a/src/services/voiceConvo.ts
+++ b/src/services/voiceConvo.ts
@@ -1,0 +1,59 @@
+import { invoke } from "@tauri-apps/api/core";
+
+/** Mirrors `VoiceConvoStatus` in src-tauri/src/commands/voice_convo.rs. */
+export interface VoiceConvoStatus {
+  available: boolean;
+  state:
+    | "idle"
+    | "listening"
+    | "user-speaking"
+    | "awaiting-brain"
+    | "speaking";
+  sttProvider: string;
+  ttsProvider: string;
+  deepgramKeyPresent: boolean;
+  cartesiaKeyPresent: boolean;
+  lastError: string | null;
+}
+
+export function voiceConvoStatus(): Promise<VoiceConvoStatus> {
+  return invoke("voice_convo_status");
+}
+
+export function startVoiceConvo(): Promise<void> {
+  return invoke("voice_convo_start");
+}
+
+export function stopVoiceConvo(): Promise<void> {
+  return invoke("voice_convo_stop");
+}
+
+export function speakConvoChunk(text: string): Promise<void> {
+  return invoke("voice_convo_speak_chunk", { text });
+}
+
+export function endConvoSpeech(): Promise<void> {
+  return invoke("voice_convo_speak_end");
+}
+
+export function cancelConvoSpeech(): Promise<void> {
+  return invoke("voice_convo_cancel_speech");
+}
+
+export function forceConvoEndTurn(): Promise<void> {
+  return invoke("voice_convo_force_end_turn");
+}
+
+/** Fire-and-forget a voice-brain message to the global bridge (same
+ *  `agent_command` path useDevshell uses for devshell_event). Voice types are
+ *  not tab-scoped in the Rust router, so these always reach the global
+ *  bridge; tab references ride inside the payload as activeTabId/taskTabId. */
+export function sendVoiceBridgeMessage(
+  payload: Record<string, unknown>,
+): void {
+  void invoke("agent_command", { payload: JSON.stringify(payload) }).catch(
+    () => {
+      /* agent not booted yet — the conversation surfaces its own errors */
+    },
+  );
+}

--- a/src/state/sessionUiSnapshot.test.ts
+++ b/src/state/sessionUiSnapshot.test.ts
@@ -264,6 +264,7 @@ describe("sessionUiSnapshot", () => {
     );
 
     expect(parsed?.tabs.map((tab) => tab.id)).toEqual([
+      "state-root",
       "managed",
       "managed-root",
       "managed-worktree",
@@ -272,8 +273,28 @@ describe("sessionUiSnapshot", () => {
     expect(parsed?.activeTabId).toBe("managed");
   });
 
+  it("keeps live sessions rooted at the exact .aethon state dir", () => {
+    // `~/.aethon` (exactly) is the bridge's fallback cwd for tabs opened
+    // with no active project. Excluding it made every webview reload close
+    // those sessions — only legacy project MIRRORS under it are junk.
+    saveSessionUiSnapshot({
+      tabs: [
+        {
+          ...makeEmptyTab("no-project", "No Project"),
+          cwd: "/Users/jamesbrink/.aethon",
+          messages: [{ role: "user", text: "hello" }],
+        },
+      ],
+      activeTabId: "no-project",
+    });
+
+    const loaded = loadSessionUiSnapshot();
+    expect(loaded?.tabs.map((tab) => tab.id)).toEqual(["no-project"]);
+    expect(loaded?.activeTabId).toBe("no-project");
+  });
+
   it("does not treat project-local .aethon folders as legacy app state", () => {
-    expect(isLegacyAethonStateCwd("/Users/jamesbrink/.aethon")).toBe(true);
+    expect(isLegacyAethonStateCwd("/Users/jamesbrink/.aethon")).toBe(false);
     expect(isLegacyAethonStateCwd("/home/james/.aethon/aethon/old")).toBe(true);
     expect(isLegacyAethonStateCwd("/Users/jamesbrink/.aethon/projects")).toBe(
       false,

--- a/src/state/sessionUiSnapshot.ts
+++ b/src/state/sessionUiSnapshot.ts
@@ -122,13 +122,17 @@ export function isLegacyAethonStateCwd(cwd: string): boolean {
     );
   if (!match) return false;
   const after = normalized.slice(match[1].length);
+  // Only legacy project MIRRORS under the state dir are junk
+  // (`~/.aethon/<old-mirror>/...`). The exact `~/.aethon` root is the
+  // bridge's fallback cwd for tabs opened with no active project — those
+  // are live, current sessions; dropping them made every webview reload
+  // close any project-less tab the user was working in.
   return (
-    after === "" ||
-    (after.startsWith("/") &&
-      after !== "/projects" &&
-      !after.startsWith("/projects/") &&
-      after !== "/worktrees" &&
-      !after.startsWith("/worktrees/"))
+    after.startsWith("/") &&
+    after !== "/projects" &&
+    !after.startsWith("/projects/") &&
+    after !== "/worktrees" &&
+    !after.startsWith("/worktrees/")
   );
 }
 

--- a/src/styles/chrome/base.css
+++ b/src/styles/chrome/base.css
@@ -358,4 +358,3 @@ body {
 .a2ui-image img {
   max-width: 100%;
 }
-

--- a/src/styles/chrome/composer.css
+++ b/src/styles/chrome/composer.css
@@ -204,4 +204,3 @@
   background: color-mix(in oklab, var(--accent) 16%, transparent);
   color: var(--text);
 }
-

--- a/src/styles/chrome/dashboard.css
+++ b/src/styles/chrome/dashboard.css
@@ -1182,4 +1182,3 @@ button.a2ui-gh-stat:hover {
   opacity: 0.4;
   cursor: not-allowed;
 }
-

--- a/src/styles/chrome/editor.css
+++ b/src/styles/chrome/editor.css
@@ -438,4 +438,3 @@
 .ae-share-badge[data-mode="read-write-trusted"] {
   color: #c5494a;
 }
-

--- a/src/styles/chrome/header.css
+++ b/src/styles/chrome/header.css
@@ -329,4 +329,3 @@
   font-style: italic;
   text-align: center;
 }
-

--- a/src/styles/chrome/layout.css
+++ b/src/styles/chrome/layout.css
@@ -65,4 +65,3 @@ body.ae-resizing-composer .a2ui-layout {
      above; the handle sits over the top edge. */
   border-top: 1px solid var(--border);
 }
-

--- a/src/styles/chrome/overlays.css
+++ b/src/styles/chrome/overlays.css
@@ -957,4 +957,3 @@
   border-radius: 4px;
   border: 1px solid var(--border);
 }
-

--- a/src/styles/chrome/overlays.css
+++ b/src/styles/chrome/overlays.css
@@ -13,19 +13,84 @@
   align-items: center;
   justify-content: center;
   z-index: var(--z-modal, 1200);
+  animation: ae-settings-scrim-in 150ms var(--ease-out, ease-out);
 }
 .ae-settings-panel {
   background: var(--modal-bg, var(--bg-elev));
   border: 1px solid var(--modal-border, var(--border));
   border-radius: var(--radius-lg, 12px);
-  width: min(860px, 94vw);
-  max-height: 85vh;
+  width: min(1180px, 94vw);
+  height: min(820px, 88vh);
   display: flex;
   flex-direction: column;
   box-shadow:
     var(--modal-shadow, 0 24px 64px rgba(0, 0, 0, 0.45)),
     var(--inner-highlight, none);
   font-family: ui-sans-serif, system-ui, sans-serif;
+  animation: ae-settings-panel-in 180ms var(--ease-out, ease-out);
+}
+@keyframes ae-settings-scrim-in {
+  from {
+    opacity: 0;
+  }
+}
+@keyframes ae-settings-panel-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.985);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .ae-settings-overlay,
+  .ae-settings-panel {
+    animation: none;
+  }
+}
+/* Nav rail + content pane. The rail sits on the base surface (one layer
+   below the panel) so the content pane reads as the lit working area. */
+.ae-settings-layout {
+  display: flex;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+.ae-settings-nav {
+  flex: 0 0 190px;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  padding: 14px 10px;
+  border-right: 1px solid var(--border);
+  background: var(--bg, transparent);
+  border-radius: 0 0 0 var(--radius-lg, 12px);
+  overflow-y: auto;
+}
+.ae-settings-nav-item {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  padding: 6px 10px;
+  text-align: left;
+  font: inherit;
+  font-size: 0.9rem;
+  color: var(--text-dim);
+  cursor: pointer;
+  transition:
+    background var(--motion-fast, 120ms) var(--ease-out, ease-out),
+    color var(--motion-fast, 120ms) var(--ease-out, ease-out);
+}
+.ae-settings-nav-item:hover {
+  color: var(--text);
+  background: var(--bg-input, rgba(127, 127, 127, 0.12));
+}
+.ae-settings-nav-item:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+.ae-settings-nav-item--active {
+  color: var(--text);
+  font-weight: 600;
+  background: var(--bg-input, rgba(127, 127, 127, 0.14));
 }
 .ae-settings-header {
   display: flex;
@@ -67,16 +132,20 @@
   color: var(--text);
 }
 .ae-settings-body {
-  padding: 16px 20px;
+  padding: 20px 28px 28px;
   overflow-y: auto;
   overscroll-behavior: none;
   flex: 1 1 auto;
 }
 .ae-settings-section {
-  margin-bottom: 22px;
+  margin-bottom: 30px;
+  /* Anchor scrolling (nav rail + focusSection) lands with breathing room. */
+  scroll-margin-top: 12px;
 }
 .ae-settings-section-title {
-  margin: 0 0 8px 0;
+  margin: 0 0 10px 0;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--border);
   font-size: 0.85rem;
   text-transform: uppercase;
   letter-spacing: 0.06em;
@@ -90,6 +159,18 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
+}
+/* One shared control column so field rows read as a grid: text-like
+   controls all end on the same right edge; numbers stay compact. */
+.ae-settings-field-control select.ae-settings-input,
+.ae-settings-field-control input.ae-settings-input[type="text"],
+.ae-settings-field-control input.ae-settings-input[type="password"] {
+  width: 320px;
+  box-sizing: border-box;
+}
+.ae-settings-field-control input.ae-settings-input[type="number"] {
+  width: 110px;
+  min-width: 0;
 }
 
 /* Extensions list — one row per extension with name + provenance + a
@@ -180,6 +261,38 @@
   color: var(--text-dim);
   font-size: 0.88rem;
   margin: 0 0 8px 0;
+}
+/* Settings → Voice → Conversation subsection. Key rows keep input +
+   buttons on one line ending at the shared control column's right edge. */
+.ae-voice-conversation-settings {
+  display: flex;
+  flex-direction: column;
+  gap: 10px; /* same rhythm as .ae-settings-section-body */
+}
+.ae-voice-conversation-settings .ae-settings-subhead {
+  margin: 12px 0 0;
+  font-size: 0.95rem;
+  color: var(--text);
+}
+.ae-voice-conversation-settings .ae-settings-note {
+  margin: 0;
+}
+.ae-voice-key-row {
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+}
+.ae-voice-conversation-settings
+  .ae-voice-key-row
+  input.ae-settings-input[type="password"],
+.ae-voice-conversation-settings
+  .ae-voice-key-row
+  input.ae-settings-input[type="text"] {
+  width: 200px;
+  min-width: 0;
+}
+.ae-voice-key-row .ae-settings-secondary {
+  white-space: nowrap;
 }
 /* Settings model picker — flex row carrying either the dropdown or the
    free-text override input plus a small toggle to swap modes. */
@@ -563,9 +676,16 @@
   }
 }
 
+@media (max-width: 900px) {
+  .ae-settings-nav {
+    display: none;
+  }
+}
 @media (max-width: 720px) {
   .ae-settings-panel {
     width: min(96vw, 860px);
+    height: auto;
+    max-height: 88vh;
   }
   .ae-settings-field {
     align-items: stretch;
@@ -575,7 +695,10 @@
   .ae-settings-field-control,
   .ae-settings-input,
   .ae-settings-model-picker,
-  .ae-settings-model-picker .ae-settings-input {
+  .ae-settings-model-picker .ae-settings-input,
+  .ae-settings-field-control select.ae-settings-input,
+  .ae-settings-field-control input.ae-settings-input[type="text"],
+  .ae-settings-field-control input.ae-settings-input[type="password"] {
     width: 100%;
     min-width: 0;
   }

--- a/src/styles/chrome/sidebar.css
+++ b/src/styles/chrome/sidebar.css
@@ -1671,4 +1671,3 @@ body.ae-resizing-sidebar .a2ui-layout {
 .ae-file-tree-context-menu {
   min-width: 220px;
 }
-

--- a/src/styles/chrome/terminal.css
+++ b/src/styles/chrome/terminal.css
@@ -688,4 +688,3 @@ body.ae-resizing-terminal * {
   font-size: 0.9em;
   color: var(--text);
 }
-

--- a/src/styles/chrome/transitions.css
+++ b/src/styles/chrome/transitions.css
@@ -42,4 +42,3 @@
     transition: none;
   }
 }
-

--- a/src/styles/mobile.css
+++ b/src/styles/mobile.css
@@ -18,7 +18,8 @@
   justify-content: center;
   gap: 16px;
   min-height: 100dvh;
-  padding: calc(var(--ae-safe-top) + 24px) 20px calc(var(--ae-safe-bottom) + 24px);
+  padding: calc(var(--ae-safe-top) + 24px) 20px
+    calc(var(--ae-safe-bottom) + 24px);
   background: var(--bg);
   color: var(--text);
   text-align: center;

--- a/src/utils/speechChunker.test.ts
+++ b/src/utils/speechChunker.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  SPEECH_SOURCE_CAP,
+  createSpeechChunker,
+  stripForSpeechSource,
+} from "./speechChunker";
+
+describe("createSpeechChunker", () => {
+  it("holds short fragments until a clause boundary past the minimum", () => {
+    const chunker = createSpeechChunker();
+    expect(chunker.push("Sure, I'll get started")).toEqual([]);
+    expect(
+      chunker.push(" on that right away. It should only take a moment"),
+    ).toEqual(["Sure, I'll get started on that right away."]);
+    expect(chunker.flush()).toBe("It should only take a moment");
+  });
+
+  it("emits the largest ready clause run, not one clause at a time", () => {
+    const chunker = createSpeechChunker();
+    const chunks = chunker.push(
+      "First sentence here, fairly long. Second one lands too! And a tail",
+    );
+    expect(chunks).toEqual([
+      "First sentence here, fairly long. Second one lands too!",
+    ]);
+    expect(chunker.flush()).toBe("And a tail");
+  });
+
+  it("does not split on decimals", () => {
+    const chunker = createSpeechChunker();
+    const chunks = chunker.push(
+      "The version is now 3.5 which everybody wanted since forever, right",
+    );
+    expect(chunks).toEqual([]);
+    expect(chunker.flush()).toContain("3.5");
+  });
+
+  it("reset drops the buffer", () => {
+    const chunker = createSpeechChunker();
+    chunker.push("something partial");
+    chunker.reset();
+    expect(chunker.flush()).toBe("");
+  });
+});
+
+describe("stripForSpeechSource", () => {
+  it("removes fenced code and caps length", () => {
+    const text = `Done.\n\`\`\`ts\nconst x = 1;\n\`\`\`\nAll green.`;
+    const out = stripForSpeechSource(text);
+    expect(out).not.toContain("const x");
+    expect(out).toContain("Done.");
+    expect(out).toContain("All green.");
+    expect(stripForSpeechSource("x".repeat(10_000))).toHaveLength(
+      SPEECH_SOURCE_CAP,
+    );
+  });
+});

--- a/src/utils/speechChunker.ts
+++ b/src/utils/speechChunker.ts
@@ -1,0 +1,78 @@
+/** Turn a streaming text delta into clause-sized TTS chunks.
+ *
+ *  Feeding a TTS websocket word-by-word produces choppy prosody; waiting for
+ *  the whole reply wastes the streaming latency win. Splitting on clause
+ *  punctuation past a minimum length is the middle ground: the first chunk
+ *  reaches the synthesizer as soon as the first sentence lands.
+ */
+
+/** Don't emit a chunk shorter than this unless flushing — very short
+ *  fragments synthesize with poor rhythm. */
+const MIN_CHUNK_CHARS = 40;
+
+const CLAUSE_BOUNDARY = /[.!?;:]/;
+
+export interface SpeechChunker {
+  /** Feed a streamed delta; returns any chunks that became ready. */
+  push(delta: string): string[];
+  /** Return whatever is buffered (possibly empty) and reset. */
+  flush(): string;
+  /** Drop the buffer (barge-in / cancel). */
+  reset(): void;
+}
+
+export function createSpeechChunker(): SpeechChunker {
+  let buffer = "";
+  return {
+    push(delta: string): string[] {
+      buffer += delta;
+      const chunks: string[] = [];
+      for (;;) {
+        const boundary = findBoundary(buffer);
+        if (boundary === -1) break;
+        chunks.push(buffer.slice(0, boundary + 1));
+        buffer = buffer.slice(boundary + 1);
+      }
+      return chunks;
+    },
+    flush(): string {
+      const rest = buffer.trim();
+      buffer = "";
+      return rest;
+    },
+    reset(): void {
+      buffer = "";
+    },
+  };
+}
+
+/** Last clause boundary at or beyond the minimum chunk size, so we emit the
+ *  largest ready clause run instead of one clause at a time. */
+function findBoundary(text: string): number {
+  for (let index = text.length - 1; index >= MIN_CHUNK_CHARS - 1; index -= 1) {
+    const char = text[index] ?? "";
+    if (!CLAUSE_BOUNDARY.test(char)) continue;
+    // "3.5" / "v1.2" style decimals are not clause boundaries.
+    if (
+      char === "." &&
+      /\d/.test(text[index - 1] ?? "") &&
+      /\d/.test(text[index + 1] ?? "")
+    ) {
+      continue;
+    }
+    return index;
+  }
+  return -1;
+}
+
+/** Ceiling on work-agent text forwarded to the voice brain as summary source
+ *  material (the bridge re-checks). */
+export const SPEECH_SOURCE_CAP = 4_000;
+
+/** Prepare work-agent prose for the brain: drop fenced code blocks (never
+ *  speakable) and cap the length. */
+export function stripForSpeechSource(text: string): string {
+  return text
+    .replace(/```[\s\S]*?(```|$)/g, " (code omitted) ")
+    .slice(0, SPEECH_SOURCE_CAP);
+}

--- a/src/utils/voiceBrainEvents.ts
+++ b/src/utils/voiceBrainEvents.ts
@@ -1,0 +1,51 @@
+/** Window-level signals for voice-brain bridge messages, decoupling the
+ *  bridge handler (which sees `voice_brain_*` messages) from the cascade
+ *  conversation hook — the same pattern as agentTurnEvents.ts. */
+
+export const VOICE_BRAIN_DELTA_EVENT = "aethon://voice-brain-delta";
+export const VOICE_BRAIN_END_EVENT = "aethon://voice-brain-end";
+export const VOICE_BRAIN_ERROR_EVENT = "aethon://voice-brain-error";
+
+export interface VoiceBrainDeltaDetail {
+  text: string;
+}
+
+export interface VoiceBrainEndDetail {
+  text: string;
+  dispatched?: { tabId: string; label: string };
+}
+
+export interface VoiceBrainErrorDetail {
+  message: string;
+}
+
+function emit<T>(name: string, detail: T): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent<T>(name, { detail }));
+}
+
+export const emitVoiceBrainDelta = (detail: VoiceBrainDeltaDetail): void =>
+  emit(VOICE_BRAIN_DELTA_EVENT, detail);
+export const emitVoiceBrainEnd = (detail: VoiceBrainEndDetail): void =>
+  emit(VOICE_BRAIN_END_EVENT, detail);
+export const emitVoiceBrainError = (detail: VoiceBrainErrorDetail): void =>
+  emit(VOICE_BRAIN_ERROR_EVENT, detail);
+
+function on<T>(name: string, listener: (detail: T) => void): () => void {
+  if (typeof window === "undefined") return () => {};
+  const handler = (event: Event) => {
+    listener((event as CustomEvent<T>).detail);
+  };
+  window.addEventListener(name, handler);
+  return () => window.removeEventListener(name, handler);
+}
+
+export const onVoiceBrainDelta = (
+  listener: (detail: VoiceBrainDeltaDetail) => void,
+): (() => void) => on(VOICE_BRAIN_DELTA_EVENT, listener);
+export const onVoiceBrainEnd = (
+  listener: (detail: VoiceBrainEndDetail) => void,
+): (() => void) => on(VOICE_BRAIN_END_EVENT, listener);
+export const onVoiceBrainError = (
+  listener: (detail: VoiceBrainErrorDetail) => void,
+): (() => void) => on(VOICE_BRAIN_ERROR_EVENT, listener);


### PR DESCRIPTION
## Summary
- Cascade voice pipeline: streaming mic → Deepgram Flux STT (semantic turn detection) → VoiceBrain pi session on the global bridge → clause-chunked Cartesia streaming TTS, with half-duplex barge-in (pre-roll replay + semantic confirm), reconnect budgets, and per-stage "auto" provider resolution falling back to local Whisper/LFM2
- VoiceBrain coordinates the work agent: dispatch_task / send_followup / check_status tools, dispatch-first (never asks questions), spoken progress updates while tasks run, summarized completion announcements deferred past in-flight turns
- Deepgram Nova-3 batch dictation provider (mic button / hold-to-talk via cloud)
- Settings overlay redesign: wider nav-rail layout, scrollspy, restructured Voice section (Dictation / Conversation / Spoken replies), brain-model select fed from the app model registry, write-only API key fields that bypass shared settings state
- Session-persistence fixes: exact ~/.aethon cwd tabs (the bridge's no-project fallback) persist and replay across reloads; graceful bridge reloads no longer misclassify as crashes (pending_reloads mark backs up the _reload_done sentinel)
- Flux keepalive protocol fix (silence frames instead of the v1 KeepAlive message that tore the socket)

## Review
- codex round 1: REQUEST_CHANGES (key handling, Cartesia format, task-event supersede) — all fixed in 03c231a
- codex round 2: APPROVE (all three RESOLVED, no new blocker/major findings)

## Testing
- check gate green: clippy, tsc -b, ESLint 0/0, 566 Rust tests, 2999 vitest
- Live-verified: brain round-trip, Deepgram Flux conversation (post-keepalive fix), settings UAT via debug-eval; Cartesia ws path is doc-derived, pending a live key