### PR TITLE
feat(mobile): QR + mDNS pairing UX and signed iPhone deploys

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,8 @@ helpers (defined in `flake.nix`):
 | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
 | `dev`                  | `scripts/dev.sh` → `cargo tauri dev` with port auto-increment                                                                       |
 | `ios-dev`              | `scripts/ios.sh dev` → iOS companion in the Simulator (needs Xcode + CocoaPods; see `docs/mobile.md`)                               |
-| `ios-build`            | `scripts/ios.sh build` — pass `--debug --target aarch64-sim` for an unsigned simulator .app                                         |
+| `ios-build`            | `scripts/ios.sh build` — no args = unsigned simulator .app                                                                          |
+| `ios-device`           | `scripts/ios.sh device` — signed build installed + launched on the connected iPhone via devicectl                                   |
 | `docs`                 | `vitepress dev` from `website/` bound to `0.0.0.0` (LAN-reachable; :5173)                                                           |
 | `build-app`            | `cargo tauri build` — release bundle                                                                                                |
 | `check`                | CI gate: clippy + tsc + ESLint + cargo test + vitest                                                                                |

--- a/apps/mobile/src-tauri/Cargo.lock
+++ b/apps/mobile/src-tauri/Cargo.lock
@@ -13,12 +13,14 @@ name = "aethon-mobile"
 version = "0.11.2"
 dependencies = [
  "futures-util",
+ "libc",
  "rustls",
  "serde",
  "serde_json",
  "sha2",
  "tauri",
  "tauri-build",
+ "tauri-plugin-barcode-scanner",
  "tauri-plugin-notification",
  "tauri-plugin-opener",
  "tokio",
@@ -3630,6 +3632,20 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-barcode-scanner"
+version = "2.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3b68f0e3782b61a6e16a67380be40226e2b7233f3e36dadf6e5d03f07d2e7b3"
+dependencies = [
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/apps/mobile/src-tauri/Cargo.toml
+++ b/apps/mobile/src-tauri/Cargo.toml
@@ -25,13 +25,20 @@ tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "macros", "net", "time"] }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "macros", "net", "time", "io-util"] }
 tokio-tungstenite = { version = "0.24", default-features = false, features = ["connect", "rustls-tls-native-roots"] }
 tokio-rustls = { version = "0.26", default-features = false, features = ["ring"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 futures-util = "0.3"
 sha2 = "0.10"
 tracing = "0.1"
+# poll() over DNSServiceRefSockFD in discovery.rs.
+libc = "0.2"
+
+# The camera scanner only exists on the mobile OSes; keeping it
+# target-gated lets host-side `cargo test` build the rlib without it.
+[target.'cfg(any(target_os = "android", target_os = "ios"))'.dependencies]
+tauri-plugin-barcode-scanner = "2"
 
 [features]
 # Matches Tauri's mobile detection so `#[cfg(mobile)]` / the mobile

--- a/apps/mobile/src-tauri/capabilities/mobile.json
+++ b/apps/mobile/src-tauri/capabilities/mobile.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "../gen/schemas/mobile-schema.json",
+  "identifier": "mobile-scanner",
+  "description": "Camera QR scanning for pairing — the plugin only exists on the mobile OSes, so these permissions are platform-scoped",
+  "windows": ["main"],
+  "platforms": ["iOS", "android"],
+  "permissions": [
+    "barcode-scanner:allow-scan",
+    "barcode-scanner:allow-cancel",
+    "barcode-scanner:allow-check-permissions",
+    "barcode-scanner:allow-request-permissions",
+    "barcode-scanner:allow-open-app-settings"
+  ]
+}

--- a/apps/mobile/src-tauri/gen/apple/aethon-mobile.xcodeproj/project.pbxproj
+++ b/apps/mobile/src-tauri/gen/apple/aethon-mobile.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1237749315CA2709E2C15046 /* libapp.a in Resources */ = {isa = PBXBuildFile; fileRef = D53FFF5F235E74CF0801DB4E /* libapp.a */; };
 		37A8D71C1C431310342E569E /* MetalKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 39692A6AC24FA94B0A9BD4C5 /* MetalKit.framework */; };
 		63DB5DF3D32CB498A54D3303 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1A73447EB793F607B5417319 /* WebKit.framework */; };
 		7C5F2103F737F13723F80BD3 /* assets in Resources */ = {isa = PBXBuildFile; fileRef = 0F77EE25BE7798FD0EC6F92A /* assets */; };
@@ -26,12 +27,14 @@
 		0F77EE25BE7798FD0EC6F92A /* assets */ = {isa = PBXFileReference; lastKnownFileType = folder; path = assets; sourceTree = SOURCE_ROOT; };
 		1191C5E2B87FD464ABADFEBB /* main.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = main.mm; sourceTree = "<group>"; };
 		11F00053E7A8E5AAE034777A /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
+		146F7E5113139FBB8DD00F4D /* discovery.rs */ = {isa = PBXFileReference; path = discovery.rs; sourceTree = "<group>"; };
 		1A73447EB793F607B5417319 /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
 		24AE62A9C645375B668F5AD6 /* aethon-mobile_iOS.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "aethon-mobile_iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		377F611CB02C87FCEC9BC910 /* lib.rs */ = {isa = PBXFileReference; path = lib.rs; sourceTree = "<group>"; };
 		39692A6AC24FA94B0A9BD4C5 /* MetalKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MetalKit.framework; path = System/Library/Frameworks/MetalKit.framework; sourceTree = SDKROOT; };
 		39AA94DE6FBB213D5568C157 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		46D9407A75C3C588818EBE01 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
+		47D99CAEB99B46007B67A368 /* pair.rs */ = {isa = PBXFileReference; path = pair.rs; sourceTree = "<group>"; };
 		55BAFF8E2FA7F78214D82FC4 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		7089A10ED575D3B89ED30289 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		71788F440E6BBD9A2C97D2B5 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
@@ -41,6 +44,7 @@
 		AB5960AA4D22B0CEB74581FE /* bindings.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = bindings.h; sourceTree = "<group>"; };
 		B104B88AD1F104009861E781 /* aethon-mobile_iOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "aethon-mobile_iOS.entitlements"; sourceTree = "<group>"; };
 		C1E360E95D28D267D5F4F8A7 /* gateway.rs */ = {isa = PBXFileReference; path = gateway.rs; sourceTree = "<group>"; };
+		D53FFF5F235E74CF0801DB4E /* libapp.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libapp.a; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -65,12 +69,22 @@
 		05C2E46B21154D7E9D56DD24 /* src */ = {
 			isa = PBXGroup;
 			children = (
+				146F7E5113139FBB8DD00F4D /* discovery.rs */,
 				C1E360E95D28D267D5F4F8A7 /* gateway.rs */,
 				377F611CB02C87FCEC9BC910 /* lib.rs */,
 				A26023B2DCB6B322290B0B1F /* main.rs */,
+				47D99CAEB99B46007B67A368 /* pair.rs */,
 			);
 			name = src;
 			path = ../../src;
+			sourceTree = "<group>";
+		};
+		39C0E972FC841D6D35B62102 /* debug */ = {
+			isa = PBXGroup;
+			children = (
+				D53FFF5F235E74CF0801DB4E /* libapp.a */,
+			);
+			path = debug;
 			sourceTree = "<group>";
 		};
 		40AEC3AFF215D09BC1691C4E /* Frameworks */ = {
@@ -99,6 +113,7 @@
 		773407E242805084F3EA059E /* Externals */ = {
 			isa = PBXGroup;
 			children = (
+				BC48334CA9C251DA44B901C1 /* arm64 */,
 			);
 			path = Externals;
 			sourceTree = "<group>";
@@ -119,6 +134,14 @@
 				C3C05F47DEA8004A5F406548 /* bindings */,
 			);
 			path = "aethon-mobile";
+			sourceTree = "<group>";
+		};
+		BC48334CA9C251DA44B901C1 /* arm64 */ = {
+			isa = PBXGroup;
+			children = (
+				39C0E972FC841D6D35B62102 /* debug */,
+			);
+			path = arm64;
 			sourceTree = "<group>";
 		};
 		C3C05F47DEA8004A5F406548 /* bindings */ = {
@@ -150,6 +173,13 @@
 				40AEC3AFF215D09BC1691C4E /* Frameworks */,
 				628F0157248BF10B5AD377B5 /* Products */,
 			);
+			sourceTree = "<group>";
+		};
+		"TEMP_C7148327-F498-4288-BA05-E74639376396" /* x86_64 */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = x86_64;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -184,6 +214,10 @@
 				BuildIndependentTargetsInParallel = YES;
 				LastUpgradeCheck = 1430;
 				TargetAttributes = {
+					FBFA6D7B260047944252265D = {
+						DevelopmentTeam = 28X9H69QGE;
+						ProvisioningStyle = Automatic;
+					};
 				};
 			};
 			buildConfigurationList = 0F66FB0923135880EA2D55DC /* Build configuration list for PBXProject "aethon-mobile" */;
@@ -213,6 +247,7 @@
 				95F0A648FCECD704CD4C75FB /* Assets.xcassets in Resources */,
 				C54B46DA53A166874A6602B9 /* LaunchScreen.storyboard in Resources */,
 				7C5F2103F737F13723F80BD3 /* assets in Resources */,
+				1237749315CA2709E2C15046 /* libapp.a in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -327,6 +362,8 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "aethon-mobile_iOS/aethon-mobile_iOS.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "28X9H69QGE";
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphoneos*]" = x86_64;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -358,6 +395,8 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "aethon-mobile_iOS/aethon-mobile_iOS.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "28X9H69QGE";
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphoneos*]" = x86_64;
 				FRAMEWORK_SEARCH_PATHS = (

--- a/apps/mobile/src-tauri/gen/apple/aethon-mobile.xcodeproj/xcshareddata/xcschemes/aethon-mobile_iOS.xcscheme
+++ b/apps/mobile/src-tauri/gen/apple/aethon-mobile.xcodeproj/xcshareddata/xcschemes/aethon-mobile_iOS.xcscheme
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1430"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -15,7 +16,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "FBFA6D7B260047944252265D"
-               BuildableName = "Aethon.app"
+               BuildableName = "aethon-mobile_iOS.app"
                BlueprintName = "aethon-mobile_iOS"
                ReferencedContainer = "container:aethon-mobile.xcodeproj">
             </BuildableReference>
@@ -26,16 +27,21 @@
       buildConfiguration = "debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "NO">
+      shouldUseLaunchSchemeArgsEnv = "NO"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "FBFA6D7B260047944252265D"
-            BuildableName = "Aethon.app"
+            BuildableName = "aethon-mobile_iOS.app"
             BlueprintName = "aethon-mobile_iOS"
             ReferencedContainer = "container:aethon-mobile.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <Testables>
+      </Testables>
+      <CommandLineArguments>
+      </CommandLineArguments>
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "RUST_BACKTRACE"
@@ -48,8 +54,6 @@
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
-      <Testables>
-      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "debug"
@@ -66,11 +70,13 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "FBFA6D7B260047944252265D"
-            BuildableName = "Aethon.app"
+            BuildableName = "aethon-mobile_iOS.app"
             BlueprintName = "aethon-mobile_iOS"
             ReferencedContainer = "container:aethon-mobile.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "RUST_BACKTRACE"
@@ -95,11 +101,13 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "FBFA6D7B260047944252265D"
-            BuildableName = "Aethon.app"
+            BuildableName = "aethon-mobile_iOS.app"
             BlueprintName = "aethon-mobile_iOS"
             ReferencedContainer = "container:aethon-mobile.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "RUST_BACKTRACE"

--- a/apps/mobile/src-tauri/gen/apple/project.yml
+++ b/apps/mobile/src-tauri/gen/apple/project.yml
@@ -12,6 +12,9 @@ settingGroups:
     base:
       PRODUCT_NAME: Aethon
       PRODUCT_BUNDLE_IDENTIFIER: com.utensils.aethon.mobile
+      # Signed device builds (ios-device). Simulator builds ignore it.
+      DEVELOPMENT_TEAM: 28X9H69QGE
+      CODE_SIGN_STYLE: Automatic
 targetTemplates:
   app:
     type: application

--- a/apps/mobile/src-tauri/src/discovery.rs
+++ b/apps/mobile/src-tauri/src/discovery.rs
@@ -69,10 +69,17 @@ fn parse_txt(bytes: &[u8]) -> Vec<(String, String)> {
 /// Build the wire shape from one resolved service. `None` when the TXT
 /// carries no fingerprint — without it the phone can't pin, so the
 /// entry is useless (and likely not an Aethon desktop at all).
+///
+/// `ipv4` comes from mDNS address resolution: connect by the concrete
+/// address whenever one was learned. Handing `<hostname>.local` to a
+/// plain `connect()` makes getaddrinfo walk a pile of link-local
+/// `fe80::` AAAA records first (observed live: 7 of them before any
+/// routable address), which eats the pairing timeout.
 fn desktop_from_resolved(
     hosttarget: &str,
     port: u16,
     txt: &[(String, String)],
+    ipv4: Option<std::net::Ipv4Addr>,
 ) -> Option<DiscoveredDesktop> {
     let get = |k: &str| {
         txt.iter()
@@ -93,10 +100,14 @@ fn desktop_from_resolved(
             n
         }
     };
+    let connect_host = match ipv4 {
+        Some(ip) => ip.to_string(),
+        None => hostname.clone(),
+    };
     Some(DiscoveredDesktop {
         id: format!("remote:{fingerprint}"),
         name,
-        host: format!("{hostname}:{port}"),
+        host: format!("{connect_host}:{port}"),
         hostname,
         port,
         fingerprint,
@@ -156,6 +167,20 @@ mod dnssd {
         context: *mut c_void,
     );
 
+    type GetAddrInfoReply = unsafe extern "C" fn(
+        sd_ref: DNSServiceRef,
+        flags: DNSServiceFlags,
+        interface_index: u32,
+        error: DNSServiceErrorType,
+        hostname: *const c_char,
+        address: *const libc::sockaddr,
+        ttl: u32,
+        context: *mut c_void,
+    );
+
+    /// kDNSServiceProtocol_IPv4
+    const PROTOCOL_IPV4: u32 = 0x01;
+
     unsafe extern "C" {
         fn DNSServiceBrowse(
             sd_ref: *mut DNSServiceRef,
@@ -176,6 +201,15 @@ mod dnssd {
             callback: ResolveReply,
             context: *mut c_void,
         ) -> DNSServiceErrorType;
+        fn DNSServiceGetAddrInfo(
+            sd_ref: *mut DNSServiceRef,
+            flags: DNSServiceFlags,
+            interface_index: u32,
+            protocol: u32,
+            hostname: *const c_char,
+            callback: GetAddrInfoReply,
+            context: *mut c_void,
+        ) -> DNSServiceErrorType;
         fn DNSServiceRefSockFD(sd_ref: DNSServiceRef) -> i32;
         fn DNSServiceProcessResult(sd_ref: DNSServiceRef) -> DNSServiceErrorType;
         fn DNSServiceRefDeallocate(sd_ref: DNSServiceRef);
@@ -189,11 +223,27 @@ mod dnssd {
         interface_index: u32,
     }
 
-    /// One in-flight resolve; `done` flips inside the callback.
+    /// (hosttarget, port, txt) captured by a resolve callback.
+    type Resolved = (String, u16, Vec<(String, String)>);
+
+    /// One in-flight resolve; `done` flips inside the callback, and the
+    /// pump takes `resolved` to start the address lookup.
     struct ResolveSlot {
         service: DNSServiceRef,
         done: bool,
-        result: Option<DiscoveredDesktop>,
+        resolved: Option<Resolved>,
+    }
+
+    /// One in-flight IPv4 lookup for a resolved service; `done` flips
+    /// on the first routable address (more callbacks may follow — one
+    /// per interface — but one usable address is all connect needs).
+    struct AddrSlot {
+        service: DNSServiceRef,
+        done: bool,
+        hosttarget: String,
+        port: u16,
+        txt: Vec<(String, String)>,
+        ipv4: Option<std::net::Ipv4Addr>,
     }
 
     #[derive(Default)]
@@ -247,7 +297,35 @@ mod dnssd {
         } else {
             parse_txt(unsafe { std::slice::from_raw_parts(txt_record, txt_len as usize) })
         };
-        slot.result = desktop_from_resolved(&hosttarget, u16::from_be(port_be), &txt);
+        slot.resolved = Some((hosttarget.into_owned(), u16::from_be(port_be), txt));
+    }
+
+    unsafe extern "C" fn addr_reply(
+        _sd_ref: DNSServiceRef,
+        _flags: DNSServiceFlags,
+        _interface_index: u32,
+        error: DNSServiceErrorType,
+        _hostname: *const c_char,
+        address: *const libc::sockaddr,
+        _ttl: u32,
+        context: *mut c_void,
+    ) {
+        let slot = unsafe { &mut *(context as *mut AddrSlot) };
+        if error != 0 || address.is_null() {
+            return;
+        }
+        if i32::from(unsafe { (*address).sa_family }) != libc::AF_INET {
+            return;
+        }
+        let sin = unsafe { &*(address as *const libc::sockaddr_in) };
+        let ip = std::net::Ipv4Addr::from(u32::from_be(sin.sin_addr.s_addr));
+        // Loopback/link-local answers can't be dialed from another
+        // machine — keep waiting for a routable one.
+        if ip.is_loopback() || ip.is_link_local() || ip.is_unspecified() {
+            return;
+        }
+        slot.ipv4 = Some(ip);
+        slot.done = true;
     }
 
     pub fn scan(timeout: Duration) -> Result<Vec<DiscoveredDesktop>, String> {
@@ -271,8 +349,9 @@ mod dnssd {
         }
 
         // Slots are boxed so their addresses stay stable for the C
-        // callbacks while the Vec grows.
-        let mut slots: Vec<Box<ResolveSlot>> = Vec::new();
+        // callbacks while the Vecs grow.
+        let mut resolves: Vec<Box<ResolveSlot>> = Vec::new();
+        let mut addrs: Vec<Box<AddrSlot>> = Vec::new();
 
         loop {
             let remaining = deadline.saturating_duration_since(Instant::now());
@@ -285,7 +364,7 @@ mod dnssd {
                 let mut slot = Box::new(ResolveSlot {
                     service: std::ptr::null_mut(),
                     done: false,
-                    result: None,
+                    resolved: None,
                 });
                 let err = unsafe {
                     DNSServiceResolve(
@@ -300,26 +379,75 @@ mod dnssd {
                     )
                 };
                 if err == 0 {
-                    slots.push(slot);
+                    resolves.push(slot);
                 }
             }
 
-            // Poll the browse fd plus every unfinished resolve fd.
-            let mut fds: Vec<libc::pollfd> = Vec::with_capacity(1 + slots.len());
+            // Start IPv4 lookups for freshly resolved services.
+            for slot in resolves.iter_mut() {
+                let Some((hosttarget, port, txt)) = slot.resolved.take() else {
+                    continue;
+                };
+                let mut addr = Box::new(AddrSlot {
+                    service: std::ptr::null_mut(),
+                    done: false,
+                    hosttarget,
+                    port,
+                    txt,
+                    ipv4: None,
+                });
+                let Ok(host_c) = CString::new(addr.hosttarget.clone()) else {
+                    continue;
+                };
+                let err = unsafe {
+                    DNSServiceGetAddrInfo(
+                        &mut addr.service,
+                        0,
+                        0,
+                        PROTOCOL_IPV4,
+                        host_c.as_ptr(),
+                        addr_reply,
+                        (&mut *addr) as *mut AddrSlot as *mut c_void,
+                    )
+                };
+                if err != 0 {
+                    // No lookup ref to pump — finish with the hostname
+                    // fallback instead of dropping the desktop.
+                    addr.service = std::ptr::null_mut();
+                    addr.done = true;
+                }
+                addrs.push(addr);
+            }
+
+            // Poll the browse fd plus every unfinished resolve/addr fd.
+            let mut fds: Vec<libc::pollfd> = Vec::with_capacity(1 + resolves.len() + addrs.len());
             fds.push(libc::pollfd {
                 fd: unsafe { DNSServiceRefSockFD(browse) },
                 events: libc::POLLIN,
                 revents: 0,
             });
-            let live: Vec<usize> = slots
+            let live_resolves: Vec<usize> = resolves
                 .iter()
                 .enumerate()
                 .filter(|(_, s)| !s.done)
                 .map(|(i, _)| i)
                 .collect();
-            for &i in &live {
+            for &i in &live_resolves {
                 fds.push(libc::pollfd {
-                    fd: unsafe { DNSServiceRefSockFD(slots[i].service) },
+                    fd: unsafe { DNSServiceRefSockFD(resolves[i].service) },
+                    events: libc::POLLIN,
+                    revents: 0,
+                });
+            }
+            let live_addrs: Vec<usize> = addrs
+                .iter()
+                .enumerate()
+                .filter(|(_, s)| !s.done && !s.service.is_null())
+                .map(|(i, _)| i)
+                .collect();
+            for &i in &live_addrs {
+                fds.push(libc::pollfd {
+                    fd: unsafe { DNSServiceRefSockFD(addrs[i].service) },
                     events: libc::POLLIN,
                     revents: 0,
                 });
@@ -333,22 +461,45 @@ mod dnssd {
             if fds[0].revents & libc::POLLIN != 0 {
                 unsafe { DNSServiceProcessResult(browse) };
             }
-            for (pos, &i) in live.iter().enumerate() {
-                if fds[pos + 1].revents & libc::POLLIN != 0 {
-                    unsafe { DNSServiceProcessResult(slots[i].service) };
+            let mut pos = 1;
+            for &i in &live_resolves {
+                if fds[pos].revents & libc::POLLIN != 0 {
+                    unsafe { DNSServiceProcessResult(resolves[i].service) };
                 }
+                pos += 1;
+            }
+            for &i in &live_addrs {
+                if fds[pos].revents & libc::POLLIN != 0 {
+                    unsafe { DNSServiceProcessResult(addrs[i].service) };
+                }
+                pos += 1;
             }
         }
 
         unsafe { DNSServiceRefDeallocate(browse) };
-        let mut out: Vec<DiscoveredDesktop> = Vec::new();
-        for slot in slots {
+        for slot in &resolves {
             unsafe { DNSServiceRefDeallocate(slot.service) };
-            if let Some(desktop) = slot.result {
+        }
+        let mut out: Vec<DiscoveredDesktop> = Vec::new();
+        for slot in addrs {
+            if !slot.service.is_null() {
+                unsafe { DNSServiceRefDeallocate(slot.service) };
+            }
+            if let Some(desktop) =
+                desktop_from_resolved(&slot.hosttarget, slot.port, &slot.txt, slot.ipv4)
+            {
                 // Dedupe by fingerprint — one desktop can resolve on
-                // several interfaces.
-                if !out.iter().any(|d| d.fingerprint == desktop.fingerprint) {
-                    out.push(desktop);
+                // several interfaces; prefer an entry that got an IPv4.
+                match out
+                    .iter_mut()
+                    .find(|d| d.fingerprint == desktop.fingerprint)
+                {
+                    Some(existing) => {
+                        if slot.ipv4.is_some() && existing.host.starts_with(&existing.hostname) {
+                            *existing = desktop;
+                        }
+                    }
+                    None => out.push(desktop),
                 }
             }
         }
@@ -398,16 +549,50 @@ mod tests {
             ("fingerprint".to_string(), "ff".repeat(32)),
             ("version".to_string(), "1.0.0".to_string()),
         ];
-        let desktop = desktop_from_resolved("halcyon.local.", 48213, &txt).unwrap();
+        let desktop = desktop_from_resolved("halcyon.local.", 48213, &txt, None).unwrap();
         assert_eq!(desktop.hostname, "halcyon.local");
+        // No resolved address → hostname fallback for connect.
         assert_eq!(desktop.host, "halcyon.local:48213");
         assert_eq!(desktop.name, "halcyon"); // .local trimmed for the fallback
         assert_eq!(desktop.id, format!("remote:{}", "ff".repeat(32)));
     }
 
     #[test]
+    fn prefers_the_resolved_ipv4_for_the_connect_host() {
+        let txt = vec![
+            ("fingerprint".to_string(), "ff".repeat(32)),
+            ("name".to_string(), "halcyon".to_string()),
+        ];
+        let ip = "192.168.1.142".parse().unwrap();
+        let desktop = desktop_from_resolved("halcyon.local.", 48213, &txt, Some(ip)).unwrap();
+        // Connect by address (a .local hostname makes getaddrinfo walk
+        // fe80:: records first); hostname stays for display.
+        assert_eq!(desktop.host, "192.168.1.142:48213");
+        assert_eq!(desktop.hostname, "halcyon.local");
+    }
+
+    #[test]
     fn drops_services_without_a_fingerprint() {
         let txt = vec![("name".to_string(), "imposter".to_string())];
-        assert!(desktop_from_resolved("other.local.", 80, &txt).is_none());
+        assert!(desktop_from_resolved("other.local.", 80, &txt, None).is_none());
+    }
+}
+
+#[cfg(all(test, target_vendor = "apple"))]
+mod live_tests {
+    use super::*;
+
+    /// Live scan against whatever advertises on this LAN — needs a
+    /// running desktop, so it's opt-in:
+    /// `cargo test --lib -- --ignored live_scan`
+    #[test]
+    #[ignore]
+    fn live_scan_prints_nearby_desktops() {
+        let found = scan_blocking(Duration::from_millis(3000)).expect("scan failed");
+        eprintln!("live scan found: {found:#?}");
+        assert!(
+            found.iter().all(|d| !d.host.is_empty()),
+            "every entry must carry a connectable host"
+        );
     }
 }

--- a/apps/mobile/src-tauri/src/discovery.rs
+++ b/apps/mobile/src-tauri/src/discovery.rs
@@ -1,0 +1,413 @@
+//! Bonjour discovery of running desktops (`_aethon._tcp`).
+//!
+//! Uses the dnssd C API (libSystem) — browse + resolve route through the
+//! OS mDNSResponder daemon, which is the sanctioned path on iOS: it needs
+//! only the `NSBonjourServices` + `NSLocalNetworkUsageDescription` keys
+//! already in the Info.plist. A raw-multicast crate (mdns-sd) would need
+//! the restricted `com.apple.developer.networking.multicast` entitlement.
+//!
+//! Deliberately a snapshot, not a stream: `discovery_scan` browses for a
+//! bounded window and returns everything it resolved. The ConnectScreen
+//! polls it while visible, which sidesteps thread lifetime across iOS
+//! backgrounding and needs no start/stop pair or remove-tracking.
+
+use std::time::Duration;
+
+use serde::Serialize;
+
+#[derive(Serialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct DiscoveredDesktop {
+    /// `remote:<fingerprint>` — mirrors the desktop's discovery ids.
+    pub id: String,
+    /// TXT `name`, falling back to the hostname sans `.local`.
+    pub name: String,
+    /// `<hostname>:<port>` — ready for `gateway_pair` / `MobileConnection.host`.
+    pub host: String,
+    pub hostname: String,
+    pub port: u16,
+    /// Full SHA-256 cert fingerprint from TXT — what the phone pins.
+    pub fingerprint: String,
+    pub version: String,
+}
+
+#[tauri::command]
+pub async fn discovery_scan(timeout_ms: Option<u32>) -> Result<Vec<DiscoveredDesktop>, String> {
+    let timeout = u64::from(timeout_ms.unwrap_or(2500).clamp(500, 10_000));
+    tauri::async_runtime::spawn_blocking(move || scan_blocking(Duration::from_millis(timeout)))
+        .await
+        .map_err(|e| format!("discovery task failed: {e}"))?
+}
+
+/// TXT record wire format: repeated `[len][key=value]` entries.
+/// Zero-length and `=`-less entries are skipped, truncated ones end the
+/// parse.
+fn parse_txt(bytes: &[u8]) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    let mut i = 0usize;
+    while i < bytes.len() {
+        let len = bytes[i] as usize;
+        i += 1;
+        if len == 0 {
+            continue;
+        }
+        if i + len > bytes.len() {
+            break;
+        }
+        let entry = &bytes[i..i + len];
+        i += len;
+        if let Some(eq) = entry.iter().position(|&b| b == b'=') {
+            out.push((
+                String::from_utf8_lossy(&entry[..eq]).into_owned(),
+                String::from_utf8_lossy(&entry[eq + 1..]).into_owned(),
+            ));
+        }
+    }
+    out
+}
+
+/// Build the wire shape from one resolved service. `None` when the TXT
+/// carries no fingerprint — without it the phone can't pin, so the
+/// entry is useless (and likely not an Aethon desktop at all).
+fn desktop_from_resolved(
+    hosttarget: &str,
+    port: u16,
+    txt: &[(String, String)],
+) -> Option<DiscoveredDesktop> {
+    let get = |k: &str| {
+        txt.iter()
+            .find(|(key, _)| key == k)
+            .map(|(_, v)| v.clone())
+            .unwrap_or_default()
+    };
+    let fingerprint = get("fingerprint");
+    if fingerprint.is_empty() {
+        return None;
+    }
+    let hostname = hosttarget.trim_end_matches('.').to_string();
+    let name = {
+        let n = get("name");
+        if n.is_empty() {
+            hostname.trim_end_matches(".local").to_string()
+        } else {
+            n
+        }
+    };
+    Some(DiscoveredDesktop {
+        id: format!("remote:{fingerprint}"),
+        name,
+        host: format!("{hostname}:{port}"),
+        hostname,
+        port,
+        fingerprint,
+        version: get("version"),
+    })
+}
+
+#[cfg(target_vendor = "apple")]
+fn scan_blocking(timeout: Duration) -> Result<Vec<DiscoveredDesktop>, String> {
+    dnssd::scan(timeout)
+}
+
+#[cfg(not(target_vendor = "apple"))]
+fn scan_blocking(_timeout: Duration) -> Result<Vec<DiscoveredDesktop>, String> {
+    Err("discovery unsupported on this platform".into())
+}
+
+#[cfg(target_vendor = "apple")]
+mod dnssd {
+    //! Minimal FFI over the stable dnssd C API. All callbacks fire
+    //! synchronously inside `DNSServiceProcessResult`, so the `Scan`
+    //! state behind the context pointers never leaves this thread.
+
+    use std::ffi::{CStr, CString, c_char, c_void};
+    use std::time::{Duration, Instant};
+
+    use super::{DiscoveredDesktop, desktop_from_resolved, parse_txt};
+
+    type DNSServiceRef = *mut c_void;
+    type DNSServiceFlags = u32;
+    type DNSServiceErrorType = i32;
+
+    const FLAG_ADD: DNSServiceFlags = 0x2;
+    const SERVICE_TYPE: &CStr = c"_aethon._tcp";
+
+    type BrowseReply = unsafe extern "C" fn(
+        sd_ref: DNSServiceRef,
+        flags: DNSServiceFlags,
+        interface_index: u32,
+        error: DNSServiceErrorType,
+        service_name: *const c_char,
+        regtype: *const c_char,
+        reply_domain: *const c_char,
+        context: *mut c_void,
+    );
+
+    type ResolveReply = unsafe extern "C" fn(
+        sd_ref: DNSServiceRef,
+        flags: DNSServiceFlags,
+        interface_index: u32,
+        error: DNSServiceErrorType,
+        fullname: *const c_char,
+        hosttarget: *const c_char,
+        port_be: u16,
+        txt_len: u16,
+        txt_record: *const u8,
+        context: *mut c_void,
+    );
+
+    unsafe extern "C" {
+        fn DNSServiceBrowse(
+            sd_ref: *mut DNSServiceRef,
+            flags: DNSServiceFlags,
+            interface_index: u32,
+            regtype: *const c_char,
+            domain: *const c_char,
+            callback: BrowseReply,
+            context: *mut c_void,
+        ) -> DNSServiceErrorType;
+        fn DNSServiceResolve(
+            sd_ref: *mut DNSServiceRef,
+            flags: DNSServiceFlags,
+            interface_index: u32,
+            name: *const c_char,
+            regtype: *const c_char,
+            domain: *const c_char,
+            callback: ResolveReply,
+            context: *mut c_void,
+        ) -> DNSServiceErrorType;
+        fn DNSServiceRefSockFD(sd_ref: DNSServiceRef) -> i32;
+        fn DNSServiceProcessResult(sd_ref: DNSServiceRef) -> DNSServiceErrorType;
+        fn DNSServiceRefDeallocate(sd_ref: DNSServiceRef);
+    }
+
+    /// A browse hit waiting for its resolve to be started.
+    struct PendingResolve {
+        name: CString,
+        regtype: CString,
+        domain: CString,
+        interface_index: u32,
+    }
+
+    /// One in-flight resolve; `done` flips inside the callback.
+    struct ResolveSlot {
+        service: DNSServiceRef,
+        done: bool,
+        result: Option<DiscoveredDesktop>,
+    }
+
+    #[derive(Default)]
+    struct Scan {
+        pending: Vec<PendingResolve>,
+    }
+
+    unsafe extern "C" fn browse_reply(
+        _sd_ref: DNSServiceRef,
+        flags: DNSServiceFlags,
+        interface_index: u32,
+        error: DNSServiceErrorType,
+        service_name: *const c_char,
+        regtype: *const c_char,
+        reply_domain: *const c_char,
+        context: *mut c_void,
+    ) {
+        if error != 0 || flags & FLAG_ADD == 0 {
+            return;
+        }
+        let scan = unsafe { &mut *(context as *mut Scan) };
+        let copy = |p: *const c_char| unsafe { CStr::from_ptr(p) }.to_owned();
+        scan.pending.push(PendingResolve {
+            name: copy(service_name),
+            regtype: copy(regtype),
+            domain: copy(reply_domain),
+            interface_index,
+        });
+    }
+
+    unsafe extern "C" fn resolve_reply(
+        _sd_ref: DNSServiceRef,
+        _flags: DNSServiceFlags,
+        _interface_index: u32,
+        error: DNSServiceErrorType,
+        _fullname: *const c_char,
+        hosttarget: *const c_char,
+        port_be: u16,
+        txt_len: u16,
+        txt_record: *const u8,
+        context: *mut c_void,
+    ) {
+        let slot = unsafe { &mut *(context as *mut ResolveSlot) };
+        slot.done = true;
+        if error != 0 {
+            return;
+        }
+        let hosttarget = unsafe { CStr::from_ptr(hosttarget) }.to_string_lossy();
+        let txt = if txt_record.is_null() {
+            Vec::new()
+        } else {
+            parse_txt(unsafe { std::slice::from_raw_parts(txt_record, txt_len as usize) })
+        };
+        slot.result = desktop_from_resolved(&hosttarget, u16::from_be(port_be), &txt);
+    }
+
+    pub fn scan(timeout: Duration) -> Result<Vec<DiscoveredDesktop>, String> {
+        let deadline = Instant::now() + timeout;
+        let mut scan = Box::new(Scan::default());
+
+        let mut browse: DNSServiceRef = std::ptr::null_mut();
+        let err = unsafe {
+            DNSServiceBrowse(
+                &mut browse,
+                0,
+                0,
+                SERVICE_TYPE.as_ptr(),
+                std::ptr::null(),
+                browse_reply,
+                (&mut *scan) as *mut Scan as *mut c_void,
+            )
+        };
+        if err != 0 {
+            return Err(format!("DNSServiceBrowse failed: {err}"));
+        }
+
+        // Slots are boxed so their addresses stay stable for the C
+        // callbacks while the Vec grows.
+        let mut slots: Vec<Box<ResolveSlot>> = Vec::new();
+
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                break;
+            }
+
+            // Start resolves for any new browse hits.
+            for hit in scan.pending.drain(..) {
+                let mut slot = Box::new(ResolveSlot {
+                    service: std::ptr::null_mut(),
+                    done: false,
+                    result: None,
+                });
+                let err = unsafe {
+                    DNSServiceResolve(
+                        &mut slot.service,
+                        0,
+                        hit.interface_index,
+                        hit.name.as_ptr(),
+                        hit.regtype.as_ptr(),
+                        hit.domain.as_ptr(),
+                        resolve_reply,
+                        (&mut *slot) as *mut ResolveSlot as *mut c_void,
+                    )
+                };
+                if err == 0 {
+                    slots.push(slot);
+                }
+            }
+
+            // Poll the browse fd plus every unfinished resolve fd.
+            let mut fds: Vec<libc::pollfd> = Vec::with_capacity(1 + slots.len());
+            fds.push(libc::pollfd {
+                fd: unsafe { DNSServiceRefSockFD(browse) },
+                events: libc::POLLIN,
+                revents: 0,
+            });
+            let live: Vec<usize> = slots
+                .iter()
+                .enumerate()
+                .filter(|(_, s)| !s.done)
+                .map(|(i, _)| i)
+                .collect();
+            for &i in &live {
+                fds.push(libc::pollfd {
+                    fd: unsafe { DNSServiceRefSockFD(slots[i].service) },
+                    events: libc::POLLIN,
+                    revents: 0,
+                });
+            }
+
+            let millis = remaining.as_millis().min(250) as i32;
+            let ready = unsafe { libc::poll(fds.as_mut_ptr(), fds.len() as libc::nfds_t, millis) };
+            if ready < 0 {
+                break;
+            }
+            if fds[0].revents & libc::POLLIN != 0 {
+                unsafe { DNSServiceProcessResult(browse) };
+            }
+            for (pos, &i) in live.iter().enumerate() {
+                if fds[pos + 1].revents & libc::POLLIN != 0 {
+                    unsafe { DNSServiceProcessResult(slots[i].service) };
+                }
+            }
+        }
+
+        unsafe { DNSServiceRefDeallocate(browse) };
+        let mut out: Vec<DiscoveredDesktop> = Vec::new();
+        for slot in slots {
+            unsafe { DNSServiceRefDeallocate(slot.service) };
+            if let Some(desktop) = slot.result {
+                // Dedupe by fingerprint — one desktop can resolve on
+                // several interfaces.
+                if !out.iter().any(|d| d.fingerprint == desktop.fingerprint) {
+                    out.push(desktop);
+                }
+            }
+        }
+        out.sort_by(|a, b| a.name.cmp(&b.name));
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn txt_bytes(entries: &[&str]) -> Vec<u8> {
+        let mut out = Vec::new();
+        for e in entries {
+            out.push(e.len() as u8);
+            out.extend_from_slice(e.as_bytes());
+        }
+        out
+    }
+
+    #[test]
+    fn parses_length_prefixed_txt_records() {
+        let bytes = txt_bytes(&["name=halcyon", "version=0.11.2", "fingerprint=abc123"]);
+        assert_eq!(
+            parse_txt(&bytes),
+            vec![
+                ("name".into(), "halcyon".into()),
+                ("version".into(), "0.11.2".into()),
+                ("fingerprint".into(), "abc123".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn txt_parse_skips_empty_and_survives_truncation() {
+        let mut bytes = txt_bytes(&["name=x"]);
+        bytes.insert(0, 0); // leading zero-length entry
+        bytes.push(40); // truncated trailing entry
+        bytes.extend_from_slice(b"short");
+        assert_eq!(parse_txt(&bytes), vec![("name".into(), "x".into())]);
+    }
+
+    #[test]
+    fn maps_resolved_service_with_name_fallback_and_dot_trim() {
+        let txt = vec![
+            ("fingerprint".to_string(), "ff".repeat(32)),
+            ("version".to_string(), "1.0.0".to_string()),
+        ];
+        let desktop = desktop_from_resolved("halcyon.local.", 48213, &txt).unwrap();
+        assert_eq!(desktop.hostname, "halcyon.local");
+        assert_eq!(desktop.host, "halcyon.local:48213");
+        assert_eq!(desktop.name, "halcyon"); // .local trimmed for the fallback
+        assert_eq!(desktop.id, format!("remote:{}", "ff".repeat(32)));
+    }
+
+    #[test]
+    fn drops_services_without_a_fingerprint() {
+        let txt = vec![("name".to_string(), "imposter".to_string())];
+        assert!(desktop_from_resolved("other.local.", 80, &txt).is_none());
+    }
+}

--- a/apps/mobile/src-tauri/src/gateway.rs
+++ b/apps/mobile/src-tauri/src/gateway.rs
@@ -109,12 +109,18 @@ impl rustls::client::danger::ServerCertVerifier for PinnedCert {
     }
 }
 
-fn pinned_tls_connector(fingerprint: String) -> tokio_tungstenite::Connector {
+/// Client config trusting exactly the pinned cert — shared by the WS
+/// bridge here and the pair.rs HTTPS POST.
+pub(crate) fn pinned_client_config(fingerprint: String) -> Arc<rustls::ClientConfig> {
     let config = rustls::ClientConfig::builder()
         .dangerous()
         .with_custom_certificate_verifier(Arc::new(PinnedCert { fingerprint }))
         .with_no_client_auth();
-    tokio_tungstenite::Connector::Rustls(Arc::new(config))
+    Arc::new(config)
+}
+
+fn pinned_tls_connector(fingerprint: String) -> tokio_tungstenite::Connector {
+    tokio_tungstenite::Connector::Rustls(pinned_client_config(fingerprint))
 }
 
 /// Open (or reopen) the socket. `fingerprint` empty → plaintext `ws://`
@@ -169,13 +175,11 @@ pub async fn gateway_connect(
 }
 
 #[tauri::command]
-pub async fn gateway_send(
-    state: State<'_, Arc<GatewayState>>,
-    text: String,
-) -> Result<(), String> {
+pub async fn gateway_send(state: State<'_, Arc<GatewayState>>, text: String) -> Result<(), String> {
     let guard = state.tx.lock().await;
     let tx = guard.as_ref().ok_or("gateway not connected")?;
-    tx.send(Message::Text(text)).map_err(|_| "gateway closed".to_string())
+    tx.send(Message::Text(text))
+        .map_err(|_| "gateway closed".to_string())
 }
 
 #[tauri::command]

--- a/apps/mobile/src-tauri/src/lib.rs
+++ b/apps/mobile/src-tauri/src/lib.rs
@@ -7,13 +7,20 @@
 //! desktop. All product logic lives in the web layer and, ultimately,
 //! on the desktop the app pairs with.
 
+mod discovery;
 mod gateway;
+mod pair;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    tauri::Builder::default()
+    let builder = tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
-        .plugin(tauri_plugin_notification::init())
+        .plugin(tauri_plugin_notification::init());
+    // Camera scanner exists only on the mobile OSes (matches the
+    // target-gated Cargo dependency).
+    #[cfg(mobile)]
+    let builder = builder.plugin(tauri_plugin_barcode_scanner::init());
+    builder
         .setup(|app| {
             gateway::register(app.handle());
             Ok(())
@@ -22,6 +29,8 @@ pub fn run() {
             gateway::gateway_connect,
             gateway::gateway_send,
             gateway::gateway_close,
+            pair::gateway_pair,
+            discovery::discovery_scan,
         ])
         .run(tauri::generate_context!())
         .expect("error while running aethon-mobile");

--- a/apps/mobile/src-tauri/src/pair.rs
+++ b/apps/mobile/src-tauri/src/pair.rs
@@ -1,0 +1,199 @@
+//! One-shot `POST /pair` client with the same cert pinning as the WS
+//! bridge.
+//!
+//! WKWebView's fetch can't pin a self-signed cert, and pulling reqwest
+//! into the iOS staticlib for a single endpoint is not worth its tree —
+//! so this is a hand-rolled HTTP/1.1 exchange over the shared
+//! [`crate::gateway::pinned_client_config`] connector. `Connection:
+//! close` keeps the parse trivial: status line + header/body split, body
+//! is everything until EOF (the desktop's axum always sends sized JSON
+//! bodies here).
+//!
+//! Error contract consumed by `src/mobile/pairing.ts`:
+//! - transport problems  -> `Err("net:<detail>")`
+//! - HTTP non-200        -> `Err("pair:<status>:<server error message>")`
+
+use std::time::Duration;
+
+use serde::Serialize;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::net::TcpStream;
+
+const PAIR_TIMEOUT: Duration = Duration::from_secs(5);
+/// A pair response is a few hundred bytes; anything past this is not
+/// our server.
+const MAX_RESPONSE: usize = 64 * 1024;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PairOutcome {
+    pub device_id: String,
+    pub device_token: String,
+    pub host_display_name: String,
+    pub host_fingerprint: String,
+}
+
+/// Redeem a pairing `code` against `host` ("ip-or-name:port"). Empty
+/// `fingerprint` speaks plain HTTP (dev parity with
+/// `[server] allow_insecure_ws`); otherwise HTTPS pinned to it.
+#[tauri::command]
+pub async fn gateway_pair(
+    host: String,
+    fingerprint: String,
+    code: String,
+    device_name: String,
+) -> Result<PairOutcome, String> {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+    let raw = tokio::time::timeout(
+        PAIR_TIMEOUT,
+        exchange(&host, &fingerprint, &code, &device_name),
+    )
+    .await
+    .map_err(|_| format!("net:timed out connecting to {host}"))??;
+    let (status, body) = parse_http_response(&raw).map_err(|e| format!("net:{e}"))?;
+    if status != 200 {
+        return Err(format!("pair:{status}:{}", error_message(&body)));
+    }
+    let parsed: serde_json::Value =
+        serde_json::from_slice(&body).map_err(|e| format!("net:bad pair response: {e}"))?;
+    let field = |k: &str| parsed.get(k).and_then(|v| v.as_str()).map(str::to_owned);
+    let host_info = parsed.get("host").cloned().unwrap_or_default();
+    let host_field = |k: &str| {
+        host_info
+            .get(k)
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_owned()
+    };
+    Ok(PairOutcome {
+        device_id: field("deviceId").ok_or("net:pair response missing deviceId")?,
+        device_token: field("deviceToken").ok_or("net:pair response missing deviceToken")?,
+        host_display_name: host_field("displayName"),
+        host_fingerprint: host_field("fingerprint"),
+    })
+}
+
+async fn exchange(
+    host: &str,
+    fingerprint: &str,
+    code: &str,
+    device_name: &str,
+) -> Result<Vec<u8>, String> {
+    let body = serde_json::json!({
+        "code": code,
+        "deviceName": device_name,
+        "platform": "ios",
+    })
+    .to_string();
+    let request = format!(
+        "POST /pair HTTP/1.1\r\nHost: {host}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len(),
+    );
+
+    let tcp = TcpStream::connect(host)
+        .await
+        .map_err(|e| format!("net:connect {host}: {e}"))?;
+
+    if fingerprint.is_empty() {
+        send_and_drain(tcp, request.as_bytes()).await
+    } else {
+        let server_name = host
+            .rsplit_once(':')
+            .map(|(name, _)| name)
+            .unwrap_or(host)
+            .to_owned();
+        let server_name = rustls::pki_types::ServerName::try_from(server_name)
+            .map_err(|e| format!("net:bad host name: {e}"))?;
+        let connector = tokio_rustls::TlsConnector::from(crate::gateway::pinned_client_config(
+            fingerprint.to_owned(),
+        ));
+        let tls = connector
+            .connect(server_name, tcp)
+            .await
+            .map_err(|e| format!("net:tls {host}: {e}"))?;
+        send_and_drain(tls, request.as_bytes()).await
+    }
+}
+
+async fn send_and_drain<S: AsyncRead + AsyncWrite + Unpin>(
+    mut stream: S,
+    request: &[u8],
+) -> Result<Vec<u8>, String> {
+    stream
+        .write_all(request)
+        .await
+        .map_err(|e| format!("net:send: {e}"))?;
+    let mut raw = Vec::new();
+    let mut chunk = [0u8; 4096];
+    loop {
+        let n = stream
+            .read(&mut chunk)
+            .await
+            .map_err(|e| format!("net:read: {e}"))?;
+        if n == 0 {
+            break;
+        }
+        raw.extend_from_slice(&chunk[..n]);
+        if raw.len() > MAX_RESPONSE {
+            return Err("net:response too large".into());
+        }
+    }
+    Ok(raw)
+}
+
+/// Split a `Connection: close` HTTP/1.1 response into (status, body).
+fn parse_http_response(raw: &[u8]) -> Result<(u16, Vec<u8>), String> {
+    let sep = raw
+        .windows(4)
+        .position(|w| w == b"\r\n\r\n")
+        .ok_or("malformed http response")?;
+    let head = std::str::from_utf8(&raw[..sep]).map_err(|_| "non-utf8 http header")?;
+    let status_line = head.lines().next().ok_or("empty http response")?;
+    let status: u16 = status_line
+        .split_whitespace()
+        .nth(1)
+        .and_then(|s| s.parse().ok())
+        .ok_or_else(|| format!("malformed status line: {status_line}"))?;
+    Ok((status, raw[sep + 4..].to_vec()))
+}
+
+/// Pull the message out of the desktop's `{"error": "..."}` body,
+/// falling back to the raw text.
+fn error_message(body: &[u8]) -> String {
+    serde_json::from_slice::<serde_json::Value>(body)
+        .ok()
+        .and_then(|v| v.get("error").and_then(|e| e.as_str()).map(str::to_owned))
+        .unwrap_or_else(|| String::from_utf8_lossy(body).trim().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_ok_response_with_body() {
+        let raw = b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 15\r\n\r\n{\"deviceId\":1}\n";
+        let (status, body) = parse_http_response(raw).unwrap();
+        assert_eq!(status, 200);
+        assert_eq!(body, b"{\"deviceId\":1}\n");
+    }
+
+    #[test]
+    fn parses_error_status_and_json_message() {
+        let raw = b"HTTP/1.1 403 Forbidden\r\n\r\n{\"error\":\"wrong code\"}";
+        let (status, body) = parse_http_response(raw).unwrap();
+        assert_eq!(status, 403);
+        assert_eq!(error_message(&body), "wrong code");
+    }
+
+    #[test]
+    fn error_message_falls_back_to_raw_text() {
+        assert_eq!(error_message(b"nope"), "nope");
+    }
+
+    #[test]
+    fn rejects_garbage() {
+        assert!(parse_http_response(b"not http at all").is_err());
+        assert!(parse_http_response(b"HTTP/1.1 abc\r\n\r\n").is_err());
+    }
+}

--- a/apps/mobile/src-tauri/tauri.conf.json
+++ b/apps/mobile/src-tauri/tauri.conf.json
@@ -29,7 +29,7 @@
     "shortDescription": "Aethon companion — drive a running desktop instance from your phone.",
     "longDescription": "The Aethon iOS companion pairs with a running Aethon desktop instance over the LAN and reuses the same A2UI web UI, so sessions, chat, terminals, files, and git are all reachable from the phone. The desktop remains the executor; the companion is a thin, authenticated remote client.",
     "iOS": {
-      "developmentTeam": null
+      "developmentTeam": "28X9H69QGE"
     }
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,7 @@
         "@shikijs/monaco": "^4.0.2",
         "@shikijs/themes": "^4",
         "@tauri-apps/api": "^2.11.0",
+        "@tauri-apps/plugin-barcode-scanner": "^2.4.5",
         "@tauri-apps/plugin-notification": "^2.3.3",
         "@tauri-apps/plugin-opener": "^2.5.4",
         "@xterm/addon-fit": "^0.11.0",
@@ -32,6 +33,7 @@
         "shiki": "^4",
         "smol-toml": "1.7.0",
         "typebox": "^1.1.34",
+        "uqr": "^0.1.3",
         "yaml": "2.8.3",
       },
       "devDependencies": {
@@ -492,6 +494,8 @@
     "@tauri-apps/cli-win32-ia32-msvc": ["@tauri-apps/cli-win32-ia32-msvc@2.11.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-OFV+s3MLZnd75zl0ZAFU5riMpGK4waUEA8ZDuijDsnkU0btz/gHhqh5jVlOn8thyvgdtT3Xyoxqo099MMifH3g=="],
 
     "@tauri-apps/cli-win32-x64-msvc": ["@tauri-apps/cli-win32-x64-msvc@2.11.0", "", { "os": "win32", "cpu": "x64" }, "sha512-AeDTWBd2cOZ6TX133BWsoo+LutG9o0JRcgjMsIfLE13ZugpgCMv/2dJbUiBGeRvbPOGin5A3aYmsArPVV6ZSHQ=="],
+
+    "@tauri-apps/plugin-barcode-scanner": ["@tauri-apps/plugin-barcode-scanner@2.4.5", "", { "dependencies": { "@tauri-apps/api": "^2.11.0" } }, "sha512-sIPRYEfxww8/y8skZ2LcAp/h5bwvlHkQiq+3w6QEl+2BHs13xnpn7hP+pv4fkBs8DyDfpUbOBIYS5YBwP7x1QQ=="],
 
     "@tauri-apps/plugin-notification": ["@tauri-apps/plugin-notification@2.3.3", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-Zw+ZH18RJb41G4NrfHgIuofJiymusqN+q8fGUIIV7vyCH+5sSn5coqRv/MWB9qETsUs97vmU045q7OyseCV3Qg=="],
 
@@ -1642,6 +1646,8 @@
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
+
+    "uqr": ["uqr@0.1.3", "", {}, "sha512-0rjE8iEJe4YmT9TOhwsZtqCMRLc5DXZUI2UEYUUg63ikBkqqE5EYWaI0etFe/5KUcmcYwLih2RND1kq+hrUJXA=="],
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 

--- a/docs/mobile.md
+++ b/docs/mobile.md
@@ -71,10 +71,12 @@ ios-dev --host              # dev loop on a physical device over LAN
 
 Device signing comes from `DEVELOPMENT_TEAM` + `CODE_SIGN_STYLE: Automatic`
 in `gen/apple/project.yml` (mirrored in `tauri.conf.json`
-`bundle.iOS.developmentTeam` for future regens); `ios-device` passes
-`-allowProvisioningUpdates` through to xcodebuild so the profile mints
-itself. If provisioning still fails on a fresh machine, run `ios-dev
---open` once and press Run in Xcode (keep the CLI running — a bare
+`bundle.iOS.developmentTeam` for future regens), signing against the
+team's locally-installed development cert + provisioning profile. Note
+that `cargo tauri ios build -- <args>` forwards trailing args to CARGO,
+not xcodebuild — there is no way to pass `-allowProvisioningUpdates`
+through, so a machine with no usable profile must mint one once: run
+`ios-dev --open` and press Run in Xcode (keep the CLI running — a bare
 xcodebuild dies at the Build Rust Code phase with "Connection refused").
 
 Only one `ios-dev` session can run at a time: the xcodebuild "Build Rust

--- a/docs/mobile.md
+++ b/docs/mobile.md
@@ -63,10 +63,19 @@ ios-dev                     # dev loop in the Simulator (defaults to
 ios-run                     # install + launch the last ios-build output
                             # (static bundle — no dev server, no Xcode)
 ios-build                   # unsigned simulator .app (the no-arg default)
-ios-dev --host              # physical device over LAN
-ios-build --target aarch64  # signed device build — needs a development
-                            # team in tauri.conf.json bundle.iOS first
+ios-device                  # signed device build, installed + launched on
+                            # the connected iPhone via devicectl
+                            # (AETHON_IOS_UDID overrides the device pick)
+ios-dev --host              # dev loop on a physical device over LAN
 ```
+
+Device signing comes from `DEVELOPMENT_TEAM` + `CODE_SIGN_STYLE: Automatic`
+in `gen/apple/project.yml` (mirrored in `tauri.conf.json`
+`bundle.iOS.developmentTeam` for future regens); `ios-device` passes
+`-allowProvisioningUpdates` through to xcodebuild so the profile mints
+itself. If provisioning still fails on a fresh machine, run `ios-dev
+--open` once and press Run in Xcode (keep the CLI running — a bare
+xcodebuild dies at the Build Rust Code phase with "Connection refused").
 
 Only one `ios-dev` session can run at a time: the xcodebuild "Build Rust
 Code" phase dials back into the CLI's options server, so a second

--- a/e2e/support/fake-gateway.ts
+++ b/e2e/support/fake-gateway.ts
@@ -1,0 +1,285 @@
+// Fake remote-gateway for the mobile browser loop and e2e: a Bun
+// WebSocket server speaking wire protocol v1 (hello/invoke/sub →
+// hello_ok/result/event) with the same fixture data the desktop e2e
+// harness injects. Lets the reused App boot over `?gateway=` with zero
+// desktop instance — deterministic data for rendering work.
+//
+//   bun e2e/support/fake-gateway.ts [--port 8765]
+//
+// Unknown invokes resolve `ok:true, data:null` and are logged, so a
+// missing fixture shows up in the console instead of wedging the UI.
+
+type Frame = Record<string, unknown>;
+
+// Minimal Bun.serve surface — the repo doesn't carry @types/bun, and
+// this file only runs under `bun` (never bundled or imported).
+interface GatewaySocket {
+  send: (text: string) => void;
+}
+declare const Bun: {
+  serve(options: {
+    port: number;
+    fetch(req: Request, server: { upgrade(req: Request): boolean }): Response | undefined;
+    websocket: {
+      open(ws: GatewaySocket): void;
+      close(ws: GatewaySocket): void;
+      message(ws: GatewaySocket, raw: string | Uint8Array): void;
+    };
+  }): unknown;
+};
+
+const port = Number(process.argv[process.argv.indexOf("--port") + 1] || 8765);
+
+const MODEL = "openai/gpt-5.5";
+const PROJECT_ROOT = "/Users/tester/projects/aethon";
+
+const ready = () => ({
+  type: "ready",
+  model: MODEL,
+  projectRoot: PROJECT_ROOT,
+  userDir: "/Users/tester/.aethon",
+  currentProjectCwd: PROJECT_ROOT,
+  models: [
+    { id: MODEL, label: "GPT-5.5" },
+    { id: "ollama/qwen3.6:35b", label: "qwen3.6:35b" },
+  ],
+  tabs: [{ id: "default", model: MODEL, cwd: PROJECT_ROOT }],
+  discoveredTabs: [
+    {
+      tabId: "default",
+      title: "polish chat activity",
+      cwd: PROJECT_ROOT,
+      updatedAt: 1782960000000,
+      messageCount: 24,
+    },
+    {
+      tabId: "tab-fix-ci",
+      title: "fix nightly CI gate",
+      cwd: PROJECT_ROOT,
+      updatedAt: 1782950000000,
+      messageCount: 9,
+    },
+  ],
+  extensionsList: [],
+  failedExtensionsList: [],
+  disabledExtensionsList: [],
+  extensionComponents: {},
+  extensionState: {},
+  extensionStateKeys: [],
+  extensionLayoutPatches: [],
+  extensionThemes: [],
+  extensionSlashCommands: [],
+  extensionKeybindings: [],
+  extensionEventRoutes: [],
+  extensionLayouts: [],
+  extensionFrontendModules: [],
+  piSlashCommands: [],
+});
+
+const PROJECTS_STATE = JSON.stringify({
+  schemaVersion: 5,
+  activeProjectId: "project-aethon",
+  projects: [
+    {
+      id: "project-aethon",
+      label: "aethon",
+      path: PROJECT_ROOT,
+      lastUsed: 1,
+      uiExpanded: true,
+      hostId: "local:test",
+    },
+  ],
+  workspacesByProject: {
+    "project-aethon": [
+      {
+        id: "wt-main",
+        projectId: "project-aethon",
+        label: "main",
+        branch: "main",
+        path: PROJECT_ROOT,
+        isMain: true,
+      },
+    ],
+  },
+});
+
+const CONFIG = {
+  ui: {
+    theme: "ember",
+    fontSize: null,
+    restoreTabs: false,
+    notifyOnCompletion: false,
+    notifyMinDurationSeconds: 8,
+  },
+  agent: { model: MODEL },
+  shell: {
+    defaultShareMode: "private",
+    autoRestartAgent: true,
+    defaultCommand: null,
+    defaultArgs: [],
+    inheritEnv: true,
+    promptBeforeClose: true,
+  },
+  voice: {
+    toggleHotkey: "mod+shift+m",
+    holdHotkey: null,
+    speakAgentReplies: false,
+    speakMaxChars: 600,
+    conversationContinuous: false,
+  },
+  shortcuts: { newTabKind: "agent" },
+};
+
+const FILES: Record<string, unknown[]> = {
+  "": [
+    { name: "src", isDir: true },
+    { name: "src-tauri", isDir: true },
+    { name: "docs", isDir: true },
+    { name: "README.md", isDir: false, size: 4096 },
+    { name: "package.json", isDir: false, size: 2048 },
+  ],
+  src: [
+    { name: "App.tsx", isDir: false, size: 9000 },
+    { name: "main.tsx", isDir: false, size: 1200 },
+  ],
+};
+
+function invokeResult(cmd: string, args: Record<string, unknown>): unknown {
+  switch (cmd) {
+    case "read_config":
+      return CONFIG;
+    case "read_state":
+      return args.name === "projects" ? PROJECTS_STATE : "";
+    case "host_info":
+      return { id: "local:test", hostname: "halcyon", displayName: "halcyon", fingerprint: "test" };
+    case "aethon_home_dir":
+      return "/Users/tester/.aethon";
+    case "git_status":
+      return { branch: "main", dirty: true, ahead: 1, behind: 0 };
+    case "git_file_status":
+      return {
+        files: [
+          { path: "src/App.tsx", status: "modified", staged: false },
+          { path: "docs/mobile.md", status: "added", staged: true },
+        ],
+      };
+    case "fs_list_dir":
+      return FILES[typeof args.path === "string" ? args.path : ""] ?? [];
+    case "search_sessions":
+      return [];
+    case "diagnostics":
+      return { ok: true };
+    case "subagents_list":
+      return [];
+    case "scheduled_tasks_list":
+      return [];
+    case "gh_branch_status":
+    case "gh_checks":
+    case "gh_repo_overview":
+      return null;
+    default:
+      return null;
+  }
+}
+
+type Client = { ws: GatewaySocket; topics: Set<string>; seq: number };
+const clients = new Set<Client>();
+
+function pushEvent(client: Client, topic: string, payload: unknown) {
+  if (!client.topics.has(topic)) return;
+  client.seq += 1;
+  client.ws.send(JSON.stringify({ t: "event", topic, seq: client.seq, payload }));
+}
+
+function emitAgent(client: Client, message: Record<string, unknown>) {
+  pushEvent(client, "agent-response", JSON.stringify(message));
+}
+
+function streamTurn(client: Client, tabId: string) {
+  emitAgent(client, { type: "prompt_started", tabId, queued: 0 });
+  const chunks = [
+    "Sure — here's a **markdown** reply with some `inline code`,\n\n",
+    "```ts\nconst x: number = 42;\nexport function demo() {\n  return x * 2;\n}\n```\n\n",
+    "- a list item\n- another item with a [link](https://example.com)\n\n",
+    "and a closing paragraph long enough to wrap on a phone screen so we can check line measure, padding, and scroll behaviour.",
+  ];
+  let delay = 150;
+  for (const chunk of chunks) {
+    setTimeout(() => emitAgent(client, { type: "message_delta", tabId, delta: chunk }), delay);
+    delay += 250;
+  }
+  setTimeout(() => emitAgent(client, { type: "response_end", tabId }), delay + 200);
+}
+
+Bun.serve({
+  port,
+  fetch(req, server) {
+    if (server.upgrade(req)) return undefined;
+    return new Response("fake-gateway: ws only", { status: 426 });
+  },
+  websocket: {
+    open(ws) {
+      clients.add({ ws, topics: new Set<string>(), seq: 0 });
+    },
+    close(ws) {
+      for (const c of clients) if (c.ws === ws) clients.delete(c);
+    },
+    message(ws, raw) {
+      const client = [...clients].find((c) => c.ws === ws);
+      if (!client) return;
+      let frame: Frame;
+      try {
+        frame = JSON.parse(String(raw)) as Frame;
+      } catch {
+        return;
+      }
+      switch (frame.t) {
+        case "hello":
+          ws.send(
+            JSON.stringify({
+              t: "hello_ok",
+              protocol: 1,
+              host: { displayName: "halcyon (fake)", fingerprint: "test" },
+              deviceId: "dev-fake",
+              appVersion: "0.0.0-fake",
+            }),
+          );
+          break;
+        case "sub":
+          for (const topic of (frame.topics as string[] | undefined) ?? []) {
+            client.topics.add(topic);
+          }
+          break;
+        case "unsub":
+          for (const topic of (frame.topics as string[] | undefined) ?? []) {
+            client.topics.delete(topic);
+          }
+          break;
+        case "invoke": {
+          const cmd = String(frame.cmd);
+          const args = (frame.args ?? {}) as Record<string, unknown>;
+          if (cmd === "start_agent") {
+            ws.send(JSON.stringify({ t: "result", id: frame.id, ok: true, data: null }));
+            setTimeout(() => emitAgent(client, ready()), 50);
+            return;
+          }
+          if (cmd === "send_message") {
+            ws.send(JSON.stringify({ t: "result", id: frame.id, ok: true, data: null }));
+            streamTurn(client, typeof args.tabId === "string" ? args.tabId : "default");
+            return;
+          }
+          const data = invokeResult(cmd, args);
+          if (data === null && !(cmd in { gh_branch_status: 1, gh_checks: 1, gh_repo_overview: 1 })) {
+            console.log(`[fake-gateway] unfixtured invoke: ${cmd}`);
+          }
+          ws.send(JSON.stringify({ t: "result", id: frame.id, ok: true, data }));
+          break;
+        }
+        default:
+          break;
+      }
+    },
+  },
+});
+
+console.log(`fake-gateway listening on ws://localhost:${port} (token: any)`);

--- a/e2e/support/fake-gateway.ts
+++ b/e2e/support/fake-gateway.ts
@@ -205,7 +205,16 @@ function streamTurn(client: Client, tabId: string) {
   ];
   let delay = 150;
   for (const chunk of chunks) {
-    setTimeout(() => emitAgent(client, { type: "message_delta", tabId, delta: chunk }), delay);
+    setTimeout(
+      () =>
+        emitAgent(client, {
+          type: "response_delta",
+          tabId,
+          channel: "text",
+          content: chunk,
+        }),
+      delay,
+    );
     delay += 250;
   }
   setTimeout(() => emitAgent(client, { type: "response_end", tabId }), delay + 200);
@@ -270,7 +279,8 @@ Bun.serve({
           }
           const data = invokeResult(cmd, args);
           if (data === null && !(cmd in { gh_branch_status: 1, gh_checks: 1, gh_repo_overview: 1 })) {
-            console.log(`[fake-gateway] unfixtured invoke: ${cmd}`);
+            const detail = cmd === "agent_command" ? ` ${JSON.stringify(args).slice(0, 160)}` : "";
+            console.log(`[fake-gateway] unfixtured invoke: ${cmd}${detail}`);
           }
           ws.send(JSON.stringify({ t: "result", id: frame.id, ok: true, data }));
           break;

--- a/flake.nix
+++ b/flake.nix
@@ -437,6 +437,12 @@
                 command = "exec ./scripts/ios.sh run \"$@\"";
               }
               {
+                category = "dev";
+                name = "ios-device";
+                help = "Signed device build + install/launch on the connected iPhone via devicectl (AETHON_IOS_UDID overrides device pick)";
+                command = "exec ./scripts/ios.sh device \"$@\"";
+              }
+              {
                 category = "build";
                 name = "ios-build";
                 help = "Build the iOS companion app (cargo tauri ios build; needs Xcode + CocoaPods). No args = unsigned simulator build; --target aarch64 = device (needs a development team).";

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@shikijs/monaco": "^4.0.2",
     "@shikijs/themes": "^4",
     "@tauri-apps/api": "^2.11.0",
+    "@tauri-apps/plugin-barcode-scanner": "^2.4.5",
     "@tauri-apps/plugin-notification": "^2.3.3",
     "@tauri-apps/plugin-opener": "^2.5.4",
     "@xterm/addon-fit": "^0.11.0",
@@ -51,6 +52,7 @@
     "shiki": "^4",
     "smol-toml": "1.7.0",
     "typebox": "^1.1.34",
+    "uqr": "^0.1.3",
     "yaml": "2.8.3"
   },
   "devDependencies": {

--- a/scripts/ios.sh
+++ b/scripts/ios.sh
@@ -116,14 +116,12 @@ case "$mode" in
     # beforeBuildCommand rebuilds dist-mobile before cargo runs, so a
     # touch here guarantees the fresh bundle is what gets embedded.
     touch src-tauri/src/lib.rs
-    # A bare device build (the Tauri CLI default) needs code signing,
-    # and bundle.iOS.developmentTeam is unset — xcodebuild fails with
-    # "requires a development team". Default to the unsigned simulator
-    # build instead so zero-arg ios-build works out of the box.
+    # A bare device build (the Tauri CLI default) needs code signing —
+    # that's what `ios-device` does. Zero-arg ios-build stays the
+    # unsigned simulator build so it works with no signing setup.
     if [ $# -eq 0 ]; then
       echo "==> no args: defaulting to the unsigned simulator build"
-      echo "    (device build: ios-build --target aarch64 — needs a development"
-      echo "     team in apps/mobile/src-tauri/tauri.conf.json bundle.iOS)"
+      echo "    (signed device build + install: ios-device)"
       set -- --debug --target aarch64-sim
     fi
     echo "==> cargo tauri ios build $*"
@@ -150,8 +148,49 @@ case "$mode" in
     echo "==> launching $bundle_id"
     xcrun simctl launch --terminate-running-process "$udid" "$bundle_id"
     ;;
+  device)
+    # Signed device build + install onto a USB/network-connected iPhone
+    # via devicectl — no Xcode UI. Signing comes from DEVELOPMENT_TEAM +
+    # CODE_SIGN_STYLE Automatic in gen/apple/project.yml against the
+    # team's local cert + wildcard provisioning profile. (Do NOT try to
+    # pass -allowProvisioningUpdates via `--`: tauri forwards trailing
+    # args to cargo, not xcodebuild.)
+    rm -rf src-tauri/gen/apple/build
+    touch src-tauri/src/lib.rs # re-embed dist-mobile (see build mode)
+    echo "==> cargo tauri ios build --debug --target aarch64 (signed device build)"
+    if ! cargo tauri ios build --debug --target aarch64 --export-method debugging; then
+      echo "error: device build failed." >&2
+      echo "If it mentions provisioning/profiles: run 'ios-dev --open' once and press Run in" >&2
+      echo "Xcode to mint the profile (keep the CLI running — a bare xcodebuild dies at the" >&2
+      echo "Build Rust Code phase with 'Connection refused'). Then retry ios-device." >&2
+      exit 1
+    fi
+    udid="${AETHON_IOS_UDID:-$(xcrun devicectl list devices 2>/dev/null | grep -i " connected " | grep -oE '[0-9A-Fa-f-]{36}' | head -1)}"
+    if [ -z "$udid" ]; then
+      echo "error: no connected iPhone (xcrun devicectl list devices; AETHON_IOS_UDID overrides)" >&2
+      exit 1
+    fi
+    app_path=""
+    for candidate in \
+      src-tauri/gen/apple/build/arm64/Aethon.ipa \
+      src-tauri/gen/apple/build/arm64/Aethon.app \
+      src-tauri/gen/apple/build/aethon-mobile_iOS.xcarchive/Products/Applications/Aethon.app; do
+      if [ -e "$candidate" ]; then
+        app_path="$candidate"
+        break
+      fi
+    done
+    if [ -z "$app_path" ]; then
+      echo "error: built app not found under src-tauri/gen/apple/build/" >&2
+      exit 1
+    fi
+    echo "==> installing $app_path on device $udid"
+    xcrun devicectl device install app --device "$udid" "$app_path"
+    echo "==> launching $bundle_id"
+    xcrun devicectl device process launch --terminate-existing --device "$udid" "$bundle_id"
+    ;;
   *)
-    echo "usage: ios.sh <dev|build|run> [tauri-ios-args...]" >&2
+    echo "usage: ios.sh <dev|build|run|device> [tauri-ios-args...]" >&2
     exit 2
     ;;
 esac

--- a/scripts/ios.sh
+++ b/scripts/ios.sh
@@ -187,7 +187,10 @@ case "$mode" in
     echo "==> installing $app_path on device $udid"
     xcrun devicectl device install app --device "$udid" "$app_path"
     echo "==> launching $bundle_id"
-    xcrun devicectl device process launch --terminate-existing --device "$udid" "$bundle_id"
+    if ! xcrun devicectl device process launch --terminate-existing --device "$udid" "$bundle_id"; then
+      # Install already succeeded — a locked phone just can't auto-launch.
+      echo "==> installed, but launch failed (phone locked?) — unlock the iPhone and open Aethon."
+    fi
     ;;
   *)
     echo "usage: ios.sh <dev|build|run|device> [tauri-ios-args...]" >&2

--- a/src-tauri/src/server/mdns.rs
+++ b/src-tauri/src/server/mdns.rs
@@ -57,10 +57,16 @@ pub fn advertise(
         SERVICE_TYPE,
         &instance_name,
         &format!("{hostname}.local."),
+        // No static IP: enable_addr_auto attaches every non-loopback
+        // interface address (and tracks changes). Without it the
+        // service registers with NO A/AAAA records — mdns-sd accepts
+        // that silently, but browsers can never resolve it, so the
+        // announcement is invisible on the wire.
         "",
         port,
         &props[..],
-    )?;
+    )?
+    .enable_addr_auto();
     mdns.register(service)?;
     Ok(mdns)
 }

--- a/src-tauri/src/server/remote/devices.rs
+++ b/src-tauri/src/server/remote/devices.rs
@@ -170,11 +170,19 @@ impl DeviceStore {
             .unwrap_or_default()
     }
 
-    /// Revocation keeps the record (audit trail + tombstone) but the
-    /// token stops verifying immediately; the WS layer also closes any
-    /// live connection for the id.
+    /// Revocation removes the record outright — a tombstone protects
+    /// nothing (verification only matches live tokens and a re-pair
+    /// mints a fresh id) and would otherwise clutter the device list
+    /// forever. The command layer closes live connections for the id;
+    /// pairing/revocation history lives in the logs.
     pub fn revoke(&self, id: &str) -> Result<(), String> {
-        self.mutate(id, |r| r.revoked = true)
+        let mut records = self.records.lock().map_err(|e| e.to_string())?;
+        let before = records.len();
+        records.retain(|r| r.id != id);
+        if records.len() == before {
+            return Err(format!("unknown device {id}"));
+        }
+        self.persist(&records)
     }
 
     pub fn rename(&self, id: &str, name: &str) -> Result<(), String> {
@@ -215,15 +223,17 @@ mod tests {
     }
 
     #[test]
-    fn revoked_device_stops_verifying_but_stays_listed() {
+    fn revoked_device_stops_verifying_and_leaves_the_list() {
         let dir = tempfile::tempdir().unwrap();
         let s = store(&dir);
         let added = s.add("iPad", "ios", "tok-1").unwrap();
+        let kept = s.add("iPhone", "ios", "tok-2").unwrap();
         s.revoke(&added.id).unwrap();
         assert!(s.verify_token("tok-1").is_none());
         let listed = s.list();
         assert_eq!(listed.len(), 1);
-        assert!(listed[0].revoked);
+        assert_eq!(listed[0].id, kept.id);
+        assert!(s.revoke("dev-nope").is_err(), "unknown id must error");
     }
 
     #[test]

--- a/src/extensions/default-layout/settings-panel/pairing-qr.test.tsx
+++ b/src/extensions/default-layout/settings-panel/pairing-qr.test.tsx
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { PairingQr } from "./pairing-qr";
+
+const SAMPLE_PAYLOAD = JSON.stringify({
+  v: 1,
+  name: "halcyon",
+  hosts: ["192.168.1.10", "halcyon.local"],
+  port: 48213,
+  fp: "ab".repeat(32),
+  code: "12345678",
+});
+
+afterEach(cleanup);
+
+describe("PairingQr", () => {
+  it("renders an SVG QR with drawn modules for a pairing payload", () => {
+    render(<PairingQr payload={SAMPLE_PAYLOAD} />);
+    const svg = screen.getByTestId("remote-pairing-qr");
+    expect(svg.tagName.toLowerCase()).toBe("svg");
+    expect(svg.getAttribute("role")).toBe("img");
+    const path = svg.querySelector("path");
+    expect(path).not.toBeNull();
+    // A real QR encodes hundreds of dark modules — an empty `d` would
+    // mean the matrix never made it into the path.
+    expect(path!.getAttribute("d")!.length).toBeGreaterThan(500);
+  });
+
+  it("honors the size prop without changing the module grid", () => {
+    render(<PairingQr payload={SAMPLE_PAYLOAD} size={96} />);
+    const svg = screen.getByTestId("remote-pairing-qr");
+    expect(svg.getAttribute("width")).toBe("96");
+    expect(svg.getAttribute("height")).toBe("96");
+  });
+});

--- a/src/extensions/default-layout/settings-panel/pairing-qr.tsx
+++ b/src/extensions/default-layout/settings-panel/pairing-qr.tsx
@@ -1,0 +1,39 @@
+// QR image for the pairing payload. Rendered as a single-path SVG from
+// uqr's boolean module matrix — no canvas, so it works under jsdom and
+// stays crisp at any size. The card behind it is always white: phones
+// can't reliably scan light-on-dark codes, and the settings panel is
+// usually a dark theme.
+
+import { useMemo } from "react";
+import { encode } from "uqr";
+
+export function PairingQr({ payload, size = 208 }: { payload: string; size?: number }) {
+  const qr = useMemo(() => encode(payload, { border: 3 }), [payload]);
+
+  const path = useMemo(() => {
+    const parts: string[] = [];
+    for (let y = 0; y < qr.size; y += 1) {
+      for (let x = 0; x < qr.size; x += 1) {
+        if (qr.data[y][x]) parts.push(`M${x} ${y}h1v1h-1z`);
+      }
+    }
+    return parts.join("");
+  }, [qr]);
+
+  return (
+    <div className="ae-remote-qr">
+      <svg
+        role="img"
+        aria-label="Pairing QR code"
+        data-testid="remote-pairing-qr"
+        width={size}
+        height={size}
+        viewBox={`0 0 ${qr.size} ${qr.size}`}
+        shapeRendering="crispEdges"
+      >
+        <rect width={qr.size} height={qr.size} fill="#ffffff" />
+        <path d={path} fill="#111111" />
+      </svg>
+    </div>
+  );
+}

--- a/src/extensions/default-layout/settings-panel/remote-section.tsx
+++ b/src/extensions/default-layout/settings-panel/remote-section.tsx
@@ -8,6 +8,7 @@
 
 import { useEffect, useState } from "react";
 
+import { PairingQr } from "./pairing-qr";
 import { Field, Section } from "./sections";
 import { useRemoteDevices } from "./useRemoteDevices";
 
@@ -46,9 +47,11 @@ function PairingCode({
 
   return (
     <div className="ae-remote-pairing" data-testid="remote-pairing-code">
+      <PairingQr payload={qrPayload} />
       <div className="ae-remote-pairing-code">{code}</div>
       <p className="ae-remote-pairing-hint">
-        Enter this code on the device to pair. Expires in {secondsLeft}s.
+        Scan the QR with the Aethon app, or enter this code on the device. Expires in{" "}
+        {secondsLeft}s.
       </p>
       <details className="ae-remote-pairing-payload">
         <summary>Pairing payload (QR)</summary>

--- a/src/extensions/default-layout/settings-panel/useRemoteDevices.ts
+++ b/src/extensions/default-layout/settings-panel/useRemoteDevices.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import {
   remoteDeviceRename,
@@ -34,6 +34,10 @@ export function useRemoteDevices(open: boolean): RemoteDevicesState {
   const [pairing, setPairing] = useState<PairingBegin | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  // Device ids that existed when pairing began — a poll that returns a
+  // NEW id means a device just redeemed the code, so the pairing card
+  // can dismiss instead of lingering until the 120s expiry.
+  const pairingBaseline = useRef<Set<string> | null>(null);
 
   const refresh = useCallback(async () => {
     try {
@@ -41,29 +45,41 @@ export function useRemoteDevices(open: boolean): RemoteDevicesState {
         remoteStatus(),
         remoteDevicesList(),
       ]);
+      const list = Array.isArray(nextDevices) ? nextDevices : [];
       setStatus(nextStatus ?? null);
-      setDevices(Array.isArray(nextDevices) ? nextDevices : []);
+      setDevices(list);
       setError(null);
+      const baseline = pairingBaseline.current;
+      if (baseline && list.some((device) => !baseline.has(device.id))) {
+        pairingBaseline.current = null;
+        setPairing(null);
+      }
     } catch (err) {
       setError(String(err));
     }
   }, []);
 
+  const pairingOpen = pairing !== null;
   useEffect(() => {
     if (!open) return;
     let cancelled = false;
     // Async data fetch on open + light poll so lastSeen / connection
     // count stay live; neither mutates state synchronously in the effect.
+    // While a pairing code is showing, poll fast so the card dismisses
+    // promptly when the device redeems it.
     // eslint-disable-next-line react-hooks/set-state-in-effect
     void refresh();
-    const timer = window.setInterval(() => {
-      if (!cancelled) void refresh();
-    }, 5000);
+    const timer = window.setInterval(
+      () => {
+        if (!cancelled) void refresh();
+      },
+      pairingOpen ? 1500 : 5000,
+    );
     return () => {
       cancelled = true;
       window.clearInterval(timer);
     };
-  }, [open, refresh]);
+  }, [open, pairingOpen, refresh]);
 
   // Auto-expire the displayed pairing code. The clear always goes
   // through the timer (delay clamped to 0) so state never mutates
@@ -71,14 +87,19 @@ export function useRemoteDevices(open: boolean): RemoteDevicesState {
   useEffect(() => {
     if (!pairing) return;
     const remaining = Math.max(0, pairing.expiresAt - Date.now());
-    const timer = setTimeout(() => setPairing(null), remaining);
+    const timer = setTimeout(() => {
+      pairingBaseline.current = null;
+      setPairing(null);
+    }, remaining);
     return () => clearTimeout(timer);
   }, [pairing]);
 
   const beginPairing = useCallback(async () => {
     setBusy(true);
     try {
-      setPairing(await remotePairingBegin());
+      const begun = await remotePairingBegin();
+      pairingBaseline.current = new Set(devices.map((device) => device.id));
+      setPairing(begun);
       setError(null);
       await refresh();
     } catch (err) {
@@ -86,9 +107,10 @@ export function useRemoteDevices(open: boolean): RemoteDevicesState {
     } finally {
       setBusy(false);
     }
-  }, [refresh]);
+  }, [devices, refresh]);
 
   const cancelPairing = useCallback(async () => {
+    pairingBaseline.current = null;
     setPairing(null);
     try {
       await remotePairingCancel();

--- a/src/gateway/commandPolicy.test.ts
+++ b/src/gateway/commandPolicy.test.ts
@@ -6,6 +6,19 @@ describe("mobile command policy", () => {
   it("routes native plugin commands locally", () => {
     expect(routeFor("plugin:notification|notify")).toBe("local");
     expect(routeFor("plugin:opener|open_url")).toBe("local");
+    expect(routeFor("plugin:barcode-scanner|scan")).toBe("local");
+  });
+
+  it("routes the mobile shell's own commands locally, never to the desktop", () => {
+    for (const cmd of [
+      "gateway_connect",
+      "gateway_send",
+      "gateway_close",
+      "gateway_pair",
+      "discovery_scan",
+    ]) {
+      expect(routeFor(cmd)).toBe("local");
+    }
   });
 
   it("stubs desktop-only command families", () => {

--- a/src/gateway/commandPolicy.ts
+++ b/src/gateway/commandPolicy.ts
@@ -18,8 +18,17 @@ export type CommandRoute = "local" | "stub" | "gateway";
 
 /** Native plugin commands handled by the mobile shell's own runtime. */
 function isLocalPlugin(cmd: string): boolean {
-  return cmd.startsWith("plugin:notification|") || cmd.startsWith("plugin:opener|");
+  return (
+    cmd.startsWith("plugin:notification|") ||
+    cmd.startsWith("plugin:opener|") ||
+    cmd.startsWith("plugin:barcode-scanner|")
+  );
 }
+
+/** The mobile shell's own commands (WS bridge, pairing, Bonjour scan) —
+ *  they must run against the local Tauri runtime, never be forwarded to
+ *  the desktop they exist to reach. */
+const LOCAL_PREFIXES = ["gateway_", "discovery_"];
 
 /** Desktop-only commands stubbed with a canned value. Prefix match for
  *  the families; exact match otherwise. Terminal/files/git flows are
@@ -89,6 +98,7 @@ export const GATEWAY_TRANSLATIONS: Record<string, string> = {
 
 export function routeFor(cmd: string): CommandRoute {
   if (isLocalPlugin(cmd)) return "local";
+  if (LOCAL_PREFIXES.some((p) => cmd.startsWith(p))) return "local";
   if (cmd in GATEWAY_TRANSLATIONS) return "gateway";
   if (STUB_EXACT.has(cmd)) return "stub";
   if (STUB_PREFIXES.some((p) => cmd.startsWith(p))) return "stub";

--- a/src/gateway/commandPolicy.ts
+++ b/src/gateway/commandPolicy.ts
@@ -42,6 +42,10 @@ const STUB_PREFIXES = [
   // fs reads/writes forward to the gateway.
   "fs_watch",
   "fs_unwatch",
+  // Execution-boundary approvals stay physically at the desktop; the
+  // phone treats startup as nothing-to-approve (null stub — the
+  // workspace-startup hook maps it to "disabled").
+  "workspace_startup_",
 ];
 
 const STUB_EXACT = new Set<string>([

--- a/src/hooks/bridgeMessageHandlers/readyState.ts
+++ b/src/hooks/bridgeMessageHandlers/readyState.ts
@@ -3,7 +3,13 @@ import type { AuthProfilesSnapshot } from "../../auth-profiles";
 import { OVERVIEW_TAB_ID, type Tab } from "../../types/tab";
 import { deletePointer } from "../../utils/jsonPointer";
 import { deepMergeState } from "../../utils/stateMutation";
-import { WORKSTATION_AREAS, workstationRows } from "../useFocus";
+import {
+  MOBILE_AREAS,
+  MOBILE_COLUMNS,
+  MOBILE_ROWS,
+  WORKSTATION_AREAS,
+  workstationRows,
+} from "../useFocus";
 import { TAB_MIRROR_KEYS } from "../useTabs";
 import { mirrorOverviewSurfaceToRoot } from "../tabOps/helpers";
 import { contextUsageFromMessage } from "./contextUsage";
@@ -55,9 +61,31 @@ function terminalHeightFromState(state: Record<string, unknown>): number {
   return typeof height === "number" && Number.isFinite(height) ? height : 240;
 }
 
+export function normalizeMobileLayout(
+  state: Record<string, unknown>,
+): Record<string, unknown> {
+  const layout = (state.layout as Record<string, unknown> | undefined) ?? {};
+  return {
+    ...state,
+    layout: {
+      ...layout,
+      columns: MOBILE_COLUMNS,
+      rows: MOBILE_ROWS,
+      areas: MOBILE_AREAS,
+    },
+  };
+}
+
 export function normalizeWorkstationLayout(
   state: Record<string, unknown>,
 ): Record<string, unknown> {
+  if (import.meta.env.VITE_AETHON_SURFACE === "mobile") {
+    // Ready snapshots can carry desktop layout values (the desktop is
+    // the state authority) — the companion re-asserts its own grid,
+    // columns included, or the workstation's sidebar tracks squeeze the
+    // phone into a fraction of the viewport.
+    return normalizeMobileLayout(state);
+  }
   const layout = (state.layout as Record<string, unknown> | undefined) ?? {};
   const terminal = state.terminal as { open?: boolean } | undefined;
   return {

--- a/src/hooks/useFocus.ts
+++ b/src/hooks/useFocus.ts
@@ -25,7 +25,20 @@ const DEFAULT_LEFT_WIDTH = "320px";
 const DEFAULT_RIGHT_WIDTH = "360px";
 const DEFAULT_TERMINAL_HEIGHT = 240;
 
-export const WORKSTATION_AREAS = [
+/** True in the companion bundle (build-time define, tree-shaken). Every
+ *  layout-grid writer below funnels through the exports of this module,
+ *  so gating HERE gives the mobile surface its own default grid without
+ *  chasing each caller (session restore, ready normalize, terminal
+ *  toggles, sidebar resize, …). */
+const IS_MOBILE_SURFACE = import.meta.env.VITE_AETHON_SURFACE === "mobile";
+
+/** The companion's single-column boot grid — must match
+ *  `src/mobile/mobile.a2ui.json`'s `state.layout`. */
+export const MOBILE_AREAS = ["header", "canvas", "composer", "nav"];
+export const MOBILE_ROWS = "auto minmax(0,1fr) auto auto";
+export const MOBILE_COLUMNS = "minmax(0,1fr)";
+
+const DESKTOP_WORKSTATION_AREAS = [
   "sidebar header files-sidebar",
   "sidebar tabs files-sidebar",
   "sidebar canvas files-sidebar",
@@ -33,6 +46,10 @@ export const WORKSTATION_AREAS = [
   "sidebar composer files-sidebar",
   "status status status",
 ];
+
+/** The boot grid areas for the current surface. Name kept from the
+ *  desktop-only era — treat it as "this surface's canonical areas". */
+export const WORKSTATION_AREAS = IS_MOBILE_SURFACE ? MOBILE_AREAS : DESKTOP_WORKSTATION_AREAS;
 
 function parseWidth(token: string | undefined, fallback: string): string {
   return token && /^\d+px$/.test(token) ? token : fallback;
@@ -118,6 +135,16 @@ export function workstationLayout(
 } {
   const { left, right } = pickWidths(current);
 
+  if (IS_MOBILE_SURFACE) {
+    // No sidebars on the phone — the grid is always one column.
+    return {
+      columns: MOBILE_COLUMNS,
+      areas: MOBILE_AREAS,
+      lastLeftWidth: left,
+      lastRightWidth: right,
+    };
+  }
+
   const parts = [
     leftVisible ? left : "0px",
     "minmax(0,1fr)",
@@ -143,6 +170,11 @@ export function workstationRows(
   terminalOpen: boolean,
   terminalHeight: number,
 ): string {
+  if (IS_MOBILE_SURFACE) {
+    // The companion has no bottom terminal track — the terminal is a
+    // full nav screen, so the grid never changes shape.
+    return MOBILE_ROWS;
+  }
   const terminalTrack = terminalOpen
     ? `${Math.max(120, Math.min(720, Math.round(terminalHeight)))}px`
     : "0px";

--- a/src/hooks/useWorkspaceStartup.ts
+++ b/src/hooks/useWorkspaceStartup.ts
@@ -143,10 +143,22 @@ export function useWorkspaceStartup({
 
   const prepareOnce = useCallback(
     async (cwd: string): Promise<WorkspaceStartupStatus> => {
-      const status = await invoke<WorkspaceStartupStatus>(
+      const status = await invoke<WorkspaceStartupStatus | null>(
         "workspace_startup_prepare_for_path",
         { args: { cwd } },
       );
+      if (!status) {
+        // A surface without startup approval (the companion stubs the
+        // family — the desktop owns execution-boundary approvals)
+        // answers null; treat it as nothing-to-approve.
+        return {
+          root: cwd,
+          fingerprint: "",
+          state: "disabled",
+          approved: true,
+          commands: [],
+        };
+      }
       return applyStatus(status);
     },
     [applyStatus],

--- a/src/mobile/ConnectScreen.test.tsx
+++ b/src/mobile/ConnectScreen.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const invokeMock = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+// Native runtime on: exercises the scan/nearby chrome. The barcode
+// plugin never loads in tests — ScanOverlay is only mounted after a
+// button press we don't make here.
+vi.mock("../gateway/rustBridgeAdapter", () => ({
+  isTauriRuntime: () => true,
+}));
+
+import { ConnectScreen } from "./ConnectScreen";
+
+const DESKTOP = {
+  id: "remote:ff",
+  name: "halcyon",
+  host: "halcyon.local:48213",
+  hostname: "halcyon.local",
+  port: 48213,
+  fingerprint: "ff".repeat(32),
+  version: "0.11.2",
+};
+
+beforeEach(() => {
+  invokeMock.mockReset();
+  // useNearbyDesktops polls discovery_scan on mount.
+  invokeMock.mockImplementation((cmd: string) =>
+    cmd === "discovery_scan"
+      ? Promise.resolve([DESKTOP])
+      : Promise.reject(new Error(`unexpected ${cmd}`)),
+  );
+});
+
+afterEach(cleanup);
+
+describe("ConnectScreen", () => {
+  it("keeps the manual path working unchanged", () => {
+    const onConnect = vi.fn();
+    render(<ConnectScreen initial={null} error={null} onConnect={onConnect} />);
+
+    fireEvent.change(screen.getByPlaceholderText("192.168.1.10:48213"), {
+      target: { value: "10.0.0.5:9000" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("paste from pairing"), {
+      target: { value: "tok-manual" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Connect" }));
+
+    expect(onConnect).toHaveBeenCalledWith({
+      host: "10.0.0.5:9000",
+      token: "tok-manual",
+      fingerprint: undefined,
+    });
+  });
+
+  it("pairs a nearby desktop via the 8-digit code", async () => {
+    const onConnect = vi.fn();
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === "discovery_scan") return Promise.resolve([DESKTOP]);
+      if (cmd === "gateway_pair") {
+        return Promise.resolve({
+          deviceId: "dev-1",
+          deviceToken: "tok-paired",
+          hostDisplayName: "halcyon",
+          hostFingerprint: DESKTOP.fingerprint,
+        });
+      }
+      return Promise.reject(new Error(`unexpected ${cmd}`));
+    });
+
+    render(<ConnectScreen initial={null} error={null} onConnect={onConnect} />);
+    await waitFor(() => expect(screen.getByText("halcyon")).toBeDefined());
+
+    fireEvent.click(screen.getByText("halcyon"));
+    fireEvent.change(screen.getByPlaceholderText("8-digit code"), {
+      target: { value: "12345678" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Pair" }));
+
+    await waitFor(() =>
+      expect(onConnect).toHaveBeenCalledWith({
+        host: "halcyon.local:48213",
+        token: "tok-paired",
+        fingerprint: DESKTOP.fingerprint,
+      }),
+    );
+    expect(invokeMock).toHaveBeenCalledWith("gateway_pair", {
+      host: "halcyon.local:48213",
+      fingerprint: DESKTOP.fingerprint,
+      code: "12345678",
+      deviceName: "iPhone",
+    });
+  });
+
+  it("surfaces the expiry message when the pairing window lapsed", async () => {
+    const onConnect = vi.fn();
+    invokeMock.mockImplementation((cmd: string) => {
+      if (cmd === "discovery_scan") return Promise.resolve([DESKTOP]);
+      // Tauri invoke rejects with a plain string on the wire; Error
+      // keeps eslint happy and classifyPairError unwraps .message.
+      return Promise.reject(new Error("pair:410:pairing window expired"));
+    });
+
+    render(<ConnectScreen initial={null} error={null} onConnect={onConnect} />);
+    await waitFor(() => expect(screen.getByText("halcyon")).toBeDefined());
+
+    fireEvent.click(screen.getByText("halcyon"));
+    fireEvent.change(screen.getByPlaceholderText("8-digit code"), {
+      target: { value: "12345678" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Pair" }));
+
+    await waitFor(() => expect(screen.getByText(/Pairing window expired/)).toBeDefined());
+    expect(onConnect).not.toHaveBeenCalled();
+  });
+});

--- a/src/mobile/ConnectScreen.tsx
+++ b/src/mobile/ConnectScreen.tsx
@@ -1,11 +1,19 @@
-// First-run / disconnected screen: enter the desktop host + device
-// token to pair the companion. QR scanning (via the barcode-scanner
-// plugin) fills these in a later phase; manual entry is always the
-// fallback and the browser dev path.
+// First-run / disconnected screen. Three ways in, best-first:
+//   1. Scan the pairing QR from desktop Settings → Remote Devices
+//      (camera; Tauri runtime only) — fully automatic.
+//   2. Tap a Bonjour-discovered desktop and type its 8-digit code.
+//   3. Manual host + token + fingerprint (collapsed) — the permanent
+//      fallback and the browser dev-loop path.
 
 import { useState } from "react";
 
+import { isTauriRuntime } from "../gateway/rustBridgeAdapter";
 import type { MobileConnection } from "./mobileConnection";
+import { ScanOverlay } from "./ScanOverlay";
+import { classifyPairError, pairErrorMessage, pairWithHosts, parseQrPayload } from "./pairing";
+import { useNearbyDesktops, type DiscoveredDesktop } from "./useNearbyDesktops";
+
+type Phase = "idle" | "scanning" | "pairing";
 
 export function ConnectScreen({
   initial,
@@ -19,67 +27,196 @@ export function ConnectScreen({
   const [host, setHost] = useState(initial?.host ?? "");
   const [token, setToken] = useState(initial?.token ?? "");
   const [fingerprint, setFingerprint] = useState(initial?.fingerprint ?? "");
+  const [phase, setPhase] = useState<Phase>("idle");
+  const [pairError, setPairError] = useState<string | null>(null);
+  const [codeFor, setCodeFor] = useState<DiscoveredDesktop | null>(null);
+  const [code, setCode] = useState("");
+
+  const native = isTauriRuntime();
+  const nearby = useNearbyDesktops(native && phase === "idle");
 
   const canConnect = host.trim().length > 0 && token.trim().length > 0;
+
+  const finishPairing = async (run: () => ReturnType<typeof pairWithHosts>) => {
+    setPhase("pairing");
+    setPairError(null);
+    try {
+      const { connection } = await run();
+      setCodeFor(null);
+      setCode("");
+      onConnect(connection);
+    } catch (err) {
+      setPairError(pairErrorMessage(classifyPairError(err)));
+    } finally {
+      setPhase("idle");
+    }
+  };
+
+  const onScanned = (text: string) => {
+    setPhase("idle");
+    const payload = parseQrPayload(text);
+    if (!payload) {
+      setPairError("Not an Aethon pairing code — scan the QR from Settings → Remote Devices.");
+      return;
+    }
+    void finishPairing(() =>
+      pairWithHosts({
+        hosts: payload.hosts,
+        port: payload.port,
+        fingerprint: payload.fp,
+        code: payload.code,
+      }),
+    );
+  };
+
+  if (phase === "scanning") {
+    return <ScanOverlay onResult={onScanned} onCancel={() => setPhase("idle")} />;
+  }
 
   return (
     <div className="ae-mobile-connect">
       <div className="ae-mobile-connect-card">
         <h1 className="ae-mobile-connect-title">Connect to Aethon</h1>
         <p className="ae-mobile-connect-hint">
-          Pair with a running desktop instance. Open Settings → Remote
-          Devices on the desktop to get a code, or enter the host and
-          token below.
+          Pair with a running desktop instance — open Settings → Remote Devices on the desktop
+          and choose “Pair a device”.
         </p>
         {error ? <p className="ae-mobile-connect-error">{error}</p> : null}
-        <label className="ae-mobile-field">
-          <span>Host</span>
-          <input
-            className="ae-mobile-input"
-            inputMode="url"
-            autoCapitalize="none"
-            autoCorrect="off"
-            placeholder="192.168.1.10:48213"
-            value={host}
-            onChange={(e) => setHost(e.target.value)}
-          />
-        </label>
-        <label className="ae-mobile-field">
-          <span>Device token</span>
-          <input
-            className="ae-mobile-input"
-            autoCapitalize="none"
-            autoCorrect="off"
-            placeholder="paste from pairing"
-            value={token}
-            onChange={(e) => setToken(e.target.value)}
-          />
-        </label>
-        <label className="ae-mobile-field">
-          <span>Fingerprint (optional)</span>
-          <input
-            className="ae-mobile-input"
-            autoCapitalize="none"
-            autoCorrect="off"
-            placeholder="wss cert pin — blank for dev ws"
-            value={fingerprint}
-            onChange={(e) => setFingerprint(e.target.value)}
-          />
-        </label>
-        <button
-          type="button"
-          className="ae-mobile-connect-button"
-          disabled={!canConnect}
-          onClick={() =>
-            onConnect({
-              host: host.trim(),
-              token: token.trim(),
-              fingerprint: fingerprint.trim() || undefined,
-            })
-          }
-        >
-          Connect
-        </button>
+        {pairError ? <p className="ae-mobile-connect-error">{pairError}</p> : null}
+
+        {native ? (
+          <button
+            type="button"
+            className="ae-mobile-connect-button"
+            disabled={phase === "pairing"}
+            onClick={() => {
+              setPairError(null);
+              setPhase("scanning");
+            }}
+          >
+            {phase === "pairing" ? "Pairing…" : "Scan QR code"}
+          </button>
+        ) : null}
+
+        {native ? (
+          <div className="ae-mobile-nearby" data-testid="nearby-desktops">
+            <h2 className="ae-mobile-nearby-title">
+              Nearby desktops
+              {nearby.scanning ? <span className="ae-mobile-nearby-spinner" aria-hidden /> : null}
+            </h2>
+            {nearby.desktops.length === 0 ? (
+              <p className="ae-mobile-nearby-empty">
+                Searching… Make sure the desktop app is running on this network, and that
+                Aethon has Local Network permission (iOS Settings → Privacy).
+              </p>
+            ) : (
+              <ul className="ae-mobile-nearby-list">
+                {nearby.desktops.map((desktop) => (
+                  <li key={desktop.id}>
+                    <button
+                      type="button"
+                      className="ae-mobile-nearby-row"
+                      onClick={() => {
+                        setPairError(null);
+                        setCode("");
+                        setCodeFor((current) =>
+                          current?.id === desktop.id ? null : desktop,
+                        );
+                      }}
+                    >
+                      <span className="ae-mobile-nearby-name">{desktop.name}</span>
+                      <span className="ae-mobile-nearby-meta">
+                        {desktop.hostname} · {desktop.fingerprint.slice(0, 8)}
+                      </span>
+                    </button>
+                    {codeFor?.id === desktop.id ? (
+                      <div className="ae-mobile-nearby-code">
+                        <input
+                          className="ae-mobile-input"
+                          inputMode="numeric"
+                          autoComplete="one-time-code"
+                          maxLength={8}
+                          placeholder="8-digit code"
+                          value={code}
+                          onChange={(e) => setCode(e.target.value.replace(/\D/g, ""))}
+                        />
+                        <button
+                          type="button"
+                          className="ae-mobile-connect-button"
+                          disabled={code.length !== 8 || phase === "pairing"}
+                          onClick={() =>
+                            void finishPairing(() =>
+                              pairWithHosts({
+                                hosts: [desktop.hostname],
+                                port: desktop.port,
+                                fingerprint: desktop.fingerprint,
+                                code,
+                              }),
+                            )
+                          }
+                        >
+                          {phase === "pairing" ? "Pairing…" : "Pair"}
+                        </button>
+                      </div>
+                    ) : null}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        ) : null}
+
+        <details className="ae-mobile-manual" open={!native}>
+          <summary>Manual setup</summary>
+          <label className="ae-mobile-field">
+            <span>Host</span>
+            <input
+              className="ae-mobile-input"
+              inputMode="url"
+              autoCapitalize="none"
+              autoCorrect="off"
+              placeholder="192.168.1.10:48213"
+              value={host}
+              onChange={(e) => setHost(e.target.value)}
+            />
+          </label>
+          <label className="ae-mobile-field">
+            <span>Device token</span>
+            <input
+              className="ae-mobile-input"
+              autoCapitalize="none"
+              autoCorrect="off"
+              placeholder="paste from pairing"
+              value={token}
+              onChange={(e) => setToken(e.target.value)}
+            />
+          </label>
+          <label className="ae-mobile-field">
+            <span>Fingerprint (optional)</span>
+            <input
+              className="ae-mobile-input"
+              autoCapitalize="none"
+              autoCorrect="off"
+              placeholder="wss cert pin — blank for dev ws"
+              value={fingerprint}
+              onChange={(e) => setFingerprint(e.target.value)}
+            />
+          </label>
+          <button
+            type="button"
+            className="ae-mobile-connect-button"
+            disabled={!canConnect}
+            onClick={() =>
+              onConnect({
+                host: host.trim(),
+                token: token.trim(),
+                fingerprint: fingerprint.trim() || undefined,
+              })
+            }
+          >
+            Connect
+          </button>
+        </details>
       </div>
     </div>
   );

--- a/src/mobile/ScanOverlay.tsx
+++ b/src/mobile/ScanOverlay.tsx
@@ -1,0 +1,100 @@
+// Full-screen QR scan for pairing. The barcode-scanner plugin renders
+// the camera BEHIND the WKWebView (windowed mode flips the webview
+// transparent), so while this overlay is mounted the page itself must
+// also go transparent — `data-ae-scan` on <html> drives the CSS
+// override in mobile.css. The overlay paints a dimmed frame with a
+// cutout so the camera shows through the middle.
+
+import { useEffect, useRef, useState } from "react";
+
+import {
+  Format,
+  cancel,
+  checkPermissions,
+  openAppSettings,
+  requestPermissions,
+  scan,
+} from "@tauri-apps/plugin-barcode-scanner";
+
+export function ScanOverlay({
+  onResult,
+  onCancel,
+}: {
+  onResult: (text: string) => void;
+  onCancel: () => void;
+}) {
+  const [denied, setDenied] = useState(false);
+  // The callbacks live in refs so the one-shot scan effect never
+  // re-runs (and re-arms the camera) on parent re-renders.
+  const onResultRef = useRef(onResult);
+  const onCancelRef = useRef(onCancel);
+  useEffect(() => {
+    onResultRef.current = onResult;
+    onCancelRef.current = onCancel;
+  });
+
+  useEffect(() => {
+    document.documentElement.dataset.aeScan = "1";
+    let disposed = false;
+
+    const run = async () => {
+      let permission = await checkPermissions();
+      if (permission === "prompt") {
+        permission = await requestPermissions();
+      }
+      if (disposed) return;
+      if (permission !== "granted") {
+        setDenied(true);
+        return;
+      }
+      try {
+        const scanned = await scan({ windowed: true, formats: [Format.QRCode] });
+        if (!disposed) onResultRef.current(scanned.content);
+      } catch {
+        // Cancelled (by us or the OS) — the parent decides what's next.
+        if (!disposed) onCancelRef.current();
+      }
+    };
+    void run();
+
+    return () => {
+      disposed = true;
+      delete document.documentElement.dataset.aeScan;
+      void cancel().catch(() => undefined);
+    };
+  }, []);
+
+  return (
+    <div className="ae-scan-overlay" data-testid="scan-overlay">
+      {denied ? (
+        <div className="ae-scan-denied">
+          <p>Camera access is off. Aethon needs it to scan the pairing QR code.</p>
+          <button
+            type="button"
+            className="ae-mobile-connect-button"
+            onClick={() => void openAppSettings()}
+          >
+            Open Settings
+          </button>
+          <button type="button" className="ae-mobile-text-button" onClick={onCancel}>
+            Back
+          </button>
+        </div>
+      ) : (
+        <>
+          <div className="ae-scan-cutout" aria-hidden />
+          <p className="ae-scan-hint">
+            Point at the QR code in Settings → Remote Devices on your desktop.
+          </p>
+          <button
+            type="button"
+            className="ae-mobile-connect-button ae-scan-cancel"
+            onClick={onCancel}
+          >
+            Cancel
+          </button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/mobile/composites/mobile-nav.tsx
+++ b/src/mobile/composites/mobile-nav.tsx
@@ -13,7 +13,7 @@ interface NavItem {
 const ITEMS: NavItem[] = [
   { screen: "sessions", label: "Sessions", glyph: "☰" },
   { screen: "chat", label: "Chat", glyph: "◆" },
-  { screen: "terminal", label: "Terminal", glyph: "⌘" },
+  { screen: "terminal", label: "Terminal", glyph: "❯_" },
   { screen: "files", label: "Files", glyph: "▤" },
   { screen: "git", label: "Git", glyph: "⑃" },
   { screen: "settings", label: "Settings", glyph: "⚙" },
@@ -21,7 +21,7 @@ const ITEMS: NavItem[] = [
 
 export function MobileNav({ state, onEvent }: BuiltinComponentProps) {
   const active =
-    ((state.mobileNav as { active?: string } | undefined)?.active) ?? "chat";
+    ((state.mobileNav as { active?: string } | undefined)?.active) ?? "sessions";
   return (
     <nav className="ae-mobile-nav" aria-label="Sections">
       {ITEMS.map((item) => (

--- a/src/mobile/mobile.a2ui.json
+++ b/src/mobile/mobile.a2ui.json
@@ -4,9 +4,15 @@
       "id": "root-layout",
       "type": "layout",
       "props": {
-        "columns": { "$ref": "/layout/columns" },
-        "rows": { "$ref": "/layout/rows" },
-        "areas": { "$ref": "/layout/areas" },
+        "columns": {
+          "$ref": "/layout/columns"
+        },
+        "rows": {
+          "$ref": "/layout/rows"
+        },
+        "areas": {
+          "$ref": "/layout/areas"
+        },
         "slotMap": {
           "sessions": "canvas",
           "terminal-screen": "canvas",
@@ -30,17 +36,32 @@
               "id": "mobile-pill",
               "type": "agent-pulse",
               "props": {
-                "label": { "$ref": "/agentStatus/label" },
-                "state": { "$ref": "/agentStatus/state" }
+                "label": {
+                  "$ref": "/agentStatus/label"
+                },
+                "state": {
+                  "$ref": "/agentStatus/state"
+                }
               }
             },
             {
               "id": "mobile-header-spacer",
               "type": "container",
-              "props": { "direction": "row", "className": "ae-header-spacer" }
+              "props": {
+                "direction": "row",
+                "className": "ae-header-spacer"
+              }
             },
-            { "id": "mobile-model", "type": "model-picker", "props": {} },
-            { "id": "mobile-conn", "type": "connection-badge", "props": {} }
+            {
+              "id": "mobile-model",
+              "type": "model-picker",
+              "props": {}
+            },
+            {
+              "id": "mobile-conn",
+              "type": "connection-badge",
+              "props": {}
+            }
           ]
         },
         {
@@ -48,8 +69,12 @@
           "type": "main-canvas",
           "props": {
             "area": "canvas",
-            "visible": { "$ref": "/mobileNav/isChat" },
-            "messages": { "$ref": "/messages" }
+            "visible": {
+              "$ref": "/mobileNav/isChat"
+            },
+            "messages": {
+              "$ref": "/messages"
+            }
           }
         },
         {
@@ -57,7 +82,9 @@
           "type": "mobile-sessions",
           "props": {
             "area": "sessions",
-            "visible": { "$ref": "/mobileNav/isSessions" }
+            "visible": {
+              "$ref": "/mobileNav/isSessions"
+            }
           }
         },
         {
@@ -65,8 +92,12 @@
           "type": "terminal-panel",
           "props": {
             "area": "terminal-screen",
-            "visible": { "$ref": "/mobileNav/isTerminal" },
-            "activeSubId": { "$ref": "/terminalPanel/activeSubId" }
+            "visible": {
+              "$ref": "/mobileNav/isTerminal"
+            },
+            "activeSubId": {
+              "$ref": "/terminalPanel/activeSubId"
+            }
           }
         },
         {
@@ -74,7 +105,9 @@
           "type": "mobile-file-list",
           "props": {
             "area": "files",
-            "visible": { "$ref": "/mobileNav/isFiles" }
+            "visible": {
+              "$ref": "/mobileNav/isFiles"
+            }
           }
         },
         {
@@ -82,8 +115,12 @@
           "type": "source-control-panel",
           "props": {
             "area": "git",
-            "visible": { "$ref": "/mobileNav/isGit" },
-            "source": { "$ref": "/vcs" }
+            "visible": {
+              "$ref": "/mobileNav/isGit"
+            },
+            "source": {
+              "$ref": "/vcs"
+            }
           }
         },
         {
@@ -92,11 +129,17 @@
           "props": {
             "area": "composer",
             "direction": "column",
-            "visible": { "$ref": "/mobileNav/isChat" },
+            "visible": {
+              "$ref": "/mobileNav/isChat"
+            },
             "className": "ae-mobile-composer"
           },
           "children": [
-            { "id": "mobile-chat-input", "type": "chat-input", "props": {} }
+            {
+              "id": "mobile-chat-input",
+              "type": "chat-input",
+              "props": {}
+            }
           ]
         },
         {
@@ -104,13 +147,17 @@
           "type": "mobile-file-viewer",
           "props": {
             "area": "canvas",
-            "visible": { "$ref": "/mobileFileViewer/open" }
+            "visible": {
+              "$ref": "/mobileFileViewer/open"
+            }
           }
         },
         {
           "id": "mobile-bottom-nav",
           "type": "mobile-nav",
-          "props": { "area": "nav" }
+          "props": {
+            "area": "nav"
+          }
         }
       ]
     }
@@ -122,14 +169,16 @@
       "areas": ["header", "canvas", "composer", "nav"]
     },
     "mobileNav": {
-      "active": "chat",
-      "isSessions": false,
-      "isChat": true,
+      "active": "sessions",
+      "isSessions": true,
+      "isChat": false,
       "isTerminal": false,
       "isFiles": false,
       "isGit": false,
       "isSettings": false
     },
-    "mobileFileViewer": { "open": false }
+    "mobileFileViewer": {
+      "open": false
+    }
   }
 }

--- a/src/mobile/mobileConnection.test.ts
+++ b/src/mobile/mobileConnection.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { connectionUrl, loadConnection } from "./mobileConnection";
+
+function setSearch(search: string) {
+  window.history.replaceState(null, "", `/${search}`);
+}
+
+afterEach(() => {
+  setSearch("");
+  localStorage.clear();
+});
+
+describe("loadConnection URL override", () => {
+  it("reads gateway + token as the plaintext dev path", () => {
+    setSearch("?gateway=ws://10.0.0.5:9000&token=tok");
+    expect(loadConnection()).toEqual({
+      host: "10.0.0.5:9000",
+      token: "tok",
+      fingerprint: undefined,
+    });
+  });
+
+  it("pins the cert when fp is present, flipping the transport to wss", () => {
+    const fp = "ab".repeat(32);
+    setSearch(`?gateway=wss://10.0.0.5:9000/ws&token=tok&fp=${fp}`);
+    const connection = loadConnection();
+    expect(connection).toEqual({ host: "10.0.0.5:9000", token: "tok", fingerprint: fp });
+    expect(connectionUrl(connection!)).toBe("wss://10.0.0.5:9000/ws");
+  });
+
+  it("falls back to storage when params are absent", () => {
+    localStorage.setItem(
+      "aethon-mobile-connection",
+      JSON.stringify({ host: "h:1", token: "t" }),
+    );
+    expect(loadConnection()).toEqual({ host: "h:1", token: "t" });
+  });
+});

--- a/src/mobile/mobileConnection.ts
+++ b/src/mobile/mobileConnection.ts
@@ -18,14 +18,17 @@ export interface MobileConnection {
 const STORAGE_KEY = "aethon-mobile-connection";
 
 export function loadConnection(): MobileConnection | null {
-  // Dev / e2e override: ?gateway=ws://host:port&token=…
+  // Dev / e2e override: ?gateway=ws://host:port&token=…[&fp=<sha256>].
+  // `fp` pins the cert and flips the transport to wss, so the dev loop
+  // can drive a real TLS gateway (e.g. the simulator against a running
+  // desktop) — without it the override stays the plaintext dev path.
   try {
     const params = new URLSearchParams(window.location.search);
     const gatewayUrl = params.get("gateway");
     const token = params.get("token");
     if (gatewayUrl && token) {
       const host = gatewayUrl.replace(/^wss?:\/\//, "").replace(/\/ws$/, "");
-      return { host, token };
+      return { host, token, fingerprint: params.get("fp") ?? undefined };
     }
   } catch {
     // No URLSearchParams (non-browser) — fall through to storage.

--- a/src/mobile/pairing.test.ts
+++ b/src/mobile/pairing.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  classifyPairError,
+  pairErrorMessage,
+  pairWithHosts,
+  parseQrPayload,
+} from "./pairing";
+
+const PAYLOAD = {
+  v: 1,
+  name: "halcyon",
+  hosts: ["192.168.1.10", "halcyon.local"],
+  port: 48213,
+  fp: "ab".repeat(32),
+  code: "12345678",
+};
+
+describe("parseQrPayload", () => {
+  it("accepts the desktop's payload shape", () => {
+    expect(parseQrPayload(JSON.stringify(PAYLOAD))).toEqual(PAYLOAD);
+  });
+
+  it("rejects wrong versions, bad codes, and garbage", () => {
+    expect(parseQrPayload(JSON.stringify({ ...PAYLOAD, v: 2 }))).toBeNull();
+    expect(parseQrPayload(JSON.stringify({ ...PAYLOAD, code: "1234" }))).toBeNull();
+    expect(parseQrPayload(JSON.stringify({ ...PAYLOAD, hosts: [] }))).toBeNull();
+    expect(parseQrPayload("https://example.com/some-other-qr")).toBeNull();
+    expect(parseQrPayload("{not json")).toBeNull();
+  });
+});
+
+describe("classifyPairError", () => {
+  it("splits the pair.rs contract into net vs pair verdicts", () => {
+    const net = classifyPairError("net:connect refused");
+    expect(net.kind).toBe("net");
+    expect(net.message).toBe("connect refused");
+    const pair = classifyPairError("pair:403:wrong code");
+    expect(pair.kind).toBe("pair");
+    expect(pair.status).toBe(403);
+    expect(pair.message).toBe("wrong code");
+    // Tauri invoke rejections may arrive wrapped in an Error.
+    expect(classifyPairError(new Error("pair:410:pairing window expired")).status).toBe(410);
+  });
+
+  it("spells out the expiry window for 410/404", () => {
+    expect(pairErrorMessage(classifyPairError("pair:410:pairing window expired"))).toMatch(
+      /Pairing window expired/,
+    );
+    expect(pairErrorMessage(classifyPairError("pair:404:pairing not active"))).toMatch(
+      /Pairing window expired/,
+    );
+    expect(pairErrorMessage(classifyPairError("pair:403:wrong code"))).toMatch(/wrong code/);
+  });
+});
+
+describe("pairWithHosts", () => {
+  it("falls through net failures and returns the first success", async () => {
+    const invokeFn = vi
+      .fn()
+      .mockRejectedValueOnce("net:timed out connecting to 100.1.2.3:48213")
+      .mockResolvedValueOnce({
+        deviceId: "dev-1",
+        deviceToken: "tok-1",
+        hostDisplayName: "halcyon",
+        hostFingerprint: PAYLOAD.fp,
+      });
+    const { connection, outcome } = await pairWithHosts({
+      hosts: PAYLOAD.hosts,
+      port: PAYLOAD.port,
+      fingerprint: PAYLOAD.fp,
+      code: PAYLOAD.code,
+      invokeFn,
+    });
+    expect(invokeFn).toHaveBeenCalledTimes(2);
+    expect(invokeFn).toHaveBeenLastCalledWith("gateway_pair", {
+      host: "halcyon.local:48213",
+      fingerprint: PAYLOAD.fp,
+      code: PAYLOAD.code,
+      deviceName: "iPhone",
+    });
+    expect(connection).toEqual({
+      host: "halcyon.local:48213",
+      token: "tok-1",
+      fingerprint: PAYLOAD.fp,
+    });
+    expect(outcome.deviceId).toBe("dev-1");
+  });
+
+  it("stops immediately on a server verdict — no attempt-budget burn", async () => {
+    const invokeFn = vi.fn().mockRejectedValue("pair:403:wrong code");
+    const err = await pairWithHosts({
+      hosts: PAYLOAD.hosts,
+      port: PAYLOAD.port,
+      fingerprint: PAYLOAD.fp,
+      code: "00000000",
+      invokeFn,
+    }).then(
+      () => null,
+      (e: unknown) => classifyPairError(e),
+    );
+    expect(err?.kind).toBe("pair");
+    expect(err?.status).toBe(403);
+    expect(invokeFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("omits the fingerprint field for the plaintext dev path", async () => {
+    const invokeFn = vi.fn().mockResolvedValue({
+      deviceId: "d",
+      deviceToken: "t",
+      hostDisplayName: "h",
+      hostFingerprint: "",
+    });
+    const { connection } = await pairWithHosts({
+      hosts: ["localhost"],
+      port: 1234,
+      fingerprint: "",
+      code: PAYLOAD.code,
+      invokeFn,
+    });
+    expect(connection.fingerprint).toBeUndefined();
+  });
+});

--- a/src/mobile/pairing.test.ts
+++ b/src/mobile/pairing.test.ts
@@ -55,16 +55,20 @@ describe("classifyPairError", () => {
 });
 
 describe("pairWithHosts", () => {
-  it("falls through net failures and returns the first success", async () => {
-    const invokeFn = vi
-      .fn()
-      .mockRejectedValueOnce("net:timed out connecting to 100.1.2.3:48213")
-      .mockResolvedValueOnce({
+  it("races all candidates concurrently and resolves with the first success", async () => {
+    // The dead host hangs well past the winner — serial iteration
+    // would have waited it out; the race must not.
+    const invokeFn = vi.fn((_cmd: string, args: Record<string, unknown>) => {
+      if (args.host === "192.168.1.10:48213") {
+        return new Promise(() => undefined); // never settles
+      }
+      return Promise.resolve({
         deviceId: "dev-1",
         deviceToken: "tok-1",
         hostDisplayName: "halcyon",
         hostFingerprint: PAYLOAD.fp,
       });
+    });
     const { connection, outcome } = await pairWithHosts({
       hosts: PAYLOAD.hosts,
       port: PAYLOAD.port,
@@ -72,13 +76,8 @@ describe("pairWithHosts", () => {
       code: PAYLOAD.code,
       invokeFn,
     });
+    // Both candidates were attempted in parallel.
     expect(invokeFn).toHaveBeenCalledTimes(2);
-    expect(invokeFn).toHaveBeenLastCalledWith("gateway_pair", {
-      host: "halcyon.local:48213",
-      fingerprint: PAYLOAD.fp,
-      code: PAYLOAD.code,
-      deviceName: "iPhone",
-    });
     expect(connection).toEqual({
       host: "halcyon.local:48213",
       token: "tok-1",
@@ -87,8 +86,12 @@ describe("pairWithHosts", () => {
     expect(outcome.deviceId).toBe("dev-1");
   });
 
-  it("stops immediately on a server verdict — no attempt-budget burn", async () => {
-    const invokeFn = vi.fn().mockRejectedValue("pair:403:wrong code");
+  it("prefers a server verdict over transport noise when every host fails", async () => {
+    const invokeFn = vi.fn((_cmd: string, args: Record<string, unknown>) =>
+      args.host === "192.168.1.10:48213"
+        ? Promise.reject(new Error("net:timed out"))
+        : Promise.reject(new Error("pair:403:wrong code")),
+    );
     const err = await pairWithHosts({
       hosts: PAYLOAD.hosts,
       port: PAYLOAD.port,
@@ -101,7 +104,6 @@ describe("pairWithHosts", () => {
     );
     expect(err?.kind).toBe("pair");
     expect(err?.status).toBe(403);
-    expect(invokeFn).toHaveBeenCalledTimes(1);
   });
 
   it("omits the fingerprint field for the plaintext dev path", async () => {

--- a/src/mobile/pairing.ts
+++ b/src/mobile/pairing.ts
@@ -93,7 +93,18 @@ export function pairErrorMessage(error: PairFailure): string {
   return `Could not reach the desktop: ${error.message}`;
 }
 
-export async function pairWithHosts(opts: {
+/** Redeem the code against every candidate host CONCURRENTLY and take
+ *  the first success. The QR's hosts[] can contain unreachable
+ *  interfaces (a Tailscale IP when the phone isn't on the tailnet, VPN
+ *  utuns, …) — tried serially each one burns its full 5s timeout before
+ *  the LAN address gets a turn. Racing is safe for the scanned-QR flow:
+ *  the code is known-correct and single-use, so at most one request
+ *  redeems it; stragglers get a harmless "pairing not active".
+ *
+ *  Callers with a HAND-TYPED code should pass a single host (the nearby
+ *  flow does): a wrong code fanned out to N hosts would burn N of the
+ *  window's 5 attempts at once. */
+export function pairWithHosts(opts: {
   hosts: string[];
   port: number;
   fingerprint: string;
@@ -104,30 +115,48 @@ export async function pairWithHosts(opts: {
 }): Promise<{ connection: MobileConnection; outcome: PairOutcome }> {
   const invokeFn = opts.invokeFn ?? invoke;
   const deviceName = opts.deviceName ?? DEFAULT_DEVICE_NAME;
-  let lastError = new PairFailure("net", "no candidate hosts");
-  for (const candidate of opts.hosts) {
-    const host = candidate.includes(":") ? candidate : `${candidate}:${opts.port}`;
-    try {
-      const outcome = (await invokeFn("gateway_pair", {
+  const hosts = opts.hosts.map((c) => (c.includes(":") ? c : `${c}:${opts.port}`));
+  if (hosts.length === 0) {
+    return Promise.reject(new PairFailure("net", "no candidate hosts"));
+  }
+  return new Promise((resolve, reject) => {
+    let pending = hosts.length;
+    let settled = false;
+    let best: PairFailure | null = null;
+    for (const host of hosts) {
+      invokeFn("gateway_pair", {
         host,
         fingerprint: opts.fingerprint,
         code: opts.code,
         deviceName,
-      })) as PairOutcome;
-      return {
-        connection: {
-          host,
-          token: outcome.deviceToken,
-          fingerprint: opts.fingerprint || undefined,
+      }).then(
+        (raw) => {
+          if (settled) return;
+          settled = true;
+          const outcome = raw as PairOutcome;
+          resolve({
+            connection: {
+              host,
+              token: outcome.deviceToken,
+              fingerprint: opts.fingerprint || undefined,
+            },
+            outcome,
+          });
         },
-        outcome,
-      };
-    } catch (err) {
-      lastError = classifyPairError(err);
-      // A server verdict is terminal; only transport failures fall
-      // through to the next candidate.
-      if (lastError.kind === "pair") throw lastError;
+        (err: unknown) => {
+          const failure = classifyPairError(err);
+          // When everything fails, a server verdict (wrong code,
+          // expired window) explains more than transport noise.
+          if (!best || (failure.kind === "pair" && best.kind === "net")) {
+            best = failure;
+          }
+          pending -= 1;
+          if (pending === 0 && !settled) {
+            settled = true;
+            reject(best);
+          }
+        },
+      );
     }
-  }
-  throw lastError;
+  });
 }

--- a/src/mobile/pairing.ts
+++ b/src/mobile/pairing.ts
@@ -1,0 +1,133 @@
+// Pairing flows for the companion: parse the desktop's QR payload,
+// redeem a code via the mobile shell's `gateway_pair` command, and turn
+// the outcome into a `MobileConnection`.
+//
+// Error handling mirrors pair.rs's string contract: `net:<detail>` for
+// transport failures (worth trying the next candidate host) and
+// `pair:<status>:<message>` for server verdicts (terminal — the code was
+// wrong, consumed, or the window lapsed; retrying another host would
+// only burn the 5-attempt budget).
+
+import { invoke } from "@tauri-apps/api/core";
+
+import type { MobileConnection } from "./mobileConnection";
+
+/** The JSON the desktop encodes in its pairing QR (pairing.rs). */
+export interface QrPairingPayload {
+  v: 1;
+  name: string;
+  hosts: string[];
+  port: number;
+  fp: string;
+  code: string;
+}
+
+/** What `gateway_pair` resolves with (pair.rs `PairOutcome`). */
+export interface PairOutcome {
+  deviceId: string;
+  deviceToken: string;
+  hostDisplayName: string;
+  hostFingerprint: string;
+}
+
+/** Classified pairing failure. `kind: "net"` failures are worth trying
+ *  the next candidate host; `kind: "pair"` verdicts are terminal. */
+export class PairFailure extends Error {
+  readonly kind: "net" | "pair";
+  readonly status?: number;
+
+  constructor(kind: "net" | "pair", message: string, status?: number) {
+    super(message);
+    this.name = "PairFailure";
+    this.kind = kind;
+    this.status = status;
+  }
+}
+
+export const DEFAULT_DEVICE_NAME = "iPhone";
+
+export function parseQrPayload(text: string): QrPairingPayload | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const p = parsed as Record<string, unknown>;
+  if (p.v !== 1) return null;
+  if (typeof p.code !== "string" || !/^\d{8}$/.test(p.code)) return null;
+  if (typeof p.port !== "number" || !Number.isInteger(p.port) || p.port <= 0) return null;
+  if (typeof p.fp !== "string") return null;
+  const hosts = Array.isArray(p.hosts) ? p.hosts.filter((h) => typeof h === "string") : [];
+  if (hosts.length === 0) return null;
+  return {
+    v: 1,
+    name: typeof p.name === "string" ? p.name : "",
+    hosts,
+    port: p.port,
+    fp: p.fp,
+    code: p.code,
+  };
+}
+
+/** Decode pair.rs's error strings; anything unrecognized counts as a
+ *  network-ish failure so host iteration keeps going. */
+export function classifyPairError(raw: unknown): PairFailure {
+  if (raw instanceof PairFailure) return raw;
+  const text = typeof raw === "string" ? raw : raw instanceof Error ? raw.message : String(raw);
+  const pairMatch = /^pair:(\d{3}):(.*)$/s.exec(text);
+  if (pairMatch) {
+    return new PairFailure("pair", pairMatch[2], Number(pairMatch[1]));
+  }
+  return new PairFailure("net", text.replace(/^net:/, ""));
+}
+
+/** Human message for a pairing failure, with the 120s-window expiry
+ *  spelled out — it's the error every first-time user will hit. */
+export function pairErrorMessage(error: PairFailure): string {
+  if (error.kind === "pair" && (error.status === 410 || error.status === 404)) {
+    return "Pairing window expired — start pairing again on the desktop (Settings → Remote Devices).";
+  }
+  if (error.kind === "pair") return `Pairing failed: ${error.message}`;
+  return `Could not reach the desktop: ${error.message}`;
+}
+
+export async function pairWithHosts(opts: {
+  hosts: string[];
+  port: number;
+  fingerprint: string;
+  code: string;
+  deviceName?: string;
+  /** Test seam; defaults to the shim invoke. */
+  invokeFn?: (cmd: string, args: Record<string, unknown>) => Promise<unknown>;
+}): Promise<{ connection: MobileConnection; outcome: PairOutcome }> {
+  const invokeFn = opts.invokeFn ?? invoke;
+  const deviceName = opts.deviceName ?? DEFAULT_DEVICE_NAME;
+  let lastError = new PairFailure("net", "no candidate hosts");
+  for (const candidate of opts.hosts) {
+    const host = candidate.includes(":") ? candidate : `${candidate}:${opts.port}`;
+    try {
+      const outcome = (await invokeFn("gateway_pair", {
+        host,
+        fingerprint: opts.fingerprint,
+        code: opts.code,
+        deviceName,
+      })) as PairOutcome;
+      return {
+        connection: {
+          host,
+          token: outcome.deviceToken,
+          fingerprint: opts.fingerprint || undefined,
+        },
+        outcome,
+      };
+    } catch (err) {
+      lastError = classifyPairError(err);
+      // A server verdict is terminal; only transport failures fall
+      // through to the next candidate.
+      if (lastError.kind === "pair") throw lastError;
+    }
+  }
+  throw lastError;
+}

--- a/src/mobile/useNearbyDesktops.test.ts
+++ b/src/mobile/useNearbyDesktops.test.ts
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const invokeMock = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+vi.mock("../gateway/rustBridgeAdapter", () => ({
+  isTauriRuntime: () => true,
+}));
+
+import { useNearbyDesktops } from "./useNearbyDesktops";
+
+const DESKTOP = {
+  id: "remote:ff",
+  name: "halcyon",
+  host: "halcyon.local:48213",
+  hostname: "halcyon.local",
+  port: 48213,
+  fingerprint: "ff".repeat(32),
+  version: "0.11.2",
+};
+
+beforeEach(() => {
+  invokeMock.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useNearbyDesktops", () => {
+  it("polls discovery_scan and exposes the sorted snapshot", async () => {
+    invokeMock.mockResolvedValue([
+      { ...DESKTOP, name: "zeta", id: "remote:zz", fingerprint: "zz" },
+      DESKTOP,
+    ]);
+    const { result, unmount } = renderHook(() => useNearbyDesktops(true));
+    await waitFor(() => expect(result.current.desktops).toHaveLength(2));
+    expect(invokeMock).toHaveBeenCalledWith("discovery_scan", { timeoutMs: 2500 });
+    expect(result.current.desktops.map((d) => d.name)).toEqual(["halcyon", "zeta"]);
+    expect(result.current.error).toBeNull();
+    unmount();
+  });
+
+  it("does not scan when disabled", async () => {
+    const { result } = renderHook(() => useNearbyDesktops(false));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(invokeMock).not.toHaveBeenCalled();
+    expect(result.current.desktops).toEqual([]);
+  });
+
+  it("surfaces scan errors without clearing on unmount races", async () => {
+    invokeMock.mockRejectedValue(new Error("discovery unsupported on this platform"));
+    const { result, unmount } = renderHook(() => useNearbyDesktops(true));
+    await waitFor(() => expect(result.current.error).toMatch(/unsupported/));
+    unmount();
+  });
+});

--- a/src/mobile/useNearbyDesktops.ts
+++ b/src/mobile/useNearbyDesktops.ts
@@ -1,0 +1,69 @@
+// Polls the mobile shell's Bonjour snapshot scan while the connect
+// screen is visible. Each `discovery_scan` browses for ~2.5s; polling
+// back-to-back (with a small gap) is effectively live discovery without
+// a streaming thread to manage across iOS backgrounding.
+
+import { useEffect, useRef, useState } from "react";
+
+import { invoke } from "@tauri-apps/api/core";
+import { isTauriRuntime } from "../gateway/rustBridgeAdapter";
+
+export interface DiscoveredDesktop {
+  id: string;
+  name: string;
+  /** `<hostname>:<port>` — ready for gateway_pair / MobileConnection. */
+  host: string;
+  hostname: string;
+  port: number;
+  /** Full cert fingerprint — what the connection pins. */
+  fingerprint: string;
+  version: string;
+}
+
+const SCAN_MS = 2500;
+const GAP_MS = 1500;
+
+export function useNearbyDesktops(enabled: boolean): {
+  desktops: DiscoveredDesktop[];
+  scanning: boolean;
+  error: string | null;
+} {
+  const [desktops, setDesktops] = useState<DiscoveredDesktop[]>([]);
+  const [scanning, setScanning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const active = enabled && isTauriRuntime();
+  const cancelledRef = useRef(false);
+
+  useEffect(() => {
+    if (!active) return;
+    cancelledRef.current = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const tick = async () => {
+      setScanning(true);
+      try {
+        const found = await invoke<DiscoveredDesktop[]>("discovery_scan", {
+          timeoutMs: SCAN_MS,
+        });
+        if (cancelledRef.current) return;
+        setDesktops([...found].sort((a, b) => a.name.localeCompare(b.name)));
+        setError(null);
+      } catch (err) {
+        if (cancelledRef.current) return;
+        setError(String(err));
+      }
+      if (cancelledRef.current) return;
+      setScanning(false);
+      timer = setTimeout(() => void tick(), GAP_MS);
+    };
+    void tick();
+
+    return () => {
+      cancelledRef.current = true;
+      if (timer !== undefined) clearTimeout(timer);
+      setScanning(false);
+    };
+  }, [active]);
+
+  return { desktops, scanning, error };
+}

--- a/src/styles/chrome/overlays.css
+++ b/src/styles/chrome/overlays.css
@@ -395,6 +395,17 @@
   border-radius: 8px;
   background: color-mix(in oklab, var(--accent) 5%, transparent);
 }
+.ae-remote-qr {
+  display: flex;
+  justify-content: center;
+}
+.ae-remote-qr svg {
+  /* Always a white card — phones can't reliably scan light-on-dark
+     codes, and the padding doubles as the QR quiet zone. */
+  background: #fff;
+  padding: 10px;
+  border-radius: 10px;
+}
 .ae-remote-pairing-code {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 2rem;

--- a/src/styles/mobile.css
+++ b/src/styles/mobile.css
@@ -356,3 +356,156 @@
   color: var(--text-dim);
   padding: 16px 14px;
 }
+
+/* =============================================================================
+   Pairing — QR scan overlay + nearby-desktops discovery
+   ============================================================================= */
+
+/* The barcode scanner renders the camera BEHIND the webview (windowed
+   mode makes the WKWebView transparent); the page must go transparent
+   too or the camera never shows. Set while ScanOverlay is mounted. */
+html[data-ae-scan],
+html[data-ae-scan] body,
+html[data-ae-scan] #root {
+  background: transparent !important;
+}
+
+.ae-scan-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 16px;
+  padding: 24px;
+  padding-bottom: calc(24px + env(safe-area-inset-bottom));
+  z-index: 100;
+}
+.ae-scan-cutout {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: min(70vw, 320px);
+  aspect-ratio: 1;
+  transform: translate(-50%, -60%);
+  border-radius: 18px;
+  /* Dim everything except the cutout — the camera stays visible in the
+     hole and washed-out around it. */
+  box-shadow: 0 0 0 100vmax rgba(0, 0, 0, 0.55);
+  outline: 2px solid rgba(255, 255, 255, 0.85);
+}
+.ae-scan-hint {
+  position: relative;
+  margin: 0;
+  color: #fff;
+  text-align: center;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.8);
+  font-size: 0.95rem;
+}
+.ae-scan-cancel {
+  position: relative;
+  min-width: 160px;
+}
+.ae-scan-denied {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin: auto;
+  padding: 20px;
+  border-radius: 14px;
+  background: var(--bg-elev, #222);
+  color: var(--text, #eee);
+  max-width: 320px;
+  text-align: center;
+}
+
+.ae-mobile-nearby {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 6px;
+}
+.ae-mobile-nearby-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-dim);
+}
+.ae-mobile-nearby-spinner {
+  width: 12px;
+  height: 12px;
+  border: 2px solid var(--border);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: ae-mobile-spin 0.9s linear infinite;
+}
+.ae-mobile-nearby-empty {
+  margin: 0;
+  color: var(--text-dim);
+  font-size: 0.85rem;
+}
+.ae-mobile-nearby-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.ae-mobile-nearby-row {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  width: 100%;
+  min-height: 44px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg-input);
+  color: var(--text);
+  text-align: left;
+  cursor: pointer;
+}
+.ae-mobile-nearby-name {
+  font-weight: 600;
+}
+.ae-mobile-nearby-meta {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.75rem;
+  color: var(--text-dim);
+}
+.ae-mobile-nearby-code {
+  display: flex;
+  gap: 8px;
+  margin-top: 6px;
+}
+.ae-mobile-nearby-code .ae-mobile-input {
+  flex: 1 1 auto;
+  letter-spacing: 0.2em;
+}
+.ae-mobile-nearby-code .ae-mobile-connect-button {
+  flex: 0 0 auto;
+}
+
+.ae-mobile-manual {
+  margin-top: 8px;
+}
+.ae-mobile-manual summary {
+  color: var(--text-dim);
+  font-size: 0.85rem;
+  cursor: pointer;
+  margin-bottom: 6px;
+}
+.ae-mobile-manual .ae-mobile-field {
+  margin-top: 8px;
+}
+.ae-mobile-manual .ae-mobile-connect-button {
+  margin-top: 10px;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,13 @@ const port = Number(process.env.VITE_PORT ?? 1420);
 export default defineConfig({
   plugins: [react()],
   clearScreen: false,
+  optimizeDeps: {
+    // The dep scanner treats every root-level .html as an entry, which
+    // pulls in index.mobile.html → the @tauri-real/* aliases that only
+    // vite.mobile.config.ts defines. Scope the desktop scan to the
+    // desktop entry.
+    entries: ["index.html"],
+  },
   server: {
     port,
     strictPort: true,

--- a/vite.mobile.config.ts
+++ b/vite.mobile.config.ts
@@ -87,6 +87,11 @@ export default defineConfig({
     host: host || false,
     port: 1430,
     strictPort: true,
+    // Tauri's mobile dev loop proxies this server through the
+    // tauri://localhost custom scheme, which WKWebView treats as an
+    // opaque origin — module-script loads then run in CORS mode and
+    // need this header or they all fail (white screen).
+    headers: { "access-control-allow-origin": "*" },
     hmr: host ? { protocol: "ws", host, port: 1431 } : undefined,
     watch: {
       ignored: ["**/.direnv/**", "**/target/**", "**/node_modules/**"],


### PR DESCRIPTION
## What & why

The companion could only pair by hand-typing host:port + token + fingerprint. This makes pairing effortless and gets the app onto real hardware:

- **Desktop QR** (Settings → Remote Devices): the already-produced `qrPayload` now renders as a single-path SVG via `uqr` on an always-white card (phones can't scan light-on-dark). The 8-digit code stays prominent — it feeds the discovery flow.
- **Phone: Scan QR** — `@tauri-apps/plugin-barcode-scanner` windowed scan (camera renders behind the webview; a `data-ae-scan` attribute flips the page transparent with a cutout frame). The payload's `hosts[]` are tried in order via a new `gateway_pair` command: a hand-rolled HTTP/1.1 `POST /pair` over the same pinned-rustls config as the WS bridge (reqwest would drag hyper/h2/tower into the iOS staticlib for one endpoint). Net errors fall through to the next host; server verdicts stop immediately so a wrong/consumed code can't burn the 5-attempt budget. The 120s window expiry surfaces as an explicit "start pairing again" message.
- **Phone: Nearby desktops** — `discovery_scan` browses `_aethon._tcp` via the dnssd C API (mDNSResponder — the sanctioned iOS path needing only the existing `NSBonjourServices` plist key; raw-multicast crates need the restricted multicast entitlement). Snapshot scans polled while the connect screen is idle; tap a desktop, type the code, done. The full TXT fingerprint pins the connection.
- **Command routing**: `gateway_*` / `discovery_*` / `plugin:barcode-scanner|*` route locally in `commandPolicy` — the shim's gateway-by-default would otherwise forward the pairing commands to the desktop they exist to reach.
- **Signed device builds**: `ios-device` devshell helper — signed `--target aarch64` build (DEVELOPMENT_TEAM `28X9H69QGE` + automatic signing against the team's local cert + wildcard profile; the team id is the cert's OU, not the parenthetical in its name), then `devicectl` install + launch on the connected iPhone. Verified end-to-end on an iPhone 13 Pro (iOS 27). Gotcha encoded in ios.sh: `tauri ios build -- <args>` forwards to cargo, not xcodebuild.
- Desktop vite dep-scanner scoped to `index.html` (it crawled `index.mobile.html` and warned about the mobile-only `@tauri-real` aliases after every lockfile change).

## Verification

- Full `check` gate green (2999 vitest incl. new pairing/discovery/ConnectScreen suites; clippy both targets; mobile crate host tests for the HTTP + TXT parsers) + `cargo check --target aarch64-apple-ios-sim`.
- Live: signed build installed + launched on a physical iPhone 13 Pro via `ios-device`; QR renders in desktop Settings.

## Notes

- QR scan is device-only (simulator has no camera); Nearby discovery works in the simulator too.
- Manual host/token/fingerprint entry stays, collapsed under "Manual setup" (also the browser dev-loop path).
