### PR TITLE
fix(remote): stop companion reconnect storm and duplicated stream text

### DIFF
--- a/apps/mobile/src-tauri/src/gateway.rs
+++ b/apps/mobile/src-tauri/src/gateway.rs
@@ -210,9 +210,10 @@ pub async fn gateway_send(state: State<'_, Arc<GatewayState>>, text: String) -> 
 
 #[tauri::command]
 pub async fn gateway_close(state: State<'_, Arc<GatewayState>>) -> Result<(), String> {
-    // Invalidate the live reader so it exits without emitting a close
-    // for a connection the JS side already abandoned.
-    state.generation.fetch_add(1, Ordering::SeqCst);
+    // No generation bump here: the JS adapter unlistens synchronously
+    // before invoking this, so stray frames from the dying socket are
+    // already undeliverable — and bumping would let a close that lands
+    // after a racing gateway_connect orphan the FRESH connection.
     // Dropping the sender ends the writer task, which closes the socket.
     *state.tx.lock().await = None;
     Ok(())

--- a/apps/mobile/src-tauri/src/gateway.rs
+++ b/apps/mobile/src-tauri/src/gateway.rs
@@ -14,6 +14,7 @@
 //! logic here — protocol semantics stay in the shared JS transport.
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use futures_util::{SinkExt, StreamExt};
 use serde::Serialize;
@@ -24,9 +25,17 @@ use tokio_tungstenite::tungstenite::Message;
 
 /// One outbound socket + its writer channel. Replacing it (reconnect)
 /// drops the previous task, closing the old socket.
+///
+/// `generation` stamps each connect; reader tasks from superseded
+/// connections check it before emitting. Without the stamp, the old
+/// socket's teardown emitted a `close` frame onto the shared
+/// `gateway-frame` stream and the JS transport read it as the NEW
+/// connection dying — every reconnect killed its successor, looping
+/// forever.
 #[derive(Default)]
 pub struct GatewayState {
     tx: Mutex<Option<mpsc::UnboundedSender<Message>>>,
+    generation: AtomicU64,
 }
 
 #[derive(Clone, Serialize)]
@@ -134,6 +143,8 @@ pub async fn gateway_connect(
     fingerprint: String,
 ) -> Result<(), String> {
     let _ = rustls::crypto::ring::default_provider().install_default();
+    let state = Arc::clone(state.inner());
+    let generation = state.generation.fetch_add(1, Ordering::SeqCst) + 1;
     let (tx, mut rx) = mpsc::unbounded_channel::<Message>();
     // Swapping the sender drops any prior writer; the old task then sees
     // its receiver close and exits, tearing down the previous socket.
@@ -147,19 +158,34 @@ pub async fn gateway_connect(
     let (ws, _) = tokio_tungstenite::connect_async_tls_with_config(&url, None, false, connector)
         .await
         .map_err(|e| format!("connect {url}: {e}"))?;
+    // The lock isn't held across the handshake await — a newer connect
+    // (or an explicit close) may have superseded this one. Dropping the
+    // ws here closes the socket without emitting anything.
+    if state.generation.load(Ordering::SeqCst) != generation {
+        return Ok(());
+    }
     let (mut sink, mut stream) = ws.split();
     emit(&app, GatewayFrame::Open);
 
     let app_reader = app.clone();
+    let reader_state = Arc::clone(&state);
     tauri::async_runtime::spawn(async move {
         while let Some(msg) = stream.next().await {
+            if reader_state.generation.load(Ordering::SeqCst) != generation {
+                // Superseded mid-stream: stop silently. Emitting (or
+                // falling through to the close emit) would interleave
+                // stale frames into the successor connection.
+                return;
+            }
             match msg {
                 Ok(Message::Text(text)) => emit(&app_reader, GatewayFrame::Message { text }),
                 Ok(Message::Close(_)) | Err(_) => break,
                 _ => {}
             }
         }
-        emit(&app_reader, GatewayFrame::Close);
+        if reader_state.generation.load(Ordering::SeqCst) == generation {
+            emit(&app_reader, GatewayFrame::Close);
+        }
     });
 
     tauri::async_runtime::spawn(async move {
@@ -184,6 +210,9 @@ pub async fn gateway_send(state: State<'_, Arc<GatewayState>>, text: String) -> 
 
 #[tauri::command]
 pub async fn gateway_close(state: State<'_, Arc<GatewayState>>) -> Result<(), String> {
+    // Invalidate the live reader so it exits without emitting a close
+    // for a connection the JS side already abandoned.
+    state.generation.fetch_add(1, Ordering::SeqCst);
     // Dropping the sender ends the writer task, which closes the socket.
     *state.tx.lock().await = None;
     Ok(())

--- a/src-tauri/src/server/remote/events.rs
+++ b/src-tauri/src/server/remote/events.rs
@@ -69,7 +69,14 @@ pub struct EventHub {
 /// Bounded so a wedged consumer can't hold unbounded memory; a receiver
 /// that observes `Lagged` is disconnected by its connection task and the
 /// client rehydrates on reconnect.
-const HUB_CAPACITY: usize = 1024;
+///
+/// Sized for the worst realistic burst, not the steady state: a project
+/// switch replays the full extension surface and an agent turn streams
+/// per-token deltas plus PTY chunks. At 1024 a phone on Wi-Fi lagged the
+/// ring during those bursts and was kicked (`bye slow-consumer`),
+/// reconnected into the same burst, and looped. Slots hold `Arc`s, so
+/// the cost of the larger ring is bounded by live frames, not capacity.
+const HUB_CAPACITY: usize = 8192;
 
 impl EventHub {
     pub fn new() -> Self {

--- a/src/gateway/rustBridgeAdapter.test.ts
+++ b/src/gateway/rustBridgeAdapter.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RustBridgeAdapter } from "./rustBridgeAdapter";
+
+// In-memory stand-in for the mobile shell's `gateway-frame` event bus.
+// The real bug lived here: each open() registered one more listener on
+// this bus but only the latest unlisten was kept, so after N reconnects
+// every frame was delivered N times (assistant text duplication, #462).
+const bus = vi.hoisted(() => ({
+  listeners: new Set<(e: { payload: unknown }) => void>(),
+}));
+
+vi.mock("@tauri-real/event", () => ({
+  listen: (_event: string, handler: (e: { payload: unknown }) => void) => {
+    bus.listeners.add(handler);
+    return Promise.resolve(() => bus.listeners.delete(handler));
+  },
+}));
+
+function emitFrame(frame: { kind: string; text?: string }): void {
+  for (const listener of [...bus.listeners]) listener({ payload: frame });
+}
+
+async function flush(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("RustBridgeAdapter", () => {
+  const invoke = vi.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    bus.listeners.clear();
+    invoke.mockClear();
+    (globalThis as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {
+      invoke,
+    };
+  });
+
+  afterEach(() => {
+    delete (globalThis as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
+  });
+
+  it("reopening replaces the gateway-frame listener instead of stacking", async () => {
+    const adapter = new RustBridgeAdapter("fp");
+    const received: string[] = [];
+    adapter.onMessage((text) => received.push(text));
+
+    adapter.open("wss://host/ws");
+    await flush();
+    expect(bus.listeners.size).toBe(1);
+
+    // The transport reuses one adapter instance across reconnects.
+    adapter.open("wss://host/ws");
+    await flush();
+    expect(bus.listeners.size).toBe(1);
+
+    emitFrame({ kind: "message", text: "hello" });
+    expect(received).toEqual(["hello"]);
+  });
+
+  it("close() during a pending open drops the late listener registration", async () => {
+    const adapter = new RustBridgeAdapter("fp");
+    adapter.open("wss://host/ws");
+    adapter.close(); // races the async listen() registration
+    await flush();
+
+    expect(bus.listeners.size).toBe(0);
+    // The superseded open must not proceed to connect either.
+    expect(invoke).not.toHaveBeenCalledWith("gateway_connect", {
+      url: "wss://host/ws",
+      fingerprint: "fp",
+    });
+  });
+
+  it("frames stop after close() even if an unlisten is still in flight", async () => {
+    const adapter = new RustBridgeAdapter("fp");
+    const received: string[] = [];
+    adapter.onMessage((text) => received.push(text));
+
+    adapter.open("wss://host/ws");
+    await flush();
+    adapter.close();
+    emitFrame({ kind: "message", text: "stale" });
+
+    expect(received).toEqual([]);
+  });
+});

--- a/src/gateway/rustBridgeAdapter.ts
+++ b/src/gateway/rustBridgeAdapter.ts
@@ -46,6 +46,11 @@ export class RustBridgeAdapter implements SocketAdapter {
   private closeHandler: () => void = () => {};
   private unlisten: (() => void) | null = null;
   private readonly fingerprint: string;
+  /** Bumped on every open()/close(). Guards both the async listen
+   *  registration and frame delivery so a superseded open can't leak a
+   *  live `gateway-frame` listener — one leaked listener per reconnect
+   *  meant every frame was delivered N times (#462). */
+  private openSeq = 0;
 
   constructor(fingerprint: string) {
     this.fingerprint = fingerprint;
@@ -57,17 +62,30 @@ export class RustBridgeAdapter implements SocketAdapter {
       this.closeHandler();
       return;
     }
+    // Reopening replaces the previous registration, never adds to it.
+    this.unlisten?.();
+    this.unlisten = null;
+    const seq = ++this.openSeq;
     void listen<GatewayFrame>("gateway-frame", (e) => {
+      if (seq !== this.openSeq) return;
       const frame = e.payload;
       if (frame.kind === "open") this.openHandler();
       else if (frame.kind === "message" && frame.text) this.messageHandler(frame.text);
       else if (frame.kind === "close") this.closeHandler();
     })
       .then((fn) => {
+        if (seq !== this.openSeq) {
+          // close() or a newer open() won the race while listen() was
+          // registering — drop this registration immediately.
+          fn();
+          return;
+        }
         this.unlisten = fn;
         return runtime.invoke("gateway_connect", { url, fingerprint: this.fingerprint });
       })
-      .catch(() => this.closeHandler());
+      .catch(() => {
+        if (seq === this.openSeq) this.closeHandler();
+      });
   }
 
   send(text: string): void {
@@ -75,6 +93,7 @@ export class RustBridgeAdapter implements SocketAdapter {
   }
 
   close(): void {
+    this.openSeq += 1;
     this.unlisten?.();
     this.unlisten = null;
     void internals()?.invoke("gateway_close");

--- a/src/gateway/transport.test.ts
+++ b/src/gateway/transport.test.ts
@@ -206,6 +206,53 @@ describe("gateway transport", () => {
     expect(t.getStatus()).toBe("idle");
   });
 
+  it("keeps escalating backoff when connections die young (slow-consumer kick loop)", async () => {
+    vi.useFakeTimers();
+    const socket = new FakeSocket();
+    const t = makeTransport(socket);
+    const connected = t.connect();
+    await vi.advanceTimersByTimeAsync(0);
+    socket.helloOk();
+    await connected;
+
+    // Kicked right after connecting — inside the stability window, so
+    // hello_ok must NOT have reset the backoff. Pre-fix this looped a
+    // kicked client back into an overloaded host every ~500ms forever.
+    socket.drop();
+    await vi.advanceTimersByTimeAsync(500); // first retry: 500ms base
+    expect(socket.opened).toBe(2);
+    await vi.advanceTimersByTimeAsync(0);
+    socket.helloOk();
+    socket.drop(); // kicked again, still young
+    await vi.advanceTimersByTimeAsync(600);
+    expect(socket.opened).toBe(2); // escalated to 1000ms — not due yet
+    await vi.advanceTimersByTimeAsync(500);
+    expect(socket.opened).toBe(3);
+  });
+
+  it("resets backoff once a connection survives the stability window", async () => {
+    vi.useFakeTimers();
+    const socket = new FakeSocket();
+    const t = makeTransport(socket);
+    const connected = t.connect();
+    await vi.advanceTimersByTimeAsync(0);
+    socket.helloOk();
+    await connected;
+
+    // Escalate the backoff with one young death…
+    socket.drop();
+    await vi.advanceTimersByTimeAsync(500);
+    expect(socket.opened).toBe(2);
+    await vi.advanceTimersByTimeAsync(0);
+    socket.helloOk();
+    // …then stay connected through the stability window.
+    await vi.advanceTimersByTimeAsync(15_000);
+    socket.drop();
+    // Backoff is back at the 500ms minimum, not the escalated 1000ms.
+    await vi.advanceTimersByTimeAsync(500);
+    expect(socket.opened).toBe(3);
+  });
+
   it("does not reconnect after an auth-failed bye", async () => {
     vi.useFakeTimers();
     const socket = new FakeSocket();

--- a/src/gateway/transport.ts
+++ b/src/gateway/transport.ts
@@ -210,9 +210,15 @@ export class GatewayTransport {
     // — every event frame was then delivered once per zombie socket
     // (the mobile text-duplication bug), and the zombie's eventual
     // close event tore down the healthy connection.
+    //
+    // A reused adapter instance (RustBridgeAdapter) is NOT closed here:
+    // its open() already replaces the frame listener, and the native
+    // gateway_connect supersedes the old socket. Racing an async
+    // gateway_close against the follow-up gateway_connect could tear
+    // down the fresh connection instead of the stale one.
     const gen = ++this.generation;
-    this.adapter?.close();
     const adapter = this.config.adapter ?? defaultAdapter();
+    if (this.adapter && this.adapter !== adapter) this.adapter.close();
     this.adapter = adapter;
     this.setStatus(this.lastHello ? "reconnecting" : "connecting");
 

--- a/src/gateway/transport.ts
+++ b/src/gateway/transport.ts
@@ -63,6 +63,12 @@ type StatusListener = (status: GatewayStatus) => void;
 const DEFAULT_TIMEOUT_MS = 30_000;
 const BACKOFF_MIN_MS = 500;
 const BACKOFF_MAX_MS = 30_000;
+/** How long a connection must survive before the reconnect backoff
+ *  resets. Resetting on hello_ok alone let a server-side slow-consumer
+ *  kick loop reconnect at the minimum delay forever (connect → kicked
+ *  seconds later → connect …), hammering a host that is already
+ *  overloaded. */
+const BACKOFF_STABLE_MS = 15_000;
 
 export class GatewayOfflineError extends Error {
   constructor(cmd: string) {
@@ -85,7 +91,13 @@ export class GatewayTransport {
   private lastHello: HelloOk | null = null;
   private backoffMs = BACKOFF_MIN_MS;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private stableTimer: ReturnType<typeof setTimeout> | null = null;
   private wantConnected = false;
+  /** Socket generation. Each openSocket() supersedes every previous
+   *  socket: callbacks captured by older generations are ignored, so a
+   *  half-open or half-dead socket can't double-deliver events or kill
+   *  a fresh connection with its own close. */
+  private generation = 0;
 
   configure(config: GatewayConfig): void {
     this.config = config;
@@ -127,6 +139,10 @@ export class GatewayTransport {
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
+    }
+    if (this.stableTimer) {
+      clearTimeout(this.stableTimer);
+      this.stableTimer = null;
     }
     // Reject an in-flight connect() so its awaiter doesn't hang forever,
     // and so a later reconnect can't resolve this abandoned attempt.
@@ -189,11 +205,19 @@ export class GatewayTransport {
 
   private openSocket(): void {
     if (!this.config) return;
+    // Supersede any previous socket BEFORE wiring the new one. Without
+    // this, a stacked reconnect left the old socket's handlers attached
+    // — every event frame was then delivered once per zombie socket
+    // (the mobile text-duplication bug), and the zombie's eventual
+    // close event tore down the healthy connection.
+    const gen = ++this.generation;
+    this.adapter?.close();
     const adapter = this.config.adapter ?? defaultAdapter();
     this.adapter = adapter;
     this.setStatus(this.lastHello ? "reconnecting" : "connecting");
 
     adapter.onOpen(() => {
+      if (gen !== this.generation) return;
       adapter.send(
         JSON.stringify({
           t: "hello",
@@ -204,8 +228,14 @@ export class GatewayTransport {
         }),
       );
     });
-    adapter.onMessage((text) => this.handleFrame(text));
-    adapter.onClose(() => this.handleClose());
+    adapter.onMessage((text) => {
+      if (gen !== this.generation) return;
+      this.handleFrame(text);
+    });
+    adapter.onClose(() => {
+      if (gen !== this.generation) return;
+      this.handleClose();
+    });
     adapter.open(this.config.url);
   }
 
@@ -220,7 +250,13 @@ export class GatewayTransport {
       case "hello_ok": {
         const hello = frame as unknown as HelloOk;
         this.lastHello = hello;
-        this.backoffMs = BACKOFF_MIN_MS;
+        // Backoff resets only once the link proves stable — see
+        // BACKOFF_STABLE_MS.
+        if (this.stableTimer) clearTimeout(this.stableTimer);
+        this.stableTimer = setTimeout(() => {
+          this.stableTimer = null;
+          this.backoffMs = BACKOFF_MIN_MS;
+        }, BACKOFF_STABLE_MS);
         this.setStatus("connected");
         this.resubscribeAll();
         this.helloResolve?.(hello);
@@ -261,6 +297,10 @@ export class GatewayTransport {
   }
 
   private handleClose(): void {
+    if (this.stableTimer) {
+      clearTimeout(this.stableTimer);
+      this.stableTimer = null;
+    }
     for (const entry of this.pending.values()) {
       clearTimeout(entry.timer);
       entry.reject(new Error("gateway connection closed"));

--- a/src/hooks/bridgeMessageHandlers/ready.test.ts
+++ b/src/hooks/bridgeMessageHandlers/ready.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { handleReady } from "./ready";
+import { resetReplayedTabsForTest } from "./readyEffects";
 import { buildHandlerFixture } from "./testFixtures";
 import { clearTauriMocks, installTauriMocks } from "../../test/tauriMocks";
 import { makeEmptyTab } from "../../types/tab";
@@ -11,6 +12,7 @@ describe("handleReady", () => {
 
   beforeEach(() => {
     installTauriMocks();
+    resetReplayedTabsForTest();
   });
   afterEach(() => {
     grammarSpy?.mockRestore();

--- a/src/hooks/bridgeMessageHandlers/ready.ts
+++ b/src/hooks/bridgeMessageHandlers/ready.ts
@@ -136,6 +136,17 @@ export const handleReady: BridgeMessageHandler = (data, ctx) => {
       | ExtensionHighlightGrammar[]
       | undefined) ?? [];
   const extStateKeys = (data.extensionStateKeys as string[] | undefined) ?? [];
+  const bridgeTabs =
+    (data.tabs as
+      | {
+          id: string;
+          model: string;
+          cwd?: string;
+          authProfileId?: string;
+          contextUsage?: Record<string, unknown>;
+          thinkingLevel?: string;
+        }[]
+      | undefined) ?? [];
   const discTabs =
     (data.discoveredTabs as DiscoveredSession[] | undefined) ?? [];
   const authProfiles =
@@ -236,17 +247,7 @@ export const handleReady: BridgeMessageHandler = (data, ctx) => {
     reduceReadyState(prev, {
       authProfiles,
       baseLayout,
-      bridgeTabs:
-        (data.tabs as
-          | {
-              id: string;
-              model: string;
-              cwd?: string;
-              authProfileId?: string;
-              contextUsage?: Record<string, unknown>;
-              thinkingLevel?: string;
-            }[]
-          | undefined) ?? [],
+      bridgeTabs,
       codexFastMode: data.codexFastMode,
       extState,
       fallbackModel,
@@ -269,5 +270,6 @@ export const handleReady: BridgeMessageHandler = (data, ctx) => {
     currentProjectCwd,
     priorActiveTabCwd,
     priorActiveTabId,
+    bridgeTabIds: new Set(bridgeTabs.map((t) => t.id)),
   });
 };

--- a/src/hooks/bridgeMessageHandlers/readyEffects.test.ts
+++ b/src/hooks/bridgeMessageHandlers/readyEffects.test.ts
@@ -230,8 +230,23 @@ describe("runReadyEffects", () => {
       ...input,
       bridgeTabIds: new Set(["tab-1", "tab-2"]),
     });
-    expect(ctx.pendingTabOpens.current.has("tab-1")).toBe(true);
-    expect(ctx.pendingTabOpens.current.has("tab-2")).toBe(true);
+    const firstOpens = new Map(ctx.pendingTabOpens.current);
+    expect(firstOpens.has("tab-1")).toBe(true);
+    expect(firstOpens.has("tab-2")).toBe(true);
+
+    // A ready that re-fires while those opens are still in flight (the
+    // bridge snapshot can't reflect them yet) must not double-send.
+    runReadyEffects(ctx, {
+      ...input,
+      bridgeTabIds: new Set<string>(),
+    });
+    expect(ctx.pendingTabOpens.current.get("tab-1")).toBe(
+      firstOpens.get("tab-1"),
+    );
+    expect(ctx.pendingTabOpens.current.get("tab-2")).toBe(
+      firstOpens.get("tab-2"),
+    );
+
     // Let the .finally() cleanup that clears pendingTabOpens flush.
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(ctx.pendingTabOpens.current.size).toBe(0);

--- a/src/hooks/bridgeMessageHandlers/readyEffects.test.ts
+++ b/src/hooks/bridgeMessageHandlers/readyEffects.test.ts
@@ -1,13 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildHandlerFixture } from "./testFixtures";
 import { clearTauriMocks, installTauriMocks } from "../../test/tauriMocks";
-import { runReadyEffects } from "./readyEffects";
+import { resetReplayedTabsForTest, runReadyEffects } from "./readyEffects";
 
 describe("runReadyEffects", () => {
   let harness: ReturnType<typeof installTauriMocks>;
 
   beforeEach(() => {
     harness = installTauriMocks();
+    resetReplayedTabsForTest();
   });
 
   afterEach(() => {
@@ -38,6 +39,7 @@ describe("runReadyEffects", () => {
       currentProjectCwd: null,
       priorActiveTabCwd: null,
       priorActiveTabId: "default",
+      bridgeTabIds: new Set<string>(),
     });
 
     expect(prepareWorkspaceStartup).toHaveBeenCalledWith("/repo/a");
@@ -68,6 +70,7 @@ describe("runReadyEffects", () => {
       currentProjectCwd: null,
       priorActiveTabCwd: null,
       priorActiveTabId: "default",
+      bridgeTabIds: new Set<string>(),
     });
 
     await ctx.pendingTabOpens.current.get("tab-1");
@@ -105,6 +108,7 @@ describe("runReadyEffects", () => {
       currentProjectCwd: null,
       priorActiveTabCwd: null,
       priorActiveTabId: "default",
+      bridgeTabIds: new Set<string>(),
     });
 
     // The exact `~/.aethon` root is the bridge's fallback cwd for tabs with
@@ -139,6 +143,7 @@ describe("runReadyEffects", () => {
       currentProjectCwd: "/wrong",
       priorActiveTabCwd: null,
       priorActiveTabId: "default",
+      bridgeTabIds: new Set<string>(),
     });
 
     expect(mocks.announceProjectToBridge).toHaveBeenCalledWith(
@@ -153,6 +158,7 @@ describe("runReadyEffects", () => {
       currentProjectCwd: "/repo/p1",
       priorActiveTabCwd: null,
       priorActiveTabId: "default",
+      bridgeTabIds: new Set<string>(),
     });
     expect(mocks.announceProjectToBridge).not.toHaveBeenCalled();
     expect(mocks.markStartupChromeReady).toHaveBeenCalledTimes(1);
@@ -174,6 +180,7 @@ describe("runReadyEffects", () => {
       currentProjectCwd: "/wrong",
       priorActiveTabCwd: "/Users/jamesbrink/.aethon",
       priorActiveTabId: "state-root",
+      bridgeTabIds: new Set<string>(),
     });
     expect(mocks.announceProjectToBridge).toHaveBeenCalledWith(
       "state-root",
@@ -189,6 +196,7 @@ describe("runReadyEffects", () => {
       currentProjectCwd: "/wrong",
       priorActiveTabCwd: "/Users/jamesbrink/.aethon/aethon/fix-old-worktree",
       priorActiveTabId: "legacy-tab",
+      bridgeTabIds: new Set<string>(),
     });
     expect(mocks.announceProjectToBridge).toHaveBeenCalledWith(
       "legacy-tab",
@@ -199,5 +207,88 @@ describe("runReadyEffects", () => {
       "/Users/jamesbrink/.aethon/aethon/fix-old-worktree",
     );
     expect(mocks.markStartupChromeReady).toHaveBeenCalledTimes(1);
+  });
+
+  it("replays each tab once per webview lifetime unless the bridge loses it", async () => {
+    const { ctx } = buildHandlerFixture({
+      state: {
+        tabs: [
+          { id: "tab-1", label: "One", model: "claude", cwd: "/repo/a" },
+          { id: "tab-2", label: "Two", model: "claude", cwd: "/repo/b" },
+        ],
+      },
+    });
+    ctx.prepareWorkspaceStartup = vi.fn().mockResolvedValue(true);
+    const input = {
+      currentProjectCwd: null,
+      priorActiveTabCwd: null,
+      priorActiveTabId: "default",
+    };
+
+    // First ready after webview load: both tabs replay.
+    runReadyEffects(ctx, {
+      ...input,
+      bridgeTabIds: new Set(["tab-1", "tab-2"]),
+    });
+    expect(ctx.pendingTabOpens.current.has("tab-1")).toBe(true);
+    expect(ctx.pendingTabOpens.current.has("tab-2")).toBe(true);
+    // Let the .finally() cleanup that clears pendingTabOpens flush.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(ctx.pendingTabOpens.current.size).toBe(0);
+
+    // ready re-fires constantly (project switches, reports from other
+    // clients). Re-replaying live tabs re-emitted session_history
+    // mid-stream and flipped the global project per ready — skip.
+    runReadyEffects(ctx, {
+      ...input,
+      bridgeTabIds: new Set(["tab-1", "tab-2"]),
+    });
+    expect(ctx.pendingTabOpens.current.size).toBe(0);
+
+    // Bridge respawned and lost tab-2: only that tab replays again.
+    runReadyEffects(ctx, {
+      ...input,
+      bridgeTabIds: new Set(["tab-1"]),
+    });
+    expect(ctx.pendingTabOpens.current.has("tab-1")).toBe(false);
+    expect(ctx.pendingTabOpens.current.has("tab-2")).toBe(true);
+    await ctx.pendingTabOpens.current.get("tab-2");
+  });
+
+  it("on the mobile surface, neither replays tabs nor announces a project", () => {
+    vi.stubEnv("VITE_AETHON_SURFACE", "mobile");
+    try {
+      const { ctx, mocks } = buildHandlerFixture({
+        state: {
+          tabs: [
+            { id: "tab-1", label: "Tab 1", model: "claude", cwd: "/repo/a" },
+          ],
+        },
+      });
+      ctx.prepareWorkspaceStartup = vi.fn().mockResolvedValue(true);
+      ctx.projectsRef.current = {
+        activeId: "p1",
+        activeWorkspaceId: null,
+        activeHostId: null,
+        projects: [{ id: "p1", label: "p1", path: "/repo/p1", lastUsed: 1 }],
+        workspacesByProject: {},
+      };
+
+      runReadyEffects(ctx, {
+        currentProjectCwd: "/wrong",
+        priorActiveTabCwd: null,
+        priorActiveTabId: "default",
+        bridgeTabIds: new Set<string>(),
+      });
+
+      // The companion is a passive reader: announcing its own local view
+      // back at the bridge is what livelocked set_project when desktop
+      // and mobile disagreed on the active project.
+      expect(mocks.announceProjectToBridge).not.toHaveBeenCalled();
+      expect(ctx.pendingTabOpens.current.size).toBe(0);
+      expect(mocks.markStartupChromeReady).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.unstubAllEnvs();
+    }
   });
 });

--- a/src/hooks/bridgeMessageHandlers/readyEffects.ts
+++ b/src/hooks/bridgeMessageHandlers/readyEffects.ts
@@ -39,6 +39,10 @@ function replayRestoredAgentTabs(
   for (const t of localTabs) {
     if ((t.kind ?? "agent") !== "agent") continue;
     if (t.id === "default") continue;
+    // A replay we already sent may not be reflected in the bridge
+    // snapshot yet (ready can re-fire while the open is in flight) —
+    // the pending gate covers that window.
+    if (ctx.pendingTabOpens.current.has(t.id)) continue;
     if (replayedTabIds.has(t.id) && bridgeTabIds.has(t.id)) continue;
     replayedTabIds.add(t.id);
     const tabProject = t.projectId

--- a/src/hooks/bridgeMessageHandlers/readyEffects.ts
+++ b/src/hooks/bridgeMessageHandlers/readyEffects.ts
@@ -8,13 +8,39 @@ export interface ReadyEffectsInput {
   currentProjectCwd: string | null;
   priorActiveTabCwd: string | null;
   priorActiveTabId: string;
+  /** Tab ids the bridge already has live sessions for (from the ready
+   *  snapshot's `tabs`). A tab that was already replayed this webview
+   *  lifetime is only replayed again if the bridge lost it. */
+  bridgeTabIds: ReadonlySet<string>;
 }
 
-function replayRestoredAgentTabs(ctx: BridgeMessageContext): void {
+/** Tabs already replayed to the bridge in this webview's lifetime.
+ *  `ready` is broadcast and re-fires on every project switch and every
+ *  `report` from ANY connected client, so replay must not re-run each
+ *  time: re-opening a live tab re-emits session_history (which can
+ *  interleave with an in-flight stream) and, when the tab's cwd differs
+ *  from the bridge's current project, flips the global project +
+ *  extension surface per ready. The first replay after a webview
+ *  reload (fresh module state) and any tab the bridge lost (missing
+ *  from the ready snapshot — bridge respawn, failed open) still go
+ *  through. */
+const replayedTabIds = new Set<string>();
+
+/** Test-only: fresh-webview replay semantics. */
+export function resetReplayedTabsForTest(): void {
+  replayedTabIds.clear();
+}
+
+function replayRestoredAgentTabs(
+  ctx: BridgeMessageContext,
+  bridgeTabIds: ReadonlySet<string>,
+): void {
   const localTabs = (ctx.stateRef.current.tabs as Tab[] | undefined) ?? [];
   for (const t of localTabs) {
     if ((t.kind ?? "agent") !== "agent") continue;
     if (t.id === "default") continue;
+    if (replayedTabIds.has(t.id) && bridgeTabIds.has(t.id)) continue;
+    replayedTabIds.add(t.id);
     const tabProject = t.projectId
       ? ctx.projectsRef.current.projects.find((p) => p.id === t.projectId)
       : null;
@@ -70,6 +96,18 @@ export function runReadyEffects(
   ctx: BridgeMessageContext,
   input: ReadyEffectsInput,
 ): void {
-  replayRestoredAgentTabs(ctx);
+  // The companion surface is a passive reader of bridge state: the
+  // desktop webview is the single writer for tab lifecycle and the
+  // global active project. `ready` is broadcast to every connected
+  // client, so if each client re-announced its own local view here,
+  // two clients with different active projects would livelock the
+  // bridge in a set_project ping-pong — each flip is a 20-60s
+  // extension unload/reload that re-emits ready and storms every
+  // event consumer.
+  if (import.meta.env.VITE_AETHON_SURFACE === "mobile") {
+    ctx.markStartupChromeReady();
+    return;
+  }
+  replayRestoredAgentTabs(ctx, input.bridgeTabIds);
   finishProjectAnnouncement(ctx, input);
 }


### PR DESCRIPTION
## Summary

The paired iPhone connected/disconnected in a loop against the nightly build, and assistant responses duplicated token-by-token (`CopCopCopCopilotilotilotilot…`) in both clients. Fixes #462.

Diagnosis came from `~/.aethon/logs/aethon.2026-07-02` + `bridge.2026-07-02.log`:
- `device dev-… lagged 677/1159/1965 events` → `bye slow-consumer` → reconnect within 1–6 s, dozens of times (15:51–15:52 storm)
- repeated `(iPhone) connected` lines with **no** intervening `disconnected` → overlapping zombie sessions
- `set_project total 22–61s` alternating between three different cwds every ~25 s for hours → two clients fighting over the global project

## The five interlocking fixes

1. **`gateway-frame` listener leak** (`src/gateway/rustBridgeAdapter.ts`): every `open()` registered a new listener but kept only the latest unlisten — one leaked listener per reconnect, so every frame was delivered N times. This is the ×N token duplication. Now replace-not-stack, with an `openSeq` guard for the `listen()`-vs-`close()` race.

2. **Phantom close from the superseded native socket** (`apps/mobile/src-tauri/src/gateway.rs`): the old reader task emitted `Close` onto the shared `gateway-frame` stream when the old socket died; the JS transport read it as the *new* connection dying → reconnect → repeat forever. Connections are now generation-stamped; superseded readers exit silently.

3. **Zombie sockets + instant-retry backoff** (`src/gateway/transport.ts`): `openSocket()` never tore down the previous adapter, and `hello_ok` reset backoff immediately, so a slow-consumer kick looped the client back into an overloaded host every ~2 s. Sockets are generation-guarded and superseded on reopen; backoff resets only after a 15 s stability window.

4. **Multi-client ready-effects livelock** (`src/hooks/bridgeMessageHandlers/readyEffects.ts`): `ready` is broadcast to every client; each client re-announced its own local active project and replayed `tab_open` (`restoreHistory`) for all tabs on every ready. Desktop + companion with different views ping-ponged `set_project` (each flip = 20–60 s extension unload/reload emitting another `ready`). The companion surface is now a passive reader (desktop webview is the single writer for tab lifecycle + global project), and desktop replays each tab once per webview lifetime unless the bridge lost its session.

5. **Event hub ring too small for bursts** (`src-tauri/src/server/remote/events.rs`): at 1024 slots a phone on Wi-Fi lagged the broadcast ring during extension-reload bursts and was kicked straight back into the storm. Now 8192 (slots hold `Arc`s; cost bounded by live frames).

## Tests

- New: `rustBridgeAdapter.test.ts` (listener-leak regressions), backoff escalation/stability tests in `transport.test.ts`, once-per-lifetime replay + mobile-passive tests in `readyEffects.test.ts`.
- Adversarially verified: the new tests fail against the pre-fix code.
- Full gate green: clippy (both crates), `tsc -b`, ESLint, `cargo test --lib` (615), vitest (3100).

## Verification notes

The mobile-side duplication mechanism is proven (leaked listeners). The desktop-side rendering of the corrupted block was observed during the livelock (repeated mid-stream `session_history` replays every ~25 s); with the livelock and replay churn removed the trigger conditions are gone — worth a re-check on the next desktop+phone streaming session.