### PR TITLE
feat(perf): boot-phase instrumentation across agent, shell, desktop, and mobile

### DIFF
--- a/agent/boot-trace.test.ts
+++ b/agent/boot-trace.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import { createBootTrace, formatBootSummary } from "./boot-trace";
+
+/** Deterministic clock: each call returns the next queued value. */
+function fakeClock(...ticks: number[]): () => number {
+  let i = 0;
+  return () => {
+    const v = ticks[Math.min(i, ticks.length - 1)];
+    i += 1;
+    return v;
+  };
+}
+
+describe("createBootTrace", () => {
+  it("records span durations in insertion order", () => {
+    // created@0, a:start@10, a:end@25, b:start@30, b:end@100, total@100
+    const trace = createBootTrace(fakeClock(0, 10, 25, 30, 100, 100));
+    trace.span("a")();
+    trace.span("b")();
+    expect(trace.summary()).toEqual({ a: 15, b: 70 });
+    expect(trace.totalMs()).toBe(100);
+    expect(Object.keys(trace.summary())).toEqual(["a", "b"]);
+  });
+
+  it("accumulates repeated span names", () => {
+    // created@0, s1:start@0, s1:end@5, s2:start@10, s2:end@30
+    const trace = createBootTrace(fakeClock(0, 0, 5, 10, 30));
+    trace.span("reload")();
+    trace.span("reload")();
+    expect(trace.summary()).toEqual({ reload: 25 });
+  });
+
+  it("ignores a second close of the same span", () => {
+    // created@0, start@0, end@10, (ignored end@50), total-read@50
+    const trace = createBootTrace(fakeClock(0, 0, 10, 50, 50));
+    const end = trace.span("once");
+    end();
+    end();
+    expect(trace.summary()).toEqual({ once: 10 });
+  });
+
+  it("rounds to 0.1ms", () => {
+    const trace = createBootTrace(fakeClock(0, 0, 1.2345, 2.789));
+    trace.span("x")();
+    expect(trace.summary()).toEqual({ x: 1.2 });
+    expect(trace.totalMs()).toBe(2.8);
+  });
+
+  it("measure() times an async phase and passes the result through", async () => {
+    const trace = createBootTrace(fakeClock(0, 5, 47));
+    const out = await trace.measure("load", () => Promise.resolve("ok"));
+    expect(out).toBe("ok");
+    expect(trace.summary()).toEqual({ load: 42 });
+  });
+
+  it("measure() closes the span when the phase rejects", async () => {
+    const trace = createBootTrace(fakeClock(0, 5, 47));
+    await expect(
+      trace.measure("boom", () => Promise.reject(new Error("nope"))),
+    ).rejects.toThrow("nope");
+    expect(trace.summary()).toEqual({ boom: 42 });
+  });
+});
+
+describe("formatBootSummary", () => {
+  it("renders total plus each span", () => {
+    const trace = createBootTrace(fakeClock(0, 0, 12, 12, 30, 40));
+    trace.span("services-init")();
+    trace.span("ensure-default-tab")();
+    expect(formatBootSummary(trace)).toBe(
+      "total=40ms services-init=12ms ensure-default-tab=18ms",
+    );
+  });
+});

--- a/agent/boot-trace.ts
+++ b/agent/boot-trace.ts
@@ -1,0 +1,69 @@
+/**
+ * Boot-phase timing spans for the bridge.
+ *
+ * `main()` creates one trace and wraps each serial boot phase in a span
+ * so the summary at `ready` / `worker_ready` shows where cold-start time
+ * went (extension loads, resource reloads, default-tab creation, …).
+ * The caller decides where the summary goes — the boot log line plus a
+ * `boot_timings` IPC frame the frontend can ignore or chart.
+ *
+ * Repeated span names accumulate (a phase that runs twice reports the
+ * sum), so call sites need no uniqueness bookkeeping. Closing a span
+ * twice is a no-op.
+ */
+
+export interface BootTrace {
+  /** Start a span; call the returned closer to end it. */
+  span(name: string): () => void;
+  /** Wrap an async phase in a span. */
+  measure<T>(name: string, fn: () => Promise<T>): Promise<T>;
+  /** Milliseconds per span, insertion order, rounded to 0.1 ms. */
+  summary(): Record<string, number>;
+  /** Milliseconds since the trace was created, rounded to 0.1 ms. */
+  totalMs(): number;
+}
+
+const round = (ms: number): number => Math.round(ms * 10) / 10;
+
+export function createBootTrace(
+  now: () => number = () => performance.now(),
+): BootTrace {
+  const started = now();
+  const spans = new Map<string, number>();
+  const span = (name: string): (() => void) => {
+    const begin = now();
+    let closed = false;
+    return () => {
+      if (closed) return;
+      closed = true;
+      spans.set(name, (spans.get(name) ?? 0) + (now() - begin));
+    };
+  };
+  return {
+    span,
+    async measure<T>(name: string, fn: () => Promise<T>): Promise<T> {
+      const end = span(name);
+      try {
+        return await fn();
+      } finally {
+        end();
+      }
+    },
+    summary(): Record<string, number> {
+      const out: Record<string, number> = {};
+      for (const [name, ms] of spans) out[name] = round(ms);
+      return out;
+    },
+    totalMs(): number {
+      return round(now() - started);
+    },
+  };
+}
+
+/** One-line boot-log summary: `total=812.4ms services-init=12.1ms …`. */
+export function formatBootSummary(trace: BootTrace): string {
+  const parts = Object.entries(trace.summary()).map(
+    ([name, ms]) => `${name}=${ms}ms`,
+  );
+  return `total=${trace.totalMs()}ms ${parts.join(" ")}`;
+}

--- a/agent/main.ts
+++ b/agent/main.ts
@@ -99,12 +99,17 @@ import { renderMemoryPromptSection } from "./memory/renderer";
 import { captureProjectExtensionBaseline, runDispatcher } from "./dispatcher";
 import { withWorkerOrigin } from "./origin-gate";
 import { buildAethonMcpExtension } from "./mcp";
+import { createBootTrace, formatBootSummary } from "./boot-trace";
 
 function rawSend(obj: Record<string, unknown>): void {
   process.stdout.write(JSON.stringify(obj) + "\n");
 }
 
 async function main(): Promise<void> {
+  // Boot-phase spans; summarized in the boot log + a `boot_timings` frame
+  // once the bridge reaches ready. See boot-trace.ts.
+  const bootTrace = createBootTrace();
+
   // -- Configuration -------------------------------------------------------
   const userDir = process.env.AETHON_USER_DIR ?? join(homedir(), ".aethon");
   const stateFile =
@@ -152,24 +157,29 @@ async function main(): Promise<void> {
   });
 
   // -- Pi service singletons ----------------------------------------------
+  const endServicesInit = bootTrace.span("services-init");
   state.authStorage = AuthStorage.create();
   state.modelRegistry = ModelRegistry.create(state.authStorage);
   state.settingsManager = SettingsManager.create(process.cwd());
   applyProviderTimeoutOverride(state);
   state.authProfiles = loadAuthProfiles(state.userDir);
+  endServicesInit();
 
   // -- User's persisted "disabled extensions" list -----------------------
   // Read before any extension load so the loader honors it on first pass.
   // Hydrate both the name set (used by the loader to skip imports) and
   // the per-entry meta map (used by the frontend to scope project-
   // directory disabled rows to the active project).
-  const disabledSnapshot = await loadDisabledExtensionsSnapshot(state.userDir);
+  const disabledSnapshot = await bootTrace.measure("disabled-snapshot", () =>
+    loadDisabledExtensionsSnapshot(state.userDir),
+  );
   for (const name of disabledSnapshot.names) state.disabledExtensions.add(name);
   for (const [name, meta] of disabledSnapshot.meta) {
     state.disabledExtensionMeta.set(name, meta);
   }
 
   // -- Bundled boot resources read synchronously --------------------------
+  const endBootFiles = bootTrace.span("boot-files");
   if (bootLayoutFile) {
     try {
       state.bootLayout = JSON.parse(readFileSync(bootLayoutFile, "utf8"));
@@ -196,6 +206,8 @@ async function main(): Promise<void> {
       }
     }
   }
+
+  endBootFiles();
 
   // -- Side-effect deps shared across modules -----------------------------
   const scheduleStateFileWrite = () => scheduleStateFileWriteImpl(state);
@@ -301,7 +313,9 @@ async function main(): Promise<void> {
       ...resolveAethonSystemPrompt(getRuntimeSnapshot(state)),
     ],
   });
-  await state.resourceLoader.reload();
+  await bootTrace.measure("resource-reload-1", () =>
+    state.resourceLoader.reload(),
+  );
 
   // -- Extension loaders --------------------------------------------------
   const loadHooks = {
@@ -326,30 +340,38 @@ async function main(): Promise<void> {
       scheduleStateFileWrite();
     },
   };
-  await loadAethonExtensions(
-    state,
-    extDeps,
-    extensionApi,
-    state.loadedExtensions,
-    loadHooks,
+  await bootTrace.measure("user-extensions", () =>
+    loadAethonExtensions(
+      state,
+      extDeps,
+      extensionApi,
+      state.loadedExtensions,
+      loadHooks,
+    ),
   );
-  await loadAethonExtensionPackages(
-    state,
-    extDeps,
-    extensionApi,
-    state.loadedExtensions,
-    {
-      onFrontendEntry: ({ name, entryPath, code }) => {
-        state.extensionFrontendModules.set(name, { name, entryPath, code });
+  await bootTrace.measure("extension-packages", () =>
+    loadAethonExtensionPackages(
+      state,
+      extDeps,
+      extensionApi,
+      state.loadedExtensions,
+      {
+        onFrontendEntry: ({ name, entryPath, code }) => {
+          state.extensionFrontendModules.set(name, { name, entryPath, code });
+        },
+        onLoaded: loadHooks.onLoaded,
+        onFailure: loadHooks.onFailure,
       },
-      onLoaded: loadHooks.onLoaded,
-      onFailure: loadHooks.onFailure,
-    },
+    ),
   );
-  await loadAethonThemeDirectory(state, {
-    registerTheme: (theme) => aethonApi.registerTheme(theme),
-  });
-  await discoverPiAethonExtensions(state.loadedExtensions);
+  await bootTrace.measure("themes", () =>
+    loadAethonThemeDirectory(state, {
+      registerTheme: (theme) => aethonApi.registerTheme(theme),
+    }),
+  );
+  await bootTrace.measure("pi-discovery", () =>
+    discoverPiAethonExtensions(state.loadedExtensions),
+  );
 
   // -- Project-extension baseline ----------------------------------------
   // Snapshot the post-non-project-load state. Anything project-directory
@@ -357,7 +379,11 @@ async function main(): Promise<void> {
   // restores the registries from this snapshot.
   captureProjectExtensionBaseline(state);
 
-  const activeProjectCwd = workerCwd ?? (await readActiveProjectCwd(userDir));
+  const activeProjectCwd =
+    workerCwd ??
+    (await bootTrace.measure("active-project-cwd", () =>
+      readActiveProjectCwd(userDir),
+    ));
   const startupCwd = resolveStartupCwd(
     activeProjectCwd,
     projectRoot,
@@ -365,20 +391,24 @@ async function main(): Promise<void> {
     process.cwd(),
   );
 
-  await loadProjectAethonExtensions(
-    state,
-    extDeps,
-    startupCwd,
-    extensionApi,
-    state.loadedExtensions,
-    state.loadedProjectExtensionFiles,
-    state.failedProjectExtensionFiles,
-    loadHooks,
+  await bootTrace.measure("project-extensions", () =>
+    loadProjectAethonExtensions(
+      state,
+      extDeps,
+      startupCwd,
+      extensionApi,
+      state.loadedExtensions,
+      state.loadedProjectExtensionFiles,
+      state.failedProjectExtensionFiles,
+      loadHooks,
+    ),
   );
   state.currentProjectCwd = startupCwd;
 
   // Reload so the appendSystemPromptOverride sees the populated extensions.
-  await state.resourceLoader.reload();
+  await bootTrace.measure("resource-reload-2", () =>
+    state.resourceLoader.reload(),
+  );
 
   const tabDeps = { send };
   if (!workerMode) {
@@ -389,13 +419,23 @@ async function main(): Promise<void> {
     // leaks into whatever the user opens next (sessions/default/ is
     // shared across project buckets).
     state.tabProjectCwds.set("default", startupCwd);
-    await ensureTab(state, tabDeps, "default");
+    await bootTrace.measure("ensure-default-tab", () =>
+      ensureTab(state, tabDeps, "default", { trace: bootTrace }),
+    );
 
     // -- Discover persisted sessions for the "Recent sessions" empty-state -
-    state.discoveredTabs = await discoverPersistedTabs(state);
+    state.discoveredTabs = await bootTrace.measure("discover-tabs", () =>
+      discoverPersistedTabs(state),
+    );
 
     scheduleStateFileWrite();
     emitReady(state, tabDeps);
+    logger.scope("boot").info(formatBootSummary(bootTrace));
+    send({
+      type: "boot_timings",
+      total: bootTrace.totalMs(),
+      spans: bootTrace.summary(),
+    });
 
     // Replay the default tab's persisted pi session history so all tabs use
     // the same session_history IPC path. Scope the read by the SAME cwd
@@ -424,6 +464,13 @@ async function main(): Promise<void> {
     markFrontendReady(state);
     scheduleStateFileWrite();
     send({ type: "worker_ready", tabId: workerTabId, cwd: startupCwd });
+    logger.scope("boot").info(formatBootSummary(bootTrace));
+    send({
+      type: "boot_timings",
+      tabId: workerTabId,
+      total: bootTrace.totalMs(),
+      spans: bootTrace.summary(),
+    });
   }
 
   // -- Run the dispatcher ------------------------------------------------

--- a/agent/tab-lifecycle/lifecycle.ts
+++ b/agent/tab-lifecycle/lifecycle.ts
@@ -40,6 +40,7 @@ import {
 } from "../devshell";
 import { wrapWithSourceGuard } from "../source-guard";
 import { logger } from "../logger";
+import type { BootTrace } from "../boot-trace";
 import { authProfileServicesForTab } from "../auth-profiles";
 import { emitGlobalReady } from "../dispatcherTypes";
 import type { AethonAgentState, TabRecord } from "../state";
@@ -56,6 +57,8 @@ export interface EnsureTabOptions {
   initialModel?: Model<Api>;
   thinkingLevel?: ThinkingLevel;
   cwdOverride?: string;
+  /** Boot-phase trace (main.ts startup only) — records tab sub-spans. */
+  trace?: BootTrace;
 }
 
 const lifecycleLog = logger.scope("tab-lifecycle");
@@ -188,6 +191,7 @@ export async function ensureTab(
     state.tabProjectCwds.set(tabId, resolvedCwd);
   }
 
+  const endSessionManagerSpan = options.trace?.span("tab:session-manager");
   let sessionManager;
   try {
     // Aethon session state is SQLite-backed; pi receives its own normal
@@ -207,6 +211,7 @@ export async function ensureTab(
       );
     sessionManager = SessionManager.inMemory();
   }
+  endSessionManagerSpan?.();
 
   // Frontend tab creation normally prepares the devshell before `tab_open`.
   // Tab workers are spawned by Rust only after that prepare step has run and
@@ -223,6 +228,7 @@ export async function ensureTab(
     // host env beats no session. ensurePrepared also self-skips before the
     // frontend handshake (startup default tab), where the query can't be
     // answered and would otherwise wedge the bridge until a fatal timeout.
+    const endDevshellSpan = options.trace?.span("tab:devshell-prepare");
     await ensureDevshellPrepared(state, deps, resolvedCwd).catch(
       (err: unknown) => {
         lifecycleLog.warn(
@@ -230,6 +236,7 @@ export async function ensureTab(
         );
       },
     );
+    endDevshellSpan?.();
   }
 
   // Shadow pi's built-in `bash` tool with our own that mounts the
@@ -248,6 +255,7 @@ export async function ensureTab(
     options.initialModel,
   );
 
+  const endCreateSessionSpan = options.trace?.span("tab:create-agent-session");
   const { session } = await createAgentSession({
     authStorage: authServices.authStorage,
     modelRegistry: authServices.modelRegistry,
@@ -272,6 +280,7 @@ export async function ensureTab(
     ...(options.initialModel ? { model: options.initialModel } : {}),
     ...(options.thinkingLevel ? { thinkingLevel: options.thinkingLevel } : {}),
   });
+  endCreateSessionSpan?.();
   lifecycleLog.info(`session ready tabId=${tabId} cwd=${resolvedCwd}`);
   installAethonRetryClassifier(session);
   installCodexFastModePayloadHook(state, session);
@@ -321,6 +330,7 @@ export async function ensureTab(
     contextUsage: contextUsageSnapshot(state, tabId, rec),
   });
   emitContextUsage(state, deps, tabId, rec);
+  const endBindSpan = options.trace?.span("tab:bind-extensions");
   await session.bindExtensions({
     uiContext: extensionUiContextForTab(),
     onError: (error) => {
@@ -329,6 +339,7 @@ export async function ensureTab(
       );
     },
   });
+  endBindSpan?.();
   const previousSlashCommands = JSON.stringify(state.piSlashCommands);
   refreshPiSlashCommands(state, session);
   if (JSON.stringify(state.piSlashCommands) !== previousSlashCommands) {

--- a/bun.lock
+++ b/bun.lock
@@ -51,6 +51,7 @@
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "jsdom": "^29.1.1",
+        "rollup-plugin-visualizer": "^7.0.1",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.59.1",
         "vite": "^8.0.1",
@@ -741,7 +742,7 @@
 
     "cli-highlight": ["cli-highlight@2.1.11", "", { "dependencies": { "chalk": "^4.0.0", "highlight.js": "^10.7.1", "mz": "^2.4.0", "parse5": "^5.1.1", "parse5-htmlparser2-tree-adapter": "^6.0.0", "yargs": "^16.0.0" }, "bin": { "highlight": "bin/highlight" } }, "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg=="],
 
-    "cliui": ["cliui@7.0.4", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^7.0.0" } }, "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ=="],
+    "cliui": ["cliui@9.0.1", "", { "dependencies": { "string-width": "^7.2.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w=="],
 
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
@@ -889,7 +890,7 @@
 
     "electron-to-chromium": ["electron-to-chromium@1.5.344", "", {}, "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg=="],
 
-    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+    "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
@@ -1112,6 +1113,8 @@
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
     "is-hexadecimal": ["is-hexadecimal@2.0.1", "", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
+
+    "is-in-ssh": ["is-in-ssh@1.0.0", "", {}, "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw=="],
 
     "is-inside-container": ["is-inside-container@1.0.0", "", { "dependencies": { "is-docker": "^3.0.0" }, "bin": { "is-inside-container": "cli.js" } }, "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA=="],
 
@@ -1355,7 +1358,7 @@
 
     "oniguruma-to-es": ["oniguruma-to-es@4.3.6", "", { "dependencies": { "oniguruma-parser": "^0.12.2", "regex": "^6.1.0", "regex-recursion": "^6.0.2" } }, "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA=="],
 
-    "open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
+    "open": ["open@11.0.0", "", { "dependencies": { "default-browser": "^5.4.0", "define-lazy-prop": "^3.0.0", "is-in-ssh": "^1.0.0", "is-inside-container": "^1.0.0", "powershell-utils": "^0.1.0", "wsl-utils": "^0.3.0" } }, "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw=="],
 
     "openai": ["openai@6.26.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA=="],
 
@@ -1416,6 +1419,8 @@
     "points-on-path": ["points-on-path@0.2.1", "", { "dependencies": { "path-data-parser": "0.1.0", "points-on-curve": "0.2.0" } }, "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g=="],
 
     "postcss": ["postcss@8.5.10", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="],
+
+    "powershell-utils": ["powershell-utils@0.1.0", "", {}, "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
@@ -1493,6 +1498,8 @@
 
     "rolldown": ["rolldown@1.0.0-rc.17", "", { "dependencies": { "@oxc-project/types": "=0.127.0", "@rolldown/pluginutils": "1.0.0-rc.17" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.17", "@rolldown/binding-darwin-arm64": "1.0.0-rc.17", "@rolldown/binding-darwin-x64": "1.0.0-rc.17", "@rolldown/binding-freebsd-x64": "1.0.0-rc.17", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA=="],
 
+    "rollup-plugin-visualizer": ["rollup-plugin-visualizer@7.0.1", "", { "dependencies": { "open": "^11.0.0", "picomatch": "^4.0.2", "source-map": "^0.7.4", "yargs": "^18.0.0" }, "peerDependencies": { "rolldown": "1.x || ^1.0.0-beta || ^1.0.0-rc", "rollup": "2.x || 3.x || 4.x" }, "optionalPeers": ["rolldown", "rollup"], "bin": { "rollup-plugin-visualizer": "dist/bin/cli.js" } }, "sha512-UJUT4+1Ho4OcWmPYU3sYXgUqI8B8Ayfe06MX7y0qCJ1K8aGoKtR/NDd/2nZqM7ADkrzny+I99Ul7GgyoiVNAgg=="],
+
     "roughjs": ["roughjs@4.6.6", "", { "dependencies": { "hachure-fill": "^0.5.2", "path-data-parser": "^0.1.0", "points-on-curve": "^0.2.0", "points-on-path": "^0.2.1" } }, "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ=="],
 
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
@@ -1543,7 +1550,7 @@
 
     "socks-proxy-agent": ["socks-proxy-agent@8.0.5", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "socks": "^2.8.3" } }, "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw=="],
 
-    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+    "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
@@ -1557,7 +1564,7 @@
 
     "std-env": ["std-env@4.1.0", "", {}, "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ=="],
 
-    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+    "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 
@@ -1683,13 +1690,13 @@
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
-    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+    "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
     "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
-    "wsl-utils": ["wsl-utils@0.1.0", "", { "dependencies": { "is-wsl": "^3.1.0" } }, "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw=="],
+    "wsl-utils": ["wsl-utils@0.3.1", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg=="],
 
     "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
 
@@ -1701,9 +1708,9 @@
 
     "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
 
-    "yargs": ["yargs@16.2.0", "", { "dependencies": { "cliui": "^7.0.2", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.0", "y18n": "^5.0.5", "yargs-parser": "^20.2.2" } }, "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw=="],
+    "yargs": ["yargs@18.0.0", "", { "dependencies": { "cliui": "^9.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "string-width": "^7.2.0", "y18n": "^5.0.5", "yargs-parser": "^22.0.0" } }, "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg=="],
 
-    "yargs-parser": ["yargs-parser@20.2.9", "", {}, "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="],
+    "yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
 
     "yauzl": ["yauzl@2.10.0", "", { "dependencies": { "buffer-crc32": "~0.2.3", "fd-slicer": "~1.1.0" } }, "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g=="],
 
@@ -1755,7 +1762,7 @@
 
     "cli-highlight/parse5": ["parse5@5.1.1", "", {}, "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="],
 
-    "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+    "cli-highlight/yargs": ["yargs@16.2.0", "", { "dependencies": { "cliui": "^7.0.2", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.0", "y18n": "^5.0.5", "yargs-parser": "^20.2.2" } }, "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw=="],
 
     "cytoscape-fcose/cose-base": ["cose-base@2.2.0", "", { "dependencies": { "layout-base": "^2.0.0" } }, "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g=="],
 
@@ -1764,6 +1771,8 @@
     "d3-sankey/d3-array": ["d3-array@2.12.1", "", { "dependencies": { "internmap": "^1.0.0" } }, "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ=="],
 
     "d3-sankey/d3-shape": ["d3-shape@1.3.7", "", { "dependencies": { "d3-path": "1" } }, "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw=="],
+
+    "escodegen/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "hast-util-raw/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
@@ -1785,6 +1794,8 @@
 
     "parse5-htmlparser2-tree-adapter/parse5": ["parse5@6.0.1", "", {}, "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="],
 
+    "pi-mcp-adapter/open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
+
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "proxy-agent/lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
@@ -1797,15 +1808,11 @@
 
     "socks/ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
 
-    "string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
     "strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
-    "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
-    "wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+    "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "@aws-crypto/sha256-browser/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
 
@@ -1817,6 +1824,12 @@
 
     "cli-highlight/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
+    "cli-highlight/yargs/cliui": ["cliui@7.0.4", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^7.0.0" } }, "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ=="],
+
+    "cli-highlight/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "cli-highlight/yargs/yargs-parser": ["yargs-parser@20.2.9", "", {}, "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="],
+
     "cytoscape-fcose/cose-base/layout-base": ["layout-base@2.0.1", "", {}, "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg=="],
 
     "d3-sankey/d3-array/internmap": ["internmap@1.0.1", "", {}, "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="],
@@ -1825,10 +1838,22 @@
 
     "hast-util-raw/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
+    "pi-mcp-adapter/open/wsl-utils": ["wsl-utils@0.1.0", "", { "dependencies": { "is-wsl": "^3.1.0" } }, "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw=="],
+
     "shiki/@shikijs/core/@shikijs/primitive": ["@shikijs/primitive@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw=="],
 
     "@aws-crypto/sha256-browser/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
 
     "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
+
+    "cli-highlight/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "cli-highlight/yargs/cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "cli-highlight/yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "cli-highlight/yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "cli-highlight/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "jsdom": "^29.1.1",
+    "rollup-plugin-visualizer": "^7.0.1",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.59.1",
     "vite": "^8.0.1",

--- a/src-tauri/src/agent_commands.rs
+++ b/src-tauri/src/agent_commands.rs
@@ -229,6 +229,8 @@ pub(crate) fn reload_agent(state: State<'_, AgentProcesses>, app: AppHandle) -> 
         guard.drain().collect()
     };
     if !children.is_empty() {
+        let kill_started = std::time::Instant::now();
+        let child_count = children.len();
         if let Ok(mut exits) = state.intentional_exits.lock() {
             for (key, _) in &children {
                 exits.insert(key.clone());
@@ -249,6 +251,12 @@ pub(crate) fn reload_agent(state: State<'_, AgentProcesses>, app: AppHandle) -> 
         if let Ok(mut meta) = state.meta.lock() {
             meta.clear();
         }
+        tracing::info!(
+            target: "aethon::boot",
+            children = child_count,
+            elapsed_ms = kill_started.elapsed().as_millis() as u64,
+            "reload_agent kill+wait complete"
+        );
     }
     let _ = app.emit("agent-reloaded", "extension-toggle");
     Ok(())

--- a/src-tauri/src/agent_process/process.rs
+++ b/src-tauri/src/agent_process/process.rs
@@ -149,7 +149,17 @@ pub(crate) fn mark_worker_ready(meta: &Arc<Mutex<HashMap<String, WorkerMeta>>>, 
     let mut map = lock_recover(meta, "worker meta (ready)");
     if let Some(entry) = map.get_mut(key) {
         entry.last_activity = Instant::now();
-        entry.bridge_ready = true;
+        // Log only the not-ready → ready transition; `report` re-emits
+        // `ready` later and a spawn-relative elapsed would be misleading.
+        if !entry.bridge_ready {
+            entry.bridge_ready = true;
+            tracing::info!(
+                target: "aethon::boot",
+                key,
+                elapsed_ms = entry.spawned_at.elapsed().as_millis() as u64,
+                "bridge ready"
+            );
+        }
     }
 }
 
@@ -193,6 +203,14 @@ async fn wait_for_worker_ready(
     let start = Instant::now();
     while start.elapsed() < timeout {
         if worker_ready(meta, key) {
+            // This wait is the hidden stall between "user acted" and the
+            // fresh worker accepting its first payload — surface it.
+            tracing::info!(
+                target: "aethon::boot",
+                key,
+                waited_ms = start.elapsed().as_millis() as u64,
+                "waited for worker ready"
+            );
             return Ok(());
         }
         if let Some(status) = lock_recover(child, "agent child (ready wait)")

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -84,6 +84,21 @@ fn prefer_stable_linux_webview_backend() {
 #[cfg(not(target_os = "linux"))]
 fn prefer_stable_linux_webview_backend() {}
 
+/// Time a boot-phase step and emit it on the `aethon::boot` target so the
+/// startup timeline is greppable (`AETHON_LOG=aethon::boot=info`, the dev
+/// default). Wraps synchronous `setup()` steps only — spawned/async work
+/// reports through its own targets.
+fn boot_span<T>(phase: &str, f: impl FnOnce() -> T) -> T {
+    let started = std::time::Instant::now();
+    let out = f();
+    tracing::info!(
+        target: "aethon::boot",
+        phase,
+        elapsed_ms = started.elapsed().as_millis() as u64
+    );
+    out
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     prefer_stable_linux_webview_backend();
@@ -350,10 +365,15 @@ pub fn run() {
 
     let app = builder
         .setup(move |app| {
-            if let Err(e) = storage::initialize(app.handle()) {
-                tracing::warn!(target: "aethon::storage", "initialize sqlite storage: {e}");
-            }
-            agent_process::cleanup_orphaned_dev_agents();
+            let setup_started = std::time::Instant::now();
+            boot_span("storage_init", || {
+                if let Err(e) = storage::initialize(app.handle()) {
+                    tracing::warn!(target: "aethon::storage", "initialize sqlite storage: {e}");
+                }
+            });
+            boot_span("orphan_cleanup", || {
+                agent_process::cleanup_orphaned_dev_agents();
+            });
             if let Some(watcher) = commands::extensions::start_agent_watcher(app.handle().clone()) {
                 app.manage(watcher);
             }
@@ -369,15 +389,17 @@ pub fn run() {
             // healthy render. Both calls are no-ops when there's no
             // sentinel/report on disk — they don't slow normal launches.
             let mut activate_after_update = false;
-            if let Ok(home) = app.path().home_dir()
-                && let Some(data_dir) = helpers::aethon_dir(Some(home))
-            {
-                activate_after_update = boot_probation::has_pending_probation(&data_dir);
-                boot_probation::show_pending_report(app.handle(), &data_dir);
-                let boot_state =
-                    Arc::clone(&app.state::<updater_state::UpdaterState>().boot_probation);
-                boot_probation::start_monitor(app.handle().clone(), boot_state, data_dir);
-            }
+            boot_span("boot_probation", || {
+                if let Ok(home) = app.path().home_dir()
+                    && let Some(data_dir) = helpers::aethon_dir(Some(home))
+                {
+                    activate_after_update = boot_probation::has_pending_probation(&data_dir);
+                    boot_probation::show_pending_report(app.handle(), &data_dir);
+                    let boot_state =
+                        Arc::clone(&app.state::<updater_state::UpdaterState>().boot_probation);
+                    boot_probation::start_monitor(app.handle().clone(), boot_state, data_dir);
+                }
+            });
 
             // Native menu — replaces Tauri's auto-generated default. Each
             // app-specific item emits a `menu` Tauri event whose payload
@@ -386,7 +408,7 @@ pub fn run() {
             // keyboard shortcuts always do the same thing. Predefined
             // macOS items (Quit / Hide / Cut / Copy / Minimize / etc.)
             // get native NS actions for free, no event handler needed.
-            commands::extensions::install_app_menu(app.handle(), &[])?;
+            boot_span("menu", || commands::extensions::install_app_menu(app.handle(), &[]))?;
             // Register the menu-click → "menu" event forwarder ONCE here.
             // install_app_menu rebuilds and re-attaches the NSMenu whenever
             // extension menu items change, but Tauri's `on_menu_event`
@@ -396,7 +418,9 @@ pub fn run() {
                 let id = event.id().0.as_str();
                 let _ = app.emit("menu", id);
             });
-            commands::extensions::install_tray(app.handle(), &[], &[])?;
+            boot_span("tray", || {
+                commands::extensions::install_tray(app.handle(), &[], &[])
+            })?;
             // Initialize the extension menu store empty; the bridge
             // ships items via `extension_menu_items` events that the
             // frontend forwards to `set_extension_menu_items`, which
@@ -409,22 +433,26 @@ pub fn run() {
             // primary monitor", replacing the previous hardcoded
             // `maximize()` that worked around the unreliable manifest
             // `"maximized": true` on macOS.
-            if let Err(err) = window_state::restore_on_setup(app.handle(), activate_after_update) {
-                tracing::warn!(target: "aethon::window_state", "restore failed: {err}");
-                // Best-effort: show the window anyway so a corrupt
-                // state file can never strand the user.
-                if let Some(w) = app.get_webview_window("main") {
-                    if activate_after_update {
-                        #[cfg(target_os = "macos")]
-                        let _ = app.handle().show();
-                        let _ = w.unminimize();
-                    }
-                    let _ = w.show();
-                    if activate_after_update {
-                        let _ = w.set_focus();
+            boot_span("window_restore_show", || {
+                if let Err(err) =
+                    window_state::restore_on_setup(app.handle(), activate_after_update)
+                {
+                    tracing::warn!(target: "aethon::window_state", "restore failed: {err}");
+                    // Best-effort: show the window anyway so a corrupt
+                    // state file can never strand the user.
+                    if let Some(w) = app.get_webview_window("main") {
+                        if activate_after_update {
+                            #[cfg(target_os = "macos")]
+                            let _ = app.handle().show();
+                            let _ = w.unminimize();
+                        }
+                        let _ = w.show();
+                        if activate_after_update {
+                            let _ = w.set_focus();
+                        }
                     }
                 }
-            }
+            });
             if let Err(err) = commands::native_windows::restore_on_setup(app.handle()) {
                 tracing::warn!(target: "aethon::native_windows", "restore failed: {err}");
             }
@@ -455,6 +483,11 @@ pub fn run() {
             tauri::async_runtime::spawn(async move {
                 commands::devshell::boot_init_cache(&app_handle, &cache).await;
             });
+            tracing::info!(
+                target: "aethon::boot",
+                total_ms = setup_started.elapsed().as_millis() as u64,
+                "setup complete"
+            );
             Ok(())
         })
         .build(tauri::generate_context!())

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { bootMark, reportBootTimeline } from "./utils/bootTrace";
 import { ExtensionRegistry } from "./extensions/ExtensionRegistry";
 import { persistStatusesDebounced } from "./gitStatusCache";
 import { defaultLayoutExtension } from "./extensions/default-layout";
@@ -802,7 +803,10 @@ export default function App() {
     routeShellWrite,
     startTaskInProject,
     sendChat,
-    markStartupChromeReady: () => setStartupChromeReady(true),
+    markStartupChromeReady: () => {
+      bootMark("agent-ready");
+      setStartupChromeReady(true);
+    },
   });
 
   // Keyboard shortcuts + A2UI event routing.
@@ -976,6 +980,18 @@ export default function App() {
     scheduledTasksOpen,
   } = useDerivedRenderState({ state, buildSidebarHistory, hostInfo });
   const chromeReady = bootConfigReady && startupChromeReady;
+
+  // Boot timeline: mark the chrome-ready flip, then log the summary once
+  // the first real-chrome frame commits. See src/utils/bootTrace.ts.
+  useEffect(() => {
+    if (!chromeReady) return;
+    bootMark("chrome-ready");
+    const raf = requestAnimationFrame(() => {
+      bootMark("chrome-ready-commit");
+      reportBootTimeline();
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [chromeReady]);
 
   return (
     <AppRoot

--- a/src/gateway/tauriCoreShim.ts
+++ b/src/gateway/tauriCoreShim.ts
@@ -14,6 +14,7 @@ export * from "@tauri-real/core";
 
 import { gatewayCommand, routeFor, stubResult } from "./commandPolicy";
 import { gateway } from "./transport";
+import { countInvoke } from "../mobile/perfMarks";
 
 interface TauriInternals {
   invoke: (cmd: string, args?: unknown, options?: unknown) => Promise<unknown>;
@@ -39,6 +40,7 @@ export function invoke<T = unknown>(
     case "stub":
       return Promise.resolve(stubResult(cmd) as T);
     case "gateway":
+      countInvoke(cmd);
       return gateway.request<T>(gatewayCommand(cmd), args);
   }
 }

--- a/src/hooks/useUpdater.ts
+++ b/src/hooks/useUpdater.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { getConfig } from "../config";
+import { bootMark } from "../utils/bootTrace";
 
 /// Background auto-update poll interval. 30 minutes matches Claudette and
 /// is well below GitHub's anonymous-API rate limits even with several
@@ -356,6 +357,7 @@ export function useUpdater(ctx: UseUpdaterContext): {
   useEffect(() => {
     let cancelled = false;
     let raf: number | null = null;
+    bootMark("react-mounted");
     invoke("boot_stage", { stage: "react_mounted", detail: null }).catch(
       () => {},
     );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,6 @@
 import { applyBootTheme } from "./themeBootstrap";
+import { bootMark } from "./utils/bootTrace";
 
+bootMark("main-eval");
 applyBootTheme();
 void import("./mainApp");

--- a/src/mainApp.tsx
+++ b/src/mainApp.tsx
@@ -18,6 +18,11 @@ import "./monaco/setup";
 import "./styles/tokens.css";
 import "./styles/themes.css";
 import "./styles/chrome.css";
+import { bootMark } from "./utils/bootTrace";
+
+// Everything above this line — including the monaco/setup side effects —
+// has evaluated by the time this mark lands.
+bootMark("mainapp-eval");
 
 // Expose Tauri's invoke globally in dev so the aethon-debug skill's TCP eval
 // server can wrap user JS to call back via __AETHON_INVOKE__('debug_eval_result', ...).
@@ -37,6 +42,7 @@ const params = new URLSearchParams(window.location.search);
 const surface = params.get("surface");
 const canvasWindowId = params.get("id") ?? "";
 
+bootMark("render-start");
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     {surface === "canvas-window" ? (

--- a/src/mobile/MobileGate.tsx
+++ b/src/mobile/MobileGate.tsx
@@ -20,6 +20,7 @@ import {
   saveConnection,
   type MobileConnection,
 } from "./mobileConnection";
+import { perfEnabled, perfMark } from "./perfMarks";
 
 type Phase = "connecting" | "connected" | "need-config";
 
@@ -48,7 +49,9 @@ export function MobileGate() {
         : undefined;
     gateway.configure({ url, token: target.token, appVersion: "companion", adapter });
     try {
+      perfMark("connect-start");
       await gateway.connect();
+      perfMark("hello-ok");
       if (persist) {
         saveConnection(target);
         setRemembered(loadRememberedConnections());
@@ -67,6 +70,26 @@ export function MobileGate() {
     if (connection) queueMicrotask(() => void connect(connection, false));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // Startup perf marks (no-ops unless perf capture is enabled): first
+  // gate paint, App mount commit, and the first agent event after
+  // connect — the last is the "hydration is flowing" proxy.
+  useEffect(() => {
+    const raf = requestAnimationFrame(() => perfMark("gate-first-paint"));
+    return () => cancelAnimationFrame(raf);
+  }, []);
+  useEffect(() => {
+    if (phase === "connected") perfMark("app-mounted");
+  }, [phase]);
+  useEffect(() => {
+    if (phase !== "connected" || !perfEnabled()) return;
+    let seen = false;
+    return gateway.subscribe("agent-response", () => {
+      if (seen) return;
+      seen = true;
+      perfMark("first-agent-event");
+    });
+  }, [phase]);
 
   // Reconnect immediately when the app returns to the foreground — iOS
   // suspends the socket on lock, so this is the common path.

--- a/src/mobile/mainMobile.tsx
+++ b/src/mobile/mainMobile.tsx
@@ -10,11 +10,13 @@ import { createRoot } from "react-dom/client";
 
 import { applyBootTheme } from "../themeBootstrap";
 import { MobileGate } from "./MobileGate";
+import { perfMark } from "./perfMarks";
 import "../styles/tokens.css";
 import "../styles/themes.css";
 import "../styles/chrome.css";
 import "../styles/mobile.css";
 
+perfMark("script-start");
 applyBootTheme();
 
 createRoot(document.getElementById("root")!).render(

--- a/src/mobile/perfMarks.test.ts
+++ b/src/mobile/perfMarks.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  __testing,
+  buildPerfReport,
+  countInvoke,
+  perfMark,
+  perfReport,
+} from "./perfMarks";
+
+beforeEach(() => {
+  __testing.reset();
+  __testing.setEnabled(true);
+});
+
+afterEach(() => {
+  __testing.reset();
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe("perfMarks", () => {
+  it("records prefixed marks readable in the report", () => {
+    perfMark("script-start");
+    perfMark("gate-first-paint");
+    const report = buildPerfReport();
+    expect(Object.keys(report.marks)).toEqual([
+      "script-start",
+      "gate-first-paint",
+    ]);
+  });
+
+  it("buckets invokes into the post-hello windows", () => {
+    vi.useFakeTimers();
+    const base = performance.now();
+    const now = vi.spyOn(performance, "now");
+
+    now.mockReturnValue(base);
+    perfMark("hello-ok");
+    countInvoke("start_agent");
+    now.mockReturnValue(base + 500);
+    countInvoke("report");
+    now.mockReturnValue(base + 3_000);
+    countInvoke("git_status");
+    now.mockReturnValue(base + 8_000);
+    countInvoke("late_command");
+
+    const report = buildPerfReport();
+    expect(report.invokesFirst1s).toBe(2);
+    expect(report.invokesFirst5s).toBe(3);
+    expect(report.invokesTotal).toBe(4);
+  });
+
+  it("counts nothing before hello-ok", () => {
+    countInvoke("early");
+    expect(buildPerfReport().invokesFirst1s).toBe(0);
+    expect(buildPerfReport().invokesTotal).toBe(1);
+  });
+
+  it("reports once, automatically after the hello-ok delay", () => {
+    vi.useFakeTimers();
+    const info = vi.spyOn(console, "info").mockImplementation(() => {});
+    perfMark("hello-ok");
+    vi.advanceTimersByTime(6_000);
+    perfReport();
+    expect(info).toHaveBeenCalledTimes(1);
+  });
+
+  it("is inert when disabled", () => {
+    __testing.setEnabled(false);
+    const info = vi.spyOn(console, "info").mockImplementation(() => {});
+    perfMark("hello-ok");
+    countInvoke("x");
+    perfReport();
+    expect(info).not.toHaveBeenCalled();
+    expect(buildPerfReport().invokesTotal).toBe(0);
+  });
+});

--- a/src/mobile/perfMarks.ts
+++ b/src/mobile/perfMarks.ts
@@ -1,0 +1,134 @@
+/**
+ * Mobile startup perf marks + boot invoke counter.
+ *
+ * Measures the companion's cold-start milestones (script-start →
+ * gate-first-paint → connect-start → hello-ok → app-mounted →
+ * first-agent-event) and counts gateway invokes in the seconds after
+ * the handshake — the direct metric for the 40-invokes/s server rate
+ * limit that used to drop startup data.
+ *
+ * Enabled in dev builds, or in release when `localStorage["aethon:perf"]`
+ * is set. Everything here is best-effort and must never throw at boot.
+ * The summary logs once ~6 s after `hello-ok` (covering the 5 s window)
+ * and, in dev, also POSTs to the Vite server's `/__perf` endpoint so
+ * on-device numbers land in the terminal without Safari attached.
+ */
+
+const PREFIX = "aethon:mobile:";
+const REPORT_DELAY_MS = 6_000;
+const INVOKE_CAP = 2_000;
+
+function computeEnabled(): boolean {
+  try {
+    if (import.meta.env.DEV) return true;
+    return localStorage.getItem("aethon:perf") !== null;
+  } catch {
+    return false;
+  }
+}
+
+let enabled = computeEnabled();
+const invokes: Array<{ cmd: string; at: number }> = [];
+let helloOkAt: number | null = null;
+let reportTimer: ReturnType<typeof setTimeout> | null = null;
+let reported = false;
+
+export function perfEnabled(): boolean {
+  return enabled;
+}
+
+export function perfMark(name: string): void {
+  if (!enabled) return;
+  try {
+    performance.mark(PREFIX + name);
+  } catch {
+    /* marks are best-effort */
+  }
+  if (name === "hello-ok" && helloOkAt === null) {
+    helloOkAt = performance.now();
+    reportTimer = setTimeout(perfReport, REPORT_DELAY_MS);
+  }
+}
+
+/** Count one gateway invoke (called from the tauriCoreShim). */
+export function countInvoke(cmd: string): void {
+  if (!enabled || invokes.length >= INVOKE_CAP) return;
+  invokes.push({ cmd, at: performance.now() });
+}
+
+function invokesWithin(windowMs: number): number {
+  if (helloOkAt === null) return 0;
+  const start = helloOkAt;
+  return invokes.filter((i) => i.at >= start && i.at <= start + windowMs)
+    .length;
+}
+
+export interface MobilePerfReport {
+  marks: Record<string, number>;
+  invokesFirst1s: number;
+  invokesFirst5s: number;
+  invokesTotal: number;
+}
+
+export function buildPerfReport(): MobilePerfReport {
+  const marks: Record<string, number> = {};
+  try {
+    for (const entry of performance.getEntriesByType("mark")) {
+      if (!entry.name.startsWith(PREFIX)) continue;
+      marks[entry.name.slice(PREFIX.length)] =
+        Math.round(entry.startTime * 10) / 10;
+    }
+  } catch {
+    /* ignore */
+  }
+  return {
+    marks,
+    invokesFirst1s: invokesWithin(1_000),
+    invokesFirst5s: invokesWithin(5_000),
+    invokesTotal: invokes.length,
+  };
+}
+
+/** Log (and in dev, beacon) the report once. Safe to call repeatedly. */
+export function perfReport(): void {
+  if (!enabled || reported) return;
+  reported = true;
+  if (reportTimer !== null) {
+    clearTimeout(reportTimer);
+    reportTimer = null;
+  }
+  const payload = buildPerfReport();
+  console.info("[aethon:mobile-perf]", payload);
+  if (import.meta.env.DEV) {
+    try {
+      void fetch("/__perf", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(payload),
+      }).catch(() => {});
+    } catch {
+      /* relative fetch unavailable outside the dev server — ignore */
+    }
+  }
+}
+
+export const __testing = {
+  reset(): void {
+    invokes.length = 0;
+    helloOkAt = null;
+    reported = false;
+    enabled = computeEnabled();
+    if (reportTimer !== null) {
+      clearTimeout(reportTimer);
+      reportTimer = null;
+    }
+    try {
+      performance.clearMarks();
+    } catch {
+      /* ignore */
+    }
+  },
+  setEnabled(value: boolean): void {
+    enabled = value;
+  },
+};

--- a/src/utils/bootTrace.test.ts
+++ b/src/utils/bootTrace.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  __testing,
+  bootMark,
+  bootTimeline,
+  reportBootTimeline,
+} from "./bootTrace";
+
+afterEach(() => {
+  __testing.reset();
+  vi.restoreAllMocks();
+});
+
+describe("bootTrace", () => {
+  it("records prefixed marks and reads them back by name", () => {
+    bootMark("main-eval");
+    bootMark("react-mounted");
+    const timeline = bootTimeline();
+    expect(Object.keys(timeline)).toEqual(["main-eval", "react-mounted"]);
+    expect(timeline["main-eval"]).toBeGreaterThanOrEqual(0);
+    expect(timeline["react-mounted"]).toBeGreaterThanOrEqual(
+      timeline["main-eval"],
+    );
+  });
+
+  it("ignores marks without the aethon prefix", () => {
+    performance.mark("someone-elses-mark");
+    bootMark("chrome-ready");
+    expect(Object.keys(bootTimeline())).toEqual(["chrome-ready"]);
+    performance.clearMarks("someone-elses-mark");
+  });
+
+  it("reports the timeline exactly once", () => {
+    const info = vi.spyOn(console, "info").mockImplementation(() => {});
+    bootMark("chrome-ready");
+    reportBootTimeline();
+    reportBootTimeline();
+    expect(info).toHaveBeenCalledTimes(1);
+    expect(info).toHaveBeenCalledWith(
+      "[aethon:boot]",
+      expect.objectContaining({ "chrome-ready": expect.any(Number) }),
+    );
+  });
+
+  it("never throws when the performance API misbehaves", () => {
+    const original = performance.mark.bind(performance);
+    vi.spyOn(performance, "mark").mockImplementation(() => {
+      throw new Error("no marks here");
+    });
+    expect(() => bootMark("x")).not.toThrow();
+    performance.mark = original;
+  });
+});

--- a/src/utils/bootTrace.ts
+++ b/src/utils/bootTrace.ts
@@ -1,0 +1,57 @@
+/**
+ * Startup timing marks for the desktop webview.
+ *
+ * Thin wrapper over `performance.mark` with an `aethon:boot:` prefix so
+ * the boot timeline is inspectable live (aethon-debug:
+ * `performance.getEntriesByType("mark")`) and summarized once as a
+ * single console line when the chrome becomes ready. Marks are
+ * best-effort — none of this may ever throw during boot.
+ *
+ * Timestamps are milliseconds since `performance.timeOrigin` (page
+ * load), so the timeline reads as absolute boot progress, not deltas.
+ */
+
+const PREFIX = "aethon:boot:";
+
+export function bootMark(name: string): void {
+  try {
+    performance.mark(PREFIX + name);
+  } catch {
+    /* environments without performance.mark — marks are best-effort */
+  }
+}
+
+/** All boot marks as `{name: msSinceTimeOrigin}`, rounded to 0.1 ms. */
+export function bootTimeline(): Record<string, number> {
+  const out: Record<string, number> = {};
+  try {
+    for (const entry of performance.getEntriesByType("mark")) {
+      if (!entry.name.startsWith(PREFIX)) continue;
+      out[entry.name.slice(PREFIX.length)] =
+        Math.round(entry.startTime * 10) / 10;
+    }
+  } catch {
+    /* ignore */
+  }
+  return out;
+}
+
+let reported = false;
+
+/** Log the timeline once (chrome-ready). Safe to call repeatedly. */
+export function reportBootTimeline(): void {
+  if (reported) return;
+  reported = true;
+  console.info("[aethon:boot]", bootTimeline());
+}
+
+export const __testing = {
+  reset(): void {
+    reported = false;
+    try {
+      performance.clearMarks();
+    } catch {
+      /* ignore */
+    }
+  },
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@
 // the schema; Vite's own defineConfig narrows it away.
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
+import { visualizer } from "rollup-plugin-visualizer";
 
 // Tauri requires a fixed dev port (devUrl in tauri.conf.json). For
 // auto-increment, the `dev` wrapper (scripts/dev.sh) finds a free port
@@ -12,7 +13,14 @@ import react from "@vitejs/plugin-react";
 const port = Number(process.env.VITE_PORT ?? 1420);
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react(),
+    // Bundle-composition report for perf work: `ANALYZE=1 bun run build`
+    // writes dist/stats.html. Never active in normal builds.
+    ...(process.env.ANALYZE
+      ? [visualizer({ filename: "dist/stats.html", gzipSize: true })]
+      : []),
+  ],
   clearScreen: false,
   optimizeDeps: {
     // The dep scanner treats every root-level .html as an entry, which

--- a/vite.mobile.config.ts
+++ b/vite.mobile.config.ts
@@ -13,6 +13,7 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import { visualizer } from "rollup-plugin-visualizer";
 
 const shim = (p: string) => fileURLToPath(new URL(p, import.meta.url));
 
@@ -37,7 +38,22 @@ export default defineConfig({
         if (existsSync(from)) renameSync(from, join(dir, "index.html"));
       },
       configureServer(server) {
-        server.middlewares.use((req, _res, next) => {
+        server.middlewares.use((req, res, next) => {
+          // Dev-only perf beacon: src/mobile/perfMarks.ts POSTs its
+          // startup report here so on-device numbers land in this
+          // terminal without Safari's inspector attached.
+          if (req.url === "/__perf" && req.method === "POST") {
+            let body = "";
+            req.on("data", (chunk: Buffer) => {
+              body += chunk.toString();
+            });
+            req.on("end", () => {
+              console.log("[aethon:mobile-perf]", body);
+              res.statusCode = 204;
+              res.end();
+            });
+            return;
+          }
           if (req.url === "/" || req.url?.startsWith("/?")) {
             req.url = `/index.mobile.html${req.url.slice(1)}`;
           }
@@ -45,6 +61,10 @@ export default defineConfig({
         });
       },
     },
+    // `ANALYZE=1 bun run build:mobile` writes dist-mobile/stats.html.
+    ...(process.env.ANALYZE
+      ? [visualizer({ filename: "dist-mobile/stats.html", gzipSize: true })]
+      : []),
   ],
   clearScreen: false,
   resolve: {


### PR DESCRIPTION
## Summary

Workstream 0 of the startup + extension-toggle performance overhaul: make every later optimization measurable and regressions detectable. **Zero behavior change** — spans, marks, and counters only.

- **Agent bridge** (`agent/boot-trace.ts`): span/measure trace wrapping every serial boot phase in `agent/main.ts` (both `resourceLoader.reload()` calls, all four extension loaders, default-tab creation, session discovery) plus `ensureTab` sub-spans (session-manager, devshell-prepare, create-agent-session, bind-extensions). One summary line in the boot log at `ready`/`worker_ready`, plus a new `boot_timings` stdout frame (unknown to the frontend today, safely ignored — no `mutationId`).
- **Rust shell** (`aethon::boot` tracing target): per-step `setup()` spans (storage_init, orphan_cleanup, boot_probation, menu, tray, window_restore_show) + setup total, bridge-ready elapsed on the not-ready→ready transition, `wait_for_worker_ready` stall duration, `reload_agent` kill+wait timing and child count.
- **Desktop webview** (`src/utils/bootTrace.ts`): `performance.mark` timeline — main-eval, mainapp-eval, render-start, react-mounted, agent-ready, chrome-ready, chrome-ready-commit — logged once at chrome-ready; live-inspectable via aethon-debug.
- **Mobile companion** (`src/mobile/perfMarks.ts`): script-start / gate-first-paint / connect-start / hello-ok / app-mounted / first-agent-event marks + a gateway invoke counter bucketed against the server's 40-invokes/s rate-limit window. Dev builds beacon the report to the Vite server's new `/__perf` endpoint so on-device numbers land in the terminal.
- **Bundle reports**: `ANALYZE=1 bun run build` / `build:mobile` writes `dist/stats.html` / `dist-mobile/stats.html` (rollup-plugin-visualizer devDep, inert otherwise).

## Baselines recorded (for the follow-up PRs to beat)

| Metric | Value |
|---|---|
| Desktop eager main-thread JS | `mainApp` 2.2 MB + `editor.api2` (monaco) 3.5 MB |
| Worker spawned at boot | `highlight.worker` 3.8 MB (Shiki + Oniguruma WASM) |
| Mobile entry chunk (blocking) | 5.8 MB |
| Mobile dist assets | 32.9 MB across 493 files |

Live boot timelines (desktop chrome-ready, agent boot_timings, mobile marks) will be captured from the next dev runs now that the probes exist — quoted in each follow-up PR as before/after.

## Test plan

- [x] `check` green (clippy + tsc -b + eslint 0-warnings + cargo test + vitest: 3109 tests / 377 files)
- [x] New unit tests: `agent/boot-trace.test.ts`, `src/utils/bootTrace.test.ts`, `src/mobile/perfMarks.test.ts` (16 tests)
- [x] `ANALYZE=1` builds verified for both surfaces (stats.html generated)
- [x] Codex peer review on the branch