### PR TITLE
perf(agent): single resource reload + orchestrated boot sequence + overlapped default-tab startup

### DIFF
--- a/agent/boot-sequence.test.ts
+++ b/agent/boot-sequence.test.ts
@@ -1,0 +1,244 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { loadAllExtensions } from "./boot-sequence";
+import { createBootTrace } from "./boot-trace";
+import {
+  AethonAgentState,
+  type AethonAgentStateOptions,
+  type AethonExtensionApi,
+} from "./state";
+
+function makeOpts(userDir: string): AethonAgentStateOptions {
+  return {
+    userDir,
+    stateFile: join(userDir, "state.json"),
+    sessionsDir: join(userDir, "sessions"),
+    docsDir: undefined,
+    projectRoot: undefined,
+    releaseMode: false,
+    bootLayoutFile: undefined,
+    layoutSlotsFile: undefined,
+    statePayloadWarnBytes: 64 * 1024,
+    statePayloadHardBytes: 512 * 1024,
+    statePayloadWarnKb: 64,
+    statePayloadHardKb: 512,
+  };
+}
+
+/** Fixture: a temp HOME with `~/.aethon`-style userDir + a temp project
+ *  (`.git`-marked) with its own `.aethon/extensions/`. HOME is
+ *  overridden so pi-extension discovery scans the fixture, not the real
+ *  machine. */
+function makeFixture() {
+  const home = mkdtempSync(join(tmpdir(), "aethon-boot-seq-"));
+  const userDir = join(home, ".aethon");
+  const extDir = join(userDir, "extensions");
+  const themesDir = join(userDir, "themes");
+  const piExtDir = join(home, ".pi", "agent", "extensions");
+  const projectDir = join(home, "project");
+  const projectExtDir = join(projectDir, ".aethon", "extensions");
+  for (const dir of [extDir, themesDir, piExtDir, projectExtDir]) {
+    mkdirSync(dir, { recursive: true });
+  }
+  mkdirSync(join(projectDir, ".git"), { recursive: true });
+
+  const state = new AethonAgentState(makeOpts(userDir));
+  const order: string[] = [];
+  const reloadSpy = vi.fn(() => {
+    order.push("reload");
+    return Promise.resolve();
+  });
+  state.resourceLoader = {
+    reload: reloadSpy,
+  } as unknown as AethonAgentState["resourceLoader"];
+
+  const sent: Record<string, unknown>[] = [];
+  const api = {
+    registerComponent(type: string, template: unknown) {
+      state.extensionComponents.set(type, template);
+      order.push(`component:${type}`);
+    },
+    registerTheme(theme: unknown) {
+      const id = (theme as { id?: string }).id ?? "unknown";
+      state.extensionThemes.set(id, theme as never);
+      order.push(`theme:${id}`);
+      return Promise.resolve({ ok: true });
+    },
+  } as unknown as AethonExtensionApi;
+
+  return {
+    home,
+    userDir,
+    extDir,
+    themesDir,
+    piExtDir,
+    projectDir,
+    projectExtDir,
+    state,
+    order,
+    reloadSpy,
+    sent,
+    api,
+    extDeps: { send: (m: Record<string, unknown>) => sent.push(m) },
+    cleanup: () => rmSync(home, { recursive: true, force: true }),
+  };
+}
+
+type Fixture = ReturnType<typeof makeFixture>;
+
+async function run(
+  f: Fixture,
+  overrides: Partial<Parameters<typeof loadAllExtensions>[3]> = {},
+) {
+  return loadAllExtensions(f.state, f.extDeps, f.api, {
+    userDir: f.userDir,
+    loadHooks: {},
+    onFrontendEntry: () => {},
+    ...overrides,
+  });
+}
+
+describe("loadAllExtensions", () => {
+  let f: Fixture;
+  const realHome = process.env.HOME;
+
+  beforeEach(() => {
+    f = makeFixture();
+    process.env.HOME = f.home;
+  });
+
+  afterEach(() => {
+    if (realHome === undefined) delete process.env.HOME;
+    else process.env.HOME = realHome;
+    f.cleanup();
+  });
+
+  it("reloads the resource loader exactly once, after every loader", async () => {
+    writeFileSync(
+      join(f.extDir, "user-ext.ts"),
+      `export function register(api) { api.registerComponent("user-comp", null); }`,
+    );
+    writeFileSync(
+      join(f.themesDir, "loose.json"),
+      JSON.stringify({ id: "loose", vars: { "--bg": "#000" } }),
+    );
+    writeFileSync(
+      join(f.projectExtDir, "proj-ext.ts"),
+      `export function register(api) { api.registerComponent("proj-comp", null); }`,
+    );
+
+    await run(f, { workerCwd: f.projectDir });
+
+    expect(f.reloadSpy).toHaveBeenCalledTimes(1);
+    expect(f.order.filter((o) => o === "reload")).toHaveLength(1);
+    expect(f.order[f.order.length - 1]).toBe("reload");
+    // Themes follow the register-loaders (later-wins is semantic).
+    expect(f.order.indexOf("theme:loose")).toBeGreaterThan(
+      f.order.indexOf("component:user-comp"),
+    );
+    // Project extensions land after everything non-project.
+    expect(f.order.indexOf("component:proj-comp")).toBeGreaterThan(
+      f.order.indexOf("theme:loose"),
+    );
+  });
+
+  it("skips disabled extensions without importing them", async () => {
+    writeFileSync(
+      join(f.extDir, "muted.ts"),
+      `export function register(api) { api.registerComponent("muted-comp", null); }`,
+    );
+    f.state.disabledExtensions.add("muted");
+
+    await run(f, { workerCwd: f.projectDir });
+
+    expect(f.order).not.toContain("component:muted-comp");
+    expect(f.sent).toContainEqual(
+      expect.objectContaining({
+        type: "extension_lifecycle",
+        name: "muted",
+        status: "disabled",
+      }),
+    );
+  });
+
+  it("pi-discovery records aethon-aware pi extensions but never overwrites loader-registered names", async () => {
+    writeFileSync(
+      join(f.extDir, "shared-name.ts"),
+      `export function register(api) { api.registerComponent("shared", null); }`,
+    );
+    writeFileSync(
+      join(f.piExtDir, "shared-name.ts"),
+      `// touches globalThis.aethon`,
+    );
+    writeFileSync(
+      join(f.piExtDir, "pi-only.ts"),
+      `// touches globalThis.aethon`,
+    );
+
+    await run(f, { workerCwd: f.projectDir });
+
+    // Control: discovery ran against the fixture HOME and found the
+    // pi-only file — guards against a vacuously-passing precedence check.
+    expect(f.state.loadedExtensions.get("pi-only")).toBe("pi-extension");
+    expect(f.state.loadedExtensions.get("shared-name")).toBe("directory");
+  });
+
+  it("captures the project baseline between non-project and project loads", async () => {
+    writeFileSync(
+      join(f.extDir, "user-ext.ts"),
+      `export function register(api) { api.registerComponent("user-comp", null); }`,
+    );
+    writeFileSync(
+      join(f.projectExtDir, "proj-ext.ts"),
+      `export function register(api) { api.registerComponent("proj-comp", null); }`,
+    );
+
+    await run(f, { workerCwd: f.projectDir });
+
+    expect(f.state.projectBaseline?.components.has("user-comp")).toBe(true);
+    expect(f.state.projectBaseline?.components.has("proj-comp")).toBe(false);
+    expect(f.state.extensionComponents.has("user-comp")).toBe(true);
+    expect(f.state.extensionComponents.has("proj-comp")).toBe(true);
+  });
+
+  it("workerCwd pins startupCwd and skips the active-project read", async () => {
+    const { startupCwd } = await run(f, { workerCwd: f.projectDir });
+    expect(startupCwd).toBe(f.projectDir);
+    expect(f.state.currentProjectCwd).toBe(f.projectDir);
+  });
+
+  it("resolves startupCwd from the persisted active project when not a worker", async () => {
+    writeFileSync(
+      join(f.userDir, "projects.json"),
+      JSON.stringify({
+        schemaVersion: 5,
+        activeId: "p1",
+        projects: [{ id: "p1", path: f.projectDir }],
+      }),
+    );
+
+    const { startupCwd } = await run(f);
+    expect(startupCwd).toBe(f.projectDir);
+  });
+
+  it("records trace spans for each phase including the single reload", async () => {
+    const trace = createBootTrace();
+    await run(f, { workerCwd: f.projectDir, trace });
+    const spans = Object.keys(trace.summary());
+    expect(spans).toEqual(
+      expect.arrayContaining([
+        "user-extensions",
+        "extension-packages",
+        "themes",
+        "pi-discovery",
+        "project-extensions",
+        "resource-reload",
+      ]),
+    );
+    expect(spans).not.toContain("resource-reload-1");
+    expect(spans).not.toContain("resource-reload-2");
+  });
+});

--- a/agent/boot-sequence.ts
+++ b/agent/boot-sequence.ts
@@ -1,0 +1,133 @@
+/**
+ * Startup extension-load orchestration, extracted from `main()` so the
+ * ordering contract is testable and the safe concurrency lives in one
+ * place. Runs identically for the global bridge and per-tab workers.
+ *
+ * ORDERING CONTRACT — do not re-order casually:
+ *
+ *  1. `loadAethonExtensions` → `loadAethonExtensionPackages` stay
+ *     strictly SERIAL: their `register()` calls share the process-global
+ *     `currentExtensionLoadScope`/`currentExtensionName` stack, and
+ *     registry later-wins order across sources is semantic.
+ *  2. Loose-file themes and pi-extension discovery are independent of
+ *     each other (different registries) and run CONCURRENTLY — but both
+ *     must FOLLOW the register-loaders: a loose theme file overrides a
+ *     `register()`-supplied theme of the same id (later-wins), and
+ *     pi-discovery's `registry.has()` precedence rule must see every
+ *     loader-registered name first.
+ *  3. `captureProjectExtensionBaseline` sits exactly between the
+ *     non-project loads above and the project load below — project
+ *     switches restore registries from this snapshot.
+ *  4. Project extensions land on top of the baseline.
+ *  5. ONE `resourceLoader.reload()` finishes the sequence: pi imports
+ *     its extensions and builds the system prompt with
+ *     `appendSystemPromptOverride` seeing every loaded extension.
+ *     Sessions bind the extension instances from this reload, so it
+ *     must be the last step before any `ensureTab`.
+ *
+ * The active-project cwd read (a pure file/sqlite read) starts
+ * immediately and resolves concurrently with steps 1–3; its value is
+ * only needed at step 4.
+ */
+
+import {
+  loadAethonExtensions,
+  loadAethonExtensionPackages,
+  loadAethonThemeDirectory,
+  loadProjectAethonExtensions,
+  discoverPiAethonExtensions,
+} from "./extension-loader";
+import type { ExtensionLoaderDeps, LoadHooks } from "./extension-loader/shared";
+import { captureProjectExtensionBaseline } from "./projectLifecycle";
+import { readActiveProjectCwd, resolveStartupCwd } from "./active-project-cwd";
+import type { AethonAgentState, AethonExtensionApi } from "./state";
+import type { BootTrace } from "./boot-trace";
+
+export interface LoadAllExtensionsOptions {
+  userDir: string;
+  /** Set for per-tab workers: skips the active-project read entirely. */
+  workerCwd?: string;
+  projectRoot?: string;
+  trace?: BootTrace;
+  loadHooks: LoadHooks;
+  onFrontendEntry: (entry: {
+    name: string;
+    entryPath: string;
+    code: string;
+  }) => void;
+}
+
+export async function loadAllExtensions(
+  state: AethonAgentState,
+  extDeps: ExtensionLoaderDeps,
+  api: AethonExtensionApi,
+  options: LoadAllExtensionsOptions,
+): Promise<{ startupCwd: string }> {
+  const { trace } = options;
+  const measure = <T>(name: string, fn: () => Promise<T>): Promise<T> =>
+    trace ? trace.measure(name, fn) : fn();
+
+  const activeProjectCwdPromise =
+    options.workerCwd !== undefined
+      ? null
+      : measure("active-project-cwd", () =>
+          readActiveProjectCwd(options.userDir),
+        );
+
+  await measure("user-extensions", () =>
+    loadAethonExtensions(
+      state,
+      extDeps,
+      api,
+      state.loadedExtensions,
+      options.loadHooks,
+    ),
+  );
+  await measure("extension-packages", () =>
+    loadAethonExtensionPackages(state, extDeps, api, state.loadedExtensions, {
+      onFrontendEntry: options.onFrontendEntry,
+      onLoaded: options.loadHooks.onLoaded,
+      onFailure: options.loadHooks.onFailure,
+    }),
+  );
+
+  await Promise.all([
+    measure("themes", () =>
+      loadAethonThemeDirectory(state, {
+        registerTheme: (theme) => api.registerTheme(theme),
+      }),
+    ),
+    measure("pi-discovery", () =>
+      discoverPiAethonExtensions(state.loadedExtensions),
+    ),
+  ]);
+
+  captureProjectExtensionBaseline(state);
+
+  const activeProjectCwd =
+    options.workerCwd ?? (await activeProjectCwdPromise) ?? undefined;
+  const startupCwd = resolveStartupCwd(
+    activeProjectCwd,
+    options.projectRoot,
+    options.userDir,
+    process.cwd(),
+  );
+
+  await measure("project-extensions", () =>
+    loadProjectAethonExtensions(
+      state,
+      extDeps,
+      startupCwd,
+      api,
+      state.loadedExtensions,
+      state.loadedProjectExtensionFiles,
+      state.failedProjectExtensionFiles,
+      options.loadHooks,
+    ),
+  );
+  state.currentProjectCwd = startupCwd;
+
+  await measure("resource-reload", () => state.resourceLoader.reload());
+
+  return { startupCwd };
+}

--- a/agent/extension-loader/discovery.ts
+++ b/agent/extension-loader/discovery.ts
@@ -7,7 +7,7 @@
  * We just record presence so the sidebar can surface them.
  */
 
-import { readdir } from "node:fs/promises";
+import { readFile, readdir } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { logger } from "../logger";
@@ -46,7 +46,7 @@ export async function discoverPiAethonExtensions(
     if (!/\.(ts|js|mjs)$/.test(name)) continue;
     const file = join(dir, name);
     try {
-      const text = await Bun.file(file).text();
+      const text = await readFile(file, "utf8");
       if (
         !text.includes("globalThis.aethon") &&
         !text.includes("aethon.register")

--- a/agent/extension-loader/packages.ts
+++ b/agent/extension-loader/packages.ts
@@ -105,16 +105,6 @@ export async function loadAethonExtensionPackages(
     });
   }
 
-  async function maybeAddPackage(packageDir: string, fallbackName: string) {
-    const result = await readManifest(packageDir, fallbackName);
-    if (!result) return;
-    if ("manifest" in result) {
-      if (!candidates.has(result.name)) candidates.set(result.name, result);
-    } else {
-      recordManifestFailure(result);
-    }
-  }
-
   async function discoverPackages(
     root: string,
     options?: { skipNodeModules?: boolean },
@@ -130,22 +120,42 @@ export async function loadAethonExtensionPackages(
       }
       return;
     }
-    for (const entry of entries) {
-      if (options?.skipNodeModules && entry === "node_modules") continue;
-      const entryPath = join(root, entry);
-      if (entry.startsWith("@")) {
-        // Scoped namespace — recurse one level.
-        let scoped: string[];
-        try {
-          scoped = await readdir(entryPath);
-        } catch {
-          continue;
+    // Read every manifest concurrently, then record the results in the
+    // original entry order — candidate insertion is first-wins and
+    // failure events are user-visible, so ordering stays deterministic.
+    const slots = await Promise.all(
+      entries.map(
+        async (
+          entry,
+        ): Promise<Array<PackageCandidate | PackageManifestFailure | null>> => {
+          if (options?.skipNodeModules && entry === "node_modules") return [];
+          const entryPath = join(root, entry);
+          if (entry.startsWith("@")) {
+            // Scoped namespace — recurse one level.
+            let scoped: string[];
+            try {
+              scoped = await readdir(entryPath);
+            } catch {
+              return [];
+            }
+            return Promise.all(
+              scoped.map((sub) =>
+                readManifest(join(entryPath, sub), `${entry}/${sub}`),
+              ),
+            );
+          }
+          return [await readManifest(entryPath, entry)];
+        },
+      ),
+    );
+    for (const slot of slots) {
+      for (const result of slot) {
+        if (!result) continue;
+        if ("manifest" in result) {
+          if (!candidates.has(result.name)) candidates.set(result.name, result);
+        } else {
+          recordManifestFailure(result);
         }
-        for (const sub of scoped) {
-          await maybeAddPackage(join(entryPath, sub), `${entry}/${sub}`);
-        }
-      } else {
-        await maybeAddPackage(entryPath, entry);
       }
     }
   }
@@ -155,6 +165,13 @@ export async function loadAethonExtensionPackages(
   });
   await discoverPackages(join(state.userDir, "extensions", "node_modules"));
 
+  // Filter pass: disabled / missing-entry candidates emit their lifecycle
+  // events in discovery order, exactly as before.
+  const loadable: Array<{
+    c: PackageCandidate;
+    entry: string;
+    filePath: string;
+  }> = [];
   for (const c of candidates.values()) {
     if (state.disabledExtensions.has(c.name)) {
       logger.scope("ext-package").info(`${c.name}: disabled by user, skipping`);
@@ -189,11 +206,29 @@ export async function loadAethonExtensionPackages(
       });
       continue;
     }
-    const filePath = join(c.dir, entry);
+    loadable.push({ c, entry, filePath: join(c.dir, entry) });
+  }
+
+  // Parallelize the entry imports (mirrors directory.ts); register()
+  // stays sequential in discovery order so registrations against shared
+  // maps stay deterministic.
+  const imports = await Promise.allSettled(
+    loadable.map(
+      ({ filePath }) =>
+        import(pathToFileURL(filePath).href) as Promise<AethonExtensionModule>,
+    ),
+  );
+
+  for (let i = 0; i < loadable.length; i++) {
+    const { c, entry, filePath } = loadable[i];
+    const result = imports[i];
     try {
-      const mod: AethonExtensionModule = await import(
-        pathToFileURL(filePath).href
-      );
+      if (result.status === "rejected") {
+        throw result.reason instanceof Error
+          ? result.reason
+          : new Error(String(result.reason));
+      }
+      const mod = result.value;
       const register = mod.register ?? mod.default?.register;
       if (typeof register !== "function") {
         logger

--- a/agent/extension-loader/themes.ts
+++ b/agent/extension-loader/themes.ts
@@ -5,7 +5,7 @@
  * through `normalizeTheme` before reaching the registry.
  */
 
-import { readdir } from "node:fs/promises";
+import { readFile, readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { logger } from "../logger";
 import type { AethonAgentState, ThemeRecord } from "../state";
@@ -73,7 +73,7 @@ export async function loadAethonThemeDirectory(
     if (!name.endsWith(".json")) continue;
     const file = join(dir, name);
     try {
-      const text = await Bun.file(file).text();
+      const text = await readFile(file, "utf8");
       const parsed = JSON.parse(text) as unknown;
       // registerTheme handles validation internally — invalid input emits
       // a notice and resolves with {ok:false}.

--- a/agent/main.ts
+++ b/agent/main.ts
@@ -67,7 +67,6 @@ import {
 import { buildWorkingContextSection } from "./system-prompt/working-context";
 import { getWorkingContext } from "./git-context";
 import { readSessionTranscript } from "./session-history";
-import { readActiveProjectCwd, resolveStartupCwd } from "./active-project-cwd";
 import {
   AethonAgentState,
   type ExtensionFailure,
@@ -81,14 +80,8 @@ import {
   scheduleStateFileWrite as scheduleStateFileWriteImpl,
 } from "./runtime-snapshot";
 import { markFrontendReady } from "./mutation-ack";
-import {
-  loadAethonExtensions,
-  loadAethonExtensionPackages,
-  loadAethonThemeDirectory,
-  loadProjectAethonExtensions,
-  discoverPersistedTabs,
-  discoverPiAethonExtensions,
-} from "./extension-loader";
+import { discoverPersistedTabs } from "./extension-loader";
+import { loadAllExtensions } from "./boot-sequence";
 import { ensureTab, emitReady, tabSessionDir } from "./tab-lifecycle";
 import { seedPreparedEnv } from "./devshell";
 import { getSubagentsForCwd } from "./subagents";
@@ -96,7 +89,7 @@ import { buildExplicitSubagentSteer } from "./subagents/steer";
 import { loadDisabledExtensionsSnapshot } from "./disabled-extensions";
 import { resolveMemoryContext, readMemoryPath } from "./memory/resolver";
 import { renderMemoryPromptSection } from "./memory/renderer";
-import { captureProjectExtensionBaseline, runDispatcher } from "./dispatcher";
+import { runDispatcher } from "./dispatcher";
 import { withWorkerOrigin } from "./origin-gate";
 import { buildAethonMcpExtension } from "./mcp";
 import { createBootTrace, formatBootSummary } from "./boot-trace";
@@ -313,11 +306,14 @@ async function main(): Promise<void> {
       ...resolveAethonSystemPrompt(getRuntimeSnapshot(state)),
     ],
   });
-  await bootTrace.measure("resource-reload-1", () =>
-    state.resourceLoader.reload(),
-  );
-
-  // -- Extension loaders --------------------------------------------------
+  // -- Extension loaders + single resource reload --------------------------
+  // Orchestration (ordering contract + safe concurrency) lives in
+  // boot-sequence.ts. The resource loader reloads ONCE, after every
+  // extension source has registered, so the appended system prompt sees
+  // them all and sessions bind the instances from that reload. (It used
+  // to also reload here, before the loaders — pure duplicate cost: pi
+  // re-imports all ~/.pi extensions per reload and nothing between the
+  // two reloads read loader state.)
   const loadHooks = {
     onLoaded: (name: string) => {
       state.loadFailures.delete(name);
@@ -340,74 +336,20 @@ async function main(): Promise<void> {
       scheduleStateFileWrite();
     },
   };
-  await bootTrace.measure("user-extensions", () =>
-    loadAethonExtensions(
-      state,
-      extDeps,
-      extensionApi,
-      state.loadedExtensions,
+  const { startupCwd } = await loadAllExtensions(
+    state,
+    extDeps,
+    extensionApi,
+    {
+      userDir,
+      workerCwd,
+      projectRoot,
+      trace: bootTrace,
       loadHooks,
-    ),
-  );
-  await bootTrace.measure("extension-packages", () =>
-    loadAethonExtensionPackages(
-      state,
-      extDeps,
-      extensionApi,
-      state.loadedExtensions,
-      {
-        onFrontendEntry: ({ name, entryPath, code }) => {
-          state.extensionFrontendModules.set(name, { name, entryPath, code });
-        },
-        onLoaded: loadHooks.onLoaded,
-        onFailure: loadHooks.onFailure,
+      onFrontendEntry: ({ name, entryPath, code }) => {
+        state.extensionFrontendModules.set(name, { name, entryPath, code });
       },
-    ),
-  );
-  await bootTrace.measure("themes", () =>
-    loadAethonThemeDirectory(state, {
-      registerTheme: (theme) => aethonApi.registerTheme(theme),
-    }),
-  );
-  await bootTrace.measure("pi-discovery", () =>
-    discoverPiAethonExtensions(state.loadedExtensions),
-  );
-
-  // -- Project-extension baseline ----------------------------------------
-  // Snapshot the post-non-project-load state. Anything project-directory
-  // extensions register lands ON TOP of this baseline; switching projects
-  // restores the registries from this snapshot.
-  captureProjectExtensionBaseline(state);
-
-  const activeProjectCwd =
-    workerCwd ??
-    (await bootTrace.measure("active-project-cwd", () =>
-      readActiveProjectCwd(userDir),
-    ));
-  const startupCwd = resolveStartupCwd(
-    activeProjectCwd,
-    projectRoot,
-    userDir,
-    process.cwd(),
-  );
-
-  await bootTrace.measure("project-extensions", () =>
-    loadProjectAethonExtensions(
-      state,
-      extDeps,
-      startupCwd,
-      extensionApi,
-      state.loadedExtensions,
-      state.loadedProjectExtensionFiles,
-      state.failedProjectExtensionFiles,
-      loadHooks,
-    ),
-  );
-  state.currentProjectCwd = startupCwd;
-
-  // Reload so the appendSystemPromptOverride sees the populated extensions.
-  await bootTrace.measure("resource-reload-2", () =>
-    state.resourceLoader.reload(),
+    },
   );
 
   const tabDeps = { send };
@@ -419,14 +361,18 @@ async function main(): Promise<void> {
     // leaks into whatever the user opens next (sessions/default/ is
     // shared across project buckets).
     state.tabProjectCwds.set("default", startupCwd);
-    await bootTrace.measure("ensure-default-tab", () =>
-      ensureTab(state, tabDeps, "default", { trace: bootTrace }),
-    );
-
-    // -- Discover persisted sessions for the "Recent sessions" empty-state -
-    state.discoveredTabs = await bootTrace.measure("discover-tabs", () =>
-      discoverPersistedTabs(state),
-    );
+    // Default-tab creation and persisted-session discovery are
+    // independent (tab construction vs. read-only session-dir metadata
+    // scan), so overlap them. Both must complete before emitReady: the
+    // ready payload carries the default tab's model/thinking level AND
+    // the discoveredTabs list.
+    const [, discovered] = await Promise.all([
+      bootTrace.measure("ensure-default-tab", () =>
+        ensureTab(state, tabDeps, "default", { trace: bootTrace }),
+      ),
+      bootTrace.measure("discover-tabs", () => discoverPersistedTabs(state)),
+    ]);
+    state.discoveredTabs = discovered;
 
     scheduleStateFileWrite();
     emitReady(state, tabDeps);

--- a/agent/tab-lifecycle/lifecycle.ts
+++ b/agent/tab-lifecycle/lifecycle.ts
@@ -256,31 +256,38 @@ export async function ensureTab(
   );
 
   const endCreateSessionSpan = options.trace?.span("tab:create-agent-session");
-  const { session } = await createAgentSession({
-    authStorage: authServices.authStorage,
-    modelRegistry: authServices.modelRegistry,
-    settingsManager: state.settingsManager,
-    sessionManager,
-    ...(state.resourceLoader
-      ? { resourceLoader: resourceLoaderForTab(state.resourceLoader, tabId) }
-      : {}),
-    customTools: [
-      devshellBashTool,
-      ...buildSessionTitleTools(state, deps, tabId),
-      ...buildA2uiTools(),
-      ...buildShellTools(),
-      ...buildDashboardTools(state),
-      ...buildEditorTools(),
-      ...buildWindowTools(),
-      ...buildMemoryTools(state, tabId),
-      ...buildSchedulerTools(state, deps, tabId),
-      buildSubagentTaskTool(state, deps, tabId),
-      buildSubagentTaskBatchTool(state, deps, tabId),
-    ],
-    ...(options.initialModel ? { model: options.initialModel } : {}),
-    ...(options.thinkingLevel ? { thinkingLevel: options.thinkingLevel } : {}),
-  });
-  endCreateSessionSpan?.();
+  let created: Awaited<ReturnType<typeof createAgentSession>>;
+  try {
+    created = await createAgentSession({
+      authStorage: authServices.authStorage,
+      modelRegistry: authServices.modelRegistry,
+      settingsManager: state.settingsManager,
+      sessionManager,
+      ...(state.resourceLoader
+        ? { resourceLoader: resourceLoaderForTab(state.resourceLoader, tabId) }
+        : {}),
+      customTools: [
+        devshellBashTool,
+        ...buildSessionTitleTools(state, deps, tabId),
+        ...buildA2uiTools(),
+        ...buildShellTools(),
+        ...buildDashboardTools(state),
+        ...buildEditorTools(),
+        ...buildWindowTools(),
+        ...buildMemoryTools(state, tabId),
+        ...buildSchedulerTools(state, deps, tabId),
+        buildSubagentTaskTool(state, deps, tabId),
+        buildSubagentTaskBatchTool(state, deps, tabId),
+      ],
+      ...(options.initialModel ? { model: options.initialModel } : {}),
+      ...(options.thinkingLevel
+        ? { thinkingLevel: options.thinkingLevel }
+        : {}),
+    });
+  } finally {
+    endCreateSessionSpan?.();
+  }
+  const { session } = created;
   lifecycleLog.info(`session ready tabId=${tabId} cwd=${resolvedCwd}`);
   installAethonRetryClassifier(session);
   installCodexFastModePayloadHook(state, session);
@@ -331,15 +338,18 @@ export async function ensureTab(
   });
   emitContextUsage(state, deps, tabId, rec);
   const endBindSpan = options.trace?.span("tab:bind-extensions");
-  await session.bindExtensions({
-    uiContext: extensionUiContextForTab(),
-    onError: (error) => {
-      lifecycleLog.warn(
-        `pi extension error tabId=${tabId} event=${error.event}: ${error.error}`,
-      );
-    },
-  });
-  endBindSpan?.();
+  try {
+    await session.bindExtensions({
+      uiContext: extensionUiContextForTab(),
+      onError: (error) => {
+        lifecycleLog.warn(
+          `pi extension error tabId=${tabId} event=${error.event}: ${error.error}`,
+        );
+      },
+    });
+  } finally {
+    endBindSpan?.();
+  }
   const previousSlashCommands = JSON.stringify(state.piSlashCommands);
   refreshPiSlashCommands(state, session);
   if (JSON.stringify(state.piSlashCommands) !== previousSlashCommands) {

--- a/src/mobile/perfMarks.ts
+++ b/src/mobile/perfMarks.ts
@@ -41,19 +41,23 @@ export function perfMark(name: string): void {
   if (!enabled) return;
   try {
     performance.mark(PREFIX + name);
+    if (name === "hello-ok" && helloOkAt === null) {
+      helloOkAt = performance.now();
+      reportTimer = setTimeout(perfReport, REPORT_DELAY_MS);
+    }
   } catch {
     /* marks are best-effort */
-  }
-  if (name === "hello-ok" && helloOkAt === null) {
-    helloOkAt = performance.now();
-    reportTimer = setTimeout(perfReport, REPORT_DELAY_MS);
   }
 }
 
 /** Count one gateway invoke (called from the tauriCoreShim). */
 export function countInvoke(cmd: string): void {
   if (!enabled || invokes.length >= INVOKE_CAP) return;
-  invokes.push({ cmd, at: performance.now() });
+  try {
+    invokes.push({ cmd, at: performance.now() });
+  } catch {
+    /* the counter is best-effort */
+  }
 }
 
 function invokesWithin(windowMs: number): number {

--- a/src/mobile/perfMarks.ts
+++ b/src/mobile/perfMarks.ts
@@ -41,12 +41,18 @@ export function perfMark(name: string): void {
   if (!enabled) return;
   try {
     performance.mark(PREFIX + name);
-    if (name === "hello-ok" && helloOkAt === null) {
-      helloOkAt = performance.now();
-      reportTimer = setTimeout(perfReport, REPORT_DELAY_MS);
-    }
   } catch {
     /* marks are best-effort */
+  }
+  // Separate best-effort block: a throwing performance.mark must not
+  // also kill report scheduling + invoke-window tracking.
+  if (name === "hello-ok" && helloOkAt === null) {
+    try {
+      helloOkAt = performance.now();
+      reportTimer = setTimeout(perfReport, REPORT_DELAY_MS);
+    } catch {
+      /* the report is best-effort */
+    }
   }
 }
 

--- a/vite.mobile.config.ts
+++ b/vite.mobile.config.ts
@@ -47,17 +47,23 @@ export default defineConfig({
             // TAURI_DEV_HOST, and perf reports are ~1 KB.
             const MAX_PERF_BODY = 64 * 1024;
             let body = "";
+            let receivedBytes = 0;
             let overflow = false;
             req.on("data", (chunk: Buffer) => {
               if (overflow) return;
-              body += chunk.toString();
-              if (body.length > MAX_PERF_BODY) {
+              // Count raw bytes BEFORE decoding so an oversized chunk
+              // is rejected without the allocation, and the limit is
+              // bytes rather than UTF-16 code units.
+              receivedBytes += chunk.length;
+              if (receivedBytes > MAX_PERF_BODY) {
                 overflow = true;
                 body = "";
                 res.statusCode = 413;
                 res.end();
                 req.destroy();
+                return;
               }
+              body += chunk.toString();
             });
             req.on("end", () => {
               if (overflow) return;

--- a/vite.mobile.config.ts
+++ b/vite.mobile.config.ts
@@ -43,11 +43,24 @@ export default defineConfig({
           // startup report here so on-device numbers land in this
           // terminal without Safari's inspector attached.
           if (req.url === "/__perf" && req.method === "POST") {
+            // Bound the body: this server can be LAN-reachable via
+            // TAURI_DEV_HOST, and perf reports are ~1 KB.
+            const MAX_PERF_BODY = 64 * 1024;
             let body = "";
+            let overflow = false;
             req.on("data", (chunk: Buffer) => {
+              if (overflow) return;
               body += chunk.toString();
+              if (body.length > MAX_PERF_BODY) {
+                overflow = true;
+                body = "";
+                res.statusCode = 413;
+                res.end();
+                req.destroy();
+              }
             });
             req.on("end", () => {
+              if (overflow) return;
               console.log("[aethon:mobile-perf]", body);
               res.statusCode = 204;
               res.end();


### PR DESCRIPTION
## Summary

A1–A3 of the boot-chain workstream (#464 laid the instrumentation). Cuts bridge cold-start work for the global bridge AND every per-tab worker — this is also the direct cost of every extension toggle today (toggle = bridge cold boots).

- **Single resource reload (A1)**: dropped the pre-loader `resourceLoader.reload()`. pi re-imports every `~/.pi` extension per reload (jiti, `moduleCache: false`) and re-runs the MCP extension factory, so the double reload double-paid both. Nothing between the two reloads read loader state (verified: the only boot-path consumers of loaded resources — `refreshPiSlashCommands` → `getSkills()` — run inside `ensureTab`, after the remaining reload). Sessions still bind the instances from the final reload. A planned warm-import of `pi-mcp-adapter` was deliberately **not** done: the adapter reads `HOME` at import time under `withAdapterHome`, and a bare warm import would poison bun's module cache with the wrong adapter home.
- **Orchestrated boot sequence (A2)**: new `agent/boot-sequence.ts::loadAllExtensions` with the ordering contract documented in one place and safe concurrency applied — the active-project cwd read starts immediately and overlaps the loaders; loose-file themes + pi-extension discovery run concurrently after the register-loaders (later-wins + `registry.has` precedence preserved); `register()` calls stay strictly serial. `packages.ts` now reads manifests and imports entries concurrently (mirroring `directory.ts`) while keeping candidate first-wins order, lifecycle-event order, and serial `register()`.
- **Overlapped default-tab startup (A3)**: default-tab creation and persisted-session discovery run under `Promise.all` — both still complete before `emitReady` (the ready payload needs the default tab's model AND `discoveredTabs`).
- **Testability fix**: `themes.ts`/`discovery.ts` used `Bun.file()`, which throws in the vitest worker — the per-file try/catch silently skipped loose themes and pi discovery in every test run. Switched to `node:fs` `readFile` (bun-native, behavior-identical) so the new tests actually exercise those paths.
- **Copilot findings from #464 addressed** (same files): ensureTab spans close in `finally`; `perfMark`/`countInvoke` honor the never-throw contract; `/__perf` bounds its request body at 64 KB.

## Test plan

- [x] New `agent/boot-sequence.test.ts` (7 tests): single reload ordered last; disabled-extension skip; pi-discovery precedence **with a control asserting discovery really ran**; baseline captured between non-project and project loads; workerCwd + persisted-project `startupCwd` resolution; trace span names.
- [x] Full `check` green (3116 tests / 378 files, clippy, tsc -b, eslint 0-warnings)
- [x] Codex peer review: "no discrete regressions" (round 1)