### PR TITLE
perf(toggle): parallel bridge kills + lazy replay of background restored tabs

### DIFF
--- a/src-tauri/src/agent_commands.rs
+++ b/src-tauri/src/agent_commands.rs
@@ -202,12 +202,21 @@ pub(crate) fn force_restart_agent(state: State<'_, AgentProcesses>) -> Result<()
         let mut guard = state.children.lock().map_err(|e| e.to_string())?;
         guard.drain().collect()
     };
+    // Two passes: dispatch the kill to every child first (signal delivery
+    // is fast), then reap — serial kill+wait paid N sequential process
+    // teardowns on multi-tab sessions.
+    let mut reap = Vec::with_capacity(children.len());
     for (key, child) in children {
-        let mut child = child.lock().map_err(|e| e.to_string())?;
-        let pid = child.id();
+        let mut guard = child.lock().map_err(|e| e.to_string())?;
+        let pid = guard.id();
         tracing::warn!(target: "aethon::agent", key = key, "force_restart_agent: killing pid={pid}");
-        let _ = child.kill();
-        let _ = child.wait();
+        let _ = guard.kill();
+        drop(guard);
+        reap.push(child);
+    }
+    for child in reap {
+        let mut guard = child.lock().map_err(|e| e.to_string())?;
+        let _ = guard.wait();
     }
     if let Ok(mut routes) = state.mutation_routes.lock() {
         routes.clear();
@@ -236,12 +245,20 @@ pub(crate) fn reload_agent(state: State<'_, AgentProcesses>, app: AppHandle) -> 
                 exits.insert(key.clone());
             }
         }
+        // Kill-all first, then reap: signal delivery is fast and the
+        // process teardowns overlap instead of paying N serial waits.
+        let mut reap = Vec::with_capacity(children.len());
         for (key, child) in children {
-            let mut child = child.lock().map_err(|e| e.to_string())?;
-            let pid = child.id();
+            let mut guard = child.lock().map_err(|e| e.to_string())?;
+            let pid = guard.id();
             tracing::info!(target: "aethon::agent", key = key, "reload_agent: killing pid={pid}");
-            let _ = child.kill();
-            let _ = child.wait();
+            let _ = guard.kill();
+            drop(guard);
+            reap.push(child);
+        }
+        for child in reap {
+            let mut guard = child.lock().map_err(|e| e.to_string())?;
+            let _ = guard.wait();
         }
         if let Ok(mut routes) = state.mutation_routes.lock() {
             routes.clear();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { bootMark, reportBootTimeline } from "./utils/bootTrace";
+import { flushDeferredTabOpen } from "./hooks/bridgeMessageHandlers/readyEffects";
 import { ExtensionRegistry } from "./extensions/ExtensionRegistry";
 import { persistStatusesDebounced } from "./gitStatusCache";
 import { defaultLayoutExtension } from "./extensions/default-layout";
@@ -980,6 +981,16 @@ export default function App() {
     scheduledTasksOpen,
   } = useDerivedRenderState({ state, buildSidebarHistory, hostInfo });
   const chromeReady = bootConfigReady && startupChromeReady;
+
+  // First activation of a restored background tab opens it in the
+  // bridge — lazy replay keeps a bridge reload at one cold boot instead
+  // of one per tab (see readyEffects.ts). Covers every activation path
+  // (tab strip, palette, dashboard, activateTabAnywhere) in one place.
+  useEffect(() => {
+    if (typeof state.activeTabId === "string") {
+      void flushDeferredTabOpen(state.activeTabId);
+    }
+  }, [state.activeTabId]);
 
   // Boot timeline: mark the chrome-ready flip, then log the summary once
   // the first real-chrome frame commits. See src/utils/bootTrace.ts.

--- a/src/extensions/default-layout/lazySurface.tsx
+++ b/src/extensions/default-layout/lazySurface.tsx
@@ -1,0 +1,52 @@
+/**
+ * Lazy registration wrapper for heavy chrome surfaces.
+ *
+ * The ExtensionRegistry + `<RegistryComponent>` indirection means a
+ * registered component's identity is resolved at render time — so a
+ * `React.lazy` wrapper registered here splits the surface into its own
+ * chunk without touching the renderer or any call site. The Suspense
+ * boundary lives INSIDE the registered component, keeping the A2UI
+ * renderer fully synchronous, and the wrapper is type-compatible with
+ * `A2UIComponentImpl`, so extension overrides via
+ * `aethon.registerComponent` keep working exactly as before (they
+ * replace the whole wrapper in the components map; bridge-shipped
+ * declarative templates still win at resolve time).
+ *
+ * `preload()` lets App warm the chunks after chrome-ready so the first
+ * open of settings/palette/editor pays ~nothing.
+ */
+
+import { Suspense, lazy, type ComponentType } from "react";
+import type { BuiltinComponentProps } from "../../components/A2UIRenderer";
+
+type SurfaceImpl = ComponentType<BuiltinComponentProps>;
+
+export type LazySurfaceComponent = SurfaceImpl & {
+  preload: () => Promise<void>;
+};
+
+export function lazySurface(
+  name: string,
+  load: () => Promise<{ default: SurfaceImpl }>,
+): LazySurfaceComponent {
+  let loadPromise: Promise<{ default: SurfaceImpl }> | null = null;
+  const memoLoad = () => (loadPromise ??= load());
+  const Lazy = lazy(memoLoad);
+  // Null fallback: every wave-1 surface either fills a flex/grid cell
+  // (canvases, panels — the chrome around it doesn't move) or is an
+  // overlay (palette, settings), so a one-frame empty state can't shift
+  // layout.
+  const Wrapper = (props: BuiltinComponentProps) => (
+    <Suspense fallback={null}>
+      <Lazy {...props} />
+    </Suspense>
+  );
+  Wrapper.displayName = `LazySurface(${name})`;
+  const surface = Wrapper as LazySurfaceComponent;
+  surface.preload = () =>
+    memoLoad().then(
+      () => undefined,
+      () => undefined,
+    );
+  return surface;
+}

--- a/src/hooks/bridgeMessageHandlers/ready.test.ts
+++ b/src/hooks/bridgeMessageHandlers/ready.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { handleReady } from "./ready";
-import { resetReplayedTabsForTest } from "./readyEffects";
+import {
+  flushDeferredTabOpen,
+  resetReplayedTabsForTest,
+} from "./readyEffects";
 import { buildHandlerFixture } from "./testFixtures";
 import { clearTauriMocks, installTauriMocks } from "../../test/tauriMocks";
 import { makeEmptyTab } from "../../types/tab";
@@ -674,7 +677,7 @@ describe("handleReady", () => {
     );
   });
 
-  it("requests transcript replay for non-default open tabs after ready", () => {
+  it("defers transcript replay for background tabs until first interaction", async () => {
     const harness = installTauriMocks();
     const { ctx } = buildHandlerFixture({
       state: {
@@ -703,6 +706,12 @@ describe("handleReady", () => {
       },
       ctx,
     );
+    // Background tab: no bridge traffic at ready (lazy replay keeps a
+    // reload at one cold boot), then the full tab_open on flush.
+    expect(
+      harness.invoke.mock.calls.filter((call) => call[0] === "agent_command"),
+    ).toEqual([]);
+    await flushDeferredTabOpen("tab-2");
     const payloads = harness.invoke.mock.calls
       .filter((call) => call[0] === "agent_command")
       .map((call) => JSON.parse(call[1].payload as string));
@@ -716,7 +725,7 @@ describe("handleReady", () => {
     ]);
   });
 
-  it("replays restored tab reasoning levels to the bridge", () => {
+  it("replays restored tab reasoning levels to the bridge", async () => {
     const harness = installTauriMocks();
     const { ctx } = buildHandlerFixture({
       state: {
@@ -752,6 +761,7 @@ describe("handleReady", () => {
       },
       ctx,
     );
+    await flushDeferredTabOpen("tab-2");
 
     const payloads = harness.invoke.mock.calls
       .filter((call) => call[0] === "agent_command")

--- a/src/hooks/bridgeMessageHandlers/readyEffects.test.ts
+++ b/src/hooks/bridgeMessageHandlers/readyEffects.test.ts
@@ -108,6 +108,50 @@ describe("runReadyEffects", () => {
     expect(flushDeferredTabOpen("tab-bg")).toBeUndefined();
   });
 
+  it("re-parks a flushed open when workspace startup is not ready", async () => {
+    const { ctx } = buildHandlerFixture({
+      state: {
+        activeTabId: "default",
+        tabs: [
+          { id: "tab-bg", label: "Background", model: "claude", cwd: "/repo/b" },
+        ],
+      },
+    });
+    const prepare = vi
+      .fn()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValue(true);
+    ctx.prepareWorkspaceStartup = prepare;
+
+    runReadyEffects(ctx, {
+      currentProjectCwd: null,
+      priorActiveTabCwd: null,
+      priorActiveTabId: "default",
+      bridgeTabIds: new Set<string>(),
+    });
+
+    // First flush: startup not approved — no tab_open, thunk re-parked.
+    await flushDeferredTabOpen("tab-bg");
+    expect(harness.invoke).not.toHaveBeenCalledWith(
+      "agent_command",
+      expect.anything(),
+    );
+    expect(hasDeferredTabOpen("tab-bg")).toBe(true);
+
+    // Next interaction retries and succeeds.
+    await flushDeferredTabOpen("tab-bg");
+    expect(harness.invoke).toHaveBeenCalledWith("agent_command", {
+      payload: JSON.stringify({
+        type: "tab_open",
+        tabId: "tab-bg",
+        model: "claude",
+        cwd: "/repo/b",
+        restoreHistory: true,
+      }),
+    });
+    expect(hasDeferredTabOpen("tab-bg")).toBe(false);
+  });
+
   it("discards a deferred open without touching the bridge", () => {
     const { ctx } = buildHandlerFixture({
       state: {

--- a/src/hooks/bridgeMessageHandlers/readyEffects.test.ts
+++ b/src/hooks/bridgeMessageHandlers/readyEffects.test.ts
@@ -1,7 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildHandlerFixture } from "./testFixtures";
 import { clearTauriMocks, installTauriMocks } from "../../test/tauriMocks";
-import { resetReplayedTabsForTest, runReadyEffects } from "./readyEffects";
+import {
+  discardDeferredTabOpen,
+  flushDeferredTabOpen,
+  hasDeferredTabOpen,
+  resetReplayedTabsForTest,
+  runReadyEffects,
+} from "./readyEffects";
 
 describe("runReadyEffects", () => {
   let harness: ReturnType<typeof installTauriMocks>;
@@ -15,9 +21,10 @@ describe("runReadyEffects", () => {
     clearTauriMocks();
   });
 
-  it("replays restored non-default agent tabs through the pending tab-open gate", async () => {
+  it("eagerly replays the active restored tab through the pending tab-open gate", async () => {
     const { ctx } = buildHandlerFixture({
       state: {
+        activeTabId: "tab-1",
         tabs: [
           {
             id: "tab-1",
@@ -58,9 +65,81 @@ describe("runReadyEffects", () => {
     });
   });
 
+  it("defers background restored tabs and opens them on flush", async () => {
+    const { ctx } = buildHandlerFixture({
+      state: {
+        activeTabId: "tab-active",
+        tabs: [
+          { id: "tab-active", label: "Active", model: "claude", cwd: "/repo/a" },
+          { id: "tab-bg", label: "Background", model: "claude", cwd: "/repo/b" },
+        ],
+      },
+    });
+    ctx.prepareWorkspaceStartup = vi.fn().mockResolvedValue(true);
+
+    runReadyEffects(ctx, {
+      currentProjectCwd: null,
+      priorActiveTabCwd: null,
+      priorActiveTabId: "default",
+      bridgeTabIds: new Set<string>(),
+    });
+
+    // Only the visible tab hit the bridge; the background tab holds a
+    // deferred open — this is the 1-cold-boot (not 1+N) property.
+    expect(ctx.pendingTabOpens.current.has("tab-active")).toBe(true);
+    expect(ctx.pendingTabOpens.current.has("tab-bg")).toBe(false);
+    expect(hasDeferredTabOpen("tab-bg")).toBe(true);
+
+    const opening = flushDeferredTabOpen("tab-bg");
+    expect(opening).toBeDefined();
+    expect(hasDeferredTabOpen("tab-bg")).toBe(false);
+    expect(ctx.pendingTabOpens.current.has("tab-bg")).toBe(true);
+    await opening;
+    expect(harness.invoke).toHaveBeenCalledWith("agent_command", {
+      payload: JSON.stringify({
+        type: "tab_open",
+        tabId: "tab-bg",
+        model: "claude",
+        cwd: "/repo/b",
+        restoreHistory: true,
+      }),
+    });
+    // A second flush is a no-op — the open is single-shot.
+    expect(flushDeferredTabOpen("tab-bg")).toBeUndefined();
+  });
+
+  it("discards a deferred open without touching the bridge", () => {
+    const { ctx } = buildHandlerFixture({
+      state: {
+        activeTabId: "default",
+        tabs: [
+          { id: "tab-bg", label: "Background", model: "claude", cwd: "/repo/b" },
+        ],
+      },
+    });
+    ctx.prepareWorkspaceStartup = vi.fn().mockResolvedValue(true);
+
+    runReadyEffects(ctx, {
+      currentProjectCwd: null,
+      priorActiveTabCwd: null,
+      priorActiveTabId: "default",
+      bridgeTabIds: new Set<string>(),
+    });
+    expect(hasDeferredTabOpen("tab-bg")).toBe(true);
+
+    discardDeferredTabOpen("tab-bg");
+    expect(hasDeferredTabOpen("tab-bg")).toBe(false);
+    expect(flushDeferredTabOpen("tab-bg")).toBeUndefined();
+    expect(harness.invoke).not.toHaveBeenCalledWith(
+      "agent_command",
+      expect.anything(),
+    );
+  });
+
   it("skips tab_open when workspace startup is not ready", async () => {
     const { ctx } = buildHandlerFixture({
       state: {
+        activeTabId: "tab-1",
         tabs: [{ id: "tab-1", label: "Tab 1", model: "claude", cwd: "/repo/a" }],
       },
     });
@@ -83,6 +162,7 @@ describe("runReadyEffects", () => {
   it("replays exact .aethon-root tabs but not legacy project mirrors", async () => {
     const { ctx } = buildHandlerFixture({
       state: {
+        activeTabId: "state-root",
         tabs: [
           {
             id: "state-root",
@@ -113,11 +193,13 @@ describe("runReadyEffects", () => {
 
     // The exact `~/.aethon` root is the bridge's fallback cwd for tabs with
     // no active project — a live session that must survive reload. Only
-    // legacy project MIRRORS under the state dir stay excluded.
+    // legacy project MIRRORS under the state dir stay excluded — no eager
+    // open AND no deferred open.
     expect(ctx.pendingTabOpens.current.has("state-root")).toBe(true);
     expect(ctx.pendingTabOpens.current.has("legacy-project")).toBe(false);
-    expect(ctx.pendingTabOpens.current.has("managed-project")).toBe(true);
-    await ctx.pendingTabOpens.current.get("managed-project");
+    expect(hasDeferredTabOpen("legacy-project")).toBe(false);
+    expect(hasDeferredTabOpen("managed-project")).toBe(true);
+    await flushDeferredTabOpen("managed-project");
     expect(ctx.prepareWorkspaceStartup).toHaveBeenCalledWith(
       "/Users/jamesbrink/.aethon",
     );
@@ -212,6 +294,7 @@ describe("runReadyEffects", () => {
   it("replays each tab once per webview lifetime unless the bridge loses it", async () => {
     const { ctx } = buildHandlerFixture({
       state: {
+        activeTabId: "tab-1",
         tabs: [
           { id: "tab-1", label: "One", model: "claude", cwd: "/repo/a" },
           { id: "tab-2", label: "Two", model: "claude", cwd: "/repo/b" },
@@ -225,27 +308,26 @@ describe("runReadyEffects", () => {
       priorActiveTabId: "default",
     };
 
-    // First ready after webview load: both tabs replay.
+    // First ready after webview load: the active tab replays, the
+    // background tab defers.
     runReadyEffects(ctx, {
       ...input,
       bridgeTabIds: new Set(["tab-1", "tab-2"]),
     });
-    const firstOpens = new Map(ctx.pendingTabOpens.current);
-    expect(firstOpens.has("tab-1")).toBe(true);
-    expect(firstOpens.has("tab-2")).toBe(true);
+    const firstOpen = ctx.pendingTabOpens.current.get("tab-1");
+    expect(firstOpen).toBeDefined();
+    expect(hasDeferredTabOpen("tab-2")).toBe(true);
 
-    // A ready that re-fires while those opens are still in flight (the
-    // bridge snapshot can't reflect them yet) must not double-send.
+    // A ready that re-fires while that open is still in flight (the
+    // bridge snapshot can't reflect it yet) must not double-send.
     runReadyEffects(ctx, {
       ...input,
       bridgeTabIds: new Set<string>(),
     });
-    expect(ctx.pendingTabOpens.current.get("tab-1")).toBe(
-      firstOpens.get("tab-1"),
-    );
-    expect(ctx.pendingTabOpens.current.get("tab-2")).toBe(
-      firstOpens.get("tab-2"),
-    );
+    expect(ctx.pendingTabOpens.current.get("tab-1")).toBe(firstOpen);
+
+    // First interaction with the background tab opens it.
+    await flushDeferredTabOpen("tab-2");
 
     // Let the .finally() cleanup that clears pendingTabOpens flush.
     await new Promise((resolve) => setTimeout(resolve, 0));
@@ -253,21 +335,24 @@ describe("runReadyEffects", () => {
 
     // ready re-fires constantly (project switches, reports from other
     // clients). Re-replaying live tabs re-emitted session_history
-    // mid-stream and flipped the global project per ready — skip.
+    // mid-stream and flipped the global project per ready — skip both
+    // the eager and deferred paths.
     runReadyEffects(ctx, {
       ...input,
       bridgeTabIds: new Set(["tab-1", "tab-2"]),
     });
     expect(ctx.pendingTabOpens.current.size).toBe(0);
+    expect(hasDeferredTabOpen("tab-2")).toBe(false);
 
-    // Bridge respawned and lost tab-2: only that tab replays again.
+    // Bridge respawned and lost tab-2: it defers again (background),
+    // and opens on the next interaction.
     runReadyEffects(ctx, {
       ...input,
       bridgeTabIds: new Set(["tab-1"]),
     });
     expect(ctx.pendingTabOpens.current.has("tab-1")).toBe(false);
-    expect(ctx.pendingTabOpens.current.has("tab-2")).toBe(true);
-    await ctx.pendingTabOpens.current.get("tab-2");
+    expect(hasDeferredTabOpen("tab-2")).toBe(true);
+    await flushDeferredTabOpen("tab-2");
   });
 
   it("on the mobile surface, neither replays tabs nor announces a project", () => {

--- a/src/hooks/bridgeMessageHandlers/readyEffects.ts
+++ b/src/hooks/bridgeMessageHandlers/readyEffects.ts
@@ -26,9 +26,84 @@ export interface ReadyEffectsInput {
  *  through. */
 const replayedTabIds = new Set<string>();
 
+/** Restored background tabs are NOT opened at ready anymore — each holds
+ *  a thunk here and opens on first interaction (activation, chat send,
+ *  control request). This is what keeps an extension-toggle bridge
+ *  reload at ONE cold boot instead of 1+N: background workers respawn
+ *  lazily when their tab is actually used, mirroring the lazy
+ *  spawn-on-first-write the workers already have. Module-level for the
+ *  same reason as `replayedTabIds`. */
+const deferredTabOpens = new Map<string, () => Promise<unknown>>();
+
 /** Test-only: fresh-webview replay semantics. */
 export function resetReplayedTabsForTest(): void {
   replayedTabIds.clear();
+  deferredTabOpens.clear();
+}
+
+/** Open a deferred restored tab now (first interaction). Returns the
+ *  in-flight open, or undefined when the tab isn't deferred — callers
+ *  fall back to `pendingTabOpens` for an open already in flight. */
+export function flushDeferredTabOpen(
+  tabId: string,
+): Promise<unknown> | undefined {
+  const thunk = deferredTabOpens.get(tabId);
+  if (!thunk) return undefined;
+  deferredTabOpens.delete(tabId);
+  return thunk();
+}
+
+/** Drop a deferred open without running it (tab closed before use). */
+export function discardDeferredTabOpen(tabId: string): void {
+  deferredTabOpens.delete(tabId);
+}
+
+/** Test-only visibility into the deferred set. */
+export function hasDeferredTabOpen(tabId: string): boolean {
+  return deferredTabOpens.has(tabId);
+}
+
+/** Test-only: seed a deferred open so consumers of
+ *  `flushDeferredTabOpen` can be tested without a full ready fixture. */
+export function seedDeferredTabOpenForTest(
+  tabId: string,
+  thunk: () => Promise<unknown>,
+): void {
+  deferredTabOpens.set(tabId, thunk);
+}
+
+function openRestoredTab(
+  ctx: BridgeMessageContext,
+  t: Tab,
+  restoredCwd: string | undefined,
+): Promise<unknown> {
+  replayedTabIds.add(t.id);
+  const opening = (async () => {
+    if (restoredCwd && ctx.prepareWorkspaceStartup) {
+      const ready = await ctx.prepareWorkspaceStartup(restoredCwd);
+      if (!ready) return;
+    }
+    return await invoke("agent_command", {
+      payload: JSON.stringify({
+        type: "tab_open",
+        tabId: t.id,
+        ...(t.model ? { model: t.model } : {}),
+        ...(t.thinkingLevel ? { thinkingLevel: t.thinkingLevel } : {}),
+        ...(restoredCwd ? { cwd: restoredCwd } : {}),
+        ...(t.authProfileId ? { authProfileId: t.authProfileId } : {}),
+        restoreHistory: true,
+      }),
+    });
+  })();
+  ctx.pendingTabOpens.current.set(t.id, opening);
+  opening
+    .catch(() => {
+      /* surfaced on next chat send */
+    })
+    .finally(() => {
+      ctx.pendingTabOpens.current.delete(t.id);
+    });
+  return opening;
 }
 
 function replayRestoredAgentTabs(
@@ -36,6 +111,7 @@ function replayRestoredAgentTabs(
   bridgeTabIds: ReadonlySet<string>,
 ): void {
   const localTabs = (ctx.stateRef.current.tabs as Tab[] | undefined) ?? [];
+  const activeTabId = ctx.stateRef.current.activeTabId;
   for (const t of localTabs) {
     if ((t.kind ?? "agent") !== "agent") continue;
     if (t.id === "default") continue;
@@ -44,37 +120,23 @@ function replayRestoredAgentTabs(
     // the pending gate covers that window.
     if (ctx.pendingTabOpens.current.has(t.id)) continue;
     if (replayedTabIds.has(t.id) && bridgeTabIds.has(t.id)) continue;
-    replayedTabIds.add(t.id);
     const tabProject = t.projectId
       ? ctx.projectsRef.current.projects.find((p) => p.id === t.projectId)
       : null;
     const restoredCwd = t.cwd ?? tabProject?.path;
     if (restoredCwd && isLegacyAethonStateCwd(restoredCwd)) continue;
-    const opening = (async () => {
-      if (restoredCwd && ctx.prepareWorkspaceStartup) {
-        const ready = await ctx.prepareWorkspaceStartup(restoredCwd);
-        if (!ready) return;
-      }
-      return await invoke("agent_command", {
-        payload: JSON.stringify({
-          type: "tab_open",
-          tabId: t.id,
-          ...(t.model ? { model: t.model } : {}),
-          ...(t.thinkingLevel ? { thinkingLevel: t.thinkingLevel } : {}),
-          ...(restoredCwd ? { cwd: restoredCwd } : {}),
-          ...(t.authProfileId ? { authProfileId: t.authProfileId } : {}),
-          restoreHistory: true,
-        }),
+    if (t.id === activeTabId) {
+      // The visible conversation opens eagerly so it's usable the
+      // moment ready lands.
+      openRestoredTab(ctx, t, restoredCwd);
+    } else {
+      // Background tabs defer; overwrite any earlier thunk so a
+      // re-fired ready refreshes the captured cwd/project data.
+      deferredTabOpens.set(t.id, () => {
+        deferredTabOpens.delete(t.id);
+        return openRestoredTab(ctx, t, restoredCwd);
       });
-    })();
-    ctx.pendingTabOpens.current.set(t.id, opening);
-    opening
-      .catch(() => {
-        /* surfaced on next chat send */
-      })
-      .finally(() => {
-        ctx.pendingTabOpens.current.delete(t.id);
-      });
+    }
   }
 }
 

--- a/src/hooks/bridgeMessageHandlers/readyEffects.ts
+++ b/src/hooks/bridgeMessageHandlers/readyEffects.ts
@@ -81,7 +81,17 @@ function openRestoredTab(
   const opening = (async () => {
     if (restoredCwd && ctx.prepareWorkspaceStartup) {
       const ready = await ctx.prepareWorkspaceStartup(restoredCwd);
-      if (!ready) return;
+      if (!ready) {
+        // Startup not approved/ready — no tab_open was sent. Re-park
+        // the open so the next interaction (or ready re-fire) retries
+        // instead of stranding the tab with a consumed thunk.
+        replayedTabIds.delete(t.id);
+        deferredTabOpens.set(t.id, () => {
+          deferredTabOpens.delete(t.id);
+          return openRestoredTab(ctx, t, restoredCwd);
+        });
+        return;
+      }
     }
     return await invoke("agent_command", {
       payload: JSON.stringify({

--- a/src/hooks/chatModelSelection.ts
+++ b/src/hooks/chatModelSelection.ts
@@ -10,6 +10,7 @@ import {
   PI_DEFAULT_MODEL_SENTINEL,
 } from "../utils/modelPicker";
 import { isAgentTabInFlight } from "../utils/agentBusy";
+import { flushDeferredTabOpen } from "./bridgeMessageHandlers/readyEffects";
 import type { UseChatContext } from "./useChat";
 
 export const THINKING_LEVELS = new Set([
@@ -60,6 +61,7 @@ export function useChatModelSelectionController(
     | "updateTab"
     | "recordProjectModel"
     | "piDefaultModelRef"
+    | "pendingTabOpens"
   >,
   deps: ChatModelSelectionDeps,
 ): ChatModelSelectionController {
@@ -69,8 +71,26 @@ export function useChatModelSelectionController(
     updateTab,
     recordProjectModel,
     piDefaultModelRef,
+    pendingTabOpens,
   } = ctx;
   const { appendMessage } = deps;
+
+  /** A restored tab whose bridge replay is deferred (or still in
+   *  flight) must finish its `tab_open` before a tab-scoped command —
+   *  otherwise set_model / set_thinking_level races the open and the
+   *  restored snapshot overwrites the user's switch. Open failures
+   *  surface through the command itself. */
+  async function awaitTabOpen(tabId: string): Promise<void> {
+    const pending =
+      flushDeferredTabOpen(tabId) ?? pendingTabOpens.current.get(tabId);
+    if (pending) {
+      try {
+        await pending;
+      } catch {
+        /* surfaced by the command that follows */
+      }
+    }
+  }
 
   // Debounced persistence of header-selected agent defaults to [agent].
   // Clicking through models / reasoning levels would otherwise do a disk read +
@@ -217,6 +237,7 @@ export function useChatModelSelectionController(
     // No live session to retarget — the default pick is all that's needed.
     if (!hasActiveAgentTab || !activeId) return;
     try {
+      await awaitTabOpen(activeId);
       await invoke("agent_command", {
         payload: JSON.stringify({
           type: "set_model",
@@ -291,6 +312,7 @@ export function useChatModelSelectionController(
     }));
     persistDefaultThinkingLevel(level);
     try {
+      await awaitTabOpen(activeId);
       await invoke("agent_command", {
         payload: JSON.stringify({
           type: "set_thinking_level",

--- a/src/hooks/chatTransport.ts
+++ b/src/hooks/chatTransport.ts
@@ -4,6 +4,7 @@ import type { ChatAttachment, ChatMessage } from "../types/a2ui";
 import type { QueuedMessage, Tab } from "../types/tab";
 import { parseSlashCommand } from "../slashCommands";
 import { isAgentTabInFlight } from "../utils/agentBusy";
+import { flushDeferredTabOpen } from "./bridgeMessageHandlers/readyEffects";
 import { queueOf, withQueue } from "./chatQueue";
 import type { UseChatContext } from "./useChat";
 
@@ -274,11 +275,13 @@ export function createChatTransportController(
         : prev,
     );
 
-    // Wait for any pending tab_open on this tab to land first so the
-    // bridge has the right initial model before the chat creates the
-    // session lazily. swallow any open errors — sendChat surfaces its
-    // own error path below.
-    const pending = pendingTabOpens.current.get(tabId);
+    // A deferred restored tab opens on this first interaction (lazy
+    // replay — see readyEffects.ts); otherwise wait for any pending
+    // tab_open so the bridge has the right initial model before the
+    // chat creates the session lazily. Swallow any open errors —
+    // sendChat surfaces its own error path below.
+    const pending =
+      flushDeferredTabOpen(tabId) ?? pendingTabOpens.current.get(tabId);
     if (pending) {
       try {
         await pending;

--- a/src/hooks/tabOps/closeTab.ts
+++ b/src/hooks/tabOps/closeTab.ts
@@ -8,6 +8,7 @@ import {
 } from "../../types/tab";
 import type { ProjectsState } from "../../projects";
 import { disposeEditorBuffer } from "../../monaco/editor-buffers";
+import { discardDeferredTabOpen } from "../bridgeMessageHandlers/readyEffects";
 import { recomputeModelPicker } from "../../utils/modelPicker";
 import { focusTerminalPanelSoon } from "../../utils/focus";
 import { CLOSED_TAB_STACK_MAX, TAB_MIRROR_KEYS } from "./constants";
@@ -241,6 +242,9 @@ export function useCloseTabActions(deps: CloseTabDeps): CloseTabActions {
   }
 
   function closeTabNow(tabId: string): void {
+    // A restored tab closed before its first interaction never needs
+    // its deferred bridge replay (see readyEffects.ts).
+    discardDeferredTabOpen(tabId);
     const tabs = (stateRef.current.tabs as Tab[] | undefined) ?? [];
     if (tabs.length === 0) return;
     const closing = tabs.find((t) => t.id === tabId);

--- a/src/hooks/useChat.test.ts
+++ b/src/hooks/useChat.test.ts
@@ -11,6 +11,10 @@ import {
   loadSessionUiSnapshot,
   saveSessionUiSnapshot,
 } from "../state/sessionUiSnapshot";
+import {
+  resetReplayedTabsForTest,
+  seedDeferredTabOpenForTest,
+} from "./bridgeMessageHandlers/readyEffects";
 
 const invoke = vi.fn<(...args: unknown[]) => Promise<unknown>>(() =>
   Promise.resolve(undefined),
@@ -236,6 +240,28 @@ describe("useChat setModel", () => {
       text: "hello",
       delivery: "sent",
     });
+  });
+
+  it("opens a deferred restored tab before sending", async () => {
+    const { ctx } = buildContext();
+    let sendSeenAtOpen: boolean | null = null;
+    seedDeferredTabOpenForTest("tab-1", () => {
+      sendSeenAtOpen = invoke.mock.calls.some(([cmd]) => cmd === "send_message");
+      return Promise.resolve(undefined);
+    });
+    try {
+      const { result } = renderHook(() => useChat(ctx));
+
+      await act(async () => {
+        await result.current.sendChat("hello");
+      });
+
+      // The deferred open ran (non-null) and strictly before send_message.
+      expect(sendSeenAtOpen).toBe(false);
+      expect(invoke).toHaveBeenCalledWith("send_message", expect.anything());
+    } finally {
+      resetReplayedTabsForTest();
+    }
   });
 
   it("lets the bridge emit the user session event when local mirroring fails", async () => {

--- a/src/hooks/useControlRequests.ts
+++ b/src/hooks/useControlRequests.ts
@@ -177,11 +177,27 @@ async function openTab(
   const cwd = stringParam(params, "cwd");
   const model = stringParam(params, "model");
   const account = stringParam(params, "account");
-  // If the id names a restored tab whose replay is deferred, open it
-  // first so the bridge state matches the pre-lazy-replay behavior.
-  const deferred = flushDeferredTabOpen(tabId);
-  if (deferred) {
-    await deferred.catch(() => {});
+  const existing = (
+    (ctx.stateRef.current.tabs as Tab[] | undefined) ?? []
+  ).find((t) => t.id === tabId);
+  if (existing) {
+    // The id names a tab that already exists locally (a restored tab —
+    // possibly with its bridge replay still deferred — or a live one).
+    // Never append a duplicate: finish/await its open and focus it.
+    await ensureControlTabOpened(ctx, tabId);
+    ctx.setActiveTab(tabId);
+    if (account) {
+      await switchAccountForTab(tabId, account, { cwd, model });
+      ctx.updateTab(tabId, (tab) => ({ ...tab, authProfileId: account }));
+    }
+    return {
+      id: tabId,
+      kind: existing.kind ?? "agent",
+      label: existing.label,
+      cwd,
+      model,
+      authProfileId: account,
+    };
   }
   ctx.newTab(tabId, label, { cwd, model });
   await ctx.pendingTabOpens.current.get(tabId);
@@ -210,6 +226,24 @@ function focusTab(
   return { activeTabId: tabId };
 }
 
+/** A deferred restored tab must finish its bridge replay before a
+ *  tab-scoped account switch targets it — otherwise auth_profile_apply
+ *  lands before tab_open and the replay restores the old profile. */
+async function ensureControlTabOpened(
+  ctx: UseControlRequestsContext,
+  tabId: string,
+): Promise<void> {
+  const pending =
+    flushDeferredTabOpen(tabId) ?? ctx.pendingTabOpens.current.get(tabId);
+  if (pending) {
+    try {
+      await pending;
+    } catch {
+      /* surfaced by the command that follows */
+    }
+  }
+}
+
 async function applyAccount(
   ctx: UseControlRequestsContext,
   params: Record<string, unknown>,
@@ -219,6 +253,7 @@ async function applyAccount(
   if (target.busy) {
     throw new Error(`tab ${target.tabId} is busy; stop or wait before switching accounts`);
   }
+  await ensureControlTabOpened(ctx, target.tabId);
   await switchAccountForTab(target.tabId, profileId, {
     cwd: target.cwd,
     model: target.model,
@@ -242,6 +277,7 @@ async function sendChat(
     if (target.busy) {
       throw new Error(`tab ${target.tabId} is busy; stop or wait before switching accounts`);
     }
+    await ensureControlTabOpened(ctx, target.tabId);
     await switchAccountForTab(target.tabId, account, {
       cwd: target.cwd,
       model: target.model,

--- a/src/hooks/useControlRequests.ts
+++ b/src/hooks/useControlRequests.ts
@@ -13,6 +13,7 @@ import {
   registerControlWait,
   type ControlWaitResult,
 } from "./controlWaitRegistry";
+import { flushDeferredTabOpen } from "./bridgeMessageHandlers/readyEffects";
 
 /** Default ceiling for `chat.send --wait` / `chat.wait` when the caller does
  *  not pass `timeoutMs`. Generous because real agent turns routinely run for
@@ -176,6 +177,12 @@ async function openTab(
   const cwd = stringParam(params, "cwd");
   const model = stringParam(params, "model");
   const account = stringParam(params, "account");
+  // If the id names a restored tab whose replay is deferred, open it
+  // first so the bridge state matches the pre-lazy-replay behavior.
+  const deferred = flushDeferredTabOpen(tabId);
+  if (deferred) {
+    await deferred.catch(() => {});
+  }
   ctx.newTab(tabId, label, { cwd, model });
   await ctx.pendingTabOpens.current.get(tabId);
   if (account) {


### PR DESCRIPTION
## Summary

B1 of the extension-toggle workstream (on top of #465's faster cold boot). A toggle previously cost **1+N bridge cold boots**: `reload_agent` killed the global bridge plus every tab worker serially (kill+wait each), then `replayRestoredAgentTabs` eagerly re-opened every restored tab at ready, respawning every worker at once. Now a toggle costs **one** cold boot:

- **Parallel kills**: `reload_agent` / `force_restart_agent` dispatch the kill to every child first, then reap — N process teardowns overlap instead of N serial waits.
- **Lazy replay**: only the ACTIVE restored tab opens eagerly at ready. Background tabs park a deferred open (module state beside the existing `replayedTabIds`) that fires on first interaction: tab activation (one App effect covers every activation path — tab strip, palette, dashboard, `activateTabAnywhere`), chat send (`chatTransport`), or a control-request open. Workers then respawn lazily via the existing spawn-on-first-write path.
- **Race gates** (codex P2): `set_model` / `set_thinking_level` flush/await the tab's deferred or in-flight open before issuing, so a switch made right after activating a restored tab can't be overwritten by the open's restored snapshot. `closeTabNow` discards a deferred open; a re-fired ready overwrites still-deferred thunks with fresh cwd/project data; the pending-open gate and replayed-once semantics are unchanged; the mobile passive-reader early-return is untouched.

## Test plan

- [x] `readyEffects`: active-eager + background-deferred, flush single-shot, discard, legacy-mirror exclusion (no eager AND no deferred), bridge-lost tab re-defers, mobile no-op — 9 tests
- [x] `ready.test`: payload parity (cwd/model/thinkingLevel/restoreHistory) via deferred flush; zero bridge traffic at ready for background tabs
- [x] `useChat`: deferred open runs strictly before `send_message` (self-falsifying probe)
- [x] Full `check` green (3126 tests / 378 files)
- [x] Codex review round 1: single P2 (model-switch race) — fixed in this PR; round 2 running