### PR TITLE
perf(desktop): monaco/shiki out of the boot path + lazy chrome surfaces

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1007,18 +1007,23 @@ export default function App() {
       bootMark("chrome-ready-commit");
       reportBootTimeline();
     });
-    const scheduleIdle: (cb: () => void) => void =
-      typeof requestIdleCallback === "function"
-        ? (cb) => requestIdleCallback(cb, { timeout: 5_000 })
-        : (cb) => setTimeout(cb, 2_000);
-    scheduleIdle(() => {
+    const onIdle = () => {
       // Boot is over: lazy surfaces rendered from here on (palette,
-      // settings, first editor tab) load immediately, and the warmup
-      // below pulls every remaining chunk in the background.
+      // settings, first editor tab) load immediately, parked loads
+      // (visible-at-boot surfaces) flush now, and the warmup below
+      // pulls every remaining chunk in the background.
       releaseLazySurfaceBootDeferral();
       preloadDefaultLayoutSurfaces();
-    });
-    return () => cancelAnimationFrame(raf);
+    };
+    const hasIdleCallback = typeof requestIdleCallback === "function";
+    const idleHandle = hasIdleCallback
+      ? requestIdleCallback(onIdle, { timeout: 5_000 })
+      : setTimeout(onIdle, 2_000);
+    return () => {
+      cancelAnimationFrame(raf);
+      if (hasIdleCallback) cancelIdleCallback(idleHandle);
+      else clearTimeout(idleHandle);
+    };
   }, [chromeReady]);
 
   return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,10 @@ import { bootMark, reportBootTimeline } from "./utils/bootTrace";
 import { flushDeferredTabOpen } from "./hooks/bridgeMessageHandlers/readyEffects";
 import { ExtensionRegistry } from "./extensions/ExtensionRegistry";
 import { persistStatusesDebounced } from "./gitStatusCache";
-import { defaultLayoutExtension } from "./extensions/default-layout";
+import {
+  defaultLayoutExtension,
+  preloadDefaultLayoutSurfaces,
+} from "./extensions/default-layout";
 import { mobileLayoutExtension } from "./mobile/mobileLayoutExtension";
 import { AppRoot } from "./app/AppRoot";
 import { BOOT_LAYOUT, hangWarnNotifId } from "./app/bootConstants";
@@ -994,6 +997,8 @@ export default function App() {
 
   // Boot timeline: mark the chrome-ready flip, then log the summary once
   // the first real-chrome frame commits. See src/utils/bootTrace.ts.
+  // Then warm the lazy surface chunks (editor, terminal, settings,
+  // palette, …) on the first idle so their first open pays ~nothing.
   useEffect(() => {
     if (!chromeReady) return;
     bootMark("chrome-ready");
@@ -1001,6 +1006,11 @@ export default function App() {
       bootMark("chrome-ready-commit");
       reportBootTimeline();
     });
+    const scheduleIdle: (cb: () => void) => void =
+      typeof requestIdleCallback === "function"
+        ? (cb) => requestIdleCallback(cb, { timeout: 5_000 })
+        : (cb) => setTimeout(cb, 2_000);
+    scheduleIdle(() => preloadDefaultLayoutSurfaces());
     return () => cancelAnimationFrame(raf);
   }, [chromeReady]);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import {
   defaultLayoutExtension,
   preloadDefaultLayoutSurfaces,
 } from "./extensions/default-layout";
+import { releaseLazySurfaceBootDeferral } from "./extensions/default-layout/lazySurface";
 import { mobileLayoutExtension } from "./mobile/mobileLayoutExtension";
 import { AppRoot } from "./app/AppRoot";
 import { BOOT_LAYOUT, hangWarnNotifId } from "./app/bootConstants";
@@ -1010,7 +1011,13 @@ export default function App() {
       typeof requestIdleCallback === "function"
         ? (cb) => requestIdleCallback(cb, { timeout: 5_000 })
         : (cb) => setTimeout(cb, 2_000);
-    scheduleIdle(() => preloadDefaultLayoutSurfaces());
+    scheduleIdle(() => {
+      // Boot is over: lazy surfaces rendered from here on (palette,
+      // settings, first editor tab) load immediately, and the warmup
+      // below pulls every remaining chunk in the background.
+      releaseLazySurfaceBootDeferral();
+      preloadDefaultLayoutSurfaces();
+    });
     return () => cancelAnimationFrame(raf);
   }, [chromeReady]);
 

--- a/src/NativeCanvasWindowApp.tsx
+++ b/src/NativeCanvasWindowApp.tsx
@@ -5,6 +5,7 @@ import A2UIRenderer from "./components/A2UIRenderer";
 import { ExtensionRegistry } from "./extensions/ExtensionRegistry";
 import { ExtensionRegistryProvider } from "./extensions/ExtensionRegistryProvider";
 import { defaultLayoutExtension } from "./extensions/default-layout";
+import { releaseLazySurfaceBootDeferral } from "./extensions/default-layout/lazySurface";
 import {
   reconcileFrontendModules,
   type ExtensionFrontendModule,
@@ -53,6 +54,11 @@ export default function NativeCanvasWindowApp({
   id,
 }: NativeCanvasWindowAppProps) {
   const [registry] = useState(() => {
+    // A native canvas window is a fresh webview spawned on demand —
+    // post-boot by definition, and it never runs App's chrome-ready
+    // release. Drop the lazy-surface boot latch so its shell/editor
+    // canvases load immediately.
+    releaseLazySurfaceBootDeferral();
     const r = new ExtensionRegistry();
     r.register(defaultLayoutExtension);
     return r;

--- a/src/extensions/default-layout/editor/canvas.tsx
+++ b/src/extensions/default-layout/editor/canvas.tsx
@@ -31,6 +31,12 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { openUrl } from "@tauri-apps/plugin-opener";
+// Side-effect import: worker factories + loader binding + language
+// registration. Must evaluate before the first `<Editor>` mount or
+// `createModel` call — living at the top of this chunk (rather than
+// mainApp.tsx) keeps monaco out of the boot bundle while preserving
+// that ordering, since models are only created inside this chunk.
+import "../../../monaco/setup";
 import * as monaco from "monaco-editor";
 
 import type { StringValue } from "../../../types/a2ui";
@@ -43,8 +49,8 @@ import {
 import { applyMonacoTheme } from "../../../monaco/theme";
 import { ensureShikiMonacoReady } from "../../../monaco/shiki";
 import {
-  createEditorBuffer,
   getEditorBuffer,
+  registerEditorBuffer,
 } from "../../../monaco/editor-buffers";
 import { pickFileViewer } from "./file-viewers";
 import { compressPath } from "./path";
@@ -395,7 +401,11 @@ export function EditorCanvas({
     const language = editorMeta.language || "plaintext";
     let buf = getEditorBuffer(tabId);
     if (!buf) {
-      buf = createEditorBuffer(tabId, editorMeta.filePath, language);
+      buf = registerEditorBuffer(
+        tabId,
+        monaco.editor.createModel("", language),
+        editorMeta.filePath,
+      );
     } else if (buf.filePath !== editorMeta.filePath) {
       // Tab was renamed (file-tree rename or folder-rename prefix
       // rewrite). Sync the cache so the next Cmd+S writes to the new

--- a/src/extensions/default-layout/editor/diff-canvas.tsx
+++ b/src/extensions/default-layout/editor/diff-canvas.tsx
@@ -17,6 +17,9 @@
 
 import { useEffect, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
+// Side-effect import: monaco worker/loader/language bootstrap must run
+// before any monaco API call in this chunk (see canvas.tsx).
+import "../../../monaco/setup";
 import * as monaco from "monaco-editor";
 
 import type { BuiltinComponentProps } from "../../../components/A2UIRenderer";

--- a/src/extensions/default-layout/index.ts
+++ b/src/extensions/default-layout/index.ts
@@ -7,31 +7,29 @@
 
 import type { A2UIPayload } from "../../types/a2ui";
 import type { A2UIExtension } from "../types";
+// Eager surfaces import their SOURCE modules directly, not the
+// ./components barrel — the barrel re-exports the editor/terminal/shell
+// families, whose side-effect imports (monaco bootstrap, xterm CSS)
+// would drag those chunks back into the boot bundle.
 import {
-  ChatHistory,
-  ChatInput,
-  EditorCanvas,
-  DiffCanvas,
   EmptyState,
   MobileDeviceLanding,
   WorkspaceLanding,
-  FileTreePanel,
-  ImageViewer,
   Layout,
-  MainCanvas,
-  MarkdownPreview,
-  QueuedMessagesPopover,
-  QuestionCard,
-  ShellCanvas,
-  Sidebar,
   StatusBar,
-  TabStrip,
-  Terminal,
-  TerminalPanel,
-  ToolCard,
+} from "./layout";
+import { Sidebar } from "./sidebar";
+import { FileTreePanel } from "./sidebar/file-tree";
+import {
+  ChatHistory,
+  ChatInput,
+  MainCanvas,
+  QueuedMessagesPopover,
   SubagentResult,
-  AuthProfilePanel,
-} from "./components";
+  ToolCard,
+} from "./chat";
+import { QuestionCard } from "./question-card";
+import { TabStrip } from "./shell/tab-strip";
 import {
   AccountSelector,
   AgentStatusPill,
@@ -39,13 +37,8 @@ import {
   ModelPicker,
   VcsStatus,
 } from "./variation-components";
-import { SourceControlPanel } from "./sidebar/source-control-panel";
 import { ComposerVisibilityPills } from "./composer-visibility-pills";
-import { CommandPalette } from "./command-palette";
 import { NotificationStack } from "./notifications";
-import { SettingsPanel } from "./settings-panel";
-import { SearchPanel } from "./search-panel";
-import { ScheduledTasksPanel } from "./scheduled-tasks-panel";
 import { ShareModeBadge } from "./share-mode-badge";
 import { GhStatsStrip } from "./dashboard/gh-stats-strip";
 import { ProjectCard } from "./dashboard/project-card";
@@ -53,8 +46,89 @@ import { TaskLauncher } from "./dashboard/task-launcher";
 import { ProjectsDashboard } from "./dashboard/projects-dashboard";
 import { ProjectDashboard } from "./dashboard/project-dashboard";
 import { IssuesSection } from "./dashboard/issues-section";
-import { SubagentsConfig } from "./dashboard/subagents-config";
+import { lazySurface } from "./lazySurface";
 import workstationPayload from "./workstation.a2ui.json";
+
+// Heavy surfaces that are closed (or invisible) at first paint load as
+// their own chunks on first mount; `preloadDefaultLayoutSurfaces` warms
+// them post-chrome-ready. Each loads its DIRECT source module so a
+// light surface (markdown preview) never rides in a heavy chunk
+// (monaco).
+const EditorCanvas = lazySurface("editor-canvas", () =>
+  import("./editor/canvas").then((m) => ({ default: m.EditorCanvas })),
+);
+const DiffCanvas = lazySurface("diff-canvas", () =>
+  import("./editor/diff-canvas").then((m) => ({ default: m.DiffCanvas })),
+);
+const ImageViewer = lazySurface("image-viewer", () =>
+  import("./editor/image-viewer").then((m) => ({ default: m.ImageViewer })),
+);
+const MarkdownPreview = lazySurface("markdown-preview", () =>
+  import("./editor/markdown-preview").then((m) => ({
+    default: m.MarkdownPreview,
+  })),
+);
+const ShellCanvas = lazySurface("shell-canvas", () =>
+  import("./shell/canvas").then((m) => ({ default: m.ShellCanvas })),
+);
+const TerminalPanel = lazySurface("terminal-panel", () =>
+  import("./shell/panel").then((m) => ({ default: m.TerminalPanel })),
+);
+const Terminal = lazySurface("terminal", () =>
+  import("./terminal").then((m) => ({ default: m.Terminal })),
+);
+const SettingsPanel = lazySurface("settings-panel", () =>
+  import("./settings-panel").then((m) => ({ default: m.SettingsPanel })),
+);
+const AuthProfilePanel = lazySurface("auth-profile-panel", () =>
+  import("./auth-profile-panel").then((m) => ({
+    default: m.AuthProfilePanel,
+  })),
+);
+const SearchPanel = lazySurface("search-panel", () =>
+  import("./search-panel").then((m) => ({ default: m.SearchPanel })),
+);
+const ScheduledTasksPanel = lazySurface("scheduled-tasks-panel", () =>
+  import("./scheduled-tasks-panel").then((m) => ({
+    default: m.ScheduledTasksPanel,
+  })),
+);
+const CommandPalette = lazySurface("command-palette", () =>
+  import("./command-palette").then((m) => ({ default: m.CommandPalette })),
+);
+const SourceControlPanel = lazySurface("source-control-panel", () =>
+  import("./sidebar/source-control-panel").then((m) => ({
+    default: m.SourceControlPanel,
+  })),
+);
+const SubagentsConfig = lazySurface("subagents-config", () =>
+  import("./dashboard/subagents-config").then((m) => ({
+    default: m.SubagentsConfig,
+  })),
+);
+
+/** Warm every lazy surface chunk. Called from App on the first idle
+ *  after chrome-ready so first-open latency is ~zero. */
+export function preloadDefaultLayoutSurfaces(): void {
+  for (const surface of [
+    EditorCanvas,
+    DiffCanvas,
+    ImageViewer,
+    MarkdownPreview,
+    ShellCanvas,
+    TerminalPanel,
+    Terminal,
+    SettingsPanel,
+    AuthProfilePanel,
+    SearchPanel,
+    ScheduledTasksPanel,
+    CommandPalette,
+    SourceControlPanel,
+    SubagentsConfig,
+  ]) {
+    void surface.preload();
+  }
+}
 
 export {
   layoutSlots,

--- a/src/extensions/default-layout/lazySurface.test.tsx
+++ b/src/extensions/default-layout/lazySurface.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+
+import type { BuiltinComponentProps } from "../../components/A2UIRenderer";
+import {
+  lazySurface,
+  releaseLazySurfaceBootDeferral,
+  resetLazySurfaceBootDeferralForTest,
+} from "./lazySurface";
+
+function surfaceProps(): BuiltinComponentProps {
+  return {
+    component: { id: "x", type: "x", props: {} },
+    state: {},
+    setState: () => {},
+    onEvent: () => {},
+  } as unknown as BuiltinComponentProps;
+}
+
+beforeEach(() => {
+  resetLazySurfaceBootDeferralForTest();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("lazySurface", () => {
+  it("does NOT start the import when rendered during the boot window", async () => {
+    // The workstation layout mounts hidden cells (display:none) at first
+    // chrome render — the import must wait for idle, not fire eagerly.
+    vi.useFakeTimers();
+    const load = vi.fn(() =>
+      Promise.resolve({ default: () => <div>loaded</div> }),
+    );
+    const Surface = lazySurface("test-surface", load);
+
+    render(<Surface {...surfaceProps()} />);
+    expect(load).not.toHaveBeenCalled();
+
+    // jsdom lacks requestIdleCallback — the setTimeout fallback fires it.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000);
+    });
+    expect(load).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("loaded")).toBeTruthy();
+  });
+
+  it("loads immediately once the boot latch is released", async () => {
+    releaseLazySurfaceBootDeferral();
+    const load = vi.fn(() =>
+      Promise.resolve({ default: () => <div>loaded-now</div> }),
+    );
+    const Surface = lazySurface("post-boot", load);
+
+    render(<Surface {...surfaceProps()} />);
+    expect(load).toHaveBeenCalledTimes(1);
+    expect(await screen.findByText("loaded-now")).toBeTruthy();
+  });
+
+  it("preload() loads now and dedupes with a later render", async () => {
+    releaseLazySurfaceBootDeferral();
+    const load = vi.fn(() =>
+      Promise.resolve({ default: () => <div>warm</div> }),
+    );
+    const Surface = lazySurface("warmed", load);
+
+    await Surface.preload();
+    expect(load).toHaveBeenCalledTimes(1);
+
+    render(<Surface {...surfaceProps()} />);
+    expect(load).toHaveBeenCalledTimes(1);
+    expect(await screen.findByText("warm")).toBeTruthy();
+  });
+
+  it("preload() never rejects even when the chunk fails", async () => {
+    releaseLazySurfaceBootDeferral();
+    const Surface = lazySurface("broken", () =>
+      Promise.reject(new Error("chunk 404")),
+    );
+    await expect(Surface.preload()).resolves.toBeUndefined();
+  });
+});

--- a/src/extensions/default-layout/lazySurface.test.tsx
+++ b/src/extensions/default-layout/lazySurface.test.tsx
@@ -47,6 +47,31 @@ describe("lazySurface", () => {
     expect(screen.getByText("loaded")).toBeTruthy();
   });
 
+  it("release flushes a parked load immediately (visible-at-boot surface)", async () => {
+    vi.useFakeTimers();
+    const load = vi.fn(() =>
+      Promise.resolve({ default: () => <div>flushed</div> }),
+    );
+    const Surface = lazySurface("restored-terminal", load);
+
+    render(<Surface {...surfaceProps()} />);
+    expect(load).not.toHaveBeenCalled();
+
+    // Chrome-ready idle: the latch release fires parked loads without
+    // waiting out their own idle timers.
+    await act(async () => {
+      releaseLazySurfaceBootDeferral();
+      await Promise.resolve();
+    });
+    expect(load).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("flushed")).toBeTruthy();
+    // The already-fired idle timer must not double-load.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+    expect(load).toHaveBeenCalledTimes(1);
+  });
+
   it("loads immediately once the boot latch is released", async () => {
     releaseLazySurfaceBootDeferral();
     const load = vi.fn(() =>

--- a/src/extensions/default-layout/lazySurface.tsx
+++ b/src/extensions/default-layout/lazySurface.tsx
@@ -34,14 +34,22 @@ export type LazySurfaceComponent = SurfaceImpl & {
  *  callback; `releaseLazySurfaceBootDeferral()` (App, at chrome-ready)
  *  drops the latch so every later open loads immediately. */
 let bootDeferralActive = true;
+/** Loads parked during the boot window. Released (all at once) the
+ *  moment App declares chrome-ready idle, so a surface that is VISIBLE
+ *  at boot (e.g. a restored-open terminal panel) starts loading at the
+ *  earliest safe moment rather than waiting out its own idle timer. */
+const parkedLoads = new Set<() => void>();
 
 export function releaseLazySurfaceBootDeferral(): void {
   bootDeferralActive = false;
+  for (const fire of [...parkedLoads]) fire();
+  parkedLoads.clear();
 }
 
 /** Test-only. */
 export function resetLazySurfaceBootDeferralForTest(): void {
   bootDeferralActive = true;
+  parkedLoads.clear();
 }
 
 const scheduleIdle: (cb: () => void) => void =
@@ -57,7 +65,15 @@ export function lazySurface(
   const memoLoad = () =>
     (loadPromise ??= bootDeferralActive
       ? new Promise<{ default: SurfaceImpl }>((resolve, reject) => {
-          scheduleIdle(() => load().then(resolve, reject));
+          let fired = false;
+          const fire = () => {
+            if (fired) return;
+            fired = true;
+            parkedLoads.delete(fire);
+            load().then(resolve, reject);
+          };
+          parkedLoads.add(fire);
+          scheduleIdle(fire);
         })
       : load());
   const Lazy = lazy(memoLoad);

--- a/src/extensions/default-layout/lazySurface.tsx
+++ b/src/extensions/default-layout/lazySurface.tsx
@@ -25,12 +25,41 @@ export type LazySurfaceComponent = SurfaceImpl & {
   preload: () => Promise<void>;
 };
 
+/** During the boot window, a rendered lazy surface must not start its
+ *  import immediately: the workstation layout mounts hidden cells
+ *  (editor-canvas, terminal-panel, …) with `display: none` at first
+ *  chrome render, and an eager trigger would pull monaco/xterm right
+ *  back into the boot sequence, competing with first paint. Loads
+ *  requested before the latch releases are queued behind an idle
+ *  callback; `releaseLazySurfaceBootDeferral()` (App, at chrome-ready)
+ *  drops the latch so every later open loads immediately. */
+let bootDeferralActive = true;
+
+export function releaseLazySurfaceBootDeferral(): void {
+  bootDeferralActive = false;
+}
+
+/** Test-only. */
+export function resetLazySurfaceBootDeferralForTest(): void {
+  bootDeferralActive = true;
+}
+
+const scheduleIdle: (cb: () => void) => void =
+  typeof requestIdleCallback === "function"
+    ? (cb) => requestIdleCallback(cb, { timeout: 3_000 })
+    : (cb) => setTimeout(cb, 1_500);
+
 export function lazySurface(
   name: string,
   load: () => Promise<{ default: SurfaceImpl }>,
 ): LazySurfaceComponent {
   let loadPromise: Promise<{ default: SurfaceImpl }> | null = null;
-  const memoLoad = () => (loadPromise ??= load());
+  const memoLoad = () =>
+    (loadPromise ??= bootDeferralActive
+      ? new Promise<{ default: SurfaceImpl }>((resolve, reject) => {
+          scheduleIdle(() => load().then(resolve, reject));
+        })
+      : load());
   const Lazy = lazy(memoLoad);
   // Null fallback: every wave-1 surface either fills a flex/grid cell
   // (canvases, panels — the chrome around it doesn't move) or is an
@@ -43,8 +72,10 @@ export function lazySurface(
   );
   Wrapper.displayName = `LazySurface(${name})`;
   const surface = Wrapper as LazySurfaceComponent;
+  // preload always loads NOW: it runs from App's post-chrome-ready idle
+  // callback, after the boot latch has been released.
   surface.preload = () =>
-    memoLoad().then(
+    (loadPromise ??= load()).then(
       () => undefined,
       () => undefined,
     );

--- a/src/mainApp.tsx
+++ b/src/mainApp.tsx
@@ -4,11 +4,10 @@ import { invoke } from "@tauri-apps/api/core";
 import App from "./App.tsx";
 import NativeCanvasWindowApp from "./NativeCanvasWindowApp";
 import { prewarmHighlighter } from "./utils/highlight";
-// Side-effect import: registers Monaco's web-worker factories and binds
-// the @monaco-editor/react loader to the bundled monaco package so the
-// editor mounts work offline / under Tauri's CSP. Must run before any
-// component imports a Monaco-backed surface.
-import "./monaco/setup";
+// NOTE: monaco's bootstrap (worker factories + loader binding) moved to
+// the top of editor/canvas.tsx + diff-canvas.tsx — the chunks that
+// actually create models — so the multi-MB monaco graph stays out of
+// the boot bundle.
 // Style entry. Order matters: shape tokens first (theme-agnostic), then
 // theme color tokens, then chrome rules (consumes everything). Import
 // each file directly here instead of chaining through `@import` in a
@@ -33,10 +32,16 @@ if (import.meta.env.DEV) {
   ).__AETHON_INVOKE__ = invoke;
 }
 
-// Spawn the Shiki highlight worker eagerly so the first user-visible code
-// block doesn't pay the cold-start cost (Oniguruma WASM + theme parse).
-// Idempotent; safe to call here.
-prewarmHighlighter();
+// Spawn the Shiki highlight worker once the main thread goes idle — warm
+// before the first realistic user message without competing with first
+// paint for CPU (the worker boot parses Oniguruma WASM + themes).
+// Idempotent; HighlightedCode renders plain text until it resolves.
+// WebKit has no requestIdleCallback — feature-detect and fall back.
+const scheduleIdle: (cb: () => void) => void =
+  typeof requestIdleCallback === "function"
+    ? (cb) => requestIdleCallback(cb, { timeout: 3_000 })
+    : (cb) => setTimeout(cb, 1_500);
+scheduleIdle(() => prewarmHighlighter());
 
 const params = new URLSearchParams(window.location.search);
 const surface = params.get("surface");

--- a/src/monaco/editor-buffers.ts
+++ b/src/monaco/editor-buffers.ts
@@ -14,7 +14,11 @@
  * the Monaco model.
  */
 
-import * as monaco from "monaco-editor";
+// Types only — this module is imported by always-loaded tab-lifecycle
+// hooks (closeTab, project ops), so a runtime monaco import here would
+// drag the whole editor chunk into the boot bundle. The canvas owns the
+// runtime import and hands models in via `registerEditorBuffer`.
+import type * as monaco from "monaco-editor";
 
 /** An editor tab's in-memory state. The Monaco model is the source of
  *  truth for buffer content + undo stack; viewState carries scroll +
@@ -54,13 +58,13 @@ export function getEditorBuffer(tabId: string): EditorBuffer | undefined {
   return EDITOR_BUFFERS.get(tabId);
 }
 
-/** Create + cache a new buffer with an empty model for `tabId`. */
-export function createEditorBuffer(
+/** Cache a new buffer around a caller-created model for `tabId`. The
+ *  canvas creates the model (it already owns the monaco import). */
+export function registerEditorBuffer(
   tabId: string,
+  model: monaco.editor.ITextModel,
   filePath: string,
-  language: string,
 ): EditorBuffer {
-  const model = monaco.editor.createModel("", language);
   const buf: EditorBuffer = {
     model,
     viewState: null,

--- a/src/monaco/theme-registry.ts
+++ b/src/monaco/theme-registry.ts
@@ -1,0 +1,94 @@
+/**
+ * Monaco-free half of the Aethon Monaco theme system.
+ *
+ * `windowApi` (always loaded at boot) and extension registration paths
+ * import THIS module, so registering a Monaco theme never pulls the
+ * multi-megabyte monaco-editor chunk into the boot bundle. The applier
+ * half (`theme.ts`, which lives inside the editor chunk) binds itself
+ * here when that chunk loads and replays anything registered early.
+ *
+ * Before the applier binds, `applyMonacoThemeIfLoaded` is a no-op by
+ * design: no editor exists yet, and the editor canvas applies the
+ * active theme on its own mount.
+ */
+
+import type * as monacoTypes from "monaco-editor";
+
+export type MonacoThemeData = monacoTypes.editor.IStandaloneThemeData;
+
+/** Monaco theme id namespace shared with the applier. */
+const PREFIX = "aethon-";
+
+/** Default Aethon theme id for null/undefined input. Matches the
+ *  initial value of `:root[data-theme]` in `useBootConfig`. */
+const DEFAULT_ID = "ember";
+
+interface ThemeRecord {
+  data: MonacoThemeData;
+}
+
+/** Live registry. Built-ins are seeded by theme.ts (set-if-absent so a
+ *  user/extension override registered before the editor chunk loads is
+ *  never clobbered); overrides land here via `registerMonacoTheme`. */
+const REGISTRY = new Map<string, ThemeRecord>();
+
+export interface MonacoThemeApplier {
+  define(id: string, data: MonacoThemeData): void;
+  apply(themeId: string | undefined | null): void;
+}
+
+let applier: MonacoThemeApplier | null = null;
+
+/** Called by theme.ts at module load (i.e. when monaco exists). Replays
+ *  every record registered before the editor chunk loaded. */
+export function bindMonacoThemeApplier(next: MonacoThemeApplier): void {
+  applier = next;
+  for (const [id, record] of REGISTRY) {
+    next.define(id, record.data);
+  }
+}
+
+/** Stable Monaco theme id for an Aethon theme id. */
+export function monacoThemeFor(themeId: string | undefined | null): string {
+  return `${PREFIX}${themeId || DEFAULT_ID}`;
+}
+
+/** Register (or replace) a Monaco theme keyed under `aethon-<id>`.
+ *  Surface for `aethon.registerMonacoTheme(id, data)`. Takes effect in
+ *  Monaco immediately when the editor chunk is loaded; otherwise the
+ *  applier replays it on bind. */
+export function registerMonacoTheme(id: string, data: MonacoThemeData): void {
+  if (!id || typeof id !== "string") return;
+  if (!data || typeof data !== "object") return;
+  REGISTRY.set(id, { data });
+  applier?.define(id, data);
+}
+
+/** Seed a built-in without clobbering an earlier override. */
+export function seedMonacoTheme(id: string, data: MonacoThemeData): void {
+  if (REGISTRY.has(id)) return;
+  REGISTRY.set(id, { data });
+}
+
+export function getMonacoThemeRecord(id: string): ThemeRecord | undefined {
+  return REGISTRY.get(id);
+}
+
+export function registeredMonacoThemes(): ReadonlyMap<string, ThemeRecord> {
+  return REGISTRY;
+}
+
+/** Apply now if the editor chunk has loaded; no-op before that. */
+export function applyMonacoThemeIfLoaded(
+  themeId: string | undefined | null,
+): void {
+  applier?.apply(themeId);
+}
+
+/** Test-only: clear records (the applier binding survives — module
+ *  identity is process-wide under vitest too). */
+export const __testingRegistry = {
+  reset(): void {
+    REGISTRY.clear();
+  },
+};

--- a/src/monaco/theme.ts
+++ b/src/monaco/theme.ts
@@ -1,11 +1,14 @@
 /**
- * Aethon Monaco theme registry.
+ * Aethon Monaco theme applier — the monaco-owning half of the theme
+ * system. Loading THIS module means loading the monaco-editor chunk;
+ * boot-path code registers through `theme-registry.ts` instead and this
+ * module replays those registrations when it loads.
  *
  * Each Aethon CSS theme has a matching Monaco theme registered as
- * `aethon-<themeId>`. We register all four built-ins eagerly at boot
- * (pre-Monaco is fine — `defineTheme` is safe to call before any
- * editor exists) so the editor never has a window where it has to
- * fall back to vanilla `vs` / `vs-dark` and look out of place.
+ * `aethon-<themeId>`. Built-ins are seeded set-if-absent at module load
+ * (pre-Monaco is fine — `defineTheme` is safe to call before any editor
+ * exists) so the editor never has a window where it falls back to
+ * vanilla `vs` / `vs-dark` and looks out of place.
  *
  * Hard-coded rather than read from CSS vars on the fly: synthesising
  * from `getComputedStyle` introduced timing races on cold start
@@ -16,9 +19,9 @@
  *
  * Overrides: extensions can replace any registered theme via
  * `aethon.registerMonacoTheme(id, data)` (mounted on `window.aethon`
- * by `useWindowApi`). The runtime registry is consulted first on
- * every `applyMonacoTheme(id)` call so a registration takes effect
- * without a reload.
+ * by `useWindowApi`, backed by theme-registry). The registry is
+ * consulted on every `applyMonacoTheme(id)` call so a registration
+ * takes effect without a reload.
  */
 
 import { textmateThemeToMonacoTheme } from "@shikijs/monaco";
@@ -28,77 +31,52 @@ import {
   type AethonThemeId,
 } from "./aethon-themes";
 import { monaco } from "./setup";
+import {
+  __testingRegistry,
+  bindMonacoThemeApplier,
+  getMonacoThemeRecord,
+  monacoThemeFor,
+  registerMonacoTheme,
+  registeredMonacoThemes,
+  seedMonacoTheme,
+  type MonacoThemeData,
+} from "./theme-registry";
 
 /** Monaco theme id namespace used for the built-ins. */
 const PREFIX = "aethon-";
 
-interface ThemeRecord {
-  data: monaco.editor.IStandaloneThemeData;
-}
-
-/** Live registry. Built-ins are seeded by `ensureRegistered()`; user
- *  / extension overrides land here via `registerMonacoTheme`. */
-const REGISTRY = new Map<string, ThemeRecord>();
-let bootSeeded = false;
 let monacoDefined = false;
 
-/** Default Aethon theme id for null/undefined input. Matches the
- *  initial value of `:root[data-theme]` in `useBootConfig`. */
+/** Default Aethon theme id for null/undefined input. */
 const DEFAULT_ID = "ember";
 
 /** Theme definitions shared with Shiki. The Shiki bridge monkey-patches
  *  `monaco.editor.setTheme()` and only accepts loaded Shiki theme names,
  *  so the built-ins must be registered in both registries under the same
  *  `aethon-*` ids. */
-const BUILTIN_THEMES: Record<AethonThemeId, monaco.editor.IStandaloneThemeData> =
+const BUILTIN_THEMES: Record<AethonThemeId, MonacoThemeData> =
   Object.fromEntries(
     AETHON_SHIKI_THEMES.map((theme) => [
       theme.name.replace(PREFIX, ""),
       textmateThemeToMonacoTheme(theme),
     ]),
-  ) as Record<AethonThemeId, monaco.editor.IStandaloneThemeData>;
+  ) as Record<AethonThemeId, MonacoThemeData>;
 
 function seedBuiltins(): void {
-  if (bootSeeded) return;
   for (const [id, data] of Object.entries(BUILTIN_THEMES)) {
-    REGISTRY.set(id, { data });
+    seedMonacoTheme(id, data);
   }
-  bootSeeded = true;
 }
 
 function defineAllInMonaco(): void {
   if (monacoDefined) return;
   try {
-    for (const [id, record] of REGISTRY) {
-      monaco.editor.defineTheme(`${PREFIX}${id}`, record.data);
+    for (const [id, record] of registeredMonacoThemes()) {
+      monaco.editor.defineTheme(monacoThemeFor(id), record.data);
     }
     monacoDefined = true;
   } catch {
     // Monaco not ready yet — the next call will retry.
-  }
-}
-
-/** Stable Monaco theme id for an Aethon theme. Used by callers that
- *  want to reference the theme without going through setTheme. */
-export function monacoThemeFor(themeId: string | undefined | null): string {
-  return `${PREFIX}${themeId || DEFAULT_ID}`;
-}
-
-/** Register (or replace) a Monaco theme keyed under `aethon-<id>`.
- *  Surface for `aethon.registerMonacoTheme(id, data)` so extensions
- *  can supply their own Monaco palette in one call. The new
- *  data takes effect immediately if `id` is the active theme. */
-export function registerMonacoTheme(
-  id: string,
-  data: monaco.editor.IStandaloneThemeData,
-): void {
-  if (!id || typeof id !== "string") return;
-  if (!data || typeof data !== "object") return;
-  REGISTRY.set(id, { data });
-  try {
-    monaco.editor.defineTheme(`${PREFIX}${id}`, data);
-  } catch {
-    // Monaco not ready — applyMonacoTheme retries on the next set.
   }
 }
 
@@ -110,16 +88,16 @@ export function applyMonacoTheme(themeId: string | undefined | null): void {
   // If this id was overridden after the initial seed, re-define it so
   // Monaco's registry has the fresh data. Cheap; defineTheme is just a
   // map write inside Monaco.
-  const record = REGISTRY.get(id);
+  const record = getMonacoThemeRecord(id);
   if (record) {
     try {
-      monaco.editor.defineTheme(`${PREFIX}${id}`, record.data);
+      monaco.editor.defineTheme(monacoThemeFor(id), record.data);
     } catch {
       /* not ready — fall through to setTheme */
     }
   }
   try {
-    monaco.editor.setTheme(`${PREFIX}${id}`);
+    monaco.editor.setTheme(monacoThemeFor(id));
   } catch {
     // Should never happen post-define, but if it does, drop to
     // built-ins so the editor still paints something useful.
@@ -141,11 +119,33 @@ export function syncMonacoThemeFromDom(): void {
   applyMonacoTheme(id);
 }
 
-/** Test-only: reset registry + seed flag so each case starts clean. */
+// Seed built-ins (set-if-absent — never clobber an override registered
+// before this chunk loaded), then bind the registry's applier so
+// registrations made from here on define into Monaco immediately, and
+// early registrations replay now.
+seedBuiltins();
+bindMonacoThemeApplier({
+  define(id, data) {
+    try {
+      monaco.editor.defineTheme(monacoThemeFor(id), data);
+    } catch {
+      // Monaco not ready — applyMonacoTheme retries on the next set.
+    }
+  },
+  apply(themeId) {
+    applyMonacoTheme(themeId);
+  },
+});
+
+// Back-compat surface: consumers inside the editor chunk keep importing
+// from here; boot-path consumers import theme-registry directly.
+export { monacoThemeFor, registerMonacoTheme };
+
+/** Test-only: reset registry + seed state so each case starts clean. */
 export const __testing = {
   reset(): void {
-    REGISTRY.clear();
-    bootSeeded = false;
+    __testingRegistry.reset();
     monacoDefined = false;
+    seedBuiltins();
   },
 };

--- a/src/runtime/windowApi.ts
+++ b/src/runtime/windowApi.ts
@@ -20,10 +20,13 @@ import {
   type ProjectsState,
 } from "../projects";
 import { registerGrammar as registerHighlightGrammar } from "../utils/highlight";
+// theme-registry, NOT theme: registering a Monaco theme from the boot
+// path must not pull the monaco-editor chunk. The registry replays
+// registrations when the editor chunk loads.
 import {
   registerMonacoTheme as registerMonacoThemeImpl,
-  applyMonacoTheme,
-} from "../monaco/theme";
+  applyMonacoThemeIfLoaded,
+} from "../monaco/theme-registry";
 import { registerFileViewer as registerFileViewerImpl } from "../extensions/default-layout/editor";
 import type * as monaco from "monaco-editor";
 import { askUserWithChat, type AskUserInput } from "../questions";
@@ -201,7 +204,7 @@ export function useWindowApi(ctx: UseWindowApiContext): void {
           document.documentElement.dataset.theme ??
           "";
         if (active === id.trim()) {
-          applyMonacoTheme(active);
+          applyMonacoThemeIfLoaded(active);
         }
         return true;
       },

--- a/src/runtime/windowApi.ts
+++ b/src/runtime/windowApi.ts
@@ -27,7 +27,9 @@ import {
   registerMonacoTheme as registerMonacoThemeImpl,
   applyMonacoThemeIfLoaded,
 } from "../monaco/theme-registry";
-import { registerFileViewer as registerFileViewerImpl } from "../extensions/default-layout/editor";
+// file-viewers directly, NOT the ./editor barrel — the barrel's canvas
+// re-exports carry the monaco bootstrap side effect.
+import { registerFileViewer as registerFileViewerImpl } from "../extensions/default-layout/editor/file-viewers";
 import type * as monaco from "monaco-editor";
 import { askUserWithChat, type AskUserInput } from "../questions";
 


### PR DESCRIPTION
## Summary

C1+C2 of the desktop-bundle workstream. The boot bundle previously parsed ~5.7 MB of main-thread JS (monaco + xterm + shiki glue all eagerly imported) and spawned the 3.8 MB Shiki highlight worker before first paint.

**C1 — sever the eager monaco edges:**
- `mainApp.tsx` no longer side-effect-imports `monaco/setup`; the bootstrap (worker factories, loader binding, language registration) runs at the top of `editor/canvas.tsx` + `diff-canvas.tsx` — the chunks that create models — preserving the run-before-first-mount invariant by module-eval order.
- `editor-buffers.ts` imports monaco as **types only**; `createEditorBuffer` → `registerEditorBuffer(tabId, model, filePath)` with the canvas creating the model. The four always-loaded tab-lifecycle hooks that call `disposeEditorBuffer` no longer reach monaco at runtime.
- `monaco/theme.ts` split: new monaco-free `theme-registry.ts` owns the record map; `windowApi` registers through it (`applyMonacoThemeIfLoaded` is a no-op until the editor chunk binds its applier and replays early registrations). Built-ins seed set-if-absent so an extension override registered pre-editor is never clobbered.
- `prewarmHighlighter` defers to idle (rIC + setTimeout fallback for WebKit).

**C2 — lazy registration at the ExtensionRegistry seam:**
- `lazySurface()` registers a `React.lazy` wrapper with Suspense INSIDE the component — the A2UI renderer stays synchronous, `aethon.registerComponent` overrides and bridge templates keep winning, zero call-site changes.
- Lazy wave 1 (14 surfaces): editor/diff canvases, image viewer, markdown preview, shell canvas, terminal(+panel), settings, search, palette, auth profiles, scheduled tasks, source control, subagents config. Each loads its DIRECT source module (a light surface never rides in a heavy chunk); eager surfaces bypass the `./components` barrel whose side effects would drag the heavy chunks back.
- App preloads every lazy chunk on the first idle after chrome-ready, so first-open latency stays ~zero.

## Measured

| Metric | Before | After |
|---|---|---|
| `mainApp` chunk | 2,196 KB | **844 KB** |
| monaco (3.5 MB) in eager graph | yes | **no** (lazy chunk) |
| xterm / @shikijs/monaco eager | yes | **no** |
| highlight.worker spawned at boot | yes | idle-deferred |

## Test plan
- [x] Full `check` green (3126 tests), including all monaco/editor/theme suites
- [x] Static-import audit of the built entry chunk: no `editor.api`/xterm references
- [x] e2e (CI) — chat surfaces stay eager; no test opens a lazy surface before Suspense resolves (Playwright auto-waits regardless)