### PR TITLE
perf(mobile): self-hosted fonts, invoke pacing + rate-limit retry, watcher stubs, boot trimming

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -38,6 +38,11 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@fontsource/geist-mono": "^5.2.8",
+        "@fontsource/geist-sans": "^5.2.5",
+        "@fontsource/inter": "^5.2.8",
+        "@fontsource/jetbrains-mono": "^5.2.8",
+        "@fontsource/playfair-display": "^5.2.8",
         "@playwright/test": "^1.60.0",
         "@tauri-apps/cli": "^2.11.0",
         "@testing-library/dom": "^10.4.1",
@@ -227,6 +232,16 @@
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.7.1", "", { "dependencies": { "@eslint/core": "^1.2.1", "levn": "^0.4.1" } }, "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ=="],
 
     "@exodus/bytes": ["@exodus/bytes@1.15.0", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ=="],
+
+    "@fontsource/geist-mono": ["@fontsource/geist-mono@5.2.8", "", {}, "sha512-YqZUb3X42GjRaHkibUNyE8K4Rk9A6I9Ez81YpJYiuJN4ggmTW2ixoQpa9EWCPfXZtIsCQJTyrDoV9OJOZO/UcA=="],
+
+    "@fontsource/geist-sans": ["@fontsource/geist-sans@5.2.5", "", {}, "sha512-anllOHyJbElRs9fV15TeDRqAeb1IKm4bSknPl6ZMoyPTx1BBy7logudcUwpNjmQLkzn4Q0JGQLRCUKJYoyST6A=="],
+
+    "@fontsource/inter": ["@fontsource/inter@5.2.8", "", {}, "sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg=="],
+
+    "@fontsource/jetbrains-mono": ["@fontsource/jetbrains-mono@5.2.8", "", {}, "sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ=="],
+
+    "@fontsource/playfair-display": ["@fontsource/playfair-display@5.2.8", "", {}, "sha512-fUEhib70SszNhQVsGbUMSsWJhr7Je0rdeuZdtGpDNu0GKF1xJM8QhpI/y0pckU25GcChXm9TLOmeZupkvvZo2g=="],
 
     "@google/genai": ["@google/genai@1.50.1", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-YbkX7H9+1Pt8wOt7DDREy8XSoiL6fRDzZQRyaVBarFf8MR3zHGqVdvM4cLbDXqPhxqvegZShgfxb8kw9C7YhAQ=="],
 

--- a/index.html
+++ b/index.html
@@ -4,12 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Aethon</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500;600;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&family=Playfair+Display:ital,wght@0,600;0,700;1,700&display=swap"
-      rel="stylesheet"
-    />
+    <!-- Fonts are self-hosted via @fontsource (src/styles/fonts.ts) —
+         no render-blocking external stylesheet on the first-paint path. -->
   </head>
   <body>
     <div id="root"></div>

--- a/index.mobile.html
+++ b/index.mobile.html
@@ -12,12 +12,9 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <title>Aethon</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500;600;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap"
-      rel="stylesheet"
-    />
+    <!-- Fonts are self-hosted via @fontsource (src/styles/fonts.ts) —
+         the phone frequently launches with no route to Google Fonts,
+         and this stylesheet render-blocked first paint. -->
   </head>
   <body>
     <div id="root"></div>

--- a/package.json
+++ b/package.json
@@ -57,6 +57,11 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@fontsource/geist-mono": "^5.2.8",
+    "@fontsource/geist-sans": "^5.2.5",
+    "@fontsource/inter": "^5.2.8",
+    "@fontsource/jetbrains-mono": "^5.2.8",
+    "@fontsource/playfair-display": "^5.2.8",
     "@playwright/test": "^1.60.0",
     "@tauri-apps/cli": "^2.11.0",
     "@testing-library/dom": "^10.4.1",

--- a/src-tauri/src/agent_process/mod.rs
+++ b/src-tauri/src/agent_process/mod.rs
@@ -30,7 +30,8 @@ mod sweep;
 
 pub(crate) use process::{
     AgentProcesses, AgentWorker, GLOBAL_AGENT_KEY, WorkerMeta, cleanup_orphaned_dev_agents,
-    ensure_global_agent, keys_to_reconcile, lock_recover, prompt_wedged, retire_agent_key,
+    ensure_global_agent, ensure_global_agent_prespawn, keys_to_reconcile, lock_recover,
+    prompt_wedged, retire_agent_key,
     route_payload_key, shutdown_all_agents, tab_agent_key, write_agent_payload,
 };
 pub(crate) use sidecar::project_root;

--- a/src-tauri/src/agent_process/process.rs
+++ b/src-tauri/src/agent_process/process.rs
@@ -319,7 +319,14 @@ pub(crate) async fn write_agent_payload(
     for _attempt in 0..2 {
         let child = {
             let mut guard = lock_recover(&state.children, "agent children (write)");
-            ensure_agent_spawned(&mut guard, &key, app, state.spawn_shared(), worker.as_ref())?;
+            ensure_agent_spawned(
+                &mut guard,
+                &key,
+                app,
+                state.spawn_shared(),
+                worker.as_ref(),
+                true,
+            )?;
             guard.get(&key).cloned().ok_or("agent not running")?
         };
 
@@ -375,6 +382,25 @@ pub(crate) fn ensure_global_agent(
     state: &State<'_, AgentProcesses>,
     app: &AppHandle,
 ) -> Result<(), String> {
+    ensure_global_agent_with_handshake(state, app, true)
+}
+
+/// Boot pre-spawn variant: no synthetic report. The frontend hasn't
+/// mounted its listener yet; its real mount-time `report` performs the
+/// handshake, keeping pre-handshake extension mutations on the
+/// retained-state path instead of the ack-timeout path.
+pub(crate) fn ensure_global_agent_prespawn(
+    state: &State<'_, AgentProcesses>,
+    app: &AppHandle,
+) -> Result<(), String> {
+    ensure_global_agent_with_handshake(state, app, false)
+}
+
+fn ensure_global_agent_with_handshake(
+    state: &State<'_, AgentProcesses>,
+    app: &AppHandle,
+    inject_handshake: bool,
+) -> Result<(), String> {
     let mut guard = lock_recover(&state.children, "agent children (ensure global)");
     ensure_agent_spawned(
         &mut guard,
@@ -382,6 +408,7 @@ pub(crate) fn ensure_global_agent(
         app,
         state.spawn_shared(),
         None,
+        inject_handshake,
     )
 }
 

--- a/src-tauri/src/agent_process/spawn.rs
+++ b/src-tauri/src/agent_process/spawn.rs
@@ -45,6 +45,7 @@ pub(super) fn ensure_agent_spawned(
     app: &AppHandle,
     shared: SpawnShared,
     worker: Option<&AgentWorker>,
+    inject_handshake: bool,
 ) -> Result<(), String> {
     let SpawnShared {
         mutation_routes,
@@ -162,7 +163,13 @@ pub(super) fn ensure_agent_spawned(
     // against a 5s timeout. Synthesise the handshake here so every
     // bridge — global and per-tab — comes up ready. Metadata is registered
     // first so any immediate stdout readiness marker can be recorded.
-    if let Some(stdin) = child.stdin.as_mut()
+    // The boot pre-spawn skips the synthetic report: no JS listener
+    // exists yet, and flipping the bridge's frontendReady early would
+    // route pre-handshake extension mutations onto the 5s-ack path
+    // instead of the retained-state path. React's mount-time report
+    // performs the real handshake.
+    if inject_handshake
+        && let Some(stdin) = child.stdin.as_mut()
         && let Err(e) = inject_initial_handshake(stdin)
     {
         tracing::warn!(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -496,7 +496,7 @@ pub fn run() {
                 tauri::async_runtime::spawn_blocking(move || {
                     let state = handle.state::<agent_process::AgentProcesses>();
                     let started = std::time::Instant::now();
-                    match agent_process::ensure_global_agent(&state, &handle) {
+                    match agent_process::ensure_global_agent_prespawn(&state, &handle) {
                         Ok(()) => tracing::info!(
                             target: "aethon::boot",
                             elapsed_ms = started.elapsed().as_millis() as u64,

--- a/src/gateway/commandPolicy.test.ts
+++ b/src/gateway/commandPolicy.test.ts
@@ -29,6 +29,11 @@ describe("mobile command policy", () => {
       "fs_watch_dirs",
       "fs_open_in_default_app",
       "git_watch_root",
+      "git_unwatch_root",
+      // Extension hot-reload watchers: desktop-local; forwarding them
+      // was a guaranteed policy Deny per project announcement at boot.
+      "watch_project_extensions",
+      "unwatch_project_extensions",
       "updater_available",
       "write_state",
       "toggle_devtools",
@@ -86,6 +91,10 @@ describe("mobile command policy", () => {
   it("gives updater_available a falsey stub and unknown stubs null", () => {
     expect(stubResult("updater_available")).toBe(false);
     expect(stubResult("native_window_list")).toBeNull();
+    // Fire-and-forget watcher stubs resolve null — matching the desktop
+    // command's Result<(), _> shape closely enough for their callers.
+    expect(stubResult("watch_project_extensions")).toBeNull();
+    expect(stubResult("unwatch_project_extensions")).toBeNull();
   });
 
   it("does not stub fs reads (they belong to the gateway)", () => {

--- a/src/gateway/commandPolicy.ts
+++ b/src/gateway/commandPolicy.ts
@@ -71,6 +71,12 @@ const STUB_EXACT = new Set<string>([
   // companion's issue-dispatch / new-workspace flows work end-to-end.
   "git_watch_root",
   "git_unwatch_root",
+  // Extension hot-reload watchers are equally desktop-local; the
+  // desktop's own webview already watches these. Forwarding them just
+  // burned two guaranteed-Deny round-trips (and rate-limit slots) per
+  // project announcement at boot.
+  "watch_project_extensions",
+  "unwatch_project_extensions",
   // Gateway-admin + control-plane: never driven from the phone.
   "server_status",
   "server_start",

--- a/src/gateway/transport.test.ts
+++ b/src/gateway/transport.test.ts
@@ -393,4 +393,28 @@ describe("invoke rate pacing + rate-limited retry", () => {
     expect(t.getStatus()).toBe("connected");
     expect(sentInvokes(socket)).toHaveLength(32);
   });
+
+  it("drops a request that timed out while queued — never sends it late", async () => {
+    vi.useFakeTimers();
+    const socket = new FakeSocket();
+    const t = await connectTransport(socket);
+
+    // Fill the budget, then queue one more with a short timeout.
+    for (let i = 0; i < 32; i++) {
+      void t.request(`filler_${i}`).catch(() => {});
+    }
+    const late = t.request("send_message", {}, { timeoutMs: 200 });
+    const lateOutcome = expect(late).rejects.toThrow("timed out");
+    expect(sentInvokes(socket)).toHaveLength(32);
+
+    // The timeout fires while the frame is still queued...
+    await vi.advanceTimersByTimeAsync(250);
+    await lateOutcome;
+    // ...so the drain at window end must NOT deliver it: a
+    // non-idempotent command can't execute after its caller failed.
+    await vi.advanceTimersByTimeAsync(1_000);
+    const cmds = sentInvokes(socket).map((f) => f.cmd);
+    expect(cmds).toHaveLength(32);
+    expect(cmds).not.toContain("send_message");
+  });
 });

--- a/src/gateway/transport.test.ts
+++ b/src/gateway/transport.test.ts
@@ -266,3 +266,131 @@ describe("gateway transport", () => {
     expect(socket.opened).toBe(1); // never retried
   });
 });
+
+describe("invoke rate pacing + rate-limited retry", () => {
+  async function connectTransport(
+    socket: FakeSocket,
+  ): Promise<GatewayTransport> {
+    const t = makeTransport(socket);
+    const connected = t.connect();
+    await Promise.resolve();
+    socket.helloOk();
+    await connected;
+    return t;
+  }
+
+  function sentInvokes(socket: FakeSocket): Array<{ id: string; cmd: string }> {
+    return socket.sent
+      .map((s) => JSON.parse(s) as { t: string; id: string; cmd: string })
+      .filter((f) => f.t === "invoke");
+  }
+
+  beforeEach(() => {
+    setJitterSource(() => 0.2);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("paces a burst to the client budget and drains FIFO", async () => {
+    vi.useFakeTimers();
+    const socket = new FakeSocket();
+    const t = await connectTransport(socket);
+
+    for (let i = 0; i < 50; i++) {
+      void t.request(`cmd_${i}`).catch(() => {});
+    }
+    const immediate = sentInvokes(socket);
+    expect(immediate).toHaveLength(32);
+    expect(immediate[0].cmd).toBe("cmd_0");
+    expect(immediate[31].cmd).toBe("cmd_31");
+
+    // The rest drain once the rolling window frees up, still in order.
+    await vi.advanceTimersByTimeAsync(1_100);
+    const all = sentInvokes(socket);
+    expect(all).toHaveLength(50);
+    expect(all[49].cmd).toBe("cmd_49");
+  });
+
+  it("re-sends the same frame after a rate-limited result and resolves on success", async () => {
+    vi.useFakeTimers();
+    const socket = new FakeSocket();
+    const t = await connectTransport(socket);
+
+    const p = t.request("git_status", { root: "/r" });
+    const id = socket.lastSentInvokeId(0);
+    socket.serverSend({
+      t: "result",
+      id,
+      ok: false,
+      error: "rate limited: too many requests, retry shortly",
+    });
+    await vi.advanceTimersByTimeAsync(260);
+
+    const invokes = sentInvokes(socket);
+    expect(invokes).toHaveLength(2);
+    // Same id — the server rejected before executing, so a re-send is
+    // a fresh attempt, not a duplicate.
+    expect(invokes[1].id).toBe(id);
+    expect(invokes[1].cmd).toBe("git_status");
+
+    socket.serverSend({ t: "result", id, ok: true, data: { branch: "main" } });
+    await expect(p).resolves.toEqual({ branch: "main" });
+  });
+
+  it("gives up after exhausting rate-limit retries", async () => {
+    vi.useFakeTimers();
+    const socket = new FakeSocket();
+    const t = await connectTransport(socket);
+
+    const p = t.request("git_status");
+    const settled = p.catch((err: Error) => err);
+    const id = socket.lastSentInvokeId(0);
+    for (const advance of [260, 520, 780]) {
+      socket.serverSend({ t: "result", id, ok: false, error: "rate limited: x" });
+      await vi.advanceTimersByTimeAsync(advance);
+    }
+    expect(sentInvokes(socket)).toHaveLength(4);
+    // Fourth rejection: attempts exhausted — surfaces the error.
+    socket.serverSend({ t: "result", id, ok: false, error: "rate limited: x" });
+    const err = await settled;
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toContain("rate limited");
+  });
+
+  it("non-rate-limit errors reject immediately without a re-send", async () => {
+    const socket = new FakeSocket();
+    const t = await connectTransport(socket);
+
+    const p = t.request("git_status");
+    const id = socket.lastSentInvokeId(0);
+    socket.serverSend({ t: "result", id, ok: false, error: "boom" });
+    await expect(p).rejects.toThrow("boom");
+    expect(sentInvokes(socket)).toHaveLength(1);
+  });
+
+  it("clears the queue on close: nothing leaks into the next connection", async () => {
+    vi.useFakeTimers();
+    const socket = new FakeSocket();
+    const t = await connectTransport(socket);
+
+    const outcomes: Array<Promise<unknown>> = [];
+    for (let i = 0; i < 40; i++) {
+      outcomes.push(t.request(`cmd_${i}`).catch((err: Error) => err.message));
+    }
+    expect(sentInvokes(socket)).toHaveLength(32);
+
+    // Connection drops with 8 frames still queued.
+    socket.close();
+    for (const outcome of outcomes.slice(32)) {
+      await expect(outcome).resolves.toBe("gateway connection closed");
+    }
+
+    // Reconnect (same adapter instance). The queued frames must NOT be
+    // replayed into the fresh socket.
+    await vi.advanceTimersByTimeAsync(2_000);
+    socket.helloOk();
+    expect(t.getStatus()).toBe("connected");
+    expect(sentInvokes(socket)).toHaveLength(32);
+  });
+});

--- a/src/gateway/transport.ts
+++ b/src/gateway/transport.ts
@@ -55,6 +55,10 @@ interface Pending {
   resolve: (value: unknown) => void;
   reject: (err: Error) => void;
   timer: ReturnType<typeof setTimeout>;
+  /** Serialized invoke frame, kept for rate-limited re-sends. */
+  frame: string;
+  /** Rate-limited re-send count so far. */
+  attempts: number;
 }
 
 type EventHandler = (payload: unknown) => void;
@@ -63,6 +67,18 @@ type StatusListener = (status: GatewayStatus) => void;
 const DEFAULT_TIMEOUT_MS = 30_000;
 const BACKOFF_MIN_MS = 500;
 const BACKOFF_MAX_MS = 30_000;
+/** Client-side invoke budget per rolling second. Deliberate headroom
+ *  under the server's 40/s fixed window (`allow_invoke` in ws.rs) —
+ *  the two windows don't align, so 32 absorbs the phase offset. Boot
+ *  fires a burst of invokes well past 40; without pacing the excess
+ *  came back "rate limited" and startup data was silently dropped. */
+const CLIENT_RATE_MAX = 32;
+const CLIENT_RATE_WINDOW_MS = 1_000;
+/** Rate-limited retry: the server rejects BEFORE `relay.invoke` runs,
+ *  so the command never executed and a same-id re-send is safe — even
+ *  for non-idempotent commands like send_message. */
+const RATE_RETRY_BASE_MS = 250;
+const RATE_RETRY_MAX_ATTEMPTS = 3;
 /** How long a connection must survive before the reconnect backoff
  *  resets. Resetting on hello_ok alone let a server-side slow-consumer
  *  kick loop reconnect at the minimum delay forever (connect → kicked
@@ -98,6 +114,16 @@ export class GatewayTransport {
    *  half-open or half-dead socket can't double-deliver events or kill
    *  a fresh connection with its own close. */
   private generation = 0;
+  /** FIFO of invoke frames awaiting a rate-budget slot. Only the
+   *  physical send is paced — `request()` semantics (fail fast when
+   *  offline, timeout from call time) are unchanged. sub/unsub/hello
+   *  frames bypass the queue; only invoke frames are rate-limited
+   *  server-side. */
+  private sendQueue: string[] = [];
+  /** Send timestamps inside the rolling rate window. */
+  private sentAt: number[] = [];
+  private drainTimer: ReturnType<typeof setTimeout> | null = null;
+  private retryTimers = new Set<ReturnType<typeof setTimeout>>();
 
   configure(config: GatewayConfig): void {
     this.config = config;
@@ -144,6 +170,8 @@ export class GatewayTransport {
       clearTimeout(this.stableTimer);
       this.stableTimer = null;
     }
+    // Deterministic even when the adapter's close event is async.
+    this.clearRatePacing();
     // Reject an in-flight connect() so its awaiter doesn't hang forever,
     // and so a later reconnect can't resolve this abandoned attempt.
     if (this.helloReject) {
@@ -170,13 +198,65 @@ export class GatewayTransport {
         this.pending.delete(id);
         reject(new Error(`gateway request timed out: ${cmd}`));
       }, timeoutMs);
+      const frame = JSON.stringify({ t: "invoke", id, cmd, args });
       this.pending.set(id, {
         resolve: resolve as (v: unknown) => void,
         reject,
         timer,
+        frame,
+        attempts: 0,
       });
-      this.adapter?.send(JSON.stringify({ t: "invoke", id, cmd, args }));
+      this.enqueueInvoke(frame);
     });
+  }
+
+  /** Send an invoke frame through the client-side rate budget: send
+   *  immediately when under budget (the common case — zero added
+   *  latency), otherwise queue FIFO and drain when the window frees. */
+  private enqueueInvoke(frame: string): void {
+    this.sendQueue.push(frame);
+    this.drainSendQueue();
+  }
+
+  private drainSendQueue(): void {
+    if (this.status !== "connected" || !this.adapter) return;
+    const now = Date.now();
+    while (
+      this.sentAt.length > 0 &&
+      this.sentAt[0] <= now - CLIENT_RATE_WINDOW_MS
+    ) {
+      this.sentAt.shift();
+    }
+    while (this.sendQueue.length > 0 && this.sentAt.length < CLIENT_RATE_MAX) {
+      const frame = this.sendQueue.shift();
+      if (frame === undefined) break;
+      this.sentAt.push(now);
+      this.adapter.send(frame);
+    }
+    if (this.sendQueue.length > 0 && this.drainTimer === null) {
+      const wait = Math.max(
+        this.sentAt[0] + CLIENT_RATE_WINDOW_MS - now,
+        10,
+      );
+      this.drainTimer = setTimeout(() => {
+        this.drainTimer = null;
+        this.drainSendQueue();
+      }, wait);
+    }
+  }
+
+  /** Drop all rate-pacing state. Runs on every close/disconnect so a
+   *  stale drain or retry timer can never write into a superseded
+   *  socket (the zombie-socket class of bug). */
+  private clearRatePacing(): void {
+    this.sendQueue.length = 0;
+    this.sentAt.length = 0;
+    if (this.drainTimer !== null) {
+      clearTimeout(this.drainTimer);
+      this.drainTimer = null;
+    }
+    for (const timer of this.retryTimers) clearTimeout(timer);
+    this.retryTimers.clear();
   }
 
   subscribe(topic: string, handler: EventHandler): () => void {
@@ -275,6 +355,25 @@ export class GatewayTransport {
         const id = frame.id as string;
         const entry = this.pending.get(id);
         if (!entry) break;
+        if (!frame.ok) {
+          const message = String(frame.error ?? "invoke failed");
+          if (
+            message.startsWith("rate limited") &&
+            entry.attempts < RATE_RETRY_MAX_ATTEMPTS
+          ) {
+            // The server rejected BEFORE executing — re-send the same
+            // frame (same id; the server doesn't track ids) after a
+            // short backoff. The request's own timeout keeps running
+            // as the overall cap; close rejects it like any pending.
+            entry.attempts += 1;
+            const timer = setTimeout(() => {
+              this.retryTimers.delete(timer);
+              if (this.pending.has(id)) this.enqueueInvoke(entry.frame);
+            }, RATE_RETRY_BASE_MS * entry.attempts);
+            this.retryTimers.add(timer);
+            break;
+          }
+        }
         this.pending.delete(id);
         clearTimeout(entry.timer);
         if (frame.ok) entry.resolve(frame.data);
@@ -307,6 +406,7 @@ export class GatewayTransport {
       clearTimeout(this.stableTimer);
       this.stableTimer = null;
     }
+    this.clearRatePacing();
     for (const entry of this.pending.values()) {
       clearTimeout(entry.timer);
       entry.reject(new Error("gateway connection closed"));

--- a/src/gateway/transport.ts
+++ b/src/gateway/transport.ts
@@ -118,8 +118,10 @@ export class GatewayTransport {
    *  physical send is paced — `request()` semantics (fail fast when
    *  offline, timeout from call time) are unchanged. sub/unsub/hello
    *  frames bypass the queue; only invoke frames are rate-limited
-   *  server-side. */
-  private sendQueue: string[] = [];
+   *  server-side. Entries carry their id so a request that timed out
+   *  while queued is dropped at drain time instead of executing after
+   *  its caller already saw the failure. */
+  private sendQueue: Array<{ id: string; frame: string }> = [];
   /** Send timestamps inside the rolling rate window. */
   private sentAt: number[] = [];
   private drainTimer: ReturnType<typeof setTimeout> | null = null;
@@ -206,15 +208,15 @@ export class GatewayTransport {
         frame,
         attempts: 0,
       });
-      this.enqueueInvoke(frame);
+      this.enqueueInvoke(id, frame);
     });
   }
 
   /** Send an invoke frame through the client-side rate budget: send
    *  immediately when under budget (the common case — zero added
    *  latency), otherwise queue FIFO and drain when the window frees. */
-  private enqueueInvoke(frame: string): void {
-    this.sendQueue.push(frame);
+  private enqueueInvoke(id: string, frame: string): void {
+    this.sendQueue.push({ id, frame });
     this.drainSendQueue();
   }
 
@@ -228,10 +230,14 @@ export class GatewayTransport {
       this.sentAt.shift();
     }
     while (this.sendQueue.length > 0 && this.sentAt.length < CLIENT_RATE_MAX) {
-      const frame = this.sendQueue.shift();
-      if (frame === undefined) break;
+      const next = this.sendQueue.shift();
+      if (next === undefined) break;
+      // Timed out (or rejected at close) while queued — never send:
+      // a non-idempotent command must not execute after its caller
+      // already received the failure.
+      if (!this.pending.has(next.id)) continue;
       this.sentAt.push(now);
-      this.adapter.send(frame);
+      this.adapter.send(next.frame);
     }
     if (this.sendQueue.length > 0 && this.drainTimer === null) {
       const wait = Math.max(
@@ -368,7 +374,7 @@ export class GatewayTransport {
             entry.attempts += 1;
             const timer = setTimeout(() => {
               this.retryTimers.delete(timer);
-              if (this.pending.has(id)) this.enqueueInvoke(entry.frame);
+              if (this.pending.has(id)) this.enqueueInvoke(id, entry.frame);
             }, RATE_RETRY_BASE_MS * entry.attempts);
             this.retryTimers.add(timer);
             break;

--- a/src/hooks/mobileBootDefer.test.ts
+++ b/src/hooks/mobileBootDefer.test.ts
@@ -42,3 +42,21 @@ describe("scheduleAfterMobileBootWindow", () => {
     expect(fn).not.toHaveBeenCalled();
   });
 });
+
+describe("mobileBootWindowElapsed", () => {
+  it("is always true on desktop", async () => {
+    const { mobileBootWindowElapsed } = await import("./mobileBootDefer");
+    expect(mobileBootWindowElapsed()).toBe(true);
+  });
+
+  it("flips false -> true across the window on mobile", async () => {
+    vi.stubEnv("VITE_AETHON_SURFACE", "mobile");
+    vi.useFakeTimers();
+    const { mobileBootWindowElapsed, resetMobileBootWindowForTest } =
+      await import("./mobileBootDefer");
+    resetMobileBootWindowForTest();
+    expect(mobileBootWindowElapsed()).toBe(false);
+    vi.advanceTimersByTime(MOBILE_BOOT_DEFER_MS + 1);
+    expect(mobileBootWindowElapsed()).toBe(true);
+  });
+});

--- a/src/hooks/mobileBootDefer.test.ts
+++ b/src/hooks/mobileBootDefer.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  MOBILE_BOOT_DEFER_MS,
+  isMobileSurface,
+  scheduleAfterMobileBootWindow,
+} from "./mobileBootDefer";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.useRealTimers();
+});
+
+describe("scheduleAfterMobileBootWindow", () => {
+  it("runs immediately on the desktop surface", () => {
+    const fn = vi.fn();
+    const cancel = scheduleAfterMobileBootWindow(fn);
+    expect(fn).toHaveBeenCalledTimes(1);
+    cancel(); // no-op — must not throw
+  });
+
+  it("defers past the boot window on mobile", () => {
+    vi.stubEnv("VITE_AETHON_SURFACE", "mobile");
+    vi.useFakeTimers();
+    expect(isMobileSurface()).toBe(true);
+    const fn = vi.fn();
+    scheduleAfterMobileBootWindow(fn);
+    expect(fn).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(MOBILE_BOOT_DEFER_MS - 1);
+    expect(fn).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancel prevents a deferred run (unmount before the window)", () => {
+    vi.stubEnv("VITE_AETHON_SURFACE", "mobile");
+    vi.useFakeTimers();
+    const fn = vi.fn();
+    const cancel = scheduleAfterMobileBootWindow(fn);
+    cancel();
+    vi.advanceTimersByTime(MOBILE_BOOT_DEFER_MS * 2);
+    expect(fn).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/mobileBootDefer.ts
+++ b/src/hooks/mobileBootDefer.ts
@@ -16,6 +16,21 @@ export function isMobileSurface(): boolean {
   return import.meta.env.VITE_AETHON_SURFACE === "mobile";
 }
 
+let bootStartedAt = Date.now();
+
+/** True once the mobile boot window has passed (always true on the
+ *  desktop surface). Effects that re-fire during hydration use this so
+ *  a re-run can't sneak past a first-run-only deferral. */
+export function mobileBootWindowElapsed(): boolean {
+  if (!isMobileSurface()) return true;
+  return Date.now() - bootStartedAt > MOBILE_BOOT_DEFER_MS;
+}
+
+/** Test-only: restart the boot window. */
+export function resetMobileBootWindowForTest(): void {
+  bootStartedAt = Date.now();
+}
+
 /** Run `fn` immediately on desktop; on the mobile companion, delay it
  *  past the boot window. Returns a cancel function (no-op on desktop —
  *  `fn` already ran). */

--- a/src/hooks/mobileBootDefer.ts
+++ b/src/hooks/mobileBootDefer.ts
@@ -1,0 +1,29 @@
+/**
+ * Mobile-surface boot deferral.
+ *
+ * The companion reuses the desktop hooks, whose mount effects were
+ * written for in-process IPC (~µs). Over the gateway every call is a
+ * WebSocket round-trip against a 40-invokes/s server budget, and the
+ * boot burst (per-project git_status + git_fetch_all + icon discovery)
+ * competed with hydration for it. Desktop-critical data is unaffected:
+ * chips paint from the persisted cache, and the active root's vcs
+ * status still refreshes immediately.
+ */
+
+export const MOBILE_BOOT_DEFER_MS = 10_000;
+
+export function isMobileSurface(): boolean {
+  return import.meta.env.VITE_AETHON_SURFACE === "mobile";
+}
+
+/** Run `fn` immediately on desktop; on the mobile companion, delay it
+ *  past the boot window. Returns a cancel function (no-op on desktop —
+ *  `fn` already ran). */
+export function scheduleAfterMobileBootWindow(fn: () => void): () => void {
+  if (!isMobileSurface()) {
+    fn();
+    return () => {};
+  }
+  const timer = setTimeout(fn, MOBILE_BOOT_DEFER_MS);
+  return () => clearTimeout(timer);
+}

--- a/src/hooks/useProjectOps.ts
+++ b/src/hooks/useProjectOps.ts
@@ -25,6 +25,7 @@ import { disposeEditorBuffer } from "../monaco/editor-buffers";
 import { useProjectStore } from "./projectOps/projectStore";
 import { sweepOrphanWorkspaceTabs } from "./projectOps/orphanTabSweep";
 import { recordWorkspaceActivation } from "./statusPollScheduler";
+import { mobileBootWindowElapsed } from "./mobileBootDefer";
 import {
   projectScopeBucketKey,
   switchProjectBucket as switchTabBucket,
@@ -299,7 +300,11 @@ export function useProjectOps(ctx: UseProjectOpsContext): UseProjectOpsActions {
       projectsLoadedRef.current = true;
       await refreshVisibleProjectWorkspaces();
       syncProjectsToState();
-      void refreshAllGitStatus();
+      // Mobile boot window: skip the immediate all-projects sweep — the
+      // deferred first tick in useProjects covers the catch-up without
+      // bursting the gateway budget during hydration. (Always runs on
+      // desktop and on any post-window re-hydration.)
+      if (mobileBootWindowElapsed()) void refreshAllGitStatus();
       const active = activeProject(ps);
       const tabId =
         (stateRef.current.activeTabId as string | undefined) ?? "default";

--- a/src/hooks/useProjectSyncEffects.ts
+++ b/src/hooks/useProjectSyncEffects.ts
@@ -1,7 +1,10 @@
 import { useCallback, useEffect, useRef, type MutableRefObject } from "react";
 import type { ProjectsState } from "../projects";
 import { discoverIcon } from "../projectIcons";
-import { scheduleAfterMobileBootWindow } from "./mobileBootDefer";
+import {
+  mobileBootWindowElapsed,
+  scheduleAfterMobileBootWindow,
+} from "./mobileBootDefer";
 import type { Tab } from "../types/tab";
 import { workspaceIdForCwd } from "./useProjectOps";
 
@@ -73,17 +76,28 @@ export function useProjectSyncEffects({
     }
   }, [projectsRef, setProjectIconUrl]);
 
-  // First run defers past the mobile boot window (fs_discover_project_icon
-  // + gh_repo_avatar_url per icon-less project would otherwise burn the
-  // gateway's boot invoke budget); later project-list changes are user
-  // actions and run immediately. Desktop is unchanged — the helper runs
-  // synchronously there.
-  const iconsBootDeferredRef = useRef(false);
+  // Inside the mobile boot window, coalesce every trigger — including
+  // the pre-hydration empty-list run AND the re-run when
+  // syncProjectsToState mirrors the persisted list — into ONE sweep at
+  // window end, so the deferred run sees the hydrated projects and the
+  // fs_discover_project_icon / gh_repo_avatar_url burst stays out of
+  // the gateway's boot budget. After the window (and always on
+  // desktop), runs are immediate.
+  const iconSweepScheduledRef = useRef(false);
+  const iconSweepCancelRef = useRef<(() => void) | null>(null);
   useEffect(() => {
-    if (!iconsBootDeferredRef.current) {
-      iconsBootDeferredRef.current = true;
-      return scheduleAfterMobileBootWindow(discoverIconsForProjects);
+    if (mobileBootWindowElapsed()) {
+      discoverIconsForProjects();
+      return;
     }
-    discoverIconsForProjects();
+    if (iconSweepScheduledRef.current) return;
+    iconSweepScheduledRef.current = true;
+    iconSweepCancelRef.current = scheduleAfterMobileBootWindow(() => {
+      iconSweepCancelRef.current = null;
+      discoverIconsForProjects();
+    });
+    // Deliberately no per-run cleanup: cancelling on a dep change would
+    // drop the coalesced sweep. Unmount cleanup lives below.
   }, [discoverIconsForProjects, state.projects]);
+  useEffect(() => () => iconSweepCancelRef.current?.(), []);
 }

--- a/src/hooks/useProjectSyncEffects.ts
+++ b/src/hooks/useProjectSyncEffects.ts
@@ -1,6 +1,7 @@
-import { useCallback, useEffect, type MutableRefObject } from "react";
+import { useCallback, useEffect, useRef, type MutableRefObject } from "react";
 import type { ProjectsState } from "../projects";
 import { discoverIcon } from "../projectIcons";
+import { scheduleAfterMobileBootWindow } from "./mobileBootDefer";
 import type { Tab } from "../types/tab";
 import { workspaceIdForCwd } from "./useProjectOps";
 
@@ -72,7 +73,17 @@ export function useProjectSyncEffects({
     }
   }, [projectsRef, setProjectIconUrl]);
 
+  // First run defers past the mobile boot window (fs_discover_project_icon
+  // + gh_repo_avatar_url per icon-less project would otherwise burn the
+  // gateway's boot invoke budget); later project-list changes are user
+  // actions and run immediately. Desktop is unchanged — the helper runs
+  // synchronously there.
+  const iconsBootDeferredRef = useRef(false);
   useEffect(() => {
+    if (!iconsBootDeferredRef.current) {
+      iconsBootDeferredRef.current = true;
+      return scheduleAfterMobileBootWindow(discoverIconsForProjects);
+    }
     discoverIconsForProjects();
   }, [discoverIconsForProjects, state.projects]);
 }

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -13,6 +13,7 @@ import {
   GIT_FETCH_INTERVAL_MS,
 } from "./gitFetchScheduler";
 import { dueStatusRoots, warmStatusRoots } from "./statusPollScheduler";
+import { scheduleAfterMobileBootWindow } from "./mobileBootDefer";
 
 export interface GitStatus {
   branch?: string;
@@ -232,6 +233,7 @@ export function useProjects(ctx: UseProjectsContext): UseProjectsActions {
   useEffect(() => {
     let cancelled = false;
     let rerun = false;
+    let cancelBootDefer: () => void = () => {};
     const tick = async () => {
       // Skip background git polling while the window is hidden — no chips are
       // visible to update, so it's pure wasted subprocess churn. The
@@ -268,8 +270,15 @@ export function useProjects(ctx: UseProjectsContext): UseProjectsActions {
       }
       gitFetchAttemptsRef.current = await loadGitFetchAttempts();
       if (cancelled) return;
-      void tick();
-      void fetchGitRemotesIfDue(tick);
+      // Desktop: refresh immediately. Mobile companion: the cached
+      // hydrate above already painted the chips — defer the first live
+      // per-project poll past the boot window so it doesn't compete
+      // with hydration for the gateway's invoke budget.
+      cancelBootDefer = scheduleAfterMobileBootWindow(() => {
+        if (cancelled) return;
+        void tick();
+        void fetchGitRemotesIfDue(tick);
+      });
     };
     void bootstrap();
     const onFocus = () => {
@@ -294,6 +303,7 @@ export function useProjects(ctx: UseProjectsContext): UseProjectsActions {
     );
     return () => {
       cancelled = true;
+      cancelBootDefer();
       window.clearInterval(interval);
       window.clearInterval(fetchInterval);
       window.removeEventListener("focus", onFocus);

--- a/src/mainApp.tsx
+++ b/src/mainApp.tsx
@@ -14,6 +14,7 @@ import { prewarmHighlighter } from "./utils/highlight";
 // single index.css — Vite's HMR dep graph tracks JS module imports
 // reliably, but `@import` chains in CSS files have produced silently
 // stale stylesheets in the webview after edits to chrome.css.
+import "./styles/fonts";
 import "./styles/tokens.css";
 import "./styles/themes.css";
 import "./styles/chrome.css";

--- a/src/mobile/mainMobile.tsx
+++ b/src/mobile/mainMobile.tsx
@@ -11,6 +11,7 @@ import { createRoot } from "react-dom/client";
 import { applyBootTheme } from "../themeBootstrap";
 import { MobileGate } from "./MobileGate";
 import { perfMark } from "./perfMarks";
+import "../styles/fonts";
 import "../styles/tokens.css";
 import "../styles/themes.css";
 import "../styles/chrome.css";

--- a/src/styles/fonts.ts
+++ b/src/styles/fonts.ts
@@ -1,0 +1,34 @@
+/**
+ * Self-hosted fonts (@fontsource woff2, `font-display: swap`).
+ *
+ * Replaces the render-blocking Google Fonts stylesheet both surfaces
+ * used to load in their HTML heads — an external network dependency on
+ * the first-paint path that stalled boot on slow links and never
+ * resolved offline (the iOS companion frequently launches with no route
+ * to fonts.googleapis.com).
+ *
+ * Weights mirror the old `<link>`: 400/500/600/700 for UI + mono
+ * families, 600/700 (+700 italic) for the Playfair wordmark.
+ * `@fontsource/geist-sans` registers family "Geist Sans" — tokens.css
+ * lists it right after "Geist" so a system-installed Geist still wins.
+ */
+
+import "@fontsource/geist-sans/400.css";
+import "@fontsource/geist-sans/500.css";
+import "@fontsource/geist-sans/600.css";
+import "@fontsource/geist-sans/700.css";
+import "@fontsource/geist-mono/400.css";
+import "@fontsource/geist-mono/500.css";
+import "@fontsource/geist-mono/600.css";
+import "@fontsource/geist-mono/700.css";
+import "@fontsource/inter/400.css";
+import "@fontsource/inter/500.css";
+import "@fontsource/inter/600.css";
+import "@fontsource/inter/700.css";
+import "@fontsource/jetbrains-mono/400.css";
+import "@fontsource/jetbrains-mono/500.css";
+import "@fontsource/jetbrains-mono/600.css";
+import "@fontsource/jetbrains-mono/700.css";
+import "@fontsource/playfair-display/600.css";
+import "@fontsource/playfair-display/700.css";
+import "@fontsource/playfair-display/700-italic.css";

--- a/src/styles/import-order.test.ts
+++ b/src/styles/import-order.test.ts
@@ -20,13 +20,20 @@ const expectedChromeImports = [
 ];
 
 describe("stylesheet import order", () => {
-  it("loads shape tokens, theme tokens, then chrome rules from mainApp", () => {
+  it("loads fonts, shape tokens, theme tokens, then chrome rules from mainApp", () => {
     const mainApp = readStyleFile("../mainApp.tsx");
     const styleImports = [...mainApp.matchAll(/import\s+["']\.\/styles\/([^"']+)["'];/g)].map(
       (match) => match[1],
     );
 
-    expect(styleImports).toEqual(["tokens.css", "themes.css", "chrome.css"]);
+    // fonts first: self-hosted @font-face declarations must be in the
+    // sheet before tokens.css names the families.
+    expect(styleImports).toEqual([
+      "fonts",
+      "tokens.css",
+      "themes.css",
+      "chrome.css",
+    ]);
   });
 
   it("keeps chrome domain imports in original cascade order", () => {

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -9,9 +9,12 @@
  * elevation shape scale, app-level layout. */
 
 :root {
-  /* Typography — Geist (UI) + Geist Mono (mono); Inter and JetBrains
-     Mono fall back gracefully when Google Fonts is unreachable. */
-  --font-ui: "Geist", "Inter", system-ui, -apple-system, sans-serif;
+  /* Typography — Geist (UI) + Geist Mono (mono), self-hosted via
+     @fontsource (see src/styles/fonts.ts). "Geist Sans" is the family
+     the bundled @fontsource/geist-sans registers; a system-installed
+     "Geist" still wins when present. */
+  --font-ui:
+    "Geist", "Geist Sans", "Inter", system-ui, -apple-system, sans-serif;
   --font-mono:
     "Geist Mono", "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo,
     monospace;


### PR DESCRIPTION
## Summary

D1–D4 of the mobile workstream (all client-side; the policy/relay lockstep is untouched). Stacked on #468 — retargets to main when it merges.

- **D1 — watcher stubs**: `watch_project_extensions` / `unwatch_project_extensions` join the companion's desktop-local stub set. Forwarding them was two guaranteed-`Deny` round-trips (and rate-limit slots) per project announcement at boot.
- **D2 — self-hosted fonts (both surfaces)**: @fontsource woff2 (`font-display: swap`) replaces the render-blocking Google Fonts stylesheet in `index.html` + `index.mobile.html`. First paint is deterministic offline — the phone frequently launches with no route to fonts.googleapis.com. `tokens.css` gains a `"Geist Sans"` fallback (the family the bundled package registers).
- **D3 — transport pacing + rate-limited retry**: the gateway transport paces invoke sends to 32 per rolling second (headroom under the server's 40/s fixed window; the windows don't align) with a FIFO queue on the physical send only — `request()` still fails fast offline and times out from call time. Rate-limited results re-send the SAME frame (the server rejects before `relay.invoke` runs, so the command never executed) up to 3× with linear backoff. Close/disconnect clears the queue and every pacing timer so nothing writes into a superseded socket (the zombie-socket bug class stays dead).
- **D4 — mobile boot trimming**: behind the existing `VITE_AETHON_SURFACE === "mobile"` gate, the first per-project git poll + `git_fetch_all` and the initial icon-discovery sweep defer 10 s past the boot window (cached statuses still paint chips instantly). Desktop behavior is byte-identical — the helper runs synchronously there.

**Measured intent**: boot invoke burst drops from >40/s (with silent server-side drops and no client retry) to ~15–20 paced sends and zero surfaced rate-limit rejections.

## Test plan
- [x] Transport: burst pacing (32 now, FIFO drain), same-id retry then resolve, retries exhausted, non-rate-limit errors unchanged, queue cleared on close with no leak into the next connection (FakeSocket + fake timers)
- [x] commandPolicy routing + stub results; mobileBootDefer helper (desktop-sync / mobile-deferred / cancel)
- [x] Fonts: both dists ship 72 woff2 files; zero fonts.googleapis.com references; import-order test updated (fonts precede tokens)
- [x] Full `check` green on the stack (3135+ tests)