### PR TITLE
perf(toggle): in-process extension hot toggle with respawn fallback + kill-switch

### DIFF
--- a/agent/active-project-cwd.test.ts
+++ b/agent/active-project-cwd.test.ts
@@ -88,3 +88,37 @@ describe("resolveStartupCwd", () => {
     expect(resolveStartupCwd(undefined, undefined, "", "/")).toBe("/");
   });
 });
+
+describe("readActiveProjectCwd", () => {
+  it("degrades to the on-disk projects.json when the state db is unopenable", async () => {
+    // SQLITE_CANTOPEN from readSqliteStateValue used to escape and fatal
+    // the whole bridge boot before the dispatcher started.
+    const { mkdtempSync, mkdirSync, writeFileSync, rmSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const { readActiveProjectCwd } = await import("./active-project-cwd");
+
+    const userDir = mkdtempSync(join(tmpdir(), "aethon-cwd-"));
+    try {
+      // Point the sqlite reader at an unopenable path: AETHON_DB_FILE's
+      // parent directory does not exist.
+      const priorDb = process.env.AETHON_DB_FILE;
+      process.env.AETHON_DB_FILE = join(userDir, "missing-dir", "aethon.sqlite3");
+      mkdirSync(userDir, { recursive: true });
+      writeFileSync(
+        join(userDir, "projects.json"),
+        JSON.stringify({
+          activeId: "p1",
+          projects: [{ id: "p1", path: "/repo/fallback" }],
+        }),
+      );
+      await expect(readActiveProjectCwd(userDir)).resolves.toBe(
+        "/repo/fallback",
+      );
+      if (priorDb === undefined) delete process.env.AETHON_DB_FILE;
+      else process.env.AETHON_DB_FILE = priorDb;
+    } finally {
+      rmSync(userDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/agent/active-project-cwd.ts
+++ b/agent/active-project-cwd.ts
@@ -72,9 +72,16 @@ export function activeProjectCwdFromJson(text: string): string | undefined {
 export async function readActiveProjectCwd(
   userDir: string,
 ): Promise<string | undefined> {
-  const sqliteProjects = readSqliteStateValue("projects.json");
-  if (sqliteProjects !== undefined) {
-    return activeProjectCwdFromJson(sqliteProjects);
+  // A missing/corrupt state db must degrade to the JSON fallback, not
+  // fatal the bridge boot — SQLITE_CANTOPEN here previously killed
+  // main() before the dispatcher ever started.
+  try {
+    const sqliteProjects = readSqliteStateValue("projects.json");
+    if (sqliteProjects !== undefined) {
+      return activeProjectCwdFromJson(sqliteProjects);
+    }
+  } catch {
+    /* fall through to the on-disk projects.json */
   }
   try {
     return activeProjectCwdFromJson(

--- a/agent/dispatcher.ts
+++ b/agent/dispatcher.ts
@@ -277,7 +277,13 @@ export async function dispatchInboundMessage(
         state.bootLayout = msg.payload;
         break;
       case "set_extension_disabled":
-        await handleSetExtensionDisabled(state, deps, notifDeps, msg);
+        await handleSetExtensionDisabled(
+          state,
+          deps,
+          notifDeps,
+          msg,
+          extensionApi,
+        );
         break;
       case "set_session_label":
         await handleSetSessionLabel(state, deps, msg);

--- a/agent/extension-hot-toggle.test.ts
+++ b/agent/extension-hot-toggle.test.ts
@@ -1,0 +1,218 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+vi.mock("./dispatcherTypes", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./dispatcherTypes")>();
+  return { ...original, emitGlobalReady: vi.fn(() => Promise.resolve()) };
+});
+
+import { loadAllExtensions } from "./boot-sequence";
+import {
+  canHotToggle,
+  hotReloadExtensions,
+  resetHotToggleForTest,
+} from "./extension-hot-toggle";
+import { emitGlobalReady } from "./dispatcherTypes";
+import {
+  AethonAgentState,
+  type AethonAgentStateOptions,
+  type AethonExtensionApi,
+} from "./state";
+
+function makeOpts(userDir: string): AethonAgentStateOptions {
+  return {
+    userDir,
+    stateFile: join(userDir, "state.json"),
+    sessionsDir: join(userDir, "sessions"),
+    docsDir: undefined,
+    projectRoot: undefined,
+    releaseMode: false,
+    bootLayoutFile: undefined,
+    layoutSlotsFile: undefined,
+    statePayloadWarnBytes: 64 * 1024,
+    statePayloadHardBytes: 512 * 1024,
+    statePayloadWarnKb: 64,
+    statePayloadHardKb: 512,
+  };
+}
+
+function makeFixture() {
+  const home = mkdtempSync(join(tmpdir(), "aethon-hot-toggle-"));
+  const userDir = join(home, ".aethon");
+  const extDir = join(userDir, "extensions");
+  mkdirSync(extDir, { recursive: true });
+  mkdirSync(join(home, ".pi", "agent", "extensions"), { recursive: true });
+
+  const state = new AethonAgentState(makeOpts(userDir));
+  state.resourceLoader = {
+    reload: vi.fn(() => Promise.resolve()),
+  } as unknown as AethonAgentState["resourceLoader"];
+
+  const sent: Record<string, unknown>[] = [];
+  const teardownRuns: string[] = [];
+  const api = {
+    registerComponent(type: string, template: unknown) {
+      state.extensionComponents.set(type, template);
+    },
+    registerTheme(theme: unknown) {
+      const id = (theme as { id?: string }).id ?? "unknown";
+      state.extensionThemes.set(id, theme as never);
+      return Promise.resolve({ ok: true });
+    },
+    onUnload(fn: () => void) {
+      // Mirror the real _onUnload scope routing.
+      if (state.currentExtensionLoadScope === "project") {
+        state.projectExtensionTeardowns.push(fn);
+      } else {
+        state.userExtensionTeardowns.push(fn);
+      }
+    },
+  } as unknown as AethonExtensionApi;
+
+  const deps = {
+    send: (m: Record<string, unknown>) => sent.push(m),
+    scheduleStateFileWrite: () => {},
+    loadHooks: {},
+  };
+
+  return {
+    home,
+    userDir,
+    extDir,
+    state,
+    sent,
+    teardownRuns,
+    api,
+    deps,
+    load: () =>
+      loadAllExtensions(state, { send: deps.send }, api, {
+        userDir,
+        workerCwd: userDir,
+        loadHooks: {},
+        onFrontendEntry: () => {},
+      }),
+    cleanup: () => rmSync(home, { recursive: true, force: true }),
+  };
+}
+
+type Fixture = ReturnType<typeof makeFixture>;
+
+describe("hot extension toggle", () => {
+  let f: Fixture;
+  const realHome = process.env.HOME;
+
+  beforeEach(() => {
+    f = makeFixture();
+    process.env.HOME = f.home;
+    resetHotToggleForTest();
+    vi.mocked(emitGlobalReady).mockClear();
+  });
+
+  afterEach(() => {
+    if (realHome === undefined) delete process.env.HOME;
+    else process.env.HOME = realHome;
+    delete process.env.AETHON_HOT_EXTENSION_TOGGLE;
+    f.cleanup();
+  });
+
+  it("applies a disable in process: teardown runs, registries rebuild, snapshot re-emits", async () => {
+    writeFileSync(
+      join(f.extDir, "keeper.ts"),
+      `export function register(api) { api.registerComponent("keeper-comp", null); }`,
+    );
+    writeFileSync(
+      join(f.extDir, "victim.ts"),
+      `export function register(api) {
+        api.registerComponent("victim-comp", null);
+        api.onUnload(() => { globalThis.__victimTornDown = true; });
+      }`,
+    );
+    await f.load();
+    expect(f.state.extensionComponents.has("victim-comp")).toBe(true);
+    expect(f.state.loadedExtensions.get("victim")).toBe("directory");
+
+    f.state.disabledExtensions.add("victim");
+    f.sent.length = 0;
+    const outcome = await hotReloadExtensions(f.state, f.deps, f.api);
+
+    expect(outcome).toBe("applied");
+    expect(
+      (globalThis as { __victimTornDown?: boolean }).__victimTornDown,
+    ).toBe(true);
+    expect(f.state.extensionComponents.has("victim-comp")).toBe(false);
+    expect(f.state.extensionComponents.has("keeper-comp")).toBe(true);
+    expect(f.state.loadedExtensions.has("victim")).toBe(false);
+    expect(f.state.loadedExtensions.get("keeper")).toBe("directory");
+    // Wholesale registry snapshot re-emitted, then a fresh ready.
+    const types = f.sent.map((m) => m.type);
+    expect(types).toContain("extension_components");
+    expect(types).toContain("extension_themes");
+    expect(emitGlobalReady).toHaveBeenCalledTimes(1);
+    // The disabled skip event surfaced during the reload pass.
+    expect(f.sent).toContainEqual(
+      expect.objectContaining({
+        type: "extension_lifecycle",
+        name: "victim",
+        status: "disabled",
+      }),
+    );
+    delete (globalThis as { __victimTornDown?: boolean }).__victimTornDown;
+  });
+
+  it("applies an enable in process: previously-skipped extension registers", async () => {
+    writeFileSync(
+      join(f.extDir, "muted.ts"),
+      `export function register(api) { api.registerComponent("muted-comp", null); }`,
+    );
+    f.state.disabledExtensions.add("muted");
+    await f.load();
+    expect(f.state.extensionComponents.has("muted-comp")).toBe(false);
+
+    f.state.disabledExtensions.delete("muted");
+    const outcome = await hotReloadExtensions(f.state, f.deps, f.api);
+    expect(outcome).toBe("applied");
+    expect(f.state.extensionComponents.has("muted-comp")).toBe(true);
+    expect(f.state.loadedExtensions.get("muted")).toBe("directory");
+  });
+
+  it("falls back when the reload pass fails", async () => {
+    (
+      f.state.resourceLoader.reload as unknown as ReturnType<typeof vi.fn>
+    ).mockRejectedValueOnce(new Error("boom"));
+    const outcome = await hotReloadExtensions(f.state, f.deps, f.api);
+    expect(outcome).toBe("fallback");
+    // The latch must release so a later toggle can retry.
+    expect(canHotToggle(f.state, "directory")).toEqual({ ok: true });
+  });
+
+  it("refuses pi extensions, the kill-switch, and concurrent reloads", async () => {
+    expect(canHotToggle(f.state, "pi-extension").ok).toBe(false);
+
+    process.env.AETHON_HOT_EXTENSION_TOGGLE = "0";
+    expect(canHotToggle(f.state, "directory").ok).toBe(false);
+    delete process.env.AETHON_HOT_EXTENSION_TOGGLE;
+
+    let resolveReload: (() => void) | null = null;
+    (
+      f.state.resourceLoader.reload as unknown as ReturnType<typeof vi.fn>
+    ).mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveReload = resolve;
+        }),
+    );
+    const inFlight = hotReloadExtensions(f.state, f.deps, f.api);
+    // The latch flips synchronously, well before the reload runs.
+    expect(canHotToggle(f.state, "directory").ok).toBe(false);
+    // Wait for the load pass to reach the (held-open) resource reload,
+    // then let it finish.
+    await vi.waitFor(() => {
+      expect(resolveReload).not.toBeNull();
+    });
+    resolveReload?.();
+    await inFlight;
+    expect(canHotToggle(f.state, "directory").ok).toBe(true);
+  });
+});

--- a/agent/extension-hot-toggle.ts
+++ b/agent/extension-hot-toggle.ts
@@ -1,0 +1,170 @@
+/**
+ * In-process extension hot toggle.
+ *
+ * Toggling an extension used to emit `reload_required` — a full bridge
+ * kill-and-respawn (session re-creation, MCP reconnect, resource
+ * reloads) because the disabled list was only consulted at cold boot.
+ * This module applies the toggle IN process instead: run every
+ * registered teardown, clear the (wholly extension-owned) registries,
+ * and re-run the exact boot load path (`loadAllExtensions`, which also
+ * re-captures the project baseline and does the single
+ * `resourceLoader.reload()`), now honoring the updated disabled set.
+ *
+ * From an extension's point of view this is indistinguishable from the
+ * respawn it replaced — full unload + fresh register() — so the
+ * teardown contract, ordering semantics, and later-wins precedence are
+ * preserved by construction rather than by per-key bookkeeping. What it
+ * does NOT touch: pi sessions (aethon extensions register no pi tools),
+ * MCP servers, in-flight prompts, or the process itself.
+ *
+ * Deliberately refused (falls back to the reload_required respawn):
+ *  - pi-extension rows: those are loaded by pi's resource loader and
+ *    bound into live sessions — a respawn is the only clean boundary.
+ *  - worker bridges: they don't own the frontend surface. (The Rust
+ *    router already sends set_extension_disabled to the global bridge
+ *    only; the guard is belt-and-braces.)
+ *  - concurrent toggles: a second toggle while a reload is in flight
+ *    would interleave registry writes.
+ *  - kill-switch: AETHON_HOT_EXTENSION_TOGGLE=0 forces the respawn
+ *    path everywhere.
+ */
+
+import { loadAllExtensions } from "./boot-sequence";
+import type { LoadHooks } from "./extension-loader/shared";
+import { emitExtensionRegistrySnapshot } from "./projectLifecycle";
+import { emitGlobalReady } from "./dispatcherTypes";
+import { logger } from "./logger";
+import type {
+  AethonAgentState,
+  AethonExtensionApi,
+  ExtensionSource,
+} from "./state";
+
+const log = logger.scope("hot-toggle");
+
+let hotReloadInFlight = false;
+
+export interface HotToggleDeps {
+  send: (obj: Record<string, unknown>) => void;
+  scheduleStateFileWrite: () => void;
+  loadHooks: LoadHooks;
+}
+
+export function canHotToggle(
+  state: AethonAgentState,
+  source: ExtensionSource,
+): { ok: true } | { ok: false; reason: string } {
+  if (process.env.AETHON_HOT_EXTENSION_TOGGLE === "0") {
+    return { ok: false, reason: "disabled via AETHON_HOT_EXTENSION_TOGGLE=0" };
+  }
+  if (source === "pi-extension") {
+    return { ok: false, reason: "pi extensions are bound into live sessions" };
+  }
+  if (typeof process.env.AETHON_WORKER_TAB_ID === "string") {
+    return { ok: false, reason: "worker bridges do not own the UI surface" };
+  }
+  if (hotReloadInFlight) {
+    return { ok: false, reason: "another hot reload is in flight" };
+  }
+  return { ok: true };
+}
+
+/** Run every registered teardown (same guarded pattern as the
+ *  project-switch unload) and clear every extension-owned registry back
+ *  to its boot-empty state, ready for a fresh load pass. */
+function resetExtensionSurface(state: AethonAgentState): void {
+  for (const teardowns of [
+    state.projectExtensionTeardowns,
+    state.userExtensionTeardowns,
+  ]) {
+    for (const fn of teardowns) {
+      try {
+        const result = fn();
+        if (
+          result &&
+          typeof (result as Promise<unknown>).catch === "function"
+        ) {
+          (result as Promise<unknown>).catch((err: unknown) => {
+            log.warn(`teardown async error: ${(err as Error).message}`);
+          });
+        }
+      } catch (err) {
+        log.warn(`teardown sync error: ${(err as Error).message}`);
+      }
+    }
+    teardowns.length = 0;
+  }
+
+  state.loadedExtensions.clear();
+  state.projectExtensionRoots.clear();
+  state.loadFailures.clear();
+  state.loadedProjectExtensionFiles.clear();
+  state.failedProjectExtensionFiles.clear();
+
+  state.extensionComponents.clear();
+  state.extensionThemes.clear();
+  state.extensionSlashCommands.clear();
+  state.extensionKeybindings.clear();
+  state.extensionMenuItems.clear();
+  state.extensionLayouts.clear();
+  state.extensionEventRoutes.clear();
+  state.eventRoutingMode = "builtin";
+  state.a2uiEventHandlers.length = 0;
+  state.registeredHandlerKeys.clear();
+  state.currentExtensionHandlerOrdinals.clear();
+  state.extensionStateTree = {};
+  state.extensionStateKeys.clear();
+  state.extensionFrontendModules.clear();
+  state.extensionHighlightGrammars.clear();
+  state.extensionLayout = undefined;
+  state.pendingLayoutPatches = [];
+  state.extPathOwners.clear();
+  state.projectBaseline = null;
+}
+
+/** Apply a toggle in process: teardown + registry reset + the exact
+ *  boot load path with the updated disabled set + wholesale re-emit.
+ *  Returns "applied" on success; "fallback" means the caller should
+ *  take the old reload_required respawn path (the reset alone leaves
+ *  state no worse than the respawn's kill would). */
+export async function hotReloadExtensions(
+  state: AethonAgentState,
+  deps: HotToggleDeps,
+  api: AethonExtensionApi,
+): Promise<"applied" | "fallback"> {
+  hotReloadInFlight = true;
+  const started = performance.now();
+  try {
+    resetExtensionSurface(state);
+    await loadAllExtensions(state, { send: deps.send }, api, {
+      userDir: state.userDir,
+      // Pin the load to the LIVE project cwd (a set_project may have
+      // moved it since boot) instead of re-reading projects.json.
+      workerCwd: state.currentProjectCwd ?? undefined,
+      projectRoot: state.projectRoot,
+      loadHooks: deps.loadHooks,
+      onFrontendEntry: ({ name, entryPath, code }) => {
+        state.extensionFrontendModules.set(name, { name, entryPath, code });
+      },
+    });
+    emitExtensionRegistrySnapshot(state, deps);
+    await emitGlobalReady(state, deps);
+    deps.scheduleStateFileWrite();
+    log.info(
+      `hot toggle applied in ${Math.round(performance.now() - started)}ms`,
+    );
+    return "applied";
+  } catch (err) {
+    log.warn(
+      `hot toggle failed (${(err as Error).message}); falling back to respawn`,
+    );
+    return "fallback";
+  } finally {
+    hotReloadInFlight = false;
+  }
+}
+
+/** Test-only: reset the in-flight latch. */
+export function resetHotToggleForTest(): void {
+  hotReloadInFlight = false;
+}

--- a/agent/extensionControl.test.ts
+++ b/agent/extensionControl.test.ts
@@ -96,6 +96,44 @@ describe("handleSetExtensionDisabled hot path", () => {
     expect(f.state.disabledExtensions.has("my-ext")).toBe(true);
   });
 
+  it("does not report success when a hot ENABLE's load failed", async () => {
+    f.state.disabledExtensions.add("my-ext");
+    f.state.disabledExtensionMeta.set("my-ext", { source: "directory" });
+    vi.mocked(hotReloadExtensions).mockImplementation((state) => {
+      state.loadFailures.set("my-ext", {
+        source: "directory",
+        status: "failed",
+        error: "register() exploded",
+      });
+      return Promise.resolve("applied" as const);
+    });
+
+    await handleSetExtensionDisabled(
+      f.state,
+      f.deps,
+      { send: f.deps.send },
+      { type: "set_extension_disabled", name: "my-ext", disabled: false },
+      f.api,
+    );
+
+    // No hotApplied success lifecycle, an error toast instead, and the
+    // workers still converge on the new disabled list.
+    expect(f.sent).not.toContainEqual(
+      expect.objectContaining({ hotApplied: true }),
+    );
+    expect(f.sent).toContainEqual(
+      expect.objectContaining({
+        type: "notification",
+        notification: expect.objectContaining({
+          title: expect.stringContaining("failed to load"),
+          kind: "error",
+        }),
+      }),
+    );
+    expect(f.types()).toContain("worker_refresh_required");
+    expect(f.types()).not.toContain("reload_required");
+  });
+
   it("falls back to the respawn when the hot reload fails", async () => {
     f.state.loadedExtensions.set("my-ext", "directory");
     vi.mocked(hotReloadExtensions).mockResolvedValue("fallback");

--- a/agent/extensionControl.test.ts
+++ b/agent/extensionControl.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+vi.mock("./extension-hot-toggle", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("./extension-hot-toggle")>();
+  return { ...original, hotReloadExtensions: vi.fn() };
+});
+
+import { handleSetExtensionDisabled } from "./extensionControl";
+import { hotReloadExtensions } from "./extension-hot-toggle";
+import {
+  AethonAgentState,
+  type AethonAgentStateOptions,
+  type AethonExtensionApi,
+} from "./state";
+
+function makeOpts(userDir: string): AethonAgentStateOptions {
+  return {
+    userDir,
+    stateFile: join(userDir, "state.json"),
+    sessionsDir: join(userDir, "sessions"),
+    docsDir: undefined,
+    projectRoot: undefined,
+    releaseMode: false,
+    bootLayoutFile: undefined,
+    layoutSlotsFile: undefined,
+    statePayloadWarnBytes: 64 * 1024,
+    statePayloadHardBytes: 512 * 1024,
+    statePayloadWarnKb: 64,
+    statePayloadHardKb: 512,
+  };
+}
+
+function makeFixture() {
+  const userDir = mkdtempSync(join(tmpdir(), "aethon-ext-control-"));
+  const state = new AethonAgentState(makeOpts(userDir));
+  const sent: Record<string, unknown>[] = [];
+  const deps = {
+    send: (m: Record<string, unknown>) => sent.push(m),
+    scheduleStateFileWrite: () => {},
+    loadHooks: {},
+  };
+  const api = {} as AethonExtensionApi;
+  return {
+    userDir,
+    state,
+    sent,
+    deps,
+    api,
+    types: () => sent.map((m) => m.type),
+    cleanup: () => rmSync(userDir, { recursive: true, force: true }),
+  };
+}
+
+type Fixture = ReturnType<typeof makeFixture>;
+
+describe("handleSetExtensionDisabled hot path", () => {
+  let f: Fixture;
+
+  beforeEach(() => {
+    f = makeFixture();
+    vi.mocked(hotReloadExtensions).mockReset();
+  });
+
+  afterEach(() => {
+    delete process.env.AETHON_HOT_EXTENSION_TOGGLE;
+    f.cleanup();
+  });
+
+  it("hot-applies a directory extension toggle: worker refresh, no respawn", async () => {
+    f.state.loadedExtensions.set("my-ext", "directory");
+    vi.mocked(hotReloadExtensions).mockResolvedValue("applied");
+
+    await handleSetExtensionDisabled(
+      f.state,
+      f.deps,
+      { send: f.deps.send },
+      { type: "set_extension_disabled", name: "my-ext", disabled: true },
+      f.api,
+    );
+
+    expect(hotReloadExtensions).toHaveBeenCalledTimes(1);
+    expect(f.sent).toContainEqual(
+      expect.objectContaining({
+        type: "extension_lifecycle",
+        name: "my-ext",
+        status: "disabled",
+        hotApplied: true,
+      }),
+    );
+    expect(f.types()).toContain("worker_refresh_required");
+    expect(f.types()).not.toContain("reload_required");
+    expect(f.state.disabledExtensions.has("my-ext")).toBe(true);
+  });
+
+  it("falls back to the respawn when the hot reload fails", async () => {
+    f.state.loadedExtensions.set("my-ext", "directory");
+    vi.mocked(hotReloadExtensions).mockResolvedValue("fallback");
+
+    await handleSetExtensionDisabled(
+      f.state,
+      f.deps,
+      { send: f.deps.send },
+      { type: "set_extension_disabled", name: "my-ext", disabled: true },
+      f.api,
+    );
+
+    expect(f.types()).toContain("reload_required");
+    expect(f.types()).not.toContain("worker_refresh_required");
+  });
+
+  it("takes the respawn path directly for pi extensions", async () => {
+    f.state.loadedExtensions.set("pi-thing", "pi-extension");
+
+    await handleSetExtensionDisabled(
+      f.state,
+      f.deps,
+      { send: f.deps.send },
+      { type: "set_extension_disabled", name: "pi-thing", disabled: true },
+      f.api,
+    );
+
+    expect(hotReloadExtensions).not.toHaveBeenCalled();
+    expect(f.types()).toContain("reload_required");
+  });
+
+  it("honors the kill-switch env", async () => {
+    process.env.AETHON_HOT_EXTENSION_TOGGLE = "0";
+    f.state.loadedExtensions.set("my-ext", "directory");
+
+    await handleSetExtensionDisabled(
+      f.state,
+      f.deps,
+      { send: f.deps.send },
+      { type: "set_extension_disabled", name: "my-ext", disabled: true },
+      f.api,
+    );
+
+    expect(hotReloadExtensions).not.toHaveBeenCalled();
+    expect(f.types()).toContain("reload_required");
+  });
+
+  it("keeps the respawn path when no extension api is supplied", async () => {
+    f.state.loadedExtensions.set("my-ext", "directory");
+
+    await handleSetExtensionDisabled(
+      f.state,
+      f.deps,
+      { send: f.deps.send },
+      { type: "set_extension_disabled", name: "my-ext", disabled: true },
+    );
+
+    expect(hotReloadExtensions).not.toHaveBeenCalled();
+    expect(f.types()).toContain("reload_required");
+  });
+});

--- a/agent/extensionControl.ts
+++ b/agent/extensionControl.ts
@@ -140,20 +140,37 @@ export async function handleSetExtensionDisabled(
   if (hot.ok && extensionApi) {
     const outcome = await hotReloadExtensions(state, deps, extensionApi);
     if (outcome === "applied") {
-      deps.send({
-        type: "extension_lifecycle",
-        name,
-        source: lifecycleSource,
-        status: disabled ? "disabled" : "enabled",
-        hotApplied: true,
-      });
-      void notify(state, notifDeps, {
-        id: `aethon:extension-toggle:${name}`,
-        title: disabled ? `Disabled \`${name}\`` : `Enabled \`${name}\``,
-        message: "Applied without a bridge restart.",
-        kind: "info",
-        durationMs: 4000,
-      });
+      // An ENABLE whose import/register failed during the reload pass
+      // must not report success: the reload itself left consistent
+      // registries (and emitted the `failed` lifecycle event), but the
+      // user's intent didn't take.
+      const enableFailed = !disabled && state.loadFailures.has(name);
+      if (enableFailed) {
+        const failure = state.loadFailures.get(name);
+        void notify(state, notifDeps, {
+          id: `aethon:extension-toggle:${name}`,
+          title: `Enabled \`${name}\`, but it failed to load`,
+          message: failure?.error ?? "See the sidebar's Failures group.",
+          kind: "error",
+          durationMs: 6000,
+        });
+      } else {
+        deps.send({
+          type: "extension_lifecycle",
+          name,
+          source: lifecycleSource,
+          status: disabled ? "disabled" : "enabled",
+          hotApplied: true,
+        });
+        void notify(state, notifDeps, {
+          id: `aethon:extension-toggle:${name}`,
+          title: disabled ? `Disabled \`${name}\`` : `Enabled \`${name}\``,
+          message: "Applied without a bridge restart.",
+          kind: "info",
+          durationMs: 4000,
+        });
+      }
+      // Workers converge on the new disabled list either way.
       deps.send({
         type: "worker_refresh_required",
         reason: `extension-toggle:${name}`,

--- a/agent/extensionControl.ts
+++ b/agent/extensionControl.ts
@@ -1,7 +1,8 @@
-import type { AethonAgentState } from "./state";
+import type { AethonAgentState, AethonExtensionApi } from "./state";
 import type { ExtensionSource } from "./state";
 import type { DispatcherDeps, InboundMessage } from "./dispatcherTypes";
 import { saveDisabledExtensionsSnapshot } from "./disabled-extensions";
+import { canHotToggle, hotReloadExtensions } from "./extension-hot-toggle";
 import { notify } from "./notifications";
 
 function extensionLifecycleSource(
@@ -17,6 +18,7 @@ export async function handleSetExtensionDisabled(
   deps: DispatcherDeps,
   notifDeps: { send: (m: Record<string, unknown>) => void },
   msg: InboundMessage,
+  extensionApi?: AethonExtensionApi,
 ): Promise<void> {
   const name = (msg as { name?: unknown }).name;
   const disabled = (msg as { disabled?: unknown }).disabled;
@@ -116,19 +118,54 @@ export async function handleSetExtensionDisabled(
     });
     return;
   }
-  // Surface the change to the frontend immediately. The loaded set
-  // doesn't change until restart; the sidebar shows a `(disabled)` row
-  // by deriving from `loadedExtensions` plus the explicit disabled list.
-  // Re-emitting the lifecycle event gives layouts and the default system
-  // message handler immediate feedback before the bridge restart.
+  // Surface the change to the frontend immediately. The sidebar shows a
+  // `(disabled)` row by deriving from `loadedExtensions` plus the
+  // explicit disabled list; the hot path below (or the respawn) makes
+  // the loaded set follow.
   deps.send({
     type: "extension_lifecycle",
     name,
     source: lifecycleSource,
     status: disabled ? "disabled" : "enabled",
   });
-  // Notify the user before signalling the bridge restart so the toast
-  // is rendered before agent-reloaded clears the in-flight UI state.
+
+  // Preferred path: apply the toggle IN process — full teardown +
+  // reload of every extension source honoring the updated disabled set
+  // — instead of killing the bridge (sessions, MCP, and in-flight
+  // prompts survive). Per-tab workers loaded their extensions at spawn,
+  // so the frontend is asked to drain them for a lazy respawn.
+  const hot = extensionApi
+    ? canHotToggle(state, lifecycleSource)
+    : { ok: false as const, reason: "extension api unavailable" };
+  if (hot.ok && extensionApi) {
+    const outcome = await hotReloadExtensions(state, deps, extensionApi);
+    if (outcome === "applied") {
+      deps.send({
+        type: "extension_lifecycle",
+        name,
+        source: lifecycleSource,
+        status: disabled ? "disabled" : "enabled",
+        hotApplied: true,
+      });
+      void notify(state, notifDeps, {
+        id: `aethon:extension-toggle:${name}`,
+        title: disabled ? `Disabled \`${name}\`` : `Enabled \`${name}\``,
+        message: "Applied without a bridge restart.",
+        kind: "info",
+        durationMs: 4000,
+      });
+      deps.send({
+        type: "worker_refresh_required",
+        reason: `extension-toggle:${name}`,
+      });
+      return;
+    }
+  }
+
+  // Fallback: kill-and-respawn (pi extensions, kill-switch, hot-path
+  // failure). Notify the user before signalling the bridge restart so
+  // the toast is rendered before agent-reloaded clears the in-flight UI
+  // state.
   void notify(state, notifDeps, {
     id: `aethon:extension-toggle:${name}`,
     title: disabled ? `Disabled \`${name}\`` : `Enabled \`${name}\``,

--- a/agent/projectLifecycle.ts
+++ b/agent/projectLifecycle.ts
@@ -155,6 +155,19 @@ export function unloadProjectExtensions(
     (p) => ({ path: p.path, value: p.value }),
   );
 
+  emitExtensionRegistrySnapshot(state, deps);
+  deps.scheduleStateFileWrite();
+}
+
+/** Wholesale re-emit of every extension registry + the effective layout.
+ *  The single source of truth for "the registries changed out from
+ *  under the frontend" — used by the project-switch unload above and by
+ *  the extension hot-toggle reload. Sent unstamped from the global
+ *  bridge, so origin gating treats it as authoritative. */
+export function emitExtensionRegistrySnapshot(
+  state: AethonAgentState,
+  deps: Pick<DispatcherDeps, "send">,
+): void {
   deps.send({
     type: "extension_components",
     components: Object.fromEntries(state.extensionComponents),
@@ -199,7 +212,7 @@ export function unloadProjectExtensions(
     type: "extension_highlight_grammars",
     grammars: [...state.extensionHighlightGrammars.values()],
   });
-  // Push the restored layout to the frontend.
+  // Push the effective layout to the frontend.
   const effective = (() => {
     if (state.extensionLayout) return state.extensionLayout;
     if (!state.bootLayout) return null;
@@ -213,7 +226,6 @@ export function unloadProjectExtensions(
   if (effective) {
     deps.send({ type: "layout_set", payload: effective });
   }
-  deps.scheduleStateFileWrite();
 }
 
 export async function handleSetProject(

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,11 @@
     "": {
       "name": "aethon",
       "dependencies": {
+        "@fontsource/geist-mono": "^5.2.8",
+        "@fontsource/geist-sans": "^5.2.5",
+        "@fontsource/inter": "^5.2.8",
+        "@fontsource/jetbrains-mono": "^5.2.8",
+        "@fontsource/playfair-display": "^5.2.8",
         "@mariozechner/pi-agent-core": "^0.73.1",
         "@mariozechner/pi-ai": "^0.73.1",
         "@mariozechner/pi-coding-agent": "^0.73.1",
@@ -38,11 +43,6 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@fontsource/geist-mono": "^5.2.8",
-        "@fontsource/geist-sans": "^5.2.5",
-        "@fontsource/inter": "^5.2.8",
-        "@fontsource/jetbrains-mono": "^5.2.8",
-        "@fontsource/playfair-display": "^5.2.8",
         "@playwright/test": "^1.60.0",
         "@tauri-apps/cli": "^2.11.0",
         "@testing-library/dom": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,11 @@
     "version:check": "node scripts/sync-version.mjs --check"
   },
   "dependencies": {
+    "@fontsource/geist-mono": "^5.2.8",
+    "@fontsource/geist-sans": "^5.2.5",
+    "@fontsource/inter": "^5.2.8",
+    "@fontsource/jetbrains-mono": "^5.2.8",
+    "@fontsource/playfair-display": "^5.2.8",
     "@mariozechner/pi-agent-core": "^0.73.1",
     "@mariozechner/pi-ai": "^0.73.1",
     "@mariozechner/pi-coding-agent": "^0.73.1",
@@ -57,11 +62,6 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@fontsource/geist-mono": "^5.2.8",
-    "@fontsource/geist-sans": "^5.2.5",
-    "@fontsource/inter": "^5.2.8",
-    "@fontsource/jetbrains-mono": "^5.2.8",
-    "@fontsource/playfair-display": "^5.2.8",
     "@playwright/test": "^1.60.0",
     "@tauri-apps/cli": "^2.11.0",
     "@testing-library/dom": "^10.4.1",

--- a/src-tauri/src/commands/extensions/mod.rs
+++ b/src-tauri/src/commands/extensions/mod.rs
@@ -52,5 +52,9 @@ pub use app_menu::*;
 pub use installer::*;
 pub use menu_items::*;
 pub use project_watch::*;
+// Re-export `reload`'s command (+ its macro-generated siblings) for the
+// generate_handler list; the debounce worker stays wired through
+// `watcher` internally.
+pub(crate) use reload::*;
 pub use tray::*;
 pub use watcher::*;

--- a/src-tauri/src/commands/extensions/reload.rs
+++ b/src-tauri/src/commands/extensions/reload.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 
 use tauri::{AppHandle, Emitter, Manager, State};
 
-use crate::agent_process::AgentProcesses;
+use crate::agent_process::{AgentProcesses, GLOBAL_AGENT_KEY};
 
 pub(super) struct DebounceMsg {
     pub(super) settle_ms: u64,
@@ -28,7 +28,6 @@ pub(super) struct DebounceMsg {
 /// across the burst wins (so a node_modules event that arrives during
 /// an extension burst doesn't get prematurely fired).
 pub(super) fn run_debounce_worker(rx: std::sync::mpsc::Receiver<DebounceMsg>, app: AppHandle) {
-    use std::io::Write;
     use std::sync::mpsc::RecvTimeoutError;
 
     loop {
@@ -50,80 +49,117 @@ pub(super) fn run_debounce_worker(rx: std::sync::mpsc::Receiver<DebounceMsg>, ap
                 Err(RecvTimeoutError::Disconnected) => return,
             }
         }
-        // Quiet — ask each bridge to drain & respawn. Clone the per-child
-        // handles first so a wedged stdin only blocks that bridge, not the
-        // whole process table.
-        let state: State<'_, AgentProcesses> = app.state();
-        let children: Vec<_> = state
-            .children
-            .lock()
-            .map(|guard| {
-                guard
-                    .iter()
-                    .map(|(key, child)| (key.clone(), Arc::clone(child)))
-                    .collect()
-            })
-            .unwrap_or_default();
-        if !children.is_empty() {
-            let mut kill_keys = Vec::new();
-            for (key, child) in children {
-                let Ok(mut child) = child.lock() else {
-                    kill_keys.push(key);
-                    continue;
-                };
-                // Capture pid before the mutable borrow on `child.stdin`
-                // so we can log it without the borrow-checker complaining
-                // about overlapping immutable + mutable borrows of `child`.
-                let pid = child.id();
-                let write_result = match child.stdin.as_mut() {
-                    Some(stdin) => writeln!(stdin, "{{\"type\":\"reload_request\"}}")
-                        .and_then(|_| stdin.flush()),
-                    None => Err(std::io::Error::other("agent stdin closed")),
-                };
-                match write_result {
-                    Ok(()) => {
-                        // Mark the ask so a drain whose `_reload_done`
-                        // sentinel gets lost still classifies its EOF as a
-                        // reload rather than a crash.
-                        if let Ok(mut pending) = state.pending_reloads.lock() {
-                            pending.insert(key.clone());
-                        }
-                        tracing::info!(
-                            target: "aethon::agent_watch",
-                            key = key,
-                            "asked pid={pid} to reload after {settle}ms settle (last paths={last_paths:?})",
-                        );
-                    }
-                    Err(err) => {
-                        tracing::warn!(
-                            target: "aethon::agent_watch",
-                            key = key,
-                            "reload_request write failed for pid={pid}: {err}; falling back to kill",
-                        );
-                        kill_keys.push(key.clone());
-                    }
-                }
+        // Quiet — ask each bridge to drain & respawn.
+        request_agent_reloads(
+            &app,
+            |_| true,
+            &format!("after {settle}ms settle (last paths={last_paths:?})"),
+        );
+    }
+}
+
+/// Ask every agent child matching `filter` to drain in-flight prompts
+/// and exit for a lazy respawn (`reload_request` → `_reload_done` →
+/// respawn-on-next-IPC), with the hard-kill fallback for wedged stdin.
+/// Shared by the file-watcher debounce worker above (all bridges) and
+/// the extension hot-toggle path (workers only — the global bridge
+/// applied the toggle in process). Clones the per-child handles first
+/// so a wedged stdin only blocks that bridge, not the whole table.
+pub(crate) fn request_agent_reloads(
+    app: &AppHandle,
+    filter: impl Fn(&str) -> bool,
+    reason: &str,
+) -> usize {
+    use std::io::Write;
+
+    let state: State<'_, AgentProcesses> = app.state();
+    let children: Vec<_> = state
+        .children
+        .lock()
+        .map(|guard| {
+            guard
+                .iter()
+                .filter(|(key, _)| filter(key))
+                .map(|(key, child)| (key.clone(), Arc::clone(child)))
+                .collect()
+        })
+        .unwrap_or_default();
+    if children.is_empty() {
+        return 0;
+    }
+    let mut asked = 0usize;
+    let mut kill_keys = Vec::new();
+    for (key, child) in children {
+        let Ok(mut child) = child.lock() else {
+            kill_keys.push(key);
+            continue;
+        };
+        // Capture pid before the mutable borrow on `child.stdin`
+        // so we can log it without the borrow-checker complaining
+        // about overlapping immutable + mutable borrows of `child`.
+        let pid = child.id();
+        let write_result = match child.stdin.as_mut() {
+            Some(stdin) => {
+                writeln!(stdin, "{{\"type\":\"reload_request\"}}").and_then(|_| stdin.flush())
             }
-            if !kill_keys.is_empty() {
-                if let Ok(mut exits) = state.intentional_exits.lock() {
-                    for key in &kill_keys {
-                        exits.insert(key.clone());
-                    }
+            None => Err(std::io::Error::other("agent stdin closed")),
+        };
+        match write_result {
+            Ok(()) => {
+                // Mark the ask so a drain whose `_reload_done`
+                // sentinel gets lost still classifies its EOF as a
+                // reload rather than a crash.
+                if let Ok(mut pending) = state.pending_reloads.lock() {
+                    pending.insert(key.clone());
                 }
-                let mut guard = match state.children.lock() {
-                    Ok(guard) => guard,
-                    Err(_) => return,
-                };
-                for key in kill_keys {
-                    if let Some(dead) = guard.remove(&key)
-                        && let Ok(mut dead) = dead.lock()
-                    {
-                        let _ = dead.kill();
-                        let _ = dead.wait();
-                    }
-                }
-                let _ = app.emit("agent-reloaded", "");
+                asked += 1;
+                tracing::info!(
+                    target: "aethon::agent_watch",
+                    key = key,
+                    "asked pid={pid} to reload {reason}",
+                );
+            }
+            Err(err) => {
+                tracing::warn!(
+                    target: "aethon::agent_watch",
+                    key = key,
+                    "reload_request write failed for pid={pid}: {err}; falling back to kill",
+                );
+                kill_keys.push(key.clone());
             }
         }
     }
+    if !kill_keys.is_empty() {
+        if let Ok(mut exits) = state.intentional_exits.lock() {
+            for key in &kill_keys {
+                exits.insert(key.clone());
+            }
+        }
+        let Ok(mut guard) = state.children.lock() else {
+            return asked;
+        };
+        for key in kill_keys {
+            if let Some(dead) = guard.remove(&key)
+                && let Ok(mut dead) = dead.lock()
+            {
+                let _ = dead.kill();
+                let _ = dead.wait();
+            }
+        }
+        let _ = app.emit("agent-reloaded", "");
+    }
+    asked
+}
+
+/// Frontend-invoked after an in-process extension hot toggle on the
+/// global bridge: per-tab workers loaded their extensions at spawn, so
+/// they drain + lazily respawn with the fresh disabled list. The global
+/// bridge is excluded — it already applied the toggle without dying.
+#[tauri::command]
+pub(crate) fn request_worker_reloads(app: AppHandle) -> Result<usize, String> {
+    Ok(request_agent_reloads(
+        &app,
+        |key| key != GLOBAL_AGENT_KEY,
+        "(extension hot toggle: worker refresh)",
+    ))
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -229,6 +229,7 @@ pub fn run() {
             agent_commands::agent_broadcast_command,
             agent_commands::force_restart_agent,
             agent_commands::reload_agent,
+            commands::extensions::request_worker_reloads,
             agent_commands::agent_diagnostics,
             agent_commands::reconcile_agent_workers,
             agent_commands::dispatch_a2ui_event,

--- a/src-tauri/src/server/remote/policy.rs
+++ b/src-tauri/src/server/remote/policy.rs
@@ -51,6 +51,7 @@ pub const COMMAND_POLICIES: &[(&str, RemotePolicy)] = &[
     ("agent_broadcast_command", Deny(LIFECYCLE)),
     ("force_restart_agent", Deny(LIFECYCLE)),
     ("reload_agent", Deny(LIFECYCLE)),
+    ("request_worker_reloads", Deny(LIFECYCLE)),
     ("agent_diagnostics", Direct),
     ("reconcile_agent_workers", Deny(LIFECYCLE)),
     ("dispatch_a2ui_event", Direct),

--- a/src/gateway/commandPolicy.test.ts
+++ b/src/gateway/commandPolicy.test.ts
@@ -34,6 +34,7 @@ describe("mobile command policy", () => {
       // was a guaranteed policy Deny per project announcement at boot.
       "watch_project_extensions",
       "unwatch_project_extensions",
+      "request_worker_reloads",
       "updater_available",
       "write_state",
       "toggle_devtools",

--- a/src/gateway/commandPolicy.ts
+++ b/src/gateway/commandPolicy.ts
@@ -77,6 +77,10 @@ const STUB_EXACT = new Set<string>([
   // project announcement at boot.
   "watch_project_extensions",
   "unwatch_project_extensions",
+  // Worker refresh after an extension hot toggle: the desktop webview
+  // performs it; the companion receiving the broadcast must not burn a
+  // doomed Deny round-trip.
+  "request_worker_reloads",
   // Gateway-admin + control-plane: never driven from the phone.
   "server_status",
   "server_start",

--- a/src/hooks/bridgeMessageHandlers/index.ts
+++ b/src/hooks/bridgeMessageHandlers/index.ts
@@ -45,6 +45,7 @@ import { handleQueueReset } from "./queueReset";
 import { handleQueued } from "./queued";
 import { handleReady } from "./ready";
 import { handleReloadRequired } from "./reloadRequired";
+import { handleWorkerRefreshRequired } from "./workerRefreshRequired";
 import { handleRegisterHighlightGrammar } from "./registerHighlightGrammar";
 import { handleResponse } from "./response";
 import { handleResponseDelta } from "./responseDelta";
@@ -109,6 +110,7 @@ export const bridgeMessageHandlers: Readonly<
   queued: handleQueued,
   ready: handleReady,
   reload_required: handleReloadRequired,
+  worker_refresh_required: handleWorkerRefreshRequired,
   register_highlight_grammar: handleRegisterHighlightGrammar,
   response: handleResponse,
   response_delta: handleResponseDelta,

--- a/src/hooks/bridgeMessageHandlers/workerRefreshRequired.ts
+++ b/src/hooks/bridgeMessageHandlers/workerRefreshRequired.ts
@@ -1,0 +1,22 @@
+import { invoke } from "@tauri-apps/api/core";
+import type { BridgeMessageHandler } from "./types";
+
+/** The global bridge applied an extension toggle in process (no
+ *  restart), but per-tab workers loaded their extensions at spawn —
+ *  ask the shell to send each `tab:*` worker a `reload_request` so it
+ *  drains in-flight prompts and lazily respawns with the fresh
+ *  disabled list. The global bridge is untouched. */
+export const handleWorkerRefreshRequired: BridgeMessageHandler = (
+  data,
+  _ctx,
+) => {
+  const reason = (data.reason as string | undefined) ?? "unspecified";
+  invoke("request_worker_reloads").catch((err: unknown) => {
+    // Best-effort: a worker that misses the refresh still picks up the
+    // toggle on its next natural respawn (idle retire, cwd change).
+    console.warn(
+      `worker_refresh_required (${reason}): request_worker_reloads failed`,
+      err,
+    );
+  });
+};

--- a/src/hooks/mobileBootDefer.test.ts
+++ b/src/hooks/mobileBootDefer.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   MOBILE_BOOT_DEFER_MS,
   isMobileSurface,
+  resetMobileBootWindowForTest,
   scheduleAfterMobileBootWindow,
 } from "./mobileBootDefer";
 
@@ -22,6 +23,7 @@ describe("scheduleAfterMobileBootWindow", () => {
   it("defers past the boot window on mobile", () => {
     vi.stubEnv("VITE_AETHON_SURFACE", "mobile");
     vi.useFakeTimers();
+    resetMobileBootWindowForTest();
     expect(isMobileSurface()).toBe(true);
     const fn = vi.fn();
     scheduleAfterMobileBootWindow(fn);
@@ -32,9 +34,34 @@ describe("scheduleAfterMobileBootWindow", () => {
     expect(fn).toHaveBeenCalledTimes(1);
   });
 
+  it("fires at the END of the window, not a full window from call time", () => {
+    vi.stubEnv("VITE_AETHON_SURFACE", "mobile");
+    vi.useFakeTimers();
+    resetMobileBootWindowForTest();
+    // 8s into the window: the deferred run lands at the 10s mark.
+    vi.advanceTimersByTime(8_000);
+    const fn = vi.fn();
+    scheduleAfterMobileBootWindow(fn);
+    vi.advanceTimersByTime(MOBILE_BOOT_DEFER_MS - 8_000 - 1);
+    expect(fn).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs immediately when called after the window has passed", () => {
+    vi.stubEnv("VITE_AETHON_SURFACE", "mobile");
+    vi.useFakeTimers();
+    resetMobileBootWindowForTest();
+    vi.advanceTimersByTime(MOBILE_BOOT_DEFER_MS + 1);
+    const fn = vi.fn();
+    scheduleAfterMobileBootWindow(fn);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
   it("cancel prevents a deferred run (unmount before the window)", () => {
     vi.stubEnv("VITE_AETHON_SURFACE", "mobile");
     vi.useFakeTimers();
+    resetMobileBootWindowForTest();
     const fn = vi.fn();
     const cancel = scheduleAfterMobileBootWindow(fn);
     cancel();

--- a/src/hooks/mobileBootDefer.ts
+++ b/src/hooks/mobileBootDefer.ts
@@ -31,14 +31,17 @@ export function resetMobileBootWindowForTest(): void {
   bootStartedAt = Date.now();
 }
 
-/** Run `fn` immediately on desktop; on the mobile companion, delay it
- *  past the boot window. Returns a cancel function (no-op on desktop —
- *  `fn` already ran). */
+/** Run `fn` immediately on desktop (or once the window has already
+ *  passed); on the mobile companion inside the boot window, delay it to
+ *  the END of the window — not a full window from call time, so a call
+ *  8s into boot fires at ~10s, not ~18s. Returns a cancel function
+ *  (no-op when `fn` already ran). */
 export function scheduleAfterMobileBootWindow(fn: () => void): () => void {
-  if (!isMobileSurface()) {
+  const remaining = MOBILE_BOOT_DEFER_MS - (Date.now() - bootStartedAt);
+  if (!isMobileSurface() || remaining <= 0) {
     fn();
     return () => {};
   }
-  const timer = setTimeout(fn, MOBILE_BOOT_DEFER_MS);
+  const timer = setTimeout(fn, remaining);
   return () => clearTimeout(timer);
 }


### PR DESCRIPTION
## Summary

B2 — the endgame of the extension-toggle workstream. Stacked on #469 → retargets to main as the train merges. Toggling an extension no longer kills the bridge in the common case.

- **In-process apply** (`agent/extension-hot-toggle.ts`): run every registered teardown (the same guarded pattern as the project-switch unload), clear the wholly extension-owned registries, and re-run the exact boot load path (`loadAllExtensions` — ordering, baseline capture, and the single `resourceLoader.reload()` preserved **by construction**) with the updated disabled set; then re-emit the wholesale registry snapshot + a fresh ready. From an extension's view this is indistinguishable from the respawn it replaces; **sessions, MCP connections, and in-flight prompts survive untouched**.
- **Refusals → the (now cheap, via B1) respawn path**: pi-extension rows (bound into live sessions — the known stale-ctx crash class), worker bridges, concurrent toggles, hot-path failures, and the `AETHON_HOT_EXTENSION_TOGGLE=0` kill-switch.
- **Shared snapshot emit**: `emitExtensionRegistrySnapshot` extracted from `unloadProjectExtensions` — project switches and hot toggles now share one wholesale re-emit (unstamped from the global bridge = authoritative under origin gating).
- **Worker convergence**: new `worker_refresh_required` message → frontend invokes `request_worker_reloads` → each `tab:*` worker gets the existing drain protocol (`reload_request` → `_reload_done` → lazy respawn with the fresh disabled list) via `request_agent_reloads`, factored out of the file-watcher debounce worker. Remote policy: `Deny(LIFECYCLE)` + companion stub (policy lockstep enforced by the exhaustiveness test).
- Bonus robustness fix found by a headless boot probe: `readActiveProjectCwd` no longer fatals the bridge on `SQLITE_CANTOPEN` — it degrades to the on-disk `projects.json`.

**Measured context** (headless bridge probe, this machine): total bridge boot 3.6 s, of which `resourceLoader.reload()` is 3.2 s (88%) — an upstream pi cost (jiti re-execution of every `~/.pi` extension). The hot toggle pays that once in-process (~3.3 s total) instead of a full respawn (process spawn + session re-create + MCP reconnect + the 20 s-capped `wait_for_worker_ready` before the next prompt), and nothing user-visible dies.

## Test plan
- [x] Engine: disable applies (teardown ran, registries rebuilt, snapshot re-emitted, disabled skip surfaced); enable registers a previously-skipped extension; reload failure falls back AND releases the latch; pi/kill-switch/concurrency refusals
- [x] Control branch matrix: hot applied → `worker_refresh_required` and NO `reload_required`; fallback / pi / kill-switch / api-less → `reload_required`
- [x] Rust: policy exhaustiveness green; 617 lib tests
- [x] Full `check` green on the stack