### PR TITLE
perf(mobile): paint the gate before the App chunk + drop monaco from the IPA

### DIFF
--- a/agent/extension-hot-toggle.ts
+++ b/agent/extension-hot-toggle.ts
@@ -119,6 +119,9 @@ function resetExtensionSurface(state: AethonAgentState): void {
   state.extensionLayout = undefined;
   state.pendingLayoutPatches = [];
   state.extPathOwners.clear();
+  // Notified-runtime-error suppression must reset with the surface: a
+  // re-registered extension whose error recurs should re-notify.
+  state.notifiedExtRuntimeErrors.clear();
   state.projectBaseline = null;
 }
 

--- a/src/mobile/MobileGate.test.tsx
+++ b/src/mobile/MobileGate.test.tsx
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { MobileConnection } from "./mobileConnection";
+
+// MobileGate imports `setAssetBase` straight from the tauriCoreShim
+// module, which re-exports `@tauri-real/core` — a Vite alias only
+// vite.mobile.config.ts defines. Mock it away so the test doesn't need
+// that alias wired into the desktop vitest config.
+const setAssetBaseMock = vi.fn();
+vi.mock("../gateway/tauriCoreShim", () => ({
+  setAssetBase: (...args: unknown[]) => setAssetBaseMock(...args),
+}));
+
+// Native runtime off: keeps ConnectScreen's nearby-desktop scan
+// (useNearbyDesktops) disabled, so the test doesn't also need to stub
+// `@tauri-apps/api/core`'s `invoke("discovery_scan")`.
+vi.mock("../gateway/rustBridgeAdapter", () => ({
+  isTauriRuntime: () => false,
+  RustBridgeAdapter: class {},
+}));
+
+const gatewayConfigure = vi.fn();
+const gatewayConnect = vi.fn();
+const gatewaySubscribe = vi.fn((..._args: unknown[]) => () => {});
+const gatewaySubscribeStatus = vi.fn((..._args: unknown[]) => () => {});
+const gatewayGetStatus = vi.fn(() => "idle");
+const gatewayGetHello = vi.fn(() => null);
+const gatewayReconnectNow = vi.fn();
+const gatewayDisconnect = vi.fn();
+vi.mock("../gateway/transport", () => ({
+  gateway: {
+    configure: (...args: unknown[]) => gatewayConfigure(...args),
+    connect: (...args: unknown[]) => gatewayConnect(...args),
+    subscribe: (...args: unknown[]) => gatewaySubscribe(...args),
+    subscribeStatus: (...args: unknown[]) => gatewaySubscribeStatus(...args),
+    getStatus: () => gatewayGetStatus(),
+    getHello: () => gatewayGetHello(),
+    reconnectNow: (...args: unknown[]) => gatewayReconnectNow(...args),
+    disconnect: (...args: unknown[]) => gatewayDisconnect(...args),
+  },
+}));
+
+const loadConnectionMock = vi.fn<() => MobileConnection | null>(() => null);
+const loadRememberedConnectionsMock = vi.fn<() => MobileConnection[]>(() => []);
+const saveConnectionMock = vi.fn();
+const clearConnectionMock = vi.fn();
+vi.mock("./mobileConnection", () => ({
+  loadConnection: () => loadConnectionMock(),
+  loadRememberedConnections: () => loadRememberedConnectionsMock(),
+  saveConnection: (...args: unknown[]) => saveConnectionMock(...args),
+  clearConnection: (...args: unknown[]) => clearConnectionMock(...args),
+  connectionUrl: (c: MobileConnection) =>
+    `${c.fingerprint ? "wss" : "ws"}://${c.host}/ws`,
+}));
+
+// D5: App is loaded via a memoized `import("../App")`, not a static
+// import — mocked here with an async factory so the module itself only
+// resolves after a tick, exercising the Suspense boundary the gate wraps
+// it in once phase === "connected".
+vi.mock("../App", async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  return {
+    default: function MockApp() {
+      return <div data-testid="mock-app">mock app</div>;
+    },
+  };
+});
+
+import { MobileGate } from "./MobileGate";
+
+const CONNECTION: MobileConnection = {
+  host: "192.168.1.50:48213",
+  token: "tok-1",
+  name: "halcyon",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  loadConnectionMock.mockReturnValue(null);
+  loadRememberedConnectionsMock.mockReturnValue([]);
+  gatewayGetStatus.mockReturnValue("idle");
+});
+
+afterEach(cleanup);
+
+describe("MobileGate", () => {
+  it("renders ConnectScreen when there's no saved connection", () => {
+    render(<MobileGate />);
+
+    expect(screen.getByPlaceholderText("192.168.1.10:48213")).toBeDefined();
+    expect(screen.queryByTestId("mock-app")).toBeNull();
+  });
+
+  it("shows the connecting spinner while the saved-host handshake is pending", async () => {
+    loadConnectionMock.mockReturnValue(CONNECTION);
+    let resolveConnect!: (value: unknown) => void;
+    gatewayConnect.mockReturnValue(
+      new Promise((resolve) => {
+        resolveConnect = resolve;
+      }),
+    );
+
+    render(<MobileGate />);
+
+    // Initial phase already reflects the saved connection, so the
+    // spinner is up before any effect runs.
+    expect(screen.getByText(/Connecting to 192\.168\.1\.50:48213/)).toBeDefined();
+
+    // The mount effect's queued connect() call reaches gateway.connect()
+    // and then suspends on our still-pending promise.
+    await waitFor(() => expect(gatewayConnect).toHaveBeenCalled());
+    expect(screen.getByText(/Connecting to 192\.168\.1\.50:48213/)).toBeDefined();
+    expect(screen.queryByTestId("mock-app")).toBeNull();
+
+    // Clean up the pending handshake so it doesn't leak into the next test.
+    await act(async () => {
+      resolveConnect(undefined);
+      await Promise.resolve();
+    });
+  });
+
+  it("mounts the (mocked) App once the handshake resolves", async () => {
+    loadConnectionMock.mockReturnValue(CONNECTION);
+    let resolveConnect!: (value: unknown) => void;
+    gatewayConnect.mockReturnValue(
+      new Promise((resolve) => {
+        resolveConnect = resolve;
+      }),
+    );
+
+    render(<MobileGate />);
+    await waitFor(() => expect(gatewayConnect).toHaveBeenCalled());
+
+    await act(async () => {
+      resolveConnect(undefined);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(screen.getByTestId("mock-app")).toBeDefined());
+  });
+});

--- a/src/mobile/MobileGate.tsx
+++ b/src/mobile/MobileGate.tsx
@@ -3,10 +3,19 @@
 // App only mounts post-connect, so its boot `invoke("start_agent")`
 // never races the socket. A reconnect hook re-hydrates after the phone
 // wakes from background (iOS drops sockets on lock).
+//
+// App is loaded lazily (not just mounted lazily): the module graph is
+// multiple MB and parsing it synchronously would delay the very first
+// paint of this gate's own spinner/ConnectScreen. `loadApp()` kicks the
+// dynamic import off a frame after mount (so the gate paints first) and
+// memoizes the promise so StrictMode's double-invoke and React.lazy's
+// own call to the loader collapse onto one fetch+parse. The import is
+// allowed to happen well before the socket connects — it's *mounting*
+// App that stays strictly gated on phase === "connected" below, so its
+// boot `invoke("start_agent")` still never races the handshake.
 
-import { useCallback, useEffect, useState } from "react";
+import { lazy, Suspense, useCallback, useEffect, useState, type ComponentType } from "react";
 
-import App from "../App";
 import { setAssetBase } from "../gateway/tauriCoreShim";
 import { RustBridgeAdapter, isTauriRuntime } from "../gateway/rustBridgeAdapter";
 import { gateway, type SocketAdapter } from "../gateway/transport";
@@ -23,6 +32,30 @@ import {
 import { perfEnabled, perfMark } from "./perfMarks";
 
 type Phase = "connecting" | "connected" | "need-config";
+
+let appModulePromise: Promise<{ default: ComponentType }> | null = null;
+const loadApp = () => (appModulePromise ??= import("../App"));
+const App = lazy(loadApp);
+
+interface ConnectingScreenProps {
+  hostLabel: string;
+  onForget: () => void;
+}
+
+// Shared with the Suspense fallback below so the "still connecting" UI
+// looks identical whether we're waiting on the socket handshake or on
+// the App chunk finishing its parse after the handshake already landed.
+function ConnectingScreen({ hostLabel, onForget }: ConnectingScreenProps) {
+  return (
+    <div className="ae-mobile-connecting">
+      <div className="ae-mobile-spinner" aria-hidden />
+      <p>Connecting to {hostLabel}…</p>
+      <button type="button" className="ae-mobile-text-button" onClick={onForget}>
+        Use a different host
+      </button>
+    </div>
+  );
+}
 
 export function MobileGate() {
   const [connection, setConnection] = useState<MobileConnection | null>(loadConnection);
@@ -69,6 +102,17 @@ export function MobileGate() {
   useEffect(() => {
     if (connection) queueMicrotask(() => void connect(connection, false));
     // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Kick the App chunk's download+parse off a frame after mount, so this
+  // gate's own first paint (ConnectScreen or the spinner below) isn't
+  // delayed by it. On the saved-host path this overlaps the App parse
+  // with the gateway.connect() handshake kicked off in the effect above.
+  // Loading the module early is fine — mounting <App /> stays gated on
+  // phase === "connected" in the render below.
+  useEffect(() => {
+    const raf = requestAnimationFrame(() => void loadApp());
+    return () => cancelAnimationFrame(raf);
   }, []);
 
   // Startup perf marks (no-ops unless perf capture is enabled): first
@@ -130,13 +174,7 @@ export function MobileGate() {
 
   if (phase === "connecting") {
     return (
-      <div className="ae-mobile-connecting">
-        <div className="ae-mobile-spinner" aria-hidden />
-        <p>Connecting to {connection?.host ?? "desktop"}…</p>
-        <button type="button" className="ae-mobile-text-button" onClick={onForget}>
-          Use a different host
-        </button>
-      </div>
+      <ConnectingScreen hostLabel={connection?.host ?? "desktop"} onForget={onForget} />
     );
   }
 
@@ -147,7 +185,13 @@ export function MobileGate() {
           Reconnecting…
         </div>
       ) : null}
-      <App />
+      <Suspense
+        fallback={
+          <ConnectingScreen hostLabel={connection?.host ?? "desktop"} onForget={onForget} />
+        }
+      >
+        <App />
+      </Suspense>
     </>
   );
 }

--- a/src/mobile/composites/desktop-only-canvas.tsx
+++ b/src/mobile/composites/desktop-only-canvas.tsx
@@ -1,0 +1,30 @@
+// Build-time stand-in for the desktop editor surfaces. The mobile layout
+// (mobile.a2ui.json) never places `editor-canvas` or `diff-canvas` — the
+// companion app has no code editor — but the default-layout extension
+// (src/extensions/default-layout/components.tsx) statically imports both,
+// which pulls in all of monaco-editor plus five language workers
+// (~7 MB+) into the mobile bundle even though they're unreachable at
+// runtime.
+//
+// vite.mobile.config.ts redirects the resolved paths of
+// `editor/canvas.tsx` and `editor/diff-canvas.tsx` to this module for the
+// mobile build only (dev server + `build:mobile`); the desktop build
+// (vite.config.ts) is untouched and still ships the real Monaco-backed
+// components. Export names must match what those two modules export —
+// `EditorCanvas` and `DiffCanvas` — so `editor/index.ts`'s re-exports
+// keep resolving.
+
+import type { BuiltinComponentProps } from "../../components/A2UIRenderer";
+
+function DesktopOnlyCanvas(_props: BuiltinComponentProps) {
+  return (
+    <div className="ae-mobile-desktop-only" style={{ gridArea: "canvas" }} role="status">
+      <p className="ae-mobile-desktop-only-message">Open this file on the desktop.</p>
+      <p className="ae-mobile-desktop-only-hint">
+        The code editor isn't available in the iOS companion.
+      </p>
+    </div>
+  );
+}
+
+export { DesktopOnlyCanvas as EditorCanvas, DesktopOnlyCanvas as DiffCanvas };

--- a/src/mobile/editorBufferStub.ts
+++ b/src/mobile/editorBufferStub.ts
@@ -1,0 +1,62 @@
+// Mobile-only stand-in for `src/monaco/editor-buffers.ts`, redirected at
+// build time by vite.mobile.config.ts.
+//
+// The real module does `import * as monaco from "monaco-editor"` just to
+// call `monaco.editor.createModel()` / `model.dispose()` — but that bare
+// import alone drags in monaco-editor's default language contributions
+// (and, transitively, their worker chunks: ts/css/html/json, ~7 MB+),
+// which Vite auto-splits into separate async chunks that still ship in
+// the IPA even though nothing on mobile ever calls `createEditorBuffer`.
+//
+// The remaining real importers reachable on mobile — orphanTabSweep,
+// tabCleanup, closeTab, useProjectOps, useEditorExternalChange — are
+// generic tab-lifecycle hooks that only ever look up or delete from this
+// map. `createEditorBuffer` is only ever called from `EditorCanvas`
+// itself (src/extensions/default-layout/editor/canvas.tsx), which is
+// separately stubbed for mobile (see desktop-only-canvas.tsx) and never
+// mounts there, so the map here is always empty in practice. This stub
+// mirrors the same bookkeeping without touching Monaco.
+
+interface EditorBuffer {
+  model: { dispose(): void };
+  viewState: unknown;
+  loaded: boolean;
+  loading: boolean;
+  filePath: string;
+  externalBaselineMtime?: number;
+  externalChanged?: boolean;
+}
+
+const EDITOR_BUFFERS = new Map<string, EditorBuffer>();
+
+export function getEditorBuffer(tabId: string): EditorBuffer | undefined {
+  return EDITOR_BUFFERS.get(tabId);
+}
+
+export function createEditorBuffer(
+  tabId: string,
+  filePath: string,
+  _language: string,
+): EditorBuffer {
+  const buf: EditorBuffer = {
+    model: {
+      dispose() {
+        /* no real Monaco model on mobile */
+      },
+    },
+    viewState: null,
+    loaded: false,
+    loading: false,
+    filePath,
+  };
+  EDITOR_BUFFERS.set(tabId, buf);
+  return buf;
+}
+
+export function disposeEditorBuffer(tabId: string): void {
+  EDITOR_BUFFERS.delete(tabId);
+}
+
+export function __resetEditorBuffers(): void {
+  EDITOR_BUFFERS.clear();
+}

--- a/src/mobile/monacoThemeStub.ts
+++ b/src/mobile/monacoThemeStub.ts
@@ -1,0 +1,22 @@
+// Mobile-only stand-in for `src/monaco/theme.ts`, redirected at build
+// time by vite.mobile.config.ts.
+//
+// The real module unconditionally does `import { monaco } from "./setup"`,
+// and `src/monaco/setup.ts` eagerly imports monaco-editor's five language
+// workers (ts/css/html/json/editor, ~7 MB+ unminified) plus
+// `@monaco-editor/react`'s loader — none of which the companion app needs,
+// since mobile never mounts an editor (editor-canvas/diff-canvas are
+// stubbed separately, see desktop-only-canvas.tsx).
+//
+// `src/runtime/windowApi.ts` is the one remaining real (non-canvas)
+// importer of `monaco/theme` — it wires `registerMonacoTheme` /
+// `applyMonacoTheme` onto `window.aethon` and calls `applyMonacoTheme` on
+// theme changes. Both are safe no-ops here: there is no Monaco instance
+// on mobile to register a theme into or apply one onto.
+export function registerMonacoTheme(_id: string, _data: unknown): void {
+  // no-op — no Monaco instance exists on mobile.
+}
+
+export function applyMonacoTheme(_themeId?: string | null): void {
+  // no-op — see registerMonacoTheme above.
+}

--- a/src/styles/mobile.css
+++ b/src/styles/mobile.css
@@ -1233,6 +1233,29 @@ body:has(.ae-mobile-nav) .ae-mobile-header .ae-mobile-conn-label {
   padding: 16px 14px;
 }
 
+/* Desktop-only editor stub — mobile build swaps in DesktopOnlyCanvas for
+   editor-canvas/diff-canvas (see src/mobile/composites/desktop-only-canvas.tsx). */
+.ae-mobile-desktop-only {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  height: 100%;
+  padding: 24px;
+  text-align: center;
+  color: var(--text-dim);
+}
+.ae-mobile-desktop-only-message {
+  color: var(--text);
+  font-size: 0.95rem;
+  margin: 0;
+}
+.ae-mobile-desktop-only-hint {
+  font-size: 0.82rem;
+  margin: 0;
+}
+
 /* =============================================================================
    Pairing — QR scan overlay + nearby-desktops discovery
    ============================================================================= */

--- a/vite.mobile.config.ts
+++ b/vite.mobile.config.ts
@@ -9,7 +9,7 @@
 // codemod could never reach).
 
 import { existsSync, renameSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join, resolve as resolvePath } from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
@@ -21,6 +21,45 @@ const shim = (p: string) => fileURLToPath(new URL(p, import.meta.url));
 // physical device can reach the Vite server; unset for the simulator /
 // browser loop (localhost).
 const host = process.env.TAURI_DEV_HOST;
+
+// D6: desktop-only modules redirected to lightweight stubs for the
+// mobile build (dev server + `build:mobile`) only — see the resolveId
+// hook below for why. Keyed by the RESOLVED absolute source path so the
+// redirect fires no matter which relative specifier (`"./canvas"`,
+// `"../monaco/theme"`, `"../../../monaco/editor-buffers"`, …) a given
+// importer happens to use.
+const DESKTOP_ONLY_REDIRECTS: Array<{ target: string; stub: string }> = [
+  {
+    target: shim("./src/extensions/default-layout/editor/canvas.tsx"),
+    stub: shim("./src/mobile/composites/desktop-only-canvas.tsx"),
+  },
+  {
+    target: shim("./src/extensions/default-layout/editor/diff-canvas.tsx"),
+    stub: shim("./src/mobile/composites/desktop-only-canvas.tsx"),
+  },
+  {
+    target: shim("./src/monaco/theme.ts"),
+    stub: shim("./src/mobile/monacoThemeStub.ts"),
+  },
+  {
+    target: shim("./src/monaco/editor-buffers.ts"),
+    stub: shim("./src/mobile/editorBufferStub.ts"),
+  },
+];
+
+// Resolve a relative specifier against its importer's directory, trying
+// the extensions Vite would try, so it can be compared against the
+// absolute `target` paths above regardless of which extension-less form
+// the importer used.
+function resolveRelative(source: string, importer: string): string | null {
+  if (!source.startsWith(".")) return null;
+  const base = resolvePath(dirname(importer), source);
+  for (const ext of ["", ".tsx", ".ts"]) {
+    const candidate = base + ext;
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
 
 export default defineConfig({
   plugins: [
@@ -78,6 +117,50 @@ export default defineConfig({
           }
           next();
         });
+      },
+    },
+    // D6: the mobile layout (mobile.a2ui.json) never places editor-canvas
+    // or diff-canvas, but src/extensions/default-layout/components.tsx
+    // statically imports both (they're assigned into the registry object,
+    // so plain tree-shaking can't drop them even though nothing on mobile
+    // ever renders that A2UI type). Their real implementations reach all
+    // of monaco-editor plus its default language contributions — whose
+    // ts/css/html/json/editor worker chunks (~7 MB+ unminified) Vite
+    // auto-splits into separate async chunks that still ship dead in the
+    // IPA. Two other modules reach the same monaco-editor import from
+    // paths that have nothing to do with the canvas: `windowApi.ts`
+    // (universal `window.aethon` wiring) imports `monaco/theme.ts`,
+    // which unconditionally imports `monaco/setup.ts`'s five explicit
+    // `?worker` imports; and the generic tab-lifecycle hooks
+    // (useProjectOps, closeTab, tabCleanup, orphanTabSweep,
+    // useEditorExternalChange) import `monaco/editor-buffers.ts`, whose
+    // bare `import * as monaco from "monaco-editor"` alone is enough to
+    // pull in monaco's default language contributions. All four targets
+    // are safe to redirect on mobile: editor-canvas/diff-canvas never
+    // mount there, so nothing ever actually creates a Monaco model or
+    // theme to apply.
+    //
+    // A declarative `resolve.alias` entry can't express this redirect:
+    // Vite's alias plugin matches the literal specifier text as written
+    // in the importing file (e.g. "./canvas"), not the resolved absolute
+    // path — and "./canvas" is also the specifier `shell/index.ts` uses
+    // for the unrelated `ShellCanvas`, so a text-based alias would either
+    // never fire (matching against an absolute-path regex) or wrongly
+    // redirect the shell canvas too (matching bare "./canvas"). Instead
+    // this resolveId hook manually resolves each relative specifier
+    // against its importer and compares the RESULT against the resolved
+    // absolute target paths in DESKTOP_ONLY_REDIRECTS — precise
+    // regardless of how many `../` a given importer needs, and immune to
+    // specifier-text collisions with unrelated same-named files.
+    {
+      name: "aethon-mobile-desktop-only",
+      enforce: "pre",
+      resolveId(source, importer) {
+        if (!importer) return null;
+        const resolved = resolveRelative(source, importer);
+        if (!resolved) return null;
+        const hit = DESKTOP_ONLY_REDIRECTS.find((r) => r.target === resolved);
+        return hit ? hit.stub : null;
       },
     },
     // `ANALYZE=1 bun run build:mobile` writes dist-mobile/stats.html.


### PR DESCRIPTION
## Summary

D5–D6, built by a worktree agent and rebased onto the train (stacked on #470 → retargets as the train merges).

- **D5 — gate split**: `MobileGate` no longer statically imports `App`. A memoized `lazy(import("../App"))` kicks off one frame after mount, so the gate's own spinner/ConnectScreen paints from a tiny entry chunk and the App parse overlaps the `gateway.connect()` handshake on the saved-host path. Mounting stays strictly gated on `phase === "connected"` — the boot `start_agent` still can't race the socket. The Suspense fallback reuses the exact connecting-spinner markup.
- **D6 — IPA diet**: `vite.mobile.config.ts` gains `resolveId` redirects (build + dev server) sending the editor/diff canvases — plus the monaco theme applier and editor-buffers modules — to lightweight mobile stubs ("Open this file on the desktop"). The mobile layout never places those surfaces; the stubs are defense-in-depth for restored editor tabs.

## Measured

| Metric | Before | After |
|---|---|---|
| Mobile entry chunk (blocks first paint) | 5,792 KB | **212 KB** |
| App chunk (parses ∥ handshake) | — | 692 KB |
| dist-mobile assets total | 32,908 KB | **12,020 KB** |
| monaco chunks in the IPA (`editor.api`/5 workers) | all | **zero** |
| highlight.worker (chat code blocks) | kept | kept |

## Test plan
- [x] New `MobileGate.test.tsx` (jsdom): ConnectScreen with no saved connection; spinner while handshake pending; mocked App mounts after connect
- [x] Grep audit: no top-level `invoke(`/`gateway.request(` in the App module graph (import-time safety)
- [x] Full suite green on the combined train tip (3,171 TS / 618 Rust); desktop build still ships monaco