### PR TITLE
perf(boot): optimistic chrome for built-ins-only sessions (cached snapshot gate + kill-switch)

### DIFF
--- a/src-tauri/src/helpers/config.rs
+++ b/src-tauri/src/helpers/config.rs
@@ -245,6 +245,16 @@ pub struct GuardrailsConfig {
 }
 
 #[derive(Default, Deserialize)]
+pub struct BootConfig {
+    /// Kill-switch for optimistic chrome. When `true` (default), a
+    /// built-ins-only session caches a boot snapshot so the next cold boot
+    /// paints the workstation before the agent bridge is ready. `false`
+    /// disables the optimization — the StartupCurtain always shows until the
+    /// bridge reports `ready`. Consumed frontend-side.
+    pub optimistic_chrome: Option<bool>,
+}
+
+#[derive(Default, Deserialize)]
 pub struct AethonConfig {
     #[serde(default)]
     pub ui: UiConfig,
@@ -270,6 +280,8 @@ pub struct AethonConfig {
     pub mcp: McpHostConfig,
     #[serde(default)]
     pub guardrails: GuardrailsConfig,
+    #[serde(default)]
+    pub boot: BootConfig,
 }
 
 /// Validate-and-normalize a tri-state thinking visibility value
@@ -580,6 +592,9 @@ pub fn parse_config_toml(input: &str) -> serde_json::Value {
             "softPromptAnchor": soft_prompt_anchor,
             "hardEnforceProjectRoot": hard_enforce_project_root,
         },
+        "boot": {
+            "optimisticChrome": cfg.boot.optimistic_chrome.unwrap_or(true),
+        },
     })
 }
 
@@ -721,6 +736,19 @@ mod tests {
         assert_eq!(
             parse_config_toml("[server]\nenabled = false\n")["server"]["enabled"],
             false
+        );
+    }
+
+    #[test]
+    fn boot_optimistic_chrome_defaults_true_and_honors_override() {
+        assert_eq!(parse_config_toml("")["boot"]["optimisticChrome"], true);
+        assert_eq!(
+            parse_config_toml("[boot]\noptimistic_chrome = false\n")["boot"]["optimisticChrome"],
+            false
+        );
+        assert_eq!(
+            parse_config_toml("[boot]\noptimistic_chrome = true\n")["boot"]["optimisticChrome"],
+            true
         );
     }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,7 +66,10 @@ import { useUpdaterConfigBridge } from "./hooks/useUpdaterConfigBridge";
 import { closeAllWorkspaceSessions } from "./hooks/tabOps/closeWorkspaceSessions";
 import type { NativeCanvasWindowRecord } from "./nativeWindows";
 import { writeState } from "./persist";
-import { shouldPaintChromeOptimistically } from "./state/chromeBootSnapshot";
+import {
+  clearChromeBootSnapshot,
+  shouldPaintChromeOptimistically,
+} from "./state/chromeBootSnapshot";
 import { useAppState } from "./state/appStore";
 import { activeWorkspaceCwd } from "./utils/activeWorkspaceRoot";
 import pkg from "../package.json" with { type: "json" };
@@ -144,6 +147,9 @@ export default function App() {
   const [startupChromeReady, setStartupChromeReady] = useState(() =>
     shouldPaintChromeOptimistically(),
   );
+  // True once the bridge's real `ready` confirmed the chrome — after
+  // that, the kill-switch revoke below must never hide working chrome.
+  const bridgeConfirmedChromeRef = useRef(false);
   const {
     stateRef,
     projectsRef,
@@ -190,7 +196,22 @@ export default function App() {
     shellInheritEnvRef,
     shellPromptBeforeCloseRef,
     reapplyConfig,
-  } = useBootConfig({ setState, piDefaultModelRef });
+  } = useBootConfig({
+    setState,
+    piDefaultModelRef,
+    // Kill-switch reconciliation: a stale built-ins-only snapshot can
+    // seed the optimistic paint before the config is readable. This
+    // callback runs in the same batch that flips bootConfigReady (the
+    // other half of the chromeReady AND), so revoking here means the
+    // disabled launch never paints optimistically — no flash. Skipped
+    // once the bridge's real ready confirmed the chrome.
+    onBootConfig: (config) => {
+      if (config.boot?.optimisticChrome === false) {
+        clearChromeBootSnapshot();
+        if (!bridgeConfirmedChromeRef.current) setStartupChromeReady(false);
+      }
+    },
+  });
 
   // ---------------------------------------------------------------------
   // UI zoom + theme switching are owned by useZoomAndTheme. The hook
@@ -825,6 +846,7 @@ export default function App() {
     sendChat,
     markStartupChromeReady: () => {
       bootMark("agent-ready");
+      bridgeConfirmedChromeRef.current = true;
       setStartupChromeReady(true);
     },
   });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,6 +66,7 @@ import { useUpdaterConfigBridge } from "./hooks/useUpdaterConfigBridge";
 import { closeAllWorkspaceSessions } from "./hooks/tabOps/closeWorkspaceSessions";
 import type { NativeCanvasWindowRecord } from "./nativeWindows";
 import { writeState } from "./persist";
+import { shouldPaintChromeOptimistically } from "./state/chromeBootSnapshot";
 import { useAppState } from "./state/appStore";
 import { activeWorkspaceCwd } from "./utils/activeWorkspaceRoot";
 import pkg from "../package.json" with { type: "json" };
@@ -128,7 +129,21 @@ export default function App() {
   // by calling window.aethon.setLayout(payload), or register a new extension via
   // window.aethon.registerExtension(extension) and switch to its layout.
   const [layout, setLayout] = useState<A2UIPayload>(BOOT_LAYOUT);
-  const [startupChromeReady, setStartupChromeReady] = useState(false);
+  // Optimistic chrome (perf/c4): when the previous run used only built-in
+  // chrome (recorded in a localStorage boot snapshot), seed this true so the
+  // workstation paints immediately instead of holding the StartupCurtain
+  // until the agent bridge's `ready` arrives. `markStartupChromeReady`
+  // (wired into useAppBridgeMessages) stays the reconciliation step — it
+  // idempotently confirms readiness once the bridge boots. Sessions that used
+  // an extension layout/frontend-module/theme record that fact and keep the
+  // curtain, so there is provably no layout/theme flash for extension users.
+  // Painting pre-`ready` exposes the composer early, but a send before ready
+  // is safe: /status seeds "starting…" (not "ready"), and Rust `send_message`
+  // → `write_agent_payload` lazily spawns the bridge and awaits worker-ready
+  // before writing to its stdin, so the message is delivered, not dropped.
+  const [startupChromeReady, setStartupChromeReady] = useState(() =>
+    shouldPaintChromeOptimistically(),
+  );
   const {
     stateRef,
     projectsRef,

--- a/src/config.ts
+++ b/src/config.ts
@@ -166,6 +166,15 @@ export interface AethonConfig {
      *  the active tab's project root. Default false. Per-tab overridable. */
     hardEnforceProjectRoot: boolean;
   };
+  /** `[boot]` section. Optional so config fixtures that predate it still
+   *  satisfy the type; `getConfig()` always populates it. */
+  boot?: {
+    /** Kill-switch for optimistic chrome. When true (default), a built-ins-
+     *  only session caches a boot snapshot so the next cold boot paints the
+     *  workstation before the bridge is ready. `false` disables that — the
+     *  StartupCurtain always shows until the bridge's `ready` arrives. */
+    optimisticChrome: boolean;
+  };
 }
 
 export const DEFAULT_AGENT_TIMEOUT_SECONDS = 300;
@@ -238,6 +247,9 @@ const DEFAULTS: AethonConfig = {
     softPromptAnchor: null,
     hardEnforceProjectRoot: false,
   },
+  boot: {
+    optimisticChrome: true,
+  },
 };
 
 function hasTauri(): boolean {
@@ -250,6 +262,19 @@ function hasTauri(): boolean {
 
 let inflight: Promise<AethonConfig> | null = null;
 
+/** Last successfully-resolved config, for synchronous reads by callers that
+ *  can't await (e.g. the bridge `ready` handler deciding whether to persist
+ *  the optimistic-chrome boot snapshot). `getConfig()` resolves well before
+ *  `ready` fires, so this is populated by then; `null` (never resolved) is
+ *  treated as "defaults" by consumers. */
+let lastResolved: AethonConfig | null = null;
+
+/** Synchronously read the last-resolved config, or `null` if `getConfig()`
+ *  hasn't resolved yet. Does not trigger a read. */
+export function getResolvedConfig(): AethonConfig | null {
+  return lastResolved;
+}
+
 /** Drop the in-memory config cache so the next `getConfig()` call
  *  re-reads from disk. Call after writing the config (Settings panel
  *  Save) so subsequent reads see fresh values without a page reload. */
@@ -260,6 +285,7 @@ export function clearConfigCache(): void {
 export function getConfig(): Promise<AethonConfig> {
   if (inflight) return inflight;
   if (!hasTauri()) {
+    lastResolved = DEFAULTS;
     inflight = Promise.resolve(DEFAULTS);
     return inflight;
   }
@@ -267,7 +293,7 @@ export function getConfig(): Promise<AethonConfig> {
     try {
       const raw = await invoke<unknown>("read_config");
       const obj = raw as Partial<AethonConfig>;
-      return {
+      const resolved: AethonConfig = {
         ui: {
           theme: normalizeTheme(obj?.ui?.theme),
           fontSize:
@@ -366,17 +392,16 @@ export function getConfig(): Promise<AethonConfig> {
               ? obj.voice.brainModel.trim()
               : null,
           sttProvider:
-            typeof obj?.voice?.sttProvider === "string" &&
-            obj.voice.sttProvider
+            typeof obj?.voice?.sttProvider === "string" && obj.voice.sttProvider
               ? obj.voice.sttProvider
               : DEFAULTS.voice.sttProvider,
           ttsProvider:
-            typeof obj?.voice?.ttsProvider === "string" &&
-            obj.voice.ttsProvider
+            typeof obj?.voice?.ttsProvider === "string" && obj.voice.ttsProvider
               ? obj.voice.ttsProvider
               : DEFAULTS.voice.ttsProvider,
           ttsVoice:
-            typeof obj?.voice?.ttsVoice === "string" && obj.voice.ttsVoice.trim()
+            typeof obj?.voice?.ttsVoice === "string" &&
+            obj.voice.ttsVoice.trim()
               ? obj.voice.ttsVoice.trim()
               : null,
           deepgramApiKeySet: obj?.voice?.deepgramApiKeySet === true,
@@ -416,9 +441,16 @@ export function getConfig(): Promise<AethonConfig> {
           hardEnforceProjectRoot:
             obj?.guardrails?.hardEnforceProjectRoot === true,
         },
+        boot: {
+          // Default true — only an explicit `false` disables optimistic chrome.
+          optimisticChrome: obj?.boot?.optimisticChrome !== false,
+        },
       };
+      lastResolved = resolved;
+      return resolved;
     } catch (err) {
       console.warn("read_config failed:", err);
+      lastResolved = DEFAULTS;
       return DEFAULTS;
     }
   })();

--- a/src/hooks/bridgeMessageHandlers/ready.test.ts
+++ b/src/hooks/bridgeMessageHandlers/ready.test.ts
@@ -1,14 +1,35 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { handleReady } from "./ready";
-import {
-  flushDeferredTabOpen,
-  resetReplayedTabsForTest,
-} from "./readyEffects";
+import { flushDeferredTabOpen, resetReplayedTabsForTest } from "./readyEffects";
 import { buildHandlerFixture } from "./testFixtures";
 import { clearTauriMocks, installTauriMocks } from "../../test/tauriMocks";
 import { makeEmptyTab } from "../../types/tab";
 import { defaultLayoutExtension } from "../../extensions/default-layout";
 import * as highlight from "../../utils/highlight";
+import {
+  __testing as chromeBootTesting,
+  readChromeBootSnapshot,
+  shouldPaintChromeOptimistically,
+} from "../../state/chromeBootSnapshot";
+
+/** Map-backed Storage for the node test env (no real localStorage). */
+function makeFakeStorage(): Storage {
+  const m = new Map<string, string>();
+  return {
+    get length() {
+      return m.size;
+    },
+    clear: () => m.clear(),
+    getItem: (k: string) => (m.has(k) ? (m.get(k) as string) : null),
+    key: (i: number) => Array.from(m.keys())[i] ?? null,
+    removeItem: (k: string) => {
+      m.delete(k);
+    },
+    setItem: (k: string, v: string) => {
+      m.set(k, String(v));
+    },
+  };
+}
 
 describe("handleReady", () => {
   let grammarSpy: ReturnType<typeof vi.spyOn> | undefined;
@@ -221,7 +242,14 @@ describe("handleReady", () => {
             id: "openai/gpt-5.5",
             label: "GPT-5.5",
             provider: "openai",
-            thinkingLevels: ["off", "minimal", "low", "medium", "high", "xhigh"],
+            thinkingLevels: [
+              "off",
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+            ],
           },
         ],
         extensionStateKeys: [],
@@ -929,6 +957,90 @@ describe("handleReady", () => {
         cwd: "/repo/a-fix-session-restore",
       }),
     ]);
+  });
+
+  describe("optimistic chrome boot snapshot", () => {
+    beforeEach(() => {
+      // Node env has no localStorage; inject a fake so the ready handler's
+      // best-effort snapshot write is observable.
+      chromeBootTesting.setStorage(makeFakeStorage());
+    });
+    afterEach(() => {
+      chromeBootTesting.reset();
+    });
+
+    it("records a built-ins-only session so the next boot paints optimistically", () => {
+      const { ctx } = buildHandlerFixture({
+        state: {
+          activeTabId: "default",
+          tabs: [{ id: "default", model: "" }],
+          sidebar: {},
+        },
+      });
+      handleReady(
+        {
+          type: "ready",
+          model: "claude",
+          models: [],
+          tabs: [{ id: "default", model: "claude" }],
+        },
+        ctx,
+      );
+      expect(readChromeBootSnapshot()).toEqual({
+        customLayout: false,
+        frontendModules: false,
+        extTheme: false,
+      });
+      expect(shouldPaintChromeOptimistically()).toBe(true);
+    });
+
+    it("records a custom extension layout so the next boot keeps the curtain", () => {
+      const { ctx } = buildHandlerFixture({
+        state: {
+          activeTabId: "default",
+          tabs: [{ id: "default", model: "" }],
+          sidebar: {},
+        },
+      });
+      handleReady(
+        {
+          type: "ready",
+          model: "claude",
+          models: [],
+          // A valid extension layout (object with a components array) is
+          // adopted as the base layout — the "custom chrome" signal.
+          extensionLayout: {
+            components: [{ id: "root", type: "container" }],
+          },
+          tabs: [{ id: "default", model: "claude" }],
+        },
+        ctx,
+      );
+      expect(readChromeBootSnapshot()?.customLayout).toBe(true);
+      expect(shouldPaintChromeOptimistically()).toBe(false);
+    });
+
+    it("records extension frontend modules so the next boot keeps the curtain", () => {
+      const { ctx } = buildHandlerFixture({
+        state: {
+          activeTabId: "default",
+          tabs: [{ id: "default", model: "" }],
+          sidebar: {},
+        },
+      });
+      handleReady(
+        {
+          type: "ready",
+          model: "claude",
+          models: [],
+          extensionFrontendModules: [{ name: "widget", code: "export {}" }],
+          tabs: [{ id: "default", model: "claude" }],
+        },
+        ctx,
+      );
+      expect(readChromeBootSnapshot()?.frontendModules).toBe(true);
+      expect(shouldPaintChromeOptimistically()).toBe(false);
+    });
   });
 
   it("does not backfill bridge tabs into the visible project bucket", () => {

--- a/src/hooks/bridgeMessageHandlers/ready.ts
+++ b/src/hooks/bridgeMessageHandlers/ready.ts
@@ -1,5 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import type { A2UIPayload } from "../../types/a2ui";
+import { getResolvedConfig } from "../../config";
+import { writeChromeBootSnapshot } from "../../state/chromeBootSnapshot";
 import { activeProject } from "../../projects";
 import type { Tab } from "../../types/tab";
 import {
@@ -272,4 +274,42 @@ export const handleReady: BridgeMessageHandler = (data, ctx) => {
     priorActiveTabId,
     bridgeTabIds: new Set(bridgeTabs.map((t) => t.id)),
   });
+  // Cache a boot snapshot for the NEXT cold boot's optimistic-chrome gate
+  // (perf/c4). Records whether THIS run used any custom extension chrome so
+  // the next launch can paint the built-in workstation before the bridge is
+  // ready without risking a flash for extension users. Desktop-only: the
+  // mobile surface always forces the boot layout, so we never write a
+  // snapshot there and its curtain path stays byte-identical. Best-effort —
+  // `getResolvedConfig()` / localStorage hiccups must never break ready
+  // ingestion.
+  if (!mobileSurface) {
+    try {
+      // Active theme id is the same source hydrateThemes reads. If it names
+      // an extension theme we can't cheaply re-inject its CSS at boot, so
+      // record it and take the curtain next time (built-in themes are applied
+      // pre-paint by the boot config pass, so they never flash).
+      const activeThemeId =
+        typeof document !== "undefined"
+          ? document.documentElement.dataset.theme
+          : undefined;
+      const extThemeActive = Boolean(
+        activeThemeId && extThemes.some((t) => t.id === activeThemeId),
+      );
+      writeChromeBootSnapshot(
+        {
+          // baseLayout === bootLayout means no (valid) extension layout was
+          // applied — the precise "did we render built-in chrome" signal.
+          customLayout: baseLayout !== ctx.bootLayout,
+          frontendModules: extFrontendModules.length > 0,
+          extTheme: extThemeActive,
+        },
+        {
+          optimisticChrome:
+            getResolvedConfig()?.boot?.optimisticChrome !== false,
+        },
+      );
+    } catch {
+      /* boot snapshot is a pure optimization; ignore failures */
+    }
+  }
 };

--- a/src/hooks/useBootConfig.ts
+++ b/src/hooks/useBootConfig.ts
@@ -19,6 +19,12 @@ import {
 export interface UseBootConfigContext {
   setState: Dispatch<SetStateAction<Record<string, unknown>>>;
   piDefaultModelRef: MutableRefObject<string>;
+  /** Runs with the freshly-read config in the same async continuation
+   *  that flips `bootConfigReady`, so any state it sets batches with
+   *  the ready flip (React auto-batching) and renders atomically with
+   *  it. App uses this to revoke an optimistic-chrome seed when
+   *  `[boot] optimistic_chrome = false` outlives a stale snapshot. */
+  onBootConfig?: (config: AethonConfig) => void;
 }
 
 export interface UseBootConfigActions {
@@ -283,6 +289,7 @@ export function useBootConfig(ctx: UseBootConfigContext): UseBootConfigActions {
         if (Number.isFinite(z) && z >= 0.7 && z <= 1.6) {
           applyUiScale(z);
         }
+        ctx.onBootConfig?.(config);
       } finally {
         if (!cancelled) setBootConfigReady(true);
       }

--- a/src/state/chromeBootSnapshot.test.ts
+++ b/src/state/chromeBootSnapshot.test.ts
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  __testing,
+  clearChromeBootSnapshot,
+  readChromeBootSnapshot,
+  shouldPaintChromeOptimistically,
+  writeChromeBootSnapshot,
+  type ChromeBootSnapshot,
+} from "./chromeBootSnapshot";
+
+const KEY = __testing.STORAGE_KEY;
+
+const builtinsOnly: ChromeBootSnapshot = {
+  customLayout: false,
+  frontendModules: false,
+  extTheme: false,
+};
+
+describe("chromeBootSnapshot", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+  afterEach(() => {
+    localStorage.clear();
+    __testing.reset();
+  });
+
+  it("round-trips a built-ins-only snapshot and paints optimistically", () => {
+    writeChromeBootSnapshot(builtinsOnly, { optimisticChrome: true });
+    expect(readChromeBootSnapshot()).toEqual(builtinsOnly);
+    expect(shouldPaintChromeOptimistically()).toBe(true);
+  });
+
+  it("does not paint optimistically when a custom layout was recorded", () => {
+    writeChromeBootSnapshot(
+      { ...builtinsOnly, customLayout: true },
+      { optimisticChrome: true },
+    );
+    expect(shouldPaintChromeOptimistically()).toBe(false);
+  });
+
+  it("does not paint optimistically when frontend modules were recorded", () => {
+    writeChromeBootSnapshot(
+      { ...builtinsOnly, frontendModules: true },
+      { optimisticChrome: true },
+    );
+    expect(shouldPaintChromeOptimistically()).toBe(false);
+  });
+
+  it("does not paint optimistically when an extension theme was active", () => {
+    writeChromeBootSnapshot(
+      { ...builtinsOnly, extTheme: true },
+      { optimisticChrome: true },
+    );
+    expect(shouldPaintChromeOptimistically()).toBe(false);
+  });
+
+  it("returns false and null when no snapshot exists", () => {
+    expect(readChromeBootSnapshot()).toBeNull();
+    expect(shouldPaintChromeOptimistically()).toBe(false);
+  });
+
+  it("treats malformed JSON as absent", () => {
+    localStorage.setItem(KEY, "{ not valid json");
+    expect(readChromeBootSnapshot()).toBeNull();
+    expect(shouldPaintChromeOptimistically()).toBe(false);
+  });
+
+  it("treats a wrong-shaped record as absent", () => {
+    localStorage.setItem(KEY, JSON.stringify({ customLayout: "yes" }));
+    expect(readChromeBootSnapshot()).toBeNull();
+    expect(shouldPaintChromeOptimistically()).toBe(false);
+  });
+
+  it("kill-switch off clears any stored snapshot at write time", () => {
+    writeChromeBootSnapshot(builtinsOnly, { optimisticChrome: true });
+    expect(readChromeBootSnapshot()).not.toBeNull();
+    // A subsequent write with the kill-switch off removes the record so the
+    // next boot can't paint optimistically off a stale snapshot.
+    writeChromeBootSnapshot(builtinsOnly, { optimisticChrome: false });
+    expect(readChromeBootSnapshot()).toBeNull();
+    expect(shouldPaintChromeOptimistically()).toBe(false);
+  });
+
+  it("clearChromeBootSnapshot removes the record", () => {
+    writeChromeBootSnapshot(builtinsOnly, { optimisticChrome: true });
+    clearChromeBootSnapshot();
+    expect(readChromeBootSnapshot()).toBeNull();
+  });
+
+  it("never throws when storage is unavailable", () => {
+    __testing.setStorage(null);
+    expect(() =>
+      writeChromeBootSnapshot(builtinsOnly, { optimisticChrome: true }),
+    ).not.toThrow();
+    expect(readChromeBootSnapshot()).toBeNull();
+    expect(shouldPaintChromeOptimistically()).toBe(false);
+    expect(() => clearChromeBootSnapshot()).not.toThrow();
+  });
+
+  it("swallows storage setItem failures", () => {
+    const throwing: Storage = {
+      length: 0,
+      clear: () => {},
+      getItem: () => null,
+      key: () => null,
+      removeItem: () => {},
+      setItem: () => {
+        throw new Error("quota exceeded");
+      },
+    };
+    __testing.setStorage(throwing);
+    expect(() =>
+      writeChromeBootSnapshot(builtinsOnly, { optimisticChrome: true }),
+    ).not.toThrow();
+  });
+});

--- a/src/state/chromeBootSnapshot.ts
+++ b/src/state/chromeBootSnapshot.ts
@@ -1,0 +1,122 @@
+// Cached prediction of what the NEXT cold boot will look like, so App can
+// paint the built-in workstation immediately instead of holding the
+// StartupCurtain until the agent bridge finishes booting. Written from the
+// bridge `ready` handler with the facts about THIS run; read synchronously
+// at App mount. A run that used any custom extension chrome (an extension
+// layout, extension frontend modules, or an active extension theme) records
+// that fact so the next boot keeps today's curtain and never flashes the
+// wrong layout/theme. Every read/write is best-effort — localStorage can
+// throw (private mode, quota, disabled storage) and a hiccup here must never
+// affect boot correctness.
+
+const STORAGE_KEY = "aethon-chrome-boot";
+
+export interface ChromeBootSnapshot {
+  /** Previous run applied an extension-provided layout (not the built-in
+   *  boot layout). Built-in chrome would paint the wrong grid. */
+  customLayout: boolean;
+  /** Previous run registered extension frontend modules (custom React
+   *  components in the ExtensionRegistry). */
+  frontendModules: boolean;
+  /** Previous run's active theme was an extension theme. Conservative v1:
+   *  extension theme CSS is NOT re-injected at boot (fragile to capture),
+   *  so an active extension theme forces the curtain to avoid a first-paint
+   *  theme flash. Built-in themes are applied before paint by the boot
+   *  config pass (`bootConfigReady`), so they never flash. */
+  extTheme: boolean;
+}
+
+// Test seam: node-env unit tests have no `localStorage`. `undefined` means
+// "resolve the real one"; an explicit value (including `null`) overrides.
+let storageOverride: Storage | null | undefined;
+
+function resolveStorage(): Storage | null {
+  if (storageOverride !== undefined) return storageOverride;
+  try {
+    return typeof localStorage !== "undefined" ? localStorage : null;
+  } catch {
+    return null;
+  }
+}
+
+export interface WriteChromeBootSnapshotOptions {
+  /** `[boot] optimistic_chrome` kill-switch. `false` clears any stored
+   *  snapshot so the next boot takes the curtain path unconditionally. */
+  optimisticChrome: boolean;
+}
+
+/** Persist the boot snapshot for the next launch. When the kill-switch is
+ *  off, remove any prior snapshot so a stale record can't keep optimism on. */
+export function writeChromeBootSnapshot(
+  snapshot: ChromeBootSnapshot,
+  { optimisticChrome }: WriteChromeBootSnapshotOptions,
+): void {
+  const store = resolveStorage();
+  if (!store) return;
+  try {
+    if (!optimisticChrome) {
+      store.removeItem(STORAGE_KEY);
+      return;
+    }
+    store.setItem(STORAGE_KEY, JSON.stringify(snapshot));
+  } catch {
+    /* best-effort */
+  }
+}
+
+/** Read the last persisted snapshot. Missing or malformed → null. */
+export function readChromeBootSnapshot(): ChromeBootSnapshot | null {
+  const store = resolveStorage();
+  if (!store) return null;
+  try {
+    const raw = store.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object") return null;
+    const rec = parsed as Record<string, unknown>;
+    if (
+      typeof rec.customLayout !== "boolean" ||
+      typeof rec.frontendModules !== "boolean" ||
+      typeof rec.extTheme !== "boolean"
+    ) {
+      return null;
+    }
+    return {
+      customLayout: rec.customLayout,
+      frontendModules: rec.frontendModules,
+      extTheme: rec.extTheme,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function clearChromeBootSnapshot(): void {
+  const store = resolveStorage();
+  if (!store) return;
+  try {
+    store.removeItem(STORAGE_KEY);
+  } catch {
+    /* best-effort */
+  }
+}
+
+/** True iff the previous run recorded a built-ins-only session — no
+ *  extension layout, no extension frontend modules, no active extension
+ *  theme. Never throws (missing/malformed snapshot → false → curtain). */
+export function shouldPaintChromeOptimistically(): boolean {
+  const snap = readChromeBootSnapshot();
+  if (!snap) return false;
+  return !snap.customLayout && !snap.frontendModules && !snap.extTheme;
+}
+
+/** Test-only: inject a storage backend (node env has no localStorage). */
+export const __testing = {
+  setStorage(store: Storage | null): void {
+    storageOverride = store;
+  },
+  reset(): void {
+    storageOverride = undefined;
+  },
+  STORAGE_KEY,
+};


### PR DESCRIPTION
## Summary

C4 — the final phase. Built by a worktree agent and rebased onto the train (stacked on the D5 PR → retargets as the train merges).

Today the whole chrome holds the `StartupCurtain` until the bridge's `ready`. Now, when the **previous** run used only built-in chrome, the workstation paints immediately and `ready` reconciles:

- **Boot snapshot** (`src/state/chromeBootSnapshot.ts`): localStorage record `{customLayout, frontendModules, extTheme}` written from `handleReady` (desktop only). `customLayout` keys off the exact "extension layout adopted" signal (`baseLayout !== bootLayout`); an active **extension** theme conservatively records `extTheme: true` → those sessions keep today's curtain, so there is provably no layout/theme flash for custom-chrome users. Built-in themes already apply pre-paint via `bootConfigReady`.
- **Gate**: `startupChromeReady` seeds from `shouldPaintChromeOptimistically()` (never throws; absent/malformed snapshot → today's exact curtain path). `markStartupChromeReady` unchanged as reconciliation.
- **Kill-switch**: `[boot] optimistic_chrome = false` — typed through `AethonConfig` (Rust `BootConfig` + optional TS `boot?` section) and enforced at snapshot **write** time (deletes the snapshot), keeping the boot read synchronous.
- **Pre-ready sends verified by trace**: `send_message` → `write_agent_payload` lazily spawns and blocks on `wait_for_worker_ready` before writing — delivered, never dropped; the status pill seeds `starting…`/`disconnected` until `reduceReadyState`. With the #468 pre-spawn, the bridge is usually already up.

e2e intentionally skipped: the harness emits `ready` a microtask after `report`, making the pre-ready window unobservable; `waitForAethonReady` polls state, not the curtain, so existing e2e is unaffected.

## Test plan
- [x] Snapshot module suite (roundtrip, built-ins-only true, customLayout/frontendModules/extTheme false, malformed/missing false, kill-switch deletes at write)
- [x] `ready.test.ts` cases: builtins-only / customLayout / frontendModules snapshot writes
- [x] Rust config test for `[boot] optimistic_chrome`; full suite green on the combined tip (3,171 TS / 618 Rust)