### PR TITLE
fix(ios): tolerate keychain ACL rewrite failures

### DIFF
--- a/.github/workflows/testflight-ios.yml
+++ b/.github/workflows/testflight-ios.yml
@@ -192,7 +192,10 @@ jobs:
             -S apple-tool:,apple:,codesign: \
             -s \
             -k "$IOS_KEYCHAIN_PASSWORD" \
-            "$KEYCHAIN_PATH"
+            "$KEYCHAIN_PATH" || {
+              status=$?
+              echo "::warning title=Keychain ACL rewrite failed::security set-key-partition-list exited with $status; continuing with the imported codesign/security tool ACL."
+            }
 
           mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
           PROFILE_UUID="$(security cms -D -i "$PROFILE_PATH" | /usr/libexec/PlistBuddy -c 'Print :UUID' /dev/stdin)"


### PR DESCRIPTION
## Summary\n- make the optional keychain partition-list rewrite warning-only after the signing identity imports successfully\n\n## Validation\n- ruby YAML parse for .github/workflows/testflight-ios.yml\n- git diff --check\n\n## Context\nThe first live TestFlight run got past PKCS#12 import after replacing the signing material, then failed on macOS runner keychain ACL rewriting with `Cannot parse a NULL or zero-length data`. The import itself grants codesign/security tool access, so this keeps the workflow moving while preserving the useful warning.