### PR TITLE
fix(ios): parse provisioning profile from file

### DIFF
--- a/.github/workflows/testflight-ios.yml
+++ b/.github/workflows/testflight-ios.yml
@@ -198,8 +198,12 @@ jobs:
             }
 
           mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
-          PROFILE_UUID="$(security cms -D -i "$PROFILE_PATH" | /usr/libexec/PlistBuddy -c 'Print :UUID' /dev/stdin)"
-          PROFILE_NAME="$(security cms -D -i "$PROFILE_PATH" | /usr/libexec/PlistBuddy -c 'Print :Name' /dev/stdin)"
+          PROFILE_PLIST="$(mktemp "$RUNNER_TEMP/aethon.mobileprovision.XXXXXX.plist")"
+          chmod 600 "$PROFILE_PLIST"
+          trap 'rm -f "$PROFILE_PLIST"' EXIT
+          security cms -D -i "$PROFILE_PATH" > "$PROFILE_PLIST"
+          PROFILE_UUID="$(/usr/libexec/PlistBuddy -c 'Print :UUID' "$PROFILE_PLIST")"
+          PROFILE_NAME="$(/usr/libexec/PlistBuddy -c 'Print :Name' "$PROFILE_PLIST")"
           cp "$PROFILE_PATH" "$HOME/Library/MobileDevice/Provisioning Profiles/$PROFILE_UUID.mobileprovision"
           security find-identity -v -p codesigning "$KEYCHAIN_PATH"
 


### PR DESCRIPTION
## Summary\n- decode the mobileprovision CMS payload to a temporary plist before reading profile UUID/name\n\n## Validation\n- reproduced PlistBuddy /dev/stdin parse failure locally\n- ruby YAML parse for .github/workflows/testflight-ios.yml\n- git diff --check