### PR TITLE
fix(ios): keep TestFlight build numbers in range

### DIFF
--- a/.github/workflows/testflight-ios.yml
+++ b/.github/workflows/testflight-ios.yml
@@ -9,7 +9,7 @@ on:
         default: ""
         type: string
       build_number:
-        description: Optional CFBundleVersion override. Defaults to UTC timestamp.
+        description: Optional CFBundleVersion override. Defaults to UTC epoch seconds.
         required: false
         default: ""
         type: string
@@ -26,7 +26,7 @@ on:
         default: ""
         type: string
       build_number:
-        description: Optional CFBundleVersion override. Defaults to UTC timestamp.
+        description: Optional CFBundleVersion override. Defaults to UTC epoch seconds.
         required: false
         default: ""
         type: string
@@ -222,11 +222,16 @@ jobs:
           MARKETING_VERSION="$(node -p 'require("./package.json").version')"
           BUILD_NUMBER="$REQUESTED_BUILD_NUMBER"
           if [ -z "$BUILD_NUMBER" ]; then
-            BUILD_NUMBER="$(date -u +%Y%m%d%H%M)"
+            BUILD_NUMBER="$(date -u +%s)"
           fi
 
-          if ! [[ "$BUILD_NUMBER" =~ ^[0-9]+([.][0-9]+){0,2}$ ]]; then
-            echo "Build number must be numeric, optionally with up to two dot-separated numeric components." >&2
+          if ! [[ "$BUILD_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "Build number must be an unsigned integer." >&2
+            exit 1
+          fi
+
+          if [ "$BUILD_NUMBER" -gt 4294967295 ]; then
+            echo "Build number must fit Tauri's iOS build-number range (0..4294967295)." >&2
             exit 1
           fi
 


### PR DESCRIPTION
## Summary\n- default TestFlight build numbers to UTC epoch seconds so Tauri's iOS CLI accepts them\n- add an explicit upper-bound guard matching Tauri's build-number range\n\n## Validation\n- ruby YAML parse for .github/workflows/testflight-ios.yml\n- git diff --check\n\n## Context\nThe live TestFlight workflow reached the signed archive step and failed because YYYYMMDDHHMM exceeds Tauri's u32 build-number range.