### PR TITLE
fix(ios): expose Rust iOS target to archive builds

### DIFF
--- a/.github/workflows/testflight-ios.yml
+++ b/.github/workflows/testflight-ios.yml
@@ -52,6 +52,7 @@ env:
   XCODE_CONFIGURATION: release
   IOS_INFO_PLIST: apps/mobile/src-tauri/gen/apple/aethon-mobile_iOS/Info.plist
   IOS_PROFILE_NAME: Aethon Companion App Store
+  RUSTUP_TOOLCHAIN: "1.92.0"
 
 jobs:
   upload:
@@ -73,8 +74,16 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.92.0"
+          toolchain: ${{ env.RUSTUP_TOOLCHAIN }}
           targets: aarch64-apple-ios
+
+      - name: Show Rust toolchain
+        run: |
+          set -euo pipefail
+          rustup target add aarch64-apple-ios --toolchain "$RUSTUP_TOOLCHAIN"
+          rustup show
+          rustc --version
+          cargo --version
 
       - name: Cache cargo registry + targets
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
## Summary\n- export RUSTUP_TOOLCHAIN=1.92.0 for the TestFlight workflow\n- explicitly add/show the aarch64-apple-ios target before the Tauri/Xcode archive build\n\n## Validation\n- ruby YAML parse for .github/workflows/testflight-ios.yml\n- git diff --check\n\n## Context\nThe live TestFlight workflow reached the archive build, but the Tauri Xcode script could not find std for aarch64-apple-ios even though the setup action requested the target.