### PR TITLE
fix(ios): make Rust toolchain default for TestFlight archives

### DIFF
--- a/.github/workflows/testflight-ios.yml
+++ b/.github/workflows/testflight-ios.yml
@@ -80,8 +80,11 @@ jobs:
       - name: Show Rust toolchain
         run: |
           set -euo pipefail
+          rustup default "$RUSTUP_TOOLCHAIN"
           rustup target add aarch64-apple-ios --toolchain "$RUSTUP_TOOLCHAIN"
           rustup show
+          rustup show active-toolchain
+          rustup target list --installed | grep -Fx aarch64-apple-ios
           rustc --version
           cargo --version
 


### PR DESCRIPTION
## Summary
- set the CI-installed Rust toolchain as the runner default before Tauri invokes Xcode
- print the active toolchain and installed iOS target for archive diagnostics

## Testing
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/testflight-ios.yml"); puts "workflow yaml ok"'\n- git diff --check