### PR TITLE
fix(ios): preserve rustup env in Xcode script

### DIFF
--- a/apps/mobile/src-tauri/gen/apple/aethon-mobile.xcodeproj/project.pbxproj
+++ b/apps/mobile/src-tauri/gen/apple/aethon-mobile.xcodeproj/project.pbxproj
@@ -273,7 +273,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cargo tauri ios xcode-script -v --platform ${PLATFORM_DISPLAY_NAME:?} --sdk-root ${SDKROOT:?} --framework-search-paths \"${FRAMEWORK_SEARCH_PATHS:?}\" --header-search-paths \"${HEADER_SEARCH_PATHS:?}\" --gcc-preprocessor-definitions \"${GCC_PREPROCESSOR_DEFINITIONS:-}\" --configuration ${CONFIGURATION:?} ${FORCE_COLOR} ${ARCHS:?}";
+			shellScript = "if [ -z \"${HOME:-}\" ]; then\n  HOME=\"$(cd ~ && pwd)\"\n  export HOME\nfi\nexport CARGO_HOME=\"${CARGO_HOME:-$HOME/.cargo}\"\nexport RUSTUP_HOME=\"${RUSTUP_HOME:-$HOME/.rustup}\"\nexport RUSTUP_TOOLCHAIN=\"${RUSTUP_TOOLCHAIN:-1.92.0}\"\nexport PATH=\"$CARGO_HOME/bin:$PATH\"\n\nif command -v rustup >/dev/null 2>&1 && rustup toolchain list | grep -q \"^${RUSTUP_TOOLCHAIN}\"; then\n  rustup target add aarch64-apple-ios --toolchain \"$RUSTUP_TOOLCHAIN\"\n  rustup run \"$RUSTUP_TOOLCHAIN\" cargo tauri ios xcode-script -v --platform \"${PLATFORM_DISPLAY_NAME:?}\" --sdk-root \"${SDKROOT:?}\" --framework-search-paths \"${FRAMEWORK_SEARCH_PATHS:?}\" --header-search-paths \"${HEADER_SEARCH_PATHS:?}\" --gcc-preprocessor-definitions \"${GCC_PREPROCESSOR_DEFINITIONS:-}\" --configuration \"${CONFIGURATION:?}\" ${FORCE_COLOR} ${ARCHS:?}\nelse\n  cargo tauri ios xcode-script -v --platform \"${PLATFORM_DISPLAY_NAME:?}\" --sdk-root \"${SDKROOT:?}\" --framework-search-paths \"${FRAMEWORK_SEARCH_PATHS:?}\" --header-search-paths \"${HEADER_SEARCH_PATHS:?}\" --gcc-preprocessor-definitions \"${GCC_PREPROCESSOR_DEFINITIONS:-}\" --configuration \"${CONFIGURATION:?}\" ${FORCE_COLOR} ${ARCHS:?}\nfi";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/apps/mobile/src-tauri/gen/apple/project.yml
+++ b/apps/mobile/src-tauri/gen/apple/project.yml
@@ -92,7 +92,22 @@ targets:
       - sdk: UIKit.framework
       - sdk: WebKit.framework
     preBuildScripts:
-      - script: cargo tauri ios xcode-script -v --platform ${PLATFORM_DISPLAY_NAME:?} --sdk-root ${SDKROOT:?} --framework-search-paths "${FRAMEWORK_SEARCH_PATHS:?}" --header-search-paths "${HEADER_SEARCH_PATHS:?}" --gcc-preprocessor-definitions "${GCC_PREPROCESSOR_DEFINITIONS:-}" --configuration ${CONFIGURATION:?} ${FORCE_COLOR} ${ARCHS:?}
+      - script: |
+          if [ -z "${HOME:-}" ]; then
+            HOME="$(cd ~ && pwd)"
+            export HOME
+          fi
+          export CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}"
+          export RUSTUP_HOME="${RUSTUP_HOME:-$HOME/.rustup}"
+          export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-1.92.0}"
+          export PATH="$CARGO_HOME/bin:$PATH"
+
+          if command -v rustup >/dev/null 2>&1 && rustup toolchain list | grep -q "^${RUSTUP_TOOLCHAIN}"; then
+            rustup target add aarch64-apple-ios --toolchain "$RUSTUP_TOOLCHAIN"
+            rustup run "$RUSTUP_TOOLCHAIN" cargo tauri ios xcode-script -v --platform "${PLATFORM_DISPLAY_NAME:?}" --sdk-root "${SDKROOT:?}" --framework-search-paths "${FRAMEWORK_SEARCH_PATHS:?}" --header-search-paths "${HEADER_SEARCH_PATHS:?}" --gcc-preprocessor-definitions "${GCC_PREPROCESSOR_DEFINITIONS:-}" --configuration "${CONFIGURATION:?}" ${FORCE_COLOR} ${ARCHS:?}
+          else
+            cargo tauri ios xcode-script -v --platform "${PLATFORM_DISPLAY_NAME:?}" --sdk-root "${SDKROOT:?}" --framework-search-paths "${FRAMEWORK_SEARCH_PATHS:?}" --header-search-paths "${HEADER_SEARCH_PATHS:?}" --gcc-preprocessor-definitions "${GCC_PREPROCESSOR_DEFINITIONS:-}" --configuration "${CONFIGURATION:?}" ${FORCE_COLOR} ${ARCHS:?}
+          fi
         name: Build Rust Code
         basedOnDependencyAnalysis: false
         outputFiles:


### PR DESCRIPTION
## Summary
- export HOME/CARGO_HOME/RUSTUP_HOME/RUSTUP_TOOLCHAIN inside the iOS Xcode Rust build phase
- run Tauri’s Xcode script through `rustup run` when the pinned toolchain is installed
- keep a plain cargo fallback for non-rustup local environments

## Testing
- ruby -e 'require "yaml"; YAML.load_file("apps/mobile/src-tauri/gen/apple/project.yml"); puts "project yaml ok"'\n- plutil -lint apps/mobile/src-tauri/gen/apple/aethon-mobile.xcodeproj/project.pbxproj\n- xcodebuild -list -project apps/mobile/src-tauri/gen/apple/aethon-mobile.xcodeproj\n- git diff --check