### PR TITLE
fix(ios): pass signing env to Tauri export

### DIFF
--- a/.github/workflows/testflight-ios.yml
+++ b/.github/workflows/testflight-ios.yml
@@ -265,28 +265,36 @@ jobs:
           CC_aarch64_apple_ios: /usr/bin/clang
           CXX_aarch64_apple_ios: /usr/bin/clang++
           CARGO_TARGET_AARCH64_APPLE_IOS_LINKER: /usr/bin/clang
+          IOS_CERTIFICATE: ${{ secrets.IOS_CERTIFICATE_BASE64 }}
+          IOS_CERTIFICATE_PASSWORD: ${{ secrets.IOS_CERTIFICATE_PASSWORD }}
+          IOS_MOBILE_PROVISION: ${{ secrets.IOS_PROVISIONING_PROFILE_BASE64 }}
         run: |
           set -euo pipefail
 
-          ARCHIVE_PATH="$RUNNER_TEMP/Aethon.xcarchive"
-          PROFILE_SPECIFIER="${IOS_PROVISIONING_PROFILE_NAME:-$IOS_PROFILE_NAME}"
-          rm -rf "$ARCHIVE_PATH" apps/mobile/src-tauri/gen/apple/build
-          touch apps/mobile/src-tauri/src/lib.rs
-          echo "Using provisioning profile: $PROFILE_SPECIFIER"
+          : "${IOS_CERTIFICATE:?IOS_CERTIFICATE is required}"
+          : "${IOS_CERTIFICATE_PASSWORD:?IOS_CERTIFICATE_PASSWORD is required}"
+          : "${IOS_MOBILE_PROVISION:?IOS_MOBILE_PROVISION is required}"
 
-          xcodebuild archive \
-            -project "$XCODE_PROJECT" \
-            -scheme "$XCODE_SCHEME" \
-            -configuration "$XCODE_CONFIGURATION" \
-            -destination "generic/platform=iOS" \
-            -archivePath "$ARCHIVE_PATH" \
-            -allowProvisioningUpdates \
-            DEVELOPMENT_TEAM="$DEVELOPMENT_TEAM" \
-            CODE_SIGN_STYLE=Manual \
-            CODE_SIGN_IDENTITY="Apple Distribution" \
-            PROVISIONING_PROFILE_SPECIFIER="$PROFILE_SPECIFIER" \
-            MARKETING_VERSION="$TESTFLIGHT_MARKETING_VERSION" \
-            CURRENT_PROJECT_VERSION="$TESTFLIGHT_BUILD_NUMBER"
+          cd apps/mobile
+          cargo tauri ios build --help | grep -F -- "--export-method"
+          rm -rf src-tauri/gen/apple/build
+          touch src-tauri/src/lib.rs
+
+          cargo tauri ios build \
+            --ci \
+            --target aarch64 \
+            --export-method app-store-connect \
+            --build-number "$TESTFLIGHT_BUILD_NUMBER" \
+            -v
+
+          ARCHIVE_PATH="$(find src-tauri/gen/apple/build -maxdepth 3 -type d -name '*.xcarchive' | head -n 1)"
+          if [ -z "$ARCHIVE_PATH" ]; then
+            echo "Tauri iOS build did not produce an xcarchive under $(pwd)/src-tauri/gen/apple/build." >&2
+            find src-tauri/gen/apple/build -maxdepth 4 -print >&2 || true
+            exit 1
+          fi
+
+          ARCHIVE_PATH="$(cd "$(dirname "$ARCHIVE_PATH")" && pwd)/$(basename "$ARCHIVE_PATH")"
 
           APP_INFO="$ARCHIVE_PATH/Products/Applications/$APP_NAME.app/Info.plist"
           MARKETING_VERSION="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$APP_INFO")"


### PR DESCRIPTION
## Summary
- return the TestFlight archive build to `cargo tauri ios build` so Tauri provides the iOS options server expected by `xcode-script`
- pass the CI signing certificate, certificate password, and provisioning profile through Tauri
- keep the existing archive discovery and App Store Connect upload/processing wait steps

## Root Cause
The direct `xcodebuild archive` path from #483 bypassed Tauri CLI setup, so the generated Xcode script could not read the temporary `<bundle-id>-server-addr` options file and failed before compiling. Tauri CLI already supports signing inputs via `IOS_CERTIFICATE`, `IOS_CERTIFICATE_PASSWORD`, and `IOS_MOBILE_PROVISION`, so this keeps the build on the supported path while still giving it the App Store signing materials.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/testflight-ios.yml"); puts "workflow yaml ok"'`\n- `git diff --check`