### PR TITLE
fix(ios): match Tauri TestFlight build versions

### DIFF
--- a/.github/workflows/testflight-ios.yml
+++ b/.github/workflows/testflight-ios.yml
@@ -455,7 +455,12 @@ jobs:
             exit 1
           end
 
+          marketing_version = ENV.fetch("TESTFLIGHT_MARKETING_VERSION")
           build_number = ENV.fetch("TESTFLIGHT_BUILD_NUMBER")
+          expected_versions = [
+            build_number,
+            "#{marketing_version}.#{build_number}"
+          ]
           app_id = app.fetch("id")
           app_name = app.dig("attributes", "name") || ENV.fetch("APP_NAME")
 
@@ -466,20 +471,23 @@ jobs:
                 "/v1/builds",
                 {
                   "filter[app]" => app_id,
-                  "filter[version]" => build_number,
                   "fields[builds]" => "version,processingState,uploadedDate,expirationDate,usesNonExemptEncryption",
-                  "limit" => "1",
+                  "limit" => "10",
                   "sort" => "-uploadedDate"
                 }
               ),
               token
             )
-            build = builds_response.fetch("data").first
+            builds = builds_response.fetch("data")
+            build = builds.find do |candidate|
+              expected_versions.include?(candidate.dig("attributes", "version"))
+            end
 
             if build
               attributes = build.fetch("attributes")
               processing_state = attributes.fetch("processingState")
-              puts "App Store Connect build #{app_name} #{ENV.fetch("TESTFLIGHT_MARKETING_VERSION")} (#{build_number}) is #{processing_state}."
+              version = attributes.fetch("version")
+              puts "App Store Connect build #{app_name} #{marketing_version} (#{version}) is #{processing_state}."
 
               if processing_state == "VALID"
                 File.open(ENV.fetch("GITHUB_ENV"), "a") do |env|
@@ -495,13 +503,15 @@ jobs:
                 exit 1
               end
             else
-              puts "Waiting for App Store Connect build #{build_number} to appear..."
+              observed_versions = builds.map { |candidate| candidate.dig("attributes", "version") }.compact
+              puts "Waiting for App Store Connect build #{expected_versions.join(" or ")} to appear..."
+              puts "Recent App Store Connect builds: #{observed_versions.join(", ")}" unless observed_versions.empty?
             end
 
             sleep 60 unless attempt == 29
           end
 
-          warn "Timed out waiting for TestFlight processing for build #{build_number}."
+          warn "Timed out waiting for TestFlight processing for build #{expected_versions.join(" or ")}."
           exit 1
           RUBY
 

--- a/.github/workflows/testflight-ios.yml
+++ b/.github/workflows/testflight-ios.yml
@@ -459,8 +459,8 @@ jobs:
           build_number = ENV.fetch("TESTFLIGHT_BUILD_NUMBER")
           expected_versions = [
             build_number,
-            "#{marketing_version}.#{build_number}"
-          ]
+            build_number.start_with?("#{marketing_version}.") ? build_number : "#{marketing_version}.#{build_number}"
+          ].uniq
           app_id = app.fetch("id")
           app_name = app.dig("attributes", "name") || ENV.fetch("APP_NAME")
 
@@ -472,7 +472,7 @@ jobs:
                 {
                   "filter[app]" => app_id,
                   "fields[builds]" => "version,processingState,uploadedDate,expirationDate,usesNonExemptEncryption",
-                  "limit" => "10",
+                  "limit" => "200",
                   "sort" => "-uploadedDate"
                 }
               ),


### PR DESCRIPTION
## Summary
- make the TestFlight processing wait accept both raw numeric build numbers and Tauri/App Store Connect's `marketingVersion.buildNumber` form
- include recent build versions in wait-loop output when the expected build is not found

## Why
The signed archive and upload path succeeded, and App Store Connect reported the uploaded Aethon Companion build as `VALID`, but the workflow kept waiting because it filtered builds by the raw epoch build number. App Store Connect reported this Tauri iOS build as `0.11.2.<buildNumber>`.

## Test plan
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/testflight-ios.yml"); puts "workflow yaml ok"'`
- `git diff --check`
- executed the updated wait Ruby locally against App Store Connect with `TESTFLIGHT_BUILD_NUMBER=1783418747`; it found `0.11.2.1783418747` as `VALID` and wrote `TESTFLIGHT_APP_ID`, `TESTFLIGHT_BUILD_ID`, and `TESTFLIGHT_APP_NAME` to `GITHUB_ENV`