### PR TITLE
fix(remote): stabilize host overview and workspace selection

### DIFF
--- a/src-tauri/src/server/remote/client.rs
+++ b/src-tauri/src/server/remote/client.rs
@@ -301,9 +301,13 @@ fn error_message(body: &[u8]) -> String {
         .unwrap_or_else(|| String::from_utf8_lossy(body).trim().to_string())
 }
 
+fn candidates_newest_first(candidates: &[String]) -> impl Iterator<Item = &String> {
+    candidates.iter().rev()
+}
+
 pub async fn invoke(host: &PairedHostRecord, cmd: &str, args: Value) -> Result<Value, String> {
     let mut last_error = None;
-    for candidate in &host.candidates {
+    for candidate in candidates_newest_first(&host.candidates) {
         match invoke_candidate(candidate, &host.fingerprint, &host.token, cmd, args.clone()).await {
             Ok(value) => return Ok(value),
             Err(err) => last_error = Some(err),
@@ -343,7 +347,7 @@ async fn connect_and_forward_events(
     cancel: &Arc<Notify>,
 ) -> Result<(), String> {
     let mut last_error = None;
-    for candidate in &host.candidates {
+    for candidate in candidates_newest_first(&host.candidates) {
         match forward_events_candidate(candidate, host, app, cancel).await {
             Ok(()) => return Ok(()),
             Err(err) => last_error = Some(err),
@@ -592,6 +596,25 @@ mod tests {
                 "  ".into(),
             ]),
             vec!["bender.local:123", "192.168.1.44:123"]
+        );
+    }
+
+    #[test]
+    fn remote_candidates_prefer_newest_addresses() {
+        let candidates = vec![
+            "bender.local:1111".to_string(),
+            "192.168.1.44:1111".to_string(),
+            "bender.local:2222".to_string(),
+        ];
+        assert_eq!(
+            candidates_newest_first(&candidates)
+                .cloned()
+                .collect::<Vec<_>>(),
+            vec![
+                "bender.local:2222".to_string(),
+                "192.168.1.44:1111".to_string(),
+                "bender.local:1111".to_string(),
+            ]
         );
     }
 

--- a/src/eventRoutes/sidebar.test.ts
+++ b/src/eventRoutes/sidebar.test.ts
@@ -768,6 +768,101 @@ describe("handleSidebarSwitchWorkspace", () => {
     });
   });
 
+  it("routes remote workspace rows from their click payload when derived mirrors are absent", async () => {
+    const { ctx, mocks, applySetState } = buildRouteFixture({
+      state: {
+        activeHostId: "remote:3eb",
+        sidebar: {
+          projects: [],
+        },
+      },
+    });
+
+    const handled = await handleSidebarSwitchWorkspace(
+      {
+        component: { id: "sidebar" },
+        eventType: "switch-workspace",
+        data: {
+          workspaceId: "remote:3eb::workspace::james-brink/fix-direnv",
+          projectId: "remote:3eb::project::urandom",
+          projectLabel: "urandom.io",
+          projectPath: "/remote/urandom",
+          hostId: "remote:3eb",
+          remoteId: "james-brink/fix-direnv",
+          remoteProjectId: "urandom",
+          label: "james-brink/fix-direnv",
+          path: "/remote/urandom-fix-direnv",
+        },
+      },
+      ctx,
+    );
+
+    expect(handled).toBe(true);
+    expect(mocks.activateWorkspace).not.toHaveBeenCalled();
+    expect(ctx.setActiveHost).toHaveBeenCalledWith("remote:3eb");
+    const next = applySetState();
+    expect(next.activeHostId).toBe("remote:3eb");
+    expect(next.activeProjectId).toBe("remote:3eb::project::urandom");
+    expect(next.activeWorkspaceId).toBe(
+      "remote:3eb::workspace::james-brink/fix-direnv",
+    );
+    expect(next.project).toMatchObject({
+      id: "remote:3eb::project::urandom",
+      remoteId: "urandom",
+      hostId: "remote:3eb",
+      label: "urandom.io",
+      path: "/remote/urandom",
+    });
+    expect(next.landing).toMatchObject({
+      kind: "workspace",
+      hostId: "remote:3eb",
+      projectId: "remote:3eb::project::urandom",
+      projectLabel: "urandom.io",
+      workspaceId: "remote:3eb::workspace::james-brink/fix-direnv",
+      workspaceLabel: "james-brink/fix-direnv",
+      path: "/remote/urandom-fix-direnv",
+    });
+  });
+
+  it("derives raw remote project ids from qualified synthetic payloads", async () => {
+    const { ctx, applySetState } = buildRouteFixture({
+      state: {
+        activeHostId: "remote:3eb",
+        sidebar: { projects: [] },
+      },
+    });
+
+    const handled = await handleSidebarSwitchWorkspace(
+      {
+        component: { id: "sidebar" },
+        eventType: "switch-workspace",
+        data: {
+          workspaceId: "remote:3eb::workspace::james-brink/fix-direnv",
+          projectId: "remote:3eb::project::urandom",
+          projectLabel: "urandom.io",
+          hostId: "remote:3eb",
+          remoteId: "james-brink/fix-direnv",
+          label: "james-brink/fix-direnv",
+          path: "/remote/urandom-fix-direnv",
+        },
+      },
+      ctx,
+    );
+
+    expect(handled).toBe(true);
+    const next = applySetState();
+    expect(next.project).toMatchObject({
+      id: "remote:3eb::project::urandom",
+      remoteId: "urandom",
+      label: "urandom.io",
+    });
+    expect(next.landing).toMatchObject({
+      projectId: "remote:3eb::project::urandom",
+      projectLabel: "urandom.io",
+      workspaceId: "remote:3eb::workspace::james-brink/fix-direnv",
+    });
+  });
+
   it("opens visible remote workspaces in new tabs with host context", async () => {
     const { ctx, mocks, applySetState } = buildRouteFixture({
       state: {
@@ -819,6 +914,36 @@ describe("handleSidebarSwitchWorkspace", () => {
       hostId: "remote:bender",
     });
     expect(applySetState().landing).toBeNull();
+  });
+
+  it("does not open a remote tab without a cwd from synthetic payloads", async () => {
+    const { ctx, mocks, applySetState } = buildRouteFixture({
+      state: {
+        activeHostId: "remote:3eb",
+        sidebar: { projects: [] },
+      },
+    });
+
+    const handled = await handleSidebarOpenWorkspaceInNewTab(
+      {
+        component: { id: "sidebar" },
+        eventType: "open-workspace-in-new-tab",
+        data: {
+          workspaceId: "remote:3eb::workspace::feature",
+          projectId: "remote:3eb::project::urandom",
+          hostId: "remote:3eb",
+          remoteId: "feature",
+          label: "feature",
+        },
+      },
+      ctx,
+    );
+
+    expect(handled).toBe(true);
+    expect(mocks.newTab).not.toHaveBeenCalled();
+    const next = applySetState();
+    expect(next.activeWorkspaceId).toBe("remote:3eb::workspace::feature");
+    expect(next.landing).toBeNull();
   });
 
   it("starts remote workspace landing sessions with host context", async () => {

--- a/src/eventRoutes/sidebar/workspace.ts
+++ b/src/eventRoutes/sidebar/workspace.ts
@@ -28,10 +28,14 @@ interface SidebarProjectItem {
 interface WorkspaceEventPayload {
   workspaceId?: string;
   projectId?: string;
+  projectLabel?: string;
+  projectPath?: string;
+  iconUrl?: string;
   hostId?: string;
   remoteId?: string;
   remoteProjectId?: string;
   path?: string;
+  label?: string;
 }
 
 interface WorkspaceMatch {
@@ -127,6 +131,15 @@ function findSidebarWorkspace(
   return null;
 }
 
+function remoteProjectIdFromQualified(id?: string): string | undefined {
+  if (!id) return undefined;
+  const marker = "::project::";
+  const markerIndex = id.indexOf(marker);
+  if (markerIndex < 0) return undefined;
+  const remoteProjectId = id.slice(markerIndex + marker.length);
+  return remoteProjectId || undefined;
+}
+
 function activateRemoteWorkspace(
   ctx: Parameters<EventRouteHandler>[1],
   match: WorkspaceMatch,
@@ -165,6 +178,40 @@ function activateRemoteWorkspace(
         }
       : null,
   }));
+}
+
+function syntheticRemoteWorkspaceMatch(
+  workspaceId: string,
+  payload: WorkspaceEventPayload,
+): WorkspaceMatch | null {
+  if (!payload.hostId || !isRemoteHostId(payload.hostId)) return null;
+  const remoteProjectId =
+    payload.remoteProjectId ?? remoteProjectIdFromQualified(payload.projectId);
+  const projectId =
+    payload.projectId ??
+    (remoteProjectId
+      ? `${payload.hostId}::project::${remoteProjectId}`
+      : undefined);
+  if (!projectId) return null;
+  const project: SidebarProjectItem = {
+    id: projectId,
+    remoteId: remoteProjectId,
+    hostId: payload.hostId,
+    label: payload.projectLabel ?? remoteProjectId ?? projectId,
+    path: payload.projectPath ?? payload.path,
+    iconUrl: payload.iconUrl,
+  };
+  const workspace: SidebarWorkspaceItem = {
+    id: workspaceId,
+    remoteId: payload.remoteId,
+    remoteProjectId,
+    projectId,
+    hostId: payload.hostId,
+    label: payload.label ?? payload.remoteId ?? "workspace",
+    path: payload.path,
+    isMain: false,
+  };
+  return { project, workspace, hostId: payload.hostId };
 }
 
 /** Workspace event family — all routed through useProjectOps actions. */
@@ -207,10 +254,12 @@ export const handleSidebarSwitchWorkspace: EventRouteHandler = (
     workspaceId,
     payload,
   );
-  if (match) {
-    const { project, workspace, hostId } = match;
+  const remoteFallback =
+    match ?? syntheticRemoteWorkspaceMatch(workspaceId, payload);
+  if (remoteFallback) {
+    const { project, workspace, hostId } = remoteFallback;
     if (hostId && isRemoteHostId(hostId)) {
-      activateRemoteWorkspace(ctx, match, { showLanding: true });
+      activateRemoteWorkspace(ctx, remoteFallback, { showLanding: true });
       return true;
     }
     const activeProjectId = ctx.stateRef.current.activeProjectId;
@@ -294,12 +343,16 @@ export const handleSidebarOpenWorkspaceInNewTab: EventRouteHandler = (
     workspaceId,
     payload,
   );
-  if (match?.hostId && isRemoteHostId(match.hostId)) {
-    activateRemoteWorkspace(ctx, match, { showLanding: false });
-    ctx.newTab(undefined, undefined, {
-      cwd: match.workspace.path,
-      hostId: match.hostId,
-    });
+  const remoteFallback =
+    match ?? syntheticRemoteWorkspaceMatch(workspaceId, payload);
+  if (remoteFallback?.hostId && isRemoteHostId(remoteFallback.hostId)) {
+    activateRemoteWorkspace(ctx, remoteFallback, { showLanding: false });
+    if (remoteFallback.workspace.path) {
+      ctx.newTab(undefined, undefined, {
+        cwd: remoteFallback.workspace.path,
+        hostId: remoteFallback.hostId,
+      });
+    }
     return true;
   }
   let projectId: string | undefined;

--- a/src/extensions/default-layout/dashboard/projects-dashboard.test.tsx
+++ b/src/extensions/default-layout/dashboard/projects-dashboard.test.tsx
@@ -5,6 +5,7 @@ import {
   fireEvent,
   render,
   screen,
+  within,
   waitFor,
 } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -34,6 +35,11 @@ const { invokeMock } = vi.hoisted(() => ({
   }),
 }));
 
+const originalClipboardDescriptor = Object.getOwnPropertyDescriptor(
+  navigator,
+  "clipboard",
+);
+
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: invokeMock,
 }));
@@ -57,6 +63,12 @@ function dashboard(props: Record<string, unknown>): A2UIComponent {
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  vi.useRealTimers();
+  if (originalClipboardDescriptor) {
+    Object.defineProperty(navigator, "clipboard", originalClipboardDescriptor);
+  } else {
+    Reflect.deleteProperty(navigator, "clipboard");
+  }
 });
 
 describe("ProjectsDashboard", () => {
@@ -89,9 +101,9 @@ describe("ProjectsDashboard", () => {
 
     expect(screen.getByLabelText("Task prompt")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Project" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Project" }).textContent).toContain(
-      "host",
-    );
+    expect(
+      screen.getByRole("button", { name: "Project" }).textContent,
+    ).toContain("host");
     expect(screen.queryByRole("button", { name: "Workspace" })).toBeNull();
   });
 
@@ -169,13 +181,353 @@ describe("ProjectsDashboard", () => {
       </ExtensionRegistryProvider>,
     );
 
-    expect(
-      screen.queryByRole("button", { name: "Open Project…" }),
-    ).toBeNull();
+    expect(screen.queryByRole("button", { name: "Open Project…" })).toBeNull();
     expect(screen.getByRole("button", { name: "New Tab" })).toBeTruthy();
     expect(screen.queryByText("Recent sessions")).toBeNull();
     expect(screen.queryByText("Ping")).toBeNull();
     expect(screen.queryByText("local subagents")).toBeNull();
+  });
+
+  it("renders paired remote host connection details on host overview", () => {
+    const registry = new ExtensionRegistry();
+    registry.register({
+      name: "test-dashboard-components",
+      components: {
+        "task-launcher": TaskLauncher,
+        "project-card": () => <div />,
+        "subagents-config": () => <div />,
+      },
+    });
+
+    render(
+      <ExtensionRegistryProvider registry={registry}>
+        <ProjectsDashboard
+          component={dashboard({
+            host: {
+              id: "remote:fp",
+              hostId: "local:bender",
+              hostname: "bender.local",
+              displayName: "bender",
+              isLocal: false,
+              paired: true,
+              connected: false,
+              discovered: true,
+              createdAt: 1_700_000_000_000,
+              lastSeen: 1_700_000_060_000,
+              fingerprint: "abcdef1234567890",
+              candidates: ["bender.local:4242", "192.168.1.44:4242"],
+            },
+            projects: [
+              {
+                id: "remote:fp::project::aethon",
+                label: "aethon",
+                path: "/remote/aethon",
+              },
+            ],
+            recentSessions: [],
+            extraCards: [],
+          })}
+          state={{}}
+          onEvent={() => {}}
+        />
+      </ExtensionRegistryProvider>,
+    );
+
+    expect(screen.getByText("Remote host")).toBeTruthy();
+    expect(screen.getByText("Paired")).toBeTruthy();
+    expect(screen.getByText("Reachable on LAN")).toBeTruthy();
+    expect(screen.getByText("Primary connection candidates")).toBeTruthy();
+    expect(screen.getByText("bender.local:4242")).toBeTruthy();
+    expect(screen.getByText("192.168.1.44:4242")).toBeTruthy();
+    expect(screen.getByText("Host ID")).toBeTruthy();
+    expect(screen.getByText("local:bender")).toBeTruthy();
+    expect(screen.getByText("abcdef1234567890")).toBeTruthy();
+  });
+
+  it("keeps noisy IPv6 candidates collapsed behind raw details", () => {
+    const registry = new ExtensionRegistry();
+    registry.register({
+      name: "test-dashboard-components",
+      components: {
+        "task-launcher": TaskLauncher,
+        "project-card": () => <div />,
+        "subagents-config": () => <div />,
+      },
+    });
+
+    const { container } = render(
+      <ExtensionRegistryProvider registry={registry}>
+        <ProjectsDashboard
+          component={dashboard({
+            host: {
+              id: "remote:fp",
+              hostId: "local:bender",
+              hostname: "bender.local",
+              displayName: "bender",
+              isLocal: false,
+              paired: true,
+              createdAt: 1_700_000_000_000,
+              lastSeen: 1_700_000_060_000,
+              fingerprint: "abcdef1234567890",
+              candidates: [
+                "aethon-fp.local:1111",
+                "192.168.1.44:1111",
+                "[fe80::1]:1111",
+                "aethon-fp.local:2222",
+                "192.168.1.44:2222",
+                "[fe80::1]:2222",
+              ],
+            },
+            projects: [],
+            recentSessions: [],
+            extraCards: [],
+          })}
+          state={{}}
+          onEvent={() => {}}
+        />
+      </ExtensionRegistryProvider>,
+    );
+
+    const primary = container.querySelector(".a2ui-host-candidates--primary");
+    expect(primary).toBeTruthy();
+    expect(
+      within(primary as HTMLElement).getByText("aethon-fp.local:2222"),
+    ).toBeTruthy();
+    expect(
+      within(primary as HTMLElement).getByText("192.168.1.44:2222"),
+    ).toBeTruthy();
+    expect(
+      within(primary as HTMLElement).queryByText("aethon-fp.local:1111"),
+    ).toBeNull();
+    expect(
+      within(primary as HTMLElement).queryByText("[fe80::1]:2222"),
+    ).toBeNull();
+    expect(screen.getByText("Show 4 raw alternate candidates")).toBeTruthy();
+  });
+
+  it("copies host candidates when clicked", async () => {
+    const writeText = vi.fn(() => Promise.resolve());
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    const registry = new ExtensionRegistry();
+    registry.register({
+      name: "test-dashboard-components",
+      components: {
+        "task-launcher": TaskLauncher,
+        "project-card": () => <div />,
+        "subagents-config": () => <div />,
+      },
+    });
+
+    render(
+      <ExtensionRegistryProvider registry={registry}>
+        <ProjectsDashboard
+          component={dashboard({
+            host: {
+              id: "remote:fp",
+              hostId: "local:bender",
+              hostname: "bender.local",
+              displayName: "bender",
+              isLocal: false,
+              paired: true,
+              candidates: ["bender.local:4242"],
+            },
+            projects: [],
+            recentSessions: [],
+            extraCards: [],
+          })}
+          state={{}}
+          onEvent={() => {}}
+        />
+      </ExtensionRegistryProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "bender.local:4242" }));
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith("bender.local:4242");
+      expect(screen.getByText("Copied")).toBeTruthy();
+    });
+  });
+
+  it("clears pending copied-candidate timers on unmount", async () => {
+    const writeText = vi.fn(() => Promise.resolve());
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    const clearTimeoutSpy = vi.spyOn(window, "clearTimeout");
+    const registry = new ExtensionRegistry();
+    registry.register({
+      name: "test-dashboard-components",
+      components: {
+        "task-launcher": TaskLauncher,
+        "project-card": () => <div />,
+        "subagents-config": () => <div />,
+      },
+    });
+
+    const { unmount } = render(
+      <ExtensionRegistryProvider registry={registry}>
+        <ProjectsDashboard
+          component={dashboard({
+            host: {
+              id: "remote:fp",
+              hostId: "local:bender",
+              hostname: "bender.local",
+              displayName: "bender",
+              isLocal: false,
+              paired: true,
+              candidates: ["bender.local:4242"],
+            },
+            projects: [],
+            recentSessions: [],
+            extraCards: [],
+          })}
+          state={{}}
+          onEvent={() => {}}
+        />
+      </ExtensionRegistryProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "bender.local:4242" }));
+    await waitFor(() => expect(writeText).toHaveBeenCalled());
+
+    unmount();
+
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+  });
+
+  it("explains when remote projects are still syncing", () => {
+    const registry = new ExtensionRegistry();
+    registry.register({
+      name: "test-dashboard-components",
+      components: {
+        "task-launcher": TaskLauncher,
+        "project-card": () => <div />,
+        "subagents-config": () => <div />,
+      },
+    });
+
+    render(
+      <ExtensionRegistryProvider registry={registry}>
+        <ProjectsDashboard
+          component={dashboard({
+            host: {
+              id: "remote:fp",
+              hostname: "bender.local",
+              displayName: "bender",
+              isLocal: false,
+              paired: true,
+              connected: true,
+              projectStatus: { state: "syncing", updatedAt: 1 },
+            },
+            projects: [],
+            recentSessions: [],
+            extraCards: [],
+          })}
+          state={{}}
+          onEvent={() => {}}
+        />
+      </ExtensionRegistryProvider>,
+    );
+
+    expect(screen.getByText("Syncing")).toBeTruthy();
+    expect(screen.getByText("Loading remote projects")).toBeTruthy();
+    expect(screen.getByText("Syncing remote projects")).toBeTruthy();
+  });
+
+  it("explains remote project snapshot failures", () => {
+    const registry = new ExtensionRegistry();
+    registry.register({
+      name: "test-dashboard-components",
+      components: {
+        "task-launcher": TaskLauncher,
+        "project-card": () => <div />,
+        "subagents-config": () => <div />,
+      },
+    });
+
+    render(
+      <ExtensionRegistryProvider registry={registry}>
+        <ProjectsDashboard
+          component={dashboard({
+            host: {
+              id: "remote:fp",
+              hostname: "bender.local",
+              displayName: "bender",
+              isLocal: false,
+              paired: true,
+              connected: true,
+              projectStatus: {
+                state: "error",
+                error: "connect timeout wss://bender.local/ws",
+                updatedAt: 1,
+              },
+            },
+            projects: [],
+            recentSessions: [],
+            extraCards: [],
+          })}
+          state={{}}
+          onEvent={() => {}}
+        />
+      </ExtensionRegistryProvider>,
+    );
+
+    expect(screen.getByText("Sync failed")).toBeTruthy();
+    expect(screen.getByText("Remote project sync failed")).toBeTruthy();
+    expect(screen.getByText("Remote projects unavailable")).toBeTruthy();
+    expect(
+      screen.getByText("connect timeout wss://bender.local/ws"),
+    ).toBeTruthy();
+  });
+
+  it("shows recently seen remote hosts distinctly from stale paired hosts", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-08T17:00:00Z"));
+    const registry = new ExtensionRegistry();
+    registry.register({
+      name: "test-dashboard-components",
+      components: {
+        "task-launcher": TaskLauncher,
+        "project-card": () => <div />,
+        "subagents-config": () => <div />,
+      },
+    });
+
+    render(
+      <ExtensionRegistryProvider registry={registry}>
+        <ProjectsDashboard
+          component={dashboard({
+            host: {
+              id: "remote:fp",
+              hostId: "local:bender",
+              hostname: "bender.local",
+              displayName: "bender",
+              isLocal: false,
+              paired: true,
+              connected: false,
+              discovered: false,
+              createdAt: Date.parse("2026-07-02T20:30:00Z"),
+              lastSeen: Date.parse("2026-07-08T16:59:30Z"),
+              fingerprint: "abcdef1234567890",
+              candidates: ["bender.local:4242"],
+            },
+            projects: [],
+            recentSessions: [],
+            extraCards: [],
+          })}
+          state={{}}
+          onEvent={() => {}}
+        />
+      </ExtensionRegistryProvider>,
+    );
+
+    expect(screen.getByText("Recently seen on LAN")).toBeTruthy();
+    expect(screen.queryByText("Not currently advertised")).toBeNull();
   });
 
   it("writes host-level startup auto-approve to global config", async () => {
@@ -227,5 +579,10 @@ describe("ProjectsDashboard", () => {
       ),
     );
     expect(checkbox).toHaveProperty("checked", true);
+    const policy = checkbox.closest(".a2ui-project-dashboard-startup-policy");
+    expect(policy).toBeTruthy();
+    expect(
+      policy?.querySelector(".a2ui-project-dashboard-startup-hint"),
+    ).toBeTruthy();
   });
 });

--- a/src/extensions/default-layout/dashboard/projects-dashboard.tsx
+++ b/src/extensions/default-layout/dashboard/projects-dashboard.tsx
@@ -16,10 +16,11 @@
  *   - "select-project-card" (forwarded from project-card) → activates.
  *   - "restore-session" — reuses tabStrip route too.
  */
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import type { BuiltinComponentProps } from "../../../components/A2UIRenderer";
 import { resolvePointer } from "../../../utils/jsonPointer";
+import { formatRelativeTime } from "../../../utils/time";
 import { AeMarkInline } from "../layout";
 import { RegistryComponent } from "../../../components/A2UIRenderer";
 import { DashboardSessionRow } from "./session-row";
@@ -43,9 +44,23 @@ interface ProjectListItem {
 
 interface HostBannerInfo {
   id: string;
+  hostId?: string;
   hostname: string;
   displayName: string;
   isLocal: boolean;
+  fingerprint?: string;
+  candidates?: string[];
+  paired?: boolean;
+  connected?: boolean;
+  discovered?: boolean;
+  createdAt?: number;
+  lastSeen?: number;
+  port?: number;
+  projectStatus?: {
+    state?: "syncing" | "ready" | "error";
+    error?: string;
+    updatedAt?: number;
+  };
 }
 
 function resolveOptional<T>(
@@ -97,6 +112,265 @@ function resolveArray<T>(v: unknown, state: Record<string, unknown>): T[] {
     return Array.isArray(r) ? (r as T[]) : [];
   }
   return Array.isArray(v) ? (v as T[]) : [];
+}
+
+function formatDateTime(ms?: number): string | null {
+  if (!ms) return null;
+  return new Date(ms).toLocaleString(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+}
+
+function statusText(host: HostBannerInfo): string {
+  if (host.projectStatus?.state === "syncing") return "Syncing";
+  if (host.projectStatus?.state === "error") return "Sync failed";
+  if (host.connected) return "Connected";
+  if (host.paired) return "Paired";
+  if (host.discovered) return "Available on LAN";
+  return "Remote";
+}
+
+function recentlySeen(host: HostBannerInfo): boolean {
+  return Boolean(host.lastSeen && Date.now() - host.lastSeen < 120_000);
+}
+
+function reachabilityText(host: HostBannerInfo): string {
+  if (host.projectStatus?.state === "syncing") return "Loading remote projects";
+  if (host.projectStatus?.state === "error")
+    return "Remote project sync failed";
+  if (host.connected) return "Event stream connected";
+  if (host.discovered) return "Reachable on LAN";
+  if (recentlySeen(host)) return "Recently seen on LAN";
+  if (host.paired) return "Not currently advertised";
+  return "Discovered";
+}
+
+function remoteProjectsEmptyState(host: HostBannerInfo): {
+  title: string;
+  body: string;
+} {
+  if (host.projectStatus?.state === "syncing") {
+    return {
+      title: "Syncing remote projects",
+      body: "Waiting for the paired host to return its project snapshot.",
+    };
+  }
+  if (host.projectStatus?.state === "error") {
+    return {
+      title: "Remote projects unavailable",
+      body:
+        host.projectStatus.error ||
+        "Aethon could not fetch the project snapshot from this host.",
+    };
+  }
+  return {
+    title: "No remote projects",
+    body: "This host returned an empty project snapshot.",
+  };
+}
+
+function candidateKey(candidate: string): string {
+  const trimmed = candidate.trim();
+  if (trimmed.startsWith("[")) {
+    const end = trimmed.indexOf("]");
+    return end > 0 ? trimmed.slice(0, end + 1) : trimmed;
+  }
+  const [host] = trimmed.split(":");
+  return host || trimmed;
+}
+
+function isNoisyCandidate(candidate: string): boolean {
+  return candidate.trim().startsWith("[");
+}
+
+function primaryCandidates(candidates: string[]): string[] {
+  const latestByHost = new Map<string, string>();
+  for (const candidate of candidates) {
+    if (isNoisyCandidate(candidate)) continue;
+    latestByHost.set(candidateKey(candidate), candidate);
+  }
+  return Array.from(latestByHost.values()).slice(0, 8);
+}
+
+function CandidateList({
+  candidates,
+  copiedCandidate,
+  onCopy,
+  primary = false,
+}: {
+  candidates: string[];
+  copiedCandidate: string | null;
+  onCopy: (candidate: string) => void;
+  primary?: boolean;
+}) {
+  return (
+    <ul
+      className={[
+        "a2ui-host-candidates",
+        primary ? "a2ui-host-candidates--primary" : "",
+      ]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      {candidates.map((candidate, index) => (
+        <li key={`${candidate}-${index}`}>
+          <button
+            type="button"
+            className="a2ui-host-candidate-copy"
+            onClick={() => onCopy(candidate)}
+            title="Copy address"
+          >
+            <code>{candidate}</code>
+            {copiedCandidate === candidate && (
+              <span className="a2ui-host-candidate-copied">Copied</span>
+            )}
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function RemoteHostDetails({ host }: { host: HostBannerInfo }) {
+  const [copiedCandidate, setCopiedCandidate] = useState<string | null>(null);
+  const copiedResetTimerRef = useRef<number | null>(null);
+  const candidates = Array.isArray(host.candidates) ? host.candidates : [];
+  const primary = primaryCandidates(candidates);
+  const primarySet = new Set(primary);
+  const rawCandidates = candidates.filter(
+    (candidate) => !primarySet.has(candidate),
+  );
+  const pairedAt = formatDateTime(host.createdAt);
+  const lastSeenAt = formatDateTime(host.lastSeen);
+
+  useEffect(() => {
+    return () => {
+      if (copiedResetTimerRef.current !== null) {
+        window.clearTimeout(copiedResetTimerRef.current);
+        copiedResetTimerRef.current = null;
+      }
+    };
+  }, []);
+
+  const copyCandidate = async (candidate: string) => {
+    try {
+      if (!navigator.clipboard) return;
+      await navigator.clipboard.writeText(candidate);
+      setCopiedCandidate(candidate);
+      if (copiedResetTimerRef.current !== null) {
+        window.clearTimeout(copiedResetTimerRef.current);
+        copiedResetTimerRef.current = null;
+      }
+      copiedResetTimerRef.current = window.setTimeout(() => {
+        copiedResetTimerRef.current = null;
+        setCopiedCandidate((current) =>
+          current === candidate ? null : current,
+        );
+      }, 1200);
+    } catch {
+      // Clipboard permission can be denied; keep the address visible
+      // without claiming it was copied.
+    }
+  };
+  return (
+    <section className="a2ui-host-details" aria-label="Remote host details">
+      <div className="a2ui-host-details-head">
+        <div>
+          <h2>Remote host</h2>
+          <p>{reachabilityText(host)}</p>
+        </div>
+        <span
+          className={[
+            "a2ui-host-details-status",
+            host.connected
+              ? "a2ui-host-details-status--connected"
+              : host.projectStatus?.state === "error"
+                ? "a2ui-host-details-status--error"
+                : host.discovered
+                  ? "a2ui-host-details-status--reachable"
+                  : "",
+          ]
+            .filter(Boolean)
+            .join(" ")}
+        >
+          {statusText(host)}
+        </span>
+      </div>
+      <dl className="a2ui-host-details-grid">
+        <div>
+          <dt>Hostname</dt>
+          <dd>{host.hostname}</dd>
+        </div>
+        {host.hostId && (
+          <div>
+            <dt>Host ID</dt>
+            <dd>{host.hostId}</dd>
+          </div>
+        )}
+        {pairedAt && (
+          <div>
+            <dt>Paired on</dt>
+            <dd>{pairedAt}</dd>
+          </div>
+        )}
+        {lastSeenAt && (
+          <div>
+            <dt>Last seen</dt>
+            <dd>
+              {lastSeenAt}
+              <span className="a2ui-host-details-muted">
+                {" "}
+                ({formatRelativeTime(host.lastSeen ?? 0)})
+              </span>
+            </dd>
+          </div>
+        )}
+        {host.port && (
+          <div>
+            <dt>Advertised port</dt>
+            <dd>{host.port}</dd>
+          </div>
+        )}
+        {host.fingerprint && (
+          <div className="a2ui-host-details-wide">
+            <dt>Fingerprint</dt>
+            <dd>
+              <code>{host.fingerprint}</code>
+            </dd>
+          </div>
+        )}
+        {candidates.length > 0 && (
+          <div className="a2ui-host-details-wide">
+            <dt>Primary connection candidates</dt>
+            <dd>
+              <CandidateList
+                candidates={
+                  primary.length > 0 ? primary : candidates.slice(0, 8)
+                }
+                copiedCandidate={copiedCandidate}
+                onCopy={copyCandidate}
+                primary
+              />
+              {rawCandidates.length > 0 && (
+                <details className="a2ui-host-candidates-raw">
+                  <summary>
+                    Show {rawCandidates.length} raw alternate candidate
+                    {rawCandidates.length === 1 ? "" : "s"}
+                  </summary>
+                  <CandidateList
+                    candidates={rawCandidates}
+                    copiedCandidate={copiedCandidate}
+                    onCopy={copyCandidate}
+                  />
+                </details>
+              )}
+            </dd>
+          </div>
+        )}
+      </dl>
+    </section>
+  );
 }
 
 export function ProjectsDashboard({
@@ -154,6 +428,10 @@ export function ProjectsDashboard({
   const showOpenProject = host?.isLocal !== false;
   const remoteHostOverview = host?.isLocal === false;
   const visibleRecentSessions = remoteHostOverview ? [] : recentSessions;
+  const remoteEmptyState =
+    remoteHostOverview && host && projects.length === 0
+      ? remoteProjectsEmptyState(host)
+      : null;
 
   useEffect(() => {
     if (!showHostStartupPolicy) {
@@ -209,6 +487,7 @@ export function ProjectsDashboard({
             </span>
           </div>
         )}
+        {remoteHostOverview && host && <RemoteHostDetails host={host} />}
         <div className="a2ui-projects-dashboard-hero" aria-hidden="true">
           <AeMarkInline size={56} radius={12} />
         </div>
@@ -255,6 +534,12 @@ export function ProjectsDashboard({
                   "Start a task on this host… choose a project, use @<subagent> or @path",
               }}
             />
+          </section>
+        )}
+        {remoteEmptyState && (
+          <section className="a2ui-projects-dashboard-section a2ui-remote-projects-empty">
+            <h2>{remoteEmptyState.title}</h2>
+            <p>{remoteEmptyState.body}</p>
           </section>
         )}
         {showHostStartupPolicy && (

--- a/src/extensions/default-layout/sidebar/index.test.tsx
+++ b/src/extensions/default-layout/sidebar/index.test.tsx
@@ -756,6 +756,108 @@ describe("Sidebar host groups", () => {
     expect(screen.getByText("nix")).toBeTruthy();
   });
 
+  it("routes clicks on rendered remote workspace rows", () => {
+    const component = sidebarComponent({
+      hostGroups: true,
+      hosts: { $ref: "/sidebar/hosts" },
+      sections: [
+        {
+          id: "projects",
+          title: "projects",
+          items: { $ref: "/sidebar/projects" },
+        },
+      ],
+    });
+    const onEvent = vi.fn<SidebarOnEvent>();
+    render(
+      <Sidebar
+        component={component}
+        state={{
+          project: null,
+          sidebar: {
+            hosts: [
+              {
+                id: "remote:bender",
+                label: "bender",
+                hint: "connected",
+                paired: true,
+                active: true,
+              },
+            ],
+            projects: [
+              {
+                id: "remote:bender::project::urandom",
+                remoteId: "urandom",
+                hostId: "remote:bender",
+                label: "urandom.io",
+                expanded: true,
+                workspaces: [
+                  {
+                    id: "remote:bender::workspace::james-brink/fix-direnv",
+                    remoteId: "james-brink/fix-direnv",
+                    remoteProjectId: "urandom",
+                    projectId: "remote:bender::project::urandom",
+                    hostId: "remote:bender",
+                    label: "james-brink/fix-direnv",
+                    branch: "james-brink/fix-direnv",
+                    path: "/remote/urandom-fix-direnv",
+                    active: false,
+                    isMain: false,
+                  },
+                ],
+              },
+            ],
+            projectsByHost: {
+              "remote:bender": [
+                {
+                  id: "remote:bender::project::urandom",
+                  remoteId: "urandom",
+                  hostId: "remote:bender",
+                  label: "urandom.io",
+                  expanded: true,
+                  workspaces: [
+                    {
+                      id: "remote:bender::workspace::james-brink/fix-direnv",
+                      remoteId: "james-brink/fix-direnv",
+                      remoteProjectId: "urandom",
+                      projectId: "remote:bender::project::urandom",
+                      hostId: "remote:bender",
+                      label: "james-brink/fix-direnv",
+                      branch: "james-brink/fix-direnv",
+                      path: "/remote/urandom-fix-direnv",
+                      active: false,
+                      isMain: false,
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        }}
+        onEvent={onEvent}
+        renderChildWithState={() => null}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("james-brink/fix-direnv"));
+
+    expect(onEvent).toHaveBeenCalledWith(
+      "switch-workspace",
+      expect.objectContaining({
+        sectionId: "projects",
+        workspaceId: "remote:bender::workspace::james-brink/fix-direnv",
+        projectId: "remote:bender::project::urandom",
+        projectLabel: "urandom.io",
+        hostId: "remote:bender",
+        remoteId: "james-brink/fix-direnv",
+        remoteProjectId: "urandom",
+        path: "/remote/urandom-fix-direnv",
+        label: "james-brink/fix-direnv",
+      }),
+      "remote:bender::workspace::james-brink/fix-direnv",
+    );
+  });
+
   it("offers pairing directly on visible discovered desktop hosts", () => {
     const { onEvent } = renderWithHost({
       hosts: [

--- a/src/extensions/default-layout/sidebar/index.tsx
+++ b/src/extensions/default-layout/sidebar/index.tsx
@@ -768,7 +768,24 @@ function SidebarSectionBlock({
                   ? extraWorkspaces.map((wt) => (
                       <WorkspaceRow
                         key={wt.id}
-                        item={wt}
+                        item={{
+                          ...wt,
+                          projectLabel:
+                            typeof item.label === "string"
+                              ? item.label
+                              : undefined,
+                          projectPath:
+                            typeof item.tooltip === "string"
+                              ? item.tooltip
+                              : typeof (item as { path?: unknown }).path ===
+                                  "string"
+                                ? ((item as { path?: string }).path ?? undefined)
+                                : undefined,
+                          projectIconUrl:
+                            typeof item.iconUrl === "string"
+                              ? item.iconUrl
+                              : undefined,
+                        }}
                         sectionId={section.id}
                         onEvent={onEvent}
                         onItemContextMenu={openWorkspaceContextMenu}

--- a/src/extensions/default-layout/sidebar/workspace-row.tsx
+++ b/src/extensions/default-layout/sidebar/workspace-row.tsx
@@ -50,6 +50,9 @@ async function liveBranchStillMatches(
 export interface WorkspaceSidebarItem {
   id: string;
   projectId?: string;
+  projectLabel?: string;
+  projectPath?: string;
+  projectIconUrl?: string;
   hostId?: string;
   remoteId?: string;
   remoteProjectId?: string;
@@ -373,9 +376,14 @@ export function WorkspaceRow({
             sectionId,
             workspaceId: item.id,
             projectId: item.projectId,
+            projectLabel: item.projectLabel,
+            projectPath: item.projectPath,
+            iconUrl: item.projectIconUrl,
             hostId: item.hostId,
             remoteId: item.remoteId,
             remoteProjectId: item.remoteProjectId,
+            path: item.path,
+            label: item.label,
           },
           item.id,
         );
@@ -390,9 +398,14 @@ export function WorkspaceRow({
             sectionId,
             workspaceId: item.id,
             projectId: item.projectId,
+            projectLabel: item.projectLabel,
+            projectPath: item.projectPath,
+            iconUrl: item.projectIconUrl,
             hostId: item.hostId,
             remoteId: item.remoteId,
             remoteProjectId: item.remoteProjectId,
+            path: item.path,
+            label: item.label,
           },
           item.id,
         );

--- a/src/hooks/useDerivedRenderState.test.ts
+++ b/src/hooks/useDerivedRenderState.test.ts
@@ -12,6 +12,7 @@ const hostInfo: UseHostInfo = {
   setActiveHost: vi.fn(),
   mobileDevices: [],
   remoteProjectsByHost: {},
+  remoteProjectStatusByHost: {},
   hosts: [
     {
       id: "local:one",
@@ -404,11 +405,17 @@ describe("useDerivedRenderState", () => {
         ...hostInfo.hosts,
         {
           id: "remote:bender",
+          hostId: "local:bender",
           hostname: "bender.local",
           displayName: "bender",
           isLocal: false,
           paired: true,
           connected: true,
+          discovered: true,
+          candidates: ["bender.local:4242", "192.168.1.44:4242"],
+          fingerprint: "bender-fp",
+          createdAt: 1,
+          lastSeen: 2,
         },
       ],
       remoteProjectsByHost: {
@@ -482,7 +489,226 @@ describe("useDerivedRenderState", () => {
     });
     expect(result.current.renderState.host).toMatchObject({
       id: "remote:bender",
+      hostId: "local:bender",
       displayName: "bender",
+      paired: true,
+      connected: true,
+      discovered: true,
+      candidates: ["bender.local:4242", "192.168.1.44:4242"],
+      fingerprint: "bender-fp",
+      createdAt: 1,
+      lastSeen: 2,
+    });
+  });
+
+  it("does not mark a remote host connected until project sync is ready", () => {
+    const remoteHostInfo: UseHostInfo = {
+      ...hostInfo,
+      activeHostId: "remote:bender",
+      hosts: [
+        ...hostInfo.hosts,
+        {
+          id: "remote:bender",
+          hostname: "bender.local",
+          displayName: "bender",
+          isLocal: false,
+          paired: true,
+          connected: true,
+          discovered: true,
+        },
+      ],
+      remoteProjectStatusByHost: {
+        "remote:bender": {
+          state: "syncing",
+          updatedAt: 10,
+        },
+      },
+    };
+    const { result } = renderHook(() =>
+      useDerivedRenderState({
+        state: {
+          tabs: [],
+          activeTabId: OVERVIEW_TAB_ID,
+          project: null,
+          sidebar: { projects: [] },
+        },
+        buildSidebarHistory: vi.fn(() => []),
+        hostInfo: remoteHostInfo,
+      }),
+    );
+
+    expect(result.current.renderState.host).toMatchObject({
+      id: "remote:bender",
+      projectStatus: { state: "syncing" },
+    });
+    expect(
+      (
+        result.current.renderState.sidebar as {
+          hosts?: Array<{ id: string; hint: string }>;
+        }
+      ).hosts,
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "remote:bender", hint: "syncing" }),
+      ]),
+    );
+  });
+
+  it("surfaces remote project snapshot failures in the host sidebar", () => {
+    const remoteHostInfo: UseHostInfo = {
+      ...hostInfo,
+      activeHostId: "remote:bender",
+      hosts: [
+        ...hostInfo.hosts,
+        {
+          id: "remote:bender",
+          hostname: "bender.local",
+          displayName: "bender",
+          isLocal: false,
+          paired: true,
+          connected: true,
+          discovered: true,
+        },
+      ],
+      remoteProjectStatusByHost: {
+        "remote:bender": {
+          state: "error",
+          error: "timeout",
+          updatedAt: 10,
+        },
+      },
+    };
+    const { result } = renderHook(() =>
+      useDerivedRenderState({
+        state: {
+          tabs: [],
+          activeTabId: OVERVIEW_TAB_ID,
+          project: null,
+          sidebar: { projects: [] },
+        },
+        buildSidebarHistory: vi.fn(() => []),
+        hostInfo: remoteHostInfo,
+      }),
+    );
+
+    expect(result.current.renderState.host).toMatchObject({
+      id: "remote:bender",
+      projectStatus: { state: "error", error: "timeout" },
+    });
+    expect(
+      (
+        result.current.renderState.sidebar as {
+          hosts?: Array<{ id: string; hint: string; tooltip: string }>;
+        }
+      ).hosts,
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "remote:bender",
+          hint: "sync failed",
+          tooltip: "bender.local · timeout",
+        }),
+      ]),
+    );
+  });
+
+  it("marks selected remote workspace mirrors active", () => {
+    const remoteHostInfo: UseHostInfo = {
+      ...hostInfo,
+      activeHostId: "remote:bender",
+      hosts: [
+        ...hostInfo.hosts,
+        {
+          id: "remote:bender",
+          hostname: "bender.local",
+          displayName: "bender",
+          isLocal: false,
+          paired: true,
+          connected: true,
+        },
+      ],
+      remoteProjectStatusByHost: {
+        "remote:bender": { state: "ready", updatedAt: 10 },
+      },
+      remoteProjectsByHost: {
+        "remote:bender": [
+          {
+            id: "remote:bender::project::urandom",
+            remoteId: "urandom",
+            hostId: "remote:bender",
+            label: "urandom.io",
+            tooltip: "/remote/urandom",
+            path: "/remote/urandom",
+            active: false,
+            expanded: true,
+            workspaces: [
+              {
+                id: "remote:bender::workspace::james-brink/fix-direnv",
+                remoteId: "james-brink/fix-direnv",
+                projectId: "remote:bender::project::urandom",
+                remoteProjectId: "urandom",
+                hostId: "remote:bender",
+                label: "james-brink/fix-direnv",
+                branch: "james-brink/fix-direnv",
+                path: "/remote/urandom-fix-direnv",
+                active: false,
+                isMain: false,
+              },
+            ],
+          },
+        ],
+      },
+    };
+    const { result } = renderHook(() =>
+      useDerivedRenderState({
+        state: {
+          tabs: [],
+          activeTabId: OVERVIEW_TAB_ID,
+          project: {
+            id: "remote:bender::project::urandom",
+            hostId: "remote:bender",
+            path: "/remote/urandom",
+          },
+          activeProjectId: "remote:bender::project::urandom",
+          activeWorkspaceId: "remote:bender::workspace::james-brink/fix-direnv",
+          sidebar: { projects: [] },
+        },
+        buildSidebarHistory: vi.fn(() => []),
+        hostInfo: remoteHostInfo,
+      }),
+    );
+
+    const sidebar = result.current.renderState.sidebar as {
+      projects?: Array<{
+        id: string;
+        active?: boolean;
+        workspaces?: Array<{ id: string; active?: boolean }>;
+      }>;
+      projectsByHost?: Record<
+        string,
+        Array<{
+          id: string;
+          workspaces?: Array<{ id: string; active?: boolean }>;
+        }>
+      >;
+    };
+    expect(sidebar.projects?.[0]).toMatchObject({
+      id: "remote:bender::project::urandom",
+      active: false,
+      workspaces: [
+        {
+          id: "remote:bender::workspace::james-brink/fix-direnv",
+          active: true,
+        },
+      ],
+    });
+    expect(sidebar.projectsByHost?.["remote:bender"]?.[0]).toMatchObject({
+      workspaces: [
+        {
+          id: "remote:bender::workspace::james-brink/fix-direnv",
+          active: true,
+        },
+      ],
     });
   });
 

--- a/src/hooks/useDerivedRenderState.ts
+++ b/src/hooks/useDerivedRenderState.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { activeTabKind, OVERVIEW_TAB_ID, type Tab } from "../types/tab";
-import type { UseHostInfo } from "./useHostInfo";
+import type { RemoteProjectStatus, UseHostInfo } from "./useHostInfo";
 import { attachAgentActivity } from "./projectOps/agentActivity";
 import { isAgentTabInFlight } from "../utils/agentBusy";
 
@@ -85,6 +85,57 @@ function implicitWorkspaceLanding(
   return null;
 }
 
+function remoteHostHint(
+  host: {
+    connected?: boolean;
+    paired?: boolean;
+    discovered?: boolean;
+    hostname: string;
+  },
+  status: RemoteProjectStatus | undefined,
+  projectCount: number,
+): string {
+  if (status?.state === "syncing") return "syncing";
+  if (status?.state === "error") return "sync failed";
+  if (
+    host.connected === true &&
+    (status?.state === "ready" || projectCount > 0)
+  ) {
+    return "connected";
+  }
+  if (host.paired) return "paired";
+  if (host.discovered) return "available";
+  return host.hostname;
+}
+
+function overlaySidebarSelection<T extends { id: string; active?: boolean }>(
+  projects: T[],
+  activeProjectId: string | null,
+  activeWorkspaceId: string | null | undefined,
+): T[] {
+  return projects.map((project) => {
+    const workspaces = Array.isArray(
+      (project as { workspaces?: unknown }).workspaces,
+    )
+      ? ((project as { workspaces?: Array<{ id: string; isMain?: boolean }> })
+          .workspaces ?? [])
+      : undefined;
+    const nextWorkspaces = workspaces?.map((workspace) => ({
+      ...workspace,
+      active:
+        workspace.id === activeWorkspaceId ||
+        (workspace.isMain === true &&
+          project.id === activeProjectId &&
+          activeWorkspaceId == null),
+    }));
+    return {
+      ...project,
+      active: project.id === activeProjectId && activeWorkspaceId == null,
+      ...(nextWorkspaces ? { workspaces: nextWorkspaces } : {}),
+    };
+  });
+}
+
 export function useDerivedRenderState({
   state,
   buildSidebarHistory,
@@ -147,11 +198,22 @@ export function useDerivedRenderState({
       activeHostId && activeHostId !== hostInfo.localHostId
         ? (hostInfo.remoteProjectsByHost[activeHostId] ?? [])
         : sidebarProjects;
+    const selectedHostScopedProjects = Array.isArray(hostScopedProjects)
+      ? overlaySidebarSelection(
+          hostScopedProjects,
+          activeProjectId,
+          state.activeWorkspaceId as string | null | undefined,
+        )
+      : hostScopedProjects;
+    const activeRemoteProjectStatus =
+      activeHostId && activeHostId !== hostInfo.localHostId
+        ? hostInfo.remoteProjectStatusByHost[activeHostId]
+        : undefined;
     const remoteHostActive =
       activeHostId !== null &&
       activeHostId !== undefined &&
       activeHostId !== hostInfo.localHostId;
-    const activeProjectSidebarEntry = hostScopedProjects.find(
+    const activeProjectSidebarEntry = selectedHostScopedProjects.find(
       (p) => p.id === activeProjectId,
     );
     const projectDashboardWorkspaces =
@@ -160,7 +222,7 @@ export function useDerivedRenderState({
       ? (state.projects as { id: string }[])
       : [];
     const activeHostProjects = remoteHostActive
-      ? (hostScopedProjects as { id: string }[])
+      ? (selectedHostScopedProjects as { id: string }[])
       : projectsArr;
     const otherProjects = activeProjectId
       ? activeHostProjects.filter((p) => p.id !== activeProjectId)
@@ -201,26 +263,31 @@ export function useDerivedRenderState({
       ...existingProjectsDashboard,
       extraCards: existingProjectsDashboard.extraCards ?? [],
     };
-    const sidebarHosts = hostInfo.hosts.map((h) => ({
-      id: h.id,
-      label: h.displayName || h.hostname,
-      hostname: h.hostname,
-      fingerprint: h.fingerprint ?? h.fingerprintPrefix,
-      candidates: h.candidates,
-      paired: h.paired === true,
-      discovered: h.discovered === true,
-      hint: h.isLocal
-        ? "this mac"
-        : h.connected === true
-          ? "connected"
-          : h.paired
-            ? "paired"
-            : h.discovered
-              ? "available"
-              : h.hostname,
-      tooltip: h.hostname,
-      active: h.id === activeHostId,
-    }));
+    const sidebarHosts = hostInfo.hosts.map((h) => {
+      const status =
+        h.id !== hostInfo.localHostId
+          ? hostInfo.remoteProjectStatusByHost[h.id]
+          : undefined;
+      const projectCount =
+        h.id !== hostInfo.localHostId
+          ? (hostInfo.remoteProjectsByHost[h.id]?.length ?? 0)
+          : sidebarProjects.length;
+      return {
+        id: h.id,
+        label: h.displayName || h.hostname,
+        hostname: h.hostname,
+        fingerprint: h.fingerprint ?? h.fingerprintPrefix,
+        candidates: h.candidates,
+        paired: h.paired === true,
+        discovered: h.discovered === true,
+        hint: h.isLocal ? "this mac" : remoteHostHint(h, status, projectCount),
+        tooltip:
+          status?.state === "error" && status.error
+            ? `${h.hostname} · ${status.error}`
+            : h.hostname,
+        active: h.id === activeHostId,
+      };
+    });
     const activeMobileDeviceId =
       landing?.kind === "mobile-device" &&
       typeof (landing as { deviceId?: unknown }).deviceId === "string"
@@ -268,6 +335,24 @@ export function useDerivedRenderState({
         : landing;
     const activeHost =
       hostInfo.hosts.find((h) => h.id === activeHostId) ?? null;
+    const activeHostDetails = activeHost
+      ? {
+          id: activeHost.id,
+          hostId: activeHost.hostId,
+          hostname: activeHost.hostname,
+          displayName: activeHost.displayName,
+          isLocal: activeHost.isLocal,
+          fingerprint: activeHost.fingerprint ?? activeHost.fingerprintPrefix,
+          candidates: activeHost.candidates,
+          paired: activeHost.paired === true,
+          connected: activeHost.connected === true,
+          discovered: activeHost.discovered === true,
+          createdAt: activeHost.createdAt,
+          lastSeen: activeHost.lastSeen,
+          port: activeHost.port,
+          projectStatus: activeRemoteProjectStatus,
+        }
+      : null;
 
     // Overlay live agent-activity onto the sidebar project rows. The tab set
     // must span every workspace: the active one in `state.tabs` plus the
@@ -313,9 +398,9 @@ export function useDerivedRenderState({
       if (t.kind !== "agent") continue;
       if (isAgentTabInFlight(t)) runningIds.add(t.id);
     }
-    const sidebarProjectsWithAgent = Array.isArray(hostScopedProjects)
+    const sidebarProjectsWithAgent = Array.isArray(selectedHostScopedProjects)
       ? attachAgentActivity(
-          hostScopedProjects as Array<{
+          selectedHostScopedProjects as Array<{
             id: string;
             workspaces?: { path?: string; isMain?: boolean }[];
           }>,
@@ -330,9 +415,16 @@ export function useDerivedRenderState({
         host.id === hostInfo.localHostId
           ? sidebarProjects
           : (hostInfo.remoteProjectsByHost[host.id] ?? []);
-      projectsByHost[host.id] = Array.isArray(hostProjects)
+      const selectedHostProjects = Array.isArray(hostProjects)
+        ? overlaySidebarSelection(
+            hostProjects,
+            activeProjectId,
+            state.activeWorkspaceId as string | null | undefined,
+          )
+        : [];
+      projectsByHost[host.id] = Array.isArray(selectedHostProjects)
         ? attachAgentActivity(
-            hostProjects as Array<{
+            selectedHostProjects as Array<{
               id: string;
               workspaces?: { path?: string; isMain?: boolean }[];
             }>,
@@ -374,7 +466,7 @@ export function useDerivedRenderState({
       hosts: hostInfo.hosts,
       mobileDevices: hostInfo.mobileDevices,
       activeHostId,
-      host: activeHost,
+      host: activeHostDetails,
     };
   }, [
     buildSidebarHistory,
@@ -383,6 +475,7 @@ export function useDerivedRenderState({
     hostInfo.localHostId,
     hostInfo.mobileDevices,
     hostInfo.remoteProjectsByHost,
+    hostInfo.remoteProjectStatusByHost,
     state,
   ]);
 

--- a/src/hooks/useHostInfo.test.ts
+++ b/src/hooks/useHostInfo.test.ts
@@ -1,18 +1,35 @@
 // @vitest-environment jsdom
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
 
 // Tauri mocks: invoke returns a local host; listen exposes a hook so
 // tests can fire host-discovered / host-removed payloads.
-const eventListeners = new Map<string, Array<(event: { payload: unknown }) => void>>();
+const eventListeners = new Map<
+  string,
+  Array<(event: { payload: unknown }) => void>
+>();
 
 const remoteDevices: unknown[] = [];
 const remoteHosts: unknown[] = [];
-const remoteSnapshots = new Map<string, { projects: unknown; icons?: unknown }>();
+const remoteSnapshots = new Map<
+  string,
+  { projects: unknown; icons?: unknown }
+>();
+const remoteSnapshotErrors = new Map<string, string>();
 
 vi.mock("@tauri-apps/api/core", () => ({
-  invoke: (cmd: string) =>
-    Promise.resolve(
+  invoke: (cmd: string, args?: { id?: string }) => {
+    if (cmd === "remote_host_project_snapshot") {
+      const hostId = args?.id ?? "remote:bender";
+      const error = remoteSnapshotErrors.get(hostId);
+      if (error) return Promise.reject(new Error(error));
+      return Promise.resolve({
+        hostId,
+        projects: remoteSnapshots.get(hostId)?.projects ?? {},
+        icons: remoteSnapshots.get(hostId)?.icons ?? {},
+      });
+    }
+    return Promise.resolve(
       cmd === "host_info"
         ? {
             id: "local:abc",
@@ -24,18 +41,13 @@ vi.mock("@tauri-apps/api/core", () => ({
           ? remoteDevices
           : cmd === "remote_hosts_list"
             ? remoteHosts
-            : cmd === "remote_host_project_snapshot"
-              ? {
-                  hostId: "remote:bender",
-                  projects: remoteSnapshots.get("remote:bender")?.projects ?? {},
-                  icons: remoteSnapshots.get("remote:bender")?.icons ?? {},
-                }
-          : null,
-    ),
+            : null,
+    );
+  },
 }));
 
 vi.mock("@tauri-apps/api/event", () => ({
-  listen: <T,>(event: string, cb: (e: { payload: T }) => void) => {
+  listen: <T>(event: string, cb: (e: { payload: T }) => void) => {
     const list = eventListeners.get(event) ?? [];
     list.push(cb as (event: { payload: unknown }) => void);
     eventListeners.set(event, list);
@@ -56,6 +68,14 @@ function fireEvent(name: string, payload: unknown): void {
 }
 
 describe("useHostInfo", () => {
+  beforeEach(() => {
+    eventListeners.clear();
+    remoteDevices.length = 0;
+    remoteHosts.length = 0;
+    remoteSnapshots.clear();
+    remoteSnapshotErrors.clear();
+  });
+
   it("resolves the local host and defaults activeHostId to it", async () => {
     const { useHostInfo } = await import("./useHostInfo");
     const { _resetLocalHostCacheForTests } = await import("../hosts");
@@ -95,13 +115,17 @@ describe("useHostInfo", () => {
       });
     });
     await waitFor(() => {
-      expect(result.current.hosts.find((h) => h.id === "remote:bender")).toBeTruthy();
+      expect(
+        result.current.hosts.find((h) => h.id === "remote:bender"),
+      ).toBeTruthy();
     });
     act(() => {
       fireEvent("host-removed", { id: "remote:bender" });
     });
     await waitFor(() => {
-      expect(result.current.hosts.find((h) => h.id === "remote:bender")).toBeUndefined();
+      expect(
+        result.current.hosts.find((h) => h.id === "remote:bender"),
+      ).toBeUndefined();
     });
   });
 
@@ -126,7 +150,9 @@ describe("useHostInfo", () => {
     const { result } = renderHook(() => useHostInfo());
 
     await waitFor(() => {
-      expect(result.current.hosts.find((h) => h.id === "device:dev-iphone")).toBeUndefined();
+      expect(
+        result.current.hosts.find((h) => h.id === "device:dev-iphone"),
+      ).toBeUndefined();
       const device = result.current.mobileDevices.find(
         (h) => h.id === "device:dev-iphone",
       );
@@ -185,12 +211,16 @@ describe("useHostInfo", () => {
     const { result } = renderHook(() => useHostInfo());
 
     await waitFor(() => {
-      expect(result.current.hosts.find((h) => h.id === "remote:bender")).toMatchObject({
+      expect(
+        result.current.hosts.find((h) => h.id === "remote:bender"),
+      ).toMatchObject({
         displayName: "bender",
         paired: true,
         connected: false,
       });
-      expect(result.current.remoteProjectsByHost["remote:bender"]?.[0]).toMatchObject({
+      expect(
+        result.current.remoteProjectsByHost["remote:bender"]?.[0],
+      ).toMatchObject({
         id: "remote:bender::project::p1",
         remoteId: "p1",
         label: "aethon",
@@ -202,6 +232,40 @@ describe("useHostInfo", () => {
             branch: "main",
           }),
         ],
+      });
+      expect(
+        result.current.remoteProjectStatusByHost["remote:bender"],
+      ).toMatchObject({
+        state: "ready",
+      });
+    });
+  });
+
+  it("keeps failed remote project snapshots visible as sync errors", async () => {
+    const { useHostInfo } = await import("./useHostInfo");
+    const { _resetLocalHostCacheForTests } = await import("../hosts");
+    _resetLocalHostCacheForTests();
+    remoteHosts.push({
+      id: "remote:bender",
+      hostId: "local:bender",
+      hostname: "bender.local",
+      displayName: "bender",
+      fingerprint: "bender",
+      candidates: ["bender.local:4242"],
+      createdAt: 1,
+      lastSeenAt: 2,
+    });
+    remoteSnapshotErrors.set("remote:bender", "timeout");
+
+    const { result } = renderHook(() => useHostInfo());
+
+    await waitFor(() => {
+      expect(result.current.remoteProjectsByHost["remote:bender"]).toEqual([]);
+      expect(
+        result.current.remoteProjectStatusByHost["remote:bender"],
+      ).toMatchObject({
+        state: "error",
+        error: "Error: timeout",
       });
     });
   });
@@ -228,7 +292,9 @@ describe("useHostInfo", () => {
     const { result } = renderHook(() => useHostInfo());
 
     await waitFor(() => {
-      expect(result.current.hosts.find((h) => h.id === "remote:bender")).toMatchObject({
+      expect(
+        result.current.hosts.find((h) => h.id === "remote:bender"),
+      ).toMatchObject({
         paired: true,
         connected: false,
       });
@@ -244,19 +310,26 @@ describe("useHostInfo", () => {
       });
     });
     await waitFor(() => {
-      expect(result.current.hosts.find((h) => h.id === "remote:bender")).toMatchObject({
+      expect(
+        result.current.hosts.find((h) => h.id === "remote:bender"),
+      ).toMatchObject({
         paired: true,
         connected: false,
+        discovered: true,
         candidates: ["bender.local:4242", "192.168.1.44:4242"],
+        lastSeen: 3,
       });
     });
     act(() => {
       fireEvent("host-removed", { id: "remote:bender" });
     });
     await waitFor(() => {
-      expect(result.current.hosts.find((h) => h.id === "remote:bender")).toMatchObject({
+      expect(
+        result.current.hosts.find((h) => h.id === "remote:bender"),
+      ).toMatchObject({
         paired: true,
         connected: false,
+        discovered: false,
       });
     });
     act(() => {
@@ -266,7 +339,9 @@ describe("useHostInfo", () => {
       });
     });
     await waitFor(() => {
-      expect(result.current.hosts.find((h) => h.id === "remote:bender")).toMatchObject({
+      expect(
+        result.current.hosts.find((h) => h.id === "remote:bender"),
+      ).toMatchObject({
         paired: true,
         connected: true,
       });

--- a/src/hooks/useHostInfo.ts
+++ b/src/hooks/useHostInfo.ts
@@ -23,6 +23,7 @@ export interface RemoteWorkspaceMirror {
   remoteId: string;
   projectId: string;
   remoteProjectId: string;
+  hostId: string;
   label: string;
   branch?: string | null;
   path: string;
@@ -45,6 +46,12 @@ export interface RemoteProjectMirror {
   workspaces: RemoteWorkspaceMirror[];
 }
 
+export interface RemoteProjectStatus {
+  state: "syncing" | "ready" | "error";
+  error?: string;
+  updatedAt: number;
+}
+
 export interface UseHostInfo {
   hosts: Host[];
   mobileDevices: Host[];
@@ -54,6 +61,7 @@ export interface UseHostInfo {
   setActiveHost: (id: string | null) => void;
   localHostId: string | null;
   remoteProjectsByHost: Record<string, RemoteProjectMirror[]>;
+  remoteProjectStatusByHost: Record<string, RemoteProjectStatus>;
 }
 
 export function useHostInfo(): UseHostInfo {
@@ -67,6 +75,9 @@ export function useHostInfo(): UseHostInfo {
   const [devices, setDevices] = useState<Host[]>([]);
   const [remoteProjectsByHost, setRemoteProjectsByHost] = useState<
     Record<string, RemoteProjectMirror[]>
+  >({});
+  const [remoteProjectStatusByHost, setRemoteProjectStatusByHost] = useState<
+    Record<string, RemoteProjectStatus>
   >({});
   const [activeHostId, setActiveHostState] = useState<string | null>(null);
 
@@ -84,6 +95,10 @@ export function useHostInfo(): UseHostInfo {
 
   function pairedHost(remote: RemoteHost): Host {
     const previous = pairedHostsRef.current.get(remote.id);
+    const previousLastSeen =
+      typeof previous?.lastSeen === "number" ? previous.lastSeen : 0;
+    const remoteLastSeen =
+      typeof remote.lastSeenAt === "number" ? remote.lastSeenAt : 0;
     return {
       id: remote.id,
       hostId: remote.hostId,
@@ -92,16 +107,21 @@ export function useHostInfo(): UseHostInfo {
       isLocal: false,
       fingerprint: remote.fingerprint,
       fingerprintPrefix: remote.fingerprint,
-      candidates: remote.candidates,
+      candidates:
+        previous?.discovered === true && previous.candidates?.length
+          ? previous.candidates
+          : remote.candidates,
       paired: true,
       connected: previous?.connected === true,
+      discovered: previous?.discovered === true,
       createdAt: remote.createdAt,
-      lastSeen: remote.lastSeenAt,
+      lastSeen: Math.max(previousLastSeen, remoteLastSeen) || undefined,
     };
   }
 
   function deviceHost(device: RemoteDevice): Host | null {
-    if (!device.id || device.revoked || device.platform === "desktop") return null;
+    if (!device.id || device.revoked || device.platform === "desktop")
+      return null;
     const platform = device.platform || "mobile";
     return {
       id: `device:${device.id}`,
@@ -162,38 +182,51 @@ export function useHostInfo(): UseHostInfo {
         const offDiscovered = await listen<Host>("host-discovered", (event) => {
           const host = event.payload;
           if (!host?.id) return;
+          const candidates =
+            Array.isArray(host.candidates) && host.candidates.length > 0
+              ? host.candidates
+              : host.port
+                ? [`${host.hostname}:${host.port}`]
+                : undefined;
           remotesRef.current.set(host.id, {
             ...host,
             isLocal: false,
             discovered: true,
             connected: false,
-            candidates:
-              Array.isArray(host.candidates) && host.candidates.length > 0
-                ? host.candidates
-                : host.port
-                  ? [`${host.hostname}:${host.port}`]
-                  : undefined,
+            candidates,
           });
           const paired = pairedHostsRef.current.get(host.id);
           if (paired) {
             pairedHostsRef.current.set(host.id, {
               ...paired,
               hostname: host.hostname,
-              candidates: host.candidates ?? paired.candidates,
+              candidates: candidates ?? paired.candidates,
               connected: paired.connected === true,
+              discovered: true,
               lastSeen: host.lastSeen ?? paired.lastSeen,
             });
             emitPairedHosts();
           }
           emitRemotes();
         });
-        const offRemoved = await listen<{ id: string }>("host-removed", (event) => {
-          const id = event.payload?.id;
-          if (!id) return;
-          if (remotesRef.current.delete(id)) {
-            emitRemotes();
-          }
-        });
+        const offRemoved = await listen<{ id: string }>(
+          "host-removed",
+          (event) => {
+            const id = event.payload?.id;
+            if (!id) return;
+            if (remotesRef.current.delete(id)) {
+              emitRemotes();
+            }
+            const paired = pairedHostsRef.current.get(id);
+            if (paired?.discovered === true) {
+              pairedHostsRef.current.set(id, {
+                ...paired,
+                discovered: false,
+              });
+              emitPairedHosts();
+            }
+          },
+        );
         const offStatus = await listen<{ id?: string; connected?: boolean }>(
           "remote-host-status-changed",
           (event) => {
@@ -240,39 +273,88 @@ export function useHostInfo(): UseHostInfo {
           next.set(remote.id, pairedHost(remote));
         }
         const nextHosts = Array.from(next.values());
-        if (!hostsEqual(Array.from(pairedHostsRef.current.values()), nextHosts)) {
+        if (
+          !hostsEqual(Array.from(pairedHostsRef.current.values()), nextHosts)
+        ) {
           pairedHostsRef.current = next;
           emitPairedHosts();
         }
-        for (const hostId of next.keys()) {
+        const hostIds = Array.from(next.keys());
+        setRemoteProjectsByHost((prev) =>
+          Object.fromEntries(
+            Object.entries(prev).filter(([hostId]) => next.has(hostId)),
+          ),
+        );
+        setRemoteProjectStatusByHost((prev) =>
+          Object.fromEntries(
+            Object.entries(prev).filter(([hostId]) => next.has(hostId)),
+          ),
+        );
+        for (const hostId of hostIds) {
           if (eventStreamsRef.current.has(hostId)) continue;
           eventStreamsRef.current.add(hostId);
           void remoteHostReconnect(hostId).catch(() => {
             eventStreamsRef.current.delete(hostId);
           });
         }
-        void refreshRemoteProjectSnapshots(Array.from(next.keys()));
+        void refreshRemoteProjectSnapshots(hostIds);
       } catch {
         // A fresh install or tests may not have the command available yet.
       }
     }
 
-    async function refreshRemoteProjectSnapshots(hostIds: string[]): Promise<void> {
+    async function refreshRemoteProjectSnapshots(
+      hostIds: string[],
+    ): Promise<void> {
+      const startedAt = Date.now();
+      setRemoteProjectStatusByHost((prev) => ({
+        ...prev,
+        ...Object.fromEntries(
+          hostIds.map((hostId) => [
+            hostId,
+            { state: "syncing" as const, updatedAt: startedAt },
+          ]),
+        ),
+      }));
       const entries = await Promise.all(
         hostIds.map(async (hostId) => {
           try {
             const snapshot = await remoteHostProjectSnapshot(hostId);
             return [
               hostId,
-              projectMirrorsFromSnapshot(hostId, snapshot.projects, snapshot.icons),
+              projectMirrorsFromSnapshot(
+                hostId,
+                snapshot.projects,
+                snapshot.icons,
+              ),
+              { state: "ready" as const, updatedAt: Date.now() },
             ] as const;
-          } catch {
-            return [hostId, []] as const;
+          } catch (err) {
+            return [
+              hostId,
+              [] as RemoteProjectMirror[],
+              {
+                state: "error" as const,
+                error: String(err),
+                updatedAt: Date.now(),
+              },
+            ] as const;
           }
         }),
       );
       if (cancelled) return;
-      setRemoteProjectsByHost(Object.fromEntries(entries));
+      setRemoteProjectsByHost((prev) => ({
+        ...prev,
+        ...Object.fromEntries(
+          entries.map(([hostId, projects]) => [hostId, projects]),
+        ),
+      }));
+      setRemoteProjectStatusByHost((prev) => ({
+        ...prev,
+        ...Object.fromEntries(
+          entries.map(([hostId, , status]) => [hostId, status]),
+        ),
+      }));
     }
 
     void refreshRemoteHosts();
@@ -355,6 +437,7 @@ export function useHostInfo(): UseHostInfo {
     setActiveHost,
     localHostId: localHost?.id ?? null,
     remoteProjectsByHost,
+    remoteProjectStatusByHost,
   };
 }
 
@@ -393,7 +476,9 @@ function projectMirrorsFromSnapshot(
         : {};
   return projects
     .filter(
-      (p): p is {
+      (
+        p,
+      ): p is {
         id: string;
         label: string;
         path: string;
@@ -416,7 +501,9 @@ function projectMirrorsFromSnapshot(
         : [];
       const workspaces = rawWorkspaces
         .filter(
-          (w): w is {
+          (
+            w,
+          ): w is {
             id: string;
             path: string;
             label?: string;

--- a/src/styles/chrome/dashboard.css
+++ b/src/styles/chrome/dashboard.css
@@ -81,6 +81,176 @@
   font-size: var(--text-xs);
 }
 
+.a2ui-host-details {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  text-align: left;
+}
+
+.a2ui-host-details-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.a2ui-host-details-head h2 {
+  margin: 0;
+  color: var(--text);
+  font-size: var(--text-md);
+  font-weight: 600;
+}
+
+.a2ui-host-details-head p {
+  margin: var(--space-1) 0 0;
+  color: var(--text-dim);
+  font-size: var(--text-sm);
+}
+
+.a2ui-host-details-status {
+  flex: 0 0 auto;
+  padding: 4px 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-dim);
+  font-size: var(--text-xs);
+  font-weight: 600;
+}
+
+.a2ui-host-details-status--reachable {
+  color: var(--accent);
+  border-color: color-mix(in oklab, var(--accent) 34%, var(--border));
+}
+
+.a2ui-host-details-status--connected {
+  color: var(--success);
+  border-color: color-mix(in oklab, var(--success) 34%, var(--border));
+}
+
+.a2ui-host-details-status--error {
+  color: var(--error);
+  border-color: color-mix(in oklab, var(--error) 34%, var(--border));
+}
+
+.a2ui-host-details-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-3);
+  margin: 0;
+}
+
+.a2ui-host-details-grid > div {
+  min-width: 0;
+}
+
+.a2ui-host-details-wide {
+  grid-column: 1 / -1;
+}
+
+.a2ui-host-details dt {
+  margin: 0 0 var(--space-1);
+  color: var(--text-dim);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.a2ui-host-details dd {
+  margin: 0;
+  color: var(--text);
+  font-size: var(--text-sm);
+  overflow-wrap: anywhere;
+}
+
+.a2ui-host-details code {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+}
+
+.a2ui-host-details-muted {
+  color: var(--text-dim);
+}
+
+.a2ui-host-candidates {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 220px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+.a2ui-host-candidates--primary {
+  max-height: none;
+  overflow: visible;
+}
+
+.a2ui-host-candidates li {
+  min-width: 0;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+}
+
+.a2ui-host-candidate-copy {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+  max-width: 100%;
+  padding: 4px 8px;
+  color: inherit;
+  background: transparent;
+  border: 0;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font: inherit;
+}
+
+.a2ui-host-candidate-copy:hover {
+  background: var(--bg-hover);
+}
+
+.a2ui-host-candidate-copy:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.a2ui-host-candidate-copy code {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.a2ui-host-candidate-copied {
+  flex: 0 0 auto;
+  color: var(--accent);
+  font-size: var(--text-xs);
+  font-weight: 600;
+}
+
+.a2ui-host-candidates-raw {
+  margin-top: var(--space-3);
+}
+
+.a2ui-host-candidates-raw summary {
+  color: var(--text-dim);
+  cursor: pointer;
+  font-size: var(--text-xs);
+}
+
+.a2ui-host-candidates-raw[open] summary {
+  margin-bottom: var(--space-2);
+}
+
 /* Project-card icon — 20px square before the label. The
    --initial modifier renders a deterministic letter tile for projects
    without a discovered logo. */
@@ -190,6 +360,13 @@ span.a2ui-project-card-icon--initial {
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--text-dim);
+}
+
+.a2ui-remote-projects-empty p {
+  margin: 0;
+  color: var(--text-dim);
+  font-size: var(--text-sm);
+  line-height: 1.45;
 }
 
 .a2ui-projects-dashboard-grid {
@@ -558,10 +735,10 @@ button.a2ui-gh-stat:hover {
   border-color: var(--accent);
 }
 .a2ui-project-dashboard-startup-policy {
-  flex-direction: row;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: var(--space-2) var(--space-3);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-1);
   margin-top: calc(var(--space-1) * -1);
   color: var(--text-dim);
   font-size: var(--chrome-text-compact);
@@ -570,6 +747,8 @@ button.a2ui-gh-stat:hover {
   display: inline-flex;
   align-items: center;
   gap: var(--space-2);
+  min-width: 0;
+  width: 100%;
   color: var(--text);
   cursor: pointer;
   user-select: none;
@@ -587,11 +766,18 @@ button.a2ui-gh-stat:hover {
   opacity: 0.56;
 }
 .a2ui-project-dashboard-startup-label {
+  min-width: 0;
   font-weight: 500;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
 }
 .a2ui-project-dashboard-startup-hint {
-  min-width: min(100%, 22rem);
+  display: block;
+  min-width: 0;
+  max-width: 100%;
   color: var(--text-dim);
+  font-size: var(--text-xs);
+  line-height: 1.35;
 }
 
 .a2ui-project-dashboard-workspaces {


### PR DESCRIPTION
## Summary
- add a detailed remote-host overview with paired/seen timestamps, fingerprint, reachability, and copyable connection candidates
- keep noisy/raw IPv6 and stale candidates collapsed while exposing primary connection candidates
- track remote project snapshot state so the sidebar shows syncing/sync failed instead of claiming connected with no projects
- prefer newest remote connection candidates in the native client and make remote workspace clicks self-contained when derived mirrors are absent from route state

## Validation
- bunx vitest run src/hooks/useHostInfo.test.ts src/hooks/useDerivedRenderState.test.ts src/extensions/default-layout/dashboard/projects-dashboard.test.tsx src/extensions/default-layout/sidebar/index.test.tsx src/eventRoutes/sidebar.test.ts
- bun run typecheck
- bun run lint
- cargo test --manifest-path src-tauri/Cargo.toml --lib -- server::remote::client::tests::remote_candidates_prefer_newest_addresses
- Live dev UAT against Bender: remote host moved from syncing to connected, candidates copied to clipboard, urandom.io populated, and the remote workspace row opened the workspace landing
