### PR TITLE
feat(models): support Codex 5.6 models and efforts

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -439,7 +439,8 @@ surface.
 - [x] **Enforced plan mode + reasoning controls** (`929c9cc`, `#319`,
       `8eaab89`) — `/plan` / `Shift+Tab` planning-only mode the agent
       enforces, a compact plan-mode toggle, and Codex reasoning-effort
-      controls (`[agent] thinking_level`).
+      controls (`[agent] thinking_level`), including model-specific GPT-5.6
+      Sol/Terra/Luna effort sets, Max, and Ultra delegation.
 - [x] **Memory** (`#270`) — `/memory`; per-user and resolved-project memory
       the agent can read and write.
 - [x] **Editor + dashboards** (`#71`, `db89c19`) — Monaco editor, file tree,
@@ -696,7 +697,7 @@ font_size = 14           # clamps to 10-24 and writes --app-font-size
 
 [agent]
 model = "anthropic/claude-sonnet-4-6"   # seeds the picker/default display
-thinking_level = "medium"               # off|minimal|low|medium|high|xhigh
+thinking_level = "medium"               # off|minimal|low|medium|high|xhigh|max|ultra
 # codex_fast_mode, provider/bash/subagent timeouts, idle_retire_minutes
 
 [mcp]

--- a/agent/auth-profiles/services-cache.ts
+++ b/agent/auth-profiles/services-cache.ts
@@ -122,6 +122,7 @@ export function refreshGlobalAuthServicesIfChanged(
   if (refreshed) {
     state.authStorage.reload();
     state.modelRegistry.refresh();
+    registerOpenAIPreviewModels(state.modelRegistry);
     globalAuthMtimes.set(state, authMtimeMs);
   }
   return refreshed;
@@ -211,6 +212,7 @@ function servicesForProfileWithStatus(
 function refreshServicePair(services: AuthProfileServices): void {
   services.authStorage.reload();
   services.modelRegistry.refresh();
+  registerOpenAIPreviewModels(services.modelRegistry);
 }
 
 function fileMtimeMs(path: string): number | undefined {

--- a/agent/chat.ts
+++ b/agent/chat.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from "node:crypto";
 import type { Api, ImageContent, Model } from "@mariozechner/pi-ai";
-import type { ThinkingLevel } from "@mariozechner/pi-agent-core";
 import type { AethonAgentState, TabRecord } from "./state";
 import type { DispatcherDeps, InboundMessage } from "./dispatcherTypes";
 import { maybeExitForReload } from "./dispatcherTypes";
@@ -31,6 +30,15 @@ import {
 import { emitSessionEvent } from "./aethon-api-sessions";
 import { logger } from "./logger";
 import { isUnderlyingSessionBusy } from "./session-busy";
+import {
+  codexReasoningLevels,
+  isCodexExtendedReasoningEffort,
+  normalizeAethonThinkingLevel,
+  piThinkingLevel,
+  selectedThinkingLevel,
+  setTabThinkingLevel,
+  type AethonThinkingLevel,
+} from "./codex-reasoning";
 
 const chatLog = logger.scope("chat");
 
@@ -126,7 +134,15 @@ export async function handleChat(
       ? {
           cwdOverride,
           initialModel,
-          thinkingLevel: requestedModel.thinkingLevel,
+          thinkingLevel: requestedModel.thinkingLevel
+            ? piThinkingLevel(requestedModel.thinkingLevel)
+            : undefined,
+          ...(requestedModel.thinkingLevel &&
+          isCodexExtendedReasoningEffort(requestedModel.thinkingLevel)
+            ? {
+                codexExtendedReasoningEffort: requestedModel.thinkingLevel,
+              }
+            : {}),
         }
       : {},
   );
@@ -138,7 +154,9 @@ export async function handleChat(
     refreshTabSessionModelFromAuthServices(state, tabId);
   }
   if (requestedModel.thinkingLevel) {
-    tab.session.setThinkingLevel(requestedModel.thinkingLevel);
+    setTabThinkingLevel(tab, requestedModel.thinkingLevel, {
+      clampUnsupportedExtended: true,
+    });
   }
   const planMode = state.tabPlanMode.get(tabId) === true;
   const wantsSteer = msg.mode === "steer";
@@ -407,7 +425,9 @@ export async function handleSetModel(
   try {
     await tab.session.setModel(next);
     if (requestedModel.thinkingLevel) {
-      tab.session.setThinkingLevel(requestedModel.thinkingLevel);
+      setTabThinkingLevel(tab, requestedModel.thinkingLevel);
+    } else {
+      tab.codexExtendedReasoningEffort = undefined;
     }
     await state.resourceLoader.reload();
   } catch (err) {
@@ -431,7 +451,7 @@ export async function handleSetThinkingLevel(
   msg: InboundMessage,
 ): Promise<void> {
   const tabId = msg.tabId ?? "default";
-  const level = normalizeThinkingLevel(msg.thinkingLevel ?? msg.value);
+  const level = normalizeAethonThinkingLevel(msg.thinkingLevel ?? msg.value);
   if (!level) {
     deps.send({
       type: "error",
@@ -451,8 +471,10 @@ export async function handleSetThinkingLevel(
     return;
   }
   try {
-    tab.session.setThinkingLevel(level);
-    state.settingsManager.setDefaultThinkingLevel(level);
+    setTabThinkingLevel(tab, level);
+    if (!isCodexExtendedReasoningEffort(level)) {
+      state.settingsManager.setDefaultThinkingLevel(level);
+    }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     deps.send({
@@ -495,34 +517,21 @@ export function modelStatePayload(
     model:
       modelOverride ??
       (session.model ? `${session.model.provider}/${session.model.id}` : ""),
-    thinkingLevel: session.thinkingLevel,
-    thinkingLevels: session.getAvailableThinkingLevels?.() ?? [],
+    thinkingLevel: selectedThinkingLevel(tab),
+    thinkingLevels:
+      codexReasoningLevels(session.model ?? undefined) ??
+      session.getAvailableThinkingLevels?.() ??
+      [],
     codexFastMode: state.codexFastMode,
     codexFastModeSupported: supportsCodexFastMode(session.model),
   };
 }
 
-const THINKING_LEVELS = new Set<ThinkingLevel>([
-  "off",
-  "minimal",
-  "low",
-  "medium",
-  "high",
-  "xhigh",
-]);
-
-function normalizeThinkingLevel(value: unknown): ThinkingLevel | undefined {
-  return typeof value === "string" &&
-    THINKING_LEVELS.has(value as ThinkingLevel)
-    ? (value as ThinkingLevel)
-    : undefined;
-}
-
 function parseModelAndThinking(
   rawModel: string | undefined,
   rawLevel: unknown,
-): { modelId?: string; thinkingLevel?: ThinkingLevel } {
-  const explicitLevel = normalizeThinkingLevel(rawLevel);
+): { modelId?: string; thinkingLevel?: AethonThinkingLevel } {
+  const explicitLevel = normalizeAethonThinkingLevel(rawLevel);
   if (!rawModel) return explicitLevel ? { thinkingLevel: explicitLevel } : {};
   const idx = rawModel.lastIndexOf(":");
   if (idx <= 0)
@@ -531,7 +540,7 @@ function parseModelAndThinking(
       ...(explicitLevel ? { thinkingLevel: explicitLevel } : {}),
     };
   const modelId = rawModel.slice(0, idx);
-  const suffix = normalizeThinkingLevel(rawModel.slice(idx + 1));
+  const suffix = normalizeAethonThinkingLevel(rawModel.slice(idx + 1));
   if (!modelId.startsWith("openai-codex/") || !suffix)
     return {
       modelId: rawModel,

--- a/agent/codex-fast-mode.test.ts
+++ b/agent/codex-fast-mode.test.ts
@@ -54,6 +54,31 @@ describe("Codex Fast mode", () => {
     );
   });
 
+  it("reads an extended effort from the matching tab session", async () => {
+    const codexModel = model("openai-codex", "gpt-5.6-sol");
+    const session = {
+      model: codexModel,
+      agent: {
+        onPayload: vi.fn((payload: unknown) => Promise.resolve(payload)),
+      },
+    };
+    const state = {
+      codexFastMode: false,
+      tabs: new Map([
+        [
+          "tab-1",
+          { session, codexExtendedReasoningEffort: "ultra" as const },
+        ],
+      ]),
+    } as unknown as AethonAgentState;
+
+    installCodexFastModePayloadHook(state, session);
+
+    await expect(session.agent.onPayload({})).resolves.toEqual({
+      reasoning: { effort: "ultra" },
+    });
+  });
+
   it("adds priority service_tier only when enabled and supported", () => {
     const payload = { model: "gpt-5.5", input: [] };
     expect(

--- a/agent/codex-fast-mode.test.ts
+++ b/agent/codex-fast-mode.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { Model } from "@mariozechner/pi-ai";
 import type { AethonAgentState } from "./state";
 import {
+  applyCodexModeToPayload,
   applyCodexFastModeToPayload,
   installCodexFastModePayloadHook,
   supportsCodexFastMode,
@@ -72,5 +73,28 @@ describe("Codex Fast mode", () => {
     expect(
       applyCodexFastModeToPayload(payload, true, model("openai", "gpt-5.5")),
     ).toBe(payload);
+  });
+
+  it("sends GPT-5.6 Max and Ultra as distinct Codex efforts", () => {
+    const sol = model("openai-codex", "gpt-5.6-sol");
+    expect(applyCodexModeToPayload({}, false, "max", sol)).toEqual({
+      reasoning: { effort: "max" },
+    });
+    expect(
+      applyCodexModeToPayload(
+        { reasoning: { effort: "xhigh", summary: "auto" } },
+        false,
+        "ultra",
+        sol,
+      ),
+    ).toEqual({ reasoning: { effort: "ultra", summary: "auto" } });
+    expect(
+      applyCodexModeToPayload(
+        {},
+        false,
+        "ultra",
+        model("openai-codex", "gpt-5.5"),
+      ),
+    ).toEqual({});
   });
 });

--- a/agent/codex-fast-mode.ts
+++ b/agent/codex-fast-mode.ts
@@ -81,10 +81,13 @@ export function installCodexFastModePayloadHook(
     const next = originalOnPayload
       ? await originalOnPayload(payload, model)
       : payload;
-    const effort = state.tabs
-      ? [...state.tabs.values()].find((tab) => tab.session === session)
-          ?.codexExtendedReasoningEffort
-      : undefined;
+    let effort: CodexExtendedReasoningEffort | undefined;
+    for (const tab of state.tabs?.values() ?? []) {
+      if (tab.session === session) {
+        effort = tab.codexExtendedReasoningEffort;
+        break;
+      }
+    }
     return applyCodexModeToPayload(
       next,
       state.codexFastMode,

--- a/agent/codex-fast-mode.ts
+++ b/agent/codex-fast-mode.ts
@@ -1,6 +1,7 @@
 import type { Api, Model } from "@mariozechner/pi-ai";
 import type { AethonAgentState } from "./state";
 import { modelSupportsPriorityServiceTier } from "./model-capabilities";
+import type { CodexExtendedReasoningEffort } from "./codex-reasoning";
 
 const patchedAgents = new WeakSet<object>();
 
@@ -33,6 +34,29 @@ export function applyCodexFastModeToPayload(
   return { ...payload, service_tier: "priority" } satisfies ProviderPayload;
 }
 
+export function applyCodexModeToPayload(
+  payload: unknown,
+  fastModeEnabled: boolean,
+  extendedEffort: CodexExtendedReasoningEffort | undefined,
+  model: Model<Api> | undefined,
+): unknown {
+  let next = applyCodexFastModeToPayload(payload, fastModeEnabled, model);
+  if (
+    !extendedEffort ||
+    model?.provider !== "openai-codex" ||
+    !/^gpt-5\.6-(?:sol|terra|luna)$/.test(model.id) ||
+    !isRecord(next)
+  ) {
+    return next;
+  }
+  const currentReasoning = isRecord(next.reasoning) ? next.reasoning : {};
+  next = {
+    ...next,
+    reasoning: { ...currentReasoning, effort: extendedEffort },
+  };
+  return next;
+}
+
 /**
  * Pi exposes request-body mutation through Agent.onPayload, while Codex usage
  * accounting reads the requested service tier from stream options. Patch both
@@ -57,9 +81,14 @@ export function installCodexFastModePayloadHook(
     const next = originalOnPayload
       ? await originalOnPayload(payload, model)
       : payload;
-    return applyCodexFastModeToPayload(
+    const effort = state.tabs
+      ? [...state.tabs.values()].find((tab) => tab.session === session)
+          ?.codexExtendedReasoningEffort
+      : undefined;
+    return applyCodexModeToPayload(
       next,
       state.codexFastMode,
+      effort,
       model ?? session.model,
     );
   };

--- a/agent/codex-reasoning.test.ts
+++ b/agent/codex-reasoning.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Model } from "@mariozechner/pi-ai";
+import type { TabRecord } from "./state";
+import {
+  codexReasoningLevels,
+  selectedThinkingLevel,
+  setTabThinkingLevel,
+} from "./codex-reasoning";
+
+function model(id: string): Model<never> {
+  return {
+    provider: "openai-codex",
+    id,
+    name: id,
+  } as unknown as Model<never>;
+}
+
+function tab(
+  id: string,
+): TabRecord & { thinkingLevelSpy: ReturnType<typeof vi.fn> } {
+  const setThinkingLevel = vi.fn();
+  return {
+    thinkingLevelSpy: setThinkingLevel,
+    session: {
+      model: model(id),
+      thinkingLevel: "medium",
+      setThinkingLevel,
+    },
+  } as unknown as TabRecord & {
+    thinkingLevelSpy: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe("Codex 5.6 reasoning efforts", () => {
+  it("keeps Sol and Terra Ultra-capable while Luna stops at Max", () => {
+    expect(codexReasoningLevels(model("gpt-5.6-sol"))).toEqual([
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max",
+      "ultra",
+    ]);
+    expect(codexReasoningLevels(model("gpt-5.6-terra"))).toEqual([
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max",
+      "ultra",
+    ]);
+    expect(codexReasoningLevels(model("gpt-5.6-luna"))).toEqual([
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max",
+    ]);
+    expect(codexReasoningLevels(model("gpt-5.5"))).toBeUndefined();
+  });
+
+  it("uses Pi xhigh underneath while preserving the selected Max effort", () => {
+    const record = tab("gpt-5.6-sol");
+    setTabThinkingLevel(record, "max");
+    expect(record.thinkingLevelSpy).toHaveBeenCalledWith("xhigh");
+    expect(selectedThinkingLevel(record)).toBe("max");
+
+    setTabThinkingLevel(record, "high");
+    expect(record.thinkingLevelSpy).toHaveBeenLastCalledWith("high");
+    expect(record.codexExtendedReasoningEffort).toBeUndefined();
+  });
+
+  it("rejects Ultra for Luna and older Codex models", () => {
+    expect(() => setTabThinkingLevel(tab("gpt-5.6-luna"), "ultra")).toThrow(
+      "ultra is not supported",
+    );
+    expect(() => setTabThinkingLevel(tab("gpt-5.5"), "max")).toThrow(
+      "max is not supported",
+    );
+  });
+
+  it("clamps a persisted Ultra default when the selected model lacks it", () => {
+    const luna = tab("gpt-5.6-luna");
+    setTabThinkingLevel(luna, "ultra", { clampUnsupportedExtended: true });
+    expect(selectedThinkingLevel(luna)).toBe("max");
+
+    const legacy = tab("gpt-5.5");
+    setTabThinkingLevel(legacy, "ultra", { clampUnsupportedExtended: true });
+    expect(legacy.thinkingLevelSpy).toHaveBeenCalledWith("xhigh");
+    expect(legacy.codexExtendedReasoningEffort).toBeUndefined();
+  });
+});

--- a/agent/codex-reasoning.ts
+++ b/agent/codex-reasoning.ts
@@ -1,0 +1,87 @@
+import type { ThinkingLevel } from "@mariozechner/pi-agent-core";
+import type { Api, Model } from "@mariozechner/pi-ai";
+import type { TabRecord } from "./state";
+
+export type CodexExtendedReasoningEffort = "max" | "ultra";
+export type AethonThinkingLevel = ThinkingLevel | CodexExtendedReasoningEffort;
+
+const BASE_LEVELS = new Set<ThinkingLevel>([
+  "off",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+]);
+
+const SOL_TERRA_LEVELS = [
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+  "ultra",
+] as const;
+const LUNA_LEVELS = ["low", "medium", "high", "xhigh", "max"] as const;
+
+export function normalizeAethonThinkingLevel(
+  value: unknown,
+): AethonThinkingLevel | undefined {
+  if (value === "max" || value === "ultra") return value;
+  return typeof value === "string" && BASE_LEVELS.has(value as ThinkingLevel)
+    ? (value as ThinkingLevel)
+    : undefined;
+}
+
+export function codexReasoningLevels(
+  model: Model<Api> | undefined,
+): readonly string[] | undefined {
+  if (model?.provider !== "openai-codex") return undefined;
+  if (model.id === "gpt-5.6-luna") return LUNA_LEVELS;
+  if (model.id === "gpt-5.6-sol" || model.id === "gpt-5.6-terra") {
+    return SOL_TERRA_LEVELS;
+  }
+  return undefined;
+}
+
+export function isCodexExtendedReasoningEffort(
+  level: AethonThinkingLevel,
+): level is CodexExtendedReasoningEffort {
+  return level === "max" || level === "ultra";
+}
+
+export function piThinkingLevel(level: AethonThinkingLevel): ThinkingLevel {
+  return isCodexExtendedReasoningEffort(level) ? "xhigh" : level;
+}
+
+export function setTabThinkingLevel(
+  tab: TabRecord,
+  level: AethonThinkingLevel,
+  options: { clampUnsupportedExtended?: boolean } = {},
+): void {
+  if (isCodexExtendedReasoningEffort(level)) {
+    const supported = codexReasoningLevels(tab.session.model ?? undefined);
+    if (!supported?.includes(level)) {
+      if (options.clampUnsupportedExtended) {
+        if (level === "ultra" && supported?.includes("max")) {
+          tab.codexExtendedReasoningEffort = "max";
+          tab.session.setThinkingLevel("xhigh");
+          return;
+        }
+        tab.codexExtendedReasoningEffort = undefined;
+        tab.session.setThinkingLevel("xhigh");
+        return;
+      }
+      throw new Error(`${level} is not supported by the selected model`);
+    }
+    tab.codexExtendedReasoningEffort = level;
+    tab.session.setThinkingLevel("xhigh");
+    return;
+  }
+  tab.codexExtendedReasoningEffort = undefined;
+  tab.session.setThinkingLevel(level);
+}
+
+export function selectedThinkingLevel(tab: TabRecord): string | undefined {
+  return tab.codexExtendedReasoningEffort ?? tab.session.thinkingLevel;
+}

--- a/agent/main.ts
+++ b/agent/main.ts
@@ -272,6 +272,13 @@ async function main(): Promise<void> {
       const subagents = getSubagentsForCwd(state, resolvedCwd).byName;
       const advert = buildSubagentsSection([...subagents.values()]);
       if (advert) systemPrompt += `\n\n${advert}`;
+      if (
+        tabId &&
+        state.tabs.get(tabId)?.codexExtendedReasoningEffort === "ultra"
+      ) {
+        systemPrompt +=
+          "\n\nUltra reasoning mode is active. Proactively delegate independent, meaningful parts of complex work to the available subagents, run suitable work in parallel, and consolidate their results. Keep simple or tightly coupled work in the primary agent.";
+      }
       // Explicit @name invocation: consume the one-shot steer for this tab
       // (clearing it prevents the subagent's own turn from re-triggering it).
       if (tabId) {

--- a/agent/openai-preview-models.test.ts
+++ b/agent/openai-preview-models.test.ts
@@ -3,7 +3,7 @@ import { AuthStorage, ModelRegistry } from "@mariozechner/pi-coding-agent";
 import { registerOpenAIPreviewModels } from "./openai-preview-models";
 
 describe("OpenAI preview model compatibility", () => {
-  it("adds GPT-5.6 to API-key OpenAI without inventing Codex models", () => {
+  it("adds GPT-5.6 to API-key OpenAI and Codex with provider-specific windows", () => {
     const registry = ModelRegistry.inMemory(AuthStorage.inMemory());
     const existingIds = registry.getAll().filter((m) => m.provider === "openai").map((m) => m.id);
     registerOpenAIPreviewModels(registry);
@@ -18,9 +18,20 @@ describe("OpenAI preview model compatibility", () => {
         contextWindow: 1_050_000,
         maxTokens: 128_000,
       });
-      expect(registry.find("openai-codex", id)).toBeUndefined();
     }
     expect(existingIds.every((id) => registry.find("openai", id))).toBe(true);
+
+    for (const id of ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]) {
+      expect(registry.find("openai-codex", id)).toMatchObject({
+        id,
+        provider: "openai-codex",
+        api: "openai-codex-responses",
+        reasoning: true,
+        input: ["text", "image"],
+        contextWindow: 272_000,
+        maxTokens: 128_000,
+      });
+    }
   });
 
   it("is idempotent", () => {

--- a/agent/openai-preview-models.ts
+++ b/agent/openai-preview-models.ts
@@ -1,4 +1,5 @@
-import type { Api, Model } from "@mariozechner/pi-ai";
+import { getModels, type Api, type Model } from "@mariozechner/pi-ai";
+import { openaiCodexOAuthProvider } from "@mariozechner/pi-ai/oauth";
 import type { ModelRegistry } from "@mariozechner/pi-coding-agent";
 
 type RegisteredModel = NonNullable<
@@ -12,21 +13,68 @@ const GPT_5_6_MODELS: RegisteredModel[] = [
   previewModel("gpt-5.6-luna", "GPT-5.6 Luna", 1, 6),
 ];
 
-/** Add preview models absent from Pi to API-key OpenAI only. */
+const CODEX_GPT_5_6_MODELS: RegisteredModel[] = [
+  codexModel("gpt-5.6-sol", "GPT-5.6 Sol", 5, 30),
+  codexModel("gpt-5.6-terra", "GPT-5.6 Terra", 2.5, 15),
+  codexModel("gpt-5.6-luna", "GPT-5.6 Luna", 1, 6),
+];
+
+/** Add current OpenAI models that Pi has not shipped yet. Pi's native model
+ * definitions take precedence as soon as they become available. */
 export function registerOpenAIPreviewModels(registry: ModelRegistry): void {
+  // Some tests and extension shims intentionally expose only the read side of
+  // ModelRegistry. Compatibility registration is a no-op on those facades.
+  if (
+    typeof (registry as { registerProvider?: unknown }).registerProvider !==
+    "function"
+  ) {
+    return;
+  }
   const existing = registry.getAll().filter((model) => model.provider === "openai");
   const knownIds = new Set(existing.map((model) => model.id));
   const missing = GPT_5_6_MODELS.filter((model) => !knownIds.has(model.id));
-  if (missing.length === 0) return;
+  if (missing.length > 0) {
+    // Dynamic registration replaces a provider's catalog, so retain every Pi
+    // built-in/custom OpenAI model. Pi's definition wins once it ships an id.
+    registry.registerProvider("openai", {
+      name: "OpenAI",
+      baseUrl: "https://api.openai.com/v1",
+      apiKey: "OPENAI_API_KEY",
+      api: "openai-responses",
+      models: [...existing.map(toRegisteredModel), ...missing],
+    });
+  }
 
-  // Dynamic registration replaces a provider's catalog, so retain every Pi
-  // built-in/custom OpenAI model. Pi's definition wins once it ships an id.
-  registry.registerProvider("openai", {
-    name: "OpenAI",
-    baseUrl: "https://api.openai.com/v1",
-    apiKey: "OPENAI_API_KEY",
-    api: "openai-responses",
-    models: [...existing.map(toRegisteredModel), ...missing],
+  registerCodexModels(registry);
+}
+
+function registerCodexModels(registry: ModelRegistry): void {
+  const existing = registry
+    .getAll()
+    .filter((model) => model.provider === "openai-codex");
+  const upstreamIds = new Set(
+    getModels("openai-codex").map((model) => model.id),
+  );
+  const compatibilityIds = new Set(
+    CODEX_GPT_5_6_MODELS.filter((model) => !upstreamIds.has(model.id)).map(
+      (model) => model.id,
+    ),
+  );
+  if (compatibilityIds.size === 0) return;
+
+  // Replace stale user-authored 5.6 entries while Pi lacks native support.
+  // This is what prevents a local models.json typo from changing compaction.
+  const retained = existing.filter((model) => !compatibilityIds.has(model.id));
+  const { id: _providerId, ...oauth } = openaiCodexOAuthProvider;
+  registry.registerProvider("openai-codex", {
+    name: "OpenAI Codex",
+    baseUrl: "https://chatgpt.com/backend-api",
+    api: "openai-codex-responses",
+    oauth,
+    models: [
+      ...retained.map(toRegisteredModel),
+      ...CODEX_GPT_5_6_MODELS.filter((model) => compatibilityIds.has(model.id)),
+    ],
   });
 }
 
@@ -50,6 +98,30 @@ function previewModel(
       cacheWrite: inputCost * 1.25,
     },
     contextWindow: 1_050_000,
+    maxTokens: 128_000,
+  };
+}
+
+function codexModel(
+  id: string,
+  name: string,
+  inputCost: number,
+  outputCost: number,
+): RegisteredModel {
+  return {
+    id,
+    name,
+    api: "openai-codex-responses",
+    reasoning: true,
+    thinkingLevelMap: { off: null, minimal: null, xhigh: "xhigh" },
+    input: ["text", "image"],
+    cost: {
+      input: inputCost,
+      output: outputCost,
+      cacheRead: inputCost / 10,
+      cacheWrite: 0,
+    },
+    contextWindow: 272_000,
     maxTokens: 128_000,
   };
 }

--- a/agent/state.ts
+++ b/agent/state.ts
@@ -331,6 +331,9 @@ export interface TabRecord {
   contextUsageTransientTokens?: number;
   contextUsageLastEmitMs?: number;
   contextUsageEmitTimer?: ReturnType<typeof setTimeout>;
+  /** Aethon-level Codex 5.6 effort layered over Pi's xhigh transport until
+   *  Pi natively models Max and Ultra. */
+  codexExtendedReasoningEffort?: "max" | "ultra";
 }
 
 export interface ProjectBaselineSnapshot {

--- a/agent/tab-lifecycle.test.ts
+++ b/agent/tab-lifecycle.test.ts
@@ -84,6 +84,32 @@ describe("modelKey + modelDescriptor", () => {
       provider: "anthropic",
     });
   });
+
+  it("exposes model-specific GPT-5.6 effort sets", () => {
+    const sol = {
+      id: "gpt-5.6-sol",
+      provider: "openai-codex",
+      name: "GPT-5.6 Sol",
+      reasoning: true,
+    };
+    const luna = { ...sol, id: "gpt-5.6-luna", name: "GPT-5.6 Luna" };
+
+    expect(modelDescriptor(sol as never).thinkingLevels).toEqual([
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max",
+      "ultra",
+    ]);
+    expect(modelDescriptor(luna as never).thinkingLevels).toEqual([
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max",
+    ]);
+  });
 });
 
 describe("ensurePickerHasModel", () => {
@@ -717,6 +743,34 @@ describe("emitReady", () => {
           id: "tab-1",
           model: "anthropic/claude-x",
           cwd: "/repo/a",
+        },
+      ],
+    });
+  });
+
+  it("preserves an Ultra selection and Sol's complete effort set", () => {
+    const f = makeFixture();
+    const rec = fakeRec("openai-codex/gpt-5.6-sol");
+    rec.id = "tab-1";
+    rec.codexExtendedReasoningEffort = "ultra";
+    f.state.tabs.set("tab-1", rec);
+
+    emitReady(f.state, f.deps);
+
+    expect(f.sent[0]).toMatchObject({
+      thinkingLevel: "ultra",
+      tabs: [
+        {
+          id: "tab-1",
+          thinkingLevel: "ultra",
+          thinkingLevels: [
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max",
+            "ultra",
+          ],
         },
       ],
     });

--- a/agent/tab-lifecycle/events.ts
+++ b/agent/tab-lifecycle/events.ts
@@ -21,6 +21,10 @@
 
 import { supportsCodexFastMode } from "../codex-fast-mode";
 import {
+  codexReasoningLevels,
+  selectedThinkingLevel,
+} from "../codex-reasoning";
+import {
   clearLiveContextUsageEstimate,
   emitContextUsage,
 } from "../context-usage";
@@ -89,8 +93,10 @@ export function handleSessionEvent(
         type: "thinking_level_changed",
         tabId,
         model: rec.session.model ? modelKey(rec.session.model) : "",
-        thinkingLevel: rec.session.thinkingLevel,
-        thinkingLevels: rec.session.getAvailableThinkingLevels(),
+        thinkingLevel: selectedThinkingLevel(rec),
+        thinkingLevels:
+          codexReasoningLevels(rec.session.model ?? undefined) ??
+          rec.session.getAvailableThinkingLevels(),
         codexFastMode: state.codexFastMode,
         codexFastModeSupported: supportsCodexFastMode(rec.session.model),
       });

--- a/agent/tab-lifecycle/lifecycle.ts
+++ b/agent/tab-lifecycle/lifecycle.ts
@@ -44,6 +44,11 @@ import type { BootTrace } from "../boot-trace";
 import { authProfileServicesForTab } from "../auth-profiles";
 import { emitGlobalReady } from "../dispatcherTypes";
 import type { AethonAgentState, TabRecord } from "../state";
+import type { CodexExtendedReasoningEffort } from "../codex-reasoning";
+import {
+  codexReasoningLevels,
+  selectedThinkingLevel,
+} from "../codex-reasoning";
 import { contextUsageSnapshot, emitContextUsage } from "../context-usage";
 import { createSqliteBackedSessionManager } from "../session-sqlite";
 import { handleSessionEvent } from "./events";
@@ -56,6 +61,7 @@ import type { TabLifecycleDeps } from "./utils";
 export interface EnsureTabOptions {
   initialModel?: Model<Api>;
   thinkingLevel?: ThinkingLevel;
+  codexExtendedReasoningEffort?: CodexExtendedReasoningEffort;
   cwdOverride?: string;
   /** Boot-phase trace (main.ts startup only) — records tab sub-spans. */
   trace?: BootTrace;
@@ -307,6 +313,9 @@ export async function ensureTab(
     queuedCount: 0,
     toolCardSeq: 0,
     responseMessageSeq: 0,
+    ...(options.codexExtendedReasoningEffort
+      ? { codexExtendedReasoningEffort: options.codexExtendedReasoningEffort }
+      : {}),
   };
   state.tabs.set(tabId, rec);
   refreshPiSlashCommands(state, session);
@@ -330,8 +339,10 @@ export async function ensureTab(
     type: "tab_ready",
     tabId,
     model: session.model ? modelKey(session.model) : "",
-    thinkingLevel: session.thinkingLevel,
-    thinkingLevels: session.getAvailableThinkingLevels(),
+    thinkingLevel: selectedThinkingLevel(rec),
+    thinkingLevels:
+      codexReasoningLevels(session.model ?? undefined) ??
+      session.getAvailableThinkingLevels(),
     codexFastMode: state.codexFastMode,
     codexFastModeSupported: supportsCodexFastMode(session.model),
     contextUsage: contextUsageSnapshot(state, tabId, rec),

--- a/agent/tab-lifecycle/models.ts
+++ b/agent/tab-lifecycle/models.ts
@@ -10,6 +10,7 @@ import type { Api, Model } from "@mariozechner/pi-ai";
 import type { AethonAgentState } from "../state";
 import { compilePattern, modelDescriptor, modelKey } from "./utils";
 import type { TabLifecycleDeps } from "./utils";
+import { registerOpenAIPreviewModels } from "../openai-preview-models";
 
 function uniqueModels(models: Model<Api>[]): Model<Api>[] {
   const seen = new Set<string>();
@@ -92,6 +93,7 @@ export async function refreshCachedModels(
   }
   try {
     state.modelRegistry.refresh();
+    registerOpenAIPreviewModels(state.modelRegistry);
   } catch (err) {
     logger
       .scope("picker")
@@ -101,6 +103,7 @@ export async function refreshCachedModels(
     try {
       services.authStorage.reload();
       services.modelRegistry.refresh();
+      registerOpenAIPreviewModels(services.modelRegistry);
     } catch (err) {
       logger
         .scope("picker")

--- a/agent/tab-lifecycle/ready-handshake.ts
+++ b/agent/tab-lifecycle/ready-handshake.ts
@@ -18,6 +18,10 @@ import { refreshPiSlashCommands } from "./slash-commands";
 import type { TabLifecycleDeps } from "./utils";
 import { modelKey } from "./utils";
 import { supportsCodexFastMode } from "../codex-fast-mode";
+import {
+  codexReasoningLevels,
+  selectedThinkingLevel,
+} from "../codex-reasoning";
 
 export function emitReady(
   state: AethonAgentState,
@@ -31,7 +35,9 @@ export function emitReady(
   deps.send({
     type: "ready",
     model: defaultModelKey(state),
-    thinkingLevel: commandSourceTab?.session.thinkingLevel,
+    thinkingLevel: commandSourceTab
+      ? selectedThinkingLevel(commandSourceTab)
+      : undefined,
     codexFastMode: state.codexFastMode,
     projectRoot: state.projectRoot,
     currentProjectCwd: state.currentProjectCwd,
@@ -41,11 +47,13 @@ export function emitReady(
     tabs: [...state.tabs.values()].map((t) => ({
       id: t.id,
       model: t.session.model ? modelKey(t.session.model) : "",
-      thinkingLevel: t.session.thinkingLevel,
+      thinkingLevel: selectedThinkingLevel(t),
       thinkingLevels:
+        codexReasoningLevels(t.session.model ?? undefined) ??
         (
           t.session as { getAvailableThinkingLevels?: () => string[] }
-        ).getAvailableThinkingLevels?.() ?? [],
+        ).getAvailableThinkingLevels?.() ??
+        [],
       codexFastModeSupported: supportsCodexFastMode(t.session.model),
       cwd: state.tabProjectCwds.get(t.id),
       authProfileId: state.tabAuthProfileIds.get(t.id),

--- a/agent/tab-lifecycle/utils.ts
+++ b/agent/tab-lifecycle/utils.ts
@@ -12,6 +12,7 @@ import {
 } from "@mariozechner/pi-ai";
 import type { AethonAgentState, ModelDescriptor } from "../state";
 import { supportsCodexFastMode } from "../codex-fast-mode";
+import { codexReasoningLevels } from "../codex-reasoning";
 
 export interface TabLifecycleDeps {
   send: (obj: Record<string, unknown>) => void;
@@ -22,7 +23,8 @@ export function modelKey(m: Model<Api>): string {
 }
 
 export function modelDescriptor(m: Model<Api>): ModelDescriptor {
-  const supportedThinkingLevels = getSupportedThinkingLevels(m);
+  const supportedThinkingLevels =
+    codexReasoningLevels(m) ?? getSupportedThinkingLevels(m);
   const thinkingLevels =
     supportedThinkingLevels.length === 1 && supportedThinkingLevels[0] === "off"
       ? []

--- a/agent/tabs.ts
+++ b/agent/tabs.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from "node:crypto";
-import type { ThinkingLevel } from "@mariozechner/pi-agent-core";
 import type { Api, Model } from "@mariozechner/pi-ai";
 import type { AethonAgentState, AethonExtensionApi } from "./state";
 import type { DispatcherDeps, InboundMessage } from "./dispatcherTypes";
@@ -20,6 +19,13 @@ import {
   hasEmittedSessionMessage,
 } from "./aethon-api-sessions";
 import { setSessionLabelForTab } from "./session-label";
+import {
+  isCodexExtendedReasoningEffort,
+  normalizeAethonThinkingLevel,
+  piThinkingLevel,
+  setTabThinkingLevel,
+  type AethonThinkingLevel,
+} from "./codex-reasoning";
 
 export async function handleTabOpen(
   state: AethonAgentState,
@@ -105,37 +111,29 @@ export async function handleTabOpen(
   const tab = await ensureTab(state, deps, tabId, {
     initialModel,
     cwdOverride,
-    thinkingLevel: modelRequest.thinkingLevel,
+    thinkingLevel: modelRequest.thinkingLevel
+      ? piThinkingLevel(modelRequest.thinkingLevel)
+      : undefined,
+    ...(modelRequest.thinkingLevel &&
+    isCodexExtendedReasoningEffort(modelRequest.thinkingLevel)
+      ? { codexExtendedReasoningEffort: modelRequest.thinkingLevel }
+      : {}),
   });
   if (modelRequest.thinkingLevel) {
-    tab.session.setThinkingLevel(modelRequest.thinkingLevel);
+    setTabThinkingLevel(tab, modelRequest.thinkingLevel, {
+      clampUnsupportedExtended: true,
+    });
   }
   if (restoreHistory) {
     deps.send({ type: "session_history", tabId, messages: restoredMessages });
   }
 }
 
-const THINKING_LEVELS = new Set<ThinkingLevel>([
-  "off",
-  "minimal",
-  "low",
-  "medium",
-  "high",
-  "xhigh",
-]);
-
-function normalizeThinkingLevel(value: unknown): ThinkingLevel | undefined {
-  return typeof value === "string" &&
-    THINKING_LEVELS.has(value as ThinkingLevel)
-    ? (value as ThinkingLevel)
-    : undefined;
-}
-
 function parseModelAndThinking(
   rawModel: unknown,
   rawLevel: unknown,
-): { modelId?: string; thinkingLevel?: ThinkingLevel } {
-  const explicitLevel = normalizeThinkingLevel(rawLevel);
+): { modelId?: string; thinkingLevel?: AethonThinkingLevel } {
+  const explicitLevel = normalizeAethonThinkingLevel(rawLevel);
   if (typeof rawModel !== "string" || rawModel.length === 0) {
     return explicitLevel ? { thinkingLevel: explicitLevel } : {};
   }
@@ -147,7 +145,7 @@ function parseModelAndThinking(
     };
   }
   const modelId = rawModel.slice(0, idx);
-  const suffix = normalizeThinkingLevel(rawModel.slice(idx + 1));
+  const suffix = normalizeAethonThinkingLevel(rawModel.slice(idx + 1));
   if (!modelId.startsWith("openai-codex/") || !suffix) {
     return {
       modelId: rawModel,

--- a/src-tauri/src/helpers/config.rs
+++ b/src-tauri/src/helpers/config.rs
@@ -43,7 +43,7 @@ pub struct UiConfig {
 pub struct AgentConfig {
     pub model: Option<String>,
     /// Default reasoning effort for new sessions on models that expose it.
-    /// Allowed: off/minimal/low/medium/high/xhigh. Unknown values are ignored.
+    /// Allowed: off/minimal/low/medium/high/xhigh/max/ultra. Unknown values are ignored.
     pub thinking_level: Option<String>,
     /// Optional Aethon-owned override for the provider/SDK request timeout,
     /// in seconds. Omitted leaves pi's own `retry.provider.timeoutMs` behavior
@@ -437,7 +437,7 @@ pub fn normalize_timeout_seconds(value: Option<u32>) -> u32 {
 
 pub fn normalize_thinking_level(value: Option<&str>) -> Option<&str> {
     match value {
-        Some("off" | "minimal" | "low" | "medium" | "high" | "xhigh") => value,
+        Some("off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | "ultra") => value,
         _ => None,
     }
 }
@@ -693,6 +693,14 @@ mod tests {
     fn parse_config_toml_ignores_unknown_thinking_level() {
         let v = parse_config_toml("[agent]\nthinking_level = \"turbo\"\n");
         assert_eq!(v["agent"]["thinkingLevel"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn parse_config_toml_accepts_codex_extended_thinking_levels() {
+        for level in ["max", "ultra"] {
+            let v = parse_config_toml(&format!("[agent]\nthinking_level = \"{level}\"\n"));
+            assert_eq!(v["agent"]["thinkingLevel"], level);
+        }
     }
 
     #[test]

--- a/src/config.ts
+++ b/src/config.ts
@@ -477,7 +477,9 @@ function normalizeThinkingLevel(value: unknown): string | null {
     value === "low" ||
     value === "medium" ||
     value === "high" ||
-    value === "xhigh"
+    value === "xhigh" ||
+    value === "max" ||
+    value === "ultra"
     ? value
     : null;
 }

--- a/src/extensions/default-layout/variation-components.test.tsx
+++ b/src/extensions/default-layout/variation-components.test.tsx
@@ -157,6 +157,46 @@ describe("ModelPicker", () => {
     expect(onEvent).toHaveBeenCalledWith("codex-fast-mode", { enabled: true });
   });
 
+  it("renders the complete Sol effort set including Max and Ultra", () => {
+    render(
+      <ModelPicker
+        component={{ id: "model-picker", type: "model-picker", props: {} }}
+        state={{
+          model: "openai-codex/gpt-5.6-sol",
+          thinkingLevel: "max",
+          sidebar: {
+            models: [
+              {
+                id: "openai-codex/gpt-5.6-sol",
+                label: "GPT-5.6 Sol",
+                thinkingLevels: [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max",
+                  "ultra",
+                ],
+              },
+            ],
+          },
+        }}
+        onEvent={vi.fn()}
+      />,
+    );
+
+    const select: HTMLSelectElement = screen.getByLabelText("Reasoning level");
+    expect(select.value).toBe("max");
+    expect([...select.options].map((option) => option.value)).toEqual([
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max",
+      "ultra",
+    ]);
+  });
+
   it("clamps stale reasoning state to the active model's supported levels", () => {
     render(
       <ModelPicker

--- a/src/extensions/default-layout/variation-components.tsx
+++ b/src/extensions/default-layout/variation-components.tsx
@@ -490,7 +490,7 @@ export function ModelPicker({
         >
           {thinkingLevels.map((level) => (
             <option key={level} value={level}>
-              {level}
+              {reasoningLevelLabel(level)}
             </option>
           ))}
         </select>
@@ -512,6 +512,29 @@ export function ModelPicker({
       ) : null}
     </span>
   );
+}
+
+function reasoningLevelLabel(level: string): string {
+  switch (level) {
+    case "off":
+      return "Off";
+    case "minimal":
+      return "Minimal";
+    case "low":
+      return "Light";
+    case "medium":
+      return "Medium";
+    case "high":
+      return "High";
+    case "xhigh":
+      return "Extra High";
+    case "max":
+      return "Max";
+    case "ultra":
+      return "Ultra";
+    default:
+      return level;
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/hooks/chatControllers.test.ts
+++ b/src/hooks/chatControllers.test.ts
@@ -107,6 +107,10 @@ describe("chat model selection helpers", () => {
       modelId: "openai-codex/gpt-5.5",
       thinkingLevel: "high",
     });
+    expect(parseModelIdWithThinking("openai-codex/gpt-5.6-sol:ultra")).toEqual({
+      modelId: "openai-codex/gpt-5.6-sol",
+      thinkingLevel: "ultra",
+    });
     expect(parseModelIdWithThinking("ollama/foo:high")).toEqual({
       modelId: "ollama/foo:high",
     });

--- a/src/hooks/chatModelSelection.ts
+++ b/src/hooks/chatModelSelection.ts
@@ -20,6 +20,8 @@ export const THINKING_LEVELS = new Set([
   "medium",
   "high",
   "xhigh",
+  "max",
+  "ultra",
 ]);
 
 export function parseModelIdWithThinking(raw: string): {

--- a/website/guide/agents.md
+++ b/website/guide/agents.md
@@ -83,13 +83,20 @@ in `~/.aethon/config.toml`:
 
 ```toml
 [agent]
-thinking_level = "medium"   # off | minimal | low | medium | high | xhigh
+thinking_level = "medium"   # off | minimal | low | medium | high | xhigh | max | ultra
 ```
 
 Leave it unset to use each provider's own default. Codex-family models also
 honour `[agent] codex_fast_mode` (trade reasoning depth for a faster, higher
 service tier). See
 [config.toml reference](/reference/config-reference) for both fields.
+
+For Codex GPT-5.6, Aethon ships Sol, Terra, and Luna under ChatGPT auth with
+their 272,000-token context window. Sol and Terra offer Light through Ultra;
+Luna offers Light through Max. The selector remains model-specific, so older
+Codex models keep their existing effort vocabulary instead of inheriting 5.6
+options they do not support. Auto-compaction still reserves the configured pi
+token margin below the model window.
 
 ## Plan mode
 

--- a/website/guide/configuration.md
+++ b/website/guide/configuration.md
@@ -27,7 +27,7 @@ model = "anthropic/claude-sonnet-4-6"
 bash_timeout_floor_seconds = 300
 subagent_timeout_seconds = 300
 idle_retire_minutes = 15
-# thinking_level = "medium"        # off|minimal|low|medium|high|xhigh; unset = provider default
+# thinking_level = "medium"        # off|minimal|low|medium|high|xhigh|max|ultra; unset = provider default
 codex_fast_mode = false
 
 [shell]
@@ -241,7 +241,7 @@ your config; the focus-aware routing above is the only behavior.
 
 ```toml
 [agent]
-thinking_level = "medium"   # off | minimal | low | medium | high | xhigh
+thinking_level = "medium"   # off | minimal | low | medium | high | xhigh | max | ultra
 codex_fast_mode = false     # Codex models: trade reasoning depth for speed
 ```
 
@@ -250,6 +250,12 @@ unset to use each provider's own default. A tab can override it per session
 from the model picker's reasoning selector (see
 [Agents](/guide/agents#reasoning-effort)). `codex_fast_mode` only affects
 Codex-family models.
+
+GPT-5.6 Sol and Terra expose Light, Medium, High, Extra High, Max, and Ultra.
+Luna stops at Max. Ultra is an orchestration mode: Aethon sends the distinct
+Codex effort and proactively uses available subagents for meaningful parallel
+work. Older models retain their provider-defined effort sets, so existing
+`off`, `minimal`, and GPT-5.5 selections continue to work.
 
 ## Enable or tune the Nix devshell wrap
 

--- a/website/reference/config-reference.md
+++ b/website/reference/config-reference.md
@@ -64,7 +64,7 @@ idle_retire_minutes = 15
 | Key | Type | Default | Notes |
 |---|---|---|---|
 | `model` | string | provider default | The default model for new agent tabs. Format depends on the provider: `anthropic/claude-sonnet-4-6`, `openai/gpt-4o`, etc. The `/model` slash command updates *the active tab's* model and persists the choice for new tabs. |
-| `thinking_level` | `"off" \| "minimal" \| "low" \| "medium" \| "high" \| "xhigh"` | unset | Default reasoning effort for new agent sessions on models that expose it. Unknown values are ignored (treated as unset). Per-session overridable via the model-picker reasoning selector. |
+| `thinking_level` | `"off" \| "minimal" \| "low" \| "medium" \| "high" \| "xhigh" \| "max" \| "ultra"` | unset | Default reasoning effort for new agent sessions on models that expose it. Options are model-specific: GPT-5.6 Sol/Terra support through Ultra, Luna through Max, and older models retain their existing sets. Unknown values are ignored (treated as unset). Per-session overridable via the model-picker reasoning selector. |
 | `codex_fast_mode` | boolean | `false` | Request Codex Fast mode (priority service tier) for supported `openai-codex` models. Wired through `AETHON_CODEX_FAST_MODE`. |
 | `provider_timeout_seconds` | integer | unset | Aethon-owned override for the provider/SDK request timeout, in seconds. Omit (or set `0`) to leave pi's own `retry.provider.timeoutMs` behavior unchanged. Clamped to 1-86400. Wired through `AETHON_PROVIDER_TIMEOUT_SECONDS`. |
 | `bash_timeout_floor_seconds` | integer | `300` | Floor applied to model-supplied bash tool timeouts, in seconds. A missing or invalid (`0`) value uses the historical 5-minute default. Clamped to 1-86400. Wired through `AETHON_BASH_TIMEOUT_FLOOR_SECONDS`. |


### PR DESCRIPTION
## Summary

- ship GPT-5.6 Sol, Terra, and Luna in the Codex OAuth catalog while upstream Pi lacks native definitions
- add model-specific Max and Ultra effort handling while retaining legacy model behavior
- correct Codex 5.6 context metadata to 272,000 tokens so compaction uses the right threshold
- preserve extended efforts through tabs, handshakes, config, Fast mode, and the model picker
- document the new models, effort availability, and backward-compatibility behavior

## Model behavior

- Sol and Terra: Light, Medium, High, Extra High, Max, Ultra
- Luna: Light, Medium, High, Extra High, Max
- older Codex models keep their existing effort sets
- unsupported persisted extended efforts clamp safely on model changes

## Verification

- `nix develop -c check`
  - sidecar bundle
  - Clippy
  - TypeScript
  - ESLint
  - 652 Rust tests passed; 5 ignored
  - 3,247 TypeScript tests passed across 389 files
- live dev-app UAT confirmed model catalogs, effort menus, model switching, 272,000-token context, and 255,616-token compaction threshold
