### PR TITLE
fix(mobile): keep iPhone layout at native scale

### DIFF
--- a/src/hooks/useBootConfig.mobile.test.tsx
+++ b/src/hooks/useBootConfig.mobile.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { installTauriMocks, type TauriMockHarness } from "../test/tauriMocks";
+import { useBootConfig } from "./useBootConfig";
+
+describe("useBootConfig on mobile", () => {
+  let harness: TauriMockHarness;
+
+  beforeEach(() => {
+    harness = installTauriMocks();
+    (window as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {};
+    vi.stubEnv("VITE_AETHON_SURFACE", "mobile");
+    document.documentElement.style.zoom = "";
+    document.documentElement.style.removeProperty("--app-ui-scale");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    delete (window as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
+    document.documentElement.style.zoom = "";
+    document.documentElement.style.removeProperty("--app-ui-scale");
+  });
+
+  it("does not apply the paired desktop's persisted UI zoom", async () => {
+    harness.invoke.mockImplementation((command: string, args?: unknown) => {
+      if (command === "read_state") {
+        return Promise.resolve(
+          (args as { name?: string } | undefined)?.name === "ui_zoom"
+            ? "1.2"
+            : "",
+        );
+      }
+      return Promise.resolve(undefined);
+    });
+
+    const { result } = renderHook(() =>
+      useBootConfig({
+        setState: vi.fn(),
+        piDefaultModelRef: { current: "" },
+      }),
+    );
+
+    await waitFor(() => expect(result.current.bootConfigReady).toBe(true));
+
+    expect(document.documentElement.style.zoom).toBe("");
+    expect(
+      document.documentElement.style.getPropertyValue("--app-ui-scale"),
+    ).toBe("");
+    expect(harness.invoke).not.toHaveBeenCalledWith("read_state", {
+      name: "ui_zoom",
+    });
+  });
+
+  it("continues to restore persisted UI zoom on desktop", async () => {
+    vi.stubEnv("VITE_AETHON_SURFACE", "desktop");
+    harness.invoke.mockImplementation((command: string, args?: unknown) => {
+      if (command === "read_state") {
+        return Promise.resolve(
+          (args as { name?: string } | undefined)?.name === "ui_zoom"
+            ? "1.2"
+            : "",
+        );
+      }
+      return Promise.resolve(undefined);
+    });
+
+    const { result } = renderHook(() =>
+      useBootConfig({
+        setState: vi.fn(),
+        piDefaultModelRef: { current: "" },
+      }),
+    );
+
+    await waitFor(() => expect(result.current.bootConfigReady).toBe(true));
+
+    expect(document.documentElement.style.zoom).toBe("1.2");
+    expect(
+      document.documentElement.style.getPropertyValue("--app-ui-scale"),
+    ).toBe("1.2");
+  });
+});

--- a/src/hooks/useBootConfig.ts
+++ b/src/hooks/useBootConfig.ts
@@ -85,6 +85,7 @@ export interface UseBootConfigActions {
  */
 export function useBootConfig(ctx: UseBootConfigContext): UseBootConfigActions {
   const { setState, piDefaultModelRef } = ctx;
+  const mobileSurface = import.meta.env.VITE_AETHON_SURFACE === "mobile";
 
   const defaultShareModeRef = useRef<ShellMeta["shareMode"]>("private");
   const notifyOnCompletionRef = useRef<boolean>(true);
@@ -276,18 +277,21 @@ export function useBootConfig(ctx: UseBootConfigContext): UseBootConfigActions {
             defaultModel: config.agent.model!,
           }));
         }
-        // Restore saved UI zoom (Cmd+/-). Stored as a string number on
-        // disk; clamp to a sensible range so a stale value can't make
-        // the UI unusable. applyUiScale writes both CSS zoom and the
-        // --app-ui-scale token that viewport-sized containers use to
-        // compensate, so zooming does not push chrome outside the window.
-        const savedZoom = (
-          await readStateWithLocalStorageFallback("ui_zoom", "")
-        ).trim();
-        if (cancelled) return;
-        const z = parseFloat(savedZoom);
-        if (Number.isFinite(z) && z >= 0.7 && z <= 1.6) {
-          applyUiScale(z);
+        // UI zoom belongs to the desktop window. On mobile `read_state`
+        // crosses the gateway to the paired desktop, so restoring ui_zoom
+        // here would apply the desktop's scale to the iPhone WKWebView and
+        // shift its document away from the device viewport.
+        if (!mobileSurface) {
+          // Stored as a string number; clamp to a sensible range so stale
+          // data cannot make the desktop UI unusable.
+          const savedZoom = (
+            await readStateWithLocalStorageFallback("ui_zoom", "")
+          ).trim();
+          if (cancelled) return;
+          const z = parseFloat(savedZoom);
+          if (Number.isFinite(z) && z >= 0.7 && z <= 1.6) {
+            applyUiScale(z);
+          }
         }
         ctx.onBootConfig?.(config);
       } finally {

--- a/src/hooks/useZoomAndTheme.test.tsx
+++ b/src/hooks/useZoomAndTheme.test.tsx
@@ -11,6 +11,8 @@ describe("useZoomAndTheme", () => {
   beforeEach(() => {
     harness = installTauriMocks();
     document.documentElement.dataset.theme = "ember";
+    document.documentElement.style.zoom = "";
+    document.documentElement.style.removeProperty("--app-ui-scale");
     document.body.innerHTML = "";
   });
 
@@ -58,5 +60,29 @@ describe("useZoomAndTheme", () => {
     expect(document.documentElement.dataset.theme).toBe("brink");
     expect(harness.invoke).not.toHaveBeenCalledWith("set_theme", expect.anything());
     expect(harness.emit).not.toHaveBeenCalledWith("theme-changed", expect.anything());
+  });
+
+  it("keeps mobile at the native viewport scale", async () => {
+    vi.stubEnv("VITE_AETHON_SURFACE", "mobile");
+    document.documentElement.style.zoom = "1.2";
+    document.documentElement.style.setProperty("--app-ui-scale", "1.2");
+    const { result } = renderHook(() =>
+      useZoomAndTheme({
+        setState: vi.fn(),
+        pushNotification: vi.fn(),
+      }),
+    );
+
+    await waitFor(() => expect(document.documentElement.style.zoom).toBe(""));
+    act(() => result.current.applyZoom(1.3));
+
+    expect(document.documentElement.style.zoom).toBe("");
+    expect(
+      document.documentElement.style.getPropertyValue("--app-ui-scale"),
+    ).toBe("");
+    expect(harness.invoke).not.toHaveBeenCalledWith(
+      "write_state",
+      expect.objectContaining({ name: "ui_zoom" }),
+    );
   });
 });

--- a/src/hooks/useZoomAndTheme.ts
+++ b/src/hooks/useZoomAndTheme.ts
@@ -2,7 +2,12 @@ import { useEffect } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { emit, listen } from "@tauri-apps/api/event";
 import { writeState } from "../persist";
-import { applyUiScale, readZoom, writeUiViewportVars } from "../utils/viewport";
+import {
+  applyUiScale,
+  readZoom,
+  resetUiScale,
+  writeUiViewportVars,
+} from "../utils/viewport";
 import { mirrorBootTheme, normalizeThemeId } from "../themeBootstrap";
 
 export const ZOOM_MIN = 0.7;
@@ -48,11 +53,12 @@ export function useZoomAndTheme(
   const mobileSurface = import.meta.env.VITE_AETHON_SURFACE === "mobile";
 
   useEffect(() => {
+    if (mobileSurface) resetUiScale();
     const onResize = () => writeUiViewportVars(readZoom());
     onResize();
     window.addEventListener("resize", onResize);
     return () => window.removeEventListener("resize", onResize);
-  }, []);
+  }, [mobileSurface]);
 
   useEffect(() => {
     if (!mobileSurface) return;
@@ -74,6 +80,10 @@ export function useZoomAndTheme(
   }, [mobileSurface, setState]);
 
   function applyZoom(next: number) {
+    // CSS zoom is a desktop-window preference. Applying it to WKWebView
+    // changes the document coordinate space and can shift the whole app
+    // away from the physical iPhone viewport.
+    if (mobileSurface) return;
     const clamped = Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, next));
     const rounded = Math.round(clamped * 100) / 100;
     applyUiScale(rounded);

--- a/src/utils/viewport.ts
+++ b/src/utils/viewport.ts
@@ -71,6 +71,16 @@ export function applyUiScale(scale: number) {
   }
 }
 
+/** Return the document to the browser/WebView's native scale. Mobile owns
+ * its viewport through device CSS pixels and safe-area insets, so desktop
+ * CSS zoom must never survive a remount or hot reload there. */
+export function resetUiScale() {
+  const root = document.documentElement;
+  root.style.removeProperty("--app-ui-scale");
+  root.style.zoom = "";
+  writeUiViewportVars(1);
+}
+
 export function readZoom(): number {
   const cur = parseFloat(
     document.documentElement.style.getPropertyValue("--app-ui-scale") ||


### PR DESCRIPTION
## Summary
- stop the mobile companion from restoring the paired desktop’s persisted CSS zoom
- reset any stale UI scale when the mobile surface mounts or hot-reloads
- make later zoom actions inert on mobile while preserving desktop zoom behavior

## Root cause
`useBootConfig` restored the shared `ui_zoom` state on every surface. On mobile, `read_state` is forwarded through the gateway to the paired desktop, so an iPhone inherited the desktop window’s zoom (for example 1.2). Applying that through CSS `zoom` changed WKWebView’s document coordinate space and shifted the whole UI off-center.

## Regression coverage
- mobile boot does not read or apply desktop `ui_zoom`
- desktop boot still restores persisted zoom
- mobile mount clears stale scale and later zoom actions do not persist or apply it

## Validation
- `bunx vitest run` (390 files, 3251 tests)
- `bun run typecheck`
- `bun run lint`
- `bun run build:mobile`
- packaged iOS simulator build/install/launch on iPhone 16 Pro (iOS 18.6)
- rendered viewport proof at 390×844: 390px document width, zero horizontal overflow, symmetric 20px gutters
- signed physical-device build completed; install awaits the paired iPhone being unlocked