### PR TITLE
fix(workspaces): dedupe issue task launches

### DIFF
--- a/src/components/A2UIRenderer.tsx
+++ b/src/components/A2UIRenderer.tsx
@@ -148,7 +148,11 @@ export interface BuiltinComponentProps {
   // matchers can target a specific row. The renderer rewrites the
   // outbound componentId to `<componentId>__tpl__<descendantId>` so the
   // bridge's existing __tpl__ separator parsing produces that descendantId.
-  onEvent: (eventType: string, data?: unknown, descendantId?: string) => void;
+  onEvent: (
+    eventType: string,
+    data?: unknown,
+    descendantId?: string,
+  ) => void | boolean | Promise<void> | Promise<boolean>;
   renderChildren?: () => React.ReactNode;
   renderChild?: (child: A2UIComponent) => React.ReactNode;
   // Composites that want to expand a registered template per-row (sidebar

--- a/src/eventRoutes/dashboard.test.ts
+++ b/src/eventRoutes/dashboard.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   handleGhStatsStrip,
   handleProjectDashboard,
@@ -540,6 +540,40 @@ describe("handleTaskLauncher", () => {
       baseBranch: "main",
       workspaceId: undefined,
     });
+  });
+
+  it("keeps the start-task route pending until task launch completes", async () => {
+    const { ctx } = buildRouteFixture();
+    let finishLaunch!: () => void;
+    const launchPending = new Promise<void>((resolve) => {
+      finishLaunch = resolve;
+    });
+    ctx.startTaskInProject = vi.fn(() => launchPending);
+    let settled = false;
+
+    const handled = Promise.resolve(
+      handleTaskLauncher(
+        {
+          component: { id: "x", type: "task-launcher" },
+          eventType: "start-task",
+          data: {
+            projectId: "p1",
+            prompt: "fix the bug",
+            newWorkspace: true,
+          },
+        },
+        ctx,
+      ),
+    ).then((value) => {
+      settled = true;
+      return value;
+    });
+    await Promise.resolve();
+
+    expect(ctx.startTaskInProject).toHaveBeenCalledTimes(1);
+    expect(settled).toBe(false);
+    finishLaunch();
+    await expect(handled).resolves.toBe(true);
   });
 
   it("start-task defaults new workspaces to the project base branch", async () => {

--- a/src/eventRoutes/dashboard.ts
+++ b/src/eventRoutes/dashboard.ts
@@ -431,8 +431,7 @@ export const handleTaskLauncher: EventRouteHandler = (
     return true;
   }
   if (eventType === "start-task") {
-    void launchStartTask(data, ctx);
-    return true;
+    return launchStartTask(data, ctx).then(() => true);
   }
   // The launcher also emits select-project-card when the project chip
   // is changed — re-dispatch to the dashboard handler.

--- a/src/extensions/default-layout/dashboard/issues-section.test.ts
+++ b/src/extensions/default-layout/dashboard/issues-section.test.ts
@@ -399,6 +399,37 @@ describe("IssuesSection", () => {
     );
   });
 
+  it("keeps an issue launch disabled until the routed task finishes", async () => {
+    let finishLaunch!: () => void;
+    const launchPending = new Promise<void>((resolve) => {
+      finishLaunch = resolve;
+    });
+    const onEvent = vi.fn((eventType: string) =>
+      eventType === "start-task" ? launchPending : undefined,
+    );
+    renderIssues(onEvent);
+
+    await screen.findByText(issue.title);
+    const send = screen.getByRole("button", { name: /send issue #85/i });
+    fireEvent.click(send);
+
+    await waitFor(() =>
+      expect(
+        onEvent.mock.calls.filter(([eventType]) => eventType === "start-task"),
+      ).toHaveLength(1),
+    );
+    expect((send as HTMLButtonElement).disabled).toBe(true);
+    (send as HTMLButtonElement).click();
+    expect(
+      onEvent.mock.calls.filter(([eventType]) => eventType === "start-task"),
+    ).toHaveLength(1);
+
+    finishLaunch();
+    await waitFor(() =>
+      expect((send as HTMLButtonElement).disabled).toBe(false),
+    );
+  });
+
   it("shows linked issue-session status and opens it instead of dispatching", async () => {
     const linked = {
       ...makeEmptyTab("issue-tab", "Issue #85", "p1"),

--- a/src/extensions/default-layout/dashboard/issues-section.tsx
+++ b/src/extensions/default-layout/dashboard/issues-section.tsx
@@ -345,7 +345,7 @@ export function IssuesSection({
         // Route through the dashboard's start-task event so the
         // launcher + start-task path stays the single source of
         // truth (UI / pi tool parity).
-        onEvent(
+        await onEvent(
           "start-task",
           {
             projectId: project.id,

--- a/src/hooks/useTaskLauncher.test.ts
+++ b/src/hooks/useTaskLauncher.test.ts
@@ -176,6 +176,69 @@ describe("useTaskLauncher", () => {
     });
   });
 
+  it("coalesces duplicate in-flight launches for the same GitHub issue", async () => {
+    const projects = makeProjects();
+    projects.workspacesByProject.p1 = [
+      {
+        id: "wt-85",
+        projectId: "p1",
+        path: "/repo/aethon-issue-85",
+        branch: "fix/issue-85-existing",
+        isMain: false,
+      },
+    ];
+    const projectsRef = ref(projects);
+    let finishWorkspace!: (path: string) => void;
+    const workspacePending = new Promise<string>((resolve) => {
+      finishWorkspace = resolve;
+    });
+    const createWorkspaceWithParams = vi.fn(() => workspacePending);
+    const newTab = vi.fn();
+    const sendChat = vi.fn(() => Promise.resolve());
+    const { result } = renderHook(() =>
+      useTaskLauncher({
+        projectsRef,
+        pushNotificationRef: ref((_: NotificationInput) => {}),
+        setActiveProjectById: vi.fn(() => true),
+        createWorkspaceWithParams,
+        activateWorkspace: vi.fn(),
+        newTab,
+        pendingTabOpens: ref(new Map()),
+        sendChat,
+      }),
+    );
+    const opts = {
+      projectId: "p1",
+      prompt: "fix issue",
+      newWorkspace: true,
+      branch: "fix/issue-85-existing",
+      sourceIssue: {
+        kind: "github-issue" as const,
+        projectId: "p1",
+        number: 85,
+        url: "https://github.com/utensils/aethon/issues/85",
+        title: "Cannot rename session tab while agent is running",
+        createdAt: 1,
+      },
+    };
+
+    let first!: ReturnType<typeof result.current>;
+    let second!: ReturnType<typeof result.current>;
+    await act(async () => {
+      first = result.current(opts);
+      second = result.current(opts);
+      await Promise.resolve();
+    });
+
+    expect(createWorkspaceWithParams).toHaveBeenCalledTimes(1);
+    finishWorkspace("/repo/aethon-issue-85");
+    await act(async () => {
+      await Promise.all([first, second]);
+    });
+    expect(newTab).toHaveBeenCalledTimes(1);
+    expect(sendChat).toHaveBeenCalledTimes(1);
+  });
+
   it("threads the per-launch model through to the new tab", async () => {
     const projectsRef = ref(makeProjects());
     const newTab = vi.fn();

--- a/src/hooks/useTaskLauncher.ts
+++ b/src/hooks/useTaskLauncher.ts
@@ -1,5 +1,6 @@
 import {
   useCallback,
+  useRef,
   type Dispatch,
   type MutableRefObject,
   type SetStateAction,
@@ -136,7 +137,10 @@ export function useTaskLauncher({
   piDefaultModelRef,
   prepareWorkspaceStartup,
 }: UseTaskLauncherOptions): (opts: StartTaskOptions) => Promise<StartTaskResult | void> {
-  return useCallback(
+  const inFlightIssueLaunchesRef = useRef<
+    Map<string, Promise<StartTaskResult | void>>
+  >(new Map());
+  const launchTask = useCallback(
     async (opts: StartTaskOptions): Promise<StartTaskResult | void> => {
       const project = projectsRef.current.projects.find(
         (p) => p.id === opts.projectId,
@@ -380,5 +384,25 @@ export function useTaskLauncher({
       stateRef,
       tabBucketsRef,
     ],
+  );
+
+  return useCallback(
+    (opts: StartTaskOptions): Promise<StartTaskResult | void> => {
+      const sourceIssue = opts.sourceIssue;
+      if (!sourceIssue) return launchTask(opts);
+
+      const issueKey = `${sourceIssue.projectId}:${sourceIssue.number}`;
+      const existing = inFlightIssueLaunchesRef.current.get(issueKey);
+      if (existing) return existing;
+
+      const tracked = launchTask(opts).finally(() => {
+        if (inFlightIssueLaunchesRef.current.get(issueKey) === tracked) {
+          inFlightIssueLaunchesRef.current.delete(issueKey);
+        }
+      });
+      inFlightIssueLaunchesRef.current.set(issueKey, tracked);
+      return tracked;
+    },
+    [launchTask],
   );
 }


### PR DESCRIPTION
## Summary

- keep the GitHub issue send action disabled until the routed task launch actually completes
- coalesce concurrent launches for the same project/issue into one in-flight task promise
- add regressions covering the UI latch, routed promise propagation, and workspace/tab/prompt deduplication

## Root cause

`IssuesSection` fired the asynchronous `start-task` route without awaiting it, then immediately cleared its local `sending` state. Worktree creation, devshell preparation, tab opening, and prompt delivery were still running, so the button became clickable again before the issue had a linked tab. Repeated clicks could enter multiple `git worktree add` operations against the same repository concurrently, leaving one failed pending row while another suffixed workspace succeeded.

## User impact

A GitHub issue now produces one workspace, one agent tab, and one initial prompt even if the action is clicked repeatedly while startup is slow. The button remains visibly disabled until the launch finishes.

## Validation

- red/green regressions in `issues-section.test.ts` and `useTaskLauncher.test.ts`
- `bunx tsc -b --noEmit`
- `bunx eslint .`
- `bunx vitest run` — 390 files, 3,260 tests
- `bun run build`
- branch-local Tauri dev UAT at `http://localhost:1420/` using real read-only issue #779 data and a stubbed pending launch: disabled during launch, rapid second click kept launch count at 1, re-enabled after completion